### PR TITLE
feat: real LLM investigator in serve (OpenAI-compatible model provider)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
+	openai "github.com/Smana/runlore/internal/model/openai"
+	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/providers/gitops/flux"
 	"github.com/Smana/runlore/internal/server"
 	"github.com/Smana/runlore/internal/trigger"
@@ -81,12 +83,21 @@ func runServe(args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	queue := investigate.NewQueue(investigate.LogInvestigator{Log: log}, log)
+	// Build the (best-effort) dynamic client once: used by both the GitOps-failure
+	// watch and the what-changed tool.
+	var fluxProvider *flux.Provider
+	if client, err := dynamicClient(); err != nil {
+		log.Warn("no kube client; GitOps features disabled", "err", err)
+	} else {
+		fluxProvider = flux.New(flux.NewDynamicReader(client), &whatchanged.Differ{})
+	}
+
+	inv := buildInvestigator(cfg, fluxProvider, log)
+	queue := investigate.NewQueue(inv, log)
 	go queue.Run(ctx)
 
-	// Best-effort GitOps-failure watch: only if enabled and a cluster is reachable.
-	if cfg.Triggers.GitOpsFailures.Enabled {
-		startGitOpsFailureWatch(ctx, cfg, queue, log)
+	if cfg.Triggers.GitOpsFailures.Enabled && fluxProvider != nil {
+		startGitOpsFailureWatch(ctx, cfg, queue, fluxProvider, log)
 	}
 
 	srv := server.New(cfg, queue, log)
@@ -102,17 +113,37 @@ func runServe(args []string) error {
 	return nil
 }
 
-// startGitOpsFailureWatch builds a dynamic client and drains Flux WatchFailures
-// into the queue. Failures here are logged, not fatal — webhook-only serving
-// continues if no cluster is reachable.
-func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, log *slog.Logger) {
-	client, err := dynamicClient()
-	if err != nil {
-		log.Warn("gitops-failure watch disabled: no kube client", "err", err)
-		return
+// buildInvestigator returns the LLM ReAct investigator when a model is configured,
+// otherwise the read-only LogInvestigator.
+func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) investigate.Investigator {
+	if cfg.Model.BaseURL == "" {
+		log.Info("no model configured; using log-only investigator")
+		return investigate.LogInvestigator{Log: log}
 	}
-	provider := flux.New(flux.NewDynamicReader(client), &whatchanged.Differ{})
-	events, err := provider.WatchFailures(ctx)
+	apiKey := ""
+	if cfg.Model.APIKeyEnv != "" {
+		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
+	}
+	model := openai.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+	var tools []investigate.Tool
+	if fp != nil {
+		tools = append(tools, investigate.WhatChangedTool{GitOps: fp})
+	}
+	log.Info("using LLM investigator", "model", cfg.Model.Model, "tools", len(tools))
+	return &investigate.LoopInvestigator{
+		Model: model,
+		Tools: tools,
+		Log:   log,
+		OnComplete: func(found providers.Investigation) {
+			log.Info("findings",
+				"confidence", found.Confidence, "root_causes", len(found.RootCauses), "unresolved", len(found.Unresolved))
+		},
+	}
+}
+
+// startGitOpsFailureWatch drains Flux WatchFailures into the queue.
+func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, fp *flux.Provider, log *slog.Logger) {
+	events, err := fp.WatchFailures(ctx)
 	if err != nil {
 		log.Warn("gitops-failure watch disabled", "err", err)
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,7 +19,15 @@ type Config struct {
 	Triggers TriggerPolicy `yaml:"triggers"`
 	Actions  ActionPolicy  `yaml:"actions"` // read-only by default; the upper rungs of the autonomy ladder
 	Forge    Forge         `yaml:"forge"`   // git-forge auth (GitHub App) for diff access + curation
-	// Providers, Catalog, Model, Notify, etc. are added as packages land.
+	Model    Model         `yaml:"model"`   // optional; when BaseURL is set, serve uses the LLM investigator
+}
+
+// Model configures the OpenAI-compatible LLM endpoint used for investigation.
+// When BaseURL is empty, serve falls back to the log-only investigator.
+type Model struct {
+	BaseURL   string `yaml:"base_url"`    // e.g. https://vllm.svc/v1
+	Model     string `yaml:"model"`       // model name
+	APIKeyEnv string `yaml:"api_key_env"` // env var holding the API key (empty = keyless)
 }
 
 // TriggerPolicy decides what RunLore reacts to.

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -1,0 +1,141 @@
+// Package openai implements providers.ModelProvider against an OpenAI-compatible
+// /chat/completions endpoint (OpenAI, in-cluster vLLM, Ollama, OpenRouter).
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Client is an OpenAI-compatible model provider.
+type Client struct {
+	baseURL string
+	model   string
+	apiKey  string
+	http    *http.Client
+}
+
+// New builds a client. apiKey may be empty (keyless vLLM/Ollama).
+func New(baseURL, model, apiKey string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   model,
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 2 * time.Minute},
+	}
+}
+
+var _ providers.ModelProvider = (*Client)(nil)
+
+type chatRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	Tools    []chatTool    `json:"tools,omitempty"`
+}
+
+type chatMessage struct {
+	Role       string         `json:"role"`
+	Content    string         `json:"content,omitempty"`
+	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+}
+
+type chatToolCall struct {
+	ID       string           `json:"id"`
+	Type     string           `json:"type"`
+	Function chatFunctionCall `json:"function"`
+}
+
+type chatFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type chatTool struct {
+	Type     string       `json:"type"`
+	Function chatFunction `json:"function"`
+}
+
+type chatFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+type chatChoice struct {
+	Message chatMessage `json:"message"`
+}
+
+type chatResponse struct {
+	Choices []chatChoice `json:"choices"`
+}
+
+// Complete sends a chat completion with tools and maps the result back.
+func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	msgs := make([]chatMessage, 0, len(req.Messages)+1)
+	if req.System != "" {
+		msgs = append(msgs, chatMessage{Role: "system", Content: req.System})
+	}
+	for _, m := range req.Messages {
+		cm := chatMessage{Role: m.Role, Content: m.Content, ToolCallID: m.ToolCallID}
+		for _, tc := range m.ToolCalls {
+			cm.ToolCalls = append(cm.ToolCalls, chatToolCall{
+				ID: tc.ID, Type: "function",
+				Function: chatFunctionCall{Name: tc.Name, Arguments: tc.Args},
+			})
+		}
+		msgs = append(msgs, cm)
+	}
+	tools := make([]chatTool, 0, len(req.Tools))
+	for _, t := range req.Tools {
+		tools = append(tools, chatTool{Type: "function", Function: chatFunction{
+			Name: t.Name, Description: t.Description, Parameters: json.RawMessage(t.Schema),
+		}})
+	}
+
+	body, err := json.Marshal(chatRequest{Model: c.model, Messages: msgs, Tools: tools})
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return providers.CompletionResponse{}, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	}
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("chat request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return providers.CompletionResponse{}, fmt.Errorf("chat status %d: %s", resp.StatusCode, string(data))
+	}
+	var cr chatResponse
+	if err := json.Unmarshal(data, &cr); err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("parse response: %w", err)
+	}
+	if len(cr.Choices) == 0 {
+		return providers.CompletionResponse{}, fmt.Errorf("no choices in response")
+	}
+	msg := cr.Choices[0].Message
+	out := providers.CompletionResponse{Text: msg.Content}
+	for _, tc := range msg.ToolCalls {
+		out.ToolCalls = append(out.ToolCalls, providers.ToolCall{ID: tc.ID, Name: tc.Function.Name, Args: tc.Function.Arguments})
+	}
+	return out, nil
+}

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -1,0 +1,55 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestComplete(t *testing.T) {
+	var gotReq chatRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer k" {
+			t.Errorf("auth header = %q, want Bearer k", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Errorf("decode request: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(chatResponse{Choices: []chatChoice{{Message: chatMessage{
+			Role: "assistant",
+			ToolCalls: []chatToolCall{{ID: "tc1", Type: "function", Function: chatFunctionCall{
+				Name: "what_changed", Arguments: `{"namespace":"apps"}`}}},
+		}}}})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-model", "k")
+	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
+		System:   "sys",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Tools:    []providers.ToolSpec{{Name: "what_changed", Description: "d", Schema: `{"type":"object"}`}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	// request mapping
+	if gotReq.Model != "test-model" {
+		t.Fatalf("model = %q", gotReq.Model)
+	}
+	if len(gotReq.Messages) != 2 || gotReq.Messages[0].Role != "system" || gotReq.Messages[1].Content != "hi" {
+		t.Fatalf("messages mapped wrong: %+v", gotReq.Messages)
+	}
+	if len(gotReq.Tools) != 1 || gotReq.Tools[0].Function.Name != "what_changed" {
+		t.Fatalf("tools mapped wrong: %+v", gotReq.Tools)
+	}
+	// response mapping
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "tc1" ||
+		resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
+		t.Fatalf("response tool calls mapped wrong: %+v", resp.ToolCalls)
+	}
+}


### PR DESCRIPTION
`lore serve` now runs a real **LLM investigation** when a model is configured.

- **`internal/model/openai`**: a hand-rolled `/chat/completions` client (covers in-cluster **vLLM**, Ollama, OpenAI, OpenRouter), **`httptest`-tested** for the request/response + tool-call mapping (CI-safe, no API key).
- **`config.Model`** (`base_url` / `model` / `api_key_env`).
- **`serve`** builds the kube client once (shared by the failure-watch + the what-changed tool); when `model.base_url` is set → `LoopInvestigator{model, [WhatChangedTool], OnComplete: log findings}`, else the read-only `LogInvestigator`.

**Verified:** gate green; the no-model smoke (log-only path) is intact. The LLM path runs against any OpenAI-compatible endpoint.

**Next:** Slack/Matrix delivery (replace the `OnComplete` log), native Anthropic, more tools (metrics/logs/catalog).