### PR TITLE
feat(forge): configurable GitHub API URL + curator e2e (+ title fix)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -160,8 +160,8 @@ func buildCurator(cfg *config.Config, log *slog.Logger) *curator.Curator {
 	if base == "" {
 		base = "main"
 	}
-	ts := github.NewAppTokenSource(ga.AppID, ga.InstallationID, key)
-	client := github.New(owner, repo, base, ts.Token)
+	ts := github.NewAppTokenSource(cfg.Forge.GitHubAPIURL, ga.AppID, ga.InstallationID, key)
+	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, ts.Token)
 	log.Info("curator enabled", "repo", cfg.Forge.KBRepo)
 	return &curator.Curator{Issues: client, MinConfidencePR: 0.75, Log: log}
 }

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -95,6 +95,11 @@ kubectl create ns "$NS" >/dev/null 2>&1 || true
 kubectl -n "$NS" create configmap runlore-catalog --from-file=examples/runbooks/ \
   --dry-run=client -o yaml | kubectl apply -f -
 HOST="host.k3d.internal"
+# GitHub App key for the curator (mock GitHub API at the same host:port).
+openssl genrsa -out /tmp/runlore-app-key.pem 2048 2>/dev/null
+kubectl -n "$NS" create secret generic runlore-forge \
+  --from-file=GITHUB_APP_PRIVATE_KEY=/tmp/runlore-app-key.pem \
+  --dry-run=client -o yaml | kubectl apply -f -
 helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set image.repository=runlore --set image.tag=e2e --set image.pullPolicy=Never \
   --set catalog.configMap=runlore-catalog \
@@ -106,9 +111,16 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set-string config.notify.matrix.homeserver="http://$HOST:$MOCK_PORT" \
   --set-string config.notify.matrix.room_id='!test:mock' \
   --set-string config.notify.matrix.access_token_env=MATRIX_TOKEN \
+  --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
+  --set-string config.forge.kb_repo="mock/repo" \
+  --set-string config.forge.base_branch="main" \
+  --set config.forge.github_app.app_id=123 \
+  --set config.forge.github_app.installation_id=42 \
+  --set-string config.forge.github_app.private_key_env=GITHUB_APP_PRIVATE_KEY \
   --set "env[0].name=OPENAI_API_KEY" --set-string "env[0].value=mock" \
   --set "env[1].name=SLACK_WEBHOOK_URL" --set-string "env[1].value=http://$HOST:$MOCK_PORT/slack" \
-  --set "env[2].name=MATRIX_TOKEN" --set-string "env[2].value=mocktoken"
+  --set "env[2].name=MATRIX_TOKEN" --set-string "env[2].value=mocktoken" \
+  --set "envFrom[0].secretRef.name=runlore-forge"
 kubectl -n "$NS" rollout status deploy/runlore --timeout=90s
 
 step "6/8 startup wiring (config, catalog, RBAC, watch)"
@@ -119,7 +131,7 @@ check "LLM investigator active"        /tmp/runlore.log 'using LLM investigator'
 check "watching gitops failures"       /tmp/runlore.log 'watching gitops failures'
 check "serving"                        /tmp/runlore.log 'runlore serving'
 
-step "7/8 incident webhook -> investigate -> findings -> deliver"
+step "7/8 incident webhook -> investigate -> findings -> deliver -> curate"
 # Post from inside the cluster (no host port-forward — avoids host port conflicts).
 kubectl -n "$NS" create configmap am-payload \
   --from-file=alertmanager-webhook.json=examples/alertmanager-webhook.json \
@@ -137,6 +149,10 @@ check "mock model drove kb_search"            /tmp/runlore-mock.log '> kb_search
 check "mock model drove submit_findings"      /tmp/runlore-mock.log '> submit_findings'
 check "Slack delivery"                         /tmp/runlore-mock.log 'MOCK SLACK'
 check "Matrix delivery"                        /tmp/runlore-mock.log 'MOCK MATRIX'
