### PR TITLE
fix(httpx): block redirects to internal addresses (P3 SSRF)

### DIFF
--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -206,7 +206,11 @@ LLPORT=18086; free_port "$LLPORT"
 kubectl -n "$NS" port-forward svc/runlore "$LLPORT:8080" >/tmp/runlore-ll-pf.log 2>&1 &
 LLPF=$!; sleep 3
 # prefix-match tolerates the _total / _total_total suffix variants of the OTel exporter.
-llmetric() { curl -sf "http://localhost:$LLPORT/metrics" 2>/dev/null | awk -v p="^runlore_$1" '$0 ~ p {print int($NF); exit}'; }
+# Capture to a var first (|| true), then echo|awk — a direct `curl|awk '…exit}'`
+# lets awk close the pipe early, SIGPIPE-killing curl (exit 23) which pipefail+set-e
+# turn into a spurious abort when the matched metric lands early in the output. Mirrors
+# the set-e-safe metric() helper below.
+llmetric() { local b; b=$(curl -sf "http://localhost:$LLPORT/metrics" 2>/dev/null || true); echo "$b" | awk -v p="^runlore_$1" '$0 ~ p {print int($NF); exit}'; }
 OPENED=$(llmetric outcomes_opened); OPENED=${OPENED:-0}
 if [[ "$OPENED" -ge 1 ]]; then green "PASS: outcome ledger recorded an investigation open (capture; opened=$OPENED)"; PASS=$((PASS+1))
 else red "FAIL: no outcome 'open' recorded (capture; opened=$OPENED)"; FAIL=$((FAIL+1)); fi

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -40,7 +40,7 @@ func New(baseURL, model, apiKey string) *Client {
 		baseURL: strings.TrimRight(baseURL, "/"),
 		model:   model,
 		apiKey:  apiKey,
-		http:    &http.Client{Timeout: 60 * time.Second},
+		http:    httpx.SecureClient(60 * time.Second),
 	}
 }
 

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
 )
 
 // AppTokenSource mints and caches GitHub App installation tokens.
@@ -37,7 +39,7 @@ func NewAppTokenSource(baseURL string, appID, installID int64, key *rsa.PrivateK
 		baseURL = DefaultBaseURL
 	}
 	return &AppTokenSource{appID: appID, installID: installID, key: key,
-		baseURL: strings.TrimRight(baseURL, "/"), http: &http.Client{Timeout: 30 * time.Second}}
+		baseURL: strings.TrimRight(baseURL, "/"), http: httpx.SecureClient(30 * time.Second)}
 }
 
 // Token returns a valid installation token, refreshing when near expiry. The

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 	"gopkg.in/yaml.v3"
 )
@@ -44,7 +45,7 @@ func New(baseURL, owner, repo, baseBranch string, token TokenFunc) *Client {
 	}
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"), owner: owner, repo: repo,
-		baseBranch: baseBranch, token: token, http: &http.Client{Timeout: 30 * time.Second},
+		baseBranch: baseBranch, token: token, http: httpx.SecureClient(30 * time.Second),
 	}
 }
 

