### PR TITLE
feat(gitops): Flux WatchFailures — react to failed reconciles

### DIFF
--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -70,6 +70,17 @@ func readyCondition(u *unstructured.Unstructured) (status, reason, message strin
 	return "", "", ""
 }
 
+// WatchKustomizations watches all Kustomizations across namespaces and forwards
+// each add/modify event as a KustomizationEvent. The channel closes when the
+// underlying watch stops or ctx is done.
+//
+// NOTE: full implementation is in Task 3; this stub satisfies the Reader interface.
+func (r *dynamicReader) WatchKustomizations(_ context.Context) (<-chan KustomizationEvent, error) {
+	ch := make(chan KustomizationEvent)
+	close(ch)
+	return ch, nil
+}
+
 // kustomizationFromUnstructured maps an unstructured Kustomization object to the
 // minimal kustomization type.
 func kustomizationFromUnstructured(u *unstructured.Unstructured) kustomization {

--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -70,15 +71,42 @@ func readyCondition(u *unstructured.Unstructured) (status, reason, message strin
 	return "", "", ""
 }
 
-// WatchKustomizations watches all Kustomizations across namespaces and forwards
-// each add/modify event as a KustomizationEvent. The channel closes when the
-// underlying watch stops or ctx is done.
-//
-// NOTE: full implementation is in Task 3; this stub satisfies the Reader interface.
-func (r *dynamicReader) WatchKustomizations(_ context.Context) (<-chan KustomizationEvent, error) {
-	ch := make(chan KustomizationEvent)
-	close(ch)
-	return ch, nil
+// WatchKustomizations watches all Kustomizations and forwards each add/modify as
+// a KustomizationEvent. The channel closes when the underlying watch stops or ctx
+// is done.
+func (r *dynamicReader) WatchKustomizations(ctx context.Context) (<-chan KustomizationEvent, error) {
+	w, err := r.client.Resource(kustomizationGVR).Namespace(metav1.NamespaceAll).Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("watch kustomizations: %w", err)
+	}
+	out := make(chan KustomizationEvent)
+	go func() {
+		defer close(out)
+		defer w.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case e, ok := <-w.ResultChan():
+				if !ok {
+					return
+				}
+				if e.Type != watch.Added && e.Type != watch.Modified {
+					continue
+				}
+				u, ok := e.Object.(*unstructured.Unstructured)
+				if !ok {
+					continue
+				}
+				select {
+				case out <- KustomizationEvent{Kustomization: kustomizationFromUnstructured(u)}:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out, nil
 }
 
 // kustomizationFromUnstructured maps an unstructured Kustomization object to the

--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -49,6 +49,27 @@ func (r *dynamicReader) GetGitRepository(ctx context.Context, namespace, name st
 	return gitRepository{Name: name, Namespace: namespace, URL: url}, nil
 }
 
+// readyCondition returns the (status, reason, message) of the Ready condition.
+func readyCondition(u *unstructured.Unstructured) (status, reason, message string) {
+	conds, found, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if !found {
+		return "", "", ""
+	}
+	for _, c := range conds {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := m["type"].(string); t == "Ready" {
+			status, _ = m["status"].(string)
+			reason, _ = m["reason"].(string)
+			message, _ = m["message"].(string)
+			return status, reason, message
+		}
+	}
+	return "", "", ""
+}
+
 // kustomizationFromUnstructured maps an unstructured Kustomization object to the
 // minimal kustomization type.
 func kustomizationFromUnstructured(u *unstructured.Unstructured) kustomization {
@@ -60,6 +81,7 @@ func kustomizationFromUnstructured(u *unstructured.Unstructured) kustomization {
 	if srcNamespace == "" {
 		srcNamespace = namespace // sourceRef.namespace defaults to the Kustomization namespace
 	}
+	readyStatus, readyReason, readyMessage := readyCondition(u)
 	return kustomization{
 		Name:            u.GetName(),
 		Namespace:       namespace,
@@ -67,5 +89,8 @@ func kustomizationFromUnstructured(u *unstructured.Unstructured) kustomization {
 		SourceName:      srcName,
 		SourceNamespace: srcNamespace,
 		Revision:        rev,
+		ReadyStatus:     readyStatus,
+		ReadyReason:     readyReason,
+		ReadyMessage:    readyMessage,
 	}
 }

--- a/internal/providers/gitops/flux/dynamic_test.go
+++ b/internal/providers/gitops/flux/dynamic_test.go
@@ -56,3 +56,23 @@ func TestDynamicReader(t *testing.T) {
 		t.Fatalf("unexpected url: %q", gr.URL)
 	}
 }
+
+func TestKustomizationReadyCondition(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "apps", "namespace": "flux-system"},
+		"spec":       map[string]any{"path": "./apps", "sourceRef": map[string]any{"name": "flux-system"}},
+		"status": map[string]any{
+			"lastAppliedRevision": "main@sha1:abc",
+			"conditions": []any{
+				map[string]any{"type": "Healthy", "status": "True"},
+				map[string]any{"type": "Ready", "status": "False", "reason": "BuildFailed", "message": "kustomize build failed"},
+			},
+		},
+	}}
+	k := kustomizationFromUnstructured(u)
+	if k.ReadyStatus != "False" || k.ReadyReason != "BuildFailed" || k.ReadyMessage != "kustomize build failed" {
+		t.Fatalf("unexpected ready condition: %+v", k)
+	}
+}

--- a/internal/providers/gitops/flux/dynamic_test.go
+++ b/internal/providers/gitops/flux/dynamic_test.go
@@ -3,7 +3,9 @@ package flux
 import (
 	"context"
 	"testing"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -74,5 +76,42 @@ func TestKustomizationReadyCondition(t *testing.T) {
 	k := kustomizationFromUnstructured(u)
 	if k.ReadyStatus != "False" || k.ReadyReason != "BuildFailed" || k.ReadyMessage != "kustomize build failed" {
 		t.Fatalf("unexpected ready condition: %+v", k)
+	}
+}
+
+func TestDynamicReaderWatch(t *testing.T) {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		kustomizationGVR: "KustomizationList",
+		gitRepositoryGVR: "GitRepositoryList",
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+	r := NewDynamicReader(client)
+
+	ch, err := r.WatchKustomizations(context.Background())
+	if err != nil {
+		t.Fatalf("WatchKustomizations: %v", err)
+	}
+
+	// Create a failing Kustomization via the fake client; the watch should surface it.
+	bad := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "bad", "namespace": "apps"},
+		"spec":       map[string]any{"path": "./apps", "sourceRef": map[string]any{"name": "flux-system"}},
+		"status": map[string]any{"conditions": []any{
+			map[string]any{"type": "Ready", "status": "False", "reason": "BuildFailed", "message": "boom"},
+		}},
+	}}
+	if _, err := client.Resource(kustomizationGVR).Namespace("apps").Create(context.Background(), bad, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.Kustomization.Name != "bad" || ev.Kustomization.ReadyStatus != "False" {
+			t.Fatalf("unexpected event: %+v", ev.Kustomization)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for watch event")
 	}
 }

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -18,6 +18,9 @@ type kustomization struct {
 	SourceName      string // spec.sourceRef.name
 	SourceNamespace string // spec.sourceRef.namespace (defaults to the Kustomization namespace)
 	Revision        string // status.lastAppliedRevision
+	ReadyStatus     string // status.conditions[type=Ready].status ("True"/"False"/"Unknown")
+	ReadyReason     string
+	ReadyMessage    string
 }
 
 // gitRepository is the minimal Flux GitRepository data the provider needs.

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -29,11 +29,17 @@ type gitRepository struct {
 	URL             string // spec.url
 }
 
