### PR TITLE
fix(recall): correct outcome-decay factor to documented Beta(1,1) prior

### DIFF
--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -193,12 +193,20 @@ func clampF(v, lo, hi float64) float64 {
 	return v
 }
 
-// outcomeFactor decays a recall's confidence by its track record using an
-// optimistic Beta prior: an entry with no history (or that always resolves)
-// scores 1.0; one that recalls-but-never-resolves decays toward 0. k is the
-// prior strength. Always in (0, 1] provided resolved ≤ recalls and k > 0.
+// outcomeFactor decays a recall's confidence by its track record as the posterior
+// mean of a symmetric Beta(k/2, k/2) prior over the resolve rate:
+//
+//	factor = (resolved + k/2) / (recalls + k)
+//
+// k is the total pseudo-observation count (the prior strength). With the default
+// k=2 this is the documented Beta(1,1) posterior (resolved+1)/(recalls+2): an entry
+// with no history sits at the prior mean 0.5, a consistently-resolving one asymptotes
+// toward 1 without ever reaching it, and one that recalls-but-never-resolves decays
+// fast (0.333 after a single unresolved recall). Always in (0, 1) for k > 0 and
+// resolved ≤ recalls. Entries with no recall history never reach this gate (they are
+// absent from OpenCounts), so a brand-new entry is not punished by the 0.5 prior mean.
 func outcomeFactor(recalls, resolved int, k float64) float64 {
-	return (float64(resolved) + k) / (float64(recalls) + k)
+	return (float64(resolved) + k/2) / (float64(recalls) + k)
 }
 
 // deriveRecallConfidence turns the match signals into an explainable confidence,

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -198,16 +198,22 @@ func TestRecalledInvestigationStampsAlertMetadata(t *testing.T) {
 }
 
 func TestOutcomeFactor(t *testing.T) {
-	const k = 2.0
+	const k = 2.0 // default prior strength; k=2 ⇒ documented Beta(1,1): (resolved+1)/(recalls+2)
 	cases := []struct {
 		recalls, resolved int
 		want              float64
 	}{
-		{0, 0, 1.0},  // no history → no penalty
-		{5, 5, 1.0},  // always resolves → no penalty
-		{3, 0, 0.4},  // (0+2)/(3+2)
-		{6, 0, 0.25}, // (0+2)/(6+2)
-		{3, 1, 0.6},  // (1+2)/(3+2) — partial resolve rate
+		// resolved=0, recalls 0..3 — a never-resolving entry decays fast.
+		{0, 0, 0.5},       // (0+1)/(0+2) — prior mean; never reaches the gate in practice
+		{1, 0, 1.0 / 3.0}, // (0+1)/(1+2) ≈ 0.333 — already below the 0.5 floor at the 1st recall
+		{2, 0, 0.25},      // (0+1)/(2+2)
+		{3, 0, 0.2},       // (0+1)/(3+2)
+		{6, 0, 0.125},     // (0+1)/(6+2)
+		// mixed resolve records.
+		{3, 1, 0.4},       // (1+1)/(3+2)
+		{3, 2, 0.6},       // (2+1)/(3+2)
+		{4, 2, 0.5},       // (2+1)/(4+2) — exactly at the floor
+		{5, 5, 6.0 / 7.0}, // (5+1)/(5+2) ≈ 0.857 — always-resolving asymptotes to 1, never exceeds it
 	}
 	for _, c := range cases {
 		got := outcomeFactor(c.recalls, c.resolved, k)
@@ -240,21 +246,24 @@ func soloRecall(oc OutcomeStats) *Recall {
 }
 
 func TestLookupDecayHealthyEntryRecalls(t *testing.T) {
+	// recalls=5 resolved=5 → factor (5+1)/(5+2)=6/7≈0.857 (a Beta posterior asymptotes
+	// to 1 with evidence but never reaches it), so confidence stays high but not maxed.
 	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 5, Resolved: 5}}})
 	e, conf := r.lookup(context.Background(), okReq())
 	if e == nil {
-		t.Fatal("healthy entry (factor 1.0) should recall")
+		t.Fatal("healthy entry (factor ~0.857) should recall")
 	}
-	if conf < 0.80 {
-		t.Fatalf("healthy entry confidence should be ~undecayed, got %v", conf)
+	if conf < 0.75 {
+		t.Fatalf("consistently-resolving entry confidence should stay high, got %v", conf)
 	}
 }
 
 func TestLookupDecayStaleEntryRejected(t *testing.T) {
-	// recalls=4 resolved=0 → factor (0+2)/(4+2)=0.333 < floor 0.5 → reject, fall through.
-	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 4, Resolved: 0}}})
+	// recalls=1 resolved=0 → factor (0+1)/(1+2)=0.333 < floor 0.5 → reject at the FIRST
+	// recall, fall through to a full investigation. This is the stricter Beta(1,1) gate.
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 1, Resolved: 0}}})
 	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
