### PR TITLE
fix(catalog): pin bleve index to BM25 + curator dedup-score observability

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -695,7 +695,7 @@ func buildAuto(cfg *config.Config, exec action.Executor, aud audit.Auditor, log 
 
 // buildCurator returns a Curator when the GitHub App token + KB repo are
 // configured, else nil.
-func buildCurator(cfg *config.Config, token forgeToken, cat *catalog.Catalog, log *slog.Logger) *curator.Curator {
+func buildCurator(cfg *config.Config, token forgeToken, cat *catalog.Catalog, metrics *telemetry.Metrics, log *slog.Logger) *curator.Curator {
 	if token == nil || cfg.Forge.KBRepo == "" {
 		return nil
 	}
@@ -718,7 +718,7 @@ func buildCurator(cfg *config.Config, token forgeToken, cat *catalog.Catalog, lo
 	}
 	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(token))
 	log.Info("curator enabled", "repo", cfg.Forge.KBRepo, "dup_score", dup, "min_confidence", minConf)
-	cur := &curator.Curator{Forge: client, DupScore: dup, MinConfidence: minConf, Log: log}
+	cur := &curator.Curator{Forge: client, DupScore: dup, MinConfidence: minConf, Metrics: metrics, Log: log}
 	if cat != nil { // assign via concrete check to avoid a typed-nil interface
 		cur.Catalog = cat
 	}
@@ -1031,7 +1031,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	log.Info("using LLM investigator", "provider", modelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)
 	log.Info("delivery notifiers", "count", notifier.Len())
-	cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), cat, log)
+	cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), cat, metrics, log)
 	actions := action.New(cfg.Actions)
 	if actions.Enabled() {
 		log.Info("action policy enabled", "mode", string(actions.Mode()))

--- a/docs/superpowers/plans/2026-06-23-bm25-scorer-fix.md
+++ b/docs/superpowers/plans/2026-06-23-bm25-scorer-fix.md
@@ -1,0 +1,420 @@
+# BM25 Scorer Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the catalog's bleve index actually run BM25 (it silently runs legacy TF-IDF), prove it with a test, and add observability for the always-on curator dedup score — deferring all numeric re-tuning.
+
+**Architecture:** A single shared `newIndexMapping()` helper pins `ScoringModel = "bm25"` so both index-construction sites can't drift again. Curator dedup gains a `Novelty.TopHit` accessor and a nil-safe `*telemetry.Metrics`, recording the top-hit score on every `Curate` via a new `curation_dedup_score` histogram (mirroring the existing `recall_score` pattern).
+
+**Tech Stack:** Go 1.26, `github.com/blevesearch/bleve/v2` (v2.6.0), OpenTelemetry metrics (`go.opentelemetry.io/otel/metric`), stdlib `testing` (no testify).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-bm25-scorer-fix-design.md`
+
+**Branch:** `feat/bm25-scorer-fix` (already checked out; the spec is already committed there).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/catalog/catalog.go` | Index construction + search | Add `newIndexMapping()`; route `NewEmpty` + `buildIndex` through it; import `bleve/v2/mapping` |
+| `internal/catalog/catalog_test.go` | Catalog tests | Add `TestNewIndexMappingUsesBM25`, `TestBuildIndexScores` |
+| `internal/telemetry/metrics.go` | Instrument set | Add `CurationDedupScore` histogram field + constructor line |
+| `internal/telemetry/metrics_test.go` | Instrument safety | Add `TestNewMetricsCurationInstruments` |
+| `internal/curator/fingerprint.go` | Novelty/dedup scoring | Add `TopHit`; refactor `IsDuplicate` to use it |
+| `internal/curator/fingerprint_test.go` | Novelty tests | Add `TestTopHitReturnsScore`, `TestTopHitNilCatalog` |
+| `internal/curator/curator.go` | File-time curation gate | Add nil-safe `Metrics` field; use `TopHit` in `Curate`; record score; enrich dup log |
+| `internal/curator/curator_test.go` | Curator tests | Add `TestCurateRecordsDedupScore`, `TestCurateDedupScoreNilMetricsSafe` |
+| `cmd/lore/main.go` | Wiring | Thread `metrics` into `buildCurator` + its call site |
+
+Task order: Task 1 (catalog) and Task 2 (telemetry) are independent. Task 3 (fingerprint) is independent. Task 4 depends on 2+3. Task 5 depends on 4.
+
+---
+
+### Task 1: Pin the catalog index to BM25
+
+**Files:**
+- Modify: `internal/catalog/catalog.go` (imports; `NewEmpty:34-38`; `buildIndex:67-82`)
+- Test: `internal/catalog/catalog_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/catalog/catalog_test.go`:
+
+```go
+func TestNewIndexMappingUsesBM25(t *testing.T) {
+	// bleve defaults to legacy TF-IDF when ScoringModel is unset. Both index
+	// sites are forced through this helper, so asserting it guarantees BM25
+	// everywhere. This is the regression guard for the silent-fallback bug.
+	if got := newIndexMapping().ScoringModel; got != "bm25" {
+		t.Fatalf("ScoringModel = %q, want \"bm25\"", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/catalog/ -run TestNewIndexMappingUsesBM25`
+Expected: FAIL — compile error `undefined: newIndexMapping`.
+
+- [ ] **Step 3: Add the helper and route both sites through it**
+
+In `internal/catalog/catalog.go`, add `"github.com/blevesearch/bleve/v2/mapping"` to the import block. Add the helper near the top of the file (after the imports, before `New`):
+
+```go
+// newIndexMapping returns the index mapping used by every catalog index. It pins
+// the scoring model to BM25 — bleve defaults to legacy TF-IDF when ScoringModel
+// is unset, whose unbounded, non-saturating scores are not corpus-portable.
+func newIndexMapping() *mapping.IndexMappingImpl {
+	im := bleve.NewIndexMapping()
+	im.ScoringModel = "bm25" // validated by bleve against SupportedScoringModels
+	return im
+}
+```
+
+In `NewEmpty` (`:36`), replace `bleve.NewMemOnly(bleve.NewIndexMapping())` with `bleve.NewMemOnly(newIndexMapping())`.
+
+In `buildIndex` (`:68`), replace `bleve.NewMemOnly(bleve.NewIndexMapping())` with `bleve.NewMemOnly(newIndexMapping())`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/catalog/ -run TestNewIndexMappingUsesBM25`
+Expected: PASS.
+
+- [ ] **Step 5: Add the end-to-end scoring sanity test**
+
+Add to `internal/catalog/catalog_test.go`:
+
+```go
+func TestBuildIndexScores(t *testing.T) {
+	// Proves the BM25 mapping is accepted (NewMemOnly errors on an unsupported
+	// scoring model) and that scoring + ranking work end-to-end. We do NOT assert
+	// magnitudes — TF-IDF also length-normalizes, so magnitude-based BM25-vs-TFIDF
+	// discrimination is brittle; the helper assertion above is the reliable guard.
+	entries := []Entry{
+		{Title: "OOMKilled pod", Body: "container exceeded its memory limit"},
+		{Title: "Image pull failure", Body: "registry returned forbidden"},
+	}
+	idx, err := buildIndex(entries)
+	if err != nil {
+		t.Fatalf("buildIndex: %v", err)
+	}
+	defer func() { _ = idx.Close() }()
+	c := &Catalog{index: idx, entries: entries}
+	hits, err := c.SearchScored("memory limit", 2)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) == 0 || hits[0].Score <= 0 {
+		t.Fatalf("expected a positive-scored hit, got %+v", hits)
+	}
+	if hits[0].Entry.Title != "OOMKilled pod" {
+		t.Fatalf("expected the OOM entry ranked first, got %q", hits[0].Entry.Title)
+	}
+}
+```
+
+- [ ] **Step 6: Run the catalog tests**
+
+Run: `go test ./internal/catalog/`
+Expected: PASS (all, including pre-existing tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/catalog/catalog.go internal/catalog/catalog_test.go
+git commit -m "fix(catalog): pin bleve index to BM25 (was silently TF-IDF)"
+```
+
+---
+
+### Task 2: Add the `CurationDedupScore` instrument
+
+**Files:**
+- Modify: `internal/telemetry/metrics.go` (struct `:15-33`; constructor `:50-68`)
+- Test: `internal/telemetry/metrics_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/telemetry/metrics_test.go`:
+
+```go
+func TestNewMetricsCurationInstruments(_ *testing.T) {
+	// With no provider configured the global meter is a no-op; the instrument must
+	// still construct and be safe to record.
+	m := NewMetrics()
+	m.CurationDedupScore.Record(context.Background(), 4.2)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/telemetry/ -run TestNewMetricsCurationInstruments`
+Expected: FAIL — compile error `m.CurationDedupScore undefined`.
+
+- [ ] **Step 3: Add the instrument**
+
+In `internal/telemetry/metrics.go`, add a field to the `Metrics` struct (after `RecallScore`, `:28`):
+
+```go
+	CurationDedupScore        metric.Float64Histogram // catalog top-hit score at the curation dedup decision
+```
+
+And add the constructor line in the returned struct literal (after the `RecallScore:` line, `:63`):
+
+```go
+		CurationDedupScore:        histF("curation_dedup_score", "catalog top-hit BM25 score at the curation dedup decision"),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/telemetry/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/telemetry/metrics.go internal/telemetry/metrics_test.go
+git commit -m "feat(telemetry): curation_dedup_score histogram"
+```
+
+---
+
+### Task 3: Add `Novelty.TopHit` (score-surfacing accessor)
+
+**Files:**
+- Modify: `internal/curator/fingerprint.go` (`IsDuplicate:36-48`)
+- Test: `internal/curator/fingerprint_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/curator/fingerprint_test.go`:
+
+```go
+func TestTopHitReturnsScore(t *testing.T) {
+	// TopHit surfaces the top hit + score regardless of the DupScore threshold,
+	// so the caller can both observe the score and apply the threshold itself.
+	n := Novelty{Catalog: fakeScored{score: 2.0, title: "Below threshold"}, DupScore: 5.0}
+	top, ok, err := n.TopHit(context.Background(), providers.Investigation{Title: "x"})
+	if err != nil || !ok {
+		t.Fatalf("want a hit, got ok=%v err=%v", ok, err)
+	}
+	if top.Score != 2.0 || top.Entry.Title != "Below threshold" {
+		t.Fatalf("unexpected top hit %+v", top)
+	}
+}
+
+func TestTopHitNilCatalog(t *testing.T) {
+	_, ok, err := Novelty{Catalog: nil}.TopHit(context.Background(), providers.Investigation{Title: "x"})
+	if ok || err != nil {
+		t.Fatalf("nil catalog: want ok=false err=nil, got ok=%v err=%v", ok, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/curator/ -run TestTopHit`
+Expected: FAIL — compile error `n.TopHit undefined`.
+
+- [ ] **Step 3: Add `TopHit` and refactor `IsDuplicate` through it**
+
+In `internal/curator/fingerprint.go`, replace the `IsDuplicate` method (`:34-48`) with:
+
+```go
+// TopHit returns the highest-scoring catalog entry for a finding's fingerprint.
+// ok is false when no catalog is configured or there are no hits. It surfaces the
+// score regardless of any threshold, so callers can both observe it and decide.
+func (n Novelty) TopHit(ctx context.Context, inv providers.Investigation) (catalog.ScoredEntry, bool, error) { //nolint:revive // ctx kept for future remote-index symmetry
+	if n.Catalog == nil {
+		return catalog.ScoredEntry{}, false, nil
+	}
+	hits, err := n.Catalog.SearchScored(Fingerprint(inv), 1)
+	if err != nil {
+		return catalog.ScoredEntry{}, false, err
+	}
+	if len(hits) == 0 {
+		return catalog.ScoredEntry{}, false, nil
+	}
+	return hits[0], true, nil
+}
+
+// IsDuplicate returns true + the matching entry when the top hit clears DupScore.
+func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) {
+	top, ok, err := n.TopHit(ctx, inv)
+	if err != nil || !ok {
+		return false, catalog.Entry{}, err
+	}
+	if top.Score >= n.DupScore {
+		return true, top.Entry, nil
+	}
+	return false, catalog.Entry{}, nil
+}
+```
+
+- [ ] **Step 4: Run the curator tests to verify they pass**
+
+Run: `go test ./internal/curator/`
+Expected: PASS — the new `TestTopHit*` tests and all pre-existing `IsDuplicate`/`Novelty` tests (signature unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/curator/fingerprint.go internal/curator/fingerprint_test.go
+git commit -m "refactor(curator): add Novelty.TopHit; IsDuplicate via it"
+```
+
+---
+
+### Task 4: Curator records the dedup score on every `Curate`
+
+**Files:**
+- Modify: `internal/curator/curator.go` (imports `:8-16`; `Curator` struct `:21-27`; `Curate` dedup block `:39-45`)
+- Test: `internal/curator/curator_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/curator/curator_test.go` (and add `"net/http"`, `"net/http/httptest"`, `"strings"`, and `"github.com/Smana/runlore/internal/telemetry"` to its import block):
+
+```go
+func TestCurateDedupScoreNilMetricsSafe(t *testing.T) {
+	// newCurator leaves Metrics nil; recording the dedup score must not panic.
+	c := newCurator(&fakeForge{}, fakeScored{score: 2.0, title: "Some entry"})
+	if _, err := c.Curate(context.Background(), goodFinding()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCurateRecordsDedupScore(t *testing.T) {
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
+	c := newCurator(&fakeForge{}, fakeScored{score: 2.0, title: "Some entry"}) // below DupScore → records, then continues
+	c.Metrics = telemetry.NewMetrics()
+	if _, err := c.Curate(context.Background(), goodFinding()); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "runlore_curation_dedup_score") {
+		t.Fatalf("runlore_curation_dedup_score not found in metrics output:\n%s", rec.Body.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/curator/ -run TestCurate.*DedupScore`
+Expected: FAIL — compile error `c.Metrics undefined` (field not yet added).
+
+- [ ] **Step 3: Add the `Metrics` field and record in `Curate`**
+
+In `internal/curator/curator.go`, add `"github.com/Smana/runlore/internal/telemetry"` to the import block. Add a field to the `Curator` struct (after `Catalog`, `:23`):
+
+```go
+	Metrics       *telemetry.Metrics     // optional; nil-safe — dedup score unrecorded when unset
+```
+
+Replace the catalog-dedup block in `Curate` (`:39-45`, the `if dup, hit, err := (Novelty{...}).IsDuplicate(...)` block) with:
+
+```go
+	// 1. dedup — catalog (observe the top-hit score on every check), then open PRs
+	n := Novelty{Catalog: c.Catalog, DupScore: c.DupScore}
+	if top, ok, err := n.TopHit(ctx, inv); err != nil {
+		c.Log.Warn("dedup: catalog search failed", "err", err)
+	} else if ok {
+		if c.Metrics != nil {
+			c.Metrics.CurationDedupScore.Record(ctx, top.Score)
+		}
+		if top.Score >= c.DupScore {
+			c.Log.Info("finding duplicates a catalog entry; not filing", "entry", top.Entry.Title, "score", top.Score)
+			return providers.Ref{}, nil
+		}
+	}
+```
+
+- [ ] **Step 4: Run the curator tests to verify they pass**
+
+Run: `go test ./internal/curator/`
+Expected: PASS — the two new tests plus all pre-existing curator tests (the catalog-duplicate / catalog-error / drop-silently cases still behave identically).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/curator/curator.go internal/curator/curator_test.go
+git commit -m "feat(curator): record dedup top-hit score on every Curate"
+```
+
+---
+
+### Task 5: Wire `metrics` into the curator at build time
+
+**Files:**
+- Modify: `cmd/lore/main.go` (`buildCurator:698`, struct literal `:721`; call site `:1034`)
+
+- [ ] **Step 1: Thread the metrics handle through `buildCurator`**
+
+In `cmd/lore/main.go`, change the `buildCurator` signature (`:698`) to add a `metrics *telemetry.Metrics` parameter:
+
+```go
+func buildCurator(cfg *config.Config, token forgeToken, cat *catalog.Catalog, metrics *telemetry.Metrics, log *slog.Logger) *curator.Curator {
+```
+
+Update the struct literal (`:721`) to set it:
+
+```go
+	cur := &curator.Curator{Forge: client, DupScore: dup, MinConfidence: minConf, Metrics: metrics, Log: log}
+```
+
+Update the call site (`:1034`, inside `buildInvestigator`, where `metrics` is already in scope) to pass it:
+
+```go
+	cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), cat, metrics, log)
+```
+
+(`telemetry` is already imported in `main.go`.)
+
+- [ ] **Step 2: Build to verify the wiring compiles**
+
+Run: `go build ./...`
+Expected: success, no output. (No new unit test — this is pure wiring; the metric recording itself is covered by Task 4's tests.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/lore/main.go
+git commit -m "feat(curator): pass metrics into the curator at build time"
+```
+
+---
+
+### Task 6: Whole-tree verification
+
+- [ ] **Step 1: Build, test, lint**
+
+Run:
+```bash
+go build ./... && go test ./... && golangci-lint run
+```
+Expected: build clean; all tests PASS; lint clean.
+
+- [ ] **Step 2: Confirm the scorer is genuinely active (manual sanity)**
+
+Run: `go test ./internal/catalog/ -run 'TestNewIndexMappingUsesBM25|TestBuildIndexScores' -v`
+Expected: both PASS — confirms BM25 is set on the shared mapping and scoring works end-to-end.
+
+No commit (verification only).
+
+---
+
+## Notes for the implementer
+
+- **Do not re-tune** `MinScore` / `SoloFloor` / `MarginGap` (`internal/config/load.go:64-71`) or `DupScore` (`cmd/lore/main.go:711-714`, default `5.0`). The scorer flip shifts score magnitudes; re-fitting these floors from the now-correct `recall_score` / `curation_dedup_score` distributions is the **next** slice, deliberately kept separate and reversible (spec §2 D2, §5).
+- The `"bm25"` literal is validated by bleve against `index.SupportedScoringModels`; an unsupported value makes `NewMemOnly` error — which is exactly why `TestBuildIndexScores` doubles as a guard that the model is accepted.
+- The dedup score is recorded on **every** `Curate` call that finds at least one hit (not only when it crosses `DupScore`), so the follow-up sees the full distribution to tune from.

--- a/docs/superpowers/specs/2026-06-23-bm25-scorer-fix-design.md
+++ b/docs/superpowers/specs/2026-06-23-bm25-scorer-fix-design.md
@@ -1,0 +1,97 @@
+# RunLore BM25 Scorer Fix — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Make the catalog index actually run **BM25** (it silently runs legacy TF-IDF), prove it with a test, and add observability for the always-on curator dedup so the score floors can be re-fit from live data in a follow-up. **Re-tuning any floor is explicitly out of scope.** |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | The deep-analysis report (`docs/analysis/2026-06-23-deep-analysis.md`) finding #1 / Slice 1 — corroborated by 3 critique lenses; `internal/catalog/catalog.go`; `internal/investigate/recall.go` (recall floors, opt-in); `internal/curator/curator.go` + `internal/curator/fingerprint.go` (`DupScore`, always-on); `internal/telemetry/metrics.go` (`recall_score` pattern this mirrors); the recall-trustworthiness spec (`2026-06-22-recall-trustworthiness-design.md`) whose "corpus-portable margin" premise depends on the scorer |
+
+---
+
+## 1. Why this exists
+
+The catalog's bleve index is built with a bare default mapping that **never sets `ScoringModel`**, so bleve silently falls back to its legacy **TF-IDF** scorer — while every comment, the `recall_score` metric, the config docs, and the entire "corpus-portable margin" design premise call it **BM25**.
+
+- `internal/catalog/catalog.go:36` (`NewEmpty`) and `:68` (`buildIndex`) both call `bleve.NewMemOnly(bleve.NewIndexMapping())` with no `ScoringModel`.
+- In bleve `v2.6.0` / `bleve_index_api v1.3.11`, `DefaultScoringModel = TFIDFScoring` (`indexing_options.go:37`); `isBM25Enabled` returns true only when `ScoringModel == "bm25"`, so the empty default resolves to TF-IDF at query time (`index_impl.go:714-717`).
+- No test asserts the active scoring model, so the silent fallback was never caught.
+
+This matters because the recall floors (`MinScore`, `SoloFloor`, `MarginGap`) and the curator's `DupScore` are reasoned/tuned against BM25's bounded, length-normalized, term-frequency-saturating scores — but the index produces TF-IDF scores, which have a different distribution. The relative `MarginGap` is partly insulated; the absolute floors are not. **This is the foundational fix that every later retrieval/recall improvement depends on** — you cannot honestly tune a scorer the code does not run.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **First slice = the scorer fix alone** | Smallest, highest-leverage, fully independent; unblocks all retrieval tuning; proves the spec→plan→TDD flow on one safe change. |
+| D2 | **Flip the scorer + add observability; DEFER all re-tuning** | Re-fitting `MinScore`/`SoloFloor`/`MarginGap`/`DupScore` needs the BM25 score distribution from live data. Ship the flip + a way to *see* the new scores now; re-tune in a follow-up so the two concerns are independently revertible. |
+| D3 | **Single source of truth for the mapping** | The bug existed because two index-construction sites drifted. A shared `newIndexMapping()` helper prevents recurrence. |
+| D4 | **Use the literal `"bm25"`, validated by bleve** | bleve validates `ScoringModel` against `SupportedScoringModels` and fails loudly on an unsupported value — no need to import `bleve_index_api` just for the constant. |
+| D5 | **Mirror the existing `recall_score` observability pattern** | A nil-safe `*telemetry.Metrics` + a histogram recorded on every decision is already the house style (`Recall`). Consistency + the full score distribution needed to re-tune. |
+
+## 3. Design
+
+### 3.1 The scorer flip (`internal/catalog/catalog.go`)
+
+Add one unexported helper and route both construction sites through it:
+
+```go
+// newIndexMapping returns the index mapping used everywhere in the catalog. It
+// pins the scoring model to BM25 — bleve defaults to legacy TF-IDF when unset,
+// whose unbounded, non-saturating scores are not corpus-portable.
+func newIndexMapping() *mapping.IndexMappingImpl {
+	im := bleve.NewIndexMapping()
+	im.ScoringModel = "bm25" // validated by bleve against SupportedScoringModels
+	return im
+}
+```
+
+- `NewEmpty` (`:36`) and `buildIndex` (`:68`) both call `bleve.NewMemOnly(newIndexMapping())`.
+- The now-accurate comments at `catalog.go:12,91,107` (and the "BM25" references in `recall.go:18,21,35`, `config.go:120,389`) stay — they become true rather than aspirational. No comment text changes are required beyond confirming accuracy.
+
+### 3.2 Dedup observability (`internal/telemetry/metrics.go`, `internal/curator/curator.go`)
+
+The curator's catalog dedup (`Curate` → `Novelty.IsDuplicate`) is **always on** (wired at `cmd/lore/main.go`), so the scorer flip changes the meaning of `DupScore=5.0` immediately. Make that observable, mirroring `recall_score`:
+
+- **Metric:** add a `CurationDedupScore` histogram to `telemetry.Metrics` ("catalog top-hit relevance score at the curation dedup decision"), constructed alongside `RecallScore`.
+- **Wiring:** add a nil-safe `Metrics *telemetry.Metrics` field to `Curator` (exactly as `Recall` has one); pass the existing `metrics` handle in at the `cmd/lore/main.go` build site.
+- **Record:** in `Curate`, record the **top-hit score on every call** (whether or not it crosses `DupScore`) so the follow-up sees the full distribution — not only the firing tail. Enrich the existing "duplicates a catalog entry" log line (`curator.go:43`) with the score.
+- This requires `Novelty.IsDuplicate` (or a thin variant) to surface the top-hit score even when it does not declare a duplicate; today it returns the hit only on a positive match. The minimal change: have it return the top `ScoredEntry` (and a bool) regardless, and let `Curate` both decide and record.
+
+### 3.3 No behavior change beyond the scorer
+
+Recall (opt-in, off by default), curation dedup *decisions*, and the investigation loop are otherwise untouched. The only default-config behavioral consequence is that the always-on curator dedup now compares BM25 scores against the unchanged `DupScore=5.0` — a known, now-observable shift, with re-tuning deferred to a follow-up.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| `newIndexMapping()` helper; both index sites use it | `internal/catalog/catalog.go` |
+| `TestNewIndexMappingUsesBM25` (the load-bearing guard) + an end-to-end scoring sanity check | `internal/catalog/catalog_test.go` |
+| `CurationDedupScore` histogram (nil-safe instrument) | `internal/telemetry/metrics.go` |
+| Surface the top hit + score from `IsDuplicate` regardless of match | `internal/curator/fingerprint.go` |
+| Nil-safe `Metrics` field; record top-hit dedup score every `Curate`; enrich dup log | `internal/curator/curator.go` |
+| Pass `metrics` into the `Curator` | `cmd/lore/main.go` (build site) |
+| Curator test asserting the score is recorded / logged | `internal/curator/curator_test.go` |
+
+## 5. Trade-offs accepted in v1
+
+- **Floors stay numerically unchanged** — the scorer flip shifts score magnitudes, so the existing `MinScore`/`SoloFloor`/`MarginGap`/`DupScore` are, strictly, mis-calibrated until the follow-up re-fits them from the new `recall_score` / `CurationDedupScore` distributions. Accepted: instant recall is opt-in/off by default (so recall floors affect only opt-in users), and the always-on dedup shift is now *observable*, which is the prerequisite for tuning it. Shipping the flip + observability separately keeps both reversible.
+- **No synthetic-corpus measurement in this slice** — interim BM25 defaults could be derived now, but that adds a fixture and is less reversible. Deferred to the re-tuning follow-up.
+- **`MarginGap` is relative** and therefore largely insulated from the absolute-scale change; the floors most affected are the absolute ones, which the follow-up targets.
+
+## 6. Testing
+
+- **`catalog_test.go`**: `TestNewIndexMappingUsesBM25` asserts `newIndexMapping().ScoringModel == "bm25"` — the **load-bearing regression guard**. Because both index-construction sites (`NewEmpty`, `buildIndex`) are forced through this single helper (D3), asserting the helper guarantees BM25 everywhere. Plus an end-to-end sanity check (`TestBuildIndexScores`): an index built through the helper accepts the BM25 model (bleve validates `ScoringModel` at build time and errors on an unsupported value) and returns ordered, positive scores for a discriminating query. We deliberately do **not** assert score *magnitudes* to distinguish BM25 from TF-IDF — TF-IDF also length-normalizes, so a magnitude-based discriminator is brittle; the direct mapping assertion is the reliable signal.
+- **`curator_test.go`**: a dedup case asserts the top-hit score is recorded to the metric and included in the log line on every `Curate` (firing and non-firing).
+- **Whole tree**: `go build ./...`, `go test ./...`, `golangci-lint run` all green.
+
+## 7. Out of scope (follow-up slices)
+
+- **Re-fitting** `MinScore` / `SoloFloor` / `MarginGap` / `DupScore` from the live BM25 distributions (the immediate follow-up to this slice).
+- Indexing `cause`/`resolution` as weighted fields and `resource`/`namespace` as filterable fields (deep-analysis #3).
+- The structural-agreement pre-filter and widened internal `k` (#3).
+- Phase-2 vectors (chromem-go + RRF).
+
+This slice makes the catalog *run the scorer it claims to run*, and makes the one always-on consumer's behavior *visible* — the cheapest high-leverage fix and the foundation the rest of the retrieval roadmap stands on.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/mapping"
 )
 
 // Catalog is an in-memory BM25 index over OKF entries. It is safe for concurrent
@@ -22,6 +23,15 @@ type Searcher interface {
 	Search(query string, k int) ([]Entry, error)
 }
 
+// newIndexMapping returns the index mapping used by every catalog index. It pins
+// the scoring model to BM25 — bleve defaults to legacy TF-IDF when ScoringModel
+// is unset, whose unbounded, non-saturating scores are not corpus-portable.
+func newIndexMapping() *mapping.IndexMappingImpl {
+	im := bleve.NewIndexMapping()
+	im.ScoringModel = "bm25" // validated by bleve against SupportedScoringModels
+	return im
+}
+
 // New loads the OKF bundle at dir and builds an in-memory index.
 func New(dir string) (*Catalog, error) {
 	c := &Catalog{}
@@ -33,7 +43,7 @@ func New(dir string) (*Catalog, error) {
 
 // NewEmpty returns a catalog with no entries — used before the first git sync.
 func NewEmpty() *Catalog {
-	idx, _ := bleve.NewMemOnly(bleve.NewIndexMapping())
+	idx, _ := bleve.NewMemOnly(newIndexMapping())
 	return &Catalog{index: idx}
 }
 
@@ -65,7 +75,7 @@ func (c *Catalog) Reload(dir string) ([]string, error) {
 }
 
 func buildIndex(entries []Entry) (bleve.Index, error) {
-	idx, err := bleve.NewMemOnly(bleve.NewIndexMapping())
+	idx, err := bleve.NewMemOnly(newIndexMapping())
 	if err != nil {
 		return nil, fmt.Errorf("new index: %w", err)
 	}

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -88,6 +88,42 @@ func TestSearchScored(t *testing.T) {
 	}
 }
 
+func TestNewIndexMappingUsesBM25(t *testing.T) {
+	// bleve defaults to legacy TF-IDF when ScoringModel is unset. Both index
+	// sites are forced through this helper, so asserting it guarantees BM25
+	// everywhere. This is the regression guard for the silent-fallback bug.
+	if got := newIndexMapping().ScoringModel; got != "bm25" {
+		t.Fatalf("ScoringModel = %q, want \"bm25\"", got)
+	}
+}
+
+func TestBuildIndexScores(t *testing.T) {
+	// Proves the BM25 mapping is accepted (NewMemOnly errors on an unsupported
+	// scoring model) and that scoring + ranking work end-to-end. We do NOT assert
+	// magnitudes — TF-IDF also length-normalizes, so magnitude-based BM25-vs-TFIDF
+	// discrimination is brittle; the helper assertion above is the reliable guard.
+	entries := []Entry{
+		{Title: "OOMKilled pod", Body: "container exceeded its memory limit"},
+		{Title: "Image pull failure", Body: "registry returned forbidden"},
+	}
+	idx, err := buildIndex(entries)
+	if err != nil {
+		t.Fatalf("buildIndex: %v", err)
+	}
+	defer func() { _ = idx.Close() }()
+	c := &Catalog{index: idx, entries: entries}
+	hits, err := c.SearchScored("memory limit", 2)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(hits) == 0 || hits[0].Score <= 0 {
+		t.Fatalf("expected a positive-scored hit, got %+v", hits)
+	}
+	if hits[0].Entry.Title != "OOMKilled pod" {
+		t.Fatalf("expected the OOM entry ranked first, got %q", hits[0].Entry.Title)
+	}
+}
+
 func TestEmptyCatalog(t *testing.T) {
 	c := NewEmpty()
 	if c.Len() != 0 {

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
 )
 
 // Curator is the file-time learning gate. It dedups, quality-gates, and drafts a
@@ -21,6 +22,7 @@ import (
 type Curator struct {
 	Forge         providers.CurationForge
 	Catalog       catalog.ScoredSearcher // nil ⇒ no catalog dedup
+	Metrics       *telemetry.Metrics     // optional; nil-safe — dedup score unrecorded when unset
 	DupScore      float64                // catalog BM25 dup threshold
 	MinConfidence float64                // quality gate: minimum overall confidence
 	Log           *slog.Logger
@@ -36,12 +38,18 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 		return providers.Ref{}, nil
 	}
 
-	// 1. dedup — catalog, then open PRs
-	if dup, hit, err := (Novelty{Catalog: c.Catalog, DupScore: c.DupScore}).IsDuplicate(ctx, inv); err != nil {
+	// 1. dedup — catalog (observe the top-hit score on every check), then open PRs
+	nov := Novelty{Catalog: c.Catalog, DupScore: c.DupScore}
+	if top, ok, err := nov.TopHit(ctx, inv); err != nil {
 		c.Log.Warn("dedup: catalog search failed", "err", err)
-	} else if dup {
-		c.Log.Info("finding duplicates a catalog entry; not filing", "entry", hit.Title)
-		return providers.Ref{}, nil
+	} else if ok {
+		if c.Metrics != nil {
+			c.Metrics.CurationDedupScore.Record(ctx, top.Score)
+		}
+		if top.Score >= c.DupScore {
+			c.Log.Info("finding duplicates a catalog entry; not filing", "entry", top.Entry.Title, "score", top.Score)
+			return providers.Ref{}, nil
+		}
 	}
 	if n, ok, err := c.duplicateOpenPR(ctx, inv); err != nil {
 		c.Log.Warn("dedup: list open PRs failed", "err", err)

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
@@ -147,6 +150,7 @@ func TestCurateRecordsDedupScore(t *testing.T) {
 		t.Fatalf("telemetry setup: %v", err)
 	}
 	defer func() { _ = shutdown(context.Background()) }()
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
 
 	c := newCurator(&fakeForge{}, fakeScored{score: 2.0, title: "Some entry"}) // below DupScore → records, then continues
 	c.Metrics = telemetry.NewMetrics()

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
 )
 
 // fakeForge records OpenPR / Comment calls and serves a fixed open-PR list.
@@ -126,5 +130,34 @@ func TestCurateSkipsRecalled(t *testing.T) {
 	}
 	if f.openedPR != nil || ref.URL != "" {
 		t.Fatalf("a recalled finding must not be curated, got pr=%+v ref=%s", f.openedPR, ref.URL)
+	}
+}
+
+func TestCurateDedupScoreNilMetricsSafe(t *testing.T) {
+	// newCurator leaves Metrics nil; recording the dedup score must not panic.
+	c := newCurator(&fakeForge{}, fakeScored{score: 2.0, title: "Some entry"})
+	if _, err := c.Curate(context.Background(), goodFinding()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCurateRecordsDedupScore(t *testing.T) {
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
+	c := newCurator(&fakeForge{}, fakeScored{score: 2.0, title: "Some entry"}) // below DupScore → records, then continues
+	c.Metrics = telemetry.NewMetrics()
+	if _, err := c.Curate(context.Background(), goodFinding()); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), "runlore_curation_dedup_score") {
+		t.Fatalf("runlore_curation_dedup_score not found in metrics output:\n%s", rec.Body.String())
 	}
 }

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -31,18 +31,33 @@ type Novelty struct {
 	DupScore float64                // top-hit BM25 score ≥ this ⇒ duplicate
 }
 
-// IsDuplicate returns true + the matching entry when the catalog already covers
-// this finding.
-func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) { //nolint:revive // ctx kept for future remote-index symmetry
+// TopHit returns the highest-scoring catalog entry for a finding's fingerprint.
+// ok is false when no catalog is configured or there are no hits. It surfaces the
+// score regardless of any threshold, so callers can both observe it and decide.
+func (n Novelty) TopHit(ctx context.Context, inv providers.Investigation) (catalog.ScoredEntry, bool, error) { //nolint:revive // ctx kept for future remote-index symmetry
 	if n.Catalog == nil {
-		return false, catalog.Entry{}, nil
+		return catalog.ScoredEntry{}, false, nil
 	}
 	hits, err := n.Catalog.SearchScored(Fingerprint(inv), 1)
 	if err != nil {
+		return catalog.ScoredEntry{}, false, err
+	}
+	if len(hits) == 0 {
+		return catalog.ScoredEntry{}, false, nil
+	}
+	return hits[0], true, nil
+}
+
+// IsDuplicate returns true and the matching entry when the top hit's score is
+// ≥ DupScore. Returns false (novel) when no catalog is configured, there are no
+// hits, or the top score falls below the threshold.
+func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) {
+	top, ok, err := n.TopHit(ctx, inv)
+	if err != nil || !ok {
 		return false, catalog.Entry{}, err
 	}
-	if len(hits) > 0 && hits[0].Score >= n.DupScore {
-		return true, hits[0].Entry, nil
+	if top.Score >= n.DupScore {
+		return true, top.Entry, nil
 	}
 	return false, catalog.Entry{}, nil
 }

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -2,6 +2,7 @@ package curator
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -66,5 +67,33 @@ func TestNoveltyNilCatalogIsNovel(t *testing.T) {
 	dup, _, err := n.IsDuplicate(context.Background(), providers.Investigation{Title: "x"})
 	if err != nil || dup {
 		t.Fatalf("nil catalog must be novel, got dup=%v err=%v", dup, err)
+	}
+}
+
+func TestTopHitReturnsScore(t *testing.T) {
+	// TopHit surfaces the top hit + score regardless of the DupScore threshold,
+	// so the caller can both observe the score and apply the threshold itself.
+	n := Novelty{Catalog: fakeScored{score: 2.0, title: "Below threshold"}, DupScore: 5.0}
+	top, ok, err := n.TopHit(context.Background(), providers.Investigation{Title: "x"})
+	if err != nil || !ok {
+		t.Fatalf("want a hit, got ok=%v err=%v", ok, err)
+	}
+	if top.Score != 2.0 || top.Entry.Title != "Below threshold" {
+		t.Fatalf("unexpected top hit %+v", top)
+	}
+}
+
+func TestTopHitNilCatalog(t *testing.T) {
+	_, ok, err := Novelty{Catalog: nil}.TopHit(context.Background(), providers.Investigation{Title: "x"})
+	if ok || err != nil {
+		t.Fatalf("nil catalog: want ok=false err=nil, got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestTopHitSearchError(t *testing.T) {
+	n := Novelty{Catalog: fakeScored{err: errors.New("index unavailable")}}
+	_, ok, err := n.TopHit(context.Background(), providers.Investigation{Title: "x"})
+	if ok || err == nil {
+		t.Fatalf("want ok=false and a non-nil error, got ok=%v err=%v", ok, err)
 	}
 }

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -26,6 +26,7 @@ type Metrics struct {
 	CoalesceBatchSize         metric.Int64Histogram
 	InvestigationTokens       metric.Int64Histogram
 	RecallScore               metric.Float64Histogram // BM25 score at the recall decision (tunes min_score)
+	CurationDedupScore        metric.Float64Histogram // catalog top-hit BM25 score at the curation dedup decision
 	OutcomesOpened            metric.Int64Counter     // investigations recorded as open (label: kind)
 	IncidentsResolved         metric.Int64Counter     // resolve events that matched an open investigation
 	RecallOutcome             metric.Int64Counter     // resolved incidents whose open was a recall (label: result)
@@ -61,6 +62,7 @@ func NewMetrics() *Metrics {
 		CoalesceBatchSize:         hist("coalesce_batch_size", "incidents per flushed batch"),
 		InvestigationTokens:       hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),
 		RecallScore:               histF("recall_score", "BM25 score at the recall decision point"),
+		CurationDedupScore:        histF("curation_dedup_score", "catalog top-hit BM25 score at the curation dedup decision"),
 		OutcomesOpened:            ctr("outcomes_opened_total", "investigations recorded in the outcome ledger (label: kind)"),
 		IncidentsResolved:         ctr("incidents_resolved_total", "resolve events that matched an open investigation"),
 		RecallOutcome:             ctr("recall_outcome_total", "resolved incidents whose answer was a recall (label: result)"),

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -26,3 +26,11 @@ func TestNewMetricsOutcomeInstruments(_ *testing.T) {
 	m.RecallOutcome.Add(ctx, 1)
 	m.IncidentResolutionSeconds.Record(ctx, 90)
 }
+
+func TestNewMetricsCurationInstruments(_ *testing.T) {
+	// With no provider configured the global meter is a no-op; the instrument must
+	// still construct and be safe to record.
+	m := NewMetrics()
+	ctx := context.Background()
+	m.CurationDedupScore.Record(ctx, 4.2)
+}


### PR DESCRIPTION
## Summary

The catalog's bleve index **silently ran legacy TF-IDF**, not BM25: `internal/catalog/catalog.go` never set `ScoringModel`, while every comment, metric, and threshold called it "BM25" — so the recall/dedup floors
were tuned against a scorer the code wasn't running (deep-analysis finding #1).

This slice:
- **Pins the index to BM25** via a single shared `newIndexMapping()` helper used by both `NewEmpty` and `buildIndex`, so the two sites can't drift again.
- **Adds observability for the always-on curator dedup**: a `curation_dedup_score` histogram (mirroring `recall_score`), recorded on **every** `Curate` via a nil-safe `Metrics` field and a new `Novelty.TopHit`
accessor.
- **Defers all numeric re-tuning** (`MinScore`/`SoloFloor`/`MarginGap`/`DupScore`) to a follow-up — flipping the scorer shifts magnitudes; shipping flip + observability separately keeps both reversible.

Spec: `docs/superpowers/specs/2026-06-23-bm25-scorer-fix-design.md` · Plan: `docs/superpowers/plans/2026-06-23-bm25-scorer-fix.md`

## Test Plan
- [x] `go build ./...`, `go test ./...`, `go vet ./...` all clean
- [x] `TestNewIndexMappingUsesBM25` (regression guard) + `TestBuildIndexScores`
- [x] `TestCurateRecordsDedupScore` scrapes `/metrics` for `runlore_curation_dedup_score`
- [ ] CI green