### PR TITLE
feat(cli): lore kb search/show — human search over the knowledge catalog

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -24,8 +24,8 @@ Usage:
   lore investigate --alert <name> [--namespace <ns>] [--message <text>]   investigate on-demand, print findings
   lore serve [--config <path>] [--addr <addr>]        run the in-cluster agent (react to incidents)
   lore catalog sync [--config <path>]                 clone/pull + index the knowledge catalog
-  lore kb search <query> [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]   search the knowledge base
-  lore kb show <entry> [--dir <catalog>]              print one KB entry (frontmatter card + body)
+  lore kb search <query> [--config <path>] [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]   search the knowledge base
+  lore kb show <entry> [--config <path>] [--dir <catalog>]   print one KB entry (frontmatter card + body)
   lore eval [--config <path>] [--cases <dir>]         replay recorded cases, score RCA identification
   lore eval --live [--scenarios <dir>] [--n 3]        live-fire on the cluster: grade coverage + RCA
   lore eval --compare <spec.yaml> [--n 3]             benchmark several models over the replay suite

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -24,6 +24,8 @@ Usage:
   lore investigate --alert <name> [--namespace <ns>] [--message <text>]   investigate on-demand, print findings
   lore serve [--config <path>] [--addr <addr>]        run the in-cluster agent (react to incidents)
   lore catalog sync [--config <path>]                 clone/pull + index the knowledge catalog
+  lore kb search <query> [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]   search the knowledge base
+  lore kb show <entry> [--dir <catalog>]              print one KB entry (frontmatter card + body)
   lore eval [--config <path>] [--cases <dir>]         replay recorded cases, score RCA identification
   lore eval --live [--scenarios <dir>] [--n 3]        live-fire on the cluster: grade coverage + RCA
   lore eval --compare <spec.yaml> [--n 3]             benchmark several models over the replay suite
@@ -61,6 +63,11 @@ func main() {
 	case "catalog":
 		if err := app.RunCatalog(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, "catalog:", err)
+			os.Exit(1)
+		}
+	case "kb":
+		if err := app.RunKB(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "kb:", err)
 			os.Exit(1)
 		}
 	case "curate":

--- a/docs/reviewing-knowledge.md
+++ b/docs/reviewing-knowledge.md
@@ -129,6 +129,28 @@ Your job is the **judgment** the machine can't make:
 
 ---
 
+## Searching the KB from the CLI
+
+The same BM25 index the agent uses for recall is available to humans:
+
+    # against a local checkout of your KB repo
+    lore kb search "crashloop web configmap" --dir ./my-kb
+
+    # or via config (catalog.dir), after `lore catalog sync`
+    lore kb search "oom worker"
+
+    # one entry in full — path, filename, or a query with a unique hit
+    lore kb show crashloop-web
+
+`--json` emits the hits for scripting. `--ledger /var/lib/runlore/outcomes.jsonl`
+adds a RESOLVE column (how often each entry's recalls preceded the incident
+actually resolving) when you have a copy of the outcome ledger.
+
+This is also the 30-second evaluation path: clone any OKF knowledge repo and
+point `--dir` at it — no cluster, no model, no config.
+
+---
+
 ## 4. Add context / refine it
 
 The PR is just Markdown — **edit it like any other PR**:

