### PR TITLE
feat(investigate): execute a turn's tool calls concurrently

### DIFF
--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -386,51 +387,132 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		}
 		nudged = false
 		messages = append(messages, providers.Message{Role: "assistant", Content: resp.Text, ToolCalls: resp.ToolCalls})
-		for _, tc := range resp.ToolCalls {
-			if tc.Name == submitFindingsName {
-				inv, perr := parseFindings(tc.Args)
-				if perr != nil {
-					messages = append(messages, providers.Message{Role: "tool", ToolCallID: tc.ID, Content: "error: " + perr.Error()})
-					continue
-				}
-				if inv.Title == "" {
-					inv.Title = req.Title // default to the triggering incident/failure
-				}
-				// Prefer the workload the investigation identified; fall back to the
-				// originating alert workload only when the model named none.
-				inv.Resource = preferDiscoveredResource(inv.Resource, req.Workload)
-				inv.Fingerprint = req.Fingerprint   // originating alert id, for outcome-ledger attribution
-				inv.Fingerprints = req.Fingerprints // coalesced batch ids; one open per constituent alert
-				inv.TriggerKey = req.TriggerKey     // deterministic dedup key stamped at trigger time (#137)
-				li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
-				if li.Metrics != nil {
-					// Usage-anchored when the provider reported usage; heuristic otherwise.
-					li.Metrics.InvestigationTokens.Record(ctx, int64(calib.estimate(sys, messages, specs)))
-				}
-				if li.Verify {
-					inv = li.verifyFindings(ctx, req, inv)
-				}
-				inv.Actions = li.reviewActions(inv.Actions)
-				result = "resolved"
-				li.deliver(req, inv)
-				return nil
+		// Turn rule for submit_findings (unchanged from the sequential loop, locked by
+		// TestSubmitFindingsMixedTurn / TestMalformedSubmitFindingsAmongCalls): a
+		// turn's calls are honoured in their ORIGINAL order, and the FIRST
+		// submit_findings whose args parse finalizes the investigation — calls before
+		// it run and have their results recorded; calls after it NEVER run. A
+		// submit_findings with malformed args does not end the turn: it is answered
+		// with a parse-error tool result in its slot and the rest of the turn
+		// proceeds. Parsing args is pure, so scanning for the terminal call up front
+		// (before any tool runs) is observably identical to the old in-order walk.
+		terminal := -1
+		var final providers.Investigation
+		for i, tc := range resp.ToolCalls {
+			if tc.Name != submitFindingsName {
+				continue
 			}
-			used[tc.Name]++
+			if inv, perr := parseFindings(tc.Args); perr == nil {
+				terminal, final = i, inv
+				break
+			}
+		}
+		run := resp.ToolCalls
+		if terminal >= 0 {
+			run = resp.ToolCalls[:terminal]
+		}
+		// used and the truncation metric are updated here, on the loop goroutine, so
+		// the workers share no mutable state (each writes only its own result slot).
+		for _, tc := range run {
+			if tc.Name != submitFindingsName { // malformed submit_findings runs no tool
+				used[tc.Name]++
+			}
+		}
+		for i, tr := range li.dispatchTools(ctx, byName, run) {
+			if tr.trimmed > 0 && li.Metrics != nil {
+				li.Metrics.ToolOutputTruncatedBytes.Add(ctx, int64(tr.trimmed))
+			}
+			messages = append(messages, providers.Message{Role: "tool", ToolCallID: run[i].ID, Content: tr.content})
+		}
+		if terminal >= 0 {
+			inv := final
+			if inv.Title == "" {
+				inv.Title = req.Title // default to the triggering incident/failure
+			}
+			// Prefer the workload the investigation identified; fall back to the
+			// originating alert workload only when the model named none.
+			inv.Resource = preferDiscoveredResource(inv.Resource, req.Workload)
+			inv.Fingerprint = req.Fingerprint   // originating alert id, for outcome-ledger attribution
+			inv.Fingerprints = req.Fingerprints // coalesced batch ids; one open per constituent alert
+			inv.TriggerKey = req.TriggerKey     // deterministic dedup key stamped at trigger time (#137)
+			li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
+			if li.Metrics != nil {
+				// Usage-anchored when the provider reported usage; heuristic otherwise.
+				li.Metrics.InvestigationTokens.Record(ctx, int64(calib.estimate(sys, messages, specs)))
+			}
+			if li.Verify {
+				inv = li.verifyFindings(ctx, req, inv)
+			}
+			inv.Actions = li.reviewActions(inv.Actions)
+			result = "resolved"
+			li.deliver(req, inv)
+			return nil
+		}
+	}
+	li.Log.Warn("investigation hit max steps", "title", req.Title, "max", maxSteps, "tools_used", used)
+	result = "max_steps"
+	return nil
+}
+
+// maxConcurrentToolCalls bounds how many of one assistant turn's tool calls run at
+// once. All investigation tools are read-only, so concurrency is safe; the cap is
+// about the backends, not the loop. 4 covers the fan-out a typical turn actually
+// requests (1–4 calls: status + events + logs + a diff), so common turns get full
+// parallelism, while bounding pressure on the shared, often rate-limited backends
+// the tools hit (the Kubernetes API server, the git forge, metrics/logs endpoints)
+// and the memory held by large not-yet-truncated outputs in flight.
+const maxConcurrentToolCalls = 4
+
+// toolResult is one tool call's post-processed outcome: the redacted, truncated
+// content destined for history, and the number of bytes truncation removed.
+type toolResult struct {
+	content string
+	trimmed int
+}
+
+// dispatchTools executes one assistant turn's tool calls concurrently (bounded by
+// maxConcurrentToolCalls) and returns their results indexed by the ORIGINAL call
+// order, so the caller appends tool results to history deterministically no matter
+// which call finished first. Per-call semantics are exactly the sequential loop's:
+// runTool applies the per-tool timeout to each call individually, and each output
+// is redacted then truncated (redact first, so a secret near the cap is still
+// masked) before it becomes a result. A submit_findings reaching here is
+// necessarily malformed (a parseable one ends the turn before dispatch); it runs
+// no tool and is answered with its parse error. Workers write only their own slot
+// of the results slice, and the WaitGroup provides the happens-before edge back to
+// the caller — no shared mutable state.
+func (li *LoopInvestigator) dispatchTools(ctx context.Context, byName map[string]Tool, calls []providers.ToolCall) []toolResult {
+	results := make([]toolResult, len(calls))
+	sem := make(chan struct{}, maxConcurrentToolCalls)
+	var wg sync.WaitGroup
+	for i, tc := range calls {
+		if tc.Name == submitFindingsName {
+			_, perr := parseFindings(tc.Args)
+			if perr == nil {
+				// Unreachable by construction (the loop dispatches only calls before
+				// the first parseable submit_findings); keep the answer well-formed
+				// rather than panicking if that invariant ever changes.
+				perr = errors.New("submit_findings already handled for this turn")
+			}
+			results[i] = toolResult{content: "error: " + perr.Error()}
+			continue
+		}
+		wg.Add(1)
+		go func(i int, tc providers.ToolCall) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
 			// Redact secrets from tool output (pod/controller logs, git diffs, status/
 			// event messages) BEFORE it enters the prompt: this is the LLM-vendor egress
 			// boundary, and since the model only ever sees redacted text, the evidence it
 			// later quotes into the KB PR + chat is protected too. Redact before truncating
 			// so a secret near the cap is still masked.
 			out, trimmed := truncateOutput(redact.Secrets(li.runTool(ctx, byName, tc)), li.MaxToolOutputBytes)
-			if trimmed > 0 && li.Metrics != nil {
-				li.Metrics.ToolOutputTruncatedBytes.Add(ctx, int64(trimmed))
-			}
-			messages = append(messages, providers.Message{Role: "tool", ToolCallID: tc.ID, Content: out})
-		}
+			results[i] = toolResult{content: out, trimmed: trimmed}
+		}(i, tc)
 	}
