### PR TITLE
M1: harden the churn paths (interrupted clone, crash, leader-flap stampede)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -281,12 +281,18 @@ func runServe(args []string) error {
 
 	reinv := buildReinvestigator(ctx, cfg, gitops, metrics, log)
 
+	// failureDedup is created ONCE (process scope), not per leadership term, so it
+	// survives leader flaps: the gitops informer's initial-LIST replay of every
+	// still-failing workload on each re-acquire is then suppressed instead of
+	// re-investigated (GO-P1A). Deduper is safe for concurrent use across terms.
+	failureDedup := trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std())
+
 	// startWork runs the leader-only loops (investigation queue + failure watch +
 	// re-investigate poller), scoped to a context cancelled when leadership is lost.
 	startWork := func(workCtx context.Context) {
 		go queue.Run(workCtx)
 		if cfg.Triggers.GitOpsFailures.Enabled && gitops != nil {
-			startGitOpsFailureWatch(workCtx, cfg, queue, gitops, metrics, log)
+			startGitOpsFailureWatch(workCtx, cfg, queue, gitops, failureDedup, metrics, log)
 		}
 		if reinv != nil {
 			log.Info("re-investigate poller enabled", "label", investigate.ReinvestigateLabel)
@@ -1375,7 +1381,11 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 // only after the failure has persisted — re-checked still Ready=False via the
 // provider's ResourceStatus — filtering reconcile-churn transients that would
 // otherwise drive confident-but-wrong root causes.
-func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, gp providers.GitOpsProvider, metrics *telemetry.Metrics, log *slog.Logger) {
+// dedup is process-scoped (created once in runServe) and shared across leadership
+// terms — NOT created here per call. The informer's initial LIST re-emits every
+// still-failing workload as an Add on each (re-)acquire, so a per-term deduper
+// (empty at term start) would re-investigate every broken app on every leader flap.
+func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investigate.Enqueuer, gp providers.GitOpsProvider, dedup *trigger.Deduper, metrics *telemetry.Metrics, log *slog.Logger) {
 	events, err := gp.WatchFailures(ctx)
 	if err != nil {
 		log.Warn("gitops-failure watch disabled", "err", err)
@@ -1384,7 +1394,7 @@ func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investig
 	deb := buildFailureDebouncer(cfg, gp, metrics, log)
 	log.Info("watching gitops failures", "engine", gitopsEngine(cfg),
 		"debounce", cfg.Triggers.GitOpsFailures.DebounceWindow())
-	go investigate.DrainFailures(ctx, events, q, trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()), deb, log)
+	go investigate.DrainFailures(ctx, events, q, dedup, deb, log)
 }
 
 // buildFailureDebouncer wires a Debouncer whose "still failing?" re-check reads

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -512,17 +512,18 @@ func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, 
 			log.Info("catalog git-sync using the forge GitHub App identity")
 		}
 		syncer := &catalog.Syncer{URL: cfg.Catalog.Git.URL, Branch: cfg.Catalog.Git.Branch, Dir: dir, Token: token, Log: log}
-		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func() {
+		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func() error {
 			skipped, err := cat.Reload(dir)
 			if err != nil {
 				log.Warn("catalog reload failed", "dir", dir, "err", err)
-				return
+				return err
 			}
 			if len(skipped) > 0 {
 				log.Warn("catalog entries skipped (unparseable)", "count", len(skipped), "files", skipped)
 			}
 			log.Info("catalog synced", "url", cfg.Catalog.Git.URL, "entries", cat.Len())
 			warnInvalid(cat)
+			return nil
 		})
 		log.Info("catalog git-sync enabled", "url", cfg.Catalog.Git.URL, "dir", dir)
 		return cat

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -60,22 +60,37 @@ func (s *Syncer) Sync(ctx context.Context) (bool, error) {
 		return false, fmt.Errorf("auth: %w", err)
 	}
 	ref := plumbing.NewBranchReferenceName(s.branch())
