### PR TITLE
feat(curator): write findings back to the forge (Learn pillar, write half)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"k8s.io/client-go/dynamic"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/investigate"
 	openai "github.com/Smana/runlore/internal/model/openai"
 	"github.com/Smana/runlore/internal/notify"
@@ -31,6 +33,8 @@ import (
 	"github.com/Smana/runlore/internal/server"
 	"github.com/Smana/runlore/internal/trigger"
 	"github.com/Smana/runlore/internal/whatchanged"
+
+	github "github.com/Smana/runlore/internal/forge/github"
 )
 
 var version = "0.0.0-dev"
@@ -131,6 +135,37 @@ func buildNotifier(cfg *config.Config, log *slog.Logger) *notify.Multi {
 	return notify.NewMulti(log, ns...)
 }
 
+// buildCurator returns a Curator when a GitHub App + KB repo are configured, else nil.
+func buildCurator(cfg *config.Config, log *slog.Logger) *curator.Curator {
+	ga := cfg.Forge.GitHubApp
+	if ga.AppID == 0 || ga.InstallationID == 0 || ga.PrivateKeyEnv == "" || cfg.Forge.KBRepo == "" {
+		return nil
+	}
+	pemData := os.Getenv(ga.PrivateKeyEnv)
+	if pemData == "" {
+		log.Warn("curator disabled: empty private key env", "env", ga.PrivateKeyEnv)
+		return nil
+	}
+	key, err := github.ParsePrivateKey(pemData)
+	if err != nil {
+		log.Warn("curator disabled: bad private key", "err", err)
+		return nil
+	}
+	owner, repo, ok := strings.Cut(cfg.Forge.KBRepo, "/")
+	if !ok {
+		log.Warn("curator disabled: kb_repo must be owner/name", "kb_repo", cfg.Forge.KBRepo)
+		return nil
+	}
+	base := cfg.Forge.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+	ts := github.NewAppTokenSource(ga.AppID, ga.InstallationID, key)
+	client := github.New(owner, repo, base, ts.Token)
+	log.Info("curator enabled", "repo", cfg.Forge.KBRepo)
+	return &curator.Curator{Issues: client, MinConfidencePR: 0.75, Log: log}
+}
+
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
 func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) investigate.Investigator {
@@ -158,6 +193,7 @@ func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) 
 	log.Info("using LLM investigator", "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)
 	log.Info("delivery notifiers", "count", notifier.Len())
+	cur := buildCurator(cfg, log)
 	return &investigate.LoopInvestigator{
 		Model: model,
 		Tools: tools,
@@ -167,6 +203,13 @@ func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) 
 				"confidence", found.Confidence, "root_causes", len(found.RootCauses), "unresolved", len(found.Unresolved))
 			if err := notifier.Deliver(context.Background(), found); err != nil {
 				log.Error("deliver findings", "err", err)
+			}
+			if cur != nil {
+				if ref, err := cur.Curate(context.Background(), found); err != nil {
+					log.Error("curate findings", "err", err)
+				} else if ref.URL != "" {
+					log.Info("curated", "url", ref.URL)
+				}
 			}
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,11 +206,11 @@ func (a ActionPolicy) Enabled() bool {
 	return a.Mode != "" && a.Mode != ActionOff
 }
 
-// Forge holds git-forge authentication. A GitHub App is the v1 default: one
-// fine-grained, short-lived identity used for both git access (clone/diff for the
-// what-changed spine) and forge operations (issues/PRs for the Curator).
+// Forge holds git-forge authentication and the curation target repo.
 type Forge struct {
-	GitHubApp GitHubApp `yaml:"github_app"`
+	GitHubApp  GitHubApp `yaml:"github_app"`
+	KBRepo     string    `yaml:"kb_repo"`     // "owner/name" — the catalog repo for curation
+	BaseBranch string    `yaml:"base_branch"` // PR target branch (default "main")
 }
 
 // GitHubApp holds GitHub App credentials. The private key mints 1-hour
