### PR TITLE
feat(investigate): re-run investigations via the reinvestigate KB label

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -166,13 +166,18 @@ func runServe(args []string) error {
 
 	inv := buildInvestigator(ctx, cfg, gitops, approvals, auto, log)
 	queue := investigate.NewQueue(inv, log)
+	reinv := buildReinvestigator(ctx, cfg, gitops, log)
 
-	// startWork runs the leader-only loops (investigation queue + failure watch),
-	// scoped to a context cancelled when leadership is lost.
+	// startWork runs the leader-only loops (investigation queue + failure watch +
+	// re-investigate poller), scoped to a context cancelled when leadership is lost.
 	startWork := func(workCtx context.Context) {
 		go queue.Run(workCtx)
 		if cfg.Triggers.GitOpsFailures.Enabled && gitops != nil {
 			startGitOpsFailureWatch(workCtx, cfg, queue, gitops, log)
+		}
+		if reinv != nil {
+			log.Info("re-investigate poller enabled", "label", investigate.ReinvestigateLabel)
+			go reinv.Poll(workCtx, 2*time.Minute)
 		}
 	}
 
@@ -506,6 +511,38 @@ func buildCurator(cfg *config.Config, token forgeToken, log *slog.Logger) *curat
 	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(token))
 	log.Info("curator enabled", "repo", cfg.Forge.KBRepo)
 	return &curator.Curator{Issues: client, MinConfidencePR: 0.75, Log: log}
+}
+
+// buildReinvestigator returns a poller that re-runs KB issues labelled
+// "reinvestigate" and posts the fresh findings back, or nil when the forge isn't
+// configured. RunLore polls the forge (outbound) — it has no inbound webhooks.
+func buildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, log *slog.Logger) *investigate.Reinvestigator {
+	token := buildForgeTokenSource(cfg, log)
+	if token == nil || cfg.Forge.KBRepo == "" {
+		return nil
+	}
+	owner, repo, ok := strings.Cut(cfg.Forge.KBRepo, "/")
+	if !ok {
+		return nil
+	}
+	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, cfg.Forge.BaseBranch, github.TokenFunc(token))
+	model, tools, recall := buildModelAndTools(ctx, cfg, gp, log)
+	run := func(ctx context.Context, req investigate.Request) (providers.Investigation, error) {
+		var res providers.Investigation
+		var got bool
+		li := &investigate.LoopInvestigator{
+			Model: model, Tools: tools, Recall: recall, Verify: true, Log: log,
+			OnComplete: func(inv providers.Investigation) { res, got = inv, true },
+		}
+		if err := li.Investigate(ctx, req); err != nil {
+			return providers.Investigation{}, err
+		}
+		if !got {
+			return providers.Investigation{}, fmt.Errorf("re-investigation was inconclusive")
+		}
+		return res, nil
+	}
+	return &investigate.Reinvestigator{Forge: client, Run: run, Log: log}
 }
 
 // runCatalog dispatches catalog subcommands.

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -46,7 +47,10 @@ func New(baseURL, owner, repo, baseBranch string, token TokenFunc) *Client {
 	}
 }
 
-var _ providers.IssueProvider = (*Client)(nil)
+var (
+	_ providers.IssueProvider = (*Client)(nil)
+	_ providers.ReinvestForge = (*Client)(nil)
+)
 
 // do performs an authenticated JSON request and decodes the response into out (if non-nil).
 func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
@@ -146,6 +150,49 @@ func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref
 			map[string]any{"labels": lifecycleLabels}, nil)
 	}
 	return providers.Ref{URL: out.HTMLURL}, nil
