### PR TITLE
Post-review hardening — P2 polish (R17/R18/R15/R24)

### DIFF
--- a/docs/superpowers/plans/2026-06-24-llm-protocol-fixes.md
+++ b/docs/superpowers/plans/2026-06-24-llm-protocol-fixes.md
@@ -1,0 +1,25 @@
+# Plan — LLM-protocol correctness fixes (Item R15)
+
+Spec: `docs/superpowers/specs/2026-06-24-llm-protocol-fixes-design.md`
+Branch: `r15-llm-protocol-fixes`
+
+## Steps
+
+1. **OpenAI — test first.** Add a test asserting the raw marshaled request body keeps
+   `"content":""` for an empty-content tool message (capture the body in the httptest
+   handler, not the decoded struct). Confirm it fails against current code.
+2. **OpenAI — fix.** Make the tool-role message always serialize `content` (dedicated
+   tool-message shape with non-omitempty `content`), keeping `omitempty` for assistant turns.
+   Gate green → commit.
+3. **Gemini — test first.** Add tests: (a) two parallel responses to the same function name
+   map to the correct originating ids on the request `functionResponse` parts; (b) a response
+   `functionCall` with an `id` carries that id into `ToolCall.ID`, with name fallback when the
+   id is absent. Confirm failure against current code.
+4. **Gemini — fix.** Parse `functionCall.id` on responses; add `id` to the request
+   `functionCall`/`functionResponse` shapes; emit the originating id on each
+   `functionResponse`; update the package doc. Gate green → commit.
+
+## Gate (before each commit)
+
+`go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...`
+(expect `0 issues`).

--- a/docs/superpowers/specs/2026-06-24-argocd-parity-design.md
+++ b/docs/superpowers/specs/2026-06-24-argocd-parity-design.md
@@ -1,0 +1,117 @@
+# Argo CD provider — closing the genuine gaps vs Flux (R24)
+
+Status: in progress
+Date: 2026-06-24
+Scope: `internal/providers/gitops/argocd/`
+
+## Problem (R24)
+
+The Argo CD `GitOpsProvider` is ~1 tier shallower than the Flux one. Three
+specific gaps were flagged. Each is challenged against the CURRENT code below,
+with a verdict and `file:line`, before any change.
+
+### Gap 1 — Multi-source apps silently dropped — CONFIRMED
+
+`applicationFromUnstructured` (`dynamic.go:79-81`) reads only the **single-source**
+fields: `spec.source.repoURL`, `spec.source.path`, `status.sync.revision`. An
+Argo CD Application that uses the multi-source schema (`spec.sources[]` — plural,
+mutually exclusive with the singular `spec.source`) therefore yields an
+`application` with empty `RepoURL`/`Revision`. `Changes` (`argocd.go:68`) then
+hits `if a.RepoURL == "" || a.Revision == "" { continue }` and drops the app —
+**with no log line**. So it is a *silent* drop, not graceful degradation.
+
+Verdict: real gap. A multi-source app contributes nothing to the change spine and
+leaves no trace that it was skipped.
+
+Fix (pragmatic, defensible): read the **first** source of `spec.sources[]` (its
+`repoURL`/`path`) and the **first** synced revision of `status.sync.revisions[]`
+when the singular fields are absent. This makes the common multi-source app
+(one Git source + one Helm/values source) produce a real, diffable Change instead
+of vanishing. When neither schema yields a usable RepoURL+Revision, emit a single
+`Debug` log noting the skip (so the blind spot is observable) instead of dropping
+silently.
+
+Why "first source" and not "a Change per source": the engine-agnostic `Change`
+carries exactly one `SourceRef`. Fanning out one Change per source would change
+the spine's cardinality and ripple into dedup/diff/blast-radius semantics far
+beyond this provider — out of scope. The first source is, in practice, the Git
+source that backs the app's manifests (the values/chart sources are refs); it is
+the most defensible single pick and matches what a human reads first. Documented
+in code.
+
+### Gap 2 — Failure trigger is health-only — CONFIRMED
+
+`WatchFailures` (`argocd.go:100`) triggers only on `HealthStatus == "Degraded"`.
+A **failed sync operation** surfaces in `status.operationState.phase ∈ {Failed,
+Error}` (the `OperationPhase` enum is Running/Terminating/Failed/Error/Succeeded).
+A sync can fail (e.g. a bad manifest, a hook error) while health is still
+`Healthy`/`Progressing` — that failure is currently missed entirely.
+
+Verdict: real gap. Add `operationState.phase ∈ {Failed,Error}` as an additional
+trigger. Carry the new field `OperationPhase` on `application`, read it in
+`applicationFromUnstructured`, and fire a FailureEvent when health is Degraded
+**or** the last sync operation phase is Failed/Error. `Reason` reflects which
+condition fired so the downstream investigation has accurate attribution.
+
+Note: the R24 text also mentioned `OutOfSync`. The current code does **not** key
+on OutOfSync, and OutOfSync alone is not a failure — it is the steady state of any
+app with auto-sync disabled or mid-drift. Triggering on it would flood the React
+loop with non-failures. Decision: do **not** add OutOfSync as a failure trigger;
+the genuine missing signal is the failed operation phase. Documented here.
+
+### Gap 3 — Events dropped under backpressure — CONFIRMED
+
+`dynamic.go:56-60` `send` does `select { case out<-ev: case <-ctx.Done(): default: }`.
+The `default:` makes the send non-blocking: when the buffered (128) channel is
+full, the event is **silently dropped**. The informer's periodic resync
+(10 min) re-delivers current state eventually, which *masks* the drop as a delayed
+blind spot rather than a hard loss — but a failure event that fires and is dropped
+won't trigger a timely React investigation.
+
+Verdict: real gap. Replace the `default:` drop with a **bounded** blocking send: a
+`time.NewTimer`-gated `select` that blocks up to a small timeout for the consumer
+to drain, and only then gives up (logging the drop). This preserves the
+"never block the informer indefinitely" invariant (a stuck consumer must not wedge
+the shared informer) while eliminating the silent instant-drop on a transient
+burst.
+
+## GitOpsInspector — decision: OUT OF SCOPE
+
+Flux implements the optional `providers.GitOpsInspector` (ResourceStatus +
+DependencyTree) over its `dependsOn`/`sourceRef` graph. Argo CD's model is
+different: an Application is a self-contained sync unit; there is no first-class
+`dependsOn` between Applications (sync waves order resources *within* an app, and
+App-of-Apps nesting is just another Application syncing child Applications). A
+faithful Argo inspector would need a different traversal (app → managed resources
+via `status.resources[]`, or app-of-apps child refs), which is a separate design,
+not "parity." R24 explicitly says "you don't have to reach full Flux parity, just
+close the genuine gaps." Consumers already type-assert for `GitOpsInspector` and
+degrade when it is absent, so omitting it is safe. Decision: do not add it now;
+recorded as a follow-up.
+
+## Tests (test-first, stdlib `testing`, dynamic fake for the reader)
+
+1. `applicationFromUnstructured` on a multi-source object (`spec.sources[]`,
+   `status.sync.revisions[]`) maps the first source's repoURL/path and the first
+   revision.
+2. `Changes` yields a Change for a multi-source app (proves it is no longer
+   dropped).
+3. `applicationFromUnstructured` reads `operationState.phase`.
+4. `WatchFailures` fires for an app whose `operationState.phase == "Failed"` (or
+   `"Error"`) even when health is not Degraded; the Reason reflects the sync
+   failure. Health-Degraded still fires (unchanged).
+5. A bounded send does not silently drop: a fast consumer receives a burst of
+   events through `WatchApplications` without loss (and the `-race` run stays
+   clean).
+
+## Gate (before each commit)
+
+`go build/vet/test ./...` · `gofmt -l .` · `golangci-lint run ./...` (0 issues,
+gosec on) · `go test -race ./internal/providers/gitops/argocd/`.
+
+## Non-goals / deviations
+
+- No `Change`-per-source fan-out (cardinality change — out of scope).
+- No OutOfSync failure trigger (non-failure steady state).
+- No GitOpsInspector for Argo (different model; follow-up).
+- Build on the existing `ctx`-threaded `Diff` signature (R4+R5) — do not revert.

--- a/docs/superpowers/specs/2026-06-24-argocd-parity-plan.md
+++ b/docs/superpowers/specs/2026-06-24-argocd-parity-plan.md
@@ -1,0 +1,40 @@
+# Plan — Argo CD parity gaps (R24)
+
+Spec: `2026-06-24-argocd-parity-design.md`. Test-first, stdlib `testing`, dynamic
+fake reader. Full gate (build/vet/test/gofmt/lint + `-race` on the argocd pkg)
+green before each commit.
+
+## Step 1 — Gap 1: multi-source sources read (no silent drop)
+- Test: `applicationFromUnstructured` on a `spec.sources[]` / `status.sync.revisions[]`
+  object → first source + first revision; multi-source history → prev from
+  `.revisions[0]`. `Changes` yields a Change for the multi-source app.
+- Impl: `sourceRepoPath` / `syncRevision` fall back from singular to first of the
+  plural arrays; `prevRevision` handles `.revisions[]`; `Changes` logs the skip at
+  Debug instead of dropping silently.
+
+## Step 2 — Gap 2: failed sync operation triggers a failure
+- Test: `WatchFailures` fires for `operationState.phase ∈ {Failed,Error}` even when
+  health is not Degraded; OutOfSync alone does not fire; health-Degraded unchanged.
+  `failureReason` table test.
+- Impl: carry `OperationPhase` on `application`, read `operationState.phase`; add
+  `failureReason` (Degraded OR Failed/Error), used by `WatchFailures`.
+
+## Step 3 — Gap 3: bounded send (no silent backpressure drop)
+- Test: `sendEvent` blocks for a slightly-late consumer (no drop); ctx cancel
+  returns promptly.
+- Impl: replace the non-blocking `default:` with a `time.NewTimer(sendTimeout)`-
+  gated select that blocks up to 5s, then logs and gives up.
+
+## Decisions (documented in spec)
+- First-source pick, not Change-per-source (cardinality out of scope).
+- No OutOfSync failure trigger (steady state, not a failure).
+- No GitOpsInspector for Argo (different dependency model; follow-up).
+- Build on the existing ctx-threaded `Diff` (R4+R5) — not reverted.
+
+## Commits
+1. spec + plan.
+2. Gap 1 (multi-source) + tests.
+3. Gap 2 (sync-failure trigger) + tests.
+4. Gap 3 (bounded send) + tests.
+
+(Implementation landed cohesively; commits below reflect the actual split.)

--- a/docs/superpowers/specs/2026-06-24-coalesce-hygiene-design.md
+++ b/docs/superpowers/specs/2026-06-24-coalesce-hygiene-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-24
 Branch: worktree-agent-a7aae1794a8d69bdf
-Status: implementing
+Status: done — all four nits implemented (nit 2 in the narrowed form), gate green incl. -race
 
 A cluster of trigger-pipeline correctness nits in `internal/coalesce` and
 `internal/trigger`. Each was challenged against the current code; the verdict

