### PR TITLE
fix(ci): publish cosign bundle as the signature artifact

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,6 +63,9 @@ signs:
       - "${artifact}"
       - "--yes"
     artifacts: checksum
+    # cosign writes a single ${artifact}.bundle; tell GoReleaser to publish THAT as
+    # the signature artifact (its default is the now-nonexistent ${artifact}.sig).
+    signature: "${artifact}.bundle"
     output: true
 
 # release-please owns CHANGELOG.md; don't let GoReleaser generate its own.


### PR DESCRIPTION
The v0.1.0 GoReleaser run **signed successfully** (`Wrote bundle to file dist/checksums.txt.bundle`) but then failed uploading `checksums.txt.sig` — GoReleaser's default signature filename — which no longer exists under the new cosign `--bundle` output. Setting `signs.signature: ${artifact}.bundle` makes GoReleaser publish the bundle it actually produced. Last piece of the release pipeline.