+}
+
+// ListIssuesByLabel returns open issues carrying the given label. Pull requests
+// (which the issues API also returns) are filtered out.
+func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+	var raw []struct {
+		Number      int       `json:"number"`
+		Title       string    `json:"title"`
+		Body        string    `json:"body"`
+		PullRequest *struct{} `json:"pull_request"`
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s", c.owner, c.repo, url.QueryEscape(label))
+	if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	var out []providers.CuratedIssue
+	for _, i := range raw {
+		if i.PullRequest != nil {
+			continue // skip PRs
+		}
+		out = append(out, providers.CuratedIssue{Number: i.Number, Title: i.Title, Body: i.Body})
+	}
+	return out, nil
+}
+
+// Comment posts a comment on an issue.
+func (c *Client) Comment(ctx context.Context, number int, body string) error {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/comments", c.owner, c.repo, number),
+		map[string]any{"body": body}, nil)
+}
+
+// ReplaceLabel removes one label and adds another (best-effort on the removal —
+// a 404 when the label isn't present is not fatal).
+func (c *Client) ReplaceLabel(ctx context.Context, number int, remove, add string) error {
+	if remove != "" {
+		// DELETE is best-effort: ignore "label not set" errors.
+		_ = c.do(ctx, http.MethodDelete, fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", c.owner, c.repo, number, url.PathEscape(remove)), nil, nil)
+	}
+	if add != "" {
+		return c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/labels", c.owner, c.repo, number),
+			map[string]any{"labels": []string{add}}, nil)
+	}
+	return nil
 }
 
 func issueTitle(inv providers.Investigation) string {

--- a/internal/investigate/reinvestigate.go
+++ b/internal/investigate/reinvestigate.go
@@ -1,0 +1,92 @@
+package investigate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// ReinvestigateLabel is the label a human adds to a curated KB issue to ask RunLore
+// to run the investigation again (e.g. after more has happened, or to get a fresh
+// look). RunLore polls for it — it receives no inbound GitHub webhooks.
+const ReinvestigateLabel = "reinvestigate"
+
+// Reinvestigator polls the forge for issues labelled ReinvestigateLabel, re-runs
+// the investigation, posts the fresh findings as a comment, and flips the label to
+// "investigating". This is the outbound-poll re-trigger path that fits RunLore's
+// no-inbound-webhook design.
+type Reinvestigator struct {
+	Forge providers.ReinvestForge
+	// Run executes a fresh investigation for the request and returns its findings.
+	Run func(ctx context.Context, req Request) (providers.Investigation, error)
+	Log *slog.Logger
+}
+
+// Poll re-investigates flagged issues on each tick until ctx is done.
+func (r *Reinvestigator) Poll(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 2 * time.Minute
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		r.pollOnce(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+	}
+}
+
+func (r *Reinvestigator) pollOnce(ctx context.Context) {
+	issues, err := r.Forge.ListIssuesByLabel(ctx, ReinvestigateLabel)
+	if err != nil {
+		r.Log.Warn("reinvestigate poll: list issues failed", "err", err)
+		return
+	}
+	for _, is := range issues {
+		req := Request{Source: SourceAlert, Title: is.Title, Message: "re-investigation requested via the reinvestigate label"}
+		inv, err := r.Run(ctx, req)
+		if err != nil {
+			r.Log.Warn("reinvestigate: run failed", "issue", is.Number, "err", err)
+			continue
+		}
+		if err := r.Forge.Comment(ctx, is.Number, reinvestComment(inv)); err != nil {
+			r.Log.Warn("reinvestigate: comment failed", "issue", is.Number, "err", err)
+			continue
+		}
+		// Move the lifecycle forward and clear the trigger so it isn't re-run every tick.
+		_ = r.Forge.ReplaceLabel(ctx, is.Number, ReinvestigateLabel, "investigating")
+		r.Log.Info("reinvestigated", "issue", is.Number, "confidence", inv.Confidence, "root_causes", len(inv.RootCauses))
+	}
+}
+
+// reinvestComment renders the fresh findings for an issue comment.
+func reinvestComment(inv providers.Investigation) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "🔁 **RunLore re-investigation** — confidence %.0f%%\n\n", inv.Confidence*100)
+	if len(inv.RootCauses) == 0 {
+		b.WriteString("_No root cause could be verified this run._\n")
+	}
+	for i, rc := range inv.RootCauses {
+		fmt.Fprintf(&b, "%d. **%s** (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
+		for _, e := range rc.Evidence {
+			fmt.Fprintf(&b, "   - %s\n", e)
+		}
+		if rc.SuggestedAction != "" {
+			fmt.Fprintf(&b, "   - suggested: %s\n", rc.SuggestedAction)
+		}
+	}
+	if len(inv.Unresolved) > 0 {
+		b.WriteString("\n**Unresolved:**\n")
+		for _, u := range inv.Unresolved {
+			fmt.Fprintf(&b, "- %s\n", u)
+		}
+	}
+	return b.String()
+}

