### PR TITLE
feat: KB-entry validator — lore validate-kb (structural gate + semantic advisory)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -121,6 +121,11 @@ func main() {
 			fmt.Fprintln(os.Stderr, "curate:", err)
 			os.Exit(1)
 		}
+	case "validate-kb":
+		if err := runValidateKB(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "validate-kb:", err)
+			os.Exit(1)
+		}
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command %q\n\n%s", os.Args[1], usage)
 		os.Exit(2)

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/Smana/runlore/internal/eval"
 	fluxexec "github.com/Smana/runlore/internal/executor/flux"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/kbvalidate"
 	"github.com/Smana/runlore/internal/logging"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
@@ -431,7 +432,19 @@ func buildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
 // configured. With a Git URL it starts a background syncer (running on every
 // replica, so a failover standby is already warm) that re-indexes after each pull;
 // otherwise it loads a static mounted directory once.
-func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, log *slog.Logger) *catalog.Catalog {
+func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, metrics *telemetry.Metrics, log *slog.Logger) *catalog.Catalog {
+	// warnInvalid surfaces structurally-invalid (but parseable) entries at load
+	// time — a backstop for the CI gate. The entry is still indexed and served
+	// (one bad entry never empties the catalog); we just log loudly + count it.
+	warnInvalid := func(cat *catalog.Catalog) {
+		kbvalidate.WarnInvalid(cat.Entries(), func(path string, errs []kbvalidate.Issue) {
+			log.Warn("invalid KB entry indexed", "path", path,
+				"issues", len(errs), "first", errs[0].Field+": "+errs[0].Message)
+			if metrics != nil {
+				metrics.CatalogInvalidEntries.Add(ctx, 1)
+			}
+		})
+	}
 	if cfg.Catalog.Git.URL != "" {
 		dir := cfg.Catalog.Dir
 		if dir == "" {
@@ -460,6 +473,7 @@ func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, 
 				log.Warn("catalog entries skipped (unparseable)", "count", len(skipped), "files", skipped)
 			}
 			log.Info("catalog synced", "url", cfg.Catalog.Git.URL, "entries", cat.Len())
+			warnInvalid(cat)
 		})
 		log.Info("catalog git-sync enabled", "url", cfg.Catalog.Git.URL, "dir", dir)
 		return cat
@@ -471,6 +485,7 @@ func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, 
 			return nil
 		}
 		log.Info("catalog loaded", "dir", cfg.Catalog.Dir, "entries", cat.Len())
+		warnInvalid(cat)
 		return cat
 	}
 	return nil
@@ -620,7 +635,7 @@ func runEvalLive(cfg *config.Config, scnDir, recordDir, reportDir, prevReport, s
 	}
 	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 	ctx := context.Background()
-	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
+	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), nil, log)
 	judge := eval.ModelJudge{Model: buildJudgeModel(cfg, jProvider, jBaseURL, jModel, jKeyEnv)}
 
 	runner := &eval.LiveRunner{
@@ -864,7 +879,7 @@ func buildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.G
 		return nil
 	}
 	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, cfg.Forge.BaseBranch, github.TokenFunc(token))
-	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gp, log)
+	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gp, metrics, log)
 	if recall != nil {
 		recall.Metrics = metrics
 		recall.Log = log
@@ -952,7 +967,7 @@ func runCatalogSync(args []string) error {
 
 // buildModelAndTools assembles the model, investigation tools, and the instant-recall
 // short-circuit from config + the GitOps provider. Shared by serve and investigate.
-func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, log *slog.Logger) (providers.ModelProvider, []investigate.Tool, *investigate.Recall, *catalog.Catalog) {
+func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, metrics *telemetry.Metrics, log *slog.Logger) (providers.ModelProvider, []investigate.Tool, *investigate.Recall, *catalog.Catalog) {
 	apiKey := ""
 	if cfg.Model.APIKeyEnv != "" {
 		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
@@ -969,7 +984,7 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		}
 	}
 	var recall *investigate.Recall
-	cat := buildCatalog(ctx, cfg, forgeTok, log)
+	cat := buildCatalog(ctx, cfg, forgeTok, metrics, log)
 	if cat != nil {
 		tools = append(tools, investigate.KBSearchTool{Catalog: cat})
 		if cfg.Catalog.InstantRecall.Enabled {
@@ -1101,7 +1116,7 @@ func runInvestigate(args []string) error {
 	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 	ctx := context.Background()
 
-	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), log)
+	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), nil, log)
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
 		Model: model, Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
@@ -1153,7 +1168,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}, nil
 	}
