### PR TITLE
  ci(helm): add chart lint + kubeconform + values schema

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,0 +1,71 @@
+name: Helm Chart
+
+# Validate the in-cluster Helm chart on every change to deploy/helm/** (or this
+# workflow). Two gates:
+#   - helm lint  -> templating sanity + values.yaml validated against the chart's
+#                   values.schema.json (Helm runs the schema automatically).
+#   - helm template | kubeconform -> render every manifest and strictly validate the
+#                   core Kubernetes kinds. Custom CRD kinds (Flux / Argo CD /
+#                   VictoriaMetrics / Cilium) have no schema in the default registry,
+#                   so -ignore-missing-schemas skips them rather than failing — only
+#                   built-in k8s objects are strictly checked.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/chart.yml'
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/chart.yml'
+  workflow_dispatch:
+
+# Least privilege: this workflow only needs to read the repo.
+permissions:
+  contents: read
+
+env:
+  CHART: deploy/helm/runlore
+  # Pinned kubeconform release. The binary is fetched from the GitHub release and
+  # verified against this SHA-256 before use (see the install step), so the download
+  # is pinned just as tightly as a commit-pinned action.
+  KUBECONFORM_VERSION: v0.8.0
+  KUBECONFORM_SHA256: 9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883
+
+jobs:
+  lint:
+    name: Lint and validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+
+      # helm lint also validates values.yaml against deploy/helm/runlore/values.schema.json.
+      - name: helm lint
+        run: helm lint "$CHART"
+
+      # Install the pinned kubeconform release, verifying the tarball checksum before
+      # extracting so a tampered/swapped asset can't run in CI.
+      - name: Install kubeconform
+        run: |
+          set -euo pipefail
+          url="https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz"
+          curl -fsSL "$url" -o kubeconform.tar.gz
+          echo "${KUBECONFORM_SHA256}  kubeconform.tar.gz" | sha256sum -c -
+          tar -xzf kubeconform.tar.gz kubeconform
+          install -m 0755 kubeconform /usr/local/bin/kubeconform
+          rm -f kubeconform.tar.gz kubeconform
+          kubeconform -v
+
+      # Render the chart and strictly validate the core k8s kinds. -ignore-missing-schemas
+      # skips the CRD kinds (Flux / Argo CD / VictoriaMetrics / Cilium) that have no
+      # schema in the default registry instead of failing on them.
+      - name: helm template | kubeconform
+        run: |
+          set -euo pipefail
+          helm template "$CHART" \
+            | kubeconform -strict -ignore-missing-schemas -summary

--- a/deploy/helm/runlore/values.schema.json
+++ b/deploy/helm/runlore/values.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "RunLore Helm chart values",
+  "description": "Permissive schema for the runlore chart. It types the well-known top-level keys to catch gross mistakes (e.g. a string where an object is expected) but deliberately keeps additionalProperties:true at the top level and inside freeform sub-objects (notably `config`, which is rendered verbatim into the app config). It is NOT a closed schema and must never reject otherwise-valid values.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "updateStrategy": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string" }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "config": {
+      "description": "Rendered verbatim into the ConfigMap mounted at /etc/runlore/runlore.yaml. Accepts arbitrary keys.",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "envFrom": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "env": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "catalog": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "configMap": { "type": "string" },
+        "gitSync": { "type": "boolean" },
+        "mountPath": { "type": "string" }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "storageClass": { "type": "string" },
+        "accessModes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "size": { "type": ["string", "integer"] },
+        "existingClaim": { "type": "string" }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer" }
+      }
+    },
+    "probes": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "startup": { "type": "object", "additionalProperties": true },
+        "liveness": { "type": "object", "additionalProperties": true },
+        "readiness": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "create": { "type": "boolean" },
+        "allowActions": { "type": "boolean" },
+        "actionNamespaces": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "controllerLogNamespaces": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "strict": { "type": "boolean" },
+        "awsPodIdentity": { "type": "boolean" },
+        "egress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "dns": { "type": "object", "additionalProperties": true },
+            "allowedCIDRs": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "namespaceSelectors": {
+              "type": "array",
+              "items": { "type": "object" }
+            },
+            "apiServerCIDRs": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "extraEgress": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "ingressFrom": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+    "vmServiceScrape": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "interval": { "type": "string" },
+        "path": { "type": "string" }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "nodeSelector": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "tolerations": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "affinity": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "curate": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "cronjob": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "schedule": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
 ## What
  The Helm chart had no CI validation — a templating regression or invalid values combo wouldn't be caught. Adds chart linting, manifest validation, and a values schema.

  ## How
  - New `.github/workflows/chart.yml` (PR + push on `deploy/helm/**`, + workflow_dispatch; `contents: read`): `helm lint`, then `helm template | kubeconform -strict -ignore-missing-schemas` (core k8s kinds strictly validated; Flux/Argo/VM/Cilium CRDs pass). Actions SHA-pinned; kubeconform pinned by version + SHA-256.
  - New permissive `deploy/helm/runlore/values.schema.json` — types the known top-level keys but `additionalProperties: true` throughout (esp. `config`, rendered verbatim); nothing `required`. Catches gross type mistakes without rejecting valid overrides.

  ## Verified
  `helm lint` clean (default + rbac/persistence/networkPolicy.strict/vmServiceScrape/curate.cronjob/arbitrary-config overrides); schema correctly *fails* `image=string`, `replicaCount=two`, `rbac.create=string`. `kubeconform` 12/14 valid (2 skipped = CRDs). `actionlint` clean.