### PR TITLE
perf(curate): fetch closed-unmerged KB PRs via GitHub Search API

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -202,6 +202,32 @@ func (c *Client) listIssues(ctx context.Context, state, label string) ([]rawIssu
 	return all, nil
 }
 
+// searchIssues fetches ALL pages of the GitHub Search API for the given query,
+// decoding the {total_count, items} envelope. Unlike listIssues (core REST issues
+// endpoint), the query is applied server-side, so the response is bounded by the
+// matching set rather than the whole label history. Search caps total results at
+// 1000 — fine for the curate suppression set. The Search API has a stricter rate
+// limit (30 req/min authenticated), so pagination stays tight: it stops on the
+// first non-full page (a full page is exactly 100).
+func (c *Client) searchIssues(ctx context.Context, query string) ([]rawIssue, error) {
+	var all []rawIssue
+	for page := 1; ; page++ {
+		var env struct {
+			TotalCount int        `json:"total_count"`
+			Items      []rawIssue `json:"items"`
+		}
+		path := fmt.Sprintf("/search/issues?q=%s&per_page=100&page=%d", url.QueryEscape(query), page)
+		if err := c.do(ctx, http.MethodGet, path, nil, &env); err != nil {
+			return nil, err
+		}
+		all = append(all, env.Items...)
+		if len(env.Items) < 100 || len(all) >= env.TotalCount { // last page (a full page is exactly 100)
+			break
+		}
+	}
+	return all, nil
+}
+
 // ListIssuesByLabel returns all open issues carrying the given label. Pull requests
 // (which the issues API also returns) are filtered out.
 func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
@@ -237,12 +263,20 @@ func (c *Client) ListPRsByLabel(ctx context.Context, label string) ([]providers.
 }
 
 // ListClosedUnmergedPRsByLabel returns closed PRs carrying the label that were NOT
-// merged — the KB entries a human deliberately rejected. Merged PRs (accepted
-// entries) and plain closed issues are filtered out. It drives the curate
+// merged — the KB entries a human deliberately rejected. It drives the curate
 // suppression set: a rejected entry that keeps recurring is escalated via a
 // knowledge-gap issue, never reopened.
+//
+// It queries the GitHub Search API (is:pr is:closed is:unmerged) so merged PRs are
+// filtered out server-side. The plain closed-issues endpoint returns every merged
+// AND unmerged KB PR ever, and the closed set only grows: over time the merged
+// entries (which we discard) dominate, so each curate run would download and decode
+// the entire KB PR history to keep a handful of rejections. The search keeps the
+// response bounded by the closed-unmerged set. The MergedAt filter below is retained
+// as a correctness backstop should the query ever be loosened.
 func (c *Client) ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
