### PR TITLE
  feat(model): internal streaming, configurable max_tokens, and refusal handling

### DIFF
--- a/dev/superpowers/plans/2026-06-29-model-layer-streaming-refusal.md
+++ b/dev/superpowers/plans/2026-06-29-model-layer-streaming-refusal.md
@@ -1,0 +1,92 @@
+# Model-layer streaming + max_tokens + refusal — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`. Design detail lives in the companion spec: [`../specs/2026-06-29-model-layer-streaming-refusal.md`](../specs/2026-06-29-model-layer-streaming-refusal.md) — read it first. Steps use `- [ ]` tracking.
+
+**Goal:** Add internal streaming, a configurable `max_tokens`, and refusal/safety handling to all three LLM providers **without changing** the `providers.ModelProvider.Complete` interface.
+
+**Architecture:** Each provider streams its HTTP response (SSE) and accumulates into the existing `CompletionResponse`. New config `model.max_tokens` (default 8192, `verify` inherits). New `CompletionResponse.StopReason` + `Refused()`; the investigation loop turns a refusal into a first-class `unresolved` outcome.
+
+**Tech stack:** Go 1.26; hand-rolled providers in `internal/model/{anthropic,openai,gemini}`; `internal/httpx` (SSRF-guarded client + `DoWithRetry`); `httptest` SSE servers for tests; `-race`.
+
+**Conventions (AGENTS.md):** TDD (failing test first), table-driven tests that verify *behaviour* not mocks, wrap errors with `%w`, doc comments on exported symbols, `gofmt`+`golangci-lint v2` clean. **No `Co-Authored-By` trailers.**
+
+**Branch:** `feat/model-streaming` off `main` (`812d923`, Wave-1 merged — `config.go` already has `containsFold`).
+
+---
+
+### Task 1: Config — `model.max_tokens` + verify inheritance
+**Files:** `internal/config/config.go` (Model struct + `Validate`), `internal/config/config_test.go`, `internal/app/model.go` (apply default + verify inheritance at provider construction).
+
+- [ ] **Test first** — `max_tokens: 16384` parses to `Model.MaxTokens==16384`; unset → `0`; negative → `Validate` error; a `model.verify` block with no `max_tokens` resolves to the parent's effective value, but overrides when set.
+- [ ] Run → fail.
+- [ ] **Implement** — add `MaxTokens int \`yaml:"max_tokens"\`` to `Model` (doc comment: "0 = use the 8192 default"); reject `< 0` in `Validate`; in `app/model.go` compute `effectiveMaxTokens := cfg.MaxTokens; if effectiveMaxTokens == 0 { effectiveMaxTokens = 8192 }` and pass it into each provider's constructor; the verify model inherits the parent's effective value unless it set its own.
+- [ ] Run → pass; `gofmt`/`vet`.
+- [ ] **Commit** `feat(config): add model.max_tokens (default 8192), verify inherits`.
+
+### Task 2: `CompletionResponse` — `StopReason` + `Refused()`
+**Files:** `internal/providers/providers.go` (CompletionResponse), `internal/providers/providers_test.go` (or a focused test near the type).
+
+- [ ] **Test first** — `Refused()` is true for stop reasons `"refusal"`, `"content_filter"`, `"safety"`, `"prohibited_content"`, `"blocklist"`, `"spii"` (case-insensitive) and false for `"end_turn"`/`"stop"`/`"max_tokens"`/empty.
+- [ ] Run → fail.
+- [ ] **Implement** — add `StopReason string` to `CompletionResponse` (keep `Truncated` for the max_tokens case); add method `func (r CompletionResponse) Refused() bool` matching the set above via `strings.EqualFold`/lowercase compare. Doc-comment both.
+- [ ] Run → pass.
+- [ ] **Commit** `feat(providers): add CompletionResponse.StopReason + Refused()`.
+
+### Task 3: `httpx` — streaming-friendly client
+**Files:** `internal/httpx/client.go` (+ `retry.go` if needed), `internal/httpx/*_test.go`.
+
+- [ ] **Test first** — a streaming response that takes longer than the old flat 2-minute deadline but keeps sending data is NOT killed; `ctx` cancellation still aborts promptly; an idle stream (no bytes) times out via a read/idle deadline.
+- [ ] Run → fail.
+- [ ] **Implement** — provide a `SecureStreamingClient(...)` (or an option on `SecureClient`) that keeps the SSRF redirect guard but removes the flat overall `Timeout`, relying on `ctx` + a `ResponseHeaderTimeout`/read-deadline for idle detection. `DoWithRetry` must retry only on connection establishment, not after streaming has begun. Keep existing `SecureClient` for non-streaming callers (forge, notifiers, metrics, logs).
+- [ ] Run → pass.
+- [ ] **Commit** `feat(httpx): streaming-friendly secure client (no flat deadline, idle timeout)`.
+
+### Task 4: Anthropic streaming
+**Files:** `internal/model/anthropic/anthropic.go`, `internal/model/anthropic/anthropic_test.go`. Mirror the existing non-streaming `Complete`; see spec §2.
+
+- [ ] **Test first** — `httptest` server emits an Anthropic SSE stream (`message_start`→`content_block_delta` text + a `tool_use` block with `input_json_delta` fragments→`message_delta` with `stop_reason`+usage→`message_stop`). Assert `Complete` returns the accumulated text, a `ToolCall{ID,Name,Args}` with reassembled JSON args, `Usage{Input,Output}`, and `StopReason`. Add a refusal case (`stop_reason:"refusal"`, empty content) → `Refused()` true. Add a mid-stream connection-drop case → error. Keep `TestNon2xxErrorOmitsBody`, `TestMessageCoalescing`, `TestPromptCacheToolsOnly` green.
+- [ ] Run → fail.
+- [ ] **Implement** — set `stream:true` and `max_tokens` (from config) on the request; consume SSE incrementally with the streaming client; accumulate text + per-block `input_json_delta` into tool_use args; map `stop_reason`→`StopReason` (+ `Truncated` when `max_tokens`). Preserve `anthropic-version`, prompt-cache breakpoints, request-id redaction.
+- [ ] Run → pass.
+- [ ] **Commit** `feat(model/anthropic): stream /v1/messages and accumulate; send max_tokens`.
+
+### Task 5: OpenAI-compatible streaming
+**Files:** `internal/model/openai/openai.go`, `internal/model/openai/openai_test.go`.
+
+- [ ] **Test first** — SSE stream of `chat.completion.chunk`s: `delta.content` fragments + `delta.tool_calls[i]` (id/name/arguments fragments by index) + a final `finish_reason` + a usage chunk (`stream_options.include_usage`). Assert accumulation, multi-tool-call reassembly by index, `Usage`, `StopReason`. Refusal case: `finish_reason:"content_filter"` → `Refused()`. Mid-stream drop → error. Keep the tool-message `content` (non-omitempty) test green.
+- [ ] Run → fail.
+- [ ] **Implement** — `stream:true` + `stream_options:{include_usage:true}` + `max_tokens`; accumulate deltas by choice/tool-call index; map `finish_reason`→`StopReason`.
+- [ ] Run → pass.
+- [ ] **Commit** `feat(model/openai): stream chat/completions and accumulate; send max_tokens`.
+
+### Task 6: Gemini streaming
+**Files:** `internal/model/gemini/gemini.go`, `internal/model/gemini/gemini_test.go`.
+
+- [ ] **Test first** — `:streamGenerateContent?alt=sse` SSE of partial `candidates`: text parts + `functionCall` parts (with id correlation) + `finishReason` + `usageMetadata`. Assert accumulation, functionCall→`ToolCall`, `Usage`, `StopReason`. Refusal: `finishReason:"SAFETY"` → `Refused()`. Mid-stream drop → error.
+- [ ] Run → fail.
+- [ ] **Implement** — switch endpoint to `:streamGenerateContent?alt=sse`; set `generationConfig.maxOutputTokens`; accumulate parts; map `finishReason`→`StopReason`. Preserve functionCall id-correlation + `resultObject` wrapping.
+- [ ] Run → pass.
+- [ ] **Commit** `feat(model/gemini): stream generateContent and accumulate; send maxOutputTokens`.
+
+### Task 7: Loop refusal handling
+**Files:** `internal/investigate/loop.go`, `internal/investigate/loop_test.go`.
+
+- [ ] **Test first** — a scriptModel whose response is `Refused()` (e.g. `StopReason:"refusal"`, no tool calls) → the investigation is delivered as `unresolved` with a note like "model declined / safety-filtered; no root cause produced"; the model is called **exactly once** (no nudge, no retry storm); `Confidence==0`, `RootCauses` empty.
+- [ ] Run → fail.
+- [ ] **Implement** — in the loop's response handling, before the prose-turn nudge path, check `resp.Refused()`: if so, build a synthetic `unresolved` investigation (reuse the timeout/budget synthetic-result pattern) with the refusal note and return it. Redaction + delivery unchanged.
+- [ ] Run → pass.
+- [ ] **Commit** `feat(investigate): treat model refusal as a first-class unresolved outcome`.
+
+### Task 8: Integration + gate
+**Files:** none new — verification.
+
+- [ ] Confirm `app/model.go` passes `max_tokens` to all 3 providers and the verify model inherits (add an `app` test if not already covered by Task 1).
+- [ ] Run the full gate: `go build ./... && go vet ./... && gofmt -l . && go test -race ./...` → all green; `golangci-lint run ./...` → 0 issues.
+- [ ] **Commit** any fixups; ensure the spec + this plan are committed on the branch.
+
+---
+
+## Self-review
+- **Spec coverage:** config max_tokens+inheritance (T1, T8), interface-unchanged streaming per provider (T3–T6), StopReason/Refused (T2), refusal→unresolved (T7), error handling (drop tests in T4–T6), testing strategy (httptest SSE per task) — all spec sections map to a task.
+- **Type consistency:** `CompletionResponse.StopReason` / `Refused()` defined in T2 and consumed in T4–T7; `MaxTokens` defined in T1 and consumed in T4–T6/T8.
+- **No placeholders:** SSE plumbing references spec §2 + the existing provider files to mirror (the implementer reads real code); new/critical code (config field, Refused set, loop branch) is specified inline.

--- a/dev/superpowers/specs/2026-06-29-model-layer-streaming-refusal.md
+++ b/dev/superpowers/specs/2026-06-29-model-layer-streaming-refusal.md
@@ -1,0 +1,60 @@
+# Model layer: internal streaming, configurable max_tokens, refusal handling
+
+- **Date:** 2026-06-29
+- **Status:** design approved; ready for implementation plan
+- **Scope:** `internal/model/{anthropic,openai,gemini}`, `internal/httpx`, `internal/config`, `internal/investigate` (loop refusal handling)
+- **Origin:** Wave-2 of the 2026-06-29 audit follow-ups ([../../plans/2026-06-29-audit-followups.md](../../plans/2026-06-29-audit-followups.md), item `MODEL-MODERNIZE`).
+
+## Context & goal
+
+RunLore's LLM client is a hand-rolled, SDK-free multi-provider HTTP client (Anthropic, OpenAI-compatible, Gemini) behind a one-method `providers.ModelProvider` interface. Today it is **non-streaming** with a flat 2-minute HTTP timeout and a hardcoded Anthropic `max_tokens: 4096` (OpenAI/Gemini send none), and it does **not** handle model refusal/safety stop reasons. Consequences: truncation/timeout risk on a long `submit_findings`; no control over output length/cost; and a refusal is misread as an empty prose turn, burning a nudge step.
+
+**Goal:** add (1) internal streaming, (2) a configurable `max_tokens`, and (3) refusal/safety handling — **without changing the `ModelProvider.Complete` interface** (design decision A).
+
+## Non-goals (deferred to a follow-up)
+
+- Caller-facing token streaming / a `CompleteStream` method.
+- Adaptive thinking / `effort`, `count_tokens`-based budgeting, `cache_read_input_tokens` parsing, cost telemetry.
+
+## Approach
+
+`ModelProvider.Complete(ctx, CompletionRequest) (CompletionResponse, error)` stays **unchanged**. Each provider switches its HTTP request to streaming (SSE) and **accumulates** the full response internally, returning the same `CompletionResponse`. The investigation loop is unchanged except for handling a new refusal signal.
+
+## Components
+
+### 1. Config (`internal/config`)
+- Add `MaxTokens int` to `config.Model` (YAML `max_tokens`), optional; default **8192** when unset.
+- `model.verify` (cheaper judge model) **inherits** `max_tokens` unless it sets its own.
+- Validation: `max_tokens >= 0`; `0` → use the 8192 default. Field must work under the strict `KnownFields(true)` decoder.
+
+### 2. Internal streaming (per provider + `internal/httpx`)
+General: build the request with provider-specific `stream:true`, POST, read the SSE body incrementally, accumulate into `CompletionResponse{Text, ToolCalls, Usage, StopReason, Truncated}`. Reuse `httpx.SecureClient` (SSRF guard) but with a **streaming-appropriate timeout**: drop the flat 2-minute overall deadline; rely on `ctx` + a per-read/idle timeout so a long generation isn't killed mid-stream. `DoWithRetry` applies to **connection establishment only**, not mid-stream (a mid-stream drop returns an error → the loop retries the whole step).
+- **Anthropic** `/v1/messages` `stream:true`: handle SSE events `message_start` (input usage), `content_block_start`/`content_block_delta` (`text_delta` → text; `input_json_delta` → accumulate tool_use partial JSON per block), `content_block_stop`, `message_delta` (`stop_reason`, output usage), `message_stop`. Reassemble `tool_use` blocks into `ToolCall{ID,Name,Args}`. Send `max_tokens`. Keep prompt-cache breakpoints + `anthropic-version`.
+- **OpenAI** `/chat/completions` `stream:true` + `stream_options:{include_usage:true}`: accumulate `choices[0].delta.content` and `delta.tool_calls[i]` by index (id/name/arguments fragments), `finish_reason`, and the final usage chunk. Send `max_tokens`. Keep the non-`omitempty` tool-message `content`.
+- **Gemini** `:streamGenerateContent?alt=sse`: accumulate `candidates[0].content.parts` (text + functionCall), `finishReason`, `usageMetadata`. Send `generationConfig.maxOutputTokens`. Keep functionCall id-correlation + `resultObject` wrapping.
+
+### 3. Refusal / safety handling (`internal/model/*` + `internal/investigate/loop.go`)
+- Add `StopReason string` to `CompletionResponse` (keep `Truncated` for the max_tokens case). Set it from each provider's terminal reason.
+- Detect refusal/safety: Anthropic `stop_reason == "refusal"`; OpenAI `finish_reason == "content_filter"`; Gemini `finishReason ∈ {SAFETY, PROHIBITED_CONTENT, BLOCKLIST, SPII}`. Expose `CompletionResponse.Refused() bool`.
+- In the loop: a `Refused()` turn ends the investigation as a first-class **`unresolved`** result with a clear note ("the model declined / safety-filtered the content; no root cause produced") — **not** an empty prose turn (no nudge), and **not** a retry.
+
+## Error handling
+- Mid-stream connection error → wrap with `%w`, return; the loop's existing error path retries/surfaces. Discard partial output.
+- `max_tokens` reached (`Truncated`) → keep the existing "re-prompt once to continue concisely".
+- Refusal → terminal `unresolved` outcome (not an error, not a retry).
+- Malformed SSE/JSON → wrap + return; never panic.
+
+## Testing (TDD)
+- Per provider: `httptest` server emitting a canned SSE stream; assert `Complete` accumulates text, multi-tool-call args (by index/block), usage, stop_reason, truncation. Mid-stream connection drop → error.
+- Refusal per provider: stream a refusal/safety terminal reason → `Refused()` true; loop test → investigation is `unresolved` with the note, model called exactly once (no retry storm).
+- `max_tokens`: assert it is sent in each provider's request; `model.verify` inherits when unset, overrides when set.
+- All existing model + loop tests stay green; run under `-race`.
+
+## Acceptance criteria
+- `Complete` interface unchanged; callers untouched.
+- All 3 providers stream internally; long outputs no longer hit the 2-minute timeout; `max_tokens` configurable (default 8192); verify inherits.
+- Refusal → first-class `unresolved` with a note; no nudge/retry burned.
+- `go build && go vet && gofmt -l . && go test -race ./...` green; `golangci-lint` clean.
+
+## Rollout
+Wave-1 is merged (`origin/main` @ `812d923`, includes the `config.go` severity change this also edits). Implement on a branch off current `main`. Single cohesive PR; split per provider if the diff gets large. Commit this spec + the implementation plan alongside the code.

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -13,21 +13,47 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// NewModelClient builds a ModelProvider for a wire protocol + endpoint.
-func NewModelClient(provider, baseURL, model, apiKey string) providers.ModelProvider {
+// defaultMaxTokens is the output-token ceiling used when model.max_tokens is unset
+// (0). It bounds a single completion's generated tokens across every provider.
+const defaultMaxTokens = 8192
+
+// effectiveMaxTokens resolves a configured max_tokens to the value sent on the wire:
+// an unset (0) value becomes the defaultMaxTokens; an explicit value is used as-is.
+func effectiveMaxTokens(configured int) int {
+	if configured <= 0 {
+		return defaultMaxTokens
+	}
+	return configured
+}
+
+// verifyMaxTokens resolves the verify pass's effective output-token cap: its own
+// override when set (>0), otherwise the parent model's effective value (so a bare
+// `verify: {model: <cheap>}` inherits the parent's cap, defaulted or explicit).
+func verifyMaxTokens(cfg *config.Config) int {
+	parent := effectiveMaxTokens(cfg.Model.MaxTokens)
+	if v := cfg.Model.Verify; v != nil && v.MaxTokens > 0 {
+		return v.MaxTokens
+	}
+	return parent
+}
+
+// NewModelClient builds a ModelProvider for a wire protocol + endpoint. maxTokens
+// is the per-request output-token ceiling passed through to the provider.
+func NewModelClient(provider, baseURL, model, apiKey string, maxTokens int) providers.ModelProvider {
 	switch provider {
 	case "anthropic":
-		return anthropic.New(baseURL, model, apiKey)
+		return anthropic.New(baseURL, model, apiKey, maxTokens)
 	case "gemini":
-		return gemini.New(baseURL, model, apiKey)
+		return gemini.New(baseURL, model, apiKey, maxTokens)
 	default:
-		return openai.New(baseURL, model, apiKey)
+		return openai.New(baseURL, model, apiKey, maxTokens)
 	}
 }
 
-// BuildModel builds the ModelProvider for the configured provider.
+// BuildModel builds the ModelProvider for the configured provider, applying the
+// effective output-token cap (model.max_tokens, defaulted when unset).
 func BuildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
-	return NewModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey)
+	return NewModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey, effectiveMaxTokens(cfg.Model.MaxTokens))
 }
 
 // BuildVerifyModel builds the optional cheaper model for the adversarial verify