+// KustomizationEvent is a single watch event for a Kustomization.
+type KustomizationEvent struct {
+	Kustomization kustomization
+}
+
 // Reader is the cluster-read surface the provider depends on. The dynamic
 // client-go implementation lives in dynamic.go; tests use a fake.
 type Reader interface {
 	ListKustomizations(ctx context.Context) ([]kustomization, error)
 	GetGitRepository(ctx context.Context, namespace, name string) (gitRepository, error)
+	WatchKustomizations(ctx context.Context) (<-chan KustomizationEvent, error)
 }
 
 // Provider implements providers.GitOpsProvider for Flux.
@@ -94,12 +100,44 @@ func (p *Provider) Diff(_ context.Context, c providers.Change) (providers.Diff, 
 	return p.differ.ForChange(c)
 }
 
-// WatchFailures is not implemented yet (next plan: watch Kustomization
-// Ready=False / source FetchFailed). It returns a closed channel.
-func (p *Provider) WatchFailures(context.Context) (<-chan providers.FailureEvent, error) {
-	ch := make(chan providers.FailureEvent)
-	close(ch)
-	return ch, nil
+// WatchFailures watches Flux Kustomizations and emits a FailureEvent whenever one
+// is Ready=False (a failed/blocked reconcile). The returned channel closes when
+// the watch ends or ctx is done.
+func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureEvent, error) {
+	src, err := p.reader.WatchKustomizations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan providers.FailureEvent)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-src:
+				if !ok {
+					return
+				}
+				k := ev.Kustomization
+				if k.ReadyStatus != "False" {
+					continue
+				}
+				fe := providers.FailureEvent{
+					Workload: providers.Workload{Kind: "Kustomization", Name: k.Name, Namespace: k.Namespace},
+					Engine:   providers.EngineFlux,
+					Reason:   k.ReadyReason,
+					Message:  k.ReadyMessage,
+				}
+				select {
+				case out <- fe:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out, nil
 }
 
 // mapKustomization builds an engine-agnostic Change from a Kustomization + its

