### PR TITLE
  feat(release): build multi-arch image via GoReleaser; slim build-image.yml to PR/main validation

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,9 +1,16 @@
 name: Build Image
 
+# Validation-only image workflow. GoReleaser (release-binaries.yml) owns the
+# release/multi-arch image on v* tags — this workflow deliberately does NOT trigger
+# on tags, to avoid double-building the release image. Here we only:
+#   - PR  -> build the image single-arch (amd64), do NOT push, gate on a Trivy fs scan.
+#   - push to main -> build + push a rolling :main amd64 image, then Trivy image scan.
+# Single-arch amd64 is sufficient for validation: the target clusters run amd64 and
+# arm64-under-QEMU dominated CI time (~10x slower Go compile). The release image is
+# multi-arch via GoReleaser.
 on:
   push:
     branches: [main]
-    tags: ['v*']
     paths:
       - '**.go'
       - 'go.mod'
@@ -28,22 +35,21 @@ env:
 
 # Serialize builds per ref so concurrent pushes can't race on the mutable :main
 # tag (last-to-finish wins, which silently published a stale image). PR builds are
-# superseded — cancel the in-flight one; branch/tag pushes each run to completion.
+# superseded — cancel the in-flight one; the main push runs to completion.
 concurrency:
   group: build-image-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build-and-push:
-    name: Build and push
+  build:
+    name: Build and validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Push the rolling :main image (only used on main pushes; harmless on PRs).
       packages: write
+      # Upload the Trivy SARIF to the GitHub Security tab (main pushes only).
       security-events: write
-      # Keyless cosign signing: the OIDC token identifies this workflow to Fulcio,
-      # which issues the short-lived signing certificate. No long-lived keys.
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -59,77 +65,50 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            # Branch-prefixed SHA tag only on branch PUSHES (empty on tags/PRs →
-            # invalid ":-<sha>"): the metadata action leaves {{branch}} empty there,
-            # which would emit the invalid tag ":-<sha>" (a tag cannot start with
-            # "-") and fail the build. `ref_type` is 'branch' on pull_request events
-            # too, so gate on event_name=push to actually exclude PRs.
-            type=sha,prefix={{branch}}-,enable=${{ github.event_name == 'push' && github.ref_type == 'branch' }}
-            # Always provide an immutable SHA tag (valid in every event context).
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
+      # Compute the lowercase :main reference once. ghcr/OCI refs must be lowercase,
+      # but github.repository_owner can contain uppercase (e.g. "Smana").
+      - name: Compute image ref
+        id: ref
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: echo "image=${IMAGE,,}:main" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push
-        id: build
+      # PR: build single-arch amd64 without pushing — keep it fast. The in-image Go
+      # compile (multi-stage Dockerfile) on amd64 is fine here; the Trivy fs scan
+      # below is the actual merge gate.
+      - name: Build (PR, no push)
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: ./Dockerfile
-          # amd64-only: the target clusters run amd64 nodes, and arm64 under QEMU
-          # emulation dominated build time (~10x slower Go compile). Reintroduce via
-          # a native-arm runner matrix + manifest merge if multi-arch is needed.
           platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+          push: false
+          load: true
+          tags: ${{ steps.ref.outputs.image }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # Buildx-native supply-chain attestations, pushed alongside the image:
-          #   provenance mode=max -> full SLSA build provenance (build steps + materials)
-          #   sbom: true          -> SPDX SBOM attestation generated from the build
-          # These are attached as OCI referrers to the pushed digest; cosign signs
-          # the same digest below.
-          provenance: mode=max
-          sbom: true
 
-      # Keyless image signing. Only runs when the image was actually pushed
-      # (digest is empty on pull_request). cosign uses the job's OIDC token to
-      # get a short-lived Fulcio cert and records the signature in Rekor.
-      - name: Install cosign
+      # main push: build + push the rolling :main amd64 image.
+      - name: Build and push (:main)
+        id: build
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign image with cosign (keyless)
-        if: github.event_name != 'pull_request'
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        # Sign by immutable digest, not a mutable tag, so the signature can't be
-        # repointed later. ghcr/OCI references must be lowercase, but
-        # github.repository_owner can contain uppercase (e.g. "Smana"), so lowercase
-        # the image name before signing.
-        run: |
-          image="${REGISTRY}/${IMAGE_NAME}"
-          cosign sign --yes "${image,,}@${DIGEST}"
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.ref.outputs.image }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # PR gate: the image isn't pushed on pull_request, so scan the filesystem
-      # (Go module graph + Dockerfile/config) and FAIL the job on HIGH/CRITICAL
-      # so a vulnerable dependency or misconfig can't merge. Post-publish runs
-      # get the image-level scan below instead.
+      # (Go module graph + Dockerfile/config) and FAIL the job on HIGH/CRITICAL so a
+      # vulnerable dependency or misconfig can't merge.
       - name: Trivy filesystem scan (PR gate)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -138,19 +117,20 @@ jobs:
           ignore-unfixed: true
           exit-code: '1'
 
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+      # main push: scan the pushed image and report findings to the Security tab.
+      - name: Trivy image scan
         if: github.event_name != 'pull_request'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: '${{ fromJSON(steps.meta.outputs.json).tags[0] }}'
