### PR TITLE
feat(investigate): raise investigation dataset quality (time, attribution, dedup, seed)

### DIFF
--- a/dev/plans/2026-07-01-investigation-dataset-quality.md
+++ b/dev/plans/2026-07-01-investigation-dataset-quality.md
@@ -1,0 +1,191 @@
+# Investigation dataset quality — what the model sees, what the human reads
+
+|              |                                                                                                      |
+| ------------ | ---------------------------------------------------------------------------------------------------- |
+| **Status**   | Analysis `v1` — top findings **implemented in this branch** (marked ✅); the rest ranked as follow-ups |
+| **Date**     | 2026-07-01                                                                                            |
+| **Scope**    | The *dataset* an investigation runs on: how each tool's payload is serialized into the prompt (time, shape, magnitude, attribution, noise), what the seed prompt carries, how truncation shapes what survives, and what the delivered notification actually tells an on-call. Companion to `2026-06-27-troubleshooting-integration-analysis.md`, which covered signal *breadth* per integration — this covers signal *fidelity* end to end. |
+| **Method**   | Direct read of every render path (`internal/investigate/*_tool.go`, `query_tools.go`, `kube_tools.go`, `truncate.go`, `loop.go` seed prompt), the payload types (`internal/providers/providers.go`), the providers that populate them (`cluster/cluster.go`, `gitops/flux`, `logs/victorialogs`), the alert intake (`source/alertmanager`), and the delivery path (`notify/format.go`, `slack.go`, `matrix.go`) — cross-checked against the eval rubric and the graded baseline transcripts (`eval/reports/*`). |
+
+---
+
+## 1. Bottom line
+
+The investigation *engine* and the tool *breadth* were already audited (2026-06-27) and are solid. The
+remaining quality ceiling is the **dataset**: several renderers strip exactly the dimensions RCA needs
+— **time** and **attribution** — and the alert intake silently discards the alert's most informative
+text before the investigation even starts. The judge transcripts show where this lands: runs score
+`root_cause 2/3 — "correct but shallow … does not state that a change introduced this state"`. The
+model can't narrate "deploy at 14:02, first crash at 14:03" when no tool output contains a timestamp
+it can line up against another.
+
+Five findings dominate (all fixed in this branch):
+
+1. **Alert annotations were never parsed.** `amAlert` had no `annotations` field
+   (`source/alertmanager/alertmanager.go:27-32`), so `Request.Message` was **empty for every
+   alert-triggered investigation** — the templated description ("container X memory at 97% of limit
+   for 15m"), the summary, and `runbook_url` were all dropped at the door. The seed prompt for an
+   alert was effectively just the alertname. This was the single cheapest, highest-value fix in the
+   codebase. ✅
+2. **The model was never told when the incident started.** `Request.At` (Alertmanager `startsAt`)
+   existed but `seedPrompt` (`loop.go:535`) never rendered it — and every tool window
+   (`since_minutes`) is relative to *now*. The model could only guess how far back to look; a default
+   60m window silently misses an onset 90 minutes ago. `Request.Labels` (pod, container, instance,
+   cluster…) were equally dropped. ✅
+3. **Renderers strip time and repeat structure.** `kube_events` sorted by recency but the
+   `KubeEvent` type carried **no timestamp** — the model saw order, never *when*. `pod_logs` rendered
+   bare messages with **no timestamps at all** (`PodLogOptions.Timestamps` unset). `what_changed`
+   dropped `Change.When` even when the engine knew it. `query_metrics_range` reported `min/max` but
+   not **when** the max happened — the one fact that correlates a spike to a deploy. ✅
+4. **Noise crowds out signal under the 50-row cap.** No renderer deduplicated repeated lines: a
+   CrashLoopBackOff emits the same panic block every restart, so the 50-row budget
+   (`maxToolRows`, `query_tools.go:14`) was spent on 50 copies of one line while the *distinct*
+   second error never rendered. Log-shaped output is now grouped — each distinct message renders
+   once with `(xN, last <time>)` — so the cap counts distinct messages. ✅
+5. **The shared notification text omitted the two anchors an on-call reads first.** `notify.Format`
+   (used by Matrix, the webhook fallback, the CLI, and Slack's plain-text fallback) never named the
+   **affected resource** nor the root cause's **ChangeRef** (the latter existed only in Slack Block
+   Kit). ✅
+
+What is **already good** and was verified, not assumed: `pod_status`'s failure surface (OOM →
+memory-limit tie-in, last-termination reason/exit-code — the fix the first eval baseline forced);
+the selector-matched-nothing fallback that prevents "workload not deployed" hallucinations;
+`buildLogsQL`'s guardrail against invalid `level=` syntax; events Warning-first + most-recent-first;
+VictoriaLogs returning newest-first so the row cap keeps the *recent* lines; redaction strictly
+before truncation; and the honest empty-result strings ("no series matched", "no dropped flows")
+that keep absence-of-signal legible.
+
+---
+
+## 2. Model-facing dataset — per-source rendering audit
+
+For each source: does the rendered text preserve **time**, **shape**, **magnitude/units**, and
+**attribution** (which pod/object emitted it)?
+
+| Tool | Time | Shape | Attribution | Verdict |
+|---|---|---|---|---|
+| `what_changed` | ❌→✅ `Change.When` was dropped at render (`whatchanged_tool.go:55`); now rendered when non-zero. **Flux never sets it** (no commit timestamp — `flux.go` maps only revisions), so the fix pays off fully only with follow-up F3. | full unified diff — good | Kustomization kind/name — good | diff content good; *when* was the gap |
+| `query_metrics` | instant-at-now only (by design; description now points at the range tool) | single scalar | full label set via `formatMetric` — good | fine as the "value now" probe |
+| `query_metrics_range` | ❌→✅ `min/max` had no timestamps; now `min=1@t max=9@t` | first/last/min/max — adequate compact trend | labels — good | the spike is now *datable* |
+| `query_logs` | per-line RFC3339 — good | newest-first (VictoriaLogs orders by `_time` desc) | ⚠️ `Fields` (pod/node) dropped at render — follow-up F5 | now deduped with counts ✅ |
+| `pod_logs` | ❌→✅ no timestamps at all; now `Timestamps: true` + parsed into `LogLine.Time` | chronological tail (300/pod, ≤5 pods) | pod-name prefix — good | time was the gap; now deduped ✅ |
+| `controller_logs` | ❌→✅ same reader; now timestamped + deduped | tail | pod-name prefix — good | ✅ |
+| `pod_status` | n/a (point-in-time) | per-container reasons + last termination + memory limit — **good** | pod + container names — good | already strong; no change |
+| `kube_events` | ❌→✅ `KubeEvent` had no time field; `LastSeen` added end-to-end | most-recent-first, count-weighted (`x13`) — good | Kind/Name — good | the count existed; the *when* didn't |
+| `network_drops` | provider-dependent (`LogLine.Time`); rendered when present ✅ | drops only (breadth gap — prior doc) | message-embedded | deduped ✅ (drop storms collapse) |
+| `cloud_what_changed` | RFC3339 per event — **already good** | newest-first, capped 25 | actor (`ManagedBy`) + resource | the model to copy |
+| `gitops_resource_status` / `gitops_tree` | condition/event lines as provider renders them | Ready/reason/message + refs — good | kind/ns/name — good | no change needed |
+
+### 2.1 Truncation policy
+
+- `MaxToolOutputBytes` **defaults to 0 = unlimited** (`config.go:176`); the shipped Helm values set
+  **32 KiB** (`values.yaml:63`). One flat byte cap for heterogeneous tools.
+- `truncateOutput` (`truncate.go`) keeps **head + tail, elides the middle**. For a *diff* this is
+  reasonable (header + trailing hunks survive). For *logs* it's the wrong shape — but after this
+  branch it rarely fires on logs: dedup collapses repetition and the 50-distinct-row cap bounds log
+  output well under 32 KiB, so byte truncation is now effectively the *diff* backstop it suits.
+- The real ceiling for list-shaped output is `maxToolRows = 50`, applied *before* byte truncation.
+  Pre-dedup, 50 rows of a crash loop ≈ 1 distinct fact. Post-dedup, 50 rows ≈ 50 distinct facts —
+  the cap's information content improved by up to ~50× without raising a single limit.
+- Per-tool byte caps (bigger for `what_changed`, smaller for status tools) remain a follow-up (F2)
+  but are much less urgent now that the noisiest producers dedup.
+
+### 2.2 Time windows
+
+Defaults: logs/metrics-range/drops 60m, pod/controller logs 30m, cloud 90m — all documented in each
+schema and all **relative to now**. The seed prompt now states the incident start time, its age, and
+explicitly: *"Tool time windows (since_minutes) are relative to now — size them to cover the start
+time."* Anchoring queries at `req.At` server-side (an `around_incident=true` mode) is follow-up F8.
+
+### 2.3 Seed prompt
+
+Before: `Incident: <title> (source=…). Workload: ns/name. Reason: <severity>. Message: <empty for
+alerts>. Severity… Environment…` — and nothing else. After: the same header plus **start time + age**,
+**alert labels** (sorted `k="v"`, 300-rune value clip), and **alert annotations** (minus the one
+already promoted to Message — so `runbook_url` now reaches the model, which pairs directly with the
+system prompt's "search the KB EARLY" instruction). All of it passes through `redact.Secrets` as
+before, and stays inside the existing "UNTRUSTED DATA" framing.
+
+---
+
+## 3. Human-facing notification
+
+Read end-to-end (`format.go` → `slack.go` blocks / `matrix.go` HTML):
+
+- **Fixed ✅:** the shared `Format` text now names the **affected resource** (`Resource: HelmRelease
+  tooling/harbor`) and each root cause's **What changed: <ChangeRef>**. Slack blocks already showed
+  ChangeRef; Matrix/webhook/CLI readers never saw either.
+- **Evidence is model-authored prose** (`Hypothesis.Evidence []string`) with no structure — no
+  source attribution, no timestamp, no query. The good runs in the eval transcripts show the model
+  *voluntarily* writing `"pod_status: …"` / `"(from kube_events)"` prefixes; the bad ones don't.
+  Making attribution structural (F1) is the top follow-up: extend `submit_findings` evidence items
+  to `{source, at, detail}` and render `• [pod_status 14:03] …`. Deferred from this branch because
+  it touches the findings schema, the verify pass, the curator, and recall — a PR of its own.
+- **Negative evidence** ("checked metrics/network — clean") builds trust and is currently only
+  visible if the model happens to write it into a summary. A `checked_ok` field is F4.
+- **Time correlation** in the headline ("deploy at 14:02, first crash at 14:03") is now *possible*
+  — the model finally has both timestamps — but not enforced. Expect it to appear in evidence
+  naturally; enforce via prompt/schema only if evals show it doesn't.
+- Unresolved, confidence badge (max of overall/top root cause), suggested next steps with
+  reversibility, KB link, approval buttons: all present and sensible. Per the open PR #196,
+  `slack.go` escaping was deliberately left untouched; all changes are in `format.go`/data shape.
+
+---
+
+## 4. Eval grounding
+
+- `eval/reports/2026-06-22-k3d-baseline.md` + the JSON transcripts: coverage is consistently 100%;
+  points are lost on **root_cause depth** (`2/3 — "doesn't explicitly state that a change
+  introduced this configuration"`) — i.e. change-attribution and time-correlation, exactly what
+  findings 1–3 target. The judge's `evidence` scores were saved by the model writing tool names
+  into evidence strings by itself; F1 makes that reliable instead of lucky.
+- The rubric's `calibration` dimension (confident-wrong penalized hardest) is served by the richer
+  dataset too: a model that *sees* the event time and the change time can verify a causal chain
+  instead of asserting one.
+- Note: the graded runs predate `query_metrics_range`/`pod_logs` (PR #163), so there is no eval
+  evidence yet for the metrics/logs renderers; the audit above is code-read-based for those.
+
+---
+
+## 5. Ranked follow-ups (not in this branch)
+
+| # | Item | Why / where | Effort |
+|---|---|---|---|
+| F1 | **Structured evidence** in `submit_findings` (`{source, at, detail}`) rendered with attribution in chat | turns "lucky" evidence quality into guaranteed; feeds rubric `evidence` + reader trust | M — schema touches verify/curator/recall |
+| F2 | Per-tool output caps + error-first line selection inside `truncateOutput` for log-shaped text | one flat 32 KiB cap suits a diff, not 10k log lines; keep first occurrence of each error | M |
+| F3 | Flux commit **timestamp/author/message** on `Change` + HelmReleases in the change spine + honor `TimeWindow` | carried from 2026-06-27 §8.3; `what_changed` now renders `When` the moment Flux supplies it | M–L |
+| F4 | `checked_ok` (negative evidence) field in findings + notification section | "what came back clean" builds on-call trust | S–M |
+| F5 | Render `LogLine.Fields` attribution (pod/node) in `query_logs` | VictoriaLogs stream fields are dropped today | S |
+| F6 | `kube_events`: fetch window > `Limit: 200` or field-select Warning server-side | in a noisy namespace Normal events crowd the 200 before the Warning filter (`cluster.go:163`) | S |
+| F7 | Raise `maxToolRows` for log tools post-dedup | 50 *distinct* messages is usually enough; revisit with eval data | S |
+| F8 | Incident-anchored queries (`around_incident` mode using `req.At` server-side) | removes the model's window arithmetic entirely | M |
+| F9 | Seed prompt: include the alert's own PromQL expr when Alertmanager provides `generatorURL` | re-running the firing expression is the canonical first metric query | S |
+
+---
+
+## 6. Implemented in this branch (summary)
+
+1. **Alert annotations parsed + promoted** — `Request.Message` from `description`→`summary`→`message`;
+   full `Request.Annotations` threaded (`source/alertmanager`, `investigate.Request`).
+2. **Seed prompt time-anchor + labels/annotations** — start time with age and window guidance;
+   sorted, value-clipped labels/annotations; message-annotation not duplicated (`loop.go`).
+3. **Timestamps everywhere they existed but weren't shown** — `KubeEvent.LastSeen` (type, provider,
+   render); `pod_logs`/`controller_logs` per-line kubelet timestamps; `what_changed` renders
+   `Change.When`; `query_metrics_range` renders `min/max@time`.
+4. **Log dedup** — shared `renderLogLines` groups identical messages `(xN, last <t>)` before the
+   50-row cap, across `pod_logs`, `controller_logs`, `query_logs`, `network_drops`.
+5. **Notification anchors** — `Format` names the affected resource and per-root-cause ChangeRef
+   (shared text path only; `slack.go` untouched per PR #196).
+
+Plus matching tool-description updates (`query_metrics` → points at the range tool; `kube_events` →
+states ordering/timestamps/counts) so the model knows the semantics it's reading.
+
+---
+
+## 7. References
+
+- Renderers: `internal/investigate/{query_tools,kube_tools,podlogs_tool,controllerlogs_tool,whatchanged_tool,cloud_tools,renderlog}.go`; caps `query_tools.go:14`, `truncate.go`.
+- Seed/loop: `internal/investigate/loop.go` (`seedPrompt`, system prompt); intake `internal/source/alertmanager/alertmanager.go`.
+- Payloads/providers: `internal/providers/providers.go`; `internal/providers/cluster/cluster.go`; `internal/providers/gitops/flux/flux.go`; `internal/logs/victorialogs/victorialogs.go`.
+- Delivery: `internal/notify/{format,slack,matrix}.go`.
+- Grounding: `eval/rubric.md`, `eval/reports/2026-06-22-k3d-baseline.md` + JSON transcripts; prior analyses `dev/plans/2026-06-27-troubleshooting-integration-analysis.md`, `dev/plans/2026-06-25-review-roadmap.md`.

--- a/internal/investigate/controllerlogs_tool.go
+++ b/internal/investigate/controllerlogs_tool.go
@@ -59,21 +59,17 @@ func (t ControllerLogsTool) Call(ctx context.Context, args string) (string, erro
 	if err != nil {
 		return "", err
 	}
-	var b strings.Builder
-	n := 0
+	kept := lines[:0:0]
 	for _, l := range lines {
 		if in.Resource != "" && !strings.Contains(l.Message, in.Resource) {
 			continue
 		}
-		if n >= maxToolRows {
-			fmt.Fprintf(&b, "… (more lines truncated)\n")
-			break
-		}
-		fmt.Fprintln(&b, l.Message)
-		n++
+		kept = append(kept, l)
 	}
-	if b.Len() == 0 {
+	if len(kept) == 0 {
 		return "no matching controller log lines", nil
 	}
+	var b strings.Builder
+	renderLogLines(&b, kept, "more lines")
 	return b.String(), nil
 }

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -37,7 +37,8 @@ type Request struct {
 	Environment  string // deployment environment (prod/staging/…)
 	Message      string
 	Labels       map[string]string
-	GroupKey     string // Alertmanager group identity (shared by all alerts in one webhook POST)
+	Annotations  map[string]string // alert annotations (runbook_url, dashboards, …); surfaced in the seed prompt
+	GroupKey     string            // Alertmanager group identity (shared by all alerts in one webhook POST)
 	At           time.Time
 	Fingerprint  string   // Alertmanager fingerprint (stable firing↔resolved); for outcome attribution
 	Fingerprints []string // coalesced batch fingerprints; one open is recorded per entry so every constituent alert's resolve matches

--- a/internal/investigate/kube_tools.go
+++ b/internal/investigate/kube_tools.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -92,7 +93,9 @@ func (t KubeEventsTool) Name() string { return "kube_events" }
 func (t KubeEventsTool) Description() string {
 	return "List recent Kubernetes Events in a namespace (Warning-only by default) — causes that live " +
 		"in the event stream, not logs or status: FailedScheduling (Insufficient cpu/memory), " +
-		"FailedMount, FailedAttachVolume, BackOff, Unhealthy probes. Optionally scope to one object's name."
+		"FailedMount, FailedAttachVolume, BackOff, Unhealthy probes. Events are most-recent-first " +
+		"with last-seen timestamps and repeat counts — use the times to correlate with change/deploy " +
+		"times. Optionally scope to one object's name."
 }
 
 // Schema returns the JSON schema for the arguments.
@@ -127,7 +130,13 @@ func (t KubeEventsTool) Call(ctx context.Context, args string) (string, error) {
 		if e.Count > 1 {
 			count = fmt.Sprintf(" (x%d)", e.Count)
 		}
-		fmt.Fprintf(&b, "%s %s %s%s: %s\n", e.Type, e.Object, e.Reason, count, e.Message)
+		// Lead with the last-seen time: it is what lets the model correlate an
+		// event to a change/deploy timestamp ("first BackOff at 14:03").
+		when := ""
+		if !e.LastSeen.IsZero() {
+			when = e.LastSeen.UTC().Format(time.RFC3339) + " "
+		}
+		fmt.Fprintf(&b, "%s%s %s %s%s: %s\n", when, e.Type, e.Object, e.Reason, count, e.Message)
 	}
 	return b.String(), nil
 }

--- a/internal/investigate/kube_tools_test.go
+++ b/internal/investigate/kube_tools_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -91,8 +92,9 @@ func TestPodStatusToolSelectorFallback(t *testing.T) {
 }
 
 func TestKubeEventsTool(t *testing.T) {
+	lastSeen := time.Date(2026, 7, 1, 14, 3, 5, 0, time.UTC)
 	tool := KubeEventsTool{Kube: fakeKube{events: []providers.KubeEvent{
-		{Type: "Warning", Reason: "FailedScheduling", Object: "Pod/valkey-0", Count: 13,
+		{Type: "Warning", Reason: "FailedScheduling", Object: "Pod/valkey-0", Count: 13, LastSeen: lastSeen,
 			Message: "0/9 nodes are available: 4 Insufficient cpu, 2 Insufficient memory."},
 	}}}
 	out, err := tool.Call(context.Background(), `{"namespace":"apps"}`)
@@ -101,5 +103,24 @@ func TestKubeEventsTool(t *testing.T) {
 	}
 	if !strings.Contains(out, "FailedScheduling") || !strings.Contains(out, "Insufficient cpu") || !strings.Contains(out, "x13") {
 		t.Fatalf("kube_events must surface reason + message + count, got:\n%s", out)
+	}
+	// The last-seen timestamp is what lets the model correlate an event to a
+	// change/deploy time ("first BackOff at 14:03").
+	if !strings.Contains(out, "2026-07-01T14:03:05Z") {
+		t.Fatalf("kube_events must surface the event's last-seen time, got:\n%s", out)
+	}
+}
+
+// A zero LastSeen (older API objects, fakes) must not render a bogus epoch time.
+func TestKubeEventsToolZeroTimeOmitted(t *testing.T) {
+	tool := KubeEventsTool{Kube: fakeKube{events: []providers.KubeEvent{
+		{Type: "Warning", Reason: "BackOff", Object: "Pod/x", Message: "restarting"},
+	}}}
+	out, err := tool.Call(context.Background(), `{"namespace":"apps"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if strings.Contains(out, "0001-01-01") {
+		t.Fatalf("kube_events must omit a zero timestamp, got:\n%s", out)
 	}
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -546,5 +547,63 @@ func seedPrompt(req Request) string {
 	if req.Environment != "" {
 		fmt.Fprintf(&b, " Environment: %s.", req.Environment)
 	}
+	// Time anchor: tool windows (since_minutes) are relative to NOW, so without the
+	// incident start time the model can only guess how far back to look — and a
+	// too-short window silently misses the onset (the highest-signal moment).
+	if !req.At.IsZero() {
+		fmt.Fprintf(&b, "\nIncident started: %s (%s before now). Tool time windows (since_minutes) are "+
+			"relative to now — size them to cover the start time.",
+			req.At.UTC().Format(time.RFC3339), fmtAge(time.Since(req.At)))
+	}
+	// Alert labels and annotations are free signal the alert already carries
+	// (container, instance, cluster; runbook_url, dashboards). The annotation
+	// already promoted to Message is skipped so it isn't duplicated. Values are
+	// clipped so one pathological label can't blow up the seed.
+	if kv := renderKV(req.Labels, ""); kv != "" {
+		fmt.Fprintf(&b, "\nAlert labels: %s", kv)
+	}
+	if kv := renderKV(req.Annotations, req.Message); kv != "" {
+		fmt.Fprintf(&b, "\nAlert annotations: %s", kv)
+	}
 	return b.String()
+}
+
+// fmtAge renders a duration as a compact human age ("42m", "3h07m"); anything
+// under a minute (including a negative age from clock skew) reads "<1m".
+func fmtAge(d time.Duration) string {
+	d = d.Round(time.Minute)
+	if d < time.Minute {
+		return "<1m"
+	}
+	if h := d / time.Hour; h > 0 {
+		return fmt.Sprintf("%dh%02dm", h, (d%time.Hour)/time.Minute)
+	}
+	return fmt.Sprintf("%dm", d/time.Minute)
+}
+
+// maxSeedValueRunes clips a single label/annotation value in the seed prompt so
+// one pathological value can't dominate the context budget.
+const maxSeedValueRunes = 300
+
+// renderKV renders a label/annotation map as sorted key="value" pairs, skipping
+// entries whose value equals skipValue (already surfaced elsewhere in the seed)
+// and clipping oversized values. Returns "" for an empty/fully-skipped map.
+func renderKV(m map[string]string, skipValue string) string {
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		if skipValue != "" && v == skipValue {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		v := m[k]
+		if r := []rune(v); len(r) > maxSeedValueRunes {
+			v = string(r[:maxSeedValueRunes]) + "…"
+		}
+		parts = append(parts, fmt.Sprintf("%s=%q", k, v))
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -1003,4 +1003,60 @@ func TestSeedPrompt(t *testing.T) {
 			t.Errorf("seed prompt should omit empty environment, got %q", got)
 		}
 	})
+	t.Run("anchors the incident start time so the model can size tool windows", func(t *testing.T) {
+		at := time.Now().Add(-42 * time.Minute)
+		got := seedPrompt(Request{Title: "PodCrashLooping", Source: SourceAlert, At: at})
+		if !strings.Contains(got, "Incident started: "+at.UTC().Format(time.RFC3339)) {
+			t.Errorf("seed prompt missing incident start time, got %q", got)
+		}
+		if !strings.Contains(got, "42m before now") {
+			t.Errorf("seed prompt missing relative age (42m), got %q", got)
+		}
+		if !strings.Contains(got, "since_minutes") {
+			t.Errorf("seed prompt should tell the model how to aim tool windows at the start time, got %q", got)
+		}
+	})
+	t.Run("omits the start line when At is zero", func(t *testing.T) {
+		got := seedPrompt(Request{Title: "X", Source: SourceAlert})
+		if strings.Contains(got, "Incident started:") {
+			t.Errorf("seed prompt should omit a zero start time, got %q", got)
+		}
+	})
+	t.Run("carries alert labels and annotations", func(t *testing.T) {
+		req := Request{
+			Title:  "KubePodCrashLooping",
+			Source: SourceAlert,
+			Labels: map[string]string{
+				"alertname": "KubePodCrashLooping",
+				"pod":       "web-abc123",
+				"container": "app",
+			},
+			Annotations: map[string]string{
+				"runbook_url": "https://runbooks.example/crashloop",
+				"description": "already surfaced as the message",
+			},
+			Message: "already surfaced as the message",
+		}
+		got := seedPrompt(req)
+		if !strings.Contains(got, `container="app"`) || !strings.Contains(got, `pod="web-abc123"`) {
+			t.Errorf("seed prompt missing alert labels, got %q", got)
+		}
+		if !strings.Contains(got, `runbook_url="https://runbooks.example/crashloop"`) {
+			t.Errorf("seed prompt missing runbook_url annotation, got %q", got)
+		}
+		// The annotation already surfaced as Message must not be duplicated.
+		if strings.Count(got, "already surfaced as the message") != 1 {
+			t.Errorf("description annotation duplicated in seed prompt, got %q", got)
+		}
+	})
+	t.Run("clips oversized label values", func(t *testing.T) {
+		long := strings.Repeat("x", 2000)
+		got := seedPrompt(Request{Title: "X", Source: SourceAlert, Labels: map[string]string{"big": long}})
+		if strings.Contains(got, long) {
+			t.Errorf("seed prompt should clip a 2000-char label value")
+		}
+		if !strings.Contains(got, "big=") {
+			t.Errorf("clipped label should still appear, got %q", got)
+		}
+	})
 }

--- a/internal/investigate/podlogs_tool.go
+++ b/internal/investigate/podlogs_tool.go
@@ -101,8 +101,6 @@ func (t PodLogsTool) Call(ctx context.Context, args string) (string, error) {
 		return "no log lines matched", nil
 	}
 	var b strings.Builder
-	renderRows(&b, len(lines), "more lines", func(i int) {
-		fmt.Fprintln(&b, lines[i].Message)
-	})
+	renderLogLines(&b, lines, "more lines")
 	return b.String(), nil
 }

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -37,7 +37,7 @@ func (t QueryMetricsTool) Name() string { return "query_metrics" }
 
 // Description returns the tool description.
 func (t QueryMetricsTool) Description() string {
-	return "Run a PromQL instant query against the metrics backend (VictoriaMetrics/Prometheus) — check saturation, error rates, restarts, resource usage."
+	return "Run a PromQL instant query against the metrics backend (VictoriaMetrics/Prometheus) — check saturation, error rates, restarts, resource usage. This returns the value NOW only; to see when a metric started rising/spiking around the incident, use query_metrics_range instead."
 }
 
 // Schema returns the JSON schema for the arguments.
@@ -130,27 +130,39 @@ func (t QueryMetricsRangeTool) Call(ctx context.Context, args string) (string, e
 	renderRows(&b, len(series), "more series", func(i int) {
 		s := series[i]
 		first, last, lo, hi := summarize(s.Points)
-		fmt.Fprintf(&b, "%s first=%g last=%g min=%g max=%g\n", formatMetric(s.Metric), first, last, lo, hi)
+		fmt.Fprintf(&b, "%s first=%g last=%g min=%g%s max=%g%s\n",
+			formatMetric(s.Metric), first, last, lo.Value, atTime(lo.Time), hi.Value, atTime(hi.Time))
 	})
 	return b.String(), nil
 }
 
-// summarize reduces a series' points to first, last, min and max — the compact
-// trend an LLM needs to tell whether a metric climbed, spiked or recovered,
-// without shipping every sample. An empty series yields all zeros.
-func summarize(points []providers.Point) (first, last, lo, hi float64) {
+// atTime renders "@<RFC3339>" for a point's timestamp, or "" when the backend
+// returned no time — WHEN a metric peaked/bottomed is what lets the model
+// correlate the spike to a change/deploy timestamp.
+func atTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return "@" + t.UTC().Format(time.RFC3339)
+}
+
+// summarize reduces a series' points to first, last, and the min/max POINTS
+// (value + when it happened) — the compact trend an LLM needs to tell whether a
+// metric climbed, spiked or recovered, and when, without shipping every sample.
+// An empty series yields zeros.
+func summarize(points []providers.Point) (first, last float64, lo, hi providers.Point) {
 	if len(points) == 0 {
-		return 0, 0, 0, 0
+		return 0, 0, providers.Point{}, providers.Point{}
 	}
 	first = points[0].Value
 	last = points[len(points)-1].Value
-	lo, hi = first, first
+	lo, hi = points[0], points[0]
 	for _, p := range points {
-		if p.Value < lo {
-			lo = p.Value
+		if p.Value < lo.Value {
+			lo = p
 		}
-		if p.Value > hi {
-			hi = p.Value
+		if p.Value > hi.Value {
+			hi = p
 		}
 	}
 	return first, last, lo, hi
@@ -200,9 +212,7 @@ func (t NetworkDropsTool) Call(ctx context.Context, args string) (string, error)
 		return "no dropped flows", nil
 	}
 	var b strings.Builder
-	renderRows(&b, len(lines), "more", func(i int) {
-		fmt.Fprintln(&b, lines[i].Message)
-	})
+	renderLogLines(&b, lines, "more")
 	return b.String(), nil
 }
 
@@ -294,8 +304,6 @@ func (t QueryLogsTool) Call(ctx context.Context, args string) (string, error) {
 		return "no log lines matched", nil
 	}
 	var b strings.Builder
-	renderRows(&b, len(lines), "more lines", func(i int) {
-		fmt.Fprintf(&b, "%s %s\n", lines[i].Time.Format(time.RFC3339), lines[i].Message)
-	})
+	renderLogLines(&b, lines, "more lines")
 	return b.String(), nil
 }

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -148,11 +148,12 @@ func TestQueryMetricsRangeTool(t *testing.T) {
 		t.Fatalf("Call: %v", err)
 	}
 	// The model must see the TREND, not a single value: first->last with min/max
-	// so a spike-then-partial-recovery (1 -> 9 -> 4) is legible.
+	// so a spike-then-partial-recovery (1 -> 9 -> 4) is legible — and WHEN the
+	// extremes happened, so the spike can be correlated to a change/deploy time.
 	if !strings.Contains(out, `http_errors{job="api"}`) {
 		t.Fatalf("missing series label:\n%s", out)
 	}
-	for _, want := range []string{"first=1", "last=4", "min=1", "max=9"} {
+	for _, want := range []string{"first=1", "last=4", "min=1@2023-11-14T22:13:20Z", "max=9@2023-11-14T22:14:20Z"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("missing %q in:\n%s", want, out)
 		}

--- a/internal/investigate/renderlog.go
+++ b/internal/investigate/renderlog.go
@@ -1,0 +1,63 @@
+package investigate
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// logGroup is one distinct log message with its repeat count and the time of its
+// last occurrence — the compact form a crash loop's near-identical spam reduces to.
+type logGroup struct {
+	first providers.LogLine // first occurrence (its Time is the first-seen time)
+	count int
+	last  time.Time // last occurrence's time; zero when the source carries no timestamps
+}
+
+// groupLogLines collapses repeated identical messages (not just consecutive ones —
+// a crash loop re-emits the same block every restart) into one group each, keeping
+// first-occurrence order. This runs BEFORE the row cap, so the cap spends its
+// budget on DISTINCT messages instead of 50 copies of the same panic line.
+func groupLogLines(lines providers.LogResult) []logGroup {
+	byMsg := map[string]int{} // message -> index into groups
+	groups := make([]logGroup, 0, len(lines))
+	for _, l := range lines {
+		if i, ok := byMsg[l.Message]; ok {
+			groups[i].count++
+			if l.Time.After(groups[i].last) {
+				groups[i].last = l.Time
+			}
+			continue
+		}
+		byMsg[l.Message] = len(groups)
+		groups = append(groups, logGroup{first: l, count: 1, last: l.Time})
+	}
+	return groups
+}
+
+// renderLogLines is the shared renderer for log-shaped tool output (pod_logs,
+// controller_logs, query_logs, network_drops): each DISTINCT message renders once
+// with its first-seen timestamp (when the source has one) and, when repeated, a
+// "(xN, last <time>)" suffix — so the model sees when a line first appeared and
+// that it kept repeating, instead of 50 identical rows. Capped at maxToolRows
+// distinct messages with the standard "… (N more <noun>)" note.
+func renderLogLines(b *strings.Builder, lines providers.LogResult, noun string) {
+	groups := groupLogLines(lines)
+	renderRows(b, len(groups), noun, func(i int) {
+		g := groups[i]
+		if !g.first.Time.IsZero() {
+			fmt.Fprintf(b, "%s ", g.first.Time.UTC().Format(time.RFC3339))
+		}
+		b.WriteString(g.first.Message)
+		if g.count > 1 {
+			if !g.last.IsZero() {
+				fmt.Fprintf(b, " (x%d, last %s)", g.count, g.last.UTC().Format(time.RFC3339))
+			} else {
+				fmt.Fprintf(b, " (x%d)", g.count)
+			}
+		}
+		b.WriteString("\n")
+	})
+}

--- a/internal/investigate/renderlog_test.go
+++ b/internal/investigate/renderlog_test.go
@@ -1,0 +1,80 @@
+package investigate
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestRenderLogLinesDedup(t *testing.T) {
+	t0 := time.Date(2026, 7, 1, 14, 0, 0, 0, time.UTC)
+	mk := func(offsetSec int, msg string) providers.LogLine {
+		return providers.LogLine{Time: t0.Add(time.Duration(offsetSec) * time.Second), Message: msg}
+	}
+
+	t.Run("collapses a repeated line into one row with count and span", func(t *testing.T) {
+		// A crash loop: the same panic line repeats across restarts, interleaved
+		// with a distinct line. Only 2 distinct rows must render, each counted.
+		lines := providers.LogResult{
+			mk(0, "panic: connection refused"),
+			mk(1, "restarting"),
+			mk(60, "panic: connection refused"),
+			mk(120, "panic: connection refused"),
+		}
+		var b strings.Builder
+		renderLogLines(&b, lines, "more lines")
+		out := b.String()
+		if strings.Count(out, "panic: connection refused") != 1 {
+			t.Fatalf("repeated message must render once, got:\n%s", out)
+		}
+		if !strings.Contains(out, "(x3, last 2026-07-01T14:02:00Z)") {
+			t.Fatalf("repeat count + last-seen missing, got:\n%s", out)
+		}
+		// First occurrence keeps its own timestamp.
+		if !strings.Contains(out, "2026-07-01T14:00:00Z panic: connection refused") {
+			t.Fatalf("first-occurrence timestamp missing, got:\n%s", out)
+		}
+		// The single-occurrence line renders plain (no count suffix).
+		if !strings.Contains(out, "restarting\n") || strings.Contains(out, "restarting (x") {
+			t.Fatalf("unique line must render without a count, got:\n%s", out)
+		}
+	})
+
+	t.Run("omits timestamps when the source has none", func(t *testing.T) {
+		lines := providers.LogResult{{Message: "web-1: started"}, {Message: "web-1: started"}}
+		var b strings.Builder
+		renderLogLines(&b, lines, "more lines")
+		out := b.String()
+		if strings.Contains(out, "0001-01-01") {
+			t.Fatalf("zero timestamps must not render, got:\n%s", out)
+		}
+		if !strings.Contains(out, "web-1: started (x2)") {
+			t.Fatalf("count without timestamps expected, got:\n%s", out)
+		}
+	})
+
+	t.Run("caps at maxToolRows DISTINCT messages", func(t *testing.T) {
+		var lines providers.LogResult
+		// 60 distinct messages, each repeated twice: dedup first, then cap — so the
+		// cap counts distinct messages, not raw lines.
+		for i := 0; i < 60; i++ {
+			msg := fmt.Sprintf("distinct line %02d", i)
+			lines = append(lines, providers.LogLine{Message: msg}, providers.LogLine{Message: msg})
+		}
+		var b strings.Builder
+		renderLogLines(&b, lines, "more lines")
+		out := b.String()
+		if !strings.Contains(out, "distinct line 49") {
+			t.Fatalf("the 50th distinct message must render, got tail:\n%s", out[len(out)-200:])
+		}
+		if strings.Contains(out, "distinct line 50") {
+			t.Fatalf("the 51st distinct message must be capped, got:\n%s", out)
+		}
+		if !strings.Contains(out, "(10 more lines)") {
+			t.Fatalf("truncation note must count remaining DISTINCT messages, got tail:\n%s", out[len(out)-200:])
+		}
+	})
+}

--- a/internal/investigate/whatchanged_tool.go
+++ b/internal/investigate/whatchanged_tool.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/whatchanged"
@@ -52,7 +53,13 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 	defer done()
 	var b strings.Builder
 	for _, c := range changes {
-		fmt.Fprintf(&b, "%s %s/%s (%s): %s..%s\n", c.Engine, c.Workload.Kind, c.Workload.Name, c.Type, c.FromRev, c.ToRev)
+		fmt.Fprintf(&b, "%s %s/%s (%s): %s..%s", c.Engine, c.Workload.Kind, c.Workload.Name, c.Type, c.FromRev, c.ToRev)
+		// When the engine knows WHEN the change landed, say so — "deploy at 14:02,
+		// first crash at 14:03" is the core change↔symptom correlation.
+		if !c.When.IsZero() {
+			fmt.Fprintf(&b, " at %s", c.When.UTC().Format(time.RFC3339))
+		}
+		b.WriteString("\n")
 		d, derr := t.GitOps.Diff(ctx, c)
 		if derr != nil {
 			fmt.Fprintf(&b, "  (diff error: %v)\n", derr)

--- a/internal/investigate/whatchanged_tool_test.go
+++ b/internal/investigate/whatchanged_tool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -44,5 +45,32 @@ func TestWhatChangedTool(t *testing.T) {
 	}
 	if tool.Name() != "what_changed" {
 		t.Fatalf("unexpected name %q", tool.Name())
+	}
+}
+
+// TestWhatChangedToolRendersWhen asserts a change's timestamp reaches the model
+// when the engine knows it — "deploy at 14:02, first crash at 14:03" is the core
+// change↔symptom correlation — and that a zero When (Flux today) renders nothing.
+func TestWhatChangedToolRendersWhen(t *testing.T) {
+	when := time.Date(2026, 7, 1, 14, 2, 0, 0, time.UTC)
+	gp := fakeGitOps{changes: []providers.Change{
+		{
+			Workload: providers.Workload{Kind: "Application", Name: "web", Namespace: "argocd"},
+			Engine:   providers.EngineArgoCD, Type: providers.ChangeSync, ToRev: "ccc", When: when,
+		},
+		{
+			Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
+			Engine:   providers.EngineFlux, Type: providers.ChangeSync, ToRev: "bbb",
+		},
+	}}
+	out, err := WhatChangedTool{GitOps: gp}.Call(context.Background(), `{"namespace":"flux-system"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !strings.Contains(out, "at 2026-07-01T14:02:00Z") {
+		t.Fatalf("change timestamp missing:\n%s", out)
+	}
+	if strings.Contains(out, "0001-01-01") {
+		t.Fatalf("zero When must not render:\n%s", out)
 	}
 }

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -13,8 +13,18 @@ import (
 func Format(inv providers.Investigation) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "*Investigation* — confidence %.0f%%\n", inv.Confidence*100)
+	// Name the affected resource up front: it is the first thing an on-call needs
+	// (which workload is this about?) and it isn't otherwise in the shared text.
+	if ref := inv.Resource.Ref(); ref != "" {
+		fmt.Fprintf(&b, "Resource: %s\n", strings.TrimSpace(inv.Resource.Kind+" "+ref))
+	}
 	for i, rc := range inv.RootCauses {
 		fmt.Fprintf(&b, "%d. *%s* (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
+		// The change the root cause pins the incident on — previously rendered only
+		// in the Slack blocks, so Matrix/webhook/CLI readers never saw it.
+		if rc.ChangeRef != "" {
+			fmt.Fprintf(&b, "   What changed: %s\n", rc.ChangeRef)
+		}
 		for _, e := range rc.Evidence {
 			fmt.Fprintf(&b, "   • %s\n", e)
 		}

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -10,9 +10,11 @@ import (
 func sampleInvestigation() providers.Investigation {
 	return providers.Investigation{
 		Confidence: 0.82,
+		Resource:   providers.Workload{Kind: "HelmRelease", Namespace: "tooling", Name: "harbor"},
 		RootCauses: []providers.Hypothesis{{
 			Summary:    "chart 1.15 enabled DB migrations; harbor-db CrashLoopBackOff",
 			Confidence: 0.82, Evidence: []string{"pg_up=0", "migration lock timeout"},
+			ChangeRef:       "flux-system/apps: abc123..def456",
 			SuggestedAction: "flux rollback hr/harbor", Reversible: true,
 		}},
 		Unresolved: []string{"why the migration lock never released"},
@@ -25,5 +27,24 @@ func TestFormat(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("formatted message missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// TestFormatResourceAndChange asserts the shared message names the affected
+// resource (which workload is this about?) and each root cause's change ref
+// (what changed?) — the two anchors an on-call reads first. Both are omitted
+// when unknown so the message never prints empty labels.
+func TestFormatResourceAndChange(t *testing.T) {
+	out := Format(sampleInvestigation())
+	if !strings.Contains(out, "HelmRelease tooling/harbor") {
+		t.Fatalf("formatted message missing the affected resource:\n%s", out)
+	}
+	if !strings.Contains(out, "flux-system/apps: abc123..def456") {
+		t.Fatalf("formatted message missing the root cause's change ref:\n%s", out)
+	}
+
+	empty := Format(providers.Investigation{RootCauses: []providers.Hypothesis{{Summary: "x"}}})
+	if strings.Contains(empty, "Resource:") || strings.Contains(empty, "What changed:") {
+		t.Fatalf("empty resource/change must not render labels:\n%s", empty)
 	}
 }

--- a/internal/providers/cluster/cluster.go
+++ b/internal/providers/cluster/cluster.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -52,8 +53,11 @@ func (r *Reader) PodLogs(ctx context.Context, q providers.PodLogQuery) (provider
 			break
 		}
 		name := pods.Items[i].Name
+		// Timestamps: the kubelet prefixes each line with RFC3339Nano; we parse it
+		// into LogLine.Time so the renderer can show WHEN a line was emitted (the
+		// signal that correlates a crash to a change/event time).
 		stream, err := r.client.CoreV1().Pods(q.Namespace).
-			GetLogs(name, &corev1.PodLogOptions{SinceSeconds: since, TailLines: &tail, Previous: q.Previous}).
+			GetLogs(name, &corev1.PodLogOptions{SinceSeconds: since, TailLines: &tail, Previous: q.Previous, Timestamps: true}).
 			Stream(ctx)
 		if err != nil {
 			continue
@@ -61,11 +65,28 @@ func (r *Reader) PodLogs(ctx context.Context, q providers.PodLogQuery) (provider
 		sc := bufio.NewScanner(stream)
 		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		for sc.Scan() {
-			out = append(out, providers.LogLine{Message: name + ": " + sc.Text()})
+			ts, msg := splitLogTimestamp(sc.Text())
+			out = append(out, providers.LogLine{Time: ts, Message: name + ": " + msg})
 		}
 		_ = stream.Close()
 	}
 	return out, nil
+}
+
+// splitLogTimestamp splits the RFC3339Nano prefix that PodLogOptions.Timestamps
+// adds to each line into a time plus the bare message. A line without a parseable
+// prefix (a fake client, a malformed line) is returned untouched with a zero time,
+// so callers never lose content.
+func splitLogTimestamp(line string) (time.Time, string) {
+	prefix, rest, found := strings.Cut(line, " ")
+	if !found {
+		prefix, rest = line, ""
+	}
+	ts, err := time.Parse(time.RFC3339Nano, prefix)
+	if err != nil {
+		return time.Time{}, line
+	}
+	return ts, rest
 }
 
 var _ providers.KubeReader = (*Reader)(nil)
@@ -161,15 +182,17 @@ func (r *Reader) Events(ctx context.Context, namespace, objectName string, warnO
 		if warnOnly && e.Type != corev1.EventTypeWarning {
 			continue
 		}
+		at := eventTime(e)
 		kept = append(kept, timedEvent{
 			ev: providers.KubeEvent{
-				Type:    e.Type,
-				Reason:  e.Reason,
-				Object:  e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
-				Message: e.Message,
-				Count:   e.Count,
+				Type:     e.Type,
+				Reason:   e.Reason,
+				Object:   e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name,
+				Message:  e.Message,
+				Count:    e.Count,
+				LastSeen: at,
 			},
-			at: eventTime(e),
+			at: at,
 		})
 	}
 	sort.SliceStable(kept, func(i, j int) bool { return kept[i].at.After(kept[j].at) })

--- a/internal/providers/cluster/cluster_test.go
+++ b/internal/providers/cluster/cluster_test.go
@@ -43,6 +43,35 @@ func TestPodLogs(t *testing.T) {
 	}
 }
 
+// TestSplitLogTimestamp covers parsing the RFC3339Nano prefix the kubelet adds
+// when PodLogOptions.Timestamps is set — the per-line time that lets the model
+// correlate a log line to a change/event timestamp. Lines without a parseable
+// prefix (fakes, malformed) pass through untouched with a zero time.
+func TestSplitLogTimestamp(t *testing.T) {
+	cases := []struct {
+		name, in, wantMsg string
+		wantZero          bool
+	}{
+		{"kubelet timestamped line", "2026-07-01T14:03:05.123456789Z panic: boom", "panic: boom", false},
+		{"no timestamp", "fake logs", "fake logs", true},
+		{"timestamp only", "2026-07-01T14:03:05Z", "", false},
+		{"empty", "", "", true},
+	}
+	for _, c := range cases {
+		ts, msg := splitLogTimestamp(c.in)
+		if msg != c.wantMsg {
+			t.Errorf("%s: msg = %q, want %q", c.name, msg, c.wantMsg)
+		}
+		if ts.IsZero() != c.wantZero {
+			t.Errorf("%s: ts.IsZero() = %v, want %v", c.name, ts.IsZero(), c.wantZero)
+		}
+	}
+	ts, _ := splitLogTimestamp("2026-07-01T14:03:05.123456789Z panic: boom")
+	if ts.UTC().Format("2006-01-02T15:04:05Z") != "2026-07-01T14:03:05Z" {
+		t.Errorf("parsed timestamp wrong: %v", ts)
+	}
+}
+
 func TestPodStatusSurfacesOOMAndLimit(t *testing.T) {
 	// An OOMKilled pod loops: its CURRENT state is Waiting{CrashLoopBackOff}; the
 	// OOMKilled/exit-137 signal lives in LastTerminationState. pod_status must surface

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -240,11 +240,12 @@ type PodStatus struct {
 // KubeEvent is a normalized Kubernetes Event — surfaces causes that live in the
 // event stream, not logs or status (FailedScheduling, FailedMount, …).
 type KubeEvent struct {
-	Type    string // Normal | Warning
-	Reason  string
-	Object  string // Kind/Name
-	Message string
-	Count   int32
+	Type     string // Normal | Warning
+	Reason   string
+	Object   string // Kind/Name
+	Message  string
+	Count    int32
+	LastSeen time.Time // when the event last fired; zero when the API omitted it
 }
 
 // KubeReader reads read-only pod status and Kubernetes Events for incident triage,

--- a/internal/source/alertmanager/alertmanager.go
+++ b/internal/source/alertmanager/alertmanager.go
@@ -27,6 +27,7 @@ type amPayload struct {
 type amAlert struct {
 	Status      string            `json:"status"`
 	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
 	StartsAt    string            `json:"startsAt"`
 	Fingerprint string            `json:"fingerprint"`
 }
@@ -76,13 +77,19 @@ func (Source) Decode(body []byte, _ http.Header) (source.DecodeResult, error) {
 			fps = []string{a.Fingerprint}
 		}
 		out.Requests = append(out.Requests, investigate.Request{
-			Source:       investigate.SourceAlert,
-			Title:        a.Labels["alertname"],
-			Severity:     a.Labels["severity"],
-			Environment:  cmp.Or(a.Labels["environment"], a.Labels["env"]),
-			Workload:     providers.Workload{Namespace: a.Labels["namespace"], Kind: kind, Name: name},
-			Reason:       a.Labels["severity"],
+			Source:      investigate.SourceAlert,
+			Title:       a.Labels["alertname"],
+			Severity:    a.Labels["severity"],
+			Environment: cmp.Or(a.Labels["environment"], a.Labels["env"]),
+			Workload:    providers.Workload{Namespace: a.Labels["namespace"], Kind: kind, Name: name},
+			Reason:      a.Labels["severity"],
+			// The description/summary annotation is the alert's most informative human
+			// text (the templated "what is wrong") — without it the seed prompt carried
+			// only the alertname. Remaining annotations (runbook_url, dashboards, …)
+			// travel on Annotations for the seed prompt to surface.
+			Message:      cmp.Or(a.Annotations["description"], a.Annotations["summary"], a.Annotations["message"]),
 			Labels:       a.Labels,
+			Annotations:  a.Annotations,
 			At:           startsAt,
 			Fingerprint:  a.Fingerprint,
 			Fingerprints: fps,

--- a/internal/source/alertmanager/alertmanager_test.go
+++ b/internal/source/alertmanager/alertmanager_test.go
@@ -102,6 +102,57 @@ func TestDecodeFiringResolvedSplit(t *testing.T) {
 	}
 }
 
+// TestDecodeAnnotations covers the alert annotations: the description (falling
+// back to summary, then message) becomes the request Message — the most
+// informative human text an alert carries — and the full annotation map is
+// threaded so the investigation seed can surface runbook_url etc.
+func TestDecodeAnnotations(t *testing.T) {
+	body := []byte(`{"alerts":[{"status":"firing",
+		"labels":{"alertname":"HighMem","namespace":"ns"},
+		"annotations":{"description":"container web memory at 97% of limit for 15m","runbook_url":"https://runbooks.example/highmem"}}]}`)
+	res, err := (&Source{}).Decode(body, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 1 {
+		t.Fatalf("want 1 request, got %d", len(res.Requests))
+	}
+	r := res.Requests[0]
+	if r.Message != "container web memory at 97% of limit for 15m" {
+		t.Fatalf("want Message from the description annotation, got %q", r.Message)
+	}
+	if r.Annotations["runbook_url"] != "https://runbooks.example/highmem" {
+		t.Fatalf("annotations not threaded: %v", r.Annotations)
+	}
+}
+
+// TestDecodeAnnotationsFallback covers the summary → message fallback order and
+// that a missing annotations object leaves Message empty (not a panic).
+func TestDecodeAnnotationsFallback(t *testing.T) {
+	cases := []struct {
+		name, body, want string
+	}{
+		{"summary fallback",
+			`{"alerts":[{"status":"firing","labels":{"alertname":"X","namespace":"ns"},"annotations":{"summary":"pods crash-looping"}}]}`,
+			"pods crash-looping"},
+		{"message fallback",
+			`{"alerts":[{"status":"firing","labels":{"alertname":"X","namespace":"ns"},"annotations":{"message":"probe failed"}}]}`,
+			"probe failed"},
+		{"no annotations",
+			`{"alerts":[{"status":"firing","labels":{"alertname":"X","namespace":"ns"}}]}`,
+			""},
+	}
+	for _, c := range cases {
+		res, err := (&Source{}).Decode([]byte(c.body), nil)
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		if got := res.Requests[0].Message; got != c.want {
+			t.Errorf("%s: Message = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
 func TestWorkloadFromLabels(t *testing.T) {
 	cases := []struct {
 		name             string


### PR DESCRIPTION
## What

Companion analysis + top-ranked fixes for **investigation dataset quality** — what the model actually sees from each data source, and what the on-call actually reads in the notification.

Full critique (per-source rendering audit, truncation policy, seed prompt, notification, eval grounding, ranked follow-ups): **`dev/plans/2026-07-01-investigation-dataset-quality.md`**.

## Verdict (short)

The engine and tool breadth are solid (already audited in `2026-06-27-troubleshooting-integration-analysis.md`). The remaining ceiling was the *dataset*: several renderers stripped exactly the dimensions RCA needs — **time** and **attribution** — and the alert intake discarded the alert's most informative text before the investigation even started. The eval baseline shows where that lands: `root_cause 2/3 — "correct but shallow … does not state that a change introduced this state"`. The model cannot narrate "deploy at 14:02, first crash at 14:03" when no tool output contains a timestamp.

## Shipped (top 5 by impact/effort)

1. **Alert annotations were never parsed** — `amAlert` had no `annotations` field, so `Request.Message` was empty for every alert-triggered investigation. Now: `description` → `summary` → `message` becomes the Message; the full annotation map (runbook_url, dashboards…) is threaded to the seed.
2. **Time-anchored seed prompt** — incident start time + age, with explicit guidance that `since_minutes` windows are relative to now; sorted, value-clipped alert labels and annotations (free signal the alert already carried).
3. **Timestamps everywhere they existed but weren't rendered** — `KubeEvent.LastSeen` end-to-end; `pod_logs`/`controller_logs` kubelet per-line timestamps; `what_changed` renders `Change.When` when the engine knows it; `query_metrics_range` renders `min=…@t max=…@t` so a spike is datable.
4. **Log dedup before the row cap** — shared `renderLogLines` collapses repeated identical messages into one row with `(xN, last <t>)` across `pod_logs`, `controller_logs`, `query_logs`, `network_drops`. A CrashLoopBackOff no longer spends all 50 rendered rows on 50 copies of the same panic line — the cap now buys ~50 *distinct* facts instead of ~1.
5. **Notification anchors** — the shared `Format` text now names the affected resource and each root cause's `ChangeRef` (previously Slack-blocks-only; Matrix/webhook/CLI readers never saw either). `slack.go` untouched; the new text flows through the existing `escapeMrkdwn(Format(inv))` path.

Plus tool-description updates so the model knows the new semantics (`query_metrics` points at the range tool for trends; `kube_events` states ordering/timestamps/counts).

## Deferred (ranked in the doc, §5)

Structured evidence `{source, at, detail}` in `submit_findings` (touches verify/curator/recall — a PR of its own); per-tool byte caps + error-first truncation; Flux commit timestamps/HelmReleases in the change spine; negative-evidence (`checked_ok`) section; `query_logs` Fields attribution; events `Limit:200` pre-filter crowding; incident-anchored query mode.

## Verified already good (not changed)

`pod_status` failure surface (OOM→limit tie-in, last-termination reason/exit-code); the selector-matched-nothing fallback; `buildLogsQL` guardrails; events Warning-first + most-recent-first; VictoriaLogs newest-first ordering; redaction strictly before truncation; honest empty-result strings.

## Quality gate

`go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — build/vet/tests pass, gofmt silent, lint 0 issues. Merged with current main (tool-choice + token calibration + slack mrkdwn escaping all preserved).