### PR TITLE
feat(observability): structured logging, richer metrics, portable Grafana dashboard + alert rules

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/Smana/runlore/internal/eval"
 	fluxexec "github.com/Smana/runlore/internal/executor/flux"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/logging"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
 	anthropic "github.com/Smana/runlore/internal/model/anthropic"
@@ -137,7 +138,7 @@ func runServe(args []string) error {
 	if err != nil {
 		return err
 	}
-	log := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	log := logging.FromConfig(os.Stdout, cfg.Logging.Format, cfg.Logging.Level)
 	setMemoryLimitFromCgroup(log) // make the GC respect the container memory cap
 
 	// Opt-in pprof on loopback only (reachable via `kubectl port-forward`, never the
@@ -288,6 +289,14 @@ func runServe(args []string) error {
 	} else {
 		leader.Store(true) // no leader election: this replica is always active + ready
 		startWork(ctx)
+	}
+
+	// Build-info + leadership gauges (runlore_build_info / runlore_leader). No-op
+	// unless telemetry installed a real provider above.
+	if cfg.Telemetry.MetricsEnabled {
+		if err := telemetry.RegisterRuntimeGauges(version, leader.Load); err != nil {
+			log.Warn("runtime gauges registration failed", "err", err)
+		}
 	}
 
 	// readyz reflects leadership so the Service routes webhooks only to the leader.
@@ -604,7 +613,7 @@ func runEvalLive(cfg *config.Config, scnDir, recordDir, reportDir, prevReport, s
 	if len(scns) == 0 {
 		return fmt.Errorf("no scenarios found in %s", scnDir)
 	}
-	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 	ctx := context.Background()
 	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
 	judge := eval.ModelJudge{Model: buildJudgeModel(cfg, jProvider, jBaseURL, jModel, jKeyEnv)}
@@ -797,7 +806,7 @@ func runCurate(args []string) error {
 	if cfg.Forge.KBRepo == "" {
 		return fmt.Errorf("curate requires forge.kb_repo")
 	}
-	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 	tok := buildForgeTokenSource(cfg, log)
 	if tok == nil {
 		return fmt.Errorf("curate requires a configured GitHub App (forge.github_app)")
@@ -861,6 +870,7 @@ func buildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.G
 		li := &investigate.LoopInvestigator{
 			Model: model, Tools: tools, Recall: recall, Verify: true, Log: log,
 			Metrics:                   metrics,
+			ModelProvider:             cfg.Model.Provider,
 			MaxSteps:                  cfg.Investigation.MaxSteps,
 			MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 			MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
@@ -897,7 +907,7 @@ func runCatalogSync(args []string) error {
 	if err != nil {
 		return err
 	}
-	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 
 	g := cfg.Catalog.Git
 	if g.URL == "" {
@@ -1083,14 +1093,15 @@ func runInvestigate(args []string) error {
 		return fmt.Errorf("investigate requires a configured model (set config.model)")
 	}
 	// Progress logs go to stderr; the findings go to stdout.
-	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 	ctx := context.Background()
 
 	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
 		Model: model, Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
-		OnComplete: func(inv providers.Investigation) { result = &inv },
+		ModelProvider: cfg.Model.Provider,
+		OnComplete:    func(inv providers.Investigation) { result = &inv },
 	}
 	title := *alert
 	if title == "" {
@@ -1159,6 +1170,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		Recall:                    recall,
 		Verify:                    true, // adversarial review of root causes before delivery/curation
 		Metrics:                   metrics,
+		ModelProvider:             cfg.Model.Provider,
 		MaxSteps:                  cfg.Investigation.MaxSteps,
 		MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -50,8 +50,17 @@ config:
       max_per_window: 0        # 0 = unlimited; set e.g. 20 to cap investigations/hour
       # window: 1h
       # max_requeues: 3
+  # Structured logging. In-cluster defaults to JSON so logs are ingestible by
+  # Loki / VictoriaLogs / CloudWatch; switch format to "text" for human-readable
+  # output. level: debug | info | warn | error. Both are overridable at runtime via
+  # the RUNLORE_LOG_FORMAT / RUNLORE_LOG_LEVEL env vars.
+  logging:
+    format: json
+    level: info
   # OpenTelemetry self-instrumentation (Prometheus-format /metrics endpoint).
   # Enable when a VMServiceScrape (or ServiceMonitor) will scrape this agent.
+  # A portable Grafana dashboard + PrometheusRule/VMRule alerts live under
+  # deploy/observability/ (see docs/observability.md).
   telemetry:
     metrics_enabled: false
   # Phase-2 backlog groomer (lore curate). `stale_after` drives the lifecycle sweep;

--- a/deploy/observability/alerts/README.md
+++ b/deploy/observability/alerts/README.md
@@ -1,0 +1,89 @@
+# RunLore alerting rules
+
+Portable alerting rules for the RunLore SRE agent. RunLore is
+metrics-backend-agnostic, so the same alert logic ships in two operator-native
+formats. The two files have **identical** rule logic (same `expr`, `for`,
+`severity`, annotations) — only `apiVersion`/`kind` differ. If you edit one,
+edit the other.
+
+## Which file for which operator
+
+| File                 | Apply when you run...                                  | Kind                                                |
+| -------------------- | ------------------------------------------------------ | --------------------------------------------------- |
+| `prometheusrule.yaml`| Prometheus Operator / kube-prometheus-stack            | `monitoring.coreos.com/v1` `PrometheusRule`         |
+| `vmrule.yaml`        | VictoriaMetrics Operator (VMAlert)                     | `operator.victoriametrics.com/v1beta1` `VMRule`     |
+
+Apply only the one matching your stack:
+
+```sh
+# Prometheus Operator / kube-prometheus-stack
+kubectl apply -f prometheusrule.yaml
+
+# VictoriaMetrics Operator
+kubectl apply -f vmrule.yaml
+```
+
+## How the operator discovers the rule
+
+Both operators discover rule objects via a label selector, so the object must
+carry labels the operator is watching for.
+
+- **Prometheus Operator (kube-prometheus-stack):** the `Prometheus` CR has a
+  `ruleSelector`. kube-prometheus-stack's default selector usually requires an
+  extra label such as `release: <helm-release-name>` (e.g.
+  `release: kube-prometheus-stack`). If the rule is not picked up, inspect the
+  selector and add the matching label to `prometheusrule.yaml`:
+
+  ```sh
+  kubectl get prometheus -A -o jsonpath='{.items[*].spec.ruleSelector}'
+  ```
+
+  A commented `release:` label is left in `prometheusrule.yaml` for this.
+
+- **VictoriaMetrics Operator:** the `VMAlert` CR has `ruleSelector` /
+  `ruleNamespaceSelector`. Many deployments select all `VMRule` in watched
+  namespaces, so no extra label is typically needed. Verify with:
+
+  ```sh
+  kubectl get vmalert -A -o jsonpath='{.items[*].spec.ruleSelector}'
+  ```
+
+Both files already carry `app.kubernetes.io/name: runlore` and
+`role: alert-rules` for selector matching.
+
+## Thresholds are starting points
+
+Every threshold and `for:` duration in these rules is a **starting point**.
+Tune them to your alert volume, model/provider latency profile, token budget,
+and SLOs before relying on them in production. Each rule has a YAML comment
+explaining its intent and what to tune.
+
+## Alert inventory and metric dependencies
+
+For the rules to evaluate, RunLore's `/metrics` endpoint must be scraped and the
+listed series must be present.
+
+| Alert                                    | Severity | Depends on metric(s)                                                            |
+| ---------------------------------------- | -------- | ------------------------------------------------------------------------------ |
+| RunloreAgentDown                         | critical | `runlore_build_info`                                                           |
+| RunloreNoActiveLeader                    | critical | `runlore_leader`                                                               |
+| RunloreMultipleLeaders                   | warning  | `runlore_leader`                                                               |
+| RunloreInvestigationsDropped             | warning  | `runlore_investigations_dropped_total`                                        |
+| RunloreInvestigationThrottlingSustained  | warning  | `runlore_investigations_throttled_total`                                      |
+| RunlorePipelineStalled                   | critical | `runlore_alerts_received_total`, `runlore_investigations_started_total`        |
+| RunloreInvestigationErrors               | warning  | `runlore_investigations_completed_total{result="error"}`                      |
+| RunloreToolErrorRateHigh                 | warning  | `runlore_tool_calls_total{tool,result}`                                       |
+| RunloreModelErrorRateHigh                | critical | `runlore_model_requests_total{provider,result}`                               |
+| RunloreModelLatencyHigh                  | warning  | `runlore_model_request_duration_seconds_bucket`                               |
+| RunloreSlowResolution                    | info     | `runlore_incident_resolution_seconds_bucket`                                  |
+| RunloreInvestigationCostHigh             | warning  | `runlore_investigation_tokens_estimated_bucket`                               |
+
+All metrics are exposed on RunLore's Prometheus `/metrics` endpoint. Histograms
+additionally expose `_sum` and `_count` series alongside the `_bucket` series
+used by the quantile rules.
+
+## Runbooks
+
+Each rule's `runbook_url` annotation points at
+`https://github.com/Smana/runlore/blob/main/docs/observability.md#<anchor>`
+(placeholders — the per-alert anchors live in that doc).

--- a/deploy/observability/alerts/prometheusrule.yaml
+++ b/deploy/observability/alerts/prometheusrule.yaml
@@ -1,0 +1,196 @@
+# RunLore alerting rules — Prometheus Operator (kube-prometheus-stack) flavor.
+#
+# This is the PrometheusRule variant. The alert logic here is IDENTICAL to the
+# VMRule variant in ./vmrule.yaml — only apiVersion/kind differ. RunLore is
+# metrics-backend-agnostic, so we ship both and you apply whichever your cluster
+# uses. Do not let the two drift: change one, change the other.
+#
+# DISCOVERY NOTE — the Prometheus Operator only loads PrometheusRule objects that
+# match the Prometheus CR's `ruleSelector`. kube-prometheus-stack's default
+# selector requires an extra label (commonly `release: <helm-release-name>`).
+# If this rule is not picked up, uncomment and adjust the label below to match
+# your Prometheus `ruleSelector` (inspect with:
+#   kubectl get prometheus -A -o jsonpath='{.items[*].spec.ruleSelector}').
+#
+#   labels:
+#     release: kube-prometheus-stack   # <-- match your stack's ruleSelector
+#
+# All thresholds below are STARTING POINTS. Tune them to your traffic, model,
+# and SLOs before treating them as production-grade.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: runlore
+  labels:
+    app.kubernetes.io/name: runlore
+    role: alert-rules
+    # release: kube-prometheus-stack   # uncomment if your ruleSelector needs it
+spec:
+  groups:
+    - name: runlore.rules
+      rules:
+        # 1. Agent is down or not being scraped.
+        # absent() fires when the series vanishes entirely from the TSDB, which
+        # means either the RunLore process is gone or the scrape target broke.
+        # Threshold/for is a starting point — tune to your scrape interval.
+        - alert: RunloreAgentDown
+          expr: absent(runlore_build_info)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore agent is down or not scraped"
+            description: "No runlore_build_info series for 5m — the RunLore agent is down or its /metrics endpoint is not being scraped."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreagentdown"
+
+        # 2. No active leader (HA): nobody is investigating.
+        # In a multi-replica HA deployment exactly one replica should hold the
+        # lease (runlore_leader == 1). If the max across replicas is 0, no one is
+        # driving investigations. Starting point — tune `for` to lease churn.
+        - alert: RunloreNoActiveLeader
+          expr: max(runlore_leader) == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore has no active leader"
+            description: "No RunLore replica holds leadership for 10m (max(runlore_leader) == 0) — no investigations are being processed."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorenoactiveleader"
+
+        # 3. Split-brain: more than one leader at once.
+        # Two replicas both believing they are leader can double-process and
+        # double-spend on the model. Should be transient at most. Tune `for`.
+        - alert: RunloreMultipleLeaders
+          expr: sum(runlore_leader) > 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore has multiple leaders (split-brain)"
+            description: "{{ $value | humanize }} RunLore replicas report leadership simultaneously — possible split-brain; investigations may be duplicated."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremultipleleaders"
+
+        # 4. Investigations are being dropped.
+        # Dropped means an alert was discarded without investigation (e.g. queue
+        # overflow). Any drop in 15m is worth a look. for:0m = fire immediately;
+        # raise the increase() threshold if low-volume drops are acceptable.
+        - alert: RunloreInvestigationsDropped
+          expr: increase(runlore_investigations_dropped_total[15m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore is dropping investigations"
+            description: "{{ $value | humanize }} investigations dropped in the last 15m — alerts are being discarded without investigation (likely queue overflow or backpressure)."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationsdropped"
+
+        # 5. Sustained throttling.
+        # Brief throttling under a burst is normal; 30m of continuous throttling
+        # means RunLore is structurally under-provisioned for its load. Tune the
+        # `for` window and rate window to your expected burstiness.
+        - alert: RunloreInvestigationThrottlingSustained
+          expr: rate(runlore_investigations_throttled_total[10m]) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigations throttled for a sustained period"
+            description: "RunLore has been throttling investigations continuously for 30m (rate {{ $value | humanize }}/s) — capacity may be insufficient for the incoming alert volume."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationthrottlingsustained"
+
+        # 6. Pipeline stalled: alerts arrive but nothing starts.
+        # Alerts are landing (received increases) yet zero investigations start —
+        # the intake-to-investigation handoff is broken. Critical. Tune windows.
+        - alert: RunlorePipelineStalled
+          expr: (increase(runlore_alerts_received_total[15m]) > 0) and (increase(runlore_investigations_started_total[15m]) == 0)
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore pipeline stalled — alerts received but no investigations started"
+            description: "{{ $value | humanize }} alerts received in the last 15m but zero investigations were started — the intake-to-investigation pipeline appears stalled."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorepipelinestalled"
+
+        # 7. Investigations completing with an error result.
+        # Investigations that finish in `result="error"` indicate the agent loop
+        # is failing mid-run. for:0m surfaces it promptly; raise the increase()
+        # threshold if a low error background rate is tolerable.
+        - alert: RunloreInvestigationErrors
+          expr: increase(runlore_investigations_completed_total{result="error"}[15m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigations are completing with errors"
+            description: "{{ $value | humanize }} investigations completed with result=error in the last 15m — the investigation loop is failing for some incidents."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationerrors"
+
+        # 8. Tool-call error rate is high.
+        # Error fraction across all tool calls > 20%, gated on a minimum call
+        # rate (>0.01/s) so the ratio is not noisy at near-zero traffic.
+        # clamp_min avoids divide-by-zero. 0.2 is a starting point.
+        - alert: RunloreToolErrorRateHigh
+          expr: sum(rate(runlore_tool_calls_total{result="error"}[15m])) / clamp_min(sum(rate(runlore_tool_calls_total[15m])), 0.001) > 0.2 and sum(rate(runlore_tool_calls_total[15m])) > 0.01
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore tool-call error rate is high"
+            description: "Tool-call error fraction is {{ $value | humanizePercentage }} over the last 15m (>20%) — investigation tools are failing frequently; check {{ $labels.tool }} integrations."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloretoolerrorratehigh"
+
+        # 9. Model-request error rate is high.
+        # Same shape as the tool-error rule but for the LLM provider, with a
+        # tighter 10% threshold — model errors stop investigations cold, so
+        # critical. Tune threshold to the provider's expected reliability.
+        - alert: RunloreModelErrorRateHigh
+          expr: sum(rate(runlore_model_requests_total{result="error"}[15m])) / clamp_min(sum(rate(runlore_model_requests_total[15m])), 0.001) > 0.1 and sum(rate(runlore_model_requests_total[15m])) > 0.01
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore model-request error rate is high"
+            description: "Model-request error fraction is {{ $value | humanizePercentage }} over the last 15m (>10%) — the LLM provider {{ $labels.provider }} is failing; investigations cannot complete."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodelerrorratehigh"
+
+        # 10. Model p95 latency high.
+        # p95 of model_request_duration over 15m exceeds 30s. Slow model calls
+        # drag out every investigation. 30s is a starting point — set it from
+        # your provider/model's observed latency profile.
+        - alert: RunloreModelLatencyHigh
+          expr: histogram_quantile(0.95, sum(rate(runlore_model_request_duration_seconds_bucket[15m])) by (le)) > 30
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore model p95 latency is high"
+            description: "p95 model-request latency is {{ $value | humanizeDuration }} over the last 15m (>30s) — investigations are slowed by model response time."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodellatencyhigh"
+
+        # 11. Slow incident resolution.
+        # p95 open->resolve time over 1h exceeds 1h. Informational SLO signal,
+        # not a paging condition. 3600s is a starting point — align with your
+        # incident-resolution SLO.
+        - alert: RunloreSlowResolution
+          expr: histogram_quantile(0.95, sum(rate(runlore_incident_resolution_seconds_bucket[1h])) by (le)) > 3600
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            summary: "RunLore incident resolution is slow"
+            description: "p95 incident resolution time (open -> resolved) is {{ $value | humanizeDuration }} over the last hour (>1h) — incidents are taking long to resolve."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreslowresolution"
+
+        # 12. Investigation token cost is high.
+        # p95 estimated tokens per investigation over 30m exceeds 100k — a cost
+        # guardrail. 100000 is a starting point; set it from your token budget
+        # and the model's pricing.
+        - alert: RunloreInvestigationCostHigh
+          expr: histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[30m])) by (le)) > 100000
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigation token cost is high"
+            description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — investigations are consuming an unusually large token budget; review cost."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationcosthigh"

--- a/deploy/observability/alerts/vmrule.yaml
+++ b/deploy/observability/alerts/vmrule.yaml
@@ -1,0 +1,192 @@
+# RunLore alerting rules — VictoriaMetrics Operator (VMRule) flavor.
+#
+# This is the VMRule variant. The alert logic here is IDENTICAL to the
+# PrometheusRule variant in ./prometheusrule.yaml — only apiVersion/kind differ.
+# RunLore is metrics-backend-agnostic, so we ship both and you apply whichever
+# your cluster uses. Do not let the two drift: change one, change the other.
+#
+# DISCOVERY NOTE — the VictoriaMetrics Operator discovers VMRule objects via the
+# `ruleSelector` / `ruleNamespaceSelector` on the VMAlert CR. By default many
+# VMAlert deployments select all VMRule in watched namespaces, so no extra label
+# is usually required. If this rule is not loaded, check your VMAlert selector:
+#   kubectl get vmalert -A -o jsonpath='{.items[*].spec.ruleSelector}'
+# and add a matching label under metadata.labels below if needed.
+#
+# All thresholds below are STARTING POINTS. Tune them to your traffic, model,
+# and SLOs before treating them as production-grade.
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMRule
+metadata:
+  name: runlore
+  labels:
+    app.kubernetes.io/name: runlore
+    role: alert-rules
+spec:
+  groups:
+    - name: runlore.rules
+      rules:
+        # 1. Agent is down or not being scraped.
+        # absent() fires when the series vanishes entirely from the TSDB, which
+        # means either the RunLore process is gone or the scrape target broke.
+        # Threshold/for is a starting point — tune to your scrape interval.
+        - alert: RunloreAgentDown
+          expr: absent(runlore_build_info)
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore agent is down or not scraped"
+            description: "No runlore_build_info series for 5m — the RunLore agent is down or its /metrics endpoint is not being scraped."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreagentdown"
+
+        # 2. No active leader (HA): nobody is investigating.
+        # In a multi-replica HA deployment exactly one replica should hold the
+        # lease (runlore_leader == 1). If the max across replicas is 0, no one is
+        # driving investigations. Starting point — tune `for` to lease churn.
+        - alert: RunloreNoActiveLeader
+          expr: max(runlore_leader) == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore has no active leader"
+            description: "No RunLore replica holds leadership for 10m (max(runlore_leader) == 0) — no investigations are being processed."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorenoactiveleader"
+
+        # 3. Split-brain: more than one leader at once.
+        # Two replicas both believing they are leader can double-process and
+        # double-spend on the model. Should be transient at most. Tune `for`.
+        - alert: RunloreMultipleLeaders
+          expr: sum(runlore_leader) > 1
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore has multiple leaders (split-brain)"
+            description: "{{ $value | humanize }} RunLore replicas report leadership simultaneously — possible split-brain; investigations may be duplicated."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremultipleleaders"
+
+        # 4. Investigations are being dropped.
+        # Dropped means an alert was discarded without investigation (e.g. queue
+        # overflow). Any drop in 15m is worth a look. for:0m = fire immediately;
+        # raise the increase() threshold if low-volume drops are acceptable.
+        - alert: RunloreInvestigationsDropped
+          expr: increase(runlore_investigations_dropped_total[15m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore is dropping investigations"
+            description: "{{ $value | humanize }} investigations dropped in the last 15m — alerts are being discarded without investigation (likely queue overflow or backpressure)."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationsdropped"
+
+        # 5. Sustained throttling.
+        # Brief throttling under a burst is normal; 30m of continuous throttling
+        # means RunLore is structurally under-provisioned for its load. Tune the
+        # `for` window and rate window to your expected burstiness.
+        - alert: RunloreInvestigationThrottlingSustained
+          expr: rate(runlore_investigations_throttled_total[10m]) > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigations throttled for a sustained period"
+            description: "RunLore has been throttling investigations continuously for 30m (rate {{ $value | humanize }}/s) — capacity may be insufficient for the incoming alert volume."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationthrottlingsustained"
+
+        # 6. Pipeline stalled: alerts arrive but nothing starts.
+        # Alerts are landing (received increases) yet zero investigations start —
+        # the intake-to-investigation handoff is broken. Critical. Tune windows.
+        - alert: RunlorePipelineStalled
+          expr: (increase(runlore_alerts_received_total[15m]) > 0) and (increase(runlore_investigations_started_total[15m]) == 0)
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore pipeline stalled — alerts received but no investigations started"
+            description: "{{ $value | humanize }} alerts received in the last 15m but zero investigations were started — the intake-to-investigation pipeline appears stalled."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runlorepipelinestalled"
+
+        # 7. Investigations completing with an error result.
+        # Investigations that finish in `result="error"` indicate the agent loop
+        # is failing mid-run. for:0m surfaces it promptly; raise the increase()
+        # threshold if a low error background rate is tolerable.
+        - alert: RunloreInvestigationErrors
+          expr: increase(runlore_investigations_completed_total{result="error"}[15m]) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigations are completing with errors"
+            description: "{{ $value | humanize }} investigations completed with result=error in the last 15m — the investigation loop is failing for some incidents."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationerrors"
+
+        # 8. Tool-call error rate is high.
+        # Error fraction across all tool calls > 20%, gated on a minimum call
+        # rate (>0.01/s) so the ratio is not noisy at near-zero traffic.
+        # clamp_min avoids divide-by-zero. 0.2 is a starting point.
+        - alert: RunloreToolErrorRateHigh
+          expr: sum(rate(runlore_tool_calls_total{result="error"}[15m])) / clamp_min(sum(rate(runlore_tool_calls_total[15m])), 0.001) > 0.2 and sum(rate(runlore_tool_calls_total[15m])) > 0.01
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore tool-call error rate is high"
+            description: "Tool-call error fraction is {{ $value | humanizePercentage }} over the last 15m (>20%) — investigation tools are failing frequently; check {{ $labels.tool }} integrations."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloretoolerrorratehigh"
+
+        # 9. Model-request error rate is high.
+        # Same shape as the tool-error rule but for the LLM provider, with a
+        # tighter 10% threshold — model errors stop investigations cold, so
+        # critical. Tune threshold to the provider's expected reliability.
+        - alert: RunloreModelErrorRateHigh
+          expr: sum(rate(runlore_model_requests_total{result="error"}[15m])) / clamp_min(sum(rate(runlore_model_requests_total[15m])), 0.001) > 0.1 and sum(rate(runlore_model_requests_total[15m])) > 0.01
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "RunLore model-request error rate is high"
+            description: "Model-request error fraction is {{ $value | humanizePercentage }} over the last 15m (>10%) — the LLM provider {{ $labels.provider }} is failing; investigations cannot complete."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodelerrorratehigh"
+
+        # 10. Model p95 latency high.
+        # p95 of model_request_duration over 15m exceeds 30s. Slow model calls
+        # drag out every investigation. 30s is a starting point — set it from
+        # your provider/model's observed latency profile.
+        - alert: RunloreModelLatencyHigh
+          expr: histogram_quantile(0.95, sum(rate(runlore_model_request_duration_seconds_bucket[15m])) by (le)) > 30
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore model p95 latency is high"
+            description: "p95 model-request latency is {{ $value | humanizeDuration }} over the last 15m (>30s) — investigations are slowed by model response time."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloremodellatencyhigh"
+
+        # 11. Slow incident resolution.
+        # p95 open->resolve time over 1h exceeds 1h. Informational SLO signal,
+        # not a paging condition. 3600s is a starting point — align with your
+        # incident-resolution SLO.
+        - alert: RunloreSlowResolution
+          expr: histogram_quantile(0.95, sum(rate(runlore_incident_resolution_seconds_bucket[1h])) by (le)) > 3600
+          for: 1h
+          labels:
+            severity: info
+          annotations:
+            summary: "RunLore incident resolution is slow"
+            description: "p95 incident resolution time (open -> resolved) is {{ $value | humanizeDuration }} over the last hour (>1h) — incidents are taking long to resolve."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreslowresolution"
+
+        # 12. Investigation token cost is high.
+        # p95 estimated tokens per investigation over 30m exceeds 100k — a cost
+        # guardrail. 100000 is a starting point; set it from your token budget
+        # and the model's pricing.
+        - alert: RunloreInvestigationCostHigh
+          expr: histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[30m])) by (le)) > 100000
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "RunLore investigation token cost is high"
+            description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — investigations are consuming an unusually large token budget; review cost."
+            runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationcosthigh"

--- a/deploy/observability/grafana/README.md
+++ b/deploy/observability/grafana/README.md
@@ -1,0 +1,61 @@
+# RunLore — Grafana dashboard
+
+`runlore.json` is a production-grade, **portable** Grafana dashboard for the RunLore SRE agent.
+
+## What it shows
+
+Panels are grouped into collapsible rows:
+
+| Row | Panels |
+| --- | --- |
+| **Overview** | Agent version (`runlore_build_info`), Active leaders (`sum(runlore_leader)`, green at exactly 1), Replicas reporting (`count(runlore_build_info)`) |
+| **Alert intake** | Received / coalesced / suppressed alert rates |
+| **Investigations** | Started/throttled/dropped rates; duration p50/p95/p99; completion rate by result |
+| **Tools & model** | Tool call rate by tool; tool error ratio; tool latency p95 by tool; model request rate by provider; model error ratio; model latency p95 by provider |
+| **Recall efficacy** | Recall hits/rejections + tokens-saved rate; BM25 recall-score heatmap |
+| **Learning loop** | Outcomes opened by kind + incidents resolved; resolution time p50/p95; recall outcome by result (pie); curation rate by kind/result |
+| **Cost** | Per-investigation token estimate p50/p95 + tokens-saved rate |
+
+Units follow conventions: rates use `ops`/`reqps`, durations use `s`, ratios use `percentunit`, token counts use `short`.
+
+## Portability — works on Prometheus **and** VictoriaMetrics
+
+The dashboard has a single templating variable, `datasource`, of type `datasource` with query `prometheus`. VictoriaMetrics registers in Grafana as a Prometheus-type datasource, so the same variable selects either backend.
+
+Every panel and every query target references `{"type": "prometheus", "uid": "${datasource}"}` — there are **no hardcoded datasource UIDs**. All `rate()` queries use `$__rate_interval`, so the dashboard adapts to the dashboard's resolution and the scrape interval automatically. The panel models target Grafana 10/11 (`schemaVersion: 39`).
+
+Pick your Prometheus or VictoriaMetrics datasource in the top-left `Data source` dropdown after import — nothing else needs editing.
+
+## How to import
+
+### Grafana UI
+
+1. Grafana → **Dashboards** → **New** → **Import**.
+2. **Upload JSON file** and select `runlore.json` (or paste its contents).
+3. When prompted, choose your Prometheus / VictoriaMetrics datasource for the `datasource` variable.
+4. Import.
+
+### Provisioning (file-based)
+
+Place `runlore.json` where a dashboard provider points, e.g.:
+
+```yaml
+# /etc/grafana/provisioning/dashboards/runlore.yaml
+apiVersion: 1
+providers:
+  - name: runlore
+    orgId: 1
+    folder: RunLore
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards/runlore
+```
+
+Copy `runlore.json` into that `path` and restart / reload Grafana. The `datasource` variable defaults to the configured default Prometheus-type datasource.
+
+## Requirements
+
+- The RunLore agent's `/metrics` endpoint must be scraped by your Prometheus or VictoriaMetrics instance (the agent exposes the `runlore_*` series this dashboard queries).
+- Grafana 10 or 11.

--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -1,0 +1,1184 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Build version reported by the running RunLore agent(s).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "blue", "value": null } ] },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 0, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "name"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "runlore_build_info",
+          "instant": true,
+          "legendFormat": "{{version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Agent version",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Number of leader replicas. Healthy = exactly 1.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 },
+              { "color": "red", "value": 2 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 8, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(runlore_leader)",
+          "instant": true,
+          "legendFormat": "leaders",
+          "refId": "A"
+        }
+      ],
+      "title": "Active leaders",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Replicas currently exporting build info (i.e. reporting to Prometheus).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "count(runlore_build_info)",
+          "instant": true,
+          "legendFormat": "replicas",
+          "refId": "A"
+        }
+      ],
+      "title": "Replicas reporting",
+      "type": "stat"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "id": 10,
+      "panels": [],
+      "title": "Alert intake",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Rate of alerts entering the coalescer, folded into existing batches, and suppressed by cooldown.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 7 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_alerts_received_total[$__rate_interval]))",
+          "legendFormat": "received",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_alerts_coalesced_total[$__rate_interval]))",
+          "legendFormat": "coalesced",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_alerts_suppressed_total[$__rate_interval]))",
+          "legendFormat": "suppressed",
+          "refId": "C"
+        }
+      ],
+      "title": "Alert intake rate",
+      "type": "timeseries"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "id": 20,
+      "panels": [],
+      "title": "Investigations",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Investigations started, requeued by the rate limiter, and dropped (max requeues / budget kill).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 21,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_investigations_started_total[$__rate_interval]))",
+          "legendFormat": "started",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_investigations_throttled_total[$__rate_interval]))",
+          "legendFormat": "throttled",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_investigations_dropped_total[$__rate_interval]))",
+          "legendFormat": "dropped",
+          "refId": "C"
+        }
+      ],
+      "title": "Investigation start/throttle/drop rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Investigation wall-clock duration percentiles.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 22,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(runlore_investigation_duration_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(runlore_investigation_duration_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(runlore_investigation_duration_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Investigation duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Completed investigations by result.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "id": 23,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (result) (rate(runlore_investigations_completed_total[$__rate_interval]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Investigation completion rate by result",
+      "type": "timeseries"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 30,
+      "panels": [],
+      "title": "Tools & model",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Tool invocation rate by tool.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "id": 31,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (tool) (rate(runlore_tool_calls_total[$__rate_interval]))",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool call rate by tool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Fraction of tool calls returning result=error.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.2 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "id": 32,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_tool_calls_total{result=\"error\"}[$__rate_interval])) / clamp_min(sum(rate(runlore_tool_calls_total[$__rate_interval])), 0.0001)",
+          "legendFormat": "error ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool error ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "p95 tool call latency by tool.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 41 },
+      "id": 33,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(runlore_tool_call_duration_seconds_bucket[$__rate_interval])) by (le, tool))",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Tool call latency p95 by tool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Model request rate by provider.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 41 },
+      "id": 34,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (provider) (rate(runlore_model_requests_total[$__rate_interval]))",
+          "legendFormat": "{{provider}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Model request rate by provider",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Fraction of model requests returning result=error.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.2 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 49 },
+      "id": 35,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_model_requests_total{result=\"error\"}[$__rate_interval])) / clamp_min(sum(rate(runlore_model_requests_total[$__rate_interval])), 0.0001)",
+          "legendFormat": "error ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Model error ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "p95 model request latency by provider.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 49 },
+      "id": 36,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(runlore_model_request_duration_seconds_bucket[$__rate_interval])) by (le, provider))",
+          "legendFormat": "{{provider}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Model request latency p95 by provider",
+      "type": "timeseries"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 57 },
+      "id": 40,
+      "panels": [],
+      "title": "Recall efficacy",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Knowledge-base instant-recall short-circuit rate (by verify result) and estimated tokens saved per second.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "tokens saved /s" },
+            "properties": [
+              { "id": "unit", "value": "short" },
+              { "id": "custom.axisPlacement", "value": "right" }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 58 },
+      "id": 41,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (result) (rate(runlore_recall_hits_total[$__rate_interval]))",
+          "legendFormat": "hits {{result}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (reason) (rate(runlore_recall_rejections_total[$__rate_interval]))",
+          "legendFormat": "rejected {{reason}}",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_recall_tokens_saved_total[$__rate_interval]))",
+          "legendFormat": "tokens saved /s",
+          "refId": "C"
+        }
+      ],
+      "title": "Recall hits & tokens saved",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Distribution of BM25 recall scores at the decision point. Use this to tune min_score.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "scaleDistribution": { "type": "linear" }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 58 },
+      "id": 42,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": { "color": "rgba(255,0,255,0.7)" },
+        "filterValues": { "le": 1e-9 },
+        "legend": { "show": true },
+        "rowsFrame": { "layout": "auto" },
+        "tooltip": { "mode": "single", "show": true, "yHistogram": false },
+        "yAxis": { "axisPlacement": "left", "reverse": false, "unit": "short" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_recall_score_bucket[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Recall score distribution (BM25)",
+      "type": "heatmap"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 66 },
+      "id": 50,
+      "panels": [],
+      "title": "Learning loop",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Investigations recorded in the outcome ledger (by kind) and incidents later resolved.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 67 },
+      "id": 51,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (kind) (rate(runlore_outcomes_opened_total[$__rate_interval]))",
+          "legendFormat": "opened {{kind}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_incidents_resolved_total[$__rate_interval]))",
+          "legendFormat": "resolved",
+          "refId": "B"
+        }
+      ],
+      "title": "Outcomes opened & incidents resolved",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Open to resolve duration percentiles.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
+      "id": 52,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(runlore_incident_resolution_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(runlore_incident_resolution_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "Incident resolution time (p50 / p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Outcome of resolved incidents whose original answer was a recall short-circuit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 75 },
+      "id": 53,
+      "options": {
+        "displayLabels": [ "percent" ],
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": [ "value" ] },
+        "pieType": "pie",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (result) (increase(runlore_recall_outcome_total[$__range]))",
+          "instant": true,
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Recall outcome by result",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Curation pass outcomes (catalog writes / dedup skips) by kind and result.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 75 },
+      "id": 54,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum by (kind, result) (rate(runlore_curations_total[$__rate_interval]))",
+          "legendFormat": "{{kind}} / {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Curation rate by kind & result",
+      "type": "timeseries"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 83 },
+      "id": 60,
+      "panels": [],
+      "title": "Cost",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Per-investigation token estimate (p50 / p95) and estimated tokens saved per second via recall.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "tokens saved /s" },
+            "properties": [ { "id": "custom.axisPlacement", "value": "right" } ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 84 },
+      "id": 61,
+      "options": {
+        "legend": { "calcs": [ "mean", "lastNotNull" ], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "tokens/investigation p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "tokens/investigation p95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_recall_tokens_saved_total[$__rate_interval]))",
+          "legendFormat": "tokens saved /s",
+          "refId": "C"
+        }
+      ],
+      "title": "Token cost & savings",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [ "runlore", "sre" ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "RunLore — SRE Agent",
+  "uid": "runlore-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,100 @@
+# Observability
+
+RunLore self-instruments with structured logs and Prometheus-compatible metrics, and
+ships a portable Grafana dashboard plus alert rules. Everything here works against
+**either Prometheus or VictoriaMetrics** — RunLore is metrics-backend-agnostic.
+
+## Logging
+
+RunLore logs via Go's `log/slog`. Output format and verbosity are configurable:
+
+```yaml
+logging:
+  format: json   # "text" (default, human-readable) | "json" (structured, for log aggregation)
+  level: info    # debug | info | warn | error
+```
+
+The Helm chart defaults to **JSON** in-cluster (so logs flow cleanly into
+Loki/VictoriaLogs/CloudWatch); the CLI defaults to text. Both are overridable at
+startup without editing config:
+
+```bash
+RUNLORE_LOG_FORMAT=json RUNLORE_LOG_LEVEL=debug lore serve --config runlore.yaml
+```
+
+Level guidance: `error` = an operation failed; `warn` = a recoverable/degraded
+condition (a backend unavailable, a provider disabled); `info` = lifecycle and
+per-incident milestones; `debug` = per-step / per-tool tracing (off in production).
+
+## Metrics
+
+When `telemetry.metrics_enabled: true`, RunLore serves the Prometheus exposition
+format at `GET /metrics` on the service port. Scrape it with a `VMServiceScrape`
+(`vmServiceScrape.enabled: true` in the chart) or any `ServiceMonitor`/scrape config.
+
+All series are prefixed `runlore_`.
+
+### Pipeline & investigations
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `runlore_build_info` | gauge | `version` | constant 1; for `absent()` liveness + version display |
+| `runlore_leader` | gauge | — | 1 on the elected leader, 0 on standbys |
+| `runlore_alerts_received_total` | counter | — | incidents passing the trigger gate into the coalescer |
+| `runlore_alerts_coalesced_total` | counter | — | incidents folded into an existing batch |
+| `runlore_alerts_suppressed_total` | counter | — | incidents dropped by cooldown |
+| `runlore_investigations_started_total` | counter | — | investigations actually begun |
+| `runlore_investigations_completed_total` | counter | `result` | investigations finished (`resolved`/`unresolved`/`recall`/`error`/`max_steps`/`budget_exceeded`/`inconclusive`) |
+| `runlore_investigation_duration_seconds` | histogram | `result` | wall-clock per investigation |
+| `runlore_investigations_throttled_total` | counter | — | starts requeued by the rate limiter |
+| `runlore_investigations_dropped_total` | counter | — | dropped (rate-limiter max-requeues or token-budget kill) |
+
+### Tools & model
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `runlore_tool_calls_total` | counter | `tool`, `result` | investigation tool calls (`ok`/`error`) |
+| `runlore_tool_call_duration_seconds` | histogram | `tool` | per-tool latency |
+| `runlore_model_requests_total` | counter | `provider`, `result` | LLM completion requests (`ok`/`error`) |
+| `runlore_model_request_duration_seconds` | histogram | `provider` | LLM completion latency |
+| `runlore_investigation_tokens_estimated` | histogram | — | per-investigation token estimate |
+
+### Recall, learning loop & curation
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `runlore_recall_hits_total` | counter | `result` | instant-recall short-circuits |
+| `runlore_recall_tokens_saved_total` | counter | — | estimated tokens saved by recall |
+| `runlore_recall_rejections_total` | counter | `reason` | recalls rejected before short-circuit |
+| `runlore_recall_score` | histogram | — | BM25 score at the recall decision |
+| `runlore_outcomes_opened_total` | counter | `kind` | investigations recorded as open |
+| `runlore_incidents_resolved_total` | counter | — | resolve events matching an open investigation |
+| `runlore_recall_outcome_total` | counter | `result` | resolved incidents whose answer was a recall |
+| `runlore_incident_resolution_seconds` | histogram | — | open→resolve duration |
+| `runlore_curations_total` | counter | `kind`, `result` | curation outcomes (`opened`/`coalesced`/`error`) |
+| `runlore_curation_dedup_score` | histogram | — | catalog top-hit BM25 score at the dedup decision |
+
+## Grafana dashboard
+
+A portable dashboard lives at [`deploy/observability/grafana/runlore.json`](../deploy/observability/grafana/runlore.json).
+It uses a single `datasource` template variable (type Prometheus), so it works with a
+Prometheus **or** a VictoriaMetrics datasource with no edits. Import it via
+**Dashboards → Import → Upload JSON**, or provision it. See the
+[grafana README](../deploy/observability/grafana/README.md).
+
+## Alerting
+
+Alert rules ship as both a Prometheus-Operator `PrometheusRule` and a
+VictoriaMetrics-Operator `VMRule` (identical rules; pick the one your stack uses):
+
+```bash
+# kube-prometheus-stack
+kubectl apply -f deploy/observability/alerts/prometheusrule.yaml
+# VictoriaMetrics Operator
+kubectl apply -f deploy/observability/alerts/vmrule.yaml
+```
+
+The rule set covers liveness (`RunloreAgentDown`), HA (`RunloreNoActiveLeader`,
+`RunloreMultipleLeaders`), pipeline health (`RunlorePipelineStalled`,
+`RunloreInvestigationsDropped`, throttling), quality (tool/model error rates,
+investigation errors), latency (model p95, slow resolution), and cost
+(`RunloreInvestigationCostHigh`). Thresholds are starting points — tune to your
+volume. See the [alerts README](../deploy/observability/alerts/README.md) for the
+per-alert metric dependencies and operator discovery notes.

--- a/docs/superpowers/specs/2026-06-24-observability-design.md
+++ b/docs/superpowers/specs/2026-06-24-observability-design.md
@@ -1,0 +1,45 @@
+# Design — Observability: structured logging, metrics, dashboard & alerts
+
+Date: 2026-06-24 · Status: approved (autonomous) · Worktree: `feat/observability`
+
+## Problem
+
+- **Logging**: `slog.NewTextHandler` was hardcoded at every site (6×) with `nil` options
+  → no JSON output, no level control, no central constructor. In-cluster logs couldn't be
+  shipped as structured records.
+- **Metrics**: a good OTel→Prometheus set existed, but lacked per-tool / per-model /
+  per-investigation-duration / completion-result / build-info / leadership signals needed
+  for a useful dashboard and meaningful alerts.
+- **No Grafana dashboard and no alert rules** shipped at all.
+
+## Changes
+
+### Logging (`internal/logging`)
+- `New(w, format, level)` builds a text or JSON slog handler at a parsed level.
+- `FromConfig(w, format, level)` applies `RUNLORE_LOG_FORMAT` / `RUNLORE_LOG_LEVEL` overrides.
+- `config.Logging{Format, Level}` (`logging:` block). All 5 live logger sites in `cmd/lore`
+  route through `FromConfig`; the `io.Discard` eval logger stays silent by design.
+- Helm defaults in-cluster to JSON/info.
+
+### Metrics (`internal/telemetry`)
+New instruments (names are the dashboard/alert contract — covered by a test):
+`runlore_build_info{version}`, `runlore_leader`, `runlore_investigation_duration_seconds{result}`,
+`runlore_investigations_completed_total{result}`, `runlore_tool_calls_total{tool,result}`,
+`runlore_tool_call_duration_seconds{tool}`, `runlore_model_requests_total{provider,result}`,
+`runlore_model_request_duration_seconds{provider}`, `runlore_curations_total{kind,result}`.
+- Gauges via `RegisterRuntimeGauges(version, isLeader)` (observable; wired in `serve` after
+  leader election). `NewMetrics()` signature is unchanged (many call sites/tests depend on it).
+- Wired at the natural chokepoints: the loop's model call + `runTool` + each `Investigate`
+  exit (deferred recorder, result-tagged), and the curator's PR/coalesce paths.
+
+### Dashboard & alerts (`deploy/observability/`, portable — any environment)
+- `grafana/runlore.json` — one `datasource` template var (Prometheus type → works for
+  Prometheus *and* VictoriaMetrics), `$__rate_interval`, no hardcoded UIDs.
+- `alerts/prometheusrule.yaml` + `alerts/vmrule.yaml` — identical 12-rule set (liveness, HA,
+  pipeline-stall, error rates, latency, cost), shipped for both operators.
+- `docs/observability.md` documents logging, the metric reference, dashboard import, alerts.
+
+## Testing
+`logging` unit tests (format/level/env-override); a telemetry test that scrapes `/metrics`
+and asserts every new contract series name is exposed (rename ⇒ test breaks).
+build / vet / gofmt / test / golangci-lint all clean.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,16 @@ type Config struct {
 
 	Investigation Investigation `yaml:"investigation"` // coalescing + rate-limit + per-investigation token controls
 	Telemetry     Telemetry     `yaml:"telemetry"`     // OpenTelemetry metrics
+	Logging       Logging       `yaml:"logging"`       // structured-logging format + verbosity
+}
+
+// Logging configures the structured logger. Format selects human-readable text
+// (default, for local CLI) or JSON (for in-cluster log aggregation). Level sets
+// verbosity. Both are overridable at startup via RUNLORE_LOG_FORMAT /
+// RUNLORE_LOG_LEVEL (see internal/logging).
+type Logging struct {
+	Format string `yaml:"format"` // "text" (default) | "json"
+	Level  string `yaml:"level"`  // "debug" | "info" (default) | "warn" | "error"
 }
 
 // Endpoint is a backend base URL; empty disables the corresponding tool.

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"log/slog"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
@@ -64,9 +67,11 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 		c.Log.Warn("dedup: list open PRs failed", "err", err)
 	} else if ok {
 		if err := c.Forge.Comment(ctx, n, coalesceComment(inv)); err != nil {
+			c.recordCuration(ctx, "pr", "error")
 			return providers.Ref{}, fmt.Errorf("coalesce comment: %w", err)
 		}
 		c.Log.Info("finding coalesced onto an open PR", "pr", n)
+		c.recordCuration(ctx, "pr", "coalesced")
 		return providers.Ref{}, nil
 	}
 
