### PR TITLE
feat(release): image-level provenance and SBOM attestations

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -42,8 +42,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Set up Docker Buildx
-        # Required for the goreleaser `dockers` entries (use: buildx) and their
-        # buildx-native --provenance / --sbom attestations.
+        # Required for the goreleaser `dockers_v2` step: it creates a docker-container
+        # builder, which supports pushing a multi-platform index with the buildx-native
+        # --provenance / --sbom (--attest=type=sbom) attestations attached.
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Container Registry

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,8 +23,8 @@ builds:
       - amd64
       - arm64
     # Stamps the version into the binary (`-X main.version`, see cmd/lore/main.go).
-    # This same binary is what the dockers step COPYs into the image, so the archive
-    # and the image always report an identical version.
+    # This same binary is what the dockers_v2 step COPYs into the image, so the
+    # archive and the image always report an identical version.
     ldflags:
       - -s -w -X main.version={{.Version}}
 
@@ -71,81 +71,63 @@ signs:
     signature: "${artifact}.bundle"
     output: true
 
-# Multi-arch container image. One `dockers` entry per architecture builds a
-# single-platform image from the prebuilt `lore` binary (no in-image compile —
-# Dockerfile.goreleaser is COPY-only), tagged with an arch suffix. `docker_manifests`
-# then fuses the two into the user-facing multi-arch tags. ghcr/OCI refs MUST be
-# lowercase, so the owner is written `smana` (the GitHub repo is github.com/Smana).
-dockers:
-  - id: lore-amd64
-    use: buildx
-    goos: linux
-    goarch: amd64
+# Multi-arch container image (dockers_v2, needs GoReleaser >= v2.12 — the release
+# workflow installs `~> v2`, so it always has it). A single `docker buildx build
+# --push` produces the multi-platform index directly — no per-arch tags, no
+# docker_manifests fuse step — from the prebuilt `lore` binaries (no in-image
+# compile — Dockerfile.goreleaser is COPY-only; dockers_v2 lays the binaries out
+# under $TARGETPLATFORM/ in the build context). Because the release build pushes
+# instead of loading into the local docker image store, buildx can attach
+# image-level attestations (the classic `dockers` + --load flow could not:
+# "docker exporter does not currently support exporting manifest lists" — the
+# v0.1.0-era failure). ghcr/OCI refs MUST be lowercase, so the owner is written
+# `smana` (the GitHub repo is github.com/Smana).
+dockers_v2:
+  - id: lore
     ids:
       - lore
     dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      # NOTE: buildx --provenance / --sbom attestations are intentionally NOT set here.
-      # The classic `dockers` step loads each per-arch image into the local docker image
-      # store (the "docker" exporter), which cannot represent the OCI index that buildx
-      # emits when attestations are attached — the build fails with:
-      #   "docker exporter does not currently support exporting manifest lists".
-      # Restoring image-level SLSA provenance + SBOM needs the push-based `dockers_v2`
-      # flow (tracked as a follow-up). cosign still signs the fused manifest lists
-      # (docker_signs) and syft still generates the per-binary archive SBOMs.
-      - "--label=org.opencontainers.image.source=https://github.com/Smana/runlore"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
-  - id: lore-arm64
-    use: buildx
-    goos: linux
-    goarch: arm64
-    ids:
-      - lore
-    dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      # Attestations omitted for the same reason as the amd64 entry above (classic
-      # dockers + local load cannot export an attestation manifest list).
-      - "--label=org.opencontainers.image.source=https://github.com/Smana/runlore"
-      - "--label=org.opencontainers.image.version={{ .Version }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
+    images:
+      - "ghcr.io/smana/runlore"
+    tags:
+      - "{{ .Version }}"
+      - "{{ .Major }}.{{ .Minor }}"
+      - "latest"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    # SBOM attestation (BuildKit-generated, --attest=type=sbom) attached to the
+    # pushed index. This is dockers_v2's default; kept explicit so it can't silently
+    # regress. GoReleaser only passes it on pushed builds, never on snapshots.
+    sbom: true
+    flags:
+      # SLSA provenance attestation (mode=max records the full build parameters —
+      # safe here: the Dockerfile is COPY-only, no secrets in build args). Pushed
+      # builds only: snapshot builds --load per-platform images into the local
+      # docker image store, whose exporter cannot represent the attestation
+      # manifest list, so the template renders empty there and GoReleaser prunes
+      # empty flags.
+      - "{{ if not .IsSnapshot }}--provenance=mode=max{{ end }}"
+    labels:
+      "org.opencontainers.image.source": "https://github.com/Smana/runlore"
+      "org.opencontainers.image.version": "{{ .Version }}"
+      "org.opencontainers.image.revision": "{{ .FullCommit }}"
+      "org.opencontainers.image.created": "{{ .Date }}"
 
