### PR TITLE
feat(ha): decouple /readyz from leadership — followers forward work to the leader

### DIFF
--- a/deploy/helm/runlore/templates/_helpers.tpl
+++ b/deploy/helm/runlore/templates/_helpers.tpl
@@ -90,6 +90,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # Routable leader identity (#264): the agent encodes this IP into the
+        # leader-election Lease identity (<podName>_<podIP>) so a NON-leader
+        # replica can proxy incoming work (webhooks, Slack interactions, action
+        # control) straight to the leader. Without it the identity degrades to
+        # name-only and followers answer 503 instead of forwarding.
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         {{- with .Values.env }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -99,11 +108,11 @@ spec:
       {{- $liveness := $probes.liveness | default dict }}
       {{- $readiness := $probes.readiness | default dict }}
       {{- if $startup.enabled }}
-      # startupProbe owns the cold-start window (catalog warm-up + leader-lease
-      # gating). It targets /healthz (process-alive), NOT /readyz: a standby
-      # replica is never the leader and so never /readyz-ready, which would
-      # deadlock a readiness-gated startupProbe. While it runs, liveness +
-      # readiness are suppressed, so warm-up emits no premature Unhealthy events.
+      # startupProbe owns the cold-start window (catalog clone + index warm-up).
+      # It targets /healthz (process-alive), NOT /readyz: a slow first catalog
+      # sync must delay readiness, never get the pod killed. While it runs,
+      # liveness + readiness are suppressed, so warm-up emits no premature
+      # Unhealthy events.
       startupProbe:
         httpGet:
           path: /healthz
@@ -121,10 +130,11 @@ spec:
         failureThreshold: {{ $liveness.failureThreshold | default 3 }}
         timeoutSeconds: {{ $liveness.timeoutSeconds | default 2 }}
       readinessProbe:
-        # /readyz is gated by leadership + catalog warmth — only the warm leader
-        # serves webhook traffic. The startupProbe covers the cold window, so no
-        # initialDelaySeconds here; the tight cadence makes leader handoff reflect
-        # in the Service endpoints within a few seconds.
+        # /readyz is gated by catalog warmth only — NOT leadership (#264), so
+        # every warm replica is Ready and `helm upgrade --wait` / Flux kstatus
+        # succeeds with replicaCount>1. A non-leader replica that receives a
+        # webhook proxies it to the leader. The startupProbe covers the cold
+        # window, so no initialDelaySeconds here.
         httpGet:
           path: /readyz
           port: http

--- a/deploy/helm/runlore/templates/networkpolicy.yaml
+++ b/deploy/helm/runlore/templates/networkpolicy.yaml
@@ -23,9 +23,28 @@ spec:
       # Scope who may reach the webhook port (e.g. the Alertmanager namespace).
       # Empty (default) ⇒ no `from:` ⇒ all sources allowed (permissive, no break).
       from:
+        # Replica-to-replica forwarding (#264): a non-leader replica proxies
+        # work-bearing requests to the leader pod on this same port, so peer
+        # pods of this release must stay reachable however ingressFrom narrows
+        # the external sources.
+        - podSelector:
+            matchLabels:
+              {{- include "runlore.selectorLabels" $ | nindent 14 }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
   egress:
+    # Replica-to-replica forwarding (#264): a non-leader replica proxies
+    # work-bearing requests to the leader pod on the serve port. Allowed in BOTH
+    # egress modes — the permissive default only opens 443/6443 and strict mode
+    # denies by default, so without this rule forwarding would be silently
+    # dropped by the CNI.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "runlore.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
     # DNS — scoped to the cluster DNS service by default (override/disable via networkPolicy.egress.dns).
     {{- if .Values.networkPolicy.egress.dns.toClusterDNS }}
     - to:

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -1,12 +1,17 @@
-# 2+ replicas give failover: only the elected leader is Ready/active; the rest are
-# hot standby. See config.leader_election below.
+# 2+ replicas give failover: every warm replica reports Ready (so the Service may
+# round-robin webhooks across all of them), but only the elected leader runs the
+# investigation queue — a non-leader replica PROXIES incoming work to the leader
+# (single hop, learned from the Lease). `helm upgrade --wait` / Flux kstatus works
+# with any replica count. See config.leader_election below.
 replicaCount: 2
 
-# Recreate avoids a rolling-update deadlock under leader election: a new pod can't
-# become Ready until it leads, but the old leader holds the Lease (and maxUnavailable
-# is 0), so an in-place rolling update stalls. Recreate terminates old pods first.
+# Readiness no longer gates on leadership (#264), so the historical rolling-update
+# deadlock (new pod not Ready until it leads, old leader holding the Lease) is gone
+# and RollingUpdate is viable. Recreate stays the shipped default because it avoids
+# two agent VERSIONS overlapping mid-rollout (briefly co-serving webhooks/leases).
 # Trade-off: ~20s downtime during the agent's own upgrade; crash-failover HA is
-# unaffected. Switch to RollingUpdate only with a leadership-independent readiness model.
+# unaffected. Set RollingUpdate for near-zero-downtime upgrades once you've
+# validated it in your environment.
 updateStrategy: Recreate
 
 # Deployment (default) shares one PVC across every replica via persistence.existingClaim
@@ -14,7 +19,7 @@ updateStrategy: Recreate
 # multi-node cluster with an RWO (single-attach) StorageClass, a second replicaCount>1
 # pod scheduled on a different node cannot attach that already-attached volume and
 # hangs. Set StatefulSet to give each replica its OWN volume via volumeClaimTemplates;
-# leader election (already topology-agnostic — only the elected leader is Ready) then
+# leader election (topology-agnostic — only the elected leader investigates) then
 # provides real HA. Trade-off: a new leader that takes over on a DIFFERENT replica's
 # volume starts with an empty local outcome ledger (the catalog is unaffected — it
 # re-clones from git). Only affects persistence.enabled=true; ConfigMap/emptyDir
@@ -78,8 +83,9 @@ config:
       # and would otherwise drive confident-but-wrong root causes. Defaults to 60s
       # when omitted; set 0 to fire immediately on every Ready=False.
       debounce: 60s
-  # HA: only the elected leader runs the informer + investigation queue and reports
-  # ready (the Service then routes webhooks to the leader). Harmless with 1 replica.
+  # HA: only the elected leader runs the informer + investigation queue. Every warm
+  # replica reports Ready (#264); a non-leader replica that receives a webhook
+  # proxies it to the leader (looked up via the Lease). Harmless with 1 replica.
   leader_election:
     enabled: true
     name: runlore-leader
@@ -289,20 +295,20 @@ service:
   port: 8080                          # the /webhook/alertmanager + /healthz + /metrics port
 
 # Health probes. The agent has a non-trivial warm-up: the HTTP server (and so
-# /healthz) comes up within ~1s, but /readyz stays 503 until this replica wins the
-# leader Lease AND — for a git-sync catalog — the first clone+index completes (a
-# real KB repo can take many seconds). A non-leader (standby) replica is /readyz
-# 503 for its whole life by design.
+# /healthz) comes up within ~1s, but /readyz stays 503 until — for a git-sync
+# catalog — the first clone+index completes (a real KB repo can take many
+# seconds). Readiness does NOT depend on leadership (#264): every replica whose
+# catalog is warm reports Ready, leader and standby alike, so `helm upgrade
+# --wait` / Flux kstatus succeeds with replicaCount>1. A non-leader replica that
+# receives a webhook proxies it to the leader.
 #
 # A startupProbe on /healthz owns the cold-start window: while it runs, the
 # liveness + readiness probes are suppressed, so warm-up never emits premature
-# "Unhealthy" readiness events. Once it passes once, the tight readiness probe
-# takes over (so a leader handoff shows up in the Service endpoints within a few
-# seconds) and liveness guards against a genuine process hang on its normal
-# cadence. The startupProbe targets /healthz, NOT /readyz: gating startup on
-# readiness would deadlock a standby replica (never leader ⇒ never ready ⇒
-# startupProbe never passes ⇒ kubelet kills the pod). Liveness is deliberately
-# NOT loosened — it still trips a real hang.
+# "Unhealthy" readiness events. Once it passes once, the readiness probe takes
+# over and liveness guards against a genuine process hang on its normal cadence.
+# The startupProbe targets /healthz, NOT /readyz: a slow first catalog sync must
+# delay readiness, never get the pod killed. Liveness is deliberately NOT
+# loosened — it still trips a real hang.
 probes:
   startup:
     enabled: true            # set false to skip the startupProbe (e.g. very fast static catalog)
@@ -314,7 +320,7 @@ probes:
     failureThreshold: 3
     timeoutSeconds: 2
   readiness:
-    periodSeconds: 5         # keep tight so leader handoff reflects in endpoints fast
+    periodSeconds: 5         # keep tight so a cold/broken catalog surfaces in endpoints fast
     failureThreshold: 3
     timeoutSeconds: 2
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -200,7 +200,8 @@ image:
   repository: ghcr.io/smana/runlore
   tag: ""            # defaults to the chart appVersion; pin in production
 
-# HA: 2+ replicas, one active leader (the rest hot standby). See leader_election below.
+# HA: 2+ replicas, one active leader; every warm replica is Ready and a non-leader
+# proxies incoming webhooks to the leader. See leader_election below.
 # If you also set persistence.enabled: true, pick workloadKind explicitly: the default
 # Deployment shares one PVC across every replica (fine with an RWX StorageClass like
 # EFS; an RWO one like EBS can't attach it to a standby on a different node — set
@@ -438,7 +439,9 @@ route:
       continue: true        # keep your existing routing too
 ```
 
-With 2+ replicas, only the **leader** is Ready, so the Service routes webhooks to it automatically.
+With 2+ replicas, every warm replica is `Ready` — the Service may route a webhook to any of them,
+and a non-leader replica transparently proxies it to the elected **leader** (single hop, looked up
+via the leader-election `Lease`), so only the leader's queue ever investigates.
 
 ### Harden for production
 
@@ -480,7 +483,8 @@ See the [Security model](security-model.md) for the full posture — redaction, 
 ## Step 6 — Verify
 
 ```bash
-# the leader becomes Ready; standbys stay NotReady (expected)
+# every replica becomes Ready once its catalog is warm; the Lease names the leader
+# (holder identity is <podName>_<podIP> — the IP lets standbys forward work to it)
 kubectl -n runlore get pods
 kubectl -n runlore get lease runlore-leader -o jsonpath='{.spec.holderIdentity}'; echo
 

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -411,10 +411,11 @@ local Git mirror of the catalog and re-indexes on change:
   every poll. A curator-merged PR moves HEAD → the next poll rebuilds exactly once.
   This runs on **every replica** (so a failover standby is already warm) and the
   per-poll rebuild cost is gone.
-- **Readiness reflects warmth.** A leader doesn't advertise `/readyz` healthy until
+- **Readiness reflects warmth.** A replica doesn't advertise `/readyz` healthy until
   its catalog has loaded at least once, so it isn't routed incident traffic before its
   knowledge base is warm (a ConfigMap-mounted static catalog is ready immediately; a
-  git-sync catalog becomes ready after its first index).
+  git-sync catalog becomes ready after its first index). Readiness is warmth only —
+  leadership is handled by request forwarding, not by keeping standbys NotReady.
 
 The compounding rate is ultimately bounded by **how fast humans merge PRs** — which is
 deliberate. The catalog is a reviewed commons, not an auto-writing cache; the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,8 +11,10 @@ two diagnostic channels:
 
 > [!note] Leader-only by design
 > With `leader_election.enabled` (the chart default, 2 replicas) **only the leader investigates**. A
-> standby logs `msg="standby; another replica leads"` and stays at `/readyz` 503 for its whole life —
-> that is intentional, not a fault. `runlore_leader == 1` marks the elected pod.
+> standby logs `msg="standby; another replica leads"`, reports `/readyz` 200 like the leader (readiness
+> is catalog warmth, not leadership), and **proxies** any webhook it receives to the leader — grep
+> `msg="forwarded to leader"` (debug) / `msg="leader forward failed"`. `runlore_leader == 1` marks the
+> elected pod; the Lease holder identity is `<podName>_<podIP>`.
 
 ---
 
@@ -151,16 +153,19 @@ with `count=` confirms how many sinks were wired — `count=0` means none are co
 
 ## `/readyz` never goes green
 
-`/readyz` is gated by **leadership AND catalog warmth** (`internal/app/runtime.go`). It returns `503`
-("`not ready`") until the pod both leads *and* has completed its first catalog index/sync.
+`/readyz` is gated by **catalog warmth** (`internal/app/runtime.go`) — deliberately **not** by
+leadership, so every warm replica (leader and standby alike) goes `Ready` and `helm upgrade --wait` /
+Flux kstatus succeeds with `replicaCount > 1`. It returns `503` ("`not ready`") until the pod has
+completed its first catalog index/sync.
 
-- A **standby** is `503` for its entire life — by design (probes target `/healthz`, not `/readyz`,
-  so a standby isn't killed). Only the leader should be `Ready`.
-- The **leader** stuck at `503` ⇒ the catalog never warmed: check `catalog.dir` / `catalog.git`
+- **Any pod** stuck at `503` ⇒ the catalog never warmed: check `catalog.dir` / `catalog.git`
   (clone failing? token wrong?) and the startup logs. `runlore_catalog_invalid_entries_total` rising
   ⇒ malformed OKF entries at load.
 - The `startupProbe` allows ~60s of warm-up; a slow first clone can exceed it — raise the chart's
   `startupProbe.failureThreshold` if needed.
+- Who leads is a separate question from readiness: read the Lease
+  (`kubectl get lease runlore-leader -o jsonpath='{.spec.holderIdentity}'` — `<podName>_<podIP>`)
+  or the `runlore_leader` gauge.
 
 ---
 

--- a/docs/upgrade-uninstall.md
+++ b/docs/upgrade-uninstall.md
@@ -13,23 +13,29 @@ helm upgrade runlore deploy/helm/runlore -n runlore -f values.yaml
 Your `values.yaml` is the source of truth; the entire agent config under `values.config` is rendered
 verbatim into the ConfigMap. Re-apply the same file (with your changes) on every upgrade.
 
-> [!warning] Expect ~20s of downtime during the agent's own upgrade
-> The Deployment uses **`strategy.type: Recreate`**, not a rolling update. Old pods are terminated
-> **before** new ones start, so the agent is briefly unavailable while the new version boots and wins
-> the leader lease.
+> [!warning] Expect ~20s of downtime during the agent's own upgrade (default strategy)
+> The Deployment ships with **`strategy.type: Recreate`**: old pods are terminated **before** new
+> ones start, so the agent is briefly unavailable while the new version boots and wins the leader
+> lease. Set `updateStrategy: RollingUpdate` for near-zero-downtime upgrades (see below).
 
-### Why `Recreate` (not a rolling update)
+### `Recreate` vs `RollingUpdate`
 
-It's a deliberate interaction with leader election. Under a rolling update with `replicaCount: 2`:
+Historically `Recreate` was **forced** by a readiness deadlock: `/readyz` was gated on leadership, a
+new pod couldn't go `Ready` while the old leader held the `Lease`, and the rolling update stalled
+(it also meant standbys were never `Ready`, so `helm upgrade --wait` / Flux kstatus timed out with
+`replicaCount > 1`).
 
-1. A new pod can't become `Ready` until it becomes the **leader** (`/readyz` is gated on leadership).
-2. The old leader still holds the `Lease`, so the new pod can't lead yet.
-3. With `maxUnavailable: 0` the old pod won't terminate until the new one is `Ready` — **deadlock**.
+That deadlock is gone: readiness now reflects **catalog warmth only** — every warm replica is
+`Ready`, and a non-leader replica proxies incoming work to the leader. `RollingUpdate` therefore
+works: the new pod warms up, goes `Ready`, the old leader terminates (draining, then releasing the
+`Lease`), and a surviving pod acquires it.
 
-`Recreate` sidesteps this by terminating the old leader first, releasing the lease so the new pod can
-acquire it. The cost is a short gap **only during the upgrade itself**. Crash-failover HA is
-unaffected: if the leader dies unexpectedly, the hot standby takes over within the lease window
-(15s lease / 10s renew / 2s retry), no upgrade involved.
+`Recreate` remains the shipped default for one reason: it never lets two agent **versions** overlap
+mid-rollout (briefly co-serving webhooks and contending for the same lease across versions). The
+cost is a short gap **only during the upgrade itself** — crash-failover HA is unaffected: if the
+leader dies unexpectedly, the hot standby takes over within the lease window (15s lease / 10s renew
+/ 2s retry), no upgrade involved. Prefer zero-downtime upgrades? Set `updateStrategy: RollingUpdate`
+after validating it in your environment.
 
 `terminationGracePeriodSeconds: 40` gives the draining leader time to finish (the internal drain is
 ~25s): on shutdown it logs `msg="shutdown: stopping intake; draining in-flight investigation"`,

--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -397,19 +397,25 @@ for _ in $(seq 1 30); do
   TOTAL=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore --no-headers 2>/dev/null | wc -l | tr -d ' ')
   READY=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore \
     -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c True || true)
