### PR TITLE
fix(curator): cap drafted KB entry title at ≤120 chars

### DIFF
--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -59,8 +59,11 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 
 	typ := entryType(inv)
 	return providers.KBEntry{
-		Type:        typ,
-		Title:       inv.Title,
+		Type: typ,
+		// Cap the free-form investigation title to kbvalidate's merge gate: a single
+		// line of ≤120 bytes. inv.Title is LLM/alert-derived and can run long or carry
+		// newlines, which would fail RunLore's own `lore validate-kb` hard checks.
+		Title:       capTitle(inv.Title),
 		Description: firstLine(inv),
 		Resource:    inv.Resource.Ref(),
 		Tags:        []string{"runlore", strings.ToLower(typ)}, // type-aligned tag (incident | playbook)
@@ -95,6 +98,47 @@ func entryType(inv providers.Investigation) string {
 		return "Playbook"
 	}
 	return "Incident"
+}
+
+// titleMaxBytes is kbvalidate's hard title limit: `len(e.Title) > 120` is a merge
+// gate error, measured in BYTES (Go `len` on a string), not runes.
+const titleMaxBytes = 120
+
+// ellipsis marks a truncated title; "…" (U+2026) is 3 bytes in UTF-8.
+const ellipsis = "…"
+
+// capTitle makes an arbitrary investigation title satisfy kbvalidate's title
+// merge gate by construction: a single line of at most titleMaxBytes bytes. It
+// collapses every whitespace run (newlines/tabs included) into a single space
+// and trims, then — if the result still exceeds the byte budget — truncates on a
+// rune boundary (preferring the last word boundary) and appends an ellipsis so
+// the FINAL byte length stays ≤ titleMaxBytes. Empty/whitespace-only input yields
+// "" so we never invent a title (the validator flags the empty title separately).
+func capTitle(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) <= titleMaxBytes {
+		return s
+	}
+
+	// Reserve room for the ellipsis; keep the prefix ≤ budget bytes.
+	budget := titleMaxBytes - len(ellipsis)
+
+	// Truncate on a rune boundary so we never split a multibyte rune.
+	cut := 0
+	for i := range s {
+		if i > budget {
+			break
+		}
+		cut = i
+	}
+	prefix := s[:cut]
+
+	// Prefer trimming back to the last space so we don't end mid-word; fall back
+	// to the hard rune-boundary cut when there's no reasonable space.
+	if sp := strings.LastIndexByte(prefix, ' '); sp > 0 {
+		prefix = prefix[:sp]
+	}
+	return strings.TrimRight(prefix, " ") + ellipsis
 }
 
 func firstLine(inv providers.Investigation) string {

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -3,7 +3,10 @@ package curator
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/kbvalidate"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -108,6 +111,101 @@ func TestDraftKBEntrySetsFingerprint(t *testing.T) {
 	}
 	if got := draftKBEntry(inv).Fingerprint; got != DupFingerprint(inv) {
 		t.Fatalf("drafted entry fingerprint = %q, want %q", got, DupFingerprint(inv))
+	}
+}
+
+// TestDraftKBEntryCapsLongTitle proves a free-form investigation title that runs
+// past kbvalidate's 120-byte single-line merge gate is capped by construction:
+// single line, ≤120 bytes, ellipsis-terminated, and structurally valid.
+func TestDraftKBEntryCapsLongTitle(t *testing.T) {
+	long := "Harbor registry is completely down across every environment because the IAM AccessKeysPerUser quota was exceeded and the credential secret could not be provisioned"
+	if len(long) <= 120 {
+		t.Fatalf("test fixture must exceed 120 bytes, got %d", len(long))
+	}
+	inv := providers.Investigation{
+		Title:      long,
+		Confidence: 0.9,
+		Resource:   providers.Workload{Namespace: "tooling", Name: "harbor-core"},
+		RootCauses: []providers.Hypothesis{{Summary: "IAM quota exceeded", Evidence: []string{"e"}, SuggestedAction: "delete an old key"}},
+	}
+	e := draftKBEntry(inv)
+	if got := len(e.Title); got > 120 {
+		t.Fatalf("title byte length = %d, want <= 120: %q", got, e.Title)
+	}
+	if strings.ContainsAny(e.Title, "\r\n") {
+		t.Fatalf("title must be a single line: %q", e.Title)
+	}
+	if !strings.HasSuffix(e.Title, "…") {
+		t.Fatalf("capped title should end with an ellipsis: %q", e.Title)
+	}
+	if !utf8.ValidString(e.Title) {
+		t.Fatalf("capped title must remain valid UTF-8: %q", e.Title)
+	}
+	// The drafted entry must clear the title field of the structural merge gate.
+	for _, iss := range kbvalidate.ValidateStructural(toCatalogEntry(e)) {
+		if iss.Field == "title" && iss.Severity == kbvalidate.SeverityError {
+			t.Fatalf("drafted title failed the merge gate: %s", iss.Message)
+		}
+	}
+}
+
+// TestDraftKBEntryCollapsesNewlinesInTitle proves an embedded newline (which the
+// validator rejects as a hard error) is collapsed to a single line.
+func TestDraftKBEntryCollapsesNewlinesInTitle(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "Harbor down\nsecond line\ttabbed",
+		RootCauses: []providers.Hypothesis{{Summary: "s"}},
+	}
+	e := draftKBEntry(inv)
+	if strings.ContainsAny(e.Title, "\r\n\t") {
+		t.Fatalf("title must be collapsed to a single line: %q", e.Title)
+	}
+	if e.Title != "Harbor down second line tabbed" {
+		t.Fatalf("title = %q, want collapsed single-space form", e.Title)
+	}
+}
+
+// TestDraftKBEntryShortTitleUnchanged proves a within-limit title is passed
+// through untouched.
+func TestDraftKBEntryShortTitleUnchanged(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		RootCauses: []providers.Hypothesis{{Summary: "s"}},
+	}
+	if e := draftKBEntry(inv); e.Title != "HarborRegistryDown" {
+		t.Fatalf("short title = %q, want it unchanged", e.Title)
+	}
+}
+
+// TestDraftKBEntryMultibyteTitleNotCorrupted proves capping a title full of
+// multibyte runes never cuts mid-rune (the result stays valid UTF-8 and ≤120
+// bytes).
+func TestDraftKBEntryMultibyteTitleNotCorrupted(t *testing.T) {
+	// Each "é" is 2 bytes; a long run of them pushes well past 120 bytes.
+	long := strings.Repeat("café éclair ", 20)
+	inv := providers.Investigation{
+		Title:      long,
+		RootCauses: []providers.Hypothesis{{Summary: "s"}},
+	}
+	e := draftKBEntry(inv)
+	if len(e.Title) > 120 {
+		t.Fatalf("title byte length = %d, want <= 120", len(e.Title))
+	}
+	if !utf8.ValidString(e.Title) {
+		t.Fatalf("capped multibyte title must remain valid UTF-8: %q", e.Title)
+	}
+}
+
+// toCatalogEntry mirrors a drafted KBEntry into the catalog.Entry shape that
+// kbvalidate.ValidateStructural consumes, so tests can run the real merge gate.
+func toCatalogEntry(e providers.KBEntry) catalog.Entry {
+	return catalog.Entry{
+		Type:        e.Type,
+		Title:       e.Title,
+		Description: e.Description,
+		Resource:    e.Resource,
+		Tags:        e.Tags,
+		Body:        e.Body,
 	}
 }
 


