### PR TITLE
  fix(investigate): constrain pod_logs to the incident namespace plus an allowlist

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -128,7 +128,10 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		reader := cluster.New(cs)
 		tools = append(tools,
 			investigate.ControllerLogsTool{Logs: reader},
-			investigate.PodLogsTool{Logs: reader},
+			// pod_logs streams raw pod logs (secrets/PII) to the LLM, so it is
+			// constrained at the app layer to the incident namespace plus this
+			// operator allowlist. The per-incident namespace is set by the loop.
+			investigate.PodLogsTool{Logs: reader, AllowedNamespaces: cfg.Investigation.PodLogNamespaces},
 			investigate.PodStatusTool{Kube: reader},
 			investigate.KubeEventsTool{Kube: reader},
 		)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,14 @@ type Investigation struct {
 	MaxToolOutputBytes        int       `yaml:"max_tool_output_bytes"`        // 0 ⇒ unlimited
 	MaxTokensPerInvestigation int       `yaml:"max_tokens_per_investigation"` // 0 ⇒ unlimited
 	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via applyDefaults
+
+	// PodLogNamespaces lists extra namespaces (beyond the incident's own) that
+	// pod_logs may read controller/crash logs from. pod_logs streams raw pod logs
+	// (which carry secrets/PII) to the external LLM, so the model is constrained to
+	// the incident namespace plus this allowlist at the application layer — not just
+	// by Kubernetes RBAC. Set this to match the Helm rbac.controllerLogNamespaces
+	// (e.g. [flux-system]); empty means the incident namespace only.
+	PodLogNamespaces []string `yaml:"pod_log_namespaces"`
 }
 
 // Coalesce folds correlated incidents into one investigation.

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -112,12 +112,16 @@ investigation:
   max_steps: 15
   max_tool_output_bytes: 16384
   max_tokens_per_investigation: 120000
+  pod_log_namespaces: [flux-system, kube-system]
 telemetry:
   metrics_enabled: true
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
 		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := strings.Join(c.Investigation.PodLogNamespaces, ","); got != "flux-system,kube-system" {
+		t.Fatalf("pod_log_namespaces: got %q", got)
 	}
 	if !c.Investigation.Coalesce.Enabled {
 		t.Fatal("coalesce.enabled should be true")

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -187,9 +187,14 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				"title", req.Title, "entry", entry.Path)
 		}
 	}
+	// Bind incident-scoped tools (pod_logs) to THIS investigation's namespace before
+	// use: a single LoopInvestigator serves many requests, so the namespace allowlist
+	// that includes the incident's own namespace must be set per request, not at
+	// construction. scopeTools copies into a fresh slice (li.Tools is never mutated).
+	tools := scopeTools(li.Tools, req.Workload.Namespace)
 	byName := map[string]Tool{}
