### PR TITLE
  feat(investigate): per-tool call timeout so one hung tool can't eat the budget

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,10 @@ Per-source enablement map; presence enables a source. `alertmanager: {}` mounts 
   `max_requeues`.
 - `timeout` — per-investigation deadline, **default 10m** (bounds a hung tool/clone so it can't starve
   the single-worker queue).
+- `tool_timeout` — per-**tool**-call timeout, **default 60s** (0 = use the default). Bounds a single
+  hung/slow provider (a stuck git clone, an unresponsive metrics/logs endpoint) so it can't eat the
+  whole per-investigation budget; on expiry the tool result is a non-fatal "timed out" note and the
+  investigation continues.
 - `max_steps` (**default 20**), `max_tool_output_bytes` (0 = unlimited), `max_tokens_per_investigation`
   (0 = unlimited, else a hard token ceiling).
 

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -148,6 +148,12 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	return model, tools, recall, cat
 }
 
+// defaultToolTimeout bounds a single tool call when investigation.tool_timeout is
+// unset (0). It keeps a hung/slow provider (a stuck git clone, an unresponsive
+// metrics/logs endpoint) from consuming the whole per-investigation budget while
+// still allowing legitimately slow queries (log scans, range PromQL) to finish.
+const defaultToolTimeout = 60 * time.Second
+
 // BuildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator. It also returns the catalog (nil when
 // no model is configured or no catalog is wired).
@@ -173,6 +179,12 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	if actions.Enabled() {
 		log.Info("action policy enabled", "mode", string(actions.Mode()))
 	}
