### PR TITLE
  feat(recall): wider candidate set + structural pre-filter (findability)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-recall-retrieval.md
+++ b/docs/superpowers/plans/2026-06-23-recall-retrieval.md
@@ -1,0 +1,238 @@
+# Recall Retrieval — Wider Candidates + Structural Pre-filter — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make instant recall find the structurally-correct catalog entry even when it isn't the top lexical hit, by fetching a wider candidate set, pre-filtering by structural agreement, and applying the margin gate among the agreeing candidates.
+
+**Architecture:** One atomic restructure of `Recall.lookup` in `internal/investigate/recall.go`: `SearchScored(query, recallCandidateK)` → structural pre-filter (preserving lexical order) → margin gate among the agreeing subset → derive + decay (unchanged) on the winner. Go-side filter; no bleve index change.
+
+**Tech Stack:** Go 1.26, stdlib `testing` (no testify). Tests use the existing `recallWith`/`okReq`/`fakeScored` helpers in `internal/investigate/` (`fakeScored.SearchScored` ignores `k` and returns all hits, so multi-candidate tests work directly).
+
+**Spec:** `docs/superpowers/specs/2026-06-23-recall-retrieval-design.md`
+
+**Branch:** `feat/recall-retrieval` (already checked out; the spec is already committed there).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/investigate/recall.go` | recall gate | `recallCandidateK` constant; restructure `lookup` (wider fetch → structural pre-filter → margin among agreeing) |
+| `internal/investigate/recall_test.go` | recall tests | add 3 tests (non-top-lexical winner, margin-among-agreeing clear winner, no-agreement); update `TestLookupMarginNearTieFallsThrough` |
+
+The change is atomic (you cannot half-restructure `lookup` and keep tests green), so it is one implementation task (T1) plus whole-package verification (T2).
+
+---
+
+### Task 1: Restructure `lookup` — wider candidates + structural pre-filter
+
+**Files:**
+- Modify: `internal/investigate/recall.go` (`lookup`, currently `:48-108`; add `recallCandidateK` const)
+- Test: `internal/investigate/recall_test.go`
+
+- [ ] **Step 1: Write the failing headline test**
+
+Add to `internal/investigate/recall_test.go`:
+
+```go
+func TestLookupStructuralWinnerBelowTopLexical(t *testing.T) {
+	// The two highest lexical hits are DIFFERENT workloads; the structurally-correct
+	// entry (apps/web) is only the 3rd lexical hit. Pre-filtering must surface it —
+	// the old k=2 / top-hit-only logic could not.
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OtherA", Path: "a.md", Resource: "apps/api"}, Score: 9.0},
+		{Entry: catalog.Entry{Title: "OtherB", Path: "b.md", Resource: "apps/worker"}, Score: 8.0},
+		{Entry: catalog.Entry{Title: "Web OOM", Path: "web.md", Resource: "apps/web"}, Score: 5.0},
+	})
+	e, _ := r.lookup(context.Background(), okReq()) // okReq workload = apps/web
+	if e == nil || e.Path != "web.md" {
+		t.Fatalf("expected the structurally-correct apps/web entry (web.md) to be recalled, got %+v", e)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/investigate/ -run TestLookupStructuralWinnerBelowTopLexical`
+Expected: FAIL — under current logic `hits[0]` is `a.md` (`apps/api`), Gate 2 rejects (`no_resource_match`), so `lookup` returns `nil` and the test's `e == nil` branch fires.
+
+- [ ] **Step 3: Restructure `lookup`**
+
+In `internal/investigate/recall.go`, add the constant just above `lookup`:
+
+```go
+// recallCandidateK is the internal lexical candidate window. Recall fetches this
+// many hits, then structurally pre-filters them, so an entry matching the alert's
+// workload is reachable even when other workloads' entries score higher on symptom
+// text alone.
+const recallCandidateK = 20
+```
+
+Replace the entire body of `lookup` (from the `SearchScored` line through `return &e, conf`) with:
+
+```go
+	// Query the symptom (title + message); severity/reason is noise for matching.
+	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), recallCandidateK)
+	if err != nil || len(hits) == 0 {
+		return nil, 0
+	}
+
+	// Structural pre-filter: keep candidates whose stored resource agrees with the
+	// alert's workload, preserving lexical order. Pre-filtering (rather than checking
+	// only the top hit) lets a structurally-correct entry win even when wrong-workload
+	// entries score higher on symptom tokens.
+	var agreeing []catalog.ScoredEntry
+	for _, h := range hits {
+		if resourceAgrees(req.Workload, h.Entry.Resource, r.RequireWorkloadMatch) != matchNone {
+			agreeing = append(agreeing, h)
+		}
+	}
+	if len(agreeing) == 0 {
+		if r.Metrics != nil {
+			r.Metrics.RecallScore.Record(ctx, hits[0].Score) // best lexical score, for miss visibility
+		}
+		r.reject(ctx, "no_resource_match")
+		return nil, 0
+	}
+
+	winner := agreeing[0]
+	score := winner.Score
+	if r.Metrics != nil {
+		r.Metrics.RecallScore.Record(ctx, score)
+	}
+
+	// Gate — margin among the structurally-agreeing candidates: a clear winner for
+	// this workload, not merely the top lexical hit. A lone agreeing hit must clear
+	// both the solo floor and the min score.
+	margin := score
+	confident := score >= r.SoloFloor && score >= r.MinScore
+	if len(agreeing) > 1 {
+		margin = score - agreeing[1].Score
+		confident = score >= r.MinScore && margin >= r.MarginGap
+	}
+	if !confident {
+		r.reject(ctx, "low_margin")
+		return nil, 0
+	}
+
+	e := winner.Entry
+	strength := resourceAgrees(req.Workload, e.Resource, r.RequireWorkloadMatch)
+	conf := deriveRecallConfidence(score, margin, strength)
+	// Outcome decay: bias confidence by the entry's resolution track record, and
+	// reject (re-investigate) an entry that recalls-but-never-resolves. Fail-safe —
+	// a rejected recall just falls through to a full investigation.
+	if r.Outcome != nil {
+		if counts, err := r.Outcome.OpenCounts(); err == nil {
+			if agg, ok := counts[e.Path]; ok { // only entries with recall history
+				f := outcomeFactor(agg.Recalls, agg.Resolved, r.OutcomePrior)
+				if f < r.OutcomeFloor {
+					r.reject(ctx, "low_outcome")
+					return nil, 0
+				}
+				conf = clampF(conf*f, 0, 0.90)
+			}
+		} else if r.Log != nil {
+			r.Log.Warn("recall: outcome stats unavailable; skipping decay", "err", err)
+		}
+	}
+	if r.Log != nil {
+		r.Log.Info("instant recall decision",
+			"alert", req.Title, "entry_id", e.Path, "score", score, "margin", margin, "confidence", conf)
+	}
+	return &e, conf
+```
+
+(The `if r == nil || r.Catalog == nil { return nil, 0 }` guard at the top of `lookup` stays; only the body below it is replaced. `resourceAgrees`, `deriveRecallConfidence`, `outcomeFactor`, `clampF`, `reject` are unchanged.)
+
+- [ ] **Step 4: Run the headline test to verify it passes**
+
+Run: `go test ./internal/investigate/ -run TestLookupStructuralWinnerBelowTopLexical`
+Expected: PASS — `agreeing = [web.md]` (the two higher hits are different workloads), solo, `5.0 >= SoloFloor 4.0` → recalls `web.md`.
+
+- [ ] **Step 5: Update the near-tie test for the new margin semantics**
+
+In `internal/investigate/recall_test.go`, replace `TestLookupMarginNearTieFallsThrough` with the version below (the runner-up now shares the winner's resource, so it is a genuine *same-workload* near-tie post-filter):
+
+```go
+func TestLookupMarginNearTieFallsThrough(t *testing.T) {
+	// Two entries for the SAME workload with a near-tie (gap 0.5 < MarginGap 1.0) →
+	// genuinely ambiguous → falls through. (Post-structural-filter the margin compares
+	// same-workload candidates, not arbitrary lexical neighbours.)
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "BadImage", Path: "b.md", Resource: "apps/web"}, Score: 5.5},
+	})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("near-tie among same-workload entries (gap 0.5 < 1.0) must fall through")
+	}
+}
+```
+
+- [ ] **Step 6: Add the remaining new tests**
+
+Add to `internal/investigate/recall_test.go`:
+
+```go
+func TestLookupMarginAmongAgreeingClearWinner(t *testing.T) {
+	// Two same-workload entries with a clear margin (gap 4.0 >= 1.0) → recall the winner.
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Web recent", Path: "web1.md", Resource: "apps/web"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "Web old", Path: "web2.md", Resource: "apps/web"}, Score: 2.0},
+	})
+	e, _ := r.lookup(context.Background(), okReq())
+	if e == nil || e.Path != "web1.md" {
+		t.Fatalf("clear same-workload winner should recall web1.md, got %+v", e)
+	}
+}
+
+func TestLookupNoAgreeingCandidateFallsThrough(t *testing.T) {
+	// Every candidate is a different workload → none agree → fall through.
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "A", Path: "a.md", Resource: "apps/api"}, Score: 9.0},
+		{Entry: catalog.Entry{Title: "B", Path: "b.md", Resource: "other/web"}, Score: 8.0},
+	})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("no structurally-agreeing candidate must fall through")
+	}
+}
+```
+
+- [ ] **Step 7: Run the full package test**
+
+Run: `go test ./internal/investigate/`
+Expected: PASS — the new/updated tests plus all pre-existing recall tests. Notably still green:
+- `TestLookupMarginClearWinner` (runner-up has empty `Resource` → filtered out → winner is solo, `6.0 >= 4.0` → recalls);
+- `TestLookupStructuralMatch` / `TestLookupStructuralNamespaceOnly` / `TestLookupStructuralMismatchFallsThrough` / `TestLookupNoStoredResourceFallsThrough`;
+- the decay tests (`soloRecall` has a single hit → solo path) and the success-metric disambiguation tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/investigate/recall.go internal/investigate/recall_test.go
+git commit -m "feat(recall): wider candidate set + structural pre-filter so the right entry is findable"
+```
+
+---
+
+### Task 2: Whole-tree verification
+
+- [ ] **Step 1: Build, test, vet**
+
+Run:
+```bash
+go build ./... && go test ./... && go vet ./...
+```
+Expected: build clean; all tests PASS; vet clean.
+
+No commit (verification only).
+
+---
+
+## Notes for the implementer
+
+- `fakeScored.SearchScored(string, int)` ignores `k` and returns all configured `hits`, so the multi-candidate tests exercise the pre-filter directly even though production fetches `recallCandidateK`.
+- The margin now compares the top two **structurally-agreeing** candidates (or applies the solo floor when only one agrees). This is the intended semantics change; the only existing test it affects is `TestLookupMarginNearTieFallsThrough`, updated in Step 5.
+- `RecallScore` is recorded for the winner on the agreeing path, and for the top lexical hit on a no-agreement miss — so the histogram stays populated for threshold tuning either way.
+- Do not add a bleve resource field, field boosting, or a config knob for `recallCandidateK` — all deferred (spec §7). `kb_search` (k=3) is a separate path; leave it.
+- `resourceAgrees` is computed per-candidate in the filter and once more for the winner (to get its `strength` for `deriveRecallConfidence`); it is cheap and pure, so the recompute is fine.

