### PR TITLE
feat(kb): strict OKF entries, deterministic dedup, self-describing bundle

### DIFF
--- a/docs/reviewing-knowledge.md
+++ b/docs/reviewing-knowledge.md
@@ -30,7 +30,9 @@ Two things happen when an investigation produces a confident, verified finding:
 ## 2. Anatomy of a proposed entry
 
 Every PR adds one Markdown file (an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
-entry). Here is a real one RunLore opened for an OOMKilled pod:
+entry) under a type directory — `incidents/kubecontaineroomkilled-for-oom-app-pod-a3938440.md`
+(title slug + a short fingerprint, so two incidents sharing a title never collide).
+Here is a real one RunLore opened for an OOMKilled pod:
 
 ```markdown
 ---
@@ -38,8 +40,11 @@ type: Incident
 title: KubeContainerOOMKilled for oom-app pod
 description: The container 'hog' is OOMKilled because its memory limit (100Mi) is too low.
 resource: runlore-test/oom-app
-tags: [runlore, incident]
-fingerprint: a393844afec8e3d1…           # deterministic identity (resource + cause)
+tags: [runlore, incident, pod, runlore-test]  # + workload kind & namespace — recall signal
+timestamp: "2026-07-03T09:14:00Z"             # OKF-recommended last-change stamp
+fingerprint: a393844afec8e3d1…                # deterministic identity (resource + cause)
+confidence: 0.9                               # queryable extension fields (OKF: frontmatter
+provenance: [flux/oom-app-values]             #   is for what you filter/index on)
 ---
 
 ## Decision
@@ -48,6 +53,8 @@ fingerprint: a393844afec8e3d1…           # deterministic identity (resource + 
 
 ## Symptom
 KubeContainerOOMKilled for oom-app pod
+
+Affected resource: Pod runlore-test/oom-app
 
 ## Investigate                              # the evidence trail (what it observed)
 - pod_status: hog OOMKilled (exit 137); memory limit 100Mi …
@@ -60,10 +67,17 @@ KubeContainerOOMKilled for oom-app pod
 
 ## Unresolved                               # what it honestly couldn't determine
 - (none)
+
+## Citations                                # OKF §8: the causing-change provenance
+[1] flux/oom-app-values
 ```
 
 The **Decision card** makes the merge call quick; the **sections** make the entry
 reusable knowledge for the next person (and for RunLore's instant recall).
+
+The same PR also keeps the OKF bundle self-describing: the entry's link line is
+added to your `index.md` (when the bundle has one) and a `**Creation**` record is
+appended to `log.md` — all in the one diff you review.
 
 ---
 

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -139,6 +139,25 @@ func (c *Catalog) Entries() []Entry {
 	return out
 }
 
+// FindFingerprint returns the entry whose frontmatter fingerprint equals fp —
+// the exact-identity lookup behind the curator's deterministic catalog dedup
+// (curated entries persist their DupFingerprint; see forge renderEntry). An empty
+// fp never matches: hand-written entries carry no fingerprint, and "" means
+// "nothing to key on".
+func (c *Catalog) FindFingerprint(fp string) (Entry, bool) {
+	if fp == "" {
+		return Entry{}, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, e := range c.entries {
+		if e.Fingerprint == fp {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
 // Ready reports whether the catalog has completed at least one successful load.
 // It stays false for a git-sync catalog (NewEmpty) until the first sync indexes,
 // so readyz can keep the leader out of rotation until its KB is warm.

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -197,3 +197,42 @@ func TestStaticCatalogReadyOnLoad(t *testing.T) {
 		t.Fatal("a static-dir catalog must be ready immediately after New")
 	}
 }
+
+// TestFindFingerprint: curated entries persist their DupFingerprint in
+// frontmatter; the catalog must answer exact-identity lookups on it so the
+// curator can dedup deterministically instead of relying on a BM25 threshold.
+func TestFindFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "curated.md", `---
+type: Incident
+title: Harbor down
+description: valkey down
+resource: tooling/harbor-core
+fingerprint: deadbeefcafebabe
+---
+body
+`)
+	writeEntry(t, dir, "hand-written.md", `---
+type: Playbook
+title: No fingerprint here
+description: hand-authored
+---
+body
+`)
+	c, err := New(dir)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	e, ok := c.FindFingerprint("deadbeefcafebabe")
+	if !ok || e.Title != "Harbor down" {
+		t.Fatalf("want the curated entry, got ok=%v e=%+v", ok, e)
+	}
+	if _, ok := c.FindFingerprint("0000000000000000"); ok {
+		t.Fatal("unknown fingerprint must not match")
+	}
+	// An empty fingerprint must never match anything — hand-written entries have
+	// no fingerprint field, and an empty query is "nothing to key on".
+	if _, ok := c.FindFingerprint(""); ok {
+		t.Fatal("empty fingerprint must never match")
+	}
+}

--- a/internal/catalog/entry.go
+++ b/internal/catalog/entry.go
@@ -9,6 +9,8 @@ type Entry struct {
 	Description string   // frontmatter: description
 	Resource    string   // frontmatter: resource
 	Tags        []string // frontmatter: tags
+	Timestamp   string   // frontmatter: timestamp (OKF-recommended, RFC3339; "" when absent)
+	Fingerprint string   // frontmatter: fingerprint (curator.DupFingerprint identity; "" on hand-written entries)
 	Body        string   // markdown body (after frontmatter)
 	Path        string   // file path relative to the bundle root
 }

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -63,6 +63,8 @@ func parseEntry(root, path string) (Entry, error) {
 		Description string   `yaml:"description"`
 		Resource    string   `yaml:"resource"`
 		Tags        []string `yaml:"tags"`
+		Timestamp   string   `yaml:"timestamp"`
+		Fingerprint string   `yaml:"fingerprint"`
 	}
 	if len(fm) > 0 {
 		if err := yaml.Unmarshal(fm, &meta); err != nil {
@@ -72,7 +74,9 @@ func parseEntry(root, path string) (Entry, error) {
 	rel, _ := filepath.Rel(root, path)
 	return Entry{
 		Type: meta.Type, Title: meta.Title, Description: meta.Description,
-		Resource: meta.Resource, Tags: meta.Tags, Body: string(body), Path: rel,
+		Resource: meta.Resource, Tags: meta.Tags,
+		Timestamp: meta.Timestamp, Fingerprint: meta.Fingerprint,
+		Body: string(body), Path: rel,
 	}, nil
 }
 

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -43,6 +43,58 @@ Ready=False after a chart bump.
 	}
 }
 
+// TestLoadParsesTimestampAndFingerprint: curated entries carry a timestamp
+// (OKF-recommended) and a deterministic dedup fingerprint in frontmatter — both
+// written by the forge serializer and consumed back here (recency-aware ranking,
+// exact-identity catalog dedup).
+func TestLoadParsesTimestampAndFingerprint(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "curated.md", `---
+type: Incident
+title: Harbor down
+description: valkey down
+resource: tooling/harbor-core
+timestamp: "2026-06-20T00:00:00Z"
+fingerprint: deadbeefcafebabe
+---
+body
+`)
+	entries, _, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Timestamp != "2026-06-20T00:00:00Z" {
+		t.Fatalf("Timestamp = %q, want 2026-06-20T00:00:00Z", e.Timestamp)
+	}
+	if e.Fingerprint != "deadbeefcafebabe" {
+		t.Fatalf("Fingerprint = %q, want deadbeefcafebabe", e.Fingerprint)
+	}
+
+	// Seed entries write the timestamp unquoted (a YAML !!timestamp scalar); it
+	// must still land in the string field rather than failing the parse.
+	writeEntry(t, dir, "seed.md", `---
+type: Playbook
+title: Seed
+description: seed entry
+timestamp: 2026-06-20T00:00:00Z
+---
+body
+`)
+	entries, skipped, err := Load(dir)
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("Load with unquoted timestamp: err=%v skipped=%v", err, skipped)
+	}
+	for _, e := range entries {
+		if e.Title == "Seed" && e.Timestamp != "2026-06-20T00:00:00Z" {
+			t.Fatalf("unquoted Timestamp = %q, want 2026-06-20T00:00:00Z", e.Timestamp)
+		}
+	}
+}
+
 func TestLoadSkipsMalformedEntry(t *testing.T) {
 	dir := t.TempDir()
 	writeEntry(t, dir, "good.md", "---\ntype: Playbook\ntitle: Good\ndescription: fine\n---\nbody\n")

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -50,7 +50,15 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 		return providers.Ref{}, nil
 	}
 
