### PR TITLE
feat(outcome): Episodes()/OpenCounts() ledger read API (learning-loop A1→A2 seam)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-outcome-episodes.md
+++ b/docs/superpowers/plans/2026-06-23-outcome-episodes.md
@@ -1,0 +1,478 @@
+# Outcome Episodes Read API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a read-only API over the append-only outcome ledger — `Episodes()` (recurrence-aware replay) and a per-entry `OpenCounts()` aggregate — the A1→A2 seam the recall-decay edge will consume.
+
+**Architecture:** All changes live in `internal/outcome/ledger.go`. A factored `readEvents()` helper replays the JSONL (reused by `New()`); `Episodes()` reconstructs every open into an `Episode`, LIFO-pairing resolves so recurrence is preserved; `OpenCounts()` rolls recall episodes up per entry. Pure addition — `Open`/`Resolve` recording is unchanged (only a behavior-preserving `Resolved bool` is added to `Episode`).
+
+**Tech Stack:** Go 1.26, stdlib only (`bufio`/`encoding/json`/`os`/`sync`/`time`), stdlib `testing` (no testify). Tests follow `internal/outcome/ledger_test.go` (`t.TempDir()`, `time.Unix`).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-outcome-episodes-design.md`
+
+**Branch:** `feat/outcome-episodes` (already checked out; the spec is already committed there).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/outcome/ledger.go` | Ledger types + record + read API | Add `readEvents()`; refactor `New()` to use it; add `Resolved bool` to `Episode` (+ set in `Resolve()`); add `Episodes()`; add `Aggregate` + `OpenCounts()` |
+| `internal/outcome/ledger_test.go` | Ledger tests | Add tests for each of the above |
+
+Task order: Task 1 (`readEvents` + `New` refactor) → Task 2 (`Resolved` field) → Task 3 (`Episodes`, needs 1+2) → Task 4 (`OpenCounts`, needs 3). No imports change in either file.
+
+---
+
+### Task 1: Factor `readEvents()` and refactor `New()` through it
+
+**Files:**
+- Modify: `internal/outcome/ledger.go` (`New` at `:45-73`)
+- Test: `internal/outcome/ledger_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/outcome/ledger_test.go`:
+
+```go
+func TestReadEventsReturnsAllInOrder(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(3000, 0)
+	_ = l.Open(Event{Fingerprint: "a", Kind: "fresh", At: t0})
+	_ = l.Open(Event{Fingerprint: "b", Kind: "recall", Entry: "x.md", At: t0.Add(time.Second)})
+	_, _, _ = l.Resolve("a", t0.Add(2*time.Second))
+	events, err := l.readEvents()
+	if err != nil {
+		t.Fatalf("readEvents: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("want 3 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Event != "open" || events[0].Fingerprint != "a" {
+		t.Fatalf("event[0] = %+v", events[0])
+	}
+	if events[2].Event != "resolve" || events[2].Fingerprint != "a" {
+		t.Fatalf("event[2] = %+v", events[2])
+	}
+}
+
+func TestReadEventsDisabledOrAbsent(t *testing.T) {
+	dis, _ := New("")
+	if ev, err := dis.readEvents(); err != nil || ev != nil {
+		t.Fatalf("disabled: want nil,nil; got %v,%v", ev, err)
+	}
+	absent, _ := New(filepath.Join(t.TempDir(), "missing.jsonl"))
+	if ev, err := absent.readEvents(); err != nil || ev != nil {
+		t.Fatalf("absent file: want nil,nil; got %v,%v", ev, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/outcome/ -run TestReadEvents`
+Expected: FAIL — compile error `l.readEvents undefined`.
+
+- [ ] **Step 3: Add `readEvents()` and refactor `New()`**
+
+In `internal/outcome/ledger.go`, replace the entire `New` function (`:45-73`) with the refactored `New` plus the new helper:
+
+```go
+// New opens (replaying) the ledger at path. An empty path returns a disabled,
+// no-op ledger (the feature is off).
+func New(path string) (*Ledger, error) {
+	l := &Ledger{path: path, open: map[string]Event{}}
+	events, err := l.readEvents()
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range events {
+		switch e.Event {
+		case "open":
+			l.open[e.Fingerprint] = e
+		case "resolve":
+			delete(l.open, e.Fingerprint)
+		}
+	}
+	return l, nil
+}
+
+// readEvents replays the ledger file in order, skipping corrupt lines. It returns
+// an empty slice when the ledger is disabled (path=="") or the file is absent.
+func (l *Ledger) readEvents() ([]Event, error) {
+	if l.path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(l.path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var events []Event
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) != nil {
+			continue // skip a corrupt line rather than fail
+		}
+		events = append(events, e)
+	}
+	return events, sc.Err()
+}
+```
+
+(No import changes: `bufio`/`encoding/json`/`errors`/`io/fs`/`os` are all still used by `readEvents`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/outcome/`
+Expected: PASS — the two new tests AND all pre-existing ledger tests (`New` behavior is unchanged: disabled/absent → empty open-index, corrupt lines skipped, real open error propagated).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/outcome/ledger.go internal/outcome/ledger_test.go
+git commit -m "refactor(outcome): factor readEvents; New replays via it"
+```
+
+---
+
+### Task 2: Add `Resolved bool` to `Episode`
+
+**Files:**
+- Modify: `internal/outcome/ledger.go` (`Episode` at `:30-34`; `Resolve` return at `:122-125`)
+- Test: `internal/outcome/ledger_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/outcome/ledger_test.go`:
+
+```go
+func TestResolveMarksEpisodeResolved(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(4000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", At: t0})
+	ep, ok, err := l.Resolve("fp", t0.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("Resolve: ok=%v err=%v", ok, err)
+	}
+	if !ep.Resolved {
+		t.Fatalf("a matched resolve must set Resolved=true: %+v", ep)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/outcome/ -run TestResolveMarksEpisodeResolved`
+Expected: FAIL — compile error `ep.Resolved undefined`.
+
+- [ ] **Step 3: Add the field and set it in `Resolve()`**
+
+In `internal/outcome/ledger.go`, change the `Episode` struct (`:30-34`) to add the field:
+
+```go
+// Episode is a matched open→resolve pair (or, from Episodes(), an unresolved open
+// when Resolved is false).
+type Episode struct {
+	Kind, Entry, Title, Resource string
+	OpenedAt, ResolvedAt         time.Time
+	Duration                     time.Duration
+	Resolved                     bool
+}
+```
+
+In `Resolve()`, change the returned `Episode` literal (`:122-125`) to set `Resolved: true`:
+
+```go
+	return Episode{
+		Kind: o.Kind, Entry: o.Entry, Title: o.Title, Resource: o.Resource,
+		OpenedAt: o.At, ResolvedAt: at, Duration: at.Sub(o.At), Resolved: true,
+	}, true, nil
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/outcome/`
+Expected: PASS — the new test plus all pre-existing tests (adding a field + setting it is behavior-preserving; no existing test asserts `Resolved`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/outcome/ledger.go internal/outcome/ledger_test.go
+git commit -m "feat(outcome): add Resolved flag to Episode"
+```
+
+---
+
+### Task 3: `Episodes()` — recurrence-aware replay
+
+**Files:**
+- Modify: `internal/outcome/ledger.go` (add `Episodes` method)
+- Test: `internal/outcome/ledger_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/outcome/ledger_test.go`:
+
+```go
+func TestEpisodesReconstructsRecurrence(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(5000, 0)
+	for i := 0; i < 3; i++ {
+		_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0.Add(time.Duration(i) * time.Second)})
+	}
+	_, _, _ = l.Resolve("fp", t0.Add(10*time.Second))
+	eps, err := l.Episodes()
+	if err != nil {
+		t.Fatalf("Episodes: %v", err)
+	}
+	if len(eps) != 3 {
+		t.Fatalf("want 3 episodes (recurrence preserved), got %d", len(eps))
+	}
+	resolved := 0
+	for _, e := range eps {
+		if e.Resolved {
+			resolved++
+		}
+	}
+	if resolved != 1 {
+		t.Fatalf("want exactly 1 resolved episode, got %d", resolved)
+	}
+}
+
+func TestEpisodesResolvedPairingAndDuration(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(6000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "first.md", At: t0})
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "second.md", At: t0.Add(time.Second)})
+	_, _, _ = l.Resolve("fp", t0.Add(5*time.Second))
+	eps, _ := l.Episodes()
+	var second Episode
+	for _, e := range eps {
+		if e.Entry == "first.md" && e.Resolved {
+			t.Fatal("LIFO: the earlier open must remain unresolved")
+		}
+		if e.Entry == "second.md" {
+			second = e
+		}
+	}
+	if !second.Resolved || second.Duration != 4*time.Second {
+		t.Fatalf("most-recent open should resolve with 4s duration: %+v", second)
+	}
+}
+
+func TestEpisodesEmptyAndDisabled(t *testing.T) {
+	dis, _ := New("")
+	if eps, err := dis.Episodes(); err != nil || eps != nil {
+		t.Fatalf("disabled: want nil,nil; got %v,%v", eps, err)
+	}
+	empty, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	if eps, err := empty.Episodes(); err != nil || len(eps) != 0 {
+		t.Fatalf("empty ledger: want 0 episodes; got %v,%v", eps, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/outcome/ -run TestEpisodes`
+Expected: FAIL — compile error `l.Episodes undefined`.
+
+- [ ] **Step 3: Implement `Episodes()`**
+
+In `internal/outcome/ledger.go`, add (after `Resolve`):
+
+```go
+// Episodes replays the full ledger and turns every open into an Episode, pairing
+// each resolve with the most-recent (LIFO) unresolved open for the same
+// fingerprint — so recurrence is preserved (N opens + 1 resolve ⇒ N episodes, 1
+// resolved). Episodes are returned in open order; all kinds are included. A
+// disabled/empty ledger yields nil.
+func (l *Ledger) Episodes() ([]Episode, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	events, err := l.readEvents()
+	if err != nil {
+		return nil, err
+	}
+	var out []Episode
+	pending := map[string][]int{} // fingerprint → stack of indices into out
+	for _, e := range events {
+		switch e.Event {
+		case "open":
+			out = append(out, Episode{
+				Kind: e.Kind, Entry: e.Entry, Title: e.Title, Resource: e.Resource,
+				OpenedAt: e.At,
+			})
+			pending[e.Fingerprint] = append(pending[e.Fingerprint], len(out)-1)
+		case "resolve":
+			stack := pending[e.Fingerprint]
+			if len(stack) == 0 {
+				continue // a resolve with no pending open (mirrors live ok=false)
+			}
+			i := stack[len(stack)-1]
+			pending[e.Fingerprint] = stack[:len(stack)-1]
+			out[i].ResolvedAt = e.At
+			out[i].Duration = e.At.Sub(out[i].OpenedAt)
+			out[i].Resolved = true
+		}
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/outcome/`
+Expected: PASS — the three new tests plus all pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/outcome/ledger.go internal/outcome/ledger_test.go
+git commit -m "feat(outcome): Episodes() reconstructs open->resolve history"
+```
+
+---
+
+### Task 4: `OpenCounts()` — per-entry aggregate
+
+**Files:**
+- Modify: `internal/outcome/ledger.go` (add `Aggregate` type + `OpenCounts` method)
+- Test: `internal/outcome/ledger_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/outcome/ledger_test.go`:
+
+```go
+func TestOpenCountsAggregatesRecallEntries(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(7000, 0)
+	for i := 0; i < 3; i++ {
+		_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0.Add(time.Duration(i) * time.Second)})
+	}
+	resolveAt := t0.Add(10 * time.Second)
+	_, _, _ = l.Resolve("fp", resolveAt)
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	a := counts["x.md"]
+	if a.Recalls != 3 || a.Resolved != 1 {
+		t.Fatalf("want recalls=3 resolved=1, got %+v", a)
+	}
+	if !a.LastConfirmed.Equal(resolveAt) {
+		t.Fatalf("LastConfirmed = %v, want %v", a.LastConfirmed, resolveAt)
+	}
+}
+
+func TestOpenCountsSkipsFresh(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(8000, 0)
+	_ = l.Open(Event{Fingerprint: "f1", Kind: "fresh", At: t0}) // fresh → no entry
+	_, _, _ = l.Resolve("f1", t0.Add(time.Minute))
+	counts, _ := l.OpenCounts()
+	if len(counts) != 0 {
+		t.Fatalf("fresh opens must not appear in OpenCounts, got %+v", counts)
+	}
+}
+
+func TestOpenCountsEmptyMapWhenDisabled(t *testing.T) {
+	dis, _ := New("")
+	counts, err := dis.OpenCounts()
+	if err != nil || counts == nil || len(counts) != 0 {
+		t.Fatalf("disabled: want empty non-nil map; got %v,%v", counts, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/outcome/ -run TestOpenCounts`
+Expected: FAIL — compile error `l.OpenCounts undefined` (and `Aggregate` undefined).
+
+- [ ] **Step 3: Implement `Aggregate` + `OpenCounts()`**
+
+In `internal/outcome/ledger.go`, add (after `Episodes`):
+
+```go
+// Aggregate is a per-entry roll-up of recall episodes: how often the entry was
+// recalled, how often the incident then resolved, and when it last resolved.
+type Aggregate struct {
+	Recalls       int
+	Resolved      int
+	LastConfirmed time.Time
+}
+
+// OpenCounts rolls Episodes up per catalog entry, counting recall episodes only
+// (fresh investigations carry no entry). It is the input to recall decay:
+// resolve-rate ≈ (Resolved+1)/(Recalls+2). A disabled/empty ledger yields an
+// empty (non-nil) map.
+func (l *Ledger) OpenCounts() (map[string]Aggregate, error) {
+	eps, err := l.Episodes()
+	if err != nil {
+		return nil, err
+	}
+	counts := map[string]Aggregate{}
+	for _, e := range eps {
+		if e.Kind != "recall" || e.Entry == "" {
+			continue
+		}
+		a := counts[e.Entry]
+		a.Recalls++
+		if e.Resolved {
+			a.Resolved++
+			if e.ResolvedAt.After(a.LastConfirmed) {
+				a.LastConfirmed = e.ResolvedAt
+			}
+		}
+		counts[e.Entry] = a
+	}
+	return counts, nil
+}
+```
+
+(Note: `OpenCounts` does NOT take `l.mu` itself — `Episodes()` already locks, and `sync.Mutex` is not reentrant.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/outcome/`
+Expected: PASS — the three new tests plus all pre-existing tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/outcome/ledger.go internal/outcome/ledger_test.go
+git commit -m "feat(outcome): OpenCounts() per-entry recall/resolved aggregate"
+```
+
+---
+
+### Task 5: Whole-package verification
+
+- [ ] **Step 1: Build, test, vet**
+
+Run:
+```bash
+go build ./... && go test ./internal/outcome/ -count=1 -v && go vet ./internal/outcome/
+```
+Expected: build clean; every test PASS (old + new); vet clean.
+
+No commit (verification only).
+
+---
+
+## Notes for the implementer
+
+- This is a **read-only** addition. Do not change `Open`/`Resolve` recording semantics beyond setting the new `Resolved` flag in the episode `Resolve()` already returns.
+- LIFO pairing is intentional — it mirrors how the live `Resolve()` matches the *latest* open for a fingerprint. Recurrence counts (`Recalls`/`Resolved`) are independent of pairing order; only *which* episode is marked resolved differs.
+- Do not wire `OpenCounts()` into `deriveRecallConfidence`, add `expired`/`link` events, a `RecurrenceStore`, or metrics — all deferred to later slices (spec §7).
+- Keep everything in `internal/outcome/ledger.go`; do not touch other packages.

--- a/docs/superpowers/specs/2026-06-23-outcome-episodes-design.md
+++ b/docs/superpowers/specs/2026-06-23-outcome-episodes-design.md
@@ -1,0 +1,109 @@
+# RunLore Outcome Episodes Read API — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Add a read-only API over the append-only outcome ledger that reconstructs open→resolve **episodes** (recurrence-aware) and rolls them up **per catalog entry** — the A1→A2 seam the recall-decay edge will consume. Pure addition; no behavior change to `Open`/`Resolve`. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | Deep-analysis report (`docs/analysis/2026-06-23-deep-analysis.md`) Slice 3 / roadmap #8; the outcome-capture spec (`2026-06-23-outcome-capture-design.md`, which named `Episodes()` at §3.1 but left it unimplemented); `internal/outcome/ledger.go`; downstream consumer #9 (bias `deriveRecallConfidence` by resolve-rate) and #10/#12 (TTL/recurrence) |
+
+---
+
+## 1. Why this exists
+
+A1 (outcome capture) records `open`/`resolve` events in an append-only JSONL ledger, but **nothing reads the history**: the in-memory `open` map is lossy by design (it keeps only the latest open per fingerprint, `ledger.go:67,102`), and `Episodes()` — named in the outcome-capture spec (§3.1) as the A2 reader — was never implemented. So the learning loop cannot yet compute the signal it needs: *for a recalled catalog entry, how often did the incident actually resolve?* This slice adds that read API. It is the prerequisite for the make-or-break decay edge (#9): an entry that recalls-but-never-resolves must be demotable, and that requires per-entry `recalls`/`resolved` counts derived from the full ledger history.
+
+This is **pure read plumbing** — it does not change recording, does not wire decay, and emits no metrics. It unblocks #9 without prematurely committing to its policy.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | Expose **both** `Episodes()` (recurrence-aware raw list) **and** `OpenCounts()` (per-entry aggregate) | `OpenCounts` is exactly what #9 consumes; `Episodes` is the raw material future consumers (#10 recurrence, A2 frontmatter surfacing) need. Matches the spec's named seam and the roadmap's test names. |
+| D2 | `Episodes()` **replays the full JSONL**, not the in-memory `open` map | The in-memory map is lossy (latest-only); the append-only file is the complete history — the only source that preserves recurrence (multiple opens per fingerprint). |
+| D3 | **LIFO** resolve-pairing | The live `Resolve` matches the latest open for a fingerprint (the overwriting map); reconstruction pops the most-recent unresolved open to mirror that attribution. Aggregate counts are pairing-order-independent regardless. |
+| D4 | `OpenCounts()` keys on **entry path**, counts **recall** episodes only | #9 decays *per-entry recall confidence*; fresh opens carry no entry (`Entry == ""`) and are skipped. |
+| D5 | **Drop `expired_count`** from the aggregate for now | No `expired`/TTL events exist yet (that is slice #10). The unresolved-episode count (`Recalls > Resolved`) already gives the negative signal #9 needs. |
+| D6 | Add an explicit `Resolved bool` to `Episode` | Cleaner for consumers than inferring from a zero `ResolvedAt`; the existing `Resolve()` (which only ever returns a matched pair) sets it `true` — a behavior-preserving one-liner. |
+
+## 3. Design
+
+### 3.1 `readEvents()` helper (DRY)
+
+Factor the JSONL scan currently inlined in `New()` (`ledger.go:58-72`) into:
+
+```go
+// readEvents replays the ledger file in order, skipping corrupt lines. Returns an
+// empty slice for a disabled (path=="") or absent file.
+func (l *Ledger) readEvents() ([]Event, error)
+```
+
+`New()` is refactored to build its open-index from `readEvents()`; `Episodes()` reconstructs from the same source. Same buffered-scanner config and corrupt-line tolerance as today.
+
+### 3.2 `Episodes() []Episode`
+
+```go
+func (l *Ledger) Episodes() ([]Episode, error)
+```
+
+- Disabled/empty → `(nil, nil)`.
+- Under `l.mu` (consistent snapshot vs concurrent appends; not hot-path), `readEvents()` then reconstruct, accumulating into `out []Episode`:
+  - `pending := map[string][]int{}` — per-fingerprint stack of **indices into `out`** for still-unresolved opens.
+  - `open` → build an `Episode` from the event (`Kind`, `Entry`, `Title`, `Resource`, `OpenedAt = e.At`, `Resolved=false`), append it to `out`, and push its index (`len(out)-1`) onto `pending[fp]`.
+  - `resolve` → pop the most-recent (LIFO) index from `pending[fp]`, if any, and mutate that `out[i]` in place: `ResolvedAt = e.At`, `Duration = e.At − out[i].OpenedAt`, `Resolved = true`. A resolve with no pending open is ignored (mirrors live `ok=false`).
+- Result preserves open-order; all kinds (recall **and** fresh) included. **3 opens + 1 resolve for one fingerprint ⇒ 3 episodes, exactly 1 `Resolved`.**
+
+`Episode` gains `Resolved bool` (added to the struct at `ledger.go:30-34`); `Resolve()` sets `Resolved: true` in the episode it returns.
+
+### 3.3 `OpenCounts() map[string]Aggregate`
+
+```go
+type Aggregate struct {
+	Recalls       int       // recall episodes for this entry
+	Resolved      int       // of those, how many resolved
+	LastConfirmed time.Time // latest ResolvedAt among them (zero if none)
+}
+
+func (l *Ledger) OpenCounts() (map[string]Aggregate, error)
+```
+
+- Derived from `Episodes()` (single source of truth): iterate, skip episodes with empty `Entry` or non-recall `Kind`, and for each `Entry` accumulate `Recalls++`, `Resolved++` when resolved, and `LastConfirmed = max(LastConfirmed, ResolvedAt)`.
+- Disabled/empty → empty (non-nil) map.
+- This is #9's direct input: smoothed resolve-rate `(Resolved+1)/(Recalls+2)`; `Recalls > Resolved` is the decay signal.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| `readEvents()` helper; `New()` refactored to use it | `internal/outcome/ledger.go` |
+| `Resolved bool` on `Episode`; `Resolve()` sets it `true` | `internal/outcome/ledger.go` |
+| `Episodes()` (replay + LIFO reconstruction) | `internal/outcome/ledger.go` |
+| `Aggregate` type + `OpenCounts()` | `internal/outcome/ledger.go` |
+| Tests | `internal/outcome/ledger_test.go` |
+
+## 5. Trade-offs accepted in v1
+
+- **Replay cost per call** — `Episodes()`/`OpenCounts()` re-read the whole file each call. Acceptable: these are analysis/decision-time calls (a recall decision or a periodic decay pass), not the alert hot-path, and the ledger is bounded by incident volume. Caching/compaction is a later concern.
+- **No fresh→entry attribution** — fresh opens (`Entry == ""`) don't contribute to `OpenCounts`; only recall episodes do. The `link` event that would credit a fresh investigation's eventual curated entry is a deferred write-path change (roadmap #10), not this read API.
+- **No `expired` signal** — unresolved episodes are represented (a recall episode with `Resolved=false`), which suffices for resolve-rate. An explicit `expired` terminal state waits for the TTL sweep (#10).
+- **Mutex held during file read** — briefly blocks appends. Acceptable given the call frequency; avoids a torn read against a concurrent append.
+
+## 6. Testing
+
+- `TestEpisodesReconstructsRecurrence`: 3 `open` (same fingerprint, `kind=recall`, `entry="x.md"`) then 1 `resolve` → `Episodes()` returns 3 episodes for the fingerprint with exactly 1 `Resolved`; `OpenCounts()["x.md"]` = `{Recalls:3, Resolved:1, LastConfirmed:<resolve time>}`.
+- `TestEpisodesResolvedPairingAndDuration`: one `open`+`resolve` → 1 resolved episode with the correct `Duration`; with two opens before one resolve, the **most-recent** open is the resolved one (LIFO).
+- `TestOpenCountsSkipsFresh`: `kind=fresh` opens (empty `Entry`) do not appear in `OpenCounts()`.
+- `TestEpisodesEmptyAndDisabled`: a disabled ledger (`path==""`) and a fresh empty file → `Episodes()` `nil`, `OpenCounts()` empty non-nil map, no error.
+- `TestEpisodesRoundTrip`: events written via `Open`/`Resolve` are reproduced by `Episodes()` (counts + kinds + durations).
+- Existing `ledger_test.go` tests must still pass unchanged (the `Resolved` field addition is behavior-preserving).
+
+## 7. Out of scope (later slices)
+
+- Wiring `OpenCounts()` into `deriveRecallConfidence` (the decay edge, #9) — the make-or-break, next.
+- The `link` event for fresh→curated-entry attribution + coalesce/race/TTL fixes (#10).
+- A ledger-backed `RecurrenceStore` for the dormant curate Recurrence pass (#12).
+- Metrics for the read API (added when #9 consumes it).
+- Ledger compaction / bounding growth.
+
+This slice makes the ledger's history *readable* — turning "the absence of a resolve line" into a queryable per-entry `recalls`/`resolved` fact — without yet acting on it.

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -119,6 +119,46 @@ func (l *Ledger) Open(e Event) error {
 	return nil
 }
 
+// Episodes replays the full ledger and turns every open into an Episode, pairing
+// each resolve with the most-recent (LIFO) unresolved open for the same
+// fingerprint — so recurrence is preserved (N opens + 1 resolve ⇒ N episodes, 1
+// resolved). Episodes are returned in open order; all kinds are included. A
+// disabled/empty ledger yields nil.
+func (l *Ledger) Episodes() ([]Episode, error) {
+	if !l.enabled() {
+		return nil, nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	events, err := l.readEvents()
+	if err != nil {
+		return nil, err
+	}
+	var out []Episode
+	pending := map[string][]int{} // fingerprint → stack of indices into out
+	for _, e := range events {
+		switch e.Event {
+		case "open":
+			out = append(out, Episode{
+				Kind: e.Kind, Entry: e.Entry, Title: e.Title, Resource: e.Resource,
+				OpenedAt: e.At,
+			})
+			pending[e.Fingerprint] = append(pending[e.Fingerprint], len(out)-1)
+		case "resolve":
+			stack := pending[e.Fingerprint]
+			if len(stack) == 0 {
+				continue // a resolve with no pending open (mirrors live ok=false)
+			}
+			i := stack[len(stack)-1]
+			pending[e.Fingerprint] = stack[:len(stack)-1]
+			out[i].ResolvedAt = e.At
+			out[i].Duration = e.At.Sub(out[i].OpenedAt)
+			out[i].Resolved = true
+		}
+	}
+	return out, nil
+}
+
 // Resolve records that an incident's alert cleared. When it matches an open
 // investigation it returns the Episode (with duration + kind) and ok=true.
 func (l *Ledger) Resolve(fp string, at time.Time) (Episode, bool, error) {

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -44,24 +44,11 @@ type Ledger struct {
 // no-op ledger (the feature is off).
 func New(path string) (*Ledger, error) {
 	l := &Ledger{path: path, open: map[string]Event{}}
-	if path == "" {
-		return l, nil
-	}
-	f, err := os.Open(path)
-	if errors.Is(err, fs.ErrNotExist) {
-		return l, nil
-	}
+	events, err := l.readEvents()
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = f.Close() }()
-	sc := bufio.NewScanner(f)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for sc.Scan() {
-		var e Event
-		if json.Unmarshal(sc.Bytes(), &e) != nil {
-			continue // skip a corrupt line rather than fail startup
-		}
+	for _, e := range events {
 		switch e.Event {
 		case "open":
 			l.open[e.Fingerprint] = e
@@ -69,7 +56,34 @@ func New(path string) (*Ledger, error) {
 			delete(l.open, e.Fingerprint)
 		}
 	}
-	return l, sc.Err()
+	return l, nil
+}
+
+// readEvents replays the ledger file in order, skipping corrupt lines. It returns
+// a nil slice when the ledger is disabled (path=="") or the file is absent.
+func (l *Ledger) readEvents() ([]Event, error) {
+	if l.path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(l.path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var events []Event
+	for sc.Scan() {
+		var e Event
+		if json.Unmarshal(sc.Bytes(), &e) != nil {
+			continue // skip a corrupt line rather than fail
+		}
+		events = append(events, e)
+	}
+	return events, sc.Err()
 }
 
 func (l *Ledger) enabled() bool { return l != nil && l.path != "" }

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -159,6 +159,41 @@ func (l *Ledger) Episodes() ([]Episode, error) {
 	return out, nil
 }
 
+// Aggregate is a per-entry roll-up of recall episodes: how often the entry was
+// recalled, how often the incident then resolved, and when it last resolved.
+type Aggregate struct {
+	Recalls       int
+	Resolved      int
+	LastConfirmed time.Time
+}
+
+// OpenCounts rolls Episodes up per catalog entry, counting recall episodes only
+// (fresh investigations carry no entry). It is the input to recall decay:
+// resolve-rate ≈ (Resolved+1)/(Recalls+2). A disabled/empty ledger yields an
+// empty (non-nil) map.
+func (l *Ledger) OpenCounts() (map[string]Aggregate, error) {
+	eps, err := l.Episodes()
+	if err != nil {
+		return nil, err
+	}
+	counts := map[string]Aggregate{}
+	for _, e := range eps {
+		if e.Kind != "recall" || e.Entry == "" {
+			continue
+		}
+		a := counts[e.Entry]
+		a.Recalls++
+		if e.Resolved {
+			a.Resolved++
+			if e.ResolvedAt.After(a.LastConfirmed) {
+				a.LastConfirmed = e.ResolvedAt
+			}
+		}
+		counts[e.Entry] = a
+	}
+	return counts, nil
+}
+
 // Resolve records that an incident's alert cleared. When it matches an open
 // investigation it returns the Episode (with duration + kind) and ok=true.
 func (l *Ledger) Resolve(fp string, at time.Time) (Episode, bool, error) {

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -26,11 +26,13 @@ type Event struct {
 	At          time.Time `json:"at"`
 }
 
-// Episode is a matched open→resolve pair.
+// Episode is a matched open→resolve pair (or, from Episodes(), an unresolved open
+// when Resolved is false).
 type Episode struct {
 	Kind, Entry, Title, Resource string
 	OpenedAt, ResolvedAt         time.Time
 	Duration                     time.Duration
+	Resolved                     bool
 }
 
 // Ledger is an append-only outcome log with an in-memory open-index.
@@ -135,6 +137,6 @@ func (l *Ledger) Resolve(fp string, at time.Time) (Episode, bool, error) {
 	delete(l.open, fp)
 	return Episode{
 		Kind: o.Kind, Entry: o.Entry, Title: o.Title, Resource: o.Resource,
-		OpenedAt: o.At, ResolvedAt: at, Duration: at.Sub(o.At),
+		OpenedAt: o.At, ResolvedAt: at, Duration: at.Sub(o.At), Resolved: true,
 	}, true, nil
 }

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -20,7 +20,7 @@ func TestLedgerOpenResolveRoundTrip(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Resolve: ok=%v err=%v", ok, err)
 	}
-	if ep.Kind != "recall" || ep.Entry != "harbor.md" || ep.Duration != 90*time.Second {
+	if ep.Kind != "recall" || ep.Entry != "harbor.md" || ep.Duration != 90*time.Second || !ep.Resolved {
 		t.Fatalf("episode: %+v", ep)
 	}
 }
@@ -93,5 +93,18 @@ func TestReadEventsDisabledOrAbsent(t *testing.T) {
 	absent, _ := New(filepath.Join(t.TempDir(), "missing.jsonl"))
 	if ev, err := absent.readEvents(); err != nil || ev != nil {
 		t.Fatalf("absent file: want nil,nil; got %v,%v", ev, err)
+	}
+}
+
+func TestResolveMarksEpisodeResolved(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(4000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", At: t0})
+	ep, ok, err := l.Resolve("fp", t0.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("Resolve: ok=%v err=%v", ok, err)
+	}
+	if !ep.Resolved {
+		t.Fatalf("a matched resolve must set Resolved=true: %+v", ep)
 	}
 }

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -108,3 +108,95 @@ func TestResolveMarksEpisodeResolved(t *testing.T) {
 		t.Fatalf("a matched resolve must set Resolved=true: %+v", ep)
 	}
 }
+
+func TestEpisodesReconstructsRecurrence(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(5000, 0)
+	for i := 0; i < 3; i++ {
+		_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0.Add(time.Duration(i) * time.Second)})
+	}
+	_, _, _ = l.Resolve("fp", t0.Add(10*time.Second))
+	eps, err := l.Episodes()
+	if err != nil {
+		t.Fatalf("Episodes: %v", err)
+	}
+	if len(eps) != 3 {
+		t.Fatalf("want 3 episodes (recurrence preserved), got %d", len(eps))
+	}
+	resolved := 0
+	for _, e := range eps {
+		if e.Resolved {
+			resolved++
+		}
+	}
+	if resolved != 1 {
+		t.Fatalf("want exactly 1 resolved episode, got %d", resolved)
+	}
+}
+
+func TestEpisodesResolvedPairingAndDuration(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(6000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "first.md", At: t0})
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "second.md", At: t0.Add(time.Second)})
+	_, _, _ = l.Resolve("fp", t0.Add(5*time.Second))
+	eps, _ := l.Episodes()
+	var second Episode
+	for _, e := range eps {
+		if e.Entry == "first.md" && e.Resolved {
+			t.Fatal("LIFO: the earlier open must remain unresolved")
+		}
+		if e.Entry == "second.md" {
+			second = e
+		}
+	}
+	if !second.Resolved || second.Duration != 4*time.Second {
+		t.Fatalf("most-recent open should resolve with 4s duration: %+v", second)
+	}
+}
+
+func TestEpisodesEmptyAndDisabled(t *testing.T) {
+	dis, _ := New("")
+	if eps, err := dis.Episodes(); err != nil || eps != nil {
+		t.Fatalf("disabled: want nil,nil; got %v,%v", eps, err)
+	}
+	empty, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	if eps, err := empty.Episodes(); err != nil || len(eps) != 0 {
+		t.Fatalf("empty ledger: want 0 episodes; got %v,%v", eps, err)
+	}
+}
+
+func TestEpisodesOrphanResolveSkipped(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(9000, 0)
+	// A resolve with no prior open is dropped; a later open for the same fingerprint stays unresolved.
+	_, _, _ = l.Resolve("fp", t0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0.Add(time.Second)})
+	eps, err := l.Episodes()
+	if err != nil {
+		t.Fatalf("Episodes: %v", err)
+	}
+	if len(eps) != 1 || eps[0].Resolved {
+		t.Fatalf("orphan resolve must be dropped and the later open left unresolved: %+v", eps)
+	}
+}
+
+func TestEpisodesTwoFingerprintsInterleaved(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(9100, 0)
+	_ = l.Open(Event{Fingerprint: "A", Kind: "recall", Entry: "a.md", At: t0})
+	_ = l.Open(Event{Fingerprint: "B", Kind: "recall", Entry: "b.md", At: t0.Add(time.Second)})
+	_, _, _ = l.Resolve("A", t0.Add(2*time.Second))
+	eps, _ := l.Episodes()
+	if len(eps) != 2 {
+		t.Fatalf("want 2 episodes, got %d", len(eps))
+	}
+	for _, e := range eps {
+		if e.Entry == "a.md" && !e.Resolved {
+			t.Fatalf("A should be resolved: %+v", e)
+		}
+		if e.Entry == "b.md" && e.Resolved {
+			t.Fatalf("B should remain unresolved: %+v", e)
+		}
+	}
+}

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -200,3 +200,78 @@ func TestEpisodesTwoFingerprintsInterleaved(t *testing.T) {
 		}
 	}
 }
+
+func TestOpenCountsAggregatesRecallEntries(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(7000, 0)
+	for i := 0; i < 3; i++ {
+		_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0.Add(time.Duration(i) * time.Second)})
+	}
+	resolveAt := t0.Add(10 * time.Second)
+	_, _, _ = l.Resolve("fp", resolveAt)
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	a := counts["x.md"]
+	if a.Recalls != 3 || a.Resolved != 1 {
+		t.Fatalf("want recalls=3 resolved=1, got %+v", a)
+	}
+	if !a.LastConfirmed.Equal(resolveAt) {
+		t.Fatalf("LastConfirmed = %v, want %v", a.LastConfirmed, resolveAt)
+	}
+}
+
+func TestOpenCountsSkipsFresh(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(8000, 0)
+	_ = l.Open(Event{Fingerprint: "f1", Kind: "fresh", At: t0}) // fresh → no entry
+	_, _, _ = l.Resolve("f1", t0.Add(time.Minute))
+	counts, _ := l.OpenCounts()
+	if len(counts) != 0 {
+		t.Fatalf("fresh opens must not appear in OpenCounts, got %+v", counts)
+	}
+}
+
+func TestOpenCountsEmptyMapWhenDisabled(t *testing.T) {
+	dis, _ := New("")
+	counts, err := dis.OpenCounts()
+	if err != nil || counts == nil || len(counts) != 0 {
+		t.Fatalf("disabled: want empty non-nil map; got %v,%v", counts, err)
+	}
+}
+
+func TestOpenCountsUnresolvedRecallCounted(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(7100, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0}) // never resolved
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	a := counts["x.md"]
+	if a.Recalls != 1 || a.Resolved != 0 {
+		t.Fatalf("unresolved recall: want recalls=1 resolved=0, got %+v", a)
+	}
+	if !a.LastConfirmed.IsZero() {
+		t.Fatalf("unresolved recall: LastConfirmed must be zero, got %v", a.LastConfirmed)
+	}
+}
+
+func TestOpenCountsMultipleEntries(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(7200, 0)
+	_ = l.Open(Event{Fingerprint: "A", Kind: "recall", Entry: "a.md", At: t0})
+	_ = l.Open(Event{Fingerprint: "B", Kind: "recall", Entry: "b.md", At: t0.Add(time.Second)})
+	_, _, _ = l.Resolve("A", t0.Add(2*time.Second))
+	counts, _ := l.OpenCounts()
+	if len(counts) != 2 {
+		t.Fatalf("want 2 entries, got %d: %+v", len(counts), counts)
+	}
+	if counts["a.md"].Resolved != 1 || counts["a.md"].Recalls != 1 {
+		t.Fatalf("a.md should be recalls=1 resolved=1: %+v", counts["a.md"])
+	}
+	if counts["b.md"].Recalls != 1 || counts["b.md"].Resolved != 0 {
+		t.Fatalf("b.md should be recalls=1 resolved=0: %+v", counts["b.md"])
+	}
+}

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -59,3 +59,39 @@ func TestLedgerDisabledWhenPathEmpty(t *testing.T) {
 		t.Fatal("disabled ledger Resolve must be ok=false")
 	}
 }
+
+func TestReadEventsReturnsAllInOrder(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t0 := time.Unix(3000, 0)
+	_ = l.Open(Event{Fingerprint: "a", Kind: "fresh", At: t0})
+	_ = l.Open(Event{Fingerprint: "b", Kind: "recall", Entry: "x.md", At: t0.Add(time.Second)})
+	_, _, _ = l.Resolve("a", t0.Add(2*time.Second))
+	events, err := l.readEvents()
+	if err != nil {
+		t.Fatalf("readEvents: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("want 3 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Event != "open" || events[0].Fingerprint != "a" {
+		t.Fatalf("event[0] = %+v", events[0])
+	}
+	if events[2].Event != "resolve" || events[2].Fingerprint != "a" {
+		t.Fatalf("event[2] = %+v", events[2])
+	}
+}
+
+func TestReadEventsDisabledOrAbsent(t *testing.T) {
+	dis, _ := New("")
+	if ev, err := dis.readEvents(); err != nil || ev != nil {
+		t.Fatalf("disabled: want nil,nil; got %v,%v", ev, err)
+	}
+	absent, _ := New(filepath.Join(t.TempDir(), "missing.jsonl"))
+	if ev, err := absent.readEvents(); err != nil || ev != nil {
+		t.Fatalf("absent file: want nil,nil; got %v,%v", ev, err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a read-only API over the append-only outcome ledger — the A1→A2 seam the recall-decay edge (#9) will consume. Pure addition; `Open`/`Resolve` recording is unchanged apart from a documented `Resolved bool` on
`Episode`.

- **`readEvents()`** — factored from `New()`'s scan loop; single source of truth for replaying the JSONL.
- **`Episodes()`** — replays the full file and reconstructs every open into an `Episode`, LIFO-pairing each resolve with the most-recent unresolved open for the same fingerprint, so **recurrence is preserved** (N
opens + 1 resolve ⇒ N episodes, 1 resolved).
- **`OpenCounts() map[string]Aggregate`** — per-entry roll-up `{Recalls, Resolved, LastConfirmed}` over recall episodes only; the direct input to recall decay (`(Resolved+1)/(Recalls+2)`).
- **Deferred** (later slices): decay wiring (#9), `link`/`expired` events (#10), `RecurrenceStore` (#12), metrics.

Spec: `docs/superpowers/specs/2026-06-23-outcome-episodes-design.md` · Plan: `docs/superpowers/plans/2026-06-23-outcome-episodes.md`

## Test Plan
- [x] `go build ./...`, `go vet ./internal/outcome/` clean
- [x] `go test ./...` — all packages pass (15 ledger tests: recurrence, LIFO pairing, orphan-resolve, multi-fingerprint, unresolved-recall, disabled/empty)
- [x] Behavior-preserving: existing `New`/`Open`/`Resolve` tests unchanged
- [ ] CI green