### PR TITLE
  feat(audit): verify chain on open (fail-closed under approve/auto) + lore audit verify

### DIFF
--- a/cmd/lore/audit.go
+++ b/cmd/lore/audit.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/config"
+)
+
+// runAudit is the `lore audit` subcommand dispatcher. Today it has a single verb,
+// `verify`, which re-walks the hash-chained action audit log and reports the first
+// broken link. It is the operator-facing counterpart to the verify-on-open check
+// that gates startup (see internal/app.BuildAuditor).
+func runAudit(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: lore audit verify --path <audit.jsonl> | --config <runlore.yaml>")
+	}
+	switch args[0] {
+	case "verify":
+		return runAuditVerify(args[1:])
+	default:
+		return fmt.Errorf("unknown audit verb %q (want: verify)", args[0])
+	}
+}
+
+// runAuditVerify parses flags for `lore audit verify` and resolves the audit-log
+// path: --path is the simple required form; --config reads
+// actions.audit_log_path from a RunLore config instead. It exits non-zero (via a
+// returned error) when the chain is broken.
+func runAuditVerify(args []string) error {
+	fs := flag.NewFlagSet("audit verify", flag.ContinueOnError)
+	path := fs.String("path", "", "path to the hash-chained audit log (JSONL)")
+	cfgPath := fs.String("config", "", "read actions.audit_log_path from this RunLore config instead of --path")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	p := *path
+	if p == "" && *cfgPath != "" {
+		cfg, err := config.Load(*cfgPath)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		p = cfg.Actions.AuditLogPath
+		if p == "" {
+			return fmt.Errorf("config %s has no actions.audit_log_path", *cfgPath)
+		}
+	}
+	return auditVerify(os.Stdout, p)
+}
+
+// auditVerify opens the audit log at path, re-walks the chain, and writes the
+// result to w: "OK: chain intact (<N> records)" on success, or returns the
+// broken-link error from audit.Verify. An empty path is a usage error. The
+// caller maps a non-nil error to a non-zero exit.
+func auditVerify(w io.Writer, path string) error {
+	if path == "" {
+		return fmt.Errorf("audit verify: --path (or a --config with actions.audit_log_path) is required")
+	}
+	f, err := os.Open(path) //nolint:gosec // G304: operator-supplied audit-log path
+	if err != nil {
+		return fmt.Errorf("audit verify: open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := audit.Verify(f); err != nil {
+		return fmt.Errorf("audit verify: %w", err)
+	}
+	// Verify consumed the file; rewind to count the (now-trusted) records for the
+	// success line.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("audit verify: seek: %w", err)
+	}
+	n := countRecords(f)
+	_, _ = fmt.Fprintf(w, "OK: chain intact (%d records)\n", n)
+	return nil
+}
+
+// countRecords counts non-empty lines (records) in an already-verified chain.
+func countRecords(r io.Reader) int {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	n := 0
+	for sc.Scan() {
+		if sc.Text() != "" {
+			n++
+		}
+	}
+	return n
+}

--- a/cmd/lore/audit_test.go
+++ b/cmd/lore/audit_test.go
@@ -82,3 +82,61 @@ func TestAuditVerifyMissingPathErrors(t *testing.T) {
 		t.Fatal("an empty --path must error")
 	}
 }
