### PR TITLE
docs: operability & config guides (troubleshooting, upgrade/uninstall, configuration, security model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,29 @@ incidents gains trust; knowledge that keeps failing decays.
 
 → **[How the learning loop works](docs/learning-loop.md)** · **[Reviewing & approving knowledge](docs/reviewing-knowledge.md)**
 
+## 🔌 Supported integrations
+
+Every backend is pluggable behind an interface — **wire what you run; an unset source just disables
+its tool.** GitOps (Flux / Argo CD) anchors the *what-changed* spine; everything else is optional and
+additive. Full setup detail in **[Data sources](docs/data-sources.md)**.
+
+| Category | Supported | Config |
+|---|---|---|
+| **GitOps** — *what changed* | Flux · Argo CD | `gitops.engine` |
+| **Metrics** | VictoriaMetrics · Prometheus *(PromQL)* | `metrics.url` |
+| **Logs** | VictoriaLogs *(LogsQL)* | `logs.url` |
+| **Network flows** | Cilium Hubble · AWS VPC Flow Logs · GCP Firewall Logs | `network.provider` |
+| **Cloud** | AWS — CloudTrail + EC2 / ASG / EKS | `cloud.provider` |
+| **Kubernetes** | client-go — pod status, events, controller logs | *(in-cluster)* |
+| **LLM** | Anthropic · Google Gemini · any OpenAI-compatible *(vLLM, Ollama, OpenRouter…)* | `model.provider` |
+| **Triggers** *(sources)* | Alertmanager webhook · GitOps failures | `sources.*` |
+| **Notifiers** | Slack · Matrix · generic webhook | `notify.*` |
+| **Knowledge base** *(git forge)* | GitHub *(App auth)* | `forge.*` |
+
 ## 🚀 Getting started
 
-RunLore runs in your Kubernetes cluster as a single Go binary, deployed via Helm.
-RunLore is a single binary deployed via Helm. Before installing, you need:
+RunLore runs in your Kubernetes cluster as a single Go binary, deployed via Helm. Before installing,
+you need:
 
 - **Data sources** — at least one wired source (each is pluggable, an unset one just disables its tool); for the *what-changed* anchor, a cluster running Flux or Argo CD, plus optionally Prometheus/VictoriaMetrics, VictoriaLogs, Hubble for richer signals
 - **An LLM** — any OpenAI-compatible endpoint, Anthropic, or Gemini (in-cluster or external)

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ we test hardest.
 ## Docs
 
 📐 [Design](docs/design.md) · 📚 [Learning loop](docs/learning-loop.md) · ✅ [Reviewing knowledge](docs/reviewing-knowledge.md) · 🚀 [Getting started](docs/getting-started.md) ·
-🔌 [Data sources](docs/data-sources.md) · 📊 [Observability](docs/observability.md) ·
-🧭 [Prior art](docs/prior-art.md) · 🛠 [Contributing](CONTRIBUTING.md)
+🔌 [Data sources](docs/data-sources.md) · ⚙️ [Configuration](docs/configuration.md) · 📊 [Observability](docs/observability.md) · 🩺 [Troubleshooting](docs/troubleshooting.md) ·
+🔒 [Security model](docs/security-model.md) · ⬆️ [Upgrade & uninstall](docs/upgrade-uninstall.md) · 🧭 [Prior art](docs/prior-art.md) · 🛠 [Contributing](CONTRIBUTING.md)
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,110 @@
+# Configuration reference
+
+A navigable map of RunLore's configuration, organized by subsystem.
+
+> [!note] `values.yaml` is the authoritative reference
+> The single source of truth for every key is the chart's
+> [`deploy/helm/runlore/values.yaml`](../deploy/helm/runlore/values.yaml) — every key carries an
+> inline rationale comment, and the whole `config:` block is rendered **verbatim** into the agent's
+> ConfigMap (`toYaml .Values.config`). This page is the overview and the *why*; `values.yaml` is the
+> exhaustive, annotated detail. The `model` / `catalog` / `outcome` / `notify` / `forge` / `network`
+> blocks ship commented-out there as copy-paste templates.
+
+## The config model — three things to know
+
+1. **Helm → ConfigMap → agent.** Everything under `values.config.*` becomes the agent's config file.
+   Outside Kubernetes, `lore serve --config runlore.yaml` reads the same shape directly.
+2. **Strict decoding — typos fail loudly.** The loader uses `KnownFields(true)`: an unknown key aborts
+   startup rather than being silently ignored, so a misspelled safety-critical field can't slip
+   through. **One exception:** the `sources:` map (it's a free-form map); a mistyped *source* key is
+   instead caught at startup by the source builder, which errors with
+   `unknown source(s) … under \`sources:\``.
+3. **Secrets by indirection.** Config never holds a secret value — it names the **environment
+   variable** (or Secret key) that holds it: `api_key_env`, `webhook_url_env`, `private_key_ref`, etc.
+   Wire those env vars from a Kubernetes `Secret` (`envFrom`/`env` in the chart). A stray dump of the
+   config therefore leaks nothing.
+
+---
+
+## Subsystems
+
+Defaults below are the behaviorally-significant ones (applied in the config loader). For the full key
+list and comments, follow each link to `values.yaml`.
+
+### `sources` — what wakes RunLore
+Per-source enablement map; presence enables a source. `alertmanager: {}` mounts the incident webhook;
+`gitops: { enabled: true }` watches GitOps `Ready=False`. Known keys: `alertmanager`, `gitops`.
+
+### `triggers` — which incidents to investigate
+- `incidents.match` / `incidents.ignore` — ANDed matchers (`severity`, `environment`, `namespaces`
+  globs, `alertnames` globs, `labels`); empty fields match anything. `ignore` excludes even if `match`
+  passes.
+- `incidents.dedup.window` — don't re-open a still-firing alert within this window.
+- `gitops_failures.debounce` — require a failure to persist this long before investigating. **Default
+  60s**; explicit `0` fires immediately on every `Ready=False`.
+
+### `investigation` — loop bounds & noise control
+- `coalesce` — fold an alert storm into one investigation. Defaults when enabled: `debounce` **30s**,
+  `max_wait` **2m**, `max_batch` **50**, `cooldown` **10m**; `correlation_labels` group related alerts.
+- `rate_limit` — `max_per_window` (**0 = unlimited**), `window` (default **1h** when a budget is set),
+  `max_requeues`.
+- `timeout` — per-investigation deadline, **default 10m** (bounds a hung tool/clone so it can't starve
+  the single-worker queue).
+- `max_steps` (**default 20**), `max_tool_output_bytes` (0 = unlimited), `max_tokens_per_investigation`
+  (0 = unlimited, else a hard token ceiling).
+
+### `catalog` — the knowledge base & instant recall
+- `dir` — local OKF bundle / git-sync mirror path; `git` — `url`, `branch` (default `main`), `interval`
+  (default 5m), `token_env`.
+- `instant_recall` — `enabled`, and when enabled the trust gates `min_score` **1.0**, `margin_gap`
+  **1.0**, `solo_floor` **4.0**, `outcome_prior` **2.0**, `outcome_floor` **0.5**;
+  `require_workload_match`; experimental `hybrid*` vector knobs.
+- The search index is in-memory bleve (BM25), rebuilt from `dir` at startup — not persisted.
+
+### `outcome` — the learning ledger
+`ledger_path` — append-only JSONL of investigation outcomes (empty disables). Drives outcome-weighted
+recall decay; **must be on the PVC** to compound (see [Upgrade & Uninstall](upgrade-uninstall.md)).
+
+### `actions` — the autonomy ladder (off by default)
+- `mode` — `off` (default) · `suggest` · `approve` · `auto` (experimental, frozen/not recommended).
+- `allow` — the envelope: `reversible_only`, `namespaces` (allowlist — **empty permits nothing**),
+  `protected_namespaces` (added to built-in `flux-system`/`kube-system` denies), `max_blast_radius`,
+  `kinds`.
+- `require_approval` + `approval_token_env`, `audit_log_path`, and `auto.*` (`dry_run`,
+  `min_confidence`, `max_per_window`, `window`).
+- **Fail-closed validation:** `approve`/`auto` require `approval_token_env`; `auto` *additionally*
+  requires `audit_log_path`, `server.webhook_token_env`, `auto.min_confidence > 0`,
+  `auto.max_per_window > 0`, and a non-empty `allow.namespaces`. See [Security model](security-model.md).
+
+### `model` — the LLM provider
+`provider` — `openai` (default; any OpenAI-compatible endpoint incl. vLLM/Ollama/OpenRouter) ·
+`anthropic` · `gemini`. `base_url`, `model`, `api_key_env`. Optional `verify` (a separate model for the
+adversarial verify pass) and `embeddings` (for hybrid recall).
+
+### `forge` — the Git host for curation
+`kb_repo` (`owner/name`), `base_branch` (default `main`), `github_api_url` (default
+`https://api.github.com`), `dup_score` (default **5.0**), `min_confidence` (default **0.75**, the
+quality bar below which a finding is chat-only). `github_app` — `app_id`, `installation_id`, and
+`private_key_ref` **or** `private_key_env`.
+
+### `notify` — where findings go
+`slack` (`webhook_url_env` or `bot_token_env`, `channel`, `signing_secret_env`, `approver_ids`),
+`matrix` (`homeserver`, `room_id`, `access_token_env`), plus inline blocks for any registered notifier
+(e.g. `webhook` with `url_env`).
+
+### `server` — the HTTP listener
+Only `webhook_token_env` (the bearer token for the incident webhook; **required under
+`actions.mode=auto`**). The listen address is the `--addr` CLI flag (`:8080` in the chart), **not** a
+config key. TLS is terminated externally (ClusterIP + NetworkPolicy).
+
+### `rbac` — chart-only (not in the agent config)
+Set under `values.rbac.*`, not `values.config`: `controllerLogNamespaces` (default `[flux-system]` —
+where `pods/log` is granted, namespaced), `allowActions` (gate for the patch Role), `actionNamespaces`
+(the patch allowlist — **must mirror `config.actions.allow.namespaces`**). See
+[Security model](security-model.md).
+
+### Other top-level keys
+`gitops.engine` (`flux` default · `argocd`), `cloud` (`provider: aws`, `region`, `cluster_name`),
+`network` (pluggable: `hubble` · `aws-vpc-flow-logs` · `gcp-firewall-logs`), `metrics`/`logs`
+(`Endpoint{url}` for the PromQL/logs query tools), `telemetry` (`metrics_enabled`, `otlp_endpoint`),
+`logging` (`format: text|json`, `level`), `leader_election` (`enabled`, `name`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -399,6 +399,41 @@ route:
 
 With 2+ replicas, only the **leader** is Ready, so the Service routes webhooks to it automatically.
 
+### Harden for production
+
+By default the webhook is **unauthenticated** and the chart's NetworkPolicy ingress is permissive
+(`ingressFrom: []` ⇒ any source) — fine for a trial, but lock both down before pointing a real alert
+stream at it:
+
+1. **Require a bearer token.** Name an env var in `server.webhook_token_env` (wired from your Secret);
+   unauthenticated requests are then rejected with `401`. A token is **mandatory** when
+   `actions.mode=auto`.
+   ```yaml
+   # values.yaml
+   config:
+     server:
+       webhook_token_env: RUNLORE_WEBHOOK_TOKEN
+   ```
+   ```yaml
+   # alertmanager — send the same token as a bearer credential
+   webhook_configs:
+     - url: http://runlore.runlore.svc:8080/webhook/alertmanager
+       http_config:
+         authorization:
+           type: Bearer
+           credentials_file: /etc/alertmanager/secrets/runlore-webhook-token
+   ```
+2. **Scope ingress** to only the namespace that should reach the webhook (e.g. your monitoring stack):
+   ```yaml
+   # values.yaml — spliced into the NetworkPolicy `from:`
+   networkPolicy:
+     ingressFrom:
+       - namespaceSelector:
+           matchLabels: { kubernetes.io/metadata.name: monitoring }
+   ```
+
+See the [Security model](security-model.md) for the full posture — redaction, RBAC, the action gate.
+
 ---
 
 ## Step 6 — Verify

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -464,5 +464,9 @@ want a sharper answer. Only RunLore-originated issues (carrying the `runlore` la
 
 ## Next
 
+- [Configuration](configuration.md) — every config key, organized by subsystem.
+- [Troubleshooting](troubleshooting.md) — why an investigation didn't start, timed out, or didn't file a PR.
+- [Security model](security-model.md) — read-only posture, redaction, RBAC, the action gate.
+- [Upgrade & uninstall](upgrade-uninstall.md) — `helm upgrade`/`uninstall`, what persists, and cleanup.
 - [Design](design.md) — architecture and the autonomy ladder.
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — run the full feature suite locally on k3d.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,110 @@
+# Security model
+
+What RunLore is allowed to do, how that's enforced, and the honest limitations. This is the **runtime**
+security model — how the agent behaves in your cluster. For reporting a vulnerability, see
+[`SECURITY.md`](../SECURITY.md). For the deeper design rationale, see [Design §9](design.md).
+
+The guiding principle: **safety is enforced in code, not promised in prose.** The agent's own claims
+(and the LLM's output) are never trusted for an authorization decision.
+
+## Read-only by default
+
+RunLore reads your cluster, metrics, logs, and network — its only writes are **markdown to Git via
+reviewed PRs**. Two independent layers keep it that way:
+
+1. **RBAC grants no write verbs by default.** The ServiceAccount gets `get/list/watch` cluster-wide
+   and nothing else (see RBAC below).
+2. **The action policy defaults to `off`** (`actions.mode`). No cluster-mutating tool is wired to the
+   LLM; the model can only *propose* an action, never dispatch one.
+
+The Curator is cluster-read-only — its "writes" are PRs and issues against your knowledge-base repo,
+never the cluster.
+
+## The action gate (climbing the autonomy ladder)
+
+When you enable `actions` (the `suggest → approve → auto` ladder), every executable action passes a
+**server-authoritative gate** (`internal/action`) that **re-derives** its safety from a canonical op
+registry and **discards the model's own metadata**:
+
+- Reversibility and blast radius come from the registry (only `suspend` / `resume` / `reconcile` are
+  executable, all reversible, blast-radius 1) — an unknown op is treated as irreversible and refused.
+- The policy envelope enforces `reversible_only`, `max_blast_radius`, an allowed-`kinds` list, and a
+  namespace allowlist. **`flux-system` and `kube-system` are always denied** as targets, regardless of
+  config; an empty `allow.namespaces` permits nothing.
+- The gate is re-validated at **every** execution boundary (approval handling *and* auto), so a stale
+  or tampered decision can't slip through (defense in depth).
+- `auto` mode starts **paused** (kill-switch engaged, fail-closed) and is gated behind
+  confidence/rate/blast limits. It exists but is **not recommended on real clusters**.
+
+The action config is **fail-closed**: `approve`/`auto` won't start without an approval token, and
+`auto` additionally requires an audit-log path, an authenticated webhook, a positive confidence
+threshold and rate cap, and a non-empty namespace allowlist (see
+[Configuration → actions](configuration.md#actions--the-autonomy-ladder-off-by-default)).
+
+## Secret redaction at the LLM and egress boundaries
+
+Tool output and incident text flow to a model provider and, for findings, into your KB PR and chat.
+`internal/redact` masks secret-shaped values at **three** boundaries:
+
+1. **Ingress** — incident text before it enters the prompt.
+2. **Tool output** — every tool result (pod/controller logs, git diffs, status/event messages) before
+   it reaches the model provider.
+3. **Delivery** — the finished investigation (root-cause summaries, evidence, suggested actions)
+   before it's copied into the KB PR body and chat.
+
+Coverage (high-precision, masks the value while keeping structure): PEM private keys, JWTs,
+GitHub / Slack / AWS / Google / Stripe keys, `user:pass@host` URLs, `Authorization` headers, and
+generic `*(password|secret|api_key|token|…): <value>` pairs.
+
+> [!warning] Residual gap — base64 Secret data
+> Redaction does **not** yet base64-decode `kind: Secret` `data:` blocks, so a Secret manifest
+> surfaced verbatim in a git diff can still reach the model unmasked (roadmap). Redaction is a
+> mitigation, not a guarantee. If you run a **public KB repo** or **untrusted-tenant namespaces**,
+> treat this as a gating concern — and prefer **self-hosting the model** (in-cluster vLLM/Ollama),
+> which keeps data in-boundary regardless.
+
+## Least-privilege RBAC
+
+The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
+
+- **ClusterRole (read-only, cluster-wide):** `get/list/watch` on Flux/ArgoCD resources and `events`,
+  `get/list` on `pods` (status only — **not** `pods/log`). No write verb. `patch` is *intentionally*
+  never granted cluster-wide.
+- **Namespaced Role for controller logs:** `pods/log` (raw log bodies, which can carry secrets/PII) is
+  granted only over `rbac.controllerLogNamespaces` (default `flux-system`) — never cluster-wide.
+- **Namespaced Role for actions:** only when `rbac.allowActions` is set, `get/patch` on
+  `kustomizations`/`helmreleases` over `rbac.actionNamespaces` — a bounded, opt-in blast radius that
+  must mirror `config.actions.allow.namespaces`.
+
+## Credentials & the GitHub App
+
+- **Short-lived tokens, no PAT.** The GitHub App mints an RS256 **JWT (~9 min)**, exchanges it for a
+  **~1-hour installation token**, and refreshes ~1 minute before expiry. There is no long-lived
+  personal access token; revocation is central (uninstall the App).
+- **Scope the App to the KB repo** (Contents/PRs/Issues read-write), plus optional read-only on your
+  GitOps source repos for the what-changed diff. Disable the App's webhook. See
+  [Getting started → GitHub App](getting-started.md).
+- **Secrets by indirection.** Every credential is referenced by the *name* of an env var / Secret key,
+  never inlined in config — so config can't leak a secret (see [Configuration](configuration.md)).
+- **Webhook auth.** The incident webhook accepts a bearer token (`server.webhook_token_env`); it is
+  **mandatory** under `actions.mode=auto` and recommended for any internet-adjacent ingress. Pair it
+  with a restrictive NetworkPolicy.
+
+## Tamper-evident audit log
+
+Every action attempt — inputs, gate result, op, target, actor, outcome — is appended to a
+**hash-chained** JSON log (`internal/audit`): each record carries the previous record's hash, the file
+is `0600` and **fsync'd after every write**, and a `Verify` pass detects the first broken link. Edits
+or deletions are therefore detectable. Outcomes recorded: `executed` / `dry-run` / `skipped` /
+`denied` / `failed`.
+
+## Honest limitations
+
+- **The model sees cluster data.** Even with redaction, tool output reaches your model provider. The
+  strongest mitigation is self-hosting the model in-cluster. The base64-Secret gap above is real.
+- **RCA can be wrong.** Frontier RCA is sub-50% on real incidents; `unresolved` is a first-class
+  output and an adversarial verify pass can only *lower* confidence. Treat findings as hypotheses, and
+  the human PR review as the load-bearing quality gate.
+- **Prompt injection is bounded, not impossible.** A poisoned alert or KB entry can bias an RCA, but it
+  **cannot** trigger a write — the action gate ignores model-authored authorization fields, and recall
+  is disabled under auto-execution so a poisoned catalog entry can't short-circuit into an action.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,180 @@
+# Troubleshooting
+
+How to diagnose the most common *"why didn't RunLore do X?"* situations. RunLore exposes
+two diagnostic channels:
+
+- **Structured logs** — every decision is a one-line `slog` event. Set `logging.format: json`
+  (or `text`) and `logging.level: debug` for the most detail. Each section below quotes the exact
+  `msg=` value to grep for.
+- **Metrics** — `runlore_*` Prometheus series, exposed when `telemetry.metrics_enabled: true`. See
+  [Observability](observability.md) for the full catalog and a Grafana dashboard.
+
+> [!note] Leader-only by design
+> With `leader_election.enabled` (the chart default, 2 replicas) **only the leader investigates**. A
+> standby logs `msg="standby; another replica leads"` and stays at `/readyz` 503 for its whole life —
+> that is intentional, not a fault. `runlore_leader == 1` marks the elected pod.
+
+---
+
+## An alert fired but no investigation started
+
+By far the most common case. Work from ingress inward.
+
+**1. Is there a per-incident decision line?** Every *admitted* alert produces exactly one log event:
+
+```
+msg=incident alert=<name> severity=<sev> namespace=<ns> investigate=<bool> reason="<reason>"
+```
+
+| `reason` | meaning | what to do |
+|---|---|---|
+| `matched trigger policy` | admitted → investigating | nothing — this is the happy path |
+| `filtered by trigger policy` | didn't match `triggers.incidents.match`, or hit `triggers.incidents.ignore` | widen `match` (check `severity`, `environment`, `namespaces` globs, `labels`); check the alert isn't in `ignore.alertnames` |
+| `deduplicated (still-firing)` | the same alert is already under investigation within `triggers.incidents.dedup.window` | expected — wait for the window to pass or the alert to resolve |
+
+> Trigger filtering and dedup are **not** counted by any metric — the `incident` log line is the only
+> place they surface. Grep it first.
+
+**2. No `incident` line at all?** The alert never reached the trigger pipeline:
+
+- **Source not enabled.** The webhook only mounts when `sources.alertmanager: {}` is set. A typo such
+  as `alertmanagr:` now **fails startup** with
+  `unknown source(s) [alertmanagr] under \`sources:\` — known sources are [alertmanager gitops]`
+  (older builds silently did nothing). Check the startup logs.
+- **Webhook rejected at ingress.** If `server.webhook_token_env` is set (mandatory under
+  `actions.mode=auto`), Alertmanager must send `Authorization: Bearer <token>`. A `401` means the
+  token is missing or wrong. The request body is also capped at 1 MiB.
+- **Metric cross-check.** `runlore_alerts_received_total` counts alerts that passed initial decoding
+  and `Decide`. Flat while alerts are firing ⇒ they're being rejected at ingress (auth/parse) or the
+  source isn't mounted.
+
+**3. Admitted, but still nothing ran?** Compare `runlore_investigations_started_total` against
+`runlore_alerts_received_total`, then:
+
+| signal | meaning | fix |
+|---|---|---|
+| `runlore_leader == 0` on all pods | no leader elected → nothing runs | check the `leases` RBAC and `leader_election` config; look for `msg="acquired leadership"` |
+| `runlore_investigations_throttled_total` rising | rate limiter engaged (`investigation.rate_limit`); `msg="investigation rate limit engaged; throttling…"` | raise `rate_limit.max_per_window` / `window`, or accept the budget |
+| `runlore_investigations_dropped_total` rising | dropped by `rate_limit.max_requeues` or the token-budget hard-stop | see the timeout/budget section below |
+| `runlore_alerts_coalesced_total` rising | folded into an existing batch (`investigation.coalesce`) | expected noise control — one investigation covers the batch |
+| `runlore_alerts_suppressed_total` rising | dropped by the coalescer **cooldown** | expected — a recently-investigated correlation is in cooldown |
+
+---
+
+## A GitOps failure didn't trigger an investigation
+
+The GitOps-failure watcher (`sources.gitops: { enabled: true }`) **debounces** before firing, to
+filter reconcile-churn transients:
+
+- `runlore_gitops_failures_debounced_total` rising ⇒ the failure cleared within the debounce window
+  and was dropped as transient. Log: `msg="gitops-failure cleared within debounce window; dropping transient"`.
+- Tune with `triggers.gitops_failures.debounce` (default **60s**; explicit `0` fires immediately on
+  every `Ready=False`).
+
+---
+
+## The investigation ran but timed out / came back empty
+
+Check `runlore_investigations_completed_total{result=…}` — the `result` label tells you how it ended:
+
+| `result` | meaning | log line | lever |
+|---|---|---|---|
+| `resolved` / `unresolved` | finished; `unresolved` = honest "couldn't determine" | `msg="investigation complete"` | — |
+| `recall` | answered instantly from the catalog | `msg="instant recall (catalog hit; skipping the loop)"` | — |
+| `timeout` | hit `investigation.timeout` (default **10m**) | `msg="investigation hit per-investigation deadline"` | raise `investigation.timeout`; check for a hung tool/provider |
+| `budget_exceeded` | hit `investigation.max_tokens_per_investigation` | `msg="investigation hard-stopped at token budget"` | raise the budget, or accept the cap |
+| `max_steps` | hit `investigation.max_steps` (default **20**) | `msg="investigation hit max steps"` | raise `max_steps`, or the loop is looping — inspect tool calls |
+| `inconclusive` | model never called `submit_findings` after a nudge | `msg="investigation inconclusive (no submit_findings after nudge)"` | often a weak/over-quantized model; try a stronger one |
+| `error` | a tool or model call failed | `msg="investigation failed; retrying"` | inspect the `err=` field |
+
+Supporting metrics: `runlore_tool_calls_total{tool,result}` and `runlore_model_requests_total{provider,result}`
+(watch the `result="error"` slice), `runlore_model_responses_truncated_total` (completions cut off at the
+output-token ceiling — a frequent cause of `inconclusive`), and `runlore_investigation_duration_seconds{result}`.
+
+---
+
+## The curator didn't open a PR
+
+RunLore files a KB pull request only for **novel, confident** findings — by design it does *not* file
+for everything. Check `runlore_curations_total{kind="pr",result=…}` and the curator log:
+
+| situation | log line | this is… |
+|---|---|---|
+| recalled answer (cache hit) | `msg="skipping curation of a recalled finding (cache hit, not novel)"` | expected — not novel |
+| below the quality bar | `msg="finding below the quality bar; chat-only, no KB artifact"` | expected — `confidence < forge.min_confidence` (default 0.75) |
+| duplicates a catalog entry | `msg="finding duplicates a catalog entry; not filing"` | expected — within `forge.dup_score` |
+| coalesced onto an open PR | `msg="finding coalesced onto an open PR"` (`result="coalesced"`) | expected — added to an existing PR |
+| **opened** | `msg="curated as PR"` with the `url` | success |
+| **error** | `msg="curate findings"` with `err=` (`result="error"`) | a forge/GitHub-App problem — check App scopes & `forge.kb_repo` |
+
+If you expected a PR and got `chat-only` or `duplicates`, the finding simply wasn't novel/confident
+enough — tune `forge.min_confidence` / `forge.dup_score` if the thresholds are wrong for you.
+
+> Knowledge-gap **issues** (opened by the separate `lore curate` recurrence agent, not the live
+> curator) are **not** counted by any metric — they only log `msg="opened knowledge-gap issue"`.
+
+---
+
+## Recall never fires (every incident runs the full loop)
+
+Instant recall requires `catalog.instant_recall.enabled: true` **and** a confident catalog hit. Check:
+
+- `runlore_recall_hits_total` is zero, and `runlore_recall_rejections_total{reason=…}` shows why
+  candidates were rejected:
+  | `reason` | meaning | lever |
+  |---|---|---|
+  | `no_resource_match` | top hit didn't match the incident's workload | `instant_recall.require_workload_match` |
+  | `low_margin` | top hit too close to the runner-up (ambiguous) | `instant_recall.margin_gap` (default 1.0) |
+  | `low_outcome` | the entry's real-world resolve-rate decayed below the floor | `instant_recall.outcome_floor` (default 0.5) |
+- `runlore_recall_score` (BM25 at the decision point) sitting below `instant_recall.min_score`
+  (default 1.0) ⇒ the catalog has no strong match yet. Recall **compounds** — it improves as merged
+  PRs accrete. A cold catalog legitimately won't recall.
+- Decision detail is logged at `msg="instant recall decision"` with `score`, `margin`, `confidence`.
+- A recalled answer that fails the adversarial verify pass falls through to a full investigation:
+  `msg="instant recall rejected by verify; running full investigation"`.
+
+---
+
+## Findings were investigated but never delivered to chat
+
+> [!warning] Delivery has no metric — logs only
+> There is currently **no** `runlore_*` counter for notifier delivery. A failed send logs
+> `msg="delivery failed" err=…` (the Slack/Matrix/webhook fan-out is best-effort and joins errors).
+> Successful sends are **not** logged. Grep `msg="delivery failed"` and `msg="deliver findings"`.
+
+Common causes: wrong `notify.slack.channel` / bot-token scope, an invalid Matrix `room_id` /
+`access_token`, or a generic-webhook endpoint returning non-2xx. At startup, `msg="delivery notifiers"`
+with `count=` confirms how many sinks were wired — `count=0` means none are configured.
+
+---
+
+## `/readyz` never goes green
+
+`/readyz` is gated by **leadership AND catalog warmth** (`internal/app/runtime.go`). It returns `503`
+("`not ready`") until the pod both leads *and* has completed its first catalog index/sync.
+
+- A **standby** is `503` for its entire life — by design (probes target `/healthz`, not `/readyz`,
+  so a standby isn't killed). Only the leader should be `Ready`.
+- The **leader** stuck at `503` ⇒ the catalog never warmed: check `catalog.dir` / `catalog.git`
+  (clone failing? token wrong?) and the startup logs. `runlore_catalog_invalid_entries_total` rising
+  ⇒ malformed OKF entries at load.
+- The `startupProbe` allows ~60s of warm-up; a slow first clone can exceed it — raise the chart's
+  `startupProbe.failureThreshold` if needed.
+
+---
+
+## Quick reference — metric → meaning
+
+The most useful series for triage (full list in [Observability](observability.md)):
+
+| metric | use it to see… |
+|---|---|
+| `runlore_alerts_received_total` | alerts that passed ingress + `Decide` |
+| `runlore_investigations_started_total` | investigations actually begun |
+| `runlore_investigations_throttled_total` / `_dropped_total` | rate-limit / budget pressure |
+| `runlore_alerts_coalesced_total` / `_suppressed_total` | storm-coalescing / cooldown drops |
+| `runlore_investigations_completed_total{result}` | how investigations ended (incl. `timeout`, `error`) |
+| `runlore_recall_hits_total{result}` / `_rejections_total{reason}` | whether instant recall is working |
+| `runlore_curations_total{kind,result}` | KB PRs opened / coalesced / errored |
+| `runlore_leader` | which replica is the active leader |
+| `runlore_model_requests_total{provider,result}` | LLM call success vs error |

--- a/docs/upgrade-uninstall.md
+++ b/docs/upgrade-uninstall.md
@@ -1,0 +1,92 @@
+# Upgrade & Uninstall
+
+How to upgrade RunLore in place, what survives a restart, and how to remove it cleanly.
+
+## Upgrading
+
+RunLore is a Helm release — upgrade like any other chart:
+
+```bash
+helm upgrade runlore deploy/helm/runlore -n runlore -f values.yaml
+```
+
+Your `values.yaml` is the source of truth; the entire agent config under `values.config` is rendered
+verbatim into the ConfigMap. Re-apply the same file (with your changes) on every upgrade.
+
+> [!warning] Expect ~20s of downtime during the agent's own upgrade
+> The Deployment uses **`strategy.type: Recreate`**, not a rolling update. Old pods are terminated
+> **before** new ones start, so the agent is briefly unavailable while the new version boots and wins
+> the leader lease.
+
+### Why `Recreate` (not a rolling update)
+
+It's a deliberate interaction with leader election. Under a rolling update with `replicaCount: 2`:
+
+1. A new pod can't become `Ready` until it becomes the **leader** (`/readyz` is gated on leadership).
+2. The old leader still holds the `Lease`, so the new pod can't lead yet.
+3. With `maxUnavailable: 0` the old pod won't terminate until the new one is `Ready` — **deadlock**.
+
+`Recreate` sidesteps this by terminating the old leader first, releasing the lease so the new pod can
+acquire it. The cost is a short gap **only during the upgrade itself**. Crash-failover HA is
+unaffected: if the leader dies unexpectedly, the hot standby takes over within the lease window
+(15s lease / 10s renew / 2s retry), no upgrade involved.
+
+`terminationGracePeriodSeconds: 40` gives the draining leader time to finish (the internal drain is
+~25s): on shutdown it logs `msg="shutdown: stopping intake; draining in-flight investigation"`,
+stops accepting new work, and lets the in-flight investigation complete.
+
+## What persists across upgrades, restarts, and failover
+
+> [!important] State is **ephemeral by default**
+> `persistence.enabled` defaults to **`false`**, which backs the data directory with an `emptyDir` —
+> wiped on every pod restart, upgrade, and failover. For anything you want to survive, enable the PVC.
+
+When `persistence.enabled: true`, the chart creates one PVC, `<release>-data`, mounted at
+**`/var/lib/runlore/catalog`** (`catalog.mountPath`). Because both replicas (leader + standby) must
+mount the same data, the PVC defaults to `accessModes: [ReadWriteMany]` — back it with an RWX class
+(EFS on EKS, Filestore on GKE, etc.), default size `1Gi`.
+
+Three things live on that volume; point their config keys inside the mount path:
+
+| What | Config key | Notes |
+|---|---|---|
+| **Catalog git-sync mirror** | `catalog.dir` (= the mount path) | the local clone of your KB repo, re-synced on an interval |
+| **Outcome ledger** | `outcome.ledger_path` (e.g. `/var/lib/runlore/catalog/outcomes.jsonl`) | append-only JSONL written by `serve`, **read by the curate CronJob** — both must share the volume |
+| **Audit log** | `actions.audit_log_path` | hash-chained, only required when `actions.mode=auto` |
+
+The **bleve search index is *not* persisted** — it is built in memory (`NewMemOnly`) and rebuilt from
+the catalog mirror at startup, so a restart simply re-indexes. Instant-recall quality is unaffected by
+losing the index; it depends on the catalog content, which lives in your Git repo.
+
+> [!note] If you run with `persistence.enabled: false`
+> The outcome ledger and audit log are lost on every restart, and the catalog re-clones from scratch
+> on boot. That's fine for a quick trial, but for the **learning loop** to compound (outcome-weighted
+> recall decay) the outcome ledger must persist — enable the PVC for any real deployment.
+
+## Uninstalling
+
+```bash
+helm uninstall runlore -n runlore
+```
+
+This removes the Deployment, Service, ConfigMap, ServiceAccount, RBAC (ClusterRole/Roles + bindings),
+and PodDisruptionBudget. It does **not** remove three things, which you must clean up by hand:
+
+1. **The PVC `<release>-data`** (and its underlying PV / EFS / Filestore volume). Helm never deletes
+   PVCs it templated, so your catalog mirror, outcome ledger, and audit log survive the uninstall:
+   ```bash
+   kubectl delete pvc <release>-data -n runlore
+   # then delete the backing PV / cloud volume if your StorageClass doesn't reclaim it
+   ```
+2. **The credentials `Secret`.** The chart never creates it — it only references an existing Secret
+   via `envFrom`/`env`. Delete whatever Secret you created for the GitHub App key, LLM API key, and
+   notifier tokens:
+   ```bash
+   kubectl delete secret <your-runlore-secret> -n runlore
+   ```
+3. **The GitHub App.** It lives in GitHub, not the cluster — RunLore only holds its installation token
+   at runtime. If you're done, delete (or uninstall) the App from your GitHub org/account settings so
+   its installation and private key are revoked.
+
+The knowledge-catalog **Git repo** is yours and is untouched by any of the above — that's the point:
+your accumulated knowledge is portable and outlives the deployment.


### PR DESCRIPTION
Round 2 of the docs work — the operability/config gaps surfaced in the readiness review. Four new docs, all **grounded in the actual code** (real metric names, decision log strings, config defaults, and Helm/PVC behavior — cross-checked, not plausible-but-wrong), linked from the README docs index and getting-started.

## New docs

- **`docs/troubleshooting.md`** — symptom → exact `runlore_*` metric + `msg=` log line → fix, for the common cases: no investigation started (trigger filter / dedup / source typo / webhook auth / no leader), timeout or empty result (the `result=` label vocabulary), curator didn't open a PR, recall never fires, delivery failed, `/readyz` never green. Honest about two real **observability gaps**: notifier delivery and trigger-filter/dedup drops have *no metric* (logs only) — flagged in-doc rather than papered over.
- **`docs/upgrade-uninstall.md`** — `helm upgrade` + the **`Recreate` ~20s self-upgrade downtime** (the leader-election deadlock rationale), what survives a restart (**state is ephemeral unless `persistence.enabled`** — the PVC backs the catalog mirror, outcome ledger, and audit log; the bleve index is rebuilt in memory), and the manual-cleanup set after uninstall (PVC, Secret, GitHub App).
- **`docs/configuration.md`** — a subsystem-organized config map (sources, triggers, investigation, catalog, actions, model, forge, notify, server, rbac, …) that **defers per-key detail to the authoritative annotated `values.yaml`** rather than duplicating it — so it can't drift out of sync (the same failure class as the demo-config bug in #158).
- **`docs/security-model.md`** — the runtime security model consolidated in one user-facing page: read-only posture, the server-authoritative action gate (re-derives reversibility/blast from an op registry, never trusts the model), the 3 redaction boundaries + the residual base64-`Secret` gap, least-privilege RBAC, short-lived GitHub App tokens, and the hash-chained audit log. Complements `SECURITY.md` (which is vuln-reporting only).

## Verification

- All relative links across the four docs + README resolve (link-checked).
- Key claims cross-checked against source: metric names (`internal/telemetry/metrics.go`), config defaults (`internal/config`), and Helm behavior (`Recreate`, `persistence.enabled: false`, mount path, grace period) in `deploy/helm/runlore`.

Docs-only; no code changes. The `dev/` artifact relocation is a separate follow-up PR.