### PR TITLE
test(clientcore): cover the shared SSE/stream parsing core

### DIFF
--- a/internal/model/clientcore/clientcore_test.go
+++ b/internal/model/clientcore/clientcore_test.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package clientcore
+
+import "testing"
+
+// TestNewBase asserts the shared constructor normalization every provider relies
+// on: base-URL fallback and trailing-slash trimming (providers join "/v1/..."
+// paths verbatim, so a trailing slash would produce "//v1/...") and the
+// maxTokens fallback (a zero config value must never reach the wire as
+// max_tokens: 0).
+func TestNewBase(t *testing.T) {
+	cases := []struct {
+		name           string
+		baseURL        string
+		defaultBaseURL string
+		maxTokens      int
+		wantURL        string
+		wantMaxTokens  int
+	}{
+		{"empty baseURL falls back to the provider default", "", "https://api.example.com", 100, "https://api.example.com", 100},
+		{"explicit baseURL wins over the default", "https://proxy.internal", "https://api.example.com", 100, "https://proxy.internal", 100},
+		{"trailing slashes are trimmed", "https://api.example.com///", "", 100, "https://api.example.com", 100},
+		{"the default is trimmed too", "", "https://api.example.com/", 100, "https://api.example.com", 100},
+		{"no baseURL and no default stays empty (openai has no public default)", "", "", 100, "", 100},
+		{"zero maxTokens falls back to DefaultMaxTokens", "https://u", "", 0, "https://u", DefaultMaxTokens},
+		{"negative maxTokens falls back to DefaultMaxTokens", "https://u", "", -5, "https://u", DefaultMaxTokens},
+		{"positive maxTokens is preserved", "https://u", "", 42, "https://u", 42},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBase(tc.baseURL, tc.defaultBaseURL, "model-x", "key-y", tc.maxTokens)
+			if b.BaseURL != tc.wantURL {
+				t.Errorf("BaseURL = %q, want %q", b.BaseURL, tc.wantURL)
+			}
+			if b.MaxTokens != tc.wantMaxTokens {
+				t.Errorf("MaxTokens = %d, want %d", b.MaxTokens, tc.wantMaxTokens)
+			}
+			if b.Model != "model-x" || b.APIKey != "key-y" {
+				t.Errorf("Model/APIKey not passed through: got %q/%q", b.Model, b.APIKey)
+			}
+		})
+	}
+}
+
+// TestNewBaseHTTPClient asserts the constructed client is the hardened streaming
+// client: no flat Timeout (a flat deadline would kill a legitimate long
+// completion mid-stream — ctx + the idle reader bound the request instead) and
+// the redirect guard wired (SSRF defense).
+func TestNewBaseHTTPClient(t *testing.T) {
+	b := NewBase("", "", "m", "k", 1)
+	if b.HTTP == nil {
+		t.Fatal("HTTP client must be set")
+	}
+	if b.HTTP.Timeout != 0 {
+		t.Errorf("streaming client must not have a flat Timeout, got %v", b.HTTP.Timeout)
+	}
+	if b.HTTP.CheckRedirect == nil {
+		t.Error("streaming client must carry the redirect guard")
+	}
+}