@@ -74,10 +79,22 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 	// later advances solved/resolved/ready-to-merge — Phase 2, not here)
 	ref, err := c.Forge.OpenPR(ctx, draftKBEntry(inv))
 	if err != nil {
+		c.recordCuration(ctx, "pr", "error")
 		return providers.Ref{}, fmt.Errorf("open PR: %w", err)
 	}
 	c.Log.Info("curated as PR", "url", ref.URL, "confidence", inv.Confidence)
+	c.recordCuration(ctx, "pr", "opened")
 	return ref, nil
+}
+
+// recordCuration increments the curations_total counter (nil-safe). kind is the
+// forge artifact (e.g. "pr"); result is opened | coalesced | error.
+func (c *Curator) recordCuration(ctx context.Context, kind, result string) {
+	if c.Metrics == nil {
+		return
+	}
+	c.Metrics.Curations.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("kind", kind), attribute.String("result", result)))
 }
 
 // duplicateOpenPR reports an open KB PR whose stored dedup fingerprint matches this

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -92,7 +93,8 @@ type LoopInvestigator struct {
 	MaxTokensPerInvestigation int // inject a budget-nudge message when the estimated token count exceeds this
 
 	// Observability — nil-safe; no-op when telemetry is disabled.
-	Metrics *telemetry.Metrics
+	Metrics       *telemetry.Metrics
+	ModelProvider string // label for model_requests/model_request_duration metrics (e.g. "anthropic")
 }
 
 // system returns the system prompt, asking for action proposals when the policy is enabled.
