### PR TITLE
feat: opt-in Slack 👍/👎 feedback loop — human ratings weigh recall trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ additive. Full setup detail in **[Data sources](docs/data-sources.md)**.
 | **Kubernetes** | client-go — pod status, events, controller logs | *(in-cluster)* |
 | **LLM** | Anthropic · Google Gemini · any OpenAI-compatible *(vLLM, Ollama, OpenRouter…)* | `model.provider` |
 | **Triggers** *(sources)* | Alertmanager webhook · GitOps failures · PagerDuty webhook *(new)* | `sources.*` |
-| **Notifiers** | Slack *(bot token: threaded summary + detail)* · Slack incoming webhook / Matrix / generic webhook *(single verdict-first message)* | `notify.*` |
+| **Notifiers** | Slack *(bot token: threaded summary + detail; opt-in 👍/👎 feedback buttons feeding the learning loop)* · Slack incoming webhook / Matrix / generic webhook *(single verdict-first message)* | `notify.*` |
 | **Knowledge base** *(git forge)* | GitHub *(App auth)* | `forge.*` |
 
 ## ⚡ Try it in one minute — no cluster, no keys

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -205,6 +205,10 @@ config:
   #     # bot_token_env: SLACK_BOT_TOKEN
   #     # channel: "#alerts"            # channel ID or name (required with bot_token_env)
   #     # signing_secret_env: SLACK_SIGNING_SECRET  # only needed for rung-2 approve/reject buttons
+  #     # feedback_buttons: true        # OPT-IN 👍/👎 rating buttons feeding the learning loop.
+  #     #   Requires Slack to reach POST /slack/interactions (Interactivity Request URL through
+  #     #   your ingress — same exposure as approve/reject buttons), plus signing_secret_env
+  #     #   and outcome.ledger_path. Startup fails loud if either is missing.
   #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }
   #   webhook:
   #     url_env: RUNLORE_WEBHOOK_NOTIFY_URL   # POST findings JSON to this URL

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,8 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
 ### `outcome` — the learning ledger
 `ledger_path` — append-only JSONL of investigation outcomes (empty disables). Drives outcome-weighted
 recall decay; **must be on the PVC** to compound (see [Upgrade & Uninstall](upgrade-uninstall.md)).
