### PR TITLE
feat(model): configurable effort/reasoning knob (anthropic, openai)

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -106,6 +106,10 @@ config:
   #   base_url: https://vllm.svc/v1
   #   model: <model-name>
   #   api_key_env: OPENAI_API_KEY
+  #   # Opt-in reasoning depth: anthropic low|medium|high|max, openai-compatible
+  #   # minimal|low|medium|high; unsupported for gemini; empty = omitted (default).
+  #   # A model that doesn't support the knob returns a 400, classified permanent.
+  #   effort: high
   #   # Route the adversarial verify pass to a cheaper/faster model to cut the
   #   # +1-call-per-investigation cost (inherits the fields above unless overridden;
   #   # omit to verify with the main model). Verify always runs — this only lowers cost.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,12 @@ recall decay; **must be on the PVC** to compound (see [Upgrade & Uninstall](upgr
 ### `model` — the LLM provider
 `provider` — `openai` (default; any OpenAI-compatible endpoint incl. vLLM/Ollama/OpenRouter) ·
 `anthropic` · `gemini`. `base_url`, `model`, `api_key_env`. Optional `verify` (a separate model for the
-adversarial verify pass) and `embeddings` (for hybrid recall).
+adversarial verify pass) and `embeddings` (for hybrid recall). Optional `effort` opts into deeper
+reasoning per request — `anthropic`: `low`·`medium`·`high`·`max` (sent as `output_config.effort`);
+`openai`: `minimal`·`low`·`medium`·`high` (sent as `reasoning_effort`); not supported for `gemini`
+(rejected at startup); empty = omitted (default). Models that don't support the knob return a 400,
+which is classified permanent (dropped, not retried). `verify.effort` overrides the parent's value,
+inheriting it when empty like the other verify fields.
 
 ### `forge` — the Git host for curation
 `kb_repo` (`owner/name`), `base_branch` (default `main`), `github_api_url` (default

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -38,22 +38,26 @@ func verifyMaxTokens(cfg *config.Config) int {
 }
 
 // NewModelClient builds a ModelProvider for a wire protocol + endpoint. maxTokens
-// is the per-request output-token ceiling passed through to the provider.
-func NewModelClient(provider, baseURL, model, apiKey string, maxTokens int) providers.ModelProvider {
+// is the per-request output-token ceiling passed through to the provider. effort
+// is the opt-in reasoning knob (config-validated per provider; "" = omitted);
+// gemini does not take it — config.Validate rejects effort for that provider.
+func NewModelClient(provider, baseURL, model, apiKey string, maxTokens int, effort string) providers.ModelProvider {
 	switch provider {
 	case "anthropic":
-		return anthropic.New(baseURL, model, apiKey, maxTokens)
+		return anthropic.New(baseURL, model, apiKey, maxTokens, effort)
 	case "gemini":
 		return gemini.New(baseURL, model, apiKey, maxTokens)
 	default:
-		return openai.New(baseURL, model, apiKey, maxTokens)
+		return openai.New(baseURL, model, apiKey, maxTokens, effort)
 	}
 }
 
 // BuildModel builds the ModelProvider for the configured provider, applying the
-// effective output-token cap (model.max_tokens, defaulted when unset).
+// effective output-token cap (model.max_tokens, defaulted when unset) and the
+// opt-in effort knob.
 func BuildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
-	return NewModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey, effectiveMaxTokens(cfg.Model.MaxTokens))
+	return NewModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey,
+		effectiveMaxTokens(cfg.Model.MaxTokens), cfg.Model.Effort)
 }
 
 // BuildVerifyModel builds the optional cheaper model for the adversarial verify
@@ -75,7 +79,8 @@ func BuildVerifyModel(cfg *config.Config) providers.ModelProvider {
 		apiKey = os.Getenv(keyEnv)
 	}
 	return NewModelClient(or(v.Provider, cfg.Model.Provider),
-		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey, verifyMaxTokens(cfg))
+		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey,
+		verifyMaxTokens(cfg), or(v.Effort, cfg.Model.Effort))
 }
 
 // BuildJudgeModel builds the (stronger) grader model from --judge-* flags, falling