@@ -105,6 +107,16 @@ func (li *LoopInvestigator) system() string {
 
 // Investigate runs the loop for a request. It implements Investigator.
 func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error {
+	// Record wall-clock duration + a completion-result label at whichever exit we take.
+	start := time.Now()
+	result := "unresolved"
+	defer func() {
+		if li.Metrics != nil {
+			attrs := metric.WithAttributes(attribute.String("result", result))
+			li.Metrics.InvestigationDuration.Record(ctx, time.Since(start).Seconds(), attrs)
+			li.Metrics.InvestigationsCompleted.Add(ctx, 1, attrs)
+		}
+	}()
 	// Instant recall is disabled under auto-execution: a poisoned catalog entry must
 	// not short-circuit a real investigation straight into an auto-executed action.
 	if li.Recall != nil && (li.Actions == nil || !li.Actions.IsAuto()) {
@@ -126,20 +138,21 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			}
 			// Instrument the recall result by verify outcome.
 			if m := li.Recall.Metrics; m != nil {
-				result := "verified"
+				recallResult := "verified"
 				switch {
 				case len(rec.RootCauses) == 0:
-					result = "rejected"
+					recallResult = "rejected"
 				case li.Verify && rec.Confidence < initialConfidence:
-					result = "downgraded"
+					recallResult = "downgraded"
 				}
 				saved := int64(li.MaxTokensPerInvestigation)
 				if saved == 0 {
 					saved = defaultRecallTokensSavedEstimate // conservative proxy when budget is unconfigured
 				}
-				m.RecallHits.Add(ctx, 1, metric.WithAttributes(attribute.String("result", result)))
+				m.RecallHits.Add(ctx, 1, metric.WithAttributes(attribute.String("result", recallResult)))
 				m.RecallTokensSaved.Add(ctx, saved)
 			}
+			result = "recall"
 			li.deliver(req, rec)
 			return nil
 		}
@@ -183,12 +196,25 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				if li.Metrics != nil {
 					li.Metrics.InvestigationsDropped.Add(ctx, 1)
 				}
+				result = "budget_exceeded"
 				li.deliver(req, budgetKillResult(req))
 				return nil
 			}
 		}
