### PR TITLE
fix(curator): dedup re-investigations by trigger key, not LLM prose

### DIFF
--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -71,14 +71,24 @@ func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (
 	return false, catalog.Entry{}, nil
 }
 
-// DupFingerprint is a deterministic identity for "the same problem on the same
-// resource": the affected-resource ref plus the sorted significant-token set of the
-// top root cause, hashed. Unlike Fingerprint (a fuzzy BM25 query), it is stable
-// across the LLM's prose phrasing, so two investigations of one incident hash
-// alike. It returns "" when there is neither a resource nor a cause to key on — an
-// empty fingerprint must never match another.
+// DupFingerprint is a deterministic identity for "the same incident", used to
+// dedupe curated PRs across re-investigations. It prefers the trigger key stamped
+// at trigger time (a structured K8s signal — the alert fingerprint, or the failing
+// resource + condition reason): re-investigations of one ongoing incident reword
+// the LLM's prose cause but share the same trigger, so keying on the trigger is
+// what coalesces them to a single open PR (#137). When no trigger key is present
+// (e.g. a human `lore investigate "<symptom>"`), it falls back to the affected-
+// resource ref plus the significant-token set of the top root cause. Unlike
+// Fingerprint (a fuzzy BM25 query) it is an exact hash. It returns "" when there is
+// nothing to key on — an empty fingerprint must never match another.
 func DupFingerprint(inv providers.Investigation) string {
 	ref := strings.ToLower(inv.Resource.Ref())
+	if tk := strings.ToLower(strings.TrimSpace(inv.TriggerKey)); tk != "" {
+		// "trigger:" namespaces the key so a trigger value can never collide with a
+		// prose causeKey from the fallback path below.
+		sum := sha256.Sum256([]byte(ref + "|trigger:" + tk))
+		return hex.EncodeToString(sum[:])
+	}
 	cause := ""
 	if len(inv.RootCauses) > 0 {
 		cause = inv.RootCauses[0].Summary

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -177,3 +177,39 @@ func TestDupFingerprintDiffersByTerseAcronymCause(t *testing.T) {
 		t.Fatalf("different terse causes on the same resource must not collide: both %q", fa)
 	}
 }
+
+// TestDupFingerprintStableAcrossProseWhenTriggerKeyPresent is the #137 regression:
+// re-investigations of one ongoing incident reword the LLM root cause, but the
+// trigger that fired them (a failing resource + condition, or an alert fingerprint)
+// is identical. Keying on that deterministic trigger makes the fingerprints match,
+// so the curator updates the one open PR instead of opening a new PR per retry.
+func TestDupFingerprintStableAcrossProseWhenTriggerKeyPresent(t *testing.T) {
+	res := providers.Workload{Kind: "Application", Namespace: "argocd", Name: "airflow"}
+	const tk = "argocd/airflow:Degraded"
+	a := providers.Investigation{
+		Resource:   res,
+		TriggerKey: tk,
+		RootCauses: []providers.Hypothesis{{Summary: "ArgoCD git repository authentication failure"}},
+	}
+	b := providers.Investigation{
+		Resource:   res,
+		TriggerKey: tk,
+		RootCauses: []providers.Hypothesis{{Summary: "Missing ExternalSecret for database credentials: Secret does not exist"}},
+	}
+	fa, fb := DupFingerprint(a), DupFingerprint(b)
+	if fa == "" || fa != fb {
+		t.Fatalf("same trigger key must hash alike across reworded causes: %q vs %q", fa, fb)
+	}
+}
+
+// TestDupFingerprintDiffersByTriggerKey guards against over-coalescing: genuinely
+// different triggers on the same resource (e.g. a Degraded vs an OutOfSync
+// condition) must not collapse into one fingerprint.
+func TestDupFingerprintDiffersByTriggerKey(t *testing.T) {
+	res := providers.Workload{Namespace: "argocd", Name: "airflow"}
+	a := providers.Investigation{Resource: res, TriggerKey: "argocd/airflow:Degraded", RootCauses: []providers.Hypothesis{{Summary: "x"}}}
+	b := providers.Investigation{Resource: res, TriggerKey: "argocd/airflow:OutOfSync", RootCauses: []providers.Hypothesis{{Summary: "x"}}}
+	if DupFingerprint(a) == DupFingerprint(b) {
+		t.Fatal("different trigger keys on the same resource must not coalesce")
+	}
+}

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -39,6 +39,7 @@ type Request struct {
 	At           time.Time
 	Fingerprint  string   // Alertmanager fingerprint (stable firing↔resolved); for outcome attribution
 	Fingerprints []string // coalesced batch fingerprints; one open is recorded per entry so every constituent alert's resolve matches
+	TriggerKey   string   // deterministic incident identity (alert fingerprint, or failing resource+condition) set at trigger time; threaded to Investigation.TriggerKey for stable dedup across reworded re-investigations (#137)
 }
 
 // workloadFromLabels derives the affected workload (kind, name) from Alertmanager
@@ -81,12 +82,13 @@ func FromIncident(inc config.Incident) Request {
 		At:           inc.StartsAt,
 		Fingerprint:  inc.Fingerprint,
 		Fingerprints: fps,
+		TriggerKey:   inc.Fingerprint, // Alertmanager fingerprint: stable across re-fires of one alert series (#137)
 	}
 }
 
 // FromFailureEvent builds a Request from a GitOps failure.
 func FromFailureEvent(fe providers.FailureEvent) Request {
-	return Request{
+	r := Request{
 		Source:   SourceGitOpsFailure,
 		Title:    fe.Workload.Kind + "/" + fe.Workload.Name + " " + fe.Reason,
 		Workload: fe.Workload,
@@ -94,6 +96,15 @@ func FromFailureEvent(fe providers.FailureEvent) Request {
 		Message:  fe.Message,
 		At:       fe.When,
 	}
+	// TriggerKey is the failing resource ref + its condition reason — both
+	// deterministic K8s fields, not LLM prose. A persistently-failing resource (e.g.
+	// an ArgoCD Application that retries every ~30m) re-fires with the same ref+reason,
+	// so its re-investigations dedupe to one curated PR however the model rewords the
+	// cause (#137). Guard the degenerate empty-ref case → fall back to prose dedup.
+	if ref := fe.Workload.Ref(); ref != "" {
+		r.TriggerKey = ref + ":" + fe.Reason
+	}
+	return r
 }
 
 // Investigator runs an investigation for a Request.

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -120,6 +120,30 @@ func TestFromFailureEvent(t *testing.T) {
 	}
 }
 
+func TestFromFailureEventSetsTriggerKey(t *testing.T) {
+	// The trigger key is the failing resource ref + the condition reason — both
+	// deterministic K8s fields, set before the LLM runs, so re-investigations of one
+	// persistent failure share it regardless of how the model rewords the cause (#137).
+	fe := providers.FailureEvent{
+		Workload: providers.Workload{Kind: "Application", Namespace: "argocd", Name: "airflow"},
+		Reason:   "Degraded",
+	}
+	if r := FromFailureEvent(fe); r.TriggerKey != "argocd/airflow:Degraded" {
+		t.Fatalf("Request.TriggerKey = %q, want argocd/airflow:Degraded", r.TriggerKey)
+	}
+}
+
+func TestFromIncidentSetsTriggerKey(t *testing.T) {
+	// For alerts the deterministic identity is the Alertmanager fingerprint.
+	if r := FromIncident(config.Incident{AlertName: "A", Namespace: "ns", Fingerprint: "fp-9"}); r.TriggerKey != "fp-9" {
+		t.Fatalf("Request.TriggerKey = %q, want fp-9", r.TriggerKey)
+	}
+	// No alert fingerprint ⇒ no trigger key (DupFingerprint falls back to the prose cause).
+	if r := FromIncident(config.Incident{AlertName: "A", Namespace: "ns"}); r.TriggerKey != "" {
+		t.Fatalf("Request.TriggerKey = %q, want empty when no fingerprint", r.TriggerKey)
+	}
+}
+
 func TestFromIncidentCarriesFingerprint(t *testing.T) {
 	r := FromIncident(config.Incident{AlertName: "A", Namespace: "ns", Fingerprint: "fp-9"})
 	if r.Fingerprint != "fp-9" {

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -319,6 +319,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				inv.Resource = preferDiscoveredResource(inv.Resource, req.Workload)
 				inv.Fingerprint = req.Fingerprint   // originating alert id, for outcome-ledger attribution
 				inv.Fingerprints = req.Fingerprints // coalesced batch ids; one open per constituent alert
+				inv.TriggerKey = req.TriggerKey     // deterministic dedup key stamped at trigger time (#137)
 				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 				if li.Metrics != nil {
 					li.Metrics.InvestigationTokens.Record(ctx, int64(estimateTokens(sys, messages, specs)))

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -35,7 +35,7 @@ func TestInstantRecallHit(t *testing.T) {
 			{Entry: catalog.Entry{Title: "Known incident", Description: "chart bump", Path: "known.md", Resource: "tooling/harbor"}, Score: 5.0}}}},
 		OnComplete: func(inv providers.Investigation) { got = &inv },
 	}
-	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Fingerprint: "fp-recall", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
+	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Fingerprint: "fp-recall", TriggerKey: "tk-recall", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
 	if model.i != 0 {
@@ -49,6 +49,9 @@ func TestInstantRecallHit(t *testing.T) {
 	}
 	if got.Fingerprint != "fp-recall" {
 		t.Fatalf("recall path must carry the alert fingerprint for outcome attribution, got %q", got.Fingerprint)
+	}
+	if got.TriggerKey != "tk-recall" {
+		t.Fatalf("recall path must propagate the trigger key for dedup, got %q", got.TriggerKey)
 	}
 }
 
@@ -123,7 +126,7 @@ func TestLoopInvestigatorActions(t *testing.T) {
 		Actions:    action.New(config.ActionPolicy{Mode: config.ActionSuggest, Allow: config.ActionAllow{ReversibleOnly: true}}),
 		OnComplete: func(inv providers.Investigation) { got = &inv },
 	}
-	if err := li.Investigate(context.Background(), Request{Title: "t", Fingerprint: "fp-loop"}); err != nil {
+	if err := li.Investigate(context.Background(), Request{Title: "t", Fingerprint: "fp-loop", TriggerKey: "tk-loop"}); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
 	// Only the reversible action is surfaced (suggest mode, reversible_only); none executed.
@@ -132,6 +135,9 @@ func TestLoopInvestigatorActions(t *testing.T) {
 	}
 	if got.Fingerprint != "fp-loop" {
 		t.Fatalf("full-loop path must carry the alert fingerprint for outcome attribution, got %q", got.Fingerprint)
+	}
+	if got.TriggerKey != "tk-loop" {
+		t.Fatalf("full-loop path must propagate the trigger key for dedup, got %q", got.TriggerKey)
 	}
 }
 

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -233,6 +233,7 @@ func recalledInvestigation(req Request, e catalog.Entry, confidence float64) pro
 		RecalledEntry: e.Path,
 		Fingerprint:   req.Fingerprint,
 		Fingerprints:  req.Fingerprints,
+		TriggerKey:    req.TriggerKey,
 		Resource:      req.Workload,
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -360,6 +360,7 @@ type Investigation struct {
 	CuratedURL    string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
 	Fingerprint   string   // originating alert fingerprint; for outcome-ledger attribution
 	Fingerprints  []string // coalesced batch fingerprints; one outcome open is recorded per entry
+	TriggerKey    string   // deterministic incident identity (alert fingerprint, or failing resource+condition) set at trigger time; curator.DupFingerprint prefers it so reworded re-investigations of one incident still dedupe (#137)
 	RecalledEntry string   // when Recalled: the catalog entry Path that was matched
 	Verified      bool     // true when the adversarial verify pass ran and a root cause survived it
 }


### PR DESCRIPTION
## What

`curator.DupFingerprint` keyed on the affected resource **plus the tokenized prose of the top root cause**. Because the root cause is LLM-generated, re-investigations of one ongoing incident worded it differently each run → different SHA-256 → `duplicateOpenPR` (file-time gate) and `curate.isDuplicatePair` (periodic sweep) never matched → **a new KB PR per retry** (the 5 ArgoCD `airflow` PRs in #137).

## Fix

Introduce a deterministic **`TriggerKey`**, stamped at trigger time from structured K8s signals — *before* the model runs:

- **Alerts** (`FromIncident`): the Alertmanager fingerprint (stable across re-fires of one alert series).
- **GitOps failures** (`FromFailureEvent`): `‹resource ref›:‹condition reason›` (e.g. `argocd/airflow:Degraded`) — both deterministic API fields, not prose.

`TriggerKey` is threaded onto the resulting `Investigation` through **both** assembly paths (full ReAct loop and instant recall). `DupFingerprint` now **prefers `TriggerKey`** over the prose cause, and **falls back** to the existing `resource + cause-token` hash when there's no trigger (e.g. a human `lore investigate "<symptom>"`). The dedup consumers are untouched — fixing the key fixes both the gate and the sweep.

For the airflow case: every ~30 min retry re-fires with the same `argocd/airflow:‹reason›` → same fingerprint → the open PR is reused instead of a 6th being opened.

## Design choice (open to feedback)

The GitOps key is **resource ref + condition reason**, deliberately dropping the volatile message substring (counts/timestamps) the issue mentioned — stable across retries, while still distinguishing a genuinely different failure *mode* (`Degraded` vs `OutOfSync`) into its own PR. If you'd prefer **ref-only** (coalesce *all* failures of one resource, more aggressive), it's a one-line change in `FromFailureEvent`.

## Tests (TDD — written failing first)

- `DupFingerprint` stable across reworded causes when a `TriggerKey` is present; differs by trigger key (no over-coalescing).
- `FromIncident` / `FromFailureEvent` set the expected key.
- `TriggerKey` propagates through both the recall and full-loop paths (extends the existing `Fingerprint`-propagation assertions).
- Existing **golden-value** and prose-fallback tests stay green (the no-trigger path is byte-for-byte unchanged).

## Quality gate

`go build ./... && go vet ./... && go test ./... && gofmt -l .` (empty) **& `golangci-lint run ./...` → `0 issues`** — all green.

Fixes #137
