### PR TITLE
feat(recall): outcome-driven recall decay (the learning-loop self-heal edge)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -893,10 +893,13 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 				MarginGap:            cfg.Catalog.InstantRecall.MarginGap,
 				SoloFloor:            cfg.Catalog.InstantRecall.SoloFloor,
 				RequireWorkloadMatch: cfg.Catalog.InstantRecall.RequireWorkloadMatch,
+				OutcomePrior:         cfg.Catalog.InstantRecall.OutcomePrior,
+				OutcomeFloor:         cfg.Catalog.InstantRecall.OutcomeFloor,
 			}
 			log.Info("instant recall enabled",
 				"min_score", cfg.Catalog.InstantRecall.MinScore,
-				"margin_gap", cfg.Catalog.InstantRecall.MarginGap, "solo_floor", cfg.Catalog.InstantRecall.SoloFloor)
+				"margin_gap", cfg.Catalog.InstantRecall.MarginGap, "solo_floor", cfg.Catalog.InstantRecall.SoloFloor,
+				"outcome_prior", cfg.Catalog.InstantRecall.OutcomePrior, "outcome_floor", cfg.Catalog.InstantRecall.OutcomeFloor)
 		}
 	}
 	if cfg.Metrics.URL != "" {
@@ -1027,6 +1030,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	if recall != nil {
 		recall.Metrics = metrics
 		recall.Log = log
+		recall.Outcome = ledger // outcome-driven decay (serve path); *outcome.Ledger satisfies OutcomeStats
 	}
 	log.Info("using LLM investigator", "provider", modelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)

--- a/docs/superpowers/plans/2026-06-23-recall-decay.md
+++ b/docs/superpowers/plans/2026-06-23-recall-decay.md
@@ -1,0 +1,411 @@
+# Outcome-Driven Recall Decay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bias instant-recall confidence by each catalog entry's resolution track record and reject (re-investigate) entries that recall-but-never-resolve — the "learns, not accumulates" edge.
+
+**Architecture:** A nil-safe `OutcomeStats` interface (satisfied by `*outcome.Ledger`) is wired onto `Recall` in the serve path. In `lookup`, after the structural gate, an optimistic Beta factor `(resolved+k)/(recalls+k)` multiplies the derived confidence; below a configurable floor the recall is rejected (fail-safe fall-through to a full investigation). Per-decision compute; A1 recording unchanged.
+
+**Tech Stack:** Go 1.26, stdlib `testing` (no testify). Tests follow `internal/investigate/recall_test.go` (fakes, `telemetry.Setup` + Prometheus scrape) and `internal/config/config_investigation_test.go` (`applyDefaults`).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-recall-decay-design.md`
+
+**Branch:** `feat/recall-decay` (already checked out; the spec is already committed there).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/config/config.go` | config schema | Add `OutcomePrior`/`OutcomeFloor` to `InstantRecall` |
+| `internal/config/load.go` | defaults | Default them (2.0 / 0.5) in `applyDefaults` |
+| `internal/config/config_investigation_test.go` | config tests | Assert defaults + explicit-respect |
+| `internal/investigate/recall.go` | recall gate | `outcomeFactor`; `OutcomeStats` interface; `Outcome`/`OutcomePrior`/`OutcomeFloor` fields; decay/gate block in `lookup`; import `outcome` |
+| `internal/investigate/recall_test.go` | recall tests | `outcomeFactor` unit + `lookup` decay scenarios + rejection metric |
+| `cmd/lore/main.go` | wiring | Set decay config on the built `Recall`; set `recall.Outcome = ledger` |
+
+Order: T1 (config) and T2 (`outcomeFactor`) are independent. T3 (recall fields + lookup) needs T2. T4 (wiring) needs T1 + T3. T5 verifies.
+
+---
+
+### Task 1: Config knobs `outcome_prior` / `outcome_floor`
+
+**Files:**
+- Modify: `internal/config/config.go` (`InstantRecall` struct, after `RequireWorkloadMatch` at `:127`)
+- Modify: `internal/config/load.go` (`applyDefaults`, inside the `if c.Catalog.InstantRecall.Enabled` block)
+- Test: `internal/config/config_investigation_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `internal/config/config_investigation_test.go`, replace `TestApplyDefaultsInstantRecall` (currently asserts only MinScore/MarginGap/SoloFloor) with the version below, and add the explicit-respect test after it:
+
+```go
+func TestApplyDefaultsInstantRecall(t *testing.T) {
+	// enabled with no tuning → margin/solo gates and decay knobs default to active values.
+	var c Config
+	c.Catalog.InstantRecall.Enabled = true
+	applyDefaults(&c)
+	ir := c.Catalog.InstantRecall
+	if ir.MinScore != 1.0 || ir.MarginGap != 1.0 || ir.SoloFloor != 4.0 {
+		t.Fatalf("instant-recall defaults not applied: %+v", ir)
+	}
+	if ir.OutcomePrior != 2.0 || ir.OutcomeFloor != 0.5 {
+		t.Fatalf("recall-decay defaults not applied: %+v", ir)
+	}
+}
+
+func TestApplyDefaultsRecallDecayExplicit(t *testing.T) {
+	// Explicit decay knobs must not be overwritten.
+	var c Config
+	c.Catalog.InstantRecall.Enabled = true
+	c.Catalog.InstantRecall.OutcomePrior = 5.0
+	c.Catalog.InstantRecall.OutcomeFloor = 0.3
+	applyDefaults(&c)
+	ir := c.Catalog.InstantRecall
+	if ir.OutcomePrior != 5.0 || ir.OutcomeFloor != 0.3 {
+		t.Fatalf("explicit recall-decay values overwritten: %+v", ir)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run 'TestApplyDefaultsInstantRecall|TestApplyDefaultsRecallDecayExplicit'`
+Expected: FAIL — compile error `ir.OutcomePrior undefined` / `ir.OutcomeFloor undefined`.
+
+- [ ] **Step 3: Add the fields and defaults**
+
+In `internal/config/config.go`, add to the `InstantRecall` struct immediately after the `RequireWorkloadMatch` field (`:127`):
+
+```go
+	OutcomePrior         float64 `yaml:"outcome_prior"`          // k — Beta prior strength for outcome decay (default 2.0)
+	OutcomeFloor         float64 `yaml:"outcome_floor"`          // reject a recall when the outcome factor drops below this (default 0.5)
+```
+
+In `internal/config/load.go`, inside the existing `if c.Catalog.InstantRecall.Enabled { ir := &c.Catalog.InstantRecall; ... }` block, after the `SoloFloor` default, add:
+
+```go
+		if ir.OutcomePrior == 0 {
+			ir.OutcomePrior = 2.0
+		}
+		if ir.OutcomeFloor == 0 {
+			ir.OutcomeFloor = 0.5
+		}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/`
+Expected: PASS (the two tests above + all pre-existing config tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/load.go internal/config/config_investigation_test.go
+git commit -m "feat(config): instant_recall outcome_prior/outcome_floor knobs"
+```
+
+---
+
+### Task 2: `outcomeFactor` (the decay function)
+
+**Files:**
+- Modify: `internal/investigate/recall.go` (add the function near `deriveRecallConfidence`)
+- Test: `internal/investigate/recall_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+In `internal/investigate/recall_test.go`, add `"math"` to the import block, and add:
+
+```go
+func TestOutcomeFactor(t *testing.T) {
+	const k = 2.0
+	cases := []struct {
+		recalls, resolved int
+		want              float64
+	}{
+		{0, 0, 1.0},  // no history → no penalty
+		{5, 5, 1.0},  // always resolves → no penalty
+		{3, 0, 0.4},  // (0+2)/(3+2)
+		{6, 0, 0.25}, // (0+2)/(6+2)
+		{4, 2, 0.6},  // (2+2)/(4+2)
+	}
+	for _, c := range cases {
+		got := outcomeFactor(c.recalls, c.resolved, k)
+		if math.Abs(got-c.want) > 1e-9 {
+			t.Fatalf("outcomeFactor(%d,%d,%v) = %v, want %v", c.recalls, c.resolved, k, got, c.want)
+		}
+		if got > 1.0 {
+			t.Fatalf("factor must be <= 1.0, got %v", got)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/investigate/ -run TestOutcomeFactor`
+Expected: FAIL — compile error `undefined: outcomeFactor`.
+
+- [ ] **Step 3: Implement `outcomeFactor`**
+
+In `internal/investigate/recall.go`, add immediately before `deriveRecallConfidence`:
+
+```go
+// outcomeFactor decays a recall's confidence by its track record using an
+// optimistic Beta prior: an entry with no history (or that always resolves)
+// scores 1.0; one that recalls-but-never-resolves decays toward 0. k is the
+// prior strength. Always in (0, 1] since resolved ≤ recalls.
+func outcomeFactor(recalls, resolved int, k float64) float64 {
+	return (float64(resolved) + k) / (float64(recalls) + k)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/investigate/ -run TestOutcomeFactor`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/investigate/recall.go internal/investigate/recall_test.go
+git commit -m "feat(recall): outcomeFactor optimistic decay function"
+```
+
+---
+
+### Task 3: Wire decay into `lookup` (`OutcomeStats` + fields + gate)
+
+**Files:**
+- Modify: `internal/investigate/recall.go` (imports; `Recall` struct `:23-32`; `lookup` tail `:74-79`)
+- Test: `internal/investigate/recall_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `internal/investigate/recall_test.go`, add `"errors"` and `"github.com/Smana/runlore/internal/outcome"` to the import block, plus (for the metric test) `"go.opentelemetry.io/otel"` and `"go.opentelemetry.io/otel/metric/noop"`. Then add:
+
+```go
+type fakeOutcome struct {
+	counts map[string]outcome.Aggregate
+	err    error
+}
+
+func (f fakeOutcome) OpenCounts() (map[string]outcome.Aggregate, error) { return f.counts, f.err }
+
+// soloRecall builds a Recall over a single strong hit that clears the margin +
+// solo gates for an apps/web workload, with decay configured (k=2, floor=0.5).
+func soloRecall(oc OutcomeStats) *Recall {
+	return &Recall{
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Path: "x.md", Resource: "apps/web"}, Score: 6.0},
+		}},
+		MinScore: 1.5, SoloFloor: 4.0, MarginGap: 1.0,
+		Outcome: oc, OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+}
+
+func TestLookupDecayHealthyEntryRecalls(t *testing.T) {
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 5, Resolved: 5}}})
+	e, conf := r.lookup(context.Background(), okReq())
+	if e == nil {
+		t.Fatal("healthy entry (factor 1.0) should recall")
+	}
+	if conf < 0.80 {
+		t.Fatalf("healthy entry confidence should be ~undecayed, got %v", conf)
+	}
+}
+
+func TestLookupDecayStaleEntryRejected(t *testing.T) {
+	// recalls=4 resolved=0 → factor (0+2)/(4+2)=0.333 < floor 0.5 → reject, fall through.
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 4, Resolved: 0}}})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("stale never-resolving entry must be rejected (fall through to investigation)")
+	}
+}
+
+func TestLookupDecayNoHistoryRecalls(t *testing.T) {
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{}}) // entry absent from counts
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("an entry with no outcome history must not be penalized")
+	}
+}
+
+func TestLookupDecayNilOutcomeRecalls(t *testing.T) {
+	r := soloRecall(nil) // no outcome stats wired
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("nil Outcome must behave as before (no decay)")
+	}
+}
+
+func TestLookupDecayStatsErrorRecalls(t *testing.T) {
+	r := soloRecall(fakeOutcome{err: errors.New("ledger unavailable")})
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("an outcome-stats error must degrade to a normal recall (skip decay)")
+	}
+}
+
+func TestLookupDecayRejectionMetric(t *testing.T) {
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 4, Resolved: 0}}})
+	r.Metrics = telemetry.NewMetrics()
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("stale entry should be rejected")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), `reason="low_outcome"`) {
+		t.Fatalf("expected recall_rejections_total{reason=\"low_outcome\"} in metrics:\n%s", rec.Body.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/investigate/ -run TestLookupDecay`
+Expected: FAIL — compile error (`Recall` has no `Outcome`/`OutcomePrior`/`OutcomeFloor` field; `OutcomeStats` undefined).
+
+- [ ] **Step 3: Add the interface, fields, and decay block**
+
+In `internal/investigate/recall.go`:
+
+(a) Add `"github.com/Smana/runlore/internal/outcome"` to the import block.
+
+(b) Add the interface just above the `Recall` struct:
+
+```go
+// OutcomeStats reports per-entry recall outcomes for confidence decay.
+// *outcome.Ledger satisfies it.
+type OutcomeStats interface {
+	OpenCounts() (map[string]outcome.Aggregate, error)
+}
+```
+
+(c) Add three fields to the `Recall` struct, immediately after `RequireWorkloadMatch`:
+
+```go
+	Outcome      OutcomeStats // optional; nil ⇒ no outcome decay
+	OutcomePrior float64      // k — Beta prior strength for decay (e.g. 2.0)
+	OutcomeFloor float64      // reject the recall when the outcome factor drops below this (e.g. 0.5)
+```
+
+(d) In `lookup`, replace the tail (the `conf := deriveRecallConfidence(...)` block through `return &e, conf`) with:
+
+```go
+	conf := deriveRecallConfidence(score, margin, strength)
+	// Outcome decay: bias confidence by the entry's resolution track record, and
+	// reject (re-investigate) an entry that recalls-but-never-resolves. Fail-safe —
+	// a rejected recall just falls through to a full investigation.
+	if r.Outcome != nil {
+		if counts, err := r.Outcome.OpenCounts(); err == nil {
+			if agg, ok := counts[e.Path]; ok { // only entries with recall history
+				f := outcomeFactor(agg.Recalls, agg.Resolved, r.OutcomePrior)
+				if f < r.OutcomeFloor {
+					r.reject(ctx, "low_outcome")
+					return nil, 0
+				}
+				conf = clampF(conf*f, 0, 0.90)
+			}
+		} else if r.Log != nil {
+			r.Log.Warn("recall: outcome stats unavailable; skipping decay", "err", err)
+		}
+	}
+	if r.Log != nil {
+		r.Log.Info("instant recall decision",
+			"alert", req.Title, "entry_id", e.Path, "score", score, "margin", margin, "confidence", conf)
+	}
+	return &e, conf
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/investigate/`
+Expected: PASS — the new decay tests plus all pre-existing recall/loop tests (decay is additive; existing tests leave `Outcome` nil).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/investigate/recall.go internal/investigate/recall_test.go
+git commit -m "feat(recall): outcome-driven confidence decay + low_outcome gate"
+```
+
+---
+
+### Task 4: Wire decay config + ledger into the serve path
+
+**Files:**
+- Modify: `cmd/lore/main.go` (`buildModelAndTools` recall literal `:890-895`; `buildInvestigator` `recall != nil` block `:1027-1030`)
+
+- [ ] **Step 1: Set the decay knobs on the built `Recall`**
+
+In `cmd/lore/main.go`, in `buildModelAndTools`, extend the `recall = &investigate.Recall{...}` literal to pass the two config knobs:
+
+```go
+			recall = &investigate.Recall{
+				Catalog:              cat,
+				MinScore:             cfg.Catalog.InstantRecall.MinScore,
+				MarginGap:            cfg.Catalog.InstantRecall.MarginGap,
+				SoloFloor:            cfg.Catalog.InstantRecall.SoloFloor,
+				RequireWorkloadMatch: cfg.Catalog.InstantRecall.RequireWorkloadMatch,
+				OutcomePrior:         cfg.Catalog.InstantRecall.OutcomePrior,
+				OutcomeFloor:         cfg.Catalog.InstantRecall.OutcomeFloor,
+			}
+```
+
+- [ ] **Step 2: Set `recall.Outcome = ledger` in `buildInvestigator`**
+
+In `cmd/lore/main.go`, in `buildInvestigator`, extend the existing `if recall != nil { ... }` block (which already sets `Metrics` and `Log`) to also wire the ledger:
+
+```go
+	if recall != nil {
+		recall.Metrics = metrics
+		recall.Log = log
+		recall.Outcome = ledger // outcome-driven decay (serve path); *outcome.Ledger satisfies OutcomeStats
+	}
+```
+
+(`ledger` is a `*outcome.Ledger` parameter of `buildInvestigator`; it is always non-nil — a disabled ledger yields empty `OpenCounts`, so decay is simply a no-op until the ledger is enabled and has data. The eval/reinvestigate/chat builders do not set `Outcome`, so they keep current behavior.)
+
+- [ ] **Step 3: Build to verify the wiring compiles**
+
+Run: `go build ./...`
+Expected: success, no output. (No new unit test — pure wiring; decay behavior is covered by Task 3.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/lore/main.go
+git commit -m "feat(recall): wire outcome decay (config + ledger) into the serve path"
+```
+
+---
+
+### Task 5: Whole-tree verification
+
+- [ ] **Step 1: Build, test, vet**
+
+Run:
+```bash
+go build ./... && go test ./... && go vet ./...
+```
+Expected: build clean; all tests PASS; vet clean.
+
+No commit (verification only).
+
+---
+
+## Notes for the implementer
+
+- **The factor only ever decays** (`resolved ≤ recalls` ⇒ factor `≤ 1.0`); it never inflates confidence. The lower clamp is `0` (not the 0.50 match-floor) on purpose — a distrusted entry may be reported well below the match-confidence floor; the *gate* (`f < OutcomeFloor`), not the floor, is the guard that forces re-investigation.
+- **Do not** add caching, decay on the reinvestigate/chat paths, frontmatter surfacing, or any change to A1 recording — all deferred (spec §7).
+- `reject(ctx, "low_outcome")` reuses the existing nil-safe rejection path; no new metric instrument is needed (`recall_rejections_total{reason}` already exists).
+- A disabled ledger (`outcome.ledger_path` empty) makes decay a transparent no-op — there is no behavior change for users who haven't enabled the outcome ledger.

--- a/docs/superpowers/specs/2026-06-23-recall-decay-design.md
+++ b/docs/superpowers/specs/2026-06-23-recall-decay-design.md
@@ -1,0 +1,143 @@
+# RunLore Outcome-Driven Recall Decay — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Bias instant-recall confidence by each catalog entry's resolution track record, and **reject** (re-investigate) entries that recall-but-never-resolve. The make-or-break "learns, not accumulates" edge. Confined to `internal/investigate/recall.go` + serve-path wiring + config; A1 recording unchanged. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | Deep-analysis report (`docs/analysis/2026-06-23-deep-analysis.md`) roadmap #9 (the thesis); builds on the merged Episodes/`OpenCounts()` read API (`2026-06-23-outcome-episodes-design.md`); recall-trustworthiness (`2026-06-22-recall-trustworthiness-design.md`, the gate/`deriveRecallConfidence` this extends); outcome-capture A1 (`2026-06-23-outcome-capture-design.md`, the correlation-not-causation caveat) |
+
+---
+
+## 1. Why this exists
+
+The learning loop captures outcomes (A1) and can now read them per entry (`OpenCounts()`), but **nothing feeds them back into recall**: `deriveRecallConfidence` is computed from BM25/structural signals alone, with zero outcome input. So a catalog entry that is recalled repeatedly and whose incident **never resolves** keeps winning the cache at full confidence — the loop accumulates but does not learn. This slice closes the edge: an entry's confidence decays with its unresolved-recall track record, and once it decays past a floor the recall is **rejected**, forcing a fresh investigation that can overturn a stale/wrong entry. A correct entry (or one with no history yet) is never penalized.
+
+This is the first edge that makes "self-improving" true. It is deliberately conservative about a noisy signal (a resolved alert is correlation, not proof our answer worked — A1 §5): the only consequence of decay is a *rejected recall → full investigation*, which is always safe.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Decay + gate** (not report-only) | Lowering the reported number alone never self-heals; the gate (reject → re-investigate) is what lets a wrong entry be overturned. The gate is fail-safe — a wrong rejection just runs a correct full investigation. |
+| D2 | **Optimistic Beta prior** `factor = (resolved+k)/(recalls+k)` | `=1.0` at zero history and when an entry always resolves; decays only as *unresolved* recalls accumulate. Fixes the roadmap's `(resolved+1)/(recalls+2)`, which scores 0.5 at zero data and would penalize correct-but-new knowledge. Since `resolved ≤ recalls`, the factor is always in `(0, 1]` — decay-only, never inflation. |
+| D3 | **Per-decision compute** (call `OpenCounts()` inside `lookup`) | Freshest + simplest. Recall frequency is low (one per qualifying alert, after trigger policy + dedup + coalescing) and the ledger is bounded; the Episodes spec already accepted replay-per-call. Caching is a clean follow-up if profiling warrants. |
+| D4 | **The prior encodes evidence — no separate min-count gate** | `factor < floor` is only reachable after several unresolved recalls (k=2, floor=0.5 ⇒ ≈3), so the prior itself is the evidence gate. |
+| D5 | **Serve path only** (`buildInvestigator`) for this slice | The dominant alert→investigate path is where recall matters most. Reinvestigate/chat leave `Outcome` nil (no decay = current behavior) — a small follow-up. |
+| D6 | **Defaults `k=2.0`, `floor=0.5`** (≈3 consecutive unresolved recalls to gate out), config-tunable | Conservative starting shape; tune from `recall_rejections_total{reason="low_outcome"}`. |
+
+## 3. Design
+
+### 3.1 How `Recall` reads outcomes (`recall.go`, `main.go`)
+
+A nil-safe interface, satisfied by `*outcome.Ledger` directly (no adapter):
+
+```go
+// OutcomeStats reports per-entry recall outcomes for confidence decay.
+// *outcome.Ledger satisfies it.
+type OutcomeStats interface {
+	OpenCounts() (map[string]outcome.Aggregate, error)
+}
+```
+
+New fields on `Recall`:
+
+```go
+Outcome      OutcomeStats // optional; nil ⇒ no decay (current behavior)
+OutcomePrior float64      // k — Beta prior strength (default 2.0)
+OutcomeFloor float64      // reject the recall when the factor drops below this (default 0.5)
+```
+
+`investigate` gains an import of `internal/outcome` (new, acyclic edge — `outcome` imports only stdlib). Wiring: `buildModelAndTools` sets `OutcomePrior`/`OutcomeFloor` from `config.InstantRecall`; `buildInvestigator` sets `recall.Outcome = ledger` (the only site where the ledger is in scope). Other `buildModelAndTools` callers (eval, reinvestigate, chat) leave `Outcome` nil.
+
+### 3.2 The decay factor
+
+```go
+// outcomeFactor decays a recall's confidence by its track record using an
+// optimistic Beta prior: an entry with no history (or that always resolves)
+// scores 1.0; one that recalls-but-never-resolves decays toward 0. k is the
+// prior strength. Always in (0, 1] since resolved ≤ recalls.
+func outcomeFactor(recalls, resolved int, k float64) float64 {
+	return (float64(resolved) + k) / (float64(recalls) + k)
+}
+```
+
+### 3.3 Where it plugs in (`lookup`, after the structural gate, before returning)
+
+```go
+conf := deriveRecallConfidence(score, margin, strength)
+if r.Outcome != nil {
+	if counts, err := r.Outcome.OpenCounts(); err == nil {
+		if agg, ok := counts[e.Path]; ok { // only entries with recall history
+			f := outcomeFactor(agg.Recalls, agg.Resolved, r.OutcomePrior)
+			if f < r.OutcomeFloor {
+				r.reject(ctx, "low_outcome") // decayed out → re-investigate
+				return nil, 0
+			}
+			conf = clampF(conf*f, 0, 0.90)
+		}
+	} else if r.Log != nil {
+		r.Log.Warn("recall: outcome stats unavailable; skipping decay", "err", err)
+	}
+}
+```
+
+- An entry with **no** recall history is absent from `counts` → untouched (optimistic default; equivalent to factor 1.0).
+- The gate reuses the existing `reject(ctx, reason)` helper → `recall_rejections_total{reason="low_outcome"}`. No new instrument.
+- A stats error degrades gracefully: skip decay, recall as before (the read API failing must not break investigations).
+- The factor is added to the existing "instant recall decision" log line for observability.
+
+### 3.4 Config
+
+Add to `config.InstantRecall` (and defaults in `config/load.go`, alongside `MinScore`/`MarginGap`/`SoloFloor`):
+
+```yaml
+catalog:
+  instant_recall:
+    outcome_prior: 2.0   # k; higher = more evidence before decay bites
+    outcome_floor: 0.5   # reject the recall below this factor
+```
+
+Defaults applied only when `instant_recall.enabled` (matching the existing knobs): `OutcomePrior` 2.0, `OutcomeFloor` 0.5.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| `OutcomeStats` interface + `Outcome`/`OutcomePrior`/`OutcomeFloor` fields | `internal/investigate/recall.go` |
+| `outcomeFactor` + decay/gate block in `lookup` | `internal/investigate/recall.go` |
+| `outcome_prior` / `outcome_floor` config + defaults | `internal/config/config.go`, `internal/config/load.go` |
+| Set `OutcomePrior`/`OutcomeFloor` on the built `Recall` | `cmd/lore/main.go` (`buildModelAndTools`) |
+| Set `recall.Outcome = ledger` | `cmd/lore/main.go` (`buildInvestigator`) |
+| Tests | `internal/investigate/recall_test.go`, `internal/config/*_test.go` |
+
+## 5. Trade-offs accepted in v1
+
+- **Correlation, not causation** — a resolved alert is not proof our answer worked, nor an unresolved one proof it didn't. The optimistic prior + a floor requiring several unresolved recalls keeps the signal conservative, and the only action is a fail-safe re-investigation. We act on the proxy deliberately; it is the best available signal and the downside is bounded.
+- **Per-decision replay** — `OpenCounts()` re-reads the bounded JSONL and briefly locks the ledger on each recall decision. Accepted (low recall frequency); caching is a deferred follow-up.
+- **Serve path only** — reinvestigate/chat recalls don't decay yet (no `Outcome` wired); they behave exactly as today. Follow-up.
+- **Hand-tuned defaults** — `k`/`floor` are conservative constants, tunable from `recall_rejections_total{reason="low_outcome"}`. Not learned.
+
+## 6. Testing
+
+- **`outcomeFactor`**: `(0,0)→1.0`; `(5,5)→1.0`; `(3,0),k=2→0.4`; `(6,0),k=2→0.25`; monotonic decrease as unresolved recalls rise; always `≤ 1.0`.
+- **`lookup` decay** (with a fake `OutcomeStats` returning a fixed `map[string]outcome.Aggregate`):
+  - healthy entry (`recalls=5, resolved=5`) → recalls, confidence ≈ derived (factor 1.0);
+  - stale entry (`recalls=4, resolved=0`, factor `2/6≈0.33 < 0.5`) → **rejected `low_outcome`**, `lookup` returns `(nil, 0)`;
+  - entry with no history (absent from the map) → recalls, confidence unchanged by decay;
+  - `Outcome == nil` → recalls, current behavior (no decay);
+  - `OpenCounts()` returns an error → recalls (decay skipped), no rejection.
+- **Metric**: a `low_outcome` rejection increments `recall_rejections_total{reason="low_outcome"}` (via the existing `reject` path; assert through the established `telemetry.Setup` + scrape pattern, or via the fake/log).
+- **Config**: `outcome_prior`/`outcome_floor` default to 2.0/0.5 when `instant_recall.enabled` and unset; explicit values are respected.
+- Existing recall tests (margin/structural/derive) must still pass — decay is additive and only engages when `Outcome` is set.
+
+## 7. Out of scope (later slices)
+
+- Surfacing `recall_count`/`resolved_count`/`last_confirmed` onto entry **git frontmatter** (write-path; a curator change).
+- Decay on the **reinvestigate / chat** recall paths.
+- **Caching** `OpenCounts()` (per-decision compute chosen).
+- Calibrating `k`/`floor` from data, or a learned decay (the defaults are an explainable starting shape).
+- Any change to A1 outcome **recording**.
+
+This slice flips the learning loop from measuring outcomes to **acting on them**: a stale or wrong entry that keeps failing to resolve decays out of the cache and gets re-investigated — the first concrete instance of RunLore learning your platform.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,6 +125,8 @@ type InstantRecall struct {
 	MarginGap            float64 `yaml:"margin_gap"`             // top hit must beat the runner-up by at least this
 	SoloFloor            float64 `yaml:"solo_floor"`             // confident bar when there is only one hit (higher than MinScore)
 	RequireWorkloadMatch bool    `yaml:"require_workload_match"` // true = exact namespace+workload; false = namespace-level agreement is enough
+	OutcomePrior         float64 `yaml:"outcome_prior"`          // Beta prior strength for outcome decay
+	OutcomeFloor         float64 `yaml:"outcome_floor"`          // reject a recall when the outcome factor drops below this
 }
 
 // CatalogGit configures periodic Git sync of the catalog into Dir.

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -38,13 +38,29 @@ func TestApplyDefaultsRateLimitWindow(t *testing.T) {
 }
 
 func TestApplyDefaultsInstantRecall(t *testing.T) {
-	// enabled with no tuning → margin and solo gates must default to active values.
+	// enabled with no tuning → margin/solo gates and decay knobs default to active values.
 	var c Config
 	c.Catalog.InstantRecall.Enabled = true
 	applyDefaults(&c)
 	ir := c.Catalog.InstantRecall
 	if ir.MinScore != 1.0 || ir.MarginGap != 1.0 || ir.SoloFloor != 4.0 {
 		t.Fatalf("instant-recall defaults not applied: %+v", ir)
+	}
+	if ir.OutcomePrior != 2.0 || ir.OutcomeFloor != 0.5 {
+		t.Fatalf("recall-decay defaults not applied: %+v", ir)
+	}
+}
+
+func TestApplyDefaultsRecallDecayExplicit(t *testing.T) {
+	// Explicit decay knobs must not be overwritten.
+	var c Config
+	c.Catalog.InstantRecall.Enabled = true
+	c.Catalog.InstantRecall.OutcomePrior = 5.0
+	c.Catalog.InstantRecall.OutcomeFloor = 0.3
+	applyDefaults(&c)
+	ir := c.Catalog.InstantRecall
+	if ir.OutcomePrior != 5.0 || ir.OutcomeFloor != 0.3 {
+		t.Fatalf("explicit recall-decay values overwritten: %+v", ir)
 	}
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -70,5 +70,11 @@ func applyDefaults(c *Config) {
 		if ir.SoloFloor == 0 {
 			ir.SoloFloor = 4.0
 		}
+		if ir.OutcomePrior == 0 {
+			ir.OutcomePrior = 2.0
+		}
+		if ir.OutcomeFloor == 0 {
+			ir.OutcomeFloor = 0.5
+		}
 	}
 }

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -122,6 +122,14 @@ func clampF(v, lo, hi float64) float64 {
 	return v
 }
 
+// outcomeFactor decays a recall's confidence by its track record using an
+// optimistic Beta prior: an entry with no history (or that always resolves)
+// scores 1.0; one that recalls-but-never-resolves decays toward 0. k is the
+// prior strength. Always in (0, 1] provided resolved ≤ recalls and k > 0.
+func outcomeFactor(recalls, resolved int, k float64) float64 {
+	return (float64(resolved) + k) / (float64(recalls) + k)
+}
+
 // deriveRecallConfidence turns the match signals into an explainable confidence,
 // capped below 1.0 — a cache hit never asserts certainty. (Constants are the shape;
 // tune via recall_score / recall_rejections.)

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -7,11 +7,18 @@ import (
 	"strings"
 
 	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
+
+// OutcomeStats reports per-entry recall outcomes for confidence decay.
+// *outcome.Ledger satisfies it.
+type OutcomeStats interface {
+	OpenCounts() (map[string]outcome.Aggregate, error)
+}
 
 // Recall short-circuits an investigation when the knowledge catalog already has a
 // trustworthy answer for the symptom — skipping the slow, paid ReAct loop. A recall
@@ -26,6 +33,10 @@ type Recall struct {
 	MarginGap            float64 // top hit must beat the runner-up by at least this
 	SoloFloor            float64 // confident bar when there is only one hit
 	RequireWorkloadMatch bool    // true = exact namespace+workload; false = namespace-level agreement is enough
+
+	Outcome      OutcomeStats // optional; nil ⇒ no outcome decay
+	OutcomePrior float64      // k — Beta prior strength for decay (e.g. 2.0)
+	OutcomeFloor float64      // reject the recall when the outcome factor drops below this (e.g. 0.5)
 
 	Metrics *telemetry.Metrics // optional; nil-safe — instruments are no-op when provider is unset
 	Log     *slog.Logger       // optional; nil-safe — log line omitted when unset
@@ -72,6 +83,23 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 	}
 
 	conf := deriveRecallConfidence(score, margin, strength)
+	// Outcome decay: bias confidence by the entry's resolution track record, and
+	// reject (re-investigate) an entry that recalls-but-never-resolves. Fail-safe —
+	// a rejected recall just falls through to a full investigation.
+	if r.Outcome != nil {
+		if counts, err := r.Outcome.OpenCounts(); err == nil {
+			if agg, ok := counts[e.Path]; ok { // only entries with recall history
+				f := outcomeFactor(agg.Recalls, agg.Resolved, r.OutcomePrior)
+				if f < r.OutcomeFloor {
+					r.reject(ctx, "low_outcome")
+					return nil, 0
+				}
+				conf = clampF(conf*f, 0, 0.90)
+			}
+		} else if r.Log != nil {
+			r.Log.Warn("recall: outcome stats unavailable; skipping decay", "err", err)
+		}
+	}
 	if r.Log != nil {
 		r.Log.Info("instant recall decision",
 			"alert", req.Title, "entry_id", e.Path, "score", score, "margin", margin, "confidence", conf)

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -2,6 +2,7 @@ package investigate
 
 import (
 	"context"
+	"errors"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -9,8 +10,11 @@ import (
 	"testing"
 
 	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
 )
 
 // recallWith builds a Recall over fixed hits with sensible trust thresholds.
@@ -186,5 +190,108 @@ func TestOutcomeFactor(t *testing.T) {
 		if got > 1.0 {
 			t.Errorf("factor must be <= 1.0, got %v", got)
 		}
+	}
+}
+
+type fakeOutcome struct {
+	counts map[string]outcome.Aggregate
+	err    error
+}
+
+func (f fakeOutcome) OpenCounts() (map[string]outcome.Aggregate, error) { return f.counts, f.err }
+
+// soloRecall builds a Recall over a single strong hit that clears the margin +
+// solo gates for an apps/web workload, with decay configured (k=2, floor=0.5).
+func soloRecall(oc OutcomeStats) *Recall {
+	return &Recall{
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Path: "x.md", Resource: "apps/web"}, Score: 6.0},
+		}},
+		MinScore: 1.5, SoloFloor: 4.0, MarginGap: 1.0,
+		Outcome: oc, OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+}
+
+func TestLookupDecayHealthyEntryRecalls(t *testing.T) {
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 5, Resolved: 5}}})
+	e, conf := r.lookup(context.Background(), okReq())
+	if e == nil {
+		t.Fatal("healthy entry (factor 1.0) should recall")
+	}
+	if conf < 0.80 {
+		t.Fatalf("healthy entry confidence should be ~undecayed, got %v", conf)
+	}
+}
+
+func TestLookupDecayStaleEntryRejected(t *testing.T) {
+	// recalls=4 resolved=0 → factor (0+2)/(4+2)=0.333 < floor 0.5 → reject, fall through.
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 4, Resolved: 0}}})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("stale never-resolving entry must be rejected (fall through to investigation)")
+	}
+}
+
+func TestLookupDecayNoHistoryRecalls(t *testing.T) {
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{}}) // entry absent from counts
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("an entry with no outcome history must not be penalized")
+	}
+}
+
+func TestLookupDecayNilOutcomeRecalls(t *testing.T) {
+	r := soloRecall(nil) // no outcome stats wired
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("nil Outcome must behave as before (no decay)")
+	}
+}
+
+func TestLookupDecayStatsErrorRecalls(t *testing.T) {
+	r := soloRecall(fakeOutcome{err: errors.New("ledger unavailable")})
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("an outcome-stats error must degrade to a normal recall (skip decay)")
+	}
+}
+
+func TestLookupDecayPartialFactorReducesConfidence(t *testing.T) {
+	// recalls=3 resolved=1 → factor (1+2)/(3+2)=0.6 (> floor 0.5) → recalls, but with
+	// confidence visibly reduced from the undecayed ~0.90 (0.90*0.6 = 0.54).
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 3, Resolved: 1}}})
+	e, conf := r.lookup(context.Background(), okReq())
+	if e == nil {
+		t.Fatal("factor 0.6 (>= floor) should still recall")
+	}
+	if conf >= 0.80 || conf <= 0.40 {
+		t.Fatalf("partial factor should visibly reduce confidence (~0.54), got %v", conf)
+	}
+}
+
+func TestLookupDecayFactorAtFloorRecalls(t *testing.T) {
+	// recalls=2 resolved=0 → factor (0+2)/(2+2)=0.5 == floor; the gate is strict (<),
+	// so it recalls (boundary case).
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 2, Resolved: 0}}})
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("factor exactly at the floor must recall (gate is strict <)")
+	}
+}
+
+func TestLookupDecayRejectionMetric(t *testing.T) {
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 4, Resolved: 0}}})
+	r.Metrics = telemetry.NewMetrics()
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("stale entry should be rejected")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), `reason="low_outcome"`) {
+		t.Fatalf("expected recall_rejections_total{reason=\"low_outcome\"} in metrics:\n%s", rec.Body.String())
 	}
 }

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -2,6 +2,7 @@ package investigate
 
 import (
 	"context"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -162,5 +163,28 @@ func TestRecalledInvestigationCarriesEntryPath(t *testing.T) {
 	inv := recalledInvestigation(Request{Title: "x"}, catalog.Entry{Title: "T", Path: "p.md"}, 0.7)
 	if inv.RecalledEntry != "p.md" {
 		t.Fatalf("RecalledEntry = %q, want p.md", inv.RecalledEntry)
+	}
+}
+
+func TestOutcomeFactor(t *testing.T) {
+	const k = 2.0
+	cases := []struct {
+		recalls, resolved int
+		want              float64
+	}{
+		{0, 0, 1.0},  // no history → no penalty
+		{5, 5, 1.0},  // always resolves → no penalty
+		{3, 0, 0.4},  // (0+2)/(3+2)
+		{6, 0, 0.25}, // (0+2)/(6+2)
+		{3, 1, 0.6},  // (1+2)/(3+2) — partial resolve rate
+	}
+	for _, c := range cases {
+		got := outcomeFactor(c.recalls, c.resolved, k)
+		if math.Abs(got-c.want) > 1e-9 {
+			t.Errorf("outcomeFactor(%d,%d,%v) = %v, want %v", c.recalls, c.resolved, k, got, c.want)
+		}
+		if got > 1.0 {
+			t.Errorf("factor must be <= 1.0, got %v", got)
+		}
 	}
 }

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -169,7 +169,7 @@ type Aggregate struct {
 
 // OpenCounts rolls Episodes up per catalog entry, counting recall episodes only
 // (fresh investigations carry no entry). It is the input to recall decay:
-// resolve-rate ≈ (Resolved+1)/(Recalls+2). A disabled/empty ledger yields an
+// resolve-rate ≈ (Resolved+k)/(Recalls+k). A disabled/empty ledger yields an
 // empty (non-nil) map.
 func (l *Ledger) OpenCounts() (map[string]Aggregate, error) {
 	eps, err := l.Episodes()


### PR DESCRIPTION
## Summary

Biases instant-recall confidence by each catalog entry's resolution track record and **rejects (re-investigates)** entries that recall-but-never-resolve — the make-or-break edge that turns "accumulates" into
"learns". Confined to recall + config + serve-path wiring; A1 recording unchanged.

- **`outcomeFactor(recalls, resolved, k)`** — optimistic Beta prior `(resolved+k)/(recalls+k)`: `1.0` at zero history / always-resolves, decays only with unresolved recalls, always `≤ 1.0`. (The naive
`(resolved+1)/(recalls+2)` was rejected — it halves correct-but-new entries.)
- **In `lookup`** (after the structural gate): multiply confidence by the factor; if it drops below `OutcomeFloor`, `reject(ctx, "low_outcome")` → fall through to a full investigation. No-history / nil-`Outcome`
/ stats-error all degrade to current behavior (fail-safe).
- **Config** `instant_recall.outcome_prior` (2.0) / `outcome_floor` (0.5); wired onto `Recall` + `recall.Outcome = ledger` in the serve path.
- **Deferred** (spec §7): frontmatter surfacing, reinvestigate/chat decay, caching, A1 recording changes.

End-to-end: a stale entry that keeps recalling but never resolves decays below the floor (~3 unresolved recalls at the defaults) and gets re-investigated — observable via
`recall_rejections_total{reason="low_outcome"}`.

Spec: `docs/superpowers/specs/2026-06-23-recall-decay-design.md` · Plan: `docs/superpowers/plans/2026-06-23-recall-decay.md`

## Test Plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — all packages pass
- [x] `outcomeFactor` unit (incl. boundary); decay branches: healthy/stale-rejected/no-history/nil/stats-error/mid-range/floor-boundary; `low_outcome` metric scrape; config defaults + explicit-respect
- [ ] CI green