### PR TITLE
feat(mcp): serve the knowledge catalog over MCP (lore mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ we test hardest.
 ## Docs
 
 📐 [Design](docs/design.md) · 📚 [Learning loop](docs/learning-loop.md) · ✅ [Reviewing knowledge](docs/reviewing-knowledge.md) · 🚀 [Getting started](docs/getting-started.md) · 🧪 [Worked example](docs/examples/harbor-registry-down.md) ·
-🔌 [Data sources](docs/data-sources.md) · ⚙️ [Configuration](docs/configuration.md) · 📊 [Observability](docs/observability.md) · 🩺 [Troubleshooting](docs/troubleshooting.md) ·
+🔌 [Data sources](docs/data-sources.md) · ⚙️ [Configuration](docs/configuration.md) · 🔗 [MCP server](docs/mcp.md) · 📊 [Observability](docs/observability.md) · 🩺 [Troubleshooting](docs/troubleshooting.md) ·
 🔒 [Security model](docs/security-model.md) · 🛡 [LLM security architecture](docs/security-architecture.md) · ⬆️ [Upgrade & uninstall](docs/upgrade-uninstall.md) · 🧭 [Prior art](docs/prior-art.md) · 📊 [Benchmarking models](docs/benchmarking.md) · 🛠 [Contributing](CONTRIBUTING.md)
 
 ## License

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -28,7 +28,7 @@ Usage:
   lore eval --live [--scenarios <dir>] [--n 3]        live-fire on the cluster: grade coverage + RCA
   lore eval --compare <spec.yaml> [--n 3]             benchmark several models over the replay suite
   lore curate [--config <path>]                       groom the KB backlog (dedup open PRs)
-  lore mcp [--config <path>]                          serve GitOps what-changed over MCP (stdio; for HolmesGPT et al.)
+  lore mcp [--config <path>] [<catalog-dir>]          serve what-changed + KB search over MCP (stdio; Claude Code, HolmesGPT, …)
   lore audit verify --path <audit.jsonl>              re-walk the action audit log; report the first broken link
   lore version                                        print version
 `

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -27,8 +27,11 @@ git clone https://github.com/you/your-kb && lore mcp ./your-kb
   `k` (default 5, cap 20). Returns scored hits: `path`, `type`, `title`,
   `description`, `resource`, `tags`, `score`.
 - **`kb_get`** — one full entry (frontmatter + markdown body) by the
-  bundle-relative `path` a search hit returned. Lookups go through the in-memory
-  index, never the filesystem, so path traversal is structurally impossible.
+  bundle-relative `path` a search hit returned. Curated entries also carry their
+  `timestamp` (last-change stamp) and `fingerprint` (dedup identity) so a client
+  can judge freshness; hand-written entries omit both. Lookups go through the
+  in-memory index, never the filesystem, so path traversal is structurally
+  impossible.
 
 The catalog directory resolves from the positional argument first, then
 `catalog.dir` in the config. The catalog is indexed once at startup; re-run

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,65 @@
+# Serving RunLore over MCP
+
+`lore mcp` is a read-only [Model Context Protocol](https://modelcontextprotocol.io)
+server on **stdio**: point any MCP client (Claude Code, HolmesGPT, kagent, an
+editor) at the binary and it can query RunLore's capabilities as tools. stdout
+carries the protocol; logs go to stderr.
+
+It serves whichever capabilities are configured — each one is optional:
+
+| Capability | Tools | Needs |
+|---|---|---|
+| GitOps what-changed | `gitops_what_changed` | a Kubernetes client + `gitops` in the config |
+| Knowledge base | `kb_search`, `kb_get` | an OKF catalog directory |
+
+## Knowledge-base tools
+
+Your merged KB entries are plain OKF markdown in Git — which means they're useful
+far beyond the agent's own instant recall: during a postmortem, reviewing an
+infra PR ("has this bitten us before?"), or on-call from a laptop. The KB tools
+need **no cluster, no model, no config file**:
+
+```bash
+git clone https://github.com/you/your-kb && lore mcp ./your-kb
+```
+
+- **`kb_search`** — BM25 search over the catalog. Args: `query` (required),
+  `k` (default 5, cap 20). Returns scored hits: `path`, `type`, `title`,
+  `description`, `resource`, `tags`, `score`.
+- **`kb_get`** — one full entry (frontmatter + markdown body) by the
+  bundle-relative `path` a search hit returned. Lookups go through the in-memory
+  index, never the filesystem, so path traversal is structurally impossible.
+
+The catalog directory resolves from the positional argument first, then
+`catalog.dir` in the config. The catalog is indexed once at startup; re-run
+`lore catalog sync` (or `git pull`) and restart to pick up new entries.
+
+## Client configuration
+
+Claude Code:
+
+```bash
+claude mcp add runlore-kb -- lore mcp /path/to/kb
+```
+
+Generic MCP client config (stdio):
+
+```json
+{
+  "mcpServers": {
+    "runlore-kb": {
+      "command": "lore",
+      "args": ["mcp", "/path/to/kb"]
+    }
+  }
+}
+```
+
+In-cluster (what-changed + KB), keep using the config file:
+
+```bash
+lore mcp --config runlore.yaml
+```
+
+A missing config file is tolerated when a catalog dir is given (KB-only mode); a
+present-but-invalid config still fails loudly.

--- a/internal/app/mcp.go
+++ b/internal/app/mcp.go
@@ -3,50 +3,112 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/kbmcp"
 	"github.com/Smana/runlore/internal/logging"
 	"github.com/Smana/runlore/internal/mcp"
+	"github.com/Smana/runlore/internal/providers"
 )
 
-// RunMCP serves RunLore's GitOps what-changed capability over the Model Context
-// Protocol (stdio JSON-RPC), so an MCP client (e.g. HolmesGPT) can call it as a
-// toolset. stdout is the protocol channel; logs go to stderr. Read-only. version
-// is injected at build time and stays in package main; it is passed through to the
+// RunMCP serves RunLore capabilities over the Model Context Protocol (stdio
+// JSON-RPC): the GitOps what-changed tool (needs a Kubernetes client +
+// config.gitops) and the knowledge-base tools kb_search/kb_get (need an OKF
+// catalog dir). Each capability is optional — an MCP client on a laptop can
+// serve just the KB from a local checkout — but an empty server is an error.
+// stdout is the protocol channel; logs go to stderr. Read-only. version is
+// injected at build time and stays in package main; it is passed through to the
 // MCP server's advertised server info.
+//
+// Usage: lore mcp [--config runlore.yaml] [catalog-dir]
+// The positional catalog-dir overrides config catalog.dir; when it is given, a
+// missing config file is tolerated (KB-only mode needs no config).
 func RunMCP(version string, args []string) error {
-	fs := flag.NewFlagSet("mcp", flag.ContinueOnError)
-	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
-	if err := fs.Parse(args); err != nil {
+	flags := flag.NewFlagSet("mcp", flag.ContinueOnError)
+	cfgPath := flags.String("config", "runlore.yaml", "path to config file")
+	if err := flags.Parse(args); err != nil {
 		return err
 	}
+	dir := flags.Arg(0)
+
 	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		// KB-only mode: with an explicit catalog dir, a merely-absent config file
+		// is fine (no cluster, no gitops). A present-but-broken config still fails
+		// loudly — silently ignoring a config the operator wrote hides mistakes.
+		if dir == "" || !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		cfg = nil
+	}
+
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	var gp providers.GitOpsProvider
+	if cfg != nil {
+		log = logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
+		gp = GitOpsFromKube(cfg, log)
+		if dir == "" {
+			dir = cfg.Catalog.Dir
+		}
+	}
+
+	var cat *catalog.Catalog
+	if dir != "" {
+		c, cerr := catalog.New(dir)
+		if cerr != nil {
+			return fmt.Errorf("load catalog %s: %w", dir, cerr)
+		}
+		cat = c
+		log.Info("knowledge catalog indexed", "dir", dir, "entries", c.Len())
+	}
+
+	tools, err := assembleMCPTools(gp, cat)
 	if err != nil {
 		return err
 	}
-	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
-	gp := GitOpsFromKube(cfg, log)
-	if gp == nil {
-		return fmt.Errorf("what_changed needs a Kubernetes client + config.gitops")
+	srv := mcp.NewServer("runlore", version, log)
+	names := make([]string, 0, len(tools))
+	for _, t := range tools {
+		srv.AddTool(t)
+		names = append(names, t.Name)
 	}
-	tool := investigate.WhatChangedTool{GitOps: gp}
-	srv := mcp.NewServer("runlore-whatchanged", version, log)
-	srv.AddTool(mcp.Tool{
-		Name:        "gitops_what_changed",
-		Description: tool.Description(),
-		InputSchema: json.RawMessage(tool.Schema()),
-		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
-			return tool.Call(ctx, string(args))
-		},
-	})
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	log.Info("runlore mcp server ready (stdio)", "tool", "gitops_what_changed")
+	log.Info("runlore mcp server ready (stdio)", "tools", names)
 	return srv.Serve(ctx, os.Stdin, os.Stdout)
+}
+
+// assembleMCPTools builds the served tool set from whichever capabilities are
+// configured. Both absent is a misconfiguration: an MCP server with no tools
+// would handshake fine and then be useless.
+func assembleMCPTools(gp providers.GitOpsProvider, cat *catalog.Catalog) ([]mcp.Tool, error) {
+	var tools []mcp.Tool
+	if gp != nil {
+		tool := investigate.WhatChangedTool{GitOps: gp}
+		tools = append(tools, mcp.Tool{
+			Name:        "gitops_what_changed",
+			Description: tool.Description(),
+			InputSchema: json.RawMessage(tool.Schema()),
+			Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+				return tool.Call(ctx, string(args))
+			},
+		})
+	}
+	if cat != nil {
+		tools = append(tools, kbmcp.Tools(cat)...)
+	}
+	if len(tools) == 0 {
+		return nil, fmt.Errorf("nothing to serve: what_changed needs a Kubernetes client + config.gitops, kb tools need catalog.dir (or `lore mcp <catalog-dir>`)")
+	}
+	return tools, nil
 }

--- a/internal/app/mcp_test.go
+++ b/internal/app/mcp_test.go
@@ -1,0 +1,77 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func testKBCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	dir := t.TempDir()
+	entry := "---\ntype: Playbook\ntitle: T\ndescription: d\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(dir, "t.md"), []byte(entry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := catalog.New(dir)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	return c
+}
+
+// assembleMCPTools decides what `lore mcp` serves: the what-changed tool needs a
+// GitOps provider, the KB tools need a catalog — each optional, but an empty
+// server is a misconfiguration, not a working state.
+func TestAssembleMCPTools(t *testing.T) {
+	var gp providers.GitOpsProvider = fakeGitOps{}
+
+	tests := []struct {
+		name    string
+		gitops  providers.GitOpsProvider
+		catalog *catalog.Catalog
+		want    []string
+		wantErr bool
+	}{
+		{"both", gp, testKBCatalog(t), []string{"gitops_what_changed", "kb_search", "kb_get"}, false},
+		{"kb only", nil, testKBCatalog(t), []string{"kb_search", "kb_get"}, false},
+		{"gitops only", gp, nil, []string{"gitops_what_changed"}, false},
+		{"neither", nil, nil, nil, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tools, err := assembleMCPTools(tc.gitops, tc.catalog)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("want error for an empty tool set")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("assembleMCPTools: %v", err)
+			}
+			var names []string
+			for _, tl := range tools {
+				names = append(names, tl.Name)
+			}
+			if len(names) != len(tc.want) {
+				t.Fatalf("tools = %v, want %v", names, tc.want)
+			}
+			for i := range tc.want {
+				if names[i] != tc.want[i] {
+					t.Fatalf("tools = %v, want %v", names, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// fakeGitOps is the minimal GitOpsProvider stand-in for tool assembly (the
+// handler is never called here).
+type fakeGitOps struct{ providers.GitOpsProvider }
+
+var _ investigate.Tool = &investigate.WhatChangedTool{}

--- a/internal/kbmcp/kbmcp.go
+++ b/internal/kbmcp/kbmcp.go
@@ -1,0 +1,150 @@
+// Package kbmcp exposes the OKF knowledge catalog as MCP tools (kb_search,
+// kb_get) for the `lore mcp` stdio server — so any MCP client (Claude Code,
+// HolmesGPT, editors) can recall RunLore's learned incident knowledge without a
+// cluster or a model. Read-only by construction: handlers only query the
+// in-memory catalog index.
+package kbmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/mcp"
+)
+
+// Search result bounds: defaultK when the caller doesn't ask, maxK as a hard cap
+// so one call can't dump an entire large catalog into a model context.
+const (
+	defaultK = 5
+	maxK     = 20
+)
+
+// searchHit is the kb_search result shape: the frontmatter card plus the BM25
+// score — enough to pick an entry without pulling every body; kb_get returns the
+// rest.
+type searchHit struct {
+	Path        string   `json:"path"`
+	Type        string   `json:"type"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Resource    string   `json:"resource,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Score       float64  `json:"score"`
+}
+
+// fullEntry is the kb_get result shape: the whole entry, body included.
+type fullEntry struct {
+	Path        string   `json:"path"`
+	Type        string   `json:"type"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Resource    string   `json:"resource,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Body        string   `json:"body"`
+}
+
+// Tools returns the KB tool set backed by cat, ready for mcp.Server.AddTool.
+func Tools(cat *catalog.Catalog) []mcp.Tool {
+	return []mcp.Tool{
+		{
+			Name: "kb_search",
+			Description: "Search the SRE knowledge base (BM25 over incident/playbook/concept entries). " +
+				"Returns up to k scored hits with path, type, title, description, resource, and tags; " +
+				"call kb_get with a hit's path for the full entry.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "query": {"type": "string", "description": "free-text search: symptom, resource, alert name, …"},
+    "k": {"type": "integer", "description": "max results (default 5, cap 20)"}
+  },
+  "required": ["query"]
+}`),
+			Handler: func(_ context.Context, args json.RawMessage) (string, error) {
+				return search(cat, args)
+			},
+		},
+		{
+			Name: "kb_get",
+			Description: "Fetch one knowledge-base entry in full (frontmatter + markdown body) " +
+				"by its bundle-relative path, as returned by kb_search.",
+			InputSchema: json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "path": {"type": "string", "description": "bundle-relative entry path, e.g. incidents/harbor-down.md"}
+  },
+  "required": ["path"]
+}`),
+			Handler: func(_ context.Context, args json.RawMessage) (string, error) {
+				return get(cat, args)
+			},
+		},
+	}
+}
+
+func search(cat *catalog.Catalog, args json.RawMessage) (string, error) {
+	var in struct {
+		Query string `json:"query"`
+		K     int    `json:"k"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return "", fmt.Errorf("kb_search args: %w", err)
+	}
+	if in.Query == "" {
+		return "", fmt.Errorf("kb_search: `query` is required")
+	}
+	k := in.K
+	if k <= 0 {
+		k = defaultK
+	}
+	if k > maxK {
+		k = maxK
+	}
+	scored, err := cat.SearchScored(in.Query, k)
+	if err != nil {
+		return "", fmt.Errorf("kb_search: %w", err)
+	}
+	hits := make([]searchHit, 0, len(scored))
+	for _, s := range scored {
+		hits = append(hits, searchHit{
+			Path: s.Entry.Path, Type: s.Entry.Type, Title: s.Entry.Title,
+			Description: s.Entry.Description, Resource: s.Entry.Resource,
+			Tags: s.Entry.Tags, Score: s.Score,
+		})
+	}
+	out, err := json.MarshalIndent(hits, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("kb_search encode: %w", err)
+	}
+	return string(out), nil
+}
+
+func get(cat *catalog.Catalog, args json.RawMessage) (string, error) {
+	var in struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return "", fmt.Errorf("kb_get args: %w", err)
+	}
+	if in.Path == "" {
+		return "", fmt.Errorf("kb_get: `path` is required")
+	}
+	// Lookup is by the indexed bundle-relative Path — never a filesystem read —
+	// so traversal cannot escape the catalog; anything not indexed is simply
+	// unknown.
+	for _, e := range cat.Entries() {
+		if e.Path != in.Path {
+			continue
+		}
+		out, err := json.MarshalIndent(fullEntry{
+			Path: e.Path, Type: e.Type, Title: e.Title, Description: e.Description,
+			Resource: e.Resource, Tags: e.Tags, Body: e.Body,
+		}, "", "  ")
+		if err != nil {
+			return "", fmt.Errorf("kb_get encode: %w", err)
+		}
+		return string(out), nil
+	}
+	return "", fmt.Errorf("kb_get: no entry at %q (use kb_search to discover paths)", in.Path)
+}

