### PR TITLE
feat: Argo CD GitOps provider (engine parity with Flux)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/Smana/runlore/internal/network/hubble"
 	"github.com/Smana/runlore/internal/notify"
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/providers/gitops/argocd"
 	"github.com/Smana/runlore/internal/providers/gitops/flux"
 	"github.com/Smana/runlore/internal/server"
 	"github.com/Smana/runlore/internal/trigger"
@@ -101,8 +102,8 @@ func runServe(args []string) error {
 	// Build kube clients once (best-effort): the dynamic client backs the
 	// GitOps-failure watch + what-changed tool; the clientset backs leader election.
 	var (
-		fluxProvider *flux.Provider
-		clientset    *kubernetes.Clientset
+		gitops    providers.GitOpsProvider
+		clientset *kubernetes.Clientset
 	)
 	if restCfg, err := restConfig(); err != nil {
 		log.Warn("no kube client; GitOps features + leader election disabled", "err", err)
@@ -110,7 +111,7 @@ func runServe(args []string) error {
 		if dc, derr := dynamic.NewForConfig(restCfg); derr != nil {
 			log.Warn("dynamic client unavailable; GitOps features disabled", "err", derr)
 		} else {
-			fluxProvider = flux.New(flux.NewDynamicReader(dc), &whatchanged.Differ{})
+			gitops = buildGitOps(cfg, dc, log)
 		}
 		if cs, cerr := kubernetes.NewForConfig(restCfg); cerr != nil {
 			log.Warn("clientset unavailable; leader election disabled", "err", cerr)
@@ -119,15 +120,15 @@ func runServe(args []string) error {
 		}
 	}
 
-	inv := buildInvestigator(ctx, cfg, fluxProvider, log)
+	inv := buildInvestigator(ctx, cfg, gitops, log)
 	queue := investigate.NewQueue(inv, log)
 
 	// startWork runs the leader-only loops (investigation queue + failure watch),
 	// scoped to a context cancelled when leadership is lost.
 	startWork := func(workCtx context.Context) {
 		go queue.Run(workCtx)
-		if cfg.Triggers.GitOpsFailures.Enabled && fluxProvider != nil {
-			startGitOpsFailureWatch(workCtx, cfg, queue, fluxProvider, log)
+		if cfg.Triggers.GitOpsFailures.Enabled && gitops != nil {
+			startGitOpsFailureWatch(workCtx, cfg, queue, gitops, log)
 		}
 	}
 
@@ -303,7 +304,7 @@ func buildCurator(cfg *config.Config, log *slog.Logger) *curator.Curator {
 
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
-func buildInvestigator(ctx context.Context, cfg *config.Config, fp *flux.Provider, log *slog.Logger) investigate.Investigator {
+func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, log *slog.Logger) investigate.Investigator {
 	if cfg.Model.BaseURL == "" {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
@@ -314,8 +315,8 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, fp *flux.Provide
 	}
 	model := openai.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
 	var tools []investigate.Tool
-	if fp != nil {
-		tools = append(tools, investigate.WhatChangedTool{GitOps: fp})
+	if gp != nil {
+		tools = append(tools, investigate.WhatChangedTool{GitOps: gp})
 	}
 	if cat := buildCatalog(ctx, cfg, log); cat != nil {
 		tools = append(tools, investigate.KBSearchTool{Catalog: cat})
@@ -355,14 +356,33 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, fp *flux.Provide
 }
 
 // startGitOpsFailureWatch drains Flux WatchFailures into the queue.
-func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, fp *flux.Provider, log *slog.Logger) {
-	events, err := fp.WatchFailures(ctx)
+func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, gp providers.GitOpsProvider, log *slog.Logger) {
+	events, err := gp.WatchFailures(ctx)
 	if err != nil {
 		log.Warn("gitops-failure watch disabled", "err", err)
 		return
 	}
-	log.Info("watching gitops failures (Flux Kustomizations)")
+	log.Info("watching gitops failures", "engine", gitopsEngine(cfg))
 	go investigate.DrainFailures(ctx, events, q, trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()))
+}
+
+// gitopsEngine returns the configured GitOps engine, defaulting to flux.
+func gitopsEngine(cfg *config.Config) string {
+	if cfg.GitOps.Engine == "argocd" {
+		return "argocd"
+	}
+	return "flux"
+}
+
+// buildGitOps builds the GitOps provider for the configured engine (flux default).
+func buildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) providers.GitOpsProvider {
+	differ := &whatchanged.Differ{}
+	if gitopsEngine(cfg) == "argocd" {
+		log.Info("gitops engine", "engine", "argocd")
+		return argocd.New(argocd.NewDynamicReader(dc), differ)
+	}
+	log.Info("gitops engine", "engine", "flux")
+	return flux.New(flux.NewDynamicReader(dc), differ)
 }
 
 // restConfig builds a Kubernetes REST config from in-cluster config, falling back

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -13,6 +13,10 @@ rules:
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["gitrepositories"]
     verbs: ["get", "list", "watch"]
+  # Argo CD engine (config.gitops.engine: argocd)
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,8 +11,9 @@ forge (issues/PRs on a repo you designate).
 
 ## Prerequisites
 
-- A Kubernetes cluster running **Flux** (the what-changed spine + failure trigger read Flux
-  `Kustomization`/`GitRepository` resources; ArgoCD is on the roadmap).
+- A Kubernetes cluster running **Flux** or **Argo CD** — select with `config.gitops.engine`
+  (`flux` default, or `argocd`). The what-changed spine + failure trigger read the engine's resources
+  (Flux `Kustomization`/`GitRepository`, or Argo CD `Application`s).
 - An **OpenAI-compatible** model endpoint — in-cluster [vLLM](https://github.com/vllm-project/vllm),
   [Ollama](https://ollama.com/), OpenAI, or OpenRouter. (Native Anthropic is on the roadmap; today,
   reach Claude via an OpenAI-compatible gateway such as OpenRouter.) Keep it in-cluster if you don't
@@ -156,6 +157,9 @@ catalog:
   # configMap: runlore-catalog
 
 config:
+  # GitOps engine the what-changed spine + failure watch read.
+  gitops:
+    engine: flux          # or "argocd"
   # React: only investigate what matters (controls noise + LLM cost).
   triggers:
     incidents:

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -174,7 +174,7 @@ check "GitHub App token exchange"              /tmp/runlore-mock.log 'MOCK GH-TO
 check "curator opened a PR (confident)"        /tmp/runlore-mock.log 'MOCK GH-PR'
 check "curated ref logged"                     /tmp/runlore.log 'msg=curated'
 
-step "8/9 GitOps failure trigger (informer on a real API server)"
+step "8/10 GitOps failure trigger (informer on a real API server)"
 kubectl create ns apps >/dev/null 2>&1 || true
 kubectl apply -f - <<'YAML'
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -188,7 +188,7 @@ sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "gitops failure -> investigate" /tmp/runlore.log 'source=gitops-failure|Kustomization/broken-app'
 
-step "9/9 leader election + failover (scale to 2)"
+step "9/10 leader election + failover (scale to 2)"
 kubectl -n "$NS" scale deploy/runlore --replicas=2 >/dev/null
 TOTAL=0; READY=0
 for _ in $(seq 1 30); do
@@ -216,6 +216,42 @@ for _ in $(seq 1 30); do
 done
 if [[ -n "$NEW" && "$NEW" != "$HOLDER" ]]; then green "PASS: failover — new leader $NEW"; PASS=$((PASS+1))
 else red "FAIL: no failover (holder still '$NEW')"; FAIL=$((FAIL+1)); fi
+
+step "10/10 ArgoCD engine (reconfigure + Application Degraded)"
+kubectl apply -f - <<'YAML'
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: { name: applications.argoproj.io }
+spec:
+  group: argoproj.io
+  scope: Namespaced
+  names: { kind: Application, plural: applications, singular: application, listKind: ApplicationList }
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources: { status: {} }
+      schema:
+        openAPIV3Schema: { type: object, x-kubernetes-preserve-unknown-fields: true }
+YAML
+kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=30s
+# Switch the engine to argocd (reuse prior values; back to 1 replica for a quick roll).
+helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
+  --set replicaCount=1 --set-string config.gitops.engine=argocd >/dev/null
+kubectl -n "$NS" rollout status deploy/runlore --timeout=90s
+sleep 3
+kubectl apply -f - <<'YAML'
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata: { name: broken-argo, namespace: apps }
+spec: { source: { repoURL: "https://github.com/org/repo", path: apps } }
+YAML
+kubectl patch application broken-argo -n apps --subresource=status --type=merge -p \
+  '{"status":{"health":{"status":"Degraded"},"sync":{"revision":"deadbeef","status":"OutOfSync"},"operationState":{"message":"image pull backoff"}}}'
+sleep 6
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "argocd engine active"          /tmp/runlore.log 'engine=argocd'
+check "argocd failure -> investigate" /tmp/runlore.log 'Application/broken-argo'
 
 step "RESULTS"
 echo "PASS=$PASS FAIL=$FAIL"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ import (
 
 // Config is the top-level RunLore configuration (loaded from YAML).
 type Config struct {
+	GitOps   GitOps        `yaml:"gitops"` // engine selection (flux default | argocd)
 	Triggers TriggerPolicy `yaml:"triggers"`
 	Actions  ActionPolicy  `yaml:"actions"` // read-only by default; the upper rungs of the autonomy ladder
 	Forge    Forge         `yaml:"forge"`   // git-forge auth (GitHub App) for diff access + curation
@@ -84,6 +85,11 @@ type MatrixNotify struct {
 	Homeserver     string `yaml:"homeserver"`
 	RoomID         string `yaml:"room_id"`
 	AccessTokenEnv string `yaml:"access_token_env"` // env var holding the access token
+}
+
+// GitOps selects the GitOps engine RunLore reads (what-changed + failure watch).
+type GitOps struct {
+	Engine string `yaml:"engine"` // "flux" (default) | "argocd"
 }
 
 // TriggerPolicy decides what RunLore reacts to.

--- a/internal/providers/gitops/argocd/argocd.go
+++ b/internal/providers/gitops/argocd/argocd.go
@@ -1,0 +1,144 @@
+// Package argocd implements providers.GitOpsProvider for Argo CD: it reads Argo CD
+// Applications from the cluster and emits engine-agnostic Changes (diffable via
+// whatchanged.Differ) and failure events — the same contract as the flux package.
+package argocd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/whatchanged"
+)
+
+// application is the minimal Argo CD Application data the provider needs.
+type application struct {
+	Name, Namespace string
+	RepoURL         string // spec.source.repoURL
+	Path            string // spec.source.path
+	Revision        string // status.sync.revision (current)
+	PrevRevision    string // previous status.history revision (diff range start)
+	HealthStatus    string // status.health.status
+	SyncStatus      string // status.sync.status
+	Message         string // status.operationState.message (failure context)
+}
+
+// ApplicationEvent is a single watch event for an Application.
+type ApplicationEvent struct {
+	Application application
+}
+
+// Reader is the cluster-read surface the provider depends on. The dynamic
+// client-go implementation lives in dynamic.go; tests use a fake.
+type Reader interface {
+	ListApplications(ctx context.Context) ([]application, error)
+	WatchApplications(ctx context.Context) (<-chan ApplicationEvent, error)
+}
+
+// Provider implements providers.GitOpsProvider for Argo CD.
+type Provider struct {
+	reader Reader
+	differ *whatchanged.Differ
+}
+
+// New builds an Argo CD provider from a Reader and a Differ.
+func New(reader Reader, differ *whatchanged.Differ) *Provider {
+	return &Provider{reader: reader, differ: differ}
+}
+
+// Changes lists Argo CD Applications and emits a Change per app: its source repo +
+// path, the deployed revision (ToRev), and the previously deployed revision
+// (FromRev, from the rollout history) when available.
+//
+// NOTE (v1 scope): the window is accepted but not yet used to filter by deploy
+// time; multi-source Applications (spec.sources) use only spec.source for now.
+func (p *Provider) Changes(ctx context.Context, _ providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
+	apps, err := p.reader.ListApplications(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var changes []providers.Change
+	for _, a := range apps {
+		if sel.Namespace != "" && a.Namespace != sel.Namespace {
+			continue
+		}
+		if sel.Name != "" && a.Name != sel.Name {
+			continue
+		}
+		if a.RepoURL == "" || a.Revision == "" {
+			continue // not enough to locate a source diff
+		}
+		changes = append(changes, mapApplication(a))
+	}
+	return changes, nil
+}
+
+// Diff resolves a Change's diff via the Differ.
+func (p *Provider) Diff(_ context.Context, c providers.Change) (providers.Diff, error) {
+	return p.differ.ForChange(c)
+}
+
+// WatchFailures watches Argo CD Applications and emits a FailureEvent whenever one
+// is Degraded. The returned channel closes when the watch ends or ctx is done.
+func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureEvent, error) {
+	src, err := p.reader.WatchApplications(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(chan providers.FailureEvent)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-src:
+				if !ok {
+					return
+				}
+				a := ev.Application
+				if a.HealthStatus != "Degraded" {
+					continue
+				}
+				fe := providers.FailureEvent{
+					Workload: providers.Workload{Kind: "Application", Name: a.Name, Namespace: a.Namespace},
+					Engine:   providers.EngineArgoCD,
+					Reason:   a.HealthStatus,
+					Message:  a.Message,
+				}
+				select {
+				case out <- fe:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out, nil
+}
+
+// mapApplication builds an engine-agnostic Change from an Application.
+func mapApplication(a application) providers.Change {
+	return providers.Change{
+		Workload: providers.Workload{Kind: "Application", Name: a.Name, Namespace: a.Namespace},
+		Engine:   providers.EngineArgoCD,
+		Type:     providers.ChangeSync,
+		Source:   providers.SourceRef{RepoURL: a.RepoURL, Path: a.Path},
+		FromRev:  parseRevision(a.PrevRevision),
+		ToRev:    parseRevision(a.Revision),
+	}
+}
+
+// parseRevision extracts the commit SHA from a revision string. Argo CD revisions
+// are usually bare SHAs; tolerate "<ref>@sha1:<sha>" and "<ref>/<sha>" too.
+func parseRevision(rev string) string {
+	if i := strings.LastIndex(rev, ":"); i >= 0 {
+		return rev[i+1:]
+	}
+	if i := strings.LastIndex(rev, "/"); i >= 0 {
+		return rev[i+1:]
+	}
+	return rev
+}
+
+var _ providers.GitOpsProvider = (*Provider)(nil)

--- a/internal/providers/gitops/argocd/argocd_test.go
+++ b/internal/providers/gitops/argocd/argocd_test.go
@@ -1,0 +1,106 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/whatchanged"
+)
+
+func TestParseRevision(t *testing.T) {
+	cases := map[string]string{
+		"abc123":           "abc123", // bare SHA (Argo CD default)
+		"main@sha1:def456": "def456",
+		"main/abc789":      "abc789",
+		"":                 "",
+	}
+	for in, want := range cases {
+		if got := parseRevision(in); got != want {
+			t.Errorf("parseRevision(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+type fakeReader struct {
+	apps   []application
+	events []ApplicationEvent
+}
+
+func (f fakeReader) ListApplications(context.Context) ([]application, error) { return f.apps, nil }
+func (f fakeReader) WatchApplications(context.Context) (<-chan ApplicationEvent, error) {
+	ch := make(chan ApplicationEvent, len(f.events))
+	for _, e := range f.events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestProviderChanges(t *testing.T) {
+	r := fakeReader{apps: []application{
+		{Name: "harbor", Namespace: "argocd", RepoURL: "https://github.com/org/repo", Path: "apps/harbor", Revision: "newsha", PrevRevision: "oldsha"},
+		{Name: "incomplete", Namespace: "argocd", RepoURL: "", Revision: "x"}, // skipped: no repoURL
+	}}
+	p := New(r, &whatchanged.Differ{})
+	changes, err := p.Changes(context.Background(), providers.TimeWindow{}, providers.Selector{})
+	if err != nil {
+		t.Fatalf("Changes: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("want 1 change (incomplete skipped), got %d", len(changes))
+	}
+	c := changes[0]
+	if c.Engine != providers.EngineArgoCD || c.Type != providers.ChangeSync {
+		t.Fatalf("unexpected engine/type: %+v", c)
+	}
+	if c.Workload != (providers.Workload{Kind: "Application", Name: "harbor", Namespace: "argocd"}) {
+		t.Fatalf("unexpected workload: %+v", c.Workload)
+	}
+	if c.Source != (providers.SourceRef{RepoURL: "https://github.com/org/repo", Path: "apps/harbor"}) {
+		t.Fatalf("unexpected source: %+v", c.Source)
+	}
+	if c.FromRev != "oldsha" || c.ToRev != "newsha" {
+		t.Fatalf("unexpected revs: from=%q to=%q", c.FromRev, c.ToRev)
+	}
+}
+
+func TestProviderChangesSelector(t *testing.T) {
+	r := fakeReader{apps: []application{
+		{Name: "harbor", Namespace: "argocd", RepoURL: "u", Revision: "a"},
+		{Name: "infra", Namespace: "argocd", RepoURL: "u", Revision: "b"},
+	}}
+	p := New(r, &whatchanged.Differ{})
+	changes, err := p.Changes(context.Background(), providers.TimeWindow{}, providers.Selector{Name: "infra"})
+	if err != nil {
+		t.Fatalf("Changes: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Workload.Name != "infra" {
+		t.Fatalf("selector did not filter to infra: %v", changes)
+	}
+}
+
+func TestWatchFailures(t *testing.T) {
+	r := fakeReader{events: []ApplicationEvent{
+		{Application: application{Name: "ok", Namespace: "argocd", HealthStatus: "Healthy"}},
+		{Application: application{Name: "bad", Namespace: "apps", HealthStatus: "Degraded", Message: "container crash"}},
+		{Application: application{Name: "prog", Namespace: "apps", HealthStatus: "Progressing"}},
+	}}
+	p := New(r, &whatchanged.Differ{})
+	ch, err := p.WatchFailures(context.Background())
+	if err != nil {
+		t.Fatalf("WatchFailures: %v", err)
+	}
+	var got []providers.FailureEvent
+	for e := range ch {
+		got = append(got, e)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 failure event (only Degraded), got %d", len(got))
+	}
+	e := got[0]
+	if e.Engine != providers.EngineArgoCD || e.Workload.Name != "bad" || e.Workload.Kind != "Application" ||
+		e.Reason != "Degraded" || e.Message != "container crash" {
+		t.Fatalf("unexpected failure event: %+v", e)
+	}
+}

--- a/internal/providers/gitops/argocd/dynamic.go
+++ b/internal/providers/gitops/argocd/dynamic.go
@@ -1,0 +1,111 @@
+package argocd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
+)
+
+// applicationGVR is the Argo CD Application resource.
+var applicationGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+
+// dynamicReader reads Argo CD Applications as unstructured objects.
+type dynamicReader struct {
+	client dynamic.Interface
+}
+
+// NewDynamicReader builds a Reader backed by a client-go dynamic client.
+func NewDynamicReader(client dynamic.Interface) Reader {
+	return &dynamicReader{client: client}
+}
+
+// ListApplications lists all Argo CD Applications across all namespaces.
+func (r *dynamicReader) ListApplications(ctx context.Context) ([]application, error) {
+	list, err := r.client.Resource(applicationGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list applications: %w", err)
+	}
+	out := make([]application, 0, len(list.Items))
+	for i := range list.Items {
+		out = append(out, applicationFromUnstructured(&list.Items[i]))
+	}
+	return out, nil
+}
+
+// WatchApplications watches all Applications via a dynamic informer (list-watch
+// with reconnection + periodic resync) and forwards each add/update. The channel
+// closes when ctx is done.
+func (r *dynamicReader) WatchApplications(ctx context.Context) (<-chan ApplicationEvent, error) {
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(r.client, 10*time.Minute)
+	informer := factory.ForResource(applicationGVR).Informer()
+
+	out := make(chan ApplicationEvent, 128)
+	send := func(obj any) {
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			return
+		}
+		ev := ApplicationEvent{Application: applicationFromUnstructured(u)}
+		select {
+		case out <- ev:
+		case <-ctx.Done():
+		default: // never block the informer; drop under backpressure
+		}
+	}
+	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { send(obj) },
+		UpdateFunc: func(_, obj any) { send(obj) },
+	}); err != nil {
+		return nil, fmt.Errorf("add event handler: %w", err)
+	}
+
+	go func() {
+		defer close(out)
+		factory.Start(ctx.Done())
+		<-ctx.Done()
+	}()
+	return out, nil
+}
+
+// applicationFromUnstructured maps an unstructured Application to the minimal type.
+func applicationFromUnstructured(u *unstructured.Unstructured) application {
+	repoURL, _, _ := unstructured.NestedString(u.Object, "spec", "source", "repoURL")
+	path, _, _ := unstructured.NestedString(u.Object, "spec", "source", "path")
+	rev, _, _ := unstructured.NestedString(u.Object, "status", "sync", "revision")
+	syncStatus, _, _ := unstructured.NestedString(u.Object, "status", "sync", "status")
+	health, _, _ := unstructured.NestedString(u.Object, "status", "health", "status")
+	msg, _, _ := unstructured.NestedString(u.Object, "status", "operationState", "message")
+	return application{
+		Name:         u.GetName(),
+		Namespace:    u.GetNamespace(),
+		RepoURL:      repoURL,
+		Path:         path,
+		Revision:     rev,
+		PrevRevision: prevRevision(u),
+		HealthStatus: health,
+		SyncStatus:   syncStatus,
+		Message:      msg,
+	}
+}
+
+// prevRevision returns the revision before the latest in status.history (the diff
+// range start), or empty if there is no prior deployment.
+func prevRevision(u *unstructured.Unstructured) string {
+	hist, found, _ := unstructured.NestedSlice(u.Object, "status", "history")
+	if !found || len(hist) < 2 {
+		return ""
+	}
+	m, ok := hist[len(hist)-2].(map[string]any)
+	if !ok {
+		return ""
+	}
+	rev, _ := m["revision"].(string)
+	return rev
+}

--- a/internal/providers/gitops/argocd/dynamic_test.go
+++ b/internal/providers/gitops/argocd/dynamic_test.go
@@ -1,0 +1,63 @@
+package argocd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+func TestApplicationFromUnstructured(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "harbor", "namespace": "argocd"},
+		"spec":       map[string]any{"source": map[string]any{"repoURL": "https://github.com/org/repo", "path": "apps/harbor"}},
+		"status": map[string]any{
+			"sync":           map[string]any{"revision": "newsha", "status": "Synced"},
+			"health":         map[string]any{"status": "Degraded"},
+			"operationState": map[string]any{"message": "boom"},
+			"history": []any{
+				map[string]any{"revision": "oldsha"},
+				map[string]any{"revision": "newsha"},
+			},
+		},
+	}}
+	a := applicationFromUnstructured(u)
+	if a.RepoURL != "https://github.com/org/repo" || a.Path != "apps/harbor" || a.Revision != "newsha" ||
+		a.PrevRevision != "oldsha" || a.HealthStatus != "Degraded" || a.SyncStatus != "Synced" || a.Message != "boom" {
+		t.Fatalf("unexpected application: %+v", a)
+	}
+}
+
+func TestDynamicReaderWatch(t *testing.T) {
+	gvrToListKind := map[schema.GroupVersionResource]string{applicationGVR: "ApplicationList"}
+	degraded := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "bad", "namespace": "apps"},
+		"spec":       map[string]any{"source": map[string]any{"repoURL": "u", "path": "p"}},
+		"status":     map[string]any{"health": map[string]any{"status": "Degraded"}},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, degraded)
+	r := NewDynamicReader(client)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := r.WatchApplications(ctx)
+	if err != nil {
+		t.Fatalf("WatchApplications: %v", err)
+	}
+	select {
+	case ev := <-ch:
+		if ev.Application.Name != "bad" || ev.Application.HealthStatus != "Degraded" {
+			t.Fatalf("unexpected event: %+v", ev.Application)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for informer event")
+	}
+}


### PR DESCRIPTION
Makes RunLore genuinely **GitOps-engine-agnostic**: the what-changed spine + failure trigger now work with **Argo CD** as well as Flux, behind the same `providers.GitOpsProvider` contract.

## Provider
- **`internal/providers/gitops/argocd`** — reads `argoproj.io/v1alpha1` `Application`s via the dynamic client/informer (mirrors the Flux package):
  - **Changes**: `spec.source.repoURL`/`path`, `status.sync.revision` (ToRev), and the prior `status.history` revision (FromRev) → engine-agnostic `Change`, diffable through the same `whatchanged.Differ`.
  - **WatchFailures**: emits on `status.health.status == Degraded`.

## Wiring
- `config.gitops.engine` (`flux` default | `argocd`) selects the provider; `serve` now holds a `providers.GitOpsProvider` (the what-changed tool + failure watch are engine-agnostic).
- Chart ClusterRole grants `argoproj.io/applications` get/list/watch.

## Verified
- Unit: mapping, selector filtering, history→FromRev, Degraded→FailureEvent, and a **dynamic-fake informer** watch (mirrors Flux's own tests; race-clean).
- **e2e on k3d — 28/28** (2 new): reconfigured a live deployment to `engine: argocd`, installed the `Application` CRD, patched one `Degraded` → the informer fired → full chain (investigate → deliver → curate, PR titled `KB: Application/broken-argo Degraded`). Flux steps 1–9 still green after the interface refactor.