### PR TITLE
feat(investigate): per-investigation token/cost reporting

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -193,6 +193,19 @@ func appendMCPTools(ctx context.Context, cfg *config.Config, log *slog.Logger, t
 	return tools
 }
 
+// toPricing converts the optional config pricing to the loop's Pricing carrier
+// (nil ⇒ nil, i.e. unpriced — token totals are reported without a cost).
+func toPricing(p *config.Pricing) *investigate.Pricing {
+	if p == nil {
+		return nil
+	}
+	return &investigate.Pricing{
+		InputUSDPerMTok:       p.InputUSDPerMTok,
+		OutputUSDPerMTok:      p.OutputUSDPerMTok,
+		CachedInputUSDPerMTok: p.CachedInputUSDPerMTok,
+	}
+}
+
 // defaultToolTimeout bounds a single tool call when investigation.tool_timeout is
 // unset (0). It keeps a hung/slow provider (a stuck git clone, an unresponsive
 // metrics/logs endpoint) from consuming the whole per-investigation budget while
@@ -247,9 +260,19 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		}
 		log.Info("interim progress updates enabled", "every_steps", progressEverySteps)
 	}
+	// Per-investigation cost reporting (optional). The verify override inherits the
+	// main pricing when it sets none (whole-struct or() inherit), so a cheaper verify
+	// model is costed correctly.
+	mainPricing := toPricing(cfg.Model.Pricing)
+	verifyPricing := mainPricing
+	if v := cfg.Model.Verify; v != nil && v.Pricing != nil {
+		verifyPricing = toPricing(v.Pricing)
+	}
 	return &investigate.LoopInvestigator{
 		Model:                     model,
 		VerifyModel:               BuildVerifyModel(cfg),
+		Pricing:                   mainPricing,
+		VerifyPricing:             verifyPricing,
 		Tools:                     tools,
 		Log:                       log,
 		Actions:                   actions,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -305,6 +305,19 @@ type Model struct {
 	// Embeddings optionally configures an OpenAI-compatible /embeddings endpoint used
 	// for hybrid recall (instant_recall.hybrid). Unset ⇒ BM25-only recall.
 	Embeddings *Embeddings `yaml:"embeddings"`
+	// Pricing optionally sets token rates so RunLore can estimate and report a
+	// per-investigation cost. Unset ⇒ token totals are reported without a dollar
+	// figure. Rates are validated non-negative.
+	Pricing *Pricing `yaml:"pricing"`
+}
+
+// Pricing sets model token rates in USD per MILLION tokens, used to estimate a
+// per-investigation cost. All rates are optional and default to 0; a rate must be
+// non-negative.
+type Pricing struct {
+	InputUSDPerMTok       float64 `yaml:"input_usd_per_mtok"`
+	OutputUSDPerMTok      float64 `yaml:"output_usd_per_mtok"`
+	CachedInputUSDPerMTok float64 `yaml:"cached_input_usd_per_mtok"`
 }
 
 // Embeddings configures an OpenAI-compatible /embeddings endpoint (vLLM/Ollama/
@@ -329,6 +342,9 @@ type ModelOverride struct {
 	// Effort overrides the parent's effort for the verify pass; empty inherits the
 	// parent's value (same vocabulary and validation as model.effort).
 	Effort string `yaml:"effort"`
+	// Pricing overrides the parent's token rates for the verify pass (a cheaper
+	// verify model has its own cost); nil inherits model.pricing.
+	Pricing *Pricing `yaml:"pricing"`
 }
 
 // Notify configures where investigation findings are delivered.
@@ -635,6 +651,19 @@ func validateEffort(field, provider, effort string) error {
 	return nil
 }
 
+// validatePricing rejects a negative token rate (which would produce a negative
+// cost). A nil *Pricing (unconfigured) is valid.
+func validatePricing(field string, p *Pricing) error {
+	if p == nil {
+		return nil
+	}
+	if p.InputUSDPerMTok < 0 || p.OutputUSDPerMTok < 0 || p.CachedInputUSDPerMTok < 0 {
+		return fmt.Errorf("%s: rates must be >= 0 (input=%g output=%g cached_input=%g)",
+			field, p.InputUSDPerMTok, p.OutputUSDPerMTok, p.CachedInputUSDPerMTok)
+	}
+	return nil
+}
+
 // Validate enforces cross-field invariants after loading — fail-closed defaults
 // for the autonomy ladder: enabling execution requires the controls that bound
 // it. Returns an error that should abort startup.
@@ -673,6 +702,16 @@ func (c *Config) Validate() error {
 	// negative reaches here). Validate fail-loud rather than silently never pinging.
 	if c.Investigation.ProgressUpdates.Enabled && c.Investigation.ProgressUpdates.EverySteps <= 0 {
 		return fmt.Errorf("investigation.progress_updates.every_steps must be > 0 when enabled, got %d", c.Investigation.ProgressUpdates.EverySteps)
+	}
+	// Pricing rates must be non-negative (a negative rate would report a negative
+	// cost). Cover the main model and the verify override (which carries its own).
+	if err := validatePricing("model.pricing", c.Model.Pricing); err != nil {
+		return err
+	}
+	if v := c.Model.Verify; v != nil {
+		if err := validatePricing("model.verify.pricing", v.Pricing); err != nil {
+			return err
+		}
 	}
 	// Reject a negative per-tool timeout: time.ParseDuration accepts negative values
 	// which silently disable the feature (fails the > 0 guard in runTool) rather than

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -228,3 +228,24 @@ func TestValidateProgressUpdatesEverySteps(t *testing.T) {
 		t.Fatalf("valid progress config rejected: %v", err)
 	}
 }
+
+func TestValidatePricingNonNegative(t *testing.T) {
+	// Negative rate on the main model is rejected.
+	var c Config
+	c.Model.Pricing = &Pricing{InputUSDPerMTok: -1}
+	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "model.pricing") {
+		t.Fatalf("expected model.pricing validation error, got %v", err)
+	}
+	// Negative rate on the verify override is rejected.
+	var c2 Config
+	c2.Model.Verify = &ModelOverride{Pricing: &Pricing{OutputUSDPerMTok: -5}}
+	if err := c2.Validate(); err == nil || !strings.Contains(err.Error(), "model.verify.pricing") {
+		t.Fatalf("expected model.verify.pricing validation error, got %v", err)
+	}
+	// Non-negative rates pass.
+	var ok Config
+	ok.Model.Pricing = &Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15, CachedInputUSDPerMTok: 0.3}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("valid pricing rejected: %v", err)
+	}
+}

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -110,3 +110,21 @@ func TestDraftKBEntrySetsFingerprint(t *testing.T) {
 		t.Fatalf("drafted entry fingerprint = %q, want %q", got, DupFingerprint(inv))
 	}
 }
