### PR TITLE
fix(config): honor explicit gitops_failures debounce: 0 (fire immediately)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -1382,7 +1382,7 @@ func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investig
 	}
 	deb := buildFailureDebouncer(cfg, gp, metrics, log)
 	log.Info("watching gitops failures", "engine", gitopsEngine(cfg),
-		"debounce", cfg.Triggers.GitOpsFailures.Debounce.Std())
+		"debounce", cfg.Triggers.GitOpsFailures.DebounceWindow())
 	go investigate.DrainFailures(ctx, events, q, trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()), deb, log)
 }
 
@@ -1407,7 +1407,7 @@ func buildFailureDebouncer(cfg *config.Config, gp providers.GitOpsProvider, metr
 			return true, nil
 		}
 	}
-	return investigate.NewDebouncer(cfg.Triggers.GitOpsFailures.Debounce.Std(), check, log).WithMetrics(metrics)
+	return investigate.NewDebouncer(cfg.Triggers.GitOpsFailures.DebounceWindow(), check, log).WithMetrics(metrics)
 }
 
 // gitopsEngine returns the configured GitOps engine, defaulting to flux.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,8 +260,22 @@ type TriggerPolicy struct {
 // would otherwise produce confident-but-wrong root causes. A zero Debounce
 // fires immediately on every Ready=False (the original behavior).
 type GitOpsFailureTrigger struct {
-	Enabled  bool     `yaml:"enabled"`
-	Debounce Duration `yaml:"debounce"` // persistence window before investigating; 0 = fire immediately
+	Enabled bool `yaml:"enabled"`
+	// Debounce is a pointer so an unset key (nil ⇒ 60s default, applied in
+	// applyDefaults) is distinguishable from an explicit `debounce: 0` (fire
+	// immediately). A plain Duration can't tell the two apart — both are the zero
+	// value — which is why `debounce: 0` used to be silently clobbered to 60s.
+	Debounce *Duration `yaml:"debounce"`
+}
+
+// DebounceWindow is the GitOps-failure debounce window. nil (unset) reads as 0
+// here, but applyDefaults fills an unset+enabled trigger with 60s; an explicit 0
+// means fire immediately on every Ready=False.
+func (g GitOpsFailureTrigger) DebounceWindow() time.Duration {
+	if g.Debounce == nil {
+		return 0
+	}
+	return g.Debounce.Std()
 }
 
 // IncidentTrigger gates incident/alert-driven investigations.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -51,12 +51,14 @@ func applyDefaults(c *Config) {
 			co.Cooldown = Duration(10 * time.Minute)
 		}
 	}
-	// GitOps-failure debounce default: when the trigger is enabled without an
-	// explicit window, wait 60s and re-check before investigating — long enough to
-	// let reconcile-churn transients clear, short enough to catch real failures
-	// promptly. Set debounce: 0 explicitly to restore fire-on-every-failure.
-	if c.Triggers.GitOpsFailures.Enabled && c.Triggers.GitOpsFailures.Debounce == 0 {
-		c.Triggers.GitOpsFailures.Debounce = Duration(60 * time.Second)
+	// GitOps-failure debounce default: when the trigger is enabled and the window is
+	// unset (nil), wait 60s and re-check before investigating — long enough to let
+	// reconcile-churn transients clear, short enough to catch real failures promptly.
+	// An explicit `debounce: 0` (non-nil) is left untouched, so it fires on every
+	// Ready=False as documented.
+	if c.Triggers.GitOpsFailures.Enabled && c.Triggers.GitOpsFailures.Debounce == nil {
+		d := Duration(60 * time.Second)
+		c.Triggers.GitOpsFailures.Debounce = &d
 	}
 	// Rate-limit window default: 1h when a per-window budget is set but no window
 	// is given (a zero window would silently allow unlimited investigations).

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -71,3 +71,29 @@ triggers:
 		t.Fatalf("explicit debounce: got %v, want 2m", c.Triggers.GitOpsFailures.Debounce.Std())
 	}
 }
+
+func TestLoadGitOpsFailureDebounceZeroFiresImmediately(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "runlore.yaml")
+	doc := `
+triggers:
+  gitops_failures:
+    enabled: true
+    debounce: 0
+`
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// An explicit `debounce: 0` must survive applyDefaults (not be clobbered to the
+	// 60s default for an unset window), so the trigger fires immediately.
+	if c.Triggers.GitOpsFailures.Debounce == nil {
+		t.Fatal("explicit debounce:0 should be non-nil (distinguishable from unset)")
+	}
+	if c.Triggers.GitOpsFailures.DebounceWindow() != 0 {
+		t.Fatalf("explicit debounce:0 should fire immediately, got %v", c.Triggers.GitOpsFailures.DebounceWindow())
+	}
+}


### PR DESCRIPTION
`GitOpsFailures.Debounce` was a `Duration`, so `applyDefaults` couldn't distinguish an **unset** window (should default to 60s) from an **explicit `debounce: 0`** (should fire immediately) — both are the zero value — and clobbered `0` → `60s`. This contradicted both doc comments ("0 = fire immediately") and the consumer (`NewDebouncer(0)` already handles 0 correctly), making it impossible to disable the debounce.

**Fix:** `Debounce` is now a `*Duration` — `nil` (unset) gets the 60s default; an explicit `0` (non-nil) is left untouched. Added `DebounceWindow()` as the nil-safe accessor used by the failure watcher.

Surfaced by the all-cases e2e (it had to use `debounce: 1s` because `0` silently became `60s`). Test-first: `TestLoadGitOpsFailureDebounceZeroFiresImmediately`. Gate green (35 pkgs, gofmt, golangci-lint 0 issues incl. gosec).