--- a/internal/httpx/client.go
+++ b/internal/httpx/client.go
@@ -1,0 +1,82 @@
+package httpx
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+// maxRedirects caps a redirect chain (Go's implicit default is also 10; we make it
+// explicit because installing a CheckRedirect replaces that default).
+const maxRedirects = 10
+
+// SecureClient returns an http.Client with the given timeout and the
+// DenyInternalRedirect policy. Use it for every outbound call to an operator- or
+// externally-configurable endpoint (model, forge, notifier, metrics/logs) so a
+// redirect can't be steered at an internal address.
+func SecureClient(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout, CheckRedirect: DenyInternalRedirect}
+}
+
+// DenyInternalRedirect is an http.Client CheckRedirect that caps the redirect chain
+// and refuses a redirect to a private/loopback/link-local target — closing the
+// redirect → 169.254.169.254 (cloud metadata) SSRF exfil path. It fails CLOSED on an
+// unresolvable target; public redirects are still followed.
+//
+// It guards only chains that ORIGINATED at a public address — the actual SSRF threat
+// (a public endpoint steered at an internal target). A chain that started internal (an
+// in-cluster model/metrics/logs backend behind a proxy, or a plain http→https / trailing
+// -slash redirect on a private host) is legitimate and is allowed, so the guard never
+// breaks in-cluster traffic. Dial-time DNS-rebinding protection is out of scope.
+func DenyInternalRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", maxRedirects)
+	}
+	// In-cluster-origin chains redirect among private addresses legitimately — only
+	// guard chains that began at a public endpoint.
+	if len(via) > 0 && hostIsInternal(via[0].URL.Hostname()) {
+		return nil
+	}
+	host := req.URL.Hostname()
+	ips, err := lookupIP(host)
+	if err != nil {
+		return fmt.Errorf("redirect host %q: %w", host, err)
+	}
+	for _, ip := range ips {
+		if isInternalIP(ip) {
+			return fmt.Errorf("refusing redirect to internal address %s (host %q)", ip, host)
+		}
+	}
+	return nil
+}
+
+// hostIsInternal reports whether host resolves entirely to internal addresses. A
+// resolution failure or empty result returns false (treat as possibly external, so
+// the redirect target is still guarded).
+func hostIsInternal(host string) bool {
+	ips, err := lookupIP(host)
+	if err != nil || len(ips) == 0 {
+		return false
+	}
+	for _, ip := range ips {
+		if !isInternalIP(ip) {
+			return false
+		}
+	}
+	return true
+}
+
+// lookupIP resolves a redirect host to IPs. A package var so tests can stub DNS
+// without touching the network; an IP literal short-circuits resolution.
+var lookupIP = func(host string) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		return []net.IP{ip}, nil
+	}
+	return net.LookupIP(host)
+}
+
+func isInternalIP(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsUnspecified()
+}

--- a/internal/httpx/client_test.go
+++ b/internal/httpx/client_test.go
@@ -1,0 +1,113 @@
+package httpx
+
+import (
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func mkreq(t *testing.T, rawurl string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodGet, rawurl, nil)
+	if err != nil {
+		t.Fatalf("new request %q: %v", rawurl, err)
+	}
+	return r
+}
+
+func TestDenyInternalRedirect(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		deny bool
+	}{
+		{"cloud metadata (link-local)", "http://169.254.169.254/latest/meta-data/", true},
+		{"loopback", "http://127.0.0.1:8080/x", true},
+		{"private 10/8", "http://10.0.0.5/x", true},
+		{"private 192.168", "http://192.168.1.1/x", true},
+		{"unspecified", "http://0.0.0.0/x", true},
+		{"public IP", "http://8.8.8.8/x", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := DenyInternalRedirect(mkreq(t, tc.url), nil)
+			if tc.deny && err == nil {
+				t.Fatalf("expected redirect to %s to be denied", tc.url)
+			}
+			if !tc.deny && err != nil {
+				t.Fatalf("expected redirect to %s to be allowed, got %v", tc.url, err)
+			}
+		})
+	}
+}
+
+func TestDenyInternalRedirectHostname(t *testing.T) {
+	orig := lookupIP
+	defer func() { lookupIP = orig }()
+
+	lookupIP = func(string) ([]net.IP, error) { return []net.IP{net.ParseIP("10.1.2.3")}, nil }
+	if err := DenyInternalRedirect(mkreq(t, "http://evil.example.com/"), nil); err == nil {
+		t.Fatal("expected deny when a hostname resolves to a private IP (DNS-based SSRF)")
+	}
+
+	lookupIP = func(string) ([]net.IP, error) { return []net.IP{net.ParseIP("93.184.216.34")}, nil }
+	if err := DenyInternalRedirect(mkreq(t, "http://ok.example.com/"), nil); err != nil {
+		t.Fatalf("expected allow when a hostname resolves to a public IP, got %v", err)
+	}
+}
+
+func TestDenyInternalRedirectFailsClosedOnResolveError(t *testing.T) {
+	orig := lookupIP
+	defer func() { lookupIP = orig }()
+	lookupIP = func(string) ([]net.IP, error) { return nil, net.UnknownNetworkError("nope") }
+	if err := DenyInternalRedirect(mkreq(t, "http://wherever.example.com/"), nil); err == nil {
+		t.Fatal("expected deny (fail closed) when the redirect host cannot be resolved")
+	}
+}
+
+func TestDenyInternalRedirectCap(t *testing.T) {
+	via := make([]*http.Request, maxRedirects)
+	if err := DenyInternalRedirect(mkreq(t, "http://8.8.8.8/"), via); err == nil {
+		t.Fatalf("expected error once the redirect cap (%d) is reached", maxRedirects)
+	}
+}
+
+func TestSecureClient(t *testing.T) {
+	c := SecureClient(5 * time.Second)
+	if c.Timeout != 5*time.Second {
+		t.Fatalf("timeout not set: %v", c.Timeout)
+	}
+	if c.CheckRedirect == nil {
+		t.Fatal("SecureClient must install a CheckRedirect policy")
+	}
+}
+
+func TestDenyInternalRedirectAllowsInternalOrigin(t *testing.T) {
+	orig := lookupIP
+	defer func() { lookupIP = orig }()
+	// Both the in-cluster origin and the redirect target resolve to a ClusterIP — e.g.
+	// an in-cluster backend doing http→https or a trailing-slash redirect on itself.
+	lookupIP = func(string) ([]net.IP, error) { return []net.IP{net.ParseIP("10.96.0.10")}, nil }
+	origin := mkreq(t, "http://vllm.ai.svc.cluster.local/v1/chat")
+	target := mkreq(t, "https://vllm.ai.svc.cluster.local/v1/chat")
+	if err := DenyInternalRedirect(target, []*http.Request{origin}); err != nil {
+		t.Fatalf("an internal-origin internal redirect must be allowed, got %v", err)
+	}
+}
+
+func TestDenyInternalRedirectBlocksExternalToInternal(t *testing.T) {
+	orig := lookupIP
+	defer func() { lookupIP = orig }()
+	lookupIP = func(host string) ([]net.IP, error) {
+		if host == "api.example.com" {
+			return []net.IP{net.ParseIP("93.184.216.34")}, nil // public origin
+		}
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil // anything else → metadata
+	}
+	origin := mkreq(t, "https://api.example.com/x")
+	target := mkreq(t, "http://metadata.example/latest")
+	if err := DenyInternalRedirect(target, []*http.Request{origin}); err == nil {
+		t.Fatal("a public→internal (metadata) redirect must be blocked")
+	}
+}

