### PR TITLE
fix(observability): warn on unreachable metrics/logs backends + stamp :main version

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -71,7 +71,13 @@ jobs:
         id: ref
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        run: echo "image=${IMAGE,,}:main" >> "$GITHUB_OUTPUT"
+        # Also stamp a meaningful version for the rolling :main image. Without a
+        # VERSION build-arg the Dockerfile defaults to "dev" (so runlore_build_info and
+        # the dashboard's version panel just read "dev"); main-<short-sha> ties a running
+        # replica back to its exact commit.
+        run: |
+          echo "image=${IMAGE,,}:main" >> "$GITHUB_OUTPUT"
+          echo "version=main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       # PR: build single-arch amd64 without pushing — keep it fast. The in-image Go
       # compile (multi-stage Dockerfile) on amd64 is fine here; the Trivy fs scan
@@ -82,6 +88,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            VERSION=${{ steps.ref.outputs.version }}
           platforms: linux/amd64
           push: false
           load: true
@@ -97,6 +105,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            VERSION=${{ steps.ref.outputs.version }}
           platforms: linux/amd64
           push: true
           tags: ${{ steps.ref.outputs.image }}

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"time"
 
@@ -111,6 +112,7 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		}
 	}
 	if cfg.Metrics.URL != "" {
+		warnIfBackendUnreachable(ctx, log, "metrics", cfg.Metrics.URL)
 		m := prometheus.NewWithAuth(cfg.Metrics.URL, cfg.Metrics.TokenEnv, cfg.Metrics.Headers)
 		tools = append(tools,
 			investigate.QueryMetricsTool{Metrics: m},
@@ -118,6 +120,7 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		)
 	}
 	if cfg.Logs.URL != "" {
+		warnIfBackendUnreachable(ctx, log, "logs", cfg.Logs.URL)
 		tools = append(tools, investigate.QueryLogsTool{Logs: victorialogs.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers)})
 	}
 	// Network-flow data source (the network_drops tool). Pluggable and CNI-agnostic:
@@ -376,6 +379,34 @@ type investigationCurator interface {
 // Narrowed to an interface so the completion pipeline is testable without an index.
 type priorEntryFinder interface {
 	FindFingerprint(fp string) (catalog.Entry, bool)
+}
+
+// warnIfBackendUnreachable probes a configured metrics/logs backend once at startup
+// and logs a loud WARN if it can't be reached. Without this the failure is SILENT and
+// insidious: a NetworkPolicy that blocks egress (or a wrong URL) doesn't stop startup —
+// the agent runs, but every metrics/logs tool call hangs until it times out mid-
+// investigation, starving the analysis of those signals (and burning the per-
+// investigation deadline half-blind). Any HTTP response — even 401/404 — counts as
+// reachable; only a connection error or timeout is a problem. Best-effort and
+// non-fatal: the probe never blocks startup beyond its short timeout.
+func warnIfBackendUnreachable(ctx context.Context, log *slog.Logger, kind, rawURL string) {
+	if log == nil || rawURL == "" {
+		return
+	}
+	pctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(pctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return // a malformed URL is caught by config validation, not here
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Warn("configured "+kind+" backend is UNREACHABLE — investigations will run WITHOUT it "+
+			"(check the NetworkPolicy egress to this endpoint's port, or the URL)",
+			"kind", kind, "url", rawURL, "err", err)
+		return
+	}
+	_ = resp.Body.Close()
 }
 
 // onInvestigationComplete runs the post-investigation pipeline once the loop returns

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -245,4 +247,32 @@ func TestBuildVerifyModel(t *testing.T) {
 	if got := BuildVerifyModel(withOverride); got == nil {
 		t.Fatal("BuildVerifyModel with override = nil, want a non-nil model")
 	}
+}
+
+// A configured-but-unreachable metrics/logs backend must WARN loudly at startup
+// (the silent-half-blind failure this guards against); a reachable one — even one
+// answering 404 — must stay quiet.
+func TestWarnIfBackendUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // any HTTP response ⇒ reachable
+	}))
+	defer srv.Close()
+
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	warnIfBackendUnreachable(context.Background(), log, "metrics", srv.URL)
+	if strings.Contains(buf.String(), "UNREACHABLE") {
+		t.Fatalf("reachable backend must not warn:\n%s", buf.String())
+	}
+
+	buf.Reset()
+	warnIfBackendUnreachable(context.Background(), log, "logs", "http://127.0.0.1:1")
+	if !strings.Contains(buf.String(), "UNREACHABLE") || !strings.Contains(buf.String(), "logs") {
+		t.Fatalf("unreachable backend must warn with its kind:\n%s", buf.String())
+	}
+
+	// Empty URL and nil logger are no-ops (no panic).
+	warnIfBackendUnreachable(context.Background(), log, "metrics", "")
+	warnIfBackendUnreachable(context.Background(), nil, "metrics", "http://127.0.0.1:1")
 }


### PR DESCRIPTION
Two observability failures that were invisible until you went looking — surfaced while diagnosing why a live `KubeAPIDown` investigation burned ~180k tokens to an inconclusive result.

## 1. Fail loud when a metrics/logs backend is unreachable

A configured `metrics.url` / `logs.url` the agent **can't reach** (a NetworkPolicy that blocks egress to its port — VictoriaMetrics `:8428` / VictoriaLogs `:9428` aren't on 443/6443 — or a wrong URL) failed **silently**: startup succeeded, but every metrics/logs tool call then **hung until it timed out mid-investigation**, starving the analysis of those signals and burning the per-investigation deadline half-blind.

Now `BuildInvestigator` **probes each configured backend once at startup** and logs a loud `WARN` if it's unreachable:

```
WARN configured metrics backend is UNREACHABLE — investigations will run WITHOUT it
     (check the NetworkPolicy egress to this endpoint's port, or the URL)
     kind=metrics url=http://vmsingle…:8428 err="dial tcp …: i/o timeout"
```

Any HTTP response — even `401`/`404` — counts as reachable; only a connection error/timeout warns. Best-effort and non-fatal (a 3s timeout, never blocks startup meaningfully).

## 2. Stamp a real version on the rolling `:main` image

The `:main` build never passed a `VERSION` build-arg, so the Dockerfile defaulted to `dev` — `runlore_build_info` and the dashboard's version panel just read **"dev"**. `build-image.yml` now stamps `VERSION=main-<short-sha>`, tying a running replica back to its exact commit.

## Testing

- `go test ./internal/app/` green; new `TestWarnIfBackendUnreachable` (reachable ⇒ quiet even on 404; unreachable ⇒ warns with its kind; empty URL / nil logger ⇒ no-op).
- Workflow YAML validated.

Companion to the cloud-native-ref NetworkPolicy egress fix (the immediate cause of the half-blind runs on the live cluster).