### PR TITLE
fix(model): classify 4xx as permanent and surface sanitized error detail (openai, gemini)

### DIFF
--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -194,14 +194,58 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		// Drain a bounded prefix so the connection can be reused, but never echo the
-		// upstream body into an Error-level log (info disclosure + log injection);
-		// surface status + sanitized request-id for correlation.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
-		return providers.CompletionResponse{}, fmt.Errorf("streamGenerateContent status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
+		// Read a bounded prefix of the error body. Never echo the raw bytes into an
+		// Error-level log (info disclosure + log injection); surface only the
+		// structured error status/message, sanitized, so 4xx causes (e.g. a 400
+		// INVALID_ARGUMENT or a 404 unknown model) are diagnosable from the error alone.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		err := fmt.Errorf("streamGenerateContent status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), geminiErrorDetail(body))
+		// A 4xx other than 429 is permanent: the request itself is bad (e.g. 400
+		// INVALID_ARGUMENT, 401/403 auth, 404 unknown model), so retrying can't help.
+		// Mark it so the investigation workqueue drops it instead of requeuing forever.
+		// 429 and 5xx are already retried by DoWithRetry and stay transient here.
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return providers.CompletionResponse{}, providers.Permanent(err)
+		}
+		return providers.CompletionResponse{}, err
 	}
 	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
 	return accumulate(stream)
+}
+
+// geminiErrorDetail extracts a sanitized ": status: message" suffix from a Gemini
+// error response body ({"error":{"code","message","status"}}), or "" if the body
+// can't be parsed as one. Only the structured error.status / error.message fields
+// are surfaced (never the raw bytes), control characters are collapsed to spaces
+// to prevent log injection, and the message is truncated — so a 4xx cause is
+// diagnosable without echoing arbitrary upstream content into an Error-level log.
+func geminiErrorDetail(body []byte) string {
+	var e struct {
+		Error struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil || (e.Error.Status == "" && e.Error.Message == "") {
+		return ""
+	}
+	msg := sanitizeLine(e.Error.Message)
+	const maxLen = 300
+	if len(msg) > maxLen {
+		msg = msg[:maxLen] + "…"
+	}
+	return fmt.Sprintf(": %s: %s", sanitizeLine(e.Error.Status), msg)
+}
+
+// sanitizeLine collapses control characters (including newlines) to spaces so an
+// upstream-controlled string can't inject additional log lines.
+func sanitizeLine(s string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, s))
 }
 
 // sseEvents parses the Gemini SSE stream into decoded genResponse chunks. It wraps the

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -71,6 +71,74 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}
 }
 
