### PR TITLE
feat(eval): exercise the instant-recall short-circuit (was dropped) + poisoned-entry proof    Body:

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -562,11 +562,11 @@ func runEvalLive(cfg *config.Config, scnDir, recordDir, reportDir, prevReport, s
 	}
 	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	ctx := context.Background()
-	model, tools, _, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
+	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
 	judge := eval.ModelJudge{Model: buildJudgeModel(cfg, jProvider, jBaseURL, jModel, jKeyEnv)}
 
 	runner := &eval.LiveRunner{
-		Model: model, BaseTools: tools, Judge: judge, Steps: shellStepRunner{}, Log: log, N: n,
+		Model: model, BaseTools: tools, Judge: judge, Steps: shellStepRunner{}, Log: log, N: n, Recall: recall,
 		OnRecord: func(scn eval.Scenario, calls []eval.Call) {
 			if err := eval.WriteCase(recordDir, eval.RecordedCase(scn, calls)); err != nil {
 				log.Warn("record case failed", "id", scn.ID, "err", err)

--- a/docs/superpowers/plans/2026-06-23-recall-in-eval.md
+++ b/docs/superpowers/plans/2026-06-23-recall-in-eval.md
@@ -1,0 +1,202 @@
+# Recall-in-Eval Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the eval harness exercise the instant-recall short-circuit (today dropped) and prove with unit tests that it fires and that a poisoned entry is caught by the verify pass.
+
+**Architecture:** Add `Recall *investigate.Recall` to `LiveRunner` and thread it into the `LoopInvestigator` that `runOnce` builds; capture the (currently discarded) recall in `runEvalLive`. The recall short-circuit sets `Investigation.Recalled = true` and runs the `Verify` pass, so tests assert on `Recalled` and on a scripted `submit_verdicts` verdict.
+
+**Tech Stack:** Go 1.26, stdlib `testing` (no testify). Reuses the eval package's fake conventions; adds a tiny `catalog.ScoredSearcher` fake + a verify-only model fake.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-recall-in-eval-design.md`
+
+**Branch:** `feat/recall-in-eval` (already checked out, off the #5-merged `main`; the spec is already committed there).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/eval/live.go` | live runner | `Recall *investigate.Recall` on `LiveRunner`; pass `Recall: lr.Recall` into the `runOnce` `LoopInvestigator` |
+| `internal/eval/live_test.go` | tests | recall-fires + poisoned-rejected tests; `fakeCatalog` (ScoredSearcher) + `verifyModel` fakes |
+| `cmd/lore/main.go` | eval CLI wiring | capture the recall return in `runEvalLive`; set `Recall` on the `LiveRunner` |
+
+Order: **T1** (live.go field + runOnce thread + tests — the testable core) → **T2** (main.go wiring — build-verified) → **T3** (verify). T1 is self-contained; T2 makes a real live run use it.
+
+---
+
+### Task 1: Thread `Recall` into the eval runner (+ prove it)
+
+**Files:**
+- Modify: `internal/eval/live.go` (`LiveRunner` struct; `runOnce`'s `LoopInvestigator`)
+- Test: `internal/eval/live_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/eval/live_test.go`. First add imports `"context"`, `"fmt"`, `"github.com/Smana/runlore/internal/catalog"` (keep the existing `io`, `slog`, `testing`, `investigate`, `providers`). Then:
+
+```go
+// fakeCatalog returns a single fixed scored entry regardless of query/k — enough
+// to drive the recall gates in a unit test.
+type fakeCatalog struct {
+	entry catalog.Entry
+	score float64
+}
+
+func (f fakeCatalog) SearchScored(string, int) ([]catalog.ScoredEntry, error) {
+	return []catalog.ScoredEntry{{Entry: f.entry, Score: f.score}}, nil
+}
+
+// verifyModel answers only the adversarial verify call (submit_verdicts) with a
+// fixed verdict for root cause index 0. On the recall short-circuit path this is
+// the sole model call (the ReAct loop is skipped).
+type verifyModel struct{ verdict string }
+
+func (m verifyModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{{ID: "v", Name: "submit_verdicts",
+		Args: fmt.Sprintf(`{"verdicts":[{"index":0,"verdict":%q}]}`, m.verdict)}}}, nil
+}
+
+// recallRunner builds a LiveRunner whose catalog has one entry matching the
+// recallScenario's namespace (so the structural gate agrees), with low recall
+// floors so a single strong hit short-circuits.
+func recallRunner(model providers.ModelProvider) *LiveRunner {
+	entry := catalog.Entry{Title: "HarborRegistryDown", Description: "IAM quota exceeded", Path: "harbor.md", Resource: "tooling"}
+	return &LiveRunner{
+		Model:  model,
+		Recall: &investigate.Recall{Catalog: fakeCatalog{entry: entry, score: 10}, MinScore: 1, SoloFloor: 1, MarginGap: 1},
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func recallScenario() Scenario {
+	return Scenario{ID: "known-pattern-recall", Trigger: Trigger{Symptom: "harbor registry down", Namespace: "tooling"}}
+}
+
+func TestRunOnceRecallShortCircuits(t *testing.T) {
+	out := recallRunner(verifyModel{verdict: "keep"}).runOnce(context.Background(), recallScenario())
+	if !out.Investigation.Recalled {
+		t.Fatal("recall should have short-circuited the loop (Investigation.Recalled=true)")
+	}
+	if len(out.Investigation.RootCauses) != 1 {
+		t.Fatalf("a kept recall should retain its single root cause, got %d", len(out.Investigation.RootCauses))
+	}
+	if len(out.Coverage.Touched) != 0 {
+		t.Fatalf("recall short-circuit must run no investigation tools, got %v", out.Coverage.Touched)
+	}
+}
+
+func TestRunOnceRecallPoisonedRejected(t *testing.T) {
+	// A poisoned entry: the verify pass rejects it → the wrong root cause is withdrawn,
+	// not short-circuited into. (Recalled stays true; the safety is an empty RootCauses.)
+	out := recallRunner(verifyModel{verdict: "reject"}).runOnce(context.Background(), recallScenario())
+	if len(out.Investigation.RootCauses) != 0 {
+		t.Fatalf("a rejected poisoned recall must withdraw its root cause, got %d", len(out.Investigation.RootCauses))
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/eval/ -run TestRunOnceRecall`
+Expected: FAIL — compile error `unknown field Recall in struct literal of type LiveRunner`.
+
+- [ ] **Step 3: Add the field and thread it**
+
+In `internal/eval/live.go`, add to the `LiveRunner` struct (after `N int`):
+
+```go
+	Recall    *investigate.Recall    // optional; when set, runOnce takes the instant-recall short-circuit (production path). nil ⇒ no recall.
+```
+
+In `runOnce`, add `Recall: lr.Recall` to the `LoopInvestigator` literal:
+
+```go
+	li := &investigate.LoopInvestigator{
+		Model: lr.Model, Tools: wrap(lr.BaseTools, rec), Log: lr.Log, Verify: true, Recall: lr.Recall,
+		OnComplete: func(got providers.Investigation) { inv = got },
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/`
+Expected: PASS — the two new tests plus all pre-existing eval tests (the existing `RunScenario` tests set no `Recall`, so `li.Recall == nil` and behavior is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/eval/live.go internal/eval/live_test.go
+git commit -m "feat(eval): exercise the instant-recall short-circuit + poisoned-entry proof"
+```
+
+---
+
+### Task 2: Capture and wire the recall in `runEvalLive`
+
+**Files:**
+- Modify: `cmd/lore/main.go` (`runEvalLive`)
+
+- [ ] **Step 1: Capture the recall return**
+
+In `cmd/lore/main.go`, `runEvalLive`, change the line that drops recall:
+```go
+	model, tools, _, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
+```
+to capture it:
+```go
+	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
+```
+
+- [ ] **Step 2: Set it on the LiveRunner**
+
+In the same function, add `Recall: recall,` to the `eval.LiveRunner{...}` literal (alongside `Model`, `BaseTools`, `Judge`, `Steps`, `Log`, `N`, `OnRecord`):
+
+```go
+	runner := &eval.LiveRunner{
+		Model: model, BaseTools: tools, Judge: judge, Steps: shellStepRunner{}, Log: log, N: n, Recall: recall,
+		OnRecord: func(scn eval.Scenario, calls []eval.Call) {
+			if err := eval.WriteCase(recordDir, eval.RecordedCase(scn, calls)); err != nil {
+				log.Warn("record case failed", "id", scn.ID, "err", err)
+			}
+		},
+	}
+```
+
+- [ ] **Step 3: Build to verify the wiring compiles**
+
+Run: `go build ./...`
+Expected: success, no output. (No new unit test — the recall behavior is covered by Task 1's `runOnce` tests; this is the production wiring so a live run uses recall when `instant_recall` is enabled and the catalog matches.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/lore/main.go
+git commit -m "feat(eval): wire recall into the live-eval runner (was dropped)"
+```
+
+---
+
+### Task 3: Whole-tree verification
+
+- [ ] **Step 1: Build, test, vet**
+
+Run:
+```bash
+go build ./... && go test ./... && go vet ./...
+```
+Expected: build clean; all tests PASS; vet clean.
+
+No commit (verification only).
+
+---
+
+## Notes for the implementer
+
+- `runOnce` is unexported but the test is in `package eval`, so it's directly callable; it does NOT run precheck/setup/teardown (those are in `RunScenario`), so the tests need no `Steps`.
+- The recall short-circuit is the *only* model call on the happy path (the ReAct loop is skipped), and it is the **verify** call — that's why `verifyModel` returns a `submit_verdicts` tool call. If recall failed to fire, the main loop would call the model and get an unrecognized `submit_verdicts` response, and `Investigation.Recalled` would be false — so the `Recalled` assertion is the definitive "short-circuit fired" proof.
+- After a `reject` verdict, `applyVerdicts` moves the root cause to `Unresolved` and empties `RootCauses` (and `Recalled` remains `true` — it *was* a recall, just withdrawn). The poisoned test asserts `len(RootCauses) == 0`, the safety property.
+- The eval `Request` carries a namespace-only `Workload` (`Workload{Namespace: scn.Trigger.Namespace}`), so the fixture entry's `Resource: "tooling"` agrees at the namespace level via `resourceAgrees` (reqW has no Name) — the recall passes Gate 2.
+- Do NOT add live-harness catalog fixture seeding, a report "recalled" column, entity precision (#4), or CI wiring (#7) — all deferred.
+- The existing eval tests set no `Recall`, so they're unaffected; keep them green.

--- a/docs/superpowers/specs/2026-06-23-recall-in-eval-design.md
+++ b/docs/superpowers/specs/2026-06-23-recall-in-eval-design.md
@@ -1,0 +1,82 @@
+# RunLore Recall-in-Eval — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Make the live-eval harness actually exercise the instant-recall short-circuit (today it's dropped, so none of the recall work is eval-tested), and prove with unit tests that it fires AND that a poisoned catalog entry is caught by the verify pass. Confined to `internal/eval/live.go`, `cmd/lore/main.go` (`runEvalLive`), and `internal/eval/live_test.go`. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | Deep-analysis report (`docs/analysis/2026-06-23-deep-analysis.md`) roadmap #6 / "the recall closed-loop scenario tests a code path that is structurally bypassed in eval"; the recall slices (BM25/decay/disambiguation/retrieval); eval-statistics (#5, the gate this runs under); next: #4 entity-precision, #7 CI |
+
+---
+
+## 1. Why this exists
+
+The recall short-circuit (`loop.go`, gated on `li.Recall != nil`) is the cache that skips the ReAct loop on a trustworthy catalog hit — five merged slices now shape it (BM25 scoring, outcome decay, workload disambiguation, wider-candidate retrieval). But the eval harness **never wires it**: `runEvalLive` discards the recall (`model, tools, _, _ := buildModelAndTools(...)`) and `runOnce` builds a `LoopInvestigator` with no `Recall` field. So the short-circuit is dead in eval — `known-pattern-recall.yaml` can only "pass" via the agent organically calling `kb_search`, a different mechanism. None of the recall work is exercised by eval, and there's no regression guard that a poisoned entry is rejected.
+
+This slice wires recall into the eval runner (so a live run takes the real production path) and adds unit tests proving the short-circuit fires and that the verify pass catches a poisoned recall.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Thread `Recall` into the eval `LoopInvestigator`** | The one structural fix: capture the dropped recall, carry it on `LiveRunner`, pass it into `runOnce`'s `LoopInvestigator`. Makes eval take the production short-circuit path. |
+| D2 | **"Recall fired" signal = `Investigation.Recalled`** | `recalledInvestigation` already sets `Recalled: true`; no new field/instrument. Tests also assert zero non-`kb` tool calls (proof the loop was skipped). |
+| D3 | **Wiring + unit tests only; no live-harness fixture seeding** | Unit tests (fakes) deterministically prove the loop closes; the live `known-pattern-recall.yaml` works against a real seeded KB on a cluster. Harness catalog-seeding is deferred (bigger plumbing). |
+| D4 | **Include a poisoned-entry test** | The safety proof: a high-recall but wrong entry must be rejected/downgraded by the verify pass, not short-circuited into a confident wrong answer. Cheap once the recall-fires test harness exists. |
+
+## 3. Design
+
+### 3.1 Wiring (`main.go` + `live.go`)
+
+- `cmd/lore/main.go` `runEvalLive`: capture the recall — `model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)`.
+- `internal/eval/live.go`: add `Recall *investigate.Recall` to the `LiveRunner` struct; `runEvalLive` sets it on the runner; `runOnce` passes `Recall: lr.Recall` into the `LoopInvestigator` it builds (alongside `Model`/`Tools`/`Log`/`Verify`/`OnComplete`).
+
+A live eval run now short-circuits whenever the configured catalog has a trustworthy matching entry (`instant_recall` enabled) — the same path production takes. When `lr.Recall` is nil (recall disabled / not configured), behavior is unchanged (the gate is `li.Recall != nil`).
+
+### 3.2 The recall-fired signal
+
+The short-circuit delivers a `recalledInvestigation` whose `Recalled` field is `true` (and records no tool call). So `RunOutcome.Investigation.Recalled` is the signal; the recorder's calls show whether any non-`kb` tool ran. Tests assert both. (Surfacing a "recalled" column in the report is deferred — minor.)
+
+### 3.3 Tests (`live_test.go`)
+
+Using the existing fake-model harness (the `scriptModel`/script style already in the package's tests) plus a small eval-local `catalog.ScoredSearcher` fake returning a fixed scored entry:
+
+- **`TestRunOnceRecallShortCircuits`**: a `LiveRunner` with `Recall` configured over a catalog whose top entry matches the scenario's symptom + workload (resource agrees), thresholds set so the gate passes, and a model scripted only to satisfy the adversarial `Verify` call (keep the finding). `runOnce` on a non-invasive scenario → assert `out.Investigation.Recalled == true` AND no non-`kb` tool call was recorded (the ReAct loop was skipped).
+- **`TestRunOnceRecallPoisonedRejected`**: same setup but the entry is "poisoned" (its recalled finding is wrong) and the model is scripted to **reject** it on the `Verify` call → assert the result is NOT a confident recalled answer (root causes withdrawn / `Recalled` not delivered as the answer), i.e. the verify pass caught it rather than short-circuiting into the wrong root cause.
+
+Both reuse the package's existing fake `StepRunner`/model conventions; `Judge` is left nil (grading is irrelevant to these assertions). The recall is a real `*investigate.Recall` over the fake `ScoredSearcher`, exercising the true `lookup` gates.
+
+### 3.4 What is unchanged
+
+The eval gate (k-of-n from #5), coverage scoring, the judge, the report, and the production/serve recall wiring. This slice only stops eval from *dropping* recall, and tests the path.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| Capture the recall return | `cmd/lore/main.go` (`runEvalLive`) |
+| `Recall *investigate.Recall` on `LiveRunner`; set it; pass into `runOnce`'s `LoopInvestigator` | `internal/eval/live.go` |
+| Recall-fires + poisoned-rejected unit tests (+ eval-local `ScoredSearcher` fake) | `internal/eval/live_test.go` |
+
+## 5. Trade-offs accepted in v1
+
+- **Unit-tested, not live-fixture-tested.** The wiring is proven by fakes; the live offline scenario (`known-pattern-recall.yaml` running without a cluster/KB) would need the live harness to seed a catalog — deferred. A real live run on a cluster with a seeded KB exercises it end-to-end via the new wiring.
+- **No new "recalled" report column.** `Investigation.Recalled` carries the signal; surfacing it per-scenario in the report is a minor follow-up.
+- **Poisoned-case verify is scripted.** The test scripts the verify model's verdict; it proves the *wiring* (verify runs on the recalled finding and can reject), not the judgement quality of a real model.
+
+## 6. Testing
+
+- `TestRunOnceRecallShortCircuits` (§3.3): recall fires → `Recalled == true`, no non-`kb` tool recorded.
+- `TestRunOnceRecallPoisonedRejected` (§3.3): poisoned entry → verify rejects → not delivered as a confident recall.
+- A nil-`Recall` `LiveRunner` still runs `runOnce` normally (no short-circuit) — unchanged behavior (covered by the existing `RunScenario` tests, which set no `Recall`).
+- `go build ./... && go test ./... && go vet ./...` green.
+
+## 7. Out of scope (later eval-cluster slices)
+
+- **#4** — raise the per-run bar to `root_cause ≥ 3` / `root_cause_entities` entity-level precision in Track A.
+- **#7** — wire eval into CI with k-of-n repeat gating.
+- Live-harness catalog fixture seeding so the recall scenario runs fully offline.
+- A "recalled" column in the report.
+
+This slice closes the gap the deep analysis flagged: the recall short-circuit — the cache five slices have been hardening — is finally exercised (and its verify-backstop proven) by the eval harness instead of being silently bypassed.

--- a/internal/eval/live.go
+++ b/internal/eval/live.go
@@ -32,6 +32,7 @@ type LiveRunner struct {
 	Log       *slog.Logger
 	N         int                    // runs per scenario (default 1 if 0)
 	OnRecord  func(Scenario, []Call) // optional: persist the run's calls (replay corpus)
+	Recall    *investigate.Recall    // optional; when set, runOnce takes the instant-recall short-circuit (production path). nil ⇒ no recall.
 }
 
 // RunOutcome is one of the N runs of a scenario.
@@ -100,7 +101,7 @@ func (lr *LiveRunner) runOnce(ctx context.Context, scn Scenario) RunOutcome {
 	rec := &Recorder{}
 	var inv providers.Investigation
 	li := &investigate.LoopInvestigator{
-		Model: lr.Model, Tools: wrap(lr.BaseTools, rec), Log: lr.Log, Verify: true,
+		Model: lr.Model, Tools: wrap(lr.BaseTools, rec), Log: lr.Log, Verify: true, Recall: lr.Recall,
 		OnComplete: func(got providers.Investigation) { inv = got },
 	}
 	req := investigate.Request{

--- a/internal/eval/live_test.go
+++ b/internal/eval/live_test.go
@@ -2,10 +2,12 @@ package eval
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
 
+	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -175,5 +177,70 @@ func TestAggregateConfidentWrongFails(t *testing.T) {
 	runs[0].Verdict.ConfidentWrong = true
 	if aggregated(runs).Pass {
 		t.Fatal("any confident-wrong run must fail")
+	}
+}
+
+// fakeCatalog returns a single fixed scored entry regardless of query/k — enough
+// to drive the recall gates in a unit test.
+type fakeCatalog struct {
+	entry catalog.Entry
+	score float64
+}
+
+func (f fakeCatalog) SearchScored(string, int) ([]catalog.ScoredEntry, error) {
+	return []catalog.ScoredEntry{{Entry: f.entry, Score: f.score}}, nil
+}
+
+// verifyModel answers only the adversarial verify call (submit_verdicts) with a
+// fixed verdict for root cause index 0. On the recall short-circuit path this is
+// the sole model call (the ReAct loop is skipped).
+type verifyModel struct{ verdict string }
+
+func (m verifyModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{{ID: "v", Name: "submit_verdicts",
+		Args: fmt.Sprintf(`{"verdicts":[{"index":0,"verdict":%q}]}`, m.verdict)}}}, nil
+}
+
+// recallRunner builds a LiveRunner whose catalog has one entry matching the
+// recallScenario's namespace (so the structural gate agrees), with low recall
+// floors so a single strong hit short-circuits.
+func recallRunner(model providers.ModelProvider) *LiveRunner {
+	entry := catalog.Entry{Title: "HarborRegistryDown", Description: "IAM quota exceeded", Path: "harbor.md", Resource: "tooling"}
+	return &LiveRunner{
+		Model:  model,
+		Recall: &investigate.Recall{Catalog: fakeCatalog{entry: entry, score: 10}, MinScore: 1, SoloFloor: 1, MarginGap: 1},
+		Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func recallScenario() Scenario {
+	return Scenario{ID: "known-pattern-recall", Trigger: Trigger{Symptom: "harbor registry down", Namespace: "tooling"}}
+}
+
+func TestRunOnceRecallShortCircuits(t *testing.T) {
+	out := recallRunner(verifyModel{verdict: "keep"}).runOnce(context.Background(), recallScenario())
+	if !out.Investigation.Recalled {
+		t.Fatal("recall should have short-circuited the loop (Investigation.Recalled=true)")
+	}
+	if len(out.Investigation.RootCauses) != 1 {
+		t.Fatalf("a kept recall should retain its single root cause, got %d", len(out.Investigation.RootCauses))
+	}
+	if len(out.Coverage.Touched) != 0 {
+		t.Fatalf("recall short-circuit must run no investigation tools, got %v", out.Coverage.Touched)
+	}
+}
+
+func TestRunOnceRecallPoisonedRejected(t *testing.T) {
+	// A poisoned entry: the verify pass rejects it → the wrong root cause is withdrawn,
+	// not short-circuited into. (Recalled stays true; the safety is an empty RootCauses.)
+	out := recallRunner(verifyModel{verdict: "reject"}).runOnce(context.Background(), recallScenario())
+	if len(out.Investigation.RootCauses) != 0 {
+		t.Fatalf("a rejected poisoned recall must withdraw its root cause, got %d", len(out.Investigation.RootCauses))
+	}
+	if !out.Investigation.Recalled {
+		t.Fatal("a rejected recall is still a recall (loop skipped): Recalled must stay true")
+	}
+	if len(out.Investigation.Unresolved) == 0 {
+		t.Fatal("a rejected recall hypothesis must be moved to Unresolved, not silently dropped")
 	}
 }


### PR DESCRIPTION
  ## Summary
  - The live-eval harness was silently dropping recall (`model, tools, _, _ := buildModelAndTools(...)`), so the instant-recall short-circuit — the cache five prior slices have been hardening (BM25, decay,
  disambiguation, wider-retrieval, k-of-n gate) — was never exercised in eval.
  - Adds `Recall *investigate.Recall` to `LiveRunner`, threads it into the `LoopInvestigator` that `runOnce` builds, and captures the previously-discarded recall in `runEvalLive`. A live run now takes the real
  production path.
  - Two unit tests prove the loop: the short-circuit fires (`Recalled==true`, zero investigation tools touched), and a poisoned catalog entry is caught by the verify pass (root cause withdrawn, hypothesis moved to
  `Unresolved`).

  ## Test Plan
  - [x] `go build ./... && go vet ./... && go test ./...` — all green
  - [x] `TestRunOnceRecallShortCircuits`, `TestRunOnceRecallPoisonedRejected` pass
  - [x] Existing eval tests unchanged (no `Recall` set ⇒ behavior identical)