### PR TITLE
feat(investigate): hard-stop the ReAct loop at the token budget

### DIFF
--- a/docs/superpowers/specs/2026-06-23-loop-hardkill-design.md
+++ b/docs/superpowers/specs/2026-06-23-loop-hardkill-design.md
@@ -1,0 +1,121 @@
+# RunLore Loop Token-Budget Hard-Kill — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation |
+| **Date** | 2026-06-23 |
+| **Scope** | Hard-stop the ReAct investigation loop when the estimated token count exceeds the configured budget after the nudge has already fired. Deliver findings gathered so far (or an explicit unresolved result). **Tool-result elision and repeated-(tool,args) loop detection are explicitly out of scope (follow-up slices).** |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | `internal/investigate/loop.go` (step loop, `budgetNudged` flag); `internal/investigate/budget.go` (`estimateTokens`, `overBudget`, `budgetNudge`); `internal/telemetry/metrics.go` (existing instruments). |
+
+---
+
+## 1. Why this exists
+
+The current loop has a soft budget: when `estimateTokens(sys, messages) > MaxTokensPerInvestigation`, it injects a `budgetNudge` message asking the model to call `submit_findings` now. This fires once, then the loop continues forever (bounded only by `maxSteps`). A runaway model that keeps calling tools will consume unbounded context, potentially OOMing the process.
+
+The fix: once the nudge has fired AND the estimate is still over budget on a subsequent step, **hard-kill** — stop the loop and deliver whatever findings were gathered.
+
+## 2. Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Kill condition: `budgetNudged == true && overBudget(estimate, max)`** | The nudge gives the model one full turn to wind down. The next over-budget check fires after the model has seen the nudge and responded. This cleanly reuses the existing `budgetNudged` flag with zero new state. |
+| D2 | **No `budgetHardKillFactor` multiplier** | A separate factor (e.g. 1.5×) adds configuration surface and complexity. The existing flag-based approach is sufficient: nudge fires at 1×, kill fires on the next over-budget check after the nudge. Simple and auditable. |
+| D3 | **Guard: `MaxTokensPerInvestigation == 0` → no hard-kill** | `overBudget` already returns false when budget ≤ 0 (unlimited). The hard-kill check reuses the same guard, so the existing "no limit" behavior is unchanged. |
+| D4 | **On hard-kill: deliver an unresolved investigation** | Panicking or returning an error would hide findings already gathered. A graceful termination with an explicit `Unresolved` entry is honest and usable. If root causes were already parsed (from a `submit_findings` call that errored), deliver them; otherwise deliver a synthetic unresolved result. |
+| D5 | **Telemetry: log a warning; reuse `InvestigationsDropped`** | Adding a new counter (`investigations_budget_killed_total`) is not trivially justified for one slice. `InvestigationsDropped` is semantically close (an investigation that did not complete normally). Log a structured warning with estimate + budget for immediate observability. |
+
+## 3. Design
+
+### 3.1 Hard-kill check in the step loop (`internal/investigate/loop.go`)
+
+The existing nudge injection sits at the top of the step loop:
+
+```go
+if !budgetNudged && overBudget(estimateTokens(sys, messages), li.MaxTokensPerInvestigation) {
+    messages = append(messages, providers.Message{Role: "user", Content: budgetNudge})
+    budgetNudged = true
+}
+```
+
+Add a second, symmetric check immediately after:
+
+```go
+if budgetNudged && overBudget(estimateTokens(sys, messages), li.MaxTokensPerInvestigation) {
+    est := estimateTokens(sys, messages)
+    li.Log.Warn("investigation hard-stopped at token budget",
+        "title", req.Title,
+        "estimate_tokens", est,
+        "budget_tokens", li.MaxTokensPerInvestigation)
+    if li.Metrics != nil {
+        li.Metrics.InvestigationsDropped.Add(ctx, 1)
+    }
+    li.deliver(req, budgetKillResult(req))
+    return nil
+}
+```
+
+`overBudget` is idempotent on the same message slice, so calling `estimateTokens` twice is fine (the estimate did not change between the two checks in the same iteration). Alternatively, call once and reuse:
+
+```go
+if est := estimateTokens(sys, messages); overBudget(est, li.MaxTokensPerInvestigation) {
+    if !budgetNudged {
+        messages = append(messages, providers.Message{Role: "user", Content: budgetNudge})
+        budgetNudged = true
+    } else {
+        // Hard-kill: nudge already fired, model did not wind down.
+        li.Log.Warn("investigation hard-stopped at token budget",
+            "title", req.Title, "estimate_tokens", est,
+            "budget_tokens", li.MaxTokensPerInvestigation)
+        if li.Metrics != nil {
+            li.Metrics.InvestigationsDropped.Add(ctx, 1)
+        }
+        li.deliver(req, budgetKillResult(req))
+        return nil
+    }
+}
+```
+
+This single-estimate form is cleaner: one `estimateTokens` call, one `overBudget` check, two branches.
+
+### 3.2 `budgetKillResult` helper (`internal/investigate/loop.go` or `budget.go`)
+
+```go
+// budgetKillResult synthesises an unresolved investigation for use when the
+// token-budget hard-kill fires (nudge fired, model did not wind down).
+func budgetKillResult(req Request) providers.Investigation {
+    return providers.Investigation{
+        Title:      req.Title,
+        Resource:   req.Workload,
+        Fingerprint: req.Fingerprint,
+        Unresolved: []string{
+            "investigation stopped: token budget exceeded after nudge (model did not submit findings in time)",
+        },
+    }
+}
+```
+
+### 3.3 No changes to `budget.go` or `telemetry/metrics.go`
+
+`overBudget`/`estimateTokens`/`budgetNudge` need no changes. The `InvestigationsDropped` counter is already defined in `telemetry.Metrics`.
+
+## 4. Invariants
+
+- `MaxTokensPerInvestigation == 0` → `overBudget` returns false → hard-kill never fires. Existing behavior preserved.
+- Nudge fires at most once (`budgetNudged` flag), hard-kill fires at most once (function returns). The model always gets at least one turn after the nudge before the kill.
+- Hard-kill delivers a result via the normal `deliver` path — `OnComplete` is called.
+
+## 5. Tests
+
+In `internal/investigate/loop_test.go`, add:
+
+- **`TestLoopHardKillOnBudgetExhaustion`**: fake model returns an infinite sequence of tool calls (never `submit_findings`); `MaxTokensPerInvestigation` is set small enough to trigger at step 2 or 3. Assert: (a) loop terminates, (b) `OnComplete` called exactly once, (c) result has an `Unresolved` entry containing "budget", (d) model called ≤ N times (bounded by kill, not `maxSteps`).
+- **`TestLoopHardKillDisabledWhenNoBudget`**: same runaway model, `MaxTokensPerInvestigation == 0`. Assert loop runs to `maxSteps` without hard-kill firing (model called exactly `maxSteps` times).
+
+## 6. Out of scope (follow-up slices)
+
+- **Tool-result elision**: truncating or dropping old tool messages from the history before re-sending.
+- **Repeated-(tool,args) loop detection**: detecting the model calling the same tool with the same args in a cycle.
+- **Provider-reported usage**: adding a `Usage` field to `CompletionResponse` and using real token counts rather than the estimate. The `estimateTokens` proxy is sufficient for this slice.
+- **`InvestigationsDropped` vs a dedicated counter**: if the budget-kill metric needs its own instrument for alerting fidelity, add it in a follow-up alongside the tool-result elision metric.

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -2,6 +2,19 @@ package investigate
 
 import "github.com/Smana/runlore/internal/providers"
 
