### PR TITLE
chore: add SPDX license headers to all Go files (+ CI guard)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,17 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
+      - name: SPDX headers
+        run: |
+          missing=""
+          for f in $(git ls-files '*.go'); do
+            head -1 "$f" | grep -q '^// SPDX-License-Identifier: Apache-2.0$' || missing="$missing $f"
+          done
+          if [ -n "$missing" ]; then
+            echo "Missing SPDX-License-Identifier header (must be the first line):"
+            for f in $missing; do echo "  $f"; done
+            exit 1
+          fi
       - run: go build ./...
       - run: go vet ./...
       - name: gofmt

--- a/cmd/lore/audit.go
+++ b/cmd/lore/audit.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/lore/audit_test.go
+++ b/cmd/lore/audit_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Command lore is the RunLore CLI and in-cluster agent entrypoint.
 //
 // RunLore is a self-improving, GitOps-native SRE agent: it reacts to incidents,

--- a/cmd/lore/validate.go
+++ b/cmd/lore/validate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/lore/validate_test.go
+++ b/cmd/lore/validate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/hack/e2e/mock/main.go
+++ b/hack/e2e/mock/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 //go:build e2e
 
 // Command mock is an e2e test double for RunLore's external backends: an

--- a/internal/action/approvals.go
+++ b/internal/action/approvals.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package action
 
 import (

--- a/internal/action/approvals_test.go
+++ b/internal/action/approvals_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package action
 
 import (

--- a/internal/action/auto.go
+++ b/internal/action/auto.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package action
 
 import (

--- a/internal/action/auto_test.go
+++ b/internal/action/auto_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package action
 
 import (

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package action
 
 import (

--- a/internal/action/policy.go
+++ b/internal/action/policy.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package action gates proposed remediations against the autonomy-ladder policy
 // (config.actions: off | suggest | approve | auto). The gate is server-authoritative:
 // reversibility and blast radius are derived from the operation (deriveSafety), not

--- a/internal/action/policy_test.go
+++ b/internal/action/policy_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package action
 
 import (

--- a/internal/action/safety.go
+++ b/internal/action/safety.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package action
 
 import (

--- a/internal/app/action.go
+++ b/internal/app/action.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/action_test.go
+++ b/internal/app/action_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/catalog_cmd.go
+++ b/internal/app/catalog_cmd.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/curate.go
+++ b/internal/app/curate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/curate_test.go
+++ b/internal/app/curate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/eval.go
+++ b/internal/app/eval.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/eval_compare.go
+++ b/internal/app/eval_compare.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/eval_compare_test.go
+++ b/internal/app/eval_compare_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/eval_test.go
+++ b/internal/app/eval_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/forge.go
+++ b/internal/app/forge.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/kube.go
+++ b/internal/app/kube.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/mcp.go
+++ b/internal/app/mcp.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/mcp_test.go
+++ b/internal/app/mcp_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package app holds the dependency-injection builders and config predicates that
 // assemble the RunLore agent. They live here (instead of in cmd/lore behind
 // main()) so the wiring that decides what ships is unit-testable.

--- a/internal/app/model_test.go
+++ b/internal/app/model_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/oncomplete_test.go
+++ b/internal/app/oncomplete_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package app
 
 import (

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package audit provides an append-only, tamper-evident record of every action
 // the agent attempts — the accountability backbone for the autonomy ladder.
 //

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package audit
 
 import (

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import "testing"

--- a/internal/catalog/entry.go
+++ b/internal/catalog/entry.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package catalog loads and searches an OKF knowledge catalog (a directory of
 // markdown files with YAML frontmatter) — the read half of RunLore's Learn pillar.
 package catalog

--- a/internal/catalog/hybrid.go
+++ b/internal/catalog/hybrid.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/hybrid_test.go
+++ b/internal/catalog/hybrid_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/section.go
+++ b/internal/catalog/section.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/section_test.go
+++ b/internal/catalog/section_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package catalog
 
 import (

--- a/internal/coalesce/add_test.go
+++ b/internal/coalesce/add_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package coalesce
 
 import (

--- a/internal/coalesce/coalescer.go
+++ b/internal/coalesce/coalescer.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package coalesce folds correlated Alertmanager incidents into a single
 // investigation, suppressing the redundant per-alert investigations a storm
 // would otherwise spawn. In-memory, mutex-guarded, clock injected for tests.

--- a/internal/coalesce/coalescer_test.go
+++ b/internal/coalesce/coalescer_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package coalesce
 
 import (

--- a/internal/coalesce/sweep_test.go
+++ b/internal/coalesce/sweep_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package coalesce
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package config defines RunLore's configuration, including provider wiring and
 // the trigger policy that decides which incidents start an investigation.
 //

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/minimal_values_test.go
+++ b/internal/config/minimal_values_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/network_test.go
+++ b/internal/config/network_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/outcome_test.go
+++ b/internal/config/outcome_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/shipped_configs_test.go
+++ b/internal/config/shipped_configs_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/config/sources_test.go
+++ b/internal/config/sources_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package config_test
 
 import (

--- a/internal/curate/curate.go
+++ b/internal/curate/curate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/curate_test.go
+++ b/internal/curate/curate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/dedup.go
+++ b/internal/curate/dedup.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/dedup_test.go
+++ b/internal/curate/dedup_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/forge.go
+++ b/internal/curate/forge.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package curate is the Phase-2 grooming agent: it dedups the KB backlog, gates
 // the decision-ready queue on incident resolution, surfaces recurring blind spots
 // as knowledge-gap issues, and drives lifecycle/decay. It writes to the forge only

--- a/internal/curate/forge_test.go
+++ b/internal/curate/forge_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/lifecycle.go
+++ b/internal/curate/lifecycle.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/lifecycle_test.go
+++ b/internal/curate/lifecycle_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/recurrence.go
+++ b/internal/curate/recurrence.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/recurrence_test.go
+++ b/internal/curate/recurrence_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/resolution.go
+++ b/internal/curate/resolution.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/resolution_test.go
+++ b/internal/curate/resolution_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/suppression.go
+++ b/internal/curate/suppression.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curate/suppression_test.go
+++ b/internal/curate/suppression_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curate
 
 import (

--- a/internal/curator/coalesce_comment_test.go
+++ b/internal/curator/coalesce_comment_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curator
 
 import (

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package curator is the file-time learning gate: it dedups a finding against the
 // catalog and open PRs, gates on quality, and drafts a merge-ready PR for novel,
 // quality findings. Uncertain/low-quality findings produce NO repo artifact (the

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curator
 
 import (

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curator
 
 import (

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curator
 
 import (

--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curator
 
 import (

--- a/internal/curator/fingerprint_test.go
+++ b/internal/curator/fingerprint_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package curator
 
 import (

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package embed provides an OpenAI-compatible embeddings client and the
 // similarity + fusion primitives for hybrid (BM25 + vector) catalog retrieval.
 //

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package embed
 
 import (

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package eval replays recorded incident cases through the investigation loop and
 // scores whether the agent identifies the root cause — a reproducible RCA benchmark
 // (cf. ITBench). A case records the evidence each tool returns, so the eval measures

--- a/internal/eval/compare.go
+++ b/internal/eval/compare.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/compare_report.go
+++ b/internal/eval/compare_report.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/compare_run.go
+++ b/internal/eval/compare_run.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/compare_test.go
+++ b/internal/eval/compare_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/coverage.go
+++ b/internal/eval/coverage.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/coverage_test.go
+++ b/internal/eval/coverage_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/forced_conclusion_test.go
+++ b/internal/eval/forced_conclusion_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/judge_test.go
+++ b/internal/eval/judge_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/live.go
+++ b/internal/eval/live.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/live_test.go
+++ b/internal/eval/live_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/recall_test.go
+++ b/internal/eval/recall_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/record.go
+++ b/internal/eval/record.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/record_test.go
+++ b/internal/eval/record_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/report_test.go
+++ b/internal/eval/report_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/scenario.go
+++ b/internal/eval/scenario.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/scenario_test.go
+++ b/internal/eval/scenario_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/score.go
+++ b/internal/eval/score.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import (

--- a/internal/eval/stats.go
+++ b/internal/eval/stats.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package eval
 
 import "sort"

--- a/internal/executor/flux/flux.go
+++ b/internal/executor/flux/flux.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package flux executes safe, reversible Flux operations (suspend / resume /
 // reconcile) on the cluster — the executable half of the autonomy ladder. It is
 // only ever invoked after explicit human approval (config.actions mode "approve").

--- a/internal/executor/flux/flux_test.go
+++ b/internal/executor/flux/flux_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package flux
 
 import (

--- a/internal/forge/github/auth.go
+++ b/internal/forge/github/auth.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package github
 
 import (

--- a/internal/forge/github/auth_test.go
+++ b/internal/forge/github/auth_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package github
 
 import (

--- a/internal/forge/github/bundle.go
+++ b/internal/forge/github/bundle.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package github
 
 // This file is OKF bundle maintenance: keep the reserved index.md / log.md files

--- a/internal/forge/github/bundle_test.go
+++ b/internal/forge/github/bundle_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package github
 
 import (

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package github is RunLore's GitHub forge client (curation + re-investigation)
 // over the GitHub REST API, authenticated with short-lived GitHub App installation
 // tokens. It satisfies providers.CurationForge / providers.ReinvestForge / curate.Forge.

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package github
 
 import (

--- a/internal/httpx/client.go
+++ b/internal/httpx/client.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/client_test.go
+++ b/internal/httpx/client_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/redact.go
+++ b/internal/httpx/redact.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/redact_test.go
+++ b/internal/httpx/redact_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/retry.go
+++ b/internal/httpx/retry.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package httpx provides small HTTP helpers shared across providers.
 package httpx
 

--- a/internal/httpx/retry_test.go
+++ b/internal/httpx/retry_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/sse.go
+++ b/internal/httpx/sse.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/sse_test.go
+++ b/internal/httpx/sse_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/streaming.go
+++ b/internal/httpx/streaming.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/httpx/streaming_test.go
+++ b/internal/httpx/streaming_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package httpx
 
 import (

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/budget_test.go
+++ b/internal/investigate/budget_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/cloud_tools.go
+++ b/internal/investigate/cloud_tools.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/cloud_tools_test.go
+++ b/internal/investigate/cloud_tools_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/compact.go
+++ b/internal/investigate/compact.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/compact_test.go
+++ b/internal/investigate/compact_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/controllerlogs_tool.go
+++ b/internal/investigate/controllerlogs_tool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/controllerlogs_tool_test.go
+++ b/internal/investigate/controllerlogs_tool_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/cost.go
+++ b/internal/investigate/cost.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/cost_test.go
+++ b/internal/investigate/cost_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/debounce.go
+++ b/internal/investigate/debounce.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/debounce_test.go
+++ b/internal/investigate/debounce_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/failures.go
+++ b/internal/investigate/failures.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/failures_test.go
+++ b/internal/investigate/failures_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/gitops_status_tool.go
+++ b/internal/investigate/gitops_status_tool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/gitops_tools_test.go
+++ b/internal/investigate/gitops_tools_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package investigate routes triggers (incident alerts, GitOps failures) into a
 // single async investigation queue and runs them. The investigation itself is
 // pluggable via Investigator: LoopInvestigator (loop.go) is the real

--- a/internal/investigate/investigate_drain_test.go
+++ b/internal/investigate/investigate_drain_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/investigate_test.go
+++ b/internal/investigate/investigate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/kbsearch_tool.go
+++ b/internal/investigate/kbsearch_tool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/kbsearch_tool_test.go
+++ b/internal/investigate/kbsearch_tool_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/kube_tools.go
+++ b/internal/investigate/kube_tools.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/kube_tools_test.go
+++ b/internal/investigate/kube_tools_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/parallel_test.go
+++ b/internal/investigate/parallel_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/podlogs_tool.go
+++ b/internal/investigate/podlogs_tool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/podlogs_tool_test.go
+++ b/internal/investigate/podlogs_tool_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/progress_test.go
+++ b/internal/investigate/progress_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/queue_ratelimit_test.go
+++ b/internal/investigate/queue_ratelimit_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/recall_decay_integration_test.go
+++ b/internal/investigate/recall_decay_integration_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/recall_hybrid_test.go
+++ b/internal/investigate/recall_hybrid_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/recurrence.go
+++ b/internal/investigate/recurrence.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/recurrence_test.go
+++ b/internal/investigate/recurrence_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/redact_approvals_test.go
+++ b/internal/investigate/redact_approvals_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // This file lives in the external test package so it can wire the real
 // investigate loop to the real action.Approvals queue AND the real HTTP server:
 // internal/server transitively imports internal/investigate (via internal/source),

--- a/internal/investigate/redact_egress_test.go
+++ b/internal/investigate/redact_egress_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/redact_wiring_test.go
+++ b/internal/investigate/redact_wiring_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/reinvestigate.go
+++ b/internal/investigate/reinvestigate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/reinvestigate_test.go
+++ b/internal/investigate/reinvestigate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/renderlog.go
+++ b/internal/investigate/renderlog.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/renderlog_test.go
+++ b/internal/investigate/renderlog_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/summarize.go
+++ b/internal/investigate/summarize.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/summarize_test.go
+++ b/internal/investigate/summarize_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/tools_test.go
+++ b/internal/investigate/tools_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/truncate.go
+++ b/internal/investigate/truncate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import "fmt"

--- a/internal/investigate/truncate_test.go
+++ b/internal/investigate/truncate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/verify_test.go
+++ b/internal/investigate/verify_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/whatchanged_tool.go
+++ b/internal/investigate/whatchanged_tool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/investigate/whatchanged_tool_test.go
+++ b/internal/investigate/whatchanged_tool_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package investigate
 
 import (

--- a/internal/kbmcp/kbmcp.go
+++ b/internal/kbmcp/kbmcp.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package kbmcp exposes the OKF knowledge catalog as MCP tools (kb_search,
 // kb_get) for the `lore mcp` stdio server — so any MCP client (Claude Code,
 // HolmesGPT, editors) can recall RunLore's learned incident knowledge without a

--- a/internal/kbmcp/kbmcp_test.go
+++ b/internal/kbmcp/kbmcp_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kbmcp
 
 import (

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package kbvalidate provides deterministic structural validation of OKF
 // knowledge-base entries (the merge gate) and an LLM-assisted semantic advisory.
 // The structural checks mirror what curator.draftKBEntry emits and what

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kbvalidate
 
 import (

--- a/internal/kbvalidate/semantic.go
+++ b/internal/kbvalidate/semantic.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kbvalidate
 
 import (

--- a/internal/kbvalidate/semantic_test.go
+++ b/internal/kbvalidate/semantic_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package kbvalidate
 
 import (

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package logging builds RunLore's slog logger with a configurable output format
 // (human-readable text or structured JSON) and verbosity level. In-cluster
 // deployments choose JSON so logs are ingestible by Loki/VictoriaLogs/CloudWatch;

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package logging
 
 import (

--- a/internal/logs/victorialogs/victorialogs.go
+++ b/internal/logs/victorialogs/victorialogs.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package victorialogs implements providers.LogsProvider against VictoriaLogs,
 // querying with LogsQL and normalizing the NDJSON response into log lines.
 package victorialogs

--- a/internal/logs/victorialogs/victorialogs_test.go
+++ b/internal/logs/victorialogs/victorialogs_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package victorialogs
 
 import (

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package mcp is a minimal Model Context Protocol server over the stdio transport
 // (newline-delimited JSON-RPC 2.0) — enough to expose RunLore tools to MCP clients
 // such as HolmesGPT, kagent, or Claude Desktop. It implements initialize, tools/list,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/mcp/tool.go
+++ b/internal/mcp/tool.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/mcp/tool_test.go
+++ b/internal/mcp/tool_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package mcp
 
 import (

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package prometheus implements providers.MetricsProvider against the Prometheus
 // HTTP API — also spoken by VictoriaMetrics — for instant and range PromQL queries.
 package prometheus

--- a/internal/metrics/prometheus/prometheus_test.go
+++ b/internal/metrics/prometheus/prometheus_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package prometheus
 
 import (

--- a/internal/model/anthropic/anthropic.go
+++ b/internal/model/anthropic/anthropic.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package anthropic implements providers.ModelProvider against the Anthropic
 // Messages API (native tool use). It maps RunLore's engine-agnostic exchange
 // (OpenAI-shaped: assistant tool_calls + separate tool messages) onto Anthropic's

--- a/internal/model/anthropic/anthropic_test.go
+++ b/internal/model/anthropic/anthropic_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package anthropic
 
 import (

--- a/internal/model/clientcore/clientcore.go
+++ b/internal/model/clientcore/clientcore.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package clientcore provides the plumbing shared by the hand-rolled model
 // provider clients (anthropic, gemini, openai): common construction defaults,
 // the streaming request pipeline (retry, status classification, idle-timeout

--- a/internal/model/clientcore/detail.go
+++ b/internal/model/clientcore/detail.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package clientcore
 
 import (

--- a/internal/model/clientcore/sse.go
+++ b/internal/model/clientcore/sse.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package clientcore
 
 import (

--- a/internal/model/clientcore/stream.go
+++ b/internal/model/clientcore/stream.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package clientcore
 
 import (

--- a/internal/model/clientcore/wire.go
+++ b/internal/model/clientcore/wire.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package clientcore
 
 import (

--- a/internal/model/gemini/gemini.go
+++ b/internal/model/gemini/gemini.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package gemini implements providers.ModelProvider against the Gemini API
 // (streamGenerateContent with native function calling). It maps RunLore's engine-
 // agnostic exchange (OpenAI-shaped: assistant tool_calls + separate tool messages)

--- a/internal/model/gemini/gemini_test.go
+++ b/internal/model/gemini/gemini_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gemini
 
 import (

--- a/internal/model/openai/openai.go
+++ b/internal/model/openai/openai.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package openai implements providers.ModelProvider against an OpenAI-compatible
 // /chat/completions endpoint (OpenAI, in-cluster vLLM, Ollama, OpenRouter).
 package openai

--- a/internal/model/openai/openai_test.go
+++ b/internal/model/openai/openai_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package openai
 
 import (

--- a/internal/network/awsvpc/awsvpc.go
+++ b/internal/network/awsvpc/awsvpc.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package awsvpc implements providers.NetworkProvider against AWS VPC Flow Logs
 // delivered to a CloudWatch Logs group, surfacing REJECT (denied) flows for an
 // investigation. All calls are read-only (FilterLogEvents).

--- a/internal/network/awsvpc/awsvpc_test.go
+++ b/internal/network/awsvpc/awsvpc_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package awsvpc
 
 import (

--- a/internal/network/gcpfirewall/gcpfirewall.go
+++ b/internal/network/gcpfirewall/gcpfirewall.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package gcpfirewall implements providers.NetworkProvider against GCP Firewall
 // Rules Logging, surfacing DENIED connections for an investigation.
 //

--- a/internal/network/gcpfirewall/gcpfirewall_test.go
+++ b/internal/network/gcpfirewall/gcpfirewall_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gcpfirewall
 
 import (

--- a/internal/network/hubble/hubble.go
+++ b/internal/network/hubble/hubble.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package hubble implements providers.NetworkProvider against Cilium Hubble Relay
 // (the observer gRPC API), surfacing dropped flows for an investigation.
 package hubble

--- a/internal/network/hubble/hubble_test.go
+++ b/internal/network/hubble/hubble_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package hubble
 
 import (

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package notify delivers completed investigations to chat (Slack, Matrix).
 package notify
 

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/matrix_feedback.go
+++ b/internal/notify/matrix_feedback.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/matrix_feedback_test.go
+++ b/internal/notify/matrix_feedback_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/matrix_test.go
+++ b/internal/notify/matrix_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/registry.go
+++ b/internal/notify/registry.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/registry_test.go
+++ b/internal/notify/registry_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package notify
 
 import (

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package webhook is a generic outgoing-webhook notifier: it POSTs each
 // investigation's findings as JSON to an operator-configured URL. It exists as
 // much to prove RunLore's notifier extensibility (drop one self-registering

--- a/internal/notify/webhook/webhook_test.go
+++ b/internal/notify/webhook/webhook_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package webhook
 
 import (

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package outcome records, in an append-only JSONL ledger, whether an
 // investigated incident later resolved and which answer was used for it — the
 // "did it actually work?" signal the learning loop reads. The ledger keeps an

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package outcome
 
 import (

--- a/internal/providers/cloud/aws/aws.go
+++ b/internal/providers/cloud/aws/aws.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package aws implements providers.CloudProvider against AWS using aws-sdk-go-v2
 // and in-cluster identity (EKS Pod Identity / IRSA, resolved by the SDK's default
 // credential chain). All calls are read-only: CloudTrail LookupEvents (the AWS

--- a/internal/providers/cloud/aws/aws_test.go
+++ b/internal/providers/cloud/aws/aws_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package aws
 
 import (

--- a/internal/providers/cloud/aws/cloudtrail.go
+++ b/internal/providers/cloud/aws/cloudtrail.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package aws
 
 import (

--- a/internal/providers/cloud/aws/resourcehealth.go
+++ b/internal/providers/cloud/aws/resourcehealth.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package aws
 
 import (

--- a/internal/providers/cloud/aws/resourcehealth_test.go
+++ b/internal/providers/cloud/aws/resourcehealth_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package aws
 
 import (

--- a/internal/providers/cluster/cluster.go
+++ b/internal/providers/cluster/cluster.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package cluster reads Kubernetes pod logs for investigation (read-only) via the
 // client-go CoreV1 GetLogs API. It backs the controller_logs tool, which surfaces
 // why a Flux controller failed to reconcile a source/object.

--- a/internal/providers/cluster/cluster_test.go
+++ b/internal/providers/cluster/cluster_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cluster
 
 import (

--- a/internal/providers/cluster/events_test.go
+++ b/internal/providers/cluster/events_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cluster
 
 import (

--- a/internal/providers/curationforge_test.go
+++ b/internal/providers/curationforge_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package providers_test
 
 import (

--- a/internal/providers/errors.go
+++ b/internal/providers/errors.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package providers
 
 import "errors"

--- a/internal/providers/errors_test.go
+++ b/internal/providers/errors_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package providers
 
 import (

--- a/internal/providers/gitops/argocd/argocd.go
+++ b/internal/providers/gitops/argocd/argocd.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package argocd implements providers.GitOpsProvider for Argo CD: it reads Argo CD
 // Applications from the cluster and emits engine-agnostic Changes (diffable via
 // whatchanged.Differ) and failure events — the same contract as the flux package.

--- a/internal/providers/gitops/argocd/argocd_test.go
+++ b/internal/providers/gitops/argocd/argocd_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package argocd
 
 import (

--- a/internal/providers/gitops/argocd/dynamic.go
+++ b/internal/providers/gitops/argocd/dynamic.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package argocd
 
 import (

--- a/internal/providers/gitops/argocd/dynamic_test.go
+++ b/internal/providers/gitops/argocd/dynamic_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package argocd
 
 import (

--- a/internal/providers/gitops/argocd/inspect.go
+++ b/internal/providers/gitops/argocd/inspect.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package argocd
 
 import (

--- a/internal/providers/gitops/argocd/inspect_test.go
+++ b/internal/providers/gitops/argocd/inspect_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package argocd
 
 import (

--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package flux
 
 import (

--- a/internal/providers/gitops/flux/dynamic_test.go
+++ b/internal/providers/gitops/flux/dynamic_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package flux
 
 import (

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package flux implements providers.GitOpsProvider for Flux: it reads Flux
 // Kustomizations and their GitRepository sources from the cluster and emits
 // engine-agnostic Changes, each diffable through whatchanged.Differ.

--- a/internal/providers/gitops/flux/flux_test.go
+++ b/internal/providers/gitops/flux/flux_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package flux
 
 import (

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package providers defines the pluggable backend contracts RunLore is built on.
 //
 // Every backend the agent touches is an interface, so the investigation loop and

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package providers_test
 
 import (

--- a/internal/ratelimit/window.go
+++ b/internal/ratelimit/window.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package ratelimit provides a sliding-window start limiter — the windowed
 // timestamp pattern from internal/action/auto.go:reserve(), reusable.
 package ratelimit

--- a/internal/ratelimit/window_test.go
+++ b/internal/ratelimit/window_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package ratelimit
 
 import (

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package redact masks secret-shaped values in free text before it crosses a
 // trust boundary — specifically before tool output (pod/controller logs, git
 // diffs, status/event messages) is fed to the LLM provider, from where the

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package redact
 
 import (

--- a/internal/redact/secret_manifest_test.go
+++ b/internal/redact/secret_manifest_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package redact
 
 import (

--- a/internal/server/coalesce_test.go
+++ b/internal/server/coalesce_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/internal/server/outcome_test.go
+++ b/internal/server/outcome_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package server exposes RunLore's HTTP endpoints (incident webhooks).
 package server
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package server
 
 import (

--- a/internal/source/alertmanager/alertmanager.go
+++ b/internal/source/alertmanager/alertmanager.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package alertmanager is the Alertmanager/VMAlert webhook source adapter.
 package alertmanager
 

--- a/internal/source/alertmanager/alertmanager_test.go
+++ b/internal/source/alertmanager/alertmanager_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package alertmanager
 
 import (

--- a/internal/source/debounce.go
+++ b/internal/source/debounce.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/debounce_test.go
+++ b/internal/source/debounce_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/gitops/gitops.go
+++ b/internal/source/gitops/gitops.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package gitops is the GitOps-failure watcher source adapter (Flux/Argo CD).
 package gitops
 

--- a/internal/source/gitops/gitops_test.go
+++ b/internal/source/gitops/gitops_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package gitops
 
 import (

--- a/internal/source/pagerduty/auth.go
+++ b/internal/source/pagerduty/auth.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package pagerduty
 
 import (

--- a/internal/source/pagerduty/auth_test.go
+++ b/internal/source/pagerduty/auth_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package pagerduty
 
 import (

--- a/internal/source/pagerduty/pagerduty.go
+++ b/internal/source/pagerduty/pagerduty.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package pagerduty is the PagerDuty V3 webhook source adapter. It turns
 // PagerDuty incident webhooks into investigation requests (incident.triggered)
 // and resolutions (incident.resolved), and authenticates each delivery with the

--- a/internal/source/pagerduty/pagerduty_test.go
+++ b/internal/source/pagerduty/pagerduty_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package pagerduty
 
 import (

--- a/internal/source/pipeline.go
+++ b/internal/source/pipeline.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/pipeline_test.go
+++ b/internal/source/pipeline_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/registry.go
+++ b/internal/source/registry.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package source registers event-source adapters and runs their core-owned
 // transports. An adapter implements Webhook (push) or Watcher (pull) and
 // self-registers via Register in an init() func; the core owns HTTP auth,

--- a/internal/source/registry_test.go
+++ b/internal/source/registry_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/registry_validate_test.go
+++ b/internal/source/registry_validate_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/watcher.go
+++ b/internal/source/watcher.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/watcher_test.go
+++ b/internal/source/watcher_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/webhook.go
+++ b/internal/source/webhook.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/source/webhook_test.go
+++ b/internal/source/webhook_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package source
 
 import (

--- a/internal/telemetry/buckets_test.go
+++ b/internal/telemetry/buckets_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package telemetry provides RunLore's self-instrumentation: an OpenTelemetry
 // metric set plus a Prometheus-exporter HTTP handler. Instruments are safe to
 // call even when no provider is configured (the global meter is a no-op), so

--- a/internal/telemetry/metrics_extra_test.go
+++ b/internal/telemetry/metrics_extra_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/internal/telemetry/setup.go
+++ b/internal/telemetry/setup.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/internal/telemetry/setup_test.go
+++ b/internal/telemetry/setup_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/internal/trigger/dedup.go
+++ b/internal/trigger/dedup.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package trigger
 
 import (

--- a/internal/trigger/dedup_test.go
+++ b/internal/trigger/dedup_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package trigger
 
 import (

--- a/internal/trigger/incident.go
+++ b/internal/trigger/incident.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package trigger ingests incidents (Alertmanager/VMAlert webhooks) and decides,
 // per the configured policy, which ones start an investigation.
 package trigger

--- a/internal/trigger/match_request_test.go
+++ b/internal/trigger/match_request_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package trigger_test
 
 import (

--- a/internal/whatchanged/clonecache.go
+++ b/internal/whatchanged/clonecache.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package whatchanged
 
 import (

--- a/internal/whatchanged/clonecache_test.go
+++ b/internal/whatchanged/clonecache_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package whatchanged
 
 import (

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Package whatchanged produces the "what changed" delta between two GitOps
 // revisions: a path-scoped unified diff (the actual landed change). It is the
 // differentiating core of RunLore's investigation spine.

--- a/internal/whatchanged/differ_auth_test.go
+++ b/internal/whatchanged/differ_auth_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package whatchanged
 
 import (

--- a/internal/whatchanged/differ_test.go
+++ b/internal/whatchanged/differ_test.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package whatchanged
 
 import (


### PR DESCRIPTION
## Summary

- Adds `// SPDX-License-Identifier: Apache-2.0` as the first line of all 311 tracked `.go` files, followed by a blank line so existing package doc comments stay attached to their `package` clause (verified with `go doc` / `go vet` spot-checks).
- No files were already headered (0/311) and no generated files were found (`Code generated` marker search came up empty), so nothing was skipped.
- Adds a "SPDX headers" CI step in `.github/workflows/ci.yaml`, running before `go build`, that checks the first line of every `git ls-files '*.go'` entry and fails the job listing any file missing the header — guards against regressions from new files.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `test -z "$(gofmt -l .)"`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` → 0 issues
- [x] Spot-checked `go doc` on packages with doc comments (e.g. `internal/providers/gitops/flux`, `internal/kbmcp`) to confirm the header didn't merge with or break the package doc comment
- [x] Verified the one file with a `//go:build` constraint (`hack/e2e/mock/main.go`) still builds/vets under the `e2e` tag with the header prepended
- [x] Manually verified the new CI guard step fails when a `.go` file is missing the header, and passes on a clean tree