### PR TITLE
fix(notify): escape untrusted text in Slack mrkdwn output

### DIFF
--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -145,8 +145,27 @@ const (
 // clients that don't render blocks). Actions carrying an ApprovalID also get
 // interactive Approve/Reject buttons (rung-2).
 func slackMessage(inv providers.Investigation) map[string]any {
-	return map[string]any{"text": Format(inv), "blocks": slackBlocks(inv)}
+	// The fallback text is parsed as mrkdwn too (notifications, block-less
+	// clients), so untrusted content embedded in it must be escaped. Escaping the
+	// composed Format output is safe because Format's own scaffolding (bold
+	// markers, bullets) contains none of mrkdwn's three control characters —
+	// TestSlackMessageFallbackEscaped guards that invariant. Matrix and the
+	// generic webhook call Format themselves and are unaffected.
+	return map[string]any{"text": escapeMrkdwn(Format(inv)), "blocks": slackBlocks(inv)}
 }
+
+// mrkdwnEscaper implements Slack's documented mrkdwn escaping: exactly three
+// characters act as control characters and must be replaced with HTML entities
+// (& first). strings.Replacer substitutes in a single left-to-right pass, so
+// the ampersands introduced by &lt;/&gt; are never re-escaped.
+var mrkdwnEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
+
+// escapeMrkdwn neutralises untrusted text (model output, evidence quoting
+// cluster logs or alert annotations) before it is interpolated into Slack
+// mrkdwn, so a hostile log line like <https://evil.example|innocent text>
+// renders as literal text instead of a clickable phishing link. Mirrors the
+// escape-first approach of the Matrix notifier's mrkdwnToHTML.
+func escapeMrkdwn(s string) string { return mrkdwnEscaper.Replace(s) }
 
 // slackBlocks renders the investigation as Block Kit. Designed to read top-down as
 // an on-call would triage: what happened → how sure → why → what to do → what's
@@ -158,6 +177,9 @@ func slackBlocks(inv providers.Investigation) []map[string]any {
 	}
 	emoji, level, pct := confidenceBadge(inv)
 	blocks := []map[string]any{
+		// The header is a plain_text object: Slack renders it literally (no mrkdwn
+		// parsing), so the untrusted title needs no escaping here — escaping would
+		// display raw &lt; entities instead.
 		{"type": "header", "text": map[string]any{"type": "plain_text", "text": truncate("🔍 "+title, 150), "emoji": true}},
 		{"type": "context", "elements": []map[string]any{
 			{"type": "mrkdwn", "text": fmt.Sprintf("%s *%s confidence* · %d%%  ·  🤖 RunLore SRE agent", emoji, level, pct)}}},
@@ -169,16 +191,16 @@ func slackBlocks(inv providers.Investigation) []map[string]any {
 			break
 		}
 		var s strings.Builder
-		fmt.Fprintf(&s, "*%d. %s*  `%.0f%%`", i+1, rc.Summary, rc.Confidence*100)
+		fmt.Fprintf(&s, "*%d. %s*  `%.0f%%`", i+1, escapeMrkdwn(rc.Summary), rc.Confidence*100)
 		if rc.ChangeRef != "" {
-			fmt.Fprintf(&s, "\n📦 *What changed:* `%s`", rc.ChangeRef)
+			fmt.Fprintf(&s, "\n📦 *What changed:* `%s`", escapeMrkdwn(rc.ChangeRef))
 		}
 		for j, e := range rc.Evidence {
 			if j >= 4 {
 				fmt.Fprintf(&s, "\n• _…%d more_", len(rc.Evidence)-j)
 				break
 			}
-			fmt.Fprintf(&s, "\n• %s", e)
+			fmt.Fprintf(&s, "\n• %s", escapeMrkdwn(e))
 		}
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
 	}
@@ -204,14 +226,16 @@ func slackBlocks(inv providers.Investigation) []map[string]any {
 				fmt.Fprintf(&s, "\n• _…%d more_", len(inv.Unresolved)-i)
 				break
 			}
-			fmt.Fprintf(&s, "\n• %s", u)
+			fmt.Fprintf(&s, "\n• %s", escapeMrkdwn(u))
 		}
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
 	}
 
 	if inv.CuratedURL != "" {
+		// The link itself is formatter-constructed; escaping the URL inside it is
+		// what Slack's docs prescribe (a raw & / < / > would corrupt the link).
 		blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
-			{"type": "mrkdwn", "text": fmt.Sprintf("📚 Logged to the knowledge base — <%s|view entry>", inv.CuratedURL)}}})
+			{"type": "mrkdwn", "text": fmt.Sprintf("📚 Logged to the knowledge base — <%s|view entry>", escapeMrkdwn(inv.CuratedURL))}}})
 	}
 
 	// Interactive Approve/Reject for any action awaiting approval (rung-2).