-	// 2. dedup — catalog (observe the top-hit score on every check), then open PRs
+	// 2. dedup — catalog exact fingerprint first (deterministic identity, no
+	// threshold to tune), then catalog BM25 (observe the top-hit score on every
+	// check), then open PRs
+	if ff, ok := c.Catalog.(fingerprintFinder); ok {
+		if e, found := ff.FindFingerprint(DupFingerprint(inv)); found {
+			c.Log.Info("finding matches a catalog entry's fingerprint; not filing", "entry", e.Title, "path", e.Path)
+			return providers.Ref{}, nil
+		}
+	}
 	nov := Novelty{Catalog: c.Catalog, DupScore: c.DupScore}
 	if top, ok, err := nov.TopHit(ctx, inv); err != nil {
 		c.Log.Warn("dedup: catalog search failed", "err", err)
@@ -85,6 +93,14 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 	c.Log.Info("curated as PR", "url", ref.URL, "confidence", inv.Confidence)
 	c.recordCuration(ctx, "pr", "opened")
 	return ref, nil
+}
+
+// fingerprintFinder is the optional exact-identity dedup surface of the catalog
+// (implemented by *catalog.Catalog). Kept an optional type-assert — like
+// providers.GitOpsInspector — so ScoredSearcher fakes and remote indexes without
+// fingerprint support keep working unchanged.
+type fingerprintFinder interface {
+	FindFingerprint(fp string) (catalog.Entry, bool)
 }
 
 // recordCuration increments the curations_total counter (nil-safe). kind is the

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -156,6 +156,38 @@ func TestCurateCatalogDuplicateDropsSilently(t *testing.T) {
 	}
 }
 
