### PR TITLE
feat(eval): RCA benchmark harness (lore eval)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,21 @@ go run -tags e2e ./hack/e2e/mock :9999
 This is how features that talk to paid/external services (the LLM, GitHub) get exercised end-to-end with
 zero credentials.
 
+## Eval harness (RCA benchmark)
+
+`lore eval` replays recorded incident cases through the investigation loop and reports the
+root-cause-identification rate — use it to measure (and guard against regressions in) RCA quality as
+the loop/prompt/tools evolve. A case (`examples/eval/*.yaml`) records the evidence each tool returns and
+the keywords the findings must contain; the loop runs against the **configured model** with that
+evidence, and each case is scored pass/fail.
+
+```bash
+lore eval --config runlore.yaml --cases examples/eval
+```
+
+It needs a configured model (`config.model`). The harness logic (`internal/eval`) is unit-tested with a
+fake model, so `go test ./internal/eval/` runs without an API key.
+
 ## Quick local demo (no cluster)
 
 ```bash

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -31,6 +32,7 @@ import (
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/eval"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
@@ -56,7 +58,7 @@ Usage:
   lore investigate [--alert <name>] [--since <dur>]   investigate an alert/symptom (on-demand)
   lore serve [--config <path>] [--addr <addr>]        run the in-cluster agent (react to incidents)
   lore catalog sync                                   sync + index the knowledge catalog
-  lore eval                                           replay past incidents, score root-cause identification
+  lore eval [--config <path>] [--cases <dir>]         replay incident cases, score RCA identification
   lore version                                        print version
 `
 
@@ -75,7 +77,12 @@ func main() {
 			fmt.Fprintln(os.Stderr, "serve:", err)
 			os.Exit(1)
 		}
-	case "investigate", "catalog", "eval":
+	case "eval":
+		if err := runEval(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "eval:", err)
+			os.Exit(1)
+		}
+	case "investigate", "catalog":
 		fmt.Printf("lore %s: not yet implemented (scaffold). See docs/design.md\n", os.Args[1])
 		os.Exit(1)
 	default:
@@ -274,6 +281,50 @@ func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, 
 		log.Info("catalog loaded", "dir", cfg.Catalog.Dir, "entries", cat.Len())
 		return cat
 	}
