### PR TITLE
fix(chart): version-less labels on volumeClaimTemplates — StatefulSet upgrades were bricked

### DIFF
--- a/deploy/helm/runlore/templates/statefulset.yaml
+++ b/deploy/helm/runlore/templates/statefulset.yaml
@@ -30,7 +30,15 @@ spec:
     - metadata:
         name: catalog
         labels:
-          {{- include "runlore.labels" . | nindent 10 }}
+          # selectorLabels ONLY — never the full label set. volumeClaimTemplates are
+          # immutable, and runlore.labels embeds helm.sh/chart + app.kubernetes.io/version:
+          # any chart/app version bump would change the template and make EVERY
+          # StatefulSet upgrade fail server-side apply ("Forbidden: updates to
+          # statefulset spec…"), looping Flux into rollback. Found live upgrading
+          # 0.6.1→0.7.0. Existing releases created with the old labels need a one-time
+          # `kubectl delete sts <name> --cascade=orphan` (pods/PVCs untouched) before
+          # the next upgrade — see docs/upgrade-uninstall.md.
+          {{- include "runlore.selectorLabels" . | nindent 10 }}
       spec:
         accessModes:
           {{- toYaml .Values.persistence.accessModes | nindent 10 }}

--- a/docs/upgrade-uninstall.md
+++ b/docs/upgrade-uninstall.md
@@ -96,3 +96,25 @@ and PodDisruptionBudget. It does **not** remove three things, which you must cle
 
 The knowledge-catalog **Git repo** is yours and is untouched by any of the above — that's the point:
 your accumulated knowledge is portable and outlives the deployment.
+
+## StatefulSet upgrades from chart ≤ 0.7.0: one-time recreate
+
+Releases installed in `workloadKind: StatefulSet` mode by chart **0.7.0 or older**
+stamped the full label set (including `helm.sh/chart` and `app.kubernetes.io/version`)
+into the `volumeClaimTemplates` — an **immutable** StatefulSet field. Any upgrade that
+bumps the chart or app version therefore fails server-side apply
+(`Forbidden: updates to statefulset spec…`) and, under Flux, loops into rollback.
+
+Fixed in the chart (the templates now stamp version-less selector labels), but an
+existing StatefulSet keeps its old immutable template. **One-time migration** before
+the next upgrade — pods and PVCs are untouched (`--cascade=orphan` deletes only the
+controller object; the recreated StatefulSet adopts both):
+
+```bash
+kubectl delete statefulset <release-name> -n <namespace> --cascade=orphan
+# then let Flux reconcile (or: helm upgrade …) — the StatefulSet is recreated
+# with the stable labels and adopts the running pods + volumes.
+```
+
+Deployments are unaffected (no immutable template fields beyond the selector, which
+was always version-less).


### PR DESCRIPTION
**Found live** on the validation cluster (EKS, StatefulSet mode, Flux): upgrading the pinned chart from 0.6.1+f180fd06 to 0.7.0+9139d328 failed every attempt with `StatefulSet.apps "runlore" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', …` and rolled back (4 retries exhausted).

**Root cause:** `volumeClaimTemplates.metadata.labels` rendered the full `runlore.labels` set — which embeds `helm.sh/chart: runlore-<version>` and `app.kubernetes.io/version`. volumeClaimTemplates are immutable, so **any chart or app version bump bricked every StatefulSet upgrade**.

**Fix:** stamp `runlore.selectorLabels` (name+instance, version-less — the same stable set the selector itself uses). Deployments were never affected.

**Migration:** an existing StatefulSet keeps its old immutable template — documented one-time `kubectl delete sts <name> --cascade=orphan` (pods/PVCs untouched; the recreated object adopts them) in docs/upgrade-uninstall.md.

Validated: helm lint + template render (labels now stable across version bumps).