+// fakeFingerprinted is a catalog fake with NO BM25 hits but an exact fingerprint
+// match — proving the deterministic dedup path is independent of the BM25
+// threshold.
+type fakeFingerprinted struct {
+	fakeScored
+	fp string
+}
+
+func (f fakeFingerprinted) FindFingerprint(fp string) (catalog.Entry, bool) {
+	if fp != "" && fp == f.fp {
+		return catalog.Entry{Title: "already merged", Fingerprint: fp}, true
+	}
+	return catalog.Entry{}, false
+}
+
+func TestCurateCatalogFingerprintMatchDropsSilently(t *testing.T) {
+	// The same incident was already merged into the catalog (its persisted
+	// fingerprint matches) even though BM25 returns nothing → drop without filing
+	// or commenting, exactly like the score-threshold duplicate path.
+	inv := goodFinding()
+	inv.Resource = providers.Workload{Namespace: "apps", Name: "web"}
+	f := &fakeForge{}
+	cat := fakeFingerprinted{fp: DupFingerprint(inv)}
+	ref, err := newCurator(f, cat).Curate(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.openedPR != nil || len(f.commented) != 0 || ref.URL != "" {
+		t.Fatalf("catalog fingerprint duplicate must drop silently, got pr=%+v comment=%v ref=%s", f.openedPR, f.commented, ref.URL)
+	}
+}
+
 func TestCurateCatalogErrorFallsThroughToPR(t *testing.T) {
 	// A catalog search error must NOT block curation: it logs a warning and falls
 	// through (fail-open) to the open-PR dedup + quality gate. With no matching open

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -14,16 +14,27 @@ import (
 func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 	var b strings.Builder
 
+	refs := changeRefs(inv)
+
 	// --- decision card ---
 	fmt.Fprintf(&b, "## Decision\n\n")
 	fmt.Fprintf(&b, "- **why keep:** %s\n", firstLine(inv))
 	fmt.Fprintf(&b, "- **confidence:** %.0f%%\n", inv.Confidence*100)
-	if cr := changeRefs(inv); cr != "" {
-		fmt.Fprintf(&b, "- **provenance:** %s\n", cr)
+	if len(refs) > 0 {
+		fmt.Fprintf(&b, "- **provenance:** %s\n", strings.Join(refs, ", "))
 	}
 
 	// --- Symptom ---
 	fmt.Fprintf(&b, "\n## Symptom\n\n%s\n", inv.Title)
+	if ref := inv.Resource.Ref(); ref != "" {
+		// Name the affected workload: what a future reader checks first, and lexical
+		// recall signal in the indexed body (the kind appears nowhere else).
+		if inv.Resource.Kind != "" {
+			fmt.Fprintf(&b, "\nAffected resource: %s %s\n", inv.Resource.Kind, ref)
+		} else {
+			fmt.Fprintf(&b, "\nAffected resource: %s\n", ref)
+		}
+	}
 
 	// --- Investigate (evidence trail) ---
 	b.WriteString("\n## Investigate\n\n")
@@ -57,15 +68,25 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 		}
 	}
 
+	// --- Citations (OKF §8: numbered references at the document bottom) ---
+	if len(refs) > 0 {
+		b.WriteString("\n## Citations\n\n")
+		for i, r := range refs {
+			fmt.Fprintf(&b, "[%d] %s\n", i+1, r)
+		}
+	}
+
 	typ := entryType(inv)
 	return providers.KBEntry{
 		Type:        typ,
 		Title:       inv.Title,
 		Description: firstLine(inv),
 		Resource:    inv.Resource.Ref(),
-		Tags:        []string{"runlore", strings.ToLower(typ)}, // type-aligned tag (incident | playbook)
+		Tags:        entryTags(inv, typ),
 		Body:        b.String(),
 		Fingerprint: DupFingerprint(inv),
+		Confidence:  inv.Confidence,
+		Provenance:  refs,
 	}
 }
 
@@ -97,6 +118,22 @@ func entryType(inv providers.Investigation) string {
 	return "Incident"
 }
 
+// entryTags derives the entry's tags: the constant runlore + type pair plus the
+// workload kind and namespace. Tags feed the catalog's BM25+embedding corpus
+// (catalog.entryText), so each derived tag is recall signal the constant pair
+// can't provide. Empties are dropped and duplicates collapsed.
+func entryTags(inv providers.Investigation, typ string) []string {
+	tags := []string{"runlore", strings.ToLower(typ)}
+	seen := map[string]bool{tags[0]: true, tags[1]: true}
+	for _, t := range []string{strings.ToLower(inv.Resource.Kind), inv.Resource.Namespace} {
+		if t != "" && !seen[t] {
+			seen[t] = true
+			tags = append(tags, t)
+		}
+	}
+	return tags
+}
+
 func firstLine(inv providers.Investigation) string {
 	if len(inv.RootCauses) > 0 {
 		return inv.RootCauses[0].Summary
@@ -105,8 +142,9 @@ func firstLine(inv providers.Investigation) string {
 }
 
 // changeRefs collects the distinct change references cited across root causes
-// (the causing/fixing-change provenance the merge bar requires).
-func changeRefs(inv providers.Investigation) string {
+// (the causing/fixing-change provenance the merge bar requires). They feed the
+// decision card, the OKF Citations section, and the provenance frontmatter.
+func changeRefs(inv providers.Investigation) []string {
 	var refs []string
 	seen := map[string]bool{}
 	for _, rc := range inv.RootCauses {
@@ -115,5 +153,5 @@ func changeRefs(inv providers.Investigation) string {
 			refs = append(refs, rc.ChangeRef)
 		}
 	}
-	return strings.Join(refs, ", ")
+	return refs
 }

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -111,6 +111,109 @@ func TestDraftKBEntrySetsFingerprint(t *testing.T) {
 	}
 }
 
+// TestDraftKBEntryTagsCarryRecallSignal: tags feed the catalog's BM25+embedding
+// corpus (catalog.entryText), so the drafted entry must tag the workload kind and
+// namespace — not just the constant [runlore, <type>] pair, which ranks nothing.
+func TestDraftKBEntryTagsCarryRecallSignal(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "Harbor down", Confidence: 0.9,
+		Resource:   providers.Workload{Kind: "Deployment", Namespace: "tooling", Name: "harbor-core"},
+		RootCauses: []providers.Hypothesis{{Summary: "valkey down", Confidence: 0.9}},
+	}
+	tags := draftKBEntry(inv).Tags
+	for _, want := range []string{"runlore", "incident", "deployment", "tooling"} {
+		found := false
+		for _, tag := range tags {
+			if tag == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("tags missing %q: %v", want, tags)
+		}
+	}
+
+	// No resource → no empty/duplicate tags sneak in.
+	tags = draftKBEntry(providers.Investigation{
+		Title: "t", Confidence: 0.9,
+		RootCauses: []providers.Hypothesis{{Summary: "s", SuggestedAction: "a"}},
+	}).Tags
+	seen := map[string]bool{}
+	for _, tag := range tags {
+		if tag == "" {
+			t.Fatalf("empty tag in %v", tags)
+		}
+		if seen[tag] {
+			t.Fatalf("duplicate tag %q in %v", tag, tags)
+		}
+		seen[tag] = true
+	}
+}
+
+// TestDraftKBEntrySymptomNamesResource: the Symptom section must carry more than
+// a copy of the title — the affected workload (kind + ref) is both what a future
+// reader checks first and lexical recall signal in the indexed body.
+func TestDraftKBEntrySymptomNamesResource(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "Harbor down", Confidence: 0.9,
+		Resource:   providers.Workload{Kind: "Deployment", Namespace: "tooling", Name: "harbor-core"},
+		RootCauses: []providers.Hypothesis{{Summary: "valkey down", Confidence: 0.9}},
+	}
+	body := draftKBEntry(inv).Body
+	if !strings.Contains(body, "Deployment tooling/harbor-core") {
+		t.Fatalf("Symptom must name the affected resource:\n%s", body)
+	}
+}
+
+// TestDraftKBEntryCitations: change provenance belongs in an OKF Citations
+// section at the entry bottom (SPEC §8) — numbered references, one per distinct
+// ChangeRef — not only squeezed into the decision card bullet.
+func TestDraftKBEntryCitations(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "Harbor down", Confidence: 0.9, Verified: true,
+		RootCauses: []providers.Hypothesis{
+			{Summary: "quota", Evidence: []string{"e"}, ChangeRef: "crossplane/xplane-harbor"},
+			{Summary: "other", Evidence: []string{"e2"}, ChangeRef: "flux/harbor-values"},
+		},
+	}
+	body := draftKBEntry(inv).Body
+	i := strings.Index(body, "## Citations")
+	if i < 0 {
+		t.Fatalf("body missing ## Citations:\n%s", body)
+	}
+	tail := body[i:]
+	if !strings.Contains(tail, "[1] crossplane/xplane-harbor") || !strings.Contains(tail, "[2] flux/harbor-values") {
+		t.Fatalf("citations must number the distinct change refs:\n%s", tail)
+	}
+
+	// No change refs → no empty Citations section.
+	inv.RootCauses = []providers.Hypothesis{{Summary: "s", Evidence: []string{"e"}, SuggestedAction: "a"}}
+	if body := draftKBEntry(inv).Body; strings.Contains(body, "## Citations") {
+		t.Fatalf("no refs must mean no Citations section:\n%s", body)
+	}
+}
+
+// TestDraftKBEntrySetsConfidenceAndProvenance: OKF guidance is to put the fields
+// you want to query/filter on in frontmatter — confidence and change provenance
+// are exactly that, so the drafted KBEntry must carry them structurally (the
+// forge serializes them as extension frontmatter keys).
+func TestDraftKBEntrySetsConfidenceAndProvenance(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "Harbor down", Confidence: 0.9, Verified: true,
+		RootCauses: []providers.Hypothesis{
+			{Summary: "quota", Evidence: []string{"e"}, ChangeRef: "crossplane/xplane-harbor"},
+			{Summary: "quota again", Evidence: []string{"e"}, ChangeRef: "crossplane/xplane-harbor"}, // dup ref collapses
+		},
+	}
+	e := draftKBEntry(inv)
+	if e.Confidence != 0.9 {
+		t.Fatalf("Confidence = %v, want 0.9", e.Confidence)
+	}
+	if len(e.Provenance) != 1 || e.Provenance[0] != "crossplane/xplane-harbor" {
+		t.Fatalf("Provenance = %v, want [crossplane/xplane-harbor]", e.Provenance)
+	}
+}
+
 // TestDraftKBEntryExcludesCost proves the per-investigation cost/usage carrier
 // never leaks into the curated KB body — cost is a delivery-time concern for
 // humans, not durable knowledge.

