### PR TITLE
fix(gitops): debounce transient Flux failures before investigating

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -274,7 +274,7 @@ func runServe(args []string) error {
 	startWork := func(workCtx context.Context) {
 		go queue.Run(workCtx)
 		if cfg.Triggers.GitOpsFailures.Enabled && gitops != nil {
-			startGitOpsFailureWatch(workCtx, cfg, queue, gitops, log)
+			startGitOpsFailureWatch(workCtx, cfg, queue, gitops, metrics, log)
 		}
 		if reinv != nil {
 			log.Info("re-investigate poller enabled", "label", investigate.ReinvestigateLabel)
@@ -1243,15 +1243,45 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	}, cat
 }
 
-// startGitOpsFailureWatch drains Flux WatchFailures into the queue.
-func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, gp providers.GitOpsProvider, log *slog.Logger) {
+// startGitOpsFailureWatch drains Flux WatchFailures into the queue. Failures are
+// debounced (when a positive window is configured): the investigation is enqueued
+// only after the failure has persisted — re-checked still Ready=False via the
+// provider's ResourceStatus — filtering reconcile-churn transients that would
+// otherwise drive confident-but-wrong root causes.
+func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, gp providers.GitOpsProvider, metrics *telemetry.Metrics, log *slog.Logger) {
 	events, err := gp.WatchFailures(ctx)
 	if err != nil {
 		log.Warn("gitops-failure watch disabled", "err", err)
 		return
 	}
-	log.Info("watching gitops failures", "engine", gitopsEngine(cfg))
-	go investigate.DrainFailures(ctx, events, q, trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()), log)
+	deb := buildFailureDebouncer(cfg, gp, metrics, log)
+	log.Info("watching gitops failures", "engine", gitopsEngine(cfg),
+		"debounce", cfg.Triggers.GitOpsFailures.Debounce.Std())
+	go investigate.DrainFailures(ctx, events, q, trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()), deb, log)
+}
+
+// buildFailureDebouncer wires a Debouncer whose "still failing?" re-check reads
+// the workload's CURRENT Ready condition via GitOpsInspector.ResourceStatus. When
+// the engine offers no inspector, the predicate is nil and the debouncer just
+// waits out the window before enqueuing (still filtering instantly-clearing
+// flaps). A zero window makes Debounce enqueue immediately.
+func buildFailureDebouncer(cfg *config.Config, gp providers.GitOpsProvider, metrics *telemetry.Metrics, log *slog.Logger) *investigate.Debouncer {
+	var check investigate.StillFailing
+	if insp, ok := gp.(providers.GitOpsInspector); ok {
+		check = func(ctx context.Context, w providers.Workload) (bool, error) {
+			rs, err := insp.ResourceStatus(ctx, w)
+			if err != nil {
+				return false, err
+			}
+			// A recovered (Ready=True) or vanished resource is no longer worth
+			// investigating; anything else (False/Unknown) is still failing.
+			if rs.NotFound || rs.Ready == "True" {
+				return false, nil
+			}
+			return true, nil
+		}
+	}
+	return investigate.NewDebouncer(cfg.Triggers.GitOpsFailures.Debounce.Std(), check, log).WithMetrics(metrics)
 }
 
 // gitopsEngine returns the configured GitOps engine, defaulting to flux.

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -30,6 +30,13 @@ config:
         window: 30m
     gitops_failures:
       enabled: true
+      # Debounce transient Flux failures: wait this long, then re-read the
+      # resource's Ready status and investigate only if it is STILL Ready=False.
+      # Filters reconcile-churn transients (e.g. a brief HealthCheckCanceled or an
+      # ArtifactFailed while a new artifact is mid-checkout) that clear on their own
+      # and would otherwise drive confident-but-wrong root causes. Defaults to 60s
+      # when omitted; set 0 to fire immediately on every Ready=False.
+      debounce: 60s
   # HA: only the elected leader runs the informer + investigation queue and reports
   # ready (the Service then routes webhooks to the leader). Harmless with 1 replica.
   leader_election:

--- a/docs/design.md
+++ b/docs/design.md
@@ -163,7 +163,12 @@ triggers:
     ignore:
       alertnames:  [Watchdog, InfoInhibitor]
     dedup: { window: 30m }              # don't re-open a still-firing alert