+		mstart := time.Now()
 		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: sys, Messages: messages, Tools: specs})
+		if li.Metrics != nil {
+			mres := "ok"
+			if err != nil {
+				mres = "error"
+			}
+			li.Metrics.ModelRequests.Add(ctx, 1, metric.WithAttributes(
+				attribute.String("provider", li.ModelProvider), attribute.String("result", mres)))
+			li.Metrics.ModelRequestDuration.Record(ctx, time.Since(mstart).Seconds(),
+				metric.WithAttributes(attribute.String("provider", li.ModelProvider)))
+		}
 		if err != nil {
+			result = "error"
 			return fmt.Errorf("model: %w", err)
 		}
 		li.Log.Debug("investigation step", "title", req.Title, "step", step, "tool_calls", len(resp.ToolCalls), "text_len", len(resp.Text))
@@ -199,6 +225,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			// only give up if it still won't after the nudge.
 			if nudged {
 				li.Log.Warn("investigation inconclusive (no submit_findings after nudge)", "title", req.Title, "tools_used", used)
+				result = "inconclusive"
 				return nil
 			}
 			nudged = true
@@ -232,6 +259,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 					inv = li.verifyFindings(ctx, req, inv)
 				}
 				inv.Actions = li.reviewActions(inv.Actions)
