### PR TITLE
feat(curate): surface standing 👎 votes on the open KB PR they contest

### DIFF
--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -303,7 +303,7 @@ keeps the backlog healthy on a schedule:
   `stale_after`), never touching human-labelled ones, and only after a back-ref
   comment. `stale_after: 0` disables the sweep.
 
-Two further passes are also wired, both **ledger-backed** (they read the outcome
+Three further passes are also wired, all **ledger-backed** (they read the outcome
 ledger, so they stay source-neutral):
 
 - **Queue** — promote a human-`solved` PR to *ready-to-merge* once its incident has
@@ -329,6 +329,11 @@ ledger, so they stay source-neutral):
     `needs-work` is a revise-and-resubmit (not a rejection) and is left to the generic
     recurrence path; `wontfix` / `not-kb-worthy` are captured as the escalation's close
     reason. A *merged* PR is an accepted entry and is never suppressed.
+- **Contested** — when humans hold standing 👎 votes on the investigation behind a
+  *pending* KB entry (a 👎 on a fresh investigation weighs nothing in recall trust —
+  there is no catalog entry yet), the pass posts one warning comment on the still-open
+  KB PR so the reviewer sees the contest before merging; idempotent via a hidden
+  per-trigger marker in the comment, no mutable store.
 
 ---
 

