### PR TITLE
feat(argocd): GitOpsInspector parity — deep status + dependency tree (FEAT-2)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -330,11 +330,12 @@ git diff*:
 | failure (React) | `Ready=False`, source `FetchFailed` | `health=Degraded`, `sync=OutOfSync` |
 | the diff | go-git between revisions over `spec.path` | go-git over `source.path` (Argo also has native `app diff`) |
 
-> **Engine depth is honest, not symmetric.** Flux is the reference implementation. The deep
-> introspection tools (`flux_status`, `flux_tree`) and the failure-persistence re-check use a Flux-only
-> `GitOpsInspector`; on ArgoCD they no-op — Argo gets revision history, the diff, and failure detection,
-> but not the deep tree/status lens. Likewise **action-approval (rung-2) is Slack-only** today; Matrix
-> is delivery-only. Both are honest current states, not full parity.
+> **Engine depth — deep lens now at parity.** Flux is the reference implementation, but the deep
+> introspection tools (`flux_status`, `flux_tree`) and the failure-persistence re-check run on the
+> `GitOpsInspector` interface, which **both Flux and Argo CD now implement** (FEAT-2): on Argo via
+> native `status.health`/`status.sync`, error conditions, and the `status.resources` tree (app-of-apps
+> aware). The tools keep their `flux_`-prefixed names for now — cosmetic, not functional. Remaining
+> honest asymmetry: **action-approval (rung-2) is Slack-only** today; Matrix is delivery-only.
 
 **Auto-discovery**: detect `argoproj.io/Application` → ArgoCD; `helm.toolkit.fluxcd.io` → Flux; probe
 the metrics endpoint → VM vs Prometheus. Config overrides. Flux + VictoriaMetrics is the primary

--- a/internal/providers/gitops/argocd/argocd.go
+++ b/internal/providers/gitops/argocd/argocd.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/whatchanged"
 )
@@ -37,6 +39,12 @@ type ApplicationEvent struct {
 type Reader interface {
 	ListApplications(ctx context.Context) ([]application, error)
 	WatchApplications(ctx context.Context) (<-chan ApplicationEvent, error)
+	// GetApplication fetches one Application as unstructured (deep inspection needs
+	// status.conditions + status.resources, which the minimal `application` omits). A
+	// NotFound error is returned verbatim so callers can distinguish "missing".
+	GetApplication(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error)
+	// ListEvents returns recent Event lines for an involved object.
+	ListEvents(ctx context.Context, namespace, name, kind string) ([]string, error)
 }
 
 // Provider implements providers.GitOpsProvider for Argo CD.
@@ -174,4 +182,7 @@ func parseRevision(rev string) string {
 	return rev
 }
 
-var _ providers.GitOpsProvider = (*Provider)(nil)
+var (
+	_ providers.GitOpsProvider  = (*Provider)(nil)
+	_ providers.GitOpsInspector = (*Provider)(nil)
+)

--- a/internal/providers/gitops/argocd/argocd_test.go
+++ b/internal/providers/gitops/argocd/argocd_test.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/whatchanged"
 )
@@ -23,8 +27,11 @@ func TestParseRevision(t *testing.T) {
 }
 
 type fakeReader struct {
-	apps   []application
-	events []ApplicationEvent
+	apps       []application
+	events     []ApplicationEvent
+	obj        *unstructured.Unstructured // returned by GetApplication
+	notFound   bool                       // GetApplication returns a NotFound error
+	eventLines []string                   // returned by ListEvents
 }
 
 func (f fakeReader) ListApplications(context.Context) ([]application, error) { return f.apps, nil }
@@ -35,6 +42,15 @@ func (f fakeReader) WatchApplications(context.Context) (<-chan ApplicationEvent,
 	}
 	close(ch)
 	return ch, nil