+
+// TestDraftKBEntryExcludesCost proves the per-investigation cost/usage carrier
+// never leaks into the curated KB body — cost is a delivery-time concern for
+// humans, not durable knowledge.
+func TestDraftKBEntryExcludesCost(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{Summary: "db down", Evidence: []string{"pg_up=0"}}},
+		Usage:      providers.UsageTotals{ModelCalls: 5, InputTokens: 42000, OutputTokens: 900, CostUSD: 0.37, Priced: true},
+	}
+	body := draftKBEntry(inv).Body
+	for _, unwanted := range []string{"model calls", "$0.37", "tokens", "cached"} {
+		if strings.Contains(body, unwanted) {
+			t.Fatalf("KB body must not carry cost/usage text %q:\n%s", unwanted, body)
+		}
+	}
+}

--- a/internal/investigate/cost.go
+++ b/internal/investigate/cost.go
@@ -1,0 +1,81 @@
+package investigate
+
+import (
+	"context"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Pricing is per-model token pricing in USD per MILLION tokens, used to estimate a
+// per-investigation cost. A nil *Pricing means unpriced (cost is not surfaced);
+// the zero value prices everything at $0.
+type Pricing struct {
+	InputUSDPerMTok       float64
+	OutputUSDPerMTok      float64
+	CachedInputUSDPerMTok float64
+}
+
+// cost estimates the USD cost of u under this pricing. Cached input tokens bill at
+// the cached rate and the rest of the input at the standard rate — InputTokens
+// INCLUDES cached (see providers.Usage), so the non-cached remainder is split out.
+func (p *Pricing) cost(u providers.UsageTotals) float64 {
+	if p == nil {
+		return 0
+	}
+	uncachedInput := u.InputTokens - u.CachedInputTokens
+	if uncachedInput < 0 {
+		uncachedInput = 0
+	}
+	return float64(uncachedInput)/1e6*p.InputUSDPerMTok +
+		float64(u.CachedInputTokens)/1e6*p.CachedInputUSDPerMTok +
+		float64(u.OutputTokens)/1e6*p.OutputUSDPerMTok
+}
+
+// addUsage accumulates one completion's provider-reported usage into a running
+// per-investigation total. Zero usage (provider didn't report) still counts as a
+// model call but adds no tokens.
+func addUsage(t *providers.UsageTotals, u providers.Usage) {
+	t.ModelCalls++
+	t.InputTokens += u.InputTokens
+	t.OutputTokens += u.OutputTokens
+	t.CachedInputTokens += u.CachedInputTokens
+}
+
+// aggregateUsage combines the loop's model usage with the verify pass's into one
+// per-investigation total and, when pricing is configured, estimates cost. The
+// loop tokens are priced at the main model's rate and the verify tokens at the
+// verify override's rate (which inherits the main rate when unset) — so a cheaper
+// verify model is costed correctly even though the token totals are reported
+// combined.
+func (li *LoopInvestigator) aggregateUsage(loop, verify providers.UsageTotals) providers.UsageTotals {
+	total := providers.UsageTotals{
+		ModelCalls:        loop.ModelCalls + verify.ModelCalls,
+		InputTokens:       loop.InputTokens + verify.InputTokens,
+		OutputTokens:      loop.OutputTokens + verify.OutputTokens,
+		CachedInputTokens: loop.CachedInputTokens + verify.CachedInputTokens,
+	}
+	if li.Pricing != nil {
+		total.Priced = true
+		verifyPricing := li.Pricing
+		if li.VerifyPricing != nil {
+			verifyPricing = li.VerifyPricing
+		}
+		total.CostUSD = li.Pricing.cost(loop) + verifyPricing.cost(verify)
+	}
+	return total
+}
+
+// recordUsageMetrics emits the per-investigation token totals (and estimated cost
+// when priced) to telemetry. Nil-safe: a no-op when metrics are disabled.
+func (li *LoopInvestigator) recordUsageMetrics(ctx context.Context, u providers.UsageTotals) {
+	if li.Metrics == nil {
+		return
+	}
+	li.Metrics.InvestigationModelCalls.Record(ctx, int64(u.ModelCalls))
+	li.Metrics.InvestigationInputTokens.Record(ctx, int64(u.InputTokens))
+	li.Metrics.InvestigationOutputTokens.Record(ctx, int64(u.OutputTokens))
+	li.Metrics.InvestigationCachedInputTokens.Record(ctx, int64(u.CachedInputTokens))
+	if u.Priced {
+		li.Metrics.InvestigationCostUSD.Record(ctx, u.CostUSD)
+	}
+}

--- a/internal/investigate/cost_test.go
+++ b/internal/investigate/cost_test.go
@@ -1,0 +1,101 @@
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"math"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// TestInvestigationUsageAccumulated proves per-investigation token totals sum
+// across every model call — the loop steps AND the adversarial verify pass — and
+// that a configured pricing yields a cost on the delivered investigation.
+func TestInvestigationUsageAccumulated(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		// step 0: a tool call.
+		{Text: "look", ToolCalls: []providers.ToolCall{{ID: "1", Name: "what_changed", Args: `{}`}},
+			Usage: providers.Usage{InputTokens: 1000, OutputTokens: 100, CachedInputTokens: 200}},
+		// step 1: submit_findings (ends the loop).
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: submitFindingsName, Args: `{"confidence":0.8,"root_causes":[{"summary":"db down","confidence":0.8}]}`}},
+			Usage: providers.Usage{InputTokens: 2000, OutputTokens: 50, CachedInputTokens: 500}},
+		// verify pass: keep the root cause.
+		{ToolCalls: []providers.ToolCall{{ID: "3", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"keep","confidence":0.8}]}`}},
+			Usage: providers.Usage{InputTokens: 300, OutputTokens: 20, CachedInputTokens: 0}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Verify:     true,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:    telemetry.NewMetrics(), // exercise the metric-emission path (no panic)
+		Pricing:    &Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15, CachedInputUSDPerMTok: 0.3},
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "DBDown"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil {
+		t.Fatal("nothing delivered")
+	}
+	u := got.Usage
+	if u.ModelCalls != 3 {
+		t.Fatalf("ModelCalls = %d, want 3 (2 loop + 1 verify)", u.ModelCalls)
+	}
+	if u.InputTokens != 3300 || u.OutputTokens != 170 || u.CachedInputTokens != 700 {
+		t.Fatalf("token totals = in %d / out %d / cached %d, want 3300/170/700",
+			u.InputTokens, u.OutputTokens, u.CachedInputTokens)
+	}
+	if !u.Priced {
+		t.Fatal("Priced must be true when pricing is configured")
+	}
+	// loop: uncached 2300@3 + 700@0.3 + 150@15 = 0.0069+0.00021+0.00225
+	// verify: uncached 300@3 + 20@15 = 0.0009+0.0003
+	want := 0.0069 + 0.00021 + 0.00225 + 0.0009 + 0.0003
+	if math.Abs(u.CostUSD-want) > 1e-9 {
+		t.Fatalf("CostUSD = %.8f, want %.8f", u.CostUSD, want)
+	}
+}
+
+// TestInvestigationUsageUnpriced proves token totals are still reported without
+// pricing, but no cost is claimed.
+func TestInvestigationUsageUnpriced(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName, Args: `{"confidence":0.7,"root_causes":[{"summary":"x"}]}`}},
+			Usage: providers.Usage{InputTokens: 1200, OutputTokens: 80, CachedInputTokens: 100}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "x"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got.Usage.ModelCalls != 1 || got.Usage.InputTokens != 1200 {
+		t.Fatalf("usage not accumulated when unpriced: %+v", got.Usage)
+	}
+	if got.Usage.Priced || got.Usage.CostUSD != 0 {
+		t.Fatalf("no pricing configured must leave Priced=false, cost=0: %+v", got.Usage)
+	}
+}
+
+// TestVerifyPricingInherits proves the verify pass's tokens are priced at the
+// verify override rate, and that a nil VerifyPricing inherits the main rate.
+func TestVerifyPricingInherits(t *testing.T) {
+	loop := providers.UsageTotals{ModelCalls: 1, InputTokens: 1000, OutputTokens: 100}
+	verify := providers.UsageTotals{ModelCalls: 1, InputTokens: 500, OutputTokens: 40}
+	li := &LoopInvestigator{Pricing: &Pricing{InputUSDPerMTok: 10, OutputUSDPerMTok: 30}}
+	// Inherit: verify tokens priced at the main rate.
+	inherited := li.aggregateUsage(loop, verify)
+	li.VerifyPricing = &Pricing{InputUSDPerMTok: 1, OutputUSDPerMTok: 3} // cheaper verify model
+	overridden := li.aggregateUsage(loop, verify)
+	if !(overridden.CostUSD < inherited.CostUSD) {
+		t.Fatalf("a cheaper verify pricing must lower the cost: inherited=%.8f overridden=%.8f",
+			inherited.CostUSD, overridden.CostUSD)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -130,6 +130,13 @@ type LoopInvestigator struct {
 	// ProgressEverySteps is the cadence for OnProgress. <= 0 disables progress
 	// pings even when OnProgress is set.
 	ProgressEverySteps int
+
+	// Pricing (optional) estimates a per-investigation cost from the accumulated
+	// token totals. nil ⇒ token totals are still reported but no cost is shown.
+	// VerifyPricing prices the adversarial verify pass's tokens; nil ⇒ it inherits
+	// Pricing (so a cheaper verify model is costed correctly when configured).
+	Pricing       *Pricing
+	VerifyPricing *Pricing
 }
 
 // system returns the system prompt, extended with action proposals when the policy is
@@ -161,6 +168,14 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	// Record wall-clock duration + a completion-result label at whichever exit we take.
 	start := time.Now()
 	result := "unresolved"
+	// Per-investigation token/cost accounting. loopTotals accumulates the ReAct
+	// loop's model calls; verifyTotals the adversarial verify pass's (main loop or
+	// recall). setUsage stamps the combined, priced totals onto whatever result we
+	// deliver, so cost is surfaced no matter which exit we take.
+	var loopTotals, verifyTotals providers.UsageTotals
+	setUsage := func(inv *providers.Investigation) {
+		inv.Usage = li.aggregateUsage(loopTotals, verifyTotals)
+	}
 	defer func() {
 		if li.Metrics != nil {
 			attrs := metric.WithAttributes(attribute.String("result", result))
@@ -185,7 +200,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			if li.Verify {
 				// Catalog content is untrusted: verify a recalled finding too, so a
 				// crafted high-recall entry can't bypass the adversarial review.
-				rec = li.verifyFindings(ctx, req, rec)
+				rec = li.verifyFindings(ctx, req, rec, &verifyTotals)
 			}
 			// Instrument the recall result by verify outcome.
 			if m := li.Recall.Metrics; m != nil {
@@ -208,6 +223,8 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			}
 			if len(rec.RootCauses) > 0 {
 				result = "recall"
+				setUsage(&rec)
+				li.recordUsageMetrics(ctx, rec.Usage)
 				li.deliver(req, rec)
 				return nil
 			}
@@ -297,7 +314,9 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 					li.Metrics.InvestigationsDropped.Add(ctx, 1)
 				}
 				result = "budget_exceeded"
-				li.deliver(req, budgetKillResult(req))
+				res := budgetKillResult(req)
+				setUsage(&res)
+				li.deliver(req, res)
 				return nil
 			}
 		}
@@ -333,7 +352,9 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 					li.Metrics.InvestigationsDropped.Add(ctx, 1)
 				}
 				result = "timeout"
-				li.deliver(req, timeoutResult(req))
+				res := timeoutResult(req)
+				setUsage(&res)
+				li.deliver(req, res)
 				return nil
 			}
 			result = "error"
@@ -343,6 +364,9 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// true input size for the request we estimated as reqHeuristic. Zero usage
 		// (provider didn't report) is a no-op — the pure heuristic keeps driving the guard.
 		calib.observe(reqHeuristic, resp.Usage)
+		// Accumulate the same reported usage the calibrator just read (no double
+		// count): one model call plus its tokens toward the per-investigation total.
+		addUsage(&loopTotals, resp.Usage)
 		li.Log.Debug("investigation step", "title", req.Title, "step", step, "tool_calls", len(resp.ToolCalls), "text_len", len(resp.Text))
 		// The provider declined the turn (a safety/refusal stop reason): deliver a
 		// first-class unresolved result rather than misreading the empty response as a
@@ -354,7 +378,9 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				li.Metrics.InvestigationsDropped.Add(ctx, 1)
 			}
 			result = "refused"
-			li.deliver(req, refusalResult(req))
+			res := refusalResult(req)
+			setUsage(&res)
+			li.deliver(req, res)
 			return nil
 		}
 		// Truncation: the provider stopped at its output-token ceiling, so this turn is
@@ -458,9 +484,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				li.Metrics.InvestigationTokens.Record(ctx, int64(calib.estimate(sys, messages, specs)))
 			}
 			if li.Verify {
-				inv = li.verifyFindings(ctx, req, inv)
+				inv = li.verifyFindings(ctx, req, inv, &verifyTotals)
 			}
 			inv.Actions = li.reviewActions(inv.Actions)
+			setUsage(&inv)
+			li.recordUsageMetrics(ctx, inv.Usage)
 			result = "resolved"
 			li.deliver(req, inv)
 			return nil

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -59,8 +59,10 @@ func parseVerdicts(args string) ([]verdict, error) {
 // verifyFindings runs one adversarial review pass over the investigation's root
 // causes, rejecting correlation-only/unverified claims and downgrading unproven
 // ones before delivery/curation. Best-effort: on any verifier error the findings
-// pass through unchanged (verification must never lose a real finding).
-func (li *LoopInvestigator) verifyFindings(ctx context.Context, req Request, inv providers.Investigation) providers.Investigation {
+// pass through unchanged (verification must never lose a real finding). The verify
+// completion's token usage is accumulated into totals (when non-nil) so the
+// per-investigation cost includes the verify pass.
+func (li *LoopInvestigator) verifyFindings(ctx context.Context, req Request, inv providers.Investigation, totals *providers.UsageTotals) providers.Investigation {
 	if len(inv.RootCauses) == 0 {
 		return inv
 	}
@@ -82,6 +84,10 @@ func (li *LoopInvestigator) verifyFindings(ctx context.Context, req Request, inv
 	if err != nil {
 		li.Log.Warn("verify pass failed; keeping findings as-is", "title", req.Title, "err", err)
 		return inv
+	}
+	// Count the verify completion toward the per-investigation token/cost total.
+	if totals != nil {
+		addUsage(totals, resp.Usage)
 	}
 	var verds []verdict
 	for _, tc := range resp.ToolCalls {

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -56,7 +56,36 @@ func Format(inv providers.Investigation) string {
 	if inv.CuratedURL != "" {
 		fmt.Fprintf(&b, "📚 Knowledge base: %s\n", inv.CuratedURL)
 	}
+	// Cost footer: a one-line usage summary for humans, appended ONLY to the shared
+	// delivery message — never to the curated KB body (the curator builds its own
+	// body and does not call Format), so cost never pollutes the knowledge base.
+	if foot := usageFooter(inv.Usage); foot != "" {
+		fmt.Fprintf(&b, "%s\n", foot)
+	}
 	return b.String()
+}
+
+// usageFooter renders the per-investigation model usage as one line:
+//
+//	N model calls · X in / Y out tokens (Z% cached)
+//
+// and appends " · ~$C.CC" only when pricing was configured (Usage.Priced).
+// Returns "" when no model call was made (e.g. a pure recall short-circuit), so
+// the footer is simply omitted.
+func usageFooter(u providers.UsageTotals) string {
+	if u.ModelCalls == 0 {
+		return ""
+	}
+	cachedPct := 0
+	if u.InputTokens > 0 {
+		cachedPct = int(float64(u.CachedInputTokens)/float64(u.InputTokens)*100 + 0.5)
+	}
+	s := fmt.Sprintf("%d model calls · %d in / %d out tokens (%d%% cached)",
+		u.ModelCalls, u.InputTokens, u.OutputTokens, cachedPct)
+	if u.Priced {
+		s += fmt.Sprintf(" · ~$%.2f", u.CostUSD)
+	}
+	return s
 }
 
 // FormatProgress renders an interim progress update as a concise plain-text

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -74,3 +74,35 @@ func TestFormatProgress(t *testing.T) {
 		t.Fatalf("empty tools map must omit the label:\n%s", bare)
 	}
 }
+
+// TestFormatUsageFooter covers the one-line cost footer: token summary always,
+// dollar figure only when priced, and omission when no model call was made.
+func TestFormatUsageFooter(t *testing.T) {
+	inv := sampleInvestigation()
+
+	// Priced: token line + dollar figure.
+	inv.Usage = providers.UsageTotals{ModelCalls: 4, InputTokens: 10000, OutputTokens: 500, CachedInputTokens: 2500, CostUSD: 0.14, Priced: true}
+	out := Format(inv)
+	for _, want := range []string{"4 model calls", "10000 in / 500 out tokens", "(25% cached)", "~$0.14"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("priced footer missing %q:\n%s", want, out)
+		}
+	}
+
+	// Unpriced: token line, no dollar figure.
+	inv.Usage = providers.UsageTotals{ModelCalls: 4, InputTokens: 10000, OutputTokens: 500, CachedInputTokens: 2500}
+	out = Format(inv)
+	if !strings.Contains(out, "4 model calls") {
+		t.Fatalf("unpriced footer must still show the token summary:\n%s", out)
+	}
+	if strings.Contains(out, "$") {
+		t.Fatalf("unpriced footer must not show a dollar figure:\n%s", out)
+	}
+
+	// No model calls (pure recall): no footer at all.
+	inv.Usage = providers.UsageTotals{}
+	out = Format(inv)
+	if strings.Contains(out, "model calls") {
+		t.Fatalf("a zero-usage investigation must omit the footer:\n%s", out)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -390,15 +390,30 @@ type Investigation struct {
 	Changes       []Change
 	Unresolved    []string // honest: what the agent could not determine
 	Confidence    float64
-	Recalled      bool     // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
-	Resource      Workload // the workload the investigation identified as affected; defaults to the originating alert workload when none was named (stored on curated entries for structural recall)
-	Actions       []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
-	CuratedURL    string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
-	Fingerprint   string   // originating alert fingerprint; for outcome-ledger attribution
-	Fingerprints  []string // coalesced batch fingerprints; one outcome open is recorded per entry
-	TriggerKey    string   // deterministic incident identity set at trigger time (alerts: host-invariant per-class key from curator.IncidentKey; GitOps: failing resource+condition). curator.DupFingerprint prefers it so reworded re-investigations (#137) AND the same alert on a different pod/node (CORE-681) still dedupe
-	RecalledEntry string   // when Recalled: the catalog entry Path that was matched
-	Verified      bool     // true when the adversarial verify pass ran and a root cause survived it
+	Recalled      bool        // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
+	Resource      Workload    // the workload the investigation identified as affected; defaults to the originating alert workload when none was named (stored on curated entries for structural recall)
+	Actions       []Action    // proposed remediations (autonomy ladder; never executed at rung "suggest")
+	CuratedURL    string      // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
+	Fingerprint   string      // originating alert fingerprint; for outcome-ledger attribution
+	Fingerprints  []string    // coalesced batch fingerprints; one outcome open is recorded per entry
+	TriggerKey    string      // deterministic incident identity set at trigger time (alerts: host-invariant per-class key from curator.IncidentKey; GitOps: failing resource+condition). curator.DupFingerprint prefers it so reworded re-investigations (#137) AND the same alert on a different pod/node (CORE-681) still dedupe
+	RecalledEntry string      // when Recalled: the catalog entry Path that was matched
+	Verified      bool        // true when the adversarial verify pass ran and a root cause survived it
+	Usage         UsageTotals // per-investigation model token/cost accounting (loop + verify); surfaced to humans + metrics, never written to the curated KB body
+}
+
+// UsageTotals aggregates model token usage over a whole investigation: every
+// model call summed — the ReAct loop, the adversarial verify pass, and any recall
+// verification. It is carried on Investigation so notifiers and metrics can
+// surface usage/cost without re-reading provider internals. Zero when no model
+// call reported usage (e.g. a pure recall short-circuit).
+type UsageTotals struct {
+	ModelCalls        int     // number of model completions made
+	InputTokens       int     // total input/prompt tokens, INCLUDING any served from cache (mirrors Usage.InputTokens)
+	OutputTokens      int     // total generated/output tokens
+	CachedInputTokens int     // subset of InputTokens that was a cache read (the saving)
+	CostUSD           float64 // estimated cost; meaningful only when Priced (model.pricing configured)
+	Priced            bool    // pricing was configured, so CostUSD is populated (may legitimately be 0)
 }
 
 // Hypothesis is one ranked root-cause candidate with its evidence.

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -16,27 +16,35 @@ const scope = "github.com/Smana/runlore"
 
 // Metrics is the RunLore instrument set, created once and shared.
 type Metrics struct {
-	AlertsReceived            metric.Int64Counter
-	AlertsCoalesced           metric.Int64Counter
-	AlertsSuppressed          metric.Int64Counter
-	InvestigationsStarted     metric.Int64Counter
-	InvestigationsThrottled   metric.Int64Counter
-	InvestigationsDropped     metric.Int64Counter
-	GitOpsFailuresDebounced   metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
-	ToolOutputTruncatedBytes  metric.Int64Counter
-	HistoryCompactions        metric.Int64Counter // mid-loop history compaction events
-	HistoryElidedBytes        metric.Int64Counter // tool-output bytes elided by compaction
-	RecallHits                metric.Int64Counter // KB cache hits, labelled by verify result
-	RecallTokensSaved         metric.Int64Counter // estimated tokens saved by a recall short-circuit
-	RecallRejections          metric.Int64Counter // recalls rejected before short-circuit (label: reason)
-	CoalesceBatchSize         metric.Int64Histogram
-	InvestigationTokens       metric.Int64Histogram
-	RecallScore               metric.Float64Histogram // BM25 score at the recall decision (tunes min_score)
-	CurationDedupScore        metric.Float64Histogram // catalog top-hit BM25 score at the curation dedup decision
-	OutcomesOpened            metric.Int64Counter     // investigations recorded as open (label: kind)
-	IncidentsResolved         metric.Int64Counter     // resolve events that matched an open investigation
-	RecallOutcome             metric.Int64Counter     // resolved incidents whose open was a recall (label: result)
-	IncidentResolutionSeconds metric.Float64Histogram // open→resolve duration, seconds
+	AlertsReceived           metric.Int64Counter
+	AlertsCoalesced          metric.Int64Counter
+	AlertsSuppressed         metric.Int64Counter
+	InvestigationsStarted    metric.Int64Counter
+	InvestigationsThrottled  metric.Int64Counter
+	InvestigationsDropped    metric.Int64Counter
+	GitOpsFailuresDebounced  metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
+	ToolOutputTruncatedBytes metric.Int64Counter
+	HistoryCompactions       metric.Int64Counter // mid-loop history compaction events
+	HistoryElidedBytes       metric.Int64Counter // tool-output bytes elided by compaction
+	RecallHits               metric.Int64Counter // KB cache hits, labelled by verify result
+	RecallTokensSaved        metric.Int64Counter // estimated tokens saved by a recall short-circuit
+	RecallRejections         metric.Int64Counter // recalls rejected before short-circuit (label: reason)
+	CoalesceBatchSize        metric.Int64Histogram
+	InvestigationTokens      metric.Int64Histogram
+	// Per-investigation model usage totals (loop + verify), recorded once at
+	// delivery — the actual provider-reported spend, distinct from the pre-request
+	// InvestigationTokens estimate.
+	InvestigationModelCalls        metric.Int64Histogram
+	InvestigationInputTokens       metric.Int64Histogram
+	InvestigationOutputTokens      metric.Int64Histogram
+	InvestigationCachedInputTokens metric.Int64Histogram
+	InvestigationCostUSD           metric.Float64Histogram // estimated per-investigation cost, USD (only when model.pricing is configured)
+	RecallScore                    metric.Float64Histogram // BM25 score at the recall decision (tunes min_score)
+	CurationDedupScore             metric.Float64Histogram // catalog top-hit BM25 score at the curation dedup decision
+	OutcomesOpened                 metric.Int64Counter     // investigations recorded as open (label: kind)
+	IncidentsResolved              metric.Int64Counter     // resolve events that matched an open investigation
+	RecallOutcome                  metric.Int64Counter     // resolved incidents whose open was a recall (label: result)
+	IncidentResolutionSeconds      metric.Float64Histogram // open→resolve duration, seconds
 
 	InvestigationDuration   metric.Float64Histogram // wall-clock per investigation (label: result)
 	InvestigationsCompleted metric.Int64Counter     // investigations finished (label: result)
@@ -67,27 +75,33 @@ func NewMetrics() *Metrics {
 		return h
 	}
 	return &Metrics{
-		AlertsReceived:            ctr("alerts_received_total", "incidents passing Decide into the coalescer"),
-		AlertsCoalesced:           ctr("alerts_coalesced_total", "incidents folded into an existing batch"),
-		AlertsSuppressed:          ctr("alerts_suppressed_total", "incidents dropped by cooldown"),
-		InvestigationsStarted:     ctr("investigations_started_total", "investigations actually begun"),
-		InvestigationsThrottled:   ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
-		InvestigationsDropped:     ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
-		GitOpsFailuresDebounced:   ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
-		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
-		HistoryCompactions:        ctr("history_compactions_total", "mid-loop tool-output history compaction events"),
-		HistoryElidedBytes:        ctr("history_elided_bytes_total", "tool-output bytes elided by mid-loop compaction"),
-		RecallHits:                ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
-		RecallTokensSaved:         ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
-		RecallRejections:          ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),
-		CoalesceBatchSize:         hist("coalesce_batch_size", "incidents per flushed batch"),
-		InvestigationTokens:       hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),
-		RecallScore:               histF("recall_score", "BM25 score at the recall decision point"),
-		CurationDedupScore:        histF("curation_dedup_score", "catalog top-hit BM25 score at the curation dedup decision"),
-		OutcomesOpened:            ctr("outcomes_opened_total", "investigations recorded in the outcome ledger (label: kind)"),
-		IncidentsResolved:         ctr("incidents_resolved_total", "resolve events that matched an open investigation"),
-		RecallOutcome:             ctr("recall_outcome_total", "resolved incidents whose answer was a recall (label: result)"),
-		IncidentResolutionSeconds: histF("incident_resolution_seconds", "open→resolve duration in seconds"),
+		AlertsReceived:           ctr("alerts_received_total", "incidents passing Decide into the coalescer"),
+		AlertsCoalesced:          ctr("alerts_coalesced_total", "incidents folded into an existing batch"),
+		AlertsSuppressed:         ctr("alerts_suppressed_total", "incidents dropped by cooldown"),
+		InvestigationsStarted:    ctr("investigations_started_total", "investigations actually begun"),
+		InvestigationsThrottled:  ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
+		InvestigationsDropped:    ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
+		GitOpsFailuresDebounced:  ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
+		ToolOutputTruncatedBytes: ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
+		HistoryCompactions:       ctr("history_compactions_total", "mid-loop tool-output history compaction events"),
+		HistoryElidedBytes:       ctr("history_elided_bytes_total", "tool-output bytes elided by mid-loop compaction"),
+		RecallHits:               ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
+		RecallTokensSaved:        ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
+		RecallRejections:         ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),
+		CoalesceBatchSize:        hist("coalesce_batch_size", "incidents per flushed batch"),
+		InvestigationTokens:      hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),
+
+		InvestigationModelCalls:        hist("investigation_model_calls", "model completions per investigation (loop + verify)"),
+		InvestigationInputTokens:       hist("investigation_input_tokens", "provider-reported input tokens per investigation, including cached (loop + verify)"),
+		InvestigationOutputTokens:      hist("investigation_output_tokens", "provider-reported output tokens per investigation (loop + verify)"),
+		InvestigationCachedInputTokens: hist("investigation_cached_input_tokens", "input tokens served from cache per investigation (loop + verify)"),
+		InvestigationCostUSD:           histF("investigation_cost_usd", "estimated per-investigation cost in USD (only when model.pricing is configured)"),
+		RecallScore:                    histF("recall_score", "BM25 score at the recall decision point"),
+		CurationDedupScore:             histF("curation_dedup_score", "catalog top-hit BM25 score at the curation dedup decision"),
+		OutcomesOpened:                 ctr("outcomes_opened_total", "investigations recorded in the outcome ledger (label: kind)"),
+		IncidentsResolved:              ctr("incidents_resolved_total", "resolve events that matched an open investigation"),
+		RecallOutcome:                  ctr("recall_outcome_total", "resolved incidents whose answer was a recall (label: result)"),
+		IncidentResolutionSeconds:      histF("incident_resolution_seconds", "open→resolve duration in seconds"),
 
 		InvestigationDuration:   histF("investigation_duration_seconds", "wall-clock duration of an investigation (label: result)"),
 		InvestigationsCompleted: ctr("investigations_completed_total", "investigations that finished (label: result)"),

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -48,3 +48,12 @@ func TestModelTokenCountersConstructed(t *testing.T) {
 		t.Fatal("NewMetrics must construct ModelInputTokens and ModelCachedInputTokens")
 	}
 }
+
+func TestNewMetricsInvestigationUsageInstruments(t *testing.T) {
+	m := NewMetrics()
+	if m.InvestigationModelCalls == nil || m.InvestigationInputTokens == nil ||
+		m.InvestigationOutputTokens == nil || m.InvestigationCachedInputTokens == nil ||
+		m.InvestigationCostUSD == nil {
+		t.Fatal("NewMetrics must construct the per-investigation usage/cost instruments")
+	}
+}


### PR DESCRIPTION
> **Stacked on #209** (`feat/investigate-progress-updates`). Review/merge that first; this PR targets its branch and its diff will collapse to just the cost-reporting commit once #209 lands.

## What

Model `Usage` was recorded per step in metrics but never aggregated per investigation nor shown to humans. This aggregates the totals and surfaces them two ways: a delivery footer for on-call, and Prometheus histograms for dashboards.

## How

- **Accumulation (loop)** — sum model calls + input / output / cached-read tokens (`Usage.CachedInputTokens`) across the ReAct loop **and** the adversarial verify pass (including the recall-path verify), reusing the exact same provider-reported `Usage` the token calibrator already reads, so nothing is double-counted. The totals are stamped onto every delivered result — resolved, recall, and the synthetic budget/timeout/refusal drops.
- **Carrier (`providers.go`)** — `Investigation.Usage` of a new doc-commented `UsageTotals` (model calls, input/output/cached tokens, cost, priced flag).
- **Config** — optional `model.pricing: { input_usd_per_mtok, output_usd_per_mtok, cached_input_usd_per_mtok }`, plus the same on the verify override (`model.verify.pricing`) with whole-struct inherit-when-empty via the existing `or()` pattern, so a cheaper verify model is costed at its own rate. Rates validated non-negative.
- **Surface (a) — footer** in the shared `notify/format.go`:
  ```
  3 model calls · 45231 in / 1200 out tokens (32% cached) · ~$0.14
  ```
  The ` · ~$C.CC` is appended **only** when pricing is configured; the footer is omitted entirely for a zero-usage (pure recall) result. The footer lives in the shared delivery message only — the curator builds the KB body itself and never calls `Format`, so **cost never pollutes the curated KB** (guarded by a test).
- **Surface (b) — Prometheus** — per-investigation histograms for model calls, input/output/cached tokens, and estimated cost (USD), following the existing `internal/telemetry` instrument patterns.

## Tests

- Accumulation across loop steps **including** the verify pass; unpriced still reports token totals with no cost; verify pricing lowers cost when cheaper.
- Footer with and without pricing, and omitted at zero usage.
- KB body excludes cost/usage text.
- Pricing non-negative validation (main + verify override).
- New metric instruments constructed.

Quality gate (`go build/vet/test ./...`, `gofmt -l .`, `golangci-lint run ./...`) green.