### PR TITLE
fix(e2e): audit_log_path for approve-mode install (unbreaks e2e rollout)

### DIFF
--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -135,6 +135,7 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set-string config.network.url="$HOST:9998" \
   --set-string config.actions.mode=approve \
   --set-string config.actions.approval_token_env=APPROVAL_TOKEN \
+  --set-string config.actions.audit_log_path=/tmp/runlore-audit.jsonl \
   --set-string config.notify.slack.signing_secret_env=SLACK_SIGNING_SECRET \
   --set rbac.allowActions=true \
   --set networkPolicy.enabled=false \


### PR DESCRIPTION
## Problem

`hack/e2e-k3d.sh` step 5 installs with `config.actions.mode=approve` but never set `config.actions.audit_log_path`. A pre-existing validation — `approve`/`auto` are executing rungs and must be audited (else they'd fall back to a Nop auditor with no hash chain) — rejects that config, so the pod crash-looped at startup and the run never got past `rollout status`. The break was masked until now by the mock-SSE issue (#208) stopping the loop earlier.

## Fix

Set `config.actions.audit_log_path=/tmp/runlore-audit.jsonl` in the step-5 approve-mode install (the auto-mode step already set it via `--reuse-values`).

## Testing

Full `hack/e2e-k3d.sh` on merged main + this fix: **PASS=45 FAIL=0**, all features verified (incident→investigate→deliver→curate→approve/auto actions→kill-switch→learning loop→storm coalesce→GitOps→leader failover→ArgoCD).