### PR TITLE
chore: remove dead code found by deadcode + golangci-lint

### DIFF
--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -130,20 +130,6 @@ func (n Novelty) TopHit(ctx context.Context, inv providers.Investigation) (catal
 	return hits[0], true, nil
 }
 
-// IsDuplicate returns true and the matching entry when the top hit's score is
-// ≥ DupScore. Returns false (novel) when no catalog is configured, there are no
-// hits, or the top score falls below the threshold.
-func (n Novelty) IsDuplicate(ctx context.Context, inv providers.Investigation) (bool, catalog.Entry, error) {
-	top, ok, err := n.TopHit(ctx, inv)
-	if err != nil || !ok {
-		return false, catalog.Entry{}, err
-	}
-	if top.Score >= n.DupScore {
-		return true, top.Entry, nil
-	}
-	return false, catalog.Entry{}, nil
-}
-
 // DupFingerprint is a deterministic identity for "the same incident", used to
 // dedupe curated PRs across re-investigations. It prefers the trigger key stamped
 // at trigger time (a structured K8s signal — the alert fingerprint, or the failing

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -41,35 +41,6 @@ func (f fakeScored) SearchScored(_ string, _ int) ([]catalog.ScoredEntry, error)
 	return []catalog.ScoredEntry{{Entry: catalog.Entry{Title: f.title}, Score: f.score}}, nil
 }
 
