### PR TITLE
feat(notify): surface an existing-KB-entry match on the delivered finding

### DIFF
--- a/internal/investigate/kbmatch_test.go
+++ b/internal/investigate/kbmatch_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeScoredCatalog implements BOTH catalog.Searcher and catalog.ScoredSearcher so
+// it can back a KBSearchTool (whose field is a Searcher) while still exposing the
+// scores the loop captures into Investigation.MatchedKnowledge. SearchScored returns
+// the hits in the given order (descending score, as bleve does), so hits[0] is the top.
+type fakeScoredCatalog struct{ hits []catalog.ScoredEntry }
+
+func (f fakeScoredCatalog) SearchScored(string, int) ([]catalog.ScoredEntry, error) {
+	return f.hits, nil
+}
+
+func (f fakeScoredCatalog) Search(_ string, _ int) ([]catalog.Entry, error) {
+	out := make([]catalog.Entry, 0, len(f.hits))
+	for _, h := range f.hits {
+		out = append(out, h.Entry)
+	}
+	return out, nil
+}
+
+// runKBLoop drives a two-turn investigation: turn 1 calls kb_search, turn 2 concludes
+// with submit_findings. It returns the delivered investigation so a test can assert on
+// the captured MatchedKnowledge.
+func runKBLoop(t *testing.T, cat catalog.Searcher) providers.Investigation {
+	t.Helper()
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "s1", Name: "kb_search", Args: `{"query":"harbor probe"}`}}},
+		{ToolCalls: []providers.ToolCall{{ID: "f1", Name: submitFindingsName, Args: `{"confidence":0.8,"root_causes":[{"summary":"probe timeout"}]}`}}},
+	}}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{KBSearchTool{Catalog: cat}},
+		Log:        discardLog,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	return got
+}
+
+// TestMatchedKnowledgeCapturedAboveBar is the core visibility case: a full
+// investigation whose kb_search hit clears the clear-match bar lands the strongest
+// pre-existing entry on Investigation.MatchedKnowledge, so the notification can show
+// RunLore already had a runbook for the incident.
+func TestMatchedKnowledgeCapturedAboveBar(t *testing.T) {
+	cat := fakeScoredCatalog{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Harbor probe runbook", Path: "runbooks/harbor.md"}, Score: kbClearMatchScore + 2},
+		{Entry: catalog.Entry{Title: "runner-up", Path: "x.md"}, Score: 1.0},
+	}}
+	got := runKBLoop(t, cat)
+	mk := got.MatchedKnowledge
+	if mk == nil {
+		t.Fatalf("expected MatchedKnowledge stamped for an above-bar kb_search hit, got nil")
+	}
+	if mk.Path != "runbooks/harbor.md" || mk.Title != "Harbor probe runbook" {
+		t.Fatalf("captured wrong entry: %+v", mk)
+	}
+	if mk.Score != kbClearMatchScore+2 {
+		t.Fatalf("Score = %v, want %v (recorded so the bar is tunable from live data)", mk.Score, kbClearMatchScore+2)
+	}
+	// URL is not derivable from the tool without new forge plumbing; the notifier
+	// shows Path instead.
+	if mk.URL != "" {
+		t.Fatalf("URL should be empty (no cheap derivation), got %q", mk.URL)
+	}
+}
+
+// TestMatchedKnowledgeBelowBarNotCaptured: a hit under the clear-match bar is not a
+// confident known-runbook match, so nothing is surfaced (surfacing a weak,
+// tangential hit would be noise that erodes trust in the signal).
+func TestMatchedKnowledgeBelowBarNotCaptured(t *testing.T) {
+	cat := fakeScoredCatalog{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "weak", Path: "weak.md"}, Score: kbClearMatchScore - 0.5},
+	}}
+	got := runKBLoop(t, cat)
+	if got.MatchedKnowledge != nil {
+		t.Fatalf("below-bar hit must NOT be captured, got %+v", got.MatchedKnowledge)
+	}
+}
+
+// TestMatchedKnowledgeKeepsStrongestAcrossCalls: across an investigation's kb_search
+// calls the tracker keeps the single strongest clear-match hit, not the last one.
+func TestMatchedKnowledgeKeepsStrongestAcrossCalls(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "s1", Name: "kb_search", Args: `{"query":"first"}`}}},
+		{ToolCalls: []providers.ToolCall{{ID: "s2", Name: "kb_search", Args: `{"query":"second"}`}}},
+		{ToolCalls: []providers.ToolCall{{ID: "f1", Name: submitFindingsName, Args: `{"confidence":0.8,"root_causes":[{"summary":"x"}]}`}}},
+	}}
+	// A stateful fake that scores its hit lower on the second call, so "strongest wins"
+	// is distinguishable from "most recent wins": the tracker must keep the first,
+	// higher score.
+	stateful := &decliningCatalog{scores: []float64{kbClearMatchScore + 3, kbClearMatchScore + 1}}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Tools:      []Tool{KBSearchTool{Catalog: stateful}},
+		Log:        discardLog,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "t"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got.MatchedKnowledge == nil {
+		t.Fatalf("expected a captured hit")
+	}
+	if got.MatchedKnowledge.Score != kbClearMatchScore+3 {
+		t.Fatalf("tracker kept Score %v, want the strongest %v", got.MatchedKnowledge.Score, kbClearMatchScore+3)
+	}
+}
+
+// decliningCatalog scores its single hit lower on each successive call, proving the
+// tracker keeps the strongest across calls (not the most recent).
+type decliningCatalog struct {
+	scores []float64
+	i      int
+}
+
+func (c *decliningCatalog) SearchScored(string, int) ([]catalog.ScoredEntry, error) {
+	s := c.scores[c.i%len(c.scores)]
+	c.i++
+	return []catalog.ScoredEntry{{Entry: catalog.Entry{Title: "e", Path: "e.md"}, Score: s}}, nil
+}
+
+func (c *decliningCatalog) Search(string, int) ([]catalog.Entry, error) {
+	return []catalog.Entry{{Title: "e", Path: "e.md"}}, nil
+}
+
+// TestStampMatchedKnowledgeSelfReferenceGuard covers the capture-side guard directly:
+// the strongest hit is never stamped when it IS the entry the answer was recalled from
+// (self-reference), a distinct entry IS stamped, and a nil best is a no-op.
+func TestStampMatchedKnowledgeSelfReferenceGuard(t *testing.T) {
+	// Self-reference: the matched entry equals the delivered recalled entry → skip.
+	inv := providers.Investigation{RecalledEntry: "runbooks/harbor.md"}
+	stampMatchedKnowledge(&inv, &providers.MatchedEntry{Path: "runbooks/harbor.md", Title: "self", Score: 9})
+	if inv.MatchedKnowledge != nil {
+		t.Fatalf("must not stamp the entry being delivered (self-reference): %+v", inv.MatchedKnowledge)
+	}
+	// A distinct pre-existing entry IS surfaced.
+	stampMatchedKnowledge(&inv, &providers.MatchedEntry{Path: "runbooks/other.md", Title: "other", Score: 9})
+	if inv.MatchedKnowledge == nil || inv.MatchedKnowledge.Path != "runbooks/other.md" {
+		t.Fatalf("distinct entry must be stamped: %+v", inv.MatchedKnowledge)
+	}
+	// nil best is a no-op.
+	var blank providers.Investigation
+	stampMatchedKnowledge(&blank, nil)
+	if blank.MatchedKnowledge != nil {
+		t.Fatalf("nil best must be a no-op, got %+v", blank.MatchedKnowledge)
+	}
+}
+
+// TestRecallShortCircuitLeavesMatchedKnowledgeNil confirms the recall path is left
+// alone: a delivered instant-recall answer carries no MatchedKnowledge (the loop never
+// ran, so kb_search never fired — and Prior/"Seen before" is the recall surface).
+func TestRecallShortCircuitLeavesMatchedKnowledgeNil(t *testing.T) {
+	model := &scriptModel{} // a model call would panic — proves the loop is skipped
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model: model,
+		Log:   discardLog,
+		Recall: &Recall{MinScore: 2.0, Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Title: "Known", Description: "d", Path: "known.md", Resource: "tooling/harbor"}, Score: 5.0}}}},
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if !got.Recalled {
+		t.Fatalf("expected a recalled delivery")
+	}
+	if got.MatchedKnowledge != nil {
+		t.Fatalf("recall path must leave MatchedKnowledge nil (Prior covers it): %+v", got.MatchedKnowledge)
+	}
+}

