### PR TITLE
feat(observability): redesign the Grafana dashboard around learning-loop SLIs

### DIFF
--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -32,9 +32,9 @@
         "x": 0,
         "y": 0
       },
-      "id": 1,
+      "id": 114,
       "panels": [],
-      "title": "Overview",
+      "title": "\ud83e\udde0 Learning loop \u2014 is it working?",
       "type": "row"
     },
     {
@@ -42,70 +42,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Build version reported by the running RunLore agent(s).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": null
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 8,
-        "x": 0,
-        "y": 1
-      },
-      "id": 2,
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "name"
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "runlore_build_info",
-          "instant": true,
-          "legendFormat": "{{version}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Agent version",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Number of leader replicas. Healthy = exactly 1.",
+      "description": "Share of incidents answered INSTANTLY from the knowledge base (recall) vs a full investigation. The headline learning-loop KPI \u2014 it should climb as the catalog compounds.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -118,28 +55,28 @@
               {
                 "color": "red",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.15
               },
               {
                 "color": "green",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
+                "value": 0.35
               }
             ]
           },
-          "unit": "none"
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 8,
+        "w": 5,
+        "x": 0,
         "y": 1
       },
-      "id": 3,
+      "id": 101,
       "options": {
         "colorMode": "background",
         "graphMode": "none",
@@ -162,13 +99,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(runlore_leader)",
-          "instant": true,
-          "legendFormat": "leaders",
-          "refId": "A"
+          "expr": "sum(increase(runlore_outcomes_opened_total{kind=\"recall\"}[$__range])) / clamp_min(sum(increase(runlore_outcomes_opened_total[$__range])), 1)",
+          "legendFormat": "fire-rate",
+          "refId": "A",
+          "instant": true
         }
       ],
-      "title": "Active leaders",
+      "title": "Recall fire-rate",
       "type": "stat"
     },
     {
@@ -176,7 +113,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Replicas currently exporting build info (i.e. reporting to Prometheus).",
+      "description": "Of the recalls that fired, the share the adversarial verify pass kept at full confidence (vs downgraded/rejected). A low value means recalls fire but don't hold up \u2014 check confirm evidence / entry quality.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -191,24 +128,28 @@
                 "value": null
               },
               {
+                "color": "yellow",
+                "value": 0.6
+              },
+              {
                 "color": "green",
-                "value": 1
+                "value": 0.85
               }
             ]
           },
-          "unit": "none"
+          "unit": "percentunit"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 5,
-        "w": 8,
-        "x": 16,
+        "w": 5,
+        "x": 5,
         "y": 1
       },
-      "id": 4,
+      "id": 102,
       "options": {
-        "colorMode": "value",
+        "colorMode": "background",
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
@@ -229,13 +170,214 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(runlore_build_info)",
-          "instant": true,
-          "legendFormat": "replicas",
-          "refId": "A"
+          "expr": "(sum(increase(runlore_recall_hits_total{result=\"verified\"}[$__range])) or vector(0)) / clamp_min(sum(increase(runlore_recall_hits_total[$__range])), 1)",
+          "legendFormat": "verified",
+          "refId": "A",
+          "instant": true
         }
       ],
-      "title": "Replicas reporting",
+      "title": "Recall precision",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Recalls that were followed by the incident actually resolving. This is the ground-truth trust signal that drives outcome decay.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 10,
+        "y": 1
+      },
+      "id": 103,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(runlore_recall_outcome_total{result=\"resolved\"}[$__range])) / clamp_min(sum(increase(runlore_outcomes_opened_total{kind=\"recall\"}[$__range])), 1)",
+          "legendFormat": "resolved",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Recall resolve-rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Estimated model tokens NOT spent because a recall short-circuited a full investigation \u2014 the compounding payoff of the catalog.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 15,
+        "y": 1
+      },
+      "id": 104,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(runlore_recall_tokens_saved_total[$__range]))",
+          "legendFormat": "saved",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Tokens saved by recall",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Structurally-invalid entries at the MOST RECENT catalog index (6m window \u2248 one git-sync). >0 means entries are silently dropped from recall \u2014 fix them (see `lore validate-kb`).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 105,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(runlore_catalog_invalid_entries_total[6m]))",
+          "legendFormat": "invalid",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Invalid KB entries",
       "type": "stat"
     },
     {
@@ -246,9 +388,9 @@
         "x": 0,
         "y": 6
       },
-      "id": 10,
+      "id": 115,
       "panels": [],
