### PR TITLE
feat(model): native Anthropic support

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
+	anthropic "github.com/Smana/runlore/internal/model/anthropic"
 	openai "github.com/Smana/runlore/internal/model/openai"
 	"github.com/Smana/runlore/internal/network/hubble"
 	"github.com/Smana/runlore/internal/notify"
@@ -215,6 +216,22 @@ func podNamespace() string {
 	return "default"
 }
 
+// modelProvider returns the configured model provider name (default "openai").
+func modelProvider(cfg *config.Config) string {
+	if cfg.Model.Provider == "anthropic" {
+		return "anthropic"
+	}
+	return "openai"
+}
+
+// buildModel builds the ModelProvider for the configured provider.
+func buildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
+	if cfg.Model.Provider == "anthropic" {
+		return anthropic.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+	}
+	return openai.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+}
+
 // buildCatalog returns the kb_search backing store, or nil when no catalog is
 // configured. With a Git URL it starts a background syncer (running on every
 // replica, so a failover standby is already warm) that re-indexes after each pull;
@@ -305,7 +322,7 @@ func buildCurator(cfg *config.Config, log *slog.Logger) *curator.Curator {
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
 func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, log *slog.Logger) investigate.Investigator {
-	if cfg.Model.BaseURL == "" {
+	if cfg.Model.BaseURL == "" && cfg.Model.Provider != "anthropic" {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
 	}
@@ -313,7 +330,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	if cfg.Model.APIKeyEnv != "" {
 		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
 	}
-	model := openai.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+	model := buildModel(cfg, apiKey)
 	var tools []investigate.Tool
 	if gp != nil {
 		tools = append(tools, investigate.WhatChangedTool{GitOps: gp})
@@ -330,7 +347,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	if cfg.Network.URL != "" {
 		tools = append(tools, investigate.NetworkDropsTool{Network: hubble.New(cfg.Network.URL)})
 	}
-	log.Info("using LLM investigator", "model", cfg.Model.Model, "tools", len(tools))
+	log.Info("using LLM investigator", "provider", modelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)
 	log.Info("delivery notifiers", "count", notifier.Len())
 	cur := buildCurator(cfg, log)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,10 +14,10 @@ forge (issues/PRs on a repo you designate).
 - A Kubernetes cluster running **Flux** or **Argo CD** — select with `config.gitops.engine`
   (`flux` default, or `argocd`). The what-changed spine + failure trigger read the engine's resources
   (Flux `Kustomization`/`GitRepository`, or Argo CD `Application`s).
-- An **OpenAI-compatible** model endpoint — in-cluster [vLLM](https://github.com/vllm-project/vllm),
-  [Ollama](https://ollama.com/), OpenAI, or OpenRouter. (Native Anthropic is on the roadmap; today,
-  reach Claude via an OpenAI-compatible gateway such as OpenRouter.) Keep it in-cluster if you don't
-  want telemetry to leave your boundary.
+- An **LLM** — either an **OpenAI-compatible** endpoint (in-cluster
+  [vLLM](https://github.com/vllm-project/vllm), [Ollama](https://ollama.com/), OpenAI, OpenRouter) or
+  **native Anthropic** (`model.provider: anthropic`). Keep it in-cluster if you don't want telemetry to
+  leave your boundary.
 - `kubectl` + `helm` (v3.12+).
 - Optional: a **metrics** backend (VictoriaMetrics/Prometheus), a **logs** backend (VictoriaLogs),
   and/or **Cilium Hubble** (Relay) — they enable the `query_metrics` / `query_logs` / `network_drops`
@@ -176,6 +176,10 @@ config:
     base_url: http://vllm.llm.svc:8000/v1   # any OpenAI-compatible endpoint
     model: <your-model-name>
     api_key_env: OPENAI_API_KEY             # omit/empty for keyless (in-cluster vLLM/Ollama)
+    # — or native Anthropic instead:
+    # provider: anthropic
+    # model: claude-sonnet-4-6
+    # api_key_env: ANTHROPIC_API_KEY        # base_url defaults to api.anthropic.com
   catalog:
     dir: /var/lib/runlore/catalog           # must match catalog.mountPath above
     git:                                     # omit this block if using a static ConfigMap

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,10 +61,13 @@ type CatalogGit struct {
 	TokenEnv string   `yaml:"token_env"` // env var with a read token (empty = anonymous/public)
 }
 
-// Model configures the OpenAI-compatible LLM endpoint used for investigation.
-// When BaseURL is empty, serve falls back to the log-only investigator.
+// Model configures the LLM used for investigation. Provider selects the wire
+// protocol: "openai" (default, OpenAI-compatible: vLLM/Ollama/OpenAI) or
+// "anthropic" (native Messages API). When unconfigured, serve uses the log-only
+// investigator.
 type Model struct {
-	BaseURL   string `yaml:"base_url"`    // e.g. https://vllm.svc/v1
+	Provider  string `yaml:"provider"`    // "openai" (default) | "anthropic"
+	BaseURL   string `yaml:"base_url"`    // OpenAI: required; Anthropic: optional (defaults to api.anthropic.com)
 	Model     string `yaml:"model"`       // model name
 	APIKeyEnv string `yaml:"api_key_env"` // env var holding the API key (empty = keyless)
 }

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -1,0 +1,177 @@
+// Package anthropic implements providers.ModelProvider against the Anthropic
+// Messages API (native tool use). It maps RunLore's engine-agnostic exchange
+// (OpenAI-shaped: assistant tool_calls + separate tool messages) onto Anthropic's
+// content-block form (tool_use blocks; tool_result blocks coalesced into one user
+// turn).
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// DefaultBaseURL is the public Anthropic API.
+const DefaultBaseURL = "https://api.anthropic.com"
+
+const (
+	defaultMaxTokens = 4096
+	apiVersion       = "2023-06-01"
+)
+
+// Client is an Anthropic Messages API model provider.
+type Client struct {
+	baseURL   string
+	model     string
+	apiKey    string
+	maxTokens int
+	http      *http.Client
+}
+
+// New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
+func New(baseURL, model, apiKey string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	return &Client{
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		model:     model,
+		apiKey:    apiKey,
+		maxTokens: defaultMaxTokens,
+		http:      &http.Client{Timeout: 2 * time.Minute},
+	}
+}
+
+var _ providers.ModelProvider = (*Client)(nil)
+
+type msgRequest struct {
+	Model     string    `json:"model"`
+	MaxTokens int       `json:"max_tokens"`
+	System    string    `json:"system,omitempty"`
+	Messages  []message `json:"messages"`
+	Tools     []tool    `json:"tools,omitempty"`
+}
+
+type message struct {
+	Role    string  `json:"role"`
+	Content []block `json:"content"`
+}
+
+type block struct {
+	Type string `json:"type"`
+	// text
+	Text string `json:"text,omitempty"`
+	// tool_use
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// tool_result
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+type tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type msgResponse struct {
+	Content []block `json:"content"`
+	Error   *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// Complete sends a Messages request with tools and maps the result back.
+func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, System: req.System, Messages: toMessages(req.Messages)}
+	for _, t := range req.Tools {
+		areq.Tools = append(areq.Tools, tool{Name: t.Name, Description: t.Description, InputSchema: json.RawMessage(t.Schema)})
+	}
+	body, err := json.Marshal(areq)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return providers.CompletionResponse{}, err
+	}
+	httpReq.Header.Set("content-type", "application/json")
+	httpReq.Header.Set("anthropic-version", apiVersion)
+	httpReq.Header.Set("x-api-key", c.apiKey)
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("messages request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return providers.CompletionResponse{}, fmt.Errorf("messages status %d: %s", resp.StatusCode, string(data))
+	}
+	var mr msgResponse
+	if err := json.Unmarshal(data, &mr); err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("parse response: %w", err)
+	}
+	if mr.Error != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("anthropic error: %s", mr.Error.Message)
+	}
+	out := providers.CompletionResponse{}
+	for _, b := range mr.Content {
+		switch b.Type {
+		case "text":
+			out.Text += b.Text
+		case "tool_use":
+			out.ToolCalls = append(out.ToolCalls, providers.ToolCall{ID: b.ID, Name: b.Name, Args: string(b.Input)})
+		}
+	}
+	return out, nil
+}
+
+// toMessages maps engine-agnostic messages to Anthropic messages. Consecutive
+// "tool" results are coalesced into a single user message (Anthropic requires all
+// tool_result blocks answering an assistant turn to share one user message).
+func toMessages(in []providers.Message) []message {
+	var out []message
+	for i := 0; i < len(in); i++ {
+		m := in[i]
+		switch m.Role {
+		case "assistant":
+			var blocks []block
+			if m.Content != "" {
+				blocks = append(blocks, block{Type: "text", Text: m.Content})
+			}
+			for _, tc := range m.ToolCalls {
+				blocks = append(blocks, block{Type: "tool_use", ID: tc.ID, Name: tc.Name, Input: rawObject(tc.Args)})
+			}
+			out = append(out, message{Role: "assistant", Content: blocks})
+		case "tool":
+			var results []block
+			for i < len(in) && in[i].Role == "tool" {
+				results = append(results, block{Type: "tool_result", ToolUseID: in[i].ToolCallID, Content: in[i].Content})
+				i++
+			}
+			i-- // outer loop will increment
+			out = append(out, message{Role: "user", Content: results})
+		default: // user (and any other) → a text block
+			out = append(out, message{Role: "user", Content: []block{{Type: "text", Text: m.Content}}})
+		}
+	}
+	return out
+}
+
+// rawObject ensures tool_use input is a JSON object ("" → {}).
+func rawObject(args string) json.RawMessage {
+	if strings.TrimSpace(args) == "" {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(args)
+}

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -1,0 +1,91 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestComplete(t *testing.T) {
+	var gotReq msgRequest
+	var gotVersion, gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotVersion, gotKey = r.Header.Get("anthropic-version"), r.Header.Get("x-api-key")
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+		_, _ = w.Write([]byte(`{"content":[
+		  {"type":"text","text":"investigating"},
+		  {"type":"tool_use","id":"tu1","name":"what_changed","input":{"namespace":"apps"}}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "claude-x", "k")
+	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
+		System:   "sys",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Tools:    []providers.ToolSpec{{Name: "what_changed", Description: "d", Schema: `{"type":"object"}`}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// headers + request mapping
+	if gotVersion != apiVersion || gotKey != "k" {
+		t.Fatalf("version=%q key=%q", gotVersion, gotKey)
+	}
+	if gotReq.Model != "claude-x" || gotReq.System != "sys" || gotReq.MaxTokens == 0 {
+		t.Fatalf("request: %+v", gotReq)
+	}
+	if len(gotReq.Tools) != 1 || gotReq.Tools[0].Name != "what_changed" || string(gotReq.Tools[0].InputSchema) != `{"type":"object"}` {
+		t.Fatalf("tools: %+v", gotReq.Tools)
+	}
+	if len(gotReq.Messages) != 1 || gotReq.Messages[0].Role != "user" || gotReq.Messages[0].Content[0].Text != "hi" {
+		t.Fatalf("messages: %+v", gotReq.Messages)
+	}
+	// response mapping: text + tool_use
+	if resp.Text != "investigating" || len(resp.ToolCalls) != 1 ||
+		resp.ToolCalls[0].ID != "tu1" || resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
+		t.Fatalf("response: %+v", resp)
+	}
+}
+
+// TestMessageCoalescing verifies the OpenAI-shaped exchange (assistant tool_calls +
+// separate tool messages) maps to Anthropic's tool_use / coalesced tool_result form.
+func TestMessageCoalescing(t *testing.T) {
+	var gotReq msgRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"done"}]}`))
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "claude-x", "k").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{
+			{Role: "user", Content: "investigate"},
+			{Role: "assistant", ToolCalls: []providers.ToolCall{
+				{ID: "a", Name: "what_changed", Args: `{"namespace":"apps"}`},
+				{ID: "b", Name: "kb_search", Args: `{"query":"x"}`},
+			}},
+			{Role: "tool", ToolCallID: "a", Content: "changed: chart bump"},
+			{Role: "tool", ToolCallID: "b", Content: "runbook: rollback"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(gotReq.Messages) != 3 {
+		t.Fatalf("want 3 messages (user, assistant, coalesced user), got %d: %+v", len(gotReq.Messages), gotReq.Messages)
+	}
+	asst := gotReq.Messages[1]
+	if asst.Role != "assistant" || len(asst.Content) != 2 || asst.Content[0].Type != "tool_use" || asst.Content[0].ID != "a" {
+		t.Fatalf("assistant turn: %+v", asst)
+	}
+	results := gotReq.Messages[2]
+	if results.Role != "user" || len(results.Content) != 2 ||
+		results.Content[0].Type != "tool_result" || results.Content[0].ToolUseID != "a" || results.Content[0].Content != "changed: chart bump" ||
+		results.Content[1].ToolUseID != "b" {
+		t.Fatalf("coalesced tool results: %+v", results)
+	}
+}


### PR DESCRIPTION
Adds native **Anthropic Messages API** support alongside the OpenAI-compatible client — so Claude works directly, no gateway needed.

## How
- **`internal/model/anthropic`** — `ModelProvider` over `/v1/messages` (`x-api-key` + `anthropic-version`), native tool use. The interesting part is mapping RunLore's engine-agnostic exchange (OpenAI-shaped: assistant `tool_calls` + separate `tool` messages) onto Anthropic's content-block form: `tool_use` blocks, and `tool_result` blocks **coalesced into a single user turn** (as Anthropic requires).
- `config.model.provider` (`openai` default | `anthropic`) selects the client; `base_url` is optional for Anthropic (defaults to `api.anthropic.com`).

## Verified
- Unit (`httptest`): request mapping (system, tools `input_schema`, headers) + response parsing (text + `tool_use`), and a dedicated test for the **OpenAI→Anthropic message coalescing** (assistant 2 tool_calls + 2 tool messages → assistant `tool_use`×2 + one user message with `tool_result`×2).
- **e2e on k3d — 28/28** still green: the model-build refactor didn't regress the OpenAI path (the loop is provider-agnostic above the `ModelProvider` interface, so the in-cluster path is unchanged).

The Anthropic wire client is pure HTTP mapping, fully covered by httptest; no new e2e reconfigure needed.