### PR TITLE
fix(ha): rejoin leader election after losing the lease without dying

### DIFF
--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -37,9 +37,22 @@ func NewHTTPServer(addr string, h http.Handler) *http.Server {
 	}
 }
 
+// Leader-election timings. Package vars (not consts) so tests can shrink them;
+// production always runs the defaults.
+var (
+	leaseDuration = 15 * time.Second
+	renewDeadline = 10 * time.Second
+	retryPeriod   = 2 * time.Second
+)
+
 // RunLeaderElection blocks running Lease-based leader election; the leader runs
-// startWork and reports ready. Lost leadership cancels the work context.
-func RunLeaderElection(ctx context.Context, cfg *config.Config, cs *kubernetes.Clientset, leader *atomic.Bool, log *slog.Logger, startWork func(context.Context)) {
+// startWork and reports ready. Lost leadership cancels the work context and the
+// replica REJOINS the election as a standby: client-go's RunOrDie returns when
+// the lease is lost without the process dying (e.g. an API-server blip past
+// RenewDeadline), and without the re-entry loop the replica would never contend
+// again — a permanent zombie standby that /healthz keeps reporting alive,
+// silently shrinking the HA pool until no replica leads at all.
+func RunLeaderElection(ctx context.Context, cfg *config.Config, cs kubernetes.Interface, leader *atomic.Bool, log *slog.Logger, startWork func(context.Context)) {
 	name := cfg.LeaderElection.Name
 	if name == "" {
 		name = "runlore-leader"
@@ -50,29 +63,37 @@ func RunLeaderElection(ctx context.Context, cfg *config.Config, cs *kubernetes.C
 		Client:     cs.CoordinationV1(),
 		LockConfig: resourcelock.ResourceLockConfig{Identity: id},
 	}
-	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
-		Lock:            lock,
-		ReleaseOnCancel: true,
-		LeaseDuration:   15 * time.Second,
-		RenewDeadline:   10 * time.Second,
-		RetryPeriod:     2 * time.Second,
-		Callbacks: leaderelection.LeaderCallbacks{
-			OnStartedLeading: func(workCtx context.Context) {
-				log.Info("acquired leadership", "id", id)
-				leader.Store(true)
-				startWork(workCtx)
+	for ctx.Err() == nil {
+		// RunOrDie blocks until leadership is lost or ctx is cancelled; the loop
+		// never spins hot — RunOrDie's internal acquire loop already paces every
+		// retry by RetryPeriod.
+		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+			Lock:            lock,
+			ReleaseOnCancel: true,
+			LeaseDuration:   leaseDuration,
+			RenewDeadline:   renewDeadline,
+			RetryPeriod:     retryPeriod,
+			Callbacks: leaderelection.LeaderCallbacks{
+				OnStartedLeading: func(workCtx context.Context) {
+					log.Info("acquired leadership", "id", id)
+					leader.Store(true)
+					startWork(workCtx)
+				},
+				OnStoppedLeading: func() {
+					log.Info("lost leadership", "id", id)
+					leader.Store(false)
+				},
+				OnNewLeader: func(current string) {
+					if current != id {
+						log.Info("standby; another replica leads", "leader", current)
+					}
+				},
 			},
-			OnStoppedLeading: func() {
-				log.Info("lost leadership", "id", id)
-				leader.Store(false)
-			},
-			OnNewLeader: func(current string) {
-				if current != id {
-					log.Info("standby; another replica leads", "leader", current)
-				}
-			},
-		},
-	})
+		})
+		if ctx.Err() == nil {
+			log.Warn("leadership lost without shutdown; rejoining election as standby", "id", id)
+		}
+	}
 }
 
 // SetMemoryLimitFromCgroup sets GOMEMLIMIT to ~90% of the cgroup v2 memory limit

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -1,8 +1,20 @@
 package app
 
 import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"net/http"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/Smana/runlore/internal/config"
 )
 
 // TestNewHTTPServer asserts the serving http.Server is built with every inbound
@@ -24,5 +36,86 @@ func TestNewHTTPServer(t *testing.T) {
 	}
 	if s.MaxHeaderBytes == 0 {
 		t.Error("MaxHeaderBytes is zero (defaults to 1MB but should be explicit)")
+	}
+}
+
+// TestRunLeaderElectionRejoinsAfterLoss captures the HA zombie-standby bug: a
+// replica that loses the lease WITHOUT dying (e.g. an API-server blip past
+// RenewDeadline, or another holder stealing the lease) must re-enter the
+// election and be able to lead again. Before the fix, RunOrDie returned after
+// the first loss and the election goroutine exited — the replica stayed a
+// permanent standby (never ready, never leading) while its kubelet probes
+// stayed green, silently shrinking the HA pool to zero over successive flaps.
+func TestRunLeaderElectionRejoinsAfterLoss(t *testing.T) {
+	// Shrink the election timings so a full lose-then-rejoin cycle fits in a test.
+	origLease, origRenew, origRetry := leaseDuration, renewDeadline, retryPeriod
+	leaseDuration, renewDeadline, retryPeriod = 400*time.Millisecond, 300*time.Millisecond, 50*time.Millisecond
+	defer func() { leaseDuration, renewDeadline, retryPeriod = origLease, origRenew, origRetry }()
+
+	t.Setenv("POD_NAME", "replica-a")
+	t.Setenv("POD_NAMESPACE", "default")
+	cs := fake.NewSimpleClientset()
+	// outage simulates an API-server blip: while set, every lease get/update
+	// fails, so the leader cannot renew within renewDeadline and drops the lease
+	// — exactly the production trigger for a leadership loss without a restart.
+	var outage atomic.Bool
+	blip := func(k8stesting.Action) (bool, runtime.Object, error) {
+		if outage.Load() {
+			return true, nil, errors.New("simulated apiserver outage")
+		}
+		return false, nil, nil
+	}
+	cs.PrependReactor("get", "leases", blip)
+	cs.PrependReactor("update", "leases", blip)
+	cfg := &config.Config{}
+	cfg.LeaderElection.Enabled = true
+	cfg.LeaderElection.Name = "test-leader"
+
+	var leader atomic.Bool
+	var terms atomic.Int32 // one startWork call per leadership term
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		RunLeaderElection(ctx, cfg, cs, &leader,
+			slog.New(slog.NewTextHandler(io.Discard, nil)),
+			func(context.Context) { terms.Add(1) })
+	}()
+
+	waitFor := func(desc string, cond func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			if cond() {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for %s", desc)
+	}
+
+	waitFor("initial leadership", leader.Load)
+
+	// Blip the API server for longer than renewDeadline: the replica must drop
+	// leadership (it cannot renew), but the process stays alive.
+	outage.Store(true)
+	waitFor("leadership loss during the apiserver blip", func() bool { return !leader.Load() })
+
+	// The blip clears. The replica must REJOIN the election and lead a second
+	// term — before the fix the election goroutine had already exited, leaving a
+	// permanent zombie standby.
+	outage.Store(false)
+	waitFor("re-acquired leadership after the blip cleared", leader.Load)
+	if got := terms.Load(); got < 2 {
+		t.Errorf("startWork ran %d time(s), want >=2 (one per leadership term)", got)
+	}
+
+	// Shutdown: cancelling the context must end the election loop.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunLeaderElection did not return after context cancel")
 	}
 }