--- a/internal/investigate/kbsearch_tool.go
+++ b/internal/investigate/kbsearch_tool.go
@@ -7,14 +7,71 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
 )
 
 // KBSearchTool lets the model search the OKF knowledge catalog (runbooks, past
 // incidents) to ground its reasoning.
 type KBSearchTool struct {
 	Catalog catalog.Searcher
+
+	// hits, when set, records the strongest clear-match kb_search hit this
+	// investigation saw so the loop can surface it on the delivered finding
+	// (Investigation.MatchedKnowledge). Per-investigation: the loop rebinds a fresh
+	// copy of the tool via withHitTracker; the shared li.Tools copy leaves it nil, so
+	// a bare KBSearchTool captures nothing.
+	hits *kbHitTracker
+}
+
+// kbClearMatchScore is the BM25 bar a kb_search hit's top score must clear to count
+// as a "clear match" worth surfacing on the notification. It mirrors instant recall's
+// default SoloFloor (config load default 4.0) — the score at which recall trusts a
+// LONE BM25 hit enough to short-circuit the whole investigation. The reasoning: if a
+// hit is strong enough that recall would have delivered it as the answer on its own,
+// it is unquestionably strong enough to tell the on-call "we already have a runbook
+// for this". Surfacing (a low-stakes hint on an investigation that still ran in full)
+// is a strictly weaker claim than recall's short-circuit, so borrowing recall's most
+// conservative single-hit bar keeps this high-precision — no noise from weak,
+// tangentially-relevant hits. BM25 scores are corpus-dependent; recording Score on
+// every match lets this be tuned from live data exactly as the recall thresholds are.
+const kbClearMatchScore = 4.0
+
+// kbHitTracker accumulates the single strongest clear-match kb_search hit across an
+// investigation's tool calls. An assistant turn's tool calls run concurrently
+// (dispatchTools), and the model may issue several kb_search calls, so observe is
+// mutex-guarded — the -race gate covers this.
+type kbHitTracker struct {
+	mu   sync.Mutex
+	best *providers.MatchedEntry
+}
+
+// observe keeps e when it out-scores the current best (or there is none yet). It
+// stores a copy so the caller's value can't be mutated after the fact.
+func (t *kbHitTracker) observe(e providers.MatchedEntry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.best == nil || e.Score > t.best.Score {
+		cp := e
+		t.best = &cp
+	}
+}
+
+// top returns the strongest recorded clear-match hit, or nil when none cleared the
+// bar. The returned pointer is the tracker's own copy; the loop treats it as read-only.
+func (t *kbHitTracker) top() *providers.MatchedEntry {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.best
+}
+
+// withHitTracker returns a copy of the tool that records its strongest clear-match hit
+// into tr. Used per investigation so the shared li.Tools copy is never given a tracker.
+func (t KBSearchTool) withHitTracker(tr *kbHitTracker) KBSearchTool {
+	t.hits = tr
+	return t
 }
 
 // Name returns the tool name.
