### PR TITLE
feat(mcp): lore mcp — serve GitOps what-changed over MCP (POS-4 Path A)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/Smana/runlore/internal/kbvalidate"
 	"github.com/Smana/runlore/internal/logging"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
+	"github.com/Smana/runlore/internal/mcp"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
 	anthropic "github.com/Smana/runlore/internal/model/anthropic"
 	gemini "github.com/Smana/runlore/internal/model/gemini"
@@ -85,6 +86,7 @@ Usage:
   lore eval [--config <path>] [--cases <dir>]         replay recorded cases, score RCA identification
   lore eval --live [--scenarios <dir>] [--n 3]        live-fire on the cluster: grade coverage + RCA
   lore curate [--config <path>]                       groom the KB backlog (dedup open PRs)
+  lore mcp [--config <path>]                          serve GitOps what-changed over MCP (stdio; for HolmesGPT et al.)
   lore version                                        print version
 `
 
@@ -121,6 +123,11 @@ func main() {
 	case "curate":
 		if err := runCurate(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "curate:", err)
+			os.Exit(1)
+		}
+	case "mcp":
+		if err := runMCP(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "mcp:", err)
 			os.Exit(1)
 		}
 	case "validate-kb":
@@ -1273,6 +1280,40 @@ func gitOpsFromKube(cfg *config.Config, log *slog.Logger) providers.GitOpsProvid
 		return nil
 	}
 	return buildGitOps(cfg, dc, log)
+}
+
+// runMCP serves RunLore's GitOps what-changed capability over the Model Context
+// Protocol (stdio JSON-RPC), so an MCP client (e.g. HolmesGPT) can call it as a
+// toolset. stdout is the protocol channel; logs go to stderr. Read-only.
+func runMCP(args []string) error {
+	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		return err
+	}
+	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
+	gp := gitOpsFromKube(cfg, log)
+	if gp == nil {
+		return fmt.Errorf("what_changed needs a Kubernetes client + config.gitops")
+	}
+	tool := investigate.WhatChangedTool{GitOps: gp}
+	srv := mcp.NewServer("runlore-whatchanged", version, log)
+	srv.AddTool(mcp.Tool{
+		Name:        "gitops_what_changed",
+		Description: tool.Description(),
+		InputSchema: json.RawMessage(tool.Schema()),
+		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+			return tool.Call(ctx, string(args))
+		},
+	})
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	log.Info("runlore mcp server ready (stdio)", "tool", "gitops_what_changed")
+	return srv.Serve(ctx, os.Stdin, os.Stdout)
 }
 
 // runInvestigate runs a single on-demand investigation and prints the findings.

--- a/docs/proposals/holmesgpt-what-changed-toolset.md
+++ b/docs/proposals/holmesgpt-what-changed-toolset.md
@@ -62,6 +62,13 @@ adding an MCP server entry to its config; **no upstream PR is required**.
   separation (HolmesGPT reasons, RunLore serves data).
 - **Cons:** an extra process to run; not "in the box" with HolmesGPT.
 
+> **Implemented (MVP, this repo).** `lore mcp` serves `gitops_what_changed` over the
+> stdio MCP transport (minimal dependency-free JSON-RPC server in `internal/mcp`,
+> reusing the existing what-changed engine; read-only). Point any MCP client at it —
+> the stdio launch command is `lore mcp --config <path>`. Validate the handshake +
+> a `tools/call` against a live MCP client (e.g. HolmesGPT) as the next step, and
+> confirm the client's exact MCP-server config key against its docs.
+
 ### Path B — native HolmesGPT toolset (deeper; upstream once proven)
 
 Contribute a toolset to the HolmesGPT repo (under its toolsets plugin dir), wrapping a

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,0 +1,194 @@
+// Package mcp is a minimal Model Context Protocol server over the stdio transport
+// (newline-delimited JSON-RPC 2.0) — enough to expose RunLore tools to MCP clients
+// such as HolmesGPT, kagent, or Claude Desktop. It implements initialize, tools/list,
+// tools/call, and ping; tool handlers return plain text. Deliberately dependency-free
+// (no SDK) to keep the single static binary.
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+)
+
+// defaultProtocolVersion is returned when the client doesn't request one. The handful
+// of methods here behave identically across MCP revisions, so the server echoes the
+// client's requested version when present (maximizing handshake compatibility).
+const defaultProtocolVersion = "2024-11-05"
+
+// Tool is an MCP tool: a name, a description, a JSON-Schema for its arguments, and a
+// handler returning text (an error is surfaced to the client as an MCP tool error).
+type Tool struct {
+	Name        string
+	Description string
+	InputSchema json.RawMessage
+	Handler     func(ctx context.Context, args json.RawMessage) (string, error)
+}
+
+// Server is a minimal MCP server. Construct with NewServer, AddTool, then Serve.
+type Server struct {
+	name, version string
+	log           *slog.Logger
+	tools         map[string]Tool
+	order         []string
+}
+
+// NewServer creates a server advertising name/version. A nil logger discards logs
+// (logs MUST NOT go to the stdout MCP channel — pass a stderr logger).
+func NewServer(name, version string, log *slog.Logger) *Server {
+	if log == nil {
+		log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Server{name: name, version: version, log: log, tools: map[string]Tool{}}
+}
+
+// AddTool registers (or replaces) a tool, preserving first-seen order for tools/list.
+func (s *Server) AddTool(t Tool) {
+	if _, ok := s.tools[t.Name]; !ok {
+		s.order = append(s.order, t.Name)
+	}
+	s.tools[t.Name] = t
+}
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"` // absent ⇒ notification (no response)
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Serve reads newline-delimited JSON-RPC requests from in and writes one response line
+// per request to out, until in is exhausted or ctx is cancelled. Notifications (no id)
+// get no response. json.Encoder writes compact, single-line JSON + a newline — exactly
+// the stdio framing MCP expects.
+func (s *Server) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // tolerate large request lines
+	enc := json.NewEncoder(out)
+	for sc.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if len(bytes.TrimSpace(sc.Bytes())) == 0 {
+			continue
+		}
+		var req rpcRequest
+		if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+			s.log.Warn("mcp: dropping unparseable request line", "err", err)
+			continue // can't form a response without an id
+		}
+		resp, respond := s.dispatch(ctx, &req)
+		if !respond {
+			continue
+		}
+		if err := enc.Encode(resp); err != nil {
+			return fmt.Errorf("mcp: write response: %w", err)
+		}
+	}
+	return sc.Err()
+}
+
+// dispatch handles one request; respond=false for notifications (and unknown
+// notifications), which get no reply.
+func (s *Server) dispatch(ctx context.Context, req *rpcRequest) (rpcResponse, bool) {
+	if len(req.ID) == 0 { // notification: act on known ones, never reply
+		return rpcResponse{}, false
+	}
+	resp := rpcResponse{JSONRPC: "2.0", ID: req.ID}
+	switch req.Method {
+	case "initialize":
+		resp.Result = s.initializeResult(req.Params)
+	case "ping":
+		resp.Result = map[string]any{}
+	case "tools/list":
+		resp.Result = s.toolsList()
+	case "tools/call":
+		resp.Result = s.toolsCall(ctx, req.Params)
+	default:
+		resp.Error = &rpcError{Code: -32601, Message: "method not found: " + req.Method}
+	}
+	return resp, true
+}
+
+func (s *Server) initializeResult(params json.RawMessage) map[string]any {
+	version := defaultProtocolVersion
+	var p struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	if len(params) > 0 && json.Unmarshal(params, &p) == nil && p.ProtocolVersion != "" {
+		version = p.ProtocolVersion
+	}
+	return map[string]any{
+		"protocolVersion": version,
+		"capabilities":    map[string]any{"tools": map[string]any{}},
+		"serverInfo":      map[string]any{"name": s.name, "version": s.version},
+	}
+}
+
+func (s *Server) toolsList() map[string]any {
+	list := make([]map[string]any, 0, len(s.order))
+	for _, name := range s.order {
+		t := s.tools[name]
+		schema := t.InputSchema
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object"}`)
+		}
+		list = append(list, map[string]any{
+			"name": t.Name, "description": t.Description, "inputSchema": schema,
+		})
+	}
+	return map[string]any{"tools": list}
+}
+
+func (s *Server) toolsCall(ctx context.Context, params json.RawMessage) map[string]any {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &p); err != nil {
+		return toolError("invalid tools/call params: " + err.Error())
+	}
+	t, ok := s.tools[p.Name]
+	if !ok {
+		return toolError("unknown tool: " + p.Name)
+	}
+	args := p.Arguments
+	if len(args) == 0 {
+		args = json.RawMessage(`{}`)
+	}
+	out, err := t.Handler(ctx, args)
+	if err != nil {
+		return toolError(err.Error())
+	}
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": out}},
+		"isError": false,
+	}
+}
+
+// toolError is the MCP convention for a failed tool call: a normal result with
+// isError=true (not a JSON-RPC error), so the model sees the failure as tool output.
+func toolError(msg string) map[string]any {
+	return map[string]any{
+		"content": []map[string]any{{"type": "text", "text": msg}},
+		"isError": true,
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,115 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func testServer() *Server {
+	s := NewServer("runlore-test", "v0", nil)
+	s.AddTool(Tool{
+		Name:        "echo",
+		Description: "echoes its args",
+		InputSchema: json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}}}`),
+		Handler:     func(_ context.Context, args json.RawMessage) (string, error) { return "got:" + string(args), nil },
+	})
+	s.AddTool(Tool{
+		Name:        "boom",
+		Description: "always errors",
+		Handler:     func(context.Context, json.RawMessage) (string, error) { return "", fmt.Errorf("kaboom") },
+	})
+	return s
+}
+
+// run feeds newline-delimited requests through Serve and decodes the response lines.
+func run(t *testing.T, s *Server, lines ...string) []map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	if err := s.Serve(context.Background(), strings.NewReader(strings.Join(lines, "\n")+"\n"), &out); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	var resps []map[string]any
+	dec := json.NewDecoder(&out)
+	for dec.More() {
+		var m map[string]any
+		if err := dec.Decode(&m); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		resps = append(resps, m)
+	}
+	return resps
+}
+
+func TestInitializeEchoesProtocolAndAdvertisesTools(t *testing.T) {
+	r := run(t, testServer(), `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}`)
+	if len(r) != 1 {
+		t.Fatalf("want 1 response, got %d", len(r))
+	}
+	res := r[0]["result"].(map[string]any)
+	if res["protocolVersion"] != "2025-06-18" {
+		t.Fatalf("should echo the client protocol version, got %v", res["protocolVersion"])
+	}
+	if _, ok := res["capabilities"].(map[string]any)["tools"]; !ok {
+		t.Fatal("must advertise the tools capability")
+	}
+	if res["serverInfo"].(map[string]any)["name"] != "runlore-test" {
+		t.Fatalf("serverInfo.name: %v", res["serverInfo"])
+	}
+}
+
+func TestNotificationGetsNoResponse(t *testing.T) {
+	r := run(t, testServer(), `{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	if len(r) != 0 {
+		t.Fatalf("a notification (no id) must not get a response, got %d", len(r))
+	}
+}
+
+func TestToolsList(t *testing.T) {
+	r := run(t, testServer(), `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	tools := r[0]["result"].(map[string]any)["tools"].([]any)
+	if len(tools) != 2 || tools[0].(map[string]any)["name"] != "echo" {
+		t.Fatalf("tools/list wrong: %v", tools)
+	}
+	if _, ok := tools[0].(map[string]any)["inputSchema"]; !ok {
+		t.Fatal("tool must carry an inputSchema")
+	}
+}
+
+func TestToolsCallSuccess(t *testing.T) {
+	r := run(t, testServer(), `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"msg":"hi"}}}`)
+	res := r[0]["result"].(map[string]any)
+	if res["isError"] != false {
+		t.Fatalf("expected success, got isError=%v", res["isError"])
+	}
+	text := res["content"].([]any)[0].(map[string]any)["text"].(string)
+	if !strings.Contains(text, `"msg":"hi"`) {
+		t.Fatalf("echoed text missing args: %q", text)
+	}
+}
+
+func TestToolsCallErrorsAreResults(t *testing.T) {
+	// A handler error and an unknown tool are both MCP tool errors (isError result),
+	// NOT JSON-RPC errors.
+	boom := run(t, testServer(), `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"boom","arguments":{}}}`)
+	if boom[0]["result"].(map[string]any)["isError"] != true {
+		t.Fatal("handler error should set isError=true")
+	}
+	unknown := run(t, testServer(), `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"nope"}}`)
+	if unknown[0]["result"].(map[string]any)["isError"] != true {
+		t.Fatal("unknown tool should set isError=true")
+	}
+}
+
+func TestUnknownMethodIsJSONRPCError(t *testing.T) {
+	r := run(t, testServer(), `{"jsonrpc":"2.0","id":6,"method":"frobnicate"}`)
+	if r[0]["error"] == nil {
+		t.Fatal("unknown method should return a JSON-RPC error")
+	}
+	if int(r[0]["error"].(map[string]any)["code"].(float64)) != -32601 {
+		t.Fatalf("want -32601, got %v", r[0]["error"])
+	}
+}


### PR DESCRIPTION
Implements **Path A** of the [HolmesGPT proposal](docs/proposals/holmesgpt-what-changed-toolset.md): expose RunLore's what-changed engine over the **Model Context Protocol** so any MCP client (HolmesGPT, kagent, Claude Desktop) can call it as a toolset — no upstream PR required to ship + demo.

- **`internal/mcp`** — a minimal, **dependency-free** MCP server over the stdio transport (newline-delimited JSON-RPC 2.0): `initialize` / `tools/list` / `tools/call` / `ping`; tool errors surface as MCP `isError` results. Keeps the single static binary (no SDK).
- **`lore mcp [--config]`** — builds the gitops provider via the existing `gitOpsFromKube` (so private-repo diffs are **authenticated** via the GitHub App token) and serves a **`gitops_what_changed`** tool backed by the existing `WhatChangedTool`. Read-only; logs to stderr (stdout is the protocol channel).

### Verification
`go build` · `go vet` · `go test -race ./...` · `golangci-lint` 0 issues. 6 MCP protocol unit tests (handshake/capabilities, notifications get no reply, tools/list schema, tools/call success + error-as-result, unknown-method → JSON-RPC −32601). Binary smoke: `lore mcp` is registered in `help`; without a cluster it fails closed (exit 1, graceful).

**Validation next step (documented):** drive the handshake + a `tools/call` from a live MCP client (HolmesGPT) — interop can't run in CI, so it's the operator demo, exactly as the proposal frames it.