-	specs := make([]providers.ToolSpec, 0, len(li.Tools)+1)
-	for _, t := range li.Tools {
+	specs := make([]providers.ToolSpec, 0, len(tools)+1)
+	for _, t := range tools {
 		byName[t.Name()] = t
 		specs = append(specs, providers.ToolSpec{Name: t.Name(), Description: t.Description(), Schema: t.Schema()})
 	}

--- a/internal/investigate/podlogs_tool.go
+++ b/internal/investigate/podlogs_tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -13,8 +14,41 @@ import (
 // optionally the PREVIOUS (last-terminated) container — the crash output of a
 // CrashLoopBackOff pod that the freshly-restarted container no longer has. This is
 // the general workload-log reader (controller_logs is Flux-controller-only).
+//
+// Because pod logs carry secrets/PII and are streamed to the external LLM, the
+// model is constrained at the application layer to a fixed allowed set of
+// namespaces — the incident's own namespace plus an operator-configured allowlist
+// — rather than trusting Kubernetes RBAC alone. A request for any other namespace
+// is rejected before the cluster is queried.
 type PodLogsTool struct {
 	Logs providers.LogReader
+
+	// IncidentNamespace is the namespace of the workload under investigation; it is
+	// always permitted. Set per-investigation by the loop from req.Workload.Namespace.
+	IncidentNamespace string
+
+	// AllowedNamespaces is the operator-configured allowlist of extra namespaces
+	// pod_logs may read (config.investigation.pod_log_namespaces). Empty ⇒ the
+	// incident namespace is the only permitted namespace (secure by default).
+	AllowedNamespaces []string
+}
+
+// withIncidentNamespace returns a copy of the tool bound to this investigation's
+// incident namespace. It implements incidentScoped so the loop can scope the shared
+// tool per request without mutating it.
+func (t PodLogsTool) withIncidentNamespace(ns string) Tool {
+	t.IncidentNamespace = ns // t is a value receiver: mutating the copy is safe
+	return t
+}
+
+// namespaceAllowed reports whether ns is in the allowed set: the incident's own
+// namespace plus the configured allowlist. An empty incident namespace (on-demand
+// runs without a workload) does not widen the set.
+func (t PodLogsTool) namespaceAllowed(ns string) bool {
+	if ns != "" && ns == t.IncidentNamespace {
+		return true
+	}
+	return slices.Contains(t.AllowedNamespaces, ns)
 }
 
 // Name returns the tool name.
@@ -47,6 +81,13 @@ func (t PodLogsTool) Call(ctx context.Context, args string) (string, error) {
 	}
 	if in.Namespace == "" {
 		return "", fmt.Errorf("namespace is required")
+	}
+	// Application-layer guard: pod logs leak secrets/PII to the external LLM, so the
+	// model may only read the incident namespace plus the configured allowlist.
+	// Return an explanatory, NON-fatal string (so the model can retry an allowed
+	// namespace) and do NOT touch the cluster.
+	if !t.namespaceAllowed(in.Namespace) {
+		return fmt.Sprintf("namespace %q is not permitted for pod_logs (allowed: the incident namespace plus the configured pod_log_namespaces allowlist)", in.Namespace), nil
 	}
 	since := in.SinceMinutes
 	if since <= 0 {

--- a/internal/investigate/podlogs_tool_test.go
+++ b/internal/investigate/podlogs_tool_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 // fakeWorkloadLogs records the PodLogs call (incl. the previous flag) and returns
-// canned lines.
+// canned lines. called reports whether the cluster was queried at all — the
+// namespace-allowlist guard must reject out-of-allowlist requests BEFORE fetching.
 type fakeWorkloadLogs struct {
 	lines       providers.LogResult
+	called      bool
 	gotNS       string
 	gotSelector string
 	gotSince    int
@@ -19,6 +21,7 @@ type fakeWorkloadLogs struct {
 }
 
 func (f *fakeWorkloadLogs) PodLogs(_ context.Context, q providers.PodLogQuery) (providers.LogResult, error) {
+	f.called = true
 	f.gotNS, f.gotSelector, f.gotSince, f.gotPrevious = q.Namespace, q.LabelSelector, q.SinceMinutes, q.Previous
 	return f.lines, nil
 }
@@ -27,7 +30,7 @@ func TestPodLogsToolPreviousContainer(t *testing.T) {
 	f := &fakeWorkloadLogs{lines: providers.LogResult{
 		{Message: "web-abc: panic: runtime error: invalid memory address or nil pointer dereference"},
 	}}
-	tool := PodLogsTool{Logs: f}
+	tool := PodLogsTool{Logs: f, IncidentNamespace: "apps"}
 	if tool.Name() != "pod_logs" {
 		t.Fatalf("name=%q", tool.Name())
 	}
@@ -47,7 +50,7 @@ func TestPodLogsToolPreviousContainer(t *testing.T) {
 
 func TestPodLogsToolDefaultsCurrentContainer(t *testing.T) {
 	f := &fakeWorkloadLogs{lines: providers.LogResult{{Message: "web-abc: serving on :8080"}}}
-	tool := PodLogsTool{Logs: f}
+	tool := PodLogsTool{Logs: f, IncidentNamespace: "apps"}
 	if _, err := tool.Call(context.Background(), `{"namespace":"apps"}`); err != nil {
 		t.Fatalf("Call: %v", err)
 	}
@@ -68,12 +71,62 @@ func TestPodLogsToolRequiresNamespace(t *testing.T) {
 }
 
 func TestPodLogsToolEmpty(t *testing.T) {
-	tool := PodLogsTool{Logs: &fakeWorkloadLogs{}}
+	tool := PodLogsTool{Logs: &fakeWorkloadLogs{}, IncidentNamespace: "apps"}
 	out, err := tool.Call(context.Background(), `{"namespace":"apps"}`)
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
 	if !strings.Contains(out, "no log lines") {
 		t.Fatalf("want a no-lines note, got: %q", out)
+	}
+}
+
+// The pod_logs tool streams raw pod logs (which carry secrets/PII) to the external
+// LLM, so the model must not be able to pull logs from arbitrary namespaces. The
+// allowed set is the incident's own namespace ∪ an operator-configured allowlist.
+
+func TestPodLogsToolAllowsIncidentNamespace(t *testing.T) {
+	f := &fakeWorkloadLogs{lines: providers.LogResult{{Message: "web-abc: serving on :8080"}}}
+	// No configured allowlist: only the incident's own namespace is permitted.
+	tool := PodLogsTool{Logs: f, IncidentNamespace: "apps"}
+	if _, err := tool.Call(context.Background(), `{"namespace":"apps","selector":"app=web"}`); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !f.called || f.gotNS != "apps" {
+		t.Fatalf("incident namespace should be fetched: called=%v ns=%q", f.called, f.gotNS)
+	}
+}
+
+func TestPodLogsToolAllowsConfiguredNamespace(t *testing.T) {
+	f := &fakeWorkloadLogs{lines: providers.LogResult{{Message: "kustomize-controller: reconciled"}}}
+	// flux-system is not the incident namespace but is on the configured allowlist.
+	tool := PodLogsTool{Logs: f, IncidentNamespace: "apps", AllowedNamespaces: []string{"flux-system"}}
+	if _, err := tool.Call(context.Background(), `{"namespace":"flux-system","selector":"app=kustomize-controller"}`); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !f.called || f.gotNS != "flux-system" {
+		t.Fatalf("allowlisted namespace should be fetched: called=%v ns=%q", f.called, f.gotNS)
+	}
+}
+
+func TestPodLogsToolRejectsOutOfAllowlistNamespace(t *testing.T) {
+	f := &fakeWorkloadLogs{lines: providers.LogResult{{Message: "secret: SHOULD-NOT-LEAK"}}}
+	tool := PodLogsTool{Logs: f, IncidentNamespace: "apps", AllowedNamespaces: []string{"flux-system"}}
+	// kube-system is neither the incident namespace nor on the allowlist.
+	out, err := tool.Call(context.Background(), `{"namespace":"kube-system"}`)
+	if err != nil {
+		t.Fatalf("the guard must return a non-fatal error string to the model, not a Go error: %v", err)
+	}
+	// Must not have queried the cluster — the guard runs BEFORE fetching.
+	if f.called {
+		t.Fatal("out-of-allowlist namespace must not reach the cluster log source")
+	}
+	// The message must be explanatory: name the rejected namespace and tell the
+	// model where the allowed set comes from.
+	if !strings.Contains(out, `namespace "kube-system" is not permitted for pod_logs`) {
+		t.Fatalf("expected an explanatory rejection naming the namespace, got: %q", out)
+	}
+	if !strings.Contains(out, "pod_log_namespaces") {
+		t.Fatalf("rejection should point at the pod_log_namespaces allowlist, got: %q", out)
 	}
 }

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -36,6 +36,30 @@ type Tool interface {
 	Call(ctx context.Context, args string) (string, error)
 }
 
+// incidentScoped is implemented by tools that must be bound to the incident's own
+// namespace before use (currently pod_logs, whose namespace allowlist includes the
+// incident namespace). The loop calls this per investigation when assembling tools,
+// since a single LoopInvestigator instance serves many requests. A tool not
+// implementing this interface is used unchanged.
+type incidentScoped interface {
+	withIncidentNamespace(ns string) Tool
+}
+
+// scopeTools binds any incident-scoped tools to this investigation's namespace,
+// returning a fresh slice so the shared li.Tools is never mutated. Non-scoped tools
+// pass through unchanged.
+func scopeTools(tools []Tool, incidentNamespace string) []Tool {
+	scoped := make([]Tool, len(tools))
+	for i, t := range tools {
+		if s, ok := t.(incidentScoped); ok {
+			scoped[i] = s.withIncidentNamespace(incidentNamespace)
+			continue
+		}
+		scoped[i] = t
+	}
+	return scoped
+}
+
 // submitFindingsName is the reserved tool the model calls to finish, supplying
 // the structured investigation result.
 const submitFindingsName = "submit_findings"


### PR DESCRIPTION
  ## What
  The `pod_logs` tool took a model-chosen namespace and streamed raw pod logs (secrets/PII) from **any** namespace to the external LLM — backstopped only by Kubernetes RBAC. Adds an application-layer namespace guard.

  ## How
  `pod_logs` may only read the **incident's own namespace** ∪ an operator-configured allowlist (`investigation.pod_log_namespaces`, default empty → incident-namespace-only, secure by default). Out-of-allowlist requests return an explanatory, non-fatal message and never touch the cluster. The incident namespace is bound per-investigation via `scopeTools` onto a copy of the tool (shared tool set never mutated); the allowlist is
  wired from config.

  ## ⚠️ Operator note (behavior change)
  This is secure-by-default: out of the box `pod_logs` is restricted to the incident's own namespace. If you set Helm `rbac.controllerLogNamespaces` (e.g. `[flux-system]`), also set `investigation.pod_log_namespaces` to the same list so `pod_logs` can read those namespaces for cross-namespace incidents. (`controller_logs` is unaffected — already flux-system-scoped.)

  ## Tests
  Allows incident-ns; allows allowlist-ns; rejects out-of-allowlist (asserts no fetch); config parse test. `go test -race ./...` green.