### PR TITLE
fix(investigate): force a final submit_findings turn at step-budget exhaustion

### DIFF
--- a/internal/eval/forced_conclusion_test.go
+++ b/internal/eval/forced_conclusion_test.go
@@ -1,0 +1,50 @@
+package eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// forcedOnlyModel is a non-converging model (issue #234's claude-sonnet-5 shape): it
+// keeps calling a benign investigation tool on every free turn and emits
+// submit_findings ONLY when the request compels it via ToolChoice. It never winds
+// down on its own, so without the loop's step-budget forced-conclusion turn it would
+// exhaust maxSteps and deliver nothing.
+type forcedOnlyModel struct{}
+
+func (forcedOnlyModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	if req.ToolChoice == "submit_findings" {
+		return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+			{ID: "f", Name: "submit_findings",
+				Args: `{"confidence":0.3,"root_causes":[{"summary":"best-effort: a bad image tag is the likely cause for eval-victim","confidence":0.3}]}`}}}, nil
+	}
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "t", Name: "what_changed", Args: `{}`}}}, nil
+}
+
+// TestRunOneForcedFinalStepDelivers is the replay-eval scenario for the step-budget
+// forced-conclusion path: a non-converging model that only answers when tool choice is
+// forced must still deliver a scored verdict through the harness (forced on the loop's
+// final step) rather than exhausting maxSteps with "no findings (loop did not submit)".
+func TestRunOneForcedFinalStepDelivers(t *testing.T) {
+	c := Case{
+		Name:     "non-converging-forced-conclusion",
+		Prompt:   "eval-victim pods not starting in runlore-eval; image pull errors",
+		Tools:    map[string]string{"what_changed": "image tag set to a nonexistent digest"},
+		Expected: Expected{MustContain: []string{"image"}},
+	}
+	r := &Runner{Model: forcedOnlyModel{}, Log: discardLog()}
+	res := r.runOne(context.Background(), c)
+
+	// The forced final step must deliver a verdict — not the silent-exhaustion sentinel.
+	for _, m := range res.Missing {
+		if m == "no findings (loop did not submit)" {
+			t.Fatalf("forced final step must deliver a verdict, not exhaust silently: %+v", res)
+		}
+	}
+	if !res.Pass {
+		t.Fatalf("the forced degraded finding names the true cause and should score a pass: %+v", res)
+	}
+}

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -143,3 +143,10 @@ const defaultRecallTokensSavedEstimate = 50_000
 // budgetNudge is the single-use message injected once when the token estimate
 // exceeds MaxTokensPerInvestigation, prompting the model to wrap up now.
 const budgetNudge = "⚠️ token budget reached — call submit_findings now with your best current hypotheses and the evidence gathered so far."
+
+// finalStepNudge is injected on the loop's LAST step (only one request remaining)
+// when the model has not already been forced to conclude by the token-budget path.
+// Paired with ToolChoice=submit_findings, it makes a non-converging model record a
+// degraded verdict on its final turn instead of exhausting the step budget in
+// silence (mitigates issue #234's blast radius).
+const finalStepNudge = "This is your FINAL step — you have no tool calls remaining. Record your conclusion NOW by calling submit_findings: give your best current hypothesis with an honest (low, if unverified) confidence, or explicitly mark the incident unresolved. Do not answer in prose."

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -307,6 +307,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	nudged := false            // set when the prose-turn nudge has fired once
 	budgetNudged := false      // set when the token-budget nudge has fired once
 	toolChoice := ""           // forced tool for every remaining request; set (sticky) when the budget nudge fires
+	forcedFinal := false       // set when the final-step nudge forced submit_findings, so a delivery on that turn is labelled degraded
 	truncationNudged := false  // set when the output-truncation nudge has fired once
 	compactionLogged := false  // set when the one-time compaction log has fired
 	used := map[string]int{}   // tool-call counts, logged so investigation breadth is observable
@@ -374,6 +375,17 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				li.deliver(req, res)
 				return nil
 			}
+		}
+		// Step-budget exhaustion: on the LAST step (only this request remains), force a
+		// terminal submit_findings so a non-converging model records a degraded verdict
+		// rather than exhausting maxSteps in silence (no notification, no KB draft —
+		// issue #234's blast radius). Reuses the token-budget path's ToolChoice
+		// mechanism; skipped when the budget path already forced it (don't double-nudge).
+		// forcedFinal marks the delivery on this turn as degraded, not a genuine resolution.
+		if step == maxSteps-1 && toolChoice != submitFindingsName {
+			messages = append(messages, providers.Message{Role: "user", Content: finalStepNudge})
+			toolChoice = submitFindingsName
+			forcedFinal = true
 		}
 		// Raw heuristic for the request about to be sent (messages may have grown since
 		// est was computed — e.g. the budget nudge); paired with resp.Usage below to
