### PR TITLE
feat(learning): curation workflow — file-time gate + lore curate agent

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -511,7 +511,7 @@ func buildAuto(cfg *config.Config, exec action.Executor, aud audit.Auditor, log 
 
 // buildCurator returns a Curator when the GitHub App token + KB repo are
 // configured, else nil.
-func buildCurator(cfg *config.Config, token forgeToken, log *slog.Logger) *curator.Curator {
+func buildCurator(cfg *config.Config, token forgeToken, cat *catalog.Catalog, log *slog.Logger) *curator.Curator {
 	if token == nil || cfg.Forge.KBRepo == "" {
 		return nil
 	}
@@ -524,9 +524,21 @@ func buildCurator(cfg *config.Config, token forgeToken, log *slog.Logger) *curat
 	if base == "" {
 		base = "main"
 	}
+	dup := cfg.Forge.DupScore
+	if dup == 0 {
+		dup = 5.0
+	}
+	minConf := cfg.Forge.MinConfidence
+	if minConf == 0 {
+		minConf = 0.75
+	}
 	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(token))
-	log.Info("curator enabled", "repo", cfg.Forge.KBRepo)
-	return &curator.Curator{Issues: client, MinConfidencePR: 0.75, Log: log}
+	log.Info("curator enabled", "repo", cfg.Forge.KBRepo, "dup_score", dup, "min_confidence", minConf)
+	cur := &curator.Curator{Forge: client, DupScore: dup, MinConfidence: minConf, Log: log}
+	if cat != nil { // assign via concrete check to avoid a typed-nil interface
+		cur.Catalog = cat
+	}
+	return cur
 }
 
 // buildReinvestigator returns a poller that re-runs KB issues labelled
@@ -542,7 +554,7 @@ func buildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.G
 		return nil
 	}
 	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, cfg.Forge.BaseBranch, github.TokenFunc(token))
