### PR TITLE
feat(model): native Google Gemini provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ flowchart LR
 - **Read-only by default, full autonomy ladder when you want it** — `off` → `suggest` → `approve` (human-gated) → `auto` (unattended). Every rung above read-only is reversible-only, envelope-bounded, audited, and kill-switchable (see [`docs/design.md`](docs/design.md)).
 - **GitOps- and metrics-agnostic** — Flux + ArgoCD, VictoriaMetrics + Prometheus; logs/network pluggable.
 - **Single static Go binary** — terminal (`lore investigate`) or in-cluster (`lore serve`).
-- **Model-agnostic** — Anthropic or any OpenAI-compatible endpoint (in-cluster vLLM, Ollama…); your telemetry needn't leave the boundary.
+- **Model-agnostic** — Anthropic, Google Gemini, or any OpenAI-compatible endpoint (in-cluster vLLM, Ollama…); your telemetry needn't leave the boundary.
 - **Built-in core providers, MCP as the extension layer** — self-contained, but composable.
 - **Pluggable notifications** — Slack + Matrix first; PagerDuty and incident.io next.
 
@@ -103,7 +103,7 @@ lore investigate --alert HarborProbeFailure --namespace apps --config runlore.ya
 - 📐 [Design](docs/design.md) · 🚀 [Getting started](docs/getting-started.md) · 🛠 [Contributing](CONTRIBUTING.md) · [Prior art](docs/prior-art.md) · [Plans](docs/plans/)
 - ✅ **End-to-end working** (verified on k3d):
   - **React** — incident webhook (trigger policy + dedup) + GitOps failure watch (**Flux & Argo CD**)