### PR DESCRIPTION
## Root cause

`RunLeaderElection` (`internal/app/server.go`) called client-go's `leaderelection.RunOrDie` **exactly once**. `RunOrDie` returns when leadership is lost *without the process dying* — an API-server blip longer than `RenewDeadline` (10s), or the Lease being taken over — so the election goroutine silently exited. The replica became a **permanent zombie standby**:

- `/healthz` stays 200 (the kubelet sees a healthy pod, no restart),
- `/readyz` stays 503 forever (leadership-gated by design),
- the replica **never contends for the Lease again**.

Each leadership flap silently shrank the HA pool. Once every replica had lost the lease once, **no replica could lead**: the Service had zero ready endpoints (total webhook outage) while every pod still looked alive. This is why the health check appeared to "work only on the leader" — any replica that had ever lost leadership could never pass readiness again, even when the lease was free.

The serve wiring already anticipated re-acquisition (`internal/app/serve.go`: `startWork` is per-term, and `failureDedup` is process-scoped "so it survives leader flaps ... on each re-acquire") — the loop just never existed.

## Reproduction (k3d, 2 replicas, leader election on)

Cluster: `runlore-ha-test`, chart installed with `replicaCount=2` and a mock model backend. Steady state was correct (leader `/readyz` 200, standby `/healthz` 200 + `/readyz` 503, 0 restarts). Then the Lease was taken over out-of-band (equivalent to a renew failure from the leader's point of view):

**Before the fix**

```
# after stealing the lease from each leader once:
--- lease (stolen holder expired) ---
holder=chaos-steal-2 renew=2026-07-04T09:33:59Z   now=2026-07-04T09:35:18Z   <- expired 64s, unclaimed
--- acquire attempts per pod ---
runlore-...-9226f: 1 acquire attempts, lost=1     <- never rejoins
runlore-...-w6ww2: 1 acquire attempts, lost=1     <- never rejoins
--- service endpoints ---
only notReadyAddresses (zero ready backends)
NAME                    READY  STATUS   RESTARTS
runlore-...-9226f       0/1    Running  0        <- healthz=200 readyz=503, forever
runlore-...-w6ww2       0/1    Running  0        <- healthz=200 readyz=503, forever
```

**After the fix** (same image tag rebuilt, same scenario)

```
time=...09:42:39 msg="lost leadership" id=runlore-...-9jr45
time=...09:42:39 msg="leadership lost without shutdown; rejoining election as standby"
I0704 09:42:39 "Attempting to acquire leader lease..."   <- second attempt
09:42:51 holder=runlore-...-vk644                        <- a live replica recovers the expired lease
# second steal (previously fatal):
09:43:28 holder=runlore-...-9jr45                        <- the FIRST ex-leader leads a second term
# pod-deletion failover:
09:44:01 holder=runlore-...-rjs9j (new pod), Ready ~20s after the leader was deleted
# final state:
leader:  healthz=200 readyz=200
standby: healthz=200 readyz=503
all pods RESTARTS=0; Service endpoints = leader IP only
```

## Fix

Loop `RunOrDie` until the context is cancelled: a lost lease puts the replica back into the election as a hot standby, logged at WARN (`leadership lost without shutdown; rejoining election as standby`). The loop cannot spin hot — `RunOrDie` blocks in its acquire path, pacing every retry by `RetryPeriod`; it only returns on leadership loss or context cancellation, and shutdown (`workCtx` cancel) still exits promptly with `ReleaseOnCancel`.

Test: `TestRunLeaderElectionRejoinsAfterLoss` drives a full acquire → API-outage → loss → rejoin → re-acquire cycle against a fake clientset (election timings lifted into package vars so the test shrinks them; the clientset parameter widened to `kubernetes.Interface`). The test failed on the rejoin step before the fix and passes in ~0.45s after it.

## Quality gate

`go build ./...` OK - `go vet ./...` OK - `go test ./...` all pass - `gofmt -l .` clean - `golangci-lint run ./...` 0 issues.