--- a/docs/superpowers/specs/2026-06-24-coalesce-hygiene-design.md
+++ b/docs/superpowers/specs/2026-06-24-coalesce-hygiene-design.md
@@ -1,0 +1,87 @@
+# Coalesce / dedup hygiene (R17)
+
+Date: 2026-06-24
+Branch: worktree-agent-a7aae1794a8d69bdf
+Status: implementing
+
+A cluster of trigger-pipeline correctness nits in `internal/coalesce` and
+`internal/trigger`. Each was challenged against the current code; the verdict
+and the chosen fix are recorded below.
+
+## Scope
+
+Four findings. All four held up under challenge; finding 2 holds only in a
+narrower form than stated, so the fix is correspondingly narrow.
+
+### Nit 1 — `recent` map never evicted (leak) — HOLDS
+
+`coalescer.go` writes `recent[k]` at three sites (critical flush, MaxBatch
+flush, sweep flush) and never deletes. `sweep` evicts only `pending`;
+`withinCooldown` reads `recent` but never trims it. `Run`/`sweep` ticks for the
+whole process lifetime (`main.go` wires `cz.Run(ctx, …)`), so over a long serve
+with churning namespaces/labels `recent` grows without bound — one permanent
+entry per distinct key ever seen.
+
+**Fix.** In `sweep`, after the pending pass, evict every `recent` entry whose
+age `>= Cooldown` (it can no longer suppress anything). When `Cooldown <= 0`,
+`recent` is never consulted by `withinCooldown`, so evict all of it. This
+mirrors the eviction the `Deduper` already does (`dedup.go`).
+
+### Nit 2 — cooldown drops a genuinely new incident — HOLDS (narrowed)
+
+Within the cooldown window a same-key incident is unconditionally `return`ed
+(suppressed). For same-key **repeats** this is the whole point (storm collapse;
+asserted by `TestAddCriticalStormSuppressedAfterFirst`). But when
+`CorrelationLabels` are configured the key is `ns/<labelvalues>`, so a
+**different, genuinely new critical alert** sharing those labels is dropped too.
+
+**Design fork.**
+- (A) "don't suppress any critical during cooldown" — rejected: re-breaks
+  storm collapse, contradicts the existing storm test.
+- (B) "reset cooldown only on quiescence" — rejected here: invasive, changes
+  flush timing semantics for the whole pipeline.
+- (C, chosen) Track the set of alertnames already flushed per key. During
+  cooldown, suppress as before **except** a `critical` whose alertname has not
+  yet been seen for that key — that is a distinct new problem, so flush it
+  (and record its alertname). Same-alertname critical repeats and all warnings
+  still suppress. Storm collapse is preserved; a genuinely new critical is not
+  lost.
+
+The seen-alertname set lives alongside `recent` and is evicted on the same
+schedule (Nit 1), so it adds no new leak.
+
+### Nit 3 — all-empty correlation labels collapse unrelated incidents — HOLDS
+
+`key()` with `CorrelationLabels` set joins `inc.Labels[l]`; a missing label is
+`""`. If **every** correlation label is absent the key degenerates to `ns/`
+(or `ns//…`), collapsing unrelated incidents in the same namespace.
+
+**Fix.** If every correlation-label value is empty, fall through to the
+no-labels path (`GroupKey`, else `ns/alertname`). Partial presence is a
+legitimate key and is left untouched.
+
+### Nit 4 — dedup fallback key omits environment — HOLDS
+
+`trigger.dedupKey` falls back to `AlertName + "/" + Namespace` when
+`Fingerprint` is empty. A policy admitting multiple environments lets
+same-name/same-namespace alerts from different environments collide on the
+fallback, deduping a distinct incident.
+
+**Fix.** Append `inc.Environment`: `AlertName + "/" + Namespace + "/" +
+Environment`. Fingerprint path unchanged.
+
+## Tests (test-first, stdlib, table-driven where it fits)
+
+- `recent` (and seen-alertname) eviction after cooldown in `sweep`.
+- new critical alertname during cooldown is flushed, not dropped; same-alertname
+  critical repeat still suppressed; warning repeat still suppressed.
+- all-empty correlation labels do not collapse unrelated incidents; partial
+  presence still correlates.
+- env-distinct fallback dedup keys do not collide.
+
+Existing coalesce/trigger tests stay green.
+
+## Gate (before each commit)
+
+`go build/vet/test ./... && gofmt -l . && golangci-lint run ./...` (0 issues,
+gosec enabled) + `go test -race ./internal/coalesce/ ./internal/trigger/`.

--- a/docs/superpowers/specs/2026-06-24-coalesce-hygiene-plan.md
+++ b/docs/superpowers/specs/2026-06-24-coalesce-hygiene-plan.md
@@ -1,0 +1,33 @@
+# Plan — Coalesce / dedup hygiene (R17)
+
+Spec: `2026-06-24-coalesce-hygiene-design.md`. Test-first, commit incrementally.
+Gate before each commit:
+`go build/vet/test ./... && gofmt -l . && golangci-lint run ./...` (0 issues) +
+`golangci-lint run ./internal/coalesce/... ./internal/trigger/...` (gosec-clean)
++ `go test -race ./internal/coalesce/ ./internal/trigger/`.
+
+## Step 1 — Nit 4: env in dedup fallback key (trigger)
+1. Test: two incidents, same alertname+namespace, no fingerprint, different
+   environment → second NOT deduped. (`engine_test.go` or new `dedupkey_test.go`)
+2. Impl: `dedupKey` appends `inc.Environment`.
+3. Gate, commit.
+
+## Step 2 — Nit 3: all-empty correlation labels fall back (coalesce key)
+1. Test: `CorrelationLabels` set, two incidents missing all those labels but
+   different alertname/groupKey → distinct keys (no collapse). Partial presence
+   still correlates.
+2. Impl: in `key()`, if every label value empty → no-labels path.
+3. Gate, commit.
+
+## Step 3 — Nit 1 + Nit 2: recent eviction + new-critical-during-cooldown
+   (coalesce). These share the per-key state struct, so one change set.
+1. Tests:
+   - eviction: after a key's entry ages past Cooldown, `sweep` drops it from
+     `recent` (and the seen-alertname set).
+   - new critical alertname during cooldown flushes; same-alertname critical
+     repeat suppressed; warning repeat suppressed.
+2. Impl: replace `recent map[string]time.Time` with a per-key record holding
+   `last time.Time` + `seen map[string]struct{}` (alertnames). `withinCooldown`
+   stays. `Add` cooldown branch: suppress unless critical with unseen alertname
+   → flush + record. `sweep` evicts aged records.
+3. Gate (incl. -race), commit.

--- a/docs/superpowers/specs/2026-06-24-confidence-clamp-budget-design.md
+++ b/docs/superpowers/specs/2026-06-24-confidence-clamp-budget-design.md
@@ -1,0 +1,93 @@
+# R18 — Clamp model confidence + fix the token-budget estimate
+
+Date: 2026-06-24
+Status: implemented
+Scope: `internal/investigate` (two correctness nits)
+
+## Problem
+
+Two independent correctness defects in `internal/investigate`, both verified against current code.
+
+### Nit 1 — model confidence is never clamped to [0,1]
+
+Model-emitted confidence flows into the system unclamped from three call sites:
+
+- `internal/investigate/tools.go:98` — `inv.Confidence = f.Confidence` (overall, copied straight from `submit_findings` JSON)
+- `internal/investigate/tools.go:102` — `rc.Confidence = rc.Confidence` (per root-cause, ditto)
+- `internal/investigate/verify.go:103,108` — `rc.Confidence = v.Confidence` (verdict confidence from the verify pass)
+
+A model emitting `1.7`, `-0.2`, or `NaN` reaches:
+
+- the **auto-action confidence gate**: `internal/action/auto.go:86` (`inv.Confidence < a.minConfidence`). `NaN < x` is always false, so a `NaN` overall confidence would *pass* the gate; `1.7` trivially passes; `-0.2` would wrongly skip.
+- **Slack / chat rendering**: `internal/notify/slack.go:143`, `internal/notify/format.go:15,17`, `internal/curator/draft.go`, `internal/forge/github/github.go:266` — all print `Confidence*100` (e.g. `170%`, `NaN%`).
+- **recall-trust / verify math**: `internal/investigate/verify.go:120-126` takes `max` over per-cause confidence; `confirm.go` caps it. `NaN` poisons the `max` comparison.
+
+### Nit 2 — token-budget estimate undercounts
+
+`internal/investigate/budget.go` `estimateTokens` (lines 21-27) sums only `len(system) + Σ len(m.Content)`. The loop (`internal/investigate/loop.go:205`) sends, on **every** step:
+
+- `Tools: specs` — the full tool schemas (name + description + JSON Schema), re-sent each step. Counted: **never**.
+- `Messages` carrying assistant `ToolCalls[].Args` (the tool-call JSON the model emitted, `internal/investigate/loop.go:238`). Counted: **never** (only `m.Content` is summed).
+
+So the estimate is systematically low; the hard-kill guard (`internal/investigate/loop.go:186-202`) fires later than intended, or — for a tool-heavy investigation whose bytes live mostly in tool-call args + schemas — effectively never.
+
+## Decision
+
+### `clamp01` helper (shared in the package)
+
+```go
+// clamp01 constrains a model-emitted confidence to [0,1]; NaN -> 0 (a NaN
+// score must never pass the auto-action gate, where NaN < x is always false).
+func clamp01(x float64) float64 {
+	switch {
+	case math.IsNaN(x):
+		return 0
+	case x < 0:
+		return 0
+	case x > 1:
+		return 1
+	default:
+		return x
+	}
+}
+```
+
+Apply in:
+- `parseFindings` (tools.go): overall `Confidence` and each root cause `Confidence`.
+- `applyVerdicts` (verify.go): wherever `rc.Confidence = v.Confidence` (the keep and downgrade branches). The `rc.Confidence /= 2` downgrade fallback operates on an already-clamped value, so the result stays in range.
+
+`+Inf`/`-Inf` are handled by the `>1`/`<0` arms. The recomputed `inv.Confidence = maxc` in `applyVerdicts` is then a max over clamped values, so it needs no separate clamp.
+
+### `estimateTokens` — add tool-call args + a one-time tool-spec byte count
+
+```go
+func estimateTokens(system string, msgs []providers.Message, tools []providers.ToolSpec) int {
+	n := len(system)
+	for _, t := range tools { // tool schemas are re-sent every step
+		n += len(t.Name) + len(t.Description) + len(t.Schema)
+	}
+	for _, m := range msgs {
+		n += len(m.Content)
+		for _, tc := range m.ToolCalls { // assistant tool-call JSON goes over the wire
+			n += len(tc.Args)
+		}
+	}
+	return n / 4
+}
+```
+
+Signature changes to take `tools`; both callers in `loop.go` (the budget check at :186 and the metric at :256) pass `specs`. The `budget_test.go` `TestEstimateTokens` updates to the new signature.
+
+This stays an under-estimate of the true wire size (it ignores JSON envelope/role overhead) but is now within the same order of magnitude as what is actually sent, which is the point: the hard-kill must fire on a runaway, tool-heavy investigation.
+
+`budgetKillResult` / `timeoutResult` are untouched.
+
+## Tests (test-first, stdlib, table-driven)
+
+- `tools_test.go`: `parseFindings` clamps overall + per-cause confidence — `1.7→1`, `-0.2→0`, `NaN→0`, in-range unchanged.
+- `verify_test.go`: `applyVerdicts` clamps verdict confidence on keep and downgrade — out-of-range and NaN.
+- `budget_test.go`: `estimateTokens` includes tool-call args and a tool-spec count; assert it exceeds the old content-only sum for the same input.
+
+## Out of scope
+
+Recall-derived confidence (`recall.go`) is computed internally from bounded signals, not copied from model JSON — not a clamp target.

