### PR TITLE
fix: case-insensitive severity matching and HTTP handler panic recovery

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"path"
 	"slices"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -360,7 +361,11 @@ func (t IncidentTrigger) MatchFields(title, severity, environment, namespace str
 
 // matchFields reports whether the incident satisfies every non-empty criterion.
 func (m IncidentMatch) matchFields(severity, environment, namespace, alertname string, labels map[string]string) bool {
-	if len(m.Severity) > 0 && !slices.Contains(m.Severity, severity) {
+	// Severity is matched case-insensitively: Alertmanager labels arrive with
+	// arbitrary casing (Critical, CRITICAL), and a config of `severity: [critical]`
+	// must still match — otherwise RunLore silently goes deaf. This also keeps the
+	// trigger consistent with the coalescer's EqualFold("critical") fast-path.
+	if len(m.Severity) > 0 && !containsFold(m.Severity, severity) {
 		return false
 	}
 	if len(m.Environment) > 0 && !slices.Contains(m.Environment, environment) {
@@ -384,6 +389,17 @@ func (m IncidentMatch) matchFields(severity, environment, namespace, alertname s
 func (m IncidentMatch) isEmpty() bool {
 	return len(m.Severity) == 0 && len(m.Environment) == 0 &&
 		len(m.Namespaces) == 0 && len(m.AlertNames) == 0 && len(m.Labels) == 0
+}
+
+// containsFold reports whether s equals any element of vals under Unicode case
+// folding (the case-insensitive counterpart of slices.Contains).
+func containsFold(vals []string, s string) bool {
+	for _, v := range vals {
+		if strings.EqualFold(v, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func globAny(patterns []string, s string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,6 +49,29 @@ func TestMatches(t *testing.T) {
 	}
 }
 
+// TestMatchSeverityCaseInsensitive guards against the "RunLore went deaf" failure:
+// Alertmanager severity labels arrive with arbitrary casing (Critical, CRITICAL),
+// so a policy configured with lowercase `critical` must still match. This also keeps
+// the trigger consistent with the coalescer, which fast-paths via EqualFold("critical").
+func TestMatchSeverityCaseInsensitive(t *testing.T) {
+	tr := IncidentTrigger{Match: IncidentMatch{Severity: []string{"critical"}}}
+	for _, alertSeverity := range []string{"critical", "Critical", "CRITICAL"} {
+		got := tr.MatchFields(sampleAlertName, alertSeverity, sampleEnvironment, sampleNamespace, sampleLabels())
+		if !got {
+			t.Errorf("severity %q: MatchFields=false, want true (case-insensitive)", alertSeverity)
+		}
+	}
+	// A genuine mismatch must still be rejected regardless of casing.
+	if tr.MatchFields(sampleAlertName, "Warning", sampleEnvironment, sampleNamespace, sampleLabels()) {
+		t.Errorf("severity %q should not match policy %q", "Warning", "critical")
+	}
+	// Casing in the policy itself must not matter either.
+	if !(IncidentTrigger{Match: IncidentMatch{Severity: []string{"CRITICAL"}}}).
+		MatchFields(sampleAlertName, "critical", sampleEnvironment, sampleNamespace, sampleLabels()) {
+		t.Errorf("policy %q should match alert severity %q", "CRITICAL", "critical")
+	}
+}
+
 func TestDurationUnmarshal(t *testing.T) {
 	var d Duration
 	if err := d.UnmarshalYAML(yamlScalar("30m")); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -96,8 +97,34 @@ func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pip
 		mux.Handle("GET /metrics", s.metrics)
 	}
 	source.MountWebhooks(mux, built, s.webhookAuthorized, pipe)
-	s.handler = mux
+	// Wrap the whole mux so a panic in any handler (current or future) returns a
+	// structured 500 and a logged stack instead of net/http's silent connection drop.
+	s.handler = recoverPanic(mux, log)
 	return s
+}
+
+// recoverPanic wraps next so a panic in any handler is recovered: it logs the
+// panic value, request method/path/remote-addr, and a stack trace at error level,
+// then writes a 500 if nothing has been written yet. Without this, net/http's
+// per-connection recover closes the connection with no response and no log.
+func recoverPanic(next http.Handler, log *slog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				if log != nil {
+					log.Error("recovered from handler panic",
+						"panic", rec,
+						"method", r.Method,
+						"path", r.URL.Path,
+						"remote_addr", r.RemoteAddr,
+						"stack", string(debug.Stack()),
+					)
+				}
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -273,6 +274,50 @@ func TestHealthz(t *testing.T) {
 	testServer().Handler().ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
+	}
+}
+
+// TestRecoverPanic verifies the panic-recovery middleware: a handler that panics
+// must yield a 500 (not a silently-dropped connection) and log the panic at error
+// level with the request method/path, without crashing the process.
+func TestRecoverPanic(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	var next http.Handler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	})
+	h := recoverPanic(next, log)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/webhook/alertmanager", nil)
+	req.RemoteAddr = "10.1.2.3:5555"
+
+	// Must not propagate the panic out of ServeHTTP.
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("panicking handler = %d, want 500", rr.Code)
+	}
+	logged := buf.String()
+	for _, want := range []string{"GET", "/webhook/alertmanager", "10.1.2.3:5555", "boom"} {
+		if !strings.Contains(logged, want) {
+			t.Errorf("recovery log missing %q; got: %s", want, logged)
+		}
+	}
+}
+
+// TestServerRecoversFromHandlerPanic verifies the middleware is wired so a panic in
+// any mounted route is recovered (here: the slack-interactions handler reached with
+// no body, which would deref a nil payload absent recovery is not guaranteed — so we
+// drive a route through the real mux and assert no panic escapes ServeHTTP).
+func TestServerRecoversFromHandlerPanic(t *testing.T) {
+	srv := New(func() bool { panic("ready panic") }, Actions{}, nil, nil, nil, discardLog)
+	rr := httptest.NewRecorder()
+	// /readyz calls ready(); the panicking ready func exercises the wired middleware.
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("panicking route through mux = %d, want 500", rr.Code)
 	}
 }
 


### PR DESCRIPTION
  ## What
  - **SEV-CASE [P1]** — Trigger severity matching was case-sensitive (`slices.Contains`, `config.go:363`), so a `Critical`/`CRITICAL` alert was silently dropped by a `severity: [critical]` policy — while the coalescer already used `EqualFold`. Now matched case-insensitively (`containsFold`), consistent with the coalescer. ("RunLore went deaf" failure mode.)
  - **PANIC-MW [P2]** — No panic recovery on the HTTP server: a handler panic returned no response and no log. Added recovery middleware wrapping the whole mux — logs panic/method/path/remote-addr + stack at error level, returns `500`.

  ## Tests
  - `TestMatchSeverityCaseInsensitive` — `Critical`/`CRITICAL` match; `Warning` rejected; policy-side casing irrelevant.
  - `TestRecoverPanic` + `TestServerRecoversFromHandlerPanic` — `500`, no process crash, panic logged with request context.
