### PR TITLE
feat: cross-step prompt caching + cache-token observability

### DIFF
--- a/docs/superpowers/plans/2026-06-30-cross-step-prompt-caching.md
+++ b/docs/superpowers/plans/2026-06-30-cross-step-prompt-caching.md
@@ -1,0 +1,543 @@
+# Cross-step Prompt Caching + Cache Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the investigation loop's dominant token cost by caching the growing conversation prefix on every provider, and make the cache win measurable.
+
+**Architecture:** Three independent provider changes behind the shared `providers.Usage` contract. Anthropic gets a rolling `cache_control` breakpoint on conversation history (active win). Gemini relies on automatic implicit caching, guarded by a prefix-stability test. All three providers parse the cache-token fields they already return, normalized so a hit-ratio is comparable, and the loop records two new metrics.
+
+**Tech Stack:** Go 1.26, standard library + OpenTelemetry metrics (already a dependency). No new module deps.
+
+## Global Constraints
+
+- Go 1.26.0; standard library + existing deps only — no new module dependencies.
+- No co-authored commits; no AI attribution in commit messages or PR text.
+- **Usage normalization (load-bearing, verified against provider docs):** `Usage.InputTokens` is the TOTAL input footprint INCLUDING cached tokens; `Usage.CachedInputTokens` is the cache-READ subset. Anthropic reports `input_tokens` as the *non-cached remainder*, so `InputTokens = input_tokens + cache_read_input_tokens + cache_creation_input_tokens`. OpenAI `prompt_tokens` and Gemini `promptTokenCount` already include the cached subset, so `InputTokens` = that value unchanged.
+- Cache fields default to 0 ("unknown / none") when a provider omits them — never fabricate.
+- Follow existing per-package test patterns: model packages use the `sseServer(t, capture, events)` helper and decode the captured request body into the provider's request struct; telemetry uses the `metrics_test.go` style.
+- Spec: `docs/superpowers/specs/2026-06-30-cross-step-prompt-caching-design.md`.
+
+---
+
+### Task 1: Anthropic — usage cache fields + T1 rolling breakpoint
+
+**Files:**
+- Modify: `internal/providers/providers.go` (extend `Usage` — first task to need it)
+- Modify: `internal/model/anthropic/anthropic.go` (`block` struct, `usageDelta`, `Complete` history marking, `accumulate` message_start)
+- Test: `internal/model/anthropic/anthropic_test.go`
+
+**Interfaces:**
+- Produces: `providers.Usage` with two new int fields `CachedInputTokens`, `CacheWriteTokens` (consumed by Tasks 2, 3, 4).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/model/anthropic/anthropic_test.go`:
+
+```go
+// TestPromptCacheHistoryBreakpoint asserts the rolling breakpoint: the last content
+// block of the last message carries cache_control, alongside system + last tool.
+func TestPromptCacheHistoryBreakpoint(t *testing.T) {
+	var gotReq msgRequest
+	srv := sseServer(t, func(r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+	}, []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	})
+	defer srv.Close()
+
+	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		System: "sys",
+		Messages: []providers.Message{
+			{Role: "user", Content: "incident"},
+			{Role: "assistant", Content: "thinking", ToolCalls: []providers.ToolCall{{ID: "t1", Name: "a", Args: "{}"}}},
+			{Role: "tool", ToolCallID: "t1", Content: "result"},
+		},
+		Tools: []providers.ToolSpec{{Name: "a", Description: "d", Schema: `{"type":"object"}`}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// system marked
+	if len(gotReq.System) == 0 || gotReq.System[0].CacheControl == nil {
+		t.Fatalf("system block should be a cache breakpoint: %+v", gotReq.System)
+	}
+	// last tool marked
+	lt := gotReq.Tools[len(gotReq.Tools)-1]
+	if lt.CacheControl == nil || lt.CacheControl.Type != "ephemeral" {
+		t.Fatalf("last tool should be a cache breakpoint: %+v", lt)
+	}
+	// last block of the last message marked (the rolling breakpoint)
+	last := gotReq.Messages[len(gotReq.Messages)-1]
+	lb := last.Content[len(last.Content)-1]
+	if lb.CacheControl == nil || lb.CacheControl.Type != "ephemeral" {
+		t.Fatalf("last message's last block should be the rolling cache breakpoint: %+v", last)
+	}
+	// an earlier message block must NOT be marked
+	if gotReq.Messages[0].Content[0].CacheControl != nil {
+		t.Fatalf("earlier message blocks must not be marked: %+v", gotReq.Messages[0])
+	}
+}
+
+// TestUsageCacheFields asserts the Anthropic usage normalization: InputTokens is the
+// sum of input + cache_read + cache_creation; the read/creation subsets are reported.
+func TestUsageCacheFields(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":30,\"cache_read_input_tokens\":100,\"cache_creation_input_tokens\":20}}}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":7}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.InputTokens != 150 || resp.Usage.CachedInputTokens != 100 || resp.Usage.CacheWriteTokens != 20 {
+		t.Fatalf("usage = %+v, want in=150 cached=100 write=20", resp.Usage)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/model/anthropic/ -run 'TestPromptCacheHistoryBreakpoint|TestUsageCacheFields' -v`
+Expected: compile error first (the new `Usage` / `block.CacheControl` fields don't exist), then FAIL.
+
+- [ ] **Step 3: Extend `providers.Usage`**
+
+In `internal/providers/providers.go`, replace the `Usage` struct:
+
+```go
+// Usage is the provider-reported token accounting for one completion.
+type Usage struct {
+	InputTokens  int // total prompt/input tokens billed, INCLUDING any served from cache (normalized across providers)
+	OutputTokens int // generated/output tokens in the reply
+	// CachedInputTokens is the subset of InputTokens that was a cache READ (Anthropic
+	// cache_read_input_tokens, OpenAI prompt_tokens_details.cached_tokens, Gemini
+	// cachedContentTokenCount) — the saving. 0 when the provider reports none.
+	CachedInputTokens int
+	// CacheWriteTokens is input tokens WRITTEN to the cache this request (Anthropic
+	// cache_creation_input_tokens, billed ~1.25x). 0 for providers that don't report it.
+	CacheWriteTokens int
+}
+```
+
+- [ ] **Step 4: Add `CacheControl` to the `block` struct**
+
+In `internal/model/anthropic/anthropic.go`, add the field to `block` (after the tool_result fields):
+
+```go
+	// tool_result
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+	// cache breakpoint (set on the last block of the last message — the rolling history breakpoint)
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
+```
+
+- [ ] **Step 5: Add cache fields to `usageDelta`**
+
+In `internal/model/anthropic/anthropic.go`, extend `usageDelta`:
+
+```go
+type usageDelta struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+}
+```
+
+- [ ] **Step 6: Mark the last message block in `Complete`, and normalize usage in `accumulate`**
+
+In `Complete`, replace the `areq := msgRequest{...}` construction so the history is marked first:
+
+```go
+	msgs := toMessages(req.Messages)
+	// Rolling cache breakpoint: mark the last content block of the last message, so the
+	// growing conversation prefix is a cache READ on the next step. The loop only ever
+	// APPENDS to history, so the prefix is byte-identical step to step — a guaranteed
+	// rolling hit. Total breakpoints stay <= 4 (system + last tool + this one). Below
+	// Anthropic's minimum cacheable size the marker is ignored, so early steps are fine.
+	if n := len(msgs); n > 0 {
+		if blocks := msgs[n-1].Content; len(blocks) > 0 {
+			blocks[len(blocks)-1].CacheControl = ephemeral
+		}
+	}
+	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Stream: true, Messages: msgs}
+```
+
+In `accumulate`, replace the `message_start` usage handling:
+
+```go
+		case "message_start":
+			if ev.Message != nil && ev.Message.Usage != nil {
+				u := ev.Message.Usage
+				// Anthropic reports input_tokens as the NON-cached remainder; total input is
+				// the sum of input + cache_read + cache_creation (per Anthropic docs).
+				out.Usage.InputTokens = u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+				out.Usage.CachedInputTokens = u.CacheReadInputTokens
+				out.Usage.CacheWriteTokens = u.CacheCreationInputTokens
+			}
+```
+
+- [ ] **Step 7: Run tests to verify pass + no regressions**
+
+Run: `go test ./internal/model/anthropic/ -v`
+Expected: PASS — the two new tests pass; existing tests including `TestPromptCacheToolsOnly`, `TestComplete`, `TestUsageAndStopReason` still pass (those send a single user message; the rolling marker lands on that message's block but they assert system/tool breakpoints and in/out token counts, which are unchanged — verify `TestComplete`'s `Usage.InputTokens` still equals its expected value since its message_start has no cache fields, so the sum equals plain input_tokens).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/providers/providers.go internal/model/anthropic/
+git commit -m "feat(anthropic): cache conversation history + report cache tokens
+
+Add a rolling cache_control breakpoint on the last block of the last message so the
+growing tool-output history is a cache read across ReAct steps (was re-billed in full
+every step). Extend providers.Usage with CachedInputTokens/CacheWriteTokens and
+populate them from the Anthropic message_start usage (input normalized to the total)."
+```
+
+---
+
+### Task 2: OpenAI — parse cached_tokens
+
+**Files:**
+- Modify: `internal/model/openai/openai.go` (`chatChunk.Usage`, `accumulate`)
+- Test: `internal/model/openai/openai_test.go`
+
+**Interfaces:**
+- Consumes: `providers.Usage.CachedInputTokens` (Task 1).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/model/openai/openai_test.go`:
+
+```go
+// TestUsageCachedTokens asserts prompt_tokens_details.cached_tokens maps to
+// CachedInputTokens (OpenAI prompt_tokens already includes the cached subset).
+func TestUsageCachedTokens(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+		"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":200,\"completion_tokens\":9,\"prompt_tokens_details\":{\"cached_tokens\":160}}}\n\n",
+		"data: [DONE]\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "m", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.InputTokens != 200 || resp.Usage.CachedInputTokens != 160 {
+		t.Fatalf("usage = %+v, want in=200 cached=160", resp.Usage)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/model/openai/ -run TestUsageCachedTokens -v`
+Expected: FAIL — `CachedInputTokens` is 0 (field not yet populated).
+
+- [ ] **Step 3: Add `prompt_tokens_details` to the usage chunk**
+
+In `internal/model/openai/openai.go`, extend the `chatChunk.Usage` anonymous struct:
+
+```go
+	Usage *struct {
+		PromptTokens       int `json:"prompt_tokens"`
+		CompletionTokens   int `json:"completion_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+	} `json:"usage"`
+```
+
+- [ ] **Step 4: Populate `CachedInputTokens` in `accumulate`**
+
+In `internal/model/openai/openai.go`, replace the `if ck.Usage != nil { ... }` block:
+
+```go
+		if ck.Usage != nil {
+			u := providers.Usage{InputTokens: ck.Usage.PromptTokens, OutputTokens: ck.Usage.CompletionTokens}
+			if ck.Usage.PromptTokensDetails != nil {
+				u.CachedInputTokens = ck.Usage.PromptTokensDetails.CachedTokens
+			}
+			out.Usage = u
+		}
+```
+
+- [ ] **Step 5: Run tests to verify pass + no regressions**
+
+Run: `go test ./internal/model/openai/ -v`
+Expected: PASS — new test passes; `TestComplete`/`TestTruncation` unchanged (their usage chunks have no `prompt_tokens_details`, so `CachedInputTokens` stays 0 and `InputTokens` is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/model/openai/
+git commit -m "feat(openai): report cached prompt tokens (prompt_tokens_details.cached_tokens)"
+```
+
+---
+
+### Task 3: Gemini — parse cachedContentTokenCount + prefix-stability guard
+
+**Files:**
+- Modify: `internal/model/gemini/gemini.go` (`UsageMetadata`, `accumulate`, client doc comment)
+- Test: `internal/model/gemini/gemini_test.go`
+
+**Interfaces:**
+- Consumes: `providers.Usage.CachedInputTokens` (Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/model/gemini/gemini_test.go` (it already imports `reflect`? if not, add `"reflect"` to imports):
+
+```go
+// TestUsageCachedContent asserts cachedContentTokenCount maps to CachedInputTokens
+// (Gemini promptTokenCount already includes the cached subset).
+func TestUsageCachedContent(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":220,\"candidatesTokenCount\":8,\"cachedContentTokenCount\":180}}\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.InputTokens != 220 || resp.Usage.CachedInputTokens != 180 {
+		t.Fatalf("usage = %+v, want in=220 cached=180", resp.Usage)
+	}
+}
+
+// TestRequestPrefixStable guards implicit caching: across two successive Complete calls
+// for an append-only conversation, the system instruction, tools, and earlier contents
+// must be byte-identical (only new turns appended), so Gemini's implicit cache hits.
+func TestRequestPrefixStable(t *testing.T) {
+	var bodies [][]byte
+	capture := func(r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, b)
+	}
+	events := []string{"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1}}\n\n"}
+	srv := sseServer(t, capture, events)
+	defer srv.Close()
+	c := New(srv.URL, "gemini-x", "k", 0)
+	tools := []providers.ToolSpec{{Name: "a", Description: "d", Schema: `{"type":"object"}`}}
+
+	// Step N
+	if _, err := c.Complete(context.Background(), providers.CompletionRequest{
+		System: "sys", Tools: tools,
+		Messages: []providers.Message{{Role: "user", Content: "incident"}},
+	}); err != nil {
+		t.Fatalf("Complete N: %v", err)
+	}
+	// Step N+1: same prefix, one appended assistant turn + tool result
+	if _, err := c.Complete(context.Background(), providers.CompletionRequest{
+		System: "sys", Tools: tools,
+		Messages: []providers.Message{
+			{Role: "user", Content: "incident"},
+			{Role: "assistant", Content: "", ToolCalls: []providers.ToolCall{{ID: "t1", Name: "a", Args: "{}"}}},
+			{Role: "tool", ToolCallID: "t1", Content: "result"},
+		},
+	}); err != nil {
+		t.Fatalf("Complete N+1: %v", err)
+	}
+
+	var r0, r1 genRequest
+	if err := json.Unmarshal(bodies[0], &r0); err != nil {
+		t.Fatalf("unmarshal r0: %v", err)
+	}
+	if err := json.Unmarshal(bodies[1], &r1); err != nil {
+		t.Fatalf("unmarshal r1: %v", err)
+	}
+	if !reflect.DeepEqual(r0.SystemInstruction, r1.SystemInstruction) {
+		t.Fatal("system instruction must be byte-stable across steps (implicit-cache prefix)")
+	}
+	if !reflect.DeepEqual(r0.Tools, r1.Tools) {
+		t.Fatal("tools must be byte-stable across steps (implicit-cache prefix)")
+	}
+	if len(r1.Contents) <= len(r0.Contents) {
+		t.Fatalf("step N+1 must append contents: len0=%d len1=%d", len(r0.Contents), len(r1.Contents))
+	}
+	if !reflect.DeepEqual(r0.Contents, r1.Contents[:len(r0.Contents)]) {
+		t.Fatal("earlier contents must be unchanged (append-only) so the prefix stays cacheable")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/model/gemini/ -run 'TestUsageCachedContent|TestRequestPrefixStable' -v`
+Expected: `TestUsageCachedContent` FAILs (CachedInputTokens 0). `TestRequestPrefixStable` should already PASS if the request is already append-only/deterministic — that is acceptable and expected (it is a guard, not a RED-first behavior test); note that in the report. If it fails, the request has unexpected volatility — stop and report.
+
+- [ ] **Step 3: Add `cachedContentTokenCount` to `UsageMetadata`**
+
+In `internal/model/gemini/gemini.go`, extend the `UsageMetadata` anonymous struct:
+
+```go
+	UsageMetadata *struct {
+		PromptTokenCount        int `json:"promptTokenCount"`
+		CandidatesTokenCount    int `json:"candidatesTokenCount"`
+		CachedContentTokenCount int `json:"cachedContentTokenCount"`
+	} `json:"usageMetadata"`
+```
+
+- [ ] **Step 4: Populate `CachedInputTokens` in `accumulate`**
+
+In `internal/model/gemini/gemini.go`, replace the `if gr.UsageMetadata != nil { ... }` assignment:
+
+```go
+		if gr.UsageMetadata != nil {
+			out.Usage = providers.Usage{
+				InputTokens:       gr.UsageMetadata.PromptTokenCount,
+				OutputTokens:      gr.UsageMetadata.CandidatesTokenCount,
+				CachedInputTokens: gr.UsageMetadata.CachedContentTokenCount,
+			}
+		}
+```
+
+- [ ] **Step 5: Add the implicit-caching doc comment**
+
+In `internal/model/gemini/gemini.go`, append to the package/`Client` doc (above `type Client struct`) a short note:
+
+```go
+// Caching: RunLore relies on Gemini's automatic IMPLICIT prefix caching (enabled on
+// Gemini 2.5+). No explicit CachedContent lifecycle is used. This depends on the request
+// prefix (system_instruction + tools + earlier contents) being byte-stable and append-only
+// across the loop's steps; TestRequestPrefixStable guards that invariant.
+```
+
+- [ ] **Step 6: Run tests to verify pass + no regressions**
+
+Run: `go test ./internal/model/gemini/ -v`
+Expected: PASS — both new tests pass; existing tests unchanged (their usageMetadata has no cachedContentTokenCount, so CachedInputTokens stays 0).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/model/gemini/
+git commit -m "feat(gemini): report cached-content tokens + guard implicit-cache prefix
+
+Parse usageMetadata.cachedContentTokenCount into Usage.CachedInputTokens, and add a
+prefix-stability test so a future change can't silently break the byte-stable,
+append-only request prefix that Gemini's implicit caching depends on."
+```
+
+---
+
+### Task 4: Telemetry counters + loop recording
+
+**Files:**
+- Modify: `internal/telemetry/metrics.go` (2 counters in the struct + `NewMetrics`)
+- Modify: `internal/investigate/loop.go` (record after each `Complete`)
+- Test: `internal/telemetry/metrics_test.go`
+
+**Interfaces:**
+- Consumes: `providers.Usage.InputTokens`, `providers.Usage.CachedInputTokens` (Task 1); `telemetry.Metrics` (existing).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/telemetry/metrics_test.go` (match the file's existing assertion style; this asserts the two new counters are constructed):
+
+```go
+func TestModelTokenCountersConstructed(t *testing.T) {
+	m := NewMetrics()
+	if m.ModelInputTokens == nil || m.ModelCachedInputTokens == nil {
+		t.Fatal("NewMetrics must construct ModelInputTokens and ModelCachedInputTokens")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/telemetry/ -run TestModelTokenCountersConstructed -v`
+Expected: compile error — the fields don't exist yet.
+
+- [ ] **Step 3: Add the two counters to the `Metrics` struct**
+
+In `internal/telemetry/metrics.go`, add to the struct near `ModelResponsesTruncated`:
+
+```go
+	ModelInputTokens        metric.Int64Counter // total input tokens across LLM requests (label: provider)
+	ModelCachedInputTokens  metric.Int64Counter // input tokens served from cache (label: provider)
+```
+
+- [ ] **Step 4: Construct them in `NewMetrics`**
+
+In `internal/telemetry/metrics.go`, add to the returned struct literal near `ModelResponsesTruncated`:
+
+```go
+		ModelInputTokens:        ctr("model_input_tokens_total", "total LLM input tokens, including cached (label: provider)"),
+		ModelCachedInputTokens:  ctr("model_cached_input_tokens_total", "LLM input tokens served from cache (label: provider)"),
+```
+
+- [ ] **Step 5: Record in the loop**
+
+In `internal/investigate/loop.go`, inside the existing `if li.Metrics != nil { ... }` block that follows the `li.Model.Complete(...)` call (the one recording `ModelRequests` + `ModelRequestDuration`), after the duration `Record`, add:
+
+```go
+			if err == nil {
+				provAttr := metric.WithAttributes(attribute.String("provider", li.ModelProvider))
+				li.Metrics.ModelInputTokens.Add(ctx, int64(resp.Usage.InputTokens), provAttr)
+				li.Metrics.ModelCachedInputTokens.Add(ctx, int64(resp.Usage.CachedInputTokens), provAttr)
+			}
+```
+
+(`metric` and `attribute` are already imported in `loop.go`. Record only on success — on error `resp` is the zero value.)
+
+- [ ] **Step 6: Run tests to verify pass + no regressions**
+
+Run: `go test ./internal/telemetry/ ./internal/investigate/ -v 2>&1 | tail -25`
+Expected: PASS — the new telemetry test passes; the existing investigate loop tests (which pass `Metrics: NewMetrics()` with `ModelProvider: "anthropic"`) still pass, exercising the new `.Add` calls without panic. (Per the codebase convention, metric *values* are not asserted — the existing `ModelRequests` recording is likewise value-untested.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/telemetry/metrics.go internal/investigate/loop.go
+git commit -m "feat(telemetry): record LLM input + cached-input tokens per provider
+
+Two counters (model_input_tokens_total, model_cached_input_tokens_total, labelled by
+provider) recorded after each completion, so the prompt-cache hit ratio is observable
+and a cache regression (cached drops to ~0) is visible."
+```
+
+---
+
+### Task 5: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build, full suite, vet**
+
+Run: `go build ./... && go test ./... && go vet ./...`
+Expected: all green. If anything fails, stop and report BLOCKED with the exact output.
+
+- [ ] **Step 2: Confirm no stray files / formatting**
+
+Run: `gofmt -l internal/providers internal/model internal/telemetry internal/investigate`
+Expected: no output (all formatted).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ① T1 Anthropic rolling breakpoint (one breakpoint, last block of last message, ≤4 total) → Task 1 Steps 4,6 + test. ✓
+- ② T2 Gemini implicit-cache reliance + prefix-stability guard + doc → Task 3 Steps 4,5 + `TestRequestPrefixStable`. ✓
+- ③ Usage extension with normalization (Anthropic sum; OpenAI/Gemini passthrough) → Task 1 Step 3, Tasks 1/2/3 population + tests. ✓
+- ③ Metrics (2 counters, provider label) + loop recording → Task 4. ✓
+- OpenAI cached_tokens → Task 2. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step is complete; commands have expected output. ✓
+
+**Type consistency:** `Usage.CachedInputTokens`/`CacheWriteTokens` defined in Task 1 Step 3 and consumed identically in Tasks 2/3/4; `ModelInputTokens`/`ModelCachedInputTokens` defined and used with matching names; test field names match the structs (`msgRequest`, `genRequest`, `chatChunk`). ✓
+
+**Note on `TestRequestPrefixStable`:** it is a guard that is expected to PASS immediately (the request is already append-only). This is intentional (a regression guard, not RED-first) and is called out in Task 3 Step 2 so the implementer doesn't treat the absent RED as a problem.

--- a/docs/superpowers/specs/2026-06-30-cross-step-prompt-caching-design.md
+++ b/docs/superpowers/specs/2026-06-30-cross-step-prompt-caching-design.md
@@ -1,0 +1,104 @@
+# Cross-step prompt caching + cache observability (T1 + T2 + ③)
+
+Status: draft for review
+Date: 2026-06-30
+Scope: one PR, dedicated worktree (`feat/model-prompt-caching`). Cost optimization + the observability to prove it.
+
+## Problem
+
+RunLore's investigation loop (`internal/investigate/loop.go`) resends the *entire* growing message history on every ReAct step (`loop.go:238`) with no window or summarization, so cumulative input is roughly O(N²) in steps × tool-output size. Prompt caching is the lever — but today it is only partly used, and entirely unmeasured:
+
+- **Anthropic** marks only the *static* prefix (system + tool schemas) as cacheable (`anthropic.go:161,173-175`). The growing tool-output history carries no cache breakpoint, so every accumulated tool result is re-billed at full input price on every later step — the dominant cost.
+- **Gemini** uses no caching. Implicit caching is automatic on Gemini 2.5+ models from a common prompt prefix (confirmed: Gemini docs, "Context caching > Implicit caching"; min 2048 tokens on 2.5, 4096 on 3.x). Our requests are already deterministic and append-only, so the prefix is *already* cache-eligible — but nothing guarantees that stays true, and nothing measures it.
+- **OpenAI** already gets automatic server-side prefix caching (covers both the static prefix and the unchanged history) with zero client work.
+- **All three** report cache usage we discard: `providers.Usage` (`providers.go:465-469`) carries only `InputTokens`/`OutputTokens`. So we cannot tell whether any caching is working, nor catch a regression that silently drops the hit rate to zero.
+
+## Design
+
+One PR, three parts, shared theme: make cross-step caching active (Anthropic), automatic-and-guarded (Gemini), and **measurable across all three providers**.
+
+### ① T1 — Anthropic: rolling cache breakpoint on conversation history
+
+Anthropic allows up to 4 `cache_control` breakpoints and caches the request prefix up to and including each marked block. Today 2 are used (system block + last tool). Add a third: mark the **last content block of the last message** in the history each step.
+
+- Add a `CacheControl *cacheControl` field (json `cache_control,omitempty`) to the `block` struct (`anthropic.go:98-109`) — it currently has none; only `systemBlock` and `tool` do.
+- In `Complete`, after `toMessages(req.Messages)`, mark the last block of the last message with the shared `ephemeral` marker. Guard the empty case (no messages, or a message with no blocks) — skip silently.
+- **One** rolling breakpoint (decision locked), giving 3 total (system + tools + history-tail), one under the limit. Each step: the previous step's marked prefix is a cache *read* (~0.1×), and Anthropic *writes* the newly-extended prefix. Below Anthropic's minimum cacheable size the breakpoint is ignored, so early steps are unaffected.
+
+Why the last message's last block: the loop only ever *appends* to `messages` (`loop.go:320,359`), so the prefix up to the prior step's final block is byte-identical on the next step — a guaranteed rolling cache hit.
+
+### ② T2 — Gemini: rely on implicit caching, guard the prefix
+
+No request restructuring. The request is already deterministic (struct/slice serialization; the only map is `resultObject`'s single-key `{"result": …}`, `gemini.go:371`) and append-only, so the prefix is stable across steps and implicit caching applies on 2.5+ models.
+
+- Add a **regression guard test**: build two successive `Complete` request bodies for a growing conversation (step N and step N+1, where N+1 appends an assistant turn + tool result) and assert the step-N serialized request is a byte-prefix of the step-N+1 request up to the divergence point — i.e. the system instruction + tools + earlier contents are byte-identical. This locks prefix stability so a future change that introduces volatility (a timestamp, map iteration, reordered field) into the cacheable prefix fails the test instead of silently killing the cache.
+- Add a doc comment on the Gemini client recording that it depends on implicit caching and why prefix determinism matters.
+
+(No change to field ordering: system_instruction is already first; Gemini processes system_instruction + tools as the stable header before the growing contents.)
+
+### ③ Cache observability — all three providers (the backbone)
+
+Extend the shared `Usage` contract so the cache win is provable and regressions are catchable.
+
+**`providers.Usage` (`providers.go:465-469`) gains two fields:**
+
+```
+InputTokens       int // total input/prompt tokens billed (INCLUDING any served from cache — normalized across providers)
+OutputTokens      int // generated/output tokens
+CachedInputTokens int // the subset of InputTokens that was a cache READ (Anthropic cache_read, OpenAI cached_tokens, Gemini cachedContent); the saving
+CacheWriteTokens  int // Anthropic only: tokens WRITTEN to cache this request (cache_creation, billed ~1.25x); 0 for providers that don't report it
+```
+
+**Critical normalization** (the one cross-provider subtlety): the providers disagree on whether `input_tokens` already includes cached tokens. Each provider MUST normalize so `InputTokens` is the *total* footprint and `CachedInputTokens` is the cached subset:
+
+- **Anthropic** reports `input_tokens` as the *non-cached remainder*, with `cache_read_input_tokens` and `cache_creation_input_tokens` separate. So set `InputTokens = input_tokens + cache_read_input_tokens + cache_creation_input_tokens`, `CachedInputTokens = cache_read_input_tokens`, `CacheWriteTokens = cache_creation_input_tokens`. (Add these two fields to `usageDelta`, `anthropic.go:148-151`; they arrive on `message_start`.)
+- **OpenAI** reports `prompt_tokens` as the *total*, with `prompt_tokens_details.cached_tokens` a subset. So `InputTokens = prompt_tokens` (unchanged), `CachedInputTokens = prompt_tokens_details.cached_tokens`. (Add `prompt_tokens_details.cached_tokens` to the usage chunk, `openai.go:122-125`.) `CacheWriteTokens = 0`.
+- **Gemini** reports `promptTokenCount` as the *total*, with `cachedContentTokenCount` a subset. So `InputTokens = promptTokenCount` (unchanged), `CachedInputTokens = cachedContentTokenCount`. (Add `cachedContentTokenCount` to `UsageMetadata`, `gemini.go:135-138`.) `CacheWriteTokens = 0`.
+
+Result: `CachedInputTokens / InputTokens` is a comparable cache-hit ratio across all three providers, and `CachedInputTokens == 0` over a multi-step investigation is the regression signal.
+
+**Metrics (`internal/telemetry/metrics.go`):** add two `Int64Counter`s labelled by provider, following the existing `ctr(...)` pattern and the `ModelRequests` naming:
+
+```
+ModelInputTokens       metric.Int64Counter // total input tokens across LLM requests (label: provider)
+ModelCachedInputTokens metric.Int64Counter // input tokens served from cache (label: provider)
+```
+
+**Recording (`loop.go`):** where model metrics are already recorded after each `Complete` (the `li.Metrics != nil` block around `loop.go:239-248`), also add `resp.Usage.InputTokens` and `resp.Usage.CachedInputTokens` to the new counters (provider label = `li.ModelProvider`). Nil-safe like the surrounding metric calls. This is recorded for the main loop's calls; the verify pass (`verify.go`) is out of scope for metric wiring in this PR (its calls are few and cheap).
+
+### OpenAI
+
+No caching change (server-side automatic). Only the part-③ `cached_tokens` parsing.
+
+## Files touched
+
+- `internal/providers/providers.go` — extend `Usage` (2 fields + doc).
+- `internal/model/anthropic/anthropic.go` — T1 (block `CacheControl` + mark last message block); usage cache fields (`usageDelta` + normalized population).
+- `internal/model/anthropic/anthropic_test.go` — T1 breakpoint test; usage normalization test.
+- `internal/model/openai/openai.go` — `cached_tokens` parsing + population.
+- `internal/model/openai/openai_test.go` — cached-token usage test.
+- `internal/model/gemini/gemini.go` — `cachedContentTokenCount` parsing + population; implicit-caching doc comment.
+- `internal/model/gemini/gemini_test.go` — cached-token usage test; **prefix-stability guard test**.
+- `internal/telemetry/metrics.go` — 2 new counters.
+- `internal/investigate/loop.go` — record the 2 new counters after each `Complete`.
+
+## Testing
+
+- **Anthropic T1:** marshal a `Complete` request with a multi-message history; assert `cache_control: ephemeral` is present on (a) the system block, (b) the last tool, and (c) the last block of the last message — and absent elsewhere. Assert total breakpoints == 3.
+- **Anthropic usage:** feed a synthetic `message_start` usage with `input_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`; assert `InputTokens == sum`, `CachedInputTokens == cache_read`, `CacheWriteTokens == cache_creation`.
+- **OpenAI usage:** feed a usage chunk with `prompt_tokens` + `prompt_tokens_details.cached_tokens`; assert `InputTokens == prompt_tokens`, `CachedInputTokens == cached_tokens`.
+- **Gemini usage:** feed `usageMetadata` with `promptTokenCount` + `cachedContentTokenCount`; assert `InputTokens == promptTokenCount`, `CachedInputTokens == cachedContentTokenCount`.
+- **Gemini prefix-stability guard:** serialize step-N and step-N+1 requests for an append-only conversation; assert the divergence point lands only where the new turn was appended (system instruction + tools + earlier contents byte-identical).
+- All existing model + loop tests stay green; `go build ./... && go vet`.
+
+## Non-goals (out of scope for this PR)
+
+- Mid-loop tool-output compaction (thread T3 — designed AFTER this, since compaction rewrites history and would invalidate T1's rolling breakpoint).
+- Token-aware truncation; per-task output caps.
+- Explicit Gemini `CachedContent` API (rejected: per-investigation create/delete lifecycle + TTL/expiry hazards aren't worth it for sub-2-minute loops).
+- Verify/judge-pass cache-metric wiring.
+- Surfacing cached tokens in the Slack/PR delivery (metrics only).
+
+## Interaction note for the next thread (T3)
+
+T1's rolling breakpoint assumes the message history is **append-only**. The T3 compaction thread will mutate/summarize earlier history, which invalidates a cached prefix at the mutation point. T3 must therefore (a) place its compaction boundary *before* the rolling breakpoint and only rewrite below it, or (b) accept a one-time cache miss on the step compaction fires. This is called out in the T3 spec when it's written; recorded here so the dependency isn't lost.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -245,6 +245,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				attribute.String("provider", li.ModelProvider), attribute.String("result", mres)))
 			li.Metrics.ModelRequestDuration.Record(ctx, time.Since(mstart).Seconds(),
 				metric.WithAttributes(attribute.String("provider", li.ModelProvider)))
+			if err == nil {
+				provAttr := metric.WithAttributes(attribute.String("provider", li.ModelProvider))
+				li.Metrics.ModelInputTokens.Add(ctx, int64(resp.Usage.InputTokens), provAttr)
+				li.Metrics.ModelCachedInputTokens.Add(ctx, int64(resp.Usage.CachedInputTokens), provAttr)
+			}
 		}
 		if err != nil {
 			// The per-investigation deadline fired (or the parent ctx was cancelled):

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -106,6 +106,8 @@ type block struct {
 	// tool_result
 	ToolUseID string `json:"tool_use_id,omitempty"`
 	Content   string `json:"content,omitempty"`
+	// cache breakpoint (set on the last block of the last message — the rolling history breakpoint)
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
 }
 
 type tool struct {
@@ -146,8 +148,10 @@ type streamEvent struct {
 // usageDelta carries token counts; input arrives on message_start, output on
 // message_delta (so the two are accumulated from different events).
 type usageDelta struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 }
 
 // Complete sends a streaming Messages request with tools and accumulates the full
@@ -156,7 +160,18 @@ type usageDelta struct {
 // truncating a long completion and lets a per-block input_json_delta reassemble tool
 // arguments incrementally.
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
-	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Stream: true, Messages: toMessages(req.Messages)}
+	msgs := toMessages(req.Messages)
+	// Rolling cache breakpoint: mark the last content block of the last message, so the
+	// growing conversation prefix is a cache READ on the next step. The loop only ever
+	// APPENDS to history, so the prefix is byte-identical step to step — a guaranteed
+	// rolling hit. Total breakpoints stay <= 4 (system + last tool + this one). Below
+	// Anthropic's minimum cacheable size the marker is ignored, so early steps are fine.
+	if n := len(msgs); n > 0 {
+		if blocks := msgs[n-1].Content; len(blocks) > 0 {
+			blocks[len(blocks)-1].CacheControl = ephemeral
+		}
+	}
+	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Stream: true, Messages: msgs}
 	if req.System != "" {
 		areq.System = []systemBlock{{Type: "text", Text: req.System, CacheControl: ephemeral}}
 	}
@@ -257,7 +272,12 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 		switch ev.Type {
 		case "message_start":
 			if ev.Message != nil && ev.Message.Usage != nil {
-				out.Usage.InputTokens = ev.Message.Usage.InputTokens
+				u := ev.Message.Usage
+				// Anthropic reports input_tokens as the NON-cached remainder; total input is
+				// the sum of input + cache_read + cache_creation (per Anthropic docs).
+				out.Usage.InputTokens = u.InputTokens + u.CacheReadInputTokens + u.CacheCreationInputTokens
+				out.Usage.CachedInputTokens = u.CacheReadInputTokens
+				out.Usage.CacheWriteTokens = u.CacheCreationInputTokens
 			}
 		case "content_block_start":
 			if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -403,6 +403,18 @@ func TestPromptCacheHistoryBreakpoint(t *testing.T) {
 	if gotReq.Messages[0].Content[0].CacheControl != nil {
 		t.Fatalf("earlier message blocks must not be marked: %+v", gotReq.Messages[0])
 	}
+	// exactly one message-level breakpoint (≤4 total is enforced; message portion must be 1)
+	msgBreakpoints := 0
+	for _, m := range gotReq.Messages {
+		for _, b := range m.Content {
+			if b.CacheControl != nil {
+				msgBreakpoints++
+			}
+		}
+	}
+	if msgBreakpoints != 1 {
+		t.Fatalf("exactly one message-level cache breakpoint expected, got %d", msgBreakpoints)
+	}
 }
 
 // TestUsageCacheFields asserts the Anthropic usage normalization: InputTokens is the

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -359,6 +359,72 @@ data: {"type":"message_stop"}
 	}
 }
 
+// TestPromptCacheHistoryBreakpoint asserts the rolling breakpoint: the last content
+// block of the last message carries cache_control, alongside system + last tool.
+func TestPromptCacheHistoryBreakpoint(t *testing.T) {
+	var gotReq msgRequest
+	srv := sseServer(t, func(r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotReq)
+	}, []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	})
+	defer srv.Close()
+
+	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		System: "sys",
+		Messages: []providers.Message{
+			{Role: "user", Content: "incident"},
+			{Role: "assistant", Content: "thinking", ToolCalls: []providers.ToolCall{{ID: "t1", Name: "a", Args: "{}"}}},
+			{Role: "tool", ToolCallID: "t1", Content: "result"},
+		},
+		Tools: []providers.ToolSpec{{Name: "a", Description: "d", Schema: `{"type":"object"}`}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// system marked
+	if len(gotReq.System) == 0 || gotReq.System[0].CacheControl == nil {
+		t.Fatalf("system block should be a cache breakpoint: %+v", gotReq.System)
+	}
+	// last tool marked
+	lt := gotReq.Tools[len(gotReq.Tools)-1]
+	if lt.CacheControl == nil || lt.CacheControl.Type != "ephemeral" {
+		t.Fatalf("last tool should be a cache breakpoint: %+v", lt)
+	}
+	// last block of the last message marked (the rolling breakpoint)
+	last := gotReq.Messages[len(gotReq.Messages)-1]
+	lb := last.Content[len(last.Content)-1]
+	if lb.CacheControl == nil || lb.CacheControl.Type != "ephemeral" {
+		t.Fatalf("last message's last block should be the rolling cache breakpoint: %+v", last)
+	}
+	// an earlier message block must NOT be marked
+	if gotReq.Messages[0].Content[0].CacheControl != nil {
+		t.Fatalf("earlier message blocks must not be marked: %+v", gotReq.Messages[0])
+	}
+}
+
+// TestUsageCacheFields asserts the Anthropic usage normalization: InputTokens is the
+// sum of input + cache_read + cache_creation; the read/creation subsets are reported.
+func TestUsageCacheFields(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":30,\"cache_read_input_tokens\":100,\"cache_creation_input_tokens\":20}}}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":7}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.InputTokens != 150 || resp.Usage.CachedInputTokens != 100 || resp.Usage.CacheWriteTokens != 20 {
+		t.Fatalf("usage = %+v, want in=150 cached=100 write=20", resp.Usage)
+	}
+}
+
 // TestPromptCacheToolsOnly verifies that with no system prompt, the tools array
 // still gets exactly one cache breakpoint — on the LAST tool, not every tool.
 func TestPromptCacheToolsOnly(t *testing.T) {

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -42,6 +42,11 @@ const (
 	idleTimeout = 2 * time.Minute
 )
 
+// Caching: RunLore relies on Gemini's automatic IMPLICIT prefix caching (enabled on
+// Gemini 2.5+). No explicit CachedContent lifecycle is used. This depends on the request
+// prefix (system_instruction + tools + earlier contents) being byte-stable and append-only
+// across the loop's steps; TestRequestPrefixStable guards that invariant.
+
 // Client is a Gemini (streamGenerateContent) model provider.
 type Client struct {
 	baseURL   string
@@ -133,8 +138,9 @@ type genResponse struct {
 	// UsageMetadata carries the per-request token counts; a pointer so an absent block
 	// parses to nil (unknown) rather than a misleading {0,0}.
 	UsageMetadata *struct {
-		PromptTokenCount     int `json:"promptTokenCount"`
-		CandidatesTokenCount int `json:"candidatesTokenCount"`
+		PromptTokenCount        int `json:"promptTokenCount"`
+		CandidatesTokenCount    int `json:"candidatesTokenCount"`
+		CachedContentTokenCount int `json:"cachedContentTokenCount"`
 	} `json:"usageMetadata"`
 	Error *struct {
 		Message string `json:"message"`
@@ -243,7 +249,11 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 		// usageMetadata accumulates across chunks (last non-nil block wins; Gemini
 		// resends the running totals, so the final chunk carries the full count).
 		if gr.UsageMetadata != nil {
-			out.Usage = providers.Usage{InputTokens: gr.UsageMetadata.PromptTokenCount, OutputTokens: gr.UsageMetadata.CandidatesTokenCount}
+			out.Usage = providers.Usage{
+				InputTokens:       gr.UsageMetadata.PromptTokenCount,
+				OutputTokens:      gr.UsageMetadata.CandidatesTokenCount,
+				CachedInputTokens: gr.UsageMetadata.CachedContentTokenCount,
+			}
 		}
 		if len(gr.Candidates) == 0 {
 			continue

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -321,6 +322,79 @@ func TestParallelSameFunctionCorrelatesByID(t *testing.T) {
 	}
 	if !strings.Contains(byID["call_2"], "b failing") {
 		t.Fatalf("call_2 response mismatched: %q", byID["call_2"])
+	}
+}
+
+// TestUsageCachedContent asserts cachedContentTokenCount maps to CachedInputTokens
+// (Gemini promptTokenCount already includes the cached subset).
+func TestUsageCachedContent(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":220,\"candidatesTokenCount\":8,\"cachedContentTokenCount\":180}}\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.InputTokens != 220 || resp.Usage.CachedInputTokens != 180 {
+		t.Fatalf("usage = %+v, want in=220 cached=180", resp.Usage)
+	}
+}
+
+// TestRequestPrefixStable guards implicit caching: across two successive Complete calls
+// for an append-only conversation, the system instruction, tools, and earlier contents
+// must be byte-identical (only new turns appended), so Gemini's implicit cache hits.
+func TestRequestPrefixStable(t *testing.T) {
+	var bodies [][]byte
+	capture := func(r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, b)
+	}
+	events := []string{"data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":1,\"candidatesTokenCount\":1}}\n\n"}
+	srv := sseServer(t, capture, events)
+	defer srv.Close()
+	c := New(srv.URL, "gemini-x", "k", 0)
+	tools := []providers.ToolSpec{{Name: "a", Description: "d", Schema: `{"type":"object"}`}}
+
+	// Step N
+	if _, err := c.Complete(context.Background(), providers.CompletionRequest{
+		System: "sys", Tools: tools,
+		Messages: []providers.Message{{Role: "user", Content: "incident"}},
+	}); err != nil {
+		t.Fatalf("Complete N: %v", err)
+	}
+	// Step N+1: same prefix, one appended assistant turn + tool result
+	if _, err := c.Complete(context.Background(), providers.CompletionRequest{
+		System: "sys", Tools: tools,
+		Messages: []providers.Message{
+			{Role: "user", Content: "incident"},
+			{Role: "assistant", Content: "", ToolCalls: []providers.ToolCall{{ID: "t1", Name: "a", Args: "{}"}}},
+			{Role: "tool", ToolCallID: "t1", Content: "result"},
+		},
+	}); err != nil {
+		t.Fatalf("Complete N+1: %v", err)
+	}
+
+	var r0, r1 genRequest
+	if err := json.Unmarshal(bodies[0], &r0); err != nil {
+		t.Fatalf("unmarshal r0: %v", err)
+	}
+	if err := json.Unmarshal(bodies[1], &r1); err != nil {
+		t.Fatalf("unmarshal r1: %v", err)
+	}
+	if !reflect.DeepEqual(r0.SystemInstruction, r1.SystemInstruction) {
+		t.Fatal("system instruction must be byte-stable across steps (implicit-cache prefix)")
+	}
+	if !reflect.DeepEqual(r0.Tools, r1.Tools) {
+		t.Fatal("tools must be byte-stable across steps (implicit-cache prefix)")
+	}
+	if len(r1.Contents) <= len(r0.Contents) {
+		t.Fatalf("step N+1 must append contents: len0=%d len1=%d", len(r0.Contents), len(r1.Contents))
+	}
+	if !reflect.DeepEqual(r0.Contents, r1.Contents[:len(r0.Contents)]) {
+		t.Fatal("earlier contents must be unchanged (append-only) so the prefix stays cacheable")
 	}
 }
 

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -338,8 +338,8 @@ func TestUsageCachedContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	if resp.Usage.InputTokens != 220 || resp.Usage.CachedInputTokens != 180 {
-		t.Fatalf("usage = %+v, want in=220 cached=180", resp.Usage)
+	if resp.Usage.InputTokens != 220 || resp.Usage.CachedInputTokens != 180 || resp.Usage.OutputTokens != 8 {
+		t.Fatalf("usage = %+v, want in=220 cached=180 out=8", resp.Usage)
 	}
 }
 
@@ -377,6 +377,9 @@ func TestRequestPrefixStable(t *testing.T) {
 		t.Fatalf("Complete N+1: %v", err)
 	}
 
+	if len(bodies) != 2 {
+		t.Fatalf("expected 2 captured request bodies, got %d", len(bodies))
+	}
 	var r0, r1 genRequest
 	if err := json.Unmarshal(bodies[0], &r0); err != nil {
 		t.Fatalf("unmarshal r0: %v", err)

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -120,8 +120,11 @@ type chatChunk struct {
 	// Usage is the per-request token count, present only on the trailing usage chunk;
 	// a pointer so an absent block parses to nil (unknown) rather than a misleading {0,0}.
 	Usage *struct {
-		PromptTokens     int `json:"prompt_tokens"`
-		CompletionTokens int `json:"completion_tokens"`
+		PromptTokens        int `json:"prompt_tokens"`
+		CompletionTokens    int `json:"completion_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
 	} `json:"usage"`
 }
 
@@ -259,7 +262,11 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 			return providers.CompletionResponse{}, fmt.Errorf("decode sse event: %w", err)
 		}
 		if ck.Usage != nil {
-			out.Usage = providers.Usage{InputTokens: ck.Usage.PromptTokens, OutputTokens: ck.Usage.CompletionTokens}
+			u := providers.Usage{InputTokens: ck.Usage.PromptTokens, OutputTokens: ck.Usage.CompletionTokens}
+			if ck.Usage.PromptTokensDetails != nil {
+				u.CachedInputTokens = ck.Usage.PromptTokensDetails.CachedTokens
+			}
+			out.Usage = u
 		}
 		if len(ck.Choices) == 0 {
 			continue // usage-only (or empty) chunk: no delta to fold

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -233,6 +233,27 @@ func TestMidStreamDrop(t *testing.T) {
 	}
 }
 
+// TestUsageCachedTokens asserts prompt_tokens_details.cached_tokens maps to
+// CachedInputTokens (OpenAI prompt_tokens already includes the cached subset).
+func TestUsageCachedTokens(t *testing.T) {
+	srv := sseServer(t, nil, []string{
+		"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+		"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+		"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":200,\"completion_tokens\":9,\"prompt_tokens_details\":{\"cached_tokens\":160}}}\n\n",
+		"data: [DONE]\n\n",
+	})
+	defer srv.Close()
+	resp, err := New(srv.URL, "m", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Usage.InputTokens != 200 || resp.Usage.CachedInputTokens != 160 {
+		t.Fatalf("usage = %+v, want in=200 cached=160", resp.Usage)
+	}
+}
+
 // TestEmptyToolResultKeepsContent guards the OpenAI-compat requirement that a
 // tool-role message always carries a "content" field, even when the tool produced
 // no output. With json:"content,omitempty" an empty result elides the field and

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -464,8 +464,15 @@ func (r CompletionResponse) Refused() bool {
 
 // Usage is the provider-reported token accounting for one completion.
 type Usage struct {
-	InputTokens  int // prompt/input tokens billed for the request
+	InputTokens  int // total prompt/input tokens billed, INCLUDING any served from cache (normalized across providers)
 	OutputTokens int // generated/output tokens in the reply
+	// CachedInputTokens is the subset of InputTokens that was a cache READ (Anthropic
+	// cache_read_input_tokens, OpenAI prompt_tokens_details.cached_tokens, Gemini
+	// cachedContentTokenCount) — the saving. 0 when the provider reports none.
+	CachedInputTokens int
+	// CacheWriteTokens is input tokens WRITTEN to the cache this request (Anthropic
+	// cache_creation_input_tokens, billed ~1.25x). 0 for providers that don't report it.
+	CacheWriteTokens int
 }
 
 // ToolCall is a model request to invoke a tool.

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -43,6 +43,8 @@ type Metrics struct {
 	ModelRequests           metric.Int64Counter     // LLM completion requests (label: provider, result)
 	ModelRequestDuration    metric.Float64Histogram // LLM completion latency, seconds (label: provider)
 	ModelResponsesTruncated metric.Int64Counter     // LLM completions cut off at the output-token ceiling (label: provider)
+	ModelInputTokens        metric.Int64Counter     // total input tokens across LLM requests (label: provider)
+	ModelCachedInputTokens  metric.Int64Counter     // input tokens served from cache (label: provider)
 	Curations               metric.Int64Counter     // curation outcomes (label: kind, result)
 	CatalogInvalidEntries   metric.Int64Counter     // structurally-invalid entries found at catalog load
 }
@@ -90,6 +92,8 @@ func NewMetrics() *Metrics {
 		ModelRequests:           ctr("model_requests_total", "LLM completion requests (label: provider, result)"),
 		ModelRequestDuration:    histF("model_request_duration_seconds", "LLM completion latency in seconds (label: provider)"),
 		ModelResponsesTruncated: ctr("model_responses_truncated_total", "LLM completions cut off at the output-token ceiling — the provider stop/finish reason indicated truncation (label: provider)"),
+		ModelInputTokens:        ctr("model_input_tokens_total", "total LLM input tokens, including cached (label: provider)"),
+		ModelCachedInputTokens:  ctr("model_cached_input_tokens_total", "LLM input tokens served from cache (label: provider)"),
 		Curations:               ctr("curations_total", "curation outcomes written to the forge (label: kind, result)"),
 		CatalogInvalidEntries:   ctr("catalog_invalid_entries_total", "structurally-invalid entries surfaced at catalog load"),
 	}

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -34,3 +34,10 @@ func TestNewMetricsCurationInstruments(_ *testing.T) {
 	ctx := context.Background()
 	m.CurationDedupScore.Record(ctx, 4.2)
 }
+
+func TestModelTokenCountersConstructed(t *testing.T) {
+	m := NewMetrics()
+	if m.ModelInputTokens == nil || m.ModelCachedInputTokens == nil {
+		t.Fatal("NewMetrics must construct ModelInputTokens and ModelCachedInputTokens")
+	}
+}


### PR DESCRIPTION
## What & why

Cuts the investigation loop's dominant token cost and makes the saving measurable. The ReAct loop resends the *entire* growing message history every step with no window, so cumulative input is ~O(N²) in steps × tool-output size. This caches the growing conversation prefix on every provider, and surfaces the cache win as metrics. Second thread from the LLM-call cost review (first was #177).

### ① Anthropic — rolling cache breakpoint on history (the active win)
Previously only the *static* prefix (system + tool schemas) carried an `ephemeral` breakpoint; the growing tool-output history was re-billed at full price every step. Now the **last content block of the last message** is marked each step, so Anthropic reads the conversation prefix at ~0.1× and writes the extended one. The loop is append-only, so the prefix is byte-identical step to step — a guaranteed rolling hit. Total breakpoints = 3 (system + last tool + history-tail), under the limit of 4; below the min cacheable size the marker is a silent no-op.

### ② Gemini — rely on implicit caching, guard the prefix
Gemini 2.5+ caches common prompt prefixes automatically; our requests are already deterministic and append-only, so the prefix is cache-eligible with no request restructure. Added a **prefix-stability guard test** (`TestRequestPrefixStable`) so a future change introducing volatility into the prefix fails CI instead of silently killing the cache, plus a doc note. Explicit `CachedContent` was rejected — its per-investigation create/delete lifecycle + TTL hazards aren't worth it for sub-2-minute loops.

### ③ Cache observability (all three providers)
`providers.Usage` gains `CachedInputTokens` (the cache-read saving) and `CacheWriteTokens` (Anthropic-only). **Normalized** so the hit-ratio is comparable: Anthropic reports `input_tokens` as the *non-cached remainder*, so `InputTokens = input + cache_read + cache_creation` (verified against Anthropic docs); OpenAI `prompt_tokens` / Gemini `promptTokenCount` already include the cached subset, so they pass through. Two per-provider metrics (`model_input_tokens_total`, `model_cached_input_tokens_total`) recorded in the loop — so the cache win is provable and a regression (cached → ~0) is visible.

OpenAI needs no caching change (server-side automatic prefix caching); it just contributes its `prompt_tokens_details.cached_tokens` to ③.

## Tests
Per-provider: cache-token usage parsing + the Anthropic breakpoint (system + last-tool + last-message-block, exactly one message-level breakpoint, none earlier) + the Gemini prefix-stability guard. Full `go test ./...` exit 0, build + vet + gofmt clean. Reviewed clean by an adversarial whole-branch pass (Ready to merge, no Critical/Important).

## Out of scope (next threads)
T3 mid-loop tool-output compaction (must respect this PR's append-only rolling-breakpoint assumption — noted in the spec); outbound MCP client (E1).

## Docs
Design spec + implementation plan under `docs/superpowers/`.
