### PR TITLE
feat: autonomy ladder rung 1 (suggested actions)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
+	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
@@ -421,10 +422,18 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	notifier := buildNotifier(cfg, log)
 	log.Info("delivery notifiers", "count", notifier.Len())
 	cur := buildCurator(cfg, forgeTok, log)
+	actions := action.New(cfg.Actions)
+	if actions.Enabled() {
+		log.Info("action suggestions enabled", "mode", string(actions.Mode()))
+		if m := actions.Mode(); m == config.ActionApprove || m == config.ActionAuto {
+			log.Warn("action mode not yet implemented; actions are SUGGESTED only, never executed", "mode", string(m))
+		}
+	}
 	return &investigate.LoopInvestigator{
-		Model: model,
-		Tools: tools,
-		Log:   log,
+		Model:   model,
+		Tools:   tools,
+		Log:     log,
+		Actions: actions,
 		OnComplete: func(found providers.Investigation) {
 			log.Info("findings",
 				"confidence", found.Confidence, "root_causes", len(found.RootCauses), "unresolved", len(found.Unresolved))

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -217,6 +217,15 @@ config:
       installation_id: 7654321               # from step 2
       private_key_env: GITHUB_APP_PRIVATE_KEY
 
+  # Autonomy ladder. Default (omitted) = off = read-only findings only. "suggest"
+  # has the agent propose remediations — never executed — filtered to the envelope.
+  # actions:
+  #   mode: suggest
+  #   allow:
+  #     reversible_only: true       # withhold irreversible suggestions
+  #     max_blast_radius: 5
+  #     kinds: [HelmRelease, Kustomization, Application]
+
   # HA toggle (default on; harmless with 1 replica).
   leader_election:
     enabled: true

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -125,6 +125,7 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set-string config.metrics.url="http://$HOST:$MOCK_PORT" \
   --set-string config.logs.url="http://$HOST:$MOCK_PORT" \
   --set-string config.network.url="$HOST:9998" \
+  --set-string config.actions.mode=suggest \
   --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.kb_repo="mock/repo" \
   --set-string config.forge.base_branch="main" \
@@ -173,6 +174,8 @@ check "curator enabled"                        /tmp/runlore.log 'curator enabled
 check "GitHub App token exchange"              /tmp/runlore-mock.log 'MOCK GH-TOKEN'
 check "curator opened a PR (confident)"        /tmp/runlore-mock.log 'MOCK GH-PR'
 check "curated ref logged"                     /tmp/runlore.log 'msg=curated'
+check "action suggestions enabled"             /tmp/runlore.log 'action suggestions enabled'
+check "suggested action surfaced (rung 1)"     /tmp/runlore.log 'suggested_actions=[1-9]'
 
 step "8/10 GitOps failure trigger (informer on a real API server)"
 kubectl create ns apps >/dev/null 2>&1 || true
@@ -236,9 +239,13 @@ spec:
 YAML
 kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=30s
 # Switch the engine to argocd (reuse prior values; back to 1 replica for a quick roll).
+# Reconfigure to the argocd engine. Leader election is disabled for this step:
+# leadership-gated readiness stalls in-place rolling updates (a known HA limitation),
+# so a single non-LE pod rolls cleanly here.
 helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
-  --set replicaCount=1 --set-string config.gitops.engine=argocd >/dev/null
-kubectl -n "$NS" rollout status deploy/runlore --timeout=90s
+  --set replicaCount=1 --set config.leader_election.enabled=false \
+  --set-string config.gitops.engine=argocd >/dev/null
+kubectl -n "$NS" rollout status deploy/runlore --timeout=120s
 sleep 3
 kubectl apply -f - <<'YAML'
 apiVersion: argoproj.io/v1alpha1

--- a/hack/e2e/mock/main.go
+++ b/hack/e2e/mock/main.go
@@ -117,7 +117,7 @@ func chatCompletions(w http.ResponseWriter, r *http.Request) {
 	case 4:
 		name, args = "network_drops", `{"namespace":"apps"}`
 	default:
-		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"]}`
+		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"],"actions":[{"description":"flux rollback hr/harbor to 1.14.2","reversible":true,"blast_radius":1,"target":{"kind":"HelmRelease","name":"harbor","namespace":"apps"}}]}`
 	}
 	log.Printf("MOCK chat/completions: toolResults=%d -> %s", toolResults, name)
 	writeJSON(w, fmt.Sprintf(
@@ -176,8 +176,8 @@ func writeJSON(w http.ResponseWriter, s string) {
 
 func truncate(s string) string {
 	s = strings.ReplaceAll(s, "\n", " ")
-	if len(s) > 200 {
-		return s[:200] + "…"
+	if len(s) > 400 {
+		return s[:400] + "…"
 	}
 	return s
 }

--- a/internal/action/policy.go
+++ b/internal/action/policy.go
@@ -1,0 +1,66 @@
+// Package action gates proposed remediations against the autonomy-ladder policy
+// (config.actions). v1 implements rung 1 ("suggest"): it filters proposals to the
+// allowed envelope and surfaces them — it never executes anything (RunLore has no
+// cluster-mutating tools). The gate is the load-bearing logic for higher rungs.
+package action
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Policy evaluates proposed actions against the configured envelope.
+type Policy struct {
+	cfg config.ActionPolicy
+}
+
+// New builds a Policy from config.
+func New(cfg config.ActionPolicy) *Policy { return &Policy{cfg: cfg} }
+
+// Enabled reports whether any non-off action mode is configured.
+func (p *Policy) Enabled() bool { return p.cfg.Enabled() }
+
+// Mode returns the configured action mode.
+func (p *Policy) Mode() config.ActionMode { return p.cfg.Mode }
+
+// Review filters proposed actions to those within the envelope (the ones safe to
+// surface as suggestions), returning the kept actions plus a reason for each
+// withheld one. When actions are disabled (mode off), nothing is surfaced.
+func (p *Policy) Review(actions []providers.Action) (kept []providers.Action, withheld []string) {
+	if !p.Enabled() {
+		return nil, nil
+	}
+	for _, a := range actions {
+		if reason := p.violation(a); reason != "" {
+			withheld = append(withheld, fmt.Sprintf("%s (%s)", actionLabel(a), reason))
+			continue
+		}
+		kept = append(kept, a)
+	}
+	return kept, withheld
+}
+
+// violation returns why an action is outside the envelope, or "" if compliant.
+func (p *Policy) violation(a providers.Action) string {
+	allow := p.cfg.Allow
+	if allow.ReversibleOnly && !a.Reversible {
+		return "irreversible; reversible_only is set"
+	}
+	if allow.MaxBlastRadius > 0 && a.BlastRadius > allow.MaxBlastRadius {
+		return fmt.Sprintf("blast radius %d exceeds max %d", a.BlastRadius, allow.MaxBlastRadius)
+	}
+	if len(allow.Kinds) > 0 && a.Target.Kind != "" && !slices.Contains(allow.Kinds, a.Target.Kind) {
+		return "kind " + a.Target.Kind + " not in allowed kinds"
+	}
+	return ""
+}
+
+func actionLabel(a providers.Action) string {
+	if a.Description != "" {
+		return a.Description
+	}
+	return a.Name
+}

--- a/internal/action/policy_test.go
+++ b/internal/action/policy_test.go
@@ -1,0 +1,43 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestDisabledSurfacesNothing(t *testing.T) {
+	p := New(config.ActionPolicy{}) // mode "" == off
+	if p.Enabled() {
+		t.Fatal("empty policy should be disabled")
+	}
+	kept, _ := p.Review([]providers.Action{{Description: "flux rollback", Reversible: true}})
+	if kept != nil {
+		t.Fatalf("disabled policy surfaced actions: %+v", kept)
+	}
+}
+
+func TestReviewEnvelope(t *testing.T) {
+	p := New(config.ActionPolicy{
+		Mode: config.ActionSuggest,
+		Allow: config.ActionAllow{
+			ReversibleOnly: true,
+			MaxBlastRadius: 5,
+			Kinds:          []string{"HelmRelease", "Kustomization"},
+		},
+	})
+	actions := []providers.Action{
+		{Description: "flux rollback hr/harbor", Reversible: true, BlastRadius: 1, Target: providers.Workload{Kind: "HelmRelease"}},
+		{Description: "delete pvc", Reversible: false, BlastRadius: 1, Target: providers.Workload{Kind: "PersistentVolumeClaim"}},
+		{Description: "scale everything", Reversible: true, BlastRadius: 50, Target: providers.Workload{Kind: "Kustomization"}},
+		{Description: "kubectl delete ns", Reversible: true, BlastRadius: 1, Target: providers.Workload{Kind: "Namespace"}},
+	}
+	kept, withheld := p.Review(actions)
+	if len(kept) != 1 || kept[0].Description != "flux rollback hr/harbor" {
+		t.Fatalf("kept = %+v", kept)
+	}
+	if len(withheld) != 3 {
+		t.Fatalf("want 3 withheld (irreversible, blast, kind), got %d: %v", len(withheld), withheld)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -12,6 +13,10 @@ const systemPrompt = `You are an SRE incident investigator. The cause is unknown
 calling the available tools to gather evidence (start with what_changed), reason about both
 change-caused and no-change causes, then call submit_findings exactly once with ranked root causes,
 evidence, and anything you could not determine. Be honest about uncertainty.`
+
+const actionsPrompt = `When you are confident in a fix, propose it in submit_findings "actions" — each
+with a description, target, blast_radius, and reversible flag. Strongly prefer REVERSIBLE, low-blast-
+radius actions (e.g. a GitOps rollback). RunLore only SUGGESTS actions to a human; it never executes them.`
 
 // LoopInvestigator is the ReAct investigation loop: it drives a ModelProvider with
 // tools, feeds tool results back, and finishes when the model calls submit_findings
@@ -22,6 +27,15 @@ type LoopInvestigator struct {
 	Log        *slog.Logger
 	MaxSteps   int
 	OnComplete func(providers.Investigation) // delivery hook (Slack/Matrix later)
+	Actions    *action.Policy                // autonomy ladder; nil/off = read-only findings only
+}
+
+// system returns the system prompt, asking for action proposals when the policy is enabled.
+func (li *LoopInvestigator) system() string {
+	if li.Actions != nil && li.Actions.Enabled() {
+		return systemPrompt + "\n\n" + actionsPrompt
+	}
+	return systemPrompt
 }
 
 // Investigate runs the loop for a request. It implements Investigator.
@@ -41,7 +55,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	}
 
 	for step := 0; step < maxSteps; step++ {
-		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: systemPrompt, Messages: messages, Tools: specs})
+		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: li.system(), Messages: messages, Tools: specs})
 		if err != nil {
 			return fmt.Errorf("model: %w", err)
 		}
@@ -60,6 +74,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				if inv.Title == "" {
 					inv.Title = req.Title // default to the triggering incident/failure
 				}
+				inv.Actions = li.reviewActions(inv.Actions)
 				li.deliver(req, inv)
 				return nil
 			}
@@ -82,10 +97,27 @@ func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool,
 	return out
 }
 
+// reviewActions filters the model's proposed actions through the policy. Disabled
+// (or mode off) → nothing surfaced (read-only). Otherwise envelope-compliant
+// actions are kept as suggestions (never executed); the rest are logged as withheld.
+func (li *LoopInvestigator) reviewActions(proposed []providers.Action) []providers.Action {
+	if li.Actions == nil || !li.Actions.Enabled() {
+		return nil
+	}
+	kept, withheld := li.Actions.Review(proposed)
+	for _, w := range withheld {
+		li.Log.Info("action withheld (outside policy envelope)", "action", w)
+	}
+	if len(kept) > 0 {
+		li.Log.Info("suggested actions (not executed)", "mode", string(li.Actions.Mode()), "count", len(kept))
+	}
+	return kept
+}
+
 func (li *LoopInvestigator) deliver(req Request, inv providers.Investigation) {
 	li.Log.Info("investigation complete",
 		"title", req.Title, "confidence", inv.Confidence,
-		"root_causes", len(inv.RootCauses), "unresolved", len(inv.Unresolved))
+		"root_causes", len(inv.RootCauses), "unresolved", len(inv.Unresolved), "suggested_actions", len(inv.Actions))
 	if li.OnComplete != nil {
 		li.OnComplete(inv)
 	}

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -6,8 +6,47 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/Smana/runlore/internal/action"
+	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+func TestLoopInvestigatorActions(t *testing.T) {
+	// submit_findings proposes a reversible and an irreversible action.
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: "submit_findings", Args: `{"confidence":0.9,"root_causes":[{"summary":"x"}],"actions":[{"description":"flux rollback hr/harbor","reversible":true},{"description":"delete the pvc","reversible":false}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Actions:    action.New(config.ActionPolicy{Mode: config.ActionSuggest, Allow: config.ActionAllow{ReversibleOnly: true}}),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "t"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	// Only the reversible action is surfaced (suggest mode, reversible_only); none executed.
+	if got == nil || len(got.Actions) != 1 || got.Actions[0].Description != "flux rollback hr/harbor" {
+		t.Fatalf("expected only the reversible action surfaced, got %+v", got)
+	}
+}
+
+func TestLoopInvestigatorActionsDisabled(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: "submit_findings", Args: `{"confidence":0.9,"root_causes":[{"summary":"x"}],"actions":[{"description":"flux rollback","reversible":true}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{ // no Actions policy => read-only, actions dropped
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	_ = li.Investigate(context.Background(), Request{Title: "t"})
+	if got == nil || len(got.Actions) != 0 {
+		t.Fatalf("expected no actions surfaced when policy disabled, got %+v", got)
+	}
+}
 
 // scriptModel returns a fixed sequence of responses, ignoring its input.
 type scriptModel struct {

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -32,7 +32,11 @@ func submitFindingsSpec() providers.ToolSpec {
 "summary":{"type":"string"},"confidence":{"type":"number"},"change_ref":{"type":"string"},
 "evidence":{"type":"array","items":{"type":"string"}},"suggested_action":{"type":"string"},"reversible":{"type":"boolean"}},
 "required":["summary"]}},
-"unresolved":{"type":"array","items":{"type":"string"}}},"required":["root_causes"]}`,
+"unresolved":{"type":"array","items":{"type":"string"}},
+"actions":{"type":"array","description":"proposed remediations; prefer reversible, low-blast-radius","items":{"type":"object","properties":{
+"description":{"type":"string"},"reversible":{"type":"boolean"},"blast_radius":{"type":"integer"},
+"target":{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}}},
+"required":["description"]}}},"required":["root_causes"]}`,
 	}
 }
 
