### PR TITLE
refactor(model): extract shared client core (retry/SSE/error plumbing)

### DIFF
--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -6,62 +6,37 @@
 package anthropic
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"iter"
 	"net/http"
 	"strings"
-	"time"
 
-	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/model/clientcore"
 	"github.com/Smana/runlore/internal/providers"
 )
 
 // DefaultBaseURL is the public Anthropic API.
 const DefaultBaseURL = "https://api.anthropic.com"
 
-const (
-	defaultMaxTokens = 4096
-	apiVersion       = "2023-06-01"
-	// responseHeaderTimeout caps the wait for response headers (time-to-first-byte);
-	// the streamed body then has no flat deadline (a long completion is legitimate).
-	responseHeaderTimeout = 2 * time.Minute
-	// idleTimeout aborts a stream that stalls (no bytes) for this long — the streaming
-	// counterpart of an overall deadline, without killing an actively-sending stream.
-	idleTimeout = 2 * time.Minute
-)
+const apiVersion = "2023-06-01"
 
 // Client is an Anthropic Messages API model provider.
 type Client struct {
-	baseURL   string
-	model     string
-	apiKey    string
-	maxTokens int
-	effort    string
-	http      *http.Client
+	clientcore.Base
+	effort string
 }
 
 // New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
-// maxTokens caps output tokens per request; <= 0 falls back to defaultMaxTokens.
-// effort opts into deeper reasoning (output_config.effort: low|medium|high|max,
-// validated in config); empty omits the field entirely.
+// maxTokens caps output tokens per request; <= 0 falls back to
+// clientcore.DefaultMaxTokens. effort opts into deeper reasoning
+// (output_config.effort: low|medium|high|max, validated in config); empty
+// omits the field entirely.
 func New(baseURL, model, apiKey string, maxTokens int, effort string) *Client {
-	if baseURL == "" {
-		baseURL = DefaultBaseURL
-	}
-	if maxTokens <= 0 {
-		maxTokens = defaultMaxTokens
-	}
 	return &Client{
-		baseURL:   strings.TrimRight(baseURL, "/"),
-		model:     model,
-		apiKey:    apiKey,
-		maxTokens: maxTokens,
-		effort:    effort,
-		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
+		Base:   clientcore.NewBase(baseURL, DefaultBaseURL, model, apiKey, maxTokens),
+		effort: effort,
 	}
 }
 
@@ -196,7 +171,7 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 			blocks[len(blocks)-1].CacheControl = ephemeral
 		}
 	}
-	areq := msgRequest{Model: c.model, MaxTokens: c.maxTokens, Stream: true, Messages: msgs}
+	areq := msgRequest{Model: c.Model, MaxTokens: c.MaxTokens, Stream: true, Messages: msgs}
 	if req.ToolChoice != "" {
 		areq.ToolChoice = &toolChoice{Type: "tool", Name: req.ToolChoice}
 	}
@@ -219,58 +194,23 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	if n := len(areq.Tools); n > 0 {
 		areq.Tools[n-1].CacheControl = ephemeral
 	}
-	body, err := json.Marshal(areq)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
-	}
-	// A child context lets the idle-timeout reader abort a stalled stream by cancelling
-	// the in-flight HTTP read; cancel always runs on return to release resources.
-	streamCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	newReq := func() (*http.Request, error) {
-		r, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
-		if err != nil {
-			return nil, err
-		}
-		r.Header.Set("content-type", "application/json")
-		r.Header.Set("anthropic-version", apiVersion)
-		r.Header.Set("x-api-key", c.apiKey)
-		return r, nil
-	}
-	// DoWithRetry retries only connection establishment / 429 / 5xx (before the stream
-	// begins); once a 200 stream is flowing it is never retried mid-stream.
-	resp, err := httpx.DoWithRetry(streamCtx, c.http, 3, newReq)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("messages request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		// Read a bounded prefix of the error body. Anthropic returns a JSON error
-		// object; surface only its structured type/message (never the raw bytes),
-		// sanitized, so 4xx causes (e.g. 400 invalid_request_error "prompt is too
-		// long", or a bad tool_use/tool_result pairing) are diagnosable from the
-		// error alone — without info disclosure or log injection.
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-		err := fmt.Errorf("messages status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), anthropicErrorDetail(body))
-		// A 4xx other than 429 is permanent: the request itself is bad (e.g. 400
-		// invalid_request_error, 401/403 auth, 404), so retrying can't help. Mark it
-		// so the investigation workqueue drops it instead of requeuing forever. 429
-		// and 5xx are already retried by DoWithRetry and stay transient here.
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
-			return providers.CompletionResponse{}, providers.Permanent(err)
-		}
-		return providers.CompletionResponse{}, err
-	}
-	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
-	return accumulate(stream)
+	return c.Stream(ctx, clientcore.Request{
+		Op:   "messages",
+		URL:  c.BaseURL + "/v1/messages",
+		Body: areq,
+		SetHeaders: func(r *http.Request) {
+			r.Header.Set("content-type", "application/json")
+			r.Header.Set("anthropic-version", apiVersion)
+			r.Header.Set("x-api-key", c.APIKey)
+		},
+		ErrorDetail: anthropicErrorDetail,
+	}, accumulate)
 }
 
 // anthropicErrorDetail extracts a sanitized ": type: message" suffix from an
