### PR TITLE
feat(curator): require Verified + provenance in the merge bar (#16)

### DIFF
--- a/docs/superpowers/plans/2026-06-23-meetsbar-verified.md
+++ b/docs/superpowers/plans/2026-06-23-meetsbar-verified.md
@@ -1,0 +1,213 @@
+# `Verified`/provenance in the curation merge bar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Only adversarially-reviewed, actionable findings may be drafted into the shared KB: surface the verify outcome as `Investigation.Verified` and require it — plus a causing/fixing provenance anchor — in the curator's `meetsBar`.
+
+**Architecture:** `applyVerdicts` sets `Verified = len(kept) > 0`; `meetsBar` requires `Verified` and that the top cause carries a `ChangeRef` or `SuggestedAction`. The verify pass is always-on in production, so this only newly excludes unverified/symptom-only findings.
+
+**Tech Stack:** Go 1.26, standard library only.
+
+## Global Constraints
+
+- Go 1.26, no new dependencies.
+- `Verified` is `true` only when the adversarial review ran AND ≥1 root cause survived; every best-effort early return in `verifyFindings` leaves it `false`.
+- `meetsBar` provenance is `ChangeRef != "" || SuggestedAction != ""` (OR, not AND — non-GitOps incidents must still curate).
+- Recalled findings (skipped by `Curate` before `meetsBar`) and eval (never curates) are out of the gate's path — do not touch them.
+- After each task: `go build ./... && go vet ./... && go test ./...` green and `gofmt -l .` empty.
+
+---
+
+### Task 1: `Investigation.Verified` field + set it in the verify pass
+
+**Files:**
+- Modify: `internal/providers/providers.go`
+- Modify: `internal/investigate/verify.go`
+- Test: `internal/investigate/verify_test.go`
+
+**Interfaces:**
+- Produces: `Investigation.Verified bool`, set `true` in `applyVerdicts` iff a cause survived.
+
+- [ ] **Step 1: Strengthen the verify tests to assert `Verified`**
+
+Read `internal/investigate/verify_test.go`. It has `TestVerifyRejectsCorrelationFinding` (all causes rejected → `len(got.RootCauses)==0`) and `TestVerifyDowngradesUnproven` (a cause survives). Add assertions:
+
+- In the all-rejected test, after the existing `len(got.RootCauses) != 0` check, add:
+```go
+	if got.Verified {
+		t.Fatal("a finding with no surviving cause must not be marked Verified")
+	}
+```
+- In the downgrade/survivor test, after confirming the cause survived, add:
+```go
+	if !got.Verified {
+		t.Fatal("a finding with a surviving reviewed cause must be marked Verified")
+	}
+```
+
+If the survivor test's captured variable differs (e.g. `got` vs a pointer), match the file's existing style.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `go test ./internal/investigate/ -run 'TestVerifyRejectsCorrelationFinding|TestVerifyDowngradesUnproven' -v`
+Expected: FAIL — `Verified` undefined (compile error).
+
+- [ ] **Step 3: Add the field and set it**
+
+In `internal/providers/providers.go`, add to the `Investigation` struct (after `RecalledEntry`):
+```go
+	Verified      bool     // true when the adversarial verify pass ran and a root cause survived it
+```
+
+In `internal/investigate/verify.go`, in `applyVerdicts`, set the flag where the surviving causes are finalized — immediately after `inv.RootCauses = kept` (and before the confidence recompute is fine; place it right after the assignment):
+```go
+	inv.RootCauses = kept
+	inv.Verified = len(kept) > 0
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `go test ./internal/investigate/ -run 'TestVerifyRejectsCorrelationFinding|TestVerifyDowngradesUnproven' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full package + gofmt**
+
+Run: `go test ./internal/investigate/ && gofmt -l internal/investigate/ internal/providers/`
+Expected: PASS; gofmt prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/providers/providers.go internal/investigate/verify.go internal/investigate/verify_test.go
+git commit -m "feat(investigate): mark Investigation.Verified when a cause survives review"
+```
+
+---
+
+### Task 2: Require `Verified` + provenance in `meetsBar`
+
+**Files:**
+- Modify: `internal/curator/curator.go`
+- Test: `internal/curator/curator_test.go`
+
+**Interfaces:**
+- Consumes: `Investigation.Verified` (Task 1), `Hypothesis.ChangeRef`, `Hypothesis.SuggestedAction`.
+
+- [ ] **Step 1: Update the fixture and add the failing tests**
+
+In `internal/curator/curator_test.go`:
+
+1. Update the `goodFinding()` fixture so it represents a verified finding — add `Verified: true` to the `Investigation` literal (it already has `ChangeRef` and `SuggestedAction` on its top cause, so it satisfies provenance). Without this, the existing happy-path test would break once `meetsBar` requires `Verified`.
+
+2. Add these tests (mirror the existing test construction — `fakeForge`, `newCurator`/`Curator{...}` with `MinConfidence`, the logger helper):
+
+```go
+func TestCurateUnverifiedDropsNoArtifact(t *testing.T) {
+	inv := goodFinding()
+	inv.Verified = false // identical to the happy-path finding, but verify did not confirm it
+	f := &fakeForge{}
+	c := &Curator{Forge: f, MinConfidence: 0.75, Log: testLogger()}
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.openedPR != nil {
+		t.Fatal("an unverified finding must not draft a KB PR")
+	}
+}
+
+func TestCurateSymptomOnlyDropsNoArtifact(t *testing.T) {
+	inv := goodFinding()
+	inv.Verified = true
+	inv.RootCauses[0].ChangeRef = ""       // no causing-change anchor
+	inv.RootCauses[0].SuggestedAction = "" // no fixing-action anchor
+	f := &fakeForge{}
+	c := &Curator{Forge: f, MinConfidence: 0.75, Log: testLogger()}
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.openedPR != nil {
+		t.Fatal("a symptom-only finding (no provenance) must not draft a KB PR")
+	}
+}
+
+func TestCurateVerifiedWithSuggestedActionOnlyOpensPR(t *testing.T) {
+	inv := goodFinding()
+	inv.Verified = true
+	inv.RootCauses[0].ChangeRef = ""               // no GitOps change...
+	inv.RootCauses[0].SuggestedAction = "scale up" // ...but a fixing action anchors it
+	f := &fakeForge{}
+	c := &Curator{Forge: f, MinConfidence: 0.75, Log: testLogger()}
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.openedPR == nil {
+		t.Fatal("a verified finding with a fixing action must curate (provenance is OR)")
+	}
+}
+```
+
+Match the actual helper names in the file: use whatever the existing tests use to build the `Curator` and the logger (e.g. an inline `slog.New(slog.NewTextHandler(io.Discard, nil))` if there is no `testLogger()`), and the real `fakeForge` field name for the opened PR (the #11 map showed `openedPR *providers.KBEntry`). If the existing tests construct the `Curator` via a helper like `newCurator(f, cat)`, reuse it and set `MinConfidence` the way they do.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `go test ./internal/curator/ -run 'TestCurateUnverified|TestCurateSymptomOnly|TestCurateVerifiedWithSuggestedActionOnly' -v`
+Expected: FAIL — `meetsBar` does not yet require `Verified`/provenance (the unverified and symptom-only findings would currently open a PR).
+
+- [ ] **Step 3: Update `meetsBar`**
+
+Replace `meetsBar` in `internal/curator/curator.go` with:
+
+```go
+// meetsBar is the file-time QUALITY gate (not the merge condition): an
+// adversarially-reviewed, confident root cause with cited evidence AND a provenance
+// anchor (a causing change or a fixing action). The resolved/accepted MERGE
+// condition is enforced later by the curate agent + the human.
+func meetsBar(inv providers.Investigation, minConf float64) bool {
+	if !inv.Verified {
+		return false // only findings that survived the adversarial review reach the shared catalog
+	}
+	if inv.Confidence < minConf || len(inv.RootCauses) == 0 {
+		return false
+	}
+	top := inv.RootCauses[0]
+	if top.Summary == "" || len(top.Evidence) == 0 {
+		return false
+	}
+	// Provenance: actionable knowledge, not a symptom restatement — anchored to a
+	// causing change (ChangeRef) or a fixing action (SuggestedAction).
+	return top.ChangeRef != "" || top.SuggestedAction != ""
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `go test ./internal/curator/ -run 'TestCurateUnverified|TestCurateSymptomOnly|TestCurateVerifiedWithSuggestedActionOnly|TestCurateNovelHighQuality|TestCurateLowQuality' -v`
+Expected: PASS (new gates fire; the happy-path test still opens a PR because `goodFinding()` now sets `Verified: true`).
+
+- [ ] **Step 5: Full suite + vet + gofmt**
+
+Run: `go build ./... && go vet ./... && go test ./... && gofmt -l .`
+Expected: all PASS; gofmt prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/curator/curator.go internal/curator/curator_test.go
+git commit -m "feat(curator): meetsBar requires Verified + provenance before drafting"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `Verified bool` field → Task 1. ✅
+- Set in `applyVerdicts` (len(kept)>0) → Task 1. ✅
+- `meetsBar` requires `Verified` → Task 2. ✅
+- Provenance OR (ChangeRef|SuggestedAction) → Task 2. ✅
+- `goodFinding` fixture updated; unverified + symptom-only + suggested-action-only tests → Task 2. ✅
+- Recall/eval untouched → no edits there. ✅
+
+**Placeholder scan:** all code shown; test-helper references explicitly "match the existing file" (the #16/#11 maps confirm `fakeForge.openedPR`). ✅
+
+**Type consistency:** `Verified` defined in Task 1 (providers) and consumed in Task 2 (curator) and the Task 1 verify tests; `ChangeRef`/`SuggestedAction` are existing `Hypothesis` fields. ✅

--- a/docs/superpowers/specs/2026-06-23-meetsbar-verified-design.md
+++ b/docs/superpowers/specs/2026-06-23-meetsbar-verified-design.md
@@ -1,0 +1,131 @@
+# `Verified`/provenance in the curation merge bar — design (roadmap #16)
+
+| | |
+|---|---|
+| **Date** | 2026-06-23 |
+| **Roadmap item** | #16 — gate KB drafting on a passed adversarial review + provenance |
+| **Depends on** | — (verify pass + `ChangeRef`/`SuggestedAction` already exist) |
+| **Effort** | M |
+
+## Problem
+
+`meetsBar` (`internal/curator/curator.go:103-109`) — the quality gate before the
+curator drafts a merge-ready KB PR — checks only confidence, a non-empty top-cause
+summary, and ≥1 evidence item:
+
+```go
+func meetsBar(inv providers.Investigation, minConf float64) bool {
+	if inv.Confidence < minConf || len(inv.RootCauses) == 0 {
+		return false
+	}
+	top := inv.RootCauses[0]
+	return top.Summary != "" && len(top.Evidence) > 0
+}
+```
+
+It **ignores the verify pass and any provenance**. So an unverified or symptom-only
+finding can still draw a "merge-ready" decision card into the shared, communal
+catalog — the exact thing the adversarial review exists to prevent. The verify pass
+already runs on every investigation (it is hardcoded `Verify: true` at all three
+`LoopInvestigator` construction sites in `cmd/lore/main.go`; there is no config
+toggle), but its result never reaches the curator.
+
+## Design
+
+Surface the verify outcome on the `Investigation`, and require it — plus an
+actionable-provenance anchor — at the merge bar.
+
+### 1. `Verified` on the Investigation (`providers.go`)
+
+Add `Verified bool` to `providers.Investigation`. Default `false`.
+
+### 2. Set it in the verify pass (`verify.go`)
+
+In `applyVerdicts`, after recomputing the surviving causes, set:
+
+```go
+inv.Verified = len(kept) > 0
+```
+
+`Verified` is therefore `true` only when the adversarial review **actually ran and at
+least one root cause survived it**. Every best-effort early return in `verifyFindings`
+(no root causes, verifier model error, no verdicts parsed — `verify.go:65,74,84`)
+leaves `Verified` at its `false` default, which is correct: a finding the reviewer
+could not confirm is not verified. (Delivery to chat is unaffected — the finding still
+goes to Slack/Matrix via the notifier; only *curation* is gated.)
+
+### 3. Require it (and provenance) at the merge bar (`curator.go`)
+
+```go
+func meetsBar(inv providers.Investigation, minConf float64) bool {
+	// Only adversarially-reviewed findings may enter the shared catalog.
+	if !inv.Verified {
+		return false
+	}
+	if inv.Confidence < minConf || len(inv.RootCauses) == 0 {
+		return false
+	}
+	top := inv.RootCauses[0]
+	if top.Summary == "" || len(top.Evidence) == 0 {
+		return false
+	}
+	// Provenance: the entry must be actionable knowledge, not a symptom restatement
+	// — anchored to a causing change (ChangeRef) or a fixing action (SuggestedAction).
+	return top.ChangeRef != "" || top.SuggestedAction != ""
+}
+```
+
+**Why `ChangeRef` OR `SuggestedAction` (not both):** requiring a causing-change
+reference for every entry would wrongly exclude legitimate non-GitOps incidents
+(saturation, cert expiry, capacity) that have no deploy to point at; requiring a
+fixing action would exclude findings whose remediation is genuinely unknown. Either
+anchor makes the entry actionable, durable knowledge; a finding with **neither** is a
+bare symptom restatement and is correctly kept out of the communal catalog. This
+faithfully delivers the roadmap's "causing/fixing provenance" intent (the
+`changeRefs` helper at `draft.go:80` already calls these "the causing/fixing-change
+provenance the merge bar requires") without over-filtering.
+
+### Scope notes (verified against the code)
+
+- **Recalled findings** are unaffected: `Curate` early-returns on `inv.Recalled`
+  before `meetsBar` (`curator.go:35`). They are verified (loop.go:125) but never
+  curated.
+- **Eval** is unaffected: the replay `Runner` builds its `LoopInvestigator` without
+  `Verify` and scores findings directly (it never calls `meetsBar`/`Curate`).
+- **Fresh production investigations** always run verify (`loop.go:232`,
+  `Verify: true`), so a genuine, confirmed finding still curates exactly as before —
+  the gate only newly excludes unverified or symptom-only findings.
+
+### Out of scope
+
+- Making verify configurable / a config toggle (it is intentionally always-on).
+- Changing what the investigator populates into `ChangeRef`/`SuggestedAction`.
+- Reworking `applyVerdicts`' confidence math.
+
+## Testing
+
+- `internal/investigate/verify_test.go`
+  - Extend `TestVerifyRejectsCorrelationFinding` (all rejected) to assert
+    `got.Verified == false` (no cause survived).
+  - Extend `TestVerifyDowngradesUnproven` (a cause survives) to assert
+    `got.Verified == true`.
+- `internal/curator/curator_test.go`
+  - Update the `goodFinding()` fixture to set `Verified: true` (in production the
+    loop sets it; the fixture must represent a verified finding so the existing
+    happy-path test still passes).
+  - `TestCurateUnverifiedDropsNoArtifact` — a finding identical to `goodFinding()`
+    but `Verified: false` → `meetsBar` fails → no PR, no error.
+  - `TestCurateSymptomOnlyDropsNoArtifact` — `Verified: true`, high confidence,
+    summary + evidence present, but top cause has **no** `ChangeRef` and **no**
+    `SuggestedAction` → dropped (provenance gate).
+  - `TestCurateVerifiedWithSuggestedActionOnlyOpensPR` — `Verified: true`, no
+    `ChangeRef` but a `SuggestedAction` set → passes (proves the OR, so non-GitOps
+    incidents still curate).
+  - Existing `TestCurateNovelHighQualityOpensPR` and `TestCurateLowQualityDropsNoArtifact` stay green.
+
+## Files touched
+
+- `internal/providers/providers.go` — add `Verified bool`.
+- `internal/investigate/verify.go` — set `inv.Verified` in `applyVerdicts`.
+- `internal/curator/curator.go` — `meetsBar` requires `Verified` + provenance.
+- `internal/investigate/verify_test.go`, `internal/curator/curator_test.go` — tests above (incl. the `goodFinding` fixture update).

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -97,15 +97,24 @@ func (c *Curator) duplicateOpenPR(ctx context.Context, inv providers.Investigati
 	return 0, false, nil
 }
 
-// meetsBar is the file-time QUALITY gate (not the merge condition): a confirmed,
-// confident root cause with cited evidence. The resolved/accepted MERGE condition
-// is enforced later by the curate agent + the human.
+// meetsBar is the file-time QUALITY gate (not the merge condition): an
+// adversarially-reviewed, confident root cause with cited evidence AND a provenance
+// anchor (a causing change or a fixing action). The resolved/accepted MERGE
+// condition is enforced later by the curate agent + the human.
 func meetsBar(inv providers.Investigation, minConf float64) bool {
+	if !inv.Verified {
+		return false // only findings that survived the adversarial review reach the shared catalog
+	}
 	if inv.Confidence < minConf || len(inv.RootCauses) == 0 {
 		return false
 	}
 	top := inv.RootCauses[0]
-	return top.Summary != "" && len(top.Evidence) > 0
+	if top.Summary == "" || len(top.Evidence) == 0 {
+		return false
+	}
+	// Provenance: actionable knowledge, not a symptom restatement — anchored to a
+	// causing change (ChangeRef) or a fixing action (SuggestedAction).
+	return top.ChangeRef != "" || top.SuggestedAction != ""
 }
 
 func coalesceComment(inv providers.Investigation) string {

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -46,7 +46,7 @@ func newCurator(f *fakeForge, cat catalog.ScoredSearcher) *Curator {
 
 func goodFinding() providers.Investigation {
 	return providers.Investigation{
-		Title: "HarborRegistryDown", Confidence: 0.9,
+		Title: "HarborRegistryDown", Confidence: 0.9, Verified: true,
 		RootCauses: []providers.Hypothesis{{
 			Summary: "IAM quota exceeded", Confidence: 0.9,
 			Evidence: []string{"CreateContainerConfigError"}, ChangeRef: "xplane-harbor", SuggestedAction: "delete a key",
@@ -100,8 +100,9 @@ func TestCurateDistinctTitleSameFingerprintCoalesces(t *testing.T) {
 	inv := providers.Investigation{
 		Title:      "freshly reworded title the LLM produced this time",
 		Confidence: 0.9,
+		Verified:   true,
 		Resource:   providers.Workload{Namespace: "apps", Name: "web"},
-		RootCauses: []providers.Hypothesis{{Summary: "image tag rollout broke readiness", Evidence: []string{"e"}}},
+		RootCauses: []providers.Hypothesis{{Summary: "image tag rollout broke readiness", Evidence: []string{"e"}, ChangeRef: "a-change"}},
 	}
 	openPR := providers.CuratedIssue{
 		Number: 7,
@@ -125,8 +126,9 @@ func TestCurateDifferentFingerprintOpensSecondPR(t *testing.T) {
 	inv := providers.Investigation{
 		Title:      "apps/web readiness failure",
 		Confidence: 0.9,
+		Verified:   true,
 		Resource:   providers.Workload{Namespace: "apps", Name: "web"},
-		RootCauses: []providers.Hypothesis{{Summary: "image tag rollout broke readiness", Evidence: []string{"e"}}},
+		RootCauses: []providers.Hypothesis{{Summary: "image tag rollout broke readiness", Evidence: []string{"e"}, ChangeRef: "a-change"}},
 	}
 	openPR := providers.CuratedIssue{
 		Number: 7, Title: "KB: unrelated",
@@ -177,6 +179,49 @@ func TestCurateLowQualityDropsNoArtifact(t *testing.T) {
 	}
 	if f.openedPR != nil || len(f.commented) != 0 || ref.URL != "" {
 		t.Fatalf("low-quality finding must produce no repo artifact, got pr=%+v comment=%v ref=%s", f.openedPR, f.commented, ref.URL)
+	}
+}
+
+func TestCurateUnverifiedDropsNoArtifact(t *testing.T) {
+	inv := goodFinding()
+	inv.Verified = false // identical to the happy-path finding, but verify did not confirm it
+	f := &fakeForge{}
+	c := &Curator{Forge: f, MinConfidence: 0.75, Log: testLogger()}
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.openedPR != nil {
+		t.Fatal("an unverified finding must not draft a KB PR")
+	}
+}
+
+func TestCurateSymptomOnlyDropsNoArtifact(t *testing.T) {
+	inv := goodFinding()
+	inv.Verified = true
+	inv.RootCauses[0].ChangeRef = ""       // no causing-change anchor
+	inv.RootCauses[0].SuggestedAction = "" // no fixing-action anchor
+	f := &fakeForge{}
+	c := &Curator{Forge: f, MinConfidence: 0.75, Log: testLogger()}
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.openedPR != nil {
+		t.Fatal("a symptom-only finding (no provenance) must not draft a KB PR")
+	}
+}
+
+func TestCurateVerifiedWithSuggestedActionOnlyOpensPR(t *testing.T) {
+	inv := goodFinding()
+	inv.Verified = true
+	inv.RootCauses[0].ChangeRef = ""               // no GitOps change...
+	inv.RootCauses[0].SuggestedAction = "scale up" // ...but a fixing action anchors it
+	f := &fakeForge{}
+	c := &Curator{Forge: f, MinConfidence: 0.75, Log: testLogger()}
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatalf("Curate: %v", err)
+	}
+	if f.openedPR == nil {
+		t.Fatal("a verified finding with a fixing action must curate (provenance is OR)")
 	}
 }
 

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -116,6 +116,7 @@ func applyVerdicts(li *LoopInvestigator, req Request, inv providers.Investigatio
 		}
 	}
 	inv.RootCauses = kept
+	inv.Verified = len(kept) > 0
 	var maxc float64
 	for _, rc := range kept {
 		if rc.Confidence > maxc {

--- a/internal/investigate/verify_test.go
+++ b/internal/investigate/verify_test.go
@@ -35,6 +35,9 @@ func TestVerifyRejectsCorrelationFinding(t *testing.T) {
 	if len(got.RootCauses) != 0 {
 		t.Fatalf("rejected root cause should be removed, got %+v", got.RootCauses)
 	}
+	if got.Verified {
+		t.Fatal("a finding with no surviving cause must not be marked Verified")
+	}
 	if got.Confidence != 0 {
 		t.Fatalf("overall confidence should drop to 0 with no surviving root cause, got %v", got.Confidence)
 	}
@@ -65,5 +68,8 @@ func TestVerifyDowngradesUnproven(t *testing.T) {
 	}
 	if got == nil || len(got.RootCauses) != 1 || got.RootCauses[0].Confidence != 0.4 || got.Confidence != 0.4 {
 		t.Fatalf("expected downgraded confidence 0.4, got %+v", got)
+	}
+	if !got.Verified {
+		t.Fatal("a finding with a surviving reviewed cause must be marked Verified")
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -360,6 +360,7 @@ type Investigation struct {
 	Fingerprint   string   // originating alert fingerprint; for outcome-ledger attribution
 	Fingerprints  []string // coalesced batch fingerprints; one outcome open is recorded per entry
 	RecalledEntry string   // when Recalled: the catalog entry Path that was matched
+	Verified      bool     // true when the adversarial verify pass ran and a root cause survived it
 }
 
 // Hypothesis is one ranked root-cause candidate with its evidence.


### PR DESCRIPTION
## Roadmap item #16 — Verified + provenance in `meetsBar`

`meetsBar` (the quality gate before the curator drafts a merge-ready KB PR) checked only confidence + a non-empty top-cause summary + ≥1 evidence item. It **ignored the verify pass and provenance**, so an unverified or symptom-only finding could draft a decision card into the shared, communal catalog — exactly what the adversarial review exists to prevent.

### Change
- **`Investigation.Verified`** (new bool) is set `inv.Verified = len(kept) > 0` in `applyVerdicts` — true only when the adversarial review **ran and a root cause survived it**. Every best-effort early return in `verifyFindings` (no causes / verifier model error / no verdicts) leaves it `false`.
- **`meetsBar` now requires** `Verified` **and** a provenance anchor: `top.ChangeRef != "" || top.SuggestedAction != ""`.

**Provenance is OR, not AND** — requiring a causing-change ref for every entry would wrongly exclude legitimate non-GitOps incidents (saturation, cert expiry); requiring a fixing action would exclude findings whose remediation is unknown. Either anchor makes the entry actionable knowledge; a finding with neither is a bare symptom restatement and is correctly kept out of the catalog.

### Why it's safe (verified against the code)
- Verify is **always-on** in production (`Verify: true` hardcoded at all three `LoopInvestigator` sites; no config toggle), so a genuine confirmed finding still curates exactly as before.
- **Recalled** findings skip `Curate` before `meetsBar`; **eval** never calls `meetsBar`; `recurrence.go` builds an Investigation for `OpenIssue` (knowledge-gap issues), not `Curate`. The gate only newly excludes unverified/symptom-only fresh findings — which are still delivered to chat, just not written to the shared KB.

### Testing
`go build/vet/test` + gofmt clean. New: unverified→dropped, symptom-only (no provenance)→dropped, verified+SuggestedAction-only→opens PR (proves the OR). Verify-side tests assert `Verified` is false when all causes are rejected and true when one survives. The `goodFinding()` fixture gains `Verified: true` (in production the loop sets it).

### Process
brainstorm → spec (`docs/superpowers/specs/2026-06-23-meetsbar-verified-design.md`) → plan → 2 subagent tasks, reviewed → whole-branch review (opus): **✅ merge, no blocking issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)