### PR TITLE
fix(recall): kb-match visibility threshold tracks the configured recall floor

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,11 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   PagerDuty) can match only resource-less entries — the weakest tier, which always requires
   `solo_floor` + `min_score`, recalls with reduced confidence, and is disabled by
   `require_workload_match: true`.
+- The **"📚 Matches known runbook"** notification block (stamped when a *full* investigation's
+  `kb_search` finds a pre-existing entry) uses `solo_floor` as its visibility bar, so it tracks
+  the same corpus/query-dependent BM25 scale recall runs in: a cluster that tunes `solo_floor`
+  **down** for sub-1.0 alert-query scores gets a correspondingly low bar instead of the signal
+  silently never firing. When instant recall is disabled it falls back to the **4.0** default.
 - The search index is in-memory bleve (BM25), rebuilt from `dir` at startup — not persisted.
 
 ### `outcome` — the learning ledger

--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -89,6 +89,7 @@ func BuildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.G
 			MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 			MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
 			Timeout:                   cfg.Investigation.Timeout.Std(),
+			KBMatchScore:              kbMatchScore(recall), // visibility bar tracks the configured recall floor
 			OnComplete:                func(inv providers.Investigation) { res, got = inv, true },
 		}
 		if err := li.Investigate(ctx, req); err != nil {

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -209,6 +209,23 @@ func toPricing(p *config.Pricing) *investigate.Pricing {
 	}
 }
 
+// kbMatchScore returns the BM25 bar the kb-match visibility signal
+// (Investigation.MatchedKnowledge — the "📚 Matches known runbook" block) uses to decide
+// a full investigation's kb_search hit is a clear known-runbook match worth surfacing.
+// kb_search runs in the SAME corpus/query-dependent BM25 score regime as instant recall,
+// so we borrow the operator's CONFIGURED recall SoloFloor (recall's most conservative
+// single-hit bar) instead of a hardcoded constant: a cluster that tunes solo_floor DOWN
+// for its sub-1.0 label-derived alert-query scores then gets a correspondingly low
+// visibility bar, rather than the signal silently never firing (live-found). A nil recall
+// (instant recall disabled) ⇒ 0, so the loop's tracker falls back to its historical 4.0
+// default (investigate.kbClearMatchScoreDefault) and behaviour is unchanged.
+func kbMatchScore(recall *investigate.Recall) float64 {
+	if recall == nil {
+		return 0
+	}
+	return recall.SoloFloor
+}
+
 // defaultToolTimeout bounds a single tool call when investigation.tool_timeout is
 // unset (0). It keeps a hung/slow provider (a stuck git clone, an unresponsive
 // metrics/logs endpoint) from consuming the whole per-investigation budget while
@@ -313,6 +330,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		Compaction:                cfg.Investigation.Compaction,
 		Timeout:                   cfg.Investigation.Timeout.Std(),
 		ToolTimeout:               toolTimeout,
