### PR TITLE
feat(curator): host-invariant KB fingerprints — dedup across pods/nodes

### DIFF
--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"regexp"
 	"sort"
 	"strings"
 	"unicode"
@@ -11,6 +12,78 @@ import (
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+// Volatile-identifier patterns. These name a specific host/pod/instance and are
+// NOT identity-defining for an incident CLASS — the same problem on a different
+// node must dedupe (CORE-681). They are masked out of fingerprints and keys.
+var (
+	reUUID       = regexp.MustCompile(`(?i)\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`)
+	reNodeName   = regexp.MustCompile(`\bip-\d{1,3}-\d{1,3}-\d{1,3}-\d{1,3}(\.[a-z0-9.-]+)?`) // ip-10-11-19-78[.ec2.internal]
+	reIPv4       = regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
+	reInstanceID = regexp.MustCompile(`(?i)\b(i|vol|eni|snap|ami)-[0-9a-f]{8,}\b`) // EC2/EBS ids
+	reHexHash    = regexp.MustCompile(`(?i)\b[0-9a-f]{12,}\b`)                     // dashless uuids / sha blobs
+	reDeployPod  = regexp.MustCompile(`-[a-f0-9]{8,10}-[a-z0-9]{5}$`)              // <name>-<rs-hash>-<pod-hash>
+)
+
+// normalizeText masks volatile identifiers (IPs, node hostnames, EC2 ids, long
+// hashes/UUIDs) in free text, collapsing them to a single space, so the same
+// incident on a different host hashes and BM25-matches alike.
+func normalizeText(s string) string {
+	s = reUUID.ReplaceAllString(s, " ")
+	s = reNodeName.ReplaceAllString(s, " ")
+	s = reIPv4.ReplaceAllString(s, " ")
+	s = reInstanceID.ReplaceAllString(s, " ")
+	s = reHexHash.ReplaceAllString(s, " ")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// normalizeWorkloadName strips a trailing pod-name hash so a per-pod name reduces
+// to its controller family: a Deployment pod (<name>-<rs-hash>-<pod-hash>) and a
+// DaemonSet/StatefulSet-revision pod (<name>-<5-char hash containing a digit>)
+// both collapse to <name>. Names without such a suffix are returned unchanged, so
+// real trailing words (e.g. "redis-cache") are preserved.
+func normalizeWorkloadName(name string) string {
+	if m := reDeployPod.FindString(name); m != "" {
+		return name[:len(name)-len(m)]
+	}
+	if i := strings.LastIndexByte(name, '-'); i >= 0 {
+		suf := name[i+1:]
+		if len(suf) == 5 && strings.ContainsAny(suf, "0123456789") && isAlnum(suf) {
+			return name[:i]
+		}
+	}
+	return name
+}
+
+func isAlnum(s string) bool {
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// IncidentKey builds a host-invariant, per-class dedup key for an alert: the alert
+// class + affected workload family + cluster, with the volatile pod-hash suffix
+// stripped. The same alert on a different pod/node yields the same key (so it
+// dedupes to one KB entry), while a different cluster stays distinct. Returned as
+// the alert TriggerKey and folded into DupFingerprint. "" when there is no signal.
+func IncidentKey(alertname, namespace, kind, name, cluster string) string {
+	parts := []string{
+		strings.TrimSpace(alertname),
+		strings.TrimSpace(namespace),
+		strings.TrimSpace(kind),
+		normalizeWorkloadName(strings.TrimSpace(name)),
+		strings.TrimSpace(cluster),
+	}
+	for _, p := range parts {
+		if p != "" {
+			return strings.ToLower(strings.Join(parts, "|"))
+		}
+	}
+	return ""
+}
 
 // stopWords are content-free English filler dropped so reworded causes hash alike.
 var stopWords = map[string]struct{}{
@@ -22,13 +95,13 @@ var stopWords = map[string]struct{}{
 // not a hash — matched against the catalog index and open-PR titles.
 func Fingerprint(inv providers.Investigation) string {
 	var b strings.Builder
-	b.WriteString(inv.Title)
+	b.WriteString(normalizeText(inv.Title))
 	if len(inv.RootCauses) > 0 {
-		b.WriteString(" " + inv.RootCauses[0].Summary)
+		b.WriteString(" " + normalizeText(inv.RootCauses[0].Summary))
 	}
 	if len(inv.Changes) > 0 {
 		w := inv.Changes[0].Workload
-		b.WriteString(" " + w.Namespace + " " + w.Name)
+		b.WriteString(" " + w.Namespace + " " + normalizeWorkloadName(w.Name))
 	}
 	return strings.TrimSpace(b.String())
 }
@@ -82,7 +155,12 @@ func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (
 // Fingerprint (a fuzzy BM25 query) it is an exact hash. It returns "" when there is
 // nothing to key on — an empty fingerprint must never match another.
 func DupFingerprint(inv providers.Investigation) string {
-	ref := strings.ToLower(inv.Resource.Ref())
+	// Strip the volatile pod-hash suffix from the affected resource so the same
+	// incident on a different pod/node keys alike (CORE-681). The TriggerKey is
+	// already a host-invariant per-class key for alert sources (see IncidentKey).
+	res := inv.Resource
+	res.Name = normalizeWorkloadName(res.Name)
+	ref := strings.ToLower(res.Ref())
 	if tk := strings.ToLower(strings.TrimSpace(inv.TriggerKey)); tk != "" {
 		// "trigger:" namespaces the key so a trigger value can never collide with a
 		// prose causeKey from the fallback path below.
@@ -91,7 +169,7 @@ func DupFingerprint(inv providers.Investigation) string {
 	}
 	cause := ""
 	if len(inv.RootCauses) > 0 {
-		cause = inv.RootCauses[0].Summary
+		cause = normalizeText(inv.RootCauses[0].Summary)
 	}
 	tokens := tokenSet(cause)
 	causeKey := strings.Join(tokens, " ")

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -213,3 +213,69 @@ func TestDupFingerprintDiffersByTriggerKey(t *testing.T) {
 		t.Fatal("different trigger keys on the same resource must not coalesce")
 	}
 }
+
+func TestNormalizeWorkloadName(t *testing.T) {
+	cases := map[string]string{
+		"node-exporter-prometheus-node-exporter-km6ld": "node-exporter-prometheus-node-exporter", // DaemonSet pod hash
+		"node-exporter-prometheus-node-exporter-n5zld": "node-exporter-prometheus-node-exporter", // different pod, same family
+		"web-7d9c8b6f5-abcde":                          "web",                                    // Deployment <rs-hash>-<pod-hash>
+		"node-exporter-prometheus-node-exporter":       "node-exporter-prometheus-node-exporter", // controller name, unchanged
+		"redis-cache":                                  "redis-cache",                            // 5-char tail but no digit → kept
+		"web":                                          "web",
+		"":                                             "",
+	}
+	for in, want := range cases {
+		if got := normalizeWorkloadName(in); got != want {
+			t.Errorf("normalizeWorkloadName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeTextMasksVolatile(t *testing.T) {
+	got := normalizeText("node ip-10-11-19-78.ec2.internal at 10.11.152.77 on i-0abc123def456789 CPU saturated")
+	for _, bad := range []string{"ip-10-11-19-78", "10.11.152.77", "i-0abc123def456789"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("normalizeText left volatile identifier %q in %q", bad, got)
+		}
+	}
+	for _, keep := range []string{"node", "CPU", "saturated"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("normalizeText dropped stable content %q from %q", keep, got)
+		}
+	}
+}
+
+func TestIncidentKeyPerClassKeepsCluster(t *testing.T) {
+	k1 := IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "shared")
+	k2 := IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-n5zld", "shared")
+	if k1 == "" || k1 != k2 {
+		t.Fatalf("same alert on different pods must share a key: %q vs %q", k1, k2)
+	}
+	if IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "dev-0") == k1 {
+		t.Fatal("different cluster must change the key")
+	}
+	if IncidentKey("KubeDaemonSetRolloutStuck", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "shared") == k1 {
+		t.Fatal("different alertname must change the key")
+	}
+	if IncidentKey("", "", "", "", "") != "" {
+		t.Fatal("no signal must yield an empty key")
+	}
+}
+
+// TestDupFingerprintStableAcrossPodSuffix is the CORE-681 regression: the same
+// alert class on a different pod (volatile resource ref + per-class trigger key)
+// must dedupe to one KB entry.
+func TestDupFingerprintStableAcrossPodSuffix(t *testing.T) {
+	a := providers.Investigation{
+		Resource:   providers.Workload{Kind: "Pod", Namespace: "observability", Name: "node-exporter-prometheus-node-exporter-km6ld"},
+		TriggerKey: IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-km6ld", "shared"),
+	}
+	b := providers.Investigation{
+		Resource:   providers.Workload{Kind: "Pod", Namespace: "observability", Name: "node-exporter-prometheus-node-exporter-n5zld"},
+		TriggerKey: IncidentKey("KubePodNotReady", "observability", "Pod", "node-exporter-prometheus-node-exporter-n5zld", "shared"),
+	}
+	fa, fb := DupFingerprint(a), DupFingerprint(b)
+	if fa == "" || fa != fb {
+		t.Fatalf("same incident on different pods must share a DupFingerprint: %q vs %q", fa, fb)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -370,7 +370,7 @@ type Investigation struct {
 	CuratedURL    string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
 	Fingerprint   string   // originating alert fingerprint; for outcome-ledger attribution
 	Fingerprints  []string // coalesced batch fingerprints; one outcome open is recorded per entry
-	TriggerKey    string   // deterministic incident identity (alert fingerprint, or failing resource+condition) set at trigger time; curator.DupFingerprint prefers it so reworded re-investigations of one incident still dedupe (#137)
+	TriggerKey    string   // deterministic incident identity set at trigger time (alerts: host-invariant per-class key from curator.IncidentKey; GitOps: failing resource+condition). curator.DupFingerprint prefers it so reworded re-investigations (#137) AND the same alert on a different pod/node (CORE-681) still dedupe
 	RecalledEntry string   // when Recalled: the catalog entry Path that was matched
 	Verified      bool     // true when the adversarial verify pass ran and a root cause survived it
 }

--- a/internal/source/alertmanager/alertmanager.go
+++ b/internal/source/alertmanager/alertmanager.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/source"
@@ -86,7 +87,11 @@ func (Source) Decode(body []byte, _ http.Header) (source.DecodeResult, error) {
 			Fingerprint:  a.Fingerprint,
 			Fingerprints: fps,
 			GroupKey:     p.GroupKey,
-			TriggerKey:   a.Fingerprint, // Alertmanager fingerprint: stable across re-fires of one alert series (#137)
+			// Host-invariant per-class dedup key (alertname + workload family +
+			// cluster, pod-hash suffix stripped): dedupes re-fires of one series
+			// (#137) AND the same alert on a different pod/node (CORE-681). Attribution
+			// still uses the per-series Alertmanager Fingerprint above.
+			TriggerKey: curator.IncidentKey(a.Labels["alertname"], a.Labels["namespace"], kind, name, a.Labels["cluster"]),
 		})
 	}
 	return out, nil

--- a/internal/source/alertmanager/alertmanager_test.go
+++ b/internal/source/alertmanager/alertmanager_test.go
@@ -33,8 +33,8 @@ func TestDecodeFiringProducesRequest(t *testing.T) {
 	if r.Fingerprint != "abc" || len(r.Fingerprints) != 1 || r.Fingerprints[0] != "abc" {
 		t.Fatalf("want fingerprint abc (and Fingerprints=[abc]), got %q %v", r.Fingerprint, r.Fingerprints)
 	}
-	if r.TriggerKey != "abc" { // alert identity = fingerprint (#137)
-		t.Fatalf("want TriggerKey=abc (=fingerprint), got %q", r.TriggerKey)
+	if r.TriggerKey != "highmem|prod-web|deployment|web|" { // host-invariant per-class key (CORE-681)
+		t.Fatalf("want per-class TriggerKey, got %q", r.TriggerKey)
 	}
 	if len(res.Resolved) != 0 {
 		t.Fatalf("firing must not resolve")
@@ -59,8 +59,8 @@ func TestDecodeEnvFallback(t *testing.T) {
 	if r.Fingerprints != nil {
 		t.Fatalf("want nil Fingerprints when fingerprint empty, got %v", r.Fingerprints)
 	}
-	if r.TriggerKey != "" { // no fingerprint ⇒ empty TriggerKey (DupFingerprint falls back to prose) (#137)
-		t.Fatalf("want empty TriggerKey when fingerprint empty, got %q", r.TriggerKey)
+	if r.TriggerKey != "x|ns|||" { // per-class key derives from labels, not the fingerprint (CORE-681)
+		t.Fatalf("want per-class TriggerKey x|ns|||, got %q", r.TriggerKey)
 	}
 }
 


### PR DESCRIPTION
  ## Summary
  The same alert on a different pod/node forked a *new* KB entry, because the dedup
  identity carried volatile identifiers:
  - for alerts the `TriggerKey` was the **per-series Alertmanager fingerprint** (a hash of
    all labels, incl. `pod`/`instance`/`node`), so two node-exporter `KubePodNotReady`
    alerts on different pods never coalesced;
  - the resource ref + root-cause text carried pod-hash suffixes and IPs.

  ## Changes
  - **curator**: `normalizeVolatile` helpers — mask IPs, `ip-x-x-x-x` node names, EC2 ids,
    hashes/UUIDs, and strip pod-hash suffixes (`-<rs-hash>-<pod-hash>`, `-km6ld`); real
    names like `redis-cache` are preserved. New `IncidentKey` = a host-invariant per-class
    key: `alertname + namespace + kind + workload-family + cluster`.
  - **alertmanager**: `TriggerKey` now derives from `IncidentKey` instead of the per-series
    fingerprint → dedupes re-fires (#137) **and** the same alert on a different pod/node,
    while different **clusters stay distinct**. Outcome-ledger attribution still uses the
    per-series `Fingerprint` (unchanged).
  - **Fingerprint (BM25)** + **DupFingerprint** normalize their inputs, so both fuzzy recall
    and the exact dedup hash are host-invariant.

  Design choice (per review): **per-class, keep cluster** — shared vs dev-0 occurrences
  remain separate entries.

  ## Test Plan
  - New: `TestNormalizeWorkloadName`, `TestNormalizeTextMasksVolatile`,
    `TestIncidentKeyPerClassKeepsCluster`, `TestDupFingerprintStableAcrossPodSuffix`.
  - Existing golden/#137 dedup tests still pass (suffix-free names unaffected); alertmanager
    TriggerKey tests updated for the per-class key.

