### PR TITLE
feat(eval): deterministic entity precision + over-claim penalty in Track A

### DIFF
--- a/docs/superpowers/plans/2026-06-23-entity-precision-trackA.md
+++ b/docs/superpowers/plans/2026-06-23-entity-precision-trackA.md
@@ -1,0 +1,270 @@
+# Entity Precision in Track A — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the replay eval (Track A) score root-cause correctness deterministically at the entity level — recall-gated precision with an over-claim/false-positive penalty — instead of pure keyword presence.
+
+**Architecture:** Two additive fields on `Expected` (`RootCauseEntities`, `Distractors`); a `claimText` helper that isolates what the investigation *blamed* (Title + each hypothesis Summary/SuggestedAction, excluding Evidence/Unresolved); and entity recall + over-claim scoring folded into `Score`, gating `Result.Pass`. Backward compatible: cases without `RootCauseEntities` score exactly as today.
+
+**Tech Stack:** Go 1.26, stdlib `testing` (no testify). Case-insensitive substring matching, same style as the existing `MustContain` scoring.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-entity-precision-trackA-design.md`
+
+**Branch:** `feat/entity-precision-trackA` (already checked out; the spec is already committed there).
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `internal/eval/case.go` | replay case schema | add `RootCauseEntities []string` + `Distractors []string` to `Expected` |
+| `internal/eval/score.go` | deterministic scoring | add `OverClaimed []string` to `Result`; add `claimText` helper; fold entity recall + over-claim into `Score`, gate `Pass` |
+| `internal/eval/eval_test.go` | scoring tests | add 5 entity-scoring tests + 1 parse assertion (co-located with the existing `TestScore`/`TestLoad`) |
+
+The schema + scoring + tests are one cohesive change (the tests won't compile until the fields exist), so it is one implementation task (T1) plus whole-tree verification (T2).
+
+---
+
+### Task 1: Entity recall + over-claim scoring in Track A
+
+**Files:**
+- Modify: `internal/eval/case.go` (`Expected` struct, currently lines 25-28)
+- Modify: `internal/eval/score.go` (`Result` struct lines 10-15; `Score` lines 19-33; add `claimText`)
+- Test: `internal/eval/eval_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/eval/eval_test.go` (it already imports `providers`, `os`, `path/filepath`, `testing`):
+
+```go
+func TestEntityRecallAllNamedPasses(t *testing.T) {
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{
+			Summary:         "apps/web crashed because rds/prod-db hit its connection cap",
+			SuggestedAction: "raise max_connections on rds/prod-db",
+		}},
+	}
+	r := Score("c", inv, Expected{
+		RootCauseEntities: []string{"apps/web", "rds/prod-db"},
+		Distractors:       []string{"apps/worker"},
+	})
+	if !r.Pass || len(r.Missing) != 0 || len(r.OverClaimed) != 0 {
+		t.Fatalf("expected clean pass, got %+v", r)
+	}
+}
+
+func TestEntityMissingFails(t *testing.T) {
+	inv := providers.Investigation{Confidence: 0.8, RootCauses: []providers.Hypothesis{{Summary: "apps/web is unhealthy"}}}
+	r := Score("c", inv, Expected{RootCauseEntities: []string{"apps/web", "rds/prod-db"}})
+	if r.Pass {
+		t.Fatal("expected fail: rds/prod-db was not named as a cause")
+	}
+	if len(r.Missing) != 1 || r.Missing[0] != "rds/prod-db" {
+		t.Fatalf("expected rds/prod-db in Missing, got %+v", r.Missing)
+	}
+}
+
+func TestOverClaimDistractorBlamedFails(t *testing.T) {
+	// All expected entities ARE named, but a distractor is also blamed → over-claim → fail.
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{Summary: "root cause is apps/web and apps/worker, both talking to rds/prod-db"}},
+	}
+	r := Score("c", inv, Expected{
+		RootCauseEntities: []string{"apps/web", "rds/prod-db"},
+		Distractors:       []string{"apps/worker"},
+	})
+	if r.Pass {
+		t.Fatalf("expected fail on over-claim, got pass: %+v", r)
+	}
+	if len(r.OverClaimed) != 1 || r.OverClaimed[0] != "apps/worker" {
+		t.Fatalf("expected apps/worker over-claimed, got %+v", r.OverClaimed)
+	}
+}
+
+func TestDistractorInEvidenceNotPenalized(t *testing.T) {
+	// The distractor appears only in Evidence/Unresolved, never in the claim → not an over-claim.
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{
+			Summary:  "apps/web crashed due to rds/prod-db saturation",
+			Evidence: []string{"ruled out apps/worker: its error rate was flat"},
+		}},
+		Unresolved: []string{"whether apps/worker retries amplified load"},
+	}
+	r := Score("c", inv, Expected{
+		RootCauseEntities: []string{"apps/web", "rds/prod-db"},
+		Distractors:       []string{"apps/worker"},
+	})
+	if !r.Pass {
+		t.Fatalf("a distractor only in evidence/unresolved must not penalize, got %+v", r)
+	}
+	if len(r.OverClaimed) != 0 {
+		t.Fatalf("no over-claim expected, got %+v", r.OverClaimed)
+	}
+}
+
+func TestNoEntitiesBackwardCompatible(t *testing.T) {
+	// A case with only must_contain behaves exactly as before: entities ignored.
+	inv := providers.Investigation{Confidence: 0.8, RootCauses: []providers.Hypothesis{{Summary: "chart bump stalled harbor-db"}}}
+	r := Score("c", inv, Expected{MustContain: []string{"chart", "harbor-db"}, MinConfidence: 0.5})
+	if !r.Pass || len(r.Missing) != 0 || len(r.OverClaimed) != 0 {
+		t.Fatalf("a must_contain-only case should pass cleanly, got %+v", r)
+	}
+}
+
+func TestLoadParsesEntities(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "db.yaml"), []byte(`
+name: db-saturation
+prompt: web 5xx spike
+tools:
+  what_changed: "no change"
+expected:
+  root_cause_entities: [apps/web, rds/prod-db]
+  distractors: [apps/worker]
+  min_confidence: 0.5
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cases, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cases) != 1 ||
+		len(cases[0].Expected.RootCauseEntities) != 2 ||
+		len(cases[0].Expected.Distractors) != 1 {
+		t.Fatalf("entity fields not parsed: %+v", cases[0].Expected)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/eval/ -run 'TestEntity|TestOverClaim|TestDistractor|TestNoEntities|TestLoadParsesEntities'`
+Expected: FAIL — compile errors `unknown field RootCauseEntities in struct literal of type Expected` and `r.OverClaimed undefined`.
+
+- [ ] **Step 3: Add the schema fields**
+
+In `internal/eval/case.go`, replace the `Expected` struct (lines 25-28):
+
+```go
+// Expected is the RCA scoring spec for a case.
+type Expected struct {
+	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the findings (recall, over full findings text)
+	MinConfidence     float64  `yaml:"min_confidence"`      // confidence floor (0 = no floor)
+	RootCauseEntities []string `yaml:"root_cause_entities"` // entities that MUST be named as the cause (entity recall, over claim text)
+	Distractors       []string `yaml:"distractors"`         // plausible-but-wrong entities that must NOT be blamed (over-claim/FP)
+}
+```
+
+- [ ] **Step 4: Add `claimText`, the `OverClaimed` field, and entity scoring**
+
+In `internal/eval/score.go`, add `OverClaimed []string` to `Result`:
+
+```go
+// Result is the score for one case.
+type Result struct {
+	Name        string
+	Pass        bool
+	Confidence  float64
+	Missing     []string // expected keywords/entities not found (or an error note); includes "over-claimed: <e>" markers
+	OverClaimed []string // distractor entities the investigation wrongly blamed (over-claim/FP)
+}
+```
+
+Replace the `Score` function body (lines 19-33) with:
+
+```go
+// Score reports whether the investigation identifies the expected root cause.
+// Keyword recall (must_contain) is matched over the full findings text. Entity
+// scoring — recall over root_cause_entities and an over-claim penalty over
+// distractors — is matched over the CLAIM text only (what was blamed), and engages
+// only when root_cause_entities is set. A case passes when nothing is missing,
+// no distractor was blamed, and confidence meets the floor.
+func Score(name string, inv providers.Investigation, exp Expected) Result {
+	hay := strings.ToLower(investigationText(inv))
+	var missing []string
+	for _, kw := range exp.MustContain {
+		if !strings.Contains(hay, strings.ToLower(kw)) {
+			missing = append(missing, kw)
+		}
+	}
+
+	var overClaimed []string
+	if len(exp.RootCauseEntities) > 0 {
+		claim := strings.ToLower(claimText(inv))
+		for _, e := range exp.RootCauseEntities {
+			if !strings.Contains(claim, strings.ToLower(e)) {
+				missing = append(missing, e)
+			}
+		}
+		for _, d := range exp.Distractors {
+			if strings.Contains(claim, strings.ToLower(d)) {
+				overClaimed = append(overClaimed, d)
+				missing = append(missing, "over-claimed: "+d)
+			}
+		}
+	}
+
+	return Result{
+		Name:        name,
+		Pass:        len(missing) == 0 && inv.Confidence >= exp.MinConfidence,
+		Confidence:  inv.Confidence,
+		Missing:     missing,
+		OverClaimed: overClaimed,
+	}
+}
+
+// claimText is what the investigation BLAMED: the title plus each hypothesis's
+// summary and suggested action. It deliberately excludes Evidence and Unresolved
+// so entity matching means "named as a cause", not "mentioned while ruling out".
+func claimText(inv providers.Investigation) string {
+	var b strings.Builder
+	b.WriteString(inv.Title)
+	for _, rc := range inv.RootCauses {
+		b.WriteString(" " + rc.Summary + " " + rc.SuggestedAction)
+	}
+	return b.String()
+}
+```
+
+(`investigationText` is unchanged and still used for `MustContain` recall.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/`
+Expected: PASS — the 6 new tests plus all pre-existing eval tests (notably `TestScore`, which uses only `MustContain` → entity block skipped → unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/eval/case.go internal/eval/score.go internal/eval/eval_test.go
+git commit -m "feat(eval): deterministic entity precision + over-claim penalty in Track A replay scoring"
+```
+
+---
+
+### Task 2: Whole-tree verification
+
+- [ ] **Step 1: Build, test, vet**
+
+Run:
+```bash
+go build ./... && go test ./... && go vet ./...
+```
+Expected: build clean; all tests PASS; vet clean.
+
+No commit (verification only).
+
+---
+
+## Notes for the implementer
+
+- The entire entity block (recall AND distractors) is gated on `len(exp.RootCauseEntities) > 0` — this is the backward-compat contract (spec D5). A distractors-only case is not supported in v1; that's intentional.
+- Over-claimed entities are mirrored into `Missing` as `"over-claimed: <e>"` so the existing failure renderer at `cmd/lore/main.go:514-515` (`missing: <joined>`) shows *why* a case failed, with no change to that call site. `OverClaimed` carries the structured list separately for any programmatic caller.
+- Matching is case-insensitive substring, identical to `MustContain`. Do NOT add word-boundary or regex matching (spec §5, YAGNI).
+- Do not touch `live.go`, the `ModelJudge`, `GroundTruth`, or `coverage.go` — Track B is explicitly out of scope (spec §3.4).
+- `Pass` keys off `len(missing) == 0`: because over-claims are appended to `missing`, a run that names every expected entity but also blames a distractor correctly fails.

--- a/docs/superpowers/specs/2026-06-23-entity-precision-trackA-design.md
+++ b/docs/superpowers/specs/2026-06-23-entity-precision-trackA-design.md
@@ -1,0 +1,124 @@
+# RunLore Entity Precision in Track A — Design
+
+| | |
+|---|---|
+| **Status** | Design `v0.1` — approved for implementation planning |
+| **Date** | 2026-06-23 |
+| **Scope** | Make the **replay** eval (Track A) score root-cause *correctness* deterministically at the entity level — recall-gated precision with an over-claim/false-positive penalty — instead of pure keyword presence. Confined to `internal/eval/case.go` (schema), `internal/eval/score.go` (scoring + `Result`), and their tests. Track B (live, LLM-judge) is untouched. |
+| **Author** | Smana (brainstormed with Claude) |
+| **Related** | Deep-analysis report roadmap #4 ("Add `root_cause_entities`; deterministic recall-gated precision in Track A; over-claim/FP penalty; reserve judge for fuzzy dims") and §line 139 ("ITBench's finding — more turns correlate with worse scores because strong models over-claim — means an eval with no over-claim penalty cannot see the dominant failure mode"). Builds on #5 (k-of-n gate, Track B) and #6 (recall-in-eval). Unblocks #7 (eval into CI). |
+
+---
+
+## 1. Why this exists
+
+RunLore has two eval tracks. **Track B** (`live.go`) runs on a live cluster and grades with an LLM judge — five fuzzy dimensions, k-of-n gate (#5). **Track A** (`eval.go`/`case.go`/`score.go`) replays recorded tool outputs through the loop and scores **deterministically** via `Score()`: every `Expected.MustContain` keyword must appear in the flattened findings text, and confidence must clear `MinConfidence`. Track A is reproducible and cluster-independent — the natural CI benchmark (#7 depends on it).
+
+The gap is in Track A's scoring. `MustContain` checks **recall only** — "did the right keyword appear anywhere in the findings?" — with **no precision and no over-claim penalty**. An investigation that blames ten entities, one of which is correct, passes. That is exactly the dominant failure mode the literature flags: strong models *over-claim*, asserting wrong entities as causes. An eval that cannot see over-claiming cannot measure the thing that most distinguishes a good RCA from a confident-wrong one.
+
+This slice makes Track A score **entity-level precision deterministically**: ground truth lists the entities that must be named as the cause (recall) and the plausible-but-wrong entities that must not be blamed (over-claim). A case passes the entity check only when it names all the right entities and none of the wrong ones — recall-gated precision, no LLM in the loop.
+
+## 2. Decisions locked during brainstorming
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Track A (replay) only** | The report's literal wording, and the home of deterministic/CI scoring. Track B's judge stays for fuzzy dims; over-claim correctness moves to a deterministic Track-A gate so we stop leaning on the biased same-family judge to catch it. |
+| D2 | **Authored distractor set** (not structured-entity precision) | Replay is text-based — static tool outputs → findings text — so the investigation rarely populates structured `Resource`/`Changes`. Detecting an over-claim deterministically needs an explicit notion of "wrong entities." Per-scenario authored `distractors` is reliable in text replay and is appropriate for a curated gold set (ITBench-style). Structured-entity precision is thin/unreliable in Track A. |
+| D3 | **Entity matching scans *claim text* only** (`Title` + each `RootCause.Summary`/`SuggestedAction`), excluding `Evidence`/`Unresolved` | Semantics: "did you *blame* this entity," not "did you mention it while ruling it out." A distractor cited as ruled-out evidence must not count as an over-claim; an expected entity must be named *as a cause*, not merely appear in raw evidence. |
+| D4 | **Binary recall-gated pass** (`recall && no over-claim`), not a graded precision float | Deterministic and sufficient for a gate. A graded precision/recall metric (e.g. fractional credit) is a later refinement. |
+| D5 | **Additive schema; backward compatible** | New `RootCauseEntities`/`Distractors` fields engage only when `RootCauseEntities` is non-empty. Existing `MustContain`-only cases score identically to today. |
+
+## 3. Design
+
+### 3.1 Schema (`case.go`, `Expected`)
+
+Add two fields to `Expected`:
+
+```go
+type Expected struct {
+	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the findings (existing)
+	MinConfidence     float64  `yaml:"min_confidence"`      // confidence floor (existing)
+	RootCauseEntities []string `yaml:"root_cause_entities"` // entities that MUST be named as the cause (recall)
+	Distractors       []string `yaml:"distractors"`         // plausible-but-wrong entities that must NOT be blamed (over-claim/FP)
+}
+```
+
+Entities are canonical, discriminative strings (e.g. `apps/web`, `rds/prod-db`, a Deployment name). Entity scoring engages only when `RootCauseEntities` is non-empty.
+
+### 3.2 Claim text vs evidence (`score.go`)
+
+A new helper isolates the *asserted cause + fix*, excluding evidence and unresolved notes:
+
+```go
+// claimText is what the investigation BLAMED: the title plus each hypothesis's
+// summary and suggested action. It deliberately excludes Evidence and Unresolved
+// so entity matching means "named as a cause", not "mentioned while ruling out".
+func claimText(inv providers.Investigation) string {
+	var b strings.Builder
+	b.WriteString(inv.Title)
+	for _, rc := range inv.RootCauses {
+		b.WriteString(" " + rc.Summary + " " + rc.SuggestedAction)
+	}
+	return b.String()
+}
+```
+
+(The existing `investigationText` — which *includes* Evidence/Unresolved — is unchanged and still used for `MustContain` recall, preserving today's behavior for keyword scoring.)
+
+### 3.3 Scoring (`score.go`, `Score`)
+
+Case-insensitive substring match (same style as `MustContain`). Over the lowercased claim text:
+
+- **recall**: every string in `RootCauseEntities` appears → un-named ones are added to `Missing`.
+- **over-claim**: any string in `Distractors` appears → collected into a new `OverClaimed []string`.
+- **entity pass** (only when `RootCauseEntities` non-empty): `len(missingEntities) == 0 && len(OverClaimed) == 0`.
+
+`Result` gains `OverClaimed []string`. The overall `Pass`:
+
+```
+Pass = keywordPass (all MustContain present, if any)
+    && entityPass   (recall met AND no over-claim, if RootCauseEntities non-empty)
+    && inv.Confidence >= MinConfidence
+```
+
+When `RootCauseEntities` is empty, `entityPass` is vacuously true → identical to today. Over-claimed entities are carried structurally in `Result.OverClaimed` **and** mirrored into `Missing` as `"over-claimed: <entity>"` entries, so existing callers that render `Missing` (the report failure note) show *why* a case failed without changing their rendering code.
+
+### 3.4 What is unchanged
+
+Track B (`live.go`), the `ModelJudge` and its rubric, `GroundTruth` (Track B's truth), `Coverage`, the replay harness (`eval.go` `Runner`/`runOne`/`staticTool`), and `MustContain`/`MinConfidence` semantics. The judge is "reserved for fuzzy dims" structurally — root-cause correctness is now a deterministic Track-A gate, not a fuzzy-judge score.
+
+## 4. Components / seams
+
+| Change | Location |
+|---|---|
+| `RootCauseEntities`, `Distractors` fields on `Expected` | `internal/eval/case.go` |
+| `claimText` helper; entity recall + over-claim scoring; `OverClaimed` on `Result`; gated `Pass` | `internal/eval/score.go` |
+| Table-driven entity-scoring tests | `internal/eval/score_test.go` (new or extend existing) |
+
+## 5. Trade-offs accepted in v1
+
+- **Substring matching** — an entity `web` could match `webhook`. Entities are canonical refs (`apps/web`), so authors pick discriminative strings; word-boundary matching is YAGNI.
+- **Per-scenario distractor authoring** — each entity-scored case must list its distractors. Accepted: it is a curated gold set, and a distractor-free case simply has no over-claim signal (recall-only, same as a `MustContain` case).
+- **Binary pass, not graded precision** — `recall && no-overclaim`. Sufficient for a gate; fractional precision/recall credit is a later refinement.
+- **Claim-text scoping is heuristic** — `Title` + `Summary` + `SuggestedAction`. If an author puts the real claim only in `Evidence`, it won't count; this is intended (evidence is not a claim).
+
+## 6. Testing
+
+Table-driven over synthetic `providers.Investigation` values (no live cluster, no LLM):
+
+- **`TestEntityRecallAllNamedPasses`** — all `RootCauseEntities` in claim text, no distractors → `Pass==true`, no `Missing`/`OverClaimed`.
+- **`TestEntityMissingFails`** — an expected entity absent from claim text → it appears in `Missing`, `Pass==false`.
+- **`TestOverClaimDistractorBlamedFails`** (headline) — a `Distractors` entity appears in claim text *while all expected entities are also present* → `OverClaimed` lists it, `Pass==false`. Proves the over-claim penalty independent of recall.
+- **`TestDistractorInEvidenceNotPenalized`** — a distractor appears only in a hypothesis's `Evidence` (and/or `Unresolved`), never in `Summary`/`SuggestedAction`/`Title` → not penalized, `Pass==true`. Proves claim-text scoping.
+- **`TestNoEntitiesBackwardCompatible`** — a case with only `MustContain` (no `RootCauseEntities`) scores identically to today (pass on keyword+confidence, ignore entities).
+- `go build ./... && go test ./... && go vet ./...` green.
+
+## 7. Out of scope (later slices)
+
+- **#7** — wiring Track A (this gate) into CI with a fail-on-threshold.
+- Graded (fractional) entity precision/recall instead of binary pass.
+- Word-boundary / structured-ref entity matching.
+- Porting the deterministic entity gate into Track B's live runner (the brainstorm's rejected "Track B too" option).
+- Structured-entity precision from `inv.Resource`/`Changes` (the rejected D2 alternative).
+
+This slice closes the deep analysis's eval-validity gap: Track A can finally *see* over-claiming — the dominant RCA failure mode — and gates on it deterministically, instead of rewarding any investigation that mentions the right keyword among many wrong ones.

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -23,8 +23,10 @@ type Case struct {
 
 // Expected is the RCA scoring spec for a case.
 type Expected struct {
-	MustContain   []string `yaml:"must_contain"`   // keywords that must appear in the findings
-	MinConfidence float64  `yaml:"min_confidence"` // confidence floor (0 = no floor)
+	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the findings (recall, over full findings text)
+	MinConfidence     float64  `yaml:"min_confidence"`      // confidence floor (0 = no floor)
+	RootCauseEntities []string `yaml:"root_cause_entities"` // entities that MUST be named as the cause (entity recall, over claim text)
+	Distractors       []string `yaml:"distractors"`         // plausible-but-wrong entities that must NOT be blamed (over-claim/FP); only evaluated when root_cause_entities is non-empty
 }
 
 // Load reads every *.yaml / *.yml case in dir.

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -52,6 +53,128 @@ func TestScore(t *testing.T) {
 	}
 	if r := Score("c", inv, Expected{MustContain: []string{"chart"}, MinConfidence: 0.95}); r.Pass {
 		t.Fatalf("expected fail on confidence floor, got %+v", r)
+	}
+}
+
+func TestEntityRecallAllNamedPasses(t *testing.T) {
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{
+			Summary:         "apps/web crashed because rds/prod-db hit its connection cap",
+			SuggestedAction: "raise max_connections on rds/prod-db",
+		}},
+	}
+	r := Score("c", inv, Expected{
+		RootCauseEntities: []string{"apps/web", "rds/prod-db"},
+		Distractors:       []string{"apps/worker"},
+	})
+	if !r.Pass || len(r.Missing) != 0 || len(r.OverClaimed) != 0 {
+		t.Fatalf("expected clean pass, got %+v", r)
+	}
+}
+
+func TestEntityMissingFails(t *testing.T) {
+	inv := providers.Investigation{Confidence: 0.8, RootCauses: []providers.Hypothesis{{Summary: "apps/web is unhealthy"}}}
+	r := Score("c", inv, Expected{RootCauseEntities: []string{"apps/web", "rds/prod-db"}})
+	if r.Pass {
+		t.Fatal("expected fail: rds/prod-db was not named as a cause")
+	}
+	if len(r.Missing) != 1 || r.Missing[0] != "rds/prod-db" {
+		t.Fatalf("expected rds/prod-db in Missing, got %+v", r.Missing)
+	}
+}
+
+func TestOverClaimDistractorBlamedFails(t *testing.T) {
+	// All expected entities ARE named, but a distractor is also blamed → over-claim → fail.
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{Summary: "root cause is apps/web and apps/worker, both talking to rds/prod-db"}},
+	}
+	r := Score("c", inv, Expected{
+		RootCauseEntities: []string{"apps/web", "rds/prod-db"},
+		Distractors:       []string{"apps/worker"},
+	})
+	if r.Pass {
+		t.Fatalf("expected fail on over-claim, got pass: %+v", r)
+	}
+	if len(r.OverClaimed) != 1 || r.OverClaimed[0] != "apps/worker" {
+		t.Fatalf("expected apps/worker over-claimed, got %+v", r.OverClaimed)
+	}
+	// The over-claim is mirrored into Missing so the report renderer shows the reason.
+	if !slices.Contains(r.Missing, "over-claimed: apps/worker") {
+		t.Fatalf("over-claim should be mirrored into Missing, got %+v", r.Missing)
+	}
+}
+
+func TestDistractorSubstringOfEntityNotOverClaim(t *testing.T) {
+	// The distractor "apps/worker" is a substring of the required "apps/worker-db".
+	// Naming only the required entity must NOT trip a false over-claim.
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{Summary: "root cause is apps/worker-db connection exhaustion"}},
+	}
+	r := Score("c", inv, Expected{
+		RootCauseEntities: []string{"apps/worker-db"},
+		Distractors:       []string{"apps/worker"},
+	})
+	if !r.Pass || len(r.OverClaimed) != 0 {
+		t.Fatalf("distractor that is a substring of a named entity must not be an over-claim, got %+v", r)
+	}
+}
+
+func TestDistractorInEvidenceNotPenalized(t *testing.T) {
+	// The distractor appears only in Evidence/Unresolved, never in the claim → not an over-claim.
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{
+			Summary:  "apps/web crashed due to rds/prod-db saturation",
+			Evidence: []string{"ruled out apps/worker: its error rate was flat"},
+		}},
+		Unresolved: []string{"whether apps/worker retries amplified load"},
+	}
+	r := Score("c", inv, Expected{
+		RootCauseEntities: []string{"apps/web", "rds/prod-db"},
+		Distractors:       []string{"apps/worker"},
+	})
+	if !r.Pass {
+		t.Fatalf("a distractor only in evidence/unresolved must not penalize, got %+v", r)
+	}
+	if len(r.OverClaimed) != 0 {
+		t.Fatalf("no over-claim expected, got %+v", r.OverClaimed)
+	}
+}
+
+func TestNoEntitiesBackwardCompatible(t *testing.T) {
+	// A case with only must_contain behaves exactly as before: entities ignored.
+	inv := providers.Investigation{Confidence: 0.8, RootCauses: []providers.Hypothesis{{Summary: "chart bump stalled harbor-db"}}}
+	r := Score("c", inv, Expected{MustContain: []string{"chart", "harbor-db"}, MinConfidence: 0.5})
+	if !r.Pass || len(r.Missing) != 0 || len(r.OverClaimed) != 0 {
+		t.Fatalf("a must_contain-only case should pass cleanly, got %+v", r)
+	}
+}
+
+func TestLoadParsesEntities(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "db.yaml"), []byte(`
+name: db-saturation
+prompt: web 5xx spike
+tools:
+  what_changed: "no change"
+expected:
+  root_cause_entities: [apps/web, rds/prod-db]
+  distractors: [apps/worker]
+  min_confidence: 0.5
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cases, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cases) != 1 ||
+		len(cases[0].Expected.RootCauseEntities) != 2 ||
+		len(cases[0].Expected.Distractors) != 1 {
+		t.Fatalf("entity fields not parsed: %+v", cases[0].Expected)
 	}
 }
 

--- a/internal/eval/score.go
+++ b/internal/eval/score.go
@@ -8,14 +8,19 @@ import (
 
 // Result is the score for one case.
 type Result struct {
-	Name       string
-	Pass       bool
-	Confidence float64
-	Missing    []string // expected keywords not found (or an error note)
+	Name        string
+	Pass        bool
+	Confidence  float64
+	Missing     []string // expected keywords/entities not found (or an error note); includes "over-claimed: <e>" markers
+	OverClaimed []string // distractor entities the investigation wrongly blamed (over-claim/FP)
 }
 
-// Score reports whether the investigation identifies the expected root cause:
-// every must_contain keyword appears in the findings and confidence meets the floor.
+// Score reports whether the investigation identifies the expected root cause.
+// Keyword recall (must_contain) is matched over the full findings text. Entity
+// scoring — recall over root_cause_entities and an over-claim penalty over
+// distractors — is matched over the CLAIM text only (what was blamed), and engages
+// only when root_cause_entities is set. A case passes when nothing is missing,
+// no distractor was blamed, and confidence meets the floor.
 func Score(name string, inv providers.Investigation, exp Expected) Result {
 	hay := strings.ToLower(investigationText(inv))
 	var missing []string
@@ -24,12 +29,57 @@ func Score(name string, inv providers.Investigation, exp Expected) Result {
 			missing = append(missing, kw)
 		}
 	}
-	return Result{
-		Name:       name,
-		Pass:       len(missing) == 0 && inv.Confidence >= exp.MinConfidence,
-		Confidence: inv.Confidence,
-		Missing:    missing,
+
+	var overClaimed []string
+	if len(exp.RootCauseEntities) > 0 {
+		claim := strings.ToLower(claimText(inv))
+		for _, e := range exp.RootCauseEntities {
+			if !strings.Contains(claim, strings.ToLower(e)) {
+				missing = append(missing, e)
+			}
+		}
+		for _, d := range exp.Distractors {
+			dl := strings.ToLower(d)
+			if !strings.Contains(claim, dl) {
+				continue
+			}
+			// Suppress the penalty when the distractor is merely a substring of a
+			// legitimately-named entity (e.g. distractor "apps/worker" inside the
+			// required "apps/worker-db"): the hit is explained by a correct claim,
+			// not an over-claim.
+			covered := false
+			for _, e := range exp.RootCauseEntities {
+				if strings.Contains(strings.ToLower(e), dl) {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				overClaimed = append(overClaimed, d)
+				missing = append(missing, "over-claimed: "+d)
+			}
+		}
 	}
+
+	return Result{
+		Name:        name,
+		Pass:        len(missing) == 0 && inv.Confidence >= exp.MinConfidence,
+		Confidence:  inv.Confidence,
+		Missing:     missing,
+		OverClaimed: overClaimed,
+	}
+}
+
+// claimText is what the investigation BLAMED: the title plus each hypothesis's
+// summary and suggested action. It deliberately excludes Evidence and Unresolved
+// so entity matching means "named as a cause", not "mentioned while ruling out".
+func claimText(inv providers.Investigation) string {
+	var b strings.Builder
+	b.WriteString(inv.Title)
+	for _, rc := range inv.RootCauses {
+		b.WriteString(" " + rc.Summary + " " + rc.SuggestedAction)
+	}
+	return b.String()
 }
 
 // investigationText flattens the findings into one searchable string.


### PR DESCRIPTION

  ## Summary
  - Track A's replay scorer only checked keyword **recall** (`must_contain` present anywhere
  in the findings) — it could not detect **over-claiming** (blaming wrong entities), the
  dominant RCA failure mode (ITBench finding).
  - Adds two ground-truth fields to `Expected`: `root_cause_entities` (must all be named **as
  the cause** → recall) and `distractors` (plausible-but-wrong entities that must **not** be
  blamed → over-claim/FP).
  - Entity matching scans **claim text only** (`Title` + each hypothesis
  `Summary`/`SuggestedAction`), excluding `Evidence`/`Unresolved`, so a distractor cited as
  *ruled-out evidence* isn't penalized. A substring-overlap guard prevents a correct
  `apps/worker-db` claim from tripping the `apps/worker` distractor.
  - A case passes the entity check iff all expected entities are named AND zero distractors
  are blamed (recall-gated precision, deterministic, no LLM). Fully backward compatible —
  `must_contain`-only cases are unchanged.

  ## Test Plan
  - [x] `go build ./... && go vet ./... && go test ./...` — all green
  - [x] 7 entity tests incl. `TestOverClaimDistractorBlamedFails` (named-right-but-also-wrong
  → fail), `TestDistractorInEvidenceNotPenalized`,
  `TestDistractorSubstringOfEntityNotOverClaim`, `TestNoEntitiesBackwardCompatible`