### PR TITLE
feat(model): support forcing a tool via ToolChoice

### DIFF
--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -69,7 +69,39 @@ Score each rubric dimension as an integer in [0, max]:
 - description (max 3): clarity, completeness, honest about what is unresolved.
 - calibration (max 2): high confidence only when correct; penalise confident-and-wrong hardest.
 Set confident_wrong=true if the result states a wrong root cause with confidence >= 0.7.
-Reply with ONLY a JSON object: {"scores":{"root_cause":N,"evidence":N,"solution":N,"description":N,"calibration":N},"confident_wrong":bool,"rationale":"..."}.`
+Record your grade by calling the submit_grade tool exactly once. If you cannot call tools, reply with
+ONLY a JSON object: {"scores":{"root_cause":N,"evidence":N,"solution":N,"description":N,"calibration":N},"confident_wrong":bool,"rationale":"..."}.`
+
+const submitGradeName = "submit_grade"
+
+// submitGradeSpec is the structured-output tool for the judge. Its schema is
+// generated from Rubric so the rubric and the tool contract cannot drift, and it
+// mirrors the Verdict struct so the tool args unmarshal directly into a Verdict.
+func submitGradeSpec() providers.ToolSpec {
+	scoreProps := map[string]any{}
+	keys := make([]string, 0, len(Rubric))
+	for _, d := range Rubric {
+		scoreProps[d.Key] = map[string]any{"type": "integer", "minimum": 0, "maximum": d.Max}
+		keys = append(keys, d.Key)
+	}
+	schema, err := json.Marshal(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"scores":          map[string]any{"type": "object", "properties": scoreProps, "required": keys},
+			"confident_wrong": map[string]any{"type": "boolean"},
+			"rationale":       map[string]any{"type": "string"},
+		},
+		"required": []string{"scores", "confident_wrong", "rationale"},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("marshal submit_grade schema: %v", err)) // static input; unreachable
+	}
+	return providers.ToolSpec{
+		Name:        submitGradeName,
+		Description: "Record the rubric grade for the investigation.",
+		Schema:      string(schema),
+	}
+}
 
 // Grade builds a blind grading prompt and parses the JSON verdict.
 func (j ModelJudge) Grade(ctx context.Context, scn Scenario, inv providers.Investigation) (Verdict, error) {
@@ -84,10 +116,30 @@ INVESTIGATION RESULT
 	resp, err := j.Model.Complete(ctx, providers.CompletionRequest{
 		System:   judgeSystem,
 		Messages: []providers.Message{{Role: "user", Content: user}},
+		Tools:    []providers.ToolSpec{submitGradeSpec()},
+		// Force the grade through the tool so the verdict arrives as schema-shaped
+		// args instead of free text that needs brace-slicing out of prose.
+		ToolChoice: submitGradeName,
 	})
 	if err != nil {
 		return Verdict{}, fmt.Errorf("judge model: %w", err)
 	}
+	for _, tc := range resp.ToolCalls {
+		if tc.Name != submitGradeName {
+			continue
+		}
+		var v Verdict
+		if err := json.Unmarshal([]byte(tc.Args), &v); err != nil {
+			return Verdict{}, fmt.Errorf("parse submit_grade args %q: %w", tc.Args, err)
+		}
+		if v.Scores == nil {
+			v.Scores = map[string]int{}
+		}
+		return v, nil
+	}
+	// Fallback ONLY when the response carries no submit_grade tool call: weak
+	// OpenAI-compatible judges sometimes ignore a forced tool_choice and reply in
+	// prose, so the legacy first-'{'..last-'}' text parser is kept for them.
 	v, err := parseVerdict(resp.Text)
 	if err != nil {
 		return Verdict{}, fmt.Errorf("parse verdict from %q: %w", resp.Text, err)

--- a/internal/eval/judge_test.go
+++ b/internal/eval/judge_test.go
@@ -8,11 +8,15 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// jsonModel returns a fixed Text payload, and records the request it saw.
+// jsonModel returns a fixed reply (a submit_grade tool call when toolArgs is set,
+// free text otherwise), and records the request it saw.
 type jsonModel struct {
-	reply     string
-	gotSystem string
-	gotUser   string
+	reply         string
+	toolArgs      string
+	gotSystem     string
+	gotUser       string
+	gotTools      []string
+	gotToolChoice string
 }
 
 func (m *jsonModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
@@ -20,9 +24,49 @@ func (m *jsonModel) Complete(_ context.Context, req providers.CompletionRequest)
 	for _, msg := range req.Messages {
 		m.gotUser += msg.Content
 	}
+	for _, tool := range req.Tools {
+		m.gotTools = append(m.gotTools, tool.Name)
+	}
+	m.gotToolChoice = req.ToolChoice
+	if m.toolArgs != "" {
+		return providers.CompletionResponse{ToolCalls: []providers.ToolCall{{ID: "g1", Name: submitGradeName, Args: m.toolArgs}}}, nil
+	}
 	return providers.CompletionResponse{Text: m.reply}, nil
 }
 
+// TestModelJudgeForcedToolCall asserts the judge is a forced tool call: the
+// request offers submit_grade and forces it via ToolChoice, and the verdict is
+// parsed from the tool-call args (not from free text).
+func TestModelJudgeForcedToolCall(t *testing.T) {
+	m := &jsonModel{toolArgs: `{"scores":{"root_cause":3,"evidence":2,"solution":2,"description":3,"calibration":2},"confident_wrong":false,"rationale":"correct + deep"}`}
+	j := ModelJudge{Model: m}
+	scn := Scenario{ID: "x", GroundTruth: GroundTruth{RootCause: "valkey down", ExpectedAction: "restart valkey"}}
+	inv := providers.Investigation{Title: "Harbor down", Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{Summary: "valkey refused", SuggestedAction: "restart valkey"}}}
+	v, err := j.Grade(context.Background(), scn, inv)
+	if err != nil {
+		t.Fatalf("Grade: %v", err)
+	}
+	if v.Scores["root_cause"] != 3 || v.Total() != 12 || v.ConfidentWrong {
+		t.Fatalf("verdict parse from tool args: %+v", v)
+	}
+	if m.gotToolChoice != submitGradeName {
+		t.Fatalf("judge must force %q, got ToolChoice=%q", submitGradeName, m.gotToolChoice)
+	}
+	offered := false
+	for _, n := range m.gotTools {
+		if n == submitGradeName {
+			offered = true
+		}
+	}
+	if !offered {
+		t.Fatalf("submit_grade tool was not offered; got %v", m.gotTools)
+	}
+}
+
+// TestModelJudgeParsesVerdict covers the free-text FALLBACK: a weak
+// OpenAI-compatible judge that ignores the forced tool call and replies in prose
+// still yields a verdict via the brace-slice parser.
 func TestModelJudgeParsesVerdict(t *testing.T) {
 	m := &jsonModel{reply: "prefix junk\n" + `{"scores":{"root_cause":3,"evidence":2,"solution":2,"description":3,"calibration":2},"confident_wrong":false,"rationale":"correct + deep"}` + "\ntrailing"}
 	j := ModelJudge{Model: m}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -231,6 +231,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 
 	nudged := false           // set when the prose-turn nudge has fired once
 	budgetNudged := false     // set when the token-budget nudge has fired once
+	toolChoice := ""          // forced tool for every remaining request; set (sticky) when the budget nudge fires
 	truncationNudged := false // set when the output-truncation nudge has fired once
 	compactionLogged := false // set when the one-time compaction log has fired
 	used := map[string]int{}  // tool-call counts, logged so investigation breadth is observable
@@ -262,6 +263,12 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			if !budgetNudged {
 				messages = append(messages, providers.Message{Role: "user", Content: budgetNudge})
 				budgetNudged = true
+				// From here on, force submit_findings on every remaining request: the
+				// model has been told to wrap up, so it must conclude — it may not
+				// ramble in prose or keep calling investigation tools. Normal loop
+				// steps (before the nudge) keep ToolChoice empty so the model stays
+				// free to pick tools or answer.
+				toolChoice = submitFindingsName
 			} else {
 				// Hard-kill: nudge already fired but the model is still over budget.
 				li.Log.Warn("investigation hard-stopped at token budget",
@@ -277,7 +284,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			}
 		}
 		mstart := time.Now()
-		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: sys, Messages: messages, Tools: specs})
+		resp, err := li.Model.Complete(ctx, providers.CompletionRequest{System: sys, Messages: messages, Tools: specs, ToolChoice: toolChoice})
 		if li.Metrics != nil {
 			mres := "ok"
 			if err != nil {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
@@ -238,13 +239,16 @@ func TestLoopInconclusiveAfterNudge(t *testing.T) {
 	}
 }
 
-// scriptModel returns a fixed sequence of responses, ignoring its input.
+// scriptModel returns a fixed sequence of responses, recording every request it
+// saw (so tests can assert what was sent, e.g. a forced ToolChoice).
 type scriptModel struct {
 	responses []providers.CompletionResponse
+	reqs      []providers.CompletionRequest
 	i         int
 }
 
-func (m *scriptModel) Complete(context.Context, providers.CompletionRequest) (providers.CompletionResponse, error) {
+func (m *scriptModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.reqs = append(m.reqs, req)
 	r := m.responses[m.i]
 	m.i++
 	return r, nil
@@ -843,6 +847,53 @@ func TestLoopHardKillOnBudgetExhaustion(t *testing.T) {
 	// Fingerprint must be propagated for outcome-ledger attribution.
 	if got.Fingerprint != "fp-kill" {
 		t.Fatalf("expected fingerprint %q, got %q", "fp-kill", got.Fingerprint)
+	}
+}
+
+// TestBudgetNudgeForcesSubmitFindings verifies the budget nudge's ToolChoice
+// contract: normal loop steps send an empty ToolChoice (the model chooses freely
+// between investigation tools and prose), and once the token-budget nudge fires
+// every subsequent request forces submit_findings so the model cannot ramble
+// instead of concluding.
+func TestBudgetNudgeForcesSubmitFindings(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		// step 0 (under budget): the model keeps investigating.
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: "noop_tool", Args: `{}`}}},
+		// step 1 (over budget, nudge fired, forced): it submits findings.
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: submitFindingsName, Args: `{"confidence":0.5,"root_causes":[{"summary":"x","confidence":0.5}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   10,
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	// Budget = exactly the step-0 estimate (overBudget is a strict >), so step 0 is
+	// unforced and step 1 — grown by the assistant turn and the tool result — trips
+	// the nudge.
+	req := Request{Title: "budget-forcing"}
+	seed := []providers.Message{{Role: "user", Content: redact.Secrets(seedPrompt(req))}}
+	li.MaxTokensPerInvestigation = estimateTokens(li.system(), seed, []providers.ToolSpec{submitFindingsSpec()})
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil || len(got.RootCauses) != 1 {
+		t.Fatalf("expected the forced submit_findings to be delivered, got %+v", got)
+	}
+	if len(model.reqs) != 2 {
+		t.Fatalf("expected 2 model calls (normal + forced), got %d", len(model.reqs))
+	}
+	if model.reqs[0].ToolChoice != "" {
+		t.Fatalf("normal loop step must not force a tool, got ToolChoice=%q", model.reqs[0].ToolChoice)
+	}
+	if model.reqs[1].ToolChoice != submitFindingsName {
+		t.Fatalf("post-nudge step must force %q, got ToolChoice=%q", submitFindingsName, model.reqs[1].ToolChoice)
+	}
+	// The nudge message itself must also have been injected.
+	last := model.reqs[1].Messages[len(model.reqs[1].Messages)-1]
+	if !strings.Contains(last.Content, "token budget") {
+		t.Fatalf("budget nudge message missing; last message: %+v", last)
 	}
 }
 

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -75,6 +75,9 @@ func (li *LoopInvestigator) verifyFindings(ctx context.Context, req Request, inv
 		System:   verifyPrompt,
 		Messages: []providers.Message{{Role: "user", Content: renderForReview(req, inv)}},
 		Tools:    []providers.ToolSpec{submitVerdictsSpec()},
+		// Force the tool: a reviewer that answers in prose silently skips the
+		// honesty check (no verdicts ⇒ findings pass through unreviewed).
+		ToolChoice: submitVerdictsName,
 	})
 	if err != nil {
 		li.Log.Warn("verify pass failed; keeping findings as-is", "title", req.Title, "err", err)

--- a/internal/investigate/verify_test.go
+++ b/internal/investigate/verify_test.go
@@ -55,6 +55,34 @@ func TestVerifyRejectsCorrelationFinding(t *testing.T) {
 	}
 }
 
+// TestVerifyForcesSubmitVerdicts asserts the adversarial pass forces the model to
+// call submit_verdicts (ToolChoice) — a reviewer that rambles in prose instead of
+// recording verdicts silently skips the honesty check, so prose is never allowed.
+func TestVerifyForcesSubmitVerdicts(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName, Args: `{"confidence":0.8,"root_causes":[{"summary":"oom","confidence":0.8,"evidence":["OOMKilled"]}]}`}}},
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"keep"}]}`}}},
+	}}
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Verify:     true,
+		OnComplete: func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(model.reqs) != 2 {
+		t.Fatalf("expected 2 model calls (loop + verify), got %d", len(model.reqs))
+	}
+	if model.reqs[0].ToolChoice != "" {
+		t.Fatalf("the investigation step must not force a tool, got ToolChoice=%q", model.reqs[0].ToolChoice)
+	}
+	if model.reqs[1].ToolChoice != submitVerdictsName {
+		t.Fatalf("verify pass must force %q, got ToolChoice=%q", submitVerdictsName, model.reqs[1].ToolChoice)
+	}
+}
+
 // TestApplyVerdictsClampsConfidence checks that an out-of-range verdict
 // confidence from the verify pass is clamped to [0,1] before it is applied to a
 // root cause's score — on both the keep and downgrade branches — and that the

