### PR TITLE
feat(eval): multi-model comparison benchmark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,15 @@ lore eval --config runlore.yaml --cases examples/eval
 It needs a configured model (`config.model`). The harness logic (`internal/eval`) is unit-tested with a
 fake model, so `go test ./internal/eval/` runs without an API key.
 
+### Comparing models (benchmark)
+
+`lore eval --compare <spec.yaml>` benchmarks **several** models against the same replay suite in one
+command and writes an aggregated report (markdown + JSON) to `eval/reports/`: per-model rubric medians,
+pass rate, coverage, confident-wrong count, total tokens, and optional estimated cost. Grading is by one
+fixed, blind judge so scores are comparable. See **[docs/benchmarking.md](docs/benchmarking.md)** for the
+spec shape, the report columns, and how to publish results honestly. The pipeline has a keyless offline
+test (`go test ./internal/app/ -run TestRunEvalCompareOffline`).
+
 ### Nightly eval (CI)
 
 `.github/workflows/eval.yaml` runs the replay eval every night (06:00 UTC) and on

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ we test hardest.
 
 📐 [Design](docs/design.md) · 📚 [Learning loop](docs/learning-loop.md) · ✅ [Reviewing knowledge](docs/reviewing-knowledge.md) · 🚀 [Getting started](docs/getting-started.md) · 🧪 [Worked example](docs/examples/harbor-registry-down.md) ·
 🔌 [Data sources](docs/data-sources.md) · ⚙️ [Configuration](docs/configuration.md) · 📊 [Observability](docs/observability.md) · 🩺 [Troubleshooting](docs/troubleshooting.md) ·
-🔒 [Security model](docs/security-model.md) · 🛡 [LLM security architecture](docs/security-architecture.md) · ⬆️ [Upgrade & uninstall](docs/upgrade-uninstall.md) · 🧭 [Prior art](docs/prior-art.md) · 🛠 [Contributing](CONTRIBUTING.md)
+🔒 [Security model](docs/security-model.md) · 🛡 [LLM security architecture](docs/security-architecture.md) · ⬆️ [Upgrade & uninstall](docs/upgrade-uninstall.md) · 🧭 [Prior art](docs/prior-art.md) · 📊 [Benchmarking models](docs/benchmarking.md) · 🛠 [Contributing](CONTRIBUTING.md)
 
 ## License
 

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -26,6 +26,7 @@ Usage:
   lore catalog sync [--config <path>]                 clone/pull + index the knowledge catalog
   lore eval [--config <path>] [--cases <dir>]         replay recorded cases, score RCA identification
   lore eval --live [--scenarios <dir>] [--n 3]        live-fire on the cluster: grade coverage + RCA