@@ -221,4 +221,5 @@ type GitHubApp struct {
 	AppID          int64  `yaml:"app_id"`
 	InstallationID int64  `yaml:"installation_id"`
 	PrivateKeyRef  string `yaml:"private_key_ref"` // Secret name/key (e.g. via External Secrets)
+	PrivateKeyEnv  string `yaml:"private_key_env"` // v1: env var holding the PEM private key
 }

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -1,0 +1,74 @@
+// Package curator writes completed investigations back to the git forge: confident
+// findings become a PR drafting an OKF knowledge entry; less-confident findings
+// become an issue. It closes RunLore's Learn loop. Writes target the forge only.
+package curator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Curator routes an investigation to a PR or an issue by confidence.
+type Curator struct {
+	Issues          providers.IssueProvider
+	MinConfidencePR float64 // confidence ≥ this drafts a PR; otherwise an issue
+	Log             *slog.Logger
+}
+
+// Curate writes the investigation to the forge and returns the created ref.
+func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (providers.Ref, error) {
+	if inv.Confidence >= c.MinConfidencePR {
+		ref, err := c.Issues.OpenPR(ctx, draftKBEntry(inv))
+		if err != nil {
+			return providers.Ref{}, fmt.Errorf("open PR: %w", err)
+		}
+		c.Log.Info("curated as PR", "url", ref.URL, "confidence", inv.Confidence)
+		return ref, nil
+	}
+	ref, err := c.Issues.OpenIssue(ctx, inv)
+	if err != nil {
+		return providers.Ref{}, fmt.Errorf("open issue: %w", err)
+	}
+	c.Log.Info("curated as issue", "url", ref.URL, "confidence", inv.Confidence)
+	return ref, nil
+}
+
+// draftKBEntry renders an investigation as an OKF knowledge entry.
+func draftKBEntry(inv providers.Investigation) providers.KBEntry {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Summary\n\nConfidence %.0f%%.\n\n## Root causes\n", inv.Confidence*100)
+	tags := []string{"runlore", "incident"}
+	for i, rc := range inv.RootCauses {
+		fmt.Fprintf(&b, "%d. **%s** (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
+		for _, e := range rc.Evidence {
+			fmt.Fprintf(&b, "   - evidence: %s\n", e)
+		}
+		if rc.SuggestedAction != "" {
+			fmt.Fprintf(&b, "   - suggested: %s (reversible=%t)\n", rc.SuggestedAction, rc.Reversible)
+		}
+	}
+	if len(inv.Unresolved) > 0 {
+		b.WriteString("\n## Unresolved\n")
+		for _, u := range inv.Unresolved {
+			fmt.Fprintf(&b, "- %s\n", u)
+		}
+	}
+	return providers.KBEntry{
+		Type:        "Incident",
+		Title:       inv.Title,
+		Description: firstLine(inv),
+		Tags:        tags,
+		Body:        b.String(),
+	}
+}
+
+func firstLine(inv providers.Investigation) string {
+	if len(inv.RootCauses) > 0 {
+		return inv.RootCauses[0].Summary
+	}
+	return inv.Title
+}

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -1,0 +1,71 @@
+package curator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeIssues records which route was taken.
+type fakeIssues struct {
+	issue *providers.Investigation
+	pr    *providers.KBEntry
+}
+
+func (f *fakeIssues) OpenIssue(_ context.Context, inv providers.Investigation) (providers.Ref, error) {
+	f.issue = &inv
+	return providers.Ref{URL: "https://github.com/x/y/issues/1"}, nil
+}
+
+func (f *fakeIssues) OpenPR(_ context.Context, e providers.KBEntry) (providers.Ref, error) {
+	f.pr = &e
+	return providers.Ref{URL: "https://github.com/x/y/pull/2"}, nil
+}
+
+func sampleInv(conf float64) providers.Investigation {
+	return providers.Investigation{
+		Title:      "Harbor probe failures after chart bump",
+		Confidence: conf,
+		RootCauses: []providers.Hypothesis{{
+			Summary:    "chart 1.15 added a DB migration; harbor-db CrashLoopBackOff",
+			Confidence: conf, Evidence: []string{"pg_up=0"}, SuggestedAction: "flux rollback hr/harbor", Reversible: true,
+		}},
+		Unresolved: []string{"why the lock never released"},
+	}
+}
+
+func newCurator(f providers.IssueProvider) *Curator {
+	return &Curator{Issues: f, MinConfidencePR: 0.75, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func TestCurateConfidentOpensPR(t *testing.T) {
+	f := &fakeIssues{}
+	ref, err := newCurator(f).Curate(context.Background(), sampleInv(0.9))
+	if err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.pr == nil || f.issue != nil {
+		t.Fatalf("expected PR route, got issue=%v pr=%v", f.issue, f.pr)
+	}
+	if !strings.Contains(ref.URL, "/pull/") {
+		t.Fatalf("unexpected ref: %s", ref.URL)
+	}
+	if f.pr.Title == "" || !strings.Contains(f.pr.Body, "chart 1.15") || f.pr.Type == "" {
+		t.Fatalf("KBEntry not drafted well: %+v", f.pr)
+	}
+}
+
+func TestCurateUncertainOpensIssue(t *testing.T) {
+	f := &fakeIssues{}
+	_, err := newCurator(f).Curate(context.Background(), sampleInv(0.4))
+	if err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.issue == nil || f.pr != nil {
+		t.Fatalf("expected issue route, got issue=%v pr=%v", f.issue, f.pr)
+	}
+}

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// AppTokenSource mints and caches GitHub App installation tokens.
+type AppTokenSource struct {
+	appID     int64
+	installID int64
+	key       *rsa.PrivateKey
+	baseURL   string
+	http      *http.Client
+
+	mu    sync.Mutex
+	token string
+	exp   time.Time
+}
+
+// NewAppTokenSource builds a token source from an App ID, installation ID, and
+// RSA private key.
+func NewAppTokenSource(appID, installID int64, key *rsa.PrivateKey) *AppTokenSource {
+	return &AppTokenSource{appID: appID, installID: installID, key: key,
+		baseURL: "https://api.github.com", http: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// Token returns a valid installation token, refreshing when near expiry.
+func (s *AppTokenSource) Token(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.token != "" && time.Now().Before(s.exp.Add(-1*time.Minute)) {
+		return s.token, nil
+	}
+	jwt, err := mintJWT(s.appID, s.key, time.Now())
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/app/installations/%d/access_tokens", s.baseURL, s.installID), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("installation token: status %d", resp.StatusCode)
+	}
+	var out struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	s.token, s.exp = out.Token, out.ExpiresAt
+	return s.token, nil
+}
+
+// mintJWT builds a short-lived RS256 JWT signed with the App private key.
+func mintJWT(appID int64, key *rsa.PrivateKey, now time.Time) (string, error) {
+	enc := func(v any) (string, error) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", err
+		}
+		return base64.RawURLEncoding.EncodeToString(b), nil
+	}
+	header, err := enc(map[string]string{"alg": "RS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+	claims, err := enc(map[string]any{
+		"iat": now.Add(-30 * time.Second).Unix(),
+		"exp": now.Add(9 * time.Minute).Unix(),
+		"iss": appID,
+	})
+	if err != nil {
+		return "", err
+	}
+	signing := header + "." + claims
+	sum := sha256.Sum256([]byte(signing))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return "", err
+	}
+	return signing + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// ParsePrivateKey parses a PEM-encoded RSA private key (PKCS#1 or PKCS#8).
+func ParsePrivateKey(pemData string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse key: %w", err)
+	}
+	rk, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA private key")
+	}
+	return rk, nil
+}

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMintJWT(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := mintJWT(12345, key, time.Unix(1_000_000, 0))
+	if err != nil {
+		t.Fatalf("mintJWT: %v", err)
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("want 3 JWT segments, got %d", len(parts))
+	}
+	// signature verifies against the public key
+	signing := parts[0] + "." + parts[1]
+	sum := sha256.Sum256([]byte(signing))
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, sum[:], sig); err != nil {
+		t.Fatalf("signature does not verify: %v", err)
+	}
+	// claims carry the app id as issuer
+	claimsJSON, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims map[string]any
+	_ = json.Unmarshal(claimsJSON, &claims)
+	if fmt.Sprint(claims["iss"]) != "12345" {
+		t.Fatalf("iss=%v", claims["iss"])
+	}
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1,0 +1,181 @@
+// Package github implements providers.IssueProvider over the GitHub REST API,
+// authenticated with short-lived GitHub App installation tokens.
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TokenFunc returns a valid installation token (minted/cached by the caller).
+type TokenFunc func(ctx context.Context) (string, error)
+
+// Client is a GitHub forge client scoped to one repo.
+type Client struct {
+	baseURL    string
+	owner      string
+	repo       string
+	baseBranch string
+	token      TokenFunc
+	http       *http.Client
+}
+
+// New builds a client. baseBranch is the PR target (e.g. "main").
+func New(owner, repo, baseBranch string, token TokenFunc) *Client {
+	return &Client{
+		baseURL: "https://api.github.com", owner: owner, repo: repo,
+		baseBranch: baseBranch, token: token, http: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+var _ providers.IssueProvider = (*Client)(nil)
+
+// do performs an authenticated JSON request and decodes the response into out (if non-nil).
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	tok, err := c.token(ctx)
+	if err != nil {
+		return fmt.Errorf("token: %w", err)
+	}
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, rdr)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("github %s %s: status %d: %s", method, path, resp.StatusCode, string(data))
+	}
+	if out != nil {
+		return json.Unmarshal(data, out)
+	}
+	return nil
+}
+
+// OpenIssue files an issue describing the investigation.
+func (c *Client) OpenIssue(ctx context.Context, inv providers.Investigation) (providers.Ref, error) {
+	body := map[string]any{"title": issueTitle(inv), "body": issueBody(inv), "labels": []string{"runlore"}}
+	var out struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues", c.owner, c.repo), body, &out); err != nil {
+		return providers.Ref{}, err
+	}
+	return providers.Ref{URL: out.HTMLURL}, nil
+}
+
+// OpenPR drafts the KB entry on a new branch and opens a PR.
+func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref, error) {
+	slug := slugify(e.Title)
+	branch := fmt.Sprintf("runlore/kb-%s-%d", slug, time.Now().Unix())
+	path := slug + ".md"
+
+	// 1. base ref SHA
+	var ref struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", c.owner, c.repo, c.baseBranch), nil, &ref); err != nil {
+		return providers.Ref{}, err
+	}
+	// 2. create branch
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/git/refs", c.owner, c.repo),
+		map[string]any{"ref": "refs/heads/" + branch, "sha": ref.Object.SHA}, nil); err != nil {
+		return providers.Ref{}, err
+	}
+	// 3. write the OKF file on the branch
+	content := base64.StdEncoding.EncodeToString([]byte(renderEntry(e)))
+	if err := c.do(ctx, http.MethodPut, fmt.Sprintf("/repos/%s/%s/contents/%s", c.owner, c.repo, path),
+		map[string]any{"message": "runlore: draft KB entry " + e.Title, "content": content, "branch": branch}, nil); err != nil {
+		return providers.Ref{}, err
+	}
+	// 4. open the PR
+	var out struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/pulls", c.owner, c.repo),
+		map[string]any{"title": "KB: " + e.Title, "head": branch, "base": c.baseBranch, "body": "Drafted by RunLore."}, &out); err != nil {
+		return providers.Ref{}, err
+	}
+	return providers.Ref{URL: out.HTMLURL}, nil
+}
+
+func issueTitle(inv providers.Investigation) string {
+	if inv.Title != "" {
+		return inv.Title
+	}
+	return "RunLore investigation"
+}
+
+func issueBody(inv providers.Investigation) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Confidence %.0f%%.\n\n", inv.Confidence*100)
+	for i, rc := range inv.RootCauses {
+		fmt.Fprintf(&b, "%d. %s (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
+	}
+	for _, u := range inv.Unresolved {
+		fmt.Fprintf(&b, "- unresolved: %s\n", u)
+	}
+	return b.String()
+}
+
+// renderEntry serializes a KBEntry as OKF markdown (frontmatter + body).
+func renderEntry(e providers.KBEntry) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	fmt.Fprintf(&b, "type: %s\n", e.Type)
+	fmt.Fprintf(&b, "title: %s\n", e.Title)
+	fmt.Fprintf(&b, "description: %s\n", e.Description)
+	if len(e.Tags) > 0 {
+		fmt.Fprintf(&b, "tags: [%s]\n", strings.Join(e.Tags, ", "))
+	}
+	b.WriteString("---\n\n")
+	b.WriteString(e.Body)
+	b.WriteString("\n")
+	return b.String()
+}
+
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func staticToken(string) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) { return "tok", nil }
+}
+
+func TestOpenIssue(t *testing.T) {
+	var gotAuth, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotPath = r.Header.Get("Authorization"), r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/issues/7"}`))
+	}))
+	defer srv.Close()
+
+	c := New("o", "r", "main", staticToken("tok"))
+	c.baseURL = srv.URL
+	ref, err := c.OpenIssue(context.Background(), providers.Investigation{Title: "Boom", Confidence: 0.4,
+		RootCauses: []providers.Hypothesis{{Summary: "db down"}}})
+	if err != nil {
+		t.Fatalf("OpenIssue: %v", err)
+	}
+	if gotAuth != "Bearer tok" || gotPath != "/repos/o/r/issues" {
+		t.Fatalf("auth=%q path=%q", gotAuth, gotPath)
+	}
+	if title, _ := gotBody["title"].(string); title != "Boom" {
+		t.Fatalf("title=%v", gotBody["title"])
+	}
+	if ref.URL != "https://github.com/o/r/issues/7" {
+		t.Fatalf("ref=%s", ref.URL)
+	}
+}
+
+func TestOpenPR(t *testing.T) {
+	var paths []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("PUT /repos/o/r/contents/", func(w http.ResponseWriter, _ *http.Request) {
+		paths = append(paths, "PUT contents")
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/9"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New("o", "r", "main", staticToken("tok"))
+	c.baseURL = srv.URL
+	ref, err := c.OpenPR(context.Background(), providers.KBEntry{Type: "Incident", Title: "DB outage", Body: "## body"})
+	if err != nil {
+		t.Fatalf("OpenPR: %v", err)
+	}
+	if ref.URL != "https://github.com/o/r/pull/9" {
+		t.Fatalf("ref=%s", ref.URL)
+	}
+	if len(paths) != 4 || !strings.Contains(strings.Join(paths, ","), "PUT contents") {
+		t.Fatalf("expected the 4-call PR sequence, got %v", paths)
+	}
+}


### PR DESCRIPTION
The **write half of the Learn pillar** — closes the loop. After an investigation, the **Curator** writes it to the git forge: confident findings draft an OKF knowledge entry as a **PR**; less-confident findings open an **issue**. Auth is a GitHub App (short-lived installation tokens); all writes target the forge, never the cluster.

- **`internal/curator`**: confidence-routed `Curate` (≥ threshold → `OpenPR(draftKBEntry(inv))`, else `OpenIssue(inv)`). Tested against a fake `IssueProvider`.
- **`internal/forge/github`**: `IssueProvider` over GitHub REST — `OpenIssue` (POST) + `OpenPR` (4-call: base ref → branch → contents → PR). `httptest`-tested.
- **`internal/forge/github/auth`**: `AppTokenSource` — JWT RS256 (hand-rolled, no dep) → installation token, cached. JWT unit-tested.
- **`config.Forge.{KBRepo, BaseBranch}`** + `GitHubApp.PrivateKeyEnv`; `serve` curates in `OnComplete` when a GitHub App is configured.

**Verified:** gate + `-race` clean; no-forge smoke (curator stays disabled).

**The Learn loop is closed:** the agent **reads** the catalog (`kb_search`) *and* **contributes back** to it (curator) — self-improving.

**Next:** novelty/dedup (don't re-file known incidents); instant-recall; catalog git-sync (read↔write); GitLab; private key via External Secrets.