### PR TITLE
feat: metrics + logs investigation tools

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -32,6 +32,8 @@ import (
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/logs/victorialogs"
+	"github.com/Smana/runlore/internal/metrics/prometheus"
 	openai "github.com/Smana/runlore/internal/model/openai"
 	"github.com/Smana/runlore/internal/notify"
 	"github.com/Smana/runlore/internal/providers"
@@ -316,6 +318,12 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, fp *flux.Provide
 	}
 	if cat := buildCatalog(ctx, cfg, log); cat != nil {
 		tools = append(tools, investigate.KBSearchTool{Catalog: cat})
+	}
+	if cfg.Metrics.URL != "" {
+		tools = append(tools, investigate.QueryMetricsTool{Metrics: prometheus.New(cfg.Metrics.URL)})
+	}
+	if cfg.Logs.URL != "" {
+		tools = append(tools, investigate.QueryLogsTool{Logs: victorialogs.New(cfg.Logs.URL)})
 	}
 	log.Info("using LLM investigator", "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -112,6 +112,8 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set-string config.notify.matrix.homeserver="http://$HOST:$MOCK_PORT" \
   --set-string config.notify.matrix.room_id='!test:mock' \
   --set-string config.notify.matrix.access_token_env=MATRIX_TOKEN \
+  --set-string config.metrics.url="http://$HOST:$MOCK_PORT" \
+  --set-string config.logs.url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.kb_repo="mock/repo" \
   --set-string config.forge.base_branch="main" \
@@ -147,6 +149,10 @@ check "investigation completed (findings)"   /tmp/runlore.log 'msg=findings'
 check "mock model received chat/completions"  /tmp/runlore-mock.log 'chat/completions'
 check "mock model drove what_changed"         /tmp/runlore-mock.log '> what_changed'
 check "mock model drove kb_search"            /tmp/runlore-mock.log '> kb_search'
+check "mock model drove query_metrics"        /tmp/runlore-mock.log '> query_metrics'
+check "mock model drove query_logs"           /tmp/runlore-mock.log '> query_logs'
+check "metrics backend queried"               /tmp/runlore-mock.log 'MOCK METRICS'
+check "logs backend queried"                  /tmp/runlore-mock.log 'MOCK LOGS'
 check "mock model drove submit_findings"      /tmp/runlore-mock.log '> submit_findings'
 check "Slack delivery"                         /tmp/runlore-mock.log 'MOCK SLACK'
 check "Matrix delivery"                        /tmp/runlore-mock.log 'MOCK MATRIX'

--- a/hack/e2e/mock/main.go
+++ b/hack/e2e/mock/main.go
@@ -26,6 +26,11 @@ func main() {
 	mux.HandleFunc("POST /v1/chat/completions", chatCompletions)
 	mux.HandleFunc("POST /slack", logOK("SLACK"))
 	mux.HandleFunc("PUT /_matrix/client/v3/rooms/{room}/send/m.room.message/{txn}", matrixSend)
+	// Metrics (Prometheus API) + logs (VictoriaLogs LogsQL).
+	mux.HandleFunc("GET /api/v1/query", logJSON("METRICS",
+		`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","job":"harbor"},"value":[1700000000,"0"]}]}}`))
+	mux.HandleFunc("POST /select/logsql/query", logJSON("LOGS",
+		`{"_time":"2026-06-20T10:00:00Z","_msg":"db connection refused","kubernetes.pod_name":"harbor-db-0"}`))
 	// Minimal GitHub API (for the curator).
 	mux.HandleFunc("POST /app/installations/{id}/access_tokens", githubToken)
 	mux.HandleFunc("POST /repos/{owner}/{repo}/issues", githubIssue)
@@ -66,6 +71,10 @@ func chatCompletions(w http.ResponseWriter, r *http.Request) {
 		name, args = "what_changed", `{"namespace":"apps"}`
 	case 1:
 		name, args = "kb_search", `{"query":"harbor helmrelease upgrade"}`
+	case 2:
+		name, args = "query_metrics", `{"query":"up"}`
+	case 3:
+		name, args = "query_logs", `{"query":"error","since_minutes":30}`
 	default:
 		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"]}`
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,14 @@ type Config struct {
 	Catalog  Catalog       `yaml:"catalog"` // OKF knowledge catalog
 
 	LeaderElection LeaderElection `yaml:"leader_election"` // HA: only the leader investigates
+
+	Metrics Endpoint `yaml:"metrics"` // PromQL backend (VictoriaMetrics/Prometheus) for query_metrics
+	Logs    Endpoint `yaml:"logs"`    // LogsQL backend (VictoriaLogs) for query_logs
+}
+
+// Endpoint is a backend base URL; empty disables the corresponding tool.
+type Endpoint struct {
+	URL string `yaml:"url"`
 }
 
 // LeaderElection configures high availability. When enabled, replicas elect a

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -1,0 +1,122 @@
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const maxToolRows = 50
+
+// QueryMetricsTool lets the model run PromQL instant queries (saturation, error
+// rates, health) against the metrics backend.
+type QueryMetricsTool struct {
+	Metrics providers.MetricsProvider
+}
+
+// Name returns the tool name.
+func (t QueryMetricsTool) Name() string { return "query_metrics" }
+
+// Description returns the tool description.
+func (t QueryMetricsTool) Description() string {
+	return "Run a PromQL instant query against the metrics backend (VictoriaMetrics/Prometheus) — check saturation, error rates, restarts, resource usage."
+}
+
+// Schema returns the JSON schema for the arguments.
+func (t QueryMetricsTool) Schema() string {
+	return `{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`
+}
+
+// Call runs the instant query and renders the series.
+func (t QueryMetricsTool) Call(ctx context.Context, args string) (string, error) {
+	var in struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	samples, err := t.Metrics.Query(ctx, in.Query, time.Time{})
+	if err != nil {
+		return "", err
+	}
+	if len(samples) == 0 {
+		return "no series matched", nil
+	}
+	var b strings.Builder
+	for i, s := range samples {
+		if i >= maxToolRows {
+			fmt.Fprintf(&b, "… (%d more series)\n", len(samples)-i)
+			break
+		}
+		fmt.Fprintf(&b, "%s = %g\n", formatMetric(s.Metric), s.Value)
+	}
+	return b.String(), nil
+}
+
+func formatMetric(m map[string]string) string {
+	name := m["__name__"]
+	labels := make([]string, 0, len(m))
+	for k, v := range m {
+		if k != "__name__" {
+			labels = append(labels, fmt.Sprintf("%s=%q", k, v))
+		}
+	}
+	sort.Strings(labels)
+	return name + "{" + strings.Join(labels, ",") + "}"
+}
+
+// QueryLogsTool lets the model query logs (LogsQL) over a recent window.
+type QueryLogsTool struct {
+	Logs providers.LogsProvider
+}
+
+// Name returns the tool name.
+func (t QueryLogsTool) Name() string { return "query_logs" }
+
+// Description returns the tool description.
+func (t QueryLogsTool) Description() string {
+	return "Query logs (LogsQL) over a recent window for errors/anomalies. Optional since_minutes bounds the window (default 60)."
+}
+
+// Schema returns the JSON schema for the arguments.
+func (t QueryLogsTool) Schema() string {
+	return `{"type":"object","properties":{"query":{"type":"string"},"since_minutes":{"type":"integer"}},"required":["query"]}`
+}
+
+// Call runs the logs query over [now-since, now] and renders the lines.
+func (t QueryLogsTool) Call(ctx context.Context, args string) (string, error) {
+	var in struct {
+		Query        string `json:"query"`
+		SinceMinutes int    `json:"since_minutes"`
+	}
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	since := in.SinceMinutes
+	if since <= 0 {
+		since = 60
+	}
+	end := time.Now()
+	start := end.Add(-time.Duration(since) * time.Minute)
+	lines, err := t.Logs.Query(ctx, in.Query, providers.TimeWindow{Start: start, End: end})
+	if err != nil {
+		return "", err
+	}
+	if len(lines) == 0 {
+		return "no log lines matched", nil
+	}
+	var b strings.Builder
+	for i, l := range lines {
+		if i >= maxToolRows {
+			fmt.Fprintf(&b, "… (%d more lines)\n", len(lines)-i)
+			break
+		}
+		fmt.Fprintf(&b, "%s %s\n", l.Time.Format(time.RFC3339), l.Message)
+	}
+	return b.String(), nil
+}

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -1,0 +1,58 @@
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeMetrics struct{ samples providers.Samples }
+
+func (f fakeMetrics) Query(context.Context, string, time.Time) (providers.Samples, error) {
+	return f.samples, nil
+}
+func (f fakeMetrics) QueryRange(context.Context, string, providers.TimeWindow, time.Duration) (providers.Matrix, error) {
+	return nil, nil
+}
+
+func TestQueryMetricsTool(t *testing.T) {
+	tool := QueryMetricsTool{Metrics: fakeMetrics{samples: providers.Samples{
+		{Metric: map[string]string{"__name__": "up", "job": "api"}, Value: 0},
+		{Metric: map[string]string{"__name__": "up", "job": "db"}, Value: 1},
+	}}}
+	if tool.Name() != "query_metrics" {
+		t.Fatalf("name=%q", tool.Name())
+	}
+	out, err := tool.Call(context.Background(), `{"query":"up"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, `up{job="api"} = 0`) || !strings.Contains(out, `up{job="db"} = 1`) {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+}
+
+type fakeLogs struct{ lines providers.LogResult }
+
+func (f fakeLogs) Query(context.Context, string, providers.TimeWindow) (providers.LogResult, error) {
+	return f.lines, nil
+}
+
+func TestQueryLogsTool(t *testing.T) {
+	tool := QueryLogsTool{Logs: fakeLogs{lines: providers.LogResult{
+		{Time: time.Unix(1700000000, 0).UTC(), Message: "db connection refused"},
+	}}}
+	if tool.Name() != "query_logs" {
+		t.Fatalf("name=%q", tool.Name())
+	}
+	out, err := tool.Call(context.Background(), `{"query":"error","since_minutes":30}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, "db connection refused") {
+		t.Fatalf("unexpected output:\n%s", out)
+	}
+}

--- a/internal/logs/victorialogs/victorialogs.go
+++ b/internal/logs/victorialogs/victorialogs.go
@@ -1,0 +1,90 @@
+// Package victorialogs implements providers.LogsProvider against VictoriaLogs,
+// querying with LogsQL and normalizing the NDJSON response into log lines.
+package victorialogs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Client queries a VictoriaLogs backend.
+type Client struct {
+	baseURL string
+	limit   int
+	http    *http.Client
+}
+
+// New builds a client for a VictoriaLogs base URL.
+func New(baseURL string) *Client {
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), limit: 100, http: &http.Client{Timeout: 30 * time.Second}}
+}
+
+var _ providers.LogsProvider = (*Client)(nil)
+
+// Query runs a LogsQL query over the window and returns normalized log lines.
+func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow) (providers.LogResult, error) {
+	form := url.Values{"query": {query}, "limit": {fmt.Sprintf("%d", c.limit)}}
+	if !w.Start.IsZero() {
+		form.Set("start", w.Start.UTC().Format(time.RFC3339))
+	}
+	if !w.End.IsZero() {
+		form.Set("end", w.End.UTC().Format(time.RFC3339))
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/select/logsql/query", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("logs query: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+	}
+	return parseNDJSON(resp.Body)
+}
+
+// parseNDJSON turns VictoriaLogs' newline-delimited JSON into log lines. Each
+// object carries `_time`, `_msg`, and arbitrary stream fields.
+func parseNDJSON(r io.Reader) (providers.LogResult, error) {
+	var out providers.LogResult
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // tolerate long log lines
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			continue // skip malformed lines rather than failing the whole query
+		}
+		ll := providers.LogLine{Fields: map[string]string{}}
+		for k, v := range m {
+			s := fmt.Sprint(v)
+			switch k {
+			case "_time":
+				ll.Time, _ = time.Parse(time.RFC3339, s)
+			case "_msg":
+				ll.Message = s
+			default:
+				ll.Fields[k] = s
+			}
+		}
+		out = append(out, ll)
+	}
+	return out, sc.Err()
+}

