### PR TITLE
FEAT-1: freeze the auto rung as experimental

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -809,7 +809,11 @@ func buildApprovals(cfg *config.Config, exec action.Executor, aud audit.Auditor,
 
 // buildAuto enables rung-3 unattended execution for action mode "auto" (requires a
 // reachable cluster). Heavily gated: reversible-only, confidence-floored, rate-
-// limited, kill-switchable, and audited. Recommend dry_run before going live.
+// limited, kill-switchable, and audited. The rung is EXPERIMENTAL and FROZEN
+// (FEAT-1): unattended execution contradicts the read-only-first posture and is the
+// only path that turns a prompt-injected finding into a cluster mutation, so it gets
+// no further investment and may be removed — prefer "approve", which captures nearly
+// all the value. Recommend dry_run if you evaluate it.
 func buildAuto(cfg *config.Config, exec action.Executor, aud audit.Auditor, log *slog.Logger) *action.Auto {
 	if cfg.Actions.Mode != config.ActionAuto {
 		return nil
@@ -819,7 +823,8 @@ func buildAuto(cfg *config.Config, exec action.Executor, aud audit.Auditor, log 
 		return nil
 	}
 	a := cfg.Actions.Auto
-	log.Warn("rung-3 AUTO execution ENABLED — reversible actions execute WITHOUT human approval",
+	log.Warn("rung-3 AUTO execution ENABLED — EXPERIMENTAL and NOT recommended on real clusters; "+
+		"reversible actions execute WITHOUT human approval. Prefer mode=approve (human-click).",
 		"dry_run", a.DryRun, "min_confidence", a.MinConfidence, "max_per_window", a.MaxPerWindow, "window", a.Window.Std().String())
 	au := action.NewAuto(exec, a, action.New(cfg.Actions), aud, log)
 	// NewAuto starts paused (fail closed by construction across cold start / failover);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -394,14 +394,14 @@ const (
 	ActionOff     ActionMode = "off"     // read-only (default): no action tools registered
 	ActionSuggest ActionMode = "suggest" // propose a command/PR; never execute
 	ActionApprove ActionMode = "approve" // execute only after explicit human approval
-	ActionAuto    ActionMode = "auto"    // execute within the allowed envelope, no click
+	ActionAuto    ActionMode = "auto"    // EXPERIMENTAL/frozen (FEAT-1): execute in-envelope, no click — not for prod
 )
 
 // ActionPolicy gates cluster-mutating actions — the upper rungs of the autonomy
 // ladder. v1 ships ActionOff; the type exists so active tools can be added later
 // behind a gate without re-architecting (see docs/design.md §9, "Act").
 type ActionPolicy struct {
-	Mode             ActionMode  `yaml:"mode"`               // off | suggest | approve | auto
+	Mode             ActionMode  `yaml:"mode"`               // off | suggest | approve | auto (experimental, frozen)
 	Allow            ActionAllow `yaml:"allow"`              // envelope, enforced even in approve/auto
 	RequireApproval  bool        `yaml:"require_approval"`   // force a human click for gated actions
 	ApprovalTokenEnv string      `yaml:"approval_token_env"` // env var with a shared secret for the approval endpoints


### PR DESCRIPTION
## Freeze the rung-3 `auto` (unattended execution) as experimental

Decision **FEAT-1** from the review. Keep the well-built, heavily-gated code, but make it unambiguously experimental and stop investing in it — unattended execution contradicts RunLore's read-only-first posture and is the *only* path that turns a prompt-injected finding into a cluster mutation. The `approve` rung (human click) captures nearly all the value.

### Changes (marking + messaging only — no behavior change)
- **Startup warning** when `mode=auto`: now states it's **EXPERIMENTAL and NOT recommended on real clusters**, and points operators to `mode=approve`.
- **Config schema** marks it: the `ActionAuto` constant and the `ActionPolicy.Mode` field note it's experimental/frozen.

`auto` still works exactly as before — paused-by-construction (fail-closed), reversible-only, confidence-floored, rate-limited, audited. This only sets expectations and signals: no further investment, and it may be removed.

### Verification
build · vet · `go test -race` (config + cmd/lore) · `golangci-lint` 0 issues.

### Follow-up
The matching `design.md` wording ("gated" → "experimental/frozen") belongs in the docs PR #116 (design.md lives on that branch) — easy to fold in there.