### PR TITLE
feat(catalog): git-sync — close the read/write loop

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -116,7 +116,7 @@ func runServe(args []string) error {
 		}
 	}
 
-	inv := buildInvestigator(cfg, fluxProvider, log)
+	inv := buildInvestigator(ctx, cfg, fluxProvider, log)
 	queue := investigate.NewQueue(inv, log)
 
 	// startWork runs the leader-only loops (investigation queue + failure watch),
@@ -211,6 +211,46 @@ func podNamespace() string {
 	return "default"
 }
 
+// buildCatalog returns the kb_search backing store, or nil when no catalog is
+// configured. With a Git URL it starts a background syncer (running on every
+// replica, so a failover standby is already warm) that re-indexes after each pull;
+// otherwise it loads a static mounted directory once.
+func buildCatalog(ctx context.Context, cfg *config.Config, log *slog.Logger) catalog.Searcher {
+	if cfg.Catalog.Git.URL != "" {
+		dir := cfg.Catalog.Dir
+		if dir == "" {
+			dir = "/var/lib/runlore/catalog"
+		}
+		cat := catalog.NewEmpty()
+		var token catalog.TokenFunc
+		if env := cfg.Catalog.Git.TokenEnv; env != "" {
+			if t := os.Getenv(env); t != "" {
+				token = func(context.Context) (string, error) { return t, nil }
+			}
+		}
+		syncer := &catalog.Syncer{URL: cfg.Catalog.Git.URL, Branch: cfg.Catalog.Git.Branch, Dir: dir, Token: token, Log: log}
+		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func() {
+			if err := cat.Reload(dir); err != nil {
+				log.Warn("catalog reload failed", "dir", dir, "err", err)
+				return
+			}
+			log.Info("catalog synced", "url", cfg.Catalog.Git.URL, "entries", cat.Len())
+		})
+		log.Info("catalog git-sync enabled", "url", cfg.Catalog.Git.URL, "dir", dir)
+		return cat
+	}
+	if cfg.Catalog.Dir != "" {
+		cat, err := catalog.New(cfg.Catalog.Dir)
+		if err != nil {
+			log.Warn("catalog disabled", "dir", cfg.Catalog.Dir, "err", err)
+			return nil
+		}
+		log.Info("catalog loaded", "dir", cfg.Catalog.Dir, "entries", cat.Len())
+		return cat
+	}
+	return nil
+}
+
 // buildNotifier assembles the configured chat notifiers (best-effort fan-out).
 func buildNotifier(cfg *config.Config, log *slog.Logger) *notify.Multi {
 	var ns []providers.Notifier
@@ -260,7 +300,7 @@ func buildCurator(cfg *config.Config, log *slog.Logger) *curator.Curator {
 
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
-func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) investigate.Investigator {
+func buildInvestigator(ctx context.Context, cfg *config.Config, fp *flux.Provider, log *slog.Logger) investigate.Investigator {
 	if cfg.Model.BaseURL == "" {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
@@ -274,13 +314,8 @@ func buildInvestigator(cfg *config.Config, fp *flux.Provider, log *slog.Logger) 
 	if fp != nil {
 		tools = append(tools, investigate.WhatChangedTool{GitOps: fp})
 	}
-	if cfg.Catalog.Dir != "" {
-		if cat, err := catalog.New(cfg.Catalog.Dir); err != nil {
-			log.Warn("catalog disabled", "dir", cfg.Catalog.Dir, "err", err)
-		} else {
-			log.Info("catalog loaded", "dir", cfg.Catalog.Dir, "entries", cat.Len())
-			tools = append(tools, investigate.KBSearchTool{Catalog: cat})
-		}
+	if cat := buildCatalog(ctx, cfg, log); cat != nil {
+		tools = append(tools, investigate.KBSearchTool{Catalog: cat})
 	}
 	log.Info("using LLM investigator", "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)

--- a/deploy/helm/runlore/templates/deployment.yaml
+++ b/deploy/helm/runlore/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
             - name: catalog
               mountPath: {{ .Values.catalog.mountPath }}
               readOnly: true
+            {{- else if .Values.catalog.gitSync }}
+            - name: catalog
+              mountPath: {{ .Values.catalog.mountPath }}
             {{- end }}
       volumes:
         - name: config
@@ -93,6 +96,9 @@ spec:
         - name: catalog
           configMap:
             name: {{ .Values.catalog.configMap }}
+        {{- else if .Values.catalog.gitSync }}
+        - name: catalog
+          emptyDir: {}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -55,7 +55,8 @@ env: []
 # Mount an OKF knowledge catalog (e.g. a ConfigMap of runbooks) so kb_search works.
 # Set config.catalog.dir to mountPath to enable it.
 catalog:
-  configMap: ""                       # ConfigMap name holding the OKF .md files
+  configMap: ""                       # ConfigMap of OKF .md files (static mode)
+  gitSync: false                      # writable mirror for config.catalog.git (closes the read/write loop)
   mountPath: /var/lib/runlore/catalog
 
 # Keeps at least one replica available during voluntary disruptions (only applied

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,8 +52,15 @@ knowledge base — runbooks, past incidents, platform constraints.
    Filenames `index.md` and `log.md` are reserved and skipped. Seed it with whatever runbooks you
    already have — the agent gets sharper at *your* platform as the catalog grows.
 
-3. **Make it available in-cluster.** v1 mounts the catalog as a `ConfigMap` (a built-in Git-sync is on
-   the roadmap). Generate it from the repo and apply it to RunLore's namespace:
+3. **Make it available in-cluster.** Two options:
+
+   **Option A — Git-sync (recommended; closes the read/write loop).** RunLore clones the repo and
+   re-pulls it on an interval, re-indexing automatically. When curation merges a PR into this repo, the
+   new knowledge flows straight back into what the agent searches — no manual step. Configure it under
+   `config.catalog.git` ([step 4](#step-4-configure-and-install)) and set `catalog.gitSync: true` (which
+   mounts a writable mirror). For a private repo, point `token_env` at a read-scoped token in the Secret.
+
+   **Option B — ConfigMap (static).** Mount a snapshot; refresh it yourself when the repo changes:
 
    ```bash
    git clone https://github.com/your-org/runlore-kb /tmp/runlore-kb
@@ -61,9 +68,6 @@ knowledge base — runbooks, past incidents, platform constraints.
      --from-file=/tmp/runlore-kb/ \
      --dry-run=client -o yaml | kubectl apply -f -
    ```
-
-   Refresh it whenever the repo changes (CI job, or re-run the command). If you enable curation
-   ([step 2](#step-2-github-app-for-curation-optional)), RunLore opens PRs against this same repo.
 
 ---
 
@@ -141,10 +145,12 @@ envFrom:
   - secretRef:
       name: runlore-secrets
 
-# Mount the OKF catalog ConfigMap from step 1.
+# Catalog source (step 1). Option A — git-sync (recommended): a writable mirror.
 catalog:
-  configMap: runlore-catalog
+  gitSync: true
   mountPath: /var/lib/runlore/catalog
+  # Option B — static ConfigMap instead:
+  # configMap: runlore-catalog
 
 config:
   # React: only investigate what matters (controls noise + LLM cost).
@@ -165,6 +171,11 @@ config:
     api_key_env: OPENAI_API_KEY             # omit/empty for keyless (in-cluster vLLM/Ollama)
   catalog:
     dir: /var/lib/runlore/catalog           # must match catalog.mountPath above
+    git:                                     # omit this block if using a static ConfigMap
+      url: https://github.com/your-org/runlore-kb
+      branch: main
+      interval: 5m
+      # token_env: KB_GIT_TOKEN              # for a private repo (key in the Secret)
 
   # Deliver: one or both.
   notify:

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/blevesearch/bleve/v2"
 )
 
-// Catalog is an in-memory BM25 index over OKF entries.
+// Catalog is an in-memory BM25 index over OKF entries. It is safe for concurrent
+// Search while a background sync calls Reload (the index is swapped atomically).
 type Catalog struct {
+	mu      sync.RWMutex
 	index   bleve.Index
 	entries []Entry
 }
@@ -21,10 +24,37 @@ type Searcher interface {
 
 // New loads the OKF bundle at dir and builds an in-memory index.
 func New(dir string) (*Catalog, error) {
-	entries, err := Load(dir)
-	if err != nil {
+	c := &Catalog{}
+	if err := c.Reload(dir); err != nil {
 		return nil, err
 	}
+	return c, nil
+}
+
+// NewEmpty returns a catalog with no entries — used before the first git sync.
+func NewEmpty() *Catalog {
+	idx, _ := bleve.NewMemOnly(bleve.NewIndexMapping())
+	return &Catalog{index: idx}
+}
+
+// Reload rebuilds the index from dir and swaps it in atomically. The new index is
+// built outside the lock so concurrent Search is only blocked for the swap.
+func (c *Catalog) Reload(dir string) error {
+	entries, err := Load(dir)
+	if err != nil {
+		return err
+	}
+	idx, err := buildIndex(entries)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.index, c.entries = idx, entries
+	c.mu.Unlock()
+	return nil
+}
+
+func buildIndex(entries []Entry) (bleve.Index, error) {
 	idx, err := bleve.NewMemOnly(bleve.NewIndexMapping())
 	if err != nil {
 		return nil, fmt.Errorf("new index: %w", err)
@@ -38,16 +68,25 @@ func New(dir string) (*Catalog, error) {
 			return nil, fmt.Errorf("index entry %d: %w", i, err)
 		}
 	}
-	return &Catalog{index: idx, entries: entries}, nil
+	return idx, nil
 }
 
 // Len reports the number of indexed entries.
-func (c *Catalog) Len() int { return len(c.entries) }
+func (c *Catalog) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
 
 var _ Searcher = (*Catalog)(nil)
 
 // Search returns up to k entries best matching the query (BM25).
 func (c *Catalog) Search(query string, k int) ([]Entry, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.index == nil {
+		return nil, nil
+	}
 	q := bleve.NewMatchQuery(query)
 	q.SetField("text")
 	req := bleve.NewSearchRequestOptions(q, k, 0, false)

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -44,3 +44,40 @@ func titles(es []Entry) []string {
 	}
 	return out
 }
+
+func TestReload(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "a.md", "---\ntitle: Alpha\n---\nx")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != 1 {
+		t.Fatalf("len = %d, want 1", c.Len())
+	}
+	// A new entry appears (e.g. a merged curation PR pulled by git-sync) and we reload.
+	writeEntry(t, dir, "b.md", "---\ntitle: Beta\n---\ny")
+	if err := c.Reload(dir); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if c.Len() != 2 {
+		t.Fatalf("after reload len = %d, want 2", c.Len())
+	}
+	if hits, _ := c.Search("Beta", 3); len(hits) == 0 {
+		t.Fatal("reloaded entry not searchable")
+	}
+}
+
+func TestEmptyCatalog(t *testing.T) {
+	c := NewEmpty()
+	if c.Len() != 0 {
+		t.Fatalf("empty len = %d", c.Len())
+	}
+	hits, err := c.Search("anything", 3)
+	if err != nil {
+		t.Fatalf("search empty: %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("empty hits = %d", len(hits))
+	}
+}

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -1,0 +1,113 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+// TokenFunc returns a git credential (e.g. a GitHub App installation token or a
+// read-scoped PAT). Used as the basic-auth password with username x-access-token.
+type TokenFunc func(ctx context.Context) (string, error)
+
+// Syncer keeps a local mirror of an OKF catalog Git repo up to date, calling
+// onSync after each successful sync so the reader can re-index. This closes the
+// read/write loop: the curator's merged PRs flow back into what the agent searches.
+type Syncer struct {
+	URL    string
+	Branch string
+	Dir    string
+	Token  TokenFunc // nil / empty => anonymous (public repo)
+	Log    *slog.Logger
+}
+
+func (s *Syncer) auth(ctx context.Context) (*githttp.BasicAuth, error) {
+	if s.Token == nil {
+		return nil, nil
+	}
+	tok, err := s.Token(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if tok == "" {
+		return nil, nil
+	}
+	return &githttp.BasicAuth{Username: "x-access-token", Password: tok}, nil
+}
+
+func (s *Syncer) branch() string {
+	if s.Branch == "" {
+		return "main"
+	}
+	return s.Branch
+}
+
+// Sync clones the repo if the mirror is absent, otherwise fast-forwards it.
+func (s *Syncer) Sync(ctx context.Context) error {
+	auth, err := s.auth(ctx)
+	if err != nil {
+		return fmt.Errorf("auth: %w", err)
+	}
+	ref := plumbing.NewBranchReferenceName(s.branch())
+	if _, statErr := os.Stat(filepath.Join(s.Dir, ".git")); statErr != nil {
+		_, cerr := git.PlainCloneContext(ctx, s.Dir, false, &git.CloneOptions{
+			URL:           s.URL,
+			ReferenceName: ref,
+			SingleBranch:  true,
+			Auth:          auth,
+		})
+		return cerr
+	}
+	repo, err := git.PlainOpen(s.Dir)
+	if err != nil {
+		return err
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+	perr := wt.PullContext(ctx, &git.PullOptions{
+		ReferenceName: ref,
+		SingleBranch:  true,
+		Auth:          auth,
+		Force:         true,
+	})
+	if perr != nil && !errors.Is(perr, git.NoErrAlreadyUpToDate) {
+		return perr
+	}
+	return nil
+}
+
+// Run does an initial sync then re-syncs every interval, calling onSync after each
+// success. It returns when ctx is done. interval <= 0 defaults to 5m.
+func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func()) {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	do := func() {
+		if err := s.Sync(ctx); err != nil {
+			s.Log.Warn("catalog git sync failed", "url", s.URL, "err", err)
+			return
+		}
+		onSync()
+	}
+	do()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			do()
+		}
+	}
+}

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -1,0 +1,66 @@
+package catalog
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func commit(t *testing.T, repo *git.Repository, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(name); err != nil {
+		t.Fatal(err)
+	}
+	_, err = wt.Commit("add "+name, &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example.com", When: time.Unix(1_700_000_000, 0)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncerCloneAndPull(t *testing.T) {
+	src := t.TempDir()
+	repo, err := git.PlainInitWithOptions(src, &git.PlainInitOptions{
+		InitOptions: git.InitOptions{DefaultBranch: plumbing.NewBranchReferenceName("main")},
+	})
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	commit(t, repo, src, "first.md", "---\ntitle: First\n---\nx")
+
+	mirror := filepath.Join(t.TempDir(), "mirror")
+	s := &Syncer{URL: src, Branch: "main", Dir: mirror, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	// First Sync clones.
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("clone sync: %v", err)
+	}
+	if es, _ := Load(mirror); len(es) != 1 || es[0].Title != "First" {
+		t.Fatalf("after clone: %v", titles(es))
+	}
+
+	// A new commit (e.g. a merged curation PR) appears upstream; Sync fast-forwards.
+	commit(t, repo, src, "second.md", "---\ntitle: Second\n---\ny")
+	if err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("pull sync: %v", err)
+	}
+	if es, _ := Load(mirror); len(es) != 2 {
+		t.Fatalf("after pull: %d entries, want 2", len(es))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,9 +35,20 @@ type LeaderElection struct {
 	Name    string `yaml:"name"` // Lease name (default "runlore-leader")
 }
 
-// Catalog configures the OKF knowledge catalog read by the agent.
+// Catalog configures the OKF knowledge catalog read by the agent. Provide either
+// a mounted Dir (e.g. a ConfigMap) or a Git repo to sync (which closes the
+// read/write loop — the curator's merged PRs flow back into what the agent reads).
 type Catalog struct {
-	Dir string `yaml:"dir"` // path to the OKF bundle (a local dir / mounted mirror)
+	Dir string     `yaml:"dir"` // OKF bundle path (mounted ConfigMap, or the git-sync mirror)
+	Git CatalogGit `yaml:"git"`
+}
+
+// CatalogGit configures periodic Git sync of the catalog into Dir.
+type CatalogGit struct {
+	URL      string   `yaml:"url"`       // repo to clone/pull; empty disables git-sync
+	Branch   string   `yaml:"branch"`    // default "main"
+	Interval Duration `yaml:"interval"`  // re-sync period (default 5m)
+	TokenEnv string   `yaml:"token_env"` // env var with a read token (empty = anonymous/public)
 }
 
 // Model configures the OpenAI-compatible LLM endpoint used for investigation.


### PR DESCRIPTION
The curator writes findings to the KB repo as PRs; **git-sync** pulls the repo back in and re-indexes, so once a PR merges the new knowledge flows straight into what the agent searches — the Learn loop closes with no manual ConfigMap refresh.

## How
- **Reloadable catalog** — `Catalog` is now concurrency-safe (RWMutex) with `Reload(dir)` that rebuilds the bleve index and swaps it atomically; `NewEmpty()` for the pre-sync state.
- **`catalog.Syncer`** (go-git) — clones the KB repo, then fast-forwards it on an interval; optional token auth (`x-access-token` basic auth) for private repos. Calls back to re-index after each successful sync.
- **Runs on every replica** (not leader-gated), so a failover standby is already warm.
- **`serve` wiring** — `buildCatalog` starts the syncer when `config.catalog.git.url` is set, else loads a static mounted dir (ConfigMap).
- **Chart** — `catalog.gitSync: true` mounts a writable emptyDir mirror (vs the read-only ConfigMap).

## Verified
- Unit: real go-git **clone + pull** against a local repo → re-index picks up the new commit; reload + empty-catalog; **race-clean**.
- Serve wiring (local, real git repo): `catalog git-sync enabled` → `catalog synced entries=1`, mirror populated.
- Chart renders the writable mirror; lint + kubeconform clean. Gate + golangci 0 issues.

Static ConfigMap mode still works unchanged. Docs updated (getting-started: git-sync is the recommended, loop-closing option).