--- a/internal/investigate/reinvestigate_test.go
+++ b/internal/investigate/reinvestigate_test.go
@@ -1,0 +1,63 @@
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeForge struct {
+	issues     []providers.CuratedIssue
+	comments   map[int]string
+	relabelled map[int][2]string // number -> {remove, add}
+}
+
+func (f *fakeForge) ListIssuesByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return f.issues, nil
+}
+func (f *fakeForge) Comment(_ context.Context, n int, body string) error {
+	if f.comments == nil {
+		f.comments = map[int]string{}
+	}
+	f.comments[n] = body
+	return nil
+}
+func (f *fakeForge) ReplaceLabel(_ context.Context, n int, remove, add string) error {
+	if f.relabelled == nil {
+		f.relabelled = map[int][2]string{}
+	}
+	f.relabelled[n] = [2]string{remove, add}
+	return nil
+}
+
+func TestReinvestigatorPollOnce(t *testing.T) {
+	forge := &fakeForge{issues: []providers.CuratedIssue{{Number: 7, Title: "HarborInstallFailed"}}}
+	var ranTitle string
+	r := &Reinvestigator{
+		Forge: forge,
+		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Run: func(_ context.Context, req Request) (providers.Investigation, error) {
+			ranTitle = req.Title
+			return providers.Investigation{
+				Confidence: 0.7,
+				RootCauses: []providers.Hypothesis{{Summary: "stuck HelmRelease", Confidence: 0.7, Evidence: []string{"exceeded retries"}}},
+			}, nil
+		},
+	}
+	r.pollOnce(context.Background())
+
+	if ranTitle != "HarborInstallFailed" {
+		t.Fatalf("re-run used title %q, want the issue title", ranTitle)
+	}
+	c, ok := forge.comments[7]
+	if !ok || !strings.Contains(c, "re-investigation") || !strings.Contains(c, "stuck HelmRelease") {
+		t.Fatalf("expected a findings comment on issue 7, got %q", c)
+	}
+	if forge.relabelled[7] != [2]string{ReinvestigateLabel, "investigating"} {
+		t.Fatalf("expected label %s→investigating, got %v", ReinvestigateLabel, forge.relabelled[7])
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -233,6 +233,27 @@ type IssueProvider interface {
 	OpenPR(ctx context.Context, entry KBEntry) (Ref, error)
 }
 
+// CuratedIssue is a minimal view of a curated KB issue, used by the re-investigate
+// loop to re-run and post results back.
+type CuratedIssue struct {
+	Number int
+	Title  string
+	Body   string
+}
+
+// ReinvestForge lists curated issues flagged for re-investigation and posts results
+// back to them. RunLore polls the forge (outbound) — it receives no inbound GitHub
+// webhooks — so a human checking the "reinvestigate" label triggers a fresh run.
+type ReinvestForge interface {
+	// ListIssuesByLabel returns open issues carrying the given label.
+	ListIssuesByLabel(ctx context.Context, label string) ([]CuratedIssue, error)
+	// Comment posts a comment on an issue.
+	Comment(ctx context.Context, number int, body string) error
+	// ReplaceLabel removes one label and adds another (lifecycle transition);
+	// either side may be empty to only add or only remove.
+	ReplaceLabel(ctx context.Context, number int, remove, add string) error
+}
+
 // ---- payloads ----------------------------------------------------------------
 
 // Sample is one instant metric value with its labels.


### PR DESCRIPTION
Closes the human-in-the-loop on the Learn loop, the way you asked.

A human adds the **`reinvestigate`** label to a curated KB issue → RunLore (leader-only) **polls** the forge for it, **re-runs** the investigation, posts the **fresh findings as a comment**, and flips the label to `investigating`.

RunLore receives **no inbound GitHub webhooks** by design, so this is an **outbound poll** (2m) — no ingress/Tailscale-funnel needed, fitting the architecture.

- `providers.ReinvestForge` (ListIssuesByLabel / Comment / ReplaceLabel) + GitHub REST impl (PRs filtered out; label removal best-effort).
- `investigate.Reinvestigator` poller wired into serve's leader-only `startWork`, gated on the forge being configured.

Test: `pollOnce` re-runs with the issue title, comments the findings, and transitions `reinvestigate → investigating`. Quality gate green.