--- a/internal/forge/github/bundle.go
+++ b/internal/forge/github/bundle.go
@@ -1,0 +1,165 @@
+package github
+
+// This file is OKF bundle maintenance: keep the reserved index.md / log.md files
+// in step with the entry a PR adds, so the bundle stays self-describing for every
+// OKF consumer (progressive-disclosure index, chronological change log) and the
+// reviewer sees the whole change in one diff.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// maintainBundle updates index.md (only when the bundle already has one — its
+// structure is the owner's choice) and creates/appends log.md (whose shape OKF §7
+// fully specifies) on the PR branch. Best-effort by contract: a failure here must
+// never lose the entry PR, so the caller ignores the returned error beyond logging.
+func (c *Client) maintainBundle(ctx context.Context, e providers.KBEntry, entryPath, branch string) error {
+	date := time.Now().UTC().Format("2006-01-02")
+
+	idx, idxSHA, found, err := c.getFile(ctx, "index.md", branch)
+	if err != nil {
+		return fmt.Errorf("read index.md: %w", err)
+	}
+	if found {
+		if err := c.putFile(ctx, "index.md", branch, idxSHA,
+			"runlore: index "+e.Title, updateIndex(idx, e, entryPath)); err != nil {
+			return err
+		}
+	}
+
+	logMD, logSHA, _, err := c.getFile(ctx, "log.md", branch)
+	if err != nil {
+		return fmt.Errorf("read log.md: %w", err)
+	}
+	return c.putFile(ctx, "log.md", branch, logSHA,
+		"runlore: log "+e.Title, updateLog(logMD, e, entryPath, date))
+}
+
+// updateIndex appends the entry's link line to its "## <Type>s" section of an
+// OKF index (creating the section at the end when absent). Links are relative to
+// the bundle root, matching the seed index style.
+func updateIndex(existing []byte, e providers.KBEntry, entryPath string) []byte {
+	section := "## " + e.Type + "s"
+	line := fmt.Sprintf("- [%s](%s) — %s", e.Title, entryPath, e.Description)
+
+	lines := strings.Split(strings.TrimRight(string(existing), "\n"), "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) == section {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		lines = append(lines, "", section, "", line)
+		return []byte(strings.Join(lines, "\n") + "\n")
+	}
+	// Insert at the section's end: just before the next heading, or at EOF.
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "#") {
+			end = i
+			break
+		}
+	}
+	// Trim the section's trailing blank lines so the new line joins the list.
+	for end > start+1 && strings.TrimSpace(lines[end-1]) == "" {
+		end--
+	}
+	out := append(append(append([]string{}, lines[:end]...), line), lines[end:]...)
+	return []byte(strings.Join(out, "\n") + "\n")
+}
+
+// updateLog records the entry in an OKF log: flat date-grouped entries, newest
+// first, bold action word (§7). A nil/empty existing log gets the standard shape.
+func updateLog(existing []byte, e providers.KBEntry, entryPath, date string) []byte {
+	heading := "## " + date
+	line := fmt.Sprintf("* **Creation**: Added [%s](%s).", e.Title, entryPath)
+
+	cur := strings.TrimRight(string(existing), "\n")
+	if strings.TrimSpace(cur) == "" {
+		return []byte("# Knowledge catalog update log\n\n" + heading + "\n\n" + line + "\n")
+	}
+	lines := strings.Split(cur, "\n")
+	for i, l := range lines {
+		if strings.TrimSpace(l) != heading {
+			continue
+		}
+		// Today's heading exists (it is the newest — logs are newest-first):
+		// slot the line right under it.
+		out := append(append(append([]string{}, lines[:i+1]...), "", line), lines[i+1:]...)
+		return []byte(strings.Join(out, "\n") + "\n")
+	}
+	// New (newest) date: insert the heading after the H1 title, before older dates.
+	at := len(lines)
+	for i, l := range lines {
+		if strings.HasPrefix(strings.TrimSpace(l), "## ") {
+			at = i
+			break
+		}
+	}
+	out := append(append(append([]string{}, lines[:at]...), heading, "", line, ""), lines[at:]...)
+	return []byte(strings.Join(out, "\n") + "\n")
+}
+
+// getFile reads a file's content + blob SHA at ref via the contents API.
+// A 404 is not an error: found=false says "the bundle doesn't have this file".
+func (c *Client) getFile(ctx context.Context, path, ref string) (data []byte, sha string, found bool, err error) {
+	tok, err := c.token(ctx)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("token: %w", err)
+	}
+	url := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s", c.baseURL, c.owner, c.repo, path, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, "", false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, "", false, nil
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, "", false, fmt.Errorf("github GET %s: status %d", path, resp.StatusCode)
+	}
+	var out struct {
+		SHA     string `json:"sha"`
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, "", false, err
+	}
+	// The contents API base64-wraps with newlines; the std decoder wants them gone.
+	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(out.Content, "\n", ""))
+	if err != nil {
+		return nil, "", false, err
+	}
+	return raw, out.SHA, true, nil
+}
+
+// putFile creates/updates a file on branch. sha is the current blob SHA when
+// updating ("" when creating).
+func (c *Client) putFile(ctx context.Context, path, branch, sha, message string, content []byte) error {
+	body := map[string]any{
+		"message": message,
+		"content": base64.StdEncoding.EncodeToString(content),
+		"branch":  branch,
+	}
+	if sha != "" {
+		body["sha"] = sha
+	}
+	return c.do(ctx, http.MethodPut, fmt.Sprintf("/repos/%s/%s/contents/%s", c.owner, c.repo, path), body, nil)
+}