--- a/internal/logs/victorialogs/victorialogs.go
+++ b/internal/logs/victorialogs/victorialogs.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -30,7 +31,7 @@ const defaultMaxLines = 1000
 
 // New builds a client for a VictoriaLogs base URL.
 func New(baseURL string) *Client {
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), limit: 100, maxLines: defaultMaxLines, http: &http.Client{Timeout: 30 * time.Second}}
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), limit: 100, maxLines: defaultMaxLines, http: httpx.SecureClient(30 * time.Second)}
 }
 
 var _ providers.LogsProvider = (*Client)(nil)

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -24,7 +25,7 @@ type Client struct {
 
 // New builds a client for a Prometheus/VictoriaMetrics base URL.
 func New(baseURL string) *Client {
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: &http.Client{Timeout: 30 * time.Second}}
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpx.SecureClient(30 * time.Second)}
 }
 
 var _ providers.MetricsProvider = (*Client)(nil)

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -46,7 +46,7 @@ func New(baseURL, model, apiKey string) *Client {
 		model:     model,
 		apiKey:    apiKey,
 		maxTokens: defaultMaxTokens,
-		http:      &http.Client{Timeout: 2 * time.Minute},
+		http:      httpx.SecureClient(2 * time.Minute),
 	}
 }
 

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -42,7 +42,7 @@ func New(baseURL, model, apiKey string) *Client {
 		baseURL: strings.TrimRight(baseURL, "/"),
 		model:   model,
 		apiKey:  apiKey,
-		http:    &http.Client{Timeout: 2 * time.Minute},
+		http:    httpx.SecureClient(2 * time.Minute),
 	}
 }
 

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -30,7 +30,7 @@ func New(baseURL, model, apiKey string) *Client {
 		baseURL: strings.TrimRight(baseURL, "/"),
 		model:   model,
 		apiKey:  apiKey,
-		http:    &http.Client{Timeout: 2 * time.Minute},
+		http:    httpx.SecureClient(2 * time.Minute),
 	}
 }
 