--- a/docs/superpowers/specs/2026-06-23-recall-retrieval-design.md
+++ b/docs/superpowers/specs/2026-06-23-recall-retrieval-design.md
@@ -1,0 +1,90 @@
+# RunLore Recall Retrieval — Wider Candidates + Structural Pre-filter — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Make instant recall *find* the structurally-correct catalog entry instead of only checking the single top lexical hit: fetch a wider candidate set, pre-filter by structural agreement, and apply the margin gate among the structurally-agreeing candidates. Confined to `internal/investigate/recall.go`. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | Deep-analysis report (`docs/analysis/2026-06-23-deep-analysis.md`) roadmap #3 / "structural agreement is a post-rank filter at k=2 — the correct entry ranked #3 is never seen"; builds directly on the disambiguation slice (`2026-06-23-recall-disambiguation-design.md`, which made `resourceAgrees` discriminate) and the BM25 scorer fix (`2026-06-23-bm25-scorer-fix-design.md`) |
+
+---
+
+## 1. Why this exists
+
+The disambiguation slice fixed *how* recall decides a workload matches (`resourceAgrees`), but recall still only ever inspects `hits[0]` from a `k=2` lexical search (`recall.go:54,78`). So the structural check is a **post-rank filter on a single candidate**: if the entry that actually matches the alert's workload is the 3rd-best lexical hit (because two other entries have more symptom-token overlap), recall never sees it and falls through to a full investigation. Symptom text is many-to-one with root causes, so the lexically-top entries are frequently the *wrong* workload — exactly when the right one is buried.
+
+This slice turns structural agreement into a **pre-filter over a wider candidate set**: fetch more candidates, keep those whose stored resource agrees with the alert's workload, and only then ask "is there a clear winner among them?" The right entry becomes findable; an irrelevant lexical neighbour can no longer block a correct recall.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Widen the internal candidate `k` + pre-filter in Go** (not a bleve filterable field) | Candidates already carry the full `Entry` (incl. `Resource`); filtering a wider slice in Go needs no index/schema change and is sufficient at current scale. A bleve `ConjunctionQuery` over an indexed `resource` field is the scale-version follow-up. |
+| D2 | **Margin gate operates among the structurally-agreeing candidates** | After pre-filtering by workload, the margin should ask "is there one clear winner *for this workload*", not "is the top lexical hit a clear winner". A lexically-similar but structurally-irrelevant neighbour must not suppress a correct recall. |
+| D3 | **`recallCandidateK = 20` as an internal constant** | Not user-facing; YAGNI on a config knob. Large enough that the structurally-correct entry is in the candidate window for realistic catalog sizes; small enough to stay cheap. |
+| D4 | **No bleve index change; no field boosting; no cause/resolution re-indexing** | Cause/resolution text is already in the indexed `text` field (via the entry `Body`). The gap was candidate *selection*, not indexed *content*. Field boosting (title^3…) is a separate concern. |
+
+## 3. Design
+
+### 3.1 Restructured `lookup` (`recall.go`)
+
+Today (`recall.go:48-108`): `SearchScored(query, 2)` → record `hits[0].Score` → Gate 1 margin over top-2 lexical → Gate 2 structural on `hits[0]` → derive + decay → return.
+
+New flow:
+
+1. **Fetch wider:** `hits, err := r.Catalog.SearchScored(query, recallCandidateK)` (`recallCandidateK = 20`). Empty/err → return `(nil, 0)` (unchanged).
+2. **Structural pre-filter:** build `agreeing []catalog.ScoredEntry` preserving lexical order, keeping each hit whose `resourceAgrees(req.Workload, hit.Entry.Resource, r.RequireWorkloadMatch) != matchNone`. If `len(agreeing) == 0`: record the top lexical score (`hits[0].Score`) for miss visibility, `reject(ctx, "no_resource_match")`, return `(nil, 0)`.
+3. **Pick the winner + record:** `winner := agreeing[0]`; `score := winner.Score`; record `score` to `RecallScore` (the value the floors gate).
+4. **Gate — margin among agreeing:**
+   - `len(agreeing) == 1`: `confident = score >= r.SoloFloor && score >= r.MinScore`; `margin = score`.
+   - else: `margin = score - agreeing[1].Score`; `confident = score >= r.MinScore && margin >= r.MarginGap`.
+   - `!confident` → `reject(ctx, "low_margin")`, return `(nil, 0)`.
+5. **Derive + decay** (unchanged): `strength := resourceAgrees(req.Workload, winner.Entry.Resource, r.RequireWorkloadMatch)`; `conf := deriveRecallConfidence(score, margin, strength)`; apply the outcome-decay block keyed on `winner.Entry.Path`; log; return `(&winner.Entry, conf)`.
+
+`recallCandidateK` is a package constant in `recall.go`. `kb_search` (the LLM grounding tool, `k=3`) is unchanged — it is a separate path, not the short-circuit.
+
+### 3.2 The margin's meaning changes (intentional)
+
+Previously the margin guarded against *lexical* ambiguity (two similar-looking entries, regardless of workload). Now it guards against ambiguity *among entries for the matched workload*. Consequences:
+
+- A lexically-similar entry for a **different** workload no longer suppresses a correct recall (it's filtered out before the margin).
+- A near-tie that should still fall through is one between **two entries for the same workload** (e.g. two incidents on `apps/web` with close scores) — genuinely ambiguous, so recall correctly declines.
+
+This updates one existing test, `TestLookupMarginNearTieFallsThrough`: its near-tie runner-up currently has an empty `Resource` (so post-filter it is no longer a competitor). It will be updated to give the runner-up the **same** resource as the winner, making it a genuine same-workload near-tie that still falls through.
+
+### 3.3 What is unchanged
+
+`resourceAgrees`, `deriveRecallConfidence`, `outcomeFactor`, the outcome-decay block, the rejection metric/reasons (`no_resource_match`, `low_margin`), the config knobs (`MinScore`/`SoloFloor`/`MarginGap`/`RequireWorkloadMatch`/decay), the catalog index, and `kb_search`.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| Widen candidate `k`; structural pre-filter; margin among agreeing; `recallCandidateK` constant | `internal/investigate/recall.go` (`lookup`) |
+| Tests (pre-filter surfaces a non-top-lexical winner; margin-among-agreeing; no-agreement; update near-tie) | `internal/investigate/recall_test.go` |
+
+## 5. Trade-offs accepted in v1
+
+- **Per-decision wider search** — `SearchScored(query, 20)` returns up to 20 candidates per recall; negligible over a bounded in-memory index, and recall frequency is low. A bleve-side resource filter (push-down) is the scale follow-up.
+- **Margin re-interpretation** — the margin now compares same-workload candidates. This is the intended, more-correct semantics, and it updates one test. For corpora where a workload has a single curated entry (the common case), the solo-floor path governs.
+- **Threshold continuity** — `MinScore`/`SoloFloor`/`MarginGap` now gate the structurally-chosen winner rather than the top lexical hit. Instant recall is opt-in/off by default and the thresholds are tunable from `recall_score` + `recall_rejections_total{reason}`, so this is acceptable; no default change.
+- **`recallCandidateK` fixed at 20** — if a workload legitimately has >20 entries more lexically-relevant ahead of the right one, the right one could still be missed (a missed recall → a correct full investigation, fail-safe). Unrealistic at current scale.
+
+## 6. Testing
+
+- **Pre-filter surfaces a non-top-lexical winner (headline):** candidates where the two highest lexical scores are *different-workload* entries and the structurally-correct entry is, say, 3rd; assert it is recalled (previously impossible at k=2).
+- **Margin among agreeing:** two **same-workload** entries with a near-tie (gap < `MarginGap`) → falls through (`low_margin`); a clear winner among same-workload entries → recalls.
+- **No structurally-agreeing candidate** in the wider set → `reject("no_resource_match")`, falls through, and `recall_score` still records the top lexical score (miss visibility).
+- **Single agreeing candidate** → solo-floor path (clears `SoloFloor`/`MinScore` → recalls; below → falls through).
+- **Update** `TestLookupMarginNearTieFallsThrough`: runner-up given the same `Resource` as the winner so the near-tie is genuine post-filter.
+- All other existing recall tests (structural matrix, decay branches, success-metric disambiguation, no-stored-resource) stay green.
+
+## 7. Out of scope (later slices)
+
+- Indexing `resource`/`namespace` as filterable bleve fields + a `ConjunctionQuery` push-down (the scale version of the pre-filter).
+- Per-field boosting (`title^3`, etc.) — the "single conflated `text` field" finding.
+- Making `recallCandidateK` (or `kb_search`'s `k`) configurable.
+- Any embeddings / hybrid-retrieval work.
+
+This slice closes the other half of the many-to-one problem: the disambiguation slice made the gate *discriminate*; this one makes the right entry *reachable*, so a correct recall is no longer lost just because a wrong-workload entry has more symptom-token overlap.

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -21,12 +21,12 @@ type OutcomeStats interface {
 }
 
 // Recall short-circuits an investigation when the knowledge catalog already has a
-// trustworthy answer for the symptom — skipping the slow, paid ReAct loop. A recall
-// must clear three gates: a BM25 margin over the runner-up (corpus-portable, unlike
-// an absolute MinScore), structural agreement on the affected resource, and (in the
-// loop) the adversarial verify pass. Confidence is derived from those signals, never
-// asserted — BM25 scores are corpus-dependent and a stale hit must not silently
-// replace an investigation.
+// trustworthy answer for the symptom — skipping the slow, paid ReAct loop. From a
+// wider candidate set it keeps only entries whose stored resource structurally
+// agrees with the alert's workload, then requires a clear margin over the runner-up
+// among those agreeing candidates, plus (in the loop) the adversarial verify pass.
+// Confidence is derived from those signals, never asserted — scores are
+// corpus-dependent and a stale hit must not silently replace an investigation.
 type Recall struct {
 	Catalog              catalog.ScoredSearcher
 	MinScore             float64 // similarity floor for the top hit
@@ -42,6 +42,12 @@ type Recall struct {
 	Log     *slog.Logger       // optional; nil-safe — log line omitted when unset
 }
 
+// recallCandidateK is the internal lexical candidate window. Recall fetches this
+// many hits, then structurally pre-filters them, so an entry matching the alert's
+// workload is reachable even when other workloads' entries score higher on symptom
+// text alone.
+const recallCandidateK = 20
+
 // lookup returns the matched entry and a DERIVED confidence when a recall is
 // trustworthy enough to short-circuit, else (nil, 0). The BM25 score is always
 // recorded (even on rejection) so the thresholds can be tuned from live data.
@@ -50,22 +56,42 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 		return nil, 0
 	}
 	// Query the symptom (title + message); severity/reason is noise for matching.
-	// k=2 so the top hit can be required to be an unambiguous winner.
-	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), 2)
+	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), recallCandidateK)
 	if err != nil || len(hits) == 0 {
 		return nil, 0
 	}
