### PR TITLE
docs(readme): clearer positioning, logical sections, polished getting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # RunLore
 
-**A read-only SRE agent that investigates incidents — and remembers what it learns.**
+**An open-source SRE agent that investigates incidents — and remembers what it learns.**
 
 [![CI](https://github.com/Smana/runlore/actions/workflows/ci.yaml/badge.svg)](https://github.com/Smana/runlore/actions/workflows/ci.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Smana/runlore)](https://goreportcard.com/report/github.com/Smana/runlore)
@@ -16,15 +16,18 @@
 
 ---
 
-RunLore is an open-source, **read-only** SRE agent that investigates any incident — *what changed?
-what's wrong?* — and posts a confidence-scored root cause to chat (Slack, Matrix…). It never touches
-your cluster.
+RunLore is an open-source SRE agent that investigates any incident — *what changed? what's wrong?*
+— and posts a confidence-scored root cause to chat (Slack, Matrix…). It is **read-only by default**:
+it reads your cluster, metrics, logs, and network flows — its only writes go to Git, via reviewed PRs.
 
 What sets it apart: it learns **your** platform. Every investigation opens a PR in a Git repo you
 own; a human merges it, building a knowledge base of your incidents and context. The same pattern
 next time gets an instant answer — no fresh investigation.
 
 **Learns your platform · single Go binary · runs in your cluster · on your models.**
+
+> **Note:** RunLore is read-only by default — it never mutates your cluster. An autonomy ladder
+> (suggest → approve → auto) is on the roadmap for teams that want to go further.
 
 ## See it in action
 
@@ -41,19 +44,19 @@ knowledge base.
 ```mermaid
 flowchart LR
     A["Incident<br/>any alert · event"] -->|"trigger policy<br/>(prod · critical · ns…)"| B
-    subgraph B["🔎 Investigate · read-only"]
+    subgraph B["🔎 Investigate"]
       direction TB
       W["what changed?<br/>deploys · infra · certs · scaling<br/>(GitOps → exact Git diff)"]
       C["what's wrong?<br/>saturation · network · nodes · deps"]
     end
     B --> R["🎯 Root cause<br/>+ confidence + evidence"]
-    R -->|"read-only"| D["💬 Slack / Matrix<br/>findings + suggested fix"]
+    R --> D["💬 Slack / Matrix<br/>findings + suggested fix"]
     R -. learn .-> K[("📚 GitHub PR<br/>draft entry in your KB")]
     K -. instant recall .-> B
 ```
 
 1. **Alert fires** — Alertmanager or a GitOps failure event triggers RunLore via webhook.
-2. **RunLore investigates** — it reads your cluster, metrics, logs, and network flows. It never writes to the cluster.
+2. **RunLore investigates** — it reads your cluster, metrics, logs, and network flows.
 3. **Findings land in Slack** — ranked root causes with confidence, the evidence trail, and suggested next steps.
 4. **A PR opens in your KB repo** — RunLore drafts what it found as a knowledge-base entry.
 5. **A human reviews and merges** — after adding resolution context, the PR is merged.

--- a/README.md
+++ b/README.md
@@ -16,16 +16,15 @@
 
 ---
 
-RunLore is an open-source, **read-only** SRE agent that wakes on any incident, investigates it —
-*what changed? what's wrong?* — and delivers a confidence-scored root cause to Slack. At the same
-time it opens a pull request in a Git repository you own, drafting what it found as a knowledge-base
-entry. A human reviews, adds context, and merges the PR: that entry is indexed, and the next time
-the same pattern hits, RunLore answers in seconds — no full investigation needed.
+RunLore is an open-source, **read-only** SRE agent that investigates any incident — *what changed?
+what's wrong?* — and posts a confidence-scored root cause to chat (Slack, Matrix…). It never touches
+your cluster.
 
-**RunLore never mutates your cluster.** It reads Kubernetes, metrics, logs, and network flows.
-Its only writes go to Git, via reviewed pull requests.
+What sets it apart: it learns **your** platform. Every investigation opens a PR in a Git repo you
+own; a human merges it, building a knowledge base of your incidents and context. The same pattern
+next time gets an instant answer — no fresh investigation.
 
-**Read-only by default · single Go binary · runs in your cluster · on your models.**
+**Learns your platform · single Go binary · runs in your cluster · on your models.**
 
 ## See it in action
 
@@ -82,72 +81,25 @@ incidents gains trust; knowledge that keeps failing decays.
 ## 🚀 Getting started
 
 RunLore runs in your Kubernetes cluster as a single Go binary, deployed via Helm.
-You need four things before installing:
+RunLore is a single binary deployed via Helm. Before installing, you need:
 
-| | What | Why |
-|---|---|---|
-| **Cluster + data sources** | Flux or Argo CD; optionally Prometheus/VictoriaMetrics, VictoriaLogs, Hubble | The investigation signals |
-| **LLM** | Any OpenAI-compatible endpoint, Anthropic, or Gemini — in-cluster or external | The investigation engine |
-| **Knowledge-base repo** | A private GitHub repo + a GitHub App (scoped read/write) | Where RunLore commits what it learns |
-| **Notifications** | A Slack webhook (or Matrix) | Where findings are delivered |
+- **Data sources** — a cluster running Flux or Argo CD; optionally Prometheus/VictoriaMetrics, VictoriaLogs, Hubble for richer signals
+- **An LLM** — any OpenAI-compatible endpoint, Anthropic, or Gemini (in-cluster or external)
+- **A knowledge-base repo** — a private GitHub repo + a scoped GitHub App; this is where RunLore commits what it learns
+- **A notification destination** — a Slack webhook, Matrix, or both
 
-### Step 1 — Create your KB repo
-
-Create a private GitHub repo (e.g. `your-org/runlore-kb`). Seed it with existing runbooks if you
-have them — RunLore will grow it from there. Then create a **GitHub App**, install it on that repo
-with `Contents` + `Pull requests` + `Issues` (read/write), and note the App ID, Installation ID,
-and private key.
-
-### Step 2 — Create your secrets
-
-```bash
-kubectl -n runlore create secret generic runlore-secrets \
-  --from-literal=SLACK_WEBHOOK_URL='https://hooks.slack.com/services/...' \
-  --from-literal=OPENAI_API_KEY='<your-api-key>' \
-  --from-file=GITHUB_APP_PRIVATE_KEY=/path/to/app.pem
-```
-
-### Step 3 — Configure
-
-Create a minimal `values.yaml`:
-
-```yaml
-envFrom:
-  - secretRef:
-      name: runlore-secrets
-
-catalog:
-  gitSync: true
-
-config:
-  gitops:
-    engine: flux             # or argocd
-  model:
-    base_url: http://vllm.llm.svc:8000/v1
-    model: your-model
-    api_key_env: OPENAI_API_KEY
-  notify:
-    slack:
-      webhook_url_env: SLACK_WEBHOOK_URL
-  forge:
-    kb_repo: your-org/runlore-kb
-    github_app:
-      app_id: 123456
-      installation_id: 7654321
-      private_key_env: GITHUB_APP_PRIVATE_KEY
-```
-
-### Step 4 — Install
+Wire your credentials into a Kubernetes `Secret`, point the chart at them via a `values.yaml`
+(GitOps engine, LLM endpoint, KB repo, notification), and install:
 
 ```bash
 helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml
 ```
 
-Then point Alertmanager at `http://runlore.runlore.svc:8080/webhook/alertmanager` and RunLore
-starts investigating.
+Then route your Alertmanager alerts to `http://runlore.runlore.svc:8080/webhook/alertmanager` —
+RunLore starts investigating immediately.
 
-> **→ [Full getting-started guide](docs/getting-started.md)** — GitHub App setup,
-> metrics/logs/network data sources, AWS cloud context, HA, and verification steps.
+**→ [Full getting-started guide](docs/getting-started.md)** — KB repo setup, GitHub App,
+credentials, complete `values.yaml` reference, data sources, and verification steps.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # RunLore
 
-**An open-source SRE agent that investigates any incident — and learns _your_ platform as it goes.**
+**A read-only SRE agent that investigates incidents — and remembers what it learns.**
 
 [![CI](https://github.com/Smana/runlore/actions/workflows/ci.yaml/badge.svg)](https://github.com/Smana/runlore/actions/workflows/ci.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Smana/runlore)](https://goreportcard.com/report/github.com/Smana/runlore)
@@ -16,107 +16,142 @@
 
 ---
 
-RunLore is an **on-call teammate that never sleeps**. It wakes on any incident — *whatever the cause* —
-investigates it like a good SRE, and hands you a confidence-scored root cause with evidence:
+RunLore is an open-source, **read-only** SRE agent that wakes on any incident, investigates it —
+*what changed? what's wrong?* — and delivers a confidence-scored root cause to Slack. At the same
+time it opens a pull request in a Git repository you own, drafting what it found as a knowledge-base
+entry. A human reviews, adds context, and merges the PR: that entry is indexed, and the next time
+the same pattern hits, RunLore answers in seconds — no full investigation needed.
 
-- **What changed?** *(the sharpest first question)* — deploys, config, images, infra, certs, scaling;
-  on a GitOps platform, the **exact Git diff**.
-- **What's wrong?** *(when nothing changed)* — saturation, network denials, node health, dependency
-  outages, load.
-
-…and then it does the thing other agents don't: it **learns**. Every resolved incident becomes a
-reviewed entry in an open, git-versioned knowledge base — so RunLore gets sharper at **your** platform,
-incident after incident.
+**RunLore never mutates your cluster.** It reads Kubernetes, metrics, logs, and network flows.
+Its only writes go to Git, via reviewed pull requests.
 
 **Read-only by default · single Go binary · runs in your cluster · on your models.**
 
-## 📚 The learning loop — RunLore's reason to exist
+## See it in action
 
-The autonomous *alert → RCA → Slack* loop is already a commodity. What isn't: an agent whose knowledge
-**compounds in a catalog you own**. A normal SRE agent answers the same incident from scratch every
-time. RunLore **remembers** — in four moves:
+A real RunLore investigation delivered to Slack: confidence-scored root cause, the evidence trail,
+suggested next steps, open questions for a human, and a link to the pull request it opened in your
+knowledge base.
 
-```mermaid
-flowchart LR
-    R["🔎 Retrieve<br/>recall a past answer"] --> C["🧪 Capture<br/>record what happened"]
-    C --> U["📝 Curate<br/>write/refine the note (PR)"]
-    U --> P["♻️ Compound<br/>merged note re-indexed"]
-    P --> R
-    classDef s fill:#eef,stroke:#557,stroke-width:1px,color:#113;
-    class R,C,U,P s;
-```
-
-- **Retrieve** — on a new incident, recall a trustworthy matching note and answer in milliseconds
-  instead of re-running a multi-minute investigation (*instant recall*).
-- **Capture** — record that the incident happened and whether it then actually resolved.
-- **Curate** — turn a fresh, *verified* finding into a reviewable catalog entry via PR (duplicates
-  collapse automatically).
-- **Compound** — once a human merges the PR, the note is re-indexed and recall-able for everyone.
-
-Two things make this **learning**, not note-taking: **outcomes feed back** (a note's trust is derived
-from its real-world resolve-rate, and a note that keeps failing *decays* out of use), and **knowledge is
-yours** — portable markdown in *your* Git, PR-reviewed, provenance-tracked, never opaque vendor memory.
-
-→ Deep dive: **[How the learning loop works](docs/learning-loop.md)**
- · 👉 Your part: **[Reviewing & approving knowledge](docs/reviewing-knowledge.md)**.
+<div align="center">
+<img src="assets/slack-notification.png" alt="RunLore Slack notification — HarborRegistryDown: 95% confidence root cause (Crossplane AccessKey hit the AWS IAM AccessKeysPerUser quota → Secret missing the username key → CreateContainerConfigError), with the evidence trail, suggested next steps, and open questions" width="760" />
+</div>
 
 ## How it works
 
 ```mermaid
 flowchart LR
     A["Incident<br/>any alert · event"] -->|"trigger policy<br/>(prod · critical · ns…)"| B
-    subgraph B["🔎 Investigate · form & test hypotheses"]
+    subgraph B["🔎 Investigate · read-only"]
       direction TB
       W["what changed?<br/>deploys · infra · certs · scaling<br/>(GitOps → exact Git diff)"]
       C["what's wrong?<br/>saturation · network · nodes · deps"]
     end
-    B --> R["🎯 Root cause<br/>+ evidence + suggested fix"]
-    R -->|"read-only"| D["💬 Deliver<br/>Slack · Matrix"]
-    R -. learn .-> K[("📚 OKF knowledge<br/>catalog · git")]
+    B --> R["🎯 Root cause<br/>+ confidence + evidence"]
+    R -->|"read-only"| D["💬 Slack / Matrix<br/>findings + suggested fix"]
+    R -. learn .-> K[("📚 GitHub PR<br/>draft entry in your KB")]
     K -. instant recall .-> B
 ```
 
-**…and here's what lands in chat** — a real RunLore investigation delivered to Slack: ranked root cause
-with confidence, the evidence trail, read-only suggested next steps, open questions for a human, and a
-link to the knowledge-base entry it learned.
+1. **Alert fires** — Alertmanager or a GitOps failure event triggers RunLore via webhook.
+2. **RunLore investigates** — it reads your cluster, metrics, logs, and network flows. It never writes to the cluster.
+3. **Findings land in Slack** — ranked root causes with confidence, the evidence trail, and suggested next steps.
+4. **A PR opens in your KB repo** — RunLore drafts what it found as a knowledge-base entry.
+5. **A human reviews and merges** — after adding resolution context, the PR is merged.
+   That entry is indexed: the same incident next time gets an instant answer, no re-investigation.
 
-<div align="center">
-<img src="assets/slack-notification.png" alt="RunLore Slack notification — HarborRegistryDown: 95% confidence root cause (Crossplane AccessKey hit the AWS IAM AccessKeysPerUser quota → Secret missing the username key → CreateContainerConfigError), with the evidence trail, suggested next steps, and open questions" width="760" />
-</div>
+## 📚 The learning loop
 
-## Three pillars
+```mermaid
+flowchart LR
+    R["🔎 Retrieve<br/>recall a past answer"] --> C["🧪 Capture<br/>record what happened"]
+    C --> U["📝 Curate<br/>write the entry (PR)"]
+    U --> P["♻️ Compound<br/>merged note re-indexed"]
+    P --> R
+    classDef s fill:#eef,stroke:#557,stroke-width:1px,color:#113;
+    class R,C,U,P s;
+```
 
-| | |
-|---|---|
-| **React** | incident/alert webhook gated by a **trigger policy** (only prod, only critical, by namespace/team/label) · GitOps failure events · on-demand CLI / chat. The event source is pluggable. |
-| **Investigate** | a ReAct loop that forms & tests hypotheses across **what changed** (deploys/infra/certs/scaling — on GitOps, the exact Git diff) **and no-change causes** (saturation/network/nodes/deps), grounds itself in your catalog, runs an **adversarial verify pass**, and reports confidence + explicit `unresolved`. |
-| **Learn** | reads the cached [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) catalog for **instant recall** and writes new incidents back as **reviewed PRs** — knowledge compounds in *your* Git. |
+The autonomous *alert → RCA → Slack* loop is a commodity. What isn't: a knowledge base that
+**compounds in a catalog you own**. Every merged PR becomes a searchable entry — plain markdown in a
+Git repo you control, PR-reviewed, with full provenance. Knowledge that consistently resolves
+incidents gains trust; knowledge that keeps failing decays.
 
-## Why RunLore
+→ **[How the learning loop works](docs/learning-loop.md)** · **[Reviewing & approving knowledge](docs/reviewing-knowledge.md)**
 
-The bet is the two parts that aren't commodity: a **GitOps-native "what changed" spine** and an
-**open knowledge base that compounds**.
+## 🚀 Getting started
 
-| | What it is | What RunLore adds |
+RunLore runs in your Kubernetes cluster as a single Go binary, deployed via Helm.
+You need four things before installing:
+
+| | What | Why |
 |---|---|---|
-| [**k8sgpt**](https://github.com/k8sgpt-ai/k8sgpt) | A *detector* — analyzers + LLM explanation | An investigation loop, cross-signal correlation, real Git diffs, and learning |
-| [**HolmesGPT**](https://github.com/HolmesGPT/holmesgpt) | The strongest OSS investigation agent | Relies on *your* hand-curated runbooks (it doesn't learn); RunLore is what-changed-first and self-improving |
-| [**kagent**](https://github.com/kagent-dev/kagent) | A generic in-cluster agent *framework* | A focused, opinionated SRE agent (RunLore can run *on* kagent later) |
+| **Cluster + data sources** | Flux or Argo CD; optionally Prometheus/VictoriaMetrics, VictoriaLogs, Hubble | The investigation signals |
+| **LLM** | Any OpenAI-compatible endpoint, Anthropic, or Gemini — in-cluster or external | The investigation engine |
+| **Knowledge-base repo** | A private GitHub repo + a GitHub App (scoped read/write) | Where RunLore commits what it learns |
+| **Notifications** | A Slack webhook (or Matrix) | Where findings are delivered |
 
-RunLore is **GitOps-engine-agnostic** (Flux + Argo CD), **metrics-backend-agnostic** (VictoriaMetrics +
-Prometheus), with **pluggable** logs and **CNI-agnostic network** signals — and the only one that learns
-into an **open** [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) catalog you own.
+### Step 1 — Create your KB repo
 
-## Get started
+Create a private GitHub repo (e.g. `your-org/runlore-kb`). Seed it with existing runbooks if you
+have them — RunLore will grow it from there. Then create a **GitHub App**, install it on that repo
+with `Contents` + `Pull requests` + `Issues` (read/write), and note the App ID, Installation ID,
+and private key.
 
-**RunLore is designed to run in your Kubernetes cluster** (`lore serve`) — that's where you get the full
-React → Investigate → Learn loop: incident webhooks, the GitOps failure watch, delivery to chat, and the
-learning catalog. The Helm chart is the supported path.
+### Step 2 — Create your secrets
 
-> ### → **[Deploy on Kubernetes — Getting Started](docs/getting-started.md)**
-> Create a knowledge-base repo + a scoped GitHub App + secrets, configure the chart, then `helm install`.
+```bash
+kubectl -n runlore create secret generic runlore-secrets \
+  --from-literal=SLACK_WEBHOOK_URL='https://hooks.slack.com/services/...' \
+  --from-literal=OPENAI_API_KEY='<your-api-key>' \
+  --from-file=GITHUB_APP_PRIVATE_KEY=/path/to/app.pem
+```
 
-Prefer to kick the tyres first? You also can, without a cluster:
+### Step 3 — Configure
+
+Create a minimal `values.yaml`:
+
+```yaml
+envFrom:
+  - secretRef:
+      name: runlore-secrets
+
+catalog:
+  gitSync: true
+
+config:
+  gitops:
+    engine: flux             # or argocd
+  model:
+    base_url: http://vllm.llm.svc:8000/v1
+    model: your-model
+    api_key_env: OPENAI_API_KEY
+  notify:
+    slack:
+      webhook_url_env: SLACK_WEBHOOK_URL
+  forge:
+    kb_repo: your-org/runlore-kb
+    github_app:
+      app_id: 123456
+      installation_id: 7654321
+      private_key_env: GITHUB_APP_PRIVATE_KEY
+```
+
+### Step 4 — Install
+
+```bash
+helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml
+```
+
+Then point Alertmanager at `http://runlore.runlore.svc:8080/webhook/alertmanager` and RunLore
+starts investigating.
+
+> **→ [Full getting-started guide](docs/getting-started.md)** — GitHub App setup,
+> metrics/logs/network data sources, AWS cloud context, HA, and verification steps.
+
+---
+
+Prefer to try it without a cluster first?
 
 ```bash
 # fire mocked Alertmanager alerts through the trigger policy (no cluster)
@@ -124,26 +159,20 @@ hack/demo.sh
 
 # verify every feature end-to-end on a throwaway k3d cluster
 hack/e2e-k3d.sh
-
-# investigate one incident on-demand from your terminal (prints the findings)
-lore investigate --alert HarborProbeFailure --namespace apps --config runlore.yaml
 ```
 
-## Design principles
+## Why RunLore
 
-- **Cause-agnostic** — reacts to any incident and investigates any cause; "what changed" is the sharpest
-  lens (deepest on GitOps), not the only one.
-- **Read-only by default, with an autonomy ladder when you want it** — `off` → `suggest` → `approve`
-  (human-gated) → `auto`. Every rung above read-only is reversible-only, envelope-bounded, audited, and
-  kill-switchable (see [`docs/design.md`](docs/design.md)).
-- **Backend-agnostic & pluggable** — Flux + Argo CD; VictoriaMetrics + Prometheus; pluggable logs;
-  **CNI-agnostic** network signals (Cilium Hubble, AWS VPC Flow Logs, or GCP Firewall Logs — see
-  [data sources](docs/data-sources.md)).
-- **Cloud-aware (read-only)** — correlates the cloud control plane (AWS CloudTrail "what changed" +
-  EC2/ASG/EKS health) via in-cluster identity (EKS Pod Identity / IRSA).
-- **Single static Go binary**, **model-agnostic** (Anthropic, Google Gemini, or any OpenAI-compatible
-  endpoint — in-cluster vLLM, Ollama…), **observable** ([metrics, dashboard & alerts](docs/observability.md)),
-  and **HA** via leader election.
+| | What it is | What RunLore adds |
+|---|---|---|
+| [**k8sgpt**](https://github.com/k8sgpt-ai/k8sgpt) | A *detector* — analyzers + LLM explanation | An investigation loop, cross-signal correlation, real Git diffs, and learning |
+| [**HolmesGPT**](https://github.com/HolmesGPT/holmesgpt) | The strongest OSS investigation agent | Relies on *your* hand-curated runbooks (it doesn't learn); RunLore is what-changed-first and self-improving |
+| [**kagent**](https://github.com/kagent-dev/kagent) | A generic in-cluster agent *framework* | A focused, opinionated SRE agent (RunLore can run *on* kagent later) |
+
+RunLore is **GitOps-engine-agnostic** (Flux + Argo CD), **metrics-backend-agnostic**
+(VictoriaMetrics + Prometheus), with pluggable logs and CNI-agnostic network signals — and the only
+OSS agent that learns into an **open** [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+catalog you own.
 
 ## Docs
 


### PR DESCRIPTION
  ## Summary

  - **Read-only posture upfront** — tagline and first paragraph now lead with
  "read-only" and explicitly state RunLore never mutates the cluster, addressing the
  recurring confusion
  - **Incident flow is unambiguous** — "How it works" rewritten as 5 numbered steps
  making clear that RunLore opens the PR and a human merges it (not the agent
  resolving the incident)
  - **Slack screenshot moved up** — appears before any diagram, as evidence before
  explanation
  - **Polished Getting Started** — replaces the one-line pointer to docs with a
  self-contained 4-step summary: prerequisites table → secrets → minimal
  `values.yaml` → `helm install`, with a link to the full guide for details
  - **Removed noise** — "Three pillars" table (duplicated "How it works") and "Design
  principles" section (belongs in `docs/design.md`, not the landing page)
  - **Comparison table repositioned** — moved after the pitch where it lands with
  more context

  ## Test plan

  - [ ] Verify mermaid diagrams render on GitHub
  - [ ] Check all internal doc links resolve (`docs/getting-started.md`,
  `docs/learning-loop.md`, etc.)
  - [ ] Confirm Slack screenshot image path is correct
  (`assets/slack-notification.png`)