### PR TITLE
feat(triggers): cancel queued investigations when the incident resolves first

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,14 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   `KubeDaemonSetRolloutStuck` during a Karpenter node-churn cycle). **Default `0`** (investigate
   immediately — today's behavior); opt-in per deployment. Composes with `coalesce` (survivors are
   batched afterwards) and `dedup` (re-fires are still suppressed before the hold begins).
+- `incidents.cancel_queued_on_resolve` — when the matching Alertmanager `resolved` webhook arrives
+  while the investigation is still **queued** (accepted, not yet started), drop it. Extends `debounce`
+  past the hold window: without it, a fire→resolve sequence whose firing already passed admission still
+  burns a full paid investigation. **Default `false`** (opt-in) — some teams want the post-hoc answer
+  to "why did it fire?" even after self-resolution. Boundaries: an **in-flight** investigation is never
+  cancelled (it completes and delivers), and a **coalesced multi-alert batch** is not cancelled on one
+  member's resolve (partial resolution is ambiguous — the rest may still be firing). Cancellations
+  count in `runlore_investigations_cancelled_total`.
 - `gitops_failures.debounce` — require a failure to persist this long before investigating. **Default
   60s**; explicit `0` fires immediately on every `Ready=False`.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -57,6 +57,7 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_investigation_duration_seconds` | histogram | `result` | wall-clock per investigation |
 | `runlore_investigations_throttled_total` | counter | — | starts requeued by the rate limiter |
 | `runlore_investigations_dropped_total` | counter | — | dropped (rate-limiter max-requeues or token-budget kill) |
+| `runlore_investigations_cancelled_total` | counter | — | queued (not yet started) investigations cancelled because the incident resolved first (`triggers.incidents.cancel_queued_on_resolve`) |
 
 ### Tools & model
 | Metric | Type | Labels | Meaning |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -59,6 +59,7 @@ msg=incident alert=<name> severity=<sev> namespace=<ns> investigate=<bool> reaso
 | `runlore_alerts_coalesced_total` rising | folded into an existing batch (`investigation.coalesce`) | expected noise control — one investigation covers the batch |
 | `runlore_alerts_suppressed_total` rising | dropped by the coalescer **cooldown** | expected — a recently-investigated correlation is in cooldown |
 | `runlore_incidents_debounced_total` rising | the alert self-resolved within `triggers.incidents.debounce` and was dropped before investigating; log: `msg="alert resolved within debounce window; dropping self-resolving incident"` | expected noise control — lower `incidents.debounce` if you want faster (but noisier) reactions, or set `0` to disable |
+| `runlore_investigations_cancelled_total` rising | the alert resolved while its investigation was still queued and `triggers.incidents.cancel_queued_on_resolve` dropped it; log: `msg="incident resolved before investigation started; cancelling queued investigation"` | expected noise control — disable the flag if you want post-hoc investigations of self-resolved alerts |
 
 ---
 

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -259,10 +259,18 @@ func RunServe(version string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("build sources: %w", err)
 	}
-	pipe := source.NewPipeline(cfg, alertEnq, resolve, log).WithMetrics(metrics).WithContext(workCtx)
+	// The queue (not alertEnq, which may be the coalescer) is wired as the
+	// pipeline's Canceller; the pipeline only calls it when
+	// triggers.incidents.cancel_queued_on_resolve is on.
+	pipe := source.NewPipeline(cfg, alertEnq, resolve, log).
+		WithMetrics(metrics).WithContext(workCtx).WithCanceller(queue)
 	if w := cfg.Triggers.Incidents.Debounce.Std(); w > 0 {
 		log.Info("incident debounce enabled",
 			"window", w, "note", "firing alerts held; dropped if resolved within the window")
+	}
+	if cfg.Triggers.Incidents.CancelQueuedOnResolve {
+		log.Info("cancel queued on resolve enabled",
+			"note", "queued (not yet started) investigations are dropped when the alert resolves first")
 	}
 
 	// startWork runs the leader-only loops (investigation queue + failure watch +

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -478,6 +478,17 @@ type IncidentTrigger struct {
 	// survivors afterwards) and `dedup` (which still suppresses re-fires before the
 	// hold begins).
 	Debounce Duration `yaml:"debounce"`
+	// CancelQueuedOnResolve drops a QUEUED — accepted but not yet started —
+	// investigation when the matching Alertmanager `resolved` webhook arrives
+	// first. It extends Debounce past the hold window: without it, a fire→resolve
+	// sequence whose firing already passed into the investigation queue still burns
+	// a full paid investigation. Opt-in (default false, preserving today's
+	// behavior) because some teams deliberately want the post-hoc answer to "why
+	// did it fire?" even after self-resolution — mirroring Debounce being opt-in.
+	// Boundaries: an IN-FLIGHT investigation is never cancelled, and a coalesced
+	// multi-alert batch is not cancelled on one member's resolve (see
+	// investigate.Queue.CancelByFingerprint).
+	CancelQueuedOnResolve bool `yaml:"cancel_queued_on_resolve"`
 }
 
 // IncidentMatch is a set of matchers ANDed together; empty fields match anything.

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -164,3 +164,32 @@ triggers:
 		t.Fatalf("explicit debounce:0 should fire immediately, got %v", c.Triggers.GitOpsFailures.DebounceWindow())
 	}
 }
+
+// TestLoadCancelQueuedOnResolve pins the yaml key spelling and the opt-in default:
+// unset ⇒ false (behavior preservation — some teams want the post-hoc investigation
+// of a self-resolved alert), explicit true parses.
+func TestLoadCancelQueuedOnResolve(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "runlore.yaml")
+	doc := `
+sources:
+  alertmanager: {}
+triggers:
+  incidents:
+    cancel_queued_on_resolve: true
+`
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !c.Triggers.Incidents.CancelQueuedOnResolve {
+		t.Fatal("explicit cancel_queued_on_resolve: true should parse")
+	}
+	// Default: off.
+	if (&Config{}).Triggers.Incidents.CancelQueuedOnResolve {
+		t.Fatal("cancel_queued_on_resolve must default to false")
+	}
+}

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -141,9 +141,21 @@ type Queue struct {
 	mu   sync.Mutex
 	wq   workqueue.TypedRateLimitingInterface[key] // current term's queue; nil between terms
 	reqs map[key]pending
-	seq  uint64
-	inv  Investigator
-	log  *slog.Logger
+	// byFP indexes pending SINGLE-fingerprint requests by their sole alert
+	// fingerprint so a resolved webhook can cancel a queued investigation
+	// (CancelByFingerprint) without scanning reqs. Multi-fingerprint batches are
+	// deliberately never indexed (see cancellableFingerprint). Maintained by
+	// Enqueue and by every delete of a reqs entry — all under mu — so an index
+	// entry can never outlive its payload.
+	byFP map[string]key
+	// inflight marks keys whose Investigate is currently running, so
+	// CancelByFingerprint never cancels an IN-FLIGHT investigation: process()
+	// has already copied the payload out of reqs and the model loop is burning
+	// spend that aborting cannot recover — let it complete and deliver.
+	inflight map[key]struct{}
+	seq      uint64
+	inv      Investigator
+	log      *slog.Logger
 
 	// Rate limiting: nil starts = unlimited; 0 maxRequeues = drop immediately on throttle.
 	starts      *ratelimit.Window  // sliding-window start budget; nil = unlimited
@@ -154,7 +166,7 @@ type Queue struct {
 
 // NewQueue builds an investigation queue. The workqueue itself is created per Run.
 func NewQueue(inv Investigator, log *slog.Logger) *Queue {
-	return &Queue{reqs: map[key]pending{}, inv: inv, log: log}
+	return &Queue{reqs: map[key]pending{}, byFP: map[string]key{}, inflight: map[key]struct{}{}, inv: inv, log: log}
 }
 
 // Enqueue submits a request. Re-enqueuing the same key before it is processed
@@ -164,12 +176,97 @@ func (q *Queue) Enqueue(r Request) {
 	k := keyOf(r)
 	q.mu.Lock()
 	q.seq++
+	// Keep the cancel index pointing at the LATEST payload: drop the entry of the
+	// payload being coalesced over, then index the new one when it qualifies.
+	if prev, ok := q.reqs[k]; ok {
+		q.unindexLocked(prev.req, k)
+	}
 	q.reqs[k] = pending{req: r, seq: q.seq}
+	if fp, ok := cancellableFingerprint(r); ok {
+		q.byFP[fp] = k
+	}
 	wq := q.wq
 	q.mu.Unlock()
 	if wq != nil {
 		wq.Add(k)
 	}
+}
+
+// cancellableFingerprint returns the fingerprint under which r may be cancelled
+// on resolve, if any. Only a SINGLE-fingerprint request qualifies: a coalesced
+// multi-alert batch (len(Fingerprints) > 1) is never cancelled on one member's
+// resolve — one alert resolving says nothing about the rest of the batch, and
+// partial resolution is ambiguous — so the batch investigation always proceeds.
+func cancellableFingerprint(r Request) (string, bool) {
+	if r.Fingerprint == "" || len(r.Fingerprints) > 1 {
+		return "", false
+	}
+	return r.Fingerprint, true
+}
+
+// unindexLocked drops r's cancel-index entry if it still points at k. The value
+// check keeps a (theoretical) same-fingerprint-different-key overwrite from
+// clobbering the newer entry. Callers must hold q.mu.
+func (q *Queue) unindexLocked(r Request, k key) {
+	fp, ok := cancellableFingerprint(r)
+	if !ok {
+		return
+	}
+	if cur, ok := q.byFP[fp]; ok && cur == k {
+		delete(q.byFP, fp)
+	}
+}
+
+// removeLocked deletes k's payload and its cancel-index entry together, so the
+// index can never point at a request that no longer exists. Callers must hold q.mu.
+func (q *Queue) removeLocked(k key, r Request) {
+	q.unindexLocked(r, k)
+	delete(q.reqs, k)
+}
+
+// CancelByFingerprint drops a QUEUED — accepted but not yet started —
+// investigation whose sole alert fingerprint matches, and reports whether one was
+// cancelled. It is called from the pipeline's resolved-webhook path when
+// triggers.incidents.cancel_queued_on_resolve is enabled, extending the debounce
+// idea past the hold window: without it, a fire→resolve sequence whose firing
+// already passed into the queue still burns a full paid investigation.
+//
+// Deliberate boundaries:
+//   - Only pending SINGLE-fingerprint requests cancel (see cancellableFingerprint);
+//     a coalesced multi-alert batch survives one member's resolve.
+//   - An IN-FLIGHT investigation is never cancelled (see the inflight field): it
+//     completes and delivers as usual.
+//
+// Cancellation is just the payload delete: the already-queued workqueue item for k
+// stays queued and no-ops when it surfaces — process() reads q.reqs[k] first and
+// its `if !ok { Forget; return }` guard already tolerates a missing key.
+func (q *Queue) CancelByFingerprint(fp string) bool {
+	if fp == "" {
+		return false
+	}
+	q.mu.Lock()
+	k, ok := q.byFP[fp]
+	if !ok {
+		q.mu.Unlock()
+		return false
+	}
+	if _, busy := q.inflight[k]; busy {
+		q.mu.Unlock()
+		return false
+	}
+	p, ok := q.reqs[k]
+	if !ok {
+		// Defensive: index and payload map change under the same mutex, so a dangling
+		// entry should be impossible — drop it rather than "cancel" nothing.
+		delete(q.byFP, fp)
+		q.mu.Unlock()
+		return false
+	}
+	q.removeLocked(k, p.req)
+	q.mu.Unlock()
+	q.log.Info("incident resolved before investigation started; cancelling queued investigation",
+		"fingerprint", fp, "title", p.req.Title)
+	return true
 }
 
 // Run builds a fresh workqueue for this leadership term, replays any pending
@@ -231,11 +328,25 @@ func (q *Queue) process(ctx context.Context, wq workqueue.TypedRateLimitingInter
 	defer wq.Done(k)
 	q.mu.Lock()
 	p, ok := q.reqs[k]
+	if ok {
+		// Shield the payload from CancelByFingerprint for the whole of process():
+		// from here the copy in p is what runs, so a concurrent resolve must not
+		// delete the map entry out from under the compare-and-delete below.
+		q.inflight[k] = struct{}{}
+	}
 	q.mu.Unlock()
 	if !ok {
+		// No payload: the request was cancelled (CancelByFingerprint) or already
+		// completed. The stale workqueue item no-ops here — cancellation relies on
+		// exactly this guard.
 		wq.Forget(k)
 		return
 	}
+	defer func() {
+		q.mu.Lock()
+		delete(q.inflight, k)
+		q.mu.Unlock()
+	}()
 	// Rate-limit gate: if the sliding-window budget is exhausted, either back off
 	// (requeue with exponential delay) or drop after max_requeues retries.
 	if q.starts != nil && !q.starts.Allow() {
@@ -246,7 +357,11 @@ func (q *Queue) process(ctx context.Context, wq workqueue.TypedRateLimitingInter
 			q.log.Warn("investigation budget exhausted; dropping (Alertmanager will re-fire)", "title", p.req.Title)
 			wq.Forget(k)
 			q.mu.Lock()
-			delete(q.reqs, k)
+			// Re-read the current payload so the cancel-index entry of whatever is
+			// stored NOW (possibly a superseding re-fire) is removed with it.
+			if cur, ok := q.reqs[k]; ok {
+				q.removeLocked(k, cur.req)
+			}
 			q.mu.Unlock()
 			q.maybeNotifyThrottle()
 			return
@@ -273,7 +388,11 @@ func (q *Queue) process(ctx context.Context, wq workqueue.TypedRateLimitingInter
 			q.log.Error("investigation failed permanently; dropping", "title", p.req.Title, "err", err)
 			wq.Forget(k)
 			q.mu.Lock()
-			delete(q.reqs, k)
+			// Same index hygiene as the budget drop above: remove whatever payload is
+			// stored now together with its cancel-index entry.
+			if cur, ok := q.reqs[k]; ok {
+				q.removeLocked(k, cur.req)
+			}
 			q.mu.Unlock()
 			return
 		}
@@ -284,9 +403,11 @@ func (q *Queue) process(ctx context.Context, wq workqueue.TypedRateLimitingInter
 	wq.Forget(k)
 	// Compare-and-delete: only drop the payload if it hasn't been superseded by a
 	// re-fired trigger while we were investigating (else the fresh trigger is lost).
+	// The cancel-index entry goes with it, so a later resolve of this fingerprint
+	// cancels nothing and a later same-key alert re-enqueues cleanly.
 	q.mu.Lock()
 	if cur, ok := q.reqs[k]; ok && cur.seq == p.seq {
-		delete(q.reqs, k)
+		q.removeLocked(k, cur.req)
 	}
 	q.mu.Unlock()
 }

--- a/internal/investigate/queue_cancel_test.go
+++ b/internal/investigate/queue_cancel_test.go
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// singleFPRequest mirrors what the Alertmanager decoder (and a coalesced batch of
+// one) produces: Fingerprint set and Fingerprints holding exactly that entry.
+func singleFPRequest(title, fp string) Request {
+	return Request{Source: SourceAlert, Title: title, Fingerprint: fp, Fingerprints: []string{fp}}
+}
+
+// TestQueueCancelPendingByFingerprint pins the core semantics: a QUEUED (not yet
+// started) single-fingerprint request is cancelled on its resolve — the payload is
+// gone, the stale workqueue item no-ops in process, and a later firing of the same
+// alert (same key) still investigates normally.
+func TestQueueCancelPendingByFingerprint(t *testing.T) {
+	inv := &countingInv{}
+	q := NewQueue(inv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[key]())
+	t.Cleanup(func() { wq.ShutDown() })
+
+	r := singleFPRequest("A", "f1")
+	q.Enqueue(r)
+	wq.Add(keyOf(r)) // the workqueue item exists before the resolve arrives
+
+	if !q.CancelByFingerprint("f1") {
+		t.Fatal("want pending single-fingerprint request cancelled")
+	}
+	// The stale workqueue item must no-op: process tolerates the missing payload.
+	k, _ := wq.Get()
+	q.process(context.Background(), wq, k)
+	if inv.n != 0 {
+		t.Fatalf("cancelled investigation must never run; got %d Investigate call(s)", inv.n)
+	}
+	// The fingerprint index entry is gone with the payload: a second resolve is a no-op.
+	if q.CancelByFingerprint("f1") {
+		t.Fatal("second cancel of the same fingerprint must report false")
+	}
+	// A later firing of the same alert (same key) still investigates.
+	q.Enqueue(r)
+	drainWith(t, q, wq)
+	if inv.n != 1 {
+		t.Fatalf("re-fired alert after a cancel must investigate; got %d", inv.n)
+	}
+}
+
+// blockingInv parks inside Investigate until released, so a test can observe the
+// queue with an investigation genuinely IN FLIGHT.
+type blockingInv struct {
+	started chan struct{}
+	release chan struct{}
+	mu      sync.Mutex
+	calls   int
+}
+
+func (b *blockingInv) Investigate(context.Context, Request) error {
+	b.mu.Lock()
+	b.calls++
+	b.mu.Unlock()
+	b.started <- struct{}{}
+	<-b.release
+	return nil
+}
+
+// TestQueueCancelInFlightRefused pins the in-flight boundary: once Investigate has
+// started, a resolve must NOT cancel it — the investigation runs to completion,
+// and afterwards there is nothing left to cancel (index cleaned on completion).
+func TestQueueCancelInFlightRefused(t *testing.T) {
+	inv := &blockingInv{started: make(chan struct{}, 1), release: make(chan struct{})}
+	q := NewQueue(inv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[key]())
+	t.Cleanup(func() { wq.ShutDown() })
+
+	q.Enqueue(singleFPRequest("A", "f1"))
+	wq.Add(keyOf(singleFPRequest("A", "f1")))
+	done := make(chan struct{})
+	go func() {
+		k, _ := wq.Get()
+		q.process(context.Background(), wq, k)
+		close(done)
+	}()
+
+	<-inv.started // Investigate is running now
+	if q.CancelByFingerprint("f1") {
+		t.Fatal("an in-flight investigation must never be cancelled")
+	}
+	close(inv.release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the in-flight investigation to finish")
+	}
+	inv.mu.Lock()
+	calls := inv.calls
+	inv.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("in-flight investigation must complete exactly once; got %d", calls)
+	}
+	// Completion cleaned both the payload and the fingerprint index.
+	if q.CancelByFingerprint("f1") {
+		t.Fatal("nothing must be cancellable after completion")
+	}
+}
+
+// TestQueueCancelMultiFingerprintBatchRefused pins the coalesced-batch boundary:
+// a batch carrying >1 fingerprints is never cancelled on one member's resolve —
+// partial resolution is ambiguous (the rest may still be firing), so the batch
+// investigation proceeds.
+func TestQueueCancelMultiFingerprintBatchRefused(t *testing.T) {
+	inv := &countingInv{}
+	q := NewQueue(inv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[key]())
+	t.Cleanup(func() { wq.ShutDown() })
+
+	q.Enqueue(Request{Source: SourceAlert, Title: "batch", Fingerprint: "f1", Fingerprints: []string{"f1", "f2"}})
+	if q.CancelByFingerprint("f1") {
+		t.Fatal("multi-fingerprint batch must not be cancelled via its representative fingerprint")
+	}
+	if q.CancelByFingerprint("f2") {
+		t.Fatal("multi-fingerprint batch must not be cancelled via a constituent fingerprint")
+	}
+	drainWith(t, q, wq)
+	if inv.n != 1 {
+		t.Fatalf("batch must investigate despite one member resolving; got %d", inv.n)
+	}
+}
+
+// TestQueueCancelIndexCleanedAfterCompletion pins index hygiene: after a normal
+// (uncancelled) completion the fingerprint index entry is removed alongside the
+// payload, and a later same-key alert enqueues and investigates as before.
+func TestQueueCancelIndexCleanedAfterCompletion(t *testing.T) {
+	inv := &countingInv{}
+	q := NewQueue(inv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[key]())
+	t.Cleanup(func() { wq.ShutDown() })
+
+	r := singleFPRequest("A", "f1")
+	q.Enqueue(r)
+	drainWith(t, q, wq)
+	if inv.n != 1 {
+		t.Fatalf("first firing must investigate; got %d", inv.n)
+	}
+	if q.CancelByFingerprint("f1") {
+		t.Fatal("a completed investigation must not be cancellable (index must be cleaned)")
+	}
+	// The same alert fires again later: same key, must investigate again.
+	q.Enqueue(r)
+	drainWith(t, q, wq)
+	if inv.n != 2 {
+		t.Fatalf("same-key alert after completion must investigate again; got %d", inv.n)
+	}
+}
+
+// TestQueueCancelEmptyOrUnknownFingerprint pins the no-op edges: an empty or
+// unknown fingerprint cancels nothing, and a fingerprint-less request is never
+// indexed (so it can never be cancelled).
+func TestQueueCancelEmptyOrUnknownFingerprint(t *testing.T) {
+	inv := &countingInv{}
+	q := NewQueue(inv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[key]())
+	t.Cleanup(func() { wq.ShutDown() })
+
+	q.Enqueue(Request{Source: SourceAlert, Title: "no-fp"})
+	if q.CancelByFingerprint("") {
+		t.Fatal("empty fingerprint must never cancel")
+	}
+	if q.CancelByFingerprint("unknown") {
+		t.Fatal("unknown fingerprint must never cancel")
+	}
+	drainWith(t, q, wq)
+	if inv.n != 1 {
+		t.Fatalf("fingerprint-less request must investigate; got %d", inv.n)
+	}
+}
+
+// TestQueueCancelCoalescedPayloadReindexed pins Enqueue's index maintenance: when
+// a re-fired trigger coalesces over a pending payload (same key, latest wins), the
+// index follows the LATEST payload — cancelling the new fingerprint works, and the
+// replaced payload's fingerprint no longer cancels anything.
+func TestQueueCancelCoalescedPayloadReindexed(t *testing.T) {
+	inv := &countingInv{}
+	q := NewQueue(inv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	wq := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[key]())
+	t.Cleanup(func() { wq.ShutDown() })
+
+	// Same key (same Source/Title, no workload), different fingerprints.
+	q.Enqueue(singleFPRequest("A", "f-old"))
+	q.Enqueue(singleFPRequest("A", "f-new"))
+	if q.CancelByFingerprint("f-old") {
+		t.Fatal("replaced payload's fingerprint must no longer cancel")
+	}
+	if !q.CancelByFingerprint("f-new") {
+		t.Fatal("latest payload's fingerprint must cancel the pending request")
+	}
+	wq.Add(keyOf(singleFPRequest("A", "f-new")))
+	k, _ := wq.Get()
+	q.process(context.Background(), wq, k)
+	if inv.n != 0 {
+		t.Fatalf("cancelled coalesced request must never run; got %d", inv.n)
+	}
+}

--- a/internal/source/pipeline.go
+++ b/internal/source/pipeline.go
@@ -18,6 +18,16 @@ import (
 // concrete episode type. A nil ResolveFunc disables resolved-alert handling.
 type ResolveFunc func(fingerprint string, at time.Time)
 
+// Canceller drops a QUEUED (not yet started) investigation whose sole alert
+// fingerprint matches, reporting whether one was cancelled. *investigate.Queue
+// implements it; serve wires the queue in explicitly (WithCanceller, mirroring
+// how resolve is wired) because the pipeline's own handle on the queue is an
+// Enqueuer — often the coalescer, and deliberately too narrow to cancel through.
+// A nil Canceller disables cancellation regardless of config.
+type Canceller interface {
+	CancelByFingerprint(fingerprint string) bool
+}
+
 // Pipeline admits inbound events from all source adapters, applies the
 // configured gate policy (MatchGated or EnableGated), deduplicates within the
 // configured window, and forwards survivors to the investigation enqueuer.
@@ -25,6 +35,7 @@ type Pipeline struct {
 	cfg      *config.Config
 	enq      investigate.Enqueuer
 	resolve  ResolveFunc
+	cancel   Canceller // optional; cancels queued investigations on resolve (opt-in via config)
 	dedup    *trigger.Deduper
 	debounce *incidentDebouncer
 	metrics  *telemetry.Metrics // optional; nil-safe ingress counters
@@ -68,6 +79,14 @@ func (p *Pipeline) WithMetrics(m *telemetry.Metrics) *Pipeline {
 	return p
 }
 
+// WithCanceller wires the investigation queue's cancel hook so the resolved path
+// can drop a QUEUED investigation when triggers.incidents.cancel_queued_on_resolve
+// is enabled. Chains off NewPipeline; a nil c leaves cancellation disabled.
+func (p *Pipeline) WithCanceller(c Canceller) *Pipeline {
+	p.cancel = c
+	return p
+}
+
 // Ingest admits each Request per the admission mode and invokes resolve for each
 // Resolution. Cascade-suppression and debounce for EnableGated sources are
 // applied at the watcher edge (see Task 6) during Phase 1.
@@ -76,6 +95,17 @@ func (p *Pipeline) Ingest(ctx context.Context, adm Admission, res DecodeResult) 
 		// Drop any firing alert still held in the debounce window: it self-resolved
 		// before its investigation began, so it never reaches the enqueuer.
 		p.debounce.Cancel(r.Fingerprint)
+		// Opt-in (triggers.incidents.cancel_queued_on_resolve): also drop a QUEUED
+		// investigation that already passed admission (and any debounce hold) but has
+		// not started — otherwise a fire→resolve sequence still burns a full paid
+		// investigation. In-flight investigations and coalesced multi-alert batches
+		// are never cancelled (see investigate.Queue.CancelByFingerprint, which also
+		// logs the cancelled incident's fingerprint + title).
+		if p.cancel != nil && p.cfg.Triggers.Incidents.CancelQueuedOnResolve {
+			if p.cancel.CancelByFingerprint(r.Fingerprint) && p.metrics != nil {
+				p.metrics.InvestigationsCancelled.Add(ctx, 1)
+			}
+		}
 		if p.resolve != nil {
 			p.resolve(r.Fingerprint, r.At)
 		}

--- a/internal/source/pipeline_test.go
+++ b/internal/source/pipeline_test.go
@@ -131,6 +131,74 @@ func TestPipelineDebounceCoexistsWithDedup(t *testing.T) {
 	}
 }
 
+// capCancel records CancelByFingerprint calls and returns a canned result.
+type capCancel struct {
+	fps []string
+	ret bool
+}
+
+func (c *capCancel) CancelByFingerprint(fp string) bool {
+	c.fps = append(c.fps, fp)
+	return c.ret
+}
+
+// TestPipelineCancelQueuedOnResolve pins the opt-in wiring: with
+// triggers.incidents.cancel_queued_on_resolve enabled, a resolved alert also
+// cancels its queued investigation — and the resolve itself still runs (the
+// outcome ledger must close regardless of cancellation).
+func TestPipelineCancelQueuedOnResolve(t *testing.T) {
+	c := matchAllCfg()
+	c.Triggers.Incidents.CancelQueuedOnResolve = true
+	can := &capCancel{ret: true}
+	var resolved []string
+	resolve := func(fp string, _ time.Time) { resolved = append(resolved, fp) }
+	p := NewPipeline(c, &capEnq{}, resolve, nil).WithCanceller(can)
+	p.Ingest(context.Background(), MatchGated, DecodeResult{
+		Resolved: []Resolution{{Fingerprint: "f9", At: time.Now()}},
+	})
+	if len(can.fps) != 1 || can.fps[0] != "f9" {
+		t.Fatalf("want queue cancel called with f9, got %+v", can.fps)
+	}
+	if len(resolved) != 1 || resolved[0] != "f9" {
+		t.Fatalf("resolve must still run after cancellation, got %+v", resolved)
+	}
+}
+
+// TestPipelineCancelQueuedDisabledByDefault pins behavior preservation: with the
+// flag off (the default) the resolved path never touches the queue, even when a
+// canceller is wired — bit-for-bit today's behavior.
+func TestPipelineCancelQueuedDisabledByDefault(t *testing.T) {
+	can := &capCancel{ret: true}
+	var resolved []string
+	resolve := func(fp string, _ time.Time) { resolved = append(resolved, fp) }
+	p := NewPipeline(matchAllCfg(), &capEnq{}, resolve, nil).WithCanceller(can)
+	p.Ingest(context.Background(), MatchGated, DecodeResult{
+		Resolved: []Resolution{{Fingerprint: "f9", At: time.Now()}},
+	})
+	if len(can.fps) != 0 {
+		t.Fatalf("opt-in off: the queue must never be touched, got %+v", can.fps)
+	}
+	if len(resolved) != 1 {
+		t.Fatalf("resolve must still run with the flag off, got %+v", resolved)
+	}
+}
+
+// TestPipelineCancelQueuedNilCancellerSafe pins nil-safety: the flag on with no
+// canceller wired must not panic, and the resolve still runs.
+func TestPipelineCancelQueuedNilCancellerSafe(t *testing.T) {
+	c := matchAllCfg()
+	c.Triggers.Incidents.CancelQueuedOnResolve = true
+	var resolved []string
+	resolve := func(fp string, _ time.Time) { resolved = append(resolved, fp) }
+	p := NewPipeline(c, &capEnq{}, resolve, nil) // no canceller
+	p.Ingest(context.Background(), MatchGated, DecodeResult{
+		Resolved: []Resolution{{Fingerprint: "f9", At: time.Now()}},
+	})
+	if len(resolved) != 1 {
+		t.Fatalf("resolve must run with no canceller wired, got %+v", resolved)
+	}
+}
+
 func TestPipelineRoutesResolvedToLedger(t *testing.T) {
 	enq := &capEnq{}
 	var resolved []string

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -24,6 +24,7 @@ type Metrics struct {
 	InvestigationsStarted     metric.Int64Counter
 	InvestigationsThrottled   metric.Int64Counter
 	InvestigationsDropped     metric.Int64Counter
+	InvestigationsCancelled   metric.Int64Counter // queued (not yet started) investigations cancelled because the incident resolved first (cancel_queued_on_resolve)
 	GitOpsFailuresDebounced   metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
 	IncidentsDebounced        metric.Int64Counter // firing alerts dropped as self-resolving (resolved within the incident debounce window)
 	ToolOutputTruncatedBytes  metric.Int64Counter
@@ -86,6 +87,7 @@ func NewMetrics() *Metrics {
 		InvestigationsStarted:     ctr("investigations_started_total", "investigations actually begun"),
 		InvestigationsThrottled:   ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
 		InvestigationsDropped:     ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
+		InvestigationsCancelled:   ctr("investigations_cancelled_total", "queued (not yet started) investigations cancelled: the incident resolved before its investigation began (triggers.incidents.cancel_queued_on_resolve)"),
 		GitOpsFailuresDebounced:   ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
 		IncidentsDebounced:        ctr("incidents_debounced_total", "firing alerts dropped as self-resolving: a matching resolved webhook arrived within the incident debounce window before investigating"),
 		ToolOutputTruncatedBytes:  ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),


### PR DESCRIPTION
## What

Opt-in `triggers.incidents.cancel_queued_on_resolve` (**default `false`**): when the matching Alertmanager `resolved` webhook arrives while the investigation is still **queued** — accepted but not yet started — drop it instead of running it.

## Why opt-in

Today a `resolved` webhook only cancels the optional pre-investigation **debounce** hold. A fire→resolve sequence whose firing already passed into the investigation queue still burns a full paid investigation. This flag extends the debounce idea past the hold window — but stays **off by default** because some teams deliberately want the post-hoc answer to *"why did it fire?"* even after self-resolution (mirroring `debounce` itself being opt-in). With the flag off, behavior is bit-for-bit unchanged (pinned by test).

## Cancellation semantics & boundaries

`Queue.CancelByFingerprint(fp) bool` maintains a fingerprint→key index updated in `Enqueue` and cleaned on every payload delete (completion, budget/permanent drops, cancellation):

- **Only pending single-fingerprint requests cancel.** A coalesced **multi-alert batch** (`len(Fingerprints) > 1`) is never cancelled on one member's resolve — partial resolution is ambiguous; the rest of the batch may still be firing.
- **An in-flight investigation is never cancelled.** Once `process()` has copied the payload the model loop is burning spend that aborting cannot recover; it completes and delivers as usual.
- Cancellation is just the payload delete under the queue mutex: the already-queued workqueue item no-ops when it surfaces (`process()`'s existing missing-key guard).
- After a cancel or completion the index entry is gone, so a later firing of the same alert (same key) enqueues and investigates normally.

## Wiring

- Explicit `Canceller` field on the source pipeline, wired in `serve` with the **queue** (not `alertEnq`, which may be the coalescer) — mirroring how `resolve` is wired.
- A cancelled investigation logs at Info with fingerprint + title, and counts in the new `runlore_investigations_cancelled_total` counter (documented in observability + troubleshooting tables).

## Tests

- Queue: pending cancelled / in-flight survives / multi-fingerprint batch survives / index cleaned after completion (later same-key alert still works) / empty+unknown fingerprint no-ops / coalesced-payload re-index. Race-detector clean.
- Pipeline: flag on ⇒ cancel called and resolve still runs; flag off ⇒ queue never touched; nil canceller safe.
- Config: yaml key parse + default-false pin.

Gate: `go build && go vet && gofmt && go test ./... && golangci-lint run` — 0 issues.