-	score := hits[0].Score
+
+	// Structural pre-filter: keep candidates whose stored resource agrees with the
+	// alert's workload, preserving lexical order. Pre-filtering (rather than checking
+	// only the top hit) lets a structurally-correct entry win even when wrong-workload
+	// entries score higher on symptom tokens.
+	var agreeing []catalog.ScoredEntry
+	for _, h := range hits {
+		if resourceAgrees(req.Workload, h.Entry.Resource, r.RequireWorkloadMatch) != matchNone {
+			agreeing = append(agreeing, h)
+		}
+	}
+	if len(agreeing) == 0 {
+		if r.Metrics != nil {
+			r.Metrics.RecallScore.Record(ctx, hits[0].Score) // best lexical score, for miss visibility
+		}
+		r.reject(ctx, "no_resource_match")
+		return nil, 0
+	}
+
+	winner := agreeing[0]
+	score := winner.Score
 	if r.Metrics != nil {
 		r.Metrics.RecallScore.Record(ctx, score)
 	}
 
-	// Gate 1 — similarity margin. A relative margin over the runner-up is portable
-	// across corpus sizes; a lone hit needs a higher solo floor.
+	// Gate — margin among the structurally-agreeing candidates: a clear winner for
+	// this workload, not merely the top lexical hit. A lone agreeing hit must clear
+	// both the solo floor and the min score.
 	margin := score
