### PR TITLE
fix(investigate): anchor token budget estimate to provider-reported usage

### DIFF
--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -1,6 +1,10 @@
 package investigate
 
-import "github.com/Smana/runlore/internal/providers"
+import (
+	"math"
+
+	"github.com/Smana/runlore/internal/providers"
+)
 
 // budgetKillResult synthesises an unresolved investigation for use when the
 // token-budget hard-kill fires (nudge fired, model did not submit findings in time).
@@ -51,11 +55,12 @@ func refusalResult(req Request) providers.Investigation {
 // tool-call JSON (m.ToolCalls[].Args), which also goes over the wire. Counting
 // only m.Content systematically under-estimated a tool-heavy investigation,
 // letting the hard-kill guard fire late or never. This estimate drives the
-// PRE-request budget guard, so it cannot use provider-reported usage (which only
-// exists post-response, on CompletionResponse.Usage); the loop records real
-// counts separately. Still an under-estimate of the true wire size (it ignores
-// JSON envelope/role overhead) but now the right order of magnitude, which is
-// what the hard-kill needs.
+// PRE-request budget guard, so by itself it cannot use provider-reported usage
+// (which only exists post-response, on CompletionResponse.Usage) — that is
+// tokenCalibration's job: it scales this heuristic by the actual/heuristic ratio
+// observed on the previous completion. Uncalibrated, this remains an
+// under-estimate of the true wire size (it ignores JSON envelope/role overhead)
+// but the right order of magnitude, which is what the hard-kill needs.
 func estimateTokens(system string, msgs []providers.Message, tools []providers.ToolSpec) int {
 	n := len(system)
 	for _, t := range tools {
@@ -68,6 +73,60 @@ func estimateTokens(system string, msgs []providers.Message, tools []providers.T
 		}
 	}
 	return n / 4
+}
+
+// tokenCalibration anchors the chars/4 pre-request heuristic to reality: after
+// each completion whose provider reported usage, it records the ratio between the
+// actual prompt size (Usage.InputTokens, which includes cached tokens) and the
+// heuristic estimate computed for that same request, then scales subsequent
+// estimates by it. A ratio survives compaction and append-only growth alike
+// because it captures the heuristic's systematic bias (tokenizer density, JSON
+// envelope/role overhead), not an absolute context size. The zero value is
+// uncalibrated: estimates fall back to the pure heuristic, so providers that
+// never report usage behave exactly as before.
+type tokenCalibration struct {
+	// ratio is actual InputTokens ÷ heuristic estimate from the most recent
+	// completion that reported usage; 0 means uncalibrated. Floored at 1 on
+	// observe, so the anchored estimate is never below the raw heuristic and the
+	// budget guard can only fire EARLIER than uncalibrated, never later.
+	ratio float64
+}
+
+// observe records the actual/heuristic ratio for a completed request: heuristic
+// is estimateTokens computed for the request as sent, usage is the provider's
+// report for it. Zero usage (provider didn't report) or a non-positive heuristic
+// leaves the calibration unchanged.
+func (c *tokenCalibration) observe(heuristic int, usage providers.Usage) {
+	if heuristic <= 0 || usage.InputTokens <= 0 {
+		return
+	}
+	r := float64(usage.InputTokens) / float64(heuristic)
+	if r < 1 {
+		r = 1 // safety floor: never estimate below the raw heuristic
+	}
+	c.ratio = r
+}
+
+// estimate returns the usage-anchored request-size estimate: estimateTokens
+// scaled (rounded up) by the last observed actual/heuristic ratio. Uncalibrated,
+// it is exactly the raw heuristic.
+func (c *tokenCalibration) estimate(system string, msgs []providers.Message, tools []providers.ToolSpec) int {
+	est := estimateTokens(system, msgs, tools)
+	if c.ratio > 1 {
+		est = int(math.Ceil(float64(est) * c.ratio))
+	}
+	return est
+}
+
+// heuristicTarget converts a token target expressed in anchored (real) tokens
+// into the raw-heuristic space that compactHistory measures in, so a calibrated
+// loop compacts down to a real target rather than an under-counted one.
+// Uncalibrated, the target passes through unchanged.
+func (c *tokenCalibration) heuristicTarget(target int) int {
+	if c.ratio > 1 {
+		return int(float64(target) / c.ratio)
+	}
+	return target
 }
 
 // overBudget reports whether est exceeds budget. budget <= 0 means unlimited.

--- a/internal/investigate/budget_test.go
+++ b/internal/investigate/budget_test.go
@@ -1,6 +1,7 @@
 package investigate
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -43,6 +44,77 @@ func TestEstimateTokensCountsToolCallArgsAndSpecs(t *testing.T) {
 	}
 	if got <= oldSum {
 		t.Fatalf("estimate (%d) should exceed old content-only sum (%d)", got, oldSum)
+	}
+}
+
+// TestTokenCalibrationEstimate proves the budget estimate is anchored to
+// provider-reported usage: once a completion reports its real InputTokens, the
+// next estimate is the chars/4 heuristic scaled by actual/heuristic. Zero usage
+// (provider didn't report) falls back to the pure heuristic, and the ratio is
+// floored at 1 so the anchored estimate is never BELOW the raw heuristic — the
+// budget guard can only fire earlier than uncalibrated, never later.
+func TestTokenCalibrationEstimate(t *testing.T) {
+	sys := "sys!"                                                                  // 4 chars
+	msgs := []providers.Message{{Role: "user", Content: strings.Repeat("x", 396)}} // 396 chars
+	const raw = 100                                                                // (4+396)/4
+	if got := estimateTokens(sys, msgs, nil); got != raw {
+		t.Fatalf("raw heuristic sanity: got %d, want %d", got, raw)
+	}
+
+	type obs struct {
+		heuristic int
+		usage     providers.Usage
+	}
+	tests := []struct {
+		name     string
+		observed []obs
+		want     int
+	}{
+		{name: "uncalibrated falls back to the pure heuristic", observed: nil, want: raw},
+		{name: "zero usage (provider did not report) leaves the heuristic",
+			observed: []obs{{heuristic: 100, usage: providers.Usage{}}}, want: raw},
+		{name: "zero heuristic is ignored (no divide-by-zero, no calibration)",
+			observed: []obs{{heuristic: 0, usage: providers.Usage{InputTokens: 500}}}, want: raw},
+		{name: "reported usage scales the next estimate (ratio 1.5)",
+			observed: []obs{{heuristic: 100, usage: providers.Usage{InputTokens: 150}}}, want: 150},
+		{name: "fractional ratio rounds up, never down",
+			observed: []obs{{heuristic: 100, usage: providers.Usage{InputTokens: 101}}}, want: 101},
+		{name: "ratio floored at 1: anchored estimate is never below the heuristic",
+			observed: []obs{{heuristic: 200, usage: providers.Usage{InputTokens: 100}}}, want: raw},
+		{name: "latest observation wins (recalibrates each completion)",
+			observed: []obs{
+				{heuristic: 100, usage: providers.Usage{InputTokens: 300}},
+				{heuristic: 100, usage: providers.Usage{InputTokens: 150}},
+			}, want: 150},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c tokenCalibration
+			for _, o := range tt.observed {
+				c.observe(o.heuristic, o.usage)
+			}
+			if got := c.estimate(sys, msgs, nil); got != tt.want {
+				t.Fatalf("estimate: got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTokenCalibrationHeuristicTarget proves the compaction target is converted
+// into raw-heuristic space (compactHistory measures with estimateTokens), so a
+// calibrated loop compacts down to a REAL 0.7×budget, not a heuristic one.
+func TestTokenCalibrationHeuristicTarget(t *testing.T) {
+	var c tokenCalibration
+	if got := c.heuristicTarget(700); got != 700 {
+		t.Fatalf("uncalibrated target must pass through: got %d, want 700", got)
+	}
+	c.observe(100, providers.Usage{InputTokens: 200}) // ratio 2
+	if got := c.heuristicTarget(700); got != 350 {
+		t.Fatalf("ratio-2 target: got %d, want 350", got)
+	}
+	c.observe(100, providers.Usage{InputTokens: 50}) // ratio floored at 1
+	if got := c.heuristicTarget(700); got != 700 {
+		t.Fatalf("floored-ratio target must pass through: got %d, want 700", got)
 	}
 }
 

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -1,7 +1,10 @@
 // Package investigate routes triggers (incident alerts, GitOps failures) into a
-// single async investigation queue. The investigation itself is pluggable via
-// Investigator; LogInvestigator is the read-only placeholder until the ReAct loop
-// lands.
+// single async investigation queue and runs them. The investigation itself is
+// pluggable via Investigator: LoopInvestigator (loop.go) is the real
+// implementation — a ReAct loop that drives a ModelProvider with tools, feeds
+// tool results back, and delivers a providers.Investigation when the model calls
+// submit_findings — while LogInvestigator remains the read-only fallback used
+// when no model is configured.
 package investigate
 
 import (
@@ -70,8 +73,9 @@ type Investigator interface {
 	Investigate(ctx context.Context, r Request) error
 }
 
-// LogInvestigator is the read-only placeholder: it logs the request it would
-// investigate. Replaced by the ReAct loop in a later phase.
+// LogInvestigator is the read-only fallback used when no model is configured:
+// it logs the request it would investigate and does nothing else. The real
+// investigation is LoopInvestigator.
 type LogInvestigator struct {
 	Log *slog.Logger
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -229,24 +229,29 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		maxSteps = 20
 	}
 
-	nudged := false           // set when the prose-turn nudge has fired once
-	budgetNudged := false     // set when the token-budget nudge has fired once
-	truncationNudged := false // set when the output-truncation nudge has fired once
-	compactionLogged := false // set when the one-time compaction log has fired
-	used := map[string]int{}  // tool-call counts, logged so investigation breadth is observable
-	sys := li.system()        // constant for the investigation; build once, not per step
+	nudged := false            // set when the prose-turn nudge has fired once
+	budgetNudged := false      // set when the token-budget nudge has fired once
+	truncationNudged := false  // set when the output-truncation nudge has fired once
+	compactionLogged := false  // set when the one-time compaction log has fired
+	used := map[string]int{}   // tool-call counts, logged so investigation breadth is observable
+	sys := li.system()         // constant for the investigation; build once, not per step
+	var calib tokenCalibration // anchors the chars/4 heuristic to provider-reported usage
 	for step := 0; step < maxSteps; step++ {
 		// Budget control: when the estimated request size exceeds the configured ceiling,
 		// inject a one-time nudge asking the model to wrap up. If the model did not wind
 		// down and the estimate is still over budget on the next step, hard-kill: deliver
-		// whatever findings exist rather than growing context unbounded.
-		est := estimateTokens(sys, messages, specs)
+		// whatever findings exist rather than growing context unbounded. The estimate is
+		// the chars/4 heuristic anchored to the previous completion's reported usage
+		// (calib); providers that report no usage fall back to the pure heuristic.
+		est := calib.estimate(sys, messages, specs)
 		// Mid-loop compaction: before the budget guard, elide superseded/old tool outputs
 		// to stay under budget so a long investigation can finish instead of hard-killing.
+		// The target is converted into raw-heuristic space (compactHistory measures with
+		// estimateTokens) so a calibrated loop compacts down to a REAL 0.7×budget.
 		if target := compactionTarget(li.MaxTokensPerInvestigation); target > 0 && est > target {
-			if compacted, elided := compactHistory(messages, sys, specs, target); elided > 0 {
+			if compacted, elided := compactHistory(messages, sys, specs, calib.heuristicTarget(target)); elided > 0 {
 				messages = compacted
-				est = estimateTokens(sys, messages, specs)
+				est = calib.estimate(sys, messages, specs)
 				if !compactionLogged {
 					li.Log.Info("compacted investigation history to bound context",
 						"title", req.Title, "elided_bytes", elided, "estimate_tokens", est)
@@ -276,6 +281,10 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				return nil
 			}
 		}
+		// Raw heuristic for the request about to be sent (messages may have grown since
+		// est was computed — e.g. the budget nudge); paired with resp.Usage below to
+		// calibrate the next step's estimate.
+		reqHeuristic := estimateTokens(sys, messages, specs)
 		mstart := time.Now()
 		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: sys, Messages: messages, Tools: specs})
 		if li.Metrics != nil {
@@ -310,6 +319,10 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			result = "error"
 			return fmt.Errorf("model: %w", err)
 		}
+		// Anchor subsequent budget estimates to reality: the provider just reported the
+		// true input size for the request we estimated as reqHeuristic. Zero usage
+		// (provider didn't report) is a no-op — the pure heuristic keeps driving the guard.
+		calib.observe(reqHeuristic, resp.Usage)
 		li.Log.Debug("investigation step", "title", req.Title, "step", step, "tool_calls", len(resp.ToolCalls), "text_len", len(resp.Text))
 		// The provider declined the turn (a safety/refusal stop reason): deliver a
 		// first-class unresolved result rather than misreading the empty response as a
@@ -383,7 +396,8 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				inv.TriggerKey = req.TriggerKey     // deterministic dedup key stamped at trigger time (#137)
 				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 				if li.Metrics != nil {
-					li.Metrics.InvestigationTokens.Record(ctx, int64(estimateTokens(sys, messages, specs)))
+					// Usage-anchored when the provider reported usage; heuristic otherwise.
+					li.Metrics.InvestigationTokens.Record(ctx, int64(calib.estimate(sys, messages, specs)))
 				}
 				if li.Verify {
 					inv = li.verifyFindings(ctx, req, inv)

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -868,6 +868,64 @@ func TestLoopHardKillDisabledWhenNoBudget(t *testing.T) {
 	}
 }
 
+// reportingRunawayModel is a runaway model (never submits findings) whose
+// completions REPORT provider usage far above the chars/4 heuristic — the
+// real-world shape when tool schemas, JSON envelope and tokenizer density make
+// the wire size much larger than the character count suggests.
+type reportingRunawayModel struct {
+	calls       int
+	inputTokens int
+}
+
+func (m *reportingRunawayModel) Complete(context.Context, providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	return providers.CompletionResponse{
+		ToolCalls: []providers.ToolCall{{ID: "u", Name: "noop_tool", Args: `{}`}},
+		Usage:     providers.Usage{InputTokens: m.inputTokens, OutputTokens: 10},
+	}, nil
+}
+
+// TestLoopBudgetAnchorsToReportedUsage verifies the budget guard is grounded in
+// provider-reported usage, not just chars/4: the message history stays tiny (the
+// heuristic alone would never cross the budget, so the pure-heuristic loop runs
+// to maxSteps), but the provider reports 400k real input tokens per request — so
+// after the first completion the anchored estimate must trip the nudge, and the
+// next over-budget check must hard-kill.
+func TestLoopBudgetAnchorsToReportedUsage(t *testing.T) {
+	model := &reportingRunawayModel{inputTokens: 400_000}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     model,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  50,
+		MaxTokensPerInvestigation: 50_000, // far above the heuristic, far below the reported usage
+		OnComplete: func(inv providers.Investigation) {
+			got = &inv
+		},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "usage-anchored", Fingerprint: "fp-usage"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	// Step 0: uncalibrated, heuristic under budget → model call 1 reports usage.
+	// Step 1: anchored estimate over budget → nudge → model call 2.
+	// Step 2: still over budget → hard-kill, no further model calls.
+	if model.calls != 2 {
+		t.Fatalf("expected exactly 2 model calls (nudge then hard-kill), got %d — the guard did not anchor to reported usage", model.calls)
+	}
+	if got == nil {
+		t.Fatal("OnComplete never called: hard-kill must deliver an unresolved result")
+	}
+	foundBudget := false
+	for _, u := range got.Unresolved {
+		if strings.Contains(u, "budget") {
+			foundBudget = true
+		}
+	}
+	if !foundBudget {
+		t.Fatalf("Unresolved entry must mention 'budget'; got: %v", got.Unresolved)
+	}
+}
+
 func TestInstantRecallUnconfirmedLowersConfidence(t *testing.T) {
 	// A recall hit with NO confirm tools available → confidence is capped at
 	// recallUnconfirmedCap before delivery.


### PR DESCRIPTION
## Problem

The token-budget guard in the ReAct loop was driven purely by a ~4-chars/token heuristic (`estimateTokens`), self-described as an under-estimate of the true wire size. On tokenizer-dense or envelope-heavy investigations the real prompt could be several times the estimate, so `max_tokens_per_investigation` fired late or never — while the provider was already reporting the true `InputTokens` on every completion, used only for metrics.

## Design

**Calibration ratio** (`tokenCalibration` in `internal/investigate/budget.go`): after each completion whose provider reported usage, record `ratio = actual InputTokens / heuristic estimate of that same request`, then scale subsequent pre-request estimates by it. Chosen over an absolute anchor (`lastInputTokens + delta`) because a ratio captures the heuristic's *systematic bias* (tokenizer density, JSON envelope/role overhead) rather than an absolute context size — it stays correct across mid-loop compaction (which shrinks the real prompt) and append-only growth alike.

Safety and fallback:
- **Ratio floored at 1** — the anchored estimate is never below the raw heuristic, so the guard can only fire *earlier* than before, never later.
- **Zero `Usage` is a no-op** — providers that don't report usage keep the pure-heuristic behaviour exactly as before.
- The mid-loop **compaction target is converted into raw-heuristic space** (`heuristicTarget`), so a calibrated loop compacts down to a real 0.7×budget instead of an under-counted one.
- Contained to `internal/investigate` (budget.go, loop.go); no change to the providers contract or model clients.

**Budget semantics unchanged.** `max_tokens_per_investigation` is documented as "a hard token ceiling" (ambiguous about cumulative spend vs context size), but the implementation — and the mid-loop-compaction design that depends on it — treat it as a per-request context-size ceiling. Kept as-is: prior output tokens are already part of the next request's input (assistant turns live in the history), and compaction only makes sense against a context-size budget. Cumulative-spend accounting would be a deliberate semantics change, out of scope here.

Also rewrites the stale `internal/investigate` package doc: `LoopInvestigator` is the real ReAct implementation; `LogInvestigator` is the read-only no-model fallback, not a "placeholder until the ReAct loop lands".

## Testing

TDD — failing tests first:
- `TestTokenCalibrationEstimate` (table-driven): uncalibrated fallback, zero-usage no-op, zero-heuristic guard, scaling, round-up, ratio floor, latest-observation-wins.
- `TestTokenCalibrationHeuristicTarget`: compaction-target conversion incl. floor.
- `TestLoopBudgetAnchorsToReportedUsage`: tiny history (heuristic would never trip the budget → pure-heuristic loop runs to maxSteps) but reported usage of 400k vs a 50k budget → exactly 2 model calls (nudge, then hard-kill) with an unresolved budget result.
- Existing zero-usage budget/compaction tests pass unchanged, proving the fallback path.

Quality gate: `go build && go vet && go test ./...` all green, `gofmt -l` clean, `golangci-lint run` 0 issues.