+// TestGeminiErrorDetail asserts the error-body parser surfaces the structured
+// Gemini error status/message (so 4xx causes like a bad model name or an invalid
+// argument are diagnosable) while never echoing a non-JSON body and never
+// emitting control characters (log-injection safe).
+func TestGeminiErrorDetail(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+	}{
+		{
+			name: "structured 400 is surfaced",
+			body: `{"error":{"code":400,"message":"Invalid JSON payload received.","status":"INVALID_ARGUMENT"}}`,
+			want: ": INVALID_ARGUMENT: Invalid JSON payload received.",
+		},
+		{name: "non-JSON body is omitted", body: maliciousBody, want: ""},
+		{name: "json without error fields is omitted", body: `{"foo":"bar"}`, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := geminiErrorDetail([]byte(tc.body)); got != tc.want {
+				t.Errorf("geminiErrorDetail(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+
+	// A message with control characters must be sanitized (no log injection).
+	inj := geminiErrorDetail([]byte(`{"error":{"status":"X","message":"line1\nline2\u001b[2Kforged"}}`))
+	if strings.ContainsAny(inj, "\n\r\x1b") {
+		t.Errorf("detail leaked control chars: %q", inj)
+	}
+	// An over-long message is truncated with an ellipsis.
+	long := geminiErrorDetail([]byte(`{"error":{"status":"S","message":"` + strings.Repeat("a", 500) + `"}}`))
+	if !strings.HasSuffix(long, "…") {
+		t.Errorf("long message should be truncated with an ellipsis: %q", long)
+	}
+}
+
+// TestNon2xxPermanence asserts a 4xx other than 429 is classified permanent (so the
+// investigation workqueue drops it), while 429 and 5xx stay transient (retryable).
+func TestNon2xxPermanence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code int
+		want bool
+	}{
+		{"400 is permanent", http.StatusBadRequest, true},
+		{"403 is permanent", http.StatusForbidden, true},
+		{"404 is permanent", http.StatusNotFound, true},
+		{"429 is transient", http.StatusTooManyRequests, false},
+		{"502 is transient", http.StatusBadGateway, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+			}))
+			defer srv.Close()
+			_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err == nil {
+				t.Fatal("want error for non-2xx response")
+			}
+			if got := providers.IsPermanent(err); got != tc.want {
+				t.Errorf("IsPermanent(status %d) = %v, want %v", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestComplete drives a full Gemini SSE stream — text parts spread across chunks, a
 // functionCall part, and a final chunk carrying finishReason "STOP" + usageMetadata —
 // and asserts the accumulated text, the reassembled tool call, usage, the stop reason,

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -221,15 +221,61 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		// Drain a bounded prefix so the connection can be reused, but never echo the
-		// upstream body into an Error-level log: base_url is operator-configurable, so a
-		// misbehaving/compromised proxy could inject arbitrary content (info disclosure +
-		// log injection). Surface the status and the upstream request-id (sanitized).
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4<<10))
-		return providers.CompletionResponse{}, fmt.Errorf("chat status %d (request-id %q)", resp.StatusCode, httpx.RequestID(resp.Header))
+		// Read a bounded prefix of the error body. base_url is operator-configurable, so
+		// never echo the raw bytes into an Error-level log (a misbehaving/compromised
+		// proxy could inject arbitrary content — info disclosure + log injection);
+		// surface only the structured error type/message, sanitized, so 4xx causes
+		// (e.g. an unknown model name or a rejected API key) are diagnosable from the
+		// error alone.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		err := fmt.Errorf("chat status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), openaiErrorDetail(body))
+		// A 4xx other than 429 is permanent: the request itself is bad (e.g. 400
+		// invalid request, 401/403 auth, 404 unknown model), so retrying can't help.
+		// Mark it so the investigation workqueue drops it instead of requeuing forever.
+		// 429 and 5xx are already retried by DoWithRetry and stay transient here.
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return providers.CompletionResponse{}, providers.Permanent(err)
+		}
+		return providers.CompletionResponse{}, err
 	}
 	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
 	return accumulate(stream)
+}
+
+// openaiErrorDetail extracts a sanitized ": type: message" suffix from an
+// OpenAI-compatible error response body ({"error":{"message","type","code"}}), or
+// "" if the body can't be parsed as one. Only the structured error.type /
+// error.message fields are surfaced (never the raw bytes), control characters are
+// collapsed to spaces to prevent log injection, and the message is truncated — so
+// a 4xx cause is diagnosable without echoing arbitrary upstream content into an
+// Error-level log.
+func openaiErrorDetail(body []byte) string {
+	var e struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil || (e.Error.Type == "" && e.Error.Message == "") {
+		return ""
+	}
+	msg := sanitizeLine(e.Error.Message)
+	const maxLen = 300
+	if len(msg) > maxLen {
+		msg = msg[:maxLen] + "…"
+	}
+	return fmt.Sprintf(": %s: %s", sanitizeLine(e.Error.Type), msg)
+}
+
+// sanitizeLine collapses control characters (including newlines) to spaces so an
+// upstream-controlled string can't inject additional log lines.
+func sanitizeLine(s string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, s))
 }
 
 // accumulate consumes an OpenAI chat/completions SSE stream and folds it into one

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -84,6 +84,74 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}
 }
 
