### PR TITLE
ci(build-image): sign image with cosign + attach SBOM and SLSA provenance

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,6 +41,9 @@ jobs:
       contents: read
       packages: write
       security-events: write
+      # Keyless cosign signing: the OIDC token identifies this workflow to Fulcio,
+      # which issues the short-lived signing certificate. No long-lived keys.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -91,7 +94,28 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: false
+          # Buildx-native supply-chain attestations, pushed alongside the image:
+          #   provenance mode=max -> full SLSA build provenance (build steps + materials)
+          #   sbom: true          -> SPDX SBOM attestation generated from the build
+          # These are attached as OCI referrers to the pushed digest; cosign signs
+          # the same digest below.
+          provenance: mode=max
+          sbom: true
+
+      # Keyless image signing. Only runs when the image was actually pushed
+      # (digest is empty on pull_request). cosign uses the job's OIDC token to
+      # get a short-lived Fulcio cert and records the signature in Rekor.
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image with cosign (keyless)
+        if: github.event_name != 'pull_request'
+        env:
+          # Sign by immutable digest, not a mutable tag, so the signature can't be
+          # repointed at a different image later.
+          IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE_DIGEST}"
 
       # PR gate: the image isn't pushed on pull_request, so scan the filesystem
       # (Go module graph + Dockerfile/config) and FAIL the job on HIGH/CRITICAL
@@ -141,7 +165,9 @@ jobs:
             echo '```'
             if [[ "${{ github.event_name }}" != "pull_request" ]]; then
               echo "**Pushed to**: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`"
+              echo "**Digest**: \`${{ steps.build.outputs.digest }}\`"
               echo "**Security scan**: ✅ Trivy (HIGH, CRITICAL)"
+              echo "**Supply chain**: ✅ cosign signature + SLSA provenance + SBOM attestation"
             else
               echo "_PR build — image built for validation, not pushed._"
             fi


### PR DESCRIPTION
## What

Hardens the GHCR image build with supply-chain attestations and a keyless signature. Build + push behavior is unchanged (still amd64, still pushes only on `main` / `v*` pushes).

- **SLSA provenance + SBOM (buildx-native):** on `docker/build-push-action`, `provenance: false` → `provenance: mode=max` (full SLSA build provenance: steps + materials) and `sbom: true` (SPDX SBOM). Both are pushed as OCI referrers attached to the image digest — no extra tooling.
- **Keyless cosign signature:** install `sigstore/cosign-installer`, then `cosign sign --yes <image>@<digest>` after push. Signs by **immutable digest** (`steps.build.outputs.digest`), not a mutable tag, so the signature can't be repointed. Signature is recorded in Rekor; cert issued by Fulcio from the workflow's OIDC identity.
- Both cosign steps are gated `if: github.event_name != 'pull_request'` (the image isn't pushed on PRs, so the digest is empty there).

## Permissions delta

Added **`id-token: write`** to the `build-and-push` job — required for keyless OIDC: GitHub mints the token, Fulcio exchanges it for a short-lived signing cert. No long-lived keys. Kept `contents: read`, `packages: write`, `security-events: write`; nothing broader.

## Pinning

New action pinned to a 40-char commit SHA + version comment, per repo convention:
- `sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2`

## How a consumer verifies

```sh
cosign verify \
  ghcr.io/<owner>/runlore:<tag> \
  --certificate-identity-regexp "^https://github.com/Smana/runlore/.github/workflows/build-image.yml@refs/.*$" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com

# SBOM / SLSA provenance attestations:
cosign download sbom       ghcr.io/<owner>/runlore@<digest>
cosign verify-attestation  ghcr.io/<owner>/runlore@<digest> \
  --type slsaprovenance \
  --certificate-identity-regexp "^https://github.com/Smana/runlore/.github/workflows/build-image.yml@refs/.*$" \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

(Pin `--certificate-identity` to the exact ref, e.g. `...build-image.yml@refs/tags/v1.0.0`, for a specific release.)

## Notes

- The first signature / attestations only materialize once this merges to `main` and a build runs (or a `v*` tag is pushed) — PR builds don't push or sign.
- Validated with `actionlint` (clean, incl. shellcheck on the `run` step) and a YAML parse check.