### PR TITLE
feat(notify): deliver findings to Slack + Matrix

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
 	openai "github.com/Smana/runlore/internal/model/openai"
+	"github.com/Smana/runlore/internal/notify"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/providers/gitops/flux"
 	"github.com/Smana/runlore/internal/server"
@@ -113,6 +114,22 @@ func runServe(args []string) error {
 	return nil
 }
 
+// buildNotifier assembles the configured chat notifiers (best-effort fan-out).
+func buildNotifier(cfg *config.Config, log *slog.Logger) *notify.Multi {
+	var ns []providers.Notifier
+	if env := cfg.Notify.Slack.WebhookURLEnv; env != "" {
+		if url := os.Getenv(env); url != "" {
+			ns = append(ns, notify.NewSlack(url))
+		}
+	}
+	if mc := cfg.Notify.Matrix; mc.Homeserver != "" && mc.RoomID != "" && mc.AccessTokenEnv != "" {
+		if tok := os.Getenv(mc.AccessTokenEnv); tok != "" {
+			ns = append(ns, notify.NewMatrix(mc.Homeserver, mc.RoomID, tok))
+		}
+	}
+	return notify.NewMulti(log, ns...)
+}
+
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
 func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) investigate.Investigator {
@@ -130,6 +147,8 @@ func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) 
 		tools = append(tools, investigate.WhatChangedTool{GitOps: fp})
 	}
 	log.Info("using LLM investigator", "model", cfg.Model.Model, "tools", len(tools))
+	notifier := buildNotifier(cfg, log)
+	log.Info("delivery notifiers", "count", notifier.Len())
 	return &investigate.LoopInvestigator{
 		Model: model,
 		Tools: tools,
@@ -137,6 +156,9 @@ func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) 
 		OnComplete: func(found providers.Investigation) {
 			log.Info("findings",
 				"confidence", found.Confidence, "root_causes", len(found.RootCauses), "unresolved", len(found.Unresolved))
+			if err := notifier.Deliver(context.Background(), found); err != nil {
+				log.Error("deliver findings", "err", err)
+			}
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Actions  ActionPolicy  `yaml:"actions"` // read-only by default; the upper rungs of the autonomy ladder
 	Forge    Forge         `yaml:"forge"`   // git-forge auth (GitHub App) for diff access + curation
 	Model    Model         `yaml:"model"`   // optional; when BaseURL is set, serve uses the LLM investigator
+	Notify   Notify        `yaml:"notify"`  // chat delivery for findings
 }
 
 // Model configures the OpenAI-compatible LLM endpoint used for investigation.