--- a/docs/superpowers/specs/2026-06-24-confidence-clamp-budget-plan.md
+++ b/docs/superpowers/specs/2026-06-24-confidence-clamp-budget-plan.md
@@ -1,0 +1,24 @@
+# R18 plan — confidence clamp + budget estimate
+
+Spec: `2026-06-24-confidence-clamp-budget-design.md`
+
+## Steps (each gated + committed)
+
+1. **Spec + plan** (this) — commit.
+2. **clamp01 + parseFindings/applyVerdicts** (test-first)
+   - Write failing tests: `tools_test.go` (overall + per-cause clamp inc. NaN), `verify_test.go` (verdict clamp keep/downgrade inc. NaN).
+   - Add `clamp01` (new tiny file `clamp.go` or top of tools.go) using `math`.
+   - Apply in `parseFindings` (tools.go) and `applyVerdicts` (verify.go).
+   - Gate green, commit.
+3. **estimateTokens tool-call args + tool-spec count** (test-first)
+   - Update `budget_test.go` `TestEstimateTokens` to new signature; add a case asserting tool-call args + tool-spec bytes are counted (and exceed old content-only sum).
+   - Change `estimateTokens` signature + body in `budget.go`; update both call sites in `loop.go` to pass `specs`.
+   - Gate green, commit.
+
+## Gate (before each commit)
+
+```
+go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+```
+
+`golangci-lint` must report `0 issues` (gosec enabled).

--- a/docs/superpowers/specs/2026-06-24-llm-protocol-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-24-llm-protocol-fixes-design.md
@@ -1,0 +1,80 @@
+# Design — LLM-protocol correctness fixes (Item R15)
+
+Date: 2026-06-24 · Status: approved (autonomous) · Worktree: `r15-llm-protocol-fixes`
+
+## Problem
+
+Two LLM-protocol correctness bugs in the model providers.
+
+### Bug 1 — OpenAI drops empty tool-result content
+
+`internal/model/openai/openai.go`: `chatMessage.Content` carries `json:"content,omitempty"`
+(line 47). A `tool`-role result whose content is the empty string then marshals to
+`{"role":"tool","tool_call_id":"…"}` — the `content` field is **absent**. The OpenAI
+chat-completions schema (and strict OpenAI-compatible servers: vLLM, Ollama) **require
+`content` to be present on a `tool` message** → the request 400s.
+
+**Reachability (challenged):** `internal/investigate/loop.go:271` appends
+`{Role:"tool", ToolCallID:tc.ID, Content:out}` where `out` is `runTool(...)`'s return
+(loop.go:267,279-300). A tool's `Call` can legitimately return `""` (a tool with no output,
+or an empty result), so an empty-content tool message is reachable in production, not just
+in theory.
+
+**Empirically confirmed:** Go `encoding/json` with `omitempty` marshals an empty `Content`
+to `{"role":"tool"}` (field elided); without `omitempty` it marshals to
+`{"role":"tool","content":""}`.
+
+**Constraint:** the same `chatMessage.Content` field is shared by system/user/assistant/tool
+messages. The OpenAI schema says an **assistant** message with `tool_calls` may *omit*
+`content` (`omitempty` is correct there), but a **tool** message must *include* it. So the
+fix must be path-specific to the tool role — not a blanket drop of `omitempty`.
+
+### Bug 2 — Gemini correlates function responses by name only
+
+`internal/model/gemini/gemini.go`: the response `functionCall` is mapped to a
+`providers.ToolCall` with `ID = p.FunctionCall.Name` (line 146) — the real Gemini call `id`
+(present on the newer API) is discarded and never even parsed. On the request side,
+`functionResponse` carries only `Name` (struct lines 71-74; populated at line 188).
+
+Per Gemini docs, when the model emits **parallel calls to the same function name**, results
+are correlated by **`id`**, not name. Two parallel same-function calls therefore collide
+under name-only matching (both `functionResponse` parts carry the same `Name`, and the
+originating `id`s are lost).
+
+**Challenge — worth fixing now?** RunLore's assistant turn *can* carry multiple
+`resp.ToolCalls` (loop.go:238-272 iterates them), so parallel calls are reachable; the
+collision only manifests when two of them target the *same* function. Echoing `id` makes
+correlation robust in all cases at near-zero cost, and the package doc already (incorrectly)
+claims name-based matching. Implemented now as a correctness hardening, with a name fallback
+for older API responses that omit `id`.
+
+## Changes
+
+### OpenAI (`internal/model/openai/openai.go`)
+- Add a dedicated `toolMessage` shape (or force `content:""` on the tool path) so a
+  `tool`-role message **always** serializes `content`, even when empty. Assistant turns keep
+  `omitempty` on `content` (canonical when `tool_calls` are present).
+
+### Gemini (`internal/model/gemini/gemini.go`)
+- Parse the response `functionCall.id` (new field on `functionCall`) and carry it into
+  `providers.ToolCall.ID`, falling back to `Name` when absent.
+- Add `id` to the `functionCall` and `functionResponse` request shapes; emit the originating
+  call's `id` on each `functionResponse` so parallel same-function results correlate
+  correctly. Name stays as the human-meaningful label; the `id`→name map still resolves the
+  response name.
+- Update the package doc to describe id-based correlation.
+
+## Tests (stdlib `testing` + `httptest`, table-driven, no testify)
+
+- **OpenAI:** a request containing an empty-content tool message keeps `"content":""` in the
+  marshaled JSON sent to the server (assert on the raw request body, not the typed struct,
+  since the struct round-trips either way).
+- **Gemini:** two parallel responses to the *same* function name map to the correct `id`s
+  (request `functionResponse` parts carry distinct ids matching the originating calls); a
+  response `functionCall` with an `id` carries that id into the `ToolCall` (fallback to name
+  when absent).
+
+## Gate
+
+`go build/vet/test ./... && gofmt -l . && golangci-lint run ./...` (0 issues, gosec on)
+green before each commit.

--- a/internal/coalesce/add_test.go
+++ b/internal/coalesce/add_test.go
@@ -69,3 +69,50 @@ func TestAddCriticalStormSuppressedAfterFirst(t *testing.T) {
 		t.Fatalf("storm alerts after the first should be suppressed, not buffered (pending=%d)", len(c.pending))
 	}
 }
+
+// During cooldown, a critical with an alertname not yet seen for the key is a
+// genuinely new problem and must flush — it must not be swallowed as storm
+// noise. Same-key correlation (CorrelationLabels) is what makes two distinct
+// alertnames share a key.
+func TestAddNewCriticalDuringCooldownFlushes(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Hour, MaxBatch: 100, Cooldown: 10 * time.Minute,
+		CorrelationLabels: []string{"app"}}, s, &now)
+	first := config.Incident{AlertName: "CrashLoop", Namespace: "ns", Severity: "critical",
+		Labels: map[string]string{"app": "web"}}
+	second := config.Incident{AlertName: "PodNotReady", Namespace: "ns", Severity: "critical",
+		Labels: map[string]string{"app": "web"}} // same key (app=web), different alertname
+
+	c.Add(first) // flush #1, seeds recent + seen{CrashLoop}
+	now = now.Add(time.Minute)
+	c.Add(second) // within cooldown but a NEW alertname → flush #2
+	if len(s.batches) != 2 {
+		t.Fatalf("a new critical alertname during cooldown must flush, batches=%d", len(s.batches))
+	}
+	// A repeat of the same alertname during cooldown is still suppressed.
+	now = now.Add(time.Minute)
+	c.Add(second) // PodNotReady again → suppressed
+	if len(s.batches) != 2 {
+		t.Fatalf("repeat critical alertname during cooldown must be suppressed, batches=%d", len(s.batches))
+	}
+}
+
+// A warning repeat during cooldown stays suppressed — only genuinely new
+// criticals get the cooldown bypass.
+func TestAddWarningDuringCooldownSuppressed(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Hour, MaxBatch: 1, Cooldown: 10 * time.Minute,
+		CorrelationLabels: []string{"app"}}, s, &now)
+	first := config.Incident{AlertName: "A", Namespace: "ns", Severity: "warning",
+		Labels: map[string]string{"app": "web"}}
+	newWarn := config.Incident{AlertName: "B", Namespace: "ns", Severity: "warning",
+		Labels: map[string]string{"app": "web"}} // same key, new alertname, but warning
+	c.Add(first) // MaxBatch=1 → flush, seeds cooldown
+	now = now.Add(time.Minute)
+	c.Add(newWarn) // new alertname but only warning → still suppressed
+	if len(s.batches) != 1 {
+		t.Fatalf("a new warning during cooldown must stay suppressed, batches=%d", len(s.batches))
+	}
+}

