### PR TITLE
feat: leader election for HA (verified on k3d: single leader + failover)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -16,11 +16,17 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
@@ -89,34 +95,120 @@ func runServe(args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Build the (best-effort) dynamic client once: used by both the GitOps-failure
-	// watch and the what-changed tool.
-	var fluxProvider *flux.Provider
-	if client, err := dynamicClient(); err != nil {
-		log.Warn("no kube client; GitOps features disabled", "err", err)
+	// Build kube clients once (best-effort): the dynamic client backs the
+	// GitOps-failure watch + what-changed tool; the clientset backs leader election.
+	var (
+		fluxProvider *flux.Provider
+		clientset    *kubernetes.Clientset
+	)
+	if restCfg, err := restConfig(); err != nil {
+		log.Warn("no kube client; GitOps features + leader election disabled", "err", err)
 	} else {
-		fluxProvider = flux.New(flux.NewDynamicReader(client), &whatchanged.Differ{})
+		if dc, derr := dynamic.NewForConfig(restCfg); derr != nil {
+			log.Warn("dynamic client unavailable; GitOps features disabled", "err", derr)
+		} else {
+			fluxProvider = flux.New(flux.NewDynamicReader(dc), &whatchanged.Differ{})
+		}
+		if cs, cerr := kubernetes.NewForConfig(restCfg); cerr != nil {
+			log.Warn("clientset unavailable; leader election disabled", "err", cerr)
+		} else {
+			clientset = cs
+		}
 	}
 
 	inv := buildInvestigator(cfg, fluxProvider, log)
 	queue := investigate.NewQueue(inv, log)
-	go queue.Run(ctx)
 
-	if cfg.Triggers.GitOpsFailures.Enabled && fluxProvider != nil {
-		startGitOpsFailureWatch(ctx, cfg, queue, fluxProvider, log)
+	// startWork runs the leader-only loops (investigation queue + failure watch),
+	// scoped to a context cancelled when leadership is lost.
+	startWork := func(workCtx context.Context) {
+		go queue.Run(workCtx)
+		if cfg.Triggers.GitOpsFailures.Enabled && fluxProvider != nil {
+			startGitOpsFailureWatch(workCtx, cfg, queue, fluxProvider, log)
+		}
 	}
 
-	srv := server.New(cfg, queue, log)
+	var leader atomic.Bool
+	useLE := cfg.LeaderElection.Enabled && clientset != nil
+	if useLE {
+		go runLeaderElection(ctx, cfg, clientset, &leader, log, startWork)
+	} else {
+		leader.Store(true) // no leader election: this replica is always active + ready
+		startWork(ctx)
+	}
+
+	// readyz reflects leadership so the Service routes webhooks only to the leader.
+	srv := server.New(cfg, queue, leader.Load, log)
 	httpSrv := &http.Server{Addr: *addr, Handler: srv.Handler()}
 	go func() {
 		<-ctx.Done()
 		_ = httpSrv.Shutdown(context.Background())
 	}()
-	log.Info("runlore serving", "addr", *addr)
+	log.Info("runlore serving", "addr", *addr, "leader_election", useLE)
 	if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return err
 	}
 	return nil
+}
+
+// runLeaderElection blocks running Lease-based leader election; the leader runs
+// startWork and reports ready. Lost leadership cancels the work context.
+func runLeaderElection(ctx context.Context, cfg *config.Config, cs *kubernetes.Clientset, leader *atomic.Bool, log *slog.Logger, startWork func(context.Context)) {
+	name := cfg.LeaderElection.Name
+	if name == "" {
+		name = "runlore-leader"
+	}
+	id := podName()
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta:  metav1.ObjectMeta{Name: name, Namespace: podNamespace()},
+		Client:     cs.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{Identity: id},
+	}
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(workCtx context.Context) {
+				log.Info("acquired leadership", "id", id)
+				leader.Store(true)
+				startWork(workCtx)
+			},
+			OnStoppedLeading: func() {
+				log.Info("lost leadership", "id", id)
+				leader.Store(false)
+			},
+			OnNewLeader: func(current string) {
+				if current != id {
+					log.Info("standby; another replica leads", "leader", current)
+				}
+			},
+		},
+	})
+}
+
+// podName returns this pod's identity for leader election.
+func podName() string {
+	if n := os.Getenv("POD_NAME"); n != "" {
+		return n
+	}
+	h, _ := os.Hostname()
+	return h
+}
+
+// podNamespace resolves the namespace from the downward API or the service-account mount.
+func podNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	if b, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(b)); ns != "" {
+			return ns
+		}
+	}
+	return "default"
 }
 
 // buildNotifier assembles the configured chat notifiers (best-effort fan-out).
@@ -226,15 +318,11 @@ func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investig
 	go investigate.DrainFailures(ctx, events, q, trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()))
 }
 
