### PR TITLE
  feat(helm): expose pod_log_namespaces (defaults to rbac.controllerLogNamespaces)

### DIFF
--- a/deploy/helm/runlore/templates/configmap.yaml
+++ b/deploy/helm/runlore/templates/configmap.yaml
@@ -6,4 +6,18 @@ metadata:
     {{- include "runlore.labels" . | nindent 4 }}
 data:
   runlore.yaml: |
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- /*
+      Render the agent config verbatim from .Values.config, but auto-default the
+      pod_logs app-layer allowlist (investigation.pod_log_namespaces) to the RBAC
+      scope (rbac.controllerLogNamespaces) when the operator has NOT set it.
+      pod_logs is constrained at the app layer to {incident namespace} ∪ this list;
+      tracking the RBAC namespaces by default keeps the two in sync (no foot-gun).
+      deepCopy so we never mutate the shared .Values tree.
+    */}}
+    {{- $config := deepCopy .Values.config }}
+    {{- $investigation := $config.investigation | default dict }}
+    {{- if not (hasKey $investigation "pod_log_namespaces") }}
+    {{-   $investigation = set $investigation "pod_log_namespaces" (.Values.rbac.controllerLogNamespaces | default list) }}
+    {{-   $config = set $config "investigation" $investigation }}
+    {{- end }}
+    {{- toYaml $config | nindent 4 }}

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -61,6 +61,16 @@ config:
     max_tokens_per_investigation: 100000
     # Cap each tool result fed back to the model (truncates large logs/diffs). 0 = unlimited.
     max_tool_output_bytes: 32768
+    # App-layer allowlist of namespaces the pod_logs / controller_logs tools may read
+    # RAW pod logs from, BEYOND the incident's own namespace (the incident namespace is
+    # always allowed at the app layer — RBAC still gates the actual read). Pod logs carry
+    # secrets/PII and are streamed to the external LLM, so the model is constrained here,
+    # not by Kubernetes RBAC alone. This MUST be a superset of where pods/log RBAC is
+    # granted (rbac.controllerLogNamespaces) or pod_logs is blocked at the app layer for
+    # those namespaces. LEAVE UNSET (commented) and the chart auto-defaults it to
+    # rbac.controllerLogNamespaces so the two stay in sync automatically — set it
+    # explicitly ONLY to widen/narrow beyond the RBAC scope.
+    # pod_log_namespaces: [flux-system]
     coalesce:
       enabled: true             # fold a correlated alert storm into ONE investigation
       # debounce: 30s           # flush batch quiet for this long
@@ -255,6 +265,12 @@ rbac:
   # because pod_status/kube_events triage arbitrary incident namespaces. Redacting
   # secrets that still surface via status/event messages and these log bodies is a
   # separate follow-up (see roadmap R19).
+  #
+  # PAIRING: this list is the RBAC scope (where pods/log is granted). The app-layer
+  # allowlist that gates which namespaces the pod_logs tool may actually read
+  # (config.investigation.pod_log_namespaces) auto-tracks this value unless overridden,
+  # so the two never drift. If you set config.investigation.pod_log_namespaces
+  # explicitly, keep it a superset of this list or pod_logs is blocked at the app layer.
   controllerLogNamespaces:
     - flux-system
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,15 @@ Per-source enablement map; presence enables a source. `alertmanager: {}` mounts 
   the single-worker queue).
 - `max_steps` (**default 20**), `max_tool_output_bytes` (0 = unlimited), `max_tokens_per_investigation`
   (0 = unlimited, else a hard token ceiling).
+- `pod_log_namespaces` — **app-layer allowlist** of namespaces the `pod_logs` tool
+  may read RAW pod logs from, *beyond* the incident's own namespace (which is always allowed; RBAC
+  still gates the actual read). Pod logs carry secrets/PII and are streamed to the external LLM, so the
+  model is constrained here — not by Kubernetes RBAC alone. **Empty ⇒ incident namespace only** (secure
+  by default). This **must be a superset of where `pods/log` RBAC is granted** (`rbac.controllerLogNamespaces`)
+  or `pod_logs` is blocked at the app layer for those namespaces. **The chart auto-defaults this to
+  `rbac.controllerLogNamespaces`** when you leave `config.investigation.pod_log_namespaces` unset, so the
+  app-layer allowlist and the RBAC scope stay in sync automatically — set it explicitly only to widen or
+  narrow beyond the RBAC scope. See [Security model → least-privilege RBAC](security-model.md).
 
 ### `catalog` — the knowledge base & instant recall
 - `dir` — local OKF bundle / git-sync mirror path; `git` — `url`, `branch` (default `main`), `interval`
