### PR TITLE
fix(demo): repair zero-cluster quickstart broken by sources.<name> migration

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -154,12 +154,16 @@ relevance, and LLM cost are all controlled here.
 - **Proactive watch** (Phase 3): periodic scan for SLO burn-rate / drift.
 - **On-demand**: `lore investigate "<symptom>"` or a chat mention in Slack/Matrix (same engine, human-initiated).
 
-Example trigger policy (`internal/config`, `config.TriggerPolicy`):
+Example trigger policy (`internal/config`, `config.TriggerPolicy`). Source *enablement*
+lives under `sources.<name>`; the `triggers` block is purely the match/ignore/dedup
+criteria applied to admitted alerts:
 
 ```yaml
+sources:                                # enablement is per-source
+  alertmanager: {}                      # mount the incident webhook ingress
+  gitops: { enabled: true }             # watch GitOps Ready=False (secondary trigger)
 triggers:
-  incidents:
-    enabled: true
+  incidents:                            # match/ignore/dedup for admitted alerts
     match:                              # ANDed; empty fields match anything
       severity:    [critical]           # only paging-grade
       environment: [prod]               # ignore staging/dev
@@ -168,8 +172,7 @@ triggers:
     ignore:
       alertnames:  [Watchdog, InfoInhibitor]
     dedup: { window: 30m }              # don't re-open a still-firing alert
-  gitops_failures:                      # secondary trigger
-    enabled: true
+  gitops_failures:                      # secondary trigger (enabled via sources.gitops)
     debounce: 60s                       # require the failure to persist this long
                                         # (re-check still Ready=False) before
                                         # investigating — filters reconcile-churn
@@ -391,13 +394,20 @@ KB git repo  ──syncer──►  local mirror  ──build──►  index:  
   Cluster-wide `pods`/`events` *get/list* (pod status + event messages, not log bodies) stays in the
   ClusterRole because `pod_status`/`kube_events` triage arbitrary incident namespaces.
 
-> [!warning] Known limitation — no content redaction yet (roadmap R19)
-> Tool output (logs, git diffs, status/event messages) currently reaches the **model provider**
-> verbatim, and model-quoted evidence is copied into the **KB pull-request body** and **chat** — so a
-> secret in a log line or manifest can egress to your LLM vendor and, if the KB repo is public, further.
-> Mitigated today by the RBAC scoping above and by **self-hosting the model** (in-cluster vLLM/Ollama
-> keeps data in-boundary); the planned fix is a scrub pass on tool output and on curated/notified
-> evidence. If you run untrusted-tenant namespaces or a public KB repo, treat this as a gating concern.
+- **Secret redaction at the model and egress boundaries (`internal/redact`).** Secret-shaped values
+  are masked at three trust boundaries before they can leave the cluster: the **incident text**
+  entering the prompt, **every tool output** (logs, git diffs, status/event messages) before it reaches
+  the **model provider**, and the **finished investigation** (root-cause summaries, evidence, suggested
+  actions) before it is copied into the **KB pull-request body** and **chat**. The ruleset is
+  high-precision — PEM private keys, JWTs, GitHub / Slack / AWS / Google / Stripe keys,
+  `user:pass@host` URLs, `Authorization` headers, and generic `*secret*/*token*/*password*: <value>`
+  pairs — masking the *value* while keeping surrounding structure so the agent can still reason ("the
+  password field changed"). Redaction is a **mitigation, not a guarantee**: it does not yet base64-decode
+  `kind: Secret` `data:` blocks, so a Secret manifest surfaced verbatim in a git diff can still reach the
+  model unmasked (roadmap). Defense-in-depth still applies — the RBAC scoping above limits what tool
+  output can contain, and **self-hosting the model** (in-cluster vLLM/Ollama) keeps data in-boundary
+  regardless. If you run a public KB repo or untrusted-tenant namespaces, treat the base64-`Secret` gap
+  as a gating concern until the decode pass lands.
 - **Append-only, tamper-evident audit log** (`internal/audit`): every action attempt — inputs, gate
   results, op, target, actor, outcome — is a hash-chained JSON line, so edits/deletions are detectable.
 - **Honest uncertainty.** `unresolved` is a first-class output field; the agent says what it doesn't

--- a/hack/demo.config.yaml
+++ b/hack/demo.config.yaml
@@ -1,0 +1,14 @@
+# Demo config for hack/demo.sh — the zero-cluster quickstart.
+#
+# Enablement of a source lives under `sources.<name>`; the trigger policy below
+# is purely the match/ignore/dedup criteria applied to admitted alerts.
+sources:
+  alertmanager: {}        # mount the /webhook/alertmanager ingress endpoint
+triggers:
+  incidents:
+    match:
+      severity: [critical]
+      environment: [prod]
+    ignore:
+      alertnames: [Watchdog]
+    dedup: { window: 30m }

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -11,22 +11,10 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ADDR=":18080"
 BIN="$(mktemp -d)/lore"
-CFG="$(mktemp)"
+CFG="$ROOT/hack/demo.config.yaml"   # committed + parse-tested (internal/config)
 LOG="$(mktemp)"
 
 go build -o "$BIN" "$ROOT/cmd/lore"
-
-cat > "$CFG" <<'EOF'
-triggers:
-  incidents:
-    enabled: true
-    match:
-      severity: [critical]
-      environment: [prod]
-    ignore:
-      alertnames: [Watchdog]
-    dedup: { window: 30m }
-EOF
 
 "$BIN" serve --config "$CFG" --addr "$ADDR" > "$LOG" 2>&1 &
 SRV=$!

--- a/internal/config/shipped_configs_test.go
+++ b/internal/config/shipped_configs_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// repoRoot walks up from the test's working directory until it finds go.mod, so
+// shipped-file paths resolve regardless of where `go test` is invoked from.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("repo root (go.mod) not found")
+		}
+		dir = parent
+	}
+}
+
+// TestShippedExampleConfigsLoad guards the config files RunLore ships to users
+// against silent drift from the config structs. hack/demo.config.yaml is the
+// zero-cluster quickstart the README points newcomers at — the literal first
+// thing a user runs — so a field removed by a migration (as happened when
+// enablement moved from triggers.*.enabled to sources.<name>) must fail loudly
+// in CI here, not at the user's terminal. Add any new shipped example config to
+// the list.
+func TestShippedExampleConfigsLoad(t *testing.T) {
+	root := repoRoot(t)
+	shipped := []string{
+		filepath.Join(root, "hack", "demo.config.yaml"),
+	}
+	for _, path := range shipped {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("shipped config missing: %v", err)
+			}
+			c, err := Load(path)
+			if err != nil {
+				t.Fatalf("shipped config must load under the strict loader: %v", err)
+			}
+			if _, ok := c.Sources["alertmanager"]; !ok {
+				t.Errorf("expected sources.alertmanager to be wired (the demo fires alertmanager webhooks)")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Repairs the zero-cluster quickstart (`hack/demo.sh`) and two stale config references in `docs/design.md` that drifted after the `sources.<name>` enablement migration removed the `triggers.*.enabled` field.

## Why

`hack/demo.sh` — the *"try it without a cluster"* path the README points newcomers at — shipped an inline config using the removed `triggers.incidents.enabled` field. Under the strict loader (`KnownFields(true)`), `lore serve` failed to parse and the demo exited non-zero. The literal first thing a new user runs was broken:

```
serve: parse config: yaml: unmarshal errors:
  line 3: field enabled not found in type config.IncidentTrigger
```

The same migration left two stale spots in `docs/design.md` (§6 example, §9 redaction note).

## Changes

- **`hack/demo.config.yaml`** (new) — demo config on the current `sources.alertmanager` shape, committed + reviewable instead of an inline heredoc.
- **`hack/demo.sh`** — point `--config` at the committed file; drop the heredoc.
- **`internal/config/shipped_configs_test.go`** (new) — loads every shipped example config through the strict loader. Reproduces the bug (red) and prevents the field-drift regression class (green). New shipped configs get added to the list.
- **`docs/design.md`** — §6 trigger-policy example → `sources.<name>` enablement shape; §9 secret-redaction note → matches the code (`internal/redact` is wired at the prompt, tool-output, and egress boundaries), documenting the residual base64-`Secret` gap (previously the doc claimed redaction did not exist yet).

## Verification

- `bash hack/demo.sh` → exit 0, webhook `202`, all 5 trigger-policy decisions logged
- `go build ./...` · `go vet ./...` · `go test -count=1 ./...` → pass
- `golangci-lint run` → 0 issues
- Regression test proven red→green (reintroduce `enabled: true` → fails with `field enabled not found` → restore → passes)