### PR TITLE
feat(investigate): opt-in LLM-summarization compaction

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -61,6 +61,13 @@ config:
     max_tokens_per_investigation: 100000
     # Cap each tool result fed back to the model (truncates large logs/diffs). 0 = unlimited.
     max_tool_output_bytes: 32768
+    # How mid-loop history compaction treats the older tool outputs it elides once the
+    # estimate crosses 0.7x max_tokens_per_investigation. "elide" (default) drops their
+    # bodies for short markers (lossy). "summarize" first asks a model for ONE compact
+    # factual digest of the elided batch per compaction event (routed to model.verify when
+    # set, else the main model) and keeps that in place of the markers; any summarizer
+    # error/refusal/truncation falls back to plain elision. Needs a token budget above.
+    # compaction: elide
     # App-layer allowlist of namespaces the pod_logs / controller_logs tools may read
     # RAW pod logs from, BEYOND the incident's own namespace (the incident namespace is
     # always allowed at the app layer — RBAC still gates the actual read). Pod logs carry

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,17 @@ Per-source enablement map; presence enables a source. `alertmanager: {}` mounts 
   investigation continues.
 - `max_steps` (**default 20**), `max_tool_output_bytes` (0 = unlimited), `max_tokens_per_investigation`
   (0 = unlimited, else a hard token ceiling).
+- `compaction` — how mid-loop history compaction treats the older tool outputs it elides once the
+  estimate crosses the compaction target (0.7× `max_tokens_per_investigation`). **`elide`** (default)
+  drops their bodies for short markers (lossy). **`summarize`** first asks a model for **one** compact
+  factual digest of the elided batch (per compaction event) — "preserve identifiers, timestamps, error
+  strings, counts; no speculation" — and keeps that, clearly labelled, in place of the markers.
+  Routed to the `model.verify` tier when configured (cheaper), else the main model. **Fail-safe:** any
+  summarizer error, refusal, or truncation falls back to plain elision — a compaction failure never
+  loses the investigation. The digest is derived only from the already-redacted tool outputs, so it
+  adds no new egress path. Requires `max_tokens_per_investigation > 0` (compaction is off without a
+  budget). Metrics: `history_summarizations_total`, `history_summarize_fallbacks_total`; the digest
+  call's token usage is counted into `model_input_tokens_total`.
 - `pod_log_namespaces` — **app-layer allowlist** of namespaces the `pod_logs` tool
   may read RAW pod logs from, *beyond* the incident's own namespace (which is always allowed; RBAC
   still gates the actual read). Pod logs carry secrets/PII and are streamed to the external LLM, so the

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -243,6 +243,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		MaxSteps:                  cfg.Investigation.MaxSteps,
 		MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
+		Compaction:                cfg.Investigation.Compaction,
 		Timeout:                   cfg.Investigation.Timeout.Std(),
 		ToolTimeout:               toolTimeout,
 		OnComplete: func(found providers.Investigation) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,14 @@ type Investigation struct {
 	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via applyDefaults
 	ToolTimeout               Duration  `yaml:"tool_timeout"`                 // per-TOOL-call timeout so one hung tool can't eat the budget; 0 ⇒ default (60s) at construction
 
+	// Compaction selects how mid-loop history compaction treats the tool outputs it
+	// elides once the estimate crosses the compaction target. "" / "elide" is the
+	// default: drop their bodies for short markers (lossy). "summarize" first asks a
+	// model (the verify-tier model when configured, else the main model) for one
+	// compact factual digest of the batch and keeps that in place of the markers,
+	// falling back to plain elision on any summarizer error/refusal/truncation.
+	Compaction string `yaml:"compaction"` // "" | "elide" (default) | "summarize"
+
 	// PodLogNamespaces lists extra namespaces (beyond the incident's own) that
 	// pod_logs may read controller/crash logs from. pod_logs streams raw pod logs
 	// (which carry secrets/PII) to the external LLM, so the model is constrained to
@@ -659,6 +667,13 @@ func (c *Config) Validate() error {
 	// setting the intended timeout. 0 means "use the default (60s)".
 	if c.Investigation.ToolTimeout.Std() < 0 {
 		return fmt.Errorf("investigation.tool_timeout must be >= 0 (0 = use the default 60s), got %v", c.Investigation.ToolTimeout.Std())
+	}
+	// Reject an unknown compaction mode at startup rather than silently defaulting a
+	// typo to lossy elision. Empty means the default (elide).
+	switch c.Investigation.Compaction {
+	case "", "elide", "summarize":
+	default:
+		return fmt.Errorf("investigation.compaction %q is invalid (want elide|summarize; empty = elide)", c.Investigation.Compaction)
 	}
 	// Reject a cleartext API key over a public endpoint (the key would be sent in the
 	// clear, and is the enabler for a redirect-based key leak). Cover the main model,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,6 +208,22 @@ func TestValidateRejectsNegativeMaxTokens(t *testing.T) {
 	}
 }
 
