### PR TITLE
feat: outcome capture — record whether investigated incidents resolve (learning-loop A1)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -1062,18 +1062,22 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 			// Record the outcome "open" first: this investigation happened for an
 			// incident, with the answer we used (recall vs fresh). A matching
 			// resolved-alert webhook later stamps whether it actually resolved.
-			if err := ledger.Open(outcome.Event{
-				Fingerprint: found.Fingerprint,
-				Kind:        outcomeKind(found.Recalled),
-				Entry:       found.RecalledEntry,
-				Title:       found.Title,
-				Resource:    resourceStr(found.Resource),
-				At:          time.Now(),
-			}); err != nil {
-				log.Warn("outcome ledger open failed", "fingerprint", found.Fingerprint, "err", err)
-			}
-			if metrics != nil {
-				metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", outcomeKind(found.Recalled))))
+			// Skip sources without an alert fingerprint (GitOps watch, reinvestigate
+			// poller) — they could never be matched by a resolved-alert webhook.
+			if found.Fingerprint != "" {
+				if err := ledger.Open(outcome.Event{
+					Fingerprint: found.Fingerprint,
+					Kind:        outcomeKind(found.Recalled),
+					Entry:       found.RecalledEntry,
+					Title:       found.Title,
+					Resource:    resourceStr(found.Resource),
+					At:          time.Now(),
+				}); err != nil {
+					log.Warn("outcome ledger open failed", "fingerprint", found.Fingerprint, "err", err)
+				}
+				if metrics != nil {
+					metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", outcomeKind(found.Recalled))))
+				}
 			}
 			// Post-investigation action handling, by mode. The loop has already
 			// filtered found.Actions to the envelope (rung 1). auto and approvals are

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -27,6 +27,8 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -52,6 +54,7 @@ import (
 	openai "github.com/Smana/runlore/internal/model/openai"
 	"github.com/Smana/runlore/internal/network/hubble"
 	"github.com/Smana/runlore/internal/notify"
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	awscloud "github.com/Smana/runlore/internal/providers/cloud/aws"
 	"github.com/Smana/runlore/internal/providers/cluster"
@@ -207,7 +210,15 @@ func runServe(args []string) error {
 	}
 	metrics := telemetry.NewMetrics() // bound to global provider (no-op when disabled)
 
-	inv := buildInvestigator(ctx, cfg, gitops, approvals, auto, metrics, log)
+	ledger, err := outcome.New(cfg.Outcome.LedgerPath)
+	if err != nil {
+		return fmt.Errorf("outcome ledger: %w", err)
+	}
+	if cfg.Outcome.LedgerPath != "" {
+		log.Info("outcome ledger enabled", "path", cfg.Outcome.LedgerPath)
+	}
+
+	inv := buildInvestigator(ctx, cfg, gitops, approvals, auto, metrics, ledger, log)
 	queue := investigate.NewQueue(inv, log)
 	var rlStarts *ratelimit.Window
 	if rl := cfg.Investigation.RateLimit; rl.MaxPerWindow > 0 {
@@ -281,6 +292,7 @@ func runServe(args []string) error {
 	}
 	srv := server.New(cfg, queue, leader.Load, acts, metricsHandler, log)
 	srv.SetMetrics(metrics) // ingress counters emit regardless of coalescing
+	srv.SetOutcomeLedger(ledger)
 	if cz != nil {
 		srv.SetCoalescer(cz)
 		go cz.Run(ctx, cfg.Investigation.Coalesce.Debounce.Std()/2)
@@ -996,9 +1008,28 @@ func runInvestigate(args []string) error {
 	return nil
 }
 
+// outcomeKind labels an outcome-ledger open as a recall (cache hit) or a fresh finding.
+func outcomeKind(recalled bool) string {
+	if recalled {
+		return "recall"
+	}
+	return "fresh"
+}
+
+// resourceStr renders a workload as "namespace/name" for the outcome ledger.
+func resourceStr(w providers.Workload) string {
+	if w.Namespace == "" {
+		return ""
+	}
+	if w.Name == "" {
+		return w.Namespace
+	}
+	return w.Namespace + "/" + w.Name
+}
+
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
-func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, auto *action.Auto, metrics *telemetry.Metrics, log *slog.Logger) investigate.Investigator {
+func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, auto *action.Auto, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) investigate.Investigator {
 	if !modelConfigured(cfg) {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}
@@ -1028,6 +1059,22 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
 		OnComplete: func(found providers.Investigation) {
+			// Record the outcome "open" first: this investigation happened for an
+			// incident, with the answer we used (recall vs fresh). A matching
+			// resolved-alert webhook later stamps whether it actually resolved.
+			if err := ledger.Open(outcome.Event{
+				Fingerprint: found.Fingerprint,
+				Kind:        outcomeKind(found.Recalled),
+				Entry:       found.RecalledEntry,
+				Title:       found.Title,
+				Resource:    resourceStr(found.Resource),
+				At:          time.Now(),
+			}); err != nil {
+				log.Warn("outcome ledger open failed", "fingerprint", found.Fingerprint, "err", err)
+			}
+			if metrics != nil {
+				metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", outcomeKind(found.Recalled))))
+			}
 			// Post-investigation action handling, by mode. The loop has already
 			// filtered found.Actions to the envelope (rung 1). auto and approvals are
 			// mutually exclusive (one is nil unless that mode is configured).

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -1016,17 +1016,6 @@ func outcomeKind(recalled bool) string {
 	return "fresh"
 }
 
-// resourceStr renders a workload as "namespace/name" for the outcome ledger.
-func resourceStr(w providers.Workload) string {
-	if w.Namespace == "" {
-		return ""
-	}
-	if w.Name == "" {
-		return w.Namespace
-	}
-	return w.Namespace + "/" + w.Name
-}
-
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator.
 func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, auto *action.Auto, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) investigate.Investigator {
@@ -1065,18 +1054,19 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 			// Skip sources without an alert fingerprint (GitOps watch, reinvestigate
 			// poller) — they could never be matched by a resolved-alert webhook.
 			if found.Fingerprint != "" {
+				kind := outcomeKind(found.Recalled)
 				if err := ledger.Open(outcome.Event{
 					Fingerprint: found.Fingerprint,
-					Kind:        outcomeKind(found.Recalled),
+					Kind:        kind,
 					Entry:       found.RecalledEntry,
 					Title:       found.Title,
-					Resource:    resourceStr(found.Resource),
+					Resource:    found.Resource.Ref(),
 					At:          time.Now(),
 				}); err != nil {
 					log.Warn("outcome ledger open failed", "fingerprint", found.Fingerprint, "err", err)
 				}
 				if metrics != nil {
-					metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", outcomeKind(found.Recalled))))
+					metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", kind)))
 				}
 			}
 			// Post-investigation action handling, by mode. The loop has already

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -66,6 +66,8 @@ config:
   #     margin_gap: 1.0                # top hit must beat the runner-up by this (corpus-portable; not an absolute floor)
   #     solo_floor: 4.0                # confident bar when there is only one hit
   #     require_workload_match: false  # true = exact namespace+workload; false = namespace-level agreement is enough
+  # outcome:
+  #   ledger_path: /var/lib/runlore/catalog/outcomes.jsonl  # learning-loop outcome ledger; point at the writable git-sync mirror PV
   # notify:
   #   slack: { webhook_url_env: SLACK_WEBHOOK_URL }
   #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }

--- a/docs/superpowers/plans/2026-06-23-outcome-capture.md
+++ b/docs/superpowers/plans/2026-06-23-outcome-capture.md
@@ -1,0 +1,600 @@
+# Outcome Capture (Learning-Loop A1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record whether an investigated incident actually resolved, attributed to the answer used (recall vs fresh), via the Alertmanager resolved-webhook signal and a persistent append-only ledger — making learning measurable.
+
+**Architecture:** A new `internal/outcome` package owns a JSONL event ledger (append-only file + an in-memory open-index replayed on startup). `ParseAlertmanager` is extended to surface `resolved` alerts; `handleAlertmanager` routes them to `ledger.Resolve`. At `OnComplete`, an `open` event is recorded with the AM fingerprint + the recalled-entry path. Four OTel counters/histograms make it observable.
+
+**Tech Stack:** Go, `encoding/json` + `bufio` (JSONL), OpenTelemetry metrics, plain `testing`. Module `github.com/Smana/runlore`.
+
+**Design spec:** `docs/superpowers/specs/2026-06-23-outcome-capture-design.md`
+
+## Global Constraints
+
+- TDD red→green per task; plain `testing`/`t.Fatalf` (no testify).
+- Before each commit: `cd /home/smana/Sources/runlore && gofmt -w <files> && go vet ./... && go build ./... && golangci-lint run && <pkg tests>` — golangci-lint must report **0 issues** (it runs gocritic/revive/staticcheck; avoid unused params — drop them or name `_`).
+- Conventional commits; **NO `Co-Authored-By` / "Generated with" / attribution trailers.**
+- Base branch `feat/outcome-capture` (off main, which has #67 + #68).
+
+**Parallelizable:** Tasks 1, 2, 3 touch disjoint files and have no inter-dependencies — build them concurrently. Tasks 4 → 5 are sequential integration on top.
+
+---
+
+## Task 1: The outcome ledger package
+
+**Files:**
+- Create: `internal/outcome/ledger.go`
+- Test: `internal/outcome/ledger_test.go`
+
+**Interfaces:**
+- Produces: `outcome.Event{Event,Fingerprint,Kind,Entry,Title,Resource string; At time.Time}`; `outcome.Episode{Kind,Entry,Title,Resource string; OpenedAt,ResolvedAt time.Time; Duration time.Duration}`; `outcome.New(path string) (*Ledger, error)`; `(*Ledger).Open(e Event) error`; `(*Ledger).Resolve(fp string, at time.Time) (Episode, bool, error)`. Empty `path` ⇒ no-op (feature off). Nil-receiver-safe.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package outcome
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLedgerOpenResolveRoundTrip(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	l, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t0 := time.Unix(1000, 0)
+	if err := l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "harbor.md", At: t0}); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ep, ok, err := l.Resolve("fp1", t0.Add(90*time.Second))
+	if err != nil || !ok {
+		t.Fatalf("Resolve: ok=%v err=%v", ok, err)
+	}
+	if ep.Kind != "recall" || ep.Entry != "harbor.md" || ep.Duration != 90*time.Second {
+		t.Fatalf("episode: %+v", ep)
+	}
+}
+
+func TestLedgerResolveWithoutOpen(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	if _, ok, err := l.Resolve("never-fired", time.Unix(1, 0)); ok || err != nil {
+		t.Fatalf("resolve with no open should be ok=false, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestLedgerReplayRebuildsOpenIndex(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(2000, 0)
+	_ = l.Open(Event{Fingerprint: "fpA", Kind: "fresh", At: t0})
+	// New ledger over the same file replays the open event.
+	l2, err := New(p)
+	if err != nil {
+		t.Fatalf("replay New: %v", err)
+	}
+	if _, ok, _ := l2.Resolve("fpA", t0.Add(time.Minute)); !ok {
+		t.Fatal("replay must rebuild the open-index so fpA resolves")
+	}
+}
+
+func TestLedgerDisabledWhenPathEmpty(t *testing.T) {
+	l, err := New("")
+	if err != nil {
+		t.Fatalf("New(\"\"): %v", err)
+	}
+	if err := l.Open(Event{Fingerprint: "x"}); err != nil {
+		t.Fatalf("Open on disabled ledger must be a no-op, got %v", err)
+	}
+	if _, ok, _ := l.Resolve("x", time.Now()); ok {
+		t.Fatal("disabled ledger Resolve must be ok=false")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`go test ./internal/outcome/`) — package/`New` undefined.
+
+- [ ] **Step 3: Implement** `internal/outcome/ledger.go`
+
+```go
+// Package outcome records, in an append-only JSONL ledger, whether an
+// investigated incident later resolved and which answer was used for it — the
+// "did it actually work?" signal the learning loop reads. The ledger keeps an
+// in-memory index of still-open incidents, rebuilt by replaying the file on
+// startup so a resolve survives a restart / leader failover.
+package outcome
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"sync"
+	"time"
+)
+
+// Event is one ledger line: an investigation opened, or an incident resolved.
+type Event struct {
+	Event       string    `json:"event"`              // "open" | "resolve"
+	Fingerprint string    `json:"fingerprint"`        // Alertmanager fingerprint (stable firing↔resolved)
+	Kind        string    `json:"kind,omitempty"`     // open: "recall" | "fresh"
+	Entry       string    `json:"entry,omitempty"`    // open+recall: the recalled entry path
+	Title       string    `json:"title,omitempty"`
+	Resource    string    `json:"resource,omitempty"`
+	At          time.Time `json:"at"`
+}
+
+// Episode is a matched open→resolve pair.
+type Episode struct {
+	Kind, Entry, Title, Resource string
+	OpenedAt, ResolvedAt         time.Time
+	Duration                     time.Duration
+}
+
+// Ledger is an append-only outcome log with an in-memory open-index.
+type Ledger struct {
+	path string
+	mu   sync.Mutex
+	open map[string]Event // fingerprint → latest unresolved open
+}
+
+// New opens (replaying) the ledger at path. An empty path returns a disabled,
+// no-op ledger (the feature is off).
+func New(path string) (*Ledger, error) {
+	l := &Ledger{path: path, open: map[string]Event{}}
+	if path == "" {
+		return l, nil
+	}
+	f, err := os.Open(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return l, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) != nil {
+			continue // skip a corrupt line rather than fail startup
+		}
+		switch e.Event {
+		case "open":
+			l.open[e.Fingerprint] = e
+		case "resolve":
+			delete(l.open, e.Fingerprint)
+		}
+	}
+	return l, sc.Err()
+}
+
+func (l *Ledger) enabled() bool { return l != nil && l.path != "" }
+
+func (l *Ledger) appendLocked(e Event) error {
+	f, err := os.OpenFile(l.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	b, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(append(b, '\n'))
+	return err
+}
+
+// Open records that an investigation completed for an incident (fingerprint).
+func (l *Ledger) Open(e Event) error {
+	if !l.enabled() {
+		return nil
+	}
+	e.Event = "open"
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.appendLocked(e); err != nil {
+		return err
+	}
+	l.open[e.Fingerprint] = e
+	return nil
+}
+
+// Resolve records that an incident's alert cleared. When it matches an open
+// investigation it returns the Episode (with duration + kind) and ok=true.
+func (l *Ledger) Resolve(fp string, at time.Time) (Episode, bool, error) {
+	if !l.enabled() {
+		return Episode{}, false, nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.appendLocked(Event{Event: "resolve", Fingerprint: fp, At: at}); err != nil {
+		return Episode{}, false, err
+	}
+	o, ok := l.open[fp]
+	if !ok {
+		return Episode{}, false, nil
+	}
+	delete(l.open, fp)
+	return Episode{
+		Kind: o.Kind, Entry: o.Entry, Title: o.Title, Resource: o.Resource,
+		OpenedAt: o.At, ResolvedAt: at, Duration: at.Sub(o.At),
+	}, true, nil
+}
+```
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./internal/outcome/`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/outcome/*.go && go vet ./internal/outcome/... && golangci-lint run ./internal/outcome/...
+git add internal/outcome/
+git commit -m "feat(outcome): append-only JSONL outcome ledger with replayed open-index"
+```
+
+---
+
+## Task 2: Outcome metrics
+
+**Files:**
+- Modify: `internal/telemetry/metrics.go`
+- Test: `internal/telemetry/metrics_test.go`
+
+**Interfaces:**
+- Produces: `Metrics.OutcomesOpened metric.Int64Counter`, `Metrics.IncidentsResolved metric.Int64Counter`, `Metrics.RecallOutcome metric.Int64Counter`, `Metrics.IncidentResolutionSeconds metric.Float64Histogram`.
+
+- [ ] **Step 1: Write the failing test** (extend the existing nil-safe test, or add)
+
+```go
+func TestNewMetricsOutcomeInstruments(t *testing.T) {
+	m := NewMetrics()
+	ctx := context.Background()
+	m.OutcomesOpened.Add(ctx, 1)
+	m.IncidentsResolved.Add(ctx, 1)
+	m.RecallOutcome.Add(ctx, 1)
+	m.IncidentResolutionSeconds.Record(ctx, 90)
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (fields undefined). Run: `go test ./internal/telemetry/ -run Outcome`
+
+- [ ] **Step 3: Implement** — add the four fields to `Metrics` (after `RecallScore`):
+
+```go
+	OutcomesOpened            metric.Int64Counter     // investigations recorded as open (label: kind)
+	IncidentsResolved         metric.Int64Counter     // resolve events that matched an open investigation
+	RecallOutcome             metric.Int64Counter     // resolved incidents whose open was a recall (label: result)
+	IncidentResolutionSeconds metric.Float64Histogram // open→resolve duration, seconds
+```
+
+and to the returned struct literal in `NewMetrics` (after the `RecallScore` line):
+
+```go
+		OutcomesOpened:            ctr("outcomes_opened_total", "investigations recorded in the outcome ledger (label: kind)"),
+		IncidentsResolved:         ctr("incidents_resolved_total", "resolve events that matched an open investigation"),
+		RecallOutcome:             ctr("recall_outcome_total", "resolved incidents whose answer was a recall (label: result)"),
+		IncidentResolutionSeconds: histF("incident_resolution_seconds", "open→resolve duration in seconds"),
+```
+
+- [ ] **Step 4: Run — expect PASS**; **Step 5: Commit**
+
+```bash
+gofmt -w internal/telemetry/*.go && golangci-lint run ./internal/telemetry/...
+git add internal/telemetry/
+git commit -m "feat(telemetry): outcome metrics (opened/resolved/recall-outcome/resolution-seconds)"
+```
+
+---
+
+## Task 3: Thread fingerprint, status, and recalled-entry
+
+**Files:**
+- Modify: `internal/config/config.go` (`Incident` struct)
+- Modify: `internal/investigate/investigate.go` (`Request` struct + `FromIncident`)
+- Modify: `internal/providers/providers.go` (`Investigation` struct)
+- Modify: `internal/investigate/recall.go` (`recalledInvestigation`)
+- Test: `internal/investigate/investigate_test.go` (or wherever `FromIncident` is tested) + `internal/investigate/recall_test.go`
+
+**Interfaces:**
+- Produces: `config.Incident.Status string`; `investigate.Request.Fingerprint string`; `providers.Investigation.Fingerprint string`, `.RecalledEntry string`. `recalledInvestigation` sets `.RecalledEntry = e.Path`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// investigate_test.go
+func TestFromIncidentCarriesFingerprint(t *testing.T) {
+	r := FromIncident(config.Incident{AlertName: "A", Namespace: "ns", Fingerprint: "fp-9"})
+	if r.Fingerprint != "fp-9" {
+		t.Fatalf("Request.Fingerprint = %q, want fp-9", r.Fingerprint)
+	}
+}
+```
+
+```go
+// recall_test.go — extend TestRecalledInvestigationUsesDerivedConfidence or add:
+func TestRecalledInvestigationCarriesEntryPath(t *testing.T) {
+	inv := recalledInvestigation(Request{Title: "x"}, catalog.Entry{Title: "T", Path: "p.md"}, 0.7)
+	if inv.RecalledEntry != "p.md" {
+		t.Fatalf("RecalledEntry = %q, want p.md", inv.RecalledEntry)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (fields undefined). Run: `go test ./internal/investigate/ -run 'FromIncidentCarriesFingerprint|RecalledInvestigationCarriesEntryPath'`
+
+- [ ] **Step 3: Implement**
+
+`config.go` — add to `Incident` (after `GroupKey`):
+```go
+	Status string // Alertmanager status: "firing" | "resolved"
+```
+
+`investigate.go` — add to `Request`:
+```go
+	Fingerprint string // Alertmanager fingerprint (stable firing↔resolved); for outcome attribution
+```
+and set it in `FromIncident`:
+```go
+		Fingerprint: inc.Fingerprint,
+```
+
+`providers.go` — add to `Investigation` (after `Resource Workload`):
+```go
+	Fingerprint   string // originating alert fingerprint; for outcome-ledger attribution
+	RecalledEntry string // when Recalled: the catalog entry Path that was matched
+```
+
+`recall.go` — in `recalledInvestigation`'s returned `Investigation`, add:
+```go
+		RecalledEntry: e.Path,
+```
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./internal/investigate/ ./internal/config/`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/config/config.go internal/investigate/investigate.go internal/providers/providers.go internal/investigate/recall.go internal/investigate/*_test.go
+go vet ./... && go build ./... && golangci-lint run
+git add internal/config/config.go internal/investigate/ internal/providers/providers.go
+git commit -m "feat(investigate): thread alert fingerprint + recalled-entry for outcome attribution"
+```
+
+---
+
+## Task 4: Ingest resolved alerts + route to the ledger
+
+**Files:**
+- Modify: `internal/trigger/incident.go` (`ParseAlertmanager`)
+- Modify: `internal/server/server.go` (`Server` struct + `handleAlertmanager` + a setter)
+- Test: `internal/trigger/incident_test.go`, `internal/server/*_test.go`
+
+**Interfaces:**
+- Consumes: `outcome.Ledger.Resolve(fp string, at time.Time) (Episode, bool, error)` (Task 1); `config.Incident.Status` (Task 3); `telemetry.Metrics` outcome counters (Task 2).
+- Produces: `(*Server).SetOutcomeLedger(l *outcome.Ledger)`.
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// incident_test.go
+func TestParseAlertmanagerSurfacesResolved(t *testing.T) {
+	body := `{"alerts":[
+		{"status":"firing","labels":{"alertname":"X","namespace":"ns"},"fingerprint":"f1"},
+		{"status":"resolved","labels":{"alertname":"X","namespace":"ns"},"fingerprint":"f1"}]}`
+	incs, err := ParseAlertmanager(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(incs) != 2 {
+		t.Fatalf("want 2 incidents (firing+resolved), got %d", len(incs))
+	}
+	var statuses []string
+	for _, i := range incs {
+		statuses = append(statuses, i.Status)
+	}
+	if statuses[0] != "firing" || statuses[1] != "resolved" {
+		t.Fatalf("statuses = %v, want [firing resolved]", statuses)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (resolved dropped; `Status` not set). Run: `go test ./internal/trigger/ -run Resolved`
+
+- [ ] **Step 3: Implement**
+
+`incident.go` — in `ParseAlertmanager`, REMOVE the firing-only `continue` and set `Status`. The loop currently does `if a.Status != "" && a.Status != "firing" { continue }`. Replace that filter; set `Status: a.Status` on the built `config.Incident`:
+```go
+	for _, a := range p.Alerts {
+		startsAt, _ := time.Parse(time.RFC3339, a.StartsAt)
+		out = append(out, config.Incident{
+			AlertName:   a.Labels["alertname"],
+			Severity:    a.Labels["severity"],
+			Environment: cmp.Or(a.Labels["environment"], a.Labels["env"]),
+			Namespace:   a.Labels["namespace"],
+			Labels:      a.Labels,
+			StartsAt:    startsAt,
+			Fingerprint: a.Fingerprint,
+			GroupKey:    p.GroupKey,
+			Status:      a.Status,
+		})
+	}
+```
+(Default `Status` when absent: treat empty as firing in the handler.)
+
+`server.go` — add a field + setter:
+```go
+	outcomeLedger *outcome.Ledger // optional; records investigation outcomes (resolved alerts)
+```
+```go
+// SetOutcomeLedger attaches the outcome ledger; resolved alerts are recorded into it.
+func (s *Server) SetOutcomeLedger(l *outcome.Ledger) { s.outcomeLedger = l }
+```
+In `handleAlertmanager`, branch on status at the top of the loop (before `Decide`):
+```go
+	for _, inc := range incidents {
+		if inc.Status == "resolved" {
+			if s.outcomeLedger != nil {
+				if ep, ok, err := s.outcomeLedger.Resolve(inc.Fingerprint, time.Now()); err != nil {
+					s.log.Warn("outcome ledger resolve failed", "fingerprint", inc.Fingerprint, "err", err)
+				} else if ok && s.otelMetrics != nil {
+					s.otelMetrics.IncidentsResolved.Add(r.Context(), 1)
+					s.otelMetrics.IncidentResolutionSeconds.Record(r.Context(), ep.Duration.Seconds())
+					if ep.Kind == "recall" {
+						s.otelMetrics.RecallOutcome.Add(r.Context(), 1, metric.WithAttributes(attribute.String("result", "resolved")))
+					}
+				}
+			}
+			continue
+		}
+		d := s.engine.Decide(inc)
+		// ... existing firing path unchanged ...
+	}
+```
+Add imports to server.go: `"time"`, `"github.com/Smana/runlore/internal/outcome"`, and (if not present) `go.opentelemetry.io/otel/attribute` + `go.opentelemetry.io/otel/metric`.
+
+> Server test: extend the package's existing `handleAlertmanager` harness (grep `TestHandleAlertmanager` in `internal/server`) — POST a resolved alert with the ledger set (a ledger over a `t.TempDir()` file with a prior `Open` for that fingerprint) and assert it does NOT enqueue/investigate and the ledger recorded the resolve. If the harness makes ledger injection awkward, a focused `incident_test.go` for the parse + a small server test asserting "resolved alert → no Enqueue" suffices.
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./internal/trigger/ ./internal/server/`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/trigger/incident.go internal/server/server.go internal/trigger/*_test.go internal/server/*_test.go
+go vet ./... && go build ./... && golangci-lint run
+git add internal/trigger/incident.go internal/server/server.go internal/trigger/incident_test.go internal/server/
+git commit -m "feat(server): ingest resolved alerts and record them in the outcome ledger"
+```
+
+---
+
+## Task 5: Record Open at OnComplete + wire the ledger, config, helm
+
+**Files:**
+- Modify: `internal/config/config.go` (new `Outcome` config + top-level field)
+- Modify: `cmd/lore/main.go` (build the ledger; `SetOutcomeLedger`; record `Open` in the production OnComplete)
+- Modify: `deploy/helm/runlore/values.yaml`
+- Test: `internal/config/*_test.go`
+
+**Interfaces:**
+- Consumes: `outcome.New`, `(*Ledger).Open`, `outcome.Event` (Task 1); `Investigation.{Fingerprint,RecalledEntry,Recalled,Resource,Title}` (Task 3); `(*Server).SetOutcomeLedger` (Task 4); `Metrics.OutcomesOpened` (Task 2).
+
+- [ ] **Step 1: Config test (failing)**
+
+```go
+func TestOutcomeConfigParse(t *testing.T) {
+	const y = "outcome:\n  ledger_path: /var/lib/runlore/catalog/outcomes.jsonl\n"
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Outcome.LedgerPath != "/var/lib/runlore/catalog/outcomes.jsonl" {
+		t.Fatalf("ledger_path: %q", c.Outcome.LedgerPath)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`go test ./internal/config/ -run TestOutcomeConfigParse`).
+
+- [ ] **Step 3: Implement**
+
+`config.go` — add a top-level field to `Config`:
+```go
+	Outcome Outcome `yaml:"outcome"` // learning-loop outcome ledger
+```
+and the type:
+```go
+// Outcome configures the learning-loop outcome ledger.
+type Outcome struct {
+	LedgerPath string `yaml:"ledger_path"` // append-only JSONL path (e.g. the git-sync mirror PV); empty disables
+}
+```
+
+`cmd/lore/main.go` — where the Server + investigator are built (the server-serve path, near the `metrics := telemetry.NewMetrics()` instance and `server.New(...)`):
+```go
+	ledger, err := outcome.New(cfg.Outcome.LedgerPath)
+	if err != nil {
+		return fmt.Errorf("outcome ledger: %w", err)
+	}
+	if cfg.Outcome.LedgerPath != "" {
+		log.Info("outcome ledger enabled", "path", cfg.Outcome.LedgerPath)
+	}
+	// after srv := server.New(...):
+	srv.SetOutcomeLedger(ledger)
+```
+Record `Open` in the **production OnComplete** (the `func(found providers.Investigation) { switch ... }` at ~main.go:1030). Add, at the top of that closure:
+```go
+		if err := ledger.Open(outcome.Event{
+			Fingerprint: found.Fingerprint,
+			Kind:        outcomeKind(found.Recalled),
+			Entry:       found.RecalledEntry,
+			Title:       found.Title,
+			Resource:    resourceStr(found.Resource),
+			At:          time.Now(),
+		}); err != nil {
+			log.Warn("outcome ledger open failed", "fingerprint", found.Fingerprint, "err", err)
+		}
+		if metrics != nil {
+			metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", outcomeKind(found.Recalled))))
+		}
+```
+Add small helpers in main:
+```go
+func outcomeKind(recalled bool) string {
+	if recalled {
+		return "recall"
+	}
+	return "fresh"
+}
+func resourceStr(w providers.Workload) string {
+	if w.Namespace == "" {
+		return ""
+	}
+	if w.Name == "" {
+		return w.Namespace
+	}
+	return w.Namespace + "/" + w.Name
+}
+```
+Import `"github.com/Smana/runlore/internal/outcome"`, `"time"`, `go.opentelemetry.io/otel/attribute`, `go.opentelemetry.io/otel/metric` (most already present). Ensure `ledger` is in scope for the OnComplete closure (build it before the investigator/server construction).
+
+`values.yaml` — under the commented `config:` example block:
+```yaml
+  # outcome:
+  #   ledger_path: /var/lib/runlore/catalog/outcomes.jsonl  # learning-loop outcome ledger; point at the writable git-sync mirror PV
+```
+
+- [ ] **Step 4: Run — expect PASS + green build**
+
+Run: `cd /home/smana/Sources/runlore && go build ./... && go test ./internal/config/ && golangci-lint run && helm lint deploy/helm/runlore`
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w internal/config/config.go cmd/lore/main.go internal/config/*_test.go
+git add internal/config/config.go cmd/lore/main.go internal/config/ deploy/helm/runlore/values.yaml
+git commit -m "feat(outcome): record investigation outcomes + wire ledger/config/helm"
+```
+
+---
+
+## Final verification
+
+- [ ] `gofmt -l ./internal/... ./cmd/...` → no output
+- [ ] `go vet ./...` → clean
+- [ ] `go build ./...` → clean
+- [ ] `golangci-lint run` → 0 issues
+- [ ] `go test ./...` → all green
+- [ ] Manual trace: a firing alert → `OnComplete` writes an `open` line (kind=recall|fresh) to the JSONL; the matching `resolved` webhook writes a `resolve` line, emits `incidents_resolved` + `incident_resolution_seconds`, and (for a recall) `recall_outcome{result=resolved}`. Restarting re-reads the open lines.
+
+## Notes for the implementer
+
+- **Ledger methods take no `ctx`** (local file I/O) — keep it that way to avoid an unused-parameter lint hit.
+- `resourceStr` (main) mirrors `resourceString` (curator) / `canonicalResource` (recall). Three private copies exist now; DRY into `providers.Workload.Resource()` is a fine follow-up but out of scope here.
+- Empty `ledger_path` ⇒ the whole feature is a no-op (default off) — every method short-circuits. Tests must cover that path.

--- a/docs/superpowers/specs/2026-06-23-outcome-capture-design.md
+++ b/docs/superpowers/specs/2026-06-23-outcome-capture-design.md
@@ -1,0 +1,111 @@
+# RunLore Outcome Capture — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Slice **A1** of the learning-loop "outcome loop": ingest the resolved-alert signal, attribute it to the answer that was used (recall vs fresh), and record it in a persistent outcome ledger. Makes learning *measurable*. No feedback/decay (A2) or dormant-pass wiring (A3) yet. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | The "accumulates ≠ learns" critique (problem #1, fix #4); slice 1 recall trustworthiness (#68); `internal/trigger/incident.go` (`ParseAlertmanager`), `internal/investigate` (`Request`/loop/`recall`), `internal/curate` (dormant `ResolutionChecker`/`Queue` — future A3 consumers) |
+
+---
+
+## 1. Why this exists
+
+The critique's #1, the make-or-break: *"accumulates ≠ learns — no outcome signal anywhere."* RunLore curates and recalls knowledge but never records whether a recalled/curated answer was followed by the incident actually **resolving**. So nothing can validate a recall, decay a stale entry, or compound. This slice closes the **first half** of the loop: capture the outcome signal + attribute it to the answer used. (A2 feeds it back into recall ranking; A3 wires the dormant curate lifecycle.)
+
+It builds directly on slice 1: recall now records *which* entry it matched and emits `recall_hits{result}` / `recall_rejections`. This slice adds the **resolution side** — when the same alert that triggered an investigation resolves, record it against the entry/answer used. Alone, it already kills critique #1 by making "did it actually work?" a queryable fact.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **First slice = outcome CAPTURE** (signal + attribution + record); feedback/decay = A2; dormant-pass wiring = A3 | The outcome loop is too big for one spec. Capture is the foundation everything else reads, and on its own it makes "did it work?" visible — killing critique #1. |
+| D2 | **Resolution signal = Alertmanager `resolved` webhook** (currently discarded) | Event-driven, low cost, and the AM `fingerprint` is **stable firing↔resolved** → clean attribution. A cluster-state `ResolutionChecker` is A3. |
+| D3 | **Persistent append-only JSONL event ledger**, keyed by AM fingerprint, at a configurable path (default the writable git-sync mirror PV) | Survives restart + leader failover; cheap per-event writes; full history. A2 reconstructs episodes; git-versioned surfacing onto entries is A2. |
+| D4 | **Attribute recalls cleanly** (`kind=recall` + entry path); **fresh investigations = `kind=fresh`, no entry link** | Recall validation is the high-value, clean case; linking a fresh finding to its eventual curated entry is murkier and belongs in A2. |
+| D5 | **Recurrence is *inferable from the ledger*** (multiple opens per fingerprint), not a separate A1 mechanism | Keep A1 to event capture; the dormant Recurrence pass / A2 interpret it. |
+
+## 3. Design
+
+### 3.1 The outcome ledger (`internal/outcome`, NEW)
+
+One small package. An append-only **JSONL event log** on disk plus an in-memory **open-index** (fingerprint → latest unresolved open) rebuilt by replaying the file on startup, so a `resolve` can be matched to its `open` (for duration + kind) and survive failover.
+
+```go
+type Event struct {
+	Event       string    `json:"event"`             // "open" | "resolve"
+	Fingerprint string    `json:"fingerprint"`        // Alertmanager fingerprint (stable firing↔resolved)
+	Kind        string    `json:"kind,omitempty"`     // open: "recall" | "fresh"
+	Entry       string    `json:"entry,omitempty"`    // open+recall: the recalled entry Path
+	Title       string    `json:"title,omitempty"`
+	Resource    string    `json:"resource,omitempty"`
+	At          time.Time `json:"at"`
+}
+
+type Ledger struct { /* path string; mu sync.Mutex; open map[string]Event */ }
+
+func New(path string) (*Ledger, error)                       // replays the file → open-index; nil-safe when path == ""
+func (l *Ledger) Open(ctx context.Context, e Event) error    // append "open"; index[fp] = e
+func (l *Ledger) Resolve(ctx context.Context, fp string, at time.Time) (Episode, bool, error) // append "resolve"; match+drop index[fp]
+func (l *Ledger) Episodes() []Episode                         // (A2) reconstructed open→resolve pairs
+```
+
+- **Append** = `O_APPEND` open, write one JSON line + `\n`, close (mutex-guarded). Cheap; full history.
+- **`Resolve`** finds `open[fp]`, returns the matched `Episode{Kind, Entry, OpenedAt, ResolvedAt, Duration}` + `ok`, appends the `resolve` line, drops the index entry. No matching open → append anyway (a resolve we never saw fire) and return `ok=false`.
+- **Path** configurable (`outcome.ledger_path`; default `<catalog mirror dir>/outcomes.jsonl`). Empty ⇒ a no-op ledger (feature off).
+
+### 3.2 Resolved-webhook ingestion (`incident.go`, `server.go`)
+
+- `ParseAlertmanager` today drops non-firing: `if a.Status != "" && a.Status != "firing" { continue }`. Change it to **return both** firing and resolved alerts, tagging each with its status — add `Status string` to `config.Incident` (already carries `Fingerprint`).
+- `handleAlertmanager` routes per incident: **firing** → the existing `Decide` → investigate/coalesce path (unchanged); **resolved** → `ledger.Resolve(inc.Fingerprint, inc.At)` — no `Decide`, no coalesce, no investigation. Reuses the existing webhook bearer-token auth.
+
+### 3.3 Attribution (`Request`/`Investigation` threading)
+
+The fingerprint must reach the point where the outcome is recorded (`OnComplete`):
+- `config.Incident.Fingerprint` exists → add `Fingerprint` to `investigate.Request` (set in `FromIncident`) and to `providers.Investigation` (carried through so `OnComplete` can read it).
+- Add `RecalledEntry string` to `providers.Investigation`, set in `recalledInvestigation` to the matched entry's `Path` (empty for fresh investigations). `Recalled bool` already exists (slice 1).
+- At **`OnComplete`** (where curation already hooks), when the ledger is enabled, append `ledger.Open({Fingerprint, Kind: recall|fresh, Entry: RecalledEntry, Title, Resource, At: now})`. `Kind = "recall"` if `inv.Recalled` else `"fresh"`.
+
+### 3.4 Metrics (`telemetry.Metrics`)
+
+- `outcomes_opened_total{kind}` — at `OnComplete`.
+- `incidents_resolved_total` + `incident_resolution_seconds` (histogram) — at `Resolve`, when it matched an open (duration = resolved − opened).
+- `recall_outcome_total{result="resolved"}` — at `Resolve`, when the matched open's `kind == "recall"`. (`unresolved` is the absence of a resolve — inferred from the ledger by A2, not emitted here.)
+
+### 3.5 Config + Helm
+
+`outcome.ledger_path` (default derived from the catalog mirror dir; empty disables). Exposed (documented) in `deploy/helm/runlore/values.yaml`.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| Ledger package (append-only JSONL + replayed open-index) | `internal/outcome/` (`ledger.go`, `ledger_test.go`) |
+| Parse + route resolved alerts | `internal/trigger/incident.go`, `internal/server/server.go` |
+| Thread fingerprint + recalled-entry | `internal/config/config.go` (`Incident.Status`), `internal/investigate` (`Request.Fingerprint`, `FromIncident`, `recalledInvestigation`), `internal/providers/providers.go` (`Investigation.Fingerprint`, `.RecalledEntry`) |
+| Record `Open` at OnComplete | `cmd/lore/main.go` (OnComplete wiring) |
+| Metrics | `internal/telemetry/metrics.go` |
+| Config + Helm | `internal/config/config.go`, `deploy/helm/runlore/values.yaml` |
+
+## 5. Trade-offs accepted in v1
+
+- **Correlation, not causation** — a resolved alert means the incident *ended*, not that *our answer fixed it*. A1 records the signal; A2 interprets it skeptically across many incidents (an entry whose recalls consistently don't resolve / recur is the demotion evidence).
+- **Fresh-investigation outcomes have no entry link** (`kind=fresh`) — recall validation is the priority; fresh→curated linkage is A2.
+- **Single-writer** — only the leader investigates and handles webhooks, so the leader owns the ledger; the path must be on leader-stable / shared storage (the mirror PV). A failover replays the JSONL to rebuild the open-index.
+- **Unbounded JSONL** — grows with incidents; periodic compaction (drop resolved episodes older than N) is a deferred follow-up.
+
+## 6. Testing
+
+- **`outcome` unit**: `Open`/`Resolve` write the correct JSONL; startup replay rebuilds the open-index; `Resolve` matches the latest open + returns the right `Episode` + duration; resolve with no open → `ok=false`; empty path ⇒ no-op (no file, no panic).
+- **`ParseAlertmanager`**: returns resolved alerts tagged `Status="resolved"`; the handler routes resolved → `Resolve` (and does NOT investigate/coalesce them).
+- **Attribution**: `OnComplete` with a recalled investigation → an `open` event `kind=recall` + entry path; a fresh investigation → `kind=fresh`, no entry.
+- **Metrics**: a matched resolve emits `incidents_resolved` + `incident_resolution_seconds`, and `recall_outcome{resolved}` when the open was a recall.
+
+## 7. Out of scope (A2, A3)
+
+- **A2** — feedback to recall: decay/demote, deriving recall confidence/gating from an entry's track record, and surfacing git-versioned aggregates (`recall_count`/`resolved_count`/`last_confirmed`) onto entry frontmatter.
+- **A3** — wiring the dormant `Queue`/`Lifecycle`/`Recurrence` curate passes + a concrete cluster-state `ResolutionChecker` + a `RecurrenceStore`.
+- **Causal attribution** (did our *action* fix it) — beyond the loop's scope; the resolved-alert proxy is the signal.
+
+This slice is deliberately the *measurement layer*: it makes the outcome a recorded fact without yet acting on it.

--- a/docs/superpowers/specs/2026-06-23-outcome-capture-design.md
+++ b/docs/superpowers/specs/2026-06-23-outcome-capture-design.md
@@ -22,7 +22,7 @@ It builds directly on slice 1: recall now records *which* entry it matched and e
 |---|---|---|
 | D1 | **First slice = outcome CAPTURE** (signal + attribution + record); feedback/decay = A2; dormant-pass wiring = A3 | The outcome loop is too big for one spec. Capture is the foundation everything else reads, and on its own it makes "did it work?" visible — killing critique #1. |
 | D2 | **Resolution signal = Alertmanager `resolved` webhook** (currently discarded) | Event-driven, low cost, and the AM `fingerprint` is **stable firing↔resolved** → clean attribution. A cluster-state `ResolutionChecker` is A3. |
-| D3 | **Persistent append-only JSONL event ledger**, keyed by AM fingerprint, at a configurable path (default the writable git-sync mirror PV) | Survives restart + leader failover; cheap per-event writes; full history. A2 reconstructs episodes; git-versioned surfacing onto entries is A2. |
+| D3 | **Persistent append-only JSONL event ledger**, keyed by AM fingerprint, at an explicit configurable path (`outcome.ledger_path`; empty disables — the default) | Survives restart + leader failover; cheap per-event writes; full history. A2 reconstructs episodes; git-versioned surfacing onto entries is A2. **Explicit opt-in** — NOT auto-derived from `catalog.dir`, which may be a read-only ConfigMap mount; operators point it at a writable path such as the git-sync mirror PV. |
 | D4 | **Attribute recalls cleanly** (`kind=recall` + entry path); **fresh investigations = `kind=fresh`, no entry link** | Recall validation is the high-value, clean case; linking a fresh finding to its eventual curated entry is murkier and belongs in A2. |
 | D5 | **Recurrence is *inferable from the ledger*** (multiple opens per fingerprint), not a separate A1 mechanism | Keep A1 to event capture; the dormant Recurrence pass / A2 interpret it. |
 
@@ -75,7 +75,9 @@ The fingerprint must reach the point where the outcome is recorded (`OnComplete`
 
 ### 3.5 Config + Helm
 
-`outcome.ledger_path` (default derived from the catalog mirror dir; empty disables). Exposed (documented) in `deploy/helm/runlore/values.yaml`.
+`outcome.ledger_path` — an **explicit** path; **empty disables** the feature (the default). Not auto-derived from `catalog.dir`, because that path may be a read-only ConfigMap mount; operators set it to a writable location (e.g. the git-sync mirror PV). Documented in `deploy/helm/runlore/values.yaml`.
+
+Note: `OnComplete` only records an `open` when the investigation carries an alert `Fingerprint` — non-alert sources (GitOps-failure watch, reinvestigate poller) are skipped, since a resolved-alert webhook could never match them.
 
 ## 4. Components / seams
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,6 +213,7 @@ type Incident struct {
 	StartsAt    time.Time
 	Fingerprint string // stable alert identity, used for dedup
 	GroupKey    string // Alertmanager group identity (shared by all alerts in one webhook POST)
+	Status      string // Alertmanager status: "firing" | "resolved"
 }
 
 // Matches reports whether an incident passes this trigger policy: enabled,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Model    Model         `yaml:"model"`   // optional; when BaseURL is set, serve uses the LLM investigator
 	Notify   Notify        `yaml:"notify"`  // chat delivery for findings
 	Catalog  Catalog       `yaml:"catalog"` // OKF knowledge catalog
+	Outcome  Outcome       `yaml:"outcome"` // learning-loop outcome ledger
 
 	LeaderElection LeaderElection `yaml:"leader_election"` // HA: only the leader investigates
 
@@ -108,6 +109,11 @@ type Catalog struct {
 	Dir           string        `yaml:"dir"` // OKF bundle path (mounted ConfigMap, or the git-sync mirror)
 	Git           CatalogGit    `yaml:"git"`
 	InstantRecall InstantRecall `yaml:"instant_recall"`
+}
+
+// Outcome configures the learning-loop outcome ledger.
+type Outcome struct {
+	LedgerPath string `yaml:"ledger_path"` // append-only JSONL path (e.g. the git-sync mirror PV); empty disables
 }
 
 // InstantRecall short-circuits the investigation loop when the catalog has a

--- a/internal/config/outcome_test.go
+++ b/internal/config/outcome_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestOutcomeConfigParse(t *testing.T) {
+	const y = "outcome:\n  ledger_path: /var/lib/runlore/catalog/outcomes.jsonl\n"
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Outcome.LedgerPath != "/var/lib/runlore/catalog/outcomes.jsonl" {
+		t.Fatalf("ledger_path: %q", c.Outcome.LedgerPath)
+	}
+}

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -61,22 +61,10 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 		Type:        "Incident",
 		Title:       inv.Title,
 		Description: firstLine(inv),
-		Resource:    resourceString(inv.Resource),
+		Resource:    inv.Resource.Ref(),
 		Tags:        []string{"runlore", "incident"},
 		Body:        b.String(),
 	}
-}
-
-// resourceString renders a workload as "namespace/name" (or just "namespace" when
-// the name is unknown), matching the recall side's structural-agreement format.
-func resourceString(w providers.Workload) string {
-	if w.Namespace == "" {
-		return ""
-	}
-	if w.Name == "" {
-		return w.Namespace
-	}
-	return w.Namespace + "/" + w.Name
 }
 
 func firstLine(inv providers.Investigation) string {

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -46,10 +46,10 @@ func TestDraftKBEntrySetsResource(t *testing.T) {
 }
 
 func TestResourceStringNamespaceOnly(t *testing.T) {
-	if got := resourceString(providers.Workload{Namespace: "apps"}); got != "apps" {
+	if got := (providers.Workload{Namespace: "apps"}).Ref(); got != "apps" {
 		t.Fatalf("namespace-only resource = %q, want apps", got)
 	}
-	if got := resourceString(providers.Workload{}); got != "" {
+	if got := (providers.Workload{}).Ref(); got != "" {
 		t.Fatalf("empty workload resource = %q, want empty", got)
 	}
 }

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -30,24 +30,26 @@ const (
 
 // Request is a normalized investigation trigger.
 type Request struct {
-	Source   Source
-	Title    string
-	Workload providers.Workload // optional; zero for alerts without a workload
-	Reason   string
-	Message  string
-	Labels   map[string]string
-	At       time.Time
+	Source      Source
+	Title       string
+	Workload    providers.Workload // optional; zero for alerts without a workload
+	Reason      string
+	Message     string
+	Labels      map[string]string
+	At          time.Time
+	Fingerprint string // Alertmanager fingerprint (stable firing↔resolved); for outcome attribution
 }
 
 // FromIncident builds a Request from a matched incident alert.
 func FromIncident(inc config.Incident) Request {
 	return Request{
-		Source:   SourceAlert,
-		Title:    inc.AlertName,
-		Workload: providers.Workload{Namespace: inc.Namespace},
-		Reason:   inc.Severity,
-		Labels:   inc.Labels,
-		At:       inc.StartsAt,
+		Source:      SourceAlert,
+		Title:       inc.AlertName,
+		Workload:    providers.Workload{Namespace: inc.Namespace},
+		Reason:      inc.Severity,
+		Labels:      inc.Labels,
+		At:          inc.StartsAt,
+		Fingerprint: inc.Fingerprint,
 	}
 }
 

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -119,3 +119,10 @@ func TestFromFailureEvent(t *testing.T) {
 		t.Fatalf("unexpected request: %+v", r)
 	}
 }
+
+func TestFromIncidentCarriesFingerprint(t *testing.T) {
+	r := FromIncident(config.Incident{AlertName: "A", Namespace: "ns", Fingerprint: "fp-9"})
+	if r.Fingerprint != "fp-9" {
+		t.Fatalf("Request.Fingerprint = %q, want fp-9", r.Fingerprint)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -198,7 +198,8 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				if inv.Title == "" {
 					inv.Title = req.Title // default to the triggering incident/failure
 				}
-				inv.Resource = req.Workload // record the originating workload for structural recall
+				inv.Resource = req.Workload       // record the originating workload for structural recall
+				inv.Fingerprint = req.Fingerprint // originating alert id, for outcome-ledger attribution
 				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 				if li.Metrics != nil {
 					li.Metrics.InvestigationTokens.Record(ctx, int64(estimateTokens(sys, messages)))

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -33,7 +33,7 @@ func TestInstantRecallHit(t *testing.T) {
 			{Entry: catalog.Entry{Title: "Known incident", Description: "chart bump", Path: "known.md", Resource: "tooling/harbor"}, Score: 5.0}}}},
 		OnComplete: func(inv providers.Investigation) { got = &inv },
 	}
-	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
+	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Fingerprint: "fp-recall", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
 	if model.i != 0 {
@@ -44,6 +44,9 @@ func TestInstantRecallHit(t *testing.T) {
 	}
 	if !got.Recalled {
 		t.Fatal("a recalled investigation must be flagged Recalled so the curator skips it")
+	}
+	if got.Fingerprint != "fp-recall" {
+		t.Fatalf("recall path must carry the alert fingerprint for outcome attribution, got %q", got.Fingerprint)
 	}
 }
 
@@ -78,12 +81,15 @@ func TestLoopInvestigatorActions(t *testing.T) {
 		Actions:    action.New(config.ActionPolicy{Mode: config.ActionSuggest, Allow: config.ActionAllow{ReversibleOnly: true}}),
 		OnComplete: func(inv providers.Investigation) { got = &inv },
 	}
-	if err := li.Investigate(context.Background(), Request{Title: "t"}); err != nil {
+	if err := li.Investigate(context.Background(), Request{Title: "t", Fingerprint: "fp-loop"}); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
 	// Only the reversible action is surfaced (suggest mode, reversible_only); none executed.
 	if got == nil || len(got.Actions) != 1 || got.Actions[0].Description != "flux rollback hr/harbor" {
 		t.Fatalf("expected only the reversible action surfaced, got %+v", got)
+	}
+	if got.Fingerprint != "fp-loop" {
+		t.Fatalf("full-loop path must carry the alert fingerprint for outcome attribution, got %q", got.Fingerprint)
 	}
 }
 

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -158,10 +158,11 @@ func recalledInvestigation(req Request, e catalog.Entry, confidence float64) pro
 		Evidence:   []string{fmt.Sprintf("instant recall: matched knowledge-base entry %q", e.Path)},
 	}
 	return providers.Investigation{
-		Title:      req.Title,
-		Confidence: confidence,
-		RootCauses: []providers.Hypothesis{rc},
-		Unresolved: []string{"recalled from the catalog without a fresh investigation — confirm it still applies"},
-		Recalled:   true,
+		Title:         req.Title,
+		Confidence:    confidence,
+		RootCauses:    []providers.Hypothesis{rc},
+		Unresolved:    []string{"recalled from the catalog without a fresh investigation — confirm it still applies"},
+		Recalled:      true,
+		RecalledEntry: e.Path,
 	}
 }

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -164,5 +164,7 @@ func recalledInvestigation(req Request, e catalog.Entry, confidence float64) pro
 		Unresolved:    []string{"recalled from the catalog without a fresh investigation — confirm it still applies"},
 		Recalled:      true,
 		RecalledEntry: e.Path,
+		Fingerprint:   req.Fingerprint,
+		Resource:      req.Workload,
 	}
 }

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -94,25 +94,13 @@ const (
 	matchExact
 )
 
-// canonicalResource renders a workload as "namespace/name", or just "namespace"
-// when the name is unknown (common for alert-triggered investigations).
-func canonicalResource(w providers.Workload) string {
-	if w.Namespace == "" {
-		return ""
-	}
-	if w.Name == "" {
-		return w.Namespace
-	}
-	return w.Namespace + "/" + w.Name
-}
-
 // resourceAgrees reports how strongly the alert's workload agrees with an entry's
 // stored resource. requireWorkload demands an exact namespace+name match.
 func resourceAgrees(reqW providers.Workload, entryResource string, requireWorkload bool) matchStrength {
 	if entryResource == "" || reqW.Namespace == "" {
 		return matchNone
 	}
-	if canonicalResource(reqW) == entryResource {
+	if reqW.Ref() == entryResource {
 		return matchExact
 	}
 	if requireWorkload {

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -157,3 +157,10 @@ func TestRecalledInvestigationUsesDerivedConfidence(t *testing.T) {
 		t.Fatalf("recalledInvestigation must use the derived confidence, got %+v", inv)
 	}
 }
+
+func TestRecalledInvestigationCarriesEntryPath(t *testing.T) {
+	inv := recalledInvestigation(Request{Title: "x"}, catalog.Entry{Title: "T", Path: "p.md"}, 0.7)
+	if inv.RecalledEntry != "p.md" {
+		t.Fatalf("RecalledEntry = %q, want p.md", inv.RecalledEntry)
+	}
+}

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -1,0 +1,126 @@
+// Package outcome records, in an append-only JSONL ledger, whether an
+// investigated incident later resolved and which answer was used for it — the
+// "did it actually work?" signal the learning loop reads. The ledger keeps an
+// in-memory index of still-open incidents, rebuilt by replaying the file on
+// startup so a resolve survives a restart / leader failover.
+package outcome
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"sync"
+	"time"
+)
+
+// Event is one ledger line: an investigation opened, or an incident resolved.
+type Event struct {
+	Event       string    `json:"event"`           // "open" | "resolve"
+	Fingerprint string    `json:"fingerprint"`     // Alertmanager fingerprint (stable firing↔resolved)
+	Kind        string    `json:"kind,omitempty"`  // open: "recall" | "fresh"
+	Entry       string    `json:"entry,omitempty"` // open+recall: the recalled entry path
+	Title       string    `json:"title,omitempty"`
+	Resource    string    `json:"resource,omitempty"`
+	At          time.Time `json:"at"`
+}
+
+// Episode is a matched open→resolve pair.
+type Episode struct {
+	Kind, Entry, Title, Resource string
+	OpenedAt, ResolvedAt         time.Time
+	Duration                     time.Duration
+}
+
+// Ledger is an append-only outcome log with an in-memory open-index.
+type Ledger struct {
+	path string
+	mu   sync.Mutex
+	open map[string]Event // fingerprint → latest unresolved open
+}
+
+// New opens (replaying) the ledger at path. An empty path returns a disabled,
+// no-op ledger (the feature is off).
+func New(path string) (*Ledger, error) {
+	l := &Ledger{path: path, open: map[string]Event{}}
+	if path == "" {
+		return l, nil
+	}
+	f, err := os.Open(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return l, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) != nil {
+			continue // skip a corrupt line rather than fail startup
+		}
+		switch e.Event {
+		case "open":
+			l.open[e.Fingerprint] = e
+		case "resolve":
+			delete(l.open, e.Fingerprint)
+		}
+	}
+	return l, sc.Err()
+}
+
+func (l *Ledger) enabled() bool { return l != nil && l.path != "" }
+
+func (l *Ledger) appendLocked(e Event) error {
+	f, err := os.OpenFile(l.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	b, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(append(b, '\n'))
+	return err
+}
+
+// Open records that an investigation completed for an incident (fingerprint).
+func (l *Ledger) Open(e Event) error {
+	if !l.enabled() {
+		return nil
+	}
+	e.Event = "open"
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.appendLocked(e); err != nil {
+		return err
+	}
+	l.open[e.Fingerprint] = e
+	return nil
+}
+
+// Resolve records that an incident's alert cleared. When it matches an open
+// investigation it returns the Episode (with duration + kind) and ok=true.
+func (l *Ledger) Resolve(fp string, at time.Time) (Episode, bool, error) {
+	if !l.enabled() {
+		return Episode{}, false, nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if err := l.appendLocked(Event{Event: "resolve", Fingerprint: fp, At: at}); err != nil {
+		return Episode{}, false, err
+	}
+	o, ok := l.open[fp]
+	if !ok {
+		return Episode{}, false, nil
+	}
+	delete(l.open, fp)
+	return Episode{
+		Kind: o.Kind, Entry: o.Entry, Title: o.Title, Resource: o.Resource,
+		OpenedAt: o.At, ResolvedAt: at, Duration: at.Sub(o.At),
+	}, true, nil
+}

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1,0 +1,61 @@
+package outcome
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLedgerOpenResolveRoundTrip(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	l, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t0 := time.Unix(1000, 0)
+	if err := l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "harbor.md", At: t0}); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ep, ok, err := l.Resolve("fp1", t0.Add(90*time.Second))
+	if err != nil || !ok {
+		t.Fatalf("Resolve: ok=%v err=%v", ok, err)
+	}
+	if ep.Kind != "recall" || ep.Entry != "harbor.md" || ep.Duration != 90*time.Second {
+		t.Fatalf("episode: %+v", ep)
+	}
+}
+
+func TestLedgerResolveWithoutOpen(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	if _, ok, err := l.Resolve("never-fired", time.Unix(1, 0)); ok || err != nil {
+		t.Fatalf("resolve with no open should be ok=false, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestLedgerReplayRebuildsOpenIndex(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(2000, 0)
+	_ = l.Open(Event{Fingerprint: "fpA", Kind: "fresh", At: t0})
+	// New ledger over the same file replays the open event.
+	l2, err := New(p)
+	if err != nil {
+		t.Fatalf("replay New: %v", err)
+	}
+	if _, ok, _ := l2.Resolve("fpA", t0.Add(time.Minute)); !ok {
+		t.Fatal("replay must rebuild the open-index so fpA resolves")
+	}
+}
+
+func TestLedgerDisabledWhenPathEmpty(t *testing.T) {
+	l, err := New("")
+	if err != nil {
+		t.Fatalf("New(\"\"): %v", err)
+	}
+	if err := l.Open(Event{Fingerprint: "x"}); err != nil {
+		t.Fatalf("Open on disabled ledger must be a no-op, got %v", err)
+	}
+	if _, ok, _ := l.Resolve("x", time.Now()); ok {
+		t.Fatal("disabled ledger Resolve must be ok=false")
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -333,15 +333,17 @@ type LogResult []LogLine
 
 // Investigation is the structured output contract of an investigation.
 type Investigation struct {
-	Title      string
-	RootCauses []Hypothesis
-	Changes    []Change
-	Unresolved []string // honest: what the agent could not determine
-	Confidence float64
-	Recalled   bool     // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
-	Resource   Workload // the originating workload; stored on curated entries for structural recall matching
-	Actions    []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
-	CuratedURL string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
+	Title         string
+	RootCauses    []Hypothesis
+	Changes       []Change
+	Unresolved    []string // honest: what the agent could not determine
+	Confidence    float64
+	Recalled      bool     // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
+	Resource      Workload // the originating workload; stored on curated entries for structural recall matching
+	Actions       []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
+	CuratedURL    string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
+	Fingerprint   string   // originating alert fingerprint; for outcome-ledger attribution
+	RecalledEntry string   // when Recalled: the catalog entry Path that was matched
 }
 
 // Hypothesis is one ranked root-cause candidate with its evidence.

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -47,6 +47,20 @@ type Workload struct {
 	Namespace string
 }
 
+// Ref renders the workload as "namespace/name", or just "namespace" when the
+// name is unknown (common for alert-triggered investigations), or "" when the
+// namespace is unknown too. It is the canonical form used for structural recall
+// matching, curated-entry resources, and outcome-ledger attribution.
+func (w Workload) Ref() string {
+	if w.Namespace == "" {
+		return ""
+	}
+	if w.Name == "" {
+		return w.Namespace
+	}
+	return w.Namespace + "/" + w.Name
+}
+
 // SourceRef points at the Git source + path backing a change.
 type SourceRef struct {
 	RepoURL string

--- a/internal/server/outcome_test.go
+++ b/internal/server/outcome_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/outcome"
+)
+
+func TestHandleAlertmanagerResolvedRoutesToLedger(t *testing.T) {
+	led, err := outcome.New(filepath.Join(t.TempDir(), "o.jsonl"))
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	if err := led.Open(outcome.Event{Fingerprint: "fp1", Kind: "recall", Entry: "e.md", At: time.Unix(1000, 0)}); err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	enq := &spyEnqueuer{}
+	srv := testServerWith(enq)
+	srv.SetOutcomeLedger(led)
+
+	body := `{"alerts":[{"status":"resolved","labels":{"alertname":"A","severity":"critical","namespace":"apps"},"fingerprint":"fp1"}]}`
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(body)))
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d", rr.Code)
+	}
+	if len(enq.reqs) != 0 {
+		t.Fatalf("resolved alert must not enqueue an investigation, got %d", len(enq.reqs))
+	}
+	// the handler's Resolve consumed the seeded open; a second Resolve finds nothing.
+	if _, ok, _ := led.Resolve("fp1", time.Unix(2000, 0)); ok {
+		t.Fatal("handler should have consumed the open for fp1 (open-index empty after resolve)")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,8 +23,11 @@ import (
 	"github.com/Smana/runlore/internal/coalesce"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/telemetry"
 	"github.com/Smana/runlore/internal/trigger"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Server handles incoming incident webhooks and applies the trigger policy.
@@ -39,8 +42,9 @@ type Server struct {
 	webhookToken string            // optional bearer token required on POST /webhook/alertmanager
 	approvers    map[string]bool   // Slack user IDs permitted to approve actions (empty = none)
 
-	coalescer   *coalesce.Coalescer // optional; folds correlated alerts before enqueueing
-	otelMetrics *telemetry.Metrics  // optional; nil-safe OTel counters
+	coalescer     *coalesce.Coalescer // optional; folds correlated alerts before enqueueing
+	otelMetrics   *telemetry.Metrics  // optional; nil-safe OTel counters
+	outcomeLedger *outcome.Ledger     // optional; records investigation outcomes (resolved alerts)
 
 	metrics http.Handler // optional; GET /metrics (OTel Prometheus exposition)
 	log     *slog.Logger
@@ -115,6 +119,11 @@ func (s *Server) SetCoalescer(cz *coalesce.Coalescer) {
 // ingress counters (alerts_received) emit even when coalescing is disabled.
 func (s *Server) SetMetrics(m *telemetry.Metrics) {
 	s.otelMetrics = m
+}
+
+// SetOutcomeLedger attaches the outcome ledger; resolved alerts are recorded into it.
+func (s *Server) SetOutcomeLedger(l *outcome.Ledger) {
+	s.outcomeLedger = l
 }
 
 func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
@@ -360,6 +369,20 @@ func (s *Server) handleAlertmanager(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, inc := range incidents {
+		if inc.Status == "resolved" {
+			if s.outcomeLedger != nil {
+				if ep, ok, err := s.outcomeLedger.Resolve(inc.Fingerprint, time.Now()); err != nil {
+					s.log.Warn("outcome ledger resolve failed", "fingerprint", inc.Fingerprint, "err", err)
+				} else if ok && s.otelMetrics != nil {
+					s.otelMetrics.IncidentsResolved.Add(r.Context(), 1)
+					s.otelMetrics.IncidentResolutionSeconds.Record(r.Context(), ep.Duration.Seconds())
+					if ep.Kind == "recall" {
+						s.otelMetrics.RecallOutcome.Add(r.Context(), 1, metric.WithAttributes(attribute.String("result", "resolved")))
+					}
+				}
+			}
+			continue
+		}
 		d := s.engine.Decide(inc)
 		s.log.Info("incident",
 			"alert", inc.AlertName, "severity", inc.Severity, "namespace", inc.Namespace,

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -13,19 +13,23 @@ const scope = "github.com/Smana/runlore"
 
 // Metrics is the RunLore instrument set, created once and shared.
 type Metrics struct {
-	AlertsReceived           metric.Int64Counter
-	AlertsCoalesced          metric.Int64Counter
-	AlertsSuppressed         metric.Int64Counter
-	InvestigationsStarted    metric.Int64Counter
-	InvestigationsThrottled  metric.Int64Counter
-	InvestigationsDropped    metric.Int64Counter
-	ToolOutputTruncatedBytes metric.Int64Counter
-	RecallHits               metric.Int64Counter // KB cache hits, labelled by verify result
-	RecallTokensSaved        metric.Int64Counter // estimated tokens saved by a recall short-circuit
-	RecallRejections         metric.Int64Counter // recalls rejected before short-circuit (label: reason)
-	CoalesceBatchSize        metric.Int64Histogram
-	InvestigationTokens      metric.Int64Histogram
-	RecallScore              metric.Float64Histogram // BM25 score at the recall decision (tunes min_score)
+	AlertsReceived            metric.Int64Counter
+	AlertsCoalesced           metric.Int64Counter
+	AlertsSuppressed          metric.Int64Counter
+	InvestigationsStarted     metric.Int64Counter
+	InvestigationsThrottled   metric.Int64Counter
+	InvestigationsDropped     metric.Int64Counter
+	ToolOutputTruncatedBytes  metric.Int64Counter
+	RecallHits                metric.Int64Counter // KB cache hits, labelled by verify result
+	RecallTokensSaved         metric.Int64Counter // estimated tokens saved by a recall short-circuit
+	RecallRejections          metric.Int64Counter // recalls rejected before short-circuit (label: reason)
+	CoalesceBatchSize         metric.Int64Histogram
+	InvestigationTokens       metric.Int64Histogram
+	RecallScore               metric.Float64Histogram // BM25 score at the recall decision (tunes min_score)
+	OutcomesOpened            metric.Int64Counter     // investigations recorded as open (label: kind)
+	IncidentsResolved         metric.Int64Counter     // resolve events that matched an open investigation
+	RecallOutcome             metric.Int64Counter     // resolved incidents whose open was a recall (label: result)
+	IncidentResolutionSeconds metric.Float64Histogram // open→resolve duration, seconds
 }
 
 // NewMetrics builds the instrument set from the global meter provider.
@@ -44,18 +48,22 @@ func NewMetrics() *Metrics {
 		return h
 	}
 	return &Metrics{
-		AlertsReceived:           ctr("alerts_received_total", "incidents passing Decide into the coalescer"),
-		AlertsCoalesced:          ctr("alerts_coalesced_total", "incidents folded into an existing batch"),
-		AlertsSuppressed:         ctr("alerts_suppressed_total", "incidents dropped by cooldown"),
-		InvestigationsStarted:    ctr("investigations_started_total", "investigations actually begun"),
-		InvestigationsThrottled:  ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
-		InvestigationsDropped:    ctr("investigations_dropped_total", "keys dropped after max_requeues"),
-		ToolOutputTruncatedBytes: ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
-		RecallHits:               ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
-		RecallTokensSaved:        ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
-		RecallRejections:         ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),
-		CoalesceBatchSize:        hist("coalesce_batch_size", "incidents per flushed batch"),
-		InvestigationTokens:      hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),
-		RecallScore:              histF("recall_score", "BM25 score at the recall decision point"),
+		AlertsReceived:            ctr("alerts_received_total", "incidents passing Decide into the coalescer"),
+		AlertsCoalesced:           ctr("alerts_coalesced_total", "incidents folded into an existing batch"),
+		AlertsSuppressed:          ctr("alerts_suppressed_total", "incidents dropped by cooldown"),
+		InvestigationsStarted:     ctr("investigations_started_total", "investigations actually begun"),
+		InvestigationsThrottled:   ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
+		InvestigationsDropped:     ctr("investigations_dropped_total", "keys dropped after max_requeues"),
+		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
+		RecallHits:                ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
+		RecallTokensSaved:         ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
+		RecallRejections:          ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),
+		CoalesceBatchSize:         hist("coalesce_batch_size", "incidents per flushed batch"),
+		InvestigationTokens:       hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),
+		RecallScore:               histF("recall_score", "BM25 score at the recall decision point"),
+		OutcomesOpened:            ctr("outcomes_opened_total", "investigations recorded in the outcome ledger (label: kind)"),
+		IncidentsResolved:         ctr("incidents_resolved_total", "resolve events that matched an open investigation"),
+		RecallOutcome:             ctr("recall_outcome_total", "resolved incidents whose answer was a recall (label: result)"),
+		IncidentResolutionSeconds: histF("incident_resolution_seconds", "open→resolve duration in seconds"),
 	}
 }

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -17,3 +17,12 @@ func TestNewMetricsNoProvider(_ *testing.T) {
 	m.CoalesceBatchSize.Record(ctx, 12)
 	m.InvestigationTokens.Record(ctx, 5000)
 }
+
+func TestNewMetricsOutcomeInstruments(_ *testing.T) {
+	m := NewMetrics()
+	ctx := context.Background()
+	m.OutcomesOpened.Add(ctx, 1)
+	m.IncidentsResolved.Add(ctx, 1)
+	m.RecallOutcome.Add(ctx, 1)
+	m.IncidentResolutionSeconds.Record(ctx, 90)
+}

--- a/internal/trigger/incident.go
+++ b/internal/trigger/incident.go
@@ -24,9 +24,10 @@ type amAlert struct {
 	Fingerprint string            `json:"fingerprint"`
 }
 
-// ParseAlertmanager reads an Alertmanager webhook body into incidents. Only
-// firing alerts are returned. "environment" is taken from the label of the same
-// name, falling back to "env".
+// ParseAlertmanager reads an Alertmanager webhook body into incidents. Both
+// firing and resolved alerts are returned, each tagged with its Status (the
+// caller routes resolved ones to the outcome ledger). "environment" is taken
+// from the label of the same name, falling back to "env".
 func ParseAlertmanager(r io.Reader) ([]config.Incident, error) {
 	var p amPayload
 	if err := json.NewDecoder(r).Decode(&p); err != nil {
@@ -34,9 +35,6 @@ func ParseAlertmanager(r io.Reader) ([]config.Incident, error) {
 	}
 	out := make([]config.Incident, 0, len(p.Alerts))
 	for _, a := range p.Alerts {
-		if a.Status != "" && a.Status != "firing" {
-			continue
-		}
 		startsAt, _ := time.Parse(time.RFC3339, a.StartsAt)
 		out = append(out, config.Incident{
 			AlertName:   a.Labels["alertname"],
@@ -47,6 +45,7 @@ func ParseAlertmanager(r io.Reader) ([]config.Incident, error) {
 			StartsAt:    startsAt,
 			Fingerprint: a.Fingerprint,
 			GroupKey:    p.GroupKey,
+			Status:      a.Status,
 		})
 	}
 	return out, nil

--- a/internal/trigger/incident_resolved_test.go
+++ b/internal/trigger/incident_resolved_test.go
@@ -1,0 +1,22 @@
+package trigger
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAlertmanagerSurfacesResolved(t *testing.T) {
+	body := `{"alerts":[
+		{"status":"firing","labels":{"alertname":"X","namespace":"ns"},"fingerprint":"f1"},
+		{"status":"resolved","labels":{"alertname":"X","namespace":"ns"},"fingerprint":"f1"}]}`
+	incs, err := ParseAlertmanager(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(incs) != 2 {
+		t.Fatalf("want 2 incidents (firing+resolved), got %d", len(incs))
+	}
+	if incs[0].Status != "firing" || incs[1].Status != "resolved" {
+		t.Fatalf("statuses = [%q %q], want [firing resolved]", incs[0].Status, incs[1].Status)
+	}
+}

--- a/internal/trigger/incident_test.go
+++ b/internal/trigger/incident_test.go
@@ -14,13 +14,16 @@ func TestParseAlertmanager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if len(incs) != 1 {
-		t.Fatalf("want 1 firing incident, got %d", len(incs))
+	if len(incs) != 2 {
+		t.Fatalf("want 2 incidents (firing + resolved), got %d", len(incs))
 	}
 	got := incs[0]
 	if got.AlertName != "HarborProbeFailure" || got.Severity != "critical" ||
 		got.Environment != "prod" || got.Namespace != "apps" || got.Fingerprint != "abc123" {
 		t.Fatalf("unexpected incident: %+v", got)
+	}
+	if got.Status != "firing" || incs[1].Status != "resolved" {
+		t.Fatalf("statuses = [%q %q], want [firing resolved]", got.Status, incs[1].Status)
 	}
 	if got.Labels["team"] != "platform" {
 		t.Fatal("labels should be preserved")


### PR DESCRIPTION
## Summary

Slice **A1** of the learning-loop "outcome loop" (the *"accumulates ≠ learns"* critique — problem #1 / fix #4). Makes RunLore's learning **measurable**: it records whether an investigated incident actually resolved, attributed to the answer that was used (recall vs fresh).

- Design: `docs/superpowers/specs/2026-06-23-outcome-capture-design.md`
- Plan: `docs/superpowers/plans/2026-06-23-outcome-capture.md`

## What changed

- **Resolution signal** — `ParseAlertmanager` now surfaces `resolved` alerts (previously dropped by a firing-only filter); `handleAlertmanager` routes them to the ledger (no investigation, no coalesce).
- **Outcome ledger** (`internal/outcome`) — an append-only JSONL event log keyed by the **stable Alertmanager `fingerprint`** (firing↔resolved), with an in-memory open-index replayed on startup so a `resolve` matches its `open` across restart / leader failover. `Open`/`Resolve` are mutex-guarded and nil-safe; an empty path disables the feature.
- **Attribution** — the alert fingerprint is threaded incident → `Request` → `Investigation`; `OnComplete` records an `open` event with `kind` (recall|fresh) + the recalled entry path + resource. The matching resolved webhook stamps `resolved_at` and computes time-to-resolution. Non-alert sources (GitOps watch, reinvestigate poller) are skipped — they could never be matched by a resolved webhook.
- **Metrics** — `outcomes_opened_total{kind}`, `incidents_resolved_total`, `incident_resolution_seconds`, `recall_outcome_total{result}` — recall validation is visible immediately.
- **Config/Helm** — `outcome.ledger_path` (explicit opt-in; empty disables; not auto-derived from `catalog.dir` since that may be a read-only ConfigMap mount), documented in `values.yaml`.

## Out of scope (next slices)

- **A2** — feed outcomes back into recall ranking (decay/demote, confidence from an entry's track record); git-versioned aggregates surfaced onto entry frontmatter.
- **A3** — wire the dormant `Queue`/`Lifecycle`/`Recurrence` curate passes + a cluster-state `ResolutionChecker`.
- **Causal attribution** — a resolved alert is correlation, not proof our answer fixed it; A1 records the signal, A2 interprets it skeptically across many incidents.

## Testing

- Unit: ledger `Open`/`Resolve`/replay/disabled/resolve-without-open; resolved-alert parse + routing (asserts no enqueue); fingerprint threading across the request→outcome seam (both recall + full-loop paths); config + metrics.
- `go build`, `go vet`, **golangci-lint 0 issues**, **`go test ./...` all pass**, **`-race` clean**.
- e2e: `hack/e2e-k3d.sh` green on a real k3d cluster.

Built spec-first (3 foundational tasks ran in parallel). **Reviewed** — an independent reviewer caught a blocker (the fingerprint was threaded + read but never *assigned* to the Investigation, making the feature inert); fixed + regression-tested across both paths. **Simplified** — DRY'd a triplicated workload renderer into `providers.Workload.Ref()`. On `main` (includes #67 + #68).
