### PR TITLE
chore: session closeout — simplify shipped code + document new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ flowchart LR
 - **Cause-agnostic** — reacts to any incident and investigates any cause; "what changed" is the sharpest lens (deepest on GitOps), not the only one.
 - **Read-only by default, full autonomy ladder when you want it** — `off` → `suggest` → `approve` (human-gated) → `auto` (unattended). Every rung above read-only is reversible-only, envelope-bounded, audited, and kill-switchable (see [`docs/design.md`](docs/design.md)).
 - **GitOps- and metrics-agnostic** — Flux + ArgoCD, VictoriaMetrics + Prometheus; logs/network pluggable.
+- **Cloud-aware (read-only)** — correlates the cloud control plane (AWS CloudTrail "what changed" + EC2/ASG/EKS health) using in-cluster identity (EKS Pod Identity / IRSA), so infra changes outside GitOps are in scope too.
 - **Single static Go binary** — terminal (`lore investigate`) or in-cluster (`lore serve`).
 - **Model-agnostic** — Anthropic, Google Gemini, or any OpenAI-compatible endpoint (in-cluster vLLM, Ollama…); your telemetry needn't leave the boundary.
 - **Built-in core providers, MCP as the extension layer** — self-contained, but composable.
@@ -101,11 +102,15 @@ lore investigate --alert HarborProbeFailure --namespace apps --config runlore.ya
 ## Status & docs
 
 - 📐 [Design](docs/design.md) · 🚀 [Getting started](docs/getting-started.md) · 🛠 [Contributing](CONTRIBUTING.md) · [Prior art](docs/prior-art.md) · [Plans](docs/plans/)
-- ✅ **End-to-end working** (verified on k3d):
+- ✅ **End-to-end working** (verified on k3d and a live EKS cluster):
   - **React** — incident webhook (trigger policy + dedup) + GitOps failure watch (**Flux & Argo CD**)
-  - **Investigate** — ReAct loop with 5 tools (`what_changed`, `kb_search`, `query_metrics`, `query_logs`, `network_drops`) + **instant recall** (skip the loop on a high-confidence catalog hit); model-agnostic (**Anthropic**, **Gemini**, or any OpenAI-compatible endpoint)
+  - **Investigate** — ReAct loop with 10 tools across every signal source + **instant recall** (skip the loop on a high-confidence catalog hit) + an **adversarial verify pass** (a skeptic model rejects correlation-only findings and re-calibrates confidence); model-agnostic (**Anthropic**, **Gemini**, or any OpenAI-compatible endpoint):
+    - *GitOps* — `what_changed` (exact Git diff; resolves `GitRepository`/`OCIRepository`/`ExternalArtifact` sources), `flux_resource_status`, `flux_tree`, `controller_logs`
+    - *Signals* — `query_metrics` (PromQL), `query_logs` (LogsQL), `network_drops` (Hubble)
+    - *Cloud (AWS)* — `cloud_what_changed` (CloudTrail), `cloud_resource_health` (EC2/ASG/EKS) via EKS Pod Identity / IRSA, **read-only**
+    - *Knowledge* — `kb_search`
   - **Deliver** — Slack (with interactive **Approve/Reject buttons**) + Matrix
-  - **Learn** — OKF catalog (read + **git-sync**) + curator PRs/issues → knowledge compounds
+  - **Learn** — OKF catalog (read + **git-sync**) + curator PRs/issues with a **lifecycle** (`triggered → investigating → solved`) → knowledge compounds; **re-run on demand** by adding the `reinvestigate` label to a curated issue
   - **Act** — full **autonomy ladder**: `off` → `suggest` → `approve` (curl or Slack buttons, token-gated) → `auto` (unattended, reversible-only, confidence-gated, rate-limited, **kill-switchable**, audited)
   - **Run** — `lore serve` (in-cluster, **HA via leader election**) or `lore investigate` (on-demand terminal); `lore eval` RCA benchmark; `lore catalog sync`. Packaged Helm chart + CI image build.
 - 🚧 Next: more notifiers (PagerDuty, incident.io), MCP extension layer, proactive (non-incident) watch.

