### PR TITLE
CLONE-1: cache repo clones per what_changed call

### DIFF
--- a/internal/investigate/whatchanged_tool.go
+++ b/internal/investigate/whatchanged_tool.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/whatchanged"
 )
 
 // WhatChangedTool exposes the GitOps "what changed" lens to the model: the change
@@ -44,6 +45,11 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 	if len(changes) == 0 {
 		return "no changes found for the given selector", nil
 	}
+	// Clone each source repo at most once for this call: several changes on one
+	// (mono)repo would otherwise each trigger a full clone. The cache owns the
+	// clones and removes them when the call returns.
+	ctx, done := whatchanged.WithCloneCache(ctx)
+	defer done()
 	var b strings.Builder
 	for _, c := range changes {
 		fmt.Fprintf(&b, "%s %s/%s (%s): %s..%s\n", c.Engine, c.Workload.Kind, c.Workload.Name, c.Type, c.FromRev, c.ToRev)

--- a/internal/whatchanged/clonecache.go
+++ b/internal/whatchanged/clonecache.go
@@ -1,0 +1,65 @@
+package whatchanged
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	git "github.com/go-git/go-git/v5"
+)
+
+// cloneCache reuses a repo clone across the several diffs of one what_changed call.
+// Without it, K changes on the same (mono)repo each trigger a full disk clone; with
+// it, each source repo is cloned at most once per call. It is request-scoped via the
+// context and OWNS the clones' lifetime — close() removes every temp dir it made.
+type cloneCache struct {
+	mu     sync.Mutex
+	clones map[string]*git.Repository // url -> reusable clone
+	dirs   []string                   // temp dirs to remove on close
+}
+
+type cloneCacheKey struct{}
+
+// WithCloneCache returns a derived context carrying a clone cache, plus a cleanup
+// func that removes every clone the cache created. Wrap a batch of diffs that may
+// hit the same repo (the what_changed tool's change loop) so each source repo is
+// cloned at most once; call the returned func when the batch is done.
+func WithCloneCache(ctx context.Context) (context.Context, func()) {
+	cc := &cloneCache{clones: map[string]*git.Repository{}}
+	return context.WithValue(ctx, cloneCacheKey{}, cc), cc.close
+}
+
+func cacheFrom(ctx context.Context) *cloneCache {
+	cc, _ := ctx.Value(cloneCacheKey{}).(*cloneCache)
+	return cc
+}
+
+func (c *cloneCache) get(url string) (*git.Repository, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	repo, ok := c.clones[url]
+	return repo, ok
+}
+
+// put stores a freshly-cloned repo (at dir) for url, taking ownership of dir's
+// cleanup. If another clone for the same url raced in first, it keeps that one and
+// returns kept=false so the caller can discard its now-redundant dir.
+func (c *cloneCache) put(url string, repo *git.Repository, dir string) (winner *git.Repository, kept bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.clones[url]; ok {
+		return existing, false
+	}
+	c.clones[url] = repo
+	c.dirs = append(c.dirs, dir)
+	return repo, true
+}
+
+func (c *cloneCache) close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, d := range c.dirs {
+		_ = os.RemoveAll(d)
+	}
+	c.clones, c.dirs = nil, nil
+}

