### PR TITLE
feat: remove the 👍/👎 verdict-feedback buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ A real RunLore investigation delivered to Slack: a verdict-first summary — the
 (no action / suggested / required / inconclusive), the confidence-scored root cause, the alert
 metadata and recurrence, top-cause "why", suggested next steps, ruled-out hypotheses and data gaps,
 and a link to the pull request it opened in your knowledge base. On a Slack **bot token** the full
-analysis lands as a threaded reply under that summary, and 👍/👎 buttons capture whether the verdict
-was accurate (feeding the learning loop).
+analysis lands as a threaded reply under that summary.
 
 <div align="center">
 <img src="assets/slack-notification.png" alt="RunLore Slack notification — verdict-first summary with confidence-scored root cause, alert metadata, recurrence, suggested next steps, ruled-out hypotheses and a link to the knowledge-base PR" width="760" />
@@ -109,7 +108,7 @@ additive. Full setup detail in **[Data sources](docs/data-sources.md)**.
 | **Kubernetes** | client-go — pod status, events, controller logs | *(in-cluster)* |
 | **LLM** | Anthropic · Google Gemini · any OpenAI-compatible *(vLLM, Ollama, OpenRouter…)* | `model.provider` |
 | **Triggers** *(sources)* | Alertmanager webhook · GitOps failures · PagerDuty webhook *(new)* | `sources.*` |
-| **Notifiers** | Slack *(bot token: threaded summary + detail, 👍/👎 feedback)* · Slack incoming webhook / Matrix / generic webhook *(single verdict-first message)* | `notify.*` |
+| **Notifiers** | Slack *(bot token: threaded summary + detail)* · Slack incoming webhook / Matrix / generic webhook *(single verdict-first message)* | `notify.*` |
 | **Knowledge base** *(git forge)* | GitHub *(App auth)* | `forge.*` |
 
 ## 🚀 Getting started

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,17 +181,10 @@ top-cause "why", suggested next steps, **ruled-out** hypotheses and **data gaps*
 limitations, kept distinct from human-only open questions):
 
 - **Slack, bot token (`bot_token_env`).** Posts a compact verdict-first summary to `channel`, then the
-  full analysis as a **threaded reply**. When `signing_secret_env` is set (same setup as Approve/Reject —
-  see below), the summary carries 👍/👎 feedback buttons; a click records the rating to the outcome
-  ledger.
+  full analysis as a **threaded reply**. When `signing_secret_env` is set and action mode is `approve`,
+  the summary carries Approve/Reject buttons on any suggested remediation (see below).
 - **Slack incoming webhook (`webhook_url_env`), Matrix, generic webhook.** Deliver the same content as a
   **single** message (incoming webhooks cannot thread and expose no interaction buttons).
-
-**Feedback buttons** render whenever the investigation has a trigger key or fingerprint. Clicks are
-HMAC-verified against `signing_secret_env` but **unprivileged** — unlike Approve/Reject they are not
-gated by `approver_ids`. A rating is persisted only when the outcome ledger is enabled
-(`outcome.ledger_path`); without it the click gets an honest "feedback isn't enabled" reply instead of a
-false "recorded" ack. Enabling them needs the same `/slack/interactions` Slack Request URL as approvals.
 
 **Generic webhook JSON payload** gained `verdict`, `severity`, `environment`, `cluster`, `tenant`,
 `alert_name`, `started_at` (RFC3339, empty when unknown), `occurrences`, `prev_curated_url`, `ruled_out`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -287,7 +287,11 @@ config:
       # bot_token_env: SLACK_BOT_TOKEN              # xoxb-… (takes precedence over webhook_url_env);
       #                                             #   posts a verdict-first summary + threaded full analysis
       # channel: C0123456789                        # channel ID or name to post to
