### PR TITLE
feat: mid-loop tool-output compaction (quality gate pending live-eval)

### DIFF
--- a/docs/superpowers/plans/2026-06-30-mid-loop-history-compaction.md
+++ b/docs/superpowers/plans/2026-06-30-mid-loop-history-compaction.md
@@ -1,0 +1,557 @@
+# Mid-loop Tool-Output Compaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Under budget pressure, elide superseded/old tool-output bodies from the loop's message history so a long investigation can finish instead of hitting the hard-kill — protecting the root-cause skeleton.
+
+**Architecture:** A pure, provider-agnostic `compactHistory` in `internal/investigate` that rewrites the `[]providers.Message` history; called at the top of each loop step before the existing budget guard; two new metrics. No model-client changes.
+
+**Tech Stack:** Go 1.26, standard library + OpenTelemetry (existing). No new deps.
+
+## Global Constraints
+
+- Go 1.26.0; standard library + existing deps only.
+- No co-authored commits; no AI attribution.
+- **Protected from elision (never elided):** the seed (first message), every assistant turn, keep-list tool results (`what_changed`, `kb_search`, `gitops_resource_status`, `gitops_tree`), and the most-recent `keepRecentToolOutputs = 3` tool results.
+- **Elision order:** superseded first (a `(tool name, args)` re-issued by a later assistant turn), then largest-byte-first; stop once the estimate is `<= target` (= `0.7 × MaxTokensPerInvestigation`). Never elide more than necessary.
+- Compaction is disabled when `MaxTokensPerInvestigation <= 0` (no reference point). Idempotent (an elided marker is never re-selected).
+- The existing nudge → hard-kill backstop is unchanged; it runs after compaction on the recomputed estimate.
+- Spec: `docs/superpowers/specs/2026-06-30-mid-loop-history-compaction-design.md`.
+
+---
+
+### Task 1: `compactHistory` + unit tests
+
+**Files:**
+- Create: `internal/investigate/compact.go`
+- Test: `internal/investigate/compact_test.go`
+
+**Interfaces:**
+- Produces (consumed by Task 3): `compactHistory(messages []providers.Message, sys string, specs []providers.ToolSpec, target int) ([]providers.Message, int)`; `compactionTarget(budget int) int`; constants `compactionBudgetFraction`, `keepRecentToolOutputs`; `keepListTools`.
+- Consumes: existing `estimateTokens(system string, msgs []providers.Message, tools []providers.ToolSpec) int` (`budget.go`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/investigate/compact_test.go`:
+
+```go
+package investigate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// toolMsg builds an assistant tool-call turn followed by its tool-result message.
+func callAndResult(id, name, args, result string) []providers.Message {
+	return []providers.Message{
+		{Role: "assistant", ToolCalls: []providers.ToolCall{{ID: id, Name: name, Args: args}}},
+		{Role: "tool", ToolCallID: id, Content: result},
+	}
+}
+
+func buildHistory(seedSize int, calls ...[]providers.Message) []providers.Message {
+	msgs := []providers.Message{{Role: "user", Content: strings.Repeat("s", seedSize)}}
+	for _, c := range calls {
+		msgs = append(msgs, c...)
+	}
+	return msgs
+}
+
+func toolResultByID(msgs []providers.Message, id string) string {
+	for _, m := range msgs {
+		if m.Role == "tool" && m.ToolCallID == id {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+func TestCompactElidesOldBeyondRecentK(t *testing.T) {
+	big := strings.Repeat("x", 4000)
+	// 5 pod_logs calls; with K=3, the oldest 2 (ids 1,2) are eligible.
+	msgs := buildHistory(10,
+		callAndResult("1", "pod_logs", `{"ns":"a"}`, big),
+		callAndResult("2", "pod_logs", `{"ns":"b"}`, big),
+		callAndResult("3", "pod_logs", `{"ns":"c"}`, big),
+		callAndResult("4", "pod_logs", `{"ns":"d"}`, big),
+		callAndResult("5", "pod_logs", `{"ns":"e"}`, big),
+	)
+	target := estimateTokens("", msgs, nil) - 1500 // force some elision
+	out, elided := compactHistory(msgs, "", nil, target)
+	if elided == 0 {
+		t.Fatal("expected some bytes elided")
+	}
+	// recent 3 (ids 3,4,5) kept verbatim
+	for _, id := range []string{"3", "4", "5"} {
+		if toolResultByID(out, id) != big {
+			t.Fatalf("recent tool result %s must be kept verbatim", id)
+		}
+	}
+	// oldest (id 1) elided to a marker
+	if !isElidedMarker(toolResultByID(out, "1")) {
+		t.Fatalf("oldest tool result should be elided, got %q", toolResultByID(out, "1"))
+	}
+}
+
+func TestCompactProtectsSeedAssistantAndKeepList(t *testing.T) {
+	big := strings.Repeat("y", 5000)
+	msgs := buildHistory(20,
+		callAndResult("1", "what_changed", `{}`, big),         // keep-listed
+		callAndResult("2", "kb_search", `{}`, big),            // keep-listed
+		callAndResult("3", "gitops_tree", `{}`, big),          // keep-listed
+		callAndResult("4", "gitops_resource_status", `{}`, big), // keep-listed
+		callAndResult("5", "pod_logs", `{}`, big),
+		callAndResult("6", "pod_logs", `{}`, big),
+		callAndResult("7", "pod_logs", `{}`, big),
+		callAndResult("8", "pod_logs", `{}`, big),
+	)
+	target := 1 // force maximum elision
+	out, _ := compactHistory(msgs, "", nil, target)
+	// keep-list tools never elided
+	for _, id := range []string{"1", "2", "3", "4"} {
+		if toolResultByID(out, id) != big {
+			t.Fatalf("keep-list tool %s must never be elided", id)
+		}
+	}
+	// seed untouched
+	if out[0].Content != strings.Repeat("y", 20) {
+		t.Fatal("seed must never be elided")
+	}
+	// assistant turns untouched (still carry their tool calls)
+	for _, m := range out {
+		if m.Role == "assistant" && len(m.ToolCalls) == 0 {
+			t.Fatal("assistant tool-call turn must be preserved")
+		}
+	}
+}
+
+func TestCompactSupersededFirst(t *testing.T) {
+	big := strings.Repeat("z", 3000)
+	small := strings.Repeat("z", 3200)
+	// id 1 (pod_logs ns=a) is superseded by id 4 (same name+args, later). id 2 is a
+	// larger, non-superseded one-off. Supersession must elide id 1 before id 2 even
+	// though id 2 is larger. Use K=3 so ids 1 and 2 are eligible (ids 3,4 are recent).
+	msgs := buildHistory(10,
+		callAndResult("1", "pod_logs", `{"ns":"a"}`, big),  // superseded by id 4
+		callAndResult("2", "controller_logs", `{"c":"x"}`, small), // larger, one-off
+		callAndResult("3", "pod_logs", `{"ns":"b"}`, big),
+		callAndResult("4", "pod_logs", `{"ns":"a"}`, big),  // re-query of id 1
+	)
+	// target that allows exactly one elision to drop under it
+	target := estimateTokens("", msgs, nil) - 600
+	out, _ := compactHistory(msgs, "", nil, target)
+	if !isElidedMarker(toolResultByID(out, "1")) {
+		t.Fatal("superseded id 1 should be elided first")
+	}
+	if isElidedMarker(toolResultByID(out, "2")) {
+		t.Fatal("non-superseded id 2 should NOT be elided when one elision sufficed")
+	}
+}
+
+func TestCompactNoopWhenUnderTarget(t *testing.T) {
+	msgs := buildHistory(10, callAndResult("1", "pod_logs", `{}`, "small"))
+	target := estimateTokens("", msgs, nil) + 1000 // already under
+	out, elided := compactHistory(msgs, "", nil, target)
+	if elided != 0 {
+		t.Fatalf("expected no-op, elided %d", elided)
+	}
+	if &out[0] == nil {
+		t.Fatal("should return the history")
+	}
+}
+
+func TestCompactDisabledTargetZero(t *testing.T) {
+	msgs := buildHistory(10, callAndResult("1", "pod_logs", `{}`, strings.Repeat("x", 9000)))
+	_, elided := compactHistory(msgs, "", nil, 0)
+	if elided != 0 {
+		t.Fatal("target<=0 must be a no-op")
+	}
+}
+
+func TestCompactIdempotent(t *testing.T) {
+	big := strings.Repeat("x", 5000)
+	msgs := buildHistory(10,
+		callAndResult("1", "pod_logs", `{}`, big),
+		callAndResult("2", "pod_logs", `{}`, big),
+		callAndResult("3", "pod_logs", `{}`, big),
+		callAndResult("4", "pod_logs", `{}`, big),
+	)
+	target := estimateTokens("", msgs, nil) - 1000
+	once, _ := compactHistory(msgs, "", nil, target)
+	twice, elided2 := compactHistory(once, "", nil, target)
+	if elided2 != 0 {
+		t.Fatalf("second compaction pass should be a no-op, elided %d", elided2)
+	}
+	_ = twice
+}
+
+func TestCompactionTarget(t *testing.T) {
+	if compactionTarget(0) != 0 || compactionTarget(-5) != 0 {
+		t.Fatal("budget<=0 disables compaction")
+	}
+	if got := compactionTarget(100000); got != 70000 {
+		t.Fatalf("compactionTarget(100000)=%d, want 70000", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/investigate/ -run 'TestCompact' -v`
+Expected: compile error (compact.go doesn't exist), then FAIL.
+
+- [ ] **Step 3: Implement `compact.go`**
+
+Create `internal/investigate/compact.go`:
+
+```go
+package investigate
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const (
+	// compactionBudgetFraction is the fraction of MaxTokensPerInvestigation at which
+	// compaction triggers and the size it elides back down to (headroom for more steps).
+	compactionBudgetFraction = 0.7
+	// keepRecentToolOutputs is the number of most-recent tool results kept verbatim
+	// (the model's active working set).
+	keepRecentToolOutputs = 3
+)
+
+// keepListTools are tools whose outputs are the structural root-cause skeleton and are
+// never elided: the change timeline, the runbook hit, the failing resource's status, and
+// the dependency-cascade root. The gitops_* pair are engine-agnostic (Flux + ArgoCD).
+var keepListTools = map[string]bool{
+	"what_changed":           true,
+	"kb_search":              true,
+	"gitops_resource_status": true,
+	"gitops_tree":            true,
+}
+
+const (
+	elidedPrefix = "[earlier "
+	elidedSuffix = " output elided to bound context]"
+)
+
+func elidedMarker(tool string) string {
+	if tool == "" {
+		tool = "tool"
+	}
+	return elidedPrefix + tool + elidedSuffix
+}
+
+func isElidedMarker(s string) bool {
+	return strings.HasPrefix(s, elidedPrefix) && strings.HasSuffix(s, elidedSuffix)
+}
+
+// compactionTarget returns the estimate at/below which compaction stops: 0.7 * budget.
+// budget <= 0 disables compaction (returns 0).
+func compactionTarget(budget int) int {
+	if budget <= 0 {
+		return 0
+	}
+	return int(float64(budget) * compactionBudgetFraction)
+}
+
+// compactHistory elides the bodies of eligible tool-result messages — superseded ones
+// first, then largest-first — until estimateTokens(sys, messages, specs) drops to or
+// below target, or no eligible output remains. Protected: the seed (index 0), every
+// assistant turn, keep-list tool results, and the most-recent keepRecentToolOutputs tool
+// results. Returns a new slice (the caller's messages are never mutated) and the number
+// of body bytes elided (0 when nothing was compacted). target <= 0 is a no-op.
+func compactHistory(messages []providers.Message, sys string, specs []providers.ToolSpec, target int) ([]providers.Message, int) {
+	if target <= 0 || estimateTokens(sys, messages, specs) <= target {
+		return messages, 0
+	}
+	// Resolve each tool-call id -> (name, args) so a tool RESULT (which carries only
+	// ToolCallID) is attributable to its tool and dedupable by (name, args).
+	type call struct{ name, args string }
+	byID := map[string]call{}
+	for _, m := range messages {
+		for _, tc := range m.ToolCalls {
+			byID[tc.ID] = call{tc.Name, tc.Args}
+		}
+	}
+	// Positions of tool-result messages, in order.
+	var toolIdx []int
+	for i, m := range messages {
+		if m.Role == "tool" {
+			toolIdx = append(toolIdx, i)
+		}
+	}
+	recentCut := len(toolIdx) - keepRecentToolOutputs // list-positions >= this are recency-protected
+	// Last list-position per (name, args) — earlier ones are superseded.
+	lastPosFor := map[call]int{}
+	for pos, mi := range toolIdx {
+		lastPosFor[byID[messages[mi].ToolCallID]] = pos
+	}
+	type cand struct {
+		mi         int
+		size       int
+		superseded bool
+	}
+	var cands []cand
+	for pos, mi := range toolIdx {
+		if pos >= recentCut {
+			continue // most-recent K
+		}
+		c := byID[messages[mi].ToolCallID]
+		if keepListTools[c.name] || isElidedMarker(messages[mi].Content) {
+			continue
+		}
+		cands = append(cands, cand{mi: mi, size: len(messages[mi].Content), superseded: lastPosFor[c] != pos})
+	}
+	// Superseded first, then largest-first.
+	sort.SliceStable(cands, func(a, b int) bool {
+		if cands[a].superseded != cands[b].superseded {
+			return cands[a].superseded
+		}
+		return cands[a].size > cands[b].size
+	})
+	// Copy so the caller's slice contents are never mutated.
+	out := make([]providers.Message, len(messages))
+	copy(out, messages)
+	elided := 0
+	for _, cd := range cands {
+		if estimateTokens(sys, out, specs) <= target {
+			break
+		}
+		name := byID[out[cd.mi].ToolCallID].name
+		before := len(out[cd.mi].Content)
+		out[cd.mi].Content = elidedMarker(name)
+		elided += before - len(out[cd.mi].Content)
+	}
+	if elided == 0 {
+		return messages, 0
+	}
+	return out, elided
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test ./internal/investigate/ -run 'TestCompact' -v`
+Expected: PASS — all compaction unit tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/investigate/compact.go internal/investigate/compact_test.go
+git commit -m "feat(investigate): compactHistory — elide superseded/old tool outputs
+
+Provider-agnostic history compaction: under budget pressure, elide the bodies of
+eligible tool-result messages (superseded first, then largest-first) until the estimate
+drops below target, protecting the seed, assistant turns, the keep-list root-cause
+skeleton (what_changed/kb_search/gitops_resource_status/gitops_tree), and the most-recent
+K outputs. Pure and idempotent; not yet wired into the loop."
+```
+
+---
+
+### Task 2: Telemetry counters
+
+**Files:**
+- Modify: `internal/telemetry/metrics.go`
+- Test: `internal/telemetry/metrics_test.go`
+
+**Interfaces:**
+- Produces (consumed by Task 3): `Metrics.HistoryCompactions`, `Metrics.HistoryElidedBytes` (both `metric.Int64Counter`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/telemetry/metrics_test.go` (match the file's existing assertion style):
+
+```go
+func TestHistoryCompactionCountersConstructed(t *testing.T) {
+	m := NewMetrics()
+	if m.HistoryCompactions == nil || m.HistoryElidedBytes == nil {
+		t.Fatal("NewMetrics must construct HistoryCompactions and HistoryElidedBytes")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/telemetry/ -run TestHistoryCompactionCountersConstructed -v`
+Expected: compile error — fields don't exist.
+
+- [ ] **Step 3: Add the fields + construction**
+
+In `internal/telemetry/metrics.go`, add to the `Metrics` struct near `ToolOutputTruncatedBytes`:
+
+```go
+	HistoryCompactions metric.Int64Counter // mid-loop history compaction events
+	HistoryElidedBytes metric.Int64Counter // tool-output bytes elided by compaction
+```
+
+And in `NewMetrics`'s returned literal, near `ToolOutputTruncatedBytes`:
+
+```go
+		HistoryCompactions: ctr("history_compactions_total", "mid-loop tool-output history compaction events"),
+		HistoryElidedBytes: ctr("history_elided_bytes_total", "tool-output bytes elided by mid-loop compaction"),
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `go test ./internal/telemetry/ -run TestHistoryCompactionCountersConstructed -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/telemetry/metrics.go internal/telemetry/metrics_test.go
+git commit -m "feat(telemetry): history compaction counters"
+```
+
+---
+
+### Task 3: Wire compaction into the loop + integration test
+
+**Files:**
+- Modify: `internal/investigate/loop.go`
+- Test: `internal/investigate/loop_test.go`
+
+**Interfaces:**
+- Consumes: `compactHistory`, `compactionTarget` (Task 1); `Metrics.HistoryCompactions`, `Metrics.HistoryElidedBytes` (Task 2).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `internal/investigate/loop_test.go` (uses the existing `scriptModel` + `bigTool`):
+
+```go
+// TestCompactionLetsInvestigationFinish drives a model that calls a big-output tool many
+// times under a low token budget; with compaction the loop reaches submit_findings
+// instead of the budget hard-kill.
+func TestCompactionLetsInvestigationFinish(t *testing.T) {
+	var resp []providers.CompletionResponse
+	for i := 1; i <= 6; i++ {
+		resp = append(resp, providers.CompletionResponse{
+			ToolCalls: []providers.ToolCall{{ID: fmtID(i), Name: "big_tool", Args: `{}`}},
+		})
+	}
+	resp = append(resp, providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "f", Name: submitFindingsName, Args: `{"confidence":0.7,"root_causes":[{"summary":"found it"}]}`},
+	}})
+
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     &scriptModel{responses: resp},
+		Tools:                     []Tool{bigTool{size: 4000}},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: 6000, // low: without compaction, 6 x ~1000-token outputs hard-kill
+		OnComplete:                func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "compaction finish test"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil || len(got.RootCauses) == 0 {
+		t.Fatalf("expected a resolved investigation via compaction, got %+v", got)
+	}
+}
+
+func fmtID(i int) string { return string(rune('0' + i)) }
+```
+
+(If `bigTool` is not in scope or `MaxToolOutputBytes` is needed to shape sizes, mirror the existing big-output test setup nearby; keep `MaxToolOutputBytes` unset so the 4000-byte outputs are not pre-truncated.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/investigate/ -run TestCompactionLetsInvestigationFinish -v`
+Expected: FAIL — without compaction wired in, the loop hits `budget_exceeded` and delivers a budget-kill result (no root causes), so `got.RootCauses` is empty.
+
+- [ ] **Step 3: Add the compaction-logged flag**
+
+In `internal/investigate/loop.go`, alongside the existing `nudged`/`budgetNudged`/`truncationNudged` flags (around the loop setup), add:
+
+```go
+	compactionLogged := false // set when the one-time compaction log has fired
+```
+
+- [ ] **Step 4: Wire compaction before the budget guard**
+
+In `internal/investigate/loop.go`, replace the existing budget-guard block at the top of the `for step := ...` loop:
+
+```go
+		if est := estimateTokens(sys, messages, specs); overBudget(est, li.MaxTokensPerInvestigation) {
+```
+
+with compaction first, then the guard on the recomputed estimate:
+
+```go
+		est := estimateTokens(sys, messages, specs)
+		// Mid-loop compaction: before the budget guard, elide superseded/old tool outputs
+		// to stay under budget so a long investigation can finish instead of hard-killing.
+		if target := compactionTarget(li.MaxTokensPerInvestigation); target > 0 && est > target {
+			if compacted, elided := compactHistory(messages, sys, specs, target); elided > 0 {
+				messages = compacted
+				est = estimateTokens(sys, messages, specs)
+				if !compactionLogged {
+					li.Log.Info("compacted investigation history to bound context",
+						"title", req.Title, "elided_bytes", elided, "estimate_tokens", est)
+					compactionLogged = true
+				}
+				if li.Metrics != nil {
+					li.Metrics.HistoryCompactions.Add(ctx, 1)
+					li.Metrics.HistoryElidedBytes.Add(ctx, int64(elided))
+				}
+			}
+		}
+		if overBudget(est, li.MaxTokensPerInvestigation) {
+```
+
+Leave the body of the `overBudget` block (nudge / hard-kill) exactly as-is — it now reads the pre-computed/recomputed `est`.
+
+- [ ] **Step 5: Run tests to verify pass + no regressions**
+
+Run: `go test ./internal/investigate/ -v 2>&1 | tail -30`
+Expected: PASS — `TestCompactionLetsInvestigationFinish` passes; the existing budget tests (nudge, hard-kill) still pass (a budget so low that even compacted history overflows still hard-kills, since compaction returns the irreducible protected set and `overBudget` then fires).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/investigate/loop.go internal/investigate/loop_test.go
+git commit -m "feat(investigate): wire mid-loop compaction before the budget guard
+
+Elide superseded/old tool outputs once the estimate crosses 0.7x the token budget, so a
+long investigation can finish instead of hard-killing; the nudge -> hard-kill backstop is
+unchanged and still fires when even the compacted, protected history overflows. Records
+history_compactions_total / history_elided_bytes_total and logs once per investigation."
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none.
+
+- [ ] **Step 1: Build, full suite, vet, fmt**
+
+Run: `go build ./... && go test ./... && go vet ./... && gofmt -l internal/investigate internal/telemetry`
+Expected: all green; `gofmt -l` prints nothing. If anything fails, stop and report BLOCKED with the exact output.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Trigger at 0.7 × budget, disabled when budget ≤ 0 → `compactionTarget` + Task 3 Step 4. ✓
+- Protected set (seed, assistant, keep-list incl. gitops_*, recent-K) → `compactHistory` + Tasks 1 tests. ✓
+- Elision order superseded-then-largest, stop at target → `compactHistory` sort + loop. ✓
+- Idempotent, no-op when nothing eligible / under target → tests. ✓
+- Backstop unchanged, runs after on recomputed est → Task 3 Step 4. ✓
+- Metrics + one-time log → Task 2 + Task 3. ✓
+- Provider-agnostic, no model-client changes → all in `internal/investigate` + telemetry. ✓
+- Eval gate is a deferred maintainer/EKS step (out of code scope) → noted in spec, not a task. ✓
+
+**Placeholder scan:** No TBD/TODO; complete code in every step; commands have expected output. The one conditional ("if `bigTool` not in scope…") in Task 3 Step 1 is a known-harness note, not a placeholder — `bigTool` exists in loop_test.go (used by the existing big-output metric test).
+
+**Type consistency:** `compactHistory`/`compactionTarget` signatures match between Task 1 definition and Task 3 use; `HistoryCompactions`/`HistoryElidedBytes` defined (Task 2) and used (Task 3) with matching names; `estimateTokens` signature matches `budget.go`.

--- a/docs/superpowers/specs/2026-06-30-mid-loop-history-compaction-design.md
+++ b/docs/superpowers/specs/2026-06-30-mid-loop-history-compaction-design.md
@@ -29,7 +29,7 @@ At the top of each loop step, after computing the existing `est := estimateToken
 
 - The **seed** (first user message).
 - **All assistant turns** (reasoning + tool-call JSON) — small, and they carry the model's *interpretation* of evidence, so conclusions survive even when raw bytes don't.
-- Tool results from **keep-list tools: `what_changed` and `kb_search`** — the root-cause spine (the change timeline + the runbook hit). The keep-list is a package constant.
+- Tool results from **keep-list tools: `what_changed`, `kb_search`, `gitops_resource_status`, `gitops_tree`** — the structural root-cause skeleton: the change timeline, the runbook hit, the failing resource's status/conditions, and the dependency-cascade root. All four are engine-agnostic (the `gitops_*` pair resolve a Flux Ready condition **or** an ArgoCD sync/health status through the same `GitOpsInspector`, which both engines implement — `argocd.go:187`, `flux.go:231`), so the skeleton is protected identically under Flux and ArgoCD. They are small (conditions + a few events + a tree), so retaining several is cheap. The keep-list is a package constant. The bulky, supersedable evidence (`pod_logs`, `controller_logs`, `query_logs`, `query_metrics`, `network_drops`) stays elidible — those are the token hogs, and the model distills them into its kept reasoning + the recent-K window.
 - The **most-recent `keepRecentToolOutputs = 3`** tool results (the model's active working set).
 
 ### Elision policy (hardened: supersession-aware, bounded)
@@ -46,7 +46,7 @@ Each elided tool-result body is replaced with `[earlier <tool> output elided to 
 ```
 compactionBudgetFraction = 0.7   // fraction of MaxTokensPerInvestigation that triggers compaction
 keepRecentToolOutputs    = 3     // most-recent tool results kept verbatim
-keepListTools            = {"what_changed", "kb_search"}  // never elided
+keepListTools            = {"what_changed", "kb_search", "gitops_resource_status", "gitops_tree"}  // never elided (engine-agnostic root-cause skeleton)
 ```
 
 Easy to promote to config later; kept internal now.
@@ -61,7 +61,7 @@ Two counters in `internal/telemetry/metrics.go` (existing `ctr(...)` pattern): `
 
 ## Quality gate (the "measure" half — a documented merge criterion)
 
-Compaction's quality impact is measured with the existing live-eval harness, NOT taken on faith. **This gate runs on a real cluster with API keys + a judge model; it is a maintainer/CI step — it cannot run in the dev sandbox.** Procedure, wired into the PR's merge criteria:
+Compaction's quality impact is measured with the existing live-eval harness, NOT taken on faith. **Deferred by decision to a later live run on a real EKS cluster (maintainer-run, with API keys + a judge model); it cannot run in the dev sandbox.** The PR ships the mechanism (unit + integration tested) and this gate is run before the branch is considered quality-cleared. Procedure:
 
 1. On `main`: `lore eval --live --scenarios eval/scenarios-k3d` → baseline report (or reuse the committed `eval/reports/2026-06-22-k3d-baseline.md`).
 2. On this branch: same command → branch report.
@@ -108,4 +108,4 @@ All existing loop/telemetry tests stay green; `go build ./... && go vet && gofmt
 
 ## Open risk acknowledged
 
-If the live eval shows a regression on a scenario where a decisive early output got elided, the mitigation order is: (1) raise `keepRecentToolOutputs`, (2) extend the keep-list (e.g. add `gitops_tree`/`gitops_resource_status`), (3) lower `compactionBudgetFraction` so compaction fires less often. The gate exists precisely to surface this before merge.
+If the live eval shows a regression on a scenario where a decisive early output got elided, the mitigation order is: (1) raise `keepRecentToolOutputs`, (2) extend the keep-list (e.g. add `pod_status`/`kube_events` — small structural signals), (3) lower `compactionBudgetFraction` so compaction fires less often. The gate exists precisely to surface this before merge.

--- a/docs/superpowers/specs/2026-06-30-mid-loop-history-compaction-design.md
+++ b/docs/superpowers/specs/2026-06-30-mid-loop-history-compaction-design.md
@@ -1,0 +1,111 @@
+# Mid-loop tool-output compaction (T3)
+
+Status: draft for review
+Date: 2026-06-30
+Scope: one PR, dedicated worktree (`feat/model-history-compaction`). Context-window management under budget pressure, with an explicit quality gate.
+
+## Problem & framing
+
+The investigation ReAct loop (`internal/investigate/loop.go`) resends the entire growing message history every step. Each tool output is already byte-truncated to `max_tool_output_bytes` (32KB) on entry, but ~19 of them still accumulate, and when the estimate crosses `max_tokens_per_investigation` the loop hard-kills (`result = "budget_exceeded"`, delivers an unresolved finding — *no root cause*).
+
+**T1 (PR #182) already cached the growing history on Anthropic and OpenAI**, so T3's value is no longer primarily cost. It is:
+1. **Context-window headroom** — compact superseded outputs so an investigation can finish instead of hard-killing.
+2. **Gemini cost** — implicit caching is opportunistic (min-token thresholds).
+3. **Less context bloat** — which can degrade answer quality on long runs.
+
+**The right quality baseline is the hard-kill, not full history.** Compaction only fires under budget pressure, where today the loop dies with no findings. So where it fires, a complete investigation on compacted history is a quality *improvement*; where the threshold is never reached, T3 is inert.
+
+**Residual quality risk (honest):** eliding old tool outputs means the model can't re-quote their raw bytes later, and naive recency-elision could drop a decisive early output. The design below minimizes this (supersession-aware + keep-list + recent-K window + kept assistant reasoning), and a **live-eval gate** proves no regression before merge.
+
+## Design
+
+A new `internal/investigate/compact.go` operating on the `[]providers.Message` history — provider-agnostic, before the history reaches any model client, so it composes with T1 regardless of merge order.
+
+### Trigger
+
+At the top of each loop step, after computing the existing `est := estimateTokens(sys, messages, specs)`: if `MaxTokensPerInvestigation > 0` and `est > compactionBudgetFraction × MaxTokensPerInvestigation` (`compactionBudgetFraction = 0.7`, package constant), run compaction, then recompute `est`. The existing nudge → hard-kill backstop then runs unchanged on the (possibly compacted) `est`. A no-op compaction falls straight through to that backstop — no infinite loop. Disabled when no budget is configured (no reference point).
+
+### What is protected (never elided)
+
+- The **seed** (first user message).
+- **All assistant turns** (reasoning + tool-call JSON) — small, and they carry the model's *interpretation* of evidence, so conclusions survive even when raw bytes don't.
+- Tool results from **keep-list tools: `what_changed` and `kb_search`** — the root-cause spine (the change timeline + the runbook hit). The keep-list is a package constant.
+- The **most-recent `keepRecentToolOutputs = 3`** tool results (the model's active working set).
+
+### Elision policy (hardened: supersession-aware, bounded)
+
+Eligible = tool-result messages that are NOT protected above. Elide eligible outputs **only until `est` drops back below the trigger threshold** (never more than necessary), in this priority order:
+
+1. **Superseded first** — an eligible output whose `(tool name, args)` is re-issued by a *later* assistant turn (a literal re-query returning refreshed data → the older one is genuinely stale).
+2. **Then largest-first** — remaining eligible outputs by byte size descending (max token reduction per elision = fewest elisions = least information lost).
+
+Each elided tool-result body is replaced with `[earlier <tool> output elided to bound context]`, where `<tool>` is resolved from the matching assistant `ToolCall` by `ToolCallID` (id→name map, as `gemini.toContents` already does). Idempotent: an already-elided marker is tiny, so it is never re-selected (it isn't large, and a marker isn't "superseded").
+
+### Constants (no new config knobs — matches the "minimal config" decision)
+
+```
+compactionBudgetFraction = 0.7   // fraction of MaxTokensPerInvestigation that triggers compaction
+keepRecentToolOutputs    = 3     // most-recent tool results kept verbatim
+keepListTools            = {"what_changed", "kb_search"}  // never elided
+```
+
+Easy to promote to config later; kept internal now.
+
+### T1 interaction
+
+Compaction rewrites tool messages *below* T1's rolling breakpoint (which is on the last message — always a kept/recent one). So the Anthropic cached prefix is invalidated **once**, on the compaction step, then re-caches on the new compacted prefix. This one-time miss is the accepted cost. No code coordination needed; T3 branches from `main` independently of #182.
+
+### Observability
+
+Two counters in `internal/telemetry/metrics.go` (existing `ctr(...)` pattern): `HistoryCompactions` (compaction events) and `HistoryElidedBytes` (total bytes elided). A one-time `Info` log per investigation when compaction first fires (title + before/after estimate). Recorded in the loop.
+
+## Quality gate (the "measure" half — a documented merge criterion)
+
+Compaction's quality impact is measured with the existing live-eval harness, NOT taken on faith. **This gate runs on a real cluster with API keys + a judge model; it is a maintainer/CI step — it cannot run in the dev sandbox.** Procedure, wired into the PR's merge criteria:
+
+1. On `main`: `lore eval --live --scenarios eval/scenarios-k3d` → baseline report (or reuse the committed `eval/reports/2026-06-22-k3d-baseline.md`).
+2. On this branch: same command → branch report.
+3. Compare with `LiveReport.RegressionsVS(baseline)` (already implemented, `internal/eval/report.go:102`). **Merge only if it returns zero regressions** (no scenario that passed on main fails/skips now), and RCA/coverage scores are not materially lower.
+
+To make compaction actually exercise in the eval, run with a tightened budget (a scenario/config `max_tokens_per_investigation` low enough that long scenarios cross the 0.7 threshold) so the gate tests the compaction path, not just the inert path.
+
+The PR description will state explicitly: **mechanism implemented + unit/integration-tested; quality gate (live eval, zero regressions) pending a maintainer run.**
+
+## Files touched
+
+- `internal/investigate/compact.go` (new) — `compactHistory(messages []providers.Message, maxEstTokens int, sys string, specs []providers.ToolSpec) (compacted []providers.Message, events CompactionStats)` (or similar signature returning bytes elided + whether it fired).
+- `internal/investigate/compact_test.go` (new) — unit tests.
+- `internal/investigate/loop.go` — call compaction at the top of the step loop before the budget guard; record metrics + the one-time log.
+- `internal/investigate/loop_test.go` — integration test (reaches `submit_findings` instead of `budget_exceeded`).
+- `internal/telemetry/metrics.go` — 2 counters.
+- Possibly `eval/` docs or `eval/rubric.md` — note the compaction gate procedure (lightweight).
+
+## Testing
+
+**Unit (`compact_test.go`), all deterministic, no model:**
+- Elides eligible old tool bodies beyond the recent-K window; keeps the most-recent K verbatim.
+- Never elides: seed, assistant turns, `what_changed`/`kb_search` results.
+- Superseded-first ordering: an output whose (tool,args) is re-issued later is elided before a larger non-superseded one.
+- Largest-first among non-superseded.
+- Stops once under threshold (does not over-elide when a partial elision suffices).
+- Marker names the correct tool (id→name resolution).
+- Idempotent (second pass on already-compacted history is a no-op / no further elision).
+- No-op when nothing eligible (all within keep-list / recent-K) — returns history unchanged.
+
+**Integration (`loop_test.go`):** a scripted model emitting many large tool outputs under a low `MaxTokensPerInvestigation`; assert the loop reaches `submit_findings` (`result = "resolved"`) where without compaction it would hit `budget_exceeded`. (Add a sibling assertion that with compaction disabled — budget so low even compacted history overflows — the hard-kill still fires, proving the backstop is intact.)
+
+**Quality (live, maintainer/CI):** the eval-gate procedure above.
+
+All existing loop/telemetry tests stay green; `go build ./... && go vet && gofmt -l`.
+
+## Non-goals
+
+- LLM-summarization compaction (rejected: extra call/latency, partly self-defeating).
+- Headline-extraction hybrid (rejected: heuristic line-picking).
+- Making the constants configurable (deferred; internal constants now).
+- Re-fetching elided outputs on demand (the model re-calls the tool if it truly needs fresh data).
+- Touching the model clients (compaction is entirely in `internal/investigate`).
+
+## Open risk acknowledged
+
+If the live eval shows a regression on a scenario where a decisive early output got elided, the mitigation order is: (1) raise `keepRecentToolOutputs`, (2) extend the keep-list (e.g. add `gitops_tree`/`gitops_resource_status`), (3) lower `compactionBudgetFraction` so compaction fires less often. The gate exists precisely to surface this before merge.

--- a/internal/investigate/compact.go
+++ b/internal/investigate/compact.go
@@ -1,0 +1,126 @@
+package investigate
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const (
+	// compactionBudgetFraction is the fraction of MaxTokensPerInvestigation at which
+	// compaction triggers and the size it elides back down to (headroom for more steps).
+	compactionBudgetFraction = 0.7
+	// keepRecentToolOutputs is the number of most-recent tool results kept verbatim
+	// (the model's active working set).
+	keepRecentToolOutputs = 3
+)
+
+// keepListTools are tools whose outputs are the structural root-cause skeleton and are
+// never elided: the change timeline, the runbook hit, the failing resource's status, and
+// the dependency-cascade root. The gitops_* pair are engine-agnostic (Flux + ArgoCD).
+var keepListTools = map[string]bool{
+	"what_changed":           true,
+	"kb_search":              true,
+	"gitops_resource_status": true,
+	"gitops_tree":            true,
+}
+
+const (
+	elidedPrefix = "[earlier "
+	elidedSuffix = " output elided to bound context]"
+)
+
+func elidedMarker(tool string) string {
+	if tool == "" {
+		tool = "tool"
+	}
+	return elidedPrefix + tool + elidedSuffix
+}
+
+func isElidedMarker(s string) bool {
+	return strings.HasPrefix(s, elidedPrefix) && strings.HasSuffix(s, elidedSuffix)
+}
+
+// compactionTarget returns the estimate at/below which compaction stops: 0.7 * budget.
+// budget <= 0 disables compaction (returns 0).
+func compactionTarget(budget int) int {
+	if budget <= 0 {
+		return 0
+	}
+	return int(float64(budget) * compactionBudgetFraction)
+}
+
+// compactHistory elides the bodies of eligible tool-result messages — superseded ones
+// first, then largest-first — until estimateTokens(sys, messages, specs) drops to or
+// below target, or no eligible output remains. Protected: the seed (index 0), every
+// assistant turn, keep-list tool results, and the most-recent keepRecentToolOutputs tool
+// results. Returns a new slice (the caller's messages are never mutated) and the number
+// of body bytes elided (0 when nothing was compacted). target <= 0 is a no-op.
+func compactHistory(messages []providers.Message, sys string, specs []providers.ToolSpec, target int) ([]providers.Message, int) {
+	if target <= 0 || estimateTokens(sys, messages, specs) <= target {
+		return messages, 0
+	}
+	// Resolve each tool-call id -> (name, args) so a tool RESULT (which carries only
+	// ToolCallID) is attributable to its tool and dedupable by (name, args).
+	type call struct{ name, args string }
+	byID := map[string]call{}
+	for _, m := range messages {
+		for _, tc := range m.ToolCalls {
+			byID[tc.ID] = call{tc.Name, tc.Args}
+		}
+	}
+	// Positions of tool-result messages, in order.
+	var toolIdx []int
+	for i, m := range messages {
+		if m.Role == "tool" {
+			toolIdx = append(toolIdx, i)
+		}
+	}
+	recentCut := len(toolIdx) - keepRecentToolOutputs // list-positions >= this are recency-protected
+	// Last list-position per (name, args) — earlier ones are superseded.
+	lastPosFor := map[call]int{}
+	for pos, mi := range toolIdx {
+		lastPosFor[byID[messages[mi].ToolCallID]] = pos
+	}
+	type cand struct {
+		mi         int
+		size       int
+		superseded bool
+	}
+	var cands []cand
+	for pos, mi := range toolIdx {
+		if pos >= recentCut {
+			continue // most-recent K
+		}
+		c := byID[messages[mi].ToolCallID]
+		if keepListTools[c.name] || isElidedMarker(messages[mi].Content) {
+			continue
+		}
+		cands = append(cands, cand{mi: mi, size: len(messages[mi].Content), superseded: lastPosFor[c] != pos})
+	}
+	// Superseded first, then largest-first.
+	sort.SliceStable(cands, func(a, b int) bool {
+		if cands[a].superseded != cands[b].superseded {
+			return cands[a].superseded
+		}
+		return cands[a].size > cands[b].size
+	})
+	// Copy so the caller's slice contents are never mutated.
+	out := make([]providers.Message, len(messages))
+	copy(out, messages)
+	elided := 0
+	for _, cd := range cands {
+		if estimateTokens(sys, out, specs) <= target {
+			break
+		}
+		name := byID[out[cd.mi].ToolCallID].name
+		before := len(out[cd.mi].Content)
+		out[cd.mi].Content = elidedMarker(name)
+		elided += before - len(out[cd.mi].Content)
+	}
+	if elided == 0 {
+		return messages, 0
+	}
+	return out, elided
+}

--- a/internal/investigate/compact.go
+++ b/internal/investigate/compact.go
@@ -97,6 +97,9 @@ func compactHistory(messages []providers.Message, sys string, specs []providers.
 		if keepListTools[c.name] || isElidedMarker(messages[mi].Content) {
 			continue
 		}
+		if len(messages[mi].Content) <= len(elidedMarker(c.name)) {
+			continue // body no larger than the marker — eliding wouldn't shrink it
+		}
 		cands = append(cands, cand{mi: mi, size: len(messages[mi].Content), superseded: lastPosFor[c] != pos})
 	}
 	// Superseded first, then largest-first.

--- a/internal/investigate/compact_test.go
+++ b/internal/investigate/compact_test.go
@@ -152,6 +152,23 @@ func TestCompactIdempotent(t *testing.T) {
 	_ = twice
 }
 
+func TestCompactSkipsBodiesNoLargerThanMarker(t *testing.T) {
+	tiny := "x" // far smaller than the ~49-byte marker
+	big := strings.Repeat("b", 5000)
+	// 5 tool results -> recentCut = 2; positions 0 (tiny, id1) and 1 (big, id2) are eligible.
+	msgs := buildHistory(10,
+		callAndResult("1", "pod_logs", `{"ns":"a"}`, tiny),
+		callAndResult("2", "pod_logs", `{"ns":"b"}`, big),
+		callAndResult("3", "pod_logs", `{"ns":"c"}`, big),
+		callAndResult("4", "pod_logs", `{"ns":"d"}`, big),
+		callAndResult("5", "pod_logs", `{"ns":"e"}`, big),
+	)
+	out, _ := compactHistory(msgs, "", nil, 1) // target=1 forces maximum elision
+	if toolResultByID(out, "1") != tiny {
+		t.Fatalf("a body smaller than the marker must be left untouched, got %q", toolResultByID(out, "1"))
+	}
+}
+
 func TestCompactionTarget(t *testing.T) {
 	if compactionTarget(0) != 0 || compactionTarget(-5) != 0 {
 		t.Fatal("budget<=0 disables compaction")

--- a/internal/investigate/compact_test.go
+++ b/internal/investigate/compact_test.go
@@ -92,25 +92,26 @@ func TestCompactProtectsSeedAssistantAndKeepList(t *testing.T) {
 }
 
 func TestCompactSupersededFirst(t *testing.T) {
-	big := strings.Repeat("z", 3000)
-	small := strings.Repeat("z", 3200)
-	// id 1 (pod_logs ns=a) is superseded by id 4 (same name+args, later). id 2 is a
-	// larger, non-superseded one-off. Supersession must elide id 1 before id 2 even
-	// though id 2 is larger. Use K=3 so ids 1 and 2 are eligible (ids 3,4 are recent).
+	smallSuperseded := strings.Repeat("z", 2400) // id1: superseded, SMALLER
+	largeOneOff := strings.Repeat("z", 4000)     // id2: not superseded, LARGER
+	big := strings.Repeat("z", 2000)
+	// 5 tool results -> recentCut = 2, so positions 0 (id1) and 1 (id2) are both eligible.
+	// id1 (pod_logs ns=a) is superseded by id5 (same name+args, later). id2 is a larger
+	// one-off. Superseded-first must elide the SMALLER id1 before the LARGER id2.
 	msgs := buildHistory(10,
-		callAndResult("1", "pod_logs", `{"ns":"a"}`, big),         // superseded by id 4
-		callAndResult("2", "controller_logs", `{"c":"x"}`, small), // larger, one-off
+		callAndResult("1", "pod_logs", `{"ns":"a"}`, smallSuperseded),
+		callAndResult("2", "controller_logs", `{"c":"x"}`, largeOneOff),
 		callAndResult("3", "pod_logs", `{"ns":"b"}`, big),
-		callAndResult("4", "pod_logs", `{"ns":"a"}`, big), // re-query of id 1
+		callAndResult("4", "pod_logs", `{"ns":"d"}`, big),
+		callAndResult("5", "pod_logs", `{"ns":"a"}`, big), // re-query of id1 -> supersedes it
 	)
-	// target that allows exactly one elision to drop under it
-	target := estimateTokens("", msgs, nil) - 600
+	target := estimateTokens("", msgs, nil) - 400 // one elision (~590 tokens) drops under it
 	out, _ := compactHistory(msgs, "", nil, target)
 	if !isElidedMarker(toolResultByID(out, "1")) {
-		t.Fatal("superseded id 1 should be elided first")
+		t.Fatal("superseded id 1 should be elided first, even though it is smaller")
 	}
 	if isElidedMarker(toolResultByID(out, "2")) {
-		t.Fatal("non-superseded id 2 should NOT be elided when one elision sufficed")
+		t.Fatal("larger non-superseded id 2 must NOT be elided when one elision sufficed")
 	}
 }
 
@@ -121,7 +122,7 @@ func TestCompactNoopWhenUnderTarget(t *testing.T) {
 	if elided != 0 {
 		t.Fatalf("expected no-op, elided %d", elided)
 	}
-	if &out[0] == nil {
+	if len(out) == 0 {
 		t.Fatal("should return the history")
 	}
 }

--- a/internal/investigate/compact_test.go
+++ b/internal/investigate/compact_test.go
@@ -1,0 +1,161 @@
+package investigate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// toolMsg builds an assistant tool-call turn followed by its tool-result message.
+func callAndResult(id, name, args, result string) []providers.Message {
+	return []providers.Message{
+		{Role: "assistant", ToolCalls: []providers.ToolCall{{ID: id, Name: name, Args: args}}},
+		{Role: "tool", ToolCallID: id, Content: result},
+	}
+}
+
+func buildHistory(seedSize int, calls ...[]providers.Message) []providers.Message {
+	msgs := []providers.Message{{Role: "user", Content: strings.Repeat("s", seedSize)}}
+	for _, c := range calls {
+		msgs = append(msgs, c...)
+	}
+	return msgs
+}
+
+func toolResultByID(msgs []providers.Message, id string) string {
+	for _, m := range msgs {
+		if m.Role == "tool" && m.ToolCallID == id {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+func TestCompactElidesOldBeyondRecentK(t *testing.T) {
+	big := strings.Repeat("x", 4000)
+	// 5 pod_logs calls; with K=3, the oldest 2 (ids 1,2) are eligible.
+	msgs := buildHistory(10,
+		callAndResult("1", "pod_logs", `{"ns":"a"}`, big),
+		callAndResult("2", "pod_logs", `{"ns":"b"}`, big),
+		callAndResult("3", "pod_logs", `{"ns":"c"}`, big),
+		callAndResult("4", "pod_logs", `{"ns":"d"}`, big),
+		callAndResult("5", "pod_logs", `{"ns":"e"}`, big),
+	)
+	target := estimateTokens("", msgs, nil) - 1500 // force some elision
+	out, elided := compactHistory(msgs, "", nil, target)
+	if elided == 0 {
+		t.Fatal("expected some bytes elided")
+	}
+	// recent 3 (ids 3,4,5) kept verbatim
+	for _, id := range []string{"3", "4", "5"} {
+		if toolResultByID(out, id) != big {
+			t.Fatalf("recent tool result %s must be kept verbatim", id)
+		}
+	}
+	// oldest (id 1) elided to a marker
+	if !isElidedMarker(toolResultByID(out, "1")) {
+		t.Fatalf("oldest tool result should be elided, got %q", toolResultByID(out, "1"))
+	}
+}
+
+func TestCompactProtectsSeedAssistantAndKeepList(t *testing.T) {
+	big := strings.Repeat("y", 5000)
+	msgs := buildHistory(20,
+		callAndResult("1", "what_changed", `{}`, big),           // keep-listed
+		callAndResult("2", "kb_search", `{}`, big),              // keep-listed
+		callAndResult("3", "gitops_tree", `{}`, big),            // keep-listed
+		callAndResult("4", "gitops_resource_status", `{}`, big), // keep-listed
+		callAndResult("5", "pod_logs", `{}`, big),
+		callAndResult("6", "pod_logs", `{}`, big),
+		callAndResult("7", "pod_logs", `{}`, big),
+		callAndResult("8", "pod_logs", `{}`, big),
+	)
+	target := 1 // force maximum elision
+	out, _ := compactHistory(msgs, "", nil, target)
+	// keep-list tools never elided
+	for _, id := range []string{"1", "2", "3", "4"} {
+		if toolResultByID(out, id) != big {
+			t.Fatalf("keep-list tool %s must never be elided", id)
+		}
+	}
+	// seed untouched
+	if out[0].Content != strings.Repeat("s", 20) {
+		t.Fatal("seed must never be elided")
+	}
+	// assistant turns untouched (still carry their tool calls)
+	for _, m := range out {
+		if m.Role == "assistant" && len(m.ToolCalls) == 0 {
+			t.Fatal("assistant tool-call turn must be preserved")
+		}
+	}
+}
+
+func TestCompactSupersededFirst(t *testing.T) {
+	big := strings.Repeat("z", 3000)
+	small := strings.Repeat("z", 3200)
+	// id 1 (pod_logs ns=a) is superseded by id 4 (same name+args, later). id 2 is a
+	// larger, non-superseded one-off. Supersession must elide id 1 before id 2 even
+	// though id 2 is larger. Use K=3 so ids 1 and 2 are eligible (ids 3,4 are recent).
+	msgs := buildHistory(10,
+		callAndResult("1", "pod_logs", `{"ns":"a"}`, big),         // superseded by id 4
+		callAndResult("2", "controller_logs", `{"c":"x"}`, small), // larger, one-off
+		callAndResult("3", "pod_logs", `{"ns":"b"}`, big),
+		callAndResult("4", "pod_logs", `{"ns":"a"}`, big), // re-query of id 1
+	)
+	// target that allows exactly one elision to drop under it
+	target := estimateTokens("", msgs, nil) - 600
+	out, _ := compactHistory(msgs, "", nil, target)
+	if !isElidedMarker(toolResultByID(out, "1")) {
+		t.Fatal("superseded id 1 should be elided first")
+	}
+	if isElidedMarker(toolResultByID(out, "2")) {
+		t.Fatal("non-superseded id 2 should NOT be elided when one elision sufficed")
+	}
+}
+
+func TestCompactNoopWhenUnderTarget(t *testing.T) {
+	msgs := buildHistory(10, callAndResult("1", "pod_logs", `{}`, "small"))
+	target := estimateTokens("", msgs, nil) + 1000 // already under
+	out, elided := compactHistory(msgs, "", nil, target)
+	if elided != 0 {
+		t.Fatalf("expected no-op, elided %d", elided)
+	}
+	if &out[0] == nil {
+		t.Fatal("should return the history")
+	}
+}
+
+func TestCompactDisabledTargetZero(t *testing.T) {
+	msgs := buildHistory(10, callAndResult("1", "pod_logs", `{}`, strings.Repeat("x", 9000)))
+	_, elided := compactHistory(msgs, "", nil, 0)
+	if elided != 0 {
+		t.Fatal("target<=0 must be a no-op")
+	}
+}
+
+func TestCompactIdempotent(t *testing.T) {
+	big := strings.Repeat("x", 5000)
+	msgs := buildHistory(10,
+		callAndResult("1", "pod_logs", `{}`, big),
+		callAndResult("2", "pod_logs", `{}`, big),
+		callAndResult("3", "pod_logs", `{}`, big),
+		callAndResult("4", "pod_logs", `{}`, big),
+	)
+	target := estimateTokens("", msgs, nil) - 1000
+	once, _ := compactHistory(msgs, "", nil, target)
+	twice, elided2 := compactHistory(once, "", nil, target)
+	if elided2 != 0 {
+		t.Fatalf("second compaction pass should be a no-op, elided %d", elided2)
+	}
+	_ = twice
+}
+
+func TestCompactionTarget(t *testing.T) {
+	if compactionTarget(0) != 0 || compactionTarget(-5) != 0 {
+		t.Fatal("budget<=0 disables compaction")
+	}
+	if got := compactionTarget(100000); got != 70000 {
+		t.Fatalf("compactionTarget(100000)=%d, want 70000", got)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -209,6 +209,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	nudged := false           // set when the prose-turn nudge has fired once
 	budgetNudged := false     // set when the token-budget nudge has fired once
 	truncationNudged := false // set when the output-truncation nudge has fired once
+	compactionLogged := false // set when the one-time compaction log has fired
 	used := map[string]int{}  // tool-call counts, logged so investigation breadth is observable
 	sys := li.system()        // constant for the investigation; build once, not per step
 	for step := 0; step < maxSteps; step++ {
@@ -216,7 +217,25 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// inject a one-time nudge asking the model to wrap up. If the model did not wind
 		// down and the estimate is still over budget on the next step, hard-kill: deliver
 		// whatever findings exist rather than growing context unbounded.
-		if est := estimateTokens(sys, messages, specs); overBudget(est, li.MaxTokensPerInvestigation) {
+		est := estimateTokens(sys, messages, specs)
+		// Mid-loop compaction: before the budget guard, elide superseded/old tool outputs
+		// to stay under budget so a long investigation can finish instead of hard-killing.
+		if target := compactionTarget(li.MaxTokensPerInvestigation); target > 0 && est > target {
+			if compacted, elided := compactHistory(messages, sys, specs, target); elided > 0 {
+				messages = compacted
+				est = estimateTokens(sys, messages, specs)
+				if !compactionLogged {
+					li.Log.Info("compacted investigation history to bound context",
+						"title", req.Title, "elided_bytes", elided, "estimate_tokens", est)
+					compactionLogged = true
+				}
+				if li.Metrics != nil {
+					li.Metrics.HistoryCompactions.Add(ctx, 1)
+					li.Metrics.HistoryElidedBytes.Add(ctx, int64(elided))
+				}
+			}
+		}
+		if overBudget(est, li.MaxTokensPerInvestigation) {
 			if !budgetNudged {
 				messages = append(messages, providers.Message{Role: "user", Content: budgetNudge})
 				budgetNudged = true

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -714,6 +714,39 @@ func TestInstantRecallConfirmedEvidenceReachesVerify(t *testing.T) {
 	}
 }
 
+// TestCompactionLetsInvestigationFinish drives a model that calls a big-output tool many
+// times under a low token budget; with compaction the loop reaches submit_findings
+// instead of the budget hard-kill.
+func TestCompactionLetsInvestigationFinish(t *testing.T) {
+	var resp []providers.CompletionResponse
+	for i := 1; i <= 6; i++ {
+		resp = append(resp, providers.CompletionResponse{
+			ToolCalls: []providers.ToolCall{{ID: fmtID(i), Name: "big_tool", Args: `{}`}},
+		})
+	}
+	resp = append(resp, providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "f", Name: submitFindingsName, Args: `{"confidence":0.7,"root_causes":[{"summary":"found it"}]}`},
+	}})
+
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     &scriptModel{responses: resp},
+		Tools:                     []Tool{bigTool{size: 4000}},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: 6000, // low: without compaction, 6 x ~1000-token outputs hard-kill
+		OnComplete:                func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "compaction finish test"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil || len(got.RootCauses) == 0 {
+		t.Fatalf("expected a resolved investigation via compaction, got %+v", got)
+	}
+}
+
+func fmtID(i int) string { return string(rune('0' + i)) }
+
 // TestSeedPrompt asserts the seed prompt threads Severity and Environment into
 // the model context when set (so it can calibrate rigor for prod vs staging,
 // critical vs warning), and omits each line — no empty label — when unset.

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -24,6 +24,8 @@ type Metrics struct {
 	InvestigationsDropped     metric.Int64Counter
 	GitOpsFailuresDebounced   metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
 	ToolOutputTruncatedBytes  metric.Int64Counter
+	HistoryCompactions        metric.Int64Counter // mid-loop history compaction events
+	HistoryElidedBytes        metric.Int64Counter // tool-output bytes elided by compaction
 	RecallHits                metric.Int64Counter // KB cache hits, labelled by verify result
 	RecallTokensSaved         metric.Int64Counter // estimated tokens saved by a recall short-circuit
 	RecallRejections          metric.Int64Counter // recalls rejected before short-circuit (label: reason)
@@ -71,6 +73,8 @@ func NewMetrics() *Metrics {
 		InvestigationsDropped:     ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
 		GitOpsFailuresDebounced:   ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
 		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
+		HistoryCompactions:        ctr("history_compactions_total", "mid-loop tool-output history compaction events"),
+		HistoryElidedBytes:        ctr("history_elided_bytes_total", "tool-output bytes elided by mid-loop compaction"),
 		RecallHits:                ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
 		RecallTokensSaved:         ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
 		RecallRejections:          ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -34,3 +34,10 @@ func TestNewMetricsCurationInstruments(_ *testing.T) {
 	ctx := context.Background()
 	m.CurationDedupScore.Record(ctx, 4.2)
 }
+
+func TestHistoryCompactionCountersConstructed(t *testing.T) {
+	m := NewMetrics()
+	if m.HistoryCompactions == nil || m.HistoryElidedBytes == nil {
+		t.Fatal("NewMetrics must construct HistoryCompactions and HistoryElidedBytes")
+	}
+}


### PR DESCRIPTION
> ⚠️ **Quality gate pending.** This ships the compaction *mechanism* (unit + integration tested). The **live-eval quality gate is deferred** to a maintainer run on a live EKS cluster (`lore eval --live`, comparing against the main baseline via `RegressionsVS`, merge only on zero regressions). Do not consider quality-cleared until that run is green.

## What & why

Under token-budget pressure, the investigation ReAct loop today resends the entire growing tool-output history every step and eventually **hard-kills** (`budget_exceeded` → no root cause). This compacts superseded/old tool-output bodies mid-loop so a long investigation can **finish instead of dying** — while protecting the root-cause skeleton. Third thread from the LLM-call review (after #177, #182).

**The right quality baseline is the hard-kill, not full history:** compaction only fires under budget pressure, where today the loop delivers nothing. Where it fires it's net-positive; where the threshold is never reached it's inert.

## How

A pure, provider-agnostic `compactHistory` (`internal/investigate/compact.go`), called at the top of each loop step **before** the existing budget guard:

- **Trigger:** estimate > `0.7 × max_tokens_per_investigation` (disabled when no budget set). The existing **nudge → hard-kill backstop is unchanged** and still fires when even the compacted, protected history overflows.
- **Never elided:** the seed, every assistant reasoning/tool-call turn, the most-recent **3** tool results, and the **keep-list root-cause skeleton** — `what_changed`, `kb_search`, `gitops_resource_status`, `gitops_tree`. The two `gitops_*` are engine-agnostic (Flux Ready condition **or** ArgoCD sync/health via the same `GitOpsInspector`), so the skeleton is protected identically under both engines.
- **Elision order:** **superseded first** (a `(tool, args)` re-issued by a later turn — genuinely stale), then **largest-first**, **stopping as soon as** the estimate drops under target — never more than necessary. The bulky `pod_logs`/`controller_logs`/`query_logs`/`query_metrics` blobs are the real targets; the model distills them into its kept reasoning + the recent-K window. Each elided body → `[earlier <tool> output elided to bound context]`.
- **Safe + idempotent:** returns a copy (never mutates the caller's slice), skips bodies no larger than the marker, and is a no-op when nothing is eligible.
- **Observability:** `history_compactions_total` + `history_elided_bytes_total`, plus a one-time log per investigation.

## Tests
Unit: protected-set enforcement, superseded-first ordering (verified RED against a largest-first mutant), stop-at-target, idempotency, no-op paths, tiny-body guard. Integration: under a low budget the loop reaches `submit_findings` (resolved) where without compaction it hard-kills — RED-without/GREEN-with. Full `go test ./...` exit 0, build + vet + gofmt clean. Adversarial whole-branch review: Ready to merge, no Critical/Important.

## Residual quality risk the deferred eval should target
Once superseded elisions are exhausted, largest-first elides the most information-dense non-keep-list body first — the eval must confirm conclusions survive when those raw bytes don't (the model's kept reasoning is the surviving trace). Mitigation levers if a scenario regresses: raise `keepRecentToolOutputs`, extend the keep-list, or lower `compactionBudgetFraction`. Run one scenario per engine (Flux + ArgoCD) to confirm keep-list tool names match.

## Docs
Design spec + plan under `docs/superpowers/`.
