### PR TITLE
fix(chart): Recreate update strategy (fixes leader-election rolling-update deadlock)

### DIFF
--- a/deploy/helm/runlore/templates/deployment.yaml
+++ b/deploy/helm/runlore/templates/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "runlore.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.updateStrategy }}
   selector:
     matchLabels:
       {{- include "runlore.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -2,6 +2,13 @@
 # hot standby. See config.leader_election below.
 replicaCount: 2
 
+# Recreate avoids a rolling-update deadlock under leader election: a new pod can't
+# become Ready until it leads, but the old leader holds the Lease (and maxUnavailable
+# is 0), so an in-place rolling update stalls. Recreate terminates old pods first.
+# Trade-off: ~20s downtime during the agent's own upgrade; crash-failover HA is
+# unaffected. Switch to RollingUpdate only with a leadership-independent readiness model.
+updateStrategy: Recreate
+
 image:
   repository: ghcr.io/smana/runlore
   tag: ""               # defaults to .Chart.AppVersion

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -239,12 +239,10 @@ spec:
 YAML
 kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=30s
 # Switch the engine to argocd (reuse prior values; back to 1 replica for a quick roll).
-# Reconfigure to the argocd engine. Leader election is disabled for this step:
-# leadership-gated readiness stalls in-place rolling updates (a known HA limitation),
-# so a single non-LE pod rolls cleanly here.
+# Reconfigure to the argocd engine. The chart's Recreate strategy makes this
+# in-place update roll cleanly under leader election (old pods terminate first).
 helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
-  --set replicaCount=1 --set config.leader_election.enabled=false \
-  --set-string config.gitops.engine=argocd >/dev/null
+  --set replicaCount=1 --set-string config.gitops.engine=argocd >/dev/null
 kubectl -n "$NS" rollout status deploy/runlore --timeout=120s
 sleep 3
 kubectl apply -f - <<'YAML'


### PR DESCRIPTION
Fixes the HA limitation surfaced by the rung-1 PR's e2e: with leadership-gated readiness, an in-place **rolling** update deadlocks — a new pod can't become Ready until it's leader, but the old leader holds the Lease and `maxUnavailable=0` blocks its termination.

## Fix
- Deployment defaults to **`strategy: Recreate`** (configurable via `updateStrategy`): old pods terminate first, so the fresh pod acquires the Lease cleanly and becomes Ready.
- Trade-off: ~20s downtime during the agent's *own* upgrade — acceptable (RunLore isn't in a request data path, and crash-failover HA via leader election is unaffected). Switch to `RollingUpdate` only with a leadership-independent readiness model.
- Reverted the e2e's LE-off workaround on the engine-reconfigure step — it now relies on Recreate.

## Verified
- **e2e on k3d — 30/30**: the in-place `gitops.engine` reconfigure (a rolling update) now rolls cleanly under leader election (replicas=2 → 1 + new template), no deadlock.