@@ -30,13 +87,31 @@ func (t KBSearchTool) Schema() string {
 	return `{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}`
 }
 
-// Call searches the catalog and renders the top matches.
+// Call searches the catalog and renders the top matches. When the catalog exposes
+// relevance scores (catalog.ScoredSearcher — the production *catalog.Catalog does),
+// the scored search is preferred so the loop can capture the strongest clear-match
+// hit for the notification; a plain Searcher falls back to the unscored path.
 func (t KBSearchTool) Call(_ context.Context, args string) (string, error) {
 	var in struct {
 		Query string `json:"query"`
 	}
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)
+	}
+	if ss, ok := t.Catalog.(catalog.ScoredSearcher); ok {
+		scored, err := ss.SearchScored(in.Query, 3)
+		if err != nil {
+			return "", err
+		}
+		t.observeTopHit(scored)
+		if len(scored) == 0 {
+			return "no matching catalog entries", nil
+		}
+		hits := make([]catalog.Entry, len(scored))
+		for i, s := range scored {
+			hits[i] = s.Entry
+		}
+		return renderHits(hits), nil
 	}
 	hits, err := t.Catalog.Search(in.Query, 3)
 	if err != nil {
@@ -45,9 +120,35 @@ func (t KBSearchTool) Call(_ context.Context, args string) (string, error) {
 	if len(hits) == 0 {
 		return "no matching catalog entries", nil
 	}
+	return renderHits(hits), nil
+}
+
+// observeTopHit records the top hit into the tracker when it clears the clear-match
+// bar. SearchScored returns hits in descending score order, so scored[0] is the top.
+// No-op when no tracker is bound (a bare tool) or nothing cleared the bar.
+func (t KBSearchTool) observeTopHit(scored []catalog.ScoredEntry) {
+	if t.hits == nil || len(scored) == 0 {
+		return
+	}
+	top := scored[0]
+	if top.Score < kbClearMatchScore {
+		return // not confidently a known-runbook match — surfacing it would be noise
+	}
+	// Carry Path + Title (+ Score). URL is deliberately left empty: the entry's web
+	// link needs the forge repo, which isn't reachable from the tool without new
+	// plumbing — the notifier shows Path instead (see MatchedEntry).
+	t.hits.observe(providers.MatchedEntry{
+		Path:  top.Entry.Path,
+		Title: top.Entry.Title,
+		Score: top.Score,
+	})
+}
+
+// renderHits formats catalog hits into the markdown the model reads.
+func renderHits(hits []catalog.Entry) string {
 	var b strings.Builder
 	for _, e := range hits {
 		fmt.Fprintf(&b, "## %s  (%s)\n%s\n%s\n\n", e.Title, e.Path, e.Description, e.Body)
 	}
-	return b.String(), nil
+	return b.String()
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -308,6 +308,17 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	// that includes the incident's own namespace must be set per request, not at
 	// construction. scopeTools copies into a fresh slice (li.Tools is never mutated).
 	tools := scopeTools(li.Tools, req.Workload.Namespace)
+	// Per-investigation kb_search hit tracker: rebind each kb_search tool to a copy
+	// that records its strongest clear-match hit here, so the loop can surface it on
+	// the delivered finding (Investigation.MatchedKnowledge) as visible proof RunLore
+	// already had knowledge for this incident. scopeTools returned a fresh slice, so
+	// replacing an element leaves the shared li.Tools untouched.
+	kbHits := &kbHitTracker{}
+	for i, t := range tools {
+		if kb, ok := t.(KBSearchTool); ok {
+			tools[i] = kb.withHitTracker(kbHits)
+		}
+	}
 	byName := map[string]Tool{}
 	specs := make([]providers.ToolSpec, 0, len(tools)+1)
 	for _, t := range tools {
@@ -570,6 +581,13 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 			// originating alert workload only when the model named none.
 			inv.Resource = preferDiscoveredResource(inv.Resource, req.Workload)
 			stampRequestFacts(&inv, req)
+			// Visibility: surface the strongest pre-existing KB entry this investigation's
+			// kb_search calls matched at clear-match strength. This is the full-loop path —
+			// the exact case the live gap exposed: kb_search found a known runbook and the
+			// model used it, yet the notification gave no sign of prior knowledge. The
+			// recall-short-circuit path is deliberately left alone (Prior/"Seen before"
+			// already covers a delivered recall).
+			stampMatchedKnowledge(&inv, kbHits.top())
 			li.Log.Info("investigation evidence gathered", "title", req.Title, "tools_used", used)
 			if li.Metrics != nil {
 				// Usage-anchored when the provider reported usage; heuristic otherwise.
@@ -826,6 +844,28 @@ func stampRequestFacts(inv *providers.Investigation, req Request) {
 	inv.Tenant = req.Labels["tenant"]
 	inv.AlertName = req.Labels["alertname"]
 	inv.StartedAt = req.At
+}
+
+// stampMatchedKnowledge records, on a completed full-loop investigation, the strongest
+// pre-existing KB entry its kb_search calls matched at clear-match strength (best), so
+// the delivered notification can show RunLore already had documented knowledge for the
+// incident. No-op when nothing cleared the bar.
+//
+// Self-reference guard: kb_search hits are PRE-EXISTING merged catalog entries, each
+// carrying a real Path, whereas the fresh finding being delivered here has no catalog
+// identity yet (curation runs later) — so a hit is inherently a different entry and this
+// is never a fresh finding "matching itself". The RecalledEntry check is belt-and-braces:
+// never stamp the very entry an answer was recalled from. The full-loop path never sets
+// RecalledEntry (recall short-circuits before the loop), so it is a no-op here, but it
+// keeps the "not the entry we are delivering" invariant explicit and future-proof.
+func stampMatchedKnowledge(inv *providers.Investigation, best *providers.MatchedEntry) {
+	if best == nil {
+		return
+	}
+	if best.Path != "" && best.Path == inv.RecalledEntry {
+		return
+	}
+	inv.MatchedKnowledge = best
 }
 
 // preferDiscoveredResource keeps the workload the investigation identified,

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -80,6 +80,26 @@ func Format(inv providers.Investigation) string {
 			fmt.Fprintf(&b, "Previous conclusion: %s\n", inv.PrevCuratedURL)
 		}
 	}
+	// Existing-KB match: a full investigation whose kb_search matched a known
+	// runbook/entry at clear-match strength — visible proof RunLore already had
+	// knowledge for this incident. Suppressed when Prior (recurrence) is set: the
+	// Seen-before block above already covers it. The scaffolding here carries no
+	// mrkdwn-meta (& < >); the untrusted title/ref stay unescaped like every other
+	// field Format emits (the notifier escapes the whole output).
+	if mk := inv.MatchedKnowledge; mk != nil && inv.Prior == nil {
+		ref := mk.URL
+		if ref == "" {
+			ref = mk.Path
+		}
+		// Em-dash (not "(ref)") so a bare URL auto-links cleanly in Matrix: the
+		// mrkdwnToHTML link regex would otherwise swallow a trailing ")" into the href,
+		// which is why Format never parenthesizes URLs elsewhere either.
+		if ref != "" {
+			fmt.Fprintf(&b, "📚 Matches known runbook: %s — %s\n", mk.Title, ref)
+		} else {
+			fmt.Fprintf(&b, "📚 Matches known runbook: %s\n", mk.Title)
+		}
+	}
 	for i, rc := range inv.RootCauses {
 		fmt.Fprintf(&b, "%d. *%s* (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
 		// The change the root cause pins the incident on — previously rendered only

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -135,6 +135,43 @@ func TestFormatSeenBeforeWithoutPrior(t *testing.T) {
 	}
 }
 
+// TestFormatMatchedKnowledge covers the shared text used by Matrix + webhook: a full
+// investigation whose kb_search matched a known runbook (MatchedKnowledge set, Prior
+// nil) renders a visible "Matches known runbook" line with the path (or URL). It is
+// suppressed when Prior is set (recurrence already covers it) and absent when unset.
+func TestFormatMatchedKnowledge(t *testing.T) {
+	// Path shown when no URL is derivable.
+	out := Format(providers.Investigation{
+		Title: "t", Confidence: 0.8,
+		MatchedKnowledge: &providers.MatchedEntry{Title: "Harbor probe runbook", Path: "runbooks/harbor.md", Score: 6},
+	})
+	if !strings.Contains(out, "📚 Matches known runbook: Harbor probe runbook — runbooks/harbor.md") {
+		t.Errorf("expected matched-runbook line with path:\n%s", out)
+	}
+	// URL preferred over path when present.
+	outURL := Format(providers.Investigation{
+		Title: "t", Confidence: 0.8,
+		MatchedKnowledge: &providers.MatchedEntry{Title: "R", Path: "p.md", URL: "https://kb/p.md", Score: 6},
+	})
+	if !strings.Contains(outURL, "📚 Matches known runbook: R — https://kb/p.md") {
+		t.Errorf("expected URL preferred over path:\n%s", outURL)
+	}
+	// Suppressed when Prior is set (don't double-render with Seen-before).
+	outPrior := Format(providers.Investigation{
+		Title: "t", Confidence: 0.8, Occurrences: 2,
+		LastOccurrence:   time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC),
+		Prior:            &providers.PriorKnowledge{Cause: "c"},
+		MatchedKnowledge: &providers.MatchedEntry{Title: "R", Path: "p.md", Score: 6},
+	})
+	if strings.Contains(outPrior, "Matches known runbook") {
+		t.Errorf("must suppress the matched-runbook line when Prior is set:\n%s", outPrior)
+	}
+	// Absent when unset.
+	if strings.Contains(Format(providers.Investigation{Title: "t"}), "Matches known runbook") {
+		t.Error("matched-runbook line must be absent when MatchedKnowledge is nil")
+	}
+}
+
 // TestFormatRuledOutAndDataGaps asserts the two honest-limits sections render
 // their bullets, mirroring the Unresolved section's shape.
 func TestFormatRuledOutAndDataGaps(t *testing.T) {

--- a/internal/notify/matrix_test.go
+++ b/internal/notify/matrix_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
 )
 
 func TestMatrixDeliver(t *testing.T) {
@@ -37,6 +39,30 @@ func TestMatrixDeliver(t *testing.T) {
 	}
 	if body, _ := gotBody["body"].(string); !strings.Contains(body, "flux rollback hr/harbor") {
 		t.Fatalf("body missing content: %v", gotBody["body"])
+	}
+}
+
+// TestMatrixDeliverMatchedKnowledge confirms the existing-KB match reaches Matrix
+// (via the shared Format): the plaintext body carries the runbook line, and a
+// derived URL becomes a clickable anchor in the HTML body.
+func TestMatrixDeliverMatchedKnowledge(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = w.Write([]byte(`{"event_id":"$abc"}`))
+	}))
+	defer srv.Close()
+
+	inv := sampleInvestigation()
+	inv.MatchedKnowledge = &providers.MatchedEntry{Title: "Harbor probe runbook", Path: "runbooks/harbor.md", URL: "https://kb.example/runbooks/harbor.md", Score: 6}
+	if err := NewMatrix(srv.URL, "!room:hs", "tok").Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if body, _ := gotBody["body"].(string); !strings.Contains(body, "Matches known runbook: Harbor probe runbook") {
+		t.Fatalf("plaintext body missing matched-runbook line: %v", gotBody["body"])
+	}
+	if fb, _ := gotBody["formatted_body"].(string); !strings.Contains(fb, `<a href="https://kb.example/runbooks/harbor.md">`) {
+		t.Errorf("formatted_body missing runbook link anchor: %s", fb)
 	}
 }
 

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -341,8 +341,9 @@ func escapeMrkdwn(s string) string { return mrkdwnEscaper.Replace(s) }
 
 // summaryBlocks renders the triage summary as Block Kit, top-down as an on-call
 // reads it: what/where (header) → verdict → key facts (fields) → seen-before KB
