### PR TITLE
feat(ci): loud eval skips and label-gated e2e on PRs

### DIFF
--- a/.github/workflows/e2e-k3d.yml
+++ b/.github/workflows/e2e-k3d.yml
@@ -13,8 +13,16 @@
 #
 # Nightly + on-demand. Schedule enabled 2026-07-06 after the first green manual
 # run (28817745501).
+#
+# Also reachable from a pull request, opt-in only: apply the `run-e2e` label. The
+# workflow triggers on labeled/opened/synchronize/reopened, but the job itself is
+# gated by `if:` on that label being present — an unlabeled PR's run is skipped
+# immediately (no runner is ever provisioned), so this expensive suite never runs
+# by default on every PR.
 on:
   workflow_dispatch:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
   schedule:
     - cron: "0 5 * * *"   # nightly 05:00 UTC (before the 06:00 eval run)
 
@@ -38,6 +46,10 @@ jobs:
   e2e:
     name: k3d end-to-end
     runs-on: ubuntu-latest
+    # Run unconditionally on schedule/workflow_dispatch; on pull_request, only when
+    # the PR carries the `run-e2e` label (checked here, not just at trigger level, so
+    # unlabeled PRs never even provision a runner for this expensive job).
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e')
     # Cold docker build of the multi-stage Go image + several helm rollouts (90-120s
     # waits each) + leader-election failover (up to 60s) + the storm/argocd phases.
     # ~12-20 min in practice; 30 leaves headroom without masking a hang.

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -3,7 +3,10 @@
 #
 # IMPORTANT: this job requires the RUNLORE_EVAL_API_KEY repo secret (an
 # Anthropic API key). When the secret is absent the run is skipped gracefully
-# (job exits 0) so the nightly schedule does not produce spurious failures.
+# (job exits 0) so the nightly schedule does not produce spurious failures —
+# but the skip is LOUD: a `::warning::` annotation (surfaced in the Actions
+# run summary / checks UI) plus a $GITHUB_STEP_SUMMARY line, so a run with no
+# key configured can never be mistaken for a real green eval.
 name: eval
 on:
   schedule:
@@ -41,14 +44,15 @@ jobs:
             echo "has_key=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Emit a clear notice and a job-summary line when the key is absent so
-      # the skip is self-documenting in the Actions UI.
+      # Emit a loud warning annotation AND a job-summary line when the key is
+      # absent so the skip is self-documenting in the Actions UI — a missing
+      # secret must never look like a quiet, real green run.
       - name: skip notice (no API key)
         if: steps.guard.outputs.has_key != 'true'
         run: |
-          echo "::notice::eval skipped — RUNLORE_EVAL_API_KEY secret not set"
+          echo "::warning title=Eval skipped::RUNLORE_EVAL_API_KEY is not set — the nightly eval did NOT run"
           echo "## eval skipped" >> "$GITHUB_STEP_SUMMARY"
