### PR TITLE
feat: Matrix 👍/👎 feedback via reactions — zero-ingress

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -215,6 +215,9 @@ config:
   #     #   your ingress — same exposure as approve/reject buttons), plus signing_secret_env
   #     #   and outcome.ledger_path. Startup fails loud if either is missing.
   #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }
+  #   # matrix.feedback_reactions: true  # OPT-IN 👍/👎 reactions feeding the learning loop.
+  #   #   ZERO-INGRESS (outbound /sync long-poll — nothing to expose, unlike Slack buttons).
+  #   #   Requires outcome.ledger_path; use an invite-only room (any member can vote).
   #   webhook:
   #     url_env: RUNLORE_WEBHOOK_NOTIFY_URL   # POST findings JSON to this URL
   # forge:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -236,7 +236,20 @@ rating is an opinion feeding the learning loop, not a cluster mutation (approve/
 user)**, latest wins — duplicate clicks are idempotent and changing your mind moves the vote. The ack
 is an ephemeral "feedback recorded" note visible only to the clicker; the investigation message is
 never modified. With the option off (the default), no buttons render and the endpoint behaves exactly
-as before (404 unless approve mode wired it).
+as before (404 unless approve mode wired it). Exposure hardening and the vote trust model are
+detailed in [security-model.md](security-model.md#the-feedback-channels--exposure--trust-model).
+
+**Matrix 👍/👎 — `matrix.feedback_reactions` (opt-in, default `false`).** The same feedback loop over
+Matrix **reactions**: react 👍/👎 to a RunLore investigation message and the rating lands in the
+outcome ledger (same per-user dedup, same trust weighting, same recurrence-cooldown re-arm — the
+ledger mechanics are shared). **Nothing is exposed**: reactions arrive over the client-server `/sync`
+long-poll — an *outbound* HTTPS request authenticated by the notifier's access token — so this is the
+zero-ingress alternative to Slack buttons. The listener runs on the leader only, skips reactions from
+before startup, ignores every emoji except 👍/👎, and only counts votes on messages **the bot itself
+sent** (attribution is anchored on `/whoami`; a member-crafted message carrying the trigger field
+attributes nothing). Startup fails loud unless `homeserver`/`room_id`/`access_token_env` and
+`outcome.ledger_path` are set. Use an **invite-only room** — any room member can vote (see
+[security-model.md](security-model.md#the-feedback-channels--exposure--trust-model)).
 
 ### `server` — the HTTP listener
 Only `webhook_token_env` (the bearer token for the incident webhook; **required under

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -218,7 +218,8 @@ Two read APIs turn this raw log into a learning signal:
   the entry's **cause and human-reviewed resolution** inline (with its recall
   resolve-rate), so the previous answer is readable without leaving chat.
 - **`Feedback()`** appends a human **`feedback`** event — the 👍/👎 buttons on Slack
-  investigation messages (opt-in, `notify.slack.feedback_buttons`; see
+  investigation messages (opt-in, `notify.slack.feedback_buttons`) or 👍/👎 **reactions**
+  on Matrix ones (opt-in, `notify.matrix.feedback_reactions`, zero-ingress; see
   [configuration.md](configuration.md#notify--where-findings-go)). A vote is attributed
   to the catalog entry behind the trigger key's **newest open** (via the same
   `byTrigger` index; a fresh investigation has no entry, so its votes are recorded but

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -139,6 +139,47 @@ truncate the sidecar too, and making it crash-consistent is fiddly. Until an ext
 mitigate operationally: keep the log on **durable storage with restricted write access** (ideally a
 medium where the agent's own identity cannot rewrite history), and back it up.
 
+## The feedback channels (👍/👎) — exposure & trust model
+
+Human feedback ratings weigh recalled-knowledge trust and re-arm the recurrence cooldown, so the
+channels that carry them are part of the security surface. The two channels have opposite exposure
+profiles and one shared trust model.
+
+**Shared trust model — votes are workspace/room-scoped opinions.** Feedback is deliberately
+*unprivileged*: any authenticated member of your Slack workspace / Matrix room can rate (it is an
+opinion feeding the learning loop, not a cluster mutation — approve/reject keep their allowlist).
+The blast radius of a hostile voter is bounded by construction: **one live vote per (incident
+trigger, user), latest wins** (no stacking), a vote is one Bernoulli observation in the same Beta
+posterior as resolve signals (several independent voters are needed to move an established entry),
+recalled answers still pass the adversarial verify pass, recall confidence is hard-capped at 0.90,
+and the worst a 👎 campaign achieves is *extra fresh investigations* (cost, not wrong answers —
+decay fails toward re-investigation, never toward trusting). Every vote is an append-only ledger
+line carrying the voter's stable id, so a campaign is auditable after the fact.
+
+**Slack (`notify.slack.feedback_buttons`) — an exposed endpoint, hardened.** Clicks arrive on
+`POST /slack/interactions`, which must be reachable from Slack's servers. Every request is verified
+against the app **signing secret** (HMAC-SHA256 over the raw body, ±5-minute timestamp window
+against replay, constant-time compare) *before* any parsing-derived action; unsigned or stale
+requests are rejected and the body read is capped at 1 MiB. Replay within the window is idempotent
+by the vote dedup. The message-update callback (`response_url`) is restricted to
+`https://*.slack.com` with a bounded client (no SSRF). **Expose only the path, not the pod**: route
+*only* `/slack/interactions` through your ingress/gateway — the same listener also serves the
+alert webhook (open when `server.webhook_token_env` is unset!), `/metrics`, and the token-gated
+control endpoints, none of which belong on the internet. If any part of the server is reachable
+from outside, set `server.webhook_token_env` regardless of action mode.
+
+**Matrix (`notify.matrix.feedback_reactions`) — nothing exposed, one explicit check.** Reactions
+arrive over the client-server `/sync` **long-poll — an outbound HTTPS request** authenticated by
+the notifier's existing access token. No inbound endpoint, no signing secret, no NetworkPolicy
+change; responses are size-capped before decoding. The one attack Matrix enables that Slack cannot
+is **attribution forgery**: any room member could post their own message carrying the
+`io.runlore.trigger_key` content field and vote on it, misdirecting ratings to an arbitrary
+incident. The listener closes this by resolving its own identity (`/whoami`) at startup and
+counting a vote **only when the reacted-to event was sent by the bot itself** — and it refuses to
+listen at all until that identity is known. Operational requirement: because vote identity is room
+membership, use an **invite-only room** (and prefer disabling federation for it); in a federated
+room, remote homeservers assert their own users' identities.
+
 ## Honest limitations
 
 - **The model sees cluster data.** Even with redaction, tool output reaches your model provider. The

--- a/docs/superpowers/plans/2026-07-09-matrix-feedback-reactions.md
+++ b/docs/superpowers/plans/2026-07-09-matrix-feedback-reactions.md
@@ -1,0 +1,45 @@
+# Matrix Feedback via Reactions Implementation Plan
+
+**Goal:** Give Matrix users the same one-click 👍/👎 feedback channel Slack got (#267) — reactions on
+RunLore's investigation messages are recorded in the outcome ledger and weigh recalled-entry trust
+(and re-arm the recurrence cooldown) through the exact same notifier-agnostic mechanics.
+
+**The headline property — no inbound exposure.** Slack feedback requires exposing
+`POST /slack/interactions` to Slack. Matrix needs nothing exposed: reactions arrive over the
+client-server **`/sync` long-poll** — an *outbound* HTTPS request authenticated by the access token
+the notifier already holds. No Request URL, no signing secret, no NetworkPolicy change.
+
+**Mechanism:**
+1. **Embed** — `Matrix.Deliver` adds a custom content field `io.runlore.trigger_key`
+   (`cmp.Or(TriggerKey, Fingerprint)`) to every investigation message. Custom keys are legal in
+   Matrix events and invisible in clients; embedding is unconditional (harmless), the *listener* is
+   the opt-in.
+2. **Listen** — a leader-only goroutine (`MatrixFeedback.Run`, started in `startWork` like the
+   reinvestigate poller) long-polls `/sync` filtered to the configured room + `m.reaction` timeline
+   events. The first response is a position handshake only (historical reactions are skipped —
+   feedback counts from startup onward); errors back off 5s and retry; leadership loss cancels.
+3. **Attribute** — a reaction (`m.annotation`) names its target event id; the listener fetches that
+   event (`/rooms/{room}/event/{id}`, small bounded cache) and reads `io.runlore.trigger_key` back.
+   No key ⇒ not one of ours ⇒ ignored. Stateless across restarts by construction.
+4. **Record** — 👍→`up`, 👎→`down` (variation selector U+FE0F stripped; every other emoji ignored),
+   `sink.Feedback(key, rating, sender, now)` with the Matrix user id (`@alice:hs`) as the dedup
+   identity. Ledger-side per-user latest-wins dedup, posterior weighting, and the 👎-breaks-cooldown
+   escape hatch (#270) all apply unchanged — zero ledger changes in this PR.
+
+**Opt-in contract:** `notify.matrix.feedback_reactions` (default off). Validate fails loud when on
+without `outcome.ledger_path` or without the Matrix notifier fields (homeserver/room_id/token env).
+Off ⇒ bit-for-bit today's behavior (the embedded content key is additive and inert).
+
+**Tasks:**
+1. `internal/config` — `MatrixNotify.FeedbackReactions` + fail-loud Validate + tests.
+2. `internal/notify/matrix.go` — embed `io.runlore.trigger_key` in Deliver (+ tests).
+3. `internal/notify/matrix_feedback.go` (new) — `FeedbackSink` interface (satisfied by
+   `*outcome.Ledger`), `MatrixFeedback` listener: filtered long-poll, handshake-then-listen, target
+   fetch + key readback, emoji mapping, backoff. httptest-scripted tests: handshake skips history,
+   👍/👎 recorded with sender, foreign emoji + keyless targets ignored, ctx cancel stops Run.
+4. `internal/app` — `BuildMatrixFeedback` (nil unless opted in + ledger enabled + token present),
+   started leader-only in `startWork`.
+5. Docs: configuration.md (option + "no exposure" contrast with Slack), learning-loop.md (second
+   feedback channel), getting-started.md + chart values comments.
+
+**Gate:** `go build && go vet && go test -race ./... && gofmt -l . && golangci-lint run` — 0 issues.

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"log/slog"
+	"os"
 
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/notify"
+	"github.com/Smana/runlore/internal/outcome"
 )
 
 // BuildNotifier assembles the configured chat notifiers (best-effort fan-out)
@@ -12,4 +14,24 @@ import (
 // generic webhook) self-register; each Build reads its own config.
 func BuildNotifier(cfg *config.Config, log *slog.Logger) (*notify.Multi, error) {
 	return notify.BuildEnabled(notify.Deps{Cfg: cfg, Log: log})
+}
+
+// BuildMatrixFeedback assembles the opt-in Matrix reaction listener
+// (notify.matrix.feedback_reactions): nil unless the option is on, the outcome
+// ledger persists, and the access token is actually present — a listener that
+// could record nowhere or authenticate as no one must not start. Validate has
+// already required the notifier fields and the ledger path with the option on;
+// the token presence is an env-var runtime fact, checked here like the
+// notifier's own builder does.
+func BuildMatrixFeedback(cfg *config.Config, ledger *outcome.Ledger, log *slog.Logger) *notify.MatrixFeedback {
+	mc := cfg.Notify.Matrix
+	if !mc.FeedbackReactions || !ledger.Enabled() {
+		return nil
+	}
+	tok := os.Getenv(mc.AccessTokenEnv)
+	if tok == "" {
+		log.Warn("matrix feedback_reactions enabled but the access token env is empty; listener disabled", "env", mc.AccessTokenEnv)
+		return nil
+	}
+	return notify.NewMatrixFeedback(mc.Homeserver, mc.RoomID, tok, ledger, log)
 }

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -283,6 +283,12 @@ func RunServe(version string, args []string) error {
 			log.Info("re-investigate poller enabled", "label", investigate.ReinvestigateLabel)
 			go reinv.Poll(workCtx, 2*time.Minute)
 		}
+		// Opt-in Matrix reaction listener — leader-only like the pollers above, so an
+		// HA deployment records each 👍/👎 exactly once, into the leader's ledger.
+		if mfb := BuildMatrixFeedback(cfg, ledger, log); mfb != nil {
+			log.Info("matrix feedback reactions enabled", "room", cfg.Notify.Matrix.RoomID)
+			go mfb.Run(workCtx)
+		}
 	}
 
 	var leader atomic.Bool

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -414,6 +414,13 @@ type MatrixNotify struct {
 	Homeserver     string `yaml:"homeserver"`
 	RoomID         string `yaml:"room_id"`
 	AccessTokenEnv string `yaml:"access_token_env"` // env var holding the access token
+	// FeedbackReactions (opt-in, default off) records 👍/👎 reactions on RunLore's
+	// investigation messages into the outcome ledger, where they weigh recalled-
+	// entry trust exactly like Slack's feedback buttons. Unlike Slack, nothing is
+	// exposed: reactions arrive over the client-server /sync long-poll — an
+	// OUTBOUND request authenticated by the access token above. Requires the three
+	// notifier fields and outcome.ledger_path; Validate fails loud otherwise.
+	FeedbackReactions bool `yaml:"feedback_reactions"`
 }
 
 // GitOps selects the GitOps engine RunLore reads (what-changed + failure watch).
@@ -898,6 +905,18 @@ func (c *Config) Validate() error {
 		}
 		if c.Outcome.LedgerPath == "" {
 			return fmt.Errorf("notify.slack.feedback_buttons requires outcome.ledger_path: ratings are recorded in the outcome ledger")
+		}
+	}
+	// Same fail-loud contract for the Matrix reaction listener: without the
+	// notifier fields it would sync nothing, without the ledger it would record
+	// nowhere — both silent lies to whoever enabled the option.
+	if c.Notify.Matrix.FeedbackReactions {
+		m := c.Notify.Matrix
+		if m.Homeserver == "" || m.RoomID == "" || m.AccessTokenEnv == "" {
+			return fmt.Errorf("notify.matrix.feedback_reactions requires homeserver, room_id and access_token_env (the reaction listener long-polls the configured room)")
+		}
+		if c.Outcome.LedgerPath == "" {
+			return fmt.Errorf("notify.matrix.feedback_reactions requires outcome.ledger_path: ratings are recorded in the outcome ledger")
 		}
 	}
 	switch c.Actions.Mode {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -589,3 +589,40 @@ func TestValidateRecurrenceCooldown(t *testing.T) {
 		t.Fatalf("cooldown with a ledger must validate clean, got: %v", err)
 	}
 }
+
+// TestValidateMatrixFeedbackReactions guards the Matrix feedback opt-in: the
+// reaction listener syncs the configured room and records into the ledger, so
+// enabling it without the notifier fields or without a ledger would silently
+// listen to nothing / record nowhere — rejected at startup instead.
+func TestValidateMatrixFeedbackReactions(t *testing.T) {
+	off := &Config{}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("feedback_reactions off must validate clean, got: %v", err)
+	}
+
+	noMatrix := &Config{}
+	noMatrix.Notify.Matrix.FeedbackReactions = true
+	noMatrix.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
+	if err := noMatrix.Validate(); err == nil {
+		t.Fatal("feedback_reactions without the matrix notifier config must be rejected")
+	}
+
+	noLedger := &Config{}
+	noLedger.Notify.Matrix.FeedbackReactions = true
+	noLedger.Notify.Matrix.Homeserver = "https://matrix.example.org"
+	noLedger.Notify.Matrix.RoomID = "!r:example.org"
+	noLedger.Notify.Matrix.AccessTokenEnv = "MATRIX_TOKEN"
+	if err := noLedger.Validate(); err == nil {
+		t.Fatal("feedback_reactions without outcome.ledger_path must be rejected")
+	}
+
+	ok := &Config{}
+	ok.Notify.Matrix.FeedbackReactions = true
+	ok.Notify.Matrix.Homeserver = "https://matrix.example.org"
+	ok.Notify.Matrix.RoomID = "!r:example.org"
+	ok.Notify.Matrix.AccessTokenEnv = "MATRIX_TOKEN"
+	ok.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("feedback_reactions fully configured must validate clean, got: %v", err)
+	}
+}

--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -74,12 +75,20 @@ func (m *Matrix) Deliver(ctx context.Context, inv providers.Investigation) error
 		m.homeserver, url.PathEscape(m.roomID), url.PathEscape(txn))
 
 	msg := Format(inv)
-	body, err := json.Marshal(map[string]string{
+	content := map[string]any{
 		"msgtype":        "m.notice",
 		"body":           plainFallback(msg),
 		"format":         "org.matrix.custom.html",
 		"formatted_body": mrkdwnToHTML(msg),
-	})
+	}
+	// Stamp the trigger identity into the event content (a custom field — legal in
+	// Matrix events, invisible in clients) so the opt-in reaction listener can join
+	// a 👍/👎 on this message back to the incident. Unconditional: the field is
+	// inert data; the LISTENER is the opt-in (notify.matrix.feedback_reactions).
+	if key := cmp.Or(inv.TriggerKey, inv.Fingerprint); key != "" {
+		content[triggerKeyContentField] = key
+	}
+	body, err := json.Marshal(content)
 	if err != nil {
 		return err
 	}

--- a/internal/notify/matrix_feedback.go
+++ b/internal/notify/matrix_feedback.go
@@ -1,0 +1,305 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+)
+
+// triggerKeyContentField is the custom event-content field Deliver stamps on
+// investigation messages and the reaction listener reads back — the join between
+// a 👍/👎 reaction and the incident it rates. Namespaced per the Matrix
+// convention for custom keys.
+const triggerKeyContentField = "io.runlore.trigger_key"
+
+// FeedbackSink records a human 👍/👎 rating on a delivered investigation
+// (implemented by *outcome.Ledger — the same method the Slack path records
+// through, so dedup, trust weighting and the recurrence-cooldown re-arm are
+// shared by construction).
+type FeedbackSink interface {
+	Feedback(triggerKey, rating, user string, at time.Time) error
+}
+
+// MatrixFeedback is the opt-in reaction listener
+// (notify.matrix.feedback_reactions): it long-polls the homeserver's /sync for
+// m.reaction events in the configured room and records 👍/👎 on RunLore's own
+// investigation messages into the outcome ledger.
+//
+// Unlike the Slack feedback path, NOTHING is exposed: /sync is an outbound
+// HTTPS long-poll authenticated by the notifier's access token — no inbound
+// endpoint, no signing secret, no NetworkPolicy change. The trade is a
+// long-lived poll loop, which runs leader-only (started in startWork, cancelled
+// with the leadership context) so an HA deployment records each reaction once.
+//
+// The first /sync response is a position handshake only: historical reactions
+// are deliberately skipped, so feedback counts from startup onward — replaying
+// a room's history through the ledger on every restart would re-stamp old
+// votes with fresh timestamps.
+type MatrixFeedback struct {
+	homeserver string
+	roomID     string
+	token      string
+	sink       FeedbackSink
+	log        *slog.Logger
+	http       *http.Client
+
+	// self is the bot's own Matrix user id (from /whoami at Run start). It is the
+	// attribution trust anchor: a vote only counts when the REACTED-TO event was
+	// sent by self. Without this check any room member could post a message
+	// carrying an io.runlore.trigger_key field of their choosing and vote on it —
+	// attributing ratings to an arbitrary incident (trust poisoning / vote
+	// misdirection). Slack has no equivalent hole (interaction payloads only ever
+	// reference buttons the app itself posted); Matrix must enforce it explicitly.
+	self string
+
+	// keyByEvent caches target-event → trigger-key lookups so N reactions to the
+	// same message cost one fetch. Bounded crudely (reset past cap): the working
+	// set is "messages still being reacted to", a handful.
+	keyByEvent map[string]string
+}
+
+// syncTimeout is the server-side long-poll hold; the HTTP client timeout must
+// comfortably exceed it or every quiet poll would surface as a client error.
+const syncTimeout = 30 * time.Second
+
+// retryBackoff is the pause after a failed sync before re-polling.
+const retryBackoff = 5 * time.Second
+
+// keyByEventCap bounds the target-event cache (reset, not evicted — simplicity
+// over LRU for a cache whose working set is a handful of recent messages).
+const keyByEventCap = 256
+
+// NewMatrixFeedback builds the reaction listener. homeserver/roomID/token are
+// the notifier's own settings; sink is where ratings land (the outcome ledger).
+func NewMatrixFeedback(homeserver, roomID, token string, sink FeedbackSink, log *slog.Logger) *MatrixFeedback {
+	return &MatrixFeedback{
+		homeserver: strings.TrimRight(homeserver, "/"),
+		roomID:     roomID,
+		token:      token,
+		sink:       sink,
+		log:        log,
+		http:       httpx.SecureClient(syncTimeout + 15*time.Second),
+		keyByEvent: map[string]string{},
+	}
+}
+
+// Run long-polls /sync until ctx is cancelled (leadership loss / shutdown).
+// Errors are logged and retried after a fixed backoff — a flaky homeserver
+// must never crash the agent; at worst feedback pauses.
+func (f *MatrixFeedback) Run(ctx context.Context) {
+	// Resolve our own identity FIRST — it anchors target-event attribution (see
+	// the self field). No identity, no listening: fail towards recording nothing.
+	for f.self == "" {
+		self, err := f.whoami(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			f.log.Warn("matrix feedback whoami failed; retrying", "err", err)
+			select {
+			case <-time.After(retryBackoff):
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+		f.self = self
+	}
+	since := ""
+	for ctx.Err() == nil {
+		next, events, err := f.sync(ctx, since)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			f.log.Warn("matrix feedback sync failed; retrying", "err", err)
+			select {
+			case <-time.After(retryBackoff):
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+		// First response = position handshake: adopt the batch token, skip the
+		// (historical) events. Everything after is live.
+		if since != "" {
+			for _, e := range events {
+				f.handleReaction(ctx, e)
+			}
+		}
+		since = next
+	}
+}
+
+// matrixEvent is the subset of a timeline event the listener needs.
+type matrixEvent struct {
+	Type    string `json:"type"`
+	Sender  string `json:"sender"`
+	Content struct {
+		RelatesTo struct {
+			RelType string `json:"rel_type"`
+			EventID string `json:"event_id"`
+			Key     string `json:"key"`
+		} `json:"m.relates_to"`
+	} `json:"content"`
+}
+
+// sync performs one filtered /sync long-poll and returns the next batch token
+// plus the room's new timeline events. The inline filter narrows the response
+// to m.reaction events in the configured room — no presence, state, or other
+// rooms' traffic ever crosses the wire.
+func (f *MatrixFeedback) sync(ctx context.Context, since string) (string, []matrixEvent, error) {
+	filter := fmt.Sprintf(`{"presence":{"types":[]},"account_data":{"types":[]},"room":{"rooms":[%q],"state":{"types":[]},"ephemeral":{"types":[]},"account_data":{"types":[]},"timeline":{"types":["m.reaction"],"limit":50}}}`, f.roomID)
+	q := url.Values{"filter": {filter}, "timeout": {fmt.Sprintf("%d", syncTimeout.Milliseconds())}}
+	if since != "" {
+		q.Set("since", since)
+	}
+	endpoint := f.homeserver + "/_matrix/client/v3/sync?" + q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	resp, err := f.http.Do(req)
+	if err != nil {
+		return "", nil, fmt.Errorf("matrix sync: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return "", nil, fmt.Errorf("matrix sync status %d", resp.StatusCode)
+	}
+	var res struct {
+		NextBatch string `json:"next_batch"`
+		Rooms     struct {
+			Join map[string]struct {
+				Timeline struct {
+					Events []matrixEvent `json:"events"`
+				} `json:"timeline"`
+			} `json:"join"`
+		} `json:"rooms"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&res); err != nil {
+		return "", nil, fmt.Errorf("matrix sync decode: %w", err)
+	}
+	if res.NextBatch == "" {
+		return "", nil, fmt.Errorf("matrix sync: empty next_batch")
+	}
+	return res.NextBatch, res.Rooms.Join[f.roomID].Timeline.Events, nil
+}
+
+// handleReaction maps one m.reaction event to a ledger rating: 👍→up, 👎→down
+// (every other emoji is ignored — reactions are a general mechanism and 🎉 on a
+// resolved incident must not count as an endorsement of the diagnosis). The
+// reaction names its target event; the trigger identity is read back from the
+// target's content — a target without the field is not one of RunLore's
+// investigation messages and is skipped.
+func (f *MatrixFeedback) handleReaction(ctx context.Context, e matrixEvent) {
+	if e.Type != "m.reaction" || e.Content.RelatesTo.RelType != "m.annotation" {
+		return
+	}
+	rating := ""
+	// Clients commonly append the emoji variation selector (U+FE0F); strip it so
+	// "👍" and "👍️" are the same vote.
+	switch strings.ReplaceAll(e.Content.RelatesTo.Key, "️", "") {
+	case "👍":
+		rating = "up"
+	case "👎":
+		rating = "down"
+	default:
+		return
+	}
+	key, err := f.triggerKeyFor(ctx, e.Content.RelatesTo.EventID)
+	if err != nil {
+		f.log.Warn("matrix feedback: target event lookup failed", "event_id", e.Content.RelatesTo.EventID, "err", err)
+		return
+	}
+	if key == "" {
+		return // not one of our investigation messages
+	}
+	if err := f.sink.Feedback(key, rating, e.Sender, time.Now()); err != nil {
+		f.log.Warn("matrix feedback recording failed", "key", key, "err", err)
+		return
+	}
+	f.log.Info("matrix feedback recorded", "key", key, "rating", rating, "user", e.Sender)
+}
+
+// whoami resolves the access token's own user id — the sender every legitimate
+// investigation message carries.
+func (f *MatrixFeedback) whoami(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.homeserver+"/_matrix/client/v3/account/whoami", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	resp, err := f.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("matrix whoami status %d", resp.StatusCode)
+	}
+	var res struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&res); err != nil {
+		return "", err
+	}
+	if res.UserID == "" {
+		return "", fmt.Errorf("matrix whoami: empty user_id")
+	}
+	return res.UserID, nil
+}
+
+// triggerKeyFor fetches the reaction's target event and returns its embedded
+// trigger identity ("" when absent, when the target was NOT sent by the bot
+// itself — a room member could otherwise stamp the field onto their own message
+// and misdirect votes — or for one of ours from before the field existed).
+// Cached per event id.
+func (f *MatrixFeedback) triggerKeyFor(ctx context.Context, eventID string) (string, error) {
+	if eventID == "" {
+		return "", nil
+	}
+	if key, ok := f.keyByEvent[eventID]; ok {
+		return key, nil
+	}
+	endpoint := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/event/%s",
+		f.homeserver, url.PathEscape(f.roomID), url.PathEscape(eventID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	resp, err := f.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("matrix event fetch status %d", resp.StatusCode)
+	}
+	var ev struct {
+		Sender  string         `json:"sender"`
+		Content map[string]any `json:"content"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&ev); err != nil {
+		return "", err
+	}
+	key, _ := ev.Content[triggerKeyContentField].(string)
+	if ev.Sender != f.self {
+		key = "" // not our message: whatever the field claims, it attributes nothing
+	}
+	if len(f.keyByEvent) >= keyByEventCap {
+		f.keyByEvent = map[string]string{} // crude bound; the live working set is tiny
+	}
+	f.keyByEvent[eventID] = key
+	return key, nil
+}

--- a/internal/notify/matrix_feedback_test.go
+++ b/internal/notify/matrix_feedback_test.go
@@ -1,0 +1,178 @@
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordSink collects Feedback calls and signals doneAt when the expected
+// number has landed, so tests wait on real progress instead of sleeping.
+type recordSink struct {
+	mu     sync.Mutex
+	got    []string // "key/rating/user"
+	doneAt int
+	done   chan struct{}
+}
+
+func (r *recordSink) Feedback(key, rating, user string, _ time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.got = append(r.got, key+"/"+rating+"/"+user)
+	if len(r.got) == r.doneAt {
+		close(r.done)
+	}
+	return nil
+}
+
+// reactionJSON builds one m.reaction timeline event.
+func reactionJSON(sender, target, key string) string {
+	return fmt.Sprintf(`{"type":"m.reaction","sender":%q,"content":{"m.relates_to":{"rel_type":"m.annotation","event_id":%q,"key":%q}}}`, sender, target, key)
+}
+
+// TestMatrixFeedbackRun scripts a homeserver: the first /sync is a position
+// handshake whose (historical) events must be SKIPPED; the second batch carries
+// a 👍 (variation selector included), a 👎, a foreign emoji, and a reaction to a
+// message without the trigger field — only the two votes reach the sink, with
+// the Matrix user ids as identities. ctx cancellation stops Run.
+func TestMatrixFeedbackRun(t *testing.T) {
+	const room = "!r:hs"
+	sink := &recordSink{doneAt: 2, done: make(chan struct{})}
+	var syncCalls int
+	var mu sync.Mutex
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/_matrix/client/v3/account/whoami":
+			_ = json.NewEncoder(w).Encode(map[string]string{"user_id": "@runlore:hs"})
+		case strings.HasPrefix(r.URL.Path, "/_matrix/client/v3/sync"):
+			mu.Lock()
+			syncCalls++
+			n := syncCalls
+			mu.Unlock()
+			if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+				t.Errorf("sync auth = %q", got)
+			}
+			timeline := ""
+			switch n {
+			case 1:
+				// Handshake response carrying a HISTORICAL reaction that must be skipped.
+				if r.URL.Query().Get("since") != "" {
+					t.Errorf("first sync must carry no since, got %q", r.URL.Query().Get("since"))
+				}
+				timeline = reactionJSON("@old:hs", "$msg1", "👍")
+			case 2:
+				if r.URL.Query().Get("since") != "s1" {
+					t.Errorf("second sync since = %q, want s1", r.URL.Query().Get("since"))
+				}
+				timeline = strings.Join([]string{
+					reactionJSON("@alice:hs", "$msg1", "👍️"), // variation selector
+					reactionJSON("@bob:hs", "$msg1", "👎"),
+					reactionJSON("@carol:hs", "$msg1", "🎉"), // foreign emoji: ignored
+					reactionJSON("@dave:hs", "$human", "👍"), // keyless target: ignored
+					reactionJSON("@eve:hs", "$spoof", "👍"),  // forged-field target: ignored
+				}, ",")
+			default:
+				// Quiet long-poll: nothing new. (The real server would hold; the test
+				// returns immediately — Run just re-polls.)
+			}
+			_, _ = fmt.Fprintf(w, `{"next_batch":"s%d","rooms":{"join":{%q:{"timeline":{"events":[%s]}}}}}`, n, room, timeline)
+		case strings.HasPrefix(r.URL.Path, "/_matrix/client/v3/rooms/"):
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/event/$msg1"):
+				_ = json.NewEncoder(w).Encode(map[string]any{"sender": "@runlore:hs",
+					"content": map[string]any{triggerKeyContentField: "trig-1"}})
+			case strings.HasSuffix(r.URL.Path, "/event/$spoof"):
+				// The attack the self-check closes: a room member posts their OWN
+				// message carrying the trigger field, then votes on it.
+				_ = json.NewEncoder(w).Encode(map[string]any{"sender": "@eve:hs",
+					"content": map[string]any{triggerKeyContentField: "victim-trigger"}})
+			default:
+				_ = json.NewEncoder(w).Encode(map[string]any{"sender": "@human:hs",
+					"content": map[string]any{"body": "a human message"}})
+			}
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	f := NewMatrixFeedback(srv.URL, room, "tok", sink, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	go func() { f.Run(ctx); close(stopped) }()
+
+	select {
+	case <-sink.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the two votes")
+	}
+	cancel()
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not stop on ctx cancel")
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	want := []string{"trig-1/up/@alice:hs", "trig-1/down/@bob:hs"}
+	if len(sink.got) != 2 || sink.got[0] != want[0] || sink.got[1] != want[1] {
+		t.Fatalf("recorded = %v, want %v", sink.got, want)
+	}
+}
+
+// TestMatrixFeedbackSyncErrorRetries: a failing homeserver is logged and
+// retried, never fatal — Run keeps polling and records once the server heals.
+func TestMatrixFeedbackSyncErrorRetries(t *testing.T) {
+	const room = "!r:hs"
+	sink := &recordSink{doneAt: 1, done: make(chan struct{})}
+	var calls int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/_matrix/client/v3/account/whoami" {
+			_ = json.NewEncoder(w).Encode(map[string]string{"user_id": "@runlore:hs"})
+			return
+		}
+		if strings.HasPrefix(r.URL.Path, "/_matrix/client/v3/rooms/") {
+			_ = json.NewEncoder(w).Encode(map[string]any{"sender": "@runlore:hs",
+				"content": map[string]any{triggerKeyContentField: "k"}})
+			return
+		}
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		switch n {
+		case 1:
+			w.WriteHeader(http.StatusBadGateway) // transient failure
+		case 2:
+			_, _ = fmt.Fprintf(w, `{"next_batch":"s1","rooms":{}}`) // handshake
+		default:
+			_, _ = fmt.Fprintf(w, `{"next_batch":"s%d","rooms":{"join":{%q:{"timeline":{"events":[%s]}}}}}`,
+				n, room, reactionJSON("@a:hs", "$m", "👍"))
+		}
+	}))
+	defer srv.Close()
+
+	f := NewMatrixFeedback(srv.URL, room, "tok", sink, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// Shrink the retry pause for the test via a tiny wrapper: not configurable by
+	// design (operators shouldn't tune it), so just tolerate the one 5s backoff.
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	go f.Run(ctx)
+	select {
+	case <-sink.done:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for recovery after a transient sync failure")
+	}
+}

--- a/internal/notify/matrix_test.go
+++ b/internal/notify/matrix_test.go
@@ -154,3 +154,44 @@ func TestMatrixTxnSurvivesRestart(t *testing.T) {
 		}
 	}
 }
+
+// TestMatrixDeliverEmbedsTriggerKey: the event content carries the trigger
+// identity (custom field, invisible in clients) so the reaction listener can
+// join a 👍/👎 back to the incident — TriggerKey first, fingerprint fallback,
+// omitted when the investigation carries neither.
+func TestMatrixDeliverEmbedsTriggerKey(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	m := NewMatrix(srv.URL, "!r:hs", "tok")
+
+	inv := sampleInvestigation()
+	inv.TriggerKey = "k1"
+	if err := m.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if got, _ := gotBody[triggerKeyContentField].(string); got != "k1" {
+		t.Fatalf("content[%s] = %v, want k1", triggerKeyContentField, gotBody[triggerKeyContentField])
+	}
+
+	inv.TriggerKey = ""
+	inv.Fingerprint = "fp9"
+	if err := m.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if got, _ := gotBody[triggerKeyContentField].(string); got != "fp9" {
+		t.Fatalf("fingerprint fallback = %v, want fp9", gotBody[triggerKeyContentField])
+	}
+
+	inv.Fingerprint = ""
+	gotBody = nil // json.Decode merges into an existing map; reset to observe omission
+	if err := m.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if _, ok := gotBody[triggerKeyContentField]; ok {
+		t.Fatalf("no trigger identity ⇒ field must be omitted, got %v", gotBody[triggerKeyContentField])
+	}
+}


### PR DESCRIPTION
Extends the human feedback loop (#267/#270) to Matrix — with the opposite exposure profile to Slack.

## What

React 👍/👎 to a RunLore investigation message in the configured Matrix room and the rating lands in the outcome ledger through the **same** `Feedback` mechanics as Slack buttons: per-user latest-wins dedup, Beta-posterior trust weighting, and the recurrence-cooldown re-arm (#270) — zero ledger changes in this PR.

**Nothing is exposed.** Reactions arrive over the client-server `/sync` **long-poll** — an *outbound* HTTPS request authenticated by the notifier's existing access token. No Request URL, no signing secret, no NetworkPolicy change. This is the zero-ingress alternative for deployments that don't want to expose `/slack/interactions`.

## Mechanism

1. `Matrix.Deliver` stamps the trigger identity into the event content (custom `io.runlore.trigger_key` field — legal, invisible in clients; unconditional, the *listener* is the opt-in).
2. A **leader-only** goroutine long-polls `/sync` filtered to the room's `m.reaction` events (first response = position handshake, history skipped; errors back off 5s; leadership loss cancels; responses size-capped).
3. A reaction's target event is fetched (small bounded cache) and the trigger key read back; 👍→up / 👎→down (variation selector normalized; every other emoji ignored — 🎉 on a resolved incident is not an endorsement of the diagnosis).

## Security (reviewed as part of the feedback-channels exposure audit)

- **Attribution forgery closed by design**: any room member could post their *own* message carrying the trigger field and vote on it, misdirecting ratings to an arbitrary incident. The listener resolves its own identity (`/whoami`) before listening and counts a vote **only when the reacted-to event was sent by the bot itself** — covered by a dedicated test. (Slack has no equivalent hole: interaction payloads only reference buttons the app itself posted.)
- Vote identity = room membership → documented requirement: **invite-only room** (federation caveat documented).
- `docs/security-model.md` gains a **"Feedback channels — exposure & trust model"** section covering both channels: the shared bounded-influence vote model (one live vote per trigger×user; decay fails toward re-investigation, never toward trusting; auditable ledger lines), and Slack exposure hardening (**expose only the `/slack/interactions` path** — the same listener serves the alert webhook, `/metrics` and the control endpoints; set `server.webhook_token_env` whenever anything is externally reachable).

## Opt-in contract

`notify.matrix.feedback_reactions` (default off). Validate fails loud without `homeserver`/`room_id`/`access_token_env` or without `outcome.ledger_path`. Off ⇒ today's behavior (the embedded content field is additive and inert).

## Tests

Scripted-homeserver harness: handshake skips history; 👍 (with U+FE0F) and 👎 recorded with Matrix user ids; foreign emoji ignored; keyless target ignored; **forged-field target ignored (the attack test)**; ctx cancel stops Run; transient homeserver failures retry and recover. Plus Deliver embed matrix (TriggerKey → fingerprint fallback → omitted) and the config validation matrix.

Full gate green: `go build` · `go vet` · `go test ./... -race` · `gofmt` · `golangci-lint` (0 issues) · `helm lint`.