### PR TITLE
feat(investigate): add controller_logs tool + RBAC for deep introspection

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/Smana/runlore/internal/network/hubble"
 	"github.com/Smana/runlore/internal/notify"
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/providers/cluster"
 	"github.com/Smana/runlore/internal/providers/gitops/argocd"
 	"github.com/Smana/runlore/internal/providers/gitops/flux"
 	"github.com/Smana/runlore/internal/server"
@@ -596,7 +597,26 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	if cfg.Network.URL != "" {
 		tools = append(tools, investigate.NetworkDropsTool{Network: hubble.New(cfg.Network.URL)})
 	}
+	// Read-only controller-log access (Flux controllers), when a cluster is reachable.
+	if cs := kubeClientset(log); cs != nil {
+		tools = append(tools, investigate.ControllerLogsTool{Logs: cluster.New(cs)})
+	}
 	return model, tools, recall
+}
+
+// kubeClientset builds a read-only clientset for pod-log access, or nil when no
+// cluster is reachable (e.g. local runs without a kubeconfig).
+func kubeClientset(log *slog.Logger) *kubernetes.Clientset {
+	restCfg, err := restConfig()
+	if err != nil {
+		return nil
+	}
+	cs, err := kubernetes.NewForConfig(restCfg)
+	if err != nil {
+		log.Warn("clientset unavailable; controller_logs disabled", "err", err)
+		return nil
+	}
+	return cs
 }
 
 // gitOpsFromKube builds the GitOps provider from the ambient kubeconfig (best-effort).

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -13,6 +13,21 @@ rules:
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["gitrepositories"]
     verbs: ["get", "list", "watch"]
