### PR TITLE
fix(release): drop buildx attestations that break local image export

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,11 +88,14 @@ dockers:
       - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
-      # Buildx-native supply-chain attestations attached to the image:
-      #   provenance mode=max -> full SLSA build provenance (steps + materials)
-      #   sbom=true           -> SPDX SBOM attestation generated from the build
-      - "--provenance=mode=max"
-      - "--sbom=true"
+      # NOTE: buildx --provenance / --sbom attestations are intentionally NOT set here.
+      # The classic `dockers` step loads each per-arch image into the local docker image
+      # store (the "docker" exporter), which cannot represent the OCI index that buildx
+      # emits when attestations are attached — the build fails with:
+      #   "docker exporter does not currently support exporting manifest lists".
+      # Restoring image-level SLSA provenance + SBOM needs the push-based `dockers_v2`
+      # flow (tracked as a follow-up). cosign still signs the fused manifest lists
+      # (docker_signs) and syft still generates the per-binary archive SBOMs.
       - "--label=org.opencontainers.image.source=https://github.com/Smana/runlore"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -108,8 +111,8 @@ dockers:
       - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
-      - "--provenance=mode=max"
-      - "--sbom=true"
+      # Attestations omitted for the same reason as the amd64 entry above (classic
+      # dockers + local load cannot export an attestation manifest list).
       - "--label=org.opencontainers.image.source=https://github.com/Smana/runlore"
       - "--label=org.opencontainers.image.version={{ .Version }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"


### PR DESCRIPTION

  The v0.3.0 release failed at the GoReleaser docker build, so no 0.3.0 image
  reached GHCR:

    docker build failed: failed to build ghcr.io/smana/runlore:0.3.0-arm64:
    ERROR: failed to build: docker exporter does not currently support exporting manifest lists

  Root cause: both per-arch `dockers` entries pass --provenance=mode=max and
  --sbom=true. With attestations, buildx emits an OCI index even for a single
  platform, but the classic `dockers` step loads the image into the local docker
  image store, whose exporter can't export a manifest list — so the per-arch
  build fails before docker_manifests runs.

  Fix: drop the two attestation flags from both entries. Per-arch images now
  build/load cleanly; docker_manifests still fuses them and cosign (docker_signs)
  still signs the manifest lists; syft still emits per-binary archive SBOMs.
  Restoring image-level provenance/SBOM needs the push-based dockers_v2 flow
  (follow-up).

  Note: to actually re-release 0.3.0, the v0.3.0 tag must be moved to a commit
  that includes this fix (or cut 0.3.1).