### PR TITLE
feat: instant recall (short-circuit on a high-confidence catalog hit)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -253,7 +253,7 @@ func buildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
 // configured. With a Git URL it starts a background syncer (running on every
 // replica, so a failover standby is already warm) that re-indexes after each pull;
 // otherwise it loads a static mounted directory once.
-func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, log *slog.Logger) catalog.Searcher {
+func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, log *slog.Logger) *catalog.Catalog {
 	if cfg.Catalog.Git.URL != "" {
 		dir := cfg.Catalog.Dir
 		if dir == "" {
@@ -432,8 +432,13 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	if gp != nil {
 		tools = append(tools, investigate.WhatChangedTool{GitOps: gp})
 	}
+	var recall *investigate.Recall
 	if cat := buildCatalog(ctx, cfg, forgeTok, log); cat != nil {
 		tools = append(tools, investigate.KBSearchTool{Catalog: cat})
+		if cfg.Catalog.InstantRecall.Enabled {
+			recall = &investigate.Recall{Catalog: cat, MinScore: cfg.Catalog.InstantRecall.MinScore}
+			log.Info("instant recall enabled", "min_score", cfg.Catalog.InstantRecall.MinScore)
+		}
 	}
 	if cfg.Metrics.URL != "" {
 		tools = append(tools, investigate.QueryMetricsTool{Metrics: prometheus.New(cfg.Metrics.URL)})
@@ -460,6 +465,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		Tools:   tools,
 		Log:     log,
 		Actions: actions,
+		Recall:  recall,
 		OnComplete: func(found providers.Investigation) {
 			// Rung 2: register envelope-compliant actions for human approval and
 			// annotate each with how to approve it. (Rung 1 only suggests; rung 2 makes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -189,6 +189,10 @@ config:
       branch: main
       interval: 5m
       # token_env: KB_GIT_TOKEN              # optional; private repos reuse the curation GitHub App by default
+    # Instant recall: skip the LLM loop when the catalog has a high-confidence match
+    # for the symptom (faster, cheaper). Off by default; tune min_score for your
+    # catalog — BM25 scores are corpus-dependent (observe the "score=" logs).
+    # instant_recall: { enabled: true, min_score: 0.3 }
 
   # Investigate signals (optional) — enable the query_metrics / query_logs tools.
   metrics:

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -78,10 +78,37 @@ func (c *Catalog) Len() int {
 	return len(c.entries)
 }
 
-var _ Searcher = (*Catalog)(nil)
+// ScoredEntry is a search hit with its BM25 relevance score.
+type ScoredEntry struct {
+	Entry Entry
+	Score float64
+}
+
+// ScoredSearcher exposes relevance scores (used by instant recall).
+type ScoredSearcher interface {
+	SearchScored(query string, k int) ([]ScoredEntry, error)
+}
+
+var (
+	_ Searcher       = (*Catalog)(nil)
+	_ ScoredSearcher = (*Catalog)(nil)
+)
 
 // Search returns up to k entries best matching the query (BM25).
 func (c *Catalog) Search(query string, k int) ([]Entry, error) {
+	scored, err := c.SearchScored(query, k)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Entry, len(scored))
+	for i, s := range scored {
+		out[i] = s.Entry
+	}
+	return out, nil
+}
+
+// SearchScored returns up to k hits with their relevance scores.
+func (c *Catalog) SearchScored(query string, k int) ([]ScoredEntry, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.index == nil {
@@ -94,13 +121,13 @@ func (c *Catalog) Search(query string, k int) ([]Entry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("search: %w", err)
 	}
-	out := make([]Entry, 0, len(res.Hits))
+	out := make([]ScoredEntry, 0, len(res.Hits))
 	for _, hit := range res.Hits {
 		i, err := strconv.Atoi(hit.ID)
 		if err != nil || i < 0 || i >= len(c.entries) {
 			continue
 		}
-		out = append(out, c.entries[i])
+		out = append(out, ScoredEntry{Entry: c.entries[i], Score: hit.Score})
 	}
 	return out, nil
 }

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -68,6 +68,26 @@ func TestReload(t *testing.T) {
 	}
 }
 
+func TestSearchScored(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "a.md", "---\ntitle: HelmRelease upgrade failure\ntags: [flux, helmrelease]\n---\nchart bump stalls the release")
+	writeEntry(t, dir, "b.md", "---\ntitle: Network policy drops\ntags: [cilium]\n---\nconnectivity timeouts")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := c.SearchScored("helmrelease chart upgrade", 2)
+	if err != nil {
+		t.Fatalf("SearchScored: %v", err)
+	}
+	if len(hits) == 0 || hits[0].Entry.Title != "HelmRelease upgrade failure" {
+		t.Fatalf("unexpected top hit: %+v", hits)
+	}
+	if hits[0].Score <= 0 {
+		t.Fatalf("expected a positive relevance score, got %v", hits[0].Score)
+	}
+}
+
 func TestEmptyCatalog(t *testing.T) {
 	c := NewEmpty()
 	if c.Len() != 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,8 +49,17 @@ type LeaderElection struct {
 // a mounted Dir (e.g. a ConfigMap) or a Git repo to sync (which closes the
 // read/write loop — the curator's merged PRs flow back into what the agent reads).
 type Catalog struct {
-	Dir string     `yaml:"dir"` // OKF bundle path (mounted ConfigMap, or the git-sync mirror)
-	Git CatalogGit `yaml:"git"`
+	Dir           string        `yaml:"dir"` // OKF bundle path (mounted ConfigMap, or the git-sync mirror)
+	Git           CatalogGit    `yaml:"git"`
+	InstantRecall InstantRecall `yaml:"instant_recall"`
+}
+
+// InstantRecall short-circuits the investigation loop when the catalog has a
+// high-confidence match for the symptom. Off by default; MinScore is the BM25
+// relevance floor (tune for your catalog).
+type InstantRecall struct {
+	Enabled  bool    `yaml:"enabled"`
+	MinScore float64 `yaml:"min_score"`
 }
 
 // CatalogGit configures periodic Git sync of the catalog into Dir.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -28,6 +28,7 @@ type LoopInvestigator struct {
 	MaxSteps   int
 	OnComplete func(providers.Investigation) // delivery hook (Slack/Matrix later)
 	Actions    *action.Policy                // autonomy ladder; nil/off = read-only findings only
+	Recall     *Recall                       // optional: short-circuit on a high-confidence catalog hit
 }
 
 // system returns the system prompt, asking for action proposals when the policy is enabled.
@@ -40,6 +41,14 @@ func (li *LoopInvestigator) system() string {
 
 // Investigate runs the loop for a request. It implements Investigator.
 func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error {
+	if li.Recall != nil {
+		if entry, score := li.Recall.lookup(req); entry != nil {
+			li.Log.Info("instant recall (catalog hit; skipping the loop)",
+				"title", req.Title, "entry", entry.Path, "score", fmt.Sprintf("%.2f", score))
+			li.deliver(req, recalledInvestigation(req, *entry))
+			return nil
+		}
+	}
 	byName := map[string]Tool{}
 	specs := make([]providers.ToolSpec, 0, len(li.Tools)+1)
 	for _, t := range li.Tools {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -6,10 +6,57 @@ import (
 	"log/slog"
 	"testing"
 
+	"strings"
+
 	"github.com/Smana/runlore/internal/action"
+	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+type fakeScored struct{ hits []catalog.ScoredEntry }
+
+func (f fakeScored) SearchScored(string, int) ([]catalog.ScoredEntry, error) { return f.hits, nil }
+
+func TestInstantRecallHit(t *testing.T) {
+	model := &scriptModel{} // no responses scripted: a call would panic, proving the loop is skipped
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model: model,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Recall: &Recall{MinScore: 2.0, Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Title: "Known incident", Description: "chart bump", Path: "known.md"}, Score: 5.0}}}},
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if model.i != 0 {
+		t.Fatalf("model was called %d times; a recall hit must skip the loop", model.i)
+	}
+	if got == nil || len(got.RootCauses) != 1 || !strings.Contains(got.RootCauses[0].Summary, "Known incident") {
+		t.Fatalf("unexpected recalled investigation: %+v", got)
+	}
+}
+
+func TestInstantRecallBelowThreshold(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName, Args: `{"confidence":0.5,"root_causes":[{"summary":"freshly investigated"}]}`}}},
+	}}
+	li := &LoopInvestigator{
+		Model: model,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Recall: &Recall{MinScore: 2.0, Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Title: "weak"}, Score: 0.5}}}}, // below threshold → loop runs
+		OnComplete: func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if model.i == 0 {
+		t.Fatal("model not called; a below-threshold score must run the loop")
+	}
+}
 
 func TestLoopInvestigatorActions(t *testing.T) {
 	// submit_findings proposes a reversible and an irreversible action.

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -1,0 +1,49 @@
+package investigate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Recall short-circuits an investigation when the knowledge catalog already has a
+// high-confidence answer for the symptom — skipping the slow, paid ReAct loop. It
+// is opt-in (off by default) with a tunable MinScore, since BM25 scores are
+// corpus-dependent and a stale hit shouldn't silently replace an investigation.
+type Recall struct {
+	Catalog  catalog.ScoredSearcher
+	MinScore float64
+}
+
+// lookup returns the best catalog entry for the request and its score if it meets
+// the threshold, else (nil, 0).
+func (r *Recall) lookup(req Request) (*catalog.Entry, float64) {
+	if r == nil || r.Catalog == nil {
+		return nil, 0
+	}
+	// Query the symptom (title + message); severity/reason is noise for matching.
+	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), 1)
+	if err != nil || len(hits) == 0 || hits[0].Score < r.MinScore {
+		return nil, 0
+	}
+	e := hits[0].Entry
+	return &e, hits[0].Score
+}
+
+// recalledInvestigation builds findings directly from a catalog entry. It is
+// explicit that this is a recalled match, not a fresh investigation.
+func recalledInvestigation(req Request, e catalog.Entry) providers.Investigation {
+	rc := providers.Hypothesis{
+		Summary:    e.Title + " — " + e.Description,
+		Confidence: 0.8,
+		Evidence:   []string{fmt.Sprintf("instant recall: matched knowledge-base entry %q", e.Path)},
+	}
+	return providers.Investigation{
+		Title:      req.Title,
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{rc},
+		Unresolved: []string{"recalled from the catalog without a fresh investigation — confirm it still applies"},
+	}
+}