-// Anthropic error response body, or "" if the body can't be parsed as one. Only
-// the structured error.type / error.message fields are surfaced (never the raw
-// bytes), control characters are collapsed to spaces to prevent log injection,
-// and the message is truncated — so a 4xx cause is diagnosable without echoing
-// arbitrary upstream content into an Error-level log.
+// Anthropic error response body, or "" if the body can't be parsed as one.
+// Only the structured error.type / error.message fields are surfaced (never
+// the raw bytes); sanitization and truncation live in clientcore.Detail.
 func anthropicErrorDetail(body []byte) string {
 	var e struct {
 		Error struct {
@@ -281,48 +221,7 @@ func anthropicErrorDetail(body []byte) string {
 	if err := json.Unmarshal(body, &e); err != nil || (e.Error.Type == "" && e.Error.Message == "") {
 		return ""
 	}
-	msg := sanitizeLine(e.Error.Message)
-	const maxLen = 300
-	if len(msg) > maxLen {
-		msg = msg[:maxLen] + "…"
-	}
-	return fmt.Sprintf(": %s: %s", sanitizeLine(e.Error.Type), msg)
-}
-
-// sanitizeLine collapses control characters (including newlines) to spaces so an
-// upstream-controlled string can't inject additional log lines.
-func sanitizeLine(s string) string {
-	return strings.TrimSpace(strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return ' '
-		}
-		return r
-	}, s))
-}
-
-// sseEvents parses the Anthropic Messages SSE stream into decoded streamEvents. It
-// wraps the generic httpx.SSEData framing primitive and json-unmarshals each event's
-// data payload; a framing/read error or a JSON decode error is surfaced via the
-// second yield value.
-func sseEvents(r io.Reader) iter.Seq2[streamEvent, error] {
-	return func(yield func(streamEvent, error) bool) {
-		for payload, err := range httpx.SSEData(r) {
-			if err != nil {
-				yield(streamEvent{}, err)
-				return
-			}
-			var ev streamEvent
-			if err := json.Unmarshal(payload, &ev); err != nil {
-				if !yield(streamEvent{}, fmt.Errorf("decode sse event: %w", err)) {
-					return
-				}
-				continue
-			}
-			if !yield(ev, nil) {
-				return
-			}
-		}
-	}
+	return clientcore.Detail(e.Error.Type, e.Error.Message)
 }
 
 // accumulate consumes an Anthropic Messages SSE stream and folds it into one
@@ -338,7 +237,7 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 	var order []int // tool block indices, in first-seen order
 	sawStop := false
 
-	for ev, err := range sseEvents(r) {
+	for ev, err := range clientcore.SSEEvents[streamEvent](r) {
 		if err != nil {
 			return providers.CompletionResponse{}, fmt.Errorf("read stream: %w", err)
 		}
@@ -410,7 +309,7 @@ func toMessages(in []providers.Message) []message {
 				blocks = append(blocks, block{Type: "text", Text: m.Content})
 			}
 			for _, tc := range m.ToolCalls {
-				blocks = append(blocks, block{Type: "tool_use", ID: tc.ID, Name: tc.Name, Input: rawObject(tc.Args)})
+				blocks = append(blocks, block{Type: "tool_use", ID: tc.ID, Name: tc.Name, Input: clientcore.RawObject(tc.Args)})
 			}
 			out = append(out, message{Role: "assistant", Content: blocks})
 		case "tool":
@@ -426,12 +325,4 @@ func toMessages(in []providers.Message) []message {
 		}
 	}
 	return out
-}
-
-// rawObject ensures tool_use input is a JSON object ("" → {}).
-func rawObject(args string) json.RawMessage {
-	if strings.TrimSpace(args) == "" {
-		return json.RawMessage("{}")
-	}
-	return json.RawMessage(args)
 }

