### PR TITLE
docs: external review — repositioning, honest limitations, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # RunLore
 
-**An open-source SRE agent that investigates any incident — and learns _your_ platform as it goes.**
+**An open-source SRE agent that investigates any incident — and turns what it learns into knowledge _you_ own, review, and can take with you.**
 
 [![CI](https://github.com/Smana/runlore/actions/workflows/ci.yaml/badge.svg)](https://github.com/Smana/runlore/actions/workflows/ci.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Smana/runlore)](https://goreportcard.com/report/github.com/Smana/runlore)
@@ -24,17 +24,19 @@ investigates it like a good SRE, and hands you a confidence-scored root cause wi
 - **What's wrong?** *(when nothing changed)* — saturation, network denials, node health, dependency
   outages, load.
 
-…and then it does the thing other agents don't: it **learns**. Every resolved incident becomes a
-reviewed entry in an open, git-versioned knowledge base — so RunLore gets sharper at **your** platform,
-incident after incident.
+…and then it does the thing the closed tools keep for themselves: it **learns in the open**. Every
+resolved incident becomes a **reviewed, git-versioned entry you own** — portable markdown, PR-reviewed,
+provenance-tracked, never opaque vendor memory — so RunLore gets sharper at **your** platform, incident
+after incident.
 
 **Read-only by default · single Go binary · runs in your cluster · on your models.**
 
 ## 📚 The learning loop — RunLore's reason to exist
 
-The autonomous *alert → RCA → Slack* loop is already a commodity. What isn't: an agent whose knowledge
-**compounds in a catalog you own**. A normal SRE agent answers the same incident from scratch every
-time. RunLore **remembers** — in four moves:
+The autonomous *alert → RCA → Slack* loop is already a commodity — and frontier models still get the
+root cause right less than half the time. What isn't a commodity: an agent that's **honest about that reality**
+and whose knowledge **compounds in a catalog you own** — open and reviewable, never opaque vendor memory.
+A normal SRE agent answers the same incident from scratch every time. RunLore **remembers** — in four moves:
 
 ```mermaid
 flowchart LR
@@ -94,18 +96,26 @@ link to the knowledge-base entry it learned.
 
 ## Why RunLore
 
-The bet is the two parts that aren't commodity: a **GitOps-native "what changed" spine** and an
-**open knowledge base that compounds**.
+The bet isn't the autonomous loop (a commodity) or the change diff alone (Komodor, Anyshift and others
+now diff changes too). It's the **combination the open tools don't have**: knowledge that **compounds in
+a catalog _you_ own and review**, grounded in the **exact GitOps change** that caused the incident, from
+an agent that's **honest about the sub-50% reality** — all **self-hosted, on your models**.
 
 | | What it is | What RunLore adds |
 |---|---|---|
 | [**k8sgpt**](https://github.com/k8sgpt-ai/k8sgpt) | A *detector* — analyzers + LLM explanation | An investigation loop, cross-signal correlation, real Git diffs, and learning |
-| [**HolmesGPT**](https://github.com/HolmesGPT/holmesgpt) | The strongest OSS investigation agent | Relies on *your* hand-curated runbooks (it doesn't learn); RunLore is what-changed-first and self-improving |
-| [**kagent**](https://github.com/kagent-dev/kagent) | A generic in-cluster agent *framework* | A focused, opinionated SRE agent (RunLore can run *on* kagent later) |
+| [**HolmesGPT**](https://github.com/HolmesGPT/holmesgpt) | The strongest OSS investigation agent | Relies on *your* hand-curated runbooks (it doesn't learn); RunLore is what-changed-first and **learns in the open** |
+| [**kagent**](https://github.com/kagent-dev/kagent) | A generic in-cluster agent *framework* — now with agent *memory* | A focused SRE agent whose knowledge is **open & reviewable**, not opaque per-agent vectors (RunLore can run *on* kagent later) |
 
 RunLore is **GitOps-engine-agnostic** (Flux + Argo CD), **metrics-backend-agnostic** (VictoriaMetrics +
-Prometheus), with **pluggable** logs and **CNI-agnostic network** signals — and the only one that learns
-into an **open** [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) catalog you own.
+Prometheus), with **pluggable** logs and **CNI-agnostic network** signals — and the only one that compounds
+incidents into an **open, reviewable catalog you own**: portable markdown
+([OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible), not a proprietary store.
+
+> **Who it's for** — teams who run **GitOps** (Flux/Argo CD), want their incident knowledge **portable and
+> self-hosted** (data-residency, cost, no lock-in), and would rather an agent say *"I don't know"* than
+> guess. If that's not you, [HolmesGPT](https://github.com/HolmesGPT/holmesgpt) or a commercial SaaS may
+> fit better — and we'll say so.
 
 ## Get started
 
@@ -136,6 +146,12 @@ lore investigate --alert HarborProbeFailure --namespace apps --config runlore.ya
 - **Read-only by default, with an autonomy ladder when you want it** — `off` → `suggest` → `approve`
   (human-gated) → `auto`. Every rung above read-only is reversible-only, envelope-bounded, audited, and
   kill-switchable (see [`docs/design.md`](docs/design.md)).
+- **Honest about the sub-50% reality** — independent benchmarks ([ITBench](https://arxiv.org/abs/2502.05352))
+  show frontier models identify the root cause less than half the time (and fully resolve far fewer).
+  RunLore treats that as the baseline:
+  `unresolved` is a first-class output, an adversarial *verify* pass can only ever **lower** a finding's
+  confidence (never invent one), and every claim is measured by a **shipped eval harness** — not asserted
+  in marketing.
 - **Backend-agnostic & pluggable** — Flux + Argo CD; VictoriaMetrics + Prometheus; pluggable logs;
   **CNI-agnostic** network signals (Cilium Hubble, AWS VPC Flow Logs, or GCP Firewall Logs — see
   [data sources](docs/data-sources.md)).

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ next time gets an instant answer — no fresh investigation.
 > **Note:** RunLore is read-only by default — it never mutates your cluster. An autonomy ladder
 > (suggest → approve → auto) is on the roadmap for teams that want to go further.
 
+**Who it's for** — teams on **GitOps** (Flux/Argo CD) who want their incident knowledge **portable and
+self-hosted** (no lock-in, your models, your data), and would rather an agent say *"I don't know"* than guess.
+
 ## See it in action
 
 A real RunLore investigation delivered to Slack: confidence-scored root cause, the evidence trail,
@@ -125,9 +128,13 @@ hack/e2e-k3d.sh
 | [**kagent**](https://github.com/kagent-dev/kagent) | A generic in-cluster agent *framework* | A focused, opinionated SRE agent (RunLore can run *on* kagent later) |
 
 RunLore is **GitOps-engine-agnostic** (Flux + Argo CD), **metrics-backend-agnostic**
-(VictoriaMetrics + Prometheus), with pluggable logs and CNI-agnostic network signals — and the only
-OSS agent that learns into an **open** [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
-catalog you own.
+(VictoriaMetrics + Prometheus), with pluggable logs and CNI-agnostic network signals. Change-aware RCA
+isn't unique — commercial tools (Komodor, Anyshift) diff changes too ([prior art](docs/prior-art.md)) —
+so the wedge is the **combination the open tools don't have**: that signal feeding an **open, portable
+catalog you own** ([OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible markdown,
+not a proprietary store), from an agent that's **honest about the sub-50% reality** — `unresolved` is a
+first-class answer, an adversarial *verify* pass can only ever lower a finding's confidence, and every
+claim is checked by a shipped eval harness.
 
 ## Docs
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -49,14 +49,17 @@ See [`prior-art.md`](prior-art.md) for the full landscape. The short version:
 
 | Capability | OSS today | Commercial today | RunLore |
 |---|---|---|---|
-| Autonomous react → investigate → report | **HolmesGPT**; k8sgpt-operator/kagent partial | the whole market's commodity | **table stakes** (we do it too) |
-| GitOps-/metrics-**agnostic** + "what-changed" Git-diff spine | nobody (all Prom/Loki/vanilla-k8s) | nobody | **differentiating wedge** |
-| Self-filling, *learning*, **open** knowledge catalog | effectively nobody | Cleric/Resolve/PagerDuty/Google — all **closed** | **the moat** |
+| Autonomous react → investigate → report | **HolmesGPT** (CNCF); k8sgpt-operator/kagent partial | the whole market's commodity | **table stakes** (we do it too) |
+| "What-changed" Git-diff RCA, GitOps-/metrics-**agnostic** | effectively nobody (OSS is Prom/Loki/vanilla-k8s) | **Komodor**, **Anyshift** do change-diff RCA | **sharp, but copyable** — *provenance* for the catalog, not the moat |
+| **Open, reviewable, outcome-weighted** knowledge catalog | nobody (HolmesGPT doesn't learn; kagent's memory is opaque) | Cleric/Resolve/PagerDuty/Google — all **closed** | **the durable wedge** |
+| Honest about the sub-50% reality (read-only-first, `unresolved`, eval-proven) | partial | mostly autonomy-theatre | **the under-sold asset** |
 
-The autonomous runtime is a commodity — if that were all RunLore is, it would be "HolmesGPT, but Go
-+ GitOps." The **open, compounding knowledge catalog** is the part that is closed-source-only
-everywhere and absent from OSS. That, plus being **GitOps-engine- and metrics-backend-agnostic**, is
-the reason to build it.
+The autonomous runtime is a commodity, and the Git diff — though sharp — is now matched by Komodor and
+Anyshift (see [`prior-art.md`](prior-art.md)). The defensible reason to build RunLore is the
+**combination the open tools don't have**: an **open, portable, PR-reviewed knowledge catalog** that
+**learns from outcomes** (HolmesGPT doesn't learn; kagent's memory is opaque), grounded in the **exact
+GitOps change**, from an agent that is **honest about what it can't determine** — all **self-hosted, on
+your models**. Target user: lock-in-averse, sovereignty-conscious, GitOps-native teams.
 
 ## 3. Goals / Non-goals
 
@@ -325,6 +328,12 @@ git diff*:
 | failure (React) | `Ready=False`, source `FetchFailed` | `health=Degraded`, `sync=OutOfSync` |
 | the diff | go-git between revisions over `spec.path` | go-git over `source.path` (Argo also has native `app diff`) |
 
+> **Engine depth is honest, not symmetric.** Flux is the reference implementation. The deep
+> introspection tools (`flux_status`, `flux_tree`) and the failure-persistence re-check use a Flux-only
+> `GitOpsInspector`; on ArgoCD they no-op — Argo gets revision history, the diff, and failure detection,
+> but not the deep tree/status lens. Likewise **action-approval (rung-2) is Slack-only** today; Matrix
+> is delivery-only. Both are honest current states, not full parity.
+
 **Auto-discovery**: detect `argoproj.io/Application` → ArgoCD; `helm.toolkit.fluxcd.io` → Flux; probe
 the metrics endpoint → VM vs Prometheus. Config overrides. Flux + VictoriaMetrics is the primary
 reference combo; Argo + Prometheus exercises the abstraction.
@@ -360,7 +369,10 @@ KB git repo  ──syncer──►  local mirror  ──build──►  index:  
   namespace are validated **server-side** (`internal/action`) — derived from the op, never trusted
   from model output — and an unknown op or out-of-allowlist target is refused. No cluster-mutating MCP
   tools are wired. The alert webhook is authenticated (required under `auto`), and the kill-switch
-  **fails closed on cold start** (auto starts paused until an authenticated resume).
+  **fails closed on cold start** (auto starts paused until an authenticated resume). *Note:* the
+  kill-switch resume and the rate-limit window are **in-memory** — a restart/failover re-pauses (safe)
+  but loses an operator's resume and resets the rate-limit counter; back them with a PVC if resume/budget
+  must survive a restart.
 - **The Curator is cluster-read-only** — its "writes" are markdown-to-git via reviewed PR + issues,
   never the cluster. Cluster mutations come only from the gated action executor above.
 - **Scoped identity.** In-cluster, the agent runs under a least-privilege, read-mostly identity
@@ -370,9 +382,15 @@ KB git repo  ──syncer──►  local mirror  ──build──►  index:  
   (which can carry secrets/PII) only from the Flux controllers, so `pods/log` is granted as a
   **namespaced** Role over `rbac.controllerLogNamespaces` (default `flux-system`) — never cluster-wide.
   Cluster-wide `pods`/`events` *get/list* (pod status + event messages, not log bodies) stays in the
-  ClusterRole because `pod_status`/`kube_events` triage arbitrary incident namespaces. Redacting
-  secrets that still surface via those status/event messages — and via the flux-system log bodies —
-  is the complementary, redaction-side mitigation (roadmap R19).
+  ClusterRole because `pod_status`/`kube_events` triage arbitrary incident namespaces.
+
+> [!warning] Known limitation — no content redaction yet (roadmap R19)
+> Tool output (logs, git diffs, status/event messages) currently reaches the **model provider**
+> verbatim, and model-quoted evidence is copied into the **KB pull-request body** and **chat** — so a
+> secret in a log line or manifest can egress to your LLM vendor and, if the KB repo is public, further.
+> Mitigated today by the RBAC scoping above and by **self-hosting the model** (in-cluster vLLM/Ollama
+> keeps data in-boundary); the planned fix is a scrub pass on tool output and on curated/notified
+> evidence. If you run untrusted-tenant namespaces or a public KB repo, treat this as a gating concern.
 - **Append-only, tamper-evident audit log** (`internal/audit`): every action attempt — inputs, gate
   results, op, target, actor, outcome — is a hash-chained JSON line, so edits/deletions are detectable.
 - **Honest uncertainty.** `unresolved` is a first-class output field; the agent says what it doesn't

--- a/docs/plans/2026-06-25-review-roadmap.md
+++ b/docs/plans/2026-06-25-review-roadmap.md
@@ -1,0 +1,264 @@
+# RunLore — Review & Roadmap (2026-06-25)
+
+> Max-effort external review of RunLore, commissioned by the author. This document
+> **sequences a 5-step review** and tracks findings. Step 1 (positioning) is complete and
+> summarized here; Steps 2–5 are scoped with method + seeded findings, ready to execute.
+>
+> **Grounding:** current `main` @ `a8a9bf4`, cross-checked against code at `file:line`. The
+> internal review note dated 2026-06-24 is **partly stale** (audit log + webhook auth have
+> since landed) and is *not* relied upon — every claim below is re-verified against current code.
+>
+> **Priority key:** **P0** blocks credibility/safety · **P1** important · **P2** nice-to-have.
+
+---
+
+## Step 1 — Alternatives & positioning  ✅ **DONE**
+
+Full analysis delivered separately. Conclusions that become work items:
+
+### Verdict
+The engineering is **real** (verified at `file:line`): the go-git what-changed spine, the closed
+learning loop, server-side safety derivation, hash-chained audit, adversarial verify. But the
+**positioning oversells defensibility**:
+
+- **Differentiator #1 — "what-changed Git diff" is *not* unique.** Komodor ships manifest-diff-for-RCA
+  with Argo/Flux today (Gartner-recognized, $90M raised); Anyshift narrates "what changed" over a
+  git-versioned infra graph; Datadog Change Tracking does commit-level correlation. RunLore's genuinely
+  *owned* slice is narrow: **rendered-manifest diff between the two commits Flux/Argo actually reconciled,
+  as the primary RCA spine.** Real, sharp, but copyable in ~a quarter. It is a *feature*, not a moat.
+- **Differentiator #2 — open, reviewable, outcome-weighted knowledge — is the stronger, genuine
+  whitespace.** Verified: HolmesGPT still does **not** learn (through v0.33.0, Jun 2026); kagent's memory
+  is **opaque** (view-only pgvector, no export, no per-entry edit, per-agent-isolated); commercial
+  "memory" is closed. *But:* the moat is **values-segment + human-bottlenecked + earned over time**, not
+  architectural — and the **OKF bet is fragile** (OKF is a 2-week-old Google **v0.1 draft**, ~0 production
+  adoption, not donated to CNCF).
+- **The most under-used asset is the honesty/eval/read-only posture** — uniquely well-aligned to the
+  category's credibility crisis (Gartner "Peak of Inflated Expectations"; ITBench ~13.8% resolution).
+
+### Repositioning actions
+- **P1 · POS-1** — Lead messaging with **open/reviewable/portable + outcome-weighted knowledge** and the
+  **honesty/eval posture**; demote the Git-diff to "the *provenance source* that makes the knowledge
+  high-quality," not a standalone wedge.
+- **P1 · POS-2** — **Stop claiming the Git diff "exists nowhere else"** (`docs/prior-art.md`, README "Why
+  RunLore"). Name Komodor/Anyshift/Datadog honestly and draw the *narrow* true line.
+- **P1 · POS-3** — **De-risk the OKF dependency.** Lean on the *concept* (git-versioned, PR-reviewed,
+  outcome-decayed knowledge — which is genuinely unique), not on OKF being a "standard." Treat OKF
+  compliance as a nice-to-have interop format, reversible if it stalls.
+- **P2 · POS-4** — Evaluate **alignment over competition**: contribute a "what-changed" toolset to
+  HolmesGPT, run *on* kagent (A2A), or be a reference OKF writer-back — turning "compete with CNCF
+  incumbents" into "be the GitOps + open-knowledge layer they don't build."
+- **P2 · POS-5** — Name the **ICP** explicitly: lock-in-averse, sovereignty-conscious, self-hosting,
+  GitOps-native platform teams (Flux/Argo + VM/Prom). Underserved and growing (EU-sovereign tailwind),
+  but narrow — own it deliberately.
+
+### Ranked threats (track, don't fix)
+1. **HolmesGPT adds change-diff + OKF write-back** — CNCF reach + MCP + existing Git toolsets ⇒ could
+   erase *both* differentiators. Highest impact.
+2. **Komodor** owns change-aware RCA commercially.
+3. **Anyshift** owns the "what-changed" narrative (versioned infra graph).
+4. **Google** could commoditize OKF into Gemini Cloud Assist.
+5. **Single-maintainer sustainability** vs CNCF-backed incumbents (structural, not technical).
+
+---
+
+## Step 2 — Feature ↔ intent audit  ✅ **DONE**
+
+**Goal.** For each shipped feature, decide: *serves the core intent* (React → Investigate → Learn,
+what-changed-first, open knowledge, read-only-first, honest about sub-50%) · *table-stakes parity*
+(keep but freeze) · or *scope-creep* (defer to protect focus). The breadth (2 GitOps engines, 2 metrics
+backends, 3 model providers, Slack+Matrix, cloud, 3 network providers, autonomy ladder, eval, HA) is
+impressive for a 5-day-old solo project but **dilutes the wedge and multiplies maintenance** — this step
+decides what to double down on vs freeze.
+
+**Method.** Walk `internal/` package-by-package; map each to a stated goal in `design.md §3`; tag
+`core | parity-freeze | defer`; flag any feature with no intent anchor.
+
+**Inventory to score:** trigger policy · GitOps-failure watch · what-changed spine · no-change
+hypotheses · instant recall · adversarial verify · output contract · curator PR/Issue · outcome
+ledger + decay · curate grooming (queue/recurrence) · autonomy ladder (off/suggest/approve/auto) ·
+providers ×8 · eval harness · observability · HA leader election.
+
+### Findings
+**Verdict: high intent-discipline — near-zero capability scope-creep.** Every package is wired and maps
+to a goal; all 8 backend impls are real (0 stubs); models at genuine parity. The mismatches:
+
+- **P1 · FEAT-1 — the `auto` rung is the one genuine intent mismatch.** It contradicts the stated
+  non-goal ("unattended prod remediation"), carries ~13 config fields + the audit subsystem for a
+  paused/off capability, and is the *sole* reason the prompt-injection→cluster-mutation threat chain
+  exists. It is, however, the most defensively-built code in the repo (fails closed, reversible-only,
+  ns-denied, server-derived envelope, authenticated, audited). **Recommendation:** freeze `auto` as
+  explicitly experimental (no further investment) and weigh removing the executable path entirely —
+  `approve` delivers ~95% of the value at a fraction of the attack surface. **Decision for the author.**
+- **P1 · FEAT-2 — "backend-agnostic" is overstated.** ArgoCD has no `GitOpsInspector` (deep tools no-op
+  on Argo); Matrix has no action-approval (rung-2 = Slack only). Either invest to parity or, preferred
+  for single-maintainer focus, **document honestly** ("Flux-first; Argo basic; approvals via Slack") → Step 4.
+- **P2 · FEAT-3 — doc/impl drift.** No "hypothesis ranker" module exists (prompt-only). 3 dead config
+  keys (`ActionPolicy.RequireApproval`, `Telemetry.OTLPEndpoint`, `GitHubApp.PrivateKeyRef`) → Step 4 docs
+  + Step 5 removal. (`GitHubApp.PrivateKeyRef` dead == the differ-auth P0 plumbing is missing.)
+- **P2 · FEAT-4 — maintenance weight is concentrated** (~110–140 config keys). Trimming dead keys + (if
+  frozen) the `auto` surface is a real simplification → Step 5.
+- **Keep & market harder:** the full Learn loop (the moat), model-agnosticism, and the **eval harness**
+  (under-sold honesty asset). Observability is correctly self-health-scoped (respects the non-goal).
+
+Status: **complete.**
+
+---
+
+## Step 3 — Issues: security / Go / performance / cost  ✅ **DONE**
+
+18 findings across 3 audits + 2 earlier-confirmed gaps, de-duped. **Fundamentals are sound** (auth,
+action gate, leader-election lifecycle, audit log) — see "Refuted/solid". Issues cluster in three
+places: the headline feature is half-wired (P0), the data-egress path lacks redaction (P1), and the
+**interruption/churn paths** (leader flap · SIGTERM · interrupted clone · crash) need hardening — the
+highest-leverage work, since those are the events an HA tool exists for.
+
+#### P0 — fix first
+- **AUTH-1 (Sec/Correctness)** — GitHub App token not plumbed into the production differ
+  (`cmd/lore/main.go:1423` builds `&whatchanged.Differ{}` empty; token source `forge/github/auth.go:20`;
+  `GitHubApp.PrivateKeyRef` is a dead key). **Private-repo what-changed is silently unauthenticated** —
+  the headline feature broken for the common case. *Fix:* wire the App token into `buildGitOps`'s differ.
+
+#### P1
+- **SEC-F1 (Sec)** — No content-redaction layer. Raw logs/diffs → LLM (`investigate/loop.go:332`);
+  model-quoted `Evidence` → KB PR body (`curator/draft.go:30`, `forge/github/github.go:109`, public-capable)
+  + chat; secret names/keys leak via pod-status (`cluster.go:111`). **Top priority for the data-residency
+  ICP**; already roadmapped as R19 — promote. *Fix:* scrub tool output pre-prompt + Evidence/Body pre-forge/notify.
+- **COST-C1 (Cost)** — No prompt caching (`anthropic.go:104`, `loop.go:230`): system+schemas+history
+  re-sent uncached every step (≤20). *Fix:* `cache_control: ephemeral` on the static prefix → 50–90%
+  input-cost cut. Biggest lever, smallest change.
+- **COST-C4 (Cost)** — $-ceilings ship OFF: `max_tokens_per_investigation`, `max_tool_output_bytes`
+  (`config.go:138`), `rate_limit.max_per_window`, storm-`coalesce` (`values.yaml:50,57`) all default
+  0/disabled. *Fix:* sane non-zero defaults + `coalesce.enabled: true`.
+- **GO-P1A (Go)** — Leader-flap stampede: GitOps-failure informer initial-LIST re-fires every Ready=False
+  workload as a *new* failure each re-acquire; `trigger.Deduper` is per-term (`flux/dynamic.go:211`,
+  `main.go:1386`). *Fix:* hoist Deduper to process scope, or seed-skip the initial sync.
+- **GO-P1B (Go)** — No graceful drain: `ShutDown()` not `ShutDownWithDrain()`, no worker join
+  (`investigate.go:193`, `main.go:287`). SIGTERM kills in-flight work → lost ledger `open`; in `auto`,
+  possible silent un-notified mutation. *Fix:* drain + WaitGroup join < `terminationGracePeriodSeconds`.
+- **PERSIST-1 (Sec/Go)** — kill-switch resume + rate-limit in-memory (`action/auto.go`,
+  `ratelimit/window.go`); fails closed (good) but resume lost + counter resets; `design.md §9` /
+  `learning-loop.md §4` imply persistence (drift). *Fix:* persist to PVC (ledger/audit already do), or fix docs.
+
+#### P2
+- **SEC-F2 (Sec)** — Model controls `Target.Name`, gate never validates it (`investigate/tools.go:178`,
+  `action/policy.go:88`) → injection steers *which* named resource in an allowed ns is suspended (bounded:
+  reversible, allowed-ns). *Fix:* require target to match a read-tool-surfaced resource.
+- **SEC-F3 (Sec)** — `runlore_reject` not approver-gated (`server.go:283`) → any valid Slack user can
+  cancel a pending remediation. *Fix:* same approver allowlist as approve.
+- **COST-C2 (Cost)** — Verify always-on, hardcoded, same expensive model (`loop.go:319`, `verify.go:67`).
+  *Fix:* configurable + cheaper judge model (`buildJudgeModel` plumbing exists).
+- **CLONE-1 (Cost/Perf/Sec; =C3+F5)** — Full clone per change, no cache (`whatchanged/differ.go:138`):
+  K clones/monorepo (latency) + disk-DoS. *Fix:* `Depth:1`/`SingleBranch` + per-investigation clone cache + cleanup.
+- **GO-P2A (Go)** — Interrupted catalog clone wedges syncer *permanently* (`catalog/sync.go:64`): partial
+  `.git` → Pull branch errors forever. *Fix:* temp-dir+rename, or `RemoveAll` before re-clone.
+- **GO-P2B (Go)** — Outcome ledger never fsyncs (`outcome/ledger.go:126`; audit does) → crash loses tail
+  → decay signal under-counts. *Fix:* `f.Sync()` in `appendLocked`.
+- **GO-P2C (Go)** — `Reload` failure advances `lastRev` (`catalog/sync.go:98`) → transient re-index
+  failure sticks catalog on old index. *Fix:* advance `lastRev` only after successful re-index.
+
+#### P3 — polish
+Guessable approval IDs (`approvals.go:62` → `crypto/rand`) · no `CheckRedirect` + `networkPolicy.strict:false`
+default (block link-local on redirect; strict+CIDRs in prod) · Slack decodes possibly-empty 2xx body →
+false failure (`slack.go:98`) · discarded `io.ReadAll` error in anthropic/gemini (`anthropic.go:128`) →
+wrap like openai · `auto.reserve()` leaks a rate slot if a pause lands in the reserve→exec window.
+
+#### Refuted / solid — do NOT spend effort here
+- **Refuted:** "Approve() TOCTOU" (claim-then-execute under one lock — safe); "workqueue dead after
+  re-acquire" (restarts correctly; bug is the *opposite* — P1-A over-fires); 156 MB binary (gitignored,
+  not in history).
+- **Solid:** server-authoritative action gate (discards model-supplied safety, re-validated at exec,
+  fail-closed kill-switch); auth (constant-time, replay window, approver + `response_url` SSRF allowlists);
+  least-privilege RBAC; untrusted text wrapped in an explicit "UNTRUSTED DATA" delimiter; atomic catalog
+  index swap; audit hash-chain.
+- **Leave as-is (intentional):** single serialized worker (caps concurrent LLM loops at 1× — core
+  cost-safety property); coalesced-but-uncapped queue (bounded by distinct alert identities); catalog-in-RAM.
+
+Status: **complete.**
+
+---
+
+## Step 4 — Docs: comprehensive, pretty, not verbose  ✅ **DONE (core); diagram + deep de-dup deferred**
+
+**Goal.** Comprehensive **and tight** — one source of truth per topic; claims aligned with Step 1.
+
+**Findings already evident:**
+- Docs are **extensive and high-quality but verbose and overlapping** — README, `design.md`, and
+  `learning-loop.md` re-explain the learning loop three times. Establish a single canonical home per
+  concept and cross-link.
+- **`prior-art.md` is partly stale** — predates Komodor/Anyshift/Azure-SRE-GA framing and the OKF-v0.1
+  reality. Reconcile with Step 1 (this is also POS-2).
+- **Overclaiming language** ("exists nowhere else", "the moat") must soften per Step 1.
+- **No architecture diagram.** Add a `draw.io` diagram under `docs/architecture/` (per house style) and
+  cite it from README/design as the source of truth.
+
+**Targets:** trim README to a scannable landing page; de-dupe design↔learning-loop; fix doc/impl drift
+(persistence); refresh prior-art; add the diagram. **Principle:** every paragraph earns its place.
+
+**Done (2026-06-25):** rewrote `prior-art.md` (current + honest — Komodor/Anyshift/Azure-GA, HolmesGPT-CNCF,
+kagent-opaque-memory, OKF-v0.1, market froth; reframed "where different" per Step 1); softened `design.md §2`
+positioning (dropped "nobody"/"the moat"; led with the open catalog + honesty); added honest **ArgoCD-depth +
+Matrix-approval** notes (`design.md §7`); promoted **redaction (R19)** from a footnote to a stated **Known
+limitation** callout covering the full egress path (`design.md §9`); added **kill-switch/rate-limit in-memory**
+precision (`design.md §9`). README already repositioned (Step 1). *Left `learning-loop.md:207` intact — its
+persistence claim is about the ledger/audit (PVC-backable), which is accurate.*
+
+**Deferred (offered):** (1) a `docs/architecture/*.drawio` diagram (house style) — bigger artifact, confirm
+scope; (2) the deep README↔`design.md`↔`learning-loop.md` de-duplication — these are good, author-voiced docs,
+so a structural trim is a separate opt-in pass, not a unilateral gut. Status: **core complete.**
+
+---
+
+## Step 5 — Improvements: sequenced plan  ✅ **DONE (plan)**
+
+Everything from Steps 1–4, grouped into 5 milestones, sized (**XS** <½d · **S** ~1d · **M** ~2–3d ·
+**L** ~1wk) and ordered. Two items are **decisions** (🧭), not code. IDs trace to earlier steps.
+
+### M0 — Make the headline true & cheap out-of-the-box · *do first · ~2–3d*
+A fresh `helm install` today has the core feature half-broken and no cost ceiling. Smallest diffs, biggest payoff.
+| Item | What | Size |
+|---|---|---|
+| **AUTH-1** (P0) ✅ | **Done** (`fee6968`, branch `fix/differ-github-app-auth`): `Differ` holds a per-clone `TokenSource`, wired from the shared App token in `buildGitOps`; fail-loud on mint error; tests + lint clean. Unblocked private-repo what-changed — the wedge. | **S** |
+| **C1** (P1) ✅ | **Done** (`d822498`): `cache_control: ephemeral` on the system block + last tool (GA, no beta header — verified vs API docs); savings surface as reduced `input_tokens`. | **S** |
+| **C4** (P1) ✅ | **Done** (`a5e6e5e`): chart ships bounded defaults (coalesce on · rate 20/window · tokens 100k · output 32KB); Go `0=unlimited` preserved so operators can opt out. helm lint clean. | **S** |
+| **C2** (P2) ✅ | **Done** (`8c6d463`): optional `model.verify` override (inherits parent fields) routes the verify pass to a cheaper model; verify stays mandatory. | **S** |
+
+### M1 — Harden the churn paths · *~3–4d · highest-leverage correctness*
+For an HA tool, leader-flap / SIGTERM / interrupted-clone / crash are the events it exists for — today lossy & noisy.
+| Item | What | Size |
+|---|---|---|
+| **GO-P1A** (P1) ✅ | **Done** (`e3419c5`): deduper hoisted to process scope, survives leader flaps; cross-term test. | **M** |
+| **GO-P1B** (P1) 🔶 | **Deferred — needs focused design.** A safe graceful drain must keep the in-flight investigation's context alive past SIGTERM *and* hold the leader lease through the drain (else a draining leader split-brains with a new one in `auto` mode). Decouples work-lifetime from the SIGTERM signal + a queue drain handshake — a delicate change to the *verified-correct* HA path; own PR + churn/drain/timeout tests. | **M** |
+| **GO-P2A** (P2) ✅ | **Done** (`99af960`): re-clone a corrupt mirror; drop a partial clone on failure. | **S** |
+| **GO-P2B** (P2) ✅ | **Done** (`99af960`): ledger fsyncs each append. | **XS** |
+| **GO-P2C** (P2) ✅ | **Done** (`99af960`): roll back `lastRev` on re-index failure → retried next tick. | **XS** |
+| **PERSIST-1** 🧭 | Persist kill-switch/rate-limit to PVC **or** stay doc-only (Step 4 clarified the docs → default doc-only unless resume must survive restart). | **S / 0** |
+
+### M2 — Close the data-egress gap · *~4–6d · top security work, ICP-critical*
+| Item | What | Size |
+|---|---|---|
+| **F1 / R19** (P1) | Content-redaction scrub: tool output → prompt, and evidence → KB PR + chat. Biggest security win; start early (long pole). | **L** |
+| **F2** (P2) | Validate action `Target.Name` against read-tool-surfaced resources (closes the injection residual). | **S–M** |
+| **F3** (P2) | Approver-gate the `runlore_reject` path. | **XS** |
+| **CLONE-1** (P2) | Shallow clone (`Depth:1`/`SingleBranch`) + per-investigation clone cache + cleanup. Also a perf/disk-DoS win. | **M** |
+| **P3 bundle** | crypto-rand approval IDs · `CheckRedirect`+`strict:true` egress · Slack empty-2xx · wrap ReadAll errors · reserve-after-pause. | **S** |
+
+### M3 — Focus & positioning decisions · *mostly decisions + small trims*
+| Item | What | Size |
+|---|---|---|
+| **FEAT-1** 🧭 | **Freeze or remove the `auto` rung.** Recommend freezing as experimental (or dropping the executable path): it contradicts the no-unattended-remediation non-goal and is the sole reason the injection→mutation surface exists; `approve` keeps ~95% of value. If removed → shed ~13 config keys + the biggest attack surface. | 🧭 / **M** |
+| **FEAT-3/4** | Remove 3 dead config keys (`ActionPolicy.RequireApproval`, `Telemetry.OTLPEndpoint`, `GitHubApp.PrivateKeyRef`); trim config if `auto` is frozen. | **S** |
+| **POS-4** 🧭 | Strategic-alignment spike: contribute a what-changed toolset to HolmesGPT / run-on-kagent (A2A) / OKF reference writer-back — turn the biggest threat into a channel. | **spike** |
+| **FEAT-2** 🧭 | ArgoCD Inspector parity — *only if* Argo demand appears; else the Step-4 honest-docs path stands. | **M / 0** |
+| Docs deferred | `docs/architecture/*.drawio` diagram; deep README↔design↔learning-loop de-dup. | **M** |
+
+### M4 — The one real capability gain · *~M · improves the moat*
+| Item | What | Size |
+|---|---|---|
+| **Hybrid BM25 + embeddings recall** | `chromem-go` behind the `catalog.Searcher` interface; embeddings via the OpenAI-compatible endpoint. Fixes lexical brittleness — the one genuine retrieval gap — no Python, still single-binary. | **M** |
+
+### Execution order
+**Now:** M0 (AUTH-1 → C1 → C4 → C2) + kick off **F1** (the long pole). → **Next:** M1 churn hardening. →
+**Then:** finish M2 (F2 / F3 / CLONE-1 / P3). → **Decisions in parallel:** FEAT-1 (`auto`), POS-4, PERSIST-1. →
+**Later:** M4 hybrid recall, M3 docs polish, FEAT-2 (only on demand).
+
+> Living doc — promote items as they land. **The review (Steps 1–5) is complete; this is the standing backlog.**

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -1,50 +1,70 @@
 # Prior art & positioning
 
-Where RunLore sits relative to the open-source and commercial AI-SRE landscape (mid-2026). This is
-the honest version: the autonomous "alert → RCA → Slack" runtime is a **commodity**; RunLore's reason
-to exist is the combination of **GitOps-/metrics-agnostic** + **what-changed Git-diff spine** +
-**open, learning knowledge catalog**.
+Where RunLore sits in the AI-SRE landscape (mid-2026). The honest version: the autonomous
+"alert → RCA → Slack" runtime is a **commodity**, and change-diff RCA is **no longer unique**. RunLore's
+defensible reason to exist is the **combination** the open tools don't have — an **open, reviewable,
+outcome-weighted** knowledge catalog, grounded in the **exact GitOps change**, from an agent that is
+**honest about the sub-50% reality** — all self-hostable.
 
 ## Open source
 
-| Project | What it is | Overlap with RunLore | What we borrow |
+| Project | What it is | Learns? | vs RunLore |
 |---|---|---|---|
-| **k8sgpt** (CNCF) | Deterministic *analyzers* + optional LLM explanation; operator does continuous scan → `Result` CRD + Slack sinks. Strictly read-only. | Shallow on investigation (single-shot `analyze`, no loop, no cross-signal correlation, no Git diff). | The **analyzer-first** idea: cheap deterministic detectors before the LLM; `Result`-as-CRD; pluggable backends; anonymization. |
-| **HolmesGPT** (CNCF, Robusta) | The strongest OSS reference: a ReAct loop over 50+ **toolsets**, **runbooks**, and an **MCP client**; autonomous alert→RCA→Slack via the Robusta platform. | **Heavy** — this is the closest thing to RunLore's runtime. But it is Prom/Loki/Datadog-centric, has no Flux-revision-aware Git diffing, and relies on *your* hand-curated runbooks (it does not learn). | The **toolset abstraction**, **runbook format**, ReAct + payload discipline, read-only-by-default posture. |
-| **kagent** (CNCF, Solo.io) | In-cluster *declarative* agent framework (agents as CRDs, MCP + A2A, Google ADK engine). Now ships **agent memory** (pgvector similarity recall) and HITL gated writes (`requireApproval`). | The in-cluster reactive-agent runtime; generic, Prom/Grafana-centric, pre-1.0. Its memory is **opaque, per-agent, in-DB** — the closed/unreviewable "memory" pattern, self-hosted. | The declarative/GitOps-native packaging idea; could be a deployment target via A2A later. |
-| **Aurora** | OSS AI-SRE with hybrid RAG over runbooks/postmortems. | The RAG/learning angle. | Hybrid retrieval (BM25 + vector) as table stakes for grounding. |
+| [**HolmesGPT**](https://github.com/HolmesGPT/holmesgpt) (CNCF Sandbox, Robusta) | Strongest OSS ReAct agent: 60+ toolsets, runbooks, MCP client; read-only. | **No** — stateless, human-authored runbooks. | The one to beat. But Prom/Loki-centric, no Flux/Argo revision-diff, no learning. We borrow its toolset + runbook discipline. |
+| [**k8sgpt**](https://github.com/k8sgpt-ai/k8sgpt) (CNCF) | Deterministic analyzers + optional LLM-explain. | No | A *detector*, not an investigation loop. We borrow analyzer-first + `Result`-as-CRD. |
+| [**kagent**](https://github.com/kagent-dev/kagent) (CNCF Sandbox, Solo.io) | Declarative in-cluster agent framework; ships pgvector **agent memory** + `requireApproval` HITL. | Memory, but **opaque** — view-only vectors, no export/edit, per-agent. | Closest on "memory" — but closed-shape. RunLore's knowledge is open, reviewable, portable. Possible deploy target via A2A. |
+| **Aurora** (Arvo AI) | Hybrid RAG over docs; auto-generates postmortems. | Postmortems, not runbook self-update. | The RAG angle. We borrow hybrid retrieval. |
 
-**Takeaway:** the loop and the runtime are solved in OSS, and kagent now ships (opaque, in-DB) memory —
-so "nobody in OSS learns" is no longer the line. The precise, still-true distinction: **nobody in OSS
-auto-fills an *open, human-readable, git-versioned, PR-reviewed* knowledge catalog — with provenance —
-from its own investigations.** Reviewability and portability, not learning-vs-not, are the moat.
+**Takeaway:** no OSS agent auto-fills an **open, git-versioned, PR-reviewed, outcome-weighted** catalog
+from its own investigations. *Reviewability + portability* — not learning-vs-not — are the distinction.
+
+## Change-aware RCA — no longer ours alone
+
+"What changed" is the #1 RCA lever, and others now ship it:
+
+- **Komodor** — workload-scoped **manifest-diff RCA** with Argo CD/Flux integration; Gartner 2026
+  "Representative Vendor". The closest commercial analogue to our diff spine.
+- **Anyshift** (ex-driftctl) — GraphRAG RCA over a **git-versioned infrastructure graph**; owns the
+  "what changed" narrative.
+- **Datadog Change Tracking** — commit-level deploy correlation (no file-level source diff).
+
+RunLore's genuinely-owned slice is narrow: the **rendered diff between the two commits Flux/Argo
+actually reconciled**, scoped to the failing workload, as the *primary* RCA spine. It is a sharp
+feature, not a moat — treat it as **provenance for the knowledge**, not the headline.
 
 ## Commercial
 
-The market has converged on one shape — *live model of prod → agentic RCA → evidence in Slack* — and
-competes on **autonomy ceiling**, **RCA depth**, and **provable eval/trust**, not features. The
-shipped default everywhere is **read-only RCA + suggest-with-approval**; only Microsoft's Azure SRE
-Agent natively takes approved write actions at GA.
+Converged on one shape — *live model of prod → agentic RCA → evidence in Slack* — competing on the
+**autonomy ceiling**. The shipped default everywhere is read-only RCA + suggest-with-approval; only
+**Microsoft Azure SRE Agent** (GA, Mar 2026) takes approved writes natively.
 
-- **Specialized**: Cleric, Resolve.ai, Traversal, Parity, NeuBird, Causely, ewake (EU/data-residency),
-  incident.io, Flip AI — all closed.
-- **Incumbents**: Datadog (Bits AI SRE), PagerDuty (SRE Agent), Grafana (Sift/Assistant), Dynatrace
-  (Davis), New Relic, Splunk/Cisco, AWS (DevOps Agent), Google (Gemini Cloud Assist), Elastic,
-  ServiceNow.
-- **Memory / learning** is claimed by Cleric (Decision Model), Resolve (context layer), PagerDuty
-  ("context flywheel"), and Google (AI Insights) — **all closed**.
+- **Specialists:** Cleric, Resolve.ai, Traversal, Parity, NeuBird, Causely, Flip AI, ewake (EU residency).
+- **Incumbents:** Datadog, PagerDuty, Grafana, Dynatrace, New Relic, AWS, Google, ServiceNow.
+- **Memory/learning** (Cleric, Resolve, PagerDuty, Google) is **all closed**.
 
-**The reality check (ITBench, IBM/ICML 2025):** independently, frontier models identify the root
-cause **< 50 %** of the time and *fully resolve* only **~11–14 %** of real K8s incidents. Treat
-sub-50 % as the baseline; design for failure; be skeptical of vendor accuracy claims.
+> [!note] The market is frothy and under scrutiny
+> Resolve.ai raised a $1B-headline Series A (Dec 2025) on ~$4M ARR; Gartner places agentic AI at the
+> "Peak of Inflated Expectations" (>40% of agentic projects predicted cancelled by 2027) and flags
+> "agent-washing." Pressure-test every "autonomous"/"%MTTR" claim against the vendor's own docs.
+
+## The eval reality
+
+**ITBench** (IBM/ICML 2025) — frontier models identify the root cause **< 50%** of the time and fully
+resolve only **~11–14%** of real K8s incidents. Treat sub-50% as the baseline; design for failure; make
+honest uncertainty a feature, not a footnote.
 
 ## Where RunLore is different
 
-1. **GitOps-engine- and metrics-backend-agnostic** (Flux + Argo, VM + Prom) — the stack the OSS
-   incumbents treat as second-class.
-2. **A "what changed" spine** — Flux/Argo revision history + a real **Git diff between deployed
-   revisions**, scoped to the affected workload. Exists nowhere else.
-3. **An open, compounding knowledge catalog** ([OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog))
-   the agent reads (cached) and writes (PR-gated). The closed tools that learn keep the knowledge;
-   RunLore's is portable markdown in *your* git, with provenance linking the issue, the causing
-   change, and the fix.
+1. **Open, reviewable, outcome-weighted knowledge** — portable markdown in *your* git, PR-reviewed,
+   provenance-tracked, with trust that decays on real-world resolve-rate. The closed tools that learn
+   keep the knowledge; the OSS agents don't learn at all.
+2. **Honest by construction** — read-only-first, `unresolved` as a first-class output, an adversarial
+   verify pass that can only *lower* confidence, and a shipped eval harness. The best-aligned response
+   to the sub-50% reality in a market full of autonomy-theatre.
+3. **GitOps-revision-exact "what changed"** — the provenance that makes the knowledge trustworthy.
+4. **Self-hostable & model-agnostic** — for lock-in-averse, sovereignty-conscious, GitOps-native teams.
+
+> **On OKF.** RunLore's catalog is [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible
+> markdown. OKF is a young Google spec (v0.1 draft, mid-2026, no CNCF governance yet); we treat it as a
+> portable interop format, not a settled standard — the value is the open, reviewable, git-versioned
+> shape, which holds regardless of OKF's trajectory.


### PR DESCRIPTION
## Docs from the external review (no code)

Aligns the public framing with what the code actually defends, documents the honest limitations, and records the review + improvement plan. Pairs with the code PRs #114 (M0) and #115 (M1).

### Changes
- **README** — lead with **open/reviewable/portable knowledge** + the **honesty/eval** posture; stop claiming the Git diff is unique (Komodor/Anyshift ship change-diff RCA); treat OKF as a portable interop format, not a settled standard; add a **"Who it's for"** (ICP) note and an explicit **"honest about the sub-50% reality"** design principle.
- **`docs/prior-art.md`** — rewritten for the current (mid-2026) landscape: Komodor, Anyshift, **Azure SRE Agent GA**, HolmesGPT→**CNCF Sandbox** (60+ toolsets, still no learning), kagent's **opaque** memory, **OKF-as-v0.1-draft**, and the frothy-but-scrutinized market.
- **`docs/design.md`** — soften §2 positioning (drop "nobody"/"the moat"); add an honest **"engine depth is not symmetric"** note in §7 (ArgoCD has no Inspector; Matrix is delivery-only / approvals are Slack-only); promote **content redaction (R19)** from a footnote to a stated **Known-limitation** callout, and add **kill-switch/rate-limit in-memory** precision in §9.
- **`docs/plans/2026-06-25-review-roadmap.md`** — the external review + sequenced improvement plan (Steps 1–5; M0/M1 status; deferred items + open decisions).

### Why
The review found the *engineering* strong but the *positioning* over-claiming. These docs make the public story match the code (and honestly name what isn't done yet), which is itself the product's differentiator: being the honest, open option.