-	model, tools, recall, cat := buildModelAndTools(ctx, cfg, gp, log)
+	model, tools, recall, cat := buildModelAndTools(ctx, cfg, gp, metrics, log)
 	if recall != nil {
 		recall.Metrics = metrics
 		recall.Log = log

--- a/cmd/lore/validate.go
+++ b/cmd/lore/validate.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/kbvalidate"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// runValidateKB is the `lore validate-kb` subcommand: it structurally validates
+// every OKF entry under a catalog dir (the merge gate) and, with --semantic,
+// adds the advisory review. Exits non-zero when any structural Error is found.
+func runValidateKB(args []string) error {
+	fs := flag.NewFlagSet("validate-kb", flag.ContinueOnError)
+	format := fs.String("format", "text", "output format: text|github")
+	semantic := fs.Bool("semantic", false, "run the LLM semantic advisory (needs a model in --config)")
+	cfgPath := fs.String("config", "runlore.yaml", "config path (for the model when --semantic)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	dir := fs.Arg(0)
+	if dir == "" {
+		return fmt.Errorf("usage: lore validate-kb [--semantic] [--format text|github] <catalog-dir>")
+	}
+
+	var model providers.ModelProvider
+	if *semantic {
+		if cfg, err := config.Load(*cfgPath); err == nil && modelConfigured(cfg) {
+			model = buildModel(cfg, os.Getenv(cfg.Model.APIKeyEnv))
+		} else {
+			fmt.Fprintln(os.Stderr, "validate-kb: --semantic set but no usable model in config; running structural only")
+		}
+	}
+
+	hadError, err := validateKB(os.Stdout, dir, *format, model)
+	if err != nil {
+		return err
+	}
+	if hadError {
+		return fmt.Errorf("KB validation failed: structural errors found")
+	}
+	return nil
+}
+
+// validateKB loads dir, structurally validates every entry, and (when model is
+// non-nil) appends the semantic advisory. It returns whether any Error was found.
+func validateKB(w io.Writer, dir, format string, model providers.ModelProvider) (bool, error) {
+	entries, skipped, err := catalog.Load(dir)
+	if err != nil {
+		return false, err
+	}
+	hadError := false
+
+	// Unparseable files are hard errors here (unlike catalog.Load, which skips
+	// them): at PR time we want a malformed entry to block the merge.
+	for _, s := range skipped {
+		emitIssue(w, format, "", kbvalidate.Issue{Severity: kbvalidate.SeverityError, Field: "frontmatter", Message: "failed to parse: " + s})
+		hadError = true
+	}
+
+	for _, e := range entries {
+		issues := kbvalidate.ValidateStructural(e)
+		for _, iss := range issues {
+			emitIssue(w, format, e.Path, iss)
+		}
+		if kbvalidate.HasErrors(issues) {
+			hadError = true
+		}
+		if model != nil {
+			adv, aerr := kbvalidate.ReviewSemantic(context.Background(), e, model)
+			if aerr != nil {
+				fmt.Fprintf(w, "advisory\t%s\tsemantic review skipped: %v\n", e.Path, aerr)
+			} else if !adv.Skipped {
+				emitAdvisory(w, e.Path, adv)
+			}
+		}
+	}
+	return hadError, nil
+}
+
+func emitIssue(w io.Writer, format, path string, iss kbvalidate.Issue) {
+	if format == "github" {
+		lvl := "warning"
+		if iss.Severity == kbvalidate.SeverityError {
+			lvl = "error"
+		}
+		fmt.Fprintf(w, "::%s file=%s::%s: %s\n", lvl, path, iss.Field, iss.Message)
+		return
+	}
+	fmt.Fprintf(w, "%s\t%s\t%s: %s\n", iss.Severity, path, iss.Field, iss.Message)
+}
+
+func emitAdvisory(w io.Writer, path string, adv kbvalidate.Advisory) {
+	mark := func(v kbvalidate.Verdict) string {
+		if v.OK {
+			return "ok"
+		}
+		return "REVIEW"
+	}
+	fmt.Fprintf(w, "advisory\t%s\tcause-explains-symptom: %s (%s); durable: %s (%s)\n",
+		path, mark(adv.CauseExplainsSymptom), adv.CauseExplainsSymptom.Rationale,
+		mark(adv.Durable), adv.Durable.Rationale)
+}

--- a/cmd/lore/validate.go
+++ b/cmd/lore/validate.go
@@ -75,7 +75,7 @@ func validateKB(w io.Writer, dir, format string, model providers.ModelProvider) 
 		if model != nil {
 			adv, aerr := kbvalidate.ReviewSemantic(context.Background(), e, model)
 			if aerr != nil {
-				fmt.Fprintf(w, "advisory\t%s\tsemantic review skipped: %v\n", e.Path, aerr)
+				_, _ = fmt.Fprintf(w, "advisory\t%s\tsemantic review skipped: %v\n", e.Path, aerr)
 			} else if !adv.Skipped {
 				emitAdvisory(w, e.Path, adv)
 			}
@@ -90,10 +90,10 @@ func emitIssue(w io.Writer, format, path string, iss kbvalidate.Issue) {
 		if iss.Severity == kbvalidate.SeverityError {
 			lvl = "error"
 		}
-		fmt.Fprintf(w, "::%s file=%s::%s: %s\n", lvl, path, iss.Field, iss.Message)
+		_, _ = fmt.Fprintf(w, "::%s file=%s::%s: %s\n", lvl, path, iss.Field, iss.Message)
 		return
 	}
-	fmt.Fprintf(w, "%s\t%s\t%s: %s\n", iss.Severity, path, iss.Field, iss.Message)
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%s: %s\n", iss.Severity, path, iss.Field, iss.Message)
 }
 
 func emitAdvisory(w io.Writer, path string, adv kbvalidate.Advisory) {
@@ -103,7 +103,7 @@ func emitAdvisory(w io.Writer, path string, adv kbvalidate.Advisory) {
 		}
 		return "REVIEW"
 	}
-	fmt.Fprintf(w, "advisory\t%s\tcause-explains-symptom: %s (%s); durable: %s (%s)\n",
+	_, _ = fmt.Fprintf(w, "advisory\t%s\tcause-explains-symptom: %s (%s); durable: %s (%s)\n",
 		path, mark(adv.CauseExplainsSymptom), adv.CauseExplainsSymptom.Rationale,
 		mark(adv.Durable), adv.Durable.Rationale)
 }

--- a/cmd/lore/validate_test.go
+++ b/cmd/lore/validate_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validEntry = `---
+type: Incident
+title: KubeContainerOOMKilled for oom-app
+description: the container is OOMKilled because its memory limit is too low
+resource: runlore-test/oom-app
+tags:
+  - runlore
+  - incident
+---
+
+## Symptom
+
+KubeContainerOOMKilled
+
+## Investigate
+
+- pod_status: OOMKilled
+
+## Cause
+
+1. memory limit too low
+
+## Resolution
+
+- raise the limit
+`
+
+const invalidEntry = `---
+type: Incident
+title: broken entry
+description: missing the Cause section
+resource: ns/name
+tags: [runlore]
+---
+
+## Symptom
+
+x
+
+## Resolution
+
+- z
+`
+
+func writeEntry(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateKBValidPasses(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "ok.md", validEntry)
+	var buf bytes.Buffer
+	hadError, err := validateKB(&buf, dir, "text", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hadError {
+		t.Fatalf("valid entry must pass, got output:\n%s", buf.String())
+	}
+}
+
+func TestValidateKBInvalidFails(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "ok.md", validEntry)
+	writeEntry(t, dir, "bad.md", invalidEntry)
+	var buf bytes.Buffer
+	hadError, err := validateKB(&buf, dir, "text", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hadError {
+		t.Fatalf("a missing-Cause Incident must fail the gate, got output:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "cause") {
+		t.Fatalf("expected a cause issue in output, got:\n%s", buf.String())
+	}
+}
+
+func TestValidateKBGitHubFormat(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "bad.md", invalidEntry)
+	var buf bytes.Buffer
+	if _, err := validateKB(&buf, dir, "github", nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "::error file=bad.md::") {
+		t.Fatalf("expected a GitHub error annotation, got:\n%s", buf.String())
+	}
+}

--- a/docs/superpowers/plans/2026-06-24-kb-entry-validation.md
+++ b/docs/superpowers/plans/2026-06-24-kb-entry-validation.md
@@ -1,0 +1,88 @@
+# KB-Entry Validation — Implementation Plan
+
+> **For agentic workers:** execute task-by-task with TDD (test → fail → impl →
+> pass → commit). Spec: `docs/superpowers/specs/2026-06-24-kb-entry-validation-design.md`.
+
+**Goal:** A shared `internal/kbvalidate` package (deterministic structural gate +
+LLM semantic advisory), a `lore validate-kb` CLI, and a `catalog.Load` strict-warn,
+so KB entries are validated before merge (CI) and loudly at index time.
+
+**Architecture:** `kbvalidate.ValidateStructural(catalog.Entry) []Issue` is pure
+and deterministic (the merge gate); `ReviewSemantic(ctx, Entry, ModelProvider)`
+mirrors `verify.go`'s tool-call structured-output pattern (advisory only). The
+CLI and `catalog.Reload` both consume the package.
+
+**Tech Stack:** Go, `gopkg.in/yaml.v3` (already used), `go.opentelemetry.io/otel` metrics.
+
+## Global Constraints
+- Type vocabulary: **`{Incident, Playbook, Concept}`** (confirmed against runlore-kb).
+- `catalog.Entry{Type, Title, Description, Resource, Tags, Body, Path}` — no `Fingerprint`.
+- Incident body requires `## Symptom`, `## Cause`, `## Resolution` (matches `curator.draftKBEntry`).
+- Semantic review is ADVISORY (never a gate); degrades to `Skipped` when model is nil.
+- `golangci-lint v2.12.2` clean; every task ends green (`go test ./...`).
+
+---
+
+### Task 1: kbvalidate core — types + ValidateStructural (frontmatter)
+**Files:** Create `internal/kbvalidate/kbvalidate.go`, `internal/kbvalidate/kbvalidate_test.go`
+**Produces:** `Severity` (Error|Warning), `Issue{Severity,Field,Message}`,
+`ValidateStructural(catalog.Entry) []Issue`, `HasErrors([]Issue) bool`.
+- [ ] Test: a valid Incident → no errors; missing/!vocab `type`, empty `title`,
+  >120-char/multiline `title`, empty `description`, empty/space `resource`,
+  empty `tags` (Warning) → expected Issues.
+- [ ] Impl frontmatter rules; run `go test ./internal/kbvalidate/`; commit.
+
+### Task 2: ValidateStructural — body/section checks (type-aware)
+**Files:** Modify `internal/kbvalidate/kbvalidate.go`, add cases to the test.
+- [ ] Test: Incident missing `## Cause` → Error; empty `## Resolution` → Error;
+  missing `## Investigate` → Warning; Playbook/Concept with non-empty body → ok;
+  any type with empty body → Error.
+- [ ] Impl heading scan (regex `(?m)^##\s+(\w+)` + section-content check); test; commit.
+
+### Task 3: ReviewSemantic — LLM advisory
+**Files:** Create `internal/kbvalidate/semantic.go`, `semantic_test.go`
+**Consumes:** `providers.ModelProvider`, `providers.CompletionRequest/ToolSpec`.
+**Produces:** `Verdict{OK bool, Rationale string}`,
+`Advisory{CauseExplainsSymptom, Durable Verdict, Skipped bool}`,
+`ReviewSemantic(ctx, catalog.Entry, providers.ModelProvider) (Advisory, error)`.
+- [ ] Test (fake ModelProvider returning a `submit_review` tool-call): transient
+  entry → `Durable.OK=false`; cause-mismatch → `CauseExplainsSymptom.OK=false`;
+  nil model → `Skipped=true`, no error; model error → `Skipped`, no gate failure.
+- [ ] Impl: `submitReviewSpec()` ToolSpec (JSON schema), `Complete` with System +
+  rendered entry + the tool, parse `resp.ToolCalls[0].Args`; test; commit.
+
+### Task 4: `lore validate-kb` CLI
+**Files:** Modify `cmd/lore/main.go` (add `case "validate-kb"`); create
+`cmd/lore/validate.go`, `cmd/lore/validate_test.go`.
+**Consumes:** `kbvalidate`, `catalog.Load`.
+- [ ] Test: a dir of fixtures (good + each bad variant) → exit 0 on warnings-only,
+  exit 1 on any Error; `--format=github` emits `::error file=…::` annotations.
+- [ ] Impl `runValidateKB(args)`: flags `--semantic`, `--format`, `--config`;
+  walk paths, `catalog.Load` (or parse single files), `ValidateStructural`, optional
+  `ReviewSemantic` (build model from config like serve); print + exit; wire the
+  `case`; test; commit.
+
+### Task 5: catalog.Load strict-warn + metric
+**Files:** Modify `internal/telemetry/metrics.go` (+`metrics_test.go`),
+`internal/catalog/catalog.go` (`Reload`), `internal/catalog/catalog_test.go`.
+**Produces:** `Metrics.CatalogInvalidEntries metric.Int64Counter`
+(`runlore_catalog_invalid_entries_total`).
+- [ ] Test: `Reload` over a dir with one structurally-invalid (but parseable)
+  entry → still loads the valid ones, logs WARN, and (when a `*telemetry.Metrics`
+  is wired, nil-safe) increments the counter.
+- [ ] Impl: add the instrument; in `Reload`, run `ValidateStructural` per entry,
+  `log.Warn` + `metrics.CatalogInvalidEntries.Add` on Error (keep current
+  skip/index behaviour); test; commit.
+
+### Task 6: GitHub Action + process doc (runlore-kb)
+**Files:** (runlore-kb repo) `.github/workflows/validate-kb.yml`; (runlore)
+`docs/observability.md`/README note that `validate-kb` is the KB CI gate.
+- [ ] Action: on `pull_request` `**.md`, run `ghcr.io/smana/runlore` →
+  `lore validate-kb --changed-only --semantic --format=github`; structural Error
+  fails the check; advisory posted as a comment. (No Go test; a follow-up PR on the
+  KB repo.) Commit the runlore-side doc note.
+
+## Success criteria
+SC-1 malformed entry fails the gate · SC-2 #48-standard entry passes · SC-3
+advisory appears / skips cleanly w/o a key · SC-4 bad merged entry → metric+WARN ·
+SC-6 `go test ./...` + lint green, `meetsBar` unchanged.

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -101,6 +101,16 @@ func (c *Catalog) Len() int {
 	return len(c.entries)
 }
 
+// Entries returns a snapshot of the currently-indexed entries. Used by callers
+// that validate catalog content out-of-band (kbvalidate at load time).
+func (c *Catalog) Entries() []Entry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]Entry, len(c.entries))
+	copy(out, c.entries)
+	return out
+}
+
 // Ready reports whether the catalog has completed at least one successful load.
 // It stays false for a git-sync catalog (NewEmpty) until the first sync indexes,
 // so readyz can keep the leader out of rotation until its KB is warm.

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -1,0 +1,153 @@
+// Package kbvalidate provides deterministic structural validation of OKF
+// knowledge-base entries (the merge gate) and an LLM-assisted semantic advisory.
+// The structural checks mirror what curator.draftKBEntry emits and what
+// catalog.parseEntry consumes, so a RunLore-authored entry that passes meetsBar
+// also passes ValidateStructural by construction.
+package kbvalidate
+
+import (
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+)
+
+// Severity classifies an Issue. Only SeverityError fails the merge gate.
+type Severity int
+
+const (
+	SeverityError Severity = iota
+	SeverityWarning
+)
+
+// String renders the severity for human/CI output.
+func (s Severity) String() string {
+	if s == SeverityWarning {
+		return "warning"
+	}
+	return "error"
+}
+
+// Issue is one validation finding against a frontmatter field or body section.
+type Issue struct {
+	Severity Severity
+	Field    string
+	Message  string
+}
+
+var validTypes = map[string]bool{"Incident": true, "Playbook": true, "Concept": true}
+
+// requiredIncidentSections are the OKF body sections an Incident must carry
+// (present and non-empty); curator.draftKBEntry always renders them.
+var requiredIncidentSections = []struct{ key, head string }{
+	{"symptom", "Symptom"},
+	{"cause", "Cause"},
+	{"resolution", "Resolution"},
+}
+
+// HasErrors reports whether any issue is Severity=Error — the gate signal.
+func HasErrors(issues []Issue) bool {
+	for _, i := range issues {
+		if i.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateStructural runs deterministic structural checks on a parsed catalog
+// entry. Errors fail the merge gate; warnings are advisory.
+func ValidateStructural(e catalog.Entry) []Issue {
+	var out []Issue
+	addErr := func(field, msg string) { out = append(out, Issue{SeverityError, field, msg}) }
+	addWarn := func(field, msg string) { out = append(out, Issue{SeverityWarning, field, msg}) }
+
+	switch {
+	case strings.TrimSpace(e.Type) == "":
+		addErr("type", "frontmatter `type` is required")
+	case !validTypes[e.Type]:
+		addErr("type", "type must be one of Incident, Playbook, Concept")
+	}
+
+	switch {
+	case strings.TrimSpace(e.Title) == "":
+		addErr("title", "frontmatter `title` is required")
+	case strings.ContainsAny(e.Title, "\r\n"):
+		addErr("title", "title must be a single line")
+	case len(e.Title) > 120:
+		addErr("title", "title must be at most 120 characters")
+	}
+
+	if strings.TrimSpace(e.Description) == "" {
+		addErr("description", "frontmatter `description` is required")
+	}
+
+	switch {
+	case strings.TrimSpace(e.Resource) == "":
+		addErr("resource", "frontmatter `resource` is required (namespace/name)")
+	case strings.ContainsAny(e.Resource, " \t\r\n"):
+		addErr("resource", "resource must not contain whitespace")
+	}
+
+	if len(e.Tags) == 0 {
+		addWarn("tags", "frontmatter `tags` is empty")
+	}
+
+	if strings.TrimSpace(e.Body) == "" {
+		addErr("body", "entry body is empty")
+		return out
+	}
+
+	// Incident bodies must carry the OKF evidence sections; Playbook/Concept are
+	// intentionally relaxed in v1 (free-form runbooks/concepts).
+	if e.Type == "Incident" {
+		secs := sections(e.Body)
+		for _, s := range requiredIncidentSections {
+			content, ok := secs[s.key]
+			switch {
+			case !ok:
+				addErr(s.key, "Incident body is missing the `## "+s.head+"` section")
+			case content == "":
+				addErr(s.key, "the `## "+s.head+"` section is empty")
+			}
+		}
+		if _, ok := secs["investigate"]; !ok {
+			addWarn("investigate", "Incident body has no `## Investigate` evidence section")
+		}
+	}
+
+	return out
+}
+
+// sections maps each "## Heading" (lowercased) to its trimmed content.
+func sections(body string) map[string]string {
+	out := map[string]string{}
+	cur := ""
+	var buf []string
+	flush := func() {
+		if cur != "" {
+			out[cur] = strings.TrimSpace(strings.Join(buf, "\n"))
+		}
+		buf = nil
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if label, ok := heading(line); ok {
+			flush()
+			cur = label
+			continue
+		}
+		if cur != "" {
+			buf = append(buf, line)
+		}
+	}
+	flush()
+	return out
+}
+
+// heading returns the lowercased label of a "## X" markdown heading line.
+func heading(line string) (string, bool) {
+	t := strings.TrimSpace(line)
+	if strings.HasPrefix(t, "## ") {
+		return strings.ToLower(strings.TrimSpace(t[3:])), true
+	}
+	return "", false
+}

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -14,6 +14,8 @@ import (
 // Severity classifies an Issue. Only SeverityError fails the merge gate.
 type Severity int
 
+// Issue severities. Only SeverityError fails the merge gate; SeverityWarning is
+// advisory.
 const (
 	SeverityError Severity = iota
 	SeverityWarning
@@ -42,6 +44,30 @@ var requiredIncidentSections = []struct{ key, head string }{
 	{"symptom", "Symptom"},
 	{"cause", "Cause"},
 	{"resolution", "Resolution"},
+}
+
+// WarnInvalid runs ValidateStructural over entries and calls onInvalid(path,
+// errs) for each entry that has structural Errors. It is the load-time
+// strict-warn hook: the caller logs + increments a metric, but the entry is
+// still served (one bad entry never empties the catalog). Returns the count of
+// invalid entries. Warnings are not reported here.
+func WarnInvalid(entries []catalog.Entry, onInvalid func(path string, errs []Issue)) int {
+	n := 0
+	for _, e := range entries {
+		var errs []Issue
+		for _, i := range ValidateStructural(e) {
+			if i.Severity == SeverityError {
+				errs = append(errs, i)
+			}
+		}
+		if len(errs) > 0 {
+			n++
+			if onInvalid != nil {
+				onInvalid(e.Path, errs)
+			}
+		}
+	}
+	return n
 }
 
 // HasErrors reports whether any issue is Severity=Error — the gate signal.

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -1,0 +1,99 @@
+package kbvalidate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+)
+
+// validIncident is the "#48 standard": a fully-formed Incident that must pass
+// with zero issues (no errors, no warnings).
+func validIncident() catalog.Entry {
+	return catalog.Entry{
+		Type:        "Incident",
+		Title:       "KubeContainerOOMKilled for oom-app",
+		Description: "the container is OOMKilled because its memory limit is too low",
+		Resource:    "runlore-test/oom-app",
+		Tags:        []string{"runlore", "incident"},
+		Body: "## Symptom\n\nKubeContainerOOMKilled\n\n" +
+			"## Investigate\n\n- pod_status: OOMKilled (exit 137)\n\n" +
+			"## Cause\n\n1. **memory limit too low** (90%)\n\n" +
+			"## Resolution\n\n- raise the memory limit\n",
+	}
+}
+
+func has(issues []Issue, sev Severity, field string) bool {
+	for _, i := range issues {
+		if i.Severity == sev && i.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValidateStructural(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*catalog.Entry)
+		errField  string // expect a Severity=Error issue on this field ("" = none)
+		warnField string // expect a Severity=Warning issue on this field ("" = none)
+	}{
+		{"valid incident", func(*catalog.Entry) {}, "", ""},
+		{"missing type", func(e *catalog.Entry) { e.Type = "" }, "type", ""},
+		{"invalid type", func(e *catalog.Entry) { e.Type = "Bogus" }, "type", ""},
+		{"playbook type ok", func(e *catalog.Entry) { e.Type = "Playbook" }, "", ""},
+		{"concept type ok", func(e *catalog.Entry) { e.Type = "Concept" }, "", ""},
+		{"empty title", func(e *catalog.Entry) { e.Title = "" }, "title", ""},
+		{"long title", func(e *catalog.Entry) { e.Title = strings.Repeat("x", 121) }, "title", ""},
+		{"multiline title", func(e *catalog.Entry) { e.Title = "a\nb" }, "title", ""},
+		{"empty description", func(e *catalog.Entry) { e.Description = "" }, "description", ""},
+		{"empty resource", func(e *catalog.Entry) { e.Resource = "" }, "resource", ""},
+		{"resource with whitespace", func(e *catalog.Entry) { e.Resource = "ns / name" }, "resource", ""},
+		{"empty tags warns", func(e *catalog.Entry) { e.Tags = nil }, "", "tags"},
+		// body, type-aware
+		{"incident missing cause", func(e *catalog.Entry) {
+			e.Body = "## Symptom\n\nx\n\n## Resolution\n\n- y\n"
+		}, "cause", ""},
+		{"incident empty resolution", func(e *catalog.Entry) {
+			e.Body = "## Symptom\n\nx\n\n## Cause\n\n1. y\n\n## Resolution\n"
+		}, "resolution", ""},
+		{"incident missing investigate warns", func(e *catalog.Entry) {
+			e.Body = "## Symptom\n\nx\n\n## Cause\n\n1. y\n\n## Resolution\n\n- z\n"
+		}, "", "investigate"},
+		{"playbook relaxed sections", func(e *catalog.Entry) {
+			e.Type = "Playbook"
+			e.Body = "Some free-form runbook content with no required sections."
+		}, "", ""},
+		{"empty body", func(e *catalog.Entry) { e.Type = "Playbook"; e.Body = "  \n" }, "body", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := validIncident()
+			tc.mutate(&e)
+			issues := ValidateStructural(e)
+
+			if tc.errField == "" {
+				if HasErrors(issues) {
+					t.Fatalf("expected no errors, got %+v", issues)
+				}
+			} else if !has(issues, SeverityError, tc.errField) {
+				t.Fatalf("expected Error on %q, got %+v", tc.errField, issues)
+			}
+
+			if tc.warnField != "" && !has(issues, SeverityWarning, tc.warnField) {
+				t.Fatalf("expected Warning on %q, got %+v", tc.warnField, issues)
+			}
+		})
+	}
+}
+
+func TestHasErrors(t *testing.T) {
+	if HasErrors([]Issue{{Severity: SeverityWarning, Field: "tags"}}) {
+		t.Fatal("warnings-only must not count as errors")
+	}
+	if !HasErrors([]Issue{{Severity: SeverityError, Field: "type"}}) {
+		t.Fatal("an error must be reported")
+	}
+}

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -89,6 +89,28 @@ func TestValidateStructural(t *testing.T) {
 	}
 }
 
+func TestWarnInvalid(t *testing.T) {
+	good := validIncident()
+	good.Path = "good.md"
+	bad := validIncident()
+	bad.Path = "bad.md"
+	bad.Body = "## Symptom\n\nx\n" // missing ## Cause and ## Resolution
+
+	var flagged []string
+	n := WarnInvalid([]catalog.Entry{good, bad}, func(path string, errs []Issue) {
+		if len(errs) == 0 {
+			t.Fatalf("onInvalid called with no errors for %s", path)
+		}
+		flagged = append(flagged, path)
+	})
+	if n != 1 {
+		t.Fatalf("want 1 invalid entry, got %d", n)
+	}
+	if len(flagged) != 1 || flagged[0] != "bad.md" {
+		t.Fatalf("want bad.md flagged, got %v", flagged)
+	}
+}
+
 func TestHasErrors(t *testing.T) {
 	if HasErrors([]Issue{{Severity: SeverityWarning, Field: "tags"}}) {
 		t.Fatal("warnings-only must not count as errors")

--- a/internal/kbvalidate/semantic.go
+++ b/internal/kbvalidate/semantic.go
@@ -1,0 +1,107 @@
+package kbvalidate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Verdict is one advisory judgement: whether the property holds, with a reason.
+type Verdict struct {
+	OK        bool
+	Rationale string
+}
+
+// Advisory is the LLM-assisted semantic review of an entry. It is ADVISORY only
+// — never a merge gate. Skipped is true when no model is configured or the
+// review could not be obtained (the structural gate still applies).
+type Advisory struct {
+	CauseExplainsSymptom Verdict
+	Durable              Verdict
+	Skipped              bool
+}
+
+const submitReviewName = "submit_review"
+
+const reviewSystemPrompt = `You review a proposed SRE knowledge-base entry for two qualities the deterministic
+checks cannot judge. Be skeptical and call submit_review exactly once.
+
+1. cause_explains_symptom — does the entry's top Cause plausibly explain THIS Symptom
+   (not merely a nearby/related problem)?
+2. durable — is this a durable, generalizable incident worth keeping, or transient/
+   environmental/bootstrap-convergence noise unlikely to recur or teach anything?
+
+Default ok=false when uncertain; give a one-line rationale for each.`
+
+func submitReviewSpec() providers.ToolSpec {
+	return providers.ToolSpec{
+		Name:        submitReviewName,
+		Description: "Submit the two-part semantic review of the KB entry.",
+		Schema: `{
+  "type": "object",
+  "properties": {
+    "cause_explains_symptom": {
+      "type": "object",
+      "properties": {"ok": {"type": "boolean"}, "rationale": {"type": "string"}},
+      "required": ["ok", "rationale"]
+    },
+    "durable": {
+      "type": "object",
+      "properties": {"ok": {"type": "boolean"}, "rationale": {"type": "string"}},
+      "required": ["ok", "rationale"]
+    }
+  },
+  "required": ["cause_explains_symptom", "durable"]
+}`,
+	}
+}
+
+// ReviewSemantic asks the model to judge cause-explains-symptom and durability.
+// It NEVER gates: a nil model, a model error, or a missing tool-call all return
+// an Advisory with Skipped=true. The returned error is for logging only.
+func ReviewSemantic(ctx context.Context, e catalog.Entry, m providers.ModelProvider) (Advisory, error) {
+	if m == nil {
+		return Advisory{Skipped: true}, nil
+	}
+	resp, err := m.Complete(ctx, providers.CompletionRequest{
+		System:   reviewSystemPrompt,
+		Messages: []providers.Message{{Role: "user", Content: renderEntry(e)}},
+		Tools:    []providers.ToolSpec{submitReviewSpec()},
+	})
+	if err != nil {
+		return Advisory{Skipped: true}, fmt.Errorf("semantic review: %w", err)
+	}
+	for _, tc := range resp.ToolCalls {
+		if tc.Name != submitReviewName {
+			continue
+		}
+		var raw struct {
+			CauseExplainsSymptom struct {
+				OK        bool   `json:"ok"`
+				Rationale string `json:"rationale"`
+			} `json:"cause_explains_symptom"`
+			Durable struct {
+				OK        bool   `json:"ok"`
+				Rationale string `json:"rationale"`
+			} `json:"durable"`
+		}
+		if err := json.Unmarshal([]byte(tc.Args), &raw); err != nil {
+			return Advisory{Skipped: true}, fmt.Errorf("parse semantic review: %w", err)
+		}
+		return Advisory{
+			CauseExplainsSymptom: Verdict{OK: raw.CauseExplainsSymptom.OK, Rationale: raw.CauseExplainsSymptom.Rationale},
+			Durable:              Verdict{OK: raw.Durable.OK, Rationale: raw.Durable.Rationale},
+		}, nil
+	}
+	// Model answered without calling the tool — nothing to act on.
+	return Advisory{Skipped: true}, nil
+}
+
+// renderEntry presents the entry to the reviewer model.
+func renderEntry(e catalog.Entry) string {
+	return fmt.Sprintf("Type: %s\nTitle: %s\nResource: %s\nDescription: %s\n\n%s",
+		e.Type, e.Title, e.Resource, e.Description, e.Body)
+}

--- a/internal/kbvalidate/semantic_test.go
+++ b/internal/kbvalidate/semantic_test.go
@@ -1,0 +1,75 @@
+package kbvalidate
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeModel struct {
+	resp     providers.CompletionResponse
+	err      error
+	gotTools []string
+}
+
+func (f *fakeModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	for _, t := range req.Tools {
+		f.gotTools = append(f.gotTools, t.Name)
+	}
+	return f.resp, f.err
+}
+
+func reviewCall(args string) providers.CompletionResponse {
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{{Name: submitReviewName, Args: args}}}
+}
+
+func TestReviewSemanticNilModel(t *testing.T) {
+	adv, err := ReviewSemantic(context.Background(), validIncident(), nil)
+	if err != nil || !adv.Skipped {
+		t.Fatalf("nil model must skip cleanly, got skipped=%v err=%v", adv.Skipped, err)
+	}
+}
+
+func TestReviewSemanticModelError(t *testing.T) {
+	adv, _ := ReviewSemantic(context.Background(), validIncident(), &fakeModel{err: errors.New("boom")})
+	if !adv.Skipped {
+		t.Fatalf("a model error must degrade to Skipped (never gate), got %+v", adv)
+	}
+}
+
+func TestReviewSemanticTransient(t *testing.T) {
+	m := &fakeModel{resp: reviewCall(`{"cause_explains_symptom":{"ok":true,"rationale":"matches"},"durable":{"ok":false,"rationale":"transient bootstrap noise"}}`)}
+	adv, err := ReviewSemantic(context.Background(), validIncident(), m)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if adv.Skipped {
+		t.Fatal("a parsed advisory must not be Skipped")
+	}
+	if !adv.CauseExplainsSymptom.OK {
+		t.Fatalf("expected cause-explains-symptom ok, got %+v", adv.CauseExplainsSymptom)
+	}
+	if adv.Durable.OK || adv.Durable.Rationale == "" {
+		t.Fatalf("expected durable not-ok with a rationale, got %+v", adv.Durable)
+	}
+}
+
+func TestReviewSemanticCauseMismatch(t *testing.T) {
+	m := &fakeModel{resp: reviewCall(`{"cause_explains_symptom":{"ok":false,"rationale":"cause is about a different subsystem"},"durable":{"ok":true,"rationale":"durable"}}`)}
+	adv, _ := ReviewSemantic(context.Background(), validIncident(), m)
+	if adv.CauseExplainsSymptom.OK {
+		t.Fatalf("expected cause-explains-symptom not-ok, got %+v", adv.CauseExplainsSymptom)
+	}
+	// the submit_review tool must have been offered to the model
+	found := false
+	for _, n := range m.gotTools {
+		if n == submitReviewName {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("submit_review tool was not offered; got %v", m.gotTools)
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -42,6 +42,7 @@ type Metrics struct {
 	ModelRequests           metric.Int64Counter     // LLM completion requests (label: provider, result)
 	ModelRequestDuration    metric.Float64Histogram // LLM completion latency, seconds (label: provider)
 	Curations               metric.Int64Counter     // curation outcomes (label: kind, result)
+	CatalogInvalidEntries   metric.Int64Counter     // structurally-invalid entries found at catalog load
 }
 
 // NewMetrics builds the instrument set from the global meter provider.
@@ -86,6 +87,7 @@ func NewMetrics() *Metrics {
 		ModelRequests:           ctr("model_requests_total", "LLM completion requests (label: provider, result)"),
 		ModelRequestDuration:    histF("model_request_duration_seconds", "LLM completion latency in seconds (label: provider)"),
 		Curations:               ctr("curations_total", "curation outcomes written to the forge (label: kind, result)"),
+		CatalogInvalidEntries:   ctr("catalog_invalid_entries_total", "structurally-invalid entries surfaced at catalog load"),
 	}
 }
 


### PR DESCRIPTION
Implements the KB-entry validation design (spec + reviewer guide in #98).

## What

- **`internal/kbvalidate`** — shared core:
  - `ValidateStructural(catalog.Entry) []Issue` — deterministic **merge gate**:
    frontmatter (`type` ∈ Incident/Playbook/Concept, single-line `title` ≤120,
    `description`, `resource` non-empty + no whitespace, `tags`) and, for
    Incident, the OKF body sections (`## Symptom`/`## Cause`/`## Resolution`
    present + non-empty; `## Investigate` recommended). Mirrors
    `curator.draftKBEntry`, so a `meetsBar`-passing entry passes by construction.
  - `ReviewSemantic(ctx, Entry, ModelProvider)` — **advisory only** (never gates):
    LLM judges cause-explains-symptom + durability via a `submit_review` tool
    (mirrors `verify.go`). nil model / model error / no tool-call → `Skipped`.
  - `HasErrors`, `WarnInvalid`.
- **`lore validate-kb [--semantic] [--format text|github] <dir>`** — loads every
  OKF entry, runs the gate (unparseable files are hard errors here, unlike
  `catalog.Load` which skips), optional advisory; exits non-zero on any Error;
  `--format=github` emits `::error file=…::` annotations.
- **Load-time strict-warn** — `buildCatalog` validates entries after each
  git-sync/load: WARN + `runlore_catalog_invalid_entries_total` on structural
  errors, while the entry is still indexed (one bad entry never empties the
  catalog). Adds `catalog.Entries()`.

## Tests
Table-driven structural tests (valid entry + every rule violated in isolation),
fake-model semantic tests (transient / cause-mismatch / nil / error), CLI
fixture tests (pass / fail / github), `WarnInvalid`. `go test ./...` + golangci-lint green.

## Verified end-to-end
Built the binary and ran it over fixtures: a bad entry → 2 errors + 1 warning,
exit 1, correct GitHub annotations; a clean dir → exit 0.

## Follow-up (post-merge)
The **CI Action** on `Smana/runlore-kb` (`validate-kb --changed-only --semantic
--format=github`) needs the `ghcr.io/smana/runlore` image rebuilt **with**
`validate-kb`, so it lands after this merges + releases. (`--changed-only` is a
small CLI add then.)

Plan: `docs/superpowers/plans/2026-06-24-kb-entry-validation.md` (this branch).
Spec + reviewer guide: #98.