### PR TITLE
feat(source): PagerDuty V3 webhook source

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ additive. Full setup detail in **[Data sources](docs/data-sources.md)**.
 | **Cloud** | AWS — CloudTrail + EC2 / ASG / EKS | `cloud.provider` |
 | **Kubernetes** | client-go — pod status, events, controller logs | *(in-cluster)* |
 | **LLM** | Anthropic · Google Gemini · any OpenAI-compatible *(vLLM, Ollama, OpenRouter…)* | `model.provider` |
-| **Triggers** *(sources)* | Alertmanager webhook · GitOps failures | `sources.*` |
+| **Triggers** *(sources)* | Alertmanager webhook · GitOps failures · PagerDuty webhook *(new)* | `sources.*` |
 | **Notifiers** | Slack · Matrix · generic webhook | `notify.*` |
 | **Knowledge base** *(git forge)* | GitHub *(App auth)* | `forge.*` |
 
@@ -171,9 +171,9 @@ between commits. It's usable today, but "stable" means different things across t
   exercise — run it with confidence.
 - **Argo CD is now end-to-end tested**, alongside Flux: the k3d suite reconfigures to the `argocd`
   engine and drives an `Application Degraded` failure through a full investigation.
-- **Functional but less exercised:** **Matrix**, **Gemini**, cloud integrations, and the network
-  (Hubble) provider. They work and are tested, but see less real-world mileage — expect rougher
-  edges and please file issues.
+- **Functional but less exercised:** **Matrix**, **Gemini**, the **PagerDuty** webhook source, cloud
+  integrations, and the network (Hubble) provider. They work and are unit-tested, but see less
+  real-world mileage — expect rougher edges and please file issues.
 - **The `auto` autonomy rung is experimental, frozen, and not recommended on real
   clusters.** The supported posture is **read-only → suggest → approve**: RunLore reads
   and recommends, a human reviews and merges. Hands-off `auto` remains on the roadmap,

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -28,6 +28,10 @@ config:
     alertmanager: {}            # enable the Alertmanager/VMAlert webhook source
     gitops:
       enabled: true             # also react to Flux/Argo CD Ready=False
+    # pagerduty:                # enable the PagerDuty V3 incident webhook (POST /webhook/pagerduty)
+    #   secret_env: PAGERDUTY_WEBHOOK_SECRET  # env var NAME holding the subscription signing secret
+    #                                         # (verifies X-PagerDuty-Signature; required once a model
+    #                                         # is configured — fails closed otherwise)
   triggers:
     # Match POLICY for admitted alerts (enablement now lives under sources.alertmanager).
     incidents:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,7 +33,27 @@ list and comments, follow each link to `values.yaml`.
 
 ### `sources` — what wakes RunLore
 Per-source enablement map; presence enables a source. `alertmanager: {}` mounts the incident webhook;