--- a/internal/model/clientcore/clientcore.go
+++ b/internal/model/clientcore/clientcore.go
@@ -1,0 +1,61 @@
+// Package clientcore provides the plumbing shared by the hand-rolled model
+// provider clients (anthropic, gemini, openai): common construction defaults,
+// the streaming request pipeline (retry, status classification, idle-timeout
+// guard), SSE event decoding, and error-detail sanitization. Everything
+// provider-specific — wire types, SSE event-accumulation grammar, error-body
+// JSON shapes, auth headers — stays in the provider packages.
+package clientcore
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+)
+
+const (
+	// DefaultMaxTokens is the output-token ceiling used when the caller passes
+	// <= 0. The anthropic client previously defaulted to 4096, diverging from
+	// openai/gemini; the app layer always passes a resolved value, so that
+	// divergence was dead in practice — aligned to 8192 here.
+	DefaultMaxTokens = 8192
+	// ResponseHeaderTimeout caps the wait for response headers
+	// (time-to-first-byte); the streamed body then has no flat deadline (a
+	// long completion is legitimate).
+	ResponseHeaderTimeout = 2 * time.Minute
+	// IdleTimeout aborts a stream that stalls (no bytes) for this long — the
+	// streaming counterpart of an overall deadline, without killing an
+	// actively-sending stream.
+	IdleTimeout = 2 * time.Minute
+)
+
+// Base carries the configuration fields common to every provider client.
+// Provider clients embed it and add their own knobs (e.g. reasoning effort).
+type Base struct {
+	BaseURL   string
+	Model     string
+	APIKey    string
+	MaxTokens int
+	HTTP      *http.Client
+}
+
+// NewBase normalizes the shared constructor inputs: an empty baseURL falls
+// back to defaultBaseURL (which may itself be empty for providers without a
+// public default), trailing slashes are trimmed, maxTokens <= 0 falls back to
+// DefaultMaxTokens, and the HTTP client is the hardened streaming client.
+func NewBase(baseURL, defaultBaseURL, model, apiKey string, maxTokens int) Base {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	if maxTokens <= 0 {
+		maxTokens = DefaultMaxTokens
+	}
+	return Base{
+		BaseURL:   strings.TrimRight(baseURL, "/"),
+		Model:     model,
+		APIKey:    apiKey,
+		MaxTokens: maxTokens,
+		HTTP:      httpx.SecureStreamingClient(ResponseHeaderTimeout),
+	}
+}

--- a/internal/model/clientcore/detail.go
+++ b/internal/model/clientcore/detail.go
@@ -1,0 +1,35 @@
+package clientcore
+
+import (
+	"fmt"
+	"strings"
+)
+
+// maxDetailLen truncates the sanitized upstream message so an
+// attacker-controlled error body can't bloat logs.
+const maxDetailLen = 300
+
+// Detail formats a provider error's structured kind/message pair as a
+// sanitized ": kind: message" error suffix. Control characters are collapsed
+// to spaces (log-injection defense) and the message is truncated, so a 4xx
+// cause is diagnosable without echoing arbitrary upstream content into an
+// Error-level log. Each provider parses its own error-body JSON shape and
+// passes the extracted fields here.
+func Detail(kind, message string) string {
+	msg := sanitizeLine(message)
+	if len(msg) > maxDetailLen {
+		msg = msg[:maxDetailLen] + "…"
+	}
+	return fmt.Sprintf(": %s: %s", sanitizeLine(kind), msg)
+}
+
+// sanitizeLine collapses control characters (including newlines) to spaces so
+// an upstream-controlled string can't inject additional log lines.
+func sanitizeLine(s string) string {
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, s))
+}

--- a/internal/model/clientcore/sse.go
+++ b/internal/model/clientcore/sse.go
@@ -1,0 +1,40 @@
+package clientcore
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"iter"
+
+	"github.com/Smana/runlore/internal/httpx"
+)
+
+// SSEEvents parses an SSE stream into decoded events of type E. It wraps the
+// generic httpx.SSEData framing primitive and json-unmarshals each event's
+// data payload; a framing/read error or a JSON decode error is surfaced via
+// the second yield value.
+//
+// A provider whose stream grammar doesn't fit (e.g. openai's non-JSON [DONE]
+// sentinel) keeps its own loop over httpx.SSEData.
+func SSEEvents[E any](r io.Reader) iter.Seq2[E, error] {
+	return func(yield func(E, error) bool) {
+		for payload, err := range httpx.SSEData(r) {
+			if err != nil {
+				var zero E
+				yield(zero, err)
+				return
+			}
+			var ev E
+			if err := json.Unmarshal(payload, &ev); err != nil {
+				var zero E
+				if !yield(zero, fmt.Errorf("decode sse event: %w", err)) {
+					return
+				}
+				continue
+			}
+			if !yield(ev, nil) {
+				return
+			}
+		}
+	}
+}

