### PR TITLE
feat(eval): wire replay eval into CI — nightly k-of-n + fail-under gate (#7)

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -1,0 +1,35 @@
+name: eval
+on:
+  schedule:
+    - cron: "0 6 * * *"        # nightly 06:00 UTC
+  workflow_dispatch: {}         # manual run from the Actions tab
+
+# Least privilege: only needs to read the repo.
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  replay-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - run: go build -o lore ./cmd/lore
+      - name: replay eval (k-of-n + fail-under gate)
+        env:
+          RUNLORE_EVAL_API_KEY: ${{ secrets.RUNLORE_EVAL_API_KEY }}
+        run: ./lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7 -report-dir eval/reports
+      - name: upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report
+          path: eval/reports/
+          if-no-files-found: warn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,23 @@ lore eval --config runlore.yaml --cases examples/eval
 It needs a configured model (`config.model`). The harness logic (`internal/eval`) is unit-tested with a
 fake model, so `go test ./internal/eval/` runs without an API key.
 
+### Nightly eval (CI)
+
+`.github/workflows/eval.yaml` runs the replay eval every night (06:00 UTC) and on
+manual dispatch. It repeats each case 5× and fails the run when the campaign
+pass-rate drops below 70% (`-n 5 -fail-under 0.7`), then uploads the JSON report as
+a build artifact.
+
+To enable it, add one repository secret — **`RUNLORE_EVAL_API_KEY`** — holding the
+API key for the provider in `eval/ci.runlore.yaml`. Without the secret the job fails
+fast (by design: a red nightly is the signal). The eval never runs on pull requests,
+so it imposes no per-PR cost and never blocks merges; the deterministic scoring logic
+is already covered by `go test ./...` on every PR.
+
+Run it locally the same way CI does:
+
+    lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7
+
 ## Quick local demo (no cluster)
 
 ```bash

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -471,7 +471,8 @@ func runEval(args []string) error {
 	recordDir := fs.String("record", "eval/fixtures", "where to write recorded runs (replay corpus)")
 	reportDir := fs.String("report-dir", "eval/reports", "where to write the campaign report")
 	prevReport := fs.String("baseline", "", "previous report JSON for regression diff")
-	n := fs.Int("n", 10, "runs per scenario (live mode)")
+	n := fs.Int("n", 1, "repeats per case (replay mode); >1 enables the k-of-n gate")
+	failUnder := fs.Float64("fail-under", 0, "fail (non-zero exit) when campaign pass-rate < this (0 = no gate)")
 	stamp := fs.String("stamp", "", "report timestamp (RFC3339); blank = now")
 	jProvider := fs.String("judge-provider", "", "judge model provider (default: investigation model)")
 	jBaseURL := fs.String("judge-base-url", "", "judge model base URL")
@@ -504,20 +505,44 @@ func runEval(args []string) error {
 		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
 	}
 	runner := &eval.Runner{Model: buildModel(cfg, apiKey), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	rep := runner.Run(context.Background(), cases)
-	for _, res := range rep.Results {
-		status := "PASS"
-		if !res.Pass {
-			status = "FAIL"
+	camp := runner.RunN(context.Background(), cases, *n)
+	for _, a := range camp.Aggregates {
+		status := "MISSED"
+		if a.Reached {
+			status = "REACHED"
 		}
-		fmt.Printf("%-4s  %-32s  confidence=%.2f", status, res.Name, res.Confidence)
-		if len(res.Missing) > 0 {
-			fmt.Printf("  missing: %s", strings.Join(res.Missing, ", "))
+		flaky := ""
+		if a.Flaky {
+			flaky = " flaky"
+		}
+		fmt.Printf("%-7s  %-32s  pass-rate=%.0f%% (n=%d)%s", status, a.Name, a.PassRate*100, a.Runs, flaky)
+		if len(a.Missing) > 0 {
+			fmt.Printf("  missing: %s", strings.Join(a.Missing, ", "))
 		}
 		fmt.Println()
 	}
-	fmt.Printf("\nRCA identified: %d/%d (%.0f%%)\n", rep.Passed(), len(rep.Results), rep.RCARate()*100)
-	return nil
+	fmt.Printf("\nreached %d/%d cases (%.0f%%)", camp.ReachedCases(), len(camp.Aggregates), camp.PassRate()*100)
+	if *failUnder > 0 {
+		fmt.Printf("  threshold=%.0f%%", *failUnder*100)
+	}
+	fmt.Println()
+
+	if *reportDir != "" {
+		st := *stamp
+		if st == "" {
+			st = time.Now().UTC().Format(time.RFC3339)
+		}
+		if b, err := camp.JSON(); err == nil {
+			if mkErr := os.MkdirAll(*reportDir, 0o755); mkErr == nil {
+				path := filepath.Join(*reportDir, strings.ReplaceAll(st, ":", "-")+"-replay.json")
+				if wErr := os.WriteFile(path, b, 0o644); wErr == nil {
+					fmt.Printf("report: %s\n", path)
+				}
+			}
+		}
+	}
+
+	return eval.GateError(camp, *failUnder)
 }
 
 // shellStepRunner executes a scenario step as a shell command (kubectl/flux/test).

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -471,7 +471,7 @@ func runEval(args []string) error {
 	recordDir := fs.String("record", "eval/fixtures", "where to write recorded runs (replay corpus)")
 	reportDir := fs.String("report-dir", "eval/reports", "where to write the campaign report")
 	prevReport := fs.String("baseline", "", "previous report JSON for regression diff")
-	n := fs.Int("n", 1, "repeats per case (replay mode); >1 enables the k-of-n gate")
+	n := fs.Int("n", 1, "runs per case: replay defaults to 1, live to 10 when unset")
 	failUnder := fs.Float64("fail-under", 0, "fail (non-zero exit) when campaign pass-rate < this (0 = no gate)")
 	stamp := fs.String("stamp", "", "report timestamp (RFC3339); blank = now")
 	jProvider := fs.String("judge-provider", "", "judge model provider (default: investigation model)")
@@ -481,6 +481,12 @@ func runEval(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	nExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "n" {
+			nExplicit = true
+		}
+	})
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {
 		return err
@@ -489,6 +495,9 @@ func runEval(args []string) error {
 		return fmt.Errorf("eval requires a configured model (set config.model)")
 	}
 	if *live {
+		if !nExplicit {
+			*n = 10
+		}
 		return runEvalLive(cfg, *scnDir, *recordDir, *reportDir, *prevReport, *stamp, *n,
 			*jProvider, *jBaseURL, *jModel, *jKeyEnv)
 	}
@@ -521,9 +530,13 @@ func runEval(args []string) error {
 		}
 		fmt.Println()
 	}
-	fmt.Printf("\nreached %d/%d cases (%.0f%%)", camp.ReachedCases(), len(camp.Aggregates), camp.PassRate()*100)
-	if *failUnder > 0 {
-		fmt.Printf("  threshold=%.0f%%", *failUnder*100)
+	if len(camp.Aggregates) == 0 {
+		fmt.Print("\nno eval cases ran")
+	} else {
+		fmt.Printf("\nreached %d/%d cases (%.0f%%)", camp.ReachedCases(), len(camp.Aggregates), camp.PassRate()*100)
+		if *failUnder > 0 {
+			fmt.Printf("  threshold=%.0f%%", *failUnder*100)
+		}
 	}
 	fmt.Println()
 
@@ -532,12 +545,16 @@ func runEval(args []string) error {
 		if st == "" {
 			st = time.Now().UTC().Format(time.RFC3339)
 		}
-		if b, err := camp.JSON(); err == nil {
-			if mkErr := os.MkdirAll(*reportDir, 0o755); mkErr == nil {
-				path := filepath.Join(*reportDir, strings.ReplaceAll(st, ":", "-")+"-replay.json")
-				if wErr := os.WriteFile(path, b, 0o644); wErr == nil {
-					fmt.Printf("report: %s\n", path)
-				}
+		if b, err := camp.JSON(); err != nil {
+			fmt.Fprintf(os.Stderr, "eval: report not written: %v\n", err)
+		} else if mkErr := os.MkdirAll(*reportDir, 0o755); mkErr != nil {
+			fmt.Fprintf(os.Stderr, "eval: report not written: %v\n", mkErr)
+		} else {
+			path := filepath.Join(*reportDir, strings.ReplaceAll(st, ":", "-")+"-replay.json")
+			if wErr := os.WriteFile(path, b, 0o644); wErr != nil {
+				fmt.Fprintf(os.Stderr, "eval: report not written: %v\n", wErr)
+			} else {
+				fmt.Printf("report: %s\n", path)
 			}
 		}
 	}

--- a/docs/superpowers/plans/2026-06-23-eval-ci.md
+++ b/docs/superpowers/plans/2026-06-23-eval-ci.md
@@ -1,0 +1,715 @@
+# Eval into CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run the deterministic-scored replay eval automatically (nightly + manual) with a k-of-n + fail-under gate that returns a non-zero exit on RCA regression, and upload the report — without imposing LLM cost or secrets on every PR.
+
+**Architecture:** Add an N-repeat aggregation layer to the existing replay `Runner` that reuses the k-of-n bar from the live path, expose `-n` / `-fail-under` flags on `lore eval` (replay), write a JSON report, and add a separate `eval.yaml` GitHub workflow that runs it on a schedule/dispatch against a committed minimal CI config.
+
+**Tech Stack:** Go 1.26, standard library only (`flag`, `encoding/json`, `sort`), GitHub Actions.
+
+## Global Constraints
+
+- Go version: **1.26** (matches `.github/workflows/ci.yaml`).
+- No new third-party dependencies.
+- Default behavior must be unchanged for local `lore eval`: `-n` default **1**, `-fail-under` default **0** (no gate). Existing `Runner.Run` / `Report` / `Score` signatures stay intact.
+- k-of-n bar is `evalMinPassRate = 0.7`; reuse it, do not introduce a parallel constant.
+- All new exported identifiers stay in package `eval` (`internal/eval`).
+- Tests stub the model via the `providers.ModelProvider` interface (single method `Complete(ctx, CompletionRequest) (CompletionResponse, error)`); they never call a live LLM.
+
+---
+
+### Task 1: Share stats helpers (`stats.go`)
+
+Pure move so replay and live share one definition. No behavior change.
+
+**Files:**
+- Create: `internal/eval/stats.go`
+- Modify: `internal/eval/live.go` (delete the moved constants + helpers)
+- Test: existing `internal/eval/live_test.go` (must still pass)
+
+**Interfaces:**
+- Produces: package-level consts `evalRootCauseBar`, `evalMinPassRate`, `evalMaxRootCauseVariance`; funcs `medianFloat([]float64) float64`, `variance([]float64) float64` — same signatures as today, now in `stats.go`.
+
+- [ ] **Step 1: Create `internal/eval/stats.go` with the moved declarations**
+
+```go
+package eval
+
+import "sort"
+
+// Shared eval gating constants and statistics helpers, used by both the replay
+// runner (eval.go) and the live runner (live.go).
+const (
+	evalRootCauseBar         = 2   // a run "reaches the root cause" at score >= 2 (live judge)
+	evalMinPassRate          = 0.7 // fraction of runs that must pass (k-of-n); also the replay flaky band edge
+	evalMaxRootCauseVariance = 0.5 // above this a live scenario is flaky → not a pass
+)
+
+// medianFloat returns the median of xs (0 for empty).
+func medianFloat(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	cp := append([]float64(nil), xs...)
+	sort.Float64s(cp)
+	m := len(cp) / 2
+	if len(cp)%2 == 1 {
+		return cp[m]
+	}
+	return (cp[m-1] + cp[m]) / 2
+}
+
+// variance returns the population variance of xs (0 for empty).
+func variance(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	mean := sum / float64(len(xs))
+	var v float64
+	for _, x := range xs {
+		v += (x - mean) * (x - mean)
+	}
+	return v / float64(len(xs))
+}
+```
+
+- [ ] **Step 2: Delete the now-duplicated declarations from `live.go`**
+
+In `internal/eval/live.go` remove the `const (...)` block holding `evalRootCauseBar`/`evalMinPassRate`/`evalMaxRootCauseVariance` (lines ~12-16) and the `func medianFloat` and `func variance` definitions (near the bottom, ~lines 186-214). Leave everything else untouched. If `sort` becomes unused in `live.go`, remove it from that file's imports; if still used (it is — `sort.Strings`), keep it.
+
+- [ ] **Step 3: Build and run the eval package tests**
+
+Run: `go build ./... && go test ./internal/eval/`
+Expected: PASS (no behavior change; live tests still green, no redeclaration errors).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/eval/stats.go internal/eval/live.go
+git commit -m "refactor(eval): lift shared gate constants + stats helpers into stats.go"
+```
+
+---
+
+### Task 2: N-repeat aggregation in the replay runner
+
+Add a campaign layer over `runOne` that repeats each case `n` times and computes the k-of-n verdict. `Runner.Run`/`runOne` are untouched.
+
+**Files:**
+- Modify: `internal/eval/eval.go`
+- Test: `internal/eval/eval_test.go`
+
+**Interfaces:**
+- Consumes: `Runner.runOne(ctx, Case) Result` (existing), `Result{Pass bool; Confidence float64; Missing []string; OverClaimed []string}` (existing), `evalMinPassRate`, `medianFloat` (Task 1).
+- Produces:
+  - `type CaseAggregate struct { Name string; Runs int; PassRate float64; Reached bool; Flaky bool; Confidence float64; Missing []string; OverClaimed []string }`
+  - `type Campaign struct { N int; Aggregates []CaseAggregate }`
+  - `func (c Campaign) ReachedCases() int`
+  - `func (c Campaign) PassRate() float64` — reached / total (0 for empty)
+  - `func (c Campaign) FlakyNames() []string`
+  - `func (r *Runner) RunN(ctx context.Context, cases []Case, n int) Campaign`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/eval/eval_test.go`. The stub returns a passing finding for the first `passN` of every `n` calls per case, then a failing one — letting a test dial the pass-rate.
+
+```go
+// rateModel passes (names harbor-db) on its first passN Complete-pairs, then fails.
+// Each replay run makes 2 Complete calls (tool, then submit_findings).
+type rateModel struct {
+	calls, passN int
+}
+
+func (m *rateModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	if m.calls%2 == 1 { // first call of a run: invoke the tool
+		return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+			{ID: "1", Name: "what_changed", Args: `{}`}}}, nil
+	}
+	run := m.calls / 2 // 1-based index of the run just completing
+	summary := "chart bump broke harbor-db migrations"
+	if run > m.passN {
+		summary = "unclear, possibly a transient blip"
+	}
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "2", Name: "submit_findings",
+			Args: `{"confidence":0.9,"root_causes":[{"summary":"` + summary + `"}]}`}}}, nil
+}
+
+func newRateRunner(passN int) *Runner {
+	return &Runner{Model: &rateModel{passN: passN}, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func harborCase() Case {
+	return Case{Name: "harbor", Prompt: "probe failing", Tools: map[string]string{"what_changed": "chart 1.15"},
+		Expected: Expected{MustContain: []string{"chart", "harbor-db"}, MinConfidence: 0.5}}
+}
+
+func TestReplayKOfNRepeats(t *testing.T) {
+	// 4 of 5 pass → pass-rate 0.8 ≥ 0.7 → reached, not flaky.
+	camp := newRateRunner(4).RunN(context.Background(), []Case{harborCase()}, 5)
+	a := camp.Aggregates[0]
+	if a.Runs != 5 || a.PassRate < 0.79 || a.PassRate > 0.81 {
+		t.Fatalf("want 5 runs at 0.8, got runs=%d rate=%.2f", a.Runs, a.PassRate)
+	}
+	if !a.Reached || a.Flaky {
+		t.Fatalf("4/5 should be reached and not flaky, got %+v", a)
+	}
+
+	// 2 of 5 pass → 0.4 < 0.7 → not reached; 0.4 is in (0.3,0.7) → flaky.
+	camp = newRateRunner(2).RunN(context.Background(), []Case{harborCase()}, 5)
+	a = camp.Aggregates[0]
+	if a.Reached {
+		t.Fatalf("2/5 must not be reached, got %+v", a)
+	}
+	if !a.Flaky {
+		t.Fatalf("2/5 (rate 0.4) should be flaky, got %+v", a)
+	}
+}
+
+func TestReplayCampaignPassRate(t *testing.T) {
+	// One reachable case (5/5) and one unreachable (0/5) → campaign pass-rate 0.5.
+	cases := []Case{harborCase(), {Name: "miss", Prompt: "x", Tools: map[string]string{"what_changed": "y"},
+		Expected: Expected{MustContain: []string{"network policy"}}}}
+	camp := newRateRunner(5).RunN(context.Background(), cases, 5)
+	if camp.ReachedCases() != 1 || camp.PassRate() != 0.5 {
+		t.Fatalf("want reached=1 rate=0.5, got reached=%d rate=%.2f", camp.ReachedCases(), camp.PassRate())
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/eval/ -run 'TestReplayKOfNRepeats|TestReplayCampaignPassRate' -v`
+Expected: FAIL — `RunN`, `Campaign`, `CaseAggregate` undefined.
+
+- [ ] **Step 3: Implement the aggregation in `eval.go`**
+
+Append to `internal/eval/eval.go`:
+
+```go
+// CaseAggregate is the k-of-n verdict for one case over N replay repeats.
+type CaseAggregate struct {
+	Name        string
+	Runs        int
+	PassRate    float64  // fraction of repeats whose Result.Pass is true
+	Reached     bool     // PassRate >= evalMinPassRate
+	Flaky       bool     // PassRate in (1-evalMinPassRate, evalMinPassRate): runs disagree
+	Confidence  float64  // median confidence over repeats
+	Missing     []string // union of missing keywords/entities across repeats
+	OverClaimed []string // union of over-claimed distractors across repeats
+}
+
+// Campaign is the aggregate of a multi-repeat replay run.
+type Campaign struct {
+	N          int
+	Aggregates []CaseAggregate
+}
+
+// ReachedCases counts cases whose pass-rate met the k-of-n bar.
+func (c Campaign) ReachedCases() int {
+	n := 0
+	for _, a := range c.Aggregates {
+		if a.Reached {
+			n++
+		}
+	}
+	return n
+}
+
+// PassRate is the fraction of cases that reached RCA (0 for empty).
+func (c Campaign) PassRate() float64 {
+	if len(c.Aggregates) == 0 {
+		return 0
+	}
+	return float64(c.ReachedCases()) / float64(len(c.Aggregates))
+}
+
+// FlakyNames lists cases whose repeats disagreed too much to trust.
+func (c Campaign) FlakyNames() []string {
+	var names []string
+	for _, a := range c.Aggregates {
+		if a.Flaky {
+			names = append(names, a.Name)
+		}
+	}
+	return names
+}
+
+// RunN replays every case n times and returns the aggregated campaign.
+func (r *Runner) RunN(ctx context.Context, cases []Case, n int) Campaign {
+	if n < 1 {
+		n = 1
+	}
+	camp := Campaign{N: n}
+	for _, c := range cases {
+		camp.Aggregates = append(camp.Aggregates, r.aggregateCase(ctx, c, n))
+	}
+	return camp
+}
+
+func (r *Runner) aggregateCase(ctx context.Context, c Case, n int) CaseAggregate {
+	confs := make([]float64, n)
+	missSet := map[string]struct{}{}
+	ocSet := map[string]struct{}{}
+	passes := 0
+	for i := 0; i < n; i++ {
+		res := r.runOne(ctx, c)
+		if res.Pass {
+			passes++
+		}
+		confs[i] = res.Confidence
+		for _, m := range res.Missing {
+			missSet[m] = struct{}{}
+		}
+		for _, o := range res.OverClaimed {
+			ocSet[o] = struct{}{}
+		}
+	}
+	rate := float64(passes) / float64(n)
+	return CaseAggregate{
+		Name:        c.Name,
+		Runs:        n,
+		PassRate:    rate,
+		Reached:     rate >= evalMinPassRate,
+		Flaky:       rate > 1-evalMinPassRate && rate < evalMinPassRate,
+		Confidence:  medianFloat(confs),
+		Missing:     sortedSet(missSet),
+		OverClaimed: sortedSet(ocSet),
+	}
+}
+
+func sortedSet(m map[string]struct{}) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+```
+
+Add `"sort"` to the imports of `eval.go` (it currently imports `context`, `log/slog`, and the two internal packages).
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/eval/ -run 'TestReplayKOfNRepeats|TestReplayCampaignPassRate' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full eval package to confirm no regressions**
+
+Run: `go test ./internal/eval/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/eval/eval.go internal/eval/eval_test.go
+git commit -m "feat(eval): N-repeat campaign aggregation with k-of-n verdict for replay"
+```
+
+---
+
+### Task 3: JSON report for replay campaigns
+
+A small, dependency-free report written to `-report-dir` for the CI artifact.
+
+**Files:**
+- Modify: `internal/eval/eval.go` (add a marshal helper) OR create `internal/eval/replay_report.go`
+- Test: `internal/eval/eval_test.go`
+
+**Interfaces:**
+- Consumes: `Campaign` (Task 2).
+- Produces: `func (c Campaign) JSON() ([]byte, error)` returning indented JSON of `{ "n": N, "pass_rate": X, "reached": k, "total": m, "cases": [CaseAggregate...] }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/eval/eval_test.go`:
+
+```go
+func TestCampaignJSON(t *testing.T) {
+	camp := newRateRunner(5).RunN(context.Background(), []Case{harborCase()}, 2)
+	b, err := camp.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	var got struct {
+		N        int     `json:"n"`
+		PassRate float64 `json:"pass_rate"`
+		Reached  int     `json:"reached"`
+		Total    int     `json:"total"`
+		Cases    []struct {
+			Name    string `json:"name"`
+			Reached bool   `json:"reached"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.N != 2 || got.Total != 1 || got.Reached != 1 || got.PassRate != 1.0 {
+		t.Fatalf("unexpected report header: %+v", got)
+	}
+	if len(got.Cases) != 1 || got.Cases[0].Name != "harbor" || !got.Cases[0].Reached {
+		t.Fatalf("unexpected case rows: %+v", got.Cases)
+	}
+}
+```
+
+Add `"encoding/json"` to the test file imports.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/eval/ -run TestCampaignJSON -v`
+Expected: FAIL — `camp.JSON` undefined.
+
+- [ ] **Step 3: Implement `JSON()` in `eval.go`**
+
+Add `"encoding/json"` to `eval.go` imports, and append:
+
+```go
+// JSON renders the campaign as an indented report for CI artifacts.
+func (c Campaign) JSON() ([]byte, error) {
+	type row struct {
+		Name        string   `json:"name"`
+		Runs        int      `json:"runs"`
+		PassRate    float64  `json:"pass_rate"`
+		Reached     bool     `json:"reached"`
+		Flaky       bool     `json:"flaky"`
+		Confidence  float64  `json:"confidence"`
+		Missing     []string `json:"missing,omitempty"`
+		OverClaimed []string `json:"over_claimed,omitempty"`
+	}
+	rows := make([]row, len(c.Aggregates))
+	for i, a := range c.Aggregates {
+		rows[i] = row(a)
+	}
+	return json.MarshalIndent(struct {
+		N        int     `json:"n"`
+		PassRate float64 `json:"pass_rate"`
+		Reached  int     `json:"reached"`
+		Total    int     `json:"total"`
+		Cases    []row   `json:"cases"`
+	}{
+		N:        c.N,
+		PassRate: c.PassRate(),
+		Reached:  c.ReachedCases(),
+		Total:    len(c.Aggregates),
+		Cases:    rows,
+	}, "", "  ")
+}
+```
+
+Note: `row(a)` works because `row`'s fields match `CaseAggregate`'s field names and types in order. If Go rejects the conversion (field tags differ but names/types/order match — conversion is allowed), keep it; the tags do not affect convertibility.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/eval/ -run TestCampaignJSON -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/eval/eval.go internal/eval/eval_test.go
+git commit -m "feat(eval): JSON campaign report for CI artifacts"
+```
+
+---
+
+### Task 4: Wire `-n` / `-fail-under` flags + gate into `runEval`
+
+Expose the campaign through the CLI, print a summary, write the report, and return a non-zero exit when the campaign pass-rate is below `-fail-under`.
+
+**Files:**
+- Modify: `cmd/lore/main.go` (the `runEval` replay path, lines ~465-521)
+- Test: `internal/eval/eval_test.go` (gate helper) — see Step 1
+
+**Interfaces:**
+- Consumes: `Runner.RunN`, `Campaign.PassRate`, `Campaign.FlakyNames`, `Campaign.JSON` (Tasks 2-3).
+- Produces: `func GateError(c Campaign, failUnder float64) error` in `internal/eval` — returns non-nil when `failUnder > 0 && c.PassRate() < failUnder`, naming missed + flaky cases; nil otherwise. (Putting the gate in the package keeps it unit-testable without driving the CLI.)
+
+- [ ] **Step 1: Write the failing test for the gate helper**
+
+Add to `internal/eval/eval_test.go`:
+
+```go
+func TestGateError(t *testing.T) {
+	miss := Case{Name: "miss", Prompt: "x", Tools: map[string]string{"what_changed": "y"},
+		Expected: Expected{MustContain: []string{"network policy"}}}
+	camp := newRateRunner(5).RunN(context.Background(), []Case{harborCase(), miss}, 5) // pass-rate 0.5
+
+	if err := GateError(camp, 0); err != nil {
+		t.Fatalf("fail-under 0 must never gate, got %v", err)
+	}
+	if err := GateError(camp, 0.4); err != nil {
+		t.Fatalf("0.5 >= 0.4 should pass, got %v", err)
+	}
+	if err := GateError(camp, 0.7); err == nil {
+		t.Fatal("0.5 < 0.7 should return a gate error")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/eval/ -run TestGateError -v`
+Expected: FAIL — `GateError` undefined.
+
+- [ ] **Step 3: Implement `GateError` in `eval.go`**
+
+Add `"fmt"` and `"strings"` to `eval.go` imports if not present, and append:
+
+```go
+// GateError returns a non-nil error when the campaign pass-rate is below failUnder
+// (which is only enforced when failUnder > 0). The message names the cases that did
+// not reach RCA and any flaky cases, so CI logs explain the failure.
+func GateError(c Campaign, failUnder float64) error {
+	if failUnder <= 0 || c.PassRate() >= failUnder {
+		return nil
+	}
+	var missed []string
+	for _, a := range c.Aggregates {
+		if !a.Reached {
+			missed = append(missed, a.Name)
+		}
+	}
+	msg := fmt.Sprintf("eval gate failed: pass-rate %.0f%% < threshold %.0f%% (reached %d/%d)",
+		c.PassRate()*100, failUnder*100, c.ReachedCases(), len(c.Aggregates))
+	if len(missed) > 0 {
+		msg += "; missed: " + strings.Join(missed, ", ")
+	}
+	if fl := c.FlakyNames(); len(fl) > 0 {
+		msg += "; flaky: " + strings.Join(fl, ", ")
+	}
+	return fmt.Errorf("%s", msg)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/eval/ -run TestGateError -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the flags and campaign wiring to `runEval`**
+
+In `cmd/lore/main.go`, inside `runEval`'s flag block (after the existing `stamp` flag, ~line 475) add:
+
+```go
+	repeats := fs.Int("n", 1, "repeats per case (replay mode); >1 enables the k-of-n gate")
+	failUnder := fs.Float64("fail-under", 0, "fail (non-zero exit) when campaign pass-rate < this (0 = no gate)")
+```
+
+Then replace the replay block that currently runs `runner.Run(...)` and prints (the section from `runner := &eval.Runner{...}` through `return nil`, ~lines 506-520) with:
+
+```go
+	runner := &eval.Runner{Model: buildModel(cfg, apiKey), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	camp := runner.RunN(context.Background(), cases, *repeats)
+	for _, a := range camp.Aggregates {
+		status := "MISSED"
+		if a.Reached {
+			status = "REACHED"
+		}
+		flaky := ""
+		if a.Flaky {
+			flaky = " flaky"
+		}
+		fmt.Printf("%-7s  %-32s  pass-rate=%.0f%% (n=%d)%s", status, a.Name, a.PassRate*100, a.Runs, flaky)
+		if len(a.Missing) > 0 {
+			fmt.Printf("  missing: %s", strings.Join(a.Missing, ", "))
+		}
+		fmt.Println()
+	}
+	fmt.Printf("\nreached %d/%d cases (%.0f%%)", camp.ReachedCases(), len(camp.Aggregates), camp.PassRate()*100)
+	if *failUnder > 0 {
+		fmt.Printf("  threshold=%.0f%%", *failUnder*100)
+	}
+	fmt.Println()
+
+	if *reportDir != "" {
+		st := *stamp
+		if st == "" {
+			st = time.Now().UTC().Format(time.RFC3339)
+		}
+		if b, err := camp.JSON(); err == nil {
+			if mkErr := os.MkdirAll(*reportDir, 0o755); mkErr == nil {
+				path := filepath.Join(*reportDir, strings.ReplaceAll(st, ":", "-")+"-replay.json")
+				if wErr := os.WriteFile(path, b, 0o644); wErr == nil {
+					fmt.Printf("report: %s\n", path)
+				}
+			}
+		}
+	}
+
+	return eval.GateError(camp, *failUnder)
+```
+
+Confirm `cmd/lore/main.go` already imports `time`, `os`, `path/filepath`, `strings`, `fmt`, `io`, `log/slog` (it does — they are used by sibling functions). If `go build` reports any as missing, add it.
+
+- [ ] **Step 6: Build and run the full test suite**
+
+Run: `go build ./... && go vet ./... && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 7: Manual back-compat smoke (defaults preserve behavior)**
+
+The default path must run each case once and never gate. Verify the flag defaults:
+
+Run: `go run ./cmd/lore eval -h 2>&1 | grep -E '\-n |\-fail-under'`
+Expected: shows `-n` default `1` and `-fail-under` default `0`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/lore/main.go internal/eval/eval.go internal/eval/eval_test.go
+git commit -m "feat(eval): -n/-fail-under flags, campaign summary, JSON report, gate exit code"
+```
+
+---
+
+### Task 5: CI eval config + nightly workflow
+
+**Files:**
+- Create: `eval/ci.runlore.yaml`
+- Create: `.github/workflows/eval.yaml`
+
+**Interfaces:**
+- Consumes: the `lore eval` flags from Task 4; `config.Model` fields `provider`, `base_url`, `model`, `api_key_env`.
+
+- [ ] **Step 1: Create the minimal CI eval config**
+
+`eval/ci.runlore.yaml`:
+
+```yaml
+# Minimal config for the nightly CI eval (replay mode).
+# Only the model block is needed — replay scenarios supply their own evidence.
+# Set the repo secret RUNLORE_EVAL_API_KEY to the API key for this provider.
+model:
+  provider: anthropic
+  model: claude-haiku-4-5-20251001
+  api_key_env: RUNLORE_EVAL_API_KEY
+```
+
+(Provider/model may be adjusted to the project's preferred cheap model; `api_key_env` MUST stay `RUNLORE_EVAL_API_KEY` to match the workflow.)
+
+- [ ] **Step 2: Create the workflow**
+
+`.github/workflows/eval.yaml`:
+
+```yaml
+name: eval
+on:
+  schedule:
+    - cron: "0 6 * * *"        # nightly 06:00 UTC
+  workflow_dispatch: {}         # manual run from the Actions tab
+
+# Least privilege: only needs to read the repo.
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  replay-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - run: go build -o lore ./cmd/lore
+      - name: replay eval (k-of-n + fail-under gate)
+        env:
+          RUNLORE_EVAL_API_KEY: ${{ secrets.RUNLORE_EVAL_API_KEY }}
+        run: ./lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7 -report-dir eval/reports
+      - name: upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report
+          path: eval/reports/
+          if-no-files-found: warn
+```
+
+- [ ] **Step 3: Validate the workflow + config locally**
+
+Run: `go run ./cmd/lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 1 2>&1 | head -5 || true`
+Expected: it loads the config and either runs (if a key is present) or fails on the missing API key — NOT a config-parse or flag error. A "requires a configured model" or auth error is acceptable here; a flag/parse panic is not.
+
+Then sanity-check YAML well-formedness:
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/eval.yaml')); yaml.safe_load(open('eval/ci.runlore.yaml')); print('yaml ok')"`
+Expected: `yaml ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add eval/ci.runlore.yaml .github/workflows/eval.yaml
+git commit -m "ci(eval): nightly + manual replay-eval workflow with fail-under gate"
+```
+
+---
+
+### Task 6: Documentation
+
+Document the nightly eval + the one required secret so a maintainer can enable it.
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (the eval section, ~lines 100-119)
+
+- [ ] **Step 1: Add a "Nightly eval in CI" subsection**
+
+Append to the eval section of `CONTRIBUTING.md`:
+
+```markdown
+### Nightly eval (CI)
+
+`.github/workflows/eval.yaml` runs the replay eval every night (06:00 UTC) and on
+manual dispatch. It repeats each case 5× and fails the run when the campaign
+pass-rate drops below 70% (`-n 5 -fail-under 0.7`), then uploads the JSON report as
+a build artifact.
+
+To enable it, add one repository secret — **`RUNLORE_EVAL_API_KEY`** — holding the
+API key for the provider in `eval/ci.runlore.yaml`. Without the secret the job fails
+fast (by design: a red nightly is the signal). The eval never runs on pull requests,
+so it imposes no per-PR cost and never blocks merges; the deterministic scoring logic
+is already covered by `go test ./...` on every PR.
+
+Run it locally the same way CI does:
+
+    lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "docs(eval): document the nightly CI eval + required secret"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Part A `-n`/`-fail-under` + defaults → Task 4. ✅
+- k-of-n via `evalMinPassRate` + flaky band → Task 2. ✅
+- DRY constants/helpers into `stats.go` → Task 1. ✅
+- JSON report to `-report-dir` → Tasks 3-4. ✅
+- Part B `eval.yaml` schedule+dispatch + artifact → Task 5. ✅
+- Committed `eval/ci.runlore.yaml` + one secret → Tasks 5-6. ✅
+- Tests `TestReplayKOfNRepeats`, `TestFailUnderExitNonZero` (covered by `TestGateError`), back-compat defaults (Task 4 Step 7 + `-n` default 1) → Tasks 2-4. ✅
+- Out of scope (k3d/live, baseline) → not added. ✅
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code. ✅
+
+**Type consistency:** `CaseAggregate`/`Campaign`/`RunN`/`ReachedCases`/`PassRate`/`FlakyNames`/`JSON`/`GateError` used consistently across Tasks 2-4; `evalMinPassRate`/`medianFloat` from Task 1 used in Task 2. The `row(a)` conversion in Task 3 depends on `row` mirroring `CaseAggregate`'s field order/types — both list `Name, Runs, PassRate, Reached, Flaky, Confidence, Missing, OverClaimed`. ✅

--- a/docs/superpowers/specs/2026-06-23-eval-ci-design.md
+++ b/docs/superpowers/specs/2026-06-23-eval-ci-design.md
@@ -60,9 +60,13 @@ each case runs `n` times. A new aggregate type holds, per case:
 - `PassRate float64` — fraction of the `n` repeats whose `Result.Pass` is true.
 - `Reached bool` — `PassRate >= evalMinPassRate` (k-of-n; reuse the **0.7** live
   constant). This is the per-case verdict.
-- `Flaky bool` — `variance(passIndicators) > evalMaxRootCauseVariance` (reuse the
-  live **0.5** bound over the 0/1 pass indicators). A flaky case is surfaced and
-  does **not** count as reached.
+- `Flaky bool` — runs disagree enough that the verdict is unsafe. A pass indicator
+  is binary, so its variance caps at 0.25 and the live `evalMaxRootCauseVariance`
+  (0.5) bound can never fire — replay therefore uses a **decision band**: `Flaky`
+  when `PassRate` falls in the open interval `(1-evalMinPassRate, evalMinPassRate)`
+  = (0.3, 0.7), i.e. neither reliably passing nor reliably failing. `Reached`
+  (≥0.7) already implies not-flaky; flaky only annotates the ambiguous-miss case in
+  the report.
 - `Confidence` (median over repeats), `Missing`, `OverClaimed` (union over repeats,
   for the report).
 
@@ -75,7 +79,9 @@ threshold, or when `fail-under == 0`, it returns nil.
 `evalMaxRootCauseVariance` and the helpers `variance`, `medianFloat` are currently
 unexported in `live.go`. Lift them into a new `internal/eval/stats.go` (same package,
 no API change) so replay and live share one definition. Pure move + the existing
-live tests keep passing.
+live tests keep passing. Replay reuses `evalMinPassRate` (for both the k-of-n bar
+and the flaky band) and `medianFloat`; `variance`/`evalMaxRootCauseVariance` and
+`evalRootCauseBar` remain live-only but live in the shared file.
 
 **Output.** Print a per-case line (`REACHED/MISSED  name  pass-rate=4/5
 flaky=false`) and a campaign summary (`reached N/M cases (X%)  threshold=70%`). Write

--- a/docs/superpowers/specs/2026-06-23-eval-ci-design.md
+++ b/docs/superpowers/specs/2026-06-23-eval-ci-design.md
@@ -1,0 +1,167 @@
+# Eval into CI — design (roadmap #7)
+
+| | |
+|---|---|
+| **Date** | 2026-06-23 |
+| **Roadmap item** | #7 — wire the eval harness into CI with a k-of-n + fail-on-threshold gate |
+| **Depends on** | #4 (deterministic entity precision, merged PR #80), #5 (k-of-n + variance, merged PR #78) |
+| **Effort** | S |
+
+## Problem
+
+The replay eval (`lore eval`, Track A) produces the project's only trustworthy
+RCA-quality signal: it replays recorded tool evidence through the real
+investigation loop and scores the result with **deterministic** entity-precision
+logic (`internal/eval/score.go` — entity recall over `root_cause_entities`, an
+over-claim penalty over `distractors`, a confidence floor). Today nothing runs it
+automatically:
+
+- `runEval` (`cmd/lore/main.go:465`) runs each case **once** and **always exits 0**
+  regardless of pass/fail — it cannot gate anything.
+- `.github/workflows/ci.yaml` runs `go build/vet/test` + lint only. `grep eval
+  .github/` is empty: eval never gates merges and no scheduled run exists, so RCA
+  regressions are invisible until someone runs the harness by hand.
+
+The k-of-n + variance machinery from #5 lives only in the **live** path
+(`internal/eval/live.go`), which needs a real cluster. The replay path — the
+cluster-free one — has no statistical gate.
+
+## Constraint that shapes the design
+
+Replay mode is **cluster-free but not LLM-free**: `staticTool` replays recorded
+tool outputs, but `LoopInvestigator` runs the live model over them
+(`internal/eval/eval.go:48-70`). Only the scoring layer is deterministic; the agent
+run is not. Therefore a CI eval needs an **LLM API key secret**, costs tokens per
+run, is **non-deterministic** per run, and **cannot run on fork PRs** (GitHub does
+not expose secrets to forked-PR workflows).
+
+Decision: **do not** make eval a per-PR blocking gate. Run it on a **schedule
+(nightly) + manual dispatch**, fail-loud on regression, upload the report. The
+existing `go test ./...` already protects the gate/scoring *logic* deterministically
+on every PR via unit tests; the nightly protects the *agent's RCA quality*.
+
+## Design
+
+### Part A — a gate in replay mode (`runEval`, `internal/eval`)
+
+**New flags** on the `lore eval` replay path (`cmd/lore/main.go:466-479`):
+
+| Flag | Type | Default | Meaning |
+|---|---|---|---|
+| `-n` | int | **1** | repeats per case. Default 1 preserves today's one-shot local behavior. |
+| `-fail-under` | float | **0** | minimum overall case pass-rate; below it the command returns a non-zero exit. Default 0 = no gate, so local `lore eval` still exits 0. |
+
+`-report-dir` (already defined, unused in replay) gains a use: replay writes a JSON
+report there for the CI artifact.
+
+**Aggregation.** The replay `Runner` (`internal/eval/eval.go`) gains repeat support:
+each case runs `n` times. A new aggregate type holds, per case:
+
+- `PassRate float64` — fraction of the `n` repeats whose `Result.Pass` is true.
+- `Reached bool` — `PassRate >= evalMinPassRate` (k-of-n; reuse the **0.7** live
+  constant). This is the per-case verdict.
+- `Flaky bool` — `variance(passIndicators) > evalMaxRootCauseVariance` (reuse the
+  live **0.5** bound over the 0/1 pass indicators). A flaky case is surfaced and
+  does **not** count as reached.
+- `Confidence` (median over repeats), `Missing`, `OverClaimed` (union over repeats,
+  for the report).
+
+**Overall gate.** `reachedCases / totalCases` is the campaign pass-rate. `runEval`
+returns a non-zero error when it is `< fail-under` (and `fail-under > 0`), with a
+message naming the cases that did not reach RCA and any flaky cases. At/above the
+threshold, or when `fail-under == 0`, it returns nil.
+
+**DRY.** The constants `evalRootCauseBar`, `evalMinPassRate`,
+`evalMaxRootCauseVariance` and the helpers `variance`, `medianFloat` are currently
+unexported in `live.go`. Lift them into a new `internal/eval/stats.go` (same package,
+no API change) so replay and live share one definition. Pure move + the existing
+live tests keep passing.
+
+**Output.** Print a per-case line (`REACHED/MISSED  name  pass-rate=4/5
+flaky=false`) and a campaign summary (`reached N/M cases (X%)  threshold=70%`). Write
+`<report-dir>/<stamp>-replay.json` containing the per-case aggregates and the
+campaign pass-rate.
+
+### Part B — CI workflow (`.github/workflows/eval.yaml`)
+
+A **new** workflow file (kept separate from `ci.yaml` so the expensive job never
+blocks PRs):
+
+```yaml
+name: eval
+on:
+  schedule:
+    - cron: "0 6 * * *"        # nightly 06:00 UTC
+  workflow_dispatch:            # manual run
+permissions:
+  contents: read
+concurrency:
+  group: eval-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  replay-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.26" }
+      - run: go build -o lore ./cmd/lore
+      - name: replay eval
+        env:
+          RUNLORE_EVAL_API_KEY: ${{ secrets.RUNLORE_EVAL_API_KEY }}
+        run: ./lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7 -report-dir eval/reports
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: eval-report
+          path: eval/reports/
+```
+
+**Committed CI eval config** `eval/ci.runlore.yaml` — a minimal config carrying only
+a `model:` block, whose `api_key_env: RUNLORE_EVAL_API_KEY` matches the secret the
+workflow injects. It defaults to the provider the repo already uses. The user adds
+exactly one repo secret (`RUNLORE_EVAL_API_KEY`) to enable the nightly. The config is
+documented inline.
+
+If the secret is unset, the configured model fails fast and the job goes red — the
+intended fail-loud behavior for the maintainer's own repo. (Forks never run this job:
+`schedule`/`workflow_dispatch` only fire on the upstream repo.)
+
+## Testing
+
+Unit tests (run on every PR via `go test ./...`, fully deterministic — they stub the
+model):
+
+- `TestReplayKOfNRepeats` — a stub model passing 4 of 5 repeats → case `Reached`
+  (≥0.7); passing 2 of 5 → not reached.
+- `TestReplayFlakyCaseNotReached` — alternating pass/fail repeats push variance over
+  0.5 → `Flaky`, not counted as reached.
+- `TestFailUnderExitNonZero` — campaign pass-rate below `-fail-under` makes `runEval`
+  return an error; at/above returns nil.
+- `TestReplayDefaultsPreserveBehavior` — `-n` and `-fail-under` unset → one run per
+  case and nil error regardless of scores (back-compat).
+- existing `live_test.go` continues to pass after the constants/helpers move
+  (`stats.go`).
+
+Workflow file validated structurally (valid YAML, pinned action majors, least-priv
+permissions).
+
+## Out of scope
+
+- Live-fire k3d in CI (needs a cluster; effort L; a separate item).
+- Baseline regression auto-commit / trend tracking.
+- Per-PR blocking eval (rejected above: secret + cost + fork limitation).
+
+## Files touched
+
+- `internal/eval/stats.go` — **new**: lifted constants + `variance`/`medianFloat`.
+- `internal/eval/live.go` — drop the moved constants/helpers.
+- `internal/eval/eval.go` — repeat support + per-case aggregate type + campaign
+  pass-rate.
+- `internal/eval/score.go` — unchanged (scoring already deterministic).
+- `cmd/lore/main.go` — `-n` / `-fail-under` flags, aggregate wiring, JSON report,
+  non-zero exit.
+- `internal/eval/eval_test.go` — new tests above.
+- `.github/workflows/eval.yaml` — **new** workflow.
+- `eval/ci.runlore.yaml` — **new** minimal CI eval config.

--- a/eval/ci.runlore.yaml
+++ b/eval/ci.runlore.yaml
@@ -1,0 +1,7 @@
+# Minimal config for the nightly CI eval (replay mode).
+# Only the model block is needed — replay scenarios supply their own evidence.
+# Set the repo secret RUNLORE_EVAL_API_KEY to the API key for this provider.
+model:
+  provider: anthropic
+  model: claude-haiku-4-5-20251001
+  api_key_env: RUNLORE_EVAL_API_KEY

--- a/eval/reports/2026-06-23T17-49-33Z-replay.json
+++ b/eval/reports/2026-06-23T17-49-33Z-replay.json
@@ -1,0 +1,19 @@
+{
+  "n": 1,
+  "pass_rate": 0,
+  "reached": 0,
+  "total": 1,
+  "cases": [
+    {
+      "name": "harbor-chart-bump",
+      "runs": 1,
+      "pass_rate": 0,
+      "reached": false,
+      "flaky": false,
+      "confidence": 0,
+      "missing": [
+        "investigation error: model: messages status 401: {\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"x-api-key header is required\"},\"request_id\":\"req_011CcLcZ9wWv6bKHnLQVdonF\"}"
+      ]
+    }
+  ]
+}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -210,7 +211,7 @@ func GateError(c Campaign, failUnder float64) error {
 	if fl := c.FlakyNames(); len(fl) > 0 {
 		msg += "; flaky: " + strings.Join(fl, ", ")
 	}
-	return fmt.Errorf("%s", msg)
+	return errors.New(msg)
 }
 
 // JSON renders the campaign as an indented report for CI artifacts.

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"sort"
 
@@ -184,4 +185,35 @@ func sortedSet(m map[string]struct{}) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// JSON renders the campaign as an indented report for CI artifacts.
+func (c Campaign) JSON() ([]byte, error) {
+	type row struct {
+		Name        string   `json:"name"`
+		Runs        int      `json:"runs"`
+		PassRate    float64  `json:"pass_rate"`
+		Reached     bool     `json:"reached"`
+		Flaky       bool     `json:"flaky"`
+		Confidence  float64  `json:"confidence"`
+		Missing     []string `json:"missing,omitempty"`
+		OverClaimed []string `json:"over_claimed,omitempty"`
+	}
+	rows := make([]row, len(c.Aggregates))
+	for i, a := range c.Aggregates {
+		rows[i] = row(a)
+	}
+	return json.MarshalIndent(struct {
+		N        int     `json:"n"`
+		PassRate float64 `json:"pass_rate"`
+		Reached  int     `json:"reached"`
+		Total    int     `json:"total"`
+		Cases    []row   `json:"cases"`
+	}{
+		N:        c.N,
+		PassRate: c.PassRate(),
+		Reached:  c.ReachedCases(),
+		Total:    len(c.Aggregates),
+		Cases:    rows,
+	}, "", "  ")
 }

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3,6 +3,7 @@ package eval
 import (
 	"context"
 	"log/slog"
+	"sort"
 
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/providers"
@@ -81,3 +82,106 @@ func (t staticTool) Name() string                                 { return t.nam
 func (t staticTool) Description() string                          { return "Returns recorded evidence for: " + t.name }
 func (t staticTool) Schema() string                               { return `{"type":"object","properties":{}}` }
 func (t staticTool) Call(context.Context, string) (string, error) { return t.output, nil }
+
+// CaseAggregate is the k-of-n verdict for one case over N replay repeats.
+type CaseAggregate struct {
+	Name        string
+	Runs        int
+	PassRate    float64  // fraction of repeats whose Result.Pass is true
+	Reached     bool     // PassRate >= evalMinPassRate
+	Flaky       bool     // PassRate in (1-evalMinPassRate, evalMinPassRate): runs disagree
+	Confidence  float64  // median confidence over repeats
+	Missing     []string // union of missing keywords/entities across repeats
+	OverClaimed []string // union of over-claimed distractors across repeats
+}
+
+// Campaign is the aggregate of a multi-repeat replay run.
+type Campaign struct {
+	N          int
+	Aggregates []CaseAggregate
+}
+
+// ReachedCases counts cases whose pass-rate met the k-of-n bar.
+func (c Campaign) ReachedCases() int {
+	n := 0
+	for _, a := range c.Aggregates {
+		if a.Reached {
+			n++
+		}
+	}
+	return n
+}
+
+// PassRate is the fraction of cases that reached RCA (0 for empty).
+func (c Campaign) PassRate() float64 {
+	if len(c.Aggregates) == 0 {
+		return 0
+	}
+	return float64(c.ReachedCases()) / float64(len(c.Aggregates))
+}
+
+// FlakyNames lists cases whose repeats disagreed too much to trust.
+func (c Campaign) FlakyNames() []string {
+	var names []string
+	for _, a := range c.Aggregates {
+		if a.Flaky {
+			names = append(names, a.Name)
+		}
+	}
+	return names
+}
+
+// RunN replays every case n times and returns the aggregated campaign.
+func (r *Runner) RunN(ctx context.Context, cases []Case, n int) Campaign {
+	if n < 1 {
+		n = 1
+	}
+	camp := Campaign{N: n}
+	for _, c := range cases {
+		camp.Aggregates = append(camp.Aggregates, r.aggregateCase(ctx, c, n))
+	}
+	return camp
+}
+
+func (r *Runner) aggregateCase(ctx context.Context, c Case, n int) CaseAggregate {
+	confs := make([]float64, n)
+	missSet := map[string]struct{}{}
+	ocSet := map[string]struct{}{}
+	passes := 0
+	for i := 0; i < n; i++ {
+		res := r.runOne(ctx, c)
+		if res.Pass {
+			passes++
+		}
+		confs[i] = res.Confidence
+		for _, m := range res.Missing {
+			missSet[m] = struct{}{}
+		}
+		for _, o := range res.OverClaimed {
+			ocSet[o] = struct{}{}
+		}
+	}
+	rate := float64(passes) / float64(n)
+	return CaseAggregate{
+		Name:        c.Name,
+		Runs:        n,
+		PassRate:    rate,
+		Reached:     rate >= evalMinPassRate,
+		Flaky:       rate > 1-evalMinPassRate && rate < evalMinPassRate,
+		Confidence:  medianFloat(confs),
+		Missing:     sortedSet(missSet),
+		OverClaimed: sortedSet(ocSet),
+	}
+}
+
+func sortedSet(m map[string]struct{}) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3,8 +3,10 @@ package eval
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"sort"
+	"strings"
 
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/providers"
@@ -185,6 +187,30 @@ func sortedSet(m map[string]struct{}) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// GateError returns a non-nil error when the campaign pass-rate is below failUnder
+// (which is only enforced when failUnder > 0). The message names the cases that did
+// not reach RCA and any flaky cases, so CI logs explain the failure.
+func GateError(c Campaign, failUnder float64) error {
+	if failUnder <= 0 || c.PassRate() >= failUnder {
+		return nil
+	}
+	var missed []string
+	for _, a := range c.Aggregates {
+		if !a.Reached {
+			missed = append(missed, a.Name)
+		}
+	}
+	msg := fmt.Sprintf("eval gate failed: pass-rate %.0f%% < threshold %.0f%% (reached %d/%d)",
+		c.PassRate()*100, failUnder*100, c.ReachedCases(), len(c.Aggregates))
+	if len(missed) > 0 {
+		msg += "; missed: " + strings.Join(missed, ", ")
+	}
+	if fl := c.FlakyNames(); len(fl) > 0 {
+		msg += "; flaky: " + strings.Join(fl, ", ")
+	}
+	return fmt.Errorf("%s", msg)
 }
 
 // JSON renders the campaign as an indented report for CI artifacts.

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -216,6 +216,7 @@ func GateError(c Campaign, failUnder float64) error {
 
 // JSON renders the campaign as an indented report for CI artifacts.
 func (c Campaign) JSON() ([]byte, error) {
+	// row mirrors CaseAggregate's field names, types, and order so row(a) is a legal conversion — keep in sync.
 	type row struct {
 		Name        string   `json:"name"`
 		Runs        int      `json:"runs"`

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -212,3 +212,66 @@ func TestRun(t *testing.T) {
 		t.Fatalf("unexpected per-case: %+v", rep.Results)
 	}
 }
+
+// rateModel passes (names harbor-db) on its first passN Complete-pairs, then fails.
+// Each replay run makes 2 Complete calls (tool, then submit_findings).
+type rateModel struct {
+	calls, passN int
+}
+
+func (m *rateModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	if m.calls%2 == 1 { // first call of a run: invoke the tool
+		return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+			{ID: "1", Name: "what_changed", Args: `{}`}}}, nil
+	}
+	run := m.calls / 2 // 1-based index of the run just completing
+	summary := "chart bump broke harbor-db migrations"
+	if run > m.passN {
+		summary = "unclear, possibly a transient blip"
+	}
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "2", Name: "submit_findings",
+			Args: `{"confidence":0.9,"root_causes":[{"summary":"` + summary + `"}]}`}}}, nil
+}
+
+func newRateRunner(passN int) *Runner {
+	return &Runner{Model: &rateModel{passN: passN}, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+func harborCase() Case {
+	return Case{Name: "harbor", Prompt: "probe failing", Tools: map[string]string{"what_changed": "chart 1.15"},
+		Expected: Expected{MustContain: []string{"chart", "harbor-db"}, MinConfidence: 0.5}}
+}
+
+func TestReplayKOfNRepeats(t *testing.T) {
+	// 4 of 5 pass → pass-rate 0.8 ≥ 0.7 → reached, not flaky.
+	camp := newRateRunner(4).RunN(context.Background(), []Case{harborCase()}, 5)
+	a := camp.Aggregates[0]
+	if a.Runs != 5 || a.PassRate < 0.79 || a.PassRate > 0.81 {
+		t.Fatalf("want 5 runs at 0.8, got runs=%d rate=%.2f", a.Runs, a.PassRate)
+	}
+	if !a.Reached || a.Flaky {
+		t.Fatalf("4/5 should be reached and not flaky, got %+v", a)
+	}
+
+	// 2 of 5 pass → 0.4 < 0.7 → not reached; 0.4 is in (0.3,0.7) → flaky.
+	camp = newRateRunner(2).RunN(context.Background(), []Case{harborCase()}, 5)
+	a = camp.Aggregates[0]
+	if a.Reached {
+		t.Fatalf("2/5 must not be reached, got %+v", a)
+	}
+	if !a.Flaky {
+		t.Fatalf("2/5 (rate 0.4) should be flaky, got %+v", a)
+	}
+}
+
+func TestReplayCampaignPassRate(t *testing.T) {
+	// One reachable case (5/5) and one unreachable (0/5) → campaign pass-rate 0.5.
+	cases := []Case{harborCase(), {Name: "miss", Prompt: "x", Tools: map[string]string{"what_changed": "y"},
+		Expected: Expected{MustContain: []string{"network policy"}}}}
+	camp := newRateRunner(5).RunN(context.Background(), cases, 5)
+	if camp.ReachedCases() != 1 || camp.PassRate() != 0.5 {
+		t.Fatalf("want reached=1 rate=0.5, got reached=%d rate=%.2f", camp.ReachedCases(), camp.PassRate())
+	}
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -277,6 +277,22 @@ func TestReplayCampaignPassRate(t *testing.T) {
 	}
 }
 
+func TestGateError(t *testing.T) {
+	miss := Case{Name: "miss", Prompt: "x", Tools: map[string]string{"what_changed": "y"},
+		Expected: Expected{MustContain: []string{"network policy"}}}
+	camp := newRateRunner(5).RunN(context.Background(), []Case{harborCase(), miss}, 5) // pass-rate 0.5
+
+	if err := GateError(camp, 0); err != nil {
+		t.Fatalf("fail-under 0 must never gate, got %v", err)
+	}
+	if err := GateError(camp, 0.4); err != nil {
+		t.Fatalf("0.5 >= 0.4 should pass, got %v", err)
+	}
+	if err := GateError(camp, 0.7); err == nil {
+		t.Fatal("0.5 < 0.7 should return a gate error")
+	}
+}
+
 func TestCampaignJSON(t *testing.T) {
 	camp := newRateRunner(5).RunN(context.Background(), []Case{harborCase()}, 2)
 	b, err := camp.JSON()

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -293,6 +293,18 @@ func TestGateError(t *testing.T) {
 	}
 }
 
+func TestReplayDefaultsPreserveBehavior(t *testing.T) {
+	// n=1 (the replay default) runs each case once; GateError with the default
+	// fail-under (0) never gates, so local `lore eval` keeps exiting 0.
+	camp := newRateRunner(5).RunN(context.Background(), []Case{harborCase()}, 1)
+	if len(camp.Aggregates) != 1 || camp.Aggregates[0].Runs != 1 {
+		t.Fatalf("n=1 should run each case once, got %+v", camp.Aggregates)
+	}
+	if err := GateError(camp, 0); err != nil {
+		t.Fatalf("default fail-under (0) must never gate, got %v", err)
+	}
+}
+
 func TestCampaignJSON(t *testing.T) {
 	camp := newRateRunner(5).RunN(context.Background(), []Case{harborCase()}, 2)
 	b, err := camp.JSON()

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"os"
@@ -273,5 +274,32 @@ func TestReplayCampaignPassRate(t *testing.T) {
 	camp := newRateRunner(5).RunN(context.Background(), cases, 5)
 	if camp.ReachedCases() != 1 || camp.PassRate() != 0.5 {
 		t.Fatalf("want reached=1 rate=0.5, got reached=%d rate=%.2f", camp.ReachedCases(), camp.PassRate())
+	}
+}
+
+func TestCampaignJSON(t *testing.T) {
+	camp := newRateRunner(5).RunN(context.Background(), []Case{harborCase()}, 2)
+	b, err := camp.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	var got struct {
+		N        int     `json:"n"`
+		PassRate float64 `json:"pass_rate"`
+		Reached  int     `json:"reached"`
+		Total    int     `json:"total"`
+		Cases    []struct {
+			Name    string `json:"name"`
+			Reached bool   `json:"reached"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.N != 2 || got.Total != 1 || got.Reached != 1 || got.PassRate != 1.0 {
+		t.Fatalf("unexpected report header: %+v", got)
+	}
+	if len(got.Cases) != 1 || got.Cases[0].Name != "harbor" || !got.Cases[0].Reached {
+		t.Fatalf("unexpected case rows: %+v", got.Cases)
 	}
 }

--- a/internal/eval/live.go
+++ b/internal/eval/live.go
@@ -174,4 +174,3 @@ func (lr *LiveRunner) aggregate(res *LiveResult) {
 		!res.ConfidentWrong &&
 		!res.Flaky
 }
-

--- a/internal/eval/live.go
+++ b/internal/eval/live.go
@@ -9,12 +9,6 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-const (
-	evalRootCauseBar         = 2   // a run "reaches the root cause" at score >= 2
-	evalMinPassRate          = 0.7 // fraction of runs that must reach it (e.g. at N=3 this requires all 3)
-	evalMaxRootCauseVariance = 0.5 // above this, the scenario is flaky → not a pass
-)
-
 // StepRunner executes a scenario's shell setup/teardown/precheck steps. The real
 // implementation shells out (kubectl/flux); tests use a fake.
 type StepRunner interface {
@@ -181,31 +175,3 @@ func (lr *LiveRunner) aggregate(res *LiveResult) {
 		!res.Flaky
 }
 
-func medianFloat(xs []float64) float64 {
-	if len(xs) == 0 {
-		return 0
-	}
-	cp := append([]float64(nil), xs...)
-	sort.Float64s(cp)
-	m := len(cp) / 2
-	if len(cp)%2 == 1 {
-		return cp[m]
-	}
-	return (cp[m-1] + cp[m]) / 2
-}
-
-func variance(xs []float64) float64 {
-	if len(xs) == 0 {
-		return 0
-	}
-	var sum float64
-	for _, x := range xs {
-		sum += x
-	}
-	mean := sum / float64(len(xs))
-	var v float64
-	for _, x := range xs {
-		v += (x - mean) * (x - mean)
-	}
-	return v / float64(len(xs))
-}

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -10,7 +10,7 @@ import (
 // LiveReport is the serializable output of one live-fire campaign run.
 type LiveReport struct {
 	At      string       `json:"at"`
-	N       int          `json:"n"` // runs per scenario (live mode); 0 in replay mode
+	N       int          `json:"n"`   // runs per scenario (live mode); 0 in replay mode
 	Ran     int          `json:"ran"` // scenarios actually investigated (not skipped)
 	Passed  int          `json:"passed"`
 	Skipped int          `json:"skipped"`

--- a/internal/eval/stats.go
+++ b/internal/eval/stats.go
@@ -1,0 +1,42 @@
+package eval
+
+import "sort"
+
+// Shared eval gating constants and statistics helpers, used by both the replay
+// runner (eval.go) and the live runner (live.go).
+const (
+	evalRootCauseBar         = 2   // a run "reaches the root cause" at score >= 2 (live judge)
+	evalMinPassRate          = 0.7 // fraction of runs that must pass (k-of-n); also the replay flaky band edge
+	evalMaxRootCauseVariance = 0.5 // above this a live scenario is flaky → not a pass
+)
+
+// medianFloat returns the median of xs (0 for empty).
+func medianFloat(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	cp := append([]float64(nil), xs...)
+	sort.Float64s(cp)
+	m := len(cp) / 2
+	if len(cp)%2 == 1 {
+		return cp[m]
+	}
+	return (cp[m-1] + cp[m]) / 2
+}
+
+// variance returns the population variance of xs (0 for empty).
+func variance(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	mean := sum / float64(len(xs))
+	var v float64
+	for _, x := range xs {
+		v += (x - mean) * (x - mean)
+	}
+	return v / float64(len(xs))
+}


### PR DESCRIPTION
## Roadmap item #7 — eval into CI

Wires the deterministic-scored **replay eval** into CI as a **nightly + manual** workflow with a k-of-n + fail-under gate, returning a non-zero exit on RCA regression and uploading the report — **without** imposing LLM cost/secrets on every PR.

### Why nightly, not a per-PR gate
Replay eval is cluster-free but **not LLM-free**: `staticTool` replays recorded tool evidence, but the loop runs the real model over it. So a per-PR eval would need an API-key secret, cost tokens per PR, be non-deterministic, and **can't run on fork PRs** (GitHub withholds secrets from forks). The deterministic *scoring* logic is already unit-tested on every PR via `go test`; the nightly protects the agent's *RCA quality*.

### What landed
- **`-n` / `-fail-under` flags** on `lore eval` (replay). Defaults preserve local behavior: `-n 1`, `-fail-under 0` (no gate, exit 0). Live-fire keeps its N=10 default via a `fs.Visit` mode-aware default (honors PR #78's statistical-soundness contract).
- **N-repeat campaign aggregation** with a k-of-n verdict (reuses `evalMinPassRate=0.7`) + a flaky decision-band `(0.3, 0.7)`.
- **JSON campaign report** written to `-report-dir` for the CI artifact.
- **`GateError`** → non-zero exit when campaign pass-rate `< fail-under`, naming missed/flaky cases.
- **`stats.go`** DRY-move of shared gate constants + `medianFloat`/`variance` (used by both replay and live).
- **`.github/workflows/eval.yaml`** — `schedule` (06:00 UTC) + `workflow_dispatch`, least-priv (`contents: read`), pinned action majors, concurrency + timeout, artifact upload `if: always()`.
- **`eval/ci.runlore.yaml`** — minimal config; `api_key_env: RUNLORE_EVAL_API_KEY` (add that one repo secret to enable the nightly).
- **CONTRIBUTING.md** — nightly-eval docs + the required secret.

### Testing
`go build ./... && go vet ./... && go test ./...` green (incl. `-race` on `internal/eval`). New tests: k-of-n repeats, campaign pass-rate, flaky band, JSON round-trip, `GateError` boundaries, back-compat defaults.

### Process
brainstorm → spec (`docs/superpowers/specs/2026-06-23-eval-ci-design.md`) → plan (`docs/superpowers/plans/2026-06-23-eval-ci.md`) → 6 subagent-implemented tasks, each task-reviewed; one Important fix (live-N regression) caught + fixed in review; whole-branch review (opus): **✅ merge, no blocking issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)