@@ -49,7 +75,7 @@ func BuildVerifyModel(cfg *config.Config) providers.ModelProvider {
 		apiKey = os.Getenv(keyEnv)
 	}
 	return NewModelClient(or(v.Provider, cfg.Model.Provider),
-		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey)
+		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey, verifyMaxTokens(cfg))
 }
 
 // BuildJudgeModel builds the (stronger) grader model from --judge-* flags, falling
@@ -62,5 +88,6 @@ func BuildJudgeModel(cfg *config.Config, provider, baseURL, model, apiKeyEnv str
 		}
 		return BuildModel(cfg, apiKey)
 	}
-	return NewModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv))
+	// A judge gets the same effective output cap as the main model (no separate knob).
+	return NewModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens))
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -3,7 +3,62 @@ package app
 import (
 	"fmt"
 	"testing"
+
+	"github.com/Smana/runlore/internal/config"
 )
+
+// TestEffectiveMaxTokens locks in the output-token defaulting: an unset (0)
+// model.max_tokens resolves to the 8192 default; an explicit value is used as-is.
+func TestEffectiveMaxTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"unset uses default", 0, defaultMaxTokens},
+		{"explicit value", 16384, 16384},
+		{"small explicit value", 256, 256},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := effectiveMaxTokens(tc.in); got != tc.want {
+				t.Fatalf("effectiveMaxTokens(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVerifyMaxTokensInherits verifies the verify pass inherits the parent's
+// EFFECTIVE max_tokens when its own override is unset (0), but uses its own value
+// when set.
+func TestVerifyMaxTokensInherits(t *testing.T) {
+	// Parent 16384, verify unset ⇒ verify inherits 16384.
+	cfg := &config.Config{Model: config.Model{
+		Provider: "anthropic", Model: "claude-x", MaxTokens: 16384,
+		Verify: &config.ModelOverride{Model: "claude-cheap"},
+	}}
+	if got := verifyMaxTokens(cfg); got != 16384 {
+		t.Fatalf("verify inherits parent effective: got %d, want 16384", got)
+	}
+
+	// Parent unset (⇒ default 8192), verify unset ⇒ verify inherits the default.
+	cfgDefault := &config.Config{Model: config.Model{
+		Provider: "anthropic", Model: "claude-x",
+		Verify: &config.ModelOverride{Model: "claude-cheap"},
+	}}
+	if got := verifyMaxTokens(cfgDefault); got != defaultMaxTokens {
+		t.Fatalf("verify inherits parent default: got %d, want %d", got, defaultMaxTokens)
+	}
+
+	// Verify override set ⇒ used as-is regardless of the parent.
+	cfgOverride := &config.Config{Model: config.Model{
+		Provider: "anthropic", Model: "claude-x", MaxTokens: 16384,
+		Verify: &config.ModelOverride{Model: "claude-cheap", MaxTokens: 2048},
+	}}
+	if got := verifyMaxTokens(cfgOverride); got != 2048 {
+		t.Fatalf("verify override: got %d, want 2048", got)
+	}
+}
 
 // TestNewModelClient locks in provider selection: each provider name maps to its
 // concrete client type, and any unknown/empty provider falls back to the OpenAI
@@ -21,7 +76,7 @@ func TestNewModelClient(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.provider, func(t *testing.T) {
-			client := NewModelClient(tc.provider, "http://endpoint/v1", "test-model", "key")
+			client := NewModelClient(tc.provider, "http://endpoint/v1", "test-model", "key", defaultMaxTokens)
 			if client == nil {
 				t.Fatalf("NewModelClient(%q) returned nil", tc.provider)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -235,6 +235,10 @@ type Model struct {
 	BaseURL   string `yaml:"base_url"`    // OpenAI: required; Anthropic/Gemini: optional (built-in default endpoint)
 	Model     string `yaml:"model"`       // model name
 	APIKeyEnv string `yaml:"api_key_env"` // env var holding the API key (empty = keyless)
+	// MaxTokens caps the model's output (generated) tokens per request. 0 = use the
+	// 8192 default. Streaming providers send it (Anthropic max_tokens, OpenAI
+	// max_tokens, Gemini generationConfig.maxOutputTokens); a too-low value truncates.
+	MaxTokens int `yaml:"max_tokens"`
 	// Verify optionally routes the adversarial verify pass to a cheaper/faster model;
 	// unset fields inherit from the parent above (so `verify: {model: <cheap>}` reuses
 	// the same provider/endpoint/key). Absent ⇒ verify runs on the main model.
@@ -260,6 +264,9 @@ type ModelOverride struct {
 	BaseURL   string `yaml:"base_url"`
 	Model     string `yaml:"model"`
 	APIKeyEnv string `yaml:"api_key_env"`
+	// MaxTokens overrides the parent's effective output-token cap for the verify pass;
+	// 0 inherits the parent's effective value.
+	MaxTokens int `yaml:"max_tokens"`
 }
 
 // Notify configures where investigation findings are delivered.
@@ -483,6 +490,14 @@ func (a ActionPolicy) Enabled() bool {
 // for the autonomy ladder: enabling execution requires the controls that bound
 // it. Returns an error that should abort startup.
 func (c *Config) Validate() error {
+	// Reject a nonsensical output-token cap before it reaches a provider request. 0
+	// means "use the default"; a negative value is always a misconfiguration.
+	if c.Model.MaxTokens < 0 {
+		return fmt.Errorf("model.max_tokens must be >= 0 (0 = use the default), got %d", c.Model.MaxTokens)
+	}
+	if c.Model.Verify != nil && c.Model.Verify.MaxTokens < 0 {
+		return fmt.Errorf("model.verify.max_tokens must be >= 0 (0 = inherit), got %d", c.Model.Verify.MaxTokens)
+	}
 	switch c.Actions.Mode {
 	case "", ActionOff, ActionSuggest:
 		return nil // read-only-ish: nothing to execute

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -136,6 +136,77 @@ func TestValidateModelDoesNotRequireWebhookToken(t *testing.T) {
 	}
 }
 
+// TestModelMaxTokensParse verifies model.max_tokens parses to Model.MaxTokens, an
+// unset key reads as 0 (the "use the default" sentinel), and the verify override
+// carries its own max_tokens (0 ⇒ inherit the parent's effective value).
+func TestModelMaxTokensParse(t *testing.T) {
+	const y = `
+model:
+  provider: anthropic
+  model: claude-x
+  max_tokens: 16384
+  verify:
+    model: claude-cheap
+`
+	var c Config
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Model.MaxTokens != 16384 {
+		t.Fatalf("model.max_tokens: want 16384, got %d", c.Model.MaxTokens)
+	}
+	// A verify block with no max_tokens leaves the override at 0 (inherit the parent).
+	if c.Model.Verify == nil || c.Model.Verify.MaxTokens != 0 {
+		t.Fatalf("verify.max_tokens absent must be 0, got %+v", c.Model.Verify)
+	}
+
+	// Absent ⇒ zero ⇒ the wiring applies the 8192 default.
+	var z Config
+	if err := yaml.Unmarshal([]byte("model:\n  provider: openai\n  model: x\n"), &z); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if z.Model.MaxTokens != 0 {
+		t.Fatalf("absent max_tokens must be 0, got %d", z.Model.MaxTokens)
+	}
+
+	// An explicit verify.max_tokens overrides the parent.
+	const yv = `
+model:
+  provider: anthropic
+  model: claude-x
+  max_tokens: 16384
+  verify:
+    model: claude-cheap
+    max_tokens: 2048
+`
+	var cv Config
+	if err := yaml.Unmarshal([]byte(yv), &cv); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cv.Model.Verify == nil || cv.Model.Verify.MaxTokens != 2048 {
+		t.Fatalf("verify.max_tokens override: want 2048, got %+v", cv.Model.Verify)
+	}
+}
+
+// TestValidateRejectsNegativeMaxTokens verifies a negative model.max_tokens (or a
+// negative verify override) is rejected by Validate — a nonsensical value that
+// would otherwise reach a provider request.
+func TestValidateRejectsNegativeMaxTokens(t *testing.T) {
+	c := &Config{Model: Model{Provider: "anthropic", MaxTokens: -1}}
+	if err := c.Validate(); err == nil {
+		t.Fatal("negative model.max_tokens must be rejected by Validate")
+	}
+	cv := &Config{Model: Model{Provider: "anthropic", Verify: &ModelOverride{MaxTokens: -5}}}
+	if err := cv.Validate(); err == nil {
+		t.Fatal("negative verify.max_tokens must be rejected by Validate")
+	}
+	// Zero and positive are fine.
+	ok := &Config{Model: Model{Provider: "anthropic", MaxTokens: 0, Verify: &ModelOverride{MaxTokens: 4096}}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("non-negative max_tokens must validate clean: %v", err)
+	}
+}
+
 func TestCurateRecurrenceThresholdParse(t *testing.T) {
 	var c Config
 	if err := yaml.Unmarshal([]byte("curate:\n  recurrence_threshold: 5\n"), &c); err != nil {

--- a/internal/httpx/sse.go
+++ b/internal/httpx/sse.go
@@ -1,0 +1,64 @@
+package httpx
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"iter"
+	"strings"
+)
+
+// maxSSELine caps a single SSE line so a hostile/buggy upstream cannot exhaust memory
+// with one unbounded line. Generous enough for large tool schemas / JSON arg deltas.
+const maxSSELine = 1 << 20 // 1 MiB
+
+// SSEData parses a Server-Sent Events stream and yields each event's concatenated
+// `data:` payload (multiple data: lines in one event are joined with newlines, per
+// the SSE spec). A blank line dispatches the accumulated event; a final event with no
+// trailing blank line is flushed at EOF. Non-data lines (event:, id:, retry:, and
+// `:`-comment lines) are ignored — callers that need the event type read it from the
+// JSON payload. A read error is yielded as the second value (so a dropped stream is
+// observable); io.EOF is treated as a clean end, not an error.
+//
+// Iteration stops when the consumer breaks or the stream ends. It is the provider's
+// SSE framing primitive; each provider unmarshals the payload into its own event type.
+func SSEData(r io.Reader) iter.Seq2[[]byte, error] {
+	return func(yield func([]byte, error) bool) {
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 0, 64<<10), maxSSELine)
+		var data []string // data: lines for the current event
+		flush := func() bool {
+			if len(data) == 0 {
+				return true
+			}
+			payload := strings.Join(data, "\n")
+			data = data[:0]
+			return yield([]byte(payload), nil)
+		}
+		for sc.Scan() {
+			line := sc.Bytes()
+			if len(line) == 0 { // blank line: dispatch the buffered event
+				if !flush() {
+					return
+				}
+				continue
+			}
+			if line[0] == ':' { // comment line
+				continue
+			}
+			field, value, _ := bytes.Cut(line, []byte(":"))
+			if string(field) != "data" {
+				continue // event:, id:, retry:, … — not part of the payload
+			}
+			// A single leading space after the colon is stripped per the SSE spec.
+			value = bytes.TrimPrefix(value, []byte(" "))
+			data = append(data, string(value))
+		}
+		if err := sc.Err(); err != nil {
+			yield(nil, err)
+			return
+		}
+		// Flush a trailing event that had no blank-line terminator before EOF.
+		flush()
+	}
+}

--- a/internal/httpx/sse_test.go
+++ b/internal/httpx/sse_test.go
@@ -1,0 +1,68 @@
+package httpx
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestSSEDataFramesEvents asserts the SSE framing is parsed correctly: each event's
+// data: line(s) are yielded as one payload at the dispatching blank line, multi-line
+// data is joined with newlines, and non-data lines (event:, comments, id:) are
+// ignored. A trailing event with no blank line is still flushed at EOF.
+func TestSSEDataFramesEvents(t *testing.T) {
+	const stream = "event: message_start\n" +
+		"data: {\"a\":1}\n" +
+		"\n" +
+		": this is a comment\n" +
+		"event: chunk\n" +
+		"data: line1\n" +
+		"data: line2\n" +
+		"\n" +
+		"data: {\"last\":true}\n" // no trailing blank line — must still flush at EOF
+
+	var got []string
+	for payload, err := range SSEData(strings.NewReader(stream)) {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got = append(got, string(payload))
+	}
+	want := []string{`{"a":1}`, "line1\nline2", `{"last":true}`}
+	if len(got) != len(want) {
+		t.Fatalf("got %d events %q, want %d %q", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("event %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestSSEDataSurfacesReadError asserts a mid-stream read error is yielded (not
+// silently swallowed) so a consumer can fail a dropped stream.
+func TestSSEDataSurfacesReadError(t *testing.T) {
+	boom := errors.New("boom")
+	r := io.MultiReader(strings.NewReader("data: {\"a\":1}\n\n"), &errReader{err: boom})
+	var sawErr error
+	var events int
+	for payload, err := range SSEData(r) {
+		if err != nil {
+			sawErr = err
+			break
+		}
+		_ = payload
+		events++
+	}
+	if events != 1 {
+		t.Fatalf("want 1 good event before the error, got %d", events)
+	}
+	if !errors.Is(sawErr, boom) {
+		t.Fatalf("read error not surfaced: %v", sawErr)
+	}
+}
+
+type errReader struct{ err error }
+
+func (e *errReader) Read([]byte) (int, error) { return 0, e.err }

--- a/internal/httpx/streaming.go
+++ b/internal/httpx/streaming.go
@@ -1,0 +1,140 @@
+package httpx
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// ErrIdleTimeout is returned by an IdleTimeoutReader when no bytes arrive within the
+// configured idle window — a stalled stream, distinct from a clean io.EOF.
+var ErrIdleTimeout = errors.New("idle stream timeout")
+
+// SecureStreamingClient returns an http.Client tuned for consuming a long-lived SSE
+// stream. Unlike SecureClient it has NO flat overall Timeout — a flat deadline would
+// kill a legitimate long completion mid-stream — and instead relies on the request
+// context (for cancellation) plus an idle/read timeout applied by the caller (see
+// NewIdleTimeoutReader). It keeps the DenyInternalRedirect SSRF guard.
+//
+// responseHeaderTimeout bounds the time spent waiting for the response headers
+// (time-to-first-byte at the protocol level) so a backend that accepts the
+// connection but never replies cannot hang the request before streaming begins;
+// once headers arrive, the body may stream for as long as it stays active.
+func SecureStreamingClient(responseHeaderTimeout time.Duration) *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.ResponseHeaderTimeout = responseHeaderTimeout
+	return &http.Client{
+		// No flat Timeout: ctx + the idle reader bound the request instead.
+		Transport:     tr,
+		CheckRedirect: DenyInternalRedirect,
+	}
+}
+
+// idleTimeoutReader wraps an io.ReadCloser and bounds the gap between successful
+// reads: if a single Read blocks longer than idle, Read returns ErrIdleTimeout and
+// invokes onIdle once (the provider passes the request's context cancel func, so the
+// stalled underlying HTTP read is also torn down). A single pump goroutine owns an
+// internal buffer and performs the blocking reads, so the timer can fire even while
+// the underlying Read is blocked — without ever sharing the caller's buffer across
+// the goroutine boundary (which would race a timed-out read against a late write).
+type idleTimeoutReader struct {
+	idle   time.Duration
+	onIdle func()
+	rc     io.ReadCloser
+
+	results chan readResult // one entry per completed pump read
+	once    sync.Once       // onIdle fires at most once
+
+	// pending holds bytes read by the pump but not yet fully copied to the caller.
+	pending []byte
+	pendErr error
+}
+
+type readResult struct {
+	data []byte
+	err  error
+}
+
+// NewIdleTimeoutReader wraps rc so that any Read which stalls for longer than idle
+// fails with ErrIdleTimeout and calls onIdle once. idle <= 0 disables the timeout
+// (rc is returned unwrapped). onIdle may be nil.
+func NewIdleTimeoutReader(rc io.ReadCloser, idle time.Duration, onIdle func()) io.ReadCloser {
+	if idle <= 0 {
+		return rc
+	}
+	r := &idleTimeoutReader{
+		idle:    idle,
+		onIdle:  onIdle,
+		rc:      rc,
+		results: make(chan readResult, 1),
+	}
+	go r.pump()
+	return r
+}
+
+// pump reads the wrapped stream into freshly-allocated buffers and delivers each
+// chunk. It exits after delivering the first error (EOF or a read error), or when a
+// Close unblocks its in-flight Read.
+func (r *idleTimeoutReader) pump() {
+	for {
+		buf := make([]byte, 32*1024)
+		n, err := r.rc.Read(buf)
+		r.results <- readResult{data: buf[:n], err: err}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Read returns the next chunk, or ErrIdleTimeout if no chunk arrives within idle.
+func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+	// Drain any buffered remainder from a previous oversized chunk first.
+	if len(r.pending) > 0 {
+		n := copy(p, r.pending)
+		r.pending = r.pending[n:]
+		if len(r.pending) == 0 && r.pendErr != nil {
+			err := r.pendErr
+			r.pendErr = nil
+			return n, err
+		}
+		return n, nil
+	}
+	timer := time.NewTimer(r.idle)
+	defer timer.Stop()
+	select {
+	case res, ok := <-r.results:
+		if !ok {
+			return 0, io.EOF
+		}
+		n := copy(p, res.data)
+		if n < len(res.data) {
+			// Caller's buffer was smaller than the chunk: stash the rest (and defer
+			// the chunk's error until the remainder is consumed).
+			r.pending = res.data[n:]
+			r.pendErr = res.err
+			return n, nil
+		}
+		return n, res.err
+	case <-timer.C:
+		r.tripIdle()
+		return 0, ErrIdleTimeout
+	}
+}
+
+func (r *idleTimeoutReader) tripIdle() {
+	r.once.Do(func() {
+		if r.onIdle != nil {
+			r.onIdle()
+		}
+		_ = r.rc.Close() // unblock the pump's in-flight Read
+	})
+}
+
+// Close closes the underlying reader and consumes the once-guard so a subsequent
+// idle expiry cannot fire onIdle after an explicit close.
+func (r *idleTimeoutReader) Close() error {
+	r.once.Do(func() {})
+	return r.rc.Close()
+}

--- a/internal/httpx/streaming_test.go
+++ b/internal/httpx/streaming_test.go
@@ -1,0 +1,176 @@
+package httpx
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSecureStreamingClientNoFlatDeadline asserts the streaming client has no flat
+// overall Timeout (so a long-but-active stream is never killed by a wall-clock
+// budget) yet keeps the SSRF redirect guard.
+func TestSecureStreamingClientNoFlatDeadline(t *testing.T) {
+	c := SecureStreamingClient(5 * time.Second)
+	if c.Timeout != 0 {
+		t.Fatalf("streaming client must have no flat Timeout, got %v", c.Timeout)
+	}
+	if c.CheckRedirect == nil {
+		t.Fatal("streaming client must keep the DenyInternalRedirect guard")
+	}
+}
+
+// TestStreamingSlowerThanOldDeadlineSurvives asserts a stream that keeps sending
+// data past the old flat 2-minute budget is not aborted: the client reads the whole
+// body even though each chunk is paced and the total exceeds a short header timeout.
+// (We compress the "2 minutes" to a fast, deterministic paced stream.)
+func TestStreamingSlowerThanOldDeadlineSurvives(t *testing.T) {
+	const chunks = 6
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("test server needs a Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl.Flush()
+		for i := 0; i < chunks; i++ {
+			_, _ = io.WriteString(w, "data: chunk\n\n")
+			fl.Flush()
+			time.Sleep(20 * time.Millisecond) // paced, but never idle long enough to trip the idle timeout
+		}
+	}))
+	defer srv.Close()
+
+	// Small ResponseHeaderTimeout (the time-to-headers cap) — the body then streams
+	// well past it. A flat Timeout would have killed this; the streaming client must not.
+	c := SecureStreamingClient(200 * time.Millisecond)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// Wrap with a generous idle timeout so only true stalls trip it.
+	body := NewIdleTimeoutReader(resp.Body, time.Second, func() {})
+	data, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("ReadAll over paced stream: %v", err)
+	}
+	if got := strings.Count(string(data), "chunk"); got != chunks {
+		t.Fatalf("read %d chunks, want %d (paced stream was cut short)", got, chunks)
+	}
+}
+
+// TestStreamingContextCancelAborts asserts cancelling the request context aborts the
+// read promptly rather than blocking on an indefinitely open stream.
+func TestStreamingContextCancelAborts(t *testing.T) {
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fl := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: first\n\n")
+		fl.Flush()
+		close(started)
+		<-r.Context().Done() // hold the stream open until the client cancels
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := SecureStreamingClient(time.Second)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	<-started
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.ReadAll(resp.Body)
+		done <- err
+	}()
+	select {
+	case <-done:
+		// aborted (with or without an error) — the read returned promptly
+	case <-time.After(2 * time.Second):
+		t.Fatal("context cancellation did not abort the streaming read promptly")
+	}
+}
+
+// TestIdleTimeoutReaderTimesOut asserts an idle stream (no bytes for longer than the
+// idle window) trips the idle timeout: the read returns an error and the onIdle hook
+// fires (the provider passes the request's cancel func here).
+func TestIdleTimeoutReaderTimesOut(t *testing.T) {
+	pr, pw := io.Pipe()
+	// Write one chunk, then go idle forever (never close, never write again).
+	go func() {
+		_, _ = pw.Write([]byte("data: first\n\n"))
+		// deliberately block: no more writes, no close → the reader goes idle
+		select {}
+	}()
+
+	idled := make(chan struct{}, 1)
+	r := NewIdleTimeoutReader(pr, 50*time.Millisecond, func() { idled <- struct{}{} })
+
+	buf := make([]byte, 64)
+	// First read returns the first chunk.
+	if _, err := r.Read(buf); err != nil {
+		t.Fatalf("first read should succeed, got %v", err)
+	}
+	// Second read blocks (no more data) and must trip the idle timeout.
+	_, err := r.Read(buf)
+	if err == nil {
+		t.Fatal("idle read must return an error once the idle window elapses")
+	}
+	if !errors.Is(err, ErrIdleTimeout) {
+		t.Fatalf("idle read error = %v, want ErrIdleTimeout", err)
+	}
+	select {
+	case <-idled:
+	case <-time.After(time.Second):
+		t.Fatal("onIdle hook did not fire on idle timeout")
+	}
+}
+
+// TestDoWithRetryDoesNotRetryMidStream asserts DoWithRetry returns a streamed 200
+// immediately (it must not buffer or retry a successful streaming response): the
+// handler is invoked exactly once.
+func TestDoWithRetryDoesNotRetryMidStream(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		fl := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: x\n\n")
+		fl.Flush()
+	}))
+	defer srv.Close()
+
+	c := SecureStreamingClient(time.Second)
+	build := func() (*http.Request, error) {
+		return http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	}
+	resp, err := DoWithRetry(context.Background(), c, 3, build)
+	if err != nil {
+		t.Fatalf("DoWithRetry: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("streaming 200 must not be retried; handler called %d times", calls)
+	}
+}

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -30,6 +30,21 @@ func timeoutResult(req Request) providers.Investigation {
 	}
 }
 
+// refusalResult synthesises an unresolved investigation for when the model declines
+// the turn — a provider safety/refusal stop reason (CompletionResponse.Refused()).
+// The incident is reported as unresolved (no guessed root cause) rather than retried
+// into the same refusal or misread as an empty prose turn.
+func refusalResult(req Request) providers.Investigation {
+	return providers.Investigation{
+		Title:       req.Title,
+		Resource:    req.Workload,
+		Fingerprint: req.Fingerprint,
+		Unresolved: []string{
+			"investigation stopped: the model declined to respond (safety-filtered or refused); no root cause was produced",
+		},
+	}
+}
+
 // estimateTokens approximates the request size (~4 chars/token) over everything
 // re-sent each step: the system prompt, the full tool schemas (name +
 // description + JSON Schema), and the message history — including the assistant

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -264,6 +264,19 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			return fmt.Errorf("model: %w", err)
 		}
 		li.Log.Debug("investigation step", "title", req.Title, "step", step, "tool_calls", len(resp.ToolCalls), "text_len", len(resp.Text))
+		// The provider declined the turn (a safety/refusal stop reason): deliver a
+		// first-class unresolved result rather than misreading the empty response as a
+		// prose turn (which would burn a nudge) or retrying into the same refusal.
+		if resp.Refused() {
+			li.Log.Warn("investigation stopped: model refused or safety-filtered the response",
+				"title", req.Title, "stop_reason", resp.StopReason)
+			if li.Metrics != nil {
+				li.Metrics.InvestigationsDropped.Add(ctx, 1)
+			}
+			result = "refused"
+			li.deliver(req, refusalResult(req))
+			return nil
+		}
 		// Truncation: the provider stopped at its output-token ceiling, so this turn is
 		// cut off — its prose is incomplete and any tool-call JSON is likely partial, so
 		// it must not be treated as a finished step. Surface it (warn + metric) and, once,

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -114,6 +114,40 @@ func TestRecallRejectedByVerifyFallsThrough(t *testing.T) {
 	}
 }
 
+func TestLoopRefusalUnresolved(t *testing.T) {
+	// The model declines the turn (a safety/refusal stop reason, empty content). The
+	// loop must deliver a first-class `unresolved` result and STOP after one call —
+	// not misread the empty response as a prose turn (which would burn a nudge) nor
+	// retry into the same refusal.
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{StopReason: "refusal"}, // no text, no tool calls
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "PodCrashLooping", Fingerprint: "fp-refuse"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if model.i != 1 {
+		t.Fatalf("model called %d times; a refusal must stop after one call (no nudge/retry)", model.i)
+	}
+	if got == nil {
+		t.Fatal("nothing delivered")
+	}
+	if len(got.RootCauses) != 0 || got.Confidence != 0 {
+		t.Fatalf("a refusal must produce no root cause: %+v", got)
+	}
+	if len(got.Unresolved) == 0 || !strings.Contains(strings.ToLower(got.Unresolved[0]), "declined") {
+		t.Fatalf("refusal must be reported as unresolved with a note, got %+v", got.Unresolved)
+	}
+	if got.Fingerprint != "fp-refuse" {
+		t.Fatalf("refusal result must carry the fingerprint for outcome attribution, got %q", got.Fingerprint)
+	}
+}
+
 func TestLoopInvestigatorActions(t *testing.T) {
 	// submit_findings proposes a reversible and an irreversible action.
 	model := &scriptModel{responses: []providers.CompletionResponse{

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"strings"
 	"time"
@@ -25,6 +26,12 @@ const DefaultBaseURL = "https://api.anthropic.com"
 const (
 	defaultMaxTokens = 4096
 	apiVersion       = "2023-06-01"
+	// responseHeaderTimeout caps the wait for response headers (time-to-first-byte);
+	// the streamed body then has no flat deadline (a long completion is legitimate).
+	responseHeaderTimeout = 2 * time.Minute
+	// idleTimeout aborts a stream that stalls (no bytes) for this long — the streaming
+	// counterpart of an overall deadline, without killing an actively-sending stream.
+	idleTimeout = 2 * time.Minute
 )
 
 // Client is an Anthropic Messages API model provider.
@@ -50,7 +57,7 @@ func New(baseURL, model, apiKey string, maxTokens int) *Client {
 		model:     model,
 		apiKey:    apiKey,
 		maxTokens: maxTokens,
-		http:      httpx.SecureClient(2 * time.Minute),
+		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
 	}
 }
 
@@ -77,6 +84,7 @@ type systemBlock struct {
 type msgRequest struct {
 	Model     string        `json:"model"`
 	MaxTokens int           `json:"max_tokens"`
+	Stream    bool          `json:"stream"`
 	System    []systemBlock `json:"system,omitempty"`
 	Messages  []message     `json:"messages"`
 	Tools     []tool        `json:"tools,omitempty"`
@@ -107,25 +115,48 @@ type tool struct {
 	CacheControl *cacheControl   `json:"cache_control,omitempty"`
 }
 
-type msgResponse struct {
-	Content []block `json:"content"`
-	// StopReason is the turn-termination reason; "max_tokens" marks an output cut off
-	// at the token ceiling (a truncated, not complete, answer).
-	StopReason string `json:"stop_reason"`
-	// Usage carries the per-request token counts; a pointer so an absent block parses
-	// to nil (unknown) rather than a misleading {0,0}.
-	Usage *struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
-	} `json:"usage"`
+// streamEvent is one parsed Anthropic SSE event (the `data:` JSON payload). The
+// Messages stream interleaves: message_start (input usage) → content_block_start /
+// content_block_delta (text_delta text; input_json_delta tool args) /
+// content_block_stop, per block → message_delta (stop_reason + output usage) →
+// message_stop. Only the fields RunLore accumulates are decoded.
+type streamEvent struct {
+	Type    string `json:"type"`
+	Index   int    `json:"index"`
+	Message *struct {
+		Usage *usageDelta `json:"usage"`
+	} `json:"message"`
+	ContentBlock *struct {
+		Type string `json:"type"` // "text" | "tool_use"
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"content_block"`
+	Delta *struct {
+		Type        string `json:"type"` // "text_delta" | "input_json_delta"
+		Text        string `json:"text"`
+		PartialJSON string `json:"partial_json"`
+		StopReason  string `json:"stop_reason"`
+	} `json:"delta"`
+	Usage *usageDelta `json:"usage"`
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error"`
 }
 
-// Complete sends a Messages request with tools and maps the result back.
+// usageDelta carries token counts; input arrives on message_start, output on
+// message_delta (so the two are accumulated from different events).
+type usageDelta struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// Complete sends a streaming Messages request with tools and accumulates the full
+// SSE response into a single CompletionResponse. Streaming is internal — callers see
+// the same one-shot interface; consuming the stream avoids the flat request deadline
+// truncating a long completion and lets a per-block input_json_delta reassemble tool
+// arguments incrementally.
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
-	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Messages: toMessages(req.Messages)}
+	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Stream: true, Messages: toMessages(req.Messages)}
 	if req.System != "" {
 		areq.System = []systemBlock{{Type: "text", Text: req.System, CacheControl: ephemeral}}
 	}
@@ -146,8 +177,12 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
+	// A child context lets the idle-timeout reader abort a stalled stream by cancelling
+	// the in-flight HTTP read; cancel always runs on return to release resources.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	newReq := func() (*http.Request, error) {
-		r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
+		r, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -156,38 +191,111 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		r.Header.Set("x-api-key", c.apiKey)
 		return r, nil
 	}
-	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
+	// DoWithRetry retries only connection establishment / 429 / 5xx (before the stream
+	// begins); once a 200 stream is flowing it is never retried mid-stream.
+	resp, err := httpx.DoWithRetry(streamCtx, c.http, 3, newReq)
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("messages request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("read response: %w", err)
-	}
 	if resp.StatusCode != http.StatusOK {
-		// Don't echo the upstream body into an Error-level log (info disclosure +
-		// log injection); surface status + sanitized request-id for correlation.
+		// Drain a bounded prefix so the connection can be reused, but never echo the
+		// upstream body into an Error-level log (info disclosure + log injection);
+		// surface status + sanitized request-id for correlation.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
 		return providers.CompletionResponse{}, fmt.Errorf("messages status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
 	}
-	var mr msgResponse
-	if err := json.Unmarshal(data, &mr); err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("parse response: %w", err)
-	}
-	if mr.Error != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("anthropic error: %s", mr.Error.Message)
-	}
-	out := providers.CompletionResponse{Truncated: mr.StopReason == "max_tokens"}
-	if mr.Usage != nil {
-		out.Usage = providers.Usage{InputTokens: mr.Usage.InputTokens, OutputTokens: mr.Usage.OutputTokens}
-	}
-	for _, b := range mr.Content {
-		switch b.Type {
-		case "text":
-			out.Text += b.Text
-		case "tool_use":
-			out.ToolCalls = append(out.ToolCalls, providers.ToolCall{ID: b.ID, Name: b.Name, Args: string(b.Input)})
+	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
+	return accumulate(stream)
+}
+
+// sseEvents parses the Anthropic Messages SSE stream into decoded streamEvents. It
+// wraps the generic httpx.SSEData framing primitive and json-unmarshals each event's
+// data payload; a framing/read error or a JSON decode error is surfaced via the
+// second yield value.
+func sseEvents(r io.Reader) iter.Seq2[streamEvent, error] {
+	return func(yield func(streamEvent, error) bool) {
+		for payload, err := range httpx.SSEData(r) {
+			if err != nil {
+				yield(streamEvent{}, err)
+				return
+			}
+			var ev streamEvent
+			if err := json.Unmarshal(payload, &ev); err != nil {
+				if !yield(streamEvent{}, fmt.Errorf("decode sse event: %w", err)) {
+					return
+				}
+				continue
+			}
+			if !yield(ev, nil) {
+				return
+			}
 		}
+	}
+}
+
+// accumulate consumes an Anthropic Messages SSE stream and folds it into one
+// CompletionResponse: text_delta fragments concatenate into Text, input_json_delta
+// fragments per content-block index reassemble each tool_use's JSON args, usage is
+// summed across message_start (input) and message_delta (output), and the
+// message_delta stop_reason maps to StopReason (and Truncated when "max_tokens").
+// A stream that ends before message_stop (a mid-stream drop) is an error.
+func accumulate(r io.Reader) (providers.CompletionResponse, error) {
+	var out providers.CompletionResponse
+	toolArgs := map[int]*strings.Builder{} // content-block index → reassembled JSON
+	toolMeta := map[int]*providers.ToolCall{}
+	var order []int // tool block indices, in first-seen order
+	sawStop := false
+
+	for ev, err := range sseEvents(r) {
+		if err != nil {
+			return providers.CompletionResponse{}, fmt.Errorf("read stream: %w", err)
+		}
+		if ev.Error != nil {
+			return providers.CompletionResponse{}, fmt.Errorf("anthropic error: %s", ev.Error.Message)
+		}
+		switch ev.Type {
+		case "message_start":
+			if ev.Message != nil && ev.Message.Usage != nil {
+				out.Usage.InputTokens = ev.Message.Usage.InputTokens
+			}
+		case "content_block_start":
+			if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
+				toolArgs[ev.Index] = &strings.Builder{}
+				toolMeta[ev.Index] = &providers.ToolCall{ID: ev.ContentBlock.ID, Name: ev.ContentBlock.Name}
+				order = append(order, ev.Index)
+			}
+		case "content_block_delta":
+			if ev.Delta == nil {
+				continue
+			}
+			switch ev.Delta.Type {
+			case "text_delta":
+				out.Text += ev.Delta.Text
+			case "input_json_delta":
+				if b := toolArgs[ev.Index]; b != nil {
+					b.WriteString(ev.Delta.PartialJSON)
+				}
+			}
+		case "message_delta":
+			if ev.Delta != nil && ev.Delta.StopReason != "" {
+				out.StopReason = ev.Delta.StopReason
+				out.Truncated = ev.Delta.StopReason == "max_tokens"
+			}
+			if ev.Usage != nil && ev.Usage.OutputTokens != 0 {
+				out.Usage.OutputTokens = ev.Usage.OutputTokens
+			}
+		case "message_stop":
+			sawStop = true
+		}
+	}
+	if !sawStop {
+		return providers.CompletionResponse{}, fmt.Errorf("stream ended before message_stop (truncated upstream)")
+	}
+	for _, idx := range order {
+		tc := *toolMeta[idx]
+		tc.Args = toolArgs[idx].String()
+		out.ToolCalls = append(out.ToolCalls, tc)
 	}
 	return out, nil
 }

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -37,15 +37,19 @@ type Client struct {
 }
 
 // New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
-func New(baseURL, model, apiKey string) *Client {
+// maxTokens caps output tokens per request; <= 0 falls back to defaultMaxTokens.
+func New(baseURL, model, apiKey string, maxTokens int) *Client {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
+	}
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
 	}
 	return &Client{
 		baseURL:   strings.TrimRight(baseURL, "/"),
 		model:     model,
 		apiKey:    apiKey,
-		maxTokens: defaultMaxTokens,
+		maxTokens: maxTokens,
 		http:      httpx.SecureClient(2 * time.Minute),
 	}
 }

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,29 @@ import (
 )
 
 const maliciousBody = "\n\x1b[2Kfake=record secret=sk-LEAKED-0123456789 level=error msg=\"forged\""
+
+// sseServer returns a test server that writes the given SSE event lines, flushing
+// after each so the client sees a real incremental stream.
+func sseServer(t *testing.T, capture func(*http.Request), events []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			capture(r)
+		}
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("server needs http.Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl.Flush()
+		for _, e := range events {
+			_, _ = io.WriteString(w, e)
+			fl.Flush()
+		}
+	}))
+}
 
 // TestNon2xxErrorOmitsBody asserts a non-2xx response yields an error that
 // excludes the upstream body but includes the status and request-id.