+// TestOpenAIErrorDetail asserts the error-body parser surfaces the structured
+// OpenAI-compatible error type/message (so 4xx causes like a bad model name are
+// diagnosable) while never echoing a non-JSON body and never emitting control
+// characters (log-injection safe).
+func TestOpenAIErrorDetail(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+	}{
+		{
+			name: "structured 404 is surfaced",
+			body: `{"error":{"message":"The model 'gpt-oops' does not exist","type":"invalid_request_error","code":"model_not_found"}}`,
+			want: ": invalid_request_error: The model 'gpt-oops' does not exist",
+		},
+		{name: "non-JSON body is omitted", body: maliciousBody, want: ""},
+		{name: "json without error fields is omitted", body: `{"foo":"bar"}`, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := openaiErrorDetail([]byte(tc.body)); got != tc.want {
+				t.Errorf("openaiErrorDetail(%q) = %q, want %q", tc.body, got, tc.want)
+			}
+		})
+	}
+
+	// A message with control characters must be sanitized (no log injection).
+	inj := openaiErrorDetail([]byte(`{"error":{"type":"x","message":"line1\nline2\u001b[2Kforged"}}`))
+	if strings.ContainsAny(inj, "\n\r\x1b") {
+		t.Errorf("detail leaked control chars: %q", inj)
+	}
+	// An over-long message is truncated with an ellipsis.
+	long := openaiErrorDetail([]byte(`{"error":{"type":"t","message":"` + strings.Repeat("a", 500) + `"}}`))
+	if !strings.HasSuffix(long, "…") {
+		t.Errorf("long message should be truncated with an ellipsis: %q", long)
+	}
+}
+
+// TestNon2xxPermanence asserts a 4xx other than 429 is classified permanent (so the
+// investigation workqueue drops it), while 429 and 5xx stay transient (retryable).
+func TestNon2xxPermanence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		code int
+		want bool
+	}{
+		{"400 is permanent", http.StatusBadRequest, true},
+		{"401 is permanent", http.StatusUnauthorized, true},
+		{"404 is permanent", http.StatusNotFound, true},
+		{"429 is transient", http.StatusTooManyRequests, false},
+		{"502 is transient", http.StatusBadGateway, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.code)
+			}))
+			defer srv.Close()
+			_, err := New(srv.URL, "test-model", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err == nil {
+				t.Fatal("want error for non-2xx response")
+			}
+			if got := providers.IsPermanent(err); got != tc.want {
+				t.Errorf("IsPermanent(status %d) = %v, want %v", tc.code, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestComplete drives a full OpenAI chat/completions SSE stream — content deltas, a
 // tool_call assembled by index (first chunk carries id+name, later chunks carry
 // arguments fragments), a finish_reason chunk, a usage-only chunk, and the [DONE]


### PR DESCRIPTION
## Problem

PR #193 hardened the Anthropic client's non-200 handling, but the OpenAI and Gemini clients were left behind:

- **Endless retries on doomed requests.** Every non-200 came back as a plain error, so a 4xx caused by a bad model name, dead API key, or malformed request was requeued by the investigation workqueue forever — burning model calls and amplifying rate-limit pressure.
- **Undiagnosable 4xx.** Both clients drained and discarded the error body (deliberately: base_url is operator-configurable, so echoing the raw body risks info disclosure and log injection), leaving only the status code and request-id — not enough to tell a bad model name from a bad payload.

## Fix

Mirrors the Anthropic precedent (#193) in both clients, adapted to each provider's error JSON shape:

- A 4xx other than 429 is wrapped in `providers.Permanent(...)` so the workqueue drops it instead of requeuing. 429 and 5xx stay transient (already retried by `httpx.DoWithRetry`).
- A bounded 4KB prefix of the error body is read and **only the structured error fields** are surfaced as a `: type: message` suffix — OpenAI-compatible `error.type`/`error.message`, Gemini `error.status`/`error.message`. Control characters are collapsed to spaces (log-injection defense) and the message is truncated to 300 chars. Raw body bytes are still never echoed.

Helpers (`openaiErrorDetail`/`geminiErrorDetail` + `sanitizeLine`) are mirrored per client, consistent with the codebase's per-client style (each client already duplicates `sseServer`, `rawObject`, …). No other restructuring.

## Testing

Table-driven tests added to both packages, modeled on the Anthropic ones:

- `TestOpenAIErrorDetail` / `TestGeminiErrorDetail`: structured error surfaced; non-JSON body omitted; JSON without error fields omitted; control chars sanitized; over-long message truncated with ellipsis.
- `TestNon2xxPermanence`: 400/401/403/404 → `providers.IsPermanent` true; 429/502 → transient.
- Existing `TestNon2xxErrorOmitsBody` still passes unchanged (malicious non-JSON body yields no detail).

Quality gate green: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — gofmt prints nothing, golangci-lint reports 0 issues.