+		KBMatchScore:              kbMatchScore(recall), // visibility bar tracks the configured recall floor
 		OnProgress:                onProgress,
 		ProgressEverySteps:        progressEverySteps,
 		OnComplete: func(found providers.Investigation) {

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -46,6 +46,7 @@ func RunInvestigate(args []string) error {
 		Model: model, VerifyModel: BuildVerifyModel(cfg), Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
 		ModelProvider: cfg.Model.Provider,
 		Timeout:       cfg.Investigation.Timeout.Std(),
+		KBMatchScore:  kbMatchScore(recall), // visibility bar tracks the configured recall floor
 		OnComplete:    func(inv providers.Investigation) { result = &inv },
 	}
 	title := *alert

--- a/internal/investigate/kbmatch_test.go
+++ b/internal/investigate/kbmatch_test.go
@@ -30,8 +30,17 @@ func (f fakeScoredCatalog) Search(_ string, _ int) ([]catalog.Entry, error) {
 
 // runKBLoop drives a two-turn investigation: turn 1 calls kb_search, turn 2 concludes
 // with submit_findings. It returns the delivered investigation so a test can assert on
-// the captured MatchedKnowledge.
+// the captured MatchedKnowledge. KBMatchScore is left 0, so the tracker falls back to
+// the 4.0 default bar — the unchanged high-bar behaviour.
 func runKBLoop(t *testing.T, cat catalog.Searcher) providers.Investigation {
+	t.Helper()
+	return runKBLoopWithMatchScore(t, cat, 0)
+}
+
+// runKBLoopWithMatchScore is runKBLoop with an explicit KBMatchScore, so a test can
+// exercise the config-tracked visibility bar: a low configured floor (the live sub-1.0
+// regime), the 4.0 default, or 0 (unconfigured ⇒ the tracker's 4.0 fallback).
+func runKBLoopWithMatchScore(t *testing.T, cat catalog.Searcher, kbMatchScore float64) providers.Investigation {
 	t.Helper()
 	model := &scriptModel{responses: []providers.CompletionResponse{
 		{ToolCalls: []providers.ToolCall{{ID: "s1", Name: "kb_search", Args: `{"query":"harbor probe"}`}}},
@@ -39,10 +48,11 @@ func runKBLoop(t *testing.T, cat catalog.Searcher) providers.Investigation {
 	}}
 	var got providers.Investigation
 	li := &LoopInvestigator{
-		Model:      model,
-		Tools:      []Tool{KBSearchTool{Catalog: cat}},
-		Log:        discardLog,
-		OnComplete: func(inv providers.Investigation) { got = inv },
+		Model:        model,
+		Tools:        []Tool{KBSearchTool{Catalog: cat}},
+		Log:          discardLog,
+		KBMatchScore: kbMatchScore,
+		OnComplete:   func(inv providers.Investigation) { got = inv },
 	}
 	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure"}); err != nil {
 		t.Fatalf("Investigate: %v", err)
@@ -56,7 +66,7 @@ func runKBLoop(t *testing.T, cat catalog.Searcher) providers.Investigation {
 // RunLore already had a runbook for the incident.
 func TestMatchedKnowledgeCapturedAboveBar(t *testing.T) {
 	cat := fakeScoredCatalog{hits: []catalog.ScoredEntry{
-		{Entry: catalog.Entry{Title: "Harbor probe runbook", Path: "runbooks/harbor.md"}, Score: kbClearMatchScore + 2},
+		{Entry: catalog.Entry{Title: "Harbor probe runbook", Path: "runbooks/harbor.md"}, Score: kbClearMatchScoreDefault + 2},
 		{Entry: catalog.Entry{Title: "runner-up", Path: "x.md"}, Score: 1.0},
 	}}
 	got := runKBLoop(t, cat)
@@ -67,8 +77,8 @@ func TestMatchedKnowledgeCapturedAboveBar(t *testing.T) {
 	if mk.Path != "runbooks/harbor.md" || mk.Title != "Harbor probe runbook" {
 		t.Fatalf("captured wrong entry: %+v", mk)
 	}
-	if mk.Score != kbClearMatchScore+2 {
-		t.Fatalf("Score = %v, want %v (recorded so the bar is tunable from live data)", mk.Score, kbClearMatchScore+2)
+	if mk.Score != kbClearMatchScoreDefault+2 {
+		t.Fatalf("Score = %v, want %v (recorded so the bar is tunable from live data)", mk.Score, kbClearMatchScoreDefault+2)
 	}
 	// URL is not derivable from the tool without new forge plumbing; the notifier
 	// shows Path instead.
@@ -82,11 +92,65 @@ func TestMatchedKnowledgeCapturedAboveBar(t *testing.T) {
 // tangential hit would be noise that erodes trust in the signal).
 func TestMatchedKnowledgeBelowBarNotCaptured(t *testing.T) {
 	cat := fakeScoredCatalog{hits: []catalog.ScoredEntry{
-		{Entry: catalog.Entry{Title: "weak", Path: "weak.md"}, Score: kbClearMatchScore - 0.5},
+		{Entry: catalog.Entry{Title: "weak", Path: "weak.md"}, Score: kbClearMatchScoreDefault - 0.5},
 	}}
 	got := runKBLoop(t, cat)
 	if got.MatchedKnowledge != nil {
 		t.Fatalf("below-bar hit must NOT be captured, got %+v", got.MatchedKnowledge)
+	}
+}
+
+// TestMatchedKnowledgeTracksLowConfiguredFloor is the live regression: on a real
+// Alertmanager-driven cluster whose label-derived alert queries score sub-1.0, the
+// operator tunes solo_floor DOWN (observed live: 0.2). A kb_search hit at 0.3 is a
+// genuine known-runbook match there and MUST be surfaced. With the old hardcoded 4.0 bar
+// it never could be — the visibility feature silently no-opped on exactly the clusters
+// that need it (a Harbor investigation matched its runbook yet showed no prior-knowledge
+// block). Wiring the tracker's bar to the configured 0.2 floor fixes it.
+func TestMatchedKnowledgeTracksLowConfiguredFloor(t *testing.T) {
+	cat := fakeScoredCatalog{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Harbor probe runbook", Path: "runbooks/harbor.md"}, Score: 0.3},
+	}}
+	got := runKBLoopWithMatchScore(t, cat, 0.2) // configured recall SoloFloor on this cluster
+	mk := got.MatchedKnowledge
+	if mk == nil {
+		t.Fatalf("expected a sub-1.0 kb_search hit stamped under a 0.2 configured floor, got nil")
+	}
+	if mk.Path != "runbooks/harbor.md" || mk.Score != 0.3 {
+		t.Fatalf("captured wrong entry: %+v", mk)
+	}
+}
+
+// TestMatchedKnowledgeDefaultFloorRejectsSub1: with the default 4.0 bar (a cluster
+// running instant recall at its default solo_floor), a 0.3 hit is far too weak to claim
+// prior knowledge — the high-bar behaviour is unchanged. This is the guard that the fix
+// LOWERS the bar only where the operator lowered solo_floor, never globally.
+func TestMatchedKnowledgeDefaultFloorRejectsSub1(t *testing.T) {
+	cat := fakeScoredCatalog{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "weak", Path: "weak.md"}, Score: 0.3},
+	}}
+	got := runKBLoopWithMatchScore(t, cat, kbClearMatchScoreDefault) // default 4.0 floor
+	if got.MatchedKnowledge != nil {
+		t.Fatalf("a 0.3 hit under the 4.0 default bar must NOT be captured, got %+v", got.MatchedKnowledge)
+	}
+}
+
+// TestMatchedKnowledgeUnconfiguredFallsBackToDefault: instant recall disabled/unconfigured
+// ⇒ no SoloFloor to borrow ⇒ KBMatchScore 0 ⇒ the tracker falls back to the historical 4.0
+// bar. A 0.3 hit is not surfaced; a hit above 4.0 still is — behaviour is unchanged when
+// nothing is configured.
+func TestMatchedKnowledgeUnconfiguredFallsBackToDefault(t *testing.T) {
+	weak := fakeScoredCatalog{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "weak", Path: "weak.md"}, Score: 0.3},
+	}}
+	if got := runKBLoopWithMatchScore(t, weak, 0); got.MatchedKnowledge != nil {
+		t.Fatalf("unconfigured (0) must fall back to 4.0; a 0.3 hit must not be captured, got %+v", got.MatchedKnowledge)
+	}
+	strong := fakeScoredCatalog{hits: []catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "Harbor probe runbook", Path: "runbooks/harbor.md"}, Score: kbClearMatchScoreDefault + 1},
+	}}
+	if got := runKBLoopWithMatchScore(t, strong, 0); got.MatchedKnowledge == nil {
+		t.Fatalf("unconfigured (0) fallback should still stamp an above-4.0 hit, got nil")
 	}
 }
 