+				result = "resolved"
 				li.deliver(req, inv)
 				return nil
 			}
@@ -244,6 +272,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		}
 	}
 	li.Log.Warn("investigation hit max steps", "title", req.Title, "max", maxSteps, "tools_used", used)
+	result = "max_steps"
 	return nil
 }
 
@@ -252,7 +281,18 @@ func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool,
 	if !ok {
 		return "unknown tool: " + tc.Name
 	}
+	tstart := time.Now()
 	out, err := tool.Call(ctx, tc.Args)
+	if li.Metrics != nil {
+		tres := "ok"
+		if err != nil {
+			tres = "error"
+		}
+		li.Metrics.ToolCalls.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("tool", tc.Name), attribute.String("result", tres)))
+		li.Metrics.ToolCallDuration.Record(ctx, time.Since(tstart).Seconds(),
+			metric.WithAttributes(attribute.String("tool", tc.Name)))
+	}
 	if err != nil {
 		return "error: " + err.Error()
 	}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,66 @@
+// Package logging builds RunLore's slog logger with a configurable output format
+// (human-readable text or structured JSON) and verbosity level. In-cluster
+// deployments choose JSON so logs are ingestible by Loki/VictoriaLogs/CloudWatch;
+// local CLI runs keep text. Format and level come from config, with the
+// RUNLORE_LOG_FORMAT / RUNLORE_LOG_LEVEL env vars overriding (so verbosity is
+// tunable without editing config — useful for a quick debug session).
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+// Format identifiers for the log handler.
+const (
+	FormatText = "text" // default; human-readable
+	FormatJSON = "json" // structured, for log aggregation backends
+)
+
+// Env vars that override the configured format/level at startup.
+const (
+	EnvFormat = "RUNLORE_LOG_FORMAT"
+	EnvLevel  = "RUNLORE_LOG_LEVEL"
+)
+
+// New returns a slog.Logger writing to w with the given format and level.
+// An unrecognized format falls back to text; an unrecognized/empty level to info.
+func New(w io.Writer, format, level string) *slog.Logger {
+	opts := &slog.HandlerOptions{Level: ParseLevel(level)}
+	var h slog.Handler
+	if strings.EqualFold(strings.TrimSpace(format), FormatJSON) {
+		h = slog.NewJSONHandler(w, opts)
+	} else {
+		h = slog.NewTextHandler(w, opts)
+	}
+	return slog.New(h)
+}
+
+// FromConfig builds a logger from the configured format/level, with the
+// RUNLORE_LOG_FORMAT / RUNLORE_LOG_LEVEL env vars taking precedence when set.
+func FromConfig(w io.Writer, format, level string) *slog.Logger {
+	if v := os.Getenv(EnvFormat); v != "" {
+		format = v
+	}
+	if v := os.Getenv(EnvLevel); v != "" {
+		level = v
+	}
+	return New(w, format, level)
+}
+
+// ParseLevel maps a level name (case-insensitive) to a slog.Level. Unknown or
+// empty values map to Info — the safe production default.
+func ParseLevel(s string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,83 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestParseLevel(t *testing.T) {
+	cases := map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"DEBUG":   slog.LevelDebug,
+		"info":    slog.LevelInfo,
+		"":        slog.LevelInfo,
+		"bogus":   slog.LevelInfo,
+		"warn":    slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"error":   slog.LevelError,
+	}
+	for in, want := range cases {
+		if got := ParseLevel(in); got != want {
+			t.Errorf("ParseLevel(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestNewJSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	log := New(&buf, FormatJSON, "info")
+	log.Info("hello", "k", "v")
+
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("output is not JSON: %v\n%s", err, buf.String())
+	}
+	if rec["msg"] != "hello" || rec["k"] != "v" {
+		t.Errorf("unexpected JSON record: %v", rec)
+	}
+}
+
+func TestNewTextFormatDefault(t *testing.T) {
+	var buf bytes.Buffer
+	// Unknown format falls back to text (not JSON).
+	log := New(&buf, "wat", "info")
+	log.Info("hello", "k", "v")
+	out := buf.String()
+	if !strings.Contains(out, "msg=hello") || !strings.Contains(out, "k=v") {
+		t.Errorf("expected text output, got: %q", out)
+	}
+	if strings.HasPrefix(strings.TrimSpace(out), "{") {
+		t.Errorf("expected text, got JSON: %q", out)
+	}
+}
+
+func TestLevelFiltersDebug(t *testing.T) {
+	var buf bytes.Buffer
+	log := New(&buf, FormatText, "info")
+	log.Debug("should be filtered")
+	if buf.Len() != 0 {
+		t.Errorf("debug line emitted at info level: %q", buf.String())
+	}
+	log.Warn("should appear")
+	if !strings.Contains(buf.String(), "should appear") {
+		t.Errorf("warn line missing: %q", buf.String())
+	}
+}
+
+func TestFromConfigEnvOverride(t *testing.T) {
+	t.Setenv(EnvFormat, "json")
+	t.Setenv(EnvLevel, "debug")
+	var buf bytes.Buffer
+	log := FromConfig(&buf, FormatText, "error") // config says text/error; env wins
+	log.Debug("dbg")
+	var rec map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &rec); err != nil {
+		t.Fatalf("env did not switch to JSON: %v\n%s", err, buf.String())
+	}
+	if rec["msg"] != "dbg" {
+		t.Errorf("env did not lower level to debug: %v", rec)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -5,7 +5,10 @@
 package telemetry
 
 import (
+	"context"
+
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -31,6 +34,14 @@ type Metrics struct {
 	IncidentsResolved         metric.Int64Counter     // resolve events that matched an open investigation
 	RecallOutcome             metric.Int64Counter     // resolved incidents whose open was a recall (label: result)
 	IncidentResolutionSeconds metric.Float64Histogram // open→resolve duration, seconds
+
+	InvestigationDuration   metric.Float64Histogram // wall-clock per investigation (label: result)
+	InvestigationsCompleted metric.Int64Counter     // investigations finished (label: result)
+	ToolCalls               metric.Int64Counter     // investigation tool calls (label: tool, result)
+	ToolCallDuration        metric.Float64Histogram // tool call latency, seconds (label: tool)
+	ModelRequests           metric.Int64Counter     // LLM completion requests (label: provider, result)
+	ModelRequestDuration    metric.Float64Histogram // LLM completion latency, seconds (label: provider)
+	Curations               metric.Int64Counter     // curation outcomes (label: kind, result)
 }
 
 // NewMetrics builds the instrument set from the global meter provider.
@@ -67,5 +78,43 @@ func NewMetrics() *Metrics {
 		IncidentsResolved:         ctr("incidents_resolved_total", "resolve events that matched an open investigation"),
 		RecallOutcome:             ctr("recall_outcome_total", "resolved incidents whose answer was a recall (label: result)"),
 		IncidentResolutionSeconds: histF("incident_resolution_seconds", "open→resolve duration in seconds"),
+
+		InvestigationDuration:   histF("investigation_duration_seconds", "wall-clock duration of an investigation (label: result)"),
+		InvestigationsCompleted: ctr("investigations_completed_total", "investigations that finished (label: result)"),
+		ToolCalls:               ctr("tool_calls_total", "investigation tool calls (label: tool, result)"),
+		ToolCallDuration:        histF("tool_call_duration_seconds", "investigation tool call latency in seconds (label: tool)"),
+		ModelRequests:           ctr("model_requests_total", "LLM completion requests (label: provider, result)"),
+		ModelRequestDuration:    histF("model_request_duration_seconds", "LLM completion latency in seconds (label: provider)"),
+		Curations:               ctr("curations_total", "curation outcomes written to the forge (label: kind, result)"),
 	}
+}
+
+// RegisterRuntimeGauges registers async gauges for build info and leadership. Call
+// once after Setup (when a real provider is installed); with the no-op provider it
+// is a harmless no-op. isLeader may be nil (always reports standby). It exposes:
+//   - runlore_build_info{version} = 1  (for `absent()` liveness + version display)
+//   - runlore_leader = 1 when this replica is the elected leader, else 0
+func RegisterRuntimeGauges(version string, isLeader func() bool) error {
+	m := otel.Meter(scope)
+	if _, err := m.Int64ObservableGauge("runlore_build_info",
+		metric.WithDescription("build info; constant 1 carrying a version label"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			o.Observe(1, metric.WithAttributes(attribute.String("version", version)))
+			return nil
+		}),
+	); err != nil {
+		return err
+	}
+	_, err := m.Int64ObservableGauge("runlore_leader",
+		metric.WithDescription("1 when this replica is the elected leader, else 0"),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			var v int64
+			if isLeader != nil && isLeader() {
+				v = 1
+			}
+			o.Observe(v)
+			return nil
+		}),
+	)
+	return err
 }