--- a/docs/reviewing-knowledge.md
+++ b/docs/reviewing-knowledge.md
@@ -227,6 +227,17 @@ resolved, and opens a **`knowledge-gap`** issue when an unsolved pattern recurs.
 It only ever comments/labels/closes — it never merges. See
 [getting-started](getting-started.md#step-7--the-learn-loop-kb-lifecycle--re-runs).
 
+The groomer also carries on-call feedback into your review: when responders hold
+standing 👎 votes on the investigation behind a pending entry (the 👍/👎 buttons
+on the chat notification), it posts a comment on the open PR — *"On-call
+feedback: N standing 👎 votes on the investigation behind this entry"* — naming
+the trigger. Treat it as a red flag on check 1/2 above: re-read the `Cause`
+against the evidence before merging. The same 👎 also re-arms re-investigation
+(it bypasses the recurrence cooldown), so a fresher, possibly corrected
+conclusion may arrive while the PR is still open — worth waiting for before you
+merge a contested diagnosis. The comment appears once per contested trigger,
+even across repeated groomer runs.
+
 ---
 
 **In one sentence:** RunLore drafts; CI checks the format; **you** check that the

--- a/internal/app/curate.go
+++ b/internal/app/curate.go
@@ -22,8 +22,10 @@ import (
 // backlog-dedup pass (collapses duplicate open PRs across history) and the
 // lifecycle sweep (closes stale, unprotected PRs by forge age). When
 // outcome.ledger_path is configured, it also runs the Queue pass (promotes
-// solved→ready-to-merge when the incident resolves) and the Recurrence pass
-// (opens a knowledge-gap issue for repeatedly-unresolved patterns).
+// solved→ready-to-merge when the incident resolves), the Recurrence pass
+// (opens a knowledge-gap issue for repeatedly-unresolved patterns), and the
+// Contested pass (warns the open KB PR when humans 👎'd the investigation
+// behind it).
 func RunCurate(args []string) error {
 	fs := flag.NewFlagSet("curate", flag.ContinueOnError)
 	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
@@ -77,6 +79,12 @@ func RunCurate(args []string) error {
 				Suppressed: curate.ClosedPRSuppression{Forge: forge},
 				Log:        log,
 			},
+			// Contested surfaces standing 👎 votes on the OPEN KB PR they relate to:
+			// a 👎 on a fresh investigation weighs nothing in recall trust (no catalog
+			// entry yet), but it is exactly what the human reviewing the pending entry
+			// needs to see before merging. Idempotent via a hidden per-trigger comment
+			// marker — no store, mirroring the other passes.
+			curate.Contested{Forge: forge, Ledger: ledger, KBRepo: cfg.Forge.KBRepo, Log: log},
 		)
 		// Warn loudly when the ledger this pod sees is absent/empty: outcome.New
 		// succeeds on a missing file, so the passes would otherwise run silently

--- a/internal/curate/contested.go
+++ b/internal/curate/contested.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/Smana/runlore/internal/outcome"
+)
+
+// ContestedForge is the forge surface the Contested pass needs. Kept separate
+// from Forge: comment listing and PR-state lookup exist for this pass alone, and
+// widening the shared interface would force every other pass's test fake to grow
+// two irrelevant methods.
+type ContestedForge interface {
+	Comment(ctx context.Context, number int, body string) error
+	ListIssueCommentBodies(ctx context.Context, number int) ([]string, error)
+	IsPROpen(ctx context.Context, number int) (bool, error)
+}
+
+// ContestedSource yields the triggers whose delivered conclusion has standing 👎
+// votes and a KB link (the outcome ledger's ContestedTriggers view).
+type ContestedSource interface {
+	ContestedTriggers() []outcome.ContestedTrigger
+}
+
+// Contested surfaces standing 👎 votes on the OPEN KB PR they relate to. The gap
+// it closes: a 👎 on a FRESH investigation weighs nothing in recall trust (there
+// is no catalog entry yet to decay), so without this pass the one human signal
+// that says "this diagnosis is contested" never reaches the person about to make
+// it permanent knowledge — the KB PR reviewer. Ledger-driven and idempotent like
+// the other passes: votes are recomputed from the ledger every run, and a hidden
+// per-trigger marker in the posted comment is the "already surfaced" record — no
+// mutable store. It only ever comments; labels, closes and merges stay with the
+// other passes and with humans.
+type Contested struct {
+	Forge  ContestedForge
+	Ledger ContestedSource
+	KBRepo string // configured forge.kb_repo ("owner/name"); KB links outside it are foreign and skipped
+	Log    *slog.Logger
+}
+
+// Run posts one warning comment per (open KB PR, contested trigger). Per-item
+// failures are logged and skipped so one flaky PR never starves the rest.
+func (p Contested) Run(ctx context.Context) error {
+	triggers := p.Ledger.ContestedTriggers()
+	if len(triggers) == 0 {
+		return nil // disabled ledger or nothing contested: zero forge calls
+	}
+	owner, repo, ok := strings.Cut(p.KBRepo, "/")
+	if !ok {
+		return fmt.Errorf("contested: kb_repo %q must be owner/name", p.KBRepo)
+	}
+	// Per-PR caches: several contested triggers can coalesce onto one PR, and the
+	// state/comment lookups are per-PR facts — fetch each once per run.
+	openState := map[int]bool{}
+	commentBodies := map[int][]string{}
+	for _, ct := range triggers {
+		num, ok := prNumberInRepo(ct.CuratedURL, owner, repo)
+		if !ok {
+			// Foreign or non-PR link (another repo, a plain issue, a malformed URL):
+			// nothing here is reviewable in kb_repo, so skip — visibly, not silently.
+			p.Log.Debug("contested: KB link is not a kb_repo pull request; skipping", "trigger", ct.TriggerKey, "url", ct.CuratedURL)
+			continue
+		}
+		open, cached := openState[num]
+		if !cached {
+			var err error
+			if open, err = p.Forge.IsPROpen(ctx, num); err != nil {
+				p.Log.Warn("contested: PR state check failed", "pr", num, "err", err)
+				continue
+			}
+			openState[num] = open
+		}
+		if !open {
+			// Merged or closed: review is over. The votes keep weighing recall trust
+			// (and the recurrence cooldown) — there is just no reviewer left to warn.
+			p.Log.Debug("contested: KB PR is not open; nothing to warn on", "trigger", ct.TriggerKey, "pr", num)
+			continue
+		}
+		marker := contestedMarker(ct.TriggerKey)
+		bodies, cached := commentBodies[num]
+		if !cached {
+			var err error
+			if bodies, err = p.Forge.ListIssueCommentBodies(ctx, num); err != nil {
+				p.Log.Warn("contested: list PR comments failed", "pr", num, "err", err)
+				continue
+			}
+			commentBodies[num] = bodies
+		}
+		if anyContains(bodies, marker) {
+			continue // already surfaced on this PR — the marker is the idempotency record
+		}
+		if err := p.Forge.Comment(ctx, num, contestedComment(ct, marker)); err != nil {
+			p.Log.Warn("contested: comment failed", "pr", num, "err", err)
+			continue
+		}
+		p.Log.Info("contested: surfaced standing downvotes on open KB PR", "pr", num, "trigger", ct.TriggerKey, "downs", ct.Downs)
+	}
+	return nil
+}
+
+// contestedComment renders the reviewer-facing warning. It must be actionable
+// (what to re-check before merging) and honest about the side effect a standing
+// 👎 already has: it re-arms re-investigation, so a fresher conclusion may
+// supersede this entry. The invisible marker makes re-runs idempotent.
+func contestedComment(ct outcome.ContestedTrigger, marker string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**On-call feedback: %d standing 👎 %s** on the investigation behind this entry (trigger `%s`).\n\n",
+		ct.Downs, pluralVote(ct.Downs), ct.TriggerKey)
+	b.WriteString("Responders contested the delivered diagnosis. Please review the Cause against the evidence before merging — merging makes it permanent, recallable knowledge.\n\n")
+	b.WriteString("Note: a standing 👎 also re-arms re-investigation (the recurrence cooldown no longer suppresses this trigger), so a fresher conclusion may follow on the next occurrence.\n\n")
+	b.WriteString(marker)
+	return b.String()
+}
+
+func pluralVote(n int) string {
+	if n == 1 {
+		return "vote"
+	}
+	return "votes"
+}
+
+// contestedMarker is the hidden idempotency marker embedded in the posted
+// comment: one per trigger key, so a second contested trigger coalesced onto the
+// same PR still gets its own warning. The key is hashed rather than embedded
+// verbatim — trigger keys are free-form source identifiers and could otherwise
+// break out of the HTML comment ("--"/">" sequences).
+func contestedMarker(triggerKey string) string {
+	sum := sha256.Sum256([]byte(triggerKey))
+	return fmt.Sprintf("<!-- runlore:contested:%x -->", sum[:8])
+}
+
+// prNumberInRepo parses rawURL as a web link to a pull request of owner/repo,
+// returning (0, false) for anything else — a plain issue, a foreign repo, or a
+// malformed URL. The match is on the URL path (/{owner}/{repo}/pull/{n}), not
+// the host: the pass only knows the API base, and the web host differs from it
+// on both github.com and GHES, while the owner/repo path identifies the repo on
+// both.
+func prNumberInRepo(rawURL, owner, repo string) (int, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 0, false
+	}
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(segs) != 4 || segs[0] != owner || segs[1] != repo || segs[2] != "pull" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(segs[3])
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// anyContains reports whether any body carries the marker.
+func anyContains(bodies []string, marker string) bool {
+	for _, b := range bodies {
+		if strings.Contains(b, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/curate/contested_test.go
+++ b/internal/curate/contested_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/outcome"
+)
+
+// contestedForge is a scripted ContestedForge: PR open-states and existing
+// comment bodies are fixtures; posted comments and call counts are recorded.
+type contestedForge struct {
+	openPRs    map[int]bool     // number → open?
+	comments   map[int][]string // number → existing comment bodies
+	stateErr   map[int]error    // number → IsPROpen failure
+	commentErr map[int]error    // number → Comment failure
+
+	posted     map[int][]string // number → bodies posted this run
+	stateCalls int
+	listCalls  int
+}
+
+func (f *contestedForge) IsPROpen(_ context.Context, n int) (bool, error) {
+	f.stateCalls++
+	if err := f.stateErr[n]; err != nil {
+		return false, err
+	}
+	return f.openPRs[n], nil
+}
+
+func (f *contestedForge) ListIssueCommentBodies(_ context.Context, n int) ([]string, error) {
+	f.listCalls++
+	return f.comments[n], nil
+}
+
+func (f *contestedForge) Comment(_ context.Context, n int, body string) error {
+	if err := f.commentErr[n]; err != nil {
+		return err
+	}
+	if f.posted == nil {
+		f.posted = map[int][]string{}
+	}
+	f.posted[n] = append(f.posted[n], body)
+	return nil
+}
+
+// fakeContested is a fixed ContestedSource.
+type fakeContested struct{ cts []outcome.ContestedTrigger }
+
+func (f fakeContested) ContestedTriggers() []outcome.ContestedTrigger { return f.cts }
+
+func contested(t *testing.T, f *contestedForge, cts ...outcome.ContestedTrigger) Contested {
+	t.Helper()
+	return Contested{Forge: f, Ledger: fakeContested{cts: cts}, KBRepo: "o/r", Log: discardLog()}
+}
+
+func TestContestedCommentsOnOpenKBPR(t *testing.T) {
+	f := &contestedForge{openPRs: map[int]bool{7: true}}
+	p := contested(t, f, outcome.ContestedTrigger{
+		TriggerKey: "alert:web-down", CuratedURL: "https://github.com/o/r/pull/7",
+		Downs: 2, Last: time.Unix(50000, 0),
+	})
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.posted[7]) != 1 {
+		t.Fatalf("want exactly one comment on PR 7, got %+v", f.posted)
+	}
+	body := f.posted[7][0]
+	for _, want := range []string{
+		"2 standing 👎",                    // the vote count the reviewer weighs
+		"alert:web-down",                  // the trigger key, so the vote is attributable
+		"before merging",                  // the actionable ask
+		"re-arm",                          // the cooldown side effect: a fresher conclusion may follow
+		contestedMarker("alert:web-down"), // the idempotency marker
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("comment missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestContestedIdempotentWhenMarkerPresent: an existing comment carrying this
+// trigger's marker means the warning was already surfaced — never re-post, even
+// though the votes still stand on every later run.
+func TestContestedIdempotentWhenMarkerPresent(t *testing.T) {
+	f := &contestedForge{
+		openPRs:  map[int]bool{7: true},
+		comments: map[int][]string{7: {"older note\n" + contestedMarker("k")}},
+	}
+	p := contested(t, f, outcome.ContestedTrigger{TriggerKey: "k", CuratedURL: "https://github.com/o/r/pull/7", Downs: 1})
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.posted) != 0 {
+		t.Fatalf("marker present: must not re-post, got %+v", f.posted)
+	}
+}
+
+// TestContestedSkipsForeignAndNonPRURLs: only a pull-request URL inside the
+// configured kb_repo is actionable. Foreign repos, plain issues, and malformed
+// URLs are skipped without any forge round-trip.
+func TestContestedSkipsForeignAndNonPRURLs(t *testing.T) {
+	f := &contestedForge{openPRs: map[int]bool{7: true}}
+	p := contested(t, f,
+		outcome.ContestedTrigger{TriggerKey: "k1", CuratedURL: "https://github.com/other/repo/pull/7", Downs: 1},
+		outcome.ContestedTrigger{TriggerKey: "k2", CuratedURL: "https://github.com/o/r/issues/7", Downs: 1},
+		outcome.ContestedTrigger{TriggerKey: "k3", CuratedURL: "://not-a-url", Downs: 1},
+		outcome.ContestedTrigger{TriggerKey: "k4", CuratedURL: "https://github.com/o/r/pull/zero", Downs: 1},
+	)
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.stateCalls != 0 || f.listCalls != 0 || len(f.posted) != 0 {
+		t.Fatalf("foreign/non-PR URLs must cost no forge calls: state=%d list=%d posted=%+v", f.stateCalls, f.listCalls, f.posted)
+	}
+}
+
+// TestContestedSkipsClosedPR: a merged/closed KB PR has left review — the votes
+// keep weighing recall trust, but there is no reviewer left to warn.
+func TestContestedSkipsClosedPR(t *testing.T) {
+	f := &contestedForge{openPRs: map[int]bool{7: false}}
+	p := contested(t, f, outcome.ContestedTrigger{TriggerKey: "k", CuratedURL: "https://github.com/o/r/pull/7", Downs: 1})
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.listCalls != 0 || len(f.posted) != 0 {
+		t.Fatalf("closed PR must get no comment (list=%d posted=%+v)", f.listCalls, f.posted)
+	}
+}
+
+// TestContestedDisabledLedgerNoop: with the outcome feature off, the pass costs
+// nothing — the disabled ledger's ContestedTriggers is nil, so no forge call is
+// ever made (the "no new config" contract).
+func TestContestedDisabledLedgerNoop(t *testing.T) {
+	f := &contestedForge{}
+	disabled, err := outcome.New("")
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	p := Contested{Forge: f, Ledger: disabled, KBRepo: "o/r", Log: discardLog()}
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if f.stateCalls != 0 || f.listCalls != 0 || len(f.posted) != 0 {
+		t.Fatalf("disabled ledger must be a total no-op, got state=%d list=%d posted=%+v", f.stateCalls, f.listCalls, f.posted)
+	}
+}
+
+// TestContestedPerItemFailuresDoNotAbort: a state-check or comment failure on
+// one trigger is logged and skipped; the remaining triggers still get their
+// warning (best-effort, like every other pass).
+func TestContestedPerItemFailuresDoNotAbort(t *testing.T) {
+	f := &contestedForge{
+		openPRs:    map[int]bool{7: true, 8: true, 9: true},
+		stateErr:   map[int]error{7: errors.New("boom")},
+		commentErr: map[int]error{8: errors.New("boom")},
+	}
+	p := contested(t, f,
+		outcome.ContestedTrigger{TriggerKey: "k1", CuratedURL: "https://github.com/o/r/pull/7", Downs: 1},
+		outcome.ContestedTrigger{TriggerKey: "k2", CuratedURL: "https://github.com/o/r/pull/8", Downs: 1},
+		outcome.ContestedTrigger{TriggerKey: "k3", CuratedURL: "https://github.com/o/r/pull/9", Downs: 1},
+	)
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.posted[9]) != 1 || len(f.posted[7]) != 0 || len(f.posted[8]) != 0 {
+		t.Fatalf("only PR 9 should carry a comment, got %+v", f.posted)
+	}
+}
+
+// TestContestedTwoTriggersOnePR: two contested triggers whose newest entries
+// coalesced onto ONE PR each get their own (distinctly markered) comment, and
+// the PR's state/comments are fetched once, not per trigger.
+func TestContestedTwoTriggersOnePR(t *testing.T) {
+	f := &contestedForge{openPRs: map[int]bool{7: true}}
+	p := contested(t, f,
+		outcome.ContestedTrigger{TriggerKey: "k1", CuratedURL: "https://github.com/o/r/pull/7", Downs: 1},
+		outcome.ContestedTrigger{TriggerKey: "k2", CuratedURL: "https://github.com/o/r/pull/7", Downs: 3},
+	)
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(f.posted[7]) != 2 {
+		t.Fatalf("want one comment per trigger, got %+v", f.posted)
+	}
+	if f.stateCalls != 1 || f.listCalls != 1 {
+		t.Fatalf("state/comments must be fetched once per PR, got state=%d list=%d", f.stateCalls, f.listCalls)
+	}
+	if contestedMarker("k1") == contestedMarker("k2") {
+		t.Fatal("markers must be distinct per trigger")
+	}
+}
+
+// TestContestedBadKBRepoErrors: a kb_repo that is not owner/name is a wiring
+// bug, surfaced as the pass error (RunCurate validates it too — belt and braces).
+func TestContestedBadKBRepoErrors(t *testing.T) {
+	p := Contested{Forge: &contestedForge{}, Ledger: fakeContested{cts: []outcome.ContestedTrigger{{TriggerKey: "k", CuratedURL: "https://x/o/r/pull/1", Downs: 1}}}, KBRepo: "just-a-name", Log: discardLog()}
+	if err := p.Run(context.Background()); err == nil {
+		t.Fatal("malformed KBRepo must error")
+	}
+}

--- a/internal/curate/curate_test.go
+++ b/internal/curate/curate_test.go
@@ -35,4 +35,5 @@ var (
 	_ Pass = Dedup{}
 	_ Pass = Queue{}
 	_ Pass = Lifecycle{}
+	_ Pass = Contested{}
 )

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -306,6 +306,45 @@ func (c *Client) Comment(ctx context.Context, number int, body string) error {
 		map[string]any{"body": body}, nil)
 }
 
+// ListIssueCommentBodies fetches ALL pages of an issue/PR's comment bodies (the
+// issues-comments endpoint serves both — PR discussion comments live there).
+// Callers scan the bodies for hidden idempotency markers, so pagination matters:
+// a marker past the first 100 comments would otherwise be invisible and the
+// caller would re-post forever.
+func (c *Client) ListIssueCommentBodies(ctx context.Context, number int) ([]string, error) {
+	var out []string
+	for page := 1; ; page++ {
+		var raw []struct {
+			Body string `json:"body"`
+		}
+		path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments?per_page=100&page=%d", c.owner, c.repo, number, page)
+		if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+			return nil, err
+		}
+		for _, r := range raw {
+			out = append(out, r.Body)
+		}
+		if len(raw) < 100 { // last page (a full page is exactly 100)
+			break
+		}
+	}
+	return out, nil
+}
+
+// IsPROpen reports whether number is an OPEN pull request. It deliberately hits
+// the pulls endpoint (not issues): a number that is actually an issue 404s there
+// instead of passing, so a caller gating "comment on the open KB PR" can never
+// be fooled into treating an issue as a PR.
+func (c *Client) IsPROpen(ctx context.Context, number int) (bool, error) {
+	var out struct {
+		State string `json:"state"` // "open" | "closed" (merged PRs report closed)
+	}
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/pulls/%d", c.owner, c.repo, number), nil, &out); err != nil {
+		return false, err
+	}
+	return out.State == "open", nil
+}
+
 // ReplaceLabel removes one label and adds another (best-effort on the removal —
 // a 404 when the label isn't present is not fatal).
 func (c *Client) ReplaceLabel(ctx context.Context, number int, remove, add string) error {

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -261,6 +261,75 @@ func TestClose(t *testing.T) {
 	}
 }
 
