### PR TITLE
Finish-up: egress secret redaction + transport robustness

### DIFF
--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -390,11 +390,38 @@ func (li *LoopInvestigator) reviewActions(proposed []providers.Action) []provide
 }
 
 func (li *LoopInvestigator) deliver(req Request, inv providers.Investigation) {
+	// Egress redaction (defense in depth): scrub secrets from the finding's
+	// human-facing text before it reaches chat or a (possibly public) KB PR. Ingress
+	// redaction already covers model-authored text; this is the single egress
+	// chokepoint that also catches any NON-model text — e.g. the confirm step's
+	// appended pod-status, or the raw incident title.
+	redactInvestigation(&inv)
 	li.Log.Info("investigation complete",
 		"title", req.Title, "confidence", inv.Confidence,
 		"root_causes", len(inv.RootCauses), "unresolved", len(inv.Unresolved), "suggested_actions", len(inv.Actions))
 	if li.OnComplete != nil {
 		li.OnComplete(inv)
+	}
+}
+
+// redactInvestigation masks secret-shaped values in a finished investigation's
+// human-facing text (title; each root cause's summary, evidence, and suggested
+// action; unresolved notes; proposed-action descriptions) before it is delivered.
+func redactInvestigation(inv *providers.Investigation) {
+	inv.Title = redact.Secrets(inv.Title)
+	for i := range inv.RootCauses {
+		rc := &inv.RootCauses[i]
+		rc.Summary = redact.Secrets(rc.Summary)
+		rc.SuggestedAction = redact.Secrets(rc.SuggestedAction)
+		for j := range rc.Evidence {
+			rc.Evidence[j] = redact.Secrets(rc.Evidence[j])
+		}
+	}
+	for i := range inv.Unresolved {
+		inv.Unresolved[i] = redact.Secrets(inv.Unresolved[i])
+	}
+	for i := range inv.Actions {
+		inv.Actions[i].Description = redact.Secrets(inv.Actions[i].Description)
 	}
 }
 

--- a/internal/investigate/redact_egress_test.go
+++ b/internal/investigate/redact_egress_test.go
@@ -1,0 +1,42 @@
+package investigate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestRedactInvestigation locks down the egress catch-all: secrets in any of a
+// finished investigation's human-facing fields are masked before delivery to chat
+// or a (possibly public) KB PR — even if they reached the finding via a non-model
+// path (so ingress redaction wouldn't have seen them).
+func TestRedactInvestigation(t *testing.T) {
+	inv := &providers.Investigation{
+		Title: "DB down: password=hunter2horse",
+		RootCauses: []providers.Hypothesis{{
+			Summary:         "leaked token ghp_0123456789abcdefghijABCDEFGHIJ0123",
+			Evidence:        []string{"controller log: token xoxb-123456789012-abcdefuvwxyz"},
+			SuggestedAction: "rotate key AKIAIOSFODNN7EXAMPLE",
+		}},
+		Unresolved: []string{"DB_SECRET=s3cr3t-value-xyz seen in events"},
+		Actions:    []providers.Action{{Description: "suspend (OPENAI_API_KEY=sk-abcdefghijklmnopqrst)"}},
+	}
+	redactInvestigation(inv)
+
+	blob := strings.Join([]string{
+		inv.Title, inv.RootCauses[0].Summary, inv.RootCauses[0].Evidence[0],
+		inv.RootCauses[0].SuggestedAction, inv.Unresolved[0], inv.Actions[0].Description,
+	}, "|")
+	for _, secret := range []string{
+		"hunter2horse", "ghp_0123456789abcdefghijABCDEFGHIJ0123", "xoxb-123456789012-abcdefuvwxyz",
+		"AKIAIOSFODNN7EXAMPLE", "s3cr3t-value-xyz", "sk-abcdefghijklmnopqrst",
+	} {
+		if strings.Contains(blob, secret) {
+			t.Fatalf("secret survived egress redaction: %q", secret)
+		}
+	}
+	if !strings.Contains(blob, "[REDACTED]") {
+		t.Fatalf("expected redaction markers, got %q", blob)
+	}
+}

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -157,7 +157,10 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		return providers.CompletionResponse{}, fmt.Errorf("messages request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, _ := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("read response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		// Don't echo the upstream body into an Error-level log (info disclosure +
 		// log injection); surface status + sanitized request-id for correlation.

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -137,7 +137,10 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		return providers.CompletionResponse{}, fmt.Errorf("generateContent request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, _ := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("read response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		// Don't echo the upstream body into an Error-level log (info disclosure +
 		// log injection); surface status + sanitized request-id for correlation.

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -95,7 +96,14 @@ func (s *SlackBot) Deliver(ctx context.Context, inv providers.Investigation) err
 		OK    bool   `json:"ok"`
 		Error string `json:"error"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("slack read response: %w", err)
+	}
+	if len(bytes.TrimSpace(respBody)) == 0 {
+		return nil // a 2xx with an empty body is a successful post, not a failure
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
 		return fmt.Errorf("slack decode response: %w", err)
 	}
 	if !result.OK {


### PR DESCRIPTION
## Egress redaction (completes F1) + transport-P3 nits

### Egress secret redaction
F1 (merged) redacts at the **model-ingress** boundary, which protects model-authored text. This adds the **egress catch-all**: at the single `deliver` chokepoint, the finished investigation's human-facing text (title; each root cause's summary / evidence / suggested action; unresolved notes; proposed-action descriptions) is scrubbed before it reaches chat or a (possibly public) KB PR. It catches any **non-model** path — e.g. the `confirm` step's appended pod-status, or the raw incident title — that ingress redaction wouldn't have seen. Idempotent + deterministic, so curator dedup fingerprints are unaffected.

### Transport-P3
- **Slack:** a 2xx with an empty body is a successful post, not a decode failure.
- **anthropic + gemini:** wrap the previously-discarded response-read error (mirrors the openai client), so a mid-body drop surfaces as `read response: …` rather than a misleading `unexpected end of JSON`.

### Deferred (with reason, not skipped)
- **config-trim:** the "dead" keys (`otlp_endpoint`, `private_key_ref`, `require_approval`) are documented **reserved placeholders**, and the config decoder is strict (`KnownFields`), so removing them would break any config that sets them — for no gain.
- **CheckRedirect** egress hardening: broad + low-value.

### Verification
build · vet · `go test -race` · `golangci-lint` 0 issues. `TestRedactInvestigation` proves secrets in every finding field are masked. **Re-ran the full k3d e2e: 45/45 — Slack + Matrix delivery, curated ref, and button approval all pass** with egress redaction wired into the publish path.