-  [[ "$TOTAL" == "2" && "$READY" == "1" ]] && break
+  # Since #264 readiness is catalog warmth, not leadership: BOTH replicas must be
+  # Ready (this is what lets `helm upgrade --wait` / Flux kstatus succeed in HA).
+  [[ "$TOTAL" == "2" && "$READY" == "2" ]] && break
   sleep 2
 done
-if [[ "$TOTAL" == "2" && "$READY" == "1" ]]; then
-  green "PASS: 2 replicas, exactly 1 Ready (leader); the other is hot standby"; PASS=$((PASS+1))
-else red "FAIL: replicas=$TOTAL ready=$READY (want 2 / 1)"; FAIL=$((FAIL+1)); fi
+if [[ "$TOTAL" == "2" && "$READY" == "2" ]]; then
+  green "PASS: 2 replicas, BOTH Ready (readiness decoupled from leadership); leader is the Lease holder"; PASS=$((PASS+1))
+else red "FAIL: replicas=$TOTAL ready=$READY (want 2 / 2)"; FAIL=$((FAIL+1)); fi
 
 HOLDER=$(kubectl -n "$NS" get lease runlore-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)
-if [[ -n "$HOLDER" ]]; then green "PASS: Lease held by $HOLDER"; PASS=$((PASS+1))
-else red "FAIL: no Lease holder"; FAIL=$((FAIL+1)); fi
+# The holder identity is now ROUTABLE — <podName>_<podIP> (#264) — so a standby
+# can proxy incoming work to the leader. Pod names are DNS-1123 (no '_' allowed),
+# so stripping from the first underscore always recovers the pod name.
+HOLDER_POD=${HOLDER%%_*}
+if [[ "$HOLDER" == *_* && -n "$HOLDER_POD" ]]; then green "PASS: Lease held by $HOLDER (routable identity)"; PASS=$((PASS+1))
+else red "FAIL: Lease holder '$HOLDER' lacks the routable <pod>_<ip> identity"; FAIL=$((FAIL+1)); fi
 
 # Failover: delete the leader; a standby must acquire the Lease.
-kubectl -n "$NS" delete pod "$HOLDER" --wait=false >/dev/null 2>&1 || true
+kubectl -n "$NS" delete pod "$HOLDER_POD" --wait=false >/dev/null 2>&1 || true
 NEW=""
 for _ in $(seq 1 30); do
   NEW=$(kubectl -n "$NS" get lease runlore-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)
@@ -435,12 +441,12 @@ for _ in $(seq 1 30); do
   TOTAL=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore --no-headers 2>/dev/null | wc -l | tr -d ' ')
   READY=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore \
     -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c True || true)
-  [[ "$TOTAL" == "2" && "$READY" == "1" ]] && break
+  [[ "$TOTAL" == "2" && "$READY" == "2" ]] && break
   sleep 2
 done
