### PR TITLE
fix(ha): survive the leader-takeover window opened by #284 (retryable shed + self-race guard)

### DIFF
--- a/hack/e2e-k3d.sh
+++ b/hack/e2e-k3d.sh
@@ -48,6 +48,32 @@ check() { # check <desc> <logfile> <pattern>
   if grep -qE "$3" "$2"; then green "PASS: $1"; PASS=$((PASS+1)); else red "FAIL: $1 (pattern: $3)"; FAIL=$((FAIL+1)); fi
 }
 
+# wait_for_leader blocks until the runlore-leader Lease is held by a pod that
+# currently exists AND is Running — i.e. leadership has settled on a live pod.
+# Since #284 decoupled /readyz from leadership, `kubectl rollout status` returns
+# as soon as the new pod is Ready, which is BEFORE it wins the Lease. In that
+# takeover window a follower's leader-tracker still points at the previous
+# (now-dead) pod, so a webhook posted immediately is proxied to a stale IP and
+# shed (503 + Retry-After). Production senders (Alertmanager) retry on that 503
+# until it settles; the e2e's one-shot curl does not — so we wait here, encoding
+# the settling that sender retries buy in production. Bounded to ~60s; on
+# timeout it returns anyway (never aborts) so the following assertion fails
+# loudly with real diagnostics instead of a bare set -e crash here.
+wait_for_leader() {
+  local holder pod phase
+  for _ in $(seq 1 30); do   # 30 * 2s = 60s
+    holder=$(kubectl -n "$NS" get lease runlore-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || true)
+    pod=${holder%%_*}   # identity is <podName>_<podIP> (#264); pod names carry no '_'
+    if [[ -n "$pod" ]]; then
+      phase=$(kubectl -n "$NS" get pod "$pod" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+      [[ "$phase" == "Running" ]] && { green "leader settled on $pod ($holder)"; return 0; }
+    fi
+    sleep 2
+  done
+  red "wait_for_leader: no live leader after 60s (holder='${holder:-}')"
+  return 0
+}
+
 step "1/8 create k3d cluster"
 k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
 k3d cluster create "$CLUSTER" --wait --timeout 120s --no-lb \
@@ -159,6 +185,7 @@ helm upgrade --install runlore deploy/helm/runlore -n "$NS" \
   --set "env[2].name=MATRIX_TOKEN" --set-string "env[2].value=mocktoken" \
   --set "envFrom[0].secretRef.name=runlore-forge"
 kubectl -n "$NS" rollout status deploy/runlore --timeout=90s
+wait_for_leader   # gate traffic on leadership settling, not just pod-Ready (#284)
 
 step "6/8 startup wiring (config, catalog, RBAC, watch)"
 sleep 3
@@ -241,6 +268,7 @@ helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
   --set "config.telemetry.metrics_enabled=true" \
   --set replicaCount=1 >/dev/null
 kubectl -n "$NS" rollout status deploy/runlore --timeout=90s >/dev/null
+wait_for_leader   # gate the storm webhook on leadership settling (#284)
 sleep 3
 
 STORM_PORT=18085; free_port "$STORM_PORT"
@@ -355,6 +383,7 @@ helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
   --set-string config.server.webhook_token_env=WEBHOOK_TOKEN \
   --set replicaCount=1 >/dev/null
 kubectl -n "$NS" rollout status deploy/runlore --timeout=120s >/dev/null
+wait_for_leader   # gate the rung-3 auto webhooks on leadership settling (#284)
 PORT=18091; free_port "$PORT"
 kubectl -n "$NS" port-forward svc/runlore "$PORT:8080" >/tmp/runlore-pf.log 2>&1 &
 PF=$!; sleep 3
@@ -542,6 +571,7 @@ kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=
 helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
   --set replicaCount=1 --set-string config.gitops.engine=argocd >/dev/null
 kubectl -n "$NS" rollout status deploy/runlore --timeout=120s
+wait_for_leader   # gate the argocd Application trigger on leadership settling (#284)
 sleep 3
 kubectl apply -f - <<'YAML'
 apiVersion: argoproj.io/v1alpha1

--- a/internal/app/leader_identity.go
+++ b/internal/app/leader_identity.go
@@ -53,7 +53,7 @@ func ParseLeaseIdentity(id string) (name, ip string) {
 //
 // The view can be briefly stale (the holder just died and no successor has
 // renewed yet) — the forwarding layer treats a failed dial as "retry shortly"
-// (502 + Retry-After) rather than trusting the tracker blindly.
+// (503 + Retry-After) rather than trusting the tracker blindly.
 type LeaderTracker struct {
 	v atomic.Value // string: the raw holder identity
 }
@@ -66,6 +66,16 @@ func (t *LeaderTracker) Set(identity string) { t.v.Store(identity) }
 func (t *LeaderTracker) Identity() string {
 	s, _ := t.v.Load().(string)
 	return s
+}
+
+// Name returns the pod-name part of the current holder identity ("" before the
+// first OnNewLeader callback, or from a bare pre-#264 identity with no IP). The
+// forwarding layer compares it against this replica's own name to detect the
+// tracker pointing at itself during a takeover and serve locally rather than
+// proxy to itself (server.Forward.LeaderName).
+func (t *LeaderTracker) Name() string {
+	name, _ := ParseLeaseIdentity(t.Identity())
+	return name
 }
 
 // Addr returns "ip:port" (IPv6 bracketed) for the current holder on the given

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -360,6 +360,13 @@ func RunServe(version string, args []string) error {
 	fwd := &server.Forward{
 		IsLeader:   leader.Load, // pinned true when leader election is disabled
 		LeaderAddr: func() string { return tracker.Addr(port) },
+		// SelfName/LeaderName close the takeover self-race: during the window
+		// after this pod wins the Lease but before IsLeader() flips — and, in a
+		// StatefulSet, while the Lease still names a dead predecessor that reused
+		// this pod's stable ordinal — the tracked holder's NAME is our own, so
+		// the follower serves locally instead of proxying to a stale IP / itself.
+		SelfName:   PodName(),
+		LeaderName: tracker.Name,
 		Log:        log,
 	}
 	srv := server.New(ReadyFunc(cat, CatalogExpected(cfg)), acts, built, pipe, metricsHandler, fwd, log)

--- a/internal/server/forward.go
+++ b/internal/server/forward.go
@@ -30,9 +30,10 @@ const (
 	// WriteTimeout (30s, NewHTTPServer) so a follower stuck on a slow leader
 	// still answers its own client instead of having the connection cut.
 	forwardTimeout = 25 * time.Second
-	// forwardRetryAfter is the Retry-After hint (seconds) on 502/503 answers:
-	// a leader handoff settles within the lease window (15s lease / 2s retry),
-	// so a short client retry usually lands on an elected leader.
+	// forwardRetryAfter is the Retry-After hint (seconds) on the 503 answers
+	// (no leader known / tracked leader unreachable): a leader handoff settles
+	// within the lease window (15s lease / 2s retry), so a short client retry
+	// usually lands on an elected leader.
 	forwardRetryAfter = "5"
 )
 
@@ -63,6 +64,18 @@ type Forward struct {
 	// mixed-version rollout) — the request is then shed with 503 + Retry-After,
 	// matching the pre-#264 behavior of a standby that received traffic.
 	LeaderAddr func() string
+	// SelfName is THIS replica's pod name (POD_NAME / hostname), i.e. the
+	// name half of its own lease identity. Paired with LeaderName it guards the
+	// takeover self-race: see the check in middleware. Empty disables the guard
+	// (single-replica, tests) — safe, since without a name to match on there is
+	// no way to mistake the tracked holder for ourselves.
+	SelfName string
+	// LeaderName returns the pod-name part of the tracked holder identity (""
+	// before the first OnNewLeader). Compared against SelfName to detect the
+	// tracker briefly pointing at THIS pod (or a dead predecessor sharing our
+	// stable StatefulSet name) so we serve locally instead of proxying to
+	// ourselves.
+	LeaderName func() string
 	// Client posts the proxied request. nil defaults to a bounded
 	// httpx.SecureClient — never http.DefaultClient (unbounded hang).
 	Client *http.Client
@@ -90,6 +103,17 @@ func (f *Forward) middleware(next http.Handler) http.Handler {
 			// original sender retries against the Service and lands on the
 			// settled leader.
 			http.Error(w, "not the leader (request already forwarded once)", http.StatusMisdirectedRequest)
+			return
+		}
+		if f.SelfName != "" && f.LeaderName != nil && f.LeaderName() == f.SelfName {
+			// Takeover self-race: IsLeader() is still false, yet the tracked
+			// holder's pod NAME is our own. Either this replica just won the
+			// Lease and OnStartedLeading hasn't flipped IsLeader() yet, or (a
+			// StatefulSet) the Lease still names a dead predecessor that reused
+			// our stable ordinal with a now-unroutable IP. Proxying would dial a
+			// stale IP or loop a request onto our own serve port; serve locally
+			// instead — by stable identity WE are the pod that owns this work.
+			next.ServeHTTP(w, r)
 			return
 		}
 		addr := ""
@@ -152,15 +176,21 @@ func (f *Forward) proxy(w http.ResponseWriter, r *http.Request, addr string) {
 	}
 	resp, err := client.Do(req) //nolint:gosec // G704: same request as above — leader-only destination, never request-controlled
 	if err != nil {
-		// The holder view can be briefly stale (the leader just died and the
-		// tracker hasn't observed a successor yet): fail fast with a retry
-		// hint rather than queueing leader-only work on a follower.
+		// A client.Do error means NO HTTP response arrived — a dial/connect/
+		// timeout failure to REACH the tracked leader, never a status returned
+		// by a live one. The holder view is briefly stale (the leader just died
+		// and the tracker hasn't observed a successor yet), so this is
+		// indistinguishable from "no leader known": shed with 503 + Retry-After,
+		// the documented retryable contract that every work-bearing sender
+		// (Alertmanager, PagerDuty, Slack) honors. A 502 here would be WRONG —
+		// those senders treat a bad-gateway as the upstream's own answer and do
+		// NOT retry, so the alert would be lost during the takeover window.
 		if f.Log != nil {
 			f.Log.Warn("leader forward failed", "leader", addr,
 				"method", r.Method, "path", r.URL.Path, "err", err)
 		}
 		w.Header().Set("Retry-After", forwardRetryAfter)
-		http.Error(w, "leader unreachable; retry", http.StatusBadGateway)
+		http.Error(w, "leader unreachable; retry", http.StatusServiceUnavailable)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/internal/server/forward_test.go
+++ b/internal/server/forward_test.go
@@ -190,24 +190,61 @@ func TestForwardUnknownLeader503(t *testing.T) {
 	}
 }
 
-// TestForwardLeaderUnreachable502: the tracker can briefly point at a dead
-// leader (mid-failover). The proxy must fail fast with 502 + Retry-After, not
-// hang or serve the work locally on a non-leader.
-func TestForwardLeaderUnreachable502(t *testing.T) {
+// TestForwardDeadLeaderUnreachable503: the tracker can briefly point at a dead
+// leader (mid-failover / takeover window) whose IP no longer answers. A dial
+// failure means we never REACHED a live leader, so it must be shed exactly like
+// "no leader known": 503 + Retry-After (which Alertmanager & co. retry on), NOT
+// a 502 (which those senders treat as the upstream's answer and do not retry).
+// It must also never serve the leader-only work locally on a non-leader.
+func TestForwardDeadLeaderUnreachable503(t *testing.T) {
 	enq := &spyEnqueuer{}
 	// 127.0.0.1:1 — reserved port, connection refused immediately.
 	srv := newForwardServer(t, follower(func() string { return "127.0.0.1:1" }), enq)
 
 	rr := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(alertBody)))
-	if rr.Code != http.StatusBadGateway {
-		t.Fatalf("unreachable leader = %d, want 502", rr.Code)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unreachable leader = %d, want 503 (retryable, not 502)", rr.Code)
 	}
 	if rr.Header().Get("Retry-After") == "" {
-		t.Error("502 for unreachable leader must carry Retry-After")
+		t.Error("503 for unreachable leader must carry Retry-After (senders retry)")
 	}
 	if len(enq.reqs) != 0 {
 		t.Error("follower served work locally when the leader was unreachable")
+	}
+}
+
+// TestForwardStaleSelfServesLocally: during a takeover the tracker can still
+// hold an identity whose pod-NAME is THIS pod's own — this pod just won the
+// Lease but IsLeader() hasn't flipped, or (StatefulSet) the Lease still names a
+// dead predecessor that reused our stable ordinal with a now-stale IP. The
+// follower must NOT proxy (dialing a stale IP, or looping onto its own port):
+// it serves the work locally, since by stable identity it owns it.
+func TestForwardStaleSelfServesLocally(t *testing.T) {
+	// A LIVE server at the tracked address, so a proxy WOULD succeed if wrongly
+	// attempted — the guard is proven by work landing locally, not by a dial
+	// error masking a missing guard.
+	tracked := newFakeLeader(t)
+	enq := &spyEnqueuer{}
+	fwd := &Forward{
+		IsLeader:   func() bool { return false }, // takeover window: not yet leader
+		LeaderAddr: tracked.addr,
+		LeaderName: func() string { return "runlore-0" },
+		SelfName:   "runlore-0", // tracked holder's name == our own
+		Log:        discardLog,
+	}
+	srv := newForwardServer(t, fwd, enq)
+
+	rr := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/webhook/alertmanager", strings.NewReader(alertBody)))
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("stale-self forward = %d, want 202 (served locally)", rr.Code)
+	}
+	if len(enq.reqs) != 1 {
+		t.Fatalf("stale-self enqueued %d locally, want 1 (own work served here)", len(enq.reqs))
+	}
+	if n := len(tracked.requests()); n != 0 {
+		t.Errorf("stale-self proxied %d request(s) to itself, want 0", n)
 	}
 }
 


### PR DESCRIPTION
## Diagnosis

PR #284 decoupled `/readyz` from leadership so every warm replica reports Ready (needed so `helm upgrade --wait` / Flux kstatus succeeds with `replicaCount>1`). Consequence: after each `helm upgrade`, `kubectl rollout status` now returns as soon as the new pod is **Ready** — which is BEFORE it wins the `runlore/runlore-leader` Lease.

In that takeover window the new pod believes it is a follower; its `LeaderTracker` still holds the PREVIOUS (now-dead) pod's identity read from the existing Lease, so `server.Forward` proxies the incoming webhook to the dead IP. The dial fails and the middleware answered **502**, which webhook senders (the Alertmanager notifier) do NOT retry → the alert is lost.

The official e2e on main (run 29077566726) is `PASS=43 FAIL=6`, each failure landing right after an upgrade: storm coalescing ×2, slack approval, rung-3 auto ×2, argocd. Pre-#284 `/readyz` gated on leadership, so nothing was routed during the window.

## Fix — two altitudes

**1. Server — `internal/server/forward.go`** (the #284 Forward middleware):

- A forward that **fails to reach** the tracked leader (a `client.Do` error = dial/connect/timeout, so no HTTP response ever arrived — never a live leader's status) is now shed as **503 + Retry-After** instead of 502, exactly like "no leader known". 503 is the documented retryable contract every work-bearing sender (Alertmanager, PagerDuty, Slack) honors; a 502 reads as the upstream's own answer and is not retried. Production senders now ride the window out via their own retries.
- **Self-race guard**: if the tracked holder identity's pod-name equals THIS pod's name (`POD_NAME`), the follower serves locally instead of proxying. Covers (a) this pod just won the Lease but `IsLeader()` hasn't flipped yet, and (b) StatefulSet — the Lease still names a dead predecessor that reused our stable ordinal with a now-stale IP. Prevents dialing a stale IP or looping a request onto our own serve port. Single-hop semantics unchanged.

Wiring: `LeaderTracker.Name()` (pod-name half of the holder identity) is passed as `Forward.LeaderName`, and `PodName()` as `Forward.SelfName`.

New / updated tests: `TestForwardDeadLeaderUnreachable503` (dial failure → 503 + Retry-After, never served locally on a non-leader) and `TestForwardStaleSelfServesLocally` (holder name == self → served locally, tracked addr never contacted). All existing forward tests still pass.

**2. e2e — `hack/e2e-k3d.sh`**: new bounded (60s) `wait_for_leader` helper that polls until the `runlore-leader` Lease `holderIdentity` parses to a pod that exists and is `Running`, called after each `kubectl rollout status` that precedes traffic (install, storm, rung-3 auto, argocd). This encodes in the harness what sender retries buy in production — the e2e's one-shot curl doesn't retry. No other restructuring.

## Proof

Full local e2e (`hack/e2e-k3d.sh`, k3d): **`PASS=49 FAIL=0` — ALL FEATURES VERIFIED** (exit 0; cluster torn down). All six previously-failing assertions now pass.

Gate, all clean: `go build ./...`, `go vet ./...`, `gofmt -l .` (empty), `go test ./...`, `golangci-lint run ./...` (0 issues), `bash -n hack/e2e-k3d.sh`.

The `run-e2e` label is applied so CI re-proves it end-to-end.