@@ -546,7 +558,14 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			inv.Actions = li.reviewActions(inv.Actions)
 			setUsage(&inv)
 			li.recordUsageMetrics(ctx, inv.Usage)
+			// A submission produced only because the final-step nudge forced it is a
+			// degraded verdict, not a genuine resolution — label it distinctly (mirrors
+			// the "budget_exceeded" convention) so the completed-total metric separates
+			// forced conclusions from real ones.
 			result = "resolved"
+			if forcedFinal {
+				result = "max_steps_degraded"
+			}
 			li.deliver(req, inv)
 			return nil
 		}

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -957,6 +957,173 @@ func (m *runawayModel) Complete(_ context.Context, _ providers.CompletionRequest
 	}, nil
 }
 
+// forceOnlyModel returns a benign non-terminal tool call on every free turn and only
+// emits submit_findings when the request FORCES it via ToolChoice — the shape of a
+// non-converging model (issue #234's claude-sonnet-5) that records a verdict solely
+// when compelled. forcedAt records the 1-based request index at which forcing was
+// first observed (0 = never).
+type forceOnlyModel struct {
+	calls    int
+	forcedAt int
+}
+
+func (m *forceOnlyModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	if req.ToolChoice == submitFindingsName {
+		if m.forcedAt == 0 {
+			m.forcedAt = m.calls
+		}
+		return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+			{ID: "f", Name: submitFindingsName,
+				Args: `{"confidence":0.3,"root_causes":[{"summary":"best-effort hypothesis under forced conclusion","confidence":0.3}]}`}}}, nil
+	}
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{
+		{ID: "t", Name: "noop_tool", Args: `{}`}}}, nil
+}
+
+// scrapeMetrics renders the OTel /metrics exposition for assertions on a result label.
+func scrapeMetrics(t *testing.T, h http.Handler) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec.Body.String()
+}
+
+// TestLoopForcesFinalSubmitAtMaxSteps proves the step-budget forced-conclusion path:
+// a non-converging model that only submits when ToolChoice compels it is forced on
+// the loop's FINAL step, its findings are delivered through the normal path, and the
+// completion is labelled result="max_steps_degraded" (distinct from "resolved") so
+// the metric can tell a forced degraded verdict from a genuine resolution.
+func TestLoopForcesFinalSubmitAtMaxSteps(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	m := telemetry.NewMetrics()
+
+	model := &forceOnlyModel{}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   4,
+		Metrics:    m,
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "NonConverging", Fingerprint: "fp-degraded"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	// Forcing must happen exactly on the final step (request index == MaxSteps): the
+	// three prior free turns were unforced, the model kept calling tools.
+	if model.forcedAt != 4 {
+		t.Fatalf("expected forcing on the final step (request 4), got forcedAt=%d (calls=%d)", model.forcedAt, model.calls)
+	}
+	// The forced submission is delivered through the normal path.
+	if got == nil || len(got.RootCauses) != 1 || got.RootCauses[0].Summary != "best-effort hypothesis under forced conclusion" {
+		t.Fatalf("forced final submit_findings not delivered: %+v", got)
+	}
+	if got.Fingerprint != "fp-degraded" {
+		t.Fatalf("forced degraded result must carry the fingerprint for attribution, got %q", got.Fingerprint)
+	}
+	// The completion counter must carry the distinct degraded label, not "resolved".
+	body := scrapeMetrics(t, h)
+	if !strings.Contains(body, `result="max_steps_degraded"`) {
+		t.Fatalf("forced final submit must record result=\"max_steps_degraded\":\n%s", body)
+	}
+	if strings.Contains(body, `result="resolved"`) {
+		t.Fatalf("a forced degraded verdict must NOT be labelled result=\"resolved\":\n%s", body)
+	}
+}
+
+// TestLoopMaxStepsFallbackWhenForceIgnored proves the fallback: a model that ignores
+// even the forced final step (never emits submit_findings) keeps the pre-existing
+// silent max_steps behaviour — nothing is delivered and the completion is labelled
+// result="max_steps".
+func TestLoopMaxStepsFallbackWhenForceIgnored(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	m := telemetry.NewMetrics()
+
+	model := &runawayModel{} // always returns noop_tool, ignoring the forced ToolChoice
+	var delivered bool
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   3,
+		Metrics:    m,
+		OnComplete: func(providers.Investigation) { delivered = true },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "IgnoresForce"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if delivered {
+		t.Fatal("a model that ignores the forced final step must deliver nothing (silent max_steps fallback)")
+	}
+	// The loop ran the full step budget, including the forced final step, then fell back.
+	if model.calls != 3 {
+		t.Fatalf("expected exactly 3 model calls (= MaxSteps), got %d", model.calls)
+	}
+	body := scrapeMetrics(t, h)
+	if !strings.Contains(body, `result="max_steps"`) {
+		t.Fatalf("ignored-force exhaustion must record result=\"max_steps\":\n%s", body)
+	}
+	if strings.Contains(body, `result="max_steps_degraded"`) {
+		t.Fatalf("no degraded verdict was produced, so result=\"max_steps_degraded\" must be absent:\n%s", body)
+	}
+}
+
+// TestLoopEarlyConclusionNotForced proves the normal early-conclusion path is
+// unchanged by the final-step forcing: a model that submits on step 0 is never forced
+// (ToolChoice stays empty) and the completion keeps result="resolved".
+func TestLoopEarlyConclusionNotForced(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+	m := telemetry.NewMetrics()
+
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName,
+			Args: `{"confidence":0.9,"root_causes":[{"summary":"chart bump broke db","confidence":0.9}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5, // plenty of headroom: step 0 concludes, final-step forcing never engages
+		Metrics:    m,
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "EarlyConclusion"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil || len(got.RootCauses) != 1 {
+		t.Fatalf("early conclusion not delivered: %+v", got)
+	}
+	if len(model.reqs) != 1 {
+		t.Fatalf("expected exactly 1 model call (early conclusion), got %d", len(model.reqs))
+	}
+	if model.reqs[0].ToolChoice != "" {
+		t.Fatalf("an early-concluding step must not be forced, got ToolChoice=%q", model.reqs[0].ToolChoice)
+	}
+	body := scrapeMetrics(t, h)
+	if !strings.Contains(body, `result="resolved"`) {
+		t.Fatalf("a genuine early conclusion must record result=\"resolved\":\n%s", body)
+	}
+	if strings.Contains(body, `result="max_steps_degraded"`) {
+		t.Fatalf("a genuine resolution must NOT be labelled degraded:\n%s", body)
+	}
+}
+
 // TestLoopHardKillOnBudgetExhaustion verifies that, after the token-budget nudge
 // has fired, the loop hard-kills on the next over-budget check and delivers an
 // unresolved result rather than running to maxSteps.


### PR DESCRIPTION
## Problem

When the ReAct investigation loop (`internal/investigate/loop.go`) exhausts `maxSteps` without the model ever calling `submit_findings`, it logged a warning, set `result = "max_steps"`, and returned **without** calling `deliver()`. The investigation silently produced **nothing** — no notification, no KB draft.

Issue #234 documents that `claude-sonnet-5` reliably hits this: it burns all 20 steps and never converges on `submit_findings`, so every such incident vanished silently.

## Change

On the loop's **final step** (only one request remaining), the loop now appends a "this is your final step" user message and forces `ToolChoice = submit_findings` for that request — reusing the existing token-budget path's forcing mechanism.

- If the forced turn yields a parseable `submit_findings`, it is delivered through the normal path, but labelled **`result = "max_steps_degraded"`** (mirroring the existing `"budget_exceeded"` convention) so `runlore_investigations_completed_total` distinguishes forced degraded verdicts from genuine `"resolved"` ones.
- If the model **still** won't submit on the forced step, the pre-existing silent `max_steps` behaviour remains as the fallback (nothing delivered).
- The forcing is **skipped when the budget path already forced** `submit_findings`, so the model is never double-nudged; the logic stays a single guarded branch.

## Scope

This **mitigates #234's blast radius** — any non-converging model now produces a degraded verdict instead of silence — but it does **not** fix #234's root cause (why the model fails to converge), so it does not close that issue.

## Tests

New tests in `internal/investigate/loop_test.go`:
- `TestLoopForcesFinalSubmitAtMaxSteps` — a model that only submits when `ToolChoice` compels it is forced on the final step; its findings are delivered and the completion counter carries `result="max_steps_degraded"` (not `"resolved"`).
- `TestLoopMaxStepsFallbackWhenForceIgnored` — a model that ignores even the forced step delivers nothing and records `result="max_steps"` (fallback preserved).
- `TestLoopEarlyConclusionNotForced` — a model that concludes on step 0 is never forced (`ToolChoice` empty) and keeps `result="resolved"`.

New replay-eval scenario in `internal/eval/forced_conclusion_test.go`:
- `TestRunOneForcedFinalStepDelivers` — drives a non-converging model that only answers when tool choice is forced through the eval harness (`Runner.runOne`) and asserts it delivers a scored, passing verdict instead of exhausting the loop with "no findings (loop did not submit)".

## Quality gate

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` (clean), and `golangci-lint run ./...` (**0 issues**) all pass.