-if [[ "$TOTAL" == "2" && "$READY" == "1" ]]; then
-  green "PASS: StatefulSet — 2 replicas, exactly 1 Ready (leader)"; PASS=$((PASS+1))
-else red "FAIL: StatefulSet replicas=$TOTAL ready=$READY (want 2 / 1)"; FAIL=$((FAIL+1)); fi
+if [[ "$TOTAL" == "2" && "$READY" == "2" ]]; then
+  green "PASS: StatefulSet — 2 replicas, BOTH Ready (readiness decoupled from leadership)"; PASS=$((PASS+1))
+else red "FAIL: StatefulSet replicas=$TOTAL ready=$READY (want 2 / 2)"; FAIL=$((FAIL+1)); fi
 
 BOUND=$(kubectl -n "$NS" get pvc -l app.kubernetes.io/name=runlore -o jsonpath='{range .items[*]}{.status.phase}{"\n"}{end}' 2>/dev/null | grep -c Bound || true)
 PVC_COUNT=$(kubectl -n "$NS" get pvc -l app.kubernetes.io/name=runlore --no-headers 2>/dev/null | wc -l | tr -d ' ')
@@ -468,29 +474,33 @@ else red "FAIL: pvcs=$PVC_COUNT bound=$BOUND (want 2 / 2)"; FAIL=$((FAIL+1)); fi
 # a fresh "acquired leadership" log line after the deletion — inside the SAME loop,
 # not as a separate check after breaking out early on a superficial ready-count.
 SS_HOLDER=$(kubectl -n "$NS" get lease runlore-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)
+SS_HOLDER_POD=${SS_HOLDER%%_*}   # identity is <podName>_<podIP> (#264)
 DELETE_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-kubectl -n "$NS" delete pod "$SS_HOLDER" --wait=false >/dev/null 2>&1 || true
+kubectl -n "$NS" delete pod "$SS_HOLDER_POD" --wait=false >/dev/null 2>&1 || true
 TOTAL=0; READY=0; NEW_LEADER=""; REACQUIRED=0
 for _ in $(seq 1 60); do
   TOTAL=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore --no-headers 2>/dev/null | wc -l | tr -d ' ')
   READY=$(kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore \
     -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c True || true)
   NEW_LEADER=$(kubectl -n "$NS" get lease runlore-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)
+  NEW_LEADER_POD=${NEW_LEADER%%_*}   # identity is <podName>_<podIP> (#264)
   REACQUIRED=0
-  if [[ -n "$NEW_LEADER" ]]; then
-    REACQUIRED=$(kubectl -n "$NS" logs "$NEW_LEADER" --since-time="$DELETE_AT" 2>/dev/null | grep -c "acquired leadership" || true)
+  if [[ -n "$NEW_LEADER_POD" ]]; then
+    REACQUIRED=$(kubectl -n "$NS" logs "$NEW_LEADER_POD" --since-time="$DELETE_AT" 2>/dev/null | grep -c "acquired leadership" || true)
   fi
-  [[ "$TOTAL" == "2" && "$READY" == "1" && "$REACQUIRED" -gt 0 ]] && break
+  # Post-recovery steady state is BOTH pods Ready again (#264) + a fresh
+  # acquisition logged after the deletion timestamp (the authoritative proof).
+  [[ "$TOTAL" == "2" && "$READY" == "2" && "$REACQUIRED" -gt 0 ]] && break
   sleep 2
 done
-if [[ "$TOTAL" == "2" && "$READY" == "1" && -n "$NEW_LEADER" && "$REACQUIRED" -gt 0 ]]; then
+if [[ "$TOTAL" == "2" && "$READY" == "2" && -n "$NEW_LEADER" && "$REACQUIRED" -gt 0 ]]; then
   green "PASS: StatefulSet failover — $NEW_LEADER logged a fresh acquisition after deletion"; PASS=$((PASS+1))
 else
   red "FAIL: StatefulSet failover (replicas=$TOTAL ready=$READY leader='$NEW_LEADER' fresh_acquisitions=$REACQUIRED)"
   FAIL=$((FAIL+1))
   echo "--- diagnostics: lease object ---"; kubectl -n "$NS" get lease runlore-leader -o yaml 2>&1
   echo "--- diagnostics: pods ---"; kubectl -n "$NS" get pods -l app.kubernetes.io/name=runlore -o wide 2>&1
-  [[ -n "$NEW_LEADER" ]] && { echo "--- diagnostics: $NEW_LEADER logs ---"; kubectl -n "$NS" logs "$NEW_LEADER" --tail=40 2>&1; }
+  [[ -n "$NEW_LEADER_POD" ]] && { echo "--- diagnostics: $NEW_LEADER_POD logs ---"; kubectl -n "$NS" logs "$NEW_LEADER_POD" --tail=40 2>&1; }
 fi
 
 # Revert to Deployment mode / replicaCount=1: step 11 below assumes `deploy/runlore`.

--- a/internal/app/leader_identity.go
+++ b/internal/app/leader_identity.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"net"
+	"strings"
+	"sync/atomic"
+)
+
+// Lease identity format (#264): "<podName>_<podIP>". Encoding the pod IP into
+// the leader-election Lease identity makes the holder ROUTABLE: a non-leader
+// replica that receives a work-bearing request (webhook, slack interaction,
+// action control) learns the leader's address from the Lease it already
+// watches (OnNewLeader) and proxies the request there — which is what lets
+// /readyz stop reflecting leadership without giving up "only the leader's
+// queue processes work".
+//
+// "_" is a safe separator because pod names are DNS-1123 subdomains (lowercase
+// alphanumerics, '-' and '.') — an underscore can never appear in a pod name.
+// IPv6 pod IPs contain ':' but never '_', so the encoding stays unambiguous.
+
+// EncodeLeaseIdentity builds the routable lease identity. With no (or an
+// invalid) pod IP it degrades to the bare name — the pre-#264 format — so a
+// misconfigured POD_IP never publishes a dial target that cannot work.
+func EncodeLeaseIdentity(podName, podIP string) string {
+	if podIP == "" || net.ParseIP(podIP) == nil {
+		return podName
+	}
+	return podName + "_" + podIP
+}
+
+// ParseLeaseIdentity splits a lease holder identity into name and IP. It is
+// deliberately defensive: an OLD-format identity (no "_", from a pre-#264
+// replica during a mixed-version rollout) or a suffix that is not a valid IP
+// yields ip == "" — forwarding is then unavailable and callers shed with
+// 503 + Retry-After instead of dialing garbage.
+func ParseLeaseIdentity(id string) (name, ip string) {
+	i := strings.LastIndex(id, "_")
+	if i < 0 {
+		return id, ""
+	}
+	if net.ParseIP(id[i+1:]) == nil {
+		return id, ""
+	}
+	return id[:i], id[i+1:]
+}
+
+// LeaderTracker atomically tracks the current lease holder identity as
+// reported by the leader-election OnNewLeader callback, so a follower can
+// route work-bearing requests to the leader. Safe for concurrent use: the
+// election goroutine writes, every request-serving goroutine reads.
+//
+// The view can be briefly stale (the holder just died and no successor has
+// renewed yet) — the forwarding layer treats a failed dial as "retry shortly"
+// (502 + Retry-After) rather than trusting the tracker blindly.
+type LeaderTracker struct {
+	v atomic.Value // string: the raw holder identity
+}
+
+// Set records the observed holder identity (called from OnNewLeader).
+func (t *LeaderTracker) Set(identity string) { t.v.Store(identity) }
+
+// Identity returns the last observed holder identity ("" before the first
+// OnNewLeader callback).
+func (t *LeaderTracker) Identity() string {
+	s, _ := t.v.Load().(string)
+	return s
+}
+
+// Addr returns "ip:port" (IPv6 bracketed) for the current holder on the given
+// serve port — every replica serves on the same port, so the follower's own
+// port is the leader's too. It returns "" when no holder is known, the
+// holder's identity carries no routable IP (old format), or port is empty.
+func (t *LeaderTracker) Addr(port string) string {
+	if port == "" {
+		return ""
+	}
+	_, ip := ParseLeaseIdentity(t.Identity())
+	if ip == "" {
+		return ""
+	}
+	return net.JoinHostPort(ip, port)
+}
+
+// ServePort extracts the port from a listen address (":8080", "0.0.0.0:8080").
+// "" when the address does not parse — the forwarding layer then reports no
+// routable leader instead of building a broken URL.
+func ServePort(addr string) string {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return ""
+	}
+	return port
+}

