### PR TITLE
fix: pin Go toolchain to 1.26.5 for the crypto/tls fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
       - run: go build ./...
       - run: go vet ./...
       - name: gofmt

--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Set up kubectl
         uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       # Guard: check whether the API key secret is set without echoing it.
       # We map the secret to an env var and test -n so the value is never

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
 
       - name: Set up Docker Buildx
         # Required for the goreleaser `dockers` entries (use: buildx) and their

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/Smana/runlore
 
 go 1.26.0
 
+toolchain go1.26.5
+
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.27
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.68.1


### PR DESCRIPTION
govulncheck fails CI on every PR since the crypto/tls vulnerability affecting go1.26.4 was published (fixed in go1.26.5) — see the `build` failure on #267, whose traces point only at pre-existing code paths.

The workflows request `go-version: "1.26"`, which the runner currently resolves to 1.26.4. Pinning `toolchain go1.26.5` in `go.mod` makes every build — CI and local — fetch 1.26.5 regardless of what setup-go installed, keeping go.mod the single source of truth.

Unblocks #267 (re-run its checks after this merges).