### PR TITLE
refactor(tools): rename flux_* deep tools to gitops_* (post-FEAT-2)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -1154,7 +1154,7 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		// Deep read-only Flux introspection (status/events + dependency tree), when
 		// the GitOps provider supports it (Flux does).
 		if insp, ok := gp.(providers.GitOpsInspector); ok {
-			tools = append(tools, investigate.FluxStatusTool{Inspector: insp}, investigate.FluxTreeTool{Inspector: insp})
+			tools = append(tools, investigate.GitOpsStatusTool{Inspector: insp}, investigate.GitOpsTreeTool{Inspector: insp})
 		}
 	}
 	var recall *investigate.Recall

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -13,7 +13,7 @@ rules:
   - apiGroups: ["source.toolkit.fluxcd.io"]
     resources: ["gitrepositories"]
     verbs: ["get", "list", "watch"]
-  # Deep read-only introspection (flux_resource_status / flux_tree): HelmReleases,
+  # Deep read-only introspection (gitops_resource_status / gitops_tree): HelmReleases,
   # the other Flux source kinds, and Events.
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]

--- a/docs/design.md
+++ b/docs/design.md
@@ -331,7 +331,7 @@ git diff*:
 | the diff | go-git between revisions over `spec.path` | go-git over `source.path` (Argo also has native `app diff`) |
 
 > **Engine depth — deep lens now at parity.** Flux is the reference implementation, but the deep
-> introspection tools (`flux_status`, `flux_tree`) and the failure-persistence re-check run on the
+> introspection tools (`gitops_resource_status`, `gitops_tree`) and the failure-persistence re-check run on the
 > `GitOpsInspector` interface, which **both Flux and Argo CD now implement** (FEAT-2): on Argo via
 > native `status.health`/`status.sync`, error conditions, and the `status.resources` tree (app-of-apps
 > aware). The tools keep their `flux_`-prefixed names for now — cosmetic, not functional. Remaining

