### PR TITLE
chart: opt-in CiliumNetworkPolicy for the EKS Pod Identity endpoint

### DIFF
--- a/deploy/helm/runlore/templates/networkpolicy.yaml
+++ b/deploy/helm/runlore/templates/networkpolicy.yaml
@@ -33,4 +33,29 @@ spec:
     {{- with .Values.networkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.networkPolicy.awsPodIdentity }}
+---
+# On Cilium clusters using EKS Pod Identity, the credential endpoint runs on the
+# node host network (link-local 169.254.170.23:80). Cilium classifies it as the
+# "host" entity, which a Kubernetes NetworkPolicy ipBlock cannot match — so the AWS
+# SDK's credential fetch is silently dropped and the cloud provider hangs. This
+# CiliumNetworkPolicy is the supported way to allow it. Enable when cloud.provider
+# is aws AND the cluster runs Cilium.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "runlore.fullname" . }}-aws-pod-identity
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      {{- include "runlore.selectorLabels" . | nindent 6 }}
+  egress:
+    - toEntities: [host]
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP
+{{- end }}
 {{- end }}

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -100,6 +100,10 @@ rbac:
 networkPolicy:
   enabled: true
   extraEgress: []   # appended verbatim, e.g. a specific model endpoint CIDR
+  # Render a CiliumNetworkPolicy allowing egress to the EKS Pod Identity credential
+  # endpoint (host entity, 169.254.170.23:80). Required for the AWS cloud provider
+  # on Cilium clusters — a plain NetworkPolicy can't match the host-network target.
+  awsPodIdentity: false
 
 # The agent runs cluster-wide informers (Kustomizations/HelmReleases), a bleve
 # catalog index, a git-sync mirror, and multi-tool LLM investigations. A thorough


### PR DESCRIPTION
In-cluster, the AWS cloud provider **hung**: the EKS Pod Identity credential endpoint is on the node host network (`169.254.170.23:80`), which Cilium classifies as the `host` entity. A k8s NetworkPolicy ipBlock can't match a host-network target, so the AWS SDK credential fetch was silently DROPPED.

Hubble confirmed: `runlore/… <> 169.254.170.23:80 (host) Policy denied DROPPED` (SYN backoff = the SDK retrying creds = the investigation blocked, no OOM).

Adds `networkPolicy.awsPodIdentity` (default false) → a CiliumNetworkPolicy with `toEntities: [host]` on TCP 80. **Validated in-cluster**: with it applied, `cloud_what_changed`/`cloud_resource_health` reach AWS via Pod Identity and the investigation completes end-to-end (no hang, no OOM at the 1.5Gi limit).