@@ -220,7 +244,7 @@ func slackBlocks(inv providers.Investigation) []map[string]any {
 			continue
 		}
 		blocks = append(blocks,
-			map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": "*Proposed action:* " + a.Description}},
+			map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": "*Proposed action:* " + escapeMrkdwn(a.Description)}},
 			map[string]any{"type": "actions", "elements": []map[string]any{
 				{"type": "button", "style": "primary", "action_id": approveActionID, "value": a.ApprovalID,
 					"text": map[string]any{"type": "plain_text", "text": "Approve"}},
@@ -255,7 +279,9 @@ func confidenceBadge(inv providers.Investigation) (emoji, level string, pct int)
 }
 
 // nextSteps collects the actionable remediations (root-cause suggestions + policy
-// actions), de-duplicated and reversibility-flagged, preserving order.
+// actions), de-duplicated and reversibility-flagged, preserving order. The
+// untrusted descriptions are mrkdwn-escaped before the formatter's own italics
+// suffix is appended, so only the payload is neutralised.
 func nextSteps(inv providers.Investigation) []string {
 	var steps []string
 	seen := map[string]bool{}
@@ -264,6 +290,7 @@ func nextSteps(inv providers.Investigation) []string {
 			return
 		}
 		seen[desc] = true
+		desc = escapeMrkdwn(desc)
 		if reversible {
 			desc += "  _(reversible)_"
 		}

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -135,6 +136,113 @@ func TestSlackBlocksLayout(t *testing.T) {
 		if !contains(s, want) {
 			t.Fatalf("blocks missing %q:\n%s", want, s)
 		}
+	}
+}
+
+func TestEscapeMrkdwn(t *testing.T) {
+	for _, tc := range []struct {
+		name, in, want string
+	}{
+		{"plain", "no specials here", "no specials here"},
+		{"link_injection", "<https://evil.example|click here to remediate>", "&lt;https://evil.example|click here to remediate&gt;"},
+		{"amp_first", "a & b < c > d", "a &amp; b &lt; c &gt; d"},
+		{"pre_escaped_stays_literal", "&lt;", "&amp;lt;"},
+		{"empty", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := escapeMrkdwn(tc.in); got != tc.want {
+				t.Errorf("escapeMrkdwn(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// mrkdwnTexts collects every mrkdwn text the blocks would send to Slack, so
+// tests assert on what Slack will actually parse (json.Marshal would obscure
+// this by encoding < and > as </>).
+func mrkdwnTexts(blocks []map[string]any) []string {
+	var out []string
+	grab := func(v any) {
+		txt, _ := v.(map[string]any)
+		if txt["type"] == "mrkdwn" {
+			if s, _ := txt["text"].(string); s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	for _, b := range blocks {
+		grab(b["text"])
+		if els, _ := b["elements"].([]map[string]any); els != nil {
+			for _, el := range els {
+				grab(el)
+			}
+		}
+	}
+	return out
+}
+
+// TestSlackBlocksEscapeUntrustedText proves that model/tool-derived fields
+// (summaries, evidence quoting cluster logs, change refs, action descriptions,
+// unresolved items) cannot inject Slack mrkdwn — most importantly the
+// <url|text> link form, a phishing vector in incident notifications — while the
+// formatter's own markup (bold, code, the KB link it constructs) keeps working.
+func TestSlackBlocksEscapeUntrustedText(t *testing.T) {
+	inv := providers.Investigation{
+		Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{
+			Summary:         "summary with <b> tag",
+			Confidence:      0.9,
+			ChangeRef:       "chart@<v2>",
+			Evidence:        []string{"error: <https://evil.example|click here to remediate>"},
+			SuggestedAction: "restart & verify",
+			Reversible:      true,
+		}},
+		Unresolved: []string{"why <img> appears in logs"},
+		Actions:    []providers.Action{{Description: "scale down <deploy>", ApprovalID: "a1"}},
+		CuratedURL: "https://github.com/o/r/issues/9",
+	}
+	joined := strings.Join(mrkdwnTexts(slackBlocks(inv)), "\n")
+
+	// The hostile log line must render inert, never as a clickable link.
+	if strings.Contains(joined, "<https://evil.example") {
+		t.Fatalf("hostile evidence rendered as live mrkdwn link:\n%s", joined)
+	}
+	for _, want := range []string{
+		"&lt;https://evil.example|click here to remediate&gt;",
+		"summary with &lt;b&gt; tag",
+		"chart@&lt;v2&gt;",
+		"restart &amp; verify",
+		"why &lt;img&gt; appears in logs",
+		"scale down &lt;deploy&gt;",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("blocks missing escaped untrusted text %q:\n%s", want, joined)
+		}
+	}
+	// Formatter-emitted markup must keep working: bold rank, code confidence,
+	// reversibility italics, and the KB link the formatter constructs itself.
+	for _, want := range []string{"*1. ", "`90%`", "_(reversible)_", "<https://github.com/o/r/issues/9|view entry>"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("blocks missing formatter-emitted markup %q:\n%s", want, joined)
+		}
+	}
+}
+
+// TestSlackMessageFallbackEscaped proves the plain-text fallback (Slack parses
+// it as mrkdwn for notifications) escapes untrusted content too, while the
+// scaffolding Format emits (bold headers) survives untouched.
+func TestSlackMessageFallbackEscaped(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence, "<https://evil.example|click here to remediate>")
+	text, _ := slackMessage(inv)["text"].(string)
+	if strings.Contains(text, "<https://evil.example") {
+		t.Fatalf("fallback text carries live mrkdwn link:\n%s", text)
+	}
+	if !strings.Contains(text, "&lt;https://evil.example|click here to remediate&gt;") {
+		t.Fatalf("fallback text missing escaped evidence:\n%s", text)
+	}
+	if !strings.Contains(text, "*Investigation*") {
+		t.Fatalf("fallback text lost formatter scaffolding:\n%s", text)
 	}
 }
 


### PR DESCRIPTION
## Problem

The Slack notifier interpolates model- and tool-derived text (root-cause summaries, evidence lines quoting cluster logs, change refs, action descriptions, unresolved items) verbatim into `mrkdwn` blocks and the plain-text fallback. Cluster logs and alert annotations are attacker-influenceable, so a hostile log line can inject live Slack markup — most importantly the link form `<https://evil.example|click here to remediate>`, which renders as a clickable phishing link inside the incident notification. Text was length-truncated but never escaped.

The Matrix notifier already gets this right: `mrkdwnToHTML` HTML-escapes first, then applies its own formatting. This PR brings the Slack path to the same escape-first design.

## Fix

Add `escapeMrkdwn` in `internal/notify/slack.go` implementing Slack's documented mrkdwn escaping — exactly three control characters, `&` → `&amp;` first, then `<` → `&lt;` and `>` → `&gt;` (a single-pass `strings.NewReplacer`, so entities are never re-escaped).

**Seam choice** — escaping lives entirely in the Slack-specific rendering path, per field, because `Format()` output is shared: Matrix runs `html.EscapeString` on it (escaping inside `Format` would double-escape), and the generic webhook and the CLI print it raw.

- `slackBlocks`: escapes only the untrusted payload fields (summary, change ref, evidence, next-step descriptions before the `_(reversible)_` suffix, unresolved items, proposed-action description). The formatter's own scaffolding (`*bold*`, `\`code\``, bullets, the KB `<url|view entry>` link it constructs) is untouched and keeps rendering.
- `slackMessage` fallback `text`: escapes the composed `Format()` output (Slack parses the fallback as mrkdwn for notifications). Safe because `Format`'s scaffolding contains none of the three control characters — a test guards that invariant.
- The header is a `plain_text` object rendered literally by Slack, so the title needs no escaping there (escaping would display raw entities).
- `CuratedURL` inside the formatter-built link is escaped too, as Slack's docs prescribe for URLs in the `<url|label>` form.

## Testing

TDD — new table-driven tests written first and confirmed failing:

- `TestEscapeMrkdwn`: ampersand-first ordering, no double-escaping of pre-escaped entities.
- `TestSlackBlocksEscapeUntrustedText`: hostile evidence `<https://evil.example|click here to remediate>` renders inert across every block type, while formatter-emitted markup (bold rank, code confidence, reversibility italics, KB link) still works.
- `TestSlackMessageFallbackEscaped`: fallback text neutralised, `Format` scaffolding survives.

Quality gate passes: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` (gofmt empty, golangci-lint 0 issues).