@@ -88,6 +93,8 @@ func BuildJudgeModel(cfg *config.Config, provider, baseURL, model, apiKeyEnv str
 		}
 		return BuildModel(cfg, apiKey)
 	}
-	// A judge gets the same effective output cap as the main model (no separate knob).
-	return NewModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens))
+	// A judge gets the same effective output cap as the main model (no separate
+	// knob), but NOT the configured effort: model.effort was validated against the
+	// configured provider, and a --judge-* flag set may target a different one.
+	return NewModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens), "")
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -76,7 +76,7 @@ func TestNewModelClient(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.provider, func(t *testing.T) {
-			client := NewModelClient(tc.provider, "http://endpoint/v1", "test-model", "key", defaultMaxTokens)
+			client := NewModelClient(tc.provider, "http://endpoint/v1", "test-model", "key", defaultMaxTokens, "")
 			if client == nil {
 				t.Fatalf("NewModelClient(%q) returned nil", tc.provider)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -276,6 +276,14 @@ type Model struct {
 	// 8192 default. Streaming providers send it (Anthropic max_tokens, OpenAI
 	// max_tokens, Gemini generationConfig.maxOutputTokens); a too-low value truncates.
 	MaxTokens int `yaml:"max_tokens"`
+	// Effort opts into deeper model reasoning per request. Provider-specific
+	// vocabulary, validated at startup: anthropic low|medium|high|max (sent as
+	// output_config.effort), openai minimal|low|medium|high (sent as
+	// reasoning_effort). Empty = omitted from requests (today's behavior). Not
+	// supported for provider gemini (its thinkingConfig has replay semantics —
+	// thought signatures — the provider-agnostic history can't carry). Models that
+	// don't support the knob return a 400, which is classified permanent.
+	Effort string `yaml:"effort"`
 	// Verify optionally routes the adversarial verify pass to a cheaper/faster model;
 	// unset fields inherit from the parent above (so `verify: {model: <cheap>}` reuses
 	// the same provider/endpoint/key). Absent ⇒ verify runs on the main model.
@@ -304,6 +312,9 @@ type ModelOverride struct {
 	// MaxTokens overrides the parent's effective output-token cap for the verify pass;
 	// 0 inherits the parent's effective value.
 	MaxTokens int `yaml:"max_tokens"`
+	// Effort overrides the parent's effort for the verify pass; empty inherits the
+	// parent's value (same vocabulary and validation as model.effort).
+	Effort string `yaml:"effort"`
 }
 
 // Notify configures where investigation findings are delivered.
@@ -573,6 +584,43 @@ func checkSecureKeyEndpoint(urlField, keyField, baseURL, apiKeyEnv string) error
 	}
 }
 
+// effortLevels is the per-provider vocabulary of the opt-in model.effort knob.
+// Unknown provider names use the "openai" set (NewModelClient routes them to the
+// OpenAI-compatible client). Gemini is deliberately absent: its thinkingConfig has
+// replay semantics (thought signatures) the provider-agnostic message history
+// can't carry, so effort is rejected there rather than half-supported.
+var effortLevels = map[string]map[string]bool{
+	"anthropic": {"low": true, "medium": true, "high": true, "max": true},
+	"openai":    {"minimal": true, "low": true, "medium": true, "high": true},
+}
+
+// validateEffort checks an effective (provider, effort) pair against the
+// per-provider vocabulary. Empty effort is always valid (the knob is opt-in and
+// omitted from requests); an empty provider defaults to the OpenAI-compatible
+// wire protocol, mirroring NewModelClient.
+func validateEffort(field, provider, effort string) error {
+	if effort == "" {
+		return nil
+	}
+	if provider == "gemini" {
+		return fmt.Errorf("%s: effort is not supported for provider gemini yet", field)
+	}
+	levels, ok := effortLevels[provider]
+	if !ok {
+		levels = effortLevels["openai"] // "", vllm, ollama, … → OpenAI-compatible client
+	}
+	if !levels[effort] {
+		valid := make([]string, 0, len(levels))
+		for l := range levels {
+			valid = append(valid, l)
+		}
+		slices.Sort(valid)
+		return fmt.Errorf("%s: %q is not a valid effort for this provider (valid: %s, or empty to omit)",
+			field, effort, strings.Join(valid, "|"))
+	}
+	return nil
+}
+
 // Validate enforces cross-field invariants after loading — fail-closed defaults
 // for the autonomy ladder: enabling execution requires the controls that bound
 // it. Returns an error that should abort startup.
@@ -584,6 +632,27 @@ func (c *Config) Validate() error {
 	}
 	if c.Model.Verify != nil && c.Model.Verify.MaxTokens < 0 {
 		return fmt.Errorf("model.verify.max_tokens must be >= 0 (0 = inherit), got %d", c.Model.Verify.MaxTokens)
+	}
+	// Effort is validated against the provider it will actually be sent to. The
+	// verify override resolves its EFFECTIVE provider and effort first (inherit-
+	// when-empty, mirroring BuildVerifyModel's or() semantics), so an inherited
+	// parent effort that is invalid for the override's provider fails at startup
+	// rather than as a per-request 400.
+	if err := validateEffort("model.effort", c.Model.Provider, c.Model.Effort); err != nil {
+		return err
+	}
+	if v := c.Model.Verify; v != nil {
+		prov := v.Provider
+		if prov == "" {
+			prov = c.Model.Provider
+		}
+		eff := v.Effort
+		if eff == "" {
+			eff = c.Model.Effort
+		}
+		if err := validateEffort("model.verify.effort (or inherited model.effort)", prov, eff); err != nil {
+			return err
+		}
 	}
 	// Reject a negative per-tool timeout: time.ParseDuration accepts negative values
 	// which silently disable the feature (fails the > 0 guard in runTool) rather than

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -204,6 +205,69 @@ func TestValidateRejectsNegativeMaxTokens(t *testing.T) {
 	ok := &Config{Model: Model{Provider: "anthropic", MaxTokens: 0, Verify: &ModelOverride{MaxTokens: 4096}}}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("non-negative max_tokens must validate clean: %v", err)
+	}
+}
+
+// TestValidateEffort locks in the per-provider effort vocabulary: anthropic
+// low|medium|high|max, openai (and any OpenAI-compatible/unknown provider)
+// minimal|low|medium|high, gemini rejected outright, and empty always fine
+// (effort is opt-in — unset keeps today's requests unchanged). The verify
+// override validates against its EFFECTIVE provider and effort (inherit-when-
+// empty, mirroring BuildVerifyModel).
+func TestValidateEffort(t *testing.T) {
+	cases := []struct {
+		name    string
+		model   Model
+		wantErr string // "" = must validate clean; otherwise a substring of the error
+	}{
+		{"empty effort is fine", Model{Provider: "anthropic"}, ""},
+		{"anthropic low", Model{Provider: "anthropic", Effort: "low"}, ""},
+		{"anthropic medium", Model{Provider: "anthropic", Effort: "medium"}, ""},
+		{"anthropic high", Model{Provider: "anthropic", Effort: "high"}, ""},
+		{"anthropic max", Model{Provider: "anthropic", Effort: "max"}, ""},
+		{"anthropic rejects minimal", Model{Provider: "anthropic", Effort: "minimal"}, "model.effort"},
+		{"openai minimal", Model{Provider: "openai", Effort: "minimal"}, ""},
+		{"openai high", Model{Provider: "openai", Effort: "high"}, ""},
+		{"openai rejects max", Model{Provider: "openai", Effort: "max"}, "model.effort"},
+		{"empty provider defaults to openai vocabulary", Model{Effort: "minimal"}, ""},
+		{"unknown provider uses the openai vocabulary", Model{Provider: "vllm", Effort: "low"}, ""},
+		{"gemini rejects effort", Model{Provider: "gemini", Effort: "low"}, "not supported for provider gemini"},
+		{"gemini without effort is fine", Model{Provider: "gemini"}, ""},
+		{
+			"verify override inherits the parent effort and provider",
+			Model{Provider: "anthropic", Effort: "max", Verify: &ModelOverride{Model: "cheap"}},
+			"",
+		},
+		{
+			"verify override effort validated against its own vocabulary",
+			Model{Provider: "anthropic", Verify: &ModelOverride{Effort: "minimal"}},
+			"model.verify.effort",
+		},
+		{
+			"inherited parent effort invalid for the override provider",
+			Model{Provider: "anthropic", Effort: "max", Verify: &ModelOverride{Provider: "openai"}},
+			"model.verify.effort",
+		},
+		{
+			"verify override to gemini rejects an inherited effort",
+			Model{Provider: "anthropic", Effort: "high", Verify: &ModelOverride{Provider: "gemini"}},
+			"not supported for provider gemini",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{Model: tc.model}
+			err := c.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() = %v, want an error containing %q", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -40,12 +40,15 @@ type Client struct {
 	model     string
 	apiKey    string
 	maxTokens int
+	effort    string
 	http      *http.Client
 }
 
 // New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
 // maxTokens caps output tokens per request; <= 0 falls back to defaultMaxTokens.
-func New(baseURL, model, apiKey string, maxTokens int) *Client {
+// effort opts into deeper reasoning (output_config.effort: low|medium|high|max,
+// validated in config); empty omits the field entirely.
+func New(baseURL, model, apiKey string, maxTokens int, effort string) *Client {
 	if baseURL == "" {
 		baseURL = DefaultBaseURL
 	}
@@ -57,6 +60,7 @@ func New(baseURL, model, apiKey string, maxTokens int) *Client {
 		model:     model,
 		apiKey:    apiKey,
 		maxTokens: maxTokens,
+		effort:    effort,
 		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
 	}
 }
@@ -82,13 +86,24 @@ type systemBlock struct {
 }
 
 type msgRequest struct {
-	Model      string        `json:"model"`
-	MaxTokens  int           `json:"max_tokens"`
-	Stream     bool          `json:"stream"`
-	System     []systemBlock `json:"system,omitempty"`
-	Messages   []message     `json:"messages"`
-	Tools      []tool        `json:"tools,omitempty"`
-	ToolChoice *toolChoice   `json:"tool_choice,omitempty"`
+	Model        string        `json:"model"`
+	MaxTokens    int           `json:"max_tokens"`
+	Stream       bool          `json:"stream"`
+	System       []systemBlock `json:"system,omitempty"`
+	Messages     []message     `json:"messages"`
+	Tools        []tool        `json:"tools,omitempty"`
+	ToolChoice   *toolChoice   `json:"tool_choice,omitempty"`
+	OutputConfig *outputConfig `json:"output_config,omitempty"`
+}
+
+// outputConfig carries Anthropic's output-level controls; RunLore only sets the
+// effort level. The thinking param is deliberately NOT enabled alongside it:
+// adaptive thinking in a multi-turn tool loop requires replaying signed thinking
+// blocks verbatim on every subsequent request, which the provider-agnostic message
+// history (providers.Message) cannot carry — explicitly out of scope here. effort
+// is constant per client, so the prompt-cache prefix stays stable across steps.
+type outputConfig struct {
+	Effort string `json:"effort"`
 }
 
 // toolChoice forces the model to call one named tool this turn
@@ -184,6 +199,9 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Stream: true, Messages: msgs}
 	if req.ToolChoice != "" {
 		areq.ToolChoice = &toolChoice{Type: "tool", Name: req.ToolChoice}
+	}
+	if c.effort != "" {
+		areq.OutputConfig = &outputConfig{Effort: c.effort}
 	}
 	if req.System != "" {
 		areq.System = []systemBlock{{Type: "text", Text: req.System, CacheControl: ephemeral}}

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -47,7 +47,7 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -122,7 +122,7 @@ func TestNon2xxPermanence(t *testing.T) {
 				w.WriteHeader(tc.code)
 			}))
 			defer srv.Close()
-			_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+			_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err == nil {
@@ -194,7 +194,7 @@ data: {"type":"message_stop"}
 	})
 	defer srv.Close()
 
-	c := New(srv.URL, "claude-x", "k", 16384)
+	c := New(srv.URL, "claude-x", "k", 16384, "")
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -280,7 +280,7 @@ data: {"type":"message_stop"}
 `,
 			})
 			defer srv.Close()
-			resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+			resp, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err != nil {
@@ -320,7 +320,7 @@ data: {"type":"message_stop"}
 `,
 	})
 	defer srv.Close()
