### PR TITLE
fix(oom): root-cause memory growth — GOMEMLIMIT + bleve index leak

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -14,8 +14,11 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	_ "net/http/pprof" // registers /debug/pprof on DefaultServeMux (loopback-only, opt-in)
 	"os"
 	"os/signal"
+	"runtime/debug"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -116,6 +119,18 @@ func runServe(args []string) error {
 		return err
 	}
 	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	setMemoryLimitFromCgroup(log) // make the GC respect the container memory cap
+
+	// Opt-in pprof on loopback only (reachable via `kubectl port-forward`, never the
+	// Service) — so a memory/CPU issue can be profiled in-cluster without exposing it.
+	if os.Getenv("RUNLORE_PPROF") == "true" {
+		go func() {
+			log.Info("pprof listening", "addr", "127.0.0.1:6060")
+			if err := http.ListenAndServe("127.0.0.1:6060", nil); err != nil {
+				log.Warn("pprof server stopped", "err", err)
+			}
+		}()
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -839,4 +854,30 @@ func restConfig() (*rest.Config, error) {
 	}
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+// setMemoryLimitFromCgroup sets GOMEMLIMIT to ~90% of the cgroup v2 memory limit
+// so the Go GC respects the container's memory cap — keeping the heap under a soft
+// ceiling and returning memory to the OS under pressure — instead of letting RSS
+// grow across investigations until the cgroup OOM-kills the process. No-op when
+// GOMEMLIMIT is set explicitly, or there is no cgroup memory limit.
+func setMemoryLimitFromCgroup(log *slog.Logger) {
+	if os.Getenv("GOMEMLIMIT") != "" {
+		return // an explicit operator override wins
+	}
+	b, err := os.ReadFile("/sys/fs/cgroup/memory.max") // cgroup v2 (EKS)
+	if err != nil {
+		return
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "" || s == "max" {
+		return // unlimited
+	}
+	cgroupMax, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || cgroupMax <= 0 {
+		return
+	}
+	limit := cgroupMax / 10 * 9 // 90%: leave headroom for non-heap (stacks, bleve, runtime)
+	debug.SetMemoryLimit(limit)
+	log.Info("GOMEMLIMIT set from cgroup", "cgroup_max_bytes", cgroupMax, "gomemlimit_bytes", limit)
 }

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -51,8 +51,16 @@ func (c *Catalog) Reload(dir string) ([]string, error) {
 		return nil, err
 	}
 	c.mu.Lock()
+	old := c.index
 	c.index, c.entries = idx, entries
 	c.mu.Unlock()
+	// Release the previous index's resources. Search holds the read lock for the
+	// whole query, so by the time the swap above acquired the write lock no query
+	// is still using `old` — closing it here is safe and prevents a bleve index
+	// leaking on every git-sync reload.
+	if old != nil {
+		_ = old.Close()
+	}
 	return skipped, nil
 }
 


### PR DESCRIPTION
The agent OOMKilled under **back-to-back** investigations (one fit 1.5Gi; the next tipped the cgroup). Root-caused (not a transcript leak — the ReAct `messages` slice is function-local + GC'd):

1. **No GOMEMLIMIT** — the Go runtime didn't know the container cap, so the heap targeted 2× live and freed memory wasn't returned to the OS → transient per-investigation peaks accumulated as RSS until the cgroup OOM-killed. `setMemoryLimitFromCgroup` reads `/sys/fs/cgroup/memory.max` and sets GOMEMLIMIT to 90% (explicit env still wins).
2. **bleve index leak** — `Catalog.Reload` built a new `NewMemOnly` index every 5-min git-sync and swapped without `Close()`-ing the old one. Now closed after the swap (safe per the Search read-lock).

Plus opt-in loopback pprof (`RUNLORE_PPROF=true`) for future in-cluster profiling. Gate green. Will verify by re-running the back-to-back scenario that OOMed.