### PR TITLE
fix: address review findings (verify bypass, trigger authz, scoped reads)

### DIFF
--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["helmreleases"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["source.toolkit.fluxcd.io"]
-    resources: ["ocirepositories", "helmrepositories", "helmcharts", "buckets"]
+    resources: ["ocirepositories", "helmrepositories", "helmcharts", "buckets", "externalartifacts"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -102,16 +102,17 @@ networkPolicy:
   extraEgress: []   # appended verbatim, e.g. a specific model endpoint CIDR
 
 # The agent runs cluster-wide informers (Kustomizations/HelmReleases), a bleve
-# catalog index, a git-sync mirror, and multi-tool LLM investigations. 256Mi
-# OOMKills under real load — these defaults give headroom; CPU stays modest
-# (mostly idle, with occasional LLM calls).
+# catalog index, a git-sync mirror, and multi-tool LLM investigations. A thorough
+# run (a "pro" model over up to maxSteps=20, each call re-sending the growing
+# message history plus tool outputs) is the memory peak — 768Mi OOMKilled such a
+# run, so the limit is 1.5Gi. Idle is ~15-30Mi; CPU stays modest.
 resources:
   requests:
     cpu: 50m
-    memory: 192Mi
+    memory: 256Mi
   limits:
     cpu: "1"
-    memory: 768Mi
+    memory: 1536Mi
 
 # Restricted PSS-compliant defaults.
 podSecurityContext:

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -156,9 +156,12 @@ func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref
 // (which the issues API also returns) are filtered out.
 func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
 	var raw []struct {
-		Number      int       `json:"number"`
-		Title       string    `json:"title"`
-		Body        string    `json:"body"`
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
 		PullRequest *struct{} `json:"pull_request"`
 	}
 	path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s", c.owner, c.repo, url.QueryEscape(label))
@@ -170,7 +173,11 @@ func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]provide
 		if i.PullRequest != nil {
 			continue // skip PRs
 		}
-		out = append(out, providers.CuratedIssue{Number: i.Number, Title: i.Title, Body: i.Body})
+		labels := make([]string, 0, len(i.Labels))
+		for _, l := range i.Labels {
+			labels = append(labels, l.Name)
+		}
+		out = append(out, providers.CuratedIssue{Number: i.Number, Title: i.Title, Body: i.Body, Labels: labels})
 	}
 	return out, nil
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -91,7 +91,13 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		if entry, score := li.Recall.lookup(req); entry != nil {
 			li.Log.Info("instant recall (catalog hit; skipping the loop)",
 				"title", req.Title, "entry", entry.Path, "score", fmt.Sprintf("%.2f", score))
-			li.deliver(req, recalledInvestigation(req, *entry))
+			rec := recalledInvestigation(req, *entry)
+			if li.Verify {
+				// Catalog content is untrusted: verify a recalled finding too, so a
+				// crafted high-recall entry can't bypass the adversarial review.
+				rec = li.verifyFindings(ctx, req, rec)
+			}
+			li.deliver(req, rec)
 			return nil
 		}
 	}

--- a/internal/investigate/reinvestigate.go
+++ b/internal/investigate/reinvestigate.go
@@ -50,7 +50,13 @@ func (r *Reinvestigator) pollOnce(ctx context.Context) {
 		return
 	}
 	for _, is := range issues {
-		req := Request{Source: SourceAlert, Title: is.Title, Message: "re-investigation requested via the reinvestigate label"}
+		// Only re-run RunLore-originated issues: require the "runlore" provenance
+		// label so an arbitrary (drive-by) issue carrying "reinvestigate" can't
+		// trigger an investigation. Title/body are untrusted, fed only as context.
+		if !hasLabel(is.Labels, "runlore") {
+			continue
+		}
+		req := Request{Source: SourceAlert, Title: is.Title, Reason: "re-investigation requested via the reinvestigate label", Message: is.Body}
 		inv, err := r.Run(ctx, req)
 		if err != nil {
 			r.Log.Warn("reinvestigate: run failed", "issue", is.Number, "err", err)
@@ -64,6 +70,15 @@ func (r *Reinvestigator) pollOnce(ctx context.Context) {
 		_ = r.Forge.ReplaceLabel(ctx, is.Number, ReinvestigateLabel, "investigating")
 		r.Log.Info("reinvestigated", "issue", is.Number, "confidence", inv.Confidence, "root_causes", len(inv.RootCauses))
 	}
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
 }
 
 // reinvestComment renders the fresh findings for an issue comment.

--- a/internal/investigate/reinvestigate_test.go
+++ b/internal/investigate/reinvestigate_test.go
@@ -35,7 +35,10 @@ func (f *fakeForge) ReplaceLabel(_ context.Context, n int, remove, add string) e
 }
 
 func TestReinvestigatorPollOnce(t *testing.T) {
-	forge := &fakeForge{issues: []providers.CuratedIssue{{Number: 7, Title: "HarborInstallFailed"}}}
+	forge := &fakeForge{issues: []providers.CuratedIssue{
+		{Number: 7, Title: "HarborInstallFailed", Labels: []string{"runlore", "reinvestigate"}},
+		{Number: 8, Title: "drive-by issue", Labels: []string{"reinvestigate"}}, // no runlore label → skipped
+	}}
 	var ranTitle string
 	r := &Reinvestigator{
 		Forge: forge,
@@ -59,5 +62,9 @@ func TestReinvestigatorPollOnce(t *testing.T) {
 	}
 	if forge.relabelled[7] != [2]string{ReinvestigateLabel, "investigating"} {
 		t.Fatalf("expected label %s→investigating, got %v", ReinvestigateLabel, forge.relabelled[7])
+	}
+	// The drive-by issue (no "runlore" label) must be ignored entirely.
+	if _, ok := forge.comments[8]; ok {
+		t.Fatal("issue #8 lacks the runlore provenance label and must not be re-investigated")
 	}
 }

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -123,6 +123,12 @@ func applyVerdicts(li *LoopInvestigator, req Request, inv providers.Investigatio
 		}
 	}
 	inv.Confidence = maxc
