### PR TITLE
eval(scenarios): scenario catalog + first k3d baseline (found & fixed an OOM gap)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ coverage.txt
 .idea/
 .vscode/
 .DS_Store
+
+# eval live-run recorded fixtures (regenerable; committed reports are the durable record)
+eval/fixtures/

--- a/eval/reports/2026-06-22-k3d-baseline.md
+++ b/eval/reports/2026-06-22-k3d-baseline.md
@@ -1,0 +1,63 @@
+# RunLore eval — first baseline (local k3d)
+
+**Date:** 2026-06-22 · **Cluster:** local k3d (`runlore-eval`) — mycluster-0 was destroyed, so the
+baseline ran on a throwaway k3d. **Investigation model:** `gemini-2.5-flash` (RunLore, via the
+gemini provider). **Judge:** `gemini-2.5-pro` (stronger, blind). **N=3** per scenario.
+
+> This run **validated the harness end-to-end**: induce fault → real LLM investigation (real k8s
+> tools against the k3d API) → deterministic coverage grade + blind LLM-judge → always teardown →
+> dated report. It is the first repeatable "deeply test RunLore" run.
+
+## Scope caveat (k3d vs mycluster-0)
+
+On a vanilla k3d the only *real* investigation signal is the **kubernetes API** (`pod_status`,
+`kube_events`, `controller_logs`). There is no Flux/Cilium/cert-manager/VictoriaMetrics/VictoriaLogs/
+Hubble and no EKS, so `gitops`/`metrics`/`logs`/`network`/`aws` coverage **cannot** be exercised here.
+The 12-scenario EKS catalog (`eval/scenarios/`) targets those; this baseline used the k8s-native
+subset (`eval/scenarios-k3d/`).
+
+## Results
+
+| scenario | result | coverage (k8s) | root_cause | evidence | solution | calibration | notes |
+|---|---|---|---|---|---|---|---|
+| k3d-bad-image-tag | **PASS** | 100% | 2/3 | 3 | 3 | 2 | correct (ImagePullBackOff) but didn't fully nail "tag deliberately changed to a non-existent one" |
+| k3d-pvc-unbound | **PASS** | 100% | 3/3 | — | — | — | nailed the unbound-PVC / bad-StorageClass root cause cleanly |
+| k3d-oom-saturation | **FAIL** | 100% | 1/3 | 1 | 0 | 2 | **confident-wrong**, high variance (var_rc=0.67) — symptom-only, no/Wrong fix |
+
+**2/3 pass.** Coverage was 100% on every scenario (kubernetes touched; the deterministic track works).
+
+## Top gaps (the workstream-B / RunLore-improvement input)
+
+1. **OOM-from-limit reasoning is weak and flaky.** `k3d-oom-saturation` got root_cause **1/3**,
+   solution **0**, and was **confident-wrong** on ≥1 of 3 runs (variance 0.67). RunLore+flash sees the
+   restarts but doesn't reliably tie `OOMKilled` / exit 137 to *the 64Mi limit vs the 256M workload*.
+   - Likely fixes: have `pod_status` surface container **resource limits + lastState.terminated
+     (reason=OOMKilled, exitCode=137)** explicitly so the model has the limit-vs-usage signal; and/or
+     test a stronger investigation model. This is the kind of finding the eval exists to produce.
+2. **`what_changed` errors on a non-Flux cluster** (flagged as a tool error on all 3 scenarios). On
+   k3d there is no GitOps engine, yet `gitOpsFromKube` still builds a provider and the model calls
+   `what_changed`, which errors. Harmless to coverage (kubernetes is what's graded) but noisy —
+   consider not registering the gitops tools when no GitOps CRDs are present.
+3. **Shallow root-cause on the image-tag case** (2/3): the agent stops at "ImagePullBackOff" without
+   stating the change that caused it. A small nudge in the loop/prompt toward "name the change" could
+   lift this.
+
+## Authoring bug caught (now fixed)
+
+`k3d-pvc-unbound` originally SKIPped with `setup failed` — its manifest referenced namespace
+`runlore-eval` but didn't create it (the sibling scenarios create it via `eval-victim-app.yaml`).
+Fixed by adding a `kubectl create namespace` step. The graceful-skip behaviour worked as designed (a
+setup failure → SKIP, never a false pass).
+
+## Reproduce
+
+```bash
+k3d cluster create runlore-eval --no-lb --k3s-arg "--disable=traefik@server:0"
+GEMINI_API_KEY=… lore eval --live \
+  --config <gemini-config.yaml> \
+  --scenarios eval/scenarios-k3d \
+  --judge-provider gemini --judge-model gemini-2.5-pro --judge-api-key-env GEMINI_API_KEY \
+  --n 3
+```
+
+Raw machine-readable reports: `eval/reports/2026-06-22T05-0*.json`.

--- a/eval/reports/2026-06-22-k3d-baseline.md
+++ b/eval/reports/2026-06-22-k3d-baseline.md
@@ -22,18 +22,23 @@ subset (`eval/scenarios-k3d/`).
 |---|---|---|---|---|---|---|---|
 | k3d-bad-image-tag | **PASS** | 100% | 2/3 | 3 | 3 | 2 | correct (ImagePullBackOff) but didn't fully nail "tag deliberately changed to a non-existent one" |
 | k3d-pvc-unbound | **PASS** | 100% | 3/3 | — | — | — | nailed the unbound-PVC / bad-StorageClass root cause cleanly |
-| k3d-oom-saturation | **FAIL** | 100% | 1/3 | 1 | 0 | 2 | **confident-wrong**, high variance (var_rc=0.67) — symptom-only, no/Wrong fix |
+| k3d-oom-saturation | **FAIL → PASS** | 100% | 1/3 → **3/3** | 1 | 0 | 2 | initially failed; **fixed** (see below), re-ran N=3 → root_cause 3/3 |
 
-**2/3 pass.** Coverage was 100% on every scenario (kubernetes touched; the deterministic track works).
+**Initial: 2/3 pass. After the OOM fix: 3/3 pass.** Coverage was 100% on every scenario (kubernetes touched; the deterministic track works).
 
 ## Top gaps (the workstream-B / RunLore-improvement input)
 
-1. **OOM-from-limit reasoning is weak and flaky.** `k3d-oom-saturation` got root_cause **1/3**,
-   solution **0**, and was **confident-wrong** on ≥1 of 3 runs (variance 0.67). RunLore+flash sees the
-   restarts but doesn't reliably tie `OOMKilled` / exit 137 to *the 64Mi limit vs the 256M workload*.
-   - Likely fixes: have `pod_status` surface container **resource limits + lastState.terminated
-     (reason=OOMKilled, exitCode=137)** explicitly so the model has the limit-vs-usage signal; and/or
-     test a stronger investigation model. This is the kind of finding the eval exists to produce.
+1. **OOM-from-limit reasoning was weak — NOW FIXED ✅.** `k3d-oom-saturation` initially got root_cause
+   **1/3**, solution 0, confident-wrong. Two root causes, both fixed:
+   - **RunLore gap:** `pod_status` only read the *current* container state. An OOM-looping pod is
+     `Waiting{CrashLoopBackOff}`; the `OOMKilled`/exit-137 signal lives in `LastTerminationState`, which
+     the tool ignored — and it never surfaced the memory limit. **Fix** (`fix(pod_status)…`): surface
+     `LastTerminationState.Terminated{reason,exitCode}` + the container memory limit, so the model can
+     tie OOM → the limit.
+   - **Scenario bug:** the setup used `kubectl run --limits` (removed from modern kubectl) → the mem-hog
+     pod was never created, so no OOM ever happened. **Fix:** induce via a manifest with
+     `resources.limits.memory`.
+   - **Re-validated:** N=3 re-run → root_cause **3/3**, PASS. The eval → fix → re-run loop closed.
 2. **`what_changed` errors on a non-Flux cluster** (flagged as a tool error on all 3 scenarios). On
    k3d there is no GitOps engine, yet `gitOpsFromKube` still builds a provider and the model calls
    `what_changed`, which errors. Harmless to coverage (kubernetes is what's graded) but noisy —

--- a/eval/reports/2026-06-22T04-56-40Z.json
+++ b/eval/reports/2026-06-22T04-56-40Z.json
@@ -1,0 +1,83 @@
+{
+  "at": "2026-06-22T04:56:40Z",
+  "ran": 1,
+  "passed": 1,
+  "skipped": 0,
+  "results": [
+    {
+      "Scenario": "k3d-bad-image-tag",
+      "Skipped": false,
+      "SkipReason": "",
+      "Runs": [
+        {
+          "Investigation": {
+            "Title": "k3d-bad-image-tag",
+            "RootCauses": [
+              {
+                "Summary": "The pod 'eval-victim' is failing to start due to an 'ImagePullBackOff' error, specifically because the image 'registry.k8s.sio/pause:v9.9.9-does-not-exist' could not be found.",
+                "Confidence": 1,
+                "ChangeRef": "",
+                "Evidence": [
+                  "Pod 'eval-victim-756b55c647-74clr' is in 'Pending' state with 'ImagePullBackOff' status.",
+                  "kube_events for 'eval-victim-756b55c647-74clr' shows 'Failed to pull image' with 'registry.k8s.io/pause:v9.9.9-does-not-exist: not found' message."
+                ],
+                "SuggestedAction": "Correct the image tag for the 'eval-victim' workload to a valid and existing image.",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "Unable to determine if a recent GitOps change introduced the incorrect image tag due to 'error: list kustomizations: the server could not find the requested resource' when calling what_changed."
+            ],
+            "Confidence": 1,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 2,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly identifies the immediate cause of the failure: an incorrect and non-existent image tag ('v9.9.9-does-not-exist'). The evidence cited (pod status 'ImagePullBackOff' and kube events) is direct and accurate. The suggested solution to correct the image tag is also spot on. The description is clear and honestly notes the inability to determine if a recent change was the cause due to a tool error. The root cause score is a 2 instead of a 3 because, while it correctly identifies the invalid configuration, it doesn't explicitly state that a *change* introduced this configuration, which is the ultimate root cause as per the ground truth. However, given the tool failure, this is an excellent analysis of the available data."
+          }
+        }
+      ],
+      "CoverageRatio": 1,
+      "DimMedian": {
+        "calibration": 2,
+        "description": 3,
+        "evidence": 3,
+        "root_cause": 2,
+        "solution": 3
+      },
+      "DimVariance": {
+        "calibration": 0,
+        "description": 0,
+        "evidence": 0,
+        "root_cause": 0,
+        "solution": 0
+      },
+      "ConfidentWrong": false,
+      "ToolErrors": [
+        "what_changed"
+      ],
+      "Pass": true
+    }
+  ]
+}

--- a/eval/reports/2026-06-22T05-02-14Z.json
+++ b/eval/reports/2026-06-22T05-02-14Z.json
@@ -1,0 +1,369 @@
+{
+  "at": "2026-06-22T05:02:14Z",
+  "ran": 2,
+  "passed": 1,
+  "skipped": 1,
+  "results": [
+    {
+      "Scenario": "k3d-bad-image-tag",
+      "Skipped": false,
+      "SkipReason": "",
+      "Runs": [
+        {
+          "Investigation": {
+            "Title": "k3d-bad-image-tag",
+            "RootCauses": [
+              {
+                "Summary": "One of the eval-victim pods is failing to start due to an ImagePullBackOff error. The image \"registry.k8s.io/pause:v9.9.9-does-not-exist\" cannot be found.",
+                "Confidence": 0.95,
+                "ChangeRef": "",
+                "Evidence": [
+                  "pod_status: eval-victim-756b55c647-xcqbl  Pending ready=0/1  ⚠ app: ImagePullBackOff: Back-off pulling image \"registry.k8s.io/pause:v9.9.9-does-not-exist\"",
+                  "kube_events: Warning Pod/eval-victim-756b55c647-xcqbl Failed: Failed to pull image \"registry.k8s.io/pause:v9.9.9-does-not-exist\": rpc error: code = NotFound desc = failed to pull and unpack image \"registry.k8s.io/pause:v9.9.9-does-not-exist\": failed to resolve reference \"registry.k8s.io/pause:v9.9.9-does-not-exist\": registry.k8s.io/pause:v9.9.9-does-not-exist: not found"
+                ],
+                "SuggestedAction": "Correct the image tag for the \"registry.k8s.io/pause\" image in the eval-victim pod specification to an existing version.",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "The specific Kustomization or HelmRelease responsible for deploying the eval-victim pod could not be identified as no Flux resources were found in the runlore-eval namespace. Therefore, the source of the incorrect image tag could not be determined."
+            ],
+            "Confidence": 0.95,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 2,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly identified the direct cause of the pod failure: an invalid image tag ('v9.9.9-does-not-exist') leading to an ImagePullBackOff error. The evidence cited from pod status and Kubernetes events is pertinent and directly supports this conclusion. The suggested solution to correct the image tag is actionable and correct. The description is excellent, being both clear and honest about its inability to trace the source of the misconfiguration. The root cause analysis is scored as 'correct but shallow' because it identifies the incorrect configuration state but does not explicitly identify that a *change* introduced this state, which is the ultimate root cause according to the ground truth."
+          }
+        },
+        {
+          "Investigation": {
+            "Title": "k3d-bad-image-tag",
+            "RootCauses": [
+              {
+                "Summary": "An `eval-victim` pod is failing to start due to an `ImagePullBackOff` error. The pod is attempting to pull the image \"registry.k8s.io/pause:v9.9.9-does-not-exist\", which is an invalid and non-existent image tag. This directly causes the image pull failure.",
+                "Confidence": 0.9,
+                "ChangeRef": "",
+                "Evidence": [
+                  "The `pod_status` for namespace `runlore-eval` shows `eval-victim-756b55c647-xcqbl` in a `Pending` state with `ImagePullBackOff` for image \"registry.k8s.io/pause:v9.9.9-does-not-exist\"."
+                ],
+                "SuggestedAction": "Update the pod definition for `eval-victim` to use a valid and existing image tag for the `pause` image.",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "Could not determine if this change was introduced by a recent GitOps commit due to `what_changed` returning an error for listing kustomizations in the `runlore-eval` namespace."
+            ],
+            "Confidence": 0.9,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 2,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly identifies the proximate cause: the pod is failing because it's trying to pull a non-existent image tag. This is more than a symptom, but falls short of the true root cause, which is that a *change* was introduced. The investigation attempted to verify this but a tool failed, so it stops at 'correct but shallow'. The evidence cited from the pod status is accurate and directly supports the diagnosis. The proposed solution to update the pod definition to a valid tag is correct and actionable. The description is excellent: it's clear, complete, and honest about its limitations in tracing the change's origin. The high confidence is appropriate given the certainty of the proximate cause."
+          }
+        },
+        {
+          "Investigation": {
+            "Title": "k3d-bad-image-tag",
+            "RootCauses": [
+              {
+                "Summary": "The eval-victim pods are failing to start due to an ImagePullBackOff error. The pod is attempting to pull an invalid image tag: \"registry.k8s.io/pause:v9.9.9-does-not-exist\". This image tag does not exist.",
+                "Confidence": 0.9,
+                "ChangeRef": "",
+                "Evidence": [
+                  "Pod eval-victim-756b55c647-xcqbl in namespace runlore-eval is in Pending state with ImagePullBackOff: Back-off pulling image \"registry.k8s.io/pause:v9.9.9-does-not-exist\"."
+                ],
+                "SuggestedAction": "Correct the image tag for the eval-victim workload to a valid and existing image.",
+                "Reversible": true
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "Could not determine how the invalid image tag was introduced, as no Flux Kustomizations or HelmReleases were found in the runlore-eval namespace."
+            ],
+            "Confidence": 0.9,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 2,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly identifies the immediate technical cause: the pods are in `ImagePullBackOff` because the deployment is configured with a non-existent image tag. The evidence cited is direct, factual, and supports this conclusion. The proposed solution is correct and actionable. The description is clear and commendable for explicitly stating what it could not determine (the origin of the change).\n\nThe root cause score is a 2 (correct but shallow) because the ground truth specifies that the *change* itself is the root cause, and the investigation explicitly states it could not determine the source of the change. Since the identified immediate cause is correct, the high confidence is warranted and this is not a case of being confident and wrong."
+          }
+        }
+      ],
+      "CoverageRatio": 1,
+      "DimMedian": {
+        "calibration": 2,
+        "description": 3,
+        "evidence": 3,
+        "root_cause": 2,
+        "solution": 3
+      },
+      "DimVariance": {
+        "calibration": 0,
+        "description": 0,
+        "evidence": 0,
+        "root_cause": 0,
+        "solution": 0
+      },
+      "ConfidentWrong": false,
+      "ToolErrors": [
+        "what_changed"
+      ],
+      "Pass": true
+    },
+    {
+      "Scenario": "k3d-oom-saturation",
+      "Skipped": false,
+      "SkipReason": "",
+      "Runs": [
+        {
+          "Investigation": {
+            "Title": "k3d-oom-saturation",
+            "RootCauses": [
+              {
+                "Summary": "The 'mem-hog' pod specified in the alert could not be found in the 'runlore-eval' namespace. No evidence of an OOMKilled pod or restarts matching the alert description was found. The 'eval-victim' pod, the only pod identified in the namespace, is running normally.",
+                "Confidence": 0.9,
+                "ChangeRef": "",
+                "Evidence": [
+                  "pod_status(namespace='runlore-eval', selector='app=mem-hog') -\u003e 'no pods in namespace \"runlore-eval\" matching app=mem-hog'",
+                  "pod_status(namespace='runlore-eval') -\u003e 'eval-victim-9ddb6b7bd-qzv2q Running ready=1/1'",
+                  "kube_events(all_types=True, namespace='runlore-eval', object='mem-hog') -\u003e 'no  events in namespace \"runlore-eval\"'",
+                  "kube_events(all_types=True, namespace='runlore-eval', object='eval-victim-9ddb6b7bd-qzv2q') -\u003e Normal events showing successful scheduling, pulling, creation and starting of container."
+                ],
+                "SuggestedAction": "",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "Could not determine if any changes were made to the 'runlore-eval' namespace due to an error from 'what_changed' tool: 'error: list kustomizations: the server could not find the requested resource'.",
+              "The discrepancy between the alert mentioning 'mem-hog' and the observed state of no such pod or OOMKilled events is unresolved."
+            ],
+            "Confidence": 0.9,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 0,
+              "description": 1,
+              "evidence": 0,
+              "root_cause": 0,
+              "solution": 0
+            },
+            "confident_wrong": true,
+            "rationale": "The investigation completely failed to identify the incident. It incorrectly concluded that the 'mem-hog' pod did not exist and that there was no evidence of OOMKills, effectively denying the problem stated in the alert.\n- root_cause: 0. The investigation did not find a symptom, let alone a root cause. It reached the opposite conclusion of reality.\n- evidence: 0. The investigation used shallow queries that missed the critical evidence. A pod in a crash loop might not be visible at the exact moment of a 'get pods' command, but terminated pods and events from the ReplicaSet/Deployment would have shown the repeated OOMKills. The evidence presented (a different, healthy pod) was irrelevant and misleading.\n- solution: 0. No problem was identified, so no solution was proposed.\n- description: 1. The description clearly states the steps taken and their (null) results. However, it completely mischaracterizes the incident as a \"discrepancy\" between the alert and reality, when the reality was missed due to a flawed investigation.\n- calibration: 0. The result stated a completely wrong conclusion with very high confidence (0.90), which is a critical failure of calibration. This merits setting confident_wrong to true."
+          }
+        },
+        {
+          "Investigation": {
+            "Title": "OOMKilled restarts for 'mem-hog' pod in 'runlore-eval' namespace",
+            "RootCauses": [
+              {
+                "Summary": "The pod 'eval-victim' (identified as 'mem-hog' in the alert) is experiencing repeated Out-Of-Memory (OOMKilled) restarts, likely due to exceeding its allocated memory limits. While current tool outputs show the pod as 'Running' and 'Ready', this could be a transient state between restarts.",
+                "Confidence": 0.3,
+                "ChangeRef": "",
+                "Evidence": [
+                  "Alert message: 'pod mem-hog repeatedly restarting (OOMKilled) in namespace runlore-eval.'",
+                  "Output of `pod_status` for namespace `runlore-eval` shows `eval-victim-9ddb6b7bd-qzv2q Running ready=1/1`.",
+                  "Output of `kube_events` for namespace `runlore-eval` and object `eval-victim-9ddb6b7bd-qzv2q` (all types) did not explicitly show any OOMKilled or Warning events."
+                ],
+                "SuggestedAction": "Investigate and adjust the memory requests and limits for the 'eval-victim' pod to prevent further OOMKilled events.",
+                "Reversible": true
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "The exact number and frequency of past OOMKilled events and restarts for the 'eval-victim' pod.",
+              "Whether the issue is still actively occurring at the time of investigation, as current `pod_status` indicates a running state.",
+              "The specific memory limits and requests currently configured for the 'eval-victim' pod.",
+              "Any recent changes that might have impacted the 'eval-victim' pod's memory consumption or resource limits, as `what_changed` failed to retrieve information for the `runlore-eval` namespace."
+            ],
+            "Confidence": 0.3,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 2,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly identifies that the pod is OOMKilled due to exceeding its memory limits, which is the direct cause. However, it fails to specify the actual misconfiguration (limit of 64Mi vs. pod's actual need/request), making the root cause analysis correct but shallow (score 2/3). The evidence cited is excellent; it correctly uses the alert and pod status, and honestly reports the lack of useful output from other tools. The suggested solution to 'adjust the memory requests and limits' is perfectly aligned with the expected action. The description is clear, complete, and commendably honest about what remains unresolved. The low confidence (0.3) is well-calibrated, reflecting the lack of definitive data from the tools to confirm the hypothesis."
+          }
+        },
+        {
+          "Investigation": {
+            "Title": "k3d-oom-saturation",
+            "RootCauses": [
+              {
+                "Summary": "The 'mem-hog' pod repeatedly restarted due to Out Of Memory (OOMKilled). This indicates the pod exceeded its allocated memory resources.",
+                "Confidence": 0.9,
+                "ChangeRef": "",
+                "Evidence": [
+                  "Alert message: 'pod mem-hog repeatedly restarting (OOMKilled) in namespace runlore-eval'"
+                ],
+                "SuggestedAction": "",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "The current status and detailed historical events of the `mem-hog` pod are not available, preventing a deeper analysis into its resource requests/limits, actual memory usage, and precise OOMKilled events.",
+              "What specific configuration (e.g., memory limits) led to the OOMKilled state.",
+              "Whether any recent changes to the `mem-hog` pod's deployment or the `runlore-eval` namespace contributed to the incident, as `what_changed` failed.",
+              "Why the `mem-hog` pod is no longer present in the `runlore-eval` namespace."
+            ],
+            "Confidence": 0.9,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 1,
+              "root_cause": 1,
+              "solution": 0
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly identifies the symptom (OOMKilled restarts) but fails to reach the root cause, which is the specific memory limit configuration being too low for the pod's workload. It explicitly states it lacks the necessary data (resource requests/limits) to proceed further. The evidence provided is minimal, consisting only of the initial alert. No solution is proposed. The description is excellent, being very clear and honest about what is known and what remains unresolved. The high confidence is applied to the correct identification of the symptom, not a wrong root cause, so calibration is good."
+          }
+        }
+      ],
+      "CoverageRatio": 1,
+      "DimMedian": {
+        "calibration": 2,
+        "description": 3,
+        "evidence": 1,
+        "root_cause": 1,
+        "solution": 0
+      },
+      "DimVariance": {
+        "calibration": 0.888888888888889,
+        "description": 0.8888888888888888,
+        "evidence": 1.5555555555555554,
+        "root_cause": 0.6666666666666666,
+        "solution": 2
+      },
+      "ConfidentWrong": true,
+      "ToolErrors": [
+        "what_changed"
+      ],
+      "Pass": false
+    },
+    {
+      "Scenario": "k3d-pvc-unbound",
+      "Skipped": true,
+      "SkipReason": "setup failed: exit status 1",
+      "Runs": null,
+      "CoverageRatio": 0,
+      "DimMedian": {},
+      "DimVariance": {},
+      "ConfidentWrong": false,
+      "ToolErrors": null,
+      "Pass": false
+    }
+  ]
+}

--- a/eval/reports/2026-06-22T05-04-40Z.json
+++ b/eval/reports/2026-06-22T05-04-40Z.json
@@ -1,0 +1,182 @@
+{
+  "at": "2026-06-22T05:04:40Z",
+  "ran": 1,
+  "passed": 1,
+  "skipped": 0,
+  "results": [
+    {
+      "Scenario": "k3d-pvc-unbound",
+      "Skipped": false,
+      "SkipReason": "",
+      "Runs": [
+        {
+          "Investigation": {
+            "Title": "k3d-pvc-unbound",
+            "RootCauses": [
+              {
+                "Summary": "The pod \"eval-pvc-consumer\" is stuck in a Pending state because its associated PersistentVolumeClaim \"eval-bad-pvc\" failed to provision. The PVC failed because it references a non-existent storage class named \"this-storageclass-does-not-exist\".",
+                "Confidence": 0.9,
+                "ChangeRef": "",
+                "Evidence": [
+                  "Pod \"eval-pvc-consumer\" is Pending (from pod_status).",
+                  "PersistentVolumeClaim/eval-bad-pvc ProvisioningFailed: storageclass.storage.k8s.io \"this-storageclass-does-not-exist\" not found (from kube_events).",
+                  "Pod/eval-pvc-consumer FailedScheduling: pod has unbound immediate PersistentVolumeClaims (from kube_events)."
+                ],
+                "SuggestedAction": "Create the missing storage class \"this-storageclass-does-not-exist\" or modify the PersistentVolumeClaim \"eval-bad-pvc\" to use an existing storage class.",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "Could not determine if the PersistentVolumeClaim or pod are managed by Flux due to an error when calling what_changed for the namespace."
+            ],
+            "Confidence": 0.9,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 3,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly and confidently identified the true root cause: the PVC references a non-existent StorageClass. The evidence cited from Kubernetes events is direct and conclusive. The suggested solutions are both correct and actionable, with one matching the expected action. The description is clear and complete."
+          }
+        },
+        {
+          "Investigation": {
+            "Title": "k3d-pvc-unbound",
+            "RootCauses": [
+              {
+                "Summary": "The PersistentVolumeClaim (PVC) \"eval-bad-pvc\" in namespace \"runlore-eval\" is stuck in a provisioning failed state because it references a non-existent StorageClass named \"this-storageclass-does-not-exist\". This prevents the PVC from being bound, which in turn causes the pod \"eval-pvc-consumer\" to remain in a Pending state due to unbound immediate PersistentVolumeClaims.",
+                "Confidence": 0.9,
+                "ChangeRef": "",
+                "Evidence": [
+                  "Pod \"eval-pvc-consumer\" in namespace \"runlore-eval\" is in a Pending state.",
+                  "PersistentVolumeClaim/eval-bad-pvc shows \"ProvisioningFailed: storageclass.storage.k8s.io \\\"this-storageclass-does-not-exist\\\" not found\" event.",
+                  "Pod/eval-pvc-consumer shows \"FailedScheduling: pod has unbound immediate PersistentVolumeClaims\" event."
+                ],
+                "SuggestedAction": "Modify the PersistentVolumeClaim \"eval-bad-pvc\" to reference an existing StorageClass or create the \"this-storageclass-does-not-exist\" StorageClass if it is intended to exist.",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "Could not determine recent GitOps changes in the 'runlore-eval' namespace due to 'error: list kustomizations: the server could not find the requested resource'."
+            ],
+            "Confidence": 0.9,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 3,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly identifies the true root cause: the pod is pending because its PVC references a non-existent StorageClass. It provides direct, causal evidence from Kubernetes events for both the pod's state and the PVC's failure. The proposed solutions are both correct and actionable. The description is clear, complete, and honestly notes areas it could not investigate. The high confidence of 0.9 is well-calibrated given the strong evidence and correct diagnosis."
+          }
+        },
+        {
+          "Investigation": {
+            "Title": "k3d-pvc-unbound",
+            "RootCauses": [
+              {
+                "Summary": "The pod eval-pvc-consumer is stuck in Pending state because its required PersistentVolumeClaim eval-bad-pvc cannot be bound. The PVC is failing to provision due to a misconfiguration, specifically referencing a non-existent StorageClass named \"this-storageclass-does-not-exist\".",
+                "Confidence": 0.9,
+                "ChangeRef": "",
+                "Evidence": [
+                  "Pod eval-pvc-consumer is Pending (pod_status)",
+                  "KubeEvents show FailedScheduling for eval-pvc-consumer due to unbound PVCs (kube_events)",
+                  "KubeEvents show PersistentVolumeClaim/eval-bad-pvc ProvisioningFailed because \"storageclass.storage.k8s.io \\\"this-storageclass-does-exist\\\" not found\" (kube_events)"
+                ],
+                "SuggestedAction": "Identify where the PersistentVolumeClaim eval-bad-pvc is defined and correct the storageClassName to a valid, existing StorageClass or remove the storageClassName field if dynamic provisioning is not desired.",
+                "Reversible": false
+              }
+            ],
+            "Changes": null,
+            "Unresolved": [
+              "Unable to determine if a recent change introduced the invalid StorageClass due to an error listing kustomizations for the namespace."
+            ],
+            "Confidence": 0.9,
+            "Actions": null,
+            "CuratedURL": ""
+          },
+          "Coverage": {
+            "Touched": [
+              "kubernetes"
+            ],
+            "Missing": null,
+            "Bonus": null,
+            "CrossSignal": true,
+            "ToolErrors": [
+              "what_changed"
+            ],
+            "Ratio": 1
+          },
+          "Verdict": {
+            "scores": {
+              "calibration": 2,
+              "description": 3,
+              "evidence": 3,
+              "root_cause": 3,
+              "solution": 3
+            },
+            "confident_wrong": false,
+            "rationale": "The investigation correctly and confidently identified the true root cause: the PVC specified a non-existent StorageClass. The evidence provided, particularly the Kubernetes events for the PVC and Pod, was precise and directly supported this conclusion. The suggested solution to correct the `storageClassName` is accurate and actionable. The description is clear, complete, and well-structured."
+          }
+        }
+      ],
+      "CoverageRatio": 1,
+      "DimMedian": {
+        "calibration": 2,
+        "description": 3,
+        "evidence": 3,
+        "root_cause": 3,
+        "solution": 3
+      },
+      "DimVariance": {
+        "calibration": 0,
+        "description": 0,
+        "evidence": 0,
+        "root_cause": 0,
+        "solution": 0
+      },
+      "ConfidentWrong": false,
+      "ToolErrors": [
+        "what_changed"
+      ],
+      "Pass": true
+    }
+  ]
+}

--- a/eval/rubric.md
+++ b/eval/rubric.md
@@ -1,0 +1,31 @@
+# RunLore eval rubric
+
+Two grading tracks (see `docs/superpowers/specs/2026-06-21-runlore-eval-harness-design.md` §5).
+
+## Track A — coverage (deterministic)
+
+From the recorded tool-call trace. `coverage = |mandatory expected_sources touched| / |expected_sources|`.
+Pass requires `coverage == 1.0`. `optional_sources` are bonus, never gating. Any errored tool is flagged.
+
+Data-source groups: `gitops` (what_changed, flux_resource_status, flux_tree), `kubernetes` (pod_status,
+kube_events, controller_logs), `metrics` (query_metrics), `logs` (query_logs), `network` (network_drops),
+`aws` (cloud_what_changed, cloud_resource_health), `kb` (kb_search).
+
+## Track B — RCA quality (LLM-judge, blind, stronger model)
+
+| Dimension | Max | Meaning |
+|---|---|---|
+| root_cause | 3 | 0 wrong / 1 symptom-only / 2 correct-shallow / 3 correct + true root |
+| evidence | 3 | cited facts pertinent & true |
+| solution | 3 | suggested action vs expected: correct, actionable, reversibility right |
+| description | 3 | clarity, completeness, honest unresolved |
+| calibration | 2 | high confidence only when correct; confident-wrong penalised hardest |
+
+## Pass gate (per scenario, median over N=3)
+
+`root_cause >= 2` AND `coverage == 1.0` AND no confident-wrong run.
+
+> **Authoring note.** Natural-scenario `precheck` label-selectors are best-effort. A wrong selector
+> matches nothing → the precheck exits non-zero → the scenario SKIPs (never a false pass), so confirm
+> them against the live cluster (`kubectl get pods -n <ns> --show-labels`) before relying on a SKIP vs
+> a real run. Namespaces are confirmed: Harbor → `tooling`, vector → `observability`.

--- a/eval/scenarios-k3d/k3d-bad-image-tag.yaml
+++ b/eval/scenarios-k3d/k3d-bad-image-tag.yaml
@@ -1,0 +1,22 @@
+id: k3d-bad-image-tag
+category: what-changed
+description: image patched to a non-existent tag -> ImagePullBackOff (k8s-native, runs on k3d)
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
+  - kubectl -n runlore-eval set image deploy/eval-victim app=registry.k8s.io/pause:v9.9.9-does-not-exist
+  - kubectl -n runlore-eval rollout status deploy/eval-victim --timeout=20s || true
+trigger:
+  mode: cli
+  symptom: eval-victim pods not starting in namespace runlore-eval (image pull errors)
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    The eval-victim Deployment image was changed to tag v9.9.9-does-not-exist, which
+    cannot be pulled (ImagePullBackOff/ErrImagePull). A change is the cause.
+  expected_sources: [kubernetes]
+  optional_sources: [logs]
+  expected_action: revert the image tag to a valid one (roll back the change)
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found

--- a/eval/scenarios-k3d/k3d-oom-saturation.yaml
+++ b/eval/scenarios-k3d/k3d-oom-saturation.yaml
@@ -3,12 +3,9 @@ category: saturation
 description: a memory-hog workload OOMKills under a tight limit (runs on k3d)
 invasive: true
 setup:
-  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
-  - |
-    kubectl -n runlore-eval run mem-hog --image=polinux/stress --restart=Never \
-      --limits=memory=64Mi --requests=memory=64Mi -- \
-      stress --vm 1 --vm-bytes 256M --vm-hang 0 || true
-  - sleep 25 # let it OOMKill a few times
+  - kubectl create namespace runlore-eval --dry-run=client -o yaml | kubectl apply -f -
+  - kubectl apply -f eval/scenarios/manifests/eval-memhog.yaml
+  - sleep 30 # let it OOMKill a few times -> CrashLoopBackOff with OOMKilled last-termination
 trigger:
   mode: cli
   symptom: pod mem-hog repeatedly restarting (OOMKilled) in namespace runlore-eval
@@ -16,13 +13,11 @@ trigger:
 ground_truth:
   root_cause: >-
     The mem-hog pod requests 256M but is capped at a 64Mi memory limit, so the kernel
-    OOMKills it repeatedly (reason OOMKilled, exit 137). Resource saturation against the
-    limit, with no Git change involved.
+    OOMKills it repeatedly (reason OOMKilled, exit 137) and it lands in CrashLoopBackOff.
+    Resource saturation against the limit, with no Git change involved.
   expected_sources: [kubernetes]
   optional_sources: [logs]
   expected_action: raise the memory limit or reduce the workload's footprint
   must_reach_root: true
 teardown:
-  - kubectl -n runlore-eval delete pod mem-hog --ignore-not-found
-  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found
   - kubectl delete ns runlore-eval --ignore-not-found

--- a/eval/scenarios-k3d/k3d-oom-saturation.yaml
+++ b/eval/scenarios-k3d/k3d-oom-saturation.yaml
@@ -1,0 +1,28 @@
+id: k3d-oom-saturation
+category: saturation
+description: a memory-hog workload OOMKills under a tight limit (runs on k3d)
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
+  - |
+    kubectl -n runlore-eval run mem-hog --image=polinux/stress --restart=Never \
+      --limits=memory=64Mi --requests=memory=64Mi -- \
+      stress --vm 1 --vm-bytes 256M --vm-hang 0 || true
+  - sleep 25 # let it OOMKill a few times
+trigger:
+  mode: cli
+  symptom: pod mem-hog repeatedly restarting (OOMKilled) in namespace runlore-eval
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    The mem-hog pod requests 256M but is capped at a 64Mi memory limit, so the kernel
+    OOMKills it repeatedly (reason OOMKilled, exit 137). Resource saturation against the
+    limit, with no Git change involved.
+  expected_sources: [kubernetes]
+  optional_sources: [logs]
+  expected_action: raise the memory limit or reduce the workload's footprint
+  must_reach_root: true
+teardown:
+  - kubectl -n runlore-eval delete pod mem-hog --ignore-not-found
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found
+  - kubectl delete ns runlore-eval --ignore-not-found

--- a/eval/scenarios-k3d/k3d-pvc-unbound.yaml
+++ b/eval/scenarios-k3d/k3d-pvc-unbound.yaml
@@ -3,6 +3,7 @@ category: storage
 description: a PVC with a non-existent StorageClass never binds; consumer Pod stays Pending (runs on k3d)
 invasive: true
 setup:
+  - kubectl create namespace runlore-eval --dry-run=client -o yaml | kubectl apply -f -
   - kubectl apply -f eval/scenarios/manifests/eval-victim-bad-pvc.yaml
   - sleep 12
 trigger:

--- a/eval/scenarios-k3d/k3d-pvc-unbound.yaml
+++ b/eval/scenarios-k3d/k3d-pvc-unbound.yaml
@@ -1,0 +1,23 @@
+id: k3d-pvc-unbound
+category: storage
+description: a PVC with a non-existent StorageClass never binds; consumer Pod stays Pending (runs on k3d)
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-bad-pvc.yaml
+  - sleep 12
+trigger:
+  mode: cli
+  symptom: pod eval-pvc-consumer stuck Pending in namespace runlore-eval (volume not bound)
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    PVC eval-bad-pvc requests storageClassName this-storageclass-does-not-exist, which
+    has no provisioner, so the claim never binds and the consumer Pod stays Pending
+    (FailedScheduling: pod has unbound immediate PersistentVolumeClaims).
+  expected_sources: [kubernetes]
+  optional_sources: []
+  expected_action: use a valid StorageClass (on k3d, the default local-path)
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-bad-pvc.yaml --ignore-not-found
+  - kubectl delete ns runlore-eval --ignore-not-found

--- a/eval/scenarios/cert-issuance-expiry.yaml
+++ b/eval/scenarios/cert-issuance-expiry.yaml
@@ -1,0 +1,24 @@
+id: cert-issuance-expiry
+category: cert
+description: a Certificate with a broken issuerRef never becomes Ready
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-bad-cert.yaml
+  - sleep 20
+trigger:
+  mode: cli
+  symptom: Certificate eval-bad-cert in namespace runlore-eval is not Ready; TLS secret missing
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    Certificate eval-bad-cert references ClusterIssuer does-not-exist-issuer, which does
+    not exist, so cert-manager cannot issue the cert — it stays Ready=False and the TLS
+    secret is never created. Any workload depending on that cert would fail its TLS path.
+  expected_sources: [kubernetes]
+  optional_sources: [logs]
+  expected_action: point issuerRef at a valid (Cluster)Issuer
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-bad-cert.yaml --ignore-not-found
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found

--- a/eval/scenarios/cloud-node-context-readonly.yaml
+++ b/eval/scenarios/cloud-node-context-readonly.yaml
@@ -1,0 +1,19 @@
+id: cloud-node-context-readonly
+category: cloud
+description: agent must surface real recent AWS control-plane changes + node health (read-only)
+invasive: false
+precheck: aws sts get-caller-identity >/dev/null 2>&1
+trigger:
+  mode: cli
+  symptom: investigate recent AWS-side changes and node-group health for the EKS cluster mycluster-0 in eu-west-3
+  namespace: kube-system
+ground_truth:
+  # No induced fault: this scenario verifies the AWS tools are exercised and that the
+  # agent reports a REAL recent CloudTrail mutation + EC2/ASG/EKS health. Pin root_cause
+  # at run time to a known recent event (e.g. the Karpenter bottlerocket AMI bump, or a
+  # node scale event) by reading CloudTrail before the run. Edit this line per run.
+  root_cause: "PIN-AT-RUNTIME: a recent CloudTrail mutating event on mycluster-0 (e.g. EC2 RunInstances/ASG update)"
+  expected_sources: [aws]
+  optional_sources: [kubernetes]
+  expected_action: confirm the change was intended; correlate with any node disruption
+  must_reach_root: false

--- a/eval/scenarios/dns-resolution-failure.yaml
+++ b/eval/scenarios/dns-resolution-failure.yaml
@@ -1,0 +1,29 @@
+id: dns-resolution-failure
+category: dns
+description: a toFQDNs policy missing the DNS L7 rule breaks name resolution silently
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
+  - |
+    kubectl -n runlore-eval run eval-dns-victim --image=curlimages/curl --restart=Never \
+      --labels=app=eval-dns-victim --command -- sleep 3600 || true
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-dns-broken.yaml
+  - sleep 15
+trigger:
+  mode: cli
+  symptom: pod eval-dns-victim in namespace runlore-eval fails all requests with name resolution errors
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    CiliumNetworkPolicy eval-dns-victim-policy allows toFQDNs but omits the kube-dns
+    egress L7 DNS rule (toPorts.rules.dns.matchPattern "*"), so Cilium proxies the DNS
+    query but never sees the response IPs — the toFQDNs allowlist has no IPs to match and
+    every connection is dropped. DNS appears to "work" while downstream traffic fails.
+  expected_sources: [network]
+  optional_sources: [logs, kubernetes]
+  expected_action: add the kube-dns egress rule with toPorts.rules.dns matchPattern "*"
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-dns-broken.yaml --ignore-not-found
+  - kubectl -n runlore-eval delete pod eval-dns-victim --ignore-not-found
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found

--- a/eval/scenarios/gitops-bad-image-tag.yaml
+++ b/eval/scenarios/gitops-bad-image-tag.yaml
@@ -1,0 +1,22 @@
+id: gitops-bad-image-tag
+category: what-changed
+description: image patched to a non-existent tag -> ImagePullBackOff
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
+  - kubectl -n runlore-eval set image deploy/eval-victim app=registry.k8s.io/pause:v9.9.9-does-not-exist
+  - kubectl -n runlore-eval rollout status deploy/eval-victim --timeout=20s || true
+trigger:
+  mode: cli
+  symptom: eval-victim pods not starting in namespace runlore-eval (image pull errors)
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    The eval-victim Deployment image was changed to tag v9.9.9-does-not-exist, which
+    cannot be pulled (ImagePullBackOff/ErrImagePull). A change is the cause.
+  expected_sources: [kubernetes, logs]
+  optional_sources: [gitops]
+  expected_action: revert the image tag to a valid one (roll back the change)
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found

--- a/eval/scenarios/gitops-broken-kustomization.yaml
+++ b/eval/scenarios/gitops-broken-kustomization.yaml
@@ -1,0 +1,23 @@
+id: gitops-broken-kustomization
+category: what-changed
+description: a Flux Kustomization pointed at a non-existent path -> Ready=False
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-bad-kustomization.yaml
+  - sleep 20 # let Flux reconcile and report Ready=False
+trigger:
+  mode: cli
+  symptom: Flux Kustomization eval-victim-broken is not ready in flux-system
+  namespace: flux-system
+ground_truth:
+  root_cause: >-
+    Kustomization/eval-victim-broken references spec.path ./this/path/does/not/exist,
+    which does not exist in the infra-artifact source, so the build fails and the
+    Kustomization is Ready=False (BuildFailed). The source ExternalArtifact itself is
+    healthy — the bad path is the root cause.
+  expected_sources: [gitops]
+  optional_sources: [kubernetes]
+  expected_action: correct spec.path (or remove the Kustomization)
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-bad-kustomization.yaml --ignore-not-found

--- a/eval/scenarios/harbor-registry-iam-quota.yaml
+++ b/eval/scenarios/harbor-registry-iam-quota.yaml
@@ -1,0 +1,18 @@
+id: harbor-registry-iam-quota
+category: dependency
+description: harbor-registry CreateContainerConfigError — Crossplane access key Secret missing username
+invasive: false
+precheck: kubectl get pods -n tooling -l app=harbor,component=registry -o jsonpath='{.items[*].status.containerStatuses[*].state.waiting.reason}' | grep -q CreateContainerConfigError
+trigger:
+  mode: cli
+  symptom: harbor registry pod not starting in namespace tooling (CreateContainerConfigError)
+  namespace: tooling
+ground_truth:
+  root_cause: >-
+    Crossplane accesskey/xplane-harbor hit the AWS IAM AccessKeysPerUser:2 quota, so
+    Secret xplane-harbor-access-key was created without a username key, leaving the
+    registry container unable to start (CreateContainerConfigError).
+  expected_sources: [kubernetes]
+  optional_sources: [aws, gitops]
+  expected_action: delete an old IAM access key for the user so Crossplane can mint a new one
+  must_reach_root: true

--- a/eval/scenarios/harbor-valkey-dependency-down.yaml
+++ b/eval/scenarios/harbor-valkey-dependency-down.yaml
@@ -1,0 +1,18 @@
+id: harbor-valkey-dependency-down
+category: dependency
+description: harbor core/jobservice/nginx CrashLoopBackOff — valkey (redis) dependency down
+invasive: false
+precheck: kubectl get pods -n tooling -l app=harbor,component=core -o jsonpath='{.items[*].status.containerStatuses[*].state.waiting.reason}' | grep -q CrashLoopBackOff
+trigger:
+  mode: cli
+  symptom: harbor core is CrashLoopBackOff in namespace tooling
+  namespace: tooling
+ground_truth:
+  root_cause: >-
+    harbor-valkey-primary:6379 connection refused (valkey is down), so harbor
+    core/jobservice/nginx crash on startup. The dependency outage, not harbor itself,
+    is the root cause.
+  expected_sources: [kubernetes, logs]
+  optional_sources: []
+  expected_action: restore the harbor-valkey-primary service (investigate why valkey is down)
+  must_reach_root: true

--- a/eval/scenarios/known-pattern-recall.yaml
+++ b/eval/scenarios/known-pattern-recall.yaml
@@ -1,0 +1,21 @@
+id: known-pattern-recall
+category: instant-recall
+description: re-firing a known symptom should short-circuit via kb_search, not re-run the full loop
+invasive: false
+# Precondition: the catalog (cfg.catalog) must contain a KB entry matching this symptom
+# AND instant_recall must be enabled in config. If not, this SKIPs. Set RUNLORE_RECALL_READY
+# once the curation loop (workstream B) has merged a relevant entry and it's indexed.
+precheck: test -n "$RUNLORE_RECALL_READY"
+trigger:
+  mode: cli
+  symptom: harbor registry pod CreateContainerConfigError in namespace tooling
+  namespace: tooling
+ground_truth:
+  root_cause: >-
+    A known, catalogued pattern: harbor registry CreateContainerConfigError from the
+    Crossplane IAM access-key quota. The agent should recall the catalog entry rather
+    than re-investigate from scratch.
+  expected_sources: [kb]
+  optional_sources: [kubernetes]
+  expected_action: apply the catalogued resolution (free an IAM access key)
+  must_reach_root: true

--- a/eval/scenarios/manifests/eval-memhog.yaml
+++ b/eval/scenarios/manifests/eval-memhog.yaml
@@ -1,0 +1,19 @@
+# A pod that requests far more memory (256M) than its limit (64Mi), so the kernel
+# OOMKills it; restartPolicy: Always makes it CrashLoopBackOff with an OOMKilled
+# LastTerminationState — the signal pod_status now surfaces. Self-contained (its own
+# namespace) so the scenario needs no other manifest.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mem-hog
+  namespace: runlore-eval
+  labels: { app: mem-hog, runlore.io/eval: "true" }
+spec:
+  restartPolicy: Always
+  containers:
+    - name: app
+      image: polinux/stress
+      args: ["stress", "--vm", "1", "--vm-bytes", "256M", "--vm-hang", "0"]
+      resources:
+        requests: { memory: 64Mi }
+        limits: { memory: 64Mi }

--- a/eval/scenarios/manifests/eval-victim-app.yaml
+++ b/eval/scenarios/manifests/eval-victim-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: runlore-eval
+  labels: { runlore.io/eval: "true" }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eval-victim
+  namespace: runlore-eval
+  labels: { app: eval-victim, runlore.io/eval: "true" }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: eval-victim } }
+  template:
+    metadata: { labels: { app: eval-victim } }
+    spec:
+      containers:
+        - name: app
+          image: registry.k8s.io/pause:3.9 # healthy baseline; scenarios mutate this
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { cpu: 50m, memory: 32Mi }

--- a/eval/scenarios/manifests/eval-victim-bad-cert.yaml
+++ b/eval/scenarios/manifests/eval-victim-bad-cert.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: eval-bad-cert
+  namespace: runlore-eval
+  labels: { runlore.io/eval: "true" }
+spec:
+  secretName: eval-bad-cert-tls
+  duration: 1h
+  issuerRef:
+    name: does-not-exist-issuer # broken issuerRef -> stuck NotReady
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames: [eval.runlore-eval.svc]

--- a/eval/scenarios/manifests/eval-victim-bad-kustomization.yaml
+++ b/eval/scenarios/manifests/eval-victim-bad-kustomization.yaml
@@ -1,0 +1,18 @@
+# A Flux Kustomization pointed at a non-existent path of a REAL, healthy
+# ExternalArtifact source (this cluster uses ArtifactGenerator → ExternalArtifact,
+# not GitRepository). The source builds fine; the path doesn't exist → Ready=False
+# (BuildFailed) — a clean "what changed / broken config" failure.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: eval-victim-broken
+  namespace: flux-system
+  labels: { runlore.io/eval: "true" }
+spec:
+  interval: 1m
+  path: ./this/path/does/not/exist
+  prune: true
+  sourceRef:
+    kind: ExternalArtifact
+    name: infra-artifact
+  timeout: 30s

--- a/eval/scenarios/manifests/eval-victim-bad-pvc.yaml
+++ b/eval/scenarios/manifests/eval-victim-bad-pvc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: eval-bad-pvc
+  namespace: runlore-eval
+  labels: { runlore.io/eval: "true" }
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: this-storageclass-does-not-exist
+  resources:
+    requests: { storage: 1Gi }
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: eval-pvc-consumer
+  namespace: runlore-eval
+  labels: { app: eval-pvc-consumer, runlore.io/eval: "true" }
+spec:
+  containers:
+    - name: app
+      image: registry.k8s.io/pause:3.9
+      volumeMounts: [{ name: data, mountPath: /data }]
+      resources: { requests: { cpu: 10m, memory: 16Mi }, limits: { cpu: 50m, memory: 32Mi } }
+  volumes:
+    - name: data
+      persistentVolumeClaim: { claimName: eval-bad-pvc }

--- a/eval/scenarios/manifests/eval-victim-dns-broken.yaml
+++ b/eval/scenarios/manifests/eval-victim-dns-broken.yaml
@@ -1,0 +1,17 @@
+# A toFQDNs policy that OMITS the kube-dns L7 DNS rule, so Cilium proxies the DNS
+# query but never sees the resolved IPs — the toFQDNs allowlist has no IPs to match
+# and every connection is dropped (the documented Cilium DNS gotcha). DNS appears to
+# "work" while downstream traffic silently fails.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: eval-dns-victim-policy
+  namespace: runlore-eval
+  labels: { runlore.io/eval: "true" }
+spec:
+  endpointSelector:
+    matchLabels: { app: eval-dns-victim }
+  egress:
+    - toFQDNs:
+        - matchName: example.com # allowed destination, but with NO DNS L7 rule below
+    # intentionally NO kube-dns egress with toPorts.rules.dns -> resolution silently breaks

--- a/eval/scenarios/manifests/eval-victim-netpol-deny.yaml
+++ b/eval/scenarios/manifests/eval-victim-netpol-deny.yaml
@@ -1,0 +1,10 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: eval-victim-deny-egress
+  namespace: runlore-eval
+  labels: { runlore.io/eval: "true" }
+spec:
+  endpointSelector:
+    matchLabels: { app: eval-victim }
+  egress: [] # default-deny all egress for the victim

--- a/eval/scenarios/network-policy-drop.yaml
+++ b/eval/scenarios/network-policy-drop.yaml
@@ -1,0 +1,24 @@
+id: network-policy-drop
+category: network
+description: a default-deny CiliumNetworkPolicy silently drops the victim's egress
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-netpol-deny.yaml
+  - sleep 15
+trigger:
+  mode: cli
+  symptom: eval-victim in namespace runlore-eval cannot reach any dependency (connection timeouts)
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    CiliumNetworkPolicy eval-victim-deny-egress applies an empty egress allowlist
+    (default-deny) to app=eval-victim, so all its outbound connections are dropped by
+    policy — which presents as application connection timeouts, not an app bug.
+  expected_sources: [network]
+  optional_sources: [kubernetes, logs]
+  expected_action: add an explicit egress allow rule (or remove the deny policy)
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-netpol-deny.yaml --ignore-not-found
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found

--- a/eval/scenarios/pvc-storage-unbound.yaml
+++ b/eval/scenarios/pvc-storage-unbound.yaml
@@ -1,0 +1,23 @@
+id: pvc-storage-unbound
+category: storage
+description: a PVC with a non-existent StorageClass never binds; its consumer Pod stays Pending
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-bad-pvc.yaml
+  - sleep 15
+trigger:
+  mode: cli
+  symptom: pod eval-pvc-consumer stuck Pending in namespace runlore-eval (volume not bound)
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    PVC eval-bad-pvc requests storageClassName this-storageclass-does-not-exist, which
+    has no provisioner, so the claim never binds and the consumer Pod stays Pending
+    (FailedScheduling: pod has unbound immediate PersistentVolumeClaims).
+  expected_sources: [kubernetes]
+  optional_sources: []
+  expected_action: use a valid StorageClass (e.g. the cluster's EBS gp3 class)
+  must_reach_root: true
+teardown:
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-bad-pvc.yaml --ignore-not-found
+  - kubectl get ns runlore-eval -o name >/dev/null 2>&1 && kubectl delete ns runlore-eval --ignore-not-found || true

--- a/eval/scenarios/saturation-mem-pressure.yaml
+++ b/eval/scenarios/saturation-mem-pressure.yaml
@@ -1,0 +1,27 @@
+id: saturation-mem-pressure
+category: saturation
+description: a memory-hog workload drives OOMKills under a tight limit
+invasive: true
+setup:
+  - kubectl apply -f eval/scenarios/manifests/eval-victim-app.yaml
+  - |
+    kubectl -n runlore-eval run mem-hog --image=polinux/stress --restart=Never \
+      --limits=memory=64Mi --requests=memory=64Mi -- \
+      stress --vm 1 --vm-bytes 256M --vm-hang 0 || true
+  - sleep 25 # let it OOMKill a few times and emit metrics
+trigger:
+  mode: cli
+  symptom: pod mem-hog repeatedly restarting (OOMKilled) in namespace runlore-eval
+  namespace: runlore-eval
+ground_truth:
+  root_cause: >-
+    The mem-hog pod requests 256M but is capped at a 64Mi memory limit, so the kernel
+    OOMKills it repeatedly (reason OOMKilled, exit 137). Resource saturation against the
+    limit, with no Git change involved.
+  expected_sources: [kubernetes]
+  optional_sources: [metrics, logs]
+  expected_action: raise the memory limit or reduce the workload's footprint
+  must_reach_root: true
+teardown:
+  - kubectl -n runlore-eval delete pod mem-hog --ignore-not-found
+  - kubectl delete -f eval/scenarios/manifests/eval-victim-app.yaml --ignore-not-found

--- a/eval/scenarios/vector-cilium-ip-exhaustion.yaml
+++ b/eval/scenarios/vector-cilium-ip-exhaustion.yaml
@@ -1,0 +1,17 @@
+id: vector-cilium-ip-exhaustion
+category: node
+description: victoria-logs-vector stuck ContainerCreating — Cilium IPAM IP exhaustion on the node
+invasive: false
+precheck: kubectl get pods -n observability -l app.kubernetes.io/name=vector -o jsonpath='{.items[*].status.phase}' | grep -q Pending
+trigger:
+  mode: cli
+  symptom: victoria-logs-vector pod stuck ContainerCreating in namespace observability
+  namespace: observability
+ground_truth:
+  root_cause: >-
+    Cilium IPAM has no IPs available on the node ("no IPs currently available on the
+    node"), so the vector pod sandbox cannot get an address and stays ContainerCreating.
+  expected_sources: [kubernetes]
+  optional_sources: [network]
+  expected_action: free or add node IP capacity (Cilium IPAM pool) so the pod can be scheduled
+  must_reach_root: true

--- a/internal/providers/cluster/cluster.go
+++ b/internal/providers/cluster/cluster.go
@@ -87,6 +87,17 @@ func (r *Reader) PodStatuses(ctx context.Context, namespace, labelSelector strin
 
 func podStatus(p *corev1.Pod) providers.PodStatus {
 	ps := providers.PodStatus{Name: p.Name, Phase: string(p.Status.Phase)}
+	// Container memory limits (from the spec) — needed to tie an OOMKill to the limit.
+	memLimit := map[string]string{}
+	addLimits := func(cs []corev1.Container) {
+		for _, c := range cs {
+			if q, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+				memLimit[c.Name] = q.String()
+			}
+		}
+	}
+	addLimits(p.Spec.InitContainers)
+	addLimits(p.Spec.Containers)
 	ready, total := 0, 0
 	collect := func(cs []corev1.ContainerStatus) {
 		for _, c := range cs {
@@ -94,11 +105,25 @@ func podStatus(p *corev1.Pod) providers.PodStatus {
 			if c.Ready {
 				ready++
 			}
+			oom := false
 			switch {
 			case c.State.Waiting != nil && c.State.Waiting.Reason != "" && c.State.Waiting.Reason != "ContainerCreating" && c.State.Waiting.Reason != "PodInitializing":
-				ps.Reasons = append(ps.Reasons, fmt.Sprintf("%s: %s: %s", c.Name, c.State.Waiting.Reason, c.State.Waiting.Message))
+				msg := fmt.Sprintf("%s: %s: %s", c.Name, c.State.Waiting.Reason, c.State.Waiting.Message)
+				// A waiting (e.g. CrashLoopBackOff) container hides WHY it died — the
+				// reason/exit code live in the LAST termination (e.g. OOMKilled, exit 137).
+				if lt := c.LastTerminationState.Terminated; lt != nil && lt.Reason != "" {
+					msg += fmt.Sprintf(" [last termination: %s (exit %d)]", lt.Reason, lt.ExitCode)
+					oom = lt.Reason == "OOMKilled"
+				}
+				ps.Reasons = append(ps.Reasons, msg)
 			case c.State.Terminated != nil && c.State.Terminated.Reason != "" && c.State.Terminated.Reason != "Completed":
 				ps.Reasons = append(ps.Reasons, fmt.Sprintf("%s: %s (exit %d): %s", c.Name, c.State.Terminated.Reason, c.State.Terminated.ExitCode, c.State.Terminated.Message))
+				oom = c.State.Terminated.Reason == "OOMKilled"
+			}
+			if oom {
+				if lim, ok := memLimit[c.Name]; ok {
+					ps.Reasons = append(ps.Reasons, fmt.Sprintf("%s: memory limit %s (OOMKilled ⇒ limit likely too low for the workload)", c.Name, lim))
+				}
 			}
 		}
 	}

--- a/internal/providers/cluster/cluster_test.go
+++ b/internal/providers/cluster/cluster_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -37,5 +38,45 @@ func TestPodLogs(t *testing.T) {
 	}
 	if strings.Contains(joined, "kustomize-controller-1:") {
 		t.Fatalf("label selector leaked another pod's logs:\n%s", joined)
+	}
+}
+
+func TestPodStatusSurfacesOOMAndLimit(t *testing.T) {
+	// An OOMKilled pod loops: its CURRENT state is Waiting{CrashLoopBackOff}; the
+	// OOMKilled/exit-137 signal lives in LastTerminationState. pod_status must surface
+	// that + the container's memory limit so the model can tie OOM → the limit.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "mem-hog", Namespace: "runlore-eval"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "app",
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Mi")},
+			},
+		}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "app",
+				Ready: false,
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "CrashLoopBackOff", Message: "back-off restarting failed container"}},
+				LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason: "OOMKilled", ExitCode: 137}},
+			}},
+		},
+	}
+	r := New(fake.NewSimpleClientset(pod))
+	got, err := r.PodStatuses(context.Background(), "runlore-eval", "")
+	if err != nil {
+		t.Fatalf("PodStatuses: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 pod, got %d", len(got))
+	}
+	joined := strings.Join(got[0].Reasons, " | ")
+	for _, want := range []string{"CrashLoopBackOff", "OOMKilled", "137", "64Mi"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("pod_status reasons %q missing %q (the OOM-from-limit signal)", joined, want)
+		}
 	}
 }


### PR DESCRIPTION
Follows #64 (the `lore eval --live` engine, now merged to main). Supersedes #65, which GitHub auto-closed when #64's branch was deleted (stacked-PR base-branch deletion). Authors the scenario catalog and runs the **first real baseline** — which found a genuine RunLore gap, fixed it, and re-validated. (mycluster-0 was destroyed mid-effort, so the baseline ran on local **k3d**.)

## What's here

- `eval/scenarios/` — the **12-scenario EKS matrix** (what-changed, saturation, network, dns, cert, storage, cloud read-only, instant-recall, + 3 natural Harbor/vector cases). Cluster-accurate: namespaces confirmed (Harbor→`tooling`, vector→`observability`); broken-Kustomization targets a real `ExternalArtifact` (this cluster is ArtifactGenerator→ExternalArtifact, not `GitRepository`).
- `eval/scenarios-k3d/` — a **k8s-native subset** that runs on vanilla k3d (bad-image-tag, pvc-unbound, oom).
- `eval/rubric.md`, `eval/scenarios/manifests/` (throwaway manifests, confined to a `runlore-eval` ns, always torn down).
- **First baseline** (`eval/reports/2026-06-22-k3d-baseline.md`): investigation = `gemini-2.5-flash`, judge = `gemini-2.5-pro` (stronger, blind), N=3 — validated the harness end-to-end with a real LLM. Scope: on vanilla k3d only the **kubernetes** data source is real.

## Eval found a real gap → fixed → re-validated

`k3d-oom-saturation` initially **FAILED** (root_cause 1/3, confident-wrong). Two root causes, both fixed:
- **RunLore (`fix(pod_status)`):** the tool only read the *current* container state, but an OOM-looping pod is `Waiting{CrashLoopBackOff}` and the `OOMKilled`/exit-137 signal lives in `LastTerminationState` (and it never surfaced the memory limit). Now surfaces both → the model can tie OOM → the limit. Unit-tested.
- **Scenario:** `kubectl run --limits` (removed from modern kubectl) → the OOM pod was never created. Now induces via a manifest with `resources.limits.memory`.

**Re-ran N=3 → root_cause 3/3, PASS. Final baseline: 3/3.**

## Test plan
- [x] `go build/vet/test ./... && gofmt -l . && golangci-lint run ./...` — green, 0 issues (incl. the new `pod_status` OOM test)
- [x] k3d baseline end-to-end (real Gemini investigate + judge); induced faults reverted (verified)
- [ ] Run the full EKS catalog when a real cluster exists again (k3d can't exercise gitops/metrics/logs/network/aws)