+func TestListIssueCommentBodies(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/o/r/issues/42/comments" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`[{"body":"first"},{"body":"second <!-- marker -->"}]`))
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	bodies, err := c.ListIssueCommentBodies(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ListIssueCommentBodies: %v", err)
+	}
+	if len(bodies) != 2 || bodies[0] != "first" || bodies[1] != "second <!-- marker -->" {
+		t.Fatalf("bodies = %#v", bodies)
+	}
+}
+
+func TestListIssueCommentBodiesPaginates(t *testing.T) {
+	// page 1 returns a full page (100) → the client must fetch page 2 for the rest,
+	// or an idempotency marker past comment #100 would be invisible.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			items := make([]string, 100)
+			for i := range items {
+				items[i] = fmt.Sprintf(`{"body":"c%d"}`, i+1)
+			}
+			_, _ = w.Write([]byte("[" + strings.Join(items, ",") + "]"))
+		case "2":
+			_, _ = w.Write([]byte(`[{"body":"c101"}]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	bodies, err := c.ListIssueCommentBodies(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("ListIssueCommentBodies: %v", err)
+	}
+	if len(bodies) != 101 || bodies[100] != "c101" {
+		t.Fatalf("want 101 bodies across 2 pages (no truncation at 100), got %d", len(bodies))
+	}
+}
+
+func TestIsPROpen(t *testing.T) {
+	state := "open"
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = fmt.Fprintf(w, `{"number":7,"state":%q}`, state)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	open, err := c.IsPROpen(context.Background(), 7)
+	if err != nil || !open {
+		t.Fatalf("IsPROpen(open) = %v, %v; want true, nil", open, err)
+	}
+	if gotPath != "/repos/o/r/pulls/7" {
+		t.Fatalf("path = %q, want the pulls endpoint (a non-PR number must 404, not pass)", gotPath)
+	}
+	state = "closed"
+	open, err = c.IsPROpen(context.Background(), 7)
+	if err != nil || open {
+		t.Fatalf("IsPROpen(closed) = %v, %v; want false, nil", open, err)
+	}
+}
+
 func TestListPRsByLabelPaginates(t *testing.T) {
 	// page 1 returns a full page (100) → the client must fetch page 2 for the rest.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -726,6 +727,56 @@ func (l *Ledger) Recurrence(triggerKey string) TriggerRecurrence {
 		}
 	}
 	return tr
+}
+
+// ContestedTrigger is one trigger whose delivered conclusion has standing 👎
+// votes AND a KB artifact to act on — the unit of work for the curate pass that
+// warns the human reviewing the pending KB PR. Downs counts LIVE "down" votes
+// after per-user dedup (a vote later moved to 👍 no longer counts); CuratedURL
+// and Last come from the trigger's newest open, matching Recurrence.
+type ContestedTrigger struct {
+	TriggerKey string
+	CuratedURL string    // KB link of the newest open (never "")
+	Downs      int       // standing 👎 votes, per-user latest-wins
+	Last       time.Time // when the trigger's newest investigation happened
+}
+
+// ContestedTriggers returns every trigger with at least one standing 👎 vote and
+// a non-empty CuratedURL, sorted by TriggerKey so the pass output is
+// deterministic. It is the inverse view of Recurrence's per-key FeedbackDown:
+// one iteration over the live votes map — O(live votes), which stays small (one
+// entry per trigger×user) and runs on the scheduled curate cadence, not a hot
+// path — joined against byTrigger for the newest open's KB link and time. A
+// contested trigger with NO KB link is deliberately excluded: there is no PR for
+// a reviewer to be warned on (the vote itself still stands in the ledger for
+// trust decay and the recurrence cooldown). Nil for a disabled (or nil) ledger.
+func (l *Ledger) ContestedTriggers() []ContestedTrigger {
+	if !l.enabled() {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	downs := map[string]int{}
+	for k, v := range l.votes {
+		if v.rating != "down" {
+			continue
+		}
+		trigger, _, ok := strings.Cut(k, "\x00")
+		if !ok {
+			continue // defensive: Feedback never writes a separator-less key
+		}
+		downs[trigger]++
+	}
+	out := make([]ContestedTrigger, 0, len(downs))
+	for trigger, n := range downs {
+		a := l.byTrigger[trigger]
+		if a.curatedURL == "" {
+			continue // no KB artifact to warn a reviewer on
+		}
+		out = append(out, ContestedTrigger{TriggerKey: trigger, CuratedURL: a.curatedURL, Downs: n, Last: a.last})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TriggerKey < out[j].TriggerKey })
+	return out
 }
 
 // Episodes replays the full ledger and turns every open into an Episode, pairing

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1302,3 +1302,72 @@ func TestRecurrenceVerdictSurvivesReplayAndCheckpoint(t *testing.T) {
 		t.Fatalf("checkpointed recurrence = %+v, want verdict=no_action count=1", r)
 	}
 }
+
+// TestContestedTriggersGroupsStandingDowns pins the grouping semantics: one
+// entry per trigger with at least one STANDING 👎 (per-user latest-wins, so a
+// moved vote no longer counts), joined with the trigger's newest-open KB link —
+// and a contested trigger with no KB link is excluded (there is no PR for a
+// reviewer to be warned on).
+func TestContestedTriggersGroupsStandingDowns(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	t0 := time.Unix(42000, 0)
+	// k1: two standing 👎 (U1, U2); U3's 👍 must not count.
+	_ = l.Open(Event{Fingerprint: "f1", Kind: "fresh", TriggerKey: "k1", CuratedURL: "https://github.com/o/r/pull/7", At: t0})
+	_ = l.Feedback("k1", "down", "U1", t0.Add(time.Minute))
+	_ = l.Feedback("k1", "down", "U2", t0.Add(2*time.Minute))
+	_ = l.Feedback("k1", "up", "U3", t0.Add(3*time.Minute))
+	// k2: contested, then the voter moved to 👍 — no standing 👎 remains.
+	_ = l.Open(Event{Fingerprint: "f2", Kind: "fresh", TriggerKey: "k2", CuratedURL: "https://github.com/o/r/pull/8", At: t0})
+	_ = l.Feedback("k2", "down", "U1", t0.Add(time.Minute))
+	_ = l.Feedback("k2", "up", "U1", t0.Add(2*time.Minute))
+	// k3: standing 👎 but no CuratedURL — excluded.
+	_ = l.Open(Event{Fingerprint: "f3", Kind: "fresh", TriggerKey: "k3", At: t0})
+	_ = l.Feedback("k3", "down", "U1", t0.Add(time.Minute))
+	got := l.ContestedTriggers()
+	if len(got) != 1 {
+		t.Fatalf("ContestedTriggers = %+v, want exactly the k1 entry", got)
+	}
+	ct := got[0]
+	if ct.TriggerKey != "k1" || ct.Downs != 2 || ct.CuratedURL != "https://github.com/o/r/pull/7" || !ct.Last.Equal(t0) {
+		t.Fatalf("ContestedTriggers[0] = %+v, want k1 downs=2 url=…/pull/7 last=t0", ct)
+	}
+}
+
+// TestContestedTriggersFollowNewestOpenSortedAndReplayed: the joined KB link and
+// last-seen time come from the trigger's NEWEST open, the output is sorted by
+// TriggerKey (deterministic pass order), and the whole standing state is rebuilt
+// identically from a fresh replay of the file.
+func TestContestedTriggersFollowNewestOpenSortedAndReplayed(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p)
+	t0 := time.Unix(43000, 0)
+	_ = l.Open(Event{Fingerprint: "f1", Kind: "fresh", TriggerKey: "k2", CuratedURL: "https://kb/old", At: t0})
+	_ = l.Feedback("k2", "down", "U1", t0.Add(time.Minute))
+	_ = l.Open(Event{Fingerprint: "f2", Kind: "fresh", TriggerKey: "k2", CuratedURL: "https://kb/new", At: t0.Add(time.Hour)})
+	_ = l.Open(Event{Fingerprint: "f3", Kind: "fresh", TriggerKey: "k1", CuratedURL: "https://kb/a", At: t0})
+	_ = l.Feedback("k1", "down", "U1", t0.Add(time.Minute))
+	got := l.ContestedTriggers()
+	if len(got) != 2 || got[0].TriggerKey != "k1" || got[1].TriggerKey != "k2" {
+		t.Fatalf("want [k1 k2] sorted by TriggerKey, got %+v", got)
+	}
+	if got[1].CuratedURL != "https://kb/new" || !got[1].Last.Equal(t0.Add(time.Hour)) {
+		t.Fatalf("k2 must carry the NEWEST open's URL/time, got %+v", got[1])
+	}
+	l2, _ := New(p) // restart / leader failover
+	if got2 := l2.ContestedTriggers(); len(got2) != 2 || got2[1].CuratedURL != "https://kb/new" || got2[0].Downs != 1 {
+		t.Fatalf("replayed ContestedTriggers = %+v", got2)
+	}
+}
+
+// TestContestedTriggersNilAndDisabled: the accessor is nil-safe and a disabled
+// ledger yields nil — the curate pass no-ops on both without special-casing.
+func TestContestedTriggersNilAndDisabled(t *testing.T) {
+	var nilLedger *Ledger
+	if got := nilLedger.ContestedTriggers(); got != nil {
+		t.Fatalf("nil ledger must yield nil, got %+v", got)
+	}
+	d, _ := New("")
+	if got := d.ContestedTriggers(); got != nil {
+		t.Fatalf("disabled ledger must yield nil, got %+v", got)
+	}
+}


### PR DESCRIPTION
## Why

The human feedback loop records 👍/👎 votes in the outcome ledger, but a 👎 on a **fresh** investigation weighs nothing in recall trust — there is no catalog entry yet to decay. That vote is exactly the signal the human reviewing the pending KB PR needs before merging a contested diagnosis into permanent, recallable knowledge. Today it dies in the ledger.

## What

A new ledger-backed `lore curate` pass (**Contested**), mirroring the idempotent, store-less design of Queue/Recurrence:

- **`outcome.Ledger.ContestedTriggers()`** — groups standing "down" votes per trigger in one iteration over the live votes map (O(live votes), per-user latest-wins already folded), joined with the `byTrigger` index for the newest open's `CuratedURL`/`Last`. Triggers with zero standing 👎 or no KB link are excluded; output sorted by trigger key; nil/disabled-safe.
- **`forge/github`**: `ListIssueCommentBodies` (paginated — an idempotency marker past comment #100 must stay visible) and `IsPROpen` (pulls endpoint, so an issue number 404s instead of passing as a PR).
- **`curate.Contested`** — for each contested trigger whose `CuratedURL` is a `kb_repo` pull request (foreign repos / plain issues / malformed URLs are skipped with a debug log) that is still **open**, post **one** warning comment naming the standing-👎 count and trigger key, asking the reviewer to re-check the Cause before merging, and noting that a standing 👎 re-arms re-investigation (recurrence cooldown), so a fresher conclusion may follow.
- **Idempotency**: a hidden `<!-- runlore:contested:<sha256(triggerKey)[:8]> -->` marker embedded in the comment; the pass lists the PR's existing comments and skips when the marker is present — no mutable store, safe to re-run. The key is hashed so free-form trigger keys can't break out of the HTML comment.
- **Wiring**: appended to the `lore curate` passes only when `outcome.ledger_path` is configured — **no new config**; a disabled ledger yields nil triggers and the pass makes zero forge calls. Per-item failures are logged and skipped; per-PR state/comment lookups are cached per run.
- **Docs**: reviewer-facing paragraph in `docs/reviewing-knowledge.md` (§8, the backlog groomer), pass summary bullet in `docs/learning-loop.md`'s Phase-2 grooming section.

## Example comment

> **On-call feedback: 2 standing 👎 votes** on the investigation behind this entry (trigger `alert:web-down`).
>
> Responders contested the delivered diagnosis. Please review the Cause against the evidence before merging — merging makes it permanent, recallable knowledge.
>
> Note: a standing 👎 also re-arms re-investigation (the recurrence cooldown no longer suppresses this trigger), so a fresher conclusion may follow on the next occurrence.

## Testing

TDD throughout: ledger grouping/join/replay + nil/disabled safety (`internal/outcome`), httptest coverage for both forge helpers incl. pagination (`internal/forge/github`), and pass behavior — comment content, marker idempotency, foreign-URL/closed-PR/disabled-ledger no-ops, per-item failure isolation, per-PR caching (`internal/curate`). Full gate: `go build`, `go vet`, `gofmt`, `go test -race ./...`, `golangci-lint run` = 0 issues.