### PR TITLE
docs(getting-started): metrics + logs config

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,6 +18,8 @@ forge (issues/PRs on a repo you designate).
   reach Claude via an OpenAI-compatible gateway such as OpenRouter.) Keep it in-cluster if you don't
   want telemetry to leave your boundary.
 - `kubectl` + `helm` (v3.12+).
+- Optional: a **metrics** backend (VictoriaMetrics/Prometheus) and/or a **logs** backend
+  (VictoriaLogs) — they enable the `query_metrics` / `query_logs` investigation tools.
 - Optional: a **Slack incoming webhook** and/or a **Matrix** account for delivery.
 - Optional: a **GitHub App** for curation (the Learn loop) — [step 2](#step-2-github-app-for-curation-optional).
 - Optional: [External Secrets Operator](https://external-secrets.io/) to sync credentials from a vault
@@ -177,6 +179,12 @@ config:
       interval: 5m
       # token_env: KB_GIT_TOKEN              # for a private repo (key in the Secret)
 
+  # Investigate signals (optional) — enable the query_metrics / query_logs tools.
+  metrics:
+    url: http://vmsingle.observability.svc:8429       # PromQL API base (VictoriaMetrics, or Prometheus on :9090)
+  logs:
+    url: http://victorialogs.observability.svc:9428   # VictoriaLogs base (LogsQL)
+
   # Deliver: one or both.
   notify:
     slack:
@@ -255,7 +263,7 @@ Fire a test: trigger a `critical`/`prod` alert (or `flux suspend`+break a Kustom
 
 ## What RunLore can and cannot do
 
-- **Cluster**: read-only. It reads Flux resources, metrics/logs (as providers land), and never writes
+- **Cluster**: read-only. It reads Flux resources, metrics (PromQL), and logs (LogsQL), and never writes
   to the cluster. RBAC is limited to watching `Kustomization`s, reading `GitRepository`s, and its own
   leader-election `Lease`.
 - **Forge**: writes issues/PRs to the one KB repo you configure, via the scoped GitHub App.


### PR DESCRIPTION
Adds `config.metrics.url` / `config.logs.url` to the getting-started values example and prerequisites (the `query_metrics`/`query_logs` tools from #20), and updates the read-only note now that those providers have landed.