### PR TITLE
chart: safer defaults — dedup rationale + networkPolicy.ingressFrom risk guidance

### DIFF
--- a/deploy/helm/runlore/templates/NOTES.txt
+++ b/deploy/helm/runlore/templates/NOTES.txt
@@ -20,6 +20,16 @@ NOTE: no `config.model` set — RunLore runs the read-only log-only investigator
 Set config.model.{base_url,model,api_key_env} to enable LLM investigations.
 {{- end }}
 
+{{- if and .Values.networkPolicy.enabled (not .Values.networkPolicy.ingressFrom) }}
+
+WARNING: networkPolicy.ingressFrom is empty — the webhook/health port
+({{ .Values.service.port }}) is reachable from ANY pod in the cluster. If the
+webhook is also unauthenticated (no config.server.webhook_token_env), any
+in-cluster workload can POST synthetic alerts and trigger paid LLM
+investigations at will. Set networkPolicy.ingressFrom to your Alertmanager
+namespace and config.server.webhook_token_env — see docs/security-model.md.
+{{- end }}
+
 {{- if and .Values.curate.cronjob.enabled (dig "outcome" "ledger_path" "" .Values.config) (not .Values.persistence.enabled) }}
 
 WARNING: the curate CronJob is enabled with config.outcome.ledger_path set, but

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -53,6 +53,11 @@ config:
     incidents:
       match:
         severity: [critical]
+      # Suppress re-investigation of a still-firing alert within this window. The code
+      # default is 0 (disabled) — without it, an alert that keeps firing burns a FULL
+      # paid LLM investigation on every Alertmanager repeat_interval. The chart ships
+      # 30m to bound cost/noise on a default install; set 0 to restore immediate
+      # re-investigation of every still-firing repeat.
       dedup:
         window: 30m
       # Pre-investigation debounce: hold a firing alert this long, then investigate
@@ -380,8 +385,16 @@ networkPolicy:
     apiServerCIDRs: []      # the Kubernetes API server endpoint(s) on 6443, e.g. ["10.0.0.1/32"]
   extraEgress: []   # appended verbatim in BOTH modes — the escape hatch for anything custom
   # Scope ingress to the webhook port. Empty (default) leaves it permissive
-  # (no `from:` ⇒ all sources) so installs don't break; set it to lock the
-  # webhook down to Alertmanager. NetworkPolicyPeer list, spliced into `from:`.
+  # (no `from:` ⇒ all sources allowed) so installs don't break on upgrade.
+  #
+  # RISK: with the default empty list, ANY pod in the cluster can reach the webhook
+  # port — and the webhook itself is UNAUTHENTICATED unless you also set
+  # server.webhook_token_env. Combined, that means any workload on the cluster (a
+  # compromised or merely misconfigured neighbor) can POST synthetic alerts and
+  # trigger paid LLM investigations at will, burning your model spend. Set
+  # ingressFrom to restrict callers to your Alertmanager namespace, AND set
+  # server.webhook_token_env — see docs/security-model.md.
+  #
   # Example — only the monitoring namespace may POST alerts:
   #   ingressFrom:
   #     - namespaceSelector:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,7 +59,9 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
 - `incidents.match` / `incidents.ignore` — ANDed matchers (`severity`, `environment`, `namespaces`
   globs, `alertnames` globs, `labels`); empty fields match anything. `ignore` excludes even if `match`
   passes.
-- `incidents.dedup.window` — don't re-open a still-firing alert within this window.
+- `incidents.dedup.window` — don't re-open a still-firing alert within this window. **Code default `0`**
+  (disabled — every repeat_interval re-investigates); the **chart ships `30m`** by default to bound
+  LLM spend on noisy still-firing alerts (see `deploy/helm/runlore/values.yaml`).
 - `incidents.debounce` — hold a firing alert this long before investigating, and skip it if a matching
   Alertmanager `resolved` webhook arrives within the window (self-resolving noise, e.g. a
   `KubeDaemonSetRolloutStuck` during a Karpenter node-churn cycle). **Default `0`** (investigate


### PR DESCRIPTION
## Summary

Two safer-defaults changes to the chart, no code-default or chart-default behavior change beyond what's noted:

**(a) Dedup rationale comment.** The chart's default `config:` block already ships `triggers.incidents.dedup.window: 30m` (set in a prior commit) — the Go code default stays `0` (disabled). Without the chart override, a still-firing alert re-investigates a full paid LLM loop on every Alertmanager `repeat_interval`. This PR adds the missing rationale comment above the `dedup:` block in `values.yaml` (cost/noise; set `0` to restore immediate re-investigation) and documents the chart-vs-code default split in `docs/configuration.md`'s `incidents.dedup.window` line. No value changed.

**(b) networkPolicy.ingressFrom risk guidance.** `networkPolicy.ingressFrom` stays `[]` by default — restricting it would break existing Alertmanager→RunLore traffic for anyone upgrading an existing install, so **the default is intentionally unchanged**. The empty default combined with the by-default-unauthenticated alert webhook means any in-cluster pod can POST synthetic alerts and burn LLM spend. Instead of changing the default:
- The `values.yaml` comment now calls out the risk explicitly (who can reach it, why it matters, what it costs) with a concrete `namespaceSelector` example scoping ingress to the monitoring namespace.
- `templates/NOTES.txt` renders a post-install `WARNING` when `networkPolicy.enabled` is `true` and `ingressFrom` is empty, pointing at `docs/security-model.md`.

## What renders differently by default

- ConfigMap (`runlore.yaml`): unchanged — `dedup.window: 30m` was already there.
- `helm install`/`upgrade` NOTES output: a new `WARNING` block appears whenever `networkPolicy.enabled=true` (the default) and `networkPolicy.ingressFrom` is empty (the default) — i.e. on a stock install today.
- `values.yaml` comments: both the `dedup` block and `networkPolicy.ingressFrom` gain longer, louder explanatory comments; no schema or default value changes.

## Test plan

- [x] `helm lint deploy/helm/runlore`
- [x] `helm template runlore deploy/helm/runlore` renders cleanly
- [x] Verified the NOTES.txt WARNING appears/disappears correctly under `networkPolicy.enabled` × `ingressFrom` combinations (temporary local render, not part of the diff)
- [x] `go test ./internal/config/ -run TestMinimalValuesConfigPassesStrictLoader`
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` (clean)
- [x] `go test ./...` (all packages pass)
- [x] `golangci-lint run ./...` → 0 issues