### PR TITLE
feat(investigate): guard action targets against unobserved resources (F2)

### DIFF
--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -69,6 +69,24 @@ structural, not configuration hygiene:
     approval token, an audit-log path, an authenticated webhook, a positive confidence threshold,
     and a positive rate cap.
 
+### Unobserved action targets never auto-execute
+
+The gate validates *op*, *kind*, and *namespace* — but the target **name** is model-authored, so a
+prompt-injected finding could steer an otherwise in-envelope action onto an arbitrary named
+resource. Each investigation therefore tracks the resources it confirmed **server-side**
+(`internal/investigate/observedresources.go`): the request's own workload (the alert/failure
+subject always counts), plus everything `what_changed`, `gitops_resource_status`, and `gitops_tree`
+actually read. An executable action whose target was never observed is handled per rung
+(`guardUnobservedTargets`):
+
+- **`auto`:** the executable op is **stripped** — the proposal is still delivered, but only as a
+  suggestion. A hallucinated or injected target cannot reach an unattended cluster write.
+- **`approve`/`suggest`:** the action stays executable but its description carries an explicit
+  *"target was never observed server-side"* warning into the approval queue and chat message. The
+  human approval is the gate; the observed set is a heuristic with false negatives (a legitimate
+  target the investigation never re-read), so under a human gate its verdict is advisory — it arms
+  the approver rather than silently starving the queue.
+
 ### Recall is disabled under auto
 
 The knowledge catalog is community-shaped markdown — **untrusted input**. Under `off`/`suggest`/

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -35,6 +35,10 @@ registry and **discards the model's own metadata**:
   config; an empty `allow.namespaces` permits nothing.
 - The gate is re-validated at **every** execution boundary (approval handling *and* auto), so a stale
   or tampered decision can't slip through (defense in depth).
+- The target **name** is corroborated against the resources the investigation actually observed
+  server-side (the triggering workload + everything the GitOps read tools returned). An unobserved
+  target **never auto-executes** (the action is downgraded to a suggestion); under `approve` it stays
+  in the queue but carries an explicit possible-injection warning for the human approver.
 - `auto` mode starts **paused** (kill-switch engaged, fail-closed) and is gated behind
   confidence/rate/blast limits. It exists but is **not recommended on real clusters**.
 

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -365,7 +365,7 @@ sleep 1
 # to re-suspend it with no human in the loop.
 kubectl patch kustomization broken-app -n apps --type=merge -p '{"spec":{"suspend":false}}' >/dev/null
 curl -s -o /dev/null -XPOST -H "Authorization: Bearer e2e-webhook" "localhost:$PORT/webhook/alertmanager" \
-  -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest1","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-1"}]}'
+  -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest1","severity":"critical","namespace":"apps","workload":"broken-app","workload_type":"Kustomization"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-1"}]}'
 sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "rung-3 auto enabled"            /tmp/runlore.log 'AUTO execution ENABLED'
@@ -373,11 +373,13 @@ check "auto-executed (no approval)"    /tmp/runlore.log 'auto-executed'
 SUSP=$(kubectl get kustomization broken-app -n apps -o jsonpath='{.spec.suspend}' 2>/dev/null || true)
 if [[ "$SUSP" == "true" ]]; then green "PASS: auto-execution suspended broken-app without human approval"; PASS=$((PASS+1))
 else red "FAIL: auto did not suspend broken-app (spec.suspend=$SUSP)"; FAIL=$((FAIL+1)); fi
-# (b) Kill-switch: pause, un-suspend, fire again, expect NO execution.
+# (b) Kill-switch: pause, un-suspend, fire again, expect NO execution. The alert
+# names the workload (like AutoTest1) so the action would be fully executable —
+# proving it is the kill-switch, not the F2 target guard, that blocks it.
 curl -s -o /dev/null -XPOST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/pause"
 kubectl patch kustomization broken-app -n apps --type=merge -p '{"spec":{"suspend":false}}' >/dev/null
 curl -s -o /dev/null -XPOST -H "Authorization: Bearer e2e-webhook" "localhost:$PORT/webhook/alertmanager" \
-  -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest2","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-2"}]}'
+  -d '{"alerts":[{"status":"firing","labels":{"alertname":"AutoTest2","severity":"critical","namespace":"apps","workload":"broken-app","workload_type":"Kustomization"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"auto-fp-2"}]}'
 sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 kill "$PF" 2>/dev/null || true; free_port "$PORT"

