### PR TITLE
feat(notify): make an instant-recall short-circuit visible in the notification

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -421,6 +421,17 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 			}
 		}
 	}
+	// A recall already carries Prior (cause + resolution, stamped by recalledInvestigation
+	// from the matched entry); enrich it with the entry's recall track record so the
+	// "⚡ instant recall" block can show the resolve rate — the outcome-ledger signal that
+	// makes the cache hit trustworthy. Read before this run's own open is recorded, so the
+	// rate describes prior recalls only.
+	if found.Recalled && found.Prior != nil && found.RecalledEntry != "" {
+		if counts, err := ledger.OpenCounts(); err == nil {
+			agg := counts[found.RecalledEntry]
+			found.Prior.Recalls, found.Prior.Resolved = agg.Recalls, agg.Resolved
+		}
+	}
 	// Curate BEFORE recording the outcome open — the open event is the durable record
 	// of THIS investigation and must carry the KB link that recurrence pointers and
 	// the learning loop later read back; delivery also links to the KB issue/PR. A

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -410,6 +410,14 @@ func recalledInvestigation(req Request, e catalog.Entry, confidence float64) pro
 		RecalledEntry: e.Path,
 		Resource:      req.Workload,
 	}
+	// Quote the entry's human-reviewed cause + resolution so the notification makes the
+	// cache hit substantive (the "⚡ instant recall" block), not just a low-confidence
+	// finding. The recall track record (resolve rate) is filled in downstream by
+	// onInvestigationComplete, which has the outcome ledger. Best-effort: empty sections
+	// simply render nothing.
+	if cause, resolution := e.Section("Cause"), e.Section("Resolution"); cause != "" || resolution != "" {
+		inv.Prior = &providers.PriorKnowledge{Cause: cause, Resolution: resolution, EntryPath: e.Path}
+	}
 	stampRequestFacts(&inv, req) // same trigger-time facts as the full-loop site, factored to prevent drift
 	return inv
 }

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -176,6 +176,24 @@ func TestRecalledInvestigationCarriesEntryPath(t *testing.T) {
 	}
 }
 
