### PR TITLE
feat(investigate): interim progress notifications

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -230,6 +230,23 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	if toolTimeout == 0 {
 		toolTimeout = defaultToolTimeout
 	}
+	// Interim progress notifications (opt-in). Wire the loop's callback to any
+	// notifier that implements the ProgressNotifier capability (Multi type-asserts
+	// per sink); delivery is best-effort — a failing ping is logged and swallowed,
+	// never failing the investigation. Left unset (nil, 0) when disabled ⇒ the loop
+	// emits nothing and makes zero extra model calls.
+	var onProgress func(providers.ProgressUpdate)
+	progressEverySteps := 0
+	if pu := cfg.Investigation.ProgressUpdates; pu.Enabled {
+		progressEverySteps = pu.EverySteps
+		onProgress = func(up providers.ProgressUpdate) {
+			// A progress ping must never fail an investigation: swallow its errors.
+			if err := notifier.DeliverProgress(context.Background(), up); err != nil {
+				log.Warn("progress notification failed", "err", err)
+			}
+		}
+		log.Info("interim progress updates enabled", "every_steps", progressEverySteps)
+	}
 	return &investigate.LoopInvestigator{
 		Model:                     model,
 		VerifyModel:               BuildVerifyModel(cfg),
@@ -245,6 +262,8 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
 		Timeout:                   cfg.Investigation.Timeout.Std(),
 		ToolTimeout:               toolTimeout,
+		OnProgress:                onProgress,
+		ProgressEverySteps:        progressEverySteps,
 		OnComplete: func(found providers.Investigation) {
 			// Record the outcome "open" first: this investigation happened for an
 			// incident, with the answer we used (recall vs fresh). A matching

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -185,6 +185,20 @@ type Investigation struct {
 	// by Kubernetes RBAC. Set this to match the Helm rbac.controllerLogNamespaces
 	// (e.g. [flux-system]); empty means the incident namespace only.
 	PodLogNamespaces []string `yaml:"pod_log_namespaces"`
+
+	// ProgressUpdates opts into interim progress notifications during a long
+	// investigation. Off by default (zero behaviour change, zero extra model calls).
+	ProgressUpdates ProgressUpdates `yaml:"progress_updates"`
+}
+
+// ProgressUpdates configures opt-in interim progress notifications: a long
+// investigation (up to 20 steps) is otherwise silent until the final message.
+// Off by default. When enabled, the loop emits one ping every EverySteps steps
+// to any notifier that supports it (Slack first); a ping is best-effort and never
+// fails the investigation.
+type ProgressUpdates struct {
+	Enabled    bool `yaml:"enabled"`
+	EverySteps int  `yaml:"every_steps"` // emit a ping every N steps; 0 ⇒ default 5 (applyDefaults). Must be > 0 when enabled.
 }
 
 // Coalesce folds correlated incidents into one investigation.
@@ -653,6 +667,12 @@ func (c *Config) Validate() error {
 		if err := validateEffort("model.verify.effort (or inherited model.effort)", prov, eff); err != nil {
 			return err
 		}
+	}
+	// Interim progress updates: a non-positive cadence while enabled is a
+	// misconfiguration (applyDefaults fills an unset 0 with 5, so only an explicit
+	// negative reaches here). Validate fail-loud rather than silently never pinging.
+	if c.Investigation.ProgressUpdates.Enabled && c.Investigation.ProgressUpdates.EverySteps <= 0 {
+		return fmt.Errorf("investigation.progress_updates.every_steps must be > 0 when enabled, got %d", c.Investigation.ProgressUpdates.EverySteps)
 	}
 	// Reject a negative per-tool timeout: time.ParseDuration accepts negative values
 	// which silently disable the feature (fails the > 0 guard in runTool) rather than

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -186,3 +186,45 @@ telemetry:
 		t.Fatal("telemetry.metrics_enabled should be true")
 	}
 }
