### PR TITLE
feat: autonomy ladder rung 3 (auto) with layered safety design

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -139,13 +139,14 @@ func runServe(args []string) error {
 		}
 	}
 
-	// Rung-2: approval-gated execution. Only built for mode "approve" with a reachable
-	// cluster; "auto" is not implemented (approval is always required).
+	// Rung-2 (approve) and rung-3 (auto) execution — mutually exclusive by mode, both
+	// requiring a reachable cluster. Token + Slack secret gate the control endpoints.
 	approvals := buildApprovals(cfg, executor, log)
+	auto := buildAuto(cfg, executor, log)
 	approvalToken := os.Getenv(cfg.Actions.ApprovalTokenEnv)
 	slackSigningSecret := os.Getenv(cfg.Notify.Slack.SigningSecretEnv)
 
-	inv := buildInvestigator(ctx, cfg, gitops, approvals, log)
+	inv := buildInvestigator(ctx, cfg, gitops, approvals, auto, log)
 	queue := investigate.NewQueue(inv, log)
 
 	// startWork runs the leader-only loops (investigation queue + failure watch),
@@ -167,7 +168,11 @@ func runServe(args []string) error {
 	}
 
 	// readyz reflects leadership so the Service routes webhooks only to the leader.
-	srv := server.New(cfg, queue, leader.Load, approvals, approvalToken, slackSigningSecret, log)
+	acts := server.Actions{Approvals: approvals, Token: approvalToken, SlackSecret: slackSigningSecret}
+	if auto != nil {
+		acts.Pauser = auto // avoid a typed-nil interface when auto is disabled
+	}
+	srv := server.New(cfg, queue, leader.Load, acts, log)
 	httpSrv := &http.Server{Addr: *addr, Handler: srv.Handler()}
 	go func() {
 		<-ctx.Done()
@@ -386,12 +391,9 @@ func buildForgeTokenSource(cfg *config.Config, log *slog.Logger) forgeToken {
 }
 
 // buildApprovals enables rung-2 approval-gated execution for action mode "approve"
-// (requires a reachable cluster). "auto" is intentionally not implemented.
+// (requires a reachable cluster).
 func buildApprovals(cfg *config.Config, exec action.Executor, log *slog.Logger) *action.Approvals {
 	if cfg.Actions.Mode != config.ActionApprove {
-		if cfg.Actions.Mode == config.ActionAuto {
-			log.Warn("action mode 'auto' is not implemented; approval is always required — use 'approve'")
-		}
 		return nil
 	}
 	if exec == nil {
@@ -400,6 +402,23 @@ func buildApprovals(cfg *config.Config, exec action.Executor, log *slog.Logger) 
 	}
 	log.Info("rung-2 approval-gated actions enabled (Flux suspend/resume/reconcile)")
 	return action.NewApprovals(exec, action.New(cfg.Actions), log)
+}
+
+// buildAuto enables rung-3 unattended execution for action mode "auto" (requires a
+// reachable cluster). Heavily gated: reversible-only, confidence-floored, rate-
+// limited, kill-switchable, and audited. Recommend dry_run before going live.
+func buildAuto(cfg *config.Config, exec action.Executor, log *slog.Logger) *action.Auto {
+	if cfg.Actions.Mode != config.ActionAuto {
+		return nil
+	}
+	if exec == nil {
+		log.Warn("auto-execution disabled: no cluster executor available")
+		return nil
+	}
+	a := cfg.Actions.Auto
+	log.Warn("rung-3 AUTO execution ENABLED — reversible actions execute WITHOUT human approval",
+		"dry_run", a.DryRun, "min_confidence", a.MinConfidence, "max_per_window", a.MaxPerWindow, "window", a.Window.Std().String())
+	return action.NewAuto(exec, a, log)
 }
 
 // buildCurator returns a Curator when the GitHub App token + KB repo are
@@ -578,7 +597,7 @@ func runInvestigate(args []string) error {
 
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
-func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, log *slog.Logger) investigate.Investigator {
+func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, auto *action.Auto, log *slog.Logger) investigate.Investigator {
 	if cfg.Model.BaseURL == "" && cfg.Model.Provider != "anthropic" {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
@@ -590,10 +609,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), log)
 	actions := action.New(cfg.Actions)
 	if actions.Enabled() {
-		log.Info("action suggestions enabled", "mode", string(actions.Mode()))
-		if m := actions.Mode(); m == config.ActionApprove || m == config.ActionAuto {
-			log.Warn("action mode not yet implemented; actions are SUGGESTED only, never executed", "mode", string(m))
-		}
+		log.Info("action policy enabled", "mode", string(actions.Mode()))
 	}
 	return &investigate.LoopInvestigator{
 		Model:   model,
@@ -602,13 +618,20 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		Actions: actions,
 		Recall:  recall,
 		OnComplete: func(found providers.Investigation) {
-			// Rung 2: register envelope-compliant actions for human approval and
-			// annotate each with how to approve it. (Rung 1 only suggests; rung 2 makes
-			// them executable after an explicit POST /actions/<id>/approve.)
-			if approvals != nil {
+			// Post-investigation action handling, by mode. The loop has already
+			// filtered found.Actions to the envelope (rung 1). auto and approvals are
+			// mutually exclusive (one is nil unless that mode is configured).
+			switch {
+			case auto != nil:
+				// Rung 3: evaluate + execute eligible actions (reversible/confidence/
+				// rate/kill-switch gated); descriptions are annotated with the outcome.
+				found.Actions = auto.Run(ctx, found)
+			case approvals != nil:
+				// Rung 2: register envelope-compliant actions for human approval; annotate
+				// with how to approve (curl) and the ApprovalID (Slack buttons).
 				for i := range found.Actions {
 					id := approvals.Register(found.Actions[i])
-					found.Actions[i].ApprovalID = id // drives Slack approve/reject buttons
+					found.Actions[i].ApprovalID = id
 					found.Actions[i].Description = fmt.Sprintf("%s — approve: POST /actions/%s/approve", found.Actions[i].Description, id)
 				}
 				if len(found.Actions) > 0 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -224,16 +224,28 @@ config:
 
   # Autonomy ladder. Default (omitted) = off = read-only findings only.
   #   suggest — propose envelope-filtered remediations, never executed.
-  #   approve — additionally register them for human approval; an approved action
-  #             executes a reversible Flux op (suspend/resume/reconcile). Requires
-  #             chart rbac.allowActions=true and (recommended) an approval token.
+  #   approve — register them for human approval (curl or Slack buttons); an approved
+  #             action executes a reversible Flux op (suspend/resume/reconcile).
+  #   auto    — execute eligible actions WITHOUT approval. Heavily gated (below).
+  # approve + auto require chart rbac.allowActions=true.
   # actions:
   #   mode: approve
-  #   approval_token_env: APPROVAL_TOKEN   # require X-Approval-Token on the endpoints
+  #   approval_token_env: APPROVAL_TOKEN   # gate the approval + kill-switch endpoints
   #   allow:
   #     reversible_only: true              # withhold irreversible suggestions
   #     max_blast_radius: 5
   #     kinds: [HelmRelease, Kustomization, Application]
+  #   # rung-3 unattended execution (mode: auto). Layered safety: auto ONLY ever runs
+  #   # reversible actions, and every decision is logged + delivered. Start with dry_run.
+  #   auto:
+  #     dry_run: true                      # log "would execute" without executing
+  #     min_confidence: 0.85               # only auto-execute above this confidence
+  #     max_per_window: 3                  # rate limit (anti-storm)
+  #     window: 1h
+  #   # Kill-switch (instant, no redeploy): POST /actions/pause | /actions/resume
+  #   # (X-Approval-Token). Scope which incidents auto acts on via the trigger policy.
+  #   # NOTE: floats like min_confidence must be set via a values file or
+  #   # `helm --set-json` — plain `--set x=0.85` is coerced to a string.
 
   # HA toggle (default on; harmless with 1 replica).
   leader_election:
@@ -301,6 +313,10 @@ Fire a test: trigger a `critical`/`prod` alert (or `flux suspend`+break a Kustom
   `POST /actions/<id>/approve` (token-gated) or **Slack Approve/Reject buttons** (enable Slack
   Interactivity with Request URL `…/slack/interactions` and set `slack.signing_secret_env`; clicks are
   HMAC-verified). The envelope is re-checked at execution and every action is audit-logged.
+- **Unattended (`actions.mode: auto`)**: executes eligible actions with **no human in the loop** — but only
+  *reversible* ops, only above `min_confidence`, rate-limited, and **instantly haltable** via
+  `POST /actions/pause` (`/resume`). Start with `dry_run: true`, scope which incidents it acts on via the
+  trigger policy, and watch the audit log + delivered summary. Irreversible actions are never auto-run.
 - **Forge**: writes issues/PRs to the one KB repo you configure, via the scoped GitHub App.
 - **Secrets**: referenced by env-var name from a `Secret` you control; nothing is inlined.
 

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -230,7 +230,43 @@ else red "FAIL: broken-app not suspended (spec.suspend=$SUSPENDED)"; FAIL=$((FAI
 check "execution audit-logged"          /tmp/runlore.log 'action approved and executed'
 check "slack button approval executed"  /tmp/runlore.log 'slack approval executed'
 
-step "9/10 leader election + failover (scale to 2)"
+step "9/11 rung-3 auto-execution + kill-switch"
+# Reconfigure to auto mode: reversible actions execute WITHOUT human approval, gated
+# by confidence + rate-limit + the kill-switch.
+helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
+  --set-string config.actions.mode=auto \
+  --set-json config.actions.auto.min_confidence=0.5 \
+  --set replicaCount=1 >/dev/null
+kubectl -n "$NS" rollout status deploy/runlore --timeout=120s >/dev/null
+PORT=18091; free_port "$PORT"
+kubectl -n "$NS" port-forward svc/runlore "$PORT:8080" >/tmp/runlore-pf.log 2>&1 &
+PF=$!; sleep 3
+# (a) Auto executes: un-suspend broken-app, fire a fresh critical incident, expect auto
+# to re-suspend it with no human in the loop.
+kubectl patch kustomization broken-app -n apps --type=merge -p '{"spec":{"suspend":false}}' >/dev/null
+curl -s -o /dev/null -XPOST "localhost:$PORT/webhook/alertmanager" \
+  -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest1","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-1"}]}'
+sleep 6
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "rung-3 auto enabled"            /tmp/runlore.log 'AUTO execution ENABLED'
+check "auto-executed (no approval)"    /tmp/runlore.log 'auto-executed'
+SUSP=$(kubectl get kustomization broken-app -n apps -o jsonpath='{.spec.suspend}' 2>/dev/null || true)
+if [[ "$SUSP" == "true" ]]; then green "PASS: auto-execution suspended broken-app without human approval"; PASS=$((PASS+1))
+else red "FAIL: auto did not suspend broken-app (spec.suspend=$SUSP)"; FAIL=$((FAIL+1)); fi
+# (b) Kill-switch: pause, un-suspend, fire again, expect NO execution.
+curl -s -o /dev/null -XPOST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/pause"
+kubectl patch kustomization broken-app -n apps --type=merge -p '{"spec":{"suspend":false}}' >/dev/null
+curl -s -o /dev/null -XPOST "localhost:$PORT/webhook/alertmanager" \
+  -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest2","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-2"}]}'
+sleep 6
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+kill "$PF" 2>/dev/null || true; free_port "$PORT"
+check "kill-switch paused auto"        /tmp/runlore.log 'auto paused'
+SUSP2=$(kubectl get kustomization broken-app -n apps -o jsonpath='{.spec.suspend}' 2>/dev/null || true)
+if [[ "$SUSP2" != "true" ]]; then green "PASS: kill-switch blocked auto-execution (broken-app left un-suspended)"; PASS=$((PASS+1))
+else red "FAIL: auto executed while paused (spec.suspend=$SUSP2)"; FAIL=$((FAIL+1)); fi
+
+step "10/11 leader election + failover (scale to 2)"
 kubectl -n "$NS" scale deploy/runlore --replicas=2 >/dev/null
 TOTAL=0; READY=0
 for _ in $(seq 1 30); do
@@ -259,7 +295,7 @@ done
 if [[ -n "$NEW" && "$NEW" != "$HOLDER" ]]; then green "PASS: failover — new leader $NEW"; PASS=$((PASS+1))
 else red "FAIL: no failover (holder still '$NEW')"; FAIL=$((FAIL+1)); fi
 
-step "10/10 ArgoCD engine (reconfigure + Application Degraded)"
+step "11/11 ArgoCD engine (reconfigure + Application Degraded)"
 kubectl apply -f - <<'YAML'
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/internal/action/auto.go
+++ b/internal/action/auto.go
@@ -1,0 +1,119 @@
+package action
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Auto executes remediations without human approval (mode "auto"), under layered
+// safety controls: it only ever runs REVERSIBLE actions, requires a minimum
+// investigation confidence, is rate-limited, can be paused instantly (kill-switch),
+// supports dry-run, and audits every decision. Anything failing a gate is surfaced
+// (annotated), never executed.
+type Auto struct {
+	exec          Executor
+	dryRun        bool
+	minConfidence float64
+	maxPerWindow  int
+	window        time.Duration
+	log           *slog.Logger
+	now           func() time.Time
+
+	mu     sync.Mutex
+	paused bool
+	recent []time.Time // recent execution timestamps (rate limiting)
+}
+
+// NewAuto builds the auto executor from the policy (window defaults to 1h).
+func NewAuto(exec Executor, p config.AutoPolicy, log *slog.Logger) *Auto {
+	window := p.Window.Std()
+	if window <= 0 {
+		window = time.Hour
+	}
+	return &Auto{
+		exec: exec, dryRun: p.DryRun, minConfidence: p.MinConfidence,
+		maxPerWindow: p.MaxPerWindow, window: window, log: log, now: time.Now,
+	}
+}
+
+// Pause engages the kill-switch: all auto-execution halts until Resume.
+func (a *Auto) Pause() { a.mu.Lock(); a.paused = true; a.mu.Unlock() }
+
+// Resume clears the kill-switch.
+func (a *Auto) Resume() { a.mu.Lock(); a.paused = false; a.mu.Unlock() }
+
+// Paused reports whether the kill-switch is engaged.
+func (a *Auto) Paused() bool { a.mu.Lock(); defer a.mu.Unlock(); return a.paused }
+
+// Run evaluates each (already envelope-compliant) action against the auto safety
+// gates and executes — or, in dry-run, logs — the eligible ones. It returns the
+// actions with their outcome annotated into the description for delivery/audit.
+func (a *Auto) Run(ctx context.Context, inv providers.Investigation) []providers.Action {
+	out := make([]providers.Action, 0, len(inv.Actions))
+	for _, act := range inv.Actions {
+		out = append(out, a.runOne(ctx, inv, act))
+	}
+	return out
+}
+
+func (a *Auto) runOne(ctx context.Context, inv providers.Investigation, act providers.Action) providers.Action {
+	annotate := func(prefix string) providers.Action {
+		act.Description = prefix + " " + act.Description
+		return act
+	}
+	switch {
+	case a.Paused():
+		a.log.Warn("auto paused; action not executed (kill-switch)", "op", act.Op, "target", target(act))
+		return annotate("[auto: skipped — paused]")
+	case inv.Confidence < a.minConfidence:
+		a.log.Info("auto skipped: confidence below threshold", "confidence", inv.Confidence, "min", a.minConfidence)
+		return annotate(fmt.Sprintf("[auto: skipped — confidence %.2f < %.2f]", inv.Confidence, a.minConfidence))
+	case !act.Reversible:
+		a.log.Warn("auto refuses irreversible action", "op", act.Op, "target", target(act))
+		return annotate("[auto: skipped — irreversible]")
+	case act.Op == "":
+		return annotate("[auto: skipped — no executable op]")
+	case a.dryRun:
+		a.log.Info("auto dry-run (would execute)", "op", act.Op, "target", target(act))
+		return annotate("[auto: dry-run — would execute]")
+	case !a.reserve():
+		a.log.Warn("auto rate limit reached; action not executed", "max", a.maxPerWindow, "window", a.window.String())
+		return annotate("[auto: skipped — rate-limited]")
+	default:
+		if err := a.exec.Execute(ctx, act); err != nil {
+			a.log.Error("auto-execute failed", "op", act.Op, "target", target(act), "err", err)
+			return annotate("[auto: FAILED — " + err.Error() + "]")
+		}
+		a.log.Info("auto-executed", "op", act.Op, "target", target(act))
+		return annotate("[auto-executed]")
+	}
+}
+
+// reserve consumes one slot from the rate-limit window if available.
+func (a *Auto) reserve() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	cutoff := a.now().Add(-a.window)
+	kept := a.recent[:0]
+	for _, t := range a.recent {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	a.recent = kept
+	if a.maxPerWindow > 0 && len(a.recent) >= a.maxPerWindow {
+		return false
+	}
+	a.recent = append(a.recent, a.now())
+	return true
+}
+
+func target(a providers.Action) string {
+	return a.Target.Kind + "/" + a.Target.Namespace + "/" + a.Target.Name
+}

--- a/internal/action/auto_test.go
+++ b/internal/action/auto_test.go
@@ -1,0 +1,104 @@
+package action
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+var revAction = providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}}
+
+func autoInv(conf float64, acts ...providers.Action) providers.Investigation {
+	return providers.Investigation{Confidence: conf, Actions: acts}
+}
+
+func TestAutoExecutes(t *testing.T) {
+	exec := &fakeExec{}
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, discardLog())
+	out := a.Run(context.Background(), autoInv(0.9, revAction))
+	if len(exec.ran) != 1 || exec.ran[0].Op != "suspend" {
+		t.Fatalf("expected one execution, got %+v", exec.ran)
+	}
+	if !strings.Contains(out[0].Description, "auto-executed") {
+		t.Fatalf("description not annotated: %q", out[0].Description)
+	}
+}
+
+func TestAutoRefusesIrreversible(t *testing.T) {
+	exec := &fakeExec{}
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, discardLog())
+	out := a.Run(context.Background(), autoInv(0.9, providers.Action{Op: "delete", Reversible: false}))
+	if len(exec.ran) != 0 {
+		t.Fatal("irreversible action must never auto-execute")
+	}
+	if !strings.Contains(out[0].Description, "irreversible") {
+		t.Fatalf("expected irreversible annotation: %q", out[0].Description)
+	}
+}
+
+func TestAutoConfidenceGate(t *testing.T) {
+	exec := &fakeExec{}
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.8}, discardLog())
+	out := a.Run(context.Background(), autoInv(0.5, revAction))
+	if len(exec.ran) != 0 {
+		t.Fatal("must not execute below the confidence threshold")
+	}
+	if !strings.Contains(out[0].Description, "confidence") {
+		t.Fatalf("expected confidence annotation: %q", out[0].Description)
+	}
+}
+
+func TestAutoDryRun(t *testing.T) {
+	exec := &fakeExec{}
+	a := NewAuto(exec, config.AutoPolicy{DryRun: true}, discardLog())
+	out := a.Run(context.Background(), autoInv(0.9, revAction))
+	if len(exec.ran) != 0 {
+		t.Fatal("dry-run must not execute")
+	}
+	if !strings.Contains(out[0].Description, "dry-run") {
+		t.Fatalf("expected dry-run annotation: %q", out[0].Description)
+	}
+}
+
+func TestAutoKillSwitch(t *testing.T) {
+	exec := &fakeExec{}
+	a := NewAuto(exec, config.AutoPolicy{}, discardLog())
+	a.Pause()
+	if !a.Paused() {
+		t.Fatal("Pause should engage the kill-switch")
+	}
+	out := a.Run(context.Background(), autoInv(1.0, revAction))
+	if len(exec.ran) != 0 {
+		t.Fatal("paused auto must not execute")
+	}
+	if !strings.Contains(out[0].Description, "paused") {
+		t.Fatalf("expected paused annotation: %q", out[0].Description)
+	}
+	a.Resume()
+	if a.Paused() {
+		t.Fatal("Resume should clear the kill-switch")
+	}
+	a.Run(context.Background(), autoInv(1.0, revAction))
+	if len(exec.ran) != 1 {
+		t.Fatal("resumed auto should execute")
+	}
+}
+
+func TestAutoRateLimit(t *testing.T) {
+	exec := &fakeExec{}
+	a := NewAuto(exec, config.AutoPolicy{MaxPerWindow: 1}, discardLog())
+	out := a.Run(context.Background(), autoInv(0.9, revAction, revAction)) // two actions, budget 1
+	if len(exec.ran) != 1 {
+		t.Fatalf("rate limit should allow exactly one, got %d", len(exec.ran))
+	}
+	if !strings.Contains(out[1].Description, "rate-limited") {
+		t.Fatalf("expected second action rate-limited: %q", out[1].Description)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,6 +242,16 @@ type ActionPolicy struct {
 	Allow            ActionAllow `yaml:"allow"`              // envelope, enforced even in approve/auto
 	RequireApproval  bool        `yaml:"require_approval"`   // force a human click for gated actions
 	ApprovalTokenEnv string      `yaml:"approval_token_env"` // env var with a shared secret for the approval endpoints
+	Auto             AutoPolicy  `yaml:"auto"`               // rung-3 unattended-execution safety controls
+}
+
+// AutoPolicy bounds unattended execution (mode "auto"). Even within these, auto
+// only ever runs REVERSIBLE actions, and every decision is audited + delivered.
+type AutoPolicy struct {
+	DryRun        bool     `yaml:"dry_run"`        // log "would execute" without executing
+	MinConfidence float64  `yaml:"min_confidence"` // only auto-execute when the investigation is at least this confident
+	MaxPerWindow  int      `yaml:"max_per_window"` // rate limit; 0 = unlimited (not recommended)
+	Window        Duration `yaml:"window"`         // rate-limit window (default 1h)
 }
 
 // ActionAllow bounds what may be acted on, even in approve/auto modes.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,18 +29,38 @@ type Server struct {
 	enqueuer    investigate.Enqueuer
 	ready       func() bool
 	approvals   *action.Approvals // nil unless action mode "approve" is configured
-	token       string            // optional shared secret for the approval endpoints
+	pauser      Pauser            // nil unless action mode "auto" is configured (kill-switch)
+	token       string            // optional shared secret for the approval/control endpoints
 	slackSecret string            // Slack signing secret; verifies interactive button clicks
 	log         *slog.Logger
 	handler     http.Handler
 }
 
+// Pauser is the rung-3 auto-execution kill-switch.
+type Pauser interface {
+	Pause()
+	Resume()
+	Paused() bool
+}
+
+// Actions bundles the optional rung-2/rung-3 wiring: the approval queue, the auto
+// kill-switch, the shared control token, and the Slack signing secret.
+type Actions struct {
+	Approvals   *action.Approvals
+	Pauser      Pauser
+	Token       string
+	SlackSecret string
+}
+
 // New builds a Server. ready reports whether this replica should serve (leadership);
-// nil = always ready. approvals (optional) enables the human-approval endpoints for
-// rung-2 actions; token (optional) is required as X-Approval-Token to use them.
-// /healthz is liveness; /readyz is readiness (gated by ready, leader-only).
-func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, approvals *action.Approvals, token, slackSecret string, log *slog.Logger) *Server {
-	s := &Server{engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, ready: ready, approvals: approvals, token: token, slackSecret: slackSecret, log: log}
+// nil = always ready. acts (optional) enables the rung-2 approval endpoints + the
+// rung-3 kill-switch, gated by acts.Token (X-Approval-Token). /healthz is liveness;
+// /readyz is readiness (gated by ready, leader-only).
+func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, acts Actions, log *slog.Logger) *Server {
+	s := &Server{
+		engine: trigger.NewEngine(cfg.Triggers.Incidents), enqueuer: enq, ready: ready,
+		approvals: acts.Approvals, pauser: acts.Pauser, token: acts.Token, slackSecret: acts.SlackSecret, log: log,
+	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook/alertmanager", s.handleAlertmanager)
 	mux.HandleFunc("POST /slack/interactions", s.handleSlackInteraction)
@@ -57,8 +77,38 @@ func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, approv
 	mux.HandleFunc("GET /actions", s.handleListActions)
 	mux.HandleFunc("POST /actions/{id}/approve", s.handleApprove)
 	mux.HandleFunc("POST /actions/{id}/reject", s.handleReject)
+	mux.HandleFunc("POST /actions/pause", s.handlePause)
+	mux.HandleFunc("POST /actions/resume", s.handleResume)
 	s.handler = mux
 	return s
+}
+
+func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
+	if s.pauser == nil {
+		http.Error(w, "auto-execution not enabled", http.StatusNotFound)
+		return
+	}
+	if !s.authorized(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	s.pauser.Pause()
+	s.log.Warn("auto-execution paused via kill-switch")
+	_, _ = fmt.Fprintln(w, "auto-execution paused")
+}
+
+func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
+	if s.pauser == nil {
+		http.Error(w, "auto-execution not enabled", http.StatusNotFound)
+		return
+	}
+	if !s.authorized(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	s.pauser.Resume()
+	s.log.Info("auto-execution resumed")
+	_, _ = fmt.Fprintln(w, "auto-execution resumed")
 }
 
 // authorized enforces the optional approval token (constant-time compare).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -34,7 +34,7 @@ func TestSlackInteraction(t *testing.T) {
 	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}})
 
 	const secret = "shh"