--- a/eval/rubric.md
+++ b/eval/rubric.md
@@ -7,7 +7,7 @@ Two grading tracks (see `docs/superpowers/specs/2026-06-21-runlore-eval-harness-
 From the recorded tool-call trace. `coverage = |mandatory expected_sources touched| / |expected_sources|`.
 Pass requires `coverage == 1.0`. `optional_sources` are bonus, never gating. Any errored tool is flagged.
 
-Data-source groups: `gitops` (what_changed, flux_resource_status, flux_tree), `kubernetes` (pod_status,
+Data-source groups: `gitops` (what_changed, gitops_resource_status, gitops_tree), `kubernetes` (pod_status,
 kube_events, controller_logs), `metrics` (query_metrics), `logs` (query_logs), `network` (network_drops),
 `aws` (cloud_what_changed, cloud_resource_health), `kb` (kb_search).
 

--- a/internal/eval/coverage.go
+++ b/internal/eval/coverage.go
@@ -11,18 +11,18 @@ import (
 // toolSource maps each investigation tool to its data-source group. submit_findings
 // and any unknown tool map to "" (ignored by coverage).
 var toolSource = map[string]string{
-	"what_changed":          "gitops",
-	"flux_resource_status":  "gitops",
-	"flux_tree":             "gitops",
-	"pod_status":            "kubernetes",
-	"kube_events":           "kubernetes",
-	"controller_logs":       "kubernetes",
-	"query_metrics":         "metrics",
-	"query_logs":            "logs",
-	"network_drops":         "network",
-	"cloud_what_changed":    "aws",
-	"cloud_resource_health": "aws",
-	"kb_search":             "kb",
+	"what_changed":           "gitops",
+	"gitops_resource_status": "gitops",
+	"gitops_tree":            "gitops",
+	"pod_status":             "kubernetes",
+	"kube_events":            "kubernetes",
+	"controller_logs":        "kubernetes",
+	"query_metrics":          "metrics",
+	"query_logs":             "logs",
+	"network_drops":          "network",
+	"cloud_what_changed":     "aws",
+	"cloud_resource_health":  "aws",
+	"kb_search":              "kb",
 }
 
 // Call is one recorded tool invocation during a live investigation.

--- a/internal/eval/coverage_test.go
+++ b/internal/eval/coverage_test.go
@@ -52,7 +52,7 @@ func TestRecordingToolRecordsError(t *testing.T) {
 func TestScoreCoverage(t *testing.T) {
 	calls := []Call{
 		{Name: "what_changed", Output: "diff"},
-		{Name: "flux_resource_status", Output: "Ready=False"},
+		{Name: "gitops_resource_status", Output: "Ready=False"},
 		{Name: "query_logs", Output: "boom"},
 		{Name: "cloud_what_changed", Err: "timeout"},
 	}

--- a/internal/investigate/controllerlogs_tool.go
+++ b/internal/investigate/controllerlogs_tool.go
@@ -27,7 +27,7 @@ func (t ControllerLogsTool) Description() string {
 	return "Read recent logs from a Flux controller (source-controller, kustomize-controller, " +
 		"helm-controller, notification-controller), optionally filtered to a resource name, over a " +
 		"window (default 30m). Use it to learn WHY a source/object failed — e.g. a GitRepository that " +
-		"was never created, an auth or checkout error — when flux_resource_status isn't enough."
+		"was never created, an auth or checkout error — when gitops_resource_status isn't enough."
 }
 
 // Schema returns the JSON schema for the arguments.

--- a/internal/investigate/gitops_status_tool.go
+++ b/internal/investigate/gitops_status_tool.go
@@ -10,31 +10,32 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// FluxStatusTool exposes a Flux/Kubernetes resource's Ready condition, key spec
-// refs (sourceRef, dependsOn) and recent Events — so the model can learn WHY a
-// resource is failing, not just that it is.
-type FluxStatusTool struct {
+// GitOpsStatusTool exposes a GitOps/Kubernetes resource's status (a Flux Ready
+// condition or an Argo CD Application's health/sync), key spec refs, and recent
+// Events — so the model can learn WHY a resource is failing, not just that it is.
+type GitOpsStatusTool struct {
 	Inspector providers.GitOpsInspector
 }
 
 // Name returns the tool name.
-func (t FluxStatusTool) Name() string { return "flux_resource_status" }
+func (t GitOpsStatusTool) Name() string { return "gitops_resource_status" }
 
 // Description returns the tool description.
-func (t FluxStatusTool) Description() string {
-	return "Get a Flux/Kubernetes resource's Ready condition (status/reason/message), key spec refs " +
-		"(sourceRef, dependsOn) and recent Events. Use this to learn WHY a resource is failing — " +
-		"follow its sourceRef/dependsOn to the root. kind is one of: Kustomization, HelmRelease, " +
-		"GitRepository, OCIRepository, HelmRepository, HelmChart, Bucket."
+func (t GitOpsStatusTool) Description() string {
+	return "Get a GitOps/Kubernetes resource's status (a Flux Ready condition or an Argo CD " +
+		"Application's health/sync: status, reason, message), key spec refs, and recent Events. Use " +
+		"this to learn WHY a resource is failing — follow its refs to the root. kind is one of: " +
+		"Application (Argo CD); Kustomization, HelmRelease, GitRepository, OCIRepository, " +
+		"HelmRepository, HelmChart, Bucket (Flux)."
 }
 
 // Schema returns the JSON schema for the arguments.
-func (t FluxStatusTool) Schema() string {
+func (t GitOpsStatusTool) Schema() string {
 	return `{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name","namespace"]}`
 }
 
 // Call fetches the resource status and renders it.
-func (t FluxStatusTool) Call(ctx context.Context, args string) (string, error) {
+func (t GitOpsStatusTool) Call(ctx context.Context, args string) (string, error) {
 	var in struct{ Kind, Name, Namespace string }
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)

--- a/internal/investigate/gitops_tools_test.go
+++ b/internal/investigate/gitops_tools_test.go
@@ -21,8 +21,8 @@ func (f fakeInspector) DependencyTree(context.Context, providers.Workload) (prov
 	return f.tree, nil
 }
 
-func TestFluxStatusTool(t *testing.T) {
-	tool := FluxStatusTool{Inspector: fakeInspector{status: providers.ResourceStatus{
+func TestGitOpsStatusTool(t *testing.T) {
+	tool := GitOpsStatusTool{Inspector: fakeInspector{status: providers.ResourceStatus{
 		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
 		Ready:    "False", Reason: "DependencyNotReady", Message: "dependency not ready",
 		Refs:   map[string]string{"sourceRef": "GitRepository/flux-system/infra-artifact", "dependsOn": "flux-system/infra"},
@@ -39,8 +39,8 @@ func TestFluxStatusTool(t *testing.T) {
 	}
 }
 
-func TestFluxStatusToolNotFound(t *testing.T) {
-	tool := FluxStatusTool{Inspector: fakeInspector{status: providers.ResourceStatus{
+func TestGitOpsStatusToolNotFound(t *testing.T) {
+	tool := GitOpsStatusTool{Inspector: fakeInspector{status: providers.ResourceStatus{
 		Workload: providers.Workload{Kind: "GitRepository", Name: "infra-artifact", Namespace: "flux-system"}, NotFound: true,
 	}}}
 	out, _ := tool.Call(context.Background(), `{"kind":"GitRepository","name":"infra-artifact","namespace":"flux-system"}`)
@@ -49,8 +49,8 @@ func TestFluxStatusToolNotFound(t *testing.T) {
 	}
 }
 
-func TestFluxTreeTool(t *testing.T) {
-	tool := FluxTreeTool{Inspector: fakeInspector{tree: providers.DepNode{
+func TestGitOpsTreeTool(t *testing.T) {
+	tool := GitOpsTreeTool{Inspector: fakeInspector{tree: providers.DepNode{
 		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}, Ready: "False", Reason: "DependencyNotReady",
 		Children: []providers.DepNode{{
 			Workload: providers.Workload{Kind: "Kustomization", Name: "infra", Namespace: "flux-system"}, Ready: "False", Reason: "DependencyNotReady",

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -9,30 +9,32 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// FluxTreeTool walks a resource's dependsOn + sourceRef graph and renders it as a
-// tree, so the model can find the ROOT failing resource behind a dependency
-// cascade (the not-Ready or missing node), not just the downstream symptom.
-type FluxTreeTool struct {
+// GitOpsTreeTool walks a resource's dependency graph (Flux dependsOn/sourceRef, or an
+// Argo CD Application's managed-resource tree) and renders it, so the model can find
+// the ROOT failing resource behind a cascade (the not-Ready/Degraded or missing
+// node), not just the downstream symptom.
+type GitOpsTreeTool struct {
 	Inspector providers.GitOpsInspector
 }
 
 // Name returns the tool name.
-func (t FluxTreeTool) Name() string { return "flux_tree" }
+func (t GitOpsTreeTool) Name() string { return "gitops_tree" }
 
 // Description returns the tool description.
-func (t FluxTreeTool) Description() string {
-	return "Walk a Flux Kustomization/HelmRelease's dependsOn + sourceRef graph and render the tree " +
-		"with each node's Ready state. Use it on a DependencyNotReady resource to find the ROOT cause " +
-		"— the first not-Ready or NOT FOUND node — instead of the downstream symptom."
+func (t GitOpsTreeTool) Description() string {
+	return "Walk a GitOps resource's dependency graph (a Flux resource's dependsOn/sourceRef, or an " +
+		"Argo CD Application's managed-resource tree) and render it with each node's Ready/health state. " +
+		"Use it on a failing resource to find the ROOT cause — the first not-Ready/Degraded or NOT FOUND " +
+		"node — instead of the downstream symptom."
 }
 
 // Schema returns the JSON schema for the arguments.
-func (t FluxTreeTool) Schema() string {
+func (t GitOpsTreeTool) Schema() string {
 	return `{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name","namespace"]}`
 }
 
 // Call walks the dependency tree and renders it.
-func (t FluxTreeTool) Call(ctx context.Context, args string) (string, error) {
+func (t GitOpsTreeTool) Call(ctx context.Context, args string) (string, error) {
 	var in struct{ Kind, Name, Namespace string }
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -38,7 +38,7 @@ NOT mean logging is the cause. Note the missing signal as unresolved and base yo
 tools that DID return data. Do not blame the subsystem whose tool failed.
 
 Drill from symptom to ROOT cause — don't stop at the first failing resource. When a Flux/GitOps
-resource is failing, call flux_resource_status on it; follow its sourceRef/dependsOn; use flux_tree
+resource is failing, call gitops_resource_status on it; follow its sourceRef/dependsOn; use gitops_tree
 to find the root (a not-Ready or NOT FOUND node); and use controller_logs / query_logs on the
 relevant controller (e.g. kustomize-controller, source-controller, helm-controller) to learn WHY it
 failed. Confirm hypotheses with metrics and, where relevant, network drops.


### PR DESCRIPTION
Completes FEAT-2's engine-agnostic story. The deep introspection tools now serve both Flux and Argo CD, so their `flux_`-prefixed names are misleading:

- `flux_resource_status` → `gitops_resource_status` (`FluxStatusTool` → `GitOpsStatusTool`)
- `flux_tree` → `gitops_tree` (`FluxTreeTool` → `GitOpsTreeTool`)

Tool descriptions reworded to cover both engines (Argo `Application` health/sync + managed-resource tree alongside Flux Ready/dependsOn/sourceRef). All references updated: the system prompt, the `controller_logs` hint, the eval coverage map + test, the rbac comment, `design.md`, `eval/rubric.md`. Files renamed to match.

Safe mechanical rename — no eval replay case or the e2e mock references these names; the inspector wiring is unchanged.

### Verification
build · vet · `go test -race ./...` · `golangci-lint` 0 issues · `helm lint`. **Full k3d e2e 45/45, ALL FEATURES VERIFIED.**