### PR TITLE
docs: document model.pricing and investigation.progress_updates

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -72,6 +72,12 @@ config:
     # set, else the main model) and keeps that in place of the markers; any summarizer
     # error/refusal/truncation falls back to plain elision. Needs a token budget above.
     # compaction: elide
+    # Interim progress delivery for long investigations (off by default). When enabled,
+    # deliver a ping (title, step count, tools used, latest interim text — redacted +
+    # escaped) every every_steps steps to notifiers that support it (Slack today).
+    # progress_updates:
+    #   enabled: true
+    #   every_steps: 5           # must be > 0 when enabled
     # App-layer allowlist of namespaces the pod_logs / controller_logs tools may read
     # RAW pod logs from, BEYOND the incident's own namespace (the incident namespace is
     # always allowed at the app layer — RBAC still gates the actual read). Pod logs carry
@@ -121,6 +127,16 @@ config:
   #   # minimal|low|medium|high; unsupported for gemini; empty = omitted (default).
   #   # A model that doesn't support the knob returns a 400, classified permanent.
   #   effort: high
+  #   # Opt into Anthropic adaptive extended thinking (anthropic-only; "adaptive" is the
+  #   # only value; rejected for other providers; empty = off). Give max_tokens headroom.
+  #   thinking: adaptive
+  #   # Per-investigation cost estimate (USD per million tokens; all >= 0). When set, the
+  #   # delivered finding gains a cost footer and the investigation_cost_usd metric is
+  #   # populated. Omit for token counts only. verify.pricing inherits these when unset.
+  #   pricing:
+  #     input_usd_per_mtok: 3.0
+  #     output_usd_per_mtok: 15.0
+  #     cached_input_usd_per_mtok: 0.3
   #   # Route the adversarial verify pass to a cheaper/faster model to cut the
   #   # +1-call-per-investigation cost (inherits the fields above unless overridden;
   #   # omit to verify with the main model). Verify always runs — this only lowers cost.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,12 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   adds no new egress path. Requires `max_tokens_per_investigation > 0` (compaction is off without a
   budget). Metrics: `history_summarizations_total`, `history_summarize_fallbacks_total`; the digest
   call's token usage is counted into `model_input_tokens_total`.
+- `progress_updates` — interim delivery for long investigations. **Off by default.** `enabled`; when
+  enabled the loop delivers a progress ping (incident title, step count, tools used so far, and the
+  model's latest interim text — redacted and mrkdwn-escaped like any other untrusted field) every
+  `every_steps` steps (**default 5**; must be `> 0` when enabled). Pings go only to notifiers that
+  implement the capability (Slack today); a delivery failure is logged and swallowed, never failing the
+  investigation.
 - `pod_log_namespaces` — **app-layer allowlist** of namespaces the `pod_logs` tool
   may read RAW pod logs from, *beyond* the incident's own namespace (which is always allowed; RBAC
   still gates the actual read). Pod logs carry secrets/PII and are streamed to the external LLM, so the
@@ -142,6 +148,14 @@ thinking is incompatible with a forced tool choice, so the client drops the thin
 the replayed thinking blocks for that single request (invalidating only the message-level prompt cache
 for that step). `verify.thinking` overrides the parent's value, inheriting it when empty like the other
 verify fields — though the verify pass always forces a tool choice, so thinking is dropped there anyway.
+
+Optional `pricing` turns the per-investigation token accounting into a cost estimate: `input_usd_per_mtok`,
+`output_usd_per_mtok`, `cached_input_usd_per_mtok` (USD per million tokens; all must be `>= 0`). When set,
+the delivered finding gains a footer line (`N model calls · X in / Y out tokens (Z% cached) · ~$C`) and the
+`investigation_cost_usd` metric is populated; without it, the footer omits the cost and only token counts
+show. Totals sum the investigation loop **and** the verify pass — loop tokens price at `model.pricing`,
+verify tokens at `model.verify.pricing` (inheriting `model.pricing` when empty). Cost never enters the
+curated KB entry, only the notification.
 
 ### `forge` — the Git host for curation
 `kb_repo` (`owner/name`), `base_branch` (default `main`), `github_api_url` (default


### PR DESCRIPTION
Two config knobs shipped in #211 (per-investigation cost reporting) and #209 (interim progress notifications) without docs. This adds them to `docs/configuration.md` and the Helm `values.yaml` template, and fills in the `thinking` knob that was documented in configuration.md but missing from the values template.

Docs-only. `helm lint` + `helm template` clean.