### PR TITLE
feat(model): opt-in Anthropic adaptive thinking with block replay

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -99,6 +99,19 @@ reasoning per request — `anthropic`: `low`·`medium`·`high`·`max` (sent as `
 which is classified permanent (dropped, not retried). `verify.effort` overrides the parent's value,
 inheriting it when empty like the other verify fields.
 
+Optional `thinking` opts into Anthropic **adaptive extended thinking** — set `thinking: adaptive` (the
+only value; sent as `thinking: {type: "adaptive"}`). **Anthropic-only**: it is rejected at startup for
+any other provider, because the client must replay the model's *signed* thinking blocks verbatim across
+the tool loop (a contract only the Anthropic client implements). Empty = omitted (default; today's
+behavior byte-for-byte). `effort` and `thinking` are independent and may both be set — `effort` is soft
+guidance for how much thinking the model does. Because thinking consumes output tokens, give `max_tokens`
+headroom when you enable it (a too-low cap truncates the answer mid-thought). Caveat: on the one
+budget-forced conclusion step (the loop forces `submit_findings` after the token-budget nudge), adaptive
+thinking is incompatible with a forced tool choice, so the client drops the thinking param **and** strips
+the replayed thinking blocks for that single request (invalidating only the message-level prompt cache
+for that step). `verify.thinking` overrides the parent's value, inheriting it when empty like the other
+verify fields — though the verify pass always forces a tool choice, so thinking is dropped there anyway.
+
 ### `forge` — the Git host for curation
 `kb_repo` (`owner/name`), `base_branch` (default `main`), `github_api_url` (default
 `https://api.github.com`), `dup_score` (default **5.0**), `min_confidence` (default **0.75**, the

--- a/internal/app/eval_compare.go
+++ b/internal/app/eval_compare.go
@@ -51,7 +51,7 @@ func RunEvalCompare(cfg *config.Config, comparePath, casesDir, reportDir, stamp 
 			apiKey = os.Getenv(entry.APIKeyEnv)
 		}
 		counting := &eval.CountingModel{
-			Inner: NewModelClient(entry.Provider, entry.BaseURL, entry.Model, apiKey, maxTokens, entry.Effort),
+			Inner: NewModelClient(entry.Provider, entry.BaseURL, entry.Model, apiKey, maxTokens, entry.Effort, ""),
 		}
 		runner := &eval.ComparisonRunner{Model: counting, Judge: judge, Log: log}
 		fmt.Printf("comparing %-20s (%s)\n", entry.Name, providerModel(entry.Provider, entry.Model))
@@ -98,7 +98,7 @@ func buildCompareJudge(cfg *config.Config, specJudge *eval.JudgeSpec, jProvider,
 	}
 	if specJudge != nil {
 		m := NewModelClient(specJudge.Provider, specJudge.BaseURL, specJudge.Model,
-			os.Getenv(specJudge.APIKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens), "")
+			os.Getenv(specJudge.APIKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens), "", "")
 		return eval.ModelJudge{Model: m}, providerModel(specJudge.Provider, specJudge.Model)
 	}
 	if ModelConfigured(cfg) {

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -41,10 +41,12 @@ func verifyMaxTokens(cfg *config.Config) int {
 // is the per-request output-token ceiling passed through to the provider. effort
 // is the opt-in reasoning knob (config-validated per provider; "" = omitted);
 // gemini does not take it — config.Validate rejects effort for that provider.
-func NewModelClient(provider, baseURL, model, apiKey string, maxTokens int, effort string) providers.ModelProvider {
+// thinking is the opt-in adaptive-thinking knob (anthropic-only, config-validated;
+// "" = omitted); only the anthropic client consumes it.
+func NewModelClient(provider, baseURL, model, apiKey string, maxTokens int, effort, thinking string) providers.ModelProvider {
 	switch provider {
 	case "anthropic":
-		return anthropic.New(baseURL, model, apiKey, maxTokens, effort)
+		return anthropic.New(baseURL, model, apiKey, maxTokens, effort, thinking)
 	case "gemini":
 		return gemini.New(baseURL, model, apiKey, maxTokens)
 	default:
@@ -54,10 +56,10 @@ func NewModelClient(provider, baseURL, model, apiKey string, maxTokens int, effo
 
 // BuildModel builds the ModelProvider for the configured provider, applying the
 // effective output-token cap (model.max_tokens, defaulted when unset) and the
-// opt-in effort knob.
+// opt-in effort and thinking knobs.
 func BuildModel(cfg *config.Config, apiKey string) providers.ModelProvider {
 	return NewModelClient(cfg.Model.Provider, cfg.Model.BaseURL, cfg.Model.Model, apiKey,
-		effectiveMaxTokens(cfg.Model.MaxTokens), cfg.Model.Effort)
+		effectiveMaxTokens(cfg.Model.MaxTokens), cfg.Model.Effort, cfg.Model.Thinking)
 }
 
 // BuildVerifyModel builds the optional cheaper model for the adversarial verify
@@ -80,7 +82,7 @@ func BuildVerifyModel(cfg *config.Config) providers.ModelProvider {
 	}
 	return NewModelClient(or(v.Provider, cfg.Model.Provider),
 		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey,
-		verifyMaxTokens(cfg), or(v.Effort, cfg.Model.Effort))
+		verifyMaxTokens(cfg), or(v.Effort, cfg.Model.Effort), or(v.Thinking, cfg.Model.Thinking))
 }
 
 // BuildJudgeModel builds the (stronger) grader model from --judge-* flags, falling
@@ -94,7 +96,7 @@ func BuildJudgeModel(cfg *config.Config, provider, baseURL, model, apiKeyEnv str
 		return BuildModel(cfg, apiKey)
 	}
 	// A judge gets the same effective output cap as the main model (no separate
-	// knob), but NOT the configured effort: model.effort was validated against the
-	// configured provider, and a --judge-* flag set may target a different one.
-	return NewModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens), "")
+	// knob), but NOT the configured effort or thinking: those were validated against
+	// the configured provider, and a --judge-* flag set may target a different one.
+	return NewModelClient(provider, baseURL, model, os.Getenv(apiKeyEnv), effectiveMaxTokens(cfg.Model.MaxTokens), "", "")
 }

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -76,7 +76,7 @@ func TestNewModelClient(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.provider, func(t *testing.T) {
-			client := NewModelClient(tc.provider, "http://endpoint/v1", "test-model", "key", defaultMaxTokens, "")
+			client := NewModelClient(tc.provider, "http://endpoint/v1", "test-model", "key", defaultMaxTokens, "", "")
 			if client == nil {
 				t.Fatalf("NewModelClient(%q) returned nil", tc.provider)
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -284,6 +284,14 @@ type Model struct {
 	// thought signatures — the provider-agnostic history can't carry). Models that
 	// don't support the knob return a 400, which is classified permanent.
 	Effort string `yaml:"effort"`
+	// Thinking opts into adaptive extended thinking, sent as thinking:{type:"adaptive"}.
+	// Only value is "adaptive"; only supported for provider anthropic (the client
+	// replays the signed thinking blocks across the tool loop). Empty = omitted from
+	// requests (today's behavior, byte-for-byte). Validated at startup; any other value
+	// or any non-anthropic provider is a clear config error. Interacts with effort:
+	// both may be set (effort is soft guidance for how much thinking Claude does).
+	// Give max_tokens headroom — thinking consumes output tokens.
+	Thinking string `yaml:"thinking"`
 	// Verify optionally routes the adversarial verify pass to a cheaper/faster model;
 	// unset fields inherit from the parent above (so `verify: {model: <cheap>}` reuses
 	// the same provider/endpoint/key). Absent ⇒ verify runs on the main model.
@@ -315,6 +323,11 @@ type ModelOverride struct {
 	// Effort overrides the parent's effort for the verify pass; empty inherits the
 	// parent's value (same vocabulary and validation as model.effort).
 	Effort string `yaml:"effort"`
+	// Thinking overrides the parent's thinking mode for the verify pass; empty inherits
+	// the parent's value (same vocabulary and validation as model.thinking). Note the
+	// verify pass always forces a tool_choice, so the Anthropic client drops thinking
+	// for that request anyway — this knob only affects any non-forced verify calls.
+	Thinking string `yaml:"thinking"`
 }
 
 // Notify configures where investigation findings are delivered.
@@ -621,6 +634,28 @@ func validateEffort(field, provider, effort string) error {
 	return nil
 }
 
+// validateThinking checks an effective (provider, thinking) pair. Empty thinking is
+// always valid (the knob is opt-in and omitted from requests). Only "adaptive" is a
+// valid mode, and only for provider anthropic — the thinking-block replay contract
+// (signed blocks carried verbatim across the tool loop) is Anthropic-specific, so any
+// other provider is rejected with a clear error rather than silently ignored.
+func validateThinking(field, provider, thinking string) error {
+	if thinking == "" {
+		return nil
+	}
+	if provider != "anthropic" {
+		p := provider
+		if p == "" {
+			p = "openai"
+		}
+		return fmt.Errorf("%s: thinking is only supported for provider anthropic (got %q)", field, p)
+	}
+	if thinking != "adaptive" {
+		return fmt.Errorf("%s: %q is not a valid thinking mode (valid: adaptive, or empty to omit)", field, thinking)
+	}
+	return nil
+}
+
 // Validate enforces cross-field invariants after loading — fail-closed defaults
 // for the autonomy ladder: enabling execution requires the controls that bound
 // it. Returns an error that should abort startup.
@@ -641,6 +676,11 @@ func (c *Config) Validate() error {
 	if err := validateEffort("model.effort", c.Model.Provider, c.Model.Effort); err != nil {
 		return err
 	}
+	// Thinking is validated against the provider it will actually be sent to, mirroring
+	// effort (and BuildVerifyModel's or() inherit-when-empty semantics).
+	if err := validateThinking("model.thinking", c.Model.Provider, c.Model.Thinking); err != nil {
+		return err
+	}
 	if v := c.Model.Verify; v != nil {
 		prov := v.Provider
 		if prov == "" {
@@ -651,6 +691,13 @@ func (c *Config) Validate() error {
 			eff = c.Model.Effort
 		}
 		if err := validateEffort("model.verify.effort (or inherited model.effort)", prov, eff); err != nil {
+			return err
+		}
+		think := v.Thinking
+		if think == "" {
+			think = c.Model.Thinking
+		}
+		if err := validateThinking("model.verify.thinking (or inherited model.thinking)", prov, think); err != nil {
 			return err
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,6 +214,52 @@ func TestValidateRejectsNegativeMaxTokens(t *testing.T) {
 // (effort is opt-in — unset keeps today's requests unchanged). The verify
 // override validates against its EFFECTIVE provider and effort (inherit-when-
 // empty, mirroring BuildVerifyModel).
+func TestValidateThinking(t *testing.T) {
+	cases := []struct {
+		name    string
+		model   Model
+		wantErr string // "" = must validate clean; otherwise a substring of the error
+	}{
+		{"empty thinking is fine", Model{Provider: "anthropic"}, ""},
+		{"anthropic adaptive", Model{Provider: "anthropic", Thinking: "adaptive"}, ""},
+		{"anthropic rejects enabled", Model{Provider: "anthropic", Thinking: "enabled"}, "not a valid thinking mode"},
+		{"anthropic rejects on", Model{Provider: "anthropic", Thinking: "on"}, "model.thinking"},
+		{"openai rejects thinking", Model{Provider: "openai", Thinking: "adaptive"}, "only supported for provider anthropic"},
+		{"empty provider rejects thinking", Model{Thinking: "adaptive"}, "only supported for provider anthropic"},
+		{"gemini rejects thinking", Model{Provider: "gemini", Thinking: "adaptive"}, "only supported for provider anthropic"},
+		{
+			"verify override inherits the parent thinking and provider",
+			Model{Provider: "anthropic", Thinking: "adaptive", Verify: &ModelOverride{Model: "cheap"}},
+			"",
+		},
+		{
+			"verify override thinking validated",
+			Model{Provider: "anthropic", Verify: &ModelOverride{Thinking: "enabled"}},
+			"model.verify.thinking",
+		},
+		{
+			"inherited parent thinking invalid for the override provider",
+			Model{Provider: "anthropic", Thinking: "adaptive", Verify: &ModelOverride{Provider: "openai"}},
+			"model.verify.thinking",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{Model: tc.model}
+			err := c.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() = %v, want an error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 func TestValidateEffort(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -386,7 +386,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			continue
 		}
 		nudged = false
-		messages = append(messages, providers.Message{Role: "assistant", Content: resp.Text, ToolCalls: resp.ToolCalls})
+		// Carry resp.Opaque onto the stored assistant turn: for the Anthropic client it
+		// holds the signed adaptive-thinking blocks that must be replayed verbatim on the
+		// next request of this tool-use conversation. Empty for providers that don't use
+		// it. Compaction protects assistant turns, so this survives history compaction.
+		messages = append(messages, providers.Message{Role: "assistant", Content: resp.Text, ToolCalls: resp.ToolCalls, Opaque: resp.Opaque})
 		// Turn rule for submit_findings (unchanged from the sequential loop, locked by
 		// TestSubmitFindingsMixedTurn / TestMalformedSubmitFindingsAmongCalls): a
 		// turn's calls are honoured in their ORIGINAL order, and the FIRST

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -2,6 +2,7 @@ package investigate
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -252,6 +253,52 @@ func (m *scriptModel) Complete(_ context.Context, req providers.CompletionReques
 	r := m.responses[m.i]
 	m.i++
 	return r, nil
+}
+
+// echoTool is a trivial tool that echoes a fixed reply, used to advance a multi-turn
+// loop (the first assistant turn calls it, the second concludes).
+type echoTool struct{ name string }
+
+func (e echoTool) Name() string                                 { return e.name }
+func (e echoTool) Description() string                          { return "echo fake tool" }
+func (e echoTool) Schema() string                               { return `{"type":"object"}` }
+func (e echoTool) Call(context.Context, string) (string, error) { return "ok", nil }
+
+// TestLoopCarriesOpaqueToHistory proves resp.Opaque flows response → assistant
+// history turn → the NEXT request unchanged: the first completion returns tool calls
+// plus an Opaque payload (e.g. signed thinking blocks); the loop must store it on the
+// assistant turn so the model's second request replays it verbatim.
+func TestLoopCarriesOpaqueToHistory(t *testing.T) {
+	opaque := json.RawMessage(`[{"type":"thinking","thinking":"reason","signature":"sig-1"}]`)
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		// Turn 1: a normal tool call, carrying provider-opaque replay content.
+		{ToolCalls: []providers.ToolCall{{ID: "c1", Name: "what_changed", Args: "{}"}}, Opaque: opaque},
+		// Turn 2: conclude.
+		{ToolCalls: []providers.ToolCall{{ID: "c2", Name: submitFindingsName, Args: `{"confidence":0.9,"root_causes":[{"summary":"x"}]}`}}},
+	}}
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{echoTool{name: "what_changed"}},
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "t"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if len(model.reqs) != 2 {
+		t.Fatalf("want 2 model requests, got %d", len(model.reqs))
+	}
+	// The second request's history must contain the assistant turn from turn 1 with the
+	// Opaque payload carried through unchanged.
+	var found bool
+	for _, m := range model.reqs[1].Messages {
+		if m.Role == "assistant" && string(m.Opaque) == string(opaque) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("assistant turn in the next request must carry resp.Opaque verbatim; messages=%+v", model.reqs[1].Messages)
+	}
 }
 
 // blockingModel blocks every Complete on ctx, returning ctx.Err() when the

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -25,18 +25,21 @@ const apiVersion = "2023-06-01"
 // Client is an Anthropic Messages API model provider.
 type Client struct {
 	clientcore.Base
-	effort string
+	effort   string
+	thinking string
 }
 
 // New builds a client. baseURL may be empty (defaults to DefaultBaseURL).
 // maxTokens caps output tokens per request; <= 0 falls back to
 // clientcore.DefaultMaxTokens. effort opts into deeper reasoning
 // (output_config.effort: low|medium|high|max, validated in config); empty
-// omits the field entirely.
-func New(baseURL, model, apiKey string, maxTokens int, effort string) *Client {
+// omits the field entirely. thinking opts into adaptive extended thinking
+// ("adaptive", validated in config); empty keeps today's byte-for-byte behaviour.
+func New(baseURL, model, apiKey string, maxTokens int, effort, thinking string) *Client {
 	return &Client{
-		Base:   clientcore.NewBase(baseURL, DefaultBaseURL, model, apiKey, maxTokens),
-		effort: effort,
+		Base:     clientcore.NewBase(baseURL, DefaultBaseURL, model, apiKey, maxTokens),
+		effort:   effort,
+		thinking: thinking,
 	}
 }
 
@@ -61,24 +64,36 @@ type systemBlock struct {
 }
 
 type msgRequest struct {
-	Model        string        `json:"model"`
-	MaxTokens    int           `json:"max_tokens"`
-	Stream       bool          `json:"stream"`
-	System       []systemBlock `json:"system,omitempty"`
-	Messages     []message     `json:"messages"`
-	Tools        []tool        `json:"tools,omitempty"`
-	ToolChoice   *toolChoice   `json:"tool_choice,omitempty"`
-	OutputConfig *outputConfig `json:"output_config,omitempty"`
+	Model        string          `json:"model"`
+	MaxTokens    int             `json:"max_tokens"`
+	Stream       bool            `json:"stream"`
+	System       []systemBlock   `json:"system,omitempty"`
+	Messages     []message       `json:"messages"`
+	Tools        []tool          `json:"tools,omitempty"`
+	ToolChoice   *toolChoice     `json:"tool_choice,omitempty"`
+	OutputConfig *outputConfig   `json:"output_config,omitempty"`
+	Thinking     *thinkingConfig `json:"thinking,omitempty"`
 }
 
 // outputConfig carries Anthropic's output-level controls; RunLore only sets the
-// effort level. The thinking param is deliberately NOT enabled alongside it:
-// adaptive thinking in a multi-turn tool loop requires replaying signed thinking
-// blocks verbatim on every subsequent request, which the provider-agnostic message
-// history (providers.Message) cannot carry — explicitly out of scope here. effort
-// is constant per client, so the prompt-cache prefix stays stable across steps.
+// effort level. effort is constant per client, so the prompt-cache prefix stays
+// stable across steps. effort and thinking are independent controls and may be sent
+// together (effort is soft guidance for how much adaptive thinking Claude does).
 type outputConfig struct {
 	Effort string `json:"effort"`
+}
+
+// thinkingConfig opts into adaptive extended thinking ({"type":"adaptive"}). In this
+// mode Claude decides when and how much to think, and interleaved thinking is enabled
+// automatically. Adaptive thinking is signed: in a multi-turn tool-use conversation
+// the assistant turn's thinking/redacted_thinking blocks MUST be replayed verbatim
+// (with their signature) on later requests — the client carries them across the
+// provider-agnostic history via providers.Message.Opaque (see accumulate/toMessages).
+//
+// budget_tokens is deliberately never sent: it is rejected (400) on Claude 4.6+ and
+// deprecated elsewhere — adaptive is the only supported on-mode for the target models.
+type thinkingConfig struct {
+	Type string `json:"type"` // "adaptive"
 }
 
 // toolChoice forces the model to call one named tool this turn
@@ -96,6 +111,14 @@ type message struct {
 }
 
 type block struct {
+	// raw, when non-nil, is the verbatim JSON for this block and the struct fields are
+	// ignored (see MarshalJSON). Used to replay a thinking/redacted_thinking block
+	// byte-for-byte with its signature: struct-tag omitempty would drop a thinking
+	// field that is empty under display:"omitted", and the API rejects a modified
+	// block. raw is never decoded from a request — it exists only to re-emit captured
+	// thinking blocks on replay.
+	raw json.RawMessage
+
 	Type string `json:"type"`
 	// text
 	Text string `json:"text,omitempty"`
@@ -108,6 +131,17 @@ type block struct {
 	Content   string `json:"content,omitempty"`
 	// cache breakpoint (set on the last block of the last message — the rolling history breakpoint)
 	CacheControl *cacheControl `json:"cache_control,omitempty"`
+}
+
+// MarshalJSON emits the verbatim raw bytes of a replayed thinking block when set,
+// otherwise the normal struct encoding. The alias sheds block's own MarshalJSON to
+// avoid infinite recursion; the unexported raw field is skipped by encoding/json.
+func (b block) MarshalJSON() ([]byte, error) {
+	if b.raw != nil {
+		return b.raw, nil
+	}
+	type alias block
+	return json.Marshal(alias(b))
 }
 
 type tool struct {
@@ -129,15 +163,18 @@ type streamEvent struct {
 		Usage *usageDelta `json:"usage"`
 	} `json:"message"`
 	ContentBlock *struct {
-		Type string `json:"type"` // "text" | "tool_use"
+		Type string `json:"type"` // "text" | "tool_use" | "thinking" | "redacted_thinking"
 		ID   string `json:"id"`
 		Name string `json:"name"`
+		Data string `json:"data"` // redacted_thinking: the full opaque payload (no deltas follow)
 	} `json:"content_block"`
 	Delta *struct {
-		Type        string `json:"type"` // "text_delta" | "input_json_delta"
+		Type        string `json:"type"` // "text_delta" | "input_json_delta" | "thinking_delta" | "signature_delta"
 		Text        string `json:"text"`
 		PartialJSON string `json:"partial_json"`
 		StopReason  string `json:"stop_reason"`
+		Thinking    string `json:"thinking"`  // thinking_delta: reasoning text (empty under display:"omitted")
+		Signature   string `json:"signature"` // signature_delta: the block's encrypted signature
 	} `json:"delta"`
 	Usage *usageDelta `json:"usage"`
 	Error *struct {
@@ -160,7 +197,16 @@ type usageDelta struct {
 // truncating a long completion and lets a per-block input_json_delta reassemble tool
 // arguments incrementally.
 func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
-	msgs := toMessages(req.Messages)
+	// Adaptive thinking is incompatible with a forced tool_choice (tool|any): the API
+	// rejects that combination (400). The forced ToolChoice happens only on the
+	// budget-forced conclusion step (submit_findings). Deterministic rule: when both
+	// are requested, drop the thinking param for THIS request AND strip the replayed
+	// thinking blocks from history (with thinking off, the API rejects thinking blocks
+	// in the assistant turns) — see toMessages(includeThinking=false). Tradeoff:
+	// switching adaptive→off invalidates the messages prompt-cache tier for this one
+	// request (tools+system stay cached); acceptable, as it fires once, terminally.
+	thinkingOn := c.thinking != "" && req.ToolChoice == ""
+	msgs := toMessages(req.Messages, thinkingOn)
 	// Rolling cache breakpoint: mark the last content block of the last message, so the
 	// growing conversation prefix is a cache READ on the next step. The loop only ever
 	// APPENDS to history, so the prefix is byte-identical step to step — a guaranteed
@@ -177,6 +223,9 @@ func (c *Client) Complete(ctx context.Context, req providers.CompletionRequest) 
 	}
 	if c.effort != "" {
 		areq.OutputConfig = &outputConfig{Effort: c.effort}
+	}
+	if thinkingOn {
+		areq.Thinking = &thinkingConfig{Type: c.thinking}
 	}
 	if req.System != "" {
 		areq.System = []systemBlock{{Type: "text", Text: req.System, CacheControl: ephemeral}}
@@ -235,6 +284,13 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 	toolArgs := map[int]*strings.Builder{} // content-block index → reassembled JSON
 	toolMeta := map[int]*providers.ToolCall{}
 	var order []int // tool block indices, in first-seen order
+	// Thinking capture (adaptive thinking): a thinking block's text arrives via
+	// thinking_delta and its signature via signature_delta, both keyed by content-block
+	// index; a redacted_thinking block carries its full payload on content_block_start.
+	// Thinking text is kept OUT of out.Text and folded into out.Opaque instead.
+	thinkText := map[int]*strings.Builder{}
+	thinkMeta := map[int]*thinkBlock{}
+	var thinkOrder []int // thinking block indices, in first-seen order
 	sawStop := false
 
 	for ev, err := range clientcore.SSEEvents[streamEvent](r) {
@@ -255,10 +311,22 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 				out.Usage.CacheWriteTokens = u.CacheCreationInputTokens
 			}
 		case "content_block_start":
-			if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
+			if ev.ContentBlock == nil {
+				continue
+			}
+			switch ev.ContentBlock.Type {
+			case "tool_use":
 				toolArgs[ev.Index] = &strings.Builder{}
 				toolMeta[ev.Index] = &providers.ToolCall{ID: ev.ContentBlock.ID, Name: ev.ContentBlock.Name}
 				order = append(order, ev.Index)
+			case "thinking":
+				thinkText[ev.Index] = &strings.Builder{}
+				thinkMeta[ev.Index] = &thinkBlock{Type: "thinking"}
+				thinkOrder = append(thinkOrder, ev.Index)
+			case "redacted_thinking":
+				// No deltas follow; the opaque payload is fully present here.
+				thinkMeta[ev.Index] = &thinkBlock{Type: "redacted_thinking", Data: ev.ContentBlock.Data}
+				thinkOrder = append(thinkOrder, ev.Index)
 			}
 		case "content_block_delta":
 			if ev.Delta == nil {
@@ -270,6 +338,14 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 			case "input_json_delta":
 				if b := toolArgs[ev.Index]; b != nil {
 					b.WriteString(ev.Delta.PartialJSON)
+				}
+			case "thinking_delta":
+				if b := thinkText[ev.Index]; b != nil {
+					b.WriteString(ev.Delta.Thinking)
+				}
+			case "signature_delta":
+				if m := thinkMeta[ev.Index]; m != nil {
+					m.Signature += ev.Delta.Signature
 				}
 			}
 		case "message_delta":
@@ -292,19 +368,95 @@ func accumulate(r io.Reader) (providers.CompletionResponse, error) {
 		tc.Args = toolArgs[idx].String()
 		out.ToolCalls = append(out.ToolCalls, tc)
 	}
+	// Serialize completed thinking blocks (in index order, with signatures) into
+	// Opaque so the loop can replay them verbatim on the next request. A "thinking"
+	// block is only completed once its signature has arrived (a mid-thinking truncation
+	// yields no signature); replaying an unsigned block would be rejected, so drop it.
+	// redacted_thinking blocks are always complete at content_block_start.
+	if raw := marshalThinking(thinkOrder, thinkMeta, thinkText); raw != nil {
+		out.Opaque = raw
+	}
 	return out, nil
+}
+
+// thinkBlock is accumulation state for one captured thinking block: its type, the
+// signature reassembled from signature_delta events ("thinking"), and the opaque
+// payload from content_block_start ("redacted_thinking"). The thinking text lives in
+// a separate builder (keyed by index) since it arrives via thinking_delta.
+type thinkBlock struct {
+	Type      string // "thinking" | "redacted_thinking"
+	Signature string // "thinking" only
+	Data      string // "redacted_thinking" only
+}
+
+// marshalThinking renders the captured thinking blocks as a JSON array of block
+// objects, or nil when there are none to replay. Each element is emitted with a
+// fixed field set (thinking + signature for thinking; data for redacted_thinking) so
+// the wire bytes are stable and reproducible for verbatim replay.
+func marshalThinking(order []int, meta map[int]*thinkBlock, text map[int]*strings.Builder) json.RawMessage {
+	var elems []json.RawMessage
+	for _, idx := range order {
+		b := meta[idx]
+		switch b.Type {
+		case "thinking":
+			if b.Signature == "" {
+				continue // incomplete/truncated thinking — cannot be replayed
+			}
+			raw, err := json.Marshal(struct {
+				Type      string `json:"type"`
+				Thinking  string `json:"thinking"`
+				Signature string `json:"signature"`
+			}{"thinking", text[idx].String(), b.Signature})
+			if err != nil {
+				continue
+			}
+			elems = append(elems, raw)
+		case "redacted_thinking":
+			raw, err := json.Marshal(struct {
+				Type string `json:"type"`
+				Data string `json:"data"`
+			}{"redacted_thinking", b.Data})
+			if err != nil {
+				continue
+			}
+			elems = append(elems, raw)
+		}
+	}
+	if len(elems) == 0 {
+		return nil
+	}
+	raw, err := json.Marshal(elems)
+	if err != nil {
+		return nil
+	}
+	return raw
 }
 
 // toMessages maps engine-agnostic messages to Anthropic messages. Consecutive
 // "tool" results are coalesced into a single user message (Anthropic requires all
 // tool_result blocks answering an assistant turn to share one user message).
-func toMessages(in []providers.Message) []message {
+//
+// When includeThinking is true, an assistant turn's replayable thinking blocks
+// (carried verbatim in Message.Opaque, produced by accumulate) are PREPENDED to that
+// turn's content — adaptive thinking requires the signed thinking blocks first, ahead
+// of text and tool_use, and unchanged. When false (thinking disabled for this request,
+// e.g. a forced tool_choice), the thinking blocks are stripped so the history stays
+// valid with thinking off.
+func toMessages(in []providers.Message, includeThinking bool) []message {
 	var out []message
 	for i := 0; i < len(in); i++ {
 		m := in[i]
 		switch m.Role {
 		case "assistant":
 			var blocks []block
+			if includeThinking && len(m.Opaque) > 0 {
+				var thinks []json.RawMessage
+				if err := json.Unmarshal(m.Opaque, &thinks); err == nil {
+					for _, t := range thinks {
+						blocks = append(blocks, block{raw: t})
+					}
+				}
+			}
 			if m.Content != "" {
 				blocks = append(blocks, block{Type: "text", Text: m.Content})
 			}

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -47,7 +47,7 @@ func TestNon2xxErrorOmitsBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -122,7 +122,7 @@ func TestNon2xxPermanence(t *testing.T) {
 				w.WriteHeader(tc.code)
 			}))
 			defer srv.Close()
-			_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+			_, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err == nil {
@@ -194,7 +194,7 @@ data: {"type":"message_stop"}
 	})
 	defer srv.Close()
 
-	c := New(srv.URL, "claude-x", "k", 16384, "")
+	c := New(srv.URL, "claude-x", "k", 16384, "", "")
 	resp, err := c.Complete(context.Background(), providers.CompletionRequest{
 		System:   "sys",
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
@@ -280,7 +280,7 @@ data: {"type":"message_stop"}
 `,
 			})
 			defer srv.Close()
-			resp, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+			resp, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err != nil {
@@ -320,7 +320,7 @@ data: {"type":"message_stop"}
 `,
 	})
 	defer srv.Close()
-	resp, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+	resp, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err != nil {
@@ -359,7 +359,7 @@ data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text
 	}))
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err == nil {
@@ -397,7 +397,7 @@ data: {"type":"message_stop"}
 	})
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{
 			{Role: "user", Content: "investigate"},
 			{Role: "assistant", ToolCalls: []providers.ToolCall{
@@ -439,7 +439,7 @@ func TestPromptCacheHistoryBreakpoint(t *testing.T) {
 	})
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 		System: "sys",
 		Messages: []providers.Message{
 			{Role: "user", Content: "incident"},
@@ -493,7 +493,7 @@ func TestUsageCacheFields(t *testing.T) {
 		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
 	})
 	defer srv.Close()
-	resp, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+	resp, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 	})
 	if err != nil {
@@ -526,7 +526,7 @@ func TestToolChoice(t *testing.T) {
 			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
 			defer srv.Close()
 
-			_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+			_, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 				Messages:   []providers.Message{{Role: "user", Content: "hi"}},
 				Tools:      []providers.ToolSpec{{Name: "submit_verdicts", Description: "d", Schema: `{"type":"object"}`}},
 				ToolChoice: tc.choice,
@@ -581,7 +581,7 @@ func TestEffort(t *testing.T) {
 			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, events)
 			defer srv.Close()
 
-			_, err := New(srv.URL, "claude-x", "k", 0, tc.effort).Complete(context.Background(), providers.CompletionRequest{
+			_, err := New(srv.URL, "claude-x", "k", 0, tc.effort, "").Complete(context.Background(), providers.CompletionRequest{
 				Messages: []providers.Message{{Role: "user", Content: "hi"}},
 			})
 			if err != nil {
@@ -618,6 +618,206 @@ func TestEffort(t *testing.T) {
 	}
 }
 
+// thinkingClose ends a minimal SSE stream (stop_reason + message_stop).
+func thinkingClose(stop string) []string {
+	return []string{
+		"event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"" + stop + "\"},\"usage\":{\"output_tokens\":1}}\n\n",
+		"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+	}
+}
+
+// TestThinkingAccumulate asserts adaptive-thinking capture: thinking_delta +
+// signature_delta reassemble into an Opaque thinking block (in index order, with a
+// redacted_thinking block preserved verbatim), the thinking TEXT never leaks into
+// CompletionResponse.Text, and tool_use/usage handling is undisturbed.
+func TestThinkingAccumulate(t *testing.T) {
+	events := append([]string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n\n",
+		// index 0: a thinking block (text via thinking_delta, signature via signature_delta)
+		"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"I should check \"}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"the logs.\"}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"sig-\"}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"abc123\"}}\n\n",
+		"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+		// index 1: a redacted_thinking block (full payload on start; no deltas)
+		"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"redacted_thinking\",\"data\":\"REDACTED_BLOB\"}}\n\n",
+		"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1}\n\n",
+		// index 2: visible text
+		"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"text_delta\",\"text\":\"Investigating.\"}}\n\n",
+		"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":2}\n\n",
+		// index 3: a tool_use block
+		"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":3,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu1\",\"name\":\"what_changed\"}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":3,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n",
+		"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":3}\n\n",
+	}, thinkingClose("tool_use")...)
+
+	srv := sseServer(t, nil, events)
+	defer srv.Close()
+	resp, err := New(srv.URL, "claude-x", "k", 0, "", "adaptive").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// Thinking text must NOT leak into Text.
+	if resp.Text != "Investigating." {
+		t.Fatalf("Text = %q, want %q (thinking text must not leak)", resp.Text, "Investigating.")
+	}
+	if strings.Contains(resp.Text, "check") {
+		t.Fatalf("thinking text leaked into Text: %q", resp.Text)
+	}
+	// tool_use undisturbed.
+	if len(resp.ToolCalls) != 1 || resp.ToolCalls[0].ID != "tu1" || resp.ToolCalls[0].Args != "{}" {
+		t.Fatalf("tool call: %+v", resp.ToolCalls)
+	}
+	// Opaque: thinking then redacted_thinking, verbatim, in index order.
+	want := `[{"type":"thinking","thinking":"I should check the logs.","signature":"sig-abc123"},{"type":"redacted_thinking","data":"REDACTED_BLOB"}]`
+	if string(resp.Opaque) != want {
+		t.Fatalf("Opaque =\n  %s\nwant\n  %s", resp.Opaque, want)
+	}
+}
+
+// TestThinkingUnsignedDropped asserts a thinking block that never received a
+// signature (e.g. truncated mid-thought) is not carried in Opaque — replaying an
+// unsigned block would be rejected by the API.
+func TestThinkingUnsignedDropped(t *testing.T) {
+	events := append([]string{
+		"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n\n",
+		"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}}\n\n",
+		"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"half a thought\"}}\n\n",
+		"event: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+	}, thinkingClose("max_tokens")...)
+	srv := sseServer(t, nil, events)
+	defer srv.Close()
+	resp, err := New(srv.URL, "claude-x", "k", 0, "", "adaptive").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{{Role: "user", Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if resp.Opaque != nil {
+		t.Fatalf("unsigned thinking block must not be replayed, got Opaque=%s", resp.Opaque)
+	}
+}
+
+// TestThinkingRequestParam asserts a thinking client sends thinking:{type:"adaptive"}
+// and coexists with effort, while an unconfigured client omits the param entirely.
+func TestThinkingRequestParam(t *testing.T) {
+	cases := []struct {
+		name, thinking, effort string
+		wantThinking           bool
+	}{
+		{"adaptive set", "adaptive", "", true},
+		{"adaptive with effort", "adaptive", "high", true},
+		{"empty omits", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body []byte
+			srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, thinkingClose("end_turn"))
+			defer srv.Close()
+			_, err := New(srv.URL, "claude-x", "k", 0, tc.effort, tc.thinking).Complete(context.Background(), providers.CompletionRequest{
+				Messages: []providers.Message{{Role: "user", Content: "hi"}},
+			})
+			if err != nil {
+				t.Fatalf("Complete: %v", err)
+			}
+			var got struct {
+				Thinking *struct {
+					Type string `json:"type"`
+				} `json:"thinking"`
+				OutputConfig *struct {
+					Effort string `json:"effort"`
+				} `json:"output_config"`
+			}
+			if err := json.Unmarshal(body, &got); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if tc.wantThinking {
+				if got.Thinking == nil || got.Thinking.Type != "adaptive" {
+					t.Fatalf(`thinking = %+v, want {"type":"adaptive"}`, got.Thinking)
+				}
+			} else {
+				if got.Thinking != nil {
+					t.Fatalf("thinking must be omitted when unset, got %+v", got.Thinking)
+				}
+				if strings.Contains(string(body), "thinking") {
+					t.Fatalf("body must not carry a thinking key when unset: %s", body)
+				}
+			}
+			// effort and thinking are independent — both present when both set.
+			if tc.effort != "" && (got.OutputConfig == nil || got.OutputConfig.Effort != tc.effort) {
+				t.Fatalf("effort should coexist with thinking: %+v", got.OutputConfig)
+			}
+		})
+	}
+}
+
+// TestThinkingReplay asserts an assistant turn's Opaque thinking blocks are prepended
+// verbatim (byte-for-byte, ahead of text and tool_use) when thinking is enabled.
+func TestThinkingReplay(t *testing.T) {
+	var body []byte
+	srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, thinkingClose("end_turn"))
+	defer srv.Close()
+	opaque := `[{"type":"thinking","thinking":"step 1","signature":"sig-XYZ"}]`
+	_, err := New(srv.URL, "claude-x", "k", 0, "", "adaptive").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{
+			{Role: "user", Content: "incident"},
+			{Role: "assistant", Content: "let me look", ToolCalls: []providers.ToolCall{{ID: "t1", Name: "a", Args: "{}"}}, Opaque: json.RawMessage(opaque)},
+			{Role: "tool", ToolCallID: "t1", Content: "result"},
+		},
+		Tools: []providers.ToolSpec{{Name: "a", Description: "d", Schema: `{"type":"object"}`}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	blk := `{"type":"thinking","thinking":"step 1","signature":"sig-XYZ"}`
+	if !strings.Contains(string(body), blk) {
+		t.Fatalf("replayed thinking block missing/modified; body=%s", body)
+	}
+	// The thinking block must precede the assistant's text and tool_use blocks.
+	tIdx := strings.Index(string(body), blk)
+	if txt := strings.Index(string(body), `"let me look"`); txt < 0 || tIdx > txt {
+		t.Fatalf("thinking block must be prepended before text; body=%s", body)
+	}
+	if tu := strings.Index(string(body), `"tool_use"`); tu < 0 || tIdx > tu {
+		t.Fatalf("thinking block must be prepended before tool_use; body=%s", body)
+	}
+}
+
+// TestThinkingToolChoiceStrip asserts the deterministic conflict rule: when a request
+// has BOTH thinking enabled AND a forced ToolChoice, the client drops the thinking
+// param AND strips the replayed Opaque thinking blocks from history for that request
+// (the API rejects thinking blocks when thinking is off).
+func TestThinkingToolChoiceStrip(t *testing.T) {
+	var body []byte
+	srv := sseServer(t, func(r *http.Request) { body, _ = io.ReadAll(r.Body) }, thinkingClose("tool_use"))
+	defer srv.Close()
+	opaque := `[{"type":"thinking","thinking":"step 1","signature":"sig-XYZ"}]`
+	_, err := New(srv.URL, "claude-x", "k", 0, "", "adaptive").Complete(context.Background(), providers.CompletionRequest{
+		Messages: []providers.Message{
+			{Role: "user", Content: "incident"},
+			{Role: "assistant", Content: "look", ToolCalls: []providers.ToolCall{{ID: "t1", Name: "a", Args: "{}"}}, Opaque: json.RawMessage(opaque)},
+			{Role: "tool", ToolCallID: "t1", Content: "result"},
+		},
+		Tools:      []providers.ToolSpec{{Name: "submit_findings", Description: "d", Schema: `{"type":"object"}`}},
+		ToolChoice: "submit_findings",
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// thinking param + replayed blocks dropped for the forced-tool request.
+	if strings.Contains(string(body), `"thinking"`) {
+		t.Fatalf("thinking param + blocks must be stripped under forced tool_choice; body=%s", body)
+	}
+	// forced tool_choice still present.
+	if !strings.Contains(string(body), `"tool_choice"`) || !strings.Contains(string(body), `"submit_findings"`) {
+		t.Fatalf("forced tool_choice should still be sent; body=%s", body)
+	}
+}
+
 // TestPromptCacheToolsOnly verifies that with no system prompt, the tools array
 // still gets exactly one cache breakpoint — on the LAST tool, not every tool.
 func TestPromptCacheToolsOnly(t *testing.T) {
@@ -648,7 +848,7 @@ data: {"type":"message_stop"}
 	})
 	defer srv.Close()
 
-	_, err := New(srv.URL, "claude-x", "k", 0, "").Complete(context.Background(), providers.CompletionRequest{
+	_, err := New(srv.URL, "claude-x", "k", 0, "", "").Complete(context.Background(), providers.CompletionRequest{
 		Messages: []providers.Message{{Role: "user", Content: "hi"}},
 		Tools: []providers.ToolSpec{
 			{Name: "a", Description: "d", Schema: `{"type":"object"}`},

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -12,6 +12,7 @@ package providers
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"time"
 )
@@ -420,6 +421,13 @@ type Message struct {
 	Content    string
 	ToolCalls  []ToolCall // assistant turn requesting tools
 	ToolCallID string     // tool turn: the call this answers
+	// Opaque is provider-specific content the client must replay verbatim; produced
+	// and consumed only by the same provider, empty otherwise. The loop carries it
+	// from a completion's CompletionResponse.Opaque onto the assistant turn it stores
+	// in history, so the same provider can prepend it on the next request. Currently
+	// the Anthropic client uses it to replay signed adaptive-thinking blocks; other
+	// providers ignore it.
+	Opaque json.RawMessage
 }
 
 // ToolSpec describes a tool offered to the model.
@@ -447,6 +455,13 @@ type CompletionResponse struct {
 	// finishReason). It is empty when the provider omits it. Refused() interprets it;
 	// the loop uses Refused() rather than matching strings itself.
 	StopReason string
+	// Opaque is provider-specific content the client must replay verbatim; produced
+	// and consumed only by the same provider, empty otherwise. The loop copies it onto
+	// the assistant Message it appends to history so the same provider can replay it on
+	// the next request. The Anthropic client serializes completed adaptive-thinking
+	// (and redacted_thinking) blocks — in order, with their signatures — into it;
+	// OpenAI/Gemini leave it empty and ignore it.
+	Opaque json.RawMessage
 }
 
 // refusalStopReasons is the set of stop reasons (across providers, lower-cased) that


### PR DESCRIPTION
## Summary

Adds an opt-in `model.thinking: adaptive` knob that enables Anthropic **adaptive extended thinking** for the investigation loop, with correct replay of *signed* thinking blocks across tool-use turns. Default (`""`) is byte-for-byte today's behavior. OpenAI/Gemini are unaffected.

## Design

- **Opaque carriage (provider-agnostic):** new `Opaque json.RawMessage` on `providers.Message` and `providers.CompletionResponse` — "provider-specific content the client must replay verbatim; produced and consumed only by the same provider; empty otherwise." The Anthropic client serializes completed `thinking`/`redacted_thinking` blocks (in order, with signatures) into it and prepends them to the assistant turn on replay. OpenAI/Gemini ignore it.
- **Loop plumbing:** `loop.go` carries `resp.Opaque` onto the appended assistant turn. Compaction only elides tool-result bodies, so it already protects the assistant turns that carry `Opaque`. Verify/kbvalidate/judge single-shot sites need no change.
- **Config:** `model.thinking` (`adaptive` only, provider `anthropic` only — clear startup error otherwise) + `model.verify.thinking` inherit-when-empty via the `or()` pattern.
- **SSE accumulation:** `thinking_delta` text + `signature_delta` fold into `Opaque`; thinking text never leaks into `CompletionResponse.Text`; tool_use/usage/text handling undisturbed.

## Wire behaviors locked in tests

- `thinking:{type:"adaptive"}` sent when configured; omitted entirely when empty. `effort` and `thinking` coexist.
- `Opaque` = `[{"type":"thinking","thinking":<text>,"signature":<sig>},{"type":"redacted_thinking","data":<blob>}]`, in index order, byte-for-byte; `thinking` field always emitted (even empty under `display:"omitted"`).
- Replay prepends the thinking block **verbatim**, ahead of text and tool_use.
- **ToolChoice conflict rule:** when a forced `tool_choice` and thinking are both requested (the one budget-forced `submit_findings` step), the client drops the `thinking` param **and** strips the replayed thinking blocks for that request (forced tool_choice + thinking is a 400). `tool_choice` is still sent.
- Unsigned (truncated) thinking blocks are dropped from `Opaque`.
- Multi-turn loop test: `Opaque` flows response → history → next request unchanged.

## Doc-vs-reality (WebFetch of adaptive-thinking.md / extended-thinking.md)

- Confirmed: enable via `thinking:{type:"adaptive"}`, no `budget_tokens`; forced `tool_choice` (`tool`/`any`) with thinking returns 400.
- Discovery: on Opus 4.8/4.7 `display` defaults to `"omitted"` — thinking blocks stream with an **empty** `thinking` field but a populated `signature`, and must still be replayed verbatim with that signature. The serialization therefore always includes the `thinking` field and keys "completed" off the signature, not the text.

## Quality gate

`go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — all clean; gofmt silent; **0 lint issues** (the emitted warning references a stale file in an unrelated worktree, not this change).