-      "title": "Alert intake",
+      "title": "\ud83d\udd0e Retrieve \u2014 instant recall",
       "type": "row"
     },
     {
@@ -256,7 +398,388 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Rate of alerts entering the coalescer, folded into existing batches, and suppressed by cooldown.",
+      "description": "Every fired recall by the verify pass's verdict: verified (kept), downgraded (confidence lowered), rejected (withdrawn \u2192 fell through to a full investigation). Watch the downgraded share.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 7
+      },
+      "id": 106,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (result) (rate(runlore_recall_hits_total[$__rate_interval]))",
+          "legendFormat": "{{result}}",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Recall outcome by verify result",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Why a candidate did NOT short-circuit: low_outcome (trust decayed), rerank_low_confidence / rerank_no_signal (reranker), low_margin (BM25). The diagnostic for 'recall never fires'.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (reason) (rate(runlore_recall_rejections_total[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Recall rejections by reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Answer source over time: recall (instant) vs fresh (full investigation).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (kind) (rate(runlore_outcomes_opened_total[$__rate_interval]))",
+          "legendFormat": "{{kind}}",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Recall vs fresh (answer mix)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Distribution of BM25 recall scores at the decision point. Use this to tune min_score.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 42,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-09
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "show": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_recall_score_bucket[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Recall score distribution (BM25)",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 116,
+      "panels": [],
+      "title": "\ud83e\uddea Capture & trust \u2014 outcome ledger",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Investigations recorded in the outcome ledger (by kind) and incidents later resolved.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -310,9 +833,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 7
+        "y": 24
       },
-      "id": 11,
+      "id": 51,
       "options": {
         "legend": {
           "calcs": [
@@ -336,8 +859,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(runlore_alerts_received_total[$__rate_interval]))",
-          "legendFormat": "received",
+          "expr": "sum by (kind) (rate(runlore_outcomes_opened_total[$__rate_interval]))",
+          "legendFormat": "opened {{kind}}",
           "refId": "A"
         },
         {
@@ -346,22 +869,12 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(runlore_alerts_coalesced_total[$__rate_interval]))",
-          "legendFormat": "coalesced",
+          "expr": "sum(rate(runlore_incidents_resolved_total[$__rate_interval]))",
+          "legendFormat": "resolved",
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(runlore_alerts_suppressed_total[$__rate_interval]))",
-          "legendFormat": "suppressed",
-          "refId": "C"
         }
       ],
-      "title": "Alert intake rate",
+      "title": "Outcomes opened & incidents resolved",
       "type": "timeseries"
     },
     {
@@ -369,7 +882,288 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Distribution of incidents per flushed batch. A right-shifted distribution means the coalescer is folding many alerts together (good fan-in); a spike at 1 means little coalescing is happening.",
+      "description": "Open to resolve duration percentiles.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 52,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(runlore_incident_resolution_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(runlore_incident_resolution_seconds_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "Incident resolution time (p50 / p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Outcome of resolved incidents whose original answer was a recall short-circuit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 53,
+      "options": {
+        "displayLabels": [
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value"
+          ]
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (result) (increase(runlore_recall_outcome_total[$__range]))",
+          "instant": true,
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Recall outcome by result",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 117,
+      "panels": [],
+      "title": "\ud83d\udcdd Curate \u2014 knowledge growth",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Curation pass outcomes (catalog writes / dedup skips) by kind and result.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 12,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (kind, result) (rate(runlore_curations_total[$__rate_interval]))",
+          "legendFormat": "{{kind}} / {{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Curation rate by kind & result",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Catalog top-hit BM25 score at the curation dedup decision. Use this to tune the dedup threshold: high scores mean a near-duplicate entry already exists.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -389,9 +1183,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 41
       },
-      "id": 13,
+      "id": 55,
       "options": {
         "calculate": false,
         "cellGap": 1,
@@ -435,13 +1229,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(runlore_coalesce_batch_size_bucket[$__rate_interval])) by (le)",
+          "expr": "sum(rate(runlore_curation_dedup_score_bucket[$__rate_interval])) by (le)",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "refId": "A"
         }
       ],
-      "title": "Coalesced batch size distribution",
+      "title": "Curation dedup score distribution (BM25)",
       "type": "heatmap"
     },
     {
@@ -450,11 +1244,353 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 49
       },
-      "id": 20,
+      "id": 118,
       "panels": [],