-# Fuse the two per-arch images into the final multi-arch tags. Each manifest list
-# references the arch-suffixed images built above.
-docker_manifests:
-  - name_template: "ghcr.io/smana/runlore:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
-      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/smana/runlore:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
-      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/smana/runlore:latest"
-    image_templates:
-      - "ghcr.io/smana/runlore:{{ .Version }}-amd64"
-      - "ghcr.io/smana/runlore:{{ .Version }}-arm64"
-
-# Keyless (Sigstore) cosign signing of the multi-arch manifest lists, by digest.
-# Runs under the job's id-token: write, so cosign gets a short-lived Fulcio cert
-# from the OIDC token and records the signature in Rekor — no long-lived keys.
-# `artifacts: manifests` signs the manifest list (not each per-arch image); cosign's
-# recursive verification still covers the referenced per-arch images.
+# Keyless (Sigstore) cosign signing of the pushed multi-arch image, pinned by digest
+# (${digest} is the index digest buildx reports; signing by digest instead of by tag
+# closes the tag-mutation race). Runs under the job's id-token: write, so cosign gets
+# a short-lived Fulcio cert from the OIDC token and records the signature in Rekor —
+# no long-lived keys. `artifacts: images` matches the dockers_v2 image refs (one per
+# tag; all three tags resolve to the same index digest); cosign's recursive
+# verification still covers the referenced per-arch images.
 docker_signs:
-  - artifacts: manifests
+  - artifacts: images
     cmd: cosign
     args:
       - "sign"
       - "--yes"
-      - "${artifact}"
+      - "${artifact}@${digest}"
     output: true
 
 # release-please owns CHANGELOG.md; don't let GoReleaser generate its own.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,13 +178,17 @@ already write — there is nothing to tag by hand.
    the commit types since the last release, bumps the version, and regenerates `CHANGELOG.md`. The first
    release PR will propose **v0.1.0** (the `feat:` history so far is a 0.x minor bump).
 3. **You merge the release PR.** That tags `vX.Y.Z` and creates the GitHub release with the changelog.