+
+func TestApplyDefaultsProgressUpdates(t *testing.T) {
+	// Enabled without an explicit cadence ⇒ default 5.
+	var c Config
+	c.Investigation.ProgressUpdates.Enabled = true
+	applyDefaults(&c)
+	if c.Investigation.ProgressUpdates.EverySteps != 5 {
+		t.Fatalf("default every_steps: got %d, want 5", c.Investigation.ProgressUpdates.EverySteps)
+	}
+	// Explicit cadence respected.
+	var c2 Config
+	c2.Investigation.ProgressUpdates.Enabled = true
+	c2.Investigation.ProgressUpdates.EverySteps = 3
+	applyDefaults(&c2)
+	if c2.Investigation.ProgressUpdates.EverySteps != 3 {
+		t.Fatalf("explicit every_steps overwritten: got %d, want 3", c2.Investigation.ProgressUpdates.EverySteps)
+	}
+	// Disabled ⇒ left at 0 (unused).
+	var c3 Config
+	applyDefaults(&c3)
+	if c3.Investigation.ProgressUpdates.EverySteps != 0 {
+		t.Fatalf("disabled every_steps must stay 0, got %d", c3.Investigation.ProgressUpdates.EverySteps)
+	}
+}
+
+func TestValidateProgressUpdatesEverySteps(t *testing.T) {
+	// Enabled with a negative cadence is rejected (applyDefaults fills unset 0 with 5,
+	// so only an explicit negative reaches Validate).
+	var c Config
+	c.Investigation.ProgressUpdates.Enabled = true
+	c.Investigation.ProgressUpdates.EverySteps = -1
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "every_steps") {
+		t.Fatalf("expected every_steps validation error, got %v", err)
+	}
+	// Enabled + positive cadence passes.
+	var ok Config
+	ok.Investigation.ProgressUpdates.Enabled = true
+	ok.Investigation.ProgressUpdates.EverySteps = 5
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("valid progress config rejected: %v", err)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -80,6 +80,12 @@ func applyDefaults(c *Config) {
 	if c.Investigation.ToolTimeout == 0 {
 		c.Investigation.ToolTimeout = Duration(60 * time.Second)
 	}
+	// Interim progress-update default: when enabled without an explicit cadence,
+	// ping every 5 steps — frequent enough to reassure on a long investigation,
+	// sparse enough to avoid chat noise. Left at 0 when disabled (unused).
+	if c.Investigation.ProgressUpdates.Enabled && c.Investigation.ProgressUpdates.EverySteps == 0 {
+		c.Investigation.ProgressUpdates.EverySteps = 5
+	}
 	// Instant-recall trust defaults: when enabled without explicit tuning, keep the
 	// margin and solo gates active. A zero margin_gap/solo_floor would degrade recall
 	// to a bare similarity threshold — the exact brittleness this feature removes.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -119,6 +119,17 @@ type LoopInvestigator struct {
 	// Observability — nil-safe; no-op when telemetry is disabled.
 	Metrics       *telemetry.Metrics
 	ModelProvider string // label for model_requests/model_request_duration metrics (e.g. "anthropic")
+
+	// OnProgress, when set, receives an interim progress snapshot every
+	// ProgressEverySteps steps of a long investigation. It is nil-safe and
+	// default-off (nil ⇒ never called; zero extra model calls). The callback must
+	// never fail the investigation: the app wires it to a best-effort delivery that
+	// logs and swallows its own errors. The interim text passed is already
+	// secret-redacted at this egress boundary.
+	OnProgress func(providers.ProgressUpdate)
+	// ProgressEverySteps is the cadence for OnProgress. <= 0 disables progress
+	// pings even when OnProgress is set.
+	ProgressEverySteps int
 }
 
 // system returns the system prompt, extended with action proposals when the policy is
@@ -424,6 +435,12 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			}
 			messages = append(messages, providers.Message{Role: "tool", ToolCallID: run[i].ID, Content: tr.content})
 		}
