### PR TITLE
fix: fall back to max root-cause confidence when overall is omitted

### DIFF
--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -220,5 +220,14 @@ func buildInvestigation(f findings) providers.Investigation {
 		Name:      f.AffectedResource.Name,
 		Namespace: f.AffectedResource.Namespace,
 	}
+	// The top-level confidence is optional in the schema and some models (e.g.
+	// GLM over the OpenAI-compatible path) only fill the per-root-cause field.
+	// A missing overall would read as 0% and verify's min(overall, maxRootCause)
+	// would pin it there, so fall back to the strongest root cause.
+	if inv.Confidence == 0 {
+		for _, rc := range inv.RootCauses {
+			inv.Confidence = max(inv.Confidence, rc.Confidence)
+		}
+	}
 	return inv
 }

--- a/internal/investigate/tools_test.go
+++ b/internal/investigate/tools_test.go
@@ -27,6 +27,51 @@ func TestParseFindings(t *testing.T) {
 	}
 }
 
+// TestParseFindingsOmittedOverallConfidenceFallsBackToRootCauses covers models
+// (observed with GLM-5.2 over the OpenAI-compatible path) that fill per-root-cause
+// confidence but omit the optional top-level field: the overall confidence must
+// fall back to the highest root-cause confidence, not default to zero — a zero
+// overall makes verify's min(overall, maxRootCause) pin the investigation to 0%.
+func TestParseFindingsOmittedOverallConfidenceFallsBackToRootCauses(t *testing.T) {
+	args := `{"root_causes":[
+	  {"summary":"low-memory OOMKill","confidence":0.88},
+	  {"summary":"secondary hypothesis","confidence":0.4}
+	],"verdict":"action_required"}`
+	inv, err := parseFindings(args)
+	if err != nil {
+		t.Fatalf("parseFindings: %v", err)
+	}
+	if inv.Confidence != 0.88 {
+		t.Fatalf("Confidence = %v, want fallback to max root-cause confidence 0.88", inv.Confidence)
+	}
+}
+
+// TestParseFindingsExplicitOverallConfidenceKept asserts the fallback does not
+// override a model that sets the top-level field, even when it is lower than the
+// per-root-cause confidences.
+func TestParseFindingsExplicitOverallConfidenceKept(t *testing.T) {
+	args := `{"confidence":0.3,"root_causes":[{"summary":"s","confidence":0.9}]}`
+	inv, err := parseFindings(args)
+	if err != nil {
+		t.Fatalf("parseFindings: %v", err)
+	}
+	if inv.Confidence != 0.3 {
+		t.Fatalf("Confidence = %v, want explicit 0.3 preserved", inv.Confidence)
+	}
+}
+
+// TestParseFindingsNoConfidenceAnywhereStaysZero asserts the fallback only fires
+// when a root cause actually carries confidence — all-omitted stays 0.
+func TestParseFindingsNoConfidenceAnywhereStaysZero(t *testing.T) {
+	inv, err := parseFindings(`{"root_causes":[{"summary":"s"}],"verdict":"inconclusive"}`)
+	if err != nil {
+		t.Fatalf("parseFindings: %v", err)
+	}
+	if inv.Confidence != 0 {
+		t.Fatalf("Confidence = %v, want 0 when no confidence supplied anywhere", inv.Confidence)
+	}
+}
+
 // TestParseFindingsVerdictRuledOutDataGaps checks the three model-contract fields
 // added for the notification overhaul map through parseFindings: a valid verdict
 // enum, and the ruled_out / data_gaps honesty channels distinct from unresolved.


### PR DESCRIPTION
## Problem

The top-level `confidence` field in the `submit_findings` schema is optional (only `root_causes` and `verdict` are required). Some models fill the per-root-cause confidence but omit the overall field — observed live with **GLM-5.2** via Z.ai's OpenAI-compatible endpoint. The omitted field unmarshals to 0, and `applyVerify`'s `min(preVerifyOverall, maxRootCause)` then pins the whole investigation to **0%** even though the root cause itself carried 0.88:

```
*Investigation* — confidence 0%
🔥 Verdict: Action required
1. *…OOMKilled…* (88%)
```

## Fix

`buildInvestigation` falls back to the strongest root-cause confidence when the overall field is absent:

- omitted overall + root causes with confidence → max root-cause confidence
- explicit overall (even lower than the root causes) → preserved
- no confidence anywhere → stays 0

## Testing

TDD: the fallback test failed first (`Confidence = 0, want 0.88`), then the fix made it pass. Full suite green with `-race`. Re-ran the same live GLM-5.2 investigation on a k3d cluster: header now reads **confidence 85%** instead of 0%.