### PR TITLE
fix: post-merge review findings (DupFingerprint collision, unverified-coalesce, curate opt-out)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -810,13 +810,12 @@ func runCurate(args []string) error {
 		base = "main"
 	}
 	forge := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(tok))
-	staleAfter := cfg.Curate.StaleAfter.Std()
-	if staleAfter == 0 {
-		staleAfter = 720 * time.Hour // 30 days
-	}
+	// StaleAfter is honoured as-is: 0/unset disables the lifecycle sweep (Lifecycle.Run
+	// returns early). The Helm chart ships config.curate.stale_after: 720h, so scheduled
+	// runs sweep at 30 days; a bare `lore curate` with no config does dedup only.
 	agent := curate.Agent{Log: log, Passes: []curate.Pass{
 		curate.Dedup{Forge: forge, Log: log},
-		curate.Lifecycle{Forge: forge, StaleAfter: staleAfter, Log: log},
+		curate.Lifecycle{Forge: forge, StaleAfter: cfg.Curate.StaleAfter.Std(), Log: log},
 	}}
 	log.Info("curate: grooming KB backlog", "repo", cfg.Forge.KBRepo)
 	agent.Run(context.Background())

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -54,8 +54,9 @@ config:
   # Enable when a VMServiceScrape (or ServiceMonitor) will scrape this agent.
   telemetry:
     metrics_enabled: false
-  # Phase-2 backlog groomer (lore curate) — staleness window for automatic curation.
-  # Only used when the curate CronJob is enabled.
+  # Phase-2 backlog groomer (lore curate) — lifecycle staleness window. Applied
+  # whenever `lore curate` runs (the CronJob or a manual invocation); 0 disables the
+  # stale-PR sweep.
   curate:
     stale_after: 720h   # close unprotected KB PRs idle longer than this; 0 disables
   # model:

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -145,4 +146,37 @@ func TestSyncerCloneAndPull(t *testing.T) {
 	if es, _, _ := Load(mirror); len(es) != 2 {
 		t.Fatalf("after pull: %d entries, want 2", len(es))
 	}
+}
+
+// TestRunReloadsOnlyOnChange locks down the core of #18 Part A: Run calls onSync on
+// the first sync, then NOT again while upstream HEAD is unchanged, and again once a
+// new commit moves HEAD. The `if changed { onSync() }` gate is what prevents the
+// every-poll full index rebuild.
+func TestRunReloadsOnlyOnChange(t *testing.T) {
+	src := initBareUpstream(t)
+	dir := t.TempDir()
+	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
+
+	var calls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() { defer close(done); s.Run(ctx, 15*time.Millisecond, func() { calls.Add(1) }) }()
+
+	// Several poll intervals with no upstream change → onSync fires exactly once
+	// (the initial sync), regardless of how many ticks elapse.
+	time.Sleep(120 * time.Millisecond)
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("with no HEAD change onSync must fire exactly once, fired %d", n)
+	}
+
+	// Move HEAD: the next poll detects the change and reloads once more.
+	commitToUpstream(t, src, "new.md", "# new")
+	time.Sleep(150 * time.Millisecond)
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("a new upstream commit must trigger exactly one more onSync, total %d (want 2)", n)
+	}
+
+	cancel()
+	<-done
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -81,3 +81,21 @@ catalog:
 		t.Fatalf("instant_recall not parsed: %+v", ir)
 	}
 }
+
+func TestCurateStaleAfterParse(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("curate:\n  stale_after: 720h\n"), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := c.Curate.StaleAfter.Std(); got != 720*time.Hour {
+		t.Fatalf("curate.stale_after: want 720h, got %v", got)
+	}
+	// Absent ⇒ zero ⇒ the lifecycle sweep is disabled (runCurate honours 0).
+	var z Config
+	if err := yaml.Unmarshal([]byte("forge:\n  kb_repo: o/r\n"), &z); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if z.Curate.StaleAfter.Std() != 0 {
+		t.Fatalf("absent stale_after must be 0, got %v", z.Curate.StaleAfter.Std())
+	}
+}

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -37,7 +37,17 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 		return providers.Ref{}, nil
 	}
 
