### PR TITLE
fix(investigate): nudge model to submit_findings instead of bailing on prose

### DIFF
--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -72,15 +72,29 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		maxSteps = 8
 	}
 
+	nudged := false
 	for step := 0; step < maxSteps; step++ {
 		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: li.system(), Messages: messages, Tools: specs})
 		if err != nil {
 			return fmt.Errorf("model: %w", err)
 		}
+		li.Log.Debug("investigation step", "title", req.Title, "step", step, "tool_calls", len(resp.ToolCalls), "text_len", len(resp.Text))
 		if len(resp.ToolCalls) == 0 {
-			li.Log.Warn("investigation inconclusive (no submit_findings)", "title", req.Title)
-			return nil
+			// The model concluded in prose instead of calling submit_findings — a
+			// common ReAct failure (Gemini in particular emits a final text turn).
+			// Nudge it once to use the tool rather than discarding the investigation;
+			// only give up if it still won't after the nudge.
+			if nudged {
+				li.Log.Warn("investigation inconclusive (no submit_findings after nudge)", "title", req.Title)
+				return nil
+			}
+			nudged = true
+			messages = append(messages,
+				providers.Message{Role: "assistant", Content: resp.Text},
+				providers.Message{Role: "user", Content: "Record your conclusion now by calling the submit_findings tool (ranked root_causes with evidence, plus anything unresolved). Do not answer in prose."})
+			continue
 		}
+		nudged = false
 		messages = append(messages, providers.Message{Role: "assistant", Content: resp.Text, ToolCalls: resp.ToolCalls})
 		for _, tc := range resp.ToolCalls {
 			if tc.Name == submitFindingsName {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -95,6 +95,53 @@ func TestLoopInvestigatorActionsDisabled(t *testing.T) {
 	}
 }
 
+func TestLoopNudgesOnProseTurn(t *testing.T) {
+	// Some models (Gemini in particular) answer the final turn in prose instead of
+	// calling submit_findings. The loop must nudge once and recover, not give up.
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{Text: "Based on the evidence, the chart bump broke the DB. Confidence ~0.8."}, // prose, no tool call
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName, Args: `{"confidence":0.8,"root_causes":[{"summary":"chart bump broke db"}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil || len(got.RootCauses) != 1 || got.RootCauses[0].Summary != "chart bump broke db" {
+		t.Fatalf("nudge did not recover findings: %+v", got)
+	}
+	if model.i != 2 {
+		t.Fatalf("expected 2 model calls (prose + nudged submit), got %d", model.i)
+	}
+}
+
+func TestLoopInconclusiveAfterNudge(t *testing.T) {
+	// If the model still won't call a tool after the nudge, give up — don't loop forever.
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{Text: "I think it's the database."},
+		{Text: "Still just the database, no tool call."},
+	}}
+	var delivered bool
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(providers.Investigation) { delivered = true },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if delivered {
+		t.Fatal("expected no delivery when the model never calls submit_findings")
+	}
+	if model.i != 2 {
+		t.Fatalf("expected exactly 2 model calls (initial + one nudge), got %d", model.i)
+	}
+}
+
 // scriptModel returns a fixed sequence of responses, ignoring its input.
 type scriptModel struct {
 	responses []providers.CompletionResponse


### PR DESCRIPTION
## Problem

Found during an end-to-end deploy on EKS with `provider: gemini`. After the enum fix (#40), investigations reached the model and ran tools, but **every one ended** `investigation inconclusive (no submit_findings)` — both GitOps-failure-triggered and webhook-triggered.

Root cause: the ReAct loop treated **any** model turn with zero tool calls as terminal and discarded the investigation. Gemini routinely answers the final turn in **prose** ("Based on the evidence, the root cause is …") instead of calling `submit_findings` — so fully-investigated incidents were thrown away.

## Fix

When a turn has no tool calls, append the model's prose + a short instruction to record its conclusion via `submit_findings`, and continue. Give up only if it **still** won't call a tool after that single nudge (bounded — no infinite loop). Adds a per-step debug log.

## Tests

- `TestLoopNudgesOnProseTurn` — prose turn → nudge → `submit_findings` completes (OnComplete fires).
- `TestLoopInconclusiveAfterNudge` — two prose turns → no delivery, exactly one nudge.

Verified with a deterministic fake model; also exercised against the live cluster (Gemini, real Flux/metrics/logs tools).