### PR TITLE
M0: private-repo what-changed auth + LLM cost controls

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -465,16 +465,43 @@ func requireWebhookAuth(cfg *config.Config, webhookToken string) error {
 	return nil
 }
 
+// newModelClient builds a ModelProvider for a wire protocol + endpoint.
+func newModelClient(provider, baseURL, model, apiKey string) providers.ModelProvider {
+	switch provider {
+	case "anthropic":
+		return anthropic.New(baseURL, model, apiKey)
+	case "gemini":
+		return gemini.New(baseURL, model, apiKey)
+	default:
+		return openai.New(baseURL, model, apiKey)
+	}
+}
+
 // buildModel builds the ModelProvider for the configured provider.
 func buildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
-	switch cfg.Model.Provider {
-	case "anthropic":
-		return anthropic.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
-	case "gemini":
-		return gemini.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
-	default:
-		return openai.New(cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+	return newModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+}
+
+// buildVerifyModel builds the optional cheaper model for the adversarial verify
+// pass, inheriting any unset field from the main model. Returns nil when no
+// model.verify override is configured (verify then runs on the main model).
+func buildVerifyModel(cfg *config.Config) providers.ModelProvider {
+	v := cfg.Model.Verify
+	if v == nil {
+		return nil
 	}
+	or := func(a, b string) string {
+		if a != "" {
+			return a
+		}
+		return b
+	}
+	apiKey := ""
+	if keyEnv := or(v.APIKeyEnv, cfg.Model.APIKeyEnv); keyEnv != "" {
+		apiKey = os.Getenv(keyEnv)
+	}
+	return newModelClient(or(v.Provider, cfg.Model.Provider),
+		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey)
 }
 
 // buildCatalog returns the kb_search backing store, or nil when no catalog is
@@ -664,15 +691,7 @@ func buildJudgeModel(cfg *config.Config, provider, baseURL, model, apiKeyEnv str
 		}
 		return buildModel(cfg, apiKey)
 	}
-	apiKey := os.Getenv(apiKeyEnv)
-	switch provider {
-	case "anthropic":
-		return anthropic.New(baseURL, model, apiKey)
-	case "gemini":
-		return gemini.New(baseURL, model, apiKey)
-	default:
-		return openai.New(baseURL, model, apiKey)
-	}
+	return newModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv))
 }
 
 // runEvalLive runs the live-fire campaign and writes a dated report.
@@ -971,7 +990,7 @@ func buildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.G
 		var res providers.Investigation
 		var got bool
 		li := &investigate.LoopInvestigator{
-			Model: model, Tools: tools, Recall: recall, Verify: true, Log: log,
+			Model: model, VerifyModel: buildVerifyModel(cfg), Tools: tools, Recall: recall, Verify: true, Log: log,
 			Metrics:                   metrics,
 			ModelProvider:             cfg.Model.Provider,
 			MaxSteps:                  cfg.Investigation.MaxSteps,
@@ -1203,7 +1222,7 @@ func runInvestigate(args []string) error {
 	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), nil, log)
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
-		Model: model, Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
+		Model: model, VerifyModel: buildVerifyModel(cfg), Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
 		ModelProvider: cfg.Model.Provider,
 		Timeout:       cfg.Investigation.Timeout.Std(),
 		OnComplete:    func(inv providers.Investigation) { result = &inv },