--- a/internal/kbmcp/kbmcp.go
+++ b/internal/kbmcp/kbmcp.go
@@ -35,6 +35,9 @@ type searchHit struct {
 }
 
 // fullEntry is the kb_get result shape: the whole entry, body included.
+// Timestamp and Fingerprint are the curated-entry provenance (last-change stamp,
+// dedup identity) — surfaced so clients can judge freshness and identity; both
+// are absent on hand-written entries.
 type fullEntry struct {
 	Path        string   `json:"path"`
 	Type        string   `json:"type"`
@@ -42,6 +45,8 @@ type fullEntry struct {
 	Description string   `json:"description,omitempty"`
 	Resource    string   `json:"resource,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
+	Timestamp   string   `json:"timestamp,omitempty"`
+	Fingerprint string   `json:"fingerprint,omitempty"`
 	Body        string   `json:"body"`
 }
 
@@ -139,7 +144,8 @@ func get(cat *catalog.Catalog, args json.RawMessage) (string, error) {
 		}
 		out, err := json.MarshalIndent(fullEntry{
 			Path: e.Path, Type: e.Type, Title: e.Title, Description: e.Description,
-			Resource: e.Resource, Tags: e.Tags, Body: e.Body,
+			Resource: e.Resource, Tags: e.Tags,
+			Timestamp: e.Timestamp, Fingerprint: e.Fingerprint, Body: e.Body,
 		}, "", "  ")
 		if err != nil {
 			return "", fmt.Errorf("kb_get encode: %w", err)

--- a/internal/kbmcp/kbmcp_test.go
+++ b/internal/kbmcp/kbmcp_test.go
@@ -1,0 +1,185 @@
+package kbmcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+)
+
+func writeEntry(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	dir := t.TempDir()
+	writeEntry(t, dir, "helmrelease.md", `---
+type: Playbook
+title: HelmRelease upgrade failure
+description: Helm chart bump leaves the release Ready=False.
+tags: [flux, helmrelease, upgrade]
+---
+A chart bump that adds a DB migration can stall the release.
+`)
+	writeEntry(t, dir, "network.md", `---
+type: Playbook
+title: CiliumNetworkPolicy drops
+description: Connectivity timeouts caused by a default-deny policy.
+tags: [cilium, network]
+---
+Check Hubble for DROPPED verdicts.
+`)
+	c, err := catalog.New(dir)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	return c
+}
+
+func tool(t *testing.T, name string) func(context.Context, json.RawMessage) (string, error) {
+	t.Helper()
+	for _, tl := range Tools(testCatalog(t)) {
+		if tl.Name == name {
+			return tl.Handler
+		}
+	}
+	t.Fatalf("tool %q not registered", name)
+	return nil
+}
+
+func TestToolsMetadata(t *testing.T) {
+	tools := Tools(testCatalog(t))
+	if len(tools) != 2 || tools[0].Name != "kb_search" || tools[1].Name != "kb_get" {
+		t.Fatalf("want [kb_search kb_get], got %+v", tools)
+	}
+	for _, tl := range tools {
+		if tl.Description == "" {
+			t.Fatalf("%s: empty description", tl.Name)
+		}
+		var js map[string]any
+		if err := json.Unmarshal(tl.InputSchema, &js); err != nil {
+			t.Fatalf("%s: schema is not valid JSON: %v", tl.Name, err)
+		}
+	}
+}
+
+func TestKBSearchReturnsScoredHits(t *testing.T) {
+	out, err := tool(t, "kb_search")(context.Background(), json.RawMessage(`{"query":"helmrelease chart migration"}`))
+	if err != nil {
+		t.Fatalf("kb_search: %v", err)
+	}
+	var hits []struct {
+		Path        string   `json:"path"`
+		Type        string   `json:"type"`
+		Title       string   `json:"title"`
+		Description string   `json:"description"`
+		Tags        []string `json:"tags"`
+		Score       float64  `json:"score"`
+	}
+	if err := json.Unmarshal([]byte(out), &hits); err != nil {
+		t.Fatalf("kb_search output is not JSON: %v\n%s", err, out)
+	}
+	if len(hits) == 0 || hits[0].Title != "HelmRelease upgrade failure" {
+		t.Fatalf("expected the HelmRelease playbook first, got %+v", hits)
+	}
+	h := hits[0]
+	if h.Path != "helmrelease.md" || h.Type != "Playbook" || h.Description == "" || len(h.Tags) != 3 || h.Score <= 0 {
+		t.Fatalf("hit is missing fields: %+v", h)
+	}
+}
+
+func TestKBSearchRequiresQuery(t *testing.T) {
+	if _, err := tool(t, "kb_search")(context.Background(), json.RawMessage(`{}`)); err == nil {
+		t.Fatal("missing query must error")
+	}
+	if _, err := tool(t, "kb_search")(context.Background(), json.RawMessage(`not json`)); err == nil {
+		t.Fatal("malformed args must error")
+	}
+}
+
+func TestKBSearchClampsK(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 25; i++ {
+		writeEntry(t, dir, fmt.Sprintf("e%d.md", i), fmt.Sprintf(`---
+type: Concept
+title: entry %d about kafka
+description: kafka broker note %d
+---
+kafka broker lag entry %d
+`, i, i, i))
+	}
+	c, err := catalog.New(dir)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	var search func(context.Context, json.RawMessage) (string, error)
+	for _, tl := range Tools(c) {
+		if tl.Name == "kb_search" {
+			search = tl.Handler
+		}
+	}
+
+	count := func(args string) int {
+		t.Helper()
+		out, err := search(context.Background(), json.RawMessage(args))
+		if err != nil {
+			t.Fatalf("kb_search %s: %v", args, err)
+		}
+		var hits []map[string]any
+		if err := json.Unmarshal([]byte(out), &hits); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return len(hits)
+	}
+	if n := count(`{"query":"kafka"}`); n != 5 {
+		t.Fatalf("k omitted must default to 5, got %d", n)
+	}
+	if n := count(`{"query":"kafka","k":-3}`); n != 5 {
+		t.Fatalf("k<=0 must default to 5, got %d", n)
+	}
+	if n := count(`{"query":"kafka","k":100}`); n != 20 {
+		t.Fatalf("k must cap at 20, got %d", n)
+	}
+}
+
+func TestKBGetReturnsFullEntry(t *testing.T) {
+	out, err := tool(t, "kb_get")(context.Background(), json.RawMessage(`{"path":"helmrelease.md"}`))
+	if err != nil {
+		t.Fatalf("kb_get: %v", err)
+	}
+	var e struct {
+		Path  string   `json:"path"`
+		Type  string   `json:"type"`
+		Title string   `json:"title"`
+		Tags  []string `json:"tags"`
+		Body  string   `json:"body"`
+	}
+	if err := json.Unmarshal([]byte(out), &e); err != nil {
+		t.Fatalf("kb_get output is not JSON: %v\n%s", err, out)
+	}
+	if e.Type != "Playbook" || e.Title != "HelmRelease upgrade failure" || !strings.Contains(e.Body, "DB migration") {
+		t.Fatalf("entry incomplete: %+v", e)
+	}
+}
+
+func TestKBGetRejectsBadPaths(t *testing.T) {
+	for _, args := range []string{
+		`{}`,                        // missing path
+		`{"path":"../secrets.md"}`,  // traversal
+		`{"path":"/etc/passwd"}`,    // absolute
+		`{"path":"nonexistent.md"}`, // unknown entry
+	} {
+		if _, err := tool(t, "kb_get")(context.Background(), json.RawMessage(args)); err == nil {
+			t.Fatalf("args %s must error", args)
+		}
+	}
+}

--- a/internal/kbmcp/kbmcp_test.go
+++ b/internal/kbmcp/kbmcp_test.go
@@ -27,6 +27,8 @@ type: Playbook
 title: HelmRelease upgrade failure
 description: Helm chart bump leaves the release Ready=False.
 tags: [flux, helmrelease, upgrade]
+timestamp: "2026-06-20T00:00:00Z"
+fingerprint: deadbeefcafebabe
 ---
 A chart bump that adds a DB migration can stall the release.
 `)
@@ -157,17 +159,33 @@ func TestKBGetReturnsFullEntry(t *testing.T) {
 		t.Fatalf("kb_get: %v", err)
 	}
 	var e struct {
-		Path  string   `json:"path"`
-		Type  string   `json:"type"`
-		Title string   `json:"title"`
-		Tags  []string `json:"tags"`
-		Body  string   `json:"body"`
+		Path        string   `json:"path"`
+		Type        string   `json:"type"`
+		Title       string   `json:"title"`
+		Tags        []string `json:"tags"`
+		Timestamp   string   `json:"timestamp"`
+		Fingerprint string   `json:"fingerprint"`
+		Body        string   `json:"body"`
 	}
 	if err := json.Unmarshal([]byte(out), &e); err != nil {
 		t.Fatalf("kb_get output is not JSON: %v\n%s", err, out)
 	}
 	if e.Type != "Playbook" || e.Title != "HelmRelease upgrade failure" || !strings.Contains(e.Body, "DB migration") {
 		t.Fatalf("entry incomplete: %+v", e)
+	}
+	// Curated entries carry a change stamp + dedup identity in frontmatter;
+	// kb_get must surface both so clients can judge freshness and identity.
+	if e.Timestamp != "2026-06-20T00:00:00Z" || e.Fingerprint != "deadbeefcafebabe" {
+		t.Fatalf("timestamp/fingerprint not surfaced: %+v", e)
+	}
+
+	// Hand-written entries have neither — the keys must be omitted, not "".
+	out, err = tool(t, "kb_get")(context.Background(), json.RawMessage(`{"path":"network.md"}`))
+	if err != nil {
+		t.Fatalf("kb_get network.md: %v", err)
+	}
+	if strings.Contains(out, `"timestamp"`) || strings.Contains(out, `"fingerprint"`) {
+		t.Fatalf("absent timestamp/fingerprint must be omitted:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Exposes the OKF knowledge catalog to MCP clients (Claude Code, Gemini CLI, editors) by extending the existing dependency-free stdio MCP server — the incident KB becomes recallable from postmortems, PR reviews, and on-call sessions, not just from RunLore itself.

## What's in it

- **`internal/kbmcp`** — two new tools on the existing `lore mcp` server:
  - `kb_search` — BM25 search over the catalog (`k` default 5, capped at 20); returns path, type, title, description, resource, tags, and score as JSON.
  - `kb_get` — full entry (frontmatter fields + body) by bundle-relative path. Lookups resolve against the in-memory index, never the filesystem, so path traversal is structurally impossible (covered by tests for `../`, absolute, unknown, and missing paths).
- **`internal/app`** — MCP capabilities are now composable: the `gitops_what_changed` tool needs kube+gitops config, the KB tools need a catalog dir, and either alone is enough. New usage: `lore mcp [--config runlore.yaml] [catalog-dir]` — a positional dir overrides `catalog.dir`, and a missing config file is tolerated in KB-only mode (a broken one still fails). Server name generalized `runlore-whatchanged` → `runlore`.
- **`docs/mcp.md`** — setup for Claude Code and generic MCP clients plus the tool reference, linked from the README docs strip.

## Design note

No new dependency: the repo's `internal/mcp` is deliberately SDK-free ("no SDK to keep the single static binary"), so the KB tools plug into that server rather than introducing the official Go SDK and a parallel implementation.

## Verification

- Every behavior test-first; `go test ./...` green, `go vet` clean, `golangci-lint run` 0 issues, `gofmt -l` clean
- End-to-end smoke test: `initialize` / `tools/list` / `tools/call kb_search` piped into `./lore mcp ./kb` with no config file — correct handshake, both tools advertised, scored hit returned

## Deferred (follow-ups)

- Live git-sync inside the server (the catalog indexes once at startup; docs say re-sync + restart)
- Embedding/hybrid search (BM25 only — no model required to run the server)
- Surfacing `timestamp`/`fingerprint` in `kb_get` output — one-liner once #232 (which adds those fields to `catalog.Entry`) merges; no file overlap with that PR is expected