+Also records the human 👍/👎 ratings when `notify.slack.feedback_buttons` is enabled (see
+[`notify`](#notify--where-findings-go) below).
 
 ### `actions` — the autonomy ladder (off by default)
 - `mode` — `off` (default) · `suggest` · `approve` · `auto` (experimental, frozen/not recommended).
@@ -177,10 +179,9 @@ synthetic findings out of the review queue while still notifying chat (see
 [reviewing-knowledge.md](reviewing-knowledge.md#expected-triage-volume)).
 
 ### `notify` — where findings go
-`slack` (`webhook_url_env` or `bot_token_env`, `channel`, `signing_secret_env`, `approver_ids`),
-`matrix` (`homeserver`, `room_id`, `access_token_env`), plus inline blocks for any registered notifier
-(e.g. `webhook` with `url_env`). No new keys were added for the verdict-first layout — the changes
-below are behavioural.
+`slack` (`webhook_url_env` or `bot_token_env`, `channel`, `signing_secret_env`, `approver_ids`,
+`feedback_buttons`), `matrix` (`homeserver`, `room_id`, `access_token_env`), plus inline blocks for any
+registered notifier (e.g. `webhook` with `url_env`).
 
 Every notifier now leads with the model's **verdict** (`no_action` / `action_suggested` /
 `action_required` / `inconclusive`) and carries the trigger-time alert metadata (severity, environment,
@@ -198,6 +199,31 @@ limitations, kept distinct from human-only open questions):
 `alert_name`, `started_at` (RFC3339, empty when unknown), `occurrences`, `prev_curated_url`, `ruled_out`
 and `data_gaps` alongside the existing `title`/`confidence`/`curated_url`/`text` fields (all
 `omitempty`).
+
+**👍/👎 feedback buttons — `feedback_buttons` (opt-in, default `false`).** When enabled, Slack
+investigation messages carry two buttons ("👍 Accurate" / "👎 Off-base") so the on-call can rate the
+diagnosis in one click. Ratings land in the **outcome ledger** and weigh the recalled entry's trust
+exactly like resolve signals do — enough 👎 and the entry falls below the recall floor and RunLore
+re-investigates instead of reusing it (see
+[learning-loop.md §6](learning-loop.md#6-the-feedback-edge--outcome-driven-decay-what-makes-it-learn)).
+This is the primary trust signal for incidents that have **no resolve channel** (GitOps failures).
+
+> [!important] Enabling this requires exposing the agent to Slack.
+> Button clicks arrive as HTTPS callbacks on **`POST /slack/interactions`**, so that endpoint must be
+> reachable **from Slack's servers** (a public Interactivity *Request URL* on your Slack app — the same
+> endpoint and the same exposure approve-mode buttons use; if you already run `actions.mode: approve`
+> with Slack buttons, nothing new is exposed). Route it through your ingress/gateway; if you use the
+> chart's `networkPolicy.ingressFrom`, allow your ingress controller, not the internet. Startup **fails
+> loud** unless both `signing_secret_env` (every click is HMAC-verified, ±5 min replay window) and
+> `outcome.ledger_path` (where ratings land) are set.
+
+Feedback is deliberately **unprivileged**: any signature-valid member of your workspace can rate — a
+rating is an opinion feeding the learning loop, not a cluster mutation (approve/reject keep their
+`approver_ids` allowlist). Anti-gaming lives in the ledger: **one live vote per (trigger key, Slack
+user)**, latest wins — duplicate clicks are idempotent and changing your mind moves the vote. The ack
+is an ephemeral "feedback recorded" note visible only to the clicker; the investigation message is
+never modified. With the option off (the default), no buttons render and the endpoint behaves exactly
+as before (404 unless approve mode wired it).
 
 ### `server` — the HTTP listener
 Only `webhook_token_env` (the bearer token for the incident webhook; **required under

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -303,6 +303,13 @@ config:
       #     api.slack.com/apps → your app → Interactivity & Shortcuts → toggle On,
       #     Request URL = https://<your-runlore-host>/slack/interactions. Read-only
       #     deployments (no actions) need none of this.
+      # feedback_buttons: true                     # OPT-IN 👍/👎 buttons: one-click human rating of the
+      #                                            #   diagnosis, recorded in the outcome ledger and weighing
+      #                                            #   the recalled entry's trust (the learning loop's human
+      #                                            #   ground truth). Needs the SAME Interactivity Request URL
+      #                                            #   exposure as Approve/Reject above (Slack must reach
+      #                                            #   /slack/interactions) + signing_secret_env +
+      #                                            #   outcome.ledger_path — startup fails loud otherwise.
     matrix:
       homeserver: https://matrix.org
       room_id: "!yourroom:matrix.org"

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -217,6 +217,14 @@ Two read APIs turn this raw log into a learning signal:
   incident's merged entry is findable by dup-fingerprint, the notification also quotes
   the entry's **cause and human-reviewed resolution** inline (with its recall
   resolve-rate), so the previous answer is readable without leaving chat.
+- **`Feedback()`** appends a human **`feedback`** event — the 👍/👎 buttons on Slack
+  investigation messages (opt-in, `notify.slack.feedback_buttons`; see
+  [configuration.md](configuration.md#notify--where-findings-go)). A vote is attributed
+  to the catalog entry behind the trigger key's **newest open** (via the same
+  `byTrigger` index; a fresh investigation has no entry, so its votes are recorded but
+  weigh nothing), deduplicated to **one live vote per (trigger key, Slack user)** —
+  a duplicate click is idempotent, changing your mind *moves* the vote — and folded
+  into `OpenCounts()` as per-entry `FeedbackUp` / `FeedbackDown`.
 
 Design choices worth calling out:
 
@@ -327,17 +335,27 @@ ledger, so they stay source-neutral):
 
 This is the make-or-break: the edge from **Capture** back into **Retrieve**.
 
-`OpenCounts()` gives, per entry, `recalls` and `resolved`. RunLore turns that into a
-**Bayesian-smoothed resolve-rate** and multiplies the derived recall confidence by it
-(`outcomeFactor`, applied in `recall.go`):
+`OpenCounts()` gives, per entry, `recalls`, `resolved`, and the human feedback votes
+(`FeedbackUp` / `FeedbackDown`). RunLore turns that into a **Bayesian-smoothed success
+rate** and multiplies the derived recall confidence by it (`outcomeFactor`, applied in
+`recall.go`):
 
 ```
-            resolved + 1
-factor  =  --------------          (a Beta(1,1) prior — k≈2 — so a brand-new
-            recalls  + 2            entry isn't punished for having no history)
+            resolved + up + 1
+factor  =  -----------------------      (a Beta(1,1) prior — k≈2 — so a brand-new
+            recalls + up + down + 2      entry isn't punished for having no history)
 
 confidence  =  clamp( base_confidence × factor , 0 , 0.90 )
 ```
+
+Human 👍/👎 votes are **extra Bernoulli observations in the same posterior** — a 👍 is
+one success, a 👎 one failure, each weighing exactly like a resolved/unresolved recall.
+That matters most where the resolve signal *cannot exist*: sources with no resolve
+channel (**GitOps failures**, reinvestigate polls, Alertmanager without `send_resolved`)
+are deliberately excluded from resolve-based decay, so without feedback their entries'
+trust is frozen at the prior forever. A human clicking 👎 is the only ground truth those
+paths can ever accumulate — and it is a judgment on the *diagnosis itself*, which an
+alert merely clearing never proves.
 
 ```mermaid
 stateDiagram-v2

--- a/docs/superpowers/plans/2026-07-09-slack-feedback-loop.md
+++ b/docs/superpowers/plans/2026-07-09-slack-feedback-loop.md
@@ -22,7 +22,7 @@ and with approvals also off the endpoint stays 404.
 
 **Architecture:** no new component, store, endpoint, dependency, or goroutine.
 
-1. **Collect** — `Ledger.Feedback(triggerKey, fingerprint, rating, user, at)` appends a
+1. **Collect** — `Ledger.Feedback(triggerKey, rating, user, at)` appends a
    `{"event":"feedback"}` line (the replay switch already ignores unknown kinds — old binaries are
    safe, see the existing comment in `foldLocked`). The server's existing HMAC-verified
    `/slack/interactions` handler gains two cases; feedback is deliberately unprivileged (any
@@ -48,8 +48,8 @@ golangci-lint run ./...` (must be 0 issues).
 
 ### Task 1: Ledger — feedback events, per-user dedup, entry attribution, checkpoint round-trip
 `internal/outcome/ledger.go` + `ledger_test.go`. Produces: `Event.User`,
-`Aggregate.FeedbackUp/FeedbackDown`, `Ledger.Feedback(triggerKey, fingerprint, rating, user string,
-at time.Time) error` (validates rating ∈ {up,down}; disabled ledger no-ops), `triggerAgg.entry`,
+`Aggregate.FeedbackUp/FeedbackDown`, `Ledger.Feedback(triggerKey, rating, user string, at time.Time)
+error` (validates rating ∈ {up,down}; disabled ledger no-ops), `triggerAgg.entry`,
 `votes map[triggerKey+"\x00"+user]feedbackVote{rating,entry}` folded on replay/live-append and
 checkpointed. Tests: credit/dedup/vote-change/fresh-open-no-attribution/newest-open-wins,
 replay equivalence, checkpoint survival, Episodes() untouched, invalid rating rejected.

--- a/docs/superpowers/plans/2026-07-09-slack-feedback-loop.md
+++ b/docs/superpowers/plans/2026-07-09-slack-feedback-loop.md
@@ -1,0 +1,83 @@
+# Slack 👍/👎 Feedback Loop (complete) Implementation Plan
+
+**Goal:** Close the human-feedback loop end to end, as an **explicit opt-in**: 👍/👎 buttons on Slack
+investigation messages record a human verdict in the outcome ledger, and those ratings feed the same
+Beta-posterior trust weighting that recall decay already uses — so a 👎 measurably lowers the recalled
+entry's confidence (and enough of them reject the recall entirely), while a 👍 builds trust.
+
+**Why feedback matters structurally:** recall decay only learns where a ground-truth resolve signal
+exists; non-resolvable sources (GitOps failures — the golden path —, reinvestigate, Alertmanager
+without `send_resolved`) neither build nor erode trust today (`applyOpenLocked`). Human feedback is
+the only possible ground-truth channel for those, and a direct judgment on the *diagnosis* (an alert
+clearing proves nothing about whether the analysis was right).
+
+**Opt-in contract (the user's requirement):** the feature is OFF by default. Enabling
+`notify.slack.feedback_buttons: true` is what makes the buttons render AND what wires the feedback
+recorder into the server. It requires exposing `POST /slack/interactions` to Slack (public Request
+URL) — the same endpoint approve-mode buttons already use — and is documented as such, prominently.
+Validation fails loud at startup if the option is on without `signing_secret_env` (unsigned clicks
+are never accepted) or without `outcome.ledger_path` (a button whose click can't be recorded is a
+lie). Disabled ⇒ bit-for-bit today's behavior: no buttons, feedback actions answer "not enabled",
+and with approvals also off the endpoint stays 404.
+
+**Architecture:** no new component, store, endpoint, dependency, or goroutine.
+
+1. **Collect** — `Ledger.Feedback(triggerKey, fingerprint, rating, user, at)` appends a
+   `{"event":"feedback"}` line (the replay switch already ignores unknown kinds — old binaries are
+   safe, see the existing comment in `foldLocked`). The server's existing HMAC-verified
+   `/slack/interactions` handler gains two cases; feedback is deliberately unprivileged (any
+   signature-valid workspace member — it's an opinion, not a cluster mutation) and must NOT
+   `replace_original` (that would wipe the investigation message).
+2. **Attribute** — the ledger joins a feedback's TriggerKey to a catalog entry via the existing
+   `byTrigger` index: `triggerAgg` gains `entry` (the newest open's `Entry`; fresh opens carry ""
+   so feedback on a fresh investigation credits nothing — recorded for analytics only).
+3. **Weigh** — `Aggregate` gains `FeedbackUp`/`FeedbackDown`; ratings are extra Bernoulli
+   pseudo-observations in the SAME Beta posterior:
+   `outcomeFactor = (resolved + up + k/2) / (recalls + up + down + k)`.
+   Anti-gaming: the fold keeps ONE vote per (TriggerKey, Slack user id), latest wins — changing
+   your mind moves the vote (un-credits the previous one), repeating it is idempotent.
+4. **Survive restarts/compaction** — votes + attribution + counts round-trip through the
+   checkpoint (`checkpointData` gains `Votes`; `triggerAggJSON` gains `Entry`; `Aggregate`'s new
+   exported ints serialize for free).
+
+**Tech Stack:** Go 1.26, stdlib only. Tests: `go test -race ./...`, table-driven + `httptest`.
+Gate before every commit: `go build ./... && go vet ./... && go test ./... && gofmt -l . &&
+golangci-lint run ./...` (must be 0 issues).
+
+## Tasks
+
+### Task 1: Ledger — feedback events, per-user dedup, entry attribution, checkpoint round-trip
+`internal/outcome/ledger.go` + `ledger_test.go`. Produces: `Event.User`,
+`Aggregate.FeedbackUp/FeedbackDown`, `Ledger.Feedback(triggerKey, fingerprint, rating, user string,
+at time.Time) error` (validates rating ∈ {up,down}; disabled ledger no-ops), `triggerAgg.entry`,
+`votes map[triggerKey+"\x00"+user]feedbackVote{rating,entry}` folded on replay/live-append and
+checkpointed. Tests: credit/dedup/vote-change/fresh-open-no-attribution/newest-open-wins,
+replay equivalence, checkpoint survival, Episodes() untouched, invalid rating rejected.
+
+### Task 2: Recall — feedback in the posterior
+`internal/investigate/recall.go` + tests. `outcomeFactor(recalls, resolved, up, down int, k float64)`;
+call site passes `agg.FeedbackUp/agg.FeedbackDown`. An entry with feedback-only history now enters
+the gate (it appears in OpenCounts), so downs alone can reject a recall — intended.
+
+### Task 3: Config — the opt-in + fail-loud validation
+`internal/config/config.go` + tests. `SlackNotify.FeedbackButtons bool yaml:"feedback_buttons"`.
+Validate: on ⇒ requires `signing_secret_env` AND `outcome.ledger_path`, with error messages that
+name the exposure requirement.
+
+### Task 4: Slack buttons (render only when opted in)
+`internal/notify/slack.go` + tests. `Slack`/`SlackBot` gain a `FeedbackButtons` field set by the
+builder from config. `summaryBlocks(inv, withFeedback bool)`; feedback actions block appended last,
+`value` = `cmp.Or(inv.TriggerKey, inv.Fingerprint)`, omitted when both empty. Renders independently
+of ApprovalID actions.
+
+### Task 5: Server — record clicks
+`internal/server/server.go` + tests. `FeedbackRecorder` interface + `Actions.Feedback`; endpoint
+guard relaxes to `(approvals == nil && feedback == nil) || slackSecret == ""`; feedback cases are
+unprivileged, respond ephemeral WITHOUT `replace_original` (updateSlack gains a `replace` flag);
+approve/reject keep the allowlist and keep replacing.
+
+### Task 6: Wiring + docs
+`internal/app/serve.go`: `acts.Feedback = ledger` only when `cfg.Notify.Slack.FeedbackButtons &&
+ledger.Enabled()`. Docs: `docs/configuration.md` (option + exposure requirement),
+`docs/learning-loop.md` (feedback events, dedup, updated formula), `docs/getting-started.md`
+(interactions Request URL note), chart values example comment.

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -313,6 +313,14 @@ func RunServe(version string, args []string) error {
 	if auto != nil {
 		acts.Pauser = auto // avoid a typed-nil interface when auto is disabled
 	}
+	// Opt-in 👍/👎 feedback: wire the recorder ONLY when the option is on AND the
+	// ledger persists (Validate already requires ledger_path + signing secret with
+	// the option, and Enabled() guards the typed-nil/disabled-ledger cases) — so
+	// with the option off the endpoint behaves exactly as before.
+	if cfg.Notify.Slack.FeedbackButtons && ledger.Enabled() {
+		acts.Feedback = ledger
+		log.Info("slack feedback buttons enabled", "endpoint", "/slack/interactions")
+	}
 	srv := server.New(ReadyFunc(leader.Load, cat, CatalogExpected(cfg)), acts, built, pipe, metricsHandler, log)
 	if cz != nil {
 		go cz.Run(workCtx, cfg.Investigation.Coalesce.Debounce.Std()/2)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -392,6 +392,13 @@ type SlackNotify struct {
 	Channel          string   `yaml:"channel"`            // channel ID or name to post to (required with bot_token_env)
 	SigningSecretEnv string   `yaml:"signing_secret_env"` // env var with the Slack signing secret (verifies button clicks)
 	ApproverIDs      []string `yaml:"approver_ids"`       // Slack user IDs allowed to approve actions (empty = no Slack approvals)
+	// FeedbackButtons (opt-in, default off) renders 👍/👎 buttons on investigation
+	// messages; clicks are recorded in the outcome ledger and weigh the recalled
+	// entry's trust like resolve signals do. Requires exposing POST
+	// /slack/interactions to Slack (an interactivity Request URL — the same
+	// endpoint approve-mode buttons use) plus signing_secret_env and
+	// outcome.ledger_path; Validate fails loud when either is missing.
+	FeedbackButtons bool `yaml:"feedback_buttons"`
 }
 
 // MatrixNotify configures Matrix delivery.
@@ -864,6 +871,17 @@ func (c *Config) Validate() error {
 	for i, v := range c.Forge.SkipVerdicts {
 		if !providers.ValidVerdict(providers.Verdict(v)) {
 			return fmt.Errorf("forge.skip_verdicts[%d]: unknown verdict %q (want no_action|action_suggested|action_required|inconclusive)", i, v)
+		}
+	}
+	// Feedback buttons are click-driven: enabling them without the pieces a click
+	// needs would either accept unsigned requests (never) or render buttons whose
+	// clicks silently vanish (a lie to the on-call). Fail loud at startup instead.
+	if c.Notify.Slack.FeedbackButtons {
+		if c.Notify.Slack.SigningSecretEnv == "" {
+			return fmt.Errorf("notify.slack.feedback_buttons requires notify.slack.signing_secret_env: clicks arrive on the exposed POST /slack/interactions endpoint and must be signature-verified")
+		}
+		if c.Outcome.LedgerPath == "" {
+			return fmt.Errorf("notify.slack.feedback_buttons requires outcome.ledger_path: ratings are recorded in the outcome ledger")
 		}
 	}
 	switch c.Actions.Mode {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -523,3 +523,38 @@ func TestValidateSkipVerdicts(t *testing.T) {
 		t.Fatal("an unknown verdict in forge.skip_verdicts must be rejected by Validate")
 	}
 }
+
+// TestValidateFeedbackButtons guards the opt-in contract of the Slack feedback
+// loop: enabling notify.slack.feedback_buttons requires BOTH the signing secret
+// (clicks arrive on the exposed /slack/interactions endpoint and must be
+// signature-verified) and the outcome ledger (a rendered button whose click
+// cannot be recorded would be a lie). Off (the default) validates clean with
+// neither.
+func TestValidateFeedbackButtons(t *testing.T) {
+	off := &Config{}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("feedback_buttons off must validate clean, got: %v", err)
+	}
+
+	noSecret := &Config{}
+	noSecret.Notify.Slack.FeedbackButtons = true
+	noSecret.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
+	if err := noSecret.Validate(); err == nil {
+		t.Fatal("feedback_buttons without notify.slack.signing_secret_env must be rejected")
+	}
+
+	noLedger := &Config{}
+	noLedger.Notify.Slack.FeedbackButtons = true
+	noLedger.Notify.Slack.SigningSecretEnv = "SLACK_SIGNING_SECRET"
+	if err := noLedger.Validate(); err == nil {
+		t.Fatal("feedback_buttons without outcome.ledger_path must be rejected")
+	}
+
+	ok := &Config{}
+	ok.Notify.Slack.FeedbackButtons = true
+	ok.Notify.Slack.SigningSecretEnv = "SLACK_SIGNING_SECRET"
+	ok.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("feedback_buttons with secret + ledger must validate clean, got: %v", err)
+	}
+}

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -126,8 +126,8 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 	// a rejected recall just falls through to a full investigation.
 	if r.Outcome != nil {
 		if counts, err := r.Outcome.OpenCounts(); err == nil {
-			if agg, ok := counts[e.Path]; ok { // only entries with recall history
-				f := outcomeFactor(agg.Recalls, agg.Resolved, r.OutcomePrior)
+			if agg, ok := counts[e.Path]; ok { // only entries with recall or feedback history
+				f := outcomeFactor(agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, r.OutcomePrior)
 				if f < r.OutcomeFloor {
 					r.reject(ctx, "low_outcome")
 					return nil, 0
@@ -194,19 +194,26 @@ func clampF(v, lo, hi float64) float64 {
 }
 
 // outcomeFactor decays a recall's confidence by its track record as the posterior
-// mean of a symmetric Beta(k/2, k/2) prior over the resolve rate:
+// mean of a symmetric Beta(k/2, k/2) prior over the success rate:
 //
-//	factor = (resolved + k/2) / (recalls + k)
+//	factor = (resolved + up + k/2) / (recalls + up + down + k)
+//
+// Human 👍/👎 feedback (up/down) are extra Bernoulli observations in the SAME
+// posterior — a 👍 is one success, a 👎 one failure, each weighing exactly like a
+// resolved/unresolved recall. That is deliberate: feedback is the only ground
+// truth non-resolvable sources (GitOps failures) can ever accumulate, since their
+// recalls are excluded from resolve-based decay (see outcome.applyOpenLocked).
 //
 // k is the total pseudo-observation count (the prior strength). With the default
-// k=2 this is the documented Beta(1,1) posterior (resolved+1)/(recalls+2): an entry
-// with no history sits at the prior mean 0.5, a consistently-resolving one asymptotes
-// toward 1 without ever reaching it, and one that recalls-but-never-resolves decays
-// fast (0.333 after a single unresolved recall). Always in (0, 1) for k > 0 and
-// resolved ≤ recalls. Entries with no recall history never reach this gate (they are
-// absent from OpenCounts), so a brand-new entry is not punished by the 0.5 prior mean.
-func outcomeFactor(recalls, resolved int, k float64) float64 {
-	return (float64(resolved) + k/2) / (float64(recalls) + k)
+// k=2 this is the documented Beta(1,1) posterior (resolved+up+1)/(recalls+up+down+2):
+// an entry with no history sits at the prior mean 0.5, a consistently-resolving one
+// asymptotes toward 1 without ever reaching it, and one that recalls-but-never-
+// resolves decays fast (0.333 after a single unresolved recall — or a single 👎).
+// Always in (0, 1) for k > 0, resolved ≤ recalls and non-negative votes. Entries
+// with no recall or feedback history never reach this gate (they are absent from
+// OpenCounts), so a brand-new entry is not punished by the 0.5 prior mean.
+func outcomeFactor(recalls, resolved, up, down int, k float64) float64 {
+	return (float64(resolved+up) + k/2) / (float64(recalls+up+down) + k)
 }
 
 // deriveRecallConfidence turns the match signals into an explainable confidence,

--- a/internal/investigate/recall_decay_integration_test.go
+++ b/internal/investigate/recall_decay_integration_test.go
@@ -81,7 +81,7 @@ apps/worker pods are OOMKilled shortly after a values change lowered the memory 
 
 	// Guard the sub-floor premise under both formulas, so the fixture stays valid if the
 	// parallel outcomeFactor change lands.
-	if f := outcomeFactor(4, 0, 2.0); f >= 0.5 {
-		t.Fatalf("fixture invalid: outcomeFactor(4,0,2)=%v is not below the 0.5 floor", f)
+	if f := outcomeFactor(4, 0, 0, 0, 2.0); f >= 0.5 {
+		t.Fatalf("fixture invalid: outcomeFactor(4,0,0,0,2)=%v is not below the 0.5 floor", f)
 	}
 }

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -198,27 +198,35 @@ func TestRecalledInvestigationStampsAlertMetadata(t *testing.T) {
 }
 
 func TestOutcomeFactor(t *testing.T) {
-	const k = 2.0 // default prior strength; k=2 ⇒ documented Beta(1,1): (resolved+1)/(recalls+2)
+	const k = 2.0 // default prior strength; k=2 ⇒ documented Beta(1,1): (resolved+up+1)/(recalls+up+down+2)
 	cases := []struct {
-		recalls, resolved int
-		want              float64
+		recalls, resolved, up, down int
+		want                        float64
 	}{
 		// resolved=0, recalls 0..3 — a never-resolving entry decays fast.
-		{0, 0, 0.5},       // (0+1)/(0+2) — prior mean; never reaches the gate in practice
-		{1, 0, 1.0 / 3.0}, // (0+1)/(1+2) ≈ 0.333 — already below the 0.5 floor at the 1st recall
-		{2, 0, 0.25},      // (0+1)/(2+2)
-		{3, 0, 0.2},       // (0+1)/(3+2)
-		{6, 0, 0.125},     // (0+1)/(6+2)
+		{0, 0, 0, 0, 0.5},       // (0+1)/(0+2) — prior mean; never reaches the gate in practice
+		{1, 0, 0, 0, 1.0 / 3.0}, // (0+1)/(1+2) ≈ 0.333 — already below the 0.5 floor at the 1st recall
+		{2, 0, 0, 0, 0.25},      // (0+1)/(2+2)
+		{3, 0, 0, 0, 0.2},       // (0+1)/(3+2)
+		{6, 0, 0, 0, 0.125},     // (0+1)/(6+2)
 		// mixed resolve records.
-		{3, 1, 0.4},       // (1+1)/(3+2)
-		{3, 2, 0.6},       // (2+1)/(3+2)
-		{4, 2, 0.5},       // (2+1)/(4+2) — exactly at the floor
-		{5, 5, 6.0 / 7.0}, // (5+1)/(5+2) ≈ 0.857 — always-resolving asymptotes to 1, never exceeds it
+		{3, 1, 0, 0, 0.4},       // (1+1)/(3+2)
+		{3, 2, 0, 0, 0.6},       // (2+1)/(3+2)
+		{4, 2, 0, 0, 0.5},       // (2+1)/(4+2) — exactly at the floor
+		{5, 5, 0, 0, 6.0 / 7.0}, // (5+1)/(5+2) ≈ 0.857 — always-resolving asymptotes to 1, never exceeds it
+		// human feedback — extra Bernoulli observations in the same posterior. The
+		// zero-recall rows are the non-resolvable-source case (GitOps): feedback is
+		// the ONLY evidence such entries can ever accumulate.
+		{0, 0, 2, 0, 0.75},      // (0+2+1)/(0+2+2) — two 👍, no resolves: trust builds
+		{0, 0, 0, 2, 0.25},      // (0+0+1)/(0+2+2) — two 👎: below the 0.5 floor, recall rejected
+		{0, 0, 0, 1, 1.0 / 3.0}, // one 👎 weighs exactly like one unresolved recall
+		{3, 2, 1, 1, 4.0 / 7.0}, // (2+1+1)/(3+1+1+2) — feedback blends with resolves
+		{5, 5, 0, 3, 0.6},       // (5+0+1)/(5+0+3+2) — 👎 erode even a perfect resolve record
 	}
 	for _, c := range cases {
-		got := outcomeFactor(c.recalls, c.resolved, k)
+		got := outcomeFactor(c.recalls, c.resolved, c.up, c.down, k)
 		if math.Abs(got-c.want) > 1e-9 {
-			t.Errorf("outcomeFactor(%d,%d,%v) = %v, want %v", c.recalls, c.resolved, k, got, c.want)
+			t.Errorf("outcomeFactor(%d,%d,%d,%d,%v) = %v, want %v", c.recalls, c.resolved, c.up, c.down, k, got, c.want)
 		}
 		if got > 1.0 {
 			t.Errorf("factor must be <= 1.0, got %v", got)
@@ -242,6 +250,30 @@ func soloRecall(oc OutcomeStats) *Recall {
 		}},
 		MinScore: 1.5, SoloFloor: 4.0, MarginGap: 1.0,
 		Outcome: oc, OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+}
+
+func TestLookupDecayFeedbackDownsReject(t *testing.T) {
+	// A non-resolvable-source entry (recalls=0, GitOps golden path) with two human
+	// 👎 and no 👍: factor = (0+0+1)/(0+0+2+2) = 0.25 < 0.5 floor → the recall is
+	// rejected and the incident falls through to a full investigation. This is the
+	// "click 👎 and the agent stops trusting this knowledge" contract.
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {FeedbackDown: 2}}})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("two 👎 with no successes must reject the recall")
+	}
+}
+
+func TestLookupDecayFeedbackUpsBuildTrust(t *testing.T) {
+	// Same entry with two 👍: factor = (0+2+1)/(0+2+2) = 0.75 → recalls, with
+	// confidence biased by the human track record instead of stuck at the prior.
+	r := soloRecall(fakeOutcome{counts: map[string]outcome.Aggregate{"x.md": {FeedbackUp: 2}}})
+	e, conf := r.lookup(context.Background(), okReq())
+	if e == nil {
+		t.Fatal("👍-endorsed entry must recall")
+	}
+	if conf <= 0 {
+		t.Fatalf("confidence must be positive, got %v", conf)
 	}
 }
 

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -246,10 +247,7 @@ func slackMessageWith(inv providers.Investigation, withFeedback bool) map[string
 // attribute, so no buttons render. Labels are plain_text (never escaped); the
 // value is opaque to Slack.
 func feedbackBlocks(inv providers.Investigation) []map[string]any {
-	key := inv.TriggerKey
-	if key == "" {
-		key = inv.Fingerprint
-	}
+	key := cmp.Or(inv.TriggerKey, inv.Fingerprint)
 	if key == "" {
 		return nil
 	}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -24,11 +24,15 @@ func init() {
 			// Bot token (chat.postMessage) takes precedence over an incoming webhook.
 			if sl := d.Cfg.Notify.Slack; sl.BotTokenEnv != "" && sl.Channel != "" {
 				if tok := os.Getenv(sl.BotTokenEnv); tok != "" {
-					return NewSlackBot(tok, sl.Channel), nil
+					b := NewSlackBot(tok, sl.Channel)
+					b.FeedbackButtons = sl.FeedbackButtons
+					return b, nil
 				}
-			} else if env := d.Cfg.Notify.Slack.WebhookURLEnv; env != "" {
-				if url := os.Getenv(env); url != "" {
-					return NewSlack(url), nil
+			} else if sl := d.Cfg.Notify.Slack; sl.WebhookURLEnv != "" {
+				if url := os.Getenv(sl.WebhookURLEnv); url != "" {
+					s := NewSlack(url)
+					s.FeedbackButtons = sl.FeedbackButtons
+					return s, nil
 				}
 			}
 			return nil, nil
@@ -40,6 +44,10 @@ func init() {
 type Slack struct {
 	webhookURL string
 	http       *http.Client
+	// FeedbackButtons (opt-in, notify.slack.feedback_buttons) appends 👍/👎 buttons
+	// so the on-call can rate the diagnosis; clicks land in the outcome ledger via
+	// the exposed /slack/interactions endpoint.
+	FeedbackButtons bool
 }
 
 // NewSlack builds a Slack webhook notifier.
@@ -55,7 +63,7 @@ var (
 // Deliver posts the formatted investigation to the webhook. When an action carries
 // an ApprovalID, it renders interactive Approve/Reject buttons (Block Kit).
 func (s *Slack) Deliver(ctx context.Context, inv providers.Investigation) error {
-	return s.post(ctx, slackMessage(inv))
+	return s.post(ctx, slackMessageWith(inv, s.FeedbackButtons))
 }
 
 // DeliverProgress posts an interim progress ping to the webhook (ProgressNotifier).
@@ -95,6 +103,9 @@ type SlackBot struct {
 	channel string
 	baseURL string
 	http    *http.Client
+	// FeedbackButtons — see Slack.FeedbackButtons; on the bot path the buttons sit
+	// on the channel summary message, never on the detail thread reply.
+	FeedbackButtons bool
 }
 
 // NewSlackBot builds a bot-token Slack notifier posting to channel (ID or name).
@@ -114,7 +125,11 @@ var (
 // implying the alert went undelivered. Nothing is threaded when the summary post
 // yields no ts (empty-body path) or the investigation has no detail beyond it.
 func (s *SlackBot) Deliver(ctx context.Context, inv providers.Investigation) error {
-	ts, err := s.post(ctx, map[string]any{"text": fallbackText(inv), "blocks": summaryBlocks(inv)})
+	summary := summaryBlocks(inv)
+	if s.FeedbackButtons {
+		summary = append(summary, feedbackBlocks(inv)...)
+	}
+	ts, err := s.post(ctx, map[string]any{"text": fallbackText(inv), "blocks": summary})
 	if err != nil {
 		return err
 	}
@@ -182,8 +197,10 @@ func (s *SlackBot) post(ctx context.Context, msg map[string]any) (string, error)
 
 // Slack interaction action_ids — must match the server's /slack/interactions handler.
 const (
-	approveActionID = "runlore_approve"
-	rejectActionID  = "runlore_reject"
+	approveActionID      = "runlore_approve"
+	rejectActionID       = "runlore_reject"
+	feedbackUpActionID   = "runlore_feedback_up"
+	feedbackDownActionID = "runlore_feedback_down"
 )
 
 // slackMessage builds the Slack payload: a verdict-first Block Kit summary
@@ -203,10 +220,45 @@ const (
 // slackDate emits a raw <!date^…> token that is blocks-only — it must never enter
 // the escaped fallback text.
 func slackMessage(inv providers.Investigation) map[string]any {
+	return slackMessageWith(inv, false)
+}
+
+// slackMessageWith is slackMessage plus the opt-in 👍/👎 feedback block appended
+// last (after the detail section) when withFeedback is set — the single-message
+// webhook path's equivalent of the bot path's buttons-on-summary.
+func slackMessageWith(inv providers.Investigation, withFeedback bool) map[string]any {
+	blocks := append(summaryBlocks(inv), detailBlocks(inv)...)
+	if withFeedback {
+		blocks = append(blocks, feedbackBlocks(inv)...)
+	}
 	return map[string]any{
 		"text":   fallbackText(inv),
-		"blocks": append(summaryBlocks(inv), detailBlocks(inv)...),
+		"blocks": blocks,
 	}
+}
+
+// feedbackBlocks renders the 👍/👎 actions block — the human end of the learning
+// loop: a click lands in the outcome ledger and weighs the recalled entry's trust
+// like a resolve signal does (the only ground-truth channel for sources with no
+// resolve webhook, e.g. GitOps failures). The button value is the TriggerKey
+// (incident identity — ratings survive re-worded re-investigations), falling back
+// to the alert fingerprint; with neither there is nothing for the ledger to
+// attribute, so no buttons render. Labels are plain_text (never escaped); the
+// value is opaque to Slack.
+func feedbackBlocks(inv providers.Investigation) []map[string]any {
+	key := inv.TriggerKey
+	if key == "" {
+		key = inv.Fingerprint
+	}
+	if key == "" {
+		return nil
+	}
+	return []map[string]any{{"type": "actions", "elements": []map[string]any{
+		{"type": "button", "action_id": feedbackUpActionID, "value": key,
+			"text": map[string]any{"type": "plain_text", "text": "👍 Accurate", "emoji": true}},
+		{"type": "button", "action_id": feedbackDownActionID, "value": key,
+			"text": map[string]any{"type": "plain_text", "text": "👎 Off-base", "emoji": true}},
+	}}}
 }
 
 // fallbackText renders the one-line notification/accessibility summary Slack

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -676,3 +676,77 @@ func TestSlackSummaryBlocksPriorKnowledgePartial(t *testing.T) {
 		}
 	}
 }
+
+// marshalBlocks JSON-encodes a Slack payload for substring assertions on
+// structures (action_ids, button values) the mrkdwn text helpers don't reach.
+func marshalBlocks(t *testing.T, msg map[string]any) string {
+	t.Helper()
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// TestSlackFeedbackButtonsOptIn pins the opt-in contract: no feedback block by
+// default; when enabled, both 👍/👎 buttons render (independently of any
+// ApprovalID actions) keyed by TriggerKey, falling back to the fingerprint, and
+// are omitted entirely when the investigation carries neither.
+func TestSlackFeedbackButtonsOptIn(t *testing.T) {
+	inv := providers.Investigation{Title: "t", TriggerKey: "k"}
+
+	if s := marshalBlocks(t, slackMessage(inv)); strings.Contains(s, "runlore_feedback") {
+		t.Fatal("feedback buttons must NOT render when the option is off (default)")
+	}
+
+	on := marshalBlocks(t, slackMessageWith(inv, true))
+	if !strings.Contains(on, `"action_id":"runlore_feedback_up"`) ||
+		!strings.Contains(on, `"action_id":"runlore_feedback_down"`) {
+		t.Fatalf("both feedback buttons must render when opted in, got: %s", on)
+	}
+	if !strings.Contains(on, `"value":"k"`) {
+		t.Fatalf("buttons must carry the TriggerKey as value, got: %s", on)
+	}
+
+	byFP := marshalBlocks(t, slackMessageWith(providers.Investigation{Title: "t", Fingerprint: "fp1"}, true))
+	if !strings.Contains(byFP, `"value":"fp1"`) {
+		t.Fatalf("buttons must fall back to the fingerprint, got: %s", byFP)
+	}
+
+	if s := marshalBlocks(t, slackMessageWith(providers.Investigation{Title: "t"}, true)); strings.Contains(s, "runlore_feedback") {
+		t.Fatal("no TriggerKey and no fingerprint ⇒ nothing to attribute ⇒ no buttons")
+	}
+}
+
+// TestSlackBotDeliverFeedbackButtons: with the option on, the bot path renders
+// the buttons on the channel summary message (never in the detail thread).
+func TestSlackBotDeliverFeedbackButtons(t *testing.T) {
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(b))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"111.222"}`))
+	}))
+	defer srv.Close()
+
+	bot := NewSlackBot("xoxb-t", "#ops")
+	bot.baseURL = srv.URL
+	bot.FeedbackButtons = true
+	inv := sampleInvestigation()
+	inv.TriggerKey = "k"
+	if err := bot.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if len(bodies) == 0 {
+		t.Fatal("no message posted")
+	}
+	if !strings.Contains(bodies[0], "runlore_feedback_up") {
+		t.Fatalf("summary message must carry the feedback buttons, got: %s", bodies[0])
+	}
+	for _, b := range bodies[1:] {
+		if strings.Contains(b, "runlore_feedback") {
+			t.Fatalf("detail thread must not repeat the buttons, got: %s", b)
+		}
+	}
+}

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -70,6 +71,12 @@ type Event struct {
 	TriggerKey string `json:"trigger_key,omitempty"` // groups recurrences of the same alert; keys the byTrigger index
 	CuratedURL string `json:"curated_url,omitempty"` // KB link surfaced as "previous: <link>" on recurrence
 	Verdict    string `json:"verdict,omitempty"`     // curator's machine verdict on the investigation
+
+	// User identifies the human behind a feedback event (a Slack user id) — the
+	// dedup key that keeps one live vote per (TriggerKey, user), latest wins.
+	// Empty on open/resolve lines. On a feedback line Kind carries the rating
+	// ("up" | "down").
+	User string `json:"user,omitempty"`
 
 	// Resolvable is set on an open when we know whether a ground-truth resolve signal
 	// can ever arrive for it: true for sources with a resolve channel (Alertmanager,
@@ -137,6 +144,12 @@ type Ledger struct {
 	// in lockstep with the durable write, rebuilt on load, like agg.
 	byTrigger map[string]triggerAgg
 
+	// votes holds the latest human feedback per (TriggerKey \x00 user), so a
+	// duplicate click is idempotent and a changed vote MOVES instead of stacking —
+	// without it, one enthusiastic clicker could sink a healthy entry under the
+	// OutcomeFloor. Folded on replay like agg; checkpointed on compaction.
+	votes map[string]feedbackVote
+
 	// droppedResolves counts orphan resolves discarded by the pendingResolves bound
 	// (see maxPendingResolvesPerFingerprint) — spurious duplicate/replayed resolve
 	// webhooks. Kept so the (otherwise silent) defensive drop is observable.
@@ -169,6 +182,7 @@ type checkpointData struct {
 	OpenIndex       map[string]Event             `json:"open_index,omitempty"`
 	PendingOpens    map[string][]pendingOpenJSON `json:"pending_opens,omitempty"`
 	PendingResolves map[string][]time.Time       `json:"pending_resolves,omitempty"`
+	Votes           map[string]feedbackVoteJSON  `json:"votes,omitempty"`
 	DroppedResolves int                          `json:"dropped_resolves,omitempty"`
 }
 
@@ -176,6 +190,12 @@ type triggerAggJSON struct {
 	Count      int       `json:"count"`
 	Last       time.Time `json:"last"`
 	CuratedURL string    `json:"curated_url,omitempty"`
+	Entry      string    `json:"entry,omitempty"`
+}
+
+type feedbackVoteJSON struct {
+	Rating string `json:"rating"`
+	Entry  string `json:"entry,omitempty"`
 }
 
 type pendingOpenJSON struct {
@@ -188,6 +208,16 @@ type triggerAgg struct {
 	count      int
 	last       time.Time
 	curatedURL string // CuratedURL of the newest open
+	entry      string // Entry of the newest open ("" for fresh) — feedback attribution target
+}
+
+// feedbackVote is the fold state of one (TriggerKey, user) feedback: the rating
+// currently held and the entry it credited at vote time — kept so a changed vote
+// can un-credit exactly what it credited, even if attribution has since moved to
+// a newer open.
+type feedbackVote struct {
+	rating string // "up" | "down"
+	entry  string // agg key credited; "" when the newest open was fresh (nothing credited)
 }
 
 // maxPendingResolvesPerFingerprint bounds the resolve-before-open buffer per
@@ -260,13 +290,16 @@ func (l *Ledger) resetStateLocked() {
 	l.pendingOpens = map[string][]pendingOpen{}
 	l.pendingResolves = map[string][]time.Time{}
 	l.byTrigger = map[string]triggerAgg{}
+	l.votes = map[string]feedbackVote{}
 	l.droppedResolves = 0
 }
 
 // foldLocked folds one replayed event into the derived state. Open/resolve maintain the
-// aggregate, open-index, pairing stacks, and occurrence index; a checkpoint seeds the
-// state a prior compaction folded away. Any other (unknown/future) kind is ignored — the
-// property old binaries rely on for the feedback kind, and now for "checkpoint" too.
+// aggregate, open-index, pairing stacks, and occurrence index; feedback folds a human
+// vote into the aggregate; a checkpoint seeds the state a prior compaction folded away.
+// Any other (unknown/future) kind is ignored — the forward-compat property binaries
+// older than a given kind rely on (they ignored "feedback" before it was folded, and
+// "checkpoint" before compaction existed).
 func (l *Ledger) foldLocked(e Event) {
 	switch e.Event {
 	case "open":
@@ -276,6 +309,8 @@ func (l *Ledger) foldLocked(e Event) {
 	case "resolve":
 		delete(l.open, e.Fingerprint)
 		l.applyResolveLocked(e.Fingerprint, e.At)
+	case "feedback":
+		l.applyFeedbackLocked(e)
 	case "checkpoint":
 		l.seedCheckpointLocked(e.Checkpoint)
 	}
@@ -302,7 +337,10 @@ func (l *Ledger) seedCheckpointLocked(cd *checkpointData) {
 		l.open[fp] = ev
 	}
 	for k, v := range cd.ByTrigger {
-		l.byTrigger[k] = triggerAgg{count: v.Count, last: v.Last, curatedURL: v.CuratedURL}
+		l.byTrigger[k] = triggerAgg{count: v.Count, last: v.Last, curatedURL: v.CuratedURL, entry: v.Entry}
+	}
+	for k, v := range cd.Votes {
+		l.votes[k] = feedbackVote{rating: v.Rating, entry: v.Entry}
 	}
 	for fp, opens := range cd.PendingOpens {
 		stack := make([]pendingOpen, 0, len(opens))
@@ -353,7 +391,13 @@ func (l *Ledger) snapshotCheckpointLocked() *checkpointData {
 	if len(l.byTrigger) > 0 {
 		cd.ByTrigger = make(map[string]triggerAggJSON, len(l.byTrigger))
 		for k, v := range l.byTrigger {
-			cd.ByTrigger[k] = triggerAggJSON{Count: v.count, Last: v.last, CuratedURL: v.curatedURL}
+			cd.ByTrigger[k] = triggerAggJSON{Count: v.count, Last: v.last, CuratedURL: v.curatedURL, Entry: v.entry}
+		}
+	}
+	if len(l.votes) > 0 {
+		cd.Votes = make(map[string]feedbackVoteJSON, len(l.votes))
+		for k, v := range l.votes {
+			cd.Votes[k] = feedbackVoteJSON{Rating: v.rating, Entry: v.entry}
 		}
 	}
 	if len(l.pendingOpens) > 0 {
@@ -627,6 +671,10 @@ func (l *Ledger) applyTriggerLocked(e Event) {
 	if !e.At.Before(a.last) {
 		a.last = e.At
 		a.curatedURL = e.CuratedURL
+		// Feedback attribution follows the newest open: a fresh open (Entry "")
+		// deliberately CLEARS it — a vote on a fresh investigation must not credit
+		// an older recall's entry.
+		a.entry = e.Entry
 	}
 	l.byTrigger[e.TriggerKey] = a
 }
@@ -706,10 +754,14 @@ func (l *Ledger) Episodes() ([]Episode, error) {
 }
 
 // Aggregate is a per-entry roll-up of recall episodes: how often the entry was
-// recalled, how often the incident then resolved, and when it last resolved.
+// recalled, how often the incident then resolved, and when it last resolved —
+// plus the human 👍/👎 votes attributed to the entry (one live vote per
+// TriggerKey+user, latest wins; see applyFeedbackLocked).
 type Aggregate struct {
 	Recalls       int
 	Resolved      int
+	FeedbackUp    int // human "the diagnosis was right" votes — success observations for decay
+	FeedbackDown  int // human "the diagnosis was wrong" votes — failure observations for decay
 	LastConfirmed time.Time
 }
 
@@ -740,6 +792,68 @@ func (l *Ledger) OpenCounts() (map[string]Aggregate, error) {
 		counts[k] = v
 	}
 	return counts, nil
+}
+
+// Feedback appends a human 👍/👎 verdict on a delivered investigation and folds it
+// into the trust aggregate. rating is "up" or "down" (anything else is an error,
+// never silently recorded); user is the stable reviewer id (a Slack user id) the
+// per-trigger dedup keys on. It is a plain append that open/resolve pairing never
+// sees — binaries older than the fold ignored the kind entirely.
+func (l *Ledger) Feedback(triggerKey, fingerprint, rating, user string, at time.Time) error {
+	if rating != "up" && rating != "down" {
+		return fmt.Errorf("feedback rating %q: want up or down", rating)
+	}
+	if !l.enabled() {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e := Event{Event: "feedback", Fingerprint: fingerprint, TriggerKey: triggerKey, Kind: rating, User: user, At: at}
+	if err := l.appendLocked(e); err != nil {
+		return err // append failed: leave the fold untouched (durable-first, like Open/Resolve)
+	}
+	l.applyFeedbackLocked(e)
+	return nil
+}
+
+// applyFeedbackLocked folds one feedback event into the per-entry aggregate.
+// Attribution goes through the byTrigger index: the vote credits the entry of the
+// NEWEST open for its TriggerKey (a fresh investigation attributes nothing — the
+// vote is still on disk for analytics, there is just no catalog entry to weigh).
+// Dedup: one live vote per (TriggerKey, user), latest wins — a repeated identical
+// vote is idempotent, a changed one first un-credits what it previously credited.
+// Unlike resolve-based decay, feedback counts regardless of resolvability: a human
+// judgment on the diagnosis is exactly the ground truth non-resolvable sources
+// (GitOps failures, reinvestigate) can never get from a resolve signal.
+func (l *Ledger) applyFeedbackLocked(e Event) {
+	if e.TriggerKey == "" || (e.Kind != "up" && e.Kind != "down") {
+		return // unattributable, or a malformed replayed line: never folded
+	}
+	key := e.TriggerKey + "\x00" + e.User
+	entry := l.byTrigger[e.TriggerKey].entry
+	if prev, ok := l.votes[key]; ok {
+		if prev.rating == e.Kind && prev.entry == entry {
+			return // duplicate click — idempotent
+		}
+		l.creditFeedbackLocked(prev.entry, prev.rating, -1)
+	}
+	l.votes[key] = feedbackVote{rating: e.Kind, entry: entry}
+	l.creditFeedbackLocked(entry, e.Kind, +1)
+}
+
+// creditFeedbackLocked adjusts entry's feedback counter for rating by delta; a
+// no-op for the empty entry (fresh-investigation votes credit nothing).
+func (l *Ledger) creditFeedbackLocked(entry, rating string, delta int) {
+	if entry == "" {
+		return
+	}
+	a := l.agg[entry]
+	if rating == "up" {
+		a.FeedbackUp += delta
+	} else {
+		a.FeedbackDown += delta
+	}
+	l.agg[entry] = a
 }
 
 // Resolve records that an incident's alert cleared. When it matches an open

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -797,9 +797,10 @@ func (l *Ledger) OpenCounts() (map[string]Aggregate, error) {
 // Feedback appends a human 👍/👎 verdict on a delivered investigation and folds it
 // into the trust aggregate. rating is "up" or "down" (anything else is an error,
 // never silently recorded); user is the stable reviewer id (a Slack user id) the
-// per-trigger dedup keys on. It is a plain append that open/resolve pairing never
-// sees — binaries older than the fold ignored the kind entirely.
-func (l *Ledger) Feedback(triggerKey, fingerprint, rating, user string, at time.Time) error {
+// per-trigger dedup keys on. Attribution is entirely TriggerKey-based — feedback
+// lines carry no alert fingerprint and open/resolve pairing never sees them;
+// binaries older than the fold ignored the kind entirely.
+func (l *Ledger) Feedback(triggerKey, rating, user string, at time.Time) error {
 	if rating != "up" && rating != "down" {
 		return fmt.Errorf("feedback rating %q: want up or down", rating)
 	}
@@ -808,7 +809,7 @@ func (l *Ledger) Feedback(triggerKey, fingerprint, rating, user string, at time.
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	e := Event{Event: "feedback", Fingerprint: fingerprint, TriggerKey: triggerKey, Kind: rating, User: user, At: at}
+	e := Event{Event: "feedback", TriggerKey: triggerKey, Kind: rating, User: user, At: at}
 	if err := l.appendLocked(e); err != nil {
 		return err // append failed: leave the fold untouched (durable-first, like Open/Resolve)
 	}

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1097,11 +1097,11 @@ func TestEpisodeCarriesDupFingerprint(t *testing.T) {
 // no-ops like every other write.
 func TestFeedbackValidatesRatingAndDisabledNoop(t *testing.T) {
 	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
-	if err := l.Feedback("k", "", "sideways", "U1", time.Unix(30000, 0)); err == nil {
+	if err := l.Feedback("k", "sideways", "U1", time.Unix(30000, 0)); err == nil {
 		t.Fatal("rating 'sideways' must be rejected")
 	}
 	d, _ := New("") // disabled
-	if err := d.Feedback("k", "", "up", "U1", time.Unix(30000, 0)); err != nil {
+	if err := d.Feedback("k", "up", "U1", time.Unix(30000, 0)); err != nil {
 		t.Fatalf("disabled ledger Feedback must no-op, got %v", err)
 	}
 }
@@ -1116,10 +1116,10 @@ func TestFeedbackCreditsRecalledEntryAndSurvivesReplay(t *testing.T) {
 	if err := l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0}); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	if err := l.Feedback("k", "fp", "down", "U1", t0.Add(time.Minute)); err != nil {
+	if err := l.Feedback("k", "down", "U1", t0.Add(time.Minute)); err != nil {
 		t.Fatalf("Feedback: %v", err)
 	}
-	if err := l.Feedback("k", "fp", "up", "U2", t0.Add(2*time.Minute)); err != nil {
+	if err := l.Feedback("k", "up", "U2", t0.Add(2*time.Minute)); err != nil {
 		t.Fatalf("Feedback: %v", err)
 	}
 	c, _ := l.OpenCounts()
@@ -1144,12 +1144,12 @@ func TestFeedbackDedupPerUserLatestWins(t *testing.T) {
 	l, _ := New(p)
 	t0 := time.Unix(31000, 0)
 	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0})
-	_ = l.Feedback("k", "", "down", "U1", t0.Add(1*time.Minute))
-	_ = l.Feedback("k", "", "down", "U1", t0.Add(2*time.Minute)) // duplicate click
+	_ = l.Feedback("k", "down", "U1", t0.Add(1*time.Minute))
+	_ = l.Feedback("k", "down", "U1", t0.Add(2*time.Minute)) // duplicate click
 	if c, _ := l.OpenCounts(); c["e.md"].FeedbackDown != 1 {
 		t.Fatalf("duplicate vote must be idempotent, got %+v", c["e.md"])
 	}
-	_ = l.Feedback("k", "", "up", "U1", t0.Add(3*time.Minute)) // changed mind
+	_ = l.Feedback("k", "up", "U1", t0.Add(3*time.Minute)) // changed mind
 	if c, _ := l.OpenCounts(); c["e.md"].FeedbackUp != 1 || c["e.md"].FeedbackDown != 0 {
 		t.Fatalf("changed vote must move, got %+v", c["e.md"])
 	}
@@ -1168,13 +1168,13 @@ func TestFeedbackAttributionFollowsNewestOpen(t *testing.T) {
 	t0 := time.Unix(32000, 0)
 	_ = l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "e1.md", TriggerKey: "k", At: t0})
 	_ = l.Open(Event{Fingerprint: "fp2", Kind: "fresh", TriggerKey: "k", At: t0.Add(time.Hour)})
-	_ = l.Feedback("k", "", "down", "U1", t0.Add(time.Hour+time.Minute))
+	_ = l.Feedback("k", "down", "U1", t0.Add(time.Hour+time.Minute))
 	c, _ := l.OpenCounts()
 	if a := c["e1.md"]; a.FeedbackDown != 0 {
 		t.Fatalf("vote on a fresh investigation must not credit an older entry, got %+v", a)
 	}
 	_ = l.Open(Event{Fingerprint: "fp3", Kind: "recall", Entry: "e2.md", TriggerKey: "k", At: t0.Add(2 * time.Hour)})
-	_ = l.Feedback("k", "", "down", "U1", t0.Add(2*time.Hour+time.Minute))
+	_ = l.Feedback("k", "down", "U1", t0.Add(2*time.Hour+time.Minute))
 	c, _ = l.OpenCounts()
 	if c["e2.md"].FeedbackDown != 1 || c["e1.md"].FeedbackDown != 0 {
 		t.Fatalf("re-vote must credit the newest open's entry only: e1=%+v e2=%+v", c["e1.md"], c["e2.md"])
@@ -1190,7 +1190,7 @@ func TestFeedbackOnNonResolvableRecallCounts(t *testing.T) {
 	t0 := time.Unix(33000, 0)
 	rf := false
 	_ = l.Open(Event{Fingerprint: "gitops:abc", Kind: "recall", Entry: "e.md", TriggerKey: "k", Resolvable: &rf, At: t0})
-	_ = l.Feedback("k", "", "down", "U1", t0.Add(time.Minute))
+	_ = l.Feedback("k", "down", "U1", t0.Add(time.Minute))
 	c, _ := l.OpenCounts()
 	if a := c["e.md"]; a.Recalls != 0 || a.FeedbackDown != 1 {
 		t.Fatalf("non-resolvable recall: want recalls=0 (excluded) down=1 (folded), got %+v", a)
@@ -1203,7 +1203,7 @@ func TestFeedbackDoesNotDisturbEpisodesOrPairing(t *testing.T) {
 	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
 	t0 := time.Unix(34000, 0)
 	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0})
-	_ = l.Feedback("k", "fp", "down", "U1", t0.Add(time.Minute))
+	_ = l.Feedback("k", "down", "U1", t0.Add(time.Minute))
 	if _, ok, err := l.Resolve("fp", t0.Add(2*time.Minute)); err != nil || !ok {
 		t.Fatalf("Resolve after feedback: ok=%v err=%v", ok, err)
 	}
@@ -1224,7 +1224,7 @@ func TestFeedbackSurvivesCompaction(t *testing.T) {
 	l, _ := New(p) // no compaction while writing
 	t0 := time.Unix(35000, 0)
 	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0})
-	_ = l.Feedback("k", "", "down", "U1", t0.Add(time.Minute))
+	_ = l.Feedback("k", "down", "U1", t0.Add(time.Minute))
 	// Pad with unrelated resolved pairs so the feedback lines fall inside the
 	// absorbed prefix, not the retained tail.
 	for i := 0; i < 20; i++ {
@@ -1237,12 +1237,12 @@ func TestFeedbackSurvivesCompaction(t *testing.T) {
 		t.Fatalf("post-compaction fold = %+v, want down=1", a["e.md"])
 	}
 	// The checkpointed vote still dedups…
-	_ = c.Feedback("k", "", "down", "U1", t0.Add(24*time.Hour))
+	_ = c.Feedback("k", "down", "U1", t0.Add(24*time.Hour))
 	if a, _ := c.OpenCounts(); a["e.md"].FeedbackDown != 1 {
 		t.Fatalf("checkpointed vote must stay idempotent, got %+v", a["e.md"])
 	}
 	// …and still moves on a changed rating.
-	_ = c.Feedback("k", "", "up", "U1", t0.Add(25*time.Hour))
+	_ = c.Feedback("k", "up", "U1", t0.Add(25*time.Hour))
 	if a, _ := c.OpenCounts(); a["e.md"].FeedbackUp != 1 || a["e.md"].FeedbackDown != 0 {
 		t.Fatalf("checkpointed vote must move, got %+v", a["e.md"])
 	}

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1091,3 +1091,159 @@ func TestEpisodeCarriesDupFingerprint(t *testing.T) {
 		t.Fatalf("Episodes dup = %+v, want one with dup-abc", eps)
 	}
 }
+
+// TestFeedbackValidatesRatingAndDisabledNoop pins the Feedback contract edges: an
+// unknown rating is an error (never silently recorded), and a disabled ledger
+// no-ops like every other write.
+func TestFeedbackValidatesRatingAndDisabledNoop(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	if err := l.Feedback("k", "", "sideways", "U1", time.Unix(30000, 0)); err == nil {
+		t.Fatal("rating 'sideways' must be rejected")
+	}
+	d, _ := New("") // disabled
+	if err := d.Feedback("k", "", "up", "U1", time.Unix(30000, 0)); err != nil {
+		t.Fatalf("disabled ledger Feedback must no-op, got %v", err)
+	}
+}
+
+// TestFeedbackCreditsRecalledEntryAndSurvivesReplay: a 👍/👎 credits the entry of
+// the newest open for the TriggerKey, and the fold is rebuilt identically from a
+// fresh replay of the file (restart / leader failover).
+func TestFeedbackCreditsRecalledEntryAndSurvivesReplay(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(30000, 0)
+	if err := l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0}); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := l.Feedback("k", "fp", "down", "U1", t0.Add(time.Minute)); err != nil {
+		t.Fatalf("Feedback: %v", err)
+	}
+	if err := l.Feedback("k", "fp", "up", "U2", t0.Add(2*time.Minute)); err != nil {
+		t.Fatalf("Feedback: %v", err)
+	}
+	c, _ := l.OpenCounts()
+	if a := c["e.md"]; a.FeedbackDown != 1 || a.FeedbackUp != 1 || a.Recalls != 1 {
+		t.Fatalf("live fold e.md = %+v, want up=1 down=1 recalls=1", a)
+	}
+	l2, err := New(p)
+	if err != nil {
+		t.Fatalf("replay New: %v", err)
+	}
+	c2, _ := l2.OpenCounts()
+	if a := c2["e.md"]; a.FeedbackDown != 1 || a.FeedbackUp != 1 || a.Recalls != 1 {
+		t.Fatalf("replayed fold e.md = %+v, want up=1 down=1 recalls=1", a)
+	}
+}
+
+// TestFeedbackDedupPerUserLatestWins: one live vote per (TriggerKey, user) — a
+// duplicate click is idempotent, a changed vote MOVES (the previous rating is
+// un-credited), and the invariant survives a fresh replay.
+func TestFeedbackDedupPerUserLatestWins(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(31000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0})
+	_ = l.Feedback("k", "", "down", "U1", t0.Add(1*time.Minute))
+	_ = l.Feedback("k", "", "down", "U1", t0.Add(2*time.Minute)) // duplicate click
+	if c, _ := l.OpenCounts(); c["e.md"].FeedbackDown != 1 {
+		t.Fatalf("duplicate vote must be idempotent, got %+v", c["e.md"])
+	}
+	_ = l.Feedback("k", "", "up", "U1", t0.Add(3*time.Minute)) // changed mind
+	if c, _ := l.OpenCounts(); c["e.md"].FeedbackUp != 1 || c["e.md"].FeedbackDown != 0 {
+		t.Fatalf("changed vote must move, got %+v", c["e.md"])
+	}
+	l2, _ := New(p)
+	if c, _ := l2.OpenCounts(); c["e.md"].FeedbackUp != 1 || c["e.md"].FeedbackDown != 0 {
+		t.Fatalf("replayed dedup state = %+v, want up=1 down=0", c["e.md"])
+	}
+}
+
+// TestFeedbackAttributionFollowsNewestOpen: the vote credits the entry of the
+// NEWEST open for the TriggerKey at vote time — a fresh investigation (no entry)
+// credits nothing, and a later re-vote against a newer recall open moves the
+// credit to the new entry.
+func TestFeedbackAttributionFollowsNewestOpen(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(32000, 0)
+	_ = l.Open(Event{Fingerprint: "fp1", Kind: "recall", Entry: "e1.md", TriggerKey: "k", At: t0})
+	_ = l.Open(Event{Fingerprint: "fp2", Kind: "fresh", TriggerKey: "k", At: t0.Add(time.Hour)})
+	_ = l.Feedback("k", "", "down", "U1", t0.Add(time.Hour+time.Minute))
+	c, _ := l.OpenCounts()
+	if a := c["e1.md"]; a.FeedbackDown != 0 {
+		t.Fatalf("vote on a fresh investigation must not credit an older entry, got %+v", a)
+	}
+	_ = l.Open(Event{Fingerprint: "fp3", Kind: "recall", Entry: "e2.md", TriggerKey: "k", At: t0.Add(2 * time.Hour)})
+	_ = l.Feedback("k", "", "down", "U1", t0.Add(2*time.Hour+time.Minute))
+	c, _ = l.OpenCounts()
+	if c["e2.md"].FeedbackDown != 1 || c["e1.md"].FeedbackDown != 0 {
+		t.Fatalf("re-vote must credit the newest open's entry only: e1=%+v e2=%+v", c["e1.md"], c["e2.md"])
+	}
+}
+
+// TestFeedbackOnNonResolvableRecallCounts pins the reason feedback exists: a
+// non-resolvable recall (GitOps — no resolve signal can ever arrive) is excluded
+// from resolve-based decay, so human feedback is its ONLY ground-truth channel
+// and must be folded regardless of resolvability.
+func TestFeedbackOnNonResolvableRecallCounts(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(33000, 0)
+	rf := false
+	_ = l.Open(Event{Fingerprint: "gitops:abc", Kind: "recall", Entry: "e.md", TriggerKey: "k", Resolvable: &rf, At: t0})
+	_ = l.Feedback("k", "", "down", "U1", t0.Add(time.Minute))
+	c, _ := l.OpenCounts()
+	if a := c["e.md"]; a.Recalls != 0 || a.FeedbackDown != 1 {
+		t.Fatalf("non-resolvable recall: want recalls=0 (excluded) down=1 (folded), got %+v", a)
+	}
+}
+
+// TestFeedbackDoesNotDisturbEpisodesOrPairing: feedback lines are invisible to
+// open/resolve pairing — Episodes() and the resolve credit are unchanged.
+func TestFeedbackDoesNotDisturbEpisodesOrPairing(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(34000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0})
+	_ = l.Feedback("k", "fp", "down", "U1", t0.Add(time.Minute))
+	if _, ok, err := l.Resolve("fp", t0.Add(2*time.Minute)); err != nil || !ok {
+		t.Fatalf("Resolve after feedback: ok=%v err=%v", ok, err)
+	}
+	eps, err := l.Episodes()
+	if err != nil || len(eps) != 1 || !eps[0].Resolved {
+		t.Fatalf("Episodes = %+v (err=%v), want exactly one resolved episode", eps, err)
+	}
+	if c, _ := l.OpenCounts(); c["e.md"].Resolved != 1 || c["e.md"].FeedbackDown != 1 {
+		t.Fatalf("aggregate = %+v, want resolved=1 down=1", c["e.md"])
+	}
+}
+
+// TestFeedbackSurvivesCompaction: votes, attribution and counters absorbed into a
+// checkpoint are reconstructed exactly — including the per-user dedup (a repeated
+// vote after compaction stays idempotent; a changed one still moves).
+func TestFeedbackSurvivesCompaction(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p) // no compaction while writing
+	t0 := time.Unix(35000, 0)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "e.md", TriggerKey: "k", At: t0})
+	_ = l.Feedback("k", "", "down", "U1", t0.Add(time.Minute))
+	// Pad with unrelated resolved pairs so the feedback lines fall inside the
+	// absorbed prefix, not the retained tail.
+	for i := 0; i < 20; i++ {
+		fp := fmt.Sprintf("pad%d", i)
+		_ = l.Open(Event{Fingerprint: fp, Kind: "fresh", At: t0.Add(time.Duration(i+10) * time.Minute)})
+		_, _, _ = l.Resolve(fp, t0.Add(time.Duration(i+11)*time.Minute))
+	}
+	c, _ := NewWithMaxEvents(p, 5) // reload triggers compaction (42 events > 5)
+	if a, _ := c.OpenCounts(); a["e.md"].FeedbackDown != 1 {
+		t.Fatalf("post-compaction fold = %+v, want down=1", a["e.md"])
+	}
+	// The checkpointed vote still dedups…
+	_ = c.Feedback("k", "", "down", "U1", t0.Add(24*time.Hour))
+	if a, _ := c.OpenCounts(); a["e.md"].FeedbackDown != 1 {
+		t.Fatalf("checkpointed vote must stay idempotent, got %+v", a["e.md"])
+	}
+	// …and still moves on a changed rating.
+	_ = c.Feedback("k", "", "up", "U1", t0.Add(25*time.Hour))
+	if a, _ := c.OpenCounts(); a["e.md"].FeedbackUp != 1 || a["e.md"].FeedbackDown != 0 {
+		t.Fatalf("checkpointed vote must move, got %+v", a["e.md"])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,7 +52,7 @@ type Pauser interface {
 // the ground-truth signal the learning loop weighs recalled knowledge by
 // (implemented by *outcome.Ledger).
 type FeedbackRecorder interface {
-	Feedback(triggerKey, fingerprint, rating, user string, at time.Time) error
+	Feedback(triggerKey, rating, user string, at time.Time) error
 }
 
 // Actions bundles the optional rung-2/rung-3 wiring: the approval queue, the auto
@@ -333,7 +333,7 @@ func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) 
 		if act.ActionID == "runlore_feedback_down" {
 			rating = "down"
 		}
-		if ferr := s.feedback.Feedback(act.Value, "", rating, p.User.ID, time.Now()); ferr != nil {
+		if ferr := s.feedback.Feedback(act.Value, rating, p.User.ID, time.Now()); ferr != nil {
 			msg = "⚠️ recording feedback failed: " + ferr.Error()
 			s.log.Warn("slack feedback failed", "key", act.Value, "err", ferr)
 		} else {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	ready        func() bool
 	approvals    *action.Approvals // nil unless action mode "approve" is configured
 	pauser       Pauser            // nil unless action mode "auto" is configured (kill-switch)
+	feedback     FeedbackRecorder  // nil unless notify.slack.feedback_buttons is on (with an enabled ledger)
 	token        string            // shared secret for the approval/control endpoints (required when actions enabled)
 	slackSecret  string            // Slack signing secret; verifies interactive button clicks
 	webhookToken string            // optional bearer token required on POST /webhook/alertmanager
@@ -47,11 +48,20 @@ type Pauser interface {
 	Paused() bool
 }
 
+// FeedbackRecorder persists a human 👍/👎 rating on a delivered investigation —
+// the ground-truth signal the learning loop weighs recalled knowledge by
+// (implemented by *outcome.Ledger).
+type FeedbackRecorder interface {
+	Feedback(triggerKey, fingerprint, rating, user string, at time.Time) error
+}
+
 // Actions bundles the optional rung-2/rung-3 wiring: the approval queue, the auto
-// kill-switch, the shared control token, and the Slack signing secret.
+// kill-switch, the shared control token, the Slack signing secret, and the opt-in
+// feedback recorder.
 type Actions struct {
 	Approvals    *action.Approvals
 	Pauser       Pauser
+	Feedback     FeedbackRecorder // opt-in 👍/👎 recording (notify.slack.feedback_buttons)
 	Token        string
 	SlackSecret  string
 	WebhookToken string   // optional bearer token required on POST /webhook/alertmanager
@@ -73,7 +83,8 @@ func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pip
 	}
 	s := &Server{
 		ready:     ready,
-		approvals: acts.Approvals, pauser: acts.Pauser, token: acts.Token, slackSecret: acts.SlackSecret,
+		approvals: acts.Approvals, pauser: acts.Pauser, feedback: acts.Feedback,
+		token: acts.Token, slackSecret: acts.SlackSecret,
 		webhookToken: acts.WebhookToken, approvers: approvers, metrics: metricsHandler, log: log,
 	}
 	mux := http.NewServeMux()
@@ -235,12 +246,15 @@ type slackInteraction struct {
 
 // handleSlackInteraction processes Block Kit button clicks: it verifies the Slack
 // request signature, then approves (executing) / rejects the referenced action
-// (privileged — approver allowlist), updating the message via response_url.
+// (privileged — approver allowlist) or records a 👍/👎 feedback rating
+// (unprivileged — an opinion, not a cluster mutation), updating the message via
+// response_url.
 func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) {
-	// The endpoint only exists to drive Approve/Reject on queued actions, so it is
-	// disabled unless approvals are wired. The signing secret stays mandatory:
-	// signature verification is never optional.
-	if s.approvals == nil || s.slackSecret == "" {
+	// The endpoint drives Approve/Reject on queued actions and the opt-in 👍/👎
+	// feedback; it stays 404 unless at least one is wired, so a deployment that
+	// enabled neither exposes no interactive callback at all. The signing secret
+	// stays mandatory: signature verification is never optional.
+	if (s.approvals == nil && s.feedback == nil) || s.slackSecret == "" {
 		http.Error(w, "slack interactions not enabled", http.StatusNotFound)
 		return
 	}
@@ -306,12 +320,35 @@ func (s *Server) handleSlackInteraction(w http.ResponseWriter, r *http.Request) 
 		} else {
 			msg = fmt.Sprintf("🚫 rejected by @%s", p.User.Username)
 		}
+	case "runlore_feedback_up", "runlore_feedback_down":
+		// Feedback is deliberately unprivileged (no approver allowlist): the
+		// signature proves the workspace, and a rating is an opinion feeding the
+		// learning loop, not a cluster mutation. Anti-gaming lives in the ledger —
+		// one live vote per (TriggerKey, user), latest wins.
+		if s.feedback == nil {
+			msg = "⚠️ feedback recording not enabled (notify.slack.feedback_buttons is off)"
+			break
+		}
+		rating := "up"
+		if act.ActionID == "runlore_feedback_down" {
+			rating = "down"
+		}
+		if ferr := s.feedback.Feedback(act.Value, "", rating, p.User.ID, time.Now()); ferr != nil {
+			msg = "⚠️ recording feedback failed: " + ferr.Error()
+			s.log.Warn("slack feedback failed", "key", act.Value, "err", ferr)
+		} else {
+			msg = fmt.Sprintf("🙏 feedback recorded (%s) — thanks @%s", rating, p.User.Username)
+			s.log.Info("slack feedback recorded", "key", act.Value, "rating", rating, "user_id", p.User.ID, "user", p.User.Username)
+		}
 	default:
 		http.Error(w, "unknown action", http.StatusBadRequest)
 		return
 	}
 	w.WriteHeader(http.StatusOK) // ack the click; update the message best-effort
-	s.updateSlack(r.Context(), p.ResponseURL, msg)
+	// Approve/reject replace the interaction message with the outcome; a feedback
+	// ack must NOT — replacing would wipe the investigation the rating is about.
+	replace := act.ActionID == "runlore_approve" || act.ActionID == "runlore_reject"
+	s.updateSlack(r.Context(), p.ResponseURL, msg, replace)
 }
 
 // verifySlack validates the Slack request signature (HMAC-SHA256 over
@@ -331,12 +368,13 @@ func (s *Server) verifySlack(h http.Header, body []byte) bool {
 	return hmac.Equal([]byte(expected), []byte(h.Get("X-Slack-Signature")))
 }
 
-// updateSlack overwrites the interaction message via its response_url with the
-// approve/reject outcome. The URL is attacker-influenceable (it arrives in the
-// interaction payload), so it is restricted to https *.slack.com and posted with a
-// bounded client — no SSRF to arbitrary internal services, no unbounded hang on
-// http.DefaultClient.
-func (s *Server) updateSlack(ctx context.Context, responseURL, text string) {
+// updateSlack answers the interaction via its response_url: approve/reject
+// overwrite the interaction message with the outcome (replaceOriginal=true),
+// feedback appends an ephemeral note instead. The URL is attacker-influenceable
+// (it arrives in the interaction payload), so it is restricted to https
+// *.slack.com and posted with a bounded client — no SSRF to arbitrary internal
+// services, no unbounded hang on http.DefaultClient.
+func (s *Server) updateSlack(ctx context.Context, responseURL, text string, replaceOriginal bool) {
 	if responseURL == "" {
 		return
 	}
@@ -345,7 +383,7 @@ func (s *Server) updateSlack(ctx context.Context, responseURL, text string) {
 		s.log.Warn("refusing slack response_url: not an https *.slack.com host", "url", responseURL)
 		return
 	}
-	body, _ := json.Marshal(map[string]any{"replace_original": true, "text": text})
+	body := slackResponseBody(text, replaceOriginal)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, responseURL, bytes.NewReader(body))
 	if err != nil {
 		return
@@ -355,6 +393,18 @@ func (s *Server) updateSlack(ctx context.Context, responseURL, text string) {
 	if resp, err := client.Do(req); err == nil {
 		_ = resp.Body.Close()
 	}
+}
+
+// slackResponseBody builds the response_url payload. A feedback ack
+// (replaceOriginal=false) is additionally marked ephemeral so the thanks note is
+// visible to the clicker only — the channel keeps the untouched investigation.
+func slackResponseBody(text string, replaceOriginal bool) []byte {
+	m := map[string]any{"replace_original": replaceOriginal, "text": text}
+	if !replaceOriginal {
+		m["response_type"] = "ephemeral"
+	}
+	b, _ := json.Marshal(m)
+	return b
 }
 
 // Handler returns the HTTP handler (built once at construction; Go 1.22+ method routing).

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -360,3 +360,107 @@ func TestHandleAlertmanagerEnqueues(t *testing.T) {
 		t.Fatalf("want 1 enqueued (only critical A), got %v", enq.reqs)
 	}
 }
+
+type recordedFeedback struct {
+	key, fp, rating, user string
+}
+
+type recordFeedback struct{ got []recordedFeedback }
+
+func (r *recordFeedback) Feedback(triggerKey, fingerprint, rating, user string, _ time.Time) error {
+	r.got = append(r.got, recordedFeedback{key: triggerKey, fp: fingerprint, rating: rating, user: user})
+	return nil
+}
+
+// TestSlackFeedbackInteraction pins the feedback contract: with ONLY the feedback
+// recorder wired (approvals nil — a read-only deployment that opted into the
+// learning loop) the endpoint is up; a signature-valid click from ANY workspace
+// user is recorded (feedback is an opinion, not a cluster mutation — no approver
+// allowlist); and an approve click on such a server is acked with "not enabled"
+// rather than 404 or a panic.
+func TestSlackFeedbackInteraction(t *testing.T) {
+	rec := &recordFeedback{}
+	const secret = "shh"
+	srv := New(nil, Actions{Feedback: rec, SlackSecret: secret}, nil, nil, nil, discardLog)
+
+	send := func(actionID, userID string) *httptest.ResponseRecorder {
+		payload := `{"user":{"id":"` + userID + `","username":"bob"},"actions":[{"action_id":"` + actionID + `","value":"trig-1"}]}`
+		body := "payload=" + url.QueryEscape(payload)
+		ts := strconv.FormatInt(time.Now().Unix(), 10)
+		req := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(body))
+		req.Header.Set("X-Slack-Request-Timestamp", ts)
+		req.Header.Set("X-Slack-Signature", slackSign(secret, ts, body))
+		rr := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rr, req)
+		return rr
+	}
+
+	if rr := send("runlore_feedback_up", "U9"); rr.Code != http.StatusOK {
+		t.Fatalf("feedback up = %d, want 200", rr.Code)
+	}
+	if rr := send("runlore_feedback_down", "U10"); rr.Code != http.StatusOK {
+		t.Fatalf("feedback down = %d, want 200", rr.Code)
+	}
+	want := []recordedFeedback{
+		{key: "trig-1", rating: "up", user: "U9"},
+		{key: "trig-1", rating: "down", user: "U10"},
+	}
+	if len(rec.got) != 2 || rec.got[0] != want[0] || rec.got[1] != want[1] {
+		t.Fatalf("recorded = %+v, want %+v", rec.got, want)
+	}
+
+	// Approve on a feedback-only server: endpoint is up, click is acked, nothing runs.
+	if rr := send("runlore_approve", "U9"); rr.Code != http.StatusOK {
+		t.Fatalf("approve with approvals==nil = %d, want 200 (acked with 'not enabled')", rr.Code)
+	}
+
+	// Unverified feedback never reaches the recorder.
+	bad := httptest.NewRequest(http.MethodPost, "/slack/interactions",
+		strings.NewReader("payload="+url.QueryEscape(`{"user":{"id":"U9"},"actions":[{"action_id":"runlore_feedback_up","value":"x"}]}`)))
+	bad.Header.Set("X-Slack-Request-Timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	bad.Header.Set("X-Slack-Signature", "v0=deadbeef")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, bad)
+	if rr.Code != http.StatusUnauthorized || len(rec.got) != 2 {
+		t.Fatalf("unsigned feedback: code=%d recorded=%d, want 401 and nothing recorded", rr.Code, len(rec.got))
+	}
+}
+
+// TestSlackFeedbackNotEnabled: on an approvals-only server (feedback recorder not
+// wired — the option is off), a feedback click is acked but records nothing.
+func TestSlackFeedbackNotEnabled(t *testing.T) {
+	exec := &recordExec{}
+	pol := action.New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{ReversibleOnly: true, Namespaces: []string{"apps"}}})
+	ap := action.NewApprovals(exec, pol, audit.Nop{}, discardLog)
+	const secret = "shh"
+	srv := New(nil, Actions{Approvals: ap, SlackSecret: secret}, nil, nil, nil, discardLog)
+
+	payload := `{"user":{"id":"U1","username":"alice"},"actions":[{"action_id":"runlore_feedback_up","value":"trig-1"}]}`
+	body := "payload=" + url.QueryEscape(payload)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	req := httptest.NewRequest(http.MethodPost, "/slack/interactions", strings.NewReader(body))
+	req.Header.Set("X-Slack-Request-Timestamp", ts)
+	req.Header.Set("X-Slack-Signature", slackSign(secret, ts, body))
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("feedback with recorder nil = %d, want 200 (acked with 'not enabled')", rr.Code)
+	}
+}
+
+// TestSlackResponseBodyReplaceFlag pins the response_url payload contract:
+// approve/reject REPLACE the interaction message with the outcome; feedback must
+// NOT (replace_original would wipe the investigation message) — it answers with
+// an ephemeral note to the clicker only.
+func TestSlackResponseBodyReplaceFlag(t *testing.T) {
+	if b := slackResponseBody("done", true); !bytes.Contains(b, []byte(`"replace_original":true`)) {
+		t.Fatalf("approve/reject body must replace_original, got %s", b)
+	}
+	fb := slackResponseBody("thanks", false)
+	if !bytes.Contains(fb, []byte(`"replace_original":false`)) {
+		t.Fatalf("feedback body must NOT replace the investigation message, got %s", fb)
+	}
+	if !bytes.Contains(fb, []byte(`"response_type":"ephemeral"`)) {
+		t.Fatalf("feedback ack must be ephemeral (clicker-only), got %s", fb)
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -362,13 +362,13 @@ func TestHandleAlertmanagerEnqueues(t *testing.T) {
 }
 
 type recordedFeedback struct {
-	key, fp, rating, user string
+	key, rating, user string
 }
 
 type recordFeedback struct{ got []recordedFeedback }
 
-func (r *recordFeedback) Feedback(triggerKey, fingerprint, rating, user string, _ time.Time) error {
-	r.got = append(r.got, recordedFeedback{key: triggerKey, fp: fingerprint, rating: rating, user: user})
+func (r *recordFeedback) Feedback(triggerKey, rating, user string, _ time.Time) error {
+	r.got = append(r.got, recordedFeedback{key: triggerKey, rating: rating, user: user})
 	return nil
 }
 


### PR DESCRIPTION
## What

Closes the human-feedback loop end to end, as a **strictly opt-in** feature (`notify.slack.feedback_buttons`, default `false`):

1. **Collect** — Slack investigation messages carry 👍 Accurate / 👎 Off-base buttons (bot summary message and single webhook message alike), keyed by TriggerKey with fingerprint fallback. Clicks arrive on the **existing** HMAC-verified `POST /slack/interactions` endpoint (two new `action_id` cases — no new endpoint, dependency, store or goroutine).
2. **Record** — `Ledger.Feedback` appends a `feedback` event (rating, trigger key, Slack user id). Old binaries replaying a ledger containing feedback lines are unaffected (unknown kinds were always ignored).
3. **Attribute** — the ledger joins the vote to the catalog entry of the trigger's **newest open** via the existing `byTrigger` index; a fresh investigation attributes nothing (recorded for analytics only).
4. **Weigh** — ratings are extra Bernoulli observations in the **same Beta posterior** as resolve signals:
   `outcomeFactor = (resolved + up + k/2) / (recalls + up + down + k)`.
   Enough 👎 pushes an entry below the `OutcomeFloor` → the recall is rejected and RunLore re-investigates instead of reusing the entry. This is the first ground-truth trust channel for **non-resolvable sources (GitOps failures — the golden path)**, whose recalls are excluded from resolve-based decay by design.

## The opt-in contract (deliberate)

Enabling the option means **exposing `/slack/interactions` to Slack** (Interactivity Request URL — the same endpoint and exposure approve-mode buttons already use). That trade-off is documented prominently (configuration.md callout, getting-started example, chart values comment) and enforced fail-loud: startup errors when the option is on without `signing_secret_env` or without `outcome.ledger_path`. **Off (default) is bit-for-bit today's behavior**: no buttons render, feedback actions answer "not enabled", and with approvals also off the endpoint stays 404.

## Safety / anti-gaming

- Feedback is deliberately **unprivileged** (signature-valid workspace member): it's an opinion feeding the learning loop, not a cluster mutation. Approve/reject keep their `approver_ids` allowlist.
- **One live vote per (TriggerKey, Slack user), latest wins** — a duplicate click is idempotent, changing your mind moves the vote (un-credits the previous one). Without this, one clicker could sink a healthy entry under the floor.
- The feedback ack is **ephemeral and never `replace_original`** — the investigation message is never wiped (approve/reject keep replacing, unchanged).
- Votes, attribution and counters **round-trip through ledger compaction** (checkpointed), and survive restart/leader-failover replay.

## Tests

TDD throughout: ledger (credit/replay equivalence, per-user dedup latest-wins, newest-open attribution incl. the fresh-open-clears case, non-resolvable-source counting, Episodes/pairing untouched, compaction survival), recall (posterior table incl. feedback rows, floor rejection on 👎-only history, trust build on 👍), notify (opt-in rendering matrix, key fallback, buttons on summary not thread), server (unprivileged recording, unsigned rejection, feedback-only server, approvals-only server, replace_original contract), config (fail-loud validation matrix).

Full gate green: `go build` · `go vet` · `go test ./... -race` · `gofmt` · `golangci-lint` (0 issues) · `helm lint`.