--- a/internal/kbvalidate/semantic.go
+++ b/internal/kbvalidate/semantic.go
@@ -70,6 +70,9 @@ func ReviewSemantic(ctx context.Context, e catalog.Entry, m providers.ModelProvi
 		System:   reviewSystemPrompt,
 		Messages: []providers.Message{{Role: "user", Content: renderEntry(e)}},
 		Tools:    []providers.ToolSpec{submitReviewSpec()},
+		// Force the tool: a prose reply degrades to Skipped (no advisory), so the
+		// model must record its review through submit_review, not text.
+		ToolChoice: submitReviewName,
 	})
 	if err != nil {
 		return Advisory{Skipped: true}, fmt.Errorf("semantic review: %w", err)

--- a/internal/kbvalidate/semantic_test.go
+++ b/internal/kbvalidate/semantic_test.go
@@ -9,15 +9,17 @@ import (
 )
 
 type fakeModel struct {
-	resp     providers.CompletionResponse
-	err      error
-	gotTools []string
+	resp          providers.CompletionResponse
+	err           error
+	gotTools      []string
+	gotToolChoice string
 }
 
 func (f *fakeModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
 	for _, t := range req.Tools {
 		f.gotTools = append(f.gotTools, t.Name)
 	}
+	f.gotToolChoice = req.ToolChoice
 	return f.resp, f.err
 }
 
@@ -71,5 +73,18 @@ func TestReviewSemanticCauseMismatch(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("submit_review tool was not offered; got %v", m.gotTools)
+	}
+}
+
+// TestReviewSemanticForcesSubmitReview asserts the semantic review forces the
+// model to call submit_review (ToolChoice) — a prose reply degrades to Skipped,
+// so the tool call must be forced rather than merely suggested.
+func TestReviewSemanticForcesSubmitReview(t *testing.T) {
+	m := &fakeModel{resp: reviewCall(`{"cause_explains_symptom":{"ok":true,"rationale":"r"},"durable":{"ok":true,"rationale":"r"}}`)}
+	if _, err := ReviewSemantic(context.Background(), validIncident(), m); err != nil {
+		t.Fatalf("ReviewSemantic: %v", err)
+	}
+	if m.gotToolChoice != submitReviewName {
+		t.Fatalf("semantic review must force %q, got ToolChoice=%q", submitReviewName, m.gotToolChoice)
 	}
 }

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -82,12 +82,22 @@ type systemBlock struct {
 }
 
 type msgRequest struct {
-	Model     string        `json:"model"`
-	MaxTokens int           `json:"max_tokens"`
-	Stream    bool          `json:"stream"`
-	System    []systemBlock `json:"system,omitempty"`
-	Messages  []message     `json:"messages"`
-	Tools     []tool        `json:"tools,omitempty"`
+	Model      string        `json:"model"`
+	MaxTokens  int           `json:"max_tokens"`
+	Stream     bool          `json:"stream"`
+	System     []systemBlock `json:"system,omitempty"`
+	Messages   []message     `json:"messages"`
+	Tools      []tool        `json:"tools,omitempty"`
+	ToolChoice *toolChoice   `json:"tool_choice,omitempty"`
+}
+
+// toolChoice forces the model to call one named tool this turn
+// ({"type":"tool","name":...}). Omitted (nil) = auto: the model chooses freely.
+// tool_choice sits below the tools/system cache tiers, so varying it per request
+// does not invalidate the tools+system prompt-cache prefix.
+type toolChoice struct {
+	Type string `json:"type"` // "tool"
+	Name string `json:"name"`
 }
 
 type message struct {
@@ -172,6 +182,9 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		}
 	}
 	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Stream: true, Messages: msgs}
