### PR TITLE
feat(incidents): pre-investigation debounce to skip self-resolving alerts

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -39,6 +39,15 @@ config:
         severity: [critical]
       dedup:
         window: 30m
+      # Pre-investigation debounce: hold a firing alert this long, then investigate
+      # only if it is STILL active — i.e. no matching Alertmanager `resolved` webhook
+      # arrived within the window. Skips self-resolving alerts (e.g. a
+      # KubeDaemonSetRolloutStuck during a Karpenter node-churn cycle) that would
+      # otherwise burn a full investigation on noise and are often already resolved by
+      # the time a finding lands. Defaults to 0 (investigate immediately, today's
+      # behavior); opt-in. Composes with coalesce (survivors are batched afterwards)
+      # and dedup (re-fires are still suppressed before the hold begins).
+      debounce: 0s
     # Failure POLICY for the gitops source (enablement lives under sources.gitops).
     gitops_failures:
       # Debounce transient Flux failures: wait this long, then re-read the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,11 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   globs, `alertnames` globs, `labels`); empty fields match anything. `ignore` excludes even if `match`
   passes.
 - `incidents.dedup.window` — don't re-open a still-firing alert within this window.
+- `incidents.debounce` — hold a firing alert this long before investigating, and skip it if a matching
+  Alertmanager `resolved` webhook arrives within the window (self-resolving noise, e.g. a
+  `KubeDaemonSetRolloutStuck` during a Karpenter node-churn cycle). **Default `0`** (investigate
+  immediately — today's behavior); opt-in per deployment. Composes with `coalesce` (survivors are
+  batched afterwards) and `dedup` (re-fires are still suppressed before the hold begins).
 - `gitops_failures.debounce` — require a failure to persist this long before investigating. **Default
   60s**; explicit `0` fires immediately on every `Ready=False`.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -172,6 +172,9 @@ triggers:
     ignore:
       alertnames:  [Watchdog, InfoInhibitor]
     dedup: { window: 30m }              # don't re-open a still-firing alert
+    debounce: 5m                        # hold a firing alert, skip it if a matching
+                                        # resolved webhook lands within the window
+                                        # (default 0 = investigate immediately)
   gitops_failures:                      # secondary trigger (enabled via sources.gitops)
     debounce: 60s                       # require the failure to persist this long
                                         # (re-check still Ready=False) before

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -226,6 +226,8 @@ config:
         # environment: [prod]           # only matches alerts that CARRY an `environment`
                                         # label — omit it if yours don't, or nothing fires
       dedup: { window: 30m }