-      "title": "Investigations",
+      "title": "\ud83d\udcb8 Cost & efficiency",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Per-investigation token estimate (p50 / p95) and estimated tokens saved per second via recall.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "tokens saved /s"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 50
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "tokens/investigation p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
+          "legendFormat": "tokens/investigation p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_recall_tokens_saved_total[$__rate_interval]))",
+          "legendFormat": "tokens saved /s",
+          "refId": "C"
+        }
+      ],
+      "title": "Token cost & savings",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Estimated USD per investigation (only populated when model.pricing is set). Recalls cost a fraction of a full loop.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 50
+      },
+      "id": 109,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(runlore_investigation_cost_usd_bucket[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "A",
+          "instant": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(runlore_investigation_cost_usd_bucket[$__rate_interval])))",
+          "legendFormat": "p95",
+          "refId": "B",
+          "instant": false
+        }
+      ],
+      "title": "Per-investigation cost (USD)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Share of input tokens served from the provider prompt cache \u2014 higher is cheaper/faster.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 50
+      },
+      "id": 110,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(runlore_model_cached_input_tokens_total[$__rate_interval])) / clamp_min(sum(rate(runlore_model_input_tokens_total[$__rate_interval])), 1)",
+          "legendFormat": "cached / input",
+          "refId": "A",
+          "instant": false
+        }
+      ],
+      "title": "Model cache hit ratio",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 119,
+      "panels": [],
+      "title": "\ud83d\udd2c Investigations",
       "type": "row"
     },
     {
@@ -514,9 +1650,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 16
+        "y": 59
       },
       "id": 21,
       "options": {
@@ -627,9 +1763,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 16
+        "w": 8,
+        "x": 8,
+        "y": 59
       },
       "id": 22,
       "options": {
@@ -740,9 +1876,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 24
+        "w": 8,
+        "x": 16,
+        "y": 59
       },
       "id": 23,
       "options": {
@@ -782,11 +1918,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 32
+        "y": 67
       },
-      "id": 30,
+      "id": 120,
       "panels": [],
-      "title": "Tools & model",
+      "title": "\ud83d\udee0 Tools & model",
       "type": "row"
     },
     {
@@ -846,9 +1982,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 33
+        "y": 68
       },
       "id": 31,
       "options": {
@@ -949,9 +2085,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 33
+        "w": 8,
+        "x": 8,
+        "y": 68
       },
       "id": 32,
       "options": {
@@ -1042,9 +2178,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 41
+        "w": 8,
+        "x": 16,
+        "y": 68
       },
       "id": 33,
       "options": {
@@ -1135,9 +2271,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 41
+        "w": 8,
+        "x": 0,
+        "y": 76
       },
       "id": 34,
       "options": {
@@ -1238,9 +2374,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 49
+        "w": 8,
+        "x": 8,
+        "y": 76
       },
       "id": 35,
       "options": {
@@ -1331,9 +2467,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 49
+        "w": 8,
+        "x": 16,
+        "y": 76
       },
       "id": 36,
       "options": {
@@ -1424,9 +2560,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 8,
         "x": 0,
-        "y": 57
+        "y": 84
       },
       "id": 12,
       "options": {
@@ -1466,11 +2602,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 92
       },
-      "id": 40,
+      "id": 121,
       "panels": [],
-      "title": "Recall efficacy",
+      "title": "\ud83d\udce5 Alert intake",
       "type": "row"
     },
     {
@@ -1478,7 +2614,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Knowledge-base instant-recall short-circuit rate (by verify result) and estimated tokens saved per second.",
+      "description": "Rate of alerts entering the coalescer, folded into existing batches, and suppressed by cooldown.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1526,32 +2662,15 @@
           },
           "unit": "ops"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "tokens saved /s"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "short"
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 66
+        "y": 93
       },
-      "id": 41,
+      "id": 11,
       "options": {
         "legend": {
           "calcs": [
@@ -1575,8 +2694,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (result) (rate(runlore_recall_hits_total[$__rate_interval]))",
-          "legendFormat": "hits {{result}}",
+          "expr": "sum(rate(runlore_alerts_received_total[$__rate_interval]))",
+          "legendFormat": "received",
           "refId": "A"
         },
         {
@@ -1585,8 +2704,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (reason) (rate(runlore_recall_rejections_total[$__rate_interval]))",
-          "legendFormat": "rejected {{reason}}",
+          "expr": "sum(rate(runlore_alerts_coalesced_total[$__rate_interval]))",
+          "legendFormat": "coalesced",
           "refId": "B"
         },
         {
@@ -1595,12 +2714,12 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(runlore_recall_tokens_saved_total[$__rate_interval]))",
-          "legendFormat": "tokens saved /s",
+          "expr": "sum(rate(runlore_alerts_suppressed_total[$__rate_interval]))",
+          "legendFormat": "suppressed",
           "refId": "C"
         }
       ],
