### PR TITLE
docs: Queue + Recurrence wired (PR #92) — sync status docs

### DIFF
--- a/docs/analysis/2026-06-23-deep-analysis.md
+++ b/docs/analysis/2026-06-23-deep-analysis.md
@@ -41,7 +41,7 @@ The **design docs are excellent** — honest about prior art (HolmesGPT, k8sgpt,
 | **Capture (A1)** — outcome ledger open/resolve | ✅ wired | `ledger.Open` `main.go:1058`; `ledger.Resolve` `server.go:374` |
 | **Curate (file-time)** — dedup → quality gate → PR | ✅ wired | `Curator.Curate` `main.go:1096` |
 | **Curate (Phase-2)** — backlog groom | ✅ **Dedup + Lifecycle wired** (was: only Dedup) | `runCurate`; opt-in `lore curate` CronJob (PR #86) |
-| **Curate (Phase-2)** — `Queue` / `Recurrence` | 🟡 **DORMANT** (tested, unwired) | deferred by design — need a resolution join / idempotent ledger driver (`Lifecycle` now wired via `updated_at`) |
+| **Curate (Phase-2)** — `Queue` / `Recurrence` | ✅ **wired** (was: dormant) | ledger-backed via `Episodes()` — Queue: exact-title resolution join; Recurrence: idempotent existence-check (PR #92) |
 | **Compound** — git-sync → bleve reindex | ✅ wired (HEAD-gated, was: every-poll) | re-indexes only on real HEAD change; readiness gated on catalog warmth (PR #82) |
 | **A2** — outcome → recall ranking / decay | ✅ **BUILT** (was: ❌ UNBUILT) | `Episodes()`/`OpenCounts()` (PR #71) feed `outcomeFactor` → `deriveRecallConfidence` decay (PR #72) |
 
@@ -194,7 +194,7 @@ Effort: **S** ≤1 day · **M** 2–4 days · **L** ≥1 week. Impact is on the 
 | 15 | loop cost — hard token kill | ✅ merged (PR #76) |
 | 7 | eval into CI (nightly k-of-n + fail-under) | ✅ merged (PR #81) — nightly+dispatch workflow; needs the `RUNLORE_EVAL_API_KEY` secret to run |
 | 11 | curation dedup fingerprint | ✅ merged (PR #83) |
-| 12 | curation Phase-2 — `lore curate` CronJob + dormant passes | 🟡 **partial** (PR #86) — scheduler (opt-in CronJob) + Lifecycle sweep wired; **Queue + Recurrence still deferred** (see below) |
+| 12 | curation Phase-2 — `lore curate` CronJob + dormant passes | ✅ **merged** (PR #86 scheduler + Dedup/Lifecycle; PR #92 Queue + Recurrence) — all four passes wired |
 | 13 | confirmatory evidence on recall | ✅ merged (PR #84) |
 | 16 | `Verified`/provenance in `meetsBar` | ✅ merged (PR #85) |
 | 17 | reversible `rollback` op | ❎ **won't build** (decided 2026-06-24) — in-cluster re-pin fights the safety model + diverges cluster↔Git; remediation stays read-only. See §9.4 |
@@ -203,8 +203,8 @@ Effort: **S** ≤1 day · **M** 2–4 days · **L** ≥1 week. Impact is on the 
 Specs/plans for each merged item live under `docs/superpowers/specs/` and `docs/superpowers/plans/` on `main`.
 
 **Remaining work:**
-- **#17 (reversible `rollback`)** — **decided against** (2026-06-24). A scoped brainstorm found the in-cluster re-pin can't fit the safety model cleanly; remediation stays read-only / propose-and-approve. Full rationale in §9.4 and `docs/design.md` (the "Act" section).
-- **#12's deferred passes** — `Queue` (`ResolutionChecker`) needs a PR↔incident resolution join (the #11 dup-fingerprint ≠ the ledger's alert-fingerprint; or a cluster-state checker); `Recurrence` needs an idempotent ledger-backed driver over `Episodes()` (a watermark or gap-issue existence-check). Both stay implemented + unit-tested in `internal/curate`; `runCurate`'s comment states each blocker. Scoped this way because their correct wiring is a genuine product decision, not mechanical.
+- **#17 (reversible `rollback`)** — **decided against** (2026-06-24). A scoped brainstorm found the in-cluster re-pin can't fit the safety model cleanly; remediation stays read-only / propose-and-approve. Full rationale in §9.4 and `docs/design.md` (the "Act" section). *This is the only roadmap item not shipped.*
+- **#12's Queue + Recurrence** — ✅ **wired** (PR #92, 2026-06-24), ledger-backed via `Episodes()`: Queue resolves a PR's incident by exact-title match against the ledger; Recurrence opens a knowledge-gap issue idempotently via an existing-issue check. The chosen exact-title join is coarser than the incident fingerprint (a human-gated promotion can fire slightly early on coalesced/cross-namespace incidents) — a documented tradeoff; the fingerprint-precise variant remains a possible future refinement.
 - **Nightly eval (#7)** runs once the `RUNLORE_EVAL_API_KEY` repo secret is set (it drives a live LLM, so it can't gate fork PRs and isn't a per-PR blocker — by design).
 
 ### 9.1 Ranked improvements
@@ -269,7 +269,7 @@ Wave 3 — Compound faster + harden
   ├─ ✅ #7  eval into CI ....................... S [needs 4,5]
   ├─ ✅ #4  entity-level precision in eval ..... M (Track A; landed ahead of #7)
   ├─ ✅ #11 deterministic dedup fingerprint .... M [needs 2]
-  ├─ 🟡 #12 curate CronJob + lifecycle ........ M [needs 8] (Queue+Recurrence deferred)
+  ├─ ✅ #12 curate CronJob + all 4 passes ..... M [needs 8] (Queue+Recurrence wired, PR #92)
   └─ ✅ #16 Verified/provenance in meetsBar .... M
 
 Wave 4 — Reliability & durability (parallel, independent)
@@ -279,7 +279,7 @@ Wave 4 — Reliability & durability (parallel, independent)
   └─ ❎ #17 reversible rollback op (product) ... L  ← decided against (§9.4)
 ```
 
-> **Status (2026-06-24, updated):** Waves 0–4 complete; **#17 decided against** (§9.4) and #12's Queue+Recurrence passes intentionally deferred. The eval-validity cluster (#4/#5/#6) is done; the full k3d e2e passes (PASS=40 FAIL=0). See §9.0 for the per-item PR map and remaining-work notes.
+> **Status (2026-06-24, updated):** Waves 0–4 complete; **17 of 18 items shipped** — only **#17 is decided against** (§9.4). #12's Queue + Recurrence passes are now wired (PR #92), so all four Phase-2 passes are live. The eval-validity cluster (#4/#5/#6) is done; the full k3d e2e passes (PASS=40 FAIL=0). See §9.0 for the per-item PR map and remaining-work notes.
 
 **Fastest credible "we learn" demo:** Wave 0 + Slice 2 + Slice 5 + #9 — a poisoned/stale entry recalls, never resolves, decays below the floor on the next occurrence, triggers a fresh re-investigation that overturns it, observable in the eval harness *and* on the entry's git frontmatter.
 

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -257,11 +257,17 @@ keeps the backlog healthy on a schedule:
   `stale_after`), never touching human-labelled ones, and only after a back-ref
   comment. `stale_after: 0` disables the sweep.
 
-> Two further passes — **Queue** (promote a PR to *ready-to-merge* once its incident
-> has resolved) and **Recurrence** (open a *knowledge-gap* issue when a pattern recurs
-> unresolved N times) — are implemented and unit-tested but **deferred from wiring**:
-> each needs a genuine design decision (an incident↔PR resolution join; an idempotent
-> ledger-backed driver) rather than mechanical plumbing.
+Two further passes are also wired, both **ledger-backed** (they read the outcome
+ledger, so they stay source-neutral):
+
+- **Queue** — promote a human-`solved` PR to *ready-to-merge* once its incident has
+  resolved. The PR↔incident join is an exact title match (a curated PR's title is
+  `"KB: " + the incident title`, which the ledger records too), so a resolved episode
+  with that title flips the PR onto the merge-ready queue. A human still merges.
+- **Recurrence** — open one *knowledge-gap* issue when an unresolved pattern (the
+  affected resource) recurs past a threshold. Idempotent by an existing-issue check
+  (the forge's open gap issues are the "already-opened" record), so re-running never
+  double-opens — no mutable store.
 
 ---
 
@@ -380,11 +386,16 @@ eval harness and treats its outputs as the source of truth:
 
 Honesty is part of the design:
 
-- **Queue / Recurrence Phase-2 passes** are built + tested but not yet wired — they
-  need real product decisions (incident↔PR resolution join; idempotent recurrence
-  driver), not mechanical wiring.
-- **Reversible `rollback` remediation** (re-pin a Kustomization/HelmRelease to the
-  prior revision) is not yet built; `auto` today can only suspend/resume/reconcile.
+- **Reversible `rollback` remediation** was scoped and **deliberately declined**: an
+  in-cluster re-pin of a Flux Kustomization must patch a shared GitRepository in the
+  protected `flux-system` namespace and diverges the cluster from Git. Remediation
+  stays read-only / propose-and-approve; `auto` executes only suspend/resume/reconcile,
+  and the agent *suggests* (never auto-applies) a rollback. The GitOps-correct form, if
+  ever revisited, is a Git-revert PR. (See `design.md`, "Act".)
+- The **Queue/Recurrence precision tradeoff**: the resolution join is by exact title,
+  coarser than the incident fingerprint — a human-gated promotion can fire slightly
+  early on coalesced or cross-namespace incidents. The fingerprint-precise variant is
+  a possible future refinement.
 - **Nightly eval** only produces signal once a model API-key secret is configured.
 
 The loop is closed and measured; these are the next increments, sequenced so each is


### PR DESCRIPTION
Syncs the docs now that #12's two deferred Phase-2 passes are merged (PR #92).

- **`docs/analysis/...deep-analysis.md`** — §0 status map (`Queue`/`Recurrence` → ✅ wired), §9.0 (#12 → ✅ merged; all four passes; remaining-work updated; **17/18 shipped, only #17 declined**), §9.3 sequencing + footer.
- **`docs/learning-loop.md`** — §5 (Queue/Recurrence now described as wired + ledger-backed), §10 "deliberately incomplete" (rollback reframed as *declined*; the exact-title precision tradeoff noted in place of the old "deferred" entry).

Docs-only; mermaid intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)