--- a/internal/model/clientcore/detail_test.go
+++ b/internal/model/clientcore/detail_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package clientcore
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDetail asserts the sanitized ": kind: message" formatting: control
+// characters (newlines, CR, ANSI escape, DEL) collapse to spaces so an
+// attacker-controlled provider error body cannot forge log lines or inject
+// terminal escapes when the detail is embedded in an Error-level log.
+func TestDetail(t *testing.T) {
+	cases := []struct{ name, kind, message, want string }{
+		{"plain kind and message", "invalid_request_error", "prompt is too long", ": invalid_request_error: prompt is too long"},
+		{"empty kind and message", "", "", ": : "},
+		{"newline collapses to a space", "k", "line1\nline2", ": k: line1 line2"},
+		{"carriage return collapses", "k", "a\rb", ": k: a b"},
+		{"ANSI escape collapses", "k", "a\x1b[2Kb", ": k: a [2Kb"},
+		{"DEL collapses", "k", "a\x7fb", ": k: a b"},
+		{"the kind is sanitized too", "bad\nkind", "m", ": bad kind: m"},
+		{"surrounding whitespace is trimmed", "  k\t", " m \n", ": k: m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Detail(tc.kind, tc.message); got != tc.want {
+				t.Errorf("Detail(%q, %q) = %q, want %q", tc.kind, tc.message, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDetailTruncation asserts an oversized upstream message is truncated with
+// an ellipsis (a hostile error body must not bloat logs) while a message exactly
+// at the limit passes through untouched.
+func TestDetailTruncation(t *testing.T) {
+	atLimit := strings.Repeat("a", maxDetailLen)
+	if got, want := Detail("k", atLimit), ": k: "+atLimit; got != want {
+		t.Errorf("message at the limit was altered: got %d bytes, want %d", len(got), len(want))
+	}
+	got := Detail("k", strings.Repeat("a", maxDetailLen+1))
+	if want := ": k: " + atLimit + "…"; got != want {
+		t.Errorf("over-limit message: got %d bytes ending %q, want %d bytes ending %q",
+			len(got), got[len(got)-3:], len(want), want[len(want)-3:])
+	}
+}
+
+// TestDetailLogInjection feeds a forged-log-record payload (the classic
+// clear-line-then-fake-record attack) and asserts no control character survives
+// into the formatted detail.
+func TestDetailLogInjection(t *testing.T) {
+	got := Detail("x", "\n\x1b[2Kforged=record level=error msg=\"fake\"\r\n")
+	if strings.ContainsAny(got, "\n\r\x1b\x7f") {
+		t.Errorf("detail leaked control characters: %q", got)
+	}
+}

--- a/internal/model/clientcore/sse_test.go
+++ b/internal/model/clientcore/sse_test.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package clientcore
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// testEvent is a minimal provider-style SSE event payload. Unknown JSON fields
+// are ignored by encoding/json, mirroring how the provider event structs decode
+// only what they accumulate.
+type testEvent struct {
+	Type string `json:"type"`
+	N    int    `json:"n"`
+}
+
+// collectSSE drains SSEEvents over r and returns the yielded events and errors,
+// each in yield order.
+func collectSSE(t *testing.T, r io.Reader) (events []testEvent, errs []error) {
+	t.Helper()
+	for ev, err := range SSEEvents[testEvent](r) {
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		events = append(events, ev)
+	}
+	return events, errs
+}
+
+// TestSSEEventsFraming asserts the framing+decoding grammar over an untrusted
+// provider stream: well-formed events decode, keep-alive comments and non-data
+// fields are invisible, a trailing unterminated event is flushed at EOF, and —
+// critically — a malformed JSON event yields a decode error WITHOUT killing the
+// stream (the provider fold decides whether to bail; one garbled frame must not
+// discard an otherwise good completion).
+func TestSSEEventsFraming(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantEvents []testEvent
+		wantErrs   int
+	}{
+		{
+			name:       "single event",
+			input:      "data: {\"type\":\"a\",\"n\":1}\n\n",
+			wantEvents: []testEvent{{Type: "a", N: 1}},
+		},
+		{
+			name:       "multiple events",
+			input:      "data: {\"type\":\"a\",\"n\":1}\n\ndata: {\"type\":\"b\",\"n\":2}\n\n",
+			wantEvents: []testEvent{{Type: "a", N: 1}, {Type: "b", N: 2}},
+		},
+		{
+			name:       "no space after the data colon (the space is optional per the SSE spec)",
+			input:      "data:{\"type\":\"a\",\"n\":1}\n\n",
+			wantEvents: []testEvent{{Type: "a", N: 1}},
+		},
+		{
+			name:       "multi-line data joins with a newline (valid JSON whitespace between tokens)",
+			input:      "data: {\"type\":\"multi\",\ndata: \"n\":3}\n\n",
+			wantEvents: []testEvent{{Type: "multi", N: 3}},
+		},
+		{
+			name:       "keep-alive comments and non-data fields are ignored",
+			input:      ": keep-alive\n\nevent: message_start\nid: 42\nretry: 1000\ndata: {\"type\":\"a\",\"n\":1}\n\n: ping\n\n",
+			wantEvents: []testEvent{{Type: "a", N: 1}},
+		},
+		{
+			name:       "final event with no trailing blank line is flushed at EOF",
+			input:      "data: {\"type\":\"tail\",\"n\":9}",
+			wantEvents: []testEvent{{Type: "tail", N: 9}},
+		},
+		{
+			name:  "empty stream yields nothing",
+			input: "",
+		},
+		{
+			name:  "comments and blank lines only yield nothing",
+			input: ": ping\n\n: pong\n\n\n",
+		},
+		{
+			name:       "CRLF line endings",
+			input:      "data: {\"type\":\"crlf\",\"n\":4}\r\n\r\n",
+			wantEvents: []testEvent{{Type: "crlf", N: 4}},
+		},
+		{
+			name:       "malformed JSON yields a decode error and the stream continues",
+			input:      "data: {oops\n\ndata: {\"type\":\"ok\",\"n\":6}\n\n",
+			wantEvents: []testEvent{{Type: "ok", N: 6}},
+			wantErrs:   1,
+		},
+		{
+			name:       "empty data payload yields a decode error and the stream continues",
+			input:      "data:\n\ndata: {\"type\":\"after\",\"n\":5}\n\n",
+			wantEvents: []testEvent{{Type: "after", N: 5}},
+			wantErrs:   1,
+		},
+		{
+			name:       "good-bad-good interleaving keeps both good events",
+			input:      "data: {\"type\":\"g1\",\"n\":1}\n\ndata: nope\n\ndata: {\"type\":\"g2\",\"n\":2}\n\n",
+			wantEvents: []testEvent{{Type: "g1", N: 1}, {Type: "g2", N: 2}},
+			wantErrs:   1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			events, errs := collectSSE(t, strings.NewReader(tc.input))
+			if !slices.Equal(events, tc.wantEvents) {
+				t.Errorf("events = %v, want %v", events, tc.wantEvents)
+			}
+			if len(errs) != tc.wantErrs {
+				t.Errorf("errors = %v, want %d of them", errs, tc.wantErrs)
+			}
+		})
+	}
+}
+
+// TestSSEEventsDecodeError asserts a decode failure surfaces the underlying
+// json error (errors.As) under the "decode sse event" wrap, so a provider log
+// pinpoints a malformed upstream frame rather than a generic read failure.
+func TestSSEEventsDecodeError(t *testing.T) {
+	_, errs := collectSSE(t, strings.NewReader("data: {truncated\n\n"))
+	if len(errs) != 1 {
+		t.Fatalf("want exactly one decode error, got %v", errs)
+	}
+	var syn *json.SyntaxError
+	if !errors.As(errs[0], &syn) {
+		t.Errorf("decode error should wrap the json error, got %v", errs[0])
+	}
+	if !strings.Contains(errs[0].Error(), "decode sse event") {
+		t.Errorf("decode error should name the failure, got %v", errs[0])
+	}
+}
+
+// errReader yields its data, then a permanent read error — a mid-stream
+// connection drop as the line scanner sees it.
+type errReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.off < len(r.data) {
+		n := copy(p, r.data[r.off:])
+		r.off += n
+		return n, nil
+	}
+	return 0, r.err
+}
+
+// TestSSEEventsReadErrorIsTerminal asserts a transport read error is yielded
+// unwrapped (so callers can errors.Is against it) after the events that were
+// fully framed before the drop — a dropped stream must be observable, never
+// silently treated as a clean end.
+func TestSSEEventsReadErrorIsTerminal(t *testing.T) {
+	drop := errors.New("connection reset by peer")
+	r := &errReader{data: []byte("data: {\"type\":\"a\",\"n\":1}\n\n"), err: drop}
+	events, errs := collectSSE(t, r)
+	if want := []testEvent{{Type: "a", N: 1}}; !slices.Equal(events, want) {
+		t.Errorf("events before the drop = %v, want %v", events, want)
+	}
+	if len(errs) != 1 || !errors.Is(errs[0], drop) {
+		t.Errorf("want the read error yielded once, got %v", errs)
+	}
+}
+
+// TestSSEEventsOversizedLineIsTerminal asserts a single line beyond the 1 MiB
+// SSE line cap aborts the stream with bufio.ErrTooLong — the memory-exhaustion
+// defense against a hostile upstream — and that nothing after it is delivered
+// (a framing error is terminal, unlike a per-event decode error).
+func TestSSEEventsOversizedLineIsTerminal(t *testing.T) {
+	input := "data: " + strings.Repeat("x", 1<<20) + "\n\ndata: {\"type\":\"never\",\"n\":1}\n\n"
+	events, errs := collectSSE(t, strings.NewReader(input))
+	if len(events) != 0 {
+		t.Errorf("no event should survive an oversized line, got %v", events)
+	}
+	if len(errs) != 1 || !errors.Is(errs[0], bufio.ErrTooLong) {
+		t.Fatalf("want a single bufio.ErrTooLong, got %v", errs)
+	}
+}
+
+// TestSSEEventsLargeEventUnderLimit asserts a large-but-legal event (a ~512 KiB
+// payload, the scale of a big tool-args delta or tool schema) still decodes —
+// the line cap must stay generous enough for real provider traffic.
+func TestSSEEventsLargeEventUnderLimit(t *testing.T) {
+	payload := fmt.Sprintf("{\"type\":\"big\",\"n\":7,\"pad\":%q}", strings.Repeat("x", 512<<10))
+	events, errs := collectSSE(t, strings.NewReader("data: "+payload+"\n\n"))
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if want := []testEvent{{Type: "big", N: 7}}; !slices.Equal(events, want) {
+		t.Errorf("events = %v, want %v", events, want)
+	}
+}
+
+// TestSSEEventsConsumerBreak asserts breaking out of the iteration — on a good
+// event or on a decode error — stops it immediately; the provider folds return
+// early on a fatal in-band provider error event, and iteration must not keep
+// reading the socket behind their back.
+func TestSSEEventsConsumerBreak(t *testing.T) {
+	for _, tc := range []struct{ name, input string }{
+		{"break on a decoded event", "data: {\"type\":\"a\",\"n\":1}\n\ndata: {\"type\":\"b\",\"n\":2}\n\n"},
+		{"break on a decode error", "data: nope\n\ndata: {\"type\":\"b\",\"n\":2}\n\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			SSEEvents[testEvent](strings.NewReader(tc.input))(func(testEvent, error) bool {
+				calls++
+				return false
+			})
+			if calls != 1 {
+				t.Errorf("iteration continued after break: %d yields, want 1", calls)
+			}
+		})
+	}
+}

