### PR TITLE
feat(recall): Gate 2 disambiguates workloads in the same namespace

### DIFF
--- a/docs/superpowers/plans/2026-06-23-recall-disambiguation.md
+++ b/docs/superpowers/plans/2026-06-23-recall-disambiguation.md
@@ -1,0 +1,387 @@
+# Recall Gate 2 Disambiguation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make instant-recall's structural gate tell apart different workloads in the same namespace, so a curated entry recalls only for the workload it describes.
+
+**Architecture:** Three coordinated changes in `internal/investigate`: (1) fix `resourceAgrees` so two distinct named workloads no longer match at namespace strength; (2) derive `Workload.Name`/`Kind` from alert labels in `FromIncident` (read side); (3) record the investigation's discovered `affected_resource` via `submit_findings` and prefer it over the originating alert workload (write side).
+
+**Tech Stack:** Go 1.26, stdlib `testing` (no testify). Tests follow `internal/investigate/recall_test.go`, `investigate_test.go`, `tools_test.go`, `loop_test.go`.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-recall-disambiguation-design.md`
+
+**Branch:** `feat/recall-disambiguation` (already checked out; the spec is already committed there).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/investigate/recall.go` | recall gate | Fix `resourceAgrees` namespace-strength branch |
+| `internal/investigate/investigate.go` | trigger→request | `workloadFromLabels` helper; use in `FromIncident` |
+| `internal/investigate/tools.go` | submit_findings | `affected_resource` schema + `findings` field + set `inv.Resource` in `parseFindings` |
+| `internal/investigate/loop.go` | ReAct loop | `preferDiscoveredResource` helper; replace the unconditional `inv.Resource = req.Workload` |
+| `*_test.go` | tests | one per change |
+
+Task order: T1 (match), T2 (read), T3 (write-parse), T4 (loop-prefer), T5 (verify). T1/T2/T3 are independent; T4 reads `inv.Resource` set by T3 but is safe in any order (zero `Resource` ⇒ falls back to the alert workload = today's behavior).
+
+---
+
+### Task 1: Fix `resourceAgrees` so distinct named workloads don't namespace-match
+
+**Files:**
+- Modify: `internal/investigate/recall.go` (`resourceAgrees`)
+- Test: `internal/investigate/recall_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/investigate/recall_test.go`:
+
+```go
+func TestResourceAgrees(t *testing.T) {
+	w := func(ns, name string) providers.Workload { return providers.Workload{Namespace: ns, Name: name} }
+	cases := []struct {
+		name      string
+		reqW      providers.Workload
+		entry     string
+		requireWL bool
+		want      matchStrength
+	}{
+		{"exact ns/name", w("apps", "payment-api"), "apps/payment-api", false, matchExact},
+		{"different names same ns -> none", w("apps", "payment-api"), "apps/web", false, matchNone},
+		{"named alert vs bare-ns entry -> namespace", w("apps", "payment-api"), "apps", false, matchNamespace},
+		{"bare-ns alert vs named entry -> namespace", w("apps", ""), "apps/web", false, matchNamespace},
+		{"both bare ns -> exact", w("apps", ""), "apps", false, matchExact},
+		{"different ns -> none", w("apps", "payment-api"), "other/web", false, matchNone},
+		{"empty entry -> none", w("apps", "payment-api"), "", false, matchNone},
+		{"require workload + exact -> exact", w("apps", "web"), "apps/web", true, matchExact},
+		{"require workload + ns-only -> none", w("apps", ""), "apps/web", true, matchNone},
+	}
+	for _, c := range cases {
+		if got := resourceAgrees(c.reqW, c.entry, c.requireWL); got != c.want {
+			t.Errorf("%s: resourceAgrees(%+v, %q, %v) = %v, want %v", c.name, c.reqW, c.entry, c.requireWL, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/investigate/ -run TestResourceAgrees`
+Expected: FAIL — `different names same ns -> none` gets `matchNamespace` (the old prefix behavior), want `matchNone`.
+
+- [ ] **Step 3: Fix the namespace-strength branch**
+
+In `internal/investigate/recall.go`, replace the namespace-strength branch of `resourceAgrees` (currently `if entryResource == reqW.Namespace || strings.HasPrefix(entryResource, reqW.Namespace+"/") { return matchNamespace }`) so it only applies when one side is a bare namespace:
+
+```go
+	// Namespace-level agreement only when one side is a bare namespace — never two
+	// distinct named workloads (that would defeat disambiguation).
+	if entryResource == reqW.Namespace { // entry is a bare namespace; reqW is in it
+		return matchNamespace
+	}
+	if reqW.Name == "" && strings.HasPrefix(entryResource, reqW.Namespace+"/") { // reqW is a bare namespace; entry named in it
+		return matchNamespace
+	}
+	return matchNone
+```
+
+(The function's earlier lines — the `entryResource == "" || reqW.Namespace == ""` guard, the `reqW.Ref() == entryResource` exact check, and the `requireWorkload` short-circuit — are unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/investigate/ -run 'TestResourceAgrees|TestLookupStructural|TestLookupNoStoredResource'`
+Expected: PASS — the new table test AND the existing structural lookup tests (they use a *nameless* alert workload, which still namespace-matches).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/investigate/recall.go internal/investigate/recall_test.go
+git commit -m "fix(recall): structural gate no longer namespace-matches distinct workloads"
+```
+
+---
+
+### Task 2: Derive `Workload.Name`/`Kind` from alert labels
+
+**Files:**
+- Modify: `internal/investigate/investigate.go` (add `workloadFromLabels`; use in `FromIncident`)
+- Test: `internal/investigate/investigate_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/investigate/investigate_test.go`:
+
+```go
+func TestWorkloadFromLabels(t *testing.T) {
+	cases := []struct {
+		name             string
+		labels           map[string]string
+		wantKind, wantNm string
+	}{
+		{"deployment", map[string]string{"deployment": "payment-api"}, "Deployment", "payment-api"},
+		{"pod only", map[string]string{"pod": "x-abc123"}, "Pod", "x-abc123"},
+		{"controller beats pod", map[string]string{"deployment": "payment-api", "pod": "payment-api-abc"}, "Deployment", "payment-api"},
+		{"workload with type", map[string]string{"workload": "w", "workload_type": "Rollout"}, "Rollout", "w"},
+		{"none", map[string]string{"severity": "critical"}, "", ""},
+	}
+	for _, c := range cases {
+		k, n := workloadFromLabels(c.labels)
+		if k != c.wantKind || n != c.wantNm {
+			t.Errorf("%s: got (%q,%q), want (%q,%q)", c.name, k, n, c.wantKind, c.wantNm)
+		}
+	}
+}
+
+func TestFromIncidentDerivesWorkload(t *testing.T) {
+	inc := config.Incident{AlertName: "Crash", Namespace: "apps", Labels: map[string]string{"namespace": "apps", "deployment": "payment-api"}}
+	r := FromIncident(inc)
+	if r.Workload.Namespace != "apps" || r.Workload.Name != "payment-api" || r.Workload.Kind != "Deployment" {
+		t.Fatalf("FromIncident workload = %+v, want apps/payment-api Deployment", r.Workload)
+	}
+}
+```
+
+(`config` is already imported in this test file — `TestFromIncident` uses `config.Incident`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/investigate/ -run 'TestWorkloadFromLabels|TestFromIncidentDerivesWorkload'`
+Expected: FAIL — compile error `undefined: workloadFromLabels`.
+
+- [ ] **Step 3: Implement the helper and use it**
+
+In `internal/investigate/investigate.go`, add the helper (e.g. just above `FromIncident`):
+
+```go
+// workloadFromLabels derives the affected workload (kind, name) from Alertmanager
+// labels, preferring a stable controller name over an ephemeral pod name.
+func workloadFromLabels(labels map[string]string) (kind, name string) {
+	for _, c := range []struct{ label, kind string }{
+		{"deployment", "Deployment"},
+		{"statefulset", "StatefulSet"},
+		{"daemonset", "DaemonSet"},
+		{"replicaset", "ReplicaSet"},
+		{"cronjob", "CronJob"},
+		{"job", "Job"},
+	} {
+		if v := labels[c.label]; v != "" {
+			return c.kind, v
+		}
+	}
+	if v := labels["workload"]; v != "" {
+		return labels["workload_type"], v // kind may be empty
+	}
+	if v := labels["pod"]; v != "" {
+		return "Pod", v
+	}
+	return "", ""
+}
+```
+
+And update `FromIncident` to derive the workload (add the `kind, name := workloadFromLabels(...)` line and use it in the `Workload` field; leave every other field as-is):
+
+```go
+// FromIncident builds a Request from a matched incident alert.
+func FromIncident(inc config.Incident) Request {
+	kind, name := workloadFromLabels(inc.Labels)
+	return Request{
+		Source:      SourceAlert,
+		Title:       inc.AlertName,
+		Workload:    providers.Workload{Namespace: inc.Namespace, Kind: kind, Name: name},
+		Reason:      inc.Severity,
+		Labels:      inc.Labels,
+		At:          inc.StartsAt,
+		Fingerprint: inc.Fingerprint,
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/investigate/`
+Expected: PASS — the two new tests plus all pre-existing tests (existing `TestFromIncident` checks only `Workload.Namespace`, so adding name/kind doesn't break it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/investigate/investigate.go internal/investigate/investigate_test.go
+git commit -m "feat(investigate): derive workload name/kind from alert labels"
+```
+
+---
+
+### Task 3: Record the discovered `affected_resource` (write side, parse)
+
+**Files:**
+- Modify: `internal/investigate/tools.go` (`submitFindingsSpec` schema; `findings` struct; `parseFindings`)
+- Test: `internal/investigate/tools_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/investigate/tools_test.go`:
+
+```go
+func TestParseFindingsAffectedResource(t *testing.T) {
+	args := `{"root_causes":[{"summary":"OOM in payment-api"}],
+	  "affected_resource":{"kind":"Deployment","name":"payment-api","namespace":"apps"}}`
+	inv, err := parseFindings(args)
+	if err != nil {
+		t.Fatalf("parseFindings: %v", err)
+	}
+	if inv.Resource.Namespace != "apps" || inv.Resource.Name != "payment-api" || inv.Resource.Kind != "Deployment" {
+		t.Fatalf("affected_resource not parsed into inv.Resource: %+v", inv.Resource)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/investigate/ -run TestParseFindingsAffectedResource`
+Expected: FAIL — `inv.Resource` is the zero `Workload` (parseFindings doesn't read `affected_resource` yet).
+
+- [ ] **Step 3: Add the schema property, struct field, and parse**
+
+In `internal/investigate/tools.go`:
+
+(a) In `submitFindingsSpec`'s `Schema` string, add the `affected_resource` property. Insert it immediately after the `"confidence":{"type":"number"},` line (the line right after `"title"`):
+
+```
+"affected_resource":{"type":"object","description":"the workload your investigation identified as the failing/affected resource","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}},
+```
+
+(b) In the `findings` struct, add (after the `Confidence float64` field):
+
+```go
+	AffectedResource struct {
+		Kind      string `json:"kind"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"affected_resource"`
+```
+
+(c) In `parseFindings`, before `return inv, nil`, set the discovered resource:
+
+```go
+	inv.Resource = providers.Workload{
+		Kind:      f.AffectedResource.Kind,
+		Name:      f.AffectedResource.Name,
+		Namespace: f.AffectedResource.Namespace,
+	}
+```
+
+(When `affected_resource` is absent this sets the zero `Workload`; the loop's fallback (Task 4) then uses the alert workload.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/investigate/`
+Expected: PASS — the new test plus all pre-existing tests (`TestParseFindings` doesn't assert `inv.Resource`, and `TestSubmitFindingsSchemaNoEmptyEnum` still holds — no empty enum added).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/investigate/tools.go internal/investigate/tools_test.go
+git commit -m "feat(investigate): submit_findings affected_resource -> inv.Resource"
+```
+
+---
+
+### Task 4: Prefer the discovered resource in the loop
+
+**Files:**
+- Modify: `internal/investigate/loop.go` (add `preferDiscoveredResource`; replace the `inv.Resource = req.Workload` line)
+- Test: `internal/investigate/loop_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/investigate/loop_test.go`:
+
+```go
+func TestPreferDiscoveredResource(t *testing.T) {
+	origin := providers.Workload{Namespace: "apps", Name: "web"}
+	cases := []struct {
+		name       string
+		discovered providers.Workload
+		want       providers.Workload
+	}{
+		{"discovered wins", providers.Workload{Namespace: "apps", Name: "payment-api", Kind: "Deployment"}, providers.Workload{Namespace: "apps", Name: "payment-api", Kind: "Deployment"}},
+		{"namespace defaulted from origin", providers.Workload{Name: "payment-api"}, providers.Workload{Namespace: "apps", Name: "payment-api"}},
+		{"empty falls back to origin", providers.Workload{}, origin},
+	}
+	for _, c := range cases {
+		if got := preferDiscoveredResource(c.discovered, origin); got != c.want {
+			t.Errorf("%s: got %+v, want %+v", c.name, got, c.want)
+		}
+	}
+}
+```
+
+(`providers` is already imported in `loop_test.go`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/investigate/ -run TestPreferDiscoveredResource`
+Expected: FAIL — compile error `undefined: preferDiscoveredResource`.
+
+- [ ] **Step 3: Add the helper and use it in the loop**
+
+In `internal/investigate/loop.go`, add the helper (e.g. near the bottom of the file, after `Investigate`):
+
+```go
+// preferDiscoveredResource keeps the workload the investigation identified,
+// defaulting a missing namespace to the originating alert's, and falls back to the
+// alert workload only when the model named none.
+func preferDiscoveredResource(discovered, origin providers.Workload) providers.Workload {
+	if discovered.Name != "" && discovered.Namespace == "" {
+		discovered.Namespace = origin.Namespace
+	}
+	if discovered.Ref() == "" {
+		return origin
+	}
+	return discovered
+}
+```
+
+And replace the line `inv.Resource = req.Workload       // record the originating workload for structural recall` with:
+
+```go
+				// Prefer the workload the investigation identified; fall back to the
+				// originating alert workload only when the model named none.
+				inv.Resource = preferDiscoveredResource(inv.Resource, req.Workload)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/investigate/`
+Expected: PASS — the helper test plus all pre-existing loop tests (when the model sets no `affected_resource`, `inv.Resource` is zero ⇒ `preferDiscoveredResource` returns `req.Workload` = today's behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/investigate/loop.go internal/investigate/loop_test.go
+git commit -m "feat(investigate): loop prefers the discovered resource over the alert workload"
+```
+
+---
+
+### Task 5: Whole-tree verification
+
+- [ ] **Step 1: Build, test, vet**
+
+Run:
+```bash
+go build ./... && go test ./... && go vet ./...
+```
+Expected: build clean; all tests PASS; vet clean.
+
+No commit (verification only).
+
+---
+
+## Notes for the implementer
+
+- The disambiguation hinges on Task 1: a named alert (`apps/payment-api`) must NOT recall a different named entry (`apps/web`). The namespace fallback is preserved only for genuinely namespace-scoped alerts/entries (one side a bare namespace).
+- Do not flip the `RequireWorkloadMatch` default, touch the curator/KB frontmatter, index `resource` as a bleve field, or change decay/eval — all deferred (spec §7). The curator improves automatically because `draftKBEntry` already stores `inv.Resource.Ref()`.
+- `providers.Workload` is all-string and comparable, so `got != want` works in the helper tests.
+- If any pre-existing test fails due to the Task 1 semantics change, inspect it: a test that asserted a *named* alert matching a *different* named entry encoded the bug — update it with a comment. (None are expected to, since the existing structural tests use a nameless alert workload.)

--- a/docs/superpowers/specs/2026-06-23-recall-disambiguation-design.md
+++ b/docs/superpowers/specs/2026-06-23-recall-disambiguation-design.md
@@ -1,0 +1,149 @@
+# RunLore Recall Disambiguation (Gate 2) — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Make instant-recall's structural gate (Gate 2) actually tell apart different workloads in the same namespace: derive the workload name from alert labels (read side), record the investigation's discovered failing resource (write side), and fix `resourceAgrees` so two distinct named workloads no longer match at namespace strength. Confined to `internal/investigate`. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | Deep-analysis report (`docs/analysis/2026-06-23-deep-analysis.md`) roadmap #2 / "Gate 2 collapses to namespace equality"; recall-trustworthiness (`2026-06-22-recall-trustworthiness-design.md`, which introduced Gate 2 / `resourceAgrees` / the `Resource` field); the recall-decay slice (`2026-06-23-recall-decay-design.md`) that sits on top of these gates |
+
+---
+
+## 1. Why this exists
+
+Gate 2 (structural agreement) is the lever the recall-trustworthiness design named to separate the many-to-one symptom→cause problem (CrashLoopBackOff = OOM | bad-image | missing-secret). In practice it cannot, for two reasons:
+
+1. **The data isn't there.** On the dominant alert path, `FromIncident` builds `Workload{Namespace: inc.Namespace}` with no `Name`, and the investigation's *discovered* failing workload is never recorded — `loop.go` overwrites `inv.Resource` with the namespace-only originating workload, and `parseFindings` has no field for an affected resource. So both the alert's workload and the curated entry's `Resource` are bare namespaces.
+2. **The matching over-matches.** Even with names present, `resourceAgrees` treats a named alert `apps/payment-api` as matching a *different* named entry `apps/web` at namespace strength, because `strings.HasPrefix("apps/web", "apps/")` is true. So any two workloads in a namespace recall each other's entries.
+
+This slice fixes all three (read, write, match) so a curated entry recalls only for the workload it is actually about — the disambiguation Gate 2 was meant to provide.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Fix `resourceAgrees` AND plumb the data** | The data fix alone doesn't disambiguate — the matching still namespace-matches different names. Both are required for the slice to achieve its goal. |
+| D2 | **Namespace-strength agreement only when one side is a *bare namespace*** | A genuinely namespace-scoped alert or entry should still recall; two *distinct named* workloads in one namespace must not. Keeps `RequireWorkloadMatch=false` default while making the gate discriminate. |
+| D3 | **Read-side label precedence: controller → `workload` → `pod`** | Controller names (Deployment/StatefulSet/…) are stable and match runbooks; pod names carry ephemeral hashes (`payment-api-7d9f-xyz`) that won't. Prefer the most matchable identifier. |
+| D4 | **`affected_resource` is structured `{namespace, kind, name}`** | Mirrors the existing `actions[].target` shape in the same schema; consistent and unambiguous. |
+| D5 | **Discovered resource wins; fall back to the alert workload only when absent** | The model's identified failing workload is what should be recorded/curated; the originating alert workload is the fallback when the model didn't name one. |
+| D6 | **Curator needs no change** | `draftKBEntry` already stores `inv.Resource.Ref()`; once `inv.Resource` carries the discovered `ns/name`, curated entries improve automatically. |
+
+## 3. Design
+
+### 3.1 Read side — workload name from alert labels (`investigate.go`)
+
+Add a helper:
+
+```go
+// workloadFromLabels derives the affected workload (kind, name) from Alertmanager
+// labels, preferring a stable controller name over an ephemeral pod name.
+func workloadFromLabels(labels map[string]string) (kind, name string)
+```
+
+Precedence (first present wins):
+1. controller labels — `deployment`→`Deployment`, `statefulset`→`StatefulSet`, `daemonset`→`DaemonSet`, `replicaset`→`ReplicaSet`, `cronjob`→`CronJob`, `job`→`Job`;
+2. `workload` (kind from `workload_type` if present, else empty);
+3. `pod` → `Pod`.
+
+`FromIncident` uses it: `kind, name := workloadFromLabels(inc.Labels); Workload{Namespace: inc.Namespace, Kind: kind, Name: name}`. No matching label → namespace-only (today's behavior).
+
+### 3.2 Write side — discovered resource (`tools.go`, `loop.go`)
+
+Add a top-level `affected_resource` to the `submit_findings` schema:
+
+```json
+"affected_resource":{"type":"object",
+  "description":"the workload your investigation identified as the failing/affected resource",
+  "properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}}
+```
+
+Add the matching field to the `findings` struct and, in `parseFindings`, set `inv.Resource = providers.Workload{Kind, Name, Namespace}` from it.
+
+In `loop.go`, replace the unconditional `inv.Resource = req.Workload` with:
+
+```go
+// Prefer the workload the investigation identified; default a missing namespace to
+// the alert's, and fall back to the originating workload only when none was named.
+if inv.Resource.Name != "" && inv.Resource.Namespace == "" {
+	inv.Resource.Namespace = req.Workload.Namespace
+}
+if inv.Resource.Ref() == "" {
+	inv.Resource = req.Workload
+}
+```
+
+(`recalledInvestigation` keeps `Resource: req.Workload`, now name-bearing from §3.1 — consistent.)
+
+### 3.3 Matching fix — `resourceAgrees` (`recall.go`)
+
+```go
+func resourceAgrees(reqW providers.Workload, entryResource string, requireWorkload bool) matchStrength {
+	if entryResource == "" || reqW.Namespace == "" {
+		return matchNone
+	}
+	if reqW.Ref() == entryResource {
+		return matchExact
+	}
+	if requireWorkload {
+		return matchNone
+	}
+	// Namespace-level agreement only when one side is a bare namespace — never two
+	// distinct named workloads (that would defeat disambiguation).
+	if entryResource == reqW.Namespace { // entry is a bare namespace; reqW is in it
+		return matchNamespace
+	}
+	if reqW.Name == "" && strings.HasPrefix(entryResource, reqW.Namespace+"/") { // reqW bare ns; entry named in it
+		return matchNamespace
+	}
+	return matchNone
+}
+```
+
+Resulting matrix (with `requireWorkload=false`):
+
+| reqW | entry | result |
+|---|---|---|
+| `apps/payment-api` | `apps/payment-api` | `matchExact` |
+| `apps/payment-api` | `apps/web` | **`matchNone`** (was `matchNamespace`) |
+| `apps/payment-api` | `apps` (bare ns) | `matchNamespace` |
+| `apps` (bare ns) | `apps/web` | `matchNamespace` |
+| `apps` (bare ns) | `apps` | `matchExact` |
+| `apps/payment-api` | `other/web` | `matchNone` |
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| `workloadFromLabels` + use in `FromIncident` | `internal/investigate/investigate.go` |
+| `resourceAgrees` namespace-strength fix | `internal/investigate/recall.go` |
+| `affected_resource` schema + `findings` field + `parseFindings` | `internal/investigate/tools.go` |
+| Prefer discovered resource over `req.Workload` | `internal/investigate/loop.go` |
+| Tests | `investigate_test.go`, `recall_test.go`, `tools_test.go`, `loop_test.go` |
+
+## 5. Trade-offs accepted in v1
+
+- **Label heuristic, not ground truth** — `workloadFromLabels` derives the workload from whatever labels the alert carries; a missing/odd label set falls back to namespace-only (today's behavior, safe). The controller-over-pod precedence is a best-effort to match curated entries.
+- **Read/write convergence is best-effort** — the read side derives from labels, the write side from the model's discovery; they may pick different identifiers for the same incident. A mismatch degrades to `matchNamespace` (if one is bare-ns) or `matchNone` (a missed recall → a correct full investigation). Fail-safe either way.
+- **`RequireWorkloadMatch` default stays `false`** — the namespace fallback remains for genuinely namespace-scoped alerts/entries; only the over-matching of distinct names is removed.
+- **Matching-semantics change** — existing recall tests that relied on the old prefix behavior are updated as part of this slice.
+
+## 6. Testing
+
+- **`workloadFromLabels`**: `{deployment:"payment-api"}`→`(Deployment, payment-api)`; `{pod:"x-abc"}`→`(Pod, x-abc)`; both present → controller wins; `{workload:"w","workload_type":"Rollout"}`→`(Rollout, w)`; none → `("","")`.
+- **`resourceAgrees`** (the matrix in §3.3), including the key `apps/payment-api` vs `apps/web` → `matchNone`, and both bare-namespace fallbacks → `matchNamespace`.
+- **`FromIncident`**: an incident with a `deployment` (or `pod`) label yields a `Workload` carrying that name + kind.
+- **`parseFindings`**: `affected_resource` populates `inv.Resource`.
+- **`loop`**: the model's discovered resource is preferred; a name without a namespace inherits the alert's namespace; absent → falls back to `req.Workload`.
+- **Disambiguation (success metric)**: two catalog entries `apps/payment-api` and `apps/web`; an alert labeled `deployment=payment-api` (ns `apps`) recalls only the `payment-api` entry; a `web` alert does not match it.
+- Existing recall/loop tests stay green (updating any that asserted the old prefix-match semantics).
+
+## 7. Out of scope (later slices)
+
+- Flipping the `RequireWorkloadMatch` default to `true`.
+- Curator / KB-frontmatter changes (the curator benefits automatically via `inv.Resource`).
+- Indexing `resource` as a filterable bleve field / widening internal `k` / cause-text indexing (roadmap #3 — the lexical-retrieval half).
+- Any decay or eval change.
+
+This slice turns Gate 2 from a namespace check into a real workload check — so a curated incident entry recalls for the workload it describes, not for every workload that happens to share its namespace.

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -40,12 +40,37 @@ type Request struct {
 	Fingerprint string // Alertmanager fingerprint (stable firing↔resolved); for outcome attribution
 }
 
+// workloadFromLabels derives the affected workload (kind, name) from Alertmanager
+// labels, preferring a stable controller name over an ephemeral pod name.
+func workloadFromLabels(labels map[string]string) (kind, name string) {
+	for _, c := range []struct{ label, kind string }{
+		{"deployment", "Deployment"},
+		{"statefulset", "StatefulSet"},
+		{"daemonset", "DaemonSet"},
+		{"replicaset", "ReplicaSet"},
+		{"cronjob", "CronJob"},
+		{"job", "Job"},
+	} {
+		if v := labels[c.label]; v != "" {
+			return c.kind, v
+		}
+	}
+	if v := labels["workload"]; v != "" {
+		return labels["workload_type"], v // kind may be empty
+	}
+	if v := labels["pod"]; v != "" {
+		return "Pod", v
+	}
+	return "", ""
+}
+
 // FromIncident builds a Request from a matched incident alert.
 func FromIncident(inc config.Incident) Request {
+	kind, name := workloadFromLabels(inc.Labels)
 	return Request{
 		Source:      SourceAlert,
 		Title:       inc.AlertName,
-		Workload:    providers.Workload{Namespace: inc.Namespace},
+		Workload:    providers.Workload{Namespace: inc.Namespace, Kind: kind, Name: name},
 		Reason:      inc.Severity,
 		Labels:      inc.Labels,
 		At:          inc.StartsAt,

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -126,3 +126,32 @@ func TestFromIncidentCarriesFingerprint(t *testing.T) {
 		t.Fatalf("Request.Fingerprint = %q, want fp-9", r.Fingerprint)
 	}
 }
+
+func TestWorkloadFromLabels(t *testing.T) {
+	cases := []struct {
+		name             string
+		labels           map[string]string
+		wantKind, wantNm string
+	}{
+		{"deployment", map[string]string{"deployment": "payment-api"}, "Deployment", "payment-api"},
+		{"pod only", map[string]string{"pod": "x-abc123"}, "Pod", "x-abc123"},
+		{"controller beats pod", map[string]string{"deployment": "payment-api", "pod": "payment-api-abc"}, "Deployment", "payment-api"},
+		{"workload with type", map[string]string{"workload": "w", "workload_type": "Rollout"}, "Rollout", "w"},
+		{"workload no type -> empty kind", map[string]string{"workload": "w"}, "", "w"},
+		{"none", map[string]string{"severity": "critical"}, "", ""},
+	}
+	for _, c := range cases {
+		k, n := workloadFromLabels(c.labels)
+		if k != c.wantKind || n != c.wantNm {
+			t.Errorf("%s: got (%q,%q), want (%q,%q)", c.name, k, n, c.wantKind, c.wantNm)
+		}
+	}
+}
+
+func TestFromIncidentDerivesWorkload(t *testing.T) {
+	inc := config.Incident{AlertName: "Crash", Namespace: "apps", Labels: map[string]string{"namespace": "apps", "deployment": "payment-api"}}
+	r := FromIncident(inc)
+	if r.Workload.Namespace != "apps" || r.Workload.Name != "payment-api" || r.Workload.Kind != "Deployment" {
+		t.Fatalf("FromIncident workload = %+v, want apps/payment-api Deployment", r.Workload)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -198,7 +198,9 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				if inv.Title == "" {
 					inv.Title = req.Title // default to the triggering incident/failure
 				}
-				inv.Resource = req.Workload       // record the originating workload for structural recall
+				// Prefer the workload the investigation identified; fall back to the
+				// originating alert workload only when the model named none.
+				inv.Resource = preferDiscoveredResource(inv.Resource, req.Workload)
 				inv.Fingerprint = req.Fingerprint // originating alert id, for outcome-ledger attribution
 				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 				if li.Metrics != nil {
@@ -259,6 +261,21 @@ func (li *LoopInvestigator) deliver(req Request, inv providers.Investigation) {
 	if li.OnComplete != nil {
 		li.OnComplete(inv)
 	}
+}
+
+// preferDiscoveredResource keeps the workload the investigation identified,
+// defaulting a missing namespace to the originating alert's, and falls back to the
+// alert workload only when the model named none.
+func preferDiscoveredResource(discovered, origin providers.Workload) providers.Workload {
+	if discovered.Name != "" && discovered.Namespace == "" {
+		discovered.Namespace = origin.Namespace
+	}
+	if discovered.Ref() == "" {
+		return origin
+	}
+	// A discovered resource with a namespace but no name (Ref()=="ns") is kept as-is —
+	// the model named a namespace-scoped resource even without a specific workload.
+	return discovered
 }
 
 func seedPrompt(req Request) string {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -205,6 +205,25 @@ func TestLoopInvestigator(t *testing.T) {
 	}
 }
 
+func TestPreferDiscoveredResource(t *testing.T) {
+	origin := providers.Workload{Namespace: "apps", Name: "web"}
+	cases := []struct {
+		name       string
+		discovered providers.Workload
+		want       providers.Workload
+	}{
+		{"discovered wins", providers.Workload{Namespace: "apps", Name: "payment-api", Kind: "Deployment"}, providers.Workload{Namespace: "apps", Name: "payment-api", Kind: "Deployment"}},
+		{"namespace defaulted from origin", providers.Workload{Name: "payment-api"}, providers.Workload{Namespace: "apps", Name: "payment-api"}},
+		{"empty falls back to origin", providers.Workload{}, origin},
+		{"namespace-only discovered kept", providers.Workload{Namespace: "ops"}, providers.Workload{Namespace: "ops"}},
+	}
+	for _, c := range cases {
+		if got := preferDiscoveredResource(c.discovered, origin); got != c.want {
+			t.Errorf("%s: got %+v, want %+v", c.name, got, c.want)
+		}
+	}
+}
+
 // bigTool is a fake Tool that returns a string of length n filled with 'z'.
 type bigTool struct{ size int }
 

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -134,7 +134,12 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 	if requireWorkload {
 		return matchNone
 	}
-	if entryResource == reqW.Namespace || strings.HasPrefix(entryResource, reqW.Namespace+"/") {
+	// Namespace-level agreement only when one side is a bare namespace — never two
+	// distinct named workloads (that would defeat disambiguation).
+	if entryResource == reqW.Namespace { // entry is a bare namespace; reqW is in it
+		return matchNamespace
+	}
+	if reqW.Name == "" && strings.HasPrefix(entryResource, reqW.Namespace+"/") { // reqW is a bare namespace; entry named in it
 		return matchNamespace
 	}
 	return matchNone

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -274,6 +274,34 @@ func TestLookupDecayFactorAtFloorRecalls(t *testing.T) {
 	}
 }
 
+func TestResourceAgrees(t *testing.T) {
+	w := func(ns, name string) providers.Workload { return providers.Workload{Namespace: ns, Name: name} }
+	cases := []struct {
+		name      string
+		reqW      providers.Workload
+		entry     string
+		requireWL bool
+		want      matchStrength
+	}{
+		{"exact ns/name", w("apps", "payment-api"), "apps/payment-api", false, matchExact},
+		{"different names same ns -> none", w("apps", "payment-api"), "apps/web", false, matchNone},
+		{"named alert vs bare-ns entry -> namespace", w("apps", "payment-api"), "apps", false, matchNamespace},
+		{"bare-ns alert vs named entry -> namespace", w("apps", ""), "apps/web", false, matchNamespace},
+		{"both bare ns -> exact", w("apps", ""), "apps", false, matchExact},
+		{"different ns -> none", w("apps", "payment-api"), "other/web", false, matchNone},
+		{"empty entry -> none", w("apps", "payment-api"), "", false, matchNone},
+		{"require workload + exact -> exact", w("apps", "web"), "apps/web", true, matchExact},
+		{"require workload + ns-only -> none", w("apps", ""), "apps/web", true, matchNone},
+		{"require workload + bare-ns entry -> none", w("apps", "web"), "apps", true, matchNone},
+		{"bare-ns alert vs different-ns bare-ns entry -> none", w("apps", ""), "other", false, matchNone},
+	}
+	for _, c := range cases {
+		if got := resourceAgrees(c.reqW, c.entry, c.requireWL); got != c.want {
+			t.Errorf("%s: resourceAgrees(%+v, %q, %v) = %v, want %v", c.name, c.reqW, c.entry, c.requireWL, got, c.want)
+		}
+	}
+}
+
 func TestLookupDecayRejectionMetric(t *testing.T) {
 	h, shutdown, err := telemetry.Setup(context.Background())
 	if err != nil {

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -274,6 +274,30 @@ func TestLookupDecayFactorAtFloorRecalls(t *testing.T) {
 	}
 }
 
+func TestLookupRecallsMatchingWorkload(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "payment.md", Resource: "apps/payment-api"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "X", Path: "b.md"}, Score: 2.0},
+	})
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps", Name: "payment-api"}}
+	if e, _ := r.lookup(context.Background(), req); e == nil {
+		t.Fatal("an alert for payment-api should recall the payment-api entry (exact match)")
+	}
+}
+
+func TestLookupDoesNotRecallDifferentWorkloadSameNamespace(t *testing.T) {
+	// The disambiguation success metric: a payment-api alert must NOT recall a
+	// different workload's (web) entry just because they share the namespace.
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "web.md", Resource: "apps/web"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "X", Path: "b.md"}, Score: 2.0},
+	})
+	req := Request{Title: "crashloop", Workload: providers.Workload{Namespace: "apps", Name: "payment-api"}}
+	if e, _ := r.lookup(context.Background(), req); e != nil {
+		t.Fatal("a payment-api alert must not recall a different workload's entry in the same namespace")
+	}
+}
+
 func TestResourceAgrees(t *testing.T) {
 	w := func(ns, name string) providers.Workload { return providers.Workload{Namespace: ns, Name: name} }
 	cases := []struct {

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -29,6 +29,7 @@ func submitFindingsSpec() providers.ToolSpec {
 		Schema: `{"type":"object","properties":{
 "title":{"type":"string"},
 "confidence":{"type":"number"},
+"affected_resource":{"type":"object","description":"the workload your investigation identified as the failing/affected resource","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}},
 "root_causes":{"type":"array","items":{"type":"object","properties":{
 "summary":{"type":"string"},"confidence":{"type":"number"},"change_ref":{"type":"string"},
 "evidence":{"type":"array","items":{"type":"string"}},"suggested_action":{"type":"string"},"reversible":{"type":"boolean"}},
@@ -59,8 +60,13 @@ func opEnumJSON() string {
 
 // findings is the JSON shape of submit_findings arguments.
 type findings struct {
-	Title      string  `json:"title"`
-	Confidence float64 `json:"confidence"`
+	Title            string  `json:"title"`
+	Confidence       float64 `json:"confidence"`
+	AffectedResource struct {
+		Kind      string `json:"kind"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"affected_resource"`
 	RootCauses []struct {
 		Summary         string   `json:"summary"`
 		Confidence      float64  `json:"confidence"`
@@ -110,6 +116,11 @@ func parseFindings(args string) (providers.Investigation, error) {
 			Reversible:  a.Reversible,
 			BlastRadius: a.BlastRadius,
 		})
+	}
+	inv.Resource = providers.Workload{
+		Kind:      f.AffectedResource.Kind,
+		Name:      f.AffectedResource.Name,
+		Namespace: f.AffectedResource.Namespace,
 	}
 	return inv, nil
 }

--- a/internal/investigate/tools_test.go
+++ b/internal/investigate/tools_test.go
@@ -74,3 +74,15 @@ func TestSubmitFindingsSchemaNoEmptyEnum(t *testing.T) {
 	}
 	walk("$", schema)
 }
+
+func TestParseFindingsAffectedResource(t *testing.T) {
+	args := `{"root_causes":[{"summary":"OOM in payment-api"}],
+	  "affected_resource":{"kind":"Deployment","name":"payment-api","namespace":"apps"}}`
+	inv, err := parseFindings(args)
+	if err != nil {
+		t.Fatalf("parseFindings: %v", err)
+	}
+	if inv.Resource.Namespace != "apps" || inv.Resource.Name != "payment-api" || inv.Resource.Kind != "Deployment" {
+		t.Fatalf("affected_resource not parsed into inv.Resource: %+v", inv.Resource)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -353,7 +353,7 @@ type Investigation struct {
 	Unresolved    []string // honest: what the agent could not determine
 	Confidence    float64
 	Recalled      bool     // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
-	Resource      Workload // the originating workload; stored on curated entries for structural recall matching
+	Resource      Workload // the workload the investigation identified as affected; defaults to the originating alert workload when none was named (stored on curated entries for structural recall)
 	Actions       []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
 	CuratedURL    string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
 	Fingerprint   string   // originating alert fingerprint; for outcome-ledger attribution


### PR DESCRIPTION
## Summary

Makes instant-recall's structural gate (Gate 2) tell apart different workloads in the same namespace, so a curated entry recalls only for the workload it describes — not every workload sharing its namespace. Three coordinated changes in `internal/investigate`:

- **Match fix** (`resourceAgrees`): two distinct named workloads in one namespace → `matchNone`. Namespace-strength agreement now applies only when one side is a bare namespace. Previously `apps/payment-api` matched `apps/web` via `HasPrefix("apps/web","apps/")`.
- **Read side** (`workloadFromLabels` → `FromIncident`): derive `Workload.Name`/`Kind` from alert labels (controller → `workload` → `pod` precedence; controllers preferred for stable, runbook-matchable names).
- **Write side** (`affected_resource` in `submit_findings` → `parseFindings` → `preferDiscoveredResource`): the loop records the workload the investigation *discovered* (defaulting a missing namespace to the alert's, falling back only when none was named). The curator stores `inv.Resource.Ref()`, so curated entries now carry the discovered `ns/name` automatically.

Net: `apps/payment-api` stops recalling `apps/web`'s entry. `RequireWorkloadMatch` default unchanged (`false`); the namespace fallback is preserved for genuinely namespace-scoped alerts/entries.

Spec: `docs/superpowers/specs/2026-06-23-recall-disambiguation-design.md` · Plan: `docs/superpowers/plans/2026-06-23-recall-disambiguation.md`

## Test Plan
- [x] `go build ./...`, `go vet ./...` clean; `go test ./...` all pass
- [x] `resourceAgrees` full matrix (esp. distinct-named-same-ns → matchNone, both bare-ns fallbacks)
- [x] `workloadFromLabels` precedence; `FromIncident` derives name/kind
- [x] `parseFindings` reads `affected_resource`; `preferDiscoveredResource` prefer/default/fallback
- [x] success-metric lookup tests: a payment-api alert recalls only the payment-api entry, not web
- [ ] CI green