### PR TITLE
ci: speed up image build (amd64-only, Go cache mounts, concurrency)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,6 +26,13 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/runlore
 
+# Serialize builds per ref so concurrent pushes can't race on the mutable :main
+# tag (last-to-finish wins, which silently published a stale image). PR builds are
+# superseded — cancel the in-flight one; branch/tag pushes each run to completion.
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-push:
     name: Build and push
@@ -73,7 +80,10 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          # amd64-only: the target clusters run amd64 nodes, and arm64 under QEMU
+          # emulation dominated build time (~10x slower Go compile). Reintroduce via
+          # a native-arm runner matrix + manifest merge if multi-arch is needed.
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -108,7 +118,7 @@ jobs:
             echo ""
             echo "**Trigger**: ${{ github.event_name }}"
             echo "**Commit**: \`${{ github.sha }}\`"
-            echo "**Platforms**: linux/amd64, linux/arm64"
+            echo "**Platforms**: linux/amd64"
             echo ""
             echo "**Tags**:"
             echo '```'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,16 @@
 FROM golang:1.26 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
-RUN go mod download
+# Cache the module download and the compiler cache across builds (BuildKit cache
+# mounts, persisted via cache-to in CI) so an unchanged dependency set or source
+# tree doesn't recompile from scratch.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 COPY . .
 ARG VERSION=dev
-RUN CGO_ENABLED=0 go build -trimpath \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -trimpath \
       -ldflags "-s -w -X main.version=${VERSION}" \
       -o /out/lore ./cmd/lore
 


### PR DESCRIPTION
## Problem

The image build took **~13–15 min**, dominated by building `linux/arm64` under **QEMU emulation** (~10× slower Go compile). Two concurrent `main` pushes also **raced on the mutable `:main` tag** — the last build to finish won, silently publishing a stale image.

## Changes

1. **amd64-only** — target clusters run amd64 nodes; drop the QEMU arm64 build. (Reintroduce multi-arch later via a native-arm runner matrix + manifest merge if needed — no emulation.)
2. **Go cache mounts** in the Dockerfile (`/go/pkg/mod` + `/root/.cache/go-build`), persisted via the existing `cache-to: type=gha` — unchanged deps/source no longer recompile from scratch.
3. **`concurrency` group per ref** — serialize branch/tag builds (fixes the `:main` race), cancel superseded PR builds.

## Expected impact

~13–15 min → **~2–3 min cold, <90s warm**.

## Note

Deployments should pin to the immutable `sha-<commit>` tag rather than `:main` (mutable) — surfaced during an end-to-end validation where the `:main` race served a stale image.