### PR TITLE
feat(notify): add Slack bot-token (chat.postMessage) delivery

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -393,7 +393,12 @@ func runEval(args []string) error {
 // buildNotifier assembles the configured chat notifiers (best-effort fan-out).
 func buildNotifier(cfg *config.Config, log *slog.Logger) *notify.Multi {
 	var ns []providers.Notifier
-	if env := cfg.Notify.Slack.WebhookURLEnv; env != "" {
+	// Bot token (chat.postMessage) takes precedence over an incoming webhook.
+	if sl := cfg.Notify.Slack; sl.BotTokenEnv != "" && sl.Channel != "" {
+		if tok := os.Getenv(sl.BotTokenEnv); tok != "" {
+			ns = append(ns, notify.NewSlackBot(tok, sl.Channel))
+		}
+	} else if env := cfg.Notify.Slack.WebhookURLEnv; env != "" {
 		if url := os.Getenv(env); url != "" {
 			ns = append(ns, notify.NewSlack(url))
 		}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -212,6 +212,10 @@ config:
   notify:
     slack:
       webhook_url_env: SLACK_WEBHOOK_URL
+      # — or a bot token (chat.postMessage) instead of an incoming webhook; the bot
+      #   must be a member of the channel (invite it / `conversations.join`):
+      # bot_token_env: SLACK_BOT_TOKEN              # xoxb-… (takes precedence over webhook_url_env)
+      # channel: C0123456789                        # channel ID or name to post to
       # signing_secret_env: SLACK_SIGNING_SECRET   # enables rung-2 Approve/Reject buttons
     matrix:
       homeserver: https://matrix.org

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,10 +98,14 @@ type Notify struct {
 	Matrix MatrixNotify `yaml:"matrix"`
 }
 
-// SlackNotify configures Slack incoming-webhook delivery and (for rung-2 actions)
-// interactive approve/reject buttons.
+// SlackNotify configures Slack delivery and (for rung-2 actions) interactive
+// approve/reject buttons. Delivery uses either an incoming webhook (WebhookURLEnv)
+// or a bot token posting to a channel via chat.postMessage (BotTokenEnv+Channel);
+// if both are set, the bot token wins.
 type SlackNotify struct {
-	WebhookURLEnv    string   `yaml:"webhook_url_env"`    // env var holding the webhook URL
+	WebhookURLEnv    string   `yaml:"webhook_url_env"`    // env var holding the incoming-webhook URL
+	BotTokenEnv      string   `yaml:"bot_token_env"`      // env var holding a bot token (xoxb-…) for chat.postMessage
+	Channel          string   `yaml:"channel"`            // channel ID or name to post to (required with bot_token_env)
 	SigningSecretEnv string   `yaml:"signing_secret_env"` // env var with the Slack signing secret (verifies button clicks)
 	ApproverIDs      []string `yaml:"approver_ids"`       // Slack user IDs allowed to approve actions (empty = no Slack approvals)
 }

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -49,6 +49,60 @@ func (s *Slack) Deliver(ctx context.Context, inv providers.Investigation) error 
 	return nil
 }
 
+// SlackBot delivers via the Slack Web API (chat.postMessage) using a bot token,
+// for workspaces that provision a bot app instead of an incoming webhook. Unlike
+// a webhook, chat.postMessage targets an explicit channel and returns HTTP 200
+// with {"ok":false,"error":...} on logical failures (e.g. not_in_channel).
+type SlackBot struct {
+	token   string
+	channel string
+	baseURL string
+	http    *http.Client
+}
+
+// NewSlackBot builds a bot-token Slack notifier posting to channel (ID or name).
+func NewSlackBot(token, channel string) *SlackBot {
+	return &SlackBot{token: token, channel: channel, baseURL: "https://slack.com", http: &http.Client{Timeout: 15 * time.Second}}
+}
+
+var _ providers.Notifier = (*SlackBot)(nil)
+
+// Deliver posts the formatted investigation to the configured channel via
+// chat.postMessage, surfacing both transport and Slack API (ok:false) errors.
+func (s *SlackBot) Deliver(ctx context.Context, inv providers.Investigation) error {
+	msg := slackMessage(inv)
+	msg["channel"] = s.channel
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL+"/api/chat.postMessage", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+s.token)
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack post: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("slack status %d", resp.StatusCode)
+	}
+	var result struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("slack decode response: %w", err)
+	}
+	if !result.OK {
+		return fmt.Errorf("slack chat.postMessage: %s", result.Error)
+	}
+	return nil
+}
+
 // Slack interaction action_ids — must match the server's /slack/interactions handler.
 const (
 	approveActionID = "runlore_approve"

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -29,6 +29,51 @@ func TestSlackDeliver(t *testing.T) {
 	}
 }
 
+func TestSlackBotDeliver(t *testing.T) {
+	var got map[string]any
+	var auth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		if r.URL.Path != "/api/chat.postMessage" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	bot := &SlackBot{token: "xoxb-test", channel: "C123", baseURL: srv.URL, http: srv.Client()}
+	if err := bot.Deliver(context.Background(), sampleInvestigation()); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if auth != "Bearer xoxb-test" {
+		t.Fatalf("auth header = %q, want Bearer xoxb-test", auth)
+	}
+	if got["channel"] != "C123" {
+		t.Fatalf("channel = %v, want C123", got["channel"])
+	}
+	if text, _ := got["text"].(string); !contains(text, "flux rollback hr/harbor") {
+		t.Fatalf("unexpected payload: %v", got)
+	}
+}
+
+func TestSlackBotAPIError(t *testing.T) {
+	// chat.postMessage returns HTTP 200 with ok:false on logical failures
+	// (e.g. not_in_channel) — Deliver must surface that as an error.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":false,"error":"not_in_channel"}`))
+	}))
+	defer srv.Close()
+
+	bot := &SlackBot{token: "xoxb-test", channel: "C123", baseURL: srv.URL, http: srv.Client()}
+	err := bot.Deliver(context.Background(), sampleInvestigation())
+	if err == nil || !contains(err.Error(), "not_in_channel") {
+		t.Fatalf("expected not_in_channel error, got %v", err)
+	}
+}
+
 func contains(s, sub string) bool { return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0) }
 func indexOf(s, sub string) int {
 	for i := 0; i+len(sub) <= len(s); i++ {


### PR DESCRIPTION
## Why

Slack delivery required an incoming **webhook URL**. Workspaces that provision a **bot app** (`xoxb-` token) instead — common when an org centrally manages Slack apps — had no way to deliver findings.

## What

Add a `SlackBot` notifier that posts to a configured channel via the Web API `chat.postMessage`. It surfaces both transport errors and Slack **logical** failures (`chat.postMessage` returns HTTP 200 with `{"ok":false,"error":...}`, e.g. `not_in_channel`).

Config:
```yaml
notify:
  slack:
    bot_token_env: SLACK_BOT_TOKEN   # xoxb-… (takes precedence over webhook_url_env)
    channel: C0123456789             # channel ID or name; bot must be a member
```

When both `bot_token_env`+`channel` and `webhook_url_env` are set, the bot token wins; otherwise behaviour is unchanged. Reuses the existing Block Kit payload (text + approve/reject buttons), adding `channel`.

## Tests

- `TestSlackBotDeliver` — bearer token + channel set, findings rendered.
- `TestSlackBotAPIError` — `ok:false` surfaced as an error.

Part of validating an end-to-end deploy on EKS where the workspace exposes a bot token, not a webhook.