--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -40,7 +41,7 @@ func NewMatrix(homeserver, roomID, token string) *Matrix {
 		homeserver: strings.TrimRight(homeserver, "/"),
 		roomID:     roomID,
 		token:      token,
-		http:       &http.Client{Timeout: 15 * time.Second},
+		http:       httpx.SecureClient(15 * time.Second),
 	}
 	m.txn.Store(time.Now().UnixNano())
 	return m

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -23,7 +24,7 @@ type Slack struct {
 
 // NewSlack builds a Slack webhook notifier.
 func NewSlack(webhookURL string) *Slack {
-	return &Slack{webhookURL: webhookURL, http: &http.Client{Timeout: 15 * time.Second}}
+	return &Slack{webhookURL: webhookURL, http: httpx.SecureClient(15 * time.Second)}
 }
 
 var _ providers.Notifier = (*Slack)(nil)
@@ -64,7 +65,7 @@ type SlackBot struct {
 
 // NewSlackBot builds a bot-token Slack notifier posting to channel (ID or name).
 func NewSlackBot(token, channel string) *SlackBot {
-	return &SlackBot{token: token, channel: channel, baseURL: "https://slack.com", http: &http.Client{Timeout: 15 * time.Second}}
+	return &SlackBot{token: token, channel: channel, baseURL: "https://slack.com", http: httpx.SecureClient(15 * time.Second)}
 }
 
 var _ providers.Notifier = (*SlackBot)(nil)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/coalesce"
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/telemetry"
@@ -339,7 +340,7 @@ func (s *Server) updateSlack(ctx context.Context, responseURL, text string) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{Timeout: 10 * time.Second}
+	client := httpx.SecureClient(10 * time.Second)
 	if resp, err := client.Do(req); err == nil {
 		_ = resp.Body.Close()
 	}


### PR DESCRIPTION
## Close the redirect → cloud-metadata SSRF path

An outbound client that follows redirects can be steered from an operator-trusted initial URL to an internal address — most dangerously `http://169.254.169.254/` (cloud metadata), exfiltrating instance credentials. The existing SSRF allowlists only cover the **initial** URL (approver / Slack `response_url`); a 3xx bypasses them.

Adds `httpx.SecureClient(timeout)` + `httpx.DenyInternalRedirect` — a `CheckRedirect` that caps the chain and refuses a hop to a private/loopback/link-local target (fails **closed** on an unresolvable host; still follows public redirects). Wired into **every** outbound client: model (anthropic/gemini/openai/embed), notifier (slack ×2/matrix), forge (github), metrics (prometheus/VM), logs (victorialogs), and the server's Slack `response_url` client.

**Only public-origin chains are guarded.** An in-cluster-origin redirect (an in-cluster backend doing `http→https` or a trailing-slash 301 among private ClusterIPs) is legitimate and allowed — so the guard never breaks in-cluster traffic. Dial-time DNS-rebinding protection is out of scope.

### Verification
`go build` · `go vet` · `go test -race ./...` (full suite) · `golangci-lint` 0 issues. Six redirect-guard unit tests (literal + DNS-resolved private denied, public allowed, internal-origin allowed, public→internal blocked, fail-closed, cap). **Full k3d e2e: 45/45, ALL FEATURES VERIFIED** — every outbound client (model · Slack · Matrix · curate→GitHub · metrics/logs) green with zero redirect-guard false positives.

### Incidental: 2nd commit — e2e harness fix
Validating this surfaced a **pre-existing flaky abort** in the e2e harness (latent on `main`): step-7b's `llmetric` piped `curl | awk '…exit}'`, so when the matched metric lands early in the `/metrics` output, awk closes the pipe and SIGPIPE-kills curl (exit 23), which `pipefail`+`set -e` turn into a spurious whole-run abort. Fixed by mirroring the already-safe `metric()` helper (capture curl to a var with `|| true`, then `echo | awk`). Unrelated to runlore — `/metrics` content is unchanged — but it's what made this PR's e2e flake; folded in so the run is reliable.
