### PR TITLE
fix(recall): confirm namespace-wide so verify can see cross-resource causes

### DIFF
--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -40,7 +40,7 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		if !ok {
 			continue
 		}
-		out, err := t.Call(ctx, confirmArgs(name, req.Workload))
+		out, err := t.Call(ctx, confirmArgs(req.Workload))
 		if err != nil {
 			if li.Log != nil {
 				li.Log.Debug("recall confirm tool failed", "tool", name, "err", err)
@@ -57,13 +57,20 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 	return inv, gathered
 }
 
-// confirmArgs builds the JSON args scoping a confirmatory tool to the workload.
-func confirmArgs(name string, w providers.Workload) string {
-	m := map[string]string{"namespace": w.Namespace}
-	if name == "kube_events" && w.Name != "" {
-		m["object"] = w.Name
-	}
-	b, _ := json.Marshal(m)
+// confirmArgs builds the JSON args for a confirmatory tool: namespace-scoped, but
+// deliberately NOT scoped to the workload object.
+//
+// A recalled incident's ROOT CAUSE frequently lives on a SIBLING resource in the same
+// namespace — a Crossplane AccessKey, a dependency, an upstream — not on the alerting
+// pod itself. Scoping kube_events to the pod (its old behaviour) captured the SYMPTOM
+// ("pod failing, secret key missing") but HID the cause (the AccessKey's
+// "LimitExceeded: AccessKeysPerUser: 2" Warning lives on a different object). The verify
+// pass, judging the recalled cause only on the gathered evidence, then couldn't confirm
+// it end-to-end and systematically DOWNGRADED a correct recall. kube_events is
+// Warning-only + namespace-wide by default ("causes that live nearby"), which is exactly
+// the causal context verify needs to keep a right recall's confidence intact.
+func confirmArgs(w providers.Workload) string {
+	b, _ := json.Marshal(map[string]string{"namespace": w.Namespace})
 	return string(b)
 }
 

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -50,7 +50,11 @@ func TestConfirmRecallAppendsCurrentState(t *testing.T) {
 	}
 }
 
-func TestConfirmRecallScopesToWorkload(t *testing.T) {
+// confirmRecall gathers state namespace-wide, NOT scoped to the workload object: a
+// recalled cause often lives on a sibling resource (a Crossplane AccessKey, a
+// dependency), so an object filter would hide the cause and make verify downgrade a
+// correct recall. kube_events must therefore carry the namespace and NO `object`.
+func TestConfirmRecallIsNamespaceWideNotObjectScoped(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "ok"}
 	ev := &fakeConfirmTool{name: "kube_events", out: "Warning"}
 	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
@@ -61,8 +65,11 @@ func TestConfirmRecallScopesToWorkload(t *testing.T) {
 	if !strings.Contains(ps.gotArgs, `"namespace":"apps"`) {
 		t.Fatalf("pod_status not scoped to namespace: %q", ps.gotArgs)
 	}
-	if !strings.Contains(ev.gotArgs, `"namespace":"apps"`) || !strings.Contains(ev.gotArgs, `"object":"web"`) {
-		t.Fatalf("kube_events not scoped to namespace+object: %q", ev.gotArgs)
+	if !strings.Contains(ev.gotArgs, `"namespace":"apps"`) {
+		t.Fatalf("kube_events not scoped to namespace: %q", ev.gotArgs)
+	}
+	if strings.Contains(ev.gotArgs, `"object"`) {
+		t.Fatalf("kube_events must NOT scope to the workload object (would hide cross-resource causes): %q", ev.gotArgs)
 	}
 }
 


### PR DESCRIPTION
## Why

Digging into why instant recall delivered at a **systematically low confidence**: on the live cluster a real, currently-firing Harbor IAM-quota incident was recalled correctly but delivered at **~0.35**, even though the recall *decision* was ~0.60.

The mechanism (confirmed live):

- `confirmRecall` gathers current state and appends it to the finding so the adversarial `verify` pass can judge the recalled cause **against reality**.
- But it scoped `kube_events` to the **alerting workload object** (`object: <pod>`). Events scoped to the harbor-registry pod show the **symptom** — `Failed: couldn't find key username in Secret tooling/xplane-harbor-access-key` — but **not the cause**.
- The cause proof, `CannotCreateExternalResource … LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2`, lives on a **different object**: the Crossplane `accesskey/xplane-harbor`.
- So `verify`, judging the recalled cause *only on the evidence given*, saw "pod failing, secret key missing" with **no evidence the cause is an IAM quota** → **downgraded** a correct recall (`downgrade` sets `confidence = min(current, verdict)`).

A recalled incident's root cause very often lives on a **sibling** resource in the same namespace — a Crossplane claim, a dependency, an upstream — not on the alerting object itself.

## What

Drop the per-object scoping in `confirmArgs`: `kube_events` is already **Warning-only + namespace-wide by default** ("causes that live nearby"), which is exactly the causal context `verify` needs. One-line behavioural change + its rationale.

This **preserves verify's rigor** — a genuinely stale recall whose cause is *contradicted* by live state is still rejected; we just stop starving verify of the cause evidence so it can no longer downgrade a *correct* recall for lack of it.

## Testing

- `go test ./internal/investigate/` green. Updated the confirm test (`TestConfirmRecallIsNamespaceWideNotObjectScoped`) to assert `kube_events` carries the namespace and **no** `object` filter.
- Will validate live: redeploy + re-fire the Harbor recall — the delivered confidence should rise now that verify can see the `LimitExceeded` Warning.

Found while investigating the learning loop end-to-end (companion to the recall-visibility work in #297).