### PR TITLE
M2: harden the action approve/reject path (F3 + P3)

### DIFF
--- a/internal/action/approvals.go
+++ b/internal/action/approvals.go
@@ -2,6 +2,8 @@ package action
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -38,7 +40,6 @@ type Approvals struct {
 	now    func() time.Time
 
 	mu      sync.Mutex
-	seq     int
 	pending map[string]entry
 }
 
@@ -59,10 +60,19 @@ func NewApprovals(exec Executor, policy *Policy, aud audit.Auditor, log *slog.Lo
 func (a *Approvals) Register(act providers.Action) string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.seq++
-	id := fmt.Sprintf("a%d", a.seq)
+	id := newID()
 	a.pending[id] = entry{action: act, created: a.now()}
 	return id
+}
+
+// newID returns an unguessable approval id. Ids appear in Slack button values and
+// on the HTTP approve/reject path; a sequential "a%d" id is trivially enumerable,
+// so a crypto/rand id is defense-in-depth behind the auth gates. crypto/rand.Read
+// does not return an error on supported platforms (Go 1.24+).
+func newID() string {
+	var b [12]byte
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
 }
 
 // List returns the non-expired pending actions.

--- a/internal/action/auto.go
+++ b/internal/action/auto.go
@@ -98,10 +98,6 @@ func (a *Auto) runOne(ctx context.Context, inv providers.Investigation, act prov
 		a.log.Info("auto dry-run (would execute)", "op", act.Op, "target", target(act))
 		a.record(act, audit.DecisionDryRun, "")
 		return annotate("[auto: dry-run — would execute]")
-	case !a.reserve():
-		a.log.Warn("auto rate limit reached; action not executed", "max", a.maxPerWindow, "window", a.window.String())
-		a.record(act, audit.DecisionSkipped, "rate-limited")
-		return annotate("[auto: skipped — rate-limited]")
 	default:
 		// Re-check the kill-switch immediately before executing: Pause() may have
 		// landed between the switch evaluation above and here (gate TOCTOU).
@@ -120,6 +116,14 @@ func (a *Auto) runOne(ctx context.Context, inv providers.Investigation, act prov
 				a.record(act, audit.DecisionDenied, reason)
 				return annotate("[auto: denied — " + reason + "]")
 			}
+		}
+		// Reserve a rate slot LAST — only once every gate (pause re-check + envelope
+		// re-validation) has passed — so a pause or policy denial landing in the gate
+		// window can't burn a slot for an action that never executed.
+		if !a.reserve() {
+			a.log.Warn("auto rate limit reached; action not executed", "max", a.maxPerWindow, "window", a.window.String())
+			a.record(act, audit.DecisionSkipped, "rate-limited")
+			return annotate("[auto: skipped — rate-limited]")
 		}
 		// executed/failed are audited at the executor seam (NewAuditedExecutor).
 		if err := a.exec.Execute(ContextWithActor(ctx, "auto"), act); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -281,6 +281,15 @@ func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) 
 			s.log.Info("slack approval executed", "id", act.Value, "user_id", p.User.ID, "user", p.User.Username, "op", executed.Op)
 		}
 	case "runlore_reject":
+		// Gate reject on the same approver allowlist as approve: a signature-valid but
+		// unlisted user must not be able to cancel a pending remediation (denial-of-
+		// remediation). Rejecting is the safe direction, but it's still a privileged
+		// decision over a queued cluster action.
+		if !s.approvers[p.User.ID] {
+			msg = "❌ not authorized to reject (user not in approver allowlist)"
+			s.log.Warn("slack reject denied: user not in allowlist", "user_id", p.User.ID, "user", p.User.Username)
+			break
+		}
 		if rerr := s.approvals.Reject(act.Value); rerr != nil {
 			msg = "⚠️ " + rerr.Error()
 		} else {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -68,6 +68,43 @@ func TestSlackInteraction(t *testing.T) {
 	}
 }
 
+// TestSlackRejectRequiresApprover locks down F3: a signature-valid but unlisted
+// user must not be able to cancel a pending remediation (denial-of-remediation).
+func TestSlackRejectRequiresApprover(t *testing.T) {
+	exec := &recordExec{}
+	pol := action.New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{ReversibleOnly: true, Namespaces: []string{"apps"}}})
+	ap := action.NewApprovals(exec, pol, audit.Nop{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "apps"}})
+
+	const secret = "shh"
+	srv := New(&config.Config{}, &spyEnqueuer{}, nil, Actions{Approvals: ap, SlackSecret: secret, ApproverIDs: []string{"U1"}}, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	reject := func(userID string) {
+		payload := `{"user":{"id":"` + userID + `","username":"x"},"actions":[{"action_id":"runlore_reject","value":"` + id + `"}]}`
+		body := "payload=" + url.QueryEscape(payload)
+		ts := strconv.FormatInt(time.Now().Unix(), 10)
+		req := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(body))
+		req.Header.Set("X-Slack-Request-Timestamp", ts)
+		req.Header.Set("X-Slack-Signature", slackSign(secret, ts, body))
+		rr := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("reject by %s = %d, want 200 (click ack)", userID, rr.Code)
+		}
+	}
+
+	// Unlisted user: the click is acked (200) but the action must remain pending.
+	reject("U2")
+	if len(ap.List()) != 1 {
+		t.Fatalf("unlisted user cancelled a pending action (denial-of-remediation); pending=%d, want 1", len(ap.List()))
+	}
+	// The approver can reject — the action is dropped.
+	reject("U1")
+	if len(ap.List()) != 0 {
+		t.Fatalf("approver reject did not drop the pending action; pending=%d, want 0", len(ap.List()))
+	}
+}
+
 type spyEnqueuer struct{ reqs []investigate.Request }
 
 func (s *spyEnqueuer) Enqueue(r investigate.Request) { s.reqs = append(s.reqs, r) }


### PR DESCRIPTION
## Action-path & approval hardening

Independent slice of M2 (the security/perf milestone). All in `internal/action` + `internal/server`; no overlap with the other open PRs.

### Changes
- **F3 (P2) — gate the Slack `reject` button on the approver allowlist.** `approve` already checked `s.approvers[user]`, but `reject` did not, so any signature-valid Slack user could cancel a *pending* remediation (denial-of-remediation). Rejecting is the safe direction, but it's still a privileged decision over a queued cluster action. (The HTTP reject path was already control-token gated.)
- **P3 — unguessable approval ids.** Ids were a sequential `a%d` (trivially enumerable) and appear in Slack button values + the HTTP approve/reject path. Now `crypto/rand` — defense-in-depth behind the auth gates.
- **P3 — `auto` reserves the rate-limit slot last.** It was reserved before the pre-exec kill-switch re-check + envelope re-validation, so a pause or policy denial landing in that gate window burned a slot for an action that never executed. Now reserved only once every gate has passed.

### Verification
`build` · `vet` · `go test -race` (action + server) · `golangci-lint` 0 issues. New test `TestSlackRejectRequiresApprover`; existing approve/interaction tests still pass.

### Rest of M2 (separate, dependency-ordered)
- **F2** (validate action `Target.Name` against read-tool-surfaced resources) — a data-flow change; own PR + injection test.
- **Egress redaction** (F1 defense-in-depth) — stacks on #117 (needs the `redact` package).
- **CLONE-1** (shallow clone + per-investigation cache) — stacks on #114 (lives in `differ.go`).
- Transport P3 nits (Slack empty-2xx, redirect policy, ReadAll-wrap).