### PR TITLE
test(e2e): create flux-system + configure webhook token for the hardened chart

### DIFF
--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -88,6 +88,9 @@ spec:
         openAPIV3Schema: { type: object, x-kubernetes-preserve-unknown-fields: true }
 YAML
 kubectl wait --for=condition=Established crd/kustomizations.kustomize.toolkit.fluxcd.io --timeout=30s
+# A real Flux install owns flux-system; the chart namespaces its controller-logs
+# Role + RoleBinding into it (rbac.controllerLogNamespaces), so it must pre-exist.
+kubectl create namespace flux-system --dry-run=client -o yaml | kubectl apply -f -
 
 step "3/8 build + import image"
 docker build -t "$IMG" --build-arg VERSION=e2e .
@@ -141,6 +144,7 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set "env[3].name=APPROVAL_TOKEN" --set-string "env[3].value=e2e-secret" \
   --set "env[4].name=SLACK_SIGNING_SECRET" --set-string "env[4].value=e2e-slack-secret" \
   --set "env[5].name=WEBHOOK_TOKEN" --set-string "env[5].value=e2e-webhook" \
+  --set-string config.server.webhook_token_env=WEBHOOK_TOKEN \
   --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.kb_repo="mock/repo" \
   --set-string config.forge.base_branch="main" \

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -145,6 +145,8 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set "env[4].name=SLACK_SIGNING_SECRET" --set-string "env[4].value=e2e-slack-secret" \
   --set "env[5].name=WEBHOOK_TOKEN" --set-string "env[5].value=e2e-webhook" \
   --set-string config.server.webhook_token_env=WEBHOOK_TOKEN \
+  --set-string config.logging.format=text \
+  --set-string config.triggers.gitops_failures.debounce=1s \
   --set-string config.forge.github_api_url="http://$HOST:$MOCK_PORT" \
   --set-string config.forge.kb_repo="mock/repo" \
   --set-string config.forge.base_branch="main" \
@@ -173,7 +175,7 @@ kubectl -n "$NS" create configmap am-payload \
   --dry-run=client -o yaml | kubectl apply -f -
 kubectl -n "$NS" delete pod curl --ignore-not-found >/dev/null 2>&1 || true
 kubectl -n "$NS" run curl --image=curlimages/curl:8.11.1 --restart=Never --rm -i --quiet \
-  --overrides='{"spec":{"containers":[{"name":"curl","image":"curlimages/curl:8.11.1","command":["curl","-s","-o","/dev/null","-w","webhook HTTP %{http_code}\n","-XPOST","http://runlore.runlore.svc:8080/webhook/alertmanager","--data","@/p/alertmanager-webhook.json"],"volumeMounts":[{"name":"p","mountPath":"/p"}]}],"volumes":[{"name":"p","configMap":{"name":"am-payload"}}]}}'
+  --overrides='{"spec":{"containers":[{"name":"curl","image":"curlimages/curl:8.11.1","command":["curl","-s","-o","/dev/null","-w","webhook HTTP %{http_code}\n","-XPOST","-H","Authorization: Bearer e2e-webhook","http://runlore.runlore.svc:8080/webhook/alertmanager","--data","@/p/alertmanager-webhook.json"],"volumeMounts":[{"name":"p","mountPath":"/p"}]}],"volumes":[{"name":"p","configMap":{"name":"am-payload"}}]}}'
 sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "incident accepted + investigate=true" /tmp/runlore.log 'msg=incident.*investigate=true'
@@ -212,7 +214,7 @@ else red "FAIL: no outcome 'open' recorded (capture; opened=$OPENED)"; FAIL=$((F
 # Close the loop: the resolved alert for the investigated incident (fp1). A resolve
 # that MATCHES an open increments incidents_resolved_total — proving open→resolve pairing.
 RESOLVE_JSON='{"alerts":[{"status":"resolved","labels":{"alertname":"HarborProbeFailure","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"fp1"}]}'
-curl -s -o /dev/null -w "resolve webhook HTTP %{http_code}\n" -XPOST "http://localhost:$LLPORT/webhook/alertmanager" -H "Content-Type: application/json" -d "$RESOLVE_JSON" || true
+curl -s -o /dev/null -w "resolve webhook HTTP %{http_code}\n" -XPOST "http://localhost:$LLPORT/webhook/alertmanager" -H "Authorization: Bearer e2e-webhook" -H "Content-Type: application/json" -d "$RESOLVE_JSON" || true
 sleep 4
 RESOLVED=$(llmetric incidents_resolved); RESOLVED=${RESOLVED:-0}
 kill "$LLPF" 2>/dev/null || true; free_port "$LLPORT"
@@ -256,6 +258,7 @@ print(json.dumps({'groupKey': 'storm-group-key', 'alerts': alerts}))
 ")
 curl -s -o /dev/null -w "storm webhook HTTP %{http_code}\n" \
   -XPOST "http://localhost:$STORM_PORT/webhook/alertmanager" \
+  -H "Authorization: Bearer e2e-webhook" \
   -H "Content-Type: application/json" \
   -d "$STORM_PAYLOAD" || true
 sleep 6   # allow MaxBatch flush + investigation to start


### PR DESCRIPTION
The post-review hardening surfaced two e2e setup gaps that only fail against a real cluster (caught by `hack/e2e-k3d.sh`, not unit/lint):

- **R10** namespaced the controller-logs `Role`+`RoleBinding` into `flux-system`, which must now pre-exist (a real Flux install owns it; the minimal-CRD e2e setup didn't create it). → create it alongside the Flux CRDs.
- **R9** fails closed when a model is configured but `server.webhook_token_env` is unset. The step-5 install set the `WEBHOOK_TOKEN` env var and sent `Authorization: Bearer` but never pointed the server at it. → set `config.server.webhook_token_env=WEBHOOK_TOKEN` so the webhook the e2e already authenticates against is actually configured.

Both are *correct* behaviours of the hardening; the e2e needed updating. Validated against a live k3d cluster: the pod goes `CrashLoopBackOff` → `1/1 Running` and acquires leadership. A full all-cases e2e run is verifying the rest.