### PR TITLE
feat(app): warn loudly at startup when the alert webhook is unauthenticated

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,7 +254,9 @@ attributes nothing). Startup fails loud unless `homeserver`/`room_id`/`access_to
 ### `server` — the HTTP listener
 Only `webhook_token_env` (the bearer token for the incident webhook; **required under
 `actions.mode=auto`**). The listen address is the `--addr` CLI flag (`:8080` in the chart), **not** a
-config key. TLS is terminated externally (ClusterIP + NetworkPolicy).
+config key. TLS is terminated externally (ClusterIP + NetworkPolicy). If `sources.alertmanager` is
+enabled and this is left unset, startup logs a warning (louder under `actions.mode=approve`) — the
+webhook stays open on purpose for cluster-internal traffic, but the risk should never be silent.
 
 ### `rbac` — chart-only (not in the agent config)
 Set under `values.rbac.*`, not `values.config`: `controllerLogNamespaces` (default `[flux-system]` —

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -61,6 +61,34 @@ func RequireWebhookAuth(cfg *config.Config, webhookToken string) error {
 	return nil
 }
 
+// WebhookAuthWarning decides the startup warning for an unauthenticated alert
+// webhook, returning "" when no warning is warranted. Unlike RequireWebhookAuth
+// (which only fails closed once a model is billed per request) and
+// config.Validate (which only hard-fails actions.mode=auto), an empty token is a
+// DELIBERATE fail-open default outside those cases — cluster-internal deployments
+// legitimately skip it. That default must not be silent: whenever the alertmanager
+// source is enabled with no token, anyone who can reach the Service can trigger
+// investigations (and, under an executing rung, actions a human then approves)
+// regardless of whether a model is configured yet. PagerDuty is deliberately
+// excluded — it authenticates via its own X-PagerDuty-Signature scheme (see
+// RequirePagerDutyAuth), so an empty shared token says nothing about its exposure.
+// actions.mode=approve escalates the wording (a human is now clicking "run" off of
+// webhook-supplied data) but stays a warning, not an error — auto already hard-fails
+// via config.Validate, and off/suggest carry no execution risk to call out.
+func WebhookAuthWarning(alertmanagerEnabled bool, webhookToken string, mode config.ActionMode) string {
+	if !alertmanagerEnabled || webhookToken != "" {
+		return ""
+	}
+	if mode == config.ActionApprove {
+		return "alert webhook is UNAUTHENTICATED (server.webhook_token_env unset) while actions.mode=approve: " +
+			"anyone who can reach the Service can trigger paid investigations whose actions a human then approves " +
+			"— set a token unless the endpoint is provably unreachable beyond trusted networks (docs/security-model.md)"
+	}
+	return "alert webhook is UNAUTHENTICATED (server.webhook_token_env unset): fine for cluster-internal traffic, " +
+		"but anyone who can reach the Service can trigger paid investigations — set a token if the endpoint is " +
+		"reachable beyond trusted networks (docs/security-model.md)"
+}
+
 // RequirePagerDutyAuth is the PagerDuty analogue of RequireWebhookAuth. The
 // PagerDuty source authenticates /webhook/pagerduty with its own
 // X-PagerDuty-Signature verification (not the shared server.webhook_token_env

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/config"
@@ -37,6 +38,50 @@ func TestRequireWebhookAuth(t *testing.T) {
 			err := RequireWebhookAuth(cfg, tc.token)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("RequireWebhookAuth err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestWebhookAuthWarning covers the (source enabled × token set × actions mode)
+// matrix: a warning fires only when the alertmanager source is enabled AND the
+// token is empty, regardless of whether a model is configured (unlike
+// RequireWebhookAuth, which only fail-closes once a model is billed per request).
+// actions.mode=approve gets the stronger wording; auto is deliberately NOT covered
+// here — config.Validate already hard-fails an empty token under auto, so this
+// helper never has to warn about it.
+func TestWebhookAuthWarning(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		token    string
+		mode     config.ActionMode
+		wantWarn bool
+		wantLoud bool // stronger approve-mode wording
+	}{
+		{"disabled + no token + off → silent (source not reachable)", false, "", config.ActionOff, false, false},
+		{"disabled + no token + approve → silent (source not reachable)", false, "", config.ActionApprove, false, false},
+		{"enabled + token + off → silent (authenticated)", true, "secret", config.ActionOff, false, false},
+		{"enabled + token + approve → silent (authenticated)", true, "secret", config.ActionApprove, false, false},
+		{"enabled + no token + off → warns", true, "", config.ActionOff, true, false},
+		{"enabled + no token + suggest → warns", true, "", config.ActionSuggest, true, false},
+		{"enabled + no token + approve → warns louder", true, "", config.ActionApprove, true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WebhookAuthWarning(tc.enabled, tc.token, tc.mode)
+			if (got != "") != tc.wantWarn {
+				t.Fatalf("WebhookAuthWarning(%v, %q, %s) = %q, wantWarn = %v", tc.enabled, tc.token, tc.mode, got, tc.wantWarn)
+			}
+			if !tc.wantWarn {
+				return
+			}
+			isLoud := strings.Contains(got, "actions.mode=approve")
+			if isLoud != tc.wantLoud {
+				t.Fatalf("WebhookAuthWarning(%v, %q, %s) loud = %v, want %v (msg: %q)", tc.enabled, tc.token, tc.mode, isLoud, tc.wantLoud, got)
+			}
+			if !strings.Contains(got, "server.webhook_token_env") || !strings.Contains(got, "docs/security-model.md") {
+				t.Fatalf("WebhookAuthWarning message missing risk/fix pointers: %q", got)
 			}
 		})
 	}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -138,6 +138,15 @@ func RunServe(version string, args []string) error {
 	if err := RequirePagerDutyAuth(cfg, pdEnabled, pdSecret); err != nil {
 		return err
 	}
+	// RequireWebhookAuth above only fail-closes once a model is configured (it bills
+	// per request); an empty token otherwise is a DELIBERATE fail-open default for
+	// cluster-internal traffic, and config.Validate only hard-fails it under
+	// actions.mode=auto. That default must not be silent, so surface it loudly here —
+	// see WebhookAuthWarning for the full decision matrix.
+	_, alertmanagerEnabled := cfg.Sources["alertmanager"]
+	if msg := WebhookAuthWarning(alertmanagerEnabled, webhookToken, cfg.Actions.Mode); msg != "" {
+		log.Warn(msg)
+	}
 
 	// Set up the single shared OTel metrics instance before building the investigator
 	// so recall + the investigation loop can record to it from the first request.


### PR DESCRIPTION
## Summary
- `server.webhook_token_env` fail-open is deliberate outside `actions.mode=auto` (cluster-internal traffic doesn't need a token), but the default was silent — nothing told an operator the alert webhook is open.
- Adds `app.WebhookAuthWarning(alertmanagerEnabled, webhookToken, mode)`, an extracted, table-tested decision helper wired into `serve.go` right after the existing `RequireWebhookAuth`/`RequirePagerDutyAuth` checks: when `sources.alertmanager` is enabled and the token is empty, log one structured `log.Warn` naming the exact risk (anyone who can reach the Service can trigger paid investigations) and the fix (set `server.webhook_token_env`, see `docs/security-model.md`).
- The warning escalates under `actions.mode=approve` (an executing rung — a human clicks "run" off webhook-supplied data) but stays a warning; `actions.mode=auto` is untouched — `config.Validate` already hard-fails an empty token there.
- PagerDuty is explicitly excluded: it authenticates `/webhook/pagerduty` via its own `X-PagerDuty-Signature` scheme (`RequirePagerDutyAuth`), so the shared token says nothing about its exposure.
- One-sentence addition to `docs/configuration.md`'s `server` section pointing at the new startup warning.

## Decision matrix implemented (`TestWebhookAuthWarning`)
| alertmanager enabled | token set | actions.mode | warns? |
|---|---|---|---|
| no | no | any | no (source unreachable) |
| yes | yes | any | no (authenticated) |
| yes | no | off / suggest | yes (standard wording) |
| yes | no | approve | yes (louder wording) |
| yes | no | auto | n/a — config.Validate already hard-fails startup before this runs |

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `test -z "$(gofmt -l .)"`
- [x] `go test ./...`
- [x] `golangci-lint run ./...` (0 issues)