-	li.Log.Warn("investigation hit max steps", "title", req.Title, "max", maxSteps, "tools_used", used)
-	result = "max_steps"
-	return nil
+	wg.Wait()
+	return results
 }
 
 func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool, tc providers.ToolCall) string {

--- a/internal/investigate/parallel_test.go
+++ b/internal/investigate/parallel_test.go
@@ -1,0 +1,257 @@
+package investigate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// slowTool is a fake investigation tool that sleeps for delay (respecting ctx) and
+// echoes its args, recording concurrency: how many calls are in flight at once and
+// which args it ran. Safe for concurrent use.
+type slowTool struct {
+	name  string
+	delay time.Duration
+
+	mu        sync.Mutex
+	inflight  int
+	maxInFly  int
+	calledFor []string
+}
+
+func (s *slowTool) Name() string        { return s.name }
+func (s *slowTool) Description() string { return "slow fake tool" }
+func (s *slowTool) Schema() string      { return `{"type":"object"}` }
+
+func (s *slowTool) Call(ctx context.Context, args string) (string, error) {
+	s.mu.Lock()
+	s.inflight++
+	if s.inflight > s.maxInFly {
+		s.maxInFly = s.inflight
+	}
+	s.calledFor = append(s.calledFor, args)
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.inflight--
+		s.mu.Unlock()
+	}()
+	select {
+	case <-time.After(s.delay):
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+	return "slow:" + args, nil
+}
+
+func (s *slowTool) maxInflight() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxInFly
+}
+
+func (s *slowTool) calls() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.calledFor...)
+}
+
+// toolResultsInOrder extracts the tool-result messages of req in history order as
+// (ToolCallID, Content) pairs.
+func toolResultsInOrder(req providers.CompletionRequest) (ids, contents []string) {
+	for _, m := range req.Messages {
+		if m.Role == "tool" {
+			ids = append(ids, m.ToolCallID)
+			contents = append(contents, m.Content)
+		}
+	}
+	return ids, contents
+}
+
+// TestToolCallsRunConcurrentlyAndKeepOrder proves the two core properties of the
+// parallel dispatch: (a) one turn's tool calls overlap in time — the turn's wall
+// clock is well under the serial sum of the per-call delays — and (b) the tool
+// results are appended to history in the ORIGINAL call order even when completion
+// order differs (the first call is the slowest).
+func TestToolCallsRunConcurrentlyAndKeepOrder(t *testing.T) {
+	const perCall = 100 * time.Millisecond
+	tool := &slowTool{name: "slow_tool", delay: perCall}
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		// One turn, four calls. Serial execution would take >= 4*perCall.
+		{ToolCalls: []providers.ToolCall{
+			{ID: "c1", Name: "slow_tool", Args: `{"n":1}`},
+			{ID: "c2", Name: "slow_tool", Args: `{"n":2}`},
+			{ID: "c3", Name: "slow_tool", Args: `{"n":3}`},
+			{ID: "c4", Name: "slow_tool", Args: `{"n":4}`},
+		}},
+		{ToolCalls: []providers.ToolCall{{ID: "f", Name: submitFindingsName,
+			Args: `{"confidence":0.7,"root_causes":[{"summary":"done"}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{tool},
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	start := time.Now()
+	if err := li.Investigate(context.Background(), Request{Title: "parallel"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	elapsed := time.Since(start)
+	if got == nil || len(got.RootCauses) != 1 {
+		t.Fatalf("investigation did not finish: %+v", got)
+	}
+	// Concurrency: 4 x 100ms serially is >= 400ms; concurrently ~100ms. 300ms is a
+	// generous margin for slow CI machines while still proving overlap.
+	if serial := 4 * perCall; elapsed >= serial-perCall {
+		t.Fatalf("turn took %v; want well under the %v serial sum (calls did not overlap)", elapsed, serial)
+	}
+	if tool.maxInflight() < 2 {
+		t.Fatalf("max in-flight calls = %d; want >= 2 (calls did not overlap)", tool.maxInflight())
+	}
+	// Ordering: the second model request carries the turn's tool results, which must
+	// be in the ORIGINAL call order regardless of completion order.
+	if len(model.reqs) != 2 {
+		t.Fatalf("expected 2 model calls, got %d", len(model.reqs))
+	}
+	ids, contents := toolResultsInOrder(model.reqs[1])
+	wantIDs := []string{"c1", "c2", "c3", "c4"}
+	if len(ids) != len(wantIDs) {
+		t.Fatalf("expected %d tool results, got %d (%v)", len(wantIDs), len(ids), ids)
+	}
+	for i, want := range wantIDs {
+		if ids[i] != want {
+			t.Fatalf("tool result order = %v, want %v", ids, wantIDs)
+		}
+		if wantContent := fmt.Sprintf(`slow:{"n":%d}`, i+1); contents[i] != wantContent {
+			t.Fatalf("tool result %s content = %q, want %q (result matched to wrong call)", ids[i], contents[i], wantContent)
+		}
+	}
+}
+
+// TestToolCallConcurrencyCap proves the worker cap: with more calls than
+// maxConcurrentToolCalls in one turn, at most maxConcurrentToolCalls run at once.
+func TestToolCallConcurrencyCap(t *testing.T) {
+	tool := &slowTool{name: "slow_tool", delay: 50 * time.Millisecond}
+	calls := make([]providers.ToolCall, 0, maxConcurrentToolCalls+3)
+	for i := 0; i < maxConcurrentToolCalls+3; i++ {
+		calls = append(calls, providers.ToolCall{ID: fmt.Sprintf("c%d", i), Name: "slow_tool", Args: fmt.Sprintf(`{"n":%d}`, i)})
+	}
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: calls},
+		{ToolCalls: []providers.ToolCall{{ID: "f", Name: submitFindingsName,
+			Args: `{"confidence":0.7,"root_causes":[{"summary":"done"}]}`}}},
+	}}
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{tool},
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		OnComplete: func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "cap"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got := tool.maxInflight(); got > maxConcurrentToolCalls {
+		t.Fatalf("max in-flight calls = %d; the cap is %d", got, maxConcurrentToolCalls)
+	}
+	if len(tool.calls()) != maxConcurrentToolCalls+3 {
+		t.Fatalf("all %d calls must run, got %d", maxConcurrentToolCalls+3, len(tool.calls()))
+	}
+}
+
+// TestSubmitFindingsMixedTurn locks the sequential turn rule under parallel
+// dispatch: when a turn mixes submit_findings with other calls, every call BEFORE
+// the first parseable submit_findings runs (and its result is recorded), the
+// submit_findings finalizes the investigation, and every call AFTER it never runs.
+func TestSubmitFindingsMixedTurn(t *testing.T) {
+	before := &slowTool{name: "before_tool"}
+	after := &slowTool{name: "after_tool"}
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{
+			{ID: "b", Name: "before_tool", Args: `{"which":"before"}`},
+			{ID: "f", Name: submitFindingsName, Args: `{"confidence":0.9,"root_causes":[{"summary":"mixed turn"}]}`},
+			{ID: "a", Name: "after_tool", Args: `{"which":"after"}`},
+		}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{before, after},
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "mixed"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil || len(got.RootCauses) != 1 || got.RootCauses[0].Summary != "mixed turn" {
+		t.Fatalf("submit_findings in a mixed turn must finalize the investigation, got %+v", got)
+	}
+	if model.i != 1 {
+		t.Fatalf("a parseable submit_findings must end the loop after one model call, got %d", model.i)
+	}
+	if calls := before.calls(); len(calls) != 1 {
+		t.Fatalf("the call BEFORE submit_findings must run exactly once, ran %d times", len(calls))
+	}
+	if calls := after.calls(); len(calls) != 0 {
+		t.Fatalf("the call AFTER submit_findings must NEVER run (sequential semantics), ran %d times: %v", len(calls), calls)
+	}
+}
+
+// TestMalformedSubmitFindingsAmongCalls locks the other half of the turn rule: a
+// submit_findings whose args do NOT parse does not end the turn — it is answered
+// with a parse-error tool result in its slot, the turn's other calls still run,
+// and the loop continues to the next step.
+func TestMalformedSubmitFindingsAmongCalls(t *testing.T) {
+	tool := &slowTool{name: "next_tool"}
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{
+			{ID: "m", Name: submitFindingsName, Args: `{"root_causes":[{"summary":`}, // malformed JSON
+			{ID: "n", Name: "next_tool", Args: `{"go":"on"}`},
+		}},
+		{ToolCalls: []providers.ToolCall{{ID: "f", Name: submitFindingsName,
+			Args: `{"confidence":0.7,"root_causes":[{"summary":"recovered"}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{tool},
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "malformed mixed"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil || len(got.RootCauses) != 1 || got.RootCauses[0].Summary != "recovered" {
+		t.Fatalf("loop must continue past a malformed submit_findings and deliver the valid one, got %+v", got)
+	}
+	if model.i != 2 {
+		t.Fatalf("expected 2 model calls (malformed turn + recovery), got %d", model.i)
+	}
+	if calls := tool.calls(); len(calls) != 1 {
+		t.Fatalf("the other call in the malformed turn must still run, ran %d times", len(calls))
+	}
+	// The malformed call's slot must carry the parse error, in original order, ahead
+	// of the other call's result.
+	ids, contents := toolResultsInOrder(model.reqs[1])
+	if len(ids) != 2 || ids[0] != "m" || ids[1] != "n" {
+		t.Fatalf("tool results must stay in call order [m n], got %v", ids)
+	}
+	if !strings.HasPrefix(contents[0], "error: ") {
+		t.Fatalf("malformed submit_findings must be answered with a parse-error result, got %q", contents[0])
+	}
+	if contents[1] != `slow:{"go":"on"}` {
+		t.Fatalf("other call's result = %q, want its own output", contents[1])
+	}
+}


### PR DESCRIPTION
## What

Executes a single assistant turn's tool calls **concurrently** instead of strictly sequentially. All investigation tools are read-only, so this is safe and cuts wall-clock latency on multi-call turns (status + events + logs + a diff) without changing any observable output.

## How

- New `dispatchTools` runs a turn's calls bounded by a worker cap (`maxConcurrentToolCalls = 4`) and returns results **indexed by the original call order**, so tool results are appended to history deterministically regardless of which call finished first (providers coalesce `tool_result` blocks; ordering must stay stable).
- Per-call semantics are byte-for-byte unchanged: the **per-tool timeout** still applies to each call individually (`runTool` is reused verbatim), and each output is **redacted then truncated** (redact first so a secret near the cap is still masked).
- Shared loop state (the `used` tool-call counters, the truncation-bytes metric) is updated on the loop goroutine; workers write only their own result slot and the `sync.WaitGroup` provides the happens-before edge — no shared mutable state. **Race-detector clean.**

## `submit_findings` turn rule (preserved + locked by tests)

Replicated exactly from the sequential loop:

- A turn's calls are honoured in **original order**, and the **first `submit_findings` whose args parse** finalizes the investigation — calls **before** it run and record results; calls **after** it **never** run.
- A `submit_findings` with **malformed** args does **not** end the turn: it is answered with a parse-error tool result in its slot and the rest of the turn proceeds.
- Parsing args is pure, so scanning for the terminal call *before* dispatch is observably identical to the old in-order walk.

## Concurrency cap rationale

`maxConcurrentToolCalls = 4` covers the fan-out a typical turn actually requests (1–4 calls), so common turns get full parallelism, while bounding pressure on the shared, often rate-limited backends the tools hit (the Kubernetes API server, the git forge, metrics/logs endpoints) and the memory held by large not-yet-truncated outputs in flight.

## Tests

- `TestToolCallsRunConcurrentlyAndKeepOrder` — four 100ms calls finish in ~0.10s (well under the 400ms serial sum, `maxInflight >= 2`) AND results stay in original call order with content matched to the right call.
- `TestToolCallConcurrencyCap` — with `cap+3` calls, at most `cap` run at once; all still run.
- `TestSubmitFindingsMixedTurn` — before-call runs, submit finalizes, after-call never runs.
- `TestMalformedSubmitFindingsAmongCalls` — malformed submit gets a parse-error result in-order, the other call still runs, loop continues to the valid submission.

Quality gate green: `go build`, `go vet`, `go test -race ./internal/investigate/...`, `go test ./...`, `gofmt -l .` (silent), `golangci-lint run ./...` (0 issues).