-  gitops_failures: { enabled: true }    # secondary trigger
+  gitops_failures:                      # secondary trigger
+    enabled: true
+    debounce: 60s                       # require the failure to persist this long
+                                        # (re-check still Ready=False) before
+                                        # investigating — filters reconcile-churn
+                                        # transients; 0 = fire immediately
 ```
 
 ### Investigate — form & test hypotheses across causes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,8 +249,18 @@ type GitOps struct {
 
 // TriggerPolicy decides what RunLore reacts to.
 type TriggerPolicy struct {
-	Incidents      IncidentTrigger `yaml:"incidents"`       // primary trigger
-	GitOpsFailures Toggle          `yaml:"gitops_failures"` // secondary trigger
+	Incidents      IncidentTrigger      `yaml:"incidents"`       // primary trigger
+	GitOpsFailures GitOpsFailureTrigger `yaml:"gitops_failures"` // secondary trigger
+}
+
+// GitOpsFailureTrigger gates GitOps-failure-driven investigations. Debounce
+// delays an investigation until the failure has persisted for that window
+// (re-checked still Ready=False), filtering reconcile-churn transients that
+// would otherwise produce confident-but-wrong root causes. A zero Debounce
+// fires immediately on every Ready=False (the original behavior).
+type GitOpsFailureTrigger struct {
+	Enabled  bool     `yaml:"enabled"`
+	Debounce Duration `yaml:"debounce"` // persistence window before investigating; 0 = fire immediately
 }
 
 // IncidentTrigger gates incident/alert-driven investigations.
@@ -273,11 +283,6 @@ type IncidentMatch struct {
 // Dedup suppresses re-investigation of a still-firing alert within Window.
 type Dedup struct {
 	Window Duration `yaml:"window"`
-}
-
-// Toggle is a simple on/off switch.
-type Toggle struct {
-	Enabled bool `yaml:"enabled"`
 }
 
 // Incident is the normalized trigger input (from Alertmanager/VMAlert).

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -51,6 +51,13 @@ func applyDefaults(c *Config) {
 			co.Cooldown = Duration(10 * time.Minute)
 		}
 	}
+	// GitOps-failure debounce default: when the trigger is enabled without an
+	// explicit window, wait 60s and re-check before investigating — long enough to
+	// let reconcile-churn transients clear, short enough to catch real failures
+	// promptly. Set debounce: 0 explicitly to restore fire-on-every-failure.
+	if c.Triggers.GitOpsFailures.Enabled && c.Triggers.GitOpsFailures.Debounce == 0 {
+		c.Triggers.GitOpsFailures.Debounce = Duration(60 * time.Second)
+	}
 	// Rate-limit window default: 1h when a per-window budget is set but no window
 	// is given (a zero window would silently allow unlimited investigations).
 	if c.Investigation.RateLimit.MaxPerWindow > 0 && c.Investigation.RateLimit.Window == 0 {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -42,4 +42,32 @@ actions:
 	if c.Actions.Enabled() {
 		t.Fatal("actions mode off should be disabled")
 	}
+	// gitops_failures enabled without an explicit debounce → 60s default applied.
+	if !c.Triggers.GitOpsFailures.Enabled {
+		t.Fatal("gitops_failures should be enabled")
+	}
+	if c.Triggers.GitOpsFailures.Debounce.Std() != 60*time.Second {
+		t.Fatalf("gitops_failures debounce default: got %v, want 60s", c.Triggers.GitOpsFailures.Debounce.Std())
+	}
+}
+
+func TestLoadGitOpsFailureDebounceExplicit(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "runlore.yaml")
+	doc := `
+triggers:
+  gitops_failures:
+    enabled: true
+    debounce: 2m
+`
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if c.Triggers.GitOpsFailures.Debounce.Std() != 2*time.Minute {
+		t.Fatalf("explicit debounce: got %v, want 2m", c.Triggers.GitOpsFailures.Debounce.Std())
+	}
 }

--- a/internal/investigate/debounce.go
+++ b/internal/investigate/debounce.go
@@ -1,0 +1,98 @@
+package investigate
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// StillFailing reports whether a workload is STILL Ready=False right now. It
+// backs the debounce re-check; the Flux/ArgoCD implementation reads the
+// resource's current Ready condition via GitOpsInspector.ResourceStatus.
+type StillFailing func(ctx context.Context, w providers.Workload) (bool, error)
+
+// Debouncer delays a GitOps-failure investigation until the failure has
+// PERSISTED for a short window, then re-reads the resource's current Ready
+// status and enqueues only if it is still failing. This filters reconcile-churn
+// transients (e.g. a brief HealthCheckCanceled or an ArtifactFailed while a new
+// artifact is mid-checkout) that clear on their own — the kind of misleading
+// status that previously produced a confident-but-wrong root cause.
+//
+// A zero window disables the wait and re-check entirely: Debounce enqueues
+// immediately, preserving the original fire-on-every-failure behavior.
+type Debouncer struct {
+	window  time.Duration
+	check   StillFailing
+	log     *slog.Logger
+	metrics *telemetry.Metrics // optional; nil-safe counter for dropped transients
+
+	// clock is injectable so tests can release the wait without real sleeps;
+	// defaults to a time.After-backed clock.
+	clock clock
+}
+
+// clock abstracts the debounce wait so tests can release it deterministically.
+type clock interface {
+	After(d time.Duration) <-chan time.Time
+}
+
+type realClock struct{}
+
+func (realClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// NewDebouncer builds a Debouncer. A zero window disables debouncing (immediate
+// enqueue). check is consulted only when window > 0.
+func NewDebouncer(window time.Duration, check StillFailing, log *slog.Logger) *Debouncer {
+	return &Debouncer{window: window, check: check, log: log, clock: realClock{}}
+}
+
+// WithMetrics installs the (nil-safe) metric set and returns the Debouncer for
+// chaining. A dropped transient increments InvestigationsDropped.
+func (d *Debouncer) WithMetrics(m *telemetry.Metrics) *Debouncer {
+	d.metrics = m
+	return d
+}
+
+// Debounce decides whether to enqueue r. With window 0 it enqueues immediately.
+// Otherwise it waits window, re-checks the workload's current Ready status, and
+// enqueues only if it is still failing — dropping (debug-logged) any failure
+// that cleared or flipped to a different transient within the window. It blocks
+// for the wait; callers run it in a goroutine per failure event.
+func (d *Debouncer) Debounce(ctx context.Context, r Request, q Enqueuer) {
+	if d.window <= 0 {
+		q.Enqueue(r)
+		return
+	}
+	select {
+	case <-ctx.Done():
+		return
+	case <-d.clock.After(d.window):
+	}
+	if d.check != nil {
+		stillFailing, err := d.check(ctx, r.Workload)
+		if err != nil {
+			// Re-check failed (transient API error): fall back to enqueuing rather
+			// than silently dropping a possibly-real failure.
+			if d.log != nil {
+				d.log.Debug("gitops-failure debounce re-check errored; enqueuing anyway",
+					"workload", r.Workload.Ref(), "reason", r.Reason, "err", err)
+			}
+			q.Enqueue(r)
+			return
+		}
+		if !stillFailing {
+			if d.log != nil {
+				d.log.Debug("gitops-failure cleared within debounce window; dropping transient",
+					"workload", r.Workload.Ref(), "reason", r.Reason, "window", d.window)
+			}
+			if d.metrics != nil {
+				d.metrics.GitOpsFailuresDebounced.Add(ctx, 1)
+			}
+			return
+		}
+	}
+	q.Enqueue(r)
+}

--- a/internal/investigate/debounce.go
+++ b/internal/investigate/debounce.go
@@ -50,7 +50,7 @@ func NewDebouncer(window time.Duration, check StillFailing, log *slog.Logger) *D
 }
 
 // WithMetrics installs the (nil-safe) metric set and returns the Debouncer for
-// chaining. A dropped transient increments InvestigationsDropped.
+// chaining. A dropped transient increments GitOpsFailuresDebounced.
 func (d *Debouncer) WithMetrics(m *telemetry.Metrics) *Debouncer {
 	d.metrics = m
 	return d

--- a/internal/investigate/debounce_test.go
+++ b/internal/investigate/debounce_test.go
@@ -1,0 +1,87 @@
+package investigate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeClock is a manually advanced clock with a controllable After channel, so
+// the debouncer's wait can be released deterministically without real sleeps.
+type fakeClock struct {
+	after chan time.Time
+}
+
+func newFakeClock() *fakeClock { return &fakeClock{after: make(chan time.Time, 1)} }
+
+func (c *fakeClock) After(time.Duration) <-chan time.Time { return c.after }
+
+// release fires the pending timer so the debouncer proceeds to the re-check.
+func (c *fakeClock) release() { c.after <- time.Now() }
+
+func wl(name string) providers.Workload {
+	return providers.Workload{Kind: "Kustomization", Name: name, Namespace: "flux-system"}
+}
+
+func TestDebouncerEnqueuesWhenStillFailing(t *testing.T) {
+	clk := newFakeClock()
+	enq := &collectEnqueuer{}
+	// Predicate: the workload is still Ready=False at re-check time.
+	stillFailing := func(context.Context, providers.Workload) (bool, error) { return true, nil }
+
+	d := NewDebouncer(60*time.Second, stillFailing, discardLog)
+	d.clock = clk
+
+	done := make(chan struct{})
+	go func() {
+		d.Debounce(context.Background(), FromFailureEvent(providers.FailureEvent{Workload: wl("apps"), Reason: "BuildFailed"}), enq)
+		close(done)
+	}()
+	clk.release()
+	<-done
+
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued (still failing), got %d", len(enq.reqs))
+	}
+}
+
+func TestDebouncerDropsRecoveredTransient(t *testing.T) {
+	clk := newFakeClock()
+	enq := &collectEnqueuer{}
+	// Predicate: the workload recovered (Ready=True) by re-check time → drop.
+	recovered := func(context.Context, providers.Workload) (bool, error) { return false, nil }
+
+	d := NewDebouncer(60*time.Second, recovered, discardLog)
+	d.clock = clk
+
+	done := make(chan struct{})
+	go func() {
+		d.Debounce(context.Background(), FromFailureEvent(providers.FailureEvent{Workload: wl("apps"), Reason: "ArtifactFailed"}), enq)
+		close(done)
+	}()
+	clk.release()
+	<-done
+
+	if len(enq.reqs) != 0 {
+		t.Fatalf("want 0 enqueued (transient recovered within window), got %d", len(enq.reqs))
+	}
+}
+
+func TestDebouncerZeroWindowEnqueuesImmediately(t *testing.T) {
+	enq := &collectEnqueuer{}
+	// A predicate that would say "recovered" — it must NOT be consulted when the
+	// window is 0 (today's immediate behavior is preserved).
+	neverCalled := func(context.Context, providers.Workload) (bool, error) {
+		t.Fatal("predicate must not be called with debounce=0")
+		return false, nil
+	}
+	d := NewDebouncer(0, neverCalled, discardLog)
+
+	d.Debounce(context.Background(), FromFailureEvent(providers.FailureEvent{Workload: wl("apps"), Reason: "BuildFailed"}), enq)
+
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued immediately with debounce=0, got %d", len(enq.reqs))
+	}
+}

--- a/internal/investigate/failures.go
+++ b/internal/investigate/failures.go
@@ -27,8 +27,14 @@ func isCascadeFailure(fe providers.FailureEvent) bool {
 // DrainFailures forwards GitOps FailureEvents into the queue as investigation
 // requests. It drops dependency-cascade symptoms (so only root failures are
 // investigated) and dedups by workload (a Ready=False resource emits repeated
-// events). A nil dedup disables dedup. It returns when src closes or ctx is done.
-func DrainFailures(ctx context.Context, src <-chan providers.FailureEvent, q Enqueuer, dedup *trigger.Deduper, log *slog.Logger) {
+// events). A nil dedup disables dedup.
+//
+// When deb is non-nil with a positive window, each surviving failure is
+// debounced: the investigation is enqueued only after the failure has PERSISTED
+// (re-checked still-Ready=False after the window), filtering reconcile-churn
+// transients. A nil deb (or a zero-window one) enqueues immediately — today's
+// behavior. It returns when src closes or ctx is done.
+func DrainFailures(ctx context.Context, src <-chan providers.FailureEvent, q Enqueuer, dedup *trigger.Deduper, deb *Debouncer, log *slog.Logger) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -47,7 +53,15 @@ func DrainFailures(ctx context.Context, src <-chan providers.FailureEvent, q Enq
 			if dedup != nil && dedup.Seen(fe.Workload.Namespace+"/"+fe.Workload.Name) {
 				continue
 			}
-			q.Enqueue(FromFailureEvent(fe))
+			r := FromFailureEvent(fe)
+			if deb != nil {
+				// Debounce per failing workload in its own goroutine so the drain loop
+				// keeps consuming events (and dedup keeps collapsing repeats) during the
+				// wait; Debounce no-ops the wait when the window is 0.
+				go deb.Debounce(ctx, r, q)
+				continue
+			}
+			q.Enqueue(r)
 		}
 	}
 }

--- a/internal/investigate/failures_test.go
+++ b/internal/investigate/failures_test.go
@@ -26,7 +26,7 @@ func TestDrainFailures(t *testing.T) {
 	close(src)
 
 	enq := &collectEnqueuer{}
-	DrainFailures(context.Background(), src, enq, trigger.NewDeduper(30*time.Minute), discardLog)
+	DrainFailures(context.Background(), src, enq, trigger.NewDeduper(30*time.Minute), nil, discardLog)
 
 	if len(enq.reqs) != 2 {
 		t.Fatalf("want 2 enqueued (one deduped), got %d", len(enq.reqs))
@@ -46,7 +46,7 @@ func TestDrainFailuresSkipsCascades(t *testing.T) {
 	close(src)
 
 	enq := &collectEnqueuer{}
-	DrainFailures(context.Background(), src, enq, trigger.NewDeduper(30*time.Minute), discardLog)
+	DrainFailures(context.Background(), src, enq, trigger.NewDeduper(30*time.Minute), nil, discardLog)
 
 	if len(enq.reqs) != 1 || enq.reqs[0].Workload.Name != "crds" {
 		t.Fatalf("want only the root 'crds' failure enqueued, got %+v", enq.reqs)

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -22,6 +22,7 @@ type Metrics struct {
 	InvestigationsStarted     metric.Int64Counter
 	InvestigationsThrottled   metric.Int64Counter
 	InvestigationsDropped     metric.Int64Counter
+	GitOpsFailuresDebounced   metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
 	ToolOutputTruncatedBytes  metric.Int64Counter
 	RecallHits                metric.Int64Counter // KB cache hits, labelled by verify result
 	RecallTokensSaved         metric.Int64Counter // estimated tokens saved by a recall short-circuit
@@ -66,6 +67,7 @@ func NewMetrics() *Metrics {
 		InvestigationsStarted:     ctr("investigations_started_total", "investigations actually begun"),
 		InvestigationsThrottled:   ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
 		InvestigationsDropped:     ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
+		GitOpsFailuresDebounced:   ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
 		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
 		RecallHits:                ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
 		RecallTokensSaved:         ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),


### PR DESCRIPTION
## The bug (observed in production)

RunLore's GitOps-failure watch fired an investigation **immediately** on ANY Flux Kustomization going `Ready=False`, with no persistence check. During normal reconcile churn a Kustomization can briefly show a **transient/misleading** condition — e.g. `HealthCheckCanceled`, or `ArtifactFailed: kustomization path not found` while a new artifact is mid-checkout.

RunLore investigated one such transient and produced a **confident-but-wrong** root cause: it concluded *"path not found: tooling/base/runlore-faulttest"* at **90% confidence** and recommended reverting a commit — but the path existed and the real cause was an `ImagePullBackOff`. The agent never reconciled the transient status against current state.

## The fix

**Debounce** GitOps-failure events: do not enqueue an investigation until the failure has **persisted**. On a failure event, wait a short configurable window, then **re-read the resource's current Ready status** (via `GitOpsInspector.ResourceStatus`) and enqueue only if it is **still** `Ready=False`. A failure that clears (or vanishes) within the window is dropped (debug-logged). This filters reconcile-churn transients while still catching real, sustained failures.

## What changed

- **`internal/investigate/debounce.go`** — new `Debouncer`: on a failure, waits the window then consults an injected `StillFailing` predicate before enqueuing. Clock injected for deterministic tests (no real sleeps). A **zero window enqueues immediately** (today's behavior, and the predicate is never consulted).
- **`internal/investigate/failures.go`** — `DrainFailures` takes a `*Debouncer`; each surviving failure is debounced in its own goroutine so the drain loop keeps consuming events (and dedup keeps collapsing repeats) during the wait. `nil` debouncer = immediate enqueue.
- **`cmd/lore/main.go`** — `startGitOpsFailureWatch` builds the debouncer; the re-check reads the workload's current Ready condition via `ResourceStatus` (a recovered `Ready=True` or vanished/`NotFound` resource → drop).
- **Config knob** — `triggers.gitops_failures.debounce` (`Duration`). Default **60s** when the trigger is enabled and unset; `0` restores fire-on-every-failure. (`gitops_failures` upgraded from a bare `Toggle` to a `GitOpsFailureTrigger` struct; the now-unused `Toggle` type removed.)
- **`deploy/helm/runlore/values.yaml`** + **`docs/design.md`** — chart value + schema snippet documenting the knob.
- **`internal/telemetry/metrics.go`** — nil-safe `runlore_gitops_failures_debounced_total` counter for dropped transients.

## Tests (TDD)

- `internal/investigate/debounce_test.go` — fake clock + fake predicate (no sleeps): a failure that **recovers** within the window is NOT enqueued; one that **stays** `Ready=False` IS; with `debounce=0` it enqueues immediately and the predicate is never called.
- `internal/config/load_test.go` — 60s default applied when enabled-but-unset; explicit `debounce: 2m` parses through.
- Existing `internal/investigate/failures_test.go` (and all others) stay green.

`go build ./...`, `go test ./...` (incl. `-race` on touched packages), and `golangci-lint run ./...` (v2.12.2) all pass.