-	srv := New(&config.Config{}, &spyEnqueuer{}, nil, ap, "", secret, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv := New(&config.Config{}, &spyEnqueuer{}, nil, Actions{Approvals: ap, SlackSecret: secret}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	payload := `{"user":{"username":"alice"},"actions":[{"action_id":"runlore_approve","value":"` + id + `"}]}`
 	body := "payload=" + url.QueryEscape(payload)
@@ -84,7 +84,7 @@ func TestActionsApprove(t *testing.T) {
 	ap := action.NewApprovals(exec, pol, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}})
 
-	srv := New(&config.Config{}, &spyEnqueuer{}, nil, ap, "secret", "", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv := New(&config.Config{}, &spyEnqueuer{}, nil, Actions{Approvals: ap, Token: "secret"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	// Missing token → 403, nothing executes.
 	rr := httptest.NewRecorder()
@@ -109,13 +109,47 @@ func TestActionsApprove(t *testing.T) {
 	}
 }
 
+type fakePauser struct{ paused bool }
+
+func (f *fakePauser) Pause()       { f.paused = true }
+func (f *fakePauser) Resume()      { f.paused = false }
+func (f *fakePauser) Paused() bool { return f.paused }
+
+func TestKillSwitch(t *testing.T) {
+	p := &fakePauser{}
+	srv := New(&config.Config{}, &spyEnqueuer{}, nil, Actions{Pauser: p, Token: "t"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Without the token → 403, kill-switch untouched.
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/actions/pause", nil))
+	if rr.Code != http.StatusForbidden || p.paused {
+		t.Fatalf("no-token pause = %d paused=%v, want 403 + untouched", rr.Code, p.paused)
+	}
+	// With the token → paused.
+	req := httptest.NewRequest(http.MethodPost, "/actions/pause", nil)
+	req.Header.Set("X-Approval-Token", "t")
+	rr = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || !p.paused {
+		t.Fatalf("pause = %d paused=%v, want 200 + paused", rr.Code, p.paused)
+	}
+	// Resume clears it.
+	req = httptest.NewRequest(http.MethodPost, "/actions/resume", nil)
+	req.Header.Set("X-Approval-Token", "t")
+	rr = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK || p.paused {
+		t.Fatalf("resume = %d paused=%v, want 200 + resumed", rr.Code, p.paused)
+	}
+}
+
 func testServerWith(enq investigate.Enqueuer) *Server {
 	cfg := &config.Config{}
 	cfg.Triggers.Incidents = config.IncidentTrigger{
 		Enabled: true,
 		Match:   config.IncidentMatch{Severity: []string{"critical"}},
 	}
-	return New(cfg, enq, nil, nil, "", "", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return New(cfg, enq, nil, Actions{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 }
 
 func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
@@ -123,7 +157,7 @@ func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
 func TestReadyz(t *testing.T) {
 	cfg := &config.Config{}
 	leader := false
-	srv := New(cfg, &spyEnqueuer{}, func() bool { return leader }, nil, "", "", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	srv := New(cfg, &spyEnqueuer{}, func() bool { return leader }, Actions{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	rr := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))


### PR DESCRIPTION
The top rung: RunLore executes remediations **without human approval** — but only under a layered safety design, because removing the human is the dangerous part.

## Safety controls (the whole point)
1. **Reversible-only, mandatory** — irreversible actions never auto-run, regardless of the envelope flag.
2. **Confidence gate** — only auto-execute above `min_confidence`.
3. **Dry-run** — `dry_run: true` logs "would execute" without executing (validate before going live).
4. **Rate limit** — `max_per_window`/`window` caps executions (anti-storm).
5. **Kill-switch** — instant `POST /actions/pause` / `/resume` (token-gated), no redeploy.
6. **Audit + notify** — every decision is logged *and* delivered (annotated `[auto-executed]` / `[auto: skipped — …]`).
7. **Environment scoping** — auto only acts on incidents the trigger policy admits (scope to non-prod there).

Out-of-bounds actions are **surfaced, never executed**. Auto + approve are mutually exclusive by mode.

## How
- `internal/action.Auto`: evaluates each (already envelope-filtered) action against the gates, executes via the shared Flux `Executor` (or logs in dry-run), and returns the actions annotated with their outcome. `Pause`/`Resume`/`Paused` implement the kill-switch.
- Server: `Actions` struct bundles the rung-2/3 wiring; adds `POST /actions/pause|resume` (token-gated, typed-nil-safe).
- Config `actions.auto.{dry_run,min_confidence,max_per_window,window}`.

## Verified
- Unit (race-clean): executes when eligible · refuses irreversible · confidence gate · dry-run · kill-switch · rate-limit · server pause/resume (403 without token).
- **e2e on k3d — 38/38**: `mode: auto` → a critical incident → the agent **suspends a Kustomization with no human in the loop** (`auto-executed`); then **pause via the kill-switch** → a second incident does **not** execute (`auto paused`, resource left un-suspended).

## Note
Helm coerces `--set x=0.85` to a string; floats like `min_confidence` need `--set-json` or a values file (documented). The autonomy ladder is now complete: **off → suggest → approve → auto**, each rung adding capability behind an explicit gate.