--- a/internal/forge/github/bundle_test.go
+++ b/internal/forge/github/bundle_test.go
@@ -1,0 +1,181 @@
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func kbEntry() providers.KBEntry {
+	return providers.KBEntry{
+		Type: "Incident", Title: "Harbor down",
+		Description: "valkey down", Fingerprint: "deadbeefcafebabe",
+	}
+}
+
+func TestUpdateIndexAppendsToTypeSection(t *testing.T) {
+	existing := `---
+okf_version: "0.1"
+type: Index
+---
+# Catalog
+
+## Playbooks
+
+- [HelmRelease upgrade failure](playbooks/helmrelease.md)
+
+## Incidents
+
+- [Old incident](incidents/old.md)
+`
+	got := string(updateIndex([]byte(existing), kbEntry(), "incidents/harbor-down-deadbeef.md"))
+	want := "- [Harbor down](incidents/harbor-down-deadbeef.md) — valkey down"
+	if !strings.Contains(got, want) {
+		t.Fatalf("index missing %q:\n%s", want, got)
+	}
+	// The new line must land inside the Incidents section, not after Playbooks.
+	if strings.Index(got, want) < strings.Index(got, "## Incidents") {
+		t.Fatalf("entry landed outside its type section:\n%s", got)
+	}
+	// The existing Playbooks section must be untouched.
+	if !strings.Contains(got, "- [HelmRelease upgrade failure](playbooks/helmrelease.md)") {
+		t.Fatalf("existing sections must be preserved:\n%s", got)
+	}
+}
+
+func TestUpdateIndexCreatesMissingSection(t *testing.T) {
+	existing := "# Catalog\n\n## Playbooks\n\n- [P](p.md)\n"
+	got := string(updateIndex([]byte(existing), kbEntry(), "incidents/h.md"))
+	if !strings.Contains(got, "## Incidents") {
+		t.Fatalf("missing new ## Incidents section:\n%s", got)
+	}
+	if !strings.Contains(got, "- [Harbor down](incidents/h.md) — valkey down") {
+		t.Fatalf("missing entry line:\n%s", got)
+	}
+}
+
+func TestUpdateLogCreatesAndPrepends(t *testing.T) {
+	// No log yet → a fresh OKF log: H1 title, newest-first date heading, bold
+	// action word.
+	got := string(updateLog(nil, kbEntry(), "incidents/h.md", "2026-07-03"))
+	for _, want := range []string{"# ", "## 2026-07-03", "* **Creation**: Added [Harbor down](incidents/h.md)."} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("fresh log missing %q:\n%s", want, got)
+		}
+	}
+
+	// Existing log with an older date → the new date heading goes FIRST (newest
+	// first), older entries preserved below.
+	existing := "# Catalog update log\n\n## 2026-06-20\n\n* **Creation**: Added [Old](o.md).\n"
+	got = string(updateLog([]byte(existing), kbEntry(), "incidents/h.md", "2026-07-03"))
+	i, j := strings.Index(got, "## 2026-07-03"), strings.Index(got, "## 2026-06-20")
+	if i < 0 || j < 0 || i > j {
+		t.Fatalf("dates must be newest-first:\n%s", got)
+	}
+
+	// Same-day second entry → reuse the existing date heading, no duplicate.
+	got = string(updateLog([]byte(got), kbEntry(), "incidents/h2.md", "2026-07-03"))
+	if strings.Count(got, "## 2026-07-03") != 1 {
+		t.Fatalf("same-day entries must share one date heading:\n%s", got)
+	}
+	if !strings.Contains(got, "(incidents/h2.md)") {
+		t.Fatalf("second same-day entry missing:\n%s", got)
+	}
+}
+
+// TestOpenPRMaintainsBundleFiles: the PR keeps the OKF bundle self-describing —
+// index.md gains the new entry's link line (when an index exists) and log.md
+// gains a chronological record, both committed on the PR branch.
+func TestOpenPRMaintainsBundleFiles(t *testing.T) {
+	puts := map[string]string{} // path -> decoded content
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("GET /repos/o/r/contents/index.md", func(w http.ResponseWriter, _ *http.Request) {
+		content := base64.StdEncoding.EncodeToString([]byte("# Catalog\n\n## Incidents\n"))
+		_, _ = w.Write([]byte(`{"sha":"idxsha","content":"` + content + `"}`))
+	})
+	mux.HandleFunc("GET /repos/o/r/contents/log.md", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+			SHA     string `json:"sha"`
+			Branch  string `json:"branch"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		raw, _ := base64.StdEncoding.DecodeString(body.Content)
+		puts[r.PathValue("path")] = string(raw)
+		if r.PathValue("path") == "index.md" && body.SHA != "idxsha" {
+			t.Errorf("index.md update must carry the blob sha, got %q", body.SHA)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"html_url":"u"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	if _, err := c.OpenPR(context.Background(), kbEntry()); err != nil {
+		t.Fatalf("OpenPR: %v", err)
+	}
+
+	idx, ok := puts["index.md"]
+	if !ok || !strings.Contains(idx, "- [Harbor down](incidents/harbor-down-deadbeef.md) — valkey down") {
+		t.Fatalf("index.md not maintained: %q", idx)
+	}
+	logMD, ok := puts["log.md"]
+	if !ok || !strings.Contains(logMD, "* **Creation**: Added [Harbor down](incidents/harbor-down-deadbeef.md).") {
+		t.Fatalf("log.md not maintained: %q", logMD)
+	}
+}
+
+// TestOpenPRSkipsIndexWhenAbsent: no index.md in the bundle → RunLore does not
+// impose one (its structure is the owner's choice); log.md is still created
+// (its shape is fully specified by OKF §7).
+func TestOpenPRSkipsIndexWhenAbsent(t *testing.T) {
+	puts := map[string]bool{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		puts[r.PathValue("path")] = true
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"html_url":"u"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	if _, err := c.OpenPR(context.Background(), kbEntry()); err != nil {
+		t.Fatalf("OpenPR: %v", err)
+	}
+	if puts["index.md"] {
+		t.Fatal("absent index.md must not be created")
+	}
+	if !puts["log.md"] {
+		t.Fatal("log.md must be created even when absent")
+	}
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -109,8 +109,9 @@ func (c *Client) OpenIssue(ctx context.Context, inv providers.Investigation) (pr
 // OpenPR drafts the KB entry on a new branch and opens a PR.
 func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref, error) {
 	slug := slugify(e.Title)
-	branch := fmt.Sprintf("runlore/kb-%s-%d", slug, time.Now().Unix())
-	path := slug + ".md"
+	now := time.Now().Unix()
+	branch := fmt.Sprintf("runlore/kb-%s-%d", slug, now)
+	path := entryPath(e, slug, now)
 
 	// 1. base ref SHA
 	var ref struct {
@@ -132,7 +133,11 @@ func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref
 		map[string]any{"message": "runlore: draft KB entry " + e.Title, "content": content, "branch": branch}, nil); err != nil {
 		return providers.Ref{}, err
 	}
-	// 4. open the PR
+	// 4. keep the OKF bundle self-describing: index.md link line + log.md record
+	// on the same branch. Best-effort — a bundle-maintenance failure must not lose
+	// the entry PR (same contract as labelling below).
+	_ = c.maintainBundle(ctx, e, path, branch)
+	// 5. open the PR
 	var out struct {
 		HTMLURL string `json:"html_url"`
 		Number  int    `json:"number"`
@@ -141,7 +146,7 @@ func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref
 		map[string]any{"title": "KB: " + e.Title, "head": branch, "base": c.baseBranch, "body": prBody(e)}, &out); err != nil {
 		return providers.Ref{}, err
 	}
-	// 5. label the PR (the create-PR API doesn't accept labels; set them via the
+	// 6. label the PR (the create-PR API doesn't accept labels; set them via the
 	// issues endpoint). Best-effort: a labelling failure must not lose the PR, so
 	// the error is intentionally ignored — the PR URL is already returned.
 	if out.Number != 0 {
@@ -314,6 +319,11 @@ type kbFrontmatter struct {
 	Tags        []string `yaml:"tags,omitempty"`
 	Timestamp   string   `yaml:"timestamp,omitempty"` // OKF-recommended; seed entries carry it, curated ones now do too
 	Fingerprint string   `yaml:"fingerprint,omitempty"`
+	// Confidence + Provenance are OKF extension keys: frontmatter is for the
+	// fields you query/filter/index on, and these are exactly that (per-entry
+	// confidence floors, "what change caused this" lookups).
+	Confidence float64  `yaml:"confidence,omitempty"`
+	Provenance []string `yaml:"provenance,omitempty"`
 }
 
 // renderEntry serializes a KBEntry as OKF markdown (frontmatter + body).
@@ -337,7 +347,11 @@ func renderEntry(e providers.KBEntry) string {
 	// entries and flux.Executor). Kept off KBEntry so draftKBEntry stays
 	// deterministic/time-free; this serializer is already the I/O boundary.
 	ts := time.Now().UTC().Format(time.RFC3339)
-	fm, _ := yaml.Marshal(kbFrontmatter{Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource, Tags: e.Tags, Timestamp: ts, Fingerprint: e.Fingerprint})
+	fm, _ := yaml.Marshal(kbFrontmatter{
+		Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource,
+		Tags: e.Tags, Timestamp: ts, Fingerprint: e.Fingerprint,
+		Confidence: e.Confidence, Provenance: e.Provenance,
+	})
 	var b strings.Builder
 	b.WriteString("---\n")
 	b.Write(fm)
@@ -345,6 +359,24 @@ func renderEntry(e providers.KBEntry) string {
 	b.WriteString(e.Body)
 	b.WriteString("\n")
 	return b.String()
+}
+
+// entryPath is where the drafted entry lives in the KB bundle: a type directory
+// ("incidents/", "playbooks/", …) plus the title slug suffixed with a short
+// fingerprint. The suffix keeps two different incidents that share a title from
+// colliding on one path — without it, the contents PUT 422s once a same-slug file
+// exists on the base branch (same symptom, different cause is a real case: the
+// coalesce comment calls it out). With no fingerprint, the branch timestamp
+// disambiguates instead.
+func entryPath(e providers.KBEntry, slug string, now int64) string {
+	suffix := e.Fingerprint
+	if len(suffix) > 8 {
+		suffix = suffix[:8]
+	}
+	if suffix == "" {
+		suffix = fmt.Sprintf("%d", now)
+	}
+	return fmt.Sprintf("%ss/%s-%s.md", strings.ToLower(e.Type), slug, suffix)
 }
 
 func slugify(s string) string {

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -129,8 +129,11 @@ func TestOpenPR(t *testing.T) {
 		paths = append(paths, r.URL.Path)
 		_, _ = w.Write([]byte(`{}`))
 	})
-	mux.HandleFunc("PUT /repos/o/r/contents/", func(w http.ResponseWriter, _ *http.Request) {
-		paths = append(paths, "PUT contents")
+	mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // bare bundle: no index.md / log.md yet
+	})
+	mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, "PUT "+r.PathValue("path"))
 		_, _ = w.Write([]byte(`{}`))
 	})
 	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
@@ -148,8 +151,55 @@ func TestOpenPR(t *testing.T) {
 	if ref.URL != "https://github.com/o/r/pull/9" {
 		t.Fatalf("ref=%s", ref.URL)
 	}
-	if len(paths) != 4 || !strings.Contains(strings.Join(paths, ","), "PUT contents") {
-		t.Fatalf("expected the 4-call PR sequence, got %v", paths)
+	// base ref → branch → entry file → log.md (bundle maintenance) → PR
+	got := strings.Join(paths, ",")
+	if len(paths) != 5 || !strings.Contains(got, "PUT incidents/db-outage-") || !strings.Contains(got, "PUT log.md") {
+		t.Fatalf("expected the 5-call PR sequence ending in pulls, got %v", paths)
+	}
+	if paths[len(paths)-1] != "/repos/o/r/pulls" {
+		t.Fatalf("the PR must be opened last, got %v", paths)
+	}
+}
+
+// TestOpenPREntryPath pins the entry file path: a type directory plus a
+// fingerprint-suffixed slug, so two different incidents that share a title can't
+// collide on the same path (the contents PUT would 422 on the second PR after the
+// first merges). With no fingerprint the branch timestamp disambiguates instead.
+func TestOpenPREntryPath(t *testing.T) {
+	openPR := func(e providers.KBEntry) string {
+		t.Helper()
+		var putPath string
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{}`))
+		})
+		mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+			putPath = r.PathValue("path")
+			_, _ = w.Write([]byte(`{}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"html_url":"u"}`))
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		if _, err := c.OpenPR(context.Background(), e); err != nil {
+			t.Fatalf("OpenPR: %v", err)
+		}
+		return putPath
+	}
+
+	got := openPR(providers.KBEntry{Type: "Incident", Title: "DB outage", Fingerprint: "deadbeefcafebabe", Body: "## body"})
+	if got != "incidents/db-outage-deadbeef.md" {
+		t.Fatalf("fingerprinted incident path = %q, want incidents/db-outage-deadbeef.md", got)
+	}
+
+	got = openPR(providers.KBEntry{Type: "Playbook", Title: "DB outage", Body: "## body"})
+	if !strings.HasPrefix(got, "playbooks/db-outage-") || !strings.HasSuffix(got, ".md") || got == "playbooks/db-outage-.md" {
+		t.Fatalf("unfingerprinted playbook path = %q, want playbooks/db-outage-<ts>.md", got)
 	}
 }
 