--- a/docs/design.md
+++ b/docs/design.md
@@ -171,13 +171,20 @@ GitOps platform it resolves to the *exact* Git diff (the spine below).
 1. **Instant recall**: `kb_search(symptom)` against the cached catalog. High-confidence known-pattern
    hit → short-circuit to the known resolution (no full loop). *(HolmesGPT data: ~40 % of incidents
    self-resolve on a runbook/pattern match; tool-calls drop 16→2.)*
-2. **What changed**: build the ranked `Change` timeline around the incident window
-   (`what_changed_near`), then `diff_revisions` for the actual landed delta. (GitOps changes today;
-   image/cloud/cert/scaling/manual sources are future inputs to the same timeline.)
+2. **What changed**: build the ranked `Change` timeline around the incident window — the Git diff on a
+   GitOps platform (`what_changed`, resolving GitRepository/OCIRepository/ExternalArtifact sources) **and**
+   the AWS control plane (`cloud_what_changed` = CloudTrail), unified in one `Change` model so an infra
+   change outside GitOps lands on the same timeline.
 3. **Ground**: retrieve relevant OKF runbooks/incidents and seed the loop.
-4. **ReAct**: pull metrics (PromQL), logs, network, k8s/node state *just-in-time* via providers; form
-   and test hypotheses across both the change-caused and no-change branches.
-5. **Output contract** (structured): ranked root cause(s) + **confidence** + `change_ref` +
+4. **ReAct**: pull metrics (PromQL), logs, network, Flux status/tree, controller logs, and cloud
+   resource health *just-in-time* via providers; form and test hypotheses across both the change-caused
+   and no-change branches.
+5. **Adversarial verify pass**: before delivery a *skeptic* model call re-examines each root cause and
+   **rejects correlation-only findings** (moving them to `unresolved`) and **re-calibrates confidence**.
+   It can only ever lower/withdraw a claim, never invent one — and if it rejects every root cause, the
+   proposed actions are dropped too. Recalled (catalog) findings go through it as well, since catalog
+   content is untrusted.
+6. **Output contract** (structured): ranked root cause(s) + **confidence** + `change_ref` +
    **evidence trail** + **suggested reversible action** + explicit **`unresolved`** (honest about what
    it couldn't determine — designed for the ITBench <50 % reality, §10).
 
@@ -200,6 +207,17 @@ investigation result
 The catalog only grows from **genuinely novel, human-sharpened** incidents. Every learned entry cites
 the **issue** (reasoning), the **causing** change, and the **fixing** change — provenance no closed
 "memory" gives you.
+
+**Lifecycle labels gate the catalog's quality.** Curated artifacts carry a lifecycle label —
+`triggered` (raw, just opened) → `investigating` → `solved` (root cause confirmed *and* resolution
+captured) — plus `wont-fix`. Only a **`solved` entry with a written resolution** should be merged as a
+reusable Playbook, so unverified findings can't silently become "knowledge."
+
+**Re-running on demand (`reinvestigate`).** RunLore takes no inbound GitHub webhooks, so re-triggering is
+an **outbound poll**: a human adds the `reinvestigate` label to a curated issue; the leader re-runs the
+investigation (with the prior finding as context), comments the fresh result, and advances the label to
+`investigating`. Only RunLore-originated issues (carrying the `runlore` provenance label) are eligible —
+a drive-by issue can't spend an investigation.
 
 **Two kinds of knowledge — seeded vs learned (a deliberate distinction).** "Learns your context" is
 only half emergent:
@@ -244,16 +262,22 @@ Interfaces live in `internal/providers/providers.go`. "For the moment" impls:
 | Metrics | `MetricsProvider` | **VictoriaMetrics**, **Prometheus** (one PromQL impl, 2 endpoints) | — |
 | Logs | `LogsProvider` | **VictoriaLogs** | Loki, … |
 | Network | `NetworkProvider` | **Hubble** | — |
-| Cloud | `CloudProvider` | — *(Phase 2)* | AWS, GCP, Azure via native SDKs; Steampipe/cloud-MCP optional |
+| Cloud | `CloudProvider` | **AWS** (CloudTrail what-changed + EC2/ASG/EKS health) | GCP, Azure via native SDKs; Steampipe/cloud-MCP optional |
 | Model | `ModelProvider` | **Anthropic**, **Gemini**, **OpenAI-compatible** (in-cluster vLLM, Ollama, OpenRouter, …) | — |
 | Notifier | `Notifier` | **Slack**, **Matrix** | PagerDuty, incident.io |
 | Issue | `IssueProvider` | **GitHub** (App auth) | GitLab (access token) |
 
-> **Cloud is Phase 2, via native SDKs.** v1 needs no cloud provider — the MVP correlates in-cluster
-> signals + what-changed. When cloud lands, `CloudProvider` uses native SDKs (`aws-sdk-go-v2`,
-> `google-cloud-go`, `azure-sdk-for-go`) with in-cluster identity (Pod/Workload Identity) — *not*
-> Steampipe and *not* shelling out to cloud CLIs (both add heavy deps and break the single-binary
-> property). Steampipe and cloud MCP servers remain available as optional MCP extensions.
+> **Cloud via native SDKs.** The AWS impl (`internal/providers/cloud/aws`, `aws-sdk-go-v2`) is **read-only**:
+> `CloudChanges` = CloudTrail `LookupEvents` (mutating events → the engine-agnostic `Change` model, so
+> cloud joins the same "what changed" timeline as Git diffs); `ResourceHealth` = EC2/ASG/EKS `Describe`.
+> Auth is **in-cluster identity** (EKS Pod Identity / IRSA via the default credential chain) — *not*
+> static keys, *not* Steampipe, *not* shelling out to cloud CLIs (both add heavy deps and break the
+> single-binary property). GCP/Azure follow the same shape. Steampipe and cloud MCP servers remain
+> available as optional MCP extensions.
+>
+> On Cilium clusters the Pod Identity credential endpoint is a host-network target (`169.254.170.23:80`),
+> which a Kubernetes NetworkPolicy can't match — the chart's `networkPolicy.awsPodIdentity` renders a
+> `CiliumNetworkPolicy` (`toEntities: [host]`) to allow it.
 
 **Why the GitOps abstraction is real, not hand-wavy** — both engines reduce to *revision history +
 git diff*:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,10 @@ forge (issues/PRs on a repo you designate).
 - Optional: a **metrics** backend (VictoriaMetrics/Prometheus), a **logs** backend (VictoriaLogs),
   and/or **Cilium Hubble** (Relay) — they enable the `query_metrics` / `query_logs` / `network_drops`
   investigation tools.
+- Optional: **AWS** read-only access — enables the `cloud_what_changed` (CloudTrail) and
+  `cloud_resource_health` (EC2/ASG/EKS) tools, the cloud-control-plane "what changed" lens for infra
+  changes outside GitOps. Auth is in-cluster identity (**EKS Pod Identity** or IRSA) — no static keys.
+  See [step 4b](#step-4b-aws-cloud-provider-optional).
 - Optional: a **Slack incoming webhook** and/or a **Matrix** account for delivery.
 - Optional: a **GitHub App** for curation (the Learn loop) — [step 2](#step-2-github-app-for-curation-optional).
 - Optional: [External Secrets Operator](https://external-secrets.io/) to sync credentials from a vault
@@ -173,8 +177,9 @@ config:
     incidents:
       enabled: true
       match:
-        severity: [critical]
-        environment: [prod]
+        severity: [critical, warning]   # match against the alert's labels
+        # environment: [prod]           # only matches alerts that CARRY an `environment`
+                                        # label — omit it if yours don't, or nothing fires
       dedup: { window: 30m }
     gitops_failures:
       enabled: true            # also react to Flux Ready=False
@@ -207,6 +212,12 @@ config:
     url: http://victorialogs.observability.svc:9428   # VictoriaLogs base (LogsQL)
   network:
     url: hubble-relay.kube-system:80                  # Cilium Hubble Relay (gRPC host:port)
+  # Cloud context (AWS) — enables cloud_what_changed (CloudTrail) + cloud_resource_health
+  # (EC2/ASG/EKS). Read-only; auth is in-cluster identity (no keys). See step 4b.
+  cloud:
+    provider: aws
+    region: eu-west-3
+    cluster_name: your-cluster        # scopes EKS nodegroup / ASG queries
 
   # Deliver: one or both.
   notify:
@@ -273,6 +284,53 @@ helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values
 
 ---
 
+## Step 4b — AWS cloud provider (optional)
+
+Enables the `cloud_what_changed` (CloudTrail) and `cloud_resource_health` (EC2/ASG/EKS) tools so the
+agent can see infra changes that never touched GitOps. **Read-only**, authenticated with **in-cluster
+identity** — no static AWS keys.
+
+1. **Config** — add the `config.cloud` block ([step 4](#step-4-configure-and-install)): `provider: aws`,
+   your `region`, and the EKS `cluster_name` (scopes nodegroup/ASG queries).
+
+2. **IAM (read-only)** — grant the agent's ServiceAccount a role with *only* these actions, no writes:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       { "Effect": "Allow", "Action": ["cloudtrail:LookupEvents"], "Resource": "*" },
+       { "Effect": "Allow", "Action": [
+           "ec2:DescribeInstances", "ec2:DescribeInstanceStatus", "ec2:DescribeTags",
+           "autoscaling:DescribeAutoScalingGroups", "autoscaling:DescribeScalingActivities",
+           "eks:DescribeCluster", "eks:DescribeNodegroup", "eks:ListNodegroups"
+         ], "Resource": "*" }
+     ]
+   }
+   ```
+
+   Bind it to the `runlore` ServiceAccount via **[EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)**
+   (preferred) or IRSA. The SDK's default credential chain picks it up — nothing to configure in RunLore.
+
+3. **Cilium clusters only** — the EKS Pod Identity credential endpoint runs on the node host network
+   (`169.254.170.23:80`), which Cilium classifies as the `host` entity. A plain Kubernetes NetworkPolicy
+   **cannot** match it, so the SDK's credential fetch is silently dropped and the cloud tools hang. Set
+   `networkPolicy.awsPodIdentity: true` (chart value) to render a `CiliumNetworkPolicy` that allows it:
+
+   ```yaml
+   networkPolicy:
+     enabled: true
+     awsPodIdentity: true   # CiliumNetworkPolicy: egress to host:80 for the Pod Identity endpoint
+   ```
+
+   Confirm with Hubble if calls hang: `hubble observe --pod runlore/<pod> --verdict DROPPED` showing
+   `169.254.170.23:80 (host) … DROPPED` is this exact issue.
+
+4. **Memory** — a thorough run (a "pro" model over the full step budget with the cloud tools) is the
+   memory peak; the chart default limit is `1.5Gi`. Lower it only if you use a smaller model / fewer tools.
+
+---
+
 ## Step 5 — Point Alertmanager at the webhook
 
 RunLore reacts to Alertmanager's webhook. Route the alerts you care about to its Service (the
@@ -314,10 +372,35 @@ Fire a test: trigger a `critical`/`prod` alert (or `flux suspend`+break a Kustom
 
 ---
 
+## Step 7 — The Learn loop: KB lifecycle & re-runs
+
+When curation is on, each investigation lands in your KB repo with a **lifecycle label** so you can tell
+raw findings from vetted knowledge:
+
+- **`triggered`** — RunLore just opened this issue/PR; a raw finding, not yet worked.
+- **`investigating`** — being worked (RunLore sets this when you ask it to re-run; see below).
+- **`solved`** — root cause confirmed *and the resolution captured*. **Only `solved` entries with a
+  written resolution should be merged** as a reusable Playbook — that's the quality gate that keeps the
+  catalog trustworthy.
+- **`wont-fix`** — closed without a Playbook.
+
+(High-confidence findings open as a **PR** drafting an OKF entry; lower-confidence ones open as an
+**issue** to triage.)
+
+**Re-run an investigation on demand.** RunLore takes no inbound GitHub webhooks, so it *polls*: add the
+**`reinvestigate`** label to one of its curated issues and within a couple of minutes it re-runs the
+investigation (building on the captured context), posts the fresh findings as a comment, and moves the
+label to `investigating`. Use it after more has happened, or once you've added a relevant Playbook and
+want a sharper answer. Only RunLore-originated issues (carrying the `runlore` label) are eligible.
+
+---
+
 ## What RunLore can and cannot do
 
 - **Cluster**: **read-only by default** — it reads Flux/Argo resources, metrics (PromQL), logs (LogsQL),
-  and network flows (Hubble), and never writes. RBAC is limited to watching those resources + its own
+  and network flows (Hubble), and never writes.
+- **Cloud (AWS, optional)**: **read-only** — CloudTrail `LookupEvents` + EC2/ASG/EKS `Describe`, via
+  in-cluster identity (EKS Pod Identity / IRSA). No mutating cloud calls exist in the code. RBAC is limited to watching those resources + its own
   leader-election `Lease`. With `actions.mode: approve` + `rbac.allowActions: true`, it can execute
   *reversible* Flux ops (suspend/resume/reconcile) **only after explicit human approval** — either
   `POST /actions/<id>/approve` (token-gated) or **Slack Approve/Reject buttons** (enable Slack

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -146,10 +146,15 @@ func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref
 	// issues endpoint). Best-effort: a labelling failure must not lose the PR, so
 	// the error is intentionally ignored — the PR URL is already returned.
 	if out.Number != 0 {
-		_ = c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/labels", c.owner, c.repo, out.Number),
-			map[string]any{"labels": lifecycleLabels}, nil)
+		_ = c.addLabels(ctx, out.Number, lifecycleLabels)
 	}
 	return providers.Ref{URL: out.HTMLURL}, nil
+}
+
+// addLabels POSTs labels onto an issue/PR (the create-PR API doesn't accept them).
+func (c *Client) addLabels(ctx context.Context, number int, labels []string) error {
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/labels", c.owner, c.repo, number),
+		map[string]any{"labels": labels}, nil)
 }
 
 // ListIssuesByLabel returns open issues carrying the given label. Pull requests
@@ -196,8 +201,7 @@ func (c *Client) ReplaceLabel(ctx context.Context, number int, remove, add strin
 		_ = c.do(ctx, http.MethodDelete, fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", c.owner, c.repo, number, url.PathEscape(remove)), nil, nil)
 	}
 	if add != "" {
-		return c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/labels", c.owner, c.repo, number),
-			map[string]any{"labels": []string{add}}, nil)
+		return c.addLabels(ctx, number, []string{add})
 	}
 	return nil
 }

--- a/internal/investigate/cloud_tools.go
+++ b/internal/investigate/cloud_tools.go
@@ -55,16 +55,13 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 		return "no mutating AWS events in the window", nil
 	}
 	var b strings.Builder
-	for i, c := range changes {
-		if i >= maxToolRows {
-			fmt.Fprintf(&b, "… (%d more)\n", len(changes)-i)
-			break
-		}
+	renderRows(&b, len(changes), "more", func(i int) {
+		c := changes[i]
 		fmt.Fprintf(&b, "%s %s %s/%s\n", c.When.Format(time.RFC3339), c.ManagedBy, c.Workload.Kind, c.Workload.Name)
 		if c.Source.Path != "" {
 			fmt.Fprintf(&b, "  %s\n", c.Source.Path)
 		}
-	}
+	})
 	return b.String(), nil
 }
 
@@ -104,12 +101,8 @@ func (t CloudResourceHealthTool) Call(ctx context.Context, args string) (string,
 		return "no AWS resource health returned", nil
 	}
 	var b strings.Builder
-	for i, l := range lines {
-		if i >= maxToolRows {
-			fmt.Fprintf(&b, "… (%d more)\n", len(lines)-i)
-			break
-		}
-		fmt.Fprintln(&b, l.Message)
-	}
+	renderRows(&b, len(lines), "more", func(i int) {
+		fmt.Fprintln(&b, lines[i].Message)
+	})
 	return b.String(), nil
 }

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -13,6 +13,19 @@ import (
 
 const maxToolRows = 50
 
+// renderRows writes up to maxToolRows rows, calling row(i) for each kept index. If
+// n exceeds the cap it appends a truncation note "… (<remaining> <noun>)". This is
+// the shared row-capping shape used by every tool that renders a bounded list.
+func renderRows(b *strings.Builder, n int, noun string, row func(i int)) {
+	for i := 0; i < n; i++ {
+		if i >= maxToolRows {
+			fmt.Fprintf(b, "… (%d %s)\n", n-i, noun)
+			return
+		}
+		row(i)
+	}
+}
+
 // QueryMetricsTool lets the model run PromQL instant queries (saturation, error
 // rates, health) against the metrics backend.
 type QueryMetricsTool struct {
@@ -48,13 +61,9 @@ func (t QueryMetricsTool) Call(ctx context.Context, args string) (string, error)
 		return "no series matched", nil
 	}
 	var b strings.Builder
-	for i, s := range samples {
-		if i >= maxToolRows {
-			fmt.Fprintf(&b, "… (%d more series)\n", len(samples)-i)
-			break
-		}
-		fmt.Fprintf(&b, "%s = %g\n", formatMetric(s.Metric), s.Value)
-	}
+	renderRows(&b, len(samples), "more series", func(i int) {
+		fmt.Fprintf(&b, "%s = %g\n", formatMetric(samples[i].Metric), samples[i].Value)
+	})
 	return b.String(), nil
 }
 
@@ -113,13 +122,9 @@ func (t NetworkDropsTool) Call(ctx context.Context, args string) (string, error)
 		return "no dropped flows", nil
 	}
 	var b strings.Builder
-	for i, l := range lines {
-		if i >= maxToolRows {
-			fmt.Fprintf(&b, "… (%d more)\n", len(lines)-i)
-			break
-		}
-		fmt.Fprintln(&b, l.Message)
-	}
+	renderRows(&b, len(lines), "more", func(i int) {
+		fmt.Fprintln(&b, lines[i].Message)
+	})
 	return b.String(), nil
 }
 
@@ -211,12 +216,8 @@ func (t QueryLogsTool) Call(ctx context.Context, args string) (string, error) {
 		return "no log lines matched", nil
 	}
 	var b strings.Builder
-	for i, l := range lines {
-		if i >= maxToolRows {
-			fmt.Fprintf(&b, "… (%d more lines)\n", len(lines)-i)
-			break
-		}
-		fmt.Fprintf(&b, "%s %s\n", l.Time.Format(time.RFC3339), l.Message)
-	}
+	renderRows(&b, len(lines), "more lines", func(i int) {
+		fmt.Fprintf(&b, "%s %s\n", lines[i].Time.Format(time.RFC3339), lines[i].Message)
+	})
 	return b.String(), nil
 }

--- a/internal/investigate/reinvestigate.go
+++ b/internal/investigate/reinvestigate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -53,7 +54,7 @@ func (r *Reinvestigator) pollOnce(ctx context.Context) {
 		// Only re-run RunLore-originated issues: require the "runlore" provenance
 		// label so an arbitrary (drive-by) issue carrying "reinvestigate" can't
 		// trigger an investigation. Title/body are untrusted, fed only as context.
-		if !hasLabel(is.Labels, "runlore") {
+		if !slices.Contains(is.Labels, "runlore") {
 			continue
 		}
 		req := Request{Source: SourceAlert, Title: is.Title, Reason: "re-investigation requested via the reinvestigate label", Message: is.Body}
@@ -70,15 +71,6 @@ func (r *Reinvestigator) pollOnce(ctx context.Context) {
 		_ = r.Forge.ReplaceLabel(ctx, is.Number, ReinvestigateLabel, "investigating")
 		r.Log.Info("reinvestigated", "issue", is.Number, "confidence", inv.Confidence, "root_causes", len(inv.RootCauses))
 	}
-}
-
-func hasLabel(labels []string, want string) bool {
-	for _, l := range labels {
-		if l == want {
-			return true
-		}
-	}
-	return false
 }
 
 // reinvestComment renders the fresh findings for an issue comment.

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -250,15 +250,25 @@ func (p *Provider) depNode(ctx context.Context, w providers.Workload, seen map[s
 	for _, dep := range dependsOn(u, w.Kind, w.Namespace) {
 		node.Children = append(node.Children, p.depNode(ctx, dep, seen))
 	}
-	if sk, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "kind"); sk != "" {
-		sn, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "name")
-		sns, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "namespace")
-		if sns == "" {
-			sns = w.Namespace
-		}
-		node.Children = append(node.Children, p.depNode(ctx, providers.Workload{Kind: sk, Name: sn, Namespace: sns}, seen))
+	if src, ok := sourceRefWorkload(u, w.Namespace); ok {
+		node.Children = append(node.Children, p.depNode(ctx, src, seen))
 	}
 	return node
+}
+
+// sourceRefWorkload reads spec.sourceRef as a Workload (namespace defaulting to the
+// parent's). ok is false when there is no sourceRef.kind to follow.
+func sourceRefWorkload(u *unstructured.Unstructured, defaultNS string) (providers.Workload, bool) {
+	kind, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "kind")
+	if kind == "" {
+		return providers.Workload{}, false
+	}
+	name, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "name")
+	ns, _, _ := unstructured.NestedString(u.Object, "spec", "sourceRef", "namespace")
+	if ns == "" {
+		ns = defaultNS
+	}
+	return providers.Workload{Kind: kind, Name: name, Namespace: ns}, true
 }
 
 // sourceRef renders "kind/namespace/name" of spec.sourceRef, or "".


### PR DESCRIPTION
Closeout for this session's work (review + simplify + docs).

**Simplifications** (behaviour-preserving, from the simplify pass; gate green):
- `renderRows()` dedups the row-capping shape across query/cloud tools
- `addLabels()` dedups the issues/labels POST (OpenPR + ReplaceLabel)
- `sourceRefWorkload()` for the sourceRef read in the flux dep walk
- `slices.Contains` replaces a hand-rolled `hasLabel`

**Docs**:
- **README** — 10 tools grouped by signal source, adversarial verify pass, AWS cloud-aware, KB lifecycle + reinvestigate.
- **getting-started** — new AWS step 4b (read-only IAM, EKS Pod Identity, the Cilium `awsPodIdentity` policy for the host:80 credential endpoint, 1.5Gi memory), `cloud` config block, trigger-label gotcha, Learn-loop lifecycle + reinvestigate.
- **design** — cloud provider shipped (AWS, read-only SDK + Pod Identity), verify pass, lifecycle labels + reinvestigate.

Gate: `gofmt` clean · `go build` · `go test ./...` · `golangci-lint` 0 issues.