-4. **The `vX.Y.Z` tag then fans out to two builds:**
-   - `build-image.yml` builds and **cosign-signs** the container image (with SLSA provenance + SBOM
-     attestation) and pushes the `vX.Y.Z` / `{major}.{minor}` tags to `ghcr.io`.
-   - the `goreleaser` job in `release-please.yml` runs [GoReleaser](https://goreleaser.com)
-     (`.goreleaser.yaml`) and **attaches the cross-platform `lore` binaries** (linux/darwin/windows ×
-     amd64/arm64) as `tar.gz`/`zip` archives, plus `checksums.txt`, a syft **SBOM per archive**, and a
-     **keyless cosign signature** of the checksums file — to the release release-please just created.
+4. **The `vX.Y.Z` tag then fires one release build — `release-binaries.yml` runs
+   [GoReleaser](https://goreleaser.com) (`.goreleaser.yaml`), which:**
+   - builds and pushes the **multi-arch container image** (the `vX.Y.Z` / `{major}.{minor}` / `latest`
+     tags on `ghcr.io/smana/runlore`) and **cosign keyless-signs it by digest**; buildx attaches
+     **SLSA provenance and SBOM attestations** to the pushed image index (attestations are produced
+     from the next tagged release onward).
+   - **attaches the cross-platform `lore` binaries** (linux/darwin/windows × amd64/arm64) as
+     `tar.gz`/`zip` archives, plus `checksums.txt`, a syft **SBOM per archive**, and a **keyless
+     cosign signature** of the checksums file — to the release release-please just created.
+
+   (`build-image.yml` only validates PR/main image builds; it does not run on tags.)
 
 The image and the binaries share the same `-X main.version` ldflags, so `lore --version` matches the
 image tag.
@@ -192,8 +196,8 @@ image tag.
 ### One-time setup (required): the `RELEASE_PLEASE_TOKEN` PAT
 
 > **This must exist before the pipeline works.** Without it the automation silently half-runs: the
-> release PR opens but **CI never runs on it**, and merging it tags the release but **neither
-> `build-image.yml` nor the `goreleaser` binaries fire**. This is a GitHub safeguard — events created
+> release PR opens but **CI never runs on it**, and merging it tags the release but **the GoReleaser
+> release build (`release-binaries.yml`) never fires**. This is a GitHub safeguard — events created
 > using the default `GITHUB_TOKEN` do **not** trigger further workflow runs.
 
 Create a **fine-grained Personal Access Token** scoped to `Smana/runlore` with these **repository**

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,11 +1,13 @@
 # COPY-only image for GoReleaser. The `lore` binary is cross-compiled by the
 # `builds.id: lore` step (linux/amd64 + linux/arm64, CGO_ENABLED=0) and placed by
-# GoReleaser at the build-context root for the matching --platform, so there is no
-# build stage here — we only assemble the runtime layer. Mirrors the runtime stage
-# of ./Dockerfile (used by build-image.yml for PR/main validation).
+# GoReleaser's dockers_v2 step under `<os>/<arch>/` in the build context — one
+# multi-platform buildx build selects the right one via $TARGETPLATFORM — so there
+# is no build stage here, we only assemble the runtime layer. Mirrors the runtime
+# stage of ./Dockerfile (used by build-image.yml for PR/main validation).
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETPLATFORM
 LABEL org.opencontainers.image.source="https://github.com/Smana/runlore"
-COPY lore /usr/local/bin/lore
+COPY $TARGETPLATFORM/lore /usr/local/bin/lore
 USER 65532:65532
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/lore"]


### PR DESCRIPTION
## What

The release pipeline signed images and binaries (cosign keyless) and produced per-archive SBOMs, but the pushed container image carried **no SLSA provenance or SBOM attestations** — the classic GoReleaser `dockers` flow `--load`-ed per-arch images into the local docker image store, whose exporter cannot represent an attestation manifest list (`docker exporter does not currently support exporting manifest lists`, the v0.1.0-era failure), so the flags were deliberately omitted.

This migrates the image to **`dockers_v2`**, whose single `docker buildx build --push` produces the multi-arch index directly (no per-arch tags, no `docker_manifests` fuse step) and can therefore attach attestations:

- **SBOM attestation** (`sbom: true` → `--attest=type=sbom`, BuildKit-generated) on the pushed index — dockers_v2's default, kept explicit so it can't silently regress.
- **SLSA provenance attestation** (`--provenance=mode=max`) via `flags`, templated to render empty on snapshot builds — snapshots `--load` per-platform images into the docker image store, where an attestation index would reproduce the original failure.
- **Signing preserved and hardened**: `docker_signs` still cosign-keyless-signs the pushed image (Fulcio via the job's `id-token: write`, recorded in Rekor), now pinned as `${artifact}@${digest}` (index digest from buildx) instead of the mutable tag. In GoReleaser's source, `artifacts: images` matches `DockerImageV2` artifacts. OCI refs remain lowercase (`ghcr.io/smana/runlore`).
- **`Dockerfile.goreleaser`**: dockers_v2 lays the prebuilt binaries out under `$TARGETPLATFORM/` in the build context, so the COPY line and an `ARG TARGETPLATFORM` were updated. Still COPY-only distroless.
- **Tags unchanged**: `{{ .Version }}`, `{{ .Major }}.{{ .Minor }}`, `latest` — now all one index instead of fused per-arch tags (the `-amd64`/`-arm64` tags disappear from GHCR; nothing in the repo referenced them).
- **CONTRIBUTING.md**: the release section now describes the actual fan-out (`release-binaries.yml` owns image + binaries; `build-image.yml` is PR/main validation only) and states the attestations are produced **from the next tagged release onward**.

## GoReleaser version

`dockers_v2` needs GoReleaser >= v2.12. The workflow installs `version: '~> v2'` (latest v2.x at run time), so **no pin bump is needed**; local validation ran on v2.16.0. `docker/setup-buildx-action` already creates a docker-container builder, which supports `--push` with attestations.

## Validated locally

- `goreleaser check` — config valid (v2.16.0)
- `goreleaser release --snapshot --clean --skip=sign,sbom,docker` — full binary/archive/checksum pipeline builds
- behavior traced in GoReleaser v2.16.0 source: publish path appends `--push --attest=type=sbom`; snapshot path `--load`s per-platform with empty-rendered flags pruned; `artifacts: images` + `${digest}` mapping for `DockerImageV2`
- `hadolint Dockerfile.goreleaser` — clean
- full gate: `go build ./...`, `go vet ./...`, `gofmt -l` (empty), `go test ./...`, `golangci-lint run ./...` → 0 issues

**Not validated locally**: the actual image build/push — no docker daemon was available in the environment, so the snapshot ran with `--skip=docker`.

## What the first tagged release must confirm

1. The multi-arch image builds and pushes as one index with all three tags.
2. `cosign verify ghcr.io/smana/runlore:<version>` succeeds (keyless, cert identity = the release workflow).
3. Attestations are attached: `docker buildx imagetools inspect ghcr.io/smana/runlore:<version>` shows the `unknown/unknown` attestation manifests, and `cosign download attestation` / `docker scout sbom` can read the SBOM + provenance.
4. The archives/checksums/bundle signing on the GitHub release is unchanged.