-// recall (when present) → why → what to do → honest limits → recurrence →
-// confidence footer → approval buttons. The full
+// recall (when present) → matched-known-runbook (when a full loop reused a known
+// entry) → why → what to do → honest limits → recurrence → confidence footer →
+// approval buttons. The full
 // analysis (every hypothesis with all evidence, the complete open-questions /
 // data-gaps / ruled-out lists) lives in detailBlocks; slackMessage appends the
 // two for the single-message webhook path.
@@ -419,6 +420,26 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 		if len(foot) > 0 {
 			fmt.Fprintf(&s, "\n%s", strings.Join(foot, " · "))
 		}
+		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
+	}
+
+	// 3c. Existing-KB match — a full investigation whose kb_search matched a known
+	// runbook/entry at clear-match strength. Make it VISIBLE that RunLore already had
+	// knowledge for this incident: the live gap was a 95%-confidence kb_search hit that
+	// the on-call could not see. Suppressed when Prior is set — the recurrence block
+	// above already says "seen before" with richer context, so don't double-render.
+	// Title/path are untrusted (entry frontmatter) and escaped; a derived URL renders
+	// as a link, else the bare path shows inline as code.
+	if mk := inv.MatchedKnowledge; mk != nil && inv.Prior == nil {
+		var s strings.Builder
+		fmt.Fprintf(&s, "📚 *Matches known runbook:* %s", escapeMrkdwn(mk.Title))
+		switch {
+		case mk.URL != "":
+			fmt.Fprintf(&s, " (<%s|%s>)", escapeMrkdwn(mk.URL), escapeMrkdwn(mk.Path))
+		case mk.Path != "":
+			fmt.Fprintf(&s, " (`%s`)", escapeMrkdwn(mk.Path))
+		}
+		s.WriteString(" — RunLore has prior knowledge for this incident.")
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
 	}
 

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -679,6 +679,68 @@ func TestSlackSummaryBlocksPriorKnowledgePartial(t *testing.T) {
 	}
 }
 