@@ -101,7 +165,7 @@ func TestMatchedKnowledgeKeepsStrongestAcrossCalls(t *testing.T) {
 	// A stateful fake that scores its hit lower on the second call, so "strongest wins"
 	// is distinguishable from "most recent wins": the tracker must keep the first,
 	// higher score.
-	stateful := &decliningCatalog{scores: []float64{kbClearMatchScore + 3, kbClearMatchScore + 1}}
+	stateful := &decliningCatalog{scores: []float64{kbClearMatchScoreDefault + 3, kbClearMatchScoreDefault + 1}}
 	var got providers.Investigation
 	li := &LoopInvestigator{
 		Model:      model,
@@ -115,8 +179,8 @@ func TestMatchedKnowledgeKeepsStrongestAcrossCalls(t *testing.T) {
 	if got.MatchedKnowledge == nil {
 		t.Fatalf("expected a captured hit")
 	}
-	if got.MatchedKnowledge.Score != kbClearMatchScore+3 {
-		t.Fatalf("tracker kept Score %v, want the strongest %v", got.MatchedKnowledge.Score, kbClearMatchScore+3)
+	if got.MatchedKnowledge.Score != kbClearMatchScoreDefault+3 {
+		t.Fatalf("tracker kept Score %v, want the strongest %v", got.MatchedKnowledge.Score, kbClearMatchScoreDefault+3)
 	}
 }
 

--- a/internal/investigate/kbsearch_tool.go
+++ b/internal/investigate/kbsearch_tool.go
@@ -26,18 +26,30 @@ type KBSearchTool struct {
 	hits *kbHitTracker
 }
 
-// kbClearMatchScore is the BM25 bar a kb_search hit's top score must clear to count
-// as a "clear match" worth surfacing on the notification. It mirrors instant recall's
-// default SoloFloor (config load default 4.0) — the score at which recall trusts a
-// LONE BM25 hit enough to short-circuit the whole investigation. The reasoning: if a
-// hit is strong enough that recall would have delivered it as the answer on its own,
-// it is unquestionably strong enough to tell the on-call "we already have a runbook
-// for this". Surfacing (a low-stakes hint on an investigation that still ran in full)
-// is a strictly weaker claim than recall's short-circuit, so borrowing recall's most
-// conservative single-hit bar keeps this high-precision — no noise from weak,
-// tangentially-relevant hits. BM25 scores are corpus-dependent; recording Score on
-// every match lets this be tuned from live data exactly as the recall thresholds are.
-const kbClearMatchScore = 4.0
+// kbClearMatchScoreDefault is the FALLBACK BM25 bar a kb_search hit's top score must
+// clear to count as a "clear match" worth surfacing on the notification. It is used only
+// when instant recall is disabled/unconfigured, so there is no configured floor to
+// borrow; when recall IS configured the per-investigation tracker instead tracks the
+// operator's CONFIGURED SoloFloor (see newKBHitTracker + the app wiring), keeping the
+// visibility bar in the same BM25 score regime kb_search actually runs in.
+//
+// Why the SoloFloor is the right thing to track: it is the score at which recall trusts a
+// LONE BM25 hit enough to short-circuit the whole investigation. If a hit is strong
+// enough that recall would have delivered it as the answer on its own, it is
+// unquestionably strong enough to tell the on-call "we already have a runbook for this".
+// Surfacing (a low-stakes hint on an investigation that still ran in full) is a strictly
+// WEAKER claim than recall's short-circuit, so borrowing recall's most conservative
+// single-hit bar keeps this high-precision — no noise from weak, tangential hits.
+//
+// The bar MUST track config because BM25 scores are corpus/query-dependent: a real
+// Alertmanager-driven cluster whose label-derived alert queries score ~0.1–0.3 tunes
+// solo_floor DOWN (observed live: 0.2). A hardcoded 4.0 would make this visibility signal
+// a silent no-op on exactly those clusters — kb_search finds the runbook, yet the "Matches
+// known runbook" block could never show (live-found). Score is recorded on every match so
+// the bar can be tuned from live data exactly as the recall thresholds are. The default is
+// kept at 4.0 (instant recall's default SoloFloor) so behaviour is unchanged when nothing
+// is configured.
+const kbClearMatchScoreDefault = 4.0
 
 // kbHitTracker accumulates the single strongest clear-match kb_search hit across an
 // investigation's tool calls. An assistant turn's tool calls run concurrently
@@ -46,6 +58,23 @@ const kbClearMatchScore = 4.0
 type kbHitTracker struct {
 	mu   sync.Mutex
 	best *providers.MatchedEntry
+	// clearMatchScore is the BM25 bar the top hit must clear to be recorded. It is set
+	// per investigation (see newKBHitTracker) from the operator's configured recall
+	// SoloFloor, so the visibility bar auto-adapts to the cluster's BM25 scale instead of
+	// being pinned to a hardcoded 4.0. Read-only after construction, so the mutex above
+	// (which guards best) need not cover it.
+	clearMatchScore float64
+}
+
+// newKBHitTracker builds a per-investigation tracker whose clear-match bar is
+// clearMatchScore. A non-positive value — instant recall disabled/unconfigured, so there
+// is no configured SoloFloor to borrow — falls back to kbClearMatchScoreDefault, keeping
+// the historical 4.0 bar so behaviour is unchanged when nothing is configured.
+func newKBHitTracker(clearMatchScore float64) *kbHitTracker {
+	if clearMatchScore <= 0 {
+		clearMatchScore = kbClearMatchScoreDefault
+	}
+	return &kbHitTracker{clearMatchScore: clearMatchScore}
 }
 
 // observe keeps e when it out-scores the current best (or there is none yet). It
@@ -131,7 +160,7 @@ func (t KBSearchTool) observeTopHit(scored []catalog.ScoredEntry) {
 		return
 	}
 	top := scored[0]
-	if top.Score < kbClearMatchScore {
+	if top.Score < t.hits.clearMatchScore {
 		return // not confidently a known-runbook match — surfacing it would be noise
 	}
 	// Carry Path + Title (+ Score). URL is deliberately left empty: the entry's web

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -179,6 +179,16 @@ type LoopInvestigator struct {
 	// Pricing (so a cheaper verify model is costed correctly when configured).
 	Pricing       *Pricing
 	VerifyPricing *Pricing
+
+	// KBMatchScore is the BM25 bar the per-investigation kb_search hit tracker uses to
+	// decide a hit is a "clear match" worth surfacing on the notification
+	// (Investigation.MatchedKnowledge). It is threaded from the operator's CONFIGURED
+	// recall SoloFloor (see BuildInvestigator) so the visibility bar tracks the same
+	// corpus/query-dependent BM25 score regime kb_search runs in: a cluster that tunes
+	// solo_floor DOWN for its sub-1.0 alert-query scores gets a correspondingly low bar
+	// instead of the feature silently no-opping. 0 (recall disabled/unconfigured) ⇒ the
+	// tracker falls back to the historical 4.0 default (kbClearMatchScoreDefault).
+	KBMatchScore float64
 }
 
 // system returns the system prompt, extended with action proposals when the policy is
@@ -313,7 +323,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	// the delivered finding (Investigation.MatchedKnowledge) as visible proof RunLore
 	// already had knowledge for this incident. scopeTools returned a fresh slice, so
 	// replacing an element leaves the shared li.Tools untouched.
-	kbHits := &kbHitTracker{}
+	kbHits := newKBHitTracker(li.KBMatchScore)
 	for i, t := range tools {
 		if kb, ok := t.(KBSearchTool); ok {
 			tools[i] = kb.withHitTracker(kbHits)


### PR DESCRIPTION
## The bug (found live)

PR #290 added the **📚 Matches known runbook** notification block — surfaced
(`Investigation.MatchedKnowledge`) when a *full* investigation's `kb_search`
tool matches a pre-existing catalog entry. The stamping was gated by a
**hardcoded constant `kbClearMatchScore = 4.0`** in
`internal/investigate/kbsearch_tool.go`, chosen to mirror the *default* recall
`SoloFloor` (4.0).

But BM25 scores are **corpus/query-dependent**. A real Alertmanager-driven
cluster tunes `catalog.instant_recall.solo_floor` **down** (observed live:
`0.2`) because label-derived alert queries score ~0.1–0.3. On such a cluster
`kb_search` hits never reach 4.0 → `MatchedKnowledge` is never stamped → **the
visibility feature silently no-ops on exactly the clusters that need it.**
Confirmed live: a Harbor investigation matched its runbook (`kb_search` found
it) yet no "Matches known runbook" block could ever show, because scores are
sub-1.0.

## The fix

Make the kb-match visibility bar **track the configured recall floor** instead
of a hardcoded 4.0. `kb_search` runs in the *same* BM25 score regime as instant
recall, and the block is documented as *strictly weaker than recall's
short-circuit*, so deriving the bar from the operator's **configured
`SoloFloor`** (recall's most conservative single-hit bar) is the right design —
it auto-adapts to the cluster's BM25 scale:

| configured `solo_floor` | kb-match bar |
| --- | --- |
| 4.0 (default) | 4.0 (unchanged) |
| 0.2 (tuned live) | 0.2 |
| recall disabled/unconfigured | 4.0 fallback |

**Homing:** derived from the existing `SoloFloor` — no new redundant config
knob. The score threads from config through the `LoopInvestigator`
(`KBMatchScore`) into the per-investigation `kbHitTracker` at construction,
exactly the way the recall thresholds already flow. `newKBHitTracker` applies
the `<= 0 → 4.0` fallback so **default-4.0 behaviour is unchanged when nothing
is configured**. Wired in all three delivery paths that carry a recall (serve /
`BuildInvestigator`, CLI `investigate`, reinvestigate poller).

## Tests (TDD)

- `TestMatchedKnowledgeTracksLowConfiguredFloor` — a 0.3 hit under a **0.2**
  configured floor **is** stamped (the live regime; fails against the old 4.0).
- `TestMatchedKnowledgeDefaultFloorRejectsSub1` — a 0.3 hit under the **4.0**
  default is **not** stamped (unchanged high-bar behaviour).
- `TestMatchedKnowledgeUnconfiguredFallsBackToDefault` — `KBMatchScore = 0`
  falls back to 4.0 (0.3 rejected, >4.0 stamped).

## Gate

`go build`, `go vet`, `gofmt -l`, `go test ./...`, `-race` on
`internal/investigate` + `internal/app`, and `golangci-lint run ./...` (**0
issues**) all green.