### PR TITLE
ci(release-please): start versioning at v0.1.0 (not 1.0.0)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
       "release-type": "go",
       "package-name": "runlore",
       "include-component-in-tag": false,
+      "initial-version": "0.1.0",
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
Sets `initial-version: 0.1.0` in release-please-config.json. Without it, release-please defaults the first release to **1.0.0**; this project starts pre-stable at **0.1.0**. After merge, release-please re-runs and updates the open release PR (#150) to propose v0.1.0.