--- a/internal/model/clientcore/stream.go
+++ b/internal/model/clientcore/stream.go
@@ -1,0 +1,89 @@
+package clientcore
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const (
+	// retryAttempts bounds httpx.DoWithRetry's attempts per completion request.
+	retryAttempts = 3
+	// maxErrorBody bounds how much of a non-200 response body is read for the
+	// error detail.
+	maxErrorBody = 4 << 10
+)
+
+// Request describes one streaming completion call. Everything
+// provider-specific about the HTTP exchange is injected here; the pipeline
+// itself (retry, status classification, idle-timeout guard) is shared.
+type Request struct {
+	// Op names the operation in error messages (e.g. "messages", "chat").
+	Op string
+	// URL is the full endpoint URL.
+	URL string
+	// Body is the provider's wire-format request struct, marshaled as JSON.
+	Body any
+	// SetHeaders sets the provider's headers (content type, auth, version).
+	SetHeaders func(*http.Request)
+	// ErrorDetail parses a provider error body into a sanitized
+	// ": kind: message" suffix for the status error (see Detail), or "" if
+	// the body isn't a recognizable provider error.
+	ErrorDetail func(body []byte) string
+}
+
+// Stream sends req as a streaming POST and hands the response body — guarded
+// by the idle-timeout reader — to accumulate, which folds the provider's SSE
+// stream into a single CompletionResponse.
+func (b *Base) Stream(ctx context.Context, req Request, accumulate func(io.Reader) (providers.CompletionResponse, error)) (providers.CompletionResponse, error) {
+	body, err := json.Marshal(req.Body)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
+	}
+	// A child context lets the idle-timeout reader abort a stalled stream by
+	// cancelling the in-flight HTTP read; cancel always runs on return to
+	// release resources.
+	streamCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	newReq := func() (*http.Request, error) {
+		r, err := http.NewRequestWithContext(streamCtx, http.MethodPost, req.URL, bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.SetHeaders(r)
+		return r, nil
+	}
+	// DoWithRetry retries only connection establishment / 429 / 5xx (before
+	// the stream begins); once a 200 stream is flowing it is never retried
+	// mid-stream.
+	resp, err := httpx.DoWithRetry(streamCtx, b.HTTP, retryAttempts, newReq)
+	if err != nil {
+		return providers.CompletionResponse{}, fmt.Errorf("%s request: %w", req.Op, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		// Read a bounded prefix of the error body. Never echo the raw bytes
+		// into an Error-level log (info disclosure + log injection); surface
+		// only the provider's structured, sanitized detail so a 4xx cause
+		// (e.g. an invalid request, an unknown model, a rejected API key) is
+		// diagnosable from the error alone.
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+		err := fmt.Errorf("%s status %d (request-id %q)%s", req.Op, resp.StatusCode, httpx.RequestID(resp.Header), req.ErrorDetail(errBody))
+		// A 4xx other than 429 is permanent: the request itself is bad (e.g.
+		// 400 invalid request, 401/403 auth, 404 unknown model), so retrying
+		// can't help. Mark it so the investigation workqueue drops it instead
+		// of requeuing forever. 429 and 5xx are already retried by DoWithRetry
+		// and stay transient here.
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return providers.CompletionResponse{}, providers.Permanent(err)
+		}
+		return providers.CompletionResponse{}, err
+	}
+	return accumulate(httpx.NewIdleTimeoutReader(resp.Body, IdleTimeout, cancel))
+}

--- a/internal/model/clientcore/wire.go
+++ b/internal/model/clientcore/wire.go
@@ -1,0 +1,15 @@
+package clientcore
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// RawObject ensures a tool call's argument payload is a JSON object ("" → {})
+// before it goes on the wire.
+func RawObject(args string) json.RawMessage {
+	if strings.TrimSpace(args) == "" {
+		return json.RawMessage("{}")
+	}
+	return json.RawMessage(args)
+}

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -14,33 +14,19 @@
 package gemini
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
-	"iter"
 	"net/http"
 	"strings"
-	"time"
 
-	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/model/clientcore"
 	"github.com/Smana/runlore/internal/providers"
 )
 
 // DefaultBaseURL is the public Gemini API.
 const DefaultBaseURL = "https://generativelanguage.googleapis.com"
