### PR TITLE
feat(slack): interactive Approve/Reject buttons for rung-2 actions

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -136,6 +136,7 @@ func runServe(args []string) error {
 	// cluster; "auto" is not implemented (approval is always required).
 	approvals := buildApprovals(cfg, executor, log)
 	approvalToken := os.Getenv(cfg.Actions.ApprovalTokenEnv)
+	slackSigningSecret := os.Getenv(cfg.Notify.Slack.SigningSecretEnv)
 
 	inv := buildInvestigator(ctx, cfg, gitops, approvals, log)
 	queue := investigate.NewQueue(inv, log)
@@ -159,7 +160,7 @@ func runServe(args []string) error {
 	}
 
 	// readyz reflects leadership so the Service routes webhooks only to the leader.
-	srv := server.New(cfg, queue, leader.Load, approvals, approvalToken, log)
+	srv := server.New(cfg, queue, leader.Load, approvals, approvalToken, slackSigningSecret, log)
 	httpSrv := &http.Server{Addr: *addr, Handler: srv.Handler()}
 	go func() {
 		<-ctx.Done()
@@ -466,6 +467,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 			if approvals != nil {
 				for i := range found.Actions {
 					id := approvals.Register(found.Actions[i])
+					found.Actions[i].ApprovalID = id // drives Slack approve/reject buttons
 					found.Actions[i].Description = fmt.Sprintf("%s — approve: POST /actions/%s/approve", found.Actions[i].Description, id)
 				}
 				if len(found.Actions) > 0 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -202,6 +202,7 @@ config:
   notify:
     slack:
       webhook_url_env: SLACK_WEBHOOK_URL
+      # signing_secret_env: SLACK_SIGNING_SECRET   # enables rung-2 Approve/Reject buttons
     matrix:
       homeserver: https://matrix.org
       room_id: "!yourroom:matrix.org"
@@ -292,9 +293,10 @@ Fire a test: trigger a `critical`/`prod` alert (or `flux suspend`+break a Kustom
 - **Cluster**: **read-only by default** — it reads Flux/Argo resources, metrics (PromQL), logs (LogsQL),
   and network flows (Hubble), and never writes. RBAC is limited to watching those resources + its own
   leader-election `Lease`. With `actions.mode: approve` + `rbac.allowActions: true`, it can execute
-  *reversible* Flux ops (suspend/resume/reconcile) **only after explicit human approval**
-  (`POST /actions/<id>/approve`, token-gated) — the envelope is re-checked at execution and every action
-  is audit-logged.
+  *reversible* Flux ops (suspend/resume/reconcile) **only after explicit human approval** — either
+  `POST /actions/<id>/approve` (token-gated) or **Slack Approve/Reject buttons** (enable Slack
+  Interactivity with Request URL `…/slack/interactions` and set `slack.signing_secret_env`; clicks are
+  HMAC-verified). The envelope is re-checked at execution and every action is audit-logged.
 - **Forge**: writes issues/PRs to the one KB repo you configure, via the scoped GitHub App.
 - **Secrets**: referenced by env-var name from a `Secret` you control; nothing is inlined.
 

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -127,8 +127,10 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set-string config.network.url="$HOST:9998" \
   --set-string config.actions.mode=approve \
   --set-string config.actions.approval_token_env=APPROVAL_TOKEN \
+  --set-string config.notify.slack.signing_secret_env=SLACK_SIGNING_SECRET \
   --set rbac.allowActions=true \
   --set "env[3].name=APPROVAL_TOKEN" --set-string "env[3].value=e2e-secret" \
+  --set "env[4].name=SLACK_SIGNING_SECRET" --set-string "env[4].value=e2e-slack-secret" \
   --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.kb_repo="mock/repo" \
   --set-string config.forge.base_branch="main" \
@@ -198,15 +200,35 @@ check "gitops failure -> investigate" /tmp/runlore.log 'source=gitops-failure|Ku
 PORT=18090; free_port "$PORT"
 kubectl -n "$NS" port-forward svc/runlore "$PORT:8080" >/tmp/runlore-pf.log 2>&1 &
 PF=$!; sleep 3
+# (a) Token endpoint → execute (suspends broken-app).
 ID=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | grep -oP '"ID":"\K[^"]+' | head -1) || true
-curl -s -o /dev/null -w "approve HTTP %{http_code}\n" -X POST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/$ID/approve" || true
+curl -s -o /dev/null -w "token approve HTTP %{http_code}\n" -X POST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/$ID/approve" || true
+# (b) Signed Slack interaction → approve another pending action (HMAC over v0:ts:body).
+ID2=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | grep -oP '"ID":"\K[^"]+' | head -1) || true
+if [[ -n "$ID2" ]]; then
+  python3 - "$ID2" "$PORT" <<'PY'
+import sys, hmac, hashlib, time, json, urllib.parse, urllib.request
+aid, port = sys.argv[1], sys.argv[2]
+payload = json.dumps({"user": {"username": "e2e"}, "actions": [{"action_id": "runlore_approve", "value": aid}]})
+body = "payload=" + urllib.parse.quote(payload)
+ts = str(int(time.time()))
+sig = "v0=" + hmac.new(b"e2e-slack-secret", f"v0:{ts}:{body}".encode(), hashlib.sha256).hexdigest()
+req = urllib.request.Request(f"http://localhost:{port}/slack/interactions", data=body.encode(),
+    headers={"X-Slack-Request-Timestamp": ts, "X-Slack-Signature": sig, "Content-Type": "application/x-www-form-urlencoded"})
+try:
+    print("slack interaction HTTP", urllib.request.urlopen(req).status)
+except Exception as e:
+    print("slack interaction error:", e)
+PY
+fi
 kill "$PF" 2>/dev/null || true; free_port "$PORT"
 sleep 3
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 SUSPENDED=$(kubectl get kustomization broken-app -n apps -o jsonpath='{.spec.suspend}' 2>/dev/null || true)
 if [[ "$SUSPENDED" == "true" ]]; then green "PASS: approved action executed (broken-app suspended)"; PASS=$((PASS+1))
 else red "FAIL: broken-app not suspended (spec.suspend=$SUSPENDED)"; FAIL=$((FAIL+1)); fi
-check "execution audit-logged"        /tmp/runlore.log 'action approved and executed'
+check "execution audit-logged"          /tmp/runlore.log 'action approved and executed'
+check "slack button approval executed"  /tmp/runlore.log 'slack approval executed'
 
 step "9/10 leader election + failover (scale to 2)"
 kubectl -n "$NS" scale deploy/runlore --replicas=2 >/dev/null

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,9 +78,11 @@ type Notify struct {
 	Matrix MatrixNotify `yaml:"matrix"`
 }
 
-// SlackNotify configures Slack incoming-webhook delivery.
+// SlackNotify configures Slack incoming-webhook delivery and (for rung-2 actions)
+// interactive approve/reject buttons.
 type SlackNotify struct {
-	WebhookURLEnv string `yaml:"webhook_url_env"` // env var holding the webhook URL
+	WebhookURLEnv    string `yaml:"webhook_url_env"`    // env var holding the webhook URL
+	SigningSecretEnv string `yaml:"signing_secret_env"` // env var with the Slack signing secret (verifies button clicks)
 }
 
 // MatrixNotify configures Matrix delivery.

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -25,9 +25,10 @@ func NewSlack(webhookURL string) *Slack {
 
 var _ providers.Notifier = (*Slack)(nil)
 
-// Deliver posts the formatted investigation to the webhook.
+// Deliver posts the formatted investigation to the webhook. When an action carries
+// an ApprovalID, it renders interactive Approve/Reject buttons (Block Kit).
 func (s *Slack) Deliver(ctx context.Context, inv providers.Investigation) error {
-	body, err := json.Marshal(map[string]string{"text": Format(inv)})
+	body, err := json.Marshal(slackMessage(inv))
 	if err != nil {
 		return err
 	}
@@ -45,6 +46,39 @@ func (s *Slack) Deliver(ctx context.Context, inv providers.Investigation) error 
 		return fmt.Errorf("slack status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// Slack interaction action_ids — must match the server's /slack/interactions handler.
+const (
+	approveActionID = "runlore_approve"
+	rejectActionID  = "runlore_reject"
+)
+
+// slackMessage builds the webhook payload: always a text fallback, plus Block Kit
+// Approve/Reject buttons for any action carrying an ApprovalID (rung-2).
+func slackMessage(inv providers.Investigation) map[string]any {
+	text := Format(inv)
+	msg := map[string]any{"text": text}
+	var actionBlocks []map[string]any
+	for _, a := range inv.Actions {
+		if a.ApprovalID == "" {
+			continue
+		}
+		actionBlocks = append(actionBlocks,
+			map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": "*Proposed action:* " + a.Description}},
+			map[string]any{"type": "actions", "elements": []map[string]any{
+				{"type": "button", "style": "primary", "action_id": approveActionID, "value": a.ApprovalID,
+					"text": map[string]any{"type": "plain_text", "text": "Approve"}},
+				{"type": "button", "style": "danger", "action_id": rejectActionID, "value": a.ApprovalID,
+					"text": map[string]any{"type": "plain_text", "text": "Reject"}},
+			}},
+		)
+	}
+	if len(actionBlocks) > 0 {
+		blocks := []map[string]any{{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": text}}}
+		msg["blocks"] = append(blocks, actionBlocks...)
+	}
+	return msg
 }
 
 // Multi delivers to several notifiers, best-effort: a failing notifier is logged,

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -46,6 +46,25 @@ func (failingNotifier) Deliver(context.Context, providers.Investigation) error {
 	return io.ErrUnexpectedEOF
 }
 
+func TestSlackMessageButtons(t *testing.T) {
+	// No ApprovalID → plain text, no interactive blocks.
+	m := slackMessage(providers.Investigation{Confidence: 0.5, Actions: []providers.Action{{Description: "x"}}})
+	if _, ok := m["blocks"]; ok {
+		t.Fatal("did not expect blocks without an ApprovalID")
+	}
+	// With ApprovalID → Block Kit Approve/Reject buttons carrying the id.
+	m = slackMessage(providers.Investigation{Confidence: 0.9, Actions: []providers.Action{{Description: "suspend ks/apps", ApprovalID: "a7"}}})
+	if _, ok := m["blocks"]; !ok {
+		t.Fatal("expected interactive blocks for a pending action")
+	}
+	raw, _ := json.Marshal(m)
+	for _, want := range []string{"runlore_approve", "runlore_reject", `"value":"a7"`, "Approve", "Reject"} {
+		if !contains(string(raw), want) {
+			t.Fatalf("rendered message missing %q:\n%s", want, raw)
+		}
+	}
+}
+
 func TestMultiBestEffort(t *testing.T) {
 	var delivered int
 	ok := notifierFunc(func(context.Context, providers.Investigation) error { delivered++; return nil })

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -93,9 +93,10 @@ type Action struct {
 	Description string
 	Op          string // executable operation: suspend | resume | reconcile (empty = suggestion only)
 	Target      Workload
-	Mutating    bool // true for any cluster write
-	Reversible  bool // a rollback/suspend is reversible; a delete may not be
-	BlastRadius int  // number of workloads affected
+	Mutating    bool   // true for any cluster write
+	Reversible  bool   // a rollback/suspend is reversible; a delete may not be
+	BlastRadius int    // number of workloads affected
+	ApprovalID  string // runtime: set when registered for approval; drives Slack approve/reject buttons
 }
 
 // TimeWindow is a [Start, End] interval.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,11 +2,20 @@
 package server
 
 import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/config"
@@ -16,23 +25,25 @@ import (
 
 // Server handles incoming incident webhooks and applies the trigger policy.
 type Server struct {
-	engine    *trigger.Engine
-	enqueuer  investigate.Enqueuer
-	ready     func() bool
-	approvals *action.Approvals // nil unless action mode "approve" is configured
-	token     string            // optional shared secret for the approval endpoints
-	log       *slog.Logger
-	handler   http.Handler
+	engine      *trigger.Engine
+	enqueuer    investigate.Enqueuer
+	ready       func() bool
+	approvals   *action.Approvals // nil unless action mode "approve" is configured
+	token       string            // optional shared secret for the approval endpoints
+	slackSecret string            // Slack signing secret; verifies interactive button clicks
+	log         *slog.Logger
+	handler     http.Handler
 }
 
 // New builds a Server. ready reports whether this replica should serve (leadership);
 // nil = always ready. approvals (optional) enables the human-approval endpoints for
 // rung-2 actions; token (optional) is required as X-Approval-Token to use them.
 // /healthz is liveness; /readyz is readiness (gated by ready, leader-only).
-func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, approvals *action.Approvals, token string, log *slog.Logger) *Server {
-	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, ready: ready, approvals: approvals, token: token, log: log}
+func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, approvals *action.Approvals, token, slackSecret string, log *slog.Logger) *Server {
+	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, ready: ready, approvals: approvals, token: token, slackSecret: slackSecret, log: log}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook/alertmanager", s.handleAlertmanager)
+	mux.HandleFunc("POST /slack/interactions", s.handleSlackInteraction)
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -106,6 +117,105 @@ func (s *Server) handleReject(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_, _ = fmt.Fprintln(w, "rejected")
+}
+
+// slackInteraction is the subset of the Block Kit interaction payload we need.
+type slackInteraction struct {
+	ResponseURL string `json:"response_url"`
+	User        struct {
+		Username string `json:"username"`
+	} `json:"user"`
+	Actions []struct {
+		ActionID string `json:"action_id"`
+		Value    string `json:"value"`
+	} `json:"actions"`
+}
+
+// handleSlackInteraction processes Block Kit approve/reject button clicks: it
+// verifies the Slack request signature, approves (executing) or rejects the
+// referenced action, and updates the message via response_url.
+func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) {
+	if s.approvals == nil || s.slackSecret == "" {
+		http.Error(w, "slack interactions not enabled", http.StatusNotFound)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+	if !s.verifySlack(r.Header, body) {
+		s.log.Warn("rejected slack interaction: bad signature")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		http.Error(w, "bad payload", http.StatusBadRequest)
+		return
+	}
+	var p slackInteraction
+	if err := json.Unmarshal([]byte(form.Get("payload")), &p); err != nil || len(p.Actions) == 0 {
+		http.Error(w, "bad payload", http.StatusBadRequest)
+		return
+	}
+	act := p.Actions[0]
+	var msg string
+	switch act.ActionID {
+	case "runlore_approve":
+		executed, aerr := s.approvals.Approve(r.Context(), act.Value)
+		if aerr != nil {
+			msg = "❌ approval failed: " + aerr.Error()
+			s.log.Warn("slack approve failed", "id", act.Value, "user", p.User.Username, "err", aerr)
+		} else {
+			msg = fmt.Sprintf("✅ approved by @%s — executed: %s %s", p.User.Username, executed.Op, executed.Description)
+			s.log.Info("slack approval executed", "id", act.Value, "user", p.User.Username, "op", executed.Op)
+		}
+	case "runlore_reject":
+		if rerr := s.approvals.Reject(act.Value); rerr != nil {
+			msg = "⚠️ " + rerr.Error()
+		} else {
+			msg = fmt.Sprintf("🚫 rejected by @%s", p.User.Username)
+		}
+	default:
+		http.Error(w, "unknown action", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK) // ack the click; update the message best-effort
+	s.updateSlack(r.Context(), p.ResponseURL, msg)
+}
+
+// verifySlack validates the Slack request signature (HMAC-SHA256 over
+// "v0:{ts}:{body}") and rejects stale (replayable) requests.
+func (s *Server) verifySlack(h http.Header, body []byte) bool {
+	tsStr := h.Get("X-Slack-Request-Timestamp")
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return false
+	}
+	if d := time.Since(time.Unix(ts, 0)); d > 5*time.Minute || d < -5*time.Minute {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(s.slackSecret))
+	_, _ = mac.Write([]byte("v0:" + tsStr + ":" + string(body)))
+	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(expected), []byte(h.Get("X-Slack-Signature")))
+}
+
+// updateSlack replaces the original message via the interaction response_url.
+func (s *Server) updateSlack(ctx context.Context, responseURL, text string) {
+	if responseURL == "" {
+		return
+	}
+	body, _ := json.Marshal(map[string]any{"replace_original": true, "text": text})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, responseURL, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if resp, err := http.DefaultClient.Do(req); err == nil {
+		_ = resp.Body.Close()
+	}
 }
 
 // Handler returns the HTTP handler (built once at construction; Go 1.22+ method routing).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,18 +2,70 @@ package server
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+func slackSign(secret, ts, body string) string {
+	m := hmac.New(sha256.New, []byte(secret))
+	_, _ = m.Write([]byte("v0:" + ts + ":" + body))
+	return "v0=" + hex.EncodeToString(m.Sum(nil))
+}
+
+func TestSlackInteraction(t *testing.T) {
+	exec := &recordExec{}
+	pol := action.New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{ReversibleOnly: true}})
+	ap := action.NewApprovals(exec, pol, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}})
+
+	const secret = "shh"
+	srv := New(&config.Config{}, &spyEnqueuer{}, nil, ap, "", secret, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	payload := `{"user":{"username":"alice"},"actions":[{"action_id":"runlore_approve","value":"` + id + `"}]}`
+	body := "payload=" + url.QueryEscape(payload)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+
+	// Bad signature → 401, nothing executes.
+	bad := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(body))
+	bad.Header.Set("X-Slack-Request-Timestamp", ts)
+	bad.Header.Set("X-Slack-Signature", "v0=deadbeef")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, bad)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("bad signature = %d, want 401", rr.Code)
+	}
+	if len(exec.ran) != 0 {
+		t.Fatal("executed on an unverified request")
+	}
+
+	// Valid signature → 200, executes.
+	good := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(body))
+	good.Header.Set("X-Slack-Request-Timestamp", ts)
+	good.Header.Set("X-Slack-Signature", slackSign(secret, ts, body))
+	rr = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, good)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("valid interaction = %d, want 200", rr.Code)
+	}
+	if len(exec.ran) != 1 || exec.ran[0].Op != "suspend" {
+		t.Fatalf("approved action not executed: %+v", exec.ran)
+	}
+}
 
 type spyEnqueuer struct{ reqs []investigate.Request }
 