--- a/internal/investigate/gitops_status_tool.go
+++ b/internal/investigate/gitops_status_tool.go
@@ -52,6 +52,8 @@ func (t GitOpsStatusTool) Call(ctx context.Context, args string) (string, error)
 			"name; the object genuinely does not exist (likely the cascade root). If you expected it to " +
 			"exist, re-check the kind/name rather than concluding it was deleted.", nil
 	}
+	// F2: the inspector confirmed this resource exists server-side — record it observed.
+	recordObserved(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s  Ready=%s", id, emptyDash(rs.Ready))
 	if rs.Reason != "" {

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -45,9 +45,22 @@ func (t GitOpsTreeTool) Call(ctx context.Context, args string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// F2: every existing node in the tree is a server-confirmed resource — record them
+	// observed so an action may legitimately target the root failure or a dependency.
+	recordObservedTree(ctx, root)
 	var b strings.Builder
 	renderDepNode(&b, root, 0)
 	return b.String(), nil
+}
+
+// recordObservedTree records every existing (non-NotFound) node of a dependency tree.
+func recordObservedTree(ctx context.Context, n providers.DepNode) {
+	if !n.NotFound {
+		recordObserved(ctx, n.Workload)
+	}
+	for _, c := range n.Children {
+		recordObservedTree(ctx, c)
+	}
 }
 
 // renderDepNode renders a node and its children with indentation, flagging the

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -207,6 +207,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		ctx, cancel = context.WithTimeout(ctx, li.Timeout)
 		defer cancel()
 	}
+	// F2: track the resources this investigation confirms SERVER-SIDE — seeded with the
+	// originating workload (the alert/failure subject is always a legitimate action
+	// target), augmented by what_changed and the gitops inspector tools. reviewActions
+	// consults the set to guard executable targets (see guardUnobservedTargets).
+	ctx = WithObservedResources(ctx, req.Workload)
 	// Record wall-clock duration + a completion-result label at whichever exit we take.
 	start := time.Now()
 	result := "unresolved"
@@ -573,7 +578,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			if li.Verify {
 				inv = li.verifyFindings(ctx, req, inv, &verifyTotals)
 			}
-			inv.Actions = li.reviewActions(inv.Actions)
+			inv.Actions = li.reviewActions(ctx, inv.Actions)
 			setUsage(&inv)
 			li.recordUsageMetrics(ctx, inv.Usage)
 			// A submission produced only because the final-step nudge forced it is a
@@ -710,10 +715,16 @@ func (li *LoopInvestigator) runTool(ctx context.Context, byName map[string]Tool,
 // reviewActions filters the model's proposed actions through the policy. Disabled
 // (or mode off) → nothing surfaced (read-only). Otherwise envelope-compliant
 // actions are kept as suggestions (never executed); the rest are logged as withheld.
-func (li *LoopInvestigator) reviewActions(proposed []providers.Action) []providers.Action {
+func (li *LoopInvestigator) reviewActions(ctx context.Context, proposed []providers.Action) []providers.Action {
 	if li.Actions == nil || !li.Actions.Enabled() {
 		return nil
 	}
+	// F2: a target the model named but nothing corroborated server-side may be a
+	// hallucinated or prompt-injected resource. Under auto (no human gate) such an
+	// action is downgraded to a non-executable suggestion; under approve/suggest it
+	// stays executable but carries an explicit warning for the human reviewer — see
+	// guardUnobservedTargets for why the failure mode is per-rung.
+	proposed = guardUnobservedTargets(ctx, proposed, li.Actions.IsAuto(), li.Log)
 	kept, withheld := li.Actions.Review(proposed)
 	for _, w := range withheld {
 		li.Log.Info("action withheld (outside policy envelope)", "action", w)

--- a/internal/investigate/observedresources.go
+++ b/internal/investigate/observedresources.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// observedResources is the set of resources an investigation confirmed SERVER-SIDE:
+// the originating workload, the GitOps changes what_changed detected, and the
+// resources the gitops_resource_status / gitops_tree inspector tools actually read.
+// It backs F2 — an action targeting a resource the investigation never observed is
+// treated as possibly hallucinated/prompt-injected: never auto-executed, and flagged
+// for the human approver (see guardUnobservedTargets). Only server-sourced identities
+// go in here; validating against the model-supplied finding would be false security.
+//
+// Context-scoped (one per investigation) and concurrency-safe.
+type observedResources struct {
+	mu    sync.Mutex
+	byKey map[wkey]struct{}   // exact (namespace, name)
+	names map[string]struct{} // name-only (namespace-tolerant fallback)
+}
+
+type wkey struct{ ns, name string }
+
+type observedCtxKey struct{}
+
+// WithObservedResources derives a context carrying an observed-resource collector
+// seeded with the given workloads (typically the originating alert/failure workload
+// — the trigger's subject is by definition a legitimate thing to act on, so it
+// ALWAYS counts as observed even when no tool re-reads it). Read tools that confirm
+// resources server-side call recordObserved; reviewActions consults the set via
+// guardUnobservedTargets.
+func WithObservedResources(ctx context.Context, seed ...providers.Workload) context.Context {
+	o := &observedResources{byKey: map[wkey]struct{}{}, names: map[string]struct{}{}}
+	for _, w := range seed {
+		o.add(w)
+	}
+	return context.WithValue(ctx, observedCtxKey{}, o)
+}
+
+func observedFrom(ctx context.Context) *observedResources {
+	o, _ := ctx.Value(observedCtxKey{}).(*observedResources)
+	return o
+}
+
+func (o *observedResources) add(w providers.Workload) {
+	if w.Name == "" {
+		return
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.byKey[wkey{w.Namespace, w.Name}] = struct{}{}
+	o.names[w.Name] = struct{}{}
+}
+
+// matches reports whether target names a resource the investigation observed. It
+// prefers an exact (namespace, name) hit, then falls back to name-only: a GitOps
+// object's namespace varies by view (the object's own namespace vs the workload's),
+// and the action gate's namespace allowlist is the authoritative namespace check —
+// so observing a resource of this NAME server-side is sufficient corroboration.
+func (o *observedResources) matches(t providers.Workload) bool {
+	if t.Name == "" {
+		return false
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if t.Namespace != "" {
+		if _, ok := o.byKey[wkey{t.Namespace, t.Name}]; ok {
+			return true
+		}
+	}
+	_, ok := o.names[t.Name]
+	return ok
+}
+
+// recordObserved adds server-confirmed resources to the investigation's observed set.
+// A no-op when ctx carries no collector (e.g. unit tests / the recall path).
+func recordObserved(ctx context.Context, ws ...providers.Workload) {
+	if o := observedFrom(ctx); o != nil {
+		for _, w := range ws {
+			o.add(w)
+		}
+	}
+}
+
+// unobservedTargetWarning is prepended to an unobserved-target action's description
+// under a human-gated mode, so the flag travels with the action into the approval
+// queue, the Slack/Matrix message, and the audit trail.
+const unobservedTargetWarning = "[WARNING: target was never observed server-side during this investigation — possible hallucinated or injected resource; verify it exists and is the right one before approving]"
+
+// guardUnobservedTargets (F2) handles proposed actions whose target the
+// investigation never corroborated server-side (not the trigger's subject, and not
+// surfaced by what_changed / gitops_resource_status / gitops_tree). The failure
+// mode is deliberately per-rung:
+//
+//   - auto (no human in the loop): the executable Op is STRIPPED — the action
+//     degrades to a suggestion that is still delivered but can never execute
+//     unattended. Fail safe: a hallucinated/injected target must not reach the
+//     cluster on the strength of model output alone.
+//   - approve/suggest (a human gates every execution): the action stays executable
+//     but its description gains an explicit unobserved-target warning. Downgrading
+//     here would either starve the approval queue of legitimate remediations or —
+//     worse — queue non-executable entries a human can "approve" into an error
+//     (both regressions the earlier strict-downgrade attempts actually caused; see
+//     the PR). The observed set is a heuristic with false negatives — an incomplete
+//     investigation may propose a perfectly correct target it never re-read — so
+//     under a human gate its verdict is advisory: it arms the approver, it does not
+//     override them.
+//
+// The server-authoritative action gate still validates op, kind, and namespace at
+// review AND at the exec boundary; this guard closes the "which named resource"
+// residual ahead of it. Suggestions and target-less actions pass through untouched,
+// and the whole guard is a no-op when ctx carries no collector.
+func guardUnobservedTargets(ctx context.Context, actions []providers.Action, autoMode bool, log *slog.Logger) []providers.Action {
+	o := observedFrom(ctx)
+	if o == nil {
+		return actions
+	}
+	for i := range actions {
+		a := &actions[i]
+		if a.Op == "" || a.Target.Name == "" {
+			continue // already a suggestion, or no named target to validate
+		}
+		if o.matches(a.Target) {
+			continue
+		}
+		if autoMode {
+			if log != nil {
+				log.Warn("action target not observed during investigation; downgrading to a non-executable suggestion (possible prompt injection)",
+					"op", a.Op, "target", a.Target.Namespace+"/"+a.Target.Name)
+			}
+			a.Op = ""
+			a.Mutating = false
+			continue
+		}
+		if log != nil {
+			log.Warn("action target not observed during investigation; flagging for the human approver (possible prompt injection)",
+				"op", a.Op, "target", a.Target.Namespace+"/"+a.Target.Name)
+		}
+		a.Description = unobservedTargetWarning + " " + a.Description
+	}
+	return actions
+}

--- a/internal/investigate/observedresources_test.go
+++ b/internal/investigate/observedresources_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestObservedResourcesMatching(t *testing.T) {
+	ctx := WithObservedResources(context.Background(), providers.Workload{Namespace: "apps", Name: "web"})
+	// A Flux Kustomization object lives in flux-system but manages "apps" — recorded
+	// with its object namespace.
+	recordObserved(ctx, providers.Workload{Kind: "Kustomization", Namespace: "flux-system", Name: "broken-app"})
+	o := observedFrom(ctx)
+
+	cases := []struct {
+		name   string
+		target providers.Workload
+		want   bool
+	}{
+		{"exact ns+name", providers.Workload{Namespace: "apps", Name: "web"}, true},
+		// The KEY fix over the first narrow attempt: the model targets broken-app in
+		// "apps" (workload view) while it was observed in "flux-system" (object view)
+		// — the name fallback matches.
+		{"name fallback across namespaces", providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "broken-app"}, true},
+		{"name only (no ns)", providers.Workload{Name: "web"}, true},
+		{"unobserved name", providers.Workload{Namespace: "apps", Name: "evil"}, false},
+		{"empty name", providers.Workload{Namespace: "apps"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := o.matches(tc.target); got != tc.want {
+				t.Fatalf("matches(%+v) = %v, want %v", tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRequestWorkloadAlwaysObserved locks the rule that keeps the e2e/auto path
+// working: the investigation request's own workload (the alert/failure subject)
+// counts as observed purely by being the trigger — no tool has to re-read it — so an
+// action targeting it stays executable even under auto's strict downgrade.
+func TestRequestWorkloadAlwaysObserved(t *testing.T) {
+	// Exactly what Investigate does first thing: seed with req.Workload.
+	reqWorkload := providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "broken-app"}
+	ctx := WithObservedResources(context.Background(), reqWorkload)
+
+	actions := []providers.Action{
+		{Op: "suspend", Mutating: true, Description: "suspend the failing Kustomization", Target: reqWorkload},
+	}
+	out := guardUnobservedTargets(ctx, actions, true /* auto: the strictest mode */, nil)
+	if out[0].Op != "suspend" || !out[0].Mutating {
+		t.Fatalf("action targeting the request's own workload must stay executable, got %+v", out[0])
+	}
+	if strings.Contains(out[0].Description, "WARNING") {
+		t.Fatalf("action targeting the request's own workload must not be flagged, got %q", out[0].Description)
+	}
+}
+
+// TestGuardUnobservedTargetsAuto is the F2 core for rung 3 (no human in the loop): an
+// executable action on an observed target survives; one on an unobserved (possibly
+// injected) target is stripped of its Op so it can never auto-execute; an existing
+// suggestion is untouched.
+func TestGuardUnobservedTargetsAuto(t *testing.T) {
+	ctx := WithObservedResources(context.Background())
+	recordObserved(ctx, providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "broken-app"})
+
+	actions := []providers.Action{
+		{Op: "suspend", Mutating: true, Target: providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "broken-app"}}, // observed → keep
+		{Op: "suspend", Mutating: true, Target: providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "evil-app"}},   // NOT observed → downgrade
+		{Op: "", Target: providers.Workload{Namespace: "apps", Name: "note"}},                                                     // already a suggestion
+	}
+	out := guardUnobservedTargets(ctx, actions, true, nil)
+
+	if out[0].Op != "suspend" || !out[0].Mutating {
+		t.Fatalf("observed-target action should be unchanged, got %+v", out[0])
+	}
+	if out[1].Op != "" || out[1].Mutating {
+		t.Fatalf("unobserved-target action should be downgraded to a non-executable suggestion, got %+v", out[1])
+	}
+	if out[2].Op != "" || out[2].Target.Name != "note" {
+		t.Fatalf("existing suggestion should be untouched, got %+v", out[2])
+	}
+}
+
+// TestGuardUnobservedTargetsApprove locks the human-gated failure mode that prevents
+// the rung-2 e2e regression: under approve/suggest an unobserved target is NOT
+// downgraded — it stays executable (so it still registers for approval and an
+// approved execution still works) but its description carries the explicit
+// unobserved-target warning for the approver. Observed targets are never flagged.
+func TestGuardUnobservedTargetsApprove(t *testing.T) {
+	ctx := WithObservedResources(context.Background())
+	recordObserved(ctx, providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "broken-app"})
+
+	actions := []providers.Action{
+		{Op: "suspend", Mutating: true, Description: "suspend broken-app", Target: providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "broken-app"}},
+		{Op: "suspend", Mutating: true, Description: "suspend evil-app", Target: providers.Workload{Kind: "Kustomization", Namespace: "apps", Name: "evil-app"}},
+	}
+	out := guardUnobservedTargets(ctx, actions, false /* approve/suggest */, nil)
+
+	if out[0].Op != "suspend" || strings.Contains(out[0].Description, "WARNING") {
+		t.Fatalf("observed-target action should be unchanged, got %+v", out[0])
+	}
+	if out[1].Op != "suspend" || !out[1].Mutating {
+		t.Fatalf("under a human gate the unobserved-target action must stay executable, got %+v", out[1])
+	}
+	if !strings.HasPrefix(out[1].Description, unobservedTargetWarning) {
+		t.Fatalf("unobserved-target action should carry the approver warning, got %q", out[1].Description)
+	}
+}
+
+func TestGuardNoCollectorIsNoop(t *testing.T) {
+	actions := []providers.Action{{Op: "suspend", Mutating: true, Target: providers.Workload{Namespace: "apps", Name: "web"}}}
+	out := guardUnobservedTargets(context.Background(), actions, true, nil) // no collector in ctx
+	if out[0].Op != "suspend" {
+		t.Fatalf("without a collector the actions must be unchanged, got %+v", out[0])
+	}
+}

--- a/internal/investigate/whatchanged_tool.go
+++ b/internal/investigate/whatchanged_tool.go
@@ -55,6 +55,10 @@ func (t WhatChangedTool) Call(ctx context.Context, args string) (string, error) 
 	defer done()
 	var b strings.Builder
 	for _, c := range changes {
+		// F2: these workloads were DETECTED server-side (Flux/Argo + git) — record them
+		// as observed so an action may legitimately target them.
+		recordObserved(ctx, c.Workload)
+		recordObserved(ctx, c.BlastRadius...)
 		fmt.Fprintf(&b, "%s %s/%s (%s): %s..%s", c.Engine, c.Workload.Kind, c.Workload.Name, c.Type, c.FromRev, c.ToRev)
 		// When the engine knows WHEN the change landed, say so — "deploy at 14:02,
 		// first crash at 14:03" is the core change↔symptom correlation.


### PR DESCRIPTION
Closes the F2 residual: the action gate validates op/kind/namespace server-side, but the target **name** is model-authored — a prompt-injected finding could steer an otherwise in-envelope (reversible, allowed-namespace) action onto an arbitrary named resource. Third attempt; the design change below is what makes it safe to land where the previous two were not.

## Why the previous attempts regressed the rung-2 (approve-mode) e2e

Both prior attempts applied a single failure mode — *unobserved target ⇒ strip the executable op* — to every rung. On the e2e that is structurally fatal, for two independent reasons:

1. **The e2e's approve-mode investigations can never observe the mock's target.** The scripted mock model always proposes `suspend Kustomization/broken-app` (ns `apps`), but it only drives `what_changed` / `kb_search` / `query_metrics` / `query_logs` / `network_drops` — never `gitops_resource_status` or `gitops_tree`. The step-7 incident (`HarborProbeFailure`) and the step-8 storm alerts carry **no `workload`/`pod` label**, so the request-workload seed is empty; and at those steps `broken-app` **does not exist in the cluster yet** (it is created in step 9), so `what_changed` surfaces nothing. Observed set = ∅ ⇒ every proposed action was downgraded.
2. **A downgraded action either starves or poisons the approval queue.** The app layer registers every envelope-kept action for approval — including `Op:""` suggestions. So the strict downgrade either (a) left too few executable entries pending (the rung-2 script approves **two** ids — token endpoint + signed Slack interaction — fed by the storm + gitops-failure investigations; with storm actions downgraded only one remained, and the Slack-approval check failed), or (b) queued a non-executable `Op:""` entry that the script's *first-pending-id* approval hit, sending `Op:""` to the executor → `unsupported op ""` → `broken-app` never suspended (flaky by map-iteration order). Either way rung-2 checks failed.

The root design error: applying auto-grade blocking to a rung that already has a human gate, on the strength of a heuristic (the observed set) that provably has false negatives.

## The design change that prevents the regression

`internal/investigate/observedresources.go` — a context-scoped, per-investigation set of resources confirmed **server-side**:

- **The request's own workload always counts as observed** (seeded in `Investigate` before anything runs): the alert/failure subject is by definition a legitimate thing to act on, even when no tool re-reads it.
- Every read tool that confirms a resource server-side registers it: `what_changed` (detected changes + blast radius), `gitops_resource_status` (the inspected resource), `gitops_tree` (every existing node).
- Matching is name-tolerant (exact `(namespace, name)`, else name-only) — a GitOps object's namespace varies by view, and the gate's namespace allowlist remains the authoritative ns check.

**Failure mode is per-rung** (`guardUnobservedTargets`), which is the actual fix:

- **auto (rung 3, no human): downgrade.** An unobserved target has its op stripped — still delivered, but only as a suggestion. A hallucinated/injected target can never reach an unattended cluster write. Blocking is correct here and the e2e's auto path **provably observes its target**: the rung-3 alerts name the failing workload (`workload`/`workload_type` labels), so the seed covers it.
- **approve/suggest (rungs 1–2, human-gated): warn, don't block.** The action stays executable and registers for approval as before, but its description carries an explicit *"target was never observed server-side during this investigation — possible hallucinated or injected resource"* warning into the approval queue, chat message, and audit trail. The human approval **is** the gate; the guard's job is to arm the approver, not to override them with a false-negative-prone heuristic.

Rung-2 therefore *cannot* regress from this validation: in approve mode, registration and approved execution are byte-for-byte the pre-F2 flow — only the description changes. The op/kind/namespace envelope is still enforced at review **and** re-validated at both execution boundaries, unchanged.

## e2e adjustments

- `AutoTest1` (rung-3 execute) names the failing workload — carried over from the parked branch: a realistic critical alert identifies its subject, and it exercises the guard's *allow* path.
- `AutoTest2` (kill-switch) now names it too, so that scenario proves the **kill-switch** blocks an otherwise fully-executable action — not the target guard masking it.

## Tests

- `TestObservedResourcesMatching` — exact, cross-namespace name fallback, miss, empty-name.
- `TestRequestWorkloadAlwaysObserved` — the seed rule under the strictest (auto) mode.
- `TestGuardUnobservedTargetsAuto` — downgrade path: unobserved op stripped; observed and pre-existing suggestions untouched.
- `TestGuardUnobservedTargetsApprove` — human-gated path: unobserved stays executable + warning prefix; observed never flagged.
- `TestGuardNoCollectorIsNoop` — no collector in ctx ⇒ behaviour unchanged.

Docs: `security-model.md` + `security-architecture.md` gain the observed-target guard section.

## Merge gate

`go build` / `go vet` / `gofmt` / `go test ./...` (46 pkgs) / `golangci-lint run` (0 issues) all pass locally. **The k3d e2e must pass before merge** — apply the `run-e2e` label (or let the nightly run) and verify the rung-2 approval checks and rung-3 auto checks in particular, since this PR exists because two predecessors failed exactly there.