@@ -227,6 +277,27 @@ func TestRenderEntryIncludesTimestamp(t *testing.T) {
 	val := strings.Trim(strings.TrimSpace(line), `"`)
 	if _, err := time.Parse(time.RFC3339, val); err != nil {
 		t.Fatalf("timestamp %q is not RFC3339: %v", val, err)
+	}
+}
+
+// TestRenderEntryIncludesConfidenceAndProvenance: confidence and change
+// provenance are queryable OKF extension frontmatter keys (frontmatter is for
+// the fields you filter/index on), omitted when unset.
+func TestRenderEntryIncludesConfidenceAndProvenance(t *testing.T) {
+	out := renderEntry(providers.KBEntry{
+		Type: "Incident", Title: "T", Confidence: 0.9,
+		Provenance: []string{"crossplane/xplane-harbor"},
+	})
+	if !strings.Contains(out, "confidence: 0.9") {
+		t.Fatalf("frontmatter missing confidence:\n%s", out)
+	}
+	if !strings.Contains(out, "provenance:") || !strings.Contains(out, "crossplane/xplane-harbor") {
+		t.Fatalf("frontmatter missing provenance:\n%s", out)
+	}
+
+	out = renderEntry(providers.KBEntry{Type: "Incident", Title: "T"})
+	if strings.Contains(out, "confidence:") || strings.Contains(out, "provenance:") {
+		t.Fatalf("unset confidence/provenance must be omitted:\n%s", out)
 	}
 }
 

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -46,19 +46,29 @@ var requiredIncidentSections = []struct{ key, head string }{
 	{"resolution", "Resolution"},
 }
 