-	resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	resp, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err != nil {
@@ -359,7 +359,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -397,7 +397,7 @@ data: {"type":"message_stop"}
 	})
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "investigate"},
 			{Role: "assistant", ToolCalls: []providers.ToolCall{
@@ -439,7 +439,7 @@ func TestPromptCacheHistoryBreakpoint(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		System: "sys",
 		Messages: []providers.Message{
 			{Role: "user", Content: "incident"},
@@ -493,7 +493,7 @@ func TestUsageCacheFields(t *testing.T) {
 		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
 	})
 	defer srv.Close()
-	resp, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	resp, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err != nil {
@@ -526,7 +526,7 @@ func TestToolChoice(t *testing.T) {
 			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
 			defer srv.Close()
 
-			_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+			_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 				Messages:   []providers.Message{{Role: "user", Content: "hi"}},
 				Tools:      []providers.ToolSpec{{Name: "submit_verdicts", Description: "d", Schema: `{"type":"object"}`}},
 				ToolChoice: tc.choice,
@@ -554,6 +554,65 @@ func TestToolChoice(t *testing.T) {
 			}
 			if got.ToolChoice == nil || got.ToolChoice.Type != "tool" || got.ToolChoice.Name != tc.choice {
 				t.Fatalf(`tool_choice = %+v, want {"type":"tool","name":%q}`, got.ToolChoice, tc.choice)
+			}
+		})
+	}
+}
+
+// TestEffort asserts a configured effort maps to Anthropic's
+// {"output_config":{"effort":"<level>"}} — and that an empty effort omits the
+// field entirely (today's requests, unchanged).
+func TestEffort(t *testing.T) {
+	events := []string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":1}}}\n\n",
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	}
+	cases := []struct {
+		name   string
+		effort string
+	}{
+		{"effort set", "high"},
+		{"empty omits the field", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body []byte
+			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
+			defer srv.Close()
+
+			_, err := New(srv.URL, "claude-x", "k", 0, tc.effort).Complete(context.Background(), providers.CompletionRequest{
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			var got struct {
+				OutputConfig *struct {
+					Effort string `json:"effort"`
+				} `json:"output_config"`
+				Thinking json.RawMessage `json:"thinking"`
+			}
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			// effort must never drag a thinking param along: adaptive thinking in a
+			// multi-turn tool loop needs signed thinking-block replay, which the
+			// provider-agnostic history can't carry.
+			if got.Thinking != nil {
+				t.Fatalf("request must not carry a thinking param, got %s", got.Thinking)
+			}
+			if tc.effort == "" {
+				if got.OutputConfig != nil {
+					t.Fatalf("output_config must be omitted when effort is unset, got %+v", got.OutputConfig)
+				}
+				if strings.Contains(string(body), "output_config") {
+					t.Fatalf("request body must not carry an output_config key when effort is unset: %s", body)
+				}
+				return
+			}
+			if got.OutputConfig == nil || got.OutputConfig.Effort != tc.effort {
+				t.Fatalf(`output_config = %+v, want {"effort":%q}`, got.OutputConfig, tc.effort)
 			}
 		})
 	}
@@ -589,7 +648,7 @@ data: {"type":"message_stop"}
 	})
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 		Tools: []providers.ToolSpec{
 			{Name: "a", Description: "d", Schema: `{"type":"object"}`},

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -34,12 +34,15 @@ type Client struct {
 	model     string
 	apiKey    string
 	maxTokens int
+	effort    string
 	http      *http.Client
 }
 
 // New builds a client. apiKey may be empty (keyless vLLM/Ollama). maxTokens caps
-// output tokens per request; <= 0 falls back to defaultMaxTokens.
-func New(baseURL, model, apiKey string, maxTokens int) *Client {
+// output tokens per request; <= 0 falls back to defaultMaxTokens. effort opts into
+// deeper reasoning (reasoning_effort: minimal|low|medium|high, validated in
+// config); empty omits the field entirely.
+func New(baseURL, model, apiKey string, maxTokens int, effort string) *Client {
 	if maxTokens <= 0 {
 		maxTokens = defaultMaxTokens
 	}
@@ -48,6 +51,7 @@ func New(baseURL, model, apiKey string, maxTokens int) *Client {
 		model:     model,
 		apiKey:    apiKey,
 		maxTokens: maxTokens,
+		effort:    effort,
 		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
 	}
 }
@@ -63,6 +67,10 @@ type chatRequest struct {
 	// ToolChoice forces the model to call one named function this turn
 	// ({"type":"function","function":{"name":...}}). Omitted (nil) = auto.
 	ToolChoice *toolChoice `json:"tool_choice,omitempty"`
+	// ReasoningEffort opts into deeper reasoning on models that support it
+	// (minimal|low|medium|high). Empty = omitted; a model that rejects the knob
+	// returns a 400, which Complete classifies permanent.
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
 	// StreamOptions asks the server to emit a trailing usage-only chunk on a streamed
 	// response (omitted otherwise, since a non-streaming request rejects it).
 	StreamOptions *streamOptions `json:"stream_options,omitempty"`
@@ -201,12 +209,13 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	}
 
 	creq := chatRequest{
-		Model:         c.model,
-		Messages:      msgs,
-		Tools:         tools,
-		MaxTokens:     c.maxTokens,
-		Stream:        true,
-		StreamOptions: &streamOptions{IncludeUsage: true},
+		Model:           c.model,
+		Messages:        msgs,
+		Tools:           tools,
+		MaxTokens:       c.maxTokens,
+		Stream:          true,
+		StreamOptions:   &streamOptions{IncludeUsage: true},
+		ReasoningEffort: c.effort,
 	}
 	if req.ToolChoice != "" {
 		creq.ToolChoice = &toolChoice{Type: "function", Function: toolChoiceFunction{Name: req.ToolChoice}}

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -63,7 +63,7 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "test-model", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "test-model", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -139,7 +139,7 @@ func TestNon2xxPermanence(t *testing.T) {
 				w.WriteHeader(tc.code)
 			}))
 			defer srv.Close()
-			_, err := New(srv.URL, "test-model", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+			_, err := New(srv.URL, "test-model", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err == nil {
@@ -175,7 +175,7 @@ func TestComplete(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := New(srv.URL, "test-model", "k", 16384)
+	c := New(srv.URL, "test-model", "k", 16384, "")
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -242,7 +242,7 @@ func TestToolChoice(t *testing.T) {
 			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
 			defer srv.Close()
 
-			_, err := New(srv.URL, "test-model", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+			_, err := New(srv.URL, "test-model", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 				Messages:   []providers.Message{{Role: "user", Content: "hi"}},
 				Tools:      []providers.ToolSpec{{Name: "submit_verdicts", Description: "d", Schema: `{"type":"object"}`}},
 				ToolChoice: tc.choice,
@@ -277,6 +277,55 @@ func TestToolChoice(t *testing.T) {
 	}
 }
 
+// TestEffort asserts a configured effort maps to the chat-completions
+// "reasoning_effort" field — and that an empty effort omits the field entirely
+// (today's requests, unchanged).
+func TestEffort(t *testing.T) {
+	events := []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	cases := []struct {
+		name   string
+		effort string
+	}{
+		{"effort set", "minimal"},
+		{"empty omits the field", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body []byte
+			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
+			defer srv.Close()
+
+			_, err := New(srv.URL, "test-model", "k", 0, tc.effort).Complete(context.Background(), providers.CompletionRequest{
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			var got struct {
+				ReasoningEffort *string `json:"reasoning_effort"`
+			}
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("decode request body: %v", err)
+			}
+			if tc.effort == "" {
+				if got.ReasoningEffort != nil {
+					t.Fatalf("reasoning_effort must be omitted when unset, got %q", *got.ReasoningEffort)
+				}
+				if strings.Contains(string(body), "reasoning_effort") {
+					t.Fatalf("request body must not carry a reasoning_effort key when unset: %s", body)
+				}
+				return
+			}
+			if got.ReasoningEffort == nil || *got.ReasoningEffort != tc.effort {
+				t.Fatalf("reasoning_effort = %v, want %q", got.ReasoningEffort, tc.effort)
+			}
+		})
+	}
+}
+
 // TestTruncation verifies a finish_reason of "length" flags Truncated while the
 // content accumulated so far is preserved.
 func TestTruncation(t *testing.T) {
@@ -287,7 +336,7 @@ func TestTruncation(t *testing.T) {
 		"data: [DONE]\n\n",
 	})
 	defer srv.Close()
-	resp, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
+	resp, err := New(srv.URL, "test-model", "", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err != nil {
@@ -316,7 +365,7 @@ func TestRefusal(t *testing.T) {
 		"data: [DONE]\n\n",
 	})
 	defer srv.Close()
-	resp, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
+	resp, err := New(srv.URL, "test-model", "", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err != nil {
@@ -349,7 +398,7 @@ func TestMidStreamDrop(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "test-model", "", 0).Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "test-model", "", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -367,7 +416,7 @@ func TestUsageCachedTokens(t *testing.T) {
 		"data: [DONE]\n\n",
 	})
 	defer srv.Close()
-	resp, err := New(srv.URL, "m", "k", 0).Complete(context.Background(), providers.CompletionRequest{
+	resp, err := New(srv.URL, "m", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err != nil {
@@ -395,7 +444,7 @@ func TestEmptyToolResultKeepsContent(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := New(srv.URL, "test-model", "", 0)
+	c := New(srv.URL, "test-model", "", 0, "")
 	_, err := c.Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "investigate"},


### PR DESCRIPTION
## Problem

There is no way to trade reasoning depth against latency/cost per deployment: the clients always send provider defaults. Operators running Anthropic or OpenAI-compatible reasoning models want to opt into deeper (or shallower) reasoning without forking the client code.

## Design

An opt-in, config-driven **effort** knob:

- **Config**: `model.effort` (yaml `effort`) plus `model.verify.effort` on the verify override, which inherits the parent's value when empty — the same `or()` pattern as the other verify fields. Empty = omitted from requests (today's behavior, the default).
- **Startup validation, per provider** (`config.Validate`):
  - `anthropic`: `low|medium|high|max`
  - `openai` (and any unknown/OpenAI-compatible provider name, which routes to the OpenAI client): `minimal|low|medium|high`
  - `gemini`: **rejected** with "effort is not supported for provider gemini yet" — Gemini's thinkingConfig has replay semantics (thought signatures) the provider-agnostic message history can't carry, so it's refused rather than half-supported.
  - The verify override validates its **effective** (provider, effort) pair — inherit-when-empty resolution mirrors `BuildVerifyModel` — so an inherited parent effort that's invalid for the override's provider fails at startup instead of as per-request 400s.
- **Wire mapping** (constructor param, extending the existing `New(baseURL, model, apiKey, maxTokens)` signature):
  - **Anthropic**: `"output_config": {"effort": "<value>"}`. The `thinking` param stays absent deliberately: adaptive thinking in a multi-turn tool loop requires replaying signed thinking blocks verbatim, which the provider-agnostic history can't carry — explicitly out of scope, noted in a comment. Effort is constant per client, so the prompt-cache prefix stays stable across loop steps.
  - **OpenAI-compatible**: `"reasoning_effort": "<value>"`.
- **Wiring**: `NewModelClient`/`BuildModel`/`BuildVerifyModel` pass it through. The judge's explicit `--judge-*` flag path passes no effort (it was validated against the *configured* provider, and judge flags may target a different one); the judge fallback path goes through `BuildModel` and inherits it.
- **Failure mode**: models that don't support the knob return a 400, which the clients already classify permanent (dropped, not retried) — documented.

## Docs

- `docs/configuration.md` — `effort` in the `model` section (vocabulary, wire fields, gemini rejection, 400-is-permanent note)
- `deploy/helm/runlore/values.yaml` — `effort` in the commented model template

## Testing

TDD (red first, then green):
- Config validation table tests (`TestValidateEffort`): full per-provider vocabulary, empty-is-fine, gemini rejection, override inheritance/effective-pair cases
- Per-client httptest (`TestEffort`): exact `output_config`/`reasoning_effort` JSON emitted when set, complete absence when unset; the Anthropic test also pins that no `thinking` param is ever sent
- Quality gate: `go build && go vet && go test ./... && gofmt -l . && golangci-lint run` — all clean

## Dependency

Stacked on #199 (`feat/model-tool-choice`), which merged — this branch includes it and `origin/main` and is based directly on `main`.