### PR TITLE
fix(whatchanged): diff lastApplied..HEAD for failing Kustomizations

### DIFF
--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -70,6 +70,27 @@ func (r *dynamicReader) GetGitRepository(ctx context.Context, namespace, name st
 	return gitRepository{Name: name, Namespace: namespace, URL: url}, nil
 }
 
+// SourceRevision returns a Flux source's current synced revision from
+// status.artifact.revision. The kind is the Kustomization's spec.sourceRef.kind
+// (GitRepository/OCIRepository/Bucket/ExternalArtifact); an empty kind defaults to
+// GitRepository, matching Flux's own default. This is the source HEAD a failing
+// Kustomization's pinned lastAppliedRevision may lag behind.
+func (r *dynamicReader) SourceRevision(ctx context.Context, kind, namespace, name string) (string, error) {
+	if kind == "" {
+		kind = "GitRepository"
+	}
+	gvr, ok := kindToGVR[kind]
+	if !ok {
+		return "", fmt.Errorf("unsupported source kind %q", kind)
+	}
+	u, err := r.client.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get %s %s/%s: %w", kind, namespace, name, err)
+	}
+	rev, _, _ := unstructured.NestedString(u.Object, "status", "artifact", "revision")
+	return rev, nil
+}
+
 // GetResource fetches one object by kind/namespace/name. The kind must be one the
 // inspector knows (see kindToGVR). A NotFound error is returned verbatim so callers
 // can distinguish "missing" from other failures.

--- a/internal/providers/gitops/flux/dynamic_test.go
+++ b/internal/providers/gitops/flux/dynamic_test.go
@@ -91,6 +91,33 @@ func fluxScene() *Provider {
 	return New(NewDynamicReader(client), nil)
 }
 
+func TestSourceRevision(t *testing.T) {
+	grObj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "GitRepository",
+		"metadata":   map[string]any{"name": "flux-system", "namespace": "flux-system"},
+		"spec":       map[string]any{"url": "https://github.com/org/repo"},
+		"status":     map[string]any{"artifact": map[string]any{"revision": "main@sha1:bbb"}},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gitRepositoryGVR: "GitRepositoryList"}, grObj)
+	r := NewDynamicReader(client)
+
+	// An empty kind defaults to GitRepository, matching Flux's own default.
+	rev, err := r.SourceRevision(context.Background(), "", "flux-system", "flux-system")
+	if err != nil {
+		t.Fatalf("SourceRevision: %v", err)
+	}
+	if rev != "main@sha1:bbb" {
+		t.Fatalf("unexpected revision: %q", rev)
+	}
+
+	// An unknown source kind is reported, not silently swallowed.
+	if _, err := r.SourceRevision(context.Background(), "Mystery", "flux-system", "flux-system"); err == nil {
+		t.Fatal("expected an error for an unsupported source kind")
+	}
+}
+
 func TestGetResourceNamespaceFallback(t *testing.T) {
 	// The Kustomization lives in flux-system, but a caller passes the workload's
 	// namespace ("apps", from an alert). GetResource must resolve it via the

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -44,6 +44,10 @@ type KustomizationEvent struct {
 type Reader interface {
 	ListKustomizations(ctx context.Context) ([]kustomization, error)
 	GetGitRepository(ctx context.Context, namespace, name string) (gitRepository, error)
+	// SourceRevision returns a source's current synced revision
+	// (status.artifact.revision) for a GitRepository/OCIRepository/Bucket/
+	// ExternalArtifact, used to find a failing Kustomization's HEAD.
+	SourceRevision(ctx context.Context, kind, namespace, name string) (string, error)
 	WatchKustomizations(ctx context.Context) (<-chan KustomizationEvent, error)
 	// GetResource fetches one object by kind/namespace/name (kinds in kindToGVR).
 	GetResource(ctx context.Context, kind, namespace, name string) (*unstructured.Unstructured, error)
@@ -112,9 +116,33 @@ func (p *Provider) Changes(ctx context.Context, _ providers.TimeWindow, sel prov
 			}
 			url = cached
 		}
-		changes = append(changes, mapKustomization(k, url))
+		fromRev, toRev := revisionRange(ctx, p.reader, k)
+		changes = append(changes, mapKustomization(k, url, fromRev, toRev))
 	}
 	return changes, nil
+}
+
+// revisionRange picks the (FromRev, ToRev) a Change should diff. For a healthy
+// Kustomization it is ("", lastApplied) — the change introduced by the applied
+// revision. For a FAILING one (Ready != True) whose source HEAD has moved past
+// lastApplied, it is (lastApplied, HEAD): Flux pins lastAppliedRevision to the last
+// HEALTHY commit on a health-check failure, so keying on it alone would diff the
+// pre-break commit and miss the breaking one. The source read is best-effort — on
+// any error (or when HEAD == lastApplied) we fall back to the single-revision range.
+func revisionRange(ctx context.Context, reader Reader, k kustomization) (fromRev, toRev string) {
+	lastApplied := parseRevision(k.Revision)
+	if k.ReadyStatus == "True" || k.ReadyStatus == "" {
+		return "", lastApplied
+	}
+	head, err := reader.SourceRevision(ctx, k.SourceKind, k.SourceNamespace, k.SourceName)
+	if err != nil {
+		return "", lastApplied // can't resolve HEAD — keep today's behavior
+	}
+	headRev := parseRevision(head)
+	if headRev == "" || headRev == lastApplied {
+		return "", lastApplied // no real gap to span
+	}
+	return lastApplied, headRev
 }
 
 // Diff resolves a Change's diff via the Differ. Changes from a non-Git source
