### PR TITLE
fix(whatchanged): recover the diff when Flux advanced past the break (health-check failures)

### DIFF
--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -125,10 +125,17 @@ func (p *Provider) Changes(ctx context.Context, _ providers.TimeWindow, sel prov
 // revisionRange picks the (FromRev, ToRev) a Change should diff. For a healthy
 // Kustomization it is ("", lastApplied) — the change introduced by the applied
 // revision. For a FAILING one (Ready != True) whose source HEAD has moved past
-// lastApplied, it is (lastApplied, HEAD): Flux pins lastAppliedRevision to the last
-// HEALTHY commit on a health-check failure, so keying on it alone would diff the
-// pre-break commit and miss the breaking one. The source read is best-effort — on
-// any error (or when HEAD == lastApplied) we fall back to the single-revision range.
+// lastApplied, it is (lastApplied, HEAD) — a best-effort attempt to span the
+// breaking commit for the case where Flux held lastAppliedRevision at the last-good
+// revision (e.g. an apply failure).
+//
+// This is only a heuristic. On a health-check *failure* Flux applies the manifest —
+// advancing lastAppliedRevision to (or past) the breaking commit — before the health
+// gate fails, so the change is at/behind lastApplied and this forward range can miss
+// it entirely. That case is recovered downstream: Differ.ForChange falls back to the
+// newest commit that actually touched the resource's path (RunLore #239). The source
+// read is best-effort — on any error (or when HEAD == lastApplied) we fall back to
+// the single-revision range.
 func revisionRange(ctx context.Context, reader Reader, k kustomization) (fromRev, toRev string) {
 	lastApplied := parseRevision(k.Revision)
 	if k.ReadyStatus == "True" || k.ReadyStatus == "" {

--- a/internal/providers/gitops/flux/flux_test.go
+++ b/internal/providers/gitops/flux/flux_test.go
@@ -92,12 +92,14 @@ func TestProviderChanges(t *testing.T) {
 	}
 }
 
-// TestProviderChangesFailingKustomizationSpansGap covers the core bug: a failing
-// Kustomization keeps status.lastAppliedRevision pinned to the last HEALTHY commit
-// (Flux does NOT advance it on a health-check failure). Keying "what changed" on
-// lastAppliedRevision alone diffs the pre-break commit and misses the breaking one.
-// For a failing Kustomization whose source HEAD differs from lastApplied, the Change
-// must span lastApplied..HEAD; otherwise behavior is unchanged.
+// TestProviderChangesFailingKustomizationSpansGap covers the apply-failure case: when
+// Flux holds status.lastAppliedRevision at the last-good commit (it couldn't apply
+// HEAD), keying "what changed" on lastAppliedRevision alone diffs the pre-break commit
+// and misses the breaking one. For a failing Kustomization whose source HEAD differs
+// from lastApplied, the Change must span lastApplied..HEAD; otherwise behavior is
+// unchanged. (The health-failure case, where Flux DOES advance lastAppliedRevision
+// past the break so this range comes back empty, is recovered by Differ.ForChange's
+// last-path-change fallback — RunLore #239.)
 func TestProviderChangesFailingKustomizationSpansGap(t *testing.T) {
 	const url = "https://github.com/org/repo"
 	cases := []struct {

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -6,7 +6,9 @@ package whatchanged
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -220,12 +222,82 @@ func (d *Differ) RemoteFromParent(ctx context.Context, url, rev, scope string) (
 // with only ToRev it diffs the change introduced by ToRev (against its parent).
 // ctx bounds the clone + patch so a caller deadline (per-investigation timeout)
 // aborts a hung remote.
+//
+// When the forward range holds no change to the resource's path it falls back to
+// the newest commit that actually touched the path. This matters on a Flux
+// health-check failure: Flux applies the manifest (advancing lastAppliedRevision to
+// the breaking commit) and only then fails the health gate, so the change is at/behind
+// the applied revision — diffing forward from it misses it entirely (RunLore #239).
 func (d *Differ) ForChange(ctx context.Context, c providers.Change) (providers.Diff, error) {
 	if c.ToRev == "" {
 		return providers.Diff{}, fmt.Errorf("change %s/%s: missing to revision", c.Workload.Namespace, c.Workload.Name)
 	}
+	var (
+		diff providers.Diff
+		err  error
+	)
 	if c.FromRev == "" {
-		return d.RemoteFromParent(ctx, c.Source.RepoURL, c.ToRev, c.Source.Path)
+		diff, err = d.RemoteFromParent(ctx, c.Source.RepoURL, c.ToRev, c.Source.Path)
+	} else {
+		diff, err = d.Remote(ctx, c.Source.RepoURL, c.FromRev, c.ToRev, c.Source.Path)
 	}
-	return d.Remote(ctx, c.Source.RepoURL, c.FromRev, c.ToRev, c.Source.Path)
+	if err != nil {
+		return diff, err
+	}
+	if len(diff.Files) == 0 && c.Source.Path != "" {
+		if fb, ferr := d.RemoteLastPathChange(ctx, c.Source.RepoURL, c.ToRev, c.Source.Path); ferr == nil && len(fb.Files) > 0 {
+			return fb, nil
+		}
+	}
+	return diff, nil
+}
+
+// RemoteLastPathChange clones url and returns the path-scoped diff of the newest
+// commit reachable from atRev that actually modified scope, against its first parent.
+// It is ForChange's fallback when the forward range holds no change to scope (see
+// RunLore #239). Returns an empty diff when scope is empty, no ancestor of atRev
+// touches scope, or the touching commit is a root commit (no parent).
+func (d *Differ) RemoteLastPathChange(ctx context.Context, url, atRev, scope string) (providers.Diff, error) {
+	if scope == "" {
+		return providers.Diff{}, nil
+	}
+	repo, cleanup, err := d.cloneToDisk(ctx, url)
+	if err != nil {
+		return providers.Diff{}, err
+	}
+	defer cleanup()
+	return lastPathChange(ctx, repo, atRev, scope)
+}
+
+// lastPathChange walks history from atRev and returns the path-scoped diff of the
+// newest commit that modified scope, against its first parent.
+func lastPathChange(ctx context.Context, repo *git.Repository, atRev, scope string) (providers.Diff, error) {
+	from, err := resolveCommit(repo, atRev)
+	if err != nil {
+		return providers.Diff{}, fmt.Errorf("resolve %q: %w", atRev, err)
+	}
+	iter, err := repo.Log(&git.LogOptions{
+		From:       from.Hash,
+		Order:      git.LogOrderCommitterTime,
+		PathFilter: func(p string) bool { return underScope(p, scope) },
+	})
+	if err != nil {
+		return providers.Diff{}, fmt.Errorf("log %s: %w", scope, err)
+	}
+	defer iter.Close()
+	to, err := iter.Next()
+	if errors.Is(err, io.EOF) {
+		return providers.Diff{}, nil // nothing in history touched scope
+	}
+	if err != nil {
+		return providers.Diff{}, fmt.Errorf("log %s: %w", scope, err)
+	}
+	if to.NumParents() == 0 {
+		return providers.Diff{}, nil // root commit: no parent to diff against
+	}
+	parent, err := to.Parent(0)
+	if err != nil {
+		return providers.Diff{}, fmt.Errorf("parent of %s: %w", to.Hash, err)
+	}
+	return diffCommits(ctx, parent, to, scope)
 }

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -191,6 +191,20 @@ func (d *Differ) Remote(ctx context.Context, url, fromRev, toRev, scope string) 
 	return diffRevisions(ctx, repo, fromRev, toRev, scope)
 }
 
+// diffAgainstFirstParent returns the path-scoped diff of the change introduced by
+// commit to (to against its first parent). A root commit (no parent) yields an
+// empty diff.
+func diffAgainstFirstParent(ctx context.Context, to *object.Commit, scope string) (providers.Diff, error) {
+	if to.NumParents() == 0 {
+		return providers.Diff{}, nil // root commit: nothing to diff against
+	}
+	from, err := to.Parent(0)
+	if err != nil {
+		return providers.Diff{}, fmt.Errorf("parent of %s: %w", to.Hash, err)
+	}
+	return diffCommits(ctx, from, to, scope)
+}
+
 // RemoteFromParent clones url and returns the path-scoped diff of the change
 // introduced by rev (rev against its first parent). A root commit (no parent)
 // yields an empty diff. ctx bounds the clone + patch.
@@ -207,14 +221,7 @@ func (d *Differ) RemoteFromParent(ctx context.Context, url, rev, scope string) (
 	if err != nil {
 		return providers.Diff{}, fmt.Errorf("resolve %q: %w", rev, err)
 	}
-	if to.NumParents() == 0 {
-		return providers.Diff{}, nil // root commit: nothing to diff against
-	}
-	from, err := to.Parent(0)
-	if err != nil {
-		return providers.Diff{}, fmt.Errorf("parent of %q: %w", rev, err)
-	}
-	return diffCommits(ctx, from, to, scope)
+	return diffAgainstFirstParent(ctx, to, scope)
 }
 
 // ForChange resolves the diff for a detected Change by cloning its source repo
@@ -244,7 +251,8 @@ func (d *Differ) ForChange(ctx context.Context, c providers.Change) (providers.D
 	if err != nil {
 		return diff, err
 	}
-	if len(diff.Files) == 0 && c.Source.Path != "" {
+	// RemoteLastPathChange is a no-op for an empty path, so no guard needed here.
+	if len(diff.Files) == 0 {
 		if fb, ferr := d.RemoteLastPathChange(ctx, c.Source.RepoURL, c.ToRev, c.Source.Path); ferr == nil && len(fb.Files) > 0 {
 			return fb, nil
 		}
@@ -292,12 +300,5 @@ func lastPathChange(ctx context.Context, repo *git.Repository, atRev, scope stri
 	if err != nil {
 		return providers.Diff{}, fmt.Errorf("log %s: %w", scope, err)
 	}
-	if to.NumParents() == 0 {
-		return providers.Diff{}, nil // root commit: no parent to diff against
-	}
-	parent, err := to.Parent(0)
-	if err != nil {
-		return providers.Diff{}, fmt.Errorf("parent of %s: %w", to.Hash, err)
-	}
-	return diffCommits(ctx, parent, to, scope)
+	return diffAgainstFirstParent(ctx, to, scope)
 }

--- a/internal/whatchanged/differ_test.go
+++ b/internal/whatchanged/differ_test.go
@@ -207,3 +207,85 @@ func TestForChangeCancelledCtx(t *testing.T) {
 		t.Fatalf("error must wrap context.Canceled (errors.Is), got: %v", err)
 	}
 }
+
+// addUnrelatedCommit adds a commit touching only other/app.yaml (not apps/harbor)
+// on top of the repo, advancing HEAD past the last apps/harbor change.
+func addUnrelatedCommit(t *testing.T, dir string) plumbing.Hash {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "other/app.yaml"), []byte("x: 3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("other/app.yaml"); err != nil {
+		t.Fatal(err)
+	}
+	h, err := wt.Commit("unrelated", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@x", When: time.Unix(3000, 0)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func TestRemoteLastPathChange(t *testing.T) {
+	dir, _, v2 := buildRepo(t)
+	addUnrelatedCommit(t, dir) // advance HEAD past the last apps/harbor change
+
+	// Finds v2 (the newest commit touching apps/harbor) and diffs it vs its parent.
+	d, err := (&Differ{}).RemoteLastPathChange(context.Background(), dir, "HEAD", "apps/harbor")
+	if err != nil {
+		t.Fatalf("RemoteLastPathChange: %v", err)
+	}
+	if len(d.Files) != 1 || d.Files[0].Path != "apps/harbor/values.yaml" ||
+		!strings.Contains(d.Files[0].Patch, "+version: 1.15.0") {
+		t.Fatalf("want the v2=%s apps/harbor delta, got %v", v2.String()[:7], paths(d.Files))
+	}
+
+	// A path never touched in history degrades to an empty diff, not an error.
+	empty, err := (&Differ{}).RemoteLastPathChange(context.Background(), dir, "HEAD", "apps/does-not-exist")
+	if err != nil {
+		t.Fatalf("RemoteLastPathChange (untouched path): %v", err)
+	}
+	if len(empty.Files) != 0 {
+		t.Fatalf("untouched path must yield an empty diff, got %v", paths(empty.Files))
+	}
+}
+
+// TestForChangeFallsBackToLastPathChange reproduces RunLore #239: on a health-check
+// failure Flux advances lastAppliedRevision to (or past) the breaking commit, so the
+// forward range diff for the resource's path is EMPTY. ForChange must then fall back
+// to the newest commit that actually touched the path — the real "what changed" —
+// rather than returning nothing (which leaves the model with only a bare SHA).
+func TestForChangeFallsBackToLastPathChange(t *testing.T) {
+	dir, _, v2 := buildRepo(t) // v2 is the last commit touching apps/harbor (the break)
+	head := addUnrelatedCommit(t, dir)
+
+	// The Change the flux provider builds for a failing Kustomization whose
+	// lastAppliedRevision advanced to HEAD: ToRev=HEAD, and HEAD did not touch
+	// apps/harbor, so the primary parent-diff of HEAD scoped to apps/harbor is empty.
+	c := providers.Change{
+		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
+		Engine:   providers.EngineFlux,
+		Type:     providers.ChangeSync,
+		ToRev:    head.String(),
+		Source:   providers.SourceRef{RepoURL: dir, Path: "apps/harbor"},
+	}
+	d, err := (&Differ{}).ForChange(context.Background(), c)
+	if err != nil {
+		t.Fatalf("ForChange: %v", err)
+	}
+	if len(d.Files) != 1 || d.Files[0].Path != "apps/harbor/values.yaml" {
+		t.Fatalf("want the last apps/harbor change (v2=%s), got %v", v2.String()[:7], paths(d.Files))
+	}
+	if !strings.Contains(d.Files[0].Patch, "+version: 1.15.0") || !strings.Contains(d.Files[0].Patch, "runMigrations") {
+		t.Fatalf("fallback diff missing the actual change:\n%s", d.Files[0].Patch)
+	}
+}


### PR DESCRIPTION
Fixes #239.

## Problem

On a Flux **health-check failure** (`wait: true`), Flux *applies* the manifest successfully — advancing `status.lastAppliedRevision` to the breaking commit — and only **then** fails the health gate. So the breaking change is **at/behind `lastAppliedRevision`**, and `revisionRange`'s forward `lastApplied..HEAD` diff (scoped to the resource's path) **misses it entirely**.

Result observed on a live cluster (v0.6.0): `what_changed` returned only a bare `FromRev..ToRev` header with **no diff content**, and the model fell back to citing — and recommending "revert" — `ToRev`, a commit that never touched the failing resource. The delivered notification even flagged it as a data gap: *"returned the commit hash… but not the diff content."*

The root wrong assumption was encoded in a comment: *"Flux pins lastAppliedRevision to the last HEALTHY commit on a health-check failure."* It doesn't — it advances it.

## Fix

`Differ.ForChange` now **falls back to the newest commit that actually touched the resource's path** when the forward range holds no change:

- New `RemoteLastPathChange` — go-git `Log` + `PathFilter` to find the last commit touching the scope, diffed against its first parent.
- Reuses the existing clone cache, so **no extra clone** in the common `what_changed` path (only engaged when the primary diff is empty).
- Lives in the **shared** differ → both **Flux and Argo CD** benefit.
- Degrades gracefully (empty scope / untouched path / root commit → empty diff, no error).

`revisionRange` is left unchanged (still correct for apply failures and drift); its comment + test previously stated the false premise and are corrected to reflect reality and point at the fallback.

## Tests (TDD)

- `TestForChangeFallsBackToLastPathChange` — the #239 repro: break in `v2`, HEAD advances via an unrelated `v3`, forward diff empty → fallback surfaces the `v2` change. (Watched it fail first — `got []` — before implementing.)
- `TestRemoteLastPathChange` — finds the touching commit; untouched path → empty diff, no error.

`go build`, `go vet`, `gofmt`, and `go test ./...` (all packages) green.