### PR TITLE
feat(serve): route triggers into an investigation queue

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -8,14 +8,25 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers/gitops/flux"
 	"github.com/Smana/runlore/internal/server"
+	"github.com/Smana/runlore/internal/trigger"
+	"github.com/Smana/runlore/internal/whatchanged"
 )
 
 var version = "0.0.0-dev"
@@ -66,7 +77,59 @@ func runServe(args []string) error {
 		return err
 	}
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	srv := server.New(cfg, nil, log)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	queue := investigate.NewQueue(investigate.LogInvestigator{Log: log}, log, 64)
+	go queue.Run(ctx)
+
+	// Best-effort GitOps-failure watch: only if enabled and a cluster is reachable.
+	if cfg.Triggers.GitOpsFailures.Enabled {
+		startGitOpsFailureWatch(ctx, cfg, queue, log)
+	}
+
+	srv := server.New(cfg, queue, log)
+	httpSrv := &http.Server{Addr: *addr, Handler: srv.Handler()}
+	go func() {
+		<-ctx.Done()
+		_ = httpSrv.Shutdown(context.Background())
+	}()
 	log.Info("runlore serving", "addr", *addr)
-	return http.ListenAndServe(*addr, srv.Handler())
+	if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+// startGitOpsFailureWatch builds a dynamic client and drains Flux WatchFailures
+// into the queue. Failures here are logged, not fatal — webhook-only serving
+// continues if no cluster is reachable.
+func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, log *slog.Logger) {
+	client, err := dynamicClient()
+	if err != nil {
+		log.Warn("gitops-failure watch disabled: no kube client", "err", err)
+		return
+	}
+	provider := flux.New(flux.NewDynamicReader(client), &whatchanged.Differ{})
+	events, err := provider.WatchFailures(ctx)
+	if err != nil {
+		log.Warn("gitops-failure watch disabled", "err", err)
+		return
+	}
+	log.Info("watching gitops failures (Flux Kustomizations)")
+	go investigate.DrainFailures(ctx, events, q, trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()))
+}
+
+// dynamicClient builds a dynamic client from in-cluster config, falling back to
+// the default kubeconfig.
+func dynamicClient() (dynamic.Interface, error) {
+	restCfg, err := rest.InClusterConfig()
+	if err != nil {
+		restCfg, err = clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dynamic.NewForConfig(restCfg)
 }

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -66,7 +66,7 @@ func runServe(args []string) error {
 		return err
 	}
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	srv := server.New(cfg, log)
+	srv := server.New(cfg, nil, log)
 	log.Info("runlore serving", "addr", *addr)
 	return http.ListenAndServe(*addr, srv.Handler())
 }

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/internal/investigate/failures.go
+++ b/internal/investigate/failures.go
@@ -1,0 +1,28 @@
+package investigate
+
+import (
+	"context"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/trigger"
+)
+
+// DrainFailures forwards GitOps FailureEvents into the queue as investigation
+// requests, deduped by workload (a Ready=False resource emits repeated events).
+// A nil dedup disables dedup. It returns when src closes or ctx is done.
+func DrainFailures(ctx context.Context, src <-chan providers.FailureEvent, q Enqueuer, dedup *trigger.Deduper) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case fe, ok := <-src:
+			if !ok {
+				return
+			}
+			if dedup != nil && dedup.Seen(fe.Workload.Namespace+"/"+fe.Workload.Name) {
+				continue
+			}
+			q.Enqueue(FromFailureEvent(fe))
+		}
+	}
+}