-	model, tools, recall := buildModelAndTools(ctx, cfg, gp, log)
+	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gp, log)
 	run := func(ctx context.Context, req investigate.Request) (providers.Investigation, error) {
 		var res providers.Investigation
 		var got bool
@@ -621,7 +633,7 @@ func runCatalogSync(args []string) error {
 
 // buildModelAndTools assembles the model, investigation tools, and the instant-recall
 // short-circuit from config + the GitOps provider. Shared by serve and investigate.
-func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, log *slog.Logger) (providers.ModelProvider, []investigate.Tool, *investigate.Recall) {
+func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, log *slog.Logger) (providers.ModelProvider, []investigate.Tool, *investigate.Recall, *catalog.Catalog) {
 	apiKey := ""
 	if cfg.Model.APIKeyEnv != "" {
 		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
@@ -638,7 +650,8 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		}
 	}
 	var recall *investigate.Recall
-	if cat := buildCatalog(ctx, cfg, forgeTok, log); cat != nil {
+	cat := buildCatalog(ctx, cfg, forgeTok, log)
+	if cat != nil {
 		tools = append(tools, investigate.KBSearchTool{Catalog: cat})
 		if cfg.Catalog.InstantRecall.Enabled {
 			recall = &investigate.Recall{Catalog: cat, MinScore: cfg.Catalog.InstantRecall.MinScore}
@@ -673,7 +686,7 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 			log.Info("cloud provider enabled", "provider", "aws", "region", cfg.Cloud.Region)
 		}
 	}
-	return model, tools, recall
+	return model, tools, recall, cat
 }
 
 // kubeClientset builds a read-only clientset for pod-log access, or nil when no
@@ -730,7 +743,7 @@ func runInvestigate(args []string) error {
 	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	ctx := context.Background()
 
-	model, tools, recall := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
+	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
 		Model: model, Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
@@ -761,11 +774,11 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
 	}
-	model, tools, recall := buildModelAndTools(ctx, cfg, gp, log)
+	model, tools, recall, cat := buildModelAndTools(ctx, cfg, gp, log)
 	log.Info("using LLM investigator", "provider", modelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)
 	log.Info("delivery notifiers", "count", notifier.Len())
-	cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), log)
+	cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), cat, log)
 	actions := action.New(cfg.Actions)
 	if actions.Enabled() {
 		log.Info("action policy enabled", "mode", string(actions.Mode()))

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Smana/runlore/internal/audit"
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/curate"
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/eval"
 	fluxexec "github.com/Smana/runlore/internal/executor/flux"
@@ -68,6 +69,7 @@ Usage:
   lore serve [--config <path>] [--addr <addr>]        run the in-cluster agent (react to incidents)
   lore catalog sync [--config <path>]                 clone/pull + index the knowledge catalog
   lore eval [--config <path>] [--cases <dir>]         replay incident cases, score RCA identification
+  lore curate [--config <path>]                       groom the KB backlog (dedup open PRs)
   lore version                                        print version
 `
 
@@ -99,6 +101,11 @@ func main() {
 	case "catalog":
 		if err := runCatalog(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "catalog:", err)
+			os.Exit(1)
+		}
+	case "curate":
+		if err := runCurate(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "curate:", err)
 			os.Exit(1)
 		}
 	default:
@@ -539,6 +546,47 @@ func buildCurator(cfg *config.Config, token forgeToken, cat *catalog.Catalog, lo
 		cur.Catalog = cat
 	}
 	return cur
+}
+
+// runCurate grooms the KB backlog (Phase-2 curation agent). v1 runs the
+// backlog-dedup pass — the highest-value, fully-wireable groom (it collapses the
+// duplicate open PRs the file-time gate couldn't see across history). The
+// resolution-gated decision-ready queue, lifecycle/decay, and recurrence→gap-issue
+// passes are implemented + tested in internal/curate but need a forge updated_at
+// field + a cluster ResolutionChecker + a recurrence store to wire — follow-up.
+func runCurate(args []string) error {
+	fs := flag.NewFlagSet("curate", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		return err
+	}
+	if cfg.Forge.KBRepo == "" {
+		return fmt.Errorf("curate requires forge.kb_repo")
+	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	tok := buildForgeTokenSource(cfg, log)
+	if tok == nil {
+		return fmt.Errorf("curate requires a configured GitHub App (forge.github_app)")
+	}
+	owner, repo, ok := strings.Cut(cfg.Forge.KBRepo, "/")
+	if !ok {
+		return fmt.Errorf("forge.kb_repo must be owner/name")
+	}
+	base := cfg.Forge.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+	forge := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(tok))
+	agent := curate.Agent{Log: log, Passes: []curate.Pass{
+		curate.Dedup{Forge: forge, Log: log},
+	}}
+	log.Info("curate: grooming KB backlog", "repo", cfg.Forge.KBRepo)
+	agent.Run(context.Background())
+	return nil
 }
 
 // buildReinvestigator returns a poller that re-runs KB issues labelled

--- a/docs/superpowers/plans/2026-06-21-learning-phase1-filetime-gate.md
+++ b/docs/superpowers/plans/2026-06-21-learning-phase1-filetime-gate.md
@@ -1,0 +1,751 @@
+# Learning Curation — Phase 1: File-time Gate (Plan 1 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the curator from filing duplicate and low-quality KB artifacts: before opening anything, dedup the finding (against the catalog + open KB PRs) and gate on quality; only novel, quality-passing findings become a merge-ready PR; the old `uncertain → OpenIssue` branch is deleted.
+
+**Architecture:** Refactor `internal/curator` from "confidence ≥ 0.75 → PR else issue" into a three-step gate (dedup → quality → draft). Add a `ListPRsByLabel` forge method (the existing `ListIssuesByLabel` filters PRs out) and a `Comment`-based coalesce path (reusing the forge methods reinvestigate already added). Upgrade the OKF drafter to the full Symptom/Investigate/Cause/Resolution shape with a decision card. **The file-time gate enforces quality + novelty only** (PRs are labelled `solved`); the `resolved`/`accepted` *merge* condition is enforced later by Phase 2 + the human.
+
+**Tech Stack:** Go 1.26 stdlib + `net/http/httptest`, `gopkg.in/yaml.v3`. Reuses `providers.{Investigation,KBEntry,Ref,CuratedIssue}`, `catalog.{ScoredSearcher,ScoredEntry,Entry}`, `internal/forge/github`.
+
+**Verified integration points (verbatim):**
+- `curator.Curator{Issues providers.IssueProvider; MinConfidencePR float64; Log *slog.Logger}`; `Curate` routes `conf ≥ MinConfidencePR → Issues.OpenPR(draftKBEntry(inv))` else `Issues.OpenIssue(inv)` (`internal/curator/curator.go:15-67`).
+- `providers.IssueProvider{ OpenIssue(ctx, Investigation)(Ref,error); OpenPR(ctx, KBEntry)(Ref,error) }` (`providers.go:273-276`). `providers.ReinvestForge{ ListIssuesByLabel(ctx,label)([]CuratedIssue,error); Comment(ctx,number,body)error; ReplaceLabel(ctx,number,remove,add)error }` (`providers.go:290-298`).
+- `github.Client` methods: `OpenIssue`, `OpenPR` (4-call + `addLabels`), `addLabels`(priv), `ListIssuesByLabel`→`[]providers.CuratedIssue` (**filters PRs out**), `Comment`, `ReplaceLabel`; `do(ctx,method,path,body,out)`; `New(baseURL,owner,repo,baseBranch,TokenFunc)`; `var lifecycleLabels = []string{"runlore","triggered"}` (`internal/forge/github/github.go`).
+- `catalog.ScoredSearcher{ SearchScored(query string,k int)([]ScoredEntry,error) }`; `ScoredEntry{Entry Entry; Score float64}`; `Entry{Type,Title,Description,Resource string; Tags []string; Body,Path string}` (`internal/catalog/catalog.go:98-143`, `entry.go:6-14`).
+- `providers.Investigation{Title string; RootCauses []Hypothesis; Changes []Change; Unresolved []string; Confidence float64; Actions []Action; CuratedURL string}`; `Hypothesis{Summary,Confidence,ChangeRef string; Evidence []string; SuggestedAction string; Reversible bool}`; `Change{Workload Workload; ...}`; `Workload{Kind,Name,Namespace string}`.
+- `buildCurator(cfg *config.Config, token forgeToken, log) *curator.Curator` builds `github.New(...)` and returns `&curator.Curator{Issues: client, MinConfidencePR: 0.75, Log: log}`; called in `buildInvestigator`, and `OnComplete` calls `cur.Curate(ctx, found)` *before* `notifier.Deliver` (`cmd/lore/main.go:514-530, 805`).
+- Test idiom: interface fakes (`fakeIssues` in `curator_test.go`) + `httptest` (`github_test.go`, `New(srv.URL, "o","r","main", staticToken("tok"))`). Gate: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/curator/fingerprint.go` + `_test.go` *(create)* | `Fingerprint(inv)` query string + `Novelty` (catalog dedup via SearchScored) |
+| `internal/forge/github/github.go` + `github_test.go` *(modify)* | add `ListPRsByLabel(ctx,label) ([]providers.CuratedIssue,error)` |
+| `internal/providers/providers.go` *(modify)* | add `CurationForge` interface (`OpenPR` + `ListPRsByLabel` + `Comment`) |
+| `internal/curator/draft.go` + `_test.go` *(create; move+expand `draftKBEntry`)* | upgraded OKF drafter (decision card + Symptom/Investigate/Cause/Resolution) |
+| `internal/curator/curator.go` + `curator_test.go` *(modify)* | new 3-step `Curate` (dedup → quality gate → draft PR \| coalesce \| drop); delete OpenIssue branch |
+| `cmd/lore/main.go` *(modify `buildCurator`)* + `internal/config/config.go` | inject catalog searcher + thresholds; config knobs |
+
+---
+
+## Task 1: Fingerprint + catalog novelty check
+
+**Files:** Create `internal/curator/fingerprint.go`, `internal/curator/fingerprint_test.go`
+
+- [ ] **Step 1: Write the failing test** — `internal/curator/fingerprint_test.go`:
+
+```go
+package curator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestFingerprintIncludesTitleRootAndWorkload(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		RootCauses: []providers.Hypothesis{{Summary: "IAM AccessKeysPerUser quota exceeded"}},
+		Changes:    []providers.Change{{Workload: providers.Workload{Namespace: "tooling", Name: "harbor-registry"}}},
+	}
+	fp := Fingerprint(inv)
+	for _, want := range []string{"HarborRegistryDown", "IAM AccessKeysPerUser quota", "tooling", "harbor-registry"} {
+		if !contains(fp, want) {
+			t.Fatalf("fingerprint %q missing %q", fp, want)
+		}
+	}
+}
+
+// fakeScored is a catalog.ScoredSearcher returning a fixed hit.
+type fakeScored struct {
+	score float64
+	title string
+}
+
+func (f fakeScored) SearchScored(_ string, _ int) ([]catalog.ScoredEntry, error) {
+	if f.title == "" {
+		return nil, nil
+	}
+	return []catalog.ScoredEntry{{Entry: catalog.Entry{Title: f.title}, Score: f.score}}, nil
+}
+
+func TestNoveltyDuplicateAboveThreshold(t *testing.T) {
+	inv := providers.Investigation{Title: "HarborRegistryDown"}
+	n := Novelty{Catalog: fakeScored{score: 9.0, title: "HarborRegistryDown"}, DupScore: 5.0}
+	dup, hit, err := n.IsDuplicate(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dup || hit.Title != "HarborRegistryDown" {
+		t.Fatalf("expected duplicate hit, got dup=%v hit=%+v", dup, hit)
+	}
+}
+
+func TestNoveltyBelowThresholdIsNovel(t *testing.T) {
+	inv := providers.Investigation{Title: "BrandNewThing"}
+	n := Novelty{Catalog: fakeScored{score: 1.0, title: "Unrelated"}, DupScore: 5.0}
+	dup, _, err := n.IsDuplicate(context.Background(), inv)
+	if err != nil || dup {
+		t.Fatalf("expected novel, got dup=%v err=%v", dup, err)
+	}
+}
+
+func TestNoveltyNilCatalogIsNovel(t *testing.T) {
+	n := Novelty{Catalog: nil, DupScore: 5.0}
+	dup, _, err := n.IsDuplicate(context.Background(), providers.Investigation{Title: "x"})
+	if err != nil || dup {
+		t.Fatalf("nil catalog must be novel, got dup=%v err=%v", dup, err)
+	}
+}
+
+func contains(s, sub string) bool { return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0) }
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curator/ -run 'TestFingerprint|TestNovelty' -v`
+
+- [ ] **Step 3: Implement** — `internal/curator/fingerprint.go`:
+
+```go
+package curator
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Fingerprint builds the dedup query string for a finding: the alert/title, the
+// top root-cause signature, and the affected workload. It is a BM25 query (fuzzy),
+// not a hash — matched against the catalog index and open-PR titles.
+func Fingerprint(inv providers.Investigation) string {
+	var b strings.Builder
+	b.WriteString(inv.Title)
+	if len(inv.RootCauses) > 0 {
+		b.WriteString(" " + inv.RootCauses[0].Summary)
+	}
+	if len(inv.Changes) > 0 {
+		w := inv.Changes[0].Workload
+		b.WriteString(" " + w.Namespace + " " + w.Name)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// Novelty decides whether a finding duplicates an existing catalog entry, by
+// scoring its fingerprint against the BM25 catalog index.
+type Novelty struct {
+	Catalog  catalog.ScoredSearcher // nil → everything is novel (no catalog configured)
+	DupScore float64                // top-hit BM25 score ≥ this ⇒ duplicate
+}
+
+// IsDuplicate returns true + the matching entry when the catalog already covers
+// this finding.
+func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) {
+	if n.Catalog == nil {
+		return false, catalog.Entry{}, nil
+	}
+	hits, err := n.Catalog.SearchScored(Fingerprint(inv), 1)
+	if err != nil {
+		return false, catalog.Entry{}, err
+	}
+	if len(hits) > 0 && hits[0].Score >= n.DupScore {
+		return true, hits[0].Entry, nil
+	}
+	return false, catalog.Entry{}, nil
+}
+```
+
+(`ctx` is unused by the in-memory index today but kept in the signature for symmetry with the forge calls and future remote indexes. If golangci-lint's `unparam`/`revive` flags it, keep it — it's part of the deliberate interface shape; do not remove.)
+
+- [ ] **Step 4: Run to verify PASS** — same command. Expect PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+cd /home/smana/Sources/runlore
+git add internal/curator/fingerprint.go internal/curator/fingerprint_test.go
+git commit -m "feat(curator): fingerprint + catalog novelty check"
+```
+
+---
+
+## Task 2: Forge — `ListPRsByLabel`
+
+**Files:** Modify `internal/forge/github/github.go`; add test to `internal/forge/github/github_test.go`
+
+Context: `ListIssuesByLabel` already exists but **filters PRs out** (GitHub's `/issues` endpoint returns both; it drops the ones with a `pull_request` field). We need the inverse for dedup: open *PRs* carrying the `runlore` label.
+
+- [ ] **Step 1: Write the failing test** — append to `internal/forge/github/github_test.go`:
+
+```go
+func TestListPRsByLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/o/r/issues" || r.URL.Query().Get("labels") != "runlore" || r.URL.Query().Get("state") != "open" {
+			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		// one PR (has pull_request), one plain issue (no pull_request) → only the PR is returned
+		_, _ = w.Write([]byte(`[
+		  {"number":48,"title":"KB: HarborRegistryDown","body":"b","labels":[{"name":"runlore"},{"name":"triggered"}],"pull_request":{"url":"x"}},
+		  {"number":39,"title":"Harbor install failing","body":"b","labels":[{"name":"runlore"}]}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	prs, err := c.ListPRsByLabel(context.Background(), "runlore")
+	if err != nil {
+		t.Fatalf("ListPRsByLabel: %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 48 || prs[0].Title != "KB: HarborRegistryDown" {
+		t.Fatalf("want only PR #48, got %+v", prs)
+	}
+	if len(prs[0].Labels) != 2 || prs[0].Labels[0] != "runlore" {
+		t.Fatalf("labels not parsed: %+v", prs[0].Labels)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/forge/github/ -run TestListPRsByLabel -v`
+
+- [ ] **Step 3: Implement** — add to `internal/forge/github/github.go` (model it on the existing `ListIssuesByLabel`; inspect that method first to mirror its JSON-decoding shape). Add after `ListIssuesByLabel`:
+
+```go
+// ListPRsByLabel returns open PRs carrying the given label. GitHub's issues
+// endpoint returns both issues and PRs; this keeps ONLY the entries that have a
+// pull_request object (the inverse of ListIssuesByLabel).
+func (c *Client) ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+	var raw []struct {
+		Number      int    `json:"number"`
+		Title       string `json:"title"`
+		Body        string `json:"body"`
+		Labels      []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		PullRequest *struct {
+			URL string `json:"url"`
+		} `json:"pull_request"`
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s&per_page=100", c.owner, c.repo, url.QueryEscape(label))
+	if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	var out []providers.CuratedIssue
+	for _, it := range raw {
+		if it.PullRequest == nil {
+			continue // a plain issue, not a PR
+		}
+		labels := make([]string, len(it.Labels))
+		for i, l := range it.Labels {
+			labels[i] = l.Name
+		}
+		out = append(out, providers.CuratedIssue{Number: it.Number, Title: it.Title, Body: it.Body, Labels: labels})
+	}
+	return out, nil
+}
+```
+
+Add `"net/url"` to the imports if not present. **Before implementing, read the existing `ListIssuesByLabel` (github.go:162) and match its exact decoding/label-parsing style** — if it already has a shared decode helper or a `CuratedIssue` mapping, reuse it rather than duplicating.
+
+- [ ] **Step 4: Run to verify PASS** — same command.
+
+- [ ] **Step 5: Gate + commit**
+```bash
+cd /home/smana/Sources/runlore
+go test ./internal/forge/github/ && gofmt -l internal/forge/github && golangci-lint run ./internal/forge/github/...
+git add internal/forge/github/github.go internal/forge/github/github_test.go
+git commit -m "feat(forge): ListPRsByLabel (open KB PRs, for dedup)"
+```
+
+---
+
+## Task 3: `CurationForge` interface
+
+**Files:** Modify `internal/providers/providers.go`
+
+The curator needs more than `IssueProvider` (open-only): it must list open PRs and comment to coalesce. Define a focused interface the `*github.Client` already satisfies.
+
+- [ ] **Step 1: Write the failing test** — `internal/providers/curationforge_test.go`:
+
+```go
+package providers_test
+
+import (
+	"github.com/Smana/runlore/internal/forge/github"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// compile-time assertion: the GitHub client satisfies CurationForge.
+var _ providers.CurationForge = (*github.Client)(nil)
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/providers/ -run xxx -v` (expect a COMPILE error: `CurationForge` undefined).
+
+- [ ] **Step 3: Implement** — add to `internal/providers/providers.go` near `IssueProvider`:
+
+```go
+// CurationForge is the forge surface the curator's file-time gate needs: open a
+// drafted PR, list open KB PRs (dedup), and comment to coalesce duplicates.
+type CurationForge interface {
+	OpenPR(ctx context.Context, entry KBEntry) (Ref, error)
+	ListPRsByLabel(ctx context.Context, label string) ([]CuratedIssue, error)
+	Comment(ctx context.Context, number int, body string) error
+}
+```
+
+- [ ] **Step 4: Run to verify PASS** — `go build ./... && go test ./internal/providers/`. (If the assertion fails, `*github.Client` is missing a method — fix the method set, not the interface.)
+
+- [ ] **Step 5: Commit**
+```bash
+cd /home/smana/Sources/runlore
+git add internal/providers/providers.go internal/providers/curationforge_test.go
+git commit -m "feat(providers): CurationForge interface (open PR + list PRs + comment)"
+```
+
+---
+
+## Task 4: Upgraded OKF drafter (decision card + full sections)
+
+**Files:** Create `internal/curator/draft.go`, `internal/curator/draft_test.go`. (Move `draftKBEntry` + `firstLine` out of `curator.go` into `draft.go` and expand.)
+
+- [ ] **Step 1: Write the failing test** — `internal/curator/draft_test.go`:
+
+```go
+package curator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestDraftKBEntryHasDecisionCardAndSections(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{
+			Summary: "IAM AccessKeysPerUser:2 quota → Secret missing username",
+			Evidence: []string{"accesskey/xplane-harbor failed", "CreateContainerConfigError"},
+			SuggestedAction: "delete an old IAM access key", Reversible: false, ChangeRef: "crossplane/xplane-harbor",
+		}},
+		Unresolved: []string{"which key to delete"},
+	}
+	e := draftKBEntry(inv)
+	if e.Type != "Incident" || e.Title != "HarborRegistryDown" {
+		t.Fatalf("meta: %+v", e)
+	}
+	body := e.Body
+	for _, want := range []string{
+		"## Decision", "why keep", "confidence", // decision card
+		"## Symptom", "## Investigate", "## Cause", "## Resolution", // OKF sections
+		"IAM AccessKeysPerUser:2", "delete an old IAM access key", "crossplane/xplane-harbor",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curator/ -run TestDraftKBEntry -v`
+
+- [ ] **Step 3: Implement** — create `internal/curator/draft.go` (move the existing `draftKBEntry`/`firstLine` here and replace the body builder):
+
+```go
+package curator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// draftKBEntry renders an investigation as a merge-ready OKF knowledge entry: a
+// decision card (why-keep + confidence) followed by the OKF sections
+// Symptom / Investigate / Cause / Resolution. The decision card makes the human
+// merge trivial; the sections make the entry reusable knowledge (the #48 standard).
+func draftKBEntry(inv providers.Investigation) providers.KBEntry {
+	var b strings.Builder
+
+	// --- decision card ---
+	fmt.Fprintf(&b, "## Decision\n\n")
+	fmt.Fprintf(&b, "- **why keep:** %s\n", firstLine(inv))
+	fmt.Fprintf(&b, "- **confidence:** %.0f%%\n", inv.Confidence*100)
+	if cr := changeRefs(inv); cr != "" {
+		fmt.Fprintf(&b, "- **provenance:** %s\n", cr)
+	}
+
+	// --- Symptom ---
+	fmt.Fprintf(&b, "\n## Symptom\n\n%s\n", inv.Title)
+
+	// --- Investigate (evidence trail) ---
+	b.WriteString("\n## Investigate\n\n")
+	for _, rc := range inv.RootCauses {
+		for _, e := range rc.Evidence {
+			fmt.Fprintf(&b, "- %s\n", e)
+		}
+	}
+
+	// --- Cause (ranked root causes) ---
+	b.WriteString("\n## Cause\n\n")
+	for i, rc := range inv.RootCauses {
+		fmt.Fprintf(&b, "%d. **%s** (%.0f%%)", i+1, rc.Summary, rc.Confidence*100)
+		if rc.ChangeRef != "" {
+			fmt.Fprintf(&b, " — change: %s", rc.ChangeRef)
+		}
+		b.WriteString("\n")
+	}
+
+	// --- Resolution (suggested, reversible-first) ---
+	b.WriteString("\n## Resolution\n\n")
+	for _, rc := range inv.RootCauses {
+		if rc.SuggestedAction != "" {
+			fmt.Fprintf(&b, "- %s (reversible=%t)\n", rc.SuggestedAction, rc.Reversible)
+		}
+	}
+	if len(inv.Unresolved) > 0 {
+		b.WriteString("\n## Unresolved\n\n")
+		for _, u := range inv.Unresolved {
+			fmt.Fprintf(&b, "- %s\n", u)
+		}
+	}
+
+	return providers.KBEntry{
+		Type:        "Incident",
+		Title:       inv.Title,
+		Description: firstLine(inv),
+		Tags:        []string{"runlore", "incident"},
+		Body:        b.String(),
+	}
+}
+
+func firstLine(inv providers.Investigation) string {
+	if len(inv.RootCauses) > 0 {
+		return inv.RootCauses[0].Summary
+	}
+	return inv.Title
+}
+
+// changeRefs collects the distinct change references cited across root causes
+// (the causing/fixing-change provenance the merge bar requires).
+func changeRefs(inv providers.Investigation) string {
+	var refs []string
+	seen := map[string]bool{}
+	for _, rc := range inv.RootCauses {
+		if rc.ChangeRef != "" && !seen[rc.ChangeRef] {
+			seen[rc.ChangeRef] = true
+			refs = append(refs, rc.ChangeRef)
+		}
+	}
+	return strings.Join(refs, ", ")
+}
+```
+
+Then **delete** the old `draftKBEntry` and `firstLine` from `curator.go` (they now live in `draft.go`).
+
+- [ ] **Step 4: Run to verify PASS** — `cd /home/smana/Sources/runlore && go test ./internal/curator/ -run TestDraftKBEntry -v`
+
+- [ ] **Step 5: Commit**
+```bash
+cd /home/smana/Sources/runlore
+git add internal/curator/draft.go internal/curator/draft_test.go internal/curator/curator.go
+git commit -m "feat(curator): merge-ready OKF drafter (decision card + Symptom/Investigate/Cause/Resolution)"
+```
+
+---
+
+## Task 5: Refactor `Curate` — dedup → quality gate → draft (delete issue branch)
+
+**Files:** Modify `internal/curator/curator.go`, `internal/curator/curator_test.go`
+
+- [ ] **Step 1: Write the failing test** — replace the body of `internal/curator/curator_test.go` with:
+
+```go
+package curator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeForge records OpenPR / Comment calls and serves a fixed open-PR list.
+type fakeForge struct {
+	openedPR  *providers.KBEntry
+	commented []int
+	openPRs   []providers.CuratedIssue
+}
+
+func (f *fakeForge) OpenPR(_ context.Context, e providers.KBEntry) (providers.Ref, error) {
+	f.openedPR = &e
+	return providers.Ref{URL: "https://github.com/x/y/pull/2"}, nil
+}
+func (f *fakeForge) ListPRsByLabel(_ context.Context, _ string) ([]providers.CuratedIssue, error) {
+	return f.openPRs, nil
+}
+func (f *fakeForge) Comment(_ context.Context, n int, _ string) error {
+	f.commented = append(f.commented, n)
+	return nil
+}
+
+func newCurator(f *fakeForge, cat catalog.ScoredSearcher) *Curator {
+	return &Curator{
+		Forge: f, Catalog: cat, DupScore: 5.0, MinConfidence: 0.75,
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func goodFinding() providers.Investigation {
+	return providers.Investigation{
+		Title: "HarborRegistryDown", Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{
+			Summary: "IAM quota exceeded", Confidence: 0.9,
+			Evidence: []string{"CreateContainerConfigError"}, ChangeRef: "xplane-harbor", SuggestedAction: "delete a key",
+		}},
+	}
+}
+
+func TestCurateNovelHighQualityOpensPR(t *testing.T) {
+	f := &fakeForge{}
+	ref, err := newCurator(f, fakeScored{}).Curate(context.Background(), goodFinding())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR == nil || ref.URL == "" {
+		t.Fatalf("expected a PR, got %+v / %s", f.openedPR, ref.URL)
+	}
+}
+
+func TestCurateDuplicateCoalescesNoPR(t *testing.T) {
+	f := &fakeForge{openPRs: []providers.CuratedIssue{{Number: 48, Title: "KB: HarborRegistryDown"}}}
+	// catalog also has it → IsDuplicate true; AND an open PR with a matching title.
+	ref, err := newCurator(f, fakeScored{score: 9, title: "HarborRegistryDown"}).Curate(context.Background(), goodFinding())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR != nil {
+		t.Fatalf("duplicate must NOT open a PR, got %+v", f.openedPR)
+	}
+	if len(f.commented) == 0 {
+		t.Fatal("duplicate should coalesce by commenting on the existing artifact")
+	}
+	if ref.URL != "" {
+		t.Fatalf("duplicate ref should be empty, got %s", ref.URL)
+	}
+}
+
+func TestCurateLowQualityDropsNoArtifact(t *testing.T) {
+	f := &fakeForge{}
+	weak := providers.Investigation{Title: "vague", Confidence: 0.3} // below bar: no root cause, low conf
+	ref, err := newCurator(f, fakeScored{}).Curate(context.Background(), weak)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR != nil || len(f.commented) != 0 || ref.URL != "" {
+		t.Fatalf("low-quality finding must produce no repo artifact, got pr=%+v comment=%v ref=%s", f.openedPR, f.commented, ref.URL)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curator/ -run TestCurate -v` (compile error: `Curator` fields changed).
+
+- [ ] **Step 3: Implement** — replace `internal/curator/curator.go` (keep the package doc comment at the top):
+
+```go
+package curator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Curator is the file-time learning gate: it dedups a finding against the catalog
+// and open PRs, gates on quality, and drafts a merge-ready PR for novel, quality
+// findings. Uncertain/low-quality findings produce NO repo artifact (the chat
+// delivery already informed the human). It never opens issues — the only issues
+// are knowledge-gap issues, opened by the curate agent (Phase 2).
+type Curator struct {
+	Forge         providers.CurationForge
+	Catalog       catalog.ScoredSearcher // nil ⇒ no catalog dedup
+	DupScore      float64                // catalog BM25 dup threshold
+	MinConfidence float64                // quality gate: minimum overall confidence
+	Log           *slog.Logger
+}
+
+// Curate applies the three-step gate. It returns the created PR ref, or an empty
+// ref when the finding was coalesced (duplicate) or dropped (below the bar).
+func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (providers.Ref, error) {
+	// 1. dedup — catalog, then open PRs
+	if dup, hit, err := (Novelty{Catalog: c.Catalog, DupScore: c.DupScore}).IsDuplicate(ctx, inv); err != nil {
+		c.Log.Warn("dedup: catalog search failed", "err", err)
+	} else if dup {
+		c.Log.Info("finding duplicates a catalog entry; not filing", "entry", hit.Title)
+		return providers.Ref{}, nil
+	}
+	if n, ok, err := c.duplicateOpenPR(ctx, inv); err != nil {
+		c.Log.Warn("dedup: list open PRs failed", "err", err)
+	} else if ok {
+		if err := c.Forge.Comment(ctx, n, coalesceComment(inv)); err != nil {
+			return providers.Ref{}, fmt.Errorf("coalesce comment: %w", err)
+		}
+		c.Log.Info("finding coalesced onto an open PR", "pr", n)
+		return providers.Ref{}, nil
+	}
+
+	// 2. quality gate — below the bar ⇒ no repo artifact (chat alert only)
+	if !meetsBar(inv, c.MinConfidence) {
+		c.Log.Info("finding below the quality bar; chat-only, no KB artifact",
+			"confidence", inv.Confidence, "root_causes", len(inv.RootCauses))
+		return providers.Ref{}, nil
+	}
+
+	// 3. draft a merge-ready PR (labelled solved by the forge lifecycle labels)
+	ref, err := c.Forge.OpenPR(ctx, draftKBEntry(inv))
+	if err != nil {
+		return providers.Ref{}, fmt.Errorf("open PR: %w", err)
+	}
+	c.Log.Info("curated as PR", "url", ref.URL, "confidence", inv.Confidence)
+	return ref, nil
+}
+
+// duplicateOpenPR reports an open KB PR whose normalized title matches this
+// finding (cheap title-slug match; deep cross-incident dedup is the curate agent).
+func (c *Curator) duplicateOpenPR(ctx context.Context, inv providers.Investigation) (int, bool, error) {
+	prs, err := c.Forge.ListPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return 0, false, err
+	}
+	want := normTitle(inv.Title)
+	for _, pr := range prs {
+		if normTitle(strings.TrimPrefix(pr.Title, "KB: ")) == want {
+			return pr.Number, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
+// meetsBar is the file-time QUALITY gate (not the merge condition): a confirmed,
+// confident root cause with cited evidence. The resolved/accepted MERGE condition
+// is enforced later by the curate agent + the human.
+func meetsBar(inv providers.Investigation, minConf float64) bool {
+	if inv.Confidence < minConf || len(inv.RootCauses) == 0 {
+		return false
+	}
+	top := inv.RootCauses[0]
+	return top.Summary != "" && len(top.Evidence) > 0
+}
+
+func normTitle(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
+
+func coalesceComment(inv providers.Investigation) string {
+	return fmt.Sprintf("RunLore saw this incident again (confidence %.0f%%). Coalesced rather than re-filed.", inv.Confidence*100)
+}
+```
+
+- [ ] **Step 4: Run to verify PASS** — `cd /home/smana/Sources/runlore && go test ./internal/curator/ -v` (all curator tests).
+
+- [ ] **Step 5: Gate + commit**
+```bash
+cd /home/smana/Sources/runlore
+go build ./... && go vet ./... && go test ./internal/curator/ ./internal/forge/... ./internal/providers/ && gofmt -l internal && golangci-lint run ./internal/...
+git add internal/curator/curator.go internal/curator/curator_test.go
+git commit -m "feat(curator): three-step file-time gate (dedup -> quality -> PR); delete issue branch"
+```
+
+---
+
+## Task 6: Wire `buildCurator` + config knobs
+
+**Files:** Modify `cmd/lore/main.go` (`buildCurator`, ~514-530), `internal/config/config.go`
+
+- [ ] **Step 1: Add config knobs** — in `internal/config/config.go`, extend the `Forge` (or a new `Curation`) struct. Add to the `Forge` struct:
+
+```go
+	DupScore      float64 `yaml:"dup_score"`      // catalog BM25 dedup threshold (default 5.0)
+	MinConfidence float64 `yaml:"min_confidence"` // file-time quality gate (default 0.75)
+```
+
+- [ ] **Step 2: Update `buildCurator`** — it must now pass the catalog searcher + thresholds. `buildCurator`'s signature gains the catalog (built in `buildModelAndTools`/`buildCatalog`). Change it to:
+
+```go
+// buildCurator returns a Curator when the GitHub App token + KB repo are
+// configured, else nil. cat may be nil (no catalog ⇒ no catalog dedup).
+func buildCurator(cfg *config.Config, token forgeToken, cat catalog.ScoredSearcher, log *slog.Logger) *curator.Curator {
+	if token == nil || cfg.Forge.KBRepo == "" {
+		return nil
+	}
+	owner, repo, ok := strings.Cut(cfg.Forge.KBRepo, "/")
+	if !ok {
+		log.Warn("curator disabled: kb_repo must be owner/name", "kb_repo", cfg.Forge.KBRepo)
+		return nil
+	}
+	base := cfg.Forge.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+	dup := cfg.Forge.DupScore
+	if dup == 0 {
+		dup = 5.0
+	}
+	minConf := cfg.Forge.MinConfidence
+	if minConf == 0 {
+		minConf = 0.75
+	}
+	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(token))
+	log.Info("curator enabled", "repo", cfg.Forge.KBRepo, "dup_score", dup, "min_confidence", minConf)
+	return &curator.Curator{Forge: client, Catalog: cat, DupScore: dup, MinConfidence: minConf, Log: log}
+}
+```
+
+Update the **call site** in `buildInvestigator` (main.go ~759-805): the catalog is built there as `cat` inside `buildModelAndTools` — thread it out (or call `buildCatalog` once and pass both to the tools and the curator). Change `cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), log)` to pass the catalog: `cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), cat, log)` where `cat` is the `*catalog.Catalog` already built for `kb_search` (it satisfies `catalog.ScoredSearcher`). If `buildModelAndTools` does not currently return the catalog, have it also return `cat` (it builds it internally at line 641) and thread it through — a small signature change, done in this task.
+
+- [ ] **Step 3: Build + gate** — `cd /home/smana/Sources/runlore && go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — all green.
+
+- [ ] **Step 4: Smoke** — serve still starts with curation enabled (or cleanly disabled without a forge):
+```bash
+cd /home/smana/Sources/runlore && go build -o /tmp/lore ./cmd/lore && /tmp/lore version
+```
+
+- [ ] **Step 5: Commit**
+```bash
+cd /home/smana/Sources/runlore
+git add cmd/lore/main.go internal/config/config.go
+git commit -m "feat(curator): wire catalog dedup + thresholds into buildCurator"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage** (`2026-06-21-runlore-learning-curation-workflow-design.md`): §4 dedup (catalog Task 1 + open-PR Task 2/5), quality gate (Task 5 `meetsBar`), merge-ready PR decision card + OKF sections (Task 4), **delete issue branch** (Task 5 — no `OpenIssue` call remains), forge "list open PRs" (Task 2), config knobs (Task 6). The §3 *merge condition* (`resolved`/`accepted`) is deliberately **out of Phase 1** (it gates merge, enforced by Phase 2 + human) — Phase 1 labels PRs `solved` via the existing `lifecycleLabels`. Coalesce uses the existing `Comment`. Cross-incident fuzzy dedup of the standing backlog is **Phase 2** (Plan 2), noted in Task 5's `duplicateOpenPR` comment.
+- **Placeholder scan:** every code step is complete; the `ctx`-unused note (Task 1) and the "read the sibling method first" note (Task 2) are guidance, not placeholders.
+- **Type consistency:** `Fingerprint`/`Novelty`/`IsDuplicate` (Task 1) consumed by `Curate` (Task 5); `CurationForge` (Task 3: `OpenPR`+`ListPRsByLabel`+`Comment`) is exactly the fake `fakeForge` and the real `*github.Client` method set (Tasks 2,5); `draftKBEntry` (Task 4) consumed by `Curate` (Task 5); `Curator` fields `{Forge,Catalog,DupScore,MinConfidence,Log}` are identical across Tasks 5 and 6. `catalog.ScoredSearcher`/`ScoredEntry`/`Entry`, `providers.CuratedIssue{Number,Title,Body,Labels}`, `KBEntry`, `Investigation`/`Hypothesis`/`Change`/`Workload` match the verbatim signatures.
+
+## What this delivers
+
+After Phase 1, the curator files **only novel, quality-passing** findings as **merge-ready** PRs (decision card + full OKF), coalesces duplicates onto the existing PR/entry instead of re-filing, and **never opens an issue**. The wall of duplicate low-quality PRs stops at the source. The standing backlog cleanup, draft upgrades, recurrence→gap-issues, the `resolved`-gated decision-ready queue, and lifecycle/decay are **Plan 2** (`...-phase2-curate-agent.md`).

--- a/docs/superpowers/plans/2026-06-21-learning-phase2-curate-agent.md
+++ b/docs/superpowers/plans/2026-06-21-learning-phase2-curate-agent.md
@@ -1,0 +1,816 @@
+# Learning Curation — Phase 2: `lore curate` Agent (Plan 2 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax. **Prerequisite:** Plan 1 (`...-phase1-filetime-gate.md`) is merged — `Fingerprint`, `Novelty`, `CurationForge`, `ListPRsByLabel`, and the upgraded drafter exist.
+
+**Goal:** A `lore curate` agent that grooms the standing backlog and maintains the human's decision-ready queue: dedup existing open PRs, re-check incident **resolution** to gate `ready-to-merge` (the `resolved`/`accepted` merge condition), detect recurring-unresolved patterns into rare `knowledge-gap` issues, and drive lifecycle/decay — writing to the forge only, never merging, never touching human-labelled artifacts.
+
+**Architecture:** A new `internal/curate` package (the groomer logic, pure + testable against forge/checker fakes) driven by a `lore curate` subcommand. It reuses Plan 1's `Fingerprint` and the forge's existing `ListPRsByLabel`/`ListIssuesByLabel`/`Comment`/`ReplaceLabel` plus two new forge methods (`Close`, `GetWorkloadHealth` is a *cluster* checker, not forge). State for recurrence lives in the KB repo itself (a `recurrence.json` the agent reads/writes via the forge) so the agent stays stateless across runs.
+
+**Tech Stack:** Go 1.26 stdlib, reuses `internal/curator` (Fingerprint), `internal/forge/github`, `internal/providers`, and a read-only cluster `ResolutionChecker` (client-go, mirrors the existing `cluster` reader used by `pod_status`).
+
+**Verified integration points (from the Plan-1 extraction):**
+- Forge `*github.Client`: `ListIssuesByLabel`, `ListPRsByLabel` (Plan 1), `Comment(ctx,number,body)`, `ReplaceLabel(ctx,number,remove,add)`, `addLabels`, `do(ctx,method,path,body,out)`. **Absent → add this plan:** `Close(ctx, number int) error` (closes an issue or PR via PATCH state=closed).
+- `providers.CuratedIssue{Number int; Title,Body string; Labels []string}` (returned by list methods).
+- `curator.Fingerprint(inv) string` (Plan 1) — reused for clustering; for an already-filed artifact we fingerprint from its title/body.
+- Command pattern: `switch os.Args[1]` + `runCurate(args []string) error` in `cmd/lore/main.go:74-108`; config via `config.Load(path)`.
+- Lifecycle labels: `runlore`, `triggered`, `investigating`, `solved`, plus new `resolved`, `accepted`, `ready-to-merge`, `knowledge-gap`, `stale`, `duplicate` (strings; GitHub creates labels on first use via the labels API).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/forge/github/github.go` + test *(modify)* | add `Close(ctx, number)` (PATCH state=closed) |
+| `internal/curate/forge.go` *(create)* | `CurateForge` interface (list PRs/issues, comment, replacelabel, close) |
+| `internal/curate/dedup.go` + test *(create)* | cluster open PRs by fingerprint; pick canonical; close duplicates with back-ref |
+| `internal/curate/resolution.go` + test *(create)* | `ResolutionChecker` iface + `ready-to-merge` gating (resolved ⇒ queue; else wait for `accepted`) |
+| `internal/curate/recurrence.go` + test *(create)* | recurrence store (read/write `recurrence.json` via forge) → open `knowledge-gap` issue on Nth unresolved |
+| `internal/curate/lifecycle.go` + test *(create)* | stale-close (no progress in window); label advancement |
+| `internal/curate/curate.go` + test *(create)* | `Curator` (Phase-2) orchestrator: runs the passes in order |
+| `cmd/lore/main.go` *(modify)* | `runCurate` subcommand (on-demand); serve-loop timer hook (scheduled) |
+
+---
+
+## Task 1: Forge — `Close`
+
+**Files:** Modify `internal/forge/github/github.go`; test in `github_test.go`.
+
+- [ ] **Step 1: Failing test** — append to `github_test.go`:
+
+```go
+func TestClose(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	if err := c.Close(context.Background(), 42); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if gotMethod != http.MethodPatch || gotPath != "/repos/o/r/issues/42" || gotBody["state"] != "closed" {
+		t.Fatalf("unexpected: %s %s body=%v", gotMethod, gotPath, gotBody)
+	}
+}
+```
+
+- [ ] **Step 2: Verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/forge/github/ -run TestClose -v`
+
+- [ ] **Step 3: Implement** — add to `github.go` (PRs and issues share the `/issues/{n}` endpoint for state):
+
+```go
+// Close closes an issue or PR (they share the issues endpoint for state).
+func (c *Client) Close(ctx context.Context, number int) error {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/repos/%s/%s/issues/%d", c.owner, c.repo, number),
+		map[string]any{"state": "closed"}, nil)
+}
+```
+
+- [ ] **Step 4: Verify PASS + commit**
+```bash
+cd /home/smana/Sources/runlore && go test ./internal/forge/github/ && gofmt -l internal/forge/github && golangci-lint run ./internal/forge/github/...
+git add internal/forge/github/github.go internal/forge/github/github_test.go
+git commit -m "feat(forge): Close (issue/PR)"
+```
+
+---
+
+## Task 2: `CurateForge` interface
+
+**Files:** Create `internal/curate/forge.go`, `internal/curate/forge_test.go`.
+
+- [ ] **Step 1: Failing test** — `forge_test.go`:
+
+```go
+package curate
+
+import (
+	"github.com/Smana/runlore/internal/forge/github"
+)
+
+// compile-time: the GitHub client satisfies CurateForge.
+var _ CurateForge = (*github.Client)(nil)
+```
+
+- [ ] **Step 2: Verify FAIL (compile)** — `cd /home/smana/Sources/runlore && go build ./internal/curate/ 2>&1`
+
+- [ ] **Step 3: Implement** — `internal/curate/forge.go`:
+
+```go
+// Package curate is the Phase-2 grooming agent: it dedups the KB backlog, gates
+// the decision-ready queue on incident resolution, surfaces recurring blind spots
+// as knowledge-gap issues, and drives lifecycle/decay. It writes to the forge only
+// — it never merges and never touches a human-labelled artifact.
+package curate
+
+import (
+	"context"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// CurateForge is the forge surface the groomer needs (all read/label/close — never merge).
+type CurateForge interface {
+	ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	Comment(ctx context.Context, number int, body string) error
+	ReplaceLabel(ctx context.Context, number int, remove, add string) error
+	Close(ctx context.Context, number int) error
+	OpenIssue(ctx context.Context, inv providers.Investigation) (providers.Ref, error)
+}
+```
+
+- [ ] **Step 4: Verify PASS + commit**
+```bash
+cd /home/smana/Sources/runlore && go build ./internal/curate/ && go vet ./internal/curate/
+git add internal/curate/forge.go internal/curate/forge_test.go
+git commit -m "feat(curate): CurateForge interface"
+```
+
+---
+
+## Task 3: Backlog dedup
+
+**Files:** Create `internal/curate/dedup.go`, `internal/curate/dedup_test.go`.
+
+- [ ] **Step 1: Failing test** — `dedup_test.go`:
+
+```go
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeForge struct {
+	prs       []providers.CuratedIssue
+	commented []int
+	closed    []int
+}
+
+func (f *fakeForge) ListPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) { return f.prs, nil }
+func (f *fakeForge) ListIssuesByLabel(context.Context, string) ([]providers.CuratedIssue, error) { return nil, nil }
+func (f *fakeForge) Comment(_ context.Context, n int, _ string) error { f.commented = append(f.commented, n); return nil }
+func (f *fakeForge) ReplaceLabel(context.Context, int, string, string) error { return nil }
+func (f *fakeForge) Close(_ context.Context, n int) error { f.closed = append(f.closed, n); return nil }
+func (f *fakeForge) OpenIssue(context.Context, providers.Investigation) (providers.Ref, error) { return providers.Ref{}, nil }
+
+func TestDedupClosesDuplicatesKeepsCanonical(t *testing.T) {
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 12, Title: "KB: Kustomization DependencyNotReady missing GitRepository"},
+		{Number: 20, Title: "KB: Kustomization/crossplane DependencyNotReady missing GitRepository"},
+		{Number: 27, Title: "KB: Kustomization DependencyNotReady due to missing GitRepository"},
+		{Number: 99, Title: "KB: Totally unrelated harbor valkey outage"},
+	}}
+	d := Dedup{Forge: f, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := d.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// the 3 DependencyNotReady PRs collapse: keep the lowest number (12), close 20 & 27.
+	if len(f.closed) != 2 || !containsInt(f.closed, 20) || !containsInt(f.closed, 27) {
+		t.Fatalf("want close [20 27], got %v", f.closed)
+	}
+	if containsInt(f.closed, 12) || containsInt(f.closed, 99) {
+		t.Fatalf("must not close canonical 12 or unrelated 99: %v", f.closed)
+	}
+	if len(f.commented) != 2 { // back-ref comment on each closed dup
+		t.Fatalf("want back-ref comments on the 2 closed dups, got %v", f.commented)
+	}
+}
+
+func containsInt(xs []int, x int) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestDedup -v`
+
+- [ ] **Step 3: Implement** — `internal/curate/dedup.go`. Cluster by a normalized title signature (token-set Jaccard over the de-noised title); keep the lowest PR number as canonical; close the rest with a back-ref comment. Use a conservative threshold so only clear dups collapse:
+
+```go
+package curate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Dedup collapses near-identical open KB PRs: the lowest-numbered PR in a cluster
+// is canonical; the rest are closed with a back-ref comment. Conservative by
+// design (high similarity threshold) — a missed merge is cheaper than a wrong close.
+type Dedup struct {
+	Forge     CurateForge
+	Threshold float64 // Jaccard over title token-sets; default 0.6 when 0
+	Log       *slog.Logger
+}
+
+func (d Dedup) Run(ctx context.Context) error {
+	thr := d.Threshold
+	if thr == 0 {
+		thr = 0.6
+	}
+	prs, err := d.Forge.ListPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return fmt.Errorf("list PRs: %w", err)
+	}
+	sort.Slice(prs, func(i, j int) bool { return prs[i].Number < prs[j].Number })
+	canonicalOf := map[int]int{} // dup PR number -> canonical PR number
+	for i := range prs {
+		if _, isDup := canonicalOf[prs[i].Number]; isDup {
+			continue
+		}
+		for j := i + 1; j < len(prs); j++ {
+			if _, taken := canonicalOf[prs[j].Number]; taken {
+				continue
+			}
+			if jaccard(titleTokens(prs[i].Title), titleTokens(prs[j].Title)) >= thr {
+				canonicalOf[prs[j].Number] = prs[i].Number
+			}
+		}
+	}
+	for dup, canon := range canonicalOf {
+		if err := d.Forge.Comment(ctx, dup, fmt.Sprintf("Duplicate of #%d — closed by RunLore curate. Reopen if these are genuinely distinct.", canon)); err != nil {
+			d.Log.Warn("dedup: comment failed", "pr", dup, "err", err)
+			continue
+		}
+		if err := d.Forge.Close(ctx, dup); err != nil {
+			d.Log.Warn("dedup: close failed", "pr", dup, "err", err)
+			continue
+		}
+		d.Log.Info("dedup: closed duplicate", "pr", dup, "canonical", canon)
+	}
+	return nil
+}
+
+var titleNoise = map[string]bool{"kb": true, "in": true, "the": true, "due": true, "to": true, "a": true, "of": true, "and": true}
+
+func titleTokens(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, w := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !(r >= 'a' && r <= 'z') && !(r >= '0' && r <= '9')
+	}) {
+		if !titleNoise[w] {
+			out[w] = true
+		}
+	}
+	return out
+}
+
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for k := range a {
+		if b[k] {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	return float64(inter) / float64(union)
+}
+
+var _ = providers.CuratedIssue{}
+```
+
+(Remove the trailing `var _ = providers.CuratedIssue{}` once the package imports settle — it's a guard so the file compiles in isolation during TDD; delete it before commit if `providers` is otherwise used.)
+
+- [ ] **Step 4: Verify PASS + commit**
+```bash
+cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestDedup -v && gofmt -l internal/curate && golangci-lint run ./internal/curate/...
+git add internal/curate/dedup.go internal/curate/dedup_test.go
+git commit -m "feat(curate): backlog dedup (cluster open PRs, close dups with back-ref)"
+```
+
+---
+
+## Task 4: Resolution check → `ready-to-merge` gate
+
+**Files:** Create `internal/curate/resolution.go`, `internal/curate/resolution_test.go`.
+
+The merge condition: `resolved` (incident cleared) ⇒ auto-`ready-to-merge`; otherwise the PR waits for a human `accepted` label. The agent re-checks the workload's health via a `ResolutionChecker` (read-only cluster).
+
+- [ ] **Step 1: Failing test** — `resolution_test.go`:
+
+```go
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type relabelForge struct {
+	*fakeForge
+	relabels [][3]string // number, remove, add (number as the first element's index won't fit; use a struct)
+}
+
+// reuse fakeForge but capture relabels
+type recordingForge struct {
+	prs      []providers.CuratedIssue
+	relabel  map[int]string // number -> added label
+}
+func (f *recordingForge) ListPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) { return f.prs, nil }
+func (f *recordingForge) ListIssuesByLabel(context.Context, string) ([]providers.CuratedIssue, error) { return nil, nil }
+func (f *recordingForge) Comment(context.Context, int, string) error { return nil }
+func (f *recordingForge) ReplaceLabel(_ context.Context, n int, _ , add string) error { if f.relabel == nil { f.relabel = map[int]string{} }; f.relabel[n] = add; return nil }
+func (f *recordingForge) Close(context.Context, int) error { return nil }
+func (f *recordingForge) OpenIssue(context.Context, providers.Investigation) (providers.Ref, error) { return providers.Ref{}, nil }
+
+// fakeChecker reports a fixed resolution per PR number.
+type fakeChecker struct{ resolved map[int]bool }
+func (c fakeChecker) IsResolved(_ context.Context, pr providers.CuratedIssue) (bool, error) { return c.resolved[pr.Number], nil }
+
+func TestResolutionQueuesResolvedOnly(t *testing.T) {
+	f := &recordingForge{prs: []providers.CuratedIssue{
+		{Number: 48, Title: "KB: HarborRegistryDown", Labels: []string{"runlore", "solved"}},
+		{Number: 50, Title: "KB: StillBroken", Labels: []string{"runlore", "solved"}},
+	}}
+	q := Queue{Forge: f, Checker: fakeChecker{resolved: map[int]bool{48: true, 50: false}},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := q.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if f.relabel[48] != "ready-to-merge" {
+		t.Fatalf("resolved PR 48 should be ready-to-merge, got %q", f.relabel[48])
+	}
+	if _, queued := f.relabel[50]; queued {
+		t.Fatalf("unresolved PR 50 must NOT be auto-queued (waits for human accepted)")
+	}
+}
+
+func TestResolutionRespectsHumanAccepted(t *testing.T) {
+	f := &recordingForge{prs: []providers.CuratedIssue{
+		{Number: 48, Title: "KB: AcceptedButUnresolved", Labels: []string{"runlore", "solved", "accepted"}},
+	}}
+	q := Queue{Forge: f, Checker: fakeChecker{resolved: map[int]bool{48: false}},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	_ = q.Run(context.Background())
+	if f.relabel[48] != "ready-to-merge" {
+		t.Fatalf("human-accepted PR should be ready-to-merge even if unresolved, got %q", f.relabel[48])
+	}
+}
+```
+
+(Delete the unused `relabelForge` stub if it lints; the `recordingForge` is the one used.)
+
+- [ ] **Step 2: Verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestResolution -v`
+
+- [ ] **Step 3: Implement** — `internal/curate/resolution.go`:
+
+```go
+package curate
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// ResolutionChecker reports whether the incident behind a curated PR has cleared
+// (alert resolved / resource healthy). Implemented read-only over the cluster.
+type ResolutionChecker interface {
+	IsResolved(ctx context.Context, pr providers.CuratedIssue) (bool, error)
+}
+
+// Queue applies the merge condition: a quality-passing (solved) PR becomes
+// ready-to-merge when the incident is resolved, OR when a human has labelled it
+// accepted. Unresolved + unaccepted PRs wait (surfaced, never auto-queued).
+type Queue struct {
+	Forge   CurateForge
+	Checker ResolutionChecker
+	Log     *slog.Logger
+}
+
+func (q Queue) Run(ctx context.Context) error {
+	prs, err := q.Forge.ListPRsByLabel(ctx, "solved")
+	if err != nil {
+		return err
+	}
+	for _, pr := range prs {
+		if slices.Contains(pr.Labels, "ready-to-merge") {
+			continue // already queued
+		}
+		accepted := slices.Contains(pr.Labels, "accepted")
+		resolved := false
+		if !accepted {
+			resolved, err = q.Checker.IsResolved(ctx, pr)
+			if err != nil {
+				q.Log.Warn("resolution check failed", "pr", pr.Number, "err", err)
+				continue
+			}
+		}
+		if accepted || resolved {
+			if err := q.Forge.ReplaceLabel(ctx, pr.Number, "", "ready-to-merge"); err != nil {
+				q.Log.Warn("queue: relabel failed", "pr", pr.Number, "err", err)
+				continue
+			}
+			q.Log.Info("queued ready-to-merge", "pr", pr.Number, "reason", reason(accepted))
+		}
+	}
+	return nil
+}
+
+func reason(accepted bool) string {
+	if accepted {
+		return "human-accepted"
+	}
+	return "resolved"
+}
+```
+
+> **Note on `ListPRsByLabel("solved")`:** GitHub's `labels=` filter is AND-of-labels for multiple, single-label here; `solved` PRs all carry `runlore` too. The concrete `ResolutionChecker` (cluster-backed) is wired in the subcommand (Task 7) using the existing read-only `cluster` reader (`pod_status`/alert state); its construction is a CLI concern, not part of this pure package.
+
+- [ ] **Step 4: Verify PASS + commit**
+```bash
+cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestResolution -v && gofmt -l internal/curate && golangci-lint run ./internal/curate/...
+git add internal/curate/resolution.go internal/curate/resolution_test.go
+git commit -m "feat(curate): resolution-gated ready-to-merge queue (resolved OR accepted)"
+```
+
+---
+
+## Task 5: Recurrence → `knowledge-gap` issue
+
+**Files:** Create `internal/curate/recurrence.go`, `internal/curate/recurrence_test.go`.
+
+When the **same** unresolved fingerprint shows up N times, open ONE `knowledge-gap` issue (the only issue type). Recurrence counts are kept in a `recurrence.json` in the KB repo so the agent is stateless between runs. (For testability this task models the store as an injected interface; the forge-backed file impl is wired in Task 7.)
+
+- [ ] **Step 1: Failing test** — `recurrence_test.go`:
+
+```go
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type memStore struct{ counts map[string]int }
+func (m *memStore) Load(context.Context) (map[string]int, error) { return m.counts, nil }
+func (m *memStore) Save(_ context.Context, c map[string]int) error { m.counts = c; return nil }
+
+type gapForge struct {
+	*recordingForge
+	openedTitles []string
+}
+func (g *gapForge) OpenIssue(_ context.Context, inv providers.Investigation) (providers.Ref, error) {
+	g.openedTitles = append(g.openedTitles, inv.Title)
+	return providers.Ref{URL: "https://github.com/x/y/issues/1"}, nil
+}
+
+func TestRecurrenceOpensGapIssueOnThreshold(t *testing.T) {
+	store := &memStore{counts: map[string]int{"flux gitrepository not found": 2}} // already seen twice
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	// a 3rd unresolved occurrence of the same pattern → opens the gap issue
+	err := r.Observe(context.Background(), "flux gitrepository not found")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gf.openedTitles) != 1 {
+		t.Fatalf("want 1 knowledge-gap issue at the threshold, got %d", len(gf.openedTitles))
+	}
+	if store.counts["flux gitrepository not found"] != 3 {
+		t.Fatalf("count not persisted: %v", store.counts)
+	}
+}
+
+func TestRecurrenceBelowThresholdNoIssue(t *testing.T) {
+	store := &memStore{counts: map[string]int{}}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	_ = r.Observe(context.Background(), "new pattern")
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("below threshold must not open an issue")
+	}
+}
+```
+
+- [ ] **Step 2: Verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestRecurrence -v`
+
+- [ ] **Step 3: Implement** — `internal/curate/recurrence.go`:
+
+```go
+package curate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// RecurrenceStore persists per-pattern unresolved counts across curate runs.
+type RecurrenceStore interface {
+	Load(ctx context.Context) (map[string]int, error)
+	Save(ctx context.Context, counts map[string]int) error
+}
+
+// Recurrence tracks unresolved-pattern recurrence and opens ONE knowledge-gap
+// issue when a pattern crosses the threshold — the only path that creates issues.
+type Recurrence struct {
+	Forge     CurateForge
+	Store     RecurrenceStore
+	Threshold int // default 3 when 0
+	Log       *slog.Logger
+}
+
+// Observe records one unresolved occurrence of a pattern (a Fingerprint-style key)
+// and opens a knowledge-gap issue when it first reaches the threshold.
+func (r Recurrence) Observe(ctx context.Context, pattern string) error {
+	thr := r.Threshold
+	if thr == 0 {
+		thr = 3
+	}
+	counts, err := r.Store.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("load recurrence: %w", err)
+	}
+	if counts == nil {
+		counts = map[string]int{}
+	}
+	counts[pattern]++
+	if counts[pattern] == thr { // exactly at threshold → open once
+		inv := providers.Investigation{
+			Title: "knowledge-gap: " + pattern,
+			RootCauses: []providers.Hypothesis{{
+				Summary: fmt.Sprintf("RunLore could not resolve %q across %d incidents — needs seeded knowledge or a RunLore fix.", pattern, thr),
+			}},
+		}
+		if _, err := r.Forge.OpenIssue(ctx, inv); err != nil {
+			return fmt.Errorf("open knowledge-gap issue: %w", err)
+		}
+		r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", thr)
+	}
+	return r.Store.Save(ctx, counts)
+}
+```
+
+(The gap issue gets the `knowledge-gap` label via the forge's default labelling on `OpenIssue` plus a `ReplaceLabel` to swap `triggered`→`knowledge-gap` in Task 7's wiring, or extend `OpenIssue` to accept labels — keep that wiring in Task 7, not here.)
+
+- [ ] **Step 4: Verify PASS + commit**
+```bash
+cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestRecurrence -v && gofmt -l internal/curate && golangci-lint run ./internal/curate/...
+git add internal/curate/recurrence.go internal/curate/recurrence_test.go
+git commit -m "feat(curate): recurrence tracking -> knowledge-gap issue"
+```
+
+---
+
+## Task 6: Lifecycle / decay (stale-close)
+
+**Files:** Create `internal/curate/lifecycle.go`, `internal/curate/lifecycle_test.go`.
+
+- [ ] **Step 1: Failing test** — `lifecycle_test.go`:
+
+```go
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestStaleClosesUnlabelledOldArtifacts(t *testing.T) {
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 70, Title: "KB: ancient draft", Labels: []string{"runlore", "triggered"}},
+		{Number: 71, Title: "KB: queued", Labels: []string{"runlore", "ready-to-merge"}},
+		{Number: 72, Title: "KB: accepted", Labels: []string{"runlore", "accepted"}},
+	}}
+	// ages keyed by number; 70 is older than the window, 71/72 irrelevant (protected labels)
+	l := Lifecycle{Forge: f, Stale: func(int) bool { return true }, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := l.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.closed) != 1 || f.closed[0] != 70 {
+		t.Fatalf("only the stale, unprotected #70 should close, got %v", f.closed)
+	}
+}
+```
+
+- [ ] **Step 2: Verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestStale -v`
+
+- [ ] **Step 3: Implement** — `internal/curate/lifecycle.go`. Protect human-touched/queued artifacts (`ready-to-merge`, `accepted`, `investigating`); close only stale `triggered`/`solved`-without-progress with a comment:
+
+```go
+package curate
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// protected labels are never auto-closed by stale sweeping.
+var protected = []string{"ready-to-merge", "accepted", "investigating", "knowledge-gap"}
+
+// Lifecycle closes stale, unprotected KB artifacts (no progress within the window).
+type Lifecycle struct {
+	Forge CurateForge
+	Stale func(number int) bool // true ⇒ older than the staleness window (wired with real ages in Task 7)
+	Log   *slog.Logger
+}
+
+func (l Lifecycle) Run(ctx context.Context) error {
+	prs, err := l.Forge.ListPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return err
+	}
+	for _, pr := range prs {
+		if isProtected(pr.Labels) || !l.Stale(pr.Number) {
+			continue
+		}
+		_ = l.Forge.Comment(ctx, pr.Number, "Closed as stale by RunLore curate (no progress in the staleness window). Reopen if still relevant.")
+		if err := l.Forge.Close(ctx, pr.Number); err != nil {
+			l.Log.Warn("stale close failed", "pr", pr.Number, "err", err)
+			continue
+		}
+		l.Log.Info("closed stale artifact", "pr", pr.Number)
+	}
+	return nil
+}
+
+func isProtected(labels []string) bool {
+	for _, p := range protected {
+		if slices.Contains(labels, p) {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = providers.CuratedIssue{}
+```
+
+(Delete the trailing `var _` guard before commit if `providers` is otherwise referenced.)
+
+- [ ] **Step 4: Verify PASS + commit**
+```bash
+cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestStale -v && gofmt -l internal/curate && golangci-lint run ./internal/curate/...
+git add internal/curate/lifecycle.go internal/curate/lifecycle_test.go
+git commit -m "feat(curate): stale-close lifecycle sweep (protects human-touched artifacts)"
+```
+
+---
+
+## Task 7: `lore curate` subcommand (orchestrator + wiring)
+
+**Files:** Create `internal/curate/curate.go` + test; modify `cmd/lore/main.go`.
+
+- [ ] **Step 1: Failing test** — `internal/curate/curate_test.go` verifies the orchestrator runs each pass and is resilient to a single pass erroring:
+
+```go
+package curate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+type countingPass struct{ ran *int; err error }
+func (p countingPass) Run(context.Context) error { *p.ran++; return p.err }
+
+func TestAgentRunsAllPasses(t *testing.T) {
+	n := 0
+	a := Agent{Passes: []Pass{countingPass{ran: &n}, countingPass{ran: &n, err: errors.New("boom")}, countingPass{ran: &n}},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	a.Run(context.Background())
+	if n != 3 {
+		t.Fatalf("all 3 passes must run even when one errors, ran=%d", n)
+	}
+}
+```
+
+- [ ] **Step 2: Verify FAIL** — `cd /home/smana/Sources/runlore && go test ./internal/curate/ -run TestAgent -v`
+
+- [ ] **Step 3: Implement** — `internal/curate/curate.go`:
+
+```go
+package curate
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Pass is one grooming pass (dedup, queue, lifecycle…). Each is independent and
+// resilient: a pass error is logged, not fatal — the agent runs the rest.
+type Pass interface {
+	Run(ctx context.Context) error
+}
+
+// Agent runs the grooming passes in order. Forge-only writes; never merges.
+type Agent struct {
+	Passes []Pass
+	Log    *slog.Logger
+}
+
+func (a Agent) Run(ctx context.Context) {
+	for _, p := range a.Passes {
+		if err := p.Run(ctx); err != nil {
+			a.Log.Error("curate pass failed", "err", err)
+		}
+	}
+}
+```
+
+Make `Dedup`, `Queue`, `Lifecycle` satisfy `Pass` (they already have `Run(ctx) error` — for `Queue`/`Dedup` it returns error; `Lifecycle.Run` returns error; good). `Recurrence.Observe` is per-pattern, so it's driven inside a small pass that lists unresolved artifacts and observes each — implement `recurrencePass` in Task 7 wiring.
+
+- [ ] **Step 4: Add the subcommand** — in `cmd/lore/main.go`, add `case "curate": ...` to the `main()` switch and a `runCurate(args []string) error` that: loads config, builds the forge client (`github.New(...)` as `buildCurator` does), builds the `ResolutionChecker` from the read-only cluster reader (reuse `kubeClientset`/`cluster.New`), builds the forge-backed `RecurrenceStore` (reads/writes `recurrence.json` via the contents API), assembles `Agent{Passes: []Pass{Dedup{...}, Queue{...}, Lifecycle{...}, recurrencePass{...}}}`, and runs it. Add `--config` and `--once`/`--interval` flags (on-demand vs scheduled). Update the `usage` const with the `lore curate` line.
+
+```go
+func runCurate(args []string) error {
+	fs := flag.NewFlagSet("curate", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		return err
+	}
+	tok := buildForgeTokenSource(cfg, slog.Default())
+	if tok == nil || cfg.Forge.KBRepo == "" {
+		return fmt.Errorf("curate requires forge (github_app) + kb_repo")
+	}
+	owner, repo, _ := strings.Cut(cfg.Forge.KBRepo, "/")
+	base := cfg.Forge.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	forge := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(tok))
+	checker := newClusterResolutionChecker(log) // read-only cluster: alert/resource health
+	agent := curate.Agent{Log: log, Passes: []curate.Pass{
+		curate.Dedup{Forge: forge, Log: log},
+		curate.Queue{Forge: forge, Checker: checker, Log: log},
+		curate.Lifecycle{Forge: forge, Stale: staleByAge(forge), Log: log},
+	}}
+	agent.Run(context.Background())
+	return nil
+}
+```
+
+(`newClusterResolutionChecker` and `staleByAge` are CLI-local helpers: the first uses `kubeClientset`/`cluster.New` to check whether the workload named in a PR's body is healthy now; the second reads PR `updated_at` via the forge. Implement them minimally in `cmd/lore/main.go`; their cluster/forge calls reuse existing patterns. The forge-backed `RecurrenceStore` + `recurrencePass` are wired here too.)
+
+- [ ] **Step 5: Gate + smoke + commit**
+```bash
+cd /home/smana/Sources/runlore
+go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+go build -o /tmp/lore ./cmd/lore && /tmp/lore curate --config /tmp/nonexistent.yaml 2>&1 | grep -q "curate requires\|open config" && echo "OK: curate wired"
+git add internal/curate/curate.go internal/curate/curate_test.go cmd/lore/main.go
+git commit -m "feat(curate): lore curate subcommand (orchestrate dedup/queue/lifecycle/recurrence)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage** (§5): backlog dedup (Task 3), draft upgrade — **deferred** (see below), recurrence→gap-issue (Task 5), decision-ready queue with resolution re-check (Task 4), lifecycle/decay (Task 6), `lore curate` on-demand + scheduled (Task 7); forge-only/never-merge/never-touch-human-labelled guardrails are enforced structurally (no `MergePR` exists; `protected` labels in Task 6; `accepted` short-circuit in Task 4). The `Close` capability (Task 1) and `CurateForge` (Task 2) underpin them.
+- **Scope deferral (honest):** §5 job 2 **"draft upgrade"** (re-investigate/rewrite thin PRs toward the #48 bar) is the one piece **not** fully specified here — it needs a re-investigation hook (the `LoopInvestigator`) + a forge "update file on an existing PR branch" method, and is the most judgment-heavy/expensive pass. It is called out as a **follow-up task** rather than given placeholder code, per the no-placeholder rule. Recommend implementing Tasks 1–7 first (they deliver the dedup + queue + recurrence + lifecycle value), then a focused mini-plan for upgrade once the rest is proven.
+- **Placeholder scan:** the `var _ = providers.CuratedIssue{}` guards (Tasks 3, 6) are explicitly flagged for deletion-on-settle, not silent placeholders; Task 7's CLI helpers are described with exact reuse points. No `TODO`/`TBD`.
+- **Type consistency:** `CurateForge` (Task 2) method set = the fakes (`fakeForge`/`recordingForge`/`gapForge`) and the real `*github.Client` (incl. `Close` from Task 1). `Dedup`/`Queue`/`Lifecycle`/`Recurrence`/`Agent`/`Pass` names and `Run(ctx) error` shape are consistent across Tasks 3–7. `providers.CuratedIssue{Number,Title,Body,Labels}` used uniformly.
+
+## What this delivers
+
+`lore curate` cleans the standing backlog (closes today's duplicate PRs with back-refs), gates the decision-ready queue on real incident resolution (`resolved` auto-queues; `accepted` is the human override; unresolved waits), surfaces recurring blind spots as rare `knowledge-gap` issues, and sweeps stale artifacts — all forge-only, never merging, never touching human-labelled items. With Plan 1 (file-time gate) it closes the loop: few, novel, merge-ready candidates in, a clean queue out, and a catalog that finally compounds (measured by eval scenario 9 flipping SKIP→PASS).

--- a/docs/superpowers/specs/2026-06-21-runlore-learning-curation-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-21-runlore-learning-curation-workflow-design.md
@@ -12,10 +12,10 @@
 
 ## 1. Why this exists — the loop produces but never compounds
 
-Observed on the live `runlore-kb` repo (2026-06-21):
+Observed on the live `runlore-kb` repo (2026-06-21, `origin/main`):
 
-- **0 of ~12 KB PRs were ever merged** — every closed one was closed *unmerged*. The catalog's only entry is the hand-authored **seed** playbook (`helmrelease-upgrade-failure.md`); the "Incidents" section is still empty, and `log.md` has no curation entries.
-- After dozens of investigations, the catalog has grown by **zero** learned entries.
+- **~2 of ~14 KB PRs ever merged** (#38 `harbor-helmrelease-terminal-failed.md`, #48 `harborregistrydown.md`); the rest were closed *unmerged*. The catalog also holds several **hand-authored seed Playbooks** committed directly to main (not via the curator). So the curator-driven loop has contributed only ~2 learned entries despite dozens of investigations — a ~14% merge rate, the rest discarded.
+- **`log.md` is never updated on merge** — merges are manual (`gh`), which doesn't run the curator, so the change log stays empty and provenance isn't recorded.
 - **Heavy duplication**: PRs #12/#20/#22/#27/#29 are all the *same* "Kustomization DependencyNotReady / missing GitRepository" incident; issues #40/#41 both "NodeTerminatedCheckAWS"; #37/#39 both "Harbor install failing."
 - **7 issues** sit open, all `triggered`, **0 promoted, 0 resolved** — a second pile-up queue.
 
@@ -63,13 +63,23 @@ curator agent (Phase 2) detects a RECURRING unresolved pattern (N× same fingerp
 |---|---|
 | `triggered` | filed, untriaged |
 | `investigating` | being worked (reinvestigate running or human engaged) |
-| `solved` | root cause **confirmed + resolution captured** — the *only* state eligible to merge |
-| `ready-to-merge` | `solved` + passed the bar + deduped → in the decision-ready queue |
+| `solved` | root cause **confirmed + resolution captured** (proposed) — necessary but *not sufficient* to merge |
+| `resolved` | the incident actually **cleared** (alert resolved / resource healthy on re-check) — the objective merge condition |
+| `accepted` | a human **explicitly accepts** a quality-passing entry as knowledge even if not yet `resolved` (the #48 case) |
+| `ready-to-merge` | quality criteria pass + deduped + (`resolved` **or** `accepted`) → in the decision-ready queue |
 | `duplicate` / `wont-fix` / `stale` | terminal-closed |
 | `knowledge-gap` | a recurring pattern RunLore can't resolve (the only issue type) |
 
-**The merge bar** (what makes an entry mergeable — the #48 standard, explicit):
-1. `solved` — root cause confirmed, not symptom-only (`must_reach_root`);
+**The merge bar.** A PR is merged only when **(A) the merge condition** *and* **(B) all quality criteria** hold.
+
+**(A) Merge condition — resolved OR accepted** (user rule: "PRs should only be merged when the incident is resolved, or accepted"):
+- `resolved` — the incident actually **cleared**: the alert resolved or the resource is healthy on the curator's re-check. This is objective and the curator can verify it, so it is what auto-applies `ready-to-merge`.
+- `accepted` — a human **explicitly accepts** the entry as correct, valuable knowledge even though the incident isn't (yet) resolved. This is the human override for correct-but-unresolved knowledge — exactly #48, where the IAM-quota fix was deferred but the entry is right.
+
+A `solved`-but-not-`resolved` PR (root cause known, fix not yet applied/confirmed) therefore **waits** — it is not auto-queued for merge; it merges only on `resolved` or explicit `accepted`. This is what stops premature/speculative entries from compounding.
+
+**(B) Quality criteria (all required):**
+1. root cause confirmed, not symptom-only (`must_reach_root`);
 2. passed the adversarial **verify** pass (not correlation-only);
 3. cites the **causing change** and the **fixing change / resolution** (provenance);
 4. **novel** — not a duplicate of catalog or open artifacts;
@@ -106,7 +116,7 @@ A new `lore curate` mode with the **cross-incident view** the file-time gate str
 1. **Backlog dedup** — cluster existing open PRs (and legacy issues) by fingerprint; close duplicates with a reversible back-ref to the canonical one. (Immediately cleans today's mess: keep 1 "DependencyNotReady", close 4 with a pointer.)
 2. **Draft upgrade** — take promising-but-thin PRs and re-shape toward the #48 bar (re-investigate if needed, rewrite into full OKF). Sub-bar drafts that can't be lifted → close `wont-fix`.
 3. **Recurrence → knowledge-gap issues** — track unresolved findings across incidents; when a fingerprint recurs N× never-solved, open **one** `knowledge-gap` issue. This is the only path that creates issues.
-4. **Decision-ready queue** — apply `ready-to-merge` to PRs that pass the bar, deduped and ranked by value — the single surface the human approves from.
+4. **Decision-ready queue** — the curator **re-checks each quality-passing candidate's incident state** (alert resolved / resource healthy) and applies `ready-to-merge` only to `resolved` ones, deduped and ranked by value — the single surface the human approves from. Correct-but-unresolved candidates wait for explicit human `accepted` (they are surfaced separately, not auto-queued).
 5. **Lifecycle + decay** — advance labels, close stale (no progress in N days), flag aging catalog entries for re-validation / recall down-weighting (`last_validated`).
 
 **Mechanism.** A `lore curate` subcommand operating over the KB git repo + forge API + catalog index. Two run modes:
@@ -151,7 +161,8 @@ Each phase is its own implementation plan (à la the eval-harness engine/catalog
 
 ## 9. Success criteria
 
-- The catalog **grows**: learned entries get merged (from a baseline of 0), and `log.md` records them.
+- The catalog **grows**: learned entries get merged (from a ~2-entry, ~14%-merge-rate baseline) and `log.md` finally records each merge with provenance.
+- PRs merge **only when `resolved` or explicitly `accepted`** — never speculative/`solved`-only entries.
 - A human approving the queue sees **few, deduped, merge-ready** candidates, each with a decision card — no duplicate walls.
 - Duplicate findings **coalesce** instead of re-filing (the 5×"DependencyNotReady" case produces 1 artifact, not 5).
 - The **only** issues that appear are rare `knowledge-gap` issues for genuinely recurring blind spots.

--- a/docs/superpowers/specs/2026-06-21-runlore-learning-curation-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-21-runlore-learning-curation-workflow-design.md
@@ -45,7 +45,7 @@ investigation finding
    │     → coalesce: comment "seen again @T, investigation <link>" + bump; file NOTHING new
    │
    ├─ NOVEL + confident + passes the MERGE BAR
-   │     → draft PR (OKF entry), labels: runlore, solved, ready-to-merge
+   │     → draft PR (OKF entry), labels: runlore, triggered  (curate agent later advances → solved → ready-to-merge)
    │     → YOU approve → merged (catalog grows, log.md appended)
    │     → YOU reject  → closed: wont-fix / rejected
    │
@@ -99,7 +99,7 @@ Enhance `internal/curator/curator.go` (today: `confidence ≥ 0.75 → OpenPR, e
 
 1. **Novelty / dedup check** — fingerprint the finding; query (a) bleve `kb_search` over the catalog and (b) a **new** forge "list open KB PRs" call. Above the match threshold → **coalesce** (comment + bump the canonical artifact) and stop; file nothing new.
 2. **Quality gate** — only findings meeting the **merge bar** (§3) get drafted as a PR. Everything below the bar → **chat alert only, no repo artifact**.
-3. **Merge-ready PR body** — the drafted PR leads with a **decision card**: one-line *why-keep*, confidence, root cause, causing change → fixing change, evidence trail, then the OKF entry diff. Labels `runlore, solved, ready-to-merge`.
+3. **Merge-ready PR body** — the drafted PR leads with a **decision card**: one-line *why-keep*, confidence, root cause, causing change → fixing change, evidence trail, then the OKF entry diff. File-time labels are `runlore, triggered`; the curate agent (Phase 2) advances `triggered → solved → ready-to-merge` once the merge condition (`resolved` or `accepted`, §3) holds — Phase 1 never applies `solved`/`ready-to-merge`.
 
 **What this needs (implementation surface):**
 - a `fingerprint(finding)` + novelty scorer (reuses the catalog index; adds a small threshold);

--- a/docs/superpowers/specs/2026-06-21-runlore-learning-curation-workflow-design.md
+++ b/docs/superpowers/specs/2026-06-21-runlore-learning-curation-workflow-design.md
@@ -1,0 +1,159 @@
+# RunLore Learning / Curation Workflow — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-21 |
+| **Scope** | Make RunLore's learning loop actually *compound* the knowledge catalog: dedup + a real merge gate + a curator agent |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | `docs/design.md` §6 "Learn" (the intended loop, largely unenforced); `internal/curator`, `internal/catalog`, `internal/forge/github`; the eval-harness initiative (`2026-06-21-runlore-eval-harness-design.md`, workstream A) |
+
+---
+
+## 1. Why this exists — the loop produces but never compounds
+
+Observed on the live `runlore-kb` repo (2026-06-21):
+
+- **0 of ~12 KB PRs were ever merged** — every closed one was closed *unmerged*. The catalog's only entry is the hand-authored **seed** playbook (`helmrelease-upgrade-failure.md`); the "Incidents" section is still empty, and `log.md` has no curation entries.
+- After dozens of investigations, the catalog has grown by **zero** learned entries.
+- **Heavy duplication**: PRs #12/#20/#22/#27/#29 are all the *same* "Kustomization DependencyNotReady / missing GitRepository" incident; issues #40/#41 both "NodeTerminatedCheckAWS"; #37/#39 both "Harbor install failing."
+- **7 issues** sit open, all `triggered`, **0 promoted, 0 resolved** — a second pile-up queue.
+
+Root problems (user-confirmed): **(1) no process/criteria** for what's worth keeping or when to merge; **(2) too much noise/duplication** burying the signal; **(3) draft quality** too low to keep. (The *unit* of knowledge — a per-incident entry — is fine; PR #48 "HarborRegistryDown" is a genuinely mergeable example and is the **quality anchor** for this design.)
+
+This design makes the **curation gate actually work** so the catalog compounds, while keeping the human as the (now trivial) merge approver.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Human stays the merge approver**, but the system delivers a short, deduped, high-quality, **decision-ready** queue | RunLore's design treats human merge review as the load-bearing quality gate; the fix is to make that decision trivial, not to automate it away. |
+| D2 | **Drop the per-investigation issue.** Uncertain findings → **chat alert only**, no KB-repo artifact | Issues never enter recall (only merged entries do); per-finding issues are a redundant pile-up nobody works (7 open, 0 promoted). |
+| D3 | **The only issues that exist** are rare **knowledge-gap** issues opened when a pattern *recurs unresolved* | The one genuinely useful signal an issue carries: "RunLore is blind here" → author seeded knowledge or fix RunLore. Requires the cross-incident view (Phase 2). |
+| D4 | **Both layers, sequenced**: Phase 1 file-time gate (stop new noise) → Phase 2 `lore curate` agent (groom backlog + ongoing) | File-time stops the flood cheaply; only a groomer can clean the standing backlog and do cross-incident dedup/upgrade/recurrence. |
+| D5 | **Per-incident entry is an acceptable unit** to merge | User explicitly did not want pattern-synthesis as a precondition; #48-style incident entries are mergeable as-is. |
+| D6 | **Curator agent writes to the forge only — never auto-merges, never auto-closes human-touched artifacts** | The curator is itself a fallible LLM; the human gate and reversibility are the backstop. |
+| D7 | **Quality anchor = PR #48** (HarborRegistryDown): correct root cause + evidence + concrete fix | A concrete, agreed standard for "mergeable," not an abstract bar. |
+
+## 3. The curation policy & lifecycle (the core)
+
+Every investigation finding flows through this state machine. It *operationalizes* the labels RunLore already applies (`triggered`/`investigating`/`solved`), which today are decorative.
+
+```
+investigation finding
+   ├─ DUPLICATE (matches an open PR or a catalog entry)
+   │     → coalesce: comment "seen again @T, investigation <link>" + bump; file NOTHING new
+   │
+   ├─ NOVEL + confident + passes the MERGE BAR
+   │     → draft PR (OKF entry), labels: runlore, solved, ready-to-merge
+   │     → YOU approve → merged (catalog grows, log.md appended)
+   │     → YOU reject  → closed: wont-fix / rejected
+   │
+   └─ uncertain / below the bar
+         → chat alert ONLY (Slack/Matrix) — NO KB-repo artifact
+
+curator agent (Phase 2) detects a RECURRING unresolved pattern (N× same fingerprint, never solved)
+   → opens ONE knowledge-gap issue, labels: runlore, knowledge-gap
+   → you: author seeded knowledge / fix RunLore / close wont-fix
+```
+
+**Label semantics (load-bearing, not cosmetic):**
+
+| Label | Meaning |
+|---|---|
+| `triggered` | filed, untriaged |
+| `investigating` | being worked (reinvestigate running or human engaged) |
+| `solved` | root cause **confirmed + resolution captured** — the *only* state eligible to merge |
+| `ready-to-merge` | `solved` + passed the bar + deduped → in the decision-ready queue |
+| `duplicate` / `wont-fix` / `stale` | terminal-closed |
+| `knowledge-gap` | a recurring pattern RunLore can't resolve (the only issue type) |
+
+**The merge bar** (what makes an entry mergeable — the #48 standard, explicit):
+1. `solved` — root cause confirmed, not symptom-only (`must_reach_root`);
+2. passed the adversarial **verify** pass (not correlation-only);
+3. cites the **causing change** and the **fixing change / resolution** (provenance);
+4. **novel** — not a duplicate of catalog or open artifacts;
+5. well-formed OKF — frontmatter + **Symptom / Investigate / Cause / Resolution** sections.
+
+**Duplicate identity.** "Same incident" = a fingerprint of `alertname + namespace + workload + root-cause signature`, matched via the existing bleve `kb_search` over the catalog **and** a forge search over open KB PRs. Near-matches **coalesce** rather than re-file — this is what kills the 5×"DependencyNotReady" problem.
+
+**Decay.** Merged entries carry `status` (draft/verified), `confidence`, `last_validated`. The curator flags stale entries for re-validation or down-weights them in recall, so wrong or aging knowledge doesn't silently poison future investigations.
+
+**Reinvestigate.** The existing `reinvestigate` outbound-poll (`internal/investigate/reinvestigate.go`), today tied to per-finding issues, is **re-pointed at `knowledge-gap` issues**: a human adds context to a gap issue and labels it `reinvestigate` → RunLore re-runs with that context → if it now reaches `solved`, the finding **promotes to a PR** (and the gap issue closes). It no longer fires on per-finding issues (those no longer exist).
+
+**Thresholds** (`recurrence count N`, `stale window`, `novelty match score`) are **configurable** with defaults set at implementation time — named here as tunables, not left undefined.
+
+## 4. Phase 1 — the file-time gate (in the existing curator)
+
+Enhance `internal/curator/curator.go` (today: `confidence ≥ 0.75 → OpenPR, else OpenIssue`) into a three-step gate. **The `else → OpenIssue` branch is deleted.**
+
+1. **Novelty / dedup check** — fingerprint the finding; query (a) bleve `kb_search` over the catalog and (b) a **new** forge "list open KB PRs" call. Above the match threshold → **coalesce** (comment + bump the canonical artifact) and stop; file nothing new.
+2. **Quality gate** — only findings meeting the **merge bar** (§3) get drafted as a PR. Everything below the bar → **chat alert only, no repo artifact**.
+3. **Merge-ready PR body** — the drafted PR leads with a **decision card**: one-line *why-keep*, confidence, root cause, causing change → fixing change, evidence trail, then the OKF entry diff. Labels `runlore, solved, ready-to-merge`.
+
+**What this needs (implementation surface):**
+- a `fingerprint(finding)` + novelty scorer (reuses the catalog index; adds a small threshold);
+- one **new method on the GitHub forge client** to list/search open KB PRs (today it can only *open* them — `internal/forge/github/github.go`);
+- the OKF-entry drafting upgraded from today's thin "## Summary / Root causes" dump to the full **Symptom/Investigate/Cause/Resolution** shape (the #48 standard);
+- the decision-card PR-body template.
+
+This is the cheap, immediate-relief layer: after it ships, what reaches the human is novel and merge-ready — never again a wall of duplicate low-quality PRs.
+
+## 5. Phase 2 — the `lore curate` agent (the groomer)
+
+A new `lore curate` mode with the **cross-incident view** the file-time gate structurally lacks. Five jobs:
+
+1. **Backlog dedup** — cluster existing open PRs (and legacy issues) by fingerprint; close duplicates with a reversible back-ref to the canonical one. (Immediately cleans today's mess: keep 1 "DependencyNotReady", close 4 with a pointer.)
+2. **Draft upgrade** — take promising-but-thin PRs and re-shape toward the #48 bar (re-investigate if needed, rewrite into full OKF). Sub-bar drafts that can't be lifted → close `wont-fix`.
+3. **Recurrence → knowledge-gap issues** — track unresolved findings across incidents; when a fingerprint recurs N× never-solved, open **one** `knowledge-gap` issue. This is the only path that creates issues.
+4. **Decision-ready queue** — apply `ready-to-merge` to PRs that pass the bar, deduped and ranked by value — the single surface the human approves from.
+5. **Lifecycle + decay** — advance labels, close stale (no progress in N days), flag aging catalog entries for re-validation / recall down-weighting (`last_validated`).
+
+**Mechanism.** A `lore curate` subcommand operating over the KB git repo + forge API + catalog index. Two run modes:
+- **on-demand**: `lore curate` (human or CI);
+- **scheduled**: in-cluster CronJob (or a serve-loop timer) on a cadence.
+
+**Write boundary (guardrails — the curator is a fallible LLM):**
+- Writes to the **forge only** (comments, labels, close-dups, gap issues, draft-branch commits). **Never auto-merges. Never auto-closes a `ready-to-merge` or any human-labeled/human-touched artifact.**
+- Dedup-close requires a **high** match threshold + leaves a reversible back-ref (reopen is one click).
+- Draft upgrades are commits to the PR branch, not merges.
+- Every curator action goes through the existing append-only **audit log** (`internal/audit`).
+
+## 6. Guardrails, observability, and tie to the eval harness
+
+**KB-poisoning defense.** Frontier RCA is <50% accurate (ITBench, `docs/design.md` §10), so a wrong merged entry is a real risk. Defenses: the merge bar requires the verify pass; the human approves every merge; entries carry `status`/`confidence`/`last_validated`; the verify pass treats recalled catalog content as untrusted; decay down-weights stale entries.
+
+**Observability (so we can tell if learning is actually improving).** Track and expose:
+- **catalog growth** (learned entries merged over time — today: 0);
+- **merge rate** (drafted PRs that merge vs close-unmerged);
+- **dedup rate** (coalesced/closed-dup vs total findings);
+- **recall hit rate** (investigations short-circuited or grounded by a learned entry);
+- **time-to-merge** for `ready-to-merge` PRs.
+
+**Tie to the eval harness (workstream A).** The eval harness's **scenario 9 (instant-recall)** is the closed-loop validation: once a curated entry for an incident exists, re-firing that incident's symptom should short-circuit via `kb_search` instead of re-investigating. That scenario goes from SKIP → PASS exactly when this curation workflow produces its first mergeable, recall-able entry — so workstream A *measures* whether workstream B is working.
+
+## 7. Phasing
+
+| Phase | Scope | Deliverable |
+|---|---|---|
+| **Phase 1** (file-time gate) | dedup + quality gate + merge-ready PR body in the curator; delete the issue branch; forge "list open PRs" method; OKF drafting upgrade | fewer, novel, merge-ready PRs; the decision card |
+| **Phase 2** (`lore curate` agent) | backlog dedup, draft upgrade, recurrence→gap-issue, decision-ready queue, lifecycle/decay; on-demand + scheduled | the groomer; a clean backlog and a single approve-from surface |
+
+Each phase is its own implementation plan (à la the eval-harness engine/catalog split).
+
+## 8. Out of scope
+
+- **Auto-merge** of any kind (human stays the gate, D1).
+- **Cross-incident pattern *synthesis*** into higher-order playbooks (per-incident entries are fine, D5) — a possible later phase, not now.
+- Vector/embedding retrieval (the catalog is BM25 today; orthogonal).
+- GitLab forge support (GitHub only, as today).
+- The autonomy ladder / cluster-mutating remediation (separate track).
+
+## 9. Success criteria
+
+- The catalog **grows**: learned entries get merged (from a baseline of 0), and `log.md` records them.
+- A human approving the queue sees **few, deduped, merge-ready** candidates, each with a decision card — no duplicate walls.
+- Duplicate findings **coalesce** instead of re-filing (the 5×"DependencyNotReady" case produces 1 artifact, not 5).
+- The **only** issues that appear are rare `knowledge-gap` issues for genuinely recurring blind spots.
+- The curator agent never merges and never closes a human-touched artifact; every action is audited and reversible.
+- Eval scenario 9 (instant-recall) flips SKIP → PASS once the first relevant entry is merged — proving the loop compounds.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -336,10 +336,12 @@ func (c *Config) Validate() error {
 
 // Forge holds git-forge authentication and the curation target repo.
 type Forge struct {
-	GitHubApp    GitHubApp `yaml:"github_app"`
-	KBRepo       string    `yaml:"kb_repo"`        // "owner/name" — the catalog repo for curation
-	BaseBranch   string    `yaml:"base_branch"`    // PR target branch (default "main")
-	GitHubAPIURL string    `yaml:"github_api_url"` // override for GHES/tests (default https://api.github.com)
+	GitHubApp     GitHubApp `yaml:"github_app"`
+	KBRepo        string    `yaml:"kb_repo"`        // "owner/name" — the catalog repo for curation
+	BaseBranch    string    `yaml:"base_branch"`    // PR target branch (default "main")
+	GitHubAPIURL  string    `yaml:"github_api_url"` // override for GHES/tests (default https://api.github.com)
+	DupScore      float64   `yaml:"dup_score"`      // file-time catalog BM25 dedup threshold (default 5.0)
+	MinConfidence float64   `yaml:"min_confidence"` // file-time quality gate: min overall confidence (default 0.75)
 }
 
 // GitHubApp holds GitHub App credentials. The private key mints 1-hour

--- a/internal/curate/curate.go
+++ b/internal/curate/curate.go
@@ -1,0 +1,27 @@
+package curate
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Pass is one grooming pass (dedup, queue, lifecycle…). Each is independent and
+// resilient: a pass error is logged, not fatal — the agent runs the rest.
+type Pass interface {
+	Run(ctx context.Context) error
+}
+
+// Agent runs the grooming passes in order. Forge-only writes; never merges.
+type Agent struct {
+	Passes []Pass
+	Log    *slog.Logger
+}
+
+// Run executes every pass, logging (not propagating) per-pass errors.
+func (a Agent) Run(ctx context.Context) {
+	for _, p := range a.Passes {
+		if err := p.Run(ctx); err != nil {
+			a.Log.Error("curate pass failed", "err", err)
+		}
+	}
+}

--- a/internal/curate/curate_test.go
+++ b/internal/curate/curate_test.go
@@ -1,0 +1,36 @@
+package curate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+type countingPass struct {
+	ran *int
+	err error
+}
+
+func (p countingPass) Run(context.Context) error { *p.ran++; return p.err }
+
+func TestAgentRunsAllPasses(t *testing.T) {
+	n := 0
+	a := Agent{Passes: []Pass{
+		countingPass{ran: &n},
+		countingPass{ran: &n, err: errors.New("boom")},
+		countingPass{ran: &n},
+	}, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	a.Run(context.Background())
+	if n != 3 {
+		t.Fatalf("all 3 passes must run even when one errors, ran=%d", n)
+	}
+}
+
+// compile-time: the grooming passes satisfy Pass.
+var (
+	_ Pass = Dedup{}
+	_ Pass = Queue{}
+	_ Pass = Lifecycle{}
+)

--- a/internal/curate/dedup.go
+++ b/internal/curate/dedup.go
@@ -37,6 +37,11 @@ func (d Dedup) Run(ctx context.Context) error {
 			if _, taken := canonicalOf[prs[j].Number]; taken {
 				continue
 			}
+			// Never auto-close a human-touched artifact (solved/ready-to-merge/
+			// accepted/investigating/knowledge-gap) as a duplicate.
+			if isProtected(prs[j].Labels) {
+				continue
+			}
 			if jaccard(titleTokens(prs[i].Title), titleTokens(prs[j].Title)) >= thr {
 				canonicalOf[prs[j].Number] = prs[i].Number
 			}

--- a/internal/curate/dedup.go
+++ b/internal/curate/dedup.go
@@ -1,0 +1,85 @@
+package curate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+)
+
+// Dedup collapses near-identical open KB PRs: the lowest-numbered PR in a cluster
+// is canonical; the rest are closed with a back-ref comment. Conservative by
+// design (high similarity threshold) — a missed merge is cheaper than a wrong close.
+type Dedup struct {
+	Forge     Forge
+	Threshold float64 // Jaccard over title token-sets; default 0.6 when 0
+	Log       *slog.Logger
+}
+
+// Run clusters open PRs by title similarity and closes duplicates.
+func (d Dedup) Run(ctx context.Context) error {
+	thr := d.Threshold
+	if thr == 0 {
+		thr = 0.6
+	}
+	prs, err := d.Forge.ListPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return fmt.Errorf("list PRs: %w", err)
+	}
+	sort.Slice(prs, func(i, j int) bool { return prs[i].Number < prs[j].Number })
+	canonicalOf := map[int]int{} // dup PR number -> canonical PR number
+	for i := range prs {
+		if _, isDup := canonicalOf[prs[i].Number]; isDup {
+			continue
+		}
+		for j := i + 1; j < len(prs); j++ {
+			if _, taken := canonicalOf[prs[j].Number]; taken {
+				continue
+			}
+			if jaccard(titleTokens(prs[i].Title), titleTokens(prs[j].Title)) >= thr {
+				canonicalOf[prs[j].Number] = prs[i].Number
+			}
+		}
+	}
+	for dup, canon := range canonicalOf {
+		if err := d.Forge.Comment(ctx, dup, fmt.Sprintf("Duplicate of #%d — closed by RunLore curate. Reopen if these are genuinely distinct.", canon)); err != nil {
+			d.Log.Warn("dedup: comment failed", "pr", dup, "err", err)
+			continue
+		}
+		if err := d.Forge.Close(ctx, dup); err != nil {
+			d.Log.Warn("dedup: close failed", "pr", dup, "err", err)
+			continue
+		}
+		d.Log.Info("dedup: closed duplicate", "pr", dup, "canonical", canon)
+	}
+	return nil
+}
+
+var titleNoise = map[string]bool{"kb": true, "in": true, "the": true, "due": true, "to": true, "a": true, "of": true, "and": true}
+
+func titleTokens(s string) map[string]bool {
+	out := map[string]bool{}
+	for _, w := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	}) {
+		if !titleNoise[w] {
+			out[w] = true
+		}
+	}
+	return out
+}
+
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for k := range a {
+		if b[k] {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	return float64(inter) / float64(union)
+}

--- a/internal/curate/dedup_test.go
+++ b/internal/curate/dedup_test.go
@@ -66,3 +66,24 @@ func TestDedupClosesDuplicatesKeepsCanonical(t *testing.T) {
 		t.Fatalf("want back-ref comments on the 2 closed dups, got %v", f.commented)
 	}
 }
+
+func TestDedupSkipsProtectedDuplicates(t *testing.T) {
+	// Three title-identical PRs; the middle one is human-`accepted`. Dedup must NOT
+	// close the protected one — it closes only the unprotected duplicate (#12),
+	// keeping the canonical (#10) and the human-touched (#11) open.
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 10, Title: "KB: Kustomization DependencyNotReady missing GitRepository"},
+		{Number: 11, Title: "KB: Kustomization DependencyNotReady missing GitRepository", Labels: []string{"runlore", "accepted"}},
+		{Number: 12, Title: "KB: Kustomization DependencyNotReady missing GitRepository"},
+	}}
+	d := Dedup{Forge: f, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := d.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if containsInt(f.closed, 11) {
+		t.Fatalf("must NOT close the protected (accepted) #11, got %v", f.closed)
+	}
+	if len(f.closed) != 1 || f.closed[0] != 12 {
+		t.Fatalf("should close only the unprotected dup #12, got %v", f.closed)
+	}
+}

--- a/internal/curate/dedup_test.go
+++ b/internal/curate/dedup_test.go
@@ -1,0 +1,68 @@
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeForge records OpenIssue/Comment/Close and serves a fixed PR list. Shared by
+// the dedup and lifecycle tests.
+type fakeForge struct {
+	prs       []providers.CuratedIssue
+	commented []int
+	closed    []int
+}
+
+func (f *fakeForge) ListPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return f.prs, nil
+}
+func (f *fakeForge) ListIssuesByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return nil, nil
+}
+func (f *fakeForge) Comment(_ context.Context, n int, _ string) error {
+	f.commented = append(f.commented, n)
+	return nil
+}
+func (f *fakeForge) ReplaceLabel(context.Context, int, string, string) error { return nil }
+func (f *fakeForge) Close(_ context.Context, n int) error {
+	f.closed = append(f.closed, n)
+	return nil
+}
+func (f *fakeForge) OpenIssue(context.Context, providers.Investigation) (providers.Ref, error) {
+	return providers.Ref{}, nil
+}
+
+func containsInt(xs []int, x int) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDedupClosesDuplicatesKeepsCanonical(t *testing.T) {
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 12, Title: "KB: Kustomization DependencyNotReady missing GitRepository"},
+		{Number: 20, Title: "KB: Kustomization crossplane DependencyNotReady missing GitRepository"},
+		{Number: 27, Title: "KB: Kustomization DependencyNotReady due to missing GitRepository"},
+		{Number: 99, Title: "KB: Totally unrelated harbor valkey outage"},
+	}}
+	d := Dedup{Forge: f, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := d.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.closed) != 2 || !containsInt(f.closed, 20) || !containsInt(f.closed, 27) {
+		t.Fatalf("want close [20 27], got %v", f.closed)
+	}
+	if containsInt(f.closed, 12) || containsInt(f.closed, 99) {
+		t.Fatalf("must not close canonical 12 or unrelated 99: %v", f.closed)
+	}
+	if len(f.commented) != 2 {
+		t.Fatalf("want back-ref comments on the 2 closed dups, got %v", f.commented)
+	}
+}

--- a/internal/curate/forge.go
+++ b/internal/curate/forge.go
@@ -1,0 +1,21 @@
+// Package curate is the Phase-2 grooming agent: it dedups the KB backlog, gates
+// the decision-ready queue on incident resolution, surfaces recurring blind spots
+// as knowledge-gap issues, and drives lifecycle/decay. It writes to the forge only
+// — it never merges and never touches a human-labelled artifact.
+package curate
+
+import (
+	"context"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Forge is the forge surface the groomer needs (all read/label/close — never merge).
+type Forge interface {
+	ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	Comment(ctx context.Context, number int, body string) error
+	ReplaceLabel(ctx context.Context, number int, remove, add string) error
+	Close(ctx context.Context, number int) error
+	OpenIssue(ctx context.Context, inv providers.Investigation) (providers.Ref, error)
+}

--- a/internal/curate/forge_test.go
+++ b/internal/curate/forge_test.go
@@ -1,0 +1,8 @@
+package curate
+
+import (
+	"github.com/Smana/runlore/internal/forge/github"
+)
+
+// compile-time: the GitHub client satisfies Forge.
+var _ Forge = (*github.Client)(nil)

--- a/internal/curate/lifecycle.go
+++ b/internal/curate/lifecycle.go
@@ -6,8 +6,10 @@ import (
 	"slices"
 )
 
-// protectedLabels are never auto-closed by stale sweeping.
-var protectedLabels = []string{"ready-to-merge", "accepted", "investigating", "knowledge-gap"}
+// protectedLabels are never auto-closed (by the stale sweep OR dedup). "solved"
+// is protected too: it marks a PR a human reviewed for content, not yet confirmed
+// for merge — auto-closing it would discard that editorial work.
+var protectedLabels = []string{"solved", "ready-to-merge", "accepted", "investigating", "knowledge-gap"}
 
 // Lifecycle closes stale, unprotected KB artifacts (no progress within the window).
 type Lifecycle struct {
@@ -26,7 +28,12 @@ func (l Lifecycle) Run(ctx context.Context) error {
 		if isProtected(pr.Labels) || !l.Stale(pr.Number) {
 			continue
 		}
-		_ = l.Forge.Comment(ctx, pr.Number, "Closed as stale by RunLore curate (no progress in the staleness window). Reopen if still relevant.")
+		// Comment first; if the back-ref comment fails, do NOT close (preserve the
+		// "why" for whoever reopens it) — mirrors Dedup.
+		if err := l.Forge.Comment(ctx, pr.Number, "Closed as stale by RunLore curate (no progress in the staleness window). Reopen if still relevant."); err != nil {
+			l.Log.Warn("stale: comment failed; not closing", "pr", pr.Number, "err", err)
+			continue
+		}
 		if err := l.Forge.Close(ctx, pr.Number); err != nil {
 			l.Log.Warn("stale close failed", "pr", pr.Number, "err", err)
 			continue

--- a/internal/curate/lifecycle.go
+++ b/internal/curate/lifecycle.go
@@ -1,0 +1,46 @@
+package curate
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+)
+
+// protectedLabels are never auto-closed by stale sweeping.
+var protectedLabels = []string{"ready-to-merge", "accepted", "investigating", "knowledge-gap"}
+
+// Lifecycle closes stale, unprotected KB artifacts (no progress within the window).
+type Lifecycle struct {
+	Forge Forge
+	Stale func(number int) bool // true ⇒ older than the staleness window (wired with real ages in the CLI)
+	Log   *slog.Logger
+}
+
+// Run closes stale, unprotected artifacts with a comment.
+func (l Lifecycle) Run(ctx context.Context) error {
+	prs, err := l.Forge.ListPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return err
+	}
+	for _, pr := range prs {
+		if isProtected(pr.Labels) || !l.Stale(pr.Number) {
+			continue
+		}
+		_ = l.Forge.Comment(ctx, pr.Number, "Closed as stale by RunLore curate (no progress in the staleness window). Reopen if still relevant.")
+		if err := l.Forge.Close(ctx, pr.Number); err != nil {
+			l.Log.Warn("stale close failed", "pr", pr.Number, "err", err)
+			continue
+		}
+		l.Log.Info("closed stale artifact", "pr", pr.Number)
+	}
+	return nil
+}
+
+func isProtected(labels []string) bool {
+	for _, p := range protectedLabels {
+		if slices.Contains(labels, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/curate/lifecycle_test.go
+++ b/internal/curate/lifecycle_test.go
@@ -14,8 +14,10 @@ func TestStaleClosesUnlabelledOldArtifacts(t *testing.T) {
 		{Number: 70, Title: "KB: ancient draft", Labels: []string{"runlore", "triggered"}},
 		{Number: 71, Title: "KB: queued", Labels: []string{"runlore", "ready-to-merge"}},
 		{Number: 72, Title: "KB: accepted", Labels: []string{"runlore", "accepted"}},
+		{Number: 73, Title: "KB: human-reviewed", Labels: []string{"runlore", "solved"}},
 	}}
-	// every PR is "stale" by age, but 71/72 are protected by their labels.
+	// every PR is "stale" by age, but 71/72/73 are protected by their labels (solved
+	// is human-reviewed-for-content and must not be auto-closed).
 	l := Lifecycle{Forge: f, Stale: func(int) bool { return true }, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 	if err := l.Run(context.Background()); err != nil {
 		t.Fatal(err)

--- a/internal/curate/lifecycle_test.go
+++ b/internal/curate/lifecycle_test.go
@@ -1,0 +1,26 @@
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestStaleClosesUnlabelledOldArtifacts(t *testing.T) {
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 70, Title: "KB: ancient draft", Labels: []string{"runlore", "triggered"}},
+		{Number: 71, Title: "KB: queued", Labels: []string{"runlore", "ready-to-merge"}},
+		{Number: 72, Title: "KB: accepted", Labels: []string{"runlore", "accepted"}},
+	}}
+	// every PR is "stale" by age, but 71/72 are protected by their labels.
+	l := Lifecycle{Forge: f, Stale: func(int) bool { return true }, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := l.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.closed) != 1 || f.closed[0] != 70 {
+		t.Fatalf("only the stale, unprotected #70 should close, got %v", f.closed)
+	}
+}

--- a/internal/curate/recurrence.go
+++ b/internal/curate/recurrence.go
@@ -1,0 +1,54 @@
+package curate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// RecurrenceStore persists per-pattern unresolved counts across curate runs.
+type RecurrenceStore interface {
+	Load(ctx context.Context) (map[string]int, error)
+	Save(ctx context.Context, counts map[string]int) error
+}
+
+// Recurrence tracks unresolved-pattern recurrence and opens ONE knowledge-gap
+// issue when a pattern crosses the threshold — the only path that creates issues.
+type Recurrence struct {
+	Forge     Forge
+	Store     RecurrenceStore
+	Threshold int // default 3 when 0
+	Log       *slog.Logger
+}
+
+// Observe records one unresolved occurrence of a pattern (a Fingerprint-style key)
+// and opens a knowledge-gap issue when it first reaches the threshold.
+func (r Recurrence) Observe(ctx context.Context, pattern string) error {
+	thr := r.Threshold
+	if thr == 0 {
+		thr = 3
+	}
+	counts, err := r.Store.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("load recurrence: %w", err)
+	}
+	if counts == nil {
+		counts = map[string]int{}
+	}
+	counts[pattern]++
+	if counts[pattern] == thr { // exactly at threshold → open once
+		inv := providers.Investigation{
+			Title: "knowledge-gap: " + pattern,
+			RootCauses: []providers.Hypothesis{{
+				Summary: fmt.Sprintf("RunLore could not resolve %q across %d incidents — needs seeded knowledge or a RunLore fix.", pattern, thr),
+			}},
+		}
+		if _, err := r.Forge.OpenIssue(ctx, inv); err != nil {
+			return fmt.Errorf("open knowledge-gap issue: %w", err)
+		}
+		r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", thr)
+	}
+	return r.Store.Save(ctx, counts)
+}

--- a/internal/curate/recurrence.go
+++ b/internal/curate/recurrence.go
@@ -38,7 +38,16 @@ func (r Recurrence) Observe(ctx context.Context, pattern string) error {
 		counts = map[string]int{}
 	}
 	counts[pattern]++
-	if counts[pattern] == thr { // exactly at threshold → open once
+	shouldOpen := counts[pattern] == thr // exactly at threshold → open once
+	// Persist the count BEFORE opening the issue. If we opened first and Save then
+	// failed, the next run would re-load the pre-increment count, re-hit the
+	// threshold, and double-open. Saving first means a later OpenIssue failure
+	// leaves the count at thr (next run increments past it → the == thr guard
+	// never re-fires).
+	if err := r.Store.Save(ctx, counts); err != nil {
+		return fmt.Errorf("save recurrence: %w", err)
+	}
+	if shouldOpen {
 		inv := providers.Investigation{
 			Title: "knowledge-gap: " + pattern,
 			RootCauses: []providers.Hypothesis{{
@@ -50,5 +59,5 @@ func (r Recurrence) Observe(ctx context.Context, pattern string) error {
 		}
 		r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", thr)
 	}
-	return r.Store.Save(ctx, counts)
+	return nil
 }

--- a/internal/curate/recurrence_test.go
+++ b/internal/curate/recurrence_test.go
@@ -2,6 +2,7 @@ package curate
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -9,10 +10,27 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-type memStore struct{ counts map[string]int }
+type memStore struct {
+	counts  map[string]int
+	saveErr error // when set, Save fails (and does not persist) — simulates a flaky store
+}
 
-func (m *memStore) Load(context.Context) (map[string]int, error)   { return m.counts, nil }
-func (m *memStore) Save(_ context.Context, c map[string]int) error { m.counts = c; return nil }
+// Load returns a COPY (like a real forge-backed store), so an increment on the
+// loaded map does not mutate the persisted state unless Save succeeds.
+func (m *memStore) Load(context.Context) (map[string]int, error) {
+	cp := make(map[string]int, len(m.counts))
+	for k, v := range m.counts {
+		cp[k] = v
+	}
+	return cp, nil
+}
+func (m *memStore) Save(_ context.Context, c map[string]int) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.counts = c
+	return nil
+}
 
 // gapForge records the issue titles it was asked to open.
 type gapForge struct {
@@ -37,6 +55,30 @@ func TestRecurrenceOpensGapIssueOnThreshold(t *testing.T) {
 	}
 	if store.counts["flux gitrepository not found"] != 3 {
 		t.Fatalf("count not persisted: %v", store.counts)
+	}
+}
+
+func TestRecurrenceSaveFailureDoesNotDoubleOpen(t *testing.T) {
+	// Save fails the first time. Because the count is persisted BEFORE the issue is
+	// opened, a Save failure means NO issue is opened that run (and the count isn't
+	// persisted) — so the next run retries and opens exactly once. Never twice.
+	store := &memStore{counts: map[string]int{"p": 2}, saveErr: errors.New("store unavailable")}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	if err := r.Observe(context.Background(), "p"); err == nil {
+		t.Fatal("want a save error on the first Observe")
+	}
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("must NOT open an issue when Save fails, got %d", len(gf.openedTitles))
+	}
+	// Retry with a working store → opens exactly once.
+	store.saveErr = nil
+	if err := r.Observe(context.Background(), "p"); err != nil {
+		t.Fatal(err)
+	}
+	if len(gf.openedTitles) != 1 {
+		t.Fatalf("want exactly 1 issue after the retry, got %d", len(gf.openedTitles))
 	}
 }
 

--- a/internal/curate/recurrence_test.go
+++ b/internal/curate/recurrence_test.go
@@ -1,0 +1,53 @@
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type memStore struct{ counts map[string]int }
+
+func (m *memStore) Load(context.Context) (map[string]int, error)   { return m.counts, nil }
+func (m *memStore) Save(_ context.Context, c map[string]int) error { m.counts = c; return nil }
+
+// gapForge records the issue titles it was asked to open.
+type gapForge struct {
+	*recordingForge
+	openedTitles []string
+}
+
+func (g *gapForge) OpenIssue(_ context.Context, inv providers.Investigation) (providers.Ref, error) {
+	g.openedTitles = append(g.openedTitles, inv.Title)
+	return providers.Ref{URL: "https://github.com/x/y/issues/1"}, nil
+}
+
+func TestRecurrenceOpensGapIssueOnThreshold(t *testing.T) {
+	store := &memStore{counts: map[string]int{"flux gitrepository not found": 2}} // already seen twice
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := r.Observe(context.Background(), "flux gitrepository not found"); err != nil {
+		t.Fatal(err)
+	}
+	if len(gf.openedTitles) != 1 {
+		t.Fatalf("want 1 knowledge-gap issue at the threshold, got %d", len(gf.openedTitles))
+	}
+	if store.counts["flux gitrepository not found"] != 3 {
+		t.Fatalf("count not persisted: %v", store.counts)
+	}
+}
+
+func TestRecurrenceBelowThresholdNoIssue(t *testing.T) {
+	store := &memStore{counts: map[string]int{}}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := r.Observe(context.Background(), "new pattern"); err != nil {
+		t.Fatal(err)
+	}
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("below threshold must not open an issue")
+	}
+}

--- a/internal/curate/resolution.go
+++ b/internal/curate/resolution.go
@@ -1,0 +1,61 @@
+package curate
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// ResolutionChecker reports whether the incident behind a curated PR has cleared
+// (alert resolved / resource healthy). Implemented read-only over the cluster.
+type ResolutionChecker interface {
+	IsResolved(ctx context.Context, pr providers.CuratedIssue) (bool, error)
+}
+
+// Queue applies the merge condition: a quality-passing (solved) PR becomes
+// ready-to-merge when the incident is resolved, OR when a human has labelled it
+// accepted. Unresolved + unaccepted PRs wait (surfaced, never auto-queued).
+type Queue struct {
+	Forge   Forge
+	Checker ResolutionChecker
+	Log     *slog.Logger
+}
+
+// Run gates each solved PR onto the decision-ready queue.
+func (q Queue) Run(ctx context.Context) error {
+	prs, err := q.Forge.ListPRsByLabel(ctx, "solved")
+	if err != nil {
+		return err
+	}
+	for _, pr := range prs {
+		if slices.Contains(pr.Labels, "ready-to-merge") {
+			continue // already queued
+		}
+		accepted := slices.Contains(pr.Labels, "accepted")
+		resolved := false
+		if !accepted {
+			resolved, err = q.Checker.IsResolved(ctx, pr)
+			if err != nil {
+				q.Log.Warn("resolution check failed", "pr", pr.Number, "err", err)
+				continue
+			}
+		}
+		if accepted || resolved {
+			if err := q.Forge.ReplaceLabel(ctx, pr.Number, "", "ready-to-merge"); err != nil {
+				q.Log.Warn("queue: relabel failed", "pr", pr.Number, "err", err)
+				continue
+			}
+			q.Log.Info("queued ready-to-merge", "pr", pr.Number, "reason", queueReason(accepted))
+		}
+	}
+	return nil
+}
+
+func queueReason(accepted bool) string {
+	if accepted {
+		return "human-accepted"
+	}
+	return "resolved"
+}

--- a/internal/curate/resolution_test.go
+++ b/internal/curate/resolution_test.go
@@ -1,0 +1,75 @@
+package curate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// recordingForge records the label added per PR number. Shared by the resolution
+// and recurrence tests.
+type recordingForge struct {
+	prs     []providers.CuratedIssue
+	relabel map[int]string // number -> added label
+}
+
+func (f *recordingForge) ListPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return f.prs, nil
+}
+func (f *recordingForge) ListIssuesByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return nil, nil
+}
+func (f *recordingForge) Comment(context.Context, int, string) error { return nil }
+func (f *recordingForge) ReplaceLabel(_ context.Context, n int, _, add string) error {
+	if f.relabel == nil {
+		f.relabel = map[int]string{}
+	}
+	f.relabel[n] = add
+	return nil
+}
+func (f *recordingForge) Close(context.Context, int) error { return nil }
+func (f *recordingForge) OpenIssue(context.Context, providers.Investigation) (providers.Ref, error) {
+	return providers.Ref{}, nil
+}
+
+// fakeChecker reports a fixed resolution per PR number.
+type fakeChecker struct{ resolved map[int]bool }
+
+func (c fakeChecker) IsResolved(_ context.Context, pr providers.CuratedIssue) (bool, error) {
+	return c.resolved[pr.Number], nil
+}
+
+func TestResolutionQueuesResolvedOnly(t *testing.T) {
+	f := &recordingForge{prs: []providers.CuratedIssue{
+		{Number: 48, Title: "KB: HarborRegistryDown", Labels: []string{"runlore", "solved"}},
+		{Number: 50, Title: "KB: StillBroken", Labels: []string{"runlore", "solved"}},
+	}}
+	q := Queue{Forge: f, Checker: fakeChecker{resolved: map[int]bool{48: true, 50: false}},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := q.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if f.relabel[48] != "ready-to-merge" {
+		t.Fatalf("resolved PR 48 should be ready-to-merge, got %q", f.relabel[48])
+	}
+	if _, queued := f.relabel[50]; queued {
+		t.Fatalf("unresolved PR 50 must NOT be auto-queued (waits for human accepted)")
+	}
+}
+
+func TestResolutionRespectsHumanAccepted(t *testing.T) {
+	f := &recordingForge{prs: []providers.CuratedIssue{
+		{Number: 48, Title: "KB: AcceptedButUnresolved", Labels: []string{"runlore", "solved", "accepted"}},
+	}}
+	q := Queue{Forge: f, Checker: fakeChecker{resolved: map[int]bool{48: false}},
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := q.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if f.relabel[48] != "ready-to-merge" {
+		t.Fatalf("human-accepted PR should be ready-to-merge even if unresolved, got %q", f.relabel[48])
+	}
+}

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -35,40 +34,4 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 	}
 	c.Log.Info("curated as issue", "url", ref.URL, "confidence", inv.Confidence)
 	return ref, nil
-}
-
-// draftKBEntry renders an investigation as an OKF knowledge entry.
-func draftKBEntry(inv providers.Investigation) providers.KBEntry {
-	var b strings.Builder
-	fmt.Fprintf(&b, "## Summary\n\nConfidence %.0f%%.\n\n## Root causes\n", inv.Confidence*100)
-	tags := []string{"runlore", "incident"}
-	for i, rc := range inv.RootCauses {
-		fmt.Fprintf(&b, "%d. **%s** (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
-		for _, e := range rc.Evidence {
-			fmt.Fprintf(&b, "   - evidence: %s\n", e)
-		}
-		if rc.SuggestedAction != "" {
-			fmt.Fprintf(&b, "   - suggested: %s (reversible=%t)\n", rc.SuggestedAction, rc.Reversible)
-		}
-	}
-	if len(inv.Unresolved) > 0 {
-		b.WriteString("\n## Unresolved\n")
-		for _, u := range inv.Unresolved {
-			fmt.Fprintf(&b, "- %s\n", u)
-		}
-	}
-	return providers.KBEntry{
-		Type:        "Incident",
-		Title:       inv.Title,
-		Description: firstLine(inv),
-		Tags:        tags,
-		Body:        b.String(),
-	}
-}
-
-func firstLine(inv providers.Investigation) string {
-	if len(inv.RootCauses) > 0 {
-		return inv.RootCauses[0].Summary
-	}
-	return inv.Title
 }

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -1,37 +1,96 @@
-// Package curator writes completed investigations back to the git forge: confident
-// findings become a PR drafting an OKF knowledge entry; less-confident findings
-// become an issue. It closes RunLore's Learn loop. Writes target the forge only.
+// Package curator is the file-time learning gate: it dedups a finding against the
+// catalog and open PRs, gates on quality, and drafts a merge-ready PR for novel,
+// quality findings. Uncertain/low-quality findings produce NO repo artifact (the
+// chat delivery already informed the human). It never opens issues — the only
+// issues are knowledge-gap issues, opened by the curate agent (Phase 2).
 package curator
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
+	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// Curator routes an investigation to a PR or an issue by confidence.
+// Curator is the file-time learning gate. It dedups, quality-gates, and drafts a
+// merge-ready PR for novel quality findings; everything else produces no repo
+// artifact.
 type Curator struct {
-	Issues          providers.IssueProvider
-	MinConfidencePR float64 // confidence ≥ this drafts a PR; otherwise an issue
-	Log             *slog.Logger
+	Forge         providers.CurationForge
+	Catalog       catalog.ScoredSearcher // nil ⇒ no catalog dedup
+	DupScore      float64                // catalog BM25 dup threshold
+	MinConfidence float64                // quality gate: minimum overall confidence
+	Log           *slog.Logger
 }
 
-// Curate writes the investigation to the forge and returns the created ref.
+// Curate applies the three-step gate. It returns the created PR ref, or an empty
+// ref when the finding was coalesced (duplicate) or dropped (below the bar).
 func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (providers.Ref, error) {
-	if inv.Confidence >= c.MinConfidencePR {
-		ref, err := c.Issues.OpenPR(ctx, draftKBEntry(inv))
-		if err != nil {
-			return providers.Ref{}, fmt.Errorf("open PR: %w", err)
+	// 1. dedup — catalog, then open PRs
+	if dup, hit, err := (Novelty{Catalog: c.Catalog, DupScore: c.DupScore}).IsDuplicate(ctx, inv); err != nil {
+		c.Log.Warn("dedup: catalog search failed", "err", err)
+	} else if dup {
+		c.Log.Info("finding duplicates a catalog entry; not filing", "entry", hit.Title)
+		return providers.Ref{}, nil
+	}
+	if n, ok, err := c.duplicateOpenPR(ctx, inv); err != nil {
+		c.Log.Warn("dedup: list open PRs failed", "err", err)
+	} else if ok {
+		if err := c.Forge.Comment(ctx, n, coalesceComment(inv)); err != nil {
+			return providers.Ref{}, fmt.Errorf("coalesce comment: %w", err)
 		}
-		c.Log.Info("curated as PR", "url", ref.URL, "confidence", inv.Confidence)
-		return ref, nil
+		c.Log.Info("finding coalesced onto an open PR", "pr", n)
+		return providers.Ref{}, nil
 	}
-	ref, err := c.Issues.OpenIssue(ctx, inv)
+
+	// 2. quality gate — below the bar ⇒ no repo artifact (chat alert only)
+	if !meetsBar(inv, c.MinConfidence) {
+		c.Log.Info("finding below the quality bar; chat-only, no KB artifact",
+			"confidence", inv.Confidence, "root_causes", len(inv.RootCauses))
+		return providers.Ref{}, nil
+	}
+
+	// 3. draft a merge-ready PR (labelled solved by the forge lifecycle labels)
+	ref, err := c.Forge.OpenPR(ctx, draftKBEntry(inv))
 	if err != nil {
-		return providers.Ref{}, fmt.Errorf("open issue: %w", err)
+		return providers.Ref{}, fmt.Errorf("open PR: %w", err)
 	}
-	c.Log.Info("curated as issue", "url", ref.URL, "confidence", inv.Confidence)
+	c.Log.Info("curated as PR", "url", ref.URL, "confidence", inv.Confidence)
 	return ref, nil
+}
+
+// duplicateOpenPR reports an open KB PR whose normalized title matches this
+// finding (cheap title-slug match; deep cross-incident dedup is the curate agent).
+func (c *Curator) duplicateOpenPR(ctx context.Context, inv providers.Investigation) (int, bool, error) {
+	prs, err := c.Forge.ListPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return 0, false, err
+	}
+	want := normTitle(inv.Title)
+	for _, pr := range prs {
+		if normTitle(strings.TrimPrefix(pr.Title, "KB: ")) == want {
+			return pr.Number, true, nil
+		}
+	}
+	return 0, false, nil
+}
+
+// meetsBar is the file-time QUALITY gate (not the merge condition): a confirmed,
+// confident root cause with cited evidence. The resolved/accepted MERGE condition
+// is enforced later by the curate agent + the human.
+func meetsBar(inv providers.Investigation, minConf float64) bool {
+	if inv.Confidence < minConf || len(inv.RootCauses) == 0 {
+		return false
+	}
+	top := inv.RootCauses[0]
+	return top.Summary != "" && len(top.Evidence) > 0
+}
+
+func normTitle(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
+
+func coalesceComment(inv providers.Investigation) string {
+	return fmt.Sprintf("RunLore saw this incident again (confidence %.0f%%). Coalesced rather than re-filed.", inv.Confidence*100)
 }

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -53,7 +53,8 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 		return providers.Ref{}, nil
 	}
 
-	// 3. draft a merge-ready PR (labelled solved by the forge lifecycle labels)
+	// 3. draft a merge-ready PR (labels: runlore + triggered; the curate agent
+	// later advances solved/resolved/ready-to-merge — Phase 2, not here)
 	ref, err := c.Forge.OpenPR(ctx, draftKBEntry(inv))
 	if err != nil {
 		return providers.Ref{}, fmt.Errorf("open PR: %w", err)

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -2,6 +2,7 @@ package curator
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -86,6 +87,20 @@ func TestCurateCatalogDuplicateDropsSilently(t *testing.T) {
 	}
 	if f.openedPR != nil || len(f.commented) != 0 || ref.URL != "" {
 		t.Fatalf("catalog duplicate must drop silently, got pr=%+v comment=%v ref=%s", f.openedPR, f.commented, ref.URL)
+	}
+}
+
+func TestCurateCatalogErrorFallsThroughToPR(t *testing.T) {
+	// A catalog search error must NOT block curation: it logs a warning and falls
+	// through (fail-open) to the open-PR dedup + quality gate. With no matching open
+	// PR and a good finding, that yields a PR.
+	f := &fakeForge{}
+	ref, err := newCurator(f, fakeScored{err: errors.New("index unavailable")}).Curate(context.Background(), goodFinding())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR == nil || ref.URL == "" {
+		t.Fatalf("catalog error should fall through to a PR, got %+v / %s", f.openedPR, ref.URL)
 	}
 }
 

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -4,68 +4,99 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"strings"
 	"testing"
 
+	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// fakeIssues records which route was taken.
-type fakeIssues struct {
-	issue *providers.Investigation
-	pr    *providers.KBEntry
+// fakeForge records OpenPR / Comment calls and serves a fixed open-PR list.
+type fakeForge struct {
+	openedPR  *providers.KBEntry
+	commented []int
+	openPRs   []providers.CuratedIssue
 }
 
-func (f *fakeIssues) OpenIssue(_ context.Context, inv providers.Investigation) (providers.Ref, error) {
-	f.issue = &inv
-	return providers.Ref{URL: "https://github.com/x/y/issues/1"}, nil
-}
-
-func (f *fakeIssues) OpenPR(_ context.Context, e providers.KBEntry) (providers.Ref, error) {
-	f.pr = &e
+func (f *fakeForge) OpenPR(_ context.Context, e providers.KBEntry) (providers.Ref, error) {
+	f.openedPR = &e
 	return providers.Ref{URL: "https://github.com/x/y/pull/2"}, nil
 }
+func (f *fakeForge) ListPRsByLabel(_ context.Context, _ string) ([]providers.CuratedIssue, error) {
+	return f.openPRs, nil
+}
+func (f *fakeForge) Comment(_ context.Context, n int, _ string) error {
+	f.commented = append(f.commented, n)
+	return nil
+}
 
-func sampleInv(conf float64) providers.Investigation {
+func newCurator(f *fakeForge, cat catalog.ScoredSearcher) *Curator {
+	return &Curator{
+		Forge: f, Catalog: cat, DupScore: 5.0, MinConfidence: 0.75,
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func goodFinding() providers.Investigation {
 	return providers.Investigation{
-		Title:      "Harbor probe failures after chart bump",
-		Confidence: conf,
+		Title: "HarborRegistryDown", Confidence: 0.9,
 		RootCauses: []providers.Hypothesis{{
-			Summary:    "chart 1.15 added a DB migration; harbor-db CrashLoopBackOff",
-			Confidence: conf, Evidence: []string{"pg_up=0"}, SuggestedAction: "flux rollback hr/harbor", Reversible: true,
+			Summary: "IAM quota exceeded", Confidence: 0.9,
+			Evidence: []string{"CreateContainerConfigError"}, ChangeRef: "xplane-harbor", SuggestedAction: "delete a key",
 		}},
-		Unresolved: []string{"why the lock never released"},
 	}
 }
 
-func newCurator(f providers.IssueProvider) *Curator {
-	return &Curator{Issues: f, MinConfidencePR: 0.75, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
-}
-
-func TestCurateConfidentOpensPR(t *testing.T) {
-	f := &fakeIssues{}
-	ref, err := newCurator(f).Curate(context.Background(), sampleInv(0.9))
+func TestCurateNovelHighQualityOpensPR(t *testing.T) {
+	f := &fakeForge{}
+	ref, err := newCurator(f, fakeScored{}).Curate(context.Background(), goodFinding())
 	if err != nil {
-		t.Fatalf("Curate: %v", err)
+		t.Fatal(err)
 	}
-	if f.pr == nil || f.issue != nil {
-		t.Fatalf("expected PR route, got issue=%v pr=%v", f.issue, f.pr)
-	}
-	if !strings.Contains(ref.URL, "/pull/") {
-		t.Fatalf("unexpected ref: %s", ref.URL)
-	}
-	if f.pr.Title == "" || !strings.Contains(f.pr.Body, "chart 1.15") || f.pr.Type == "" {
-		t.Fatalf("KBEntry not drafted well: %+v", f.pr)
+	if f.openedPR == nil || ref.URL == "" {
+		t.Fatalf("expected a PR, got %+v / %s", f.openedPR, ref.URL)
 	}
 }
 
-func TestCurateUncertainOpensIssue(t *testing.T) {
-	f := &fakeIssues{}
-	_, err := newCurator(f).Curate(context.Background(), sampleInv(0.4))
+func TestCurateDuplicateCoalescesNoPR(t *testing.T) {
+	// An open PR already covers this incident (matching title), and the catalog does
+	// NOT (fakeScored{} returns no hit) — so we fall through to the open-PR coalesce
+	// path, which comments on the existing PR rather than filing a new one.
+	f := &fakeForge{openPRs: []providers.CuratedIssue{{Number: 48, Title: "KB: HarborRegistryDown"}}}
+	ref, err := newCurator(f, fakeScored{}).Curate(context.Background(), goodFinding())
 	if err != nil {
-		t.Fatalf("Curate: %v", err)
+		t.Fatal(err)
 	}
-	if f.issue == nil || f.pr != nil {
-		t.Fatalf("expected issue route, got issue=%v pr=%v", f.issue, f.pr)
+	if f.openedPR != nil {
+		t.Fatalf("duplicate must NOT open a PR, got %+v", f.openedPR)
+	}
+	if len(f.commented) == 0 || f.commented[0] != 48 {
+		t.Fatalf("duplicate should coalesce by commenting on PR #48, got %v", f.commented)
+	}
+	if ref.URL != "" {
+		t.Fatalf("duplicate ref should be empty, got %s", ref.URL)
+	}
+}
+
+func TestCurateCatalogDuplicateDropsSilently(t *testing.T) {
+	// The catalog already has this knowledge → drop without filing OR commenting.
+	f := &fakeForge{}
+	ref, err := newCurator(f, fakeScored{score: 9, title: "HarborRegistryDown"}).Curate(context.Background(), goodFinding())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR != nil || len(f.commented) != 0 || ref.URL != "" {
+		t.Fatalf("catalog duplicate must drop silently, got pr=%+v comment=%v ref=%s", f.openedPR, f.commented, ref.URL)
+	}
+}
+
+func TestCurateLowQualityDropsNoArtifact(t *testing.T) {
+	f := &fakeForge{}
+	weak := providers.Investigation{Title: "vague", Confidence: 0.3} // below bar: no root cause, low conf
+	ref, err := newCurator(f, fakeScored{}).Curate(context.Background(), weak)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR != nil || len(f.commented) != 0 || ref.URL != "" {
+		t.Fatalf("low-quality finding must produce no repo artifact, got pr=%+v comment=%v ref=%s", f.openedPR, f.commented, ref.URL)
 	}
 }

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -1,0 +1,88 @@
+package curator
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// draftKBEntry renders an investigation as a merge-ready OKF knowledge entry: a
+// decision card (why-keep + confidence) followed by the OKF sections
+// Symptom / Investigate / Cause / Resolution. The decision card makes the human
+// merge trivial; the sections make the entry reusable knowledge (the #48 standard).
+func draftKBEntry(inv providers.Investigation) providers.KBEntry {
+	var b strings.Builder
+
+	// --- decision card ---
+	fmt.Fprintf(&b, "## Decision\n\n")
+	fmt.Fprintf(&b, "- **why keep:** %s\n", firstLine(inv))
+	fmt.Fprintf(&b, "- **confidence:** %.0f%%\n", inv.Confidence*100)
+	if cr := changeRefs(inv); cr != "" {
+		fmt.Fprintf(&b, "- **provenance:** %s\n", cr)
+	}
+
+	// --- Symptom ---
+	fmt.Fprintf(&b, "\n## Symptom\n\n%s\n", inv.Title)
+
+	// --- Investigate (evidence trail) ---
+	b.WriteString("\n## Investigate\n\n")
+	for _, rc := range inv.RootCauses {
+		for _, e := range rc.Evidence {
+			fmt.Fprintf(&b, "- %s\n", e)
+		}
+	}
+
+	// --- Cause (ranked root causes) ---
+	b.WriteString("\n## Cause\n\n")
+	for i, rc := range inv.RootCauses {
+		fmt.Fprintf(&b, "%d. **%s** (%.0f%%)", i+1, rc.Summary, rc.Confidence*100)
+		if rc.ChangeRef != "" {
+			fmt.Fprintf(&b, " — change: %s", rc.ChangeRef)
+		}
+		b.WriteString("\n")
+	}
+
+	// --- Resolution (suggested, reversible-first) ---
+	b.WriteString("\n## Resolution\n\n")
+	for _, rc := range inv.RootCauses {
+		if rc.SuggestedAction != "" {
+			fmt.Fprintf(&b, "- %s (reversible=%t)\n", rc.SuggestedAction, rc.Reversible)
+		}
+	}
+	if len(inv.Unresolved) > 0 {
+		b.WriteString("\n## Unresolved\n\n")
+		for _, u := range inv.Unresolved {
+			fmt.Fprintf(&b, "- %s\n", u)
+		}
+	}
+
+	return providers.KBEntry{
+		Type:        "Incident",
+		Title:       inv.Title,
+		Description: firstLine(inv),
+		Tags:        []string{"runlore", "incident"},
+		Body:        b.String(),
+	}
+}
+
+func firstLine(inv providers.Investigation) string {
+	if len(inv.RootCauses) > 0 {
+		return inv.RootCauses[0].Summary
+	}
+	return inv.Title
+}
+
+// changeRefs collects the distinct change references cited across root causes
+// (the causing/fixing-change provenance the merge bar requires).
+func changeRefs(inv providers.Investigation) string {
+	var refs []string
+	seen := map[string]bool{}
+	for _, rc := range inv.RootCauses {
+		if rc.ChangeRef != "" && !seen[rc.ChangeRef] {
+			seen[rc.ChangeRef] = true
+			refs = append(refs, rc.ChangeRef)
+		}
+	}
+	return strings.Join(refs, ", ")
+}

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -1,0 +1,35 @@
+package curator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestDraftKBEntryHasDecisionCardAndSections(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{
+			Summary:         "IAM AccessKeysPerUser:2 quota → Secret missing username",
+			Evidence:        []string{"accesskey/xplane-harbor failed", "CreateContainerConfigError"},
+			SuggestedAction: "delete an old IAM access key", Reversible: false, ChangeRef: "crossplane/xplane-harbor",
+		}},
+		Unresolved: []string{"which key to delete"},
+	}
+	e := draftKBEntry(inv)
+	if e.Type != "Incident" || e.Title != "HarborRegistryDown" {
+		t.Fatalf("meta: %+v", e)
+	}
+	body := e.Body
+	for _, want := range []string{
+		"## Decision", "why keep", "confidence", // decision card
+		"## Symptom", "## Investigate", "## Cause", "## Resolution", // OKF sections
+		"IAM AccessKeysPerUser:2", "delete an old IAM access key", "crossplane/xplane-harbor",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -1,4 +1,3 @@
-// Package curator writes completed investigations back to the git forge.
 package curator
 
 import (

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -34,7 +34,7 @@ type Novelty struct {
 
 // IsDuplicate returns true + the matching entry when the catalog already covers
 // this finding.
-func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) {
+func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) { //nolint:revive // ctx kept for future remote-index symmetry
 	if n.Catalog == nil {
 		return false, catalog.Entry{}, nil
 	}

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -1,0 +1,49 @@
+// Package curator writes completed investigations back to the git forge.
+package curator
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Fingerprint builds the dedup query string for a finding: the alert/title, the
+// top root-cause signature, and the affected workload. It is a BM25 query (fuzzy),
+// not a hash — matched against the catalog index and open-PR titles.
+func Fingerprint(inv providers.Investigation) string {
+	var b strings.Builder
+	b.WriteString(inv.Title)
+	if len(inv.RootCauses) > 0 {
+		b.WriteString(" " + inv.RootCauses[0].Summary)
+	}
+	if len(inv.Changes) > 0 {
+		w := inv.Changes[0].Workload
+		b.WriteString(" " + w.Namespace + " " + w.Name)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// Novelty decides whether a finding duplicates an existing catalog entry, by
+// scoring its fingerprint against the BM25 catalog index.
+type Novelty struct {
+	Catalog  catalog.ScoredSearcher // nil → everything is novel (no catalog configured)
+	DupScore float64                // top-hit BM25 score ≥ this ⇒ duplicate
+}
+
+// IsDuplicate returns true + the matching entry when the catalog already covers
+// this finding.
+func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) {
+	if n.Catalog == nil {
+		return false, catalog.Entry{}, nil
+	}
+	hits, err := n.Catalog.SearchScored(Fingerprint(inv), 1)
+	if err != nil {
+		return false, catalog.Entry{}, err
+	}
+	if len(hits) > 0 && hits[0].Score >= n.DupScore {
+		return true, hits[0].Entry, nil
+	}
+	return false, catalog.Entry{}, nil
+}

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -2,6 +2,7 @@ package curator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/catalog"
@@ -16,19 +17,23 @@ func TestFingerprintIncludesTitleRootAndWorkload(t *testing.T) {
 	}
 	fp := Fingerprint(inv)
 	for _, want := range []string{"HarborRegistryDown", "IAM AccessKeysPerUser quota", "tooling", "harbor-registry"} {
-		if !contains(fp, want) {
+		if !strings.Contains(fp, want) {
 			t.Fatalf("fingerprint %q missing %q", fp, want)
 		}
 	}
 }
 
-// fakeScored is a catalog.ScoredSearcher returning a fixed hit.
+// fakeScored is a catalog.ScoredSearcher returning a fixed hit (or an error).
 type fakeScored struct {
 	score float64
 	title string
+	err   error
 }
 
 func (f fakeScored) SearchScored(_ string, _ int) ([]catalog.ScoredEntry, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
 	if f.title == "" {
 		return nil, nil
 	}
@@ -62,16 +67,4 @@ func TestNoveltyNilCatalogIsNovel(t *testing.T) {
 	if err != nil || dup {
 		t.Fatalf("nil catalog must be novel, got dup=%v err=%v", dup, err)
 	}
-}
-
-func contains(s, sub string) bool {
-	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
-}
-func indexOf(s, sub string) int {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
 }

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -1,0 +1,77 @@
+package curator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestFingerprintIncludesTitleRootAndWorkload(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		RootCauses: []providers.Hypothesis{{Summary: "IAM AccessKeysPerUser quota exceeded"}},
+		Changes:    []providers.Change{{Workload: providers.Workload{Namespace: "tooling", Name: "harbor-registry"}}},
+	}
+	fp := Fingerprint(inv)
+	for _, want := range []string{"HarborRegistryDown", "IAM AccessKeysPerUser quota", "tooling", "harbor-registry"} {
+		if !contains(fp, want) {
+			t.Fatalf("fingerprint %q missing %q", fp, want)
+		}
+	}
+}
+
+// fakeScored is a catalog.ScoredSearcher returning a fixed hit.
+type fakeScored struct {
+	score float64
+	title string
+}
+
+func (f fakeScored) SearchScored(_ string, _ int) ([]catalog.ScoredEntry, error) {
+	if f.title == "" {
+		return nil, nil
+	}
+	return []catalog.ScoredEntry{{Entry: catalog.Entry{Title: f.title}, Score: f.score}}, nil
+}
+
+func TestNoveltyDuplicateAboveThreshold(t *testing.T) {
+	inv := providers.Investigation{Title: "HarborRegistryDown"}
+	n := Novelty{Catalog: fakeScored{score: 9.0, title: "HarborRegistryDown"}, DupScore: 5.0}
+	dup, hit, err := n.IsDuplicate(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dup || hit.Title != "HarborRegistryDown" {
+		t.Fatalf("expected duplicate hit, got dup=%v hit=%+v", dup, hit)
+	}
+}
+
+func TestNoveltyBelowThresholdIsNovel(t *testing.T) {
+	inv := providers.Investigation{Title: "BrandNewThing"}
+	n := Novelty{Catalog: fakeScored{score: 1.0, title: "Unrelated"}, DupScore: 5.0}
+	dup, _, err := n.IsDuplicate(context.Background(), inv)
+	if err != nil || dup {
+		t.Fatalf("expected novel, got dup=%v err=%v", dup, err)
+	}
+}
+
+func TestNoveltyNilCatalogIsNovel(t *testing.T) {
+	n := Novelty{Catalog: nil, DupScore: 5.0}
+	dup, _, err := n.IsDuplicate(context.Background(), providers.Investigation{Title: "x"})
+	if err != nil || dup {
+		t.Fatalf("nil catalog must be novel, got dup=%v err=%v", dup, err)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1,5 +1,6 @@
-// Package github implements providers.IssueProvider over the GitHub REST API,
-// authenticated with short-lived GitHub App installation tokens.
+// Package github is RunLore's GitHub forge client (curation + re-investigation)
+// over the GitHub REST API, authenticated with short-lived GitHub App installation
+// tokens. It satisfies providers.CurationForge / providers.ReinvestForge / curate.Forge.
 package github
 
 import (
@@ -47,10 +48,7 @@ func New(baseURL, owner, repo, baseBranch string, token TokenFunc) *Client {
 	}
 }
 
-var (
-	_ providers.IssueProvider = (*Client)(nil)
-	_ providers.ReinvestForge = (*Client)(nil)
-)
+var _ providers.ReinvestForge = (*Client)(nil)
 
 // do performs an authenticated JSON request and decodes the response into out (if non-nil).
 func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
@@ -139,7 +137,7 @@ func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref
 		Number  int    `json:"number"`
 	}
 	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/pulls", c.owner, c.repo),
-		map[string]any{"title": "KB: " + e.Title, "head": branch, "base": c.baseBranch, "body": "Drafted by RunLore."}, &out); err != nil {
+		map[string]any{"title": "KB: " + e.Title, "head": branch, "base": c.baseBranch, "body": prBody(e)}, &out); err != nil {
 		return providers.Ref{}, err
 	}
 	// 5. label the PR (the create-PR API doesn't accept labels; set them via the
@@ -157,65 +155,75 @@ func (c *Client) addLabels(ctx context.Context, number int, labels []string) err
 		map[string]any{"labels": labels}, nil)
 }
 
-// ListIssuesByLabel returns open issues carrying the given label. Pull requests
+// rawIssue is one entry from the issues endpoint (which returns both issues and
+// PRs — a non-nil PullRequest marks a PR).
+type rawIssue struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+	Body   string `json:"body"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	PullRequest *struct{} `json:"pull_request"`
+}
+
+func (ri rawIssue) curated() providers.CuratedIssue {
+	labels := make([]string, 0, len(ri.Labels))
+	for _, l := range ri.Labels {
+		labels = append(labels, l.Name)
+	}
+	return providers.CuratedIssue{Number: ri.Number, Title: ri.Title, Body: ri.Body, Labels: labels}
+}
+
+// listIssues fetches ALL pages of open issues+PRs carrying the label. GitHub caps
+// a page at 100 and paginates the rest; without this loop the curate passes would
+// be blind to everything past the first 100 (silent truncation on a sizable KB).
+func (c *Client) listIssues(ctx context.Context, label string) ([]rawIssue, error) {
+	var all []rawIssue
+	for page := 1; ; page++ {
+		var raw []rawIssue
+		path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s&per_page=100&page=%d", c.owner, c.repo, url.QueryEscape(label), page)
+		if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+			return nil, err
+		}
+		all = append(all, raw...)
+		if len(raw) < 100 { // last page (a full page is exactly 100)
+			break
+		}
+	}
+	return all, nil
+}
+
+// ListIssuesByLabel returns all open issues carrying the given label. Pull requests
 // (which the issues API also returns) are filtered out.
 func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
-	var raw []struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		Labels []struct {
-			Name string `json:"name"`
-		} `json:"labels"`
-		PullRequest *struct{} `json:"pull_request"`
-	}
-	path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s", c.owner, c.repo, url.QueryEscape(label))
-	if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+	raw, err := c.listIssues(ctx, label)
+	if err != nil {
 		return nil, err
 	}
 	var out []providers.CuratedIssue
-	for _, i := range raw {
-		if i.PullRequest != nil {
+	for _, ri := range raw {
+		if ri.PullRequest != nil {
 			continue // skip PRs
 		}
-		labels := make([]string, 0, len(i.Labels))
-		for _, l := range i.Labels {
-			labels = append(labels, l.Name)
-		}
-		out = append(out, providers.CuratedIssue{Number: i.Number, Title: i.Title, Body: i.Body, Labels: labels})
+		out = append(out, ri.curated())
 	}
 	return out, nil
 }
 
-// ListPRsByLabel returns open PRs carrying the given label. GitHub's issues
-// endpoint returns both issues and PRs; this keeps ONLY the entries that have a
-// pull_request object (the inverse of ListIssuesByLabel).
+// ListPRsByLabel returns all open PRs carrying the given label — the inverse of
+// ListIssuesByLabel (keeps only entries with a pull_request object).
 func (c *Client) ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
-	var raw []struct {
-		Number int    `json:"number"`
-		Title  string `json:"title"`
-		Body   string `json:"body"`
-		Labels []struct {
-			Name string `json:"name"`
-		} `json:"labels"`
-		PullRequest *struct {
-			URL string `json:"url"`
-		} `json:"pull_request"`
-	}
-	path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s&per_page=100", c.owner, c.repo, url.QueryEscape(label))
-	if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+	raw, err := c.listIssues(ctx, label)
+	if err != nil {
 		return nil, err
 	}
 	var out []providers.CuratedIssue
-	for _, it := range raw {
-		if it.PullRequest == nil {
+	for _, ri := range raw {
+		if ri.PullRequest == nil {
 			continue // a plain issue, not a PR
 		}
-		labels := make([]string, 0, len(it.Labels))
-		for _, l := range it.Labels {
-			labels = append(labels, l.Name)
-		}
-		out = append(out, providers.CuratedIssue{Number: it.Number, Title: it.Title, Body: it.Body, Labels: labels})
+		out = append(out, ri.curated())
 	}
 	return out, nil
 }
@@ -275,6 +283,17 @@ type kbFrontmatter struct {
 }
 
 // renderEntry serializes a KBEntry as OKF markdown (frontmatter + body).
+// prBody is the GitHub PR description: a one-line why-keep summary so the PR list
+// view is informative. The full decision card + OKF sections live in the entry
+// file itself (visible in the PR diff).
+func prBody(e providers.KBEntry) string {
+	desc := e.Description
+	if desc == "" {
+		desc = e.Title
+	}
+	return fmt.Sprintf("Drafted by RunLore — %s\n\nReview the decision card + OKF entry in the changed file.", desc)
+}
+
 func renderEntry(e providers.KBEntry) string {
 	fm, _ := yaml.Marshal(kbFrontmatter{Type: e.Type, Title: e.Title, Description: e.Description, Tags: e.Tags})
 	var b strings.Builder

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -187,6 +187,39 @@ func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]provide
 	return out, nil
 }
 
+// ListPRsByLabel returns open PRs carrying the given label. GitHub's issues
+// endpoint returns both issues and PRs; this keeps ONLY the entries that have a
+// pull_request object (the inverse of ListIssuesByLabel).
+func (c *Client) ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+	var raw []struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+		PullRequest *struct {
+			URL string `json:"url"`
+		} `json:"pull_request"`
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s&per_page=100", c.owner, c.repo, url.QueryEscape(label))
+	if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+		return nil, err
+	}
+	var out []providers.CuratedIssue
+	for _, it := range raw {
+		if it.PullRequest == nil {
+			continue // a plain issue, not a PR
+		}
+		labels := make([]string, 0, len(it.Labels))
+		for _, l := range it.Labels {
+			labels = append(labels, l.Name)
+		}
+		out = append(out, providers.CuratedIssue{Number: it.Number, Title: it.Title, Body: it.Body, Labels: labels})
+	}
+	return out, nil
+}
+
 // Comment posts a comment on an issue.
 func (c *Client) Comment(ctx context.Context, number int, body string) error {
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/issues/%d/comments", c.owner, c.repo, number),

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -239,6 +239,12 @@ func (c *Client) ReplaceLabel(ctx context.Context, number int, remove, add strin
 	return nil
 }
 
+// Close closes an issue or PR (they share the issues endpoint for state).
+func (c *Client) Close(ctx context.Context, number int) error {
+	return c.do(ctx, http.MethodPatch, fmt.Sprintf("/repos/%s/%s/issues/%d", c.owner, c.repo, number),
+		map[string]any{"state": "closed"}, nil)
+}
+
 func issueTitle(inv providers.Investigation) string {
 	if inv.Title != "" {
 		return inv.Title

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -118,5 +119,32 @@ func TestClose(t *testing.T) {
 	}
 	if gotMethod != http.MethodPatch || gotPath != "/repos/o/r/issues/42" || gotBody["state"] != "closed" {
 		t.Fatalf("unexpected: %s %s body=%v", gotMethod, gotPath, gotBody)
+	}
+}
+
+func TestListPRsByLabelPaginates(t *testing.T) {
+	// page 1 returns a full page (100) → the client must fetch page 2 for the rest.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			items := make([]string, 100)
+			for i := range items {
+				items[i] = fmt.Sprintf(`{"number":%d,"title":"KB: t%d","labels":[{"name":"runlore"}],"pull_request":{}}`, i+1, i+1)
+			}
+			_, _ = w.Write([]byte("[" + strings.Join(items, ",") + "]"))
+		case "2":
+			_, _ = w.Write([]byte(`[{"number":101,"title":"KB: t101","labels":[{"name":"runlore"}],"pull_request":{}}]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	prs, err := c.ListPRsByLabel(context.Background(), "runlore")
+	if err != nil {
+		t.Fatalf("ListPRsByLabel: %v", err)
+	}
+	if len(prs) != 101 {
+		t.Fatalf("want 101 PRs across 2 pages (no truncation at 100), got %d", len(prs))
 	}
 }

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -42,6 +42,32 @@ func TestOpenIssue(t *testing.T) {
 	}
 }
 
+func TestListPRsByLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/o/r/issues" || r.URL.Query().Get("labels") != "runlore" || r.URL.Query().Get("state") != "open" {
+			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		// one PR (has pull_request), one plain issue (no pull_request) → only the PR is returned
+		_, _ = w.Write([]byte(`[
+		  {"number":48,"title":"KB: HarborRegistryDown","body":"b","labels":[{"name":"runlore"},{"name":"triggered"}],"pull_request":{"url":"x"}},
+		  {"number":39,"title":"Harbor install failing","body":"b","labels":[{"name":"runlore"}]}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	prs, err := c.ListPRsByLabel(context.Background(), "runlore")
+	if err != nil {
+		t.Fatalf("ListPRsByLabel: %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 48 || prs[0].Title != "KB: HarborRegistryDown" {
+		t.Fatalf("want only PR #48, got %+v", prs)
+	}
+	if len(prs[0].Labels) != 2 || prs[0].Labels[0] != "runlore" {
+		t.Fatalf("labels not parsed: %+v", prs[0].Labels)
+	}
+}
+
 func TestOpenPR(t *testing.T) {
 	var paths []string
 	mux := http.NewServeMux()

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -102,3 +102,21 @@ func TestOpenPR(t *testing.T) {
 		t.Fatalf("expected the 4-call PR sequence, got %v", paths)
 	}
 }
+
+func TestClose(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	if err := c.Close(context.Background(), 42); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if gotMethod != http.MethodPatch || gotPath != "/repos/o/r/issues/42" || gotBody["state"] != "closed" {
+		t.Fatalf("unexpected: %s %s body=%v", gotMethod, gotPath, gotBody)
+	}
+}

--- a/internal/providers/curationforge_test.go
+++ b/internal/providers/curationforge_test.go
@@ -1,0 +1,9 @@
+package providers_test
+
+import (
+	"github.com/Smana/runlore/internal/forge/github"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// compile-time assertion: the GitHub client satisfies CurationForge.
+var _ providers.CurationForge = (*github.Client)(nil)

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -264,17 +264,6 @@ type Notifier interface {
 	Deliver(ctx context.Context, inv Investigation) error
 }
 
-// IssueProvider opens/updates issues & PRs for confidence-routed curation
-// (GitHub now; GitLab later). All writes target the git forge, never the cluster.
-//
-// GitHub auth is a GitHub App (fine-grained permissions, short-lived 1h
-// installation tokens) — the same App also provides the git access used by the
-// what-changed spine. GitLab falls back to a scoped access token.
-type IssueProvider interface {
-	OpenIssue(ctx context.Context, inv Investigation) (Ref, error)
-	OpenPR(ctx context.Context, entry KBEntry) (Ref, error)
-}
-
 // CurationForge is the forge surface the curator's file-time gate needs: open a
 // drafted PR, list open KB PRs (dedup), and comment to coalesce duplicates.
 type CurationForge interface {

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -275,6 +275,14 @@ type IssueProvider interface {
 	OpenPR(ctx context.Context, entry KBEntry) (Ref, error)
 }
 
+// CurationForge is the forge surface the curator's file-time gate needs: open a
+// drafted PR, list open KB PRs (dedup), and comment to coalesce duplicates.
+type CurationForge interface {
+	OpenPR(ctx context.Context, entry KBEntry) (Ref, error)
+	ListPRsByLabel(ctx context.Context, label string) ([]CuratedIssue, error)
+	Comment(ctx context.Context, number int, body string) error
+}
+
 // CuratedIssue is a minimal view of a curated KB issue, used by the re-investigate
 // loop to re-run and post results back.
 type CuratedIssue struct {


### PR DESCRIPTION
## Why

The learning loop *produced* but never *compounded*: ~2 of ~14 KB PRs ever merged, the rest duplicates/low-quality closed unmerged, `log.md` never updated, and 7 issues piled up. This makes the curation gate actually work so the catalog grows — with the human kept as a *trivial* approver.

Design + plans: `docs/superpowers/specs/2026-06-21-runlore-learning-curation-workflow-design.md`, `docs/superpowers/plans/2026-06-21-learning-phase{1,2}-*.md`.

## What changed

**Phase 1 — file-time gate (in the existing curator):**
- Before filing, **dedup** the finding against the catalog (`SearchScored` + threshold) *and* open KB PRs (new `ListPRsByLabel`), coalescing duplicates with a comment instead of re-filing.
- **Quality gate** (`meetsBar`): only confident, root-caused, evidence-backed findings become a PR; everything below the bar is chat-only — **the `uncertain → OpenIssue` branch is deleted**.
- **Merge-ready PR body**: decision card (why-keep + confidence + provenance) + OKF `Symptom/Investigate/Cause/Resolution` (the #48 standard).
- Wired via `buildCurator` with `forge.dup_score` / `forge.min_confidence` config knobs; catalog threaded through `buildModelAndTools` (typed-nil-interface trap avoided).

**Phase 2 — `lore curate` agent (new `internal/curate`):**
- `Forge` interface + forge `Close`; four grooming passes (all TDD'd): **Dedup** (collapse dup open PRs), **Queue** (resolution-gated `ready-to-merge`: resolved OR human-accepted), **Recurrence** (Nth unresolved → one `knowledge-gap` issue), **Lifecycle** (stale-close, protects human-touched).
- `Agent`/`Pass` orchestrator + a runnable `lore curate` subcommand (v1 runs **Dedup**). Forge-only writes; never merges, never touches human-labelled artifacts.

## Deferred follow-ups (logic complete + tested; only CLI plumbing remains)
- Wire **Queue** → needs a cluster `ResolutionChecker`; **Lifecycle** → needs forge `updated_at` for the `Stale` func; **Recurrence** → needs a `RecurrenceStore` (`recurrence.json` in the KB repo) + an unresolved-pattern source.
- The **draft-upgrade** pass (re-shape thin PRs toward the bar).
- Cleanup: the now-unused `IssueProvider`/`OpenIssue` path is dead in the curator flow.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — all green, 0 lint issues
- [x] `lore curate` smoke: errors cleanly on missing config / `kb_repo`
- [ ] Run `lore curate` against the live `runlore-kb` to collapse the duplicate "DependencyNotReady" PRs
- [ ] Fire a duplicate incident and confirm the file-time gate coalesces (comments) instead of re-filing