### PR TITLE
test(e2e): mock answers the verify pass (fix curation under #16 Verified gate)

### DIFF
--- a/hack/e2e/mock/main.go
+++ b/hack/e2e/mock/main.go
@@ -90,14 +90,30 @@ func (mockObserver) GetFlows(_ *observerpb.GetFlowsRequest, stream observerpb.Ob
 
 // chatCompletions scripts the ReAct loop: call what_changed, then kb_search, then
 // submit_findings — driven by how many tool results the request already carries.
+// The adversarial verify pass is a separate, tool-result-free request that offers
+// ONLY the submit_verdicts tool; detect it by that tool and keep the cause so a
+// curatable (Verified) finding survives to the curator.
 func chatCompletions(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Messages []struct {
 			Role string `json:"role"`
 		} `json:"messages"`
+		Tools []struct {
+			Function struct {
+				Name string `json:"name"`
+			} `json:"function"`
+		} `json:"tools"`
 	}
 	body, _ := io.ReadAll(r.Body)
 	_ = json.Unmarshal(body, &req)
+	for _, t := range req.Tools {
+		if t.Function.Name == "submit_verdicts" {
+			// Verify pass: keep the (single) root cause so the finding is Verified.
+			log.Printf("MOCK chat/completions: verify -> submit_verdicts (keep)")
+			writeJSON(w, `{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"v0","type":"function","function":{"name":"submit_verdicts","arguments":"{\"verdicts\":[{\"index\":0,\"verdict\":\"keep\",\"confidence\":0.9,\"reason\":\"mock: evidence supports the cause\"}]}"}}]}}]}`)
+			return
+		}
+	}
 	toolResults := 0
 	for _, m := range req.Messages {
 		if m.Role == "tool" {


### PR DESCRIPTION
## Fix the k3d e2e curation regression introduced by #16

Running the capstone `hack/e2e-k3d.sh` after merging the roadmap batch surfaced two failures:
```
FAIL: curator opened a PR (confident)   (pattern: MOCK GH-PR)
FAIL: curated ref logged                (pattern: msg=curated)
```
with the agent logging `finding below the quality bar; chat-only, no KB artifact` (confidence 0.9, root_causes 1).

### Root cause
#16 made `meetsBar` require `Investigation.Verified` (the adversarial verify pass kept a cause). The verify pass is a **separate, tool-result-free** model request offering **only** the `submit_verdicts` tool. The e2e mock LLM picks its response by counting tool-results, so the verify request (0 tool-results) fell into the `what_changed` case — verify parsed no verdicts, hit its best-effort early return, and left `Verified=false`. After #16 that drops the finding before curation. (Production is unaffected: a real LLM answers the verify prompt.)

### Fix
Detect the verify request by its `submit_verdicts` tool and return a `keep` verdict for the root cause, so `applyVerdicts` sets `Verified=true` and the finding curates as before.

### Verification
Full `hack/e2e-k3d.sh`: **`PASS=40 FAIL=0` — ALL FEATURES VERIFIED** (webhook→investigate→findings→deliver→curate→PR, storm coalescing, GitOps failure, rung-2 approvals, rung-3 auto + kill-switch, leader failover, ArgoCD engine). This also confirms the six merged roadmap items (#7/#18/#11/#13/#16/#12) don't regress the end-to-end path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)