+	if req.ToolChoice != "" {
+		areq.ToolChoice = &toolChoice{Type: "tool", Name: req.ToolChoice}
+	}
 	if req.System != "" {
 		areq.System = []systemBlock{{Type: "text", Text: req.System, CacheControl: ephemeral}}
 	}

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -504,6 +504,61 @@ func TestUsageCacheFields(t *testing.T) {
 	}
 }
 
+// TestToolChoice asserts CompletionRequest.ToolChoice maps to Anthropic's forced
+// tool_choice — {"type":"tool","name":"<name>"} — and that an empty ToolChoice
+// omits the field entirely (provider default: auto).
+func TestToolChoice(t *testing.T) {
+	events := []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":1}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	}
+	cases := []struct {
+		name   string
+		choice string
+	}{
+		{"forced tool", "submit_verdicts"},
+		{"empty omits the field", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body []byte
+			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
+			defer srv.Close()
+
+			_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+				Messages:   []providers.Message{{Role: "user", Content: "hi"}},
+				Tools:      []providers.ToolSpec{{Name: "submit_verdicts", Description: "d", Schema: `{"type":"object"}`}},
+				ToolChoice: tc.choice,
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			var got struct {
+				ToolChoice *struct {
+					Type string `json:"type"`
+					Name string `json:"name"`
+				} `json:"tool_choice"`
+			}
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if tc.choice == "" {
+				if got.ToolChoice != nil {
+					t.Fatalf("tool_choice must be omitted when unset, got %+v", got.ToolChoice)
+				}
+				if strings.Contains(string(body), "tool_choice") {
+					t.Fatalf("request body must not carry a tool_choice key when unset: %s", body)
+				}
+				return
+			}
+			if got.ToolChoice == nil || got.ToolChoice.Type != "tool" || got.ToolChoice.Name != tc.choice {
+				t.Fatalf(`tool_choice = %+v, want {"type":"tool","name":%q}`, got.ToolChoice, tc.choice)
+			}
+		})
+	}
+}
+
 // TestPromptCacheToolsOnly verifies that with no system prompt, the tools array
 // still gets exactly one cache breakpoint — on the LAST tool, not every tool.
 func TestPromptCacheToolsOnly(t *testing.T) {

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -80,7 +80,22 @@ type genRequest struct {
 	SystemInstruction *content          `json:"system_instruction,omitempty"`
 	Contents          []content         `json:"contents"`
 	Tools             []tool            `json:"tools,omitempty"`
+	ToolConfig        *toolConfig       `json:"toolConfig,omitempty"`
 	GenerationConfig  *generationConfig `json:"generationConfig,omitempty"`
+}
+
+// toolConfig carries Gemini's function-calling controls. RunLore only emits it to
+// FORCE a tool: mode ANY restricted to a single allowed function name. Omitted
+// (nil) = AUTO: the model chooses freely between prose and any declared function.
+// It is only ever set on single-shot structured-output requests, so the loop's
+// append-only prefix stability (implicit caching) is unaffected.
+type toolConfig struct {
+	FunctionCallingConfig functionCallingConfig `json:"functionCallingConfig"`
+}
+
+type functionCallingConfig struct {
+	Mode                 string   `json:"mode"` // "ANY" = the model MUST call a function
+	AllowedFunctionNames []string `json:"allowedFunctionNames,omitempty"`
 }
 
 // generationConfig carries per-request decoding controls. MaxOutputTokens caps the
@@ -165,6 +180,11 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 			decls = append(decls, functionDeclaration{Name: t.Name, Description: t.Description, Parameters: json.RawMessage(t.Schema)})
 		}
 		greq.Tools = []tool{{FunctionDeclarations: decls}}
