### PR TITLE
chore: deferred hardening follow-ups (altitude + low-severity) + e2e adaptation

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -152,8 +152,13 @@ func runServe(args []string) error {
 		return aerr
 	}
 	defer auditClose()
-	approvals := buildApprovals(cfg, executor, aud, log)
-	auto := buildAuto(cfg, executor, aud, log)
+	// Audit every cluster mutation at the single Execute seam (both rungs go through it).
+	execForActions := executor
+	if executor != nil {
+		execForActions = action.NewAuditedExecutor(executor, aud)
+	}
+	approvals := buildApprovals(cfg, execForActions, aud, log)
+	auto := buildAuto(cfg, execForActions, aud, log)
 	slackSigningSecret := os.Getenv(cfg.Notify.Slack.SigningSecretEnv)
 	webhookToken := os.Getenv(cfg.Server.WebhookTokenEnv)
 
@@ -448,7 +453,7 @@ func buildAuto(cfg *config.Config, exec action.Executor, aud audit.Auditor, log 
 	a := cfg.Actions.Auto
 	log.Warn("rung-3 AUTO execution ENABLED — reversible actions execute WITHOUT human approval",
 		"dry_run", a.DryRun, "min_confidence", a.MinConfidence, "max_per_window", a.MaxPerWindow, "window", a.Window.Std().String())
-	au := action.NewAuto(exec, a, aud, log)
+	au := action.NewAuto(exec, a, action.New(cfg.Actions), aud, log)
 	// NewAuto starts paused (fail closed by construction across cold start / failover);
 	// surface that to the operator, who resumes via the authenticated /actions/resume.
 	log.Warn("rung-3 auto starts PAUSED (kill-switch engaged) — POST /actions/resume to begin auto-execution")

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -51,7 +51,8 @@ check() { # check <desc> <logfile> <pattern>
 step "1/8 create k3d cluster"
 k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
 k3d cluster create "$CLUSTER" --wait --timeout 120s --no-lb \
-  --k3s-arg "--disable=traefik@server:0"
+  --k3s-arg "--disable=traefik@server:0" \
+  --k3s-arg "--kubelet-arg=eviction-hard=imagefs.available<1%,nodefs.available<1%@server:0"   # tolerate a near-full dev host (absolute free space is ample)
 kubectl config use-context "k3d-$CLUSTER" >/dev/null
 
 step "2/8 install minimal Flux CRDs (Kustomization + GitRepository)"
@@ -110,6 +111,8 @@ openssl genrsa -out /tmp/runlore-app-key.pem 2048 2>/dev/null
 kubectl -n "$NS" create secret generic runlore-forge \
   --from-file=GITHUB_APP_PRIVATE_KEY=/tmp/runlore-app-key.pem \
   --dry-run=client -o yaml | kubectl apply -f -
+# apps ns must exist before install: the namespace-scoped action Role is created here.
+kubectl create namespace apps --dry-run=client -o yaml | kubectl apply -f -
 helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set image.repository=runlore --set image.tag=e2e --set image.pullPolicy=Never \
   --set replicaCount=1 \
@@ -129,8 +132,13 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set-string config.actions.approval_token_env=APPROVAL_TOKEN \
   --set-string config.notify.slack.signing_secret_env=SLACK_SIGNING_SECRET \
   --set rbac.allowActions=true \
+  --set networkPolicy.enabled=false \
+  --set "config.actions.allow.namespaces={apps}" \
+  --set "rbac.actionNamespaces={apps}" \
+  --set "config.notify.slack.approver_ids={U_E2E}" \
   --set "env[3].name=APPROVAL_TOKEN" --set-string "env[3].value=e2e-secret" \
   --set "env[4].name=SLACK_SIGNING_SECRET" --set-string "env[4].value=e2e-slack-secret" \
+  --set "env[5].name=WEBHOOK_TOKEN" --set-string "env[5].value=e2e-webhook" \
   --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.kb_repo="mock/repo" \
   --set-string config.forge.base_branch="main" \
@@ -209,7 +217,7 @@ if [[ -n "$ID2" ]]; then
   python3 - "$ID2" "$PORT" <<'PY'
 import sys, hmac, hashlib, time, json, urllib.parse, urllib.request
 aid, port = sys.argv[1], sys.argv[2]
-payload = json.dumps({"user": {"username": "e2e"}, "actions": [{"action_id": "runlore_approve", "value": aid}]})
+payload = json.dumps({"user": {"id": "U_E2E", "username": "e2e"}, "actions": [{"action_id": "runlore_approve", "value": aid}]})
 body = "payload=" + urllib.parse.quote(payload)
 ts = str(int(time.time()))
 sig = "v0=" + hmac.new(b"e2e-slack-secret", f"v0:{ts}:{body}".encode(), hashlib.sha256).hexdigest()
@@ -236,15 +244,21 @@ step "9/11 rung-3 auto-execution + kill-switch"
 helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
   --set-string config.actions.mode=auto \
   --set-json config.actions.auto.min_confidence=0.5 \
+  --set-json config.actions.auto.max_per_window=5 \
+  --set-string config.actions.audit_log_path=/tmp/runlore-audit.jsonl \
+  --set-string config.server.webhook_token_env=WEBHOOK_TOKEN \
   --set replicaCount=1 >/dev/null
 kubectl -n "$NS" rollout status deploy/runlore --timeout=120s >/dev/null
 PORT=18091; free_port "$PORT"
 kubectl -n "$NS" port-forward svc/runlore "$PORT:8080" >/tmp/runlore-pf.log 2>&1 &
 PF=$!; sleep 3
+# Auto starts paused (fail-closed cold start); resume before exercising execution.
+curl -s -o /dev/null -XPOST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/resume"
+sleep 1
 # (a) Auto executes: un-suspend broken-app, fire a fresh critical incident, expect auto
 # to re-suspend it with no human in the loop.
 kubectl patch kustomization broken-app -n apps --type=merge -p '{"spec":{"suspend":false}}' >/dev/null
-curl -s -o /dev/null -XPOST "localhost:$PORT/webhook/alertmanager" \
+curl -s -o /dev/null -XPOST -H "Authorization: Bearer e2e-webhook" "localhost:$PORT/webhook/alertmanager" \
   -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest1","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-1"}]}'
 sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
@@ -256,7 +270,7 @@ else red "FAIL: auto did not suspend broken-app (spec.suspend=$SUSP)"; FAIL=$((F
 # (b) Kill-switch: pause, un-suspend, fire again, expect NO execution.
 curl -s -o /dev/null -XPOST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/pause"
 kubectl patch kustomization broken-app -n apps --type=merge -p '{"spec":{"suspend":false}}' >/dev/null
-curl -s -o /dev/null -XPOST "localhost:$PORT/webhook/alertmanager" \
+curl -s -o /dev/null -XPOST -H "Authorization: Bearer e2e-webhook" "localhost:$PORT/webhook/alertmanager" \
   -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest2","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-2"}]}'
 sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1

--- a/internal/action/approvals.go
+++ b/internal/action/approvals.go
@@ -102,12 +102,12 @@ func (a *Approvals) Approve(ctx context.Context, id, actor string) (providers.Ac
 		return providers.Action{}, fmt.Errorf("action no longer within policy: %s", reason)
 	}
 	a.log.Info("executing approved action", "id", id, "actor", actor, "op", act.Op, "target", target(act))
-	if err := a.exec.Execute(ctx, act); err != nil {
-		recordAttempt(a.audit, actor, act, audit.DecisionFailed, err.Error())
+	// executed/failed are audited at the executor seam (NewAuditedExecutor); the
+	// actor is carried in the context so the record attributes the right approver.
+	if err := a.exec.Execute(ContextWithActor(ctx, actor), act); err != nil {
 		a.log.Error("approved action failed", "id", id, "err", err)
 		return providers.Action{}, err
 	}
-	recordAttempt(a.audit, actor, act, audit.DecisionExecuted, "")
 	a.log.Info("approved action executed", "id", id)
 	return act, nil
 }

--- a/internal/action/approvals.go
+++ b/internal/action/approvals.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -10,6 +11,9 @@ import (
 	"github.com/Smana/runlore/internal/audit"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+// ErrNoPending is returned when an approval id is unknown, already consumed, or expired.
+var ErrNoPending = errors.New("no pending action")
 
 // Executor runs an approved action against the cluster.
 type Executor interface {
@@ -89,7 +93,7 @@ func (a *Approvals) Approve(ctx context.Context, id, actor string) (providers.Ac
 	}
 	a.mu.Unlock()
 	if !ok {
-		return providers.Action{}, fmt.Errorf("no pending action %q", id)
+		return providers.Action{}, fmt.Errorf("%w %q", ErrNoPending, id)
 	}
 	// Defense in depth: re-evaluate the server-authoritative envelope at exec time.
 	act := deriveSafety(e.action)

--- a/internal/action/auto.go
+++ b/internal/action/auto.go
@@ -23,6 +23,7 @@ type Auto struct {
 	minConfidence float64
 	maxPerWindow  int
 	window        time.Duration
+	policy        *Policy
 	audit         audit.Auditor
 	log           *slog.Logger
 	now           func() time.Time
@@ -32,11 +33,12 @@ type Auto struct {
 	recent []time.Time // recent execution timestamps (rate limiting)
 }
 
-// NewAuto builds the auto executor from the policy (window defaults to 1h). A nil
+// NewAuto builds the auto executor from the policy (window defaults to 1h). policy
+// is the action envelope, re-checked at the exec boundary (defense in depth). A nil
 // auditor falls back to a no-op. The returned Auto starts with the kill-switch
 // ENGAGED (paused) — fail closed by construction, so a process/leader restart can
 // never resume unattended execution on its own; an operator must Resume() it.
-func NewAuto(exec Executor, p config.AutoPolicy, aud audit.Auditor, log *slog.Logger) *Auto {
+func NewAuto(exec Executor, p config.AutoPolicy, policy *Policy, aud audit.Auditor, log *slog.Logger) *Auto {
 	window := p.Window.Std()
 	if window <= 0 {
 		window = time.Hour
@@ -46,7 +48,7 @@ func NewAuto(exec Executor, p config.AutoPolicy, aud audit.Auditor, log *slog.Lo
 	}
 	return &Auto{
 		exec: exec, dryRun: p.DryRun, minConfidence: p.MinConfidence,
-		maxPerWindow: p.MaxPerWindow, window: window, audit: aud, log: log, now: time.Now,
+		maxPerWindow: p.MaxPerWindow, window: window, policy: policy, audit: aud, log: log, now: time.Now,
 		paused: true,
 	}
 }
@@ -108,13 +110,23 @@ func (a *Auto) runOne(ctx context.Context, inv providers.Investigation, act prov
 			a.record(act, audit.DecisionSkipped, "paused")
 			return annotate("[auto: skipped — paused]")
 		}
-		if err := a.exec.Execute(ctx, act); err != nil {
+		// Defense in depth: re-derive + re-validate the full envelope at the exec
+		// boundary (as Approvals.Approve does), so a mutated or un-Reviewed action
+		// can't reach the cluster — reversibility/blast come from the op, not the model.
+		act = deriveSafety(act)
+		if a.policy != nil {
+			if reason := a.policy.violation(act); reason != "" {
+				a.log.Warn("auto denied at exec boundary", "op", act.Op, "target", target(act), "reason", reason)
+				a.record(act, audit.DecisionDenied, reason)
+				return annotate("[auto: denied — " + reason + "]")
+			}
+		}
+		// executed/failed are audited at the executor seam (NewAuditedExecutor).
+		if err := a.exec.Execute(ContextWithActor(ctx, "auto"), act); err != nil {
 			a.log.Error("auto-execute failed", "op", act.Op, "target", target(act), "err", err)
-			a.record(act, audit.DecisionFailed, err.Error())
 			return annotate("[auto: FAILED — " + err.Error() + "]")
 		}
 		a.log.Info("auto-executed", "op", act.Op, "target", target(act))
-		a.record(act, audit.DecisionExecuted, fmt.Sprintf("confidence %.2f", inv.Confidence))
 		return annotate("[auto-executed]")
 	}
 }

--- a/internal/action/auto_test.go
+++ b/internal/action/auto_test.go
@@ -13,7 +13,12 @@ import (
 
 func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
-var revAction = providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}}
+// autoPolicy allows the "apps" namespace so re-validation at the exec boundary passes.
+func autoPolicy() *Policy {
+	return New(config.ActionPolicy{Mode: config.ActionAuto, Allow: config.ActionAllow{ReversibleOnly: true, Namespaces: []string{"apps"}}})
+}
+
+var revAction = providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "apps"}}
 
 func autoInv(conf float64, acts ...providers.Action) providers.Investigation {
 	return providers.Investigation{Confidence: conf, Actions: acts}
@@ -21,7 +26,7 @@ func autoInv(conf float64, acts ...providers.Action) providers.Investigation {
 
 func TestAutoExecutes(t *testing.T) {
 	exec := &fakeExec{}
-	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, nil, discardLog())
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, autoPolicy(), nil, discardLog())
 	a.Resume() // NewAuto starts paused (fail closed); opt in to execution
 	out := a.Run(context.Background(), autoInv(0.9, revAction))
 	if len(exec.ran) != 1 || exec.ran[0].Op != "suspend" {
@@ -34,7 +39,7 @@ func TestAutoExecutes(t *testing.T) {
 
 func TestAutoRefusesIrreversible(t *testing.T) {
 	exec := &fakeExec{}
-	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, nil, discardLog())
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, autoPolicy(), nil, discardLog())
 	a.Resume() // NewAuto starts paused (fail closed); opt in to execution
 	out := a.Run(context.Background(), autoInv(0.9, providers.Action{Op: "delete", Reversible: false}))
 	if len(exec.ran) != 0 {
@@ -47,7 +52,7 @@ func TestAutoRefusesIrreversible(t *testing.T) {
 
 func TestAutoConfidenceGate(t *testing.T) {
 	exec := &fakeExec{}
-	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.8}, nil, discardLog())
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.8}, autoPolicy(), nil, discardLog())
 	a.Resume()
 	out := a.Run(context.Background(), autoInv(0.5, revAction))
 	if len(exec.ran) != 0 {
@@ -60,7 +65,7 @@ func TestAutoConfidenceGate(t *testing.T) {
 
 func TestAutoDryRun(t *testing.T) {
 	exec := &fakeExec{}
-	a := NewAuto(exec, config.AutoPolicy{DryRun: true}, nil, discardLog())
+	a := NewAuto(exec, config.AutoPolicy{DryRun: true}, autoPolicy(), nil, discardLog())
 	a.Resume()
 	out := a.Run(context.Background(), autoInv(0.9, revAction))
 	if len(exec.ran) != 0 {
@@ -73,7 +78,7 @@ func TestAutoDryRun(t *testing.T) {
 
 func TestAutoKillSwitch(t *testing.T) {
 	exec := &fakeExec{}
-	a := NewAuto(exec, config.AutoPolicy{}, nil, discardLog())
+	a := NewAuto(exec, config.AutoPolicy{}, autoPolicy(), nil, discardLog())
 	a.Pause()
 	if !a.Paused() {
 		t.Fatal("Pause should engage the kill-switch")
@@ -97,7 +102,7 @@ func TestAutoKillSwitch(t *testing.T) {
 
 func TestAutoRateLimit(t *testing.T) {
 	exec := &fakeExec{}
-	a := NewAuto(exec, config.AutoPolicy{MaxPerWindow: 1}, nil, discardLog())
+	a := NewAuto(exec, config.AutoPolicy{MaxPerWindow: 1}, autoPolicy(), nil, discardLog())
 	a.Resume()
 	out := a.Run(context.Background(), autoInv(0.9, revAction, revAction)) // two actions, budget 1
 	if len(exec.ran) != 1 {
@@ -110,11 +115,27 @@ func TestAutoRateLimit(t *testing.T) {
 
 func TestNewAutoStartsPaused(t *testing.T) {
 	exec := &fakeExec{}
-	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, nil, discardLog())
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, autoPolicy(), nil, discardLog())
 	if !a.Paused() {
 		t.Fatal("NewAuto must start paused (fail closed by construction)")
 	}
 	if out := a.Run(context.Background(), autoInv(1.0, revAction)); len(exec.ran) != 0 {
 		t.Fatalf("a freshly built (paused) auto must not execute before Resume; ran=%+v out=%+v", exec.ran, out)
+	}
+}
+
+func TestAutoDeniesProtectedNamespace(t *testing.T) {
+	exec := &fakeExec{}
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, autoPolicy(), nil, discardLog())
+	a.Resume()
+	// flux-system is a built-in protected namespace; the exec-boundary re-validation
+	// must deny it even though it's reversible and confident.
+	protected := providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "x", Namespace: "flux-system"}}
+	out := a.Run(context.Background(), autoInv(1.0, protected))
+	if len(exec.ran) != 0 {
+		t.Fatalf("auto must deny a protected-namespace target at the exec boundary; ran=%+v", exec.ran)
+	}
+	if !strings.Contains(out[0].Description, "denied") {
+		t.Fatalf("expected denied annotation: %q", out[0].Description)
 	}
 }

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -1,0 +1,52 @@
+package action
+
+import (
+	"context"
+
+	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// actorKey types the context value carrying the actor responsible for an action.
+type actorKey struct{}
+
+// ContextWithActor tags ctx with the actor accountable for an execution (e.g.
+// "auto" or "approve:slack:U123"), so the audited executor can attribute its record.
+func ContextWithActor(ctx context.Context, actor string) context.Context {
+	return context.WithValue(ctx, actorKey{}, actor)
+}
+
+func actorFromContext(ctx context.Context) string {
+	if a, ok := ctx.Value(actorKey{}).(string); ok && a != "" {
+		return a
+	}
+	return "unknown"
+}
+
+// auditedExecutor wraps an Executor so every execution attempt is audited at the
+// one seam both rungs converge on — the executed/failed records are guaranteed by
+// construction, regardless of caller. Gate decisions (skipped/denied/dry-run)
+// never reach Execute and stay with the caller.
+type auditedExecutor struct {
+	inner Executor
+	aud   audit.Auditor
+}
+
+// NewAuditedExecutor wraps inner so executed/failed attempts are recorded to aud,
+// attributed to the actor carried in the context (see ContextWithActor).
+func NewAuditedExecutor(inner Executor, aud audit.Auditor) Executor {
+	if aud == nil {
+		aud = audit.Nop{}
+	}
+	return &auditedExecutor{inner: inner, aud: aud}
+}
+
+func (e *auditedExecutor) Execute(ctx context.Context, a providers.Action) error {
+	actor := actorFromContext(ctx)
+	if err := e.inner.Execute(ctx, a); err != nil {
+		recordAttempt(e.aud, actor, a, audit.DecisionFailed, err.Error())
+		return err
+	}
+	recordAttempt(e.aud, actor, a, audit.DecisionExecuted, "")
+	return nil
+}

--- a/internal/action/policy.go
+++ b/internal/action/policy.go
@@ -82,6 +82,9 @@ func (p *Policy) violation(a providers.Action) string {
 // namespaceViolation enforces the target-namespace allow/deny lists. A protected
 // namespace is always denied; otherwise the namespace must appear in the
 // operator's allowlist (an empty allowlist permits no executable target).
+//
+// TODO: when a second target dimension is needed (environment, labels), extract a
+// composable TargetPolicy.Evaluate(target) instead of adding inline branches here.
 func (p *Policy) namespaceViolation(ns string) string {
 	if ns == "" {
 		return "target namespace required"

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -40,13 +40,17 @@ func NewAppTokenSource(baseURL string, appID, installID int64, key *rsa.PrivateK
 		baseURL: strings.TrimRight(baseURL, "/"), http: &http.Client{Timeout: 30 * time.Second}}
 }
 
-// Token returns a valid installation token, refreshing when near expiry.
+// Token returns a valid installation token, refreshing when near expiry. The
+// network refresh runs WITHOUT holding the lock (double-checked locking), so a
+// slow/hung GitHub round-trip can't block every other token consumer.
 func (s *AppTokenSource) Token(ctx context.Context) (string, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.token != "" && time.Now().Before(s.exp.Add(-1*time.Minute)) {
-		return s.token, nil
+	if tok := s.cached(); tok != "" {
+		s.mu.Unlock()
+		return tok, nil
 	}
+	s.mu.Unlock()
+
 	jwt, err := mintJWT(s.appID, s.key, time.Now())
 	if err != nil {
 		return "", err
@@ -73,8 +77,22 @@ func (s *AppTokenSource) Token(ctx context.Context) (string, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return "", err
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if tok := s.cached(); tok != "" {
+		return tok, nil // a concurrent caller refreshed while we fetched
+	}
 	s.token, s.exp = out.Token, out.ExpiresAt
 	return s.token, nil
+}
+
+// cached returns the current token if still valid, else "". Caller holds s.mu.
+func (s *AppTokenSource) cached() string {
+	if s.token != "" && time.Now().Before(s.exp.Add(-1*time.Minute)) {
+		return s.token
+	}
+	return ""
 }
 
 // mintJWT builds a short-lived RS256 JWT signed with the App private key.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Smana/runlore/internal/providers"
+	"gopkg.in/yaml.v3"
 )
 
 // TokenFunc returns a valid installation token (minted/cached by the caller).
@@ -77,7 +78,7 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("github %s %s: status %d: %s", method, path, resp.StatusCode, string(data))
+		return fmt.Errorf("github %s %s: status %d: %s", method, path, resp.StatusCode, string(data[:min(len(data), 512)]))
 	}
 	if out != nil {
 		return json.Unmarshal(data, out)
@@ -153,16 +154,22 @@ func issueBody(inv providers.Investigation) string {
 	return b.String()
 }
 
+// kbFrontmatter is the YAML frontmatter of an OKF entry. Marshaled (not string-
+// formatted) so a newline-bearing title/description from LLM output can't inject
+// extra frontmatter keys.
+type kbFrontmatter struct {
+	Type        string   `yaml:"type"`
+	Title       string   `yaml:"title"`
+	Description string   `yaml:"description"`
+	Tags        []string `yaml:"tags,omitempty"`
+}
+
 // renderEntry serializes a KBEntry as OKF markdown (frontmatter + body).
 func renderEntry(e providers.KBEntry) string {
+	fm, _ := yaml.Marshal(kbFrontmatter{Type: e.Type, Title: e.Title, Description: e.Description, Tags: e.Tags})
 	var b strings.Builder
 	b.WriteString("---\n")
-	fmt.Fprintf(&b, "type: %s\n", e.Type)
-	fmt.Fprintf(&b, "title: %s\n", e.Title)
-	fmt.Fprintf(&b, "description: %s\n", e.Description)
-	if len(e.Tags) > 0 {
-		fmt.Fprintf(&b, "tags: [%s]\n", strings.Join(e.Tags, ", "))
-	}
+	b.Write(fm)
 	b.WriteString("---\n\n")
 	b.WriteString(e.Body)
 	b.WriteString("\n")

--- a/internal/httpx/retry.go
+++ b/internal/httpx/retry.go
@@ -1,0 +1,49 @@
+// Package httpx provides small HTTP helpers shared across providers.
+package httpx
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// DoWithRetry issues build()'s request with bounded exponential backoff, retrying
+// on a network error, HTTP 429, or 5xx — a transient upstream failure shouldn't
+// fail the whole investigation. Other 4xx and 2xx return immediately. build is
+// invoked fresh each attempt so a consumed request body is rebuilt. The backoff
+// respects ctx cancellation. The last response (a 429/5xx) is returned so the
+// caller can surface its status.
+func DoWithRetry(ctx context.Context, client *http.Client, attempts int, build func() (*http.Request, error)) (*http.Response, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var resp *http.Response
+	var err error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(200*(1<<uint(i-1))) * time.Millisecond):
+			}
+		}
+		var req *http.Request
+		if req, err = build(); err != nil {
+			return nil, err
+		}
+		resp, err = client.Do(req)
+		if err != nil {
+			continue // network error: retry
+		}
+		if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode < 500 {
+			return resp, nil // success or non-retryable
+		}
+		if i < attempts-1 {
+			_ = resp.Body.Close() // retrying: discard this body
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/internal/httpx/retry_test.go
+++ b/internal/httpx/retry_test.go
@@ -1,0 +1,58 @@
+package httpx
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDoWithRetrySucceedsAfterTransient(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&n, 1) < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := DoWithRetry(context.Background(), srv.Client(), 3, func() (*http.Request, error) {
+		return http.NewRequest(http.MethodGet, srv.URL, nil)
+	})
+	if err != nil {
+		t.Fatalf("DoWithRetry: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d, want 200", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&n); got != 3 {
+		t.Fatalf("attempts = %d, want 3 (two 500s then 200)", got)
+	}
+}
+
+func TestDoWithRetryNoRetryOn4xx(t *testing.T) {
+	var n int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&n, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	resp, err := DoWithRetry(context.Background(), srv.Client(), 3, func() (*http.Request, error) {
+		return http.NewRequest(http.MethodGet, srv.URL, nil)
+	})
+	if err != nil {
+		t.Fatalf("DoWithRetry: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&n); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (4xx is not retried)", got)
+	}
+}

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -34,11 +35,25 @@ func submitFindingsSpec() providers.ToolSpec {
 "required":["summary"]}},
 "unresolved":{"type":"array","items":{"type":"string"}},
 "actions":{"type":"array","description":"proposed remediations; prefer reversible, low-blast-radius","items":{"type":"object","properties":{
-"description":{"type":"string"},"op":{"type":"string","enum":["suspend","resume","reconcile",""],"description":"executable op (Flux); omit for a suggestion only"},
+"description":{"type":"string"},"op":{"type":"string","enum":` + opEnumJSON() + `,"description":"executable op (Flux); omit for a suggestion only"},
 "reversible":{"type":"boolean"},"blast_radius":{"type":"integer"},
 "target":{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}}},
 "required":["description"]}}},"required":["root_causes"]}`,
 	}
+}
+
+// opEnumJSON renders the executable-op enum for the schema from the canonical
+// registry (providers.Ops, sorted) plus "" (suggestion only), so the model-facing
+// schema can't drift from what the gate and executor actually accept.
+func opEnumJSON() string {
+	ops := make([]string, 0, len(providers.Ops)+1)
+	for op := range providers.Ops {
+		ops = append(ops, op)
+	}
+	sort.Strings(ops)
+	ops = append(ops, "")
+	b, _ := json.Marshal(ops)
+	return string(b)
 }
 
 // findings is the JSON shape of submit_findings arguments.

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -115,7 +115,7 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return providers.CompletionResponse{}, fmt.Errorf("messages status %d: %s", resp.StatusCode, string(data))
+		return providers.CompletionResponse{}, fmt.Errorf("messages status %d: %s", resp.StatusCode, string(data[:min(len(data), 512)]))
 	}
 	var mr msgResponse
 	if err := json.Unmarshal(data, &mr); err != nil {

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -100,15 +101,17 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
-	if err != nil {
-		return providers.CompletionResponse{}, err
+	newReq := func() (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("content-type", "application/json")
+		r.Header.Set("anthropic-version", apiVersion)
+		r.Header.Set("x-api-key", c.apiKey)
+		return r, nil
 	}
-	httpReq.Header.Set("content-type", "application/json")
-	httpReq.Header.Set("anthropic-version", apiVersion)
-	httpReq.Header.Set("x-api-key", c.apiKey)
-
-	resp, err := c.http.Do(httpReq)
+	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("messages request: %w", err)
 	}

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -123,7 +123,7 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		return providers.CompletionResponse{}, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return providers.CompletionResponse{}, fmt.Errorf("chat status %d: %s", resp.StatusCode, string(data))
+		return providers.CompletionResponse{}, fmt.Errorf("chat status %d: %s", resp.StatusCode, string(data[:min(len(data), 512)]))
 	}
 	var cr chatResponse
 	if err := json.Unmarshal(data, &cr); err != nil {

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -105,15 +106,18 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
-	if err != nil {
-		return providers.CompletionResponse{}, err
+	newReq := func() (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Content-Type", "application/json")
+		if c.apiKey != "" {
+			r.Header.Set("Authorization", "Bearer "+c.apiKey)
+		}
+		return r, nil
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	if c.apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-	}
-	resp, err := c.http.Do(httpReq)
+	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("chat request: %w", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -158,7 +159,11 @@ func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 	act, err := s.approvals.Approve(r.Context(), id, "approve:http")
 	if err != nil {
 		s.log.Warn("action approval failed", "id", id, "err", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		code := http.StatusInternalServerError
+		if errors.Is(err, action.ErrNoPending) {
+			code = http.StatusNotFound
+		}
+		http.Error(w, err.Error(), code)
 		return
 	}
 	s.log.Info("action approved and executed", "id", id, "op", act.Op)


### PR DESCRIPTION
## Summary

Follow-up to #36 — the deferred Low-severity fixes and the high-value architectural ("altitude") improvements from the review, plus the e2e suite adapted to the hardened behavior. All locally validated (`go build`/`vet`/`test -race`/`golangci-lint`/`gofmt`) **and the full k3d e2e passes (11/11 steps)**.

## Architectural (safe-by-construction)

- **Auto re-validates at the exec boundary** — `Auto` now holds the `*Policy` and re-derives + re-runs `violation` immediately before `Execute`, matching `Approvals.Approve`'s defense-in-depth. A protected-namespace / unknown-op action is denied on the unattended path even if it bypassed `Review`. (`+TestAutoDeniesProtectedNamespace`)
- **`auditedExecutor` seam** — executed/failed audit records now emit at the single `Execute` choke point (`NewAuditedExecutor`), attributed via a context-carried actor; callers keep only gate decisions. Any future `Execute` caller is audited by construction.
- **Op registry source-of-truth** — `submit_findings`' op enum is generated from `providers.Ops` (no longer hardcoded), so the model-facing schema can't drift from the gate/executor.

## Low-severity fixes

- **YAML-safe KB frontmatter** — `renderEntry` uses `yaml.Marshal` (no frontmatter injection from LLM-authored titles).
- **Redacted error bodies** — upstream responses truncated to 512B in error strings (github/openai/anthropic).
- **Correct approve status** — `action.ErrNoPending` → 404 vs 500 (was a blanket 400).
- **GitHub token single-flight** — `AppTokenSource.Token` refreshes outside the lock (double-checked), so a slow refresh no longer blocks every consumer.
- **Model retry/backoff** — new `internal/httpx.DoWithRetry` (bounded exp-backoff; retries network/429/5xx; ctx-aware), wired into the OpenAI + Anthropic clients (unit-tested).

## e2e

`hack/e2e-k3d.sh` adapted to the hardened ladder (NetworkPolicy off for the host-mock suite, `actions.allow.namespaces`/`rbac.actionNamespaces`, auto's new Validate fields, fail-closed auto resume, webhook bearer, Slack approver-ID, pre-create `apps` ns, and an eviction-threshold relax so a near-full dev host doesn't taint the throwaway node). **Full run: 11/11 steps green** (approve + auto + kill-switch + leader-election failover + ArgoCD).

## Skipped (with reason)

- auth-as-middleware — per-handler guards are already correct/fail-closed; reordering risks the route-status tests for no security gain.
- `buildForgeTokenSource` dedupe — low value (2 long-lived cached sources, not per-call).
- hubble TLS — config-schema follow-up; in-cluster Relay is plaintext by convention and `hubble.New` already accepts a TLS dial-opt.
- composable `TargetPolicy` — left a TODO; warranted once a second target dimension (env/label) returns.

## Validation

`go build ./...` · `go vet ./...` · `go test ./... -race` (incl. new httpx + action tests) · `golangci-lint run` (0 issues) · `gofmt` — all green. k3d e2e: **11/11 steps pass**.