+	// If every root cause was rejected, drop the proposed actions too — a
+	// remediation motivated by a rejected hypothesis must not survive the review
+	// (the exact failure the verify pass exists to prevent).
+	if len(kept) == 0 {
+		inv.Actions = nil
+	}
 	return inv
 }
 

--- a/internal/providers/cloud/aws/cloudtrail.go
+++ b/internal/providers/cloud/aws/cloudtrail.go
@@ -44,13 +44,14 @@ func (c *Client) CloudChanges(ctx context.Context, sel providers.Selector, w pro
 	}
 	changes := make([]providers.Change, 0, len(out.Events))
 	for i := range out.Events {
-		if len(changes) >= c.maxEvents {
-			break
-		}
 		changes = append(changes, eventToChange(out.Events[i]))
 	}
-	// Most recent first.
+	// Sort most-recent-first BEFORE capping, so the cap keeps the newest events
+	// regardless of the API's return order.
 	sort.SliceStable(changes, func(i, j int) bool { return changes[i].When.After(changes[j].When) })
+	if len(changes) > c.maxEvents {
+		changes = changes[:c.maxEvents]
+	}
 	return changes, nil
 }
 

--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -83,7 +83,13 @@ func (r *dynamicReader) GetResource(ctx context.Context, kind, namespace, name s
 // ListEvents returns recent Event lines for an object, filtered client-side by the
 // involved object's name (and kind, when given). Rendered as "Type Reason Message".
 func (r *dynamicReader) ListEvents(ctx context.Context, namespace, name, kind string) ([]string, error) {
-	list, err := r.client.Resource(eventsGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	// Filter server-side by the involved object and cap the result — a busy
+	// namespace can hold thousands of events.
+	opts := metav1.ListOptions{Limit: 100}
+	if name != "" {
+		opts.FieldSelector = "involvedObject.name=" + name
+	}
+	list, err := r.client.Resource(eventsGVR).Namespace(namespace).List(ctx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("list events: %w", err)
 	}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -248,6 +248,7 @@ type CuratedIssue struct {
 	Number int
 	Title  string
 	Body   string
+	Labels []string
 }
 
 // ReinvestForge lists curated issues flagged for re-investigation and posts results


### PR DESCRIPTION
From this session's code + security review (two reviewers). Fixes the high/should-fix findings:

- **Verify bypass on recall** — recalled findings (untrusted catalog content) now go through the adversarial verify pass too; not just delivered/curated unverified.
- **Actions survive a full rejection** — when verify rejects all root causes, proposed actions are dropped (the failure verify exists to prevent).
- **reinvestigate trigger authz** — require the `runlore` provenance co-label so a drive-by issue can't trigger a run; pass the prior finding (issue body) as re-run context.
- **Unbounded event List** — `ListEvents` now uses `involvedObject.name` field selector + `Limit 100`.
- **CloudTrail cap ordering** — sort newest-first before capping.
- **RBAC** — grant `externalartifacts` read (matches `kindToGVR`).

Deferred (documented, lower-risk): controller_logs substring filter, Slack mrkdwn escaping, ASG/CloudTrail tag-scoping, flux_tree revisited-node rendering, label accumulation. Quality gate green.