### PR TITLE
feat(notify): richer Slack Block Kit message + KB link

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -702,15 +702,17 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 			}
 			log.Info("findings",
 				"confidence", found.Confidence, "root_causes", len(found.RootCauses), "unresolved", len(found.Unresolved))
-			if err := notifier.Deliver(context.Background(), found); err != nil {
-				log.Error("deliver findings", "err", err)
-			}
+			// Curate first so the delivered message can link to the KB issue/PR.
 			if cur != nil {
 				if ref, err := cur.Curate(context.Background(), found); err != nil {
 					log.Error("curate findings", "err", err)
 				} else if ref.URL != "" {
+					found.CuratedURL = ref.URL
 					log.Info("curated", "url", ref.URL)
 				}
+			}
+			if err := notifier.Deliver(context.Background(), found); err != nil {
+				log.Error("deliver findings", "err", err)
 			}
 		},
 	}

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -42,5 +42,8 @@ func Format(inv providers.Investigation) string {
 			fmt.Fprintf(&b, "   • %s%s\n", a.Description, rev)
 		}
 	}
+	if inv.CuratedURL != "" {
+		fmt.Fprintf(&b, "📚 Knowledge base: %s\n", inv.CuratedURL)
+	}
 	return b.String()
 }

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -109,17 +110,87 @@ const (
 	rejectActionID  = "runlore_reject"
 )
 