+}
+func (f fakeReader) GetApplication(_ context.Context, _, name string) (*unstructured.Unstructured, error) {
+	if f.notFound {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "applications"}, name)
+	}
+	return f.obj, nil
+}
+func (f fakeReader) ListEvents(context.Context, string, string, string) ([]string, error) {
+	return f.eventLines, nil
 }
 
 func TestProviderChanges(t *testing.T) {

--- a/internal/providers/gitops/argocd/dynamic.go
+++ b/internal/providers/gitops/argocd/dynamic.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,6 +17,9 @@ import (
 
 // applicationGVR is the Argo CD Application resource.
 var applicationGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+
+// eventsGVR is the core v1 Events resource (for ListEvents).
+var eventsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
 
 // sendTimeout bounds how long the informer handler blocks waiting for the
 // consumer to drain a watch event before giving up. It is large enough to ride
@@ -43,6 +47,58 @@ func (r *dynamicReader) ListApplications(ctx context.Context) ([]application, er
 	out := make([]application, 0, len(list.Items))
 	for i := range list.Items {
 		out = append(out, applicationFromUnstructured(&list.Items[i]))
+	}
+	return out, nil
+}
+
+// GetApplication fetches one Application as unstructured. Argo Applications usually
+// live in the argocd namespace, not the workload's; if the caller passes the
+// workload's namespace and the app isn't there, fall back to a name search across all
+// namespaces before trusting the NotFound.
+func (r *dynamicReader) GetApplication(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+	u, err := r.client.Resource(applicationGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err == nil {
+		return u, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+	if list, lerr := r.client.Resource(applicationGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); lerr == nil {
+		for i := range list.Items {
+			if list.Items[i].GetName() == name {
+				return &list.Items[i], nil
+			}
+		}
+	}
+	return nil, err // genuinely absent in every namespace: return the original NotFound
+}
+
+// ListEvents returns recent Event lines for an involved object, filtered by name
+// (server-side) + kind (client-side), rendered as "Type Reason Message".
+func (r *dynamicReader) ListEvents(ctx context.Context, namespace, name, kind string) ([]string, error) {
+	opts := metav1.ListOptions{Limit: 100}
+	if name != "" {
+		opts.FieldSelector = "involvedObject.name=" + name
+	}
+	list, err := r.client.Resource(eventsGVR).Namespace(namespace).List(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("list events: %w", err)
+	}
+	var out []string
+	for i := range list.Items {
+		o := list.Items[i].Object
+		if n, _, _ := unstructured.NestedString(o, "involvedObject", "name"); n != name {
+			continue
+		}
+		if kind != "" {
+			if k, _, _ := unstructured.NestedString(o, "involvedObject", "kind"); k != "" && k != kind {
+				continue
+			}
+		}
+		typ, _, _ := unstructured.NestedString(o, "type")
+		reason, _, _ := unstructured.NestedString(o, "reason")
+		msg, _, _ := unstructured.NestedString(o, "message")
+		out = append(out, fmt.Sprintf("%s %s %s", typ, reason, msg))
 	}
 	return out, nil
 }

--- a/internal/providers/gitops/argocd/inspect.go
+++ b/internal/providers/gitops/argocd/inspect.go
@@ -1,0 +1,175 @@
+package argocd
+
+import (
+	"context"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// ResourceStatus reports an Argo CD Application's health + sync status, key
+// source/destination refs, error conditions, and recent Events — the Argo analogue of
+// the Flux inspector's "why is it failing" lens. A missing Application is reported via
+// NotFound (often the cascade root), not an error.
+func (p *Provider) ResourceStatus(ctx context.Context, w providers.Workload) (providers.ResourceStatus, error) {
+	rs := providers.ResourceStatus{Workload: w, Refs: map[string]string{}}
+	u, err := p.reader.GetApplication(ctx, w.Namespace, w.Name)
+	if apierrors.IsNotFound(err) {
+		rs.NotFound = true
+		return rs, nil
+	}
+	if err != nil {
+		return rs, err
+	}
+	rs.Ready, rs.Reason, rs.Message = appReady(u)
+	if repo, _, _ := unstructured.NestedString(u.Object, "spec", "source", "repoURL"); repo != "" {
+		rs.Refs["repoURL"] = repo
+		if path, _, _ := unstructured.NestedString(u.Object, "spec", "source", "path"); path != "" {
+			rs.Refs["path"] = path
+		}
+		if tr, _, _ := unstructured.NestedString(u.Object, "spec", "source", "targetRevision"); tr != "" {
+			rs.Refs["targetRevision"] = tr
+		}
+	}
+	if dns, _, _ := unstructured.NestedString(u.Object, "spec", "destination", "namespace"); dns != "" {
+		rs.Refs["destinationNamespace"] = dns
+	}
+	if sync, _, _ := unstructured.NestedString(u.Object, "status", "sync", "status"); sync != "" {
+		rs.Refs["sync"] = sync
+	}
+	// Use the resolved object's namespace/name (GetApplication may have found it in
+	// another namespace than the workload selector's).
+	rs.Events, _ = p.reader.ListEvents(ctx, u.GetNamespace(), u.GetName(), "Application") // best-effort
+	return rs, nil
+}
+
+// DependencyTree returns the Application with its FAILING managed resources
+// (status.resources whose health is not Healthy/Progressing) as children, recursing
+// into child Applications (app-of-apps) — so the root failure behind a degraded app is
+// visible. Best-effort: child read errors don't abort the walk.
+func (p *Provider) DependencyTree(ctx context.Context, w providers.Workload) (providers.DepNode, error) {
+	return p.appNode(ctx, w, map[string]bool{}), nil
+}
+
+func (p *Provider) appNode(ctx context.Context, w providers.Workload, seen map[string]bool) providers.DepNode {
+	node := providers.DepNode{Workload: w}
+	key := w.Namespace + "/" + w.Name
+	if seen[key] {
+		return node // cycle guard (app-of-apps loops)
+	}
+	seen[key] = true
+	u, err := p.reader.GetApplication(ctx, w.Namespace, w.Name)
+	if apierrors.IsNotFound(err) {
+		node.NotFound = true
+		return node
+	}
+	if err != nil {
+		return node
+	}
+	node.Ready, node.Reason, _ = appReady(u)
+	for _, r := range managedResources(u) {
+		if r.Kind == "Application" && r.Name != "" { // app-of-apps: recurse, surface if not healthy
+			child := p.appNode(ctx, providers.Workload{Kind: "Application", Name: r.Name, Namespace: r.Namespace}, seen)
+			if child.Ready != "True" || child.NotFound || len(child.Children) > 0 {
+				node.Children = append(node.Children, child)
+			}
+			continue
+		}
+		// Surface only failing managed resources to point at the root failure; Healthy
+		// and Progressing (transient) ones are noise. An unassessed resource (no
+		// health) is left out.
+		if r.Health != "" && r.Health != "Healthy" && r.Health != "Progressing" {
+			node.Children = append(node.Children, providers.DepNode{
+				Workload: providers.Workload{Kind: r.Kind, Name: r.Name, Namespace: r.Namespace},
+				Ready:    healthToReady(r.Health),
+				Reason:   r.Health,
+			})
+		}
+	}
+	return node
+}
+
+// appReady maps Argo health + sync into the (Ready, Reason, Message) shape the
+// inspector contract expects. Ready is "True"/"False"/"Unknown"/"" — Healthy→True,
+// Degraded/Missing→False, a failed sync forces False, others Unknown.
+func appReady(u *unstructured.Unstructured) (ready, reason, message string) {
+	health, _, _ := unstructured.NestedString(u.Object, "status", "health", "status")
+	phase, _, _ := unstructured.NestedString(u.Object, "status", "operationState", "phase")
+	opMsg, _, _ := unstructured.NestedString(u.Object, "status", "operationState", "message")
+	ready = healthToReady(health)
+	reason = health
+	if phase == "Failed" || phase == "Error" {
+		reason = strings.TrimSpace(reason + " Sync" + phase)
+		if ready != "False" {
+			ready = "False" // a failed sync is not-ready even if health hasn't flipped yet
+		}
+	}
+	msgs := conditionMessages(u)
+	if opMsg != "" {
+		msgs = append([]string{opMsg}, msgs...)
+	}
+	return ready, reason, strings.Join(msgs, "; ")
+}
+
+func healthToReady(h string) string {
+	switch h {
+	case "Healthy":
+		return "True"
+	case "Degraded", "Missing":
+		return "False"
+	case "":
+		return ""
+	default:
+		return "Unknown" // Progressing, Suspended, Unknown
+	}
+}
+
+// conditionMessages surfaces Argo error/warning conditions (ComparisonError,
+// SyncError, InvalidSpecError, *Warning) as "Type: message".
+func conditionMessages(u *unstructured.Unstructured) []string {
+	conds, _, _ := unstructured.NestedSlice(u.Object, "status", "conditions")
+	var out []string
+	for _, c := range conds {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := m["type"].(string)
+		msg, _ := m["message"].(string)
+		if msg == "" {
+			continue
+		}
+		lt := strings.ToLower(typ)
+		if strings.Contains(lt, "error") || strings.Contains(lt, "warning") {
+			out = append(out, typ+": "+msg)
+		}
+	}
+	return out
+}
+
+type managedResource struct{ Kind, Name, Namespace, Health string }
+
+// managedResources parses status.resources[] — the Application's managed objects with
+// their per-resource health.
+func managedResources(u *unstructured.Unstructured) []managedResource {
+	raw, _, _ := unstructured.NestedSlice(u.Object, "status", "resources")
+	out := make([]managedResource, 0, len(raw))
+	for _, r := range raw {
+		m, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		kind, _ := m["kind"].(string)
+		name, _ := m["name"].(string)
+		ns, _ := m["namespace"].(string)
+		health := ""
+		if h, ok := m["health"].(map[string]any); ok {
+			health, _ = h["status"].(string)
+		}
+		out = append(out, managedResource{Kind: kind, Name: name, Namespace: ns, Health: health})
+	}
+	return out
+}

--- a/internal/providers/gitops/argocd/inspect_test.go
+++ b/internal/providers/gitops/argocd/inspect_test.go
@@ -1,0 +1,120 @@
+package argocd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/whatchanged"
+)
+
+// appObj builds an unstructured Argo Application for inspector tests.
+func appObj(health, sync, phase string, conditions, resources []any) *unstructured.Unstructured {
+	status := map[string]any{
+		"health": map[string]any{"status": health},
+		"sync":   map[string]any{"status": sync},
+	}
+	if phase != "" {
+		status["operationState"] = map[string]any{"phase": phase, "message": "sync failed: image pull error"}
+	}
+	if conditions != nil {
+		status["conditions"] = conditions
+	}
+	if resources != nil {
+		status["resources"] = resources
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "broken-app", "namespace": "argocd"},
+		"spec": map[string]any{
+			"source":      map[string]any{"repoURL": "https://example.com/repo", "path": "apps/web", "targetRevision": "main"},
+			"destination": map[string]any{"namespace": "apps"},
+		},
+		"status": status,
+	}}
+}
+
+func TestArgoResourceStatusDegraded(t *testing.T) {
+	p := New(fakeReader{
+		obj: appObj("Degraded", "OutOfSync", "", []any{
+			map[string]any{"type": "ComparisonError", "message": "rpc error: repo not found"},
+		}, nil),
+		eventLines: []string{"Warning SyncFailed manifests failed to apply"},
+	}, &whatchanged.Differ{})
+
+	rs, err := p.ResourceStatus(context.Background(), providers.Workload{Kind: "Application", Name: "broken-app", Namespace: "argocd"})
+	if err != nil {
+		t.Fatalf("ResourceStatus: %v", err)
+	}
+	if rs.Ready != "False" {
+		t.Fatalf("Degraded health → Ready False, got %q", rs.Ready)
+	}
+	if rs.Reason != "Degraded" {
+		t.Fatalf("Reason: %q", rs.Reason)
+	}
+	if rs.Refs["repoURL"] == "" || rs.Refs["sync"] != "OutOfSync" {
+		t.Fatalf("refs missing/wrong: %v", rs.Refs)
+	}
+	if !strings.Contains(rs.Message, "repo not found") {
+		t.Fatalf("message should carry the error condition: %q", rs.Message)
+	}
+	if len(rs.Events) != 1 {
+		t.Fatalf("events: %v", rs.Events)
+	}
+}
+
+func TestArgoResourceStatusHealthy(t *testing.T) {
+	p := New(fakeReader{obj: appObj("Healthy", "Synced", "", nil, nil)}, &whatchanged.Differ{})
+	rs, _ := p.ResourceStatus(context.Background(), providers.Workload{Kind: "Application", Name: "ok", Namespace: "argocd"})
+	if rs.Ready != "True" {
+		t.Fatalf("Healthy → Ready True, got %q", rs.Ready)
+	}
+}
+
+func TestArgoResourceStatusSyncFailedForcesNotReady(t *testing.T) {
+	// Health hasn't flipped (still Healthy) but the sync operation Failed → not ready.
+	p := New(fakeReader{obj: appObj("Healthy", "Synced", "Failed", nil, nil)}, &whatchanged.Differ{})
+	rs, _ := p.ResourceStatus(context.Background(), providers.Workload{Kind: "Application", Name: "x", Namespace: "argocd"})
+	if rs.Ready != "False" {
+		t.Fatalf("failed sync → Ready False, got %q", rs.Ready)
+	}
+	if !strings.Contains(rs.Reason, "SyncFailed") {
+		t.Fatalf("reason should note SyncFailed: %q", rs.Reason)
+	}
+}
+
+func TestArgoResourceStatusNotFound(t *testing.T) {
+	p := New(fakeReader{notFound: true}, &whatchanged.Differ{})
+	rs, err := p.ResourceStatus(context.Background(), providers.Workload{Kind: "Application", Name: "ghost", Namespace: "argocd"})
+	if err != nil {
+		t.Fatalf("NotFound must not be an error: %v", err)
+	}
+	if !rs.NotFound {
+		t.Fatal("expected NotFound")
+	}
+}
+
+func TestArgoDependencyTreeSurfacesFailingResources(t *testing.T) {
+	resources := []any{
+		map[string]any{"kind": "Deployment", "name": "web", "namespace": "apps", "health": map[string]any{"status": "Degraded"}},
+		map[string]any{"kind": "Service", "name": "web", "namespace": "apps", "health": map[string]any{"status": "Healthy"}},   // filtered
+		map[string]any{"kind": "Pod", "name": "web-x", "namespace": "apps", "health": map[string]any{"status": "Progressing"}}, // filtered (transient)
+	}
+	p := New(fakeReader{obj: appObj("Degraded", "Synced", "", nil, resources)}, &whatchanged.Differ{})
+	tree, err := p.DependencyTree(context.Background(), providers.Workload{Kind: "Application", Name: "broken-app", Namespace: "argocd"})
+	if err != nil {
+		t.Fatalf("DependencyTree: %v", err)
+	}
+	if tree.Ready != "False" {
+		t.Fatalf("root app Ready: %q", tree.Ready)
+	}
+	if len(tree.Children) != 1 {
+		t.Fatalf("only the Degraded resource should surface, got %d: %+v", len(tree.Children), tree.Children)
+	}
+	c := tree.Children[0]
+	if c.Workload.Kind != "Deployment" || c.Workload.Name != "web" || c.Ready != "False" || c.Reason != "Degraded" {
+		t.Fatalf("failing child wrong: %+v", c)
+	}
+}


### PR DESCRIPTION
Closes the "backend-agnostic is overstated" gap: the deep gitops tools (`flux_status`, `flux_tree`) and the failure-persistence re-check no longer no-op on Argo CD.

Argo now implements `providers.GitOpsInspector`:
- **ResourceStatus** — Application `health`/`sync` → the Ready string (Healthy→True, Degraded/Missing→False, a failed sync forces False), source/destination/sync refs, error+warning conditions folded into Message, and recent Events.
- **DependencyTree** — the Application plus its **failing** managed resources (`status.resources` whose health isn't Healthy/Progressing), recursing into child Applications (app-of-apps) with a cycle guard — surfacing the root failure.

The `Reader` gains `GetApplication` (raw unstructured — for conditions + the resource tree) and `ListEvents` (mirrors the Flux reader). The inspector tools **auto-wire** for Argo via the existing `gp.(GitOpsInspector)` assertion — no `main.go` change. Tools keep their `flux_`-prefixed names for now (cosmetic; a follow-up renames them).

### Verification
build · vet · `go test -race ./...` · `golangci-lint` 0 issues. 5 new inspector tests (Degraded/Healthy/sync-failed/NotFound + refs/conditions/events; DependencyTree surfaces only failing resources). **Full k3d e2e 45/45, ALL FEATURES VERIFIED** — the Argo `broken-argo` scenario investigates end-to-end. `design.md` engine-depth note updated to "deep-lens parity."