@@ -44,19 +68,66 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}
 }
 
+// TestComplete drives a full Anthropic SSE stream — message_start (input usage),
+// a text content block, a tool_use block assembled from input_json_delta fragments,
+// content_block_stop, message_delta (stop_reason + output usage), message_stop — and
+// asserts the accumulated text, the reassembled tool call, and the request mapping
+// (stream:true + max_tokens + headers + prompt-cache breakpoints).
 func TestComplete(t *testing.T) {
 	var gotReq msgRequest
 	var gotVersion, gotKey string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := sseServer(t, func(r *http.Request) {
 		gotVersion, gotKey = r.Header.Get("anthropic-version"), r.Header.Get("x-api-key")
 		_ = json.NewDecoder(r.Body).Decode(&gotReq)
-		_, _ = w.Write([]byte(`{"content":[
-		  {"type":"text","text":"investigating"},
-		  {"type":"tool_use","id":"tu1","name":"what_changed","input":{"namespace":"apps"}}]}`))
-	}))
+	}, []string{
+		`event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":120,"output_tokens":1}}}
+
+`,
+		`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"investi"}}
+
+`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"gating"}}
+
+`,
+		`event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+`,
+		`event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu1","name":"what_changed","input":{}}}
+
+`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"namespace\":"}}
+
+`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"apps\"}"}}
+
+`,
+		`event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+`,
+		`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":45}}
+
+`,
+		`event: message_stop
+data: {"type":"message_stop"}
+
+`,
+	})
 	defer srv.Close()
 
-	c := New(srv.URL, "claude-x", "k", 0)
+	c := New(srv.URL, "claude-x", "k", 16384)
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -69,8 +140,8 @@ func TestComplete(t *testing.T) {
 	if gotVersion != apiVersion || gotKey != "k" {
 		t.Fatalf("version=%q key=%q", gotVersion, gotKey)
 	}
-	if gotReq.Model != "claude-x" || gotReq.MaxTokens == 0 {
-		t.Fatalf("request: %+v", gotReq)
+	if gotReq.Model != "claude-x" || !gotReq.Stream || gotReq.MaxTokens != 16384 {
+		t.Fatalf("request (want stream:true, max_tokens:16384): %+v", gotReq)
 	}
 	// system is sent as a content-block array carrying a prompt-cache breakpoint
 	if len(gotReq.System) != 1 || gotReq.System[0].Text != "sys" ||
@@ -80,58 +151,67 @@ func TestComplete(t *testing.T) {
 	if len(gotReq.Tools) != 1 || gotReq.Tools[0].Name != "what_changed" || string(gotReq.Tools[0].InputSchema) != `{"type":"object"}` {
 		t.Fatalf("tools: %+v", gotReq.Tools)
 	}
-	// the last tool is the cache breakpoint for the (static) tool schemas
 	if gotReq.Tools[0].CacheControl == nil || gotReq.Tools[0].CacheControl.Type != "ephemeral" {
 		t.Fatalf("last tool should be a cache breakpoint: %+v", gotReq.Tools[0])
 	}
 	if len(gotReq.Messages) != 1 || gotReq.Messages[0].Role != "user" || gotReq.Messages[0].Content[0].Text != "hi" {
 		t.Fatalf("messages: %+v", gotReq.Messages)
 	}
-	// response mapping: text + tool_use
-	if resp.Text != "investigating" || len(resp.ToolCalls) != 1 ||
-		resp.ToolCalls[0].ID != "tu1" || resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
-		t.Fatalf("response: %+v", resp)
+	// response accumulation: text + reassembled tool_use args + usage + stop reason
+	if resp.Text != "investigating" {
+		t.Fatalf("accumulated text = %q, want %q", resp.Text, "investigating")
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "tu1" || resp.ToolCalls[0].Name != "what_changed" ||
+		resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
+		t.Fatalf("tool call: %+v", resp.ToolCalls)
+	}
+	if resp.Usage.InputTokens != 120 || resp.Usage.OutputTokens != 45 {
+		t.Fatalf("usage = %+v, want in=120 out=45", resp.Usage)
+	}
+	if resp.StopReason != "tool_use" {
+		t.Fatalf("StopReason = %q, want tool_use", resp.StopReason)
 	}
 }
 
-// TestUsageAndStopReason verifies the Anthropic usage block and stop_reason are
-// parsed onto CompletionResponse: token counts surface on Usage, and a "max_tokens"
-// stop_reason flags Truncated. A response omitting usage parses to the zero value.
+// TestUsageAndStopReason verifies usage accumulation and stop_reason mapping over a
+// minimal SSE stream: a "max_tokens" stop_reason flags Truncated; "end_turn" does not.
 func TestUsageAndStopReason(t *testing.T) {
 	tests := []struct {
 		name          string
-		body          string
-		wantIn        int
-		wantOut       int
+		stopReason    string
 		wantTruncated bool
 	}{
-		{
-			name:          "usage + end_turn (not truncated)",
-			body:          `{"stop_reason":"end_turn","usage":{"input_tokens":120,"output_tokens":45},"content":[{"type":"text","text":"done"}]}`,
-			wantIn:        120,
-			wantOut:       45,
-			wantTruncated: false,
-		},
-		{
-			name:          "max_tokens stop_reason flags truncation",
-			body:          `{"stop_reason":"max_tokens","usage":{"input_tokens":200,"output_tokens":4096},"content":[{"type":"text","text":"cut off"}]}`,
-			wantIn:        200,
-			wantOut:       4096,
-			wantTruncated: true,
-		},
-		{
-			name:          "usage omitted parses to zero value",
-			body:          `{"stop_reason":"end_turn","content":[{"type":"text","text":"done"}]}`,
-			wantIn:        0,
-			wantOut:       0,
-			wantTruncated: false,
-		},
+		{"end_turn (not truncated)", "end_turn", false},
+		{"max_tokens flags truncation", "max_tokens", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write([]byte(tt.body))
-			}))
+			srv := sseServer(t, nil, []string{
+				`event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":200}}}
+
+`,
+				`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+`,
+				`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"done"}}
+
+`,
+				`event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+`,
+				`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"` + tt.stopReason + `"},"usage":{"output_tokens":4096}}
+
+`,
+				`event: message_stop
+data: {"type":"message_stop"}
+
+`,
+			})
 			defer srv.Close()
 			resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -139,13 +219,84 @@ func TestUsageAndStopReason(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Complete: %v", err)
 			}
-			if resp.Usage.InputTokens != tt.wantIn || resp.Usage.OutputTokens != tt.wantOut {
-				t.Fatalf("usage = %+v, want in=%d out=%d", resp.Usage, tt.wantIn, tt.wantOut)
+			if resp.Usage.InputTokens != 200 || resp.Usage.OutputTokens != 4096 {
+				t.Fatalf("usage = %+v, want in=200 out=4096", resp.Usage)
+			}
+			if resp.Text != "done" {
+				t.Fatalf("text = %q, want done", resp.Text)
 			}
 			if resp.Truncated != tt.wantTruncated {
 				t.Fatalf("Truncated = %v, want %v", resp.Truncated, tt.wantTruncated)
 			}
+			if resp.StopReason != tt.stopReason {
+				t.Fatalf("StopReason = %q, want %q", resp.StopReason, tt.stopReason)
+			}
 		})
+	}
+}
+
+// TestRefusal verifies a stop_reason of "refusal" with no content surfaces as a
+// CompletionResponse that reports Refused()==true.
+func TestRefusal(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		`event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":50}}}
+
+`,
+		`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"refusal"},"usage":{"output_tokens":0}}
+
+`,
+		`event: message_stop
+data: {"type":"message_stop"}
+
+`,
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if !resp.Refused() {
+		t.Fatalf("want Refused()==true for stop_reason refusal, got StopReason=%q", resp.StopReason)
+	}
+	if resp.Text != "" || len(resp.ToolCalls) != 0 {
+		t.Fatalf("refusal must carry no content: text=%q calls=%+v", resp.Text, resp.ToolCalls)
+	}
+}
+
+// TestMidStreamDrop verifies a connection dropped mid-stream (before message_stop)
+// surfaces as an error rather than a silently-truncated success.
+func TestMidStreamDrop(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fl := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Start a message but never finish it; then drop the connection.
+		_, _ = io.WriteString(w, `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":10}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"par`)
+		fl.Flush()
+		// Abruptly close mid-event by hijacking and closing the TCP connection.
+		if hj, ok := w.(http.Hijacker); ok {
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("want an error when the stream is dropped before message_stop")
 	}
 }
 
@@ -153,10 +304,30 @@ func TestUsageAndStopReason(t *testing.T) {
 // separate tool messages) maps to Anthropic's tool_use / coalesced tool_result form.
 func TestMessageCoalescing(t *testing.T) {
 	var gotReq msgRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := sseServer(t, func(r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&gotReq)
-		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"done"}]}`))
-	}))
+	}, []string{
+		`event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}
+
+`,
+		`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"done"}}
+
+`,
+		`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+`,
+		`event: message_stop
+data: {"type":"message_stop"}
+
+`,
+	})
 	defer srv.Close()
 
 	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
