### PR TITLE
  feat(metrics,logs): optional bearer-token + header auth for metrics/logs endpoints

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -82,14 +82,14 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		}
 	}
 	if cfg.Metrics.URL != "" {
-		m := prometheus.New(cfg.Metrics.URL)
+		m := prometheus.NewWithAuth(cfg.Metrics.URL, cfg.Metrics.TokenEnv, cfg.Metrics.Headers)
 		tools = append(tools,
 			investigate.QueryMetricsTool{Metrics: m},
 			investigate.QueryMetricsRangeTool{Metrics: m},
 		)
 	}
 	if cfg.Logs.URL != "" {
-		tools = append(tools, investigate.QueryLogsTool{Logs: victorialogs.New(cfg.Logs.URL)})
+		tools = append(tools, investigate.QueryLogsTool{Logs: victorialogs.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers)})
 	}
 	// Network-flow data source (the network_drops tool). Pluggable and CNI-agnostic:
 	// no provider is enabled by default. The selected provider must match the cluster's

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,9 +60,22 @@ type Logging struct {
 	Level  string `yaml:"level"`  // "debug" | "info" (default) | "warn" | "error"
 }
 
-// Endpoint is a backend base URL; empty disables the corresponding tool.
+// Endpoint is a backend base URL with optional auth; empty URL disables the
+// corresponding tool. Auth follows the secrets-by-indirection convention used
+// elsewhere (model.api_key_env, forge.*_env): the config stores the NAME of an
+// env var, never the secret itself, and the value is read at runtime.
 type Endpoint struct {
 	URL string `yaml:"url"`
+
+	// TokenEnv names an env var holding a bearer token for the backend. When set
+	// and the var is non-empty, requests carry "Authorization: Bearer <token>".
+	// Empty (default) ⇒ no Authorization header (unchanged, keyless behaviour).
+	TokenEnv string `yaml:"token_env"`
+
+	// Headers are static request headers added to every backend request — e.g. a
+	// tenant header for a multi-tenant VictoriaMetrics/VictoriaLogs instance
+	// ("X-Scope-OrgID: <tenant>"). Empty (default) ⇒ no extra headers.
+	Headers map[string]string `yaml:"headers"`
 }
 
 // Cloud configures the cloud context provider. Auth is in-cluster identity (EKS

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -74,6 +74,68 @@ triggers:
 	}
 }
 
+func TestLoadEndpointAuth(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "runlore.yaml")
+	// Both backends carry optional auth: a bearer token (by env-var name) and static
+	// headers. The strict KnownFields(true) decoder must accept token_env/headers.
+	doc := `
+metrics:
+  url: https://vm.example.com
+  token_env: VM_TOKEN
+  headers:
+    X-Scope-OrgID: tenant-a
+logs:
+  url: https://vl.example.com
+  token_env: VL_TOKEN
+  headers:
+    X-Scope-OrgID: tenant-b
+    X-Extra: v
+`
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if c.Metrics.TokenEnv != "VM_TOKEN" {
+		t.Fatalf("metrics.token_env: got %q, want VM_TOKEN", c.Metrics.TokenEnv)
+	}
+	if c.Metrics.Headers["X-Scope-OrgID"] != "tenant-a" {
+		t.Fatalf("metrics.headers[X-Scope-OrgID]: got %q, want tenant-a", c.Metrics.Headers["X-Scope-OrgID"])
+	}
+	if c.Logs.TokenEnv != "VL_TOKEN" {
+		t.Fatalf("logs.token_env: got %q, want VL_TOKEN", c.Logs.TokenEnv)
+	}
+	if c.Logs.Headers["X-Scope-OrgID"] != "tenant-b" || c.Logs.Headers["X-Extra"] != "v" {
+		t.Fatalf("logs.headers: got %v", c.Logs.Headers)
+	}
+}
+
+func TestLoadEndpointAuthOptional(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "runlore.yaml")
+	// URL-only endpoints (the pre-auth shape) must still decode, with empty auth.
+	doc := `
+metrics:
+  url: https://vm.example.com
+`
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if c.Metrics.URL != "https://vm.example.com" {
+		t.Fatalf("metrics.url: got %q", c.Metrics.URL)
+	}
+	if c.Metrics.TokenEnv != "" || len(c.Metrics.Headers) != 0 {
+		t.Fatalf("url-only endpoint should have empty auth, got token_env=%q headers=%v", c.Metrics.TokenEnv, c.Metrics.Headers)
+	}
+}
+
 func TestLoadGitOpsFailureDebounceZeroFiresImmediately(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "runlore.yaml")

