### PR TITLE
fix(e2e): survive Helm 4 SSA + enable the nightly k3d schedule

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -11,14 +11,12 @@
 # workflow only installs the CLIs it needs and invokes it. Exit code: 0 when all
 # checks pass, 1 when any check fails (RESULTS prints "PASS=N FAIL=M").
 #
-# Trigger: workflow_dispatch ONLY for now — a scheduled run can't be verified before
-# it first goes green, and a spurious red nightly is noise. Enable the schedule below
-# after a green manual run.
+# Nightly + on-demand. Schedule enabled 2026-07-06 after the first green manual
+# run (28817745501).
 on:
   workflow_dispatch:
-  # Enable after a green manual run.
-  # schedule:
-  #   - cron: "0 5 * * *"   # nightly 05:00 UTC (before the 06:00 eval run)
+  schedule:
+    - cron: "0 5 * * *"   # nightly 05:00 UTC (before the 06:00 eval run)
 
 # Least privilege: the script only reads the checked-out repo and talks to a local
 # k3d cluster + host-side mock backends. It pushes nothing and needs no token.

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -387,7 +387,11 @@ if [[ "$SUSP2" != "true" ]]; then green "PASS: kill-switch blocked auto-executio
 else red "FAIL: auto executed while paused (spec.suspend=$SUSP2)"; FAIL=$((FAIL+1)); fi
 
 step "10/11 leader election + failover (scale to 2)"
-kubectl -n "$NS" scale deploy/runlore --replicas=2 >/dev/null
+# Scale via helm, not `kubectl scale`: Helm 4 applies server-side, and kubectl
+# scale hands .spec.replicas to the "kubectl" field manager, which makes the
+# next `helm upgrade` fail with a field-ownership conflict on that field.
+helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
+  --set replicaCount=2 >/dev/null
 TOTAL=0; READY=0
 for _ in $(seq 1 30); do
   TOTAL=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore --no-headers 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
## What

- **Fix the e2e suite under Helm 4**: the runner's setup action now pulls Helm v4.2.2, which applies releases server-side. The failover phase's `kubectl scale deploy/runlore --replicas=2` handed `.spec.replicas` to the `kubectl` field manager (scale subresource), so the phase-11 `helm upgrade --reuse-values` failed with a field-ownership conflict:

  ```
  Error: UPGRADE FAILED: conflict occurred while applying object runlore/runlore
  apps/v1, Kind=Deployment: Apply failed with 1 conflict: conflict with "kubectl"
  with subresource "scale" using apps/v1: .spec.replicas
  ```

  Scale to 2 via `helm upgrade --reuse-values --set replicaCount=2` instead — the same pattern every other replica change in the script already uses, so Helm keeps ownership of the field throughout. (First manual run 28817358426 failed exactly here, after all phase 1–10 checks passed.)

- **Enable the nightly schedule** (05:00 UTC, before the 06:00 eval run). The workflow's stated policy was to enable it only after a green manual run: run [28817745501](https://github.com/Smana/runlore/actions/runs/28817745501) is that green run, on this branch with the fix applied — all ~30 assertions passed.

## Why now

Post-announcement regressions in cluster integration (leader election, auto-execution rungs, alert-storm coalescing, curator PRs) were only covered by a manual-only workflow. This was P0-4 of the launch-readiness punch list.