### PR TITLE
docs: README as a project presentation (learning-loop & Kubernetes first), refresh getting-started + design

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,40 +10,54 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/Smana/runlore)](https://goreportcard.com/report/github.com/Smana/runlore)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/Smana/runlore)](go.mod)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-early%20development-orange)](docs/design.md)
+[![Status](https://img.shields.io/badge/status-active%20development-brightgreen)](docs/design.md)
 
 </div>
 
 ---
 
 RunLore is an **on-call teammate that never sleeps**. It wakes on any incident — *whatever the cause* —
-and works it like a good SRE:
+investigates it like a good SRE, and hands you a confidence-scored root cause with evidence:
 
 - **What changed?** *(the sharpest first question)* — deploys, config, images, infra, certs, scaling;
   on a GitOps platform, the **exact Git diff**.
-- **What's wrong?** *(when nothing changed)* — saturation, network drops, node health, dependency
+- **What's wrong?** *(when nothing changed)* — saturation, network denials, node health, dependency
   outages, load.
 
-…then it hands you a confidence-scored root cause with evidence and **learns** — each resolved incident
-becomes a reviewed entry in an open, git-versioned knowledge base, so it gets sharper at **your**
-platform over time.
+…and then it does the thing other agents don't: it **learns**. Every resolved incident becomes a
+reviewed entry in an open, git-versioned knowledge base — so RunLore gets sharper at **your** platform,
+incident after incident.
 
-**Read-only first · single Go binary · in your terminal or your cluster · on your models.**
+**Read-only by default · single Go binary · runs in your cluster · on your models.**
 
-## Why another one?
+## 📚 The learning loop — RunLore's reason to exist
 
-The autonomous *alert → RCA → Slack* loop is already a **commodity**. RunLore's bet is the part that
-isn't: a **GitOps-native "what changed" spine** and an **open knowledge base that compounds**.
+The autonomous *alert → RCA → Slack* loop is already a commodity. What isn't: an agent whose knowledge
+**compounds in a catalog you own**. A normal SRE agent answers the same incident from scratch every
+time. RunLore **remembers** — in four moves:
 
-| | What it is | What RunLore adds |
-|---|---|---|
-| [**k8sgpt**](https://github.com/k8sgpt-ai/k8sgpt) | A *detector* — analyzers + LLM explanation | An investigation loop, cross-signal correlation, real Git diffs, and learning |
-| [**HolmesGPT**](https://github.com/HolmesGPT/holmesgpt) | The strongest OSS investigation agent | Prometheus/Loki-centric and relies on *your* hand-curated runbooks (it doesn't learn); RunLore is metrics-agnostic, what-changed-first, and self-improving |
-| [**kagent**](https://github.com/kagent-dev/kagent) | A generic in-cluster agent *framework* | A focused, opinionated SRE agent (and RunLore can run *on* kagent later) |
+```mermaid
+flowchart LR
+    R["🔎 Retrieve<br/>recall a past answer"] --> C["🧪 Capture<br/>record what happened"]
+    C --> U["📝 Curate<br/>write/refine the note (PR)"]
+    U --> P["♻️ Compound<br/>merged note re-indexed"]
+    P --> R
+    classDef s fill:#eef,stroke:#557,stroke-width:1px,color:#113;
+    class R,C,U,P s;
+```
 
-RunLore is **GitOps-engine-agnostic** (Flux + Argo), **metrics-backend-agnostic** (VictoriaMetrics +
-Prometheus), and the only one that **learns into an open** [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
-knowledge catalog you own — portable markdown in git, never vendor lock-in.
+- **Retrieve** — on a new incident, recall a trustworthy matching note and answer in milliseconds
+  instead of re-running a multi-minute investigation (*instant recall*).
+- **Capture** — record that the incident happened and whether it then actually resolved.
+- **Curate** — turn a fresh, *verified* finding into a reviewable catalog entry via PR (duplicates
+  collapse automatically).
+- **Compound** — once a human merges the PR, the note is re-indexed and recall-able for everyone.
+
+Two things make this **learning**, not note-taking: **outcomes feed back** (a note's trust is derived
+from its real-world resolve-rate, and a note that keeps failing *decays* out of use), and **knowledge is
+yours** — portable markdown in *your* Git, PR-reviewed, provenance-tracked, never opaque vendor memory.
+
+→ Deep dive: **[How the learning loop works](docs/learning-loop.md)**.
 
 ## How it works
 
@@ -61,7 +75,9 @@ flowchart LR
     K -. instant recall .-> B
 ```
 
-**…and here's what lands in chat** — a real RunLore investigation delivered to Slack: ranked root cause with confidence, the evidence trail, read-only suggested next steps, open questions for a human, and a link to the knowledge-base entry it learned.
+**…and here's what lands in chat** — a real RunLore investigation delivered to Slack: ranked root cause
+with confidence, the evidence trail, read-only suggested next steps, open questions for a human, and a
+link to the knowledge-base entry it learned.
 
 <div align="center">
 <img src="assets/slack-notification.png" alt="RunLore Slack notification — HarborRegistryDown: 95% confidence root cause (Crossplane AccessKey hit the AWS IAM AccessKeysPerUser quota → Secret missing the username key → CreateContainerConfigError), with the evidence trail, suggested next steps, and open questions" width="760" />
@@ -71,55 +87,68 @@ flowchart LR
 
 | | |
 |---|---|
-| **React** | incident/alert webhook gated by a **trigger policy** (only prod, only critical, by namespace/team/label) · GitOps failure events · proactive watch · on-demand CLI / chat |
-| **Investigate** | forms & tests hypotheses across **what changed** (deploys/infra/certs/scaling — on GitOps, the exact Git diff) **and no-change causes** (saturation/network/nodes/deps) · runbook-grounded · confidence + explicit `unresolved` |
-| **Learn** | reads a cached [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) catalog (instant recall) and writes new incidents back via reviewed PRs — knowledge compounds in *your* git |
+| **React** | incident/alert webhook gated by a **trigger policy** (only prod, only critical, by namespace/team/label) · GitOps failure events · on-demand CLI / chat. The event source is pluggable. |
+| **Investigate** | a ReAct loop that forms & tests hypotheses across **what changed** (deploys/infra/certs/scaling — on GitOps, the exact Git diff) **and no-change causes** (saturation/network/nodes/deps), grounds itself in your catalog, runs an **adversarial verify pass**, and reports confidence + explicit `unresolved`. |
+| **Learn** | reads the cached [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) catalog for **instant recall** and writes new incidents back as **reviewed PRs** — knowledge compounds in *your* Git. |
 
-## Design principles
+## Why RunLore
 
-- **Cause-agnostic** — reacts to any incident and investigates any cause; "what changed" is the sharpest lens (deepest on GitOps), not the only one.
-- **Read-only by default, full autonomy ladder when you want it** — `off` → `suggest` → `approve` (human-gated) → `auto` (unattended). Every rung above read-only is reversible-only, envelope-bounded, audited, and kill-switchable (see [`docs/design.md`](docs/design.md)).
-- **GitOps- and metrics-agnostic** — Flux + ArgoCD, VictoriaMetrics + Prometheus; logs/network pluggable.
-- **Cloud-aware (read-only)** — correlates the cloud control plane (AWS CloudTrail "what changed" + EC2/ASG/EKS health) using in-cluster identity (EKS Pod Identity / IRSA), so infra changes outside GitOps are in scope too.
-- **Single static Go binary** — terminal (`lore investigate`) or in-cluster (`lore serve`).
-- **Model-agnostic** — Anthropic, Google Gemini, or any OpenAI-compatible endpoint (in-cluster vLLM, Ollama…); your telemetry needn't leave the boundary.
-- **Built-in core providers, MCP as the extension layer** — self-contained, but composable.
-- **Pluggable notifications** — Slack + Matrix first; PagerDuty and incident.io next.
+The bet is the two parts that aren't commodity: a **GitOps-native "what changed" spine** and an
+**open knowledge base that compounds**.
 
-## Quickstart
+| | What it is | What RunLore adds |
+|---|---|---|
+| [**k8sgpt**](https://github.com/k8sgpt-ai/k8sgpt) | A *detector* — analyzers + LLM explanation | An investigation loop, cross-signal correlation, real Git diffs, and learning |
+| [**HolmesGPT**](https://github.com/HolmesGPT/holmesgpt) | The strongest OSS investigation agent | Relies on *your* hand-curated runbooks (it doesn't learn); RunLore is what-changed-first and self-improving |
+| [**kagent**](https://github.com/kagent-dev/kagent) | A generic in-cluster agent *framework* | A focused, opinionated SRE agent (RunLore can run *on* kagent later) |
 
-**Deploy to a cluster** → **[Getting Started](docs/getting-started.md)**: create a knowledge-base repo,
-a scoped GitHub App, the secrets, then `helm install`. **Hack on it** → **[CONTRIBUTING](CONTRIBUTING.md)**.
+RunLore is **GitOps-engine-agnostic** (Flux + Argo CD), **metrics-backend-agnostic** (VictoriaMetrics +
+Prometheus), with **pluggable** logs and **CNI-agnostic network** signals — and the only one that learns
+into an **open** [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) catalog you own.
+
+## Get started
+
+**RunLore is designed to run in your Kubernetes cluster** (`lore serve`) — that's where you get the full
+React → Investigate → Learn loop: incident webhooks, the GitOps failure watch, delivery to chat, and the
+learning catalog. The Helm chart is the supported path.
+
+> ### → **[Deploy on Kubernetes — Getting Started](docs/getting-started.md)**
+> Create a knowledge-base repo + a scoped GitHub App + secrets, configure the chart, then `helm install`.
+
+Prefer to kick the tyres first? You also can, without a cluster:
 
 ```bash
-# try it locally, no cluster: fire mocked Alertmanager alerts through the trigger policy
+# fire mocked Alertmanager alerts through the trigger policy (no cluster)
 hack/demo.sh
 
 # verify every feature end-to-end on a throwaway k3d cluster
 hack/e2e-k3d.sh
 
-# run the agent against incident webhooks
-lore serve --config runlore.yaml
-
-# or investigate one incident on-demand from your terminal (prints the findings)
+# investigate one incident on-demand from your terminal (prints the findings)
 lore investigate --alert HarborProbeFailure --namespace apps --config runlore.yaml
 ```
 
-## Status & docs
+## Design principles
 
-- 📐 [Design](docs/design.md) · 🚀 [Getting started](docs/getting-started.md) · 🛠 [Contributing](CONTRIBUTING.md) · [Prior art](docs/prior-art.md) · [Plans](docs/plans/)
-- ✅ **End-to-end working** (verified on k3d and a live EKS cluster):
-  - **React** — incident webhook (trigger policy + dedup) + GitOps failure watch (**Flux & Argo CD**)
-  - **Investigate** — ReAct loop with 10 tools across every signal source + **instant recall** (skip the loop on a high-confidence catalog hit) + an **adversarial verify pass** (a skeptic model rejects correlation-only findings and re-calibrates confidence); model-agnostic (**Anthropic**, **Gemini**, or any OpenAI-compatible endpoint):
-    - *GitOps* — `what_changed` (exact Git diff; resolves `GitRepository`/`OCIRepository`/`ExternalArtifact` sources), `flux_resource_status`, `flux_tree`, `controller_logs`
-    - *Signals* — `query_metrics` (PromQL), `query_logs` (LogsQL), `network_drops` (Hubble)
-    - *Cloud (AWS)* — `cloud_what_changed` (CloudTrail), `cloud_resource_health` (EC2/ASG/EKS) via EKS Pod Identity / IRSA, **read-only**
-    - *Knowledge* — `kb_search`
-  - **Deliver** — Slack (with interactive **Approve/Reject buttons**) + Matrix
-  - **Learn** — OKF catalog (read + **git-sync**) + curator PRs/issues with a **lifecycle** (`triggered → investigating → solved`) → knowledge compounds; **re-run on demand** by adding the `reinvestigate` label to a curated issue
-  - **Act** — full **autonomy ladder**: `off` → `suggest` → `approve` (curl or Slack buttons, token-gated) → `auto` (unattended, reversible-only, confidence-gated, rate-limited, **kill-switchable**, audited)
-  - **Run** — `lore serve` (in-cluster, **HA via leader election**) or `lore investigate` (on-demand terminal); `lore eval` RCA benchmark; `lore catalog sync`. Packaged Helm chart + CI image build.
-- 🚧 Next: more notifiers (PagerDuty, incident.io), MCP extension layer, proactive (non-incident) watch.
+- **Cause-agnostic** — reacts to any incident and investigates any cause; "what changed" is the sharpest
+  lens (deepest on GitOps), not the only one.
+- **Read-only by default, with an autonomy ladder when you want it** — `off` → `suggest` → `approve`
+  (human-gated) → `auto`. Every rung above read-only is reversible-only, envelope-bounded, audited, and
+  kill-switchable (see [`docs/design.md`](docs/design.md)).
+- **Backend-agnostic & pluggable** — Flux + Argo CD; VictoriaMetrics + Prometheus; pluggable logs;
+  **CNI-agnostic** network signals (Cilium Hubble, AWS VPC Flow Logs, or GCP Firewall Logs — see
+  [data sources](docs/data-sources.md)).
+- **Cloud-aware (read-only)** — correlates the cloud control plane (AWS CloudTrail "what changed" +
+  EC2/ASG/EKS health) via in-cluster identity (EKS Pod Identity / IRSA).
+- **Single static Go binary**, **model-agnostic** (Anthropic, Google Gemini, or any OpenAI-compatible
+  endpoint — in-cluster vLLM, Ollama…), **observable** ([metrics, dashboard & alerts](docs/observability.md)),
+  and **HA** via leader election.
+
+## Docs
+
+📐 [Design](docs/design.md) · 📚 [Learning loop](docs/learning-loop.md) · 🚀 [Getting started](docs/getting-started.md) ·
+🔌 [Data sources](docs/data-sources.md) · 📊 [Observability](docs/observability.md) ·
+🧭 [Prior art](docs/prior-art.md) · 🛠 [Contributing](CONTRIBUTING.md)
 
 ## License
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -7,7 +7,7 @@
 
 | | |
 |---|---|
-| **Status** | Draft `v0.1` (design) |
+| **Status** | `v1` — MVP + Phase-2 learning loop shipped (React + Investigate + Learn closed end-to-end; autonomy ladder off/suggest/approve shipped, `auto` gated) |
 | **Date** | 2026-06-20 |
 | **CLI** | `lore` |
 | **Module** | `github.com/Smana/runlore` *(adjustable — could move to a dedicated org)* |
@@ -75,10 +75,12 @@ the reason to build it.
   with no LiteLLM-style multi-broker dependency.
 
 **Non-goals (for now)**
-- Autonomous **remediation** of production — *in the initial versions*. Cluster-mutating actions
-  are off; "writes" in early phases mean *markdown to git via reviewed PR*. This is the **first rung
-  of an autonomy ladder, not a permanent constraint**: the architecture (§9, "Act") is built so
-  *active tools* slot in later behind a policy gate, without re-architecting.
+- **Unattended** remediation of production. The autonomy ladder's lower rungs are **shipped**
+  (`off`/`suggest`/`approve`): in `approve` the agent executes only *reversible* Flux ops
+  (suspend/resume/reconcile) **after explicit human approval**, validated server-side. The top rung
+  (`auto`, execute without approval) **exists but is gated and not recommended on real clusters**
+  (§6, §9). Default remains read-only; "writes" without an approved action mean *markdown to git via
+  reviewed PR*.
 - Being an observability platform. RunLore *reads* your metrics/logs; it doesn't store them.
 - Re-implementing interactive Flux/k8s debugging that `gitops-cluster-debug` + MCPs already do.
 - Multi-agent / A2A orchestration. A single tight investigation loop first.
@@ -238,23 +240,27 @@ To keep the catalog an asset and not a liability (frontier RCA is <50 % accurate
 is down-weighted, and stale entries decay or get re-validated. Curation (the PR/issue review) is
 **load-bearing**, not free — it is the quality gate that separates this from opaque vendor "memory."
 
-### Act — evolve toward (gated) action *(future)*
+### Act — the (gated) autonomy ladder
 
-Read-only is the **starting posture, not the ceiling.** RunLore is designed to climb an **autonomy
-ladder** as eval earns trust — without re-architecting, because an action is just *a tool with extra
-metadata behind a policy gate*:
+Read-only is the **default posture, not the ceiling.** RunLore climbs an **autonomy ladder** as eval
+earns trust — an action is just *a tool with extra metadata behind a policy gate*:
 
 ```
 read-only  →  suggest (PR/command)  →  approve-to-execute (human click)  →  bounded auto
 rung 0         rung 1                   rung 2                              (reversible + low-blast
-(v1)                                                                        + non-critical only)
+(default)      (v1, shipped)           (v1, shipped)                       + non-critical only;
+                                                                            gated, not recommended)
 ```
 
 Every action tool declares `mutating` / `reversible` / `blastRadius` / `target`; an **action policy**
 (mirroring the trigger policy) sets the **mode** (`off | suggest | approve | auto`), scoped by
-environment, reversibility, and blast radius. v1 ships `mode: off` and registers no action tools —
-adding remediation later is *enabling a gated capability + config*, not new architecture. The
-metadata already exists (`providers.Action`, `config.ActionPolicy`) so nothing has to be retrofitted.
+environment, reversibility, and blast radius. **Rungs `off`/`suggest`/`approve` are wired in v1**: in
+`approve`, an approved decision executes a **reversible** Flux op (suspend/resume/reconcile), with
+reversibility/blast-radius/target validated **server-side** (`internal/action`) — never trusted from
+model output. Rung **`auto`** (execute without approval) **exists but is gated** (reversible-only,
+confidence-thresholded, rate-limited, kill-switchable, off by default) and **is not recommended on
+real clusters**. The metadata (`providers.Action`, `config.ActionPolicy`) was in place from day one, so
+none of this was a retrofit.
 
 > **Decision (2026-06-24) — no in-cluster mutating `rollback`.** A reversible "re-pin to the
 > prior revision" op was scoped and rejected. The executor today runs only namespace-scoped,
@@ -359,17 +365,17 @@ KB git repo  ──syncer──►  local mirror  ──build──►  index:  
   results, op, target, actor, outcome — is a hash-chained JSON line, so edits/deletions are detectable.
 - **Honest uncertainty.** `unresolved` is a first-class output field; the agent says what it doesn't
   know rather than hallucinating.
-**Designed to evolve — the autonomy ladder.** Read-only-first is rung 0, not the ceiling. When action
-tools are introduced (Phase 4+), they are gated by an **action capability model** + **action policy**
-(`providers.Action` + `config.ActionPolicy`):
+**The autonomy ladder.** Read-only is the default rung, not the ceiling. Action tools are gated by an
+**action capability model** + **action policy** (`providers.Action` + `config.ActionPolicy`):
 - every action declares `mutating` / `reversible` / `blastRadius` / `target`;
 - the policy sets the **mode** (`off | suggest | approve | auto`), scoped by environment,
   reversibility, and blast radius — **irreversibility is the trip-wire for mandatory human approval**;
-- **dry-run / preview by default**, **append-only audit**, and **rollback** for anything applied;
+- **dry-run / preview by default**, **append-only audit**, and reversibility for anything applied;
 - scoped agent identity (RBAC) is the hard backstop regardless of policy.
 
-These types exist from day one (carrying no enabled actions in v1) precisely so the read-only→active
-evolution needs no retrofit.
+`off`/`suggest`/`approve` are **shipped in v1** (the executor runs only reversible Flux ops, behind
+human approval); `auto` exists but is **gated and not recommended on real clusters**. The capability
+metadata was present from day one, so reaching the higher rungs needed no retrofit.
 
 ## 10. Evaluation
 
@@ -393,14 +399,14 @@ as the baseline and makes failure handling a first-class primitive.
   `anthropic-sdk-go` + `openai-go` (models).
 - Distribution: single binary + container image + **Helm chart** (`deploy/helm/runlore`).
 
-## 12. Phased roadmap (read-only throughout P1–P3)
+## 12. Phased roadmap (read-only by default; autonomy ladder's lower rungs shipped)
 
 | Pillar | Phase 1 (MVP) | Phase 2 | Phase 3 | Phase 4 |
 |---|---|---|---|---|
 | **React** | Incident-triggered (Alertmanager/VMAlert) + **trigger policy** (env/severity/namespace/label filters + dedup) | + GitOps-failure events, chat mention (Slack/Matrix), `lore investigate` | + proactive SLO-burn watch | — |
 | **Investigate** | what-changed spine + VM/VL/Hubble correlation + OKF-runbook grounding + confidence/`unresolved` | + ArgoCD + Prometheus providers proven | + cloud context (native SDKs: AWS/GCP/Azure) + cross-incident pattern recognition | — |
 | **Learn** | catalog **read** (cached index, instant recall) | catalog **write** (confidence-routed Issue/PR curation) — *loop closes* | hybrid vector retrieval, auto-curated playbooks, postmortems | — |
-| **Act** | rung 0: read-only (no action tools) | — | — | climb the ladder: suggest → approve-to-execute → bounded reversible auto (eval-earned, policy-gated) |
+| **Act** | rung 0: read-only (default) | **shipped:** suggest + approve-to-execute (reversible Flux ops, human-approved, server-authoritative); `auto` exists but gated/not recommended | — | further rungs as eval earns trust (policy-gated) |
 
 Phase 1 headline: *an alert fires → RunLore investigates by correlating what-changed with
 metrics/logs → posts a confidence-scored RCA + suggested rollback to chat (Slack/Matrix), grounded in the catalog.*

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,6 +4,10 @@ This guide deploys RunLore into a real cluster: it reacts to incidents, investig
 LLM (grounded in your knowledge catalog), delivers findings to chat, and — optionally — curates what
 it learns back to a Git repo as pull requests.
 
+**Running in-cluster (`lore serve`, via Helm) is the recommended way to run RunLore** — that's how it
+reacts to incidents continuously and closes the Learn loop. The CLI (`lore investigate "<symptom>"`) is
+for one-off local runs against the same engine; see [CONTRIBUTING.md](../CONTRIBUTING.md) for that.
+
 RunLore is **read-only on your cluster**: it never mutates workloads. Its only writes go to the Git
 forge (issues/PRs on a repo you designate).
 
@@ -11,35 +15,51 @@ forge (issues/PRs on a repo you designate).
 
 ## Prerequisites
 
-- A Kubernetes cluster running **Flux** or **Argo CD** — select with `config.gitops.engine`
-  (`flux` default, or `argocd`). The what-changed spine + failure trigger read the engine's resources
-  (Flux `Kustomization`/`GitRepository`, or Argo CD `Application`s).
+### Required
+
+- A **Kubernetes cluster running [Flux](https://fluxcd.io/flux/installation/) or
+  [Argo CD](https://argo-cd.readthedocs.io/en/stable/getting_started/)** — select with
+  `config.gitops.engine` (`flux` default, or `argocd`). The what-changed spine + failure trigger read
+  the engine's resources (Flux `Kustomization`/`GitRepository`, or Argo CD `Application`s). Any
+  conformant cluster works — EKS, GKE, AKS, or local [k3d](https://k3d.io/) / [kind](https://kind.sigs.k8s.io/)
+  (follow each project's install docs); RunLore only needs Flux or Argo CD running on it.
 - An **LLM** — either an **OpenAI-compatible** endpoint (in-cluster
   [vLLM](https://github.com/vllm-project/vllm), [Ollama](https://ollama.com/), OpenAI, OpenRouter) or
   **native Anthropic** (`model.provider: anthropic`). Keep it in-cluster if you don't want telemetry to
   leave your boundary.
 - `kubectl` + `helm` (v3.12+).
-- Optional: a **metrics** backend (VictoriaMetrics/Prometheus), a **logs** backend (VictoriaLogs),
+
+### Optional (but recommended)
+
+- A **GitHub App** for curation — [step 2](#step-2-github-app-for-curation-optional). **Without it the
+  Learn loop (curation) is disabled**: RunLore still reacts and investigates, but it can't write what it
+  learns back to your KB repo. Since the learning loop is RunLore's differentiator, this is **strongly
+  recommended**.
+
+### Optional
+
+- A **metrics** backend (VictoriaMetrics/Prometheus), a **logs** backend (VictoriaLogs),
   and/or a **network-flow** source — they enable the `query_metrics` / `query_logs` / `network_drops`
   investigation tools. The network signal is **pluggable and CNI-agnostic**: Cilium Hubble, **AWS VPC
   Flow Logs** (any AWS VPC, incl. EKS with the AWS VPC CNI), or **GCP Firewall Logs** (any GCP VPC,
   incl. GKE). RunLore does **not** assume Cilium.
-- Optional: **AWS** read-only access — enables the `cloud_what_changed` (CloudTrail) and
+- **AWS** read-only access — enables the `cloud_what_changed` (CloudTrail) and
   `cloud_resource_health` (EC2/ASG/EKS) tools, the cloud-control-plane "what changed" lens for infra
   changes outside GitOps. Auth is in-cluster identity (**EKS Pod Identity** or IRSA) — no static keys.
   See [step 4b](#step-4b-aws-cloud-provider-optional).
-- Optional: a **Slack incoming webhook** and/or a **Matrix** account for delivery.
-- Optional: a **GitHub App** for curation (the Learn loop) — [step 2](#step-2-github-app-for-curation-optional).
-- Optional: [External Secrets Operator](https://external-secrets.io/) to sync credentials from a vault
+- A **Slack incoming webhook** and/or a **Matrix** account for delivery.
+- [External Secrets Operator](https://external-secrets.io/) to sync credentials from a vault
   (recommended over raw `Secret`s in production).
 
 ---
 
 ## Step 1 — Create the knowledge-catalog repo
 
-RunLore reads (and, with curation, writes) an **[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
-knowledge catalog**: a Git repo of markdown files, each with YAML frontmatter. This is *your* portable
-knowledge base — runbooks, past incidents, platform constraints.
+**This Git repo is where RunLore commits what it learns** — every resolved incident is curated back here
+as a PR (the Learn loop), and the agent reads from it to ground future investigations. It's an
+**[OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) knowledge catalog**: a Git repo of
+markdown files, each with YAML frontmatter. This is *your* portable knowledge base — runbooks, past
+incidents, platform constraints.
 
 1. Create a new (private) Git repo, e.g. `your-org/runlore-kb`.
 2. Add entries as markdown files — **one file per entry** (YAML frontmatter + a markdown body). Name
@@ -147,6 +167,12 @@ config references each by its env-var name (`api_key_env`, `webhook_url_env`, `p
 ---
 
 ## Step 4 — Configure and install
+
+RunLore installs **in-cluster with one Helm command** (this is the recommended deployment). You give it
+a `values.yaml` and run `helm install` — jump to **[Install](#install)** below if you just want the
+command.
+
+### The configuration you'll provide
 
 Create a `values.yaml`. This is a complete production-style example — trim what you don't use:
 
@@ -287,7 +313,9 @@ config:
     enabled: true
 ```
 
-Install:
+### Install
+
+With the `values.yaml` above, deploy RunLore with a single command:
 
 ```bash
 helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml


### PR DESCRIPTION
## Why

The README mixed a project pitch with a changelog-style status wall, didn't put the **learning loop** (RunLore's actual differentiator) front and centre, and didn't make clear that **Kubernetes is the recommended way to run it**. `design.md` still said "Draft v0.1" and framed the autonomy ladder as entirely future. This makes the docs reflect what RunLore actually is today.

## README — now a pure project presentation
- **Leads with the learning loop** (Retrieve → Capture → Curate → Compound) as the reason RunLore exists: open, git-versioned, PR-reviewed, outcome-decayed knowledge you own — not opaque vendor memory. Links to `docs/learning-loop.md`.
- **Kubernetes-first**: a prominent "Deploy on Kubernetes — Getting Started" callout; `lore serve` (Helm) is presented as the supported path, with the local CLI/demo demoted to "kick the tyres".
- **Drops the inline changelog** ("✅ End-to-end working…", "🚧 Next…") in favour of a clean Docs section linking the deep docs (design, learning loop, getting started, data sources, observability, prior art).
- Refreshes the principles (CNI-agnostic network, observability) and the status badge.

## `docs/getting-started.md` — Kubernetes made obvious
- States up front that in-cluster (`lore serve` via Helm) is the recommended path.
- **Prerequisites split** into **Required** (cluster + Flux/Argo CD with install-doc links, LLM endpoint, kubectl/helm) vs **Optional but recommended** (the GitHub App — now plainly stated as *required for the Learn loop*).
- The `helm install` command is **prominent** (its own `### Install` heading) instead of buried in the values example; the knowledge-catalog step leads with *why*.

## `docs/design.md` — de-stale
- Status: `Draft v0.1` → **`v1` — MVP + Phase-2 learning loop shipped**.
- Autonomy ladder framing corrected: `off`/`suggest`/`approve` are **shipped** (reversible-only Flux ops, server-authoritative safety); `auto` **exists but is gated / not recommended on real clusters**. Vectors, MCP layer, and proactive watch remain correctly-future.

Docs-only; no code changes. All README links resolve; markdown fences balanced.