@@ -28,6 +29,24 @@ type Model struct {
 	BaseURL   string `yaml:"base_url"`    // e.g. https://vllm.svc/v1
 	Model     string `yaml:"model"`       // model name
 	APIKeyEnv string `yaml:"api_key_env"` // env var holding the API key (empty = keyless)
+}
+
+// Notify configures where investigation findings are delivered.
+type Notify struct {
+	Slack  SlackNotify  `yaml:"slack"`
+	Matrix MatrixNotify `yaml:"matrix"`
+}
+
+// SlackNotify configures Slack incoming-webhook delivery.
+type SlackNotify struct {
+	WebhookURLEnv string `yaml:"webhook_url_env"` // env var holding the webhook URL
+}
+
+// MatrixNotify configures Matrix delivery.
+type MatrixNotify struct {
+	Homeserver     string `yaml:"homeserver"`
+	RoomID         string `yaml:"room_id"`
+	AccessTokenEnv string `yaml:"access_token_env"` // env var holding the access token
 }
 
 // TriggerPolicy decides what RunLore reacts to.

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -1,0 +1,36 @@
+// Package notify delivers completed investigations to chat (Slack, Matrix).
+package notify
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Format renders an Investigation as a concise markdown-ish message used by all
+// notifiers.
+func Format(inv providers.Investigation) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "*Investigation* — confidence %.0f%%\n", inv.Confidence*100)
+	for i, rc := range inv.RootCauses {
+		fmt.Fprintf(&b, "%d. *%s* (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
+		for _, e := range rc.Evidence {
+			fmt.Fprintf(&b, "   • %s\n", e)
+		}
+		if rc.SuggestedAction != "" {
+			rev := ""
+			if rc.Reversible {
+				rev = " (reversible)"
+			}
+			fmt.Fprintf(&b, "   → suggested: %s%s\n", rc.SuggestedAction, rev)
+		}
+	}
+	if len(inv.Unresolved) > 0 {
+		b.WriteString("*Unresolved:*\n")
+		for _, u := range inv.Unresolved {
+			fmt.Fprintf(&b, "   • %s\n", u)
+		}
+	}
+	return b.String()
+}

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -1,0 +1,29 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func sampleInvestigation() providers.Investigation {
+	return providers.Investigation{
+		Confidence: 0.82,
+		RootCauses: []providers.Hypothesis{{
+			Summary:    "chart 1.15 enabled DB migrations; harbor-db CrashLoopBackOff",
+			Confidence: 0.82, Evidence: []string{"pg_up=0", "migration lock timeout"},
+			SuggestedAction: "flux rollback hr/harbor", Reversible: true,
+		}},
+		Unresolved: []string{"why the migration lock never released"},
+	}
+}
+
+func TestFormat(t *testing.T) {
+	out := Format(sampleInvestigation())
+	for _, want := range []string{"82%", "chart 1.15", "pg_up=0", "flux rollback hr/harbor", "reversible", "why the migration lock"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("formatted message missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -1,0 +1,64 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Matrix delivers via the Matrix client-server send API.
+type Matrix struct {
+	homeserver string
+	roomID     string
+	token      string
+	http       *http.Client
+	txn        atomic.Int64
+}
+
+// NewMatrix builds a Matrix notifier. homeserver is the base URL (e.g.
+// https://matrix.org); roomID is like "!abc:hs"; token is an access token.
+func NewMatrix(homeserver, roomID, token string) *Matrix {
+	return &Matrix{
+		homeserver: strings.TrimRight(homeserver, "/"),
+		roomID:     roomID,
+		token:      token,
+		http:       &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+var _ providers.Notifier = (*Matrix)(nil)
+
+// Deliver sends the formatted investigation as an m.notice message.
+func (m *Matrix) Deliver(ctx context.Context, inv providers.Investigation) error {
+	txn := fmt.Sprintf("runlore-%d", m.txn.Add(1))
+	endpoint := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/send/m.room.message/%s",
+		m.homeserver, url.PathEscape(m.roomID), url.PathEscape(txn))
+
+	body, err := json.Marshal(map[string]string{"msgtype": "m.notice", "body": Format(inv)})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.token)
+	resp, err := m.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("matrix send: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("matrix status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/notify/matrix_test.go
+++ b/internal/notify/matrix_test.go
@@ -1,0 +1,39 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMatrixDeliver(t *testing.T) {
+	var gotPath, gotAuth string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"event_id":"$abc"}`))
+	}))
+	defer srv.Close()
+
+	err := NewMatrix(srv.URL, "!room:hs", "tok").Deliver(context.Background(), sampleInvestigation())
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if !strings.Contains(gotPath, "/_matrix/client/v3/rooms/") || !strings.Contains(gotPath, "/send/m.room.message/") {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Fatalf("auth = %q", gotAuth)
+	}
+	if mt, _ := gotBody["msgtype"].(string); mt != "m.notice" {
+		t.Fatalf("msgtype = %v", gotBody["msgtype"])
+	}
+	if body, _ := gotBody["body"].(string); !strings.Contains(body, "flux rollback hr/harbor") {
+		t.Fatalf("body missing content: %v", gotBody["body"])
+	}
+}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -1,0 +1,75 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Slack delivers via a Slack incoming webhook.
+type Slack struct {
+	webhookURL string
+	http       *http.Client
+}
+
+// NewSlack builds a Slack webhook notifier.
+func NewSlack(webhookURL string) *Slack {
+	return &Slack{webhookURL: webhookURL, http: &http.Client{Timeout: 15 * time.Second}}
+}
+
+var _ providers.Notifier = (*Slack)(nil)
+
+// Deliver posts the formatted investigation to the webhook.
+func (s *Slack) Deliver(ctx context.Context, inv providers.Investigation) error {
+	body, err := json.Marshal(map[string]string{"text": Format(inv)})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack post: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("slack status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// Multi delivers to several notifiers, best-effort: a failing notifier is logged,
+// not propagated, so one bad sink doesn't block the others.
+type Multi struct {
+	notifiers []providers.Notifier
+	log       *slog.Logger
+}
+
+// NewMulti builds a fan-out notifier.
+func NewMulti(log *slog.Logger, notifiers ...providers.Notifier) *Multi {
+	return &Multi{notifiers: notifiers, log: log}
+}
+
+var _ providers.Notifier = (*Multi)(nil)
+
+// Deliver fans out to every notifier; errors are logged, never returned.
+func (m *Multi) Deliver(ctx context.Context, inv providers.Investigation) error {
+	for _, n := range m.notifiers {
+		if err := n.Deliver(ctx, inv); err != nil {
+			m.log.Error("delivery failed", "err", err)
+		}
+	}
+	return nil
+}
+
+// Len reports how many notifiers are configured.
+func (m *Multi) Len() int { return len(m.notifiers) }

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -1,0 +1,67 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestSlackDeliver(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := NewSlack(srv.URL).Deliver(context.Background(), sampleInvestigation()); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	text, _ := got["text"].(string)
+	if text == "" || !contains(text, "flux rollback hr/harbor") {
+		t.Fatalf("unexpected slack payload: %v", got)
+	}
+}
+
+func contains(s, sub string) bool { return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0) }
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// failingNotifier always errors.
+type failingNotifier struct{}
+
+func (failingNotifier) Deliver(context.Context, providers.Investigation) error {
+	return io.ErrUnexpectedEOF
+}
+
+func TestMultiBestEffort(t *testing.T) {
+	var delivered int
+	ok := notifierFunc(func(context.Context, providers.Investigation) error { delivered++; return nil })
+	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), failingNotifier{}, ok)
+	// Must not return an error even though one notifier fails, and must still call the good one.
+	if err := m.Deliver(context.Background(), sampleInvestigation()); err != nil {
+		t.Fatalf("Multi.Deliver returned error: %v", err)
+	}
+	if delivered != 1 {
+		t.Fatalf("good notifier called %d times, want 1", delivered)
+	}
+}
+
+// notifierFunc adapts a func to providers.Notifier.
+type notifierFunc func(context.Context, providers.Investigation) error
+
+func (f notifierFunc) Deliver(ctx context.Context, inv providers.Investigation) error {
+	return f(ctx, inv)
+}


### PR DESCRIPTION
Delivers completed investigations to chat.

- **`internal/notify`**: a shared `Format(Investigation)` renderer + a `Slack` notifier (incoming webhook) + a `Matrix` notifier (client-server `send` API) + `Multi` (best-effort fan-out — one bad sink doesn't block the others). Both notifiers are hand-rolled HTTP, **`httptest`-tested** (CI-safe, no real tokens).
- **`config.Notify`**: `slack.webhook_url_env`, `matrix.{homeserver,room_id,access_token_env}` (secrets via env).
- **`serve`**: builds the configured notifiers; the investigator's `OnComplete` fans out to all.

**Verified:** gate green; `serve` starts. The full path now runs **trigger → policy → workqueue → ReAct loop → findings → Slack/Matrix.**

**Next:** Slack Block Kit + action buttons; the Curator (issue/PR) + catalog (the Learn pillar); secrets via External Secrets.