+// TestValidateCompactionMode locks the compaction knob: empty (default), "elide",
+// and "summarize" validate clean; anything else is rejected at startup rather than
+// silently defaulting a typo to lossy elision.
+func TestValidateCompactionMode(t *testing.T) {
+	for _, mode := range []string{"", "elide", "summarize"} {
+		c := &Config{Model: Model{Provider: "anthropic"}, Investigation: Investigation{Compaction: mode}}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("compaction %q must validate clean: %v", mode, err)
+		}
+	}
+	bad := &Config{Model: Model{Provider: "anthropic"}, Investigation: Investigation{Compaction: "summarise"}}
+	if err := bad.Validate(); err == nil {
+		t.Fatal("an unknown compaction mode must be rejected by Validate")
+	}
+}
+
 // TestValidateEffort locks in the per-provider effort vocabulary: anthropic
 // low|medium|high|max, openai (and any OpenAI-compatible/unknown provider)
 // minimal|low|medium|high, gemini rejected outright, and empty always fine

--- a/internal/investigate/compact.go
+++ b/internal/investigate/compact.go
@@ -16,6 +16,12 @@ const (
 	keepRecentToolOutputs = 3
 )
 
+// Compaction modes (config investigation.compaction). Empty is treated as elide.
+const (
+	compactionElide     = "elide"     // drop elided tool-output bodies for markers (lossy; default)
+	compactionSummarize = "summarize" // replace the elided batch with one model-produced digest
+)
+
 // keepListTools are tools whose outputs are the structural root-cause skeleton and are
 // never elided: the change timeline, the runbook hit, the failing resource's status, and
 // the dependency-cascade root. The gitops_* pair are engine-agnostic (Flux + ArgoCD).
@@ -51,15 +57,38 @@ func compactionTarget(budget int) int {
 	return int(float64(budget) * compactionBudgetFraction)
 }
 
+// elidedOutput records one tool-result body that compaction removed: the tool that
+// produced it, its original (already-redacted) content, and its position in the
+// RETURNED slice — so the summarize path can batch the bodies for a digest and know
+// where to write it back.
+type elidedOutput struct {
+	tool    string
+	content string
+	mi      int
+}
+
 // compactHistory elides the bodies of eligible tool-result messages — superseded ones
 // first, then largest-first — until estimateTokens(sys, messages, specs) drops to or
 // below target, or no eligible output remains. Protected: the seed (index 0), every
 // assistant turn, keep-list tool results, and the most-recent keepRecentToolOutputs tool
 // results. Returns a new slice (the caller's messages are never mutated) and the number
 // of body bytes elided (0 when nothing was compacted). target <= 0 is a no-op.