@@ -49,6 +53,16 @@ type findings struct {
 		Reversible      bool     `json:"reversible"`
 	} `json:"root_causes"`
 	Unresolved []string `json:"unresolved"`
+	Actions    []struct {
+		Description string `json:"description"`
+		Reversible  bool   `json:"reversible"`
+		BlastRadius int    `json:"blast_radius"`
+		Target      struct {
+			Kind      string `json:"kind"`
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"target"`
+	} `json:"actions"`
 }
 
 // parseFindings turns submit_findings arguments into a providers.Investigation.
@@ -66,6 +80,16 @@ func parseFindings(args string) (providers.Investigation, error) {
 			Evidence:        rc.Evidence,
 			SuggestedAction: rc.SuggestedAction,
 			Reversible:      rc.Reversible,
+		})
+	}
+	for _, a := range f.Actions {
+		inv.Actions = append(inv.Actions, providers.Action{
+			Name:        a.Description,
+			Description: a.Description,
+			Target:      providers.Workload{Kind: a.Target.Kind, Name: a.Target.Name, Namespace: a.Target.Namespace},
+			Mutating:    true,
+			Reversible:  a.Reversible,
+			BlastRadius: a.BlastRadius,
 		})
 	}
 	return inv, nil

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -32,5 +32,15 @@ func Format(inv providers.Investigation) string {
 			fmt.Fprintf(&b, "   • %s\n", u)
 		}
 	}
+	if len(inv.Actions) > 0 {
+		b.WriteString("*Suggested actions* (not executed — apply manually):\n")
+		for _, a := range inv.Actions {
+			rev := ""
+			if a.Reversible {
+				rev = " (reversible)"
+			}
+			fmt.Fprintf(&b, "   • %s%s\n", a.Description, rev)
+		}
+	}
 	return b.String()
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -219,6 +219,7 @@ type Investigation struct {
 	Changes    []Change
 	Unresolved []string // honest: what the agent could not determine
 	Confidence float64
+	Actions    []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
 }
 
 // Hypothesis is one ranked root-cause candidate with its evidence.


### PR DESCRIPTION
Rung 1 of the autonomy ladder: the agent **proposes** remediations — but **nothing is executed** (RunLore has no cluster-mutating tools; this is structural, not a flag). Off by default (read-only findings only).

## How
- The model proposes structured actions in `submit_findings` (`actions[]`: description, target, blast_radius, reversible) when `config.actions.mode != off`; mapped to `providers.Investigation.Actions`.
- **`internal/action.Policy`** — gates proposals against the envelope (`reversible_only`, `max_blast_radius`, `kinds`); `Review` keeps only envelope-compliant suggestions and logs the rest as withheld. Mode off → nothing surfaced.
- The loop appends an "propose reversible remediation" instruction to the system prompt only when enabled, and Reviews actions before delivery; the formatter renders a "Suggested actions (not executed — apply manually)" section.
- `serve` builds the policy from `config.actions`; warns that `approve`/`auto` aren't implemented (suggestions only).

## Verified
- Unit: policy envelope filtering (irreversible/blast/kind withheld); parse; loop (reversible surfaced, irreversible withheld, disabled → none).
- **e2e on k3d — 30/30**: with `actions.mode=suggest`, the agent surfaced a reversible action (`action suggestions enabled` + `suggested_actions=1`), delivered marked "not executed".

## ⚠️ Discovered (separate follow-up): rolling-update + leader election
The e2e's in-place engine reconfigure surfaced a real HA limitation: **leadership-gated readiness deadlocks in-place rolling updates** (a new pod can't become Ready until it's leader, but the old leader holds the Lease, and `maxUnavailable=0` blocks its termination). Worked around in the e2e (disable LE on that step). Proper fix (chart `strategy: Recreate`, or a readiness-model change) is a follow-up PR — flagging it rather than papering over it.