--- a/internal/app/leader_identity_test.go
+++ b/internal/app/leader_identity_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import "testing"
+
+func TestEncodeLeaseIdentity(t *testing.T) {
+	tests := []struct {
+		name, podName, podIP, want string
+	}{
+		{"name plus ip", "runlore-abc12", "10.1.2.3", "runlore-abc12_10.1.2.3"},
+		{"no ip falls back to name-only (old format)", "runlore-abc12", "", "runlore-abc12"},
+		// Never publish an unroutable identity: garbage in POD_IP must not
+		// produce an identity followers would try (and fail) to dial.
+		{"invalid ip falls back to name-only", "runlore-abc12", "not-an-ip", "runlore-abc12"},
+		{"ipv6", "runlore-0", "fd00::1", "runlore-0_fd00::1"},
+	}
+	for _, tt := range tests {
+		if got := EncodeLeaseIdentity(tt.podName, tt.podIP); got != tt.want {
+			t.Errorf("%s: EncodeLeaseIdentity(%q, %q) = %q, want %q", tt.name, tt.podName, tt.podIP, got, tt.want)
+		}
+	}
+}
+
+func TestParseLeaseIdentity(t *testing.T) {
+	tests := []struct {
+		name, id, wantName, wantIP string
+	}{
+		{"new format", "runlore-abc12_10.1.2.3", "runlore-abc12", "10.1.2.3"},
+		{"ipv6", "runlore-0_fd00::1", "runlore-0", "fd00::1"},
+		// OLD-format identity (pre-#264 replica during a mixed-version rollout):
+		// no IP ⇒ forwarding unavailable ⇒ callers behave as before (503 + retry).
+		{"old format name-only", "runlore-abc12", "runlore-abc12", ""},
+		// Defensive: a suffix that isn't a valid IP is NOT split off — the whole
+		// string is the name, and no bogus dial target is ever produced.
+		{"underscore but invalid ip", "pod_notanip", "pod_notanip", ""},
+		{"empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		name, ip := ParseLeaseIdentity(tt.id)
+		if name != tt.wantName || ip != tt.wantIP {
+			t.Errorf("%s: ParseLeaseIdentity(%q) = (%q, %q), want (%q, %q)",
+				tt.name, tt.id, name, ip, tt.wantName, tt.wantIP)
+		}
+	}
+}
+
+func TestLeaderTrackerAddr(t *testing.T) {
+	var tr LeaderTracker
+	// No holder observed yet: nothing to route to.
+	if got := tr.Addr("8080"); got != "" {
+		t.Errorf("empty tracker Addr = %q, want \"\"", got)
+	}
+	// Old-format holder (no IP): forwarding unavailable, not a bogus address.
+	tr.Set("runlore-old")
+	if got := tr.Addr("8080"); got != "" {
+		t.Errorf("old-format holder Addr = %q, want \"\"", got)
+	}
+	tr.Set("runlore-abc12_10.1.2.3")
+	if got := tr.Addr("8080"); got != "10.1.2.3:8080" {
+		t.Errorf("Addr = %q, want 10.1.2.3:8080", got)
+	}
+	// IPv6 must be bracketed for use as a URL host.
+	tr.Set("runlore-0_fd00::1")
+	if got := tr.Addr("8080"); got != "[fd00::1]:8080" {
+		t.Errorf("ipv6 Addr = %q, want [fd00::1]:8080", got)
+	}
+	// Defensive: without a port there is no routable address.
+	if got := tr.Addr(""); got != "" {
+		t.Errorf("empty-port Addr = %q, want \"\"", got)
+	}
+}
+
+func TestServePort(t *testing.T) {
+	tests := []struct{ addr, want string }{
+		{":8080", "8080"},
+		{"0.0.0.0:9090", "9090"},
+		{"not-an-addr", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := ServePort(tt.addr); got != tt.want {
+			t.Errorf("ServePort(%q) = %q, want %q", tt.addr, got, tt.want)
+		}
+	}
+}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -18,6 +18,14 @@ func PodName() string {
 	return h
 }
 
+// PodIP returns this pod's IP from the downward API (POD_IP, set by the chart).
+// Empty outside Kubernetes or on a chart that predates #264 — the lease
+// identity then degrades to the name-only format and leader forwarding is
+// unavailable (followers answer 503 + Retry-After instead of proxying).
+func PodIP() string {
+	return os.Getenv("POD_IP")
+}
+
 // PodNamespace resolves the namespace from the downward API or the service-account mount.
 func PodNamespace() string {
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
@@ -31,20 +39,29 @@ func PodNamespace() string {
 	return "default"
 }
 
-// ReadyFunc gates readiness on leadership AND a warm catalog. When a catalog is
-// configured, the leader must NOT advertise ready until its knowledge base is
-// loaded and warm — otherwise it would serve incident traffic blind. This
+// ReadyFunc gates readiness on process + catalog health — and deliberately NOT
+// on leadership (#264). Readiness used to also require holding the leader
+// Lease, which kept every standby replica permanently NotReady: with
+// replicaCount>1, `helm upgrade --wait` / kstatus (Flux helm-controller) could
+// never observe the release Ready and timed out on every upgrade. Every warm
+// replica now reports Ready; "only the leader processes work" is preserved by
+// the forwarding layer instead (server.Forward proxies work-bearing requests
+// from followers to the leader learned from the Lease).
+//
+// The catalog gate stays: a replica must NOT advertise ready until its
+// knowledge base is loaded and warm — otherwise it would serve incident
+// traffic blind (and, as a follower, could be promoted to leader cold). This
 // distinguishes the two ways BuildCatalog returns a nil catalog:
 //
 //   - configured but the load failed (configured=true, cat=nil): stay 503. A
 //     static catalog has no syncer to recover, so the pod stays not-ready and the
 //     misconfiguration surfaces loudly instead of silently serving with no KB.
 //   - not configured at all (configured=false, cat=nil): no catalog gate;
-//     readiness is pure leadership.
+//     the replica is ready as soon as it serves.
 //
 // A configured-but-not-yet-warm catalog (git-sync NewEmpty, cat!=nil &&
 // !Ready()) is also held at 503 until its first successful sync.
-func ReadyFunc(leader func() bool, cat *catalog.Catalog, configured bool) func() bool {
+func ReadyFunc(cat *catalog.Catalog, configured bool) func() bool {
 	return func() bool {
 		if configured && (cat == nil || !cat.Ready()) {
 			return false
@@ -52,6 +69,6 @@ func ReadyFunc(leader func() bool, cat *catalog.Catalog, configured bool) func()
 		if cat != nil && !cat.Ready() {
 			return false
 		}
-		return leader()
+		return true
 	}
 }

--- a/internal/app/runtime_test.go
+++ b/internal/app/runtime_test.go
@@ -8,41 +8,47 @@ import (
 	"github.com/Smana/runlore/internal/catalog"
 )
 
+// TestReadyFunc pins the #264 readiness model: /readyz is process + catalog
+// health ONLY — leadership is deliberately NOT an input. Before #264 readiness
+// also required holding the leader Lease, which kept every standby replica
+// permanently NotReady, so `helm upgrade --wait` / kstatus (Flux
+// helm-controller) could never see a replicaCount>1 release become Ready and
+// timed out on every upgrade. Leader/follower is now a routing concern
+// (server.Forward proxies work-bearing requests to the leader), not a
+// readiness concern.
 func TestReadyFunc(t *testing.T) {
-	leaderTrue := func() bool { return true }
-	leaderFalse := func() bool { return false }
-
-	// No catalog configured → gate is pure leadership passthrough.
-	if !ReadyFunc(leaderTrue, nil, false)() {
-		t.Fatal("unconfigured + nil catalog + leader=true should be ready")
-	}
-	if ReadyFunc(leaderFalse, nil, false)() {
-		t.Fatal("unconfigured + nil catalog + leader=false should not be ready")
+	// No catalog configured → always ready (leader AND follower alike).
+	if !ReadyFunc(nil, false)() {
+		t.Fatal("unconfigured + nil catalog should be ready")
 	}
 
-	// A catalog was CONFIGURED but failed to load (cat == nil). Never serve incident
-	// traffic with no knowledge base: stay 503 even while leader. This is the bug —
-	// a configured-but-failed catalog used to be indistinguishable from "unconfigured"
-	// and collapsed readiness to pure leadership.
-	if ReadyFunc(leaderTrue, nil, true)() {
-		t.Fatal("configured + failed-to-load catalog (nil) must block readiness even when leader=true")
+	// A catalog was CONFIGURED but failed to load (cat == nil). Never serve
+	// incident traffic with no knowledge base: stay 503. A static catalog has no
+	// syncer to recover, so the misconfiguration must surface loudly.
+	if ReadyFunc(nil, true)() {
+		t.Fatal("configured + failed-to-load catalog (nil) must block readiness")
 	}
 
-	// A not-yet-warm configured catalog blocks readiness even when leader.
+	// A not-yet-warm catalog blocks readiness — on every replica: each replica
+	// syncs/indexes its own catalog copy and must be warm before it can either
+	// investigate (leader) or take over on failover (follower).
 	cold := catalog.NewEmpty()
-	if ReadyFunc(leaderTrue, cold, true)() {
-		t.Fatal("cold catalog must block readiness even when leader=true")
+	if ReadyFunc(cold, true)() {
+		t.Fatal("cold configured catalog must block readiness")
+	}
+	if ReadyFunc(cold, false)() {
+		t.Fatal("cold catalog must block readiness even when not gate-configured")
 	}
 
-	// A warm catalog is ready only when also leader.
+	// A warm catalog is ready — with no leadership condition attached.
 	warm, err := catalog.New(t.TempDir())
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	if !ReadyFunc(leaderTrue, warm, true)() {
-		t.Fatal("warm catalog + leader=true should be ready")
+	if !ReadyFunc(warm, true)() {
+		t.Fatal("warm catalog should be ready")
 	}
-	if ReadyFunc(leaderFalse, warm, true)() {
-		t.Fatal("warm catalog + leader=false should not be ready")
+	if !ReadyFunc(warm, false)() {
+		t.Fatal("warm catalog should be ready regardless of the configured flag")
 	}
 }

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -303,11 +303,15 @@ func RunServe(version string, args []string) error {
 	}
 
 	var leader atomic.Bool
+	// tracker learns the current lease holder from OnNewLeader; combined with the
+	// routable identity (<podName>_<podIP>, #264) it gives a follower the
+	// leader's address so incoming work can be proxied there.
+	tracker := &LeaderTracker{}
 	useLE := cfg.LeaderElection.Enabled && clientset != nil
 	if useLE {
-		go RunLeaderElection(workCtx, cfg, clientset, &leader, log, startWork)
+		go RunLeaderElection(workCtx, cfg, clientset, &leader, tracker, log, startWork)
 	} else {
-		leader.Store(true) // no leader election: this replica is always active + ready
+		leader.Store(true) // no leader election: this replica is always active
 		startWork(workCtx)
 	}
 
@@ -319,7 +323,6 @@ func RunServe(version string, args []string) error {
 		}
 	}
 
-	// readyz reflects leadership so the Service routes webhooks only to the leader.
 	acts := server.Actions{
 		Approvals:    approvals,
 		Token:        approvalToken,
@@ -338,7 +341,20 @@ func RunServe(version string, args []string) error {
 		acts.Feedback = ledger
 		log.Info("slack feedback buttons enabled", "endpoint", "/slack/interactions")
 	}
-	srv := server.New(ReadyFunc(leader.Load, cat, CatalogExpected(cfg)), acts, built, pipe, metricsHandler, log)
+	// /readyz is process + catalog health, NOT leadership (#264): every warm
+	// replica reports Ready (so `helm upgrade --wait` / Flux kstatus succeeds
+	// with replicaCount>1) and the Service may route a webhook to any of them —
+	// a follower then proxies work-bearing requests to the leader via fwd. The
+	// leader's address comes from the lease identity on this same serve port;
+	// an old-format identity (no IP, pre-#264 holder during a mixed-version
+	// rollout) yields no address and the follower sheds with 503 + Retry-After.
+	port := ServePort(*addr)
+	fwd := &server.Forward{
+		IsLeader:   leader.Load, // pinned true when leader election is disabled
+		LeaderAddr: func() string { return tracker.Addr(port) },
+		Log:        log,
+	}
+	srv := server.New(ReadyFunc(cat, CatalogExpected(cfg)), acts, built, pipe, metricsHandler, fwd, log)
 	if cz != nil {
 		go cz.Run(workCtx, cfg.Investigation.Coalesce.Debounce.Std()/2)
 	}

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -48,18 +48,24 @@ var (
 )
 
 // RunLeaderElection blocks running Lease-based leader election; the leader runs
-// startWork and reports ready. Lost leadership cancels the work context and the
-// replica REJOINS the election as a standby: client-go's RunOrDie returns when
-// the lease is lost without the process dying (e.g. an API-server blip past
-// RenewDeadline), and without the re-entry loop the replica would never contend
-// again — a permanent zombie standby that /healthz keeps reporting alive,
-// silently shrinking the HA pool until no replica leads at all.
-func RunLeaderElection(ctx context.Context, cfg *config.Config, cs kubernetes.Interface, leader *atomic.Bool, log *slog.Logger, startWork func(context.Context)) {
+// startWork. Lost leadership cancels the work context and the replica REJOINS
+// the election as a standby: client-go's RunOrDie returns when the lease is
+// lost without the process dying (e.g. an API-server blip past RenewDeadline),
+// and without the re-entry loop the replica would never contend again — a
+// permanent zombie standby that /healthz keeps reporting alive, silently
+// shrinking the HA pool until no replica leads at all.
+//
+// The lease identity is "<podName>_<podIP>" (#264): every replica learns the
+// holder through OnNewLeader and records it in tracker, so a follower can
+// PROXY incoming work-bearing requests to the leader (server.Forward) —
+// /readyz no longer reflects leadership, so the Service routes to any warm
+// replica. tracker may be nil (no forwarding wired, e.g. tests).
+func RunLeaderElection(ctx context.Context, cfg *config.Config, cs kubernetes.Interface, leader *atomic.Bool, tracker *LeaderTracker, log *slog.Logger, startWork func(context.Context)) {
 	name := cfg.LeaderElection.Name
 	if name == "" {
 		name = "runlore-leader"
 	}
-	id := PodName()
+	id := EncodeLeaseIdentity(PodName(), PodIP())
 	lock := &resourcelock.LeaseLock{
 		LeaseMeta:  metav1.ObjectMeta{Name: name, Namespace: PodNamespace()},
 		Client:     cs.CoordinationV1(),
@@ -86,6 +92,13 @@ func RunLeaderElection(ctx context.Context, cfg *config.Config, cs kubernetes.In
 					leader.Store(false)
 				},
 				OnNewLeader: func(current string) {
+					// Record the holder FIRST so forwarding has a target as
+					// early as possible; the callback also fires on the leader
+					// itself (current == id), which is harmless — the leader
+					// serves locally and never consults the tracker.
+					if tracker != nil {
+						tracker.Set(current)
+					}
 					if current != id {
 						log.Info("standby; another replica leads", "leader", current)
 					}

--- a/internal/app/server_test.go
+++ b/internal/app/server_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
@@ -56,6 +57,7 @@ func TestRunLeaderElectionRejoinsAfterLoss(t *testing.T) {
 
 	t.Setenv("POD_NAME", "replica-a")
 	t.Setenv("POD_NAMESPACE", "default")
+	t.Setenv("POD_IP", "10.9.8.7")
 	cs := fake.NewSimpleClientset()
 	// outage simulates an API-server blip: while set, every lease get/update
 	// fails, so the leader cannot renew within renewDeadline and drops the lease
@@ -74,13 +76,14 @@ func TestRunLeaderElectionRejoinsAfterLoss(t *testing.T) {
 	cfg.LeaderElection.Name = "test-leader"
 
 	var leader atomic.Bool
+	var tracker LeaderTracker
 	var terms atomic.Int32 // one startWork call per leadership term
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		RunLeaderElection(ctx, cfg, cs, &leader,
+		RunLeaderElection(ctx, cfg, cs, &leader, &tracker,
 			slog.New(slog.NewTextHandler(io.Discard, nil)),
 			func(context.Context) { terms.Add(1) })
 	}()
@@ -98,6 +101,20 @@ func TestRunLeaderElectionRejoinsAfterLoss(t *testing.T) {
 	}
 
 	waitFor("initial leadership", leader.Load)
+
+	// #264: the lease identity must be ROUTABLE — <podName>_<podIP> — so a
+	// follower can proxy work-bearing requests to the holder. Assert both the
+	// written Lease and the OnNewLeader-fed tracker expose it.
+	lease, err := cs.CoordinationV1().Leases("default").Get(ctx, "test-leader", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get lease: %v", err)
+	}
+	if got := *lease.Spec.HolderIdentity; got != "replica-a_10.9.8.7" {
+		t.Errorf("lease holder identity = %q, want replica-a_10.9.8.7", got)
+	}
+	waitFor("tracker learned the routable holder", func() bool {
+		return tracker.Addr("8080") == "10.9.8.7:8080"
+	})
 
 	// Blip the API server for longer than renewDeadline: the replica must drop
 	// leadership (it cannot renew), but the process stays alive.

--- a/internal/investigate/redact_approvals_test.go
+++ b/internal/investigate/redact_approvals_test.go
@@ -94,7 +94,7 @@ func TestApprovalQueueServesRedactedActions(t *testing.T) {
 
 	// And the HTTP surface: GET /actions serves the queue as JSON to a
 	// token-holding caller — the body must not contain the secret either.
-	srv := server.New(nil, server.Actions{Approvals: approvals, Token: "tok"}, nil, nil, nil, discard)
+	srv := server.New(nil, server.Actions{Approvals: approvals, Token: "tok"}, nil, nil, nil, nil, discard)
 	req := httptest.NewRequest(http.MethodGet, "/actions", nil)
 	req.Header.Set("X-Approval-Token", "tok")
 	rr := httptest.NewRecorder()

--- a/internal/server/forward.go
+++ b/internal/server/forward.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+)
+
+// ForwardedHeader marks a request a follower has already proxied once to the
+// replica it believed was the leader. A request carrying it is NEVER forwarded
+// again: if the receiver isn't the leader either (a stale holder view during a
+// failover, or two followers briefly pointing at each other), it answers 421
+// instead of hopping on — forwarding is strictly single-hop, loops are
+// structurally impossible.
+const ForwardedHeader = "X-Runlore-Forwarded"
+
+const (
+	// forwardBodyCap bounds a forwarded request body to the same 1 MiB every
+	// local work handler enforces (webhook body cap, slack-interaction cap) —
+	// the proxy hop must not become the way around the intake bound.
+	forwardBodyCap = 1 << 20
+	// forwardTimeout bounds the proxied round trip. Kept under the serving
+	// WriteTimeout (30s, NewHTTPServer) so a follower stuck on a slow leader
+	// still answers its own client instead of having the connection cut.
+	forwardTimeout = 25 * time.Second
+	// forwardRetryAfter is the Retry-After hint (seconds) on 502/503 answers:
+	// a leader handoff settles within the lease window (15s lease / 2s retry),
+	// so a short client retry usually lands on an elected leader.
+	forwardRetryAfter = "5"
+)
+
+// hopHeaders are the hop-by-hop headers (RFC 9110 §7.6.1) a proxy must not
+// pass along; everything else — notably Authorization and the Slack/PagerDuty
+// signature headers — is preserved so the leader authenticates the forwarded
+// request exactly as if it had arrived there directly.
+var hopHeaders = []string{
+	"Connection", "Proxy-Connection", "Keep-Alive", "Proxy-Authenticate",
+	"Proxy-Authorization", "Te", "Trailer", "Transfer-Encoding", "Upgrade",
+}
+
+// Forward routes work-bearing requests from a non-leader replica to the
+// current leader. Since #264 /readyz no longer reflects leadership — every
+// warm replica is Ready and the Service may route to any of them — so "only
+// the leader's queue processes work" is preserved here instead of by
+// readiness-based routing: a follower that receives a work-bearing request
+// (source webhooks, slack interactions, action control) proxies it to the
+// leader it learned from the leader-election Lease. A nil *Forward (CLI,
+// tests, single-replica without leader election) serves everything locally.
+type Forward struct {
+	// IsLeader reports whether THIS replica currently leads. With leader
+	// election disabled the caller pins it true, so everything serves locally.
+	IsLeader func() bool
+	// LeaderAddr returns the "host:port" of the current lease holder, or ""
+	// when no holder is known yet or the holder's identity carries no routable
+	// IP (an old-format identity from a pre-#264 replica during a
+	// mixed-version rollout) — the request is then shed with 503 + Retry-After,
+	// matching the pre-#264 behavior of a standby that received traffic.
+	LeaderAddr func() string
+	// Client posts the proxied request. nil defaults to a bounded
+	// httpx.SecureClient — never http.DefaultClient (unbounded hang).
+	Client *http.Client
+	Log    *slog.Logger
+}
+
+// middleware wraps a work-bearing handler with the leader/follower routing
+// decision. Nil-receiver safe: with no Forward configured the handler serves
+// locally, exactly the pre-#264 behavior. Local-only endpoints (/healthz,
+// /readyz, /metrics) are deliberately NOT wrapped by the caller — probes and
+// scrapes are always about THIS replica.
+func (f *Forward) middleware(next http.Handler) http.Handler {
+	if f == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if f.IsLeader != nil && f.IsLeader() {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.Header.Get(ForwardedHeader) != "" {
+			// Already proxied once and this replica STILL isn't the leader:
+			// the sender's holder view is stale (mid-failover). 421 instead of
+			// re-forwarding keeps routing single-hop and loop-free; the
+			// original sender retries against the Service and lands on the
+			// settled leader.
+			http.Error(w, "not the leader (request already forwarded once)", http.StatusMisdirectedRequest)
+			return
+		}
+		addr := ""
+		if f.LeaderAddr != nil {
+			addr = f.LeaderAddr()
+		}
+		if addr == "" {
+			// No routable leader: none elected yet, or the holder runs a
+			// pre-#264 build whose lease identity has no IP. Shed with a retry
+			// hint — every work-bearing sender (Alertmanager, PagerDuty,
+			// Slack) retries on 5xx.
+			w.Header().Set("Retry-After", forwardRetryAfter)
+			http.Error(w, "no leader known; retry", http.StatusServiceUnavailable)
+			return
+		}
+		f.proxy(w, r, addr)
+	})
+}
+
+// proxy relays r to the leader at addr (plain http: pod-to-pod inside the
+// cluster on the shared serve port) and copies the response back verbatim.
+func (f *Forward) proxy(w http.ResponseWriter, r *http.Request, addr string) {
+	// Read the body up front, bounded like local handling, so the proxied
+	// request carries a Content-Length and an oversized payload surfaces as a
+	// clean 413 here instead of a mid-stream break on the leader.
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, forwardBodyCap))
+	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			http.Error(w, "payload too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	u := *r.URL
+	u.Scheme = "http"
+	u.Host = addr
+	// gosec G704 (SSRF) is a false positive here: this is a deliberate reverse
+	// proxy whose DESTINATION is never request-controlled — addr comes from the
+	// leader-election Lease identity (a net.ParseIP-validated pod IP, written
+	// via authenticated API-server access) plus this replica's own serve port.
+	// Only the path/query are relayed, which is the entire point of forwarding.
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, u.String(), bytes.NewReader(body)) //nolint:gosec // G704: fixed in-cluster host from the Lease, see above
+	if err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	// Preserve every end-to-end header: the bearer token and the Slack /
+	// PagerDuty HMAC signatures (computed over the byte-identical body relayed
+	// above) must verify on the leader exactly as they would have locally.
+	req.Header = r.Header.Clone()
+	for _, h := range hopHeaders {
+		req.Header.Del(h)
+	}
+	req.Header.Set(ForwardedHeader, "1")
+	client := f.Client
+	if client == nil {
+		client = httpx.SecureClient(forwardTimeout)
+	}
+	resp, err := client.Do(req) //nolint:gosec // G704: same request as above — leader-only destination, never request-controlled
+	if err != nil {
+		// The holder view can be briefly stale (the leader just died and the
+		// tracker hasn't observed a successor yet): fail fast with a retry
+		// hint rather than queueing leader-only work on a follower.
+		if f.Log != nil {
+			f.Log.Warn("leader forward failed", "leader", addr,
+				"method", r.Method, "path", r.URL.Path, "err", err)
+		}
+		w.Header().Set("Retry-After", forwardRetryAfter)
+		http.Error(w, "leader unreachable; retry", http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if f.Log != nil {
+		f.Log.Debug("forwarded to leader", "leader", addr,
+			"method", r.Method, "path", r.URL.Path, "status", resp.StatusCode)
+	}
+	hdr := w.Header()
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			hdr.Add(k, v)
+		}
+	}
+	for _, h := range hopHeaders {
+		hdr.Del(h)
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}

--- a/internal/server/forward_test.go
+++ b/internal/server/forward_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/source"
+	"gopkg.in/yaml.v3"
+)
+
+// alertBody is a minimal firing alert that passes the severity=critical trigger
+// policy, so a locally-served webhook actually enqueues (proving "served here").
+const alertBody = `{"alerts":[{"status":"firing","labels":{"alertname":"A","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"fp1"}]}`
+
+// recordedReq captures what the fake leader received, so tests can assert the
+// proxied request preserved method/path/query/headers/body.
+type recordedReq struct {
+	method, path, query, body string
+	header                    http.Header
+}
+
+// fakeLeader is an httptest server standing in for the leader replica. It
+// records every request and answers a recognizable status + body + header so
+// the follower's passthrough of the leader's response is observable.
+type fakeLeader struct {
+	srv *httptest.Server
+	mu  sync.Mutex
+	got []recordedReq
+}
+
+func newFakeLeader(t *testing.T) *fakeLeader {
+	t.Helper()
+	fl := &fakeLeader{}
+	fl.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		fl.mu.Lock()
+		fl.got = append(fl.got, recordedReq{
+			method: r.Method, path: r.URL.Path, query: r.URL.RawQuery,
+			body: string(b), header: r.Header.Clone(),
+		})
+		fl.mu.Unlock()
+		w.Header().Set("X-Answered-By", "leader")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("accepted-by-leader"))
+	}))
+	t.Cleanup(fl.srv.Close)
+	return fl
+}
+
+func (fl *fakeLeader) addr() string { return fl.srv.Listener.Addr().String() }
+
+func (fl *fakeLeader) requests() []recordedReq {
+	fl.mu.Lock()
+	defer fl.mu.Unlock()
+	return append([]recordedReq(nil), fl.got...)
+}
+
+// newForwardServer builds a full Server (alertmanager webhook mounted, metrics
+// stub wired) with the given Forward — the follower/leader under test.
+func newForwardServer(t *testing.T, fwd *Forward, enq investigate.Enqueuer) *Server {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Sources = map[string]yaml.Node{"alertmanager": {}}
+	cfg.Triggers.Incidents = config.IncidentTrigger{
+		Match: config.IncidentMatch{Severity: []string{"critical"}},
+	}
+	built, err := source.BuildEnabled(source.Deps{Cfg: cfg, Raw: cfg.Sources})
+	if err != nil {
+		t.Fatalf("build sources: %v", err)
+	}
+	pipe := source.NewPipeline(cfg, enq, nil, discardLog)
+	metrics := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("metrics-of-this-replica"))
+	})
+	return New(nil, Actions{}, built, pipe, metrics, fwd, discardLog)
+}
+
+func follower(addr func() string) *Forward {
+	return &Forward{IsLeader: func() bool { return false }, LeaderAddr: addr, Log: discardLog}
+}
+
+// TestForwardFollowerProxiesToLeader is the core #264 behavior: a non-leader
+// replica that receives a work-bearing request proxies it — method, path,
+// query, headers, and byte-identical body — to the leader, marks the hop with
+// X-Runlore-Forwarded, and relays the leader's response verbatim.
+func TestForwardFollowerProxiesToLeader(t *testing.T) {
+	leader := newFakeLeader(t)
+	enq := &spyEnqueuer{}
+	srv := newForwardServer(t, follower(leader.addr), enq)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/alertmanager?src=am", strings.NewReader(alertBody))
+	req.Header.Set("Authorization", "Bearer tok")
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("follower relayed status = %d, want 202", rr.Code)
+	}
+	if got := rr.Body.String(); got != "accepted-by-leader" {
+		t.Errorf("relayed body = %q, want the leader's body", got)
+	}
+	if got := rr.Header().Get("X-Answered-By"); got != "leader" {
+		t.Errorf("relayed header X-Answered-By = %q, want leader", got)
+	}
+	if len(enq.reqs) != 0 {
+		t.Errorf("follower enqueued locally (%d) — work must only run on the leader", len(enq.reqs))
+	}
+	got := leader.requests()
+	if len(got) != 1 {
+		t.Fatalf("leader received %d requests, want 1", len(got))
+	}
+	r := got[0]
+	if r.method != http.MethodPost || r.path != "/webhook/alertmanager" || r.query != "src=am" {
+		t.Errorf("proxied request = %s %s?%s, want POST /webhook/alertmanager?src=am", r.method, r.path, r.query)
+	}
+	if r.body != alertBody {
+		t.Errorf("proxied body not byte-identical:\n got %q\nwant %q", r.body, alertBody)
+	}
+	// Auth material must survive the hop: the leader verifies the bearer token /
+	// HMAC signatures exactly as if the request had arrived there directly.
+	if got := r.header.Get("Authorization"); got != "Bearer tok" {
+		t.Errorf("proxied Authorization = %q, want Bearer tok", got)
+	}
+	if got := r.header.Get(ForwardedHeader); got != "1" {
+		t.Errorf("proxied %s = %q, want 1 (single-hop marker)", ForwardedHeader, got)
+	}
+}
+
+// TestForwardActionRoutesProxied: the action control endpoints are work-bearing
+// (the approval queue and the auto kill-switch live in the leader process), so a
+// follower must proxy them too.
+func TestForwardActionRoutesProxied(t *testing.T) {
+	leader := newFakeLeader(t)
+	srv := newForwardServer(t, follower(leader.addr), &spyEnqueuer{})
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/actions", nil))
+	if rr.Code != http.StatusAccepted { // the fake leader answers 202 to everything
+		t.Fatalf("GET /actions on follower = %d, want the leader's 202", rr.Code)
+	}
+	got := leader.requests()
+	if len(got) != 1 || got[0].path != "/actions" {
+		t.Fatalf("leader saw %+v, want one GET /actions", got)
+	}
+}
+
+// TestForwardLoopHeaderRejected: forwarding is strictly single-hop. A request
+// that already carries the forwarded marker but lands on a non-leader (stale
+// holder view mid-failover) is answered 421 — never forwarded again, so two
+// followers can never bounce a request between each other.
+func TestForwardLoopHeaderRejected(t *testing.T) {
+	leader := newFakeLeader(t)
+	srv := newForwardServer(t, follower(leader.addr), &spyEnqueuer{})
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(alertBody))
+	req.Header.Set(ForwardedHeader, "1")
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("already-forwarded request on non-leader = %d, want 421", rr.Code)
+	}
+	if n := len(leader.requests()); n != 0 {
+		t.Errorf("leader was contacted %d time(s) for a loop-marked request, want 0", n)
+	}
+}
+
+// TestForwardUnknownLeader503: no holder known (none elected yet, or the holder
+// runs an old build whose lease identity carries no IP) → shed with 503 +
+// Retry-After. The webhook senders (Alertmanager, PagerDuty, Slack) retry.
+func TestForwardUnknownLeader503(t *testing.T) {
+	srv := newForwardServer(t, follower(func() string { return "" }), &spyEnqueuer{})
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(alertBody)))
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unknown leader = %d, want 503", rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Error("503 for unknown leader must carry Retry-After (senders retry)")
+	}
+}
+
+// TestForwardLeaderUnreachable502: the tracker can briefly point at a dead
+// leader (mid-failover). The proxy must fail fast with 502 + Retry-After, not
+// hang or serve the work locally on a non-leader.
+func TestForwardLeaderUnreachable502(t *testing.T) {
+	enq := &spyEnqueuer{}
+	// 127.0.0.1:1 — reserved port, connection refused immediately.
+	srv := newForwardServer(t, follower(func() string { return "127.0.0.1:1" }), enq)
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(alertBody)))
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("unreachable leader = %d, want 502", rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Error("502 for unreachable leader must carry Retry-After")
+	}
+	if len(enq.reqs) != 0 {
+		t.Error("follower served work locally when the leader was unreachable")
+	}
+}
+
+// TestForwardLeaderServesLocally: the leader (or a replica with leader election
+// disabled — same IsLeader()=true) never proxies; work runs in-process.
+func TestForwardLeaderServesLocally(t *testing.T) {
+	other := newFakeLeader(t) // would record if the leader wrongly proxied
+	enq := &spyEnqueuer{}
+	fwd := &Forward{IsLeader: func() bool { return true }, LeaderAddr: other.addr, Log: discardLog}
+	srv := newForwardServer(t, fwd, enq)
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(alertBody)))
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("leader local serve = %d, want 202", rr.Code)
+	}
+	if len(enq.reqs) != 1 {
+		t.Fatalf("leader enqueued %d locally, want 1", len(enq.reqs))
+	}
+	if n := len(other.requests()); n != 0 {
+		t.Errorf("leader proxied %d request(s), want 0", n)
+	}
+}
+
+// TestForwardLocalEndpointsNeverProxied: /healthz, /readyz, and /metrics are
+// about THIS replica (kubelet probes, Prometheus scrapes) — a follower must
+// answer them itself, never proxy them to the leader.
+func TestForwardLocalEndpointsNeverProxied(t *testing.T) {
+	leader := newFakeLeader(t)
+	srv := newForwardServer(t, follower(leader.addr), &spyEnqueuer{})
+
+	for _, path := range []string{"/healthz", "/readyz", "/metrics"} {
+		rr := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusOK {
+			t.Errorf("GET %s on follower = %d, want 200 (served locally)", path, rr.Code)
+		}
+		if rr.Header().Get("X-Answered-By") == "leader" {
+			t.Errorf("GET %s was proxied to the leader", path)
+		}
+	}
+	if got := len(leader.requests()); got != 0 {
+		t.Fatalf("leader received %d request(s) for local-only endpoints, want 0", got)
+	}
+}
+
+// TestForwardOversizedBodyRejected: the proxy bounds the forwarded body with
+// the same 1 MiB cap local handlers enforce — forwarding must not become the
+// way around the intake bound.
+func TestForwardOversizedBodyRejected(t *testing.T) {
+	leader := newFakeLeader(t)
+	srv := newForwardServer(t, follower(leader.addr), &spyEnqueuer{})
+
+	big := strings.NewReader(strings.Repeat("a", (1<<20)+1))
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", big))
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized forwarded body = %d, want 413", rr.Code)
+	}
+	if n := len(leader.requests()); n != 0 {
+		t.Errorf("oversized body reached the leader (%d request(s)), want 0", n)
+	}
+}
+
+// TestForwardNilServesLocally: no Forward configured (CLI paths, tests) —
+// everything serves locally, exactly the pre-#264 behavior.
+func TestForwardNilServesLocally(t *testing.T) {
+	enq := &spyEnqueuer{}
+	srv := newForwardServer(t, nil, enq)
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(alertBody)))
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("nil Forward = %d, want 202", rr.Code)
+	}
+	if len(enq.reqs) != 1 {
+		t.Fatalf("nil Forward enqueued %d, want 1 (local)", len(enq.reqs))
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,14 +71,19 @@ type Actions struct {
 }
 
 // New builds a Server. ready reports whether this replica should serve; nil =
-// always ready. The caller composes what readiness means (e.g. leadership AND a
-// warm catalog). acts (optional) enables the rung-2 approval endpoints + the
-// rung-3 kill-switch, gated by acts.Token (X-Approval-Token). /healthz is liveness;
-// /readyz is readiness (gated by the caller-supplied ready func). built + pipe wire
-// the registered event sources: webhook sources are mounted at their paths and feed
-// the ingest pipeline. metricsHandler (optional) serves OTel Prometheus metrics on
-// GET /metrics when non-nil.
-func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pipeline, metricsHandler http.Handler, log *slog.Logger) *Server {
+// always ready. The caller composes what readiness means (e.g. a warm catalog —
+// since #264 deliberately NOT leadership, so every warm replica is Ready and
+// Helm --wait/kstatus succeeds with replicaCount>1). acts (optional) enables the
+// rung-2 approval endpoints + the rung-3 kill-switch, gated by acts.Token
+// (X-Approval-Token). /healthz is liveness; /readyz is readiness (gated by the
+// caller-supplied ready func). built + pipe wire the registered event sources:
+// webhook sources are mounted at their paths and feed the ingest pipeline.
+// metricsHandler (optional) serves OTel Prometheus metrics on GET /metrics when
+// non-nil. fwd (optional) is the leader-forwarding policy: every WORK-BEARING
+// route (source webhooks, slack interactions, action control) goes through it
+// so a follower proxies the request to the leader; nil serves everything
+// locally.
+func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pipeline, metricsHandler http.Handler, fwd *Forward, log *slog.Logger) *Server {
 	approvers := make(map[string]bool, len(acts.ApproverIDs))
 	for _, id := range acts.ApproverIDs {
 		approvers[id] = true
@@ -90,7 +95,14 @@ func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pip
 		webhookToken: acts.WebhookToken, approvers: approvers, metrics: metricsHandler, log: log,
 	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /slack/interactions", s.handleSlackInteraction)
+	// work marks a route as work-bearing: on a follower the request is proxied
+	// to the leader (single hop, see Forward). Authentication happens on the
+	// leader — headers and body are relayed byte-identical, so the bearer token
+	// and HMAC signatures verify there exactly as they would here. The
+	// local-only endpoints below (/healthz, /readyz, /metrics) are NEVER
+	// wrapped: probes and scrapes are always about THIS replica.
+	work := fwd.middleware // nil-receiver safe: identity when fwd == nil
+	mux.Handle("POST /slack/interactions", work(http.HandlerFunc(s.handleSlackInteraction)))
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -101,15 +113,19 @@ func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pip
 		}
 		w.WriteHeader(http.StatusOK)
 	})