@@ -32,7 +84,7 @@ func TestActionsApprove(t *testing.T) {
 	ap := action.NewApprovals(exec, pol, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}})
 
-	srv := New(&config.Config{}, &spyEnqueuer{}, nil, ap, "secret", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv := New(&config.Config{}, &spyEnqueuer{}, nil, ap, "secret", "", slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	// Missing token → 403, nothing executes.
 	rr := httptest.NewRecorder()
@@ -63,7 +115,7 @@ func testServerWith(enq investigate.Enqueuer) *Server {
 		Enabled: true,
 		Match:   config.IncidentMatch{Severity: []string{"critical"}},
 	}
-	return New(cfg, enq, nil, nil, "", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return New(cfg, enq, nil, nil, "", "", slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
 
 func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
@@ -71,7 +123,7 @@ func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
 func TestReadyz(t *testing.T) {
 	cfg := &config.Config{}
 	leader := false
-	srv := New(cfg, &spyEnqueuer{}, func() bool { return leader }, nil, "", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv := New(cfg, &spyEnqueuer{}, func() bool { return leader }, nil, "", "", slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	rr := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))


### PR DESCRIPTION
Replaces curl-only approval with **Slack Block Kit buttons**: a pending rung-2 action renders **Approve**/**Reject** buttons; the click is verified and routed to the same `Approvals` store (execute on approve).

## How
- **Block Kit** — the Slack notifier renders Approve/Reject buttons for any action carrying an `ApprovalID` (set when registered for approval); plain text otherwise. The button `value` is the approval id.
- **`POST /slack/interactions`** — verifies the Slack request signature (HMAC-SHA256 over `v0:{ts}:{body}`, constant-time compare, 5-minute replay window), parses the `block_actions` payload, and approves (executing) or rejects the referenced action; best-effort updates the message via `response_url`.
- Config `notify.slack.signing_secret_env`; wired into the server. The token endpoint (`/actions/<id>/approve`) still works for non-Slack approvals.

## Security
Unsigned/forged clicks are rejected (401) before touching the queue; same envelope re-check + audit log as the token path; both paths share one `Approvals` store on the leader.

## Verified
- Unit: signature verification (bad sig → 401, no execution; valid → 200 + executes), Block Kit rendering (buttons + id present only when an `ApprovalID` is set).
- **e2e on k3d — 33/33**: a **signed** `/slack/interactions` POST approved a pending action → executed (`slack interaction HTTP 200` → `slack approval executed`), alongside the token path.

Real Slack setup: enable Interactivity, point the Request URL at `…/slack/interactions`, set the signing secret. Docs updated.