@@ -192,10 +363,30 @@ func TestMessageCoalescing(t *testing.T) {
 // still gets exactly one cache breakpoint — on the LAST tool, not every tool.
 func TestPromptCacheToolsOnly(t *testing.T) {
 	var gotReq msgRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := sseServer(t, func(r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&gotReq)
-		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}]}`))
-	}))
+	}, []string{
+		`event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":1}}}
+
+`,
+		`event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+`,
+		`event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}
+
+`,
+		`event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+
+`,
+		`event: message_stop
+data: {"type":"message_stop"}
+
+`,
+	})
 	defer srv.Close()
 
 	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -23,7 +23,7 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -56,7 +56,7 @@ func TestComplete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "claude-x", "k")
+	c := New(srv.URL, "claude-x", "k", 0)
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -133,7 +133,7 @@ func TestUsageAndStopReason(t *testing.T) {
 				_, _ = w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
-			resp, err := New(srv.URL, "claude-x", "k").Complete(context.Background(), providers.CompletionRequest{
+			resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err != nil {
@@ -159,7 +159,7 @@ func TestMessageCoalescing(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "investigate"},
 			{Role: "assistant", ToolCalls: []providers.ToolCall{
@@ -198,7 +198,7 @@ func TestPromptCacheToolsOnly(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 		Tools: []providers.ToolSpec{
 			{Name: "a", Description: "d", Schema: `{"type":"object"}`},

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -25,24 +25,33 @@ import (
 // DefaultBaseURL is the public Gemini API.
 const DefaultBaseURL = "https://generativelanguage.googleapis.com"
 
+// defaultMaxTokens is the output-token ceiling used when the caller passes <= 0.
+const defaultMaxTokens = 8192
+
 // Client is a Gemini (generateContent) model provider.
 type Client struct {
-	baseURL string
-	model   string
-	apiKey  string
-	http    *http.Client
+	baseURL   string
+	model     string
+	apiKey    string
+	maxTokens int
+	http      *http.Client
 }
 
 // New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
-func New(baseURL, model, apiKey string) *Client {
+// maxTokens caps output tokens per request; <= 0 falls back to defaultMaxTokens.
+func New(baseURL, model, apiKey string, maxTokens int) *Client {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		model:   model,
-		apiKey:  apiKey,
-		http:    httpx.SecureClient(2 * time.Minute),
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		model:     model,
+		apiKey:    apiKey,
+		maxTokens: maxTokens,
+		http:      httpx.SecureClient(2 * time.Minute),
 	}
 }
 

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -1,11 +1,16 @@
 // Package gemini implements providers.ModelProvider against the Gemini API
-// (generateContent with native function calling). It maps RunLore's engine-
+// (streamGenerateContent with native function calling). It maps RunLore's engine-
 // agnostic exchange (OpenAI-shaped: assistant tool_calls + separate tool messages)
 // onto Gemini's contents/parts form: assistant turns become role "model" with
 // functionCall parts, and tool results coalesce into one role "user" turn of
 // functionResponse parts. Each call/response carries the originating call id, so
 // parallel calls to the same function name correlate by id (Gemini's rule for
 // parallel calls); when the model returns no id, correlation falls back to name.
+//
+// Streaming is internal: callers see the same one-shot Complete interface, but the
+// request uses :streamGenerateContent?alt=sse and the SSE chunks are accumulated
+// into a single CompletionResponse. Consuming the stream avoids a flat request
+// deadline truncating a long completion.
 package gemini
 
 import (
@@ -14,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"strings"
 	"time"
@@ -25,10 +31,18 @@ import (
 // DefaultBaseURL is the public Gemini API.
 const DefaultBaseURL = "https://generativelanguage.googleapis.com"
 
-// defaultMaxTokens is the output-token ceiling used when the caller passes <= 0.
-const defaultMaxTokens = 8192
+const (
+	// defaultMaxTokens is the output-token ceiling used when the caller passes <= 0.
+	defaultMaxTokens = 8192
+	// responseHeaderTimeout caps the wait for response headers (time-to-first-byte);
+	// the streamed body then has no flat deadline (a long completion is legitimate).
+	responseHeaderTimeout = 2 * time.Minute
+	// idleTimeout aborts a stream that stalls (no bytes) for this long — the streaming
+	// counterpart of an overall deadline, without killing an actively-sending stream.
+	idleTimeout = 2 * time.Minute
+)
 
-// Client is a Gemini (generateContent) model provider.
+// Client is a Gemini (streamGenerateContent) model provider.
 type Client struct {
 	baseURL   string
 	model     string
@@ -51,16 +65,24 @@ func New(baseURL, model, apiKey string, maxTokens int) *Client {
 		model:     model,
 		apiKey:    apiKey,
 		maxTokens: maxTokens,
-		http:      httpx.SecureClient(2 * time.Minute),
+		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
 	}
 }
 
 var _ providers.ModelProvider = (*Client)(nil)
 
 type genRequest struct {
-	SystemInstruction *content  `json:"system_instruction,omitempty"`
-	Contents          []content `json:"contents"`
-	Tools             []tool    `json:"tools,omitempty"`
+	SystemInstruction *content          `json:"system_instruction,omitempty"`
+	Contents          []content         `json:"contents"`
+	Tools             []tool            `json:"tools,omitempty"`
+	GenerationConfig  *generationConfig `json:"generationConfig,omitempty"`
+}
+
+// generationConfig carries per-request decoding controls. MaxOutputTokens caps the
+// output tokens; without it Gemini applies the model's (often small) default and a
+// long completion is silently cut off (a MAX_TOKENS truncation).
+type generationConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty"`
 }
 
 type content struct {
@@ -96,11 +118,16 @@ type functionDeclaration struct {
 	Parameters  json.RawMessage `json:"parameters,omitempty"`
 }
 
+// genResponse is one GenerateContentResponse — the shape of both a full response and
+// each SSE stream chunk (?alt=sse emits one per data: event). Only the fields RunLore
+// accumulates are decoded.
 type genResponse struct {
 	Candidates []struct {
 		Content content `json:"content"`
 		// FinishReason is the candidate-termination reason; "MAX_TOKENS" marks an output
-		// cut off at the token ceiling (a truncated, not complete, answer).
+		// cut off at the token ceiling (a truncated, not complete, answer). Safety stops
+		// (SAFETY, PROHIBITED_CONTENT, BLOCKLIST, SPII) surface raw via StopReason, which
+		// providers.Refused recognizes. It is empty on intermediate stream chunks.
 		FinishReason string `json:"finishReason"`
 	} `json:"candidates"`
 	// UsageMetadata carries the per-request token counts; a pointer so an absent block
@@ -114,9 +141,15 @@ type genResponse struct {
 	} `json:"error"`
 }
 
-// Complete sends a generateContent request with tools and maps the result back.
+// Complete sends a streaming streamGenerateContent request with tools and accumulates
+// the full SSE response into a single CompletionResponse. Streaming is internal —
+// callers see the same one-shot interface; consuming the stream avoids the flat
+// request deadline truncating a long completion.
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
-	greq := genRequest{Contents: toContents(req.Messages)}
+	greq := genRequest{
+		Contents:         toContents(req.Messages),
+		GenerationConfig: &generationConfig{MaxOutputTokens: c.maxTokens},
+	}
 	if req.System != "" {
 		greq.SystemInstruction = &content{Parts: []part{{Text: req.System}}}
 	}
@@ -131,9 +164,15 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
-	url := fmt.Sprintf("%s/v1beta/models/%s:generateContent", c.baseURL, c.model)
+	// ?alt=sse switches streamGenerateContent from a JSON array to a Server-Sent
+	// Events stream: one GenerateContentResponse per data: event, ending at EOF.
+	url := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", c.baseURL, c.model)
+	// A child context lets the idle-timeout reader abort a stalled stream by cancelling
+	// the in-flight HTTP read; cancel always runs on return to release resources.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	newReq := func() (*http.Request, error) {
-		r, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		r, err := http.NewRequestWithContext(streamCtx, http.MethodPost, url, bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -141,52 +180,103 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		r.Header.Set("x-goog-api-key", c.apiKey)
 		return r, nil
 	}
-	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
+	// DoWithRetry retries only connection establishment / 429 / 5xx (before the stream
+	// begins); once a 200 stream is flowing it is never retried mid-stream.
+	resp, err := httpx.DoWithRetry(streamCtx, c.http, 3, newReq)
 	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("generateContent request: %w", err)
+		return providers.CompletionResponse{}, fmt.Errorf("streamGenerateContent request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("read response: %w", err)
-	}
 	if resp.StatusCode != http.StatusOK {
-		// Don't echo the upstream body into an Error-level log (info disclosure +
-		// log injection); surface status + sanitized request-id for correlation.
-		return providers.CompletionResponse{}, fmt.Errorf("generateContent status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
+		// Drain a bounded prefix so the connection can be reused, but never echo the
+		// upstream body into an Error-level log (info disclosure + log injection);
+		// surface status + sanitized request-id for correlation.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
+		return providers.CompletionResponse{}, fmt.Errorf("streamGenerateContent status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
 	}
-	var gr genResponse
-	if err := json.Unmarshal(data, &gr); err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("parse response: %w", err)
-	}
-	if gr.Error != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("gemini error: %s", gr.Error.Message)
-	}
-	out := providers.CompletionResponse{}
-	if gr.UsageMetadata != nil {
-		out.Usage = providers.Usage{InputTokens: gr.UsageMetadata.PromptTokenCount, OutputTokens: gr.UsageMetadata.CandidatesTokenCount}
-	}
-	if len(gr.Candidates) == 0 {
-		return out, nil
-	}
-	out.Truncated = gr.Candidates[0].FinishReason == "MAX_TOKENS"
-	for _, p := range gr.Candidates[0].Content.Parts {
-		switch {
-		case p.FunctionCall != nil:
-			// Newer Gemini responses carry a call id that correlates parallel calls
-			// to the same function; fall back to the name when the id is absent.
-			id := p.FunctionCall.ID
-			if id == "" {
-				id = p.FunctionCall.Name
+	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
+	return accumulate(stream)
+}
+
+// sseEvents parses the Gemini SSE stream into decoded genResponse chunks. It wraps the
+// generic httpx.SSEData framing primitive and json-unmarshals each event's data
+// payload (one full GenerateContentResponse per event); a framing/read error or a JSON
+// decode error is surfaced via the second yield value.
+func sseEvents(r io.Reader) iter.Seq2[genResponse, error] {
+	return func(yield func(genResponse, error) bool) {
+		for payload, err := range httpx.SSEData(r) {
+			if err != nil {
+				yield(genResponse{}, err)
+				return
 			}
-			out.ToolCalls = append(out.ToolCalls, providers.ToolCall{
-				ID:   id,
-				Name: p.FunctionCall.Name,
-				Args: argString(p.FunctionCall.Args),
-			})
-		case p.Text != "":
-			out.Text += p.Text
+			var gr genResponse
+			if err := json.Unmarshal(payload, &gr); err != nil {
+				if !yield(genResponse{}, fmt.Errorf("decode sse event: %w", err)) {
+					return
+				}
+				continue
+			}
+			if !yield(gr, nil) {
+				return
+			}
 		}
+	}
+}
+
+// accumulate consumes a Gemini SSE stream and folds it into one CompletionResponse:
+// text parts concatenate into Text, functionCall parts become ToolCalls (id-correlated,
+// name fallback), usageMetadata is taken last-one-wins, and a candidate finishReason
+// maps to StopReason (and Truncated when "MAX_TOKENS"; safety reasons like "SAFETY"
+// surface raw so providers.Refused recognizes them). A read error, or a stream that
+// ends before any finishReason (a mid-stream drop), is an error.
+func accumulate(r io.Reader) (providers.CompletionResponse, error) {
+	var out providers.CompletionResponse
+	sawFinish := false
+
+	for gr, err := range sseEvents(r) {
+		if err != nil {
+			return providers.CompletionResponse{}, fmt.Errorf("read stream: %w", err)
+		}
+		if gr.Error != nil {
+			return providers.CompletionResponse{}, fmt.Errorf("gemini error: %s", gr.Error.Message)
+		}
+		// usageMetadata accumulates across chunks (last non-nil block wins; Gemini
+		// resends the running totals, so the final chunk carries the full count).
+		if gr.UsageMetadata != nil {
+			out.Usage = providers.Usage{InputTokens: gr.UsageMetadata.PromptTokenCount, OutputTokens: gr.UsageMetadata.CandidatesTokenCount}
+		}
+		if len(gr.Candidates) == 0 {
+			continue
+		}
+		cand := gr.Candidates[0]
+		if cand.FinishReason != "" {
+			sawFinish = true
+			out.StopReason = cand.FinishReason
+			out.Truncated = cand.FinishReason == "MAX_TOKENS"
+		}
+		for _, p := range cand.Content.Parts {
+			switch {
+			case p.FunctionCall != nil:
+				// Newer Gemini responses carry a call id that correlates parallel calls
+				// to the same function; fall back to the name when the id is absent.
+				id := p.FunctionCall.ID
+				if id == "" {
+					id = p.FunctionCall.Name
+				}
+				out.ToolCalls = append(out.ToolCalls, providers.ToolCall{
+					ID:   id,
+					Name: p.FunctionCall.Name,
+					Args: argString(p.FunctionCall.Args),
+				})
+			case p.Text != "":
+				out.Text += p.Text
+			}
+		}
+	}
+	// A stream that ends before any finishReason is a mid-stream drop, not a clean
+	// completion — surface it as an error rather than a silently-truncated success.
+	if !sawFinish {
+		return providers.CompletionResponse{}, fmt.Errorf("stream ended before a finishReason (truncated upstream)")
 	}
 	return out, nil
 }

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -23,7 +23,7 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -57,7 +57,7 @@ func TestComplete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "gemini-x", "k")
+	c := New(srv.URL, "gemini-x", "k", 0)
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -131,7 +131,7 @@ func TestUsageAndFinishReason(t *testing.T) {
 				_, _ = w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
-			resp, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+			resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err != nil {
@@ -158,7 +158,7 @@ func TestToolResultCoalescing(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "investigate"},
 			{Role: "assistant", ToolCalls: []providers.ToolCall{
@@ -202,7 +202,7 @@ func TestParallelSameFunctionCorrelatesByID(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "investigate"},
 			{Role: "assistant", ToolCalls: []providers.ToolCall{
@@ -275,7 +275,7 @@ func TestResponseFunctionCallID(t *testing.T) {
 				_, _ = w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
-			resp, err := New(srv.URL, "gemini-x", "k").Complete(context.Background(), providers.CompletionRequest{
+			resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err != nil {

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,31 @@ import (
 )
 
 const maliciousBody = "\n\x1b[2Kfake=record secret=sk-LEAKED-0123456789 level=error msg=\"forged\""
+
+// sseServer returns a test server that writes the given SSE event lines, flushing
+// after each so the client sees a real incremental stream. Gemini's
+// :streamGenerateContent?alt=sse stream is one JSON GenerateContentResponse per
+// data: event, ending at EOF (no [DONE] sentinel).
+func sseServer(t *testing.T, capture func(*http.Request), events []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			capture(r)
+		}
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("server needs http.Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl.Flush()
+		for _, e := range events {
+			_, _ = io.WriteString(w, e)
+			fl.Flush()
+		}
+	}))
+}
 
 // TestNon2xxErrorOmitsBody asserts a non-2xx response yields an error that
 // excludes the upstream body but includes the status and request-id.
@@ -44,20 +70,28 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}
 }
 
+// TestComplete drives a full Gemini SSE stream — text parts spread across chunks, a
+// functionCall part, and a final chunk carrying finishReason "STOP" + usageMetadata —
+// and asserts the accumulated text, the reassembled tool call, usage, the stop reason,
+// and the request mapping (the request hit :streamGenerateContent with
+// generationConfig.maxOutputTokens set, plus the api-key header).
 func TestComplete(t *testing.T) {
 	var gotReq genRequest
-	var gotKey, gotPath string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var gotKey, gotPath, gotRawQuery string
+	srv := sseServer(t, func(r *http.Request) {
 		gotKey = r.Header.Get("x-goog-api-key")
 		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
 		_ = json.NewDecoder(r.Body).Decode(&gotReq)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[
-		  {"text":"investigating"},
-		  {"functionCall":{"name":"what_changed","args":{"namespace":"apps"}}}]}}]}`))
-	}))
+	}, []string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"investi"}]}}]}` + "\n\n",
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"gating"}]}}]}` + "\n\n",
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"what_changed","args":{"namespace":"apps"}}}]}}]}` + "\n\n",
+		`data: {"candidates":[{"finishReason":"STOP","content":{"role":"model","parts":[]}}],"usageMetadata":{"promptTokenCount":140,"candidatesTokenCount":48}}` + "\n\n",
+	})
 	defer srv.Close()
 