+
+// writeConfig writes a minimal RunLore config that sets actions.audit_log_path to
+// logPath (mode is left unset, so config validation passes) and returns its path.
+func writeConfig(t *testing.T, dir, logPath string) string {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "runlore.yaml")
+	body := "actions:\n  audit_log_path: " + logPath + "\n"
+	if err := os.WriteFile(cfgPath, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return cfgPath
+}
+
+// TestRunAuditVerifyConfigIntactOK exercises the --config code path: the audit-log
+// path is resolved from actions.audit_log_path, and an intact chain verifies.
+func TestRunAuditVerifyConfigIntactOK(t *testing.T) {
+	dir := t.TempDir()
+	logPath := writeAuditChain(t, dir)
+	cfgPath := writeConfig(t, dir, logPath)
+
+	if err := runAuditVerify([]string{"--config", cfgPath}); err != nil {
+		t.Fatalf("intact chain via --config must verify, got: %v", err)
+	}
+}
+
+// TestRunAuditVerifyConfigTamperedFails exercises --config against a broken chain:
+// the resolved path's chain is tampered, so verification (and the command) fails.
+func TestRunAuditVerifyConfigTamperedFails(t *testing.T) {
+	dir := t.TempDir()
+	logPath := writeAuditChain(t, dir)
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	lines[1] = strings.Replace(lines[1], "apps", "flux-system", 1)
+	if err := os.WriteFile(logPath, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := writeConfig(t, dir, logPath)
+
+	if err := runAuditVerify([]string{"--config", cfgPath}); err == nil {
+		t.Fatal("tampered chain via --config must fail")
+	}
+}
+
+// TestRunAuditVerifyConfigNoAuditPathErrors checks that a --config without
+// actions.audit_log_path is a usage error (nothing to verify).
+func TestRunAuditVerifyConfigNoAuditPathErrors(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "runlore.yaml")
+	if err := os.WriteFile(cfgPath, []byte("actions:\n  mode: off\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := runAuditVerify([]string{"--config", cfgPath}); err == nil {
+		t.Fatal("a --config with no actions.audit_log_path must error")
+	}
+}

--- a/cmd/lore/audit_test.go
+++ b/cmd/lore/audit_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/audit"
+)
+
+// writeAuditChain writes a fresh, intact audit chain of n records and returns its path.
+func writeAuditChain(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "audit.jsonl")
+	l, err := audit.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for _, op := range []string{"suspend", "resume", "reconcile"} {
+		if err := l.Log(audit.Record{Actor: "auto", Op: op, Target: "Kustomization/apps/web", Decision: audit.DecisionExecuted}); err != nil {
+			t.Fatalf("log: %v", err)
+		}
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return path
+}
+
+func TestAuditVerifyIntactOK(t *testing.T) {
+	path := writeAuditChain(t, t.TempDir())
+	var buf bytes.Buffer
+	if err := auditVerify(&buf, path); err != nil {
+		t.Fatalf("intact chain must verify, got: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "OK") {
+		t.Fatalf("expected an OK line, got: %q", out)
+	}
+	if !strings.Contains(out, "3") {
+		t.Fatalf("expected the record count (3) in output, got: %q", out)
+	}
+}
+
+func TestAuditVerifyTamperedFails(t *testing.T) {
+	path := writeAuditChain(t, t.TempDir())
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	lines[1] = strings.Replace(lines[1], "apps", "flux-system", 1)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := auditVerify(&buf, path); err == nil {
+		t.Fatalf("tampered chain must fail, output: %q", buf.String())
+	}
+}
+
+func TestAuditVerifyEmptyFileOK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := auditVerify(&buf, path); err != nil {
+		t.Fatalf("empty chain must verify (0 records), got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "0") {
+		t.Fatalf("expected 0-record OK line, got: %q", buf.String())
+	}
+}
+
+func TestAuditVerifyMissingPathErrors(t *testing.T) {
+	var buf bytes.Buffer
+	if err := auditVerify(&buf, ""); err == nil {
+		t.Fatal("an empty --path must error")
+	}
+}

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -28,6 +28,7 @@ Usage:
   lore eval --live [--scenarios <dir>] [--n 3]        live-fire on the cluster: grade coverage + RCA
   lore curate [--config <path>]                       groom the KB backlog (dedup open PRs)
   lore mcp [--config <path>]                          serve GitOps what-changed over MCP (stdio; for HolmesGPT et al.)
+  lore audit verify --path <audit.jsonl>              re-walk the action audit log; report the first broken link
   lore version                                        print version
 `
 
@@ -69,6 +70,11 @@ func main() {
 	case "mcp":
 		if err := app.RunMCP(version, os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "mcp:", err)
+			os.Exit(1)
+		}
+	case "audit":
+		if err := runAudit(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "audit:", err)
 			os.Exit(1)
 		}
 	case "validate-kb":

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -36,8 +36,9 @@ registry and **discards the model's own metadata**:
 - `auto` mode starts **paused** (kill-switch engaged, fail-closed) and is gated behind
   confidence/rate/blast limits. It exists but is **not recommended on real clusters**.
 
-The action config is **fail-closed**: `approve`/`auto` won't start without an approval token, and
-`auto` additionally requires an audit-log path, an authenticated webhook, a positive confidence
+The action config is **fail-closed**: `approve`/`auto` won't start without an approval token **and an
+audit-log path** (both modes execute cluster mutations, so both must be audited), and `auto`
+additionally requires an authenticated webhook, a positive confidence
 threshold and rate cap, and a non-empty namespace allowlist (see
 [Configuration → actions](configuration.md#actions--the-autonomy-ladder-off-by-default)).
 
@@ -107,8 +108,11 @@ recorded: `executed` / `dry-run` / `skipped` / `denied` / `failed`.
 
 The chain is **load-bearing**, not just an artifact tests check:
 
-- **Verified on startup, fail-closed under `approve`/`auto`.** When the agent opens the log it re-walks
-  the existing chain. If a link is broken and `actions.mode` is `approve` or `auto`, **startup fails** —
+- **Verified on startup, fail-closed under `approve`/`auto`.** Both executing modes are **required** to
+  set `actions.audit_log_path` (enforced by config validation), so the guarantee always has a chain to
+  verify — neither can silently downgrade to an unaudited run. When the agent opens the log it re-walks
+  the existing chain in a single read pass and reuses that same handle for appends (no verify→append
+  re-read window). If a link is broken and `actions.mode` is `approve` or `auto`, **startup fails** —
   RunLore refuses to execute and audit cluster mutations against a history it can no longer vouch for.
   Under `off`/`suggest` (nothing executes) it logs a loud **warning** and keeps appending, so a
   read-only deployment isn't blocked by a damaged file. An empty or absent log is a valid (zero-record)

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -102,9 +102,33 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
 
 Every action attempt — inputs, gate result, op, target, actor, outcome — is appended to a
 **hash-chained** JSON log (`internal/audit`): each record carries the previous record's hash, the file
-is `0600` and **fsync'd after every write**, and a `Verify` pass detects the first broken link. Edits
-or deletions are therefore detectable. Outcomes recorded: `executed` / `dry-run` / `skipped` /
-`denied` / `failed`.
+is `0600` and **fsync'd after every write**, and a `Verify` pass detects the first broken link. Outcomes
+recorded: `executed` / `dry-run` / `skipped` / `denied` / `failed`.
+
+The chain is **load-bearing**, not just an artifact tests check:
+
+- **Verified on startup, fail-closed under `approve`/`auto`.** When the agent opens the log it re-walks
+  the existing chain. If a link is broken and `actions.mode` is `approve` or `auto`, **startup fails** —
+  RunLore refuses to execute and audit cluster mutations against a history it can no longer vouch for.
+  Under `off`/`suggest` (nothing executes) it logs a loud **warning** and keeps appending, so a
+  read-only deployment isn't blocked by a damaged file. An empty or absent log is a valid (zero-record)
+  chain.
+- **Verifiable on demand.** `lore audit verify --path <audit.jsonl>` (or `--config <runlore.yaml>` to
+  read `actions.audit_log_path`) re-walks the chain out-of-band: it prints `OK: chain intact (<N>
+  records)` and exits `0`, or prints the first broken link and exits non-zero. Run it from CI, a cron, or
+  an incident review.
+
+Verification catches **insertion**, **edit** (any byte of a recorded field), and **mid-chain deletion**
+— each breaks a `prev_hash`/`hash` link.
+
+**Honest residual limit — tail-truncation.** Dropping the *most-recent* records leaves a shorter but
+internally consistent prefix, which still verifies. Chain verification alone therefore cannot detect
+that the tail was lopped off. Fully closing this needs an **external anchor** (e.g. periodically
+publishing the head hash + record count to an append-only store the writer can't rewrite), which is out
+of scope: a sidecar high-water mark doesn't help — a privileged writer that can truncate the log can
+truncate the sidecar too, and making it crash-consistent is fiddly. Until an external anchor exists,
+mitigate operationally: keep the log on **durable storage with restricted write access** (ideally a
+medium where the agent's own identity cannot rewrite history), and back it up.
 
 ## Honest limitations
 

--- a/internal/app/action.go
+++ b/internal/app/action.go
@@ -11,13 +11,38 @@ import (
 
 // BuildAuditor opens the append-only action audit log when configured, else a
 // no-op. Validate already requires AuditLogPath when actions.mode=auto.
-func BuildAuditor(cfg *config.Config) (audit.Auditor, func(), error) {
+//
+// The existing hash chain is verified on open (OpenVerified). If it is broken
+// (insertion, edit, or mid-chain deletion) the response is mode-gated, because
+// this is where cfg is available:
+//   - approve/auto (RunLore executes + audits actions) → return an error so
+//     startup FAILS CLOSED: it must not append to, or act against, a chain whose
+//     integrity can no longer be vouched for.
+//   - off/suggest (nothing is executed) → log a WARNING and proceed: the auditor
+//     still opens and keeps appending, so a non-executing deployment isn't blocked.
+//
+// An empty or absent chain is valid (not broken). Tail-truncation (dropping the
+// most-recent records) leaves a valid prefix and is NOT detectable here — see
+// docs/security-model.md.
+func BuildAuditor(cfg *config.Config, log *slog.Logger) (audit.Auditor, func(), error) {
 	if cfg.Actions.AuditLogPath == "" {
 		return audit.Nop{}, func() {}, nil
 	}
-	l, err := audit.Open(cfg.Actions.AuditLogPath)
+	l, err := audit.OpenVerified(cfg.Actions.AuditLogPath)
 	if err != nil {
-		return nil, func() {}, fmt.Errorf("open audit log: %w", err)
+		if cfg.Actions.Mode == config.ActionApprove || cfg.Actions.Mode == config.ActionAuto {
+			// Fail closed: an executing rung must not act against an untrustworthy chain.
+			return nil, func() {}, fmt.Errorf("audit log integrity check failed (mode=%s, fail closed): %w", cfg.Actions.Mode, err)
+		}
+		// Non-executing mode: warn and fall back to a plain append so the deployment
+		// still records, but the broken history is surfaced loudly.
+		log.Warn("audit log chain failed verification; proceeding because actions are not executed in this mode",
+			"mode", cfg.Actions.Mode, "path", cfg.Actions.AuditLogPath, "err", err)
+		plain, oerr := audit.Open(cfg.Actions.AuditLogPath)
+		if oerr != nil {
+			return nil, func() {}, fmt.Errorf("open audit log: %w", oerr)
+		}
+		return plain, func() { _ = plain.Close() }, nil
 	}
 	return l, func() { _ = l.Close() }, nil
 }

--- a/internal/app/action.go
+++ b/internal/app/action.go
@@ -10,7 +10,8 @@ import (
 )
 
 // BuildAuditor opens the append-only action audit log when configured, else a
-// no-op. Validate already requires AuditLogPath when actions.mode=auto.
+// no-op. Validate already requires AuditLogPath for both executing modes
+// (approve and auto), so the Nop fallback below only ever applies to off/suggest.
 //
 // The existing hash chain is verified on open (OpenVerified). If it is broken
 // (insertion, edit, or mid-chain deletion) the response is mode-gated, because

--- a/internal/app/action_test.go
+++ b/internal/app/action_test.go
@@ -184,6 +184,30 @@ func TestBuildAuditorUnreadableLogFailsClosed(t *testing.T) {
 	}
 }
 
+// TestBuildAuditorDirPathFailsClosed checks the uid-independent fail-closed
+// guarantee: pointing AuditLogPath at a directory causes os.OpenFile to return
+// EISDIR for any uid (including root), so OpenVerified fails and BuildAuditor
+// must return an error under the executing modes. This test must never be skipped.
+func TestBuildAuditorDirPathFailsClosed(t *testing.T) {
+	// A directory path causes EISDIR on OpenFile(O_RDWR|O_CREATE) for all uids.
+	dirPath := t.TempDir()
+	for _, mode := range []config.ActionMode{config.ActionApprove, config.ActionAuto} {
+		t.Run(string(mode), func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Actions.Mode = mode
+			cfg.Actions.AuditLogPath = dirPath
+
+			_, closeFn, err := BuildAuditor(cfg, discardLog())
+			if closeFn != nil {
+				closeFn()
+			}
+			if err == nil {
+				t.Fatalf("mode=%s with a directory AuditLogPath must fail closed (error), got nil", mode)
+			}
+		})
+	}
+}
+
 func TestBuildAuditorNoPathIsNop(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Actions.Mode = config.ActionApprove

--- a/internal/app/action_test.go
+++ b/internal/app/action_test.go
@@ -134,6 +134,56 @@ func TestBuildAuditorIntactChainUnderApprove(t *testing.T) {
 	}
 }
 
+func TestBuildAuditorIntactChainUnderAuto(t *testing.T) {
+	path := writeIntactChain(t, t.TempDir())
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionAuto
+	cfg.Actions.AuditLogPath = path
+
+	aud, closeFn, err := BuildAuditor(cfg, discardLog())
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if err != nil {
+		t.Fatalf("auto over an intact chain must succeed, got: %v", err)
+	}
+	if aud == nil {
+		t.Fatal("intact chain under auto must return an auditor")
+	}
+}
+
+// TestBuildAuditorUnreadableLogFailsClosed checks that an I/O error reading the
+// log (here: an existing, non-empty file the process cannot open) — a non-
+// IsNotExist error — blocks startup under the executing modes, just like a content
+// mismatch. Fail-closed must cover "can't read it", not only "read it and it's
+// tampered".
+func TestBuildAuditorUnreadableLogFailsClosed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("chmod 000 does not deny root; skipping permission-based I/O test")
+	}
+	for _, mode := range []config.ActionMode{config.ActionApprove, config.ActionAuto} {
+		t.Run(string(mode), func(t *testing.T) {
+			path := writeIntactChain(t, t.TempDir())
+			if err := os.Chmod(path, 0o000); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(path, 0o600) }) // let TempDir cleanup remove it
+
+			cfg := &config.Config{}
+			cfg.Actions.Mode = mode
+			cfg.Actions.AuditLogPath = path
+
+			_, closeFn, err := BuildAuditor(cfg, discardLog())
+			if closeFn != nil {
+				closeFn()
+			}
+			if err == nil {
+				t.Fatalf("mode=%s over an unreadable log must fail closed (error), got nil", mode)
+			}
+		})
+	}
+}
+
 func TestBuildAuditorNoPathIsNop(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Actions.Mode = config.ActionApprove

--- a/internal/app/action_test.go
+++ b/internal/app/action_test.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/config"
+)
+
+// writeIntactChain writes a fresh, intact audit chain to a file in dir and
+// returns its path.
+func writeIntactChain(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "audit.jsonl")
+	l, err := audit.Open(path)
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	for _, op := range []string{"suspend", "resume", "reconcile"} {
+		if err := l.Log(audit.Record{Actor: "auto", Op: op, Target: "Kustomization/apps/web", Decision: audit.DecisionExecuted}); err != nil {
+			t.Fatalf("seed log: %v", err)
+		}
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("seed close: %v", err)
+	}
+	return path
+}
+
+// writeBrokenChain writes an intact chain, then tampers with a record's content
+// so chain verification fails, and returns its path.
+func writeBrokenChain(t *testing.T, dir string) string {
+	t.Helper()
+	path := writeIntactChain(t, dir)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 records, got %d", len(lines))
+	}
+	lines[1] = strings.Replace(lines[1], "apps", "flux-system", 1)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestBuildAuditorBrokenChainFailsClosedUnderApprove(t *testing.T) {
+	path := writeBrokenChain(t, t.TempDir())
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionApprove
+	cfg.Actions.AuditLogPath = path
+
+	_, closeFn, err := BuildAuditor(cfg, discardLog())
+	if closeFn != nil {
+		closeFn()
+	}
+	if err == nil {
+		t.Fatal("approve over a broken chain must fail closed (error), got nil")
+	}
+}
+
+func TestBuildAuditorBrokenChainFailsClosedUnderAuto(t *testing.T) {
+	path := writeBrokenChain(t, t.TempDir())
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionAuto
+	cfg.Actions.AuditLogPath = path
+
+	_, closeFn, err := BuildAuditor(cfg, discardLog())
+	if closeFn != nil {
+		closeFn()
+	}
+	if err == nil {
+		t.Fatal("auto over a broken chain must fail closed (error), got nil")
+	}
+}
+
+func TestBuildAuditorBrokenChainWarnsUnderSuggest(t *testing.T) {
+	path := writeBrokenChain(t, t.TempDir())
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionSuggest
+	cfg.Actions.AuditLogPath = path
+
+	aud, closeFn, err := BuildAuditor(cfg, discardLog())
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if err != nil {
+		t.Fatalf("suggest over a broken chain must proceed (warn), got error: %v", err)
+	}
+	if aud == nil {
+		t.Fatal("suggest over a broken chain must still return an auditor")
+	}
+}
+
+func TestBuildAuditorBrokenChainWarnsUnderOff(t *testing.T) {
+	path := writeBrokenChain(t, t.TempDir())
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionOff
+	cfg.Actions.AuditLogPath = path
+
+	aud, closeFn, err := BuildAuditor(cfg, discardLog())
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if err != nil {
+		t.Fatalf("off over a broken chain must proceed (warn), got error: %v", err)
+	}
+	if aud == nil {
+		t.Fatal("off over a broken chain must still return an auditor")
+	}
+}
+
+func TestBuildAuditorIntactChainUnderApprove(t *testing.T) {
+	path := writeIntactChain(t, t.TempDir())
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionApprove
+	cfg.Actions.AuditLogPath = path
+
+	aud, closeFn, err := BuildAuditor(cfg, discardLog())
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if err != nil {
+		t.Fatalf("approve over an intact chain must succeed, got: %v", err)
+	}
+	if aud == nil {
+		t.Fatal("intact chain under approve must return an auditor")
+	}
+}
+
+func TestBuildAuditorNoPathIsNop(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionApprove
+	// no AuditLogPath
+	aud, closeFn, err := BuildAuditor(cfg, discardLog())
+	if closeFn != nil {
+		defer closeFn()
+	}
+	if err != nil {
+		t.Fatalf("no audit path must not error, got: %v", err)
+	}
+	if _, ok := aud.(audit.Nop); !ok {
+		t.Fatalf("no audit path must yield a Nop auditor, got %T", aud)
+	}
+}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -113,7 +113,7 @@ func RunServe(version string, args []string) error {
 		return fmt.Errorf("actions enabled (mode=%s) but %s is empty: refusing to start with unauthenticated control endpoints (fail closed)",
 			cfg.Actions.Mode, cfg.Actions.ApprovalTokenEnv)
 	}
-	aud, auditClose, aerr := BuildAuditor(cfg)
+	aud, auditClose, aerr := BuildAuditor(cfg, log)
 	if aerr != nil {
 		return aerr
 	}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -103,6 +103,9 @@ func OpenVerified(path string) (*Logger, error) {
 	// Reuse the verified fd as the append handle: seek past the verified tail so the
 	// next write lands at end-of-file. Seeding lastHash from the verified scan (not a
 	// second os.Open) means an append always chains from bytes we just vouched for.
+	// Safety: a one-time seek-to-end is sufficient because Logger is single-writer
+	// (mutex-guarded, single process/Logger owner); a second writer or a stray Seek
+	// on this fd would silently produce a mid-file write and corrupt the chain.
 	if _, err := f.Seek(0, io.SeekEnd); err != nil {
 		_ = f.Close()
 		return nil, fmt.Errorf("audit: seek to append: %w", err)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -75,6 +75,29 @@ func Open(path string) (*Logger, error) {
 	return &Logger{w: f, closer: f, syncFn: f.Sync, lastHash: last, now: time.Now}, nil
 }
 
+// OpenVerified opens the audit log like Open, but first re-walks the existing
+// chain with Verify and refuses to open a chain whose integrity is broken
+// (insertion, edit, or mid-chain deletion). An empty or absent file is a valid
+// (zero-record) chain. Callers that must fail closed against an untrustworthy
+// chain (executing action modes) should use this instead of Open; the mode-based
+// fail/warn policy lives at the call site where the config is available.
+func OpenVerified(path string) (*Logger, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path is the operator-configured audit log
+	switch {
+	case os.IsNotExist(err):
+		// Absent file: nothing to verify (empty chain is valid).
+	case err != nil:
+		return nil, fmt.Errorf("audit: open %s for verify: %w", path, err)
+	default:
+		verr := Verify(f)
+		_ = f.Close()
+		if verr != nil {
+			return nil, fmt.Errorf("audit: existing chain failed verification: %w", verr)
+		}
+	}
+	return Open(path)
+}
+
 // NewWriter builds a Logger over an arbitrary writer (tests).
 func NewWriter(w io.Writer) *Logger {
 	return &Logger{w: w, now: time.Now}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -76,26 +76,38 @@ func Open(path string) (*Logger, error) {
 }
 
 // OpenVerified opens the audit log like Open, but first re-walks the existing
-// chain with Verify and refuses to open a chain whose integrity is broken
-// (insertion, edit, or mid-chain deletion). An empty or absent file is a valid
-// (zero-record) chain. Callers that must fail closed against an untrustworthy
-// chain (executing action modes) should use this instead of Open; the mode-based
-// fail/warn policy lives at the call site where the config is available.
+// chain and refuses to open a chain whose integrity is broken (insertion, edit,
+// or mid-chain deletion). An empty or absent file is a valid (zero-record) chain.
+// Callers that must fail closed against an untrustworthy chain (executing action
+// modes) should use this instead of Open; the mode-based fail/warn policy lives at
+// the call site where the config is available.
+//
+// It reads the file EXACTLY ONCE: the same scan that verifies the chain also
+// yields the trusted seed hash, and that fd is reused as the append handle (seeked
+// to end). This closes a TOCTOU window the previous implementation had — it
+// verified, closed the fd, then re-read the tail via a second os.Open to seed the
+// chaining hash, letting an attacker overwrite the tail in between so the Logger
+// chained from a tampered base. Now the seed comes from the verified bytes and the
+// handle is never reopened, so there is no verify→append gap.
 func OpenVerified(path string) (*Logger, error) {
-	f, err := os.Open(path) //nolint:gosec // G304: path is the operator-configured audit log
-	switch {
-	case os.IsNotExist(err):
-		// Absent file: nothing to verify (empty chain is valid).
-	case err != nil:
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600) //nolint:gosec // G304: path is the operator-configured audit log
+	if err != nil {
 		return nil, fmt.Errorf("audit: open %s for verify: %w", path, err)
-	default:
-		verr := Verify(f)
-		_ = f.Close()
-		if verr != nil {
-			return nil, fmt.Errorf("audit: existing chain failed verification: %w", verr)
-		}
 	}
-	return Open(path)
+	// Verify and capture the trusted last hash from the SAME read pass.
+	last, verr := verifyChain(f)
+	if verr != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("audit: existing chain failed verification: %w", verr)
+	}
+	// Reuse the verified fd as the append handle: seek past the verified tail so the
+	// next write lands at end-of-file. Seeding lastHash from the verified scan (not a
+	// second os.Open) means an append always chains from bytes we just vouched for.
+	if _, err := f.Seek(0, io.SeekEnd); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("audit: seek to append: %w", err)
+	}
+	return &Logger{w: f, closer: f, syncFn: f.Sync, lastHash: last, now: time.Now}, nil
 }
 
 // NewWriter builds a Logger over an arbitrary writer (tests).
@@ -178,6 +190,16 @@ func lastHash(path string) (string, error) {
 
 // Verify re-walks a chain and reports the first broken link, if any.
 func Verify(r io.Reader) error {
+	_, err := verifyChain(r)
+	return err
+}
+
+// verifyChain re-walks a chain in a single pass, returning the last record's hash
+// (the trusted seed for a subsequent append) alongside the first broken-link
+// error, if any. Both the public Verify and OpenVerified share it; OpenVerified
+// uses the returned hash to seed its Logger from the very bytes it just verified,
+// so the file is read exactly once and there is no verify→append re-read window.
+func verifyChain(r io.Reader) (string, error) {
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	prev := ""
@@ -190,17 +212,20 @@ func Verify(r io.Reader) error {
 		n++
 		var rec Record
 		if err := json.Unmarshal([]byte(line), &rec); err != nil {
-			return fmt.Errorf("audit: record %d: %w", n, err)
+			return "", fmt.Errorf("audit: record %d: %w", n, err)
 		}
 		if rec.PrevHash != prev {
-			return fmt.Errorf("audit: record %d: prev_hash mismatch (chain broken)", n)
+			return "", fmt.Errorf("audit: record %d: prev_hash mismatch (chain broken)", n)
 		}
 		if hashRecord(rec) != rec.Hash {
-			return fmt.Errorf("audit: record %d: hash mismatch (record tampered)", n)
+			return "", fmt.Errorf("audit: record %d: hash mismatch (record tampered)", n)
 		}
 		prev = rec.Hash
 	}
-	return sc.Err()
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	return prev, nil
 }
 
 // Nop is an Auditor that drops records (local/no-audit fallback).

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -94,6 +94,42 @@ func TestOpenVerifiedTampered(t *testing.T) {
 	}
 }
 
+// TestOpenVerifiedGenesisRoundTrip proves the empty→first-genesis-append path
+// produces a valid chain: open an absent file via OpenVerified, write the first
+// (genesis) record, close, re-read, and re-Verify the chain. Mirrors what
+// TestOpenVerifiedIntact does for the non-empty starting case.
+func TestOpenVerifiedGenesisRoundTrip(t *testing.T) {
+	for _, name := range []string{"absent", "empty"} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "audit.jsonl")
+			if name == "empty" {
+				if err := os.WriteFile(path, nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			l, err := OpenVerified(path)
+			if err != nil {
+				t.Fatalf("OpenVerified on %s file must succeed, got: %v", name, err)
+			}
+			if err := l.Log(Record{Actor: "auto", Op: "suspend", Target: "Kustomization/apps/web", Decision: DecisionExecuted}); err != nil {
+				t.Fatalf("genesis log: %v", err)
+			}
+			if err := l.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if err := Verify(strings.NewReader(string(b))); err != nil {
+				t.Fatalf("genesis chain must verify cleanly: %v", err)
+			}
+		})
+	}
+}
+
 func TestOpenVerifiedMidChainDeletion(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.jsonl")
 	writeChain(t, path)

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -1,0 +1,119 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeChain writes a fresh, intact 3-record chain to path and returns it closed.
+func writeChain(t *testing.T, path string) {
+	t.Helper()
+	l, err := Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for _, op := range []string{"suspend", "resume", "reconcile"} {
+		if err := l.Log(Record{Actor: "auto", Op: op, Target: "Kustomization/apps/web", Decision: DecisionExecuted}); err != nil {
+			t.Fatalf("log: %v", err)
+		}
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestOpenVerifiedIntact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	writeChain(t, path)
+
+	l, err := OpenVerified(path)
+	if err != nil {
+		t.Fatalf("OpenVerified on an intact chain must succeed, got: %v", err)
+	}
+	// The returned Logger must keep appending cleanly (chain seeded from disk).
+	if err := l.Log(Record{Actor: "auto", Op: "suspend", Target: "Kustomization/apps/api", Decision: DecisionSkipped, Reason: "paused"}); err != nil {
+		t.Fatalf("append after OpenVerified: %v", err)
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if err := Verify(strings.NewReader(string(b))); err != nil {
+		t.Fatalf("chain must stay verifiable after OpenVerified append: %v", err)
+	}
+}
+
+func TestOpenVerifiedAbsentFile(t *testing.T) {
+	// An absent file is an empty (valid) chain — OpenVerified must create + succeed.
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	l, err := OpenVerified(path)
+	if err != nil {
+		t.Fatalf("OpenVerified on an absent file must succeed (empty chain is valid), got: %v", err)
+	}
+	_ = l.Close()
+}
+
+func TestOpenVerifiedEmptyFile(t *testing.T) {
+	// An existing but empty file is a valid (zero-record) chain.
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	l, err := OpenVerified(path)
+	if err != nil {
+		t.Fatalf("OpenVerified on an empty file must succeed, got: %v", err)
+	}
+	_ = l.Close()
+}
+
+func TestOpenVerifiedTampered(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	writeChain(t, path)
+
+	// Tamper with the middle record's target without recomputing the hash.
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 records, got %d", len(lines))
+	}
+	lines[1] = strings.Replace(lines[1], "apps", "flux-system", 1)
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := OpenVerified(path); err == nil {
+		t.Fatal("OpenVerified must return an error on a tampered chain")
+	}
+}
+
+func TestOpenVerifiedMidChainDeletion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	writeChain(t, path)
+
+	// Drop the middle record: the surviving record 2's prev_hash no longer matches
+	// record 1's hash (insertion/mid-chain deletion is caught; tail-truncation is not).
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 records, got %d", len(lines))
+	}
+	kept := []string{lines[0], lines[2]}
+	if err := os.WriteFile(path, []byte(strings.Join(kept, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := OpenVerified(path); err == nil {
+		t.Fatal("OpenVerified must return an error on a mid-chain deletion")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -527,14 +527,18 @@ func (c *Config) Validate() error {
 		if c.Actions.ApprovalTokenEnv == "" {
 			return fmt.Errorf("actions.mode=%s requires actions.approval_token_env (control/kill-switch endpoints fail closed without it)", c.Actions.Mode)
 		}
+		// Both executing rungs mutate the cluster, so both must be audited: the hash
+		// chain is verified fail-closed on open (see internal/app.BuildAuditor). Without
+		// an audit_log_path approve would silently fall back to a Nop auditor — no chain,
+		// no verify, no fail-closed — yet it still executes cluster mutations.
+		if c.Actions.AuditLogPath == "" {
+			return fmt.Errorf("actions.mode=%s requires actions.audit_log_path (an executing rung must be audited)", c.Actions.Mode)
+		}
 		if c.Actions.Mode == ActionApprove {
 			return nil
 		}
-		// auto-only: unattended execution additionally needs audit, an authenticated
-		// webhook, and bounded gates.
-		if c.Actions.AuditLogPath == "" {
-			return fmt.Errorf("actions.mode=auto requires actions.audit_log_path (auto-execution must be audited)")
-		}
+		// auto-only: unattended execution additionally needs an authenticated webhook
+		// and bounded gates.
 		if c.Server.WebhookTokenEnv == "" {
 			return fmt.Errorf("actions.mode=auto requires server.webhook_token_env (the alert webhook must be authenticated)")
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -224,3 +224,26 @@ func TestCurateRecurrenceThresholdParse(t *testing.T) {
 		t.Fatalf("absent recurrence_threshold must be 0, got %d", z.Curate.RecurrenceThreshold)
 	}
 }
+
+// TestValidateApproveRequiresAuditLog asserts approve mode is held to the same
+// audit requirement as auto: an executing rung that mutates the cluster must have
+// an audit_log_path (so the hash chain is verified fail-closed on open). Without
+// it, approve would silently fall back to a Nop auditor.
+func TestValidateApproveRequiresAuditLog(t *testing.T) {
+	// approve with the token but NO audit_log_path → rejected.
+	missing := &Config{}
+	missing.Actions.Mode = ActionApprove
+	missing.Actions.ApprovalTokenEnv = "RUNLORE_APPROVAL_TOKEN"
+	if err := missing.Validate(); err == nil {
+		t.Fatal("approve without actions.audit_log_path must be rejected")
+	}
+
+	// approve WITH both the token and an audit_log_path → validates.
+	ok := &Config{}
+	ok.Actions.Mode = ActionApprove
+	ok.Actions.ApprovalTokenEnv = "RUNLORE_APPROVAL_TOKEN"
+	ok.Actions.AuditLogPath = "/var/lib/runlore/audit.jsonl"
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("approve with token + audit_log_path must validate clean, got: %v", err)
+	}
+}


### PR DESCRIPTION
  ## What
  The hash-chained "tamper-evident" audit log wasn't actually verified at runtime — `audit.Verify` was dead code (test-only) and `audit.Open` only seeded the last hash. This makes the chain load-bearing.

  ## How
  - **Verify on open:** new `audit.OpenVerified(path)` re-walks the existing chain (insertion/edit/mid-chain deletion → error) before opening for append; an absent/empty chain is valid.
  - **Fail-closed, mode-gated** (in `BuildAuditor`): a broken chain → **startup error under `approve`/`auto`** (must not act+audit against an untrustworthy chain); under `off`/`suggest` it logs a loud warning and falls back to plain append (a non-executing deployment isn't blocked).
  - **CLI:** `lore audit verify --path <audit.jsonl>` (or `--config <runlore.yaml>`) → `OK: chain intact (N records)` / the broken-link error, exit 0/1.
  - **Docs:** `security-model.md` updated with the honest residual limit — **tail-truncation** leaves a valid prefix and isn't caught by chain verification; fully mitigating needs an external anchor (out of scope), so pair with durable, write-restricted storage.

  ## Tests
  15 new (audit/app/cmd): verify-on-open rejects tampered / accepts intact+empty; `BuildAuditor` fail-closed under approve/auto, warn+proceed under off/suggest; CLI intact→ok, tampered→error. `go test -race ./...` green (re-verified under `TZ=UTC -count=1`); `golangci-lint` 0 issues.