### PR TITLE
fix(curator): normalize the workload name in the written resource frontmatter

### DIFF
--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -86,7 +86,7 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 		// newlines, which would fail RunLore's own `lore validate-kb` hard checks.
 		Title:       capTitle(inv.Title),
 		Description: firstLine(inv),
-		Resource:    inv.Resource.Ref(),
+		Resource:    normalizeResource(inv.Resource),
 		Tags:        entryTags(inv, typ),
 		Body:        b.String(),
 		Fingerprint: DupFingerprint(inv),
@@ -97,6 +97,30 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 		Occurrences:    inv.Occurrences,
 		PrevCuratedURL: inv.PrevCuratedURL,
 	}
+}
+
+// normalizeResource renders the affected workload as its canonical namespace/name
+// ref with the volatile pod-hash suffix stripped from the NAME segment only (via
+// the curator-local normalizeWorkloadName → providers.NormalizeWorkloadName, the
+// single source of truth for CORE-681).
+//
+// WHY: a pod-scoped alert (KubePodNotReady carries only a `pod` label) resolves to
+// the FULL pod name INCLUDING the ReplicaSet/pod-hash suffix, e.g.
+// "tooling/harbor-registry-59598dbd57-ltkzw". Written verbatim to the entry's
+// resource: frontmatter that (1) pollutes the human-facing entry with a hash that
+// changes every rollout; (2) breaks recall's structural matching against future
+// occurrences (the READ side normalizes before comparing — this is the WRITE side);
+// (3) forks a second KB entry from an already-normalized one ("tooling/harbor-
+// registry"), driving duplicate entries. Normalizing here aligns the WRITTEN
+// resource with what DupFingerprint already normalizes internally, so the dedup
+// identity is unchanged — only the stored, human/recall-facing ref is corrected.
+//
+// It reuses Workload.Ref(), so the namespace is never touched and the empty /
+// bare-namespace cases pass through unchanged; w is a value copy, so mutating its
+// Name is local. Idempotent (NormalizeWorkloadName is).
+func normalizeResource(w providers.Workload) string {
+	w.Name = normalizeWorkloadName(w.Name)
+	return w.Ref()
 }
 
 // entryType derives the OKF type for a drafted entry. The default is Incident: a

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -95,6 +95,90 @@ func TestDraftKBEntrySetsResource(t *testing.T) {
 	}
 }
 
