### PR TITLE
fix(investigate): redact action Name at the egress chokepoint

### DIFF
--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -498,7 +498,8 @@ func (li *LoopInvestigator) deliver(req Request, inv providers.Investigation) {
 
 // redactInvestigation masks secret-shaped values in a finished investigation's
 // human-facing text (title; each root cause's summary, evidence, and suggested
-// action; unresolved notes; proposed-action descriptions) before it is delivered.
+// action; unresolved notes; proposed-action names and descriptions) before it is
+// delivered.
 func redactInvestigation(inv *providers.Investigation) {
 	inv.Title = redact.Secrets(inv.Title)
 	for i := range inv.RootCauses {
@@ -513,6 +514,11 @@ func redactInvestigation(inv *providers.Investigation) {
 		inv.Unresolved[i] = redact.Secrets(inv.Unresolved[i])
 	}
 	for i := range inv.Actions {
+		// Name and Description both carry model-authored text (buildInvestigation
+		// copies the description into Name), and both are serialized verbatim on
+		// GET /actions — scrub both. Target is left alone: it is a Kubernetes
+		// resource identifier the executor acts on, not free text.
+		inv.Actions[i].Name = redact.Secrets(inv.Actions[i].Name)
 		inv.Actions[i].Description = redact.Secrets(inv.Actions[i].Description)
 	}
 }

--- a/internal/investigate/redact_approvals_test.go
+++ b/internal/investigate/redact_approvals_test.go
@@ -1,0 +1,110 @@
+// This file lives in the external test package so it can wire the real
+// investigate loop to the real action.Approvals queue AND the real HTTP server:
+// internal/server transitively imports internal/investigate (via internal/source),
+// so an in-package test importing server would be an import cycle.
+package investigate_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/action"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/server"
+)
+
+// scriptedModel replays canned completion responses in order.
+type scriptedModel struct {
+	responses []providers.CompletionResponse
+	i         int
+}
+
+func (m *scriptedModel) Complete(context.Context, providers.CompletionRequest) (providers.CompletionResponse, error) {
+	r := m.responses[m.i]
+	m.i++
+	return r, nil
+}
+
+// TestApprovalQueueServesRedactedActions locks in the redaction ordering for the
+// rung-2 (approve) path: deliver() runs redactInvestigation BEFORE OnComplete
+// (internal/investigate/loop.go), and the app wiring registers actions with the
+// approvals queue INSIDE OnComplete (internal/app/investigate.go) — so the copies
+// the approvals queue holds, and that GET /actions serves, are the post-redaction
+// ones. If registration ever moves ahead of the egress redaction (or the
+// redaction moves after OnComplete), this test fails.
+func TestApprovalQueueServesRedactedActions(t *testing.T) {
+	const secret = "hunter2horse"
+	// The model proposes an envelope-compliant action whose description carries a
+	// secret, as quoted evidence from logs might.
+	findingsArgs := `{"confidence":0.9,` +
+		`"root_causes":[{"summary":"credential rotation broke the app","confidence":0.9,"evidence":["e"]}],` +
+		`"actions":[{"description":"suspend web; logs showed password=` + secret + `",` +
+		`"op":"suspend","reversible":true,"target":{"kind":"Kustomization","name":"web","namespace":"apps"}}]}`
+	model := &scriptedModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: "submit_findings", Args: findingsArgs}}},
+	}}
+
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pol := action.New(config.ActionPolicy{
+		Mode:  config.ActionApprove,
+		Allow: config.ActionAllow{ReversibleOnly: true, Namespaces: []string{"apps"}},
+	})
+	approvals := action.NewApprovals(nil, pol, nil, discard)
+
+	li := &investigate.LoopInvestigator{
+		Model:    model,
+		MaxSteps: 3,
+		Actions:  pol,
+		Log:      discard,
+		OnComplete: func(found providers.Investigation) {
+			// Mirrors the rung-2 wiring in internal/app/investigate.go: register each
+			// envelope-compliant action for human approval.
+			for i := range found.Actions {
+				found.Actions[i].ApprovalID = approvals.Register(found.Actions[i])
+			}
+		},
+	}
+	if err := li.Investigate(context.Background(), investigate.Request{Title: "web down"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	// The queue itself must hold the redacted copy.
+	pending := approvals.List()
+	if len(pending) != 1 {
+		t.Fatalf("pending actions = %d, want 1", len(pending))
+	}
+	desc := pending[0].Action.Description
+	if strings.Contains(desc, secret) {
+		t.Fatalf("approvals queue holds an unredacted secret: %q", desc)
+	}
+	// Sanity: the assertion above isn't passing because the description was
+	// dropped or rewritten — the redaction marker replaced the secret in place.
+	if !strings.Contains(desc, "[REDACTED]") {
+		t.Fatalf("expected a redaction marker in the queued description, got %q", desc)
+	}
+
+	// And the HTTP surface: GET /actions serves the queue as JSON to a
+	// token-holding caller — the body must not contain the secret either.
+	srv := server.New(nil, server.Actions{Approvals: approvals, Token: "tok"}, nil, nil, nil, discard)
+	req := httptest.NewRequest(http.MethodGet, "/actions", nil)
+	req.Header.Set("X-Approval-Token", "tok")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /actions = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, secret) {
+		t.Fatalf("GET /actions served an unredacted secret: %q", body)
+	}
+	if !strings.Contains(body, "[REDACTED]") {
+		t.Fatalf("expected the redacted action in the /actions response, got %q", body)
+	}
+}

