### PR TITLE
GO-P1B: graceful drain of the in-flight investigation on shutdown

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -163,6 +163,18 @@ func runServe(args []string) error {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
+	// drainGracePeriod bounds how long shutdown waits for the in-flight investigation
+	// to finish before forcing it. Keep it under the pod's terminationGracePeriodSeconds
+	// (the chart sets 40s) so the process exits cleanly before SIGKILL.
+	const drainGracePeriod = 25 * time.Second
+	// workCtx drives the leader-only work (leader election, the investigation queue,
+	// failure watch, coalescer) and is intentionally SEPARATE from the SIGTERM signal
+	// (ctx): on shutdown the leader keeps workCtx alive, drains the in-flight
+	// investigation to completion (lease still held, so no other replica acts), then
+	// cancels workCtx — releasing the lease. Lost leadership still cancels its own
+	// LE-derived context and aborts promptly.
+	workCtx, stopWork := context.WithCancel(context.Background())
+	defer stopWork()
 
 	// Build kube clients once (best-effort): the dynamic client backs the
 	// GitOps-failure watch + what-changed tool; the clientset backs leader election.
@@ -303,10 +315,10 @@ func runServe(args []string) error {
 	var leader atomic.Bool
 	useLE := cfg.LeaderElection.Enabled && clientset != nil
 	if useLE {
-		go runLeaderElection(ctx, cfg, clientset, &leader, log, startWork)
+		go runLeaderElection(workCtx, cfg, clientset, &leader, log, startWork)
 	} else {
 		leader.Store(true) // no leader election: this replica is always active + ready
-		startWork(ctx)
+		startWork(workCtx)
 	}
 
 	// Build-info + leadership gauges (runlore_build_info / runlore_leader). No-op
@@ -333,17 +345,27 @@ func runServe(args []string) error {
 	srv.SetOutcomeLedger(ledger)
 	if cz != nil {
 		srv.SetCoalescer(cz)
-		go cz.Run(ctx, cfg.Investigation.Coalesce.Debounce.Std()/2)
+		go cz.Run(workCtx, cfg.Investigation.Coalesce.Debounce.Std()/2)
 	}
 	httpSrv := newHTTPServer(*addr, srv.Handler())
+	// Graceful shutdown: on SIGTERM, stop accepting webhooks, let the in-flight
+	// investigation finish within a bounded grace (lease still held), then release.
+	drained := make(chan struct{})
 	go func() {
+		defer close(drained)
 		<-ctx.Done()
+		log.Info("shutdown: stopping intake; draining in-flight investigation")
 		_ = httpSrv.Shutdown(context.Background())
+		dctx, cancelDrain := context.WithTimeout(context.Background(), drainGracePeriod)
+		queue.Drain(dctx)
+		cancelDrain()
+		stopWork() // release the leader lease + stop the queue/watch/coalescer
 	}()
 	log.Info("runlore serving", "addr", *addr, "leader_election", useLE)
 	if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return err
 	}
+	<-drained // wait for the graceful drain to finish before exiting
 	return nil
 }
 

--- a/deploy/helm/runlore/templates/deployment.yaml
+++ b/deploy/helm/runlore/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         {{- include "runlore.selectorLabels" . | nindent 8 }}
     spec:
+      # Give the leader time to gracefully drain its in-flight investigation on
+      # SIGTERM (record the outcome + deliver) before SIGKILL — must exceed the
+      # agent's internal drain grace (25s). Raise both for longer investigations.
+      terminationGracePeriodSeconds: 40
       serviceAccountName: {{ include "runlore.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -208,6 +208,32 @@ func (q *Queue) Run(ctx context.Context) {
 	}
 }
 
+// Drain stops the current term's queue from starting new work and waits for an
+// in-flight investigation to finish, up to ctx's deadline. It is the graceful
+// counterpart to a workCtx cancel (which aborts immediately — used on LOST
+// leadership): on SIGTERM the leader keeps its work context alive and calls Drain so
+// the in-flight investigation can COMPLETE (record its outcome + deliver) before the
+// process exits, instead of being killed mid-flight. A no-op when not running (no
+// leadership / between terms). If the deadline fires first it returns, and the
+// caller's subsequent workCtx cancel aborts the straggler.
+func (q *Queue) Drain(ctx context.Context) {
+	q.mu.Lock()
+	wq := q.wq
+	q.mu.Unlock()
+	if wq == nil {
+		return
+	}
+	done := make(chan struct{})
+	// ShutDownWithDrain stops new Get()s but waits for the in-flight item (Get-but-
+	// not-Done) to finish — unlike ShutDown(), which drops it. The worker's per-item
+	// ctx is workCtx (still alive during the drain), so the investigation completes.
+	go func() { wq.ShutDownWithDrain(); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
+}
+
 func (q *Queue) process(ctx context.Context, wq workqueue.TypedRateLimitingInterface[key], k key) {
 	defer wq.Done(k)
 	q.mu.Lock()

--- a/internal/investigate/investigate_drain_test.go
+++ b/internal/investigate/investigate_drain_test.go
@@ -1,0 +1,107 @@
+package investigate
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// blockingInvestigator blocks in Investigate until released, recording the ctx error
+// at finish so a test can prove the investigation completed (ctx not cancelled =
+// graceful drain) vs was aborted (ctx cancelled).
+type blockingInvestigator struct {
+	started  chan struct{}
+	release  chan struct{}
+	finished chan struct{}
+	ctxErr   error
+}
+
+func newBlockingInvestigator() *blockingInvestigator {
+	return &blockingInvestigator{
+		started:  make(chan struct{}, 1),
+		release:  make(chan struct{}),
+		finished: make(chan struct{}),
+	}
+}
+
+func (b *blockingInvestigator) Investigate(ctx context.Context, _ Request) error {
+	b.started <- struct{}{}
+	select {
+	case <-b.release:
+		b.ctxErr = ctx.Err() // expect nil on a graceful drain
+		close(b.finished)
+		return nil
+	case <-ctx.Done():
+		b.ctxErr = ctx.Err()
+		return ctx.Err()
+	}
+}
+
+// TestQueueDrainLetsInFlightFinish locks down GO-P1B: Drain waits for the in-flight
+// investigation to COMPLETE (its ctx not cancelled), rather than aborting it.
+func TestQueueDrainLetsInFlightFinish(t *testing.T) {
+	b := newBlockingInvestigator()
+	q := NewQueue(b, discardLog)
+	workCtx, cancel := context.WithCancel(context.Background()) // NOT cancelled during the drain
+	defer cancel()
+	go q.Run(workCtx)
+	q.Enqueue(Request{Source: SourceAlert, Title: "x"})
+
+	<-b.started // the investigation is in-flight
+
+	drainReturned := make(chan struct{})
+	go func() { q.Drain(context.Background()); close(drainReturned) }()
+
+	// Drain must NOT return while the investigation is still running.
+	select {
+	case <-drainReturned:
+		t.Fatal("Drain returned before the in-flight investigation finished")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(b.release) // let it finish
+	<-b.finished
+
+	select {
+	case <-drainReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Drain did not return after the investigation finished")
+	}
+	if b.ctxErr != nil {
+		t.Fatalf("investigation was aborted during graceful drain (ctx err %v); want a clean finish", b.ctxErr)
+	}
+}
+
+// TestQueueDrainRespectsDeadline ensures a stuck investigation can't hang shutdown:
+// Drain returns when its deadline fires even if the in-flight work never finishes.
+func TestQueueDrainRespectsDeadline(t *testing.T) {
+	b := newBlockingInvestigator()
+	q := NewQueue(b, discardLog)
+	workCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go q.Run(workCtx)
+	q.Enqueue(Request{Source: SourceAlert, Title: "x"})
+	<-b.started
+
+	dctx, dcancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	defer dcancel()
+	start := time.Now()
+	q.Drain(dctx) // never released → must return at the deadline
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("Drain ignored its deadline with a stuck investigation (took %s)", elapsed)
+	}
+	close(b.release) // cleanup
+}
+
+// TestQueueDrainNoLeaderNoop: Drain is a no-op when the queue isn't running (a
+// standby replica has nothing in flight).
+func TestQueueDrainNoLeaderNoop(t *testing.T) {
+	q := NewQueue(newBlockingInvestigator(), discardLog)
+	done := make(chan struct{})
+	go func() { q.Drain(context.Background()); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Drain should be an immediate no-op when not running")
+	}
+}


### PR DESCRIPTION
## Let the in-flight investigation finish on SIGTERM (don't kill it)

On SIGTERM the in-flight investigation was killed mid-flight: no outcome-ledger `open` recorded (the learning signal for that incident lost), and in auto mode a cluster mutation could land with the process dying before it notified. The deferred M1 item.

**Fix:** decouple the leader-only work context (`workCtx` — leader election, queue, failure watch, coalescer) from the SIGTERM signal. On shutdown the leader now:
1. stops accepting webhooks,
2. **drains the in-flight investigation to completion** within a bounded grace (`Queue.Drain` → workqueue `ShutDownWithDrain`; the work context stays alive so the investigation finishes and records its outcome),
3. **then** cancels `workCtx` — releasing the leader lease only *after* the drain.

Because the lease is held throughout the drain, **no other replica acts** during it (no split-brain). **Lost leadership is unchanged** — it cancels its own LE-derived context and aborts promptly (a deposed leader must not keep acting). `runServe` waits for the drain before exiting.

- **Chart:** `terminationGracePeriodSeconds: 40` so the pod gives the 25s drain room before SIGKILL (raise both for longer investigations).
- FEAT-1 (auto frozen) further de-risks this — a brief read-only/approve overlap would be harmless even without the lease-held guarantee.

### Verification
build · vet · `go test -race` · `golangci-lint` 0 issues · `helm lint`. New unit tests: `Drain` lets the in-flight finish (ctx **not** cancelled = graceful, not abort), respects its deadline on a stuck investigation, and is a no-op on a standby. **Re-ran the full k3d e2e: 45/45 — including leader-election, lease, and FAILOVER-to-a-new-leader**, confirming the lifecycle refactor is sound.