-func TestNoveltyDuplicateAboveThreshold(t *testing.T) {
-	inv := providers.Investigation{Title: "HarborRegistryDown"}
-	n := Novelty{Catalog: fakeScored{score: 9.0, title: "HarborRegistryDown"}, DupScore: 5.0}
-	dup, hit, err := n.IsDuplicate(context.Background(), inv)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !dup || hit.Title != "HarborRegistryDown" {
-		t.Fatalf("expected duplicate hit, got dup=%v hit=%+v", dup, hit)
-	}
-}
-
-func TestNoveltyBelowThresholdIsNovel(t *testing.T) {
-	inv := providers.Investigation{Title: "BrandNewThing"}
-	n := Novelty{Catalog: fakeScored{score: 1.0, title: "Unrelated"}, DupScore: 5.0}
-	dup, _, err := n.IsDuplicate(context.Background(), inv)
-	if err != nil || dup {
-		t.Fatalf("expected novel, got dup=%v err=%v", dup, err)
-	}
-}
-
-func TestNoveltyNilCatalogIsNovel(t *testing.T) {
-	n := Novelty{Catalog: nil, DupScore: 5.0}
-	dup, _, err := n.IsDuplicate(context.Background(), providers.Investigation{Title: "x"})
-	if err != nil || dup {
-		t.Fatalf("nil catalog must be novel, got dup=%v err=%v", dup, err)
-	}
-}
-
 func TestTopHitReturnsScore(t *testing.T) {
 	// TopHit surfaces the top hit + score regardless of the DupScore threshold,
 	// so the caller can both observe the score and apply the threshold itself.

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -21,39 +21,6 @@ type Runner struct {
 	Log   *slog.Logger
 }
 
-// Report aggregates case results.
-type Report struct {
-	Results []Result
-}
-
-// Passed counts cases whose root cause was identified.
-func (r Report) Passed() int {
-	n := 0
-	for _, res := range r.Results {
-		if res.Pass {
-			n++
-		}
-	}
-	return n
-}
-
-// RCARate is the fraction of cases whose root cause was identified.
-func (r Report) RCARate() float64 {
-	if len(r.Results) == 0 {
-		return 0
-	}
-	return float64(r.Passed()) / float64(len(r.Results))
-}
-
-// Run replays every case and scores it.
-func (r *Runner) Run(ctx context.Context, cases []Case) Report {
-	var rep Report
-	for _, c := range cases {
-		rep.Results = append(rep.Results, r.runOne(ctx, c))
-	}
-	return rep
-}
-
 func (r *Runner) runOne(ctx context.Context, c Case) Result {
 	tools := make([]investigate.Tool, 0, len(c.Tools))
 	for name, output := range c.Tools {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -179,41 +179,6 @@ expected:
 	}
 }
 
-// scriptModel returns a fixed response sequence: call a tool, then submit_findings.
-type scriptModel struct {
-	calls int
-}
-
-func (m *scriptModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
-	m.calls++
-	if m.calls == 1 {
-		return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
-			{ID: "1", Name: "what_changed", Args: `{}`}}}, nil
-	}
-	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
-		{ID: "2", Name: "submit_findings", Args: `{"confidence":0.9,"root_causes":[{"summary":"chart bump broke harbor-db migrations"}]}`}}}, nil
-}
-
-func TestRun(t *testing.T) {
-	cases := []Case{
-		{Name: "hit", Prompt: "probe failing", Tools: map[string]string{"what_changed": "chart 1.15"},
-			Expected: Expected{MustContain: []string{"chart", "harbor-db"}, MinConfidence: 0.5}},
-		{Name: "miss", Prompt: "probe failing", Tools: map[string]string{"what_changed": "chart 1.15"},
-			Expected: Expected{MustContain: []string{"network policy"}}},
-	}
-	r := &Runner{Model: &scriptModel{}, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	rep := r.Run(context.Background(), cases)
-	if len(rep.Results) != 2 {
-		t.Fatalf("want 2 results, got %d", len(rep.Results))
-	}
-	if rep.Passed() != 1 || rep.RCARate() != 0.5 {
-		t.Fatalf("want 1 passed / 0.5 rate, got passed=%d rate=%.2f", rep.Passed(), rep.RCARate())
-	}
-	if !rep.Results[0].Pass || rep.Results[1].Pass {
-		t.Fatalf("unexpected per-case: %+v", rep.Results)
-	}
-}
-
 // rateModel passes (names harbor-db) on its first passN Complete-pairs, then fails.
 // Each replay run makes 2 Complete calls (tool, then submit_findings).
 type rateModel struct {

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -24,15 +24,6 @@ var Rubric = []Dimension{
 	{"calibration", 2}, // high confidence only when correct
 }
 
-// RubricMax is the maximum total score across all dimensions.
-func RubricMax() int {
-	n := 0
-	for _, d := range Rubric {
-		n += d.Max
-	}
-	return n
-}
-
 // Verdict is the judge's structured grade for one investigation.
 type Verdict struct {
 	Scores         map[string]int `json:"scores"`

--- a/internal/eval/judge_test.go
+++ b/internal/eval/judge_test.go
@@ -86,9 +86,3 @@ func TestModelJudgeParsesVerdict(t *testing.T) {
 		t.Fatalf("prompt missing ground truth/investigation: %q", m.gotUser)
 	}
 }
-
-func TestRubricMax(t *testing.T) {
-	if RubricMax() != 14 { // 3+3+3+3+2
-		t.Fatalf("rubric max = %d, want 14", RubricMax())
-	}
-}


### PR DESCRIPTION
## What

Dead-code audit of `cmd/` + `internal/` using `golang.org/x/tools/cmd/deadcode` cross-checked with `golangci-lint` (`unused`). Removes five production functions that were superseded and survived only through their own unit tests, plus those now-orphaned tests. **126 deletions, no behavior change.**

## Removed

| Symbol | Why it is dead |
|---|---|
| `internal/eval` `Runner.Run`, `Report`, `Report.Passed`, `Report.RCARate` | Legacy single-pass replay API. The eval command (`internal/app/eval.go`) runs `Runner.RunN` → `Campaign` (k-of-n aggregation) exclusively; nothing in the binary constructs a `Report`. Orphaned `TestRun` + its `scriptModel` fixture dropped; the replay pipeline stays covered by `TestReplayKOfNRepeats` (same `runOne` path). |
| `internal/eval` `RubricMax` | Unused everywhere except its own test; the judge sums scores via `Verdict.Total` and no renderer prints an "out of N" denominator. |
| `internal/curator` `Novelty.IsDuplicate` | Superseded: `curator.go` deliberately inlines the `score >= DupScore` decision on `Novelty.TopHit` so it can record `CurationDedupScore` on every check. Only its own three tests called it; `TopHit` keeps dedicated tests (score surfacing, nil catalog, search error). |

## Kept (flagged by `deadcode` without `-test`, verified as intentional)

`audit.NewWriter`, `eval.ParseComparisonReport`, `investigate.compactHistory`, `victorialogs.New`, `prometheus.New`, `incidentDebouncer.waitIdle`, `source.resetForTest` — all documented test helpers or convenience constructors used by tests (the `-test` run reports **zero** findings, before and after).

## Verification

```
go build ./...                                   ok
go vet ./...                                     ok
go test ./...                                    all packages pass
gofmt -l .                                       clean
golangci-lint run ./...                          0 issues.
deadcode -test ./...                             no findings
```