-// dynamicClient builds a dynamic client from in-cluster config, falling back to
-// the default kubeconfig.
-func dynamicClient() (dynamic.Interface, error) {
-	restCfg, err := rest.InClusterConfig()
-	if err != nil {
-		restCfg, err = clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
-		if err != nil {
-			return nil, err
-		}
+// restConfig builds a Kubernetes REST config from in-cluster config, falling back
+// to the default kubeconfig.
+func restConfig() (*rest.Config, error) {
+	if cfg, err := rest.InClusterConfig(); err == nil {
+		return cfg, nil
 	}
-	return dynamic.NewForConfig(restCfg)
+	return clientcmd.BuildConfigFromFlags("", clientcmd.RecommendedHomeFile)
 }

--- a/deploy/helm/runlore/templates/deployment.yaml
+++ b/deploy/helm/runlore/templates/deployment.yaml
@@ -43,10 +43,18 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.env }}
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -54,11 +62,12 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 10
           readinessProbe:
+            # /readyz is gated by leadership — only the leader serves webhook traffic.
             httpGet:
-              path: /healthz
+              path: /readyz
               port: http
             initialDelaySeconds: 2
-            periodSeconds: 10
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/deploy/helm/runlore/templates/pdb.yaml
+++ b/deploy/helm/runlore/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.podDisruptionBudget.create (gt (int .Values.replicaCount) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "runlore.fullname" . }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "runlore.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -28,4 +28,33 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "runlore.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
+# Namespaced lease access for leader election (HA).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "runlore.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "runlore.fullname" . }}-leader-election
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "runlore.fullname" . }}-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "runlore.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -1,4 +1,6 @@
-replicaCount: 1
+# 2+ replicas give failover: only the elected leader is Ready/active; the rest are
+# hot standby. See config.leader_election below.
+replicaCount: 2
 
 image:
   repository: ghcr.io/smana/runlore
@@ -21,6 +23,11 @@ config:
         window: 30m
     gitops_failures:
       enabled: true
+  # HA: only the elected leader runs the informer + investigation queue and reports
+  # ready (the Service then routes webhooks to the leader). Harmless with 1 replica.
+  leader_election:
+    enabled: true
+    name: runlore-leader
   # model:
   #   base_url: https://vllm.svc/v1
   #   model: <model-name>
@@ -50,6 +57,12 @@ env: []
 catalog:
   configMap: ""                       # ConfigMap name holding the OKF .md files
   mountPath: /var/lib/runlore/catalog
+
+# Keeps at least one replica available during voluntary disruptions (only applied
+# when replicaCount > 1).
+podDisruptionBudget:
+  create: true
+  minAvailable: 1
 
 service:
   type: ClusterIP

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -102,6 +102,7 @@ kubectl -n "$NS" create secret generic runlore-forge \
   --dry-run=client -o yaml | kubectl apply -f -
 helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set image.repository=runlore --set image.tag=e2e --set image.pullPolicy=Never \
+  --set replicaCount=1 \
   --set catalog.configMap=runlore-catalog \
   --set-string config.catalog.dir=/var/lib/runlore/catalog \
   --set-string config.model.base_url="http://$HOST:$MOCK_PORT/v1" \
@@ -154,7 +155,7 @@ check "GitHub App token exchange"              /tmp/runlore-mock.log 'MOCK GH-TO
 check "curator opened a PR (confident)"        /tmp/runlore-mock.log 'MOCK GH-PR'
 check "curated ref logged"                     /tmp/runlore.log 'msg=curated'
 
-step "8/8 GitOps failure trigger (informer on a real API server)"
+step "8/9 GitOps failure trigger (informer on a real API server)"
 kubectl create ns apps >/dev/null 2>&1 || true
 kubectl apply -f - <<'YAML'
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -167,6 +168,35 @@ kubectl patch kustomization broken-app -n apps --subresource=status --type=merge
 sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "gitops failure -> investigate" /tmp/runlore.log 'source=gitops-failure|Kustomization/broken-app'