-	// 1. dedup — catalog (observe the top-hit score on every check), then open PRs
+	// 1. quality gate FIRST — a finding below the bar (e.g. unverified) produces NO
+	// repo artifact at all: not a PR, and not a coalesce comment on an existing PR.
+	// Gating before dedup keeps the open-PR coalesce path from posting an unreviewed
+	// finding onto a verified PR.
+	if !meetsBar(inv, c.MinConfidence) {
+		c.Log.Info("finding below the quality bar; chat-only, no KB artifact",
+			"confidence", inv.Confidence, "root_causes", len(inv.RootCauses))
+		return providers.Ref{}, nil
+	}
+
+	// 2. dedup — catalog (observe the top-hit score on every check), then open PRs
 	nov := Novelty{Catalog: c.Catalog, DupScore: c.DupScore}
 	if top, ok, err := nov.TopHit(ctx, inv); err != nil {
 		c.Log.Warn("dedup: catalog search failed", "err", err)
@@ -57,13 +67,6 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 			return providers.Ref{}, fmt.Errorf("coalesce comment: %w", err)
 		}
 		c.Log.Info("finding coalesced onto an open PR", "pr", n)
-		return providers.Ref{}, nil
-	}
-
-	// 2. quality gate — below the bar ⇒ no repo artifact (chat alert only)
-	if !meetsBar(inv, c.MinConfidence) {
-		c.Log.Info("finding below the quality bar; chat-only, no KB artifact",
-			"confidence", inv.Confidence, "root_causes", len(inv.RootCauses))
 		return providers.Ref{}, nil
 	}
 

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -185,13 +185,22 @@ func TestCurateLowQualityDropsNoArtifact(t *testing.T) {
 func TestCurateUnverifiedDropsNoArtifact(t *testing.T) {
 	inv := goodFinding()
 	inv.Verified = false // identical to the happy-path finding, but verify did not confirm it
-	f := &fakeForge{}
+	// An open PR carrying this finding's exact fingerprint marker: an unverified
+	// finding must NOT coalesce a comment onto it — a comment is a repo artifact too.
+	f := &fakeForge{openPRs: []providers.CuratedIssue{{
+		Number: 7,
+		Title:  "KB: prior",
+		Body:   "Drafted by RunLore\n\n" + providers.FingerprintMarker(DupFingerprint(inv)),
+	}}}
 	c := &Curator{Forge: f, MinConfidence: 0.75, Log: testLogger()}
 	if _, err := c.Curate(context.Background(), inv); err != nil {
 		t.Fatalf("Curate: %v", err)
 	}
 	if f.openedPR != nil {
 		t.Fatal("an unverified finding must not draft a KB PR")
+	}
+	if len(f.commented) != 0 {
+		t.Fatalf("an unverified finding must not coalesce a comment onto an open PR, got %v", f.commented)
 	}
 }
 

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -84,10 +84,18 @@ func DupFingerprint(inv providers.Investigation) string {
 		cause = inv.RootCauses[0].Summary
 	}
 	tokens := tokenSet(cause)
-	if ref == "" && len(tokens) == 0 {
+	causeKey := strings.Join(tokens, " ")
+	if len(tokens) == 0 {
+		// The token-set erased the whole cause (all sub-3-char or stopword tokens,
+		// e.g. "IO GC" or "db up"). Fall back to the raw lowercased summary so two
+		// genuinely different terse/acronym causes on the same resource do not
+		// collapse to the same fingerprint and falsely coalesce.
+		causeKey = strings.ToLower(strings.TrimSpace(cause))
+	}
+	if ref == "" && causeKey == "" {
 		return ""
 	}
-	sum := sha256.Sum256([]byte(ref + "|" + strings.Join(tokens, " ")))
+	sum := sha256.Sum256([]byte(ref + "|" + causeKey))
 	return hex.EncodeToString(sum[:])
 }
 

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -160,3 +160,20 @@ func TestDupFingerprintGoldenValue(t *testing.T) {
 		t.Fatalf("golden fingerprint mismatch: expected %q, got %q", expected, got)
 	}
 }