@@ -167,16 +195,18 @@ func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureE
 	return out, nil
 }
 
-// mapKustomization builds an engine-agnostic Change from a Kustomization + its
-// resolved source URL.
-func mapKustomization(k kustomization, repoURL string) providers.Change {
+// mapKustomization builds an engine-agnostic Change from a Kustomization, its
+// resolved source URL, and the (fromRev, toRev) range computed by revisionRange.
+// A healthy Kustomization carries an empty fromRev (diff the change introduced by
+// toRev); a failing one whose source HEAD moved past lastApplied spans the gap.
+func mapKustomization(k kustomization, repoURL, fromRev, toRev string) providers.Change {
 	return providers.Change{
 		Workload: providers.Workload{Kind: "Kustomization", Name: k.Name, Namespace: k.Namespace},
 		Engine:   providers.EngineFlux,
 		Type:     providers.ChangeSync,
 		Source:   providers.SourceRef{RepoURL: repoURL, Path: k.Path},
-		ToRev:    parseRevision(k.Revision),
-		// FromRev empty: diff the change introduced by ToRev.
+		FromRev:  fromRev,
+		ToRev:    toRev,
 	}
 }
 

--- a/internal/providers/gitops/flux/flux_test.go
+++ b/internal/providers/gitops/flux/flux_test.go
@@ -31,6 +31,9 @@ func TestParseRevision(t *testing.T) {
 type fakeReader struct {
 	ks  []kustomization
 	grs map[string]gitRepository // key: namespace/name
+	// srcRevs maps "kind/namespace/name" → the source's current artifact
+	// revision (status.artifact.revision). Absent entries return an error.
+	srcRevs map[string]string
 }
 
 func (f fakeReader) ListKustomizations(context.Context) ([]kustomization, error) { return f.ks, nil }
@@ -39,6 +42,12 @@ func (f fakeReader) GetGitRepository(_ context.Context, ns, name string) (gitRep
 		return gr, nil
 	}
 	return gitRepository{}, fmt.Errorf("gitrepository %s/%s not found", ns, name)
+}
+func (f fakeReader) SourceRevision(_ context.Context, kind, ns, name string) (string, error) {
+	if rev, ok := f.srcRevs[kind+"/"+ns+"/"+name]; ok {
+		return rev, nil
+	}
+	return "", fmt.Errorf("source %s/%s/%s revision not found", kind, ns, name)
 }
 func (f fakeReader) WatchKustomizations(context.Context) (<-chan KustomizationEvent, error) {
 	ch := make(chan KustomizationEvent)
@@ -80,6 +89,76 @@ func TestProviderChanges(t *testing.T) {
 	}
 	if c.ToRev != "abc123" || c.FromRev != "" {
 		t.Fatalf("unexpected revs: from=%q to=%q", c.FromRev, c.ToRev)
+	}
+}
+
+// TestProviderChangesFailingKustomizationSpansGap covers the core bug: a failing
+// Kustomization keeps status.lastAppliedRevision pinned to the last HEALTHY commit
+// (Flux does NOT advance it on a health-check failure). Keying "what changed" on
+// lastAppliedRevision alone diffs the pre-break commit and misses the breaking one.
+// For a failing Kustomization whose source HEAD differs from lastApplied, the Change
+// must span lastApplied..HEAD; otherwise behavior is unchanged.
+func TestProviderChangesFailingKustomizationSpansGap(t *testing.T) {
+	const url = "https://github.com/org/repo"
+	cases := []struct {
+		name        string
+		readyStatus string
+		lastApplied string // status.lastAppliedRevision
+		srcHead     string // source status.artifact.revision (current synced HEAD)
+		wantFrom    string
+		wantTo      string
+	}{
+		{
+			// The bug repro: failing health check, HEAD (B) is past lastApplied (A).
+			name:        "failing with source ahead spans lastApplied..HEAD",
+			readyStatus: "False", lastApplied: "main@sha1:aaa", srcHead: "main@sha1:bbb",
+			wantFrom: "aaa", wantTo: "bbb",
+		},
+		{
+			// Healthy: keep today's behavior exactly (diff the change introduced by ToRev).
+			name:        "healthy keeps single-rev behavior",
+			readyStatus: "True", lastApplied: "main@sha1:aaa", srcHead: "main@sha1:bbb",
+			wantFrom: "", wantTo: "aaa",
+		},
+		{
+			// Failing but source HEAD == lastApplied: no real gap, no false span.
+			name:        "failing with source equal to lastApplied keeps single-rev behavior",
+			readyStatus: "False", lastApplied: "main@sha1:aaa", srcHead: "main@sha1:aaa",
+			wantFrom: "", wantTo: "aaa",
+		},
+		{
+			// Ready != True (the spec's "failing" predicate) also covers Unknown
+			// (e.g. reconciling/progressing): span the gap so an in-flight breaking
+			// commit past the last-applied one is surfaced rather than missed.
+			name:        "ready-unknown with source ahead spans lastApplied..HEAD",
+			readyStatus: "Unknown", lastApplied: "main@sha1:aaa", srcHead: "main@sha1:bbb",
+			wantFrom: "aaa", wantTo: "bbb",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := fakeReader{
+				ks: []kustomization{{
+					Name: "apps", Namespace: "flux-system", Path: "./apps",
+					SourceKind: "GitRepository", SourceName: "flux-system", SourceNamespace: "flux-system",
+					Revision: tc.lastApplied, ReadyStatus: tc.readyStatus,
+				}},
+				grs:     map[string]gitRepository{"flux-system/flux-system": {URL: url}},
+				srcRevs: map[string]string{"GitRepository/flux-system/flux-system": tc.srcHead},
+			}
+			p := New(r, &whatchanged.Differ{})
+			changes, err := p.Changes(context.Background(), providers.TimeWindow{}, providers.Selector{})
+			if err != nil {
+				t.Fatalf("Changes: %v", err)
+			}
+			if len(changes) != 1 {
+				t.Fatalf("want 1 change, got %d", len(changes))
+			}
+			if changes[0].FromRev != tc.wantFrom || changes[0].ToRev != tc.wantTo {
+				t.Fatalf("revs: from=%q to=%q, want from=%q to=%q",
+					changes[0].FromRev, changes[0].ToRev, tc.wantFrom, tc.wantTo)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## The bug

When a Flux Kustomization fails its **health check**, Flux keeps `status.lastAppliedRevision` pinned to the **last healthy** commit — it does **not** advance it on a health-check failure. `what_changed` keyed on `lastAppliedRevision`, so it diffed the *pre-break* commit (the healthy one) and missed the **breaking** commit, which is newer and sits in the source's current `HEAD`.

Field repro:
- Commit **A** applied a healthy `Deployment` → `lastAppliedRevision=A`, `Ready=True`.
- Commit **B** changed the image to a bad one → pod `ImagePullBackOff` → Kustomization `Ready=False (HealthCheckFailed)`, but `lastAppliedRevision` stayed at **A**.
- `what_changed` then diffed **A** (showing the *healthy* Deployment being added) and suggested "revert A" — wrong; **B** is the culprit.

## The fix

In `internal/providers/gitops/flux`, when building the `providers.Change` for a Kustomization that is **failing** (`Ready != True`) **and** whose managing source's current revision differs from its `lastAppliedRevision`, the Change now spans the gap:

- `FromRev = lastAppliedRevision` (last healthy)
- `ToRev   = source HEAD revision` (`status.artifact.revision` of the Kustomization's `sourceRef`)

so `what_changed` diffs `lastApplied..HEAD` and surfaces the breaking commit(s).

For a **healthy** Kustomization (or when the source HEAD == `lastAppliedRevision`), behavior is unchanged: `ToRev = lastApplied`, `FromRev = ""` (diff the change introduced by `ToRev`). The source read is **best-effort** — any error falls back to the single-revision range. The differ already supports both revision modes (`Remote` for `From..To`, `RemoteFromParent` for `To` alone), so no differ change was needed.

### Changes
- `flux.Reader` gains `SourceRevision(ctx, kind, ns, name)`, implemented on the dynamic reader by reading `status.artifact.revision` off the source (GitRepository / OCIRepository / Bucket / ExternalArtifact) via the existing dynamic client + GVR map. Empty kind defaults to `GitRepository` (Flux's own default).
- `Provider.Changes` computes the `(FromRev, ToRev)` range per Kustomization via a new `revisionRange` helper and passes it to `mapKustomization`.

## Tests

Table-driven `TestProviderChangesFailingKustomizationSpansGap` (with a fake `Reader`):
- **failing**, source HEAD `B` ahead of `lastApplied=A` ⇒ `FromRev=A, ToRev=B` (the bug case)
- **healthy** ⇒ `ToRev=lastApplied, FromRev=""` (unchanged)
- **failing**, source HEAD == `lastApplied` ⇒ unchanged (no false gap)
- **Ready=Unknown** (progressing), source ahead ⇒ spans the gap (`Ready != True`)

Plus `TestSourceRevision` covering the new reader (reads `status.artifact.revision`; errors on an unsupported kind).

Written test-first (red → green). `go build ./...`, `go test ./...`, `gofmt`, and `golangci-lint run ./...` all pass.