### PR TITLE
docs(readme): lead with the zero-setup demo before the production install

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,38 @@ additive. Full setup detail in **[Data sources](docs/data-sources.md)**.
 | **Notifiers** | Slack *(bot token: threaded summary + detail)* · Slack incoming webhook / Matrix / generic webhook *(single verdict-first message)* | `notify.*` |
 | **Knowledge base** *(git forge)* | GitHub *(App auth)* | `forge.*` |
 
-## 🚀 Getting started
+## ⚡ Try it in one minute — no cluster, no keys
 
-RunLore runs in your Kubernetes cluster as a single Go binary, deployed via Helm. Before installing,
-you need:
+Before you wire up a cluster, see the front of the pipeline for yourself. This runs `lore serve`
+locally with a keyless demo config and fires a batch of mocked Alertmanager alerts at it — no
+Kubernetes, no LLM, no credentials. You only need Go and `curl`:
+
+```bash
+hack/demo.sh
+```
+
+It builds the binary, starts the server, POSTs [`examples/alertmanager-webhook.json`](examples/alertmanager-webhook.json)
+to the webhook, and prints the **trigger policy** deciding which alerts become incidents:
+
+```text
+=== trigger-policy decisions ===
+msg=incident alert=HarborProbeFailure severity=critical namespace=apps investigate=true  reason="matched trigger policy"
+msg=incident alert=HarborProbeFailure severity=critical namespace=apps investigate=false reason="deduplicated (still-firing)"
+msg=incident alert=NoisyWarn        severity=warning  namespace=apps investigate=false reason="filtered by trigger policy"
+msg=incident alert=StagingCrit      severity=critical namespace=apps investigate=false reason="filtered by trigger policy"
+msg=incident alert=Watchdog         severity=critical namespace=apps investigate=false reason="filtered by trigger policy"
+```
+
+That's one alert admitted (critical + prod), the rest correctly deduped, severity-filtered,
+environment-filtered, and ignore-listed — the exact gate that controls noise and LLM cost in
+production. The demo stops there: a full investigation (root cause → chat → PR) needs a real cluster,
+an LLM, and a knowledge base, which is the production install below. To exercise every feature
+end-to-end on a throwaway cluster, `hack/e2e-k3d.sh` spins one up with [k3d](https://k3d.io/).
+
+## 🚀 Getting started (production install)
+
+Ready to point it at real incidents? RunLore runs in your Kubernetes cluster as a single Go binary,
+deployed via Helm. Before installing, you need:
 
 - **Data sources** — at least one wired source (each is pluggable, an unset one just disables its tool); for the *what-changed* anchor, a cluster running Flux or Argo CD, plus optionally Prometheus/VictoriaMetrics, VictoriaLogs, Hubble for richer signals
 - **An LLM** — any OpenAI-compatible endpoint, Anthropic, or Gemini (in-cluster or external)
@@ -131,18 +159,6 @@ Then point a source at RunLore — for example, route your Alertmanager alerts t
 
 **→ [Full getting-started guide](docs/getting-started.md)** — KB repo setup, GitHub App,
 credentials, complete `values.yaml` reference, data sources, and verification steps.
-
----
-
-Prefer to try it without a cluster first?
-
-```bash
-# fire mocked Alertmanager alerts through the trigger policy (no cluster)
-hack/demo.sh
-
-# verify every feature end-to-end on a throwaway k3d cluster
-hack/e2e-k3d.sh
-```
 
 ## Why RunLore
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,11 @@ forge (issues/PRs on a repo you designate).
 
 > For local development / testing on k3d, see [CONTRIBUTING.md](../CONTRIBUTING.md) instead.
 
+> **Just want a quick look first?** `hack/demo.sh` runs `lore serve` locally with a keyless config and
+> fires mocked Alertmanager alerts through the trigger policy — no cluster, no LLM, no credentials
+> (just Go + `curl`). It shows which alerts become incidents; the full investigate → chat → curate loop
+> below needs the cluster, LLM, and KB repo. See the [README quickstart](../README.md#-try-it-in-one-minute--no-cluster-no-keys).
+
 ## Prerequisites
 
 ### Required


### PR DESCRIPTION
## What

Inverts the README on-ramp so the zero-setup demo comes first. For launch (HN/Reddit) readers, the previous flow led with four heavy production prerequisites (cluster + GitOps engine, LLM key, GitHub App + KB repo, notifier) and buried `hack/demo.sh` as an afterthought — the highest bounce point.

## Changes

- **New "⚡ Try it in one minute — no cluster, no keys" section** right after Supported integrations and before the production install. It shows the `hack/demo.sh` invocation, the actual trigger-policy output, and — honestly — states the demo exercises only the trigger policy (admit / dedup / filter / ignore), not a full LLM investigation, which the production install covers.
- **Renamed the install section to "🚀 Getting started (production install)"** and reframed its intro as the next step. Content (prerequisites, Helm, GitHub App) is unchanged.
- **Removed the now-redundant "prefer to try it without a cluster first?" block** at the bottom of the old section (its demo + k3d pointers are folded into the new section).
- **`docs/getting-started.md`**: added a top-of-page callout pointing to the demo path so the docs match the new README flow. Surgical, no rewrite.

## Verified

Ran `hack/demo.sh` locally — builds `cmd/lore`, serves with the keyless demo config, POSTs the mocked webhook (HTTP 202), and prints the trigger-policy decisions. Requires only Go + `curl`; no cluster, no keys, no LLM. The README output block is copied from a real run.
