### PR TITLE
fix(curate): fall through to Jaccard on divergent open-PR fingerprints

### DIFF
--- a/internal/curate/dedup.go
+++ b/internal/curate/dedup.go
@@ -68,18 +68,28 @@ func (d Dedup) Run(ctx context.Context) error {
 // fingerprint-FIRST: every curator-drafted PR carries a deterministic
 // DupFingerprint persisted in its body as a marker (the same identity the
 // file-time gate's Curator.duplicateOpenPR reads back). When BOTH PRs carry a
-// parseable marker, they are duplicates iff the fingerprints are EQUAL — stable
-// across the LLM's title phrasing, which is exactly the title fragility
-// DupFingerprint was built to retire. A coincidental title match cannot collapse
-// PRs with different fingerprints, and reworded titles with one fingerprint do.
+// parseable marker and the fingerprints are EQUAL, that is the strong signal —
+// duplicates regardless of title phrasing, exactly the title fragility
+// DupFingerprint was built to retire.
 //
-// Title-Jaccard is the FALLBACK for markerless PRs (legacy/hand-filed entries with
-// no marker) — additive, not a regression.
+// EQUAL fingerprints are conclusive; DIFFERENT fingerprints are NOT. The same
+// incident yields two different fingerprints when investigated via an alert
+// (trigger-key identity) versus a manual `lore investigate` (cause-token identity),
+// so a fingerprint mismatch cannot be trusted to mean "distinct". Rather than
+// short-circuit to false — which let those cross-path duplicates escape dedup and
+// merge as permanent catalog dupes — we fall through to title-Jaccard, the same
+// check the markerless path uses. The tradeoff: two genuinely distinct incidents on
+// the same resource with similar titles can now be collapsed by Jaccard where the
+// fingerprint mismatch used to shield them; that shield was also hiding true
+// duplicates, so catching them is the intended net.
+//
+// Title-Jaccard is also the FALLBACK for markerless PRs (legacy/hand-filed entries
+// with no marker).
 func isDuplicatePair(a, b providers.CuratedIssue, thr float64) bool {
 	fa := providers.ParseFingerprintMarker(a.Body)
 	fb := providers.ParseFingerprintMarker(b.Body)
-	if fa != "" && fb != "" {
-		return fa == fb
+	if fa != "" && fb != "" && fa == fb {
+		return true
 	}
 	return jaccard(titleTokens(a.Title), titleTokens(b.Title)) >= thr
 }

--- a/internal/curate/dedup_test.go
+++ b/internal/curate/dedup_test.go
@@ -90,20 +90,41 @@ func TestDedupCollapsesByFingerprintAcrossRewordedTitles(t *testing.T) {
 	}
 }
 
-// TestDedupKeepsDistinctFingerprintsDespiteIdenticalTitles proves fingerprint
-// equality OVERRIDES a coincidental title match: two byte-identical titles whose
-// fingerprints DIFFER must stay open (title-Jaccard alone would wrongly close one).
-func TestDedupKeepsDistinctFingerprintsDespiteIdenticalTitles(t *testing.T) {
+// TestDedupCollapsesDivergentFingerprintsWhenTitlesSimilar is the regression guard
+// for the divergent-fingerprint hole: the SAME incident investigated once via an
+// alert (trigger-key fingerprint) and once via a manual `lore investigate`
+// (cause-token fingerprint) produces two DIFFERENT markers. Different fingerprints
+// must NOT short-circuit dedup — the pass falls through to title-Jaccard, so the
+// similar-titled true duplicate is caught and collapsed onto the canonical PR.
+func TestDedupCollapsesDivergentFingerprintsWhenTitlesSimilar(t *testing.T) {
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 3, Title: "KB: Kustomization DependencyNotReady missing GitRepository", Body: "x\n\n" + providers.FingerprintMarker("fp-alert")},
+		{Number: 7, Title: "KB: Kustomization DependencyNotReady due to missing GitRepository", Body: "x\n\n" + providers.FingerprintMarker("fp-manual")},
+	}}
+	d := Dedup{Forge: f, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := d.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.closed) != 1 || f.closed[0] != 7 {
+		t.Fatalf("divergent fingerprints with similar titles must collapse #7 onto #3 via Jaccard, got closed=%v", f.closed)
+	}
+}
+
+// TestDedupKeepsDivergentFingerprintsWhenTitlesDissimilar proves the fall-through is
+// still guarded by the title check: two genuinely distinct incidents (different
+// fingerprints AND dissimilar titles) must stay open — Jaccard below threshold keeps
+// them apart, so the divergent-fingerprint fall-through introduces no false close.
+func TestDedupKeepsDivergentFingerprintsWhenTitlesDissimilar(t *testing.T) {
 	f := &fakeForge{prs: []providers.CuratedIssue{
 		{Number: 3, Title: "KB: Kustomization DependencyNotReady missing GitRepository", Body: "x\n\n" + providers.FingerprintMarker("fp-one")},
-		{Number: 7, Title: "KB: Kustomization DependencyNotReady missing GitRepository", Body: "x\n\n" + providers.FingerprintMarker("fp-two")},
+		{Number: 7, Title: "KB: apps/web pod readiness probe failing after deploy", Body: "x\n\n" + providers.FingerprintMarker("fp-two")},
 	}}
 	d := Dedup{Forge: f, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 	if err := d.Run(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if len(f.closed) != 0 {
-		t.Fatalf("distinct fingerprints must NOT collapse despite identical titles, got closed=%v", f.closed)
+		t.Fatalf("divergent fingerprints with dissimilar titles must NOT collapse, got closed=%v", f.closed)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes a hole in the Phase-2 open-PR dedup pass (`internal/curate/dedup.go`,
`isDuplicatePair`). Previously, when **both** PRs carried a parseable
`DupFingerprint` marker, the function returned `fa == fb` and **skipped the
title-Jaccard fallback entirely**. Different fingerprints therefore short-circuited
to a non-duplicate verdict without ever consulting the title check.

## Why it's a real bug

`curator.DupFingerprint` has two identity branches:

- **trigger-key-based** when the incident has a `TriggerKey` (alerts / GitOps), and
- **cause-token-based** otherwise (manual `lore investigate`).

So the **same** incident investigated once via an alert and once via a manual run
produces two **different** fingerprints. Both PRs carry markers, `fa != fb`, and
`isDuplicatePair` returned `false` before Jaccard ever ran — both PRs escaped dedup,
both could merge, leaving **permanent duplicate KB entries** in the catalog.

## The fix

- **Equal** fingerprints remain conclusive — the strong, deterministic signal, kept
  exactly as-is (collapse regardless of title phrasing).
- **Different** fingerprints no longer short-circuit to `false`; they fall through to
  the same title-Jaccard check the markerless path already uses (default threshold
  0.6). The rest of the pass is untouched (lowest-numbered PR canonical, protected
  labels skipped, comment-before-close).

## Intended tradeoff

Two genuinely **distinct** incidents on the same resource with **similar titles** can
now be collapsed by Jaccard, where the fingerprint mismatch used to shield them from a
false-positive title match. That same shield was also hiding **true** duplicates (the
bug), so catching them is the intended net. Distinct incidents with **dissimilar**
titles stay safe — Jaccard below threshold keeps them apart. Both directions are
covered by tests.

## Tests (TDD, failing test written first)

- `TestDedupCollapsesDivergentFingerprintsWhenTitlesSimilar` — divergent fingerprints
  + similar titles now collapse (the regression guard for this bug).
- `TestDedupKeepsDivergentFingerprintsWhenTitlesDissimilar` — divergent fingerprints
  + dissimilar titles stay open (no false close introduced).
- `TestDedupCollapsesByFingerprintAcrossRewordedTitles` (existing) — equal
  fingerprints still collapse regardless of titles.

The obsolete `TestDedupKeepsDistinctFingerprintsDespiteIdenticalTitles`, which encoded
the now-removed buggy protection, was replaced by the two tests above.

## Possible follow-up (out of scope)

Unifying the two `DupFingerprint` identity branches in
`internal/curator/fingerprint.go` would remove the divergence at the source, but it
would invalidate the markers on all existing open/closed PRs and the closed-PR
suppression set, so it is deliberately left out of this change.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l internal/curate/`, and
`golangci-lint run ./internal/curate/...` (0 issues) all green.