-
-const (
-	// defaultMaxTokens is the output-token ceiling used when the caller passes <= 0.
-	defaultMaxTokens = 8192
-	// responseHeaderTimeout caps the wait for response headers (time-to-first-byte);
-	// the streamed body then has no flat deadline (a long completion is legitimate).
-	responseHeaderTimeout = 2 * time.Minute
-	// idleTimeout aborts a stream that stalls (no bytes) for this long — the streaming
-	// counterpart of an overall deadline, without killing an actively-sending stream.
-	idleTimeout = 2 * time.Minute
-)
 
 // Caching: RunLore relies on Gemini's automatic IMPLICIT prefix caching (enabled on
 // Gemini 2.5+). No explicit CachedContent lifecycle is used. This depends on the request
@@ -49,29 +35,14 @@ const (
 
 // Client is a Gemini (streamGenerateContent) model provider.
 type Client struct {
-	baseURL   string
-	model     string
-	apiKey    string
-	maxTokens int
-	http      *http.Client
+	clientcore.Base
 }
 
 // New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
-// maxTokens caps output tokens per request; <= 0 falls back to defaultMaxTokens.
+// maxTokens caps output tokens per request; <= 0 falls back to
+// clientcore.DefaultMaxTokens.
 func New(baseURL, model, apiKey string, maxTokens int) *Client {
-	if baseURL == "" {
-		baseURL = DefaultBaseURL
-	}
-	if maxTokens <= 0 {
-		maxTokens = defaultMaxTokens
-	}
-	return &Client{
-		baseURL:   strings.TrimRight(baseURL, "/"),
-		model:     model,
-		apiKey:    apiKey,
-		maxTokens: maxTokens,
-		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
-	}
+	return &Client{Base: clientcore.NewBase(baseURL, DefaultBaseURL, model, apiKey, maxTokens)}
 }
 
 var _ providers.ModelProvider = (*Client)(nil)
@@ -169,7 +140,7 @@ type genResponse struct {
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
 	greq := genRequest{
 		Contents:         toContents(req.Messages),
-		GenerationConfig: &generationConfig{MaxOutputTokens: c.maxTokens},
+		GenerationConfig: &generationConfig{MaxOutputTokens: c.MaxTokens},
 	}
 	if req.System != "" {
 		greq.SystemInstruction = &content{Parts: []part{{Text: req.System}}}
@@ -186,59 +157,25 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 			Mode: "ANY", AllowedFunctionNames: []string{req.ToolChoice},
 		}}
 	}
-	body, err := json.Marshal(greq)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
-	}
-	// ?alt=sse switches streamGenerateContent from a JSON array to a Server-Sent
-	// Events stream: one GenerateContentResponse per data: event, ending at EOF.
-	url := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", c.baseURL, c.model)
-	// A child context lets the idle-timeout reader abort a stalled stream by cancelling
-	// the in-flight HTTP read; cancel always runs on return to release resources.
-	streamCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	newReq := func() (*http.Request, error) {
-		r, err := http.NewRequestWithContext(streamCtx, http.MethodPost, url, bytes.NewReader(body))
-		if err != nil {
-			return nil, err
-		}
-		r.Header.Set("Content-Type", "application/json")
-		r.Header.Set("x-goog-api-key", c.apiKey)
-		return r, nil
-	}
-	// DoWithRetry retries only connection establishment / 429 / 5xx (before the stream
-	// begins); once a 200 stream is flowing it is never retried mid-stream.
-	resp, err := httpx.DoWithRetry(streamCtx, c.http, 3, newReq)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("streamGenerateContent request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		// Read a bounded prefix of the error body. Never echo the raw bytes into an
-		// Error-level log (info disclosure + log injection); surface only the
-		// structured error status/message, sanitized, so 4xx causes (e.g. a 400
-		// INVALID_ARGUMENT or a 404 unknown model) are diagnosable from the error alone.
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-		err := fmt.Errorf("streamGenerateContent status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), geminiErrorDetail(body))
-		// A 4xx other than 429 is permanent: the request itself is bad (e.g. 400
-		// INVALID_ARGUMENT, 401/403 auth, 404 unknown model), so retrying can't help.
-		// Mark it so the investigation workqueue drops it instead of requeuing forever.
-		// 429 and 5xx are already retried by DoWithRetry and stay transient here.
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
-			return providers.CompletionResponse{}, providers.Permanent(err)
-		}
-		return providers.CompletionResponse{}, err
-	}
-	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
-	return accumulate(stream)
+	return c.Stream(ctx, clientcore.Request{
+		Op: "streamGenerateContent",
+		// ?alt=sse switches streamGenerateContent from a JSON array to a Server-Sent
+		// Events stream: one GenerateContentResponse per data: event, ending at EOF.
+		URL:  fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", c.BaseURL, c.Model),
+		Body: greq,
+		SetHeaders: func(r *http.Request) {
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("x-goog-api-key", c.APIKey)
+		},
+		ErrorDetail: geminiErrorDetail,
+	}, accumulate)
 }
 
 // geminiErrorDetail extracts a sanitized ": status: message" suffix from a Gemini
 // error response body ({"error":{"code","message","status"}}), or "" if the body
 // can't be parsed as one. Only the structured error.status / error.message fields
