### PR TITLE
fix(redact): broaden high-precision secret coverage (anchored token rules, AWS secret cue)

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -27,12 +27,26 @@ var rules = []rule{
 	{regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`), mask},
 	// GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_).
 	{regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`), mask},
-	// OpenAI / Anthropic-style keys.
-	{regexp.MustCompile(`sk-[A-Za-z0-9_-]{16,}`), mask},
+	// GitHub fine-grained personal access token.
+	{regexp.MustCompile(`\bgithub_pat_[0-9A-Za-z_]{22,}\b`), mask},
+	// OpenAI / Anthropic-style keys (anchored so a benign "sk-" inside a word
+	// like "task-management" is not matched).
+	{regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{16,}\b`), mask},
+	// Stripe live keys (secret / restricted).
+	{regexp.MustCompile(`\b(?:sk|rk)_live_[0-9A-Za-z]{16,}\b`), mask},
+	// Google OAuth access token.
+	{regexp.MustCompile(`\bya29\.[0-9A-Za-z_-]{20,}`), mask},
 	// Slack tokens.
 	{regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`), mask},
 	// AWS access key id.
 	{regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`), mask},
+	// AWS secret access key, but ONLY when an AWS context cue is adjacent. The
+	// ':' / '=' separated forms (aws_secret_access_key=..., "SecretAccessKey":
+	// "...") are already covered by the generic key=value rule below; this adds
+	// the whitespace-separated case while deliberately NOT introducing a bare
+	// [A-Za-z0-9/+]{40} rule, which would false-positive on git SHAs and
+	// base64 log blobs.
+	{regexp.MustCompile(`(?i)(aws[_-]?secret[_-]?access[_-]?key\s+)[A-Za-z0-9/+]{40}\b`), `${1}[REDACTED]`},
 	// Google API key.
 	{regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`), mask},
 	// Credentials in a URL: scheme://user:PASSWORD@host → mask the password.

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -14,9 +14,17 @@ func TestSecretsMasks(t *testing.T) {
 		keeps string // structure that SHOULD survive (optional)
 	}{
 		{"github token", "found ghp_0123456789abcdefghijABCDEFGHIJ0123 here", "ghp_0123456789abcdefghijABCDEFGHIJ0123", "found"},
+		{"github fine-grained pat", "token github_pat_11ABCDE0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGH used", "github_pat_11ABCDE0123456789_abcdefghijklmnopqrstuvwxyzABCDEFGH", "token"},
 		{"openai key", "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwx", "sk-abcdefghijklmnopqrstuvwx", ""},
+		{"openai key mid sentence", "the key sk-abcdefghijklmnopqrstuvwx is here", "sk-abcdefghijklmnopqrstuvwx", "the key"},
+		{"stripe live secret key", "stripe sk_live_0123456789abcdefABCDEF here", "sk_live_0123456789abcdefABCDEF", "stripe"},
+		{"stripe live restricted key", "stripe rk_live_0123456789abcdefABCDEF here", "rk_live_0123456789abcdefABCDEF", "stripe"},
+		{"google oauth token", "Authorization uses ya29.A0ARrdaM9abcdefghij_klmnopqrstuvw-XYZ123 today", "ya29.A0ARrdaM9abcdefghij_klmnopqrstuvw-XYZ123", "today"},
 		{"slack token", "token xoxb-123456789012-abcdefuvwxyz", "xoxb-123456789012-abcdefuvwxyz", ""},
 		{"aws key id", "AccessKeyId: " + secret, secret, "AccessKeyId"},
+		{"aws secret kv equals", "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "aws_secret_access_key"},
+		{"aws secret kv quoted json", `"aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "aws_secret_access_key"},
+		{"aws secret cue whitespace", "aws_secret_access_key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", "aws_secret_access_key"},
 		{"jwt", "auth eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk", "eyJzdWIiOiIxIn0", ""},
 		{"password kv", `password: hunter2horse`, "hunter2horse", "password"},
 		{"secret env", "DB_SECRET=s3cr3t-value-xyz", "s3cr3t-value-xyz", ""},
@@ -55,10 +63,40 @@ func TestSecretsKeepsBenign(t *testing.T) {
 		"cpu: 250m\nmemory: 512Mi",
 		"reason: CrashLoopBackOff, restartCount: 7",
 		"level=info msg=\"reconcile succeeded\" duration=1.2s",
+		// 40-char git SHA (looks like an AWS secret but has no AWS cue).
+		"merged commit a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 to main",
+		// 40-char hex value with no AWS cue, in a benign field.
+		"checksum: da39a3ee5e6b4b0d3255bfef95601890afd80709",
+		// base64 log blob with no AWS cue.
+		"payload ZHVtbXliYXNlNjRibG9iZGF0YXdpdGhvdXRhd3ljdWVoZXJl in trace",
+		// "sk-" as a substring inside ordinary words must not trip the token rule.
+		"this is task-management, disk-usage and ask-me-anything",
+		// "ya29." substring inside a larger word must not match.
+		"the library libya29things is fine",
 	}
 	for _, s := range benign {
 		if got := Secrets(s); got != s {
 			t.Errorf("benign text was altered:\n  in:  %q\n  out: %q", s, got)
 		}
+	}
+}
+
+// TestAWSSecretRequiresCue pins the high-precision contract for the 40-char AWS
+// secret: it is redacted only when an AWS context cue is adjacent. The exact
+// same value with no cue (it is shaped like a base64 blob / SHA) must survive,
+// so we never false-positive on benign 40-char tokens.
+func TestAWSSecretRequiresCue(t *testing.T) {
+	const val = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" // 40 chars
+
+	// With an AWS cue adjacent (whitespace-separated), the value is masked.
+	withCue := "aws_secret_access_key " + val
+	if got := Secrets(withCue); strings.Contains(got, val) {
+		t.Fatalf("AWS secret with cue should be redacted, got %q", got)
+	}
+
+	// With no AWS cue, the identical 40-char value must be left intact.
+	noCue := "blob value " + val + " end"
+	if got := Secrets(noCue); got != noCue {
+		t.Fatalf("40-char value without AWS cue must survive, got %q", got)
 	}
 }


### PR DESCRIPTION
Hardens the secret-redaction rules in `internal/redact` while honoring the package's high-precision philosophy: mask the secret value, preserve surrounding structure, and introduce **no new false positives**.

## Gaps closed
- **Anchored the `sk-` rule** (`\bsk-[A-Za-z0-9_-]{16,}\b`). It was unanchored and could match mid-token; a benign `sk-` inside a word (e.g. `task-management`, `disk-usage`, `ask-me-anything`) is no longer touched.
- **Added unambiguous high-signal formats**, all anchored:
  - GitHub fine-grained PAT — `\bgithub_pat_[0-9A-Za-z_]{22,}\b`
  - Google OAuth access token — `\bya29\.[0-9A-Za-z_-]{20,}`
  - Stripe live keys — `\b(?:sk|rk)_live_[0-9A-Za-z]{16,}\b`
- **AWS secret access key.** Verified empirically that the generic `key=value` rule already catches every `:` / `=` separated form (`aws_secret_access_key=…`, `AWS_SECRET_ACCESS_KEY="…"`, `"aws_secret_access_key": "…"`, `SecretAccessKey: …`). The only real gap was the **whitespace-separated** form, which is now covered by a rule gated on an adjacent AWS context cue: `(?i)(aws[_-]?secret[_-]?access[_-]?key\s+)[A-Za-z0-9/+]{40}\b`.

## False-positive guards
- **No bare `[A-Za-z0-9/+]{40}` rule** was added — it would false-positive on git SHAs and base64 blobs. The 40-char AWS secret is only redacted when an AWS cue is adjacent.
- New table-driven negative cases prove a 40-char git SHA, a 40-char hex checksum, a base64 log blob with no AWS cue, and `sk-`/`ya29.` substrings inside ordinary words all survive untouched. A dedicated test pins the "AWS cue required" contract (same 40-char value: masked with a cue, intact without).
- Idempotency preserved (running twice == once).

## Quality gate (green)
```
$ go build ./... && go vet ./... && go test ./... && test -z "$(gofmt -l .)" && golangci-lint run ./...
ok  	github.com/Smana/runlore/internal/redact	0.006s
... (all packages ok)
0 issues.
GATE_EXIT=0
```