+      # debounce: 5m           # hold a firing alert this long, then skip it if it
+                               # self-resolved within the window (default 0 = off)
     # gitops_failures:
     #   debounce: 60s          # re-check window before investigating a Flux failure
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -51,6 +51,7 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_alerts_received_total` | counter | — | incidents passing the trigger gate into the coalescer |
 | `runlore_alerts_coalesced_total` | counter | — | incidents folded into an existing batch |
 | `runlore_alerts_suppressed_total` | counter | — | incidents dropped by cooldown |
+| `runlore_incidents_debounced_total` | counter | — | firing alerts dropped as self-resolving (a matching `resolved` webhook arrived within `triggers.incidents.debounce`) |
 | `runlore_investigations_started_total` | counter | — | investigations actually begun |
 | `runlore_investigations_completed_total` | counter | `result` | investigations finished (`resolved`/`unresolved`/`recall`/`error`/`max_steps`/`budget_exceeded`/`inconclusive`) |
 | `runlore_investigation_duration_seconds` | histogram | `result` | wall-clock per investigation |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -58,6 +58,7 @@ msg=incident alert=<name> severity=<sev> namespace=<ns> investigate=<bool> reaso
 | `runlore_investigations_dropped_total` rising | dropped by `rate_limit.max_requeues` or the token-budget hard-stop | see the timeout/budget section below |
 | `runlore_alerts_coalesced_total` rising | folded into an existing batch (`investigation.coalesce`) | expected noise control — one investigation covers the batch |
 | `runlore_alerts_suppressed_total` rising | dropped by the coalescer **cooldown** | expected — a recently-investigated correlation is in cooldown |
+| `runlore_incidents_debounced_total` rising | the alert self-resolved within `triggers.incidents.debounce` and was dropped before investigating; log: `msg="alert resolved within debounce window; dropping self-resolving incident"` | expected noise control — lower `incidents.debounce` if you want faster (but noisier) reactions, or set `0` to disable |
 
 ---
 

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -242,7 +242,11 @@ func RunServe(version string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("build sources: %w", err)
 	}
-	pipe := source.NewPipeline(cfg, alertEnq, resolve, log).WithMetrics(metrics)
+	pipe := source.NewPipeline(cfg, alertEnq, resolve, log).WithMetrics(metrics).WithContext(workCtx)
+	if w := cfg.Triggers.Incidents.Debounce.Std(); w > 0 {
+		log.Info("incident debounce enabled",
+			"window", w, "note", "firing alerts held; dropped if resolved within the window")
+	}
 
 	// startWork runs the leader-only loops (investigation queue + failure watch +
 	// re-investigate poller), scoped to a context cancelled when leadership is lost.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -436,6 +436,17 @@ type IncidentTrigger struct {
 	Match  IncidentMatch `yaml:"match"`  // must match to investigate
 	Ignore IncidentMatch `yaml:"ignore"` // excludes even if Match passes
 	Dedup  Dedup         `yaml:"dedup"`
+	// Debounce is the pre-investigation hold for a firing alert: after admission
+	// (match + dedup) RunLore waits this long and investigates only if the alert
+	// is still active — i.e. no matching Alertmanager `resolved` webhook arrived
+	// within the window. It filters self-resolving alerts (e.g. a
+	// KubeDaemonSetRolloutStuck during a Karpenter node-churn cycle) that would
+	// otherwise burn a full investigation on noise. A zero window (the default)
+	// disables the hold and investigates immediately, preserving today's behavior;
+	// it is opt-in per deployment. It composes with `coalesce` (which batches the
+	// survivors afterwards) and `dedup` (which still suppresses re-fires before the
+	// hold begins).
+	Debounce Duration `yaml:"debounce"`
 }
 
 // IncidentMatch is a set of matchers ANDed together; empty fields match anything.

--- a/internal/source/debounce.go
+++ b/internal/source/debounce.go
@@ -1,0 +1,161 @@
+package source
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// incidentDebouncer delays a firing alert's investigation until the alert has
+// PERSISTED for a short window, then enqueues it only if it is still active —
+// i.e. no matching Alertmanager `resolved` webhook cancelled it within the
+// window. It filters self-resolving alerts (e.g. a KubeDaemonSetRolloutStuck
+// during a Karpenter node-churn cycle) that would otherwise burn a full
+// investigation on noise and are frequently already resolved by the time a
+// finding is delivered.
+//
+// It is event-driven, mirroring the GitOps-failure debouncer's intent but using
+// the resolved webhook RunLore already receives as the "still active?" signal
+// (the cheapest backstop) rather than re-querying alert state. A zero window
+// disables the hold entirely: Hold enqueues immediately, preserving the original
+// investigate-on-admission behavior.
+//
+// In the pipeline the hold sits AFTER match+dedup (so re-fires are already
+// suppressed) and BEFORE the coalescer (so survivors are still storm-batched).
+type incidentDebouncer struct {
+	window  time.Duration
+	log     *slog.Logger
+	metrics *telemetry.Metrics // optional; nil-safe counter for dropped self-resolving alerts
+
+	mu      sync.Mutex
+	pending map[string]chan struct{} // key → cancel channel of an in-flight hold
+
+	wg sync.WaitGroup // tracks in-flight holds so tests can wait on the enqueue decision
+
+	// clock is injectable so tests can release the hold without real sleeps;
+	// defaults to a time.After-backed clock.
+	clock clock
+}
+
+// clock abstracts the debounce wait so tests can release it deterministically.
+type clock interface {
+	After(d time.Duration) <-chan time.Time
+}
+
+type realClock struct{}
+
+func (realClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// newIncidentDebouncer builds an incidentDebouncer. A zero (or negative) window
+// disables debouncing (immediate enqueue).
+func newIncidentDebouncer(window time.Duration, log *slog.Logger) *incidentDebouncer {
+	return &incidentDebouncer{
+		window:  window,
+		log:     log,
+		pending: make(map[string]chan struct{}),
+		clock:   realClock{},
+	}
+}
+
+// withMetrics installs the (nil-safe) metric set. A dropped self-resolving alert
+// increments IncidentsDebounced.
+func (d *incidentDebouncer) withMetrics(m *telemetry.Metrics) *incidentDebouncer {
+	d.metrics = m
+	return d
+}
+
+// Hold decides whether/when to enqueue r. With window 0 it enqueues immediately
+// (today's behavior). Otherwise it returns without blocking; a background goroutine
+// waits the window and enqueues only if the hold was not cancelled by a matching
+// Cancel (resolved webhook) or the context. The hold is keyed by the alert
+// Fingerprint — the only handle a resolved webhook carries; a fingerprint-less alert
+// is held uncancellably (no pending entry, no cancel channel) and simply waits the
+// window out.
+func (d *incidentDebouncer) Hold(ctx context.Context, r investigate.Request, enq investigate.Enqueuer) {
+	if d.window <= 0 {
+		enq.Enqueue(r)
+		return
+	}
+	fp := r.Fingerprint
+	var cancel chan struct{}
+	if fp != "" {
+		cancel = make(chan struct{})
+		d.register(fp, cancel)
+	}
+	d.wg.Add(1)
+	go d.wait(ctx, r, enq, fp, cancel)
+}
+
+// wait blocks for the window then enqueues, unless cancelled (resolved) or the
+// context is done first.
+func (d *incidentDebouncer) wait(ctx context.Context, r investigate.Request, enq investigate.Enqueuer, fp string, cancel chan struct{}) {
+	defer d.wg.Done()
+	// A nil cancel channel (fingerprint-less hold) blocks forever in the select, so such
+	// a hold can only end via the window firing or the context — never a Cancel.
+	select {
+	case <-ctx.Done():
+		d.unregister(fp, cancel)
+		return
+	case <-cancel:
+		// A matching resolved webhook arrived within the window: drop the incident.
+		// unregister was already done by Cancel, which closed this channel.
+		if d.log != nil {
+			d.log.Debug("alert resolved within debounce window; dropping self-resolving incident",
+				"alert", r.Title, "fingerprint", r.Fingerprint, "window", d.window)
+		}
+		if d.metrics != nil {
+			d.metrics.IncidentsDebounced.Add(ctx, 1)
+		}
+		return
+	case <-d.clock.After(d.window):
+		d.unregister(fp, cancel)
+		enq.Enqueue(r)
+	}
+}
+
+// Cancel drops a pending hold whose alert fingerprint matches (called from the
+// resolved-webhook path). It is a no-op for an empty fingerprint or an unknown
+// key. Safe for concurrent use.
+func (d *incidentDebouncer) Cancel(fingerprint string) {
+	// Nothing is ever pending when debounce is off (window 0), so skip the lock on the
+	// default-configuration resolved-webhook path.
+	if d == nil || d.window <= 0 || fingerprint == "" {
+		return
+	}
+	d.mu.Lock()
+	ch, ok := d.pending[fingerprint]
+	if ok {
+		delete(d.pending, fingerprint)
+	}
+	d.mu.Unlock()
+	if ok {
+		close(ch) // releases the waiting goroutine, which drops the incident
+	}
+}
+
+// register records an in-flight hold. A pre-existing entry for the same key
+// (should not happen once dedup runs first, but be defensive) is dropped from the
+// map without closing it: its goroutine will simply wait its own window out.
+func (d *incidentDebouncer) register(key string, ch chan struct{}) {
+	d.mu.Lock()
+	d.pending[key] = ch
+	d.mu.Unlock()
+}
+
+// unregister removes the hold only if the stored channel is still this one, so a
+// replaced/cancelled entry is never clobbered.
+func (d *incidentDebouncer) unregister(key string, ch chan struct{}) {
+	d.mu.Lock()
+	if cur, ok := d.pending[key]; ok && cur == ch {
+		delete(d.pending, key)
+	}
+	d.mu.Unlock()
+}
+
+// waitIdle blocks until all in-flight holds have finished. Used by tests (after
+// releasing the clock or cancelling) to observe the terminal enqueue decision.
+func (d *incidentDebouncer) waitIdle() { d.wg.Wait() }

--- a/internal/source/debounce_test.go
+++ b/internal/source/debounce_test.go
@@ -1,0 +1,94 @@
+package source
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/investigate"
+)
+
+// fakeClock is a manually advanced clock whose After channel is released on
+// demand, so the incident debouncer's hold can be fired deterministically
+// without real sleeps.
+type fakeClock struct{ after chan time.Time }
+
+func newFakeClock() *fakeClock { return &fakeClock{after: make(chan time.Time, 1)} }
+
+func (c *fakeClock) After(time.Duration) <-chan time.Time { return c.after }
+
+// release fires the pending timer so the debouncer proceeds to enqueue.
+func (c *fakeClock) release() { c.after <- time.Now() }
+
+func TestIncidentDebouncerZeroWindowEnqueuesImmediately(t *testing.T) {
+	enq := &capEnq{}
+	d := newIncidentDebouncer(0, nil)
+	d.Hold(context.Background(), investigate.Request{Title: "A", Fingerprint: "f1"}, enq)
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued immediately with debounce=0, got %d", len(enq.reqs))
+	}
+}
+
+func TestIncidentDebouncerEnqueuesWhenStillActive(t *testing.T) {
+	clk := newFakeClock()
+	enq := &capEnq{}
+	d := newIncidentDebouncer(60*time.Second, nil)
+	d.clock = clk
+
+	// No resolved webhook arrives; releasing the timer must enqueue the survivor.
+	d.Hold(context.Background(), investigate.Request{Title: "A", Fingerprint: "f1"}, enq)
+	clk.release()
+	d.waitIdle()
+
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued (still active at window end), got %d", len(enq.reqs))
+	}
+}
+
+func TestIncidentDebouncerDropsResolvedWithinWindow(t *testing.T) {
+	clk := newFakeClock()
+	enq := &capEnq{}
+	d := newIncidentDebouncer(60*time.Second, nil)
+	d.clock = clk
+
+	// Hold the alert, then a matching resolved arrives inside the window → drop.
+	d.Hold(context.Background(), investigate.Request{Title: "A", Fingerprint: "f1"}, enq)
+	d.Cancel("f1")
+	d.waitIdle()
+
+	if len(enq.reqs) != 0 {
+		t.Fatalf("want 0 enqueued (resolved within window), got %d", len(enq.reqs))
+	}
+}
+
+func TestIncidentDebouncerCancelIgnoresUnrelatedFingerprint(t *testing.T) {
+	clk := newFakeClock()
+	enq := &capEnq{}
+	d := newIncidentDebouncer(60*time.Second, nil)
+	d.clock = clk
+
+	d.Hold(context.Background(), investigate.Request{Title: "A", Fingerprint: "f1"}, enq)
+	d.Cancel("other") // a resolve for a different alert must not drop this hold
+	clk.release()
+	d.waitIdle()
+
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued (unrelated resolve ignored), got %d", len(enq.reqs))
+	}
+}
+
+func TestIncidentDebouncerContextCancelDrops(t *testing.T) {
+	clk := newFakeClock()
+	enq := &capEnq{}
+	d := newIncidentDebouncer(60*time.Second, nil)
+	d.clock = clk
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d.Hold(ctx, investigate.Request{Title: "A", Fingerprint: "f1"}, enq)
+	cancel()
+	d.waitIdle()
+
+	if len(enq.reqs) != 0 {
+		t.Fatalf("want 0 enqueued (context cancelled during hold), got %d", len(enq.reqs))
+	}
+}

--- a/internal/source/pipeline.go
+++ b/internal/source/pipeline.go
@@ -20,12 +20,20 @@ type ResolveFunc func(fingerprint string, at time.Time)
 // configured gate policy (MatchGated or EnableGated), deduplicates within the
 // configured window, and forwards survivors to the investigation enqueuer.
 type Pipeline struct {
-	cfg     *config.Config
-	enq     investigate.Enqueuer
-	resolve ResolveFunc
-	dedup   *trigger.Deduper
-	metrics *telemetry.Metrics // optional; nil-safe ingress counters
-	log     *slog.Logger
+	cfg      *config.Config
+	enq      investigate.Enqueuer
+	resolve  ResolveFunc
+	dedup    *trigger.Deduper
+	debounce *incidentDebouncer
+	metrics  *telemetry.Metrics // optional; nil-safe ingress counters
+	log      *slog.Logger
+
+	// baseCtx bounds the lifetime of background debounce holds, which outlive the
+	// per-request HTTP context that delivered the alert (a hold survives seconds to
+	// minutes; the webhook handler returns immediately). Defaults to
+	// context.Background(); serve binds it to the app/work context via WithContext
+	// so holds stop cleanly on shutdown.
+	baseCtx context.Context
 }
 
 // NewPipeline creates a Pipeline. resolve may be nil to disable resolved-alert
@@ -33,19 +41,39 @@ type Pipeline struct {
 func NewPipeline(cfg *config.Config, enq investigate.Enqueuer, resolve ResolveFunc, log *slog.Logger) *Pipeline {
 	return &Pipeline{
 		cfg: cfg, enq: enq, resolve: resolve, log: log,
-		dedup: trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()),
+		dedup:    trigger.NewDeduper(cfg.Triggers.Incidents.Dedup.Window.Std()),
+		debounce: newIncidentDebouncer(cfg.Triggers.Incidents.Debounce.Std(), log),
+		baseCtx:  context.Background(),
 	}
 }
 
+// WithContext binds the lifetime of background debounce holds to ctx (typically
+// the app/work context) so they stop cleanly on shutdown instead of running to
+// their window end. Chains off NewPipeline; a nil ctx is ignored.
+func (p *Pipeline) WithContext(ctx context.Context) *Pipeline {
+	if ctx != nil {
+		p.baseCtx = ctx
+	}
+	return p
+}
+
 // WithMetrics attaches the OTel metrics instance so admitted alerts (MatchGated)
-// increment AlertsReceived. Chains off NewPipeline; nil m is a no-op.
-func (p *Pipeline) WithMetrics(m *telemetry.Metrics) *Pipeline { p.metrics = m; return p }
+// increment AlertsReceived and debounced self-resolving alerts increment
+// IncidentsDebounced. Chains off NewPipeline; nil m is a no-op.
+func (p *Pipeline) WithMetrics(m *telemetry.Metrics) *Pipeline {
+	p.metrics = m
+	p.debounce.withMetrics(m)
+	return p
+}
 
 // Ingest admits each Request per the admission mode and invokes resolve for each
 // Resolution. Cascade-suppression and debounce for EnableGated sources are
 // applied at the watcher edge (see Task 6) during Phase 1.
 func (p *Pipeline) Ingest(ctx context.Context, adm Admission, res DecodeResult) {
 	for _, r := range res.Resolved {
+		// Drop any firing alert still held in the debounce window: it self-resolved
+		// before its investigation began, so it never reaches the enqueuer.
+		p.debounce.Cancel(r.Fingerprint)
 		if p.resolve != nil {
 			p.resolve(r.Fingerprint, r.At)
 		}
@@ -68,7 +96,13 @@ func (p *Pipeline) Ingest(ctx context.Context, adm Admission, res DecodeResult) 
 		if adm == MatchGated && p.metrics != nil {
 			p.metrics.AlertsReceived.Add(ctx, 1)
 		}
-		p.enq.Enqueue(req)
+		// Pre-investigation debounce (opt-in; window 0 = enqueue immediately). Runs
+		// AFTER dedup (re-fires already suppressed) and BEFORE the coalescer sink
+		// (survivors are still storm-batched): the hold is released early — dropping
+		// the incident — if a matching resolved webhook arrives within the window.
+		// The hold runs on baseCtx, not the request ctx (the webhook handler returns
+		// before the window elapses).
+		p.debounce.Hold(p.baseCtx, req, p.enq)
 	}
 }
 

--- a/internal/source/pipeline_test.go
+++ b/internal/source/pipeline_test.go
@@ -55,6 +55,80 @@ func TestPipelineDedupsStillFiring(t *testing.T) {
 	}
 }
 
+func debounceCfg(window time.Duration) *config.Config {
+	c := matchAllCfg()
+	c.Triggers.Incidents.Debounce = config.Duration(window)
+	return c
+}
+
+func TestPipelineDebounceHoldsThenEnqueues(t *testing.T) {
+	enq := &capEnq{}
+	clk := newFakeClock()
+	p := NewPipeline(debounceCfg(60*time.Second), enq, nil, nil)
+	p.debounce.clock = clk
+
+	p.Ingest(context.Background(), MatchGated, DecodeResult{
+		Requests: []investigate.Request{{Title: "A", Fingerprint: "f1"}},
+	})
+	// Nothing enqueued yet — the alert is held for the window.
+	if len(enq.reqs) != 0 {
+		t.Fatalf("want 0 enqueued while held, got %d", len(enq.reqs))
+	}
+	clk.release()
+	p.debounce.waitIdle()
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued after window (still active), got %d", len(enq.reqs))
+	}
+}
+
+func TestPipelineDebounceDropsSelfResolvingAlert(t *testing.T) {
+	enq := &capEnq{}
+	clk := newFakeClock()
+	p := NewPipeline(debounceCfg(60*time.Second), enq, nil, nil)
+	p.debounce.clock = clk
+
+	// Firing alert is held; a matching resolved webhook arrives within the window.
+	p.Ingest(context.Background(), MatchGated, DecodeResult{
+		Requests: []investigate.Request{{Title: "A", Fingerprint: "f1"}},
+	})
+	p.Ingest(context.Background(), MatchGated, DecodeResult{
+		Resolved: []Resolution{{Fingerprint: "f1", At: time.Now()}},
+	})
+	p.debounce.waitIdle()
+	if len(enq.reqs) != 0 {
+		t.Fatalf("want 0 enqueued (self-resolved within debounce window), got %d", len(enq.reqs))
+	}
+}
+
+func TestPipelineDebounceZeroWindowUnchanged(t *testing.T) {
+	enq := &capEnq{}
+	p := NewPipeline(debounceCfg(0), enq, nil, nil)
+	p.Ingest(context.Background(), MatchGated, DecodeResult{
+		Requests: []investigate.Request{{Title: "A", Fingerprint: "f1"}},
+	})
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want 1 enqueued immediately with debounce=0, got %d", len(enq.reqs))
+	}
+}
+
+func TestPipelineDebounceCoexistsWithDedup(t *testing.T) {
+	enq := &capEnq{}
+	clk := newFakeClock()
+	p := NewPipeline(debounceCfg(60*time.Second), enq, nil, nil)
+	p.debounce.clock = clk
+
+	r := DecodeResult{Requests: []investigate.Request{{Title: "A", Fingerprint: "f1"}}}
+	// A re-fire of the same alert is suppressed by dedup BEFORE the hold begins,
+	// so only one hold is created.
+	p.Ingest(context.Background(), MatchGated, r)
+	p.Ingest(context.Background(), MatchGated, r)
+	clk.release()
+	p.debounce.waitIdle()
+	if len(enq.reqs) != 1 {
+		t.Fatalf("want dedup+debounce to yield 1, got %d", len(enq.reqs))
+	}
+}
+
 func TestPipelineRoutesResolvedToLedger(t *testing.T) {
 	enq := &capEnq{}
 	var resolved []string

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -23,6 +23,7 @@ type Metrics struct {
 	InvestigationsThrottled   metric.Int64Counter
 	InvestigationsDropped     metric.Int64Counter
 	GitOpsFailuresDebounced   metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
+	IncidentsDebounced        metric.Int64Counter // firing alerts dropped as self-resolving (resolved within the incident debounce window)
 	ToolOutputTruncatedBytes  metric.Int64Counter
 	HistoryCompactions        metric.Int64Counter // mid-loop history compaction events
 	HistoryElidedBytes        metric.Int64Counter // tool-output bytes elided by compaction
@@ -84,6 +85,7 @@ func NewMetrics() *Metrics {
 		InvestigationsThrottled:   ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
 		InvestigationsDropped:     ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
 		GitOpsFailuresDebounced:   ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
+		IncidentsDebounced:        ctr("incidents_debounced_total", "firing alerts dropped as self-resolving: a matching resolved webhook arrived within the incident debounce window before investigating"),
 		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),
 		HistoryCompactions:        ctr("history_compactions_total", "mid-loop tool-output history compaction events"),
 		HistoryElidedBytes:        ctr("history_elided_bytes_total", "tool-output bytes elided by mid-loop compaction"),


### PR DESCRIPTION
## What

Adds `triggers.incidents.debounce` (Duration, default `0` = current behaviour) — a pre-investigation hold for the Alertmanager/incidents source. After a firing alert is admitted (match + dedup), RunLore waits the window and investigates only if the alert is **still active**: if a matching Alertmanager `resolved` webhook arrives within the window, the incident is dropped and no investigation runs.

This filters self-resolving alerts (e.g. `KubeDaemonSetRolloutStuck` during a Karpenter node-churn cycle) that otherwise burn a full investigation on noise and are frequently already resolved by delivery time.

## How

- New `internal/source/debounce.go` — `incidentDebouncer`: event-driven hold keyed on the alert fingerprint (the handle `resolved` webhooks carry); a matching `Cancel` releases the hold and drops the incident.
- Wired into `Pipeline.Ingest`: the hold sits **after dedup** (re-fires already suppressed) and **before the coalescer** (survivors are still storm-batched). The resolved loop calls `Cancel`.
- Holds run on the pipeline's base/work context (not the per-request HTTP context, which returns before the window elapses); `serve` binds it so holds stop cleanly on shutdown.
- New `runlore_incidents_debounced_total` metric.
- Docs + Helm `values.yaml` updated consistently with the GitOps `debounce` counterpart.

Mirrors the intent of the existing `triggers.gitops_failures.debounce` but uses the resolved webhook as the "still active?" signal rather than re-querying state.

## Composition

`match → dedup → **debounce** → coalesce → queue`. Default `0` preserves today's behaviour; opt-in per deployment.

## Notes

- The optional alert-state **re-query backstop** is intentionally **not** included: the webhook source is push-only and has no alert-state querier, so re-query would require a new Alertmanager client — disproportionate to the "cheapest implementation" goal. The resolved-webhook cancellation is the primary and sufficient signal.
- Does not help sustained-but-benign alerts (out of scope — pair with alert-side `for:` / inhibition).

## Tests

9 new tests (debouncer unit + pipeline integration), including self-resolve-within-window drop, zero-window unchanged behaviour, and coexistence with dedup. `go test -race ./internal/source/...` clean; full `go test ./...`, `gofmt`, `go vet`, `golangci-lint` all green.

Closes #221
