### PR TITLE
docs: document enabling Slack Interactivity for buttons

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -288,6 +288,10 @@ config:
       #                                             #   posts a verdict-first summary + threaded full analysis
       # channel: C0123456789                        # channel ID or name to post to
       # signing_secret_env: SLACK_SIGNING_SECRET   # enables Approve/Reject + 👍/👎 feedback buttons
+      #   ↳ the buttons also need Interactivity turned ON in the Slack app itself:
+      #     api.slack.com/apps → your app → Interactivity & Shortcuts → toggle On,
+      #     Request URL = https://<your-runlore-host>/slack/interactions. Without this
+      #     Slack shows "The app is not configured to handle interactive responses" on click.
     matrix:
       homeserver: https://matrix.org
       room_id: "!yourroom:matrix.org"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -149,6 +149,37 @@ with `count=` confirms how many sinks were wired — `count=0` means none are co
 
 ---
 
+## Slack buttons (👍/👎, Approve/Reject) do nothing or error
+
+Clicking a button and getting **"The app is not configured to handle interactive responses"** (or the
+click silently doing nothing) is a **Slack app configuration** problem, not a RunLore one — Slack
+never even reaches RunLore. The buttons are delivered by RunLore, but the *round-trip* on click is
+driven by your Slack app's **Interactivity** feature, which is off by default.
+
+Fix it in the Slack app (**[api.slack.com/apps](https://api.slack.com/apps)** → your app):
+
+1. **Features → Interactivity & Shortcuts → toggle Interactivity On.**
+2. Set the **Request URL** to your RunLore server's public endpoint:
+   `https://<your-runlore-host>/slack/interactions` (the server exposes `POST /slack/interactions`).
+   Slack must be able to reach it — expose the `server` port via Ingress/LoadBalancer.
+3. **Save Changes.** No re-install of the app is needed for this toggle.
+
+Then, on the RunLore side, both button families need the **signing secret** so clicks can be
+HMAC-verified — without it the endpoint returns `404 slack interactions not enabled`:
+
+- Set `notify.slack.signing_secret_env` (the app's **Basic Information → Signing Secret**).
+- 👍/👎 **verdict feedback** additionally records only when the outcome ledger is on
+  (`outcome.ledger_path`); otherwise the click gets an honest *"feedback isn't enabled"* reply
+  instead of a false "recorded" ack.
+- **Approve/Reject** additionally require `actions.mode: approve` (or `auto`) and the clicker's Slack
+  ID in `notify.slack.approver_ids`; feedback buttons are unprivileged (anyone in the channel can rate).
+
+Once wired, a click hits `POST /slack/interactions` on the leader; a verification failure logs at that
+handler. See [Configuration → notifiers](configuration.md) and the
+[Getting started](getting-started.md) Slack setup for the full picture.
+
+---
+
 ## `/readyz` never goes green
 
 `/readyz` is gated by **leadership AND catalog warmth** (`internal/app/runtime.go`). It returns `503`


### PR DESCRIPTION
## What

Documents the Slack app configuration required for the 👍/👎 verdict-feedback and Approve/Reject buttons to work.

## Why

Clicking a button and getting **"The app is not configured to handle interactive responses"** (or a silent no-op) is a **Slack app config** gap, not a RunLore bug — the click never reaches RunLore. The buttons are delivered fine, but the round-trip on click requires the Slack app's **Interactivity & Shortcuts** feature to be toggled on with a Request URL of `https://<your-runlore-host>/slack/interactions` (RunLore serves `POST /slack/interactions`). The docs referenced that Request URL in passing but never spelled out the toggle as a setup step.

## Changes

- **`docs/troubleshooting.md`** — new section keyed on the exact Slack error string, walking through: the Interactivity toggle, the Request URL, the `signing_secret_env` requirement (else the endpoint returns `404 slack interactions not enabled`), and the per-family prerequisites (`outcome.ledger_path` for feedback recording; `actions.mode` + `notify.slack.approver_ids` for Approve/Reject).
- **`docs/getting-started.md`** — makes the Interactivity requirement explicit right next to `signing_secret_env` in the `values.yaml` example.

Docs-only; verified config field names (`signing_secret_env`, `approver_ids`, `ledger_path`) and the `/slack/interactions` route against the code.