### PR TITLE
fix(investigate): pod_status falls back to namespace when a selector matches nothing

### DIFF
--- a/internal/investigate/kube_tools.go
+++ b/internal/investigate/kube_tools.go
@@ -42,10 +42,29 @@ func (t PodStatusTool) Call(ctx context.Context, args string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// A caller-supplied selector that matches nothing is indistinguishable from a
+	// genuinely empty namespace — and that false negative has produced confident-
+	// but-wrong "workload not deployed" findings (the model tends to guess
+	// app=<name>, but workloads commonly label with app.kubernetes.io/name). Fall
+	// back to the whole namespace so a non-matching selector can't read as "no pods
+	// exist"; the model still sees the real (e.g. CrashLoopBackOff) pods.
+	var note string
+	if len(pods) == 0 && in.Selector != "" {
+		all, err := t.Kube.PodStatuses(ctx, in.Namespace, "")
+		if err != nil {
+			return "", err
+		}
+		if len(all) > 0 {
+			note = fmt.Sprintf("selector %s matched no pods; showing all %d pod(s) in namespace %q instead:\n",
+				in.Selector, len(all), in.Namespace)
+			pods = all
+		}
+	}
 	if len(pods) == 0 {
 		return fmt.Sprintf("no pods in namespace %q%s", in.Namespace, selectorSuffix(in.Selector)), nil
 	}
 	var b strings.Builder
+	b.WriteString(note)
 	for i, p := range pods {
 		if i >= maxToolRows {
 			fmt.Fprintf(&b, "… (%d more)\n", len(pods)-i)

--- a/internal/investigate/kube_tools_test.go
+++ b/internal/investigate/kube_tools_test.go
@@ -40,6 +40,56 @@ func TestPodStatusTool(t *testing.T) {
 	}
 }
 
+// selectorKube returns matched pods only for a specific selector, and allPods for
+// the empty (whole-namespace) selector — modelling a workload whose real labels
+// don't match a guessed `app=<name>` selector.
+type selectorKube struct {
+	matchSelector string
+	matched       []providers.PodStatus
+	allPods       []providers.PodStatus
+}
+
+func (f selectorKube) PodStatuses(_ context.Context, _ string, selector string) ([]providers.PodStatus, error) {
+	if selector == "" {
+		return f.allPods, nil
+	}
+	if selector == f.matchSelector {
+		return f.matched, nil
+	}
+	return nil, nil
+}
+func (f selectorKube) Events(context.Context, string, string, bool) ([]providers.KubeEvent, error) {
+	return nil, nil
+}
+
+// A guessed label selector that matches nothing must NOT read as an empty
+// namespace: that false negative produced confident-but-wrong "workload not
+// deployed" RCAs. pod_status falls back to the whole namespace so the real
+// (e.g. CrashLoopBackOff) pods still reach the model.
+func TestPodStatusToolSelectorFallback(t *testing.T) {
+	tool := PodStatusTool{Kube: selectorKube{
+		matchSelector: "app.kubernetes.io/name=image-gallery",
+		allPods: []providers.PodStatus{
+			{Name: "xplane-image-gallery-xwdk7", Phase: "Running", Ready: "0/1", Reasons: []string{
+				"image-gallery: CrashLoopBackOff: back-off restarting failed container",
+			}},
+		},
+	}}
+	out, err := tool.Call(context.Background(), `{"namespace":"apps","selector":"app=xplane-image-gallery"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if strings.Contains(out, "no pods in namespace") {
+		t.Fatalf("a non-matching selector must not read as an empty namespace, got:\n%s", out)
+	}
+	if !strings.Contains(out, "xplane-image-gallery-xwdk7") || !strings.Contains(out, "CrashLoopBackOff") {
+		t.Fatalf("fallback must surface the real namespace pods, got:\n%s", out)
+	}
+	if !strings.Contains(out, "app=xplane-image-gallery") {
+		t.Fatalf("fallback should note the selector that matched nothing, got:\n%s", out)
+	}
+}
+
 func TestKubeEventsTool(t *testing.T) {
 	tool := KubeEventsTool{Kube: fakeKube{events: []providers.KubeEvent{
 		{Type: "Warning", Reason: "FailedScheduling", Object: "Pod/valkey-0", Count: 13,


### PR DESCRIPTION
## Problem

A caller-supplied label selector that matches **zero** pods was rendered as `no pods in namespace X matching <selector>` — **indistinguishable from a genuinely empty namespace**. The model tends to guess `app=<name>` (primed by the `pod_status` schema example `app=harbor`), but workloads commonly label with `app.kubernetes.io/name=...`, so the guess misses and the false negative cascades into a **confident-but-wrong "workload not deployed"** root cause — without ever reaching `pod_logs`.

## Observed live (cloud-native-ref EKS, v0.2.0 deploy validation)

An alert for `apps/xplane-image-gallery` (real labels `app.kubernetes.io/name=image-gallery`, one replica CrashLoopBackOff on S3 `Access Denied`) produced a **0.9-confidence** `missing GitOps resources` RCA. The drafted entry's evidence showed:
```
pod_status ... "no pods in namespace apps matching app=xplane-image-gallery"
gitops_resource_status Kustomization/HelmRelease ... NOT FOUND   (it's a Crossplane App XR)
```
Given two aligned false negatives, "not deployed" was a *reasonable* conclusion — the bug is the misleading tool output, not the model.

## Fix

When a non-empty selector matches nothing, fall back to listing the whole namespace with a note, so a non-matching selector can't read as "no pods exist" and the real (e.g. crashing) pods still reach the model.

## Test

TDD: `TestPodStatusToolSelectorFallback` reproduces the false negative (fails before, passes after). Full suite + golangci-lint green.