--- a/internal/investigate/redact_egress_test.go
+++ b/internal/investigate/redact_egress_test.go
@@ -20,13 +20,16 @@ func TestRedactInvestigation(t *testing.T) {
 			SuggestedAction: "rotate key AKIAIOSFODNN7EXAMPLE",
 		}},
 		Unresolved: []string{"DB_SECRET=s3cr3t-value-xyz seen in events"},
-		Actions:    []providers.Action{{Description: "suspend (OPENAI_API_KEY=sk-abcdefghijklmnopqrst)"}},
+		Actions: []providers.Action{{
+			Name:        "suspend (password=hunter2horse)", // buildInvestigation copies the description into Name
+			Description: "suspend (OPENAI_API_KEY=sk-abcdefghijklmnopqrst)",
+		}},
 	}
 	redactInvestigation(inv)
 
 	blob := strings.Join([]string{
 		inv.Title, inv.RootCauses[0].Summary, inv.RootCauses[0].Evidence[0],
-		inv.RootCauses[0].SuggestedAction, inv.Unresolved[0], inv.Actions[0].Description,
+		inv.RootCauses[0].SuggestedAction, inv.Unresolved[0], inv.Actions[0].Name, inv.Actions[0].Description,
 	}, "|")
 	for _, secret := range []string{
 		"hunter2horse", "ghp_0123456789abcdefghijABCDEFGHIJ0123", "xoxb-123456789012-abcdefuvwxyz",


### PR DESCRIPTION
## Problem

Audit question: does `GET /actions` (internal/server/server.go:169-180) ever serve un-redacted secret material from the approvals queue?

## Analysis

The **ordering** is safe: `deliver()` runs `redactInvestigation(&inv)` (internal/investigate/loop.go:490) **before** `OnComplete(inv)` (loop.go:495), and the only `Approvals.Register` call site sits inside `OnComplete` (internal/app/investigate.go:297) — so the queue receives post-redaction copies.

But the regression test written to lock that in caught a **different, real gap**: `buildInvestigation` copies the model-authored description into `Action.Name` (internal/investigate/tools.go:199), while `redactInvestigation` only scrubbed `Action.Description` (loop.go:515-517). `GET /actions` JSON-encodes the whole `providers.Action`, so a secret quoted into a proposed action leaked verbatim through the `Name` field:

```
"Name":"suspend web; logs showed password=hunter2horse",
"Description":"suspend web; logs showed password=[REDACTED]"
```

## Fix

Redact `Name` alongside `Description` at the existing egress chokepoint (`redactInvestigation`) — narrowest seam, no double-redaction, covers every downstream consumer of `deliver()` (approvals queue, /actions, Slack, KB PRs). `Target` is deliberately untouched: it is the Kubernetes resource identifier the executor acts on, not free text.

## Tests

- `TestApprovalQueueServesRedactedActions` (new, internal/investigate/redact_approvals_test.go): end-to-end wiring test — fake model proposes an envelope-compliant action whose description carries a secret; asserts the copy registered in the real `action.Approvals` queue is redacted **and** the real `GET /actions` handler response contains no secret. Written first (TDD); failed on `Name` before the fix. Also locks in the redact-before-OnComplete ordering.
- `TestRedactInvestigation` extended to cover `Action.Name`.

Quality gate: `go build && go vet && go test ./... && gofmt -l . && golangci-lint run` all clean (0 issues).