### PR TITLE
docs: add community-health files and project-status section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for RunLore.
+# These owners are requested for review on every pull request.
+# See https://docs.github.com/articles/about-code-owners
+
+* @Smana

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,114 @@
+name: Bug report
+description: Report something in RunLore that isn't working as expected
+title: "bug: <short summary>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in as much as you can —
+        it makes reproduction much faster.
+
+        **Security issue?** Do **not** file it here. Report vulnerabilities privately
+        via the [Security advisories page](https://github.com/Smana/runlore/security/advisories/new).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug — what you observed.
+      placeholder: RunLore returned ... / the investigation crashed with ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: What you expected instead.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: RunLore version or commit SHA
+      description: Output of `lore version`, the image tag, or the Git commit SHA you built from.
+      placeholder: "v0.x.y / git sha abc1234"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment-mode
+    attributes:
+      label: Deployment mode
+      description: How were you running RunLore when this happened?
+      options:
+        - "lore serve (in-cluster, via Helm)"
+        - "lore investigate (CLI, one-shot)"
+        - "lore eval (eval harness)"
+        - "Other / not sure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: gitops-engine
+    attributes:
+      label: GitOps engine
+      description: Which what-changed source is configured?
+      options:
+        - Flux
+        - Argo CD
+        - None
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: model-provider
+    attributes:
+      label: Model provider
+      description: Anthropic, Gemini, or an OpenAI-compatible endpoint — and the model id if relevant.
+      placeholder: "Anthropic claude-... / OpenAI-compatible (vLLM, ...) / Gemini ..."
+    validations:
+      required: true
+
+  - type: input
+    id: backends
+    attributes:
+      label: Metrics / logs / network backends
+      description: e.g. VictoriaMetrics, Prometheus, VictoriaLogs, Hubble — or none.
+      placeholder: "metrics: VictoriaMetrics · logs: VictoriaLogs · network: Hubble"
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. Configure ...
+        2. Fire an alert / run `lore investigate ...`
+        3. See ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: |
+        Relevant log output, error messages, or config snippets.
+        **Redact secrets, tokens, API keys, and cluster identifiers** before pasting.
+      render: text
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Environment details, screenshots, or context that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,6 +5,3 @@ contact_links:
     about: >-
       Found a security issue? Report it privately via GitHub security advisories —
       please do NOT open a public issue for vulnerabilities.
-  - name: Questions & discussion
-    url: https://github.com/Smana/runlore/discussions
-    about: For usage questions, ideas, and general discussion (not bug reports).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Smana/runlore/security/advisories/new
+    about: >-
+      Found a security issue? Report it privately via GitHub security advisories —
+      please do NOT open a public issue for vulnerabilities.
+  - name: Questions & discussion
+    url: https://github.com/Smana/runlore/discussions
+    about: For usage questions, ideas, and general discussion (not bug reports).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Suggest an idea or improvement for RunLore
+title: "feat: <short summary>"
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! RunLore is an opinionated, **read-only-first** SRE agent
+        built around one loop: **React → Investigate → Learn**, feeding an **open,
+        portable knowledge base you own**. Proposals that sharpen that loop land best.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem are you trying to solve? What's painful or missing today?
+      placeholder: "When investigating X, RunLore can't ... so I have to ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like RunLore to do? Describe the behavior or capability.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, existing workarounds, or related tools you looked at.
+    validations:
+      required: false
+
+  - type: textarea
+    id: fit
+    attributes:
+      label: How does it fit RunLore's intent?
+      description: |
+        Help us place this. How does it serve the **React → Investigate → Learn** loop,
+        the **read-only-first** posture (writes only to Git via reviewed PRs), and the
+        **open, portable knowledge** principle (no proprietary lock-in)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Sketches, links, prior art, or example output that would help.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing to RunLore! Keep the change small and focused
+(one concern per PR), and describe what changed and how you verified it.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Linked issue
+
+<!-- e.g. Closes #123 — or "n/a" -->
+
+## How was it verified?
+
+<!-- Cite the gate results, and `hack/e2e-k3d.sh` if it touches a feature path. -->
+
+## Checklist
+
+<!-- The quality gate below is exactly what CI runs (.github/workflows/ci.yaml). -->
+
+- [ ] `go build ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes (`-race` where goroutines are involved)
+- [ ] `gofmt -l .` prints nothing
+- [ ] `golangci-lint run ./...` reports 0 issues
+- [ ] Test added first (TDD) — the failing test came before the implementation
+- [ ] Docs updated (README / `docs/`) if behavior or config changed
+- [ ] Respects **read-only-first**: no new cluster writes; the only writes are to Git via reviewed PRs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to RunLore are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+RunLore is **pre-1.0 and under active development** — there are no tagged releases
+yet, so everything currently lives under `[Unreleased]`.
+
+## [Unreleased]
+
+### Added
+
+- **React → Investigate → Learn loop.** A read-only-first SRE agent that triggers on
+  Alertmanager alerts and GitOps-failure events, runs a ReAct investigation
+  (`what_changed` → `kb_search` → `submit_findings`), and posts a confidence-scored
+  root cause with an evidence trail and suggested next steps.
+- **What-changed-first RCA.** Git revision diffing surfaces the exact change behind an
+  incident, via the configured GitOps engine.
+- **GitOps providers.** Flux (informer-backed) and Argo CD, behind an
+  engine-agnostic provider contract.
+- **Metrics-agnostic signals.** VictoriaMetrics and Prometheus, with pluggable logs
+  (VictoriaLogs) and CNI-agnostic network flows (Hubble).
+- **Pluggable models.** Anthropic, Gemini, and any OpenAI-compatible endpoint, in or
+  out of cluster.
+- **The learning loop.** Every investigation drafts a knowledge-base entry as a GitHub
+  pull request into a repo you own (OKF-compatible markdown); merged entries are
+  indexed (bleve) so the same incident gets instant recall next time. Curation is
+  confidence-routed.
+- **Honest-about-uncertainty RCA.** `unresolved` is a first-class answer, and an
+  adversarial *verify* pass can only ever lower a finding's confidence.
+- **Notifications.** Slack and Matrix notifiers with fan-out.
+- **Delivery.** A single Go binary deployed via Helm; `lore serve` (in-cluster,
+  webhook-driven) and `lore investigate` (one-shot CLI). Leader election for HA.
+- **Eval harness.** `lore eval` replays recorded incident cases and reports the
+  root-cause-identification rate; a nightly CI eval guards against RCA regressions.
+
+[Unreleased]: https://github.com/Smana/runlore/commits/main

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[smaine.kahlouch@ogenki.io](mailto:smaine.kahlouch@ogenki.io).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ not a proprietary store), from an agent that's **honest about the sub-50% realit
 first-class answer, an adversarial *verify* pass can only ever lower a finding's confidence, and every
 claim is checked by a shipped eval harness.
 
+## Project status & stability
+
+RunLore is **pre-1.0 and under active development** — interfaces and config may shift
+between commits. It's usable today, but "stable" means different things across the surface:
+
+- **The supported golden path is eval-tested and stable.** That's **Flux** +
+  **VictoriaMetrics / Prometheus** + an **Anthropic or OpenAI-compatible** model +
+  **Slack** + **GitHub** for the knowledge base. This is the path the [nightly eval](CONTRIBUTING.md#nightly-eval-ci)
+  and the [k3d e2e suite](CONTRIBUTING.md#end-to-end-on-k3d) exercise — run it with confidence.
+- **Functional but less exercised:** **Argo CD**, **Matrix**, **Gemini**, cloud
+  integrations, and the network (Hubble) provider. They work and are tested, but see
+  less real-world mileage — expect rougher edges and please file issues.
+- **The `auto` autonomy rung is experimental, frozen, and not recommended on real
+  clusters.** The supported posture is **read-only → suggest → approve**: RunLore reads
+  and recommends, a human reviews and merges. Hands-off `auto` remains on the roadmap,
+  off by default, and should not be pointed at production.
+
+If you stay on the golden path with a human in the approval loop, you're on the surface
+we test hardest.
+
 ## Docs
 
 📐 [Design](docs/design.md) · 📚 [Learning loop](docs/learning-loop.md) · ✅ [Reviewing knowledge](docs/reviewing-knowledge.md) · 🚀 [Getting started](docs/getting-started.md) ·

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Security Policy
+
+RunLore is an SRE agent that runs **inside your cluster** with privileged reach: it
+holds a GitHub App key, LLM provider credentials, and reads Kubernetes Secrets to
+investigate incidents. A vulnerability here can expose those credentials or the
+clusters RunLore observes — so please report it **privately**, not in a public issue.
+
+## Reporting a vulnerability
+
+**Preferred — GitHub private security advisories.** Open the repository's
+[**Security** tab → **Report a vulnerability**](https://github.com/Smana/runlore/security/advisories/new).
+This keeps the report, the discussion, and any fix coordination private until a patch
+is ready, and gives you credit on the published advisory.
+
+**Fallback — email.** If you can't use GitHub advisories, write to
+**[smaine.kahlouch@ogenki.io](mailto:smaine.kahlouch@ogenki.io)**. Encrypt the report
+if you can; otherwise keep the details minimal in the first message and we'll move to a
+private channel.
+
+Please **do not** open a public GitHub issue, discussion, or pull request for a
+suspected vulnerability — that discloses it to everyone before there's a fix.
+
+### What to include
+
+A good report lets us reproduce and assess impact quickly:
+
+- a description of the issue and the **impact** you believe it has;
+- the affected component (e.g. the GitHub forge, the model client, config loading,
+  the webhook server) and the version or commit SHA;
+- **reproduction steps** or a proof of concept;
+- any relevant logs or config — **redact secrets, tokens, and cluster identifiers**.
+
+## Supported versions
+
+RunLore is **pre-1.0 and under active development**. Security fixes land only on the
+**latest `main` and the newest tagged release** — there are no maintained back-release
+branches. If you're running an older commit, the fix is to update.
+
+| Version            | Supported |
+| ------------------ | --------- |
+| latest `main`      | ✅        |
+| newest release     | ✅        |
+| anything older     | ❌        |
+
+## What to expect
+
+- **Acknowledgement within 72 hours** of your report.
+- An initial assessment (severity, whether we can reproduce, likely timeline) shortly
+  after.
+- **Coordinated disclosure.** We'll work with you on a fix and agree on a disclosure
+  date; please give us reasonable time to ship a patch before going public. Once the
+  fix is released we'll publish an advisory and credit you (unless you'd rather stay
+  anonymous).
+
+Thank you for helping keep RunLore and the people who run it safe.


### PR DESCRIPTION
Adds the missing OSS community-health files. **Docs/config only — no code changes (no `.go` files touched).**

## Files added
- `SECURITY.md` — private disclosure path (GitHub security advisories preferred, email fallback), pre-1.0 support policy, 72h acknowledgement + coordinated disclosure.
- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1, enforcement contact `smaine.kahlouch@ogenki.io`.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — issue **form** (what happened/expected, version/SHA, deployment mode, GitOps engine, model provider, backends, repro, redacted logs).
- `.github/ISSUE_TEMPLATE/feature_request.yml` — issue **form** (problem, proposed solution, alternatives, fit with React→Investigate→Learn / read-only-first / open knowledge).
- `.github/ISSUE_TEMPLATE/config.yml` — `blank_issues_enabled: false`, contact link routing vulnerabilities to Security advisories.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary + linked issue + checklist mirroring the real quality gate (build/vet/test, `gofmt -l` empty, golangci-lint 0 issues, TDD, docs, read-only-first).
- `.github/CODEOWNERS` — `* @Smana`.
- `CHANGELOG.md` — Keep a Changelog 1.1.0, `[Unreleased]` only (no fabricated version/date — there are no releases yet).

## Files changed
- `README.md` — new **Project status & stability** section (golden path is eval-tested/stable; Argo CD / Matrix / Gemini / cloud / network are functional but less exercised; `auto` rung is experimental, frozen, not for real clusters — supported posture is read-only → suggest → approve).

## Validation
- Both issue-form YAMLs validated against GitHub's issue-forms schema (top-level `name`/`description`, `body` list with valid `type`/`attributes`, no duplicate ids).
- README anchors to `CONTRIBUTING.md` (`#nightly-eval-ci`, `#end-to-end-on-k3d`) confirmed to resolve.