### PR TITLE
fix(chart): raise default memory (256Mi OOMKills under real load)

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -101,13 +101,17 @@ networkPolicy:
   enabled: true
   extraEgress: []   # appended verbatim, e.g. a specific model endpoint CIDR
 
+# The agent runs cluster-wide informers (Kustomizations/HelmReleases), a bleve
+# catalog index, a git-sync mirror, and multi-tool LLM investigations. 256Mi
+# OOMKills under real load — these defaults give headroom; CPU stays modest
+# (mostly idle, with occasional LLM calls).
 resources:
   requests:
     cpu: 50m
-    memory: 64Mi
+    memory: 192Mi
   limits:
     cpu: "1"
-    memory: 256Mi
+    memory: 768Mi
 
 # Restricted PSS-compliant defaults.
 podSecurityContext:


### PR DESCRIPTION
## Why

On a real cluster the pod was `OOMKilled` (exit 137) at the **256Mi** default. The agent runs cluster-wide informers (Kustomizations/HelmReleases), a bleve catalog index, a git-sync mirror, and multi-tool LLM investigations — 256Mi isn't enough.

## What

Defaults: requests `64Mi → 192Mi`, limit `256Mi → 768Mi`. CPU unchanged (mostly idle, occasional LLM calls). Chart-only; users can still override.

Found during live end-to-end validation on EKS.