### PR TITLE
fix(argocd): populate ResourceStatus refs from spec.sources[0] for multi-source apps

### DIFF
--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -33,9 +33,14 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
-  # Argo CD engine (config.gitops.engine: argocd)
+  # Argo CD engine (config.gitops.engine: argocd).
+  # applications: reactive watch (WatchFailures) + deep inspection (ResourceStatus/DependencyTree).
+  # applicationsets: read-only during investigations — generator failures don't yet trigger
+  #   the React loop (v2 roadmap), but the inspector can surface AppSet status as context.
+  # appprojects: read-only during investigations — RBAC denials manifest as Application
+  #   conditions; the inspector can cross-reference the project definition for root-cause.
   - apiGroups: ["argoproj.io"]
-    resources: ["applications"]
+    resources: ["applications", "applicationsets", "appprojects"]
     verbs: ["get", "list", "watch"]
   # NOTE: execution rights (patch) are intentionally NOT granted cluster-wide here.
   # They are scoped to rbac.actionNamespaces as namespaced Roles below, so a
@@ -86,11 +91,12 @@ subjects:
     namespace: {{ .Release.Namespace }}
 {{- range .Values.rbac.controllerLogNamespaces }}
 ---
-# controller_logs: read RAW Flux controller pod logs in THIS namespace only (default
-# flux-system) — never cluster-wide — because pod logs may carry secrets/PII and tool
-# output is sent to an external LLM. pods get/list is repeated here (in addition to the
-# cluster-wide grant) so the Role is self-contained: controller_logs lists the matching
-# controller pods before streaming pods/log.
+# controller_logs: read RAW gitops controller pod logs in THIS namespace only
+# (flux-system for Flux, argocd for ArgoCD — set via rbac.controllerLogNamespaces) —
+# never cluster-wide — because pod logs may carry secrets/PII and tool output is sent
+# to an external LLM. pods get/list is repeated here (in addition to the cluster-wide
+# grant) so the Role is self-contained: controller_logs lists the matching controller
+# pods before streaming pods/log.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/internal/providers/gitops/argocd/inspect.go
+++ b/internal/providers/gitops/argocd/inspect.go
@@ -25,12 +25,20 @@ func (p *Provider) ResourceStatus(ctx context.Context, w providers.Workload) (pr
 		return rs, err
 	}
 	rs.Ready, rs.Reason, rs.Message = appReady(u)
-	if repo, _, _ := unstructured.NestedString(u.Object, "spec", "source", "repoURL"); repo != "" {
+	// sourceRepoPath handles both single-source (spec.source) and multi-source
+	// (spec.sources[0]) schemas, mirroring the Changes() path in dynamic.go.
+	if repo, path := sourceRepoPath(u); repo != "" {
 		rs.Refs["repoURL"] = repo
-		if path, _, _ := unstructured.NestedString(u.Object, "spec", "source", "path"); path != "" {
+		if path != "" {
 			rs.Refs["path"] = path
 		}
-		if tr, _, _ := unstructured.NestedString(u.Object, "spec", "source", "targetRevision"); tr != "" {
+		tr, _, _ := unstructured.NestedString(u.Object, "spec", "source", "targetRevision")
+		if tr == "" {
+			if first, ok := firstSourceMap(u, "spec", "sources"); ok {
+				tr, _ = first["targetRevision"].(string)
+			}
+		}
+		if tr != "" {
 			rs.Refs["targetRevision"] = tr
 		}
 	}

--- a/internal/providers/gitops/argocd/inspect_test.go
+++ b/internal/providers/gitops/argocd/inspect_test.go
@@ -85,6 +85,47 @@ func TestArgoResourceStatusSyncFailedForcesNotReady(t *testing.T) {
 	}
 }
 
+func TestArgoResourceStatusMultiSource(t *testing.T) {
+	// Multi-source app: spec.source is absent; spec.sources[] carries the refs.
+	// ResourceStatus must populate repoURL/path/targetRevision from sources[0],
+	// matching the behaviour of the Changes() path (sourceRepoPath in dynamic.go).
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "multi-src", "namespace": "argocd"},
+		"spec": map[string]any{
+			"sources": []any{
+				map[string]any{
+					"repoURL":        "https://example.com/infra",
+					"path":           "apps/payment",
+					"targetRevision": "v1.2.3",
+				},
+				map[string]any{
+					"repoURL":        "https://example.com/values",
+					"targetRevision": "HEAD",
+				},
+			},
+			"destination": map[string]any{"namespace": "payment"},
+		},
+		"status": map[string]any{
+			"health": map[string]any{"status": "Degraded"},
+			"sync":   map[string]any{"status": "OutOfSync"},
+		},
+	}}
+	p := New(fakeReader{obj: obj}, &whatchanged.Differ{})
+	rs, err := p.ResourceStatus(context.Background(), providers.Workload{Kind: "Application", Name: "multi-src", Namespace: "argocd"})
+	if err != nil {
+		t.Fatalf("ResourceStatus: %v", err)
+	}
+	if rs.Refs["repoURL"] != "https://example.com/infra" {
+		t.Fatalf("repoURL should come from sources[0], got %q", rs.Refs["repoURL"])
+	}
+	if rs.Refs["path"] != "apps/payment" {
+		t.Fatalf("path from sources[0]: got %q", rs.Refs["path"])
+	}
+	if rs.Refs["targetRevision"] != "v1.2.3" {
+		t.Fatalf("targetRevision from sources[0]: got %q", rs.Refs["targetRevision"])
+	}
+}
+
 func TestArgoResourceStatusNotFound(t *testing.T) {
 	p := New(fakeReader{notFound: true}, &whatchanged.Differ{})
 	rs, err := p.ResourceStatus(context.Background(), providers.Workload{Kind: "Application", Name: "ghost", Namespace: "argocd"})


### PR DESCRIPTION
ResourceStatus() was only reading spec.source (single-source schema). Multi-source apps (spec.sources[]) left repoURL/path/targetRevision empty in the status refs. Fix uses the existing sourceRepoPath() helper (already used in Changes()). Adds TestArgoResourceStatusMultiSource to cover the regression. Also expands the Helm RBAC to include applicationsets and appprojects.