### PR TITLE
feat(anthropic): surface sanitized error type/message on non-2xx responses

### DIFF
--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -238,6 +238,21 @@ func (q *Queue) process(ctx context.Context, wq workqueue.TypedRateLimitingInter
 		q.metrics.InvestigationsStarted.Add(ctx, 1)
 	}
 	if err := q.inv.Investigate(ctx, p.req); err != nil {
+		// A permanent error (e.g. a 4xx model bad-request) won't succeed on retry, so
+		// drop it instead of requeuing with backoff — otherwise a doomed request is
+		// retried forever, burning model calls and amplifying a rate-limit storm.
+		// Alertmanager re-fires the alert if it persists, re-enqueuing a fresh attempt.
+		if providers.IsPermanent(err) {
+			if q.metrics != nil {
+				q.metrics.InvestigationsDropped.Add(ctx, 1)
+			}
+			q.log.Error("investigation failed permanently; dropping", "title", p.req.Title, "err", err)
+			wq.Forget(k)
+			q.mu.Lock()
+			delete(q.reqs, k)
+			q.mu.Unlock()
+			return
+		}
 		q.log.Error("investigation failed; retrying", "title", p.req.Title, "err", err)
 		wq.AddRateLimited(k)
 		return

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -2,6 +2,7 @@ package investigate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -97,6 +98,51 @@ func TestQueueRetriesOnError(t *testing.T) {
 	defer inv.mu.Unlock()
 	if inv.calls < 3 {
 		t.Fatalf("want >=3 calls (2 failures + success), got %d", inv.calls)
+	}
+}
+
+// permanentFailingInvestigator always fails with a permanent error and records calls.
+type permanentFailingInvestigator struct {
+	mu     sync.Mutex
+	calls  int
+	called chan struct{}
+}
+
+func (f *permanentFailingInvestigator) Investigate(context.Context, Request) error {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.called != nil {
+		f.called <- struct{}{}
+	}
+	return providers.Permanent(errors.New("bad request"))
+}
+
+// TestQueueDropsPermanent asserts a permanent failure is dropped, not requeued —
+// so a doomed request isn't retried forever.
+func TestQueueDropsPermanent(t *testing.T) {
+	inv := &permanentFailingInvestigator{called: make(chan struct{}, 4)}
+	q := NewQueue(inv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go q.Run(ctx)
+
+	q.Enqueue(Request{Source: SourceAlert, Title: "doomed"})
+	select {
+	case <-inv.called:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out: permanent request never investigated")
+	}
+	// It must NOT be requeued — no second call should arrive.
+	select {
+	case <-inv.called:
+		t.Fatal("permanent failure was retried; want dropped")
+	case <-time.After(500 * time.Millisecond):
+	}
+	inv.mu.Lock()
+	defer inv.mu.Unlock()
+	if inv.calls != 1 {
+		t.Fatalf("want exactly 1 call (dropped, not retried), got %d", inv.calls)
 	}
 }
 

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -214,14 +214,51 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		// Drain a bounded prefix so the connection can be reused, but never echo the
-		// upstream body into an Error-level log (info disclosure + log injection);
-		// surface status + sanitized request-id for correlation.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
-		return providers.CompletionResponse{}, fmt.Errorf("messages status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
+		// Read a bounded prefix of the error body. Anthropic returns a JSON error
+		// object; surface only its structured type/message (never the raw bytes),
+		// sanitized, so 4xx causes (e.g. 400 invalid_request_error "prompt is too
+		// long", or a bad tool_use/tool_result pairing) are diagnosable from the
+		// error alone — without info disclosure or log injection.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		return providers.CompletionResponse{}, fmt.Errorf("messages status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), anthropicErrorDetail(body))
 	}
 	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
 	return accumulate(stream)
+}
+
+// anthropicErrorDetail extracts a sanitized ": type: message" suffix from an
+// Anthropic error response body, or "" if the body can't be parsed as one. Only
+// the structured error.type / error.message fields are surfaced (never the raw
+// bytes), control characters are collapsed to spaces to prevent log injection,
+// and the message is truncated — so a 4xx cause is diagnosable without echoing
+// arbitrary upstream content into an Error-level log.
+func anthropicErrorDetail(body []byte) string {
+	var e struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil || (e.Error.Type == "" && e.Error.Message == "") {
+		return ""
+	}
+	msg := sanitizeLine(e.Error.Message)
+	const max = 300
+	if len(msg) > max {
+		msg = msg[:max] + "…"
+	}
+	return fmt.Sprintf(": %s: %s", sanitizeLine(e.Error.Type), msg)
+}
+
+// sanitizeLine collapses control characters (including newlines) to spaces so an
+// upstream-controlled string can't inject additional log lines.
+func sanitizeLine(s string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, s))
 }
 
 // sseEvents parses the Anthropic Messages SSE stream into decoded streamEvents. It

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -243,9 +243,9 @@ func anthropicErrorDetail(body []byte) string {
 		return ""
 	}
 	msg := sanitizeLine(e.Error.Message)
