### PR TITLE
M2 (part 1): redact secrets before they reach the model (F1)

### DIFF
--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
@@ -189,7 +190,9 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	}
 	specs = append(specs, submitFindingsSpec())
 
-	messages := []providers.Message{{Role: "user", Content: seedPrompt(req)}}
+	// Redact secrets from the (untrusted) incident text before it enters the prompt,
+	// so a secret in an alert annotation/message never reaches the model provider.
+	messages := []providers.Message{{Role: "user", Content: redact.Secrets(seedPrompt(req))}}
 	maxSteps := li.MaxSteps
 	if maxSteps <= 0 {
 		// Enough headroom to query every signal source (gitops/cloud/logs/metrics/
@@ -325,7 +328,12 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				return nil
 			}
 			used[tc.Name]++
-			out, trimmed := truncateOutput(li.runTool(ctx, byName, tc), li.MaxToolOutputBytes)
+			// Redact secrets from tool output (pod/controller logs, git diffs, status/
+			// event messages) BEFORE it enters the prompt: this is the LLM-vendor egress
+			// boundary, and since the model only ever sees redacted text, the evidence it
+			// later quotes into the KB PR + chat is protected too. Redact before truncating
+			// so a secret near the cap is still masked.
+			out, trimmed := truncateOutput(redact.Secrets(li.runTool(ctx, byName, tc)), li.MaxToolOutputBytes)
 			if trimmed > 0 && li.Metrics != nil {
 				li.Metrics.ToolOutputTruncatedBytes.Add(ctx, int64(trimmed))
 			}

