### PR TITLE
refactor(cmd): extract model builders + config predicates to internal/app

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
 	"github.com/Smana/runlore/internal/action"
+	"github.com/Smana/runlore/internal/app"
 	"github.com/Smana/runlore/internal/audit"
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/coalesce"
@@ -53,9 +54,6 @@ import (
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/mcp"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
-	anthropic "github.com/Smana/runlore/internal/model/anthropic"
-	gemini "github.com/Smana/runlore/internal/model/gemini"
-	openai "github.com/Smana/runlore/internal/model/openai"
 	"github.com/Smana/runlore/internal/network/awsvpc"
 	"github.com/Smana/runlore/internal/network/gcpfirewall"
 	"github.com/Smana/runlore/internal/network/hubble"
@@ -228,7 +226,7 @@ func runServe(args []string) error {
 	auto := buildAuto(cfg, execForActions, aud, log)
 	slackSigningSecret := os.Getenv(cfg.Notify.Slack.SigningSecretEnv)
 	webhookToken := os.Getenv(cfg.Server.WebhookTokenEnv)
-	if err := requireWebhookAuth(cfg, webhookToken); err != nil {
+	if err := app.RequireWebhookAuth(cfg, webhookToken); err != nil {
 		return err
 	}
 
@@ -348,7 +346,7 @@ func runServe(args []string) error {
 	if auto != nil {
 		acts.Pauser = auto // avoid a typed-nil interface when auto is disabled
 	}
-	srv := server.New(cfg, queue, readyFunc(leader.Load, cat, catalogConfigured(cfg)), acts, metricsHandler, log)
+	srv := server.New(cfg, queue, app.ReadyFunc(leader.Load, cat, app.CatalogConfigured(cfg)), acts, metricsHandler, log)
 	srv.SetMetrics(metrics) // ingress counters emit regardless of coalescing
 	srv.SetOutcomeLedger(ledger)
 	if cz != nil {
@@ -402,9 +400,9 @@ func runLeaderElection(ctx context.Context, cfg *config.Config, cs *kubernetes.C
 	if name == "" {
 		name = "runlore-leader"
 	}
-	id := podName()
+	id := app.PodName()
 	lock := &resourcelock.LeaseLock{
-		LeaseMeta:  metav1.ObjectMeta{Name: name, Namespace: podNamespace()},
+		LeaseMeta:  metav1.ObjectMeta{Name: name, Namespace: app.PodNamespace()},
 		Client:     cs.CoordinationV1(),
 		LockConfig: resourcelock.ResourceLockConfig{Identity: id},
 	}
@@ -431,113 +429,6 @@ func runLeaderElection(ctx context.Context, cfg *config.Config, cs *kubernetes.C
 			},
 		},
 	})
-}
-
-// podName returns this pod's identity for leader election.
-func podName() string {
-	if n := os.Getenv("POD_NAME"); n != "" {
-		return n
-	}
-	h, _ := os.Hostname()
-	return h
-}
-
-// podNamespace resolves the namespace from the downward API or the service-account mount.
-func podNamespace() string {
-	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
-		return ns
-	}
-	if b, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-		if ns := strings.TrimSpace(string(b)); ns != "" {
-			return ns
-		}
-	}
-	return "default"
-}
-
-// modelProvider returns the configured model provider name (default "openai").
-func modelProvider(cfg *config.Config) string {
-	switch cfg.Model.Provider {
-	case "anthropic", "gemini":
-		return cfg.Model.Provider
-	default:
-		return "openai"
-	}
-}
-
-// modelConfigured reports whether a usable model is configured: a provider with a
-// built-in default endpoint (anthropic, gemini), or any provider with a base_url.
-func modelConfigured(cfg *config.Config) bool {
-	switch cfg.Model.Provider {
-	case "anthropic", "gemini":
-		return true
-	default:
-		return cfg.Model.BaseURL != ""
-	}
-}
-
-// catalogConfigured reports whether the operator asked for a knowledge catalog
-// (a mounted dir or a git-sync repo). It is independent of whether the load
-// succeeded: readyFunc uses it to keep a configured-but-failed catalog (which
-// buildCatalog returns as nil) from collapsing readiness to pure leadership and
-// serving incident traffic with no knowledge base.
-func catalogConfigured(cfg *config.Config) bool {
-	return cfg.Catalog.Dir != "" || cfg.Catalog.Git.URL != ""
-}
-
-// requireWebhookAuth fails closed on the serve path when the LLM investigator is
-// wired but the alert webhook is anonymous. The webhook's labels/annotations flow
-// verbatim into the LLM prompt (and bill the model), so an unauthenticated caller
-// must not reach it once a model is configured — regardless of actions.mode. This
-// lives on the serve path, NOT in config.Validate: Validate is shared by every
-// subcommand (e.g. `lore investigate` legitimately needs a model and has no
-// webhook), so the requirement is scoped to where the webhook is actually served.
-// It mirrors the approval-token fail-closed guard above.
-func requireWebhookAuth(cfg *config.Config, webhookToken string) error {
-	if modelConfigured(cfg) && webhookToken == "" {
-		return fmt.Errorf("model configured but server.webhook_token_env (%q) is empty: refusing to start with an unauthenticated alert webhook (fail closed)",
-			cfg.Server.WebhookTokenEnv)
-	}
-	return nil
-}
-
-// newModelClient builds a ModelProvider for a wire protocol + endpoint.
-func newModelClient(provider, baseURL, model, apiKey string) providers.ModelProvider {
-	switch provider {
-	case "anthropic":
-		return anthropic.New(baseURL, model, apiKey)
-	case "gemini":
-		return gemini.New(baseURL, model, apiKey)
-	default:
-		return openai.New(baseURL, model, apiKey)
-	}
-}
-
-// buildModel builds the ModelProvider for the configured provider.
-func buildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
-	return newModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey)
-}
-
-// buildVerifyModel builds the optional cheaper model for the adversarial verify
-// pass, inheriting any unset field from the main model. Returns nil when no
-// model.verify override is configured (verify then runs on the main model).
-func buildVerifyModel(cfg *config.Config) providers.ModelProvider {
-	v := cfg.Model.Verify
-	if v == nil {
-		return nil
-	}
-	or := func(a, b string) string {
-		if a != "" {
-			return a
-		}
-		return b
-	}
-	apiKey := ""
-	if keyEnv := or(v.APIKeyEnv, cfg.Model.APIKeyEnv); keyEnv != "" {
-		apiKey = os.Getenv(keyEnv)
-	}
-	return newModelClient(or(v.Provider, cfg.Model.Provider),
-		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey)
 }
 
 // buildCatalog returns the kb_search backing store, or nil when no catalog is