-	c := New(srv.URL, "gemini-x", "k", 0)
+	c := New(srv.URL, "gemini-x", "k", 16384)
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -66,14 +100,20 @@ func TestComplete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	// auth header + URL
+	// auth header + streaming endpoint
 	if gotKey != "k" {
 		t.Fatalf("x-goog-api-key = %q", gotKey)
 	}
-	if !strings.HasSuffix(gotPath, "/v1beta/models/gemini-x:generateContent") {
-		t.Fatalf("path = %q", gotPath)
+	if !strings.HasSuffix(gotPath, "/v1beta/models/gemini-x:streamGenerateContent") {
+		t.Fatalf("path = %q, want a :streamGenerateContent endpoint", gotPath)
 	}
-	// request mapping: system_instruction, tools (functionDeclarations), contents
+	if !strings.Contains(gotRawQuery, "alt=sse") {
+		t.Fatalf("query = %q, want alt=sse", gotRawQuery)
+	}
+	// request mapping: generationConfig.maxOutputTokens, system_instruction, tools, contents
+	if gotReq.GenerationConfig == nil || gotReq.GenerationConfig.MaxOutputTokens != 16384 {
+		t.Fatalf("generationConfig (want maxOutputTokens:16384): %+v", gotReq.GenerationConfig)
+	}
 	if gotReq.SystemInstruction == nil || gotReq.SystemInstruction.Parts[0].Text != "sys" {
 		t.Fatalf("system: %+v", gotReq.SystemInstruction)
 	}
@@ -85,65 +125,100 @@ func TestComplete(t *testing.T) {
 	if len(gotReq.Contents) != 1 || gotReq.Contents[0].Role != "user" || gotReq.Contents[0].Parts[0].Text != "hi" {
 		t.Fatalf("contents: %+v", gotReq.Contents)
 	}
-	// response mapping: text + functionCall → ToolCall (args object → string)
-	if resp.Text != "investigating" || len(resp.ToolCalls) != 1 ||
-		resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
-		t.Fatalf("response: %+v", resp)
+	// response accumulation: text fragments concatenate, functionCall → ToolCall,
+	// usage and stop reason surface.
+	if resp.Text != "investigating" {
+		t.Fatalf("accumulated text = %q, want %q", resp.Text, "investigating")
+	}
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
+		t.Fatalf("tool call: %+v", resp.ToolCalls)
+	}
+	if resp.Usage.InputTokens != 140 || resp.Usage.OutputTokens != 48 {
+		t.Fatalf("usage = %+v, want in=140 out=48", resp.Usage)
+	}
+	if resp.StopReason != "STOP" {
+		t.Fatalf("StopReason = %q, want STOP", resp.StopReason)
+	}
+	if resp.Truncated {
+		t.Fatalf("STOP must not flag Truncated")
 	}
 }
 