--- a/internal/logs/victorialogs/victorialogs_test.go
+++ b/internal/logs/victorialogs/victorialogs_test.go
@@ -1,0 +1,60 @@
+package victorialogs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestQuery(t *testing.T) {
+	var gotQuery, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select/logsql/query" {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		gotCT = r.Header.Get("Content-Type")
+		if vals, err := parseForm(string(body)); err == nil {
+			gotQuery = vals
+		}
+		_, _ = io.WriteString(w, `{"_time":"2026-06-20T10:00:00Z","_msg":"db connection refused","kubernetes.pod_name":"harbor-db-0"}
+{"_time":"2026-06-20T10:00:01Z","_msg":"retrying","kubernetes.pod_name":"harbor-core-1"}
+`)
+	}))
+	defer srv.Close()
+
+	res, err := New(srv.URL).Query(context.Background(), `{namespace="apps"} | error`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if !strings.Contains(gotCT, "x-www-form-urlencoded") {
+		t.Fatalf("content-type=%q", gotCT)
+	}
+	if gotQuery == "" {
+		t.Fatalf("query not form-encoded")
+	}
+	if len(res) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(res))
+	}
+	if res[0].Message != "db connection refused" || res[0].Fields["kubernetes.pod_name"] != "harbor-db-0" {
+		t.Fatalf("unexpected first line: %+v", res[0])
+	}
+	if res[0].Time.IsZero() {
+		t.Fatalf("_time not parsed")
+	}
+}
+
+// parseForm returns the decoded "query" value if present.
+func parseForm(body string) (string, error) {
+	for _, kv := range strings.Split(body, "&") {
+		if strings.HasPrefix(kv, "query=") {
+			return kv, nil
+		}
+	}
+	return "", io.EOF
+}

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -1,0 +1,135 @@
+// Package prometheus implements providers.MetricsProvider against the Prometheus
+// HTTP API — also spoken by VictoriaMetrics — for instant and range PromQL queries.
+package prometheus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Client queries a Prometheus-compatible metrics backend.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New builds a client for a Prometheus/VictoriaMetrics base URL.
+func New(baseURL string) *Client {
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: &http.Client{Timeout: 30 * time.Second}}
+}
+
+var _ providers.MetricsProvider = (*Client)(nil)
+
+type apiResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error"`
+	Data   struct {
+		ResultType string            `json:"resultType"`
+		Result     []json.RawMessage `json:"result"`
+	} `json:"data"`
+}
+
+// Query runs an instant PromQL query (at = zero means "now").
+func (c *Client) Query(ctx context.Context, promql string, at time.Time) (providers.Samples, error) {
+	v := url.Values{"query": {promql}}
+	if !at.IsZero() {
+		v.Set("time", strconv.FormatInt(at.Unix(), 10))
+	}
+	resp, err := c.get(ctx, "/api/v1/query", v)
+	if err != nil {
+		return nil, err
+	}
+	out := make(providers.Samples, 0, len(resp.Data.Result))
+	for _, raw := range resp.Data.Result {
+		var item struct {
+			Metric map[string]string `json:"metric"`
+			Value  [2]any            `json:"value"`
+		}
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return nil, err
+		}
+		ts, val := parsePoint(item.Value)
+		out = append(out, providers.Sample{Metric: item.Metric, Value: val, Time: ts})
+	}
+	return out, nil
+}
+
+// QueryRange runs a range PromQL query over a window.
+func (c *Client) QueryRange(ctx context.Context, promql string, w providers.TimeWindow, step time.Duration) (providers.Matrix, error) {
+	if step <= 0 {
+		step = time.Minute
+	}
+	v := url.Values{
+		"query": {promql},
+		"start": {strconv.FormatInt(w.Start.Unix(), 10)},
+		"end":   {strconv.FormatInt(w.End.Unix(), 10)},
+		"step":  {strconv.FormatInt(int64(step.Seconds()), 10)},
+	}
+	resp, err := c.get(ctx, "/api/v1/query_range", v)
+	if err != nil {
+		return nil, err
+	}
+	out := make(providers.Matrix, 0, len(resp.Data.Result))
+	for _, raw := range resp.Data.Result {
+		var item struct {
+			Metric map[string]string `json:"metric"`
+			Values [][2]any          `json:"values"`
+		}
+		if err := json.Unmarshal(raw, &item); err != nil {
+			return nil, err
+		}
+		s := providers.Series{Metric: item.Metric}
+		for _, p := range item.Values {
+			ts, val := parsePoint(p)
+			s.Points = append(s.Points, providers.Point{Time: ts, Value: val})
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func (c *Client) get(ctx context.Context, path string, v url.Values) (*apiResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path+"?"+v.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("metrics query: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("metrics status %d: %s", resp.StatusCode, string(data))
+	}
+	var r apiResponse
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse metrics response: %w", err)
+	}
+	if r.Status != "success" {
+		return nil, fmt.Errorf("metrics error: %s", r.Error)
+	}
+	return &r, nil
+}
+
+// parsePoint parses a Prometheus [unixTime, "value"] pair.
+func parsePoint(p [2]any) (time.Time, float64) {
+	var ts time.Time
+	if f, ok := p[0].(float64); ok {
+		ts = time.Unix(int64(f), 0).UTC()
+	}
+	var val float64
+	if s, ok := p[1].(string); ok {
+		val, _ = strconv.ParseFloat(s, 64)
+	}
+	return ts, val
+}

--- a/internal/metrics/prometheus/prometheus_test.go
+++ b/internal/metrics/prometheus/prometheus_test.go
@@ -1,0 +1,63 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestQuery(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.Query().Get("query")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[
+		  {"metric":{"__name__":"up","job":"api"},"value":[1700000000,"0"]},
+		  {"metric":{"__name__":"up","job":"db"},"value":[1700000000,"1"]}]}}`))
+	}))
+	defer srv.Close()
+
+	s, err := New(srv.URL).Query(context.Background(), "up", time.Unix(1700000000, 0))
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotPath != "/api/v1/query" || gotQuery != "up" {
+		t.Fatalf("path=%q query=%q", gotPath, gotQuery)
+	}
+	if len(s) != 2 || s[0].Metric["job"] != "api" || s[0].Value != 0 || s[1].Value != 1 {
+		t.Fatalf("unexpected samples: %+v", s)
+	}
+}
+
+func TestQueryRange(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/query_range" {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"matrix","result":[
+		  {"metric":{"pod":"x"},"values":[[1700000000,"1"],[1700000060,"2"]]}]}}`))
+	}))
+	defer srv.Close()
+
+	m, err := New(srv.URL).QueryRange(context.Background(), "rate(x[5m])",
+		providers.TimeWindow{Start: time.Unix(1700000000, 0), End: time.Unix(1700000300, 0)}, time.Minute)
+	if err != nil {
+		t.Fatalf("QueryRange: %v", err)
+	}
+	if len(m) != 1 || len(m[0].Points) != 2 || m[0].Points[1].Value != 2 {
+		t.Fatalf("unexpected matrix: %+v", m)
+	}
+}
+
+func TestQueryError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"error","error":"bad query"}`))
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL).Query(context.Background(), "(", time.Time{}); err == nil {
+		t.Fatal("expected error for status=error")
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -175,16 +175,42 @@ type IssueProvider interface {
 	OpenPR(ctx context.Context, entry KBEntry) (Ref, error)
 }
 
-// ---- payloads (sketched; refined as impls land) ------------------------------
+// ---- payloads ----------------------------------------------------------------
 
-// Samples is a placeholder instant-query result envelope.
-type Samples struct{ Raw []byte }
+// Sample is one instant metric value with its labels.
+type Sample struct {
+	Metric map[string]string
+	Value  float64
+	Time   time.Time
+}
 
-// Matrix is a placeholder range-query result envelope.
-type Matrix struct{ Raw []byte }
+// Point is a single (time, value) in a range series.
+type Point struct {
+	Time  time.Time
+	Value float64
+}
 
-// LogResult is a placeholder logs/network query result envelope.
-type LogResult struct{ Raw []byte }
+// Series is a labeled time series (range query).
+type Series struct {
+	Metric map[string]string
+	Points []Point
+}
+
+// LogLine is one normalized log entry (engine-agnostic).
+type LogLine struct {
+	Time    time.Time
+	Message string
+	Fields  map[string]string
+}
+
+// Samples is an instant-vector result.
+type Samples []Sample
+
+// Matrix is a range-query result.
+type Matrix []Series
+
+// LogResult is a logs/network query result.
+type LogResult []LogLine
 
 // Investigation is the structured output contract of an investigation.
 type Investigation struct {


### PR DESCRIPTION
Gives the investigation loop signals beyond "what changed": **metrics** (PromQL) and **logs** (LogsQL) — the no-change causes (saturation, errors, restarts, anomalies).

## Providers
- **`internal/metrics/prometheus`** — `MetricsProvider` over the Prometheus HTTP API (`/api/v1/query` + `/query_range`), also spoken by **VictoriaMetrics**. Parses vector/matrix into structured `Sample`/`Series`.
- **`internal/logs/victorialogs`** — `LogsProvider` over **VictoriaLogs** LogsQL (`/select/logsql/query`), normalizing the NDJSON response (`_time`/`_msg`/fields) into `LogLine`s.
- Refined the placeholder `Samples`/`Matrix`/`LogResult` envelopes into structured, engine-agnostic payload types.

## Tools
- **`query_metrics`** — PromQL instant query; renders `metric{labels} = value`.
- **`query_logs`** — LogsQL over a `since_minutes` window; renders `time message`.
- Wired into `serve` when `config.metrics.url` / `config.logs.url` are set.

## Verified
- Unit (`httptest`): metrics vector/range parsing + error status; logs NDJSON parsing + form-encoding; both tools render via fakes.
- **e2e on k3d — 24/24** (4 new): the loop drove `query_metrics` + `query_logs`, and both mock backends were queried (the logs call carried the form-encoded LogsQL + window).

Both optional — absent config simply omits the tool.