-	confident := score >= r.SoloFloor && score >= r.MinScore // a lone hit must clear both floors
-	if len(hits) > 1 {
-		margin = score - hits[1].Score
+	confident := score >= r.SoloFloor && score >= r.MinScore
+	if len(agreeing) > 1 {
+		margin = score - agreeing[1].Score
 		confident = score >= r.MinScore && margin >= r.MarginGap
 	}
 	if !confident {
@@ -73,15 +99,8 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 		return nil, 0
 	}
 
-	// Gate 2 — structural agreement: the alert's workload must match the entry's
-	// stored resource. This attacks "symptoms are many-to-one with root causes".
-	e := hits[0].Entry
+	e := winner.Entry
 	strength := resourceAgrees(req.Workload, e.Resource, r.RequireWorkloadMatch)
-	if strength == matchNone {
-		r.reject(ctx, "no_resource_match")
-		return nil, 0
-	}
-
 	conf := deriveRecallConfidence(score, margin, strength)
 	// Outcome decay: bias confidence by the entry's resolution track record, and
 	// reject (re-investigate) an entry that recalls-but-never-resolves. Fail-safe —

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -86,12 +86,15 @@ func TestLookupMarginClearWinner(t *testing.T) {
 }
 
 func TestLookupMarginNearTieFallsThrough(t *testing.T) {
+	// Two entries for the SAME workload with a near-tie (gap 0.5 < MarginGap 1.0) →
+	// genuinely ambiguous → falls through. (Post-structural-filter the margin compares
+	// same-workload candidates, not arbitrary lexical neighbours.)
 	r := recallWith([]catalog.ScoredEntry{
 		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web"}, Score: 6.0},
-		{Entry: catalog.Entry{Title: "BadImage", Path: "b.md"}, Score: 5.5},
+		{Entry: catalog.Entry{Title: "BadImage", Path: "b.md", Resource: "apps/web"}, Score: 5.5},
 	})
 	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
-		t.Fatal("near-tie (gap 0.5 < 1.0) must fall through")
+		t.Fatal("near-tie among same-workload entries (gap 0.5 < 1.0) must fall through")
 	}
 }
 