-// TestUsageAndFinishReason verifies the Gemini usageMetadata and candidate finishReason
-// are parsed onto CompletionResponse: prompt/candidates token counts surface on Usage, and a
-// "MAX_TOKENS" finishReason flags Truncated. A response omitting usageMetadata parses to zero.
-func TestUsageAndFinishReason(t *testing.T) {
-	tests := []struct {
-		name          string
-		body          string
-		wantIn        int
-		wantOut       int
-		wantTruncated bool
-	}{
-		{
-			name:          "usageMetadata + STOP (not truncated)",
-			body:          `{"candidates":[{"finishReason":"STOP","content":{"role":"model","parts":[{"text":"done"}]}}],"usageMetadata":{"promptTokenCount":140,"candidatesTokenCount":48}}`,
-			wantIn:        140,
-			wantOut:       48,
-			wantTruncated: false,
-		},
-		{
-			name:          "MAX_TOKENS finishReason flags truncation",
-			body:          `{"candidates":[{"finishReason":"MAX_TOKENS","content":{"role":"model","parts":[{"text":"cut off"}]}}],"usageMetadata":{"promptTokenCount":220,"candidatesTokenCount":4096}}`,
-			wantIn:        220,
-			wantOut:       4096,
-			wantTruncated: true,
-		},
-		{
-			name:          "usageMetadata omitted parses to zero value",
-			body:          `{"candidates":[{"finishReason":"STOP","content":{"role":"model","parts":[{"text":"done"}]}}]}`,
-			wantIn:        0,
-			wantOut:       0,
-			wantTruncated: false,
-		},
+// TestTruncation verifies a finishReason of "MAX_TOKENS" flags Truncated and that the
+// last usageMetadata wins across chunks.
+func TestTruncation(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"cut "}]}}],"usageMetadata":{"promptTokenCount":220,"candidatesTokenCount":1}}` + "\n\n",
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"off"}]}}]}` + "\n\n",
+		`data: {"candidates":[{"finishReason":"MAX_TOKENS","content":{"role":"model","parts":[]}}],"usageMetadata":{"promptTokenCount":220,"candidatesTokenCount":4096}}` + "\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write([]byte(tt.body))
-			}))
-			defer srv.Close()
-			resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
-				Messages: []providers.Message{{Role: "user", Content: "hi"}},
-			})
-			if err != nil {
-				t.Fatalf("Complete: %v", err)
-			}
-			if resp.Usage.InputTokens != tt.wantIn || resp.Usage.OutputTokens != tt.wantOut {
-				t.Fatalf("usage = %+v, want in=%d out=%d", resp.Usage, tt.wantIn, tt.wantOut)
-			}
-			if resp.Truncated != tt.wantTruncated {
-				t.Fatalf("Truncated = %v, want %v", resp.Truncated, tt.wantTruncated)
-			}
-		})
+	if resp.Text != "cut off" {
+		t.Fatalf("text = %q, want %q", resp.Text, "cut off")
+	}
+	if !resp.Truncated {
+		t.Fatalf("MAX_TOKENS must flag Truncated")
+	}
+	if resp.StopReason != "MAX_TOKENS" {
+		t.Fatalf("StopReason = %q, want MAX_TOKENS", resp.StopReason)
+	}
+	// last usageMetadata wins
+	if resp.Usage.InputTokens != 220 || resp.Usage.OutputTokens != 4096 {
+		t.Fatalf("usage = %+v, want in=220 out=4096 (last wins)", resp.Usage)
+	}
+}
+
+// TestRefusal verifies a safety finishReason ("SAFETY") with no content surfaces as a
+// CompletionResponse that reports Refused()==true (the raw reason is carried into
+// StopReason, which providers.Refused recognizes).
+func TestRefusal(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		`data: {"candidates":[{"finishReason":"SAFETY","content":{"role":"model","parts":[]}}],"usageMetadata":{"promptTokenCount":50,"candidatesTokenCount":0}}` + "\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if !resp.Refused() {
+		t.Fatalf("want Refused()==true for finishReason SAFETY, got StopReason=%q", resp.StopReason)
+	}
+	if resp.Text != "" || len(resp.ToolCalls) != 0 {
+		t.Fatalf("refusal must carry no content: text=%q calls=%+v", resp.Text, resp.ToolCalls)
+	}
+}
+
+// TestMidStreamDrop verifies a connection dropped mid-stream (before any finishReason
+// is seen) surfaces as an error rather than a silently-truncated success.
+func TestMidStreamDrop(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fl := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Start emitting content but never send a finishReason; then drop the connection.
+		_, _ = io.WriteString(w, `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"par`)
+		fl.Flush()
+		// Abruptly close mid-event by hijacking and closing the TCP connection.
+		if hj, ok := w.(http.Hijacker); ok {
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("want an error when the stream is dropped before a finishReason")
 	}
 }
 