+// A recall quotes the entry's Cause + Resolution into Prior so the notifier can make
+// the cache hit substantive ("⚡ instant recall") instead of a bare low-confidence
+// finding. The resolve-rate is filled in downstream (needs the ledger).
+func TestRecalledInvestigationStampsPrior(t *testing.T) {
+	e := catalog.Entry{Title: "T", Path: "p.md", Body: "## Cause\nIAM quota hit\n\n## Resolution\ndelete a key\n"}
+	inv := recalledInvestigation(Request{Title: "x"}, e, 0.7)
+	if inv.Prior == nil {
+		t.Fatal("recall must stamp Prior from the matched entry")
+	}
+	if inv.Prior.Cause != "IAM quota hit" || inv.Prior.Resolution != "delete a key" || inv.Prior.EntryPath != "p.md" {
+		t.Fatalf("Prior not stamped from entry sections: %+v", inv.Prior)
+	}
+	// An entry with no Cause/Resolution sections leaves Prior nil (nothing to quote).
+	if got := recalledInvestigation(Request{Title: "x"}, catalog.Entry{Title: "T", Path: "p.md"}, 0.7); got.Prior != nil {
+		t.Fatalf("Prior must be nil when the entry has no Cause/Resolution: %+v", got.Prior)
+	}
+}
+
 func TestRecalledInvestigationStampsAlertMetadata(t *testing.T) {
 	// The recall short-circuit must carry the same trigger-time facts as the full
 	// loop so a recalled delivery renders an identical notification metadata block.

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -63,7 +63,26 @@ func Format(inv providers.Investigation) string {
 	// (Prior), the previous cause and human-reviewed resolution are quoted
 	// inline — the zero-click payoff of the knowledge base; otherwise the
 	// counter + link still tell the reader this is not new.
-	if inv.Occurrences > 1 {
+	if inv.Recalled && inv.Prior != nil {
+		// Recall short-circuit: make the knowledge-base cache hit explicit (no fresh
+		// investigation ran) and quote the known answer + its resolve-rate track record.
+		p := inv.Prior
+		b.WriteString("⚡ Instant recall — answered from your knowledge base, no investigation was run\n")
+		if p.Cause != "" {
+			fmt.Fprintf(&b, "   Known cause: %s\n", p.Cause)
+		}
+		if p.Resolution != "" {
+			fmt.Fprintf(&b, "   Validated resolution: %s\n", p.Resolution)
+		}
+		if p.Recalls > 0 {
+			fmt.Fprintf(&b, "   Resolve rate: %d/%d recalls resolved\n", p.Resolved, p.Recalls)
+		}
+		if ref := inv.PrevCuratedURL; ref != "" {
+			fmt.Fprintf(&b, "   Knowledge-base entry: %s\n", ref)
+		} else if p.EntryPath != "" {
+			fmt.Fprintf(&b, "   Knowledge-base entry: %s\n", p.EntryPath)
+		}
+	} else if inv.Occurrences > 1 {
 		fmt.Fprintf(&b, "📚 Seen before: ×%d — last investigated %s\n", inv.Occurrences, inv.LastOccurrence.UTC().Format(time.RFC3339))
 		if p := inv.Prior; p != nil {
 			if p.Cause != "" {

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -116,6 +116,36 @@ func TestFormatPriorKnowledge(t *testing.T) {
 	}
 }
 
+// TestFormatRecall asserts a recall renders the explicit "⚡ Instant recall"
+// block (known answer + resolve rate + entry) regardless of the occurrence counter,
+// and never the "Seen before" fresh-recurrence framing.
+func TestFormatRecall(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "HarborRegistryDown", Confidence: 0.6,
+		Recalled: true, RecalledEntry: "harbor-registry-down.md",
+		Occurrences: 1, // fresh trigger key
+		Prior: &providers.PriorKnowledge{
+			Cause: "AccessKey hit IAM quota", Resolution: "delete an unused access key",
+			EntryPath: "harbor-registry-down.md", Recalls: 3, Resolved: 3,
+		},
+	}
+	out := Format(inv)
+	for _, want := range []string{
+		"⚡ Instant recall — answered from your knowledge base, no investigation was run",
+		"Known cause: AccessKey hit IAM quota",
+		"Validated resolution: delete an unused access key",
+		"Resolve rate: 3/3 recalls resolved",
+		"Knowledge-base entry: harbor-registry-down.md",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Format recall missing %q\n---\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Seen before") {
+		t.Errorf("recall must not use the Seen-before framing\n%s", out)
+	}
+}
+
 // TestFormatSeenBeforeWithoutPrior asserts that without Prior the block keeps
 // today's counter+link shape (no empty labels).
 func TestFormatSeenBeforeWithoutPrior(t *testing.T) {

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -403,16 +403,33 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 	// count, date and link all live here.
 	if p := inv.Prior; p != nil {
 		var s strings.Builder
-		fmt.Fprintf(&s, "📚 *Seen before ×%d* — last %s", inv.Occurrences, slackDate(inv.LastOccurrence))
+		// Two shapes share this block. A RECALL short-circuited the loop: without an
+		// explicit marker the message reads as a low-confidence fresh investigation, so
+		// lead with "⚡ Instant recall" and label the quoted sections as the KNOWN answer.
+		// A recurring FRESH investigation instead leads with the "Seen before ×N" counter.
+		causeLabel, resLabel := "Prior cause", "Prior resolution"
+		if inv.Recalled {
+			s.WriteString("⚡ *Instant recall* — answered from your knowledge base, no investigation was run")
+			causeLabel, resLabel = "Known cause", "Validated resolution"
+		} else {
+			fmt.Fprintf(&s, "📚 *Seen before ×%d* — last %s", inv.Occurrences, slackDate(inv.LastOccurrence))
+		}
 		if p.Cause != "" {
-			fmt.Fprintf(&s, "\n*Prior cause:* %s", escapeMrkdwn(p.Cause))
+			fmt.Fprintf(&s, "\n*%s:* %s", causeLabel, escapeMrkdwn(p.Cause))
 		}
 		if p.Resolution != "" {
-			fmt.Fprintf(&s, "\n*Prior resolution:* %s", escapeMrkdwn(p.Resolution))
+			fmt.Fprintf(&s, "\n*%s:* %s", resLabel, escapeMrkdwn(p.Resolution))
 		}
 		foot := make([]string, 0, 2)
-		if inv.PrevCuratedURL != "" {
-			foot = append(foot, fmt.Sprintf("<%s|previous entry>", escapeMrkdwn(inv.PrevCuratedURL)))
+		switch {
+		case inv.PrevCuratedURL != "":
+			label := "previous entry"
+			if inv.Recalled {
+				label = "knowledge-base entry"
+			}
+			foot = append(foot, fmt.Sprintf("<%s|%s>", escapeMrkdwn(inv.PrevCuratedURL), label))
+		case inv.Recalled && p.EntryPath != "":
+			foot = append(foot, fmt.Sprintf("`%s`", escapeMrkdwn(p.EntryPath)))
 		}
 		if p.Recalls > 0 {
 			foot = append(foot, fmt.Sprintf("resolve rate %d/%d", p.Resolved, p.Recalls))

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -614,6 +614,47 @@ func TestSlackSummaryBlocksPriorKnowledge(t *testing.T) {
 	}
 }
 
+// A recall short-circuit must be VISIBLE: the block leads with "⚡ Instant recall"
+// (not "Seen before"), labels the quoted sections as the KNOWN answer, links the
+// knowledge-base entry, and shows the resolve-rate track record — otherwise the
+// notification reads as a low-confidence fresh investigation.
+func TestSlackSummaryBlocksRecall(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "HarborRegistryDown", Confidence: 0.6,
+		Recalled:      true,
+		RecalledEntry: "harbor-registry-down.md",
+		Occurrences:   1, // fresh trigger key — recall framing must not depend on the counter
+		Prior: &providers.PriorKnowledge{
+			Cause: "AccessKey hit IAM quota", Resolution: "delete an unused access key",
+			EntryPath: "harbor-registry-down.md", Recalls: 3, Resolved: 3,
+		},
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	for _, want := range []string{
+		"⚡ *Instant recall*",
+		"no investigation was run",
+		"*Known cause:* AccessKey hit IAM quota",
+		"*Validated resolution:* delete an unused access key",
+		"`harbor-registry-down.md`", // entry path shown inline when no curated URL
+		"resolve rate 3/3",
+	} {
+		if !strings.Contains(txt, want) {
+			t.Errorf("recall summary missing %q\n%s", want, txt)
+		}
+	}
+	for _, absent := range []string{"Seen before", "Prior cause"} {
+		if strings.Contains(txt, absent) {
+			t.Errorf("recall block must not use the fresh-recurrence framing %q\n%s", absent, txt)
+		}
+	}
+	// With a curated URL, the entry links instead of showing the bare path.
+	inv.PrevCuratedURL = "https://kb/pr/42"
+	txt = blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "knowledge-base entry") {
+		t.Errorf("recall with curated URL must link the knowledge-base entry\n%s", txt)
+	}
+}
+
 // Without Prior, the legacy counter field + context pointer stay untouched.
 func TestSlackSummaryBlocksRecurrenceWithoutPrior(t *testing.T) {
 	inv := providers.Investigation{


### PR DESCRIPTION
## Why

When instant recall matches a known incident it **short-circuits the whole investigation** — the headline payoff of the learning loop. But the notification gave no sign of it: a recall rendered as a bare, low-confidence finding (no verdict badge, confidence tempered by the confirm/verify pass), visually **indistinguishable from a weak fresh investigation**. The on-call couldn't tell that RunLore had answered *instantly from its own knowledge base*, nor see the track record that makes the cached answer trustworthy.

Found while validating the learning loop end-to-end on a live cluster: the Harbor recall fired correctly (`instant recall (catalog hit; skipping the loop)`), but the delivered Slack message looked like a 30 %-confidence investigation with no indication it was a recall.

## What

A recalled finding now leads with an explicit block (Slack + text/webhook):

```
⚡ Instant recall — answered from your knowledge base, no investigation was run
   Known cause: <the entry's ## Cause>
   Validated resolution: <the entry's human-reviewed ## Resolution>
   <knowledge-base entry link> · resolve rate 3/3
```

- `recalledInvestigation` stamps `Prior` (Cause + Resolution) from the matched entry.
- `onInvestigationComplete` enriches it with the entry's **recall track record** (resolve rate) from the outcome ledger — the signal that makes a cache hit trustworthy.
- The Slack and text/webhook notifiers branch on `Recalled`: the recall framing above, versus the existing `📚 Seen before ×N` block for a recurring **fresh** investigation. Keyed on `Recalled` (not the occurrence counter), so a recall on a first-seen trigger key still surfaces the cache hit.

No change to recall *behaviour* — purely how a recall is rendered. The `Seen before ×N` recurrence block for fresh re-investigations is untouched.

## Testing

- New unit tests: `TestSlackSummaryBlocksRecall`, `TestFormatRecall`, `TestRecalledInvestigationStampsPrior` (+ the empty-sections nil case).
- `go test ./internal/notify/ ./internal/investigate/ ./internal/app/` green; `go vet` + `gofmt` clean.
- Will validate live: redeploy + fire the Harbor recall and screenshot the new block.