-          echo "The \`RUNLORE_EVAL_API_KEY\` repo secret (Anthropic API key) is not configured. Set it to enable nightly eval runs." >> "$GITHUB_STEP_SUMMARY"
+          echo "The \`RUNLORE_EVAL_API_KEY\` repo secret (Anthropic API key) is not configured, so this run did **not** exercise the eval harness. Set the secret to enable nightly eval runs." >> "$GITHUB_STEP_SUMMARY"
 
       - name: build lore binary
         if: steps.guard.outputs.has_key == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,12 @@ incident webhook → trigger policy · the ReAct loop (`what_changed → kb_sear
 Slack + Matrix delivery · GitOps-failure informer on real `Kustomization` CRDs · the curator
 (GitHub App token → PR) · leader election (single active leader + failover).
 
+In CI (`.github/workflows/e2e-k3d.yml`) the suite runs nightly (05:00 UTC), on manual dispatch —
+and **on demand on a pull request**: apply the **`run-e2e`** label to the PR. Unlabeled PRs never
+start the job (it is `if:`-gated on the label, so no runner time is spent), keeping the
+~15-minute suite opt-in rather than a per-PR tax. Apply the label when a change touches the
+deployment path, the chart, or a behaviour the e2e asserts.
+
 ### The mock backends
 
 `hack/e2e/mock/main.go` (behind the `e2e` build tag, so it's excluded from normal builds) stands in for
@@ -129,14 +135,24 @@ pass-rate drops below 70% (`-n 5 -fail-under 0.7`), then uploads the JSON report
 a build artifact.
 
 To enable it, add one repository secret — **`RUNLORE_EVAL_API_KEY`** — holding the
-API key for the provider in `eval/ci.runlore.yaml`. Without the secret the job fails
-fast (by design: a red nightly is the signal). The eval never runs on pull requests,
-so it imposes no per-PR cost and never blocks merges; the deterministic scoring logic
-is already covered by `go test ./...` on every PR.
+API key for the provider in `eval/ci.runlore.yaml`. Without the secret the job is
+**skipped, not failed** — a fork or a repo without the secret configured stays
+green — but the skip is loud: a `::warning::` annotation plus a `$GITHUB_STEP_SUMMARY`
+line call it out in the Actions UI, so a run with no key never reads as a real,
+quiet pass. The eval never runs on pull requests, so it imposes no per-PR cost and
+never blocks merges; the deterministic scoring logic is already covered by
+`go test ./...` on every PR.
 
 Run it locally the same way CI does:
 
     lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7
+
+One of the replay cases, `examples/eval/poisoned-recall-verify.yaml`, is
+self-seeding (its own fixture catalog under `examples/eval/fixtures/poisoned-recall`)
+and needs no extra setup; its sibling **live-fire** scenario,
+`eval/scenarios/poisoned-recall-rejected.yaml` (run via `lore eval --live`, not by
+any CI workflow), instead requires a poisoned catalog entry to be manually seeded
+into a real cluster's catalog and `RUNLORE_POISON_READY` set, or it SKIPs.
 
 ## Quick local demo (no cluster)
 


### PR DESCRIPTION
Two CI blind spots fixed: a missing eval secret looked like a green run, and the k3d e2e suite was unreachable from a PR.

## eval.yaml — loud skip instead of silent skip

When `RUNLORE_EVAL_API_KEY` is absent the job still succeeds (forks without secrets must not go red), but the skip is now impossible to miss:

- `::warning title=Eval skipped::RUNLORE_EVAL_API_KEY is not set — the nightly eval did NOT run` — an annotation surfaced in the Actions run header/checks UI (upgraded from the previous quiet `::notice::`)
- a `$GITHUB_STEP_SUMMARY` section stating the eval did **not** exercise the harness

The guard step (secret presence checked via env mapping, never echoed) is unchanged; only the visibility of the skip changes.

## e2e-k3d.yml — reachable from PRs, opt-in via label

- Added a `pull_request` trigger with `types: [labeled, opened, synchronize, reopened]`.
- The job is gated with `if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-e2e')`, so an unlabeled PR skips at job level — no runner is provisioned for the ~15-minute suite.
- `workflow_dispatch` and the nightly `schedule` (05:00 UTC) are unchanged.

To run the suite on a PR: apply the **`run-e2e`** label (a later push to a labeled PR re-runs it via `synchronize`).

## CONTRIBUTING.md

- Fixed the stale claim that the nightly eval "fails fast" without the secret — it skips loudly, documented as such.
- Documented the `run-e2e` label in the e2e section.
- One sentence on poisoned-recall seeding: the replay case `examples/eval/poisoned-recall-verify.yaml` is self-seeding (fixture catalog) and runs in the nightly eval; the live-fire `eval/scenarios/poisoned-recall-rejected.yaml` requires a manually seeded poisoned catalog entry + `RUNLORE_POISON_READY`, else it SKIPs (that skip is already explicit in the live report, not silent — no workflow runs it).

## Verification

- `actionlint` on both workflows: clean
- `go build ./... && go test ./internal/eval/`: pass
