### PR TITLE
  fix(redact): mask base64 data values in kind: Secret manifests

### DIFF
--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -10,7 +10,10 @@
 // not a substitute for not logging secrets.
 package redact
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 const mask = "[REDACTED]"
 
@@ -68,5 +71,123 @@ func Secrets(s string) string {
 	for _, r := range rules {
 		s = r.re.ReplaceAllString(s, r.repl)
 	}
-	return s
+	return k8sSecretData(s)
+}
+
+// diffPrefixRE matches an optional git-diff line marker ("+ ", "- ", or a single
+// leading space used for context lines). It is captured so the marker can be
+// preserved while the YAML body is inspected/rewritten.
+var diffPrefixRE = regexp.MustCompile(`^([+\- ]?)(.*)$`)
+
+// docMarkerRE matches a YAML document separator ("---", possibly trailing
+// content) after any diff marker has been stripped.
+var docMarkerRE = regexp.MustCompile(`^---(\s.*)?$`)
+
+// kindSecretRE matches a top-level `kind: Secret` line (with optional quoting),
+// after any diff marker has been stripped. It deliberately anchors at the start
+// of the (de-marked) line so an inner "kind:" value cannot trip it.
+var kindSecretRE = regexp.MustCompile(`^kind:\s*["']?Secret["']?\s*$`)
+
+// kindAnyRE matches any top-level `kind:` line, used to detect a switch to a
+// non-Secret document.
+var kindAnyRE = regexp.MustCompile(`^kind:\s*\S`)
+
+// dataKeyRE matches a `data:` or `stringData:` mapping key (no inline value),
+// capturing its indentation. Anchored after diff-marker stripping.
+var dataKeyRE = regexp.MustCompile(`^(\s*)(?:data|stringData):\s*$`)
+
+// dataEntryRE matches a `  key: value` mapping entry inside a data block,
+// capturing indentation, the "key:" portion, and the value. Block scalars
+// (`key: |` / `key: >`) are handled separately so their following lines are
+// masked too.
+var dataEntryRE = regexp.MustCompile(`^(\s*)([^\s:][^:]*:\s*)(\S.*)$`)
+
+// k8sSecretData performs a line-oriented pass that masks the VALUES under a
+// `data:`/`stringData:` block of a `kind: Secret` document, preserving keys and
+// all surrounding structure. Non-Secret documents (e.g. kind: ConfigMap) are
+// left untouched. It tolerates git-diff line markers ("+ ", "- ", leading
+// space) because a Secret most often surfaces inside a `what_changed` diff.
+//
+// A data block ends at: a dedent to a column <= the data key's indent, a new
+// top-level key, a `kind:` line, or a YAML document separator ("---"). The pass
+// is idempotent: once a value is the mask string it stays the mask string.
+func k8sSecretData(s string) string {
+	if !strings.Contains(s, "kind:") {
+		return s
+	}
+	// Preserve a trailing-newline / no-trailing-newline shape exactly.
+	lines := strings.Split(s, "\n")
+
+	inSecret := false    // current YAML document is a kind: Secret
+	inDataBlock := false // currently inside that Secret's data:/stringData: block
+	dataIndent := 0      // indent (in columns) of the data: key
+
+	for i, raw := range lines {
+		m := diffPrefixRE.FindStringSubmatch(raw)
+		prefix, body := m[1], m[2]
+
+		// Document boundary: a separator resets all document state.
+		if docMarkerRE.MatchString(body) {
+			inSecret, inDataBlock = false, false
+			continue
+		}
+
+		// A new document's kind: line (re)sets whether we are in a Secret.
+		if kindAnyRE.MatchString(body) {
+			inSecret = kindSecretRE.MatchString(body)
+			inDataBlock = false
+			continue
+		}
+
+		if !inSecret {
+			continue
+		}
+
+		if inDataBlock {
+			indent := leadingSpaces(body)
+			// Block ends on dedent to <= the data key indent, or a blank line
+			// that is not part of the block. Blank lines inside indented data
+			// are unusual; treat a blank line as ending the block.
+			if strings.TrimSpace(body) == "" {
+				inDataBlock = false
+				continue
+			}
+			if indent <= dataIndent {
+				inDataBlock = false
+				// fall through: this line may itself open another data block or
+				// be a sibling key — re-evaluate below.
+			} else {
+				if entry := dataEntryRE.FindStringSubmatch(body); entry != nil {
+					val := strings.TrimRight(entry[3], " ")
+					if val != mask {
+						lines[i] = prefix + entry[1] + entry[2] + mask
+					}
+				}
+				continue
+			}
+		}
+
+		// Detect the start of a data:/stringData: block within the Secret.
+		if dk := dataKeyRE.FindStringSubmatch(body); dk != nil {
+			inDataBlock = true
+			dataIndent = leadingSpaces(dk[1])
+			continue
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// leadingSpaces counts leading space/tab characters (column-ish indent). Tabs
+// are invalid YAML indentation, so counting them as one each is sufficient for
+// the dedent comparison.
+func leadingSpaces(s string) int {
+	n := 0
+	for _, r := range s {
+		if r == ' ' || r == '\t' {
+			n++
+			continue
+		}
+		break
+	}
+	return n
 }

--- a/internal/redact/secret_manifest_test.go
+++ b/internal/redact/secret_manifest_test.go
@@ -1,0 +1,134 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSecretsMasksK8sSecretData covers the REDACT-B64 gap: base64-encoded values
+// inside a Kubernetes `kind: Secret` manifest (the `data:` / `stringData:` block)
+// are masked, keys and surrounding structure preserved. ConfigMaps and other
+// kinds are left untouched to avoid over-masking.
+func TestSecretsMasksK8sSecretData(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		gone  []string // substrings that must NOT survive
+		keeps []string // structure that SHOULD survive
+	}{
+		{
+			name: "secret data two base64 values",
+			in: "apiVersion: v1\n" +
+				"kind: Secret\n" +
+				"metadata:\n" +
+				"  name: db-creds\n" +
+				"  namespace: prod\n" +
+				"type: Opaque\n" +
+				"data:\n" +
+				"  username: YWRtaW4=\n" +
+				"  password: c3VwM3JzM2NyZXQ=\n",
+			gone:  []string{"YWRtaW4=", "c3VwM3JzM2NyZXQ="},
+			keeps: []string{"kind: Secret", "name: db-creds", "namespace: prod", "username:", "password:"},
+		},
+		{
+			name: "secret data inside git diff plus prefix",
+			in: "diff --git a/secret.yaml b/secret.yaml\n" +
+				"@@ -1,8 +1,9 @@\n" +
+				"+apiVersion: v1\n" +
+				"+kind: Secret\n" +
+				"+metadata:\n" +
+				"+  name: db-creds\n" +
+				"+type: Opaque\n" +
+				"+data:\n" +
+				"+  username: YWRtaW4=\n" +
+				"+  password: c3VwM3JzM2NyZXQ=\n",
+			gone:  []string{"YWRtaW4=", "c3VwM3JzM2NyZXQ="},
+			keeps: []string{"kind: Secret", "username:", "password:"},
+		},
+		{
+			name: "stringData values masked",
+			in: "kind: Secret\n" +
+				"metadata:\n" +
+				"  name: api\n" +
+				"stringData:\n" +
+				"  token: my-plaintext-token\n" +
+				"  apiKey: another-plaintext-value\n",
+			gone:  []string{"my-plaintext-token", "another-plaintext-value"},
+			keeps: []string{"kind: Secret", "token:", "apiKey:"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := Secrets(tc.in)
+			for _, g := range tc.gone {
+				if strings.Contains(out, g) {
+					t.Fatalf("secret value survived redaction: %q\n -> %q", g, out)
+				}
+			}
+			if !strings.Contains(out, mask) {
+				t.Fatalf("expected a redaction marker, got %q", out)
+			}
+			for _, k := range tc.keeps {
+				if !strings.Contains(out, k) {
+					t.Fatalf("structure %q should survive, got %q", k, out)
+				}
+			}
+			// Idempotent: redacting again changes nothing.
+			if again := Secrets(out); again != out {
+				t.Fatalf("not idempotent: %q -> %q", out, again)
+			}
+		})
+	}
+}
+
+// TestSecretsDoesNotMaskConfigMap guards against over-masking: a non-Secret
+// document with a `data:` block (here a ConfigMap) must be left intact.
+func TestSecretsDoesNotMaskConfigMap(t *testing.T) {
+	in := "apiVersion: v1\n" +
+		"kind: ConfigMap\n" +
+		"metadata:\n" +
+		"  name: app-config\n" +
+		"data:\n" +
+		"  log_level: info\n" +
+		"  replicas: \"3\"\n"
+	if got := Secrets(in); got != in {
+		t.Fatalf("ConfigMap data must not be masked:\n  in:  %q\n  out: %q", in, got)
+	}
+}
+
+// TestSecretsConfigMapThenSecret pins the document-boundary behaviour: a `---`
+// separator ends the ConfigMap document, and the following Secret document's
+// data block IS masked while the ConfigMap's data block is NOT.
+func TestSecretsConfigMapThenSecret(t *testing.T) {
+	in := "kind: ConfigMap\n" +
+		"data:\n" +
+		"  log_level: info\n" +
+		"---\n" +
+		"kind: Secret\n" +
+		"data:\n" +
+		"  password: c3VwM3JzM2NyZXQ=\n"
+	out := Secrets(in)
+	if strings.Contains(out, "c3VwM3JzM2NyZXQ=") {
+		t.Fatalf("Secret value should be masked, got %q", out)
+	}
+	if !strings.Contains(out, "log_level: info") {
+		t.Fatalf("ConfigMap value should survive, got %q", out)
+	}
+}
+
+// TestSecretsSecretBlockEndsAtTopLevelKey ensures masking stops when the
+// data/stringData block ends at a sibling top-level key, so values outside the
+// block are not masked.
+func TestSecretsSecretBlockEndsAtTopLevelKey(t *testing.T) {
+	in := "kind: Secret\n" +
+		"data:\n" +
+		"  password: c3VwM3JzM2NyZXQ=\n" +
+		"type: Opaque\n"
+	out := Secrets(in)
+	if strings.Contains(out, "c3VwM3JzM2NyZXQ=") {
+		t.Fatalf("Secret data value should be masked, got %q", out)
+	}
+	if !strings.Contains(out, "type: Opaque") {
+		t.Fatalf("sibling top-level key should survive intact, got %q", out)
+	}
+}


### PR DESCRIPTION
  ## What
  `redact.Secrets` masked secrets via regex but didn't handle base64 `data:` values inside `kind: Secret` manifests — so a Secret in a `what_changed` git diff reached the LLM (and a possibly-public KB PR) unmasked. Closes that disclosed gap.

  ## How
  Adds a structural, line-oriented pass (`k8sSecretData`) after the regex rules: on a top-level `kind: Secret` document it masks the **values** under `data:`/`stringData:` (keys preserved), ending the block on dedent / new top-level key / new `kind:` / `---`. Diff-marker-aware (`+ `/`- `/space), idempotent, **ConfigMap-safe**. Values are masked, not base64-decoded (simpler + safer).

  ## Tests
  Secret data masked (keys intact); same inside a git diff; `stringData:` masked; ConfigMap `data:` NOT masked; idempotency + document-boundary cases. `go test -race ./...` green.