-	var repo *git.Repository
-	if _, statErr := os.Stat(filepath.Join(s.Dir, ".git")); statErr != nil {
-		repo, err = git.PlainCloneContext(ctx, s.Dir, false, &git.CloneOptions{
+	clone := func() (*git.Repository, error) {
+		repo, cerr := git.PlainCloneContext(ctx, s.Dir, false, &git.CloneOptions{
 			URL:           s.URL,
 			ReferenceName: ref,
 			SingleBranch:  true,
 			Auth:          auth,
 		})
-		if err != nil {
+		if cerr != nil {
+			// Drop the partial checkout so an interrupted/failed clone can't leave a
+			// half-written .git that wedges every future Pull — the next tick re-clones.
+			_ = os.RemoveAll(s.Dir)
+			return nil, cerr
+		}
+		return repo, nil
+	}
+	var repo *git.Repository
+	if _, statErr := os.Stat(filepath.Join(s.Dir, ".git")); statErr != nil {
+		if repo, err = clone(); err != nil {
+			return false, err
+		}
+	} else if repo, err = git.PlainOpen(s.Dir); err != nil {
+		// A present-but-unreadable mirror (e.g. an earlier clone killed mid-write)
+		// would otherwise error on every Pull forever — discard it and re-clone.
+		s.Log.Warn("catalog mirror unreadable; re-cloning", "dir", s.Dir, "err", err)
+		if rmErr := os.RemoveAll(s.Dir); rmErr != nil {
+			return false, fmt.Errorf("remove corrupt mirror: %w", rmErr)
+		}
+		if repo, err = clone(); err != nil {
 			return false, err
 		}
 	} else {
-		repo, err = git.PlainOpen(s.Dir)
-		if err != nil {
-			return false, err
-		}
 		wt, werr := repo.Worktree()
 		if werr != nil {
 			return false, werr
@@ -102,18 +117,26 @@ func (s *Syncer) Sync(ctx context.Context) (bool, error) {
 
 // Run does an initial sync then re-syncs every interval, calling onSync after each
 // success. It returns when ctx is done. interval <= 0 defaults to 5m.
-func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func()) {
+func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func() error) {
 	if interval <= 0 {
 		interval = 5 * time.Minute
 	}
 	do := func() {
+		prev := s.lastRev
 		changed, err := s.Sync(ctx)
 		if err != nil {
 			s.Log.Warn("catalog git sync failed", "url", s.URL, "err", err)
 			return
 		}
-		if changed {
-			onSync()
+		if !changed {
+			return
+		}
+		if err := onSync(); err != nil {
+			// Re-index failed: roll back to the previous synced revision so the next
+			// tick retries it, instead of sticking the catalog on a stale/empty index
+			// until upstream HEAD next moves. (Sync already advanced lastRev.)
+			s.lastRev = prev
+			s.Log.Warn("catalog re-index failed; will retry next sync", "url", s.URL, "err", err)
 		}
 	}
 	do()

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -117,6 +117,25 @@ func commit(t *testing.T, repo *git.Repository, dir, name, content string) {
 	}
 }
 
+// TestSyncRecoversFromCorruptMirror locks down the wedge fix: a present-but-broken
+// .git (e.g. an earlier clone killed mid-write) is discarded and re-cloned, instead
+// of erroring on every future Pull forever.
+func TestSyncRecoversFromCorruptMirror(t *testing.T) {
+	src := initBareUpstream(t)
+	dir := t.TempDir()
+	// Plant a corrupt mirror: a `.git` that PlainOpen cannot read (Stat still sees it).
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
+	if _, err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("Sync should recover by re-cloning a corrupt mirror, got: %v", err)
+	}
+	if es, _, _ := Load(dir); len(es) != 1 {
+		t.Fatalf("after recovery clone: want 1 entry, got %d", len(es))
+	}
+}
+
 func TestSyncerCloneAndPull(t *testing.T) {
 	src := t.TempDir()
 	repo, err := git.PlainInitWithOptions(src, &git.PlainInitOptions{
@@ -161,7 +180,10 @@ func TestRunReloadsOnlyOnChange(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
-	go func() { defer close(done); s.Run(ctx, 15*time.Millisecond, func() { calls.Add(1) }) }()
+	go func() {
+		defer close(done)
+		s.Run(ctx, 15*time.Millisecond, func() error { calls.Add(1); return nil })
+	}()
 
 	// Several poll intervals with no upstream change → onSync fires exactly once
 	// (the initial sync), regardless of how many ticks elapse.

--- a/internal/investigate/failures_test.go
+++ b/internal/investigate/failures_test.go
@@ -52,3 +52,30 @@ func TestDrainFailuresSkipsCascades(t *testing.T) {
 		t.Fatalf("want only the root 'crds' failure enqueued, got %+v", enq.reqs)
 	}
 }
+
+// TestDrainFailuresDedupSurvivesAcrossRuns locks down GO-P1A: a deduper shared across
+// two DrainFailures runs (two leadership terms) suppresses the second term's
+// initial-LIST replay of a still-failing workload, instead of re-investigating it.
+// A per-term deduper would enqueue twice; the process-scoped one enqueues once.
+func TestDrainFailuresDedupSurvivesAcrossRuns(t *testing.T) {
+	wl := providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}
+	dedup := trigger.NewDeduper(30 * time.Minute) // process-scoped: survives both runs
+	enq := &collectEnqueuer{}
+
+	// Term 1: the failure is seen and investigated.
+	src1 := make(chan providers.FailureEvent, 1)
+	src1 <- providers.FailureEvent{Workload: wl, Reason: "BuildFailed"}
+	close(src1)
+	DrainFailures(context.Background(), src1, enq, dedup, nil, discardLog)
+
+	// Term 2 (leader re-acquired): the informer relists and re-emits the same
+	// still-failing workload — the shared deduper must suppress the replay.
+	src2 := make(chan providers.FailureEvent, 1)
+	src2 <- providers.FailureEvent{Workload: wl, Reason: "BuildFailed"}
+	close(src2)
+	DrainFailures(context.Background(), src2, enq, dedup, nil, discardLog)
+
+	if len(enq.reqs) != 1 {
+		t.Fatalf("a still-failing workload replayed on leader re-acquire must be investigated once, got %d", len(enq.reqs))
+	}
+}

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -133,8 +133,12 @@ func (l *Ledger) appendLocked(e Event) error {
 	if err != nil {
 		return err
 	}
-	_, err = f.Write(append(b, '\n'))
-	return err
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	// fsync so an unclean crash/SIGKILL can't lose the tail open/resolve event — the
+	// ledger is the durable truth for recall-decay attribution (the audit log fsyncs too).
+	return f.Sync()
 }
 
 // Open records that an investigation completed for an incident (fingerprint).


### PR DESCRIPTION
## M1 — churn-path hardening

Second milestone of the broader review. For an HA agent, leader-flap / SIGTERM / interrupted-clone / crash are the events it *exists* to handle — these were lossy or noisy. Two commits, four fixes; all read-only-path, no behavior change on the happy path.

### Changes
- **`fix(catalog,outcome)` — survive interrupted clone, failed re-index, and crash** (`99af960`)
  - **GO-P2A:** the catalog syncer re-clones a present-but-unreadable mirror (an earlier clone killed mid-write) instead of erroring on every future `Pull` *forever*; a failed clone drops its partial checkout so the next tick re-clones cleanly.
  - **GO-P2C:** a failed re-index rolls back `lastRev` so the next poll retries that revision, instead of sticking the catalog on a stale/empty index until upstream HEAD next moves (`onSync` now returns an error).
  - **GO-P2B:** the outcome ledger `fsync`s each append (as the audit log already does), so an unclean crash/SIGKILL can't lose the tail `open`/`resolve` event that drives recall-decay attribution.
- **`fix(serve)` — hoist gitops-failure deduper to process scope** (`e3419c5`)
  - **GO-P1A:** a client-go SharedInformer re-emits every existing object as an `Add` on its initial LIST, so each leader re-acquire replayed every still-failing workload as a fresh failure — and the per-term deduper (empty at term start) couldn't suppress it, re-investigating every broken app on every flap. The deduper is now process-scoped (and is already concurrent-safe). Long-failing workloads are still re-investigated after the dedup window, as intended — only the per-flap replay is suppressed.

### Deferred (on purpose): GO-P1B graceful drain
A *safe* graceful drain must keep the in-flight investigation's context alive past SIGTERM **and** hold the leader lease through the drain — otherwise a draining leader (lease released by `ReleaseOnCancel`) can run concurrently with a freshly-elected one and double-execute a mutation in `auto` mode (split-brain). That decouples work-lifetime from the SIGTERM signal and adds a queue drain handshake — a delicate change to the verified-correct HA path that deserves its own PR + a churn/drain/timeout test matrix, rather than being rushed in here.

### Verification
`gofmt` · `go build` · `go vet` · `go test -race` (catalog, outcome, investigate, cmd/lore) · `golangci-lint` **0 issues**. New tests: `TestSyncRecoversFromCorruptMirror`, `TestDrainFailuresDedupSurvivesAcrossRuns`.