--- a/internal/investigate/failures_test.go
+++ b/internal/investigate/failures_test.go
@@ -1,0 +1,33 @@
+package investigate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/trigger"
+)
+
+type collectEnqueuer struct{ reqs []Request }
+
+func (c *collectEnqueuer) Enqueue(r Request) { c.reqs = append(c.reqs, r) }
+
+func TestDrainFailures(t *testing.T) {
+	src := make(chan providers.FailureEvent, 3)
+	wl := providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}
+	src <- providers.FailureEvent{Workload: wl, Reason: "BuildFailed"}
+	src <- providers.FailureEvent{Workload: wl, Reason: "BuildFailed"} // duplicate within window → deduped
+	src <- providers.FailureEvent{Workload: providers.Workload{Kind: "Kustomization", Name: "infra", Namespace: "flux-system"}, Reason: "HealthCheckFailed"}
+	close(src)
+
+	enq := &collectEnqueuer{}
+	DrainFailures(context.Background(), src, enq, trigger.NewDeduper(30*time.Minute))
+
+	if len(enq.reqs) != 2 {
+		t.Fatalf("want 2 enqueued (one deduped), got %d", len(enq.reqs))
+	}
+	if enq.reqs[0].Source != SourceGitOpsFailure {
+		t.Fatalf("unexpected source: %v", enq.reqs[0].Source)
+	}
+}

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -1,0 +1,119 @@
+// Package investigate routes triggers (incident alerts, GitOps failures) into a
+// single async investigation queue. The investigation itself is pluggable via
+// Investigator; LogInvestigator is the read-only placeholder until the ReAct loop
+// lands.
+package investigate
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Source identifies what triggered an investigation.
+type Source string
+
+const (
+	// SourceAlert means the investigation was triggered by an incident alert.
+	SourceAlert Source = "alert"
+	// SourceGitOpsFailure means the investigation was triggered by a GitOps failure.
+	SourceGitOpsFailure Source = "gitops-failure"
+)
+
+// Request is a normalized investigation trigger.
+type Request struct {
+	Source   Source
+	Title    string
+	Workload providers.Workload // optional; zero for alerts without a workload
+	Reason   string
+	Message  string
+	Labels   map[string]string
+	At       time.Time
+}
+
+// FromIncident builds a Request from a matched incident alert.
+func FromIncident(inc config.Incident) Request {
+	return Request{
+		Source:   SourceAlert,
+		Title:    inc.AlertName,
+		Workload: providers.Workload{Namespace: inc.Namespace},
+		Reason:   inc.Severity,
+		Labels:   inc.Labels,
+		At:       inc.StartsAt,
+	}
+}
+
+// FromFailureEvent builds a Request from a GitOps failure.
+func FromFailureEvent(fe providers.FailureEvent) Request {
+	return Request{
+		Source:   SourceGitOpsFailure,
+		Title:    fe.Workload.Kind + "/" + fe.Workload.Name + " " + fe.Reason,
+		Workload: fe.Workload,
+		Reason:   fe.Reason,
+		Message:  fe.Message,
+		At:       fe.When,
+	}
+}
+
+// Investigator runs an investigation for a Request.
+type Investigator interface {
+	Investigate(ctx context.Context, r Request) error
+}
+
+// LogInvestigator is the read-only placeholder: it logs the request it would
+// investigate. Replaced by the ReAct loop in a later phase.
+type LogInvestigator struct {
+	Log *slog.Logger
+}
+
+// Investigate logs the request.
+func (l LogInvestigator) Investigate(_ context.Context, r Request) error {
+	l.Log.Info("investigate",
+		"source", string(r.Source), "title", r.Title,
+		"workload", r.Workload.Namespace+"/"+r.Workload.Name, "reason", r.Reason)
+	return nil
+}
+
+// Enqueuer accepts investigation requests.
+type Enqueuer interface {
+	Enqueue(r Request)
+}
+
+// Queue is a buffered, single-worker investigation queue.
+type Queue struct {
+	ch  chan Request
+	inv Investigator
+	log *slog.Logger
+}
+
+// NewQueue builds a Queue with the given buffer size.
+func NewQueue(inv Investigator, log *slog.Logger, buffer int) *Queue {
+	return &Queue{ch: make(chan Request, buffer), inv: inv, log: log}
+}
+
+// Enqueue submits a request. If the buffer is full it logs and drops (backpressure)
+// rather than blocking the caller (e.g. the webhook handler).
+func (q *Queue) Enqueue(r Request) {
+	select {
+	case q.ch <- r:
+	default:
+		q.log.Warn("investigation queue full; dropping", "title", r.Title, "source", string(r.Source))
+	}
+}
+
+// Run consumes the queue until ctx is done.
+func (q *Queue) Run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case r := <-q.ch:
+			if err := q.inv.Investigate(ctx, r); err != nil {
+				q.log.Error("investigation failed", "title", r.Title, "err", err)
+			}
+		}
+	}
+}

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -1,0 +1,73 @@
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// spyInvestigator records the requests it receives.
+type spyInvestigator struct {
+	mu   sync.Mutex
+	got  []Request
+	done chan struct{}
+}
+
+func (s *spyInvestigator) Investigate(_ context.Context, r Request) error {
+	s.mu.Lock()
+	s.got = append(s.got, r)
+	s.mu.Unlock()
+	if s.done != nil {
+		s.done <- struct{}{}
+	}
+	return nil
+}
+
+func TestQueueDispatches(t *testing.T) {
+	spy := &spyInvestigator{done: make(chan struct{}, 2)}
+	q := NewQueue(spy, slog.New(slog.NewTextHandler(io.Discard, nil)), 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go q.Run(ctx)
+
+	q.Enqueue(Request{Source: SourceAlert, Title: "A"})
+	q.Enqueue(Request{Source: SourceGitOpsFailure, Title: "B"})
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-spy.done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for dispatch")
+		}
+	}
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.got) != 2 {
+		t.Fatalf("want 2 dispatched, got %d", len(spy.got))
+	}
+}
+
+func TestFromIncident(t *testing.T) {
+	inc := config.Incident{AlertName: "HighLatency", Severity: "critical", Namespace: "apps", Labels: map[string]string{"team": "x"}}
+	r := FromIncident(inc)
+	if r.Source != SourceAlert || r.Title != "HighLatency" || r.Reason != "critical" || r.Workload.Namespace != "apps" {
+		t.Fatalf("unexpected request: %+v", r)
+	}
+}
+
+func TestFromFailureEvent(t *testing.T) {
+	fe := providers.FailureEvent{
+		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
+		Engine:   providers.EngineFlux, Reason: "BuildFailed", Message: "boom",
+	}
+	r := FromFailureEvent(fe)
+	if r.Source != SourceGitOpsFailure || r.Workload != fe.Workload || r.Reason != "BuildFailed" || r.Message != "boom" {
+		t.Fatalf("unexpected request: %+v", r)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,19 +6,21 @@ import (
 	"net/http"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/trigger"
 )
 
 // Server handles incoming incident webhooks and applies the trigger policy.
 type Server struct {
-	engine  *trigger.Engine
-	log     *slog.Logger
-	handler http.Handler
+	engine   *trigger.Engine
+	enqueuer investigate.Enqueuer
+	log      *slog.Logger
+	handler  http.Handler
 }
 
-// New builds a Server from config, wiring its routes once.
-func New(cfg *config.Config, log *slog.Logger) *Server {
-	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), log: log}
+// New builds a Server from config and an investigation enqueuer.
+func New(cfg *config.Config, enq investigate.Enqueuer, log *slog.Logger) *Server {
+	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, log: log}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook/alertmanager", s.handleAlertmanager)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -44,7 +46,9 @@ func (s *Server) handleAlertmanager(w http.ResponseWriter, r *http.Request) {
 		s.log.Info("incident",
 			"alert", inc.AlertName, "severity", inc.Severity, "namespace", inc.Namespace,
 			"investigate", d.Investigate, "reason", d.Reason)
-		// Phase 1+ (later plan): if d.Investigate, enqueue an investigation here.
+		if d.Investigate {
+			s.enqueuer.Enqueue(investigate.FromIncident(inc))
+		}
 	}
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,16 +9,23 @@ import (
 	"testing"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
 )
 
