### PR TITLE
fix(ci): tag-trigger goreleaser, cosign bundle format, valid image tags on releases

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -69,10 +69,11 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            # Branch-prefixed SHA tag only on branch pushes: on pull_request the
-            # metadata action leaves {{branch}} empty, which would emit the invalid
-            # tag ":-<sha>" (a tag cannot start with "-") and fail the build.
-            type=sha,prefix={{branch}}-,enable=${{ github.event_name != 'pull_request' }}
+            # Branch-prefixed SHA tag only on branch pushes (empty on tags/PRs →
+            # invalid ":-<sha>"): the metadata action leaves {{branch}} empty there,
+            # which would emit the invalid tag ":-<sha>" (a tag cannot start with
+            # "-") and fail the build.
+            type=sha,prefix={{branch}}-,enable=${{ github.ref_type == 'branch' }}
             # Always provide an immutable SHA tag (valid in every event context).
             type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,50 @@
+name: Release Binaries
+
+# Triggered by the v* tag itself, not by release-please's release_created output.
+# release-please creates the v* tag via its PAT, which fires both this workflow and
+# build-image. Decoupling from release_created means re-pointing an existing tag
+# (a re-cut) rebuilds the artifacts; release-please already created the GitHub
+# release and .goreleaser.yaml uses release.mode: keep-existing, so GoReleaser only
+# uploads assets to it.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # Keyless cosign signing of the checksums file: the OIDC token identifies this
+      # workflow to Fulcio, which issues the short-lived signing certificate.
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # GoReleaser needs the full history (and tags) to build the release.
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: "1.26"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Install syft
+        # Provides the syft binary GoReleaser shells out to for the per-archive SBOMs.
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          # Default token is enough: the release for this tag already exists (created
+          # by release-please) and GoReleaser only uploads assets to it.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
 
 # Top-level least privilege. release-please needs to write the release PR and the
-# release/tag; the goreleaser job widens its own permissions below.
+# release/tag. Binary artifacts are built by release-binaries.yml, which the v*
+# tag created here triggers.
 permissions:
   contents: write
   pull-requests: write
@@ -14,10 +15,6 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-    outputs:
-      # Whether merging the release PR just cut a release on this push.
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - name: Run release-please
         id: release
@@ -25,46 +22,7 @@ jobs:
         with:
           # Fine-grained PAT (NOT the default GITHUB_TOKEN): pushing the release PR /
           # tag with GITHUB_TOKEN would NOT trigger downstream workflows (CI on the
-          # release PR, build-image + goreleaser on the v* tag). See CONTRIBUTING.md.
+          # release PR, build-image + release-binaries on the v* tag). See CONTRIBUTING.md.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  goreleaser:
-    name: GoReleaser
-    needs: release-please
-    if: needs.release-please.outputs.release_created
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      # Keyless cosign signing of the checksums file: the OIDC token identifies this
-      # workflow to Fulcio, which issues the short-lived signing certificate.
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # GoReleaser needs the full history (and tags) to build the release.
-          fetch-depth: 0
-
-      - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version: "1.26"
-
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Install syft
-        # Provides the syft binary GoReleaser shells out to for the per-archive SBOMs.
-        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
-        with:
-          version: '~> v2'
-          args: release --clean
-        env:
-          # Default token is enough: the release for this tag already exists (created
-          # by release-please) and GoReleaser only uploads assets to it.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -51,14 +51,17 @@ signs:
   # id-token: write, so cosign gets a short-lived Fulcio cert from the OIDC token
   # and records the signature in Rekor — no long-lived keys. Verifying the
   # checksums transitively covers every archive it lists.
+  #
+  # New Sigstore bundle format: current cosign defaults to a single
+  # `${artifact}.bundle` (sig + cert) and IGNORES the legacy
+  # --output-signature/--output-certificate flags, so those are gone. Consumers
+  # verify with `cosign verify-blob --bundle checksums.txt.bundle …`.
   - cmd: cosign
-    certificate: '${artifact}.pem'
     args:
-      - sign-blob
-      - '--output-certificate=${certificate}'
-      - '--output-signature=${signature}'
-      - '${artifact}'
-      - '--yes'
+      - "sign-blob"
+      - "--bundle=${artifact}.bundle"
+      - "${artifact}"
+      - "--yes"
     artifacts: checksum
     output: true
 


### PR DESCRIPTION
## Why

The first real release (v0.1.0) surfaced two runtime bugs in the release pipeline plus a structural issue that makes a re-cut impossible. This fixes all three.

## Fixes

### 1. Invalid image tag on tag pushes (`build-image.yml`)
The branch-prefixed SHA tag was gated on `github.event_name != 'pull_request'`, which still fires on **tag** pushes. On a tag push `{{branch}}` is empty, so the metadata action emitted the invalid reference `:-<sha>` and the build failed with `invalid reference format`. Changed the guard to `enable=${{ github.ref_type == 'branch' }}` — this tag is only meaningful on branch pushes (empty on tags/PRs).

### 2. cosign checksum signing failed (`.goreleaser.yaml`)
The `signs:` block used the deprecated `--output-signature` / `--output-certificate` flags. The installed cosign defaults to the new Sigstore **bundle** format, silently ignores those flags, then fails with:
`Error: signing dist/checksums.txt: create bundle file: open : no such file or directory`.
Rewrote the block to emit a single `checksums.txt.bundle` (signature + cert) via `--bundle=${artifact}.bundle`, and dropped the deprecated args and the `certificate:` field. Consumers now verify with `cosign verify-blob --bundle checksums.txt.bundle …`.

### 3. Decouple binary release from `release_created` (tag-triggered)
The `goreleaser` job lived in `release-please.yml`, gated on `needs.release-please.outputs.release_created`, so it only ever ran on the release-PR merge and could **not** be re-run for an existing tag. Moved it to a dedicated tag-triggered workflow `release-binaries.yml` (`on: push.tags: ['v*']` + `workflow_dispatch`). release-please creates the `v*` tag via the PAT, which triggers both this and `build-image`; `.goreleaser.yaml` keeps `release.mode: keep-existing` so it only uploads assets to the release release-please already created. Re-pointing the tag now rebuilds artifacts. The now-unused `outputs:` (`release_created`, `tag_name`) were removed from `release-please.yml`.

## Validation

- `goreleaser check` → passes (1 config validated).
- `actionlint` on `release-please.yml`, `release-binaries.yml`, `build-image.yml` → clean.
- Every `uses:` is a 40-char SHA pin with its `# vX.Y.Z` comment (SHAs reused from the existing workflows).
- No Go changes, so the required `build` check is unaffected.

## Follow-up after merge

The v0.1.0 artifacts (broken by bugs 1 & 2) will be rebuilt by re-pointing the `v0.1.0` tag at the merge commit, which fires `release-binaries.yml` and `build-image.yml` against the now-correct config.
