### PR TITLE
feat: recurrence cooldown — stop re-investigating a just-answered trigger

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -124,6 +124,11 @@ config:
       max_per_window: 20        # cap investigations per window (window defaults to 1h); 0 = unlimited
       # window: 1h
       # max_requeues: 3
+    # recurrence_cooldown: 30m  # OPT-IN: skip re-investigating a trigger answered conclusively less
+    #                           #   than this long ago (a still-firing alert otherwise re-investigates
+    #                           #   every repeat_interval; a failing GitOps resource every ~10m resync).
+    #                           #   An inconclusive prior always retries; a 👎 re-arms immediately.
+    #                           #   Requires outcome.ledger_path.
   # Structured logging. In-cluster defaults to JSON so logs are ingestible by
   # Loki / VictoriaLogs / CloudWatch; switch format to "text" for human-readable
   # output. level: debug | info | warn | error. Both are overridable at runtime via

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,19 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   `max_wait` **2m**, `max_batch` **50**, `cooldown` **10m**; `correlation_labels` group related alerts.
 - `rate_limit` — `max_per_window` (**0 = unlimited**), `window` (default **1h** when a budget is set),
   `max_requeues`.
+- `recurrence_cooldown` — **opt-in (default 0 = off)** per-trigger suppression: skip re-investigating a
+  trigger whose previous investigation completed less than this long ago, **concluded** (verdict ≠
+  `inconclusive`), and has **no standing 👎 feedback**. Without it, nothing keys on the trigger before
+  the paid loop: a still-firing alert re-investigates on every Alertmanager `repeat_interval` and a
+  persistently-failing GitOps resource on every informer resync (**~10 minutes**) — each a full model
+  run re-delivering the same answer as fresh noise. A suppressed occurrence costs nothing and says
+  nothing (no model call, no notification, no ledger open — the previous notification remains *the*
+  answer); the next occurrence past the cooldown re-investigates in full. Two human-deferential
+  escape hatches: an inconclusive prior never suppresses (there is no answer worth repeating), and a
+  👎 on the previous message re-arms investigation immediately (see
+  [`notify.slack.feedback_buttons`](#notify--where-findings-go)). Requires `outcome.ledger_path`
+  (fails loud at startup without it). A sensible production value is `30m`–`1h`. Suppressions show up
+  as `runlore_investigations_completed_total{result="recurrence_suppressed"}`.
 - `timeout` — per-investigation deadline, **default 10m** (bounds a hung tool/clone so it can't starve
   the single-worker queue).
 - `tool_timeout` — per-**tool**-call timeout, **default 60s** (0 = use the default). Bounds a single

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -381,6 +381,16 @@ This is the answer to the hardest objection against KB-backed agents ("what happ
 when a confidently-worded wrong belief gets in?"): the loop has a mechanism to lose
 trust in it and overturn it.
 
+The same per-trigger index also powers the **recurrence cooldown**
+(`investigation.recurrence_cooldown`, opt-in): a trigger the agent conclusively
+answered moments ago is not re-investigated — no model call, no duplicate
+notification — until the cooldown lapses. The escape hatches are human-deferential
+by design: an `inconclusive` prior never suppresses (there is no answer worth
+repeating), and a standing 👎 on the trigger re-arms investigation immediately. So
+feedback does two jobs: it weighs *recalled knowledge* (the decay above) and it
+governs *when the agent may repeat itself* — both steered by the same one-click
+human signal.
+
 ---
 
 ## 7. Compound — merged knowledge becomes everyone's, fast

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -53,7 +53,7 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_alerts_suppressed_total` | counter | — | incidents dropped by cooldown |
 | `runlore_incidents_debounced_total` | counter | — | firing alerts dropped as self-resolving (a matching `resolved` webhook arrived within `triggers.incidents.debounce`) |
 | `runlore_investigations_started_total` | counter | — | investigations actually begun |
-| `runlore_investigations_completed_total` | counter | `result` | investigations finished (`resolved`/`unresolved`/`recall`/`error`/`max_steps`/`budget_exceeded`/`inconclusive`) |
+| `runlore_investigations_completed_total` | counter | `result` | investigations finished (`resolved`/`unresolved`/`recall`/`error`/`max_steps`/`budget_exceeded`/`inconclusive`/`recurrence_suppressed`) |
 | `runlore_investigation_duration_seconds` | histogram | `result` | wall-clock per investigation |
 | `runlore_investigations_throttled_total` | counter | — | starts requeued by the rate limiter |
 | `runlore_investigations_dropped_total` | counter | — | dropped (rate-limiter max-requeues or token-budget kill) |

--- a/docs/superpowers/plans/2026-07-03-notification-overhaul.md
+++ b/docs/superpowers/plans/2026-07-03-notification-overhaul.md
@@ -1,0 +1,695 @@
+# Notification Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework investigation notifications so an on-call can answer "do I need to do anything?" in one glance: an explicit verdict, a metadata field block, recurrence awareness, ruled-out/data-gap separation, Slack threading (compact channel message + full detail in a thread reply), and 👍/👎 feedback buttons feeding the outcome ledger.
+
+**Architecture:** Three new model-populated fields (`verdict`, `ruled_out`, `data_gaps`) flow through the `submit_findings` schema → `findings` struct → `providers.Investigation`. Alert metadata (severity, cluster, tenant, alertname, startsAt) is stamped from the `investigate.Request` at loop completion. The outcome ledger gains a TriggerKey index so `OnComplete` can stamp occurrence counts before delivery. The Slack notifier splits its blocks into a compact summary (channel) and a detail message (thread reply via `chat.postMessage` `ts`); the shared `notify.Format` and webhook payload gain the new sections so Matrix/webhook stay comprehensive.
+
+**Tech Stack:** Go 1.26, stdlib only (no new deps). Tests: `go test -race ./...`, table-driven + `httptest`. Lint: `golangci-lint run ./...` (v2 config), `gofmt`.
+
+## Global Constraints
+
+- Go 1.26 (go.mod); CI runs `go build ./...`, `go vet ./...`, `test -z "$(gofmt -l .)"`, `go test -race ./...`.
+- Never add AI attribution to commits or PRs. Commit messages use conventional-commit prefixes (`feat:`, `fix:`, `test:`, `docs:`) matching repo history.
+- **mrkdwn-escape invariant** (`slack.go:176-182` + `TestSlackMessageFallbackEscaped`): the Slack fallback `text` is `escapeMrkdwn(Format(inv))` — any new scaffolding added to `Format` must contain NONE of `&`, `<`, `>`. Never put Slack `<!date^…>` tokens in `Format` output (they'd be escaped/corrupted); those are Slack-blocks-only.
+- All untrusted (model/alert/tool) strings interpolated into Slack mrkdwn blocks go through `escapeMrkdwn`. Header blocks are `plain_text` — never escape those.
+- Slack section text caps at 3000 chars — keep using `truncate(s, 2900)`. `fields` array: max 10 items, each ≤2000 chars.
+- New `outcome.Event` fields must be `omitempty` and new event kinds must be ignored by old replay switches (append-only file format stays backward/forward compatible).
+- Keep comment density/style of surrounding code (this repo comments the *why* heavily).
+
+## Verdict vocabulary (used across tasks)
+
+| enum value | emoji | label |
+|---|---|---|
+| `no_action` | ✅ | No action needed |
+| `action_suggested` | 🛠 | Action suggested |
+| `action_required` | 🔥 | Action required |
+| `inconclusive` | ❓ | Inconclusive |
+
+Empty verdict (old investigations, recall entries, non-conforming model) ⇒ omit verdict rendering everywhere; never invent one.
+
+**Descoped (record in PR description as follow-ups):** live "still firing / resolved" status at send time (needs resolve-state race handling in the ledger); splitting next-steps into remediation vs alert-tuning (needs model-side classification of suggestions); regenerating the README screenshot (human task).
+
+---
+
+### Task 1: Verdict/RuledOut/DataGaps through the model contract
+
+**Files:**
+- Modify: `internal/providers/providers.go` (~line 388 `Investigation`, and add `Verdict` type above it)
+- Modify: `internal/investigate/tools.go` (schema `:72-85`, `findings` `:105-133`, `buildInvestigation` `:185-214`)
+- Modify: `internal/investigate/loop.go` (systemPrompt `:22-74`)
+- Modify: `internal/investigate/budget.go` (synthetic results at `:16,31,46`)
+- Modify: `internal/eval/score.go` (`investigationText` `:86-94`)
+- Test: `internal/investigate/tools_test.go`, `internal/eval/score_test.go` (or wherever `investigationText` is covered)
+
+**Interfaces:**
+- Produces: `providers.Verdict` (string type) + constants `providers.VerdictNoAction|VerdictActionSuggested|VerdictActionRequired|VerdictInconclusive`; `Investigation.Verdict providers.Verdict`, `Investigation.RuledOut []string`, `Investigation.DataGaps []string`. All later tasks rely on these exact names.
+
+- [ ] **Step 1: Write the failing test** — extend `TestParseFindings`-style coverage in `tools_test.go`:
+
+```go
+func TestParseFindingsVerdictRuledOutDataGaps(t *testing.T) {
+	args := `{"title":"t","verdict":"no_action",
+		"ruled_out":["plan deleted — plans still discovered in aws_backup_info"],
+		"data_gaps":["CloudTrail truncated at 25 rows by SSM noise"],
+		"root_causes":[{"summary":"s"}]}`
+	inv, err := parseFindings(args)
+	if err != nil {
+		t.Fatalf("parseFindings: %v", err)
+	}
+	if inv.Verdict != providers.VerdictNoAction {
+		t.Fatalf("Verdict = %q, want no_action", inv.Verdict)
+	}
+	if len(inv.RuledOut) != 1 || len(inv.DataGaps) != 1 {
+		t.Fatalf("RuledOut/DataGaps not mapped: %+v", inv)
+	}
+}
+
+func TestParseFindingsUnknownVerdictNormalized(t *testing.T) {
+	inv, err := parseFindings(`{"verdict":"looks_fine","root_causes":[{"summary":"s"}]}`)
+	if err != nil {
+		t.Fatalf("parseFindings: %v", err)
+	}
+	if inv.Verdict != "" {
+		t.Fatalf("unknown verdict must map to empty, got %q", inv.Verdict)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — `go test ./internal/investigate/ -run TestParseFindingsVerdict -v` → FAIL (unknown fields / undefined `providers.VerdictNoAction`).
+
+- [ ] **Step 3: Implement.** In `providers.go`, immediately above `Investigation`:
+
+```go
+// Verdict classifies an investigation's actionability for the humans reading the
+// notification — the "do I need to do anything?" answer, separate from confidence
+// (how sure the model is) and severity (how the alert was labelled).
+type Verdict string
+
+const (
+	VerdictNoAction        Verdict = "no_action"        // benign / self-healed / synthetic; nothing to do
+	VerdictActionSuggested Verdict = "action_suggested" // a human should follow the suggested next steps
+	VerdictActionRequired  Verdict = "action_required"  // live impact; act promptly
+	VerdictInconclusive    Verdict = "inconclusive"     // could not be determined with available data
+)
+
+// ValidVerdict reports whether v is one of the model-facing enum values; the
+// parser normalizes anything else to "" so formatters can safely omit it.
+func ValidVerdict(v Verdict) bool {
+	switch v {
+	case VerdictNoAction, VerdictActionSuggested, VerdictActionRequired, VerdictInconclusive:
+		return true
+	}
+	return false
+}
+```
+
+Add to `Investigation` (after `Unresolved`):
+
+```go
+	Verdict  Verdict  // model-classified actionability; "" when the model omitted it (rendered nowhere)
+	RuledOut []string // hypotheses considered and rejected, one line each with the disproving evidence
+	DataGaps []string // signals that could not be obtained (tool errors, missing metrics, truncation) — a data limitation, not a question for a human
+```
+
+In `tools.go` `findings` struct add `Verdict string \`json:"verdict"\``, `RuledOut []string \`json:"ruled_out"\``, `DataGaps []string \`json:"data_gaps"\``. In `buildInvestigation` map them, normalizing the verdict:
+
+```go
+	inv := providers.Investigation{Title: f.Title, Confidence: clamp01(f.Confidence),
+		Unresolved: f.Unresolved, RuledOut: f.RuledOut, DataGaps: f.DataGaps}
+	if v := providers.Verdict(f.Verdict); providers.ValidVerdict(v) {
+		inv.Verdict = v
+	}
+```
+
+In `submitFindingsSpec()` schema add, after `"unresolved"`:
+
+```
+"verdict":{"type":"string","enum":["no_action","action_suggested","action_required","inconclusive"],"description":"actionability for the on-call: no_action (benign/self-healed/synthetic), action_suggested (a human should follow the next steps), action_required (live impact needing prompt action), inconclusive (could not determine)"},
+"ruled_out":{"type":"array","items":{"type":"string"},"description":"hypotheses you considered and REJECTED, one line each naming the disproving evidence"},
+"data_gaps":{"type":"array","items":{"type":"string"},"description":"signals you could not obtain (tool errors, missing metrics, truncated output) that limited the investigation - data limitations, NOT questions for a human"},
+```
+
+and change the `"unresolved"` description to `"genuine open questions only a human can answer - put tool or data limitations in data_gaps instead"` (add a description key to it). Extend `"required"` to `["root_causes","verdict"]`.
+
+In `loop.go` `systemPrompt`, append after the RIGOR block:
+
+```
+CLASSIFY the outcome in submit_findings "verdict": no_action (benign, self-healed, synthetic test,
+or noise), action_suggested (a human should follow your next steps), action_required (live impact
+needing prompt action), inconclusive. Separate honesty channels: "unresolved" is ONLY for questions a
+human must answer; a tool error, missing metric, or truncated output goes in "data_gaps"; a hypothesis
+you checked and disproved goes in "ruled_out" with the disproving evidence.
+```
+
+In `budget.go`, each synthetic Investigation gets `Verdict: providers.VerdictInconclusive` (match the existing struct-literal style at `:16,31,46`).
+
+In `eval/score.go` `investigationText`, append RuledOut and DataGaps lines exactly like the existing Unresolved handling at `:92` (recall text only; leave `claimText` untouched).
+
+- [ ] **Step 4: Run** — `go test ./internal/investigate/... ./internal/eval/... ./internal/providers/...` → PASS. `go vet ./...`.
+- [ ] **Step 5: Commit** — `feat(investigate): add verdict, ruled_out and data_gaps to the findings contract`
+
+---
+
+### Task 2: Verify pass routes rejected hypotheses to RuledOut
+
+**Files:**
+- Modify: `internal/investigate/verify.go` (`applyVerdicts` `:111-158`)
+- Test: `internal/investigate/verify_test.go`
+
+**Interfaces:**
+- Consumes: `Investigation.RuledOut`, `providers.VerdictInconclusive` (Task 1).
+- Produces: rejected hypotheses land in `inv.RuledOut` (formatted `"<summary> — <reason>"`), no longer in `inv.Unresolved`; when the verify pass rejects every hypothesis, `inv.Verdict` becomes `VerdictInconclusive`.
+
+- [ ] **Step 1: Failing test** in `verify_test.go` (follow the existing fixture style there — read the file first):
+
+```go
+// A rejected hypothesis is honesty about what was ruled out, not an open
+// question for a human: it must land in RuledOut, and rejecting everything
+// downgrades the verdict to inconclusive.
+func TestApplyVerdictsRejectedGoesToRuledOut(t *testing.T) { /* build an inv with one
+	hypothesis + a reject verdict via the existing test harness; assert:
+	len(inv.RuledOut)==1 && strings.Contains(inv.RuledOut[0], "<summary>");
+	no "Rejected hypothesis" entry in inv.Unresolved;
+	inv.Verdict == providers.VerdictInconclusive when it was VerdictNoAction before */ }
+```
+
+- [ ] **Step 2: Run** — `go test ./internal/investigate/ -run TestApplyVerdicts -v` → FAIL.
+- [ ] **Step 3: Implement** in `applyVerdicts`: replace the `:137` append-to-Unresolved (`"Rejected hypothesis: %s — %s"`) with `inv.RuledOut = append(inv.RuledOut, fmt.Sprintf("%s — %s", h.Summary, reason))` (keep whatever reason variable exists there), and where `inv.Verified = len(kept) > 0` is set (`:142`) add:
+
+```go
+	if len(kept) == 0 && inv.Verdict != "" {
+		// Everything the model concluded was refuted by the adversarial pass — an
+		// actionable verdict would be a confident claim with no surviving support.
+		inv.Verdict = providers.VerdictInconclusive
+	}
+```
+
+Update any existing verify tests asserting the old Unresolved wording.
+- [ ] **Step 4: Run** — `go test ./internal/investigate/...` → PASS.
+- [ ] **Step 5: Commit** — `feat(investigate): verify pass records rejected hypotheses in ruled_out`
+
+---
+
+### Task 3: Stamp alert metadata onto the Investigation
+
+**Files:**
+- Modify: `internal/providers/providers.go` (`Investigation`)
+- Modify: `internal/investigate/loop.go` (stamping block `:491-501`)
+- Modify: `internal/investigate/recall.go` (recall short-circuit ~`:231` — same stamping)
+- Test: `internal/investigate/loop_test.go` (or `investigate_test.go`, wherever a completed-loop investigation is asserted)
+
+**Interfaces:**
+- Consumes: `investigate.Request` fields (`Severity`, `Environment`, `Labels`, `At`).
+- Produces: `Investigation.Severity`, `.Environment`, `.Cluster`, `.Tenant`, `.AlertName string`, `.StartedAt time.Time` — Task 6/7 render these; Task 5 does not depend on them.
+
+- [ ] **Step 1: Failing test**: drive the existing fake-model loop harness with a Request carrying `Severity: "warning"`, `Environment: "prod"`, `At: start`, `Labels: map[string]string{"alertname":"BackupJobsMissing","cluster":"sanofi-003","tenant":"sanofi-003"}`; assert the delivered investigation carries all six fields.
+- [ ] **Step 2: Run** → FAIL (fields don't exist).
+- [ ] **Step 3: Implement.** `Investigation` gains (grouped after `Resource`, with a doc comment noting they are trigger-time facts for notification rendering, empty for sources that lack them):
+
+```go
+	Severity    string    // alert severity label at trigger time
+	Environment string    // deployment environment (prod/staging/…)
+	Cluster     string    // alert "cluster" label
+	Tenant      string    // alert "tenant" label
+	AlertName   string    // triggering alert name (labels["alertname"]); "" for non-alert sources
+	StartedAt   time.Time // incident start (alert startsAt / failure time)
+```
+
+In `loop.go` after the `inv.TriggerKey = req.TriggerKey` line:
+
+```go
+	// Trigger-time facts for the notification's metadata block: the model never
+	// sees or sets these; they come verbatim from the alert.
+	inv.Severity = req.Severity
+	inv.Environment = req.Environment
+	inv.Cluster = req.Labels["cluster"]
+	inv.Tenant = req.Labels["tenant"]
+	inv.AlertName = req.Labels["alertname"]
+	inv.StartedAt = req.At
+```
+
+Apply the same stamping to the recall short-circuit result in `recall.go` (find where the recalled Investigation gets Fingerprint/TriggerKey and mirror it — factor a small `stampRequestFacts(inv *providers.Investigation, req Request)` helper in `loop.go` and call it from both sites so they cannot drift).
+- [ ] **Step 4: Run** — `go test ./internal/investigate/...` → PASS.
+- [ ] **Step 5: Commit** — `feat(investigate): carry alert metadata onto the investigation for notification rendering`
+
+---
+
+### Task 4: Ledger — TriggerKey occurrences index + feedback events
+
+**Files:**
+- Modify: `internal/outcome/ledger.go`
+- Test: `internal/outcome/ledger_test.go`
+
+**Interfaces:**
+- Produces (Task 5/9 consume — exact signatures):
+  - `Event` gains `TriggerKey string \`json:"trigger_key,omitempty"\``, `CuratedURL string \`json:"curated_url,omitempty"\``, `Verdict string \`json:"verdict,omitempty"\``.
+  - `func (l *Ledger) Occurrences(triggerKey string) (n int, last time.Time, lastCuratedURL string)` — count of prior "open" events with that TriggerKey, the newest one's At and CuratedURL. Disabled ledger or empty key ⇒ `(0, time.Time{}, "")`.
+  - `func (l *Ledger) Feedback(triggerKey, fingerprint, rating string, at time.Time) error` — appends `{"event":"feedback","trigger_key":…,"fingerprint":…,"kind":rating,"at":…}`; rating is `"up"` or `"down"` (validate, reject others).
+
+- [ ] **Step 1: Failing tests** in `ledger_test.go` (follow existing temp-file test style):
+
+```go
+func TestOccurrencesByTriggerKey(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	t1 := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(6 * time.Hour)
+	_ = l.Open(Event{Fingerprint: "f1", TriggerKey: "k", CuratedURL: "https://kb/1", At: t1})
+	_ = l.Open(Event{Fingerprint: "f2", TriggerKey: "k", CuratedURL: "https://kb/2", At: t2})
+	_ = l.Open(Event{Fingerprint: "f3", TriggerKey: "other", At: t2})
+	n, last, url := l.Occurrences("k")
+	if n != 2 || !last.Equal(t2) || url != "https://kb/2" {
+		t.Fatalf("Occurrences = %d %v %q", n, last, url)
+	}
+	// index survives a replay (restart)
+	l2, _ := New(l.path)
+	if n, _, _ := l2.Occurrences("k"); n != 2 {
+		t.Fatalf("after replay: %d", n)
+	}
+}
+
+func TestFeedbackAppendsAndIsIgnoredByReplay(t *testing.T) {
+	// Feedback must not disturb open/resolve pairing or OpenCounts.
+	// Append open + feedback + resolve; assert Episodes() still pairs 1 episode
+	// and Feedback("k","f","sideways",…) returns an error.
+}
+```
+
+(`l.path` is unexported — inside the same package the test may use it, matching existing tests; check and mirror.)
+- [ ] **Step 2: Run** — `go test ./internal/outcome/ -v` → FAIL.
+- [ ] **Step 3: Implement.** Add fields to `Event`. Add to `Ledger` struct:
+
+```go
+	// byTrigger indexes "open" events per TriggerKey so delivery can render
+	// "Nth occurrence — previous: <KB link>" without replaying the file. Maintained
+	// in lockstep with the durable write, rebuilt on load, like agg.
+	byTrigger map[string]triggerAgg
+```
+
+```go
+// triggerAgg is the per-TriggerKey occurrence roll-up backing Occurrences.
+type triggerAgg struct {
+	count      int
+	last       time.Time
+	curatedURL string // CuratedURL of the newest open
+}
+```
+
+In `loadLocked`: reset `l.byTrigger = map[string]triggerAgg{}` and fold `case "open"` through a new `applyTriggerLocked(e)`; call the same from `Open` after `applyOpenLocked(e)`:
+
+```go
+// applyTriggerLocked folds one open into the per-TriggerKey occurrence index.
+func (l *Ledger) applyTriggerLocked(e Event) {
+	if e.TriggerKey == "" {
+		return
+	}
+	a := l.byTrigger[e.TriggerKey]
+	a.count++
+	if !e.At.Before(a.last) {
+		a.last = e.At
+		a.curatedURL = e.CuratedURL
+	}
+	l.byTrigger[e.TriggerKey] = a
+}
+```
+
+```go
+// Occurrences reports how many investigations have been recorded for a
+// TriggerKey, when the most recent one happened, and its KB link — the
+// recurrence facts the notifier renders. Zero values for a disabled ledger,
+// an empty key, or a never-seen key.
+func (l *Ledger) Occurrences(triggerKey string) (int, time.Time, string) {
+	if !l.enabled() || triggerKey == "" {
+		return 0, time.Time{}, ""
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	a := l.byTrigger[triggerKey]
+	return a.count, a.last, a.curatedURL
+}
+```
+
+```go
+// Feedback appends a human 👍/👎 verdict on a delivered investigation. It is a
+// pure append: replay ignores unknown event kinds, so feedback never disturbs
+// open/resolve pairing or the recall aggregate.
+func (l *Ledger) Feedback(triggerKey, fingerprint, rating string, at time.Time) error {
+	if !l.enabled() {
+		return nil
+	}
+	if rating != "up" && rating != "down" {
+		return fmt.Errorf("feedback rating %q: want up or down", rating)
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.appendLocked(Event{Event: "feedback", TriggerKey: triggerKey, Fingerprint: fingerprint, Kind: rating, At: at})
+}
+```
+
+(`fmt` import.) The `loadLocked`/`Episodes` switches already ignore unknown event kinds — verify, don't change.
+- [ ] **Step 4: Run** — `go test ./internal/outcome/... -race` → PASS.
+- [ ] **Step 5: Commit** — `feat(outcome): index opens by trigger key and record human feedback events`
+
+---
+
+### Task 5: OnComplete — stamp recurrence, reorder curate before ledger open
+
+**Files:**
+- Modify: `internal/providers/providers.go` (`Investigation`: recurrence fields)
+- Modify: `internal/app/investigate.go` (`OnComplete` closure `:291-365`)
+- Test: `internal/app/` (find the existing test that exercises `BuildInvestigator`'s OnComplete — if none covers ordering, add `internal/app/oncomplete_test.go` with a fake notifier + temp-file ledger)
+
+**Interfaces:**
+- Consumes: `Ledger.Occurrences` (Task 4), `Investigation.TriggerKey`.
+- Produces: `Investigation.Occurrences int` (1 = first time, N = this is the Nth), `Investigation.LastOccurrence time.Time`, `Investigation.PrevCuratedURL string`. Open events now carry `TriggerKey`, `CuratedURL`, `Verdict`.
+
+- [ ] **Step 1: Failing test**: with a real temp-file ledger pre-seeded with one open for TriggerKey "k" (CuratedURL "https://kb/prev", At = 4h ago), run the OnComplete closure with an investigation carrying TriggerKey "k"; assert the notifier received `Occurrences == 2`, `PrevCuratedURL == "https://kb/prev"`, and the ledger's newly appended open event has `TriggerKey == "k"` and the fresh `CuratedURL`.
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement.** `Investigation` gains:
+
+```go
+	Occurrences    int       // Nth recorded investigation of this TriggerKey (1 = first); 0 = unknown/ledger disabled
+	LastOccurrence time.Time // when the previous occurrence was investigated
+	PrevCuratedURL string    // the previous occurrence's KB link, for the "same conclusion as before" pointer
+```
+
+Rework `OnComplete` order to: **(1) query recurrence → (2) curate → (3) ledger opens → (4) actions → (5) deliver**. Concretely:
+
+```go
+	// Recurrence facts BEFORE recording this run's own open, so the count and
+	// "previous" pointer describe prior investigations only.
+	if n, last, url := ledger.Occurrences(found.TriggerKey); n > 0 {
+		found.Occurrences = n + 1
+		found.LastOccurrence = last
+		found.PrevCuratedURL = url
+	} else if found.TriggerKey != "" {
+		found.Occurrences = 1
+	}
+```
+
+Move the existing `cur.Curate` block **above** the ledger-open loop (updating its "Curate first so the delivered message can link to the KB issue/PR" comment to also say the open event stores the link for recurrence pointers), then extend the open event literal with:
+
+```go
+			TriggerKey: found.TriggerKey,
+			CuratedURL: found.CuratedURL,
+			Verdict:    string(found.Verdict),
+```
+
+Keep the action-handling switch where it is (before deliver). Note in the moved comment why curate now precedes the outcome open: the open event is the durable record of *this* investigation and must carry the KB link that recurrence pointers and the learning loop read.
+- [ ] **Step 4: Run** — `go test ./internal/app/... -race` → PASS.
+- [ ] **Step 5: Commit** — `feat(app): stamp recurrence facts and persist trigger key + KB link on outcome opens`
+
+---
+
+### Task 6: Shared Format() + webhook payload — verdict, metadata, ruled-out, data-gaps, recurrence
+
+**Files:**
+- Modify: `internal/notify/format.go`
+- Modify: `internal/notify/webhook/webhook.go` (`payload` `:44-51`, `Deliver`)
+- Test: `internal/notify/format_test.go`, `internal/notify/webhook/webhook_test.go`, `internal/notify/matrix_test.go` (only if its fixtures break)
+
+**Interfaces:**
+- Produces: `verdictBadge(v providers.Verdict) (emoji, label string)` in `format.go` (package `notify`, exported to nothing — same-package Slack code uses it in Task 7). Format output gains lines: `Verdict: <label>`, `Alert: … · severity … · cluster … · tenant …`, `Started: <RFC3339>`, `Occurrence: #N (last …; previous …)`, `*Ruled out:*`, `*Data gaps:*` sections.
+
+- [ ] **Step 1: Failing tests** in `format_test.go` — extend `sampleInvestigation()` with the new fields and assert each new line renders, plus omission cases (zero verdict ⇒ no "Verdict:" line; Occurrences ≤ 1 ⇒ no "Occurrence:" line; empty slices ⇒ no sections). **Constraint check test**: assert the composed output of a fully-populated investigation contains none of `& < >` beyond what evidence strings inject (guards the fallback-escape invariant).
+- [ ] **Step 2: Run** — `go test ./internal/notify/ -run TestFormat -v` → FAIL.
+- [ ] **Step 3: Implement** in `format.go`:
+
+```go
+// verdictBadge maps a model verdict to its emoji + human label. Empty/unknown
+// verdicts return ("", "") and are rendered nowhere — never invent a verdict.
+func verdictBadge(v providers.Verdict) (emoji, label string) {
+	switch v {
+	case providers.VerdictNoAction:
+		return "✅", "No action needed"
+	case providers.VerdictActionSuggested:
+		return "🛠", "Action suggested"
+	case providers.VerdictActionRequired:
+		return "🔥", "Action required"
+	case providers.VerdictInconclusive:
+		return "❓", "Inconclusive"
+	}
+	return "", ""
+}
+```
+
+In `Format`, after the confidence line: verdict line (`fmt.Fprintf(&b, "%s Verdict: %s\n", emoji, label)` when label ≠ ""); after the Resource line, a compact metadata line assembled from non-empty parts joined with " · " (`Alert: <AlertName>`, `severity <Severity>`, `env <Environment>`, `cluster <Cluster>`, `tenant <Tenant>`); `Started: <StartedAt RFC3339>` when non-zero; recurrence line when `Occurrences > 1`:
+
+```go
+		fmt.Fprintf(&b, "Occurrence: #%d — last investigated %s\n", inv.Occurrences, inv.LastOccurrence.UTC().Format(time.RFC3339))
+		if inv.PrevCuratedURL != "" {
+			fmt.Fprintf(&b, "Previous conclusion: %s\n", inv.PrevCuratedURL)
+		}
+```
+
+After the Unresolved section, two new sections mirroring its shape: `*Ruled out:*` over `inv.RuledOut` and `*Data gaps:*` over `inv.DataGaps`. (Plain `·`/`•` and `*` only — no `&<>`.)
+
+In `webhook.go`, extend `payload`:
+
+```go
+	Verdict        string   `json:"verdict,omitempty"`
+	Severity       string   `json:"severity,omitempty"`
+	Cluster        string   `json:"cluster,omitempty"`
+	Tenant         string   `json:"tenant,omitempty"`
+	AlertName      string   `json:"alert_name,omitempty"`
+	StartedAt      string   `json:"started_at,omitempty"` // RFC3339; "" when unknown
+	Occurrences    int      `json:"occurrences,omitempty"`
+	PrevCuratedURL string   `json:"prev_curated_url,omitempty"`
+	RuledOut       []string `json:"ruled_out,omitempty"`
+	DataGaps       []string `json:"data_gaps,omitempty"`
+```
+
+populated in `Deliver` (`StartedAt` via `inv.StartedAt.UTC().Format(time.RFC3339)` guarded by `!inv.StartedAt.IsZero()`). Extend `TestDeliverPOSTsJSON` for the new keys.
+- [ ] **Step 4: Run** — `go test ./internal/notify/... -race` → PASS (fix matrix fixtures if the richer `sampleInvestigation` breaks assertions).
+- [ ] **Step 5: Commit** — `feat(notify): render verdict, alert metadata, recurrence, ruled-out and data-gaps in the shared format`
+
+---
+
+### Task 7: Slack layout overhaul — summary/detail blocks, fields, compact fallback
+
+**Files:**
+- Modify: `internal/notify/slack.go` (`slackMessage` `:175-183`, `slackBlocks` `:231-317`, add `summaryBlocks`/`detailBlocks`/`metadataFields`/`slackDate`)
+- Test: `internal/notify/slack_test.go`
+
+**Interfaces:**
+- Consumes: `verdictBadge` (Task 6), all Investigation fields (Tasks 1-5).
+- Produces (Task 8 consumes): `summaryBlocks(inv providers.Investigation) []map[string]any` and `detailBlocks(inv providers.Investigation) []map[string]any` (detail returns nil when there is nothing beyond the summary). `slackMessage(inv)` becomes the **single-message** composition `append(summaryBlocks, detailBlocks...)` used by the webhook path. `fallbackText(inv providers.Investigation) string` — one line: `🔍 <title> — <verdict label> (<pct>% confidence)`.
+
+**Summary layout (top-down triage order):**
+1. `header` (plain_text): `🔍 ` + `inv.AlertName` when set (else Title), truncated 150. When AlertName is set, append ` — ` + first non-empty of Tenant/Cluster + `/` + `Resource.Ref()`.
+2. Verdict `section` (mrkdwn): `{emoji} *{label}* — {escapeMrkdwn(Title)}` truncated 2900 (only when verdict non-empty; when empty, fall back to the current confidence context line as the second block).
+3. `section` with `"fields"` (only non-empty entries, ≤10): `*Alert:*\n<name> (<severity>)`, `*Cluster:*\n<tenant · cluster>`, `*Resource:*\n<Kind Ref()>`, `*Started:*\n<slackDate(StartedAt)>`, `*What changed:*\n<top root cause ChangeRef, escaped, truncated 200, or "none">`, `*Recurrence:*\n🔁 #<N> · last <slackDate(LastOccurrence)>` (only when Occurrences > 1).
+4. Top root cause `section`: `*Why:* {escaped summary}` + up to 3 evidence bullets (escaped). When >1 root causes: trailing `_…full analysis in thread_` context hint (in Task 8 wording; for now `_…{n-1} more hypotheses below_`).
+5. Next-steps section — reuse the existing `nextSteps(inv)`, cap at 3 with `_…N more_`.
+6. `❌ *Ruled out:*` one section, items joined with `\n• ` (cap 3, `_…N more_`) — only when non-empty.
+7. `context`: `⚠️ Data gaps: ` + items joined `" · "`, escaped, truncated (only when non-empty).
+8. Recurrence pointer `context` when `PrevCuratedURL != ""`: `🔁 Previously investigated — <{escapeMrkdwn(PrevCuratedURL)}|previous conclusion>`.
+9. Footer `context`: `{confEmoji} {level} confidence · {pct}%` + ` · ✓ verified` when `inv.Verified` + ` · 🤖 RunLore SRE agent` + KB link (`📚 <url|view entry>`) + usage one-liner (`usageFooter`), joined with `  ·  `, truncated 2900. **This replaces** the old top confidence context line, the separate KB context block, and the fallback's usage footer position — confidence moves to the bottom, verdict owns the top.
+10. Approve/Reject actions blocks (existing code, unchanged) + feedback buttons (Task 9 adds them here).
+
+**Detail layout** (`detailBlocks`): header `section` `*Full analysis*`; every root cause rendered as today's per-RC section but with **all** evidence (still `truncate(…, 2900)` per section); full `*❓ Open questions*` section (all items); full `*⚠️ Data gaps:*` section (all items, bullets); full `*❌ Ruled out:*` (all items). Returns nil when `len(inv.RootCauses) ≤ 1 && Unresolved/DataGaps/RuledOut` all fit the summary caps (keep the rule simple: nil only when all three slices are empty and ≤1 root cause with ≤3 evidence — otherwise emit).
+
+**Helpers:**
+
+```go
+// slackDate renders t as a Slack date token that displays in the reader's local
+// timezone, with the RFC3339 UTC form as the no-JS fallback. Slack-blocks-only:
+// the token uses raw <>, so it must never enter the escaped fallback text.
+func slackDate(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return fmt.Sprintf("<!date^%d^{date_short_pretty} {time}|%s>", t.Unix(), t.UTC().Format(time.RFC3339))
+}
+```
+
+`fallbackText`: verdict label from `verdictBadge`; omit the ` — <label>` part when empty; pct from `confidenceBadge`.
+
+```go
+func fallbackText(inv providers.Investigation) string {
+	title := inv.Title
+	if title == "" {
+		title = "Investigation"
+	}
+	_, level, pct := confidenceBadge(inv)
+	s := "🔍 " + title
+	if _, label := verdictBadge(inv.Verdict); label != "" {
+		s += " — " + label
+	}
+	return escapeMrkdwn(fmt.Sprintf("%s (%s confidence · %d%%)", s, level, pct))
+}
+```
+
+`slackMessage` becomes `{"text": fallbackText(inv), "blocks": append(summaryBlocks(inv), detailBlocks(inv)...)}`.
+
+- [ ] **Step 1: Failing tests** (extend `slack_test.go`; use the `mrkdwnTexts` helper):
+  - `TestSlackSummaryLayout`: fully-populated investigation → first block header contains AlertName; second block contains `*No action needed*`; a fields section contains `*Cluster:*` and `*Recurrence:*`; footer context contains `confidence` and `view entry`; verify the OLD top-of-message confidence context line is gone (block[1] is not a context block).
+  - `TestSlackFallbackOneLine`: `slackMessage(inv)["text"]` has no `\n` and contains the verdict label; hostile title still escaped (`&lt;`).
+  - `TestSlackDetailBlocksFullEvidence`: 6-evidence root cause → summary shows 3 + `…`, detail blocks contain all 6.
+  - `TestSlackNoVerdictFallsBack`: verdict "" → no `*No action needed*` anywhere, layout still renders confidence.
+  - Keep/extend `TestSlackBlocksEscapeUntrustedText` with the new untrusted surfaces (ChangeRef in fields, DataGaps, RuledOut, PrevCuratedURL).
+  - Update `TestSlackBlocksLayout`, `TestSlackMessageFallbackEscaped` (fallback is now `fallbackText`, not `Format` — the test's invariant shifts: hostile **title** must be escaped) and `TestSlackDeliver`/`TestSlackBotDeliver` content expectations.
+- [ ] **Step 2: Run** — `go test ./internal/notify/ -v` → FAIL.
+- [ ] **Step 3: Implement** per the layout above. Update the `slackMessage`/`slackBlocks` doc comments (the escape-invariant comment at `:176-182` now describes `fallbackText`'s per-field escaping instead of whole-Format escaping).
+- [ ] **Step 4: Run** — `go test ./internal/notify/... -race` → PASS. `golangci-lint run ./internal/notify/...`.
+- [ ] **Step 5: Commit** — `feat(notify): verdict-first slack layout with metadata fields and compact fallback`
+
+---
+
+### Task 8: Slack threading — detail as a thread reply on the bot path
+
+**Files:**
+- Modify: `internal/notify/slack.go` (`SlackBot.post` `:124-162`, `SlackBot.Deliver` `:112-114`)
+- Test: `internal/notify/slack_test.go`
+
+**Interfaces:**
+- Consumes: `summaryBlocks`/`detailBlocks`/`fallbackText` (Task 7).
+- Produces: `func (s *SlackBot) post(ctx context.Context, msg map[string]any) (string, error)` — returns the posted message's `ts` ("" for empty-body 2xx). Webhook `Slack.Deliver` keeps the single combined message (unchanged from Task 7).
+
+- [ ] **Step 1: Failing test**:
+
+```go
+func TestSlackBotDeliverThreadsDetail(t *testing.T) {
+	// httptest server: first POST returns {"ok":true,"ts":"111.222"}; record each
+	// request body. Deliver a multi-hypothesis investigation.
+	// Assert: 2 POSTs; first has no "thread_ts" and its blocks contain the verdict
+	// summary; second has "thread_ts":"111.222" and its blocks contain "Full analysis";
+	// second's fallback text is short ("Full analysis" + title).
+}
+
+func TestSlackBotDeliverNoThreadWhenNoDetail(t *testing.T) {
+	// minimal investigation (detailBlocks nil) → exactly 1 POST.
+}
+
+func TestSlackBotDeliverDetailBestEffort(t *testing.T) {
+	// second POST returns {"ok":false,"error":"ratelimited"} → Deliver still
+	// returns nil (summary delivered = notification delivered); or assert the
+	// error is returned — DECISION: best-effort, return nil, matching the
+	// progress-ping precedent that a secondary message never fails delivery.
+}
+```
+
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement.** Change `SlackBot.post` to return `(string, error)`: extend the decoded result struct with `TS string \`json:"ts"\``, return `result.TS, nil` on success ("" on the empty-body path). Update `DeliverProgress` call site (`_, err := s.post(…)`). Rewrite `SlackBot.Deliver`:
+
+```go
+// Deliver posts the compact summary to the channel, then the full analysis as a
+// thread reply so the channel stays a scannable triage feed. The thread post is
+// best-effort: the summary IS the notification; a failed detail reply is logged
+// by the caller's Multi wrapper, never surfaced as a delivery failure.
+func (s *SlackBot) Deliver(ctx context.Context, inv providers.Investigation) error {
+	ts, err := s.post(ctx, map[string]any{"text": fallbackText(inv), "blocks": summaryBlocks(inv)})
+	if err != nil {
+		return err
+	}
+	detail := detailBlocks(inv)
+	if ts == "" || len(detail) == 0 {
+		return nil
+	}
+	msg := map[string]any{"text": "Full analysis: " + escapeMrkdwn(truncate(inv.Title, 120)), "blocks": detail, "thread_ts": ts}
+	if _, err := s.post(ctx, msg); err != nil {
+		return fmt.Errorf("slack detail thread (summary delivered): %w", err)
+	}
+	return nil
+}
+```
+
+**Decision locked in:** a detail-thread failure returns a wrapped error (so `Multi` logs it) — the wrapped message makes clear the summary landed. The webhook `Slack.Deliver` stays `s.post(ctx, slackMessage(inv))` (combined blocks).
+- [ ] **Step 4: Run** — `go test ./internal/notify/... -race` → PASS.
+- [ ] **Step 5: Commit** — `feat(notify): thread the full analysis under a compact slack summary`
+
+---
+
+### Task 9: 👍/👎 feedback buttons → outcome ledger
+
+**Files:**
+- Modify: `internal/notify/slack.go` (constants `:164-168`, feedback actions block in `summaryBlocks`)
+- Modify: `internal/server/server.go` (`handleSlackInteraction` `:239-304`, `Server` struct + constructor)
+- Modify: `internal/app/serve.go` (wire the ledger into the server, ~`:155-160` where the ledger is built)
+- Test: `internal/notify/slack_test.go`, `internal/server/server_test.go` (find the existing slack-interaction signature-test helpers and reuse them)
+
+**Interfaces:**
+- Consumes: `Ledger.Feedback` (Task 4).
+- Produces: action_ids `runlore_feedback_up` / `runlore_feedback_down`; button `value` = `inv.TriggerKey`, falling back to `inv.Fingerprint` (buttons omitted when both empty). Server gains a `feedback` field of interface type `FeedbackRecorder`:
+
+```go
+// FeedbackRecorder persists a human 👍/👎 on a delivered investigation
+// (implemented by *outcome.Ledger).
+type FeedbackRecorder interface {
+	Feedback(triggerKey, fingerprint, rating string, at time.Time) error
+}
+```
+
+- [ ] **Step 1: Failing tests**:
+  - notify: `TestSlackFeedbackButtons` — investigation with TriggerKey "k" → summary blocks contain an actions block with both feedback action_ids and `"value":"k"`; investigation with neither TriggerKey nor Fingerprint → no feedback block. Feedback buttons render even when no ApprovalID actions exist.
+  - server: `TestSlackFeedbackInteraction` — signed interaction payload with `action_id: "runlore_feedback_up"`, value "k" → 200, recorder called with `("k", "", "up")`, works with `approvals == nil`; user NOT in the approver allowlist still succeeds (feedback is unprivileged); `runlore_approve` with `approvals == nil` returns a "not enabled" message rather than 404.
+- [ ] **Step 2: Run** → FAIL.
+- [ ] **Step 3: Implement.**
+  - `slack.go`: constants `feedbackUpActionID = "runlore_feedback_up"`, `feedbackDownActionID = "runlore_feedback_down"`. At the end of `summaryBlocks`:
+
+```go
+	// Human feedback on the verdict — ground truth for the learning loop. Keyed by
+	// TriggerKey (incident identity) so ratings survive re-worded re-investigations.
+	if key := cmp.Or(inv.TriggerKey, inv.Fingerprint); key != "" {
+		blocks = append(blocks, map[string]any{"type": "actions", "elements": []map[string]any{
+			{"type": "button", "action_id": feedbackUpActionID, "value": key,
+				"text": map[string]any{"type": "plain_text", "text": "👍 Accurate", "emoji": true}},
+			{"type": "button", "action_id": feedbackDownActionID, "value": key,
+				"text": map[string]any{"type": "plain_text", "text": "👎 Off-base", "emoji": true}},
+		}})
+	}
+```
+
+  - `server.go`: relax the guard to `if (s.approvals == nil && s.feedback == nil) || s.slackSecret == ""`; in the approve/reject cases, guard `s.approvals == nil` → `msg = "❌ approvals not enabled"`. New cases:
+
+```go
+	case "runlore_feedback_up", "runlore_feedback_down":
+		if s.feedback == nil {
+			msg = "⚠️ feedback recording not enabled (no outcome ledger configured)"
+			break
+		}
+		rating := "up"
+		if act.ActionID == "runlore_feedback_down" {
+			rating = "down"
+		}
+		if ferr := s.feedback.Feedback(act.Value, "", rating, time.Now()); ferr != nil {
+			msg = "⚠️ recording feedback failed: " + ferr.Error()
+			s.log.Warn("slack feedback failed", "key", act.Value, "err", ferr)
+		} else {
+			msg = fmt.Sprintf("🙏 feedback recorded (%s) — thanks @%s", rating, p.User.Username)
+			s.log.Info("slack feedback recorded", "key", act.Value, "rating", rating, "user", p.User.Username)
+		}
+```
+
+    **Important:** feedback must NOT `replace_original` (that would wipe the investigation message). `updateSlack` hardcodes `replace_original: true` — add a boolean param (or a sibling `appendSlack`) posting `{"replace_original": false, "response_url" …, "text": msg}` for the feedback cases; approve/reject keep replacing.
+  - Wire: follow how `approvals`/`slackSecret` reach the `Server` (constructor/opts in `server.go` + call site in `internal/app/serve.go`) and pass the built `*outcome.Ledger` the same way. A nil ledger stays a nil interface — guard with a typed-nil check at the wiring site (`if ledger != nil { opts.Feedback = ledger }`).
+- [ ] **Step 4: Run** — `go test ./internal/server/... ./internal/notify/... ./internal/app/... -race` → PASS.
+- [ ] **Step 5: Commit** — `feat(feedback): slack 👍/👎 buttons record investigation feedback in the outcome ledger`
+
+---
+
+### Task 10: Docs
+
+**Files:**
+- Modify: `README.md` (`:39-44` layout caption, `:107` notifier table)
+- Modify: `docs/configuration.md` (`:171-173` notify section)
+- Modify: `docs/getting-started.md` (`:282-293` notify YAML, `:466,502-503` interactions notes)
+- Modify: `docs/learning-loop.md` (outcome ledger: new feedback events + trigger-key index)
+- Check: `hack/demo.config.yaml` (no schema change expected — confirm)
+
+**Interfaces:** none (prose only).
+
+- [ ] **Step 1:** Update README caption to describe the new layout (verdict-first summary + threaded full analysis + feedback buttons) and add a note that the screenshot predates the layout (regenerating it is a human follow-up). Update the notifier table: Slack bot = threaded summary/detail; webhook Slack + Matrix + generic webhook = single comprehensive message.
+- [ ] **Step 2:** configuration.md/getting-started.md: document that feedback buttons require `signing_secret_env` + the `/slack/interactions` Request URL (same setup as approvals) and that ratings land in the outcome ledger (`outcome.ledger_path`). Document the new webhook JSON payload fields (verdict, severity, cluster, tenant, alert_name, started_at, occurrences, prev_curated_url, ruled_out, data_gaps).
+- [ ] **Step 3:** learning-loop.md: describe `feedback` ledger events and the TriggerKey occurrence index.
+- [ ] **Step 4:** `go build ./... && go test -race ./... && test -z "$(gofmt -l .)" && go vet ./...` — full suite green.
+- [ ] **Step 5: Commit** — `docs: document verdict-first notifications, threading and feedback buttons`
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: verdict line (T1/6/7), confidence demotion (T7 footer), threading (T8), open-questions split into data gaps (T1/6/7), metadata fields block (T3/6/7), recurrence (T4/5/6/7), ruled-out (T1/2/6/7), fallback one-liner (T7), ChangeRef out of backticks (T7 fields render), copyable commands — covered by keeping mrkdwn code-block passthrough? NO: commands arrive as prose inside suggestions; wrapping them is model-output-dependent — dropped as unimplementable formatter-side, noted in PR description instead. Timestamps `<!date^` (T7), feedback buttons (T9), docs (T10).
+- Type consistency: `Verdict` is `providers.Verdict` on Investigation but `string` in `outcome.Event` (deliberate: the ledger is a serialization boundary). `post` returns `(string, error)` — `DeliverProgress` call sites updated in T8.
+- Ordering hazard: T5 reorders curate before ledger-open — the failing test must pin the new order (curated URL present on the open event).

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -245,6 +245,14 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	if actions.Enabled() {
 		log.Info("action policy enabled", "mode", string(actions.Mode()))
 	}
+	// Recurrence cooldown (opt-in): suppress re-investigating a trigger the agent
+	// conclusively answered moments ago. Validate already requires a ledger with a
+	// non-zero cooldown; Enabled() guards the disabled-ledger edge regardless.
+	var recurrence *investigate.RecurrenceGate
+	if d := cfg.Investigation.RecurrenceCooldown.Std(); d > 0 && ledger.Enabled() {
+		recurrence = &investigate.RecurrenceGate{Outcome: ledger, Cooldown: d, Log: log}
+		log.Info("recurrence cooldown enabled", "cooldown", d)
+	}
 	// Per-tool timeout: default to 60s when unset (0) so one hung tool can't eat the
 	// whole per-investigation budget; an explicit config value flows through as-is.
 	toolTimeout := cfg.Investigation.ToolTimeout.Std()
@@ -293,6 +301,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		Log:                       log,
 		Actions:                   actions,
 		Recall:                    recall,
+		Recurrence:                recurrence,
 		Verify:                    true, // adversarial review of root causes before delivery/curation
 		Metrics:                   metrics,
 		ModelProvider:             cfg.Model.Provider,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,6 +180,14 @@ type Investigation struct {
 	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via applyDefaults
 	ToolTimeout               Duration  `yaml:"tool_timeout"`                 // per-TOOL-call timeout so one hung tool can't eat the budget; 0 ⇒ default (60s) at construction
 
+	// RecurrenceCooldown (opt-in, 0 = off) suppresses re-investigating a trigger
+	// whose previous investigation completed less than this long ago, concluded
+	// (verdict ≠ inconclusive), and has no standing 👎 feedback. Without it a
+	// still-firing alert re-investigates on every Alertmanager repeat_interval and
+	// a persistently-failing GitOps resource on every informer resync (~10m).
+	// Requires outcome.ledger_path (the gate reads the ledger's trigger index).
+	RecurrenceCooldown Duration `yaml:"recurrence_cooldown"`
+
 	// Compaction selects how mid-loop history compaction treats the tool outputs it
 	// elides once the estimate crosses the compaction target. "" / "elide" is the
 	// default: drop their bodies for short markers (lossy). "summarize" first asks a
@@ -872,6 +880,14 @@ func (c *Config) Validate() error {
 		if !providers.ValidVerdict(providers.Verdict(v)) {
 			return fmt.Errorf("forge.skip_verdicts[%d]: unknown verdict %q (want no_action|action_suggested|action_required|inconclusive)", i, v)
 		}
+	}
+	// The recurrence cooldown reads the outcome ledger's trigger index; without a
+	// ledger it would silently never suppress — fail loud instead. A negative
+	// duration is always a misconfiguration (mirrors tool_timeout).
+	if d := c.Investigation.RecurrenceCooldown.Std(); d < 0 {
+		return fmt.Errorf("investigation.recurrence_cooldown must be >= 0 (0 = off), got %v", d)
+	} else if d > 0 && c.Outcome.LedgerPath == "" {
+		return fmt.Errorf("investigation.recurrence_cooldown requires outcome.ledger_path (the suppression gate reads the ledger's per-trigger index)")
 	}
 	// Feedback buttons are click-driven: enabling them without the pieces a click
 	// needs would either accept unsigned requests (never) or render buttons whose

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -558,3 +558,34 @@ func TestValidateFeedbackButtons(t *testing.T) {
 		t.Fatalf("feedback_buttons with secret + ledger must validate clean, got: %v", err)
 	}
 }
+
+// TestValidateRecurrenceCooldown: the suppression gate reads the outcome
+// ledger's trigger index, so a cooldown without a ledger would silently never
+// suppress — rejected at startup. Negative durations are misconfigurations; 0
+// (off) and a properly-backed positive value validate clean.
+func TestValidateRecurrenceCooldown(t *testing.T) {
+	off := &Config{}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("cooldown off must validate clean, got: %v", err)
+	}
+
+	noLedger := &Config{}
+	noLedger.Investigation.RecurrenceCooldown = Duration(30 * time.Minute)
+	if err := noLedger.Validate(); err == nil {
+		t.Fatal("recurrence_cooldown without outcome.ledger_path must be rejected")
+	}
+
+	neg := &Config{}
+	neg.Investigation.RecurrenceCooldown = Duration(-time.Minute)
+	neg.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
+	if err := neg.Validate(); err == nil {
+		t.Fatal("a negative recurrence_cooldown must be rejected")
+	}
+
+	ok := &Config{}
+	ok.Investigation.RecurrenceCooldown = Duration(30 * time.Minute)
+	ok.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("cooldown with a ledger must validate clean, got: %v", err)
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -225,11 +225,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	}()
 	// Recurrence cooldown (opt-in) — checked BEFORE recall: within the cooldown even
 	// a recallable answer would only re-deliver what the channel already shows. A
-	// suppressed occurrence costs nothing and says nothing (no model call, no
-	// notification, no ledger open — see RecurrenceGate for why not recording the
-	// open is load-bearing); the next occurrence past the cooldown re-investigates
-	// in full. An inconclusive prior never suppresses, and a standing 👎 re-arms
-	// investigation immediately.
+	// suppressed occurrence makes no model call, sends no notification, records no
+	// ledger open (see RecurrenceGate for why not recording the open is load-bearing
+	// — and for the workqueue/rate-limit slot it does still spend); the next
+	// occurrence past the cooldown re-investigates in full. An inconclusive prior
+	// never suppresses, and a standing 👎 re-arms investigation immediately.
 	if prior, ok := li.Recurrence.suppress(req, time.Now()); ok {
 		result = "recurrence_suppressed"
 		li.Log.Info("recurrence cooldown: suppressing re-investigation",

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -117,6 +117,7 @@ type LoopInvestigator struct {
 	OnComplete func(providers.Investigation) // delivery hook (Slack/Matrix later)
 	Actions    *action.Policy                // autonomy ladder; nil/off = read-only findings only
 	Recall     *Recall                       // optional: short-circuit on a high-confidence catalog hit
+	Recurrence *RecurrenceGate               // optional: suppress re-investigating a just-answered trigger
 	Verify     bool                          // run an adversarial review of root causes before delivery
 
 	// OnRecall, when set, receives one RecallDecision per investigation whenever a
@@ -222,6 +223,21 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			li.Metrics.InvestigationsCompleted.Add(ctx, 1, attrs)
 		}
 	}()
+	// Recurrence cooldown (opt-in) — checked BEFORE recall: within the cooldown even
+	// a recallable answer would only re-deliver what the channel already shows. A
+	// suppressed occurrence costs nothing and says nothing (no model call, no
+	// notification, no ledger open — see RecurrenceGate for why not recording the
+	// open is load-bearing); the next occurrence past the cooldown re-investigates
+	// in full. An inconclusive prior never suppresses, and a standing 👎 re-arms
+	// investigation immediately.
+	if prior, ok := li.Recurrence.suppress(req, time.Now()); ok {
+		result = "recurrence_suppressed"
+		li.Log.Info("recurrence cooldown: suppressing re-investigation",
+			"title", req.Title, "trigger_key", req.TriggerKey,
+			"occurrences", prior.Count, "last_investigated", prior.Last,
+			"verdict", prior.Verdict, "prev_url", prior.CuratedURL)
+		return nil
+	}
 	// Instant recall is disabled under auto-execution: a poisoned catalog entry must
 	// not short-circuit a real investigation straight into an auto-executed action.
 	if li.Recall != nil && (li.Actions == nil || !li.Actions.IsAuto()) {

--- a/internal/investigate/recurrence.go
+++ b/internal/investigate/recurrence.go
@@ -29,12 +29,18 @@ type RecurrenceStats interface {
 //   - a standing 👎 on the trigger breaks the cooldown immediately — a human
 //     saying "that diagnosis is wrong" re-arms the very next occurrence.
 //
-// A suppressed occurrence costs nothing and says nothing: no model call, no
-// notification, no ledger open. That last part is load-bearing — recording an
-// open would slide the byTrigger newest-open timestamp and the cooldown would
-// never lapse while the incident keeps firing. Anchored on the last REAL
-// investigation, a persistent failure is re-investigated once per cooldown
-// (with its recurrence count intact) instead of once per resync.
+// A suppressed occurrence makes no model call, sends no notification, and
+// records no ledger open. (It does still consume a workqueue turn and a
+// rate-limiter slot — the gate runs below Queue.process like its sibling, the
+// recall short-circuit; the same accepted tradeoff for both.) Not recording
+// the open is load-bearing — an open would slide the byTrigger newest-open
+// timestamp and the cooldown would never lapse while the incident keeps
+// firing. Anchored on the last REAL investigation, a persistent failure is
+// re-investigated once per cooldown (with its recurrence count intact) instead
+// of once per resync. The flip side: the ledger keeps no durable record of
+// suppressed firings (only the recurrence_suppressed metric and a log line see
+// them) — a future consumer needing raw firing frequency is the moment to
+// promote suppression to a first-class event kind, not before.
 type RecurrenceGate struct {
 	Outcome  RecurrenceStats
 	Cooldown time.Duration // 0 disables the gate (default: off, opt-in)

--- a/internal/investigate/recurrence.go
+++ b/internal/investigate/recurrence.go
@@ -1,0 +1,65 @@
+package investigate
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// RecurrenceStats is the per-TriggerKey ledger snapshot the suppression gate
+// reads. *outcome.Ledger satisfies it.
+type RecurrenceStats interface {
+	Recurrence(triggerKey string) outcome.TriggerRecurrence
+}
+
+// RecurrenceGate suppresses re-investigating a trigger that was conclusively
+// investigated moments ago. Without it, nothing keys on TriggerKey before the
+// paid loop: Alertmanager re-sends a still-firing alert every repeat_interval
+// and a persistently-failing GitOps resource re-emits every informer resync
+// (~10m), each re-running a full investigation that re-delivers the same answer
+// as fresh noise — the recall short-circuit only helps once the KB PR is MERGED,
+// so the human-review window is exactly when the repetition is worst.
+//
+// The gate is deliberately human-deferential, in both directions:
+//   - it only suppresses a CONCLUSIVE prior answer (verdict no_action /
+//     action_suggested / action_required) — an inconclusive or pre-verdict prior
+//     never suppresses, because there is no answer worth not repeating;
+//   - a standing 👎 on the trigger breaks the cooldown immediately — a human
+//     saying "that diagnosis is wrong" re-arms the very next occurrence.
+//
+// A suppressed occurrence costs nothing and says nothing: no model call, no
+// notification, no ledger open. That last part is load-bearing — recording an
+// open would slide the byTrigger newest-open timestamp and the cooldown would
+// never lapse while the incident keeps firing. Anchored on the last REAL
+// investigation, a persistent failure is re-investigated once per cooldown
+// (with its recurrence count intact) instead of once per resync.
+type RecurrenceGate struct {
+	Outcome  RecurrenceStats
+	Cooldown time.Duration // 0 disables the gate (default: off, opt-in)
+	Log      *slog.Logger  // optional; nil-safe
+}
+
+// suppress reports whether req should be suppressed, returning the prior
+// investigation's facts for the caller's log line. now is a parameter so the
+// decision matrix is testable without sleeping.
+func (g *RecurrenceGate) suppress(req Request, now time.Time) (outcome.TriggerRecurrence, bool) {
+	if g == nil || g.Outcome == nil || g.Cooldown <= 0 || req.TriggerKey == "" {
+		return outcome.TriggerRecurrence{}, false
+	}
+	r := g.Outcome.Recurrence(req.TriggerKey)
+	if r.Count == 0 || now.Sub(r.Last) >= g.Cooldown {
+		return r, false
+	}
+	switch providers.Verdict(r.Verdict) {
+	case providers.VerdictNoAction, providers.VerdictActionSuggested, providers.VerdictActionRequired:
+		// conclusive — eligible for suppression
+	default:
+		return r, false // inconclusive or pre-verdict: retry, we owe a real answer
+	}
+	if r.FeedbackDown > 0 {
+		return r, false // a human contested the diagnosis: cooldown broken
+	}
+	return r, true
+}

--- a/internal/investigate/recurrence_test.go
+++ b/internal/investigate/recurrence_test.go
@@ -1,0 +1,87 @@
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeRecurrenceStats struct{ r outcome.TriggerRecurrence }
+
+func (f fakeRecurrenceStats) Recurrence(string) outcome.TriggerRecurrence { return f.r }
+
+// TestRecurrenceGateDecisions pins the full suppression matrix: suppress ONLY
+// when the trigger was investigated within the cooldown, the prior verdict was
+// conclusive, and no human currently contests it — every other combination
+// re-investigates.
+func TestRecurrenceGateDecisions(t *testing.T) {
+	now := time.Unix(50000, 0)
+	recent := now.Add(-5 * time.Minute)
+	stale := now.Add(-2 * time.Hour)
+	req := Request{Title: "t", TriggerKey: "k"}
+	cases := []struct {
+		name string
+		gate *RecurrenceGate
+		req  Request
+		want bool
+	}{
+		{"suppresses a fresh conclusive uncontested recurrence",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 1, Last: recent, Verdict: "no_action"}}, Cooldown: time.Hour}, req, true},
+		{"action_required is conclusive too",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 2, Last: recent, Verdict: "action_required"}}, Cooldown: time.Hour}, req, true},
+		{"nil gate never suppresses", nil, req, false},
+		{"cooldown 0 (off) never suppresses",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 1, Last: recent, Verdict: "no_action"}}}, req, false},
+		{"no trigger key never suppresses",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 1, Last: recent, Verdict: "no_action"}}, Cooldown: time.Hour}, Request{Title: "t"}, false},
+		{"never investigated",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{}, Cooldown: time.Hour}, req, false},
+		{"cooldown expired — re-investigate",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 3, Last: stale, Verdict: "no_action"}}, Cooldown: time.Hour}, req, false},
+		{"inconclusive prior — retry, there is no answer worth repeating",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 1, Last: recent, Verdict: "inconclusive"}}, Cooldown: time.Hour}, req, false},
+		{"pre-verdict prior (old events) — retry",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 1, Last: recent}}, Cooldown: time.Hour}, req, false},
+		{"a standing 👎 breaks the cooldown — the human re-arms investigation",
+			&RecurrenceGate{Outcome: fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 1, Last: recent, Verdict: "no_action", FeedbackDown: 1}}, Cooldown: time.Hour}, req, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, got := c.gate.suppress(c.req, now); got != c.want {
+				t.Fatalf("suppress = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestInvestigateSuppressedRecurrenceSkipsModelAndDelivery: a suppressed
+// recurrence must cost nothing and say nothing — no model call, no OnComplete
+// (no notification, no curation, no ledger open), nil error. The previous
+// notification remains THE answer until the cooldown lapses or a 👎 lands.
+func TestInvestigateSuppressedRecurrenceSkipsModelAndDelivery(t *testing.T) {
+	model := &blockingModel{}
+	delivered := 0
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(providers.Investigation) { delivered++ },
+		Recurrence: &RecurrenceGate{
+			Outcome:  fakeRecurrenceStats{outcome.TriggerRecurrence{Count: 1, Last: time.Now().Add(-time.Minute), Verdict: "no_action"}},
+			Cooldown: time.Hour,
+		},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "t", TriggerKey: "k"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if model.calls != 0 {
+		t.Fatalf("model called %d times during a suppressed recurrence, want 0", model.calls)
+	}
+	if delivered != 0 {
+		t.Fatalf("OnComplete called %d times during a suppressed recurrence, want 0", delivered)
+	}
+}

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -191,6 +191,7 @@ type triggerAggJSON struct {
 	Last       time.Time `json:"last"`
 	CuratedURL string    `json:"curated_url,omitempty"`
 	Entry      string    `json:"entry,omitempty"`
+	Verdict    string    `json:"verdict,omitempty"`
 }
 
 type feedbackVoteJSON struct {
@@ -203,12 +204,14 @@ type pendingOpenJSON struct {
 	Counted bool   `json:"counted,omitempty"`
 }
 
-// triggerAgg is the per-TriggerKey occurrence roll-up backing Occurrences.
+// triggerAgg is the per-TriggerKey occurrence roll-up backing Occurrences and
+// Recurrence.
 type triggerAgg struct {
 	count      int
 	last       time.Time
 	curatedURL string // CuratedURL of the newest open
 	entry      string // Entry of the newest open ("" for fresh) — feedback attribution target
+	verdict    string // Verdict of the newest open — the suppression gate's "conclusive?" input
 }
 
 // feedbackVote is the fold state of one (TriggerKey, user) feedback: the rating
@@ -337,7 +340,7 @@ func (l *Ledger) seedCheckpointLocked(cd *checkpointData) {
 		l.open[fp] = ev
 	}
 	for k, v := range cd.ByTrigger {
-		l.byTrigger[k] = triggerAgg{count: v.Count, last: v.Last, curatedURL: v.CuratedURL, entry: v.Entry}
+		l.byTrigger[k] = triggerAgg{count: v.Count, last: v.Last, curatedURL: v.CuratedURL, entry: v.Entry, verdict: v.Verdict}
 	}
 	for k, v := range cd.Votes {
 		l.votes[k] = feedbackVote{rating: v.Rating, entry: v.Entry}
@@ -391,7 +394,7 @@ func (l *Ledger) snapshotCheckpointLocked() *checkpointData {
 	if len(l.byTrigger) > 0 {
 		cd.ByTrigger = make(map[string]triggerAggJSON, len(l.byTrigger))
 		for k, v := range l.byTrigger {
-			cd.ByTrigger[k] = triggerAggJSON{Count: v.count, Last: v.last, CuratedURL: v.curatedURL, Entry: v.entry}
+			cd.ByTrigger[k] = triggerAggJSON{Count: v.count, Last: v.last, CuratedURL: v.curatedURL, Entry: v.entry, Verdict: v.verdict}
 		}
 	}
 	if len(l.votes) > 0 {
@@ -673,8 +676,9 @@ func (l *Ledger) applyTriggerLocked(e Event) {
 		a.curatedURL = e.CuratedURL
 		// Feedback attribution follows the newest open: a fresh open (Entry "")
 		// deliberately CLEARS it — a vote on a fresh investigation must not credit
-		// an older recall's entry.
+		// an older recall's entry. The verdict tracks the newest open the same way.
 		a.entry = e.Entry
+		a.verdict = e.Verdict
 	}
 	l.byTrigger[e.TriggerKey] = a
 }
@@ -691,6 +695,39 @@ func (l *Ledger) Occurrences(triggerKey string) (int, time.Time, string) {
 	defer l.mu.Unlock()
 	a := l.byTrigger[triggerKey]
 	return a.count, a.last, a.curatedURL
+}
+
+// TriggerRecurrence is the per-TriggerKey snapshot the pre-investigation
+// suppression gate reads: how many investigations this trigger has had, when the
+// last one was and what it concluded, its KB link, and how many humans currently
+// contest that conclusion.
+type TriggerRecurrence struct {
+	Count        int
+	Last         time.Time
+	Verdict      string // newest open's verdict ("" for pre-verdict events)
+	CuratedURL   string
+	FeedbackDown int // LIVE 👎 votes for this trigger, after per-user dedup
+}
+
+// Recurrence returns the trigger's recurrence snapshot. FeedbackDown counts the
+// votes map's current "down" entries for the key — O(live votes), which stays
+// small (one entry per trigger×user) and off the recall hot path (read once per
+// incoming investigation). Zero value for a disabled ledger or unseen key.
+func (l *Ledger) Recurrence(triggerKey string) TriggerRecurrence {
+	if !l.enabled() || triggerKey == "" {
+		return TriggerRecurrence{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	a := l.byTrigger[triggerKey]
+	tr := TriggerRecurrence{Count: a.count, Last: a.last, Verdict: a.verdict, CuratedURL: a.curatedURL}
+	prefix := triggerKey + "\x00"
+	for k, v := range l.votes {
+		if v.rating == "down" && strings.HasPrefix(k, prefix) {
+			tr.FeedbackDown++
+		}
+	}
+	return tr
 }
 
 // Episodes replays the full ledger and turns every open into an Episode, pairing

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -686,15 +686,11 @@ func (l *Ledger) applyTriggerLocked(e Event) {
 // Occurrences reports how many investigations have been recorded for a
 // TriggerKey, when the most recent one happened, and its KB link — the
 // recurrence facts the notifier renders. Zero values for a disabled ledger,
-// an empty key, or a never-seen key.
+// an empty key, or a never-seen key. A narrowing of Recurrence for the
+// delivery path, which has no use for the verdict or the 👎-vote count.
 func (l *Ledger) Occurrences(triggerKey string) (int, time.Time, string) {
-	if !l.enabled() || triggerKey == "" {
-		return 0, time.Time{}, ""
-	}
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	a := l.byTrigger[triggerKey]
-	return a.count, a.last, a.curatedURL
+	r := l.Recurrence(triggerKey)
+	return r.Count, r.Last, r.CuratedURL
 }
 
 // TriggerRecurrence is the per-TriggerKey snapshot the pre-investigation

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1264,15 +1264,15 @@ func TestRecurrenceQuery(t *testing.T) {
 		t.Fatalf("Recurrence = %+v, want count=2 last=+1h verdict=action_suggested url=kb/2", r)
 	}
 	// Two users contest; one changes their mind back to 👍 — one live 👎 remains.
-	_ = l.Feedback("k", "", "down", "U1", t0.Add(2*time.Hour))
-	_ = l.Feedback("k", "", "down", "U2", t0.Add(2*time.Hour))
-	_ = l.Feedback("k", "", "up", "U2", t0.Add(3*time.Hour))
+	_ = l.Feedback("k", "down", "U1", t0.Add(2*time.Hour))
+	_ = l.Feedback("k", "down", "U2", t0.Add(2*time.Hour))
+	_ = l.Feedback("k", "up", "U2", t0.Add(3*time.Hour))
 	if r := l.Recurrence("k"); r.FeedbackDown != 1 {
 		t.Fatalf("live 👎 votes = %d, want 1 (U2 moved to up)", r.FeedbackDown)
 	}
 	// Votes on another trigger never leak into k.
 	_ = l.Open(Event{Fingerprint: "f3", Kind: "fresh", TriggerKey: "other", At: t0})
-	_ = l.Feedback("other", "", "down", "U9", t0.Add(time.Hour))
+	_ = l.Feedback("other", "down", "U9", t0.Add(time.Hour))
 	if r := l.Recurrence("k"); r.FeedbackDown != 1 {
 		t.Fatalf("cross-trigger vote leaked: %+v", r)
 	}

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1247,3 +1247,56 @@ func TestFeedbackSurvivesCompaction(t *testing.T) {
 		t.Fatalf("checkpointed vote must move, got %+v", a["e.md"])
 	}
 }
+
+// TestRecurrenceQuery pins the per-TriggerKey snapshot the pre-investigation
+// suppression gate reads: investigation count, when the last one was, its
+// verdict + KB link, and the number of LIVE 👎 votes (after per-user dedup).
+func TestRecurrenceQuery(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(40000, 0)
+	if r := l.Recurrence("k"); r.Count != 0 || r.FeedbackDown != 0 {
+		t.Fatalf("unseen key must be zero, got %+v", r)
+	}
+	_ = l.Open(Event{Fingerprint: "f1", Kind: "fresh", TriggerKey: "k", CuratedURL: "https://kb/1", Verdict: "no_action", At: t0})
+	_ = l.Open(Event{Fingerprint: "f2", Kind: "recall", Entry: "e.md", TriggerKey: "k", CuratedURL: "https://kb/2", Verdict: "action_suggested", At: t0.Add(time.Hour)})
+	r := l.Recurrence("k")
+	if r.Count != 2 || !r.Last.Equal(t0.Add(time.Hour)) || r.Verdict != "action_suggested" || r.CuratedURL != "https://kb/2" {
+		t.Fatalf("Recurrence = %+v, want count=2 last=+1h verdict=action_suggested url=kb/2", r)
+	}
+	// Two users contest; one changes their mind back to 👍 — one live 👎 remains.
+	_ = l.Feedback("k", "", "down", "U1", t0.Add(2*time.Hour))
+	_ = l.Feedback("k", "", "down", "U2", t0.Add(2*time.Hour))
+	_ = l.Feedback("k", "", "up", "U2", t0.Add(3*time.Hour))
+	if r := l.Recurrence("k"); r.FeedbackDown != 1 {
+		t.Fatalf("live 👎 votes = %d, want 1 (U2 moved to up)", r.FeedbackDown)
+	}
+	// Votes on another trigger never leak into k.
+	_ = l.Open(Event{Fingerprint: "f3", Kind: "fresh", TriggerKey: "other", At: t0})
+	_ = l.Feedback("other", "", "down", "U9", t0.Add(time.Hour))
+	if r := l.Recurrence("k"); r.FeedbackDown != 1 {
+		t.Fatalf("cross-trigger vote leaked: %+v", r)
+	}
+}
+
+// TestRecurrenceVerdictSurvivesReplayAndCheckpoint: the newest open's verdict —
+// what the suppression gate keys its "conclusive?" decision on — must be
+// identical after a fresh replay and after compaction absorbs the opens.
+func TestRecurrenceVerdictSurvivesReplayAndCheckpoint(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(41000, 0)
+	_ = l.Open(Event{Fingerprint: "f1", Kind: "fresh", TriggerKey: "k", Verdict: "no_action", At: t0})
+	for i := 0; i < 20; i++ {
+		fp := fmt.Sprintf("pad%d", i)
+		_ = l.Open(Event{Fingerprint: fp, Kind: "fresh", At: t0.Add(time.Duration(i+1) * time.Minute)})
+		_, _, _ = l.Resolve(fp, t0.Add(time.Duration(i+2)*time.Minute))
+	}
+	l2, _ := New(p) // plain replay
+	if r := l2.Recurrence("k"); r.Verdict != "no_action" {
+		t.Fatalf("replayed verdict = %q, want no_action", r.Verdict)
+	}
+	c, _ := NewWithMaxEvents(p, 5) // compaction absorbs the opens into a checkpoint
+	if r := c.Recurrence("k"); r.Verdict != "no_action" || r.Count != 1 {
+		t.Fatalf("checkpointed recurrence = %+v, want verdict=no_action count=1", r)
+	}
+}


### PR DESCRIPTION
> **Stacked on #267** (the 👎-breaks-the-cooldown escape hatch consumes its feedback votes). GitHub will retarget this PR to `main` when #267 merges; I'll rebase it then so only these 5 commits remain.

## Why

Nothing keys on **TriggerKey** before the paid loop today: a still-firing alert re-investigates on every Alertmanager `repeat_interval`, and a persistently-failing GitOps resource re-emits on every informer resync (**~10 minutes**) — each a full model run re-delivering the same answer as fresh noise. The window is worst exactly where the human gate lives: instant recall only works once the KB PR is **merged**, so every recurrence during human review pays a full investigation. (This is the root of the pilot's noise volume.)

## What

An **opt-in** pre-investigation gate (`investigation.recurrence_cooldown`, default 0 = off, checked before the recall gate): skip the loop when the trigger was investigated within the cooldown, the prior verdict was **conclusive**, and no human contests it. A suppressed occurrence makes **no model call, sends no notification, records no ledger open** — the previous notification remains *the* answer; the next occurrence past the cooldown re-investigates in full, recurrence count intact.

Two **human-deferential escape hatches**:
- an `inconclusive` (or pre-verdict) prior **never** suppresses — there is no answer worth repeating;
- a standing **👎 on the trigger breaks the cooldown immediately** — the same one-click signal that decays recalled knowledge (#267) also re-arms investigation. Feedback now does both jobs.

Not recording the open is load-bearing: an open would slide the newest-open anchor and the cooldown would never lapse while the incident keeps firing. Anchored on the last *real* investigation, a persistent failure re-investigates once per cooldown instead of once per resync. Suppressed firings are observable via `runlore_investigations_completed_total{result="recurrence_suppressed"}` + a structured log line (deliberately no durable ledger record — promoting suppression to a first-class event kind is the move if a raw-firing-frequency consumer ever appears).

## Mechanics

- `outcome`: the `byTrigger` index now tracks the newest open's **verdict** (checkpointed like entry/curatedURL); new `Recurrence(triggerKey)` query returns count/last/verdict/KB-link/live-👎 in one locked read; `Occurrences` becomes a narrowing of it.
- `investigate`: `RecurrenceGate` next to its sibling, the recall short-circuit; full decision matrix table-tested; a loop-level test pins zero model calls + zero deliveries on suppression.
- `config`: fail-loud validation — negative rejected; a positive cooldown without `outcome.ledger_path` refuses to start.
- Docs: configuration.md (full contract + recommended `30m`–`1h`), learning-loop.md (feedback's second job), observability.md (new result label), chart values example.

Includes a 4-angle cleanup pass (reuse/simplification/efficiency/altitude) — applied `Occurrences`→`Recurrence` delegation and corrected the "costs nothing" claim (a suppressed occurrence still spends a workqueue turn and rate-limiter slot, the same pre-existing tradeoff the recall short-circuit accepts).

Full gate green: `go build` · `go vet` · `go test ./... -race` · `gofmt` · `golangci-lint` (0 issues) · `helm lint`.