-      # signing_secret_env: SLACK_SIGNING_SECRET   # enables Approve/Reject + 👍/👎 feedback buttons
+      # signing_secret_env: SLACK_SIGNING_SECRET   # enables Approve/Reject buttons (needs actions.mode: approve)
+      #   ↳ Approve/Reject also needs Interactivity turned ON in the Slack app:
+      #     api.slack.com/apps → your app → Interactivity & Shortcuts → toggle On,
+      #     Request URL = https://<your-runlore-host>/slack/interactions. Read-only
+      #     deployments (no actions) need none of this.
     matrix:
       homeserver: https://matrix.org
       room_id: "!yourroom:matrix.org"
@@ -503,11 +507,6 @@ want a sharper answer. Only RunLore-originated issues (carrying the `runlore` la
   `POST /actions/<id>/approve` (token-gated) or **Slack Approve/Reject buttons** (enable Slack
   Interactivity with Request URL `…/slack/interactions` and set `slack.signing_secret_env`; clicks are
   HMAC-verified). The envelope is re-checked at execution and every action is audit-logged.
-- **Verdict feedback (Slack bot token)**: delivered summaries carry 👍/👎 buttons rating whether the
-  verdict was accurate. They use the **same** Interactivity Request URL (`…/slack/interactions`) and
-  `slack.signing_secret_env` as the Approve/Reject buttons, but are **unprivileged** (no
-  `approver_ids` allowlist — anyone in the channel can rate). A rating is recorded to the outcome
-  ledger only when `outcome.ledger_path` is set; otherwise the click gets an honest "not enabled" reply.
 - **Unattended (`actions.mode: auto`)**: executes eligible actions with **no human in the loop** — but only
   *reversible* ops, only above `min_confidence`, rate-limited, and **instantly haltable** via
   `POST /actions/pause` (`/resume`). Start with `dry_run: true`, scope which incidents it acts on via the

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -180,11 +180,6 @@ record of **whether a recalled answer preceded the incident actually resolving**
 - When the matching **incident-resolved signal** arrives (a resolved-alert webhook
   today; any source's "cleared" event by design), RunLore appends a **`resolve`** event
   for that fingerprint.
-- When a human clicks 👍/👎 on a delivered Slack summary, RunLore appends a
-  **`feedback`** event (`kind: up|down`) keyed by the incident's trigger key (falling
-  back to fingerprint). Feedback is a *pure append*: replay ignores unknown event kinds,
-  so a rating never disturbs open→resolve pairing — it's captured ground truth for future
-  learning, distinct from the mechanical resolve signal.
 
 The `open` event also now records the incident's **trigger key**, the **curated KB link**
 (so a recurrence can surface "previous: <link>"), and the curator's machine **verdict** —

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -307,14 +307,6 @@ func RunServe(version string, args []string) error {
 	if auto != nil {
 		acts.Pauser = auto // avoid a typed-nil interface when auto is disabled
 	}
-	// Only wire the ledger as a FeedbackRecorder when it actually persists: a
-	// disabled ledger (empty ledger_path) silently no-ops Feedback, so the server
-	// would ack "feedback recorded" while dropping it. Leaving the interface nil
-	// makes the handler answer honestly ("feedback recording not enabled"). Also
-	// covers the typed-nil trap: a nil *Ledger must never become a non-nil interface.
-	if ledger.Enabled() {
-		acts.Feedback = ledger
-	}
 	srv := server.New(ReadyFunc(leader.Load, cat, CatalogConfigured(cfg)), acts, built, pipe, metricsHandler, log)
 	if cz != nil {
 		go cz.Run(workCtx, cfg.Investigation.Coalesce.Debounce.Std()/2)

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -2,7 +2,6 @@ package notify
 
 import (
 	"bytes"
-	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -183,10 +182,8 @@ func (s *SlackBot) post(ctx context.Context, msg map[string]any) (string, error)
 
 // Slack interaction action_ids — must match the server's /slack/interactions handler.
 const (
-	approveActionID      = "runlore_approve"
-	rejectActionID       = "runlore_reject"
-	feedbackUpActionID   = "runlore_feedback_up"
-	feedbackDownActionID = "runlore_feedback_down"
+	approveActionID = "runlore_approve"
+	rejectActionID  = "runlore_reject"
 )
 
 // slackMessage builds the Slack payload: a verdict-first Block Kit summary
@@ -443,19 +440,6 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 					"text": map[string]any{"type": "plain_text", "text": "Reject"}},
 			}},
 		)
