### PR TITLE
fix(outcome): harden the outcome ledger (GitOps capture, decay poisoning, unbounded growth)

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -374,6 +374,12 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 			if i == 0 {
 				triggerKey = found.TriggerKey
 			}
+			// Whether a resolve signal can ever arrive for this open: true for sources
+			// with a resolve channel (Alertmanager/PagerDuty — real fingerprints), false
+			// for sources that never emit one (GitOps/reinvestigate — synthetic derived
+			// fingerprints). A non-resolvable recall open is recorded for recurrence but
+			// kept out of recall decay (see outcome.applyOpenLocked).
+			resolvable := !outcome.Derived(fp)
 			if err := ledger.Open(outcome.Event{
 				Fingerprint:    fp,
 				DupFingerprint: dupFP,
@@ -384,6 +390,7 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 				TriggerKey:     triggerKey,
 				CuratedURL:     found.CuratedURL,
 				Verdict:        string(found.Verdict),
+				Resolvable:     &resolvable,
 				At:             now,
 			}); err != nil {
 				log.Warn("outcome ledger open failed", "fingerprint", fp, "err", err)

--- a/internal/app/oncomplete_test.go
+++ b/internal/app/oncomplete_test.go
@@ -205,3 +205,45 @@ func TestOnCompleteRecordsGitOpsIncident(t *testing.T) {
 		t.Fatalf("GitOps open must appear as one episode, got %+v", eps)
 	}
 }
+
+// TestOnCompleteGitOpsRecallNotCountedTowardDecay pins Defect 2 at the emission site:
+// a RECALL open for a GitOps incident (synthetic fingerprint, no resolve channel) is
+// marked non-resolvable, so it does NOT increment the entry's Recalls (which could
+// otherwise never be balanced by a Resolved and would decay a correct entry forever) —
+// while an equivalent Alertmanager recall (real fingerprint) does count.
+func TestOnCompleteGitOpsRecallNotCountedTowardDecay(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	ledger, err := outcome.New(path)
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	notifier := notify.NewMulti(discardLog(), &captureNotifier{})
+
+	gitopsFP := outcome.DeriveFingerprint(outcome.GitOpsFingerprintPrefix, "argocd/airflow:Degraded")
+	gitops := providers.Investigation{
+		Title:         "airflow Degraded",
+		Fingerprint:   gitopsFP,
+		Fingerprints:  []string{gitopsFP},
+		TriggerKey:    "argocd/airflow:Degraded",
+		Recalled:      true,
+		RecalledEntry: "airflow.md",
+	}
+	onInvestigationComplete(context.Background(), gitops, ledger, nil, notifier, nil, nil, nil, discardLog())
+
+	if c, _ := ledger.OpenCounts(); c["airflow.md"].Recalls != 0 {
+		t.Fatalf("a non-resolvable GitOps recall must not count toward Recalls, got %+v", c["airflow.md"])
+	}
+
+	// An Alertmanager recall of a different entry (real fingerprint) DOES count.
+	alert := providers.Investigation{
+		Title:         "harbor down",
+		Fingerprint:   "a1b2c3d4",
+		Fingerprints:  []string{"a1b2c3d4"},
+		Recalled:      true,
+		RecalledEntry: "harbor.md",
+	}
+	onInvestigationComplete(context.Background(), alert, ledger, nil, notifier, nil, nil, nil, discardLog())
+	if c, _ := ledger.OpenCounts(); c["harbor.md"].Recalls != 1 {
+		t.Fatalf("a resolvable Alertmanager recall must count toward Recalls, got %+v", c["harbor.md"])
+	}
+}

--- a/internal/app/oncomplete_test.go
+++ b/internal/app/oncomplete_test.go
@@ -167,3 +167,41 @@ func TestOnCompleteCountsOneOccurrencePerInvestigation(t *testing.T) {
 		t.Errorf("delivered Occurrences on 2nd run = %d, want 2", sink.got.Occurrences)
 	}
 }
+
+// TestOnCompleteRecordsGitOpsIncident pins Defect 1's fix: a GitOps-failure incident
+// (no external alert fingerprint, only a derived gitops:<hash> id) must record an
+// outcome open and show up in Occurrences and Episodes — previously the open-emission
+// guard skipped it entirely, so pure-GitOps patterns were invisible to the loop.
+func TestOnCompleteRecordsGitOpsIncident(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	ledger, err := outcome.New(path)
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	sink := &captureNotifier{}
+	notifier := notify.NewMulti(discardLog(), sink)
+
+	// What FromFailureEvent+the loop produce for a GitOps failure: a synthetic
+	// fingerprint and a trigger key, no Alertmanager id.
+	fp := outcome.DeriveFingerprint(outcome.GitOpsFingerprintPrefix, "argocd/airflow:Degraded")
+	found := providers.Investigation{
+		Title:        "airflow Degraded",
+		Fingerprint:  fp,
+		Fingerprints: []string{fp},
+		TriggerKey:   "argocd/airflow:Degraded",
+	}
+	onInvestigationComplete(context.Background(), found, ledger, nil, notifier, nil, nil, nil, discardLog())
+
+	// The GitOps incident is now captured: an open was recorded (Occurrences ≥ 1) ...
+	if n, _, _ := ledger.Occurrences("argocd/airflow:Degraded"); n != 1 {
+		t.Fatalf("GitOps incident must record one occurrence, got %d", n)
+	}
+	// ... and appears in Episodes (so the Phase-2 Recurrence pass can see it).
+	eps, err := ledger.Episodes()
+	if err != nil {
+		t.Fatalf("Episodes: %v", err)
+	}
+	if len(eps) != 1 || eps[0].Title != "airflow Degraded" {
+		t.Fatalf("GitOps open must appear as one episode, got %+v", eps)
+	}
+}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -152,12 +152,18 @@ func RunServe(version string, args []string) error {
 	}
 	metrics := telemetry.NewMetrics() // bound to global provider (no-op when disabled)
 