--- a/docs/superpowers/plans/2026-07-07-kb-related-knowledge-pr.md
+++ b/docs/superpowers/plans/2026-07-07-kb-related-knowledge-pr.md
@@ -1,0 +1,430 @@
+# "Related knowledge" in KB PRs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every drafted KB PR carries a `## Related knowledge` section in its **body** (never the entry file): the nearest catalog entries with score + resource + web link, plus a trigger-recurrence line — so the reviewer can judge "duplicate? already documented?" without leaving the PR. Spec: `docs/superpowers/specs/2026-07-07-kb-human-surfaces-design.md`, Feature 3.
+
+**Architecture:** The curator already runs a BM25 dedup search at draft time and discards the hits after the duplicate check; `Novelty` gains a `Hits(ctx, inv, k)` method so one k=5 search serves both the dup decision (top hit) and the reviewer context (all hits above a noise floor). `providers.KBEntry` gains `Related []RelatedEntry` + recurrence-fact fields (stamped by `draftKBEntry` from the Investigation — recurrence facts are read *before* curation in `onInvestigationComplete`, so they're already present). The GitHub forge's `prBody` becomes a method and renders the section with blob URLs derived from the client's API base.
+
+**Tech Stack:** Go 1.26, stdlib only. Tests: `go test -race ./...`, table-driven with the existing `fakeForge`/`fakeScored` fakes. Lint: `golangci-lint run ./...`, `gofmt`.
+
+## Global Constraints
+
+- Go 1.26 (go.mod); CI runs `go build ./...`, `go vet ./...`, `test -z "$(gofmt -l .)"`, `go test -race ./...`.
+- Never add AI attribution to commits or PRs. Conventional-commit prefixes (`feat:`, `fix:`, `test:`, `docs:`).
+- The section goes in the **PR body only** — `renderEntry` (the committed OKF file) must not change, so `lore validate-kb` and the catalog loader are unaffected.
+- The hidden `FingerprintMarker` must remain parseable from the PR body (`ParseFingerprintMarker`) — keep it the LAST element of the body.
+- A related-search failure at draft time omits the section; the PR still opens (best-effort).
+- Keep the comment density/style of surrounding code (this repo comments the *why* heavily).
+- Work on a dedicated branch (e.g. `feat/kb-related-knowledge`), one PR for this whole plan.
+
+---
+
+### Task 1: `providers.RelatedEntry` + KBEntry fields, `Novelty.Hits`, curator population
+
+**Files:**
+- Modify: `internal/providers/providers.go` (KBEntry ~line 471; RelatedEntry type below it)
+- Modify: `internal/curator/fingerprint.go` (`Novelty` ~line 109: add `Hits`, reimplement `TopHit` on top)
+- Modify: `internal/curator/curator.go` (`Curate` dedup block ~lines 76–87 and the OpenPR call ~line 102)
+- Modify: `internal/curator/draft.go` (`draftKBEntry` return literal ~line 80)
+- Test: `internal/curator/curator_test.go`, `internal/curator/draft_test.go`
+
+**Interfaces:**
+- Consumes: `catalog.ScoredSearcher.SearchScored(query, k)`; existing `Fingerprint(inv)` query builder; `Investigation.Occurrences` / `PrevCuratedURL` (stamped before curation by `onInvestigationComplete`).
+- Produces: `providers.RelatedEntry{Path, Title, Resource string; Score float64}`; `KBEntry.Related []RelatedEntry`, `KBEntry.Occurrences int`, `KBEntry.PrevCuratedURL string`; `Novelty.Hits(ctx, inv, k) ([]catalog.ScoredEntry, error)`. Task 2 renders these in the PR body.
+
+- [ ] **Step 1: Write the failing tests.** In `internal/curator/curator_test.go` (reuse `fakeForge`, `newCurator`, `goodFinding`; the file already has a `fakeScored` — add a variant that returns several hits if it can't):
+
+```go
+// multiScored returns a fixed multi-hit result for any query — the shape the
+// related-knowledge section consumes.
+type multiScored struct{ hits []catalog.ScoredEntry }
+
+func (m multiScored) SearchScored(string, int) ([]catalog.ScoredEntry, error) { return m.hits, nil }
+
+func TestCurateAttachesRelatedKnowledge(t *testing.T) {
+	f := &fakeForge{}
+	cat := multiScored{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Path: "incidents/a.md", Title: "A", Resource: "apps/web"}, Score: 2.5},
+		{Entry: catalog.Entry{Path: "incidents/b.md", Title: "B"}, Score: 0.9},
+		{Entry: catalog.Entry{Path: "incidents/noise.md", Title: "noise"}, Score: 0.05}, // below the floor
+	}}
+	inv := goodFinding()
+	inv.Occurrences = 3
+	inv.PrevCuratedURL = "https://kb/pr/12"
+	if _, err := newCurator(f, cat).Curate(context.Background(), inv); err != nil {
+		t.Fatalf("curate: %v", err)
+	}
+	if f.openedPR == nil {
+		t.Fatal("no PR opened")
+	}
+	e := *f.openedPR
+	if len(e.Related) != 2 {
+		t.Fatalf("Related = %+v, want the 2 hits above the noise floor", e.Related)
+	}
+	if e.Related[0].Path != "incidents/a.md" || e.Related[0].Score != 2.5 || e.Related[0].Resource != "apps/web" {
+		t.Errorf("Related[0] = %+v", e.Related[0])
+	}
+	if e.Occurrences != 3 || e.PrevCuratedURL != "https://kb/pr/12" {
+		t.Errorf("recurrence facts not stamped: occ=%d prev=%q", e.Occurrences, e.PrevCuratedURL)
+	}
+}
+
+// The dup decision is unchanged: a top hit at/above DupScore still skips the PR
+// (no Related work happens for a duplicate).
+func TestCurateDupStillSkipsWithMultiHits(t *testing.T) {
+	f := &fakeForge{}
+	cat := multiScored{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Path: "incidents/dup.md", Title: "dup"}, Score: 9.0}, // ≥ DupScore 5.0
+	}}
+	ref, err := newCurator(f, cat).Curate(context.Background(), goodFinding())
+	if err != nil {
+		t.Fatalf("curate: %v", err)
+	}
+	if ref.URL != "" || f.openedPR != nil {
+		t.Fatal("duplicate finding must not open a PR")
+	}
+}
+```
+
+In `internal/curator/draft_test.go`:
+
+```go
+func TestDraftKBEntryCarriesRecurrenceFacts(t *testing.T) {
+	inv := goodFinding()
+	inv.Occurrences = 2
+	inv.PrevCuratedURL = "https://kb/pr/7"
+	e := draftKBEntry(inv)
+	if e.Occurrences != 2 || e.PrevCuratedURL != "https://kb/pr/7" {
+		t.Errorf("KBEntry recurrence facts = occ %d prev %q", e.Occurrences, e.PrevCuratedURL)
+	}
+	// The committed FILE must not gain reviewer-context sections.
+	if strings.Contains(e.Body, "Related knowledge") {
+		t.Error("entry body must never contain the PR-only Related knowledge section")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/curator/ -run 'TestCurateAttaches|TestCurateDupStill|TestDraftKBEntryCarries' -v`
+Expected: compile FAIL — `Related`, `Occurrences` undefined on KBEntry.
+
+- [ ] **Step 3: Implement.**
+
+In `internal/providers/providers.go`, extend `KBEntry` (after `Provenance`):
+
+```go
+	// Reviewer context, rendered in the PR BODY only — never in the committed
+	// entry file (renderEntry ignores these), so the catalog and validator are
+	// untouched. Related is the draft-time BM25 neighborhood; the recurrence
+	// facts mirror Investigation.Occurrences/PrevCuratedURL.
+	Related        []RelatedEntry
+	Occurrences    int
+	PrevCuratedURL string
+```
+
+and add below the struct:
+
+```go
+// RelatedEntry is a nearby catalog entry surfaced to the KB PR reviewer so
+// "is this a duplicate / what do we already know?" is answerable in the PR.
+type RelatedEntry struct {
+	Path     string  // bundle-relative entry path (the forge renders the web link)
+	Title    string
+	Resource string  // affected resource, when the entry names one
+	Score    float64 // BM25 score at draft time (corpus-relative — a hint, not a ranking guarantee)
+}
+```
+
+In `internal/curator/fingerprint.go`, add `Hits` and express `TopHit` through it:
+
+```go
+// Hits returns up to k catalog entries scored against the finding's
+// fingerprint — hits[0] drives the duplicate decision, the full slice feeds
+// the PR's related-knowledge section (one search, two consumers).
+func (n Novelty) Hits(ctx context.Context, inv providers.Investigation, k int) ([]catalog.ScoredEntry, error) { //nolint:revive // ctx kept for future remote-index symmetry
+	if n.Catalog == nil {
+		return nil, nil
+	}
+	return n.Catalog.SearchScored(Fingerprint(inv), k)
+}
+```
+
+and reimplement `TopHit` (keeping its signature and doc comment) as:
+
+```go
+	hits, err := n.Hits(ctx, inv, 1)
+	if err != nil {
+		return catalog.ScoredEntry{}, false, err
+	}
+	if len(hits) == 0 {
+		return catalog.ScoredEntry{}, false, nil
+	}
+	return hits[0], true, nil
+```
+
+In `internal/curator/curator.go`, add the constants near the top of the file:
+
+```go
+// Related-knowledge bounds: how many BM25 neighbors a drafted PR shows the
+// reviewer, and the noise floor below which a "neighbor" is lexical debris.
+// The floor is deliberately low — BM25 absolute scores are corpus-dependent
+// (see the recall margin gate), so the top-k cap does the real limiting and
+// the floor only drops near-zero matches on genuinely novel incidents.
+const (
+	relatedK     = 5
+	relatedFloor = 0.2
+)
+```
+
+replace the `nov := ...; if top, ok, err := nov.TopHit(...)` block (~lines 76–87) with:
+
+```go
+	nov := Novelty{Catalog: c.Catalog, DupScore: c.DupScore}
+	hits, herr := nov.Hits(ctx, inv, relatedK)
+	if herr != nil {
+		c.Log.Warn("dedup: catalog search failed", "err", herr)
+	} else if len(hits) > 0 {
+		if c.Metrics != nil {
+			c.Metrics.CurationDedupScore.Record(ctx, hits[0].Score)
+		}
+		if hits[0].Score >= c.DupScore {
+			c.Log.Info("finding duplicates a catalog entry; not filing", "entry", hits[0].Entry.Title, "score", hits[0].Score)
+			return providers.Ref{}, nil
+		}
+	}
+```
+
+and replace the OpenPR call (~line 102):
+
+```go
+	entry := draftKBEntry(inv)
+	// Reviewer context: the finding is novel, so its BM25 neighborhood is
+	// precisely what the reviewer needs to double-check that call.
+	entry.Related = relatedEntries(hits)
+	ref, err := c.Forge.OpenPR(ctx, entry)
+```
+
+and add the helper:
+
+```go
+// relatedEntries maps the draft-time search hits to the PR's reviewer-context
+// list, dropping noise-floor matches. Order (best first) is preserved.
+func relatedEntries(hits []catalog.ScoredEntry) []providers.RelatedEntry {
+	var out []providers.RelatedEntry
+	for _, h := range hits {
+		if h.Score < relatedFloor {
+			continue
+		}
+		out = append(out, providers.RelatedEntry{
+			Path: h.Entry.Path, Title: h.Entry.Title, Resource: h.Entry.Resource, Score: h.Score,
+		})
+	}
+	return out
+}
+```
+
+In `internal/curator/draft.go`, add to the `providers.KBEntry{...}` literal in `draftKBEntry`:
+
+```go
+		// Recurrence facts for the PR body's related-knowledge section — stamped
+		// on the Investigation BEFORE curation runs (see onInvestigationComplete).
+		Occurrences:    inv.Occurrences,
+		PrevCuratedURL: inv.PrevCuratedURL,
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/curator/ -race -v`
+Expected: PASS — new tests plus every pre-existing curator test (the TopHit rewrite must not change dedup behavior).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/providers/providers.go internal/curator/
+git commit -m "feat(curator): attach the BM25 neighborhood + recurrence facts to drafted KB entries"
+```
+
+---
+
+### Task 2: render `## Related knowledge` in the GitHub PR body
+
+**Files:**
+- Modify: `internal/forge/github/github.go` (`prBody` ~line 367 → method; `OpenPR` call site ~line 146; new `relatedSection` + `blobURL` helpers)
+- Test: `internal/forge/github/github_test.go`
+
+**Interfaces:**
+- Consumes: `KBEntry.Related` / `.Occurrences` / `.PrevCuratedURL` (Task 1); `Client.baseURL/owner/repo/baseBranch`.
+- Produces: PR bodies containing `## Related knowledge` with `[Title](https://<host>/<owner>/<repo>/blob/<branch>/<path>)` items and a `Trigger seen ×N` line; the fingerprint marker stays last and parseable.
+
+- [ ] **Step 1: Write the failing test** — add to `github_test.go` (the package already tests unexported helpers directly):
+
+```go
+func TestPRBodyRelatedKnowledge(t *testing.T) {
+	c := New("", "acme", "kb", "main", nil) // public GitHub host
+	e := providers.KBEntry{
+		Title: "T", Description: "d", Fingerprint: "abc123",
+		Related: []providers.RelatedEntry{
+			{Path: "incidents/a.md", Title: "A", Resource: "apps/web", Score: 2.5},
+			{Path: "incidents/b.md", Title: "B", Score: 0.9},
+		},
+		Occurrences:    3,
+		PrevCuratedURL: "https://kb/pr/12",
+	}
+	body := c.prBody(e)
+	for _, want := range []string{
+		"## Related knowledge",
+		"[A](https://github.com/acme/kb/blob/main/incidents/a.md)",
+		"score 2.50",
+		"resource apps/web",
+		"[B](https://github.com/acme/kb/blob/main/incidents/b.md)",
+		"Trigger seen ×3",
+		"previous entry: https://kb/pr/12",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("prBody missing %q\n---\n%s", want, body)
+		}
+	}
+	// The dedup marker survives, still parseable, still last.
+	if got := providers.ParseFingerprintMarker(body); got != "abc123" {
+		t.Errorf("ParseFingerprintMarker = %q, want abc123", got)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(body), providers.FingerprintMarker("abc123")) {
+		t.Error("fingerprint marker must remain the last body element")
+	}
+}
+
+func TestPRBodyNoRelatedSectionWhenEmpty(t *testing.T) {
+	c := New("", "acme", "kb", "main", nil)
+	body := c.prBody(providers.KBEntry{Title: "T", Fingerprint: "abc123"})
+	if strings.Contains(body, "Related knowledge") {
+		t.Errorf("no-hit, first-sighting PR must not carry an empty section:\n%s", body)
+	}
+}
+
+func TestBlobURLEnterpriseHost(t *testing.T) {
+	c := New("https://ghe.example.com/api/v3", "acme", "kb", "main", nil)
+	want := "https://ghe.example.com/acme/kb/blob/main/incidents/a.md"
+	if got := c.blobURL("incidents/a.md"); got != want {
+		t.Errorf("blobURL = %q, want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/forge/github/ -run 'TestPRBody|TestBlobURL' -v`
+Expected: compile FAIL — `c.prBody` / `c.blobURL` undefined (prBody is currently a package function).
+
+- [ ] **Step 3: Implement.** Turn `prBody` into a method and append the section **before** the marker (the marker stays last):
+
+```go
+func (c *Client) prBody(e providers.KBEntry) string {
+	desc := e.Description
+	if desc == "" {
+		desc = e.Title
+	}
+	body := fmt.Sprintf("Drafted by RunLore — %s\n\nReview the decision card + OKF entry in the changed file.", desc)
+	if s := c.relatedSection(e); s != "" {
+		body += "\n\n" + s
+	}
+	if m := providers.FingerprintMarker(e.Fingerprint); m != "" {
+		body += "\n\n" + m
+	}
+	return body
+}
+
+// relatedSection renders the reviewer context: the draft-time BM25 neighborhood
+// (linked, scored) and the trigger's recurrence line. Empty when there is
+// nothing to say — a genuinely novel first sighting gets no noise section.
+func (c *Client) relatedSection(e providers.KBEntry) string {
+	if len(e.Related) == 0 && e.Occurrences <= 1 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("## Related knowledge\n")
+	for _, r := range e.Related {
+		fmt.Fprintf(&b, "\n- [%s](%s) — score %.2f", r.Title, c.blobURL(r.Path), r.Score)
+		if r.Resource != "" {
+			fmt.Fprintf(&b, " · resource %s", r.Resource)
+		}
+	}
+	if e.Occurrences > 1 {
+		fmt.Fprintf(&b, "\n\nTrigger seen ×%d", e.Occurrences)
+		if e.PrevCuratedURL != "" {
+			fmt.Fprintf(&b, " · previous entry: %s", e.PrevCuratedURL)
+		}
+	}
+	return b.String()
+}
+
+// blobURL is the web URL of a catalog file on the base branch. The web host is
+// the API base with its API suffix stripped: api.github.com → github.com;
+// GHES https://ghe.example.com/api/v3 → https://ghe.example.com. Relative
+// links are NOT an option here — GitHub does not resolve them in PR bodies.
+func (c *Client) blobURL(path string) string {
+	host := c.baseURL
+	if host == DefaultBaseURL {
+		host = "https://github.com"
+	} else {
+		host = strings.TrimSuffix(host, "/api/v3")
+	}
+	branch := c.baseBranch
+	if branch == "" {
+		branch = "main"
+	}
+	return fmt.Sprintf("%s/%s/%s/blob/%s/%s", host, c.owner, c.repo, branch, path)
+}
+```
+
+Update the one call site in `OpenPR` (~line 146): `"body": prBody(e)` → `"body": c.prBody(e)`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/forge/github/ -race -v`
+Expected: PASS — new tests plus every pre-existing forge test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/forge/github/
+git commit -m "feat(forge): render a Related knowledge section in drafted KB PR bodies"
+```
+
+---
+
+### Task 3: docs + full verification
+
+**Files:**
+- Modify: `docs/reviewing-knowledge.md` (reviewer-facing description)
+- Modify: `docs/learning-loop.md` (§5 Curate, one sentence)
+
+- [ ] **Step 1: Docs.** In `docs/reviewing-knowledge.md`, where the PR review flow is described, add:
+
+```markdown
+### Related knowledge in the PR
+
+Each drafted PR ends with a **Related knowledge** section: the closest existing
+entries at draft time (linked, with their BM25 score and affected resource) and
+— when the trigger has fired before — a `Trigger seen ×N` line pointing at the
+previous entry. Use it to answer the two review questions cheaply: *is this a
+duplicate of something merged?* and *does this incident keep coming back?*
+Scores are corpus-relative hints, not a ranking guarantee.
+```
+
+In `docs/learning-loop.md` §5 (Curate), after the DRAFT box description, add one sentence:
+
+> The drafted PR body also carries a *Related knowledge* section — the dedup search's k=5 neighborhood plus the trigger's recurrence line — so the human reviewing the entry sees what the catalog already holds.
+
+- [ ] **Step 2: Full verification**
+
+Run: `go build ./... && go vet ./... && test -z "$(gofmt -l .)" && go test -race ./... && golangci-lint run ./...`
+Expected: all green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reviewing-knowledge.md docs/learning-loop.md
+git commit -m "docs(kb): document the Related knowledge PR section"
+```

--- a/docs/superpowers/plans/2026-07-07-kb-seen-before-notification.md
+++ b/docs/superpowers/plans/2026-07-07-kb-seen-before-notification.md
@@ -1,0 +1,755 @@
+# "Seen before" Notification Block Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a known incident recurs, the notification quotes the merged KB entry's cause and human-reviewed resolution inline (plus its recall track record), so the on-call reads the previous answer with zero clicks. Spec: `docs/superpowers/specs/2026-07-07-kb-human-surfaces-design.md`, Feature 1.
+
+**Architecture:** At completion (`onInvestigationComplete`), a recurring fresh investigation looks up the merged catalog entry by its `DupFingerprint` (already stored in entry frontmatter), extracts `## Cause` / `## Resolution` excerpts via a new `catalog.Entry.Section()`, joins the entry's recall/resolve aggregate from the outcome ledger, and stamps a new `providers.PriorKnowledge` onto the `Investigation`. `notify.Format` (Matrix/webhook/fallback) and the Slack summary blocks render it as a "📚 Seen before" block placed before the current root cause. Everything is best-effort: any miss degrades to today's counter+link.
+
+**Tech Stack:** Go 1.26, stdlib only. Tests: `go test -race ./...`, table-driven. Lint: `golangci-lint run ./...`, `gofmt`.
+
+## Global Constraints
+
+- Go 1.26 (go.mod); CI runs `go build ./...`, `go vet ./...`, `test -z "$(gofmt -l .)"`, `go test -race ./...`.
+- Never add AI attribution to commits or PRs. Conventional-commit prefixes (`feat:`, `fix:`, `test:`, `docs:`).
+- **mrkdwn-escape invariant** (`internal/notify/slack.go` + `TestFormatScaffoldingHasNoMrkdwnMeta`): any scaffolding (literals) added to `notify.Format` must contain NONE of `&`, `<`, `>`. Slack `<!date^…>` tokens are Slack-blocks-only, never in `Format`.
+- All untrusted strings (model prose, KB entry bodies, URLs) interpolated into Slack mrkdwn blocks go through `escapeMrkdwn`. Slack section text: `truncate(s, 2900)`.
+- Prior-knowledge stamping and rendering are best-effort: a lookup/parse failure must never fail or delay delivery.
+- Keep the comment density/style of surrounding code (this repo comments the *why* heavily).
+- Work on a dedicated branch (e.g. `feat/kb-seen-before`), one PR for this whole plan.
+
+---
+
+### Task 1: `catalog.Entry.Section` — quotable OKF section excerpts
+
+**Files:**
+- Create: `internal/catalog/section.go`
+- Test: `internal/catalog/section_test.go`
+
+**Interfaces:**
+- Produces: `func (e Entry) Section(name string) string` — first paragraph of the `## <name>` markdown section, flattened to one line, `**` stripped, truncated to 300 runes with `…`. `""` when absent/empty. Tasks 2 depends on this exact behavior.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package catalog
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// Section quotes an entry's Cause/Resolution into chat + PR bodies: first
+// paragraph only, one line, bold markers stripped, hard length cap.
+func TestEntrySection(t *testing.T) {
+	body := `## Decision
+
+- **why keep:** x
+
+## Cause
+
+1. **ConfigMap truncated after kustomize bump** (85%) — change: flux/apps
+2. **DNS flake** (10%)
+
+## Resolution
+
+- revert the patch and pin kustomize 5.3.2 (reversible=true)
+
+## Citations
+
+[1] flux/apps
+`
+	e := Entry{Body: body}
+	cases := []struct{ name, want string }{
+		{"Cause", "1. ConfigMap truncated after kustomize bump (85%) — change: flux/apps 2. DNS flake (10%)"},
+		{"Resolution", "- revert the patch and pin kustomize 5.3.2 (reversible=true)"},
+		{"resolution", "- revert the patch and pin kustomize 5.3.2 (reversible=true)"}, // case-insensitive
+		{"Symptom", ""}, // absent section
+	}
+	for _, c := range cases {
+		if got := e.Section(c.name); got != c.want {
+			t.Errorf("Section(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// The first BLANK line after content ends the excerpt: a second paragraph in
+// the same section is not quoted.
+func TestEntrySectionFirstParagraphOnly(t *testing.T) {
+	e := Entry{Body: "## Cause\n\nfirst para line one\nline two\n\nsecond para\n\n## Next\n\nx\n"}
+	if got := e.Section("Cause"); got != "first para line one line two" {
+		t.Errorf("Section(Cause) = %q, want first paragraph only", got)
+	}
+}
+
+func TestEntrySectionTruncates(t *testing.T) {
+	e := Entry{Body: "## Cause\n\n" + strings.Repeat("word ", 200) + "\n"}
+	got := e.Section("Cause")
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("long section not truncated: %q", got)
+	}
+	if n := utf8.RuneCountInString(got); n > 301 {
+		t.Fatalf("excerpt is %d runes, want ≤ 301 (300 + ellipsis)", n)
+	}
+}
+
+func TestEntrySectionMalformed(t *testing.T) {
+	cases := []struct{ label, body string }{
+		{"empty body", ""},
+		{"heading only", "## Cause\n"},
+		{"heading then next heading", "## Cause\n\n## Resolution\n\n- x\n"},
+	}
+	for _, c := range cases {
+		if got := (Entry{Body: c.body}).Section("Cause"); got != "" {
+			t.Errorf("%s: Section(Cause) = %q, want \"\"", c.label, got)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/catalog/ -run TestEntrySection -v`
+Expected: FAIL — `e.Section undefined`.
+
+- [ ] **Step 3: Implement `internal/catalog/section.go`**
+
+```go
+package catalog
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// sectionMaxRunes caps a Section excerpt: enough to quote an entry's cause or
+// resolution in a chat notification / PR body without reproducing the document.
+const sectionMaxRunes = 300
+
+// Section returns the first paragraph of the entry body's "## <name>" markdown
+// section, flattened to a single line — the quotable essence of what the entry
+// says. Matching is case-insensitive and accepts any ATX heading level. Bold
+// markers (**) are stripped: the excerpt is interpolated into Slack mrkdwn and
+// PR bodies, where a literal ** renders as stray asterisks. Returns "" when the
+// section is absent or empty — callers must treat that as "nothing to quote"
+// and never render an empty block.
+func (e Entry) Section(name string) string {
+	want := strings.TrimSpace(name)
+	var para []string
+	in := false
+	for _, ln := range strings.Split(e.Body, "\n") {
+		trimmed := strings.TrimSpace(ln)
+		if h := headingText(trimmed); h != "" {
+			if in {
+				break // next section starts: the excerpt is done
+			}
+			in = strings.EqualFold(h, want)
+			continue
+		}
+		if !in {
+			continue
+		}
+		if trimmed == "" {
+			if len(para) > 0 {
+				break // blank line after content: first paragraph is done
+			}
+			continue // leading blank between the heading and its content
+		}
+		para = append(para, trimmed)
+	}
+	s := strings.ReplaceAll(strings.Join(para, " "), "**", "")
+	return truncateRunes(s, sectionMaxRunes)
+}
+
+// headingText returns the text of an ATX markdown heading line ("## Cause" →
+// "Cause"), or "" when the line is not a heading.
+func headingText(line string) string {
+	i := 0
+	for i < len(line) && line[i] == '#' {
+		i++
+	}
+	if i == 0 || i > 6 || i >= len(line) || line[i] != ' ' {
+		return ""
+	}
+	return strings.TrimSpace(line[i:])
+}
+
+// truncateRunes caps s at max runes, appending … when cut — rune-aware so a
+// multibyte character is never split.
+func truncateRunes(s string, max int) string {
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	r := []rune(s)
+	return strings.TrimRight(string(r[:max]), " ") + "…"
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/catalog/ -run TestEntrySection -v`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/catalog/section.go internal/catalog/section_test.go
+git commit -m "feat(catalog): add Entry.Section for quotable OKF section excerpts"
+```
+
+---
+
+### Task 2: `providers.PriorKnowledge` + stamping in `onInvestigationComplete`
+
+**Files:**
+- Modify: `internal/providers/providers.go` (Investigation struct, after `PrevCuratedURL` ~line 443)
+- Modify: `internal/app/investigate.go` (`onInvestigationComplete` ~line 319, its closure call site ~line 299, and the `dupFP` computation ~line 360)
+- Test: `internal/app/oncomplete_test.go`
+
+**Interfaces:**
+- Consumes: `catalog.Entry.Section(name string) string` (Task 1); existing `Catalog.FindFingerprint(fp) (Entry, bool)`; `curator.DupFingerprint(inv)`; `ledger.OpenCounts() (map[string]outcome.Aggregate, error)`.
+- Produces: `providers.PriorKnowledge{Cause, Resolution, EntryPath string; Recalls, Resolved int}`; `Investigation.Prior *PriorKnowledge`; new `onInvestigationComplete` signature with a `prior priorEntryFinder` param inserted after `ledger`. Tasks 3–5 rely on `Investigation.Prior` and its field names exactly.
+
+- [ ] **Step 1: Write the failing tests** — append to `internal/app/oncomplete_test.go` (imports to add: `github.com/Smana/runlore/internal/catalog`):
+
+```go
+// fakePrior stubs the catalog's exact-identity lookup so the completion
+// pipeline can be tested without building a bleve index.
+type fakePrior struct {
+	e  catalog.Entry
+	ok bool
+}
+
+func (f fakePrior) FindFingerprint(string) (catalog.Entry, bool) { return f.e, f.ok }
+
+// TestOnCompleteStampsPriorKnowledge: a recurring fresh investigation whose
+// merged KB entry is findable by dup-fingerprint must deliver Prior with the
+// entry's Cause/Resolution excerpts and its recall track record.
+func TestOnCompleteStampsPriorKnowledge(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	ledger, err := outcome.New(path)
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	// Prior open for the same trigger key ⇒ this run is occurrence #2.
+	if err := ledger.Open(outcome.Event{
+		Fingerprint: "fp0", TriggerKey: "k", CuratedURL: "https://kb/prev",
+		At: time.Now().Add(-4 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	// Track record for the merged entry: one resolvable recall that resolved.
+	rv := true
+	if err := ledger.Open(outcome.Event{
+		Fingerprint: "fpr", Kind: "recall", Entry: "incidents/e.md",
+		Resolvable: &rv, At: time.Now().Add(-3 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed recall open: %v", err)
+	}
+	if _, _, err := ledger.Resolve("fpr", time.Now().Add(-2*time.Hour)); err != nil {
+		t.Fatalf("seed resolve: %v", err)
+	}
+
+	entry := catalog.Entry{
+		Path: "incidents/e.md",
+		Body: "## Cause\n\n1. **bad kustomize bump** (85%)\n\n## Resolution\n\n- revert and pin 5.3.2\n",
+	}
+	sink := &captureNotifier{}
+	notifier := notify.NewMulti(discardLog(), sink)
+	found := providers.Investigation{Title: "disk pressure", Fingerprint: "fp1", TriggerKey: "k"}
+	onInvestigationComplete(context.Background(), found, ledger, fakePrior{e: entry, ok: true}, nil, notifier, nil, nil, nil, discardLog())
+
+	p := sink.got.Prior
+	if p == nil {
+		t.Fatal("Prior not stamped on a recurring fresh investigation")
+	}
+	if p.Cause != "1. bad kustomize bump (85%)" {
+		t.Errorf("Prior.Cause = %q", p.Cause)
+	}
+	if p.Resolution != "- revert and pin 5.3.2" {
+		t.Errorf("Prior.Resolution = %q", p.Resolution)
+	}
+	if p.EntryPath != "incidents/e.md" {
+		t.Errorf("Prior.EntryPath = %q", p.EntryPath)
+	}
+	if p.Recalls != 1 || p.Resolved != 1 {
+		t.Errorf("Prior track record = %d/%d, want 1/1", p.Resolved, p.Recalls)
+	}
+}
+
+// Recalled investigations must NOT get Prior (the recalled entry IS the
+// delivered answer), and a first sighting or a fingerprint miss leaves it nil.
+func TestOnCompletePriorKnowledgeSkips(t *testing.T) {
+	entry := catalog.Entry{Path: "incidents/e.md", Body: "## Cause\n\nc\n\n## Resolution\n\nr\n"}
+	cases := []struct {
+		label    string
+		seed     bool // seed a prior open (⇒ Occurrences 2)
+		recalled bool
+		found    bool // FindFingerprint hit
+	}{
+		{"recall path", true, true, true},
+		{"first sighting", false, false, true},
+		{"no merged entry", true, false, false},
+	}
+	for _, c := range cases {
+		path := filepath.Join(t.TempDir(), "outcomes.jsonl")
+		ledger, err := outcome.New(path)
+		if err != nil {
+			t.Fatalf("%s: new ledger: %v", c.label, err)
+		}
+		if c.seed {
+			if err := ledger.Open(outcome.Event{Fingerprint: "fp0", TriggerKey: "k", At: time.Now().Add(-time.Hour)}); err != nil {
+				t.Fatalf("%s: seed: %v", c.label, err)
+			}
+		}
+		sink := &captureNotifier{}
+		notifier := notify.NewMulti(discardLog(), sink)
+		found := providers.Investigation{Title: "t", Fingerprint: "fp1", TriggerKey: "k", Recalled: c.recalled}
+		onInvestigationComplete(context.Background(), found, ledger, fakePrior{e: entry, ok: c.found}, nil, notifier, nil, nil, nil, discardLog())
+		if sink.got.Prior != nil {
+			t.Errorf("%s: Prior = %+v, want nil", c.label, sink.got.Prior)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/app/ -run TestOnCompletePrior -v`
+Expected: compile FAIL — wrong argument count for `onInvestigationComplete`, `Prior` undefined.
+
+- [ ] **Step 3: Implement.** In `internal/providers/providers.go`, immediately after the `PrevCuratedURL` field of `Investigation` (~line 443), add the field, and the type right after the `Investigation` struct:
+
+```go
+	Prior          *PriorKnowledge // what the merged KB entry already says about this recurring incident; nil when unknown (see PriorKnowledge)
+```
+
+```go
+// PriorKnowledge is what the knowledge base already says about a recurring
+// incident: excerpts of the merged entry's Cause and (human-reviewed)
+// Resolution sections, plus the entry's recall track record from the outcome
+// ledger. Stamped at completion — never seen by the model — and only on FRESH
+// investigations of a recurring TriggerKey whose merged entry is findable by
+// dup-fingerprint; nil otherwise, so notifiers fall back to the counter+link.
+type PriorKnowledge struct {
+	Cause      string // excerpt of the merged entry's "## Cause" section
+	Resolution string // excerpt of "## Resolution" — carries the human's review edits, the payoff of curation
+	EntryPath  string // catalog path of the merged entry
+	Recalls    int    // times the entry answered an incident via instant recall
+	Resolved   int    // recalls followed by an incident-resolved signal
+}
+```
+
+In `internal/app/investigate.go`:
+
+1. Add the narrow interface next to `investigationCurator` (~line 308):
+
+```go
+// priorEntryFinder is the catalog's exact-identity lookup used to quote the
+// merged KB entry on a recurring incident (implemented by *catalog.Catalog).
+// Narrowed to an interface so the completion pipeline is testable without an index.
+type priorEntryFinder interface {
+	FindFingerprint(fp string) (catalog.Entry, bool)
+}
+```
+
+2. Change the signature (insert `prior` after `ledger`):
+
+```go
+func onInvestigationComplete(ctx context.Context, found providers.Investigation, ledger *outcome.Ledger, prior priorEntryFinder, cur investigationCurator, notifier *notify.Multi, auto *action.Auto, approvals *action.Approvals, metrics *telemetry.Metrics, log *slog.Logger) {
+```
+
+3. Directly after the existing recurrence-facts block (after `found.Occurrences = 1` ~line 330), hoist the dup fingerprint and stamp Prior:
+
+```go
+	// The dedup fingerprint is this incident's deterministic identity: the merged
+	// KB entry carries it in frontmatter and the ledger opens below stamp it —
+	// computed once for both uses.
+	dupFP := curator.DupFingerprint(found)
+	// Prior knowledge: on a RECURRING fresh investigation, quote what the merged
+	// KB entry already says (cause + human-reviewed resolution + recall track
+	// record) so the on-call reads the previous answer in the notification
+	// instead of clicking through to the forge. Recalls are excluded — the
+	// recalled entry IS the answer being delivered. Best-effort by construction:
+	// no merged entry, empty sections, or a ledger error leave Prior nil and the
+	// notification falls back to the counter+link it already carries.
+	if found.Occurrences > 1 && !found.Recalled && prior != nil {
+		if e, ok := prior.FindFingerprint(dupFP); ok {
+			cause, resolution := e.Section("Cause"), e.Section("Resolution")
+			if cause != "" || resolution != "" {
+				pk := &providers.PriorKnowledge{Cause: cause, Resolution: resolution, EntryPath: e.Path}
+				if counts, err := ledger.OpenCounts(); err == nil {
+					agg := counts[e.Path]
+					pk.Recalls, pk.Resolved = agg.Recalls, agg.Resolved
+				}
+				found.Prior = pk
+			}
+		}
+	}
+```
+
+4. Delete the now-duplicate `dupFP := curator.DupFingerprint(found)` inside the `if len(fps) > 0` block (~line 360) — the comment above it moves up with the hoisted computation.
+
+5. Update the `OnComplete` closure (~line 299). A nil `*catalog.Catalog` must stay a nil **interface** — a typed-nil would pass the `!= nil` guard and panic on the first lookup:
+
+```go
+		var prior priorEntryFinder
+		if cat != nil {
+			prior = cat
+		}
+```
+(place just before the `return &investigate.LoopInvestigator{...}`), and in the closure:
+
+```go
+			OnComplete: func(found providers.Investigation) {
+				onInvestigationComplete(ctx, found, ledger, prior, curOrNil, notifier, auto, approvals, metrics, log)
+			},
+```
+
+6. Update every existing `onInvestigationComplete(` call in `internal/app/oncomplete_test.go` to pass `nil` as the new 4th argument (after `ledger`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/app/ -race -v -run TestOnComplete`
+Expected: PASS — the two new tests and all pre-existing `TestOnComplete*` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/providers/providers.go internal/app/investigate.go internal/app/oncomplete_test.go
+git commit -m "feat(app): stamp prior KB knowledge on recurring fresh investigations"
+```
+
+---
+
+### Task 3: render Prior in `notify.Format` (Matrix/webhook text/Slack fallback)
+
+**Files:**
+- Modify: `internal/notify/format.go` (~lines 58–65, the `inv.Occurrences > 1` block)
+- Test: `internal/notify/format_test.go`
+
+**Interfaces:**
+- Consumes: `Investigation.Prior` (Task 2).
+- Produces: `Format` output containing `📚 Seen before: ×N`, `Prior cause:`, `Prior resolution:`, `Resolve rate: R/N recalls resolved`, `Previous conclusion: <url>` lines. Scaffolding stays free of `&` `<` `>`.
+
+- [ ] **Step 1: Write the failing test** — add to `format_test.go`:
+
+```go
+func TestFormatPriorKnowledge(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "t", Confidence: 0.8,
+		Occurrences:    3,
+		LastOccurrence: time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC),
+		PrevCuratedURL: "https://kb/pr/12",
+		Prior: &providers.PriorKnowledge{
+			Cause: "ConfigMap truncated after kustomize bump", Resolution: "revert the patch and pin 5.3.2",
+			Recalls: 3, Resolved: 3,
+		},
+	}
+	out := Format(inv)
+	for _, want := range []string{
+		"📚 Seen before: ×3 — last investigated 2026-06-25T10:00:00Z",
+		"Prior cause: ConfigMap truncated after kustomize bump",
+		"Prior resolution: revert the patch and pin 5.3.2",
+		"Resolve rate: 3/3 recalls resolved",
+		"Previous conclusion: https://kb/pr/12",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Format missing %q\n---\n%s", want, out)
+		}
+	}
+}
+
+// Without Prior the block keeps today's counter+link shape (no empty labels).
+func TestFormatSeenBeforeWithoutPrior(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "t", Confidence: 0.8,
+		Occurrences: 2, LastOccurrence: time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC),
+		PrevCuratedURL: "https://kb/pr/12",
+	}
+	out := Format(inv)
+	if !strings.Contains(out, "📚 Seen before: ×2") {
+		t.Errorf("missing seen-before counter:\n%s", out)
+	}
+	for _, absent := range []string{"Prior cause:", "Prior resolution:", "Resolve rate:"} {
+		if strings.Contains(out, absent) {
+			t.Errorf("Format must omit %q when Prior is nil:\n%s", absent, out)
+		}
+	}
+}
+```
+
+Also update the two existing expectations:
+- In `TestFormatVerdictMetadataRecurrence` (~line 68): replace the expected substring `"Occurrence: #` (old wording) with `"📚 Seen before: ×` (keep the same occurrence number the test already uses).
+- In `TestFormatScaffoldingHasNoMrkdwnMeta` (~line 131): extend the fixture Investigation with `Occurrences: 2, LastOccurrence: time.Now(), PrevCuratedURL: "https://kb/pr/1", Prior: &providers.PriorKnowledge{Cause: "c", Resolution: "r", Recalls: 1, Resolved: 1}` so the invariant covers the new scaffolding.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/notify/ -run TestFormat -v`
+Expected: FAIL — new tests missing output; `TestFormatVerdictMetadataRecurrence` still passes until the impl changes (that's fine).
+
+- [ ] **Step 3: Implement** — replace the `inv.Occurrences > 1` block in `Format` (format.go:58-65) with:
+
+```go
+	// Seen-before block: only when this is a repeat of a known incident (a first
+	// sighting — Occurrences ≤ 1, or 0 = ledger disabled — prints nothing). When
+	// the completion pipeline found the merged KB entry for this incident
+	// (Prior), the previous cause and human-reviewed resolution are quoted
+	// inline — the zero-click payoff of the knowledge base; otherwise the
+	// counter + link still tell the reader this is not new.
+	if inv.Occurrences > 1 {
+		fmt.Fprintf(&b, "📚 Seen before: ×%d — last investigated %s\n", inv.Occurrences, inv.LastOccurrence.UTC().Format(time.RFC3339))
+		if p := inv.Prior; p != nil {
+			if p.Cause != "" {
+				fmt.Fprintf(&b, "   Prior cause: %s\n", p.Cause)
+			}
+			if p.Resolution != "" {
+				fmt.Fprintf(&b, "   Prior resolution: %s\n", p.Resolution)
+			}
+			if p.Recalls > 0 {
+				fmt.Fprintf(&b, "   Resolve rate: %d/%d recalls resolved\n", p.Resolved, p.Recalls)
+			}
+		}
+		if inv.PrevCuratedURL != "" {
+			fmt.Fprintf(&b, "Previous conclusion: %s\n", inv.PrevCuratedURL)
+		}
+	}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/notify/ -race -run TestFormat -v`
+Expected: PASS — including the updated `TestFormatVerdictMetadataRecurrence` and `TestFormatScaffoldingHasNoMrkdwnMeta`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/notify/format.go internal/notify/format_test.go
+git commit -m "feat(notify): quote prior KB cause/resolution in the shared format"
+```
+
+---
+
+### Task 4: render Prior in the Slack summary blocks
+
+**Files:**
+- Modify: `internal/notify/slack.go` (`summaryBlocks` — insert block 3b after the metadata-fields block ~line 341; `metadataFields` ~line 487; block 8 ~line 408)
+- Test: `internal/notify/slack_test.go`
+
+**Interfaces:**
+- Consumes: `Investigation.Prior` (Task 2).
+- Produces: a Slack `section` block `📚 *Seen before ×N* — last <date> …` placed between metadata fields and the top root cause; when `Prior != nil` the old `Recurrence` metadata field and the block-8 context pointer are suppressed (the new block carries count + link).
+
+- [ ] **Step 1: Write the failing test** — add to `slack_test.go`:
+
+```go
+// blocksText flattens summaryBlocks into one string for containment asserts.
+func blocksText(t *testing.T, blocks []map[string]any) string {
+	t.Helper()
+	b, err := json.Marshal(blocks)
+	if err != nil {
+		t.Fatalf("marshal blocks: %v", err)
+	}
+	return string(b)
+}
+
+func TestSlackSummaryBlocksPriorKnowledge(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "CrashLoopBackOff", Confidence: 0.86,
+		Occurrences:    3,
+		LastOccurrence: time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC),
+		PrevCuratedURL: "https://kb/pr/12",
+		Prior: &providers.PriorKnowledge{
+			Cause: "ConfigMap truncated <v5.4>", Resolution: "revert & pin 5.3.2",
+			Recalls: 3, Resolved: 3,
+		},
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	for _, want := range []string{
+		"📚 *Seen before ×3*",
+		"*Prior cause:* ConfigMap truncated &lt;v5.4&gt;", // untrusted entry text is escaped
+		"*Prior resolution:* revert &amp; pin 5.3.2",
+		"previous entry",     // link label
+		"resolve rate 3/3",   // track record
+	} {
+		if !strings.Contains(txt, want) {
+			t.Errorf("summary blocks missing %q\n%s", want, txt)
+		}
+	}
+	// The new block replaces the old pointers: no duplicate recurrence renders.
+	for _, absent := range []string{"Previously investigated", "*Recurrence:*"} {
+		if strings.Contains(txt, absent) {
+			t.Errorf("summary blocks must not still render %q when Prior is set\n%s", absent, txt)
+		}
+	}
+}
+
+// Without Prior, the legacy counter field + context pointer stay untouched.
+func TestSlackSummaryBlocksRecurrenceWithoutPrior(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "CrashLoopBackOff", Confidence: 0.86,
+		Occurrences: 2, LastOccurrence: time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC),
+		PrevCuratedURL: "https://kb/pr/12",
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "Previously investigated") {
+		t.Errorf("legacy recurrence pointer missing without Prior\n%s", txt)
+	}
+	if strings.Contains(txt, "Seen before") {
+		t.Errorf("Seen-before block must not render without Prior\n%s", txt)
+	}
+}
+```
+
+(Add `"encoding/json"` and `"time"` to the test imports if absent.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/notify/ -run TestSlackSummaryBlocks -v`
+Expected: FAIL — no Seen-before block yet.
+
+- [ ] **Step 3: Implement.** In `summaryBlocks`, insert after the metadata-fields block (after ~line 341) :
+
+```go
+	// 3b. Prior knowledge — on a recurring incident with a merged KB entry, quote
+	// what the KB already says (cause + human-reviewed resolution + track record)
+	// before the current analysis: history frames how the on-call reads what
+	// follows, with zero clicks. The entry excerpts are untrusted (model prose,
+	// human edits) and escaped; when this block renders, the legacy Recurrence
+	// field and the previously-investigated context pointer are suppressed —
+	// count, date and link all live here.
+	if p := inv.Prior; p != nil {
+		var s strings.Builder
+		fmt.Fprintf(&s, "📚 *Seen before ×%d* — last %s", inv.Occurrences, slackDate(inv.LastOccurrence))
+		if p.Cause != "" {
+			fmt.Fprintf(&s, "\n*Prior cause:* %s", escapeMrkdwn(p.Cause))
+		}
+		if p.Resolution != "" {
+			fmt.Fprintf(&s, "\n*Prior resolution:* %s", escapeMrkdwn(p.Resolution))
+		}
+		foot := make([]string, 0, 2)
+		if inv.PrevCuratedURL != "" {
+			foot = append(foot, fmt.Sprintf("<%s|previous entry>", escapeMrkdwn(inv.PrevCuratedURL)))
+		}
+		if p.Recalls > 0 {
+			foot = append(foot, fmt.Sprintf("resolve rate %d/%d", p.Resolved, p.Recalls))
+		}
+		if len(foot) > 0 {
+			fmt.Fprintf(&s, "\n%s", strings.Join(foot, " · "))
+		}
+		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
+	}
+```
+
+In `metadataFields` (~line 487), suppress the redundant field when the block renders:
+
+```go
+	if inv.Occurrences > 1 && inv.Prior == nil {
+		add("Recurrence", fmt.Sprintf("🔁 #%d · last %s", inv.Occurrences, slackDate(inv.LastOccurrence)))
+	}
+```
+
+In block 8 (~line 408), same suppression:
+
+```go
+	if inv.PrevCuratedURL != "" && inv.Prior == nil {
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/notify/ -race -v`
+Expected: PASS — new tests plus every pre-existing Slack test (fallback-escape invariant included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/notify/slack.go internal/notify/slack_test.go
+git commit -m "feat(notify): Slack seen-before block with prior cause and resolution"
+```
+
+---
+
+### Task 5: webhook payload, docs, full verification
+
+**Files:**
+- Modify: `internal/notify/webhook/webhook.go` (payload struct ~line 44, `Deliver` ~line 65)
+- Modify: `docs/learning-loop.md` (§4, the paragraph on recurrence facts)
+- Test: `internal/notify/webhook/webhook_test.go`
+
+**Interfaces:**
+- Consumes: `Investigation.Prior` (Task 2).
+- Produces: webhook JSON gains `"prior": {"cause", "resolution", "entry_path", "recalls", "resolved"}` (omitted when nil).
+
+- [ ] **Step 1: Write the failing test** — in `webhook_test.go`, add a case asserting the JSON body (follow the file's existing `httptest` pattern):
+
+```go
+func TestWebhookDeliverPriorKnowledge(t *testing.T) {
+	var got payload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+	}))
+	defer srv.Close()
+	n := New(srv.URL)
+	inv := providers.Investigation{
+		Title: "t", Confidence: 0.8, Occurrences: 3,
+		Prior: &providers.PriorKnowledge{Cause: "c", Resolution: "r", EntryPath: "incidents/e.md", Recalls: 3, Resolved: 2},
+	}
+	if err := n.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	if got.Prior == nil || got.Prior.Cause != "c" || got.Prior.Resolution != "r" ||
+		got.Prior.EntryPath != "incidents/e.md" || got.Prior.Recalls != 3 || got.Prior.Resolved != 2 {
+		t.Errorf("prior payload = %+v", got.Prior)
+	}
+}
+```
+
+(`webhook.New(url string) *Notifier` is the actual constructor — the call above matches it. Add `net/http`, `net/http/httptest`, `encoding/json`, `context` to the test imports if absent.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/notify/webhook/ -run TestWebhookDeliverPrior -v`
+Expected: FAIL — `got.Prior` undefined.
+
+- [ ] **Step 3: Implement.** In `webhook.go` add below `payload`:
+
+```go
+// priorPayload mirrors providers.PriorKnowledge for webhook consumers: what the
+// merged KB entry said last time this incident fired.
+type priorPayload struct {
+	Cause      string `json:"cause,omitempty"`
+	Resolution string `json:"resolution,omitempty"`
+	EntryPath  string `json:"entry_path,omitempty"`
+	Recalls    int    `json:"recalls,omitempty"`
+	Resolved   int    `json:"resolved,omitempty"`
+}
+```
+
+Add to `payload`: `Prior *priorPayload \`json:"prior,omitempty"\`` and in `Deliver`, before marshalling:
+
+```go
+	var prior *priorPayload
+	if p := inv.Prior; p != nil {
+		prior = &priorPayload{Cause: p.Cause, Resolution: p.Resolution, EntryPath: p.EntryPath, Recalls: p.Recalls, Resolved: p.Resolved}
+	}
+```
+and set `Prior: prior,` in the `payload{...}` literal.
+
+- [ ] **Step 4: Docs.** In `docs/learning-loop.md` §4, extend the paragraph that ends "…so a repeat alert is visibly flagged as recurring rather than looking brand-new." with one sentence:
+
+> When the recurring incident's merged entry is findable by dup-fingerprint, the notification also quotes the entry's **cause and human-reviewed resolution** inline (with its recall resolve-rate), so the previous answer is readable without leaving chat.
+
+- [ ] **Step 5: Full verification**
+
+Run: `go build ./... && go vet ./... && test -z "$(gofmt -l .)" && go test -race ./... && golangci-lint run ./...`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/notify/webhook/ docs/learning-loop.md
+git commit -m "feat(notify): carry prior KB knowledge in the webhook payload"
+```

--- a/docs/superpowers/plans/2026-07-07-lore-kb-cli.md
+++ b/docs/superpowers/plans/2026-07-07-lore-kb-cli.md
@@ -1,0 +1,740 @@
+# `lore kb search` / `lore kb show` CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A human search surface over the existing BM25 knowledge index: `lore kb search "<query>"` prints a readable hits table (optional resolve-rate from a ledger file, optional JSON), `lore kb show <entry>` prints one full entry. Spec: `docs/superpowers/specs/2026-07-07-kb-human-surfaces-design.md`, Feature 2.
+
+**Architecture:** A new `internal/app/kb_cmd.go` hosts `RunKB` (dispatch) + `runKBSearch`/`runKBShow`, writing to an injected `io.Writer` for testability. The catalog loads like `lore mcp` does: explicit `--dir` wins, else config `catalog.dir` (the CLI never clones — it points at `lore catalog sync`). Resolve-rate is opt-in via `--ledger <jsonl>` (the ledger lives in-cluster, not on workstations) using `outcome.OpenCounts()` keyed by entry path. Output is a stdlib `text/tabwriter` table — no ANSI, no new dependencies.
+
+**Tech Stack:** Go 1.26, stdlib only (`flag`, `text/tabwriter`, `encoding/json`). Tests: `go test -race ./...`, table-driven with fixture catalogs in `t.TempDir()`. Lint: `golangci-lint run ./...`, `gofmt`.
+
+## Global Constraints
+
+- Go 1.26 (go.mod); CI runs `go build ./...`, `go vet ./...`, `test -z "$(gofmt -l .)"`, `go test -race ./...`.
+- Never add AI attribution to commits or PRs. Conventional-commit prefixes (`feat:`, `fix:`, `test:`, `docs:`).
+- Zero new dependencies. No ANSI escape codes (tabwriter alignment suffices; also keeps output pipe-safe).
+- Scripting contract: no results ⇒ non-zero exit (return an error); `--json` output is machine-stable.
+- An unreadable `--ledger` warns and omits the RESOLVE column — it never fails the search. It must also never CREATE the file (stat before open).
+- Keep the comment density/style of surrounding code (this repo comments the *why* heavily).
+- Work on a dedicated branch (e.g. `feat/lore-kb-cli`), one PR for this whole plan.
+
+---
+
+### Task 1: `RunKB` dispatch + `kb search` with the hits table
+
+**Files:**
+- Create: `internal/app/kb_cmd.go`
+- Test: `internal/app/kb_cmd_test.go`
+
+**Interfaces:**
+- Consumes: `catalog.New(dir)`, `Catalog.SearchScored(query, k)`, `catalog.ScoredEntry{Entry, Score}`, `config.Load(path)` (`cfg.Catalog.Dir`, `cfg.Catalog.Git.URL`).
+- Produces: `RunKB(args []string) error` (dispatch: `search` | `show`); `runKBSearch(args []string, w io.Writer) error`; `loadKBCatalog(cfgPath, dir string) (*catalog.Catalog, error)`; `relAge(ts string) string`. Tasks 2–4 extend these; Task 5 wires `RunKB` into `main.go`.
+
+- [ ] **Step 1: Write the failing test** — create `internal/app/kb_cmd_test.go`:
+
+```go
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeKBFixture materializes a small OKF catalog: two entries whose lexical
+// overlap with the test queries is deliberately asymmetric.
+func writeKBFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	ts := time.Now().Add(-12 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	entries := map[string]string{
+		"incidents/crashloop-web.md": "---\ntype: Incident\ntitle: CrashLoop web ConfigMap truncated\ndescription: web pods crashloop after kustomize bump\nresource: apps/web\ntags: [runlore, incident]\ntimestamp: \"" + ts + "\"\n---\n## Cause\n\nConfigMap truncated\n\n## Resolution\n\nrevert the patch\n",
+		"incidents/oom-worker.md":    "---\ntype: Incident\ntitle: OOM worker limits too low\ndescription: worker OOMKilled under load\nresource: apps/worker\n---\n## Cause\n\nlimits too low\n",
+	}
+	for path, content := range entries {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestKBSearchTable(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	err := runKBSearch([]string{"--dir", dir, "crashloop", "web", "configmap"}, &out)
+	if err != nil {
+		t.Fatalf("runKBSearch: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"SCORE", "ENTRY", "TITLE", "RESOURCE", "LAST SEEN",
+		"incidents/crashloop-web.md", "apps/web", "12d ago"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("table missing %q:\n%s", want, got)
+		}
+	}
+	// The lexically-distant entry may or may not appear, but the best match must
+	// be the FIRST data row.
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) < 2 || !strings.Contains(lines[1], "crashloop-web") {
+		t.Errorf("best hit is not the first row:\n%s", got)
+	}
+	// No RESOLVE column without --ledger.
+	if strings.Contains(got, "RESOLVE") {
+		t.Errorf("RESOLVE column must be absent without --ledger:\n%s", got)
+	}
+}
+
+func TestKBSearchNoResultsIsError(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "zzz-nothing-matches-this"}, &out); err == nil {
+		t.Fatal("want error on zero hits (non-zero exit for scripting)")
+	}
+}
+
+func TestKBSearchUsageErrors(t *testing.T) {
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", t.TempDir()}, &out); err == nil {
+		t.Fatal("want usage error when the query is empty")
+	}
+	if err := RunKB([]string{"frobnicate"}); err == nil {
+		t.Fatal("want usage error on unknown subcommand")
+	}
+	if err := RunKB(nil); err == nil {
+		t.Fatal("want usage error with no subcommand")
+	}
+}
+
+func TestRelAge(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		ts   string
+		want string
+	}{
+		{now.Add(-30 * time.Minute).Format(time.RFC3339), "30m ago"},
+		{now.Add(-5 * time.Hour).Format(time.RFC3339), "5h ago"},
+		{now.Add(-26 * time.Hour).Format(time.RFC3339), "1d ago"},
+		{"", ""},          // hand-written entry without a timestamp
+		{"not-a-date", ""}, // malformed
+		{now.Add(time.Hour).Format(time.RFC3339), ""}, // future: clock skew, say nothing
+	}
+	for _, c := range cases {
+		if got := relAge(c.ts); got != c.want {
+			t.Errorf("relAge(%q) = %q, want %q", c.ts, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/app/ -run 'TestKBSearch|TestRelAge' -v`
+Expected: compile FAIL — `runKBSearch`, `RunKB`, `relAge` undefined.
+
+- [ ] **Step 3: Implement `internal/app/kb_cmd.go`**
+
+```go
+package app
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/outcome"
+)
+
+// RunKB dispatches the human-facing knowledge-base read commands. `lore catalog
+// sync` remains the machine/ops write surface; `lore kb` is how a person asks
+// "what do we already know about this?" without an MCP client or a cluster.
+func RunKB(args []string) error {
+	const usage = "usage: lore kb search <query> [flags] | lore kb show <entry> [flags]"
+	if len(args) == 0 {
+		return fmt.Errorf("%s", usage)
+	}
+	switch args[0] {
+	case "search":
+		return runKBSearch(args[1:], os.Stdout)
+	case "show":
+		return runKBShow(args[1:], os.Stdout)
+	}
+	return fmt.Errorf("unknown kb subcommand %q\n%s", args[0], usage)
+}
+
+// loadKBCatalog opens the catalog for the read commands: an explicit --dir
+// wins; otherwise config catalog.dir. The CLI never clones — a git-synced
+// catalog is materialized by `lore catalog sync` (or a running agent), so the
+// error message points there instead of failing cryptically.
+func loadKBCatalog(cfgPath, dir string) (*catalog.Catalog, error) {
+	if dir == "" {
+		cfg, err := config.Load(cfgPath)
+		if err != nil {
+			return nil, fmt.Errorf("load config: %w (or pass --dir <catalog>)", err)
+		}
+		dir = cfg.Catalog.Dir
+		if dir == "" {
+			return nil, fmt.Errorf("no catalog configured (set catalog.dir or pass --dir <catalog>)")
+		}
+	}
+	cat, err := catalog.New(dir)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog %s: %w (for a git-synced catalog, run `lore catalog sync` first)", dir, err)
+	}
+	if cat.Len() == 0 {
+		return nil, fmt.Errorf("catalog %s has no entries (for a git-synced catalog, run `lore catalog sync` first)", dir)
+	}
+	return cat, nil
+}
+
+func runKBSearch(args []string, w io.Writer) error {
+	fs := flag.NewFlagSet("kb search", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	dir := fs.String("dir", "", "catalog directory (overrides config catalog.dir)")
+	k := fs.Int("k", 10, "maximum results")
+	asJSON := fs.Bool("json", false, "emit results as JSON")
+	ledgerPath := fs.String("ledger", "", "outcome ledger JSONL; adds the RESOLVE column")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	query := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if query == "" {
+		return fmt.Errorf("usage: lore kb search <query> [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]")
+	}
+	cat, err := loadKBCatalog(*cfgPath, *dir)
+	if err != nil {
+		return err
+	}
+	hits, err := cat.SearchScored(query, *k)
+	if err != nil {
+		return err
+	}
+	if len(hits) == 0 {
+		return fmt.Errorf("no entries match %q", query)
+	}
+	counts := ledgerCounts(*ledgerPath, w)
+	if *asJSON {
+		return writeHitsJSON(w, hits, counts)
+	}
+	writeHitsTable(w, hits, counts, *ledgerPath != "")
+	return nil
+}
+
+// ledgerCounts loads per-entry recall/resolve aggregates from an optional
+// ledger file. The ledger lives in-cluster, so this is opt-in for humans who
+// copied it locally; a missing/unreadable file warns and omits the column —
+// never fails the search, and never CREATES the file (outcome.New would).
+func ledgerCounts(path string, w io.Writer) map[string]outcome.Aggregate {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		fmt.Fprintf(w, "warning: ledger %s unreadable (%v); RESOLVE column omitted\n", path, err)
+		return nil
+	}
+	l, err := outcome.New(path)
+	if err != nil {
+		fmt.Fprintf(w, "warning: ledger %s unreadable (%v); RESOLVE column omitted\n", path, err)
+		return nil
+	}
+	counts, _ := l.OpenCounts() // documented always-nil error
+	return counts
+}
+
+func writeHitsTable(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate, withResolve bool) {
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	head := "SCORE\tENTRY\tTITLE\tRESOURCE\tLAST SEEN"
+	if withResolve {
+		head += "\tRESOLVE"
+	}
+	fmt.Fprintln(tw, head)
+	for _, h := range hits {
+		row := fmt.Sprintf("%.2f\t%s\t%s\t%s\t%s",
+			h.Score, h.Entry.Path, truncateCell(h.Entry.Title, 60), h.Entry.Resource, relAge(h.Entry.Timestamp))
+		if withResolve {
+			// Resolve-rate is "resolved/recalled" per catalog entry; "-" for an
+			// entry the ledger has never seen recalled.
+			if agg := counts[h.Entry.Path]; agg.Recalls > 0 {
+				row += fmt.Sprintf("\t%d/%d", agg.Resolved, agg.Recalls)
+			} else {
+				row += "\t-"
+			}
+		}
+		fmt.Fprintln(tw, row)
+	}
+	_ = tw.Flush()
+}
+
+// truncateCell keeps table rows scannable: cap a free-text cell at max runes.
+func truncateCell(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return strings.TrimRight(string(r[:max]), " ") + "…"
+}
+
+// relAge renders an entry's RFC3339 timestamp as a coarse relative age ("12d
+// ago") — what a human scans for ("is this knowledge fresh?"). "" for absent,
+// malformed, or future timestamps (hand-written entries carry none).
+func relAge(ts string) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < 0:
+		return ""
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+```
+
+Also add these two stubs at the bottom so the file compiles before Tasks 2 and 4 (each task replaces its stub):
+
+```go
+// runKBShow is implemented in Task 2 of the plan.
+func runKBShow(args []string, w io.Writer) error {
+	return fmt.Errorf("kb show: not implemented yet")
+}
+
+// writeHitsJSON is implemented in Task 4 of the plan.
+func writeHitsJSON(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate) error {
+	_ = json.NewEncoder(w)
+	return fmt.Errorf("kb search --json: not implemented yet")
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/app/ -race -run 'TestKBSearch|TestRelAge' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/kb_cmd.go internal/app/kb_cmd_test.go
+git commit -m "feat(cli): lore kb search — human search over the knowledge catalog"
+```
+
+---
+
+### Task 2: `kb show` — print one full entry
+
+**Files:**
+- Modify: `internal/app/kb_cmd.go` (replace the `runKBShow` stub)
+- Test: `internal/app/kb_cmd_test.go`
+
+**Interfaces:**
+- Consumes: `loadKBCatalog`, `Catalog.Entries()`, `Catalog.SearchScored` (Task 1).
+- Produces: `runKBShow(args []string, w io.Writer) error` — exact path or filename match first, unique-search-hit fallback, disambiguation error otherwise.
+
+- [ ] **Step 1: Write the failing test** — append to `kb_cmd_test.go`:
+
+```go
+func TestKBShow(t *testing.T) {
+	dir := writeKBFixture(t)
+	cases := []struct{ label, arg string }{
+		{"exact path", "incidents/crashloop-web.md"},
+		{"filename slug", "crashloop-web"},
+		{"search fallback unique", "configmap truncated kustomize"},
+	}
+	for _, c := range cases {
+		var out strings.Builder
+		if err := runKBShow([]string{"--dir", dir, c.arg}, &out); err != nil {
+			t.Fatalf("%s: runKBShow: %v", c.label, err)
+		}
+		got := out.String()
+		for _, want := range []string{"CrashLoop web ConfigMap truncated", "type: Incident",
+			"resource: apps/web", "## Cause", "revert the patch"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("%s: output missing %q:\n%s", c.label, want, got)
+			}
+		}
+	}
+}
+
+func TestKBShowNoMatchIsError(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBShow([]string{"--dir", dir, "zzz-nothing"}, &out); err == nil {
+		t.Fatal("want error when nothing matches")
+	}
+	if err := runKBShow([]string{"--dir", dir}, &out); err == nil {
+		t.Fatal("want usage error when the entry argument is missing")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/app/ -run TestKBShow -v`
+Expected: FAIL — "not implemented yet".
+
+- [ ] **Step 3: Implement** — replace the `runKBShow` stub:
+
+```go
+// runKBShow prints one entry in full: the frontmatter card, then the body. The
+// argument is a bundle-relative path or a bare filename; when neither matches
+// exactly, a search fallback accepts a UNIQUE hit and otherwise lists the
+// candidates instead of guessing — showing the wrong runbook is worse than
+// asking the human to pick.
+func runKBShow(args []string, w io.Writer) error {
+	fs := flag.NewFlagSet("kb show", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	dir := fs.String("dir", "", "catalog directory (overrides config catalog.dir)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	arg := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if arg == "" {
+		return fmt.Errorf("usage: lore kb show <entry-path | filename | query> [--dir <catalog>]")
+	}
+	cat, err := loadKBCatalog(*cfgPath, *dir)
+	if err != nil {
+		return err
+	}
+	e, ok := findEntry(cat, arg)
+	if !ok {
+		hits, serr := cat.SearchScored(arg, 5)
+		if serr != nil {
+			return serr
+		}
+		switch len(hits) {
+		case 0:
+			return fmt.Errorf("no entry matches %q", arg)
+		case 1:
+			e = hits[0].Entry
+		default:
+			var b strings.Builder
+			for _, h := range hits {
+				fmt.Fprintf(&b, "  %s — %s\n", h.Entry.Path, h.Entry.Title)
+			}
+			return fmt.Errorf("no exact match for %q; candidates:\n%s", arg, strings.TrimRight(b.String(), "\n"))
+		}
+	}
+	writeEntry(w, e)
+	return nil
+}
+
+// findEntry matches by exact bundle-relative path, then by bare filename (with
+// or without the .md suffix).
+func findEntry(cat *catalog.Catalog, arg string) (catalog.Entry, bool) {
+	base := strings.TrimSuffix(arg, ".md")
+	for _, e := range cat.Entries() {
+		if e.Path == arg || strings.TrimSuffix(filepath.Base(e.Path), ".md") == base {
+			return e, true
+		}
+	}
+	return catalog.Entry{}, false
+}
+
+// writeEntry prints the frontmatter card then the markdown body — the same
+// information a reviewer sees on the file, without leaving the terminal.
+func writeEntry(w io.Writer, e catalog.Entry) {
+	fmt.Fprintf(w, "# %s\n\n", e.Title)
+	card := [][2]string{
+		{"path", e.Path}, {"type", e.Type}, {"description", e.Description},
+		{"resource", e.Resource}, {"tags", strings.Join(e.Tags, ", ")},
+		{"last seen", relAge(e.Timestamp)}, {"fingerprint", shortFP(e.Fingerprint)},
+	}
+	for _, kv := range card {
+		if kv[1] != "" {
+			fmt.Fprintf(w, "%s: %s\n", kv[0], kv[1])
+		}
+	}
+	fmt.Fprintf(w, "\n%s\n", strings.TrimSpace(e.Body))
+}
+
+// shortFP abbreviates the 64-hex dup fingerprint for display; identity checks
+// belong to machines, humans only need "has one / which one roughly".
+func shortFP(fp string) string {
+	if len(fp) > 12 {
+		return fp[:12] + "…"
+	}
+	return fp
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/app/ -race -run TestKBShow -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/kb_cmd.go internal/app/kb_cmd_test.go
+git commit -m "feat(cli): lore kb show — print one knowledge entry in full"
+```
+
+---
+
+### Task 3: `--ledger` resolve-rate column
+
+**Files:**
+- Modify: `internal/app/kb_cmd_test.go` (the plumbing already exists from Task 1 — this task proves it end-to-end)
+- Test: `internal/app/kb_cmd_test.go`
+
+**Interfaces:**
+- Consumes: `outcome.New(path)`, `Ledger.Open/Resolve`, `Aggregate{Recalls, Resolved}` keyed by entry path (the `Entry` field of recall opens).
+
+- [ ] **Step 1: Write the failing-or-proving test** — append:
+
+```go
+func TestKBSearchLedgerResolveColumn(t *testing.T) {
+	dir := writeKBFixture(t)
+	// Build a real ledger: the crashloop entry was recalled twice, resolved once.
+	ledgerPath := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	l, err := outcome.New(ledgerPath)
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	rv := true
+	for _, fp := range []string{"a", "b"} {
+		if err := l.Open(outcome.Event{
+			Fingerprint: fp, Kind: "recall", Entry: "incidents/crashloop-web.md",
+			Resolvable: &rv, At: time.Now().Add(-time.Hour),
+		}); err != nil {
+			t.Fatalf("seed open: %v", err)
+		}
+	}
+	if _, _, err := l.Resolve("a", time.Now()); err != nil {
+		t.Fatalf("seed resolve: %v", err)
+	}
+
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--ledger", ledgerPath, "crashloop", "web"}, &out); err != nil {
+		t.Fatalf("runKBSearch: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "RESOLVE") {
+		t.Errorf("RESOLVE header missing:\n%s", got)
+	}
+	if !strings.Contains(got, "1/2") {
+		t.Errorf("resolve-rate 1/2 missing:\n%s", got)
+	}
+}
+
+func TestKBSearchLedgerMissingWarnsAndOmits(t *testing.T) {
+	dir := writeKBFixture(t)
+	missing := filepath.Join(t.TempDir(), "nope.jsonl")
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--ledger", missing, "crashloop"}, &out); err != nil {
+		t.Fatalf("a missing ledger must not fail the search: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "warning: ledger") {
+		t.Errorf("missing warning line:\n%s", got)
+	}
+	// Stat-before-open: the warning path must not have created the file.
+	if _, err := os.Stat(missing); err == nil {
+		t.Error("--ledger must never create the ledger file")
+	}
+}
+```
+
+(Add `github.com/Smana/runlore/internal/outcome` to the test imports.)
+
+- [ ] **Step 2: Run**
+
+Run: `go test ./internal/app/ -race -run TestKBSearchLedger -v`
+Expected: PASS if Task 1's plumbing is correct; otherwise fix `ledgerCounts`/`writeHitsTable` until green. (This task exists as its own reviewer gate: the ledger join is the only cross-package behavior in the CLI.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/app/kb_cmd_test.go
+git commit -m "test(cli): prove the kb search --ledger resolve-rate column end-to-end"
+```
+
+---
+
+### Task 4: `--json` output
+
+**Files:**
+- Modify: `internal/app/kb_cmd.go` (replace the `writeHitsJSON` stub)
+- Test: `internal/app/kb_cmd_test.go`
+
+**Interfaces:**
+- Produces: `writeHitsJSON(w, hits, counts) error` emitting a JSON array of `{path, type, title, description, resource, tags, score, last_seen, recalls, resolved}` (omitempty on optional fields).
+
+- [ ] **Step 1: Write the failing test** — append:
+
+```go
+func TestKBSearchJSON(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--json", "crashloop", "web"}, &out); err != nil {
+		t.Fatalf("runKBSearch --json: %v", err)
+	}
+	var hits []struct {
+		Path     string  `json:"path"`
+		Type     string  `json:"type"`
+		Title    string  `json:"title"`
+		Resource string  `json:"resource"`
+		Score    float64 `json:"score"`
+		LastSeen string  `json:"last_seen"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &hits); err != nil {
+		t.Fatalf("output is not a JSON array: %v\n%s", err, out.String())
+	}
+	if len(hits) == 0 || hits[0].Path != "incidents/crashloop-web.md" {
+		t.Fatalf("unexpected hits: %+v", hits)
+	}
+	if hits[0].Score <= 0 || hits[0].Type != "Incident" || hits[0].Resource != "apps/web" {
+		t.Errorf("hit fields not mapped: %+v", hits[0])
+	}
+}
+```
+
+(Add `encoding/json` to the test imports.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/app/ -run TestKBSearchJSON -v`
+Expected: FAIL — "not implemented yet".
+
+- [ ] **Step 3: Implement** — replace the `writeHitsJSON` stub:
+
+```go
+// kbHit is the machine-readable search result (the CLI counterpart of the
+// kb_search MCP tool's hit shape, plus the optional ledger track record).
+type kbHit struct {
+	Path        string   `json:"path"`
+	Type        string   `json:"type,omitempty"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Resource    string   `json:"resource,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Score       float64  `json:"score"`
+	LastSeen    string   `json:"last_seen,omitempty"` // frontmatter timestamp, RFC3339
+	Recalls     int      `json:"recalls,omitempty"`
+	Resolved    int      `json:"resolved,omitempty"`
+}
+
+func writeHitsJSON(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate) error {
+	out := make([]kbHit, 0, len(hits))
+	for _, h := range hits {
+		agg := counts[h.Entry.Path]
+		out = append(out, kbHit{
+			Path: h.Entry.Path, Type: h.Entry.Type, Title: h.Entry.Title,
+			Description: h.Entry.Description, Resource: h.Entry.Resource, Tags: h.Entry.Tags,
+			Score: h.Score, LastSeen: h.Entry.Timestamp,
+			Recalls: agg.Recalls, Resolved: agg.Resolved,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/app/ -race -run TestKBSearch -v`
+Expected: PASS (JSON + table + ledger tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/kb_cmd.go internal/app/kb_cmd_test.go
+git commit -m "feat(cli): lore kb search --json for scripting"
+```
+
+---
+
+### Task 5: wire into `main.go`, usage, docs, full verification
+
+**Files:**
+- Modify: `cmd/lore/main.go` (usage string ~line 21, dispatch switch ~line 41)
+- Modify: `docs/reviewing-knowledge.md` (new section)
+- Test: manual smoke (below) — `main.go` has no unit tests; dispatch parity with the other cases.
+
+**Interfaces:**
+- Consumes: `app.RunKB(args)` (Task 1).
+
+- [ ] **Step 1: Wire the dispatch.** In `cmd/lore/main.go` add to the usage string (after the `lore catalog sync` line):
+
+```
+  lore kb search <query> [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]   search the knowledge base
+  lore kb show <entry> [--dir <catalog>]              print one KB entry (frontmatter card + body)
+```
+
+and to the switch (after `case "catalog":`):
+
+```go
+	case "kb":
+		if err := app.RunKB(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, "kb:", err)
+			os.Exit(1)
+		}
+```
+
+- [ ] **Step 2: Docs.** In `docs/reviewing-knowledge.md`, add a section (place it near the reviewing-workflow material):
+
+```markdown
+## Searching the KB from the CLI
+
+The same BM25 index the agent uses for recall is available to humans:
+
+    # against a local checkout of your KB repo
+    lore kb search "crashloop web configmap" --dir ./my-kb
+
+    # or via config (catalog.dir), after `lore catalog sync`
+    lore kb search "oom worker"
+
+    # one entry in full — path, filename, or a query with a unique hit
+    lore kb show crashloop-web
+
+`--json` emits the hits for scripting. `--ledger /var/lib/runlore/outcomes.jsonl`
+adds a RESOLVE column (how often each entry's recalls preceded the incident
+actually resolving) when you have a copy of the outcome ledger.
+
+This is also the 30-second evaluation path: clone any OKF knowledge repo and
+point `--dir` at it — no cluster, no model, no config.
+```
+
+- [ ] **Step 3: Smoke test end-to-end**
+
+```bash
+go build -o /tmp/lore ./cmd/lore
+mkdir -p /tmp/kbdemo/incidents
+printf -- '---\ntype: Incident\ntitle: demo entry\ndescription: d\nresource: apps/demo\n---\n## Cause\n\nx\n' > /tmp/kbdemo/incidents/demo.md
+/tmp/lore kb search "demo" --dir /tmp/kbdemo
+/tmp/lore kb show demo --dir /tmp/kbdemo
+/tmp/lore kb search "no-match-zzz" --dir /tmp/kbdemo; echo "exit=$?"
+```
+Expected: a table with the demo entry; the full entry; `exit=1` with a clear message.
+
+- [ ] **Step 4: Full verification**
+
+Run: `go build ./... && go vet ./... && test -z "$(gofmt -l .)" && go test -race ./... && golangci-lint run ./...`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/lore/main.go docs/reviewing-knowledge.md
+git commit -m "feat(cli): wire lore kb into the entrypoint and document it"
+```

--- a/docs/superpowers/specs/2026-07-07-kb-human-surfaces-design.md
+++ b/docs/superpowers/specs/2026-07-07-kb-human-surfaces-design.md
@@ -1,0 +1,163 @@
+# KB human surfaces — design
+
+**Date:** 2026-07-07
+**Status:** approved for planning
+
+## Problem
+
+RunLore's knowledge base is heavily engineered for *agent* consumption (3-gate
+recall, Bayesian decay, deterministic dedup) but nearly invisible to *humans*:
+
+- When a known incident recurs, the notification shows only an occurrence
+  counter and a "previous" link. The valuable knowledge — the previously
+  confirmed cause and the human-reviewed resolution — is behind a click to
+  GitHub, at exactly the moment (on-call, incident open) when zero-click
+  matters most.
+- The BM25 index exists and is exposed over MCP for LLM clients, but a human
+  has no search interface at all beyond GitHub code search over markdown.
+- The KB PR reviewer — the human who pays the curation cost — gets no context
+  to judge "is this a duplicate? what do we already know about this?".
+
+This is also an adoption problem: the README's core promise is "it remembers
+what it learns", but no human-visible moment ever demonstrates the memory
+working. The humans who review and merge KB PRs never see the dividends.
+
+## Scope
+
+Three independent features, one PR each (parallel worktrees):
+
+1. **"Seen before" block in notifications** — inline prior cause/resolution on
+   recurring incidents.
+2. **`lore kb search` / `lore kb show`** — human CLI over the existing index.
+3. **"Related knowledge" section in drafted KB PRs** — reviewer context.
+
+Out of scope (deliberately): Slack slash command, web UI, periodic digest.
+These serve personas (cold-exploration engineer, lead) not prioritized in this
+round, and each drags new surface area (exposed HTTP endpoint, authn). Revisit
+after the three features above land.
+
+## Feature 1 — "Seen before" block in notifications
+
+### Data source decision
+
+**Chosen: catalog lookup by fingerprint at delivery time.**
+
+- The outcome ledger already stamps each `open` with the incident's
+  `DupFingerprint`; curated entries carry the same fingerprint in their YAML
+  frontmatter (`catalog.Entry.Fingerprint`).
+- At delivery, a merged entry found by that fingerprint reflects the
+  **human-edited resolution** added at review time — which is precisely the
+  value curation adds. A ledger-denormalized snapshot (rejected) would freeze
+  the model's pre-review prose; a forge fetch (rejected) puts a network call
+  and rate limits on the delivery path.
+
+### Components
+
+- `catalog.Entry.Section(name string) string` — extract the first paragraph of
+  a `## <name>` markdown section from the entry body, truncated (~300 chars).
+  Returns `""` on missing/malformed sections. Shared by features 1 and (test
+  fixtures aside) reusable anywhere entry bodies are summarized.
+- `Catalog.ByFingerprint(fp string) (*Entry, bool)` — O(1) map built during
+  indexing (fingerprint is already parsed from frontmatter), rebuilt with the
+  index on git-sync. Entries without a fingerprint are simply absent.
+- `providers.PriorKnowledge` struct on `Investigation`:
+  `{Count int, LastSeen time.Time, Cause string, Resolution string,
+  EntryURL string, PrevLink string, ResolveRate string}`.
+
+### Flow (at `OnComplete`, where recurrence facts are already stamped)
+
+1. Incident is recurring (`Occurrences() >= 2` for its trigger key) → its
+   `DupFingerprint` is already computed for the ledger open.
+2. `catalog.ByFingerprint(fp)` hit → fill `PriorKnowledge` with
+   `Section("Cause")`, `Section("Resolution")`, the entry URL, and the
+   resolve-rate from `OpenCounts()`.
+3. No merged entry (PR still open, or entry lacks a fingerprint) → fill only
+   `Count/LastSeen/PrevLink` — same information as today, rendered in the new
+   block.
+4. Merged entry found but both sections empty/malformed → treat as case 3
+   (never render an empty knowledge block).
+
+### Rendering
+
+- Block: `📚 Seen before ×N · last seen <relative date>` + 2–3 lines of prior
+  cause and resolution + entry link + resolve-rate.
+- Placement: directly under the verdict/title, **before** the current root
+  cause — history frames how the reader interprets what follows.
+- Surfaces: Slack blocks (channel message, not the thread — this is the
+  zero-click information) **and** `notify.Format` (so Matrix/webhook carry it
+  too). The existing mrkdwn-escape invariant applies: no `&`, `<`, `>` in
+  `Format` scaffolding; all model/entry strings escaped in Slack blocks.
+- **Recall path excluded**: a recalled answer already presents the KB entry;
+  the block applies only to *fresh* investigations of a recurring trigger.
+- **Best-effort**: any lookup/parse error degrades to the counter+link form or
+  drops the block; it must never fail or delay delivery.
+
+## Feature 2 — `lore kb search` / `lore kb show`
+
+New CLI namespace `lore kb` — the human *read* surface. The existing
+`lore catalog sync` (a machine/ops write operation) is untouched.
+
+- `lore kb search "<query>" [--config <path>] [-k 10] [--json] [--ledger <path>]`
+  - Loads the catalog the same way `lore mcp`/`BuildCatalog` does (local dir
+    or git clone per config), runs the same BM25 search the agent uses.
+  - Output: aligned text table — `SCORE · ENTRY · TITLE · RESOURCE · LAST
+    SEEN`. `LAST SEEN` derives from the entry's `timestamp` frontmatter
+    (blank when absent). `--json` emits the hits as JSON for scripting.
+  - `--ledger <jsonl>`: the outcome ledger lives in-cluster, not on
+    workstations, so resolve-rate is opt-in — when the flag points at a
+    readable ledger file, a `RESOLVE` column (e.g. `3/3`) is added via
+    `OpenCounts()`; otherwise the column is omitted entirely.
+- `lore kb show <entry>` — full entry: frontmatter card then markdown body.
+  Argument is a path or slug; if no exact match, fall back to a search — a
+  unique hit is shown, multiple hits are listed as disambiguation.
+- Constraints: stdlib only (no table/color deps); ANSI color only when stdout
+  is a TTY; exit non-zero on no results (scripting-friendly).
+
+Side benefit: a 30-second demo path for adopters —
+`git clone <their-kb> && lore kb search "oom"`.
+
+## Feature 3 — "Related knowledge" section in drafted KB PRs
+
+At draft time the curator **already runs** a BM25 search for dedup; its hits
+are currently discarded after the duplicate check. Reuse them:
+
+- Append a `## Related knowledge` section to the **PR body** (not the entry
+  file): the top 3–5 nearest entries as linked titles with score and resource,
+  plus — when the trigger is recurring — one line of history via
+  `Occurrences()`: `Trigger seen ×N · previous entry: <link>`.
+- Rendered below the existing fingerprint marker, same mechanics as the
+  decision card.
+- Omitted entirely when no hit clears a score floor (no noise on genuinely
+  novel incidents).
+- `kbvalidate` is unaffected: the section lives in the PR body; the merged
+  entry file is unchanged.
+
+## Error handling (cross-cutting)
+
+Every feature is best-effort relative to its host path:
+
+- Feature 1: lookup/parse failure → degrade to counter+link or omit; delivery
+  never blocks.
+- Feature 2: unreadable catalog/config → clear error message, non-zero exit;
+  unreadable `--ledger` → warn and omit the column.
+- Feature 3: search failure at draft time → section omitted; the PR still
+  opens.
+
+## Testing
+
+- `Section()`: table-driven over malformed/missing/nested-heading fixtures.
+- `ByFingerprint`: absent fingerprint, duplicate fingerprints (last-indexed
+  wins, deterministically), rebuild-on-sync.
+- Notification: Slack block rendering with the escape invariant
+  (`TestSlackMessageFallbackEscaped` pattern), `Format` output for
+  Matrix/webhook, recall-path exclusion, fallback cases.
+- CLI: golden-output tests over a fixture catalog; `--json` schema; ledger
+  present/absent.
+- Curator: golden PR-body tests with/without related hits and recurrence.
+
+## Sequencing
+
+Three independent PRs from parallel worktrees. The shared `Section()` helper
+ships in the Feature 1 PR (Feature 3 uses entry titles/links only, so there is
+no cross-PR dependency; if that changes, extract `Section()` as a tiny base
+PR).

--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -247,8 +247,33 @@ func shortFP(fp string) string {
 	return fp
 }
 
-// writeHitsJSON is implemented in Task 4 of the plan.
-func writeHitsJSON(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate) error { //nolint:revive // hits/counts kept: Task 4 replaces this stub with the real signature
-	_ = json.NewEncoder(w)
-	return fmt.Errorf("kb search --json: not implemented yet")
+// kbHit is the machine-readable search result (the CLI counterpart of the
+// kb_search MCP tool's hit shape, plus the optional ledger track record).
+type kbHit struct {
+	Path        string   `json:"path"`
+	Type        string   `json:"type,omitempty"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Resource    string   `json:"resource,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Score       float64  `json:"score"`
+	LastSeen    string   `json:"last_seen,omitempty"` // frontmatter timestamp, RFC3339
+	Recalls     int      `json:"recalls,omitempty"`
+	Resolved    int      `json:"resolved,omitempty"`
+}
+
+func writeHitsJSON(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate) error {
+	out := make([]kbHit, 0, len(hits))
+	for _, h := range hits {
+		agg := counts[h.Entry.Path]
+		out = append(out, kbHit{
+			Path: h.Entry.Path, Type: h.Entry.Type, Title: h.Entry.Title,
+			Description: h.Entry.Description, Resource: h.Entry.Resource, Tags: h.Entry.Tags,
+			Score: h.Score, LastSeen: h.Entry.Timestamp,
+			Recalls: agg.Recalls, Resolved: agg.Resolved,
+		})
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
 }

--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/outcome"
+)
+
+// RunKB dispatches the human-facing knowledge-base read commands. `lore catalog
+// sync` remains the machine/ops write surface; `lore kb` is how a person asks
+// "what do we already know about this?" without an MCP client or a cluster.
+func RunKB(args []string) error {
+	const usage = "usage: lore kb search <query> [flags] | lore kb show <entry> [flags]"
+	if len(args) == 0 {
+		return fmt.Errorf("%s", usage)
+	}
+	switch args[0] {
+	case "search":
+		return runKBSearch(args[1:], os.Stdout)
+	case "show":
+		return runKBShow(args[1:], os.Stdout)
+	}
+	return fmt.Errorf("unknown kb subcommand %q\n%s", args[0], usage)
+}
+
+// loadKBCatalog opens the catalog for the read commands: an explicit --dir
+// wins; otherwise config catalog.dir. The CLI never clones — a git-synced
+// catalog is materialized by `lore catalog sync` (or a running agent), so the
+// error message points there instead of failing cryptically.
+func loadKBCatalog(cfgPath, dir string) (*catalog.Catalog, error) {
+	if dir == "" {
+		cfg, err := config.Load(cfgPath)
+		if err != nil {
+			return nil, fmt.Errorf("load config: %w (or pass --dir <catalog>)", err)
+		}
+		dir = cfg.Catalog.Dir
+		if dir == "" {
+			return nil, fmt.Errorf("no catalog configured (set catalog.dir or pass --dir <catalog>)")
+		}
+	}
+	cat, err := catalog.New(dir)
+	if err != nil {
+		return nil, fmt.Errorf("load catalog %s: %w (for a git-synced catalog, run `lore catalog sync` first)", dir, err)
+	}
+	if cat.Len() == 0 {
+		return nil, fmt.Errorf("catalog %s has no entries (for a git-synced catalog, run `lore catalog sync` first)", dir)
+	}
+	return cat, nil
+}
+
+func runKBSearch(args []string, w io.Writer) error {
+	fs := flag.NewFlagSet("kb search", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	dir := fs.String("dir", "", "catalog directory (overrides config catalog.dir)")
+	k := fs.Int("k", 10, "maximum results")
+	asJSON := fs.Bool("json", false, "emit results as JSON")
+	ledgerPath := fs.String("ledger", "", "outcome ledger JSONL; adds the RESOLVE column")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	query := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if query == "" {
+		return fmt.Errorf("usage: lore kb search <query> [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]")
+	}
+	cat, err := loadKBCatalog(*cfgPath, *dir)
+	if err != nil {
+		return err
+	}
+	hits, err := cat.SearchScored(query, *k)
+	if err != nil {
+		return err
+	}
+	if len(hits) == 0 {
+		return fmt.Errorf("no entries match %q", query)
+	}
+	counts := ledgerCounts(*ledgerPath, w)
+	if *asJSON {
+		return writeHitsJSON(w, hits, counts)
+	}
+	writeHitsTable(w, hits, counts, *ledgerPath != "")
+	return nil
+}
+
+// ledgerCounts loads per-entry recall/resolve aggregates from an optional
+// ledger file. The ledger lives in-cluster, so this is opt-in for humans who
+// copied it locally; a missing/unreadable file warns and omits the column —
+// never fails the search, and never CREATES the file (outcome.New would).
+func ledgerCounts(path string, w io.Writer) map[string]outcome.Aggregate {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		_, _ = fmt.Fprintf(w, "warning: ledger %s unreadable (%v); RESOLVE column omitted\n", path, err)
+		return nil
+	}
+	l, err := outcome.New(path)
+	if err != nil {
+		_, _ = fmt.Fprintf(w, "warning: ledger %s unreadable (%v); RESOLVE column omitted\n", path, err)
+		return nil
+	}
+	counts, _ := l.OpenCounts() // documented always-nil error
+	return counts
+}
+
+func writeHitsTable(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate, withResolve bool) {
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	head := "SCORE\tENTRY\tTITLE\tRESOURCE\tLAST SEEN"
+	if withResolve {
+		head += "\tRESOLVE"
+	}
+	_, _ = fmt.Fprintln(tw, head)
+	for _, h := range hits {
+		row := fmt.Sprintf("%.2f\t%s\t%s\t%s\t%s",
+			h.Score, h.Entry.Path, truncateCell(h.Entry.Title, 60), h.Entry.Resource, relAge(h.Entry.Timestamp))
+		if withResolve {
+			// Resolve-rate is "resolved/recalled" per catalog entry; "-" for an
+			// entry the ledger has never seen recalled.
+			if agg := counts[h.Entry.Path]; agg.Recalls > 0 {
+				row += fmt.Sprintf("\t%d/%d", agg.Resolved, agg.Recalls)
+			} else {
+				row += "\t-"
+			}
+		}
+		_, _ = fmt.Fprintln(tw, row)
+	}
+	_ = tw.Flush()
+}
+
+// truncateCell keeps table rows scannable: cap a free-text cell at maxLen runes.
+func truncateCell(s string, maxLen int) string {
+	r := []rune(s)
+	if len(r) <= maxLen {
+		return s
+	}
+	return strings.TrimRight(string(r[:maxLen]), " ") + "…"
+}
+
+// relAge renders an entry's RFC3339 timestamp as a coarse relative age ("12d
+// ago") — what a human scans for ("is this knowledge fresh?"). "" for absent,
+// malformed, or future timestamps (hand-written entries carry none).
+func relAge(ts string) string {
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return ""
+	}
+	d := time.Since(t)
+	switch {
+	case d < 0:
+		return ""
+	case d < time.Hour:
+		return fmt.Sprintf("%dm ago", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
+	}
+}
+
+// runKBShow is implemented in Task 2 of the plan.
+func runKBShow(args []string, w io.Writer) error { //nolint:revive // args kept: Task 2 replaces this stub with the real signature
+	return fmt.Errorf("kb show: not implemented yet")
+}
+
+// writeHitsJSON is implemented in Task 4 of the plan.
+func writeHitsJSON(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate) error { //nolint:revive // hits/counts kept: Task 4 replaces this stub with the real signature
+	_ = json.NewEncoder(w)
+	return fmt.Errorf("kb search --json: not implemented yet")
+}

--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -64,19 +64,32 @@ func loadKBCatalog(cfgPath, dir string) (*catalog.Catalog, error) {
 // the reverse, and the usage strings promise both. Each round parses what it
 // can, peels one positional, and re-parses the rest; returned positionals
 // preserve their order.
+// A bare `--` is the flag terminator: once seen, everything after it is a
+// literal positional argument (never re-parsed as a flag), so a query like
+// `-k` can be searched for literally with `lore kb search -- -k`.
 func parseInterleaved(fs *flag.FlagSet, args []string) ([]string, error) {
+	head := args
+	var tail []string
+	for i, a := range args {
+		if a == "--" {
+			head = args[:i]
+			tail = args[i+1:]
+			break
+		}
+	}
 	var positional []string
 	for {
-		if err := fs.Parse(args); err != nil {
+		if err := fs.Parse(head); err != nil {
 			return nil, err
 		}
-		args = fs.Args()
-		if len(args) == 0 {
-			return positional, nil
+		head = fs.Args()
+		if len(head) == 0 {
+			break
 		}
-		positional = append(positional, args[0])
-		args = args[1:]
+		positional = append(positional, head[0])
+		head = head[1:]
 	}
+	return append(positional, tail...), nil
 }
 
 func runKBSearch(args []string, w io.Writer) error {
@@ -92,7 +105,7 @@ func runKBSearch(args []string, w io.Writer) error {
 	}
 	query := strings.TrimSpace(strings.Join(rest, " "))
 	if query == "" {
-		return fmt.Errorf("usage: lore kb search <query> [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]")
+		return fmt.Errorf("usage: lore kb search <query> [--config <path>] [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]")
 	}
 	cat, err := loadKBCatalog(*cfgPath, *dir)
 	if err != nil {
@@ -105,7 +118,7 @@ func runKBSearch(args []string, w io.Writer) error {
 	if len(hits) == 0 {
 		return fmt.Errorf("no entries match %q", query)
 	}
-	counts := ledgerCounts(*ledgerPath, w)
+	counts := ledgerCounts(*ledgerPath, os.Stderr)
 	if *asJSON {
 		return writeHitsJSON(w, hits, counts)
 	}
@@ -115,23 +128,24 @@ func runKBSearch(args []string, w io.Writer) error {
 
 // ledgerCounts loads per-entry recall/resolve aggregates from an optional
 // ledger file. The ledger lives in-cluster, so this is opt-in for humans who
-// copied it locally; a missing/unreadable file warns and omits the column —
-// never fails the search, and never CREATES the file (outcome.New would).
-func ledgerCounts(path string, w io.Writer) map[string]outcome.Aggregate {
+// copied it locally; a missing/unreadable file warns (to warn — kept off the
+// results stream so --json stays clean) and omits the column — never fails
+// the search, and never CREATES the file (outcome.New would).
+func ledgerCounts(path string, warn io.Writer) map[string]outcome.Aggregate {
 	if path == "" {
 		return nil
 	}
+	var openErr error
 	if _, err := os.Stat(path); err != nil {
-		_, _ = fmt.Fprintf(w, "warning: ledger %s unreadable (%v); RESOLVE column omitted\n", path, err)
-		return nil
+		openErr = err
+	} else if l, err := outcome.New(path); err != nil {
+		openErr = err
+	} else {
+		counts, _ := l.OpenCounts() // documented always-nil error
+		return counts
 	}
-	l, err := outcome.New(path)
-	if err != nil {
-		_, _ = fmt.Fprintf(w, "warning: ledger %s unreadable (%v); RESOLVE column omitted\n", path, err)
-		return nil
-	}
-	counts, _ := l.OpenCounts() // documented always-nil error
-	return counts
+	_, _ = fmt.Fprintf(warn, "warning: ledger %s unreadable (%v); RESOLVE column omitted\n", path, openErr)
+	return nil
 }
 
 func writeHitsTable(w io.Writer, hits []catalog.ScoredEntry, counts map[string]outcome.Aggregate, withResolve bool) {
@@ -203,14 +217,17 @@ func runKBShow(args []string, w io.Writer) error {
 	}
 	arg := strings.TrimSpace(strings.Join(rest, " "))
 	if arg == "" {
-		return fmt.Errorf("usage: lore kb show <entry-path | filename | query> [--dir <catalog>]")
+		return fmt.Errorf("usage: lore kb show <entry-path | filename | query> [--config <path>] [--dir <catalog>]")
 	}
 	cat, err := loadKBCatalog(*cfgPath, *dir)
 	if err != nil {
 		return err
 	}
-	e, ok := findEntry(cat, arg)
+	e, candidates, ok := findEntry(cat, arg)
 	if !ok {
+		if len(candidates) > 1 {
+			return fmt.Errorf("ambiguous entry %q; candidates:\n%s", arg, renderCandidates(candidates))
+		}
 		hits, serr := cat.SearchScored(arg, 5)
 		if serr != nil {
 			return serr
@@ -221,11 +238,11 @@ func runKBShow(args []string, w io.Writer) error {
 		case 1:
 			e = hits[0].Entry
 		default:
-			var b strings.Builder
-			for _, h := range hits {
-				_, _ = fmt.Fprintf(&b, "  %s — %s\n", h.Entry.Path, h.Entry.Title)
+			entries := make([]catalog.Entry, len(hits))
+			for i, h := range hits {
+				entries[i] = h.Entry
 			}
-			return fmt.Errorf("no exact match for %q; candidates:\n%s", arg, strings.TrimRight(b.String(), "\n"))
+			return fmt.Errorf("no exact match for %q; candidates:\n%s", arg, renderCandidates(entries))
 		}
 	}
 	writeEntry(w, e)
@@ -233,15 +250,35 @@ func runKBShow(args []string, w io.Writer) error {
 }
 
 // findEntry matches by exact bundle-relative path, then by bare filename (with
-// or without the .md suffix).
-func findEntry(cat *catalog.Catalog, arg string) (catalog.Entry, bool) {
+// or without the .md suffix). An exact path match wins immediately — paths are
+// unique. Basename matches are collected in full: exactly one is an
+// unambiguous hit, but two or more (e.g. incidents/foo.md and
+// runbooks/foo.md) are ambiguous — the caller renders them as candidates
+// instead of the command silently guessing the first one found.
+func findEntry(cat *catalog.Catalog, arg string) (e catalog.Entry, candidates []catalog.Entry, ok bool) {
 	base := strings.TrimSuffix(arg, ".md")
 	for _, e := range cat.Entries() {
-		if e.Path == arg || strings.TrimSuffix(filepath.Base(e.Path), ".md") == base {
-			return e, true
+		if e.Path == arg {
+			return e, nil, true
+		}
+		if strings.TrimSuffix(filepath.Base(e.Path), ".md") == base {
+			candidates = append(candidates, e)
 		}
 	}
-	return catalog.Entry{}, false
+	if len(candidates) == 1 {
+		return candidates[0], nil, true
+	}
+	return catalog.Entry{}, candidates, false
+}
+
+// renderCandidates formats a disambiguation list ("  path — title" per
+// entry), shared by the search-fallback and basename-collision pickers.
+func renderCandidates(entries []catalog.Entry) string {
+	var b strings.Builder
+	for _, e := range entries {
+		_, _ = fmt.Fprintf(&b, "  %s — %s\n", e.Path, e.Title)
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // writeEntry prints the frontmatter card then the markdown body — the same

--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -165,9 +166,85 @@ func relAge(ts string) string {
 	}
 }
 
-// runKBShow is implemented in Task 2 of the plan.
-func runKBShow(args []string, w io.Writer) error { //nolint:revive // args kept: Task 2 replaces this stub with the real signature
-	return fmt.Errorf("kb show: not implemented yet")
+// runKBShow prints one entry in full: the frontmatter card, then the body. The
+// argument is a bundle-relative path or a bare filename; when neither matches
+// exactly, a search fallback accepts a UNIQUE hit and otherwise lists the
+// candidates instead of guessing — showing the wrong runbook is worse than
+// asking the human to pick.
+func runKBShow(args []string, w io.Writer) error {
+	fs := flag.NewFlagSet("kb show", flag.ContinueOnError)
+	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	dir := fs.String("dir", "", "catalog directory (overrides config catalog.dir)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	arg := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if arg == "" {
+		return fmt.Errorf("usage: lore kb show <entry-path | filename | query> [--dir <catalog>]")
+	}
+	cat, err := loadKBCatalog(*cfgPath, *dir)
+	if err != nil {
+		return err
+	}
+	e, ok := findEntry(cat, arg)
+	if !ok {
+		hits, serr := cat.SearchScored(arg, 5)
+		if serr != nil {
+			return serr
+		}
+		switch len(hits) {
+		case 0:
+			return fmt.Errorf("no entry matches %q", arg)
+		case 1:
+			e = hits[0].Entry
+		default:
+			var b strings.Builder
+			for _, h := range hits {
+				_, _ = fmt.Fprintf(&b, "  %s — %s\n", h.Entry.Path, h.Entry.Title)
+			}
+			return fmt.Errorf("no exact match for %q; candidates:\n%s", arg, strings.TrimRight(b.String(), "\n"))
+		}
+	}
+	writeEntry(w, e)
+	return nil
+}
+
+// findEntry matches by exact bundle-relative path, then by bare filename (with
+// or without the .md suffix).
+func findEntry(cat *catalog.Catalog, arg string) (catalog.Entry, bool) {
+	base := strings.TrimSuffix(arg, ".md")
+	for _, e := range cat.Entries() {
+		if e.Path == arg || strings.TrimSuffix(filepath.Base(e.Path), ".md") == base {
+			return e, true
+		}
+	}
+	return catalog.Entry{}, false
+}
+
+// writeEntry prints the frontmatter card then the markdown body — the same
+// information a reviewer sees on the file, without leaving the terminal.
+func writeEntry(w io.Writer, e catalog.Entry) {
+	_, _ = fmt.Fprintf(w, "# %s\n\n", e.Title)
+	card := [][2]string{
+		{"path", e.Path}, {"type", e.Type}, {"description", e.Description},
+		{"resource", e.Resource}, {"tags", strings.Join(e.Tags, ", ")},
+		{"last seen", relAge(e.Timestamp)}, {"fingerprint", shortFP(e.Fingerprint)},
+	}
+	for _, kv := range card {
+		if kv[1] != "" {
+			_, _ = fmt.Fprintf(w, "%s: %s\n", kv[0], kv[1])
+		}
+	}
+	_, _ = fmt.Fprintf(w, "\n%s\n", strings.TrimSpace(e.Body))
+}
+
+// shortFP abbreviates the 64-hex dup fingerprint for display; identity checks
+// belong to machines, humans only need "has one / which one roughly".
+func shortFP(fp string) string {
+	if len(fp) > 12 {
+		return fp[:12] + "…"
+	}
+	return fp
 }
 
 // writeHitsJSON is implemented in Task 4 of the plan.

--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -58,6 +58,27 @@ func loadKBCatalog(cfgPath, dir string) (*catalog.Catalog, error) {
 	return cat, nil
 }
 
+// parseInterleaved parses fs against args while tolerating positionals BEFORE
+// flags — stdlib flag stops at the first non-flag token, but a human types
+// `lore kb search "crashloop web" --dir ./kb` (query first) as naturally as
+// the reverse, and the usage strings promise both. Each round parses what it
+// can, peels one positional, and re-parses the rest; returned positionals
+// preserve their order.
+func parseInterleaved(fs *flag.FlagSet, args []string) ([]string, error) {
+	var positional []string
+	for {
+		if err := fs.Parse(args); err != nil {
+			return nil, err
+		}
+		args = fs.Args()
+		if len(args) == 0 {
+			return positional, nil
+		}
+		positional = append(positional, args[0])
+		args = args[1:]
+	}
+}
+
 func runKBSearch(args []string, w io.Writer) error {
 	fs := flag.NewFlagSet("kb search", flag.ContinueOnError)
 	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
@@ -65,10 +86,11 @@ func runKBSearch(args []string, w io.Writer) error {
 	k := fs.Int("k", 10, "maximum results")
 	asJSON := fs.Bool("json", false, "emit results as JSON")
 	ledgerPath := fs.String("ledger", "", "outcome ledger JSONL; adds the RESOLVE column")
-	if err := fs.Parse(args); err != nil {
+	rest, err := parseInterleaved(fs, args)
+	if err != nil {
 		return err
 	}
-	query := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	query := strings.TrimSpace(strings.Join(rest, " "))
 	if query == "" {
 		return fmt.Errorf("usage: lore kb search <query> [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]")
 	}
@@ -175,10 +197,11 @@ func runKBShow(args []string, w io.Writer) error {
 	fs := flag.NewFlagSet("kb show", flag.ContinueOnError)
 	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
 	dir := fs.String("dir", "", "catalog directory (overrides config catalog.dir)")
-	if err := fs.Parse(args); err != nil {
+	rest, err := parseInterleaved(fs, args)
+	if err != nil {
 		return err
 	}
-	arg := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	arg := strings.TrimSpace(strings.Join(rest, " "))
 	if arg == "" {
 		return fmt.Errorf("usage: lore kb show <entry-path | filename | query> [--dir <catalog>]")
 	}

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -219,16 +219,99 @@ func TestKBShowFlagsAfterArg(t *testing.T) {
 func TestKBSearchLedgerMissingWarnsAndOmits(t *testing.T) {
 	dir := writeKBFixture(t)
 	missing := filepath.Join(t.TempDir(), "nope.jsonl")
+
+	// The warning itself is exercised directly against ledgerCounts's warn
+	// writer — the seam that keeps it off stdout/the JSON stream.
+	var warn strings.Builder
+	if counts := ledgerCounts(missing, &warn); counts != nil {
+		t.Errorf("missing ledger must yield nil counts, got %+v", counts)
+	}
+	if !strings.Contains(warn.String(), "warning: ledger") {
+		t.Errorf("missing warning line:\n%s", warn.String())
+	}
+	// Stat-before-open: the warning path must not have created the file.
+	if _, err := os.Stat(missing); err == nil {
+		t.Error("--ledger must never create the ledger file")
+	}
+
+	// Through the search path, stdout (w) carries ONLY the table — no warning
+	// text mixed in; diagnostics go to stderr instead.
 	var out strings.Builder
 	if err := runKBSearch([]string{"--dir", dir, "--ledger", missing, "crashloop"}, &out); err != nil {
 		t.Fatalf("a missing ledger must not fail the search: %v", err)
 	}
 	got := out.String()
-	if !strings.Contains(got, "warning: ledger") {
-		t.Errorf("missing warning line:\n%s", got)
+	if strings.Contains(got, "warning:") {
+		t.Errorf("stdout must not contain the ledger warning:\n%s", got)
 	}
-	// Stat-before-open: the warning path must not have created the file.
-	if _, err := os.Stat(missing); err == nil {
-		t.Error("--ledger must never create the ledger file")
+	if !strings.Contains(got, "SCORE") {
+		t.Errorf("stdout must still contain the results table:\n%s", got)
+	}
+
+	// --json must be a clean stream: nothing before the opening bracket.
+	var jsonOut strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--json", "--ledger", missing, "crashloop"}, &jsonOut); err != nil {
+		t.Fatalf("--json with a missing ledger must not fail: %v", err)
+	}
+	jsonGot := jsonOut.String()
+	if trimmed := strings.TrimLeft(jsonGot, " \t\n"); !strings.HasPrefix(trimmed, "[") {
+		t.Errorf("--json output must start with '[' (no warning text mixed in):\n%s", jsonGot)
+	}
+	var hits []map[string]any
+	if err := json.Unmarshal([]byte(jsonGot), &hits); err != nil {
+		t.Fatalf("output is not a clean JSON array: %v\n%s", err, jsonGot)
+	}
+}
+
+// The usage strings promise both orders around `--`; a literal `--` must stop
+// flag parsing for good, so a query token that looks like a flag (e.g. "-k")
+// stays a literal search term instead of colliding with -k/--json/etc.
+func TestKBSearchDashDashTerminator(t *testing.T) {
+	dir := writeKBFixture(t)
+
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--", "crashloop"}, &out); err != nil {
+		t.Fatalf("post-`--` query must parse: %v", err)
+	}
+	if !strings.Contains(out.String(), "incidents/crashloop-web.md") {
+		t.Errorf("expected hit missing:\n%s", out.String())
+	}
+
+	var out2 strings.Builder
+	err := runKBSearch([]string{"--dir", dir, "--", "-k"}, &out2)
+	if err == nil {
+		t.Fatal("want the no-match error for literal query \"-k\", not a flag parse")
+	}
+	if !strings.Contains(err.Error(), `no entries match "-k"`) {
+		t.Errorf("want the literal no-match error, got: %v", err)
+	}
+}
+
+// findEntry must not silently guess between two entries sharing a basename —
+// runKBShow should surface both candidates instead of picking the first one.
+func TestKBShowAmbiguousBasename(t *testing.T) {
+	dir := t.TempDir()
+	entries := map[string]string{
+		"incidents/foo.md": "---\ntype: Incident\ntitle: Foo from incidents\n---\nbody\n",
+		"runbooks/foo.md":  "---\ntype: Runbook\ntitle: Foo from runbooks\n---\nbody\n",
+	}
+	for path, content := range entries {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out strings.Builder
+	err := runKBShow([]string{"--dir", dir, "foo"}, &out)
+	if err == nil {
+		t.Fatal("want a disambiguation error for a duplicate basename")
+	}
+	for _, want := range []string{"incidents/foo.md", "runbooks/foo.md"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("candidates must list %q:\n%v", want, err)
+		}
 	}
 }

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,6 +164,31 @@ func TestKBSearchLedgerResolveColumn(t *testing.T) {
 	}
 	if !strings.Contains(got, "1/2") {
 		t.Errorf("resolve-rate 1/2 missing:\n%s", got)
+	}
+}
+
+func TestKBSearchJSON(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--json", "crashloop", "web"}, &out); err != nil {
+		t.Fatalf("runKBSearch --json: %v", err)
+	}
+	var hits []struct {
+		Path     string  `json:"path"`
+		Type     string  `json:"type"`
+		Title    string  `json:"title"`
+		Resource string  `json:"resource"`
+		Score    float64 `json:"score"`
+		LastSeen string  `json:"last_seen"`
+	}
+	if err := json.Unmarshal([]byte(out.String()), &hits); err != nil {
+		t.Fatalf("output is not a JSON array: %v\n%s", err, out.String())
+	}
+	if len(hits) == 0 || hits[0].Path != "incidents/crashloop-web.md" {
+		t.Fatalf("unexpected hits: %+v", hits)
+	}
+	if hits[0].Score <= 0 || hits[0].Type != "Incident" || hits[0].Resource != "apps/web" {
+		t.Errorf("hit fields not mapped: %+v", hits[0])
 	}
 }
 

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -192,6 +192,30 @@ func TestKBSearchJSON(t *testing.T) {
 	}
 }
 
+// The usage strings promise query-first invocations; stdlib flag alone would
+// silently swallow trailing flags into the query.
+func TestKBSearchFlagsAfterQuery(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBSearch([]string{"crashloop", "web", "--dir", dir}, &out); err != nil {
+		t.Fatalf("flags after query must parse: %v", err)
+	}
+	if !strings.Contains(out.String(), "incidents/crashloop-web.md") {
+		t.Errorf("expected hit missing:\n%s", out.String())
+	}
+}
+
+func TestKBShowFlagsAfterArg(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBShow([]string{"crashloop-web", "--dir", dir}, &out); err != nil {
+		t.Fatalf("flags after arg must parse: %v", err)
+	}
+	if !strings.Contains(out.String(), "CrashLoop web ConfigMap truncated") {
+		t.Errorf("expected entry missing:\n%s", out.String())
+	}
+}
+
 func TestKBSearchLedgerMissingWarnsAndOmits(t *testing.T) {
 	dir := writeKBFixture(t)
 	missing := filepath.Join(t.TempDir(), "nope.jsonl")

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -1,0 +1,98 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeKBFixture materializes a small OKF catalog: two entries whose lexical
+// overlap with the test queries is deliberately asymmetric.
+func writeKBFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	ts := time.Now().Add(-12 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	entries := map[string]string{
+		"incidents/crashloop-web.md": "---\ntype: Incident\ntitle: CrashLoop web ConfigMap truncated\ndescription: web pods crashloop after kustomize bump\nresource: apps/web\ntags: [runlore, incident]\ntimestamp: \"" + ts + "\"\n---\n## Cause\n\nConfigMap truncated\n\n## Resolution\n\nrevert the patch\n",
+		"incidents/oom-worker.md":    "---\ntype: Incident\ntitle: OOM worker limits too low\ndescription: worker OOMKilled under load\nresource: apps/worker\n---\n## Cause\n\nlimits too low\n",
+	}
+	for path, content := range entries {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestKBSearchTable(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	err := runKBSearch([]string{"--dir", dir, "crashloop", "web", "configmap"}, &out)
+	if err != nil {
+		t.Fatalf("runKBSearch: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"SCORE", "ENTRY", "TITLE", "RESOURCE", "LAST SEEN",
+		"incidents/crashloop-web.md", "apps/web", "12d ago"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("table missing %q:\n%s", want, got)
+		}
+	}
+	// The lexically-distant entry may or may not appear, but the best match must
+	// be the FIRST data row.
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) < 2 || !strings.Contains(lines[1], "crashloop-web") {
+		t.Errorf("best hit is not the first row:\n%s", got)
+	}
+	// No RESOLVE column without --ledger.
+	if strings.Contains(got, "RESOLVE") {
+		t.Errorf("RESOLVE column must be absent without --ledger:\n%s", got)
+	}
+}
+
+func TestKBSearchNoResultsIsError(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "zzz-nothing-matches-this"}, &out); err == nil {
+		t.Fatal("want error on zero hits (non-zero exit for scripting)")
+	}
+}
+
+func TestKBSearchUsageErrors(t *testing.T) {
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", t.TempDir()}, &out); err == nil {
+		t.Fatal("want usage error when the query is empty")
+	}
+	if err := RunKB([]string{"frobnicate"}); err == nil {
+		t.Fatal("want usage error on unknown subcommand")
+	}
+	if err := RunKB(nil); err == nil {
+		t.Fatal("want usage error with no subcommand")
+	}
+}
+
+func TestRelAge(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		ts   string
+		want string
+	}{
+		{now.Add(-30 * time.Minute).Format(time.RFC3339), "30m ago"},
+		{now.Add(-5 * time.Hour).Format(time.RFC3339), "5h ago"},
+		{now.Add(-26 * time.Hour).Format(time.RFC3339), "1d ago"},
+		{"", ""},           // hand-written entry without a timestamp
+		{"not-a-date", ""}, // malformed
+		{now.Add(time.Hour).Format(time.RFC3339), ""}, // future: clock skew, say nothing
+	}
+	for _, c := range cases {
+		if got := relAge(c.ts); got != c.want {
+			t.Errorf("relAge(%q) = %q, want %q", c.ts, got, c.want)
+		}
+	}
+}

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Smana/runlore/internal/outcome"
 )
 
 // writeKBFixture materializes a small OKF catalog: two entries whose lexical
@@ -127,5 +129,56 @@ func TestRelAge(t *testing.T) {
 		if got := relAge(c.ts); got != c.want {
 			t.Errorf("relAge(%q) = %q, want %q", c.ts, got, c.want)
 		}
+	}
+}
+
+func TestKBSearchLedgerResolveColumn(t *testing.T) {
+	dir := writeKBFixture(t)
+	// Build a real ledger: the crashloop entry was recalled twice, resolved once.
+	ledgerPath := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	l, err := outcome.New(ledgerPath)
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	rv := true
+	for _, fp := range []string{"a", "b"} {
+		if err := l.Open(outcome.Event{
+			Fingerprint: fp, Kind: "recall", Entry: "incidents/crashloop-web.md",
+			Resolvable: &rv, At: time.Now().Add(-time.Hour),
+		}); err != nil {
+			t.Fatalf("seed open: %v", err)
+		}
+	}
+	if _, _, err := l.Resolve("a", time.Now()); err != nil {
+		t.Fatalf("seed resolve: %v", err)
+	}
+
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--ledger", ledgerPath, "crashloop", "web"}, &out); err != nil {
+		t.Fatalf("runKBSearch: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "RESOLVE") {
+		t.Errorf("RESOLVE header missing:\n%s", got)
+	}
+	if !strings.Contains(got, "1/2") {
+		t.Errorf("resolve-rate 1/2 missing:\n%s", got)
+	}
+}
+
+func TestKBSearchLedgerMissingWarnsAndOmits(t *testing.T) {
+	dir := writeKBFixture(t)
+	missing := filepath.Join(t.TempDir(), "nope.jsonl")
+	var out strings.Builder
+	if err := runKBSearch([]string{"--dir", dir, "--ledger", missing, "crashloop"}, &out); err != nil {
+		t.Fatalf("a missing ledger must not fail the search: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "warning: ledger") {
+		t.Errorf("missing warning line:\n%s", got)
+	}
+	// Stat-before-open: the warning path must not have created the file.
+	if _, err := os.Stat(missing); err == nil {
+		t.Error("--ledger must never create the ledger file")
 	}
 }

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -77,6 +77,39 @@ func TestKBSearchUsageErrors(t *testing.T) {
 	}
 }
 
+func TestKBShow(t *testing.T) {
+	dir := writeKBFixture(t)
+	cases := []struct{ label, arg string }{
+		{"exact path", "incidents/crashloop-web.md"},
+		{"filename slug", "crashloop-web"},
+		{"search fallback unique", "configmap truncated kustomize"},
+	}
+	for _, c := range cases {
+		var out strings.Builder
+		if err := runKBShow([]string{"--dir", dir, c.arg}, &out); err != nil {
+			t.Fatalf("%s: runKBShow: %v", c.label, err)
+		}
+		got := out.String()
+		for _, want := range []string{"CrashLoop web ConfigMap truncated", "type: Incident",
+			"resource: apps/web", "## Cause", "revert the patch"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("%s: output missing %q:\n%s", c.label, want, got)
+			}
+		}
+	}
+}
+
+func TestKBShowNoMatchIsError(t *testing.T) {
+	dir := writeKBFixture(t)
+	var out strings.Builder
+	if err := runKBShow([]string{"--dir", dir, "zzz-nothing"}, &out); err == nil {
+		t.Fatal("want error when nothing matches")
+	}
+	if err := runKBShow([]string{"--dir", dir}, &out); err == nil {
+		t.Fatal("want usage error when the entry argument is missing")
+	}
+}
+
 func TestRelAge(t *testing.T) {
 	now := time.Now()
 	cases := []struct {


### PR DESCRIPTION
## What

The BM25 knowledge index was previously reachable only by the agent (instant recall) and by MCP clients (`lore mcp`). This PR adds the **human** read surface:

```
$ lore kb search "crashloop web configmap" --dir ./my-kb
SCORE  ENTRY                        TITLE                              RESOURCE  LAST SEEN
6.20   incidents/crashloop-web.md   CrashLoop web ConfigMap truncated  apps/web  12d ago

$ lore kb show crashloop-web
# CrashLoop web ConfigMap truncated
path: incidents/crashloop-web.md
…full frontmatter card + body…
```

Spec: `docs/superpowers/specs/2026-07-07-kb-human-surfaces-design.md` (Feature 2). One of three sibling PRs from that spec (see also #259).

## Details

- **`lore kb search`** — same BM25 search the agent uses; aligned table; `--json` for scripting (stable field names, results only on stdout — diagnostics go to stderr); `-k`, `--dir` (overrides config `catalog.dir`), `--config`.
- **`--ledger <jsonl>`** — opt-in `RESOLVE` column (`resolved/recalled` per entry from the outcome ledger). Missing/unreadable file: warns on stderr, omits the column, never fails the search, never *creates* the file.
- **`lore kb show`** — exact path → bare filename → unique-search-hit fallback; multiple candidates are listed instead of guessed (same for duplicate basenames).
- **Human-friendly arg parsing** — flags work before *or* after the query (`lore kb search "oom" --dir ./kb`); `--` terminates flags per convention.
- Scripting contract: no results ⇒ exit 1. Zero new dependencies, no ANSI.
- Docs: "Searching the KB from the CLI" section in `docs/reviewing-knowledge.md` — also the 30-second demo path: clone any OKF repo and point `--dir` at it (no cluster, no model, no config).

Full gate green: `go build`, `go vet`, `gofmt`, `go test -race ./...` (45 pkgs), `golangci-lint` (0 issues). Per-task reviews + whole-branch review (which live-smoked the built binary) done; its Important finding (ledger warning corrupting `--json` stdout) fixed in the last commit.