-	}
-
-	// 11. Human feedback on the verdict — ground truth for the learning loop. Keyed by
-	// TriggerKey (incident identity) so ratings survive re-worded re-investigations,
-	// falling back to the fingerprint. Unlike the approval buttons these render for
-	// every delivered investigation, independent of any pending action.
-	if key := cmp.Or(inv.TriggerKey, inv.Fingerprint); key != "" {
-		blocks = append(blocks, map[string]any{"type": "actions", "elements": []map[string]any{
-			{"type": "button", "action_id": feedbackUpActionID, "value": key,
-				"text": map[string]any{"type": "plain_text", "text": "👍 Accurate", "emoji": true}},
-			{"type": "button", "action_id": feedbackDownActionID, "value": key,
-				"text": map[string]any{"type": "plain_text", "text": "👎 Off-base", "emoji": true}},
-		}})
 	}
 	return blocks
 }

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -222,32 +222,6 @@ func TestSlackMessageButtons(t *testing.T) {
 	}
 }
 
-func TestSlackFeedbackButtons(t *testing.T) {
-	// TriggerKey present → a feedback actions block with both action_ids and the key
-	// as the button value. Feedback renders even with no ApprovalID actions.
-	blocks := summaryBlocks(providers.Investigation{Confidence: 0.5, TriggerKey: "k"})
-	raw, _ := json.Marshal(blocks)
-	for _, want := range []string{"runlore_feedback_up", "runlore_feedback_down", `"value":"k"`, "Accurate", "Off-base"} {
-		if !contains(string(raw), want) {
-			t.Fatalf("feedback blocks missing %q:\n%s", want, raw)
-		}
-	}
-
-	// No TriggerKey but a Fingerprint → falls back to the fingerprint as the value.
-	blocks = summaryBlocks(providers.Investigation{Confidence: 0.5, Fingerprint: "fp1"})
-	raw, _ = json.Marshal(blocks)
-	if !contains(string(raw), `"value":"fp1"`) {
-		t.Fatalf("feedback value should fall back to Fingerprint:\n%s", raw)
-	}
-
-	// Neither TriggerKey nor Fingerprint → no feedback block at all.
-	blocks = summaryBlocks(providers.Investigation{Confidence: 0.5})
-	raw, _ = json.Marshal(blocks)
-	if contains(string(raw), "runlore_feedback") {
-		t.Fatalf("did not expect feedback buttons without a TriggerKey or Fingerprint:\n%s", raw)
-	}
-}
-
 func TestSlackBlocksLayout(t *testing.T) {
 	inv := providers.Investigation{
 		Title:      "VictoriaTracesDown",

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"sync"
@@ -22,13 +21,13 @@ type Event struct {
 	Fingerprint    string `json:"fingerprint"`               // Alertmanager fingerprint (stable firing↔resolved)
 	DupFingerprint string `json:"dup_fingerprint,omitempty"` // curator dedup fingerprint (resource+cause); the curated-PR resolution join key
 
-	Kind     string    `json:"kind,omitempty"`  // open: "recall" | "fresh"; feedback: "up" | "down"
+	Kind     string    `json:"kind,omitempty"`  // open: "recall" | "fresh"
 	Entry    string    `json:"entry,omitempty"` // open+recall: the recalled entry path
 	Title    string    `json:"title,omitempty"`
 	Resource string    `json:"resource,omitempty"`
 	At       time.Time `json:"at"`
 
-	// Recurrence/feedback fields (written by the delivery path). Kept omitempty so the
+	// Recurrence fields (written by the delivery path). Kept omitempty so the
 	// append-only file stays backward/forward compatible with older readers.
 	TriggerKey string `json:"trigger_key,omitempty"` // groups recurrences of the same alert; keys the byTrigger index
 	CuratedURL string `json:"curated_url,omitempty"` // KB link surfaced as "previous: <link>" on recurrence
@@ -257,9 +256,9 @@ func (l *Ledger) enabled() bool { return l != nil && l.path != "" }
 
 // Enabled reports whether the ledger will actually persist events (a non-empty
 // ledger_path was configured); nil-safe. Exported for wiring sites: a disabled
-// ledger's methods silently no-op, so handing it to a consumer that acks writes
-// (e.g. the server's FeedbackRecorder) would lie about persistence. Cheaper than
-// Status(), which re-reads the whole file.
+// ledger's methods silently no-op, so handing it to a consumer that assumes its
+// writes land would misrepresent persistence. Cheaper than Status(), which
+// re-reads the whole file.
 func (l *Ledger) Enabled() bool { return l.enabled() }
 
 // Status is a cheap snapshot of the ledger's on-disk reality, used to tell apart
@@ -353,21 +352,6 @@ func (l *Ledger) Occurrences(triggerKey string) (int, time.Time, string) {
 	defer l.mu.Unlock()
 	a := l.byTrigger[triggerKey]
 	return a.count, a.last, a.curatedURL
-}
-
-// Feedback appends a human 👍/👎 verdict on a delivered investigation. It is a
-// pure append: replay ignores unknown event kinds, so feedback never disturbs
-// open/resolve pairing or the recall aggregate.
-func (l *Ledger) Feedback(triggerKey, fingerprint, rating string, at time.Time) error {
-	if !l.enabled() {
-		return nil
-	}
-	if rating != "up" && rating != "down" {
-		return fmt.Errorf("feedback rating %q: want up or down", rating)
-	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.appendLocked(Event{Event: "feedback", TriggerKey: triggerKey, Fingerprint: fingerprint, Kind: rating, At: at})
 }
 
 // Episodes replays the full ledger and turns every open into an Episode, pairing

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -815,47 +815,6 @@ func TestOccurrencesEmptyKeyAndDisabled(t *testing.T) {
 	}
 }
 
-// TestFeedbackAppendsAndIsIgnoredByReplay ensures a feedback event is a pure append:
-// it must not disturb open/resolve pairing (Episodes still pairs exactly one episode)
-// and an invalid rating is rejected.
-func TestFeedbackAppendsAndIsIgnoredByReplay(t *testing.T) {
-	p := filepath.Join(t.TempDir(), "o.jsonl")
-	l, _ := New(p)
-	t0 := time.Unix(18000, 0)
-	_ = l.Open(Event{Fingerprint: "f", TriggerKey: "k", Kind: "recall", Entry: "x.md", At: t0})
-	if err := l.Feedback("k", "f", "up", t0.Add(time.Second)); err != nil {
-		t.Fatalf("Feedback up: %v", err)
-	}
-	_, _, _ = l.Resolve("f", t0.Add(2*time.Second))
-
-	// The feedback line is ignored by replay: pairing is untouched.
-	eps, err := l.Episodes()
-	if err != nil {
-		t.Fatalf("Episodes: %v", err)
-	}
-	resolved := 0
-	for _, e := range eps {
-		if e.Resolved {
-			resolved++
-		}
-	}
-	if len(eps) != 1 || resolved != 1 {
-		t.Fatalf("feedback must not disturb pairing: want 1 episode/1 resolved, got %d/%d", len(eps), resolved)
-	}
-	// OpenCounts (cache) is likewise undisturbed and equals a from-scratch replay.
-	assertCacheEqualsReplay(t, l, p)
-
-	// An invalid rating is rejected.
-	if err := l.Feedback("k", "f", "sideways", t0.Add(3*time.Second)); err == nil {
-		t.Fatal("Feedback with an invalid rating must return an error")
-	}
-	// A disabled ledger no-ops Feedback (no error).
-	dis, _ := New("")
-	if err := dis.Feedback("k", "f", "sideways", t0); err != nil {
-		t.Fatalf("disabled Feedback must be a no-op even for a bad rating: %v", err)
-	}
-}
-
 // TestLedgerEnabled pins the exported wiring predicate: only a ledger with a
 // configured path reports Enabled, and a nil receiver is safe (mirrors enabled()).
 func TestLedgerEnabled(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,7 +34,6 @@ type Server struct {
 	slackSecret  string            // Slack signing secret; verifies interactive button clicks
 	webhookToken string            // optional bearer token required on POST /webhook/alertmanager
 	approvers    map[string]bool   // Slack user IDs permitted to approve actions (empty = none)
-	feedback     FeedbackRecorder  // nil unless an outcome ledger is configured; records 👍/👎 clicks
 
 	metrics http.Handler // optional; GET /metrics (OTel Prometheus exposition)
 	log     *slog.Logger
@@ -48,12 +47,6 @@ type Pauser interface {
 	Paused() bool
 }
 
-// FeedbackRecorder persists a human 👍/👎 on a delivered investigation
-// (implemented by *outcome.Ledger).
-type FeedbackRecorder interface {
-	Feedback(triggerKey, fingerprint, rating string, at time.Time) error
-}
-
 // Actions bundles the optional rung-2/rung-3 wiring: the approval queue, the auto
 // kill-switch, the shared control token, and the Slack signing secret.
 type Actions struct {
@@ -61,9 +54,8 @@ type Actions struct {
 	Pauser       Pauser
 	Token        string
 	SlackSecret  string
-	WebhookToken string           // optional bearer token required on POST /webhook/alertmanager
-	ApproverIDs  []string         // Slack user IDs permitted to approve actions
-	Feedback     FeedbackRecorder // nil unless an outcome ledger is configured; records unprivileged 👍/👎 clicks
+	WebhookToken string   // optional bearer token required on POST /webhook/alertmanager
+	ApproverIDs  []string // Slack user IDs permitted to approve actions
 }
 
 // New builds a Server. ready reports whether this replica should serve; nil =
@@ -82,7 +74,7 @@ func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pip
 	s := &Server{
 		ready:     ready,
 		approvals: acts.Approvals, pauser: acts.Pauser, token: acts.Token, slackSecret: acts.SlackSecret,
-		webhookToken: acts.WebhookToken, approvers: approvers, feedback: acts.Feedback, metrics: metricsHandler, log: log,
+		webhookToken: acts.WebhookToken, approvers: approvers, metrics: metricsHandler, log: log,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /slack/interactions", s.handleSlackInteraction)
@@ -242,14 +234,13 @@ type slackInteraction struct {
 }
 
 // handleSlackInteraction processes Block Kit button clicks: it verifies the Slack
-// request signature, then either approves (executing) / rejects the referenced
-// action (privileged — approver allowlist) or records an unprivileged 👍/👎 in the
-// outcome ledger, updating the message via response_url.
+// request signature, then approves (executing) / rejects the referenced action
+// (privileged — approver allowlist), updating the message via response_url.
 func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) {
-	// Admit the request when EITHER approvals or feedback is wired — a feedback-only
-	// server (outcome ledger, no rung-2 actions) still serves 👍/👎 clicks. The
-	// signing secret stays mandatory: signature verification is never optional.
-	if (s.approvals == nil && s.feedback == nil) || s.slackSecret == "" {
+	// The endpoint only exists to drive Approve/Reject on queued actions, so it is
+	// disabled unless approvals are wired. The signing secret stays mandatory:
+	// signature verification is never optional.
+	if s.approvals == nil || s.slackSecret == "" {
 		http.Error(w, "slack interactions not enabled", http.StatusNotFound)
 		return
 	}
@@ -274,9 +265,6 @@ func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	act := p.Actions[0]
-	// Feedback acks are appended (replace_original:false) so the investigation stays
-	// on screen; approve/reject replace the message with the outcome.
-	replaceOriginal := true
 	var msg string
 	switch act.ActionID {
 	case "runlore_approve":
@@ -318,32 +306,12 @@ func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) 
 		} else {
 			msg = fmt.Sprintf("🚫 rejected by @%s", p.User.Username)
 		}
-	case "runlore_feedback_up", "runlore_feedback_down":
-		// Feedback is deliberately unprivileged: no approver-allowlist check. The
-		// signature proves the click came from the workspace; anyone on-call may rate a
-		// verdict. The ack is appended, not replaced, so the investigation stays visible.
-		replaceOriginal = false
-		if s.feedback == nil {
-			msg = "⚠️ feedback recording not enabled (no outcome ledger configured)"
-			break
-		}
-		rating := "up"
-		if act.ActionID == "runlore_feedback_down" {
-			rating = "down"
-		}
-		if ferr := s.feedback.Feedback(act.Value, "", rating, time.Now()); ferr != nil {
-			msg = "⚠️ recording feedback failed: " + ferr.Error()
-			s.log.Warn("slack feedback failed", "key", act.Value, "err", ferr)
-		} else {
-			msg = fmt.Sprintf("🙏 feedback recorded (%s) — thanks @%s", rating, p.User.Username)
-			s.log.Info("slack feedback recorded", "key", act.Value, "rating", rating, "user", p.User.Username)
-		}
 	default:
 		http.Error(w, "unknown action", http.StatusBadRequest)
 		return
 	}
 	w.WriteHeader(http.StatusOK) // ack the click; update the message best-effort
-	s.updateSlack(r.Context(), p.ResponseURL, msg, replaceOriginal)
+	s.updateSlack(r.Context(), p.ResponseURL, msg)
 }
 
 // verifySlack validates the Slack request signature (HMAC-SHA256 over
@@ -363,13 +331,12 @@ func (s *Server) verifySlack(h http.Header, body []byte) bool {
 	return hmac.Equal([]byte(expected), []byte(h.Get("X-Slack-Signature")))
 }
 
-// updateSlack posts text back to the interaction response_url. When replaceOriginal
-// is true it overwrites the message (approve/reject outcomes); when false it appends
-// a new message so the investigation stays visible (feedback acks must never wipe it).
-// The URL is attacker-influenceable (it arrives in the interaction payload), so
-// it is restricted to https *.slack.com and posted with a bounded client — no
-// SSRF to arbitrary internal services, no unbounded hang on http.DefaultClient.
-func (s *Server) updateSlack(ctx context.Context, responseURL, text string, replaceOriginal bool) {
+// updateSlack overwrites the interaction message via its response_url with the
+// approve/reject outcome. The URL is attacker-influenceable (it arrives in the
+// interaction payload), so it is restricted to https *.slack.com and posted with a
+// bounded client — no SSRF to arbitrary internal services, no unbounded hang on
+// http.DefaultClient.
+func (s *Server) updateSlack(ctx context.Context, responseURL, text string) {
 	if responseURL == "" {
 		return
 	}
@@ -378,7 +345,7 @@ func (s *Server) updateSlack(ctx context.Context, responseURL, text string, repl
 		s.log.Warn("refusing slack response_url: not an https *.slack.com host", "url", responseURL)
 		return
 	}
-	body, _ := json.Marshal(map[string]any{"replace_original": replaceOriginal, "text": text})
+	body, _ := json.Marshal(map[string]any{"replace_original": true, "text": text})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, responseURL, bytes.NewReader(body))
 	if err != nil {
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Smana/runlore/internal/audit"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
-	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/source"
 	_ "github.com/Smana/runlore/internal/source/alertmanager" // self-registers the alertmanager webhook source
@@ -125,91 +124,16 @@ func TestSlackRejectRequiresApprover(t *testing.T) {
 	}
 }
 
-// recordFeedback is a spy FeedbackRecorder capturing the last recorded rating.
-type recordFeedback struct {
-	calls []struct{ key, fp, rating string }
-}
-
-func (r *recordFeedback) Feedback(triggerKey, fingerprint, rating string, _ time.Time) error {
-	r.calls = append(r.calls, struct{ key, fp, rating string }{triggerKey, fingerprint, rating})
-	return nil
-}
-
-// TestSlackFeedbackInteraction locks the 👍/👎 path: feedback is unprivileged (works
-// with approvals==nil and for a user NOT in the approver allowlist), up/down map to
-// the ledger ratings, and an approve click with approvals==nil returns a "not
-// enabled" ack rather than a 404.
-func TestSlackFeedbackInteraction(t *testing.T) {
+// TestSlackInteractionDisabledWithoutApprovals pins the contract that the
+// /slack/interactions endpoint exists ONLY to drive Approve/Reject on queued
+// actions: with no approval queue wired (a read-only deployment) it must 404 — even
+// for a signature-valid click — so a read-only RunLore exposes no interactive
+// callback at all.
+func TestSlackInteractionDisabledWithoutApprovals(t *testing.T) {
 	const secret = "shh"
-	fb := &recordFeedback{}
-	// No approvals, an empty approver allowlist: feedback must still be recorded.
-	srv := New(nil, Actions{SlackSecret: secret, Feedback: fb}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{SlackSecret: secret}, nil, nil, nil, discardLog)
 
-	post := func(actionID, value string) *httptest.ResponseRecorder {
-		payload := `{"user":{"id":"U9","username":"bob"},"actions":[{"action_id":"` + actionID + `","value":"` + value + `"}]}`
-		body := "payload=" + url.QueryEscape(payload)
-		ts := strconv.FormatInt(time.Now().Unix(), 10)
-		req := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(body))
-		req.Header.Set("X-Slack-Request-Timestamp", ts)
-		req.Header.Set("X-Slack-Signature", slackSign(secret, ts, body))
-		rr := httptest.NewRecorder()
-		srv.Handler().ServeHTTP(rr, req)
-		return rr
-	}
-
-	// 👍 from a non-allowlisted user, approvals disabled → 200, recorded as ("k","","up").
-	if rr := post("runlore_feedback_up", "k"); rr.Code != http.StatusOK {
-		t.Fatalf("feedback up = %d, want 200", rr.Code)
-	}
-	// 👎 → recorded as ("k2","","down").
-	if rr := post("runlore_feedback_down", "k2"); rr.Code != http.StatusOK {
-		t.Fatalf("feedback down = %d, want 200", rr.Code)
-	}
-	if len(fb.calls) != 2 {
-		t.Fatalf("expected 2 feedback calls, got %d: %+v", len(fb.calls), fb.calls)
-	}
-	if fb.calls[0] != (struct{ key, fp, rating string }{"k", "", "up"}) {
-		t.Fatalf("up call = %+v, want {k  up}", fb.calls[0])
-	}
-	if fb.calls[1] != (struct{ key, fp, rating string }{"k2", "", "down"}) {
-		t.Fatalf("down call = %+v, want {k2  down}", fb.calls[1])
-	}
-
-	// runlore_approve with approvals==nil must ack (200), not 404 — the guard now
-	// admits feedback-only servers, so approve returns a "not enabled" message.
-	if rr := post("runlore_approve", "a1"); rr.Code != http.StatusOK {
-		t.Fatalf("approve with approvals==nil = %d, want 200 (not-enabled ack)", rr.Code)
-	}
-}
-
-// TestSlackFeedbackDisabledLedger pins the honest-reply wiring: a disabled outcome
-// ledger (empty path) must NOT be handed to the server as a FeedbackRecorder — its
-// Feedback() silently no-ops, so acking "recorded" would lie to the on-call. With
-// no recorder wired the handler's feedback==nil branch answers "not enabled" (and
-// never logs a recorded event), while the click is still acked with a 200.
-func TestSlackFeedbackDisabledLedger(t *testing.T) {
-	led, err := outcome.New("") // empty ledger_path → disabled
-	if err != nil {
-		t.Fatalf("outcome.New: %v", err)
-	}
-
-	// Mirror the serve.go wiring predicate: a disabled ledger stays a nil interface.
-	exec := &recordExec{}
-	pol := action.New(config.ActionPolicy{Mode: config.ActionApprove})
-	ap := action.NewApprovals(exec, pol, audit.Nop{}, discardLog)
-	const secret = "shh"
-	acts := Actions{Approvals: ap, SlackSecret: secret}
-	if led.Enabled() {
-		acts.Feedback = led
-	}
-	if acts.Feedback != nil {
-		t.Fatal("disabled ledger must not be wired as a FeedbackRecorder")
-	}
-
-	var logBuf bytes.Buffer
-	srv := New(nil, acts, nil, nil, nil, slog.New(slog.NewTextHandler(&logBuf, nil)))
-
-	payload := `{"user":{"id":"U9","username":"bob"},"actions":[{"action_id":"runlore_feedback_up","value":"k"}]}`
+	payload := `{"user":{"id":"U1","username":"alice"},"actions":[{"action_id":"runlore_approve","value":"a1"}]}`
 	body := "payload=" + url.QueryEscape(payload)
 	ts := strconv.FormatInt(time.Now().Unix(), 10)
 	req := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(body))
@@ -218,11 +142,8 @@ func TestSlackFeedbackDisabledLedger(t *testing.T) {
 	rr := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("feedback click with disabled ledger = %d, want 200 (honest not-enabled ack)", rr.Code)
-	}
-	if strings.Contains(logBuf.String(), "feedback recorded") {
-		t.Fatalf("disabled ledger must not claim feedback was recorded; log:\n%s", logBuf.String())
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("interactions with approvals==nil = %d, want 404 (endpoint disabled)", rr.Code)
 	}
 }
 


### PR DESCRIPTION
## Why

The 👍/👎 "Accurate / Off-base" feedback buttons were a **write-only affordance**. A click appended a `{event:"feedback", kind:"up|down"}` line to the outcome ledger that **no code path ever read back**:

- `loadLocked` — the only ledger replay — folds `case "open"` and `case "resolve"` only; there is no `case "feedback"`.
- Recall confidence decay (`outcomeFactor`) is driven **entirely** by open→resolve pairing (*did the recalled incident actually resolve*), never by votes.
- No eval, `lore curate`, metric, or dashboard consumed feedback events.

So the buttons advertised a "feedback edge that feeds the learning loop" the code never honored — while forcing a **public Slack Interactivity callback endpoint** onto any deployment that wanted them. That's a poor trade, and actively misleading, especially for **read-only** (the default) private clusters that would otherwise need no inbound endpoint at all.

## What changed

**Removed**
- The feedback buttons + their `runlore_feedback_*` action_ids in the Slack notifier.
- `Ledger.Feedback`, the server `FeedbackRecorder` interface, and the `serve.go` wiring.
- The `handleSlackInteraction` feedback case and the now-constant `replaceOriginal` plumbing.
- Docs claiming feedback trains the learning loop (README, configuration, getting-started, learning-loop).

**Kept**
- **Approve/Reject** — those execute/cancel a *real* queued action and are gated behind the opt-in autonomy ladder.

## Consequence (nice simplification)

The `/slack/interactions` endpoint now exists **only when approvals are wired**. A read-only deployment (the default) exposes **no interactive callback at all** — Slack Interactivity becomes required solely when you opt into `actions.mode: approve`, a coherent story ("you let Slack trigger cluster ops, so you wire the callback"). A new test pins the 404-when-no-approvals contract.

The objective, Git-anchored learning signal (recalled → resolved) is unchanged and needs no human clicks.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test ./...` — **45 packages, 0 failures** (includes the new `TestSlackInteractionDisabledWithoutApprovals` and the Slack block-layout tests).
- k3d end-to-end (`hack/e2e-k3d.sh`) to follow — validates Slack delivery + the Approve/Reject button flow still work end-to-end.

Closes the feature that #236 documented (that docs PR will be closed).