@@ -99,9 +108,10 @@ config key. TLS is terminated externally (ClusterIP + NetworkPolicy).
 
 ### `rbac` — chart-only (not in the agent config)
 Set under `values.rbac.*`, not `values.config`: `controllerLogNamespaces` (default `[flux-system]` —
-where `pods/log` is granted, namespaced), `allowActions` (gate for the patch Role), `actionNamespaces`
-(the patch allowlist — **must mirror `config.actions.allow.namespaces`**). See
-[Security model](security-model.md).
+where `pods/log` is granted, namespaced; the app-layer `config.investigation.pod_log_namespaces`
+allowlist **auto-tracks this value** unless overridden, so RBAC scope and app guard never drift),
+`allowActions` (gate for the patch Role), `actionNamespaces` (the patch allowlist — **must mirror
+`config.actions.allow.namespaces`**). See [Security model](security-model.md).
 
 ### Other top-level keys
 `gitops.engine` (`flux` default · `argocd`), `cloud` (`provider: aws`, `region`, `cluster_name`),

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -70,8 +70,16 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
 - **ClusterRole (read-only, cluster-wide):** `get/list/watch` on Flux/ArgoCD resources and `events`,
   `get/list` on `pods` (status only — **not** `pods/log`). No write verb. `patch` is *intentionally*
   never granted cluster-wide.
-- **Namespaced Role for controller logs:** `pods/log` (raw log bodies, which can carry secrets/PII) is
+- **Namespaced Role for pod/controller logs:** `pods/log` (raw log bodies, which can carry secrets/PII) is
   granted only over `rbac.controllerLogNamespaces` (default `flux-system`) — never cluster-wide.
+- **Defense-in-depth app-layer guard:** because pod logs are streamed to the external LLM, the `pod_logs`
+  tool is *also* constrained in the agent config to **{the incident's own namespace} ∪
+  `config.investigation.pod_log_namespaces`** — a request for any other namespace is rejected before the
+  cluster is queried, not just denied by RBAC. The chart **auto-defaults `pod_log_namespaces` to
+  `rbac.controllerLogNamespaces`**, so the app-layer allowlist tracks the RBAC scope by default (no
+  silent drift); leaving both at the defaults limits raw-log reads to the incident namespace plus
+  `flux-system`. The app guard must stay a superset of the RBAC namespaces, or `pod_logs` is blocked at
+  the app layer for namespaces RBAC would otherwise permit.
 - **Namespaced Role for actions:** only when `rbac.allowActions` is set, `get/patch` on
   `kustomizations`/`helmreleases` over `rbac.actionNamespaces` — a bounded, opt-in blast radius that
   must mirror `config.actions.allow.namespaces`.


### PR DESCRIPTION
  ## What
  Completes the PODLOG-NS fix's operability: the `pod_logs` app-layer allowlist (`investigation.pod_log_namespaces`) had no Helm path, so it couldn't be set via values — and the secure-by-default behaviour meant `pod_logs` was incident-namespace-only until configured.

  ## How
  `templates/configmap.yaml` auto-defaults `investigation.pod_log_namespaces` to `rbac.controllerLogNamespaces` when the operator hasn't set it (deep-copy so `.Values` is never mutated), so the app-layer allowlist tracks the RBAC scope automatically — no drift foot-gun. An explicit `config.investigation.pod_log_namespaces` (including `[]`) wins. Documented in `values.yaml` (+ pairing note by `rbac.controllerLogNamespaces`),
  `configuration.md`, `security-model.md`.

  ## Verified
  `helm lint` clean; `helm template` proofs: default → `[flux-system]`; `--set rbac.controllerLogNamespaces={flux-system,kube-system}` → both render into `pod_log_namespaces`; explicit override wins; explicit `[]` preserved.