@@ -152,10 +227,11 @@ func TestUsageAndFinishReason(t *testing.T) {
 // functionResponse form, named by the originating call.
 func TestToolResultCoalescing(t *testing.T) {
 	var gotReq genRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := sseServer(t, func(r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&gotReq)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"done"}]}}]}`))
-	}))
+	}, []string{
+		`data: {"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"done"}]}}]}` + "\n\n",
+	})
 	defer srv.Close()
 
 	_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
@@ -196,10 +272,11 @@ func TestToolResultCoalescing(t *testing.T) {
 // originating call's id (not just the shared name), so Gemini maps them correctly.
 func TestParallelSameFunctionCorrelatesByID(t *testing.T) {
 	var gotReq genRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := sseServer(t, func(r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&gotReq)
-		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"done"}]}}]}`))
-	}))
+	}, []string{
+		`data: {"candidates":[{"finishReason":"STOP","content":{"parts":[{"text":"done"}]}}]}` + "\n\n",
+	})
 	defer srv.Close()
 
 	_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
@@ -248,32 +325,37 @@ func TestParallelSameFunctionCorrelatesByID(t *testing.T) {
 }
 
 // TestResponseFunctionCallID verifies the model's functionCall id (newer API) is
-// carried into ToolCall.ID, and that absent id falls back to the function name.
+// carried into ToolCall.ID across the stream, and that an absent id falls back to the
+// function name.
 func TestResponseFunctionCallID(t *testing.T) {
 	tests := []struct {
 		name     string
-		body     string
+		events   []string
 		wantID   string
 		wantName string
 	}{
 		{
-			name:     "id present",
-			body:     `{"candidates":[{"content":{"parts":[{"functionCall":{"id":"call_xyz","name":"what_changed","args":{}}}]}}]}`,
+			name: "id present",
+			events: []string{
+				`data: {"candidates":[{"content":{"parts":[{"functionCall":{"id":"call_xyz","name":"what_changed","args":{}}}]}}]}` + "\n\n",
+				`data: {"candidates":[{"finishReason":"STOP","content":{"parts":[]}}]}` + "\n\n",
+			},
 			wantID:   "call_xyz",
 			wantName: "what_changed",
 		},
 		{
-			name:     "id absent falls back to name",
-			body:     `{"candidates":[{"content":{"parts":[{"functionCall":{"name":"what_changed","args":{}}}]}}]}`,
+			name: "id absent falls back to name",
+			events: []string{
+				`data: {"candidates":[{"content":{"parts":[{"functionCall":{"name":"what_changed","args":{}}}]}}]}` + "\n\n",
+				`data: {"candidates":[{"finishReason":"STOP","content":{"parts":[]}}]}` + "\n\n",
+			},
 			wantID:   "what_changed",
 			wantName: "what_changed",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write([]byte(tt.body))
-			}))
+			srv := sseServer(t, nil, tt.events)
 			defer srv.Close()
 			resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -16,21 +16,30 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
+// defaultMaxTokens is the output-token ceiling used when the caller passes <= 0.
+const defaultMaxTokens = 8192
+
 // Client is an OpenAI-compatible model provider.
 type Client struct {
-	baseURL string
-	model   string
-	apiKey  string
-	http    *http.Client
+	baseURL   string
+	model     string
+	apiKey    string
+	maxTokens int
+	http      *http.Client
 }
 
-// New builds a client. apiKey may be empty (keyless vLLM/Ollama).
-func New(baseURL, model, apiKey string) *Client {
+// New builds a client. apiKey may be empty (keyless vLLM/Ollama). maxTokens caps
+// output tokens per request; <= 0 falls back to defaultMaxTokens.
+func New(baseURL, model, apiKey string, maxTokens int) *Client {
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		model:   model,
-		apiKey:  apiKey,
-		http:    httpx.SecureClient(2 * time.Minute),
+		baseURL:   strings.TrimRight(baseURL, "/"),
+		model:     model,
+		apiKey:    apiKey,
+		maxTokens: maxTokens,
+		http:      httpx.SecureClient(2 * time.Minute),
 	}
 }
 

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -19,6 +19,15 @@ import (
 // defaultMaxTokens is the output-token ceiling used when the caller passes <= 0.
 const defaultMaxTokens = 8192
 
+const (
+	// responseHeaderTimeout caps the wait for response headers (time-to-first-byte);
+	// the streamed body then has no flat deadline (a long completion is legitimate).
+	responseHeaderTimeout = 2 * time.Minute
+	// idleTimeout aborts a stream that stalls (no bytes) for this long — the streaming
+	// counterpart of an overall deadline, without killing an actively-sending stream.
+	idleTimeout = 2 * time.Minute
+)
+
 // Client is an OpenAI-compatible model provider.
 type Client struct {
 	baseURL   string
@@ -39,16 +48,27 @@ func New(baseURL, model, apiKey string, maxTokens int) *Client {
 		model:     model,
 		apiKey:    apiKey,
 		maxTokens: maxTokens,
-		http:      httpx.SecureClient(2 * time.Minute),
+		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
 	}
 }
 
 var _ providers.ModelProvider = (*Client)(nil)
 
 type chatRequest struct {
-	Model    string     `json:"model"`
-	Messages []any      `json:"messages"` // chatMessage | toolMessage
-	Tools    []chatTool `json:"tools,omitempty"`
+	Model     string     `json:"model"`
+	Messages  []any      `json:"messages"` // chatMessage | toolMessage
+	Tools     []chatTool `json:"tools,omitempty"`
+	MaxTokens int        `json:"max_tokens,omitempty"`
+	Stream    bool       `json:"stream"`
+	// StreamOptions asks the server to emit a trailing usage-only chunk on a streamed
+	// response (omitted otherwise, since a non-streaming request rejects it).
+	StreamOptions *streamOptions `json:"stream_options,omitempty"`
+}
+
+// streamOptions toggles streaming extras; include_usage adds a final chunk whose
+// choices array is empty and whose usage block carries the per-request token counts.
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 type chatMessage struct {
@@ -90,24 +110,53 @@ type chatFunction struct {
 	Parameters  json.RawMessage `json:"parameters"`
 }
 
-type chatChoice struct {
-	Message chatMessage `json:"message"`
-	// FinishReason is the choice-termination reason; "length" marks an output cut off
-	// at the token ceiling (a truncated, not complete, answer).
-	FinishReason string `json:"finish_reason"`
-}
-
-type chatResponse struct {
-	Choices []chatChoice `json:"choices"`
-	// Usage carries the per-request token counts; a pointer so an absent block parses
-	// to nil (unknown) rather than a misleading {0,0}.
+// chatChunk is one parsed chat/completions SSE event (the `data:` JSON payload). The
+// stream interleaves: content/tool_call delta chunks (choices[0].delta), a final
+// finish_reason chunk (choices[0].finish_reason), and — with stream_options.
+// include_usage — a trailing usage-only chunk (empty choices, populated usage),
+// followed by a literal `[DONE]` sentinel. Only the accumulated fields are decoded.
+type chatChunk struct {
+	Choices []chunkChoice `json:"choices"`
+	// Usage is the per-request token count, present only on the trailing usage chunk;
+	// a pointer so an absent block parses to nil (unknown) rather than a misleading {0,0}.
 	Usage *struct {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
 	} `json:"usage"`
 }
 
-// Complete sends a chat completion with tools and maps the result back.
+type chunkChoice struct {
+	Delta chunkDelta `json:"delta"`
+	// FinishReason is the choice-termination reason, non-empty only on the final
+	// content chunk; "length" marks an output cut off at the token ceiling.
+	FinishReason string `json:"finish_reason"`
+}
+
+type chunkDelta struct {
+	Content   string          `json:"content"`
+	ToolCalls []chunkToolCall `json:"tool_calls"`
+}
+
+// chunkToolCall is one tool-call fragment. Fragments are keyed by Index: the first
+// fragment for an index carries ID and Function.Name, later fragments carry
+// Function.Arguments string fragments that concatenate into the full JSON args.
+type chunkToolCall struct {
+	Index    int               `json:"index"`
+	ID       string            `json:"id"`
+	Type     string            `json:"type"`
+	Function chunkFunctionCall `json:"function"`
+}
+
+type chunkFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// Complete sends a streaming chat completion with tools and accumulates the full SSE
+// response into a single CompletionResponse. Streaming is internal — callers see the
+// same one-shot interface; consuming the stream avoids the flat request deadline
+// truncating a long completion and lets per-index argument fragments reassemble each
+// tool call's JSON args incrementally.
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
 	msgs := make([]any, 0, len(req.Messages)+1)
 	if req.System != "" {
@@ -135,12 +184,23 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		}})
 	}
 
-	body, err := json.Marshal(chatRequest{Model: c.model, Messages: msgs, Tools: tools})
+	body, err := json.Marshal(chatRequest{
+		Model:         c.model,
+		Messages:      msgs,
+		Tools:         tools,
+		MaxTokens:     c.maxTokens,
+		Stream:        true,
+		StreamOptions: &streamOptions{IncludeUsage: true},
+	})
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
+	// A child context lets the idle-timeout reader abort a stalled stream by cancelling
+	// the in-flight HTTP read; cancel always runs on return to release resources.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	newReq := func() (*http.Request, error) {
-		r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+		r, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -150,37 +210,89 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		}
 		return r, nil
 	}
-	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
+	// DoWithRetry retries only connection establishment / 429 / 5xx (before the stream
+	// begins); once a 200 stream is flowing it is never retried mid-stream.
+	resp, err := httpx.DoWithRetry(streamCtx, c.http, 3, newReq)
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("chat request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("read response: %w", err)
-	}
 	if resp.StatusCode != http.StatusOK {
-		// Do not echo the upstream body: base_url is operator-configurable, so a
-		// misbehaving/compromised proxy could inject arbitrary content into an
-		// Error-level log (info disclosure + log injection). Surface the status and
-		// the upstream request-id (sanitized) for correlation instead.
+		// Drain a bounded prefix so the connection can be reused, but never echo the
+		// upstream body into an Error-level log: base_url is operator-configurable, so a
+		// misbehaving/compromised proxy could inject arbitrary content (info disclosure +
+		// log injection). Surface the status and the upstream request-id (sanitized).
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
 		return providers.CompletionResponse{}, fmt.Errorf("chat status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
 	}
-	var cr chatResponse
-	if err := json.Unmarshal(data, &cr); err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("parse response: %w", err)
+	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
+	return accumulate(stream)
+}
+
+// accumulate consumes an OpenAI chat/completions SSE stream and folds it into one
+// CompletionResponse: content deltas concatenate into Text, tool-call fragments per
+// choice index reassemble each tool call's JSON args (first fragment carries id/name,
+// later carry arguments fragments), the choice finish_reason maps to StopReason (and
+// Truncated when "length"), and the trailing usage-only chunk fills Usage. A read
+// error, or a stream that ends with no finish_reason and no [DONE] (a mid-stream
+// drop), is an error rather than a silently-truncated success.
+func accumulate(r io.Reader) (providers.CompletionResponse, error) {
+	var out providers.CompletionResponse
+	type toolAcc struct {
+		id, name string
+		args     strings.Builder
 	}
-	if len(cr.Choices) == 0 {
-		return providers.CompletionResponse{}, fmt.Errorf("no choices in response")
+	toolByIndex := map[int]*toolAcc{}
+	var order []int // tool-call indices, in first-seen order
+	done := false   // saw the finish_reason and/or the [DONE] terminator
+
+	for payload, err := range httpx.SSEData(r) {
+		if err != nil {
+			return providers.CompletionResponse{}, fmt.Errorf("read stream: %w", err)
+		}
+		if string(bytes.TrimSpace(payload)) == "[DONE]" {
+			done = true
+			break
+		}
+		var ck chatChunk
+		if err := json.Unmarshal(payload, &ck); err != nil {
+			return providers.CompletionResponse{}, fmt.Errorf("decode sse event: %w", err)
+		}
+		if ck.Usage != nil {
+			out.Usage = providers.Usage{InputTokens: ck.Usage.PromptTokens, OutputTokens: ck.Usage.CompletionTokens}
+		}
+		if len(ck.Choices) == 0 {
+			continue // usage-only (or empty) chunk: no delta to fold
+		}
+		choice := ck.Choices[0]
+		out.Text += choice.Delta.Content
+		for _, tc := range choice.Delta.ToolCalls {
+			acc := toolByIndex[tc.Index]
+			if acc == nil {
+				acc = &toolAcc{}
+				toolByIndex[tc.Index] = acc
+				order = append(order, tc.Index)
+			}
+			if tc.ID != "" {
+				acc.id = tc.ID
+			}
+			if tc.Function.Name != "" {
+				acc.name = tc.Function.Name
+			}
+			acc.args.WriteString(tc.Function.Arguments)
+		}
+		if choice.FinishReason != "" {
+			out.StopReason = choice.FinishReason
+			out.Truncated = choice.FinishReason == "length"
+			done = true
+		}
 	}
-	choice := cr.Choices[0]
-	msg := choice.Message
-	out := providers.CompletionResponse{Text: msg.Content, Truncated: choice.FinishReason == "length"}
-	if cr.Usage != nil {
-		out.Usage = providers.Usage{InputTokens: cr.Usage.PromptTokens, OutputTokens: cr.Usage.CompletionTokens}
+	if !done {
+		return providers.CompletionResponse{}, fmt.Errorf("stream ended before finish_reason or [DONE] (truncated upstream)")
 	}
-	for _, tc := range msg.ToolCalls {
-		out.ToolCalls = append(out.ToolCalls, providers.ToolCall{ID: tc.ID, Name: tc.Function.Name, Args: tc.Function.Arguments})
+	for _, idx := range order {
+		acc := toolByIndex[idx]
+		out.ToolCalls = append(out.ToolCalls, providers.ToolCall{ID: acc.id, Name: acc.name, Args: acc.args.String()})
 	}
 	return out, nil
 }

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -36,7 +36,7 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "test-model", "k").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "test-model", "k", 0).Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -74,7 +74,7 @@ func TestComplete(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "test-model", "k")
+	c := New(srv.URL, "test-model", "k", 0)
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -140,7 +140,7 @@ func TestUsageAndFinishReason(t *testing.T) {
 				_, _ = w.Write([]byte(tt.body))
 			}))
 			defer srv.Close()
-			resp, err := New(srv.URL, "test-model", "").Complete(context.Background(), providers.CompletionRequest{
+			resp, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err != nil {
@@ -170,7 +170,7 @@ func TestEmptyToolResultKeepsContent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := New(srv.URL, "test-model", "")
+	c := New(srv.URL, "test-model", "", 0)
 	_, err := c.Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "investigate"},

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -14,16 +14,43 @@ import (
 
 // decodedRequest mirrors chatRequest for test decoding: chatRequest.Messages is
 // []any (mixed chatMessage/toolMessage) on the wire, which round-trips through a
-// typed []chatMessage here for assertions.
+// typed []chatMessage here for assertions. The streaming knobs (stream,
+// max_tokens, stream_options) are decoded too so a test can assert the request.
 type decodedRequest struct {
-	Model    string        `json:"model"`
-	Messages []chatMessage `json:"messages"`
-	Tools    []chatTool    `json:"tools"`
+	Model         string         `json:"model"`
+	Messages      []chatMessage  `json:"messages"`
+	Tools         []chatTool     `json:"tools"`
+	MaxTokens     int            `json:"max_tokens"`
+	Stream        bool           `json:"stream"`
+	StreamOptions *streamOptions `json:"stream_options"`
 }
 
 // maliciousBody is an upstream-controlled error body carrying a secret and a
 // forged log record (newline + ANSI). A non-2xx error must not echo any of it.
 const maliciousBody = "\n\x1b[2Kfake=record secret=sk-LEAKED-0123456789 level=error msg=\"forged\""
+
+// sseServer returns a test server that writes the given SSE event lines, flushing
+// after each so the client sees a real incremental stream.
+func sseServer(t *testing.T, capture func(*http.Request), events []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			capture(r)
+		}
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("server needs http.Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fl.Flush()
+		for _, e := range events {
+			_, _ = io.WriteString(w, e)
+			fl.Flush()
+		}
+	}))
+}
 
 // TestNon2xxErrorOmitsBody asserts a non-2xx response yields an error that
 // excludes the upstream body (no secret, no newline) but includes the status and
@@ -57,24 +84,30 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}
 }
 
+// TestComplete drives a full OpenAI chat/completions SSE stream — content deltas, a
+// tool_call assembled by index (first chunk carries id+name, later chunks carry
+// arguments fragments), a finish_reason chunk, a usage-only chunk, and the [DONE]
+// terminator — and asserts the accumulated text, the reassembled tool call, usage,
+// stop reason, and the request mapping (stream:true + max_tokens + stream_options).
 func TestComplete(t *testing.T) {
 	var gotReq decodedRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "Bearer k" {
-			t.Errorf("auth header = %q, want Bearer k", got)
-		}
-		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
-			t.Errorf("decode request: %v", err)
-		}
-		_ = json.NewEncoder(w).Encode(chatResponse{Choices: []chatChoice{{Message: chatMessage{
-			Role: "assistant",
-			ToolCalls: []chatToolCall{{ID: "tc1", Type: "function", Function: chatFunctionCall{
-				Name: "what_changed", Arguments: `{"namespace":"apps"}`}}},
-		}}}})
-	}))
+	var gotAuth string
+	srv := sseServer(t, func(r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+	}, []string{
+		`data: {"choices":[{"index":0,"delta":{"role":"assistant","content":"investi"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"content":"gating"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"tc1","type":"function","function":{"name":"what_changed","arguments":""}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"namespace\":"}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"apps\"}"}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":120,"completion_tokens":45}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
 	defer srv.Close()
 
-	c := New(srv.URL, "test-model", "k", 0)
+	c := New(srv.URL, "test-model", "k", 16384)
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -85,8 +118,17 @@ func TestComplete(t *testing.T) {
 	}
 
 	// request mapping
+	if gotAuth != "Bearer k" {
+		t.Fatalf("auth header = %q, want Bearer k", gotAuth)
+	}
 	if gotReq.Model != "test-model" {
 		t.Fatalf("model = %q", gotReq.Model)
+	}
+	if !gotReq.Stream || gotReq.MaxTokens != 16384 {
+		t.Fatalf("request (want stream:true, max_tokens:16384): %+v", gotReq)
+	}
+	if gotReq.StreamOptions == nil || !gotReq.StreamOptions.IncludeUsage {
+		t.Fatalf("request must set stream_options.include_usage: %+v", gotReq.StreamOptions)
 	}
 	if len(gotReq.Messages) != 2 || gotReq.Messages[0].Role != "system" || gotReq.Messages[1].Content != "hi" {
 		t.Fatalf("messages mapped wrong: %+v", gotReq.Messages)
@@ -94,65 +136,100 @@ func TestComplete(t *testing.T) {
 	if len(gotReq.Tools) != 1 || gotReq.Tools[0].Function.Name != "what_changed" {
 		t.Fatalf("tools mapped wrong: %+v", gotReq.Tools)
 	}
-	// response mapping
+
+	// response accumulation: text + reassembled tool call args + usage + stop reason
+	if resp.Text != "investigating" {
+		t.Fatalf("accumulated text = %q, want %q", resp.Text, "investigating")
+	}
 	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "tc1" ||
 		resp.ToolCalls[0].Name != "what_changed" || resp.ToolCalls[0].Args != `{"namespace":"apps"}` {
-		t.Fatalf("response tool calls mapped wrong: %+v", resp.ToolCalls)
+		t.Fatalf("tool call: %+v", resp.ToolCalls)
+	}
+	if resp.Usage.InputTokens != 120 || resp.Usage.OutputTokens != 45 {
+		t.Fatalf("usage = %+v, want in=120 out=45", resp.Usage)
+	}
+	if resp.StopReason != "tool_calls" {
+		t.Fatalf("StopReason = %q, want tool_calls", resp.StopReason)
 	}
 }
 
-// TestUsageAndFinishReason verifies the OpenAI usage block and choice finish_reason
-// are parsed onto CompletionResponse: prompt/completion tokens surface on Usage, and a
-// "length" finish_reason flags Truncated. A response omitting usage parses to the zero value.
-func TestUsageAndFinishReason(t *testing.T) {
-	tests := []struct {
-		name          string
-		body          string
-		wantIn        int
-		wantOut       int
-		wantTruncated bool
-	}{
-		{
-			name:          "usage + stop (not truncated)",
-			body:          `{"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"done"}}],"usage":{"prompt_tokens":130,"completion_tokens":42}}`,
-			wantIn:        130,
-			wantOut:       42,
-			wantTruncated: false,
-		},
-		{
-			name:          "length finish_reason flags truncation",
-			body:          `{"choices":[{"finish_reason":"length","message":{"role":"assistant","content":"cut off"}}],"usage":{"prompt_tokens":210,"completion_tokens":4096}}`,
-			wantIn:        210,
-			wantOut:       4096,
-			wantTruncated: true,
-		},
-		{
-			name:          "usage omitted parses to zero value",
-			body:          `{"choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"done"}}]}`,
-			wantIn:        0,
-			wantOut:       0,
-			wantTruncated: false,
-		},
+// TestTruncation verifies a finish_reason of "length" flags Truncated while the
+// content accumulated so far is preserved.
+func TestTruncation(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"cut off"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"length"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":210,"completion_tokens":4096}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				_, _ = w.Write([]byte(tt.body))
-			}))
-			defer srv.Close()
-			resp, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
-				Messages: []providers.Message{{Role: "user", Content: "hi"}},
-			})
-			if err != nil {
-				t.Fatalf("Complete: %v", err)
-			}
-			if resp.Usage.InputTokens != tt.wantIn || resp.Usage.OutputTokens != tt.wantOut {
-				t.Fatalf("usage = %+v, want in=%d out=%d", resp.Usage, tt.wantIn, tt.wantOut)
-			}
-			if resp.Truncated != tt.wantTruncated {
-				t.Fatalf("Truncated = %v, want %v", resp.Truncated, tt.wantTruncated)
-			}
-		})
+	if resp.Text != "cut off" {
+		t.Fatalf("text = %q, want %q", resp.Text, "cut off")
+	}
+	if !resp.Truncated {
+		t.Fatalf("Truncated = false, want true for finish_reason length")
+	}
+	if resp.StopReason != "length" {
+		t.Fatalf("StopReason = %q, want length", resp.StopReason)
+	}
+	if resp.Usage.InputTokens != 210 || resp.Usage.OutputTokens != 4096 {
+		t.Fatalf("usage = %+v, want in=210 out=4096", resp.Usage)
+	}
+}
+
+// TestRefusal verifies a finish_reason of "content_filter" with no content surfaces
+// as a CompletionResponse that reports Refused()==true.
+func TestRefusal(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":50,"completion_tokens":0}}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if !resp.Refused() {
+		t.Fatalf("want Refused()==true for finish_reason content_filter, got StopReason=%q", resp.StopReason)
+	}
+	if resp.Text != "" || len(resp.ToolCalls) != 0 {
+		t.Fatalf("refusal must carry no content: text=%q calls=%+v", resp.Text, resp.ToolCalls)
+	}
+}
+
+// TestMidStreamDrop verifies a connection dropped mid-stream (before any
+// finish_reason and before [DONE]) surfaces as an error rather than a
+// silently-truncated success.
+func TestMidStreamDrop(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fl := w.(http.Flusher)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		// Start emitting content but never send a finish_reason or [DONE].
+		_, _ = io.WriteString(w, `data: {"choices":[{"index":0,"delta":{"content":"par`)
+		fl.Flush()
+		// Abruptly close mid-event by hijacking and closing the TCP connection.
+		if hj, ok := w.(http.Hijacker); ok {
+			conn, _, _ := hj.Hijack()
+			_ = conn.Close()
+		}
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("want an error when the stream is dropped before a finish_reason / [DONE]")
 	}
 }
 