+// budgetKillResult synthesises an unresolved investigation for use when the
+// token-budget hard-kill fires (nudge fired, model did not submit findings in time).
+func budgetKillResult(req Request) providers.Investigation {
+	return providers.Investigation{
+		Title:       req.Title,
+		Resource:    req.Workload,
+		Fingerprint: req.Fingerprint,
+		Unresolved: []string{
+			"investigation stopped: token budget exceeded after nudge (model did not submit findings in time)",
+		},
+	}
+}
+
 // estimateTokens approximates the request size (~4 chars/token) over the system
 // prompt plus the full message history — the cost actually re-sent each step.
 // Provider-reported usage is not exposed in CompletionResponse today.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -160,11 +160,26 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	used := map[string]int{} // tool-call counts, logged so investigation breadth is observable
 	sys := li.system()       // constant for the investigation; build once, not per step
 	for step := 0; step < maxSteps; step++ {
-		// Inject a one-time budget nudge when the estimated request size exceeds the
-		// configured ceiling, prompting the model to wrap up with current findings.
-		if !budgetNudged && overBudget(estimateTokens(sys, messages), li.MaxTokensPerInvestigation) {
-			messages = append(messages, providers.Message{Role: "user", Content: budgetNudge})
-			budgetNudged = true
+		// Budget control: when the estimated request size exceeds the configured ceiling,
+		// inject a one-time nudge asking the model to wrap up. If the model did not wind
+		// down and the estimate is still over budget on the next step, hard-kill: deliver
+		// whatever findings exist rather than growing context unbounded.
+		if est := estimateTokens(sys, messages); overBudget(est, li.MaxTokensPerInvestigation) {
+			if !budgetNudged {
+				messages = append(messages, providers.Message{Role: "user", Content: budgetNudge})
+				budgetNudged = true
+			} else {
+				// Hard-kill: nudge already fired but the model is still over budget.
+				li.Log.Warn("investigation hard-stopped at token budget",
+					"title", req.Title,
+					"estimate_tokens", est,
+					"budget_tokens", li.MaxTokensPerInvestigation)
+				if li.Metrics != nil {
+					li.Metrics.InvestigationsDropped.Add(ctx, 1)
+				}
+				li.deliver(req, budgetKillResult(req))
+				return nil
+			}
 		}
 		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: sys, Messages: messages, Tools: specs})
 		if err != nil {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -277,3 +277,92 @@ func TestLoopToolOutputTruncatedMetric(t *testing.T) {
 		t.Fatalf("runlore_tool_output_truncated_bytes_total not in metrics:\n%s", body)
 	}
 }