+
+step "9/9 leader election + failover (scale to 2)"
+kubectl -n "$NS" scale deploy/runlore --replicas=2 >/dev/null
+TOTAL=0; READY=0
+for _ in $(seq 1 30); do
+  TOTAL=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  READY=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore \
+    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c True || true)
+  [[ "$TOTAL" == "2" && "$READY" == "1" ]] && break
+  sleep 2
+done
+if [[ "$TOTAL" == "2" && "$READY" == "1" ]]; then
+  green "PASS: 2 replicas, exactly 1 Ready (leader); the other is hot standby"; PASS=$((PASS+1))
+else red "FAIL: replicas=$TOTAL ready=$READY (want 2 / 1)"; FAIL=$((FAIL+1)); fi
+
+HOLDER=$(kubectl -n "$NS" get lease runlore-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)
+if [[ -n "$HOLDER" ]]; then green "PASS: Lease held by $HOLDER"; PASS=$((PASS+1))
+else red "FAIL: no Lease holder"; FAIL=$((FAIL+1)); fi
+
+# Failover: delete the leader; a standby must acquire the Lease.
+kubectl -n "$NS" delete pod "$HOLDER" --wait=false >/dev/null 2>&1 || true
+NEW=""
+for _ in $(seq 1 30); do
+  NEW=$(kubectl -n "$NS" get lease runlore-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)
+  [[ -n "$NEW" && "$NEW" != "$HOLDER" ]] && break
+  sleep 2
+done
+if [[ -n "$NEW" && "$NEW" != "$HOLDER" ]]; then green "PASS: failover — new leader $NEW"; PASS=$((PASS+1))
+else red "FAIL: no failover (holder still '$NEW')"; FAIL=$((FAIL+1)); fi
 
 step "RESULTS"
 echo "PASS=$PASS FAIL=$FAIL"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,17 @@ type Config struct {
 	Model    Model         `yaml:"model"`   // optional; when BaseURL is set, serve uses the LLM investigator
 	Notify   Notify        `yaml:"notify"`  // chat delivery for findings
 	Catalog  Catalog       `yaml:"catalog"` // OKF knowledge catalog
+
+	LeaderElection LeaderElection `yaml:"leader_election"` // HA: only the leader investigates
+}
+
+// LeaderElection configures high availability. When enabled, replicas elect a
+// leader via a Lease; only the leader runs the informer watch + investigation
+// queue and reports ready (so the Service routes webhooks to it). Run >1 replica
+// for failover. Disabled by default (single-replica / local).
+type LeaderElection struct {
+	Enabled bool   `yaml:"enabled"`
+	Name    string `yaml:"name"` // Lease name (default "runlore-leader")
 }
 
 // Catalog configures the OKF knowledge catalog read by the agent.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,16 +14,27 @@ import (
 type Server struct {
 	engine   *trigger.Engine
 	enqueuer investigate.Enqueuer
+	ready    func() bool
 	log      *slog.Logger
 	handler  http.Handler
 }
 
-// New builds a Server from config and an investigation enqueuer.
-func New(cfg *config.Config, enq investigate.Enqueuer, log *slog.Logger) *Server {
-	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, log: log}
+// New builds a Server from config and an investigation enqueuer. ready reports
+// whether this replica should serve traffic (e.g. it holds leadership); when nil,
+// the replica is always ready. /healthz is liveness (always OK); /readyz is
+// readiness (gated by ready) so the Service routes webhooks only to the leader.
+func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, log *slog.Logger) *Server {
+	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, ready: ready, log: log}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook/alertmanager", s.handleAlertmanager)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if s.ready != nil && !s.ready() {
+			http.Error(w, "not ready (standby)", http.StatusServiceUnavailable)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	s.handler = mux

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -22,10 +22,35 @@ func testServerWith(enq investigate.Enqueuer) *Server {
 		Enabled: true,
 		Match:   config.IncidentMatch{Severity: []string{"critical"}},
 	}
-	return New(cfg, enq, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return New(cfg, enq, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
 
 func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
+
+func TestReadyz(t *testing.T) {
+	cfg := &config.Config{}
+	leader := false
+	srv := New(cfg, &spyEnqueuer{}, func() bool { return leader }, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("standby readyz = %d, want 503", rr.Code)
+	}
+	leader = true
+	rr = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("leader readyz = %d, want 200", rr.Code)
+	}
+	// liveness is always OK regardless of leadership
+	leader = false
+	rr = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("healthz = %d, want 200", rr.Code)
+	}
+}
 
 func TestHandleAlertmanager(t *testing.T) {
 	body := `{"alerts":[{"status":"firing","labels":{"alertname":"A","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"fp1"}]}`


### PR DESCRIPTION
Adds high availability via Lease-based leader election. Run 2+ replicas; only the elected leader is active.

## Design
- **Leader-only loops**: the informer watch + investigation queue run under the leader's context (cancelled on lost leadership). Standbys idle, ready to take over.
- **Readiness = leadership**: `/healthz` is liveness (always OK); new `/readyz` returns 200 only on the leader. The Service's readiness probe uses `/readyz`, so **webhooks route only to the leader** — no shared/distributed queue needed.
- Config `leader_election.{enabled,name}` (default enabled; harmless with 1 replica). Pod identity via the downward API (`POD_NAME`/`POD_NAMESPACE`).

## Chart
- Namespaced **Role/RoleBinding** for `coordination.k8s.io/leases`.
- Downward-API env, `/readyz` readiness probe, **PodDisruptionBudget** (minAvailable 1), **replicaCount: 2** by default.

## Verified on k3d (20/20 checks, incl. 3 new HA checks)
- 2 replicas → **exactly 1 Ready (leader)**, 1 hot standby
- **Lease** held by the leader pod
- **Failover**: deleted the leader → a standby acquired the Lease and became Ready

All prior feature checks still green. Gate + `-race` clean; `TestReadyz` covers the readiness gating.