-// WarnInvalid runs ValidateStructural over entries and calls onInvalid(path,
-// errs) for each entry that has structural Errors. It is the load-time
-// strict-warn hook: the caller logs + increments a metric, but the entry is
-// still served (one bad entry never empties the catalog). Returns the count of
-// invalid entries. Warnings are not reported here.
+// WarnInvalid is the load-time strict-warn hook: it calls onInvalid(path, errs)
+// for each invalid entry; the caller logs + increments a metric, but the entry
+// is still served (one bad entry never empties the catalog). Returns the count
+// of invalid entries. Warnings are not reported here.
+//
+// It is deliberately looser than the merge gate: OKF conformance (§9) requires
+// consumers to tolerate unknown types gracefully, so an entry outside the
+// RunLore vocabulary (a foreign bundle's "Metric", "API Endpoint", …) is checked
+// only for OKF conformance — a non-empty `type`. Entries claiming a RunLore type
+// are held to the full ValidateStructural shape, since those are the ones the
+// merge gate promised were well-formed.
 func WarnInvalid(entries []catalog.Entry, onInvalid func(path string, errs []Issue)) int {
 	n := 0
 	for _, e := range entries {
 		var errs []Issue
-		for _, i := range ValidateStructural(e) {
-			if i.Severity == SeverityError {
-				errs = append(errs, i)
+		if validTypes[e.Type] {
+			for _, i := range ValidateStructural(e) {
+				if i.Severity == SeverityError {
+					errs = append(errs, i)
+				}
 			}
+		} else if strings.TrimSpace(e.Type) == "" {
+			errs = append(errs, Issue{SeverityError, "type", "frontmatter `type` is required (OKF conformance)"})
 		}
 		if len(errs) > 0 {
 			n++
@@ -107,9 +117,15 @@ func ValidateStructural(e catalog.Entry) []Issue {
 		addErr("description", "frontmatter `description` is required")
 	}
 
+	// resource is required for Incident only: an incident is anchored to a concrete
+	// affected object, while Playbook/Concept entries are abstract knowledge — OKF
+	// leaves resource "omitted for abstract concepts", and curator.entryType drafts
+	// a Playbook precisely when the finding is resource-agnostic.
 	switch {
 	case strings.TrimSpace(e.Resource) == "":
-		addErr("resource", "frontmatter `resource` is required (namespace/name)")
+		if e.Type == "Incident" {
+			addErr("resource", "frontmatter `resource` is required for Incident (namespace/name)")
+		}
 	case strings.ContainsAny(e.Resource, " \t\r\n"):
 		addErr("resource", "resource must not contain whitespace")
 	}
@@ -169,11 +185,16 @@ func sections(body string) map[string]string {
 	return out
 }
 
-// heading returns the lowercased label of a "## X" markdown heading line.
+// heading returns the lowercased label of a "# X" or "## X" markdown heading
+// line. Both levels are section headings here: OKF's conventional headings are H1
+// (the seed entries follow that style) while curator-drafted entries use H2.
 func heading(line string) (string, bool) {
 	t := strings.TrimSpace(line)
-	if strings.HasPrefix(t, "## ") {
+	switch {
+	case strings.HasPrefix(t, "## "):
 		return strings.ToLower(strings.TrimSpace(t[3:])), true
+	case strings.HasPrefix(t, "# "):
+		return strings.ToLower(strings.TrimSpace(t[2:])), true
 	}
 	return "", false
 }

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -50,6 +50,12 @@ func TestValidateStructural(t *testing.T) {
 		{"empty description", func(e *catalog.Entry) { e.Description = "" }, "description", ""},
 		{"empty resource", func(e *catalog.Entry) { e.Resource = "" }, "resource", ""},
 		{"resource with whitespace", func(e *catalog.Entry) { e.Resource = "ns / name" }, "resource", ""},
+		// resource is required for Incident only: a Playbook/Concept is abstract,
+		// generalized knowledge — OKF says resource is "omitted for abstract concepts",
+		// and entryType only drafts a Playbook when the finding is resource-agnostic.
+		{"playbook empty resource ok", func(e *catalog.Entry) { e.Type = "Playbook"; e.Resource = "" }, "", ""},
+		{"concept empty resource ok", func(e *catalog.Entry) { e.Type = "Concept"; e.Resource = "" }, "", ""},
+		{"playbook resource with whitespace", func(e *catalog.Entry) { e.Type = "Playbook"; e.Resource = "ns / name" }, "resource", ""},
 		{"empty tags warns", func(e *catalog.Entry) { e.Tags = nil }, "", "tags"},
 		// body, type-aware
 		{"incident missing cause", func(e *catalog.Entry) {
@@ -66,6 +72,12 @@ func TestValidateStructural(t *testing.T) {
 			e.Body = "Some free-form runbook content with no required sections."
 		}, "", ""},
 		{"empty body", func(e *catalog.Entry) { e.Type = "Playbook"; e.Body = "  \n" }, "body", ""},
+		// OKF's conventional section headings are H1 ("# Citations") and the seed
+		// entries follow that style — a hand-written Incident using H1 sections must
+		// validate, not fail with "missing section".
+		{"incident with H1 sections", func(e *catalog.Entry) {
+			e.Body = "# Symptom\n\nx\n\n# Investigate\n\n- e\n\n# Cause\n\n1. y\n\n# Resolution\n\n- z\n"
+		}, "", ""},
 	}
 
 	for _, tc := range tests {
@@ -108,6 +120,36 @@ func TestWarnInvalid(t *testing.T) {
 	}
 	if len(flagged) != 1 || flagged[0] != "bad.md" {
 		t.Fatalf("want bad.md flagged, got %v", flagged)
+	}
+}
+
+// TestWarnInvalidToleratesForeignTypes: OKF conformance (§9) requires consumers
+// to tolerate unknown types gracefully. A foreign OKF bundle entry (type
+// "Metric", no resource, free-form body) is conformant knowledge — the load-time
+// hook must serve it without flagging. Only RunLore-vocabulary entries are held
+// to the structural merge-gate shape at load time, and OKF non-conformance
+// (empty type) is still flagged.
+func TestWarnInvalidToleratesForeignTypes(t *testing.T) {
+	foreign := catalog.Entry{
+		Path: "foreign.md", Type: "Metric", Title: "requests_total",
+		Body: "A counter of HTTP requests.",
+	}
+	noType := catalog.Entry{Path: "no-type.md", Title: "t", Body: "b"}
+	brokenIncident := validIncident()
+	brokenIncident.Path = "broken.md"
+	brokenIncident.Body = "## Symptom\n\nx\n" // missing Cause/Resolution
+
+	var flagged []string
+	n := WarnInvalid([]catalog.Entry{foreign, noType, brokenIncident}, func(path string, _ []Issue) {
+		flagged = append(flagged, path)
+	})
+	if n != 2 {
+		t.Fatalf("want 2 invalid (no-type + broken incident), got %d: %v", n, flagged)
+	}
+	for _, p := range flagged {
+		if p == "foreign.md" {
+			t.Fatal("a foreign-typed OKF entry must not be flagged at load time")
+		}
 	}
 }
 

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -434,8 +434,10 @@ type KBEntry struct {
 	Description string
 	Resource    string
 	Tags        []string
-	Body        string // markdown
-	Fingerprint string // deterministic dedup fingerprint (see curator.DupFingerprint)
+	Body        string   // markdown
+	Fingerprint string   // deterministic dedup fingerprint (see curator.DupFingerprint)
+	Confidence  float64  // overall investigation confidence; queryable extension frontmatter (0 = unset)
+	Provenance  []string // distinct causing-change refs; queryable extension frontmatter
 }
 
 // Ref is a URL handle to a created issue or PR.


### PR DESCRIPTION
Aligns the knowledge base with the [OKF v0.1 spec](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) and fixes two curation defects found while reviewing the entry format.

## Defects

- **Playbooks could never pass their own merge gate.** `entryType` only drafts a Playbook when the finding is resource-agnostic, but the validator required `resource` for all types. `resource` is now required for `Incident` only — OKF leaves it "omitted for abstract concepts".
- **Same-title entries broke PR creation.** Entries were written as `<slug>.md` at the repo root; once one merged, the next same-title finding 422'd the contents PUT. Entries now land under a type directory with a short fingerprint suffix: `incidents/<slug>-<fp8>.md`.

## Recall signal

- Drafted tags carry the workload kind + namespace (previously always `[runlore, incident|playbook]`), and the Symptom section names the affected resource — both feed the BM25/embedding corpus (`catalog.entryText`).
- `timestamp` and `fingerprint` frontmatter are parsed into `catalog.Entry`, and the curator dedups on an **exact catalog fingerprint match** (new `Catalog.FindFingerprint`, optional-interface wired) before falling back to the tunable BM25 threshold.

## OKF conformance

- The validator accepts both H1 (OKF-conventional, used by seed entries) and H2 (drafted) section headings.
- Drafted entries render an OKF §8 `## Citations` section from change refs; `confidence` + `provenance` become queryable extension frontmatter keys.
- Load-time validation is OKF-permissive per §9 (foreign types like "Metric" are only checked for a non-empty `type`); the `validate-kb` merge gate stays strict for the RunLore vocabulary.
- KB PRs keep the bundle self-describing: the entry's link line is added to `index.md` (only when the bundle has one) and a newest-first `**Creation**` record is appended to `log.md` — best-effort, so bundle maintenance can never lose the entry PR.

Docs: the entry-anatomy example in `docs/reviewing-knowledge.md` reflects the new output.

## Verification

- `go test ./...` green (every change test-first), `go vet` clean, `golangci-lint run` 0 issues
- `lore validate-kb examples/runbooks` passes end-to-end (seed Playbook with H1 sections + wildcard resource)