--- a/internal/investigate/redact_wiring_test.go
+++ b/internal/investigate/redact_wiring_test.go
@@ -1,0 +1,75 @@
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// recordModel captures the messages of every Complete call, so a test can assert
+// what actually crossed the boundary to the model.
+type recordModel struct {
+	seen      []providers.Message
+	responses []providers.CompletionResponse
+	i         int
+}
+
+func (m *recordModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.seen = append(m.seen, req.Messages...)
+	r := m.responses[m.i]
+	m.i++
+	return r, nil
+}
+
+// leakyTool returns tool output containing secrets, as a real log line / diff might.
+type leakyTool struct{}
+
+func (leakyTool) Name() string        { return "leaky_logs" }
+func (leakyTool) Description() string { return "returns logs" }
+func (leakyTool) Schema() string      { return `{"type":"object","properties":{}}` }
+func (leakyTool) Call(context.Context, string) (string, error) {
+	return "log: password=hunter2horse token ghp_0123456789abcdefghijABCDEFGHIJ0123", nil
+}
+
+// TestLoopRedactsToolOutputBeforeModel verifies tool output is redacted before it
+// reaches the model — secrets in logs/diffs never cross the LLM-vendor boundary,
+// and since the model only sees redacted text, its quoted evidence is clean too (F1).
+func TestLoopRedactsToolOutputBeforeModel(t *testing.T) {
+	model := &recordModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: "leaky_logs", Args: "{}"}}},
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: submitFindingsName, Args: `{"confidence":0.5,"root_causes":[{"summary":"x","confidence":0.5,"evidence":["e"]}]}`}}},
+		{ToolCalls: []providers.ToolCall{{ID: "3", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"keep","confidence":0.5}]}`}}},
+	}}
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{leakyTool{}},
+		MaxSteps:   5,
+		Verify:     true,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	for _, m := range model.seen {
+		if strings.Contains(m.Content, "hunter2horse") || strings.Contains(m.Content, "ghp_0123456789abcdefghijABCDEFGHIJ0123") {
+			t.Fatalf("tool output reached the model with a secret unredacted: %q", m.Content)
+		}
+	}
+	// Sanity: the redacted tool result WAS delivered (the marker is present), so the
+	// assertion above isn't passing simply because the tool result never arrived.
+	var sawRedacted bool
+	for _, m := range model.seen {
+		if strings.Contains(m.Content, "[REDACTED]") {
+			sawRedacted = true
+		}
+	}
+	if !sawRedacted {
+		t.Fatal("expected the redacted tool result to reach the model")
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,58 @@
+// Package redact masks secret-shaped values in free text before it crosses a
+// trust boundary — specifically before tool output (pod/controller logs, git
+// diffs, status/event messages) is fed to the LLM provider, from where the
+// model's quoted evidence would otherwise flow on into a (possibly public) KB
+// pull request and chat. It is deliberately HIGH-PRECISION: it targets clearly
+// secret-shaped tokens and sensitive key=value pairs, masking the *value* while
+// preserving surrounding structure (the key name, the diff line) so the
+// investigation can still reason ("the password field changed") without the
+// secret leaving the boundary. It is not a guarantee — redaction is a mitigation,
+// not a substitute for not logging secrets.
+package redact
+
+import "regexp"
+
+const mask = "[REDACTED]"
+
+type rule struct {
+	re   *regexp.Regexp
+	repl string // may reference ${1}, ${2}
+}
+
+// rules run in order; each is independent and idempotent over already-masked text.
+var rules = []rule{
+	// PEM private key blocks (RSA/EC/OPENSSH/PGP/…).
+	{regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`), "[REDACTED PRIVATE KEY]"},
+	// JWT (header.payload.signature, base64url).
+	{regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`), mask},
+	// GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_).
+	{regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`), mask},
+	// OpenAI / Anthropic-style keys.
+	{regexp.MustCompile(`sk-[A-Za-z0-9_-]{16,}`), mask},
+	// Slack tokens.
+	{regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`), mask},
+	// AWS access key id.
+	{regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`), mask},
+	// Google API key.
+	{regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`), mask},
+	// Credentials in a URL: scheme://user:PASSWORD@host → mask the password.
+	{regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:@/]+:)[^\s@/]+(@)`), `${1}[REDACTED]${2}`},
+	// HTTP auth header tokens — keep the scheme, mask the credential.
+	{regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{12,}`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(basic\s+)[A-Za-z0-9+/=]{8,}`), `${1}[REDACTED]`},
+	// Sensitive key = value / key: value (the value is masked, the key kept). An
+	// env-var-style prefix (DB_SECRET, OPENAI_API_KEY) is allowed before the keyword.
+	{regexp.MustCompile(`(?i)([\w.\-]*(?:password|passwd|secret|api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|token|credentials?|dsn|connection[_-]?string)"?\s*[:=]\s*"?)([^\s"',}]+)`), `${1}[REDACTED]`},
+}
+
+// Secrets masks secret-shaped substrings in s, returning the redacted text.
+// It is safe to call on already-redacted text (idempotent).
+func Secrets(s string) string {
+	if s == "" {
+		return s
+	}
+	for _, r := range rules {
+		s = r.re.ReplaceAllString(s, r.repl)
+	}
+	return s
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,64 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSecretsMasks(t *testing.T) {
+	secret := "AKIAIOSFODNN7EXAMPLE"
+	cases := []struct {
+		name  string
+		in    string
+		gone  string // substring that must NOT survive
+		keeps string // structure that SHOULD survive (optional)
+	}{
+		{"github token", "found ghp_0123456789abcdefghijABCDEFGHIJ0123 here", "ghp_0123456789abcdefghijABCDEFGHIJ0123", "found"},
+		{"openai key", "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx", "sk-abcdefghijklmnopqrstuvwx", ""},
+		{"slack token", "token xoxb-123456789012-abcdefuvwxyz", "xoxb-123456789012-abcdefuvwxyz", ""},
+		{"aws key id", "AccessKeyId: " + secret, secret, "AccessKeyId"},
+		{"jwt", "auth eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk", "eyJzdWIiOiIxIn0", ""},
+		{"password kv", `password: hunter2horse`, "hunter2horse", "password"},
+		{"secret env", "DB_SECRET=s3cr3t-value-xyz", "s3cr3t-value-xyz", ""},
+		{"url creds", "postgres://app:sup3rs3cret@db.svc:5432/x", "sup3rs3cret", "postgres://app:"},
+		{"bearer", "Authorization: Bearer abcDEF123456ghiJKL789", "abcDEF123456ghiJKL789", "Bearer"},
+		{"private key", "k:\n-----BEGIN RSA PRIVATE KEY-----\nMIIBwetcetc\n-----END RSA PRIVATE KEY-----\n", "MIIBwetcetc", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := Secrets(tc.in)
+			if strings.Contains(out, tc.gone) {
+				t.Fatalf("secret survived redaction: %q -> %q", tc.in, out)
+			}
+			if !strings.Contains(out, "[REDACTED") {
+				t.Fatalf("expected a redaction marker, got %q", out)
+			}
+			if tc.keeps != "" && !strings.Contains(out, tc.keeps) {
+				t.Fatalf("structure %q should survive, got %q", tc.keeps, out)
+			}
+			// Idempotent: redacting again changes nothing.
+			if again := Secrets(out); again != out {
+				t.Fatalf("not idempotent: %q -> %q", out, again)
+			}
+		})
+	}
+}
+
+// TestSecretsKeepsBenign guards against over-redaction of ordinary investigation
+// text (config values, image tags, diff markers, metrics) — false positives would
+// blind the model to real evidence.
+func TestSecretsKeepsBenign(t *testing.T) {
+	benign := []string{
+		"replicas: 3",
+		"image: registry.k8s.io/pause:3.9",
+		"@@ -1,3 +1,4 @@",
+		"cpu: 250m\nmemory: 512Mi",
+		"reason: CrashLoopBackOff, restartCount: 7",
+		"level=info msg=\"reconcile succeeded\" duration=1.2s",
+	}
+	for _, s := range benign {
+		if got := Secrets(s); got != s {
+			t.Errorf("benign text was altered:\n  in:  %q\n  out: %q", s, got)
+		}
+	}
+}


