### PR TITLE
fix(ci): lowercase image ref before cosign sign

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -112,10 +112,14 @@ jobs:
       - name: Sign image with cosign (keyless)
         if: github.event_name != 'pull_request'
         env:
-          # Sign by immutable digest, not a mutable tag, so the signature can't be
-          # repointed at a different image later.
-          IMAGE_DIGEST: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
-        run: cosign sign --yes "${IMAGE_DIGEST}"
+          DIGEST: ${{ steps.build.outputs.digest }}
+        # Sign by immutable digest, not a mutable tag, so the signature can't be
+        # repointed later. ghcr/OCI references must be lowercase, but
+        # github.repository_owner can contain uppercase (e.g. "Smana"), so lowercase
+        # the image name before signing.
+        run: |
+          image="${REGISTRY}/${IMAGE_NAME}"
+          cosign sign --yes "${image,,}@${DIGEST}"
 
       # PR gate: the image isn't pushed on pull_request, so scan the filesystem
       # (Go module graph + Dockerfile/config) and FAIL the job on HIGH/CRITICAL


### PR DESCRIPTION
## Bug

The first push to `main` after #140 **failed** at *Sign image with cosign (keyless)*:

```
Error: signing [ghcr.io/Smana/runlore@sha256:…]: parsing reference: could not parse reference
```

The cosign step builds the ref from `IMAGE_NAME` (= `${{ github.repository_owner }}/runlore` = `Smana/runlore`). OCI / ghcr repository names **must be lowercase**, so the uppercase `Smana` produces an unparseable reference. The image build/push, SLSA provenance and SBOM all succeeded — only cosign's reference parsing failed. The step is gated `if: github.event_name != 'pull_request'`, so it never executed on #140's PR and the bug only surfaced on the first `main` push.

## Fix

Lowercase the image reference (`${image,,}`) before signing. One line, no other behavior change.

## Validation

cosign only runs on non-PR events, so this is verified by the next `main` build-image run after merge (which I'll confirm goes green).
