### PR TITLE
fix(docs): remove stale flux_* tool name references after ArgoCD parity

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -122,7 +122,13 @@ config:
   #     volumes and `lore curate`'s Queue + Recurrence passes read an empty ledger
   #     (the command warns loudly at startup when the ledger it sees is absent/empty).
   # notify:
-  #   slack: { webhook_url_env: SLACK_WEBHOOK_URL }
+  #   slack:
+  #     # Option A — incoming webhook (simplest):
+  #     webhook_url_env: SLACK_WEBHOOK_URL
+  #     # Option B — bot token (chat.postMessage; reuse an existing Slack app, e.g. Alertmanager's):
+  #     # bot_token_env: SLACK_BOT_TOKEN
+  #     # channel: "#alerts"            # channel ID or name (required with bot_token_env)
+  #     # signing_secret_env: SLACK_SIGNING_SECRET  # only needed for rung-2 approve/reject buttons
   #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }
   # forge:
   #   kb_repo: owner/name
@@ -235,6 +241,7 @@ rbac:
   # The controller_logs tool only ever reads the Flux controllers (source/kustomize/
   # helm/notification), which live in flux-system by convention, so the default is the
   # single flux-system namespace. Override ONLY if you relocate the Flux controllers.
+  # For ArgoCD deployments (config.gitops.engine: argocd), override to [argocd] instead.
   # Cluster-wide `pods` get/list (pod STATUS, not log bodies) stays in the ClusterRole
   # because pod_status/kube_events triage arbitrary incident namespaces. Redacting
   # secrets that still surface via status/event messages and these log bodies is a

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -8,7 +8,7 @@ assumed).
 
 | Signal | Tool(s) | Interface | Providers (v1) | Config key |
 |---|---|---|---|---|
-| GitOps "what changed" | `what_changed`, `flux_*` | `GitOpsProvider` | Flux, ArgoCD | `gitops.engine` |
+| GitOps "what changed" | `what_changed`, `gitops_*` | `GitOpsProvider` | Flux, ArgoCD | `gitops.engine` |
 | Metrics | `query_metrics` | `MetricsProvider` | VictoriaMetrics, Prometheus (PromQL) | `metrics.url` |
 | Logs | `query_logs` | `LogsProvider` | VictoriaLogs (LogsQL) | `logs.url` |
 | **Network flows** | `network_drops` | `NetworkProvider` | **Cilium Hubble · AWS VPC Flow Logs · GCP Firewall Logs** | `network.provider` |

--- a/docs/design.md
+++ b/docs/design.md
@@ -339,8 +339,7 @@ git diff*:
 > introspection tools (`gitops_resource_status`, `gitops_tree`) and the failure-persistence re-check run on the
 > `GitOpsInspector` interface, which **both Flux and Argo CD now implement** (FEAT-2): on Argo via
 > native `status.health`/`status.sync`, error conditions, and the `status.resources` tree (app-of-apps
-> aware). The tools keep their `flux_`-prefixed names for now — cosmetic, not functional. Remaining
-> honest asymmetry: **action-approval (rung-2) is Slack-only** today; Matrix is delivery-only.
+> aware). Remaining honest asymmetry: **action-approval (rung-2) is Slack-only** today; Matrix is delivery-only.
 
 **Auto-discovery**: detect `argoproj.io/Application` → ArgoCD; `helm.toolkit.fluxcd.io` → Flux; probe
 the metrics endpoint → VM vs Prometheus. Config overrides. Flux + VictoriaMetrics is the primary


### PR DESCRIPTION
Remove sentence in docs/design.md claiming tools keep flux_-prefixed names — they were renamed to gitops_*. Update docs/data-sources.md tools column accordingly.