-`gitops: { enabled: true }` watches GitOps `Ready=False`. Known keys: `alertmanager`, `gitops`.
+`gitops: { enabled: true }` watches GitOps `Ready=False`; `pagerduty: {}` mounts the PagerDuty V3
+incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
+
+- **`pagerduty`** — mounts `POST /webhook/pagerduty` for [PagerDuty V3 webhook subscriptions](https://developer.pagerduty.com/docs/webhooks-overview).
+  `incident.triggered` starts an investigation; `incident.resolved` closes the outcome (like an
+  Alertmanager resolved alert); every other event type is ignored. The incident title becomes the
+  investigation title, priority (else urgency) the severity, and the service name, incident number and
+  `html_url` ride along as labels. PagerDuty carries **no Kubernetes namespace or workload**, so those
+  stay empty — recall and structural matching tolerate an empty workload.
+  - `secret_env` — names the env var holding the webhook **signing secret** (config stores the env-var
+    *name*, never the value). Each delivery is verified against its `X-PagerDuty-Signature` header
+    (`v1=`-prefixed HMAC-SHA256 of the raw body; multiple comma-separated signatures are accepted so a
+    zero-downtime secret rotation works — any match passes, constant-time). This **replaces** the shared
+    `server.webhook_token_env` bearer token for this path (PagerDuty signs, it cannot send a bearer
+    token). An **unset** secret leaves the webhook open (mirrors the optional Alertmanager token) — but
+    it **fails closed** when a model is configured or `actions.mode=auto`: RunLore refuses to start with
+    an unauthenticated PagerDuty webhook once a model is wired.
+  - PD-side setup: create a [webhook subscription](https://developer.pagerduty.com/api-reference/b3A6MjkyNDc4NA-create-a-webhook-subscription)
+    (delivery URL `https://<runlore>/webhook/pagerduty`), subscribe to the `incident.triggered` /
+    `incident.resolved` events, and put the subscription's generated secret in the env var named by
+    `secret_env`.
 
 ### `triggers` — which incidents to investigate
 - `incidents.match` / `incidents.ignore` — ANDed matchers (`severity`, `environment`, `namespaces`

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -52,6 +52,20 @@ func RequireWebhookAuth(cfg *config.Config, webhookToken string) error {
 	return nil
 }
 
+// RequirePagerDutyAuth is the PagerDuty analogue of RequireWebhookAuth. The
+// PagerDuty source authenticates /webhook/pagerduty with its own
+// X-PagerDuty-Signature verification (not the shared server.webhook_token_env
+// bearer token), so the shared guard does not cover it. When the source is
+// enabled and a model is configured, it must carry a signing secret — otherwise
+// an unauthenticated caller could drive (and bill) the model. Fail closed on the
+// serve path only, mirroring RequireWebhookAuth.
+func RequirePagerDutyAuth(cfg *config.Config, enabled bool, secret string) error {
+	if enabled && ModelConfigured(cfg) && secret == "" {
+		return fmt.Errorf("model configured and sources.pagerduty enabled but its secret_env is empty: refusing to start with an unauthenticated PagerDuty webhook (fail closed)")
+	}
+	return nil
+}
+
 // OutcomeKind labels an outcome-ledger open as a recall (cache hit) or a fresh finding.
 func OutcomeKind(recalled bool) string {
 	if recalled {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -42,6 +42,34 @@ func TestRequireWebhookAuth(t *testing.T) {
 	}
 }
 
+// TestRequirePagerDutyAuth mirrors TestRequireWebhookAuth for the PagerDuty
+// source: its X-PagerDuty-Signature verification replaces the shared bearer
+// token on /webhook/pagerduty, so once a model is configured an enabled
+// PagerDuty source must carry a signing secret.
+func TestRequirePagerDutyAuth(t *testing.T) {
+	model := config.Model{Provider: "anthropic"} // built-in endpoint counts as configured
+	tests := []struct {
+		name    string
+		model   config.Model
+		enabled bool
+		secret  string
+		wantErr bool
+	}{
+		{"enabled + model + secret → ok", model, true, "s", false},
+		{"enabled + model + no secret → refused", model, true, "", true},
+		{"enabled + no model + no secret → ok (log-only)", config.Model{}, true, "", false},
+		{"disabled + model + no secret → ok", model, false, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := RequirePagerDutyAuth(&config.Config{Model: tc.model}, tc.enabled, tc.secret)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("RequirePagerDutyAuth err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestModelProvider locks in the provider-name normalization: anthropic/gemini
 // pass through; everything else (including "" and unknown) defaults to "openai".
 func TestModelProvider(t *testing.T) {

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Smana/runlore/internal/source"
 	_ "github.com/Smana/runlore/internal/source/alertmanager" // self-registers the alertmanager webhook source
 	_ "github.com/Smana/runlore/internal/source/gitops"       // self-registers the gitops-failure watcher source
+	"github.com/Smana/runlore/internal/source/pagerduty"
 	"github.com/Smana/runlore/internal/telemetry"
 	"github.com/Smana/runlore/internal/trigger"
 )
@@ -128,6 +129,13 @@ func RunServe(version string, args []string) error {
 	slackSigningSecret := os.Getenv(cfg.Notify.Slack.SigningSecretEnv)
 	webhookToken := os.Getenv(cfg.Server.WebhookTokenEnv)
 	if err := RequireWebhookAuth(cfg, webhookToken); err != nil {
+		return err
+	}
+	// The PagerDuty source authenticates its own webhook via X-PagerDuty-Signature
+	// (not the shared bearer token), so guard it separately on the same fail-closed
+	// policy: an enabled source with a configured model must carry a signing secret.
+	pdSecret, pdEnabled := pagerduty.Secret(cfg.Sources)
+	if err := RequirePagerDutyAuth(cfg, pdEnabled, pdSecret); err != nil {
 		return err
 	}
 

--- a/internal/config/sources_test.go
+++ b/internal/config/sources_test.go
@@ -13,6 +13,7 @@ import (
 	// Blank-import the adapters so they self-register and their Build funcs run.
 	_ "github.com/Smana/runlore/internal/source/alertmanager"
 	_ "github.com/Smana/runlore/internal/source/gitops"
+	_ "github.com/Smana/runlore/internal/source/pagerduty"
 )
 
 // fakeGitOps is a minimal GitOpsProvider so the gitops source Build (which requires
@@ -51,6 +52,7 @@ func TestSourcesMapEnablesAdapters(t *testing.T) {
 sources:
   alertmanager: {}
   gitops: { enabled: true }
+  pagerduty: {}
 `)
 	built, err := source.BuildEnabled(source.Deps{Cfg: c, GitOps: fakeGitOps{}, Raw: c.Sources})
 	if err != nil {
@@ -60,8 +62,8 @@ sources:
 	for _, b := range built {
 		names[b.Desc.Name] = true
 	}
-	if !names["alertmanager"] || !names["gitops"] {
-		t.Fatalf("want both alertmanager+gitops built, got %v", names)
+	if !names["alertmanager"] || !names["gitops"] || !names["pagerduty"] {
+		t.Fatalf("want alertmanager+gitops+pagerduty built, got %v", names)
 	}
 }
 

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -28,6 +28,8 @@ const (
 	SourceAlert Source = "alert"
 	// SourceGitOpsFailure means the investigation was triggered by a GitOps failure.
 	SourceGitOpsFailure Source = "gitops-failure"
+	// SourcePagerDuty means the investigation was triggered by a PagerDuty incident.
+	SourcePagerDuty Source = "pagerduty"
 )
 
 // Request is a normalized investigation trigger.

--- a/internal/source/pagerduty/auth.go
+++ b/internal/source/pagerduty/auth.go
@@ -1,0 +1,51 @@
+package pagerduty
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"strings"
+)
+
+// signatureHeader is the header PagerDuty V3 signs each delivery with.
+const signatureHeader = "X-PagerDuty-Signature"
+
+// Authenticate verifies a PagerDuty V3 webhook delivery. The X-PagerDuty-Signature
+// header carries one or more comma-separated `v1=<hex>` signatures (multiple during
+// a zero-downtime secret rotation), each an HMAC-SHA256 of the raw request body
+// keyed by the signing secret. The request is authentic if ANY signature matches
+// (constant-time compare).
+//
+// When the source has no secret configured the webhook is open (returns true),
+// mirroring the alertmanager source's optional bearer token. The serve path
+// enforces fail-closed policy (a configured model, or mode=auto, requires a
+// secret) before this is reached — see app.RequirePagerDutyAuth and Build.
+func (s Source) Authenticate(body []byte, h http.Header) bool {
+	if s.secret == "" {
+		return true
+	}
+	raw := h.Get(signatureHeader)
+	if raw == "" {
+		return false // secret configured but no signature: fail closed
+	}
+	mac := hmac.New(sha256.New, []byte(s.secret))
+	mac.Write(body)
+	want := mac.Sum(nil)
+
+	for _, sig := range strings.Split(raw, ",") {
+		sig = strings.TrimSpace(sig)
+		hexSig, ok := strings.CutPrefix(sig, "v1=")
+		if !ok {
+			continue // only the v1 scheme is understood
+		}
+		got, err := hex.DecodeString(hexSig)
+		if err != nil {
+			continue
+		}
+		if hmac.Equal(got, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/source/pagerduty/auth_test.go
+++ b/internal/source/pagerduty/auth_test.go
@@ -1,0 +1,73 @@
+package pagerduty
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"testing"
+)
+
+func sign(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func header(sigs ...string) http.Header {
+	h := http.Header{}
+	for _, s := range sigs {
+		if h.Get("X-PagerDuty-Signature") == "" {
+			h.Set("X-PagerDuty-Signature", s)
+		} else {
+			h.Set("X-PagerDuty-Signature", h.Get("X-PagerDuty-Signature")+","+s)
+		}
+	}
+	return h
+}
+
+// TestAuthenticateKnownVector pins the signature scheme to an independently
+// computed vector (openssl dgst -sha256 -hmac) so the implementation and the
+// test can't drift together.
+func TestAuthenticateKnownVector(t *testing.T) {
+	body := []byte(`{"event":{"event_type":"incident.triggered"}}`)
+	h := header("v1=68849d40f1a568b635d5ecd1ef218196974faba516f08b3a57330de1bd378770")
+	if !(Source{secret: "it-is-a-secret"}).Authenticate(body, h) {
+		t.Fatal("known-good signature must verify")
+	}
+}
+
+// TestAuthenticate is the signature-verification table: valid, invalid,
+// multiple signatures (zero-downtime rotation), missing header, unset secret.
+func TestAuthenticate(t *testing.T) {
+	const secret = "it-is-a-secret"
+	body := []byte(`{"event":{"event_type":"incident.triggered"}}`)
+	valid := sign(secret, body)
+	other := sign("rotated-secret", body)
+
+	cases := []struct {
+		name   string
+		secret string
+		header http.Header
+		want   bool
+	}{
+		{"valid signature", secret, header(valid), true},
+		{"invalid signature", secret, header(other), false},
+		{"tampered body", secret, header(sign(secret, []byte(`{}`))), false},
+		{"multiple signatures, one valid", secret, header(other, valid), true},
+		{"multiple signatures with spaces", secret, header(other, " "+valid), true},
+		{"multiple signatures, none valid", secret, header(other, sign("x", body)), false},
+		{"missing header", secret, http.Header{}, false},
+		{"garbage header", secret, header("v1=zzzz"), false},
+		{"unset secret leaves webhook open", "", http.Header{}, true},
+		{"unset secret ignores any signature", "", header(other), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Source{secret: tc.secret}.Authenticate(body, tc.header)
+			if got != tc.want {
+				t.Fatalf("Authenticate = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/source/pagerduty/pagerduty.go
+++ b/internal/source/pagerduty/pagerduty.go
@@ -1,0 +1,214 @@
+// Package pagerduty is the PagerDuty V3 webhook source adapter. It turns
+// PagerDuty incident webhooks into investigation requests (incident.triggered)
+// and resolutions (incident.resolved), and authenticates each delivery with the
+// X-PagerDuty-Signature HMAC scheme.
+package pagerduty
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/source"
+)
+
+// pdConfig is the `sources.pagerduty` config block. secret_env names the env var
+// holding the webhook signing secret (config stores the NAME, never the value —
+// consistent with the repo's env-var-indirection pattern).
+type pdConfig struct {
+	SecretEnv string `yaml:"secret_env"`
+}
+
+// osGetenv is a package-level indirection point for os.Getenv (kept trivial;
+// tests set real env vars via t.Setenv).
+var osGetenv = os.Getenv
+
+// Source is the PagerDuty V3 webhook source adapter. secret is the signing
+// secret used to verify X-PagerDuty-Signature; an empty secret leaves the
+// webhook open (mirroring the alertmanager source's optional bearer token).
+type Source struct {
+	secret string
+}
+
+// pdPayload is the subset of the PagerDuty V3 webhook envelope we consume. Each
+// delivery carries a single event; the incident lives under event.data.
+type pdPayload struct {
+	Event pdEvent `json:"event"`
+}
+
+type pdEvent struct {
+	EventType  string     `json:"event_type"`
+	OccurredAt string     `json:"occurred_at"`
+	Data       pdIncident `json:"data"`
+}
+
+// pdIncident is the V3 `incident` event-data object (the shape shared by
+// incident.triggered / incident.resolved / …).
+type pdIncident struct {
+	ID       string `json:"id"`
+	HTMLURL  string `json:"html_url"`
+	Number   int    `json:"number"`
+	Title    string `json:"title"`
+	Urgency  string `json:"urgency"`
+	Priority *pdRef `json:"priority"` // null when the incident has no priority
+	Service  pdRef  `json:"service"`
+}
+
+// pdRef is a PagerDuty resource reference; only id + summary are consumed.
+type pdRef struct {
+	ID      string `json:"id"`
+	Summary string `json:"summary"`
+}
+
+// Decode parses a PagerDuty V3 webhook body. incident.triggered becomes an
+// investigation Request; incident.resolved becomes a Resolution keyed by the
+// incident id (stable across the triggered↔resolved pair); every other event
+// type is ignored. PagerDuty carries no Kubernetes namespace/workload, so those
+// fields stay empty — recall and structural matching tolerate that.
+func (Source) Decode(body []byte, _ http.Header) (source.DecodeResult, error) {
+	var p pdPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return source.DecodeResult{}, fmt.Errorf("pagerduty: decode webhook body: %w", err)
+	}
+	inc := p.Event.Data
+	switch p.Event.EventType {
+	case "incident.resolved":
+		return source.DecodeResult{
+			Resolved: []source.Resolution{{Fingerprint: inc.ID, At: time.Now()}},
+		}, nil
+	case "incident.triggered":
+		return source.DecodeResult{Requests: []investigate.Request{toRequest(p.Event)}}, nil
+	default:
+		// acknowledged, priority_updated, service.*, … — not investigation triggers.
+		return source.DecodeResult{}, nil
+	}
+}
+
+// toRequest maps an incident.triggered event to a normalized investigation Request.
+func toRequest(ev pdEvent) investigate.Request {
+	inc := ev.Data
+	// Priority (e.g. "P1") is the operator-set incident importance; fall back to
+	// urgency (high/low) when the incident has no priority.
+	severity := inc.Urgency
+	if inc.Priority != nil && inc.Priority.Summary != "" {
+		severity = inc.Priority.Summary
+	}
+	occurredAt, _ := time.Parse(time.RFC3339, ev.OccurredAt)
+
+	labels := map[string]string{}
+	putLabel(labels, "service", inc.Service.Summary)
+	putLabel(labels, "service_id", inc.Service.ID)
+	if inc.Number != 0 {
+		labels["incident_number"] = strconv.Itoa(inc.Number)
+	}
+	putLabel(labels, "html_url", inc.HTMLURL)
+	putLabel(labels, "urgency", inc.Urgency)
+	if inc.Priority != nil {
+		putLabel(labels, "priority", inc.Priority.Summary)
+	}
+
+	var fps []string
+	if inc.ID != "" {
+		fps = []string{inc.ID}
+	}
+
+	return investigate.Request{
+		Source:   investigate.SourcePagerDuty,
+		Title:    inc.Title,
+		Severity: severity,
+		Reason:   severity,
+		// The V3 incident object has no free-text description, so compose a compact
+		// human-readable summary from the incident metadata for the seed prompt.
+		Message:      composeMessage(inc),
+		Labels:       labels,
+		At:           occurredAt,
+		Fingerprint:  inc.ID,
+		Fingerprints: fps,
+		// Host-invariant per-class dedup key. PagerDuty's only scoping dimension is
+		// the service, so it takes the cluster slot; namespace/kind/name stay empty.
+		// Re-fires of the same incident title on the same service dedupe to one PR (#137).
+		TriggerKey: curator.IncidentKey(inc.Title, "", "", "", inc.Service.Summary),
+	}
+}
+
+func composeMessage(inc pdIncident) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "PagerDuty incident #%d", inc.Number)
+	if inc.Service.Summary != "" {
+		fmt.Fprintf(&b, " on service %q", inc.Service.Summary)
+	}
+	if inc.Urgency != "" {
+		fmt.Fprintf(&b, ", urgency %s", inc.Urgency)
+	}
+	if inc.Priority != nil && inc.Priority.Summary != "" {
+		fmt.Fprintf(&b, ", priority %s", inc.Priority.Summary)
+	}
+	if inc.HTMLURL != "" {
+		fmt.Fprintf(&b, " (%s)", inc.HTMLURL)
+	}
+	return b.String()
+}
+
+func putLabel(m map[string]string, k, v string) {
+	if v != "" {
+		m[k] = v
+	}
+}
+
+// Secret reads the PagerDuty source config from the raw `sources:` map and
+// resolves its signing secret from the env var named by secret_env. It reports
+// the resolved secret and whether the source is enabled (its key is present).
+// It lives here (not just in Build) so the serve path can enforce fail-closed
+// auth before wiring the webhook. Config errors collapse to (empty, present):
+// Build re-decodes the same block and surfaces the error at startup.
+func Secret(raw map[string]yaml.Node) (secret string, enabled bool) {
+	node, ok := raw["pagerduty"]
+	if !ok {
+		return "", false
+	}
+	var c pdConfig
+	if err := node.Decode(&c); err != nil {
+		return "", true
+	}
+	if c.SecretEnv == "" {
+		return "", true
+	}
+	return osGetenv(c.SecretEnv), true
+}
+
+func init() {
+	source.Register(source.Descriptor{
+		Name: "pagerduty",
+		Kind: source.Webhook, Admission: source.MatchGated, Path: "/webhook/pagerduty",
+		Build: func(d source.Deps) (any, error) {
+			node, ok := d.Raw["pagerduty"]
+			if !ok {
+				return nil, nil // disabled: no sources.pagerduty key
+			}
+			var c pdConfig
+			if err := node.Decode(&c); err != nil {
+				return nil, fmt.Errorf("pagerduty: decode sources.pagerduty: %w", err)
+			}
+			secret := ""
+			if c.SecretEnv != "" {
+				secret = osGetenv(c.SecretEnv)
+			}
+			// Fail closed under mode=auto: an unattended executor must not accept
+			// unauthenticated incident webhooks. Mirrors config.Validate's
+			// server.webhook_token_env requirement for the shared bearer webhook.
+			if d.Cfg != nil && d.Cfg.Actions.Mode == config.ActionAuto && secret == "" {
+				return nil, fmt.Errorf("actions.mode=auto requires sources.pagerduty.secret_env (the PagerDuty webhook must verify signatures)")
+			}
+			return Source{secret: secret}, nil
+		},
+	})
+}

--- a/internal/source/pagerduty/pagerduty_test.go
+++ b/internal/source/pagerduty/pagerduty_test.go
@@ -1,0 +1,257 @@
+package pagerduty
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/source"
+)
+
+// TestDecodeTriggeredProducesRequest locks in the full V3 incident.triggered →
+// investigate.Request mapping against a recorded payload (the documented V3
+// incident example, event_type set to incident.triggered).
+func TestDecodeTriggeredProducesRequest(t *testing.T) {
+	body, err := os.ReadFile("testdata/incident_triggered.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Source{}.Decode(body, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 1 {
+		t.Fatalf("want 1 request, got %d", len(res.Requests))
+	}
+	r := res.Requests[0]
+	if r.Source != investigate.SourcePagerDuty {
+		t.Fatalf("want Source=pagerduty, got %q", r.Source)
+	}
+	if r.Title != "A little bump in the road" {
+		t.Fatalf("want incident title, got %q", r.Title)
+	}
+	if r.Severity != "P1" { // priority wins over urgency when present
+		t.Fatalf("want Severity=P1, got %q", r.Severity)
+	}
+	if r.Reason != "P1" {
+		t.Fatalf("want Reason=P1 (mirrors alertmanager Reason=severity), got %q", r.Reason)
+	}
+	// PagerDuty has no Kubernetes context: workload + environment stay empty and
+	// recall/structural matching tolerates that.
+	if r.Workload.Namespace != "" || r.Workload.Kind != "" || r.Workload.Name != "" {
+		t.Fatalf("want zero Workload, got %+v", r.Workload)
+	}
+	if r.Environment != "" {
+		t.Fatalf("want empty Environment, got %q", r.Environment)
+	}
+	// The V3 incident object has no description field, so the message is a
+	// composed human-readable summary of the incident metadata.
+	for _, part := range []string{"#2", `"API Service"`, "urgency high", "priority P1", "https://acme.pagerduty.com/incidents/PGR0VU2"} {
+		if !strings.Contains(r.Message, part) {
+			t.Fatalf("Message %q should contain %q", r.Message, part)
+		}
+	}
+	wantLabels := map[string]string{
+		"service":         "API Service",
+		"service_id":      "PF9KMXH",
+		"incident_number": "2",
+		"html_url":        "https://acme.pagerduty.com/incidents/PGR0VU2",
+		"urgency":         "high",
+		"priority":        "P1",
+	}
+	for k, want := range wantLabels {
+		if got := r.Labels[k]; got != want {
+			t.Fatalf("Labels[%q] = %q, want %q", k, got, want)
+		}
+	}
+	if r.Fingerprint != "PGR0VU2" || len(r.Fingerprints) != 1 || r.Fingerprints[0] != "PGR0VU2" {
+		t.Fatalf("want incident-id fingerprint PGR0VU2 (and Fingerprints=[PGR0VU2]), got %q %v", r.Fingerprint, r.Fingerprints)
+	}
+	// Per-class dedup key: title + service (in the cluster slot — the only scoping
+	// dimension PagerDuty has), same normalization as the alertmanager source.
+	if r.TriggerKey != "a little bump in the road||||api service" {
+		t.Fatalf("want per-class TriggerKey, got %q", r.TriggerKey)
+	}
+	wantAt, _ := time.Parse(time.RFC3339, "2020-10-02T18:45:22.169Z")
+	if !r.At.Equal(wantAt) {
+		t.Fatalf("want At=%v (event.occurred_at), got %v", wantAt, r.At)
+	}
+	if len(res.Resolved) != 0 {
+		t.Fatalf("triggered must not resolve, got %+v", res.Resolved)
+	}
+}
+
+// TestDecodeResolvedProducesResolution locks in incident.resolved → Resolution
+// keyed by the incident id (stable triggered↔resolved), carrying receipt time.
+func TestDecodeResolvedProducesResolution(t *testing.T) {
+	body, err := os.ReadFile("testdata/incident_resolved.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Source{}.Decode(body, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 0 {
+		t.Fatalf("resolved must not enqueue, got %+v", res.Requests)
+	}
+	if len(res.Resolved) != 1 || res.Resolved[0].Fingerprint != "PGR0VU2" {
+		t.Fatalf("want resolved PGR0VU2, got %+v", res.Resolved)
+	}
+	if res.Resolved[0].At.IsZero() {
+		t.Fatal("Resolution.At must not be zero (should be receipt time)")
+	}
+}
+
+// TestDecodeIgnoredEventTypes: every non-triggered/non-resolved event type is
+// dropped without error (202 upstream, nothing ingested).
+func TestDecodeIgnoredEventTypes(t *testing.T) {
+	for _, et := range []string{
+		"incident.acknowledged",
+		"incident.annotated",
+		"incident.priority_updated",
+		"incident.unacknowledged",
+		"service.updated",
+	} {
+		t.Run(et, func(t *testing.T) {
+			body := []byte(`{"event":{"event_type":"` + et + `","data":{"id":"PGR0VU2","title":"x"}}}`)
+			res, err := Source{}.Decode(body, nil)
+			if err != nil {
+				t.Fatalf("ignored event type must not error: %v", err)
+			}
+			if len(res.Requests) != 0 || len(res.Resolved) != 0 {
+				t.Fatalf("event %q must be dropped, got %+v", et, res)
+			}
+		})
+	}
+}
+
+// TestDecodeSeverityFallsBackToUrgency: no priority on the incident → urgency
+// is the severity.
+func TestDecodeSeverityFallsBackToUrgency(t *testing.T) {
+	body := []byte(`{"event":{"event_type":"incident.triggered","occurred_at":"2020-10-02T18:45:22Z",
+		"data":{"id":"P1","number":7,"title":"DB down","urgency":"high"}}}`)
+	res, err := Source{}.Decode(body, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 1 {
+		t.Fatalf("want 1 request, got %d", len(res.Requests))
+	}
+	r := res.Requests[0]
+	if r.Severity != "high" {
+		t.Fatalf("want Severity=high (urgency fallback), got %q", r.Severity)
+	}
+	if _, ok := r.Labels["priority"]; ok {
+		t.Fatalf("empty priority must not appear in labels, got %v", r.Labels)
+	}
+}
+
+func TestDecodeBadJSON(t *testing.T) {
+	if _, err := (Source{}).Decode([]byte(`{not json`), nil); err == nil {
+		t.Fatal("want decode error on malformed JSON")
+	}
+}
+
+// descriptor returns the registered pagerduty source descriptor.
+func descriptor(t *testing.T) source.Descriptor {
+	t.Helper()
+	for _, d := range source.Registered() {
+		if d.Name == "pagerduty" {
+			return d
+		}
+	}
+	t.Fatal("pagerduty source not registered")
+	return source.Descriptor{}
+}
+
+func rawSources(t *testing.T, doc string) map[string]yaml.Node {
+	t.Helper()
+	var raw map[string]yaml.Node
+	if err := yaml.Unmarshal([]byte(doc), &raw); err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// TestBuild covers enablement, secret resolution, and the mode=auto fail-closed
+// rule (mirrors config.Validate requiring server.webhook_token_env under auto).
+func TestBuild(t *testing.T) {
+	d := descriptor(t)
+	if d.Kind != source.Webhook || d.Path != "/webhook/pagerduty" || d.Admission != source.MatchGated {
+		t.Fatalf("bad descriptor: %+v", d)
+	}
+
+	t.Run("absent key disables", func(t *testing.T) {
+		impl, err := d.Build(source.Deps{Cfg: &config.Config{}, Raw: rawSources(t, "alertmanager: {}")})
+		if err != nil || impl != nil {
+			t.Fatalf("want disabled (nil, nil), got %v, %v", impl, err)
+		}
+	})
+
+	t.Run("secret_env resolves via env", func(t *testing.T) {
+		t.Setenv("PD_TEST_SECRET", "s3cr3t")
+		impl, err := d.Build(source.Deps{Cfg: &config.Config{}, Raw: rawSources(t, "pagerduty: { secret_env: PD_TEST_SECRET }")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if impl.(Source).secret != "s3cr3t" {
+			t.Fatalf("secret not resolved from env: %+v", impl)
+		}
+	})
+
+	t.Run("unset secret builds open source", func(t *testing.T) {
+		impl, err := d.Build(source.Deps{Cfg: &config.Config{}, Raw: rawSources(t, "pagerduty: {}")})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if impl.(Source).secret != "" {
+			t.Fatalf("want empty secret, got %+v", impl)
+		}
+	})
+
+	t.Run("mode=auto without secret fails closed", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Actions.Mode = config.ActionAuto
+		_, err := d.Build(source.Deps{Cfg: cfg, Raw: rawSources(t, "pagerduty: {}")})
+		if err == nil || !strings.Contains(err.Error(), "secret_env") {
+			t.Fatalf("want fail-closed error naming secret_env, got %v", err)
+		}
+	})
+
+	t.Run("malformed block errors", func(t *testing.T) {
+		_, err := d.Build(source.Deps{Cfg: &config.Config{}, Raw: rawSources(t, "pagerduty: { secret_env: [1, 2] }")})
+		if err == nil {
+			t.Fatal("want error on malformed sources.pagerduty block")
+		}
+	})
+}
+
+// TestSecret covers the exported serve-path guard helper.
+func TestSecret(t *testing.T) {
+	t.Setenv("PD_TEST_SECRET", "s3cr3t")
+	cases := []struct {
+		name        string
+		doc         string
+		wantSecret  string
+		wantEnabled bool
+	}{
+		{"absent", "alertmanager: {}", "", false},
+		{"enabled with secret", "pagerduty: { secret_env: PD_TEST_SECRET }", "s3cr3t", true},
+		{"enabled without secret_env", "pagerduty: {}", "", true},
+		{"enabled with unset env var", "pagerduty: { secret_env: PD_TEST_UNSET }", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			secret, enabled := Secret(rawSources(t, tc.doc))
+			if secret != tc.wantSecret || enabled != tc.wantEnabled {
+				t.Fatalf("Secret() = (%q, %v), want (%q, %v)", secret, enabled, tc.wantSecret, tc.wantEnabled)
+			}
+		})
+	}
+}

--- a/internal/source/pagerduty/testdata/incident_resolved.json
+++ b/internal/source/pagerduty/testdata/incident_resolved.json
@@ -1,0 +1,53 @@
+{
+  "event": {
+    "id": "7a112a3f-89f9-4bd7-9d47-cd6a7c9e4f6b",
+    "event_type": "incident.resolved",
+    "resource_type": "incident",
+    "occurred_at": "2020-10-02T19:02:10.401Z",
+    "agent": {
+      "html_url": "https://acme.pagerduty.com/users/PLH1HKV",
+      "id": "PLH1HKV",
+      "self": "https://api.pagerduty.com/users/PLH1HKV",
+      "summary": "Tenex Engineer",
+      "type": "user_reference"
+    },
+    "client": null,
+    "data": {
+      "id": "PGR0VU2",
+      "type": "incident",
+      "self": "https://api.pagerduty.com/incidents/PGR0VU2",
+      "html_url": "https://acme.pagerduty.com/incidents/PGR0VU2",
+      "number": 2,
+      "status": "resolved",
+      "incident_key": "d3640fbd41094207a1c11e58e46b1662",
+      "created_at": "2020-10-02T18:45:22Z",
+      "title": "A little bump in the road",
+      "service": {
+        "html_url": "https://acme.pagerduty.com/services/PF9KMXH",
+        "id": "PF9KMXH",
+        "self": "https://api.pagerduty.com/services/PF9KMXH",
+        "summary": "API Service",
+        "type": "service_reference"
+      },
+      "assignees": [],
+      "escalation_policy": {
+        "html_url": "https://acme.pagerduty.com/escalation_policies/PUS0KTE",
+        "id": "PUS0KTE",
+        "self": "https://api.pagerduty.com/escalation_policies/PUS0KTE",
+        "summary": "Default",
+        "type": "escalation_policy_reference"
+      },
+      "teams": [],
+      "priority": {
+        "html_url": "https://acme.pagerduty.com/account/incident_priorities",
+        "id": "PSO75BM",
+        "self": "https://api.pagerduty.com/priorities/PSO75BM",
+        "summary": "P1",
+        "type": "priority_reference"
+      },
+      "urgency": "high",
+      "conference_bridge": null,
+      "resolve_reason": null
+    }
+  }
+}

--- a/internal/source/pagerduty/testdata/incident_triggered.json
+++ b/internal/source/pagerduty/testdata/incident_triggered.json
@@ -1,0 +1,74 @@
+{
+  "event": {
+    "id": "5ac64822-4adc-4fda-ade0-410becf0de4f",
+    "event_type": "incident.triggered",
+    "resource_type": "incident",
+    "occurred_at": "2020-10-02T18:45:22.169Z",
+    "agent": {
+      "html_url": "https://acme.pagerduty.com/users/PLH1HKV",
+      "id": "PLH1HKV",
+      "self": "https://api.pagerduty.com/users/PLH1HKV",
+      "summary": "Tenex Engineer",
+      "type": "user_reference"
+    },
+    "client": {
+      "name": "PagerDuty"
+    },
+    "data": {
+      "id": "PGR0VU2",
+      "type": "incident",
+      "self": "https://api.pagerduty.com/incidents/PGR0VU2",
+      "html_url": "https://acme.pagerduty.com/incidents/PGR0VU2",
+      "number": 2,
+      "status": "triggered",
+      "incident_key": "d3640fbd41094207a1c11e58e46b1662",
+      "created_at": "2020-10-02T18:45:22Z",
+      "title": "A little bump in the road",
+      "service": {
+        "html_url": "https://acme.pagerduty.com/services/PF9KMXH",
+        "id": "PF9KMXH",
+        "self": "https://api.pagerduty.com/services/PF9KMXH",
+        "summary": "API Service",
+        "type": "service_reference"
+      },
+      "assignees": [
+        {
+          "html_url": "https://acme.pagerduty.com/users/PTUXL6G",
+          "id": "PTUXL6G",
+          "self": "https://api.pagerduty.com/users/PTUXL6G",
+          "summary": "User 123",
+          "type": "user_reference"
+        }
+      ],
+      "escalation_policy": {
+        "html_url": "https://acme.pagerduty.com/escalation_policies/PUS0KTE",
+        "id": "PUS0KTE",
+        "self": "https://api.pagerduty.com/escalation_policies/PUS0KTE",
+        "summary": "Default",
+        "type": "escalation_policy_reference"
+      },
+      "teams": [
+        {
+          "html_url": "https://acme.pagerduty.com/teams/PFCVPS0",
+          "id": "PFCVPS0",
+          "self": "https://api.pagerduty.com/teams/PFCVPS0",
+          "summary": "Engineering",
+          "type": "team_reference"
+        }
+      ],
+      "priority": {
+        "html_url": "https://acme.pagerduty.com/account/incident_priorities",
+        "id": "PSO75BM",
+        "self": "https://api.pagerduty.com/priorities/PSO75BM",
+        "summary": "P1",
+        "type": "priority_reference"
+      },
+      "urgency": "high",
+      "conference_bridge": {
+        "conference_number": "+1 1234123412,,987654321#",
+        "conference_url": "https://example.com"
+      },
+      "resolve_reason": null
+    }
+  }
+}

--- a/internal/source/webhook.go
+++ b/internal/source/webhook.go
@@ -6,13 +6,26 @@ import (
 	"net/http"
 )
 
+// Authenticator is implemented by a webhook source that authenticates each
+// delivery from the request body itself (e.g. an HMAC signature over the raw
+// body) rather than via the shared bearer token. When a source implements it,
+// the core calls Authenticate after reading the body and skips the shared auth:
+// a source that signs its own requests (PagerDuty) cannot present the operator's
+// bearer token, so it owns authentication end-to-end.
+type Authenticator interface {
+	Authenticate(body []byte, h http.Header) bool
+}
+
 // Handler builds the HTTP handler for a webhook source: shared auth, body cap,
-// decode, and ingest. auth (may be nil) authenticates the request; bodyCap is
-// the max body size in bytes; pipe ingests the decoded result.
+// decode, and ingest. auth (may be nil) authenticates the request via the shared
+// bearer token; a source implementing Authenticator authenticates itself from the
+// body instead (shared auth is skipped for it). bodyCap is the max body size in
+// bytes; pipe ingests the decoded result.
 func (b Built) Handler(auth func(*http.Request) bool, bodyCap int64, pipe *Pipeline) http.HandlerFunc {
 	wh := b.Impl.(WebhookSource)
+	selfAuth, selfAuths := b.Impl.(Authenticator)
 	return func(w http.ResponseWriter, r *http.Request) {
-		if auth != nil && !auth(r) {
+		if !selfAuths && auth != nil && !auth(r) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -25,6 +38,10 @@ func (b Built) Handler(auth func(*http.Request) bool, bodyCap int64, pipe *Pipel
 				return
 			}
 			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if selfAuths && !selfAuth.Authenticate(body, r.Header) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 		res, derr := wh.Decode(body, r.Header)

--- a/internal/source/webhook_test.go
+++ b/internal/source/webhook_test.go
@@ -102,6 +102,59 @@ func TestHandlerValidRequest(t *testing.T) {
 	}
 }
 
+// fakeAuthDecoder is a WebhookSource that also self-authenticates (Authenticator),
+// like the pagerduty source's HMAC signature check.
+type fakeAuthDecoder struct {
+	fakeDecoder
+	ok bool
+}
+
+func (f fakeAuthDecoder) Authenticate(_ []byte, _ http.Header) bool { return f.ok }
+
+// TestHandlerSelfAuthRejects: a source-level Authenticate failure is a 401 and
+// nothing reaches the pipeline.
+func TestHandlerSelfAuthRejects(t *testing.T) {
+	enq := &capEnq{}
+	pipe := NewPipeline(matchAllCfg(), enq, nil, nil)
+	b := webhookBuilt(fakeDecoder{result: oneRequestResult()})
+	b.Impl = fakeAuthDecoder{fakeDecoder{result: oneRequestResult()}, false}
+
+	h := b.Handler(nil, 1<<20, pipe)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/test", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", rec.Code)
+	}
+	if len(enq.reqs) != 0 {
+		t.Fatalf("want 0 enqueued after failed self-auth, got %d", len(enq.reqs))
+	}
+}
+
+// TestHandlerSelfAuthReplacesSharedAuth: a source that implements Authenticator
+// owns its authentication — the shared bearer-token auth must NOT apply to it
+// (PagerDuty signs requests; it cannot send the operator's bearer token).
+func TestHandlerSelfAuthReplacesSharedAuth(t *testing.T) {
+	enq := &capEnq{}
+	pipe := NewPipeline(matchAllCfg(), enq, nil, nil)
+	b := webhookBuilt(fakeDecoder{result: oneRequestResult()})
+	b.Impl = fakeAuthDecoder{fakeDecoder{result: oneRequestResult()}, true}
+	sharedAuthRejectsAll := func(*http.Request) bool { return false }
+
+	h := b.Handler(sharedAuthRejectsAll, 1<<20, pipe)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/test", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202 (self-auth replaces shared auth), got %d", rec.Code)
+	}
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued, got %d", len(enq.reqs))
+	}
+}
+
 func TestMountWebhooks(t *testing.T) {
 	enq := &capEnq{}
 	pipe := NewPipeline(matchAllCfg(), enq, nil, nil)


### PR DESCRIPTION
## Problem

RunLore's sources are pluggable, but incidents could only arrive from Alertmanager or GitOps failures. PagerDuty — named as a planned source in `docs/learning-loop.md` — had no adapter, so teams whose on-call incidents live in PagerDuty couldn't trigger investigations.

## Design

A new `pagerduty` `WebhookSource` (`internal/source/pagerduty/`) mirroring the alertmanager adapter end-to-end.

**Payload** — PagerDuty [V3 webhooks](https://developer.pagerduty.com/docs/webhooks-overview). Each delivery carries a single `event`; the incident lives under `event.data`. Field shapes verified against PagerDuty's published V3 payload reference.

**Trigger mapping**

| PD event | RunLore |
|---|---|
| `incident.triggered` | investigation `Request` |
| `incident.resolved` | `Resolution` (closes outcome, like an AM resolved alert) |
| everything else (`acknowledged`, `priority_updated`, `service.*`, …) | ignored |

`incident.triggered` → Request field mapping:

| Request field | Source |
|---|---|
| `Title` | `data.title` |
| `Severity` / `Reason` | `data.priority.summary` (e.g. `P1`), falling back to `data.urgency` (`high`/`low`) |
| `Message` | composed summary (`#<number>` · service · urgency · priority · `html_url`) — the V3 incident object has no free-text description |
| `Labels` | `service`, `service_id`, `incident_number`, `html_url`, `urgency`, `priority` |
| `Fingerprint` / `Fingerprints` | `data.id` (stable across the triggered↔resolved pair) |
| `TriggerKey` | `curator.IncidentKey(title, "", "", "", service)` — service takes the cluster slot, PD's only scoping dimension |
| `At` | `event.occurred_at` |
| `Workload` / `Environment` / `Namespace` | **empty** — PagerDuty has no Kubernetes context; recall and structural matching tolerate an empty workload |

**Auth semantics** — verify the `X-PagerDuty-Signature` header: one or more comma-separated `v1=<hex>` HMAC-SHA256 signatures of the **raw body**, keyed by the subscription signing secret. Accept if **any** matches (multiple signatures support zero-downtime secret rotation); constant-time compare (`hmac.Equal`).

- Secret via env-var indirection: config stores the env-var **name** (`sources.pagerduty.secret_env`), never the value — consistent with the repo pattern.
- **Unset** secret leaves the webhook open (mirrors alertmanager's optional bearer token).
- **Fails closed** when configured but signature is missing/invalid, and when a model is configured or `actions.mode=auto` (an enabled source then *requires* a secret — `app.RequirePagerDutyAuth` on the serve path + a `Build`-time `auto` guard).
- PagerDuty signs its own deliveries and cannot present the operator's bearer token, so a new `source.Authenticator` interface lets a source own authentication from the body; the shared bearer-token auth is skipped for it.

## Testing

TDD, failing tests first. Table-driven, with recorded V3 payload fixtures (`testdata/incident_triggered.json`, `incident_resolved.json`):

- Decode: full triggered→Request mapping, resolved→Resolution, ignored event types, priority↔urgency fallback, malformed JSON.
- Signature verification: valid, invalid, tampered body, multiple signatures (one valid / none valid), missing header, garbage, unset secret — plus a pinned known-vector (independently computed via `openssl dgst`) so impl and test can't drift together.
- `Build`: enablement, env-var secret resolution, `mode=auto` fail-closed, malformed block.
- Framework: `Handler` self-auth (rejects on failure, replaces shared auth on success); `app.RequirePagerDutyAuth` fail-closed table.

Quality gate green: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — gofmt silent, 0 lint issues.

## Docs

`docs/configuration.md` (fields, `/webhook/pagerduty` mount, PD-side subscription setup, auth semantics), README source list (Triggers row + new/less-exercised stability tier), and a commented `sources.pagerduty` block in `values.yaml`.