-	raw, err := c.listIssues(ctx, "closed", label)
+	query := fmt.Sprintf("repo:%s/%s is:pr is:closed is:unmerged label:%s", c.owner, c.repo, label)
+	raw, err := c.searchIssues(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -92,16 +92,24 @@ func TestListPRsByLabelParsesUpdatedAt(t *testing.T) {
 
 func TestListClosedUnmergedPRsByLabel(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/o/r/issues" || r.URL.Query().Get("state") != "closed" {
-			t.Fatalf("unexpected request: %s?%s", r.URL.Path, r.URL.RawQuery)
+		// Now driven by the Search API, which filters merged PRs out server-side.
+		q := r.URL.Query().Get("q")
+		if r.URL.Path != "/search/issues" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
-		// a closed-unmerged PR (merged_at null), a merged PR (merged_at set → excluded),
-		// and a plain closed issue (no pull_request → excluded)
-		_, _ = w.Write([]byte(`[
+		for _, want := range []string{"repo:o/r", "is:pr", "is:closed", "is:unmerged", "label:runlore"} {
+			if !strings.Contains(q, want) {
+				t.Fatalf("query %q missing qualifier %q", q, want)
+			}
+		}
+		// Search-API envelope. A closed-unmerged PR (merged_at null) that must be
+		// returned, a merged PR (merged_at set → excluded by the MergedAt backstop),
+		// and a plain issue (no pull_request → excluded).
+		_, _ = w.Write([]byte(`{"total_count":1,"items":[
 		  {"number":48,"title":"KB: A","body":"b","labels":[{"name":"runlore"},{"name":"not-kb-worthy"}],"pull_request":{"url":"x","merged_at":null}},
 		  {"number":50,"title":"KB: B","body":"b","labels":[{"name":"runlore"}],"pull_request":{"url":"y","merged_at":"2026-06-01T12:00:00Z"}},
 		  {"number":39,"title":"plain issue","body":"b","labels":[{"name":"runlore"}]}
-		]`))
+		]}`))
 	}))
 	defer srv.Close()
 
@@ -115,6 +123,36 @@ func TestListClosedUnmergedPRsByLabel(t *testing.T) {
 	}
 	if len(prs[0].Labels) != 2 || prs[0].Labels[1] != "not-kb-worthy" {
 		t.Fatalf("labels not parsed: %+v", prs[0].Labels)
+	}
+}
+
+func TestListClosedUnmergedPRsByLabelPaginates(t *testing.T) {
+	// page 1 returns a full page (100) → the client must fetch page 2 for the rest.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/issues" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			items := make([]string, 100)
+			for i := range items {
+				items[i] = fmt.Sprintf(`{"number":%d,"title":"KB: t%d","labels":[{"name":"runlore"}],"pull_request":{"merged_at":null}}`, i+1, i+1)
+			}
+			_, _ = w.Write([]byte(`{"total_count":101,"items":[` + strings.Join(items, ",") + `]}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"total_count":101,"items":[{"number":101,"title":"KB: t101","labels":[{"name":"runlore"}],"pull_request":{"merged_at":null}}]}`))
+		default:
+			_, _ = w.Write([]byte(`{"total_count":101,"items":[]}`))
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	prs, err := c.ListClosedUnmergedPRsByLabel(context.Background(), "runlore")
+	if err != nil {
+		t.Fatalf("ListClosedUnmergedPRsByLabel: %v", err)
+	}
+	if len(prs) != 101 {
+		t.Fatalf("want 101 PRs across 2 pages (no truncation at 100), got %d", len(prs))
 	}
 }
 


### PR DESCRIPTION
## Problem

`ListClosedUnmergedPRsByLabel` drives the curate suppression set — the closed-but-unmerged KB PRs a human deliberately rejected. It fetched **every** closed KB PR from the core REST issues endpoint (`GET /repos/{o}/{r}/issues?state=closed&labels=runlore`, paginated 100/page across all pages), then discarded the merged ones client-side via `MergedAt != nil`.

The closed set only ever grows: every accepted (merged) and rejected (unmerged) KB PR accumulates forever, and the merged entries — which get thrown away — dominate over time. So each `lore curate` run downloaded and JSON-decoded the entire KB PR history just to keep a handful of unmerged rejections. Cost grew **linearly and unboundedly** with total merged KB PR count.

## Fix

Query the GitHub Search API instead, filtering merged PRs out **server-side**:

```
GET /search/issues?q=repo:{o}/{r}+is:pr+is:closed+is:unmerged+label:{label}
```

The response is now bounded by the closed-unmerged set rather than the whole label history.

- New private helper `searchIssues(ctx, query)` hits `/search/issues`, decodes the `{total_count, items}` envelope, and paginates (`per_page=100`, breaking on the first non-full page or once `total_count` items are collected). `items` are the same `rawIssue` shape already parsed, mapped through the existing `rawIssue.curated()`.
- The `q` value is `url.QueryEscape`d (it carries spaces/colons).
- The existing `MergedAt`/`PullRequest == nil` filters are **retained as a correctness backstop** should the query ever be loosened.
- `listIssues`, `ListIssuesByLabel`, and `ListPRsByLabel` are untouched — they're bounded by the open backlog and stay on the plain issues endpoint.

Caller behavior is unchanged: same return type, same filtering result — only the fetch mechanism changes. The Search API's stricter rate limit (30 req/min) is respected by keeping pagination tight.

## Tests

- Updated `TestListClosedUnmergedPRsByLabel` to assert the request now hits `/search/issues` with the expected `q` qualifiers, returns a Search-envelope payload, and still excludes a merged PR (proving the backstop) and a plain issue while returning only the closed-unmerged PR #48.
- Added `TestListClosedUnmergedPRsByLabelPaginates` covering two full pages of search results.

Closes #225