-	mux.HandleFunc("GET /actions", s.handleListActions)
-	mux.HandleFunc("POST /actions/{id}/approve", s.handleApprove)
-	mux.HandleFunc("POST /actions/{id}/reject", s.handleReject)
-	mux.HandleFunc("POST /actions/pause", s.handlePause)
-	mux.HandleFunc("POST /actions/resume", s.handleResume)
+	// The action-control endpoints are work-bearing too: the approval queue and
+	// the auto kill-switch live in the LEADER process (registered by its
+	// investigation loop), so a follower answering locally would list an empty
+	// queue or pause a pauser nothing consults.
+	mux.Handle("GET /actions", work(http.HandlerFunc(s.handleListActions)))
+	mux.Handle("POST /actions/{id}/approve", work(http.HandlerFunc(s.handleApprove)))
+	mux.Handle("POST /actions/{id}/reject", work(http.HandlerFunc(s.handleReject)))
+	mux.Handle("POST /actions/pause", work(http.HandlerFunc(s.handlePause)))
+	mux.Handle("POST /actions/resume", work(http.HandlerFunc(s.handleResume)))
 	if s.metrics != nil {
 		mux.Handle("GET /metrics", s.metrics)
 	}
-	source.MountWebhooks(mux, built, s.webhookAuthorized, pipe)
+	source.MountWebhooks(mux, built, s.webhookAuthorized, pipe, work)
 	// Wrap the whole mux so a panic in any handler (current or future) returns a
 	// structured 500 and a logged stack instead of net/http's silent connection drop.
 	s.handler = recoverPanic(mux, log)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -40,7 +40,7 @@ func newAlertServer(cfg *config.Config, enq investigate.Enqueuer, resolve source
 		panic(err)
 	}
 	pipe := source.NewPipeline(cfg, enq, resolve, discardLog)
