### PR TITLE
M4 (part 1): hybrid-retrieval foundation — embeddings + cosine + RRF

### DIFF
--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -1,0 +1,167 @@
+// Package embed provides an OpenAI-compatible embeddings client and the
+// similarity + fusion primitives for hybrid (BM25 + vector) catalog retrieval.
+//
+// It is the in-house alternative to a Python embedding sidecar or a vector-DB
+// dependency: embeddings are served by the same OpenAI-compatible endpoint as the
+// model (in-cluster vLLM, Ollama, OpenAI), and similarity is brute-force cosine
+// over the (small) catalog — no new datastore, still a single static binary.
+//
+// This package is the foundation only; wiring hybrid retrieval into the catalog
+// index and the recall gates is an eval-validated follow-up (the BM25-tuned recall
+// thresholds must be re-measured for fused scores, not guessed).
+package embed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+)
+
+// Client calls an OpenAI-compatible /embeddings endpoint.
+type Client struct {
+	baseURL string
+	model   string
+	apiKey  string
+	http    *http.Client
+}
+
+// New builds an embeddings client. apiKey may be empty (keyless vLLM/Ollama).
+func New(baseURL, model, apiKey string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   model,
+		apiKey:  apiKey,
+		http:    &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+type embedRequest struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponse struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+}
+
+// Embed returns one vector per input text, in input order. Empty input → nil.
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	body, err := json.Marshal(embedRequest{Model: c.model, Input: texts})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	newReq := func() (*http.Request, error) {
+		r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/embeddings", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set("Content-Type", "application/json")
+		if c.apiKey != "" {
+			r.Header.Set("Authorization", "Bearer "+c.apiKey)
+		}
+		return r, nil
+	}
+	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
+	if err != nil {
+		return nil, fmt.Errorf("embeddings request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// base_url is operator-configurable; don't echo the upstream body (info
+		// disclosure + log injection). Surface status + sanitized request-id only.
+		return nil, fmt.Errorf("embeddings status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
+	}
+	var er embedResponse
+	if err := json.Unmarshal(data, &er); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if len(er.Data) != len(texts) {
+		return nil, fmt.Errorf("embeddings: got %d vectors for %d inputs", len(er.Data), len(texts))
+	}
+	// The API may return data out of order; place each by its declared index.
+	out := make([][]float32, len(texts))
+	for _, d := range er.Data {
+		if d.Index < 0 || d.Index >= len(out) {
+			return nil, fmt.Errorf("embeddings: index %d out of range", d.Index)
+		}
+		out[d.Index] = d.Embedding
+	}
+	for i, v := range out {
+		if len(v) == 0 {
+			return nil, fmt.Errorf("embeddings: missing vector for input %d", i)
+		}
+	}
+	return out, nil
+}
+
+// Cosine returns the cosine similarity of two equal-length vectors, in [-1, 1].
+// Mismatched-length or zero-norm vectors return 0 ("no signal").
+func Cosine(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}
+
+// Fused is an id with its fused relevance score.
+type Fused struct {
+	ID    string
+	Score float64
+}
+
+// FuseRRF combines several rankings of the same id space by Reciprocal Rank Fusion:
+// score(id) = Σ 1/(k + rank), rank 0-based within each ranking; an id absent from a
+// ranking contributes nothing. RRF is scale-free — it fuses BM25 and cosine rankings
+// without their different score magnitudes distorting the result. k dampens low ranks
+// (60 is the common default). Results are sorted by descending fused score, ties
+// broken by id for determinism.
+func FuseRRF(k float64, rankings ...[]string) []Fused {
+	if k <= 0 {
+		k = 60
+	}
+	score := map[string]float64{}
+	for _, r := range rankings {
+		for rank, id := range r {
+			score[id] += 1.0 / (k + float64(rank))
+		}
+	}
+	out := make([]Fused, 0, len(score))
+	for id, s := range score {
+		out = append(out, Fused{ID: id, Score: s})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -1,0 +1,120 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestEmbed(t *testing.T) {
+	var gotModel string
+	var gotInput []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req embedRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotModel, gotInput = req.Model, req.Input
+		// Return vectors deliberately OUT OF ORDER to exercise index placement.
+		_, _ = w.Write([]byte(`{"data":[
+			{"index":1,"embedding":[0.0,1.0]},
+			{"index":0,"embedding":[1.0,0.0]}]}`))
+	}))
+	defer srv.Close()
+
+	vecs, err := New(srv.URL, "text-embed", "k").Embed(context.Background(), []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if gotModel != "text-embed" || len(gotInput) != 2 {
+		t.Fatalf("request: model=%q input=%v", gotModel, gotInput)
+	}
+	if len(vecs) != 2 || vecs[0][0] != 1.0 || vecs[1][1] != 1.0 {
+		t.Fatalf("vectors not placed by index: %v", vecs)
+	}
+}
+
+func TestEmbedEmptyInput(t *testing.T) {
+	v, err := New("http://unused", "m", "").Embed(context.Background(), nil)
+	if err != nil || v != nil {
+		t.Fatalf("empty input should no-op, got (%v, %v)", v, err)
+	}
+}
+
+func TestEmbedCountMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[1.0]}]}`)) // 1 vector for 2 inputs
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL, "m", "").Embed(context.Background(), []string{"a", "b"}); err == nil {
+		t.Fatal("want error on vector/input count mismatch")
+	}
+}
+
+func TestEmbedNon2xxOmitsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Request-Id", "req-9")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`secret=sk-LEAKED upstream detail`))
+	}))
+	defer srv.Close()
+	_, err := New(srv.URL, "m", "").Embed(context.Background(), []string{"a"})
+	if err == nil {
+		t.Fatal("want error for non-2xx")
+	}
+	if strings.Contains(err.Error(), "sk-LEAKED") || strings.Contains(err.Error(), "upstream detail") {
+		t.Fatalf("error leaked upstream body: %v", err)
+	}
+	if !strings.Contains(err.Error(), "502") || !strings.Contains(err.Error(), "req-9") {
+		t.Fatalf("error should carry status + request-id: %v", err)
+	}
+}
+
+func TestCosine(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b []float32
+		want float64
+	}{
+		{"identical", []float32{1, 0, 1}, []float32{1, 0, 1}, 1},
+		{"orthogonal", []float32{1, 0}, []float32{0, 1}, 0},
+		{"opposite", []float32{1, 1}, []float32{-1, -1}, -1},
+		{"mismatched length", []float32{1, 0}, []float32{1}, 0},
+		{"zero vector", []float32{0, 0}, []float32{1, 1}, 0},
+		{"empty", nil, nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Cosine(tc.a, tc.b); math.Abs(got-tc.want) > 1e-9 {
+				t.Fatalf("Cosine = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFuseRRF(t *testing.T) {
+	// "b" ranks top of BOTH lists → should win; "a" is second in both; "z" appears
+	// in only one list, low → last. (Symmetric ranks would tie, so both lists agree
+	// on the b>a order to make the winner unambiguous.)
+	bm25 := []string{"b", "a", "z"}
+	vec := []string{"b", "a"}
+	fused := FuseRRF(0, bm25, vec) // k<=0 → default 60
+
+	if len(fused) != 3 {
+		t.Fatalf("want 3 fused ids, got %d: %+v", len(fused), fused)
+	}
+	if fused[0].ID != "b" {
+		t.Fatalf("'b' (high in both rankings) should rank first, got %q (%+v)", fused[0].ID, fused)
+	}
+	if fused[len(fused)-1].ID != "z" {
+		t.Fatalf("'z' (single low appearance) should rank last, got %q", fused[len(fused)-1].ID)
+	}
+	// Scores must be descending.
+	for i := 1; i < len(fused); i++ {
+		if fused[i].Score > fused[i-1].Score {
+			t.Fatalf("fused scores not descending: %+v", fused)
+		}
+	}
+}


### PR DESCRIPTION
## Hybrid-retrieval foundation (the building block for better recall)

First, **unwired**, regression-free part of M4 — the highest-value *capability* item (recall quality = the open catalog's payoff). New `internal/embed`:

- **OpenAI-compatible `/embeddings` client** — served by the same in-cluster endpoint as the model (vLLM/Ollama/OpenAI): no Python sidecar, no vector DB, no data egress, still a single static binary. Same hardening as the chat client (httpx retry; never echoes the upstream body — status + sanitized request-id only).
- **Cosine similarity** — brute-force is ample for the small catalog.
- **Scale-free Reciprocal Rank Fusion** — fuses BM25 and cosine rankings without their different score magnitudes distorting the result.

**Zero runtime change** — nothing imports it yet. Fully unit-tested (embeddings client incl. out-of-order data + count-mismatch + no-body-on-error; cosine edge cases; RRF ordering).

### Part 2 is intentionally separate — and eval-gated
Wiring this into the catalog index + recall requires re-tuning recall's gates, which today key off **BM25 absolute scores**. Fused scores live on a different scale, so the thresholds must be **measured on the replay-eval scenarios** (live model + embeddings endpoint) — not guessed, or recall silently breaks. That validation belongs in an environment with model access; this PR lands the verified primitives so part 2 is a focused, measurable step.