### PR TITLE
fix: don't gate readyz on catalog when no model is configured

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -29,11 +29,20 @@ func ModelConfigured(cfg *config.Config) bool {
 
 // CatalogConfigured reports whether the operator asked for a knowledge catalog
 // (a mounted dir or a git-sync repo). It is independent of whether the load
-// succeeded: ReadyFunc uses it to keep a configured-but-failed catalog (which
-// BuildCatalog returns as nil) from collapsing readiness to pure leadership and
-// serving incident traffic with no knowledge base.
+// succeeded.
 func CatalogConfigured(cfg *config.Config) bool {
 	return cfg.Catalog.Dir != "" || cfg.Catalog.Git.URL != ""
+}
+
+// CatalogExpected reports whether readiness should gate on a built catalog: a
+// catalog source AND a usable model. With a model, a configured-but-failed
+// catalog (BuildCatalog returns nil) keeps the pod at /readyz 503 instead of
+// collapsing readiness to pure leadership and serving incidents with no KB.
+// Without a model, BuildInvestigator skips the catalog entirely (log-only
+// investigator, cat=nil by design, not by failure), so gating on it would hold
+// every replica — leader included — at 503 forever.
+func CatalogExpected(cfg *config.Config) bool {
+	return CatalogConfigured(cfg) && ModelConfigured(cfg)
 }
 
 // RequireWebhookAuth fails closed on the serve path when the LLM investigator is

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -119,6 +119,34 @@ func TestModelConfigured(t *testing.T) {
 	}
 }
 
+// TestCatalogExpected locks in the readiness-gate predicate: a catalog is only
+// expected when BOTH a catalog source and a usable model are configured. Without
+// a model, BuildInvestigator deliberately skips the catalog (log-only
+// investigator), so gating readiness on it would hold even the leader at 503
+// forever (issue #251).
+func TestCatalogExpected(t *testing.T) {
+	tests := []struct {
+		name     string
+		dir      string
+		provider string
+		want     bool
+	}{
+		{"catalog and model", "/var/lib/runlore/catalog", "anthropic", true},
+		{"catalog without model", "/var/lib/runlore/catalog", "", false},
+		{"model without catalog", "", "anthropic", false},
+		{"neither", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Model: config.Model{Provider: tc.provider}}
+			cfg.Catalog.Dir = tc.dir
+			if got := CatalogExpected(cfg); got != tc.want {
+				t.Fatalf("CatalogExpected = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestCatalogConfigured locks in the catalog-configured predicate: a mounted dir
 // OR a git-sync URL counts as configured; neither does not.
 func TestCatalogConfigured(t *testing.T) {

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -313,7 +313,7 @@ func RunServe(version string, args []string) error {
 	if auto != nil {
 		acts.Pauser = auto // avoid a typed-nil interface when auto is disabled
 	}
-	srv := server.New(ReadyFunc(leader.Load, cat, CatalogConfigured(cfg)), acts, built, pipe, metricsHandler, log)
+	srv := server.New(ReadyFunc(leader.Load, cat, CatalogExpected(cfg)), acts, built, pipe, metricsHandler, log)
 	if cz != nil {
 		go cz.Run(workCtx, cfg.Investigation.Coalesce.Debounce.Std()/2)
 	}


### PR DESCRIPTION
Fixes #251.

## Problem

With `catalog.dir` (or `catalog.git.url`) configured but **no model**, every replica — including the elected leader — stayed `/readyz` 503 forever, leaving the Service with zero ready endpoints. Reproduced in k3d during the #250 HA investigation.

## Root cause

`BuildInvestigator` deliberately returns a nil catalog when no model is configured (log-only investigator has nothing to use it for), but `ReadyFunc`'s `configured && cat == nil` guard — designed to catch configured-but-**failed** catalog loads — can't distinguish that intentional nil from a broken KB.

## Fix

New `CatalogExpected` predicate (`CatalogConfigured && ModelConfigured`), used at the `ReadyFunc` call site in `serve.go`:

- catalog + model, load failed → still held at 503 (existing safety preserved)
- catalog + **no model** (log-only) → ready on leadership alone (the fix)

TDD: `TestCatalogExpected` written first and watched fail (`undefined: CatalogExpected`), then the predicate added. Full quality gate green: build, vet, `go test ./...`, gofmt clean, golangci-lint 0 issues.