-// are surfaced (never the raw bytes), control characters are collapsed to spaces
-// to prevent log injection, and the message is truncated — so a 4xx cause is
-// diagnosable without echoing arbitrary upstream content into an Error-level log.
+// are surfaced (never the raw bytes); sanitization and truncation live in
+// clientcore.Detail.
 func geminiErrorDetail(body []byte) string {
 	var e struct {
 		Error struct {
@@ -249,48 +186,7 @@ func geminiErrorDetail(body []byte) string {
 	if err := json.Unmarshal(body, &e); err != nil || (e.Error.Status == "" && e.Error.Message == "") {
 		return ""
 	}
-	msg := sanitizeLine(e.Error.Message)
-	const maxLen = 300
-	if len(msg) > maxLen {
-		msg = msg[:maxLen] + "…"
-	}
-	return fmt.Sprintf(": %s: %s", sanitizeLine(e.Error.Status), msg)
-}
-
-// sanitizeLine collapses control characters (including newlines) to spaces so an
-// upstream-controlled string can't inject additional log lines.
-func sanitizeLine(s string) string {
-	return strings.TrimSpace(strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return ' '
-		}
-		return r
-	}, s))
-}
-
-// sseEvents parses the Gemini SSE stream into decoded genResponse chunks. It wraps the
-// generic httpx.SSEData framing primitive and json-unmarshals each event's data
-// payload (one full GenerateContentResponse per event); a framing/read error or a JSON
-// decode error is surfaced via the second yield value.
-func sseEvents(r io.Reader) iter.Seq2[genResponse, error] {
-	return func(yield func(genResponse, error) bool) {
-		for payload, err := range httpx.SSEData(r) {
-			if err != nil {
-				yield(genResponse{}, err)
-				return
-			}
-			var gr genResponse
-			if err := json.Unmarshal(payload, &gr); err != nil {
-				if !yield(genResponse{}, fmt.Errorf("decode sse event: %w", err)) {
-					return
-				}
-				continue
-			}
-			if !yield(gr, nil) {
-				return
-			}
-		}
-	}
+	return clientcore.Detail(e.Error.Status, e.Error.Message)
 }
 
 // accumulate consumes a Gemini SSE stream and folds it into one CompletionResponse:
@@ -303,7 +199,7 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 	var out providers.CompletionResponse
 	sawFinish := false
 
-	for gr, err := range sseEvents(r) {
+	for gr, err := range clientcore.SSEEvents[genResponse](r) {
 		if err != nil {
 			return providers.CompletionResponse{}, fmt.Errorf("read stream: %w", err)
 		}
@@ -384,7 +280,7 @@ func toContents(in []providers.Message) []content {
 				parts = append(parts, part{FunctionCall: &functionCall{
 					ID:   wireID(tc.ID, tc.Name),
 					Name: tc.Name,
-					Args: rawObject(tc.Args),
+					Args: clientcore.RawObject(tc.Args),
 				}})
 			}
 			out = append(out, content{Role: "model", Parts: parts})
@@ -420,14 +316,6 @@ func wireID(id, name string) string {
 		return ""
 	}
 	return id
-}
-
-// rawObject ensures functionCall args is a JSON object ("" → {}).
-func rawObject(args string) json.RawMessage {
-	if strings.TrimSpace(args) == "" {
-		return json.RawMessage("{}")
-	}
-	return json.RawMessage(args)
 }
 
 // argString renders a response functionCall's args (a JSON object) as the string

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -10,49 +10,28 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/model/clientcore"
 	"github.com/Smana/runlore/internal/providers"
-)
-
-// defaultMaxTokens is the output-token ceiling used when the caller passes <= 0.
-const defaultMaxTokens = 8192
-
-const (
-	// responseHeaderTimeout caps the wait for response headers (time-to-first-byte);
-	// the streamed body then has no flat deadline (a long completion is legitimate).
-	responseHeaderTimeout = 2 * time.Minute
-	// idleTimeout aborts a stream that stalls (no bytes) for this long — the streaming
-	// counterpart of an overall deadline, without killing an actively-sending stream.
-	idleTimeout = 2 * time.Minute
 )
 
 // Client is an OpenAI-compatible model provider.
 type Client struct {
-	baseURL   string
-	model     string
-	apiKey    string
-	maxTokens int
-	effort    string
-	http      *http.Client
+	clientcore.Base
+	effort string
 }
 
 // New builds a client. apiKey may be empty (keyless vLLM/Ollama). maxTokens caps
