### PR TITLE
docs: production getting-started + contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing
+
+Thanks for hacking on RunLore. This covers local development and testing. For *deploying* RunLore to a
+real cluster, see [docs/getting-started.md](docs/getting-started.md).
+
+## Prerequisites
+
+- **Go 1.26+**
+- **golangci-lint v2.12.2** (the CI version)
+- For the end-to-end suite: **docker**, **[k3d](https://k3d.io/) v5+**, **kubectl**, **helm v3.12+**,
+  and `openssl` (generates a throwaway GitHub App key).
+
+## The quality gate
+
+Every change must keep this green (it's what CI runs, see `.github/workflows/ci.yaml`):
+
+```bash
+go build ./...
+go vet ./...
+go test ./...
+gofmt -l .                 # must print nothing
+golangci-lint run ./...    # must report 0 issues
+```
+
+Run race detection on anything touching goroutines (the queue, informer, leader election):
+
+```bash
+go test -race ./...
+```
+
+## Project layout
+
+```
+cmd/lore/            CLI + the `serve` entrypoint (wiring)
+internal/
+  config/            config schema + trigger policy
+  trigger/           incident parsing, policy decision, dedup
+  server/            HTTP: /webhook/alertmanager, /healthz, /readyz
+  investigate/       the workqueue + the ReAct loop + tools (what_changed, kb_search)
+  catalog/           OKF load + bleve index + Search (the Learn read half)
+  curator/           confidence-routed curation (the Learn write half)
+  forge/github/      GitHub IssueProvider (issues/PRs) + App token source
+  model/openai/      OpenAI-compatible ModelProvider
+  notify/            Slack + Matrix notifiers + fan-out
+  providers/         the backend interface contracts (the architecture seam)
+  whatchanged/       Git revision diffing
+  providers/gitops/flux/   Flux GitOpsProvider (informer-backed)
+deploy/helm/runlore/ the Helm chart
+hack/                demo + the k3d e2e harness
+docs/                design, getting-started, plans
+```
+
+`internal/providers/providers.go` is the contract: everything the agent touches is an interface, so the
+loop is written against engine-agnostic types, never against Flux/OpenAI/GitHub directly.
+
+## How we work
+
+- **TDD.** Write the failing test first, then the implementation. Non-trivial work starts from a plan in
+  [`docs/plans/`](docs/plans) (a bite-sized, test-first task list).
+- **Small, focused commits**, conventional-commit style (`feat(scope): …`, `fix(scope): …`,
+  `test(...)`, `docs(...)`, `ci: …`). One concern per commit.
+- **Branch + PR**; keep the gate green on the branch.
+
+## Unit testing
+
+External backends are tested without network using `httptest` (the OpenAI client, Slack/Matrix, the
+GitHub forge) and fakes (the GitOps `Reader`, the catalog `Searcher`, a scripted `ModelProvider`). The
+Flux adapter is tested against a dynamic fake client. So `go test ./...` covers the logic of every
+feature with no cluster.
+
+## End-to-end on k3d
+
+`hack/e2e-k3d.sh` is the real-cluster proof: it spins up a throwaway k3d cluster, installs minimal Flux
+CRDs, builds + imports the image, `helm install`s the chart, and verifies **each feature against a real
+API server** with mock external backends. It asserts 20 checks and tears down on exit.
+
+```bash
+hack/e2e-k3d.sh           # full run, deletes the cluster afterwards
+hack/e2e-k3d.sh --keep    # leave the cluster + mock up for inspection
+```
+
+What it covers: deployment + RBAC + config load · catalog (`kb_search`) from a mounted ConfigMap ·
+incident webhook → trigger policy · the ReAct loop (`what_changed → kb_search → submit_findings`) ·
+Slack + Matrix delivery · GitOps-failure informer on real `Kustomization` CRDs · the curator
+(GitHub App token → PR) · leader election (single active leader + failover).
+
+### The mock backends
+
+`hack/e2e/mock/main.go` (behind the `e2e` build tag, so it's excluded from normal builds) stands in for
+the OpenAI chat endpoint (it scripts the tool-call sequence), Slack, Matrix, and the GitHub API. It runs
+on the host; the in-cluster agent reaches it via `host.k3d.internal`. Build it standalone with:
+
+```bash
+go run -tags e2e ./hack/e2e/mock :9999
+```
+
+This is how features that talk to paid/external services (the LLM, GitHub) get exercised end-to-end with
+zero credentials.
+
+## Quick local demo (no cluster)
+
+```bash
+hack/demo.sh    # fires mocked Alertmanager alerts through the trigger policy
+```
+
+## Submitting a change
+
+1. Branch from `main`.
+2. Make the change test-first; keep the gate green (`-race` where relevant).
+3. If it touches the deployment or a feature path, run `hack/e2e-k3d.sh`.
+4. Open a PR describing **what** changed and **how it was verified** (cite the gate / e2e results).

--- a/README.md
+++ b/README.md
@@ -81,23 +81,25 @@ flowchart LR
 
 ## Quickstart
 
-> Early development — the React foundation (`lore serve`) works today; the investigation loop is landing.
+**Deploy to a cluster** → **[Getting Started](docs/getting-started.md)**: create a knowledge-base repo,
+a scoped GitHub App, the secrets, then `helm install`. **Hack on it** → **[CONTRIBUTING](CONTRIBUTING.md)**.
 
 ```bash
-go build ./...
-
-# end-to-end demo: fire mocked Alertmanager alerts through the trigger policy
+# try it locally, no cluster: fire mocked Alertmanager alerts through the trigger policy
 hack/demo.sh
 
-# run the agent: react to incident webhooks per your trigger policy
+# verify every feature end-to-end on a throwaway k3d cluster (20 checks)
+hack/e2e-k3d.sh
+
+# run the agent against incident webhooks
 lore serve --config runlore.yaml
 ```
 
 ## Status & docs
 
-- 📐 [Design](docs/design.md) · [Prior art & positioning](docs/prior-art.md) · [Plans](docs/plans/)
-- ✅ Phase 1 — React foundation (trigger policy + `lore serve`)
-- 🚧 What-changed spine (Git revision diffing) → GitOps providers (Flux/Argo) → correlation → catalog → investigation loop
+- 📐 [Design](docs/design.md) · 🚀 [Getting started](docs/getting-started.md) · 🛠 [Contributing](CONTRIBUTING.md) · [Prior art](docs/prior-art.md) · [Plans](docs/plans/)
+- ✅ **End-to-end working** (verified on k3d): **React** (incident webhook + Flux failure watch, policy-gated) → **Investigate** (ReAct loop over an OpenAI-compatible model + `what_changed` + `kb_search`) → **Deliver** (Slack/Matrix) → **Learn** (OKF catalog read + curator PRs/issues). Packaged Helm chart with **HA via leader election**.
+- 🚧 Next: more investigation tools (metrics/logs/network), catalog Git-sync, ArgoCD provider, native Anthropic.
 
 ## License
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,256 @@
+# Getting Started (Kubernetes)
+
+This guide deploys RunLore into a real cluster: it reacts to incidents, investigates them with an
+LLM (grounded in your knowledge catalog), delivers findings to chat, and — optionally — curates what
+it learns back to a Git repo as pull requests.
+
+RunLore is **read-only on your cluster**: it never mutates workloads. Its only writes go to the Git
+forge (issues/PRs on a repo you designate).
+
+> For local development / testing on k3d, see [CONTRIBUTING.md](../CONTRIBUTING.md) instead.
+
+## Prerequisites
+
+- A Kubernetes cluster running **Flux** (the what-changed spine + failure trigger read Flux
+  `Kustomization`/`GitRepository` resources; ArgoCD is on the roadmap).
+- An **OpenAI-compatible** model endpoint — in-cluster [vLLM](https://github.com/vllm-project/vllm),
+  [Ollama](https://ollama.com/), OpenAI, or OpenRouter. (Native Anthropic is on the roadmap; today,
+  reach Claude via an OpenAI-compatible gateway such as OpenRouter.) Keep it in-cluster if you don't
+  want telemetry to leave your boundary.
+- `kubectl` + `helm` (v3.12+).
+- Optional: a **Slack incoming webhook** and/or a **Matrix** account for delivery.
+- Optional: a **GitHub App** for curation (the Learn loop) — [step 2](#step-2-github-app-for-curation-optional).
+- Optional: [External Secrets Operator](https://external-secrets.io/) to sync credentials from a vault
+  (recommended over raw `Secret`s in production).
+
+---
+
+## Step 1 — Create the knowledge-catalog repo
+
+RunLore reads (and, with curation, writes) an **[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+knowledge catalog**: a Git repo of markdown files, each with YAML frontmatter. This is *your* portable
+knowledge base — runbooks, past incidents, platform constraints.
+
+1. Create a new (private) Git repo, e.g. `your-org/runlore-kb`.
+2. Add entries as `<slug>.md` at the repo root:
+
+   ```markdown
+   ---
+   type: Playbook
+   title: HelmRelease upgrade failure
+   description: A Helm chart bump leaves the release Ready=False.
+   tags: [flux, helmrelease, upgrade]
+   ---
+   # Symptom
+   Ready=False after a chart bump; often a DB migration that didn't complete.
+
+   # Checks
+   - `flux get hr -A | grep -i false`
+   - the rendered diff between the two chart versions
+   ```
+
+   Filenames `index.md` and `log.md` are reserved and skipped. Seed it with whatever runbooks you
+   already have — the agent gets sharper at *your* platform as the catalog grows.
+
+3. **Make it available in-cluster.** v1 mounts the catalog as a `ConfigMap` (a built-in Git-sync is on
+   the roadmap). Generate it from the repo and apply it to RunLore's namespace:
+
+   ```bash
+   git clone https://github.com/your-org/runlore-kb /tmp/runlore-kb
+   kubectl -n runlore create configmap runlore-catalog \
+     --from-file=/tmp/runlore-kb/ \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+
+   Refresh it whenever the repo changes (CI job, or re-run the command). If you enable curation
+   ([step 2](#step-2-github-app-for-curation-optional)), RunLore opens PRs against this same repo.
+
+---
+
+## Step 2 — GitHub App for curation (optional)
+
+The **Curator** writes findings back to your KB repo: confident root causes become a **PR** drafting an
+OKF entry; less-confident ones become an **issue**. Auth is a **GitHub App** — the secure choice over a
+personal access token: fine-grained permissions, per-repo installation, and short-lived (1-hour)
+installation tokens minted on demand from the App's private key (no long-lived credential in the cluster).
+
+### Create the App
+
+1. **Settings → Developer settings → GitHub Apps → New GitHub App.**
+2. Homepage URL: anything (e.g. your repo). Disable Webhooks (RunLore doesn't receive GitHub webhooks).
+3. **Repository permissions** (least privilege — grant only these):
+
+   | Permission | Access | Why |
+   |---|---|---|
+   | Contents | **Read & write** | push the drafted OKF entry to a branch on the KB repo |
+   | Pull requests | **Read & write** | open the curation PR |
+   | Issues | **Read & write** | open issues for lower-confidence findings |
+
+   If your Flux source repos are **private** and you want real Git diffs from them, also grant
+   **Contents: Read-only** and install the App on those repos. Public source repos need nothing.
+4. **Create**, then **Generate a private key** — download the `.pem` (you only see it once).
+5. Note the **App ID** (on the App's page).
+6. **Install App** → install it on **only the specific repos** it needs (the KB repo, plus any private
+   source repos) — *not* "All repositories". Open the installation and note the **Installation ID**
+   (the number in the install settings URL: `.../installations/<id>`).
+
+### Security best practices
+
+- **Never commit the private key** or put it in `values.yaml`. Store it in a `Secret`
+  ([step 3](#step-3-credentials)) — ideally synced from a vault via External Secrets.
+- **Scope the installation** to specific repos, and grant only the three write permissions above.
+- Installation tokens are already **short-lived (1h) and auto-refreshed** — there is no long-lived
+  token to leak. **Rotate the App private key** periodically anyway.
+- Restrict who can administer the App in your org.
+- RunLore's writes are confined to the forge — it has **no cluster-mutating permissions**.
+
+---
+
+## Step 3 — Credentials
+
+Create a `Secret` with the credentials your config references by env-var name. In production, prefer an
+`ExternalSecret` that pulls these from your vault instead of `kubectl create secret`.
+
+```bash
+kubectl -n runlore create secret generic runlore-secrets \
+  --from-literal=OPENAI_API_KEY='<model-api-key-or-omit-if-keyless>' \
+  --from-literal=SLACK_WEBHOOK_URL='https://hooks.slack.com/services/...' \
+  --from-literal=MATRIX_TOKEN='<matrix-access-token>' \
+  --from-file=GITHUB_APP_PRIVATE_KEY=/path/to/app-private-key.pem
+```
+
+Only include the keys you use. The chart injects the whole Secret as env vars via `envFrom`, and the
+config references each by its env-var name (`api_key_env`, `webhook_url_env`, `private_key_env`, …).
+
+---
+
+## Step 4 — Configure and install
+
+Create a `values.yaml`. This is a complete production-style example — trim what you don't use:
+
+```yaml
+image:
+  repository: ghcr.io/smana/runlore
+  tag: ""            # defaults to the chart appVersion; pin in production
+
+# HA: 2+ replicas, one active leader (the rest hot standby). See leader_election below.
+replicaCount: 2
+
+# Inject the whole Secret as env vars (referenced by *_env config keys below).
+envFrom:
+  - secretRef:
+      name: runlore-secrets
+
+# Mount the OKF catalog ConfigMap from step 1.
+catalog:
+  configMap: runlore-catalog
+  mountPath: /var/lib/runlore/catalog
+
+config:
+  # React: only investigate what matters (controls noise + LLM cost).
+  triggers:
+    incidents:
+      enabled: true
+      match:
+        severity: [critical]
+        environment: [prod]
+      dedup: { window: 30m }
+    gitops_failures:
+      enabled: true            # also react to Flux Ready=False
+
+  # Investigate: the model + the catalog the loop searches.
+  model:
+    base_url: http://vllm.llm.svc:8000/v1   # any OpenAI-compatible endpoint
+    model: <your-model-name>
+    api_key_env: OPENAI_API_KEY             # omit/empty for keyless (in-cluster vLLM/Ollama)
+  catalog:
+    dir: /var/lib/runlore/catalog           # must match catalog.mountPath above
+
+  # Deliver: one or both.
+  notify:
+    slack:
+      webhook_url_env: SLACK_WEBHOOK_URL
+    matrix:
+      homeserver: https://matrix.org
+      room_id: "!yourroom:matrix.org"
+      access_token_env: MATRIX_TOKEN
+
+  # Learn: curate findings to your KB repo (omit this block to disable).
+  forge:
+    kb_repo: your-org/runlore-kb            # the repo from step 1
+    base_branch: main
+    # github_api_url: https://ghe.example.com/api/v3   # only for GitHub Enterprise Server
+    github_app:
+      app_id: 123456                         # from step 2
+      installation_id: 7654321               # from step 2
+      private_key_env: GITHUB_APP_PRIVATE_KEY
+
+  # HA toggle (default on; harmless with 1 replica).
+  leader_election:
+    enabled: true
+```
+
+Install:
+
+```bash
+helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml
+```
+
+> The chart needs the `deploy/helm/runlore` directory from this repo. A packaged chart repo is on the
+> roadmap; for now, `git clone` and install from the path (or `helm package` it yourself).
+
+---
+
+## Step 5 — Point Alertmanager at the webhook
+
+RunLore reacts to Alertmanager's webhook. Route the alerts you care about to its Service (the
+**trigger policy** in `config` is the real filter — Alertmanager routing is just the firehose):
+
+```yaml
+# alertmanager config
+receivers:
+  - name: runlore
+    webhook_configs:
+      - url: http://runlore.runlore.svc:8080/webhook/alertmanager
+route:
+  routes:
+    - receiver: runlore
+      continue: true        # keep your existing routing too
+```
+
+With 2+ replicas, only the **leader** is Ready, so the Service routes webhooks to it automatically.
+
+---
+
+## Step 6 — Verify
+
+```bash
+# the leader becomes Ready; standbys stay NotReady (expected)
+kubectl -n runlore get pods
+kubectl -n runlore get lease runlore-leader -o jsonpath='{.spec.holderIdentity}'; echo
+
+# startup wiring
+kubectl -n runlore logs deploy/runlore | grep -E 'catalog loaded|using LLM investigator|curator enabled|watching gitops failures|serving'
+```
+
+Expected lines: `catalog loaded … entries=N`, `using LLM investigator`, `watching gitops failures`,
+`curator enabled` (if configured), `runlore serving`.
+
+Fire a test: trigger a `critical`/`prod` alert (or `flux suspend`+break a Kustomization). You should see
+`msg=incident … investigate=true` → `msg=findings …`, a message in Slack/Matrix, and (if curation is on)
+`msg=curated url=…` pointing at a PR/issue on your KB repo.
+
+---
+
+## What RunLore can and cannot do
+
+- **Cluster**: read-only. It reads Flux resources, metrics/logs (as providers land), and never writes
+  to the cluster. RBAC is limited to watching `Kustomization`s, reading `GitRepository`s, and its own
+  leader-election `Lease`.
+- **Forge**: writes issues/PRs to the one KB repo you configure, via the scoped GitHub App.
+- **Secrets**: referenced by env-var name from a `Secret` you control; nothing is inlined.
+
+## Next
+
+- [Design](design.md) — architecture and the autonomy ladder.
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — run the full feature suite locally on k3d.


### PR DESCRIPTION
The current README quickstart wasn't usable for real clusters. Adds proper docs:

## `docs/getting-started.md` (users)
Step-by-step production deploy:
1. **Create the KB repo** — OKF markdown layout; mount it as a ConfigMap (Git-sync on the roadmap).
2. **GitHub App for curation** — why an App over a PAT (fine-grained, short-lived 1h tokens), the exact least-privilege permissions (Contents/PRs/Issues write on the KB repo; Contents read on private source repos), and **security best practices** (key in a Secret/External Secrets, scope the install to specific repos, rotate, no cluster writes).
3. **Credentials** — one Secret, referenced by env-var name.
4. **values.yaml** — a complete production example (triggers, model, catalog, notify, forge, HA).
5. **helm install** → **point Alertmanager at the Service** → **verify** (leader, logs, a test alert).

## `CONTRIBUTING.md` (developers)
The quality gate, project layout, TDD/plan workflow, unit-test approach (`httptest`/fakes), and the **k3d e2e** (`hack/e2e-k3d.sh`, 20 checks) + the mock backends.

## README
Refreshed the stale Quickstart/Status — the loop, Learn, delivery, and HA are done; links the new guides.