+// TestDraftKBEntryNormalizesResourceHash is the CORE-681 WRITE-side fix: a
+// pod-scoped alert (KubePodNotReady carries only a `pod` label) resolves to the
+// FULL pod name INCLUDING the volatile ReplicaSet/pod-hash suffix, e.g.
+// "tooling/harbor-registry-59598dbd57-ltkzw". Writing that verbatim to the entry's
+// resource: frontmatter (1) pollutes the human-facing entry with a hash that churns
+// every rollout, (2) breaks recall's structural matching against future occurrences
+// (the READ side normalizes before comparing), and (3) forks a second KB entry from
+// an already-normalized one. The written resource must be normalized to the
+// controller family; the namespace is never touched, and empty/bare-namespace refs
+// pass through unchanged.
+func TestDraftKBEntryNormalizesResourceHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource providers.Workload
+		want     string
+	}{
+		{
+			name:     "pod-scoped alert: hash-carrying full pod name is stripped to the controller family",
+			resource: providers.Workload{Kind: "Pod", Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"},
+			want:     "tooling/harbor-registry",
+		},
+		{
+			name:     "controller-level name already normalized is idempotent",
+			resource: providers.Workload{Kind: "Deployment", Namespace: "tooling", Name: "harbor-registry"},
+			want:     "tooling/harbor-registry",
+		},
+		{
+			name:     "bare namespace (no name) is written as-is",
+			resource: providers.Workload{Namespace: "tooling"},
+			want:     "tooling",
+		},
+		{
+			name:     "empty resource stays empty",
+			resource: providers.Workload{},
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv := providers.Investigation{
+				Title:      "KubePodNotReady",
+				Confidence: 0.9,
+				Resource:   tt.resource,
+				RootCauses: []providers.Hypothesis{{Summary: "readiness probe failing", Evidence: []string{"e"}}},
+			}
+			if got := draftKBEntry(inv).Resource; got != tt.want {
+				t.Fatalf("KBEntry.Resource = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDraftKBEntryResourceNormalizationLeavesDedupIdentityStable is the vigilance
+// guard for the write-side fix: normalizing the WRITTEN resource must NOT perturb
+// the dedup identity. DupFingerprint already normalizes the pod hash internally and
+// is computed independently of KBEntry.Resource, so the drafted entry's fingerprint
+// still equals DupFingerprint, and two occurrences on different pods still coalesce
+// to one KB entry (their fingerprints match).
+func TestDraftKBEntryResourceNormalizationLeavesDedupIdentityStable(t *testing.T) {
+	hashed := providers.Investigation{
+		Title:      "KubePodNotReady",
+		Confidence: 0.9,
+		Resource:   providers.Workload{Kind: "Pod", Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"},
+		RootCauses: []providers.Hypothesis{{Summary: "readiness probe failing", Evidence: []string{"e"}}},
+	}
+	normalized := hashed
+	normalized.Resource = providers.Workload{Kind: "Pod", Namespace: "tooling", Name: "harbor-registry"}
+
+	// The drafted entry's fingerprint must still equal DupFingerprint (the write-side
+	// resource change did not perturb the identity field).
+	if got, want := draftKBEntry(hashed).Fingerprint, DupFingerprint(hashed); got != want {
+		t.Fatalf("drafted entry fingerprint = %q, want %q (must equal DupFingerprint)", got, want)
+	}
+	// The dedup identity is pod-hash invariant — the hash-carrying occurrence and the
+	// already-normalized one coalesce to a single KB entry.
+	if a, b := DupFingerprint(hashed), DupFingerprint(normalized); a == "" || a != b {
+		t.Fatalf("dedup identity must be pod-hash invariant: %q vs %q", a, b)
+	}
+	// ...and the written resource is normalized identically for both.
+	if a, b := draftKBEntry(hashed).Resource, draftKBEntry(normalized).Resource; a != b {
+		t.Fatalf("written resource must match across the pod-hash: %q vs %q", a, b)
+	}
+}
+
 func TestResourceStringNamespaceOnly(t *testing.T) {
 	if got := (providers.Workload{Namespace: "apps"}).Ref(); got != "apps" {
 		t.Fatalf("namespace-only resource = %q, want apps", got)


### PR DESCRIPTION
## The bug (found live)

When RunLore curates an investigation into a KB entry, the `resource:` field written to the entry's frontmatter is the investigation's raw resolved workload. For a pod-scoped alert (`KubePodNotReady` carries only a `pod` label), that resolves to the **full pod name including the volatile ReplicaSet/pod-hash suffix**, e.g. `resource: tooling/harbor-registry-59598dbd57-ltkzw`.

Confirmed live: KB PR #87 carries `resource: tooling/harbor-registry-59598dbd57-ltkzw` while the pre-existing entry has the correct `resource: tooling/harbor-registry`.

This is wrong three ways:
1. It pollutes the human-facing entry with a hash that changes every rollout.
2. It breaks recall's structural matching against future occurrences — a sibling PR just fixed the READ side to normalize before comparing; **this is the WRITE side**.
3. A correctly-normalized entry (`tooling/harbor-registry`) plus a new hash-carrying one are two different resources, contributing to duplicate KB entries.

## The fix (write-side normalization)

`draftKBEntry` set `KBEntry.Resource = inv.Resource.Ref()` (the raw ref) at `internal/curator/draft.go`. This changes it to normalize the **NAME segment only** via a small local `normalizeResource` helper that delegates to the curator-local `normalizeWorkloadName` → `providers.NormalizeWorkloadName` (the shared, idempotent CORE-681 normalizer — single source of truth, also used by the recall READ side, so the two paths can never drift). It reuses `Workload.Ref()`, so:
- the namespace is never touched;
- empty and bare-namespace refs pass through unchanged;
- it is idempotent (an already-controller-level name is left as-is).

`tooling/harbor-registry-59598dbd57-ltkzw` → `tooling/harbor-registry`.

## Dedup identity is unchanged

`DupFingerprint` already strips the pod hash internally (`res.Name = normalizeWorkloadName(res.Name)`) and is computed **independently** of `KBEntry.Resource`. So this write-side change does not touch the dedup identity:
- `KBEntry.Fingerprint` still equals `DupFingerprint(inv)`;
- the whole `TestDupFingerprint*` suite — including the pinned `TestDupFingerprintGoldenValue` and the CORE-681 `TestDupFingerprintStableAcrossPodSuffix` — stays **green, untouched**.

A new `TestDraftKBEntryResourceNormalizationLeavesDedupIdentityStable` asserts this explicitly.

## Tests (TDD)

New `TestDraftKBEntryNormalizesResourceHash` (table): hash-carrying pod name → stripped to controller family; already-normalized controller name → idempotent; bare namespace → as-is; empty → empty. Written failing-first, then made green.

## Gate

`go build ./... && go vet ./... && gofmt -l . (clean) && go test ./... && golangci-lint run ./...` = 0 issues; `-race` on `internal/curator/...` green.