-func testServer() *Server {
+type spyEnqueuer struct{ reqs []investigate.Request }
+
+func (s *spyEnqueuer) Enqueue(r investigate.Request) { s.reqs = append(s.reqs, r) }
+
+func testServerWith(enq investigate.Enqueuer) *Server {
 	cfg := &config.Config{}
 	cfg.Triggers.Incidents = config.IncidentTrigger{
 		Enabled: true,
 		Match:   config.IncidentMatch{Severity: []string{"critical"}},
 	}
-	return New(cfg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return New(cfg, enq, slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
+
+func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
 
 func TestHandleAlertmanager(t *testing.T) {
 	body := `{"alerts":[{"status":"firing","labels":{"alertname":"A","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"fp1"}]}`
@@ -45,5 +52,22 @@ func TestHealthz(t *testing.T) {
 	testServer().Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
+	}
+}
+
+func TestHandleAlertmanagerEnqueues(t *testing.T) {
+	enq := &spyEnqueuer{}
+	body := `{"alerts":[
+	  {"status":"firing","labels":{"alertname":"A","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"fp1"},
+	  {"status":"firing","labels":{"alertname":"B","severity":"warning","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"fp2"}
+	]}`
+	req := httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	testServerWith(enq).Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", rr.Code)
+	}
+	if len(enq.reqs) != 1 || enq.reqs[0].Title != "A" {
+		t.Fatalf("want 1 enqueued (only critical A), got %v", enq.reqs)
 	}
 }


### PR DESCRIPTION
Wires `lore serve` into a single async **investigation queue**: matched incident webhooks **and** (best-effort) Flux `WatchFailures` both enqueue a normalized `Request` that a worker dispatches to the investigator (`LogInvestigator` stub for now). The React pillar is now end-to-end.

- `internal/investigate`: `Request` + `FromIncident`/`FromFailureEvent` + `Investigator`/`LogInvestigator` + `Queue` (worker) + `DrainFailures` (deduped).
- `internal/server`: enqueues on policy match.
- `cmd/lore serve`: queue + worker + graceful shutdown + best-effort GitOps-failure watch (in-cluster → kubeconfig).

**Verified** e2e smoke (webhook → `investigate=true` → `msg=investigate`). Gate: build/vet/test (+`-race`)/gofmt + golangci-lint 0 issues.

The investigation itself is a stub — the real ReAct loop replaces `LogInvestigator` next.