--- a/internal/logs/victorialogs/victorialogs.go
+++ b/internal/logs/victorialogs/victorialogs.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -21,17 +22,35 @@ import (
 // Client queries a VictoriaLogs backend.
 type Client struct {
 	baseURL  string
-	limit    int // per-request page size
-	maxLines int // total cap across pages
+	tokenEnv string            // env var holding a bearer token; empty ⇒ no auth
+	headers  map[string]string // static extra request headers (e.g. tenant header)
+	limit    int               // per-request page size
+	maxLines int               // total cap across pages
 	http     *http.Client
 }
 
 // defaultMaxLines bounds the total number of lines Query returns across pages.
 const defaultMaxLines = 1000
 
-// New builds a client for a VictoriaLogs base URL.
+// New builds a client for a VictoriaLogs base URL, unauthenticated.
 func New(baseURL string) *Client {
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), limit: 100, maxLines: defaultMaxLines, http: httpx.SecureClient(30 * time.Second)}
+	return NewWithAuth(baseURL, "", nil)
+}
+
+// NewWithAuth builds a client that adds optional auth to every request. tokenEnv
+// names an env var holding a bearer token (empty, or pointing at an unset/empty
+// var, ⇒ no Authorization header); headers are static request headers (e.g.
+// "X-Scope-OrgID" for a multi-tenant backend). The token is read from the
+// environment at request-build time and is never logged.
+func NewWithAuth(baseURL, tokenEnv string, headers map[string]string) *Client {
+	return &Client{
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		tokenEnv: tokenEnv,
+		headers:  headers,
+		limit:    100,
+		maxLines: defaultMaxLines,
+		http:     httpx.SecureClient(30 * time.Second),
+	}
 }
 
 var _ providers.LogsProvider = (*Client)(nil)