-  - **Investigate** — ReAct loop with 5 tools (`what_changed`, `kb_search`, `query_metrics`, `query_logs`, `network_drops`) + **instant recall** (skip the loop on a high-confidence catalog hit); model-agnostic (**Anthropic** or any OpenAI-compatible endpoint)
+  - **Investigate** — ReAct loop with 5 tools (`what_changed`, `kb_search`, `query_metrics`, `query_logs`, `network_drops`) + **instant recall** (skip the loop on a high-confidence catalog hit); model-agnostic (**Anthropic**, **Gemini**, or any OpenAI-compatible endpoint)
   - **Deliver** — Slack (with interactive **Approve/Reject buttons**) + Matrix
   - **Learn** — OKF catalog (read + **git-sync**) + curator PRs/issues → knowledge compounds
   - **Act** — full **autonomy ladder**: `off` → `suggest` → `approve` (curl or Slack buttons, token-gated) → `auto` (unattended, reversible-only, confidence-gated, rate-limited, **kill-switchable**, audited)

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -40,6 +40,7 @@ import (
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
 	anthropic "github.com/Smana/runlore/internal/model/anthropic"
+	gemini "github.com/Smana/runlore/internal/model/gemini"
 	openai "github.com/Smana/runlore/internal/model/openai"
 	"github.com/Smana/runlore/internal/network/hubble"
 	"github.com/Smana/runlore/internal/notify"
@@ -269,18 +270,35 @@ func podNamespace() string {
 
 // modelProvider returns the configured model provider name (default "openai").
 func modelProvider(cfg *config.Config) string {
-	if cfg.Model.Provider == "anthropic" {
-		return "anthropic"
+	switch cfg.Model.Provider {
+	case "anthropic", "gemini":
+		return cfg.Model.Provider
+	default:
+		return "openai"
 	}
-	return "openai"
+}
+
+// modelConfigured reports whether a usable model is configured: a provider with a
+// built-in default endpoint (anthropic, gemini), or any provider with a base_url.
+func modelConfigured(cfg *config.Config) bool {
+	switch cfg.Model.Provider {
+	case "anthropic", "gemini":
+		return true
+	default:
+		return cfg.Model.BaseURL != ""
+	}
 }
 
 // buildModel builds the ModelProvider for the configured provider.
 func buildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
-	if cfg.Model.Provider == "anthropic" {
+	switch cfg.Model.Provider {
+	case "anthropic":
 		return anthropic.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+	case "gemini":
+		return gemini.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+	default:
+		return openai.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
 	}
-	return openai.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
 }
 
 // buildCatalog returns the kb_search backing store, or nil when no catalog is
@@ -341,7 +359,7 @@ func runEval(args []string) error {
 	if err != nil {
 		return err
 	}
-	if cfg.Model.BaseURL == "" && cfg.Model.Provider != "anthropic" {
+	if !modelConfigured(cfg) {
 		return fmt.Errorf("eval requires a configured model (set config.model)")
 	}
 	cases, err := eval.Load(*casesDir)
@@ -603,7 +621,7 @@ func runInvestigate(args []string) error {
 	if err != nil {
 		return err
 	}
-	if cfg.Model.BaseURL == "" && cfg.Model.Provider != "anthropic" {
+	if !modelConfigured(cfg) {
 		return fmt.Errorf("investigate requires a configured model (set config.model)")
 	}
 	// Progress logs go to stderr; the findings go to stdout.
@@ -637,7 +655,7 @@ func runInvestigate(args []string) error {
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
 func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, auto *action.Auto, log *slog.Logger) investigate.Investigator {
-	if cfg.Model.BaseURL == "" && cfg.Model.Provider != "anthropic" {
+	if !modelConfigured(cfg) {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
 	}

--- a/docs/design.md
+++ b/docs/design.md
@@ -66,8 +66,8 @@ the reason to build it.
 - An **open OKF knowledge catalog** the agent reads (fast, cached) and writes (PR-gated) — knowledge
   is portable markdown in git, never vendor lock-in.
 - **Single static Go binary**; runs in your terminal (`lore investigate`) or in-cluster (`lore serve`).
-- **Two model interfaces in v1: Anthropic and OpenAI-compatible.** The latter covers an in-cluster
-  vLLM, Ollama, OpenRouter, or any OpenAI-compatible endpoint — so data needn't leave the boundary,
+- **Three model providers: Anthropic, Google Gemini, and OpenAI-compatible.** The last covers an
+  in-cluster vLLM, Ollama, OpenRouter, or any OpenAI-compatible endpoint — so data needn't leave the boundary,
   with no LiteLLM-style multi-broker dependency.
 
 **Non-goals (for now)**
@@ -245,7 +245,7 @@ Interfaces live in `internal/providers/providers.go`. "For the moment" impls:
 | Logs | `LogsProvider` | **VictoriaLogs** | Loki, … |
 | Network | `NetworkProvider` | **Hubble** | — |
 | Cloud | `CloudProvider` | — *(Phase 2)* | AWS, GCP, Azure via native SDKs; Steampipe/cloud-MCP optional |
-| Model | `ModelProvider` | **Anthropic**, **OpenAI-compatible** (in-cluster vLLM, Ollama, OpenRouter, …) | — |
+| Model | `ModelProvider` | **Anthropic**, **Gemini**, **OpenAI-compatible** (in-cluster vLLM, Ollama, OpenRouter, …) | — |
 | Notifier | `Notifier` | **Slack**, **Matrix** | PagerDuty, incident.io |
 | Issue | `IssueProvider` | **GitHub** (App auth) | GitLab (access token) |
 
@@ -367,7 +367,7 @@ internal/
   catalog/                     syncer + local mirror + bleve/chromem-go index + kb_search
   curator/                     confidence-routed Issue/PR crystallization → OKF entries
   audit/                       append-only decision/tool-call log
-  model/                       ModelProvider impls (anthropic, openai-compatible)
+  model/                       ModelProvider impls (anthropic, gemini, openai-compatible)
   notify/                      Notifier impls (slack, matrix; pagerduty/incident.io later)
   providers/
     providers.go               the interfaces + the Change model (the contract)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,8 +86,8 @@ type CatalogGit struct {
 // "anthropic" (native Messages API). When unconfigured, serve uses the log-only
 // investigator.
 type Model struct {
-	Provider  string `yaml:"provider"`    // "openai" (default) | "anthropic"
-	BaseURL   string `yaml:"base_url"`    // OpenAI: required; Anthropic: optional (defaults to api.anthropic.com)
+	Provider  string `yaml:"provider"`    // "openai" (default) | "anthropic" | "gemini"
+	BaseURL   string `yaml:"base_url"`    // OpenAI: required; Anthropic/Gemini: optional (built-in default endpoint)
 	Model     string `yaml:"model"`       // model name
 	APIKeyEnv string `yaml:"api_key_env"` // env var holding the API key (empty = keyless)
 }

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -1,0 +1,223 @@
+// Package gemini implements providers.ModelProvider against the Gemini API
+// (generateContent with native function calling). It maps RunLore's engine-
+// agnostic exchange (OpenAI-shaped: assistant tool_calls + separate tool messages)
+// onto Gemini's contents/parts form: assistant turns become role "model" with
+// functionCall parts, and tool results coalesce into one role "user" turn of
+// functionResponse parts (Gemini matches a response to its call by function name).
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// DefaultBaseURL is the public Gemini API.
+const DefaultBaseURL = "https://generativelanguage.googleapis.com"
+
+// Client is a Gemini (generateContent) model provider.
+type Client struct {
+	baseURL string
+	model   string
+	apiKey  string
+	http    *http.Client
+}
+
+// New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
+func New(baseURL, model, apiKey string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   model,
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 2 * time.Minute},
+	}
+}
+
+var _ providers.ModelProvider = (*Client)(nil)
+
+type genRequest struct {
+	SystemInstruction *content  `json:"system_instruction,omitempty"`
+	Contents          []content `json:"contents"`
+	Tools             []tool    `json:"tools,omitempty"`
+}
+
+type content struct {
+	Role  string `json:"role,omitempty"`
+	Parts []part `json:"parts"`
+}
+
+type part struct {
+	Text             string            `json:"text,omitempty"`
+	FunctionCall     *functionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *functionResponse `json:"functionResponse,omitempty"`
+}
+
+type functionCall struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args,omitempty"`
+}
+
+type functionResponse struct {
+	Name     string          `json:"name"`
+	Response json.RawMessage `json:"response"`
+}
+
+type tool struct {
+	FunctionDeclarations []functionDeclaration `json:"functionDeclarations"`
+}
+
+type functionDeclaration struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+}
+
+type genResponse struct {
+	Candidates []struct {
+		Content content `json:"content"`
+	} `json:"candidates"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// Complete sends a generateContent request with tools and maps the result back.
+func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	greq := genRequest{Contents: toContents(req.Messages)}
+	if req.System != "" {
+		greq.SystemInstruction = &content{Parts: []part{{Text: req.System}}}
+	}
+	if len(req.Tools) > 0 {
+		decls := make([]functionDeclaration, 0, len(req.Tools))
+		for _, t := range req.Tools {
+			decls = append(decls, functionDeclaration{Name: t.Name, Description: t.Description, Parameters: json.RawMessage(t.Schema)})
+		}
+		greq.Tools = []tool{{FunctionDeclarations: decls}}
+	}
+	body, err := json.Marshal(greq)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+	url := fmt.Sprintf("%s/v1beta/models/%s:generateContent", c.baseURL, c.model)
+	newReq := func() (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("x-goog-api-key", c.apiKey)
+		return r, nil
+	}
+	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("generateContent request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return providers.CompletionResponse{}, fmt.Errorf("generateContent status %d: %s", resp.StatusCode, string(data[:min(len(data), 512)]))
+	}
+	var gr genResponse
+	if err := json.Unmarshal(data, &gr); err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("parse response: %w", err)
+	}
+	if gr.Error != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("gemini error: %s", gr.Error.Message)
+	}
+	out := providers.CompletionResponse{}
+	if len(gr.Candidates) == 0 {
+		return out, nil
+	}
+	for _, p := range gr.Candidates[0].Content.Parts {
+		switch {
+		case p.FunctionCall != nil:
+			out.ToolCalls = append(out.ToolCalls, providers.ToolCall{
+				ID:   p.FunctionCall.Name, // Gemini matches a function response to its call by name
+				Name: p.FunctionCall.Name,
+				Args: argString(p.FunctionCall.Args),
+			})
+		case p.Text != "":
+			out.Text += p.Text
+		}
+	}
+	return out, nil
+}
+
+// toContents maps engine-agnostic messages to Gemini contents. Assistant turns
+// become role "model" (text + functionCall parts); consecutive tool results are
+// coalesced into a single role "user" turn of functionResponse parts, named by the
+// function they answer (resolved from the originating tool call's id).
+func toContents(in []providers.Message) []content {
+	idToName := map[string]string{}
+	for _, m := range in {
+		for _, tc := range m.ToolCalls {
+			idToName[tc.ID] = tc.Name
+		}
+	}
+	var out []content
+	for i := 0; i < len(in); i++ {
+		m := in[i]
+		switch m.Role {
+		case "assistant":
+			var parts []part
+			if m.Content != "" {
+				parts = append(parts, part{Text: m.Content})
+			}
+			for _, tc := range m.ToolCalls {
+				parts = append(parts, part{FunctionCall: &functionCall{Name: tc.Name, Args: rawObject(tc.Args)}})
+			}
+			out = append(out, content{Role: "model", Parts: parts})
+		case "tool":
+			var parts []part
+			for i < len(in) && in[i].Role == "tool" {
+				name := idToName[in[i].ToolCallID]
+				if name == "" {
+					name = in[i].ToolCallID
+				}
+				parts = append(parts, part{FunctionResponse: &functionResponse{Name: name, Response: resultObject(in[i].Content)}})
+				i++
+			}
+			i-- // outer loop will increment
+			out = append(out, content{Role: "user", Parts: parts})
+		default: // user (and any other) → a text part
+			out = append(out, content{Role: "user", Parts: []part{{Text: m.Content}}})
+		}
+	}
+	return out
+}
+
+// rawObject ensures functionCall args is a JSON object ("" → {}).
+func rawObject(args string) json.RawMessage {
+	if strings.TrimSpace(args) == "" {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(args)
+}
+
+// argString renders a response functionCall's args (a JSON object) as the string
+// RunLore's ToolCall carries; empty/null becomes "{}".
+func argString(raw json.RawMessage) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" {
+		return "{}"
+	}
+	return s
+}
+
+// resultObject wraps a tool's string output as Gemini's functionResponse.response
+// object (Gemini requires an object, not a bare string).
+func resultObject(out string) json.RawMessage {
+	b, _ := json.Marshal(map[string]string{"result": out})
+	return b
+}

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -1,0 +1,104 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestComplete(t *testing.T) {
+	var gotReq genRequest
+	var gotKey, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("x-goog-api-key")
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[
+		  {"text":"investigating"},
+		  {"functionCall":{"name":"what_changed","args":{"namespace":"apps"}}}]}}]}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "gemini-x", "k")
+	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
+		System:   "sys",
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Tools:    []providers.ToolSpec{{Name: "what_changed", Description: "d", Schema: `{"type":"object"}`}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// auth header + URL
+	if gotKey != "k" {
+		t.Fatalf("x-goog-api-key = %q", gotKey)
+	}
+	if !strings.HasSuffix(gotPath, "/v1beta/models/gemini-x:generateContent") {
+		t.Fatalf("path = %q", gotPath)
+	}
+	// request mapping: system_instruction, tools (functionDeclarations), contents
+	if gotReq.SystemInstruction == nil || gotReq.SystemInstruction.Parts[0].Text != "sys" {
+		t.Fatalf("system: %+v", gotReq.SystemInstruction)
+	}
+	if len(gotReq.Tools) != 1 || len(gotReq.Tools[0].FunctionDeclarations) != 1 ||
+		gotReq.Tools[0].FunctionDeclarations[0].Name != "what_changed" ||
+		string(gotReq.Tools[0].FunctionDeclarations[0].Parameters) != `{"type":"object"}` {
+		t.Fatalf("tools: %+v", gotReq.Tools)
+	}
+	if len(gotReq.Contents) != 1 || gotReq.Contents[0].Role != "user" || gotReq.Contents[0].Parts[0].Text != "hi" {
+		t.Fatalf("contents: %+v", gotReq.Contents)
+	}
+	// response mapping: text + functionCall → ToolCall (args object → string)
+	if resp.Text != "investigating" || len(resp.ToolCalls) != 1 ||
+		resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
+		t.Fatalf("response: %+v", resp)
+	}
+}
+
+// TestToolResultCoalescing verifies the OpenAI-shaped exchange (assistant tool_calls
+// + separate tool messages) maps to Gemini's model functionCall / coalesced user
+// functionResponse form, named by the originating call.
+func TestToolResultCoalescing(t *testing.T) {
+	var gotReq genRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"done"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{
+			{Role: "user", Content: "investigate"},
+			{Role: "assistant", ToolCalls: []providers.ToolCall{
+				{ID: "a", Name: "what_changed", Args: `{"namespace":"apps"}`},
+				{ID: "b", Name: "kb_search", Args: `{"query":"x"}`},
+			}},
+			{Role: "tool", ToolCallID: "a", Content: "changed: chart bump"},
+			{Role: "tool", ToolCallID: "b", Content: "runbook: rollback"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(gotReq.Contents) != 3 {
+		t.Fatalf("want 3 contents (user, model, coalesced user), got %d: %+v", len(gotReq.Contents), gotReq.Contents)
+	}
+	model := gotReq.Contents[1]
+	if model.Role != "model" || len(model.Parts) != 2 ||
+		model.Parts[0].FunctionCall == nil || model.Parts[0].FunctionCall.Name != "what_changed" {
+		t.Fatalf("model turn: %+v", model)
+	}
+	results := gotReq.Contents[2]
+	if results.Role != "user" || len(results.Parts) != 2 ||
+		results.Parts[0].FunctionResponse == nil || results.Parts[0].FunctionResponse.Name != "what_changed" ||
+		results.Parts[1].FunctionResponse == nil || results.Parts[1].FunctionResponse.Name != "kb_search" {
+		t.Fatalf("coalesced tool results: %+v", results)
+	}
+	if !strings.Contains(string(results.Parts[0].FunctionResponse.Response), "chart bump") {
+		t.Fatalf("functionResponse.response should wrap the tool output: %s", results.Parts[0].FunctionResponse.Response)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **native Google Gemini** model provider — first-class, alongside Anthropic and OpenAI-compatible. Select it via:

```yaml
model:
  provider: gemini
  model: gemini-2.5-flash        # any Gemini model
  api_key_env: GEMINI_API_KEY
  # base_url optional (defaults to https://generativelanguage.googleapis.com)
```

## Details

`internal/model/gemini` implements `providers.ModelProvider` against Gemini's `generateContent` API with native function calling. It mirrors the Anthropic provider:

- Maps RunLore's OpenAI-shaped exchange (assistant `tool_calls` + separate `tool` messages) onto Gemini's `contents`/`parts`: assistant turns → role `model` with `functionCall` parts; tool results coalesced into one role `user` turn of `functionResponse` parts, matched to their originating call by **function name** (Gemini's matching key).
- `system` → `system_instruction`; tools → `functionDeclarations`; `x-goog-api-key` auth; args object↔string conversion in both directions.
- Reuses `internal/httpx.DoWithRetry` (bounded backoff on 429/5xx) and truncates error bodies — consistent with the OpenAI/Anthropic providers.
- Wiring: `buildModel`/`modelProvider` handle `gemini`; a new `modelConfigured()` helper replaces three duplicated "is a model set?" checks so Gemini's built-in default endpoint counts as configured (like Anthropic).

## Note

Gemini also works today via the existing OpenAI-compatible provider (Google ships an OpenAI-compat endpoint). This PR adds the **native** path for full tool-use fidelity, cleaner config, and no dependence on the compat shim.

## Tests / validation

- Unit tests: request mapping (system_instruction / functionDeclarations / contents / URL / auth header) + response mapping (text + functionCall→ToolCall) + tool-result coalescing.
- `go build` · `go vet` · `go test ./... -race` · `golangci-lint` (0 issues) · `gofmt` — all green.
- `generateContent` + function-calling shape verified against the official Gemini API docs (context7).