### PR DESCRIPTION
## Root cause

`curator.draftKBEntry` copied `inv.Title` verbatim into the KB entry's `title`
frontmatter. That title is free-form and LLM/alert-derived, so it can run past
kbvalidate's hard limits:

- `len(e.Title) > 120` (a **byte**-length check) → error
- title containing `\r`/`\n` → error (must be a single line)

The result: the curator could draft entries that fail RunLore's own
`lore validate-kb` merge gate.

## Fix

A self-contained, deterministic cap at the source (`draftKBEntry` is a pure
function with no model access, so no client is plumbed through). New
`capTitle(s string) string` helper:

1. Collapses every whitespace run (newlines/tabs included) into single spaces
   and trims — guarantees a single line.
2. Returns as-is when the byte length is ≤120.
3. Otherwise truncates on a **rune boundary** (never mid multibyte rune),
   preferring the last word boundary, then appends a 3-byte `…` so the final
   byte length stays ≤120.
4. Empty/whitespace-only input stays empty — we never invent a title (the
   validator flags the empty title separately, which is correct).

Full detail already lives in the entry `description`/`body`, so capping the
title loses nothing.

## Tests (TDD)

Added to `internal/curator/draft_test.go`, written failing first: long
multi-word title capped to ≤120 bytes ending in `…` and passing the real
`kbvalidate.ValidateStructural` title check; embedded newlines collapsed;
short title unchanged; multibyte-rune title near the boundary stays valid
UTF-8 and uncorrupted.

The validator and all unrelated code are untouched.

Closes #227