-// output tokens per request; <= 0 falls back to defaultMaxTokens. effort opts into
-// deeper reasoning (reasoning_effort: minimal|low|medium|high, validated in
-// config); empty omits the field entirely.
+// output tokens per request; <= 0 falls back to clientcore.DefaultMaxTokens.
+// effort opts into deeper reasoning (reasoning_effort: minimal|low|medium|high,
+// validated in config); empty omits the field entirely.
 func New(baseURL, model, apiKey string, maxTokens int, effort string) *Client {
-	if maxTokens <= 0 {
-		maxTokens = defaultMaxTokens
-	}
 	return &Client{
-		baseURL:   strings.TrimRight(baseURL, "/"),
-		model:     model,
-		apiKey:    apiKey,
-		maxTokens: maxTokens,
-		effort:    effort,
-		http:      httpx.SecureStreamingClient(responseHeaderTimeout),
+		// No public default base URL: an OpenAI-compatible endpoint is always
+		// operator-configured, so an empty baseURL stays empty.
+		Base:   clientcore.NewBase(baseURL, "", model, apiKey, maxTokens),
+		effort: effort,
 	}
 }
 
@@ -209,10 +188,10 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	}
 
 	creq := chatRequest{
-		Model:           c.model,
+		Model:           c.Model,
 		Messages:        msgs,
 		Tools:           tools,
-		MaxTokens:       c.maxTokens,
+		MaxTokens:       c.MaxTokens,
 		Stream:          true,
 		StreamOptions:   &streamOptions{IncludeUsage: true},
 		ReasoningEffort: c.effort,
@@ -220,61 +199,25 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	if req.ToolChoice != "" {
 		creq.ToolChoice = &toolChoice{Type: "function", Function: toolChoiceFunction{Name: req.ToolChoice}}
 	}
-	body, err := json.Marshal(creq)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("marshal request: %w", err)
-	}
-	// A child context lets the idle-timeout reader abort a stalled stream by cancelling
-	// the in-flight HTTP read; cancel always runs on return to release resources.
-	streamCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	newReq := func() (*http.Request, error) {
-		r, err := http.NewRequestWithContext(streamCtx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
-		if err != nil {
-			return nil, err
-		}
-		r.Header.Set("Content-Type", "application/json")
-		if c.apiKey != "" {
-			r.Header.Set("Authorization", "Bearer "+c.apiKey)
-		}
-		return r, nil
-	}
-	// DoWithRetry retries only connection establishment / 429 / 5xx (before the stream
-	// begins); once a 200 stream is flowing it is never retried mid-stream.
-	resp, err := httpx.DoWithRetry(streamCtx, c.http, 3, newReq)
-	if err != nil {
-		return providers.CompletionResponse{}, fmt.Errorf("chat request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		// Read a bounded prefix of the error body. base_url is operator-configurable, so
-		// never echo the raw bytes into an Error-level log (a misbehaving/compromised
-		// proxy could inject arbitrary content — info disclosure + log injection);
-		// surface only the structured error type/message, sanitized, so 4xx causes
-		// (e.g. an unknown model name or a rejected API key) are diagnosable from the
-		// error alone.
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-		err := fmt.Errorf("chat status %d (request-id %q)%s", resp.StatusCode, httpx.RequestID(resp.Header), openaiErrorDetail(body))
-		// A 4xx other than 429 is permanent: the request itself is bad (e.g. 400
-		// invalid request, 401/403 auth, 404 unknown model), so retrying can't help.
-		// Mark it so the investigation workqueue drops it instead of requeuing forever.
-		// 429 and 5xx are already retried by DoWithRetry and stay transient here.
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
-			return providers.CompletionResponse{}, providers.Permanent(err)
-		}
-		return providers.CompletionResponse{}, err
-	}
-	stream := httpx.NewIdleTimeoutReader(resp.Body, idleTimeout, cancel)
-	return accumulate(stream)
+	return c.Stream(ctx, clientcore.Request{
+		Op:   "chat",
+		URL:  c.BaseURL + "/chat/completions",
+		Body: creq,
+		SetHeaders: func(r *http.Request) {
+			r.Header.Set("Content-Type", "application/json")
+			if c.APIKey != "" {
+				r.Header.Set("Authorization", "Bearer "+c.APIKey)
+			}
+		},
+		ErrorDetail: openaiErrorDetail,
+	}, accumulate)
 }
 
 // openaiErrorDetail extracts a sanitized ": type: message" suffix from an
 // OpenAI-compatible error response body ({"error":{"message","type","code"}}), or
 // "" if the body can't be parsed as one. Only the structured error.type /