--- a/internal/model/clientcore/stream_test.go
+++ b/internal/model/clientcore/stream_test.go
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package clientcore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// writeStream writes chunks to w as an incrementally flushed 200 stream, so the
+// client sees real streaming delivery rather than one buffered body.
+func writeStream(t *testing.T, w http.ResponseWriter, chunks ...string) {
+	t.Helper()
+	fl, ok := w.(http.Flusher)
+	if !ok {
+		t.Error("server needs http.Flusher")
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+	fl.Flush()
+	for _, c := range chunks {
+		_, _ = io.WriteString(w, c)
+		fl.Flush()
+	}
+}
+
+// textAccumulate is the simplest accumulate: read the whole stream into Text.
+// It stands in for a provider's SSE fold where only the pipeline is under test.
+func textAccumulate(r io.Reader) (providers.CompletionResponse, error) {
+	b, err := io.ReadAll(r)
+	if err != nil {
+		return providers.CompletionResponse{}, err
+	}
+	return providers.CompletionResponse{Text: string(b)}, nil
+}
+
+// baseFor builds a Base pointed at the test server, as a provider constructor would.
+func baseFor(url string) Base {
+	return NewBase(url, "", "model-x", "key-y", 0)
+}
+
+// wireReq is a stand-in provider request body.
+type wireReq struct {
+	Prompt string `json:"prompt"`
+}
+
+// streamRequest builds a Request the way a provider does: full URL, JSON body,
+// injected headers, and an ErrorDetail that recognizes nothing (overridden by
+// tests that exercise the detail path).
+func streamRequest(url string) Request {
+	return Request{
+		Op:   "chat",
+		URL:  url + "/v1/chat",
+		Body: wireReq{Prompt: "hi"},
+		SetHeaders: func(r *http.Request) {
+			r.Header.Set("Content-Type", "application/json")
+			r.Header.Set("X-Api-Key", "key-y")
+		},
+		ErrorDetail: func([]byte) string { return "" },
+	}
+}
+
+// TestStreamSendsRequestAndAccumulates asserts the pipeline end to end on the
+// happy path: the wire body is the marshaled req.Body, method/URL/headers are
+// as injected, and accumulate receives the full incrementally-flushed response
+// body (through the idle-timeout guard) with its result returned untouched.
+func TestStreamSendsRequestAndAccumulates(t *testing.T) {
+	var (
+		mu                                sync.Mutex
+		gotMethod, gotPath, gotCT, gotKey string
+		gotBody                           []byte
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotMethod, gotPath, gotCT, gotKey, gotBody = r.Method, r.URL.Path, r.Header.Get("Content-Type"), r.Header.Get("X-Api-Key"), body
+		mu.Unlock()
+		writeStream(t, w, "data: hel", "lo\n\n")
+	}))
+	defer srv.Close()
+
+	b := baseFor(srv.URL)
+	resp, err := b.Stream(context.Background(), streamRequest(srv.URL), textAccumulate)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if want := "data: hello\n\n"; resp.Text != want {
+		t.Errorf("accumulated body = %q, want %q", resp.Text, want)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/v1/chat" {
+		t.Errorf("path = %q, want /v1/chat", gotPath)
+	}
+	if gotCT != "application/json" || gotKey != "key-y" {
+		t.Errorf("SetHeaders not applied: content-type %q, api key %q", gotCT, gotKey)
+	}
+	if want := `{"prompt":"hi"}`; string(gotBody) != want {
+		t.Errorf("wire body = %q, want %q", gotBody, want)
+	}
+}
+
+// TestStreamAccumulateErrorPassesThrough asserts accumulate's error is returned
+// verbatim: the provider folds surface their own rich errors (e.g. "stream
+// ended before message_stop") and the pipeline must not re-wrap or swallow them.
+func TestStreamAccumulateErrorPassesThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeStream(t, w, "data: x\n\n")
+	}))
+	defer srv.Close()
+
+	sentinel := errors.New("stream ended before message_stop")
+	b := baseFor(srv.URL)
+	_, err := b.Stream(context.Background(), streamRequest(srv.URL), func(io.Reader) (providers.CompletionResponse, error) {
+		return providers.CompletionResponse{}, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Stream error = %v, want the accumulate sentinel", err)
+	}
+}
+
+// TestStreamMarshalFailureNeverSendsRequest asserts an unmarshalable body fails
+// fast with a "marshal request" error before any bytes hit the network.
+func TestStreamMarshalFailureNeverSendsRequest(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	req := streamRequest(srv.URL)
+	req.Body = make(chan int) // json.Marshal cannot encode a channel
+	b := baseFor(srv.URL)
+	_, err := b.Stream(context.Background(), req, textAccumulate)
+	if err == nil || !strings.Contains(err.Error(), "marshal request") {
+		t.Errorf("want a marshal error, got %v", err)
+	}
+	if got := hits.Load(); got != 0 {
+		t.Errorf("server was hit %d times; a marshal failure must not send a request", got)
+	}
+}
+
+// TestStreamBadURL asserts a malformed URL surfaces as a wrapped "<op> request"
+// error from the build path rather than a panic or a bare transport error.
+func TestStreamBadURL(t *testing.T) {
+	b := baseFor("")
+	req := streamRequest("")
+	req.URL = "://not-a-url"
+	_, err := b.Stream(context.Background(), req, textAccumulate)
+	if err == nil || !strings.Contains(err.Error(), "chat request:") {
+		t.Errorf("want a wrapped request error naming the op, got %v", err)
+	}
+}
+
+// TestStreamStatusClassification asserts the permanence/retry contract for
+// non-200 responses: a 4xx other than 429 is permanent (the investigation
+// workqueue must drop a doomed request instead of requeuing it forever) and is
+// never retried, while 429 and 5xx stay transient and are retried up to
+// retryAttempts before surfacing.
+func TestStreamStatusClassification(t *testing.T) {
+	cases := []struct {
+		name          string
+		status        int
+		wantPermanent bool
+		wantAttempts  int32
+	}{
+		{"400 invalid request is permanent, no retry", http.StatusBadRequest, true, 1},
+		{"401 bad auth is permanent, no retry", http.StatusUnauthorized, true, 1},
+		{"404 unknown model is permanent, no retry", http.StatusNotFound, true, 1},
+		{"429 rate limit is transient and retried", http.StatusTooManyRequests, false, retryAttempts},
+		{"500 upstream failure is transient and retried", http.StatusInternalServerError, false, retryAttempts},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				attempts.Add(1)
+				// Keep the 429 retry waits near-zero via the server hint; a 5xx
+				// uses the client's own exponential backoff (still test-fast).
+				w.Header().Set("Retry-After-Ms", "1")
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			b := baseFor(srv.URL)
+			_, err := b.Stream(context.Background(), streamRequest(srv.URL), textAccumulate)
+			if err == nil {
+				t.Fatal("want an error for a non-200 response")
+			}
+			if got := providers.IsPermanent(err); got != tc.wantPermanent {
+				t.Errorf("IsPermanent = %v, want %v (err: %v)", got, tc.wantPermanent, err)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("status %d", tc.status)) {
+				t.Errorf("error should carry the status: %v", err)
+			}
+			if !strings.Contains(err.Error(), "chat") {
+				t.Errorf("error should carry the op name: %v", err)
+			}
+			if got := attempts.Load(); got != tc.wantAttempts {
+				t.Errorf("attempts = %d, want %d", got, tc.wantAttempts)
+			}
+		})
+	}
+}
+
+// TestStreamErrorDetailAndBoundedBody asserts a non-200 error carries the two
+// fields that make a 4xx diagnosable — the upstream request-id and the
+// provider's sanitized detail suffix — while the raw body is never echoed and
+// the body read handed to ErrorDetail is bounded (an attacker-sized error body
+// must not be slurped into memory).
+func TestStreamErrorDetailAndBoundedBody(t *testing.T) {
+	huge := strings.Repeat("A", maxErrorBody*4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Request-Id", "req-42")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, huge)
+	}))
+	defer srv.Close()
+
+	// gotLen is written synchronously inside the Stream call — no lock needed.
+	gotLen := -1
+	req := streamRequest(srv.URL)
+	req.ErrorDetail = func(body []byte) string {
+		gotLen = len(body)
+		return Detail("invalid_request_error", "prompt too long")
+	}
+	b := baseFor(srv.URL)
+	_, err := b.Stream(context.Background(), req, textAccumulate)
+	if err == nil {
+		t.Fatal("want an error for a 400 response")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `(request-id "req-42")`) {
+		t.Errorf("error should carry the request-id: %q", msg)
+	}
+	if !strings.Contains(msg, ": invalid_request_error: prompt too long") {
+		t.Errorf("error should carry the sanitized detail suffix: %q", msg)
+	}
+	if strings.Contains(msg, "AAAA") {
+		t.Errorf("error echoed the raw upstream body: %q", msg)
+	}
+	if gotLen != maxErrorBody {
+		t.Errorf("ErrorDetail saw %d body bytes, want the bounded %d", gotLen, maxErrorBody)
+	}
+}
+
+// TestStreamRetryThenSuccess asserts a transient 500 on the first attempt is
+// retried into a successful stream, and that the retry carries the full request
+// body and headers again — the body reader is consumed per attempt, so build()
+// must reconstruct the request from scratch.
+func TestStreamRetryThenSuccess(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		bodies []string
+		keys   []string
+	)
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(body))
+		keys = append(keys, r.Header.Get("X-Api-Key"))
+		mu.Unlock()
+		if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		writeStream(t, w, "data: ok\n\n")
+	}))
+	defer srv.Close()
+
+	b := baseFor(srv.URL)
+	resp, err := b.Stream(context.Background(), streamRequest(srv.URL), textAccumulate)
+	if err != nil {
+		t.Fatalf("Stream after a transient 500: %v", err)
+	}
+	if want := "data: ok\n\n"; resp.Text != want {
+		t.Errorf("accumulated body = %q, want %q", resp.Text, want)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) != 2 {
+		t.Fatalf("attempts = %d, want 2", len(bodies))
+	}
+	for i, got := range bodies {
+		if want := `{"prompt":"hi"}`; got != want {
+			t.Errorf("attempt %d body = %q, want %q (the body must be rebuilt per attempt)", i+1, got, want)
+		}
+	}
+	for i, k := range keys {
+		if k != "key-y" {
+			t.Errorf("attempt %d lost its headers: api key %q", i+1, k)
+		}
+	}
+}
+
+// TestStreamContextCancelMidStream asserts cancelling the caller's context
+// while the body is streaming surfaces promptly as a read error inside
+// accumulate (via the child context wired into the HTTP request) instead of
+// blocking forever on an open stream.
+func TestStreamContextCancelMidStream(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeStream(t, w, "data: first\n\n")
+		<-r.Context().Done() // hold the stream open until the client aborts
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	b := baseFor(srv.URL)
+	done := make(chan error, 1)
+	go func() {
+		_, err := b.Stream(ctx, streamRequest(srv.URL), func(r io.Reader) (providers.CompletionResponse, error) {
+			buf := make([]byte, 64)
+			if _, err := r.Read(buf); err != nil { // the first chunk arrives fine
+				return providers.CompletionResponse{}, fmt.Errorf("first chunk: %w", err)
+			}
+			cancel() // the caller's deadline/cancellation fires mid-stream
+			if _, err := io.ReadAll(r); err != nil {
+				return providers.CompletionResponse{}, err
+			}
+			return providers.CompletionResponse{}, errors.New("read past cancellation without an error")
+		})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("want an error after mid-stream cancellation")
+		}
+		if strings.Contains(err.Error(), "read past cancellation") {
+			t.Fatalf("the stream kept flowing after cancellation: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancellation did not abort the stream promptly")
+	}
+}
+
+// TestStreamWithSSEEventsEndToEnd drives the two seams together exactly as a
+// provider does: Stream hands the idle-guarded body to an accumulate folding
+// SSEEvents. Keep-alive comments, event: fields, and chunk boundaries that
+// split an event mid-line must all be invisible to the fold.
+func TestStreamWithSSEEventsEndToEnd(t *testing.T) {
+	chunks := []string{
+		": keep-alive\n\n",
+		"data: {\"type\":\"delta\",\"te", // an event split across two flushes
+		"xt\":\"hel\"}\n\n",
+		"event: content\ndata: {\"type\":\"delta\",\"text\":\"lo\"}\n\n",
+		"data: {\"type\":\"stop\"}\n\n",
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeStream(t, w, chunks...)
+	}))
+	defer srv.Close()
+
+	type wireEvent struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	acc := func(r io.Reader) (providers.CompletionResponse, error) {
+		var out providers.CompletionResponse
+		sawStop := false
+		for ev, err := range SSEEvents[wireEvent](r) {
+			if err != nil {
+				return providers.CompletionResponse{}, err
+			}
+			switch ev.Type {
+			case "delta":
+				out.Text += ev.Text
+			case "stop":
+				sawStop = true
+			}
+		}
+		if !sawStop {
+			return providers.CompletionResponse{}, errors.New("stream ended before stop")
+		}
+		return out, nil
+	}
+
+	b := baseFor(srv.URL)
+	resp, err := b.Stream(context.Background(), streamRequest(srv.URL), acc)
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	if resp.Text != "hello" {
+		t.Errorf("folded text = %q, want %q", resp.Text, "hello")
+	}
+}