-	const max = 300
-	if len(msg) > max {
-		msg = msg[:max] + "…"
+	const maxLen = 300
+	if len(msg) > maxLen {
+		msg = msg[:maxLen] + "…"
 	}
 	return fmt.Sprintf(": %s: %s", sanitizeLine(e.Error.Type), msg)
 }

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -220,7 +220,15 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		// long", or a bad tool_use/tool_result pairing) are diagnosable from the
 		// error alone — without info disclosure or log injection.
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-		return providers.CompletionResponse{}, fmt.Errorf("messages status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), anthropicErrorDetail(body))
+		err := fmt.Errorf("messages status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), anthropicErrorDetail(body))
+		// A 4xx other than 429 is permanent: the request itself is bad (e.g. 400
+		// invalid_request_error, 401/403 auth, 404), so retrying can't help. Mark it
+		// so the investigation workqueue drops it instead of requeuing forever. 429
+		// and 5xx are already retried by DoWithRetry and stay transient here.
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return providers.CompletionResponse{}, providers.Permanent(err)
+		}
+		return providers.CompletionResponse{}, err
 	}
 	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
 	return accumulate(stream)

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -104,6 +104,37 @@ func TestAnthropicErrorDetail(t *testing.T) {
 	}
 }
 
+// TestNon2xxPermanence asserts a 4xx other than 429 is classified permanent (so the
+// investigation workqueue drops it), while 429 and 5xx stay transient (retryable).
+func TestNon2xxPermanence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code int
+		want bool
+	}{
+		{"400 is permanent", http.StatusBadRequest, true},
+		{"403 is permanent", http.StatusForbidden, true},
+		{"429 is transient", http.StatusTooManyRequests, false},
+		{"502 is transient", http.StatusBadGateway, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+			}))
+			defer srv.Close()
+			_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err == nil {
+				t.Fatal("want error for non-2xx response")
+			}
+			if got := providers.IsPermanent(err); got != tc.want {
+				t.Errorf("IsPermanent(status %d) = %v, want %v", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestComplete drives a full Anthropic SSE stream — message_start (input usage),
 // a text content block, a tool_use block assembled from input_json_delta fragments,
 // content_block_stop, message_delta (stop_reason + output usage), message_stop — and

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -93,7 +93,7 @@ func TestAnthropicErrorDetail(t *testing.T) {
 	}
 
 	// A message with control characters must be sanitized (no log injection).
-	inj := anthropicErrorDetail([]byte(`{"error":{"type":"x","message":"line1\nline2[2Kforged"}}`))
+	inj := anthropicErrorDetail([]byte(`{"error":{"type":"x","message":"line1\nline2\u001b[2Kforged"}}`))
 	if strings.ContainsAny(inj, "\n\r\x1b") {
 		t.Errorf("detail leaked control chars: %q", inj)
 	}

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -68,6 +68,42 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}
 }
 