+	// Per-tool timeout: default to 60s when unset (0) so one hung tool can't eat the
+	// whole per-investigation budget; an explicit config value flows through as-is.
+	toolTimeout := cfg.Investigation.ToolTimeout.Std()
+	if toolTimeout == 0 {
+		toolTimeout = defaultToolTimeout
+	}
 	return &investigate.LoopInvestigator{
 		Model:                     model,
 		VerifyModel:               BuildVerifyModel(cfg),
@@ -187,6 +199,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
 		Timeout:                   cfg.Investigation.Timeout.Std(),
+		ToolTimeout:               toolTimeout,
 		OnComplete: func(found providers.Investigation) {
 			// Record the outcome "open" first: this investigation happened for an
 			// incident, with the answer we used (recall vs fresh). A matching

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/audit"
@@ -95,6 +96,34 @@ func TestBuildInvestigatorSelectsImplementation(t *testing.T) {
 		}
 		if _, ok := inv.(*investigate.LoopInvestigator); !ok {
 			t.Fatalf("want *LoopInvestigator, got %T", inv)
+		}
+	})
+
+	t.Run("per-tool timeout: default when unset, explicit respected", func(t *testing.T) {
+		// Unset tool_timeout (0) ⇒ the 60s default is applied at construction, mirroring
+		// the other investigation defaults.
+		cfg := &config.Config{Model: config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}}
+		inv, _, err := BuildInvestigator(context.Background(), cfg, nil, nil, nil, nil, nil, log)
+		if err != nil {
+			t.Fatal(err)
+		}
+		li, ok := inv.(*investigate.LoopInvestigator)
+		if !ok {
+			t.Fatalf("want *LoopInvestigator, got %T", inv)
+		}
+		if li.ToolTimeout != defaultToolTimeout {
+			t.Fatalf("unset tool_timeout must default to %v, got %v", defaultToolTimeout, li.ToolTimeout)
+		}
+
+		// Explicit tool_timeout flows through unchanged.
+		cfg.Investigation.ToolTimeout = config.Duration(5 * time.Second)
+		inv2, _, err := BuildInvestigator(context.Background(), cfg, nil, nil, nil, nil, nil, log)
+		if err != nil {
+			t.Fatal(err)
+		}
+		li2 := inv2.(*investigate.LoopInvestigator)
+		if li2.ToolTimeout != 5*time.Second {
+			t.Fatalf("explicit tool_timeout not wired: got %v, want 5s", li2.ToolTimeout)
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -507,6 +507,12 @@ func (c *Config) Validate() error {
 	if c.Model.Verify != nil && c.Model.Verify.MaxTokens < 0 {
 		return fmt.Errorf("model.verify.max_tokens must be >= 0 (0 = inherit), got %d", c.Model.Verify.MaxTokens)
 	}
+	// Reject a negative per-tool timeout: time.ParseDuration accepts negative values
+	// which silently disable the feature (fails the > 0 guard in runTool) rather than
+	// setting the intended timeout. 0 means "use the default (60s)".
+	if c.Investigation.ToolTimeout.Std() < 0 {
+		return fmt.Errorf("investigation.tool_timeout must be >= 0 (0 = use the default 60s), got %v", c.Investigation.ToolTimeout.Std())
+	}
 	switch c.Actions.Mode {
 	case "", ActionOff, ActionSuggest:
 		return nil // read-only-ish: nothing to execute

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,7 @@ type Investigation struct {
 	MaxToolOutputBytes        int       `yaml:"max_tool_output_bytes"`        // 0 ⇒ unlimited
 	MaxTokensPerInvestigation int       `yaml:"max_tokens_per_investigation"` // 0 ⇒ unlimited
 	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via applyDefaults
+	ToolTimeout               Duration  `yaml:"tool_timeout"`                 // per-TOOL-call timeout so one hung tool can't eat the budget; 0 ⇒ default (60s) at construction
 
 	// PodLogNamespaces lists extra namespaces (beyond the incident's own) that
 	// pod_logs may read controller/crash logs from. pod_logs streams raw pod logs

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -53,6 +53,43 @@ func TestApplyDefaultsInvestigationTimeout(t *testing.T) {
 	}
 }
 
+func TestApplyDefaultsToolTimeout(t *testing.T) {
+	// Unset ⇒ 60s default is applied so cfg.Investigation.ToolTimeout is non-zero
+	// after Load(); BuildInvestigator's 0→60s guard then becomes a no-op safety net.
+	var c Config
+	applyDefaults(&c)
+	if c.Investigation.ToolTimeout.Std() != 60*time.Second {
+		t.Fatalf("default ToolTimeout: got %v, want 60s", c.Investigation.ToolTimeout.Std())
+	}
+	// Explicit value is respected, not overwritten.
+	var c2 Config
+	c2.Investigation.ToolTimeout = Duration(30 * time.Second)
+	applyDefaults(&c2)
+	if c2.Investigation.ToolTimeout.Std() != 30*time.Second {
+		t.Fatalf("explicit ToolTimeout overwritten: got %v, want 30s", c2.Investigation.ToolTimeout.Std())
+	}
+}
+
+func TestValidateRejectsNegativeToolTimeout(t *testing.T) {
+	// time.ParseDuration accepts negative durations; a negative tool_timeout
+	// silently disables the feature (fails the > 0 guard) instead of setting a
+	// timeout, so it must be rejected at validation time.
+	c := &Config{Investigation: Investigation{ToolTimeout: Duration(-1 * time.Second)}}
+	if err := c.Validate(); err == nil {
+		t.Fatal("negative investigation.tool_timeout must be rejected by Validate")
+	}
+	// Zero is the "use the default" sentinel and must be accepted.
+	ok := &Config{}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("zero tool_timeout (use default) must validate clean: %v", err)
+	}
+	// Positive value is fine.
+	pos := &Config{Investigation: Investigation{ToolTimeout: Duration(45 * time.Second)}}
+	if err := pos.Validate(); err != nil {
+		t.Fatalf("positive tool_timeout must validate clean: %v", err)
+	}
+}
+
 func TestApplyDefaultsInstantRecall(t *testing.T) {
 	// enabled with no tuning → margin/solo gates and decay knobs default to active values.
 	var c Config

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -112,6 +112,7 @@ investigation:
   max_steps: 15
   max_tool_output_bytes: 16384
   max_tokens_per_investigation: 120000
+  tool_timeout: 45s
   pod_log_namespaces: [flux-system, kube-system]
 telemetry:
   metrics_enabled: true
@@ -137,6 +138,9 @@ telemetry:
 	}
 	if c.Investigation.MaxSteps != 15 || c.Investigation.MaxToolOutputBytes != 16384 {
 		t.Fatalf("scalar fields: %+v", c.Investigation)
+	}
+	if c.Investigation.ToolTimeout.Std() != 45*time.Second {
+		t.Fatalf("tool_timeout: got %v, want 45s", c.Investigation.ToolTimeout.Std())
 	}
 	if got := strings.Join(c.Investigation.Coalesce.CorrelationLabels, ","); got != "alertname,namespace" {
 		t.Fatalf("correlation_labels: got %q", got)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -72,6 +72,14 @@ func applyDefaults(c *Config) {
 	if c.Investigation.Timeout == 0 {
 		c.Investigation.Timeout = Duration(10 * time.Minute)
 	}
+	// Per-tool-call timeout: default to 60s when unset so one hung tool can't eat
+	// the whole per-investigation budget while still allowing legitimately slow queries
+	// (log scans, range PromQL) to finish. BuildInvestigator's 0→60s guard becomes a
+	// no-op when already defaulted here; it remains as a safety net for callers that
+	// bypass Load (e.g. tests that build a LoopInvestigator directly).
+	if c.Investigation.ToolTimeout == 0 {
+		c.Investigation.ToolTimeout = Duration(60 * time.Second)
+	}
 	// Instant-recall trust defaults: when enabled without explicit tuning, keep the
 	// margin and solo gates active. A zero margin_gap/solo_floor would degrade recall
 	// to a bare similarity threshold — the exact brittleness this feature removes.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -100,6 +100,14 @@ type LoopInvestigator struct {
 	// delivers a synthetic timeout result rather than starving the queue worker.
 	Timeout time.Duration
 
+	// ToolTimeout bounds a SINGLE tool call so one hung/slow provider (a stuck git
+	// clone, an unresponsive metrics/logs endpoint) can't consume the whole
+	// per-investigation budget. On expiry runTool returns a clear, NON-fatal "timed
+	// out" string that becomes the tool result and the loop continues. 0 disables it
+	// (tool calls then share only the per-investigation Timeout). Defaulted at
+	// construction (see internal/app/investigate.go).
+	ToolTimeout time.Duration
+
 	// Cost controls (0 means disabled/unlimited):
 	MaxToolOutputBytes        int // truncate tool results larger than this before adding to history
 	MaxTokensPerInvestigation int // inject a budget-nudge message when the estimated token count exceeds this
@@ -374,8 +382,18 @@ func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool,
 	if !ok {
 		return "unknown tool: " + tc.Name
 	}
+	// Per-tool timeout: bound this single call so one hung/slow provider (a stuck git
+	// clone, an unresponsive metrics/logs endpoint) can't drain the per-investigation
+	// budget. tctx is derived from ctx, so the parent investigation deadline still
+	// fires first when it's the smaller of the two.
+	tctx := ctx
+	if li.ToolTimeout > 0 {
+		var cancel context.CancelFunc
+		tctx, cancel = context.WithTimeout(ctx, li.ToolTimeout)
+		defer cancel()
+	}
 	tstart := time.Now()
-	out, err := tool.Call(ctx, tc.Args)
+	out, err := tool.Call(tctx, tc.Args)
 	if li.Metrics != nil {
 		tres := "ok"
 		if err != nil {
@@ -387,6 +405,17 @@ func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool,
 			metric.WithAttributes(attribute.String("tool", tc.Name)))
 	}
 	if err != nil {
+		// The PER-TOOL deadline fired, but the parent investigation is NOT itself done:
+		// surface a clear, NON-fatal message so the loop records it as this tool's result
+		// and continues — one hung tool must not abort the whole investigation. When the
+		// parent ctx is also done (the investigation deadline, or an upstream cancel), fall
+		// through to the normal error path so the loop's deadline handling takes over —
+		// don't mask the investigation-level deadline as a per-tool timeout.
+		if li.ToolTimeout > 0 && errors.Is(tctx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			li.Log.Warn("tool call hit per-tool timeout",
+				"tool", tc.Name, "tool_timeout", li.ToolTimeout)
+			return fmt.Sprintf("tool %q timed out after %s", tc.Name, li.ToolTimeout)
+		}
 		return "error: " + err.Error()
 	}
 	return out

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -394,9 +394,18 @@ func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool,
 	}
 	tstart := time.Now()
 	out, err := tool.Call(tctx, tc.Args)
+	// Classify the result BEFORE recording the metric so the per-tool timeout path
+	// gets a distinct result="timeout" label rather than the generic "error". The
+	// detection condition mirrors the non-fatal return below: the per-tool deadline
+	// fired (tctx expired) but the parent investigation is NOT itself done (ctx.Err()
+	// is nil), so the loop can continue with other tools.
+	isPerToolTimeout := li.ToolTimeout > 0 && err != nil && errors.Is(tctx.Err(), context.DeadlineExceeded) && ctx.Err() == nil
 	if li.Metrics != nil {
 		tres := "ok"
-		if err != nil {
+		switch {
+		case isPerToolTimeout:
+			tres = "timeout"
+		case err != nil:
 			tres = "error"
 		}
 		li.Metrics.ToolCalls.Add(ctx, 1, metric.WithAttributes(
@@ -411,7 +420,7 @@ func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool,
 		// parent ctx is also done (the investigation deadline, or an upstream cancel), fall
 		// through to the normal error path so the loop's deadline handling takes over —
 		// don't mask the investigation-level deadline as a per-tool timeout.
-		if li.ToolTimeout > 0 && errors.Is(tctx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+		if isPerToolTimeout {
 			li.Log.Warn("tool call hit per-tool timeout",
 				"tool", tc.Name, "tool_timeout", li.ToolTimeout)
 			return fmt.Sprintf("tool %q timed out after %s", tc.Name, li.ToolTimeout)

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -312,6 +312,137 @@ func TestInvestigateNoDeadlineWhenZero(t *testing.T) {
 	}
 }
 
+// blockingTool's Call blocks until its context is cancelled (a stuck git clone /
+// unresponsive metrics-logs endpoint stand-in). It records how many times Call ran
+// and whether the most recent call observed its context expire.
+type blockingTool struct {
+	name      string
+	calls     int
+	ctxExpiry error
+}
+
+func (b *blockingTool) Name() string        { return b.name }
+func (b *blockingTool) Description() string { return "" }
+func (b *blockingTool) Schema() string      { return "{}" }
+func (b *blockingTool) Call(ctx context.Context, _ string) (string, error) {
+	b.calls++
+	<-ctx.Done()
+	b.ctxExpiry = ctx.Err()
+	return "", ctx.Err()
+}
+
+// TestRunToolPerToolTimeout asserts a hung tool is bounded by ToolTimeout: runTool
+// returns a clear, non-fatal "timed out" string PROMPTLY (without waiting on the
+// much larger parent deadline) so the loop records it and continues.
+func TestRunToolPerToolTimeout(t *testing.T) {
+	tool := &blockingTool{name: "stuck_tool"}
+	li := &LoopInvestigator{
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ToolTimeout: 20 * time.Millisecond,
+	}
+	byName := map[string]Tool{tool.Name(): tool}
+
+	type res struct {
+		out string
+		dur time.Duration
+	}
+	ch := make(chan res, 1)
+	go func() {
+		start := time.Now()
+		// Parent ctx carries a far larger deadline so the only thing that can unblock
+		// the tool promptly is the per-tool timeout, not the investigation deadline.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		out := li.runTool(ctx, byName, providers.ToolCall{ID: "1", Name: tool.Name(), Args: "{}"})
+		ch <- res{out: out, dur: time.Since(start)}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.dur > 2*time.Second {
+			t.Fatalf("runTool did not honour the per-tool timeout (took %v)", r.dur)
+		}
+		if !strings.Contains(strings.ToLower(r.out), "timed out") {
+			t.Fatalf("expected a non-fatal timeout message, got %q", r.out)
+		}
+		if !strings.Contains(r.out, tool.Name()) {
+			t.Fatalf("timeout message should name the tool, got %q", r.out)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTool hung past the per-tool timeout")
+	}
+	if tool.calls != 1 {
+		t.Fatalf("tool should have been called exactly once, got %d", tool.calls)
+	}
+}
+
+// TestRunToolFastUnaffected asserts a fast tool returns its normal output when a
+// per-tool timeout is configured (the timeout must not alter the happy path).
+func TestRunToolFastUnaffected(t *testing.T) {
+	tool := &fakeConfirmTool{name: "fast_tool", out: "all good"}
+	li := &LoopInvestigator{
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ToolTimeout: time.Second, // generous; the fast tool returns well within it
+	}
+	byName := map[string]Tool{tool.Name(): tool}
+	out := li.runTool(context.Background(), byName, providers.ToolCall{ID: "1", Name: tool.Name(), Args: `{"k":"v"}`})
+	if out != "all good" {
+		t.Fatalf("fast tool output altered by per-tool timeout: got %q", out)
+	}
+	if tool.gotArgs != `{"k":"v"}` {
+		t.Fatalf("per-tool timeout wrapping must pass args through, got %q", tool.gotArgs)
+	}
+}
+
+// TestRunToolParentDeadlineNotSwallowed asserts that when the PARENT investigation
+// deadline fires (not the per-tool one), runTool does NOT report a per-tool timeout:
+// the investigation-level deadline must surface as a normal error so the loop's own
+// deadline handling (synthetic timeout result) takes over rather than being masked
+// as a per-tool timeout-and-continue.
+func TestRunToolParentDeadlineNotSwallowed(t *testing.T) {
+	tool := &blockingTool{name: "stuck_tool"}
+	li := &LoopInvestigator{
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ToolTimeout: 10 * time.Second, // far larger than the parent deadline below
+	}
+	byName := map[string]Tool{tool.Name(): tool}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	ch := make(chan string, 1)
+	go func() {
+		ch <- li.runTool(ctx, byName, providers.ToolCall{ID: "1", Name: tool.Name(), Args: "{}"})
+	}()
+	select {
+	case out := <-ch:
+		// The parent investigation deadline fired, NOT the per-tool timeout. It must
+		// not be reported as a per-tool "timed out" message (which the loop would treat
+		// as a recorded tool result and continue) — it must surface as a normal error.
+		if strings.Contains(strings.ToLower(out), "timed out") {
+			t.Fatalf("parent deadline was masked as a per-tool timeout: %q", out)
+		}
+		if !strings.HasPrefix(out, "error:") {
+			t.Fatalf("parent-deadline cancellation should surface as a normal error, got %q", out)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runTool hung past the parent deadline")
+	}
+}
+
+// TestRunToolTimeoutDisabled asserts ToolTimeout==0 leaves runTool's behaviour
+// unchanged: a tool error is returned verbatim as before (no per-tool wrapping).
+func TestRunToolTimeoutDisabled(t *testing.T) {
+	tool := &fakeConfirmTool{name: "ok_tool", out: "fine"}
+	li := &LoopInvestigator{
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ToolTimeout: 0, // disabled
+	}
+	byName := map[string]Tool{tool.Name(): tool}
+	if out := li.runTool(context.Background(), byName, providers.ToolCall{ID: "1", Name: tool.Name(), Args: "{}"}); out != "fine" {
+		t.Fatalf("ToolTimeout==0 must not alter a normal call, got %q", out)
+	}
+}
+
 // errModel returns a plain (non-context) error on Complete — a backend rejecting
 // the request (auth, 5xx, malformed response), distinct from the deadline path.
 type errModel struct {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -443,6 +443,100 @@ func TestRunToolTimeoutDisabled(t *testing.T) {
 	}
 }
 
+// TestRunToolTimeoutMetricLabel verifies that a per-tool timeout is recorded with
+// result="timeout" (not "error") so it is distinguishable from a real backend
+// failure in dashboards/alerts. The fix moved timeout classification BEFORE the
+// metric block so the correct label reaches the counter.
+func TestRunToolTimeoutMetricLabel(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	m := telemetry.NewMetrics()
+
+	tool := &blockingTool{name: "hung_tool"}
+	li := &LoopInvestigator{
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ToolTimeout: 20 * time.Millisecond,
+		Metrics:     m,
+	}
+	byName := map[string]Tool{tool.Name(): tool}
+
+	// Parent ctx has a far longer deadline so only the per-tool timeout fires.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out := li.runTool(ctx, byName, providers.ToolCall{ID: "1", Name: tool.Name(), Args: "{}"})
+	if !strings.Contains(strings.ToLower(out), "timed out") {
+		t.Fatalf("expected a timed-out message, got %q", out)
+	}
+
+	// Scrape /metrics and confirm result="timeout" appears (not result="error").
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	body := rec.Body.String()
+	if !strings.Contains(body, `result="timeout"`) {
+		t.Fatalf("per-tool timeout must record result=\"timeout\", not result=\"error\":\n%s", body)
+	}
+	if strings.Contains(body, `result="error"`) {
+		t.Fatalf("per-tool timeout must NOT record result=\"error\" (it was mis-classified before the fix):\n%s", body)
+	}
+}
+
+// TestInvestigatePerToolTimeoutNonFatal is a loop-level integration test proving
+// the full path: a model requests a hung tool, the per-tool timeout fires (non-
+// fatal), the loop records the "timed out" message in history and continues to a
+// second model call, which submits findings — the investigation reaches a result
+// rather than aborting.
+func TestInvestigatePerToolTimeoutNonFatal(t *testing.T) {
+	hung := &blockingTool{name: "hung_tool"}
+
+	// The scriptModel returns two responses:
+	//   1. request the blocking tool
+	//   2. after seeing the timed-out result in history, submit findings
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: hung.Name(), Args: "{}"}}},
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: submitFindingsName,
+			Args: `{"confidence":0.7,"root_causes":[{"summary":"found despite hung tool"}]}`}}},
+	}}
+
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:       model,
+		Tools:       []Tool{hung},
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:    5,
+		ToolTimeout: 20 * time.Millisecond, // short so the test is fast
+		OnComplete:  func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "HungToolTest"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	// The loop must have reached a result (non-fatal timeout → loop continued).
+	if got == nil {
+		t.Fatal("investigation must deliver a result when a tool times out (non-fatal)")
+	}
+	if len(got.RootCauses) != 1 || got.RootCauses[0].Summary != "found despite hung tool" {
+		t.Fatalf("unexpected finding: %+v", got)
+	}
+	// The model must have been called twice: once to get the tool call, once
+	// after the timed-out message was recorded in history.
+	if model.i != 2 {
+		t.Fatalf("expected 2 model calls (tool request + findings after timeout), got %d", model.i)
+	}
+	// The blocking tool must have been called exactly once and its context must
+	// have expired via the per-tool deadline (not the parent investigation).
+	if hung.calls != 1 {
+		t.Fatalf("hung_tool should have been called exactly once, got %d", hung.calls)
+	}
+	if !errors.Is(hung.ctxExpiry, context.DeadlineExceeded) {
+		t.Fatalf("hung_tool context should have expired via deadline, got %v", hung.ctxExpiry)
+	}
+}
+
 // errModel returns a plain (non-context) error on Complete — a backend rejecting
 // the request (auth, 5xx, malformed response), distinct from the deadline path.
 type errModel struct {


### PR DESCRIPTION
  ## What
  Tool calls in the investigation loop share the single per-investigation deadline with no per-tool bound — so one hung/slow provider (stuck git clone, dead metrics/logs endpoint) could drain the whole budget. Adds a per-tool timeout.

  ## How
  - New `investigation.tool_timeout` (Duration; **default 60s**, applied at construction; `0` ⇒ 60s).
  - `runTool` wraps each call in `context.WithTimeout(ctx, ToolTimeout)` (derived from the investigation ctx, so the parent deadline still wins when smaller).
  - A per-tool timeout returns a non-fatal `tool %q timed out after %s` so the loop records it and continues. It's **distinguished from the investigation deadline** by `errors.Is(tctx.Err(), DeadlineExceeded) && ctx.Err() == nil` — if the parent ctx is also done it falls through to the normal path, so the loop's synthetic-timeout result isn't masked.

  ## Tests (-race)
  Blocking tool → timeout message (~20ms, no hang, tool called once); fast tool unaffected; parent-deadline-not-swallowed; timeout-disabled. The discrimination guard was **mutation-tested** (removing `ctx.Err()==nil` fails the parent-deadline test). Caveat: like the per-investigation deadline, a provider must honor its ctx for in-flight work to actually cancel.