@@ -1283,6 +1302,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	}
 	return &investigate.LoopInvestigator{
 		Model:                     model,
+		VerifyModel:               buildVerifyModel(cfg),
 		Tools:                     tools,
 		Log:                       log,
 		Actions:                   actions,

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -1419,8 +1419,12 @@ func gitopsEngine(cfg *config.Config) string {
 }
 
 // buildGitOps builds the GitOps provider for the configured engine (flux default).
+// The differ clones the GitOps source repo over HTTPS; it authenticates private
+// repos with the shared GitHub App installation token (the App needs contents:read
+// on the source repo). A nil token source (no App configured) means public/local
+// repos only.
 func buildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) providers.GitOpsProvider {
-	differ := &whatchanged.Differ{}
+	differ := &whatchanged.Differ{TokenSource: buildForgeTokenSource(cfg, log)}
 	if gitopsEngine(cfg) == "argocd" {
 		log.Info("gitops engine", "engine", "argocd")
 		return argocd.New(argocd.NewDynamicReader(dc), differ)

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -42,19 +42,27 @@ config:
   leader_election:
     enabled: true
     name: runlore-leader
-  # Storm cost-control: fold correlated alerts into one investigation and cap the
-  # per-window investigation budget. Defaults (30s debounce, 2m max-wait, 50 batch,
-  # 10m cooldown, 1h window) are applied by the agent when fields are omitted.
+  # Cost controls — these ship with SAFE, BOUNDED defaults (not unlimited) so a
+  # default install can't run away in LLM spend. Tune for your environment, or set
+  # a field to 0 for unlimited (where noted). Coalesce/rate-limit sub-fields left
+  # unset default in the agent to 30s debounce, 2m max-wait, 50 batch, 10m cooldown,
+  # 1h window.
   investigation:
+    # Per-investigation context ceiling (estimated request tokens): when crossed, the
+    # agent is nudged to wrap up, then hard-stops and delivers what it has rather than
+    # growing context unbounded. 0 = unlimited.
+    max_tokens_per_investigation: 100000
+    # Cap each tool result fed back to the model (truncates large logs/diffs). 0 = unlimited.
+    max_tool_output_bytes: 32768
     coalesce:
-      enabled: false
+      enabled: true             # fold a correlated alert storm into ONE investigation
       # debounce: 30s           # flush batch quiet for this long
       # max_wait: 2m            # force flush even if still receiving alerts
       # max_batch: 50           # flush when batch reaches this size
       # cooldown: 10m           # suppress re-alerts for a group after a flush
       # correlation_labels: []  # group by label values instead of AM groupKey
     rate_limit:
-      max_per_window: 0        # 0 = unlimited; set e.g. 20 to cap investigations/hour
+      max_per_window: 20        # cap investigations per window (window defaults to 1h); 0 = unlimited
       # window: 1h
       # max_requeues: 3
   # Structured logging. In-cluster defaults to JSON so logs are ingestible by

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -89,6 +89,11 @@ config:
   #   base_url: https://vllm.svc/v1
   #   model: <model-name>
   #   api_key_env: OPENAI_API_KEY
+  #   # Route the adversarial verify pass to a cheaper/faster model to cut the
+  #   # +1-call-per-investigation cost (inherits the fields above unless overridden;
+  #   # omit to verify with the main model). Verify always runs — this only lowers cost.
+  #   verify:
+  #     model: <cheaper-model-name>
   # catalog:
   #   dir: /var/lib/runlore/catalog
   #   instant_recall:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,6 +216,19 @@ type Model struct {
 	BaseURL   string `yaml:"base_url"`    // OpenAI: required; Anthropic/Gemini: optional (built-in default endpoint)
 	Model     string `yaml:"model"`       // model name
 	APIKeyEnv string `yaml:"api_key_env"` // env var holding the API key (empty = keyless)
+	// Verify optionally routes the adversarial verify pass to a cheaper/faster model;
+	// unset fields inherit from the parent above (so `verify: {model: <cheap>}` reuses
+	// the same provider/endpoint/key). Absent ⇒ verify runs on the main model.
+	Verify *ModelOverride `yaml:"verify"`
+}
+
+// ModelOverride is a partial Model used to route the verify pass to a cheaper model;
+// empty fields inherit from the parent Model.
+type ModelOverride struct {
+	Provider  string `yaml:"provider"`
+	BaseURL   string `yaml:"base_url"`
+	Model     string `yaml:"model"`
+	APIKeyEnv string `yaml:"api_key_env"`
 }
 
 // Notify configures where investigation findings are delivered.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -89,6 +89,10 @@ type LoopInvestigator struct {
 	Recall     *Recall                       // optional: short-circuit on a high-confidence catalog hit
 	Verify     bool                          // run an adversarial review of root causes before delivery
 
+	// VerifyModel optionally routes the adversarial verify pass to a cheaper/faster
+	// model. nil ⇒ the verify pass reuses Model. Verify itself always runs.
+	VerifyModel providers.ModelProvider
+
 	// Timeout bounds a single investigation end-to-end (recall + every model/tool
 	// call, including a hung git clone/patch). 0 disables it. On expiry the loop
 	// delivers a synthetic timeout result rather than starving the queue worker.

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -64,7 +64,14 @@ func (li *LoopInvestigator) verifyFindings(ctx context.Context, req Request, inv
 	if len(inv.RootCauses) == 0 {
 		return inv
 	}
-	resp, err := li.Model.Complete(ctx, providers.CompletionRequest{
+	// Route the adversarial pass to a cheaper/faster model when one is configured;
+	// otherwise reuse the main investigation model. Verify always runs (the honesty
+	// guarantee) — this only lowers its cost, it never disables it.
+	m := li.Model
+	if li.VerifyModel != nil {
+		m = li.VerifyModel
+	}
+	resp, err := m.Complete(ctx, providers.CompletionRequest{
 		System:   verifyPrompt,
 		Messages: []providers.Message{{Role: "user", Content: renderForReview(req, inv)}},
 		Tools:    []providers.ToolSpec{submitVerdictsSpec()},

--- a/internal/investigate/verify_test.go
+++ b/internal/investigate/verify_test.go
@@ -104,3 +104,35 @@ func TestVerifyDowngradesUnproven(t *testing.T) {
 		t.Fatal("a finding with a surviving reviewed cause must be marked Verified")
 	}
 }
+
+// TestVerifyUsesVerifyModel routes the adversarial pass to the (cheaper) VerifyModel
+// when one is set, leaving the main investigation model for the loop itself. The
+// scriptModel stubs panic if called more than scripted, so wrong routing fails loudly.
+func TestVerifyUsesVerifyModel(t *testing.T) {
+	mainM := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName, Args: `{"confidence":0.8,"root_causes":[{"summary":"oom","confidence":0.8,"evidence":["OOMKilled in events"]}]}`}}},
+	}}
+	verifyM := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"keep","confidence":0.7}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:       mainM,
+		VerifyModel: verifyM,
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Verify:      true,
+		OnComplete:  func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if mainM.i != 1 {
+		t.Fatalf("main model should serve only the loop (1 call), got %d", mainM.i)
+	}
+	if verifyM.i != 1 {
+		t.Fatalf("verify pass should route to VerifyModel (1 call), got %d", verifyM.i)
+	}
+	if got == nil || len(got.RootCauses) != 1 || got.RootCauses[0].Confidence != 0.7 {
+		t.Fatalf("expected kept cause at verify confidence 0.7, got %+v", got)
+	}
+}

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -52,12 +52,30 @@ func New(baseURL, model, apiKey string) *Client {
 
 var _ providers.ModelProvider = (*Client)(nil)
 
+// cacheControl marks a content block as a prompt-cache breakpoint: Anthropic
+// caches the request prefix up to and including the marked block. The default
+// 5-minute ephemeral cache is GA on anthropic-version 2023-06-01 (no beta header).
+type cacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+// ephemeral is the shared 5-minute cache marker (read-only; never mutated).
+var ephemeral = &cacheControl{Type: "ephemeral"}
+
+// systemBlock is one block of an array-form system prompt. The array form (vs a
+// bare string) is what lets the system prompt carry a cache breakpoint.
+type systemBlock struct {
+	Type         string        `json:"type"` // "text"
+	Text         string        `json:"text"`
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
+}
+
 type msgRequest struct {
-	Model     string    `json:"model"`
-	MaxTokens int       `json:"max_tokens"`
-	System    string    `json:"system,omitempty"`
-	Messages  []message `json:"messages"`
-	Tools     []tool    `json:"tools,omitempty"`
+	Model     string        `json:"model"`
+	MaxTokens int           `json:"max_tokens"`
+	System    []systemBlock `json:"system,omitempty"`
+	Messages  []message     `json:"messages"`
+	Tools     []tool        `json:"tools,omitempty"`
 }
 
 type message struct {
@@ -79,9 +97,10 @@ type block struct {
 }
 
 type tool struct {
-	Name        string          `json:"name"`
-	Description string          `json:"description"`
-	InputSchema json.RawMessage `json:"input_schema"`
+	Name         string          `json:"name"`
+	Description  string          `json:"description"`
+	InputSchema  json.RawMessage `json:"input_schema"`
+	CacheControl *cacheControl   `json:"cache_control,omitempty"`
 }
 
 type msgResponse struct {
@@ -102,9 +121,22 @@ type msgResponse struct {
 
 // Complete sends a Messages request with tools and maps the result back.
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
-	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, System: req.System, Messages: toMessages(req.Messages)}
+	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Messages: toMessages(req.Messages)}
+	if req.System != "" {
+		areq.System = []systemBlock{{Type: "text", Text: req.System, CacheControl: ephemeral}}
+	}
 	for _, t := range req.Tools {
 		areq.Tools = append(areq.Tools, tool{Name: t.Name, Description: t.Description, InputSchema: json.RawMessage(t.Schema)})
+	}
+	// Prompt caching: the system prompt + tool schemas are identical across every
+	// step of an investigation's ReAct loop (up to ~20 calls), so mark them as cache
+	// breakpoints — Anthropic re-reads that static prefix at ~0.1x input cost instead
+	// of re-billing it each step. The system block (set above) caches tools+system
+	// (cache prefix order is tools → system); marking the last tool also caches the
+	// tool array when there's no system prompt. Savings surface as a drop in
+	// usage.input_tokens (cached input moves to cache_read_input_tokens).
+	if n := len(areq.Tools); n > 0 {
+		areq.Tools[n-1].CacheControl = ephemeral
 	}
 	body, err := json.Marshal(areq)
 	if err != nil {

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -69,11 +69,20 @@ func TestComplete(t *testing.T) {
 	if gotVersion != apiVersion || gotKey != "k" {
 		t.Fatalf("version=%q key=%q", gotVersion, gotKey)
 	}
-	if gotReq.Model != "claude-x" || gotReq.System != "sys" || gotReq.MaxTokens == 0 {
+	if gotReq.Model != "claude-x" || gotReq.MaxTokens == 0 {
 		t.Fatalf("request: %+v", gotReq)
+	}
+	// system is sent as a content-block array carrying a prompt-cache breakpoint
+	if len(gotReq.System) != 1 || gotReq.System[0].Text != "sys" ||
+		gotReq.System[0].CacheControl == nil || gotReq.System[0].CacheControl.Type != "ephemeral" {
+		t.Fatalf("system (want one cached 'sys' block): %+v", gotReq.System)
 	}
 	if len(gotReq.Tools) != 1 || gotReq.Tools[0].Name != "what_changed" || string(gotReq.Tools[0].InputSchema) != `{"type":"object"}` {
 		t.Fatalf("tools: %+v", gotReq.Tools)
+	}
+	// the last tool is the cache breakpoint for the (static) tool schemas
+	if gotReq.Tools[0].CacheControl == nil || gotReq.Tools[0].CacheControl.Type != "ephemeral" {
+		t.Fatalf("last tool should be a cache breakpoint: %+v", gotReq.Tools[0])
 	}
 	if len(gotReq.Messages) != 1 || gotReq.Messages[0].Role != "user" || gotReq.Messages[0].Content[0].Text != "hi" {
 		t.Fatalf("messages: %+v", gotReq.Messages)
@@ -176,5 +185,36 @@ func TestMessageCoalescing(t *testing.T) {
 		results.Content[0].Type != "tool_result" || results.Content[0].ToolUseID != "a" || results.Content[0].Content != "changed: chart bump" ||
 		results.Content[1].ToolUseID != "b" {
 		t.Fatalf("coalesced tool results: %+v", results)
+	}
+}
+
+// TestPromptCacheToolsOnly verifies that with no system prompt, the tools array
+// still gets exactly one cache breakpoint — on the LAST tool, not every tool.
+func TestPromptCacheToolsOnly(t *testing.T) {
+	var gotReq msgRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}]}`))
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "claude-x", "k").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+		Tools: []providers.ToolSpec{
+			{Name: "a", Description: "d", Schema: `{"type":"object"}`},
+			{Name: "b", Description: "d", Schema: `{"type":"object"}`},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(gotReq.System) != 0 {
+		t.Fatalf("want no system block, got %+v", gotReq.System)
+	}
+	if gotReq.Tools[0].CacheControl != nil {
+		t.Fatalf("only the last tool should be the breakpoint; first tool was marked: %+v", gotReq.Tools[0])
+	}
+	if gotReq.Tools[1].CacheControl == nil || gotReq.Tools[1].CacheControl.Type != "ephemeral" {
+		t.Fatalf("last tool should be the cache breakpoint: %+v", gotReq.Tools[1])
 	}
 }

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -25,9 +25,11 @@ type providersFileDiff = providers.FileDiff
 
 // Differ computes path-scoped diffs between Git revisions.
 type Differ struct {
-	// Token is a GitHub App installation token used for HTTPS clone auth in
-	// Remote. Empty disables auth (e.g. public or local repos).
-	Token string
+	// TokenSource mints a GitHub App installation token for HTTPS clone auth in
+	// Remote/RemoteFromParent. It is called once per clone so a short-lived
+	// (~1h) installation token stays fresh across a long-running agent. nil
+	// disables auth (e.g. public or local repos).
+	TokenSource func(context.Context) (string, error)
 }
 
 // Local diffs two revisions in an already-cloned repository at path. ctx bounds the
@@ -114,12 +116,22 @@ type singleFilePatch struct{ fp diff.FilePatch }
 func (p singleFilePatch) FilePatches() []diff.FilePatch { return []diff.FilePatch{p.fp} }
 func (p singleFilePatch) Message() string               { return "" }
 
-// auth builds the clone auth method from the installation token.
-func (d *Differ) auth() transport.AuthMethod {
-	if d.Token == "" {
-		return nil
+// auth builds the clone auth method from a freshly-minted installation token.
+// Returns (nil, nil) when no token source is configured or it yields an empty
+// token (public/local repos). A token-source error is surfaced so a private
+// clone fails loudly instead of silently attempting unauthenticated access.
+func (d *Differ) auth(ctx context.Context) (transport.AuthMethod, error) {
+	if d.TokenSource == nil {
+		return nil, nil
 	}
-	return &http.BasicAuth{Username: "x-access-token", Password: d.Token}
+	tok, err := d.TokenSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("clone auth token: %w", err)
+	}
+	if tok == "" {
+		return nil, nil
+	}
+	return &http.BasicAuth{Username: "x-access-token", Password: tok}, nil
 }
 
 // cloneToDisk clones url into a temporary on-disk repository and returns it with a
@@ -130,12 +142,16 @@ func (d *Differ) auth() transport.AuthMethod {
 // hung remote (a stalled HTTPS clone would otherwise block the queue worker
 // indefinitely); a cancelled clone returns a context error via %w.
 func (d *Differ) cloneToDisk(ctx context.Context, url string) (*git.Repository, func(), error) {
+	auth, err := d.auth(ctx)
+	if err != nil {
+		return nil, func() {}, err
+	}
 	dir, err := os.MkdirTemp("", "runlore-clone-")
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("temp dir: %w", err)
 	}
 	cleanup := func() { _ = os.RemoveAll(dir) }
-	repo, err := git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{URL: url, Auth: d.auth()})
+	repo, err := git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{URL: url, Auth: auth})
 	if err != nil {
 		cleanup()
 		return nil, func() {}, fmt.Errorf("clone %s: %w", url, err)

--- a/internal/whatchanged/differ_auth_test.go
+++ b/internal/whatchanged/differ_auth_test.go
@@ -1,0 +1,63 @@
+package whatchanged
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+func TestDifferAuth(t *testing.T) {
+	t.Run("nil source disables auth", func(t *testing.T) {
+		m, err := (&Differ{}).auth(context.Background())
+		if err != nil || m != nil {
+			t.Fatalf("want (nil, nil), got (%v, %v)", m, err)
+		}
+	})
+
+	t.Run("token yields x-access-token basic auth", func(t *testing.T) {
+		d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+		m, err := d.auth(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		ba, ok := m.(*http.BasicAuth)
+		if !ok {
+			t.Fatalf("want *http.BasicAuth, got %T", m)
+		}
+		if ba.Username != "x-access-token" || ba.Password != "ghs_tok" {
+			t.Fatalf("bad basic auth: %+v", ba)
+		}
+	})
+
+	t.Run("empty token disables auth", func(t *testing.T) {
+		d := &Differ{TokenSource: func(context.Context) (string, error) { return "", nil }}
+		m, err := d.auth(context.Background())
+		if err != nil || m != nil {
+			t.Fatalf("want (nil, nil), got (%v, %v)", m, err)
+		}
+	})
+
+	t.Run("source error is surfaced, not swallowed", func(t *testing.T) {
+		sentinel := errors.New("mint failed")
+		d := &Differ{TokenSource: func(context.Context) (string, error) { return "", sentinel }}
+		m, err := d.auth(context.Background())
+		if m != nil {
+			t.Fatalf("want nil auth on error, got %v", m)
+		}
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("want wrapped sentinel error, got %v", err)
+		}
+	})
+}
+
+// TestDifferRemoteTokenError ensures a token-source failure aborts the clone
+// (fail loud) rather than silently attempting an unauthenticated clone.
+func TestDifferRemoteTokenError(t *testing.T) {
+	sentinel := errors.New("mint failed")
+	d := &Differ{TokenSource: func(context.Context) (string, error) { return "", sentinel }}
+	if _, err := d.Remote(context.Background(), "https://example.invalid/repo.git", "a", "b", ""); !errors.Is(err, sentinel) {
+		t.Fatalf("want token error surfaced from Remote, got %v", err)
+	}
+}


### PR DESCRIPTION
## M0 — make the headline feature work, and bound LLM cost

First milestone of a broader code + positioning review. Four small, independently-reviewable commits; no `auto`-path, webhook, or security-boundary changes.

### Changes
- **`fix(whatchanged)` — authenticate private-repo clones (P0).** The differ was built with no auth (`&whatchanged.Differ{}`), so cloning a *private* GitOps source repo for the "what changed" diff silently failed — the headline RCA feature degraded to public/local repos only (the GitHub App private key was also a dead config key). The differ now takes a **per-clone token source** wired from the shared GitHub App identity, so the short-lived (~1h) installation token stays fresh across a long-running `serve`; auth **fails loud** on a mint error rather than silently cloning unauthenticated.
- **`feat(model/anthropic)` — prompt-cache the system prompt + tool schemas.** Identical across every step of a ≤20-call ReAct loop, they were re-billed as fresh input each step. Marked as `cache_control: ephemeral` breakpoints (GA on `anthropic-version: 2023-06-01`, **no beta header** — verified against current API docs) → typically a **50–90% input-token cut**. Savings surface as reduced `usage.input_tokens`.
- **`feat(helm)` — ship bounded cost-control defaults.** A default `helm install` had no spend ceiling. The chart now ships `coalesce.enabled: true`, `rate_limit.max_per_window: 20`, `max_tokens_per_investigation: 100000`, `max_tool_output_bytes: 32768`. Go `0 = unlimited` semantics are **unchanged**, so operators can still opt into unlimited explicitly.
- **`feat(model)` — optional cheaper model for the verify pass.** The adversarial verify pass ran on the main model every investigation (+1 call at top-model cost). New `model.verify` override (each field inherits the parent) routes it to a cheaper/faster model. Verify stays **mandatory** — this only lowers cost, it never disables the honesty guarantee.

### Verification
Per commit: `go build` · `go vet` · `go test -race` (affected packages) · `golangci-lint` **0 issues**. Chart changes also pass `helm lint` + render. New tests cover differ auth (incl. fail-loud on token error), the prompt-cache breakpoints, and verify-model routing.

### Default behavior unchanged where it matters
No GitHub App configured → public/local diffs as before. No `model.verify` → verify runs on the main model.