-		t.Fatal("stale never-resolving entry must be rejected (fall through to investigation)")
+		t.Fatal("an entry that recalls once and never resolves must be rejected (fall through to investigation)")
 	}
 }
 
@@ -280,9 +289,9 @@ func TestLookupDecayStatsErrorRecalls(t *testing.T) {
 }
 
 func TestLookupDecayPartialFactorReducesConfidence(t *testing.T) {
-	// recalls=3 resolved=1 → factor (1+2)/(3+2)=0.6 (> floor 0.5) → recalls, but with
+	// recalls=3 resolved=2 → factor (2+1)/(3+2)=0.6 (> floor 0.5) → recalls, but with
 	// confidence visibly reduced from the undecayed ~0.90 (0.90*0.6 = 0.54).
-	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 3, Resolved: 1}}})
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 3, Resolved: 2}}})
 	e, conf := r.lookup(context.Background(), okReq())
 	if e == nil {
 		t.Fatal("factor 0.6 (>= floor) should still recall")
@@ -293,9 +302,9 @@ func TestLookupDecayPartialFactorReducesConfidence(t *testing.T) {
 }
 
 func TestLookupDecayFactorAtFloorRecalls(t *testing.T) {
-	// recalls=2 resolved=0 → factor (0+2)/(2+2)=0.5 == floor; the gate is strict (<),
+	// recalls=4 resolved=2 → factor (2+1)/(4+2)=0.5 == floor; the gate is strict (<),
 	// so it recalls (boundary case).
-	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 2, Resolved: 0}}})
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {Recalls: 4, Resolved: 2}}})
 	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
 		t.Fatal("factor exactly at the floor must recall (gate is strict <)")
 	}


### PR DESCRIPTION
## What was wrong

`docs/learning-loop.md` §6 documents the recall outcome-decay factor as a Beta(1,1)
posterior mean: `factor = (resolved + 1) / (recalls + 2)`. The code
(`internal/investigate/recall.go`) instead implemented:

```go
outcomeFactor(recalls, resolved, k) = (resolved + k) / (recalls + k)
```

with `k = OutcomePrior` (default **2.0**), i.e. the effective default was
`(resolved+2)/(recalls+2)` — a symmetric *optimistic* prior. A stale/poisoned entry
that recalls but never resolves survived far longer than documented, and the code
comment even claimed a no-history entry "scores 1.0", contradicting the doc.

## The fix

```go
factor = (resolved + k/2) / (recalls + k)
```

the posterior mean of a symmetric **Beta(k/2, k/2)** prior. `OutcomePrior` keeps its
single-knob meaning ("total pseudo-observations"); with the unchanged default `k=2`
this is exactly the documented `(resolved+1)/(recalls+2)`. The code comment is
rewritten to describe the real prior. **`OutcomePrior` and `OutcomeFloor` defaults are
unchanged.** Entries with no recall history are still absent from `OpenCounts()` and
skip the gate entirely, so a brand-new entry is never punished by the 0.5 prior mean.

## Behavior change — stricter decay (before → after)

With `OutcomeFloor = 0.5` and the strict `<` gate, a never-resolving entry (0 resolves):

| recalls | before `(0+2)/(n+2)` | after `(0+1)/(n+2)` | after: rejected? |
|--------:|---------------------:|--------------------:|:----------------:|
| 1       | 0.75                 | 0.333               | **yes (1st recall)** |
| 2       | 0.50                 | 0.25                | yes              |
| 3       | 0.40                 | 0.20                | yes              |

Before, a poisoned entry was rejected only at its **3rd** recall (2/5 = 0.4 < 0.5);
now it is rejected at the **1st** (1/3 = 0.333 < 0.5). A consistently-resolving entry
still passes — its factor asymptotes toward 1 with evidence (e.g. 5/5 → 6/7 ≈ 0.857).

## Test evidence (TDD — tests written first, then the fix)

`internal/investigate/recall_test.go`:
- `TestOutcomeFactor` — Beta(1,1) values for recalls=0..3 at resolved=0, plus mixed
  records (3/1, 3/2, 4/2 at-floor, 5/5).
- `TestLookupDecayStaleEntryRejected` — an entry with **1 recall / 0 resolves** is
  rejected (`reason="low_outcome"`) and `lookup` falls through to full investigation.
- `TestLookupDecayHealthyEntryRecalls` — a consistently-resolving entry keeps passing.
- `TestLookupDecayFactorAtFloorRecalls` / `TestLookupDecayPartialFactorReducesConfidence`
  re-anchored to inputs that hit the same floor/partial semantics under the new formula.
- `TestLookupDecayRejectionMetric` — emits `recall_rejections_total{reason="low_outcome"}`.

Gate green:

```
go build ./...      ok
go vet ./...        ok
go test ./...       ok (all packages)
gofmt -l .          (clean)
golangci-lint run   0 issues
```

Scope: only `internal/investigate/recall.go` + its test. `docs/learning-loop.md`
(already the target behavior) is left untouched.