--- a/internal/telemetry/metrics_extra_test.go
+++ b/internal/telemetry/metrics_extra_test.go
@@ -1,0 +1,67 @@
+package telemetry
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// TestNewInstrumentsExposeContractNames records the A2 instruments and asserts the
+// exact Prometheus series names appear at /metrics — these names are the contract the
+// Grafana dashboard and the alert rules depend on, so a rename must break this test.
+func TestNewInstrumentsExposeContractNames(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+
+	h, shutdown, err := Setup(context.Background())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
+	m := NewMetrics()
+	ctx := context.Background()
+	m.InvestigationDuration.Record(ctx, 1.5, metric.WithAttributes(attribute.String("result", "resolved")))
+	m.InvestigationsCompleted.Add(ctx, 1, metric.WithAttributes(attribute.String("result", "resolved")))
+	m.ToolCalls.Add(ctx, 1, metric.WithAttributes(attribute.String("tool", "query_metrics"), attribute.String("result", "ok")))
+	m.ToolCallDuration.Record(ctx, 0.2, metric.WithAttributes(attribute.String("tool", "query_metrics")))
+	m.ModelRequests.Add(ctx, 1, metric.WithAttributes(attribute.String("provider", "anthropic"), attribute.String("result", "ok")))
+	m.ModelRequestDuration.Record(ctx, 0.9, metric.WithAttributes(attribute.String("provider", "anthropic")))
+	m.Curations.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", "pr"), attribute.String("result", "opened")))
+
+	if err := RegisterRuntimeGauges("1.2.3", func() bool { return true }); err != nil {
+		t.Fatalf("register gauges: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	want := []string{
+		"runlore_investigation_duration_seconds",
+		"runlore_investigations_completed_total",
+		"runlore_tool_calls_total",
+		"runlore_tool_call_duration_seconds",
+		"runlore_model_requests_total",
+		"runlore_model_request_duration_seconds",
+		"runlore_curations_total",
+		"runlore_build_info",
+		"runlore_leader",
+	}
+	for _, name := range want {
+		if !strings.Contains(body, name) {
+			t.Errorf("missing series %q in /metrics output", name)
+		}
+	}
+	// build_info must carry the version label, and leader must read 1 here.
+	if !strings.Contains(body, `version="1.2.3"`) {
+		t.Errorf("runlore_build_info missing version label\n%s", body)
+	}
+}


### PR DESCRIPTION
## Why

Three gaps in RunLore's self-observability:
- **Logging** hardcoded `slog.NewTextHandler` at every site — no JSON output, no level control, no central constructor. In-cluster logs couldn't be shipped as structured records.
- **Metrics** had a solid base but lacked per-tool / per-model / investigation-duration / completion-result / build-info / leadership signals.
- **No Grafana dashboard and no alert rules** shipped at all.

## What

### Logging (`internal/logging`)
- `FromConfig(w, format, level)` builds a text or JSON slog handler at a parsed level, with `RUNLORE_LOG_FORMAT` / `RUNLORE_LOG_LEVEL` env overrides. New `config.Logging` block.
- All 5 live logger sites route through it (the `io.Discard` eval logger stays silent by design). Helm defaults in-cluster to **JSON** (ingestible by Loki/VictoriaLogs/CloudWatch).

### Metrics (`internal/telemetry`) — names are the dashboard/alert contract (covered by a test)
- `runlore_build_info{version}`, `runlore_leader` (observable gauges via `RegisterRuntimeGauges`, wired in `serve` after leader election; `NewMetrics()` signature unchanged).
- `runlore_investigation_duration_seconds{result}` + `runlore_investigations_completed_total{result}` (deferred, result-tagged at every loop exit).
- `runlore_tool_calls_total{tool,result}` + `runlore_tool_call_duration_seconds{tool}`.
- `runlore_model_requests_total{provider,result}` + `runlore_model_request_duration_seconds{provider}`.
- `runlore_curations_total{kind,result}` (curator PR / coalesce paths).

### Dashboard & alerts (`deploy/observability/` — portable to ANY Prometheus/VictoriaMetrics)
- `grafana/runlore.json`: a single `datasource` template variable (Prometheus type → also covers VictoriaMetrics), `$__rate_interval`, no hardcoded UIDs; 7 rows / 20 panels.
- `alerts/prometheusrule.yaml` + `alerts/vmrule.yaml`: identical 12-rule set (liveness, HA, pipeline-stall, tool/model error rates, latency, cost) for both operators.
- `docs/observability.md`: logging config, full metric reference, dashboard import, alert install.

## Verification
- New tests: `logging` (format/level/env-override); a telemetry test scraping `/metrics` that asserts every new contract series name (a rename breaks it).
- `go build`, `go vet`, `gofmt -l`, `go test ./...` (34 pkgs, 0 failures), `golangci-lint run` — all clean.