### PR TITLE
feat(curate): escalate recurring closed-unmerged KB entries via a knowledge-gap issue

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -118,7 +118,10 @@ config:
   # when config.outcome.ledger_path is set (they read the outcome ledger).
   curate:
     stale_after: 720h          # close unprotected KB PRs idle longer than this; 0 disables
-    recurrence_threshold: 3    # open a knowledge-gap issue after this many unresolved occurrences; 0 ⇒ 3
+    recurrence_threshold: 3    # open a knowledge-gap issue after this many unresolved occurrences; 0 ⇒ 3.
+                               # Also the trigger for escalating a closed-unmerged (human-rejected) KB
+                               # entry that keeps recurring: RunLore links the closed PR in a knowledge-gap
+                               # issue rather than reopening it.
   # model:
   #   base_url: https://vllm.svc/v1
   #   model: <model-name>

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -273,9 +273,21 @@ ledger, so they stay source-neutral):
   `"KB: " + the incident title`, which the ledger records too), so a resolved episode
   with that title flips the PR onto the merge-ready queue. A human still merges.
 - **Recurrence** — open one *knowledge-gap* issue when an unresolved pattern (the
-  affected resource) recurs past a threshold. Idempotent by an existing-issue check
-  (the forge's open gap issues are the "already-opened" record), so re-running never
-  double-opens — no mutable store.
+  affected resource) recurs past `recurrence_threshold`. Idempotent by an existing-issue
+  check (the forge's open gap issues are the "already-opened" record), so re-running
+  never double-opens — no mutable store.
+  - **Closed-unmerged escalation.** When a human closes a drafted KB PR *without
+    merging*, that is a deliberate "not KB-worthy". RunLore does **not** reopen it (a
+    reopen re-litigates a human "no" and resurrects exactly the entries humans reject).
+    Instead the entry's `DupFingerprint` is treated as **suppressed** — derived each run
+    from the forge's closed-unmerged `runlore` PRs, so there is still no mutable store —
+    and its recurrences are counted *silently* on the fingerprint. Once they cross
+    `recurrence_threshold`, Recurrence escalates via a knowledge-gap issue that **links
+    the closed PR** and cites the count ("closed unmerged but has recurred N times —
+    reconsider?"), respecting the close instead of overriding it. A close labelled
+    `needs-work` is a revise-and-resubmit (not a rejection) and is left to the generic
+    recurrence path; `wontfix` / `not-kb-worthy` are captured as the escalation's close
+    reason. A *merged* PR is an accepted entry and is never suppressed.
 
 ---
 

--- a/internal/app/curate.go
+++ b/internal/app/curate.go
@@ -64,7 +64,17 @@ func RunCurate(args []string) error {
 		}
 		agent.Passes = append(agent.Passes,
 			curate.Queue{Forge: forge, Checker: curate.LedgerResolutionChecker{Ledger: ledger}, Log: log},
-			curate.Recurrence{Forge: forge, Ledger: ledger, Threshold: cfg.Curate.RecurrenceThreshold, Log: log},
+			// Recurrence escalates recurring UNRESOLVED patterns AND recurring
+			// closed-unmerged (human-rejected) entries: the latter via a knowledge-gap
+			// issue that links the closed PR — never reopening it. The suppression set is
+			// derived from the forge's closed-unmerged KB PRs on every run (no store).
+			curate.Recurrence{
+				Forge:      forge,
+				Ledger:     ledger,
+				Threshold:  cfg.Curate.RecurrenceThreshold,
+				Suppressed: curate.ClosedPRSuppression{Forge: forge},
+				Log:        log,
+			},
 		)
 		// Warn loudly when the ledger this pod sees is absent/empty: outcome.New
 		// succeeds on a missing file, so the passes would otherwise run silently

--- a/internal/curate/recurrence.go
+++ b/internal/curate/recurrence.go
@@ -25,11 +25,20 @@ type Recurrence struct {
 		Episodes() ([]outcome.Episode, error)
 	}
 	Threshold int // default 3 when 0
-	Log       *slog.Logger
+	// Suppressed, when set, is the set of KB entries a human closed WITHOUT merging
+	// (keyed by DupFingerprint). Their episodes are counted SEPARATELY — silently,
+	// keyed on the fingerprint — and, past the threshold, escalate via a knowledge-gap
+	// issue that LINKS the closed PR ("closed unmerged but recurred N times —
+	// reconsider?") instead of the plain gap message. A close-without-merge is a
+	// deliberate "no": we respect it and never reopen the PR. Nil disables the branch
+	// (behaviour is then identical to the pre-suppression pass).
+	Suppressed SuppressionSource
+	Log        *slog.Logger
 }
 
 // Run opens a knowledge-gap issue for each pattern that crosses the threshold and has
-// none open yet.
+// none open yet. Episodes belonging to a suppressed (closed-unmerged) entry are routed
+// to a separate escalation that links the closed PR rather than the generic gap issue.
 func (r Recurrence) Run(ctx context.Context) error {
 	thr := r.Threshold
 	if thr == 0 {
@@ -39,11 +48,36 @@ func (r Recurrence) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("recurrence: load episodes: %w", err)
 	}
-	// Count UNRESOLVED occurrences per pattern (affected resource; title fallback).
+	// Fetch the suppression set only when an unresolved fingerprinted episode could
+	// match it — otherwise the (paginated) forge round-trip is wasted work on a quiet
+	// or fingerprint-less ledger.
+	var suppressed map[string]SuppressedEntry
+	if r.Suppressed != nil && hasFingerprintedUnresolved(eps) {
+		if suppressed, err = r.Suppressed.Suppressed(ctx); err != nil {
+			return fmt.Errorf("recurrence: load suppressed entries: %w", err)
+		}
+	}
+	// Count UNRESOLVED occurrences. Episodes whose fingerprint is suppressed are counted
+	// on the fingerprint (the precise incident identity of the rejected entry); the rest
+	// are counted per pattern (affected resource; title fallback). Suppressed episodes
+	// never feed the generic pattern count, so a rejected entry is escalated once — via
+	// the PR-linking issue — never doubly.
 	counts := map[string]int{}
+	sup := map[string]*supAgg{} // suppressed DupFingerprint -> unresolved count + display pattern
 	for _, e := range eps {
 		if e.Resolved {
 			continue
+		}
+		if e.DupFingerprint != "" {
+			if _, ok := suppressed[e.DupFingerprint]; ok {
+				a := sup[e.DupFingerprint]
+				if a == nil {
+					a = &supAgg{pattern: recurrencePattern(e)}
+					sup[e.DupFingerprint] = a
+				}
+				a.count++
+				continue
+			}
 		}
 		counts[recurrencePattern(e)]++
 	}
@@ -59,23 +93,75 @@ func (r Recurrence) Run(ctx context.Context) error {
 			open[p] = true
 		}
 	}
+	// Suppressed entries first: their PR-linking escalation takes precedence over a
+	// plain gap issue on a colliding pattern.
+	for fp, a := range sup {
+		if a.count < thr || open[a.pattern] {
+			continue
+		}
+		se := suppressed[fp]
+		summary := fmt.Sprintf("The KB entry for %q was closed unmerged (#%d%s) but the incident has recurred %d times — reconsider whether it is knowledge-base-worthy. RunLore did not reopen the closed PR: a close-without-merge is a deliberate human decision.", a.pattern, se.PRNumber, reasonSuffix(se.Reason), a.count)
+		if r.openGap(ctx, a.pattern, summary) {
+			open[a.pattern] = true // guard against a same-run generic duplicate on this pattern
+			r.Log.Info("escalated recurring closed-unmerged KB entry", "pattern", a.pattern, "pr", se.PRNumber, "count", a.count)
+		}
+	}
 	for pattern, n := range counts {
 		if n < thr || open[pattern] {
 			continue
 		}
-		inv := providers.Investigation{
-			Title: gapTitlePrefix + pattern,
-			RootCauses: []providers.Hypothesis{{
-				Summary: fmt.Sprintf("RunLore could not resolve incidents on %q across %d occurrences — needs seeded knowledge or a RunLore fix.", pattern, n),
-			}},
+		summary := fmt.Sprintf("RunLore could not resolve incidents on %q across %d occurrences — needs seeded knowledge or a RunLore fix.", pattern, n)
+		if r.openGap(ctx, pattern, summary) {
+			r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", n)
 		}
-		if _, err := r.Forge.OpenIssue(ctx, inv); err != nil {
-			r.Log.Warn("recurrence: open knowledge-gap issue failed", "pattern", pattern, "err", err)
-			continue // best-effort; other patterns still processed
-		}
-		r.Log.Info("opened knowledge-gap issue", "pattern", pattern, "count", n)
 	}
 	return nil
+}
+
+// supAgg accumulates the unresolved count and display pattern for one suppressed
+// (closed-unmerged) DupFingerprint.
+type supAgg struct {
+	count   int
+	pattern string
+}
+
+// hasFingerprintedUnresolved reports whether any episode is unresolved and carries a
+// DupFingerprint — the precondition for the suppression set to be worth fetching.
+func hasFingerprintedUnresolved(eps []outcome.Episode) bool {
+	for _, e := range eps {
+		if !e.Resolved && e.DupFingerprint != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// gapIssue builds the knowledge-gap issue envelope shared by the generic and the
+// closed-unmerged escalation paths (same title namespace, single-hypothesis body).
+func gapIssue(pattern, summary string) providers.Investigation {
+	return providers.Investigation{
+		Title:      gapTitlePrefix + pattern,
+		RootCauses: []providers.Hypothesis{{Summary: summary}},
+	}
+}
+
+// openGap opens one knowledge-gap issue, returning whether it succeeded; a failure is
+// logged and swallowed so the pass stays best-effort across the remaining patterns.
+func (r Recurrence) openGap(ctx context.Context, pattern, summary string) bool {
+	if _, err := r.Forge.OpenIssue(ctx, gapIssue(pattern, summary)); err != nil {
+		r.Log.Warn("recurrence: open knowledge-gap issue failed", "pattern", pattern, "err", err)
+		return false
+	}
+	return true
+}
+
+// reasonSuffix renders the close reason for the escalation summary, or "" when the
+// close carried no distinguishing label.
+func reasonSuffix(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return ", closed as " + reason
 }
 
 // recurrencePattern groups unresolved incidents by the affected resource, falling

--- a/internal/curate/recurrence_test.go
+++ b/internal/curate/recurrence_test.go
@@ -2,22 +2,49 @@ package curate
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// gapForge records the issue titles it was asked to open. It embeds recordingForge
-// (which supplies ListIssuesByLabel from its `issues` field) and overrides OpenIssue.
+// gapForge records the issues it was asked to open (title + full investigation) and
+// counts Close calls. It embeds recordingForge (which supplies ListIssuesByLabel from
+// its `issues` field) and overrides OpenIssue/Close.
 type gapForge struct {
 	*recordingForge
 	openedTitles []string
+	openedInvs   []providers.Investigation
+	closes       int
 }
 
 func (g *gapForge) OpenIssue(_ context.Context, inv providers.Investigation) (providers.Ref, error) {
 	g.openedTitles = append(g.openedTitles, inv.Title)
+	g.openedInvs = append(g.openedInvs, inv)
 	return providers.Ref{URL: "https://github.com/x/y/issues/1"}, nil
+}
+
+func (g *gapForge) Close(context.Context, int) error {
+	g.closes++
+	return nil
+}
+
+// fakeSuppression is a fixed SuppressionSource for recurrence escalation tests.
+type fakeSuppression struct{ set map[string]SuppressedEntry }
+
+func (f fakeSuppression) Suppressed(context.Context) (map[string]SuppressedEntry, error) {
+	return f.set, nil
+}
+
+// suppressedEpisodes builds n unresolved episodes for a pattern all carrying the
+// same DupFingerprint (a recurring, previously-rejected incident).
+func suppressedEpisodes(pattern, fp string, n int) []outcome.Episode {
+	eps := make([]outcome.Episode, n)
+	for i := range eps {
+		eps[i] = outcome.Episode{Resource: pattern, DupFingerprint: fp, Resolved: false}
+	}
+	return eps
 }
 
 func unresolved(pattern string, n int) []outcome.Episode {
@@ -76,6 +103,123 @@ func TestRecurrenceResolvedEpisodesDoNotCount(t *testing.T) {
 	}
 	if len(gf.openedTitles) != 0 {
 		t.Fatalf("resolved episodes must not count, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceEscalatesSuppressedAtThreshold(t *testing.T) {
+	eps := suppressedEpisodes("apps/web", "fp-web", 3)
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{
+		Forge:      gf,
+		Ledger:     fakeLedger{eps: eps},
+		Threshold:  3,
+		Suppressed: fakeSuppression{set: map[string]SuppressedEntry{"fp-web": {Fingerprint: "fp-web", PRNumber: 7, Reason: "not-kb-worthy"}}},
+		Log:        discardLog(),
+	}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedInvs) != 1 {
+		t.Fatalf("want exactly one escalation issue, got %d: %v", len(gf.openedInvs), gf.openedTitles)
+	}
+	inv := gf.openedInvs[0]
+	if inv.Title != "knowledge-gap: apps/web" {
+		t.Fatalf("title = %q", inv.Title)
+	}
+	summary := inv.RootCauses[0].Summary
+	if !strings.Contains(summary, "#7") {
+		t.Fatalf("escalation must link the closed PR #7: %q", summary)
+	}
+	if !strings.Contains(summary, "3") {
+		t.Fatalf("escalation must cite the recurrence count: %q", summary)
+	}
+	if !strings.Contains(summary, "not-kb-worthy") {
+		t.Fatalf("escalation should mention the close reason: %q", summary)
+	}
+	// Respect the human "no": we escalate via an issue, we do NOT reopen/close the PR.
+	if gf.closes != 0 {
+		t.Fatalf("suppressed escalation must not close/reopen the PR, got %d closes", gf.closes)
+	}
+}
+
+func TestRecurrenceSuppressedBelowThresholdSilent(t *testing.T) {
+	eps := suppressedEpisodes("apps/web", "fp-web", 2) // below threshold
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{
+		Forge:      gf,
+		Ledger:     fakeLedger{eps: eps},
+		Threshold:  3,
+		Suppressed: fakeSuppression{set: map[string]SuppressedEntry{"fp-web": {Fingerprint: "fp-web", PRNumber: 7}}},
+		Log:        discardLog(),
+	}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedInvs) != 0 {
+		t.Fatalf("below threshold must escalate nothing, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceSuppressedNotDoubleCounted(t *testing.T) {
+	// A suppressed fingerprint's episodes must not ALSO feed the generic pattern
+	// count: exactly one (enriched) issue, never a plain gap issue on top.
+	eps := suppressedEpisodes("apps/web", "fp-web", 4)
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{
+		Forge:      gf,
+		Ledger:     fakeLedger{eps: eps},
+		Threshold:  3,
+		Suppressed: fakeSuppression{set: map[string]SuppressedEntry{"fp-web": {Fingerprint: "fp-web", PRNumber: 7}}},
+		Log:        discardLog(),
+	}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedInvs) != 1 {
+		t.Fatalf("want exactly one issue for a suppressed pattern, got %d: %v", len(gf.openedInvs), gf.openedTitles)
+	}
+}
+
+func TestRecurrenceSuppressedIdempotent(t *testing.T) {
+	eps := suppressedEpisodes("apps/web", "fp-web", 5)
+	gf := &gapForge{recordingForge: &recordingForge{
+		issues: []providers.CuratedIssue{{Title: "knowledge-gap: apps/web"}}, // already escalated
+	}}
+	r := Recurrence{
+		Forge:      gf,
+		Ledger:     fakeLedger{eps: eps},
+		Threshold:  3,
+		Suppressed: fakeSuppression{set: map[string]SuppressedEntry{"fp-web": {Fingerprint: "fp-web", PRNumber: 7}}},
+		Log:        discardLog(),
+	}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedInvs) != 0 {
+		t.Fatalf("an existing gap issue must prevent a duplicate escalation, got %v", gf.openedTitles)
+	}
+}
+
+func TestRecurrenceNonSuppressedUnaffectedBySuppressionSource(t *testing.T) {
+	// A recurring pattern whose fingerprint is NOT suppressed still gets the plain
+	// generic knowledge-gap issue even when a suppression source is wired.
+	eps := suppressedEpisodes("apps/api", "fp-api", 3) // fp-api not in the suppression set
+	gf := &gapForge{recordingForge: &recordingForge{}}
+	r := Recurrence{
+		Forge:      gf,
+		Ledger:     fakeLedger{eps: eps},
+		Threshold:  3,
+		Suppressed: fakeSuppression{set: map[string]SuppressedEntry{"fp-web": {PRNumber: 7}}},
+		Log:        discardLog(),
+	}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gf.openedTitles) != 1 || gf.openedTitles[0] != "knowledge-gap: apps/api" {
+		t.Fatalf("non-suppressed pattern should still open a generic gap issue, got %v", gf.openedTitles)
+	}
+	if s := gf.openedInvs[0].RootCauses[0].Summary; strings.Contains(s, "#7") || strings.Contains(s, "closed") {
+		t.Fatalf("generic issue must not reference a closed PR: %q", s)
 	}
 }
 

--- a/internal/curate/suppression.go
+++ b/internal/curate/suppression.go
@@ -1,0 +1,105 @@
+package curate
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// SuppressedEntry is a KB entry a human closed WITHOUT merging — a deliberate
+// "not knowledge-base-worthy". It is keyed on the entry's DupFingerprint so the
+// recurrence pass can keep counting the incident silently and, past the threshold,
+// escalate via a knowledge-gap issue that LINKS the closed PR — never reopening it.
+type SuppressedEntry struct {
+	Fingerprint string // curator DupFingerprint (resource+cause); the join key against ledger episodes
+	PRNumber    int    // the closed-unmerged KB PR to reference in the escalation
+	Reason      string // the close-reason label, when one distinguishes it (e.g. "wontfix"); "" otherwise
+}
+
+// SuppressionSource yields the set of suppressed fingerprints (closed-unmerged KB
+// entries a human rejected), keyed by DupFingerprint. Recurrence consults it to
+// escalate-via-issue instead of re-litigating a human "no".
+type SuppressionSource interface {
+	Suppressed(ctx context.Context) (map[string]SuppressedEntry, error)
+}
+
+// ClosedPRLister lists closed-but-unmerged KB PRs carrying a label. Merged PRs are
+// accepted entries (never suppressed) and are filtered out by the implementation.
+type ClosedPRLister interface {
+	ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+}
+
+// suppressReviseLabels mark a closed KB PR as "revise & resubmit" rather than an
+// outright rejection: the entry IS considered KB-worthy, it just needs work. Such a
+// close is NOT suppressed (it must not be escalated as a "reconsider" — a human
+// already said yes-with-changes), so its incident flows through the generic
+// recurrence path instead.
+var suppressReviseLabels = []string{"needs-work"}
+
+// suppressRejectLabels are explicit "not KB-worthy" close reasons; the first one
+// present is captured on the SuppressedEntry so the escalation can cite it. A close
+// with NO distinguishing label is treated as a rejection too (the default) — the
+// escalation still fires, just without a named reason.
+var suppressRejectLabels = []string{"wontfix", "not-kb-worthy"}
+
+// ClosedPRSuppression derives the suppression set on every run from the forge's
+// closed-unmerged KB PRs — no mutable store or watermark, mirroring Recurrence's
+// idempotent, ledger-driven design. The forge retains closed PRs, and each carries
+// the same hidden DupFingerprint marker the drafter stamped, so the set is
+// reconstructable each pass. A markerless (legacy/hand-filed) close is skipped:
+// there is no stable key to suppress or count it on.
+type ClosedPRSuppression struct {
+	Forge ClosedPRLister
+}
+
+// Suppressed implements SuppressionSource.
+func (s ClosedPRSuppression) Suppressed(ctx context.Context) (map[string]SuppressedEntry, error) {
+	prs, err := s.Forge.ListClosedUnmergedPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return nil, fmt.Errorf("suppression: list closed-unmerged KB PRs: %w", err)
+	}
+	out := map[string]SuppressedEntry{}
+	for _, pr := range prs {
+		fp := providers.ParseFingerprintMarker(pr.Body)
+		if fp == "" {
+			continue // markerless: nothing stable to key the suppression on
+		}
+		reason, suppress := classifyClose(pr.Labels)
+		if !suppress {
+			continue // revise-and-resubmit: not a deliberate rejection
+		}
+		// One fingerprint may have several closed PRs over time; keep the most recent
+		// (highest-numbered) close as the reference.
+		if cur, ok := out[fp]; ok && cur.PRNumber >= pr.Number {
+			continue
+		}
+		out[fp] = SuppressedEntry{Fingerprint: fp, PRNumber: pr.Number, Reason: reason}
+	}
+	return out, nil
+}
+
+// classifyClose reads a closed KB PR's labels to decide whether the close is a
+// deliberate rejection (suppress=true) and, if so, its named reason. A "revise"
+// label wins: it is an accept-with-changes, not a rejection.
+func classifyClose(labels []string) (reason string, suppress bool) {
+	if _, ok := firstLabelIn(labels, suppressReviseLabels); ok {
+		return "", false
+	}
+	if l, ok := firstLabelIn(labels, suppressRejectLabels); ok {
+		return l, true
+	}
+	return "", true // no distinguishing label: a plain close-without-merge is still a "no"
+}
+
+// firstLabelIn returns the first label from set that is present in labels, and whether
+// any matched. It keeps the label-set membership checks out of classifyClose.
+func firstLabelIn(labels, set []string) (string, bool) {
+	for _, l := range set {
+		if slices.Contains(labels, l) {
+			return l, true
+		}
+	}
+	return "", false
+}

--- a/internal/curate/suppression_test.go
+++ b/internal/curate/suppression_test.go
@@ -1,0 +1,81 @@
+package curate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeClosedPRs is a fixed ClosedPRLister for suppression tests.
+type fakeClosedPRs struct{ prs []providers.CuratedIssue }
+
+func (f fakeClosedPRs) ListClosedUnmergedPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return f.prs, nil
+}
+
+// body builds a PR body carrying the hidden fingerprint marker, matching what the
+// curator stamps at draft time (providers.FingerprintMarker).
+func body(fp string) string { return "Drafted by RunLore.\n\n" + providers.FingerprintMarker(fp) }
+
+func TestClosedPRSuppressionRecordsFingerprint(t *testing.T) {
+	s := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 7, Title: "KB: apps/web DNS", Body: body("fp-web"), Labels: []string{"runlore"}},
+	}}}
+	got, err := s.Suppressed(context.Background())
+	if err != nil {
+		t.Fatalf("Suppressed: %v", err)
+	}
+	se, ok := got["fp-web"]
+	if !ok {
+		t.Fatalf("fp-web not recorded, got %+v", got)
+	}
+	if se.PRNumber != 7 || se.Reason != "" {
+		t.Fatalf("entry = %+v, want PRNumber 7, empty reason", se)
+	}
+}
+
+func TestClosedPRSuppressionCapturesRejectReason(t *testing.T) {
+	s := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 9, Body: body("fp-x"), Labels: []string{"runlore", "not-kb-worthy"}},
+	}}}
+	got, _ := s.Suppressed(context.Background())
+	if got["fp-x"].Reason != "not-kb-worthy" {
+		t.Fatalf("reason = %q, want not-kb-worthy", got["fp-x"].Reason)
+	}
+}
+
+func TestClosedPRSuppressionExcludesNeedsWork(t *testing.T) {
+	// needs-work is "revise & resubmit", NOT a deliberate rejection: it must not be
+	// suppressed (so it is never escalated as a closed-unmerged reconsideration).
+	s := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 3, Body: body("fp-revise"), Labels: []string{"runlore", "needs-work"}},
+	}}}
+	got, _ := s.Suppressed(context.Background())
+	if _, ok := got["fp-revise"]; ok {
+		t.Fatalf("needs-work must not be suppressed, got %+v", got)
+	}
+}
+
+func TestClosedPRSuppressionSkipsMarkerlessPR(t *testing.T) {
+	// No fingerprint marker → nothing stable to key the suppression on; skip it.
+	s := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 5, Title: "KB: legacy", Body: "hand-filed, no marker", Labels: []string{"runlore"}},
+	}}}
+	got, _ := s.Suppressed(context.Background())
+	if len(got) != 0 {
+		t.Fatalf("markerless PR must be skipped, got %+v", got)
+	}
+}
+
+func TestClosedPRSuppressionKeepsMostRecentClose(t *testing.T) {
+	// Two closes for one fingerprint: the most recent (highest-numbered) wins.
+	s := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 4, Body: body("fp-dup"), Labels: []string{"runlore"}},
+		{Number: 11, Body: body("fp-dup"), Labels: []string{"runlore", "wontfix"}},
+	}}}
+	got, _ := s.Suppressed(context.Background())
+	if got["fp-dup"].PRNumber != 11 || got["fp-dup"].Reason != "wontfix" {
+		t.Fatalf("entry = %+v, want PR 11 wontfix", got["fp-dup"])
+	}
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -166,7 +166,12 @@ type rawIssue struct {
 	Labels    []struct {
 		Name string `json:"name"`
 	} `json:"labels"`
-	PullRequest *struct{} `json:"pull_request"`
+	// PullRequest is non-nil on PRs. MergedAt is null for a closed-but-unmerged PR
+	// (a rejected KB entry) and set once it merges (an accepted one), letting the
+	// closed-unmerged listing tell a human "no" from a human "yes".
+	PullRequest *struct {
+		MergedAt *time.Time `json:"merged_at"`
+	} `json:"pull_request"`
 }
 
 func (ri rawIssue) curated() providers.CuratedIssue {
@@ -177,14 +182,15 @@ func (ri rawIssue) curated() providers.CuratedIssue {
 	return providers.CuratedIssue{Number: ri.Number, Title: ri.Title, Body: ri.Body, Labels: labels, UpdatedAt: ri.UpdatedAt}
 }
 
-// listIssues fetches ALL pages of open issues+PRs carrying the label. GitHub caps
-// a page at 100 and paginates the rest; without this loop the curate passes would
-// be blind to everything past the first 100 (silent truncation on a sizable KB).
-func (c *Client) listIssues(ctx context.Context, label string) ([]rawIssue, error) {
+// listIssues fetches ALL pages of issues+PRs carrying the label in the given state
+// ("open" or "closed"). GitHub caps a page at 100 and paginates the rest; without
+// this loop the curate passes would be blind to everything past the first 100 (silent
+// truncation on a sizable KB).
+func (c *Client) listIssues(ctx context.Context, state, label string) ([]rawIssue, error) {
 	var all []rawIssue
 	for page := 1; ; page++ {
 		var raw []rawIssue
-		path := fmt.Sprintf("/repos/%s/%s/issues?state=open&labels=%s&per_page=100&page=%d", c.owner, c.repo, url.QueryEscape(label), page)
+		path := fmt.Sprintf("/repos/%s/%s/issues?state=%s&labels=%s&per_page=100&page=%d", c.owner, c.repo, state, url.QueryEscape(label), page)
 		if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
 			return nil, err
 		}
@@ -199,7 +205,7 @@ func (c *Client) listIssues(ctx context.Context, label string) ([]rawIssue, erro
 // ListIssuesByLabel returns all open issues carrying the given label. Pull requests
 // (which the issues API also returns) are filtered out.
 func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
-	raw, err := c.listIssues(ctx, label)
+	raw, err := c.listIssues(ctx, "open", label)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +222,7 @@ func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]provide
 // ListPRsByLabel returns all open PRs carrying the given label — the inverse of
 // ListIssuesByLabel (keeps only entries with a pull_request object).
 func (c *Client) ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
-	raw, err := c.listIssues(ctx, label)
+	raw, err := c.listIssues(ctx, "open", label)
 	if err != nil {
 		return nil, err
 	}
@@ -224,6 +230,29 @@ func (c *Client) ListPRsByLabel(ctx context.Context, label string) ([]providers.
 	for _, ri := range raw {
 		if ri.PullRequest == nil {
 			continue // a plain issue, not a PR
+		}
+		out = append(out, ri.curated())
+	}
+	return out, nil
+}
+
+// ListClosedUnmergedPRsByLabel returns closed PRs carrying the label that were NOT
+// merged — the KB entries a human deliberately rejected. Merged PRs (accepted
+// entries) and plain closed issues are filtered out. It drives the curate
+// suppression set: a rejected entry that keeps recurring is escalated via a
+// knowledge-gap issue, never reopened.
+func (c *Client) ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+	raw, err := c.listIssues(ctx, "closed", label)
+	if err != nil {
+		return nil, err
+	}
+	var out []providers.CuratedIssue
+	for _, ri := range raw {
+		if ri.PullRequest == nil {
+			continue // a plain issue, not a PR
+		}
+		if ri.PullRequest.MergedAt != nil {
+			continue // merged: an accepted entry, not a rejection
 		}
 		out = append(out, ri.curated())
 	}

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -90,6 +90,34 @@ func TestListPRsByLabelParsesUpdatedAt(t *testing.T) {
 	}
 }
 
+func TestListClosedUnmergedPRsByLabel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/o/r/issues" || r.URL.Query().Get("state") != "closed" {
+			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		}
+		// a closed-unmerged PR (merged_at null), a merged PR (merged_at set → excluded),
+		// and a plain closed issue (no pull_request → excluded)
+		_, _ = w.Write([]byte(`[
+		  {"number":48,"title":"KB: A","body":"b","labels":[{"name":"runlore"},{"name":"not-kb-worthy"}],"pull_request":{"url":"x","merged_at":null}},
+		  {"number":50,"title":"KB: B","body":"b","labels":[{"name":"runlore"}],"pull_request":{"url":"y","merged_at":"2026-06-01T12:00:00Z"}},
+		  {"number":39,"title":"plain issue","body":"b","labels":[{"name":"runlore"}]}
+		]`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	prs, err := c.ListClosedUnmergedPRsByLabel(context.Background(), "runlore")
+	if err != nil {
+		t.Fatalf("ListClosedUnmergedPRsByLabel: %v", err)
+	}
+	if len(prs) != 1 || prs[0].Number != 48 {
+		t.Fatalf("want only the closed-unmerged PR #48, got %+v", prs)
+	}
+	if len(prs[0].Labels) != 2 || prs[0].Labels[1] != "not-kb-worthy" {
+		t.Fatalf("labels not parsed: %+v", prs[0].Labels)
+	}
+}
+
 func TestOpenPR(t *testing.T) {
 	var paths []string
 	mux := http.NewServeMux()


### PR DESCRIPTION
## What

When a human **closes an auto-drafted KB PR without merging**, that's a deliberate "not knowledge-base-worthy." RunLore now respects that decision: it **never reopens** the closed PR. Instead it suppresses the entry's `DupFingerprint`, keeps counting recurrences silently, and once they cross `curate.recurrence_threshold` **escalates via a knowledge-gap issue** that links the closed PR and cites the count — "closed unmerged but recurred N times, reconsider?".

This avoids zombie PRs that re-litigate a human "no" (the entries most likely to recur are exactly the benign/noisy ones humans reject) and sidesteps stale-branch/stale-diff problems on reopen.

## How

- `internal/curate/suppression.go` (new) — `ClosedPRSuppression` derives the suppression set on every run from the forge's **closed-unmerged** `runlore` PRs (no mutable store/watermark — mirrors Recurrence's idempotent, ledger-driven design). Each closed PR still carries the hidden `DupFingerprint` marker the drafter stamped, which is the join key. Captures the close reason (`wontfix` / `not-kb-worthy`); a `needs-work` close is treated as revise-and-resubmit and is **not** suppressed.
- `internal/curate/recurrence.go` — optional `SuppressionSource`. Suppressed episodes are counted per `DupFingerprint` (separately from the generic pattern count, so a rejected entry is escalated once, not doubly) and routed to a PR-linking escalation processed before the generic loop. Nil source ⇒ behaviour identical to before.
- `internal/forge/github/github.go` — `ListClosedUnmergedPRsByLabel` (`state=closed`, filters out `merged_at != null` = accepted entries); `listIssues` parametrised by state.
- Wired into `lore curate` (only when the outcome ledger is configured — same gate as before).
- Docs (`learning-loop.md`) + Helm `values.yaml` document the escalation.

Reuses the **existing** Recurrence pass, `gapTitlePrefix` idempotency guard, `OpenIssue` knowledge-gap path, and `recurrence_threshold` — no parallel machinery.

## Notes

- The optional **`needs-work → open a fresh PR referencing the old`** arm is **not** implemented: the curate agent is forge-only and lacks the curator/investigation content needed to re-draft. `needs-work` closes fall through to generic recurrence instead. Flagged as a deliberate scope boundary.
- Suppression relies on the closed PR carrying the fingerprint marker (all curator-drafted PRs do); markerless legacy closes are skipped by design.
- Reason-label vocabulary (`needs-work` / `wontfix` / `not-kb-worthy`) is hardcoded constants consistent with existing `protectedLabels` / `lifecycleLabels`; no new config field.

## Tests

11 new tests across suppression, recurrence, and forge — including "escalates at threshold linking the closed PR with **zero** closes/no reopen", below-threshold-silent, not-double-counted, idempotent re-run, and merged/plain-issue exclusion. Full `go test ./...`, `gofmt`, `go vet`, `golangci-lint` all green.

Closes #222