-      "title": "Recall hits & tokens saved",
+      "title": "Alert intake rate",
       "type": "timeseries"
     },
     {
@@ -1608,7 +2727,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Distribution of BM25 recall scores at the decision point. Use this to tune min_score.",
+      "description": "Distribution of incidents per flushed batch. A right-shifted distribution means the coalescer is folding many alerts together (good fan-in); a spike at 1 means little coalescing is happening.",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1628,9 +2747,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 66
+        "y": 93
       },
-      "id": 42,
+      "id": 13,
       "options": {
         "calculate": false,
         "cellGap": 1,
@@ -1674,13 +2793,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(runlore_recall_score_bucket[$__rate_interval])) by (le)",
+          "expr": "sum(rate(runlore_coalesce_batch_size_bucket[$__rate_interval])) by (le)",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "refId": "A"
         }
       ],
-      "title": "Recall score distribution (BM25)",
+      "title": "Coalesced batch size distribution",
       "type": "heatmap"
     },
     {
@@ -1689,11 +2808,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 74
+        "y": 101
       },
-      "id": 50,
+      "id": 122,
       "panels": [],
-      "title": "Learning loop",
+      "title": "\ud83d\udda5 Fleet",
       "type": "row"
     },
     {
@@ -1701,250 +2820,38 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Investigations recorded in the outcome ledger (by kind) and incidents later resolved.",
+      "description": "Running image version (runlore_build_info). Deduplicated per distinct version, so a rollout shows old+new briefly, steady-state shows one.",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "text",
                 "value": null
               }
             ]
           },
-          "unit": "ops"
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 5,
+        "w": 8,
         "x": 0,
-        "y": 75
+        "y": 102
       },
-      "id": 51,
+      "id": 111,
       "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (kind) (rate(runlore_outcomes_opened_total[$__rate_interval]))",
-          "legendFormat": "opened {{kind}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(runlore_incidents_resolved_total[$__rate_interval]))",
-          "legendFormat": "resolved",
-          "refId": "B"
-        }
-      ],
-      "title": "Outcomes opened & incidents resolved",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Open to resolve duration percentiles.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 75
-      },
-      "id": 52,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(runlore_incident_resolution_seconds_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "p50",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(runlore_incident_resolution_seconds_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "p95",
-          "refId": "B"
-        }
-      ],
-      "title": "Incident resolution time (p50 / p95)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Outcome of resolved incidents whose original answer was a recall short-circuit.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 83
-      },
-      "id": 53,
-      "options": {
-        "displayLabels": [
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "value"
-          ]
-        },
-        "pieType": "pie",
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -1952,10 +2859,7 @@
           "fields": "",
           "values": false
         },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
+        "textMode": "name"
       },
       "pluginVersion": "11.0.0",
       "targets": [
@@ -1965,91 +2869,68 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (result) (increase(runlore_recall_outcome_total[$__range]))",
-          "instant": true,
-          "legendFormat": "{{result}}",
-          "refId": "A"
+          "expr": "max by (version) (last_over_time(runlore_build_info[2m]))",
+          "legendFormat": "{{version}}",
+          "refId": "A",
+          "instant": true
         }
       ],
-      "title": "Recall outcome by result",
-      "type": "piechart"
+      "title": "Agent version",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Curation pass outcomes (catalog writes / dedup skips) by kind and result.",
+      "description": "Elected leaders (healthy = 1). Bounded to a 1m window so a just-rolled replica's stale series doesn't linger; a transient 2 during a rollout is expected (yellow), 0 is a real problem (red).",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 12,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "yellow",
+                "value": 2
               }
             ]
           },
-          "unit": "ops"
+          "unit": "none"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 83
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 102
       },
-      "id": 54,
+      "id": 112,
       "options": {
-        "legend": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
           "calcs": [
-            "mean",
             "lastNotNull"
           ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "textMode": "auto"
       },
       "pluginVersion": "11.0.0",
       "targets": [
@@ -2059,196 +2940,64 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (kind, result) (rate(runlore_curations_total[$__rate_interval]))",
-          "legendFormat": "{{kind}} / {{result}}",
-          "refId": "A"
+          "expr": "sum(last_over_time(runlore_leader[1m]))",
+          "legendFormat": "leaders",
+          "refId": "A",
+          "instant": true
         }
       ],