+	return nil
+}
+
+// runEval replays recorded incident cases through the investigation loop and
+// reports the RCA-identification rate. Requires a configured model.
+func runEval(args []string) error {
+	fs := flag.NewFlagSet("eval", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	casesDir := fs.String("cases", "examples/eval", "directory of eval cases")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		return err
+	}
+	if cfg.Model.BaseURL == "" && cfg.Model.Provider != "anthropic" {
+		return fmt.Errorf("eval requires a configured model (set config.model)")
+	}
+	cases, err := eval.Load(*casesDir)
+	if err != nil {
+		return err
+	}
+	if len(cases) == 0 {
+		return fmt.Errorf("no eval cases found in %s", *casesDir)
+	}
+	apiKey := ""
+	if cfg.Model.APIKeyEnv != "" {
+		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
+	}
+	runner := &eval.Runner{Model: buildModel(cfg, apiKey), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	rep := runner.Run(context.Background(), cases)
+	for _, res := range rep.Results {
+		status := "PASS"
+		if !res.Pass {
+			status = "FAIL"
+		}
+		fmt.Printf("%-4s  %-32s  confidence=%.2f", status, res.Name, res.Confidence)
+		if len(res.Missing) > 0 {
+			fmt.Printf("  missing: %s", strings.Join(res.Missing, ", "))
+		}
+		fmt.Println()
+	}
+	fmt.Printf("\nRCA identified: %d/%d (%.0f%%)\n", rep.Passed(), len(rep.Results), rep.RCARate()*100)
 	return nil
 }
 

--- a/examples/eval/harbor-chart-bump.yaml
+++ b/examples/eval/harbor-chart-bump.yaml
@@ -1,0 +1,24 @@
+# An eval case: recorded evidence the tools return for a past incident, plus the
+# root cause the agent should identify. Run with: lore eval --cases examples/eval
+name: harbor-chart-bump
+prompt: |
+  HarborProbeFailure (critical, prod, namespace apps): harbor-core readiness probes
+  are failing and the Service is returning 503s.
+tools:
+  what_changed: |
+    flux Kustomization/apps  aaa111..bbb222
+    --- apps/harbor/values.yaml
+    -  tag: 1.14.2
+    +  tag: 1.15.0          # chart 1.15 enables DB schema migrations on startup
+  query_metrics: |
+    up{job="harbor-core"} = 0
+    kube_pod_container_status_restarts_total{pod="harbor-db-0"} = 7
+  query_logs: |
+    harbor-db-0  FATAL: could not obtain migration lock; another migration is in progress
+    harbor-core  dial tcp harbor-db:5432: connect: connection refused
+  network_drops: |
+    (no dropped flows)
+expected:
+  # The agent should tie the failure to the chart bump's DB migration on harbor-db.
+  must_contain: [chart, migration, harbor-db]
+  min_confidence: 0.5

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -1,0 +1,59 @@
+// Package eval replays recorded incident cases through the investigation loop and
+// scores whether the agent identifies the root cause — a reproducible RCA benchmark
+// (cf. ITBench). A case records the evidence each tool returns, so the eval measures
+// the model+loop's reasoning over fixed evidence, independent of a live cluster.
+package eval
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Case is one replayable incident.
+type Case struct {
+	Name     string            `yaml:"name"`
+	Prompt   string            `yaml:"prompt"` // the incident description (seeds the loop)
+	Tools    map[string]string `yaml:"tools"`  // tool name -> recorded evidence the tool returns
+	Expected Expected          `yaml:"expected"`
+}
+
+// Expected is the RCA scoring spec for a case.
+type Expected struct {
+	MustContain   []string `yaml:"must_contain"`   // keywords that must appear in the findings
+	MinConfidence float64  `yaml:"min_confidence"` // confidence floor (0 = no floor)
+}
+
+// Load reads every *.yaml / *.yml case in dir.
+func Load(dir string) ([]Case, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var cases []Case
+	for _, e := range entries {
+		if e.IsDir() || !isYAML(e.Name()) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		var c Case
+		if err := yaml.Unmarshal(data, &c); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", e.Name(), err)
+		}
+		if c.Name == "" {
+			c.Name = strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
+		}
+		cases = append(cases, c)
+	}
+	return cases, nil
+}
+
+func isYAML(name string) bool {
+	return strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml")
+}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1,0 +1,83 @@
+package eval
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Runner replays cases through the investigation loop with a given model.
+type Runner struct {
+	Model providers.ModelProvider
+	Log   *slog.Logger
+}
+
+// Report aggregates case results.
+type Report struct {
+	Results []Result
+}
+
+// Passed counts cases whose root cause was identified.
+func (r Report) Passed() int {
+	n := 0
+	for _, res := range r.Results {
+		if res.Pass {
+			n++
+		}
+	}
+	return n
+}
+
+// RCARate is the fraction of cases whose root cause was identified.
+func (r Report) RCARate() float64 {
+	if len(r.Results) == 0 {
+		return 0
+	}
+	return float64(r.Passed()) / float64(len(r.Results))
+}
+
+// Run replays every case and scores it.
+func (r *Runner) Run(ctx context.Context, cases []Case) Report {
+	var rep Report
+	for _, c := range cases {
+		rep.Results = append(rep.Results, r.runOne(ctx, c))
+	}
+	return rep
+}
+
+func (r *Runner) runOne(ctx context.Context, c Case) Result {
+	tools := make([]investigate.Tool, 0, len(c.Tools))
+	for name, output := range c.Tools {
+		tools = append(tools, staticTool{name: name, output: output})
+	}
+	var got providers.Investigation
+	done := false
+	li := &investigate.LoopInvestigator{
+		Model: r.Model,
+		Tools: tools,
+		Log:   r.Log,
+		OnComplete: func(inv providers.Investigation) {
+			got, done = inv, true
+		},
+	}
+	req := investigate.Request{Source: investigate.SourceAlert, Title: c.Name, Message: c.Prompt}
+	if err := li.Investigate(ctx, req); err != nil {
+		return Result{Name: c.Name, Missing: []string{"investigation error: " + err.Error()}}
+	}
+	if !done {
+		return Result{Name: c.Name, Missing: []string{"no findings (loop did not submit)"}}
+	}
+	return Score(c.Name, got, c.Expected)
+}
+
+// staticTool replays a case's recorded evidence to the model, regardless of args.
+type staticTool struct {
+	name, output string
+}
+
+func (t staticTool) Name() string                                 { return t.name }
+func (t staticTool) Description() string                          { return "Returns recorded evidence for: " + t.name }
+func (t staticTool) Schema() string                               { return `{"type":"object","properties":{}}` }
+func (t staticTool) Call(context.Context, string) (string, error) { return t.output, nil }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1,0 +1,91 @@
+package eval
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "harbor.yaml"), []byte(`
+name: harbor-chart-bump
+prompt: HarborProbeFailure in apps
+tools:
+  what_changed: "chart 1.15 enabled DB migrations"
+expected:
+  must_contain: [chart, migration]
+  min_confidence: 0.5
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignored"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cases, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cases) != 1 || cases[0].Name != "harbor-chart-bump" {
+		t.Fatalf("unexpected cases: %+v", cases)
+	}
+	if cases[0].Tools["what_changed"] == "" || len(cases[0].Expected.MustContain) != 2 || cases[0].Expected.MinConfidence != 0.5 {
+		t.Fatalf("case not parsed: %+v", cases[0])
+	}
+}
+
+func TestScore(t *testing.T) {
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{Summary: "chart bump enabled a DB migration that stalled harbor-db"}},
+	}
+	if r := Score("c", inv, Expected{MustContain: []string{"chart", "harbor-db"}, MinConfidence: 0.5}); !r.Pass {
+		t.Fatalf("expected pass, got %+v", r)
+	}
+	if r := Score("c", inv, Expected{MustContain: []string{"network"}}); r.Pass || len(r.Missing) != 1 {
+		t.Fatalf("expected fail with 1 missing, got %+v", r)
+	}
+	if r := Score("c", inv, Expected{MustContain: []string{"chart"}, MinConfidence: 0.95}); r.Pass {
+		t.Fatalf("expected fail on confidence floor, got %+v", r)
+	}
+}
+
+// scriptModel returns a fixed response sequence: call a tool, then submit_findings.
+type scriptModel struct {
+	calls int
+}
+
+func (m *scriptModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	if m.calls == 1 {
+		return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+			{ID: "1", Name: "what_changed", Args: `{}`}}}, nil
+	}
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "2", Name: "submit_findings", Args: `{"confidence":0.9,"root_causes":[{"summary":"chart bump broke harbor-db migrations"}]}`}}}, nil
+}
+
+func TestRun(t *testing.T) {
+	cases := []Case{
+		{Name: "hit", Prompt: "probe failing", Tools: map[string]string{"what_changed": "chart 1.15"},
+			Expected: Expected{MustContain: []string{"chart", "harbor-db"}, MinConfidence: 0.5}},
+		{Name: "miss", Prompt: "probe failing", Tools: map[string]string{"what_changed": "chart 1.15"},
+			Expected: Expected{MustContain: []string{"network policy"}}},
+	}
+	r := &Runner{Model: &scriptModel{}, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	rep := r.Run(context.Background(), cases)
+	if len(rep.Results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(rep.Results))
+	}
+	if rep.Passed() != 1 || rep.RCARate() != 0.5 {
+		t.Fatalf("want 1 passed / 0.5 rate, got passed=%d rate=%.2f", rep.Passed(), rep.RCARate())
+	}
+	if !rep.Results[0].Pass || rep.Results[1].Pass {
+		t.Fatalf("unexpected per-case: %+v", rep.Results)
+	}
+}

--- a/internal/eval/score.go
+++ b/internal/eval/score.go
@@ -1,0 +1,44 @@
+package eval
+
+import (
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Result is the score for one case.
+type Result struct {
+	Name       string
+	Pass       bool
+	Confidence float64
+	Missing    []string // expected keywords not found (or an error note)
+}
+
+// Score reports whether the investigation identifies the expected root cause:
+// every must_contain keyword appears in the findings and confidence meets the floor.
+func Score(name string, inv providers.Investigation, exp Expected) Result {
+	hay := strings.ToLower(investigationText(inv))
+	var missing []string
+	for _, kw := range exp.MustContain {
+		if !strings.Contains(hay, strings.ToLower(kw)) {
+			missing = append(missing, kw)
+		}
+	}
+	return Result{
+		Name:       name,
+		Pass:       len(missing) == 0 && inv.Confidence >= exp.MinConfidence,
+		Confidence: inv.Confidence,
+		Missing:    missing,
+	}
+}
+
+// investigationText flattens the findings into one searchable string.
+func investigationText(inv providers.Investigation) string {
+	var b strings.Builder
+	b.WriteString(inv.Title)
+	for _, rc := range inv.RootCauses {
+		b.WriteString(" " + rc.Summary + " " + rc.SuggestedAction + " " + strings.Join(rc.Evidence, " "))
+	}
+	b.WriteString(" " + strings.Join(inv.Unresolved, " "))
+	return b.String()
+}


### PR DESCRIPTION
`lore eval` replays recorded incident cases through the investigation loop and scores whether the agent identifies the root cause — a reproducible RCA benchmark (cf. ITBench) to measure and guard RCA quality as the loop/prompt/tools evolve.

## How
- **`internal/eval`** — a `Case` records a prompt, the evidence each tool returns (keyed by tool name), and the expected RCA (`must_contain` keywords + `min_confidence`). The `Runner` replays each case through a `LoopInvestigator` built with the **configured model** and **static tools** that return the case's recorded evidence, captures the `Investigation` (via `OnComplete`), and `Score`s it. `Report` aggregates the RCA-identification rate.
- Replaying recorded evidence makes the eval about the **model+loop's reasoning**, reproducible and cluster-free.
- **`lore eval --config … --cases …`** prints per-case PASS/FAIL + the aggregate rate; ships a sample case (`examples/eval/harbor-chart-bump.yaml`).

## Verified
- Unit (no API key): `Load` parsing, `Score` (keyword + confidence floor), and `Run` with a fake scripted model (1 hit / 1 miss → 50% rate).
- CLI smoke against the mock model: `PASS … RCA identified: 1/1 (100%)`.

Docs: CONTRIBUTING documents the harness.