+  # Deep read-only introspection (flux_resource_status / flux_tree): HelmReleases,
+  # the other Flux source kinds, and Events.
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["ocirepositories", "helmrepositories", "helmcharts", "buckets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+  # controller_logs: read Flux controller pod logs (read-only).
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
   # Argo CD engine (config.gitops.engine: argocd)
   - apiGroups: ["argoproj.io"]
     resources: ["applications"]

--- a/internal/investigate/controllerlogs_tool.go
+++ b/internal/investigate/controllerlogs_tool.go
@@ -1,0 +1,79 @@
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fluxControllerNamespace is where Flux controllers run by convention.
+const fluxControllerNamespace = "flux-system"
+
+// ControllerLogsTool reads recent logs from a Flux controller, optionally filtered
+// to a resource name — surfacing WHY a source/object failed to reconcile (auth,
+// reference not found, build error) when resource status alone isn't enough.
+type ControllerLogsTool struct {
+	Logs providers.LogReader
+}
+
+// Name returns the tool name.
+func (t ControllerLogsTool) Name() string { return "controller_logs" }
+
+// Description returns the tool description.
+func (t ControllerLogsTool) Description() string {
+	return "Read recent logs from a Flux controller (source-controller, kustomize-controller, " +
+		"helm-controller, notification-controller), optionally filtered to a resource name, over a " +
+		"window (default 30m). Use it to learn WHY a source/object failed — e.g. a GitRepository that " +
+		"was never created, an auth or checkout error — when flux_resource_status isn't enough."
+}
+
+// Schema returns the JSON schema for the arguments.
+func (t ControllerLogsTool) Schema() string {
+	return `{"type":"object","properties":` +
+		`{"controller":{"type":"string","enum":["source-controller","kustomize-controller","helm-controller","notification-controller"]},` +
+		`"resource":{"type":"string","description":"optional: only lines mentioning this name"},` +
+		`"since_minutes":{"type":"integer"}},"required":["controller"]}`
+}
+
+// Call fetches and renders the controller's recent logs.
+func (t ControllerLogsTool) Call(ctx context.Context, args string) (string, error) {
+	var in struct {
+		Controller   string `json:"controller"`
+		Resource     string `json:"resource"`
+		SinceMinutes int    `json:"since_minutes"`
+	}
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	if in.Controller == "" {
+		return "", fmt.Errorf("controller is required")
+	}
+	since := in.SinceMinutes
+	if since <= 0 {
+		since = 30
+	}
+	lines, err := t.Logs.PodLogs(ctx, fluxControllerNamespace, "app="+in.Controller, since)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	n := 0
+	for _, l := range lines {
+		if in.Resource != "" && !strings.Contains(l.Message, in.Resource) {
+			continue
+		}
+		if n >= maxToolRows {
+			fmt.Fprintf(&b, "… (more lines truncated)\n")
+			break
+		}
+		fmt.Fprintln(&b, l.Message)
+		n++
+	}
+	if b.Len() == 0 {
+		return "no matching controller log lines", nil
+	}
+	return b.String(), nil
+}

--- a/internal/investigate/controllerlogs_tool_test.go
+++ b/internal/investigate/controllerlogs_tool_test.go
@@ -1,0 +1,63 @@
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeLogReader returns canned pod-log lines and records the call.
+type fakeLogReader struct {
+	lines              providers.LogResult
+	gotNS, gotSelector string
+	gotSince           int
+}
+
+func (f *fakeLogReader) PodLogs(_ context.Context, namespace, labelSelector string, sinceMinutes int) (providers.LogResult, error) {
+	f.gotNS, f.gotSelector, f.gotSince = namespace, labelSelector, sinceMinutes
+	return f.lines, nil
+}
+
+func TestControllerLogsTool(t *testing.T) {
+	r := &fakeLogReader{lines: providers.LogResult{
+		{Message: "source-controller-1: ERROR GitRepository/infra-artifact failed to checkout: reference not found"},
+		{Message: "source-controller-1: INFO reconciliation finished"},
+	}}
+	tool := ControllerLogsTool{Logs: r}
+	if tool.Name() != "controller_logs" {
+		t.Fatalf("name=%q", tool.Name())
+	}
+	out, err := tool.Call(context.Background(), `{"controller":"source-controller","resource":"infra-artifact","since_minutes":15}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	// Scoping: queried flux-system with the controller's app selector and our window.
+	if r.gotNS != "flux-system" || r.gotSelector != "app=source-controller" || r.gotSince != 15 {
+		t.Fatalf("unexpected query: ns=%q selector=%q since=%d", r.gotNS, r.gotSelector, r.gotSince)
+	}
+	// Resource filter keeps only the matching line.
+	if !strings.Contains(out, "reference not found") {
+		t.Fatalf("expected the matching line, got:\n%s", out)
+	}
+	if strings.Contains(out, "reconciliation finished") {
+		t.Fatalf("resource filter should have excluded the non-matching line:\n%s", out)
+	}
+}
+
+func TestControllerLogsToolDefaultsAndEmpty(t *testing.T) {
+	r := &fakeLogReader{lines: providers.LogResult{{Message: "x: line"}}}
+	tool := ControllerLogsTool{Logs: r}
+	// since defaults to 30 when unset; a resource filter with no match → friendly message.
+	out, err := tool.Call(context.Background(), `{"controller":"kustomize-controller","resource":"nope"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if r.gotSince != 30 {
+		t.Fatalf("since default = %d, want 30", r.gotSince)
+	}
+	if !strings.Contains(out, "no matching controller log lines") {
+		t.Fatalf("expected empty message, got: %s", out)
+	}
+}

--- a/internal/providers/cluster/cluster.go
+++ b/internal/providers/cluster/cluster.go
@@ -1,0 +1,65 @@
+// Package cluster reads Kubernetes pod logs for investigation (read-only) via the
+// client-go CoreV1 GetLogs API. It backs the controller_logs tool, which surfaces
+// why a Flux controller failed to reconcile a source/object.
+package cluster
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const (
+	maxPods   = 5   // bound the fan-out across matching pods
+	tailLines = 300 // per-pod tail cap (bounded fetch)
+)
+
+// Reader reads pod logs via a client-go clientset (read-only).
+type Reader struct{ client kubernetes.Interface }
+
+// New builds a log Reader from a clientset.
+func New(client kubernetes.Interface) *Reader { return &Reader{client: client} }
+
+var _ providers.LogReader = (*Reader)(nil)
+
+// PodLogs returns recent log lines from up to maxPods pods matching labelSelector
+// in namespace, bounded to the last sinceMinutes. Each line is prefixed with its
+// pod name. Best-effort: a pod whose log stream fails is skipped, not fatal.
+func (r *Reader) PodLogs(ctx context.Context, namespace, labelSelector string, sinceMinutes int) (providers.LogResult, error) {
+	pods, err := r.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("list pods (%s/%s): %w", namespace, labelSelector, err)
+	}
+	var since *int64
+	if sinceMinutes > 0 {
+		s := int64(sinceMinutes) * 60
+		since = &s
+	}
+	tail := int64(tailLines)
+	var out providers.LogResult
+	for i := range pods.Items {
+		if i >= maxPods {
+			break
+		}
+		name := pods.Items[i].Name
+		stream, err := r.client.CoreV1().Pods(namespace).
+			GetLogs(name, &corev1.PodLogOptions{SinceSeconds: since, TailLines: &tail}).
+			Stream(ctx)
+		if err != nil {
+			continue
+		}
+		sc := bufio.NewScanner(stream)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			out = append(out, providers.LogLine{Message: name + ": " + sc.Text()})
+		}
+		_ = stream.Close()
+	}
+	return out, nil
+}

--- a/internal/providers/cluster/cluster_test.go
+++ b/internal/providers/cluster/cluster_test.go
@@ -1,0 +1,41 @@
+package cluster
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestPodLogs(t *testing.T) {
+	pod := func(name string, labels map[string]string) *corev1.Pod {
+		return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "flux-system", Labels: labels}}
+	}
+	client := fake.NewSimpleClientset(
+		pod("source-controller-1", map[string]string{"app": "source-controller"}),
+		pod("kustomize-controller-1", map[string]string{"app": "kustomize-controller"}),
+	)
+	r := New(client)
+
+	lines, err := r.PodLogs(context.Background(), "flux-system", "app=source-controller", 30)
+	if err != nil {
+		t.Fatalf("PodLogs: %v", err)
+	}
+	if len(lines) == 0 {
+		t.Fatal("expected log lines from the matching pod")
+	}
+	joined := ""
+	for _, l := range lines {
+		joined += l.Message + "\n"
+	}
+	// Only the label-matched pod's logs are returned (scoping), prefixed by pod name.
+	if !strings.Contains(joined, "source-controller-1:") {
+		t.Fatalf("expected source-controller-1 logs, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "kustomize-controller-1:") {
+		t.Fatalf("label selector leaked another pod's logs:\n%s", joined)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -189,6 +189,14 @@ type NetworkProvider interface {
 	Drops(ctx context.Context, sel Selector, w TimeWindow) (LogResult, error)
 }
 
+// LogReader reads recent pod logs from the cluster (read-only), backing the
+// controller_logs investigation tool. Implemented with client-go CoreV1 GetLogs.
+type LogReader interface {
+	// PodLogs returns recent log lines from pods matching labelSelector in
+	// namespace, bounded to the last sinceMinutes (0 = no lower bound).
+	PodLogs(ctx context.Context, namespace, labelSelector string, sinceMinutes int) (LogResult, error)
+}
+
 // CloudProvider abstracts cloud-side context for an incident (managed-DB status,
 // instance/node health, load-balancer/target health, recent cloud events).
 //


### PR DESCRIPTION
## Why

The Flux-depth findings repeatedly bottomed out at *"pod events and logs required"* — `flux_resource_status` tells you a resource is failing and its conditions, but not **why** the underlying source/object failed (checkout/auth error, never created). `controller_logs` closes that gap (phase 2 of the depth brief).

## What

- **`controller_logs` tool** — reads recent logs from a Flux controller (`source-controller`/`kustomize-controller`/`helm-controller`/`notification-controller`), optional `resource` grep, `since_minutes` window. Maps the controller to its `app=` selector in `flux-system`.
- **`providers.LogReader`** — read-only, backed by client-go `CoreV1 GetLogs` (`internal/providers/cluster`), bounded by maxPods + tailLines. Built from the existing rest config; gated off when no cluster is reachable.
- **RBAC** — the ClusterRole now grants read on `helmreleases`, the other Flux source kinds, `events`, and `pods`/`pods/log`. These are needed by `flux_resource_status`/`flux_tree`/`controller_logs`; without them the in-cluster SA gets `forbidden`.

All read-only (no new mutating verbs).

## Tests

- `PodLogs` against a fake clientset: label scoping (other pods excluded), pod-name prefix.
- Tool against a fake reader: namespace/selector/window construction, resource filter, `since` default, empty message.

Quality gate green (build, vet, test, gofmt, golangci-lint 0 issues).