-// slackMessage builds the webhook payload: always a text fallback, plus Block Kit
-// Approve/Reject buttons for any action carrying an ApprovalID (rung-2).
+// slackMessage builds the Slack payload: a Block Kit layout (header, confidence
+// badge, ranked root causes with evidence, suggested next steps, open questions,
+// KB link) plus a plain-text fallback (used for notifications/accessibility and by
+// clients that don't render blocks). Actions carrying an ApprovalID also get
+// interactive Approve/Reject buttons (rung-2).
 func slackMessage(inv providers.Investigation) map[string]any {
-	text := Format(inv)
-	msg := map[string]any{"text": text}
-	var actionBlocks []map[string]any
+	return map[string]any{"text": Format(inv), "blocks": slackBlocks(inv)}
+}
+
+// slackBlocks renders the investigation as Block Kit. Designed to read top-down as
+// an on-call would triage: what happened → how sure → why → what to do → what's
+// still open.
+func slackBlocks(inv providers.Investigation) []map[string]any {
+	title := inv.Title
+	if title == "" {
+		title = "Investigation"
+	}
+	emoji, level, pct := confidenceBadge(inv)
+	blocks := []map[string]any{
+		{"type": "header", "text": map[string]any{"type": "plain_text", "text": truncate("🔍 "+title, 150), "emoji": true}},
+		{"type": "context", "elements": []map[string]any{
+			{"type": "mrkdwn", "text": fmt.Sprintf("%s *%s confidence* · %d%%  ·  🤖 RunLore SRE agent", emoji, level, pct)}}},
+	}
+
+	// Ranked root causes, each with what-changed + evidence.
+	for i, rc := range inv.RootCauses {
+		if i >= 5 {
+			break
+		}
+		var s strings.Builder
+		fmt.Fprintf(&s, "*%d. %s*  `%.0f%%`", i+1, rc.Summary, rc.Confidence*100)
+		if rc.ChangeRef != "" {
+			fmt.Fprintf(&s, "\n📦 *What changed:* `%s`", rc.ChangeRef)
+		}
+		for j, e := range rc.Evidence {
+			if j >= 4 {
+				fmt.Fprintf(&s, "\n• _…%d more_", len(rc.Evidence)-j)
+				break
+			}
+			fmt.Fprintf(&s, "\n• %s", e)
+		}
+		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
+	}
+
+	// Suggested next steps — the resolution guide. Combines per-root-cause
+	// suggestions and any policy-surfaced actions, de-duplicated, reversibility flagged.
+	if steps := nextSteps(inv); len(steps) > 0 {
+		var s strings.Builder
+		s.WriteString("*🛠 Suggested next steps*  _(read-only — RunLore won't apply these)_")
+		for _, st := range steps {
+			fmt.Fprintf(&s, "\n• %s", st)
+		}
+		blocks = append(blocks,
+			map[string]any{"type": "divider"},
+			map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
+	}
+
+	if len(inv.Unresolved) > 0 {
+		var s strings.Builder
+		s.WriteString("*❓ Open questions* _(needs a human)_")
+		for i, u := range inv.Unresolved {
+			if i >= 5 {
+				fmt.Fprintf(&s, "\n• _…%d more_", len(inv.Unresolved)-i)
+				break
+			}
+			fmt.Fprintf(&s, "\n• %s", u)
+		}
+		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
+	}
+
+	if inv.CuratedURL != "" {
+		blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
+			{"type": "mrkdwn", "text": fmt.Sprintf("📚 Logged to the knowledge base — <%s|view entry>", inv.CuratedURL)}}})
+	}
+
+	// Interactive Approve/Reject for any action awaiting approval (rung-2).
 	for _, a := range inv.Actions {
 		if a.ApprovalID == "" {
 			continue
 		}
-		actionBlocks = append(actionBlocks,
+		blocks = append(blocks,
 			map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": "*Proposed action:* " + a.Description}},
 			map[string]any{"type": "actions", "elements": []map[string]any{
 				{"type": "button", "style": "primary", "action_id": approveActionID, "value": a.ApprovalID,
@@ -129,11 +200,63 @@ func slackMessage(inv providers.Investigation) map[string]any {
 			}},
 		)
 	}
-	if len(actionBlocks) > 0 {
-		blocks := []map[string]any{{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": text}}}
-		msg["blocks"] = append(blocks, actionBlocks...)
+	return blocks
+}
+
+// confidenceBadge returns a visual confidence indicator. The headline confidence
+// is the max of the overall score and the top root cause's — models frequently
+// leave the top-level field at 0 while ranking a high-confidence root cause, and
+// showing "0%" next to an 80% root cause reads as broken.
+func confidenceBadge(inv providers.Investigation) (emoji, level string, pct int) {
+	c := inv.Confidence
+	for _, rc := range inv.RootCauses {
+		if rc.Confidence > c {
+			c = rc.Confidence
+		}
 	}
-	return msg
+	pct = int(c*100 + 0.5)
+	switch {
+	case c >= 0.7:
+		return "🟢", "High", pct
+	case c >= 0.4:
+		return "🟡", "Medium", pct
+	default:
+		return "🔴", "Low", pct
+	}
+}
+
+// nextSteps collects the actionable remediations (root-cause suggestions + policy
+// actions), de-duplicated and reversibility-flagged, preserving order.
+func nextSteps(inv providers.Investigation) []string {
+	var steps []string
+	seen := map[string]bool{}
+	add := func(desc string, reversible bool) {
+		if desc == "" || seen[desc] {
+			return
+		}
+		seen[desc] = true
+		if reversible {
+			desc += "  _(reversible)_"
+		}
+		steps = append(steps, desc)
+	}
+	for _, rc := range inv.RootCauses {
+		add(rc.SuggestedAction, rc.Reversible)
+	}
+	for _, a := range inv.Actions {
+		add(a.Description, a.Reversible)
+	}
+	return steps
+}
+
+// truncate caps a string to n runes, appending an ellipsis when cut (Slack section
+// text is limited to 3000 chars).
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
 }
 
 // Multi delivers to several notifiers, best-effort: a failing notifier is logged,

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -92,20 +92,48 @@ func (failingNotifier) Deliver(context.Context, providers.Investigation) error {
 }
 
 func TestSlackMessageButtons(t *testing.T) {
-	// No ApprovalID → plain text, no interactive blocks.
-	m := slackMessage(providers.Investigation{Confidence: 0.5, Actions: []providers.Action{{Description: "x"}}})
-	if _, ok := m["blocks"]; ok {
-		t.Fatal("did not expect blocks without an ApprovalID")
+	// No ApprovalID → rich blocks, but no interactive Approve/Reject elements.
+	m := slackMessage(providers.Investigation{Confidence: 0.5, RootCauses: []providers.Hypothesis{{Summary: "x"}}, Actions: []providers.Action{{Description: "x"}}})
+	raw, _ := json.Marshal(m)
+	if contains(string(raw), "runlore_approve") {
+		t.Fatalf("did not expect Approve/Reject buttons without an ApprovalID:\n%s", raw)
 	}
 	// With ApprovalID → Block Kit Approve/Reject buttons carrying the id.
 	m = slackMessage(providers.Investigation{Confidence: 0.9, Actions: []providers.Action{{Description: "suspend ks/apps", ApprovalID: "a7"}}})
 	if _, ok := m["blocks"]; !ok {
 		t.Fatal("expected interactive blocks for a pending action")
 	}
-	raw, _ := json.Marshal(m)
+	raw, _ = json.Marshal(m)
 	for _, want := range []string{"runlore_approve", "runlore_reject", `"value":"a7"`, "Approve", "Reject"} {
 		if !contains(string(raw), want) {
 			t.Fatalf("rendered message missing %q:\n%s", want, raw)
+		}
+	}
+}
+
+func TestSlackBlocksLayout(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "VictoriaTracesDown",
+		Confidence: 0, // model left top-level at 0 …
+		RootCauses: []providers.Hypothesis{{
+			Summary: "crds sync broke victoria-traces", Confidence: 0.8, // … but a root cause is 80%
+			ChangeRef: "crds@abc123", Evidence: []string{"reconcile failed", "stalled resources"},
+			SuggestedAction: "flux rollback hr/victoria-traces", Reversible: true,
+		}},
+		Unresolved: []string{"why the migration stalled"},
+		CuratedURL: "https://github.com/o/r/issues/9",
+	}
+	blocks := slackBlocks(inv)
+	if blocks[0]["type"] != "header" {
+		t.Fatalf("first block must be a header, got %v", blocks[0]["type"])
+	}
+	raw, _ := json.Marshal(blocks)
+	s := string(raw)
+	// Headline confidence falls back to the top root cause (80%, High), not the 0% top-level.
+	for _, want := range []string{"VictoriaTracesDown", "High confidence", "80%", "What changed", "crds@abc123",
+		"Suggested next steps", "flux rollback hr/victoria-traces", "(reversible)", "Open questions", "view entry"} {
+		if !contains(s, want) {
+			t.Fatalf("blocks missing %q:\n%s", want, s)
 		}
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -238,6 +238,7 @@ type Investigation struct {
 	Unresolved []string // honest: what the agent could not determine
 	Confidence float64
 	Actions    []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
+	CuratedURL string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
 }
 
 // Hypothesis is one ranked root-cause candidate with its evidence.


### PR DESCRIPTION
## Why

The first real Slack notification was a dense plain-text blob — hard to scan, weak as a resolution guide, and showed a misleading "0% confidence" next to an 80% root cause. (Feedback from live testing.)

## What

Rebuild Slack delivery as **Block Kit**, structured the way an on-call triages — *what happened → how sure → why → what to do → what's open*:

- **Header** with the incident title + a **confidence badge** (🟢/🟡/🔴 High/Medium/Low %). The headline confidence falls back to the top root cause's score — models routinely leave the top-level field at 0 while ranking a high-confidence root cause.
- **Ranked root causes**, each with a *📦 What changed* line and capped evidence bullets.
- **🛠 Suggested next steps** — the resolution guide — merging per-root-cause suggestions + policy actions, de-duplicated, reversibility-flagged.
- **❓ Open questions** for what needs a human.
- **📚 KB link**: curation now runs *before* delivery so the message links the logged issue/PR (new `Investigation.CuratedURL`).

Approve/Reject buttons (rung-2) preserved. Plain-text fallback (`Format`, also used by Matrix) retained for notifications/accessibility, now with the KB link.

## Tested

- Unit: block layout, confidence fallback (0% top-level → High from 80% root cause), buttons only with a pending ApprovalID.
- Live: posted to a real Slack channel from `lore serve` against the cluster; confident finding (0.9) curated as PR + linked in the message.