### PR TITLE
fix(recall): normalize the workload identity before structural match

### DIFF
--- a/internal/curator/fingerprint.go
+++ b/internal/curator/fingerprint.go
@@ -24,7 +24,6 @@ var (
 	reIPv4       = regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`)
 	reInstanceID = regexp.MustCompile(`(?i)\b(i|vol|eni|snap|ami)-[0-9a-f]{8,}\b`) // EC2/EBS ids
 	reHexHash    = regexp.MustCompile(`(?i)\b[0-9a-f]{12,}\b`)                     // dashless uuids / sha blobs
-	reDeployPod  = regexp.MustCompile(`-[a-f0-9]{8,10}-[a-z0-9]{5}$`)              // <name>-<rs-hash>-<pod-hash>
 )
 
 // normalizeText masks volatile identifiers (IPs, node hostnames, EC2 ids, long
@@ -39,31 +38,13 @@ func normalizeText(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-// normalizeWorkloadName strips a trailing pod-name hash so a per-pod name reduces
-// to its controller family: a Deployment pod (<name>-<rs-hash>-<pod-hash>) and a
-// DaemonSet/StatefulSet-revision pod (<name>-<5-char hash containing a digit>)
-// both collapse to <name>. Names without such a suffix are returned unchanged, so
-// real trailing words (e.g. "redis-cache") are preserved.
+// normalizeWorkloadName strips a trailing pod-name hash so a per-pod name reduces to
+// its controller family. The implementation is shared with the instant-recall
+// structural gate — it lives in providers.NormalizeWorkloadName (the single source
+// of truth, see CORE-681) so the dedup and recall paths can never drift. This thin
+// alias keeps the curator's internal call sites (and their tests) unchanged.
 func normalizeWorkloadName(name string) string {
-	if m := reDeployPod.FindString(name); m != "" {
-		return name[:len(name)-len(m)]
-	}
-	if i := strings.LastIndexByte(name, '-'); i >= 0 {
-		suf := name[i+1:]
-		if len(suf) == 5 && strings.ContainsAny(suf, "0123456789") && isAlnum(suf) {
-			return name[:i]
-		}
-	}
-	return name
-}
-
-func isAlnum(s string) bool {
-	for _, r := range s {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
-			return false
-		}
-	}
-	return true
+	return providers.NormalizeWorkloadName(name)
 }
 
 // IncidentKey builds a host-invariant, per-class dedup key for an alert: the alert

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -194,7 +194,18 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 	if entryResource == "" || reqW.Namespace == "" {
 		return matchNone
 	}
-	if reqW.Ref() == entryResource {
+	// Strip the volatile pod-hash suffix off the NAME segment on BOTH sides before
+	// the structural comparison. A pod-scoped alert (KubePodNotReady carries only a
+	// `pod` label — no deployment/workload label) arrives with the full pod name,
+	// e.g. tooling/harbor-registry-59598dbd57-ltkzw, while the KB entry stores the
+	// normalized controller family tooling/harbor-registry. Without normalization the
+	// two never agree → the recall is rejected (no_resource_match) and a full paid
+	// investigation runs despite a perfect KB entry (live-found). Normalizing BOTH
+	// sides also matches an entry written before the curator-side CORE-681 fix, which
+	// may itself still carry a pod hash. Only the name is normalized — never the
+	// namespace — and the normalization is the same idempotent one the dedup path
+	// uses, so two distinct workloads never collapse together.
+	if normalizeResourceRef(reqW.Ref()) == normalizeResourceRef(entryResource) {
 		return matchExact
 	}
 	if requireWorkload {
@@ -209,6 +220,20 @@ func resourceAgrees(reqW providers.Workload, entryResource string, requireWorklo
 		return matchNamespace
 	}
 	return matchNone
+}
+
+// normalizeResourceRef strips the volatile pod-hash suffix from the NAME segment of
+// a "namespace/name" resource ref, leaving a bare "namespace" (or "") untouched. It
+// splits on the first "/" only — Kubernetes namespaces and names never contain a
+// slash — so the namespace is never normalized, only the name. It delegates to the
+// shared providers.NormalizeWorkloadName so the recall gate and the curator dedup
+// path strip identically (and idempotently).
+func normalizeResourceRef(ref string) string {
+	ns, name, ok := strings.Cut(ref, "/")
+	if !ok {
+		return ref // bare namespace (or empty): no name segment to normalize
+	}
+	return ns + "/" + providers.NormalizeWorkloadName(name)
 }
 
 func clampF(v, lo, hi float64) float64 {

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -406,6 +406,66 @@ func TestResourceAgrees(t *testing.T) {
 	}
 }
 
+// TestResourceAgreesNormalizesPodHash is the live-found recall bug: a pod-scoped
+// alert (KubePodNotReady carries only a `pod` label — no deployment/workload label)
+// yields a Workload whose Name is the FULL pod name INCLUDING the volatile
+// ReplicaSet/pod-hash suffix, e.g. tooling/harbor-registry-59598dbd57-ltkzw. The
+// structural gate must strip that suffix off the NAME segment on BOTH sides so the
+// request still agrees (matchExact) with the normalized controller family stored on
+// the KB entry (tooling/harbor-registry) — otherwise a perfect KB entry is skipped
+// and a full paid investigation runs. It must NOT loosen anything: distinct
+// workloads still disagree, strict mode is unaffected, the scopeless tier holds.
+func TestResourceAgreesNormalizesPodHash(t *testing.T) {
+	w := func(ns, name string) providers.Workload { return providers.Workload{Namespace: ns, Name: name} }
+	cases := []struct {
+		name      string
+		reqW      providers.Workload
+		entry     string
+		requireWL bool
+		want      matchStrength
+	}{
+		// (i) full pod-name request vs the normalized-workload entry → exact.
+		{"full pod name req vs normalized entry", w("tooling", "harbor-registry-59598dbd57-ltkzw"), "tooling/harbor-registry", false, matchExact},
+		// (ii) reverse — the entry itself carries a pod hash (written before the
+		// curator-side CORE-681 fix, like the live duplicate), request normalized.
+		{"normalized req vs hashed entry", w("tooling", "harbor-registry"), "tooling/harbor-registry-59598dbd57-ltkzw", false, matchExact},
+		// both sides carry a DIFFERENT hash of the same family → still exact.
+		{"both sides hashed same family", w("tooling", "harbor-registry-59598dbd57-ltkzw"), "tooling/harbor-registry-abcdef1234-qrstu", false, matchExact},
+		// (iii) two DIFFERENT workloads must still NOT match after normalization.
+		{"different workloads still none", w("tooling", "harbor-registry-59598dbd57-ltkzw"), "tooling/harbor-core", false, matchNone},
+		// (iv) strict require_workload_match: the normalized family match still exact…
+		{"strict + normalized family exact", w("tooling", "harbor-registry-59598dbd57-ltkzw"), "tooling/harbor-registry", true, matchExact},
+		// …but a genuine mismatch stays none under strict.
+		{"strict + different workload none", w("tooling", "harbor-registry-59598dbd57-ltkzw"), "tooling/harbor-core", true, matchNone},
+		// normalization must never cross a namespace boundary.
+		{"same family different namespace none", w("tooling", "harbor-registry-59598dbd57-ltkzw"), "other/harbor-registry", false, matchNone},
+		// (v) the scopeless tier is untouched by name normalization.
+		{"scopeless still scopeless", w("", ""), "", false, matchScopeless},
+	}
+	for _, c := range cases {
+		if got := resourceAgrees(c.reqW, c.entry, c.requireWL); got != c.want {
+			t.Errorf("%s: resourceAgrees(%+v, %q, %v) = %v, want %v", c.name, c.reqW, c.entry, c.requireWL, got, c.want)
+		}
+	}
+}
+
+// TestLookupRecallsPodScopedAlert is the end-to-end live-found bug: a pod-scoped
+// alert whose workload name carries the volatile pod-hash suffix must now FIRE
+// instant recall against a KB entry whose resource is the normalized controller
+// family — where before the fix it rejected with no_resource_match and ran a full
+// paid investigation.
+func TestLookupRecallsPodScopedAlert(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Harbor registry pod not ready", Path: "harbor.md", Resource: "tooling/harbor-registry"}, Score: 6.0},
+		{Entry: catalog.Entry{Title: "unrelated", Path: "b.md"}, Score: 2.0},
+	})
+	req := Request{Title: "KubePodNotReady", Workload: providers.Workload{Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"}}
+	e, _ := r.lookup(context.Background(), req)
+	if e == nil || e.Path != "harbor.md" {
+		t.Fatalf("a pod-scoped alert must recall the normalized-workload entry harbor.md, got %+v", e)
+	}
+}
+
 func TestLookupStructuralWinnerBelowTopLexical(t *testing.T) {
 	// The two highest lexical hits are DIFFERENT workloads; the structurally-correct
 	// entry (apps/web) is only the 3rd lexical hit. Pre-filtering must surface it —

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -15,8 +15,10 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // ---- engine-agnostic "what changed" model ------------------------------------
@@ -63,6 +65,46 @@ func (w Workload) Ref() string {
 		return w.Namespace
 	}
 	return w.Namespace + "/" + w.Name
+}
+
+// reDeployPod matches a volatile pod-name suffix: a Deployment pod is
+// <name>-<rs-hash>-<pod-hash>, e.g. "harbor-registry-59598dbd57-ltkzw". The suffix
+// names one ephemeral pod, not the controller family it belongs to.
+var reDeployPod = regexp.MustCompile(`-[a-f0-9]{8,10}-[a-z0-9]{5}$`) // <name>-<rs-hash>-<pod-hash>
+
+// NormalizeWorkloadName strips a trailing pod-name hash so a per-pod name reduces
+// to its controller family: a Deployment pod (<name>-<rs-hash>-<pod-hash>) and a
+// DaemonSet/StatefulSet-revision pod (<name>-<5-char hash containing a digit>)
+// both collapse to <name>. Names without such a suffix are returned unchanged, so
+// real trailing words (e.g. "redis-cache") are preserved. It is idempotent.
+//
+// This is the single source of truth for pod-hash normalization. It is shared by
+// the curator dedup path (curator.DupFingerprint / IncidentKey — CORE-681, so the
+// same incident on a different pod dedupes to one KB entry) AND the instant-recall
+// structural gate (investigate.resourceAgrees), so a pod-scoped alert carrying the
+// volatile hash still matches the normalized workload stored on a KB entry. Homed
+// here — not in curator — because both packages already import providers, which
+// owns the Workload type; investigate must not import curator (no cycle).
+func NormalizeWorkloadName(name string) string {
+	if m := reDeployPod.FindString(name); m != "" {
+		return name[:len(name)-len(m)]
+	}
+	if i := strings.LastIndexByte(name, '-'); i >= 0 {
+		suf := name[i+1:]
+		if len(suf) == 5 && strings.ContainsAny(suf, "0123456789") && isAlnum(suf) {
+			return name[:i]
+		}
+	}
+	return name
+}
+
+func isAlnum(s string) bool {
+	for _, r := range s {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
 }
 
 // SourceRef points at the Git source + path backing a change.

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -29,6 +29,33 @@ func TestCompletionResponseRefused(t *testing.T) {
 	}
 }
 
+// TestNormalizeWorkloadName pins the shared pod-hash normalization now homed in the
+// providers package (both curator dedup and instant-recall matching call it). The
+// boundary is the safe one the curator tests already established: strip a
+// Deployment <rs-hash>-<pod-hash> and a DaemonSet/StatefulSet 5-char hash, but
+// never a legitimate trailing word like "redis-cache". It must be idempotent.
+func TestNormalizeWorkloadName(t *testing.T) {
+	cases := map[string]string{
+		"node-exporter-prometheus-node-exporter-km6ld": "node-exporter-prometheus-node-exporter", // DaemonSet pod hash
+		"web-7d9c8b6f5-abcde":                          "web",                                    // Deployment <rs-hash>-<pod-hash>
+		"harbor-registry-59598dbd57-ltkzw":             "harbor-registry",                        // the live pod-scoped alert
+		"node-exporter-prometheus-node-exporter":       "node-exporter-prometheus-node-exporter", // controller name, unchanged
+		"redis-cache":                                  "redis-cache",                            // 5-char tail but no digit → kept
+		"web":                                          "web",
+		"":                                             "",
+	}
+	for in, want := range cases {
+		if got := providers.NormalizeWorkloadName(in); got != want {
+			t.Errorf("NormalizeWorkloadName(%q) = %q, want %q", in, got, want)
+		}
+		// Idempotency: a second pass must be a no-op (the recall gate normalizes both
+		// sides, sometimes an already-normalized value).
+		if got := providers.NormalizeWorkloadName(want); got != want {
+			t.Errorf("NormalizeWorkloadName not idempotent for %q: %q", want, got)
+		}
+	}
+}
+
 func TestFingerprintMarkerRoundTrip(t *testing.T) {
 	const fp = "abc123def456"
 	body := "Drafted by RunLore — x\n\n" + providers.FingerprintMarker(fp)


### PR DESCRIPTION
## The bug (found live on a real cluster)

A pod-scoped alert (`KubePodNotReady` carries only a `pod` label — no `deployment`/`workload` label) produces a `req.Workload` whose `Name` is the **full pod name including the volatile ReplicaSet/pod-hash suffix**, e.g. `tooling/harbor-registry-59598dbd57-ltkzw`.

Instant recall's structural gate `resourceAgrees(reqW, entryResource, requireWorkload)` compared `reqW.Ref()` against the KB entry's stored `resource` (`tooling/harbor-registry`, the normalized workload). The recall path **never stripped the pod hash**, so:

```
reqW.Ref() = tooling/harbor-registry-59598dbd57-ltkzw
entry      = tooling/harbor-registry
→ not equal, and no namespace-level rule fires → matchNone
→ recall rejected with reason "no_resource_match"
→ a full, paid investigation runs despite a perfect KB entry existing
```

Combined with a separate dedup bug, this also produced a **duplicate KB PR** on the real incident.

## Why the dedup path was already fine

The curator dedup path already strips the hash — `curator.normalizeWorkloadName` (CORE-681), called from `DupFingerprint`/`IncidentKey`/`Fingerprint`. But that function was **unexported in package `curator`**, so `internal/investigate/recall.go` could not reuse it, and the recall path did no normalization at all.

## The fix

1. **Shared helper, no import cycle.** Extracted the normalization to `providers.NormalizeWorkloadName(name string)` — both `curator` and `investigate` already import `providers`, which owns the `Workload` type, and `investigate` must not import `curator`. Moved `reDeployPod`/`isAlnum` there too. The logic is byte-for-byte the current curator implementation (the `reDeployPod` regex path + the 5-char-alnum-with-digit heuristic). `curator.normalizeWorkloadName` is now a thin alias, so every curator call site and its tests are **unchanged and green**.

2. **Both-sides normalization in `resourceAgrees`.** Before the exact structural comparison, the NAME segment of BOTH sides is normalized via a small `normalizeResourceRef` helper: the incoming `reqW.Ref()` **and** the entry's stored `resource` — because an entry written before the curator-side fix (like the live duplicate) may itself still carry a pod hash. Only the **name** is stripped, never the namespace (split on the first `/` only; K8s namespaces/names contain no slash).

   ```go
   if normalizeResourceRef(reqW.Ref()) == normalizeResourceRef(entryResource) {
       return matchExact
   }
   ```

## Guardrails preserved (no loosening)

- The **scopeless tier** (workload-less PagerDuty sources) is untouched.
- Strict **`require_workload_match`** mode is unaffected — the exact-match check runs before it, so a genuine mismatch still returns `matchNone`.
- The **namespace-level rules** are unchanged; two distinct named workloads still never agree.
- Normalization is **idempotent** and does not over-strip legitimate names (e.g. `redis-cache` is preserved) — bounded by the existing `NormalizeWorkloadName` tests.

## Tests (TDD — written failing first)

- `providers.TestNormalizeWorkloadName`: the shared helper's boundary + idempotency, including the live `harbor-registry-59598dbd57-ltkzw → harbor-registry` case.
- `investigate.TestResourceAgreesNormalizesPodHash`: (i) full-pod-name request `matchExact` a normalized entry; (ii) the reverse (entry carries the hash); (iii) two DIFFERENT workloads still `matchNone`; (iv) strict mode unaffected; (v) scopeless tier unaffected; plus a cross-namespace negative.
- `investigate.TestLookupRecallsPodScopedAlert`: end-to-end `lookup` now FIRES instant recall on a pod-scoped alert against a normalized entry.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test ./...` (all pass), `golangci-lint run ./...` → **0 issues**. Race tests green on `internal/investigate/...`, `internal/curator/...`, `internal/providers/...`.