### PR TITLE
fix(gitops/flux): resolve ExternalArtifact/OCI sources, not just GitRepository

### DIFF
--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -22,13 +22,14 @@ var (
 
 // kindToGVR maps the Flux Kinds the inspector understands to their GVR.
 var kindToGVR = map[string]schema.GroupVersionResource{
-	"Kustomization":  kustomizationGVR,
-	"GitRepository":  gitRepositoryGVR,
-	"HelmRelease":    {Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
-	"OCIRepository":  {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"},
-	"HelmRepository": {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"},
-	"HelmChart":      {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmcharts"},
-	"Bucket":         {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "buckets"},
+	"Kustomization":    kustomizationGVR,
+	"GitRepository":    gitRepositoryGVR,
+	"HelmRelease":      {Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
+	"OCIRepository":    {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"},
+	"HelmRepository":   {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"},
+	"HelmChart":        {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmcharts"},
+	"Bucket":           {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "buckets"},
+	"ExternalArtifact": {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "externalartifacts"},
 }
 
 // dynamicReader reads Flux CRDs as unstructured objects via the dynamic client.
@@ -167,6 +168,7 @@ func (r *dynamicReader) WatchKustomizations(ctx context.Context) (<-chan Kustomi
 // minimal kustomization type.
 func kustomizationFromUnstructured(u *unstructured.Unstructured) kustomization {
 	path, _, _ := unstructured.NestedString(u.Object, "spec", "path")
+	srcKind, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "kind")
 	srcName, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "name")
 	srcNamespace, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "namespace")
 	rev, _, _ := unstructured.NestedString(u.Object, "status", "lastAppliedRevision")
@@ -179,6 +181,7 @@ func kustomizationFromUnstructured(u *unstructured.Unstructured) kustomization {
 		Name:            u.GetName(),
 		Namespace:       namespace,
 		Path:            path,
+		SourceKind:      srcKind,
 		SourceName:      srcName,
 		SourceNamespace: srcNamespace,
 		Revision:        rev,

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -19,6 +19,7 @@ import (
 type kustomization struct {
 	Name, Namespace string
 	Path            string // spec.path
+	SourceKind      string // spec.sourceRef.kind (GitRepository | OCIRepository | Bucket | ExternalArtifact)
 	SourceName      string // spec.sourceRef.name
 	SourceNamespace string // spec.sourceRef.namespace (defaults to the Kustomization namespace)
 	Revision        string // status.lastAppliedRevision
@@ -82,29 +83,47 @@ func (p *Provider) Changes(ctx context.Context, _ providers.TimeWindow, sel prov
 		if sel.Name != "" && k.Name != sel.Name {
 			continue
 		}
-		if k.Path == "" || k.Revision == "" || k.SourceName == "" {
-			continue // not enough to locate a source diff
+		if k.Revision == "" || k.SourceName == "" {
+			continue // nothing applied yet / no source to attribute the change to
 		}
-		key := k.SourceNamespace + "/" + k.SourceName
-		url, ok := urlCache[key]
-		if !ok {
-			gr, err := p.reader.GetGitRepository(ctx, k.SourceNamespace, k.SourceName)
-			if err != nil {
-				return nil, err
+		isGit := k.SourceKind == "" || k.SourceKind == "GitRepository"
+		// Only a GitRepository source has a Git URL we can diff. Other source kinds
+		// (OCIRepository, Bucket, ExternalArtifact — e.g. ArtifactGenerator output)
+		// still produced a change worth reporting; emit it without a diffable URL
+		// rather than erroring the whole lookup (which is what made "what changed"
+		// fail on ArtifactGenerator-based GitOps).
+		url := ""
+		if isGit {
+			if k.Path == "" {
+				continue // a GitRepository change with no path can't be located for a diff
 			}
-			url = gr.URL
-			urlCache[key] = url
-		}
-		if url == "" {
-			continue
+			key := k.SourceNamespace + "/" + k.SourceName
+			cached, ok := urlCache[key]
+			if !ok {
+				gr, err := p.reader.GetGitRepository(ctx, k.SourceNamespace, k.SourceName)
+				if err != nil {
+					continue // source not resolvable (missing/transient) — skip, don't abort
+				}
+				cached = gr.URL
+				urlCache[key] = cached
+			}
+			if cached == "" {
+				continue
+			}
+			url = cached
 		}
 		changes = append(changes, mapKustomization(k, url))
 	}
 	return changes, nil
 }
 
-// Diff resolves a Change's diff via the Differ.
+// Diff resolves a Change's diff via the Differ. Changes from a non-Git source
+// (OCIRepository/Bucket/ExternalArtifact) carry no Git URL — there is no Git diff
+// to show, so return an empty diff rather than failing.
 func (p *Provider) Diff(_ context.Context, c providers.Change) (providers.Diff, error) {
+	if c.Source.RepoURL == "" {
+		return providers.Diff{}, nil
+	}
 	return p.differ.ForChange(c)
 }
 

--- a/internal/providers/gitops/flux/flux_test.go
+++ b/internal/providers/gitops/flux/flux_test.go
@@ -83,6 +83,36 @@ func TestProviderChanges(t *testing.T) {
 	}
 }
 
+func TestProviderChangesExternalArtifactSource(t *testing.T) {
+	// A Kustomization sourced from an ExternalArtifact (ArtifactGenerator output)
+	// must still produce a change — without erroring on a missing GitRepository,
+	// which is what broke "what changed" on ArtifactGenerator-based GitOps.
+	r := fakeReader{
+		ks: []kustomization{
+			{Name: "crossplane-configuration", Namespace: "flux-system", Path: ".",
+				SourceKind: "ExternalArtifact", SourceName: "infra-artifact", SourceNamespace: "flux-system",
+				Revision: "sha256:abc"},
+		},
+		grs: map[string]gitRepository{}, // no GitRepository exists — must NOT cause an error
+	}
+	p := New(r, &whatchanged.Differ{})
+	changes, err := p.Changes(context.Background(), providers.TimeWindow{}, providers.Selector{})
+	if err != nil {
+		t.Fatalf("Changes must not error on a non-Git source: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Workload.Name != "crossplane-configuration" {
+		t.Fatalf("expected 1 change for the ExternalArtifact-sourced Kustomization, got %+v", changes)
+	}
+	if changes[0].Source.RepoURL != "" {
+		t.Fatalf("non-Git source should have no RepoURL, got %q", changes[0].Source.RepoURL)
+	}
+	// And its diff is an empty (no-op) result, not an error.
+	d, derr := p.Diff(context.Background(), changes[0])
+	if derr != nil || len(d.Files) != 0 {
+		t.Fatalf("expected empty diff for non-Git source, got files=%d err=%v", len(d.Files), derr)
+	}
+}
+
 func TestProviderChangesSelector(t *testing.T) {
 	r := fakeReader{
 		ks: []kustomization{


### PR DESCRIPTION
## Why

On ArtifactGenerator-based GitOps (this platform), Kustomization sources are **`ExternalArtifact`** (e.g. `infra-artifact`), not `GitRepository`. The Flux provider resolved sources via `GetGitRepository` **only** and **aborted `Changes` on the first not-found** — so `what_changed` errored *"gitrepository <x>-artifact not found"* on every real workload, and investigations hallucinated a missing source (the root of several junk KB findings).

## What

- Capture `spec.sourceRef.kind`. Resolve a Git URL (+ require a path) **only** for GitRepository sources; for `OCIRepository`/`Bucket`/`ExternalArtifact`, emit the change **without** a diffable URL instead of erroring.
- A GitRepository that doesn't resolve is **skipped, not fatal** (no more all-or-nothing).
- `Diff` returns an empty no-op for non-Git sources.
- Add `ExternalArtifact` to `kindToGVR` so `flux_resource_status`/`flux_tree` resolve it (it exists) instead of `NOT FOUND`.

## Test

`TestProviderChangesExternalArtifactSource` — an ExternalArtifact-sourced Kustomization with no GitRepository present yields one change (no error), empty diff. Quality gate green.