### PR TITLE
fix(catalog): skip README.md when loading the KB (docs, not an entry)

### DIFF
--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -13,7 +13,9 @@ import (
 )
 
 // Load walks dir and parses every concept .md file into an Entry. The reserved
-// OKF files index.md and log.md are skipped.
+// OKF files index.md and log.md — and a repo README.md — are skipped: they are
+// human-facing docs, not knowledge entries, so indexing them would pollute search
+// and (README, which carries no OKF frontmatter) trip the validator for no reason.
 //
 // A file that fails to parse (e.g. malformed YAML frontmatter) is skipped rather
 // than failing the whole load — its path is returned in skipped so the caller can
@@ -36,7 +38,7 @@ func Load(dir string) (entries []Entry, skipped []string, err error) {
 		if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".md") {
 			return nil
 		}
-		if base == "index.md" || base == "log.md" {
+		if base == "index.md" || base == "log.md" || strings.EqualFold(base, "readme.md") {
 			return nil
 		}
 		e, perr := parseEntry(dir, path)

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -27,6 +27,7 @@ tags: [flux, helmrelease, upgrade]
 Ready=False after a chart bump.
 `)
 	writeEntry(t, dir, "index.md", "---\ntype: Index\n---\n# ignored\n") // reserved, skipped
+	writeEntry(t, dir, "README.md", "# repo docs, no frontmatter\n")     // reserved, skipped
 	writeEntry(t, dir, "notes.txt", "not markdown")                      // skipped
 
 	entries, _, err := Load(dir)
@@ -34,7 +35,7 @@ Ready=False after a chart bump.
 		t.Fatalf("Load: %v", err)
 	}
 	if len(entries) != 1 {
-		t.Fatalf("want 1 entry (index.md + .txt skipped), got %d", len(entries))
+		t.Fatalf("want 1 entry (index.md + README.md + .txt skipped), got %d", len(entries))
 	}
 	e := entries[0]
 	if e.Type != "Playbook" || e.Title != "HelmRelease upgrade failure" || len(e.Tags) != 3 {


### PR DESCRIPTION
## Why

While hardening the learning loop I ran RunLore's own `lore validate-kb` against the live KB repo (`Smana/runlore-kb`) and found the repo's `README.md` reported as a broken entry:

```
error  README.md  type: frontmatter `type` is required (OKF conformance)
```

The live indexer logs the same on every load (`invalid KB entry indexed path=README.md`). A `README.md` is human-facing documentation with no OKF frontmatter — it is **not** a knowledge entry. Two consequences:

1. **A KB repo can never pass its own merge gate.** Adding a `validate-kb` CI to the KB repo (in progress) would fail purely on the README.
2. **BM25 pollution.** The README's meta-content about how the catalog works gets indexed and can surface in `kb_search` during investigations.

## What

Reserve `README.md` (case-insensitively) alongside the OKF-reserved `index.md` and `log.md`, so it is skipped by both the live indexer and `validate-kb`. One-line change in `catalog.Load` plus a doc-comment and a test case.

## Testing

- `go test ./internal/catalog/` — extended the reserved-files test to also write a `README.md` and assert it is skipped (entry count stays 1).
- Re-ran `lore validate-kb` against the KB repo: `README.md` is no longer reported (the remaining findings are genuine content issues in a few entries, fixed in the companion `runlore-kb` cleanup PR).