@@ -163,11 +240,14 @@ func TestUsageAndFinishReason(t *testing.T) {
 // raw request body the server receives, since the typed struct hides the omission.
 func TestEmptyToolResultKeepsContent(t *testing.T) {
 	var rawBody string
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := sseServer(t, func(r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		rawBody = string(b)
-		_ = json.NewEncoder(w).Encode(chatResponse{Choices: []chatChoice{{Message: chatMessage{Role: "assistant", Content: "ok"}}}})
-	}))
+	}, []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	})
 	defer srv.Close()
 
 	c := New(srv.URL, "test-model", "", 0)

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -434,6 +434,32 @@ type CompletionResponse struct {
 	// Gemini finishReason "MAX_TOKENS"). It distinguishes a cut-off answer from a
 	// complete one, so the loop need not treat a truncated reply as final.
 	Truncated bool
+	// StopReason is the provider's raw turn-termination reason, normalized to the
+	// provider's own vocabulary (Anthropic stop_reason, OpenAI finish_reason, Gemini
+	// finishReason). It is empty when the provider omits it. Refused() interprets it;
+	// the loop uses Refused() rather than matching strings itself.
+	StopReason string
+}
+
+// refusalStopReasons is the set of stop reasons (across providers, lower-cased) that
+// mean the model declined the request on safety/policy grounds rather than producing
+// an answer. Anthropic emits "refusal"; OpenAI "content_filter"; Gemini "SAFETY",
+// "PROHIBITED_CONTENT", "BLOCKLIST", "SPII".
+var refusalStopReasons = map[string]bool{
+	"refusal":            true,
+	"content_filter":     true,
+	"safety":             true,
+	"prohibited_content": true,
+	"blocklist":          true,
+	"spii":               true,
+}
+
+// Refused reports whether the model declined the request on safety/policy grounds
+// (a successful response with no usable answer) rather than terminating normally.
+// The comparison is case-insensitive so a provider's casing (e.g. Gemini's "SAFETY")
+// does not matter. The loop treats a refusal as a first-class unresolved outcome.
+func (r CompletionResponse) Refused() bool {
+	return refusalStopReasons[strings.ToLower(r.StopReason)]
 }
 
 // Usage is the provider-reported token accounting for one completion.

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -6,6 +6,27 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
+// TestCompletionResponseRefused locks in the refusal classification: a safety/policy
+// stop reason (case-insensitive) reports Refused()==true; a normal termination
+// (end_turn/stop/length/max_tokens) or an empty reason reports false.
+func TestCompletionResponseRefused(t *testing.T) {
+	refused := []string{
+		"refusal", "content_filter", "safety", "prohibited_content", "blocklist", "spii",
+		"Refusal", "CONTENT_FILTER", "Safety", "SPII", // case-insensitive
+	}
+	for _, sr := range refused {
+		if !(providers.CompletionResponse{StopReason: sr}).Refused() {
+			t.Errorf("StopReason %q should report Refused()==true", sr)
+		}
+	}
+	notRefused := []string{"end_turn", "stop", "max_tokens", "length", "MAX_TOKENS", "tool_use", ""}
+	for _, sr := range notRefused {
+		if (providers.CompletionResponse{StopReason: sr}).Refused() {
+			t.Errorf("StopReason %q should report Refused()==false", sr)
+		}
+	}
+}
+
 func TestFingerprintMarkerRoundTrip(t *testing.T) {
 	const fp = "abc123def456"
 	body := "Drafted by RunLore — x\n\n" + providers.FingerprintMarker(fp)


### PR DESCRIPTION

  ## What
  Adds internal streaming, a configurable `max_tokens`, and refusal/safety handling to all three LLM providers — **without changing the `ModelProvider.Complete` interface** (streaming is internal: each provider streams the SSE response and accumulates it). Spec + plan: `dev/superpowers/{specs,plans}/2026-06-29-model-layer-streaming-refusal.md`.

  ## Changes
  - **Streaming (internal):** Anthropic `/v1/messages`, OpenAI `/chat/completions`, and Gemini `:streamGenerateContent?alt=sse` now stream + accumulate via a shared `httpx.SSEData` framing primitive and a `SecureStreamingClient` (SSRF guard kept; the flat 2-min deadline replaced by a header/idle timeout so long completions aren't truncated). Tool-call args reassemble from per-fragment deltas; a mid-stream drop is a hard
  error, not a silent truncation.
  - **`max_tokens`:** new optional `model.max_tokens` (default 8192; `model.verify` inherits). Sent to all three providers (Anthropic `max_tokens`, OpenAI `max_tokens`, Gemini `generationConfig.maxOutputTokens`).
  - **Refusal/safety:** new `CompletionResponse.StopReason` + `Refused()` (Anthropic `refusal`, OpenAI `content_filter`, Gemini `SAFETY`/`PROHIBITED_CONTENT`/…). The investigation loop turns a refusal into a first-class **`unresolved`** outcome with a note — no burned nudge, no retry storm.

  ## Verified
  `go build` · `go vet` · `gofmt -l` clean · **`go test -race ./...` → 43 packages, 0 failures**. New table-driven SSE tests per provider (full-stream accumulation, truncation, refusal, mid-stream-drop) + a loop refusal→unresolved test. `golangci-lint` wasn't run locally (not installed here) — CI gates it.

  ## Notes
  - Preserved: Anthropic prompt-cache breakpoints, OpenAI tool-message `content` (vLLM/Ollama), Gemini functionCall id-correlation, and non-2xx error-body omission across all providers.
  - Deferred (out of scope): adaptive thinking/effort, `count_tokens` budgeting, `cache_read` parsing, cost telemetry.