+		// Interim progress ping (opt-in, off by default): a lightweight status update
+		// on this turn's boundary so a long investigation isn't silent until the end.
+		// Runs on the loop goroutine after dispatchTools has joined (used is stable),
+		// so it shares no mutable state with the workers. Best-effort — the callback
+		// swallows its own delivery errors and never fails the investigation.
+		li.emitProgress(req, step, maxSteps, used, resp.Text)
 		if terminal >= 0 {
 			inv := final
 			if inv.Title == "" {
@@ -583,6 +600,32 @@ func (li *LoopInvestigator) reviewActions(proposed []providers.Action) []provide
 		li.Log.Info("suggested actions (not executed)", "mode", string(li.Actions.Mode()), "count", len(kept))
 	}
 	return kept
+}
+
+// emitProgress fires the interim progress callback on a step boundary (every
+// ProgressEverySteps steps). It is a no-op when disabled (no callback, or a
+// non-positive cadence) — so the default path costs nothing. step is 0-based; the
+// update reports it 1-based. The used map is copied so the consumer can never race
+// the loop's later writes, and the model-derived interim text is secret-redacted
+// here (the LLM-egress boundary) before it leaves the loop.
+func (li *LoopInvestigator) emitProgress(req Request, step, maxSteps int, used map[string]int, interim string) {
+	if li.OnProgress == nil || li.ProgressEverySteps <= 0 {
+		return
+	}
+	if (step+1)%li.ProgressEverySteps != 0 {
+		return
+	}
+	toolsUsed := make(map[string]int, len(used))
+	for k, v := range used {
+		toolsUsed[k] = v
+	}
+	li.OnProgress(providers.ProgressUpdate{
+		Title:     req.Title,
+		Step:      step + 1,
+		MaxSteps:  maxSteps,
+		ToolsUsed: toolsUsed,
+		Interim:   redact.Secrets(interim),
+	})
 }
 
 func (li *LoopInvestigator) deliver(req Request, inv providers.Investigation) {

--- a/internal/investigate/progress_test.go
+++ b/internal/investigate/progress_test.go
@@ -1,0 +1,101 @@
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// progressScript drives a multi-step investigation: two tool-calling turns then a
+// submit_findings. Interim text on the second turn carries a secret so redaction
+// at the egress boundary can be asserted.
+func progressScript() []providers.CompletionResponse {
+	return []providers.CompletionResponse{
+		{Text: "starting", ToolCalls: []providers.ToolCall{{ID: "1", Name: "what_changed", Args: `{}`}}},
+		{Text: "found token ghp_abcdefghijklmnopqrstuvwx in the logs", ToolCalls: []providers.ToolCall{{ID: "2", Name: "kb_search", Args: `{}`}}},
+		{Text: "one more look", ToolCalls: []providers.ToolCall{{ID: "3", Name: "pod_status", Args: `{}`}}},
+		{ToolCalls: []providers.ToolCall{{ID: "4", Name: submitFindingsName, Args: `{"confidence":0.7,"root_causes":[{"summary":"done"}]}`}}},
+	}
+}
+
+func TestProgressFiresEveryNSteps(t *testing.T) {
+	var got []providers.ProgressUpdate
+	li := &LoopInvestigator{
+		Model:              &scriptModel{responses: progressScript()},
+		Log:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ProgressEverySteps: 2,
+		OnProgress:         func(up providers.ProgressUpdate) { got = append(got, up) },
+		OnComplete:         func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "HarborDown"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	// Cadence 2 over steps 0..3 (1-based 1..4): fires at step 2 and step 4.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 progress pings at cadence 2, got %d: %+v", len(got), got)
+	}
+	first := got[0]
+	if first.Step != 2 || first.MaxSteps != 20 {
+		t.Fatalf("first ping step/max = %d/%d, want 2/20", first.Step, first.MaxSteps)
+	}
+	if first.Title != "HarborDown" {
+		t.Fatalf("ping title = %q, want HarborDown", first.Title)
+	}
+	// Tools requested so far this run are reflected (counts by name).
+	if first.ToolsUsed["what_changed"] != 1 || first.ToolsUsed["kb_search"] != 1 {
+		t.Fatalf("ping tools-used = %+v, want what_changed:1 kb_search:1", first.ToolsUsed)
+	}
+	// The model interim text is secret-redacted before it leaves the loop.
+	if strings.Contains(first.Interim, "ghp_abcdefghijklmnopqrstuvwx") {
+		t.Fatalf("interim text leaked a secret: %q", first.Interim)
+	}
+	if !strings.Contains(first.Interim, "[REDACTED]") {
+		t.Fatalf("interim text was not redacted: %q", first.Interim)
+	}
+}
+
+func TestProgressDisabledByDefault(t *testing.T) {
+	var fired int
+	li := &LoopInvestigator{
+		Model:              &scriptModel{responses: progressScript()},
+		Log:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ProgressEverySteps: 0, // disabled even though OnProgress is set
+		OnProgress:         func(providers.ProgressUpdate) { fired++ },
+		OnComplete:         func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if fired != 0 {
+		t.Fatalf("progress must not fire when cadence <= 0, fired %d times", fired)
+	}
+}
+
+// captured records that the returned callback also copies the tools map (so a
+// consumer can't race/observe later loop mutations of the same map).
+func TestProgressCopiesToolsMap(t *testing.T) {
+	var snapshots []map[string]int
+	li := &LoopInvestigator{
+		Model:              &scriptModel{responses: progressScript()},
+		Log:                slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ProgressEverySteps: 2,
+		OnProgress:         func(up providers.ProgressUpdate) { snapshots = append(snapshots, up.ToolsUsed) },
+		OnComplete:         func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(snapshots) < 2 {
+		t.Fatalf("expected >=2 snapshots, got %d", len(snapshots))
+	}
+	// Mutating an earlier snapshot must not affect a later one — each ping carries
+	// its own copy, not the live loop map aliased across pings.
+	snapshots[0]["injected"] = 99
+	if _, ok := snapshots[1]["injected"]; ok {
+		t.Fatal("progress tools-used map is aliased across pings; it must be copied")
+	}
+}

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -3,6 +3,7 @@ package notify
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -56,4 +57,39 @@ func Format(inv providers.Investigation) string {
 		fmt.Fprintf(&b, "📚 Knowledge base: %s\n", inv.CuratedURL)
 	}
 	return b.String()
+}
+
+// FormatProgress renders an interim progress update as a concise plain-text
+// status line, shared by notifiers (Slack fallback; Matrix/webhook later). The
+// fields are untrusted (title + model interim text), so a mrkdwn-parsing notifier
+// escapes the composed output before sending.
+func FormatProgress(up providers.ProgressUpdate) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Investigating: %s — step %d/%d\n", up.Title, up.Step, up.MaxSteps)
+	if s := progressToolsSummary(up.ToolsUsed); s != "" {
+		fmt.Fprintf(&b, "Tools used: %s\n", s)
+	}
+	if t := strings.TrimSpace(up.Interim); t != "" {
+		fmt.Fprintf(&b, "%s\n", t)
+	}
+	return b.String()
+}
+
+// progressToolsSummary renders the tools-used map as a stable, name-sorted
+// "name×count" list (e.g. "kb_search×1, what_changed×2"). Returns "" for an empty
+// map so callers can omit the line.
+func progressToolsSummary(used map[string]int) string {
+	if len(used) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(used))
+	for n := range used {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(names))
+	for _, n := range names {
+		parts = append(parts, fmt.Sprintf("%s×%d", n, used[n]))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -48,3 +48,29 @@ func TestFormatResourceAndChange(t *testing.T) {
 		t.Fatalf("empty resource/change must not render labels:\n%s", empty)
 	}
 }
+
+// TestFormatProgress covers the shared interim status line: title, step counter,
+// name-sorted tools-used summary, and interim text. Empty fields are omitted.
+func TestFormatProgress(t *testing.T) {
+	out := FormatProgress(providers.ProgressUpdate{
+		Title:     "HarborDown",
+		Step:      5,
+		MaxSteps:  20,
+		ToolsUsed: map[string]int{"what_changed": 2, "kb_search": 1},
+		Interim:   "narrowed to harbor-db",
+	})
+	for _, want := range []string{"HarborDown", "step 5/20", "kb_search×1", "what_changed×2", "narrowed to harbor-db"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("progress line missing %q:\n%s", want, out)
+		}
+	}
+	// Sorted order: kb_search before what_changed.
+	if strings.Index(out, "kb_search") > strings.Index(out, "what_changed") {
+		t.Fatalf("tools-used not name-sorted:\n%s", out)
+	}
+	// No tools + no interim ⇒ just the header line, no "Tools used:" label.
+	bare := FormatProgress(providers.ProgressUpdate{Title: "x", Step: 1, MaxSteps: 20})
+	if strings.Contains(bare, "Tools used:") {
+		t.Fatalf("empty tools map must omit the label:\n%s", bare)
+	}
+}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -47,12 +47,26 @@ func NewSlack(webhookURL string) *Slack {
 	return &Slack{webhookURL: webhookURL, http: httpx.SecureClient(15 * time.Second)}
 }
 