@@ -326,6 +329,42 @@ func TestResourceAgrees(t *testing.T) {
 	}
 }
 
+func TestLookupStructuralWinnerBelowTopLexical(t *testing.T) {
+	// The two highest lexical hits are DIFFERENT workloads; the structurally-correct
+	// entry (apps/web) is only the 3rd lexical hit. Pre-filtering must surface it —
+	// the old k=2 / top-hit-only logic could not.
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OtherA", Path: "a.md", Resource: "apps/api"}, Score: 9.0},
+		{Entry: catalog.Entry{Title: "OtherB", Path: "b.md", Resource: "apps/worker"}, Score: 8.0},
+		{Entry: catalog.Entry{Title: "Web OOM", Path: "web.md", Resource: "apps/web"}, Score: 5.0},
+	})
+	e, _ := r.lookup(context.Background(), okReq())
+	if e == nil || e.Path != "web.md" {
+		t.Fatalf("expected the structurally-correct apps/web entry (web.md) to be recalled, got %+v", e)
+	}
+}
+
+func TestLookupMarginAmongAgreeingClearWinner(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Web recent", Path: "web1.md", Resource: "apps/web"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "Web old", Path: "web2.md", Resource: "apps/web"}, Score: 2.0},
+	})
+	e, _ := r.lookup(context.Background(), okReq())
+	if e == nil || e.Path != "web1.md" {
+		t.Fatalf("clear same-workload winner should recall web1.md, got %+v", e)
+	}
+}
+
+func TestLookupNoAgreeingCandidateFallsThrough(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "A", Path: "a.md", Resource: "apps/api"}, Score: 9.0},
+		{Entry: catalog.Entry{Title: "B", Path: "b.md", Resource: "other/web"}, Score: 8.0},
+	})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("no structurally-agreeing candidate must fall through")
+	}
+}
+
 func TestLookupDecayRejectionMetric(t *testing.T) {
 	h, shutdown, err := telemetry.Setup(context.Background())
 	if err != nil {
@@ -345,5 +384,21 @@ func TestLookupDecayRejectionMetric(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if !strings.Contains(rec.Body.String(), `reason="low_outcome"`) {
 		t.Fatalf("expected recall_rejections_total{reason=\"low_outcome\"} in metrics:\n%s", rec.Body.String())
+	}
+}
+
+func TestLookupMarginAmongAgreeingWithDistractor(t *testing.T) {
+	// Two agreeing same-workload entries separated by a higher-scoring wrong-workload
+	// distractor. The winner must be the higher-lexical agreeing entry (web1.md @6.0),
+	// and the margin its gap to the next AGREEING entry (web2.md @2.0 → gap 4.0 >= 1.0),
+	// not the distractor (api.md). So it recalls web1.md.
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Web hot", Path: "web1.md", Resource: "apps/web"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "API noise", Path: "api.md", Resource: "apps/api"}, Score: 5.0},
+		{Entry: catalog.Entry{Title: "Web cold", Path: "web2.md", Resource: "apps/web"}, Score: 2.0},
+	})
+	e, _ := r.lookup(context.Background(), okReq()) // okReq workload = apps/web
+	if e == nil || e.Path != "web1.md" {
+		t.Fatalf("winner must be the higher-lexical agreeing entry web1.md, got %+v", e)
 	}
 }