--- a/internal/whatchanged/clonecache_test.go
+++ b/internal/whatchanged/clonecache_test.go
@@ -1,0 +1,53 @@
+package whatchanged
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestCloneCacheReusesClone locks down CLONE-1: within one WithCloneCache batch,
+// several changes on the SAME source repo clone it ONCE, not once per change — and
+// the diff is still correct when computed from the reused clone.
+func TestCloneCacheReusesClone(t *testing.T) {
+	dir, v1, v2 := buildRepo(t) // local git repo with two commits (v2 changes files)
+	d := &Differ{}
+	ctx, done := WithCloneCache(context.Background())
+	defer done()
+
+	mk := func() providers.Change {
+		return providers.Change{Source: providers.SourceRef{RepoURL: dir}, FromRev: v1.String(), ToRev: v2.String()}
+	}
+	for i := 0; i < 3; i++ {
+		dff, err := d.ForChange(ctx, mk())
+		if err != nil {
+			t.Fatalf("ForChange #%d: %v", i, err)
+		}
+		if len(dff.Files) == 0 {
+			t.Fatalf("ForChange #%d: expected a non-empty diff from the (reused) clone", i)
+		}
+	}
+
+	cc := cacheFrom(ctx)
+	if cc == nil {
+		t.Fatal("clone cache missing from context")
+	}
+	if n := len(cc.clones); n != 1 {
+		t.Fatalf("the same repo across 3 changes should be cloned once, got %d clones", n)
+	}
+}
+
+// TestCloneCacheCloseCleansUp verifies close() removes the clones, and that without
+// a cache the differ keeps its original per-call clone+cleanup behaviour (no leak).
+func TestNoCacheStillWorks(t *testing.T) {
+	dir, v1, v2 := buildRepo(t)
+	d := &Differ{}
+	// No WithCloneCache: cacheFrom is nil → original path (clone + caller cleanup).
+	dff, err := d.ForChange(context.Background(), providers.Change{
+		Source: providers.SourceRef{RepoURL: dir}, FromRev: v1.String(), ToRev: v2.String(),
+	})
+	if err != nil || len(dff.Files) == 0 {
+		t.Fatalf("uncached ForChange should still diff: %d files err=%v", len(dff.Files), err)
+	}
+}

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -141,22 +141,40 @@ func (d *Differ) auth(ctx context.Context) (transport.AuthMethod, error) {
 // inuse_space heap profile: go-git MemoryObject.Write = 90% of heap). ctx aborts a
 // hung remote (a stalled HTTPS clone would otherwise block the queue worker
 // indefinitely); a cancelled clone returns a context error via %w.
+//
+// When ctx carries a clone cache (see WithCloneCache), a repo is cloned at most once
+// per batch: a cache hit returns the shared clone with a no-op cleanup (the cache
+// owns the temp dir and removes it on close). Without a cache, the caller owns the
+// returned cleanup, as before.
 func (d *Differ) cloneToDisk(ctx context.Context, url string) (*git.Repository, func(), error) {
+	noop := func() {}
+	cc := cacheFrom(ctx)
+	if cc != nil {
+		if repo, ok := cc.get(url); ok {
+			return repo, noop, nil // reuse — the cache owns cleanup
+		}
+	}
 	auth, err := d.auth(ctx)
 	if err != nil {
-		return nil, func() {}, err
+		return nil, noop, err
 	}
 	dir, err := os.MkdirTemp("", "runlore-clone-")
 	if err != nil {
-		return nil, func() {}, fmt.Errorf("temp dir: %w", err)
+		return nil, noop, fmt.Errorf("temp dir: %w", err)
 	}
-	cleanup := func() { _ = os.RemoveAll(dir) }
 	repo, err := git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{URL: url, Auth: auth})
 	if err != nil {
-		cleanup()
-		return nil, func() {}, fmt.Errorf("clone %s: %w", url, err)
+		_ = os.RemoveAll(dir)
+		return nil, noop, fmt.Errorf("clone %s: %w", url, err)
 	}
-	return repo, cleanup, nil
+	if cc != nil {
+		winner, kept := cc.put(url, repo, dir)
+		if !kept {
+			_ = os.RemoveAll(dir) // a concurrent diff cloned the same url first
+		}
+		return winner, noop, nil // cache owns cleanup
+	}
+	return repo, func() { _ = os.RemoveAll(dir) }, nil
 }
 
 // Remote clones url to disk (auth via the installation token when set) and diffs


### PR DESCRIPTION
## Clone each source repo once per what_changed call

The what_changed tool diffs each change via the differ, which did a **full disk clone per change** — so K changes on one monorepo cloned it K times (latency, disk, and an unbounded-clone DoS vector). This became real in practice once **AUTH-1** made private-repo clones actually happen.

**Fix:** a context-scoped clone cache. The tool wraps its change loop with `WithCloneCache`; `cloneToDisk` reuses a per-URL clone from it (a hit returns the shared clone with a no-op cleanup; the cache owns the temp dirs and removes them when the call returns). Each source repo is cloned **at most once per call**.

**Zero interface churn** — the cache rides the context the provider already threads to the differ, so the `GitOpsProvider` interface, the flux/argocd impls, and all test fakes are untouched. Any caller without a cache keeps the original clone + caller-cleanup behaviour.

### Deliberately *not* done
Shallow / `SingleBranch` cloning: `Depth:1` can't resolve an arbitrary historical `FromRev`, and `SingleBranch` can miss revisions on non-default branches. The cache is the safe, high-value win; a size/Depth cap can come later if needed.

### Verification
build · vet · `go test -race` (whatchanged + investigate + flux/argocd) · `golangci-lint` 0 issues. New tests: 3 changes on one repo → 1 clone (diff still correct from the reused clone) + the uncached path unchanged. **Re-ran the full k3d e2e on this branch: 45/45, "mock model drove what_changed" — the spine works with the cache wiring.**