### PR TITLE
fix: two pre-launch correctness bugs (warn-event ordering, silent source-key typo)

### DIFF
--- a/internal/providers/cluster/cluster.go
+++ b/internal/providers/cluster/cluster.go
@@ -145,21 +145,36 @@ func (r *Reader) Events(ctx context.Context, namespace, objectName string, warnO
 	if err != nil {
 		return nil, fmt.Errorf("list events (%s): %w", namespace, err)
 	}
-	out := make([]providers.KubeEvent, 0, len(list.Items))
+	// Carry each kept event's timestamp alongside it: warnOnly filtering makes
+	// the kept slice shorter than list.Items, so the sort must not index back
+	// into list.Items (the indices diverge and ordering would read the wrong
+	// events' timestamps).
+	type timedEvent struct {
+		ev providers.KubeEvent
+		at time.Time
+	}
+	kept := make([]timedEvent, 0, len(list.Items))
 	for i := range list.Items {
 		e := &list.Items[i]
 		if warnOnly && e.Type != corev1.EventTypeWarning {
 			continue
 		}
-		out = append(out, providers.KubeEvent{
-			Type:    e.Type,
-			Reason:  e.Reason,
-			Object:  e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
-			Message: e.Message,
-			Count:   e.Count,
+		kept = append(kept, timedEvent{
+			ev: providers.KubeEvent{
+				Type:    e.Type,
+				Reason:  e.Reason,
+				Object:  e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
+				Message: e.Message,
+				Count:   e.Count,
+			},
+			at: eventTime(e),
 		})
 	}
-	sort.SliceStable(out, func(i, j int) bool { return eventTime(&list.Items[i]).After(eventTime(&list.Items[j])) })
+	sort.SliceStable(kept, func(i, j int) bool { return kept[i].at.After(kept[j].at) })
+	out := make([]providers.KubeEvent, len(kept))
+	for i := range kept {
+		out[i] = kept[i].ev
+	}
 	return out, nil
 }
 

--- a/internal/providers/cluster/events_test.go
+++ b/internal/providers/cluster/events_test.go
@@ -1,0 +1,49 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestEventsWarnOnlyOrdersByOwnTimestamp guards against a filtered-slice /
+// original-index mismatch: when warnOnly drops a Normal event, the surviving
+// Warning events must still be returned most-recent-first by THEIR OWN
+// timestamps — not ordered by whichever original-list entry happened to land at
+// their post-filter index.
+func TestEventsWarnOnlyOrdersByOwnTimestamp(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	ev := func(name, reason, etype string, ageSec int) *corev1.Event {
+		return &corev1.Event{
+			ObjectMeta:     metav1.ObjectMeta{Name: name, Namespace: "apps"},
+			Type:           etype,
+			Reason:         reason,
+			LastTimestamp:  metav1.NewTime(base.Add(time.Duration(ageSec) * time.Second)),
+			InvolvedObject: corev1.ObjectReference{Kind: "Pod", Name: "p1"},
+		}
+	}
+	// List order (a, b, c): a NEW Normal event that warnOnly drops, then an OLD
+	// warning, then a NEW warning. The dropped Normal sits at the original index
+	// the buggy comparator reads for the first surviving warning.
+	r := New(fake.NewSimpleClientset(
+		ev("a-normal", "NormalEvt", corev1.EventTypeNormal, 100),
+		ev("b-warn-old", "WarnOld", corev1.EventTypeWarning, 10),
+		ev("c-warn-new", "WarnNew", corev1.EventTypeWarning, 50),
+	))
+
+	out, err := r.Events(context.Background(), "apps", "", true)
+	if err != nil {
+		t.Fatalf("Events: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("warnOnly should return 2 warnings (Normal filtered), got %d: %+v", len(out), out)
+	}
+	if out[0].Reason != "WarnNew" || out[1].Reason != "WarnOld" {
+		t.Fatalf("warnings not most-recent-first by own timestamp: got [%s, %s], want [WarnNew, WarnOld]",
+			out[0].Reason, out[1].Reason)
+	}
+}

--- a/internal/source/registry.go
+++ b/internal/source/registry.go
@@ -116,8 +116,30 @@ func Registered() []Descriptor {
 // non-nil results. A nil return from Build means the adapter is disabled (no
 // config); an error aborts startup.
 func BuildEnabled(deps Deps) ([]Built, error) {
+	descs := Registered()
+	// Reject typo'd keys under `sources:` loudly. The sources map escapes the
+	// config loader's strict (KnownFields) decode, so an unknown key here (e.g.
+	// "alertmanagr") would otherwise silently disable a source and leave the
+	// agent healthy but deaf.
+	known := make(map[string]bool, len(descs))
+	names := make([]string, 0, len(descs))
+	for _, d := range descs {
+		known[d.Name] = true
+		names = append(names, d.Name)
+	}
+	var unknown []string
+	for name := range deps.Raw {
+		if !known[name] {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return nil, fmt.Errorf("unknown source(s) %v under `sources:` — known sources are %v", unknown, names)
+	}
+
 	var built []Built
-	for _, d := range Registered() {
+	for _, d := range descs {
 		impl, err := d.Build(deps)
 		if err != nil {
 			return nil, fmt.Errorf("source %q: %w", d.Name, err)

--- a/internal/source/registry_validate_test.go
+++ b/internal/source/registry_validate_test.go
@@ -1,0 +1,46 @@
+package source
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// TestBuildEnabledRejectsUnknownSourceKey ensures a typo under `sources:` fails
+// loudly. The sources map escapes the config loader's strict (KnownFields)
+// decode, so without this guard a mistyped key (e.g. "alertmanagr") would
+// silently disable ingestion and leave the agent healthy but deaf.
+func TestBuildEnabledRejectsUnknownSourceKey(t *testing.T) {
+	resetForTest()
+	Register(Descriptor{Name: "alertmanager", Kind: Webhook, Path: "/webhook/alertmanager",
+		Build: func(Deps) (any, error) { return fakeWebhook{}, nil }})
+
+	raw := map[string]yaml.Node{"alertmanagr": {}} // typo
+	_, err := BuildEnabled(Deps{Cfg: &config.Config{}, Raw: raw})
+	if err == nil {
+		t.Fatal("expected BuildEnabled to reject unknown source key 'alertmanagr'")
+	}
+	if !strings.Contains(err.Error(), "alertmanagr") {
+		t.Fatalf("error should name the unknown key, got: %v", err)
+	}
+}
+
+// TestBuildEnabledAcceptsKnownSourceKey guards against over-rejection: a
+// correctly-spelled key must still build.
+func TestBuildEnabledAcceptsKnownSourceKey(t *testing.T) {
+	resetForTest()
+	Register(Descriptor{Name: "alertmanager", Kind: Webhook, Path: "/webhook/alertmanager",
+		Build: func(Deps) (any, error) { return fakeWebhook{}, nil }})
+
+	raw := map[string]yaml.Node{"alertmanager": {}}
+	built, err := BuildEnabled(Deps{Cfg: &config.Config{}, Raw: raw})
+	if err != nil {
+		t.Fatalf("known source key should build: %v", err)
+	}
+	if len(built) != 1 {
+		t.Fatalf("expected 1 built source, got %d", len(built))
+	}
+}


### PR DESCRIPTION
Two small, independent correctness fixes found during a pre-launch review — the kind a first community reviewer would otherwise catch. Each is a self-contained commit with a red→green regression test.

## 1. `fix(cluster)` — warn-only events ordered by the wrong timestamps

`Reader.Events()` built its result by filtering `list.Items` (dropping `Normal` events when `warnOnly`), but the sort comparator indexed back into the **original** `list.Items` at the post-filter positions:

```go
sort.SliceStable(out, func(i, j int) bool { return eventTime(&list.Items[i]).After(eventTime(&list.Items[j])) })
```

Once any event was filtered out, the two slices' indices diverged, so surviving warnings were ordered by **unrelated events' timestamps** — silently wrong "most-recent-first" ordering in the warning-only incident-triage path (no panic; indices stay in range). Fix: carry each kept event's timestamp alongside it and sort on that.

## 2. `fix(source)` — typo'd `sources:` key silently disabled ingestion

The `sources:` map decodes into a `map[string]yaml.Node`, which **escapes** the config loader's strict `KnownFields(true)` check. A mistyped key (e.g. `alertmanagr`) parsed cleanly and silently disabled the source — the agent came up healthy but **deaf**, contradicting the loader's fail-loud contract. `BuildEnabled` now cross-checks every `sources:` key against the registered adapter names and fails startup with a clear error:

```
unknown source(s) [alertmanagr] under `sources:` — known sources are [alertmanager gitops]
```

Validated against the registry (not `config.Validate`) to avoid the `source → config` import cycle. Confirmed both legit keys (`alertmanager`, `gitops`) self-register and are blank-imported in `serve.go`, so no valid config is rejected.

## Verification

- `go build ./...` · `go vet ./...` · `go test -count=1 ./...` → pass
- `golangci-lint run` → 0 issues
- Both regression tests proven red→green (reproduce the bug → fail → fix → pass)