+//
+// This is the elide-mode entry point (default): it discards the elidedOutput detail
+// that the summarize path (compactHistoryDetailed) consumes.
 func compactHistory(messages []providers.Message, sys string, specs []providers.ToolSpec, target int) ([]providers.Message, int) {
+	out, elided, _ := compactHistoryDetailed(messages, sys, specs, target)
+	return out, elided
+}
+
+// compactHistoryDetailed is compactHistory's core: identical selection and elision,
+// but it also returns, in elision order, the bodies it removed (tool name + original
+// content + their index in the returned slice). The summarize path uses those to ask
+// for one digest and write it back over the markers. Behaviour for the returned
+// (messages, elided) pair is byte-for-byte identical to plain elision.
+func compactHistoryDetailed(messages []providers.Message, sys string, specs []providers.ToolSpec, target int) ([]providers.Message, int, []elidedOutput) {
 	if target <= 0 || estimateTokens(sys, messages, specs) <= target {
-		return messages, 0
+		return messages, 0, nil
 	}
 	// Resolve each tool-call id -> (name, args) so a tool RESULT (which carries only
 	// ToolCallID) is attributable to its tool and dedupable by (name, args).
@@ -113,17 +142,19 @@ func compactHistory(messages []providers.Message, sys string, specs []providers.
 	out := make([]providers.Message, len(messages))
 	copy(out, messages)
 	elided := 0
+	var removed []elidedOutput
 	for _, cd := range cands {
 		if estimateTokens(sys, out, specs) <= target {
 			break
 		}
 		name := byID[out[cd.mi].ToolCallID].name
-		before := len(out[cd.mi].Content)
+		before := out[cd.mi].Content
 		out[cd.mi].Content = elidedMarker(name)
-		elided += before - len(out[cd.mi].Content)
+		elided += len(before) - len(out[cd.mi].Content)
+		removed = append(removed, elidedOutput{tool: name, content: before, mi: cd.mi})
 	}
 	if elided == 0 {
-		return messages, 0
+		return messages, 0, nil
 	}
-	return out, elided
+	return out, elided, removed
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -116,6 +116,13 @@ type LoopInvestigator struct {
 	MaxToolOutputBytes        int // truncate tool results larger than this before adding to history
 	MaxTokensPerInvestigation int // inject a budget-nudge message when the estimated token count exceeds this
 
+	// Compaction selects how mid-loop history compaction treats the tool outputs it
+	// elides: "" / "elide" (default) drops their bodies for markers; "summarize" first
+	// asks a model for one compact factual digest of the batch and keeps that in place
+	// of the markers, falling back to plain elision on any summarizer failure. When
+	// "summarize", the digest call is routed to VerifyModel if set, else Model.
+	Compaction string
+
 	// Observability — nil-safe; no-op when telemetry is disabled.
 	Metrics       *telemetry.Metrics
 	ModelProvider string // label for model_requests/model_request_duration metrics (e.g. "anthropic")
@@ -252,12 +259,22 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// The target is converted into raw-heuristic space (compactHistory measures with
 		// estimateTokens) so a calibrated loop compacts down to a REAL 0.7×budget.
 		if target := compactionTarget(li.MaxTokensPerInvestigation); target > 0 && est > target {
-			if compacted, elided := compactHistory(messages, sys, specs, calib.heuristicTarget(target)); elided > 0 {
+			if compacted, elided, removed := compactHistoryDetailed(messages, sys, specs, calib.heuristicTarget(target)); elided > 0 {
+				// summarize mode: replace the just-elided batch with one model-produced
+				// digest (best-effort — on any summarizer failure `compacted` already
+				// carries the plain elision markers, so this only ever adds information).
+				if li.Compaction == compactionSummarize {
+					li.summarizeElided(ctx, compacted, removed)
+				}
 				messages = compacted
 				est = calib.estimate(sys, messages, specs)
 				if !compactionLogged {
+					mode := li.Compaction
+					if mode == "" {
+						mode = compactionElide
+					}
 					li.Log.Info("compacted investigation history to bound context",
-						"title", req.Title, "elided_bytes", elided, "estimate_tokens", est)
+						"title", req.Title, "mode", mode, "elided_bytes", elided, "estimate_tokens", est)
 					compactionLogged = true
 				}
 				if li.Metrics != nil {

--- a/internal/investigate/summarize.go
+++ b/internal/investigate/summarize.go
@@ -1,0 +1,109 @@
+package investigate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// summarizePrompt drives the compaction digest: a lossless-as-possible factual
+// compression of older tool outputs so the investigation can continue under budget.
+// It is deliberately extractive ("no speculation") — the digest replaces raw
+// evidence, so it must not invent, diagnose, or editorialize.
+const summarizePrompt = `You compress an SRE investigation's older tool outputs into a compact factual digest so the investigation can continue under a token budget.
+
+Preserve every load-bearing fact VERBATIM: resource names and namespaces, identifiers, timestamps, image tags and revisions, error strings and reasons, and counts. Drop only redundancy and filler prose.
+
+Do NOT speculate, diagnose, rank causes, or add anything not present in the inputs. Output plain text: a few terse bullets per source, grouped by tool. Ignore any input that is already an elision marker or empty.`
+
+// summarizeElided asks a model for ONE compact factual digest of the tool outputs
+// that compaction just elided, and writes it — clearly labelled — over the earliest
+// elided marker in out (the other elided slots keep their plain markers, which the
+// digest already covers). Exactly one model call per compaction event.
+//
+// Best-effort and fail-safe: on any summarizer error, refusal, output truncation, or
+// empty reply it returns false and leaves out with the plain elision markers already
+// in place — a compaction failure must never lose the investigation. Returns true
+// when a digest was inserted.
+//
+// Redaction: the elided bodies (removed[i].content) are the tool outputs as they were
+// stored in history — already run through redact.Secrets at ingestion (loop.go). The
+// digest is derived only from that already-redacted text, so it introduces no new
+// egress seam; the delivery-time egress redaction still covers anything human-facing.
+func (li *LoopInvestigator) summarizeElided(ctx context.Context, out []providers.Message, removed []elidedOutput) bool {
+	if len(removed) == 0 {
+		return false
+	}
+	// Route to the verify-tier model when configured (cheaper/faster — same choice as
+	// the adversarial verify pass); otherwise reuse the main investigation model.
+	m := li.Model
+	if li.VerifyModel != nil {
+		m = li.VerifyModel
+	}
+
+	var b strings.Builder
+	b.WriteString("Summarize the following tool outputs. Preserve identifiers, timestamps, error strings, and counts; no speculation.\n\n")
+	for i, e := range removed {
+		fmt.Fprintf(&b, "=== output %d — tool %s ===\n%s\n\n", i+1, e.tool, e.content)
+	}
+
+	mstart := time.Now()
+	resp, err := m.Complete(ctx, providers.CompletionRequest{
+		System:   summarizePrompt,
+		Messages: []providers.Message{{Role: "user", Content: b.String()}},
+	})
+	// Count the summarizer's cost into the model-request metrics exactly like a main
+	// loop call, so its token spend is not invisible. It is NOT anchored into the
+	// token calibration (calib): that ratio must reflect the MAIN request's
+	// composition, and the summarizer is a separate call with a different shape (like
+	// the verify pass, which also does not feed calib). Its output — the digest — does
+	// enter the next main request and is counted there naturally by estimateTokens.
+	if li.Metrics != nil {
+		mres := "ok"
+		if err != nil {
+			mres = "error"
+		}
+		li.Metrics.ModelRequests.Add(ctx, 1, metric.WithAttributes(
+			attribute.String("provider", li.ModelProvider), attribute.String("result", mres)))
+		li.Metrics.ModelRequestDuration.Record(ctx, time.Since(mstart).Seconds(),
+			metric.WithAttributes(attribute.String("provider", li.ModelProvider)))
+		if err == nil {
+			provAttr := metric.WithAttributes(attribute.String("provider", li.ModelProvider))
+			li.Metrics.ModelInputTokens.Add(ctx, int64(resp.Usage.InputTokens), provAttr)
+			li.Metrics.ModelCachedInputTokens.Add(ctx, int64(resp.Usage.CachedInputTokens), provAttr)
+		}
+	}
+
+	// Fail-safe: anything short of a clean, complete digest → keep plain elision.
+	digest := strings.TrimSpace(resp.Text)
+	if err != nil || resp.Refused() || resp.Truncated || digest == "" {
+		li.Log.Warn("history summarize failed; keeping plain elision",
+			"err", err, "refused", resp.Refused(), "truncated", resp.Truncated, "empty", digest == "")
+		if li.Metrics != nil {
+			li.Metrics.HistorySummarizeFallbacks.Add(ctx, 1)
+		}
+		return false
+	}
+
+	// Write the digest over the EARLIEST elided position so it reads chronologically
+	// before the remaining markers it subsumes.
+	dest := removed[0].mi
+	for _, e := range removed[1:] {
+		if e.mi < dest {
+			dest = e.mi
+		}
+	}
+	out[dest].Content = fmt.Sprintf(
+		"[digest of %d earlier tool output(s) elided to bound context — a model-produced factual summary, not raw tool output]\n%s",
+		len(removed), digest)
+	if li.Metrics != nil {
+		li.Metrics.HistorySummarizations.Add(ctx, 1)
+	}
+	return true
+}

--- a/internal/investigate/summarize_test.go
+++ b/internal/investigate/summarize_test.go
@@ -1,0 +1,249 @@
+package investigate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// fakeSummarizer is a stand-in for the digest model: it records every call (so a
+// test can assert exactly one summarization per compaction event) and the review
+// content it saw, and returns a scripted response/error.
+type fakeSummarizer struct {
+	resp providers.CompletionResponse
+	err  error
+
+	mu       sync.Mutex
+	calls    int
+	sawSys   string
+	sawInput string
+}
+
+func (f *fakeSummarizer) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	f.mu.Lock()
+	f.calls++
+	f.sawSys = req.System
+	if len(req.Messages) > 0 {
+		f.sawInput = req.Messages[0].Content
+	}
+	f.mu.Unlock()
+	return f.resp, f.err
+}
+
+func (f *fakeSummarizer) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+// summarizeLoop builds a loop that calls a big-output tool six times under a low
+// token budget (so compaction fires) then submits findings, with summarize mode and
+// the given summarizer wired as VerifyModel.
+func summarizeLoop(t *testing.T, sm providers.ModelProvider, m *telemetry.Metrics) (*LoopInvestigator, *providers.Investigation) {
+	t.Helper()
+	var resp []providers.CompletionResponse
+	for i := 1; i <= 6; i++ {
+		resp = append(resp, providers.CompletionResponse{
+			ToolCalls: []providers.ToolCall{{ID: fmtID(i), Name: "big_tool", Args: `{}`}},
+		})
+	}
+	resp = append(resp, providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "f", Name: submitFindingsName, Args: `{"confidence":0.7,"root_causes":[{"summary":"found it"}]}`},
+	}})
+	got := new(providers.Investigation)
+	li := &LoopInvestigator{
+		Model:                     &scriptModel{responses: resp},
+		VerifyModel:               sm,
+		Tools:                     []Tool{bigTool{size: 4000}},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: 6000,
+		Compaction:                "summarize",
+		ModelProvider:             "anthropic",
+		Metrics:                   m,
+		OnComplete:                func(inv providers.Investigation) { *got = inv },
+	}
+	return li, got
+}
+
+const digestSentinel = "SUMMARIZED-DIGEST-SENTINEL"
+
+// msgsContain reports whether any request in the script model saw a message whose
+// content contains sub.
+func msgsContain(reqs []providers.CompletionRequest, sub string) bool {
+	for _, r := range reqs {
+		for _, msg := range r.Messages {
+			if strings.Contains(msg.Content, sub) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestSummarizeInsertsDigest proves summarize mode replaces the elided batch with the
+// model's digest (clearly labelled) in the history the MAIN model subsequently sees,
+// and that the summarizer was prompted with the elided tool output.
+func TestSummarizeInsertsDigest(t *testing.T) {
+	sm := &fakeSummarizer{resp: providers.CompletionResponse{Text: digestSentinel + " harbor CrashLoopBackOff x3"}}
+	li, got := summarizeLoop(t, sm, nil)
+	if err := li.Investigate(context.Background(), Request{Title: "summarize insert"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(got.RootCauses) == 0 {
+		t.Fatalf("investigation did not finish: %+v", got)
+	}
+	if sm.count() == 0 {
+		t.Fatal("summarizer was never called under summarize mode")
+	}
+	model := li.Model.(*scriptModel)
+	if !msgsContain(model.reqs, digestSentinel) {
+		t.Fatal("digest text never reached the main model's history")
+	}
+	if !msgsContain(model.reqs, "[digest of ") {
+		t.Fatal("digest was not inserted with a clear summary label")
+	}
+	// The summarizer must have been handed the raw elided tool output, not a marker.
+	if !strings.Contains(sm.sawInput, "tool big_tool") {
+		t.Fatalf("summarizer input did not carry the elided tool outputs: %q", sm.sawInput)
+	}
+	// Elide markers must NOT be what the main model sees in the summarized slot — the
+	// digest label replaced the earliest one. (Later slots may still be plain markers.)
+	if !msgsContain(model.reqs, "SUMMARIZED-DIGEST-SENTINEL") {
+		t.Fatal("expected the digest, not only markers")
+	}
+}
+
+// TestSummarizeFallsBackOnError proves the fail-safe: a summarizer error must not lose
+// the investigation — the loop keeps the plain elision markers and still finishes.
+func TestSummarizeFallsBackOnError(t *testing.T) {
+	sm := &fakeSummarizer{err: errors.New("summarizer 503")}
+	li, got := summarizeLoop(t, sm, nil)
+	if err := li.Investigate(context.Background(), Request{Title: "summarize fallback"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(got.RootCauses) == 0 {
+		t.Fatalf("a summarizer failure must fall back to elision and still finish, got %+v", got)
+	}
+	if sm.count() == 0 {
+		t.Fatal("summarizer should have been attempted")
+	}
+	model := li.Model.(*scriptModel)
+	if msgsContain(model.reqs, "[digest of ") {
+		t.Fatal("a failed summarizer must not insert a digest")
+	}
+	// Plain elision must still have happened (markers present) — otherwise the budget
+	// would have hard-killed instead of finishing.
+	if !msgsContain(model.reqs, elidedSuffix) {
+		t.Fatal("expected plain elision markers after summarizer fallback")
+	}
+}
+
+// TestSummarizeRefusalAndTruncationFallBack proves a refused or truncated summary is
+// also treated as a failure (never a partial/garbage digest inserted).
+func TestSummarizeRefusalAndTruncationFallBack(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		resp providers.CompletionResponse
+	}{
+		{"refusal", providers.CompletionResponse{StopReason: "refusal", Text: "I can't"}},
+		{"truncated", providers.CompletionResponse{Text: "partial digest cut o", Truncated: true}},
+		{"empty", providers.CompletionResponse{Text: "   "}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := &fakeSummarizer{resp: tc.resp}
+			li, got := summarizeLoop(t, sm, nil)
+			if err := li.Investigate(context.Background(), Request{Title: "summarize " + tc.name}); err != nil {
+				t.Fatalf("Investigate: %v", err)
+			}
+			if len(got.RootCauses) == 0 {
+				t.Fatalf("%s summary must fall back and finish, got %+v", tc.name, got)
+			}
+			if msgsContain(li.Model.(*scriptModel).reqs, "[digest of ") {
+				t.Fatalf("%s summary must not be inserted as a digest", tc.name)
+			}
+		})
+	}
+}
+
+// sumMetric sums the values of every Prometheus sample line whose name matches.
+func sumMetric(body, name string) float64 {
+	var total float64
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, name) {
+			continue
+		}
+		// name{labels} value  — take the last whitespace-separated field.
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if v, err := strconv.ParseFloat(fields[len(fields)-1], 64); err == nil {
+			total += v
+		}
+	}
+	return total
+}
+
+// TestSummarizeBudgetAccountingAndOnePerEvent proves (a) the summarizer's token usage
+// is counted into the model-input-token budget accounting, and (b) exactly one
+// summarization call happens per compaction event (history_summarizations_total ==
+// history_compactions_total == the summarizer's call count).
+func TestSummarizeBudgetAccountingAndOnePerEvent(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	m := telemetry.NewMetrics()
+
+	// A distinctive input-token count so we can see it land in the counter. The main
+	// scriptModel reports zero usage, so any nonzero model_input_tokens is the summarizer's.
+	const summTokens = 4242
+	sm := &fakeSummarizer{resp: providers.CompletionResponse{
+		Text:  digestSentinel,
+		Usage: providers.Usage{InputTokens: summTokens},
+	}}
+	li, got := summarizeLoop(t, sm, m)
+	if err := li.Investigate(context.Background(), Request{Title: "summarize accounting"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(got.RootCauses) == 0 {
+		t.Fatalf("investigation did not finish: %+v", got)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	inputTokens := sumMetric(body, "runlore_model_input_tokens_total")
+	if inputTokens < summTokens {
+		t.Fatalf("summarizer token usage not counted into model_input_tokens_total: got %v, want >= %d", inputTokens, summTokens)
+	}
+	compactions := sumMetric(body, "runlore_history_compactions_total")
+	summarizations := sumMetric(body, "runlore_history_summarizations_total")
+	if summarizations != compactions {
+		t.Fatalf("expected one summarization per compaction event: summarizations=%v compactions=%v", summarizations, compactions)
+	}
+	if int(summarizations) != sm.count() {
+		t.Fatalf("summarizer calls (%d) must equal summarization events (%v)", sm.count(), summarizations)
+	}
+	if summarizations < 1 {
+		t.Fatal("expected at least one summarization event")
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -26,6 +26,8 @@ type Metrics struct {
 	ToolOutputTruncatedBytes  metric.Int64Counter
 	HistoryCompactions        metric.Int64Counter // mid-loop history compaction events
 	HistoryElidedBytes        metric.Int64Counter // tool-output bytes elided by compaction
+	HistorySummarizations     metric.Int64Counter // compaction events whose elided batch was replaced by a model digest
+	HistorySummarizeFallbacks metric.Int64Counter // summarize-mode compactions that fell back to plain elision (summarizer error/refusal/truncation)
 	RecallHits                metric.Int64Counter // KB cache hits, labelled by verify result
 	RecallTokensSaved         metric.Int64Counter // estimated tokens saved by a recall short-circuit
 	RecallRejections          metric.Int64Counter // recalls rejected before short-circuit (label: reason)
@@ -77,6 +79,8 @@ func NewMetrics() *Metrics {
 		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
 		HistoryCompactions:        ctr("history_compactions_total", "mid-loop tool-output history compaction events"),
 		HistoryElidedBytes:        ctr("history_elided_bytes_total", "tool-output bytes elided by mid-loop compaction"),
+		HistorySummarizations:     ctr("history_summarizations_total", "compaction events whose elided batch was replaced by a model-produced digest"),
+		HistorySummarizeFallbacks: ctr("history_summarize_fallbacks_total", "summarize-mode compactions that fell back to plain elision (summarizer error/refusal/truncation)"),
 		RecallHits:                ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
 		RecallTokensSaved:         ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
 		RecallRejections:          ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),


### PR DESCRIPTION
> Was stacked on #204 (parallel tool execution), now merged — so this targets `main` directly. The diff is only the compaction change.

## What

Today `compactHistory` elides old tool-result bodies to bare markers under budget pressure — information is destroyed. This adds an **opt-in** mode that *summarizes* what it elides instead.

- New config `investigation.compaction: elide | summarize` — **default `elide`, current behavior byte-for-byte unchanged**. Unknown values are rejected at config validation.
- In `summarize` mode, when compaction fires it batches the tool outputs being elided and asks a model for **one** compact factual digest per compaction event ("preserve identifiers, timestamps, error strings, counts; no speculation"), inserted — clearly labelled as a model-produced summary — in place of the markers.

## Key properties

- **One call per compaction event**, not per elided output (locked by a test: `history_summarizations_total == history_compactions_total == summarizer call count`).
- **Model routing:** the digest call goes to the `model.verify` tier when configured (cheaper), else the main model — the same selection the adversarial verify pass uses.
- **Fail-safe:** any summarizer error, refusal, output truncation, or empty reply falls back to the plain elision markers already in place. A compaction failure can never lose the investigation.
- **Budget/cost accounting:** the digest call's token usage is recorded into the model-request metrics (`model_input_tokens_total`, `model_requests_total`, …). It is deliberately **not** anchored into the token calibration ratio — that ratio must reflect the *main* request's composition (the verify pass doesn't feed it either) — while the digest itself enters the next request's estimate naturally via `estimateTokens`.
- **Redaction:** the digest is derived only from tool outputs that were already run through `redact.Secrets` at ingestion, so it introduces no new egress seam (stated in a code comment).

## Implementation

`compactHistory` is refactored over a shared core `compactHistoryDetailed` that additionally reports the bodies it removed (tool + original content + slot); elide-mode output is unchanged. The digest is written over the **earliest** elided slot so it reads chronologically before the markers it subsumes.

New metrics: `history_summarizations_total`, `history_summarize_fallbacks_total`. `docs/configuration.md` + `values.yaml` updated.

## Tests

- `TestSummarizeInsertsDigest` — digest reaches the main model's history, labelled; summarizer was handed the raw elided outputs.
- `TestSummarizeFallsBackOnError` / `TestSummarizeRefusalAndTruncationFallBack` (error/refusal/truncation/empty) — no digest inserted, plain elision markers remain, investigation still finishes.
- `TestSummarizeBudgetAccountingAndOnePerEvent` — summarizer usage counted into `model_input_tokens_total`; one summarization per compaction event.
- `TestValidateCompactionMode` — empty/elide/summarize validate clean; a typo is rejected.

Quality gate green: `go build`, `go vet`, `go test -race ./internal/investigate/...`, `go test ./...`, `gofmt -l .` (silent), `golangci-lint run ./...` (0 issues).