### PR TITLE
feat(investigate): confront recalled findings with current cluster state before verify (#13)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-recall-confirmatory.md
+++ b/docs/superpowers/plans/2026-06-23-recall-confirmatory.md
@@ -1,0 +1,395 @@
+# Confirmatory evidence on the recall short-circuit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On an instant-recall hit, confront the recalled finding with current cluster state (the existing `pod_status`/`kube_events` tools, scoped to the workload) and feed that real evidence to the verify pass; when state can't be gathered, cap the recalled confidence lower.
+
+**Architecture:** A new `confirmRecall` method reuses the loop's own tools to append current-state evidence to the recalled finding before verify runs; `capRecallConfidence` lowers confidence when confirmation was unavailable. Both wired into the recall block in `loop.go`.
+
+**Tech Stack:** Go 1.26, standard library (`encoding/json`, `fmt`, `strings`), existing `internal/investigate` tool interface.
+
+## Global Constraints
+
+- Go 1.26, standard library only, no new dependencies, no new wiring in `cmd/lore/main.go` (reuse `li.Tools`).
+- Best-effort/fail-safe: a missing namespace, absent tools, or a tool error must degrade to `gathered=false` (then the lower cap) — never crash, never drop the finding.
+- `capRecallConfidence` only ever LOWERS confidence; apply it BEFORE verify so verify's max-of-survivors recomputation stays consistent, and BEFORE `initialConfidence` is captured (so the cap is not mis-counted as a verify "downgrade" in metrics).
+- Do not change `recalledInvestigation`'s existing recall-label evidence line; the confirmatory evidence is appended alongside it.
+- After each task: `go build ./... && go vet ./... && go test ./...` green and `gofmt -l .` empty.
+
+---
+
+### Task 1: `confirmRecall` + `capRecallConfidence` helpers
+
+**Files:**
+- Create: `internal/investigate/confirm.go`
+- Test: `internal/investigate/confirm_test.go`
+
+**Interfaces:**
+- Consumes: `LoopInvestigator.Tools []Tool` (each `Tool` has `Name()`/`Call(ctx,args)`), `Request.Workload providers.Workload` (`Namespace`,`Name`), `providers.Investigation`/`Hypothesis`.
+- Produces:
+  - `const recallUnconfirmedCap = 0.70`
+  - `var recallConfirmTools = []string{"pod_status", "kube_events"}`
+  - `func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, bool)`
+  - `func capRecallConfidence(inv providers.Investigation, ceiling float64) providers.Investigation`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/investigate/confirm_test.go` (package `investigate`, matching the other test files):
+
+```go
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeConfirmTool is a confirmatory Tool that records the args it was called with.
+type fakeConfirmTool struct {
+	name    string
+	out     string
+	err     error
+	gotArgs string
+}
+
+func (f *fakeConfirmTool) Name() string        { return f.name }
+func (f *fakeConfirmTool) Description() string  { return "" }
+func (f *fakeConfirmTool) Schema() string       { return "{}" }
+func (f *fakeConfirmTool) Call(_ context.Context, args string) (string, error) {
+	f.gotArgs = args
+	return f.out, f.err
+}
+
+func recalledInv() providers.Investigation {
+	return providers.Investigation{
+		Title:      "web down",
+		Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{Summary: "image tag rollout", Confidence: 0.9,
+			Evidence: []string{"instant recall: matched knowledge-base entry \"x\""}}},
+		Resource: providers.Workload{Namespace: "apps", Name: "web"},
+	}
+}
+
+func TestConfirmRecallAppendsCurrentState(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff"}
+	li := &LoopInvestigator{Tools: []Tool{ps}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("expected gathered=true when a confirm tool returns output")
+	}
+	joined := strings.Join(inv.RootCauses[0].Evidence, "\n")
+	if !strings.Contains(joined, "CrashLoopBackOff") || !strings.Contains(joined, "pod_status") {
+		t.Fatalf("current-state evidence not appended: %q", joined)
+	}
+}
+
+func TestConfirmRecallScopesToWorkload(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "ok"}
+	ev := &fakeConfirmTool{name: "kube_events", out: "Warning"}
+	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
+		t.Fatal("expected gathered=true")
+	}
+	if !strings.Contains(ps.gotArgs, `"namespace":"apps"`) {
+		t.Fatalf("pod_status not scoped to namespace: %q", ps.gotArgs)
+	}
+	if !strings.Contains(ev.gotArgs, `"namespace":"apps"`) || !strings.Contains(ev.gotArgs, `"object":"web"`) {
+		t.Fatalf("kube_events not scoped to namespace+object: %q", ev.gotArgs)
+	}
+}
+
+func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "x"}
+	li := &LoopInvestigator{Tools: []Tool{ps}}
+	req := Request{Workload: providers.Workload{}} // no namespace
+	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if gathered {
+		t.Fatal("no namespace must skip confirmation")
+	}
+	if ps.gotArgs != "" {
+		t.Fatalf("tool must not be called without a namespace, got args %q", ps.gotArgs)
+	}
+	if len(inv.RootCauses[0].Evidence) != 1 {
+		t.Fatalf("evidence must be unchanged, got %v", inv.RootCauses[0].Evidence)
+	}
+}
+
+func TestConfirmRecallToolsAbsentSkips(t *testing.T) {
+	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "what_changed", out: "x"}}}
+	req := Request{Workload: providers.Workload{Namespace: "apps"}}
+	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
+		t.Fatal("no confirm tools present must yield gathered=false")
+	}
+}
+
+func TestConfirmRecallToolErrorTolerated(t *testing.T) {
+	bad := &fakeConfirmTool{name: "pod_status", err: context.DeadlineExceeded}
+	good := &fakeConfirmTool{name: "kube_events", out: "Warning FailedMount"}
+	li := &LoopInvestigator{Tools: []Tool{bad, good}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("one tool erroring must not prevent the other from confirming")
+	}
+	if !strings.Contains(strings.Join(inv.RootCauses[0].Evidence, "\n"), "FailedMount") {
+		t.Fatal("the surviving tool's output should be appended")
+	}
+}
+
+func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
+	inv := providers.Investigation{Confidence: 0.9, RootCauses: []providers.Hypothesis{{Confidence: 0.9}, {Confidence: 0.5}}}
+	out := capRecallConfidence(inv, 0.70)
+	if out.Confidence != 0.70 || out.RootCauses[0].Confidence != 0.70 {
+		t.Fatalf("values above the ceiling must be lowered: %+v", out)
+	}
+	if out.RootCauses[1].Confidence != 0.5 {
+		t.Fatalf("a value already below the ceiling must be untouched, got %v", out.RootCauses[1].Confidence)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `go test ./internal/investigate/ -run 'TestConfirmRecall|TestCapRecallConfidence' -v`
+Expected: FAIL — `confirmRecall` / `capRecallConfidence` undefined.
+
+- [ ] **Step 3: Implement `internal/investigate/confirm.go`**
+
+```go
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// recallUnconfirmedCap is the recall-confidence ceiling applied when current cluster
+// state could not be gathered to confront the recalled entry.
+const recallUnconfirmedCap = 0.70
+
+// recallConfirmTools are the read-only, namespace-scoped checks used to confront a
+// recalled finding with current cluster state, in priority order. They are the same
+// tools the agent uses, resolved from the loop's tool set.
+var recallConfirmTools = []string{"pod_status", "kube_events"}
+
+// confirmRecall gathers current cluster state for the recalled workload and appends
+// it to the top hypothesis's evidence, so the verify pass can judge the recalled
+// cause against reality rather than a tautology. Best-effort: a missing namespace,
+// absent tools, or a tool error yields gathered=false. gathered is true when at
+// least one confirm tool returned non-empty output (including "no pods"/"no events"
+// — still real current state).
+func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, bool) {
+	if req.Workload.Namespace == "" || len(inv.RootCauses) == 0 {
+		return inv, false
+	}
+	byName := make(map[string]Tool, len(li.Tools))
+	for _, t := range li.Tools {
+		byName[t.Name()] = t
+	}
+	gathered := false
+	for _, name := range recallConfirmTools {
+		t, ok := byName[name]
+		if !ok {
+			continue
+		}
+		out, err := t.Call(ctx, confirmArgs(name, req.Workload))
+		if err != nil {
+			if li.Log != nil {
+				li.Log.Debug("recall confirm tool failed", "tool", name, "err", err)
+			}
+			continue
+		}
+		if out = strings.TrimSpace(out); out == "" {
+			continue
+		}
+		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
+			fmt.Sprintf("current state — %s:\n%s", name, out))
+		gathered = true
+	}
+	return inv, gathered
+}
+
+// confirmArgs builds the JSON args scoping a confirmatory tool to the workload.
+func confirmArgs(name string, w providers.Workload) string {
+	m := map[string]string{"namespace": w.Namespace}
+	if name == "kube_events" && w.Name != "" {
+		m["object"] = w.Name
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+// capRecallConfidence lowers the investigation's overall and per-hypothesis
+// confidence to at most ceiling (it never raises any value).
+func capRecallConfidence(inv providers.Investigation, ceiling float64) providers.Investigation {
+	if inv.Confidence > ceiling {
+		inv.Confidence = ceiling
+	}
+	for i := range inv.RootCauses {
+		if inv.RootCauses[i].Confidence > ceiling {
+			inv.RootCauses[i].Confidence = ceiling
+		}
+	}
+	return inv
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `go test ./internal/investigate/ -run 'TestConfirmRecall|TestCapRecallConfidence' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full package + gofmt**
+
+Run: `go test ./internal/investigate/ && gofmt -l internal/investigate/`
+Expected: PASS; gofmt prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/investigate/confirm.go internal/investigate/confirm_test.go
+git commit -m "feat(investigate): confirmRecall gathers current state; capRecallConfidence"
+```
+
+---
+
+### Task 2: Wire the confirmatory step into the recall block
+
+**Files:**
+- Modify: `internal/investigate/loop.go`
+- Test: `internal/investigate/loop_test.go`
+
+**Interfaces:**
+- Consumes: `confirmRecall`, `capRecallConfidence`, `recallUnconfirmedCap` (Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Read `internal/investigate/loop_test.go` first to mirror its existing recall-test construction (how it builds `LoopInvestigator` with a `Recall`, the `scriptModel`/fake catalog, and how it captures the delivered investigation via `OnComplete`). Then add, using those same patterns:
+
+```go
+func TestInstantRecallUnconfirmedLowersConfidence(t *testing.T) {
+	// A recall hit with NO confirm tools available → confidence is capped at
+	// recallUnconfirmedCap before delivery.
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		// Recall configured to return a high-confidence hit; mirror the existing
+		// recall-hit test's setup (fake catalog/recall thresholds).
+		// Tools intentionally omit pod_status/kube_events.
+		Tools:      nil,
+		Verify:     false,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+		Log:        testLoggerLoop(),
+		Recall:     <recall returning a hit, per the existing TestInstantRecallHit setup>,
+	}
+	req := Request{Title: "web down", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got.Confidence > recallUnconfirmedCap {
+		t.Fatalf("unconfirmed recall must be capped at %.2f, got %.2f", recallUnconfirmedCap, got.Confidence)
+	}
+}
+
+func TestInstantRecallConfirmedEvidenceReachesVerify(t *testing.T) {
+	// A recall hit + a confirm tool whose output contradicts the entry + a verify
+	// model that rejects the (now evidence-bearing) root cause → the delivered
+	// finding is rejected (root causes emptied), proving the confirmatory evidence
+	// reached verify rather than the tautological string.
+	var got providers.Investigation
+	ps := &fakeConfirmTool{name: "pod_status", out: "web Running ready=1/1 (healthy — contradicts the recalled crash)"}
+	li := &LoopInvestigator{
+		Tools:  []Tool{ps},
+		Verify: true,
+		// Model used only by verify here (recall short-circuits the loop): script it
+		// to submit a single "reject" verdict for index 0. Mirror verify_test.go's
+		// scriptModel verdict-response shape.
+		Model:      <scriptModel returning one submit_verdicts call: reject index 0>,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+		Log:        testLoggerLoop(),
+		Recall:     <recall returning a hit, per TestInstantRecallHit setup>,
+	}
+	req := Request{Title: "web down", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(got.RootCauses) != 0 {
+		t.Fatalf("verify should have rejected the recalled cause using current-state evidence, got %+v", got.RootCauses)
+	}
+}
+```
+
+IMPORTANT: the `<...>` placeholders above MUST be filled from the actual existing
+`loop_test.go` patterns — reuse its recall-hit fixture (the fake `Recall`/catalog
+that makes `lookup` return an entry) and `verify_test.go`'s `scriptModel` verdict
+shape. `fakeConfirmTool` is defined in `confirm_test.go` (same package) and is reusable
+here. If `loop_test.go` already has a logger helper, use it; otherwise use
+`slog.New(slog.NewTextHandler(io.Discard, nil))`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `go test ./internal/investigate/ -run 'TestInstantRecallUnconfirmed|TestInstantRecallConfirmed' -v`
+Expected: FAIL — confidence not yet capped / evidence not yet reaching verify.
+
+- [ ] **Step 3: Wire the recall block in `loop.go`**
+
+In the recall short-circuit (after `rec := recalledInvestigation(req, *entry, conf)`), insert the confirmatory step and cap, so the block reads:
+
+```go
+			rec := recalledInvestigation(req, *entry, conf)
+			rec, confirmed := li.confirmRecall(ctx, req, rec)
+			if !confirmed {
+				// Could not confront the entry with current state — be less assertive
+				// so an unverifiable recall does not present at full recall confidence.
+				rec = capRecallConfidence(rec, recallUnconfirmedCap)
+			}
+			initialConfidence := rec.Confidence
+			if li.Verify {
+				// Catalog content is untrusted: verify a recalled finding too, so a
+				// crafted high-recall entry can't bypass the adversarial review.
+				rec = li.verifyFindings(ctx, req, rec)
+			}
+```
+
+The rest of the block (metrics, `li.deliver(req, rec)`, `return nil`) is unchanged.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `go test ./internal/investigate/ -run 'TestInstantRecallUnconfirmed|TestInstantRecallConfirmed' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + vet + gofmt**
+
+Run: `go build ./... && go vet ./... && go test ./... && gofmt -l .`
+Expected: all PASS; gofmt prints nothing. In particular the existing `TestInstantRecallHit` must still pass (it has no namespace-scoped confirm tools, so it now takes the unconfirmed-cap path — confirm its assertions still hold; if it asserted an exact confidence above 0.70, update it to reflect the cap and note why).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/investigate/loop.go internal/investigate/loop_test.go
+git commit -m "feat(investigate): confront recalled findings with current state before verify"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Confirmatory step reusing pod_status/kube_events scoped to the workload → Task 1 (`confirmRecall`). ✅
+- Append real evidence to the recalled finding before verify → Tasks 1, 2. ✅
+- Lower confidence cap when unconfirmed → Task 1 (`capRecallConfidence`) + Task 2 wiring. ✅
+- Best-effort/fail-safe (no namespace / absent tools / tool error) → Task 1 tests. ✅
+- Apply cap before verify + before `initialConfidence` → Task 2 Step 3. ✅
+- No `main.go` wiring, reuse `li.Tools` → Task 1. ✅
+
+**Placeholder scan:** Task 2's `<...>` are explicitly flagged to fill from existing `loop_test.go`/`verify_test.go` fixtures (test wiring that depends on patterns the implementer must read), not production-code placeholders. All production code (confirm.go, the loop.go block) is complete. ✅
+
+**Type consistency:** `confirmRecall(ctx, req, inv) (Investigation, bool)`, `capRecallConfidence(inv, ceiling)`, `recallUnconfirmedCap`, `recallConfirmTools` defined in Task 1 and consumed in Task 2 with matching signatures. `fakeConfirmTool` defined in Task 1's test file, reused in Task 2 (same package). ✅

--- a/docs/superpowers/specs/2026-06-23-recall-confirmatory-design.md
+++ b/docs/superpowers/specs/2026-06-23-recall-confirmatory-design.md
@@ -1,0 +1,139 @@
+# Confirmatory evidence on the recall short-circuit — design (roadmap #13)
+
+| | |
+|---|---|
+| **Date** | 2026-06-23 |
+| **Roadmap item** | #13 — feed real cluster state to verify on the instant-recall path (or cap confidence when unavailable) |
+| **Depends on** | #2 (discovered `Resource`, merged) |
+| **Effort** | M |
+
+## Problem
+
+On the instant-recall short-circuit, `recalledInvestigation`
+(`internal/investigate/recall.go:199-219`) sets the finding's sole evidence to a
+**tautological string**: `"instant recall: matched knowledge-base entry %q"`. The
+verify pass (`verifyFindings`, `verify.go:59-87`) judges each root cause **"ONLY on
+the evidence given"** and can only *lower* confidence. Given only that string,
+verify is a no-op on the recall path: a confidently-worded but **wrong or stale**
+catalog entry sails through. (Bounded today: verify is the 3rd gate, recall is off
+under `auto`, and recalled confidence is capped at 0.90 — but the gate that should
+catch a stale belief cannot.)
+
+All the parts to fix it already exist: the `pod_status` and `kube_events` tools
+(`kube_tools.go`, backed by `providers.KubeReader`) return current pod health and
+the Kubernetes event stream for a namespace, and `req.Workload` (namespace + optional
+name, reliable since #2) is available at recall time.
+
+## Design
+
+On a recall hit, run a **minimal, non-LLM confirmatory step** — call the existing
+`pod_status` and `kube_events` tools scoped to the alert's workload — and append
+their output to the recalled finding's evidence **before** verify. Verify then judges
+the recalled cause against current cluster state and can downgrade/reject a stale
+entry. When confirmatory evidence cannot be gathered, fall back to a lower confidence
+cap.
+
+### Confirmatory step (`internal/investigate/confirm.go`, new)
+
+```go
+const recallUnconfirmedCap = 0.70 // recall confidence ceiling when current state could not be gathered
+
+// recallConfirmTools are the read-only, namespace-scoped checks used to confirm a
+// recalled finding against current cluster state, in priority order.
+var recallConfirmTools = []string{"pod_status", "kube_events"}
+
+// confirmRecall gathers current cluster state for the recalled workload and appends
+// it to the finding's top hypothesis evidence, so the verify pass can judge the
+// recalled cause against reality rather than a tautology. It reuses the investigation
+// tools already wired into the loop (no new dependency). Best-effort: a missing
+// namespace, absent tools, or a tool error simply yields gathered=false. gathered is
+// true when at least one confirmatory tool returned output (including "no pods" /
+// "no events" — that is still real current state).
+func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, bool)
+```
+
+- Scope: `pod_status` is called with `{"namespace": ns}`; `kube_events` with
+  `{"namespace": ns, "object": name}` (object omitted when the name is unknown),
+  where `ns/name = req.Workload`. If `ns == ""`, return `(inv, false)`.
+- Tool resolution: build a name→tool map from `li.Tools`; for each name in
+  `recallConfirmTools` that is present, `Call` it. Swallow per-tool errors (log at
+  debug); skip empty output.
+- On success, append each rendered block to `inv.RootCauses[0].Evidence` as
+  `"current state — <tool>:\n<output>"`, and return `(inv, true)`. If nothing was
+  gathered, return `(inv, false)` unchanged.
+
+### Wiring in the loop (`internal/investigate/loop.go`)
+
+Replace the recall block's build→verify sequence:
+
+```go
+rec := recalledInvestigation(req, *entry, conf)
+rec, confirmed := li.confirmRecall(ctx, req, rec)
+if !confirmed {
+    // Could not confront the entry with current state — be less assertive so an
+    // unverifiable recall does not present at full recall confidence.
+    rec = capRecallConfidence(rec, recallUnconfirmedCap)
+}
+initialConfidence := rec.Confidence
+if li.Verify {
+    rec = li.verifyFindings(ctx, req, rec) // now judges against real evidence when confirmed
+}
+```
+
+`capRecallConfidence(inv, cap)` lowers `inv.Confidence` and every
+`inv.RootCauses[i].Confidence` to at most `cap` (only ever lowers). Applying the cap
+**before** verify keeps verify's max-of-survivors recomputation consistent.
+
+The existing recall metrics block (`result = verified|downgraded|rejected` by
+comparing to `initialConfidence`) is unchanged and now also reflects a
+confirmatory-driven downgrade.
+
+### Why this shape
+
+- **Reuses the agent's own tools** — no new `KubeReader` plumbing through `main.go`;
+  the confirmatory check renders exactly what the model would see.
+- **Deterministic + cheap** — 1–2 in-cluster read calls, no extra LLM round-trip, so
+  recall stays the fast path.
+- **Combines both roadmap options** — confirmatory evidence when the workload is
+  known and tools are present; a lower confidence cap when it is not.
+- **Fail-safe** — every failure mode (no namespace, no tools, tool error) degrades to
+  the lower-cap path, never to a crash or a lost finding.
+
+### Out of scope
+
+- Adding new confirmatory tools (metrics/logs) — `pod_status` + `kube_events` are the
+  fast, universally-available kube checks; widen later if needed.
+- Changing `recalledInvestigation`'s tautological label line (kept as an explicit
+  "this was a recall" marker; the real evidence is appended alongside it).
+- Recall behavior under `auto` (still disabled there by design).
+
+## Testing
+
+- `internal/investigate/confirm_test.go`
+  - `TestConfirmRecallAppendsCurrentState` — a fake `pod_status` tool returning
+    "web CrashLoopBackOff" → evidence gains the block, `gathered==true`.
+  - `TestConfirmRecallScopesToWorkload` — assert `pod_status` receives the request's
+    namespace and `kube_events` receives the workload name as `object` (a fake tool
+    records the args it was called with).
+  - `TestConfirmRecallNoNamespaceSkips` — empty `req.Workload.Namespace` →
+    `gathered==false`, evidence unchanged, no tool called.
+  - `TestConfirmRecallToolsAbsentSkips` — `li.Tools` without the confirm tools →
+    `gathered==false`.
+  - `TestConfirmRecallToolErrorTolerated` — a confirm tool returning an error is
+    skipped; if the other yields output, `gathered==true`; if both fail, `false`.
+  - `TestCapRecallConfidenceOnlyLowers` — caps inv + per-hypothesis confidence to the
+    ceiling; a value already below is untouched.
+- `internal/investigate/loop_test.go`
+  - `TestInstantRecallUnconfirmedLowersConfidence` — recall hit with no confirm tools
+    → delivered confidence ≤ `recallUnconfirmedCap`.
+  - `TestInstantRecallConfirmedEvidenceReachesVerify` — recall hit + a confirm tool
+    whose output contradicts the entry + a `scriptModel` verify that rejects →
+    delivered finding is rejected/downgraded (proves real evidence reached verify).
+- Existing recall/verify/loop tests stay green.
+
+## Files touched
+
+- `internal/investigate/confirm.go` — **new**: `confirmRecall`, `capRecallConfidence`, `recallConfirmTools`, `recallUnconfirmedCap`.
+- `internal/investigate/loop.go` — wire the confirmatory step + cap into the recall block.
+- `internal/investigate/confirm_test.go` — **new** tests above.
+- `internal/investigate/loop_test.go` — two recall-path tests above.

--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -1,0 +1,80 @@
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// recallUnconfirmedCap is the recall-confidence ceiling applied when current cluster
+// state could not be gathered to confront the recalled entry.
+const recallUnconfirmedCap = 0.70
+
+// recallConfirmTools are the read-only, namespace-scoped checks used to confront a
+// recalled finding with current cluster state, in priority order. They are the same
+// tools the agent uses, resolved from the loop's tool set.
+var recallConfirmTools = []string{"pod_status", "kube_events"}
+
+// confirmRecall gathers current cluster state for the recalled workload and appends
+// it to the top hypothesis's evidence, so the verify pass can judge the recalled
+// cause against reality rather than a tautology. Best-effort: a missing namespace,
+// absent tools, or a tool error yields gathered=false. gathered is true when at
+// least one confirm tool returned non-empty output (including "no pods"/"no events"
+// — still real current state).
+func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, bool) {
+	if req.Workload.Namespace == "" || len(inv.RootCauses) == 0 {
+		return inv, false
+	}
+	byName := make(map[string]Tool, len(li.Tools))
+	for _, t := range li.Tools {
+		byName[t.Name()] = t
+	}
+	gathered := false
+	for _, name := range recallConfirmTools {
+		t, ok := byName[name]
+		if !ok {
+			continue
+		}
+		out, err := t.Call(ctx, confirmArgs(name, req.Workload))
+		if err != nil {
+			if li.Log != nil {
+				li.Log.Debug("recall confirm tool failed", "tool", name, "err", err)
+			}
+			continue
+		}
+		if out = strings.TrimSpace(out); out == "" {
+			continue
+		}
+		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
+			fmt.Sprintf("current state — %s:\n%s", name, out))
+		gathered = true
+	}
+	return inv, gathered
+}
+
+// confirmArgs builds the JSON args scoping a confirmatory tool to the workload.
+func confirmArgs(name string, w providers.Workload) string {
+	m := map[string]string{"namespace": w.Namespace}
+	if name == "kube_events" && w.Name != "" {
+		m["object"] = w.Name
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+// capRecallConfidence lowers the investigation's overall and per-hypothesis
+// confidence to at most ceiling (it never raises any value).
+func capRecallConfidence(inv providers.Investigation, ceiling float64) providers.Investigation {
+	if inv.Confidence > ceiling {
+		inv.Confidence = ceiling
+	}
+	for i := range inv.RootCauses {
+		if inv.RootCauses[i].Confidence > ceiling {
+			inv.RootCauses[i].Confidence = ceiling
+		}
+	}
+	return inv
+}

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -1,0 +1,114 @@
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeConfirmTool is a confirmatory Tool that records the args it was called with.
+type fakeConfirmTool struct {
+	name    string
+	out     string
+	err     error
+	gotArgs string
+}
+
+func (f *fakeConfirmTool) Name() string        { return f.name }
+func (f *fakeConfirmTool) Description() string { return "" }
+func (f *fakeConfirmTool) Schema() string      { return "{}" }
+func (f *fakeConfirmTool) Call(_ context.Context, args string) (string, error) {
+	f.gotArgs = args
+	return f.out, f.err
+}
+
+func recalledInv() providers.Investigation {
+	return providers.Investigation{
+		Title:      "web down",
+		Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{Summary: "image tag rollout", Confidence: 0.9,
+			Evidence: []string{"instant recall: matched knowledge-base entry \"x\""}}},
+		Resource: providers.Workload{Namespace: "apps", Name: "web"},
+	}
+}
+
+func TestConfirmRecallAppendsCurrentState(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff"}
+	li := &LoopInvestigator{Tools: []Tool{ps}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("expected gathered=true when a confirm tool returns output")
+	}
+	joined := strings.Join(inv.RootCauses[0].Evidence, "\n")
+	if !strings.Contains(joined, "CrashLoopBackOff") || !strings.Contains(joined, "pod_status") {
+		t.Fatalf("current-state evidence not appended: %q", joined)
+	}
+}
+
+func TestConfirmRecallScopesToWorkload(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "ok"}
+	ev := &fakeConfirmTool{name: "kube_events", out: "Warning"}
+	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
+		t.Fatal("expected gathered=true")
+	}
+	if !strings.Contains(ps.gotArgs, `"namespace":"apps"`) {
+		t.Fatalf("pod_status not scoped to namespace: %q", ps.gotArgs)
+	}
+	if !strings.Contains(ev.gotArgs, `"namespace":"apps"`) || !strings.Contains(ev.gotArgs, `"object":"web"`) {
+		t.Fatalf("kube_events not scoped to namespace+object: %q", ev.gotArgs)
+	}
+}
+
+func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "x"}
+	li := &LoopInvestigator{Tools: []Tool{ps}}
+	req := Request{Workload: providers.Workload{}} // no namespace
+	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if gathered {
+		t.Fatal("no namespace must skip confirmation")
+	}
+	if ps.gotArgs != "" {
+		t.Fatalf("tool must not be called without a namespace, got args %q", ps.gotArgs)
+	}
+	if len(inv.RootCauses[0].Evidence) != 1 {
+		t.Fatalf("evidence must be unchanged, got %v", inv.RootCauses[0].Evidence)
+	}
+}
+
+func TestConfirmRecallToolsAbsentSkips(t *testing.T) {
+	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "what_changed", out: "x"}}}
+	req := Request{Workload: providers.Workload{Namespace: "apps"}}
+	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
+		t.Fatal("no confirm tools present must yield gathered=false")
+	}
+}
+
+func TestConfirmRecallToolErrorTolerated(t *testing.T) {
+	bad := &fakeConfirmTool{name: "pod_status", err: context.DeadlineExceeded}
+	good := &fakeConfirmTool{name: "kube_events", out: "Warning FailedMount"}
+	li := &LoopInvestigator{Tools: []Tool{bad, good}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("one tool erroring must not prevent the other from confirming")
+	}
+	if !strings.Contains(strings.Join(inv.RootCauses[0].Evidence, "\n"), "FailedMount") {
+		t.Fatal("the surviving tool's output should be appended")
+	}
+}
+
+func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
+	inv := providers.Investigation{Confidence: 0.9, RootCauses: []providers.Hypothesis{{Confidence: 0.9}, {Confidence: 0.5}}}
+	out := capRecallConfidence(inv, 0.70)
+	if out.Confidence != 0.70 || out.RootCauses[0].Confidence != 0.70 {
+		t.Fatalf("values above the ceiling must be lowered: %+v", out)
+	}
+	if out.RootCauses[1].Confidence != 0.5 {
+		t.Fatalf("a value already below the ceiling must be untouched, got %v", out.RootCauses[1].Confidence)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -112,6 +112,12 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			li.Log.Info("instant recall (catalog hit; skipping the loop)",
 				"title", req.Title, "entry", entry.Path, "confidence", fmt.Sprintf("%.2f", conf))
 			rec := recalledInvestigation(req, *entry, conf)
+			rec, confirmed := li.confirmRecall(ctx, req, rec)
+			if !confirmed {
+				// Could not confront the entry with current state — be less assertive
+				// so an unverifiable recall does not present at full recall confidence.
+				rec = capRecallConfidence(rec, recallUnconfirmedCap)
+			}
 			initialConfidence := rec.Confidence
 			if li.Verify {
 				// Catalog content is untrusted: verify a recalled finding too, so a

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -366,3 +366,53 @@ func TestLoopHardKillDisabledWhenNoBudget(t *testing.T) {
 		t.Fatalf("expected exactly 5 model calls (= maxSteps), got %d — hard-kill must not fire when budget=0", model.calls)
 	}
 }
+
+func TestInstantRecallUnconfirmedLowersConfidence(t *testing.T) {
+	// A recall hit with NO confirm tools available → confidence is capped at
+	// recallUnconfirmedCap before delivery.
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Tools:      nil, // intentionally omit pod_status/kube_events so confirmRecall returns gathered=false
+		Verify:     false,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Recall: &Recall{MinScore: 2.0, Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Title: "Known incident", Description: "chart bump", Path: "known.md", Resource: "apps/web"}, Score: 5.0}}}},
+	}
+	req := Request{Title: "web down", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got.Confidence > recallUnconfirmedCap {
+		t.Fatalf("unconfirmed recall must be capped at %.2f, got %.2f", recallUnconfirmedCap, got.Confidence)
+	}
+}
+
+func TestInstantRecallConfirmedEvidenceReachesVerify(t *testing.T) {
+	// A recall hit + a confirm tool whose output contradicts the entry + a verify
+	// model that rejects the (now evidence-bearing) root cause → the delivered
+	// finding is rejected (root causes emptied), proving the confirmatory evidence
+	// reached verify rather than the tautological string.
+	var got providers.Investigation
+	ps := &fakeConfirmTool{name: "pod_status", out: "web Running ready=1/1 (healthy — contradicts the recalled crash)"}
+	li := &LoopInvestigator{
+		Tools:  []Tool{ps},
+		Verify: true,
+		// Model used only by verify here (recall short-circuits the loop): script it
+		// to submit a single "reject" verdict for index 0.
+		Model: &scriptModel{responses: []providers.CompletionResponse{
+			{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"reject","confidence":0.1,"reason":"current state shows healthy pod — contradicts recalled crash"}]}`}}},
+		}},
+		OnComplete: func(inv providers.Investigation) { got = inv },
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Recall: &Recall{MinScore: 2.0, Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Title: "Known incident", Description: "crash loop", Path: "known.md", Resource: "apps/web"}, Score: 5.0}}}},
+	}
+	req := Request{Title: "web down", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(got.RootCauses) != 0 {
+		t.Fatalf("verify should have rejected the recalled cause using current-state evidence, got %+v", got.RootCauses)
+	}
+}

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -388,21 +388,42 @@ func TestInstantRecallUnconfirmedLowersConfidence(t *testing.T) {
 	}
 }
 
+// contentRejectModel is a verify-pass model that makes its verdict content-dependent:
+//   - if req.Messages[0].Content contains the sentinel "current state — pod_status"
+//     the confirmatory evidence reached verify → reject (root causes emptied → test PASSES).
+//   - if the sentinel is absent (confirmRecall wiring removed) → keep (root cause survives
+//     → len(got.RootCauses)==1 → test FAILS), proving the test discriminates.
+type contentRejectModel struct{}
+
+func (contentRejectModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	const sentinel = "current state — pod_status"
+	verdict := "keep"
+	if len(req.Messages) > 0 && strings.Contains(req.Messages[0].Content, sentinel) {
+		verdict = "reject"
+	}
+	args := `{"verdicts":[{"index":0,"verdict":"` + verdict + `","confidence":0.1,"reason":"content-dependent verdict"}]}`
+	return providers.CompletionResponse{
+		ToolCalls: []providers.ToolCall{{ID: "1", Name: submitVerdictsName, Args: args}},
+	}, nil
+}
+
 func TestInstantRecallConfirmedEvidenceReachesVerify(t *testing.T) {
 	// A recall hit + a confirm tool whose output contradicts the entry + a verify
 	// model that rejects the (now evidence-bearing) root cause → the delivered
 	// finding is rejected (root causes emptied), proving the confirmatory evidence
 	// reached verify rather than the tautological string.
+	//
+	// The contentRejectModel makes the verdict content-dependent: it rejects only
+	// when "current state — pod_status" appears in the review content (i.e. when
+	// confirmRecall wiring is intact). Without the wiring the sentinel is absent,
+	// the model returns "keep", root causes survive, and len==0 assertion fails —
+	// proving the test genuinely discriminates.
 	var got providers.Investigation
 	ps := &fakeConfirmTool{name: "pod_status", out: "web Running ready=1/1 (healthy — contradicts the recalled crash)"}
 	li := &LoopInvestigator{
-		Tools:  []Tool{ps},
-		Verify: true,
-		// Model used only by verify here (recall short-circuits the loop): script it
-		// to submit a single "reject" verdict for index 0.
-		Model: &scriptModel{responses: []providers.CompletionResponse{
-			{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"reject","confidence":0.1,"reason":"current state shows healthy pod — contradicts recalled crash"}]}`}}},
-		}},
+		Tools:      []Tool{ps},
+		Verify:     true,
+		Model:      contentRejectModel{},
 		OnComplete: func(inv providers.Investigation) { got = inv },
 		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Recall: &Recall{MinScore: 2.0, Catalog: fakeScored{hits: []catalog.ScoredEntry{


### PR DESCRIPTION
## Roadmap item #13 — confirmatory evidence on the recall short-circuit

On an instant-recall hit, `recalledInvestigation` set the finding's only evidence to a **tautological string** (`"instant recall: matched knowledge-base entry X"`). The verify pass judges "ONLY on the evidence given" and can only lower confidence — so on the recall path it was a **no-op**: a confidently-worded but wrong/stale catalog entry sailed through.

### Change
On a recall hit, run a minimal **non-LLM confirmatory step** and feed real cluster state to verify:

- **`confirmRecall`** resolves the existing `pod_status` + `kube_events` tools from `li.Tools` (no new wiring), scopes them to `req.Workload` (namespace, name→`object` for events), and appends their current-state output to the recalled finding's top-hypothesis evidence. `verifyFindings` → `renderForReview` already renders the Evidence field, so verify now judges the recalled cause against reality and can downgrade/reject a stale entry.
- **Fail-safe cap:** when state can't be gathered (no namespace / tools absent / tool error / empty output), `capRecallConfidence` lowers the recalled confidence to ≤ **0.70** so an unverifiable recall isn't presented at full confidence. This combines both options the roadmap offered.
- Wired into `loop.go`'s recall block as `confirmRecall → cap-if-unconfirmed → verify`, applied **before** `initialConfidence` capture so a cap is never mis-counted as a verify "downgrade" in the recall metrics.

Cheap (1–2 in-cluster reads, no extra LLM call), reuses the agent's own tools, recall still disabled under `auto`, existing 0.90 cap + outcome decay untouched.

### Testing
`go build/vet/test` + gofmt clean. The key test `TestInstantRecallConfirmedEvidenceReachesVerify` is **mutation-verified discriminating**: its verify model returns "keep" unless the `current state — pod_status` evidence is present and "reject" when it is, so removing the `confirmRecall` wiring makes it (and `TestInstantRecallUnconfirmedLowersConfidence`) FAIL. Plus 6 unit tests for confirmRecall scoping/fail-safe/cap.

### Process
brainstorm → spec (`docs/superpowers/specs/2026-06-23-recall-confirmatory-design.md`) → plan → 2 subagent tasks, each task-reviewed; one Important test-discrimination gap caught + fixed (content-dependent verify model) → whole-branch review (opus, with a mutation test): **✅ merge, no blocking issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)