@@ -88,6 +107,7 @@ func (c *Client) queryPage(ctx context.Context, query string, w providers.TimeWi
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	c.setAuth(req)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("logs query: %w", err)
@@ -98,6 +118,20 @@ func (c *Client) queryPage(ctx context.Context, query string, w providers.TimeWi
 		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
 	}
 	return parseNDJSON(resp.Body)
+}
+
+// setAuth applies the optional bearer token and static headers to req. The token
+// is read from the environment here (request-build time) and never logged; an
+// unset/empty token var leaves the request unauthenticated.
+func (c *Client) setAuth(req *http.Request) {
+	if c.tokenEnv != "" {
+		if tok := os.Getenv(c.tokenEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
 }
 
 // truncationLine is the sentinel appended when Query stops at its cap with more

--- a/internal/logs/victorialogs/victorialogs_test.go
+++ b/internal/logs/victorialogs/victorialogs_test.go
@@ -51,6 +51,49 @@ func TestQuery(t *testing.T) {
 	}
 }
 
+func TestQueryAuthHeaders(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_VL_TOKEN", "s3cr3t")
+	var gotAuth, gotTenant, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotTenant = r.Header.Get("X-Scope-OrgID")
+		gotCT = r.Header.Get("Content-Type")
+		_, _ = io.WriteString(w, ``)
+	}))
+	defer srv.Close()
+
+	c := NewWithAuth(srv.URL, "RUNLORE_TEST_VL_TOKEN", map[string]string{"X-Scope-OrgID": "tenant-b"})
+	if _, err := c.Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "Bearer s3cr3t" {
+		t.Fatalf("Authorization: got %q, want %q", gotAuth, "Bearer s3cr3t")
+	}
+	if gotTenant != "tenant-b" {
+		t.Fatalf("X-Scope-OrgID: got %q, want tenant-b", gotTenant)
+	}
+	// Auth headers must not displace the form Content-Type the query relies on.
+	if !strings.Contains(gotCT, "x-www-form-urlencoded") {
+		t.Fatalf("content-type=%q", gotCT)
+	}
+}
+
+func TestQueryNoAuthByDefault(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, ``)
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("unconfigured client must send no Authorization header, got %q", gotAuth)
+	}
+}
+
 // parseForm returns the decoded "query" value if present.
 func parseForm(body string) (string, error) {
 	for _, kv := range strings.Split(body, "&") {

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -19,13 +20,29 @@ import (
 
 // Client queries a Prometheus-compatible metrics backend.
 type Client struct {
-	baseURL string
-	http    *http.Client
+	baseURL  string
+	tokenEnv string            // env var holding a bearer token; empty ⇒ no auth
+	headers  map[string]string // static extra request headers (e.g. tenant header)
+	http     *http.Client
 }
 
-// New builds a client for a Prometheus/VictoriaMetrics base URL.
+// New builds a client for a Prometheus/VictoriaMetrics base URL, unauthenticated.
 func New(baseURL string) *Client {
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpx.SecureClient(30 * time.Second)}
+	return NewWithAuth(baseURL, "", nil)
+}
+
+// NewWithAuth builds a client that adds optional auth to every request. tokenEnv
+// names an env var holding a bearer token (empty, or pointing at an unset/empty
+// var, ⇒ no Authorization header); headers are static request headers (e.g.
+// "X-Scope-OrgID" for a multi-tenant backend). The token is read from the
+// environment at request-build time and is never logged.
+func NewWithAuth(baseURL, tokenEnv string, headers map[string]string) *Client {
+	return &Client{
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		tokenEnv: tokenEnv,
+		headers:  headers,
+		http:     httpx.SecureClient(30 * time.Second),
+	}
 }
 
 var _ providers.MetricsProvider = (*Client)(nil)
@@ -103,6 +120,7 @@ func (c *Client) get(ctx context.Context, path string, v url.Values) (*apiRespon
 	if err != nil {
 		return nil, err
 	}
+	c.setAuth(req)
 	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("metrics query: %w", err)
@@ -120,6 +138,20 @@ func (c *Client) get(ctx context.Context, path string, v url.Values) (*apiRespon
 		return nil, fmt.Errorf("metrics error: %s", r.Error)
 	}
 	return &r, nil
+}
+
+// setAuth applies the optional bearer token and static headers to req. The token
+// is read from the environment here (request-build time) and never logged; an
+// unset/empty token var leaves the request unauthenticated.
+func (c *Client) setAuth(req *http.Request) {
+	if c.tokenEnv != "" {
+		if tok := os.Getenv(c.tokenEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
 }
 
 // parsePoint parses a Prometheus [unixTime, "value"] pair.

--- a/internal/metrics/prometheus/prometheus_test.go
+++ b/internal/metrics/prometheus/prometheus_test.go
@@ -52,6 +52,74 @@ func TestQueryRange(t *testing.T) {
 	}
 }
 
+func TestQueryAuthHeaders(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_VM_TOKEN", "s3cr3t")
+	var gotAuth, gotTenant string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotTenant = r.Header.Get("X-Scope-OrgID")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	c := NewWithAuth(srv.URL, "RUNLORE_TEST_VM_TOKEN", map[string]string{"X-Scope-OrgID": "tenant-a"})
+	if _, err := c.Query(context.Background(), "up", time.Time{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "Bearer s3cr3t" {
+		t.Fatalf("Authorization: got %q, want %q", gotAuth, "Bearer s3cr3t")
+	}
+	if gotTenant != "tenant-a" {
+		t.Fatalf("X-Scope-OrgID: got %q, want tenant-a", gotTenant)
+	}
+
+	// The custom header must also ride QueryRange (both request builders share get()).
+	gotAuth, gotTenant = "", ""
+	if _, err := c.QueryRange(context.Background(), "rate(up[5m])",
+		providers.TimeWindow{Start: time.Unix(1700000000, 0), End: time.Unix(1700000300, 0)}, time.Minute); err != nil {
+		t.Fatalf("QueryRange: %v", err)
+	}
+	if gotAuth != "Bearer s3cr3t" || gotTenant != "tenant-a" {
+		t.Fatalf("QueryRange auth: auth=%q tenant=%q", gotAuth, gotTenant)
+	}
+}
+
+func TestQueryNoAuthByDefault(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	if _, err := New(srv.URL).Query(context.Background(), "up", time.Time{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("unconfigured client must send no Authorization header, got %q", gotAuth)
+	}
+}
+
+func TestQueryTokenEnvUnset(t *testing.T) {
+	// TokenEnv names a var that is not set ⇒ no Authorization header (treated as
+	// keyless), mirroring the model provider's empty-key behaviour.
+	t.Setenv("RUNLORE_TEST_VM_TOKEN", "")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	c := NewWithAuth(srv.URL, "RUNLORE_TEST_VM_TOKEN", nil)
+	if _, err := c.Query(context.Background(), "up", time.Time{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("empty token must send no Authorization header, got %q", gotAuth)
+	}
+}
+
 func TestQueryError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"status":"error","error":"bad query"}`))


### PR DESCRIPTION
  ## What
  The Metrics (Prometheus/VictoriaMetrics) and Logs (VictoriaLogs) backends used a URL-only `Endpoint` config — no auth — so any token-protected or multi-tenant (e.g. `X-Scope-OrgID`) backend was unreachable. Adds optional auth.

  ## How
  - `Endpoint` gains `token_env` (name of an env var holding a bearer token — matches the project's secrets-by-indirection convention; value read at runtime, never inlined/logged) and `headers` (static extra request headers, e.g. a tenant header).
  - `prometheus.NewWithAuth` / `victorialogs.NewWithAuth` set `Authorization: Bearer <token>` (when `token_env` resolves non-empty) + the configured headers on every request; `New(url)` retained as the URL-only path. **Wired into the metrics/logs tools in `internal/app/investigate.go`** so it's live.
  - Empty config ⇒ no auth (unchanged behaviour). SecureClient/retries/error-body-omission untouched.

  ## Tests
  `httptest` servers capturing inbound headers, via `t.Setenv`: Authorization + custom header present when configured (prometheus covers Query + QueryRange); none when unset; empty-env-var ⇒ no header. `go test -race ./...` green.