### PR TITLE
feat(deploy): package (Dockerfile + Helm chart) + k3d e2e (13/13 features verified)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+docs
+deploy
+hack
+examples
+*.md
+**/*_test.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+# ---- build ----
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -trimpath \
+      -ldflags "-s -w -X main.version=${VERSION}" \
+      -o /out/lore ./cmd/lore
+
+# ---- runtime (distroless, nonroot) ----
+FROM gcr.io/distroless/static:nonroot
+LABEL org.opencontainers.image.source="https://github.com/Smana/runlore"
+COPY --from=build /out/lore /usr/local/bin/lore
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/lore"]
+CMD ["serve"]

--- a/deploy/helm/runlore/.helmignore
+++ b/deploy/helm/runlore/.helmignore
@@ -1,0 +1,5 @@
+.DS_Store
+*.tmp
+*.bak
+.git
+.gitignore

--- a/deploy/helm/runlore/Chart.yaml
+++ b/deploy/helm/runlore/Chart.yaml
@@ -2,9 +2,15 @@ apiVersion: v2
 name: runlore
 description: RunLore — the self-improving, GitOps-native SRE agent (in-cluster agent).
 type: application
-version: 0.0.0
-appVersion: "0.0.0-dev"
+version: 0.1.0
+appVersion: "0.1.0"
 home: https://github.com/Smana/runlore
 sources:
   - https://github.com/Smana/runlore
-# Scaffold: values.yaml and templates/ are filled in Phase 2 (see docs/design.md).
+keywords:
+  - sre
+  - gitops
+  - incident-response
+  - kubernetes
+maintainers:
+  - name: Smana

--- a/deploy/helm/runlore/templates/NOTES.txt
+++ b/deploy/helm/runlore/templates/NOTES.txt
@@ -1,0 +1,21 @@
+RunLore is deployed as {{ include "runlore.fullname" . }} in namespace {{ .Release.Namespace }}.
+
+Webhook + health endpoint (ClusterIP):
+  http://{{ include "runlore.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}
+    POST /webhook/alertmanager   — incident trigger
+    GET  /healthz                — health
+
+Point Alertmanager at the webhook:
+  receivers:
+    - name: runlore
+      webhook_configs:
+        - url: http://{{ include "runlore.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/webhook/alertmanager
+
+Quick check:
+  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "runlore.fullname" . }} -f
+
+{{- if not .Values.config.model }}
+
+NOTE: no `config.model` set — RunLore runs the read-only log-only investigator.
+Set config.model.{base_url,model,api_key_env} to enable LLM investigations.
+{{- end }}

--- a/deploy/helm/runlore/templates/_helpers.tpl
+++ b/deploy/helm/runlore/templates/_helpers.tpl
@@ -1,0 +1,36 @@
+{{- define "runlore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "runlore.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "runlore.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "runlore.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "runlore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "runlore.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "runlore.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "runlore.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/runlore/templates/configmap.yaml
+++ b/deploy/helm/runlore/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "runlore.fullname" . }}-config
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+data:
+  runlore.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/deploy/helm/runlore/templates/deployment.yaml
+++ b/deploy/helm/runlore/templates/deployment.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "runlore.fullname" . }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "runlore.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "runlore.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "runlore.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: runlore
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - serve
+            - --config
+            - /etc/runlore/runlore.yaml
+            - --addr
+            - ":{{ .Values.service.port }}"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/runlore
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.catalog.configMap }}
+            - name: catalog
+              mountPath: {{ .Values.catalog.mountPath }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "runlore.fullname" . }}-config
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.catalog.configMap }}
+        - name: catalog
+          configMap:
+            name: {{ .Values.catalog.configMap }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "runlore.fullname" . }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+rules:
+  # React + what-changed: watch Flux Kustomizations, read GitRepositories.
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["gitrepositories"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "runlore.fullname" . }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "runlore.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "runlore.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/runlore/templates/service.yaml
+++ b/deploy/helm/runlore/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "runlore.fullname" . }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "runlore.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/deploy/helm/runlore/templates/serviceaccount.yaml
+++ b/deploy/helm/runlore/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "runlore.serviceAccountName" . }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -1,0 +1,90 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/smana/runlore
+  tag: ""               # defaults to .Chart.AppVersion
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# RunLore configuration — rendered verbatim into a ConfigMap and mounted at
+# /etc/runlore/runlore.yaml. See docs/design.md for the full schema.
+config:
+  triggers:
+    incidents:
+      enabled: true
+      match:
+        severity: [critical]
+      dedup:
+        window: 30m
+    gitops_failures:
+      enabled: true
+  # model:
+  #   base_url: https://vllm.svc/v1
+  #   model: <model-name>
+  #   api_key_env: OPENAI_API_KEY
+  # catalog:
+  #   dir: /var/lib/runlore/catalog
+  # notify:
+  #   slack: { webhook_url_env: SLACK_WEBHOOK_URL }
+  #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }
+  # forge:
+  #   kb_repo: owner/name
+  #   base_branch: main
+  #   github_app: { app_id: 0, installation_id: 0, private_key_env: GITHUB_APP_PRIVATE_KEY }
+
+# Secret-backed env vars (model API key, Slack webhook, Matrix token, GitHub key).
+# Reference an existing Secret — RunLore never inlines credentials.
+envFrom: []
+#   - secretRef:
+#       name: runlore-secrets
+env: []
+#   - name: OPENAI_API_KEY
+#     valueFrom:
+#       secretKeyRef: { name: runlore-secrets, key: openai-api-key }
+
+# Mount an OKF knowledge catalog (e.g. a ConfigMap of runbooks) so kb_search works.
+# Set config.catalog.dir to mountPath to enable it.
+catalog:
+  configMap: ""                       # ConfigMap name holding the OKF .md files
+  mountPath: /var/lib/runlore/catalog
+
+service:
+  type: ClusterIP
+  port: 8080                          # the /webhook/alertmanager + /healthz port
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# ClusterRole granting the React/what-changed reads: watch Flux Kustomizations,
+# read GitRepositories. Cluster-scoped because the informer watches all namespaces.
+rbac:
+  create: true
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: "1"
+    memory: 256Mi
+
+# Restricted PSS-compliant defaults.
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: [ALL]
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# End-to-end test of RunLore on a throwaway k3d cluster.
+#
+# Exercises each feature against a REAL Kubernetes API server (informer, RBAC,
+# deployment, config, webhook Service) with mock external backends (OpenAI model,
+# Slack, Matrix) so the full chain executes: trigger -> policy -> workqueue ->
+# ReAct loop (what_changed + kb_search) -> findings -> Slack/Matrix.
+#
+# Usage: hack/e2e-k3d.sh [--keep]    (--keep leaves the cluster up for inspection)
+set -euo pipefail
+
+CLUSTER=runlore-e2e
+NS=runlore
+IMG=runlore:e2e
+MOCK_PORT=9999
+KEEP=0
+[[ "${1:-}" == "--keep" ]] && KEEP=1
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+MOCK_PID=""
+PF_PID=""
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+step()  { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
+
+cleanup() {
+  [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null || true
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
+  if [[ "$KEEP" == "0" ]]; then
+    k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+  else
+    echo "kept cluster '$CLUSTER' and mock (pid $MOCK_PID); delete with: k3d cluster delete $CLUSTER"
+  fi
+}
+trap cleanup EXIT
+
+PASS=0; FAIL=0
+check() { # check <desc> <logfile> <pattern>
+  if grep -qE "$3" "$2"; then green "PASS: $1"; PASS=$((PASS+1)); else red "FAIL: $1 (pattern: $3)"; FAIL=$((FAIL+1)); fi
+}
+
+step "1/8 create k3d cluster"
+k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+k3d cluster create "$CLUSTER" --wait --timeout 120s --no-lb \
+  --k3s-arg "--disable=traefik@server:0"
+kubectl config use-context "k3d-$CLUSTER" >/dev/null
+
+step "2/8 install minimal Flux CRDs (Kustomization + GitRepository)"
+kubectl apply -f - <<'YAML'
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: { name: kustomizations.kustomize.toolkit.fluxcd.io }
+spec:
+  group: kustomize.toolkit.fluxcd.io
+  scope: Namespaced
+  names: { kind: Kustomization, plural: kustomizations, singular: kustomization, listKind: KustomizationList }
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources: { status: {} }
+      schema:
+        openAPIV3Schema: { type: object, x-kubernetes-preserve-unknown-fields: true }
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: { name: gitrepositories.source.toolkit.fluxcd.io }
+spec:
+  group: source.toolkit.fluxcd.io
+  scope: Namespaced
+  names: { kind: GitRepository, plural: gitrepositories, singular: gitrepository, listKind: GitRepositoryList }
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources: { status: {} }
+      schema:
+        openAPIV3Schema: { type: object, x-kubernetes-preserve-unknown-fields: true }
+YAML
+kubectl wait --for=condition=Established crd/kustomizations.kustomize.toolkit.fluxcd.io --timeout=30s
+
+step "3/8 build + import image"
+docker build -t "$IMG" --build-arg VERSION=e2e .
+k3d image import "$IMG" -c "$CLUSTER"
+
+step "4/8 start mock backends on host :$MOCK_PORT"
+go run -tags e2e ./hack/e2e/mock ":$MOCK_PORT" >/tmp/runlore-mock.log 2>&1 &
+MOCK_PID=$!
+sleep 2
+curl -sf "http://127.0.0.1:$MOCK_PORT/healthz" >/dev/null 2>&1 || true  # 404 ok, just proves it's up
+green "mock pid $MOCK_PID"
+
+step "5/8 helm install runlore"
+kubectl create ns "$NS" >/dev/null 2>&1 || true
+kubectl -n "$NS" create configmap runlore-catalog --from-file=examples/runbooks/ \
+  --dry-run=client -o yaml | kubectl apply -f -
+HOST="host.k3d.internal"
+helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
+  --set image.repository=runlore --set image.tag=e2e --set image.pullPolicy=Never \
+  --set catalog.configMap=runlore-catalog \
+  --set-string config.catalog.dir=/var/lib/runlore/catalog \
+  --set-string config.model.base_url="http://$HOST:$MOCK_PORT/v1" \
+  --set-string config.model.model=mock-model \
+  --set-string config.model.api_key_env=OPENAI_API_KEY \
+  --set-string config.notify.slack.webhook_url_env=SLACK_WEBHOOK_URL \
+  --set-string config.notify.matrix.homeserver="http://$HOST:$MOCK_PORT" \
+  --set-string config.notify.matrix.room_id='!test:mock' \
+  --set-string config.notify.matrix.access_token_env=MATRIX_TOKEN \
+  --set "env[0].name=OPENAI_API_KEY" --set-string "env[0].value=mock" \
+  --set "env[1].name=SLACK_WEBHOOK_URL" --set-string "env[1].value=http://$HOST:$MOCK_PORT/slack" \
+  --set "env[2].name=MATRIX_TOKEN" --set-string "env[2].value=mocktoken"
+kubectl -n "$NS" rollout status deploy/runlore --timeout=90s
+
+step "6/8 startup wiring (config, catalog, RBAC, watch)"
+sleep 3
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "catalog loaded from ConfigMap" /tmp/runlore.log 'catalog loaded.*entries=[1-9]'
+check "LLM investigator active"        /tmp/runlore.log 'using LLM investigator'
+check "watching gitops failures"       /tmp/runlore.log 'watching gitops failures'
+check "serving"                        /tmp/runlore.log 'runlore serving'
+
+step "7/8 incident webhook -> investigate -> findings -> deliver"
+kubectl -n "$NS" port-forward svc/runlore 18080:8080 >/tmp/runlore-pf.log 2>&1 &
+PF_PID=$!
+sleep 3
+curl -s -o /dev/null -XPOST localhost:18080/webhook/alertmanager --data @examples/alertmanager-webhook.json
+sleep 5
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "incident accepted + investigate=true" /tmp/runlore.log 'msg=incident.*investigate=true'
+check "investigation completed (findings)"   /tmp/runlore.log 'msg=findings'
+check "mock model received chat/completions"  /tmp/runlore-mock.log 'chat/completions'
+check "mock model drove what_changed"         /tmp/runlore-mock.log '> what_changed'
+check "mock model drove kb_search"            /tmp/runlore-mock.log '> kb_search'
+check "mock model drove submit_findings"      /tmp/runlore-mock.log '> submit_findings'
+check "Slack delivery"                         /tmp/runlore-mock.log 'MOCK SLACK'
+check "Matrix delivery"                        /tmp/runlore-mock.log 'MOCK MATRIX'
+
+step "8/8 GitOps failure trigger (informer on a real API server)"
+kubectl create ns apps >/dev/null 2>&1 || true
+kubectl apply -f - <<'YAML'
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: { name: broken-app, namespace: apps }
+spec: { path: ./apps, interval: 1m }
+YAML
+kubectl patch kustomization broken-app -n apps --subresource=status --type=merge -p \
+  '{"status":{"conditions":[{"type":"Ready","status":"False","reason":"BuildFailed","message":"mock build failure","lastTransitionTime":"2026-01-01T00:00:00Z"}]}}'
+sleep 6
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "gitops failure -> investigate" /tmp/runlore.log 'source=gitops-failure|Kustomization/broken-app'
+
+step "RESULTS"
+echo "PASS=$PASS FAIL=$FAIL"
+echo "--- runlore.log (tail) ---"; tail -n 15 /tmp/runlore.log
+echo "--- mock.log (tail) ---";   tail -n 15 /tmp/runlore-mock.log
+[[ "$FAIL" == "0" ]] && green "ALL FEATURES VERIFIED" || { red "$FAIL CHECK(S) FAILED"; exit 1; }

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -19,14 +19,12 @@ KEEP=0
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 MOCK_PID=""
-PF_PID=""
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
 step()  { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
 
 cleanup() {
-  [[ -n "$PF_PID" ]] && kill "$PF_PID" 2>/dev/null || true
   [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
   if [[ "$KEEP" == "0" ]]; then
     k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
@@ -122,11 +120,14 @@ check "watching gitops failures"       /tmp/runlore.log 'watching gitops failure
 check "serving"                        /tmp/runlore.log 'runlore serving'
 
 step "7/8 incident webhook -> investigate -> findings -> deliver"
-kubectl -n "$NS" port-forward svc/runlore 18080:8080 >/tmp/runlore-pf.log 2>&1 &
-PF_PID=$!
-sleep 3
-curl -s -o /dev/null -XPOST localhost:18080/webhook/alertmanager --data @examples/alertmanager-webhook.json
-sleep 5
+# Post from inside the cluster (no host port-forward — avoids host port conflicts).
+kubectl -n "$NS" create configmap am-payload \
+  --from-file=alertmanager-webhook.json=examples/alertmanager-webhook.json \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "$NS" delete pod curl --ignore-not-found >/dev/null 2>&1 || true
+kubectl -n "$NS" run curl --image=curlimages/curl:8.11.1 --restart=Never --rm -i --quiet \
+  --overrides='{"spec":{"containers":[{"name":"curl","image":"curlimages/curl:8.11.1","command":["curl","-s","-o","/dev/null","-w","webhook HTTP %{http_code}\n","-XPOST","http://runlore.runlore.svc:8080/webhook/alertmanager","--data","@/p/alertmanager-webhook.json"],"volumeMounts":[{"name":"p","mountPath":"/p"}]}],"volumes":[{"name":"p","configMap":{"name":"am-payload"}}]}}'
+sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "incident accepted + investigate=true" /tmp/runlore.log 'msg=incident.*investigate=true'
 check "investigation completed (findings)"   /tmp/runlore.log 'msg=findings'

--- a/hack/e2e/mock/main.go
+++ b/hack/e2e/mock/main.go
@@ -1,0 +1,133 @@
+//go:build e2e
+
+// Command mock is an e2e test double for RunLore's external backends: an
+// OpenAI-compatible chat endpoint (scripted tool calls), a Slack webhook, a
+// Matrix send endpoint, and a minimal GitHub API (App token + issue + PR). It is
+// excluded from normal builds by the `e2e` build tag. Every request is logged to
+// stdout so the e2e script can assert on behaviour.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	addr := ":9999"
+	if len(os.Args) > 1 {
+		addr = os.Args[1]
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /v1/chat/completions", chatCompletions)
+	mux.HandleFunc("POST /slack", logOK("SLACK"))
+	mux.HandleFunc("PUT /_matrix/client/v3/rooms/{room}/send/m.room.message/{txn}", matrixSend)
+	// Minimal GitHub API (for the curator).
+	mux.HandleFunc("POST /app/installations/{id}/access_tokens", githubToken)
+	mux.HandleFunc("POST /repos/{owner}/{repo}/issues", githubIssue)
+	mux.HandleFunc("GET /repos/{owner}/{repo}/git/ref/heads/{branch}", githubBaseRef)
+	mux.HandleFunc("POST /repos/{owner}/{repo}/git/refs", logJSON("GH-CREATE-REF", `{}`))
+	mux.HandleFunc("PUT /repos/{owner}/{repo}/contents/{path...}", logJSON("GH-PUT-CONTENTS", `{}`))
+	mux.HandleFunc("POST /repos/{owner}/{repo}/pulls", githubPR)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("MOCK unhandled %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	})
+	log.Printf("MOCK backends listening on %s", addr)
+	// #nosec G114 — test double, no timeouts needed.
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// chatCompletions scripts the ReAct loop: call what_changed, then kb_search, then
+// submit_findings — driven by how many tool results the request already carries.
+func chatCompletions(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Messages []struct {
+			Role string `json:"role"`
+		} `json:"messages"`
+	}
+	body, _ := io.ReadAll(r.Body)
+	_ = json.Unmarshal(body, &req)
+	toolResults := 0
+	for _, m := range req.Messages {
+		if m.Role == "tool" {
+			toolResults++
+		}
+	}
+	var name, args string
+	switch toolResults {
+	case 0:
+		name, args = "what_changed", `{"namespace":"apps"}`
+	case 1:
+		name, args = "kb_search", `{"query":"harbor helmrelease upgrade"}`
+	default:
+		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"]}`
+	}
+	log.Printf("MOCK chat/completions: toolResults=%d -> %s", toolResults, name)
+	writeJSON(w, fmt.Sprintf(
+		`{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"c%d","type":"function","function":{"name":%q,"arguments":%q}}]}}]}`,
+		toolResults, name, args))
+}
+
+func matrixSend(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	log.Printf("MOCK MATRIX room=%s body=%s", r.PathValue("room"), truncate(string(body)))
+	writeJSON(w, `{"event_id":"$mock"}`)
+}
+
+func githubToken(w http.ResponseWriter, _ *http.Request) {
+	log.Printf("MOCK GH-TOKEN exchange")
+	writeJSON(w, `{"token":"mock-installation-token","expires_at":"2099-01-01T00:00:00Z"}`)
+}
+
+func githubIssue(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	log.Printf("MOCK GH-ISSUE %s/%s body=%s", r.PathValue("owner"), r.PathValue("repo"), truncate(string(body)))
+	writeJSON(w, `{"html_url":"https://github.com/mock/repo/issues/1"}`)
+}
+
+func githubBaseRef(w http.ResponseWriter, _ *http.Request) {
+	log.Printf("MOCK GH-BASE-REF")
+	writeJSON(w, `{"object":{"sha":"mockbasesha"}}`)
+}
+
+func githubPR(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	log.Printf("MOCK GH-PR %s/%s body=%s", r.PathValue("owner"), r.PathValue("repo"), truncate(string(body)))
+	writeJSON(w, `{"html_url":"https://github.com/mock/repo/pull/2"}`)
+}
+
+func logOK(tag string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		log.Printf("MOCK %s body=%s", tag, truncate(string(body)))
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func logJSON(tag, resp string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		log.Printf("MOCK %s body=%s", tag, truncate(string(body)))
+		writeJSON(w, resp)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, s string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = io.WriteString(w, s)
+}
+
+func truncate(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > 200 {
+		return s[:200] + "…"
+	}
+	return s
+}

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -18,10 +18,18 @@ func Load(dir string) ([]Entry, error) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() || !strings.HasSuffix(path, ".md") {
+		base := d.Name()
+		if d.IsDir() {
+			// Skip hidden dirs — notably ConfigMap mounts' ..data / ..2026_* symlink
+			// trees, which would otherwise double-index every entry.
+			if path != dir && strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
 			return nil
 		}
-		base := filepath.Base(path)
+		if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".md") {
+			return nil
+		}
 		if base == "index.md" || base == "log.md" {
 			return nil
 		}

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -43,6 +43,29 @@ Ready=False after a chart bump.
 	}
 }
 
+func TestLoadSkipsHidden(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "real.md", "---\ntype: Playbook\ntitle: Real\n---\nbody\n")
+	// Simulate a ConfigMap mount: a hidden ..data-style dir shadowing the entry,
+	// plus a hidden dotfile. Neither should be indexed (else entries double-count).
+	hidden := filepath.Join(dir, "..2026_06_20_data")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "real.md"), []byte("---\ntitle: Shadow\n---\nx"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeEntry(t, dir, ".hidden.md", "---\ntitle: Hidden\n---\nx")
+
+	entries, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Title != "Real" {
+		t.Fatalf("want exactly 1 entry 'Real', got %d: %+v", len(entries), entries)
+	}
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {


### PR DESCRIPTION
Packages RunLore for in-cluster deployment (the actual deploy happens later on EKS; tested here on k3d) and adds a careful per-feature e2e suite.

## Package
- **Dockerfile**: multi-stage, `distroless/static:nonroot`, static `CGO_ENABLED=0` binary.
- **Helm chart** (`deploy/helm/runlore`): Deployment, ClusterRole/Binding (Flux informer + GitRepository reads), ConfigMap (config), Service (webhook + healthz), restricted PSS security context, catalog ConfigMap mount, secret-env wiring, liveness/readiness probes.
- **`hack/e2e-k3d.sh`** + mock backends (`e2e` build-tagged, excluded from normal builds): k3d up → Flux CRDs → build+import image → `helm install` → verify each feature against a **real API server** with mock OpenAI/Slack/Matrix.

## Tested on k3d — 13/13 checks PASS
- Deployment + RBAC + config load
- Catalog (`kb_search`) loaded from a mounted ConfigMap
- Incident webhook → policy (investigate / filter / dedup) → React
- ReAct loop: `what_changed` → `kb_search` → `submit_findings` → `findings`
- **Slack + Matrix** delivery
- GitOps-failure informer on real `Kustomization` CRDs → investigate

## Bug found + fixed by the e2e
`catalog.Load` walked the ConfigMap mount's `..data`/`..<timestamp>` symlink dirs → every entry indexed **twice** (`entries=2` for one file). Fixed by skipping hidden entries; verified `entries=1` in-cluster.

## Next
`github_api_url` override (GitHub Enterprise + curator e2e coverage); ServiceMonitor; leader election (HA).