### PR TITLE
fix(model): drop empty op enum value rejected by Gemini

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,7 +36,11 @@ knowledge catalog**: a Git repo of markdown files, each with YAML frontmatter. T
 knowledge base — runbooks, past incidents, platform constraints.
 
 1. Create a new (private) Git repo, e.g. `your-org/runlore-kb`.
-2. Add entries as `<slug>.md` at the repo root:
+2. Add entries as markdown files — **one file per entry** (YAML frontmatter + a markdown body). Name
+   each file with a short, descriptive kebab-case **slug** (e.g. `helmrelease-upgrade-failure.md`); the
+   slug is just the entry's identity — not indexed, not a frontmatter field (the Curator names learned
+   entries `slugify(title).md`). Put them at the repo root or in subfolders (`playbooks/`, `incidents/`,
+   …); the whole tree is indexed recursively. Example:
 
    ```markdown
    ---
@@ -53,8 +57,10 @@ knowledge base — runbooks, past incidents, platform constraints.
    - the rendered diff between the two chart versions
    ```
 
-   Filenames `index.md` and `log.md` are reserved and skipped. Seed it with whatever runbooks you
-   already have — the agent gets sharper at *your* platform as the catalog grows.
+   `index.md` and `log.md` are reserved (a human listing + a changelog) and skipped by the indexer — as
+   are dot-files. What `kb_search` actually matches is the frontmatter `title`/`description`/`tags` plus
+   the body, **not** the filename — so write those well. Seed it with whatever runbooks you already
+   have; the agent gets sharper at *your* platform as the catalog grows.
 
 3. **Make it available in-cluster.** Two options:
 

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -43,15 +43,16 @@ func submitFindingsSpec() providers.ToolSpec {
 }
 
 // opEnumJSON renders the executable-op enum for the schema from the canonical
-// registry (providers.Ops, sorted) plus "" (suggestion only), so the model-facing
-// schema can't drift from what the gate and executor actually accept.
+// registry (providers.Ops, sorted), so the model-facing schema can't drift from
+// what the gate and executor actually accept. A "suggestion only" action is
+// expressed by omitting op (it is not a required field) — never by an empty enum
+// value: Gemini's generateContent rejects empty enum members with HTTP 400.
 func opEnumJSON() string {
-	ops := make([]string, 0, len(providers.Ops)+1)
+	ops := make([]string, 0, len(providers.Ops))
 	for op := range providers.Ops {
 		ops = append(ops, op)
 	}
 	sort.Strings(ops)
-	ops = append(ops, "")
 	b, _ := json.Marshal(ops)
 	return string(b)
 }

--- a/internal/investigate/tools_test.go
+++ b/internal/investigate/tools_test.go
@@ -1,6 +1,12 @@
 package investigate
 
-import "testing"
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
 
 func TestParseFindings(t *testing.T) {
 	args := `{"confidence":0.82,"root_causes":[
@@ -17,4 +23,54 @@ func TestParseFindings(t *testing.T) {
 	if rc.Confidence != 0.82 || rc.SuggestedAction != "flux rollback hr/harbor" || !rc.Reversible || len(rc.Evidence) != 2 {
 		t.Fatalf("unexpected root cause: %+v", rc)
 	}
+}
+
+// TestOpEnumNoEmptyValue guards against re-introducing an empty-string enum
+// member: Gemini's generateContent rejects empty enum values with HTTP 400
+// ("enum[n]: cannot be empty"). The op field is optional — "suggestion only" is
+// expressed by omitting it, not by an empty enum value — so the advertised enum
+// must equal the canonical executable-op set exactly.
+func TestOpEnumNoEmptyValue(t *testing.T) {
+	var ops []string
+	if err := json.Unmarshal([]byte(opEnumJSON()), &ops); err != nil {
+		t.Fatalf("opEnumJSON is not valid JSON: %v", err)
+	}
+	if slices.Contains(ops, "") {
+		t.Fatalf("op enum contains an empty value (Gemini rejects it): %q", ops)
+	}
+	want := []string{"reconcile", "resume", "suspend"}
+	if len(ops) != len(providers.Ops) || !slices.Equal(ops, want) {
+		t.Fatalf("op enum = %q, want %q (canonical providers.Ops, sorted)", ops, want)
+	}
+}
+
+// TestSubmitFindingsSchemaNoEmptyEnum walks the whole submit_findings parameter
+// schema and asserts no enum anywhere carries an empty value — the shape sent
+// verbatim to every model provider must be Gemini-compatible.
+func TestSubmitFindingsSchemaNoEmptyEnum(t *testing.T) {
+	var schema any
+	if err := json.Unmarshal([]byte(submitFindingsSpec().Schema), &schema); err != nil {
+		t.Fatalf("submit_findings schema is not valid JSON: %v", err)
+	}
+	var walk func(path string, v any)
+	walk = func(path string, v any) {
+		switch n := v.(type) {
+		case map[string]any:
+			if e, ok := n["enum"].([]any); ok {
+				for i, val := range e {
+					if s, ok := val.(string); ok && s == "" {
+						t.Fatalf("empty enum value at %s.enum[%d]", path, i)
+					}
+				}
+			}
+			for k, child := range n {
+				walk(path+"."+k, child)
+			}
+		case []any:
+			for _, child := range n {
+				walk(path, child)
+			}
+		}
+	}
+	walk("$", schema)
 }


### PR DESCRIPTION
## Problem

Every investigation failed with `provider=gemini`. Gemini's `generateContent` rejects empty enum members with HTTP 400:

```
GenerateContentRequest.tools[0].function_declarations[5].parameters.properties[actions].items.properties[op].enum[3]: cannot be empty
```

The `submit_findings` tool built the `actions[].op` enum from the canonical `providers.Ops` set **plus an empty string** ("suggestion only"). OpenAI/Anthropic tolerate it; Gemini does not.

## Fix

`op` is optional — "suggestion only" is expressed by **omitting** it — so the empty enum value was redundant. Drop it; the advertised enum now equals the canonical executable-op set (`reconcile`, `resume`, `suspend`).

## Tests

- `TestOpEnumNoEmptyValue` — op enum has no empty value and equals `providers.Ops` sorted.
- `TestSubmitFindingsSchemaNoEmptyEnum` — walks the full schema, rejects any empty enum member.

Found while validating a real end-to-end deploy on EKS (Gemini provider, Flux gitops failure trigger).