### PR TITLE
feat(serve): log successful finding delivery

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -315,6 +315,9 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 			}
 			if err := notifier.Deliver(context.Background(), found); err != nil {
 				log.Error("deliver findings", "err", err)
+			} else {
+				log.Info("delivered findings",
+					"confidence", found.Confidence, "root_causes", len(found.RootCauses), "curated_url", found.CuratedURL)
 			}
 		},
 	}, cat, nil


### PR DESCRIPTION
## Problem
On the serve path, only **delivery failures** are logged (`internal/app/investigate.go`): a successful `notifier.Deliver()` is silent. When verifying a real deployment, there was no log line confirming a finding actually reached chat (Slack `#alerts`) — you had to read the notifier source to infer "no error == delivered". That's a relevant operational event with no log.

## Change
Add an INFO `delivered findings` line on the success branch, with `confidence`, `root_causes`, and `curated_url` so the delivered outcome is visible alongside the existing `findings` / `curated` lines.

## Test plan
- `go build ./internal/app/` ✓, `gofmt` clean.
- Verified live: with this line, a delivered investigation now logs `delivered findings confidence=… curated_url=…`; a failed one still logs `deliver findings err=…` as before.