### PR TITLE
feat(recall): scopeless matching so workload-less incidents (PagerDuty) can recall

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,7 +41,10 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   Alertmanager resolved alert); every other event type is ignored. The incident title becomes the
   investigation title, priority (else urgency) the severity, and the service name, incident number and
   `html_url` ride along as labels. PagerDuty carries **no Kubernetes namespace or workload**, so those
-  stay empty — recall and structural matching tolerate an empty workload.
+  stay empty — such workload-less incidents can recall **only entries that are themselves resource-less**
+  (hand-written runbooks / curated Playbooks without a `resource` frontmatter): the scopeless tier, the
+  weakest match. It must clear `solo_floor` **and** `min_score` even with multiple candidates, recalls
+  with reduced confidence, and `require_workload_match: true` disables it entirely.
   - `secret_env` — names the env var holding the webhook **signing secret** (config stores the env-var
     *name*, never the value). Each delivery is verified against its `X-PagerDuty-Signature` header
     (`v1=`-prefixed HMAC-SHA256 of the raw body; multiple comma-separated signatures are accepted so a
@@ -126,7 +129,10 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   (default 5m), `token_env`.
 - `instant_recall` — `enabled`, and when enabled the trust gates `min_score` **1.0**, `margin_gap`
   **1.0**, `solo_floor` **4.0**, `outcome_prior` **2.0**, `outcome_floor` **0.5**;
-  `require_workload_match`; experimental `hybrid*` vector knobs.
+  `require_workload_match`; experimental `hybrid*` vector knobs. A workload-less incident (e.g.
+  PagerDuty) can match only resource-less entries — the weakest tier, which always requires
+  `solo_floor` + `min_score`, recalls with reduced confidence, and is disabled by
+  `require_workload_match: true`.
 - The search index is in-memory bleve (BM25), rebuilt from `dir` at startup — not persisted.
 
 ### `outcome` — the learning ledger

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -134,7 +134,11 @@ Why each gate exists:
   symptoms → one cause": a `CrashLoopBackOff` in `apps/web` should not recall an OOM
   runbook for `apps/worker`. It's a **pre-filter** over a wide candidate set (k=20),
   not a check of only the top lexical hit, so the structurally-correct entry can win
-  even when a wrong-workload entry scores higher on symptom words.
+  even when a wrong-workload entry scores higher on symptom words. A **workload-less**
+  incident (PagerDuty carries no Kubernetes namespace/name) agrees only with entries
+  that are themselves resource-less — the weakest ("scopeless") tier: it always
+  requires `solo_floor` + `min_score`, starts at reduced confidence, and
+  `require_workload_match: true` disables it.
 - **Gate 2 — relative margin.** The top agreeing hit must beat the runner-up by a
   configured gap (or clear a solo floor when there's only one). Because BM25 scores
   are corpus-dependent, RunLore trusts the *gap between candidates*, not an absolute

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -278,7 +278,7 @@ type InstantRecall struct {
 	MinScore             float64 `yaml:"min_score"`              // similarity floor for the top hit
 	MarginGap            float64 `yaml:"margin_gap"`             // top hit must beat the runner-up by at least this
 	SoloFloor            float64 `yaml:"solo_floor"`             // confident bar when there is only one hit (higher than MinScore)
-	RequireWorkloadMatch bool    `yaml:"require_workload_match"` // true = exact namespace+workload; false = namespace-level agreement is enough
+	RequireWorkloadMatch bool    `yaml:"require_workload_match"` // true = exact namespace+workload (also disables scopeless matching); false = namespace-level agreement is enough
 	OutcomePrior         float64 `yaml:"outcome_prior"`          // Beta prior strength for outcome decay
 	OutcomeFloor         float64 `yaml:"outcome_floor"`          // reject a recall when the outcome factor drops below this
 

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -23,8 +23,10 @@ type OutcomeStats interface {
 // Recall short-circuits an investigation when the knowledge catalog already has a
 // trustworthy answer for the symptom — skipping the slow, paid ReAct loop. From a
 // wider candidate set it keeps only entries whose stored resource structurally
-// agrees with the alert's workload, then requires a clear margin over the runner-up
-// among those agreeing candidates, plus (in the loop) the adversarial verify pass.
+// agrees with the alert's workload (a workload-less request agrees only with
+// resource-less entries — the scopeless tier), then requires a clear margin over
+// the runner-up among those agreeing candidates, plus (in the loop) the
+// adversarial verify pass.
 // Confidence is derived from those signals, never asserted — scores are
 // corpus-dependent and a stale hit must not silently replace an investigation.
 type Recall struct {
@@ -32,7 +34,7 @@ type Recall struct {
 	MinScore             float64 // similarity floor for the top hit
 	MarginGap            float64 // top hit must beat the runner-up by at least this
 	SoloFloor            float64 // confident bar when there is only one hit
-	RequireWorkloadMatch bool    // true = exact namespace+workload; false = namespace-level agreement is enough
+	RequireWorkloadMatch bool    // true = exact namespace+workload (also disables scopeless matching); false = namespace-level agreement is enough
 
 	// Hybrid, when non-nil AND it has vectors, switches recall to fused BM25+embedding
 	// retrieval gated on COSINE similarity (HybridMinScore / HybridMarginGap) instead
@@ -107,11 +109,18 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 	// Gate — margin among the structurally-agreeing candidates: a clear winner for
 	// this workload, not merely the top lexical hit. A lone agreeing hit must clear
 	// both the solo floor and the min score.
+	strength := resourceAgrees(req.Workload, winner.Entry.Resource, r.RequireWorkloadMatch)
 	margin := score
 	confident := score >= soloFloor && score >= minScore
 	if len(agreeing) > 1 {
 		margin = score - agreeing[1].Score
 		confident = score >= minScore && margin >= marginGap
+	}
+	// A scopeless match carries zero structural evidence, so the margin gate alone
+	// is too weak: regardless of how many candidates agree, a scopeless winner must
+	// ALSO clear the solo floor + min score, exactly like a lone hit.
+	if strength == matchScopeless {
+		confident = confident && score >= soloFloor && score >= minScore
 	}
 	if !confident {
 		r.reject(ctx, "low_margin")
@@ -119,7 +128,6 @@ func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float
 	}
 
 	e := winner.Entry
-	strength := resourceAgrees(req.Workload, e.Resource, r.RequireWorkloadMatch)
 	conf := deriveRecallConfidence(score, margin, strength)
 	// Outcome decay: bias confidence by the entry's resolution track record, and
 	// reject (re-investigate) an entry that recalls-but-never-resolves. Fail-safe —
@@ -156,13 +164,31 @@ type matchStrength int
 
 const (
 	matchNone matchStrength = iota
+	// matchScopeless is the weakest agreeing tier: BOTH sides carry no workload
+	// scope at all. It exists so workload-less incident sources (PagerDuty carries
+	// no Kubernetes namespace/name) can still recall hand-written runbooks and
+	// curated Playbooks that are themselves resource-less. It provides zero
+	// structural evidence, so the gate and the derived confidence treat it as
+	// strictly weaker than any scoped tier.
+	matchScopeless
 	matchNamespace
 	matchExact
 )
 
 // resourceAgrees reports how strongly the alert's workload agrees with an entry's
-// stored resource. requireWorkload demands an exact namespace+name match.
+// stored resource. requireWorkload demands an exact namespace+name match — which
+// also disables the scopeless tier (a scopeless pair can never provide one).
 func resourceAgrees(reqW providers.Workload, entryResource string, requireWorkload bool) matchStrength {
+	// Scopeless tier: a request with NO workload at all may agree ONLY with entries
+	// that are themselves resource-less. This never loosens scoped matching — a
+	// request carrying ANY scope hint (namespace, or even a bare name) falls through
+	// to the unchanged rules below, where a resource-less entry never agrees.
+	if reqW.Namespace == "" && reqW.Name == "" {
+		if entryResource == "" && !requireWorkload {
+			return matchScopeless
+		}
+		return matchNone
+	}
 	if entryResource == "" || reqW.Namespace == "" {
 		return matchNone
 	}
@@ -223,6 +249,13 @@ func deriveRecallConfidence(score, margin float64, strength matchStrength) float
 	base := 0.55
 	if score > 0 {
 		base = 0.55 + 0.30*clampF(margin/score, 0, 1) // decisive winner → up to 0.85
+	}
+	// Scopeless is the weakest tier: with zero structural evidence the confidence
+	// rides on the lexical margin alone, so it starts lower AND is capped below
+	// every scoped tier — a workload-less recall must never look as trustworthy as
+	// a namespace- or workload-anchored one.
+	if strength == matchScopeless {
+		return clampF(base-0.10, 0.45, 0.70)
 	}
 	if strength == matchExact {
 		base += 0.05

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -386,6 +386,16 @@ func TestResourceAgrees(t *testing.T) {
 		{"require workload + ns-only -> none", w("apps", ""), "apps/web", true, matchNone},
 		{"require workload + bare-ns entry -> none", w("apps", "web"), "apps", true, matchNone},
 		{"bare-ns alert vs different-ns bare-ns entry -> none", w("apps", ""), "other", false, matchNone},
+		// Scopeless tier: a request with NO workload at all (PagerDuty incidents carry
+		// no Kubernetes namespace/name) agrees ONLY with entries that are themselves
+		// resource-less — the weakest tier, and strict mode disables it entirely.
+		{"scopeless request vs scopeless entry -> scopeless", w("", ""), "", false, matchScopeless},
+		{"scopeless request vs named entry -> none", w("", ""), "apps/web", false, matchNone},
+		{"scopeless request vs bare-ns entry -> none", w("", ""), "apps", false, matchNone},
+		{"require workload + scopeless both sides -> none (strict stays strict)", w("", ""), "", true, matchNone},
+		// A name without a namespace is partial workload info, not scopeless — the
+		// conservative reading refuses the weakest tier when ANY scope hint exists.
+		{"nameless-namespace request with name vs scopeless entry -> none", w("", "web"), "", false, matchNone},
 	}
 	for _, c := range cases {
 		if got := resourceAgrees(c.reqW, c.entry, c.requireWL); got != c.want {
@@ -449,6 +459,124 @@ func TestLookupDecayRejectionMetric(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if !strings.Contains(rec.Body.String(), `reason="low_outcome"`) {
 		t.Fatalf("expected recall_rejections_total{reason=\"low_outcome\"} in metrics:\n%s", rec.Body.String())
+	}
+}
+
+// TestScopelessNeverLoosensScopedMatching states the scopeless-tier invariant: the
+// new tier applies ONLY when BOTH sides carry no scope. A request with any workload
+// scope never matches a resource-less entry, and a scopeless request never matches
+// an entry with any stored resource — the existing Kubernetes matching semantics
+// are untouched in every direction.
+func TestScopelessNeverLoosensScopedMatching(t *testing.T) {
+	scopedReqs := []providers.Workload{
+		{Namespace: "apps", Name: "web"},
+		{Namespace: "apps"}, // namespace-only alert is still scoped
+	}
+	for _, reqW := range scopedReqs {
+		for _, strict := range []bool{false, true} {
+			if got := resourceAgrees(reqW, "", strict); got != matchNone {
+				t.Errorf("scoped request %+v vs resource-less entry (strict=%v) = %v, want matchNone", reqW, strict, got)
+			}
+		}
+	}
+	for _, entry := range []string{"apps/web", "apps", "other"} {
+		for _, strict := range []bool{false, true} {
+			if got := resourceAgrees(providers.Workload{}, entry, strict); got != matchNone {
+				t.Errorf("scopeless request vs scoped entry %q (strict=%v) = %v, want matchNone", entry, strict, got)
+			}
+		}
+	}
+}
+
+// scopelessReq is a request with no Kubernetes workload at all — the PagerDuty shape.
+func scopelessReq() Request {
+	return Request{Title: "checkout latency spike", Workload: providers.Workload{}}
+}
+
+// TestLookupScopeless drives the recall gate end-to-end for workload-less requests:
+// a scopeless request may recall ONLY resource-less entries, and — because a
+// scopeless match carries zero structural evidence — the winner must clear the solo
+// floor AND min score no matter how many candidates agree (the margin gate alone is
+// too weak). Strict mode (require_workload_match) disables the tier entirely.
+func TestLookupScopeless(t *testing.T) {
+	entry := func(path, resource string, score float64) catalog.ScoredEntry {
+		return catalog.ScoredEntry{Entry: catalog.Entry{Title: "Checkout runbook", Path: path, Resource: resource}, Score: score}
+	}
+	cases := []struct {
+		name       string
+		hits       []catalog.ScoredEntry
+		strict     bool
+		wantRecall bool
+	}{
+		{
+			// Lone resource-less entry clearing solo floor (4.0) + min score (1.5).
+			"scopeless solo hit above solo floor recalls",
+			[]catalog.ScoredEntry{entry("runbook.md", "", 6.0)},
+			false, true,
+		},
+		{
+			// Two agreeing scopeless entries with a decisive margin (4.0 >= 1.0) AND a
+			// winner above the solo floor: all gates clear.
+			"scopeless multi-candidate clearing solo floor recalls",
+			[]catalog.ScoredEntry{entry("runbook.md", "", 6.0), entry("old.md", "", 2.0)},
+			false, true,
+		},
+		{
+			// Margin alone would pass (2.5 >= 1.0, min 1.5 met) but the winner is below
+			// the solo floor (3.5 < 4.0): without structural evidence that is not enough.
+			"scopeless multi-candidate below solo floor falls through",
+			[]catalog.ScoredEntry{entry("runbook.md", "", 3.5), entry("old.md", "", 1.0)},
+			false, false,
+		},
+		{
+			// A scopeless request must never recall scoped entries, however strong.
+			"scopeless request vs scoped entries falls through",
+			[]catalog.ScoredEntry{entry("web.md", "apps/web", 9.0), entry("ns.md", "apps", 8.0)},
+			false, false,
+		},
+		{
+			// Strict mode: require_workload_match promises exact namespace+name
+			// agreement, which a scopeless pair can never provide.
+			"strict mode never recalls scopeless",
+			[]catalog.ScoredEntry{entry("runbook.md", "", 6.0)},
+			true, false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := recallWith(c.hits)
+			r.RequireWorkloadMatch = c.strict
+			e, conf := r.lookup(context.Background(), scopelessReq())
+			if got := e != nil; got != c.wantRecall {
+				t.Fatalf("recall = %v (entry %+v), want %v", got, e, c.wantRecall)
+			}
+			if e != nil && conf > 0.70 {
+				t.Fatalf("scopeless recall confidence must stay low (<= 0.70), got %v", conf)
+			}
+		})
+	}
+}
+
+// TestDeriveRecallConfidenceScopelessWeakest pins the confidence ordering: at any
+// identical (score, margin), scopeless < namespace < exact — a workload-less recall
+// must never look as trustworthy as a structurally-anchored one — and the scopeless
+// ceiling stays below the namespace tier's even at a maximal margin.
+func TestDeriveRecallConfidenceScopelessWeakest(t *testing.T) {
+	points := []struct{ score, margin float64 }{
+		{8.0, 6.0}, // decisive winner
+		{6.0, 6.0}, // solo hit (margin == score)
+		{2.0, 0.4}, // marginal winner
+	}
+	for _, p := range points {
+		sl := deriveRecallConfidence(p.score, p.margin, matchScopeless)
+		ns := deriveRecallConfidence(p.score, p.margin, matchNamespace)
+		ex := deriveRecallConfidence(p.score, p.margin, matchExact)
+		if !(sl < ns && ns < ex) {
+			t.Errorf("at (%v, %v): want scopeless < namespace < exact, got %v, %v, %v", p.score, p.margin, sl, ns, ex)
+		}
+		if sl > 0.70 {
+			t.Errorf("at (%v, %v): scopeless confidence must be capped at 0.70, got %v", p.score, p.margin, sl)
+		}
 	}
 }
 

--- a/internal/source/pagerduty/pagerduty.go
+++ b/internal/source/pagerduty/pagerduty.go
@@ -73,7 +73,8 @@ type pdRef struct {
 // investigation Request; incident.resolved becomes a Resolution keyed by the
 // incident id (stable across the triggered↔resolved pair); every other event
 // type is ignored. PagerDuty carries no Kubernetes namespace/workload, so those
-// fields stay empty — recall and structural matching tolerate that.
+// fields stay empty — such workload-less requests can recall only entries that
+// are themselves resource-less (the scopeless tier; see investigate.resourceAgrees).
 func (Source) Decode(body []byte, _ http.Header) (source.DecodeResult, error) {
 	var p pdPayload
 	if err := json.Unmarshal(body, &p); err != nil {

--- a/internal/source/pagerduty/pagerduty_test.go
+++ b/internal/source/pagerduty/pagerduty_test.go
@@ -41,8 +41,9 @@ func TestDecodeTriggeredProducesRequest(t *testing.T) {
 	if r.Reason != "P1" {
 		t.Fatalf("want Reason=P1 (mirrors alertmanager Reason=severity), got %q", r.Reason)
 	}
-	// PagerDuty has no Kubernetes context: workload + environment stay empty and
-	// recall/structural matching tolerates that.
+	// PagerDuty has no Kubernetes context: workload + environment stay empty. Recall
+	// can still fire via the scopeless tier — but only against entries that are
+	// themselves resource-less (see investigate.resourceAgrees).
 	if r.Workload.Namespace != "" || r.Workload.Kind != "" || r.Workload.Name != "" {
 		t.Fatalf("want zero Workload, got %+v", r.Workload)
 	}


### PR DESCRIPTION
## Problem

Instant recall's structural pre-filter (`resourceAgrees`) required the request's workload and the entry's stored resource to *both be present and* agree. PagerDuty incidents carry **no Kubernetes namespace/name** (`internal/source/pagerduty` leaves the workload zero), so `resourceAgrees` returned `matchNone` for every candidate and **a PagerDuty incident could never recall — ever**, even against a hand-written runbook that is itself resource-less. Every lookup ended in `recall_rejections_total{reason="no_resource_match"}`.

### Doc-claim verdict

The claim "recall and structural matching tolerate an empty workload" **was wrong** before this PR: an empty workload yielded zero agreeing candidates and recall always rejected with `no_resource_match`. (Note: the claim lives in **`docs/configuration.md`'s PagerDuty section** — `docs/getting-started.md` has no PagerDuty section and never carried it. The same wrong claim also appeared in code comments in `internal/source/pagerduty/pagerduty.go` and its test.) All occurrences now state exactly what holds.

### Can entries be resource-less? (what recall can now hit)

- **Curated entries — yes.** `curator.draftKBEntry` stamps `Resource: inv.Resource.Ref()`; for a PagerDuty investigation where the model discovers no workload, `preferDiscoveredResource` falls back to the request's empty workload and `Ref()` is `""`. `curator.entryType` drafts such resource-agnostic findings as **Playbook** (when the top cause has a suggested action and no change ref).
- **Hand-written entries — yes.** The catalog loader treats the `resource` frontmatter as optional, and `kbvalidate` requires it **only for `Incident`** — `Playbook`/`Concept` entries legitimately omit it ("OKF leaves resource omitted for abstract concepts"). A resource-less *Incident* fails the `lore validate-kb` merge gate, so a validated KB's resource-less corpus is exactly the abstract runbook knowledge scopeless recall targets.

## Change

New weakest tier `matchScopeless` (below `matchNamespace`/`matchExact`): a request with **no workload at all** may agree **only** with entries whose stored resource is also empty.

### Invariants (each pinned by a test)

1. **No loosening of scoped matching, in any direction** — a scoped request (even namespace-only) never matches a resource-less entry, and a scopeless request never matches an entry with any stored resource (`TestScopelessNeverLoosensScopedMatching`, extended `TestResourceAgrees` table). A request with a name but no namespace is treated as scoped, not scopeless (conservative).
2. **Scopeless must clear `solo_floor` AND `min_score` regardless of how many candidates agree** — the margin gate alone is too weak with zero structural evidence (`TestLookupScopeless`).
3. **Weakest confidence** — `deriveRecallConfidence` starts a scopeless match lower and caps it at **0.70**, strictly below the namespace and exact tiers at any (score, margin) (`TestDeriveRecallConfidenceScopelessWeakest`).
4. **Strict stays strict** — `require_workload_match: true` disables scopeless matching entirely (`TestResourceAgrees`, `TestLookupScopeless` strict case).

## Docs

- `docs/configuration.md`: fixed the wrong PagerDuty claim; one-sentence addition to the `instant_recall` paragraph.
- `docs/learning-loop.md`: Gate 1 now describes the scopeless tier.
- `internal/source/pagerduty`: comments aligned with the real behavior.

## Verification

`go build` / `go vet` / `gofmt` clean, `go test ./...` green (incl. the offline recall eval tests in `internal/eval`), `golangci-lint run` = 0 issues (after `cache clean`).