### PR TITLE
feat: recall trustworthiness — confident-recall gate + derived confidence

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -875,8 +875,16 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	if cat != nil {
 		tools = append(tools, investigate.KBSearchTool{Catalog: cat})
 		if cfg.Catalog.InstantRecall.Enabled {
-			recall = &investigate.Recall{Catalog: cat, MinScore: cfg.Catalog.InstantRecall.MinScore}
-			log.Info("instant recall enabled", "min_score", cfg.Catalog.InstantRecall.MinScore)
+			recall = &investigate.Recall{
+				Catalog:              cat,
+				MinScore:             cfg.Catalog.InstantRecall.MinScore,
+				MarginGap:            cfg.Catalog.InstantRecall.MarginGap,
+				SoloFloor:            cfg.Catalog.InstantRecall.SoloFloor,
+				RequireWorkloadMatch: cfg.Catalog.InstantRecall.RequireWorkloadMatch,
+			}
+			log.Info("instant recall enabled",
+				"min_score", cfg.Catalog.InstantRecall.MinScore,
+				"margin_gap", cfg.Catalog.InstantRecall.MarginGap, "solo_floor", cfg.Catalog.InstantRecall.SoloFloor)
 		}
 	}
 	if cfg.Metrics.URL != "" {

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -60,6 +60,12 @@ config:
   #   api_key_env: OPENAI_API_KEY
   # catalog:
   #   dir: /var/lib/runlore/catalog
+  #   instant_recall:
+  #     enabled: true
+  #     min_score: 1.5                 # similarity floor for the top hit
+  #     margin_gap: 1.0                # top hit must beat the runner-up by this (corpus-portable; not an absolute floor)
+  #     solo_floor: 4.0                # confident bar when there is only one hit
+  #     require_workload_match: false  # true = exact namespace+workload; false = namespace-level agreement is enough
   # notify:
   #   slack: { webhook_url_env: SLACK_WEBHOOK_URL }
   #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }

--- a/docs/superpowers/plans/2026-06-22-recall-trustworthiness.md
+++ b/docs/superpowers/plans/2026-06-22-recall-trustworthiness.md
@@ -1,0 +1,659 @@
+# Recall Trustworthiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make instant recall short-circuit a full investigation only when it's *trustworthy* — a BM25 *margin* over the runner-up + *structural agreement* on the resource — with a *derived* confidence (no more hardcoded `0.8`), and never re-curate a cache hit.
+
+**Architecture:** All recall-side logic lives in `internal/investigate/recall.go` (the `lookup` gate + a derived-confidence formula). A new `Investigation.Recalled` flag lets the curator skip a recalled finding; a new `Investigation.Resource` carries the originating workload so curated entries store it (enabling structural agreement on future recalls). Reuses the existing `catalog.Entry.Resource` and `providers.KBEntry.Resource` fields (both already exist, just unused).
+
+**Tech Stack:** Go, bleve (BM25), OpenTelemetry metrics, plain `testing`. Module `github.com/Smana/runlore`.
+
+**Design spec:** `docs/superpowers/specs/2026-06-22-recall-trustworthiness-design.md`
+
+**Conventions:** TDD red→green per task; before each commit `cd /home/smana/Sources/runlore && gofmt -w <files> && go vet ./... && go build ./... && golangci-lint run && <pkg tests>`. Plain `testing`/`t.Fatalf` (no testify). Conventional commits; **NO `Co-Authored-By` / attribution trailers**. Depends on PR #67's recall metrics (this branch is based on it).
+
+---
+
+## Task 1: Config knobs + `recall_rejections_total` metric
+
+**Files:**
+- Modify: `internal/config/config.go` (`InstantRecall` struct)
+- Modify: `internal/telemetry/metrics.go`
+- Test: `internal/config/config_test.go` (or the existing config test file)
+
+- [ ] **Step 1: Write the failing test** (append to the config test file)
+
+```go
+func TestInstantRecallTrustConfig(t *testing.T) {
+	const y = `
+catalog:
+  instant_recall:
+    enabled: true
+    min_score: 1.5
+    margin_gap: 1.0
+    solo_floor: 4.0
+    require_workload_match: false
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ir := c.Catalog.InstantRecall
+	if !ir.Enabled || ir.MinScore != 1.5 || ir.MarginGap != 1.0 || ir.SoloFloor != 4.0 || ir.RequireWorkloadMatch {
+		t.Fatalf("instant_recall not parsed: %+v", ir)
+	}
+}
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`MarginGap`/`SoloFloor`/`RequireWorkloadMatch` undefined)
+
+Run: `go test ./internal/config/ -run TestInstantRecallTrustConfig`
+
+- [ ] **Step 3: Extend `InstantRecall`** in `internal/config/config.go`
+
+```go
+type InstantRecall struct {
+	Enabled              bool    `yaml:"enabled"`
+	MinScore             float64 `yaml:"min_score"`             // similarity floor for the top hit
+	MarginGap            float64 `yaml:"margin_gap"`            // top hit must beat the runner-up by at least this
+	SoloFloor            float64 `yaml:"solo_floor"`            // confident bar when there is only one hit (higher than MinScore)
+	RequireWorkloadMatch bool    `yaml:"require_workload_match"` // true = exact namespace+workload; false = namespace-level agreement is enough
+}
+```
+
+- [ ] **Step 4: Add the metric** in `internal/telemetry/metrics.go` — add the field to `Metrics` (after `RecallTokensSaved`):
+
+```go
+	RecallRejections metric.Int64Counter // recalls rejected before short-circuit (label: reason)
+```
+
+and in `NewMetrics`'s returned struct literal (after the `RecallTokensSaved` line):
+
+```go
+		RecallRejections:         ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),
+```
+
+- [ ] **Step 5: Run + commit**
+
+Run: `go test ./internal/config/ ./internal/telemetry/ && go build ./...`
+```bash
+gofmt -w internal/config/config.go internal/telemetry/metrics.go
+git add internal/config/config.go internal/telemetry/metrics.go internal/config/*_test.go
+git commit -m "feat(recall): config knobs (margin/solo_floor/structural) + recall_rejections metric"
+```
+
+---
+
+## Task 2: Margin gate in `lookup`
+
+Today `lookup` searches `k=1` and accepts any hit ≥ `MinScore`. Make it search `k=2` and only accept an *unambiguous* winner.
+
+**Files:**
+- Modify: `internal/investigate/recall.go` (`Recall` struct + `lookup`)
+- Test: `internal/investigate/recall_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func recallWith(hits []catalog.ScoredEntry) *Recall {
+	return &Recall{Catalog: fakeScored{hits: hits}, MinScore: 1.5, MarginGap: 1.0, SoloFloor: 4.0}
+}
+
+func TestLookupMarginClearWinner(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "BadImage", Path: "b.md"}, Score: 2.0},
+	})
+	if e, _ := r.lookup(context.Background(), Request{Title: "pod crashloop"}); e == nil {
+		t.Fatal("clear winner (gap 4.0 ≥ 1.0) should recall")
+	}
+}
+
+func TestLookupMarginNearTieFallsThrough(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "BadImage", Path: "b.md"}, Score: 5.5},
+	})
+	if e, _ := r.lookup(context.Background(), Request{Title: "pod crashloop"}); e != nil {
+		t.Fatal("near-tie (gap 0.5 < 1.0) must fall through")
+	}
+}
+
+func TestLookupLoneWeakHitFallsThrough(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md"}, Score: 3.0}, // below SoloFloor 4.0
+	})
+	if e, _ := r.lookup(context.Background(), Request{Title: "pod crashloop"}); e != nil {
+		t.Fatal("a lone hit below solo_floor must fall through")
+	}
+}
+```
+
+> These tests set no `Resource` on the entries and leave `Request.Workload` zero; **Task 3 adds the structural gate** which would otherwise reject them — so write Task 2's impl to *pass the margin gate and (for now) return the entry without a structural check*. Task 3's tests will then drive the structural gate, and these three tests get a `Resource`+`Workload` added in Task 3 Step 3 so they keep passing. (If you prefer, give these entries `Resource: "ns"` and `Request{Workload: providers.Workload{Namespace: "ns"}}` now to be forward-compatible.)
+
+- [ ] **Step 2: Run — expect FAIL** (`MarginGap`/`SoloFloor` fields undefined on `Recall`)
+
+Run: `go test ./internal/investigate/ -run TestLookupMargin`
+
+- [ ] **Step 3: Add fields + margin logic** in `recall.go`
+
+Add to the `Recall` struct (after `MinScore float64`):
+```go
+	MarginGap            float64 // top hit must beat the runner-up by at least this
+	SoloFloor            float64 // confident bar when there is only one hit
+	RequireWorkloadMatch bool    // structural strictness (used in Task 3)
+```
+
+Rewrite the tail of `lookup` (replace the `if score < r.MinScore { return nil, 0 }` block onward). Bump the search to `k=2`:
+```go
+	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), 2)
+	if err != nil || len(hits) == 0 {
+		return nil, 0
+	}
+	score := hits[0].Score
+	if r.Metrics != nil {
+		r.Metrics.RecallScore.Record(ctx, score)
+	}
+	margin := score
+	confident := score >= r.SoloFloor
+	if len(hits) > 1 {
+		margin = score - hits[1].Score
+		confident = score >= r.MinScore && margin >= r.MarginGap
+	}
+	if !confident {
+		r.reject(ctx, "low_margin")
+		return nil, 0
+	}
+	e := hits[0].Entry
+	return &e, score
+```
+
+Add a nil-safe reject helper:
+```go
+func (r *Recall) reject(ctx context.Context, reason string) {
+	if r.Metrics != nil {
+		r.Metrics.RecallRejections.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", reason)))
+	}
+}
+```
+(Imports: `go.opentelemetry.io/otel/metric`, `go.opentelemetry.io/otel/attribute` — already used in `loop.go`.)
+
+- [ ] **Step 4: Run — expect PASS**; **Step 5: Commit**
+
+```bash
+gofmt -w internal/investigate/recall.go internal/investigate/recall_test.go
+go vet ./... && go build ./... && golangci-lint run ./internal/investigate/...
+git add internal/investigate/recall.go internal/investigate/recall_test.go
+git commit -m "feat(recall): require a BM25 margin over the runner-up (corpus-portable, not absolute MinScore)"
+```
+
+---
+
+## Task 3: Structural agreement gate
+
+A confident recall also requires the entry's stored `Resource` to agree with the incoming alert's workload.
+
+**Files:**
+- Modify: `internal/investigate/recall.go`
+- Test: `internal/investigate/recall_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func structuralRecall(entryResource string, requireWorkload bool) *Recall {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: entryResource}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "X", Path: "b.md"}, Score: 2.0},
+	})
+	r.RequireWorkloadMatch = requireWorkload
+	return r
+}
+
+func TestLookupStructuralMatch(t *testing.T) {
+	r := structuralRecall("apps/web", false)
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if e, _ := r.lookup(context.Background(), req); e == nil {
+		t.Fatal("exact resource match should recall")
+	}
+}
+
+func TestLookupStructuralNamespaceOnly(t *testing.T) {
+	r := structuralRecall("apps/web", false)
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps"}} // name unknown from the alert
+	if e, _ := r.lookup(context.Background(), req); e == nil {
+		t.Fatal("namespace agreement should recall when require_workload_match=false")
+	}
+}
+
+func TestLookupStructuralMismatchFallsThrough(t *testing.T) {
+	r := structuralRecall("apps/web", false)
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "kube-system"}}
+	if e, _ := r.lookup(context.Background(), req); e != nil {
+		t.Fatal("different namespace must fall through")
+	}
+}
+
+func TestLookupNoStoredResourceFallsThrough(t *testing.T) {
+	r := structuralRecall("", false) // entry predates the write-side change
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps"}}
+	if e, _ := r.lookup(context.Background(), req); e != nil {
+		t.Fatal("entry with no stored resource must fall through (fail-safe)")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (the lookup doesn't yet check resource)
+
+Run: `go test ./internal/investigate/ -run TestLookupStructural`
+
+- [ ] **Step 3: Implement the gate + helpers** in `recall.go`
+
+```go
+type matchStrength int
+
+const (
+	matchNone matchStrength = iota
+	matchNamespace
+	matchExact
+)
+
+// canonicalResource renders a workload as "namespace/name", or just "namespace"
+// when the name is unknown (common for alert-triggered investigations).
+func canonicalResource(w providers.Workload) string {
+	if w.Namespace == "" {
+		return ""
+	}
+	if w.Name == "" {
+		return w.Namespace
+	}
+	return w.Namespace + "/" + w.Name
+}
+
+// resourceAgrees reports how strongly the alert's workload agrees with an entry's
+// stored resource. requireWorkload demands an exact namespace+name match.
+func resourceAgrees(reqW providers.Workload, entryResource string, requireWorkload bool) matchStrength {
+	if entryResource == "" || reqW.Namespace == "" {
+		return matchNone
+	}
+	if canonicalResource(reqW) == entryResource {
+		return matchExact
+	}
+	if requireWorkload {
+		return matchNone
+	}
+	if entryResource == reqW.Namespace || strings.HasPrefix(entryResource, reqW.Namespace+"/") {
+		return matchNamespace
+	}
+	return matchNone
+}
+```
+
+In `lookup`, after `e := hits[0].Entry` and before returning, add:
+```go
+	if resourceAgrees(req.Workload, e.Resource, r.RequireWorkloadMatch) == matchNone {
+		r.reject(ctx, "no_resource_match")
+		return nil, 0
+	}
+	return &e, score
+```
+
+Also update the Task-2 tests' entries to set `Resource: "ns"` and `Request{Workload: providers.Workload{Namespace: "ns"}}` so they still pass (or confirm you did that in Task 2 Step 1).
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./internal/investigate/ -run TestLookup`); **Step 5: Commit**
+
+```bash
+gofmt -w internal/investigate/recall.go internal/investigate/recall_test.go
+go vet ./... && go build ./... && golangci-lint run ./internal/investigate/...
+git add internal/investigate/recall.go internal/investigate/recall_test.go
+git commit -m "feat(recall): structural-agreement gate (alert workload must match the entry's resource)"
+```
+
+---
+
+## Task 4: Derived recall confidence (replace the hardcoded `0.8`)
+
+**Files:**
+- Modify: `internal/investigate/recall.go` (`lookup` returns derived confidence; `recalledInvestigation` takes it)
+- Modify: `internal/investigate/loop.go` (pass the confidence through)
+- Test: `internal/investigate/recall_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+func TestDeriveRecallConfidence(t *testing.T) {
+	// decisive winner, exact match → high but capped < 1
+	hi := deriveRecallConfidence(8.0, 6.0, matchExact)
+	if hi <= 0.8 || hi > 0.9 {
+		t.Fatalf("decisive+exact should be (0.8, 0.9], got %v", hi)
+	}
+	// marginal winner, namespace-only → lower
+	lo := deriveRecallConfidence(2.0, 0.4, matchNamespace)
+	if lo >= hi || lo < 0.5 {
+		t.Fatalf("marginal+namespace should be lower and ≥ 0.5, got %v (hi=%v)", lo, hi)
+	}
+}
+
+func TestRecalledInvestigationUsesDerivedConfidence(t *testing.T) {
+	inv := recalledInvestigation(Request{Title: "x"}, catalog.Entry{Title: "T", Description: "D", Path: "p.md"}, 0.72)
+	if inv.Confidence != 0.72 || inv.RootCauses[0].Confidence != 0.72 {
+		t.Fatalf("recalledInvestigation must use the derived confidence, got %+v", inv)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`deriveRecallConfidence` undefined; `recalledInvestigation` arity)
+
+Run: `go test ./internal/investigate/ -run 'TestDeriveRecallConfidence|TestRecalledInvestigationUses'`
+
+- [ ] **Step 3: Implement** in `recall.go`
+
+```go
+func clampF(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// deriveRecallConfidence turns the match signals into an explainable confidence,
+// capped below 1.0 — a cache hit never asserts certainty. (Constants are the
+// shape; tune via recall_score / recall_rejections.)
+func deriveRecallConfidence(score, margin float64, strength matchStrength) float64 {
+	base := 0.55
+	if score > 0 {
+		base = 0.55 + 0.30*clampF(margin/score, 0, 1) // decisive winner → up to 0.85
+	}
+	if strength == matchExact {
+		base += 0.05
+	}
+	return clampF(base, 0.50, 0.90)
+}
+```
+
+Change `recalledInvestigation` signature + the two `0.8` literals:
+```go
+func recalledInvestigation(req Request, e catalog.Entry, confidence float64) providers.Investigation {
+	rc := providers.Hypothesis{
+		Summary:    e.Title + " — " + e.Description,
+		Confidence: confidence,
+		Evidence:   []string{fmt.Sprintf("instant recall: matched knowledge-base entry %q", e.Path)},
+	}
+	return providers.Investigation{
+		Title:      req.Title,
+		Confidence: confidence,
+		RootCauses: []providers.Hypothesis{rc},
+		Unresolved: []string{"recalled from the catalog without a fresh investigation — confirm it still applies"},
+	}
+}
+```
+
+In `lookup`, return the derived confidence instead of the raw score. Capture `strength` from the structural check and compute confidence at the end:
+```go
+	strength := resourceAgrees(req.Workload, e.Resource, r.RequireWorkloadMatch)
+	if strength == matchNone {
+		r.reject(ctx, "no_resource_match")
+		return nil, 0
+	}
+	return &e, deriveRecallConfidence(score, margin, strength)
+```
+
+In `loop.go`, the recall short-circuit currently does `rec := recalledInvestigation(req, *entry)` after `entry, score := li.Recall.lookup(...)`. Update both: rename `score` → `conf` and pass it:
+```go
+	if entry, conf := li.Recall.lookup(ctx, req); entry != nil {
+		li.Log.Info("instant recall (catalog hit; skipping the loop)",
+			"title", req.Title, "entry", entry.Path, "confidence", fmt.Sprintf("%.2f", conf))
+		rec := recalledInvestigation(req, *entry, conf)
+		...
+```
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./internal/investigate/`); **Step 5: Commit**
+
+```bash
+gofmt -w internal/investigate/recall.go internal/investigate/loop.go internal/investigate/recall_test.go
+go vet ./... && go build ./... && golangci-lint run ./internal/investigate/...
+git add internal/investigate/recall.go internal/investigate/loop.go internal/investigate/recall_test.go
+git commit -m "feat(recall): derive recall confidence from match signals (replaces hardcoded 0.8)"
+```
+
+---
+
+## Task 5: Don't curate recalled findings
+
+A recall matched an existing entry → not novel. Flag the investigation and have the curator skip it (chat delivery is unaffected).
+
+**Files:**
+- Modify: `internal/providers/providers.go` (`Investigation.Recalled`)
+- Modify: `internal/investigate/recall.go` (`recalledInvestigation` sets it)
+- Modify: `internal/curator/curator.go` (`Curate` early-returns when `Recalled`)
+- Test: `internal/curator/curator_test.go`
+
+- [ ] **Step 1: Write the failing test** (reuse the package's existing curator test harness for building a `Curator` + a fake forge — grep `func TestCurate` in `internal/curator/curator_test.go`)
+
+```go
+func TestCurateSkipsRecalled(t *testing.T) {
+	c := newTestCurator(t) // existing helper; fake forge that records drafted PRs
+	inv := providers.Investigation{
+		Title: "Known incident", Confidence: 0.8, Recalled: true,
+		RootCauses: []providers.Hypothesis{{Summary: "x", Confidence: 0.8}},
+	}
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if c.forge.drafted != 0 { // adjust to the harness's recorder
+		t.Fatalf("a recalled finding must not be curated, drafted=%d", c.forge.drafted)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`Recalled` undefined)
+
+Run: `go test ./internal/curator/ -run TestCurateSkipsRecalled`
+
+- [ ] **Step 3: Implement**
+
+In `internal/providers/providers.go`, add to `Investigation` (after `Confidence float64`):
+```go
+	Recalled bool // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
+```
+
+In `internal/investigate/recall.go`, set it in `recalledInvestigation`'s returned `Investigation`:
+```go
+		Recalled:   true,
+```
+
+In `internal/curator/curator.go`, at the top of `Curate` (after the existing early guards):
+```go
+	if inv.Recalled {
+		c.Log.Info("skipping curation of a recalled finding (cache hit, not novel)", "title", inv.Title)
+		return providers.Ref{}, nil
+	}
+```
+
+- [ ] **Step 4: Run — expect PASS**; **Step 5: Commit**
+
+```bash
+gofmt -w internal/providers/providers.go internal/investigate/recall.go internal/curator/curator.go internal/curator/curator_test.go
+go vet ./... && go build ./... && golangci-lint run
+git add internal/providers/providers.go internal/investigate/recall.go internal/curator/curator.go internal/curator/curator_test.go
+git commit -m "feat(curator): skip curation of recalled findings (a cache hit is not novel)"
+```
+
+---
+
+## Task 6: Write-side — entries store their originating resource
+
+So future recalls have a `Resource` to agree with. Thread the workload onto the `Investigation`, set it at investigation build time, and write it into the curated entry's frontmatter.
+
+**Files:**
+- Modify: `internal/providers/providers.go` (`Investigation.Resource`)
+- Modify: `internal/investigate/loop.go` (set `inv.Resource` from `req.Workload`)
+- Modify: `internal/curator/draft.go` (`draftKBEntry` sets `KBEntry.Resource`)
+- Test: `internal/curator/draft_test.go` (create or extend)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestDraftKBEntrySetsResource(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "Harbor down", Confidence: 0.9,
+		Resource:   providers.Workload{Namespace: "tooling", Name: "harbor-core"},
+		RootCauses: []providers.Hypothesis{{Summary: "valkey down", Confidence: 0.9}},
+	}
+	e := draftKBEntry(inv)
+	if e.Resource != "tooling/harbor-core" {
+		t.Fatalf("KBEntry.Resource = %q, want tooling/harbor-core", e.Resource)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`Investigation.Resource` undefined; `KBEntry.Resource` empty)
+
+Run: `go test ./internal/curator/ -run TestDraftKBEntrySetsResource`
+
+- [ ] **Step 3: Implement**
+
+In `providers.go`, add to `Investigation` (after `Recalled bool`):
+```go
+	Resource Workload // the originating workload, stored on curated entries for structural recall matching
+```
+
+In `internal/curator/draft.go`, set `Resource` in the returned `KBEntry` (it already has the field). Reuse the canonical form — add a small exported helper to `providers` so both curator and recall share it, OR inline `namespace/name` here:
+```go
+		Resource: resourceString(inv.Resource),
+```
+and add to `draft.go`:
+```go
+func resourceString(w providers.Workload) string {
+	if w.Namespace == "" {
+		return ""
+	}
+	if w.Name == "" {
+		return w.Namespace
+	}
+	return w.Namespace + "/" + w.Name
+}
+```
+(This mirrors `canonicalResource` in `recall.go`; if you prefer DRY, move one copy to `providers` as `Workload.Resource()` and call it from both — a clean small refactor, but two private copies is acceptable since they're in different packages.)
+
+In `internal/investigate/loop.go`, set the resource on the investigation the model produces (the `submit_findings` success path, near `inv.Title = req.Title`):
+```go
+	inv.Resource = req.Workload
+```
+
+- [ ] **Step 4: Frontmatter serialization** — confirm the KBEntry → markdown writer emits `resource:`. Grep for where `KBEntry` becomes file content (`grep -rn "Type:" internal/curator internal/forge` or the function that writes the PR file body). The `catalog.Entry` parser already reads `resource:` frontmatter, so the writer must emit it:
+```yaml
+resource: {{ .Resource }}
+```
+Add the `resource:` line to that template/writer if absent (omit the line when `Resource == ""`). Add/extend a round-trip test if the writer has one.
+
+- [ ] **Step 5: Run + commit**
+
+Run: `go test ./internal/curator/ ./internal/catalog/ && go build ./...`
+```bash
+gofmt -w internal/providers/providers.go internal/curator/draft.go internal/investigate/loop.go internal/curator/draft_test.go
+go vet ./... && golangci-lint run
+git add internal/providers/providers.go internal/curator/draft.go internal/investigate/loop.go internal/curator/draft_test.go
+git commit -m "feat(curator): store the originating resource on curated entries (enables structural recall)"
+```
+
+---
+
+## Task 7: Wire the new config into the Recall constructor + skip-curate verification
+
+**Files:**
+- Modify: `cmd/lore/main.go` (where `&Recall{...}` / `Recall` is built from config)
+- Test: `internal/investigate/loop_test.go` (recall path doesn't curate)
+
+- [ ] **Step 1: Wire config** — locate where `Recall` is constructed in `cmd/lore/main.go` (grep `Recall{` or `MinScore`) and pass the new knobs:
+```go
+	&investigate.Recall{
+		Catalog:              cat,
+		MinScore:             cfg.Catalog.InstantRecall.MinScore,
+		MarginGap:            cfg.Catalog.InstantRecall.MarginGap,
+		SoloFloor:            cfg.Catalog.InstantRecall.SoloFloor,
+		RequireWorkloadMatch: cfg.Catalog.InstantRecall.RequireWorkloadMatch,
+		Metrics:              metrics,
+		Log:                  log,
+	}
+```
+
+- [ ] **Step 2: Loop-level test** — assert the recall short-circuit produces a `Recalled` investigation (so the curator skips it). Reuse the `fakeScored` + a stub model from `loop_test.go`:
+
+```go
+func TestRecallShortCircuitMarksRecalled(t *testing.T) {
+	var delivered providers.Investigation
+	li := &LoopInvestigator{
+		Recall: &Recall{
+			Catalog:  fakeScored{hits: []catalog.ScoredEntry{{Entry: catalog.Entry{Title: "Known", Path: "k.md", Resource: "apps/web"}, Score: 9.0}}},
+			MinScore: 1.5, MarginGap: 1.0, SoloFloor: 4.0,
+		},
+		OnComplete: func(inv providers.Investigation) { delivered = inv },
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	err := li.Investigate(context.Background(), Request{Title: "alert", Workload: providers.Workload{Namespace: "apps", Name: "web"}})
+	if err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if !delivered.Recalled {
+		t.Fatal("a recalled investigation must be flagged Recalled so the curator skips it")
+	}
+}
+```
+
+- [ ] **Step 3: Run — expect PASS** (`go test ./internal/investigate/ -run TestRecallShortCircuit`)
+
+- [ ] **Step 4: Commit**
+
+```bash
+gofmt -w cmd/lore/main.go internal/investigate/loop_test.go
+go vet ./... && go build ./... && golangci-lint run
+git add cmd/lore/main.go internal/investigate/loop_test.go
+git commit -m "feat(recall): wire margin/structural config; verify recall flags Recalled"
+```
+
+---
+
+## Task 8: Helm values + docs
+
+**Files:**
+- Modify: `deploy/helm/runlore/values.yaml`
+
+- [ ] **Step 1: Expose the knobs** under the existing `config.catalog.instant_recall` block:
+```yaml
+    instant_recall:
+      enabled: true
+      min_score: 1.5
+      margin_gap: 1.0
+      solo_floor: 4.0
+      require_workload_match: false
+```
+
+- [ ] **Step 2: Render-check + commit**
+
+Run: `helm template deploy/helm/runlore | grep -A6 instant_recall && helm lint deploy/helm/runlore`
+```bash
+git add deploy/helm/runlore/values.yaml
+git commit -m "feat(helm): expose instant-recall trust knobs"
+```
+
+---
+
+## Final verification
+
+- [ ] `gofmt -l ./internal/... ./cmd/...` → no output
+- [ ] `go vet ./...` → clean
+- [ ] `go build ./...` → clean
+- [ ] `golangci-lint run` → 0 issues
+- [ ] `go test ./...` → all green
+- [ ] Manual sanity: a near-tie or namespace-mismatch alert falls through to a full investigation; an exact, decisive match recalls with a derived (not 0.8) confidence and does **not** open a KB PR.
+
+---
+
+## Notes for the implementer
+
+- **`canonicalResource` (recall.go) and `resourceString` (draft.go) must agree** — same `namespace/name` format — or structural matching silently breaks. If you DRY them into one `providers.Workload.Resource()` method, call it from both.
+- **`Request.Workload` is often namespace-only** for alert-triggered investigations (`FromIncident` sets only `Namespace`). That's why `require_workload_match` defaults `false` and namespace-level agreement is accepted — exact matches mostly come from workload labels when present.
+- **Pre-existing entries have empty `Resource`** → they fall through (fail-safe) until re-curated with Task 6's write-side. This is intended.

--- a/docs/superpowers/specs/2026-06-22-recall-trustworthiness-design.md
+++ b/docs/superpowers/specs/2026-06-22-recall-trustworthiness-design.md
@@ -1,0 +1,106 @@
+# RunLore Recall Trustworthiness — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-22 |
+| **Scope** | Make instant recall (the KB cache) trustworthy enough to short-circuit an investigation: a multi-signal confident-recall gate, *derived* recall confidence, no duplicate-PR on a recall, and a minimal write-side resource field. First slice of the learning-loop critique. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | The "accumulates ≠ learns" learning-loop critique; `internal/investigate/recall.go` + `loop.go`; `internal/catalog`; `internal/curator/draft.go`; the storm PR's recall metrics (`recall_score`, `recall_hits{result}`) which this builds on; phase-2: embeddings behind `catalog.Searcher` |
+
+---
+
+## 1. Why this exists
+
+Instant recall is RunLore's KB cache: a BM25 match on the alert *symptom* short-circuits the whole investigation with **0 LLM calls**, returning a finding with a **hardcoded `Confidence: 0.8`** (`recall.go:59,64`). Per the project critique this is the "deepest flaw": **symptoms are many-to-one with root causes** (CrashLoopBackOff = OOM | bad image | missing secret | failed migration | probe regression), so a lexical symptom match can confidently return the *wrong* root cause for *this* occurrence. The absolute `MinScore` threshold (`recall.go:47`) isn't portable across corpora (a 5-entry seed vs a 500-entry catalog), and the `0.8` is fabricated.
+
+The just-merged storm PR added the **measurement** layer — `recall_score` (histogram of the BM25 score at every decision) and `recall_hits{result=verified|downgraded|rejected}`. This spec adds the **trust** layer on top: a recall short-circuits only when multiple independent signals agree, and its confidence is *derived* from those signals rather than asserted.
+
+This is the **first** of several learning-loop slices. Deliberately out of scope (separate specs): the outcome loop / decay (the "does it actually learn" core), embeddings, the broader confidence-de-overloading on the investigation path, and the full KB write-format (Type/Tags) fix.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **First slice = recall trustworthiness** (not the outcome loop) | Self-contained; builds directly on the recall metrics just shipped; de-risks the outcome loop, which needs trustworthy recall before it can sensibly decay/demote. |
+| D2 | **Multi-signal confident-recall**: similarity margin **AND** structural agreement **AND** verify-survives | A single lexical signal can't separate many-to-one symptom→cause; a structural-agreement gate (resource match) is the lever that can. |
+| D3 | **Similarity = BM25 + a *relative* margin (v1); embeddings deferred** | A margin (gap to the runner-up) is corpus-portable, unlike an absolute `MinScore`. Embeddings add a provider-coverage gap (no Anthropic embeddings endpoint) + a vector index → phase-2 behind `catalog.Searcher`. |
+| D4 | **Recall confidence is *derived*** from match signals + verify (replaces the hardcoded `0.8`); capped < 1.0 | A cache hit must never assert certainty, and the number must be explainable — not an LLM scalar, not a constant. |
+| D5 | **Don't curate recalled findings** | A recall matched an existing entry → not novel; skip `Curate()` on the recall path. |
+| D6 | **Entries store their originating resource** (minimal write-side add) | Structural agreement needs it; the broader Type/Tags write-format fix stays a separate slice. |
+| D7 | **Confidence scope = recall path only** | Keep the spec tight; full-investigation confidence derivation + gate-separation is a follow-up that pairs with the outcome loop. |
+
+## 3. Design
+
+### 3.1 The confident-recall gate (`recall.go`)
+
+**Today:** BM25 search on `Title + " " + Message`; take the top hit; `if score < MinScore` → no recall; else return a finding with `Confidence: 0.8`.
+
+**New:** short-circuit ONLY when all three hold (otherwise fall through to a normal investigation):
+
+1. **Similarity margin** — over the top-2 bleve results:
+   - `score₀ ≥ floor` (a low sanity floor — keeps `MinScore`'s role but lower), AND
+   - `score₀ − score₁ ≥ margin_gap` (or `score₀ / score₁ ≥ margin_ratio`) — the top hit is an *unambiguous* winner. The margin is *relative*, so it's portable across corpus sizes.
+   - If only one hit exists, require `score₀ ≥ solo_floor` (a higher bar — a single weak match is not confident).
+2. **Structural agreement** — the incoming alert's resource (`namespace`, plus `workload` kind/name from labels) matches the matched entry's stored `Resource` (§3.4). An entry with no stored resource (predating §3.4) fails this gate → fall through. (Fail-safe: a missed recall just means a correct full investigation.)
+3. **Verify survives** (unchanged) — the recalled finding still passes the adversarial `verifyFindings` pass already wired in `loop.go`.
+
+Emit `recall_rejections_total{reason="low_margin"|"no_resource_match"}` (a new counter; verify-rejection is already `recall_hits{result=rejected}`) so the thresholds are tunable from live data alongside `recall_score`.
+
+### 3.2 Derived recall confidence (replaces the hardcoded `0.8`)
+
+A transparent, documented function — not an LLM number, not a constant:
+
+```
+base   = lerp(marginStrength)        → [0.55 .. 0.85]   // unambiguous winner higher, marginal lower
+struct = +0.05 if exact (ns+workload) | +0.00 if namespace-only
+verify = ×1.0 verified | ×0.5 downgraded | (rejected ⇒ recall fails — no value returned)
+recallConfidence = clamp(base + struct, 0.50, 0.90) × verify
+```
+
+The exact constants are config knobs (§3.5); the *shape* is the contract. Capped at 0.90 — a cache hit never claims certainty. This value flows wherever the old `0.8` did.
+
+### 3.3 Don't-curate-recalled (`loop.go`)
+
+On the recall short-circuit path, do **not** call `Curate()` (the `OnComplete` → curation hook). A recall is by definition a match against an existing entry; re-curating would draft a near-duplicate PR (the curator's novelty dedup *might* catch it, but skipping is both correct and cheaper). The `recall_hits` metric already records the hit for visibility; per-entry recall bookkeeping (recall counts, last-recalled) is deferred to the outcome-loop spec.
+
+### 3.4 Write-side: entries store their originating resource (`curator/draft.go`, `catalog`)
+
+`draftKBEntry` currently leaves `Resource` empty (`curator/draft.go`). Populate it from the investigation's incident — `{Namespace, Kind, Name}` of the affected workload, which the curator already has (the dedup fingerprint already uses workload namespace/name). Add a structured `Resource` to the catalog `Entry` (front-matter) and include it in the bleve index. This is the **minimal** write-side change that makes §3.1's structural agreement possible; the broader Type/Tags fix (still hardcoded `Incident` / `["runlore","incident"]`) remains a separate "KB write quality" slice.
+
+### 3.5 Config
+
+New knobs (under the catalog/recall config): `margin_gap` (or `margin_ratio`), `floor`, `solo_floor`, and structural strictness (`require_workload_match` — exact `ns+workload` vs namespace-only). Conservative defaults; tune from `recall_score` + `recall_rejections_total`.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| Confident-recall gate (margin + structural + derived confidence) | `internal/investigate/recall.go` |
+| Skip curation on the recall short-circuit | `internal/investigate/loop.go` |
+| `Resource` field on `Entry` + index it | `internal/catalog/` (entry + index) |
+| Populate `Resource` on draft | `internal/curator/draft.go` |
+| `recall_rejections_total{reason}` counter | `internal/telemetry/metrics.go` + `recall.go` |
+| Margin / floor / strictness config | `internal/config/config.go` |
+
+## 5. Trade-offs accepted in v1
+
+- **BM25 margin, not embeddings** — a reworded symptom with low lexical overlap won't recall even if semantically identical. Acceptable: a missed recall is just a (correct) full investigation; embeddings are the phase-2 upgrade behind `catalog.Searcher`.
+- **Structural agreement requires a stored resource** — entries written before §3.4 (empty `Resource`) won't recall until re-curated. Acceptable: fail-safe (fall through to investigate); the corpus heals as new entries are written.
+- **Derived confidence is hand-tuned, not learned** — the outcome loop (later slice) will calibrate it from real resolution data. For now it's an explainable formula, which already beats a fabricated `0.8`.
+
+## 6. Testing
+
+- **`recall_test.go`**: clear winner (large margin) short-circuits; near-tie (small margin) falls through; lone weak hit falls through; structural match required (resource mismatch → fall through); entry with no stored resource → fall through; derived-confidence formula across margin/struct/verify combinations.
+- **`loop_test.go`**: the recall short-circuit path does **not** call `Curate`.
+- **`curator/draft` test**: `Resource` populated from the incident.
+- **Live tuning**: `recall_score` + `recall_rejections_total` after seeding the catalog.
+
+## 7. Out of scope (other learning-loop slices)
+
+- The **outcome loop** / decay / demotion + per-entry recall bookkeeping — the "learns, not accumulates" core. The next slice.
+- **Embeddings** — hybrid BM25+embeddings behind `catalog.Searcher`; the provider-coverage problem (no Anthropic endpoint) is solved there.
+- **Full investigation-confidence derivation + gate-separation** (the broader half of critique fix #5) — pairs naturally with the outcome loop.
+- **KB write-format Type/Tags fix** — this spec adds only the `Resource` field needed for structural agreement.
+
+This is a focused, shippable first slice: it makes the cache *defensible* and *measured* without yet claiming it *learns*.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,8 +114,11 @@ type Catalog struct {
 // high-confidence match for the symptom. Off by default; MinScore is the BM25
 // relevance floor (tune for your catalog).
 type InstantRecall struct {
-	Enabled  bool    `yaml:"enabled"`
-	MinScore float64 `yaml:"min_score"`
+	Enabled              bool    `yaml:"enabled"`
+	MinScore             float64 `yaml:"min_score"`              // similarity floor for the top hit
+	MarginGap            float64 `yaml:"margin_gap"`             // top hit must beat the runner-up by at least this
+	SoloFloor            float64 `yaml:"solo_floor"`             // confident bar when there is only one hit (higher than MinScore)
+	RequireWorkloadMatch bool    `yaml:"require_workload_match"` // true = exact namespace+workload; false = namespace-level agreement is enough
 }
 
 // CatalogGit configures periodic Git sync of the catalog into Dir.

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -37,6 +37,17 @@ func TestApplyDefaultsRateLimitWindow(t *testing.T) {
 	}
 }
 
+func TestApplyDefaultsInstantRecall(t *testing.T) {
+	// enabled with no tuning → margin and solo gates must default to active values.
+	var c Config
+	c.Catalog.InstantRecall.Enabled = true
+	applyDefaults(&c)
+	ir := c.Catalog.InstantRecall
+	if ir.MinScore != 1.0 || ir.MarginGap != 1.0 || ir.SoloFloor != 4.0 {
+		t.Fatalf("instant-recall defaults not applied: %+v", ir)
+	}
+}
+
 func TestApplyDefaultsDoesNotOverride(t *testing.T) {
 	// Explicit values must not be overwritten.
 	var c Config

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,3 +61,23 @@ func TestDurationUnmarshal(t *testing.T) {
 func yamlScalar(s string) *yaml.Node {
 	return &yaml.Node{Kind: yaml.ScalarNode, Value: s}
 }
+
+func TestInstantRecallTrustConfig(t *testing.T) {
+	const y = `
+catalog:
+  instant_recall:
+    enabled: true
+    min_score: 1.5
+    margin_gap: 1.0
+    solo_floor: 4.0
+    require_workload_match: false
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ir := c.Catalog.InstantRecall
+	if !ir.Enabled || ir.MinScore != 1.5 || ir.MarginGap != 1.0 || ir.SoloFloor != 4.0 || ir.RequireWorkloadMatch {
+		t.Fatalf("instant_recall not parsed: %+v", ir)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -56,4 +56,19 @@ func applyDefaults(c *Config) {
 	if c.Investigation.RateLimit.MaxPerWindow > 0 && c.Investigation.RateLimit.Window == 0 {
 		c.Investigation.RateLimit.Window = Duration(time.Hour)
 	}
+	// Instant-recall trust defaults: when enabled without explicit tuning, keep the
+	// margin and solo gates active. A zero margin_gap/solo_floor would degrade recall
+	// to a bare similarity threshold — the exact brittleness this feature removes.
+	if c.Catalog.InstantRecall.Enabled {
+		ir := &c.Catalog.InstantRecall
+		if ir.MinScore == 0 {
+			ir.MinScore = 1.0
+		}
+		if ir.MarginGap == 0 {
+			ir.MarginGap = 1.0
+		}
+		if ir.SoloFloor == 0 {
+			ir.SoloFloor = 4.0
+		}
+	}
 }

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -29,6 +29,13 @@ type Curator struct {
 // Curate applies the three-step gate. It returns the created PR ref, or an empty
 // ref when the finding was coalesced (duplicate) or dropped (below the bar).
 func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (providers.Ref, error) {
+	// A recall is a match against an existing entry — not novel; never re-curate it
+	// (chat delivery still happens upstream). Avoids drafting near-duplicate PRs.
+	if inv.Recalled {
+		c.Log.Info("skipping curation of a recalled finding (cache hit, not novel)", "title", inv.Title)
+		return providers.Ref{}, nil
+	}
+
 	// 1. dedup — catalog, then open PRs
 	if dup, hit, err := (Novelty{Catalog: c.Catalog, DupScore: c.DupScore}).IsDuplicate(ctx, inv); err != nil {
 		c.Log.Warn("dedup: catalog search failed", "err", err)

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -115,3 +115,16 @@ func TestCurateLowQualityDropsNoArtifact(t *testing.T) {
 		t.Fatalf("low-quality finding must produce no repo artifact, got pr=%+v comment=%v ref=%s", f.openedPR, f.commented, ref.URL)
 	}
 }
+
+func TestCurateSkipsRecalled(t *testing.T) {
+	f := &fakeForge{}
+	inv := goodFinding() // high quality: would normally open a PR
+	inv.Recalled = true  // but it's a cache hit, not novel
+	ref, err := newCurator(f, fakeScored{}).Curate(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR != nil || ref.URL != "" {
+		t.Fatalf("a recalled finding must not be curated, got pr=%+v ref=%s", f.openedPR, ref.URL)
+	}
+}

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -61,9 +61,22 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 		Type:        "Incident",
 		Title:       inv.Title,
 		Description: firstLine(inv),
+		Resource:    resourceString(inv.Resource),
 		Tags:        []string{"runlore", "incident"},
 		Body:        b.String(),
 	}
+}
+
+// resourceString renders a workload as "namespace/name" (or just "namespace" when
+// the name is unknown), matching the recall side's structural-agreement format.
+func resourceString(w providers.Workload) string {
+	if w.Namespace == "" {
+		return ""
+	}
+	if w.Name == "" {
+		return w.Namespace
+	}
+	return w.Namespace + "/" + w.Name
 }
 
 func firstLine(inv providers.Investigation) string {

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -33,3 +33,23 @@ func TestDraftKBEntryHasDecisionCardAndSections(t *testing.T) {
 		}
 	}
 }
+
+func TestDraftKBEntrySetsResource(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "Harbor down", Confidence: 0.9,
+		Resource:   providers.Workload{Namespace: "tooling", Name: "harbor-core"},
+		RootCauses: []providers.Hypothesis{{Summary: "valkey down", Confidence: 0.9}},
+	}
+	if e := draftKBEntry(inv); e.Resource != "tooling/harbor-core" {
+		t.Fatalf("KBEntry.Resource = %q, want tooling/harbor-core", e.Resource)
+	}
+}
+
+func TestResourceStringNamespaceOnly(t *testing.T) {
+	if got := resourceString(providers.Workload{Namespace: "apps"}); got != "apps" {
+		t.Fatalf("namespace-only resource = %q, want apps", got)
+	}
+	if got := resourceString(providers.Workload{}); got != "" {
+		t.Fatalf("empty workload resource = %q, want empty", got)
+	}
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -279,6 +279,7 @@ type kbFrontmatter struct {
 	Type        string   `yaml:"type"`
 	Title       string   `yaml:"title"`
 	Description string   `yaml:"description"`
+	Resource    string   `yaml:"resource,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
 }
 
@@ -295,7 +296,7 @@ func prBody(e providers.KBEntry) string {
 }
 
 func renderEntry(e providers.KBEntry) string {
-	fm, _ := yaml.Marshal(kbFrontmatter{Type: e.Type, Title: e.Title, Description: e.Description, Tags: e.Tags})
+	fm, _ := yaml.Marshal(kbFrontmatter{Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource, Tags: e.Tags})
 	var b strings.Builder
 	b.WriteString("---\n")
 	b.Write(fm)

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -198,6 +198,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				if inv.Title == "" {
 					inv.Title = req.Title // default to the triggering incident/failure
 				}
+				inv.Resource = req.Workload // record the originating workload for structural recall
 				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 				if li.Metrics != nil {
 					li.Metrics.InvestigationTokens.Record(ctx, int64(estimateTokens(sys, messages)))

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -108,10 +108,10 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	// Instant recall is disabled under auto-execution: a poisoned catalog entry must
 	// not short-circuit a real investigation straight into an auto-executed action.
 	if li.Recall != nil && (li.Actions == nil || !li.Actions.IsAuto()) {
-		if entry, score := li.Recall.lookup(ctx, req); entry != nil {
+		if entry, conf := li.Recall.lookup(ctx, req); entry != nil {
 			li.Log.Info("instant recall (catalog hit; skipping the loop)",
-				"title", req.Title, "entry", entry.Path, "score", fmt.Sprintf("%.2f", score))
-			rec := recalledInvestigation(req, *entry)
+				"title", req.Title, "entry", entry.Path, "confidence", fmt.Sprintf("%.2f", conf))
+			rec := recalledInvestigation(req, *entry, conf)
 			initialConfidence := rec.Confidence
 			if li.Verify {
 				// Catalog content is untrusted: verify a recalled finding too, so a

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -42,6 +42,9 @@ func TestInstantRecallHit(t *testing.T) {
 	if got == nil || len(got.RootCauses) != 1 || !strings.Contains(got.RootCauses[0].Summary, "Known incident") {
 		t.Fatalf("unexpected recalled investigation: %+v", got)
 	}
+	if !got.Recalled {
+		t.Fatal("a recalled investigation must be flagged Recalled so the curator skips it")
+	}
 }
 
 func TestInstantRecallBelowThreshold(t *testing.T) {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -30,10 +30,10 @@ func TestInstantRecallHit(t *testing.T) {
 		Model: model,
 		Log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Recall: &Recall{MinScore: 2.0, Catalog: fakeScored{hits: []catalog.ScoredEntry{
-			{Entry: catalog.Entry{Title: "Known incident", Description: "chart bump", Path: "known.md"}, Score: 5.0}}}},
+			{Entry: catalog.Entry{Title: "Known incident", Description: "chart bump", Path: "known.md", Resource: "tooling/harbor"}, Score: 5.0}}}},
 		OnComplete: func(inv providers.Investigation) { got = &inv },
 	}
-	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure"}); err != nil {
+	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
 	if model.i != 0 {

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -9,59 +9,157 @@ import (
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Recall short-circuits an investigation when the knowledge catalog already has a
-// high-confidence answer for the symptom — skipping the slow, paid ReAct loop. It
-// is opt-in (off by default) with a tunable MinScore, since BM25 scores are
-// corpus-dependent and a stale hit shouldn't silently replace an investigation.
+// trustworthy answer for the symptom — skipping the slow, paid ReAct loop. A recall
+// must clear three gates: a BM25 margin over the runner-up (corpus-portable, unlike
+// an absolute MinScore), structural agreement on the affected resource, and (in the
+// loop) the adversarial verify pass. Confidence is derived from those signals, never
+// asserted — BM25 scores are corpus-dependent and a stale hit must not silently
+// replace an investigation.
 type Recall struct {
-	Catalog  catalog.ScoredSearcher
-	MinScore float64
-	Metrics  *telemetry.Metrics // optional; nil-safe — instruments are no-op when provider is unset
-	Log      *slog.Logger       // optional; nil-safe — log line omitted when unset
+	Catalog              catalog.ScoredSearcher
+	MinScore             float64 // similarity floor for the top hit
+	MarginGap            float64 // top hit must beat the runner-up by at least this
+	SoloFloor            float64 // confident bar when there is only one hit
+	RequireWorkloadMatch bool    // true = exact namespace+workload; false = namespace-level agreement is enough
+
+	Metrics *telemetry.Metrics // optional; nil-safe — instruments are no-op when provider is unset
+	Log     *slog.Logger       // optional; nil-safe — log line omitted when unset
 }
 
-// lookup returns the best catalog entry for the request and its score if it meets
-// the threshold, else (nil, 0). The BM25 score is always recorded in the histogram
-// when hits exist, even when below threshold, to allow threshold tuning.
+// lookup returns the matched entry and a DERIVED confidence when a recall is
+// trustworthy enough to short-circuit, else (nil, 0). The BM25 score is always
+// recorded (even on rejection) so the thresholds can be tuned from live data.
 func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float64) {
 	if r == nil || r.Catalog == nil {
 		return nil, 0
 	}
 	// Query the symptom (title + message); severity/reason is noise for matching.
-	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), 1)
+	// k=2 so the top hit can be required to be an unambiguous winner.
+	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), 2)
 	if err != nil || len(hits) == 0 {
 		return nil, 0
 	}
 	score := hits[0].Score
-	// Always record score at the decision point — needed to tune MinScore threshold.
 	if r.Metrics != nil {
 		r.Metrics.RecallScore.Record(ctx, score)
 	}
-	if r.Log != nil {
-		r.Log.Info("kb recall decision",
-			"alert", req.Title, "entry_id", hits[0].Entry.Path, "score", score,
-			"min_score", r.MinScore, "hit", score >= r.MinScore)
+
+	// Gate 1 — similarity margin. A relative margin over the runner-up is portable
+	// across corpus sizes; a lone hit needs a higher solo floor.
+	margin := score
+	confident := score >= r.SoloFloor && score >= r.MinScore // a lone hit must clear both floors
+	if len(hits) > 1 {
+		margin = score - hits[1].Score
+		confident = score >= r.MinScore && margin >= r.MarginGap
 	}
-	if score < r.MinScore {
+	if !confident {
+		r.reject(ctx, "low_margin")
 		return nil, 0
 	}
+
+	// Gate 2 — structural agreement: the alert's workload must match the entry's
+	// stored resource. This attacks "symptoms are many-to-one with root causes".
 	e := hits[0].Entry
-	return &e, score
+	strength := resourceAgrees(req.Workload, e.Resource, r.RequireWorkloadMatch)
+	if strength == matchNone {
+		r.reject(ctx, "no_resource_match")
+		return nil, 0
+	}
+
+	conf := deriveRecallConfidence(score, margin, strength)
+	if r.Log != nil {
+		r.Log.Info("instant recall decision",
+			"alert", req.Title, "entry_id", e.Path, "score", score, "margin", margin, "confidence", conf)
+	}
+	return &e, conf
 }
 
-// recalledInvestigation builds findings directly from a catalog entry. It is
-// explicit that this is a recalled match, not a fresh investigation.
-func recalledInvestigation(req Request, e catalog.Entry) providers.Investigation {
+// reject records a rejection reason (nil-safe).
+func (r *Recall) reject(ctx context.Context, reason string) {
+	if r.Metrics != nil {
+		r.Metrics.RecallRejections.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", reason)))
+	}
+}
+
+type matchStrength int
+
+const (
+	matchNone matchStrength = iota
+	matchNamespace
+	matchExact
+)
+
+// canonicalResource renders a workload as "namespace/name", or just "namespace"
+// when the name is unknown (common for alert-triggered investigations).
+func canonicalResource(w providers.Workload) string {
+	if w.Namespace == "" {
+		return ""
+	}
+	if w.Name == "" {
+		return w.Namespace
+	}
+	return w.Namespace + "/" + w.Name
+}
+
+// resourceAgrees reports how strongly the alert's workload agrees with an entry's
+// stored resource. requireWorkload demands an exact namespace+name match.
+func resourceAgrees(reqW providers.Workload, entryResource string, requireWorkload bool) matchStrength {
+	if entryResource == "" || reqW.Namespace == "" {
+		return matchNone
+	}
+	if canonicalResource(reqW) == entryResource {
+		return matchExact
+	}
+	if requireWorkload {
+		return matchNone
+	}
+	if entryResource == reqW.Namespace || strings.HasPrefix(entryResource, reqW.Namespace+"/") {
+		return matchNamespace
+	}
+	return matchNone
+}
+
+func clampF(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// deriveRecallConfidence turns the match signals into an explainable confidence,
+// capped below 1.0 — a cache hit never asserts certainty. (Constants are the shape;
+// tune via recall_score / recall_rejections.)
+func deriveRecallConfidence(score, margin float64, strength matchStrength) float64 {
+	base := 0.55
+	if score > 0 {
+		base = 0.55 + 0.30*clampF(margin/score, 0, 1) // decisive winner → up to 0.85
+	}
+	if strength == matchExact {
+		base += 0.05
+	}
+	return clampF(base, 0.50, 0.90)
+}
+
+// recalledInvestigation builds findings directly from a catalog entry, using the
+// derived recall confidence. It is explicit that this is a recalled match, not a
+// fresh investigation.
+func recalledInvestigation(req Request, e catalog.Entry, confidence float64) providers.Investigation {
 	rc := providers.Hypothesis{
 		Summary:    e.Title + " — " + e.Description,
-		Confidence: 0.8,
+		Confidence: confidence,
 		Evidence:   []string{fmt.Sprintf("instant recall: matched knowledge-base entry %q", e.Path)},
 	}
 	return providers.Investigation{
 		Title:      req.Title,
-		Confidence: 0.8,
+		Confidence: confidence,
 		RootCauses: []providers.Hypothesis{rc},
 		Unresolved: []string{"recalled from the catalog without a fresh investigation — confirm it still applies"},
 	}

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -162,5 +162,6 @@ func recalledInvestigation(req Request, e catalog.Entry, confidence float64) pro
 		Confidence: confidence,
 		RootCauses: []providers.Hypothesis{rc},
 		Unresolved: []string{"recalled from the catalog without a fresh investigation — confirm it still applies"},
+		Recalled:   true,
 	}
 }

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -8,28 +8,39 @@ import (
 	"testing"
 
 	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
-// TestRecallScoreRecordedNilSafe verifies that a Recall with nil Metrics does not
-// panic when a hit is found and scored — the nil check in lookup must guard it.
+// recallWith builds a Recall over fixed hits with sensible trust thresholds.
+func recallWith(hits []catalog.ScoredEntry) *Recall {
+	return &Recall{Catalog: fakeScored{hits: hits}, MinScore: 1.5, MarginGap: 1.0, SoloFloor: 4.0}
+}
+
+// okReq is a request whose workload matches the "apps/web" test entries.
+func okReq() Request {
+	return Request{Title: "pod crashloop", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+}
+
+// TestRecallScoreRecordedNilSafe verifies a Recall with nil Metrics does not panic
+// when a hit is found and scored.
 func TestRecallScoreRecordedNilSafe(t *testing.T) {
 	r := &Recall{
-		Catalog:  fakeScored{hits: []catalog.ScoredEntry{{Entry: catalog.Entry{Title: "x", Path: "x.md"}, Score: 5.0}}},
-		MinScore: 2.0,
-		Metrics:  nil, // no-op: must not panic
+		Catalog:  fakeScored{hits: []catalog.ScoredEntry{{Entry: catalog.Entry{Title: "x", Path: "x.md", Resource: "ns"}, Score: 5.0}}},
+		MinScore: 2.0, SoloFloor: 2.0,
+		Metrics: nil, // no-op: must not panic
 	}
-	entry, score := r.lookup(context.Background(), Request{Title: "incident"})
+	entry, conf := r.lookup(context.Background(), Request{Title: "incident", Workload: providers.Workload{Namespace: "ns"}})
 	if entry == nil {
-		t.Fatal("expected a hit above threshold")
+		t.Fatal("expected a confident hit")
 	}
-	if score != 5.0 {
-		t.Fatalf("score: got %v, want 5.0", score)
+	if conf <= 0 || conf > 0.9 {
+		t.Fatalf("derived confidence out of range: %v", conf)
 	}
 }
 
-// TestRecallScoreRecordedRealProvider verifies that a hit records the BM25 score
-// in the OTel histogram and increments RecallHits via the Prometheus exposition.
+// TestRecallScoreRecordedRealProvider verifies a hit records the BM25 score in the
+// OTel histogram, scraped via the Prometheus exposition.
 func TestRecallScoreRecordedRealProvider(t *testing.T) {
 	h, shutdown, err := telemetry.Setup(context.Background())
 	if err != nil {
@@ -39,26 +50,110 @@ func TestRecallScoreRecordedRealProvider(t *testing.T) {
 
 	m := telemetry.NewMetrics() // instruments bound to the real provider
 	r := &Recall{
-		Catalog:  fakeScored{hits: []catalog.ScoredEntry{{Entry: catalog.Entry{Title: "Known", Path: "known.md"}, Score: 7.5}}},
-		MinScore: 2.0,
-		Metrics:  m,
+		Catalog:  fakeScored{hits: []catalog.ScoredEntry{{Entry: catalog.Entry{Title: "Known", Path: "known.md", Resource: "ns"}, Score: 7.5}}},
+		MinScore: 2.0, SoloFloor: 2.0,
+		Metrics: m,
 	}
-
-	// Trigger a lookup that passes the threshold — score must be recorded.
-	entry, _ := r.lookup(context.Background(), Request{Title: "HarborProbeFailure"})
+	entry, _ := r.lookup(context.Background(), Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "ns"}})
 	if entry == nil {
-		t.Fatal("expected a hit above threshold")
+		t.Fatal("expected a confident hit")
 	}
 
-	// Scrape the /metrics exposition and confirm the score series appeared.
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("metrics status: %d", rec.Code)
 	}
-	body := rec.Body.String()
-	if !strings.Contains(body, "runlore_recall_score") {
-		t.Fatalf("runlore_recall_score not found in metrics output:\n%s", body)
+	if !strings.Contains(rec.Body.String(), "runlore_recall_score") {
+		t.Fatalf("runlore_recall_score not found in metrics output:\n%s", rec.Body.String())
+	}
+}
+
+func TestLookupMarginClearWinner(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "BadImage", Path: "b.md"}, Score: 2.0},
+	})
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("clear winner (gap 4.0 >= 1.0) should recall")
+	}
+}
+
+func TestLookupMarginNearTieFallsThrough(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "BadImage", Path: "b.md"}, Score: 5.5},
+	})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("near-tie (gap 0.5 < 1.0) must fall through")
+	}
+}
+
+func TestLookupLoneWeakHitFallsThrough(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web"}, Score: 3.0}, // below SoloFloor 4.0
+	})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("a lone hit below solo_floor must fall through")
+	}
+}
+
+func structuralRecall(entryResource string, requireWorkload bool) *Recall {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: entryResource}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "X", Path: "b.md"}, Score: 2.0},
+	})
+	r.RequireWorkloadMatch = requireWorkload
+	return r
+}
+
+func TestLookupStructuralMatch(t *testing.T) {
+	r := structuralRecall("apps/web", false)
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if e, _ := r.lookup(context.Background(), req); e == nil {
+		t.Fatal("exact resource match should recall")
+	}
+}
+
+func TestLookupStructuralNamespaceOnly(t *testing.T) {
+	r := structuralRecall("apps/web", false)
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps"}} // name unknown from the alert
+	if e, _ := r.lookup(context.Background(), req); e == nil {
+		t.Fatal("namespace agreement should recall when require_workload_match=false")
+	}
+}
+
+func TestLookupStructuralMismatchFallsThrough(t *testing.T) {
+	r := structuralRecall("apps/web", false)
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "kube-system"}}
+	if e, _ := r.lookup(context.Background(), req); e != nil {
+		t.Fatal("different namespace must fall through")
+	}
+}
+
+func TestLookupNoStoredResourceFallsThrough(t *testing.T) {
+	r := structuralRecall("", false) // entry predates the write-side change
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps"}}
+	if e, _ := r.lookup(context.Background(), req); e != nil {
+		t.Fatal("entry with no stored resource must fall through (fail-safe)")
+	}
+}
+
+func TestDeriveRecallConfidence(t *testing.T) {
+	hi := deriveRecallConfidence(8.0, 6.0, matchExact)
+	if hi <= 0.8 || hi > 0.9 {
+		t.Fatalf("decisive+exact should be (0.8, 0.9], got %v", hi)
+	}
+	lo := deriveRecallConfidence(2.0, 0.4, matchNamespace)
+	if lo >= hi || lo < 0.5 {
+		t.Fatalf("marginal+namespace should be lower and >= 0.5, got %v (hi=%v)", lo, hi)
+	}
+}
+
+func TestRecalledInvestigationUsesDerivedConfidence(t *testing.T) {
+	inv := recalledInvestigation(Request{Title: "x"}, catalog.Entry{Title: "T", Description: "D", Path: "p.md"}, 0.72)
+	if inv.Confidence != 0.72 || inv.RootCauses[0].Confidence != 0.72 {
+		t.Fatalf("recalledInvestigation must use the derived confidence, got %+v", inv)
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -339,6 +339,7 @@ type Investigation struct {
 	Unresolved []string // honest: what the agent could not determine
 	Confidence float64
 	Recalled   bool     // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
+	Resource   Workload // the originating workload; stored on curated entries for structural recall matching
 	Actions    []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
 	CuratedURL string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -338,6 +338,7 @@ type Investigation struct {
 	Changes    []Change
 	Unresolved []string // honest: what the agent could not determine
 	Confidence float64
+	Recalled   bool     // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
 	Actions    []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
 	CuratedURL string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -22,6 +22,7 @@ type Metrics struct {
 	ToolOutputTruncatedBytes metric.Int64Counter
 	RecallHits               metric.Int64Counter // KB cache hits, labelled by verify result
 	RecallTokensSaved        metric.Int64Counter // estimated tokens saved by a recall short-circuit
+	RecallRejections         metric.Int64Counter // recalls rejected before short-circuit (label: reason)
 	CoalesceBatchSize        metric.Int64Histogram
 	InvestigationTokens      metric.Int64Histogram
 	RecallScore              metric.Float64Histogram // BM25 score at the recall decision (tunes min_score)
@@ -52,6 +53,7 @@ func NewMetrics() *Metrics {
 		ToolOutputTruncatedBytes: ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
 		RecallHits:               ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
 		RecallTokensSaved:        ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
+		RecallRejections:         ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),
 		CoalesceBatchSize:        hist("coalesce_batch_size", "incidents per flushed batch"),
 		InvestigationTokens:      hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),
 		RecallScore:              histF("recall_score", "BM25 score at the recall decision point"),


### PR DESCRIPTION
## Summary

First slice of the learning-loop redesign (the *"accumulates ≠ learns"* critique). Makes RunLore's **instant recall** — the KB cache that short-circuits an investigation — *trustworthy*, replacing BM25-on-symptom + a hardcoded `0.8` confidence.

- Design: `docs/superpowers/specs/2026-06-22-recall-trustworthiness-design.md`
- Plan: `docs/superpowers/plans/2026-06-22-recall-trustworthiness.md`

## What changed

- **Confident-recall gate** (`internal/investigate/recall.go`) — a recall short-circuits only when ALL hold: a BM25 **relative margin** over the runner-up (corpus-portable, unlike an absolute `min_score`; a lone hit must clear both `solo_floor` and `min_score`), **structural agreement** (the alert's namespace/workload matches the entry's stored resource), and the existing adversarial **verify** pass. Any miss → a normal investigation.
- **Derived confidence** — replaces the hardcoded `0.8` with an explainable formula over the match signals (margin strength + structural match + verify), capped < 1.0. A cache hit never asserts certainty.
- **Don't curate recalled findings** — a recall matched an existing entry → not novel; the curator skips it (chat delivery unaffected), so a cache hit can't spawn a near-duplicate PR.
- **Write-side** — curated entries now store their originating resource (`namespace/name` in frontmatter), so recall's structural gate heals over time as new entries are written.
- **Observability** — `recall_rejections_total{reason="low_margin"|"no_resource_match"}` makes the thresholds tunable from live data, alongside the existing `recall_score` histogram.
- **Config** — `instant_recall.{margin_gap, solo_floor, require_workload_match}` with safe defaults applied when recall is enabled.

## Out of scope (future learning-loop slices)

Embeddings (hybrid BM25+embeddings behind `catalog.Searcher`); the outcome loop / decay (the "actually learns" core); the broader investigation-confidence de-overloading; the full Type/Tags write-format fix (this PR adds only the resource field).

## Testing

- Unit: margin gate (clear winner / near-tie / lone weak), structural agreement (exact / namespace-only / mismatch / no-stored-resource), derived-confidence formula, skip-curate-on-recall, resource population, config defaults.
- `go build`, `go vet`, **golangci-lint 0 issues**, **`go test ./...` all pass**, **`-race` clean**.
- e2e: `hack/e2e-k3d.sh` green on a real k3d cluster (full chain).

Built spec-first; depends on the recall metrics from #67 (now merged), rebased onto `main`.
