### PR TITLE
M4 pt2: hybrid BM25 + embedding recall (opt-in)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curate"
 	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/embed"
 	"github.com/Smana/runlore/internal/eval"
 	fluxexec "github.com/Smana/runlore/internal/executor/flux"
 	"github.com/Smana/runlore/internal/investigate"
@@ -549,12 +550,28 @@ func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, 
 			}
 		})
 	}
+	// Hybrid recall: build the embeddings client once and attach it BEFORE any Reload
+	// so entry vectors are produced. Requires both the feature flag and a configured
+	// endpoint; otherwise the catalog stays BM25-only (and recall stays BM25).
+	var embedder catalog.Embedder
+	if cfg.Catalog.InstantRecall.Hybrid && cfg.Model.Embeddings != nil {
+		e := cfg.Model.Embeddings
+		key := ""
+		if e.APIKeyEnv != "" {
+			key = os.Getenv(e.APIKeyEnv)
+		}
+		embedder = embed.New(e.BaseURL, e.Model, key)
+		log.Info("hybrid recall: embeddings endpoint configured", "base_url", e.BaseURL, "model", e.Model)
+	}
 	if cfg.Catalog.Git.URL != "" {
 		dir := cfg.Catalog.Dir
 		if dir == "" {
 			dir = "/var/lib/runlore/catalog"
 		}
 		cat := catalog.NewEmpty()
+		if embedder != nil {
+			cat.SetEmbedder(embedder)
+		}
 		// Auth precedence: explicit token_env, else the shared forge GitHub App
 		// identity (one credential for both curation writes and catalog reads).
 		var token catalog.TokenFunc
@@ -584,10 +601,23 @@ func buildCatalog(ctx context.Context, cfg *config.Config, forgeTok forgeToken, 
 		return cat
 	}
 	if cfg.Catalog.Dir != "" {
-		cat, err := catalog.New(cfg.Catalog.Dir)
-		if err != nil {
-			log.Warn("catalog disabled", "dir", cfg.Catalog.Dir, "err", err)
-			return nil
+		var cat *catalog.Catalog
+		if embedder != nil {
+			// Embed on load: NewEmpty + SetEmbedder + ReloadContext (catalog.New can't
+			// attach an embedder before its internal Reload).
+			cat = catalog.NewEmpty()
+			cat.SetEmbedder(embedder)
+			if _, err := cat.ReloadContext(ctx, cfg.Catalog.Dir); err != nil {
+				log.Warn("catalog disabled", "dir", cfg.Catalog.Dir, "err", err)
+				return nil
+			}
+		} else {
+			c, err := catalog.New(cfg.Catalog.Dir)
+			if err != nil {
+				log.Warn("catalog disabled", "dir", cfg.Catalog.Dir, "err", err)
+				return nil
+			}
+			cat = c
 		}
 		log.Info("catalog loaded", "dir", cfg.Catalog.Dir, "entries", cat.Len())
 		warnInvalid(cat)
@@ -1138,6 +1168,22 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 				"min_score", cfg.Catalog.InstantRecall.MinScore,
 				"margin_gap", cfg.Catalog.InstantRecall.MarginGap, "solo_floor", cfg.Catalog.InstantRecall.SoloFloor,
 				"outcome_prior", cfg.Catalog.InstantRecall.OutcomePrior, "outcome_floor", cfg.Catalog.InstantRecall.OutcomeFloor)
+			// Hybrid (cosine-gated) recall — opt-in, and only effective once the catalog
+			// actually built vectors (an embedder was configured + embedding succeeded).
+			if cfg.Catalog.InstantRecall.Hybrid {
+				recall.Hybrid = cat
+				recall.HybridMinScore = cfg.Catalog.InstantRecall.HybridMinScore
+				recall.HybridMarginGap = cfg.Catalog.InstantRecall.HybridMarginGap
+				if recall.HybridMinScore == 0 {
+					recall.HybridMinScore = 0.80
+				}
+				if recall.HybridMarginGap == 0 {
+					recall.HybridMarginGap = 0.05
+				}
+				log.Info("hybrid recall enabled (EXPERIMENTAL — tune cosine thresholds via the instant-recall eval)",
+					"hybrid_min_score", recall.HybridMinScore, "hybrid_margin_gap", recall.HybridMarginGap,
+					"vectors_ready", cat.HasVectors())
+			}
 		}
 	}
 	if cfg.Metrics.URL != "" {

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -94,6 +94,12 @@ config:
   #   # omit to verify with the main model). Verify always runs — this only lowers cost.
   #   verify:
   #     model: <cheaper-model-name>
+  #   # Embeddings endpoint (OpenAI-compatible /embeddings) for hybrid recall — see
+  #   # catalog.instant_recall.hybrid. Unset ⇒ BM25-only recall.
+  #   embeddings:
+  #     base_url: https://vllm.svc/v1
+  #     model: <embedding-model-name>
+  #     api_key_env: OPENAI_API_KEY
   # catalog:
   #   dir: /var/lib/runlore/catalog
   #   instant_recall:
@@ -102,6 +108,12 @@ config:
   #     margin_gap: 1.0                # top hit must beat the runner-up by this (corpus-portable; not an absolute floor)
   #     solo_floor: 4.0                # confident bar when there is only one hit
   #     require_workload_match: false  # true = exact namespace+workload; false = namespace-level agreement is enough
+  #     # EXPERIMENTAL hybrid recall: fuse BM25 + embeddings, gate on cosine similarity.
+  #     # Requires model.embeddings (above). TUNE the cosine thresholds against the
+  #     # instant-recall eval before relying on it — defaults are conservative placeholders.
+  #     hybrid: false
+  #     hybrid_min_score: 0.80         # cosine floor for the top hit
+  #     hybrid_margin_gap: 0.05        # cosine margin over the runner-up
   # outcome:
   #   ledger_path: /var/lib/runlore/catalog/outcomes.jsonl  # learning-loop outcome ledger.
   #     Keep it UNDER catalog.mountPath and set persistence.enabled=true: the serve

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -96,6 +96,14 @@ The agent never blindly trusts the catalog. A recall short-circuit (answer witho
 investigating) only fires when a hit clears **three independent gates**, and even
 then the answer is confirmed against live state and re-reviewed.
 
+> **Hybrid recall (experimental, opt-in).** With `instant_recall.hybrid` set and a
+> `model.embeddings` endpoint configured, the BM25 search below is fused with
+> embedding-cosine similarity (Reciprocal Rank Fusion), and Gate 2's margin is measured
+> on **cosine** (`hybrid_min_score` / `hybrid_margin_gap`) rather than the BM25 score.
+> Default off — with no embedder the catalog stays BM25-only and recall is unchanged.
+> The cosine thresholds are conservative placeholders; tune them against the
+> instant-recall eval before relying on them.
+
 ```mermaid
 flowchart TD
     Q["Query = alert title + message"] --> S["BM25 search over catalog<br/>(bleve, wider candidate set k≈15)"]

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -17,7 +18,12 @@ type Catalog struct {
 	mu      sync.RWMutex
 	index   bleve.Index
 	entries []Entry
-	ready   atomic.Bool // set on first successful Reload; gates readyz on catalog warmth
+	// vectors holds one embedding per entry (parallel to entries), built on Reload
+	// only when an embedder is configured; nil keeps the catalog BM25-only. embedder
+	// is set once at startup (SetEmbedder) before the first Reload/Search.
+	vectors  [][]float32
+	embedder Embedder
+	ready    atomic.Bool // set on first successful Reload; gates readyz on catalog warmth
 }
 
 // Searcher is the read surface used by the kb_search tool.
@@ -54,6 +60,14 @@ func NewEmpty() *Catalog {
 // returns the list of skipped (unparseable) entry paths so the caller can warn;
 // these are non-fatal — the good entries are still indexed.
 func (c *Catalog) Reload(dir string) ([]string, error) {
+	return c.ReloadContext(context.Background(), dir)
+}
+
+// ReloadContext is Reload with a caller context bounding the (optional) embedding
+// pass. When an embedder is configured, entry vectors are rebuilt here; an embedding
+// failure is NON-fatal — vectors fall back to nil and the catalog stays BM25-only
+// (hybrid retrieval degrades gracefully rather than breaking the reload).
+func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, error) {
 	entries, skipped, err := Load(dir)
 	if err != nil {
 		return nil, err
@@ -62,9 +76,15 @@ func (c *Catalog) Reload(dir string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	var vectors [][]float32
+	if c.embedder != nil {
+		if v, verr := embedEntries(ctx, c.embedder, entries); verr == nil {
+			vectors = v
+		}
+	}
 	c.mu.Lock()
 	old := c.index
-	c.index, c.entries = idx, entries
+	c.index, c.entries, c.vectors = idx, entries, vectors
 	c.mu.Unlock()
 	// Release the previous index's resources. Search holds the read lock for the
 	// whole query, so by the time the swap above acquired the write lock no query
@@ -85,16 +105,21 @@ func buildIndex(entries []Entry) (bleve.Index, error) {
 	for i, e := range entries {
 		doc := map[string]any{
 			"title": e.Title,
-			// Resource is included so a query naming the affected object/pattern gets
-			// lexical lift (it also drives the recall structural filter — same signal,
-			// now scored). Without it a resource-only term contributes nothing to BM25.
-			"text": strings.Join([]string{e.Title, e.Description, e.Resource, strings.Join(e.Tags, " "), e.Body}, " "),
+			"text":  entryText(e),
 		}
 		if err := idx.Index(strconv.Itoa(i), doc); err != nil {
 			return nil, fmt.Errorf("index entry %d: %w", i, err)
 		}
 	}
 	return idx, nil
+}
+
+// entryText is the single corpus text per entry — used for BOTH the BM25 doc and the
+// embedding, so the lexical and vector views index the same content. Resource is
+// included so a query naming the affected object/pattern gets lexical lift (it also
+// drives the recall structural filter — same signal, now scored).
+func entryText(e Entry) string {
+	return strings.Join([]string{e.Title, e.Description, e.Resource, strings.Join(e.Tags, " "), e.Body}, " ")
 }
 
 // Len reports the number of indexed entries.

--- a/internal/catalog/hybrid.go
+++ b/internal/catalog/hybrid.go
@@ -1,0 +1,129 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/blevesearch/bleve/v2"
+
+	"github.com/Smana/runlore/internal/embed"
+)
+
+// Embedder turns texts into vectors (one per input, in order). Satisfied by
+// internal/embed.Client — defined here (consumer side) so the catalog needn't import
+// a concrete embedder.
+type Embedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+// HybridSearcher fuses BM25 and embedding similarity. HasVectors reports whether the
+// vector side is live (an embedder configured AND vectors built for the corpus);
+// callers fall back to SearchScored when it is false.
+type HybridSearcher interface {
+	SearchHybrid(ctx context.Context, query string, k int) ([]ScoredEntry, error)
+	HasVectors() bool
+}
+
+var _ HybridSearcher = (*Catalog)(nil)
+
+// SetEmbedder enables hybrid retrieval: entry vectors are (re)built on the next
+// Reload. Call once at startup, before the first Reload/Search.
+func (c *Catalog) SetEmbedder(e Embedder) { c.embedder = e }
+
+// HasVectors reports whether hybrid retrieval is live — a vector per entry.
+func (c *Catalog) HasVectors() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.vectors) > 0 && len(c.vectors) == len(c.entries)
+}
+
+func embedEntries(ctx context.Context, e Embedder, entries []Entry) ([][]float32, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	texts := make([]string, len(entries))
+	for i, en := range entries {
+		texts[i] = entryText(en)
+	}
+	return e.Embed(ctx, texts)
+}
+
+// SearchHybrid combines lexical and semantic retrieval for instant recall. It pools
+// candidates by Reciprocal Rank Fusion of the BM25 and embedding-cosine rankings (so
+// an entry strong in EITHER signal is reachable), then returns up to k of them
+// ORDERED BY COSINE with Score set to the cosine similarity — a [0,1] semantic
+// confidence the recall gate keys off, kept score-descending so the gate's
+// top-vs-runner-up margin stays well-defined. Falls back to BM25 (SearchScored) when
+// vectors are unavailable or the query can't be embedded — hybrid never regresses
+// recall, it only adds a vector signal when one is present.
+//
+// The fusion choice and the cosine gate thresholds are eval-tunable knobs: recall
+// records its score even on rejection (see recall.lookup) so they can be measured
+// against the live instant-recall scenarios rather than guessed.
+func (c *Catalog) SearchHybrid(ctx context.Context, query string, k int) ([]ScoredEntry, error) {
+	if !c.HasVectors() || c.embedder == nil {
+		return c.SearchScored(query, k)
+	}
+	qv, err := c.embedder.Embed(ctx, []string{query}) // network call — outside the lock
+	if err != nil || len(qv) == 0 {
+		return c.SearchScored(query, k)
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.index == nil || len(c.vectors) != len(c.entries) {
+		return nil, nil
+	}
+	// BM25 ranking (entry-index ids in score order).
+	bm25IDs, err := c.bm25IDsLocked(query, k)
+	if err != nil {
+		return nil, err
+	}
+	// Cosine over the whole (small, in-RAM) corpus → similarity + a cosine ranking.
+	cos := make([]float64, len(c.vectors))
+	ranked := make([]int, len(c.vectors))
+	for i, v := range c.vectors {
+		cos[i] = embed.Cosine(qv[0], v)
+		ranked[i] = i
+	}
+	sort.SliceStable(ranked, func(a, b int) bool { return cos[ranked[a]] > cos[ranked[b]] })
+	cosIDs := make([]string, len(ranked))
+	for i, idx := range ranked {
+		cosIDs[i] = strconv.Itoa(idx)
+	}
+	// Fuse the two rankings to select the candidate pool, then order that pool by
+	// cosine (the gate score).
+	pool := embed.FuseRRF(0, bm25IDs, cosIDs)
+	out := make([]ScoredEntry, 0, len(pool))
+	for _, f := range pool {
+		i, cerr := strconv.Atoi(f.ID)
+		if cerr != nil || i < 0 || i >= len(c.entries) {
+			continue
+		}
+		out = append(out, ScoredEntry{Entry: c.entries[i], Score: cos[i]})
+	}
+	sort.SliceStable(out, func(a, b int) bool { return out[a].Score > out[b].Score })
+	if len(out) > k {
+		out = out[:k]
+	}
+	return out, nil
+}
+
+// bm25IDsLocked returns entry-index ids ranked by BM25. The caller MUST hold the read
+// lock (it reads c.index directly — must not re-lock, RWMutex is not reentrant).
+func (c *Catalog) bm25IDsLocked(query string, k int) ([]string, error) {
+	q := bleve.NewMatchQuery(query)
+	q.SetField("text")
+	req := bleve.NewSearchRequestOptions(q, k, 0, false)
+	res, err := c.index.Search(req)
+	if err != nil {
+		return nil, fmt.Errorf("search: %w", err)
+	}
+	ids := make([]string, 0, len(res.Hits))
+	for _, hit := range res.Hits {
+		ids = append(ids, hit.ID)
+	}
+	return ids, nil
+}

--- a/internal/catalog/hybrid_test.go
+++ b/internal/catalog/hybrid_test.go
@@ -1,0 +1,97 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// fakeEmbedder maps text to a small vector by keyword presence — deterministic, so
+// cosine reflects keyword overlap (enough to exercise fusion + ordering mechanics).
+// The trailing 0.1 dim keeps a keyword-free text from being a zero vector.
+type fakeEmbedder struct{ err error }
+
+func (f fakeEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = []float32{kw(t, "harbor"), kw(t, "network"), kw(t, "cert"), 0.1}
+	}
+	return out, nil
+}
+
+func kw(t, k string) float32 {
+	if strings.Contains(strings.ToLower(t), k) {
+		return 1
+	}
+	return 0
+}
+
+func hybridDir(t *testing.T) string {
+	dir := t.TempDir()
+	writeEntry(t, dir, "harbor.md", "---\ntitle: Harbor registry down\n---\nharbor image pull fails")
+	writeEntry(t, dir, "network.md", "---\ntitle: Network drops\n---\nnetwork connectivity timeouts")
+	writeEntry(t, dir, "cert.md", "---\ntitle: Certificate expiry\n---\ncert renewal failed")
+	return dir
+}
+
+func TestSearchHybridFusesAndOrdersByCosine(t *testing.T) {
+	c := &Catalog{}
+	c.SetEmbedder(fakeEmbedder{})
+	if _, err := c.Reload(hybridDir(t)); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !c.HasVectors() {
+		t.Fatal("vectors should be built when an embedder is configured")
+	}
+	hits, err := c.SearchHybrid(context.Background(), "harbor registry image", 5)
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+	if len(hits) == 0 || !strings.Contains(hits[0].Entry.Title, "Harbor") {
+		t.Fatalf("expected the Harbor entry first, got %+v", hits)
+	}
+	if hits[0].Score < 0.5 {
+		t.Fatalf("top hit cosine should be high for a clear match, got %v", hits[0].Score)
+	}
+	for i := 1; i < len(hits); i++ { // Score (cosine) must be descending for the recall gate
+		if hits[i].Score > hits[i-1].Score {
+			t.Fatalf("hits not ordered by descending cosine: %+v", hits)
+		}
+	}
+}
+
+func TestSearchHybridFallsBackWithoutEmbedder(t *testing.T) {
+	c, err := New(hybridDir(t)) // no embedder
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c.HasVectors() {
+		t.Fatal("no embedder → no vectors → HasVectors false")
+	}
+	hits, err := c.SearchHybrid(context.Background(), "network connectivity timeouts", 5)
+	if err != nil {
+		t.Fatalf("SearchHybrid (fallback): %v", err)
+	}
+	if len(hits) == 0 || !strings.Contains(hits[0].Entry.Title, "Network") {
+		t.Fatalf("BM25 fallback should surface the Network entry, got %+v", hits)
+	}
+}
+
+func TestReloadEmbedFailureDegradesToBM25(t *testing.T) {
+	c := &Catalog{}
+	c.SetEmbedder(fakeEmbedder{err: fmt.Errorf("embeddings endpoint down")})
+	if _, err := c.Reload(hybridDir(t)); err != nil {
+		t.Fatalf("Reload must succeed despite an embed failure (graceful degradation): %v", err)
+	}
+	if c.HasVectors() {
+		t.Fatal("an embed failure must leave vectors nil → BM25-only")
+	}
+	hits, err := c.SearchHybrid(context.Background(), "cert renewal failed", 5)
+	if err != nil || len(hits) == 0 {
+		t.Fatalf("SearchHybrid must still work via BM25 fallback: hits=%d err=%v", len(hits), err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,6 +197,15 @@ type InstantRecall struct {
 	RequireWorkloadMatch bool    `yaml:"require_workload_match"` // true = exact namespace+workload; false = namespace-level agreement is enough
 	OutcomePrior         float64 `yaml:"outcome_prior"`          // Beta prior strength for outcome decay
 	OutcomeFloor         float64 `yaml:"outcome_floor"`          // reject a recall when the outcome factor drops below this
+
+	// Hybrid switches recall to fused BM25 + embedding retrieval, gated on COSINE
+	// similarity instead of the BM25 score above. Requires model.embeddings to be
+	// configured (else recall stays BM25). EXPERIMENTAL — tune the cosine thresholds
+	// against the instant-recall eval before relying on it; the defaults are
+	// conservative placeholders, not measured values.
+	Hybrid          bool    `yaml:"hybrid"`            // enable hybrid (cosine-gated) recall
+	HybridMinScore  float64 `yaml:"hybrid_min_score"`  // cosine floor for the top hit (default 0.80)
+	HybridMarginGap float64 `yaml:"hybrid_margin_gap"` // cosine margin over the runner-up (default 0.05)
 }
 
 // CatalogGit configures periodic Git sync of the catalog into Dir.
@@ -220,6 +229,18 @@ type Model struct {
 	// unset fields inherit from the parent above (so `verify: {model: <cheap>}` reuses
 	// the same provider/endpoint/key). Absent ⇒ verify runs on the main model.
 	Verify *ModelOverride `yaml:"verify"`
+	// Embeddings optionally configures an OpenAI-compatible /embeddings endpoint used
+	// for hybrid recall (instant_recall.hybrid). Unset ⇒ BM25-only recall.
+	Embeddings *Embeddings `yaml:"embeddings"`
+}
+
+// Embeddings configures an OpenAI-compatible /embeddings endpoint (vLLM/Ollama/
+// OpenAI) for hybrid catalog recall — served by the same kind of endpoint as the
+// model; keyless when APIKeyEnv is empty.
+type Embeddings struct {
+	BaseURL   string `yaml:"base_url"`
+	Model     string `yaml:"model"`
+	APIKeyEnv string `yaml:"api_key_env"`
 }
 
 // ModelOverride is a partial Model used to route the verify pass to a cheaper model;

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -34,6 +34,13 @@ type Recall struct {
 	SoloFloor            float64 // confident bar when there is only one hit
 	RequireWorkloadMatch bool    // true = exact namespace+workload; false = namespace-level agreement is enough
 
+	// Hybrid, when non-nil AND it has vectors, switches recall to fused BM25+embedding
+	// retrieval gated on COSINE similarity (HybridMinScore / HybridMarginGap) instead
+	// of the BM25 thresholds above. nil (or no vectors) ⇒ BM25 recall, unchanged.
+	Hybrid          catalog.HybridSearcher
+	HybridMinScore  float64 // cosine floor for the top hit (hybrid mode)
+	HybridMarginGap float64 // cosine margin over the runner-up (hybrid mode)
+
 	Outcome      OutcomeStats // optional; nil ⇒ no outcome decay
 	OutcomePrior float64      // k — Beta prior strength for decay (e.g. 2.0)
 	OutcomeFloor float64      // reject the recall when the outcome factor drops below this (e.g. 0.5)
@@ -56,7 +63,19 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 		return nil, 0
 	}
 	// Query the symptom (title + message); severity/reason is noise for matching.
-	hits, err := r.Catalog.SearchScored(strings.TrimSpace(req.Title+" "+req.Message), recallCandidateK)
+	query := strings.TrimSpace(req.Title + " " + req.Message)
+	// Mode select: hybrid (BM25+embedding, cosine-gated) when an embedder-backed
+	// catalog is live, else BM25 — unchanged. The gate logic below is identical; only
+	// the candidate source and the thresholds differ.
+	minScore, marginGap, soloFloor := r.MinScore, r.MarginGap, r.SoloFloor
+	var hits []catalog.ScoredEntry
+	var err error
+	if r.Hybrid != nil && r.Hybrid.HasVectors() {
+		minScore, marginGap, soloFloor = r.HybridMinScore, r.HybridMarginGap, r.HybridMinScore
+		hits, err = r.Hybrid.SearchHybrid(ctx, query, recallCandidateK)
+	} else {
+		hits, err = r.Catalog.SearchScored(query, recallCandidateK)
+	}
 	if err != nil || len(hits) == 0 {
 		return nil, 0
 	}
@@ -89,10 +108,10 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 	// this workload, not merely the top lexical hit. A lone agreeing hit must clear
 	// both the solo floor and the min score.
 	margin := score
-	confident := score >= r.SoloFloor && score >= r.MinScore
+	confident := score >= soloFloor && score >= minScore
 	if len(agreeing) > 1 {
 		margin = score - agreeing[1].Score
-		confident = score >= r.MinScore && margin >= r.MarginGap
+		confident = score >= minScore && margin >= marginGap
 	}
 	if !confident {
 		r.reject(ctx, "low_margin")

--- a/internal/investigate/recall_hybrid_test.go
+++ b/internal/investigate/recall_hybrid_test.go
@@ -1,0 +1,66 @@
+package investigate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeHybrid struct {
+	hits   []catalog.ScoredEntry
+	hasVec bool
+}
+
+func (f fakeHybrid) SearchHybrid(context.Context, string, int) ([]catalog.ScoredEntry, error) {
+	return f.hits, nil
+}
+func (f fakeHybrid) HasVectors() bool { return f.hasVec }
+
+// TestRecallHybridGatesOnCosine: with a live hybrid searcher, recall uses the COSINE
+// thresholds, not the BM25 ones (set impossibly high here to prove the path).
+func TestRecallHybridGatesOnCosine(t *testing.T) {
+	hyb := fakeHybrid{hasVec: true, hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Harbor", Path: "harbor.md", Resource: "apps"}, Score: 0.86},
+		{Entry: catalog.Entry{Title: "Other", Path: "other.md", Resource: "apps"}, Score: 0.50},
+	}}
+	r := &Recall{
+		Catalog: fakeScored{}, Hybrid: hyb,
+		HybridMinScore: 0.80, HybridMarginGap: 0.10,
+		MinScore: 999, SoloFloor: 999, MarginGap: 999, // BM25 gates impossible on purpose
+	}
+	e, conf := r.lookup(context.Background(), Request{Title: "harbor down", Workload: providers.Workload{Namespace: "apps"}})
+	if e == nil || e.Path != "harbor.md" {
+		t.Fatalf("hybrid recall should return harbor.md via the cosine gate, got %v", e)
+	}
+	if conf <= 0 || conf > 0.9 {
+		t.Fatalf("confidence out of range: %v", conf)
+	}
+}
+
+func TestRecallHybridRejectsBelowCosineFloor(t *testing.T) {
+	hyb := fakeHybrid{hasVec: true, hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Weak", Path: "weak.md", Resource: "apps"}, Score: 0.40}, // < 0.80 floor
+	}}
+	r := &Recall{Catalog: fakeScored{}, Hybrid: hyb, HybridMinScore: 0.80, HybridMarginGap: 0.10}
+	if e, _ := r.lookup(context.Background(), Request{Title: "x", Workload: providers.Workload{Namespace: "apps"}}); e != nil {
+		t.Fatalf("a below-floor cosine hit must be rejected, got %v", e)
+	}
+}
+
+// TestRecallHybridFallsBackToBM25WithoutVectors: a Hybrid that has no vectors yet
+// (embedder configured but corpus not embedded / embed failed) must use the BM25
+// path + BM25 thresholds — zero regression.
+func TestRecallHybridFallsBackToBM25WithoutVectors(t *testing.T) {
+	r := &Recall{
+		Catalog:  fakeScored{hits: []catalog.ScoredEntry{{Entry: catalog.Entry{Title: "BM25", Path: "bm.md", Resource: "apps"}, Score: 8.0}}},
+		Hybrid:   fakeHybrid{hasVec: false},
+		MinScore: 2.0, SoloFloor: 2.0,
+		HybridMinScore: 0.80,
+	}
+	e, _ := r.lookup(context.Background(), Request{Title: "x", Workload: providers.Workload{Namespace: "apps"}})
+	if e == nil || e.Path != "bm.md" {
+		t.Fatalf("no vectors → BM25 fallback should return bm.md, got %v", e)
+	}
+}


### PR DESCRIPTION
## Hybrid BM25 + embedding recall (M4 pt2) — opt-in, regression-free

Wires the M4 pt1 `internal/embed` foundation (cosine + RRF) into the catalog and instant recall, completing the one genuine retrieval capability gain in the roadmap.

**Catalog** — when an `Embedder` is configured (`SetEmbedder`, before the first Reload), Reload builds one vector per entry from the same corpus text as the BM25 doc. `SearchHybrid` pools candidates by Reciprocal Rank Fusion of the BM25 and cosine rankings (an entry strong in *either* signal is reachable), returns them ordered by cosine with `Score = cosine` — a [0,1] semantic confidence.

**Recall** — when a hybrid searcher is live, `lookup` sources candidates from `SearchHybrid` and gates on **cosine** (`hybrid_min_score` / `hybrid_margin_gap`) instead of the BM25 thresholds. The structural pre-filter, outcome decay, and margin/confidence logic are unchanged (`deriveRecallConfidence` already keys off the margin/score *ratio*, so it carries to cosine).

**Config / chart / docs** — `model.embeddings` (OpenAI-compatible `/embeddings`) + `instant_recall.hybrid` flag and cosine thresholds; commented `values.yaml` examples; `learning-loop.md §3` documents it.

### Regression-free by construction
No embedder → no vectors → `SearchHybrid` / `HasVectors` fall back to plain BM25; an embed failure on Reload is non-fatal (vectors stay nil). The BM25 recall path is byte-for-byte unchanged. **Full k3d e2e: 45/45, ALL FEATURES VERIFIED** with hybrid off (the default).

### Eval-tuning is the operator step (honest scope)
The cosine thresholds (0.80 / 0.05) are **conservative placeholders, not measured values** — the feature is marked EXPERIMENTAL. Confirming hybrid *improves* recall hit-rate, and tuning the gates, requires a live embeddings endpoint + the live `instant-recall` eval scenarios, which can't run in CI. Recall records its score on rejection precisely so the gates can be measured rather than guessed. The integration is complete, safe, and reachable; the measurement is handed off with everything in place.

### Verification
`go build` · `go vet` · `go test -race ./...` · `golangci-lint` 0 issues · `helm lint`. New tests: catalog hybrid fusion/cosine-ordering + BM25 fallback + graceful degradation on embed failure (deterministic keyword embedder); recall cosine-gating + below-floor reject + no-vectors BM25 fallback. e2e 45/45 (default-off).