+
+// TestDupFingerprintDiffersByTerseAcronymCause guards against a false-collision:
+// two different terse/acronym causes on the SAME resource whose tokens all filter
+// out (sub-3-char / stopwords) must not hash to the same fingerprint (which would
+// silently coalesce unrelated incidents). The raw-summary fallback prevents it.
+func TestDupFingerprintDiffersByTerseAcronymCause(t *testing.T) {
+	res := providers.Workload{Namespace: "apps", Name: "web"}
+	a := providers.Investigation{Resource: res, RootCauses: []providers.Hypothesis{{Summary: "IO GC"}}}
+	b := providers.Investigation{Resource: res, RootCauses: []providers.Hypothesis{{Summary: "db up"}}}
+	fa, fb := DupFingerprint(a), DupFingerprint(b)
+	if fa == "" || fb == "" {
+		t.Fatalf("a terse cause on a known resource must still produce a fingerprint: %q %q", fa, fb)
+	}
+	if fa == fb {
+		t.Fatalf("different terse causes on the same resource must not collide: both %q", fa)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,7 +93,7 @@ func New(cfg *config.Config, enq investigate.Enqueuer, ready func() bool, acts A
 	})
 	mux.HandleFunc("GET /readyz", func(w http.ResponseWriter, _ *http.Request) {
 		if s.ready != nil && !s.ready() {
-			http.Error(w, "not ready (standby)", http.StatusServiceUnavailable)
+			http.Error(w, "not ready", http.StatusServiceUnavailable)
 			return
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Post-merge audit fixes

A 6-agent parallel audit of today's roadmap batch (PRs #81–#87) found **two real bugs** plus gaps. #7, #13, and all cross-item seams reviewed **clean**; build/vet/gofmt/`-race` and the full k3d e2e (**PASS=40 FAIL=0**) pass after these fixes.

### Critical — `DupFingerprint` false collision
When a finding has a non-empty resource but a cause whose tokens all filter out (sub-3-char / stopwords — e.g. `"IO GC"`, `"db up"`), the cause key reduced to empty, so the canonical input became `"resource|"` for **any** such cause → different incidents hashed identically → **silent false coalescing** onto one PR. The empty-guard only fired when the resource was *also* empty. Fix: fall back to the raw lowercased summary when the token-set is empty. The golden hash is unchanged (non-empty-token inputs are unaffected); added a terse-cause regression test.

### Important — unverified finding posts a coalesce comment
`duplicateOpenPR` ran **before** `meetsBar`, so an unverified finding matching an open PR's fingerprint marker posted a coalesce *comment* — a repo artifact — violating #16's "no artifact" contract. The existing test passed vacuously (empty fake forge). Fix: move the quality gate to the **top** of `Curate` (below-bar findings now produce zero repo artifacts); the test now seeds a matching open PR and asserts no comment.

### Important — `stale_after: 0` could not disable the lifecycle sweep
`runCurate` forced `staleAfter 0→720h`, so the documented opt-out didn't work. Fix: honour `0`/unset as disabled (`Lifecycle.Run` already returns early); the chart ships `720h`, so scheduled runs still sweep and a bare `lore curate` does dedup only.

### Minor
- `/readyz` 503 body `"not ready (standby)"` → `"not ready"` (misleading for a catalog-cold leader).
- Added `TestRunReloadsOnlyOnChange` — the #18 onSync-only-on-change gate had no behavioural test.
- Added a `curate.stale_after` config-parse test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)