+	}
+	if req.ToolChoice != "" {
+		greq.ToolConfig = &toolConfig{FunctionCallingConfig: functionCallingConfig{
+			Mode: "ANY", AllowedFunctionNames: []string{req.ToolChoice},
+		}}
 	}
 	body, err := json.Marshal(greq)
 	if err != nil {

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -213,6 +213,63 @@ func TestComplete(t *testing.T) {
 	}
 }
 
+// TestToolChoice asserts CompletionRequest.ToolChoice maps to Gemini's forced
+// function calling — toolConfig.functionCallingConfig with mode ANY and the tool
+// name in allowedFunctionNames — and that an empty ToolChoice omits toolConfig
+// entirely (provider default: AUTO).
+func TestToolChoice(t *testing.T) {
+	events := []string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"finishReason":"STOP"}]}` + "\n\n",
+	}
+	cases := []struct {
+		name   string
+		choice string
+	}{
+		{"forced tool", "submit_verdicts"},
+		{"empty omits toolConfig", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body []byte
+			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
+			defer srv.Close()
+
+			_, err := New(srv.URL, "gemini-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+				Messages:   []providers.Message{{Role: "user", Content: "hi"}},
+				Tools:      []providers.ToolSpec{{Name: "submit_verdicts", Description: "d", Schema: `{"type":"object"}`}},
+				ToolChoice: tc.choice,
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			var got struct {
+				ToolConfig *struct {
+					FunctionCallingConfig struct {
+						Mode                 string   `json:"mode"`
+						AllowedFunctionNames []string `json:"allowedFunctionNames"`
+					} `json:"functionCallingConfig"`
+				} `json:"toolConfig"`
+			}
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if tc.choice == "" {
+				if got.ToolConfig != nil {
+					t.Fatalf("toolConfig must be omitted when unset, got %+v", got.ToolConfig)
+				}
+				if strings.Contains(string(body), "toolConfig") {
+					t.Fatalf("request body must not carry a toolConfig key when unset: %s", body)
+				}
+				return
+			}
+			if got.ToolConfig == nil || got.ToolConfig.FunctionCallingConfig.Mode != "ANY" ||
+				!reflect.DeepEqual(got.ToolConfig.FunctionCallingConfig.AllowedFunctionNames, []string{tc.choice}) {
+				t.Fatalf(`toolConfig = %+v, want functionCallingConfig{mode:"ANY", allowedFunctionNames:[%q]}`, got.ToolConfig, tc.choice)
+			}
+		})
+	}
+}
+
 // TestTruncation verifies a finishReason of "MAX_TOKENS" flags Truncated and that the
 // last usageMetadata wins across chunks.
 func TestTruncation(t *testing.T) {

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -60,9 +60,22 @@ type chatRequest struct {
 	Tools     []chatTool `json:"tools,omitempty"`
 	MaxTokens int        `json:"max_tokens,omitempty"`
 	Stream    bool       `json:"stream"`
+	// ToolChoice forces the model to call one named function this turn
+	// ({"type":"function","function":{"name":...}}). Omitted (nil) = auto.
+	ToolChoice *toolChoice `json:"tool_choice,omitempty"`
 	// StreamOptions asks the server to emit a trailing usage-only chunk on a streamed
 	// response (omitted otherwise, since a non-streaming request rejects it).
 	StreamOptions *streamOptions `json:"stream_options,omitempty"`
+}
+
+// toolChoice is the forced-function form of the chat-completions tool_choice.
+type toolChoice struct {
+	Type     string             `json:"type"` // "function"
+	Function toolChoiceFunction `json:"function"`
+}
+
+type toolChoiceFunction struct {
+	Name string `json:"name"`
 }
 
 // streamOptions toggles streaming extras; include_usage adds a final chunk whose
@@ -187,14 +200,18 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 		}})
 	}
 
-	body, err := json.Marshal(chatRequest{
+	creq := chatRequest{
 		Model:         c.model,
 		Messages:      msgs,
 		Tools:         tools,
 		MaxTokens:     c.maxTokens,
 		Stream:        true,
 		StreamOptions: &streamOptions{IncludeUsage: true},
-	})
+	}
+	if req.ToolChoice != "" {
+		creq.ToolChoice = &toolChoice{Type: "function", Function: toolChoiceFunction{Name: req.ToolChoice}}
+	}
+	body, err := json.Marshal(creq)
 	if err != nil {
 		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
 	}

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -221,6 +221,62 @@ func TestComplete(t *testing.T) {
 	}
 }
 
+// TestToolChoice asserts CompletionRequest.ToolChoice maps to the OpenAI forced
+// tool_choice — {"type":"function","function":{"name":"<name>"}} — and that an
+// empty ToolChoice omits the field entirely (provider default: auto).
+func TestToolChoice(t *testing.T) {
+	events := []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	cases := []struct {
+		name   string
+		choice string
+	}{
+		{"forced tool", "submit_verdicts"},
+		{"empty omits the field", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body []byte
+			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
+			defer srv.Close()
+
+			_, err := New(srv.URL, "test-model", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+				Messages:   []providers.Message{{Role: "user", Content: "hi"}},
+				Tools:      []providers.ToolSpec{{Name: "submit_verdicts", Description: "d", Schema: `{"type":"object"}`}},
+				ToolChoice: tc.choice,
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			var got struct {
+				ToolChoice *struct {
+					Type     string `json:"type"`
+					Function struct {
+						Name string `json:"name"`
+					} `json:"function"`
+				} `json:"tool_choice"`
+			}
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if tc.choice == "" {
+				if got.ToolChoice != nil {
+					t.Fatalf("tool_choice must be omitted when unset, got %+v", got.ToolChoice)
+				}
+				if strings.Contains(string(body), "tool_choice") {
+					t.Fatalf("request body must not carry a tool_choice key when unset: %s", body)
+				}
+				return
+			}
+			if got.ToolChoice == nil || got.ToolChoice.Type != "function" || got.ToolChoice.Function.Name != tc.choice {
+				t.Fatalf(`tool_choice = %+v, want {"type":"function","function":{"name":%q}}`, got.ToolChoice, tc.choice)
+			}
+		})
+	}
+}
+
 // TestTruncation verifies a finish_reason of "length" flags Truncated while the
 // content accumulated so far is preserved.
 func TestTruncation(t *testing.T) {

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -404,6 +404,13 @@ type CompletionRequest struct {
 	System   string
 	Messages []Message
 	Tools    []ToolSpec
+	// ToolChoice optionally names one tool from Tools that the model MUST call on
+	// this turn ("" = provider default: the model chooses freely between prose and
+	// any tool). Set it on structured-output turns — submit_verdicts, submit_review,
+	// submit_grade, and the post-budget-nudge submit_findings — where a prose reply
+	// is never acceptable; leave it empty on normal investigation steps so the model
+	// keeps the freedom to pick tools or answer.
+	ToolChoice string
 }
 
 // Message is one turn in an LLM exchange.


### PR DESCRIPTION
## Problem

Structured-output turns rely on prompt nudging today: verify expects `submit_verdicts`, kbvalidate expects `submit_review`, the loop nudges toward `submit_findings` when over budget, and the eval judge slices free-text JSON out of prose (first-`{` to last-`}`). A model that answers in prose silently skips the verify honesty check, degrades the semantic review to "skipped", rambles past the token budget into a hard-kill, or breaks the judge parser.

## Design

- `providers.CompletionRequest` gains `ToolChoice string`: `""` = provider default (auto); a tool name = the model MUST call that tool. Doc-commented on the contract.
- Wire mapping per client:
  - **Anthropic**: `"tool_choice": {"type": "tool", "name": "<name>"}` (below the tools/system cache tiers, so per-request variation keeps the prompt-cache prefix intact)
  - **OpenAI-compatible**: `"tool_choice": {"type": "function", "function": {"name": "<name>"}}`
  - **Gemini**: top-level `"toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["<name>"]}}` — only emitted when forcing, so the loop's append-only prefix stability (implicit caching) is unaffected
  - Empty `ToolChoice` omits the field entirely (today's behavior).
- Call sites:
  - **verify.go** forces `submit_verdicts`
  - **kbvalidate/semantic.go** forces `submit_review`
  - **loop.go**: once the token-budget nudge fires, every remaining request forces `submit_findings` (sticky) so the model concludes instead of rambling; normal loop steps keep `ToolChoice` empty — the model needs freedom to pick investigation tools or answer
  - **eval/judge.go**: the judge becomes a forced `submit_grade` tool call whose schema is generated from `Rubric` (no drift) and unmarshals directly into `Verdict`; the brace-slice text parser survives ONLY as a fallback for weak OpenAI-compatible judges that ignore a forced tool_choice

## Testing

TDD (all new tests written first, red, then wired green):
- Per-client httptest asserting the exact `tool_choice`/`toolConfig` JSON emitted — and its complete absence when unset (anthropic/openai/gemini `TestToolChoice`)
- Call-site tests: `TestVerifyForcesSubmitVerdicts`, `TestReviewSemanticForcesSubmitReview`, `TestBudgetNudgeForcesSubmitFindings` (asserts normal step = empty, post-nudge = forced), `TestModelJudgeForcedToolCall` + fallback coverage
- Quality gate: `go build && go vet && go test ./... && gofmt -l . && golangci-lint run` — all clean

## Dependency

Originally stacked on #195 (`fix/model-permanent-4xx-errors`), which merged while this was in flight — the branch includes its commit and is based directly on `main`.