--- a/internal/providers/gitops/flux/flux_test.go
+++ b/internal/providers/gitops/flux/flux_test.go
@@ -38,6 +38,11 @@ func (f fakeReader) GetGitRepository(_ context.Context, ns, name string) (gitRep
 	}
 	return gitRepository{}, fmt.Errorf("gitrepository %s/%s not found", ns, name)
 }
+func (f fakeReader) WatchKustomizations(context.Context) (<-chan KustomizationEvent, error) {
+	ch := make(chan KustomizationEvent)
+	close(ch)
+	return ch, nil
+}
 
 func TestProviderChanges(t *testing.T) {
 	r := fakeReader{
@@ -85,5 +90,45 @@ func TestProviderChangesSelector(t *testing.T) {
 	}
 	if len(changes) != 1 || changes[0].Workload.Name != "infra" {
 		t.Fatalf("selector did not filter to infra: %v", changes)
+	}
+}
+
+// streamReader is a fakeReader that also serves a fixed watch stream.
+type streamReader struct {
+	fakeReader
+	events []KustomizationEvent
+}
+
+func (s streamReader) WatchKustomizations(_ context.Context) (<-chan KustomizationEvent, error) {
+	ch := make(chan KustomizationEvent, len(s.events))
+	for _, e := range s.events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestWatchFailures(t *testing.T) {
+	r := streamReader{events: []KustomizationEvent{
+		{Kustomization: kustomization{Name: "ok", Namespace: "flux-system", ReadyStatus: "True"}},
+		{Kustomization: kustomization{Name: "bad", Namespace: "apps", ReadyStatus: "False", ReadyReason: "BuildFailed", ReadyMessage: "boom"}},
+		{Kustomization: kustomization{Name: "progressing", Namespace: "apps", ReadyStatus: "Unknown"}},
+	}}
+	p := New(r, &whatchanged.Differ{})
+	ch, err := p.WatchFailures(context.Background())
+	if err != nil {
+		t.Fatalf("WatchFailures: %v", err)
+	}
+	var got []providers.FailureEvent
+	for e := range ch {
+		got = append(got, e)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 failure event (only Ready=False), got %d", len(got))
+	}
+	e := got[0]
+	if e.Engine != providers.EngineFlux || e.Workload.Name != "bad" || e.Workload.Kind != "Kustomization" ||
+		e.Reason != "BuildFailed" || e.Message != "boom" {
+		t.Fatalf("unexpected failure event: %+v", e)
 	}
 }


### PR DESCRIPTION
## What

Implements the Flux provider's **`WatchFailures`** React trigger: watch Kustomizations and emit a `providers.FailureEvent` when one goes **`Ready=False`** — so a bad GitOps rollout triggers an investigation *before* a metrics alert fires.

## How

- `kustomization` carries the **Ready condition** (status/reason/message), extracted from `status.conditions`.
- `Reader.WatchKustomizations` streams events behind the interface (so mapping is testable without a cluster); `dynamicReader` wraps the dynamic client's `Watch`.
- `Provider.WatchFailures` maps `Ready=False` events → `FailureEvent` via a `ctx`-respecting goroutine (no leaks; race-clean).

## Testing

Pure mapping vs a fake `Reader` stream; the dynamic watch vs the client-go dynamic fake. Gate: build/vet/test (incl. `-race`)/gofmt + **golangci-lint 0 issues**.

## Next

Wire into `lore serve`; HelmRelease + GitRepository (`FetchFailed`) failures; ArgoCD `Application` health.