--- a/internal/coalesce/coalescer.go
+++ b/internal/coalesce/coalescer.go
@@ -56,10 +56,20 @@ func New(cfg Config, out func([]config.Incident)) *Coalescer {
 func (c *Coalescer) key(inc config.Incident) string {
 	if len(c.cfg.CorrelationLabels) > 0 {
 		parts := make([]string, 0, len(c.cfg.CorrelationLabels))
+		anyPresent := false
 		for _, l := range c.cfg.CorrelationLabels {
-			parts = append(parts, inc.Labels[l])
+			v := inc.Labels[l]
+			if v != "" {
+				anyPresent = true
+			}
+			parts = append(parts, v)
 		}
-		return inc.Namespace + "/" + strings.Join(parts, "/")
+		// Only correlate on label values when at least one is present. If every
+		// configured label is absent the key would degenerate to "ns/" and
+		// collapse unrelated incidents, so fall through to the GroupKey path.
+		if anyPresent {
+			return inc.Namespace + "/" + strings.Join(parts, "/")
+		}
 	}
 	if inc.GroupKey != "" {
 		return inc.GroupKey

--- a/internal/coalesce/coalescer.go
+++ b/internal/coalesce/coalescer.go
@@ -30,6 +30,16 @@ type batch struct {
 	firstSeen, lastSeen time.Time
 }
 
+// cooldown records, per correlation key, when an investigation last fired and
+// which alertnames it has already covered. The alertname set lets a genuinely
+// new critical problem (an unseen alertname sharing the key) bypass the
+// cooldown, while same-alertname repeats — the storm noise the cooldown exists
+// to quash — stay suppressed. Evicted by sweep once aged past Cooldown.
+type cooldown struct {
+	last time.Time
+	seen map[string]struct{} // alertnames already flushed under this key
+}
+
 // Coalescer buffers correlated incidents and flushes one investigation per key.
 type Coalescer struct {
 	cfg     Config
@@ -39,14 +49,14 @@ type Coalescer struct {
 
 	mu      sync.Mutex
 	pending map[string]*batch
-	recent  map[string]time.Time
+	recent  map[string]*cooldown
 }
 
 // New builds a Coalescer. out is called with each flushed batch.
 func New(cfg Config, out func([]config.Incident)) *Coalescer {
 	return &Coalescer{
 		cfg: cfg, now: time.Now, out: out,
-		pending: map[string]*batch{}, recent: map[string]time.Time{},
+		pending: map[string]*batch{}, recent: map[string]*cooldown{},
 	}
 }
 
@@ -103,20 +113,22 @@ func (c *Coalescer) Add(inc config.Incident) {
 	c.mu.Lock()
 	now := c.now()
 	switch {
-	case c.withinCooldown(k, now):
+	case c.withinCooldown(k, now) && !c.newCriticalDuringCooldown(k, inc):
 		// An investigation for this key already fired within the cooldown — suppress
 		// the rest of the storm. This is checked before the critical fast-path so a
 		// storm of critical alerts collapses to one investigation (the first) plus
-		// suppressions, rather than one investigation per alert.
+		// suppressions, rather than one investigation per alert. The exception
+		// (newCriticalDuringCooldown) lets a critical with an alertname not yet seen
+		// for this key through, since that is a genuinely new problem, not storm noise.
 		c.mu.Unlock()
 		if m := c.Metrics; m != nil {
 			m.AlertsSuppressed.Add(context.Background(), 1)
 		}
 		return
 	case strings.EqualFold(inc.Severity, "critical"):
-		// First critical for this key (not in cooldown): flush immediately with no
-		// debounce wait, draining any pending batch. Subsequent same-key alerts fall
-		// into the cooldown case above and are suppressed.
+		// Critical (first for this key, or a new alertname during cooldown): flush
+		// immediately with no debounce wait, draining any pending batch. Same-key
+		// same-alertname criticals fall into the cooldown case above and are suppressed.
 		flush = []config.Incident{inc}
 		if b, ok := c.pending[k]; ok {
 			flush = make([]config.Incident, 0, len(b.incidents)+1)
@@ -124,7 +136,7 @@ func (c *Coalescer) Add(inc config.Incident) {
 			flush = append(flush, inc)
 			delete(c.pending, k)
 		}
-		c.recent[k] = now
+		c.markFlushed(k, now, flush)
 	default:
 		b := c.pending[k]
 		if b == nil {
@@ -136,7 +148,7 @@ func (c *Coalescer) Add(inc config.Incident) {
 		if c.cfg.MaxBatch > 0 && len(b.incidents) >= c.cfg.MaxBatch {
 			flush = b.incidents
 			delete(c.pending, k)
-			c.recent[k] = now
+			c.markFlushed(k, now, flush)
 		}
 	}
 	c.mu.Unlock()
@@ -160,9 +172,40 @@ func (c *Coalescer) emit(batch []config.Incident) {
 	}
 }
 
+// withinCooldown reports whether key k fired an investigation recently enough
+// that same-key alerts should be suppressed. Caller holds mu.
 func (c *Coalescer) withinCooldown(k string, now time.Time) bool {
-	t, ok := c.recent[k]
-	return ok && c.cfg.Cooldown > 0 && now.Sub(t) < c.cfg.Cooldown
+	cd, ok := c.recent[k]
+	return ok && c.cfg.Cooldown > 0 && now.Sub(cd.last) < c.cfg.Cooldown
+}
+
+// newCriticalDuringCooldown reports whether inc is a critical alert whose
+// alertname has not yet been covered by the current cooldown for key k — i.e. a
+// genuinely new problem that should bypass suppression. Caller holds mu.
+func (c *Coalescer) newCriticalDuringCooldown(k string, inc config.Incident) bool {
+	if !strings.EqualFold(inc.Severity, "critical") {
+		return false
+	}
+	cd, ok := c.recent[k]
+	if !ok {
+		return true
+	}
+	_, seen := cd.seen[inc.AlertName]
+	return !seen
+}
+
+// markFlushed records, for key k, that an investigation fired at now covering
+// the alertnames in the flushed batch. Caller holds mu.
+func (c *Coalescer) markFlushed(k string, now time.Time, batch []config.Incident) {
+	cd := c.recent[k]
+	if cd == nil {
+		cd = &cooldown{seen: map[string]struct{}{}}
+		c.recent[k] = cd
+	}
+	cd.last = now
+	for _, in := range batch {
+		cd.seen[in.AlertName] = struct{}{}
+	}
 }
 
 // sweep flushes every pending batch that has been quiet for >= Debounce or is
@@ -177,12 +220,25 @@ func (c *Coalescer) sweep() {
 		if debounced || maxWaited {
 			flushes = append(flushes, b.incidents)
 			delete(c.pending, k)
-			c.recent[k] = now
+			c.markFlushed(k, now, b.incidents)
 		}
 	}
+	c.evictExpiredCooldowns(now)
 	c.mu.Unlock()
 	for _, f := range flushes {
 		c.emit(f)
+	}
+}
+
+// evictExpiredCooldowns drops recent records that can no longer suppress
+// anything, keeping the map bounded over a long serve with churning keys. An
+// entry is dead once aged past Cooldown; when Cooldown <= 0, withinCooldown
+// never consults recent, so every entry is dead weight. Caller holds mu.
+func (c *Coalescer) evictExpiredCooldowns(now time.Time) {
+	for k, cd := range c.recent {
+		if c.cfg.Cooldown <= 0 || now.Sub(cd.last) >= c.cfg.Cooldown {
+			delete(c.recent, k)
+		}
 	}
 }
 

--- a/internal/coalesce/coalescer_test.go
+++ b/internal/coalesce/coalescer_test.go
@@ -30,6 +30,41 @@ func TestKeyCorrelationLabels(t *testing.T) {
 	}
 }
 
+// When every configured correlation label is absent from an incident, the key
+// must NOT collapse to "ns/" (which would coalesce unrelated incidents). It
+// falls back to GroupKey, else ns/alertname.
+func TestKeyAllEmptyCorrelationLabelsFallBack(t *testing.T) {
+	c := New(Config{CorrelationLabels: []string{"app", "team"}}, nil)
+	// Two unrelated incidents in the same namespace, neither carrying the
+	// correlation labels, must not share a key.
+	a := config.Incident{AlertName: "DiskFull", Namespace: "ns", GroupKey: "gk-a"}
+	b := config.Incident{AlertName: "OOMKill", Namespace: "ns", GroupKey: "gk-b"}
+	if ka, kb := c.key(a), c.key(b); ka == kb {
+		t.Fatalf("all-empty correlation labels must not collapse unrelated incidents, both = %q", ka)
+	}
+	// Falls back to GroupKey when present.
+	if got := c.key(a); got != "gk-a" {
+		t.Fatalf("all-empty labels should fall back to groupKey, got %q", got)
+	}
+	// And to ns/alertname when GroupKey is also empty.
+	noGK := config.Incident{AlertName: "DiskFull", Namespace: "ns"}
+	if got := c.key(noGK); got != "ns/DiskFull" {
+		t.Fatalf("all-empty labels + no groupKey should fall back to ns/alertname, got %q", got)
+	}
+}
+
+// Partial presence of correlation labels is a legitimate key and must still
+// correlate (not fall back).
+func TestKeyPartialCorrelationLabelsStillCorrelate(t *testing.T) {
+	c := New(Config{CorrelationLabels: []string{"app", "team"}}, nil)
+	withApp := config.Incident{AlertName: "X", Namespace: "ns", GroupKey: "gk1",
+		Labels: map[string]string{"app": "web"}}
+	// "team" is absent → partial. Key must use the labels, not fall back to GroupKey.
+	if got := c.key(withApp); got != "ns/web/" {
+		t.Fatalf("partial labels should still correlate on label values, got %q", got)
+	}
+}
+
 func TestSummarize(t *testing.T) {
 	s := Summarize([]config.Incident{
 		inc("X", "ns", "warning", "g"),

--- a/internal/coalesce/sweep_test.go
+++ b/internal/coalesce/sweep_test.go
@@ -23,6 +23,30 @@ func TestSweepFlushesAfterDebounce(t *testing.T) {
 	}
 }
 
+// sweep must evict cooldown records once they age past Cooldown, otherwise the
+// recent map grows without bound over a long serve with churning keys.
+func TestSweepEvictsExpiredCooldown(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 5 * time.Minute}, s, &now)
+	c.Add(inc("X", "ns", "warning", "GK")) // MaxBatch=1 → flush, seeds recent[GK]
+	if len(c.recent) != 1 {
+		t.Fatalf("expected one recent entry after flush, got %d", len(c.recent))
+	}
+	// Still within cooldown → kept.
+	now = now.Add(4 * time.Minute)
+	c.sweep()
+	if len(c.recent) != 1 {
+		t.Fatalf("entry within cooldown must be kept, got %d", len(c.recent))
+	}
+	// Aged past cooldown → evicted.
+	now = now.Add(2 * time.Minute) // total 6m >= 5m cooldown
+	c.sweep()
+	if len(c.recent) != 0 {
+		t.Fatalf("entry aged past cooldown must be evicted, got %d", len(c.recent))
+	}
+}
+
 func TestSweepMaxWaitCap(t *testing.T) {
 	now := time.Unix(0, 0)
 	s := &sink{}

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -15,13 +15,25 @@ func budgetKillResult(req Request) providers.Investigation {
 	}
 }
 
-// estimateTokens approximates the request size (~4 chars/token) over the system
-// prompt plus the full message history — the cost actually re-sent each step.
-// Provider-reported usage is not exposed in CompletionResponse today.
-func estimateTokens(system string, msgs []providers.Message) int {
+// estimateTokens approximates the request size (~4 chars/token) over everything
+// re-sent each step: the system prompt, the full tool schemas (name +
+// description + JSON Schema), and the message history — including the assistant
+// tool-call JSON (m.ToolCalls[].Args), which also goes over the wire. Counting
+// only m.Content systematically under-estimated a tool-heavy investigation,
+// letting the hard-kill guard fire late or never. Provider-reported usage is
+// not exposed in CompletionResponse today. Still an under-estimate of the true
+// wire size (it ignores JSON envelope/role overhead) but now the right order of
+// magnitude, which is what the hard-kill needs.
+func estimateTokens(system string, msgs []providers.Message, tools []providers.ToolSpec) int {
 	n := len(system)
+	for _, t := range tools {
+		n += len(t.Name) + len(t.Description) + len(t.Schema)
+	}
 	for _, m := range msgs {
 		n += len(m.Content)
+		for _, tc := range m.ToolCalls {
+			n += len(tc.Args)
+		}
 	}
 	return n / 4
 }

--- a/internal/investigate/budget_test.go
+++ b/internal/investigate/budget_test.go
@@ -11,9 +11,38 @@ func TestEstimateTokens(t *testing.T) {
 		{Role: "user", Content: "12345678"},  // 8 chars
 		{Role: "assistant", Content: "1234"}, // 4 chars
 	}
-	// (len(system)=4 + 8 + 4) / 4 = 4
-	if got := estimateTokens("sys!", msgs); got != 4 {
-		t.Fatalf("estimateTokens: got %d, want 4", got)
+	// system(4) + content(8+4) = 16; no tools, no tool-calls. 16/4 = 4.
+	if got := estimateTokens("sys!", msgs, nil); got != 4 {
+		t.Fatalf("estimateTokens (content only): got %d, want 4", got)
+	}
+}
+
+// TestEstimateTokensCountsToolCallArgsAndSpecs proves the estimate now includes
+// the assistant tool-call JSON (m.ToolCalls[].Args) and the full tool schemas
+// (re-sent every step) — bytes the old content-only sum ignored, which let the
+// hard-kill guard fire late or never on a tool-heavy investigation.
+func TestEstimateTokensCountsToolCallArgsAndSpecs(t *testing.T) {
+	msgs := []providers.Message{
+		{Role: "assistant", Content: "ab", ToolCalls: []providers.ToolCall{
+			{Name: "kube", Args: `{"k":"v"}`}, // 9 chars of args
+		}},
+	}
+	tools := []providers.ToolSpec{
+		{Name: "kube", Description: "desc", Schema: `{"type":"object"}`}, // 4+4+17 = 25 chars
+	}
+
+	// Old behaviour summed only system + content.
+	oldSum := (len("sys") + len("ab")) / 4 // (3 + 2)/4 = 1
+
+	got := estimateTokens("sys", msgs, tools)
+
+	// New behaviour adds tool-call args (9) and tool-spec bytes (25):
+	// (3 + 25 + 2 + 9) / 4 = 39/4 = 9.
+	if got != 9 {
+		t.Fatalf("estimateTokens with tool-calls+specs: got %d, want 9", got)
+	}
+	if got <= oldSum {
+		t.Fatalf("estimate (%d) should exceed old content-only sum (%d)", got, oldSum)
 	}
 }
 

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -183,7 +183,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// inject a one-time nudge asking the model to wrap up. If the model did not wind
 		// down and the estimate is still over budget on the next step, hard-kill: deliver
 		// whatever findings exist rather than growing context unbounded.
-		if est := estimateTokens(sys, messages); overBudget(est, li.MaxTokensPerInvestigation) {
+		if est := estimateTokens(sys, messages, specs); overBudget(est, li.MaxTokensPerInvestigation) {
 			if !budgetNudged {
 				messages = append(messages, providers.Message{Role: "user", Content: budgetNudge})
 				budgetNudged = true
@@ -253,7 +253,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				inv.Fingerprints = req.Fingerprints // coalesced batch ids; one open per constituent alert
 				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 				if li.Metrics != nil {
-					li.Metrics.InvestigationTokens.Record(ctx, int64(estimateTokens(sys, messages)))
+					li.Metrics.InvestigationTokens.Record(ctx, int64(estimateTokens(sys, messages, specs)))
 				}
 				if li.Verify {
 					inv = li.verifyFindings(ctx, req, inv)

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -4,10 +4,28 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/Smana/runlore/internal/providers"
 )
+
+// clamp01 constrains a model-emitted confidence to [0,1]; NaN -> 0. A NaN score
+// must never pass the auto-action gate, where NaN < threshold is always false,
+// nor poison the max() that recomputes overall confidence after the verify pass.
+// +Inf/-Inf fall through the >1 / <0 arms.
+func clamp01(x float64) float64 {
+	switch {
+	case math.IsNaN(x):
+		return 0
+	case x < 0:
+		return 0
+	case x > 1:
+		return 1
+	default:
+		return x
+	}
+}
 
 // Tool is a model-callable capability used during an investigation.
 type Tool interface {
@@ -95,11 +113,11 @@ func parseFindings(args string) (providers.Investigation, error) {
 	if err := json.Unmarshal([]byte(args), &f); err != nil {
 		return providers.Investigation{}, fmt.Errorf("parse findings: %w", err)
 	}
-	inv := providers.Investigation{Title: f.Title, Confidence: f.Confidence, Unresolved: f.Unresolved}
+	inv := providers.Investigation{Title: f.Title, Confidence: clamp01(f.Confidence), Unresolved: f.Unresolved}
 	for _, rc := range f.RootCauses {
 		inv.RootCauses = append(inv.RootCauses, providers.Hypothesis{
 			Summary:         rc.Summary,
-			Confidence:      rc.Confidence,
+			Confidence:      clamp01(rc.Confidence),
 			ChangeRef:       rc.ChangeRef,
 			Evidence:        rc.Evidence,
 			SuggestedAction: rc.SuggestedAction,

--- a/internal/investigate/tools_test.go
+++ b/internal/investigate/tools_test.go
@@ -2,6 +2,7 @@ package investigate
 
 import (
 	"encoding/json"
+	"math"
 	"slices"
 	"testing"
 
@@ -73,6 +74,65 @@ func TestSubmitFindingsSchemaNoEmptyEnum(t *testing.T) {
 		}
 	}
 	walk("$", schema)
+}
+
+// TestClamp01 covers the helper directly, including the NaN case JSON cannot
+// express (JSON has no NaN literal). NaN must clamp to 0 so it can never slip
+// through the auto-action gate, where NaN < x is always false.
+func TestClamp01(t *testing.T) {
+	cases := []struct {
+		name string
+		in   float64
+		want float64
+	}{
+		{"above one", 1.7, 1},
+		{"below zero", -0.2, 0},
+		{"nan", math.NaN(), 0},
+		{"pos inf", math.Inf(1), 1},
+		{"neg inf", math.Inf(-1), 0},
+		{"in range", 0.42, 0.42},
+		{"exactly one", 1, 1},
+		{"exactly zero", 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := clamp01(tc.in); got != tc.want {
+				t.Fatalf("clamp01(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseFindingsClampsConfidence verifies model-emitted confidence is clamped
+// to [0,1] for both the overall and per-root-cause scores, so an out-of-range
+// value can never reach the auto-action gate or the renderers.
+func TestParseFindingsClampsConfidence(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string // JSON number for confidence (both overall and per-cause)
+		want float64
+	}{
+		{"above one", "1.7", 1},
+		{"below zero", "-0.2", 0},
+		{"in range", "0.42", 0.42},
+		{"exactly one", "1", 1},
+		{"exactly zero", "0", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := `{"confidence":` + tc.val + `,"root_causes":[{"summary":"x","confidence":` + tc.val + `}]}`
+			inv, err := parseFindings(args)
+			if err != nil {
+				t.Fatalf("parseFindings: %v", err)
+			}
+			if inv.Confidence != tc.want {
+				t.Fatalf("overall confidence = %v, want %v", inv.Confidence, tc.want)
+			}
+			if len(inv.RootCauses) != 1 || inv.RootCauses[0].Confidence != tc.want {
+				t.Fatalf("root-cause confidence = %v, want %v", inv.RootCauses[0].Confidence, tc.want)
+			}
+		})
+	}
 }
 
 func TestParseFindingsAffectedResource(t *testing.T) {

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -100,12 +100,12 @@ func applyVerdicts(li *LoopInvestigator, req Request, inv providers.Investigatio
 		switch {
 		case !ok || v.Verdict == "keep":
 			if ok && v.Confidence > 0 {
-				rc.Confidence = v.Confidence
+				rc.Confidence = clamp01(v.Confidence)
 			}
 			kept = append(kept, rc)
 		case v.Verdict == "downgrade":
 			if v.Confidence > 0 {
-				rc.Confidence = v.Confidence
+				rc.Confidence = clamp01(v.Confidence)
 			} else {
 				rc.Confidence /= 2
 			}

--- a/internal/investigate/verify_test.go
+++ b/internal/investigate/verify_test.go
@@ -55,6 +55,37 @@ func TestVerifyRejectsCorrelationFinding(t *testing.T) {
 	}
 }
 
+// TestApplyVerdictsClampsConfidence checks that an out-of-range verdict
+// confidence from the verify pass is clamped to [0,1] before it overwrites a
+// root cause's score — on both the keep and downgrade branches — and that the
+// recomputed overall confidence (a max over survivors) is in range too. NaN is
+// not reachable here (the `v.Confidence > 0` guard skips it: NaN > 0 is false);
+// NaN clamping is covered at the model-JSON boundary in tools_test.
+func TestApplyVerdictsClampsConfidence(t *testing.T) {
+	li := &LoopInvestigator{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	cases := []struct {
+		name    string
+		verdict string
+		conf    float64
+		want    float64
+	}{
+		{"keep above one", "keep", 1.7, 1},
+		{"downgrade above one", "downgrade", 1.4, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := providers.Investigation{RootCauses: []providers.Hypothesis{{Summary: "x", Confidence: 0.5}}}
+			out := applyVerdicts(li, Request{}, inv, []verdict{{Index: 0, Verdict: tc.verdict, Confidence: tc.conf}})
+			if len(out.RootCauses) != 1 || out.RootCauses[0].Confidence != tc.want {
+				t.Fatalf("root-cause confidence = %v, want %v", out.RootCauses[0].Confidence, tc.want)
+			}
+			if out.Confidence != tc.want {
+				t.Fatalf("overall confidence = %v, want %v", out.Confidence, tc.want)
+			}
+		})
+	}
+}
+
 func TestVerifyDowngradesUnproven(t *testing.T) {
 	model := &scriptModel{responses: []providers.CompletionResponse{
 		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName, Args: `{"confidence":0.9,"root_causes":[{"summary":"db migration stalled","confidence":0.9,"evidence":["migration lock held"]}]}`}}},

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -3,7 +3,9 @@
 // agnostic exchange (OpenAI-shaped: assistant tool_calls + separate tool messages)
 // onto Gemini's contents/parts form: assistant turns become role "model" with
 // functionCall parts, and tool results coalesce into one role "user" turn of
-// functionResponse parts (Gemini matches a response to its call by function name).
+// functionResponse parts. Each call/response carries the originating call id, so
+// parallel calls to the same function name correlate by id (Gemini's rule for
+// parallel calls); when the model returns no id, correlation falls back to name.
 package gemini
 
 import (
@@ -64,11 +66,13 @@ type part struct {
 }
 
 type functionCall struct {
+	ID   string          `json:"id,omitempty"` // call id; correlates parallel same-name calls
 	Name string          `json:"name"`
 	Args json.RawMessage `json:"args,omitempty"`
 }
 
 type functionResponse struct {
+	ID       string          `json:"id,omitempty"` // echoes the originating functionCall id
 	Name     string          `json:"name"`
 	Response json.RawMessage `json:"response"`
 }
@@ -142,8 +146,14 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	for _, p := range gr.Candidates[0].Content.Parts {
 		switch {
 		case p.FunctionCall != nil:
+			// Newer Gemini responses carry a call id that correlates parallel calls
+			// to the same function; fall back to the name when the id is absent.
+			id := p.FunctionCall.ID
+			if id == "" {
+				id = p.FunctionCall.Name
+			}
 			out.ToolCalls = append(out.ToolCalls, providers.ToolCall{
-				ID:   p.FunctionCall.Name, // Gemini matches a function response to its call by name
+				ID:   id,
 				Name: p.FunctionCall.Name,
 				Args: argString(p.FunctionCall.Args),
 			})
@@ -156,8 +166,13 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 
 // toContents maps engine-agnostic messages to Gemini contents. Assistant turns
 // become role "model" (text + functionCall parts); consecutive tool results are
-// coalesced into a single role "user" turn of functionResponse parts, named by the
-// function they answer (resolved from the originating tool call's id).
+// coalesced into a single role "user" turn of functionResponse parts. Each call/
+// response carries the originating call id so parallel calls to the SAME function
+// name correlate correctly; the name resolves from the id and is kept as a label.
+//
+// A call id equal to its function name is a fallback (older Gemini API responses
+// without a real id): that id is not emitted on the wire, preserving name-only
+// behavior for single calls and matching what the model itself sent.
 func toContents(in []providers.Message) []content {
 	idToName := map[string]string{}
 	for _, m := range in {
@@ -175,17 +190,26 @@ func toContents(in []providers.Message) []content {
 				parts = append(parts, part{Text: m.Content})
 			}
 			for _, tc := range m.ToolCalls {
-				parts = append(parts, part{FunctionCall: &functionCall{Name: tc.Name, Args: rawObject(tc.Args)}})
+				parts = append(parts, part{FunctionCall: &functionCall{
+					ID:   wireID(tc.ID, tc.Name),
+					Name: tc.Name,
+					Args: rawObject(tc.Args),
+				}})
 			}
 			out = append(out, content{Role: "model", Parts: parts})
 		case "tool":
 			var parts []part
 			for i < len(in) && in[i].Role == "tool" {
-				name := idToName[in[i].ToolCallID]
+				id := in[i].ToolCallID
+				name := idToName[id]
 				if name == "" {
-					name = in[i].ToolCallID
+					name = id
 				}
-				parts = append(parts, part{FunctionResponse: &functionResponse{Name: name, Response: resultObject(in[i].Content)}})
+				parts = append(parts, part{FunctionResponse: &functionResponse{
+					ID:       wireID(id, name),
+					Name:     name,
+					Response: resultObject(in[i].Content),
+				}})
 				i++
 			}
 			i-- // outer loop will increment
@@ -195,6 +219,16 @@ func toContents(in []providers.Message) []content {
 		}
 	}
 	return out
+}
+
+// wireID returns the call id to send on the wire, or "" when the id is just the
+// function name (our fallback for older API responses with no real id) — in which
+// case Gemini correlates by name as before.
+func wireID(id, name string) string {
+	if id == name {
+		return ""
+	}
+	return id
 }
 
 // rawObject ensures functionCall args is a JSON object ("" → {}).

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -102,3 +102,100 @@ func TestToolResultCoalescing(t *testing.T) {
 		t.Fatalf("functionResponse.response should wrap the tool output: %s", results.Parts[0].FunctionResponse.Response)
 	}
 }
+
+// TestParallelSameFunctionCorrelatesByID verifies that two parallel calls to the
+// SAME function name correlate by id: each request functionResponse carries the
+// originating call's id (not just the shared name), so Gemini maps them correctly.
+func TestParallelSameFunctionCorrelatesByID(t *testing.T) {
+	var gotReq genRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"done"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{
+			{Role: "user", Content: "investigate"},
+			{Role: "assistant", ToolCalls: []providers.ToolCall{
+				{ID: "call_1", Name: "get_status", Args: `{"ns":"a"}`},
+				{ID: "call_2", Name: "get_status", Args: `{"ns":"b"}`}, // same function, different id
+			}},
+			{Role: "tool", ToolCallID: "call_1", Content: "status: a ok"},
+			{Role: "tool", ToolCallID: "call_2", Content: "status: b failing"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// model turn: both functionCall parts carry their id.
+	model := gotReq.Contents[1]
+	if len(model.Parts) != 2 ||
+		model.Parts[0].FunctionCall == nil || model.Parts[0].FunctionCall.ID != "call_1" ||
+		model.Parts[1].FunctionCall == nil || model.Parts[1].FunctionCall.ID != "call_2" {
+		t.Fatalf("model functionCall ids wrong: %+v", model.Parts)
+	}
+	// coalesced tool results: each functionResponse carries the originating id, and
+	// the response payload matches the right call.
+	res := gotReq.Contents[2]
+	if len(res.Parts) != 2 {
+		t.Fatalf("want 2 functionResponse parts, got %d: %+v", len(res.Parts), res.Parts)
+	}
+	byID := map[string]string{}
+	for _, p := range res.Parts {
+		if p.FunctionResponse == nil {
+			t.Fatalf("nil functionResponse: %+v", p)
+		}
+		if p.FunctionResponse.Name != "get_status" {
+			t.Fatalf("functionResponse name = %q, want get_status", p.FunctionResponse.Name)
+		}
+		byID[p.FunctionResponse.ID] = string(p.FunctionResponse.Response)
+	}
+	if !strings.Contains(byID["call_1"], "a ok") {
+		t.Fatalf("call_1 response mismatched: %q", byID["call_1"])
+	}
+	if !strings.Contains(byID["call_2"], "b failing") {
+		t.Fatalf("call_2 response mismatched: %q", byID["call_2"])
+	}
+}
+
+// TestResponseFunctionCallID verifies the model's functionCall id (newer API) is
+// carried into ToolCall.ID, and that absent id falls back to the function name.
+func TestResponseFunctionCallID(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantID   string
+		wantName string
+	}{
+		{
+			name:     "id present",
+			body:     `{"candidates":[{"content":{"parts":[{"functionCall":{"id":"call_xyz","name":"what_changed","args":{}}}]}}]}`,
+			wantID:   "call_xyz",
+			wantName: "what_changed",
+		},
+		{
+			name:     "id absent falls back to name",
+			body:     `{"candidates":[{"content":{"parts":[{"functionCall":{"name":"what_changed","args":{}}}]}}]}`,
+			wantID:   "what_changed",
+			wantName: "what_changed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+			resp, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != tt.wantID || resp.ToolCalls[0].Name != tt.wantName {
+				t.Fatalf("ToolCall = %+v, want id=%q name=%q", resp.ToolCalls, tt.wantID, tt.wantName)
+			}
+		})
+	}
+}

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -37,9 +37,9 @@ func New(baseURL, model, apiKey string) *Client {
 var _ providers.ModelProvider = (*Client)(nil)
 
 type chatRequest struct {
-	Model    string        `json:"model"`
-	Messages []chatMessage `json:"messages"`
-	Tools    []chatTool    `json:"tools,omitempty"`
+	Model    string     `json:"model"`
+	Messages []any      `json:"messages"` // chatMessage | toolMessage
+	Tools    []chatTool `json:"tools,omitempty"`
 }
 
 type chatMessage struct {
@@ -47,6 +47,16 @@ type chatMessage struct {
 	Content    string         `json:"content,omitempty"`
 	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string         `json:"tool_call_id,omitempty"`
+}
+
+// toolMessage is the tool-role result. Its content has no omitempty: the OpenAI
+// chat-completions schema (and strict OpenAI-compatible servers — vLLM, Ollama)
+// require a "content" field on a tool message, so an empty tool result must still
+// serialize "content":"" rather than be elided.
+type toolMessage struct {
+	Role       string `json:"role"`
+	Content    string `json:"content"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
 }
 
 type chatToolCall struct {
@@ -81,11 +91,16 @@ type chatResponse struct {
 
 // Complete sends a chat completion with tools and maps the result back.
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
-	msgs := make([]chatMessage, 0, len(req.Messages)+1)
+	msgs := make([]any, 0, len(req.Messages)+1)
 	if req.System != "" {
 		msgs = append(msgs, chatMessage{Role: "system", Content: req.System})
 	}
 	for _, m := range req.Messages {
+		if m.Role == "tool" {
+			// Tool results use a shape that always emits "content" (see toolMessage).
+			msgs = append(msgs, toolMessage{Role: m.Role, Content: m.Content, ToolCallID: m.ToolCallID})
+			continue
+		}
 		cm := chatMessage{Role: m.Role, Content: m.Content, ToolCallID: m.ToolCallID}
 		for _, tc := range m.ToolCalls {
 			cm.ToolCalls = append(cm.ToolCalls, chatToolCall{

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -3,15 +3,26 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
 )
 
+// decodedRequest mirrors chatRequest for test decoding: chatRequest.Messages is
+// []any (mixed chatMessage/toolMessage) on the wire, which round-trips through a
+// typed []chatMessage here for assertions.
+type decodedRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	Tools    []chatTool    `json:"tools"`
+}
+
 func TestComplete(t *testing.T) {
-	var gotReq chatRequest
+	var gotReq decodedRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer k" {
 			t.Errorf("auth header = %q, want Bearer k", got)
@@ -51,5 +62,40 @@ func TestComplete(t *testing.T) {
 	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "tc1" ||
 		resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
 		t.Fatalf("response tool calls mapped wrong: %+v", resp.ToolCalls)
+	}
+}
+
+// TestEmptyToolResultKeepsContent guards the OpenAI-compat requirement that a
+// tool-role message always carries a "content" field, even when the tool produced
+// no output. With json:"content,omitempty" an empty result elides the field and
+// strict servers (OpenAI/vLLM/Ollama) reject the request with 400. We assert on the
+// raw request body the server receives, since the typed struct hides the omission.
+func TestEmptyToolResultKeepsContent(t *testing.T) {
+	var rawBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		rawBody = string(b)
+		_ = json.NewEncoder(w).Encode(chatResponse{Choices: []chatChoice{{Message: chatMessage{Role: "assistant", Content: "ok"}}}})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "test-model", "")
+	_, err := c.Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{
+			{Role: "user", Content: "investigate"},
+			{Role: "assistant", ToolCalls: []providers.ToolCall{{ID: "tc1", Name: "noop", Args: "{}"}}},
+			{Role: "tool", ToolCallID: "tc1", Content: ""}, // empty tool result
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	// The tool message must serialize an explicit (empty) content field.
+	if !strings.Contains(rawBody, `"tool_call_id":"tc1"`) {
+		t.Fatalf("tool message missing from request body: %s", rawBody)
+	}
+	if !strings.Contains(rawBody, `"content":""`) {
+		t.Fatalf("empty tool result must keep \"content\":\"\" in request body, got: %s", rawBody)
 	}
 }

--- a/internal/providers/gitops/argocd/argocd.go
+++ b/internal/providers/gitops/argocd/argocd.go
@@ -5,21 +5,25 @@ package argocd
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/whatchanged"
 )
 
-// application is the minimal Argo CD Application data the provider needs.
+// application is the minimal Argo CD Application data the provider needs. Source
+// fields hold the FIRST source for a multi-source app (spec.sources[]), falling
+// back from the singular spec.source — see applicationFromUnstructured.
 type application struct {
 	Name, Namespace string
-	RepoURL         string // spec.source.repoURL
-	Path            string // spec.source.path
-	Revision        string // status.sync.revision (current)
+	RepoURL         string // spec.source.repoURL (or spec.sources[0].repoURL)
+	Path            string // spec.source.path (or spec.sources[0].path)
+	Revision        string // status.sync.revision (or status.sync.revisions[0])
 	PrevRevision    string // previous status.history revision (diff range start)
 	HealthStatus    string // status.health.status
 	SyncStatus      string // status.sync.status
+	OperationPhase  string // status.operationState.phase (Failed/Error => sync failed)
 	Message         string // status.operationState.message (failure context)
 }
 
@@ -50,8 +54,13 @@ func New(reader Reader, differ *whatchanged.Differ) *Provider {
 // path, the deployed revision (ToRev), and the previously deployed revision
 // (FromRev, from the rollout history) when available.
 //
+// Multi-source Applications (spec.sources[]) are supported: the first source +
+// first revision back the Change (see applicationFromUnstructured). An app that
+// still resolves no diffable source is logged at Debug and skipped, so the blind
+// spot is observable rather than silent.
+//
 // NOTE (v1 scope): the window is accepted but not yet used to filter by deploy
-// time; multi-source Applications (spec.sources) use only spec.source for now.
+// time; each Change reflects the current synced revision.
 func (p *Provider) Changes(ctx context.Context, _ providers.TimeWindow, sel providers.Selector) ([]providers.Change, error) {
 	apps, err := p.reader.ListApplications(ctx)
 	if err != nil {
@@ -66,6 +75,9 @@ func (p *Provider) Changes(ctx context.Context, _ providers.TimeWindow, sel prov
 			continue
 		}
 		if a.RepoURL == "" || a.Revision == "" {
+			slog.Debug("argocd: skipping application with no diffable source",
+				"application", a.Namespace+"/"+a.Name,
+				"hasRepoURL", a.RepoURL != "", "hasRevision", a.Revision != "")
 			continue // not enough to locate a source diff
 		}
 		changes = append(changes, mapApplication(a))
@@ -78,8 +90,11 @@ func (p *Provider) Diff(_ context.Context, c providers.Change) (providers.Diff, 
 	return p.differ.ForChange(c)
 }
 
-// WatchFailures watches Argo CD Applications and emits a FailureEvent whenever one
-// is Degraded. The returned channel closes when the watch ends or ctx is done.
+// WatchFailures watches Argo CD Applications and emits a FailureEvent when an app
+// is health-Degraded OR its last sync operation FAILED (operationState.phase ∈
+// {Failed, Error}). The sync-operation check catches a failed reconcile that has
+// not (yet) manifested as Degraded health — a signal the health-only check missed.
+// The returned channel closes when the watch ends or ctx is done.
 func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureEvent, error) {
 	src, err := p.reader.WatchApplications(ctx)
 	if err != nil {
@@ -96,14 +111,15 @@ func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureE
 				if !ok {
 					return
 				}
-				a := ev.Application
-				if a.HealthStatus != "Degraded" {
+				reason, failed := failureReason(ev.Application)
+				if !failed {
 					continue
 				}
+				a := ev.Application
 				fe := providers.FailureEvent{
 					Workload: providers.Workload{Kind: "Application", Name: a.Name, Namespace: a.Namespace},
 					Engine:   providers.EngineArgoCD,
-					Reason:   a.HealthStatus,
+					Reason:   reason,
 					Message:  a.Message,
 				}
 				select {
@@ -115,6 +131,22 @@ func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureE
 		}
 	}()
 	return out, nil
+}
+
+// failureReason classifies an Application as failing or not. It fires on
+// health-Degraded and on a failed sync operation (operationState.phase ∈
+// {Failed, Error}); the returned reason names which condition fired (health takes
+// precedence in the reason string). It deliberately does NOT fire on OutOfSync,
+// which is the steady state of any app with auto-sync off or mid-drift, not a
+// failure.
+func failureReason(a application) (reason string, failed bool) {
+	if a.HealthStatus == "Degraded" {
+		return a.HealthStatus, true
+	}
+	if a.OperationPhase == "Failed" || a.OperationPhase == "Error" {
+		return "Sync" + a.OperationPhase, true
+	}
+	return "", false
 }
 
 // mapApplication builds an engine-agnostic Change from an Application.

--- a/internal/providers/gitops/argocd/argocd_test.go
+++ b/internal/providers/gitops/argocd/argocd_test.go
@@ -65,6 +65,27 @@ func TestProviderChanges(t *testing.T) {
 	}
 }
 
+func TestProviderChangesMultiSource(t *testing.T) {
+	// A multi-source app (its source fields populated from spec.sources[0] by the
+	// reader) must yield a Change, not be silently dropped.
+	r := fakeReader{apps: []application{
+		{Name: "multi", Namespace: "argocd", RepoURL: "https://github.com/org/manifests", Path: "apps/multi", Revision: "newsha", PrevRevision: "oldsha"},
+	}}
+	p := New(r, &whatchanged.Differ{})
+	changes, err := p.Changes(context.Background(), providers.TimeWindow{}, providers.Selector{})
+	if err != nil {
+		t.Fatalf("Changes: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("want 1 change for multi-source app, got %d", len(changes))
+	}
+	c := changes[0]
+	if c.Source != (providers.SourceRef{RepoURL: "https://github.com/org/manifests", Path: "apps/multi"}) ||
+		c.FromRev != "oldsha" || c.ToRev != "newsha" {
+		t.Fatalf("unexpected multi-source change: %+v", c)
+	}
+}
+
 func TestProviderChangesSelector(t *testing.T) {
 	r := fakeReader{apps: []application{
 		{Name: "harbor", Namespace: "argocd", RepoURL: "u", Revision: "a"},
@@ -85,22 +106,55 @@ func TestWatchFailures(t *testing.T) {
 		{Application: application{Name: "ok", Namespace: "argocd", HealthStatus: "Healthy"}},
 		{Application: application{Name: "bad", Namespace: "apps", HealthStatus: "Degraded", Message: "container crash"}},
 		{Application: application{Name: "prog", Namespace: "apps", HealthStatus: "Progressing"}},
+		// healthy app whose last sync OPERATION failed — must still trigger.
+		{Application: application{Name: "syncfail", Namespace: "apps", HealthStatus: "Healthy", OperationPhase: "Failed", Message: "bad manifest"}},
+		// OutOfSync alone is NOT a failure (auto-sync off / mid-drift steady state).
+		{Application: application{Name: "drift", Namespace: "apps", HealthStatus: "Healthy", SyncStatus: "OutOfSync"}},
 	}}
 	p := New(r, &whatchanged.Differ{})
 	ch, err := p.WatchFailures(context.Background())
 	if err != nil {
 		t.Fatalf("WatchFailures: %v", err)
 	}
-	var got []providers.FailureEvent
+	got := map[string]providers.FailureEvent{}
 	for e := range ch {
-		got = append(got, e)
+		got[e.Workload.Name] = e
 	}
-	if len(got) != 1 {
-		t.Fatalf("want 1 failure event (only Degraded), got %d", len(got))
+	if len(got) != 2 {
+		t.Fatalf("want 2 failure events (Degraded + Sync Failed), got %d: %+v", len(got), got)
 	}
-	e := got[0]
-	if e.Engine != providers.EngineArgoCD || e.Workload.Name != "bad" || e.Workload.Kind != "Application" ||
+	if e := got["bad"]; e.Engine != providers.EngineArgoCD || e.Workload.Kind != "Application" ||
 		e.Reason != "Degraded" || e.Message != "container crash" {
-		t.Fatalf("unexpected failure event: %+v", e)
+		t.Fatalf("unexpected degraded failure event: %+v", e)
+	}
+	if e := got["syncfail"]; e.Reason != "SyncFailed" || e.Message != "bad manifest" {
+		t.Fatalf("unexpected sync-failed failure event: %+v", e)
+	}
+}
+
+func TestFailureReason(t *testing.T) {
+	cases := []struct {
+		name       string
+		app        application
+		wantReason string
+		wantFailed bool
+	}{
+		{"healthy", application{HealthStatus: "Healthy"}, "", false},
+		{"progressing", application{HealthStatus: "Progressing"}, "", false},
+		{"degraded", application{HealthStatus: "Degraded"}, "Degraded", true},
+		{"sync-failed", application{HealthStatus: "Healthy", OperationPhase: "Failed"}, "SyncFailed", true},
+		{"sync-error", application{HealthStatus: "Healthy", OperationPhase: "Error"}, "SyncError", true},
+		{"sync-running", application{HealthStatus: "Healthy", OperationPhase: "Running"}, "", false},
+		{"outofsync-not-failure", application{HealthStatus: "Healthy", SyncStatus: "OutOfSync"}, "", false},
+		// health-Degraded takes precedence in the reason even if a sync also failed.
+		{"degraded-precedence", application{HealthStatus: "Degraded", OperationPhase: "Failed"}, "Degraded", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, failed := failureReason(tc.app)
+			if failed != tc.wantFailed || reason != tc.wantReason {
+				t.Errorf("failureReason(%+v) = (%q,%v), want (%q,%v)", tc.app, reason, failed, tc.wantReason, tc.wantFailed)
+			}
+		})
 	}
 }

--- a/internal/providers/gitops/argocd/dynamic.go
+++ b/internal/providers/gitops/argocd/dynamic.go
@@ -75,28 +75,60 @@ func (r *dynamicReader) WatchApplications(ctx context.Context) (<-chan Applicati
 }
 
 // applicationFromUnstructured maps an unstructured Application to the minimal type.
+// It supports both the single-source schema (spec.source / status.sync.revision)
+// and the multi-source schema (spec.sources[] / status.sync.revisions[]); for a
+// multi-source app the FIRST source + first revision are used (the Git source that
+// backs the manifests), so the app contributes to the change spine instead of
+// being silently dropped.
 func applicationFromUnstructured(u *unstructured.Unstructured) application {
-	repoURL, _, _ := unstructured.NestedString(u.Object, "spec", "source", "repoURL")
-	path, _, _ := unstructured.NestedString(u.Object, "spec", "source", "path")
-	rev, _, _ := unstructured.NestedString(u.Object, "status", "sync", "revision")
+	repoURL, path := sourceRepoPath(u)
+	rev := syncRevision(u)
 	syncStatus, _, _ := unstructured.NestedString(u.Object, "status", "sync", "status")
 	health, _, _ := unstructured.NestedString(u.Object, "status", "health", "status")
+	phase, _, _ := unstructured.NestedString(u.Object, "status", "operationState", "phase")
 	msg, _, _ := unstructured.NestedString(u.Object, "status", "operationState", "message")
 	return application{
-		Name:         u.GetName(),
-		Namespace:    u.GetNamespace(),
-		RepoURL:      repoURL,
-		Path:         path,
-		Revision:     rev,
-		PrevRevision: prevRevision(u),
-		HealthStatus: health,
-		SyncStatus:   syncStatus,
-		Message:      msg,
+		Name:           u.GetName(),
+		Namespace:      u.GetNamespace(),
+		RepoURL:        repoURL,
+		Path:           path,
+		Revision:       rev,
+		PrevRevision:   prevRevision(u),
+		HealthStatus:   health,
+		SyncStatus:     syncStatus,
+		OperationPhase: phase,
+		Message:        msg,
 	}
 }
 
+// sourceRepoPath returns the repoURL + path of the Application's source. It reads
+// the singular spec.source first, then falls back to the FIRST entry of the
+// multi-source spec.sources[].
+func sourceRepoPath(u *unstructured.Unstructured) (repoURL, path string) {
+	repoURL, _, _ = unstructured.NestedString(u.Object, "spec", "source", "repoURL")
+	if repoURL != "" {
+		path, _, _ = unstructured.NestedString(u.Object, "spec", "source", "path")
+		return repoURL, path
+	}
+	if first, ok := firstSourceMap(u, "spec", "sources"); ok {
+		repoURL, _ = first["repoURL"].(string)
+		path, _ = first["path"].(string)
+	}
+	return repoURL, path
+}
+
+// syncRevision returns the synced revision: status.sync.revision (single-source)
+// or the first of status.sync.revisions[] (multi-source).
+func syncRevision(u *unstructured.Unstructured) string {
+	if rev, _, _ := unstructured.NestedString(u.Object, "status", "sync", "revision"); rev != "" {
+		return rev
+	}
+	return firstRevision(u, "status", "sync", "revisions")
+}
+
 // prevRevision returns the revision before the latest in status.history (the diff
-// range start), or empty if there is no prior deployment.
+// range start), or empty if there is no prior deployment. Handles both the
+// singular .revision and the multi-source plural .revisions[] (first element).
 func prevRevision(u *unstructured.Unstructured) string {
 	hist, found, _ := unstructured.NestedSlice(u.Object, "status", "history")
 	if !found || len(hist) < 2 {
@@ -106,6 +138,39 @@ func prevRevision(u *unstructured.Unstructured) string {
 	if !ok {
 		return ""
 	}
-	rev, _ := m["revision"].(string)
-	return rev
+	if rev, ok := m["revision"].(string); ok && rev != "" {
+		return rev
+	}
+	return firstString(m["revisions"])
+}
+
+// firstSourceMap returns the first element of an object-array field (e.g.
+// spec.sources) as a map, or ok=false when absent/empty.
+func firstSourceMap(u *unstructured.Unstructured, fields ...string) (map[string]any, bool) {
+	s, found, _ := unstructured.NestedSlice(u.Object, fields...)
+	if !found || len(s) == 0 {
+		return nil, false
+	}
+	m, ok := s[0].(map[string]any)
+	return m, ok
+}
+
+// firstRevision returns the first element of a string-array field (e.g.
+// status.sync.revisions), or "".
+func firstRevision(u *unstructured.Unstructured, fields ...string) string {
+	s, found, _ := unstructured.NestedSlice(u.Object, fields...)
+	if !found {
+		return ""
+	}
+	return firstString(s)
+}
+
+// firstString returns the first string element of a []any, or "".
+func firstString(v any) string {
+	s, ok := v.([]any)
+	if !ok || len(s) == 0 {
+		return ""
+	}
+	str, _ := s[0].(string)
+	return str
 }

--- a/internal/providers/gitops/argocd/dynamic.go
+++ b/internal/providers/gitops/argocd/dynamic.go
@@ -3,6 +3,7 @@ package argocd
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +16,13 @@ import (
 
 // applicationGVR is the Argo CD Application resource.
 var applicationGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+
+// sendTimeout bounds how long the informer handler blocks waiting for the
+// consumer to drain a watch event before giving up. It is large enough to ride
+// out a transient consumer stall (so we don't silently drop a failure event on a
+// burst) yet finite, so a wedged consumer can never block the shared informer
+// indefinitely.
+const sendTimeout = 5 * time.Second
 
 // dynamicReader reads Argo CD Applications as unstructured objects.
 type dynamicReader struct {
@@ -53,11 +61,7 @@ func (r *dynamicReader) WatchApplications(ctx context.Context) (<-chan Applicati
 			return
 		}
 		ev := ApplicationEvent{Application: applicationFromUnstructured(u)}
-		select {
-		case out <- ev:
-		case <-ctx.Done():
-		default: // never block the informer; drop under backpressure
-		}
+		sendEvent(ctx, out, ev)
 	}
 	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj any) { send(obj) },
@@ -72,6 +76,25 @@ func (r *dynamicReader) WatchApplications(ctx context.Context) (<-chan Applicati
 		<-ctx.Done()
 	}()
 	return out, nil
+}
+
+// sendEvent forwards a watch event to out with a BOUNDED block. A full channel no
+// longer means an instant silent drop (the old `default:` branch): we wait up to
+// sendTimeout for the consumer to drain, so a transient burst doesn't lose a
+// failure event. If the consumer is wedged past the timeout we give up and log —
+// the shared informer must never be blocked indefinitely. ctx cancellation returns
+// immediately.
+func sendEvent(ctx context.Context, out chan<- ApplicationEvent, ev ApplicationEvent) {
+	timer := time.NewTimer(sendTimeout)
+	defer timer.Stop()
+	select {
+	case out <- ev:
+	case <-ctx.Done():
+	case <-timer.C:
+		slog.Warn("argocd: dropped watch event (consumer backpressure)",
+			"application", ev.Application.Namespace+"/"+ev.Application.Name,
+			"timeout", sendTimeout)
+	}
 }
 
 // applicationFromUnstructured maps an unstructured Application to the minimal type.

--- a/internal/providers/gitops/argocd/dynamic_test.go
+++ b/internal/providers/gitops/argocd/dynamic_test.go
@@ -65,6 +65,54 @@ func TestApplicationFromUnstructuredMultiSource(t *testing.T) {
 	}
 }
 
+// TestSendEventBoundedNoDrop proves the bounded send does not silently drop an
+// event when the channel is momentarily full: a consumer that drains slightly
+// later still receives it (the old non-blocking `default:` branch dropped it).
+func TestSendEventBoundedNoDrop(t *testing.T) {
+	out := make(chan ApplicationEvent) // unbuffered: send blocks until drained
+	ev := ApplicationEvent{Application: application{Name: "x", Namespace: "ns"}}
+
+	done := make(chan struct{})
+	go func() {
+		sendEvent(context.Background(), out, ev) // must block, not drop
+		close(done)
+	}()
+
+	// Consumer drains after a short delay; the bounded send (5s) must wait for it.
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case got := <-out:
+		if got.Application.Name != "x" {
+			t.Fatalf("unexpected event: %+v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("event was dropped or send did not block for the consumer")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendEvent did not return after the consumer drained")
+	}
+}
+
+// TestSendEventCtxCancel proves a cancelled ctx unblocks the send promptly even
+// when no consumer ever drains (so a wedged consumer can't pin the informer).
+func TestSendEventCtxCancel(t *testing.T) {
+	out := make(chan ApplicationEvent) // no consumer
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		sendEvent(ctx, out, ApplicationEvent{})
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendEvent did not return on ctx cancel")
+	}
+}
+
 func TestDynamicReaderWatch(t *testing.T) {
 	gvrToListKind := map[schema.GroupVersionResource]string{applicationGVR: "ApplicationList"}
 	degraded := &unstructured.Unstructured{Object: map[string]any{

--- a/internal/providers/gitops/argocd/dynamic_test.go
+++ b/internal/providers/gitops/argocd/dynamic_test.go
@@ -20,7 +20,7 @@ func TestApplicationFromUnstructured(t *testing.T) {
 		"status": map[string]any{
 			"sync":           map[string]any{"revision": "newsha", "status": "Synced"},
 			"health":         map[string]any{"status": "Degraded"},
-			"operationState": map[string]any{"message": "boom"},
+			"operationState": map[string]any{"phase": "Succeeded", "message": "boom"},
 			"history": []any{
 				map[string]any{"revision": "oldsha"},
 				map[string]any{"revision": "newsha"},
@@ -29,8 +29,39 @@ func TestApplicationFromUnstructured(t *testing.T) {
 	}}
 	a := applicationFromUnstructured(u)
 	if a.RepoURL != "https://github.com/org/repo" || a.Path != "apps/harbor" || a.Revision != "newsha" ||
-		a.PrevRevision != "oldsha" || a.HealthStatus != "Degraded" || a.SyncStatus != "Synced" || a.Message != "boom" {
+		a.PrevRevision != "oldsha" || a.HealthStatus != "Degraded" || a.SyncStatus != "Synced" || a.Message != "boom" ||
+		a.OperationPhase != "Succeeded" {
 		t.Fatalf("unexpected application: %+v", a)
+	}
+}
+
+// TestApplicationFromUnstructuredMultiSource verifies that a multi-source app
+// (spec.sources[] / status.sync.revisions[], no singular spec.source) is mapped
+// from its FIRST source + first revision instead of being silently dropped.
+func TestApplicationFromUnstructuredMultiSource(t *testing.T) {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   map[string]any{"name": "multi", "namespace": "argocd"},
+		"spec": map[string]any{"sources": []any{
+			map[string]any{"repoURL": "https://github.com/org/manifests", "path": "apps/multi"},
+			map[string]any{"repoURL": "https://github.com/org/values", "ref": "values"},
+		}},
+		"status": map[string]any{
+			"sync":   map[string]any{"revisions": []any{"newsha", "valsha"}, "status": "Synced"},
+			"health": map[string]any{"status": "Healthy"},
+			"history": []any{
+				map[string]any{"revisions": []any{"oldsha", "oldval"}},
+				map[string]any{"revisions": []any{"newsha", "valsha"}},
+			},
+		},
+	}}
+	a := applicationFromUnstructured(u)
+	if a.RepoURL != "https://github.com/org/manifests" || a.Path != "apps/multi" || a.Revision != "newsha" {
+		t.Fatalf("multi-source first source/revision not mapped: %+v", a)
+	}
+	if a.PrevRevision != "oldsha" {
+		t.Fatalf("multi-source prev revision not mapped from history[-2].revisions[0]: %+v", a)
 	}
 }
 

--- a/internal/trigger/engine.go
+++ b/internal/trigger/engine.go
@@ -34,5 +34,8 @@ func dedupKey(inc config.Incident) string {
 	if inc.Fingerprint != "" {
 		return inc.Fingerprint
 	}
-	return inc.AlertName + "/" + inc.Namespace
+	// Include environment: a policy admitting multiple environments can route
+	// same-name/same-namespace alerts from different environments here, and they
+	// are distinct incidents that must not collide on the fingerprint-less path.
+	return inc.AlertName + "/" + inc.Namespace + "/" + inc.Environment
 }

--- a/internal/trigger/engine_test.go
+++ b/internal/trigger/engine_test.go
@@ -27,3 +27,23 @@ func TestEngineDecide(t *testing.T) {
 		t.Fatal("warning should be filtered by policy")
 	}
 }
+
+// dedupKey must keep environment in its fingerprint-less fallback, so two
+// same-name/same-namespace criticals from different environments don't collide.
+func TestDedupKeyFallbackEnvironmentDistinct(t *testing.T) {
+	prod := config.Incident{AlertName: "AppDown", Namespace: "shop", Environment: "prod"}
+	stg := config.Incident{AlertName: "AppDown", Namespace: "shop", Environment: "staging"}
+	if got, other := dedupKey(prod), dedupKey(stg); got == other {
+		t.Fatalf("different environments must yield distinct dedup keys, both = %q", got)
+	}
+	// same env still collapses (real dedup of a repeat)
+	if dedupKey(prod) != dedupKey(config.Incident{AlertName: "AppDown", Namespace: "shop", Environment: "prod"}) {
+		t.Fatal("same name/namespace/env must share a dedup key")
+	}
+	// fingerprint, when present, still wins regardless of environment
+	a := config.Incident{AlertName: "X", Namespace: "n", Environment: "prod", Fingerprint: "fp"}
+	b := config.Incident{AlertName: "X", Namespace: "n", Environment: "staging", Fingerprint: "fp"}
+	if dedupKey(a) != dedupKey(b) {
+		t.Fatal("a shared fingerprint must dedup across environments")
+	}
+}


### PR DESCRIPTION
## Post-review hardening — P2 polish

Follow-up to #102 with the P2 correctness/robustness items from the review. **Stacked on `feat/post-review-hardening`** so this diff is P2-only; GitHub will retarget the base to `main` automatically once #102 merges.

Same discipline as #102: each item was re-challenged against the current code, built test-first, and carries a spec + plan under `docs/superpowers/{specs,plans}/`.

| # | Change | Type |
|---|---|---|
| **R17** | Coalesce/trigger hygiene: evict the unbounded `recent` cooldown map; a *genuinely new* incident (unseen alertname) bypasses cooldown instead of being dropped (storm-collapse for repeats preserved); no key collapse when **all** correlation labels are empty; `environment` added to the dedup fallback key. | fix |
| **R18** | Clamp model + verdict confidence to `[0,1]` (NaN→0 — a `NaN` confidence previously *passed* the auto-action gate since `NaN < min` is false); count tool-call args + re-sent tool schemas in the token-budget estimate (was content-only → hard-kill fired late/never). | fix |
| **R15** | OpenAI: always serialize `content` on `tool` messages (empty included) so strict OpenAI-compatible servers (vLLM/Ollama) don't 400 — assistant turns keep canonical `omitempty`. Gemini: correlate function responses by `id` (single-call requests stay byte-identical via a `wireID` guard). | fix |
| **R24** | Argo CD parity: map multi-source apps (`spec.sources[]` / `status.sync.revisions[]`) instead of silently dropping them from the change spine; trigger on a failed sync `operationState.phase ∈ {Failed,Error}`, not health-only (OutOfSync deliberately excluded — it's steady state, not failure); bounded watch send instead of a silent drop under backpressure. | feat |

### Notable challenge outcomes
- **R17** narrowed the "don't suppress criticals during cooldown" idea to "only an *unseen alertname* bypasses" — the broad version would have re-broken storm collapse.
- **R24** scoped out an Argo `GitOpsInspector` (Argo's sync-wave model needs a different traversal than Flux's `dependsOn` — separate design, not parity) and kept multi-source as one Change per app (the engine-agnostic `Change` carries a single `SourceRef`).

### Verification
- `go test ./...` → **35 packages pass**; `gofmt` clean; `golangci-lint run ./...` → **0 issues** with **gosec over the entire tree** (these branches predated gosec being enabled, so this is the real security check); `-race` clean on coalesce / trigger / investigate / argocd / model.
- One integration conflict resolved: `budget.go` — kept both `timeoutResult` (from R4+R5) and R18's new `estimateTokens(…, tools)` signature. R17/R15/R24 merged clean.