+
+// runawayModel always returns a tool call (never submit_findings), simulating a
+// model that keeps calling tools and never winds down regardless of nudges.
+type runawayModel struct {
+	calls int
+}
+
+func (m *runawayModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	// Return a benign no-op tool call so the loop has something to dispatch.
+	return providers.CompletionResponse{
+		ToolCalls: []providers.ToolCall{{ID: "r", Name: "noop_tool", Args: `{}`}},
+	}, nil
+}
+
+// TestLoopHardKillOnBudgetExhaustion verifies that, after the token-budget nudge
+// has fired, the loop hard-kills on the next over-budget check and delivers an
+// unresolved result rather than running to maxSteps.
+func TestLoopHardKillOnBudgetExhaustion(t *testing.T) {
+	model := &runawayModel{}
+	var got *providers.Investigation
+	var deliveries int
+	// MaxTokensPerInvestigation = 1 forces the nudge to fire on step 0 (the real
+	// system prompt alone exceeds 1 token), making the hard-kill trigger at step 1.
+	li := &LoopInvestigator{
+		Model:                     model,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  50, // far higher than the expected kill point
+		MaxTokensPerInvestigation: 1,  // triggers immediately; proves kill happens before maxSteps
+		OnComplete: func(inv providers.Investigation) {
+			deliveries++
+			got = &inv
+		},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "runaway", Fingerprint: "fp-kill"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	// The loop must have terminated well before maxSteps.
+	if model.calls >= 50 {
+		t.Fatalf("hard-kill did not fire: model was called %d times (= maxSteps), loop ran to the end", model.calls)
+	}
+	// OnComplete must have been called exactly once.
+	if deliveries != 1 {
+		t.Fatalf("expected exactly 1 delivery, got %d", deliveries)
+	}
+	if got == nil {
+		t.Fatal("OnComplete never called")
+	}
+	// The delivered result must carry an Unresolved entry that mentions the budget.
+	if len(got.Unresolved) == 0 {
+		t.Fatalf("expected at least one Unresolved entry on hard-kill, got none; result: %+v", got)
+	}
+	foundBudget := false
+	for _, u := range got.Unresolved {
+		if strings.Contains(u, "budget") {
+			foundBudget = true
+			break
+		}
+	}
+	if !foundBudget {
+		t.Fatalf("Unresolved entry must mention 'budget'; got: %v", got.Unresolved)
+	}
+	// Fingerprint must be propagated for outcome-ledger attribution.
+	if got.Fingerprint != "fp-kill" {
+		t.Fatalf("expected fingerprint %q, got %q", "fp-kill", got.Fingerprint)
+	}
+}
+
+// TestLoopHardKillDisabledWhenNoBudget verifies that MaxTokensPerInvestigation=0
+// (unlimited) suppresses the hard-kill entirely: a runaway model runs for the full
+// maxSteps, exactly as before this change.
+func TestLoopHardKillDisabledWhenNoBudget(t *testing.T) {
+	model := &runawayModel{}
+	li := &LoopInvestigator{
+		Model:                     model,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  5,
+		MaxTokensPerInvestigation: 0, // disabled — no hard-kill
+		OnComplete:                func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "unlimited"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	// With no budget the loop must exhaust maxSteps normally (runaway model never
+	// calls submit_findings, so the loop runs until maxSteps).
+	if model.calls != 5 {
+		t.Fatalf("expected exactly 5 model calls (= maxSteps), got %d — hard-kill must not fire when budget=0", model.calls)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -54,7 +54,7 @@ func NewMetrics() *Metrics {
 		AlertsSuppressed:          ctr("alerts_suppressed_total", "incidents dropped by cooldown"),
 		InvestigationsStarted:     ctr("investigations_started_total", "investigations actually begun"),
 		InvestigationsThrottled:   ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
-		InvestigationsDropped:     ctr("investigations_dropped_total", "keys dropped after max_requeues"),
+		InvestigationsDropped:     ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
 		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
 		RecallHits:                ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
 		RecallTokensSaved:         ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),


### PR DESCRIPTION
  The loop only NUDGED at MaxTokensPerInvestigation and otherwise ran unbounded (OOM/runaway risk). Now: once the estimate exceeds the budget AND the nudge already fired, the loop terminates and delivers gracefully
  (findings so far, or an explicit unresolved result) via the normal path. No-op when the budget is 0. Based on the existing token estimate (no provider-usage change). Deferred: tool-result elision,
  loop-detection, real provider usage.
  Spec: docs/superpowers/specs/2026-06-23-loop-hardkill-design.md
  - [x] build/test/vet green; runaway-model test proves termination; budget=0 unchanged