### PR TITLE
feat(helm): opt-in RWX persistence for ledger+audit; fsync audit writes

### DIFF
--- a/deploy/helm/runlore/templates/deployment.yaml
+++ b/deploy/helm/runlore/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             - name: catalog
               mountPath: {{ .Values.catalog.mountPath }}
               readOnly: true
-            {{- else if .Values.catalog.gitSync }}
+            {{- else if or .Values.catalog.gitSync .Values.persistence.enabled }}
             - name: catalog
               mountPath: {{ .Values.catalog.mountPath }}
             {{- end }}
@@ -98,9 +98,14 @@ spec:
         - name: catalog
           configMap:
             name: {{ .Values.catalog.configMap }}
-        {{- else if .Values.catalog.gitSync }}
+        {{- else if or .Values.catalog.gitSync .Values.persistence.enabled }}
         - name: catalog
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "runlore.fullname" .)) }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/runlore/templates/pvc.yaml
+++ b/deploy/helm/runlore/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "runlore.fullname" . }}-data
+  labels:
+    {{- include "runlore.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -67,7 +67,7 @@ config:
   #     solo_floor: 4.0                # confident bar when there is only one hit
   #     require_workload_match: false  # true = exact namespace+workload; false = namespace-level agreement is enough
   # outcome:
-  #   ledger_path: /var/lib/runlore/catalog/outcomes.jsonl  # learning-loop outcome ledger; point at the writable git-sync mirror PV
+  #   ledger_path: /var/lib/runlore/catalog/outcomes.jsonl  # learning-loop outcome ledger; for durability set persistence.enabled and point this at the persistent mount (catalog.mountPath)
   # notify:
   #   slack: { webhook_url_env: SLACK_WEBHOOK_URL }
   #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }
@@ -92,6 +92,20 @@ catalog:
   configMap: ""                       # ConfigMap of OKF .md files (static mode)
   gitSync: false                      # writable mirror for config.catalog.git (closes the read/write loop)
   mountPath: /var/lib/runlore/catalog
+
+# Durability for the writable data path (catalog.mountPath) where the outcome
+# ledger and the hash-chained audit log live. Disabled by default: the data path
+# is an emptyDir and is DESTROYED on pod restart, upgrade, or leader failover.
+# Enable to back it with a ReadWriteMany volume (e.g. EFS/Filestore) so the
+# outcome ledger + audit log survive pod restarts AND leader failover. RWX is
+# required because the standby replica must mount the same data to take over.
+# Leave disabled (emptyDir) for non-HA / ephemeral setups.
+persistence:
+  enabled: false
+  storageClass: ""
+  accessModes: ["ReadWriteMany"]
+  size: 1Gi
+  existingClaim: ""                   # reuse a pre-provisioned PVC instead of templating one
 
 # Keeps at least one replica available during voluntary disruptions (only applied
 # when replicaCount > 1).

--- a/docs/superpowers/specs/2026-06-23-durability-design.md
+++ b/docs/superpowers/specs/2026-06-23-durability-design.md
@@ -1,0 +1,82 @@
+# Durability: opt-in RWX volume + audit fsync
+
+Date: 2026-06-23
+Slice: #14 durability
+Status: accepted
+
+## Problem
+
+The outcome ledger (`outcome.ledger_path`, the learning signal) and the
+hash-chained audit log (`actions.audit_log_path`, the tamper-evident accountability
+record) both live under the catalog data path (`/var/lib/runlore/catalog`, the
+`catalog` volume `mountPath`). In the shipped Helm chart that volume is an
+`emptyDir` (rendered only on the `catalog.gitSync` branch), so both files are
+**destroyed on every pod restart, upgrade, or leader failover** — even though the
+audit package docstring promises a "durable, ordered, complete record … [that]
+survives process restarts."
+
+Two independent gaps:
+
+1. **Storage gap (Helm):** an `emptyDir` cannot survive pod replacement, and the
+   `Deployment` uses `Recreate` + leader election, so an upgrade tears the pod
+   down entirely. There is no persistent backing.
+2. **Write gap (Go):** `audit.Logger.Log` writes via an `io.Writer` with no
+   `fsync`, so even on a durable volume an unclean crash can lose the tail of the
+   hash chain (the most recent, most relevant records).
+
+## Scope
+
+- Opt-in persistent volume for the writable catalog/ledger/audit data path (Helm).
+- `fsync` after each audit write when the Logger is backed by a real file (Go).
+- Fix the misleading `values.yaml` comment that points `ledger_path` at a
+  non-existent "git-sync mirror PV".
+
+Out of scope (deferred): see below.
+
+## Decision
+
+**Opt-in ReadWriteMany shared volume, default off.**
+
+- Add a `persistence` block to `values.yaml`, **disabled by default**. When
+  enabled it provisions (or reuses) a PVC and mounts it at the existing
+  `catalog.mountPath`, so the ledger and audit log survive restarts *and* leader
+  failover. When disabled, behavior is **byte-identical to today** (`emptyDir`).
+- **ReadWriteMany** (e.g. EFS / Filestore) is the access mode because the
+  `Deployment` runs 2 replicas with leader election: the standby must be able to
+  mount the same data so it can read the seeded hash chain and the ledger when it
+  takes leadership. A single-writer RWO volume would block the standby's mount.
+- A new `templates/pvc.yaml` renders only when `persistence.enabled` **and**
+  `persistence.existingClaim` is empty (standard Helm guard). When
+  `existingClaim` is set, the Deployment references it directly and no PVC is
+  created.
+- In `deployment.yaml` the `catalog` volume becomes a `persistentVolumeClaim`
+  when `persistence.enabled`, else falls back to `emptyDir: {}`. The mount path
+  is unchanged, so nothing downstream of the path changes.
+
+**fsync audit writes.** `audit.Logger` gains an optional `sync func() error`:
+`Open(path)` sets it to the `*os.File`'s `Sync`; `NewWriter(io.Writer)` leaves
+it nil (an arbitrary writer can't fsync). `Log` calls `sync` after a successful
+write, skipping gracefully when nil. The record / hash-chain format is unchanged.
+
+## Why opt-in (the fork)
+
+Forcing a PVC would (a) require RWX storage every cluster may not have, and (b)
+change the default render for non-HA / ephemeral users who are fine with
+`emptyDir`. Opt-in keeps the zero-config path working and lets durability-needing
+operators turn it on with one flag.
+
+## Deferred
+
+- **StatefulSet** with per-replica RWO PVCs (would avoid the RWX requirement but
+  needs per-pod ledger reconciliation and a different leader-handoff story).
+- **Automatic ledger-path derivation** from the persistence mount (today the
+  operator still sets `outcome.ledger_path` / `actions.audit_log_path` by hand;
+  the fixed comment documents pointing them at the persistent mount).
+
+## Verification
+
+- `go build ./... && go test ./... && go vet ./...` green.
+- `helm template deploy/helm/runlore` (default) renders `emptyDir`, no PVC.
+- `helm template deploy/helm/runlore --set persistence.enabled=true` renders a
+  PVC and a `persistentVolumeClaim` volume.
+- `helm lint deploy/helm/runlore` passes.

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -56,6 +56,7 @@ type Logger struct {
 	mu       sync.Mutex
 	w        io.Writer
 	closer   io.Closer
+	syncFn   func() error // fsync the backing file after each write; nil for NewWriter
 	lastHash string
 	now      func() time.Time
 }
@@ -71,7 +72,7 @@ func Open(path string) (*Logger, error) {
 	if err != nil {
 		return nil, fmt.Errorf("audit: open %s: %w", path, err)
 	}
-	return &Logger{w: f, closer: f, lastHash: last, now: time.Now}, nil
+	return &Logger{w: f, closer: f, syncFn: f.Sync, lastHash: last, now: time.Now}, nil
 }
 
 // NewWriter builds a Logger over an arbitrary writer (tests).
@@ -103,6 +104,13 @@ func (l *Logger) Log(r Record) error {
 	}
 	if _, err := l.w.Write(append(line, '\n')); err != nil {
 		return fmt.Errorf("audit: write: %w", err)
+	}
+	// fsync so the tail of the tamper-evident chain survives an unclean crash.
+	// nil for NewWriter (an arbitrary writer can't be synced).
+	if l.syncFn != nil {
+		if err := l.syncFn(); err != nil {
+			return fmt.Errorf("audit: sync: %w", err)
+		}
 	}
 	l.lastHash = r.Hash
 	return nil

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -2,6 +2,8 @@ package audit
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -33,5 +35,54 @@ func TestChainDetectsTampering(t *testing.T) {
 	lines[1] = strings.Replace(lines[1], "apps", "flux-system", 1)
 	if err := Verify(strings.NewReader(strings.Join(lines, "\n"))); err == nil {
 		t.Fatal("verify should detect a tampered record")
+	}
+}
+
+// TestOpenFileAppendsAndSyncs checks that a Logger opened on a real file appends
+// a verifiable chain (the fsync-on-write path must not error and must persist
+// every record to disk).
+func TestOpenFileAppendsAndSyncs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	l, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for _, op := range []string{"suspend", "resume", "reconcile"} {
+		if err := l.Log(Record{Actor: "auto", Op: op, Target: "Kustomization/apps/web", Decision: DecisionExecuted}); err != nil {
+			t.Fatalf("log: %v", err)
+		}
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if got := strings.Count(strings.TrimSpace(string(b)), "\n") + 1; got != 3 {
+		t.Fatalf("want 3 records on disk, got %d", got)
+	}
+	if err := Verify(bytes.NewReader(b)); err != nil {
+		t.Fatalf("verify file-backed chain: %v", err)
+	}
+
+	// Reopening seeds the chain from disk: a further append must chain cleanly.
+	l2, err := Open(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if err := l2.Log(Record{Actor: "auto", Op: "suspend", Target: "Kustomization/apps/api", Decision: DecisionSkipped, Reason: "paused"}); err != nil {
+		t.Fatalf("log after reopen: %v", err)
+	}
+	if err := l2.Close(); err != nil {
+		t.Fatalf("close reopen: %v", err)
+	}
+	b, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back after reopen: %v", err)
+	}
+	if err := Verify(bytes.NewReader(b)); err != nil {
+		t.Fatalf("verify chain across reopen: %v", err)
 	}
 }


### PR DESCRIPTION
  The outcome ledger + hash-chained audit log were on emptyDir (lost on restart/failover). Adds an opt-in `persistence` ReadWriteMany volume (default OFF = emptyDir, render byte-identical to today), fsyncs each
  audit write, and fixes the misleading values.yaml ledger_path comment. RWX so the standby can mount the same data on leader failover.
  Deferred: StatefulSet/per-replica RWO; auto path derivation.
  Spec: docs/superpowers/specs/2026-06-23-durability-design.md
  - [x] build/test/vet green; helm template default == main (proven); PVC renders when enabled; helm lint clean