### PR TITLE
fix(catalog): fence-aware Section excerpts + partial-Prior render pins

### DIFF
--- a/internal/catalog/section.go
+++ b/internal/catalog/section.go
@@ -20,8 +20,20 @@ func (e Entry) Section(name string) string {
 	want := strings.TrimSpace(name)
 	var para []string
 	in := false
+	inFence := false
 	for _, ln := range strings.Split(e.Body, "\n") {
 		trimmed := strings.TrimSpace(ln)
+		// Fenced code blocks are opaque: a "# comment" line inside one is code,
+		// not a section boundary, and commands aren't quotable prose — skip the
+		// whole fence (markers included) wherever it appears, so the excerpt is
+		// the section's first PROSE paragraph.
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
 		if h := headingText(trimmed); h != "" {
 			if in {
 				break // next section starts: the excerpt is done
@@ -57,7 +69,7 @@ func headingText(line string) string {
 	return strings.TrimSpace(line[i:])
 }
 
-// truncateRunes caps s at max runes, appending … when cut — rune-aware so a
+// truncateRunes caps s at n runes, appending … when cut — rune-aware so a
 // multibyte character is never split.
 func truncateRunes(s string, n int) string {
 	if utf8.RuneCountInString(s) <= n {

--- a/internal/catalog/section_test.go
+++ b/internal/catalog/section_test.go
@@ -72,3 +72,24 @@ func TestEntrySectionMalformed(t *testing.T) {
 		}
 	}
 }
+
+// A human-edited Resolution often carries a fenced command block whose "#"
+// comment lines would otherwise parse as headings and truncate the excerpt —
+// fences are opaque: skipped entirely, never section boundaries.
+func TestEntrySectionSkipsFencedCode(t *testing.T) {
+	body := "## Resolution\n\n```bash\n# revert the patch\nkubectl rollout undo deploy/web\n```\n\nRevert the patch and pin 5.3.2.\n\n## Next\n\nx\n"
+	if got := (Entry{Body: body}).Section("Resolution"); got != "Revert the patch and pin 5.3.2." {
+		t.Errorf("Section(Resolution) = %q, want the prose after the fence", got)
+	}
+	// A section that is ONLY a fence has nothing quotable.
+	only := "## Resolution\n\n```\nkubectl get pods\n```\n\n## Next\n\nx\n"
+	if got := (Entry{Body: only}).Section("Resolution"); got != "" {
+		t.Errorf("fence-only section = %q, want \"\"", got)
+	}
+	// A "## heading" line inside a fence in an EARLIER section must not
+	// derail which section is matched.
+	earlier := "## Cause\n\n```\n## Resolution\n```\n\ncause text\n\n## Resolution\n\nreal resolution\n"
+	if got := (Entry{Body: earlier}).Section("Resolution"); got != "real resolution" {
+		t.Errorf("Section(Resolution) with fenced fake heading = %q, want %q", got, "real resolution")
+	}
+}

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -627,3 +627,52 @@ func TestSlackSummaryBlocksRecurrenceWithoutPrior(t *testing.T) {
 		t.Errorf("Seen-before block must not render without Prior\n%s", txt)
 	}
 }
+
+// The seen-before block's sub-lines are each independently optional: a partial
+// PriorKnowledge must render only what it has — no empty labels, no dangling
+// footer separator.
+func TestSlackSummaryBlocksPriorKnowledgePartial(t *testing.T) {
+	cases := []struct {
+		label   string
+		prior   *providers.PriorKnowledge
+		prevURL string
+		want    []string
+		absent  []string
+	}{
+		{
+			label: "cause only", prior: &providers.PriorKnowledge{Cause: "c"}, prevURL: "https://kb/pr/1",
+			want:   []string{"*Prior cause:* c", "previous entry"},
+			absent: []string{"*Prior resolution:*", "resolve rate"},
+		},
+		{
+			label: "resolution only", prior: &providers.PriorKnowledge{Resolution: "r"}, prevURL: "https://kb/pr/1",
+			want:   []string{"*Prior resolution:* r", "previous entry"},
+			absent: []string{"*Prior cause:*", "resolve rate"},
+		},
+		{
+			label: "track record without link", prior: &providers.PriorKnowledge{Cause: "c", Recalls: 2, Resolved: 1},
+			want:   []string{"*Prior cause:* c", "resolve rate 1/2"},
+			absent: []string{"previous entry"},
+		},
+	}
+	for _, c := range cases {
+		inv := providers.Investigation{
+			Title: "t", Confidence: 0.8,
+			Occurrences:    2,
+			LastOccurrence: time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC),
+			PrevCuratedURL: c.prevURL,
+			Prior:          c.prior,
+		}
+		txt := blocksText(t, summaryBlocks(inv))
+		for _, w := range c.want {
+			if !strings.Contains(txt, w) {
+				t.Errorf("%s: blocks missing %q\n%s", c.label, w, txt)
+			}
+		}
+		for _, a := range c.absent {
+			if strings.Contains(txt, a) {
+				t.Errorf("%s: blocks must omit %q\n%s", c.label, a, txt)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Follow-ups from the #261 whole-branch review (none were merge-blocking):

- **`Entry.Section()` fence-awareness** — a human-edited `## Resolution` containing a ` ```bash ` block with `#` comment lines used to truncate the excerpt at the fence opener (the comment parsed as an ATX heading). Fenced code is now opaque: skipped entirely, so the quoted excerpt is the section's first *prose* paragraph; a fence-only section yields `""` and the notification falls back to counter+link as designed.
- **Partial-`PriorKnowledge` render pins** — table-driven Slack-block tests for cause-only, resolution-only, and track-record-without-link, so a future edit can't render an empty `*Prior resolution:*` label or a dangling footer.
- Stale `max` → `n` word in the `truncateRunes` doc comment.

Gate green: `go build`, `go vet`, `gofmt`, `go test -race ./...` (45 pkgs), `golangci-lint` (0 issues).