### PR TITLE
feat(outcome): per-fingerprint coalesce attribution + order-independent Episodes

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -240,6 +240,15 @@ func runServe(args []string) error {
 			if len(incs) > 1 {
 				rep.Message = coalesce.Summarize(incs)
 			}
+			// Record every constituent fingerprint so each alert's resolve webhook
+			// matches an open (a single incident stays one fingerprint).
+			var fps []string
+			for _, inc := range incs {
+				if inc.Fingerprint != "" {
+					fps = append(fps, inc.Fingerprint)
+				}
+			}
+			rep.Fingerprints = fps
 			queue.Enqueue(rep)
 		}
 		cz = coalesce.New(coalesce.Config{
@@ -1057,20 +1066,29 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 			// resolved-alert webhook later stamps whether it actually resolved.
 			// Skip sources without an alert fingerprint (GitOps watch, reinvestigate
 			// poller) — they could never be matched by a resolved-alert webhook.
-			if found.Fingerprint != "" {
+			fps := found.Fingerprints
+			if len(fps) == 0 && found.Fingerprint != "" {
+				fps = []string{found.Fingerprint}
+			}
+			if len(fps) > 0 {
 				kind := outcomeKind(found.Recalled)
-				if err := ledger.Open(outcome.Event{
-					Fingerprint: found.Fingerprint,
-					Kind:        kind,
-					Entry:       found.RecalledEntry,
-					Title:       found.Title,
-					Resource:    found.Resource.Ref(),
-					At:          time.Now(),
-				}); err != nil {
-					log.Warn("outcome ledger open failed", "fingerprint", found.Fingerprint, "err", err)
-				}
-				if metrics != nil {
-					metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", kind)))
+				now := time.Now()
+				// One open per constituent fingerprint (coalesced batches fan out), so
+				// every alert's resolve webhook can later match this investigation.
+				for _, fp := range fps {
+					if err := ledger.Open(outcome.Event{
+						Fingerprint: fp,
+						Kind:        kind,
+						Entry:       found.RecalledEntry,
+						Title:       found.Title,
+						Resource:    found.Resource.Ref(),
+						At:          now,
+					}); err != nil {
+						log.Warn("outcome ledger open failed", "fingerprint", fp, "err", err)
+					}
+					if metrics != nil {
+						metrics.OutcomesOpened.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", kind)))
+					}
 				}
 			}
 			// Post-investigation action handling, by mode. The loop has already

--- a/docs/superpowers/specs/2026-06-23-outcome-attribution-design.md
+++ b/docs/superpowers/specs/2026-06-23-outcome-attribution-design.md
@@ -1,0 +1,73 @@
+# Outcome attribution: coalesce + order-independent Episodes
+
+Date: 2026-06-23
+Slice: #10 outcome attribution
+
+## Problem
+
+The outcome ledger ("did the answer actually work?") has two attribution bugs:
+
+- **(A) Coalesced batches orphan fingerprints.** When the coalescer folds N
+  correlated alerts into one investigation, the `OnComplete` hook records a
+  single `open` for `incs[0]`'s fingerprint only. The other N-1 fingerprints are
+  never opened, so their resolved-alert webhooks match nothing and their
+  resolutions are silently lost — under-counting `Resolved` and skewing recall
+  decay.
+
+- **(B) `Episodes()` drops a resolve that arrives before its open.** `Episodes()`
+  replays the file in order and pairs each `resolve` with the most-recent
+  unresolved `open` (LIFO). A `resolve` seen before any `open` for that
+  fingerprint is dropped. This happens for a transient incident that fires,
+  triggers an investigation, then clears *mid-investigation* — the resolve
+  webhook lands before the investigation's `open` is written. The episode then
+  looks unresolved even though it resolved.
+
+## Approach
+
+### Part A — record an open per coalesced fingerprint
+
+- `investigate.Request` gains `Fingerprints []string` (the batch's fingerprints),
+  keeping the existing single `Fingerprint` field.
+- `FromIncident` sets `Fingerprints` to `[inc.Fingerprint]` (or nil when empty).
+- The coalescer flush sink (`cmd/lore/main.go`) sets `rep.Fingerprints` to every
+  non-empty fingerprint in the batch. A single incident stays one fingerprint.
+- `Request.Fingerprints` is threaded through `loop.go` and `recall.go` onto
+  `providers.Investigation.Fingerprints`.
+- `OnComplete` records one `ledger.Open(...)` per fingerprint (falling back to the
+  singular `Fingerprint` when the slice is empty), so each constituent alert's
+  resolve webhook can match.
+
+### Part B — order-independent `Episodes()` pairing
+
+Replay maintains two per-fingerprint queues:
+
+- `pendingOpens map[string][]int` — indices into the result `out` slice (LIFO).
+- `pendingResolves map[string][]time.Time` — resolve times seen before any open.
+
+On `open`: if a pending resolve exists, pop one and resolve the just-appended
+episode (guard `Duration` ≥ 0: if the resolve predates the open, use 0).
+Otherwise push the episode's index onto `pendingOpens`.
+
+On `resolve`: if a pending open exists, pop the most-recent (LIFO) and resolve it
+(unchanged behavior). Otherwise buffer the resolve time on `pendingResolves`.
+
+Recurrence semantics are unchanged (N opens + 1 resolve ⇒ N episodes, 1 resolved).
+
+The existing `TestEpisodesOrphanResolveSkipped` asserted the old drop behavior;
+it is replaced by `TestEpisodesResolveBeforeOpenPairs` asserting the new pairing.
+
+## Deferred (out of scope)
+
+- **TTL expiry** of never-resolving opens (follow-up): opens with no resolve grow
+  the in-memory index unbounded.
+- **Live metrics on a buffered (early) resolve.** `Resolve()` still returns
+  `ok=false` when the open hasn't been written yet (live path unchanged); only the
+  replay-based `Episodes()` now reconciles the ordering. The metric/learning signal
+  is recovered at replay time, not at the moment of the early webhook.
+
+## Note on disjointness
+
+This slice touches `internal/outcome/ledger.go`, `internal/investigate/{investigate,
+loop,recall}.go`, `internal/providers/providers.go`, and `cmd/lore/main.go`. The
+edited `loop.go` region (the single `inv.Fingerprint = req.Fingerprint` line) is
+disjoint from other in-flight work in that file.

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -30,14 +30,15 @@ const (
 
 // Request is a normalized investigation trigger.
 type Request struct {
-	Source      Source
-	Title       string
-	Workload    providers.Workload // optional; zero for alerts without a workload
-	Reason      string
-	Message     string
-	Labels      map[string]string
-	At          time.Time
-	Fingerprint string // Alertmanager fingerprint (stable firing↔resolved); for outcome attribution
+	Source       Source
+	Title        string
+	Workload     providers.Workload // optional; zero for alerts without a workload
+	Reason       string
+	Message      string
+	Labels       map[string]string
+	At           time.Time
+	Fingerprint  string   // Alertmanager fingerprint (stable firing↔resolved); for outcome attribution
+	Fingerprints []string // coalesced batch fingerprints; one open is recorded per entry so every constituent alert's resolve matches
 }
 
 // workloadFromLabels derives the affected workload (kind, name) from Alertmanager
@@ -67,14 +68,19 @@ func workloadFromLabels(labels map[string]string) (kind, name string) {
 // FromIncident builds a Request from a matched incident alert.
 func FromIncident(inc config.Incident) Request {
 	kind, name := workloadFromLabels(inc.Labels)
+	var fps []string
+	if inc.Fingerprint != "" {
+		fps = []string{inc.Fingerprint}
+	}
 	return Request{
-		Source:      SourceAlert,
-		Title:       inc.AlertName,
-		Workload:    providers.Workload{Namespace: inc.Namespace, Kind: kind, Name: name},
-		Reason:      inc.Severity,
-		Labels:      inc.Labels,
-		At:          inc.StartsAt,
-		Fingerprint: inc.Fingerprint,
+		Source:       SourceAlert,
+		Title:        inc.AlertName,
+		Workload:     providers.Workload{Namespace: inc.Namespace, Kind: kind, Name: name},
+		Reason:       inc.Severity,
+		Labels:       inc.Labels,
+		At:           inc.StartsAt,
+		Fingerprint:  inc.Fingerprint,
+		Fingerprints: fps,
 	}
 }
 

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -127,6 +127,17 @@ func TestFromIncidentCarriesFingerprint(t *testing.T) {
 	}
 }
 
+func TestFromIncidentSetsFingerprints(t *testing.T) {
+	r := FromIncident(config.Incident{AlertName: "A", Namespace: "ns", Fingerprint: "fp-9"})
+	if len(r.Fingerprints) != 1 || r.Fingerprints[0] != "fp-9" {
+		t.Fatalf("Request.Fingerprints = %v, want [fp-9]", r.Fingerprints)
+	}
+	// No fingerprint ⇒ nil (so coalescer can append non-empty ones without a "" entry).
+	if r2 := FromIncident(config.Incident{AlertName: "A", Namespace: "ns"}); r2.Fingerprints != nil {
+		t.Fatalf("Request.Fingerprints = %v, want nil when fingerprint empty", r2.Fingerprints)
+	}
+}
+
 func TestWorkloadFromLabels(t *testing.T) {
 	cases := []struct {
 		name             string

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -201,7 +201,8 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				// Prefer the workload the investigation identified; fall back to the
 				// originating alert workload only when the model named none.
 				inv.Resource = preferDiscoveredResource(inv.Resource, req.Workload)
-				inv.Fingerprint = req.Fingerprint // originating alert id, for outcome-ledger attribution
+				inv.Fingerprint = req.Fingerprint   // originating alert id, for outcome-ledger attribution
+				inv.Fingerprints = req.Fingerprints // coalesced batch ids; one open per constituent alert
 				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 				if li.Metrics != nil {
 					li.Metrics.InvestigationTokens.Record(ctx, int64(estimateTokens(sys, messages)))

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -213,6 +213,7 @@ func recalledInvestigation(req Request, e catalog.Entry, confidence float64) pro
 		Recalled:      true,
 		RecalledEntry: e.Path,
 		Fingerprint:   req.Fingerprint,
+		Fingerprints:  req.Fingerprints,
 		Resource:      req.Workload,
 	}
 }

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -122,8 +122,11 @@ func (l *Ledger) Open(e Event) error {
 // Episodes replays the full ledger and turns every open into an Episode, pairing
 // each resolve with the most-recent (LIFO) unresolved open for the same
 // fingerprint — so recurrence is preserved (N opens + 1 resolve ⇒ N episodes, 1
-// resolved). Episodes are returned in open order; all kinds are included. A
-// disabled/empty ledger yields nil.
+// resolved). Pairing is order-independent: a resolve that arrives BEFORE its open
+// (a transient incident that cleared mid-investigation, so the resolve webhook
+// landed before the open was recorded) is buffered and paired with the next open
+// for that fingerprint. Episodes are returned in open order; all kinds are
+// included. A disabled/empty ledger yields nil.
 func (l *Ledger) Episodes() ([]Episode, error) {
 	if !l.enabled() {
 		return nil, nil
@@ -135,7 +138,17 @@ func (l *Ledger) Episodes() ([]Episode, error) {
 		return nil, err
 	}
 	var out []Episode
-	pending := map[string][]int{} // fingerprint → stack of indices into out
+	pendingOpens := map[string][]int{}          // fingerprint → stack of indices into out (LIFO)
+	pendingResolves := map[string][]time.Time{} // fingerprint → buffered resolve times (resolve-before-open)
+	resolveAt := func(i int, at time.Time) {
+		out[i].ResolvedAt = at
+		d := at.Sub(out[i].OpenedAt)
+		if d < 0 {
+			d = 0 // guard: a resolve recorded before its open is not negative duration
+		}
+		out[i].Duration = d
+		out[i].Resolved = true
+	}
 	for _, e := range events {
 		switch e.Event {
 		case "open":
@@ -143,17 +156,23 @@ func (l *Ledger) Episodes() ([]Episode, error) {
 				Kind: e.Kind, Entry: e.Entry, Title: e.Title, Resource: e.Resource,
 				OpenedAt: e.At,
 			})
-			pending[e.Fingerprint] = append(pending[e.Fingerprint], len(out)-1)
+			i := len(out) - 1
+			if rs := pendingResolves[e.Fingerprint]; len(rs) > 0 {
+				resolveAt(i, rs[0]) // pair with the earliest buffered (early) resolve
+				pendingResolves[e.Fingerprint] = rs[1:]
+				continue
+			}
+			pendingOpens[e.Fingerprint] = append(pendingOpens[e.Fingerprint], i)
 		case "resolve":
-			stack := pending[e.Fingerprint]
+			stack := pendingOpens[e.Fingerprint]
 			if len(stack) == 0 {
-				continue // a resolve with no pending open (mirrors live ok=false)
+				// No pending open yet — buffer this resolve for a later open.
+				pendingResolves[e.Fingerprint] = append(pendingResolves[e.Fingerprint], e.At)
+				continue
 			}
 			i := stack[len(stack)-1]
-			pending[e.Fingerprint] = stack[:len(stack)-1]
-			out[i].ResolvedAt = e.At
-			out[i].Duration = e.At.Sub(out[i].OpenedAt)
-			out[i].Resolved = true
+			pendingOpens[e.Fingerprint] = stack[:len(stack)-1]
+			resolveAt(i, e.At)
 		}
 	}
 	return out, nil

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -166,18 +166,45 @@ func TestEpisodesEmptyAndDisabled(t *testing.T) {
 	}
 }
 
-func TestEpisodesOrphanResolveSkipped(t *testing.T) {
+// TestEpisodesResolveBeforeOpenPairs verifies the new order-independent pairing:
+// a resolve written BEFORE its open (a transient incident that cleared
+// mid-investigation, so the resolve webhook landed before the open was recorded)
+// now PAIRS with the later open — the open becomes a resolved episode.
+func TestEpisodesResolveBeforeOpenPairs(t *testing.T) {
 	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
 	t0 := time.Unix(9000, 0)
-	// A resolve with no prior open is dropped; a later open for the same fingerprint stays unresolved.
 	_, _, _ = l.Resolve("fp", t0)
 	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0.Add(time.Second)})
 	eps, err := l.Episodes()
 	if err != nil {
 		t.Fatalf("Episodes: %v", err)
 	}
-	if len(eps) != 1 || eps[0].Resolved {
-		t.Fatalf("orphan resolve must be dropped and the later open left unresolved: %+v", eps)
+	if len(eps) != 1 || !eps[0].Resolved {
+		t.Fatalf("resolve-before-open must pair: want 1 resolved episode, got %+v", eps)
+	}
+	// Resolve predates the open here, so Duration is guarded to 0 (never negative).
+	if eps[0].Duration != 0 {
+		t.Fatalf("duration must be guarded non-negative when resolve predates open: %v", eps[0].Duration)
+	}
+}
+
+// TestEpisodesCoalescedMultiFingerprintResolves checks the ledger-level shape of
+// a coalesced attribution: opening the same Title/Kind for several constituent
+// fingerprints, then a resolve for any one of them, marks that episode resolved.
+func TestEpisodesCoalescedMultiFingerprintResolves(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(9500, 0)
+	for _, fp := range []string{"a", "b", "c"} {
+		if err := l.Open(Event{Fingerprint: fp, Kind: "recall", Entry: "x.md", Title: "BatchAlert", At: t0}); err != nil {
+			t.Fatalf("Open(%s): %v", fp, err)
+		}
+	}
+	ep, ok, err := l.Resolve("c", t0.Add(time.Minute))
+	if err != nil || !ok {
+		t.Fatalf("Resolve(c): want ok=true, got ok=%v err=%v", ok, err)
+	}
+	if !ep.Resolved || ep.Title != "BatchAlert" {
+		t.Fatalf("constituent resolve must mark its episode resolved: %+v", ep)
 	}
 }
 

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -357,6 +357,7 @@ type Investigation struct {
 	Actions       []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
 	CuratedURL    string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
 	Fingerprint   string   // originating alert fingerprint; for outcome-ledger attribution
+	Fingerprints  []string // coalesced batch fingerprints; one outcome open is recorded per entry
 	RecalledEntry string   // when Recalled: the catalog entry Path that was matched
 }
 


### PR DESCRIPTION
  Fixes two outcome-ledger attribution gaps feeding recall decay:
  - Coalesced batches now record an `open` for EVERY constituent fingerprint (was only incs[0] — the other N-1 were orphaned, their resolved-webhooks matching nothing). `Fingerprints []string` threaded
  Request→Investigation; OnComplete opens one per fingerprint.
  - `Episodes()` now pairs a resolve with its open regardless of on-disk order (two-queue reconstruction), so a transient incident that cleared mid-investigation is no longer lost. Recurrence semantics unchanged.
  Deferred: TTL-expiry of never-resolving opens; live metrics on a buffered early-resolve. No Open/Resolve/server/metrics signature changes.
  Spec: docs/superpowers/specs/2026-06-23-outcome-attribution-design.md
  - [x] build/test/vet green; reviewer stress-tested Episodes interleavings