### PR DESCRIPTION
When the knowledge catalog already has a high-confidence answer for the symptom, skip the (slow, paid) ReAct loop and deliver the recalled entry directly. **Off by default**; opt-in with a tunable threshold.

## How
- **`catalog.SearchScored`** exposes BM25 relevance scores (`ScoredEntry`/`ScoredSearcher`); `Search` is now a thin wrapper.
- **`investigate.Recall`** — before the loop, queries the catalog with the symptom (title + message; severity is noise, excluded). If the top hit's score ≥ `min_score`, the loop is skipped and an Investigation is built from the entry — explicitly marked recalled (Unresolved notes "confirm it still applies").
- `config.catalog.instant_recall.{enabled,min_score}`; wired into the `LoopInvestigator`.

## Why opt-in + tunable
BM25 scores are corpus-dependent (and degenerate on a tiny catalog — a term in 100% of docs has ~0 IDF), and short-circuiting risks a stale match silently replacing an investigation. So it's off by default; operators tune `min_score` by observing the `score=` logs.

## Verified
- Unit: `SearchScored` returns positive scores; recall hits above threshold (loop skipped, model **not** called) and falls through below threshold (loop runs).
- Local serve smoke (real BM25, 3-entry catalog): a matching incident logged `instant recall (catalog hit; skipping the loop) … score=0.47` — model never invoked; non-matching incidents ran the full loop.

Not added to the k3d e2e: enabling recall globally would short-circuit the suite's loop-driven checks; it's in-process logic over the catalog (no cluster dependency), covered by unit + serve smoke.