@@ -664,7 +555,7 @@ func runEval(args []string) error {
 	if err != nil {
 		return err
 	}
-	if !modelConfigured(cfg) {
+	if !app.ModelConfigured(cfg) {
 		return fmt.Errorf("eval requires a configured model (set config.model)")
 	}
 	if *live {
@@ -686,7 +577,7 @@ func runEval(args []string) error {
 	if cfg.Model.APIKeyEnv != "" {
 		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
 	}
-	runner := &eval.Runner{Model: buildModel(cfg, apiKey), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	runner := &eval.Runner{Model: app.BuildModel(cfg, apiKey), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 	camp := runner.RunN(context.Background(), cases, *n)
 	for _, a := range camp.Aggregates {
 		status := "MISSED"
@@ -747,19 +638,6 @@ func (shellStepRunner) Run(ctx context.Context, step string) error {
 	return cmd.Run()
 }
 
-// buildJudgeModel builds the (stronger) grader model from --judge-* flags, falling
-// back to the configured investigation model when unset.
-func buildJudgeModel(cfg *config.Config, provider, baseURL, model, apiKeyEnv string) providers.ModelProvider {
-	if provider == "" && model == "" {
-		apiKey := ""
-		if cfg.Model.APIKeyEnv != "" {
-			apiKey = os.Getenv(cfg.Model.APIKeyEnv)
-		}
-		return buildModel(cfg, apiKey)
-	}
-	return newModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv))
-}
-
 // runEvalLive runs the live-fire campaign and writes a dated report.
 func runEvalLive(cfg *config.Config, scnDir, recordDir, reportDir, prevReport, stamp string, n int,
 	jProvider, jBaseURL, jModel, jKeyEnv string) error {
@@ -773,7 +651,7 @@ func runEvalLive(cfg *config.Config, scnDir, recordDir, reportDir, prevReport, s
 	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 	ctx := context.Background()
 	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), nil, log)
-	judge := eval.ModelJudge{Model: buildJudgeModel(cfg, jProvider, jBaseURL, jModel, jKeyEnv)}
+	judge := eval.ModelJudge{Model: app.BuildJudgeModel(cfg, jProvider, jBaseURL, jModel, jKeyEnv)}
 
 	runner := &eval.LiveRunner{
 		Model: model, BaseTools: tools, Judge: judge, Steps: shellStepRunner{}, Log: log, N: n, Recall: recall,
@@ -1061,7 +939,7 @@ func buildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.G
 		var res providers.Investigation
 		var got bool
 		li := &investigate.LoopInvestigator{
-			Model: model, VerifyModel: buildVerifyModel(cfg), Tools: tools, Recall: recall, Verify: true, Log: log,
+			Model: model, VerifyModel: app.BuildVerifyModel(cfg), Tools: tools, Recall: recall, Verify: true, Log: log,
 			Metrics:                   metrics,
 			ModelProvider:             cfg.Model.Provider,
 			MaxSteps:                  cfg.Investigation.MaxSteps,
@@ -1146,7 +1024,7 @@ func buildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	if cfg.Model.APIKeyEnv != "" {
 		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
 	}
-	model := buildModel(cfg, apiKey)
+	model := app.BuildModel(cfg, apiKey)
 	forgeTok := buildForgeTokenSource(cfg, log)
 	var tools []investigate.Tool
 	if gp != nil {
@@ -1333,7 +1211,7 @@ func runInvestigate(args []string) error {
 	if err != nil {
 		return err
 	}
-	if !modelConfigured(cfg) {
+	if !app.ModelConfigured(cfg) {
 		return fmt.Errorf("investigate requires a configured model (set config.model)")
 	}
 	// Progress logs go to stderr; the findings go to stdout.
@@ -1343,7 +1221,7 @@ func runInvestigate(args []string) error {
 	model, tools, recall, _ := buildModelAndTools(ctx, cfg, gitOpsFromKube(cfg, log), nil, log)
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
-		Model: model, VerifyModel: buildVerifyModel(cfg), Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
+		Model: model, VerifyModel: app.BuildVerifyModel(cfg), Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
 		ModelProvider: cfg.Model.Provider,
 		Timeout:       cfg.Investigation.Timeout.Std(),
 		OnComplete:    func(inv providers.Investigation) { result = &inv },
@@ -1366,44 +1244,11 @@ func runInvestigate(args []string) error {
 	return nil
 }
 
-// outcomeKind labels an outcome-ledger open as a recall (cache hit) or a fresh finding.
-func outcomeKind(recalled bool) string {
-	if recalled {
-		return "recall"
-	}
-	return "fresh"
-}
-
-// readyFunc gates readiness on leadership AND a warm catalog. When a catalog is
-// configured, the leader must NOT advertise ready until its knowledge base is
-// loaded and warm — otherwise it would serve incident traffic blind. This
-// distinguishes the two ways buildCatalog returns a nil catalog:
-//
-//   - configured but the load failed (configured=true, cat=nil): stay 503. A
-//     static catalog has no syncer to recover, so the pod stays not-ready and the
-//     misconfiguration surfaces loudly instead of silently serving with no KB.
-//   - not configured at all (configured=false, cat=nil): no catalog gate;
-//     readiness is pure leadership.
-//
-// A configured-but-not-yet-warm catalog (git-sync NewEmpty, cat!=nil &&
-// !Ready()) is also held at 503 until its first successful sync.
-func readyFunc(leader func() bool, cat *catalog.Catalog, configured bool) func() bool {
-	return func() bool {
-		if configured && (cat == nil || !cat.Ready()) {
-			return false
-		}
-		if cat != nil && !cat.Ready() {
-			return false
-		}
-		return leader()
-	}
-}
-
 // buildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator. It also returns the catalog (nil when
 // no model is configured or no catalog is wired).
 func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, auto *action.Auto, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) (investigate.Investigator, *catalog.Catalog) {
-	if !modelConfigured(cfg) {
+	if !app.ModelConfigured(cfg) {
 		log.Info("no model configured; using log-only investigator")
 		return investigate.LogInvestigator{Log: log}, nil
 	}
@@ -1413,7 +1258,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		recall.Log = log
 		recall.Outcome = ledger // outcome-driven decay (serve path); *outcome.Ledger satisfies OutcomeStats
 	}
-	log.Info("using LLM investigator", "provider", modelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
+	log.Info("using LLM investigator", "provider", app.ModelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
 	notifier := buildNotifier(cfg, log)
 	log.Info("delivery notifiers", "count", notifier.Len())
 	cur := buildCurator(cfg, buildForgeTokenSource(cfg, log), cat, metrics, log)
@@ -1423,7 +1268,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	}
 	return &investigate.LoopInvestigator{
 		Model:                     model,
-		VerifyModel:               buildVerifyModel(cfg),
+		VerifyModel:               app.BuildVerifyModel(cfg),
 		Tools:                     tools,
 		Log:                       log,
 		Actions:                   actions,
@@ -1446,7 +1291,7 @@ func buildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 				fps = []string{found.Fingerprint}
 			}
 			if len(fps) > 0 {
-				kind := outcomeKind(found.Recalled)
+				kind := app.OutcomeKind(found.Recalled)
 				now := time.Now()
 				// The deterministic dedup fingerprint (resource+cause) is the curated PR's
 				// stable resolution-join key: it is the same value draftKBEntry stamps into
@@ -1526,7 +1371,7 @@ func startGitOpsFailureWatch(ctx context.Context, cfg *config.Config, q investig
 		return
 	}
 	deb := buildFailureDebouncer(cfg, gp, metrics, log)
-	log.Info("watching gitops failures", "engine", gitopsEngine(cfg),
+	log.Info("watching gitops failures", "engine", app.GitopsEngine(cfg),
 		"debounce", cfg.Triggers.GitOpsFailures.DebounceWindow())
 	go investigate.DrainFailures(ctx, events, q, dedup, deb, log)
 }
@@ -1555,14 +1400,6 @@ func buildFailureDebouncer(cfg *config.Config, gp providers.GitOpsProvider, metr
 	return investigate.NewDebouncer(cfg.Triggers.GitOpsFailures.DebounceWindow(), check, log).WithMetrics(metrics)
 }
 
-// gitopsEngine returns the configured GitOps engine, defaulting to flux.
-func gitopsEngine(cfg *config.Config) string {
-	if cfg.GitOps.Engine == "argocd" {
-		return "argocd"
-	}
-	return "flux"
-}
-
 // buildGitOps builds the GitOps provider for the configured engine (flux default).
 // The differ clones the GitOps source repo over HTTPS; it authenticates private
 // repos with the shared GitHub App installation token (the App needs contents:read
@@ -1570,7 +1407,7 @@ func gitopsEngine(cfg *config.Config) string {
 // repos only.
 func buildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) providers.GitOpsProvider {
 	differ := &whatchanged.Differ{TokenSource: buildForgeTokenSource(cfg, log)}
-	if gitopsEngine(cfg) == "argocd" {
+	if app.GitopsEngine(cfg) == "argocd" {
 		log.Info("gitops engine", "engine", "argocd")
 		return argocd.New(argocd.NewDynamicReader(dc), differ)
 	}

--- a/cmd/lore/main_test.go
+++ b/cmd/lore/main_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 )
 
@@ -52,42 +51,6 @@ func TestBuildModelAndToolsSmoke(t *testing.T) {
 	}
 }
 
-// TestRequireWebhookAuth asserts the serve-path fail-closed guard: a configured
-// model with an empty webhook token must refuse to start; everything else is
-// allowed. Scoped to serve only — config.Validate stays untouched so non-serve
-// subcommands (e.g. `lore investigate`) with a model and no webhook still run.
-func TestRequireWebhookAuth(t *testing.T) {
-	// openai/vllm needs a base_url to count as configured; anthropic/gemini are
-	// configured via their built-in endpoint even with an empty base_url.
-	openaiModel := config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1"}
-	anthropicModel := config.Model{Provider: "anthropic"} // built-in endpoint
-	noModel := config.Model{}                             // unconfigured
-
-	tests := []struct {
-		name    string
-		model   config.Model
-		token   string
-		wantErr bool
-	}{
-		{"model + token → ok", openaiModel, "secret", false},
-		{"model + no token → refused", openaiModel, "", true},
-		{"anthropic built-in + no token → refused", anthropicModel, "", true},
-		{"anthropic built-in + token → ok", anthropicModel, "secret", false},
-		{"no model + no token → ok (log-only)", noModel, "", false},
-		{"no model + token → ok", noModel, "secret", false},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := &config.Config{Model: tc.model}
-			cfg.Server.WebhookTokenEnv = "RUNLORE_WEBHOOK_TOKEN"
-			err := requireWebhookAuth(cfg, tc.token)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("requireWebhookAuth err = %v, wantErr = %v", err, tc.wantErr)
-			}
-		})
-	}
-}
-
 // TestNewHTTPServer asserts the serving http.Server is built with every inbound
 // timeout/size bound set (non-zero) — Go's defaults are zero (unlimited), the
 // Slowloris/DoS gap R9(a) closes.
@@ -107,44 +70,5 @@ func TestNewHTTPServer(t *testing.T) {
 	}
 	if s.MaxHeaderBytes == 0 {
 		t.Error("MaxHeaderBytes is zero (defaults to 1MB but should be explicit)")
-	}
-}
-
-func TestReadyFunc(t *testing.T) {
-	leaderTrue := func() bool { return true }
-	leaderFalse := func() bool { return false }
-
-	// No catalog configured → gate is pure leadership passthrough.
-	if !readyFunc(leaderTrue, nil, false)() {
-		t.Fatal("unconfigured + nil catalog + leader=true should be ready")
-	}
-	if readyFunc(leaderFalse, nil, false)() {
-		t.Fatal("unconfigured + nil catalog + leader=false should not be ready")
-	}
-
-	// A catalog was CONFIGURED but failed to load (cat == nil). Never serve incident
-	// traffic with no knowledge base: stay 503 even while leader. This is the bug —
-	// a configured-but-failed catalog used to be indistinguishable from "unconfigured"
-	// and collapsed readiness to pure leadership.
-	if readyFunc(leaderTrue, nil, true)() {
-		t.Fatal("configured + failed-to-load catalog (nil) must block readiness even when leader=true")
-	}
-
-	// A not-yet-warm configured catalog blocks readiness even when leader.
-	cold := catalog.NewEmpty()
-	if readyFunc(leaderTrue, cold, true)() {
-		t.Fatal("cold catalog must block readiness even when leader=true")
-	}
-
-	// A warm catalog is ready only when also leader.
-	warm, err := catalog.New(t.TempDir())
-	if err != nil {
-		t.Fatalf("New: %v", err)
-	}
-	if !readyFunc(leaderTrue, warm, true)() {
-		t.Fatal("warm catalog + leader=true should be ready")
-	}
-	if readyFunc(leaderFalse, warm, true)() {
-		t.Fatal("warm catalog + leader=false should not be ready")
 	}
 }

--- a/cmd/lore/validate.go
+++ b/cmd/lore/validate.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/Smana/runlore/internal/app"
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/kbvalidate"
@@ -31,8 +32,8 @@ func runValidateKB(args []string) error {
 
 	var model providers.ModelProvider
 	if *semantic {
-		if cfg, err := config.Load(*cfgPath); err == nil && modelConfigured(cfg) {
-			model = buildModel(cfg, os.Getenv(cfg.Model.APIKeyEnv))
+		if cfg, err := config.Load(*cfgPath); err == nil && app.ModelConfigured(cfg) {
+			model = app.BuildModel(cfg, os.Getenv(cfg.Model.APIKeyEnv))
 		} else {
 			fmt.Fprintln(os.Stderr, "validate-kb: --semantic set but no usable model in config; running structural only")
 		}

--- a/docs/superpowers/plans/2026-06-26-main-internal-app-extraction.md
+++ b/docs/superpowers/plans/2026-06-26-main-internal-app-extraction.md
@@ -1,0 +1,77 @@
+# `cmd/lore/main.go` → `internal/app` Extraction Plan
+
+> **For agentic workers:** behaviour-preserving refactor. The safety net is the existing
+> `go test ./...` staying green at every step; new tests are characterization tests that lock in
+> the moved functions' current behaviour. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Shrink the 1615-line `cmd/lore/main.go` god-file by moving its dependency-injection
+builders and helpers into a testable `internal/app` package, so the assembly that decides what
+ships is unit-tested instead of sitting at ~9% coverage behind `main()`.
+
+**Architecture:** A single `internal/app` package holds the constructors/predicates as exported
+functions; `cmd/lore` keeps `main()` + the `run*` subcommand handlers (CLI orchestration is a
+`cmd` concern) and calls into `app`. Done in cohesive, independently-green phases so each is a
+reviewable PR. No behaviour changes — only relocation + new tests.
+
+**Tech Stack:** Go 1.26, standard library, existing internal packages. White-box tests
+(`package app`).
+
+## Global Constraints
+
+- Behaviour-preserving: every phase keeps `go build ./... && go vet ./... && go test ./... && gofmt -l .` (empty) `&& golangci-lint run ./...` (`0 issues`) green.
+- Module path `github.com/Smana/runlore`; exported `app` symbols carry doc comments (revive).
+- No `Co-Authored-By` / AI-attribution lines in commits or PRs (user policy).
+- Function bodies move **verbatim** (only the package clause, exported name, and call sites change) so diffs read as relocations.
+
+---
+
+## Phase 1 — Foundation: model builders + config predicates (THIS PR)
+
+Establish `internal/app` and move the leaf, low-dependency functions — the easiest, mostly-untested
+units — proving the package + test pattern before the heavier builders.
+
+**Files:**
+- Create `internal/app/model.go` — `NewModelClient`, `BuildModel`, `BuildVerifyModel`, `BuildJudgeModel` (moved from `main.go:505-541,752-761`). Drops the `anthropic`/`gemini`/`openai` imports from `main.go` (used nowhere else).
+- Create `internal/app/config.go` — `ModelProvider`, `ModelConfigured`, `CatalogConfigured`, `GitopsEngine`, `RequireWebhookAuth`, `OutcomeKind` (moved from `main.go:459-502,1370-1374,1559-1564`).
+- Create `internal/app/runtime.go` — `PodName`, `PodNamespace`, `ReadyFunc` (moved from `main.go:437-456,1390-1400`).
+- Create `internal/app/{model,config,runtime}_test.go` — characterization tests; **relocate** the existing `RequireWebhookAuth`/`ReadyFunc` cases out of `cmd/lore/main_test.go`.
+- Modify `cmd/lore/main.go` — delete the moved bodies; add `internal/app` import; rewrite ~36 call sites to `app.X`.
+- Modify `cmd/lore/validate.go:34-35` — `modelConfigured`→`app.ModelConfigured`, `buildModel`→`app.BuildModel`.
+
+**Interfaces produced (signatures unchanged, now exported):**
+- `app.NewModelClient(provider, baseURL, model, apiKey string) providers.ModelProvider`
+- `app.BuildModel(cfg *config.Config, apiKey string) providers.ModelProvider`
+- `app.BuildVerifyModel(cfg *config.Config) providers.ModelProvider`
+- `app.BuildJudgeModel(cfg *config.Config, provider, baseURL, model, apiKeyEnv string) providers.ModelProvider`
+- `app.ModelProvider(cfg) string` · `app.ModelConfigured(cfg) bool` · `app.CatalogConfigured(cfg) bool` · `app.GitopsEngine(cfg) string` · `app.RequireWebhookAuth(cfg, token string) error` · `app.OutcomeKind(recalled bool) string`
+- `app.PodName() string` · `app.PodNamespace() string` · `app.ReadyFunc(leader func() bool, cat *catalog.Catalog, configured bool) func() bool`
+
+- [ ] **Step 1** — Create `internal/app/{model,config,runtime}.go` with the moved bodies (verbatim, exported, doc comments preserved).
+- [ ] **Step 2** — `go build ./internal/app/` to confirm the new package compiles in isolation.
+- [ ] **Step 3** — Delete the moved bodies from `main.go`; add the `app` import; rewrite call sites to `app.X`; drop the now-unused `anthropic`/`gemini`/`openai` imports. Update `validate.go`.
+- [ ] **Step 4** — `go build ./... && go vet ./...` — confirm the whole module still compiles.
+- [ ] **Step 5** — Relocate the `RequireWebhookAuth` + `ReadyFunc` test cases from `cmd/lore/main_test.go` into `internal/app/{config,runtime}_test.go` (white-box); add characterization tests for `ModelProvider`/`ModelConfigured`/`CatalogConfigured`/`GitopsEngine`/`OutcomeKind`/`NewModelClient` provider-selection (asserts the concrete client type per provider).
+- [ ] **Step 6** — `go test ./... && test -z "$(gofmt -l .)" && golangci-lint run ./...` — all green.
+- [ ] **Step 7** — Commit `refactor(cmd): extract model builders + config predicates to internal/app`; push; open PR.
+
+## Phase 2 — Builder family (follow-up PR)
+
+Move the heavier constructors + their private helpers into `internal/app`, cohesively:
+`buildCatalog`, `buildNotifier`, `buildForgeTokenSource` (+ the `forgeToken` type), `buildAuditor`,
+`buildApprovals`, `buildAuto`, `buildCurator`, `buildReinvestigator`, `buildModelAndTools`,
+`buildInvestigator` (+ its `OnComplete` closure), `buildFailureDebouncer`, `buildGitOps`,
+`gitOpsFromKube`, `kubeClientset`, `restConfig`, `startGitOpsFailureWatch`, `newHTTPServer`,
+`runLeaderElection`, `setMemoryLimitFromCgroup`. Files: `internal/app/{catalog,forge,action,curator,investigate,gitops,server,leader}.go`. Add wiring tests asserting the assembled graph (e.g. `BuildInvestigator` returns `LogInvestigator` with no model, `LoopInvestigator` with one; `BuildAuto` nil unless `auto` mode).
+
+## Phase 3 — Subcommand orchestration (follow-up PR)
+
+Move `runServe`/`runEval`/`runEvalLive`/`runInvestigate`/`runCurate`/`runCatalog`/`runCatalogSync`/`runMCP`
+into `internal/app` as `App` methods (or `Run*` funcs) so `runServe`'s 242-line wiring becomes
+testable; `cmd/lore/main.go` collapses to `main()` + flag dispatch (~60 lines). `runValidateKB`
+stays in `cmd/lore` (already small, in `validate.go`).
+
+## Self-review
+
+- **Coverage:** Phase 1 moves every targeted function; the `anthropic`/`gemini`/`openai`-only-in-`newModelClient` fact is verified (`grep`), so the import drop is safe. `validate.go` + `main_test.go` callers are accounted for.
+- **Type consistency:** exported names are the capitalized originals; signatures unchanged.
+- **No behaviour change:** the existing suite is the regression guard; new tests are characterization-only.

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,0 +1,69 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// ModelProvider returns the configured model provider name (default "openai").
+func ModelProvider(cfg *config.Config) string {
+	switch cfg.Model.Provider {
+	case "anthropic", "gemini":
+		return cfg.Model.Provider
+	default:
+		return "openai"
+	}
+}
+
+// ModelConfigured reports whether a usable model is configured: a provider with a
+// built-in default endpoint (anthropic, gemini), or any provider with a base_url.
+func ModelConfigured(cfg *config.Config) bool {
+	switch cfg.Model.Provider {
+	case "anthropic", "gemini":
+		return true
+	default:
+		return cfg.Model.BaseURL != ""
+	}
+}
+
+// CatalogConfigured reports whether the operator asked for a knowledge catalog
+// (a mounted dir or a git-sync repo). It is independent of whether the load
+// succeeded: ReadyFunc uses it to keep a configured-but-failed catalog (which
+// BuildCatalog returns as nil) from collapsing readiness to pure leadership and
+// serving incident traffic with no knowledge base.
+func CatalogConfigured(cfg *config.Config) bool {
+	return cfg.Catalog.Dir != "" || cfg.Catalog.Git.URL != ""
+}
+
+// RequireWebhookAuth fails closed on the serve path when the LLM investigator is
+// wired but the alert webhook is anonymous. The webhook's labels/annotations flow
+// verbatim into the LLM prompt (and bill the model), so an unauthenticated caller
+// must not reach it once a model is configured — regardless of actions.mode. This
+// lives on the serve path, NOT in config.Validate: Validate is shared by every
+// subcommand (e.g. `lore investigate` legitimately needs a model and has no
+// webhook), so the requirement is scoped to where the webhook is actually served.
+// It mirrors the approval-token fail-closed guard.
+func RequireWebhookAuth(cfg *config.Config, webhookToken string) error {
+	if ModelConfigured(cfg) && webhookToken == "" {
+		return fmt.Errorf("model configured but server.webhook_token_env (%q) is empty: refusing to start with an unauthenticated alert webhook (fail closed)",
+			cfg.Server.WebhookTokenEnv)
+	}
+	return nil
+}
+
+// OutcomeKind labels an outcome-ledger open as a recall (cache hit) or a fresh finding.
+func OutcomeKind(recalled bool) string {
+	if recalled {
+		return "recall"
+	}
+	return "fresh"
+}
+
+// GitopsEngine returns the configured GitOps engine, defaulting to flux.
+func GitopsEngine(cfg *config.Config) string {
+	if cfg.GitOps.Engine == "argocd" {
+		return "argocd"
+	}
+	return "flux"
+}

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// TestRequireWebhookAuth asserts the serve-path fail-closed guard: a configured
+// model with an empty webhook token must refuse to start; everything else is
+// allowed. Scoped to serve only — config.Validate stays untouched so non-serve
+// subcommands (e.g. `lore investigate`) with a model and no webhook still run.
+func TestRequireWebhookAuth(t *testing.T) {
+	// openai/vllm needs a base_url to count as configured; anthropic/gemini are
+	// configured via their built-in endpoint even with an empty base_url.
+	openaiModel := config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1"}
+	anthropicModel := config.Model{Provider: "anthropic"} // built-in endpoint
+	noModel := config.Model{}                             // unconfigured
+
+	tests := []struct {
+		name    string
+		model   config.Model
+		token   string
+		wantErr bool
+	}{
+		{"model + token → ok", openaiModel, "secret", false},
+		{"model + no token → refused", openaiModel, "", true},
+		{"anthropic built-in + no token → refused", anthropicModel, "", true},
+		{"anthropic built-in + token → ok", anthropicModel, "secret", false},
+		{"no model + no token → ok (log-only)", noModel, "", false},
+		{"no model + token → ok", noModel, "secret", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Model: tc.model}
+			cfg.Server.WebhookTokenEnv = "RUNLORE_WEBHOOK_TOKEN"
+			err := RequireWebhookAuth(cfg, tc.token)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("RequireWebhookAuth err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestModelProvider locks in the provider-name normalization: anthropic/gemini
+// pass through; everything else (including "" and unknown) defaults to "openai".
+func TestModelProvider(t *testing.T) {
+	tests := []struct {
+		provider string
+		want     string
+	}{
+		{"anthropic", "anthropic"},
+		{"gemini", "gemini"},
+		{"openai", "openai"},
+		{"", "openai"},
+		{"vllm", "openai"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.provider, func(t *testing.T) {
+			cfg := &config.Config{Model: config.Model{Provider: tc.provider}}
+			if got := ModelProvider(cfg); got != tc.want {
+				t.Fatalf("ModelProvider(%q) = %q, want %q", tc.provider, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestModelConfigured locks in usable-model detection: anthropic/gemini are
+// configured via their built-in endpoint; every other provider needs a base_url.
+func TestModelConfigured(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		baseURL  string
+		want     bool
+	}{
+		{"anthropic built-in", "anthropic", "", true},
+		{"gemini built-in", "gemini", "", true},
+		{"openai with base_url", "openai", "http://vllm:8000/v1", true},
+		{"openai without base_url", "openai", "", false},
+		{"empty provider with base_url", "", "http://vllm:8000/v1", true},
+		{"empty provider without base_url", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Model: config.Model{Provider: tc.provider, BaseURL: tc.baseURL}}
+			if got := ModelConfigured(cfg); got != tc.want {
+				t.Fatalf("ModelConfigured = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCatalogConfigured locks in the catalog-configured predicate: a mounted dir
+// OR a git-sync URL counts as configured; neither does not.
+func TestCatalogConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+		url  string
+		want bool
+	}{
+		{"neither", "", "", false},
+		{"dir only", "/var/lib/runlore/catalog", "", true},
+		{"git url only", "", "https://github.com/x/kb", true},
+		{"both", "/var/lib/runlore/catalog", "https://github.com/x/kb", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Catalog.Dir = tc.dir
+			cfg.Catalog.Git.URL = tc.url
+			if got := CatalogConfigured(cfg); got != tc.want {
+				t.Fatalf("CatalogConfigured = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitopsEngine locks in the engine selection: "argocd" passes through; every
+// other value (including "" and unknown) defaults to "flux".
+func TestGitopsEngine(t *testing.T) {
+	tests := []struct {
+		engine string
+		want   string
+	}{
+		{"argocd", "argocd"},
+		{"flux", "flux"},
+		{"", "flux"},
+		{"unknown", "flux"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.engine, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.GitOps.Engine = tc.engine
+			if got := GitopsEngine(cfg); got != tc.want {
+				t.Fatalf("GitopsEngine(%q) = %q, want %q", tc.engine, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestOutcomeKind locks in the recall/fresh labelling of an outcome-ledger open.
+func TestOutcomeKind(t *testing.T) {
+	if got := OutcomeKind(true); got != "recall" {
+		t.Fatalf("OutcomeKind(true) = %q, want %q", got, "recall")
+	}
+	if got := OutcomeKind(false); got != "fresh" {
+		t.Fatalf("OutcomeKind(false) = %q, want %q", got, "fresh")
+	}
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,0 +1,66 @@
+// Package app holds the dependency-injection builders and config predicates that
+// assemble the RunLore agent. They live here (instead of in cmd/lore behind
+// main()) so the wiring that decides what ships is unit-testable.
+package app
+
+import (
+	"os"
+
+	"github.com/Smana/runlore/internal/config"
+	anthropic "github.com/Smana/runlore/internal/model/anthropic"
+	gemini "github.com/Smana/runlore/internal/model/gemini"
+	openai "github.com/Smana/runlore/internal/model/openai"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// NewModelClient builds a ModelProvider for a wire protocol + endpoint.
+func NewModelClient(provider, baseURL, model, apiKey string) providers.ModelProvider {
+	switch provider {
+	case "anthropic":
+		return anthropic.New(baseURL, model, apiKey)
+	case "gemini":
+		return gemini.New(baseURL, model, apiKey)
+	default:
+		return openai.New(baseURL, model, apiKey)
+	}
+}
+
+// BuildModel builds the ModelProvider for the configured provider.
+func BuildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
+	return NewModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+}
+
+// BuildVerifyModel builds the optional cheaper model for the adversarial verify
+// pass, inheriting any unset field from the main model. Returns nil when no
+// model.verify override is configured (verify then runs on the main model).
+func BuildVerifyModel(cfg *config.Config) providers.ModelProvider {
+	v := cfg.Model.Verify
+	if v == nil {
+		return nil
+	}
+	or := func(a, b string) string {
+		if a != "" {
+			return a
+		}
+		return b
+	}
+	apiKey := ""
+	if keyEnv := or(v.APIKeyEnv, cfg.Model.APIKeyEnv); keyEnv != "" {
+		apiKey = os.Getenv(keyEnv)
+	}
+	return NewModelClient(or(v.Provider, cfg.Model.Provider),
+		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey)
+}
+
+// BuildJudgeModel builds the (stronger) grader model from --judge-* flags, falling
+// back to the configured investigation model when unset.
+func BuildJudgeModel(cfg *config.Config, provider, baseURL, model, apiKeyEnv string) providers.ModelProvider {
+	if provider == "" && model == "" {
+		apiKey := ""
+		if cfg.Model.APIKeyEnv != "" {
+			apiKey = os.Getenv(cfg.Model.APIKeyEnv)
+		}
+		return BuildModel(cfg, apiKey)
+	}
+	return NewModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv))
+}

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -1,0 +1,33 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestNewModelClient locks in provider selection: each provider name maps to its
+// concrete client type, and any unknown/empty provider falls back to the OpenAI
+// (vLLM-compatible) client.
+func TestNewModelClient(t *testing.T) {
+	tests := []struct {
+		provider string
+		wantType string
+	}{
+		{"anthropic", "*anthropic.Client"},
+		{"gemini", "*gemini.Client"},
+		{"openai", "*openai.Client"},
+		{"", "*openai.Client"},
+		{"vllm", "*openai.Client"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.provider, func(t *testing.T) {
+			client := NewModelClient(tc.provider, "http://endpoint/v1", "test-model", "key")
+			if client == nil {
+				t.Fatalf("NewModelClient(%q) returned nil", tc.provider)
+			}
+			if got := fmt.Sprintf("%T", client); got != tc.wantType {
+				t.Fatalf("NewModelClient(%q) type = %s, want %s", tc.provider, got, tc.wantType)
+			}
+		})
+	}
+}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"os"
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+)
+
+// PodName returns this pod's identity for leader election.
+func PodName() string {
+	if n := os.Getenv("POD_NAME"); n != "" {
+		return n
+	}
+	h, _ := os.Hostname()
+	return h
+}
+
+// PodNamespace resolves the namespace from the downward API or the service-account mount.
+func PodNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	if b, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(b)); ns != "" {
+			return ns
+		}
+	}
+	return "default"
+}
+
+// ReadyFunc gates readiness on leadership AND a warm catalog. When a catalog is
+// configured, the leader must NOT advertise ready until its knowledge base is
+// loaded and warm — otherwise it would serve incident traffic blind. This
+// distinguishes the two ways BuildCatalog returns a nil catalog:
+//
+//   - configured but the load failed (configured=true, cat=nil): stay 503. A
+//     static catalog has no syncer to recover, so the pod stays not-ready and the
+//     misconfiguration surfaces loudly instead of silently serving with no KB.
+//   - not configured at all (configured=false, cat=nil): no catalog gate;
+//     readiness is pure leadership.
+//
+// A configured-but-not-yet-warm catalog (git-sync NewEmpty, cat!=nil &&
+// !Ready()) is also held at 503 until its first successful sync.
+func ReadyFunc(leader func() bool, cat *catalog.Catalog, configured bool) func() bool {
+	return func() bool {
+		if configured && (cat == nil || !cat.Ready()) {
+			return false
+		}
+		if cat != nil && !cat.Ready() {
+			return false
+		}
+		return leader()
+	}
+}

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -1,0 +1,46 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+)
+
+func TestReadyFunc(t *testing.T) {
+	leaderTrue := func() bool { return true }
+	leaderFalse := func() bool { return false }
+
+	// No catalog configured → gate is pure leadership passthrough.
+	if !ReadyFunc(leaderTrue, nil, false)() {
+		t.Fatal("unconfigured + nil catalog + leader=true should be ready")
+	}
+	if ReadyFunc(leaderFalse, nil, false)() {
+		t.Fatal("unconfigured + nil catalog + leader=false should not be ready")
+	}
+
+	// A catalog was CONFIGURED but failed to load (cat == nil). Never serve incident
+	// traffic with no knowledge base: stay 503 even while leader. This is the bug —
+	// a configured-but-failed catalog used to be indistinguishable from "unconfigured"
+	// and collapsed readiness to pure leadership.
+	if ReadyFunc(leaderTrue, nil, true)() {
+		t.Fatal("configured + failed-to-load catalog (nil) must block readiness even when leader=true")
+	}
+
+	// A not-yet-warm configured catalog blocks readiness even when leader.
+	cold := catalog.NewEmpty()
+	if ReadyFunc(leaderTrue, cold, true)() {
+		t.Fatal("cold catalog must block readiness even when leader=true")
+	}
+
+	// A warm catalog is ready only when also leader.
+	warm, err := catalog.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !ReadyFunc(leaderTrue, warm, true)() {
+		t.Fatal("warm catalog + leader=true should be ready")
+	}
+	if ReadyFunc(leaderFalse, warm, true)() {
+		t.Fatal("warm catalog + leader=false should not be ready")
+	}
+}


### PR DESCRIPTION
## What this does

Phase 1 of the [`cmd/lore/main.go` → `internal/app` extraction plan](docs/superpowers/plans/2026-06-26-main-internal-app-extraction.md): start shrinking the 1615-line `cmd/lore/main.go` god-file by moving its leaf, low-dependency dependency-injection builders and config predicates into a new, unit-testable `internal/app` package.

### Moved (13 functions, now exported)

- **`internal/app/model.go`** — `NewModelClient`, `BuildModel`, `BuildVerifyModel`, `BuildJudgeModel` (carries the `// Package app …` doc).
- **`internal/app/config.go`** — `ModelProvider`, `ModelConfigured`, `CatalogConfigured`, `GitopsEngine`, `RequireWebhookAuth`, `OutcomeKind`.
- **`internal/app/runtime.go`** — `PodName`, `PodNamespace`, `ReadyFunc`.

Function bodies move **verbatim** — only the `package` clause, the capitalized exported names, a few now-stale intra-comment symbol references, and the call sites change, so the diff reads as a relocation. Three previously-undocumented symbols (`BuildJudgeModel`, `OutcomeKind`, `PodName`) gain a one-line doc comment (revive).

### Rewiring

- `cmd/lore/main.go`: bodies deleted; all ~19 call sites rewritten to `app.X`; the now-unused `anthropic`/`gemini`/`openai` aliased imports dropped (verified they were used **only** in `newModelClient`).
- `cmd/lore/validate.go`: `app.ModelConfigured` / `app.BuildModel`.

### Import-surface reduction

`cmd/lore` no longer imports the three model-provider packages directly (`internal/model/{anthropic,gemini,openai}`); it now depends on a single `internal/app` import. Provider selection lives behind `app.NewModelClient`.

### Behaviour-preserving

No logic changes. The existing test suite is the regression guard and stays green. The `RequireWebhookAuth` + `ReadyFunc` cases are **relocated** from `cmd/lore/main_test.go` into `internal/app` as `package app` white-box tests; added characterization tests lock in `ModelProvider`, `ModelConfigured`, `CatalogConfigured`, `GitopsEngine`, `OutcomeKind`, and `NewModelClient` provider→concrete-type selection.

`cmd/lore/main.go`: **1615 → 1452 lines**.

### Quality gate (green)

`go build ./... && go vet ./... && go test ./... && test -z "$(gofmt -l .)" && golangci-lint run ./...` — all pass; `gofmt -l .` empty, golangci-lint `0 issues`.

### Follow-ups (per the plan doc)

- **Phase 2** — the heavier builder family (`buildCatalog`, `buildNotifier`, `buildForgeTokenSource`, `buildModelAndTools`, `buildInvestigator`, `buildGitOps`, the HTTP/leader-election helpers, …) + wiring tests.
- **Phase 3** — the `run*` subcommand handlers become `internal/app` methods so `runServe`'s 242-line wiring becomes testable, collapsing `main.go` to flag dispatch.