-	ledger, err := outcome.New(cfg.Outcome.LedgerPath)
+	// max_events is a three-state knob: unset (nil) ⇒ the generous default; explicit 0 ⇒
+	// compaction disabled; N ⇒ compact when the ledger exceeds N events.
+	maxEvents := outcome.DefaultMaxEvents
+	if cfg.Outcome.MaxEvents != nil {
+		maxEvents = *cfg.Outcome.MaxEvents
+	}
+	ledger, err := outcome.NewWithMaxEvents(cfg.Outcome.LedgerPath, maxEvents)
 	if err != nil {
 		return fmt.Errorf("outcome ledger: %w", err)
 	}
 	if cfg.Outcome.LedgerPath != "" {
-		log.Info("outcome ledger enabled", "path", cfg.Outcome.LedgerPath)
+		log.Info("outcome ledger enabled", "path", cfg.Outcome.LedgerPath, "max_events", maxEvents)
 	}
 
 	inv, cat, err := BuildInvestigator(ctx, cfg, gitops, approvals, auto, metrics, ledger, log)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,6 +253,11 @@ type Catalog struct {
 // Outcome configures the learning-loop outcome ledger.
 type Outcome struct {
 	LedgerPath string `yaml:"ledger_path"` // append-only JSONL path (e.g. the git-sync mirror PV); empty disables
+	// MaxEvents bounds the JSONL before it is compacted on load (startup / leadership
+	// Reload): older paired events are folded into a checkpoint record so the file stops
+	// growing forever. A pointer for a three-state knob: nil (key absent) ⇒ a generous
+	// default (outcome.DefaultMaxEvents); an explicit 0 ⇒ compaction disabled.
+	MaxEvents *int `yaml:"max_events"`
 }
 
 // InstantRecall short-circuits the investigation loop when the catalog has a

--- a/internal/config/outcome_test.go
+++ b/internal/config/outcome_test.go
@@ -15,4 +15,27 @@ func TestOutcomeConfigParse(t *testing.T) {
 	if c.Outcome.LedgerPath != "/var/lib/runlore/catalog/outcomes.jsonl" {
 		t.Fatalf("ledger_path: %q", c.Outcome.LedgerPath)
 	}
+	// max_events absent ⇒ nil (the wiring applies the default).
+	if c.Outcome.MaxEvents != nil {
+		t.Fatalf("absent max_events must be nil, got %v", *c.Outcome.MaxEvents)
+	}
+}
+
+// TestOutcomeMaxEventsThreeState pins the tri-state max_events knob: an explicit 0
+// (compaction disabled) must be distinguishable from an absent key (nil ⇒ default).
+func TestOutcomeMaxEventsThreeState(t *testing.T) {
+	var zero Config
+	if err := yaml.Unmarshal([]byte("outcome:\n  max_events: 0\n"), &zero); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if zero.Outcome.MaxEvents == nil || *zero.Outcome.MaxEvents != 0 {
+		t.Fatalf("explicit max_events: 0 must parse to &0, got %v", zero.Outcome.MaxEvents)
+	}
+	var n Config
+	if err := yaml.Unmarshal([]byte("outcome:\n  max_events: 1000\n"), &n); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if n.Outcome.MaxEvents == nil || *n.Outcome.MaxEvents != 1000 {
+		t.Fatalf("max_events: 1000 must parse to &1000, got %v", n.Outcome.MaxEvents)
+	}
 }

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -15,6 +15,7 @@ import (
 
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/ratelimit"
 	"github.com/Smana/runlore/internal/telemetry"
@@ -68,6 +69,20 @@ func FromFailureEvent(fe providers.FailureEvent) Request {
 	if ref := fe.Workload.Ref(); ref != "" {
 		r.TriggerKey = ref + ":" + fe.Reason
 	}
+	// A GitOps failure carries no external alert fingerprint. Without one the outcome
+	// ledger's open-emission guard skips it entirely — no open event, no Occurrences
+	// recurrence facts, and the Phase-2 Recurrence pass (which reads Episodes) never
+	// sees pure-GitOps patterns. Derive a stable, deterministic fingerprint from the
+	// incident identity (the trigger key, else the title) so these incidents are
+	// captured like any other; the gitops: prefix keeps it from ever colliding with an
+	// Alertmanager fingerprint (and marks the open non-resolvable — no resolve webhook
+	// can ever match it).
+	key := r.TriggerKey
+	if key == "" {
+		key = r.Title
+	}
+	r.Fingerprint = outcome.DeriveFingerprint(outcome.GitOpsFingerprintPrefix, key)
+	r.Fingerprints = []string{r.Fingerprint}
 	return r
 }
 

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -154,6 +155,31 @@ func TestFromFailureEvent(t *testing.T) {
 	r := FromFailureEvent(fe)
 	if r.Source != SourceGitOpsFailure || r.Workload != fe.Workload || r.Reason != "BuildFailed" || r.Message != "boom" {
 		t.Fatalf("unexpected request: %+v", r)
+	}
+}
+
+// TestFromFailureEventDerivesFingerprint pins the fix for GitOps incidents being
+// invisible to the outcome ledger: a GitOps failure now carries a stable, deterministic
+// synthetic fingerprint (gitops:<hash> of its trigger key) so the open-emission guard
+// records it, and re-firings of the same failure derive the SAME id (recurrence).
+func TestFromFailureEventDerivesFingerprint(t *testing.T) {
+	fe := providers.FailureEvent{
+		Workload: providers.Workload{Kind: "Application", Namespace: "argocd", Name: "airflow"},
+		Reason:   "Degraded",
+	}
+	r := FromFailureEvent(fe)
+	if r.Fingerprint == "" {
+		t.Fatal("GitOps failure must derive a fingerprint (else the outcome ledger skips it)")
+	}
+	if !outcome.Derived(r.Fingerprint) {
+		t.Fatalf("derived fingerprint %q must be recognised as synthetic/non-resolvable", r.Fingerprint)
+	}
+	if len(r.Fingerprints) != 1 || r.Fingerprints[0] != r.Fingerprint {
+		t.Fatalf("Fingerprints must mirror the derived id: %+v", r.Fingerprints)
+	}
+	// Deterministic: a re-firing of the same failure derives the same id (recurrence).
+	if again := FromFailureEvent(fe); again.Fingerprint != r.Fingerprint {
+		t.Fatalf("re-firing must derive the same fingerprint: %q != %q", again.Fingerprint, r.Fingerprint)
 	}
 }
 

--- a/internal/investigate/reinvestigate.go
+++ b/internal/investigate/reinvestigate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -58,6 +59,14 @@ func (r *Reinvestigator) pollOnce(ctx context.Context) {
 			continue
 		}
 		req := Request{Source: SourceAlert, Title: is.Title, Reason: "re-investigation requested via the reinvestigate label", Message: is.Body}
+		// Like a GitOps failure, a reinvestigate poll carries no external alert
+		// fingerprint. Derive a stable, deterministic one from the issue identity so the
+		// incident is not invisible to the outcome ledger (see outcome.DeriveFingerprint).
+		// The reinvestigate: prefix marks it as non-resolvable (no resolve webhook can
+		// match it).
+		fp := outcome.DeriveFingerprint(outcome.ReinvestigateFingerprintPrefix, fmt.Sprintf("issue-%d", is.Number))
+		req.Fingerprint = fp
+		req.Fingerprints = []string{fp}
 		inv, err := r.Run(ctx, req)
 		if err != nil {
 			r.Log.Warn("reinvestigate: run failed", "issue", is.Number, "err", err)

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -68,7 +68,21 @@ type Event struct {
 	TriggerKey string `json:"trigger_key,omitempty"` // groups recurrences of the same alert; keys the byTrigger index
 	CuratedURL string `json:"curated_url,omitempty"` // KB link surfaced as "previous: <link>" on recurrence
 	Verdict    string `json:"verdict,omitempty"`     // curator's machine verdict on the investigation
+
+	// Resolvable is set on an open when we know whether a ground-truth resolve signal
+	// can ever arrive for it: true for sources with a resolve channel (Alertmanager,
+	// PagerDuty), false for sources that never emit one (GitOps, reinvestigate, or
+	// Alertmanager with send_resolved off). A pointer for a three-state distinction:
+	// nil ⇒ the field is absent, i.e. a LEGACY open written before this field existed —
+	// those came from Alertmanager/PagerDuty and are treated as resolvable. Only a
+	// non-resolvable recall open is excluded from recall decay (see applyOpenLocked).
+	Resolvable *bool `json:"resolvable,omitempty"`
 }
+
+// resolvable reports whether a ground-truth resolve signal can ever arrive for this
+// open. A legacy open (field absent ⇒ nil) came from Alertmanager/PagerDuty, which do
+// emit resolves, so it defaults to resolvable.
+func (e Event) resolvable() bool { return e.Resolvable == nil || *e.Resolvable }
 
 // Episode is a matched open→resolve pair (or, from Episodes(), an unresolved open
 // when Resolved is false).
@@ -203,7 +217,14 @@ func (l *Ledger) Reload() error {
 // already buffered for this fingerprint, the open is paired immediately and also
 // counts as resolved. Must be called with mu held (or during single-threaded New).
 func (l *Ledger) applyOpenLocked(e Event) {
-	counted := e.Kind == "recall" && e.Entry != ""
+	// A recall open counts toward decay ONLY when it is resolvable — i.e. a resolve
+	// signal for it can actually arrive. A non-resolvable recall (GitOps, reinvestigate,
+	// or Alertmanager with send_resolved off) neither builds nor erodes trust: counting
+	// it toward Recalls with no possible Resolved would decay a CORRECT entry's
+	// resolve-rate forever, on evidence the source can never provide. So decay is only
+	// learned where a ground-truth resolve signal exists. Episodes()/Occurrences() still
+	// include EVERY open regardless of resolvability, so recurrence counting is unaffected.
+	counted := e.Kind == "recall" && e.Entry != "" && e.resolvable()
 	if counted {
 		a := l.agg[e.Entry]
 		a.Recalls++

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -7,13 +7,49 @@ package outcome
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io/fs"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
+
+// Fingerprint prefixes for incidents RunLore assigns a synthetic id to because the
+// triggering source carries no external alert fingerprint (an Alertmanager/PagerDuty
+// incident id). They are chosen so a derived id can never collide with a real
+// fingerprint, and they double as the "no ground-truth resolve channel" marker that
+// keeps such recall opens out of recall-decay (see Event.Resolvable / applyOpenLocked).
+const (
+	// GitOpsFingerprintPrefix marks a fingerprint derived from a GitOps failure's
+	// resource-ref + condition reason.
+	GitOpsFingerprintPrefix = "gitops:"
+	// ReinvestigateFingerprintPrefix marks a fingerprint derived for a reinvestigate poll.
+	ReinvestigateFingerprintPrefix = "reinvestigate:"
+)
+
+// DeriveFingerprint returns a stable, deterministic fingerprint for an incident that
+// carries no external alert id, formed as prefix + a short hex sha256 of key (e.g. the
+// trigger key, or resource-ref+reason). Determinism is the point: the same recurring
+// incident derives the SAME fingerprint every time, so its opens roll up into
+// Occurrences/Episodes as recurrences — while the prefix keeps it from ever colliding
+// with a real Alertmanager/PagerDuty fingerprint.
+func DeriveFingerprint(prefix, key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return prefix + hex.EncodeToString(sum[:8])
+}
+
+// Derived reports whether fp was assigned by DeriveFingerprint (a synthetic id for a
+// source with no external fingerprint). Such incidents have no resolve channel — no
+// resolved-alert webhook can ever match them — so their recall opens are recorded for
+// recurrence but never counted toward recall decay (see Event.Resolvable).
+func Derived(fp string) bool {
+	return strings.HasPrefix(fp, GitOpsFingerprintPrefix) ||
+		strings.HasPrefix(fp, ReinvestigateFingerprintPrefix)
+}
 
 // Event is one ledger line: an investigation opened, or an incident resolved.
 type Event struct {

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -12,7 +12,9 @@ import (
 	"encoding/json"
 	"errors"
 	"io/fs"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -77,6 +79,13 @@ type Event struct {
 	// those came from Alertmanager/PagerDuty and are treated as resolvable. Only a
 	// non-resolvable recall open is excluded from recall decay (see applyOpenLocked).
 	Resolvable *bool `json:"resolvable,omitempty"`
+
+	// Checkpoint is set only on a compaction record (Event=="checkpoint"); nil on every
+	// open/resolve. It carries the folded aggregate state of the events a compaction
+	// dropped. Kept omitempty so normal lines are unaffected, and a distinct event kind
+	// so OLD binaries — whose switch has no "checkpoint" case — ignore it gracefully
+	// (they lose the pre-horizon aggregates, but do not choke).
+	Checkpoint *checkpointData `json:"checkpoint,omitempty"`
 }
 
 // resolvable reports whether a ground-truth resolve signal can ever arrive for this
@@ -132,6 +141,46 @@ type Ledger struct {
 	// (see maxPendingResolvesPerFingerprint) — spurious duplicate/replayed resolve
 	// webhooks. Kept so the (otherwise silent) defensive drop is observable.
 	droppedResolves int
+
+	// maxEvents bounds the JSONL before loadLocked compacts it (0 disables). corruptLines
+	// records how many lines the last load could not parse (so the skip is observable, not
+	// silent). log carries a logger for those warnings; never nil after New.
+	maxEvents    int
+	corruptLines int
+	log          *slog.Logger
+}
+
+// DefaultMaxEvents is the generous default compaction bound used by New (and by the
+// serve wiring when outcome.max_events is unset). Chosen high enough that a healthy
+// ledger never compacts in normal operation; compaction is a growth backstop, not a
+// routine trim.
+const DefaultMaxEvents = 50000
+
+// checkpointData is the per-load snapshot a compaction writes so a later replay can
+// reconstruct the exact in-memory state the dropped (absorbed) events produced, without
+// re-reading them. It carries the complete mutable fold state: the per-entry aggregate,
+// the per-TriggerKey occurrence index, the open-index + pairing stacks for still-unresolved
+// opens, buffered early resolves, and the dropped-resolve counter. loadLocked seeds from
+// it, then folds the retained tail on top. Unexported index types (triggerAgg, pendingOpen)
+// have exported JSON mirrors here so they serialize.
+type checkpointData struct {
+	Agg             map[string]Aggregate         `json:"agg,omitempty"`
+	ByTrigger       map[string]triggerAggJSON    `json:"by_trigger,omitempty"`
+	OpenIndex       map[string]Event             `json:"open_index,omitempty"`
+	PendingOpens    map[string][]pendingOpenJSON `json:"pending_opens,omitempty"`
+	PendingResolves map[string][]time.Time       `json:"pending_resolves,omitempty"`
+	DroppedResolves int                          `json:"dropped_resolves,omitempty"`
+}
+
+type triggerAggJSON struct {
+	Count      int       `json:"count"`
+	Last       time.Time `json:"last"`
+	CuratedURL string    `json:"curated_url,omitempty"`
+}
+
+type pendingOpenJSON struct {
+	Entry   string `json:"entry,omitempty"`
+	Counted bool   `json:"counted,omitempty"`
 }
 
 // triggerAgg is the per-TriggerKey occurrence roll-up backing Occurrences.
@@ -151,10 +200,17 @@ type triggerAgg struct {
 // pair with a real open, and dropping it leaves the brief-window pairing intact.
 const maxPendingResolvesPerFingerprint = 64
 
-// New opens (replaying) the ledger at path. An empty path returns a disabled,
-// no-op ledger (the feature is off).
+// New opens (replaying) the ledger at path with the default compaction bound
+// (DefaultMaxEvents). An empty path returns a disabled, no-op ledger (the feature is off).
 func New(path string) (*Ledger, error) {
-	l := &Ledger{path: path}
+	return NewWithMaxEvents(path, DefaultMaxEvents)
+}
+
+// NewWithMaxEvents opens (replaying) the ledger at path, compacting the JSONL on load
+// when it exceeds maxEvents (0 disables compaction). An empty path returns a disabled,
+// no-op ledger.
+func NewWithMaxEvents(path string, maxEvents int) (*Ledger, error) {
+	l := &Ledger{path: path, maxEvents: maxEvents, log: slog.Default()}
 	if err := l.loadLocked(); err != nil {
 		return nil, err
 	}
@@ -170,26 +226,200 @@ func New(path string) (*Ledger, error) {
 // The read is performed BEFORE any reset: if readEvents returns an error the prior
 // cache is left untouched — callers see a stale-but-valid cache rather than an empty one.
 func (l *Ledger) loadLocked() error {
-	events, err := l.readEvents()
+	events, corrupt, err := l.readEvents()
 	if err != nil {
 		return err // prior cache untouched
 	}
+	l.resetStateLocked()
+	l.corruptLines = corrupt
+	if corrupt > 0 {
+		// A corrupt line is a real signal (truncated write, disk corruption, a stray
+		// edit) — surface it rather than dropping it silently.
+		l.log.Warn("outcome ledger: skipped corrupt JSONL lines", "count", corrupt, "path", l.path)
+	}
+	for _, e := range events {
+		l.foldLocked(e)
+	}
+	// Compaction backstop: an append-only ledger replayed in full on every startup /
+	// leadership Reload / curate Episodes() grows without bound. When it exceeds the
+	// configured cap, fold the oldest events into a single checkpoint record and keep a
+	// recent tail — the in-memory state above is already the full, correct state, so a
+	// failed rewrite is non-fatal (log and keep serving the uncompacted file).
+	if l.maxEvents > 0 && len(events) > l.maxEvents {
+		if cerr := l.compactLocked(events); cerr != nil {
+			l.log.Warn("outcome ledger: compaction failed; continuing with uncompacted file", "err", cerr, "path", l.path)
+		}
+	}
+	return nil
+}
+
+// resetStateLocked clears all derived in-memory state to empty (non-nil) maps.
+func (l *Ledger) resetStateLocked() {
 	l.open = map[string]Event{}
 	l.agg = map[string]Aggregate{}
 	l.pendingOpens = map[string][]pendingOpen{}
 	l.pendingResolves = map[string][]time.Time{}
 	l.byTrigger = map[string]triggerAgg{}
 	l.droppedResolves = 0
-	for _, e := range events {
-		switch e.Event {
-		case "open":
-			l.open[e.Fingerprint] = e
-			l.applyOpenLocked(e)
-			l.applyTriggerLocked(e)
-		case "resolve":
-			delete(l.open, e.Fingerprint)
-			l.applyResolveLocked(e.Fingerprint, e.At)
+}
+
+// foldLocked folds one replayed event into the derived state. Open/resolve maintain the
+// aggregate, open-index, pairing stacks, and occurrence index; a checkpoint seeds the
+// state a prior compaction folded away. Any other (unknown/future) kind is ignored — the
+// property old binaries rely on for the feedback kind, and now for "checkpoint" too.
+func (l *Ledger) foldLocked(e Event) {
+	switch e.Event {
+	case "open":
+		l.open[e.Fingerprint] = e
+		l.applyOpenLocked(e)
+		l.applyTriggerLocked(e)
+	case "resolve":
+		delete(l.open, e.Fingerprint)
+		l.applyResolveLocked(e.Fingerprint, e.At)
+	case "checkpoint":
+		l.seedCheckpointLocked(e.Checkpoint)
+	}
+}
+
+// seedCheckpointLocked restores the derived state a compaction saved. A checkpoint is
+// always the first line of a compacted file, so this seeds onto the freshly-reset (empty)
+// maps and the retained tail then folds on top. It sets state DIRECTLY (no re-crediting),
+// because the checkpoint already accounts for every event it absorbed.
+func (l *Ledger) seedCheckpointLocked(cd *checkpointData) {
+	if cd == nil {
+		return
+	}
+	// Copy every map/slice out of the decoded event: the ledger's live state must never
+	// ALIAS the event held in the replay slice, or a later fold (or the compaction scratch
+	// re-seeding from the same event) would mutate both through the shared reference.
+	for k, v := range cd.Agg {
+		l.agg[k] = v
+	}
+	for fp, ats := range cd.PendingResolves {
+		l.pendingResolves[fp] = append([]time.Time(nil), ats...)
+	}
+	for fp, ev := range cd.OpenIndex {
+		l.open[fp] = ev
+	}
+	for k, v := range cd.ByTrigger {
+		l.byTrigger[k] = triggerAgg{count: v.Count, last: v.Last, curatedURL: v.CuratedURL}
+	}
+	for fp, opens := range cd.PendingOpens {
+		stack := make([]pendingOpen, 0, len(opens))
+		for _, o := range opens {
+			stack = append(stack, pendingOpen{entry: o.Entry, counted: o.Counted})
 		}
+		l.pendingOpens[fp] = stack
+	}
+	l.droppedResolves += cd.DroppedResolves
+}
+
+// compactLocked rewrites the ledger file as [checkpoint][recent tail]: it folds the
+// oldest events (everything but the most recent maxEvents-1) into a checkpoint that
+// captures their exact aggregate contribution, and retains the tail as raw lines. The
+// caller's live state is untouched (already the full, correct state); this only shrinks
+// the file. Episodes() replay is preserved for the retained tail — episodes older than
+// this horizon are folded into the checkpoint (still counted in the aggregate) but are no
+// longer individually replayable, which the Phase-2 Queue/Recurrence passes tolerate
+// (they only need recent history).
+func (l *Ledger) compactLocked(events []Event) error {
+	keep := l.maxEvents - 1 // reserve one slot for the checkpoint line
+	if keep < 0 {
+		keep = 0
+	}
+	cut := len(events) - keep
+	if cut <= 0 {
+		return nil // nothing old enough to absorb
+	}
+	// Fold the absorbed prefix in a throwaway ledger to snapshot the state it produces,
+	// without disturbing the caller's live (full) state.
+	scratch := &Ledger{log: l.log}
+	scratch.resetStateLocked()
+	for _, e := range events[:cut] {
+		scratch.foldLocked(e)
+	}
+	return l.rewriteFileLocked(scratch.snapshotCheckpointLocked(), events[cut:])
+}
+
+// snapshotCheckpointLocked captures the receiver's derived state into a checkpointData.
+// Safe to reference the live maps directly: the receiver is a throwaway scratch ledger.
+func (l *Ledger) snapshotCheckpointLocked() *checkpointData {
+	cd := &checkpointData{
+		Agg:             l.agg,
+		OpenIndex:       l.open,
+		PendingResolves: l.pendingResolves,
+		DroppedResolves: l.droppedResolves,
+	}
+	if len(l.byTrigger) > 0 {
+		cd.ByTrigger = make(map[string]triggerAggJSON, len(l.byTrigger))
+		for k, v := range l.byTrigger {
+			cd.ByTrigger[k] = triggerAggJSON{Count: v.count, Last: v.last, CuratedURL: v.curatedURL}
+		}
+	}
+	if len(l.pendingOpens) > 0 {
+		cd.PendingOpens = make(map[string][]pendingOpenJSON, len(l.pendingOpens))
+		for fp, opens := range l.pendingOpens {
+			js := make([]pendingOpenJSON, 0, len(opens))
+			for _, o := range opens {
+				js = append(js, pendingOpenJSON{Entry: o.entry, Counted: o.counted})
+			}
+			cd.PendingOpens[fp] = js
+		}
+	}
+	return cd
+}
+
+// rewriteFileLocked atomically replaces the ledger file with the checkpoint followed by
+// the retained tail events, via a temp file + fsync + rename (so an interrupted compaction
+// can never leave a half-written ledger).
+func (l *Ledger) rewriteFileLocked(cd *checkpointData, tail []Event) error {
+	dir := filepath.Dir(l.path)
+	tmp, err := os.CreateTemp(dir, ".outcomes-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename succeeds.
+	defer func() { _ = os.Remove(tmpName) }()
+	w := bufio.NewWriter(tmp)
+	writeLine := func(e Event) error {
+		b, mErr := json.Marshal(e)
+		if mErr != nil {
+			return mErr
+		}
+		if _, wErr := w.Write(append(b, '\n')); wErr != nil {
+			return wErr
+		}
+		return nil
+	}
+	if err := writeLine(Event{Event: "checkpoint", At: time.Now(), Checkpoint: cd}); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	for _, e := range tail {
+		if err := writeLine(e); err != nil {
+			_ = tmp.Close()
+			return err
+		}
+	}
+	if err := w.Flush(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil { // durability before the rename
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, l.path); err != nil {
+		return err
+	}
+	// fsync the directory so the rename itself survives a crash.
+	if d, derr := os.Open(dir); derr == nil { //nolint:gosec // G304: dir is the parent of the operator-configured ledger path
+		_ = d.Sync()
+		_ = d.Close()
 	}
 	return nil
 }
@@ -282,31 +512,35 @@ func (l *Ledger) creditResolveLocked(entry string, at time.Time) {
 	l.agg[entry] = a
 }
 
-// readEvents replays the ledger file in order, skipping corrupt lines. It returns
-// a nil slice when the ledger is disabled (path=="") or the file is absent.
-func (l *Ledger) readEvents() ([]Event, error) {
+// readEvents replays the ledger file in order, skipping (and counting) corrupt lines.
+// The second return is the number of unparseable lines skipped — surfaced by the caller
+// so the skip is observable, never silent. It returns a nil slice when the ledger is
+// disabled (path=="") or the file is absent.
+func (l *Ledger) readEvents() ([]Event, int, error) {
 	if l.path == "" {
-		return nil, nil
+		return nil, 0, nil
 	}
 	f, err := os.Open(l.path)
 	if errors.Is(err, fs.ErrNotExist) {
-		return nil, nil
+		return nil, 0, nil
 	}
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer func() { _ = f.Close() }()
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var events []Event
+	var corrupt int
 	for sc.Scan() {
 		var e Event
 		if json.Unmarshal(sc.Bytes(), &e) != nil {
-			continue // skip a corrupt line rather than fail
+			corrupt++ // skip a corrupt line rather than fail, but count it
+			continue
 		}
 		events = append(events, e)
 	}
-	return events, sc.Err()
+	return events, corrupt, sc.Err()
 }
 
 func (l *Ledger) enabled() bool { return l != nil && l.path != "" }
@@ -342,7 +576,7 @@ func (l *Ledger) Status() Status {
 	if _, err := os.Stat(l.path); err == nil {
 		s.Present = true
 	}
-	if events, err := l.readEvents(); err == nil {
+	if events, _, err := l.readEvents(); err == nil {
 		s.Events = len(events)
 	}
 	return s
@@ -425,7 +659,7 @@ func (l *Ledger) Episodes() ([]Episode, error) {
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	events, err := l.readEvents()
+	events, _, err := l.readEvents()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -507,6 +508,153 @@ func TestLegacyOpenMissingResolvableCountsAsResolvable(t *testing.T) {
 	}
 }
 
+// countLines returns the number of JSONL lines in the file, and how many are
+// checkpoint records.
+func countLines(t *testing.T, path string) (total, checkpoints int) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(b), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		total++
+		var e Event
+		if json.Unmarshal([]byte(line), &e) == nil && e.Event == "checkpoint" {
+			checkpoints++
+		}
+	}
+	return total, checkpoints
+}
+
+// TestCompactionPreservesAggregatesAndUnresolvedOpens pins Defect 3: when the file
+// exceeds max_events it is compacted on reload into a checkpoint + a recent tail, and
+// the reloaded state must be IDENTICAL — per-entry aggregates (OpenCounts), Occurrences,
+// and any still-unresolved open (which must remain resolvable). The file must actually
+// shrink and gain exactly one checkpoint record.
+func TestCompactionPreservesAggregatesAndUnresolvedOpens(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := NewWithMaxEvents(p, 8) // small bound to force compaction on reload
+	t0 := time.Unix(30000, 0)
+	at := func(d int) time.Time { return t0.Add(time.Duration(d) * time.Second) }
+
+	// Six resolved recall pairs (12 events) on entry x.md under trigger key "k".
+	for i := 0; i < 6; i++ {
+		fp := fmt.Sprintf("fp%d", i)
+		_ = l.Open(Event{Fingerprint: fp, Kind: "recall", Entry: "x.md", TriggerKey: "k", Resolvable: boolPtr(true), At: at(i * 2)})
+		_, _, _ = l.Resolve(fp, at(i*2+1))
+	}
+	// One still-unresolved recall open that must survive compaction.
+	_ = l.Open(Event{Fingerprint: "live", Kind: "recall", Entry: "x.md", Resolvable: boolPtr(true), At: at(100)})
+
+	before, _ := l.OpenCounts()
+	if before["x.md"].Recalls != 7 || before["x.md"].Resolved != 6 {
+		t.Fatalf("pre-condition: want recalls=7 resolved=6, got %+v", before["x.md"])
+	}
+	nOcc, lastOcc, _ := l.Occurrences("k")
+
+	// Reload from the file — this triggers compaction (13 raw events > bound 8).
+	l2, err := NewWithMaxEvents(p, 8)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	// The file was compacted: fewer lines, exactly one checkpoint.
+	total, ckpts := countLines(t, p)
+	if ckpts != 1 {
+		t.Fatalf("compacted file must carry exactly one checkpoint, got %d (total lines %d)", ckpts, total)
+	}
+	if total > 8 {
+		t.Fatalf("compacted file must be bounded at max_events (8), got %d lines", total)
+	}
+
+	// Aggregates are identical across the compaction round-trip.
+	after, _ := l2.OpenCounts()
+	if after["x.md"].Recalls != before["x.md"].Recalls ||
+		after["x.md"].Resolved != before["x.md"].Resolved ||
+		!after["x.md"].LastConfirmed.Equal(before["x.md"].LastConfirmed) {
+		t.Fatalf("compaction changed aggregates: before=%+v after=%+v", before["x.md"], after["x.md"])
+	}
+	// Occurrences survive too.
+	if n, last, _ := l2.Occurrences("k"); n != nOcc || !last.Equal(lastOcc) {
+		t.Fatalf("compaction changed Occurrences: before=(%d,%v) after=(%d,%v)", nOcc, lastOcc, n, last)
+	}
+	// The still-unresolved open survives: a resolve for it still pairs.
+	if _, ok, _ := l2.Resolve("live", at(200)); !ok {
+		t.Fatal("an unresolved open must survive compaction (still resolvable after reload)")
+	}
+
+	// A SECOND reload (now over the compacted file: checkpoint + tail) is still correct —
+	// the checkpoint round-trips through another compaction cycle.
+	l3, err := NewWithMaxEvents(p, 8)
+	if err != nil {
+		t.Fatalf("second reload: %v", err)
+	}
+	if c := (mustCounts(t, l3))["x.md"]; c.Recalls != 7 {
+		t.Fatalf("after second reload, aggregates must still hold, got %+v", c)
+	}
+}
+
+func mustCounts(t *testing.T, l *Ledger) map[string]Aggregate {
+	t.Helper()
+	c, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	return c
+}
+
+// TestCompactionDisabledWhenZero ensures max_events=0 disables compaction: the file is
+// left fully intact (no checkpoint) however large it grows.
+func TestCompactionDisabledWhenZero(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := NewWithMaxEvents(p, 0) // disabled
+	t0 := time.Unix(31000, 0)
+	for i := 0; i < 20; i++ {
+		fp := fmt.Sprintf("fp%d", i)
+		_ = l.Open(Event{Fingerprint: fp, Kind: "recall", Entry: "x.md", Resolvable: boolPtr(true), At: t0.Add(time.Duration(i) * time.Second)})
+		_, _, _ = l.Resolve(fp, t0.Add(time.Duration(i)*time.Second+time.Millisecond))
+	}
+	if _, err := NewWithMaxEvents(p, 0); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	total, ckpts := countLines(t, p)
+	if ckpts != 0 {
+		t.Fatalf("compaction disabled must write no checkpoint, got %d", ckpts)
+	}
+	if total != 40 {
+		t.Fatalf("compaction disabled must keep all 40 events, got %d", total)
+	}
+}
+
+// TestCorruptLineCountedNotSilent pins that a corrupt JSONL line is surfaced (counted),
+// not silently dropped — the good events still load.
+func TestCorruptLineCountedNotSilent(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	t0 := time.Unix(32000, 0)
+	good1, _ := json.Marshal(Event{Event: "open", Fingerprint: "fp", Kind: "recall", Entry: "a.md", At: t0})
+	good2, _ := json.Marshal(Event{Event: "resolve", Fingerprint: "fp", At: t0.Add(time.Minute)})
+	content := string(good1) + "\nnot json at all{{{\n" + string(good2) + "\n"
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	l, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	l.mu.Lock()
+	corrupt := l.corruptLines
+	l.mu.Unlock()
+	if corrupt != 1 {
+		t.Fatalf("want exactly 1 corrupt line counted, got %d", corrupt)
+	}
+	if c, _ := l.OpenCounts(); c["a.md"].Recalls != 1 {
+		t.Fatalf("good events must still load around the corrupt line, got %+v", c["a.md"])
+	}
+}
+
 func TestStatusDisabled(t *testing.T) {
 	l, _ := New("")
 	s := l.Status()
@@ -626,7 +774,7 @@ func TestReadEventsReturnsAllInOrder(t *testing.T) {
 	_ = l.Open(Event{Fingerprint: "a", Kind: "fresh", At: t0})
 	_ = l.Open(Event{Fingerprint: "b", Kind: "recall", Entry: "x.md", At: t0.Add(time.Second)})
 	_, _, _ = l.Resolve("a", t0.Add(2*time.Second))
-	events, err := l.readEvents()
+	events, _, err := l.readEvents()
 	if err != nil {
 		t.Fatalf("readEvents: %v", err)
 	}
@@ -643,12 +791,12 @@ func TestReadEventsReturnsAllInOrder(t *testing.T) {
 
 func TestReadEventsDisabledOrAbsent(t *testing.T) {
 	dis, _ := New("")
-	if ev, err := dis.readEvents(); err != nil || ev != nil {
-		t.Fatalf("disabled: want nil,nil; got %v,%v", ev, err)
+	if ev, corrupt, err := dis.readEvents(); err != nil || ev != nil || corrupt != 0 {
+		t.Fatalf("disabled: want nil,0,nil; got %v,%v,%v", ev, corrupt, err)
 	}
 	absent, _ := New(filepath.Join(t.TempDir(), "missing.jsonl"))
-	if ev, err := absent.readEvents(); err != nil || ev != nil {
-		t.Fatalf("absent file: want nil,nil; got %v,%v", ev, err)
+	if ev, corrupt, err := absent.readEvents(); err != nil || ev != nil || corrupt != 0 {
+		t.Fatalf("absent file: want nil,0,nil; got %v,%v,%v", ev, corrupt, err)
 	}
 }
 

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -453,6 +453,60 @@ func TestDeriveFingerprintStableAndPrefixed(t *testing.T) {
 	}
 }
 
+// boolPtr is a test helper for the tri-state Resolvable field.
+func boolPtr(b bool) *bool { return &b }
+
+// TestNonResolvableRecallOpenNotCountedButInEpisodes pins Defect 2: a recall open from
+// a source with NO resolve channel (Resolvable=false — GitOps / send_resolved off) must
+// NOT increment Recalls (so a correct entry's resolve-rate can't decay on evidence that
+// can never arrive), yet it MUST still appear in Episodes so recurrence counting keeps
+// working.
+func TestNonResolvableRecallOpenNotCountedButInEpisodes(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(21000, 0)
+	// A resolvable recall (alert) — counts toward decay.
+	_ = l.Open(Event{Fingerprint: "amfp", Kind: "recall", Entry: "x.md", Resolvable: boolPtr(true), At: t0})
+	// A non-resolvable recall (gitops) — must NOT count toward decay.
+	_ = l.Open(Event{Fingerprint: "gitops:abc", Kind: "recall", Entry: "x.md", Resolvable: boolPtr(false), At: t0.Add(time.Second)})
+
+	c, _ := l.OpenCounts()
+	if c["x.md"].Recalls != 1 {
+		t.Fatalf("only the resolvable recall must count toward Recalls, got %+v", c["x.md"])
+	}
+
+	// Both opens must still be present as episodes (recurrence counting is unaffected).
+	eps, _ := l.Episodes()
+	if len(eps) != 2 {
+		t.Fatalf("both opens (resolvable and not) must appear in Episodes, got %d", len(eps))
+	}
+	// And the property survives a reload (the cache is rebuilt from the file).
+	l2, _ := New(p)
+	if c2, _ := l2.OpenCounts(); c2["x.md"].Recalls != 1 {
+		t.Fatalf("after reload, non-resolvable recall must still not count, got %+v", c2["x.md"])
+	}
+}
+
+// TestLegacyOpenMissingResolvableCountsAsResolvable pins backward compatibility: an
+// open written by an OLD binary has no "resolvable" field (nil on decode). It came from
+// Alertmanager/PagerDuty, which do emit resolves, so it must be treated as resolvable
+// and count toward Recalls exactly as before.
+func TestLegacyOpenMissingResolvableCountsAsResolvable(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	// A legacy open line: no "resolvable" key at all.
+	legacy := `{"event":"open","fingerprint":"fp","kind":"recall","entry":"x.md","at":"2026-07-01T10:00:00Z"}` + "\n"
+	if err := os.WriteFile(p, []byte(legacy), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	l, err := New(p)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if c, _ := l.OpenCounts(); c["x.md"].Recalls != 1 {
+		t.Fatalf("a legacy open (no resolvable field) must count as resolvable, got %+v", c["x.md"])
+	}
+}
+
 func TestStatusDisabled(t *testing.T) {
 	l, _ := New("")
 	s := l.Status()

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -426,6 +426,33 @@ func TestPendingResolvesBounded(t *testing.T) {
 	}
 }
 
+// TestDeriveFingerprintStableAndPrefixed pins the synthetic fingerprint derivation
+// used for sources with no external alert id (GitOps failures, reinvestigate polls):
+// it is deterministic (same key ⇒ same id, so recurrences roll up), carries the given
+// prefix, distinguishes distinct keys, and is recognised by Derived().
+func TestDeriveFingerprintStableAndPrefixed(t *testing.T) {
+	a := DeriveFingerprint(GitOpsFingerprintPrefix, "argocd/airflow:Degraded")
+	b := DeriveFingerprint(GitOpsFingerprintPrefix, "argocd/airflow:Degraded")
+	if a != b {
+		t.Fatalf("derivation must be deterministic: %q != %q", a, b)
+	}
+	if len(a) <= len(GitOpsFingerprintPrefix) || a[:len(GitOpsFingerprintPrefix)] != GitOpsFingerprintPrefix {
+		t.Fatalf("derived id %q must carry the %q prefix", a, GitOpsFingerprintPrefix)
+	}
+	if c := DeriveFingerprint(GitOpsFingerprintPrefix, "other/thing:Failed"); c == a {
+		t.Fatalf("distinct keys must derive distinct fingerprints, both %q", c)
+	}
+	if !Derived(a) {
+		t.Fatalf("a gitops-derived fingerprint must be reported Derived: %q", a)
+	}
+	if !Derived(DeriveFingerprint(ReinvestigateFingerprintPrefix, "issue-7")) {
+		t.Fatal("a reinvestigate-derived fingerprint must be reported Derived")
+	}
+	if Derived("f0e1a2b3") { // a real Alertmanager fingerprint (opaque hex, no prefix)
+		t.Fatal("a real Alertmanager fingerprint must NOT be reported Derived")
+	}
+}
+
 func TestStatusDisabled(t *testing.T) {
 	l, _ := New("")
 	s := l.Status()


### PR DESCRIPTION
Hardens the CAPTURE stage (`internal/outcome`) against three confirmed defects found in a code audit. Each is a separate, well-scoped commit; strict TDD (failing test first per defect).

## Defect 1 — GitOps incidents were invisible to the ledger
`FromFailureEvent` set only a `TriggerKey`, never a `Fingerprint`, so the open-emission guard (`len(fps) > 0`) skipped `ledger.Open(...)` entirely for GitOps-failure incidents: no `open` events, no `Occurrences()` recurrence facts on notifications, and the Phase-2 Recurrence pass (which reads `Episodes()`) could never see pure-GitOps patterns.

**Fix:** `outcome.DeriveFingerprint(prefix, key)` derives a stable, deterministic id (short sha256 of the trigger key / issue identity) under a namespaced prefix that cannot collide with an Alertmanager/PagerDuty fingerprint — `gitops:<hash>` for GitOps failures, `reinvestigate:<hash>` for reinvestigate polls. Re-firings of the same failure derive the same id, so they roll up as recurrences. Wired into `FromFailureEvent` and the reinvestigate poller.

## Defect 2 — sources that never emit a resolve permanently poisoned decay
Only Alertmanager and PagerDuty emit resolve signals. A recall `open` from a source with no resolve channel (GitOps/reinvestigate after Defect 1, or Alertmanager with `send_resolved` off) counted `Recalls++` forever with no possible `Resolved++`, so a **correct** entry's resolve-rate decayed until Gate 3 disabled recall for it — punished on evidence that can never arrive.

**Fix:** a tri-state `Resolvable *bool` on the open `Event` (`json:"resolvable,omitempty"`). A pointer is required for the three-state distinction the spec demands: `nil` (field absent) ⇒ a **legacy** open, treated as resolvable since it came from Alertmanager/PagerDuty; `true`/`false` set explicitly at the emission site from the incident source (real fingerprint ⇒ resolvable, derived ⇒ not). `applyOpenLocked` counts a recall toward `Recalls` **only when resolvable**; `Episodes()` and `Occurrences()` still include **every** open, so recurrence counting is unchanged. Decay is thus only learned where a ground-truth resolve signal exists.

## Defect 3 — unbounded ledger growth + silent corrupt-line drop
The JSONL only appended; `readEvents` loaded every event into memory, so startup, leadership `Reload()`, and every curate `Episodes()` replayed the whole file, forever growing. Corrupt lines were dropped silently.

**Fix:**
- **Compaction** (`outcome.max_events`, default 50000; `0` = disabled — a tri-state `*int` config so an explicit 0 is distinguishable from unset). On load, when the file exceeds the bound it is atomically rewritten (temp file + fsync + rename, plus a dir fsync) as a single **`checkpoint`** record followed by a recent tail. The checkpoint carries the exact folded state the dropped events produced — per-entry aggregates, the per-`TriggerKey` occurrence index, and the open-index + pairing stacks for still-unresolved opens — so `OpenCounts`/`Occurrences` and unresolved-open resolution survive the round-trip. `loadLocked` seeds from the checkpoint then folds the tail on top.
- **Forward/backward compat:** unknown/future event kinds (including `checkpoint`) are still ignored gracefully on replay, so an **old binary reading a compacted file does not choke** — it loses only the pre-horizon aggregates. `Episodes()` replay is preserved for the retained tail; older episodes are folded into the checkpoint and no longer individually replayable (the Phase-2 Queue/Recurrence passes only need recent history).
- **Corrupt lines** are now counted and logged (a warning with a count) instead of skipped silently.

## Behaviour changes
- GitOps + reinvestigate incidents now record `open` events (visible in `Occurrences`/`Episodes`).
- Non-resolvable recall opens no longer move recall decay in either direction.
- The ledger file is compacted on load past `outcome.max_events`; old episodes beyond the horizon are folded into a checkpoint (aggregates preserved, individual replay dropped).
- New config key `outcome.max_events`.

## Verification
`go build ./...`, `go vet ./...`, `gofmt -l .`, `go test ./...`, and `go test -race ./internal/{outcome,app,investigate}/` all green; `golangci-lint run` reports 0 issues on the touched packages. New tests cover: GitOps incident records an open and shows up in Occurrences/Episodes; non-resolvable recall not counted but present in Episodes; legacy opens (no `resolvable` field) still counted; compaction preserves aggregates + unresolved opens across reload round-trips (including a second compaction cycle); `max_events=0` disables compaction; corrupt line counted, not silent.