+          image-ref: ${{ steps.ref.outputs.image }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
 
       - name: Upload Trivy results to GitHub Security
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: github.event_name != 'pull_request'
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-runlore'
@@ -159,22 +139,19 @@ jobs:
         if: always()
         run: |
           {
-            echo "## 🏗️ RunLore Image Build"
+            echo "## RunLore Image Build (validation)"
             echo ""
             echo "**Trigger**: ${{ github.event_name }}"
             echo "**Commit**: \`${{ github.sha }}\`"
             echo "**Platforms**: linux/amd64"
             echo ""
-            echo "**Tags**:"
-            echo '```'
-            echo "${{ steps.meta.outputs.tags }}"
-            echo '```'
             if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-              echo "**Pushed to**: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`"
+              echo "**Pushed**: \`${{ steps.ref.outputs.image }}\`"
               echo "**Digest**: \`${{ steps.build.outputs.digest }}\`"
-              echo "**Security scan**: ✅ Trivy (HIGH, CRITICAL)"
-              echo "**Supply chain**: ✅ cosign signature + SLSA provenance + SBOM attestation"
+              echo "**Security scan**: Trivy image (HIGH, CRITICAL) -> Security tab"
             else
-              echo "_PR build — image built for validation, not pushed._"
+              echo "_PR build - image built single-arch for validation, not pushed. Trivy fs scan gates the merge._"
             fi
+            echo ""
+            echo "_The release/multi-arch image is built and signed by GoReleaser on v* tags._"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,11 +1,17 @@
-name: Release Binaries
+name: Release
 
 # Triggered by the v* tag itself, not by release-please's release_created output.
-# release-please creates the v* tag via its PAT, which fires both this workflow and
-# build-image. Decoupling from release_created means re-pointing an existing tag
-# (a re-cut) rebuilds the artifacts; release-please already created the GitHub
-# release and .goreleaser.yaml uses release.mode: keep-existing, so GoReleaser only
-# uploads assets to it.
+# release-please creates the v* tag via its PAT, which fires this workflow.
+# Decoupling from release_created means re-pointing an existing tag (a re-cut)
+# rebuilds the artifacts; release-please already created the GitHub release and
+# .goreleaser.yaml uses release.mode: keep-existing, so GoReleaser only uploads
+# assets to it.
+#
+# GoReleaser produces the full release here: the signed cross-platform `lore`
+# binaries/archives/checksums AND the signed multi-arch (amd64+arm64) container
+# image — built, pushed to ghcr.io/smana/runlore, fused into a manifest, cosign
+# keyless-signed, and shipped with SLSA provenance + SBOM attestations.
+# build-image.yml now only validates PR/main builds (no release builds).
 on:
   push:
     tags: ['v*']
@@ -17,8 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # Keyless cosign signing of the checksums file: the OIDC token identifies this
-      # workflow to Fulcio, which issues the short-lived signing certificate.
+      # Push the container image + attestations to GHCR (GitHub Packages).
+      packages: write
+      # Keyless cosign signing of the checksums file and the image manifest: the
+      # OIDC token identifies this workflow to Fulcio, which issues the short-lived
+      # signing certificate.
       id-token: write
     steps:
       - name: Checkout
@@ -31,6 +40,18 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
+
+      - name: Set up Docker Buildx
+        # Required for the goreleaser `dockers` entries (use: buildx) and their
+        # buildx-native --provenance / --sbom attestations.
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -46,5 +67,6 @@ jobs:
           args: release --clean
         env:
           # Default token is enough: the release for this tag already exists (created
-          # by release-please) and GoReleaser only uploads assets to it.
+          # by release-please) and GoReleaser only uploads assets to it; packages:
+          # write above lets the same token push the image to GHCR.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,9 @@
-# GoReleaser builds and publishes the signed cross-platform `lore` binaries.
-# Scope: BINARIES ONLY. The container image is built and signed separately by
-# .github/workflows/build-image.yml on the same v* tag, and CHANGELOG.md is owned
-# by release-please — so docker and changelog are deliberately absent here.
+# GoReleaser builds and publishes the signed cross-platform `lore` binaries AND the
+# signed multi-arch (linux/amd64 + linux/arm64) container image on each v* tag.
+# The same goreleaser-built `lore` binary ships in the archives and the image, so
+# there is no version-skew hazard between them.
+# Scope here: binaries + image. CHANGELOG.md is owned by release-please (changelog is
+# disabled below). build-image.yml only does PR/main validation, not release builds.
 # Docs: https://goreleaser.com
 version: 2
 
@@ -20,8 +22,9 @@ builds:
     goarch:
       - amd64
       - arm64
-    # MUST stay in sync with the Dockerfile / build-image.yml ldflags so the binary
-    # and the image report the same version (`-X main.version`, see cmd/lore/main.go).
+    # Stamps the version into the binary (`-X main.version`, see cmd/lore/main.go).
+    # This same binary is what the dockers step COPYs into the image, so the archive
+    # and the image always report an identical version.
     ldflags:
       - -s -w -X main.version={{.Version}}
 
@@ -66,6 +69,80 @@ signs:
     # cosign writes a single ${artifact}.bundle; tell GoReleaser to publish THAT as
     # the signature artifact (its default is the now-nonexistent ${artifact}.sig).
     signature: "${artifact}.bundle"
+    output: true
+
+# Multi-arch container image. One `dockers` entry per architecture builds a
+# single-platform image from the prebuilt `lore` binary (no in-image compile —
+# Dockerfile.goreleaser is COPY-only), tagged with an arch suffix. `docker_manifests`
+# then fuses the two into the user-facing multi-arch tags. ghcr/OCI refs MUST be
+# lowercase, so the owner is written `smana` (the GitHub repo is github.com/Smana).
+dockers:
+  - id: lore-amd64
+    use: buildx
+    goos: linux
+    goarch: amd64
+    ids:
+      - lore
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      # Buildx-native supply-chain attestations attached to the image:
+      #   provenance mode=max -> full SLSA build provenance (steps + materials)
+      #   sbom=true           -> SPDX SBOM attestation generated from the build
+      - "--provenance=mode=max"
+      - "--sbom=true"
+      - "--label=org.opencontainers.image.source=https://github.com/Smana/runlore"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+  - id: lore-arm64
+    use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+      - lore
+    dockerfile: Dockerfile.goreleaser
+    image_templates:
+      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--provenance=mode=max"
+      - "--sbom=true"
+      - "--label=org.opencontainers.image.source=https://github.com/Smana/runlore"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+
+# Fuse the two per-arch images into the final multi-arch tags. Each manifest list
+# references the arch-suffixed images built above.
+docker_manifests:
+  - name_template: "ghcr.io/smana/runlore:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
+      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/smana/runlore:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
+      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/smana/runlore:latest"
+    image_templates:
+      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
+      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
+
+# Keyless (Sigstore) cosign signing of the multi-arch manifest lists, by digest.
+# Runs under the job's id-token: write, so cosign gets a short-lived Fulcio cert
+# from the OIDC token and records the signature in Rekor — no long-lived keys.
+# `artifacts: manifests` signs the manifest list (not each per-arch image); cosign's
+# recursive verification still covers the referenced per-arch images.
+docker_signs:
+  - artifacts: manifests
+    cmd: cosign
+    args:
+      - "sign"
+      - "--yes"
+      - "${artifact}"
     output: true
 
 # release-please owns CHANGELOG.md; don't let GoReleaser generate its own.

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,12 @@
+# COPY-only image for GoReleaser. The `lore` binary is cross-compiled by the
+# `builds.id: lore` step (linux/amd64 + linux/arm64, CGO_ENABLED=0) and placed by
+# GoReleaser at the build-context root for the matching --platform, so there is no
+# build stage here — we only assemble the runtime layer. Mirrors the runtime stage
+# of ./Dockerfile (used by build-image.yml for PR/main validation).
+FROM gcr.io/distroless/static:nonroot
+LABEL org.opencontainers.image.source="https://github.com/Smana/runlore"
+COPY lore /usr/local/bin/lore
+USER 65532:65532
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/lore"]
+CMD ["serve"]


### PR DESCRIPTION
  ## What
  Moves the multi-arch container image into **GoReleaser** (which already cross-compiles amd64+arm64), and slims `build-image.yml` to PR/main validation. Supersedes the separate native-runner matrix approach (#172).

  - **`.goreleaser.yaml`**: `dockers:` (per-arch, `use: buildx`, COPY the prebuilt binary via the new COPY-only `Dockerfile.goreleaser`), `docker_manifests:` (`:{version}`, `:{major}.{minor}`, `:latest`), `docker_signs:` (cosign keyless, by digest). The image now ships the **exact** released binary — eliminating the Dockerfile↔goreleaser ldflags-sync hazard the config used to warn about.
  - **`release-binaries.yml`** → renamed **Release**; adds `packages: write` + GHCR login + buildx; now produces the binaries **and** the signed multi-arch image on `v*` tags.
  - **`build-image.yml`** → validation only: PR builds amd64 (no push) + Trivy fs gate; main push builds + pushes a rolling lowercase `:main` + Trivy image scan. Dropped the `v*` trigger so the release image isn't built twice.

  ## Verified
  `goreleaser check` ✓ · `actionlint` (both workflows) ✓ · no double image-build on tags · all OCI refs lowercase `ghcr.io/smana/runlore`.

  ## ⚠️ Verify on first release
  Image-level **provenance/SBOM attestations** (`--provenance=mode=max --sbom=true`) pass `goreleaser check`, but buildx only persists them through GoReleaser's `--load` build if the runner uses the **containerd image store** (otherwise they're dropped with a warning). cosign **signing** of the manifest is unaffected. On the first `v*` release, confirm with `docker buildx imagetools inspect ghcr.io/smana/runlore:<ver>`; if
  attestations are absent, enable the containerd snapshotter on the runner (or migrate to `dockers_v2`).