-      "title": "Curation rate by kind & result",
-      "type": "timeseries"
+      "title": "Active leaders",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Catalog top-hit BM25 score at the curation dedup decision. Use this to tune the dedup threshold: high scores mean a near-duplicate entry already exists.",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 91
-      },
-      "id": 55,
-      "options": {
-        "calculate": false,
-        "cellGap": 1,
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "Spectral",
-          "steps": 64
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": 1e-09
-        },
-        "legend": {
-          "show": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "tooltip": {
-          "mode": "single",
-          "show": true,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": false,
-          "unit": "short"
-        }
-      },
-      "pluginVersion": "11.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(runlore_curation_dedup_score_bucket[$__rate_interval])) by (le)",
-          "format": "heatmap",
-          "legendFormat": "{{le}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Curation dedup score distribution (BM25)",
-      "type": "heatmap"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 99
-      },
-      "id": 60,
-      "panels": [],
-      "title": "Cost",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Per-investigation token estimate (p50 / p95) and estimated tokens saved per second via recall.",
+      "description": "Replicas that reported in the last minute (1m window excludes recently-terminated pods, so it doesn't over-count during rollouts).",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
               }
             ]
           },
-          "unit": "short"
+          "unit": "none"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "tokens saved /s"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 100
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 102
       },
-      "id": 61,
+      "id": 113,
       "options": {
-        "legend": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
           "calcs": [
-            "mean",
             "lastNotNull"
           ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
+        "textMode": "auto"
       },
       "pluginVersion": "11.0.0",
       "targets": [
@@ -2258,33 +3007,14 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "tokens/investigation p50",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "tokens/investigation p95",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(runlore_recall_tokens_saved_total[$__rate_interval]))",
-          "legendFormat": "tokens saved /s",
-          "refId": "C"
+          "expr": "count(last_over_time(runlore_build_info[1m]))",
+          "legendFormat": "replicas",
+          "refId": "A",
+          "instant": true
         }
       ],
-      "title": "Token cost & savings",
-      "type": "timeseries"
+      "title": "Replicas reporting",
+      "type": "stat"
     }
   ],
   "preload": false,
@@ -2292,12 +3022,17 @@
   "schemaVersion": 39,
   "tags": [
     "runlore",
-    "sre"
+    "sre",
+    "learning-loop"
   ],
   "templating": {
     "list": [
       {
-        "current": {"selected": true, "text": "default", "value": "default"},
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Data source",

--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -371,7 +371,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(runlore_catalog_invalid_entries_total[6m]))",
+          "expr": "sum(increase(runlore_catalog_invalid_entries_total[6m])) or vector(0)",
           "legendFormat": "invalid",
           "refId": "A",
           "instant": true


### PR DESCRIPTION
The shipped dashboard led with generic "agent is up" stats (version, leaders, replicas) and buried the learning-loop signals in raw-rate panels — and the top stats were fragile (version read `dev`, and leaders/replicas over-counted stale series during rollouts, painting red).

Rechallenged it to answer **"is the learning loop actually working?"** at a glance.

## What

- **New headline SLI row** — recall **fire-rate** (recall vs full investigation), **precision** (share the verify pass kept at full confidence), **resolve-rate** (recalls the incident then resolved — the trust signal), **tokens saved**, and **invalid KB entries** (silent-drop hygiene).
- **Retrieve** row reframed — recall outcome by verify verdict (verified/downgraded/rejected), rejection reasons (why recall didn't fire), recall-vs-fresh answer mix, BM25 score distribution.
- **Added** per-investigation USD cost (p50/p95) and model cache-hit ratio.
- **Fleet** stats (version/leaders/replicas) demoted to the bottom with **stale-series-robust** queries (`last_over_time` windows) and a **deduplicated** version — a rollout no longer paints them red or over-counts.
- SLI ratios default absent numerators to `vector(0)` (show 0%, not "No data"); invalid-entries scoped to a ~one-git-sync window so it reflects the CURRENT index, not a 6h accumulation.

## Verified live

Deployed to Grafana via cloud-native-ref's `GrafanaDashboard` CR and checked against real VictoriaMetrics data: the headline row reads fire-rate 30.8% / resolve-rate 100% / tokens-saved 200K, and the recall panels surface the verify `downgraded` share (the over-conservatism fixed in #299). Templated `${datasource}` so it imports into any Grafana.