### PR TITLE
feat(curate): wire Queue + Recurrence Phase-2 passes (ledger-backed, source-neutral)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -778,11 +778,10 @@ func buildCurator(cfg *config.Config, token forgeToken, cat *catalog.Catalog, me
 
 // runCurate grooms the KB backlog (Phase-2 curation agent). It runs the
 // backlog-dedup pass (collapses duplicate open PRs across history) and the
-// lifecycle sweep (closes stale, unprotected PRs by forge age). The
-// resolution-gated decision-ready queue and the recurrence→gap-issue pass are
-// implemented + tested in internal/curate but still need wiring: Queue needs a
-// ResolutionChecker (alert/ledger join), Recurrence needs an idempotent
-// ledger-backed driver over Episodes() — follow-up.
+// lifecycle sweep (closes stale, unprotected PRs by forge age). When
+// outcome.ledger_path is configured, it also runs the Queue pass (promotes
+// solved→ready-to-merge when the incident resolves) and the Recurrence pass
+// (opens a knowledge-gap issue for repeatedly-unresolved patterns).
 func runCurate(args []string) error {
 	fs := flag.NewFlagSet("curate", flag.ContinueOnError)
 	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
@@ -817,6 +816,20 @@ func runCurate(args []string) error {
 		curate.Dedup{Forge: forge, Log: log},
 		curate.Lifecycle{Forge: forge, StaleAfter: cfg.Curate.StaleAfter.Std(), Log: log},
 	}}
+	// Queue + Recurrence read the outcome ledger; wire them only when it is configured.
+	if cfg.Outcome.LedgerPath != "" {
+		ledger, lerr := outcome.New(cfg.Outcome.LedgerPath)
+		if lerr != nil {
+			return fmt.Errorf("open outcome ledger %q: %w", cfg.Outcome.LedgerPath, lerr)
+		}
+		agent.Passes = append(agent.Passes,
+			curate.Queue{Forge: forge, Checker: curate.LedgerResolutionChecker{Ledger: ledger}, Log: log},
+			curate.Recurrence{Forge: forge, Ledger: ledger, Threshold: cfg.Curate.RecurrenceThreshold, Log: log},
+		)
+		log.Info("curate: Queue + Recurrence enabled", "ledger", cfg.Outcome.LedgerPath)
+	} else {
+		log.Info("curate: outcome ledger not configured; Queue + Recurrence passes skipped")
+	}
 	log.Info("curate: grooming KB backlog", "repo", cfg.Forge.KBRepo)
 	agent.Run(context.Background())
 	return nil

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -54,11 +54,13 @@ config:
   # Enable when a VMServiceScrape (or ServiceMonitor) will scrape this agent.
   telemetry:
     metrics_enabled: false
-  # Phase-2 backlog groomer (lore curate) — lifecycle staleness window. Applied
-  # whenever `lore curate` runs (the CronJob or a manual invocation); 0 disables the
-  # stale-PR sweep.
+  # Phase-2 backlog groomer (lore curate). `stale_after` drives the lifecycle sweep;
+  # the Queue (promote solved→ready-to-merge on resolution) and Recurrence
+  # (open a knowledge-gap issue for repeatedly-unresolved patterns) passes also run
+  # when config.outcome.ledger_path is set (they read the outcome ledger).
   curate:
-    stale_after: 720h   # close unprotected KB PRs idle longer than this; 0 disables
+    stale_after: 720h          # close unprotected KB PRs idle longer than this; 0 disables
+    recurrence_threshold: 3    # open a knowledge-gap issue after this many unresolved occurrences; 0 ⇒ 3
   # model:
   #   base_url: https://vllm.svc/v1
   #   model: <model-name>

--- a/docs/superpowers/plans/2026-06-24-curate-queue-recurrence.md
+++ b/docs/superpowers/plans/2026-06-24-curate-queue-recurrence.md
@@ -1,0 +1,570 @@
+# Wire Queue + Recurrence curation passes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up the two dormant Phase-2 curation passes — `Queue` (promote a solved PR to ready-to-merge when its incident resolved) and `Recurrence` (open one knowledge-gap issue when an unresolved pattern recurs) — both ledger-backed and idempotent.
+
+**Architecture:** Both read the outcome ledger via `Episodes()` (no source-specific API). `LedgerResolutionChecker` joins a PR to its incident by exact title (`"KB: "+inv.Title` ↔ `Episode.Title`). `Recurrence.Run` recomputes unresolved-pattern counts from the ledger each run and is idempotent because the forge's existing knowledge-gap issues are the "already-opened" record. `runCurate` wires both when `outcome.ledger_path` is configured.
+
+**Tech Stack:** Go 1.26, standard library (`strings`, `fmt`), existing `internal/outcome` + `internal/curate` packages.
+
+## Global Constraints
+
+- Go 1.26, no new third-party dependencies.
+- Both passes touch only the KB forge (relabel a PR / open an issue) — never the cluster. They run only under the opt-in curate CronJob.
+- The resolution/recurrence signal is the outcome ledger's events — **source-neutral** (no Alertmanager-specific code).
+- Knowledge-gap artifacts are *issues*; the `Lifecycle` stale-sweep lists *PRs* only, so they are never auto-closed. Do not change that.
+- `Recurrence` default threshold is **3** when unset/zero.
+- The `Episodes()` dependency is taken as a small interface `interface{ Episodes() ([]outcome.Episode, error) }` for test-fakeability; the concrete `*outcome.Ledger` satisfies it. (`curate` may import `outcome`; there is no cycle.)
+- After each task: `go build ./... && go vet ./... && go test ./...` green and `gofmt -l .` empty.
+
+---
+
+### Task 1: `LedgerResolutionChecker` + Queue-through-ledger
+
+**Files:**
+- Modify: `internal/curate/resolution.go`
+- Test: `internal/curate/resolution_test.go`
+
+**Interfaces:**
+- Consumes: `outcome.Episode` (fields `Title string`, `Resource string`, `Resolved bool`), `providers.CuratedIssue` (`Number int`, `Title string`, `Labels []string`), existing `Queue`.
+- Produces: `type LedgerResolutionChecker struct { Ledger interface{ Episodes() ([]outcome.Episode, error) } }` with `func (c LedgerResolutionChecker) IsResolved(ctx context.Context, pr providers.CuratedIssue) (bool, error)`. A shared test fake `type fakeLedger struct{ eps []outcome.Episode }` with `Episodes()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/curate/resolution_test.go` (it already imports `context`, `io`, `log/slog`, `testing`, `providers`; add `"github.com/Smana/runlore/internal/outcome"`):
+
+```go
+// fakeLedger is a fixed Episodes() source for resolution/recurrence tests.
+type fakeLedger struct{ eps []outcome.Episode }
+
+func (f fakeLedger) Episodes() ([]outcome.Episode, error) { return f.eps, nil }
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestLedgerResolutionCheckerResolvedTitle(t *testing.T) {
+	c := LedgerResolutionChecker{Ledger: fakeLedger{eps: []outcome.Episode{
+		{Title: "HarborRegistryDown", Resolved: true},
+		{Title: "Other", Resolved: false},
+	}}}
+	got, err := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: HarborRegistryDown"})
+	if err != nil || !got {
+		t.Fatalf("a resolved episode with the PR's title must be resolved=true; got %v err=%v", got, err)
+	}
+}
+
+func TestLedgerResolutionCheckerUnresolved(t *testing.T) {
+	c := LedgerResolutionChecker{Ledger: fakeLedger{eps: []outcome.Episode{
+		{Title: "HarborRegistryDown", Resolved: false}, // opened, never resolved
+	}}}
+	got, _ := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: HarborRegistryDown"})
+	if got {
+		t.Fatal("an unresolved episode must yield resolved=false")
+	}
+	// absent entirely → false
+	if got, _ := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: Unknown"}); got {
+		t.Fatal("a title with no episode must yield resolved=false")
+	}
+}
+
+func TestLedgerResolutionCheckerEmptyTitle(t *testing.T) {
+	c := LedgerResolutionChecker{Ledger: fakeLedger{eps: []outcome.Episode{{Title: "", Resolved: true}}}}
+	if got, _ := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: "}); got {
+		t.Fatal("an empty title must never match (avoids resolving on a blank episode)")
+	}
+}
+
+func TestQueuePromotesResolvedViaLedger(t *testing.T) {
+	f := &recordingForge{prs: []providers.CuratedIssue{
+		{Number: 48, Title: "KB: HarborRegistryDown", Labels: []string{"runlore", "solved"}},
+		{Number: 50, Title: "KB: StillBroken", Labels: []string{"runlore", "solved"}},
+	}}
+	led := fakeLedger{eps: []outcome.Episode{{Title: "HarborRegistryDown", Resolved: true}}}
+	q := Queue{Forge: f, Checker: LedgerResolutionChecker{Ledger: led}, Log: discardLog()}
+	if err := q.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.relabel[48] != "ready-to-merge" {
+		t.Fatalf("the resolved PR #48 should be queued ready-to-merge, got %v", f.relabel)
+	}
+	if _, ok := f.relabel[50]; ok {
+		t.Fatalf("the unresolved PR #50 must not be queued, got %v", f.relabel)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `go test ./internal/curate/ -run 'LedgerResolutionChecker|QueuePromotesResolvedViaLedger' -v`
+Expected: FAIL — `LedgerResolutionChecker` undefined.
+
+- [ ] **Step 3: Implement `LedgerResolutionChecker`**
+
+In `internal/curate/resolution.go`, add `"strings"` and `"github.com/Smana/runlore/internal/outcome"` to the imports, and append:
+
+```go
+// LedgerResolutionChecker reports a curated PR's incident has resolved when the
+// outcome ledger holds a resolved episode whose title matches the PR's. A curated
+// PR's title is "KB: " + the incident title, and the ledger records each open with
+// that same incident title — so the join is an exact title match. Source-agnostic:
+// it reads the ledger's resolve events, never a trigger-specific API.
+type LedgerResolutionChecker struct {
+	Ledger interface {
+		Episodes() ([]outcome.Episode, error)
+	}
+}
+
+// IsResolved implements ResolutionChecker.
+func (c LedgerResolutionChecker) IsResolved(_ context.Context, pr providers.CuratedIssue) (bool, error) {
+	title := strings.TrimSpace(strings.TrimPrefix(pr.Title, "KB: "))
+	if title == "" {
+		return false, nil
+	}
+	eps, err := c.Ledger.Episodes()
+	if err != nil {
+		return false, err
+	}
+	for _, e := range eps {
+		if e.Resolved && e.Title == title {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `go test ./internal/curate/ -run 'LedgerResolutionChecker|QueuePromotesResolvedViaLedger' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Full package + gofmt**
+
+Run: `go test ./internal/curate/ && gofmt -l internal/curate/`
+Expected: PASS; gofmt prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/curate/resolution.go internal/curate/resolution_test.go
+git commit -m "feat(curate): LedgerResolutionChecker — resolve a PR's incident via the outcome ledger"
+```
+
+---
+
+### Task 2: ledger-driven `Recurrence.Run` (replaces `Store`/`Observe`)
+
+**Files:**
+- Modify: `internal/curate/recurrence.go`
+- Modify: `internal/curate/resolution_test.go` (add an `issues` field to `recordingForge`)
+- Test: `internal/curate/recurrence_test.go` (rewrite)
+
+**Interfaces:**
+- Consumes: `outcome.Episode`, `fakeLedger` (Task 1), `Forge` (`ListIssuesByLabel`, `OpenIssue`).
+- Produces: `type Recurrence struct { Forge Forge; Ledger interface{ Episodes() ([]outcome.Episode, error) }; Threshold int; Log *slog.Logger }` with `func (r Recurrence) Run(ctx context.Context) error`; `const gapTitlePrefix = "knowledge-gap: "`; `func recurrencePattern(e outcome.Episode) string`. The old `RecurrenceStore`/`Observe` are removed.
+
+- [ ] **Step 1: Give `recordingForge` an issues list**
+
+In `internal/curate/resolution_test.go`, change the `recordingForge` struct and its `ListIssuesByLabel` so existing knowledge-gap issues can be returned (the recurrence idempotency guard needs this):
+
+```go
+type recordingForge struct {
+	prs     []providers.CuratedIssue
+	issues  []providers.CuratedIssue // returned by ListIssuesByLabel
+	relabel map[int]string           // number -> added label
+}
+```
+
+and:
+
+```go
+func (f *recordingForge) ListIssuesByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return f.issues, nil
+}
+```
+
+(Leave the other `recordingForge` methods unchanged.)
+
+- [ ] **Step 2: Rewrite the recurrence tests**
+
+Replace the entire body of `internal/curate/recurrence_test.go` with (note `memStore` is gone; `gapForge` stays):
+
+```go
+package curate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// gapForge records the issue titles it was asked to open. It embeds recordingForge
+// (which supplies ListIssuesByLabel from its `issues` field) and overrides OpenIssue.
+type gapForge struct {
+	*recordingForge
+	openedTitles []string
+}
+
+func (g *gapForge) OpenIssue(_ context.Context, inv providers.Investigation) (providers.Ref, error) {
+	g.openedTitles = append(g.openedTitles, inv.Title)
+	return providers.Ref{URL: "https://github.com/x/y/issues/1"}, nil
+}
+
+func unresolved(pattern string, n int) []outcome.Episode {
+	eps := make([]outcome.Episode, n)
+	for i := range eps {
+		eps[i] = outcome.Episode{Resource: pattern, Resolved: false}
+	}
+	return eps
+}
+
+func TestRecurrenceOpensGapIssueAtThreshold(t *testing.T) {
+	eps := append(unresolved("apps/web", 3), outcome.Episode{Resource: "apps/worker", Resolved: false}) // worker: only 1
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: eps}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 1 || gf.openedTitles[0] != "knowledge-gap: apps/web" {
+		t.Fatalf("want one gap issue for apps/web, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceBelowThresholdNoIssue(t *testing.T) {
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: unresolved("apps/web", 2)}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("below threshold must open nothing, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceIdempotentWhenIssueExists(t *testing.T) {
+	gf := &gapForge{recordingForge: &recordingForge{
+		issues: []providers.CuratedIssue{{Title: "knowledge-gap: apps/web"}}, // already open
+	}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: unresolved("apps/web", 5)}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("an existing gap issue must prevent a duplicate, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceResolvedEpisodesDoNotCount(t *testing.T) {
+	eps := []outcome.Episode{
+		{Resource: "apps/web", Resolved: true}, {Resource: "apps/web", Resolved: true},
+		{Resource: "apps/web", Resolved: false}, // only 1 unresolved
+	}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: eps}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("resolved episodes must not count, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrencePatternFallsBackToTitle(t *testing.T) {
+	eps := []outcome.Episode{
+		{Title: "DNSFailure", Resolved: false}, {Title: "DNSFailure", Resolved: false}, {Title: "DNSFailure", Resolved: false},
+	}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: eps}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 1 || gf.openedTitles[0] != "knowledge-gap: DNSFailure" {
+		t.Fatalf("a resource-less episode should group by title, got %v", gf.openedTitles)
+	}
+}
+```
+
+- [ ] **Step 3: Run to verify they fail**
+
+Run: `go test ./internal/curate/ -run TestRecurrence -v`
+Expected: FAIL to compile — `Recurrence` has no `Ledger`/`Run` (still the old `Store`/`Observe`).
+
+- [ ] **Step 4: Rewrite `recurrence.go`**
+
+Replace the entire contents of `internal/curate/recurrence.go` with:
+
+```go
+package curate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// gapTitlePrefix titles every knowledge-gap issue; it is also the existence-check
+// key (the pass opens at most one issue per pattern).
+const gapTitlePrefix = "knowledge-gap: "
+
+// Recurrence opens ONE knowledge-gap issue when an unresolved incident pattern recurs
+// at least Threshold times. It is ledger-driven and idempotent: it recomputes counts
+// from the outcome ledger every run and opens an issue only when no knowledge-gap
+// issue for that pattern already exists — so re-running never double-opens (no mutable
+// store or watermark).
+type Recurrence struct {
+	Forge  Forge
+	Ledger interface {
+		Episodes() ([]outcome.Episode, error)
+	}
+	Threshold int // default 3 when 0
+	Log       *slog.Logger
+}
+
+// Run opens a knowledge-gap issue for each pattern that crosses the threshold and has
+// none open yet.
+func (r Recurrence) Run(ctx context.Context) error {
+	thr := r.Threshold
+	if thr == 0 {
+		thr = 3
+	}
+	eps, err := r.Ledger.Episodes()
+	if err != nil {
+		return fmt.Errorf("recurrence: load episodes: %w", err)
+	}
+	// Count UNRESOLVED occurrences per pattern (affected resource; title fallback).
+	counts := map[string]int{}
+	for _, e := range eps {
+		if e.Resolved {
+			continue
+		}
+		counts[recurrencePattern(e)]++
+	}
+	// Existing knowledge-gap issues are the idempotency guard. OpenIssue labels issues
+	// "runlore"/"triggered" and titles them gapTitlePrefix+pattern, so match by title.
+	existing, err := r.Forge.ListIssuesByLabel(ctx, "runlore")
+	if err != nil {
+		return fmt.Errorf("recurrence: list issues: %w", err)
+	}
+	open := map[string]bool{}
+	for _, iss := range existing {
+		if p, ok := strings.CutPrefix(iss.Title, gapTitlePrefix); ok {
+			open[p] = true
+		}
+	}
+	for pattern, n := range counts {
+		if n < thr || open[pattern] {
+			continue
+		}
+		inv := providers.Investigation{
+			Title: gapTitlePrefix + pattern,
+			RootCauses: []providers.Hypothesis{{
+				Summary: fmt.Sprintf("RunLore could not resolve incidents on %q across %d occurrences — needs seeded knowledge or a RunLore fix.", pattern, n),
+			}},
+		}
+		if _, err := r.Forge.OpenIssue(ctx, inv); err != nil {
+			r.Log.Warn("recurrence: open knowledge-gap issue failed", "pattern", pattern, "err", err)
+			continue // best-effort; other patterns still processed
+		}
+		r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", n)
+	}
+	return nil
+}
+
+// recurrencePattern groups unresolved incidents by the affected resource, falling
+// back to the incident title when no resource was identified.
+func recurrencePattern(e outcome.Episode) string {
+	if e.Resource != "" {
+		return e.Resource
+	}
+	return e.Title
+}
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+Run: `go test ./internal/curate/ -run TestRecurrence -v`
+Expected: PASS.
+
+- [ ] **Step 6: Full package + build + gofmt**
+
+Run: `go build ./... && go test ./internal/curate/ && gofmt -l internal/curate/`
+Expected: build PASS (no leftover references to the removed `RecurrenceStore`/`Observe`); tests PASS; gofmt prints nothing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/curate/recurrence.go internal/curate/recurrence_test.go internal/curate/resolution_test.go
+git commit -m "feat(curate): ledger-driven Recurrence.Run (idempotent via existing-issue check)"
+```
+
+---
+
+### Task 3: `curate.recurrence_threshold` config
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Test: `internal/config/config_test.go`
+
+**Interfaces:**
+- Produces: `Curate.RecurrenceThreshold int` (`yaml:"recurrence_threshold"`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/config/config_test.go` (it already imports `time`, `yaml`):
+
+```go
+func TestCurateRecurrenceThresholdParse(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("curate:\n  recurrence_threshold: 5\n"), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Curate.RecurrenceThreshold != 5 {
+		t.Fatalf("recurrence_threshold: want 5, got %d", c.Curate.RecurrenceThreshold)
+	}
+	// Absent ⇒ zero ⇒ the pass applies its own default (3).
+	var z Config
+	if err := yaml.Unmarshal([]byte("curate:\n  stale_after: 240h\n"), &z); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if z.Curate.RecurrenceThreshold != 0 {
+		t.Fatalf("absent recurrence_threshold must be 0, got %d", z.Curate.RecurrenceThreshold)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/config/ -run TestCurateRecurrenceThresholdParse -v`
+Expected: FAIL — `Curate` has no `RecurrenceThreshold` field.
+
+- [ ] **Step 3: Add the field**
+
+In `internal/config/config.go`, extend the `Curate` struct:
+
+```go
+type Curate struct {
+	StaleAfter          Duration `yaml:"stale_after"`          // close unprotected KB PRs idle longer than this; 0 disables (default 720h)
+	RecurrenceThreshold int      `yaml:"recurrence_threshold"` // open a knowledge-gap issue after this many unresolved occurrences of a pattern; 0 ⇒ default 3
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/config/ -run TestCurateRecurrenceThresholdParse -v`
+Expected: PASS.
+
+- [ ] **Step 5: Build + gofmt**
+
+Run: `go build ./... && gofmt -l internal/config/`
+Expected: build PASS; gofmt prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): curate.recurrence_threshold knob"
+```
+
+---
+
+### Task 4: wire Queue + Recurrence into `runCurate` + chart note
+
+**Files:**
+- Modify: `cmd/lore/main.go` (the `runCurate` agent construction)
+- Modify: `deploy/helm/runlore/values.yaml` (curate comment)
+
+**Interfaces:**
+- Consumes: `curate.Queue`, `curate.LedgerResolutionChecker`, `curate.Recurrence` (Tasks 1-2), `cfg.Curate.RecurrenceThreshold` (Task 3), `cfg.Outcome.LedgerPath`, `outcome.New` (already imported in `main.go`).
+
+- [ ] **Step 1: Wire the passes**
+
+In `cmd/lore/main.go`'s `runCurate`, replace the agent construction (currently `curate.Dedup` + `curate.Lifecycle`) and its `agent.Run` call with:
+
+```go
+	agent := curate.Agent{Log: log, Passes: []curate.Pass{
+		curate.Dedup{Forge: forge, Log: log},
+		curate.Lifecycle{Forge: forge, StaleAfter: cfg.Curate.StaleAfter.Std(), Log: log},
+	}}
+	// Queue + Recurrence read the outcome ledger; wire them only when it is configured.
+	if cfg.Outcome.LedgerPath != "" {
+		ledger, lerr := outcome.New(cfg.Outcome.LedgerPath)
+		if lerr != nil {
+			return fmt.Errorf("open outcome ledger %q: %w", cfg.Outcome.LedgerPath, lerr)
+		}
+		agent.Passes = append(agent.Passes,
+			curate.Queue{Forge: forge, Checker: curate.LedgerResolutionChecker{Ledger: ledger}, Log: log},
+			curate.Recurrence{Forge: forge, Ledger: ledger, Threshold: cfg.Curate.RecurrenceThreshold, Log: log},
+		)
+		log.Info("curate: Queue + Recurrence enabled", "ledger", cfg.Outcome.LedgerPath)
+	} else {
+		log.Info("curate: outcome ledger not configured; Queue + Recurrence passes skipped")
+	}
+	log.Info("curate: grooming KB backlog", "repo", cfg.Forge.KBRepo)
+	agent.Run(context.Background())
+```
+
+Confirm `cmd/lore/main.go` imports `outcome` (`github.com/Smana/runlore/internal/outcome`) — it does (the serve path opens the ledger). `fmt` is imported.
+
+- [ ] **Step 2: Build + vet + full suite + gofmt**
+
+Run: `go build ./... && go vet ./... && go test ./... && gofmt -l .`
+Expected: all PASS; gofmt prints nothing.
+
+- [ ] **Step 3: Manual smoke — curate still parses + runs with a ledger configured**
+
+```bash
+printf 'forge:\n  kb_repo: o/r\noutcome:\n  ledger_path: /tmp/curate-ledger.jsonl\ncurate:\n  recurrence_threshold: 3\n' > /tmp/curate-smoke.yaml
+go run ./cmd/lore curate -config /tmp/curate-smoke.yaml 2>&1 | head -3 || true
+```
+Expected: it parses the config and then fails on the missing GitHub App (`curate requires a configured GitHub App`) — NOT a yaml/ledger/flag error. (The ledger path need not exist; `outcome.New` tolerates an absent file.)
+
+- [ ] **Step 4: Update the chart comment**
+
+In `deploy/helm/runlore/values.yaml`, update the `config.curate` comment to note the ledger requirement (find the block added in #12):
+
+```yaml
+  # Phase-2 backlog groomer (lore curate). `stale_after` drives the lifecycle sweep;
+  # the Queue (promote solved→ready-to-merge on resolution) and Recurrence
+  # (open a knowledge-gap issue for repeatedly-unresolved patterns) passes also run
+  # when config.outcome.ledger_path is set (they read the outcome ledger).
+  curate:
+    stale_after: 720h          # close unprotected KB PRs idle longer than this; 0 disables
+    recurrence_threshold: 3    # open a knowledge-gap issue after this many unresolved occurrences; 0 ⇒ 3
+```
+
+(Keep `stale_after`'s existing value; add the `recurrence_threshold` line and the comment update.)
+
+- [ ] **Step 5: Render smoke**
+
+Run: `helm template t deploy/helm/runlore | python3 -c "import sys,yaml; list(yaml.safe_load_all(sys.stdin)); print('helm yaml ok')"`
+Expected: `helm yaml ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/lore/main.go deploy/helm/runlore/values.yaml
+git commit -m "feat(curate): wire Queue + Recurrence in lore curate when the ledger is configured"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `LedgerResolutionChecker` (exact title join, reuse `Episodes()`) → Task 1. ✅
+- Ledger-driven `Recurrence.Run`, idempotent existence-check, pattern = resource/title → Task 2. ✅
+- Remove `Store`/`Observe` → Task 2. ✅
+- `cfg.Curate.RecurrenceThreshold` (default 3) → Task 3. ✅
+- `runCurate` wires both only when `outcome.ledger_path` set → Task 4. ✅
+- Source-neutral (ledger only), forge-only writes, gap issues immune to stale-sweep → Tasks 1-2 (no Lifecycle change). ✅
+- Chart comment (no behavioral change) → Task 4. ✅
+
+**Placeholder scan:** every step shows complete code; no TBD/TODO. ✅
+
+**Type consistency:** `LedgerResolutionChecker.Ledger` and `Recurrence.Ledger` use the same `interface{ Episodes() ([]outcome.Episode, error) }`; `fakeLedger`/`discardLog`/`recordingForge.issues`/`gapForge` defined in Task 1/2 and reused consistently; `gapTitlePrefix`/`recurrencePattern` defined in Task 2; `Queue` is the existing type (unchanged). The `outcome.Episode` fields used (`Title`, `Resource`, `Resolved`) match `internal/outcome/ledger.go`. ✅

--- a/docs/superpowers/specs/2026-06-24-curate-queue-recurrence-design.md
+++ b/docs/superpowers/specs/2026-06-24-curate-queue-recurrence-design.md
@@ -1,0 +1,232 @@
+# Wire the Queue + Recurrence Phase-2 curation passes — design (roadmap #12 follow-up)
+
+| | |
+|---|---|
+| **Date** | 2026-06-24 |
+| **Roadmap item** | #12 (deferred passes) — light up `Queue` and `Recurrence` |
+| **Depends on** | #8 (`Episodes()` ledger read API, merged), #12 (curate CronJob + Dedup/Lifecycle, merged) |
+| **Effort** | M |
+
+## Problem
+
+`internal/curate/` has four grooming passes. After #12, `runCurate` wires only `Dedup`
+and `Lifecycle`. The other two were deferred because their *correct* wiring needed a
+design decision rather than mechanical plumbing:
+
+- **`Queue`** (`resolution.go`) promotes a human-`solved` PR to `ready-to-merge` once
+  the incident behind it has resolved (or a human added `accepted`). It needs a real
+  `ResolutionChecker` — a way to ask "has this PR's incident cleared?"
+- **`Recurrence`** (`recurrence.go`) opens **one** knowledge-gap issue when an
+  unresolved pattern recurs N times. Its current `Store`/`Observe` increment model is
+  not a `Run()` pass and double-opens if driven naively from a full ledger replay.
+
+This spec wires both, **ledger-backed and idempotent**, reusing #8's `Episodes()`.
+
+## Source-neutrality (design principle)
+
+RunLore's trigger/event sources are **pluggable** (incident webhook, GitOps
+failures, timer, chat, CLI). This design does **not** assume Alertmanager. The
+resolution signal is the **outcome ledger's `resolve` events** — recorded by whatever
+source reports an incident cleared (an Alertmanager resolved-alert today; another
+source tomorrow). Both passes read the ledger, never a source-specific API, so they
+stay source-agnostic.
+
+## Design
+
+### A. `Queue` — `LedgerResolutionChecker`
+
+The join from a curated PR back to its incident is an **exact title match**, which
+holds by construction:
+
+- A curated PR's title is `"KB: " + inv.Title` (`github.OpenPR`).
+- The outcome ledger records each open with `Title: inv.Title` (`ledger.Open` in
+  `main.go`), surfaced as `Episode.Title`.
+
+```go
+// LedgerResolutionChecker reports a PR's incident resolved when the outcome ledger
+// holds a resolved episode whose title matches the PR's. Source-agnostic: it reads
+// the ledger's resolve events, never a trigger-specific API.
+type LedgerResolutionChecker struct {
+    Ledger interface{ Episodes() ([]outcome.Episode, error) }
+}
+
+func (c LedgerResolutionChecker) IsResolved(ctx context.Context, pr providers.CuratedIssue) (bool, error) {
+    title := strings.TrimSpace(strings.TrimPrefix(pr.Title, "KB: "))
+    if title == "" {
+        return false, nil
+    }
+    eps, err := c.Ledger.Episodes()
+    if err != nil {
+        return false, err
+    }
+    for _, e := range eps {
+        if e.Resolved && e.Title == title {
+            return true, nil
+        }
+    }
+    return false, nil
+}
+```
+
+No new markers, no curator (serve-path) change, no new ledger method — it reuses
+`Episodes()`. A PR whose incident has not resolved simply waits for a human
+`accepted` label, exactly as `Queue` already handles. `Queue.Run` is unchanged.
+
+The checker depends on the small `Episodes()` interface above (not `*outcome.Ledger`
+directly) purely for **test-fakeability** — a fake episodes source in tests. There is
+no import cycle: `curate` may import `outcome` freely (`outcome` does not import
+`curate`); the interface still references `outcome.Episode`.
+
+### B. `Recurrence` — ledger-driven `Run`, idempotent via existence-check
+
+Replace the dormant `Store`/`Observe` increment model with a `Run(ctx)` pass that
+recomputes from the ledger each run and is idempotent because the forge's existing
+issues are the "already-opened" record (no mutable store, no watermark):
+
+```go
+type Recurrence struct {
+    Forge     Forge
+    Ledger    interface{ Episodes() ([]outcome.Episode, error) }
+    Threshold int // default 3 when 0
+    Log       *slog.Logger
+}
+
+func (r Recurrence) Run(ctx context.Context) error {
+    thr := r.Threshold
+    if thr == 0 { thr = 3 }
+    eps, err := r.Ledger.Episodes()
+    if err != nil { return err }
+
+    // Count UNRESOLVED episodes per pattern (affected resource; title fallback).
+    counts := map[string]int{}
+    for _, e := range eps {
+        if e.Resolved { continue }
+        counts[recurrencePattern(e)]++
+    }
+
+    // Existing knowledge-gap issues — the idempotency guard. Match by title among
+    // runlore issues (OpenIssue labels them runlore/triggered, titles them
+    // "knowledge-gap: <pattern>").
+    existing, err := r.Forge.ListIssuesByLabel(ctx, "runlore")
+    if err != nil { return err }
+    open := map[string]bool{}
+    for _, iss := range existing {
+        if p, ok := strings.CutPrefix(iss.Title, gapTitlePrefix); ok {
+            open[p] = true
+        }
+    }
+
+    for pattern, n := range counts {
+        if n < thr || open[pattern] { continue }
+        inv := providers.Investigation{
+            Title: gapTitlePrefix + pattern,
+            RootCauses: []providers.Hypothesis{{
+                Summary: fmt.Sprintf("RunLore could not resolve incidents on %q across %d occurrences — needs seeded knowledge or a RunLore fix.", pattern, n),
+            }},
+        }
+        if _, err := r.Forge.OpenIssue(ctx, inv); err != nil {
+            r.Log.Warn("recurrence: open knowledge-gap issue failed", "pattern", pattern, "err", err)
+            continue // best-effort; other patterns still processed
+        }
+        r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", n)
+    }
+    return nil
+}
+
+const gapTitlePrefix = "knowledge-gap: "
+
+// recurrencePattern groups unresolved incidents by the affected resource, falling
+// back to the incident title when no resource was identified.
+func recurrencePattern(e outcome.Episode) string {
+    if e.Resource != "" { return e.Resource }
+    return e.Title
+}
+```
+
+The old `RecurrenceStore` interface + `Observe` method are **removed** (the pass was
+never wired, so there are no consumers); `recurrence_test.go` is rewritten for `Run`.
+
+Map-iteration order is irrelevant: each qualifying pattern opens at most one issue per
+run, guarded by `open[pattern]`; ordering does not affect the outcome.
+
+### C. Wiring & config (`runCurate`, `cmd/lore/main.go`)
+
+`runCurate` opens the outcome ledger **read-only** (same path the serve process
+writes) and adds both passes when it is configured:
+
+```go
+agent := curate.Agent{Log: log, Passes: []curate.Pass{
+    curate.Dedup{Forge: forge, Log: log},
+    curate.Lifecycle{Forge: forge, StaleAfter: cfg.Curate.StaleAfter.Std(), Log: log},
+}}
+if cfg.Outcome.LedgerPath != "" {
+    ledger, err := outcome.New(cfg.Outcome.LedgerPath)
+    if err != nil {
+        return fmt.Errorf("open outcome ledger: %w", err)
+    }
+    agent.Passes = append(agent.Passes,
+        curate.Queue{Forge: forge, Checker: curate.LedgerResolutionChecker{Ledger: ledger}, Log: log},
+        curate.Recurrence{Forge: forge, Ledger: ledger, Threshold: cfg.Curate.RecurrenceThreshold, Log: log},
+    )
+} else {
+    log.Info("curate: outcome ledger not configured; Queue + Recurrence passes skipped")
+}
+```
+
+- New config field `cfg.Curate.RecurrenceThreshold int` (`yaml:"recurrence_threshold"`,
+  default 3 when 0).
+- `outcome.New` already tolerates an absent/empty file (read returns no episodes), so a
+  ledger configured but not yet written yields no false positives.
+- The curate CronJob already mounts the persistence volume that holds the ledger
+  (`config.outcome.ledger_path` on `catalog.mountPath`); no chart change is required
+  beyond documenting that Queue/Recurrence need `outcome.ledger_path` + the PVC.
+
+### D. Safety & scope
+
+Both passes touch **only the KB forge** (relabel a PR, open an issue), never the
+cluster, under the **opt-in curate CronJob**. Knowledge-gap artifacts are *issues*,
+and the `Lifecycle` stale-sweep lists *PRs* only (`pull_request != nil`), so gap
+issues are never auto-closed. The forge token already needs issues/PR write for
+curation; no new RBAC.
+
+## Testing
+
+- `internal/curate/resolution_test.go`
+  - keep the existing `Queue.Run` tests (fake checker) — they still pass unchanged.
+  - add `TestLedgerResolutionCheckerResolvedTitle` (a resolved episode with the PR's
+    title ⇒ true), `…Unresolved` (only unresolved/absent ⇒ false), `…StripsKBPrefix`
+    (matches `"KB: X"` against episode title `"X"`), `…EmptyTitle` (false).
+  - `TestQueuePromotesResolvedViaLedger` — `Queue` over a fake forge + a fake
+    `Episodes()` source, asserting a `solved` PR whose title resolved is relabelled
+    `ready-to-merge`, and an unresolved one is not.
+- `internal/curate/recurrence_test.go` (rewrite)
+  - `TestRecurrenceOpensGapIssueAtThreshold` — 3 unresolved episodes on `apps/web`,
+    none on a 1-occurrence resource ⇒ one issue titled `knowledge-gap: apps/web`.
+  - `TestRecurrenceBelowThresholdNoIssue`.
+  - `TestRecurrenceIdempotentWhenIssueExists` — an existing `knowledge-gap: apps/web`
+    issue ⇒ no duplicate even at threshold.
+  - `TestRecurrenceResolvedEpisodesDoNotCount`.
+  - `TestRecurrencePatternFallsBackToTitle` — a resource-less episode groups by title.
+- `internal/config/config_test.go` — `curate.recurrence_threshold` parses.
+- Fakes: a `fakeEpisodes` implementing `Episodes() ([]outcome.Episode, error)`; reuse
+  the existing `recordingForge`/`gapForge` style for forge assertions.
+
+## Out of scope
+
+- Embedding alert fingerprints on PRs / a `ResolvedFingerprints()` ledger method (the
+  exact-title join is sufficient; this was the heavier alternative).
+- An e2e for the CronJob passes (the CronJob is opt-in/manual; unit coverage is the
+  gate). The existing k3d e2e is unaffected.
+- Changing how resolution is *recorded* (that is the source-pluggable trigger layer,
+  unchanged here).
+
+## Files touched
+
+- `internal/curate/resolution.go` — `LedgerResolutionChecker`.
+- `internal/curate/recurrence.go` — ledger-driven `Run`; remove `Store`/`Observe`.
+- `internal/config/config.go` — `Curate.RecurrenceThreshold`.
+- `cmd/lore/main.go` — open the ledger read-only; wire Queue + Recurrence.
+- `internal/curate/resolution_test.go`, `internal/curate/recurrence_test.go`,
+  `internal/config/config_test.go` — tests above.
+- `deploy/helm/runlore/values.yaml` — comment that Queue/Recurrence need
+  `config.outcome.ledger_path` + persistence (no behavioral chart change).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -385,7 +385,8 @@ func (c *Config) Validate() error {
 
 // Curate configures the Phase-2 backlog groomer (lore curate).
 type Curate struct {
-	StaleAfter Duration `yaml:"stale_after"` // close unprotected KB PRs idle longer than this; 0 disables (default 720h)
+	StaleAfter          Duration `yaml:"stale_after"`          // close unprotected KB PRs idle longer than this; 0 disables (default 720h)
+	RecurrenceThreshold int      `yaml:"recurrence_threshold"` // open a knowledge-gap issue after this many unresolved occurrences of a pattern; 0 ⇒ default 3
 }
 
 // Forge holds git-forge authentication and the curation target repo.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -99,3 +99,21 @@ func TestCurateStaleAfterParse(t *testing.T) {
 		t.Fatalf("absent stale_after must be 0, got %v", z.Curate.StaleAfter.Std())
 	}
 }
+
+func TestCurateRecurrenceThresholdParse(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("curate:\n  recurrence_threshold: 5\n"), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Curate.RecurrenceThreshold != 5 {
+		t.Fatalf("recurrence_threshold: want 5, got %d", c.Curate.RecurrenceThreshold)
+	}
+	// Absent ⇒ zero ⇒ the pass applies its own default (3).
+	var z Config
+	if err := yaml.Unmarshal([]byte("curate:\n  stale_after: 240h\n"), &z); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if z.Curate.RecurrenceThreshold != 0 {
+		t.Fatalf("absent recurrence_threshold must be 0, got %d", z.Curate.RecurrenceThreshold)
+	}
+}

--- a/internal/curate/recurrence.go
+++ b/internal/curate/recurrence.go
@@ -4,60 +4,85 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// RecurrenceStore persists per-pattern unresolved counts across curate runs.
-type RecurrenceStore interface {
-	Load(ctx context.Context) (map[string]int, error)
-	Save(ctx context.Context, counts map[string]int) error
-}
+// gapTitlePrefix titles every knowledge-gap issue; it is also the existence-check
+// key (the pass opens at most one issue per pattern).
+const gapTitlePrefix = "knowledge-gap: "
 
-// Recurrence tracks unresolved-pattern recurrence and opens ONE knowledge-gap
-// issue when a pattern crosses the threshold — the only path that creates issues.
+// Recurrence opens ONE knowledge-gap issue when an unresolved incident pattern recurs
+// at least Threshold times. It is ledger-driven and idempotent: it recomputes counts
+// from the outcome ledger every run and opens an issue only when no knowledge-gap
+// issue for that pattern already exists — so re-running never double-opens (no mutable
+// store or watermark).
 type Recurrence struct {
-	Forge     Forge
-	Store     RecurrenceStore
+	Forge  Forge
+	Ledger interface {
+		Episodes() ([]outcome.Episode, error)
+	}
 	Threshold int // default 3 when 0
 	Log       *slog.Logger
 }
 
-// Observe records one unresolved occurrence of a pattern (a Fingerprint-style key)
-// and opens a knowledge-gap issue when it first reaches the threshold.
-func (r Recurrence) Observe(ctx context.Context, pattern string) error {
+// Run opens a knowledge-gap issue for each pattern that crosses the threshold and has
+// none open yet.
+func (r Recurrence) Run(ctx context.Context) error {
 	thr := r.Threshold
 	if thr == 0 {
 		thr = 3
 	}
-	counts, err := r.Store.Load(ctx)
+	eps, err := r.Ledger.Episodes()
 	if err != nil {
-		return fmt.Errorf("load recurrence: %w", err)
+		return fmt.Errorf("recurrence: load episodes: %w", err)
 	}
-	if counts == nil {
-		counts = map[string]int{}
+	// Count UNRESOLVED occurrences per pattern (affected resource; title fallback).
+	counts := map[string]int{}
+	for _, e := range eps {
+		if e.Resolved {
+			continue
+		}
+		counts[recurrencePattern(e)]++
 	}
-	counts[pattern]++
-	shouldOpen := counts[pattern] == thr // exactly at threshold → open once
-	// Persist the count BEFORE opening the issue. If we opened first and Save then
-	// failed, the next run would re-load the pre-increment count, re-hit the
-	// threshold, and double-open. Saving first means a later OpenIssue failure
-	// leaves the count at thr (next run increments past it → the == thr guard
-	// never re-fires).
-	if err := r.Store.Save(ctx, counts); err != nil {
-		return fmt.Errorf("save recurrence: %w", err)
+	// Existing knowledge-gap issues are the idempotency guard. OpenIssue labels issues
+	// "runlore"/"triggered" and titles them gapTitlePrefix+pattern, so match by title.
+	existing, err := r.Forge.ListIssuesByLabel(ctx, "runlore")
+	if err != nil {
+		return fmt.Errorf("recurrence: list issues: %w", err)
 	}
-	if shouldOpen {
+	open := map[string]bool{}
+	for _, iss := range existing {
+		if p, ok := strings.CutPrefix(iss.Title, gapTitlePrefix); ok {
+			open[p] = true
+		}
+	}
+	for pattern, n := range counts {
+		if n < thr || open[pattern] {
+			continue
+		}
 		inv := providers.Investigation{
-			Title: "knowledge-gap: " + pattern,
+			Title: gapTitlePrefix + pattern,
 			RootCauses: []providers.Hypothesis{{
-				Summary: fmt.Sprintf("RunLore could not resolve %q across %d incidents — needs seeded knowledge or a RunLore fix.", pattern, thr),
+				Summary: fmt.Sprintf("RunLore could not resolve incidents on %q across %d occurrences — needs seeded knowledge or a RunLore fix.", pattern, n),
 			}},
 		}
 		if _, err := r.Forge.OpenIssue(ctx, inv); err != nil {
-			return fmt.Errorf("open knowledge-gap issue: %w", err)
+			r.Log.Warn("recurrence: open knowledge-gap issue failed", "pattern", pattern, "err", err)
+			continue // best-effort; other patterns still processed
 		}
-		r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", thr)
+		r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", n)
 	}
 	return nil
+}
+
+// recurrencePattern groups unresolved incidents by the affected resource, falling
+// back to the incident title when no resource was identified.
+func recurrencePattern(e outcome.Episode) string {
+	if e.Resource != "" {
+		return e.Resource
+	}
+	return e.Title
 }

--- a/internal/curate/recurrence_test.go
+++ b/internal/curate/recurrence_test.go
@@ -2,37 +2,14 @@ package curate
 
 import (
 	"context"
-	"errors"
-	"io"
-	"log/slog"
 	"testing"
 
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
 
-type memStore struct {
-	counts  map[string]int
-	saveErr error // when set, Save fails (and does not persist) — simulates a flaky store
-}
-
-// Load returns a COPY (like a real forge-backed store), so an increment on the
-// loaded map does not mutate the persisted state unless Save succeeds.
-func (m *memStore) Load(context.Context) (map[string]int, error) {
-	cp := make(map[string]int, len(m.counts))
-	for k, v := range m.counts {
-		cp[k] = v
-	}
-	return cp, nil
-}
-func (m *memStore) Save(_ context.Context, c map[string]int) error {
-	if m.saveErr != nil {
-		return m.saveErr
-	}
-	m.counts = c
-	return nil
-}
-
-// gapForge records the issue titles it was asked to open.
+// gapForge records the issue titles it was asked to open. It embeds recordingForge
+// (which supplies ListIssuesByLabel from its `issues` field) and overrides OpenIssue.
 type gapForge struct {
 	*recordingForge
 	openedTitles []string
@@ -43,53 +20,75 @@ func (g *gapForge) OpenIssue(_ context.Context, inv providers.Investigation) (pr
 	return providers.Ref{URL: "https://github.com/x/y/issues/1"}, nil
 }
 
-func TestRecurrenceOpensGapIssueOnThreshold(t *testing.T) {
-	store := &memStore{counts: map[string]int{"flux gitrepository not found": 2}} // already seen twice
-	gf := &gapForge{recordingForge: &recordingForge{}}
-	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	if err := r.Observe(context.Background(), "flux gitrepository not found"); err != nil {
-		t.Fatal(err)
+func unresolved(pattern string, n int) []outcome.Episode {
+	eps := make([]outcome.Episode, n)
+	for i := range eps {
+		eps[i] = outcome.Episode{Resource: pattern, Resolved: false}
 	}
-	if len(gf.openedTitles) != 1 {
-		t.Fatalf("want 1 knowledge-gap issue at the threshold, got %d", len(gf.openedTitles))
-	}
-	if store.counts["flux gitrepository not found"] != 3 {
-		t.Fatalf("count not persisted: %v", store.counts)
-	}
+	return eps
 }
 
-func TestRecurrenceSaveFailureDoesNotDoubleOpen(t *testing.T) {
-	// Save fails the first time. Because the count is persisted BEFORE the issue is
-	// opened, a Save failure means NO issue is opened that run (and the count isn't
-	// persisted) — so the next run retries and opens exactly once. Never twice.
-	store := &memStore{counts: map[string]int{"p": 2}, saveErr: errors.New("store unavailable")}
+func TestRecurrenceOpensGapIssueAtThreshold(t *testing.T) {
+	eps := append(unresolved("apps/web", 3), outcome.Episode{Resource: "apps/worker", Resolved: false}) // worker: only 1
 	gf := &gapForge{recordingForge: &recordingForge{}}
-	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
-
-	if err := r.Observe(context.Background(), "p"); err == nil {
-		t.Fatal("want a save error on the first Observe")
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: eps}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
-	if len(gf.openedTitles) != 0 {
-		t.Fatalf("must NOT open an issue when Save fails, got %d", len(gf.openedTitles))
-	}
-	// Retry with a working store → opens exactly once.
-	store.saveErr = nil
-	if err := r.Observe(context.Background(), "p"); err != nil {
-		t.Fatal(err)
-	}
-	if len(gf.openedTitles) != 1 {
-		t.Fatalf("want exactly 1 issue after the retry, got %d", len(gf.openedTitles))
+	if len(gf.openedTitles) != 1 || gf.openedTitles[0] != "knowledge-gap: apps/web" {
+		t.Fatalf("want one gap issue for apps/web, got %v", gf.openedTitles)
 	}
 }
 
 func TestRecurrenceBelowThresholdNoIssue(t *testing.T) {
-	store := &memStore{counts: map[string]int{}}
 	gf := &gapForge{recordingForge: &recordingForge{}}
-	r := Recurrence{Forge: gf, Store: store, Threshold: 3, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	if err := r.Observe(context.Background(), "new pattern"); err != nil {
-		t.Fatal(err)
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: unresolved("apps/web", 2)}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
 	}
 	if len(gf.openedTitles) != 0 {
-		t.Fatalf("below threshold must not open an issue")
+		t.Fatalf("below threshold must open nothing, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceIdempotentWhenIssueExists(t *testing.T) {
+	gf := &gapForge{recordingForge: &recordingForge{
+		issues: []providers.CuratedIssue{{Title: "knowledge-gap: apps/web"}}, // already open
+	}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: unresolved("apps/web", 5)}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("an existing gap issue must prevent a duplicate, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceResolvedEpisodesDoNotCount(t *testing.T) {
+	eps := []outcome.Episode{
+		{Resource: "apps/web", Resolved: true}, {Resource: "apps/web", Resolved: true},
+		{Resource: "apps/web", Resolved: false}, // only 1 unresolved
+	}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: eps}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 0 {
+		t.Fatalf("resolved episodes must not count, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrencePatternFallsBackToTitle(t *testing.T) {
+	eps := []outcome.Episode{
+		{Title: "DNSFailure", Resolved: false}, {Title: "DNSFailure", Resolved: false}, {Title: "DNSFailure", Resolved: false},
+	}
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{Forge: gf, Ledger: fakeLedger{eps: eps}, Threshold: 3, Log: discardLog()}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 1 || gf.openedTitles[0] != "knowledge-gap: DNSFailure" {
+		t.Fatalf("a resource-less episode should group by title, got %v", gf.openedTitles)
 	}
 }

--- a/internal/curate/resolution.go
+++ b/internal/curate/resolution.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"slices"
+	"strings"
 
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -58,4 +60,33 @@ func queueReason(accepted bool) string {
 		return "human-accepted"
 	}
 	return "resolved"
+}
+
+// LedgerResolutionChecker reports a curated PR's incident has resolved when the
+// outcome ledger holds a resolved episode whose title matches the PR's. A curated
+// PR's title is "KB: " + the incident title, and the ledger records each open with
+// that same incident title — so the join is an exact title match. Source-agnostic:
+// it reads the ledger's resolve events, never a trigger-specific API.
+type LedgerResolutionChecker struct {
+	Ledger interface {
+		Episodes() ([]outcome.Episode, error)
+	}
+}
+
+// IsResolved implements ResolutionChecker.
+func (c LedgerResolutionChecker) IsResolved(_ context.Context, pr providers.CuratedIssue) (bool, error) {
+	title := strings.TrimSpace(strings.TrimPrefix(pr.Title, "KB: "))
+	if title == "" {
+		return false, nil
+	}
+	eps, err := c.Ledger.Episodes()
+	if err != nil {
+		return false, err
+	}
+	for _, e := range eps {
+		if e.Resolved && e.Title == title {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/curate/resolution_test.go
+++ b/internal/curate/resolution_test.go
@@ -14,14 +14,15 @@ import (
 // and recurrence tests.
 type recordingForge struct {
 	prs     []providers.CuratedIssue
-	relabel map[int]string // number -> added label
+	issues  []providers.CuratedIssue // returned by ListIssuesByLabel
+	relabel map[int]string           // number -> added label
 }
 
 func (f *recordingForge) ListPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
 	return f.prs, nil
 }
 func (f *recordingForge) ListIssuesByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
-	return nil, nil
+	return f.issues, nil
 }
 func (f *recordingForge) Comment(context.Context, int, string) error { return nil }
 func (f *recordingForge) ReplaceLabel(_ context.Context, n int, _, add string) error {

--- a/internal/curate/resolution_test.go
+++ b/internal/curate/resolution_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -42,6 +43,13 @@ func (c fakeChecker) IsResolved(_ context.Context, pr providers.CuratedIssue) (b
 	return c.resolved[pr.Number], nil
 }
 
+// fakeLedger is a fixed Episodes() source for resolution/recurrence tests.
+type fakeLedger struct{ eps []outcome.Episode }
+
+func (f fakeLedger) Episodes() ([]outcome.Episode, error) { return f.eps, nil }
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
 func TestResolutionQueuesResolvedOnly(t *testing.T) {
 	f := &recordingForge{prs: []providers.CuratedIssue{
 		{Number: 48, Title: "KB: HarborRegistryDown", Labels: []string{"runlore", "solved"}},
@@ -71,5 +79,55 @@ func TestResolutionRespectsHumanAccepted(t *testing.T) {
 	}
 	if f.relabel[48] != "ready-to-merge" {
 		t.Fatalf("human-accepted PR should be ready-to-merge even if unresolved, got %q", f.relabel[48])
+	}
+}
+
+func TestLedgerResolutionCheckerResolvedTitle(t *testing.T) {
+	c := LedgerResolutionChecker{Ledger: fakeLedger{eps: []outcome.Episode{
+		{Title: "HarborRegistryDown", Resolved: true},
+		{Title: "Other", Resolved: false},
+	}}}
+	got, err := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: HarborRegistryDown"})
+	if err != nil || !got {
+		t.Fatalf("a resolved episode with the PR's title must be resolved=true; got %v err=%v", got, err)
+	}
+}
+
+func TestLedgerResolutionCheckerUnresolved(t *testing.T) {
+	c := LedgerResolutionChecker{Ledger: fakeLedger{eps: []outcome.Episode{
+		{Title: "HarborRegistryDown", Resolved: false}, // opened, never resolved
+	}}}
+	got, _ := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: HarborRegistryDown"})
+	if got {
+		t.Fatal("an unresolved episode must yield resolved=false")
+	}
+	// absent entirely → false
+	if got, _ := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: Unknown"}); got {
+		t.Fatal("a title with no episode must yield resolved=false")
+	}
+}
+
+func TestLedgerResolutionCheckerEmptyTitle(t *testing.T) {
+	c := LedgerResolutionChecker{Ledger: fakeLedger{eps: []outcome.Episode{{Title: "", Resolved: true}}}}
+	if got, _ := c.IsResolved(context.Background(), providers.CuratedIssue{Title: "KB: "}); got {
+		t.Fatal("an empty title must never match (avoids resolving on a blank episode)")
+	}
+}
+
+func TestQueuePromotesResolvedViaLedger(t *testing.T) {
+	f := &recordingForge{prs: []providers.CuratedIssue{
+		{Number: 48, Title: "KB: HarborRegistryDown", Labels: []string{"runlore", "solved"}},
+		{Number: 50, Title: "KB: StillBroken", Labels: []string{"runlore", "solved"}},
+	}}
+	led := fakeLedger{eps: []outcome.Episode{{Title: "HarborRegistryDown", Resolved: true}}}
+	q := Queue{Forge: f, Checker: LedgerResolutionChecker{Ledger: led}, Log: discardLog()}
+	if err := q.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.relabel[48] != "ready-to-merge" {
+		t.Fatalf("the resolved PR #48 should be queued ready-to-merge, got %v", f.relabel)
+	}
+	if _, ok := f.relabel[50]; ok {
+		t.Fatalf("the unresolved PR #50 must not be queued, got %v", f.relabel)
 	}
 }


### PR DESCRIPTION
## #12 follow-up — light up the two deferred Phase-2 curation passes

Both were left dormant in #12 because their *correct* wiring needed a design decision. They are now **ledger-backed, idempotent, and source-neutral** (they read the outcome ledger's events — no Alertmanager-specific code).

### Queue — `LedgerResolutionChecker`
Promotes a human-`solved` PR to `ready-to-merge` once its incident resolved (or a human added `accepted`). The PR↔incident join is **exact-title**, which holds by construction: a curated PR's title is `"KB: " + inv.Title` and the ledger records each open with that same `inv.Title`. `IsResolved` strips `"KB: "` and returns true iff a **resolved** episode has that title. No new markers, no curator/serve-path change — reuses `Episodes()`.

### Recurrence — ledger-driven `Run`, idempotent
Counts **unresolved** episodes per **pattern** (affected resource, title fallback) and opens **one** `"knowledge-gap: <pattern>"` issue per pattern at/over the threshold (default 3) **iff none already exists** (existence-check among `runlore` issues by title). No mutable store or watermark — re-running never double-opens. The old `RecurrenceStore`/`Observe` are removed.

### Wiring & safety
- `runCurate` opens the ledger **read-only** and appends Queue + Recurrence **only when `outcome.ledger_path` is set** (else Dedup+Lifecycle only, unchanged). `outcome.New` failure returns cleanly; an absent ledger yields no episodes → no false promotions.
- New config `curate.recurrence_threshold` (default 3).
- Both touch only the **KB forge** (relabel a PR / open an issue) under the **opt-in curate CronJob** — no cluster mutation. Gap artifacts are *issues*, immune to the PR stale-sweep.

### Known tradeoff (documented, deferred)
The exact-title join is coarser than the incident fingerprint: for a coalesced batch or the same alert across two namespaces, a `solved` PR could be promoted slightly early. Because `Queue` only relabels a human-`solved` PR (a human still merges — **never auto-merge**), the worst case is surfacing-for-merge early, never a false positive into any mutation. The precise alternative (embedding alert fingerprints + a `ResolvedFingerprints()` ledger method) is the spec's deferred "Out of scope."

### Testing
`go build/vet/test` + gofmt clean; helm renders. Unit-covers the checker (resolved/unresolved/absent/empty-title + Queue-through-ledger), `Recurrence.Run` (threshold, below-threshold, idempotent-existing, resolved-don't-count, pattern-fallback-title), and the config parse.

### Process
brainstorm → spec (`docs/superpowers/specs/2026-06-24-curate-queue-recurrence-design.md`) → plan → 4 subagent tasks, each reviewed → whole-branch review (opus): **✅ merge, no blocking issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)