### PR TITLE
feat: autonomy ladder rung 2 (approval-gated execution)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/eval"
+	fluxexec "github.com/Smana/runlore/internal/executor/flux"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
@@ -113,6 +114,7 @@ func runServe(args []string) error {
 	var (
 		gitops    providers.GitOpsProvider
 		clientset *kubernetes.Clientset
+		executor  action.Executor // rung-2 action executor (Flux), when a cluster is reachable
 	)
 	if restCfg, err := restConfig(); err != nil {
 		log.Warn("no kube client; GitOps features + leader election disabled", "err", err)
@@ -121,6 +123,7 @@ func runServe(args []string) error {
 			log.Warn("dynamic client unavailable; GitOps features disabled", "err", derr)
 		} else {
 			gitops = buildGitOps(cfg, dc, log)
+			executor = fluxexec.New(dc)
 		}
 		if cs, cerr := kubernetes.NewForConfig(restCfg); cerr != nil {
 			log.Warn("clientset unavailable; leader election disabled", "err", cerr)
@@ -129,7 +132,12 @@ func runServe(args []string) error {
 		}
 	}
 
-	inv := buildInvestigator(ctx, cfg, gitops, log)
+	// Rung-2: approval-gated execution. Only built for mode "approve" with a reachable
+	// cluster; "auto" is not implemented (approval is always required).
+	approvals := buildApprovals(cfg, executor, log)
+	approvalToken := os.Getenv(cfg.Actions.ApprovalTokenEnv)
+
+	inv := buildInvestigator(ctx, cfg, gitops, approvals, log)
 	queue := investigate.NewQueue(inv, log)
 
 	// startWork runs the leader-only loops (investigation queue + failure watch),
@@ -151,7 +159,7 @@ func runServe(args []string) error {
 	}
 
 	// readyz reflects leadership so the Service routes webhooks only to the leader.
-	srv := server.New(cfg, queue, leader.Load, log)
+	srv := server.New(cfg, queue, leader.Load, approvals, approvalToken, log)
 	httpSrv := &http.Server{Addr: *addr, Handler: srv.Handler()}
 	go func() {
 		<-ctx.Done()
@@ -369,6 +377,23 @@ func buildForgeTokenSource(cfg *config.Config, log *slog.Logger) forgeToken {
 	return github.NewAppTokenSource(cfg.Forge.GitHubAPIURL, ga.AppID, ga.InstallationID, key).Token
 }
 
+// buildApprovals enables rung-2 approval-gated execution for action mode "approve"
+// (requires a reachable cluster). "auto" is intentionally not implemented.
+func buildApprovals(cfg *config.Config, exec action.Executor, log *slog.Logger) *action.Approvals {
+	if cfg.Actions.Mode != config.ActionApprove {
+		if cfg.Actions.Mode == config.ActionAuto {
+			log.Warn("action mode 'auto' is not implemented; approval is always required — use 'approve'")
+		}
+		return nil
+	}
+	if exec == nil {
+		log.Warn("approval-gated actions disabled: no cluster executor available")
+		return nil
+	}
+	log.Info("rung-2 approval-gated actions enabled (Flux suspend/resume/reconcile)")
+	return action.NewApprovals(exec, action.New(cfg.Actions), log)
+}
+
 // buildCurator returns a Curator when the GitHub App token + KB repo are
 // configured, else nil.
 func buildCurator(cfg *config.Config, token forgeToken, log *slog.Logger) *curator.Curator {
@@ -391,7 +416,7 @@ func buildCurator(cfg *config.Config, token forgeToken, log *slog.Logger) *curat
 
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
-func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, log *slog.Logger) investigate.Investigator {
+func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, log *slog.Logger) investigate.Investigator {
 	if cfg.Model.BaseURL == "" && cfg.Model.Provider != "anthropic" {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
@@ -435,6 +460,18 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		Log:     log,
 		Actions: actions,
 		OnComplete: func(found providers.Investigation) {
+			// Rung 2: register envelope-compliant actions for human approval and
+			// annotate each with how to approve it. (Rung 1 only suggests; rung 2 makes
+			// them executable after an explicit POST /actions/<id>/approve.)
+			if approvals != nil {
+				for i := range found.Actions {
+					id := approvals.Register(found.Actions[i])
+					found.Actions[i].Description = fmt.Sprintf("%s — approve: POST /actions/%s/approve", found.Actions[i].Description, id)
+				}
+				if len(found.Actions) > 0 {
+					log.Info("actions registered for approval", "count", len(found.Actions))
+				}
+			}
 			log.Info("findings",
 				"confidence", found.Confidence, "root_causes", len(found.RootCauses), "unresolved", len(found.Unresolved))
 			if err := notifier.Deliver(context.Background(), found); err != nil {

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -17,6 +17,16 @@ rules:
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]
     verbs: ["get", "list", "watch"]
+  {{- if .Values.rbac.allowActions }}
+  # Rung-2 execution (config.actions.mode: approve) — suspend/resume/reconcile Flux
+  # resources after human approval. Off by default: granting patch is a privilege.
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["patch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "patch"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -85,6 +85,9 @@ serviceAccount:
 # read GitRepositories. Cluster-scoped because the informer watches all namespaces.
 rbac:
   create: true
+  # allowActions grants patch on Flux resources for rung-2 execution
+  # (config.actions.mode: approve). Off by default — read-only without it.
+  allowActions: false
 
 resources:
   requests:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -217,12 +217,16 @@ config:
       installation_id: 7654321               # from step 2
       private_key_env: GITHUB_APP_PRIVATE_KEY
 
-  # Autonomy ladder. Default (omitted) = off = read-only findings only. "suggest"
-  # has the agent propose remediations — never executed — filtered to the envelope.
+  # Autonomy ladder. Default (omitted) = off = read-only findings only.
+  #   suggest — propose envelope-filtered remediations, never executed.
+  #   approve — additionally register them for human approval; an approved action
+  #             executes a reversible Flux op (suspend/resume/reconcile). Requires
+  #             chart rbac.allowActions=true and (recommended) an approval token.
   # actions:
-  #   mode: suggest
+  #   mode: approve
+  #   approval_token_env: APPROVAL_TOKEN   # require X-Approval-Token on the endpoints
   #   allow:
-  #     reversible_only: true       # withhold irreversible suggestions
+  #     reversible_only: true              # withhold irreversible suggestions
   #     max_blast_radius: 5
   #     kinds: [HelmRelease, Kustomization, Application]
 
@@ -285,9 +289,12 @@ Fire a test: trigger a `critical`/`prod` alert (or `flux suspend`+break a Kustom
 
 ## What RunLore can and cannot do
 
-- **Cluster**: read-only. It reads Flux resources, metrics (PromQL), logs (LogsQL), and network flows (Hubble), and never writes
-  to the cluster. RBAC is limited to watching `Kustomization`s, reading `GitRepository`s, and its own
-  leader-election `Lease`.
+- **Cluster**: **read-only by default** — it reads Flux/Argo resources, metrics (PromQL), logs (LogsQL),
+  and network flows (Hubble), and never writes. RBAC is limited to watching those resources + its own
+  leader-election `Lease`. With `actions.mode: approve` + `rbac.allowActions: true`, it can execute
+  *reversible* Flux ops (suspend/resume/reconcile) **only after explicit human approval**
+  (`POST /actions/<id>/approve`, token-gated) — the envelope is re-checked at execution and every action
+  is audit-logged.
 - **Forge**: writes issues/PRs to the one KB repo you configure, via the scoped GitHub App.
 - **Secrets**: referenced by env-var name from a `Secret` you control; nothing is inlined.
 

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -125,7 +125,10 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set-string config.metrics.url="http://$HOST:$MOCK_PORT" \
   --set-string config.logs.url="http://$HOST:$MOCK_PORT" \
   --set-string config.network.url="$HOST:9998" \
-  --set-string config.actions.mode=suggest \
+  --set-string config.actions.mode=approve \
+  --set-string config.actions.approval_token_env=APPROVAL_TOKEN \
+  --set rbac.allowActions=true \
+  --set "env[3].name=APPROVAL_TOKEN" --set-string "env[3].value=e2e-secret" \
   --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.kb_repo="mock/repo" \
   --set-string config.forge.base_branch="main" \
@@ -174,8 +177,8 @@ check "curator enabled"                        /tmp/runlore.log 'curator enabled
 check "GitHub App token exchange"              /tmp/runlore-mock.log 'MOCK GH-TOKEN'
 check "curator opened a PR (confident)"        /tmp/runlore-mock.log 'MOCK GH-PR'
 check "curated ref logged"                     /tmp/runlore.log 'msg=curated'
-check "action suggestions enabled"             /tmp/runlore.log 'action suggestions enabled'
-check "suggested action surfaced (rung 1)"     /tmp/runlore.log 'suggested_actions=[1-9]'
+check "rung-2 approval-gated actions enabled"  /tmp/runlore.log 'approval-gated actions enabled'
+check "action registered for approval"         /tmp/runlore.log 'actions registered for approval'
 
 step "8/10 GitOps failure trigger (informer on a real API server)"
 kubectl create ns apps >/dev/null 2>&1 || true
@@ -190,6 +193,20 @@ kubectl patch kustomization broken-app -n apps --subresource=status --type=merge
 sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "gitops failure -> investigate" /tmp/runlore.log 'source=gitops-failure|Kustomization/broken-app'
+
+# Rung 2: approve a pending suspend action and verify it executes on the cluster.
+PORT=18090; free_port "$PORT"
+kubectl -n "$NS" port-forward svc/runlore "$PORT:8080" >/tmp/runlore-pf.log 2>&1 &
+PF=$!; sleep 3
+ID=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | grep -oP '"ID":"\K[^"]+' | head -1) || true
+curl -s -o /dev/null -w "approve HTTP %{http_code}\n" -X POST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/$ID/approve" || true
+kill "$PF" 2>/dev/null || true; free_port "$PORT"
+sleep 3
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+SUSPENDED=$(kubectl get kustomization broken-app -n apps -o jsonpath='{.spec.suspend}' 2>/dev/null || true)
+if [[ "$SUSPENDED" == "true" ]]; then green "PASS: approved action executed (broken-app suspended)"; PASS=$((PASS+1))
+else red "FAIL: broken-app not suspended (spec.suspend=$SUSPENDED)"; FAIL=$((FAIL+1)); fi
+check "execution audit-logged"        /tmp/runlore.log 'action approved and executed'
 
 step "9/10 leader election + failover (scale to 2)"
 kubectl -n "$NS" scale deploy/runlore --replicas=2 >/dev/null

--- a/hack/e2e/mock/main.go
+++ b/hack/e2e/mock/main.go
@@ -117,7 +117,7 @@ func chatCompletions(w http.ResponseWriter, r *http.Request) {
 	case 4:
 		name, args = "network_drops", `{"namespace":"apps"}`
 	default:
-		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"],"actions":[{"description":"flux rollback hr/harbor to 1.14.2","reversible":true,"blast_radius":1,"target":{"kind":"HelmRelease","name":"harbor","namespace":"apps"}}]}`
+		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"],"actions":[{"description":"suspend the failing Kustomization to stop the reconcile loop","op":"suspend","reversible":true,"blast_radius":1,"target":{"kind":"Kustomization","name":"broken-app","namespace":"apps"}}]}`
 	}
 	log.Printf("MOCK chat/completions: toolResults=%d -> %s", toolResults, name)
 	writeJSON(w, fmt.Sprintf(

--- a/internal/action/approvals.go
+++ b/internal/action/approvals.go
@@ -1,0 +1,124 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Executor runs an approved action against the cluster.
+type Executor interface {
+	Execute(ctx context.Context, a providers.Action) error
+}
+
+// Pending is an action awaiting human approval.
+type Pending struct {
+	ID     string
+	Action providers.Action
+}
+
+// Approvals queues actions proposed under "approve" mode until a human approves
+// (then it executes via the Executor) or rejects them. In-memory, held on the
+// leader; entries expire after a TTL.
+type Approvals struct {
+	exec   Executor
+	policy *Policy
+	ttl    time.Duration
+	log    *slog.Logger
+	now    func() time.Time
+
+	mu      sync.Mutex
+	seq     int
+	pending map[string]entry
+}
+
+type entry struct {
+	action  providers.Action
+	created time.Time
+}
+
+// NewApprovals builds an approval queue.
+func NewApprovals(exec Executor, policy *Policy, log *slog.Logger) *Approvals {
+	return &Approvals{exec: exec, policy: policy, ttl: 30 * time.Minute, log: log, now: time.Now, pending: map[string]entry{}}
+}
+
+// Register queues an action for approval and returns its id.
+func (a *Approvals) Register(act providers.Action) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.seq++
+	id := fmt.Sprintf("a%d", a.seq)
+	a.pending[id] = entry{action: act, created: a.now()}
+	return id
+}
+
+// List returns the non-expired pending actions.
+func (a *Approvals) List() []Pending {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.gc()
+	out := make([]Pending, 0, len(a.pending))
+	for id, e := range a.pending {
+		out = append(out, Pending{ID: id, Action: e.action})
+	}
+	return out
+}
+
+// Approve executes the pending action after re-checking the envelope, then removes
+// it. Errors if the id is unknown/expired, the action is now out of policy, or
+// execution fails.
+func (a *Approvals) Approve(ctx context.Context, id string) (providers.Action, error) {
+	a.mu.Lock()
+	e, ok := a.pending[id]
+	if ok && a.now().Sub(e.created) > a.ttl {
+		delete(a.pending, id)
+		ok = false
+	}
+	a.mu.Unlock()
+	if !ok {
+		return providers.Action{}, fmt.Errorf("no pending action %q", id)
+	}
+	// Defense in depth: re-evaluate the envelope at execution time.
+	if reason := a.policy.violation(e.action); reason != "" {
+		a.remove(id)
+		return providers.Action{}, fmt.Errorf("action no longer within policy: %s", reason)
+	}
+	a.log.Info("executing approved action", "id", id, "op", e.action.Op,
+		"target", e.action.Target.Kind+"/"+e.action.Target.Namespace+"/"+e.action.Target.Name)
+	if err := a.exec.Execute(ctx, e.action); err != nil {
+		a.log.Error("approved action failed", "id", id, "err", err)
+		return providers.Action{}, err
+	}
+	a.remove(id)
+	a.log.Info("approved action executed", "id", id)
+	return e.action, nil
+}
+
+// Reject drops a pending action.
+func (a *Approvals) Reject(id string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, ok := a.pending[id]; !ok {
+		return fmt.Errorf("no pending action %q", id)
+	}
+	delete(a.pending, id)
+	return nil
+}
+
+func (a *Approvals) remove(id string) {
+	a.mu.Lock()
+	delete(a.pending, id)
+	a.mu.Unlock()
+}
+
+func (a *Approvals) gc() {
+	for id, e := range a.pending {
+		if a.now().Sub(e.created) > a.ttl {
+			delete(a.pending, id)
+		}
+	}
+}

--- a/internal/action/approvals_test.go
+++ b/internal/action/approvals_test.go
@@ -1,0 +1,81 @@
+package action
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeExec struct {
+	ran []providers.Action
+	err error
+}
+
+func (f *fakeExec) Execute(_ context.Context, a providers.Action) error {
+	f.ran = append(f.ran, a)
+	return f.err
+}
+
+func newApprovals(exec Executor) *Approvals {
+	pol := New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{ReversibleOnly: true}})
+	return NewApprovals(exec, pol, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestApproveExecutes(t *testing.T) {
+	exec := &fakeExec{}
+	a := newApprovals(exec)
+	id := a.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}})
+	if len(a.List()) != 1 {
+		t.Fatalf("want 1 pending, got %d", len(a.List()))
+	}
+	if _, err := a.Approve(context.Background(), id); err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+	if len(exec.ran) != 1 || exec.ran[0].Op != "suspend" {
+		t.Fatalf("executor not run: %+v", exec.ran)
+	}
+	if len(a.List()) != 0 {
+		t.Fatal("approved action should be removed from pending")
+	}
+	if _, err := a.Approve(context.Background(), id); err == nil {
+		t.Fatal("re-approving a consumed id should error")
+	}
+}
+
+func TestApproveReChecksEnvelope(t *testing.T) {
+	exec := &fakeExec{}
+	a := newApprovals(exec)
+	// An irreversible action slips into the queue; Approve must re-check + refuse.
+	id := a.Register(providers.Action{Op: "suspend", Reversible: false})
+	if _, err := a.Approve(context.Background(), id); err == nil {
+		t.Fatal("expected refusal: irreversible under reversible_only")
+	}
+	if len(exec.ran) != 0 {
+		t.Fatal("executor must not run for an out-of-policy action")
+	}
+}
+
+func TestReject(t *testing.T) {
+	a := newApprovals(&fakeExec{})
+	id := a.Register(providers.Action{Op: "suspend", Reversible: true})
+	if err := a.Reject(id); err != nil {
+		t.Fatalf("Reject: %v", err)
+	}
+	if _, err := a.Approve(context.Background(), id); err == nil {
+		t.Fatal("approving a rejected id should error")
+	}
+}
+
+func TestExpiry(t *testing.T) {
+	a := newApprovals(&fakeExec{})
+	id := a.Register(providers.Action{Op: "suspend", Reversible: true})
+	a.now = func() time.Time { return time.Now().Add(time.Hour) } // past the 30m TTL
+	if _, err := a.Approve(context.Background(), id); err == nil {
+		t.Fatal("expired action should not be approvable")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -227,9 +227,10 @@ const (
 // ladder. v1 ships ActionOff; the type exists so active tools can be added later
 // behind a gate without re-architecting (see docs/design.md §9, "Act").
 type ActionPolicy struct {
-	Mode            ActionMode  `yaml:"mode"`             // off | suggest | approve | auto
-	Allow           ActionAllow `yaml:"allow"`            // envelope, enforced even in approve/auto
-	RequireApproval bool        `yaml:"require_approval"` // force a human click for gated actions
+	Mode             ActionMode  `yaml:"mode"`               // off | suggest | approve | auto
+	Allow            ActionAllow `yaml:"allow"`              // envelope, enforced even in approve/auto
+	RequireApproval  bool        `yaml:"require_approval"`   // force a human click for gated actions
+	ApprovalTokenEnv string      `yaml:"approval_token_env"` // env var with a shared secret for the approval endpoints
 }
 
 // ActionAllow bounds what may be acted on, even in approve/auto modes.

--- a/internal/executor/flux/flux.go
+++ b/internal/executor/flux/flux.go
@@ -1,0 +1,60 @@
+// Package flux executes safe, reversible Flux operations (suspend / resume /
+// reconcile) on the cluster — the executable half of the autonomy ladder. It is
+// only ever invoked after explicit human approval (config.actions mode "approve").
+package flux
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Executor runs reversible Flux operations via the dynamic client.
+type Executor struct {
+	client dynamic.Interface
+	now    func() string // injectable for tests
+}
+
+// New builds an Executor backed by a dynamic client.
+func New(client dynamic.Interface) *Executor {
+	return &Executor{client: client, now: func() string { return time.Now().UTC().Format(time.RFC3339) }}
+}
+
+var gvrByKind = map[string]schema.GroupVersionResource{
+	"Kustomization": {Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"},
+	"HelmRelease":   {Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
+}
+
+// Execute applies the action's reversible Flux operation to its target.
+func (e *Executor) Execute(ctx context.Context, a providers.Action) error {
+	gvr, ok := gvrByKind[a.Target.Kind]
+	if !ok {
+		return fmt.Errorf("unsupported target kind %q (want Kustomization or HelmRelease)", a.Target.Kind)
+	}
+	if a.Target.Name == "" || a.Target.Namespace == "" {
+		return fmt.Errorf("action target needs name and namespace")
+	}
+	var patch string
+	switch a.Op {
+	case "suspend":
+		patch = `{"spec":{"suspend":true}}`
+	case "resume":
+		patch = `{"spec":{"suspend":false}}`
+	case "reconcile":
+		patch = fmt.Sprintf(`{"metadata":{"annotations":{"reconcile.fluxcd.io/requestedAt":%q}}}`, e.now())
+	default:
+		return fmt.Errorf("unsupported op %q (want suspend, resume, or reconcile)", a.Op)
+	}
+	if _, err := e.client.Resource(gvr).Namespace(a.Target.Namespace).
+		Patch(ctx, a.Target.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("flux %s %s/%s: %w", a.Op, a.Target.Namespace, a.Target.Name, err)
+	}
+	return nil
+}

--- a/internal/executor/flux/flux_test.go
+++ b/internal/executor/flux/flux_test.go
@@ -1,0 +1,72 @@
+package flux
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func newClient() *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		gvrByKind["Kustomization"]: "KustomizationList",
+	}
+	ks := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "apps", "namespace": "flux-system"},
+		"spec":       map[string]any{"suspend": false},
+	}}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, ks)
+}
+
+func get(t *testing.T, c *dynamicfake.FakeDynamicClient) *unstructured.Unstructured {
+	t.Helper()
+	u, err := c.Resource(gvrByKind["Kustomization"]).Namespace("flux-system").Get(context.Background(), "apps", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}
+
+func TestSuspend(t *testing.T) {
+	c := newClient()
+	e := New(c)
+	a := providers.Action{Op: "suspend", Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}}
+	if err := e.Execute(context.Background(), a); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if s, _, _ := unstructured.NestedBool(get(t, c).Object, "spec", "suspend"); !s {
+		t.Fatal("spec.suspend not set to true")
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	c := newClient()
+	e := New(c)
+	e.now = func() string { return "2026-06-20T00:00:00Z" }
+	a := providers.Action{Op: "reconcile", Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}}
+	if err := e.Execute(context.Background(), a); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ann, _, _ := unstructured.NestedStringMap(get(t, c).Object, "metadata", "annotations")
+	if ann["reconcile.fluxcd.io/requestedAt"] != "2026-06-20T00:00:00Z" {
+		t.Fatalf("reconcile annotation not set: %v", ann)
+	}
+}
+
+func TestUnsupported(t *testing.T) {
+	e := New(newClient())
+	if err := e.Execute(context.Background(), providers.Action{Op: "delete", Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}}); err == nil {
+		t.Fatal("expected error for unsupported op")
+	}
+	if err := e.Execute(context.Background(), providers.Action{Op: "suspend", Target: providers.Workload{Kind: "Pod", Name: "x", Namespace: "y"}}); err == nil {
+		t.Fatal("expected error for unsupported kind")
+	}
+}

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -34,7 +34,8 @@ func submitFindingsSpec() providers.ToolSpec {
 "required":["summary"]}},
 "unresolved":{"type":"array","items":{"type":"string"}},
 "actions":{"type":"array","description":"proposed remediations; prefer reversible, low-blast-radius","items":{"type":"object","properties":{
-"description":{"type":"string"},"reversible":{"type":"boolean"},"blast_radius":{"type":"integer"},
+"description":{"type":"string"},"op":{"type":"string","enum":["suspend","resume","reconcile",""],"description":"executable op (Flux); omit for a suggestion only"},
+"reversible":{"type":"boolean"},"blast_radius":{"type":"integer"},
 "target":{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}}},
 "required":["description"]}}},"required":["root_causes"]}`,
 	}
@@ -55,6 +56,7 @@ type findings struct {
 	Unresolved []string `json:"unresolved"`
 	Actions    []struct {
 		Description string `json:"description"`
+		Op          string `json:"op"`
 		Reversible  bool   `json:"reversible"`
 		BlastRadius int    `json:"blast_radius"`
 		Target      struct {
@@ -86,6 +88,7 @@ func parseFindings(args string) (providers.Investigation, error) {
 		inv.Actions = append(inv.Actions, providers.Action{
 			Name:        a.Description,
 			Description: a.Description,
+			Op:          a.Op,
 			Target:      providers.Workload{Kind: a.Target.Kind, Name: a.Target.Name, Namespace: a.Target.Namespace},
 			Mutating:    true,
 			Reversible:  a.Reversible,

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -85,16 +85,16 @@ type FailureEvent struct {
 	When     time.Time
 }
 
-// Action describes a cluster-mutating operation a provider could expose (e.g. a
-// rollback, a reconcile, a scale). In v1 no actions are registered — RunLore is
-// read-only. The metadata exists so active tools can be added later behind
-// config.ActionPolicy (the autonomy ladder) without re-architecting.
+// Action describes a remediation the agent can propose and (at the upper autonomy
+// rungs, after approval) execute. Op names a concrete, reversible operation an
+// Executor can run; an empty Op is a suggestion only.
 type Action struct {
 	Name        string
 	Description string
+	Op          string // executable operation: suspend | resume | reconcile (empty = suggestion only)
 	Target      Workload
 	Mutating    bool // true for any cluster write
-	Reversible  bool // a rollback is reversible; a delete may not be
+	Reversible  bool // a rollback/suspend is reversible; a delete may not be
 	BlastRadius int  // number of workloads affected
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,9 +2,13 @@
 package server
 
 import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 
+	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/trigger"
@@ -12,19 +16,21 @@ import (
 
 // Server handles incoming incident webhooks and applies the trigger policy.
 type Server struct {
-	engine   *trigger.Engine
-	enqueuer investigate.Enqueuer
-	ready    func() bool
-	log      *slog.Logger
-	handler  http.Handler
+	engine    *trigger.Engine
+	enqueuer  investigate.Enqueuer
+	ready     func() bool
+	approvals *action.Approvals // nil unless action mode "approve" is configured
+	token     string            // optional shared secret for the approval endpoints
+	log       *slog.Logger
+	handler   http.Handler
 }
 
-// New builds a Server from config and an investigation enqueuer. ready reports
-// whether this replica should serve traffic (e.g. it holds leadership); when nil,
-// the replica is always ready. /healthz is liveness (always OK); /readyz is
-// readiness (gated by ready) so the Service routes webhooks only to the leader.
-func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, log *slog.Logger) *Server {
-	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, ready: ready, log: log}
+// New builds a Server. ready reports whether this replica should serve (leadership);
+// nil = always ready. approvals (optional) enables the human-approval endpoints for
+// rung-2 actions; token (optional) is required as X-Approval-Token to use them.
+// /healthz is liveness; /readyz is readiness (gated by ready, leader-only).
+func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, approvals *action.Approvals, token string, log *slog.Logger) *Server {
+	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, ready: ready, approvals: approvals, token: token, log: log}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook/alertmanager", s.handleAlertmanager)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
@@ -37,8 +43,69 @@ func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, log *s
 		}
 		w.WriteHeader(http.StatusOK)
 	})
+	mux.HandleFunc("GET /actions", s.handleListActions)
+	mux.HandleFunc("POST /actions/{id}/approve", s.handleApprove)
+	mux.HandleFunc("POST /actions/{id}/reject", s.handleReject)
 	s.handler = mux
 	return s
+}
+
+// authorized enforces the optional approval token (constant-time compare).
+func (s *Server) authorized(r *http.Request) bool {
+	if s.token == "" {
+		return true
+	}
+	return subtle.ConstantTimeCompare([]byte(r.Header.Get("X-Approval-Token")), []byte(s.token)) == 1
+}
+
+func (s *Server) handleListActions(w http.ResponseWriter, r *http.Request) {
+	if s.approvals == nil {
+		http.Error(w, "actions not enabled", http.StatusNotFound)
+		return
+	}
+	if !s.authorized(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.approvals.List())
+}
+
+func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
+	if s.approvals == nil {
+		http.Error(w, "actions not enabled", http.StatusNotFound)
+		return
+	}
+	if !s.authorized(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	id := r.PathValue("id")
+	act, err := s.approvals.Approve(r.Context(), id)
+	if err != nil {
+		s.log.Warn("action approval failed", "id", id, "err", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.log.Info("action approved and executed", "id", id, "op", act.Op)
+	_, _ = fmt.Fprintf(w, "executed: %s %s\n", act.Op, act.Description)
+}
+
+func (s *Server) handleReject(w http.ResponseWriter, r *http.Request) {
+	if s.approvals == nil {
+		http.Error(w, "actions not enabled", http.StatusNotFound)
+		return
+	}
+	if !s.authorized(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	id := r.PathValue("id")
+	if err := s.approvals.Reject(id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, _ = fmt.Fprintln(w, "rejected")
 }
 
 // Handler returns the HTTP handler (built once at construction; Go 1.22+ method routing).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -8,13 +9,53 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
 )
 
 type spyEnqueuer struct{ reqs []investigate.Request }
 
 func (s *spyEnqueuer) Enqueue(r investigate.Request) { s.reqs = append(s.reqs, r) }
+
+type recordExec struct{ ran []providers.Action }
+
+func (r *recordExec) Execute(_ context.Context, a providers.Action) error {
+	r.ran = append(r.ran, a)
+	return nil
+}
+
+func TestActionsApprove(t *testing.T) {
+	exec := &recordExec{}
+	pol := action.New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{ReversibleOnly: true}})
+	ap := action.NewApprovals(exec, pol, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}})
+
+	srv := New(&config.Config{}, &spyEnqueuer{}, nil, ap, "secret", slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Missing token → 403, nothing executes.
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/actions/"+id+"/approve", nil))
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("no-token approve = %d, want 403", rr.Code)
+	}
+	if len(exec.ran) != 0 {
+		t.Fatal("executor ran without a valid token")
+	}
+
+	// With token → executes.
+	req := httptest.NewRequest(http.MethodPost, "/actions/"+id+"/approve", nil)
+	req.Header.Set("X-Approval-Token", "secret")
+	rr = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("approve = %d, want 200", rr.Code)
+	}
+	if len(exec.ran) != 1 || exec.ran[0].Op != "suspend" {
+		t.Fatalf("executor not run as expected: %+v", exec.ran)
+	}
+}
 
 func testServerWith(enq investigate.Enqueuer) *Server {
 	cfg := &config.Config{}
@@ -22,7 +63,7 @@ func testServerWith(enq investigate.Enqueuer) *Server {
 		Enabled: true,
 		Match:   config.IncidentMatch{Severity: []string{"critical"}},
 	}
-	return New(cfg, enq, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return New(cfg, enq, nil, nil, "", slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
 
 func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
@@ -30,7 +71,7 @@ func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
 func TestReadyz(t *testing.T) {
 	cfg := &config.Config{}
 	leader := false
-	srv := New(cfg, &spyEnqueuer{}, func() bool { return leader }, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv := New(cfg, &spyEnqueuer{}, func() bool { return leader }, nil, "", slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	rr := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))


### PR DESCRIPTION
Rung 2: the agent can **execute** a remediation — but only a *reversible* Flux op, **only after explicit human approval**, within the envelope, audited. Off by default; `auto` is intentionally not implemented (approval is always required).

## How
- **`internal/executor/flux`** — executes reversible Flux ops via the dynamic client: `suspend`/`resume` (patch `spec.suspend`) and `reconcile` (annotation). Only Kustomization/HelmRelease; unknown ops/kinds rejected.
- **`internal/action.Approvals`** — in-memory queue (on the leader): proposed actions are registered with an id + TTL; `Approve` **re-checks the envelope** (defense in depth), executes, and audit-logs; `Reject` drops.
- **Server endpoints** — `GET /actions`, `POST /actions/{id}/approve`, `/reject`, gated by an optional `X-Approval-Token` (constant-time compare).
- `submit_findings` gains `op`; the loop registers envelope-compliant actions (rung-1 filter) and the delivery tells the human how to approve each.
- **Chart**: `rbac.allowActions` (default **false**) grants Flux `patch` only when execution is enabled; `config.actions.approval_token_env` for the secret.

## Safety
Read-only by default · no mutating tools in the loop (execution is a separate, approval-only path) · envelope re-checked at execution · reversible-only ops · token-gated endpoint · audit log · approval served only by the leader.

## Verified
- Unit: executor (dynamic-fake suspend/reconcile/reject), approvals (approve-executes / re-check refuses irreversible / reject / TTL expiry; race-clean), server endpoint (403 without token → 200 + executes with token).
- **e2e on k3d — 32/32**: `actions.mode=approve` → a Degraded Kustomization triggers an investigation that registers a suspend action → `POST /actions/<id>/approve` (token) → the executor **patches the real Kustomization `spec.suspend=true`** with the gated RBAC; audit-logged.

## Note
Approval UX is an HTTP endpoint (curl/port-forward) for v1; Slack interactive buttons are a follow-up. `auto` mode remains unimplemented by design.