-var _ providers.Notifier = (*Slack)(nil)
+var (
+	_ providers.Notifier         = (*Slack)(nil)
+	_ providers.ProgressNotifier = (*Slack)(nil)
+)
 
 // Deliver posts the formatted investigation to the webhook. When an action carries
 // an ApprovalID, it renders interactive Approve/Reject buttons (Block Kit).
 func (s *Slack) Deliver(ctx context.Context, inv providers.Investigation) error {
-	body, err := json.Marshal(slackMessage(inv))
+	return s.post(ctx, slackMessage(inv))
+}
+
+// DeliverProgress posts an interim progress ping to the webhook (ProgressNotifier).
+func (s *Slack) DeliverProgress(ctx context.Context, up providers.ProgressUpdate) error {
+	return s.post(ctx, slackProgressMessage(up))
+}
+
+// post marshals a Slack payload and POSTs it to the incoming webhook, surfacing
+// transport and non-2xx errors. Shared by Deliver and DeliverProgress.
+func (s *Slack) post(ctx context.Context, msg map[string]any) error {
+	body, err := json.Marshal(msg)
 	if err != nil {
 		return err
 	}
@@ -88,12 +102,26 @@ func NewSlackBot(token, channel string) *SlackBot {
 	return &SlackBot{token: token, channel: channel, baseURL: "https://slack.com", http: httpx.SecureClient(15 * time.Second)}
 }
 
-var _ providers.Notifier = (*SlackBot)(nil)
+var (
+	_ providers.Notifier         = (*SlackBot)(nil)
+	_ providers.ProgressNotifier = (*SlackBot)(nil)
+)
 
 // Deliver posts the formatted investigation to the configured channel via
 // chat.postMessage, surfacing both transport and Slack API (ok:false) errors.
 func (s *SlackBot) Deliver(ctx context.Context, inv providers.Investigation) error {
-	msg := slackMessage(inv)
+	return s.post(ctx, slackMessage(inv))
+}
+
+// DeliverProgress posts an interim progress ping to the channel (ProgressNotifier).
+func (s *SlackBot) DeliverProgress(ctx context.Context, up providers.ProgressUpdate) error {
+	return s.post(ctx, slackProgressMessage(up))
+}
+
+// post targets the message at the configured channel and sends it via
+// chat.postMessage, surfacing transport and Slack API (ok:false) errors. Shared
+// by Deliver and DeliverProgress.
+func (s *SlackBot) post(ctx context.Context, msg map[string]any) error {
 	msg["channel"] = s.channel
 	body, err := json.Marshal(msg)
 	if err != nil {
@@ -152,6 +180,38 @@ func slackMessage(inv providers.Investigation) map[string]any {
 	// TestSlackMessageFallbackEscaped guards that invariant. Matrix and the
 	// generic webhook call Format themselves and are unaffected.
 	return map[string]any{"text": escapeMrkdwn(Format(inv)), "blocks": slackBlocks(inv)}
+}
+
+// slackProgressMessage builds the Slack payload for an interim progress ping: a
+// compact header + context line + the model's interim text. The fallback text is
+// the escaped shared FormatProgress output (parsed as mrkdwn by block-less
+// clients); the blocks escape each untrusted field the same way delivery does, so
+// a hostile interim line like <https://evil|x> renders inert, never a live link.
+func slackProgressMessage(up providers.ProgressUpdate) map[string]any {
+	return map[string]any{"text": escapeMrkdwn(FormatProgress(up)), "blocks": slackProgressBlocks(up)}
+}
+
+// slackProgressBlocks renders an interim progress update as Block Kit.
+func slackProgressBlocks(up providers.ProgressUpdate) []map[string]any {
+	title := up.Title
+	if title == "" {
+		title = "Investigation"
+	}
+	// The header is plain_text (Slack renders it literally, no mrkdwn parsing), so
+	// the untrusted title needs no escaping here.
+	status := fmt.Sprintf("⏳ *Investigating* · step %d/%d", up.Step, up.MaxSteps)
+	if s := progressToolsSummary(up.ToolsUsed); s != "" {
+		status += " · " + escapeMrkdwn(s)
+	}
+	blocks := []map[string]any{
+		{"type": "header", "text": map[string]any{"type": "plain_text", "text": truncate("🔍 "+title, 150), "emoji": true}},
+		{"type": "context", "elements": []map[string]any{{"type": "mrkdwn", "text": status}}},
+	}
+	if t := strings.TrimSpace(up.Interim); t != "" {
+		blocks = append(blocks, map[string]any{"type": "section",
+			"text": map[string]any{"type": "mrkdwn", "text": truncate(escapeMrkdwn(t), 2900)}})
+	}
+	return blocks
 }
 
 // mrkdwnEscaper implements Slack's documented mrkdwn escaping: exactly three
@@ -327,7 +387,10 @@ func NewMulti(log *slog.Logger, notifiers ...providers.Notifier) *Multi {
 	return &Multi{notifiers: notifiers, log: log}
 }
 
-var _ providers.Notifier = (*Multi)(nil)
+var (
+	_ providers.Notifier         = (*Multi)(nil)
+	_ providers.ProgressNotifier = (*Multi)(nil)
+)
 
 // Deliver fans out to every notifier (best-effort: one bad sink never blocks the
 // others), logs each failure, and returns the joined errors so the caller can tell
@@ -341,6 +404,24 @@ func (m *Multi) Deliver(ctx context.Context, inv providers.Investigation) error 
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// DeliverProgress fans an interim progress ping out to every wrapped notifier
+// that implements ProgressNotifier (the type-assert capability check), skipping
+// those that don't (Matrix/webhook may no-op for now). It is best-effort by
+// contract: a failing sink is logged and swallowed, never propagated — a progress
+// ping must never fail an investigation. Returns nil always.
+func (m *Multi) DeliverProgress(ctx context.Context, up providers.ProgressUpdate) error {
+	for _, n := range m.notifiers {
+		pn, ok := n.(providers.ProgressNotifier)
+		if !ok {
+			continue
+		}
+		if err := pn.DeliverProgress(ctx, up); err != nil {
+			m.log.Error("progress delivery failed (swallowed)", "err", err)
+		}
+	}
+	return nil
 }
 
 // Len reports how many notifiers are configured.

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -265,4 +266,74 @@ type notifierFunc func(context.Context, providers.Investigation) error
 
 func (f notifierFunc) Deliver(ctx context.Context, inv providers.Investigation) error {
 	return f(ctx, inv)
+}
+
+// TestSlackProgressRenderEscapesInterim proves an interim progress ping renders
+// the untrusted model text inert: a hostile <url|text> line must not become a
+// clickable link in either the blocks or the plain-text fallback.
+func TestSlackProgressRenderEscapesInterim(t *testing.T) {
+	up := providers.ProgressUpdate{
+		Title:     "HarborDown",
+		Step:      5,
+		MaxSteps:  20,
+		ToolsUsed: map[string]int{"what_changed": 2, "kb_search": 1},
+		Interim:   "checking <https://evil.example|click here to remediate>",
+	}
+	msg := slackProgressMessage(up)
+	joined := strings.Join(mrkdwnTexts(msg["blocks"].([]map[string]any)), "\n")
+	text, _ := msg["text"].(string)
+	for _, s := range []string{joined, text} {
+		if strings.Contains(s, "<https://evil.example") {
+			t.Fatalf("hostile interim rendered as a live mrkdwn link:\n%s", s)
+		}
+		if !strings.Contains(s, "&lt;https://evil.example|click here to remediate&gt;") {
+			t.Fatalf("interim text was not escaped:\n%s", s)
+		}
+	}
+	// Status context carries the step counter and the tools-used summary.
+	if !strings.Contains(joined, "step 5/20") {
+		t.Fatalf("progress blocks missing the step counter:\n%s", joined)
+	}
+	if !strings.Contains(joined, "kb_search×1") || !strings.Contains(joined, "what_changed×2") {
+		t.Fatalf("progress blocks missing the tools-used summary:\n%s", joined)
+	}
+}
+
+// captureProgress is a fake ProgressNotifier recording every ping (and optionally
+// failing) — the test double for the capability fan-out.
+type captureProgress struct {
+	got  []providers.ProgressUpdate
+	fail bool
+}
+
+func (c *captureProgress) Deliver(context.Context, providers.Investigation) error { return nil }
+func (c *captureProgress) DeliverProgress(_ context.Context, up providers.ProgressUpdate) error {
+	c.got = append(c.got, up)
+	if c.fail {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+// TestMultiDeliverProgressCapability proves Multi fans a progress ping only to
+// notifiers implementing ProgressNotifier (a plain notifier is skipped), and that
+// a failing progress sink is swallowed — a ping never fails an investigation.
+func TestMultiDeliverProgressCapability(t *testing.T) {
+	plain := notifierFunc(func(context.Context, providers.Investigation) error {
+		t.Fatal("a plain (non-progress) notifier must not receive Deliver on a progress ping")
+		return nil
+	})
+	cap1 := &captureProgress{}
+	cap2 := &captureProgress{fail: true} // failing sink: must be swallowed
+	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), plain, cap1, cap2)
+	up := providers.ProgressUpdate{Title: "x", Step: 5, MaxSteps: 20}
+	if err := m.DeliverProgress(context.Background(), up); err != nil {
+		t.Fatalf("DeliverProgress must swallow sink errors, got %v", err)
+	}
+	if len(cap1.got) != 1 || cap1.got[0].Step != 5 {
+		t.Fatalf("progress-capable notifier got %+v, want one ping at step 5", cap1.got)
+	}
+	if len(cap2.got) != 1 {
+		t.Fatalf("a failing progress sink must still be attempted, got %d", len(cap2.got))
+	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -290,6 +290,31 @@ type Notifier interface {
 	Deliver(ctx context.Context, inv Investigation) error
 }
 
+// ProgressUpdate is a lightweight interim status ping for a still-running
+// investigation. It is NOT an Investigation (there are no findings yet) — it
+// exists so a long (up to 20-step) investigation is not silent until the final
+// message. Interim is model-derived text that may quote tool output; the loop
+// redacts it (redact.Secrets) before it leaves, and notifiers must still escape
+// it as untrusted like any other model text.
+type ProgressUpdate struct {
+	Title     string         // incident title (untrusted alert text)
+	Step      int            // current step (1-based)
+	MaxSteps  int            // step ceiling
+	ToolsUsed map[string]int // investigation tool name → call count so far
+	Interim   string         // model's latest interim assistant text (already secret-redacted), if any
+}
+
+// ProgressNotifier is an OPTIONAL capability a Notifier may implement to receive
+// interim progress pings during a long investigation. It is separate from
+// Notifier so a progress ping (not an Investigation) never widens the Notifier
+// contract: the app type-asserts for it and wires progress delivery only to the
+// notifiers that support it (Slack first; Matrix/webhook may no-op for now).
+// Delivery of a progress ping is best-effort — a failure is logged and swallowed,
+// never failing the investigation.
+type ProgressNotifier interface {
+	DeliverProgress(ctx context.Context, up ProgressUpdate) error
+}
+
 // CurationForge is the forge surface the curator's file-time gate needs: open a
 // drafted PR, list open KB PRs (dedup), and comment to coalesce duplicates.
 type CurationForge interface {


### PR DESCRIPTION
## What

Long investigations (up to 20 steps) were silent until the final delivery. This adds **opt-in interim progress notifications** — a lightweight status ping every N steps — so an on-call sees a long investigation is making progress.

Off by default: zero behaviour change and **zero extra model calls** when disabled.

## How

- **Config** — `investigation.progress_updates: { enabled: bool (default false), every_steps: int (default 5) }`. Strict-decode friendly; `every_steps` defaults to 5 via `applyDefaults` and is validated `> 0` when enabled.
- **Capability interface** (`internal/providers`), separate from `Notifier` so a progress ping never widens the delivery contract:
  ```go
  type ProgressNotifier interface {
      DeliverProgress(ctx context.Context, up ProgressUpdate) error
  }
  ```
  `ProgressUpdate` carries: incident title, step/max, tools-used (name→count from the loop's `used` map), and the model's latest interim assistant text (if any).
- **Loop** — emits a ping every N steps on a turn boundary, *after* `dispatchTools` has joined, so it shares no mutable state with the concurrent tool workers (the parallel-tools guarantees are untouched). The interim text is model-derived and may quote tool output, so it is `redact.Secrets`-scrubbed at the egress boundary before it leaves the loop; the tools-used map is copied per ping.
- **Slack** implements `DeliverProgress` (both webhook + bot), escaping the untrusted interim text with `escapeMrkdwn` like every other field. `Multi` type-asserts each sink and fans a ping only to capable ones, **swallowing failures** — a progress ping never fails an investigation. Matrix/webhook no-op for now.
- **App** wires the loop callback to the notifier only when enabled.

## Tests

- Loop: fires at cadence N, respects disabled (`every_steps <= 0`), redaction applied, tools map copied per ping.
- Slack progress render incl. a hostile interim (`<https://evil|x>` renders inert in both blocks and fallback).
- `Multi.DeliverProgress` fans only to capable sinks and swallows a failing one.
- Config default + validation.

Quality gate (`go build/vet/test ./...`, `gofmt -l .`, `golangci-lint run ./...`) green.