+// TestSlackSummaryBlocksMatchedKnowledge covers the visibility fix: when a full
+// investigation's kb_search matched a known runbook (MatchedKnowledge set, Prior nil),
+// the summary renders a prominent "Matches known runbook" block with the escaped
+// title + path, so the on-call sees RunLore already had knowledge for the incident.
+func TestSlackSummaryBlocksMatchedKnowledge(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "HarborProbeFailure", Confidence: 0.8,
+		MatchedKnowledge: &providers.MatchedEntry{
+			Title: "Harbor probe & TLS <runbook>", // untrusted entry text must be escaped
+			Path:  "runbooks/harbor.md", Score: 6.2,
+		},
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	for _, want := range []string{
+		"📚 *Matches known runbook:* Harbor probe &amp; TLS &lt;runbook&gt;",
+		"`runbooks/harbor.md`",
+		"RunLore has prior knowledge for this incident.",
+	} {
+		if !strings.Contains(txt, want) {
+			t.Errorf("summary blocks missing %q\n%s", want, txt)
+		}
+	}
+}
+
+// TestSlackSummaryBlocksMatchedKnowledgeURL: when a web URL is derivable it renders
+// as a link (label = path) instead of an inline code path.
+func TestSlackSummaryBlocksMatchedKnowledgeURL(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "t", Confidence: 0.8,
+		MatchedKnowledge: &providers.MatchedEntry{Title: "Runbook", Path: "runbooks/h.md", URL: "https://kb/runbooks/h.md", Score: 5},
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "<https://kb/runbooks/h.md|runbooks/h.md>") {
+		t.Errorf("expected a linked entry, got\n%s", txt)
+	}
+}
+
+// TestSlackSummaryBlocksMatchedKnowledgeOmitted: the block is absent when there is
+// no match, and — crucially — suppressed when Prior is set, so recurrence and
+// existing-KB never double-render.
+func TestSlackSummaryBlocksMatchedKnowledgeOmitted(t *testing.T) {
+	// No match at all.
+	bare := blocksText(t, summaryBlocks(providers.Investigation{Title: "t", Confidence: 0.8}))
+	if strings.Contains(bare, "Matches known runbook") {
+		t.Errorf("must not render the block without MatchedKnowledge\n%s", bare)
+	}
+	// Match present but Prior set → the Seen-before block covers it; suppress this one.
+	withPrior := providers.Investigation{
+		Title: "t", Confidence: 0.8, Occurrences: 3,
+		LastOccurrence:   time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC),
+		Prior:            &providers.PriorKnowledge{Cause: "c"},
+		MatchedKnowledge: &providers.MatchedEntry{Title: "Runbook", Path: "runbooks/h.md", Score: 9},
+	}
+	txt := blocksText(t, summaryBlocks(withPrior))
+	if strings.Contains(txt, "Matches known runbook") {
+		t.Errorf("must NOT render the existing-KB block when Prior is set (double-render)\n%s", txt)
+	}
+	if !strings.Contains(txt, "Seen before") {
+		t.Errorf("expected the recurrence block to render instead\n%s", txt)
+	}
+}
+
 // marshalBlocks JSON-encodes a Slack payload for substring assertions on
 // structures (action_ids, button values) the mrkdwn text helpers don't reach.
 func marshalBlocks(t *testing.T, msg map[string]any) string {

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -44,24 +44,35 @@ var _ providers.Notifier = (*Notifier)(nil)
 
 // payload is the JSON body sent to the webhook endpoint.
 type payload struct {
-	Title          string        `json:"title"`
-	Confidence     float64       `json:"confidence"`
-	Namespace      string        `json:"namespace,omitempty"`
-	Resource       string        `json:"resource,omitempty"`
-	CuratedURL     string        `json:"curated_url,omitempty"`
-	Text           string        `json:"text"`
-	Verdict        string        `json:"verdict,omitempty"`
-	Severity       string        `json:"severity,omitempty"`
-	Cluster        string        `json:"cluster,omitempty"`
-	Environment    string        `json:"environment,omitempty"`
-	Tenant         string        `json:"tenant,omitempty"`
-	AlertName      string        `json:"alert_name,omitempty"`
-	StartedAt      string        `json:"started_at,omitempty"` // RFC3339; "" when unknown
-	Occurrences    int           `json:"occurrences,omitempty"`
-	PrevCuratedURL string        `json:"prev_curated_url,omitempty"`
-	RuledOut       []string      `json:"ruled_out,omitempty"`
-	DataGaps       []string      `json:"data_gaps,omitempty"`
-	Prior          *priorPayload `json:"prior,omitempty"`
+	Title            string          `json:"title"`
+	Confidence       float64         `json:"confidence"`
+	Namespace        string          `json:"namespace,omitempty"`
+	Resource         string          `json:"resource,omitempty"`
+	CuratedURL       string          `json:"curated_url,omitempty"`
+	Text             string          `json:"text"`
+	Verdict          string          `json:"verdict,omitempty"`
+	Severity         string          `json:"severity,omitempty"`
+	Cluster          string          `json:"cluster,omitempty"`
+	Environment      string          `json:"environment,omitempty"`
+	Tenant           string          `json:"tenant,omitempty"`
+	AlertName        string          `json:"alert_name,omitempty"`
+	StartedAt        string          `json:"started_at,omitempty"` // RFC3339; "" when unknown
+	Occurrences      int             `json:"occurrences,omitempty"`
+	PrevCuratedURL   string          `json:"prev_curated_url,omitempty"`
+	RuledOut         []string        `json:"ruled_out,omitempty"`
+	DataGaps         []string        `json:"data_gaps,omitempty"`
+	Prior            *priorPayload   `json:"prior,omitempty"`
+	MatchedKnowledge *matchedPayload `json:"matched_knowledge,omitempty"`
+}
+
+// matchedPayload mirrors providers.MatchedEntry for webhook consumers: the
+// pre-existing KB entry this investigation's kb_search matched at clear-match
+// strength (distinct from prior, which reports recurrence).
+type matchedPayload struct {
+	Path  string  `json:"path,omitempty"`
+	Title string  `json:"title,omitempty"`
+	URL   string  `json:"url,omitempty"`
+	Score float64 `json:"score,omitempty"`
 }
 
 // priorPayload mirrors providers.PriorKnowledge for webhook consumers: what the
@@ -84,25 +95,33 @@ func (n *Notifier) Deliver(ctx context.Context, inv providers.Investigation) err
 	if p := inv.Prior; p != nil {
 		prior = &priorPayload{Cause: p.Cause, Resolution: p.Resolution, EntryPath: p.EntryPath, Recalls: p.Recalls, Resolved: p.Resolved}
 	}
+	// Existing-KB match, mirroring the shared Format text's guard: surface it only when
+	// Prior is nil, so the structured field never disagrees with the payload's `text`
+	// (Prior/recurrence already covers the "seen before" case — don't double-signal).
+	var matched *matchedPayload
+	if mk := inv.MatchedKnowledge; mk != nil && inv.Prior == nil {
+		matched = &matchedPayload{Path: mk.Path, Title: mk.Title, URL: mk.URL, Score: mk.Score}
+	}
 	body, err := json.Marshal(payload{
-		Title:          inv.Title,
-		Confidence:     inv.Confidence,
-		Namespace:      inv.Resource.Namespace,
-		Resource:       inv.Resource.Name,
-		CuratedURL:     inv.CuratedURL,
-		Text:           notify.Format(inv),
-		Verdict:        string(inv.Verdict),
-		Severity:       inv.Severity,
-		Cluster:        inv.Cluster,
-		Environment:    inv.Environment,
-		Tenant:         inv.Tenant,
-		AlertName:      inv.AlertName,
-		StartedAt:      startedAt,
-		Occurrences:    inv.Occurrences,
-		PrevCuratedURL: inv.PrevCuratedURL,
-		RuledOut:       inv.RuledOut,
-		DataGaps:       inv.DataGaps,
-		Prior:          prior,
+		Title:            inv.Title,
+		Confidence:       inv.Confidence,
+		Namespace:        inv.Resource.Namespace,
+		Resource:         inv.Resource.Name,
+		CuratedURL:       inv.CuratedURL,
+		Text:             notify.Format(inv),
+		Verdict:          string(inv.Verdict),
+		Severity:         inv.Severity,
+		Cluster:          inv.Cluster,
+		Environment:      inv.Environment,
+		Tenant:           inv.Tenant,
+		AlertName:        inv.AlertName,
+		StartedAt:        startedAt,
+		Occurrences:      inv.Occurrences,
+		PrevCuratedURL:   inv.PrevCuratedURL,
+		RuledOut:         inv.RuledOut,
+		DataGaps:         inv.DataGaps,
+		Prior:            prior,
+		MatchedKnowledge: matched,
 	})
 	if err != nil {
 		return err

--- a/internal/notify/webhook/webhook_test.go
+++ b/internal/notify/webhook/webhook_test.go
@@ -155,6 +155,56 @@ func TestWebhookDeliverPriorKnowledge(t *testing.T) {
 	}
 }
 
+func TestWebhookDeliverMatchedKnowledge(t *testing.T) {
+	var got payload
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+	}))
+	defer srv.Close()
+	n := New(srv.URL)
+	inv := providers.Investigation{
+		Title: "t", Confidence: 0.8,
+		MatchedKnowledge: &providers.MatchedEntry{Path: "runbooks/harbor.md", Title: "Harbor probe runbook", URL: "https://kb/runbooks/harbor.md", Score: 6.2},
+	}
+	if err := n.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	if got.MatchedKnowledge == nil {
+		t.Fatal("matched_knowledge payload missing")
+	}
+	if got.MatchedKnowledge.Path != "runbooks/harbor.md" || got.MatchedKnowledge.Title != "Harbor probe runbook" ||
+		got.MatchedKnowledge.URL != "https://kb/runbooks/harbor.md" || got.MatchedKnowledge.Score != 6.2 {
+		t.Errorf("matched payload = %+v", got.MatchedKnowledge)
+	}
+}
+
+// TestWebhookMatchedKnowledgeSuppressedByPrior mirrors the shared-text guard: when
+// Prior is set, matched_knowledge is omitted so the structured field never disagrees
+// with the payload's `text` (recurrence already covers the "seen before" case).
+func TestWebhookMatchedKnowledgeSuppressedByPrior(t *testing.T) {
+	var got payload
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+	}))
+	defer srv.Close()
+	n := New(srv.URL)
+	inv := providers.Investigation{
+		Title: "t", Confidence: 0.8, Occurrences: 2,
+		Prior:            &providers.PriorKnowledge{Cause: "c"},
+		MatchedKnowledge: &providers.MatchedEntry{Path: "p.md", Title: "R", Score: 6},
+	}
+	if err := n.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("deliver: %v", err)
+	}
+	if got.MatchedKnowledge != nil {
+		t.Errorf("matched_knowledge must be omitted when Prior is set, got %+v", got.MatchedKnowledge)
+	}
+}
+
 func TestBuildRegisteredFromExtra(t *testing.T) {
 	const envVar = "TEST_WH_URL"
 	const testURL = "http://127.0.0.1:9999/hook" // unreachable; we only test Build, not Deliver

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -444,6 +444,32 @@ type Investigation struct {
 	LastOccurrence time.Time       // when the previous occurrence was investigated
 	PrevCuratedURL string          // the previous occurrence's KB link, for the "same conclusion as before" pointer
 	Prior          *PriorKnowledge // what the merged KB entry already says about this recurring incident; nil when unknown (see PriorKnowledge)
+	// MatchedKnowledge is the single strongest PRE-EXISTING knowledge-base entry that
+	// this investigation's kb_search calls matched at clear-match strength — the visible
+	// proof that RunLore already had documented knowledge for the incident. It is stamped
+	// by the ReAct loop (never by the model) and is DISTINCT from Prior: Prior reports
+	// RECURRENCE ("this exact incident, investigated N times before", from the outcome
+	// ledger), whereas MatchedKnowledge reports that a FULL investigation reused a known
+	// runbook/entry even on a first sighting. nil when no kb_search hit cleared the bar.
+	// Notifiers render it only when Prior == nil (the recurrence block already covers the
+	// "seen before" case — don't double-render).
+	MatchedKnowledge *MatchedEntry
+}
+
+// MatchedEntry is the strongest pre-existing catalog entry an investigation's
+// kb_search calls matched at clear-match strength. It closes a live visibility gap:
+// when a full investigation's kb_search found a known runbook and used it, the
+// delivered notification previously gave NO sign RunLore already had knowledge for
+// the incident (the "Seen before"/Prior block only fires on a ledger recurrence, not
+// when a full loop reuses a known entry). Path + Title always populate; URL only when
+// a web link is cheaply derivable (else the notifier shows Path). Score is the BM25
+// relevance of the matching hit — recorded so the clear-match bar can be tuned from
+// live data, like the recall thresholds.
+type MatchedEntry struct {
+	Path  string  // catalog path of the matched entry (bundle-relative)
+	Title string  // entry title, for the human-facing line
+	URL   string  // web link to the entry when cheaply derivable; "" ⇒ notifier shows Path
+	Score float64 // BM25 relevance score of the matching kb_search hit
 }
 
 // PriorKnowledge is what the knowledge base already says about a recurring


### PR DESCRIPTION
## The live gap

During a full investigation on a real cluster, `kb_search` matched an **existing** runbook at 95% confidence and the agent used it — but the delivered notification gave **no visible sign** RunLore already had knowledge for the incident. The on-call saw what looked like a fresh finding. The existing "Seen before"/`Prior` block only appears when instant recall short-circuits (a ledger recurrence, `Occurrences > 1`); it is **absent** when a full ReAct loop runs and `kb_search` matched a known entry.

Requirement: **it must be VISIBLE that we had a KB hit.**

## Capture

The loop rebinds each `kb_search` tool to a per-investigation `kbHitTracker` that keeps the single strongest hit clearing a **clear-match bar**, then stamps the winner onto the completed full-loop finding as `Investigation.MatchedKnowledge` (right after `stampRequestFacts`, in `internal/investigate/loop.go`). Capture reads the BM25 scores via `catalog.ScoredSearcher` (the production `*catalog.Catalog` implements it; a bare `Searcher` fake falls back and captures nothing).

The recall short-circuit path is deliberately **left alone** — `Prior`/"Seen before" already covers a delivered recall.

### Threshold rationale

`kbClearMatchScore = 4.0`, mirroring instant recall's default `SoloFloor` (config load default) — the BM25 score at which recall trusts a **lone** hit enough to short-circuit the entire investigation. Surfacing a hint on an investigation that still ran in full is a strictly weaker claim than recall's short-circuit, so borrowing recall's most conservative single-hit bar keeps this **high-precision**: no noise from weak, tangential hits. BM25 scores are corpus-dependent, so `Score` is recorded on every match to let the bar be tuned from live data exactly as the recall thresholds are.

## Prior vs MatchedKnowledge

- `Prior` = **recurrence**: "this exact incident, investigated N times before" (from the outcome ledger).
- `MatchedKnowledge` = "this investigation matched a **known KB entry**" — which a first sighting can also do.

**No self-reference:** `kb_search` hits are pre-existing *merged* catalog entries (each with a real `Path`); the fresh finding being delivered has no catalog identity yet (curation runs later), so a hit is inherently a different entry. A belt-and-braces `RecalledEntry` guard makes the "not the entry we're delivering" invariant explicit.

## Surface

A prominent block rendered only when `MatchedKnowledge != nil && Prior == nil` (don't double-render with the recurrence block):

- **Slack** `summaryBlocks`: `📚 *Matches known runbook:* <title> (<path|url>) — RunLore has prior knowledge for this incident.`
- **Shared `Format`** (Matrix + webhook text): `📚 Matches known runbook: <title> — <ref>` (em-dash so a bare URL auto-links cleanly in Matrix — parentheses would let the link regex swallow the trailing `)`).
- **Webhook**: structured `matched_knowledge` field.

Untrusted `title`/`path` are escaped via the existing `escapeMrkdwn`. `URL` is carried only when cheaply derivable (no new forge plumbing); otherwise the notifier shows `Path`.

## Tests (TDD)

- Capture: above-bar hit lands on `MatchedKnowledge`; below-bar does not; strongest-across-calls wins; self-reference/recalled-entry guard; recall short-circuit leaves it nil.
- Render: Slack block (escaping, URL-link vs code-path, omitted when unset / when `Prior` set); `Format` (path/URL/suppressed/absent); Matrix (line + link anchor); webhook payload field + `Prior` suppression.

## Gate

`go build`, `go vet`, `gofmt -l`, `go test ./...`, `golangci-lint run ./...` (0 issues), and `-race` on `investigate` + `notify` — all green.