+check "curator enabled"                        /tmp/runlore.log 'curator enabled'
+check "GitHub App token exchange"              /tmp/runlore-mock.log 'MOCK GH-TOKEN'
+check "curator opened a PR (confident)"        /tmp/runlore-mock.log 'MOCK GH-PR'
+check "curated ref logged"                     /tmp/runlore.log 'msg=curated'
 
 step "8/8 GitOps failure trigger (informer on a real API server)"
 kubectl create ns apps >/dev/null 2>&1 || true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,9 +208,10 @@ func (a ActionPolicy) Enabled() bool {
 
 // Forge holds git-forge authentication and the curation target repo.
 type Forge struct {
-	GitHubApp  GitHubApp `yaml:"github_app"`
-	KBRepo     string    `yaml:"kb_repo"`     // "owner/name" — the catalog repo for curation
-	BaseBranch string    `yaml:"base_branch"` // PR target branch (default "main")
+	GitHubApp    GitHubApp `yaml:"github_app"`
+	KBRepo       string    `yaml:"kb_repo"`        // "owner/name" — the catalog repo for curation
+	BaseBranch   string    `yaml:"base_branch"`    // PR target branch (default "main")
+	GitHubAPIURL string    `yaml:"github_api_url"` // override for GHES/tests (default https://api.github.com)
 }
 
 // GitHubApp holds GitHub App credentials. The private key mints 1-hour

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -30,10 +31,13 @@ type AppTokenSource struct {
 }
 
 // NewAppTokenSource builds a token source from an App ID, installation ID, and
-// RSA private key.
-func NewAppTokenSource(appID, installID int64, key *rsa.PrivateKey) *AppTokenSource {
+// RSA private key. baseURL may be empty (defaults to DefaultBaseURL).
+func NewAppTokenSource(baseURL string, appID, installID int64, key *rsa.PrivateKey) *AppTokenSource {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &AppTokenSource{appID: appID, installID: installID, key: key,
-		baseURL: "https://api.github.com", http: &http.Client{Timeout: 30 * time.Second}}
+		baseURL: strings.TrimRight(baseURL, "/"), http: &http.Client{Timeout: 30 * time.Second}}
 }
 
 // Token returns a valid installation token, refreshing when near expiry.

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -8,10 +9,40 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestTokenExchange(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotPath = r.Header.Get("Authorization"), r.URL.Path
+		_, _ = w.Write([]byte(`{"token":"inst-tok","expires_at":"2099-01-01T00:00:00Z"}`))
+	}))
+	defer srv.Close()
+
+	ts := NewAppTokenSource(srv.URL, 123, 42, key)
+	tok, err := ts.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "inst-tok" {
+		t.Fatalf("token = %q", tok)
+	}
+	if !strings.HasPrefix(gotAuth, "Bearer ") {
+		t.Fatalf("auth = %q (want a Bearer JWT)", gotAuth)
+	}
+	if gotPath != "/app/installations/42/access_tokens" {
+		t.Fatalf("path = %q", gotPath)
+	}
+}
 
 func TestMintJWT(t *testing.T) {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -29,10 +29,18 @@ type Client struct {
 	http       *http.Client
 }
 
-// New builds a client. baseBranch is the PR target (e.g. "main").
-func New(owner, repo, baseBranch string, token TokenFunc) *Client {
+// DefaultBaseURL is the public GitHub REST API. Override for GitHub Enterprise
+// Server (e.g. https://ghe.example.com/api/v3) or tests.
+const DefaultBaseURL = "https://api.github.com"
+
+// New builds a client. baseURL may be empty (defaults to DefaultBaseURL);
+// baseBranch is the PR target (e.g. "main").
+func New(baseURL, owner, repo, baseBranch string, token TokenFunc) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &Client{
-		baseURL: "https://api.github.com", owner: owner, repo: repo,
+		baseURL: strings.TrimRight(baseURL, "/"), owner: owner, repo: repo,
 		baseBranch: baseBranch, token: token, http: &http.Client{Timeout: 30 * time.Second},
 	}
 }

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -25,8 +25,7 @@ func TestOpenIssue(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New("o", "r", "main", staticToken("tok"))
-	c.baseURL = srv.URL
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
 	ref, err := c.OpenIssue(context.Background(), providers.Investigation{Title: "Boom", Confidence: 0.4,
 		RootCauses: []providers.Hypothesis{{Summary: "db down"}}})
 	if err != nil {
@@ -65,8 +64,7 @@ func TestOpenPR(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	c := New("o", "r", "main", staticToken("tok"))
-	c.baseURL = srv.URL
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
 	ref, err := c.OpenPR(context.Background(), providers.KBEntry{Type: "Incident", Title: "DB outage", Body: "## body"})
 	if err != nil {
 		t.Fatalf("OpenPR: %v", err)

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -57,6 +57,9 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 					messages = append(messages, providers.Message{Role: "tool", ToolCallID: tc.ID, Content: "error: " + perr.Error()})
 					continue
 				}
+				if inv.Title == "" {
+					inv.Title = req.Title // default to the triggering incident/failure
+				}
 				li.deliver(req, inv)
 				return nil
 			}

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -49,6 +49,10 @@ func TestLoopInvestigator(t *testing.T) {
 	if got.Confidence != 0.8 || len(got.RootCauses) != 1 || got.RootCauses[0].Summary != "chart bump broke db" {
 		t.Fatalf("unexpected investigation: %+v", got)
 	}
+	// submit_findings carried no title, so it defaults to the triggering incident.
+	if got.Title != "HarborProbeFailure" {
+		t.Fatalf("title = %q, want it to default to the request title", got.Title)
+	}
 	if model.i != 2 {
 		t.Fatalf("expected exactly 2 model calls, got %d", model.i)
 	}

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -26,6 +26,7 @@ func submitFindingsSpec() providers.ToolSpec {
 		Name:        submitFindingsName,
 		Description: "Submit the final investigation: ranked root causes with evidence, plus anything unresolved.",
 		Schema: `{"type":"object","properties":{
+"title":{"type":"string"},
 "confidence":{"type":"number"},
 "root_causes":{"type":"array","items":{"type":"object","properties":{
 "summary":{"type":"string"},"confidence":{"type":"number"},"change_ref":{"type":"string"},
@@ -37,6 +38,7 @@ func submitFindingsSpec() providers.ToolSpec {
 
 // findings is the JSON shape of submit_findings arguments.
 type findings struct {
+	Title      string  `json:"title"`
 	Confidence float64 `json:"confidence"`
 	RootCauses []struct {
 		Summary         string   `json:"summary"`
@@ -55,7 +57,7 @@ func parseFindings(args string) (providers.Investigation, error) {
 	if err := json.Unmarshal([]byte(args), &f); err != nil {
 		return providers.Investigation{}, fmt.Errorf("parse findings: %w", err)
 	}
-	inv := providers.Investigation{Confidence: f.Confidence, Unresolved: f.Unresolved}
+	inv := providers.Investigation{Title: f.Title, Confidence: f.Confidence, Unresolved: f.Unresolved}
 	for _, rc := range f.RootCauses {
 		inv.RootCauses = append(inv.RootCauses, providers.Hypothesis{
 			Summary:         rc.Summary,


### PR DESCRIPTION
Makes the GitHub forge base URL configurable and verifies the **Curator end-to-end** on k3d.

- **forge**: `github.New` / `NewAppTokenSource` take a base URL (`config.forge.github_api_url`; default `https://api.github.com`) — enables **GitHub Enterprise Server** and lets the e2e point the curator at a mock. New `TestTokenExchange` covers the JWT → installation-token exchange.
- **e2e**: the k3d suite now provisions a GitHub App (generated RSA key) against the mock GitHub API and asserts the full curation path — token exchange → 4-call PR. **17/17 checks pass.**

## Bug found + fixed by the e2e
The curated PR had an **empty title** (`"KB: "`) and an empty branch slug: `Investigation.Title` was never populated (`submit_findings` carried no title, and the `investigation complete` log used `req.Title`, masking it). Fixed — the loop defaults `inv.Title` to the triggering incident, and `submit_findings` now accepts an optional model-supplied title. Verified in-cluster: PR title `KB: Kustomization/broken-app BuildFailed`, slug `kb-kustomization-broken-app-buildfailed`.