--- a/internal/model/clientcore/wire_test.go
+++ b/internal/model/clientcore/wire_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package clientcore
+
+import "testing"
+
+// TestRawObject asserts the "" → {} normalization: a model sometimes emits a
+// tool call with empty arguments, and several provider APIs reject an empty
+// input payload with a 400 — so the empty string must become the empty object,
+// while any non-blank payload passes through verbatim (RawObject normalizes, it
+// does not validate).
+func TestRawObject(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"empty becomes the empty object", "", "{}"},
+		{"whitespace-only becomes the empty object", " \t\r\n ", "{}"},
+		{"an object passes through verbatim", `{"a":1}`, `{"a":1}`},
+		{"non-object JSON passes through verbatim (no validation)", `[1,2]`, `[1,2]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(RawObject(tc.in)); got != tc.want {
+				t.Errorf("RawObject(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`internal/model/clientcore` was the **only zero-test package in the repo** — and it is the shared SSE/stream parsing core for untrusted provider responses (anthropic/openai/gemini). This adds a table-driven suite over every exported seam, mirroring the source layout (one `_test.go` per source file).

**Coverage: 100.0% of statements** (`go test -cover`, also green under `-race`).

## Behaviors covered

**`SSEEvents` (sse.go)** — the untrusted-stream decode path:
- well-formed single/multi-event streams; `data:` with and without the optional space; multi-line `data:` joined with a newline; CRLF line endings
- keep-alive `:` comments and `event:`/`id:`/`retry:` fields ignored; empty/comment-only streams yield nothing
- a trailing unterminated event is flushed at EOF
- a malformed/empty JSON payload yields a decode error (wrapping the `json` error, `errors.As`-able) **without killing the stream** — good events on either side still arrive
- a transport read error is terminal and yielded unwrapped (`errors.Is`-able)
- the 1 MiB SSE line cap: an oversized line aborts with `bufio.ErrTooLong` and nothing after it is delivered; a large-but-legal ~512 KiB event still decodes
- consumer-break semantics: breaking on a good event or on a decode error stops iteration immediately

**`Base.Stream` (stream.go)** — the request pipeline, all via `httptest`:
- request construction: POST, injected URL/headers, wire body = marshaled `req.Body`; accumulate receives the full incrementally-flushed stream and its result/error pass through untouched
- marshal failure fails fast with zero network requests; a malformed URL surfaces as a wrapped "<op> request" error
- **permanent-vs-transient classification**: 400/401/404 → `providers.Permanent`, exactly 1 attempt; 429/500 → transient, retried exactly `retryAttempts` (3) times; errors carry op + status
- non-200 diagnosability: request-id and the sanitized `ErrorDetail` suffix present, raw upstream body never echoed, error-body read bounded to 4 KiB
- retry-then-success: the request body and headers are rebuilt on the second attempt
- context cancellation mid-stream aborts the read promptly inside accumulate
- an end-to-end `Stream`+`SSEEvents` fold (split-chunk events, keep-alives) exactly as the providers use the two seams together

**`NewBase` / `Detail` / `RawObject`**:
- base-URL fallback + trailing-slash trimming, maxTokens fallback, hardened streaming client wiring (no flat timeout, redirect guard)
- `Detail` log-injection defense (control chars collapsed), 300-byte truncation with ellipsis, boundary behavior
- `RawObject` empty/whitespace → `{}`, verbatim pass-through otherwise

## Not covered (and why)

The 2-minute `IdleTimeout` constant is not injectable, so the idle expiry itself is not exercised here; the idle-reader mechanics (timeout trip, `onIdle` hook) are already covered in `internal/httpx/streaming_test.go`.

## Bugs found

None — production code is untouched; every behavior matched its documented contract.

## Quality gate

`go build` ✓ · `go vet` ✓ · `gofmt` clean ✓ · `go test ./...` all green ✓ · `golangci-lint run` → **0 issues** ✓