-// error.message fields are surfaced (never the raw bytes), control characters are
-// collapsed to spaces to prevent log injection, and the message is truncated — so
-// a 4xx cause is diagnosable without echoing arbitrary upstream content into an
-// Error-level log.
+// error.message fields are surfaced (never the raw bytes); sanitization and
+// truncation live in clientcore.Detail.
 func openaiErrorDetail(body []byte) string {
 	var e struct {
 		Error struct {
@@ -285,23 +228,7 @@ func openaiErrorDetail(body []byte) string {
 	if err := json.Unmarshal(body, &e); err != nil || (e.Error.Type == "" && e.Error.Message == "") {
 		return ""
 	}
-	msg := sanitizeLine(e.Error.Message)
-	const maxLen = 300
-	if len(msg) > maxLen {
-		msg = msg[:maxLen] + "…"
-	}
-	return fmt.Sprintf(": %s: %s", sanitizeLine(e.Error.Type), msg)
-}
-
-// sanitizeLine collapses control characters (including newlines) to spaces so an
-// upstream-controlled string can't inject additional log lines.
-func sanitizeLine(s string) string {
-	return strings.TrimSpace(strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return ' '
-		}
-		return r
-	}, s))
+	return clientcore.Detail(e.Error.Type, e.Error.Message)
 }
 
 // accumulate consumes an OpenAI chat/completions SSE stream and folds it into one


### PR DESCRIPTION
## What

Pure, behavior-preserving refactor: the plumbing duplicated across the three hand-rolled LLM clients (`internal/model/{anthropic,gemini,openai}`) now lives in one shared package, `internal/model/clientcore`.

Built on top of #200 (`feat/model-effort`), which merged while this was in flight — so this PR targets `main` directly and already includes the effort knob in the refactored constructors.

## What moved where

| Shared (new `internal/model/clientcore`) | Previously |
|---|---|
| `Base` / `NewBase` — constructor normalization (baseURL default + `TrimRight`, maxTokens fallback, `httpx.SecureStreamingClient`) plus the shared `ResponseHeaderTimeout` / `IdleTimeout` constants | hand-rolled 3× |
| `Base.Stream` — the full request/stream pipeline: marshal, child stream context + cancel, header-setting closure, `httpx.DoWithRetry(…, 3, …)`, bounded 4 KiB error-body read, `providers.Permanent` for non-429 4xx, `httpx.NewIdleTimeoutReader` handoff to the provider's `accumulate` | duplicated 3× (~45 lines each) |
| `SSEEvents[E]` — generic SSE decode iterator | duplicated **verbatim** in anthropic + gemini |
| `Detail` + `sanitizeLine` — sanitize / truncate (300) / format machinery for error details | duplicated 3× |
| `RawObject` — empty tool args → `{}` | duplicated in anthropic + gemini |

## What deliberately stayed per-provider, and why

- **Wire request/response types** and per-provider request mutations (tool_choice/toolConfig, effort/reasoning_effort, cache_control) — genuinely different grammars.
- **SSE event accumulation** (`accumulate`) — each provider's event grammar differs (Anthropic block events, Gemini chunked `GenerateContentResponse`s, OpenAI deltas).
- **Error-body JSON parsing** (`anthropicErrorDetail` etc.) — shapes differ (`type` vs `status`); they're now thin parsers delegating sanitize/truncate to `clientcore.Detail`, and their tests stay put unmodified.
- **openai's SSE loop** — NOT unified onto `SSEEvents`: its `[DONE]` sentinel check and fatal-decode error text (`decode sse event: …` vs `read stream: decode sse event: …`) differ, so sharing it would change observable behavior. Abstracting around that would cost more code than the duplication it removes.

## Behavior notes

- **Zero behavior change**: no wire format, header, timeout, retry count, or error-message text changed. All existing provider tests pass **unmodified** (they exercise everything through `New(...).Complete(...)` against httptest servers plus the error-detail parsers, which stayed).
- One latent inconsistency fixed while here: anthropic's dead `defaultMaxTokens = 4096` (the app layer always passes a resolved value) is aligned to openai/gemini's 8192 via `clientcore.DefaultMaxTokens`, with a comment explaining why it's unobservable.

## LOC delta

`8 files changed, 318 insertions(+), 372 deletions(-)` → **net −54 lines**, with the three provider files shedding ~370 lines of duplication.

## Quality gate

`go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — all green, gofmt silent, golangci-lint 0 issues.