-	return New(nil, Actions{}, built, pipe, nil, discardLog)
+	return New(nil, Actions{}, built, pipe, nil, nil, discardLog)
 }
 
 func slackSign(secret, ts, body string) string {
@@ -56,7 +56,7 @@ func TestSlackInteraction(t *testing.T) {
 	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "apps"}})
 
 	const secret = "shh"
-	srv := New(nil, Actions{Approvals: ap, SlackSecret: secret, ApproverIDs: []string{"U1"}}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{Approvals: ap, SlackSecret: secret, ApproverIDs: []string{"U1"}}, nil, nil, nil, nil, discardLog)
 
 	payload := `{"user":{"id":"U1","username":"alice"},"actions":[{"action_id":"runlore_approve","value":"` + id + `"}]}`
 	body := "payload=" + url.QueryEscape(payload)
@@ -98,7 +98,7 @@ func TestSlackRejectRequiresApprover(t *testing.T) {
 	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "apps"}})
 
 	const secret = "shh"
-	srv := New(nil, Actions{Approvals: ap, SlackSecret: secret, ApproverIDs: []string{"U1"}}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{Approvals: ap, SlackSecret: secret, ApproverIDs: []string{"U1"}}, nil, nil, nil, nil, discardLog)
 
 	reject := func(userID string) {
 		payload := `{"user":{"id":"` + userID + `","username":"x"},"actions":[{"action_id":"runlore_reject","value":"` + id + `"}]}`
@@ -133,7 +133,7 @@ func TestSlackRejectRequiresApprover(t *testing.T) {
 // callback at all.
 func TestSlackInteractionDisabledWithoutApprovals(t *testing.T) {
 	const secret = "shh"
-	srv := New(nil, Actions{SlackSecret: secret}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{SlackSecret: secret}, nil, nil, nil, nil, discardLog)
 
 	payload := `{"user":{"id":"U1","username":"alice"},"actions":[{"action_id":"runlore_approve","value":"a1"}]}`
 	body := "payload=" + url.QueryEscape(payload)
@@ -166,7 +166,7 @@ func TestActionsApprove(t *testing.T) {
 	ap := action.NewApprovals(exec, pol, audit.Nop{}, slog.New(slog.NewTextHandler(io.Discard, nil)))
 	id := ap.Register(providers.Action{Op: "suspend", Reversible: true, Target: providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "apps"}})
 
-	srv := New(nil, Actions{Approvals: ap, Token: "secret"}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{Approvals: ap, Token: "secret"}, nil, nil, nil, nil, discardLog)
 
 	// Missing token → 403, nothing executes.
 	rr := httptest.NewRecorder()
@@ -199,7 +199,7 @@ func (f *fakePauser) Paused() bool { return f.paused }
 
 func TestKillSwitch(t *testing.T) {
 	p := &fakePauser{}
-	srv := New(nil, Actions{Pauser: p, Token: "t"}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{Pauser: p, Token: "t"}, nil, nil, nil, nil, discardLog)
 
 	// Without the token → 403, kill-switch untouched.
 	rr := httptest.NewRecorder()
@@ -238,7 +238,7 @@ func testServer() *Server { return testServerWith(&spyEnqueuer{}) }
 
 func TestReadyz(t *testing.T) {
 	leader := false
-	srv := New(func() bool { return leader }, Actions{}, nil, nil, nil, discardLog)
+	srv := New(func() bool { return leader }, Actions{}, nil, nil, nil, nil, discardLog)
 
 	rr := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
@@ -337,7 +337,7 @@ func TestRecoverPanic(t *testing.T) {
 // no body, which would deref a nil payload absent recovery is not guaranteed — so we
 // drive a route through the real mux and assert no panic escapes ServeHTTP).
 func TestServerRecoversFromHandlerPanic(t *testing.T) {
-	srv := New(func() bool { panic("ready panic") }, Actions{}, nil, nil, nil, discardLog)
+	srv := New(func() bool { panic("ready panic") }, Actions{}, nil, nil, nil, nil, discardLog)
 	rr := httptest.NewRecorder()
 	// /readyz calls ready(); the panicking ready func exercises the wired middleware.
 	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/readyz", nil))
@@ -383,7 +383,7 @@ func (r *recordFeedback) Feedback(triggerKey, rating, user string, _ time.Time) 
 func TestSlackFeedbackInteraction(t *testing.T) {
 	rec := &recordFeedback{}
 	const secret = "shh"
-	srv := New(nil, Actions{Feedback: rec, SlackSecret: secret}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{Feedback: rec, SlackSecret: secret}, nil, nil, nil, nil, discardLog)
 
 	send := func(actionID, userID string) *httptest.ResponseRecorder {
 		payload := `{"user":{"id":"` + userID + `","username":"bob"},"actions":[{"action_id":"` + actionID + `","value":"trig-1"}]}`
@@ -435,7 +435,7 @@ func TestSlackFeedbackNotEnabled(t *testing.T) {
 	pol := action.New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{ReversibleOnly: true, Namespaces: []string{"apps"}}})
 	ap := action.NewApprovals(exec, pol, audit.Nop{}, discardLog)
 	const secret = "shh"
-	srv := New(nil, Actions{Approvals: ap, SlackSecret: secret}, nil, nil, nil, discardLog)
+	srv := New(nil, Actions{Approvals: ap, SlackSecret: secret}, nil, nil, nil, nil, discardLog)
 
 	payload := `{"user":{"id":"U1","username":"alice"},"actions":[{"action_id":"runlore_feedback_up","value":"trig-1"}]}`
 	body := "payload=" + url.QueryEscape(payload)

--- a/internal/source/webhook.go
+++ b/internal/source/webhook.go
@@ -56,12 +56,19 @@ func (b Built) Handler(auth func(*http.Request) bool, bodyCap int64, pipe *Pipel
 	}
 }
 
-// MountWebhooks registers every Webhook-kind source at its Path on mux.
-func MountWebhooks(mux *http.ServeMux, built []Built, auth func(*http.Request) bool, pipe *Pipeline) {
+// MountWebhooks registers every Webhook-kind source at its Path on mux. wrap
+// (optional, nil = none) decorates each handler — the serve path passes the
+// leader-forwarding middleware (#264) so a non-leader replica proxies webhook
+// deliveries to the leader instead of ingesting into its own idle queue.
+func MountWebhooks(mux *http.ServeMux, built []Built, auth func(*http.Request) bool, pipe *Pipeline, wrap func(http.Handler) http.Handler) {
 	for _, b := range built {
 		if b.Desc.Kind != Webhook {
 			continue
 		}
-		mux.HandleFunc("POST "+b.Desc.Path, b.Handler(auth, 1<<20, pipe))
+		var h http.Handler = b.Handler(auth, 1<<20, pipe)
+		if wrap != nil {
+			h = wrap(h)
+		}
+		mux.Handle("POST "+b.Desc.Path, h)
 	}
 }

--- a/internal/source/webhook_test.go
+++ b/internal/source/webhook_test.go
@@ -180,7 +180,7 @@ func TestMountWebhooks(t *testing.T) {
 	}
 
 	mux := http.NewServeMux()
-	MountWebhooks(mux, built, nil, pipe)
+	MountWebhooks(mux, built, nil, pipe, nil)
 
 	// Send a request to the registered webhook path
 	req := httptest.NewRequest(http.MethodPost, "/webhook/wh1", strings.NewReader(`{}`))


### PR DESCRIPTION
Fixes #264

## Problem

`/readyz` was gated on **leadership**, so with `replicaCount > 1` every standby replica was permanently NotReady. `helm upgrade --wait` / kstatus (Flux helm-controller) can never observe such a release become Ready — every upgrade timed out (confirmed live; cloud-native-ref had to set `disableWait`).

## Design

**1. `/readyz` = process + catalog health, leadership removed.** The catalog-warmth gating is unchanged (a cold/failed catalog still holds 503). Every warm replica now reports Ready, so `--wait`/kstatus succeeds and the Service may round-robin. Who leads stays observable via the Lease and the `runlore_leader` gauge — no `/leaderz` endpoint was added because nothing needs one (probes target `/healthz`; the e2e suite and docs were updated off readyz-as-leadership).

**2. Routable lease identity: `<podName>_<podIP>`.** The chart injects `POD_IP` (downward API) in the shared pod template (both `Deployment` and `StatefulSet` paths). `_` is a safe separator — DNS-1123 pod names cannot contain it; IPv6 is supported (bracketed on dial). Followers learn the holder via the **existing** `OnNewLeader` callback, stored atomically (`LeaderTracker`).

**3. Follower → leader forwarding (`server.Forward`).** A small reverse-proxy middleware wraps ONLY the work-bearing routes:

- `POST /webhook/*` (all registered webhook sources: alertmanager, pagerduty)
- `POST /slack/interactions`
- `GET /actions`, `POST /actions/{id}/approve|reject`, `POST /actions/pause|resume` (the approval queue and the auto kill-switch live in the leader process)

Never forwarded: `/healthz`, `/readyz`, `/metrics` — probes/scrapes are about *this* replica.

Semantics: leader (or leader election disabled) serves locally; follower proxies with byte-identical body + end-to-end headers (bearer token and Slack/PagerDuty HMAC signatures verify on the leader), the same 1 MiB body cap as local handling, a bounded client (httpx idiom, 25s < the 30s server WriteTimeout), plain http on the shared serve port. **Single hop**: `X-Runlore-Forwarded: 1` marks the hop; a marked request landing on a non-leader answers **421** — loops are structurally impossible. Unknown leader ⇒ **503 + Retry-After**; unreachable leader ⇒ **502 + Retry-After** (all work-bearing senders retry).

**4. NetworkPolicy.** Replica-to-replica traffic on the serve port is now allowed in both directions — egress in BOTH modes (the permissive default only opens 443/6443; strict denies by default) and ingress even when `ingressFrom` narrows sources. Without these rules the CNI would silently drop forwarding.

## Old-identity compatibility

Parsing is defensive: an old-format identity (bare pod name, no `_<valid-IP>` suffix — e.g. a pre-upgrade replica still holding the lease during a mixed-version rollout, or `POD_IP` unset) yields "forwarding unavailable" and the follower sheds with 503 + Retry-After — the pre-#264 behavior of a standby receiving traffic. With the default `Recreate` strategy the mixed-identity window is effectively nil. A garbage `POD_IP` is never encoded (validated with `net.ParseIP` on both sides), so no bogus dial target can ever be published or parsed.

## Chart / docs

- `Recreate` stays the default `updateStrategy`, but the comment now reflects reality: the readiness deadlock that forced it is gone; `RollingUpdate` is viable and documented as the near-zero-downtime option.
- `docs/getting-started.md`, `docs/troubleshooting.md`, `docs/upgrade-uninstall.md`, `docs/learning-loop.md` updated (standby-NotReady caveat removed everywhere).
- `hack/e2e-k3d.sh`: asserts BOTH replicas Ready (Deployment + StatefulSet paths), asserts the routable identity format, and parses the pod name out of the holder identity before `kubectl delete pod` / `logs`.

## Tests

- Identity encode/parse (round-trip, old format, invalid-IP suffix, IPv6) + `LeaderTracker.Addr`.
- ReadyFunc matrix (catalog warm/cold/failed × configured) — leadership dimension removed by construction.
- Proxy tests with two httptest servers: follower forwards (method/path/query/body/headers preserved, hop marker set), loop header ⇒ 421 (leader untouched), unknown leader ⇒ 503 + Retry-After, unreachable leader ⇒ 502, leader serves locally, `/healthz` `/readyz` `/metrics` never proxied, oversized body ⇒ 413, nil Forward ⇒ local (CLI paths).
- Leader-election test asserts the Lease holder identity is `replica-a_10.9.8.7` and the tracker learns it.

Gate: `go build ./... && go vet ./... && gofmt -l . && go test ./... && golangci-lint run ./...` → 0 issues; `helm lint` + `helm template` both workloadKinds + `test-workloadkind.sh` 11/11.

## Before relying on this in production

Live HA validation is still required: 2 replicas, kill the leader mid-traffic, and run a real `helm upgrade --wait` (Flux helm-controller) — then cloud-native-ref can drop `disableWait`.
