### PR TITLE
feat(investigate): pod_status + kube_events tools; flux namespace fallback

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -639,9 +639,15 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	if cfg.Network.URL != "" {
 		tools = append(tools, investigate.NetworkDropsTool{Network: hubble.New(cfg.Network.URL)})
 	}
-	// Read-only controller-log access (Flux controllers), when a cluster is reachable.
+	// Read-only cluster access (Flux controller logs + pod status + events), when a
+	// cluster is reachable. The same reader backs all three tools.
 	if cs := kubeClientset(log); cs != nil {
-		tools = append(tools, investigate.ControllerLogsTool{Logs: cluster.New(cs)})
+		reader := cluster.New(cs)
+		tools = append(tools,
+			investigate.ControllerLogsTool{Logs: reader},
+			investigate.PodStatusTool{Kube: reader},
+			investigate.KubeEventsTool{Kube: reader},
+		)
 	}
 	// Cloud context (AWS): CloudTrail "what changed" + EC2/ASG/EKS health. Opt-in.
 	if cfg.Cloud.Provider == "aws" {

--- a/internal/investigate/fluxstatus_tool.go
+++ b/internal/investigate/fluxstatus_tool.go
@@ -45,7 +45,9 @@ func (t FluxStatusTool) Call(ctx context.Context, args string) (string, error) {
 	}
 	id := fmt.Sprintf("%s %s/%s", in.Kind, in.Namespace, in.Name)
 	if rs.NotFound {
-		return id + ": NOT FOUND (the object does not exist — likely the cascade root)", nil
+		return id + ": NOT FOUND — searched the given namespace, flux-system, and all namespaces by " +
+			"name; the object genuinely does not exist (likely the cascade root). If you expected it to " +
+			"exist, re-check the kind/name rather than concluding it was deleted.", nil
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s  Ready=%s", id, emptyDash(rs.Ready))

--- a/internal/investigate/kube_tools.go
+++ b/internal/investigate/kube_tools.go
@@ -1,0 +1,128 @@
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// PodStatusTool surfaces pod-level failures (CreateContainerConfigError,
+// ImagePullBackOff, CrashLoopBackOff, …) that never reach logs because the
+// container never started — the gap the GitOps/logs/metrics tools can't fill.
+type PodStatusTool struct {
+	Kube providers.KubeReader
+}
+
+// Name returns the tool name.
+func (t PodStatusTool) Name() string { return "pod_status" }
+
+// Description returns the tool description.
+func (t PodStatusTool) Description() string {
+	return "List pod health in a namespace with per-container waiting/terminated reasons + messages — " +
+		"the FIRST tool to reach for when a workload won't start (CreateContainerConfigError, " +
+		"ImagePullBackOff, CrashLoopBackOff, RunContainerError). The message names the exact cause " +
+		"(e.g. a missing Secret/ConfigMap key). Unhealthy pods are listed first. Optional label selector."
+}
+
+// Schema returns the JSON schema for the arguments.
+func (t PodStatusTool) Schema() string {
+	return `{"type":"object","properties":{"namespace":{"type":"string"},"selector":{"type":"string","description":"optional label selector, e.g. app=harbor"}},"required":["namespace"]}`
+}
+
+// Call lists pod statuses and renders them.
+func (t PodStatusTool) Call(ctx context.Context, args string) (string, error) {
+	var in struct{ Namespace, Selector string }
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	pods, err := t.Kube.PodStatuses(ctx, in.Namespace, in.Selector)
+	if err != nil {
+		return "", err
+	}
+	if len(pods) == 0 {
+		return fmt.Sprintf("no pods in namespace %q%s", in.Namespace, selectorSuffix(in.Selector)), nil
+	}
+	var b strings.Builder
+	for i, p := range pods {
+		if i >= maxToolRows {
+			fmt.Fprintf(&b, "… (%d more)\n", len(pods)-i)
+			break
+		}
+		fmt.Fprintf(&b, "%s  %s ready=%s\n", p.Name, p.Phase, p.Ready)
+		for _, r := range p.Reasons {
+			fmt.Fprintf(&b, "  ⚠ %s\n", r)
+		}
+	}
+	return b.String(), nil
+}
+
+// KubeEventsTool surfaces causes that live in the Kubernetes event stream rather
+// than logs or status — FailedScheduling (Insufficient cpu/memory), FailedMount,
+// FailedAttachVolume, BackOff, etc.
+type KubeEventsTool struct {
+	Kube providers.KubeReader
+}
+
+// Name returns the tool name.
+func (t KubeEventsTool) Name() string { return "kube_events" }
+
+// Description returns the tool description.
+func (t KubeEventsTool) Description() string {
+	return "List recent Kubernetes Events in a namespace (Warning-only by default) — causes that live " +
+		"in the event stream, not logs or status: FailedScheduling (Insufficient cpu/memory), " +
+		"FailedMount, FailedAttachVolume, BackOff, Unhealthy probes. Optionally scope to one object's name."
+}
+
+// Schema returns the JSON schema for the arguments.
+func (t KubeEventsTool) Schema() string {
+	return `{"type":"object","properties":{"namespace":{"type":"string"},"object":{"type":"string","description":"optional involvedObject name to scope to"},"all_types":{"type":"boolean","description":"include Normal events too (default: Warning only)"}},"required":["namespace"]}`
+}
+
+// Call lists events and renders them.
+func (t KubeEventsTool) Call(ctx context.Context, args string) (string, error) {
+	var in struct {
+		Namespace string `json:"namespace"`
+		Object    string `json:"object"`
+		AllTypes  bool   `json:"all_types"`
+	}
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	events, err := t.Kube.Events(ctx, in.Namespace, in.Object, !in.AllTypes)
+	if err != nil {
+		return "", err
+	}
+	if len(events) == 0 {
+		return fmt.Sprintf("no %s events in namespace %q", warnLabel(in.AllTypes), in.Namespace), nil
+	}
+	var b strings.Builder
+	for i, e := range events {
+		if i >= maxToolRows {
+			fmt.Fprintf(&b, "… (%d more)\n", len(events)-i)
+			break
+		}
+		count := ""
+		if e.Count > 1 {
+			count = fmt.Sprintf(" (x%d)", e.Count)
+		}
+		fmt.Fprintf(&b, "%s %s %s%s: %s\n", e.Type, e.Object, e.Reason, count, e.Message)
+	}
+	return b.String(), nil
+}
+
+func selectorSuffix(sel string) string {
+	if sel == "" {
+		return ""
+	}
+	return " matching " + sel
+}
+
+func warnLabel(allTypes bool) string {
+	if allTypes {
+		return ""
+	}
+	return "Warning"
+}

--- a/internal/investigate/kube_tools_test.go
+++ b/internal/investigate/kube_tools_test.go
@@ -1,0 +1,55 @@
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeKube struct {
+	pods   []providers.PodStatus
+	events []providers.KubeEvent
+}
+
+func (f fakeKube) PodStatuses(context.Context, string, string) ([]providers.PodStatus, error) {
+	return f.pods, nil
+}
+func (f fakeKube) Events(context.Context, string, string, bool) ([]providers.KubeEvent, error) {
+	return f.events, nil
+}
+
+func TestPodStatusTool(t *testing.T) {
+	tool := PodStatusTool{Kube: fakeKube{pods: []providers.PodStatus{
+		{Name: "harbor-registry-x", Phase: "Pending", Ready: "1/2", Reasons: []string{
+			"registry: CreateContainerConfigError: couldn't find key username in Secret tooling/xplane-harbor-access-key",
+		}},
+	}}}
+	out, err := tool.Call(context.Background(), `{"namespace":"tooling"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	// The exact root cause (the missing key) must reach the model.
+	if !strings.Contains(out, "CreateContainerConfigError") || !strings.Contains(out, "couldn't find key username") {
+		t.Fatalf("pod_status must surface the container reason + message, got:\n%s", out)
+	}
+	empty, _ := PodStatusTool{Kube: fakeKube{}}.Call(context.Background(), `{"namespace":"x"}`)
+	if !strings.Contains(empty, "no pods") {
+		t.Fatalf("expected empty message, got %q", empty)
+	}
+}
+
+func TestKubeEventsTool(t *testing.T) {
+	tool := KubeEventsTool{Kube: fakeKube{events: []providers.KubeEvent{
+		{Type: "Warning", Reason: "FailedScheduling", Object: "Pod/valkey-0", Count: 13,
+			Message: "0/9 nodes are available: 4 Insufficient cpu, 2 Insufficient memory."},
+	}}}
+	out, err := tool.Call(context.Background(), `{"namespace":"apps"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, "FailedScheduling") || !strings.Contains(out, "Insufficient cpu") || !strings.Contains(out, "x13") {
+		t.Fatalf("kube_events must surface reason + message + count, got:\n%s", out)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -36,6 +36,15 @@ to find the root (a not-Ready or NOT FOUND node); and use controller_logs / quer
 relevant controller (e.g. kustomize-controller, source-controller, helm-controller) to learn WHY it
 failed. Confirm hypotheses with metrics and, where relevant, network drops.
 
+When a WORKLOAD won't run (pods not Ready, a HelmRelease install timing out), the cause is usually at
+the pod level — call pod_status on the namespace FIRST: it names container failures verbatim
+(CreateContainerConfigError → the exact missing Secret/ConfigMap key; ImagePullBackOff; CrashLoopBackOff;
+RunContainerError). Then call kube_events for causes that live only in the event stream
+(FailedScheduling "Insufficient cpu/memory", FailedMount, FailedAttachVolume, failing probes). These two
+tools see pod-level failures that logs and Flux status cannot — a container that never started has no
+logs, and "Insufficient cpu" is an Event, not a log line. Note Flux objects (Kustomization/HelmRelease)
+live in flux-system, not the workload's namespace.
+
 RIGOR — correctness over plausibility. A wrong-but-confident root cause is worse than an honest
 "unresolved":
 - Correlation is NOT causation. "The incident started after change X" does not prove X caused it.

--- a/internal/providers/cluster/cluster.go
+++ b/internal/providers/cluster/cluster.go
@@ -7,6 +7,8 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"sort"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,4 +64,83 @@ func (r *Reader) PodLogs(ctx context.Context, namespace, labelSelector string, s
 		_ = stream.Close()
 	}
 	return out, nil
+}
+
+var _ providers.KubeReader = (*Reader)(nil)
+
+// PodStatuses returns pod health in a namespace (optional label selector), with
+// per-container waiting/terminated reasons — surfacing pod-level failures
+// (CreateContainerConfigError, ImagePullBackOff, CrashLoopBackOff) that never
+// reach logs because the container never started. Unhealthy pods sort first.
+func (r *Reader) PodStatuses(ctx context.Context, namespace, labelSelector string) ([]providers.PodStatus, error) {
+	pods, err := r.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("list pods (%s): %w", namespace, err)
+	}
+	out := make([]providers.PodStatus, 0, len(pods.Items))
+	for i := range pods.Items {
+		out = append(out, podStatus(&pods.Items[i]))
+	}
+	sort.SliceStable(out, func(i, j int) bool { return !out[i].Healthy && out[j].Healthy })
+	return out, nil
+}
+
+func podStatus(p *corev1.Pod) providers.PodStatus {
+	ps := providers.PodStatus{Name: p.Name, Phase: string(p.Status.Phase)}
+	ready, total := 0, 0
+	collect := func(cs []corev1.ContainerStatus) {
+		for _, c := range cs {
+			total++
+			if c.Ready {
+				ready++
+			}
+			switch {
+			case c.State.Waiting != nil && c.State.Waiting.Reason != "" && c.State.Waiting.Reason != "ContainerCreating" && c.State.Waiting.Reason != "PodInitializing":
+				ps.Reasons = append(ps.Reasons, fmt.Sprintf("%s: %s: %s", c.Name, c.State.Waiting.Reason, c.State.Waiting.Message))
+			case c.State.Terminated != nil && c.State.Terminated.Reason != "" && c.State.Terminated.Reason != "Completed":
+				ps.Reasons = append(ps.Reasons, fmt.Sprintf("%s: %s (exit %d): %s", c.Name, c.State.Terminated.Reason, c.State.Terminated.ExitCode, c.State.Terminated.Message))
+			}
+		}
+	}
+	collect(p.Status.InitContainerStatuses)
+	collect(p.Status.ContainerStatuses)
+	ps.Ready = fmt.Sprintf("%d/%d", ready, total)
+	ps.Healthy = len(ps.Reasons) == 0 && (p.Status.Phase == corev1.PodRunning || p.Status.Phase == corev1.PodSucceeded) && ready == total
+	return ps
+}
+
+// Events returns recent Events in a namespace (optionally for one object,
+// optionally Warning-only), most-recent first.
+func (r *Reader) Events(ctx context.Context, namespace, objectName string, warnOnly bool) ([]providers.KubeEvent, error) {
+	opts := metav1.ListOptions{Limit: 200}
+	if objectName != "" {
+		opts.FieldSelector = "involvedObject.name=" + objectName
+	}
+	list, err := r.client.CoreV1().Events(namespace).List(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list events (%s): %w", namespace, err)
+	}
+	out := make([]providers.KubeEvent, 0, len(list.Items))
+	for i := range list.Items {
+		e := &list.Items[i]
+		if warnOnly && e.Type != corev1.EventTypeWarning {
+			continue
+		}
+		out = append(out, providers.KubeEvent{
+			Type:    e.Type,
+			Reason:  e.Reason,
+			Object:  e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
+			Message: e.Message,
+			Count:   e.Count,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return eventTime(&list.Items[i]).After(eventTime(&list.Items[j])) })
+	return out, nil
+}
+
+func eventTime(e *corev1.Event) time.Time {
+	if !e.LastTimestamp.IsZero() {
+		return e.LastTimestamp.Time
+	}
+	return e.EventTime.Time
 }

--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -12,6 +13,10 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 )
+
+// fluxSystemNamespace is where Flux objects conventionally live, regardless of the
+// namespace a workload they manage runs in.
+const fluxSystemNamespace = "flux-system"
 
 // Flux CRD resources (v1).
 var (
@@ -74,10 +79,30 @@ func (r *dynamicReader) GetResource(ctx context.Context, kind, namespace, name s
 		return nil, fmt.Errorf("unsupported kind %q", kind)
 	}
 	u, err := r.client.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
+	if err == nil {
+		return u, nil
+	}
+	if !apierrors.IsNotFound(err) {
 		return nil, err
 	}
-	return u, nil
+	// Namespace fallback. Flux objects usually live in flux-system, not the
+	// namespace of the workload they manage — so a caller passing the workload's
+	// namespace (e.g. an alert's "apps") would otherwise get a misleading NotFound
+	// that reads as "the resource doesn't exist". Retry in flux-system, then search
+	// all namespaces by name, before trusting the NotFound.
+	if namespace != fluxSystemNamespace {
+		if u2, err2 := r.client.Resource(gvr).Namespace(fluxSystemNamespace).Get(ctx, name, metav1.GetOptions{}); err2 == nil {
+			return u2, nil
+		}
+	}
+	if list, lerr := r.client.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); lerr == nil {
+		for i := range list.Items {
+			if list.Items[i].GetName() == name {
+				return &list.Items[i], nil
+			}
+		}
+	}
+	return nil, err // genuinely absent in every namespace: return the original NotFound
 }
 
 // ListEvents returns recent Event lines for an object, filtered client-side by the

--- a/internal/providers/gitops/flux/dynamic_test.go
+++ b/internal/providers/gitops/flux/dynamic_test.go
@@ -91,6 +91,34 @@ func fluxScene() *Provider {
 	return New(NewDynamicReader(client), nil)
 }
 
+func TestGetResourceNamespaceFallback(t *testing.T) {
+	// The Kustomization lives in flux-system, but a caller passes the workload's
+	// namespace ("apps", from an alert). GetResource must resolve it via the
+	// flux-system / all-namespaces fallback instead of returning NotFound.
+	ksObj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "apps", "namespace": "flux-system"},
+		"spec":       map[string]any{"path": "./apps"},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{kustomizationGVR: "KustomizationList"}, ksObj)
+	r := NewDynamicReader(client)
+
+	got, err := r.GetResource(context.Background(), "Kustomization", "apps", "apps")
+	if err != nil {
+		t.Fatalf("expected fallback resolution, got error: %v", err)
+	}
+	if got.GetNamespace() != "flux-system" || got.GetName() != "apps" {
+		t.Fatalf("expected flux-system/apps, got %s/%s", got.GetNamespace(), got.GetName())
+	}
+
+	// A genuinely absent object still returns NotFound.
+	if _, err := r.GetResource(context.Background(), "Kustomization", "apps", "does-not-exist"); err == nil {
+		t.Fatal("expected NotFound for an absent object")
+	}
+}
+
 func TestResourceStatus(t *testing.T) {
 	p := fluxScene()
 	// A present, failing Kustomization: conditions + refs are surfaced.

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -200,6 +200,39 @@ type LogReader interface {
 	PodLogs(ctx context.Context, namespace, labelSelector string, sinceMinutes int) (LogResult, error)
 }
 
+// PodStatus is a pod's high-level health: phase, ready count, and per-container
+// waiting/terminated reasons — the pod-level signals (CreateContainerConfigError,
+// ImagePullBackOff, CrashLoopBackOff, …) that never reach logs because the
+// container never started.
+type PodStatus struct {
+	Name    string
+	Phase   string
+	Ready   string   // "1/2"
+	Healthy bool     // Running/Succeeded with all containers ready and no waiting reasons
+	Reasons []string // e.g. "registry: CreateContainerConfigError: couldn't find key username in Secret …"
+}
+
+// KubeEvent is a normalized Kubernetes Event — surfaces causes that live in the
+// event stream, not logs or status (FailedScheduling, FailedMount, …).
+type KubeEvent struct {
+	Type    string // Normal | Warning
+	Reason  string
+	Object  string // Kind/Name
+	Message string
+	Count   int32
+}
+
+// KubeReader reads read-only pod status and Kubernetes Events for incident triage,
+// backing the pod_status / kube_events tools. Implemented with client-go CoreV1.
+type KubeReader interface {
+	// PodStatuses returns pod health in a namespace, optionally narrowed by a label
+	// selector (empty = all pods).
+	PodStatuses(ctx context.Context, namespace, labelSelector string) ([]PodStatus, error)
+	// Events returns recent Events in a namespace; objectName "" = all objects;
+	// warnOnly restricts to Warning events.
+	Events(ctx context.Context, namespace, objectName string, warnOnly bool) ([]KubeEvent, error)
+}
+
 // CloudProvider abstracts read-only cloud-side context for an incident. It adds
 // the AWS-layer "what changed" lens (mutating control-plane events) and cloud
 // resource health (instances/ASGs/nodegroups) that the in-cluster signals can't see.


### PR DESCRIPTION
Two fixes from grading live investigations against real ground truth — each had **blocked finding the actual root cause** (see the harbor + unschedulable-pods simulations).

**1. Pod-level blindness → `pod_status` + `kube_events`.** `CreateContainerConfigError` (the exact missing Secret key), `ImagePullBackOff`, `CrashLoopBackOff` live in pod container status; `FailedScheduling` (Insufficient cpu/memory), `FailedMount/AttachVolume` live in Events — unreachable via logs/Flux/metrics, so the agent guessed. Two read-only tools (client-go CoreV1, RBAC already grants pods+events); the prompt steers to them for "workload won't run".

**2. Flux namespace artifact → fallback.** `flux_resource_status`/`flux_tree` reported a real `flux-system` Kustomization as **NOT FOUND** when queried in the workload's namespace (`apps`), and the model read that as "deleted" → a confident-wrong root cause. `GetResource` now falls back to flux-system, then all namespaces by name, before trusting NotFound; the message says so.

Tests cover both. Gate: gofmt clean · build · `go test ./...` · golangci-lint 0 issues.