+  lore eval --compare <spec.yaml> [--n 3]             benchmark several models over the replay suite
   lore curate [--config <path>]                       groom the KB backlog (dedup open PRs)
   lore mcp [--config <path>]                          serve GitOps what-changed over MCP (stdio; for HolmesGPT et al.)
   lore audit verify --path <audit.jsonl>              re-walk the action audit log; report the first broken link

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,126 @@
+# Benchmarking models with RunLore
+
+RunLore is model-agnostic: you pick the model behind the investigation loop. This
+page shows how to benchmark several models against RunLore's own eval harness in
+**one command** and publish an honest comparison.
+
+> [!important] Run RunLore on *your* models
+> The comparison runs the **replay** eval suite (recorded incident evidence, no
+> live cluster) so it is reproducible and cheap. It measures the model+loop's
+> reasoning over fixed evidence — not a live cluster's flakiness. See the
+> [replay-vs-live caveat](#replay-vs-live) before publishing.
+
+## One command
+
+```bash
+lore eval --compare eval/compare.example.yaml --cases examples/eval -n 3
+```
+
+This benchmarks every model in the spec against the same replay cases, grades each
+run with one fixed judge, and writes an aggregated report to
+`eval/reports/<stamp>-compare.md` (human) and `.json` (machine). It needs **no
+`config.model`** — the spec carries its own per-entry models and judge.
+
+### The comparison spec
+
+A small YAML listing the models to benchmark and (optionally) the judge. See
+[`eval/compare.example.yaml`](../eval/compare.example.yaml):
+
+```yaml
+judge:                       # optional; one fixed judge for every entry (blind grading)
+  provider: anthropic
+  model: claude-opus-4-1
+  api_key_env: RUNLORE_JUDGE_API_KEY
+models:
+  - name: haiku-4.5          # report label (must be unique)
+    provider: anthropic      # openai (default) | anthropic | gemini
+    model: claude-haiku-4-5-20251001
+    api_key_env: RUNLORE_ANTHROPIC_API_KEY
+    prices: {input_usd: 1.00, output_usd: 5.00}   # optional → enables the cost column
+  - name: gpt-5-mini
+    provider: openai
+    base_url: https://api.openai.com/v1
+    model: gpt-5-mini
+    api_key_env: RUNLORE_OPENAI_API_KEY
+    effort: medium           # reasoning_effort (openai-compatible only; not gemini)
+    prices: {input_usd: 0.25, output_usd: 2.00}
+  - name: local-qwen3        # keyless: a local vLLM/Ollama endpoint
+    provider: openai
+    base_url: http://localhost:8000/v1
+    model: qwen3-30b
+```
+
+Entry fields: `name` (required, unique), `model` (required), `provider`,
+`base_url`, `api_key_env` (empty = keyless), `effort` (openai/anthropic only —
+gemini is rejected), `prices` (optional; omit to omit the cost column for that
+entry). Unknown keys are rejected so a typo in a published spec fails loudly.
+
+The **judge** precedence is: `--judge-*` flags → the spec's `judge:` block →
+`config.model`. Keeping the judge in the spec makes a published comparison
+self-describing — the judge disclosure travels with the results.
+
+## The report
+
+The comparison report has one row per model, in **spec order** (a comparison
+should not silently reorder by score), with these columns:
+
+| column | meaning |
+|---|---|
+| `model` | the entry's report label |
+| `provider/model` | wire provider + model name (+ `effort=` when set) |
+| `pass rate` | fraction of cases that reached the k-of-n bar (`reached/total`) |
+| `reached` | cases whose pass-rate met the bar (median over N) |
+| `root_cause` / `evidence` / `solution` / `description` / `calibration` | per-dimension **median** rubric score over every graded run (`—` when ungraded) |
+| `coverage` | median data-source coverage ratio over all runs |
+| `confident-wrong` | graded runs that stated a wrong root cause with high confidence |
+| `in tok` / `out tok` | total provider-reported input/output tokens across the whole benchmark |
+| `est. cost (USD)` | `in·input_usd + out·output_usd` per MTok — **only shown when at least one entry supplies `prices`** |
+
+A second table gives the per-case pass rate (k-of-n) for each model, with `flaky`
+flagged when runs disagree too much to trust. Case rows are sorted by name and the
+JSON is deterministic, so two reports diff cleanly.
+
+Rubric dimensions and the pass gate are defined in [`eval/rubric.md`](../eval/rubric.md).
+Token usage is the provider-reported count per completion (see
+`providers.Usage`), summed across the loop **and** the judge by the runner's
+`CountingModel` wrapper.
+
+## Publishing results honestly
+
+RunLore's positioning is honesty about model performance. When you publish a
+comparison, disclose:
+
+1. **N runs.** State the `-n` you used (median over N; the pass gate is k-of-n at
+   ≥70%). A single run is not a benchmark — one lucky pass hides a flaky model.
+   Report the per-case table so flakiness is visible.
+2. **The judge model.** Grading is by an LLM judge (blind — the judge never sees
+   which model produced a result). The report prints the judge identity; keep it.
+   Prefer a judge **stronger than any model under test**, and never let a model
+   grade itself in the same run (bias).
+3. **<a id="replay-vs-live"></a>Replay vs live.** These numbers are **replay**:
+   fixed, recorded evidence. They isolate reasoning quality but do **not** capture
+   live-cluster tool flakiness, latency, or evidence-gathering gaps. Live-fire
+   (`lore eval --live`) is the harder, cluster-bound test. Label replay results as
+   replay.
+4. **ITBench context.** Independent work (ITBench, IBM/ICML 2025, see
+   [`docs/prior-art.md`](prior-art.md)) found frontier models identify the root
+   cause **< 50%** of the time and fully resolve only ~11–14% of real K8s
+   incidents. Treat sub-50% as the baseline; a high replay pass-rate is a ceiling,
+   not a field number. Design for failure and make honest uncertainty a feature.
+5. **Versioned report.** Commit the generated `eval/reports/<stamp>-compare.md`
+   and `.json` so a published claim points at a reproducible artifact (the spec,
+   the case corpus at that commit, the judge, and N are all recoverable).
+
+## Offline validation (keyless CI)
+
+The comparison pipeline is covered by an integration test that runs it end-to-end
+against a local, **keyless** OpenAI-compatible mock endpoint
+(`internal/app/eval_compare_test.go`): the mock streams the tool calls the replay
+loop needs (`what_changed` → `query_metrics` → `query_logs` → `submit_findings`)
+and answers the judge's forced `submit_grade` tool with a fixed rubric grade plus a
+token-usage block. So CI exercises load → per-entry replay → coverage → blind
+grading → aggregation → report writing with no API key and no network. Run it with:
+
+```bash
+go test ./internal/app/ -run TestRunEvalCompareOffline
+```

--- a/eval/compare.example.yaml
+++ b/eval/compare.example.yaml
@@ -1,0 +1,40 @@
+# Model-comparison spec for `lore eval --compare eval/compare.example.yaml`.
+#
+# Benchmarks several model configurations against the SAME replay suite
+# (--cases, default examples/eval) and writes one aggregated report to
+# eval/reports/<stamp>-compare.md / .json. Every entry is graded by ONE fixed
+# judge (below), and grading is blind — the judge never sees which entry produced
+# a result — so the rubric scores are directly comparable.
+#
+# Set the api_key_env vars in your shell before running. Entries with no
+# api_key_env are keyless (a local vLLM/Ollama endpoint).
+
+# Optional. The single judge used for every entry. Omit to fall back to --judge-*
+# flags, then to config.model. A strong model is recommended (see docs/benchmarking.md).
+judge:
+  provider: anthropic
+  model: claude-opus-4-1
+  api_key_env: RUNLORE_JUDGE_API_KEY
+
+models:
+  # A frontier hosted model, with optional per-MTok USD prices → adds a cost column.
+  - name: haiku-4.5
+    provider: anthropic
+    model: claude-haiku-4-5-20251001
+    api_key_env: RUNLORE_ANTHROPIC_API_KEY
+    prices: {input_usd: 1.00, output_usd: 5.00}
+
+  # An OpenAI-compatible model with the reasoning-effort knob (openai/vLLM only).
+  - name: gpt-5-mini
+    provider: openai
+    base_url: https://api.openai.com/v1
+    model: gpt-5-mini
+    api_key_env: RUNLORE_OPENAI_API_KEY
+    effort: medium
+    prices: {input_usd: 0.25, output_usd: 2.00}
+
+  # A local, keyless model (no api_key_env, no prices → cost column left blank for it).
+  - name: local-qwen3
+    provider: openai
+    base_url: http://localhost:8000/v1
+    model: qwen3-30b

--- a/internal/app/eval.go
+++ b/internal/app/eval.go
@@ -36,6 +36,7 @@ func RunEval(args []string) error {
 	jBaseURL := fs.String("judge-base-url", "", "judge model base URL")
 	jModel := fs.String("judge-model", "", "judge model name")
 	jKeyEnv := fs.String("judge-api-key-env", "", "env var holding the judge API key")
+	compare := fs.String("compare", "", "path to a model-comparison spec (benchmark several models over the replay suite)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -48,6 +49,16 @@ func RunEval(args []string) error {
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {
 		return err
+	}
+	// The comparison spec carries its own per-entry models (and optionally its own
+	// judge), so it does NOT require a configured config.model — it only borrows the
+	// config's output-token cap and, as a fallback, the config judge.
+	if *compare != "" {
+		if !nExplicit {
+			*n = compareDefaultN
+		}
+		return RunEvalCompare(cfg, *compare, *casesDir, *reportDir, *stamp, *n,
+			*jProvider, *jBaseURL, *jModel, *jKeyEnv)
 	}
 	if !ModelConfigured(cfg) {
 		return fmt.Errorf("eval requires a configured model (set config.model)")

--- a/internal/app/eval_compare.go
+++ b/internal/app/eval_compare.go
@@ -1,0 +1,119 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/eval"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// compareDefaultN is the runs-per-case used by the comparison benchmark when -n is
+// not given. It matches the rubric's "median over N=3": enough repeats to compute a
+// stable median and a k-of-n pass rate, without the cost of the live default (10).
+const compareDefaultN = 3
+
+// RunEvalCompare benchmarks every model in the comparison spec against the replay
+// suite and writes one aggregated report (markdown + JSON) to reportDir. The judge
+// is fixed across entries (blind grading already anonymizes which model produced a
+// result), so scores are comparable. It reuses the single-run replay machinery per
+// entry via eval.ComparisonRunner.
+func RunEvalCompare(cfg *config.Config, comparePath, casesDir, reportDir, stamp string, n int,
+	jProvider, jBaseURL, jModel, jKeyEnv string) error {
+	spec, err := eval.LoadCompareSpec(comparePath)
+	if err != nil {
+		return err
+	}
+	cases, err := eval.Load(casesDir)
+	if err != nil {
+		return err
+	}
+	if len(cases) == 0 {
+		return fmt.Errorf("no eval cases found in %s", casesDir)
+	}
+
+	judge, judgeLabel := buildCompareJudge(cfg, spec.Judge, jProvider, jBaseURL, jModel, jKeyEnv)
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	maxTokens := effectiveMaxTokens(cfg.Model.MaxTokens)
+	ctx := context.Background()
+
+	models := make([]eval.ModelComparison, 0, len(spec.Models))
+	for _, entry := range spec.Models {
+		apiKey := ""
+		if entry.APIKeyEnv != "" {
+			apiKey = os.Getenv(entry.APIKeyEnv)
+		}
+		counting := &eval.CountingModel{
+			Inner: NewModelClient(entry.Provider, entry.BaseURL, entry.Model, apiKey, maxTokens, entry.Effort),
+		}
+		runner := &eval.ComparisonRunner{Model: counting, Judge: judge, Log: log}
+		fmt.Printf("comparing %-20s (%s)\n", entry.Name, providerModel(entry.Provider, entry.Model))
+		compared := runner.RunCases(ctx, cases, n)
+		models = append(models, eval.AggregateModel(entry, compared, counting.Total()))
+	}
+
+	if stamp == "" {
+		stamp = time.Now().UTC().Format(time.RFC3339)
+	}
+	rep := eval.NewComparisonReport(stamp, n, judgeLabel, models)
+	md := rep.Markdown()
+	fmt.Print("\n" + md)
+
+	if reportDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(reportDir, 0o750); err != nil {
+		return fmt.Errorf("create report dir: %w", err)
+	}
+	base := filepath.Join(reportDir, strings.ReplaceAll(stamp, ":", "-")+"-compare")
+	jsonBytes, err := rep.JSON()
+	if err != nil {
+		return fmt.Errorf("render comparison JSON: %w", err)
+	}
+	if err := os.WriteFile(base+".json", jsonBytes, 0o600); err != nil {
+		return fmt.Errorf("write comparison JSON: %w", err)
+	}
+	if err := os.WriteFile(base+".md", []byte(md), 0o600); err != nil {
+		return fmt.Errorf("write comparison markdown: %w", err)
+	}
+	fmt.Printf("\nreport: %s.md / .json\n", base)
+	return nil
+}
+
+// buildCompareJudge resolves the fixed judge for a comparison run, and returns a
+// "provider/model" disclosure label for the report. Precedence: --judge-* flags,
+// then the spec's judge block, then the configured investigation model. A nil
+// judge (no flags, no spec judge, no config model) disables rubric grading —
+// pass/coverage/token columns still populate.
+func buildCompareJudge(cfg *config.Config, specJudge *eval.JudgeSpec, jProvider, jBaseURL, jModel, jKeyEnv string) (eval.Judge, string) {
+	if jModel != "" || jProvider != "" {
+		return eval.ModelJudge{Model: BuildJudgeModel(cfg, jProvider, jBaseURL, jModel, jKeyEnv)}, providerModel(jProvider, jModel)
+	}
+	if specJudge != nil {
+		m := NewModelClient(specJudge.Provider, specJudge.BaseURL, specJudge.Model,
+			os.Getenv(specJudge.APIKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens), "")
+		return eval.ModelJudge{Model: m}, providerModel(specJudge.Provider, specJudge.Model)
+	}
+	if ModelConfigured(cfg) {
+		return eval.ModelJudge{Model: BuildJudgeModel(cfg, "", "", "", "")}, providerModel(cfg.Model.Provider, cfg.Model.Model)
+	}
+	return nil, "(none — rubric grading disabled)"
+}
+
+// providerModel renders a "provider/model" label, defaulting an empty provider to
+// the OpenAI-compatible wire protocol (mirrors NewModelClient's routing).
+func providerModel(provider, model string) string {
+	if provider == "" {
+		provider = "openai"
+	}
+	return provider + "/" + model
+}
+
+var _ providers.ModelProvider = (*eval.CountingModel)(nil)

--- a/internal/app/eval_compare_test.go
+++ b/internal/app/eval_compare_test.go
@@ -1,0 +1,238 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/eval"
+)
+
+// mockModelServer is a keyless, offline OpenAI-compatible /chat/completions
+// endpoint that streams (SSE) the tool calls the replay loop and the LLM-judge
+// need: it scripts what_changed → query_metrics → query_logs → submit_findings by
+// counting the tool-role messages already in the request, and answers a judge turn
+// (identified by the submit_grade tool) with a fixed rubric grade plus a usage
+// block. It lets the whole model-comparison pipeline run in `go test` without any
+// API key — the same double the e2e uses, reduced to what this test exercises and
+// speaking SSE (which the streaming client requires).
+func mockModelServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Messages []struct {
+				Role string `json:"role"`
+			} `json:"messages"`
+			Tools []struct {
+				Function struct {
+					Name string `json:"name"`
+				} `json:"function"`
+			} `json:"tools"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+
+		for _, tool := range req.Tools {
+			if tool.Function.Name == "submit_grade" {
+				writeSSE(t, w, "submit_grade",
+					`{"scores":{"root_cause":3,"evidence":3,"solution":2,"description":2,"calibration":2},"confident_wrong":false,"rationale":"mock: correct root cause"}`)
+				return
+			}
+		}
+		toolResults := 0
+		for _, m := range req.Messages {
+			if m.Role == "tool" {
+				toolResults++
+			}
+		}
+		var name, args string
+		switch toolResults {
+		case 0:
+			name, args = "what_changed", `{"namespace":"apps"}`
+		case 1:
+			name, args = "query_metrics", `{"query":"up"}`
+		case 2:
+			name, args = "query_logs", `{"query":"error","since_minutes":30}`
+		default:
+			name, args = "submit_findings",
+				`{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db migrations","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":[]}`
+		}
+		writeSSE(t, w, name, args)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// writeSSE streams one tool call as chat/completions SSE: a tool-call delta chunk,
+// a finish_reason chunk, a usage chunk (so token totals + cost are exercised), then
+// the [DONE] sentinel.
+func writeSSE(t *testing.T, w http.ResponseWriter, name, args string) {
+	t.Helper()
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("test server needs http.Flusher")
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+	fl.Flush()
+	call, _ := json.Marshal(map[string]any{
+		"choices": []any{map[string]any{"delta": map[string]any{
+			"tool_calls": []any{map[string]any{
+				"index": 0, "id": "c1", "type": "function",
+				"function": map[string]any{"name": name, "arguments": args},
+			}},
+		}}},
+	})
+	for _, event := range []string{
+		"data: " + string(call) + "\n\n",
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":100}}` + "\n\n",
+		"data: [DONE]\n\n",
+	} {
+		_, _ = io.WriteString(w, event)
+		fl.Flush()
+	}
+}
+
+// writeCompareCase writes a replay case carrying ground truth so the comparison
+// exercises coverage + rubric grading, not only keyword pass/fail.
+func writeCompareCase(t *testing.T, dir string) {
+	t.Helper()
+	body := `
+name: harbor-chart-bump
+prompt: HarborProbeFailure in apps
+tools:
+  what_changed: "chart 1.15 enabled DB migrations"
+  query_metrics: "up{job=harbor-core}=0"
+  query_logs: "harbor-db FATAL migration lock"
+expected:
+  must_contain: [chart, harbor-db]
+  min_confidence: 0.5
+ground_truth:
+  root_cause: "the chart bump enabled a DB migration that stalled harbor-db"
+  expected_sources: [gitops, metrics, logs]
+  expected_action: "roll back the chart"
+  must_reach_root: true
+`
+	if err := os.WriteFile(filepath.Join(dir, "harbor.yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func minimalConfig(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "runlore.yaml")
+	if err := os.WriteFile(path, []byte("model:\n  provider: openai\n  model: x\n  base_url: http://unused\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestRunEvalCompareOffline drives the whole comparison pipeline against the
+// keyless mock model: two entries + a spec judge, over one ground-truthed replay
+// case, and asserts the written report has the aggregated columns populated.
+func TestRunEvalCompareOffline(t *testing.T) {
+	srv := mockModelServer(t)
+	base := srv.URL + "/v1"
+
+	dir := t.TempDir()
+	casesDir := filepath.Join(dir, "cases")
+	if err := os.MkdirAll(casesDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeCompareCase(t, casesDir)
+
+	spec := fmt.Sprintf(`
+judge:
+  provider: openai
+  base_url: %s
+  model: mock-judge
+models:
+  - name: model-a
+    provider: openai
+    base_url: %s
+    model: mock-a
+    prices: {input_usd: 3, output_usd: 15}
+  - name: model-b
+    provider: openai
+    base_url: %s
+    model: mock-b
+`, base, base, base)
+	comparePath := filepath.Join(dir, "compare.yaml")
+	if err := os.WriteFile(comparePath, []byte(spec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reportDir := filepath.Join(dir, "reports")
+
+	cfg, err := config.Load(minimalConfig(t, dir))
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	if err := RunEvalCompare(cfg, comparePath, casesDir, reportDir, "2026-07-02T00:00:00Z", 2, "", "", "", ""); err != nil {
+		t.Fatalf("RunEvalCompare: %v", err)
+	}
+
+	jsonPath := filepath.Join(reportDir, "2026-07-02T00-00-00Z-compare.json")
+	raw, err := os.ReadFile(jsonPath) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	rep, err := eval.ParseComparisonReport(raw)
+	if err != nil {
+		t.Fatalf("parse report: %v", err)
+	}
+	if rep.N != 2 || len(rep.Models) != 2 {
+		t.Fatalf("header: N=%d models=%d", rep.N, len(rep.Models))
+	}
+	if rep.Judge != "openai/mock-judge" {
+		t.Fatalf("judge disclosure: %q", rep.Judge)
+	}
+	// Spec order preserved.
+	if rep.Models[0].Name != "model-a" || rep.Models[1].Name != "model-b" {
+		t.Fatalf("model order: %+v", rep.Models)
+	}
+
+	a := rep.Models[0]
+	// The scripted loop names harbor-db with confidence 0.9 → case passes both runs.
+	if a.PassRate != 1.0 || a.Reached != 1 || a.Total != 1 {
+		t.Fatalf("model-a pass aggregation: %+v", a)
+	}
+	// Coverage: what_changed(gitops) + query_metrics(metrics) + query_logs(logs) = all 3 expected → 1.0.
+	if a.CoverageMedian != 1.0 {
+		t.Fatalf("model-a coverage median: %v", a.CoverageMedian)
+	}
+	// Judge graded every run: root_cause median 3, no confident-wrong.
+	if a.RubricMedian == nil || a.RubricMedian["root_cause"] != 3 {
+		t.Fatalf("model-a rubric: %+v", a.RubricMedian)
+	}
+	if a.GradedRuns != 2 || a.ConfidentWrong != 0 {
+		t.Fatalf("model-a graded=%d confidentWrong=%d", a.GradedRuns, a.ConfidentWrong)
+	}
+	// Usage accumulates across every completion (loop + judge); cost = prices × MTok.
+	if a.InputTokens == 0 || a.OutputTokens == 0 {
+		t.Fatalf("model-a tokens not recorded: %+v", a)
+	}
+	if a.CostUSD == nil || *a.CostUSD <= 0 {
+		t.Fatalf("model-a cost: %v", a.CostUSD)
+	}
+	// model-b supplied no prices → no cost.
+	if rep.Models[1].CostUSD != nil {
+		t.Fatalf("model-b must have no cost: %v", rep.Models[1].CostUSD)
+	}
+
+	// The markdown sibling is written and shows the cost column (some entry priced).
+	md, err := os.ReadFile(filepath.Join(reportDir, "2026-07-02T00-00-00Z-compare.md")) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read markdown: %v", err)
+	}
+	if !strings.Contains(string(md), "est. cost (USD)") || !strings.Contains(string(md), "openai/mock-judge") {
+		t.Fatalf("markdown missing expected columns:\n%s", md)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -594,6 +594,14 @@ var effortLevels = map[string]map[string]bool{
 	"openai":    {"minimal": true, "low": true, "medium": true, "high": true},
 }
 
+// ValidateEffort checks an effective (provider, effort) pair against the
+// per-provider effort vocabulary, so callers that build a ModelProvider outside
+// config.Load (e.g. the eval model-comparison runner) share one source of truth.
+// field names the setting in the returned error. Empty effort is always valid.
+func ValidateEffort(field, provider, effort string) error {
+	return validateEffort(field, provider, effort)
+}
+
 // validateEffort checks an effective (provider, effort) pair against the
 // per-provider vocabulary. Empty effort is always valid (the knob is opt-in and
 // omitted from requests); an empty provider defaults to the OpenAI-compatible

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -19,6 +19,11 @@ type Case struct {
 	Prompt   string            `yaml:"prompt"` // the incident description (seeds the loop)
 	Tools    map[string]string `yaml:"tools"`  // tool name -> recorded evidence the tool returns
 	Expected Expected          `yaml:"expected"`
+	// GroundTruth is optional live-scenario ground truth carried into replay. When
+	// present it unlocks the richer scoring the model-comparison benchmark reports:
+	// data-source coverage (expected_sources) and blind LLM-judge rubric grading
+	// (root_cause / expected_action). Absent ⇒ keyword-only scoring, as before.
+	GroundTruth *GroundTruth `yaml:"ground_truth,omitempty"`
 }
 
 // Expected is the RCA scoring spec for a case.

--- a/internal/eval/compare.go
+++ b/internal/eval/compare.go
@@ -1,0 +1,99 @@
+package eval
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Smana/runlore/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+// CompareSpec is the multi-model benchmark description: the model entries to
+// benchmark against the replay suite, and (optionally) the judge that grades
+// every entry. Keeping the judge in the spec makes a published comparison
+// self-describing — the judge disclosure travels with the results.
+type CompareSpec struct {
+	Judge  *JudgeSpec   `yaml:"judge,omitempty"`
+	Models []ModelEntry `yaml:"models"`
+}
+
+// JudgeSpec identifies the (single, fixed) judge model used for every entry.
+// Grading is blind: the judge never sees which entry produced an investigation.
+type JudgeSpec struct {
+	Provider  string `yaml:"provider"`
+	BaseURL   string `yaml:"base_url"`
+	Model     string `yaml:"model"`
+	APIKeyEnv string `yaml:"api_key_env"`
+}
+
+// ModelEntry is one model configuration to benchmark.
+type ModelEntry struct {
+	Name      string `yaml:"name"`     // report label; must be unique
+	Provider  string `yaml:"provider"` // "openai" (default) | "anthropic" | "gemini"
+	BaseURL   string `yaml:"base_url"`
+	Model     string `yaml:"model"`
+	APIKeyEnv string `yaml:"api_key_env"` // env var holding the API key (empty = keyless)
+	// Effort is the OpenAI-compatible reasoning_effort request field (e.g. "low",
+	// "medium", "high"). Only valid for the openai provider; other providers reject it.
+	Effort string `yaml:"effort,omitempty"`
+	// Prices enables the estimated-cost column; omit it to omit the column.
+	Prices *Prices `yaml:"prices,omitempty"`
+}
+
+// Prices is optional per-million-token (MTok) pricing for cost estimation.
+type Prices struct {
+	InputUSD  float64 `yaml:"input_usd" json:"input_usd"`
+	OutputUSD float64 `yaml:"output_usd" json:"output_usd"`
+}
+
+// LoadCompareSpec reads and validates a comparison spec. Unknown keys are
+// rejected so a typo (e.g. "pricess") fails loudly instead of silently skewing
+// a published benchmark.
+func LoadCompareSpec(path string) (CompareSpec, error) {
+	f, err := os.Open(path) //nolint:gosec // G304: path is the operator-supplied compare file
+	if err != nil {
+		return CompareSpec{}, fmt.Errorf("open compare spec: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	var spec CompareSpec
+	dec := yaml.NewDecoder(f)
+	dec.KnownFields(true)
+	if err := dec.Decode(&spec); err != nil {
+		return CompareSpec{}, fmt.Errorf("parse compare spec %s: %w", path, err)
+	}
+	if err := spec.validate(); err != nil {
+		return CompareSpec{}, fmt.Errorf("invalid compare spec %s: %w", path, err)
+	}
+	return spec, nil
+}
+
+func (s CompareSpec) validate() error {
+	if len(s.Models) == 0 {
+		return fmt.Errorf("models: at least one entry is required")
+	}
+	seen := map[string]bool{}
+	for i, e := range s.Models {
+		if e.Name == "" {
+			return fmt.Errorf("models[%d]: name is required", i)
+		}
+		if e.Model == "" {
+			return fmt.Errorf("models[%d] (%s): model is required", i, e.Name)
+		}
+		if seen[e.Name] {
+			return fmt.Errorf("models[%d]: duplicate name %q", i, e.Name)
+		}
+		seen[e.Name] = true
+		// Effort is validated against the provider it will actually be sent to, using
+		// config's single source of truth (anthropic low|medium|high|max, openai
+		// minimal|low|medium|high, rejected for gemini). An empty provider defaults to
+		// the OpenAI-compatible wire protocol, mirroring NewModelClient.
+		field := fmt.Sprintf("models[%d] (%s).effort", i, e.Name)
+		if err := config.ValidateEffort(field, e.Provider, e.Effort); err != nil {
+			return err
+		}
+	}
+	if s.Judge != nil && s.Judge.Model == "" {
+		return fmt.Errorf("judge: model is required when a judge block is present")
+	}
+	return nil
+}

--- a/internal/eval/compare_report.go
+++ b/internal/eval/compare_report.go
@@ -1,0 +1,274 @@
+package eval
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// CompareCaseRow is one case's k-of-n verdict for one model, in the comparison.
+type CompareCaseRow struct {
+	Name     string  `json:"name"`
+	Runs     int     `json:"runs"`
+	PassRate float64 `json:"pass_rate"`
+	Reached  bool    `json:"reached"`
+	Flaky    bool    `json:"flaky"`
+	Coverage float64 `json:"coverage"` // median coverage ratio over the case's runs
+}
+
+// ModelComparison is one model entry's aggregated result across all cases.
+type ModelComparison struct {
+	Name     string `json:"name"` // the entry's report label
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	Effort   string `json:"effort,omitempty"`
+
+	// Aggregate scores.
+	PassRate       float64            `json:"pass_rate"`               // fraction of cases that reached the k-of-n bar
+	Reached        int                `json:"reached"`                 // cases whose pass-rate met the k-of-n bar
+	Total          int                `json:"total"`                   // cases run
+	RubricMedian   map[string]float64 `json:"rubric_median,omitempty"` // per-dimension median over graded runs; nil when ungraded
+	GradedRuns     int                `json:"graded_runs"`             // runs the judge graded (0 ⇒ rubric omitted)
+	CoverageMedian float64            `json:"coverage_median"`         // median coverage ratio over all runs
+	ConfidentWrong int                `json:"confident_wrong"`         // graded runs flagged confident-and-wrong
+
+	// Usage + cost.
+	InputTokens  int      `json:"input_tokens"`
+	OutputTokens int      `json:"output_tokens"`
+	CostUSD      *float64 `json:"cost_usd,omitempty"` // present only when the entry supplied prices
+
+	Cases []CompareCaseRow `json:"cases"`
+}
+
+// AggregateModel folds a model entry's per-case replay runs into one comparison
+// row. Per-case pass uses the same k-of-n bar as the single-run campaign; rubric
+// medians and confident-wrong are computed over every graded run; coverage is the
+// median over every run; cost is computed only when the entry supplied prices.
+// Case rows come out sorted by name so two reports diff cleanly.
+func AggregateModel(entry ModelEntry, cases []ComparedCase, usage providers.Usage) ModelComparison {
+	mc := ModelComparison{
+		Name: entry.Name, Provider: entry.Provider, Model: entry.Model, Effort: entry.Effort,
+		Total:        len(cases),
+		InputTokens:  usage.InputTokens,
+		OutputTokens: usage.OutputTokens,
+	}
+
+	var allCoverage []float64
+	perDim := map[string][]float64{}
+	for _, cc := range cases {
+		passes := 0
+		var covs []float64
+		for _, run := range cc.Runs {
+			if run.Result.Pass {
+				passes++
+			}
+			covs = append(covs, run.Coverage.Ratio)
+			allCoverage = append(allCoverage, run.Coverage.Ratio)
+			if run.Graded {
+				mc.GradedRuns++
+				if run.Verdict.ConfidentWrong {
+					mc.ConfidentWrong++
+				}
+				for _, d := range Rubric {
+					perDim[d.Key] = append(perDim[d.Key], float64(run.Verdict.Scores[d.Key]))
+				}
+			}
+		}
+		n := len(cc.Runs)
+		rate := 0.0
+		if n > 0 {
+			rate = float64(passes) / float64(n)
+		}
+		row := CompareCaseRow{
+			Name:     cc.Name,
+			Runs:     n,
+			PassRate: rate,
+			Reached:  rate >= evalMinPassRate,
+			Flaky:    rate > 1-evalMinPassRate && rate < evalMinPassRate,
+			Coverage: medianFloat(covs),
+		}
+		if row.Reached {
+			mc.Reached++
+		}
+		mc.Cases = append(mc.Cases, row)
+	}
+	sort.Slice(mc.Cases, func(i, j int) bool { return mc.Cases[i].Name < mc.Cases[j].Name })
+
+	if mc.Total > 0 {
+		mc.PassRate = float64(mc.Reached) / float64(mc.Total)
+	}
+	mc.CoverageMedian = medianFloat(allCoverage)
+	if mc.GradedRuns > 0 {
+		mc.RubricMedian = map[string]float64{}
+		for _, d := range Rubric {
+			mc.RubricMedian[d.Key] = medianFloat(perDim[d.Key])
+		}
+	}
+	if entry.Prices != nil {
+		cost := float64(usage.InputTokens)/1e6*entry.Prices.InputUSD +
+			float64(usage.OutputTokens)/1e6*entry.Prices.OutputUSD
+		mc.CostUSD = &cost
+	}
+	return mc
+}
+
+// ComparisonReport is the aggregate of a multi-model benchmark run: one row per
+// model entry, in spec order (comparisons should not reorder by score), plus the
+// disclosure a published benchmark needs — N runs and the judge model identity.
+type ComparisonReport struct {
+	At     string            `json:"at"`
+	N      int               `json:"n"`     // runs per case
+	Judge  string            `json:"judge"` // judge model disclosure, e.g. "anthropic/claude-…"
+	Models []ModelComparison `json:"models"`
+}
+
+// NewComparisonReport builds a report from already-aggregated model rows,
+// preserving the given (spec) order.
+func NewComparisonReport(at string, n int, judge string, models []ModelComparison) ComparisonReport {
+	return ComparisonReport{At: at, N: n, Judge: judge, Models: models}
+}
+
+// JSON renders the deterministic machine-readable comparison report.
+func (r ComparisonReport) JSON() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// ParseComparisonReport reads a report back from its JSON form (baseline diffs, tests).
+func ParseComparisonReport(b []byte) (ComparisonReport, error) {
+	var rep ComparisonReport
+	if err := json.Unmarshal(b, &rep); err != nil {
+		return ComparisonReport{}, fmt.Errorf("parse comparison report: %w", err)
+	}
+	return rep, nil
+}
+
+// anyPriced reports whether at least one model row carries an estimated cost, so
+// the cost column is shown only when some entry supplied prices.
+func (r ComparisonReport) anyPriced() bool {
+	for _, m := range r.Models {
+		if m.CostUSD != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// Markdown renders the human comparison report: a per-model summary table (rubric
+// breakdown, pass rate, coverage, confident-wrong, tokens, optional cost) followed
+// by a per-case pass-rate matrix. Deterministic: models keep spec order, cases sort
+// by name.
+func (r ComparisonReport) Markdown() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# RunLore model comparison — %s\n\n", r.At)
+	fmt.Fprintf(&b, "N=%d runs/case · pass-rate bar ≥%.0f%% · judge: `%s` · blind grading (the judge never sees which model produced a result).\n\n",
+		r.N, evalMinPassRate*100, r.Judge)
+
+	showCost := r.anyPriced()
+	header := []string{"model", "provider/model", "pass rate", "reached"}
+	for _, d := range Rubric {
+		header = append(header, d.Key)
+	}
+	header = append(header, "coverage", "confident-wrong", "in tok", "out tok")
+	if showCost {
+		header = append(header, "est. cost (USD)")
+	}
+	b.WriteString("## Summary\n\n")
+	b.WriteString("| " + strings.Join(header, " | ") + " |\n")
+	b.WriteString("|" + strings.Repeat("---|", len(header)) + "\n")
+
+	for _, m := range r.Models {
+		provModel := m.Model
+		if m.Provider != "" {
+			provModel = m.Provider + "/" + m.Model
+		}
+		if m.Effort != "" {
+			provModel += " (effort=" + m.Effort + ")"
+		}
+		cells := []string{
+			m.Name,
+			provModel,
+			fmt.Sprintf("%.0f%% (%d/%d)", m.PassRate*100, m.Reached, m.Total),
+			fmt.Sprintf("%d/%d", m.Reached, m.Total),
+		}
+		for _, d := range Rubric {
+			if m.RubricMedian == nil {
+				cells = append(cells, "—")
+			} else {
+				cells = append(cells, fmt.Sprintf("%.1f/%d", m.RubricMedian[d.Key], d.Max))
+			}
+		}
+		cells = append(cells,
+			fmt.Sprintf("%.0f%%", m.CoverageMedian*100),
+			fmt.Sprintf("%d", m.ConfidentWrong),
+			fmt.Sprintf("%d", m.InputTokens),
+			fmt.Sprintf("%d", m.OutputTokens),
+		)
+		if showCost {
+			if m.CostUSD != nil {
+				cells = append(cells, fmt.Sprintf("$%.2f", *m.CostUSD))
+			} else {
+				cells = append(cells, "—")
+			}
+		}
+		b.WriteString("| " + strings.Join(cells, " | ") + " |\n")
+	}
+
+	b.WriteString("\n## Per-case pass rate (k-of-n)\n\n")
+	names := caseNames(r.Models)
+	b.WriteString("| case | " + strings.Join(modelLabels(r.Models), " | ") + " |\n")
+	b.WriteString("|---|" + strings.Repeat("---|", len(r.Models)) + "\n")
+	for _, name := range names {
+		row := []string{name}
+		for _, m := range r.Models {
+			row = append(row, caseCell(m, name))
+		}
+		b.WriteString("| " + strings.Join(row, " | ") + " |\n")
+	}
+	return b.String()
+}
+
+// caseNames returns the union of case names across all models, sorted.
+func caseNames(models []ModelComparison) []string {
+	set := map[string]bool{}
+	for _, m := range models {
+		for _, c := range m.Cases {
+			set[c.Name] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for n := range set {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func modelLabels(models []ModelComparison) []string {
+	out := make([]string, len(models))
+	for i, m := range models {
+		out[i] = m.Name
+	}
+	return out
+}
+
+// caseCell renders one model's verdict for one case: pass-rate, with a "flaky"
+// or "—" (case not run for this model) annotation.
+func caseCell(m ModelComparison, name string) string {
+	for _, c := range m.Cases {
+		if c.Name != name {
+			continue
+		}
+		s := fmt.Sprintf("%.0f%%", c.PassRate*100)
+		switch {
+		case c.Reached:
+			s += " ✓"
+		case c.Flaky:
+			s += " flaky"
+		}
+		return s
+	}
+	return "—"
+}

--- a/internal/eval/compare_run.go
+++ b/internal/eval/compare_run.go
@@ -1,0 +1,125 @@
+package eval
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// CountingModel wraps a ModelProvider and sums the provider-reported token usage
+// across completions. The loop only logs/meters each response's Usage, so this
+// wrapper is what turns per-response usage into a per-benchmark total.
+type CountingModel struct {
+	Inner providers.ModelProvider
+
+	mu    sync.Mutex
+	total providers.Usage
+}
+
+// Complete delegates to Inner and accumulates the response usage on success.
+func (c *CountingModel) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	resp, err := c.Inner.Complete(ctx, req)
+	if err == nil {
+		c.mu.Lock()
+		c.total.InputTokens += resp.Usage.InputTokens
+		c.total.OutputTokens += resp.Usage.OutputTokens
+		c.total.CachedInputTokens += resp.Usage.CachedInputTokens
+		c.total.CacheWriteTokens += resp.Usage.CacheWriteTokens
+		c.mu.Unlock()
+	}
+	return resp, err
+}
+
+// Total returns the usage accumulated so far.
+func (c *CountingModel) Total() providers.Usage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.total
+}
+
+// ComparedRun is one replay run of one case for one model entry: the
+// deterministic keyword score, the tool-call coverage, and (when the case
+// carries ground truth and a judge is set) the judge's rubric verdict.
+type ComparedRun struct {
+	Result   Result
+	Coverage Coverage
+	Verdict  Verdict
+	Graded   bool
+}
+
+// ComparedCase is all N runs of one case for one model entry.
+type ComparedCase struct {
+	Name string
+	Runs []ComparedRun
+}
+
+// ComparisonRunner benchmarks one model entry over the replay cases. It mirrors
+// the replay Runner (static tools, same loop) but additionally records tool
+// calls for coverage and grades every run with a fixed judge, so entries can be
+// compared on the full rubric — not only keyword pass/fail.
+type ComparisonRunner struct {
+	Model providers.ModelProvider // the entry under test (wrap with CountingModel for token totals)
+	Judge Judge                   // fixed across entries; nil skips rubric grading
+	Log   *slog.Logger
+}
+
+// RunCases replays every case n times against the entry's model.
+func (cr *ComparisonRunner) RunCases(ctx context.Context, cases []Case, n int) []ComparedCase {
+	if n < 1 {
+		n = 1
+	}
+	out := make([]ComparedCase, 0, len(cases))
+	for _, c := range cases {
+		cc := ComparedCase{Name: c.Name}
+		for i := 0; i < n; i++ {
+			cc.Runs = append(cc.Runs, cr.runOnce(ctx, c))
+		}
+		out = append(out, cc)
+	}
+	return out
+}
+
+func (cr *ComparisonRunner) runOnce(ctx context.Context, c Case) ComparedRun {
+	rec := &Recorder{}
+	tools := make([]investigate.Tool, 0, len(c.Tools))
+	for name, output := range c.Tools {
+		tools = append(tools, staticTool{name: name, output: output})
+	}
+	var got providers.Investigation
+	done := false
+	li := &investigate.LoopInvestigator{
+		Model: cr.Model,
+		Tools: wrap(tools, rec),
+		Log:   cr.Log,
+		OnComplete: func(inv providers.Investigation) {
+			got, done = inv, true
+		},
+	}
+	req := investigate.Request{Source: investigate.SourceAlert, Title: c.Name, Message: c.Prompt}
+	if err := li.Investigate(ctx, req); err != nil {
+		return ComparedRun{Result: Result{Name: c.Name, Missing: []string{"investigation error: " + err.Error()}}}
+	}
+	if !done {
+		return ComparedRun{Result: Result{Name: c.Name, Missing: []string{"no findings (loop did not submit)"}}}
+	}
+
+	run := ComparedRun{Result: Score(c.Name, got, c.Expected)}
+	var expected, optional []string
+	if c.GroundTruth != nil {
+		expected, optional = c.GroundTruth.ExpectedSources, c.GroundTruth.OptionalSources
+	}
+	run.Coverage = ScoreCoverage(expected, optional, rec.Calls())
+	if cr.Judge != nil && c.GroundTruth != nil {
+		scn := Scenario{ID: c.Name, GroundTruth: *c.GroundTruth}
+		v, err := cr.Judge.Grade(ctx, scn, got)
+		if err != nil {
+			cr.Log.Warn("judge error", "case", c.Name, "err", err)
+		} else {
+			run.Verdict, run.Graded = v, true
+		}
+	}
+	return run
+}

--- a/internal/eval/compare_test.go
+++ b/internal/eval/compare_test.go
@@ -1,0 +1,307 @@
+package eval
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func writeSpec(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "compare.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadCompareSpec(t *testing.T) {
+	path := writeSpec(t, `
+judge:
+  provider: anthropic
+  model: claude-judge
+  api_key_env: JUDGE_KEY
+models:
+  - name: haiku
+    provider: anthropic
+    model: claude-haiku
+    api_key_env: KEY_A
+    prices: {input_usd: 1, output_usd: 5}
+  - name: local-qwen
+    provider: openai
+    base_url: http://localhost:8000/v1
+    model: qwen3
+    effort: low
+`)
+	spec, err := LoadCompareSpec(path)
+	if err != nil {
+		t.Fatalf("LoadCompareSpec: %v", err)
+	}
+	if spec.Judge == nil || spec.Judge.Model != "claude-judge" || spec.Judge.Provider != "anthropic" {
+		t.Fatalf("judge not parsed: %+v", spec.Judge)
+	}
+	if len(spec.Models) != 2 {
+		t.Fatalf("want 2 models, got %+v", spec.Models)
+	}
+	if spec.Models[0].Name != "haiku" || spec.Models[0].Prices == nil || spec.Models[0].Prices.OutputUSD != 5 {
+		t.Fatalf("first entry not parsed: %+v", spec.Models[0])
+	}
+	if spec.Models[1].Effort != "low" || spec.Models[1].Prices != nil {
+		t.Fatalf("second entry not parsed: %+v", spec.Models[1])
+	}
+}
+
+func TestLoadCompareSpecRejectsBadSpecs(t *testing.T) {
+	tests := []struct {
+		name, body, wantErr string
+	}{
+		{"no models", `models: []`, "at least one"},
+		{"missing name", `models: [{model: m}]`, "name"},
+		{"missing model", `models: [{name: a}]`, "model"},
+		{"duplicate names", `models: [{name: a, model: m1}, {name: a, model: m2}]`, "duplicate"},
+		{"effort on gemini", `models: [{name: a, provider: gemini, model: m, effort: high}]`, "effort is not supported for provider gemini"},
+		{"bad effort level", `models: [{name: a, provider: openai, model: m, effort: turbo}]`, "not a valid effort"},
+		{"unknown key", `models: [{name: a, model: m, pricess: {}}]`, "field pricess not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadCompareSpec(writeSpec(t, tt.body))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadCompareSpecEffortAccepted(t *testing.T) {
+	// Effort is valid on the OpenAI-compatible default and on anthropic (different
+	// vocabularies), matching config's per-provider effort validation.
+	for _, body := range []string{
+		`models: [{name: a, model: m, effort: high}]`,                      // empty provider ⇒ openai-compatible
+		`models: [{name: a, provider: anthropic, model: m, effort: max}]`,  // anthropic-only level
+		`models: [{name: a, provider: openai, model: m, effort: minimal}]`, // openai-only level
+	} {
+		if _, err := LoadCompareSpec(writeSpec(t, body)); err != nil {
+			t.Fatalf("effort should be accepted for %q: %v", body, err)
+		}
+	}
+}
+
+// comparedCase builds a ComparedCase from compact per-run tuples.
+type runTuple struct {
+	pass           bool
+	coverage       float64
+	rootCause      int
+	graded         bool
+	confidentWrong bool
+}
+
+func comparedCase(name string, runs ...runTuple) ComparedCase {
+	cc := ComparedCase{Name: name}
+	for _, r := range runs {
+		cr := ComparedRun{
+			Result:   Result{Name: name, Pass: r.pass},
+			Coverage: Coverage{Ratio: r.coverage},
+			Graded:   r.graded,
+		}
+		if r.graded {
+			cr.Verdict = Verdict{
+				Scores: map[string]int{
+					"root_cause": r.rootCause, "evidence": 2, "solution": 2,
+					"description": 2, "calibration": 1,
+				},
+				ConfidentWrong: r.confidentWrong,
+			}
+		}
+		cc.Runs = append(cc.Runs, cr)
+	}
+	return cc
+}
+
+func TestAggregateModel(t *testing.T) {
+	entry := ModelEntry{Name: "m", Provider: "openai", Model: "gpt-x",
+		Prices: &Prices{InputUSD: 2, OutputUSD: 10}}
+	cases := []ComparedCase{
+		// zeta before alpha: case rows must come out sorted by name.
+		comparedCase("zeta",
+			runTuple{pass: true, coverage: 1.0, rootCause: 3, graded: true},
+			runTuple{pass: true, coverage: 0.5, rootCause: 2, graded: true},
+			runTuple{pass: false, coverage: 1.0, rootCause: 1, graded: true, confidentWrong: true},
+		),
+		comparedCase("alpha",
+			runTuple{pass: true, coverage: 1.0, rootCause: 3, graded: true},
+			runTuple{pass: true, coverage: 1.0, rootCause: 3, graded: true},
+			runTuple{pass: true, coverage: 1.0, rootCause: 3, graded: true},
+		),
+	}
+	mc := AggregateModel(entry, cases, providers.Usage{InputTokens: 1_000_000, OutputTokens: 100_000})
+
+	if mc.Name != "m" || mc.Model != "gpt-x" {
+		t.Fatalf("identity: %+v", mc)
+	}
+	// alpha 3/3 reached; zeta 2/3 (0.67 < 0.7) not reached → pass rate 0.5.
+	if mc.Reached != 1 || mc.PassRate != 0.5 {
+		t.Fatalf("want reached=1 pass-rate=0.5, got reached=%d rate=%.2f", mc.Reached, mc.PassRate)
+	}
+	if len(mc.Cases) != 2 || mc.Cases[0].Name != "alpha" || mc.Cases[1].Name != "zeta" {
+		t.Fatalf("case rows must be sorted by name: %+v", mc.Cases)
+	}
+	if !mc.Cases[0].Reached || mc.Cases[1].Reached {
+		t.Fatalf("per-case reached wrong: %+v", mc.Cases)
+	}
+	// root_cause over all graded runs: 3,2,1,3,3,3 → median 3.
+	if mc.RubricMedian["root_cause"] != 3 {
+		t.Fatalf("root_cause median: %+v", mc.RubricMedian)
+	}
+	// calibration is 1 in every graded run.
+	if mc.RubricMedian["calibration"] != 1 {
+		t.Fatalf("calibration median: %+v", mc.RubricMedian)
+	}
+	if mc.GradedRuns != 6 {
+		t.Fatalf("graded runs: %d", mc.GradedRuns)
+	}
+	// coverage over all runs: 1,0.5,1,1,1,1 → median 1.
+	if mc.CoverageMedian != 1.0 {
+		t.Fatalf("coverage median: %v", mc.CoverageMedian)
+	}
+	if mc.ConfidentWrong != 1 {
+		t.Fatalf("confident-wrong count: %d", mc.ConfidentWrong)
+	}
+	if mc.InputTokens != 1_000_000 || mc.OutputTokens != 100_000 {
+		t.Fatalf("tokens: %+v", mc)
+	}
+	// cost: 1 MTok in × $2 + 0.1 MTok out × $10 = $3.
+	if mc.CostUSD == nil || *mc.CostUSD != 3.0 {
+		t.Fatalf("cost: %v", mc.CostUSD)
+	}
+}
+
+func TestAggregateModelNoPricesNoJudge(t *testing.T) {
+	cases := []ComparedCase{comparedCase("only",
+		runTuple{pass: true, coverage: 1.0},
+		runTuple{pass: true, coverage: 1.0},
+	)}
+	mc := AggregateModel(ModelEntry{Name: "m", Model: "x"}, cases, providers.Usage{})
+	if mc.CostUSD != nil {
+		t.Fatalf("no prices ⇒ no cost, got %v", mc.CostUSD)
+	}
+	if mc.RubricMedian != nil || mc.GradedRuns != 0 {
+		t.Fatalf("no graded runs ⇒ no rubric medians, got %+v", mc.RubricMedian)
+	}
+	if mc.PassRate != 1.0 || !mc.Cases[0].Reached {
+		t.Fatalf("pass aggregation: %+v", mc)
+	}
+}
+
+func TestAggregateModelFlakyBand(t *testing.T) {
+	// 1/2 pass → rate 0.5, inside (0.3, 0.7) → flaky, not reached.
+	cases := []ComparedCase{comparedCase("f",
+		runTuple{pass: true, coverage: 1.0},
+		runTuple{pass: false, coverage: 1.0},
+	)}
+	mc := AggregateModel(ModelEntry{Name: "m", Model: "x"}, cases, providers.Usage{})
+	if !mc.Cases[0].Flaky || mc.Cases[0].Reached {
+		t.Fatalf("0.5 should be flaky and not reached: %+v", mc.Cases[0])
+	}
+}
+
+func costPtr(v float64) *float64 { return &v }
+
+func comparisonFixture() ComparisonReport {
+	return NewComparisonReport("2026-07-02T00:00:00Z", 3, "anthropic/claude-judge", []ModelComparison{
+		{
+			Name: "haiku", Provider: "anthropic", Model: "claude-haiku",
+			PassRate: 1.0, Reached: 2,
+			Cases: []CompareCaseRow{
+				{Name: "alpha", Runs: 3, PassRate: 1, Reached: true, Coverage: 1},
+				{Name: "zeta", Runs: 3, PassRate: 1, Reached: true, Coverage: 1},
+			},
+			RubricMedian: map[string]float64{
+				"root_cause": 3, "evidence": 2.5, "solution": 2, "description": 2, "calibration": 2,
+			},
+			GradedRuns: 6, CoverageMedian: 1.0, ConfidentWrong: 0,
+			InputTokens: 500_000, OutputTokens: 40_000, CostUSD: costPtr(0.9),
+		},
+		{
+			Name: "local-qwen", Provider: "openai", Model: "qwen3", Effort: "low",
+			PassRate: 0.5, Reached: 1,
+			Cases: []CompareCaseRow{
+				{Name: "alpha", Runs: 3, PassRate: 1, Reached: true, Coverage: 1},
+				{Name: "zeta", Runs: 3, PassRate: 0.33, Reached: false, Flaky: true, Coverage: 0.5},
+			},
+			GradedRuns: 0, CoverageMedian: 0.75, ConfidentWrong: 2,
+			InputTokens: 800_000, OutputTokens: 90_000,
+		},
+	})
+}
+
+func TestComparisonMarkdown(t *testing.T) {
+	md := comparisonFixture().Markdown()
+
+	for _, want := range []string{
+		"# RunLore model comparison — 2026-07-02T00:00:00Z",
+		"anthropic/claude-judge", // judge disclosure
+		"N=3",
+		"| haiku |",
+		"| local-qwen |",
+		"est. cost (USD)",
+		"| alpha |",
+		"| zeta |",
+		"flaky",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown missing %q\n%s", want, md)
+		}
+	}
+	// Spec order preserved: haiku row before local-qwen row.
+	if strings.Index(md, "| haiku |") > strings.Index(md, "| local-qwen |") {
+		t.Fatalf("models must render in spec order:\n%s", md)
+	}
+	// Ungraded model renders rubric cells as em-dashes, not zeros.
+	qwenRow := ""
+	for _, line := range strings.Split(md, "\n") {
+		if strings.HasPrefix(line, "| local-qwen |") {
+			qwenRow = line
+			break
+		}
+	}
+	if !strings.Contains(qwenRow, "—") {
+		t.Fatalf("ungraded rubric cells should be —: %q", qwenRow)
+	}
+}
+
+func TestComparisonMarkdownOmitsCostColumnWithoutPrices(t *testing.T) {
+	rep := comparisonFixture()
+	rep.Models[0].CostUSD = nil
+	md := rep.Markdown()
+	if strings.Contains(md, "est. cost") {
+		t.Fatalf("cost column must be omitted when no entry has prices:\n%s", md)
+	}
+}
+
+func TestComparisonJSONRoundTrip(t *testing.T) {
+	rep := comparisonFixture()
+	b, err := rep.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	got, err := ParseComparisonReport(b)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got.At != rep.At || got.N != 3 || got.Judge != "anthropic/claude-judge" || len(got.Models) != 2 {
+		t.Fatalf("round trip header: %+v", got)
+	}
+	if got.Models[0].CostUSD == nil || *got.Models[0].CostUSD != 0.9 {
+		t.Fatalf("cost lost in round trip: %+v", got.Models[0])
+	}
+	if got.Models[1].CostUSD != nil {
+		t.Fatalf("absent cost must stay absent: %+v", got.Models[1])
+	}
+	if got.Models[0].RubricMedian["evidence"] != 2.5 {
+		t.Fatalf("rubric lost in round trip: %+v", got.Models[0].RubricMedian)
+	}
+}

--- a/internal/eval/record.go
+++ b/internal/eval/record.go
@@ -21,6 +21,7 @@ func RecordedCase(scn Scenario, calls []Call) Case {
 		}
 		tools[c.Name] = c.Output
 	}
+	gt := scn.GroundTruth
 	return Case{
 		Name:   scn.ID,
 		Prompt: scn.Trigger.Symptom,
@@ -29,6 +30,9 @@ func RecordedCase(scn Scenario, calls []Call) Case {
 			MustContain:   nil, // authored later when promoting a fixture into the regression set
 			MinConfidence: 0,
 		},
+		// Carry the scenario's ground truth so the recorded fixture supports the
+		// model-comparison benchmark's coverage + rubric scoring without re-authoring.
+		GroundTruth: &gt,
 	}
 }
 

--- a/internal/eval/record_test.go
+++ b/internal/eval/record_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestRecordedCase(t *testing.T) {
 	scn := Scenario{ID: "harbor-valkey", Trigger: Trigger{Symptom: "harbor core crashlooping"},
-		GroundTruth: GroundTruth{RootCause: "valkey down"}}
+		GroundTruth: GroundTruth{RootCause: "valkey down", ExpectedSources: []string{"kubernetes"}}}
 	calls := []Call{
 		{Name: "pod_status", Output: "first"},
 		{Name: "pod_status", Output: "second"}, // last wins (v1 single-output replay limit)
@@ -26,6 +26,10 @@ func TestRecordedCase(t *testing.T) {
 	}
 	if _, ok := c.Tools["submit_findings"]; ok {
 		t.Fatal("submit_findings must be excluded")
+	}
+	if c.GroundTruth == nil || c.GroundTruth.RootCause != "valkey down" ||
+		len(c.GroundTruth.ExpectedSources) != 1 || c.GroundTruth.ExpectedSources[0] != "kubernetes" {
+		t.Fatalf("recorded case must carry the scenario ground truth: %+v", c.GroundTruth)
 	}
 }
 


### PR DESCRIPTION
## What

One command to benchmark several model configurations against RunLore's replay eval suite and produce a **publishable comparison** — backing the project's "run it on your models" + honesty positioning.

```bash
lore eval --compare eval/compare.example.yaml --cases examples/eval -n 3
```

Runs every model in the spec against the same replay cases, grades each run with one **fixed, blind** judge, and writes an aggregated report (markdown + JSON) to `eval/reports/<stamp>-compare.{md,json}`. Needs **no `config.model`** — the spec carries its own per-entry models and judge.

## How it fits the existing harness

- **Reuses the single-run replay machinery** per entry: `eval.ComparisonRunner` drives the same static-tool + investigation-loop path as `Runner`, additionally recording tool calls for coverage and grading each run with the fixed judge (`ModelJudge` / forced `submit_grade`, unchanged from #199).
- **Blind grading already anonymizes** which model produced a result, so one judge across all entries keeps scores comparable.
- `eval.CountingModel` wraps each entry's model to sum `providers.Usage` across the loop **and** the judge.
- `Case` gains an optional `ground_truth` (carried by `RecordedCase` from live scenarios), which unlocks coverage + rubric grading for replay fixtures.
- Effort is validated per-provider through a newly exported `config.ValidateEffort` — one source of truth (anthropic `low|medium|high|max`, openai `minimal|low|medium|high`, rejected for gemini).

## Report columns

Summary table (one row per model, **spec order**): `model`, `provider/model` (+`effort=`), `pass rate`, `reached`, per-dimension rubric medians `root_cause` / `evidence` / `solution` / `description` / `calibration` (`—` when ungraded), `coverage`, `confident-wrong`, `in tok`, `out tok`, and `est. cost (USD)` (**only when at least one entry supplies `prices`**). A second table gives per-case k-of-n pass rate with `flaky` flagged. Deterministic ordering; JSON round-trips.

## Offline validation (keyless CI)

`TestRunEvalCompareOffline` (`internal/app/eval_compare_test.go`) drives the whole pipeline — load → per-entry replay → coverage → blind grading → aggregation → report writing — against a local, **keyless** streaming OpenAI-compatible mock endpoint. The mock speaks SSE (required by the streaming client), scripts the replay tool calls (`what_changed` → `query_metrics` → `query_logs` → `submit_findings`) and answers the judge's forced `submit_grade` with a fixed grade + usage block. No API key, no network:

```bash
go test ./internal/app/ -run TestRunEvalCompareOffline
```

## Docs

`docs/benchmarking.md` — how to run it, the column set, and honest-publishing guidance (N runs, judge-model disclosure, replay-vs-live caveat, ITBench <50% context from `docs/prior-art.md`, versioned `eval/reports/` convention). Linked from README + CONTRIBUTING; `eval/compare.example.yaml` is a ready-to-edit spec.

## Quality gate

`go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — all green, gofmt silent, **0 lint issues**. No real (paid) evals were run.