### PR DESCRIPTION
## F1 — content redaction at the model boundary

The top security gap from the review (and the one that matters most for the data-residency / self-hosting ICP). First part of **M2**.

**Problem:** there was no content-redaction layer. Raw pod/controller logs and git diffs were fed verbatim to the LLM provider, and the model's quoted evidence then flowed into the (possibly public) KB pull request + chat — so a token/DSN in a log line could egress to the model vendor and, via a public KB repo, the world. (`design.md §9` tracked this as R19.)

**Fix:**
- New `internal/redact` package — a **high-precision, structure-preserving** masker: PEM private keys, JWTs, GitHub/OpenAI/Slack/AWS/Google token formats, credentials in URLs, `Bearer`/`Basic` headers, and sensitive `key=value` pairs (the **value** is masked, the **key** kept, so the model can still reason "the password field changed").
- Wired at the **model-ingress boundary** in the investigate loop: tool output (logs/diffs/status/events) and the untrusted incident seed are redacted **before** entering the prompt.

**Why one boundary is enough for the common case:** the model only ever sees redacted text, so the evidence it later quotes into the KB PR + chat is protected too — those paths emit only model-authored `Summary`/`Evidence` (verified, no raw diff/log text). Redaction is **always-on** and deliberately high-precision so it doesn't blind the model to real evidence (benign config/diff/metric text is provably untouched).

**Tests:** redactor unit (positive secret formats + benign-keeps + idempotency) and a loop integration test proving tool output is redacted before the model sees it. `build` · `vet` · `go test -race` · `golangci-lint` 0 issues.

### Follow-ups (rest of M2, not in this PR)
- **Egress defense-in-depth** — redact at the curator PR body + notify as a catch-all for any non-model path (e.g. `confirm`-appended pod status; lower severity, names-not-values).
- **F2** (validate action `Target.Name`), **F3** (approver-gate the reject path), **CLONE-1** (shallow clone + cache), and the **P3 polish bundle**.