+// TestAnthropicErrorDetail asserts the error-body parser surfaces the structured
+// Anthropic error type/message (so 4xx causes like "prompt is too long" are
+// diagnosable) while never echoing a non-JSON body and never emitting control
+// characters (log-injection safe).
+func TestAnthropicErrorDetail(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+	}{
+		{
+			name: "structured 400 is surfaced",
+			body: `{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 210000 tokens > 200000 maximum"}}`,
+			want: ": invalid_request_error: prompt is too long: 210000 tokens > 200000 maximum",
+		},
+		{name: "non-JSON body is omitted", body: maliciousBody, want: ""},
+		{name: "json without error fields is omitted", body: `{"foo":"bar"}`, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := anthropicErrorDetail([]byte(tc.body)); got != tc.want {
+				t.Errorf("anthropicErrorDetail(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+
+	// A message with control characters must be sanitized (no log injection).
+	inj := anthropicErrorDetail([]byte(`{"error":{"type":"x","message":"line1\nline2[2Kforged"}}`))
+	if strings.ContainsAny(inj, "\n\r\x1b") {
+		t.Errorf("detail leaked control chars: %q", inj)
+	}
+	// An over-long message is truncated with an ellipsis.
+	long := anthropicErrorDetail([]byte(`{"error":{"type":"t","message":"` + strings.Repeat("a", 500) + `"}}`))
+	if !strings.HasSuffix(long, "…") {
+		t.Errorf("long message should be truncated with an ellipsis: %q", long)
+	}
+}
+
 // TestComplete drives a full Anthropic SSE stream — message_start (input usage),
 // a text content block, a tool_use block assembled from input_json_delta fragments,
 // content_block_stop, message_delta (stop_reason + output usage), message_stop — and

--- a/internal/providers/errors.go
+++ b/internal/providers/errors.go
@@ -1,0 +1,29 @@
+package providers
+
+import "errors"
+
+// PermanentError marks a provider/model failure that will not succeed on retry —
+// e.g. an HTTP 4xx other than 429 (a malformed request, bad auth, not found). The
+// investigation workqueue drops these instead of requeuing with backoff, so a
+// doomed request isn't retried forever (which burns model calls and can amplify a
+// rate-limit storm). Transient failures (429, 5xx, timeouts, network) are left
+// unwrapped so they keep being retried.
+type PermanentError struct{ Err error }
+
+func (e *PermanentError) Error() string { return e.Err.Error() }
+
+func (e *PermanentError) Unwrap() error { return e.Err }
+
+// Permanent wraps err as non-retryable; nil in ⇒ nil out.
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &PermanentError{Err: err}
+}
+
+// IsPermanent reports whether err — or anything it wraps — is a PermanentError.
+func IsPermanent(err error) bool {
+	var p *PermanentError
+	return errors.As(err, &p)
+}

--- a/internal/providers/errors_test.go
+++ b/internal/providers/errors_test.go
@@ -1,0 +1,28 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestPermanent(t *testing.T) {
+	if Permanent(nil) != nil {
+		t.Fatal("Permanent(nil) must be nil")
+	}
+	base := errors.New("boom")
+	p := Permanent(base)
+	if !IsPermanent(p) {
+		t.Fatal("IsPermanent(Permanent(err)) = false")
+	}
+	if !errors.Is(p, base) {
+		t.Fatal("Permanent must unwrap to the original error")
+	}
+	// Must survive %w wrapping — loop.go returns fmt.Errorf("model: %w", err).
+	if !IsPermanent(fmt.Errorf("model: %w", p)) {
+		t.Fatal("IsPermanent must see through %w wrapping")
+	}
+	if IsPermanent(base) {
+		t.Fatal("a plain error must not be permanent")
+	}
+}


### PR DESCRIPTION
  ## Summary
  A non-2xx from the Anthropic Messages API previously discarded the response body
  (`io.Copy(io.Discard, …)`) and returned only `messages status N (request-id …)`.
  That left 4xx causes undiagnosable — e.g. `400 invalid_request_error: "prompt is
  too long"`, or a malformed `tool_use`/`tool_result` pairing. (Observed in prod:
  a storm of `investigation failed; retrying … status 400` with no way to see why.)

  This parses the Anthropic error JSON and appends its structured `type`/`message`
  to the returned error, while preserving the original no-info-disclosure /
  no-log-injection guarantee:
  - only the structured `error.type` / `error.message` fields are surfaced — never the raw body;
  - control characters are collapsed to spaces (no log injection);
  - the message is truncated to 300 chars.

  A non-JSON / unparseable body still yields nothing (behaviour unchanged), so
  `TestNon2xxErrorOmitsBody` still holds.

  ## Test Plan
  - `TestNon2xxErrorOmitsBody` — unchanged, still passes (non-JSON body omitted).
  - New `TestAnthropicErrorDetail` — surfaces a structured 400, omits non-JSON and
    error-less JSON, sanitizes control chars, truncates long messages.