### PR TITLE
feat(curate): add skip_verdicts gate so benign findings don't draft KB PRs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,8 +165,16 @@ curated KB entry, only the notification.
 ### `forge` — the Git host for curation
 `kb_repo` (`owner/name`), `base_branch` (default `main`), `github_api_url` (default
 `https://api.github.com`), `dup_score` (default **5.0**), `min_confidence` (default **0.75**, the
-quality bar below which a finding is chat-only). `github_app` — `app_id`, `installation_id`, and
-`private_key_ref` **or** `private_key_env`.
+quality bar below which a finding is chat-only), `skip_verdicts` (default **empty** — draft every
+verdict). `github_app` — `app_id`, `installation_id`, and `private_key_ref` **or** `private_key_env`.
+
+`skip_verdicts` is a list of investigation verdicts that must **not** draft a KB PR — the finding
+still reaches chat, but no repo artifact is created. Values are validated at startup against the
+verdict enum (`no_action` / `action_suggested` / `action_required` / `inconclusive`); an unknown
+value fails fast. Empty (the default) preserves the original behaviour: every verdict is eligible.
+Recommended production value is `skip_verdicts: ["no_action"]`, which keeps benign / self-healed /
+synthetic findings out of the review queue while still notifying chat (see
+[reviewing-knowledge.md](reviewing-knowledge.md#expected-triage-volume)).
 
 ### `notify` — where findings go
 `slack` (`webhook_url_env` or `bot_token_env`, `channel`, `signing_secret_env`, `approver_ids`),

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -301,6 +301,7 @@ config:
   forge:
     kb_repo: your-org/runlore-kb            # the repo from step 1
     base_branch: main
+    skip_verdicts: [no_action]              # keep benign/self-healed/synthetic findings out of the PR queue (chat still notified)
     # github_api_url: https://ghe.example.com/api/v3   # only for GitHub Enterprise Server
     github_app:
       app_id: 123456                         # from step 2

--- a/docs/reviewing-knowledge.md
+++ b/docs/reviewing-knowledge.md
@@ -27,6 +27,36 @@ Two things happen when an investigation produces a confident, verified finding:
 
 ---
 
+## Expected triage volume
+
+Be honest with yourself about the queue this creates. In a 6-day pilot RunLore
+drafted **29 PRs (~3.5/day)**, and **~72% were closed without merging** — not
+because they were wrong, but because they weren't worth permanent knowledge:
+benign infrastructure churn, synthetic test canaries, and near-duplicates of
+entries the catalog already held. That's a real reviewer-fatigue risk: a queue
+that's mostly noise trains people to stop looking.
+
+Three `forge` knobs cut that volume *before* a PR is ever opened, so the queue you
+see is closer to the ~28% worth keeping:
+
+- **`skip_verdicts: ["no_action"]`** — the biggest lever. A `no_action` verdict is
+  RunLore's own "benign / self-healed / synthetic; nothing to do" classification.
+  Skipping it keeps those findings out of the review queue entirely while still
+  notifying chat, so nobody's blind to them — they just don't become PRs.
+- **`min_confidence`** (default `0.75`) — the quality bar. Findings the model
+  isn't confident about stay chat-only, never a PR.
+- **`dup_score`** (default `5.0`) — the dedup threshold. A finding that closely
+  matches an existing catalog entry is coalesced (a comment on the open PR) or
+  dropped, instead of drafting a near-duplicate.
+
+None of these fabricate or hide knowledge — every skipped finding is still
+delivered to chat. They only decide what's worth a *permanent, reviewed* entry.
+Recommended starting point for a production install: `skip_verdicts: ["no_action"]`,
+then tune `min_confidence` up if benign churn still leaks through. See
+[configuration.md](configuration.md#forge--the-git-host-for-curation).
+
+---
+
 ## 2. Anatomy of a proposed entry
 
 Every PR adds one Markdown file (an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)

--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -39,9 +39,19 @@ func BuildCurator(cfg *config.Config, token ForgeToken, cat *catalog.Catalog, me
 	if minConf == 0 {
 		minConf = 0.75
 	}
+	// Verdicts the operator has configured to stay out of the KB review queue (e.g.
+	// no_action). nil when unset ⇒ every verdict is eligible to draft a PR. Validated
+	// against the verdict enum in Config.Validate, so entries here are already known.
+	var skipVerdicts map[providers.Verdict]bool
+	if len(cfg.Forge.SkipVerdicts) > 0 {
+		skipVerdicts = make(map[providers.Verdict]bool, len(cfg.Forge.SkipVerdicts))
+		for _, v := range cfg.Forge.SkipVerdicts {
+			skipVerdicts[providers.Verdict(v)] = true
+		}
+	}
 	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(token))
-	log.Info("curator enabled", "repo", cfg.Forge.KBRepo, "dup_score", dup, "min_confidence", minConf)
-	cur := &curator.Curator{Forge: client, DupScore: dup, MinConfidence: minConf, Metrics: metrics, Log: log}
+	log.Info("curator enabled", "repo", cfg.Forge.KBRepo, "dup_score", dup, "min_confidence", minConf, "skip_verdicts", cfg.Forge.SkipVerdicts)
+	cur := &curator.Curator{Forge: client, DupScore: dup, MinConfidence: minConf, SkipVerdicts: skipVerdicts, Metrics: metrics, Log: log}
 	if cat != nil { // assign via concrete check to avoid a typed-nil interface
 		cur.Catalog = cat
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/providers"
 )
 
 // Config is the top-level RunLore configuration (loaded from YAML).
@@ -856,6 +858,14 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+	// Curation verdict gate: reject an unknown verdict in forge.skip_verdicts at
+	// startup rather than silently ignoring a typo (which would leave benign findings
+	// drafting PRs into the review queue). Empty is valid — every verdict is eligible.
+	for i, v := range c.Forge.SkipVerdicts {
+		if !providers.ValidVerdict(providers.Verdict(v)) {
+			return fmt.Errorf("forge.skip_verdicts[%d]: unknown verdict %q (want no_action|action_suggested|action_required|inconclusive)", i, v)
+		}
+	}
 	switch c.Actions.Mode {
 	case "", ActionOff, ActionSuggest:
 		return nil // read-only-ish: nothing to execute
@@ -908,6 +918,12 @@ type Forge struct {
 	GitHubAPIURL  string    `yaml:"github_api_url"` // override for GHES/tests (default https://api.github.com)
 	DupScore      float64   `yaml:"dup_score"`      // file-time catalog BM25 dedup threshold (default 5.0)
 	MinConfidence float64   `yaml:"min_confidence"` // file-time quality gate: min overall confidence (default 0.75)
+	// SkipVerdicts lists investigation verdicts that must NOT draft a KB PR — the
+	// finding is still delivered to chat, but no repo artifact is created. Values are
+	// validated against the verdict enum (no_action|action_suggested|action_required|
+	// inconclusive). Empty (default) draws no distinction: every verdict is eligible,
+	// preserving pre-gate behaviour. Recommended production value: ["no_action"].
+	SkipVerdicts []string `yaml:"skip_verdicts"`
 }
 
 // GitHubApp holds GitHub App credentials. The private key mints 1-hour

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -479,3 +479,47 @@ func TestValidateApproveRequiresAuditLog(t *testing.T) {
 		t.Fatalf("approve with token + audit_log_path must validate clean, got: %v", err)
 	}
 }
+
+// TestForgeSkipVerdictsParse verifies forge.skip_verdicts parses into the string
+// list and that an absent key reads as nil (empty ⇒ draft every verdict, the
+// backward-compatible default).
+func TestForgeSkipVerdictsParse(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("forge:\n  kb_repo: o/r\n  skip_verdicts: [no_action, inconclusive]\n"), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := c.Forge.SkipVerdicts; len(got) != 2 || got[0] != "no_action" || got[1] != "inconclusive" {
+		t.Fatalf("forge.skip_verdicts: want [no_action inconclusive], got %v", got)
+	}
+	// Absent ⇒ nil ⇒ every verdict is eligible to draft a PR (pre-gate behaviour).
+	var z Config
+	if err := yaml.Unmarshal([]byte("forge:\n  kb_repo: o/r\n"), &z); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if z.Forge.SkipVerdicts != nil {
+		t.Fatalf("absent skip_verdicts must be nil, got %v", z.Forge.SkipVerdicts)
+	}
+}
+
+// TestValidateSkipVerdicts guards the verdict gate's config surface: known verdict
+// values validate clean, an unknown value is rejected at startup (rather than
+// silently ignoring a typo that would leave benign PRs flowing), and an empty list
+// validates clean.
+func TestValidateSkipVerdicts(t *testing.T) {
+	ok := &Config{}
+	ok.Forge.SkipVerdicts = []string{"no_action", "action_suggested", "action_required", "inconclusive"}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("all known verdicts must validate clean, got: %v", err)
+	}
+
+	empty := &Config{}
+	if err := empty.Validate(); err != nil {
+		t.Fatalf("empty skip_verdicts must validate clean, got: %v", err)
+	}
+
+	bad := &Config{}
+	bad.Forge.SkipVerdicts = []string{"no_action", "definitely_not_a_verdict"}
+	if err := bad.Validate(); err == nil {
+		t.Fatal("an unknown verdict in forge.skip_verdicts must be rejected by Validate")
+	}
+}

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -27,7 +27,11 @@ type Curator struct {
 	Metrics       *telemetry.Metrics     // optional; nil-safe — dedup score unrecorded when unset
 	DupScore      float64                // catalog BM25 dup threshold
 	MinConfidence float64                // quality gate: minimum overall confidence
-	Log           *slog.Logger
+	// SkipVerdicts holds verdicts that must NOT draft a KB PR (e.g. no_action).
+	// A nil/empty map draws no distinction — every verdict is eligible, preserving
+	// pre-gate behaviour.
+	SkipVerdicts map[providers.Verdict]bool
+	Log          *slog.Logger
 }
 
 // Curate applies the three-step gate. It returns the created PR ref, or an empty
@@ -37,6 +41,16 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 	// (chat delivery still happens upstream). Avoids drafting near-duplicate PRs.
 	if inv.Recalled {
 		c.Log.Info("skipping curation of a recalled finding (cache hit, not novel)", "title", inv.Title)
+		return providers.Ref{}, nil
+	}
+
+	// Verdict gate: an operator can configure benign verdicts (e.g. no_action) to
+	// stay out of the KB review queue — chat delivery already informed the human, so
+	// no repo artifact (PR or coalesce comment) is created. Sits alongside the quality
+	// and dedup gates; nil/empty map ⇒ every verdict is eligible (backward-compatible).
+	if c.SkipVerdicts[inv.Verdict] {
+		c.Log.Info("skipping curation: verdict configured to skip a KB PR (chat-only)",
+			"verdict", inv.Verdict, "title", inv.Title)
 		return providers.Ref{}, nil
 	}
 

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -65,6 +65,54 @@ func TestCurateNovelHighQualityOpensPR(t *testing.T) {
 	}
 }
 
+func TestCurateSkippedVerdictDraftsNothing(t *testing.T) {
+	// A no_action finding is otherwise novel + high-quality, but the operator has
+	// configured no_action to stay out of the KB review queue: no PR, no coalesce
+	// comment, no repo artifact at all.
+	inv := goodFinding()
+	inv.Verdict = providers.VerdictNoAction
+	c := newCurator(&fakeForge{}, fakeScored{})
+	c.SkipVerdicts = map[providers.Verdict]bool{providers.VerdictNoAction: true}
+	ref, err := c.Curate(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.URL != "" || c.Forge.(*fakeForge).openedPR != nil {
+		t.Fatalf("a skipped verdict must draft nothing, got ref=%q pr=%+v", ref.URL, c.Forge.(*fakeForge).openedPR)
+	}
+}
+
+func TestCurateNonSkippedVerdictUnaffected(t *testing.T) {
+	// The same skip config, but an action_required finding is NOT in the skip set,
+	// so it drafts a PR as usual.
+	inv := goodFinding()
+	inv.Verdict = providers.VerdictActionRequired
+	c := newCurator(&fakeForge{}, fakeScored{})
+	c.SkipVerdicts = map[providers.Verdict]bool{providers.VerdictNoAction: true}
+	ref, err := c.Curate(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.URL == "" || c.Forge.(*fakeForge).openedPR == nil {
+		t.Fatalf("a non-skipped verdict must draft a PR, got ref=%q", ref.URL)
+	}
+}
+
+func TestCurateNoSkipConfigDraftsEveryVerdict(t *testing.T) {
+	// With no SkipVerdicts configured (nil map), even a no_action verdict drafts a
+	// PR — the backward-compatible default preserves pre-gate behaviour.
+	inv := goodFinding()
+	inv.Verdict = providers.VerdictNoAction
+	c := newCurator(&fakeForge{}, fakeScored{}) // SkipVerdicts left nil
+	ref, err := c.Curate(context.Background(), inv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.URL == "" || c.Forge.(*fakeForge).openedPR == nil {
+		t.Fatalf("empty skip config must draft every verdict, got ref=%q", ref.URL)
+	}
+}
+
 func TestCurateDuplicateCoalescesNoPR(t *testing.T) {
 	// An open PR already covers this incident (matching fingerprint marker in body),
 	// and the catalog does NOT (fakeScored{} returns no hit) — so we fall through to


### PR DESCRIPTION
## Motivation

Every completed investigation carries a `verdict` (`no_action`, `action_suggested`, `action_required`, `inconclusive`), but nothing in the curation path consulted it — a "benign, no action needed" conclusion drafted a KB pull request like any other.

Pilot data made the cost concrete: **29 PRs drafted in 6 days (~3.5/day), ~72% closed without merging** — not because they were wrong, but because they weren't worth permanent knowledge (benign infra churn, synthetic test canaries, near-duplicates of entries the catalog already held). A queue that's mostly noise is a real reviewer-fatigue risk.

## What this does

Adds `forge.skip_verdicts`: a list of verdicts that must **not** draft a KB PR. The finding is still delivered to chat — only the repo artifact is suppressed.

- **Config**: `skip_verdicts` string list next to `dup_score` / `min_confidence`. Validated at startup against the verdict enum (`no_action|action_suggested|action_required|inconclusive`); an unknown value fails fast rather than silently letting benign PRs flow.
- **Default preserves current behaviour**: empty = draft every verdict (backward-compatible).
- **Gate placement**: sits in `Curator.Curate` alongside the existing quality (`min_confidence`) and dedup (`dup_score`) gates — a nil/empty map draws no distinction.
- **Recommended production value**: `skip_verdicts: ["no_action"]`.

## Docs

- `docs/configuration.md` — documents the new key and validation.
- `docs/reviewing-knowledge.md` — new "Expected triage volume" section using the pilot numbers, explaining how `skip_verdicts` + `min_confidence` + `dup_score` reduce the queue (keeps the doc's existing honest tone).
- `docs/getting-started.md` — example forge block now shows the recommended value.

(No Helm chart in this repo, so no chart surfaces to update.)

## Tests (TDD — failing first, then implementation)

- `internal/config`: `TestForgeSkipVerdictsParse`, `TestValidateSkipVerdicts` (including rejection of unknown verdict values, and empty-config-validates-clean).
- `internal/curator`: `TestCurateSkippedVerdictDraftsNothing`, `TestCurateNonSkippedVerdictUnaffected`, `TestCurateNoSkipConfigDraftsEveryVerdict`.

## Quality gate

`go build ./...` · `go vet ./...` · `go test ./...` · `gofmt -l .` (empty) · `golangci-lint run ./...` (0 issues) — all pass.