### PR DESCRIPTION
  ## Summary

  Makes instant recall *find* the structurally-correct catalog entry even when it isn't the
  top lexical hit. Today the structural check runs on `hits[0]` of a `k=2` search, so an
  entry that matches the alert's workload but ranks 3rd lexically is never seen. This slice
  restructures `Recall.lookup` (all in `internal/investigate/recall.go`):

  - **Fetch wider:** `SearchScored(query, recallCandidateK)` with `recallCandidateK = 20`
  (internal constant).
  - **Structural pre-filter:** keep only candidates whose stored `Resource` agrees with the
  alert workload (`resourceAgrees != matchNone`), preserving lexical order.
  - **Margin among the agreeing subset:** winner vs next-agreeing (or solo floor) — so a
  lexically-similar but wrong-workload neighbor can't block a correct recall, and the right
  entry is reachable.
  - Derive + outcome-decay unchanged, keyed on the winner.

  The margin's meaning shifts (intentionally) from "lexical clear winner" to "clear winner
  among the matched workload's entries"; one existing test
  (`TestLookupMarginNearTieFallsThrough`) is updated so its runner-up shares the resource (a
  genuine same-workload near-tie). No bleve index change, no config knob, `kb_search`
  untouched.

  Complements the disambiguation slice (#73): that made the gate *discriminate*; this makes
  the right entry *reachable*.

  Spec: `docs/superpowers/specs/2026-06-23-recall-retrieval-design.md` · Plan:
  `docs/superpowers/plans/2026-06-23-recall-retrieval.md`

  The margin's meaning shifts (intentionally) from "lexical clear winner" to "clear winner among the matched workload's entries"; one existing test (`TestLookupMarginNearTieFallsThrough`)
  is updated so its runner-up shares the resource (a genuine same-workload near-tie). No bleve index change, no config knob, `kb_search` untouched.

  Complements the disambiguation slice (#73): that made the gate *discriminate*; this makes the right entry *reachable*.

  Spec: `docs/superpowers/specs/2026-06-23-recall-retrieval-design.md` · Plan: `docs/superpowers/plans/2026-06-23-recall-retrieval.md`

  ## Test Plan
  - [x] `go build ./...`, `go vet ./...` clean; `go test ./...` all pass
  - [x] headline: a structurally-correct entry ranked 3rd lexically is now recalled
  - [x] interleaved-distractor order preservation (winner = highest-lexical agreeing; runner-up = next agreeing)
  - [x] margin-among-agreeing near-tie → falls through; clear winner → recalls; no-agreement → falls through
  - [x] existing structural / decay / success-metric tests stay green
  - [ ] CI green