### PR TITLE
  perf(outcome): cache ledger aggregates instead of replaying the JSONL per recall

### DIFF
--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -239,6 +239,14 @@ func RunServe(version string, args []string) error {
 	// startWork runs the leader-only loops (investigation queue + failure watch +
 	// re-investigate poller), scoped to a context cancelled when leadership is lost.
 	startWork := func(workCtx context.Context) {
+		// Re-sync the outcome ledger's cached aggregate from the shared file on every
+		// (re-)acquisition of leadership. In multi-replica HA the file may have grown
+		// while another replica led and this process was a follower; the cache is built
+		// incrementally and would otherwise be stale, corrupting recall-decay. A failed
+		// reload must NOT crash the leader — log and keep serving the prior cache.
+		if rerr := ledger.Reload(); rerr != nil {
+			log.Warn("outcome ledger reload on leadership failed; serving prior cache", "err", rerr)
+		}
 		go queue.Run(workCtx)
 		// The gitops watcher source is built only when sources.gitops.enabled, so
 		// RunWatchers no-ops when no watcher source is present.

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -98,16 +98,19 @@ func New(path string) (*Ledger, error) {
 // back in. It is the single shared cache-build path called by New (single-threaded)
 // and Reload (under mu) — keeping the two in lockstep. A disabled/absent ledger leaves
 // the freshly-reset (empty) maps in place.
+//
+// The read is performed BEFORE any reset: if readEvents returns an error the prior
+// cache is left untouched — callers see a stale-but-valid cache rather than an empty one.
 func (l *Ledger) loadLocked() error {
+	events, err := l.readEvents()
+	if err != nil {
+		return err // prior cache untouched
+	}
 	l.open = map[string]Event{}
 	l.agg = map[string]Aggregate{}
 	l.pendingOpens = map[string][]pendingOpen{}
 	l.pendingResolves = map[string][]time.Time{}
 	l.droppedResolves = 0
-	events, err := l.readEvents()
-	if err != nil {
-		return err
-	}
 	for _, e := range events {
 		switch e.Event {
 		case "open":
@@ -368,7 +371,10 @@ type Aggregate struct {
 // (Resolved+k)/(Recalls+k), and runs on the recall hot path once per incident
 // lookup. It returns the cached aggregate — built once at New and maintained
 // incrementally on every Open/Resolve — so it is O(entries) and never re-reads the
-// file; the value equals a fresh full replay of the ledger for any event sequence.
+// file; the value equals a fresh full replay of the ledger for any event sequence
+// below the maxPendingResolvesPerFingerprint cap — above the cap (pathological
+// orphan-resolve load), dropped excess resolves mean the cache and an unbounded
+// Episodes() replay may diverge.
 // A disabled/empty ledger yields an empty (non-nil) map. The returned map is a
 // fresh copy the caller may freely mutate.
 //

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -66,21 +66,47 @@ type Ledger struct {
 	// entry) it credits without re-reading the file.
 	pendingOpens    map[string][]pendingOpen // fingerprint → LIFO stack of unresolved opens
 	pendingResolves map[string][]time.Time   // fingerprint → buffered early resolves (resolve-before-open), FIFO
+
+	// droppedResolves counts orphan resolves discarded by the pendingResolves bound
+	// (see maxPendingResolvesPerFingerprint) — spurious duplicate/replayed resolve
+	// webhooks. Kept so the (otherwise silent) defensive drop is observable.
+	droppedResolves int
 }
+
+// maxPendingResolvesPerFingerprint bounds the resolve-before-open buffer per
+// fingerprint. The legitimate window (a transient incident whose resolve webhook
+// lands before its open is recorded) needs only a handful of slots; anything beyond
+// this generous cap is spurious — duplicate/replayed resolve webhooks, or resolves
+// whose open was never recorded — and applyResolveLocked would otherwise buffer it
+// forever, growing pendingResolves without limit on a long-lived leader. When full we
+// drop the OLDEST entry (FIFO): a long-buffered resolve is the least likely to ever
+// pair with a real open, and dropping it leaves the brief-window pairing intact.
+const maxPendingResolvesPerFingerprint = 64
 
 // New opens (replaying) the ledger at path. An empty path returns a disabled,
 // no-op ledger (the feature is off).
 func New(path string) (*Ledger, error) {
-	l := &Ledger{
-		path:            path,
-		open:            map[string]Event{},
-		agg:             map[string]Aggregate{},
-		pendingOpens:    map[string][]pendingOpen{},
-		pendingResolves: map[string][]time.Time{},
+	l := &Ledger{path: path}
+	if err := l.loadLocked(); err != nil {
+		return nil, err
 	}
+	return l, nil
+}
+
+// loadLocked (re)builds all in-memory state from a full replay of the file: it resets
+// the open-index, the cached aggregate, and the pairing state, then folds every event
+// back in. It is the single shared cache-build path called by New (single-threaded)
+// and Reload (under mu) — keeping the two in lockstep. A disabled/absent ledger leaves
+// the freshly-reset (empty) maps in place.
+func (l *Ledger) loadLocked() error {
+	l.open = map[string]Event{}
+	l.agg = map[string]Aggregate{}
+	l.pendingOpens = map[string][]pendingOpen{}
+	l.pendingResolves = map[string][]time.Time{}
+	l.droppedResolves = 0
 	events, err := l.readEvents()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	for _, e := range events {
 		switch e.Event {
@@ -92,7 +118,25 @@ func New(path string) (*Ledger, error) {
 			l.applyResolveLocked(e.Fingerprint, e.At)
 		}
 	}
-	return l, nil
+	return nil
+}
+
+// Reload re-replays the ledger file under the write lock and rebuilds the cached
+// aggregate, open-index, and pairing state from scratch. The cache is otherwise
+// maintained incrementally and so only reflects writes made through THIS process: in a
+// multi-replica HA deployment sharing one ledger file, a replica that loses then
+// re-acquires leadership would keep serving its pre-handover cache, missing every
+// open/resolve another replica appended while it was a follower — stale aggregates and
+// thus wrong recall-decay. Call Reload when this process (re-)acquires leadership so it
+// re-syncs with those external writes. It takes the write lock (no torn read against a
+// concurrent OpenCounts). A disabled/nil ledger is a no-op.
+func (l *Ledger) Reload() error {
+	if !l.enabled() {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.loadLocked()
 }
 
 // applyOpenLocked folds one open event into the cached aggregate, mirroring
@@ -126,7 +170,18 @@ func (l *Ledger) applyOpenLocked(e Event) {
 func (l *Ledger) applyResolveLocked(fp string, at time.Time) {
 	stack := l.pendingOpens[fp]
 	if len(stack) == 0 {
-		l.pendingResolves[fp] = append(l.pendingResolves[fp], at)
+		// No pending open yet — buffer this resolve for a later open (resolve-before-open).
+		// Defensive bound: orphan resolves that never pair (duplicate/replayed resolve
+		// webhooks, or resolves whose open was never recorded) would otherwise accumulate
+		// here forever on a long-lived leader. Cap the per-fingerprint buffer, dropping the
+		// oldest excess — these are spurious; the legitimate brief window needs only a few,
+		// so its pairing is untouched.
+		rs := l.pendingResolves[fp]
+		if len(rs) >= maxPendingResolvesPerFingerprint {
+			l.droppedResolves++
+			rs = rs[1:] // drop oldest (FIFO) to make room for the newer resolve
+		}
+		l.pendingResolves[fp] = append(rs, at)
 		return
 	}
 	top := stack[len(stack)-1]
@@ -316,6 +371,11 @@ type Aggregate struct {
 // file; the value equals a fresh full replay of the ledger for any event sequence.
 // A disabled/empty ledger yields an empty (non-nil) map. The returned map is a
 // fresh copy the caller may freely mutate.
+//
+// Behaviour note: because the read moved to New/Reload, OpenCounts no longer performs
+// file I/O and so can no longer return a read error — any error reading the ledger
+// surfaces at construction (New) or re-sync (Reload) time, not per call. The error
+// return is retained for signature stability and is always nil here.
 func (l *Ledger) OpenCounts() (map[string]Aggregate, error) {
 	if l == nil {
 		return map[string]Aggregate{}, nil

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -38,17 +38,46 @@ type Episode struct {
 	Resolved                     bool
 }
 
-// Ledger is an append-only outcome log with an in-memory open-index.
+// pendingOpen is one unresolved open held in a fingerprint's LIFO pairing stack.
+// Every open (fresh or recall) joins the stack so a resolve pops the correct one;
+// counted records a recall open (Kind=="recall" && Entry!="") whose resolution
+// should credit agg[entry].
+type pendingOpen struct {
+	entry   string
+	counted bool
+}
+
+// Ledger is an append-only outcome log with an in-memory open-index and a cached
+// per-entry recall aggregate (the OpenCounts roll-up). The aggregate is built once
+// by replaying the file at New and then maintained INCREMENTALLY under mu on every
+// Open/Resolve, so OpenCounts is O(1) and never re-reads the file — it lived on the
+// recall hot path, which previously replayed the whole JSONL per incident lookup.
 type Ledger struct {
 	path string
 	mu   sync.Mutex
 	open map[string]Event // fingerprint → latest unresolved open
+
+	// agg is the cached OpenCounts result: per recall entry, its recall/resolve
+	// counts and last-confirmed time. Equal to a fresh full replay for any event
+	// sequence (the same LIFO, order-independent pairing as Episodes()).
+	agg map[string]Aggregate
+	// pendingOpens/pendingResolves carry the same pairing state Episodes() rebuilds
+	// per replay, but kept live so a resolve can find which open (and thus which
+	// entry) it credits without re-reading the file.
+	pendingOpens    map[string][]pendingOpen // fingerprint → LIFO stack of unresolved opens
+	pendingResolves map[string][]time.Time   // fingerprint → buffered early resolves (resolve-before-open), FIFO
 }
 
 // New opens (replaying) the ledger at path. An empty path returns a disabled,
 // no-op ledger (the feature is off).
 func New(path string) (*Ledger, error) {
-	l := &Ledger{path: path, open: map[string]Event{}}
+	l := &Ledger{
+		path:            path,
+		open:            map[string]Event{},
+		agg:             map[string]Aggregate{},
+		pendingOpens:    map[string][]pendingOpen{},
+		pendingResolves: map[string][]time.Time{},
+	}
 	events, err := l.readEvents()
 	if err != nil {
 		return nil, err
@@ -57,11 +86,65 @@ func New(path string) (*Ledger, error) {
 		switch e.Event {
 		case "open":
 			l.open[e.Fingerprint] = e
+			l.applyOpenLocked(e)
 		case "resolve":
 			delete(l.open, e.Fingerprint)
+			l.applyResolveLocked(e.Fingerprint, e.At)
 		}
 	}
 	return l, nil
+}
+
+// applyOpenLocked folds one open event into the cached aggregate, mirroring
+// Episodes(): a counted recall open increments Recalls; if an early resolve is
+// already buffered for this fingerprint, the open is paired immediately and also
+// counts as resolved. Must be called with mu held (or during single-threaded New).
+func (l *Ledger) applyOpenLocked(e Event) {
+	counted := e.Kind == "recall" && e.Entry != ""
+	if counted {
+		a := l.agg[e.Entry]
+		a.Recalls++
+		l.agg[e.Entry] = a
+	}
+	// Order-independent pairing: a resolve that arrived before this open is buffered;
+	// pair with the earliest such resolve (FIFO), matching Episodes().
+	if rs := l.pendingResolves[e.Fingerprint]; len(rs) > 0 {
+		at := rs[0]
+		l.pendingResolves[e.Fingerprint] = rs[1:]
+		if counted {
+			l.creditResolveLocked(e.Entry, at)
+		}
+		return
+	}
+	l.pendingOpens[e.Fingerprint] = append(l.pendingOpens[e.Fingerprint], pendingOpen{entry: e.Entry, counted: counted})
+}
+
+// applyResolveLocked folds one resolve event into the cached aggregate, mirroring
+// Episodes(): pop the most-recent unresolved open (LIFO) for the fingerprint and,
+// if it was a counted recall, credit its resolution; with no pending open, buffer
+// the resolve for a later open. Must be called with mu held (or during New).
+func (l *Ledger) applyResolveLocked(fp string, at time.Time) {
+	stack := l.pendingOpens[fp]
+	if len(stack) == 0 {
+		l.pendingResolves[fp] = append(l.pendingResolves[fp], at)
+		return
+	}
+	top := stack[len(stack)-1]
+	l.pendingOpens[fp] = stack[:len(stack)-1]
+	if top.counted {
+		l.creditResolveLocked(top.entry, at)
+	}
+}
+
+// creditResolveLocked records a resolved recall for entry: Resolved++ and bump
+// LastConfirmed to the latest resolve time. Must be called with mu held (or New).
+func (l *Ledger) creditResolveLocked(entry string, at time.Time) {
+	a := l.agg[entry]
+	a.Resolved++
+	if at.After(a.LastConfirmed) {
+		a.LastConfirmed = at
+	}
+	l.agg[entry] = a
 }
 
 // readEvents replays the ledger file in order, skipping corrupt lines. It returns
@@ -150,9 +233,10 @@ func (l *Ledger) Open(e Event) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if err := l.appendLocked(e); err != nil {
-		return err
+		return err // append failed: leave both index and cache untouched
 	}
 	l.open[e.Fingerprint] = e
+	l.applyOpenLocked(e) // keep the OpenCounts cache in lockstep with the durable write
 	return nil
 }
 
@@ -224,29 +308,23 @@ type Aggregate struct {
 	LastConfirmed time.Time
 }
 
-// OpenCounts rolls Episodes up per catalog entry, counting recall episodes only
-// (fresh investigations carry no entry). It is the input to recall decay:
-// resolve-rate ≈ (Resolved+k)/(Recalls+k). A disabled/empty ledger yields an
-// empty (non-nil) map.
+// OpenCounts rolls recall episodes up per catalog entry (fresh investigations
+// carry no entry). It is the input to recall decay: resolve-rate ≈
+// (Resolved+k)/(Recalls+k), and runs on the recall hot path once per incident
+// lookup. It returns the cached aggregate — built once at New and maintained
+// incrementally on every Open/Resolve — so it is O(entries) and never re-reads the
+// file; the value equals a fresh full replay of the ledger for any event sequence.
+// A disabled/empty ledger yields an empty (non-nil) map. The returned map is a
+// fresh copy the caller may freely mutate.
 func (l *Ledger) OpenCounts() (map[string]Aggregate, error) {
-	eps, err := l.Episodes()
-	if err != nil {
-		return nil, err
+	if l == nil {
+		return map[string]Aggregate{}, nil
 	}
-	counts := map[string]Aggregate{}
-	for _, e := range eps {
-		if e.Kind != "recall" || e.Entry == "" {
-			continue
-		}
-		a := counts[e.Entry]
-		a.Recalls++
-		if e.Resolved {
-			a.Resolved++
-			if e.ResolvedAt.After(a.LastConfirmed) {
-				a.LastConfirmed = e.ResolvedAt
-			}
-		}
-		counts[e.Entry] = a
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	counts := make(map[string]Aggregate, len(l.agg))
+	for k, v := range l.agg {
+		counts[k] = v
 	}
 	return counts, nil
 }
@@ -260,8 +338,9 @@ func (l *Ledger) Resolve(fp string, at time.Time) (Episode, bool, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if err := l.appendLocked(Event{Event: "resolve", Fingerprint: fp, At: at}); err != nil {
-		return Episode{}, false, err
+		return Episode{}, false, err // append failed: leave both index and cache untouched
 	}
+	l.applyResolveLocked(fp, at) // keep the OpenCounts cache in lockstep with the durable write
 	o, ok := l.open[fp]
 	if !ok {
 		return Episode{}, false, nil

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -266,6 +266,96 @@ func TestOpenCountsCacheConcurrent(t *testing.T) {
 	}
 }
 
+// TestReloadResyncsExternalWrites simulates multi-replica HA failover: a SECOND
+// Ledger pointed at the SAME file (another replica's leader) appends opens/resolves
+// while the first instance is a follower. The first instance's incrementally-built
+// cache stays stale until Reload re-replays the shared file — exactly what a
+// re-acquired leader must do so its recall-decay aggregate is not stale.
+func TestReloadResyncsExternalWrites(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	a, err := New(p) // "pod A": builds its cache over the (empty) file
+	if err != nil {
+		t.Fatalf("New a: %v", err)
+	}
+	if c, _ := a.OpenCounts(); len(c) != 0 {
+		t.Fatalf("pod A must start empty, got %+v", c)
+	}
+
+	// "pod B": another replica writes to the shared file while A is a follower.
+	b, err := New(p)
+	if err != nil {
+		t.Fatalf("New b: %v", err)
+	}
+	t0 := time.Unix(16000, 0)
+	_ = b.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "a.md", At: t0})
+	_, _, _ = b.Resolve("fp", t0.Add(time.Minute))
+
+	// A's cache never saw B's writes, so it is stale.
+	if c, _ := a.OpenCounts(); c["a.md"].Recalls != 0 {
+		t.Fatalf("pre-Reload pod A must be stale (recalls=0), got %+v", c["a.md"])
+	}
+
+	// Re-acquiring leadership triggers Reload, re-syncing with B's external writes.
+	if err := a.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if c, _ := a.OpenCounts(); c["a.md"].Recalls != 1 || c["a.md"].Resolved != 1 || !c["a.md"].LastConfirmed.Equal(t0.Add(time.Minute)) {
+		t.Fatalf("post-Reload pod A must reflect B's writes, got %+v", c["a.md"])
+	}
+	assertCacheEqualsReplay(t, a, p)
+
+	// Reload rebuilds the open-index too, so A can resolve an open B recorded.
+	_ = b.Open(Event{Fingerprint: "fp2", Kind: "recall", Entry: "c.md", At: t0.Add(2 * time.Minute)})
+	if err := a.Reload(); err != nil {
+		t.Fatalf("Reload 2: %v", err)
+	}
+	if _, ok, _ := a.Resolve("fp2", t0.Add(3*time.Minute)); !ok {
+		t.Fatal("post-Reload pod A must see B's open in its rebuilt index")
+	}
+}
+
+// TestReloadDisabledOrNilNoop ensures Reload is a safe no-op on a disabled (path=="")
+// or nil ledger — the leadership wiring calls it unconditionally.
+func TestReloadDisabledOrNilNoop(t *testing.T) {
+	dis, _ := New("")
+	if err := dis.Reload(); err != nil {
+		t.Fatalf("disabled Reload must be a no-op: %v", err)
+	}
+	var nilLedger *Ledger
+	if err := nilLedger.Reload(); err != nil {
+		t.Fatalf("nil Reload must be a no-op: %v", err)
+	}
+}
+
+// TestPendingResolvesBounded verifies the defensive per-fingerprint cap on buffered
+// orphan resolves: far more spurious resolves than the cap stay bounded and the excess
+// is counted, while the legitimate resolve-before-open pairing still works.
+func TestPendingResolvesBounded(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(17000, 0)
+	// Many orphan resolves for one fingerprint (e.g. duplicate/replayed resolve
+	// webhooks whose open was never recorded).
+	n := maxPendingResolvesPerFingerprint + 100
+	for i := 0; i < n; i++ {
+		_, _, _ = l.Resolve("orphan", t0.Add(time.Duration(i)*time.Second))
+	}
+	l.mu.Lock()
+	got := len(l.pendingResolves["orphan"])
+	dropped := l.droppedResolves
+	l.mu.Unlock()
+	if got > maxPendingResolvesPerFingerprint {
+		t.Fatalf("pendingResolves must be bounded at %d, got %d", maxPendingResolvesPerFingerprint, got)
+	}
+	if dropped == 0 {
+		t.Fatalf("excess orphan resolves must be counted as dropped, got 0")
+	}
+	// The brief-window case still pairs: a buffered resolve pairs with a later open.
+	_ = l.Open(Event{Fingerprint: "orphan", Kind: "recall", Entry: "z.md", At: t0.Add(time.Duration(n) * time.Second)})
+	if c, _ := l.OpenCounts(); c["z.md"].Recalls != 1 || c["z.md"].Resolved != 1 {
+		t.Fatalf("a buffered resolve must still pair with a later open: %+v", c["z.md"])
+	}
+}
+
 func TestStatusDisabled(t *testing.T) {
 	l, _ := New("")
 	s := l.Status()

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -314,6 +314,76 @@ func TestReloadResyncsExternalWrites(t *testing.T) {
 	}
 }
 
+// TestReloadErrorPreservesPriorCache is a regression test for the ordering bug where
+// loadLocked wiped the cache maps before calling readEvents: if readEvents fails the
+// cache was left empty rather than preserving the pre-Reload state. This test appends
+// a line longer than the bufio.Scanner buffer (>1 MiB) so readEvents returns
+// bufio.ErrTooLong, then asserts that Reload returns a non-nil error AND that
+// OpenCounts still equals the pre-Reload value (not empty).
+func TestReloadErrorPreservesPriorCache(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t0 := time.Unix(20000, 0)
+	// Populate the ledger so OpenCounts is non-empty.
+	_ = l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "a.md", At: t0})
+	_ = l.Open(Event{Fingerprint: "fp2", Kind: "recall", Entry: "b.md", At: t0.Add(time.Second)})
+	_, _, _ = l.Resolve("fp1", t0.Add(2*time.Second))
+
+	// Capture the pre-Reload cache.
+	before, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts before: %v", err)
+	}
+	if len(before) == 0 {
+		t.Fatal("pre-condition: OpenCounts must be non-empty before Reload")
+	}
+
+	// Append a line >1 MiB (the Scanner max token size) to make readEvents fail with
+	// bufio.ErrTooLong. This is uid-independent (no chmod needed).
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open ledger file for poisoning: %v", err)
+	}
+	// 1 MiB + 1 byte of non-JSON to exceed the scanner buffer.
+	giant := make([]byte, 1024*1024+1)
+	for i := range giant {
+		giant[i] = 'x'
+	}
+	giant[len(giant)-1] = '\n'
+	if _, err := f.Write(giant); err != nil {
+		f.Close()
+		t.Fatalf("write giant line: %v", err)
+	}
+	f.Close()
+
+	// Reload must return a non-nil error.
+	reloadErr := l.Reload()
+	if reloadErr == nil {
+		t.Fatal("Reload over a >1 MiB line must return a non-nil error")
+	}
+
+	// Cache must be unchanged — not empty.
+	after, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts after failed Reload: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("failed Reload must preserve prior cache: before=%+v after=%+v", before, after)
+	}
+	for k, w := range before {
+		got, ok := after[k]
+		if !ok {
+			t.Fatalf("entry %q missing from cache after failed Reload: before=%+v after=%+v", k, before, after)
+		}
+		if got.Recalls != w.Recalls || got.Resolved != w.Resolved || !got.LastConfirmed.Equal(w.LastConfirmed) {
+			t.Fatalf("cache mismatch for %q after failed Reload: before=%+v after=%+v", k, w, got)
+		}
+	}
+}
+
 // TestReloadDisabledOrNilNoop ensures Reload is a safe no-op on a disabled (path=="")
 // or nil ledger — the leadership wiring calls it unconditionally.
 func TestReloadDisabledOrNilNoop(t *testing.T) {

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1,11 +1,257 @@
 package outcome
 
 import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
+
+// replayOpenCounts is an independent oracle: it computes the per-entry recall
+// aggregate by replaying every event in the file from scratch, mirroring the
+// documented Episodes()→OpenCounts() semantics (LIFO pairing, order-independent
+// resolve-before-open buffering). The cached OpenCounts() must equal this for
+// any event sequence.
+func replayOpenCounts(t *testing.T, path string) map[string]Aggregate {
+	t.Helper()
+	ref, err := New(path)
+	if err != nil {
+		t.Fatalf("oracle New: %v", err)
+	}
+	eps, err := ref.Episodes() // Episodes still replays the file, so it is a fresh source of truth
+	if err != nil {
+		t.Fatalf("oracle Episodes: %v", err)
+	}
+	counts := map[string]Aggregate{}
+	for _, e := range eps {
+		if e.Kind != "recall" || e.Entry == "" {
+			continue
+		}
+		a := counts[e.Entry]
+		a.Recalls++
+		if e.Resolved {
+			a.Resolved++
+			if e.ResolvedAt.After(a.LastConfirmed) {
+				a.LastConfirmed = e.ResolvedAt
+			}
+		}
+		counts[e.Entry] = a
+	}
+	return counts
+}
+
+func assertCacheEqualsReplay(t *testing.T, l *Ledger, path string) {
+	t.Helper()
+	cached, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	want := replayOpenCounts(t, path)
+	if !reflect.DeepEqual(cached, want) {
+		t.Fatalf("cache != replay\n cached=%+v\n replay=%+v", cached, want)
+	}
+}
+
+// TestOpenCountsCacheEqualsReplaySequence drives a varied open/resolve sequence
+// (recurrence, multiple entries, resolve-before-open, fresh, interleaving) and
+// asserts the live cached OpenCounts() equals a from-scratch replay of the file.
+func TestOpenCountsCacheEqualsReplaySequence(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(10000, 0)
+	at := func(d int) time.Time { return t0.Add(time.Duration(d) * time.Second) }
+
+	// recurrence on one entry: 3 opens, 1 resolve (LIFO ⇒ exactly 1 resolved)
+	_ = l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "x.md", At: at(0)})
+	_ = l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "x.md", At: at(1)})
+	_ = l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "x.md", At: at(2)})
+	_, _, _ = l.Resolve("fp1", at(5))
+	// a fresh open (must never appear in counts)
+	_ = l.Open(Event{Fingerprint: "fr", Kind: "fresh", At: at(6)})
+	_, _, _ = l.Resolve("fr", at(7))
+	// second entry, resolved once
+	_ = l.Open(Event{Fingerprint: "fp2", Kind: "recall", Entry: "y.md", At: at(8)})
+	_, _, _ = l.Resolve("fp2", at(9))
+	// resolve-before-open: the resolve lands first, then the open pairs with it
+	_, _, _ = l.Resolve("fp3", at(10))
+	_ = l.Open(Event{Fingerprint: "fp3", Kind: "recall", Entry: "z.md", At: at(11)})
+	// unresolved recall
+	_ = l.Open(Event{Fingerprint: "fp4", Kind: "recall", Entry: "w.md", At: at(12)})
+
+	assertCacheEqualsReplay(t, l, p)
+
+	// Spot-check the documented shape too, not only DeepEqual against the oracle.
+	counts, _ := l.OpenCounts()
+	if got := counts["x.md"]; got.Recalls != 3 || got.Resolved != 1 || !got.LastConfirmed.Equal(at(5)) {
+		t.Fatalf("x.md = %+v", got)
+	}
+	if got := counts["z.md"]; got.Recalls != 1 || got.Resolved != 1 {
+		t.Fatalf("resolve-before-open z.md = %+v", got)
+	}
+	if got := counts["w.md"]; got.Recalls != 1 || got.Resolved != 0 {
+		t.Fatalf("unresolved w.md = %+v", got)
+	}
+	if _, ok := counts["fresh"]; ok {
+		t.Fatalf("fresh must not be counted: %+v", counts)
+	}
+}
+
+// TestOpenCountsCacheReflectsAppendsAfterConstruction ensures the cache is
+// updated INCREMENTALLY on appends made after New(), not only at load.
+func TestOpenCountsCacheReflectsAppendsAfterConstruction(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p) // constructed over an empty/absent file
+	if c, _ := l.OpenCounts(); len(c) != 0 {
+		t.Fatalf("fresh ledger must start empty, got %+v", c)
+	}
+	t0 := time.Unix(11000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "a.md", At: t0})
+	if c, _ := l.OpenCounts(); c["a.md"].Recalls != 1 || c["a.md"].Resolved != 0 {
+		t.Fatalf("after Open, want recalls=1 resolved=0, got %+v", c["a.md"])
+	}
+	_, _, _ = l.Resolve("fp", t0.Add(time.Minute))
+	if c, _ := l.OpenCounts(); c["a.md"].Resolved != 1 || !c["a.md"].LastConfirmed.Equal(t0.Add(time.Minute)) {
+		t.Fatalf("after Resolve, want resolved=1 with LastConfirmed bumped, got %+v", c["a.md"])
+	}
+	assertCacheEqualsReplay(t, l, p)
+}
+
+// TestOpenCountsCacheBuiltFromExistingFile ensures opening a ledger over a file
+// that already has events builds the cache once at construction (no append needed).
+func TestOpenCountsCacheBuiltFromExistingFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	seed, _ := New(p)
+	t0 := time.Unix(12000, 0)
+	_ = seed.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "a.md", At: t0})
+	_ = seed.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "a.md", At: t0.Add(time.Second)})
+	_, _, _ = seed.Resolve("fp", t0.Add(5*time.Second))
+
+	reopened, err := New(p)
+	if err != nil {
+		t.Fatalf("reopen New: %v", err)
+	}
+	c, _ := reopened.OpenCounts()
+	if c["a.md"].Recalls != 2 || c["a.md"].Resolved != 1 || !c["a.md"].LastConfirmed.Equal(t0.Add(5*time.Second)) {
+		t.Fatalf("reopened cache from file = %+v", c["a.md"])
+	}
+	assertCacheEqualsReplay(t, reopened, p)
+}
+
+// TestOpenCountsCacheSkipsCorruptLinesOnLoad ensures the initial cache build
+// skips corrupt JSONL lines (matching readEvents' tolerance) rather than failing.
+func TestOpenCountsCacheSkipsCorruptLinesOnLoad(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	t0 := time.Unix(13000, 0)
+	good1, _ := json.Marshal(Event{Event: "open", Fingerprint: "fp", Kind: "recall", Entry: "a.md", At: t0})
+	good2, _ := json.Marshal(Event{Event: "resolve", Fingerprint: "fp", At: t0.Add(time.Minute)})
+	content := string(good1) + "\n" + "this is not json{{{\n" + string(good2) + "\n"
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	l, err := New(p)
+	if err != nil {
+		t.Fatalf("New over file with a corrupt line must not fail: %v", err)
+	}
+	c, _ := l.OpenCounts()
+	if c["a.md"].Recalls != 1 || c["a.md"].Resolved != 1 {
+		t.Fatalf("corrupt line must be skipped, good events counted: %+v", c["a.md"])
+	}
+	assertCacheEqualsReplay(t, l, p)
+}
+
+// TestOpenCountsCacheRandomizedEqualsReplay fuzzes many random open/resolve
+// sequences (across fingerprints and entries, including resolve-before-open) and
+// asserts the cached OpenCounts() always equals a from-scratch replay.
+func TestOpenCountsCacheRandomizedEqualsReplay(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	fps := []string{"f0", "f1", "f2"}
+	entries := []string{"a.md", "b.md", ""} // "" ⇒ fresh-style open
+	t0 := time.Unix(14000, 0)
+	for trial := 0; trial < 40; trial++ {
+		p := filepath.Join(t.TempDir(), fmt.Sprintf("o%d.jsonl", trial))
+		l, _ := New(p)
+		n := 5 + rng.Intn(25)
+		for i := 0; i < n; i++ {
+			fp := fps[rng.Intn(len(fps))]
+			at := t0.Add(time.Duration(i) * time.Second)
+			if rng.Intn(2) == 0 {
+				entry := entries[rng.Intn(len(entries))]
+				kind := "recall"
+				if entry == "" {
+					kind = "fresh"
+				}
+				_ = l.Open(Event{Fingerprint: fp, Kind: kind, Entry: entry, At: at})
+			} else {
+				_, _, _ = l.Resolve(fp, at)
+			}
+		}
+		assertCacheEqualsReplay(t, l, p)
+	}
+}
+
+// TestOpenCountsCacheConcurrent exercises concurrent Open/Resolve and OpenCounts
+// to catch data races (run under -race). It asserts the final cached aggregate
+// equals a from-scratch replay of the file.
+func TestOpenCountsCacheConcurrent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(15000, 0)
+	const writers = 8
+	const perWriter = 50
+	var writersWG, readersWG sync.WaitGroup
+
+	// readers hammer OpenCounts concurrently with the writers, until stop is closed
+	stop := make(chan struct{})
+	for r := 0; r < 4; r++ {
+		readersWG.Add(1)
+		go func() {
+			defer readersWG.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if _, err := l.OpenCounts(); err != nil {
+						t.Errorf("OpenCounts: %v", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	for w := 0; w < writers; w++ {
+		writersWG.Add(1)
+		go func(w int) {
+			defer writersWG.Done()
+			fp := fmt.Sprintf("fp%d", w)
+			entry := fmt.Sprintf("e%d.md", w)
+			for i := 0; i < perWriter; i++ {
+				at := t0.Add(time.Duration(w*perWriter+i) * time.Second)
+				_ = l.Open(Event{Fingerprint: fp, Kind: "recall", Entry: entry, At: at})
+				_, _, _ = l.Resolve(fp, at.Add(time.Millisecond))
+			}
+		}(w)
+	}
+
+	writersWG.Wait() // all appends done
+	close(stop)      // let readers exit
+	readersWG.Wait()
+
+	assertCacheEqualsReplay(t, l, p)
+	c, _ := l.OpenCounts()
+	for w := 0; w < writers; w++ {
+		entry := fmt.Sprintf("e%d.md", w)
+		if c[entry].Recalls != perWriter || c[entry].Resolved != perWriter {
+			t.Fatalf("%s: want recalls=%d resolved=%d, got %+v", entry, perWriter, perWriter, c[entry])
+		}
+	}
+}
 
 func TestStatusDisabled(t *testing.T) {
 	l, _ := New("")

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -354,10 +354,10 @@ func TestReloadErrorPreservesPriorCache(t *testing.T) {
 	}
 	giant[len(giant)-1] = '\n'
 	if _, err := f.Write(giant); err != nil {
-		f.Close()
+		_ = f.Close()
 		t.Fatalf("write giant line: %v", err)
 	}
-	f.Close()
+	_ = f.Close()
 
 	// Reload must return a non-nil error.
 	reloadErr := l.Reload()

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -52,8 +51,22 @@ func assertCacheEqualsReplay(t *testing.T, l *Ledger, path string) {
 		t.Fatalf("OpenCounts: %v", err)
 	}
 	want := replayOpenCounts(t, path)
-	if !reflect.DeepEqual(cached, want) {
-		t.Fatalf("cache != replay\n cached=%+v\n replay=%+v", cached, want)
+	if len(cached) != len(want) {
+		t.Fatalf("cache != replay (entries %d vs %d)\n cached=%+v\n replay=%+v", len(cached), len(want), cached, want)
+	}
+	// Compare field-by-field. LastConfirmed is a time.Time and MUST be compared by
+	// instant (.Equal), not reflect.DeepEqual: the cache holds in-memory (time.Local)
+	// times while the replay holds JSON-parsed times, so their *Location pointers differ
+	// (e.g. time.Local vs time.UTC when the process runs in UTC, as CI does) even when
+	// the instants are identical — DeepEqual would spuriously fail.
+	for k, w := range want {
+		got, ok := cached[k]
+		if !ok {
+			t.Fatalf("cache missing entry %q\n cached=%+v\n replay=%+v", k, cached, want)
+		}
+		if got.Recalls != w.Recalls || got.Resolved != w.Resolved || !got.LastConfirmed.Equal(w.LastConfirmed) {
+			t.Fatalf("cache != replay for %q: cached=%+v replay=%+v", k, got, w)
+		}
 	}
 }
 


### PR DESCRIPTION
  ## What
  `OpenCounts()` re-read and replayed the **entire** append-only JSONL ledger from disk on every call — on the recall hot path (once per incident lookup), under the full mutex. Now O(1) via an incrementally-maintained in-memory aggregate.

  ## How
  The aggregate is built once when the ledger opens (one file read) and updated incrementally on each `Open`/`Resolve` **after** the fsync'd append, **under the existing lock**. `OpenCounts` returns a copy of the cache — no disk I/O. The incremental fold mirrors `Episodes()` exactly (per-fingerprint LIFO open stack + FIFO resolve-before-open buffer). `OpenCounts`'s contract is unchanged (`recall.go` untouched); `Episodes()`
  still replays for its full-reconstruction callers.

  ## Tests (-race, 28 total)
  Cache==replay equivalence proven against a from-scratch replay **oracle** — including a 40-sequence randomized test and an 8-writer × 4-reader concurrency test. The oracle tests were confirmed green on the *original* replay impl first, then stayed green after caching.