### PR TITLE
  fix(helm): bump chart to 0.2.0 and keep Chart.yaml synced via release-please

### DIFF
--- a/deploy/helm/runlore/Chart.yaml
+++ b/deploy/helm/runlore/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: runlore
 description: RunLore — the self-improving, GitOps-native SRE agent (in-cluster agent).
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 home: https://github.com/Smana/runlore
 sources:
   - https://github.com/Smana/runlore

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,18 @@
       "package-name": "runlore",
       "include-component-in-tag": false,
       "initial-version": "0.1.0",
+      "extra-files": [
+        {
+          "type": "yaml",
+          "path": "deploy/helm/runlore/Chart.yaml",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "yaml",
+          "path": "deploy/helm/runlore/Chart.yaml",
+          "jsonpath": "$.appVersion"
+        }
+      ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
  ## What
  - **CHART-VER [P1]** — `Chart.yaml` was stuck at `0.1.0` while the project released `v0.2.0`. Since `deployment.yaml` defaults the image tag to `.Chart.AppVersion`, a fresh `helm install` pulled the **stale `0.1.0` image**. Bumped `version` + `appVersion` to `0.2.0`.
  - **RELEASE-CHART [P1]** — release-please never bumped the chart (no `extra-files` entry), so it would drift again on the next release. Added `type: yaml` + `jsonpath` updaters for `$.version` and `$.appVersion` so future releases keep `Chart.yaml` in sync automatically.

  Verified: `helm lint` clean; `release-please-config.json` is valid JSON.
