### PR TITLE
docs: digestibility + human-in-the-loop + notifier-agnostic pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ next time gets an instant answer — no fresh investigation.
 
 **Learns your platform · single Go binary · runs in your cluster · on your models.**
 
-> **Note:** RunLore is **read-only by default** — investigations never mutate your cluster; the only
-> default write surface is Git, via reviewed PRs. Teams that want more can climb the autonomy ladder
-> (`suggest` → `approve`): even at the top supported rung RunLore only executes *reversible* GitOps
-> operations after an **explicit human approval** — a human stays in the loop at every step
+> **The autonomy ladder.** Teams that want more than the read-only default can climb `suggest` →
+> `approve`: even at the top supported rung RunLore only executes *reversible* GitOps operations after
+> an **explicit human approval** — a human stays in the loop at every step
 > (see [Project status](#project-status--stability)).
 
 **Who it's for** — **SRE and platform teams** who want their incident knowledge **portable and
@@ -39,12 +38,12 @@ diff — but GitOps isn't required: every data source is pluggable, and an unset
 
 ## See it in action
 
-Two sides of the same incident, delivered to Slack — the whole point of the learning loop in one place.
+Two sides of the same incident, delivered to your chat (shown here in Slack; Matrix delivers the same findings) — the whole point of the learning loop in one place.
 
 **First time — a full investigation.** A verdict-first summary: the actionability call
 (no action / suggested / required / inconclusive), the confidence-scored root cause, the alert
 metadata and recurrence, top-cause "why", suggested next steps, ruled-out hypotheses and data gaps,
-and a link to the pull request it opened in your knowledge base. On a Slack **bot token** the full
+and a link to the pull request it opened in your knowledge base. With the Slack notifier's **bot token**, the full
 analysis lands as a threaded reply under that summary. The footer shows the real cost — model calls
 and tokens.
 
@@ -121,7 +120,7 @@ additive. Full setup detail in **[Data sources](docs/data-sources.md)**.
 | **Kubernetes** | client-go — pod status, events, controller logs | *(in-cluster)* |
 | **LLM** | Anthropic · Google Gemini · any OpenAI-compatible *(vLLM, Ollama, OpenRouter…)* | `model.provider` |
 | **Triggers** *(sources)* | Alertmanager webhook · GitOps failures · PagerDuty webhook *(new)* | `sources.*` |
-| **Notifiers** | Slack *(bot token: threaded summary + detail; opt-in 👍/👎 feedback buttons feeding the learning loop)* · Slack incoming webhook / Matrix / generic webhook *(single verdict-first message)* | `notify.*` |
+| **Notifiers** | Slack *(bot token: threaded summary + detail; opt-in 👍/👎 buttons)* · Matrix *(opt-in 👍/👎 reactions)* — both feed the learning loop · Slack incoming webhook / generic webhook *(single verdict-first message)* | `notify.*` |
 | **Knowledge base** *(git forge)* | GitHub *(App auth)* | `forge.*` |
 
 ## ⚡ Try it in one minute — no cluster, no keys
@@ -189,12 +188,14 @@ credentials, complete `values.yaml` reference, data sources, and verification st
 
 RunLore is **GitOps-engine-agnostic** (Flux + Argo CD), **metrics-backend-agnostic**
 (VictoriaMetrics + Prometheus), with pluggable logs and CNI-agnostic network signals. Change-aware RCA
-isn't unique — commercial tools (Komodor, Anyshift) diff changes too ([prior art](docs/prior-art.md)) —
-so the wedge is the **combination the open tools don't have**: that signal feeding an **open, portable
+isn't unique — commercial tools (Komodor, Anyshift) diff changes too ([prior art](docs/prior-art.md)).
+The wedge is the **combination the open tools don't have**: that signal feeding an **open, portable
 catalog you own** ([OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible markdown,
-not a proprietary store), from an agent that's **honest about the sub-50% reality** — `unresolved` is a
-first-class answer, an adversarial *verify* pass can only ever lower a finding's confidence, and every
-claim is checked by a shipped eval harness.
+not a proprietary store), from an agent that's **honest about the sub-50% reality**:
+
+- `unresolved` is a first-class answer;
+- an adversarial *verify* pass can only ever *lower* a finding's confidence, never raise it;
+- every claim is checked by a shipped eval harness.
 
 ## Project status & stability
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -118,7 +118,7 @@ tools, but never *require* them).
           │   ├─ runbook grounding      (OKF playbooks)                              │
           │   ├─ tool orchestration     (providers, built-in + MCP)                  │
           │   └─ hypothesis ranker + explicit `unresolved`                           │
-          │  Curator — confidence-routed: known→recall · novel→PR · uncertain→Issue  │
+          │  Curator — confidence-routed: known→recall · novel→PR · uncertain→chat  │
           │  Catalog — syncer + local mirror + bleve/chromem-go index (kb_search)    │
           │  Model: Anthropic | OpenAI-compatible (in-cluster vLLM | Ollama)         │
           │  Audit log (append-only) → (P3) cross-incident memory                    │
@@ -224,15 +224,15 @@ to incidents. The loop is `retrieve → capture → curate → compound`, routed
 
 ```
 investigation result
-  ├─ KB hit (known)          → post known resolution. No issue, no PR. (instant recall)
+  ├─ KB hit (known)          → post the known resolution. No issue, no PR. (instant recall)
   ├─ novel + confident       → draft OKF entry as a PR; humans refine via review → merge → reindex
-  └─ novel + uncertain       → open a GitHub ISSUE (findings + open questions);
-                               humans answer in-thread; on resolve/`/kb` →
-                               crystallize thread → OKF PR → merge → reindex
+  └─ novel + uncertain       → chat-only: the findings + open questions are delivered to chat, but
+                               NO repo artifact is written — a below-bar guess must not enter the catalog
 ```
-The catalog only grows from **genuinely novel, human-sharpened** incidents. Every learned entry cites
-the **issue** (reasoning), the **causing** change, and the **fixing** change — provenance no closed
-"memory" gives you.
+The catalog only grows from **genuinely novel, human-sharpened** incidents. (Issues are opened *only*
+by the scheduled Phase-2 grooming, and only for a **recurring unresolved pattern** — a "knowledge gap",
+never for a one-off uncertain finding.) Every learned entry cites its **evidence trail**, the
+**causing** change, and the **fixing** change — provenance no closed "memory" gives you.
 
 **Lifecycle labels gate the catalog's quality.** Curated artifacts carry a lifecycle label —
 `triggered` (raw, just opened) → `investigating` → `solved` (root cause confirmed *and* resolution
@@ -484,7 +484,7 @@ internal/
     cloud/{aws,gcp,azure}/     CloudProvider — native SDKs, Phase 2+ (Steampipe/MCP optional)
 deploy/helm/runlore/           in-cluster chart (Phase 2)
 examples/runbooks/             seed OKF catalog (ships as default knowledge)
-docs/                          design.md, prior-art.md
+docs/                          design.md, learning-loop.md, getting-started.md, … (see the Docs index)
 ```
 
 ## 14. Open questions & risks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ forge (issues/PRs on a repo you designate).
   `cloud_resource_health` (EC2/ASG/EKS) tools, the cloud-control-plane "what changed" lens for infra
   changes outside GitOps. Auth is in-cluster identity (**EKS Pod Identity** or IRSA) — no static keys.
   See [step 4b](#step-4b-aws-cloud-provider-optional).
-- A **Slack incoming webhook** and/or a **Matrix** account for delivery.
+- A **notifier** for delivery — a **Slack incoming webhook**, a **Matrix** account, or a generic outgoing webhook.
 - [External Secrets Operator](https://external-secrets.io/) to sync credentials from a vault
   (recommended over raw `Secret`s in production).
 
@@ -120,8 +120,9 @@ incidents, platform constraints.
 
 ## Step 2 — GitHub App for curation (optional)
 
-The **Curator** writes findings back to your KB repo: confident root causes become a **PR** drafting an
-OKF entry; less-confident ones become an **issue**. Auth is a **GitHub App** — the secure choice over a
+The **Curator** writes findings back to your KB repo: confident, *verified* root causes become a **PR**
+drafting an OKF entry; less-confident ones are delivered to chat only — **no repo artifact** (a below-bar
+guess must not enter the catalog). Auth is a **GitHub App** — the secure choice over a
 personal access token: fine-grained permissions, per-repo installation, and short-lived (1-hour)
 installation tokens minted on demand from the App's private key (no long-lived credential in the cluster).
 
@@ -135,7 +136,7 @@ installation tokens minted on demand from the App's private key (no long-lived c
    |---|---|---|
    | Contents | **Read & write** | push the drafted OKF entry to a branch on the KB repo |
    | Pull requests | **Read & write** | open the curation PR |
-   | Issues | **Read & write** | open issues for lower-confidence findings |
+   | Issues | **Read & write** | open knowledge-gap issues for recurring unresolved patterns (Phase-2 grooming) |
 
    If your Flux source repos are **private** and you want real Git diffs from them, also grant
    **Contents: Read-only** and install the App on those repos. Public source repos need nothing.
@@ -263,10 +264,10 @@ config:
       branch: main
       interval: 5m
       # token_env: KB_GIT_TOKEN              # optional; private repos reuse the curation GitHub App by default
-    # Instant recall: skip the LLM loop when the catalog has a high-confidence match
-    # for the symptom (faster, cheaper). Off by default; the shipped default
-    # min_score is 1.0 — tune it for your catalog, BM25 scores are
-    # corpus-dependent (observe the "score=" logs).
+    # Instant recall: skip the LLM loop when the catalog has a trustworthy match for
+    # the incident (faster, cheaper). Off by default. Once enabled, the fire-gate is
+    # calibrated by an LLM reranker (on by default) — no per-corpus BM25 tuning needed;
+    # min_score is only a trivial secondary cost guard. See docs/learning-loop.md (§3).
     # instant_recall: { enabled: true }
 
   # Investigate signals (optional) — enable the query_metrics / query_logs tools.

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -2,9 +2,18 @@
 
 > Companion to [`design.md`](design.md). This document explains the **learning
 > loop** specifically: what "learning" means in RunLore, how each stage works, and
-> *why* it was built the way it was. It reflects the system after the 2026-06-23
-> roadmap batch (instant-recall trust, outcome ledger + decay, curation gates,
-> scheduled grooming, sync/readiness hardening, and the eval harness).
+> *why* it was built the way it was.
+
+> **TL;DR.** On an incident, RunLore first tries to **recall** a trustworthy past
+> answer from a git-versioned catalog — instant, no investigation; otherwise it
+> investigates. It then **captures** whether the incident actually resolved,
+> **curates** a verified, novel finding into a **human-reviewed pull request**, and
+> once a human merges it the note **compounds** (recall-able next time). What makes
+> this *learning* and not note-taking: a note's trust is **derived from its real-world
+> resolve-rate** (plus 👍/👎 votes), so a note that stops working **decays** and can be
+> overturned. And the human stays in the loop throughout — **RunLore drafts, a human
+> merges; nothing is auto-written.** (Deep dives: §3 Retrieve, §4 Capture, §6 Decay,
+> §8 Validation.)
 
 ---
 
@@ -97,6 +106,11 @@ The agent never blindly trusts the catalog. A recall short-circuit (answer witho
 investigating) only fires when a hit clears **three independent gates**, and even
 then the answer is confirmed against live state and re-reviewed.
 
+> **First read?** Skip the next two blockquotes and go straight to the **three-gate
+> diagram** below — that's the core of recall. The two boxes are opt-in *refinements*
+> to how the gate scores a candidate (hybrid embeddings, and the LLM reranker that is
+> on by default); come back to them when you want to tune it.
+
 > **Hybrid recall (experimental, opt-in).** With `instant_recall.hybrid` set and a
 > `model.embeddings` endpoint configured, the BM25 search below is fused with
 > embedding-cosine similarity (Reciprocal Rank Fusion), and Gate 2's margin is measured
@@ -188,10 +202,13 @@ Then two safety backstops before the recalled answer is delivered:
 
 - **Confirm against current state** (`internal/investigate/confirm.go`). Before
   trusting a remembered answer, RunLore makes 1–2 cheap, read-only cluster calls
-  (`pod_status`, `kube_events`) scoped to the workload and appends that *current
-  state* to the finding. This is non-LLM and fast. If it can't gather state (no
-  namespace / tools absent), the recalled confidence is capped lower (0.70) so an
-  unconfirmable memory isn't presented at full confidence.
+  (`pod_status`, `kube_events`) scoped to the workload's **namespace** — deliberately
+  namespace-wide, *not* just the alerting object — so a cause living on a
+  **neighbouring resource** (a dependency, an upstream, a Crossplane claim, not the
+  pod that alerted) is still confirmed, and appends that *current state* to the
+  finding. This is non-LLM and fast. If it can't gather state (no namespace / tools
+  absent), the recalled confidence is capped lower (0.70) so an unconfirmable memory
+  isn't presented at full confidence.
 - **Verify pass** (`internal/investigate/verify.go`). An adversarial reviewer judges
   the finding **only on the evidence given** and can *only lower* confidence. Because
   the confirm step injected real cluster state, verify can now actually catch a stale
@@ -271,7 +288,7 @@ Two read APIs turn this raw log into a learning signal:
   [configuration.md](configuration.md#notify--where-findings-go)). A vote is attributed
   to the catalog entry behind the trigger key's **newest open** (via the same
   `byTrigger` index; a fresh investigation has no entry, so its votes are recorded but
-  weigh nothing), deduplicated to **one live vote per (trigger key, Slack user)** —
+  weigh nothing), deduplicated to **one live vote per (trigger key, user)** —
   a duplicate click is idempotent, changing your mind *moves* the vote — and folded
   into `OpenCounts()` as per-entry `FeedbackUp` / `FeedbackDown`.
 
@@ -407,8 +424,9 @@ one success, a 👎 one failure, each weighing exactly like a resolved/unresolve
 That matters most where the resolve signal *cannot exist*: sources with no resolve
 channel (**GitOps failures**, reinvestigate polls, Alertmanager without `send_resolved`)
 are deliberately excluded from resolve-based decay, so without feedback their entries'
-trust is frozen at the prior forever. A human clicking 👎 is the only ground truth those
-paths can ever accumulate — and it is a judgment on the *diagnosis itself*, which an
+trust is frozen at the prior forever. A human's explicit 👎 (a Slack click or a Matrix
+reaction) is the only ground truth those paths can ever accumulate — and it is a
+judgment on the *diagnosis itself*, which an
 alert merely clearing never proves.
 
 ```mermaid
@@ -442,8 +460,8 @@ notification — until the cooldown lapses. The escape hatches are human-deferen
 by design: an `inconclusive` prior never suppresses (there is no answer worth
 repeating), and a standing 👎 on the trigger re-arms investigation immediately. So
 feedback does two jobs: it weighs *recalled knowledge* (the decay above) and it
-governs *when the agent may repeat itself* — both steered by the same one-click
-human signal.
+governs *when the agent may repeat itself* — both steered by the same single
+human 👍/👎 signal.
 
 ---
 

--- a/docs/reviewing-knowledge.md
+++ b/docs/reviewing-knowledge.md
@@ -127,9 +127,9 @@ there's nothing to show.
 
 ## 3. Reviewing it — three checks
 
-Formatting is already enforced for you (a CI check validates the structure — see
-[KB-entry validation](../dev/superpowers/specs/2026-06-24-kb-entry-validation-design.md)).
-Your job is the **judgment** the machine can't make:
+Formatting is already enforced for you — a CI check on the KB repo validates each
+entry's structure (`lore validate-kb`). Your job is the **judgment** the machine
+can't make:
 
 1. **Is the cause real?** Does the `Investigate` evidence actually support the
    `Cause`? (The evidence is quoted verbatim from live cluster/cloud/Git state.)
@@ -199,7 +199,9 @@ separate approval UI — your Git review *is* the gate.
 
 - **Instant recall.** On the next matching incident, RunLore recalls the entry
   (after confirming it against current state and re-verifying it) instead of
-  running a full investigation — saving minutes and tokens.
+  running a full investigation — saving minutes and tokens. On-call sees an explicit
+  **⚡ Instant recall** block in chat quoting this entry's cause, its human-reviewed
+  resolution, and its resolve-rate — the visible payoff of your review.
 - **Outcomes feed back.** RunLore records whether incidents that recalled this
   entry actually resolved. An entry with a poor real-world resolve-rate is
   **automatically decayed out of recall** — so bad knowledge stops being used
@@ -229,7 +231,7 @@ It only ever comments/labels/closes — it never merges. See
 
 The groomer also carries on-call feedback into your review: when responders hold
 standing 👎 votes on the investigation behind a pending entry (the 👍/👎 buttons
-on the chat notification), it posts a comment on the open PR — *"On-call
+or Matrix reactions on the chat notification), it posts a comment on the open PR — *"On-call
 feedback: N standing 👎 votes on the investigation behind this entry"* — naming
 the trigger. Treat it as a red flag on check 1/2 above: re-read the `Cause`
 against the evidence before merging. The same 👎 also re-arms re-investigation


### PR DESCRIPTION
A new-reader review across the front-line docs (README, learning-loop, design, reviewing-knowledge, getting-started), targeting three things: **digestible**, **human-in-the-loop front-and-center**, and a **clear, consistent learning-loop** explanation — plus a **notifier-agnostic** wording pass.

## Digestibility & human-in-the-loop
- **`learning-loop.md`**: a **TL;DR / reading-map** up top that leads with the human-merge boundary (*"RunLore drafts, a human merges; nothing is auto-written"*); a "first read? skip to the three-gate diagram" signpost in §3 so the opt-in reranker/hybrid deep-dives stop burying the lede; stale currency date dropped.
- **README**: de-duplicate "read-only by default" (the Note now leads with the autonomy ladder); the run-on "Why RunLore" paragraph broken into bullets.

## Factual fixes (docs contradicted the code)
- **`learning-loop.md`**: the recall **confirm** step is now **namespace-wide, not workload-scoped** — so a cause on a *neighbouring* resource is confirmed (matches `confirm.go`). The old text was the exact opposite and undersold the feature.
- **Reconciled the "uncertain finding" path across four docs**: a below-bar finding is **chat-only, NO repo artifact** — it never opens an issue (issues are only the Phase-2 knowledge-gap issues for recurring unresolved patterns). `design.md` + `getting-started.md` said "open an issue", which is stale; verified against `internal/curator/curator.go`.
- **`getting-started.md`**: the `instant_recall` note no longer tells operators to hand-tune a corpus-specific BM25 `min_score` — the on-by-default reranker calibrates the fire-gate.

## Notifier-agnostic
Stop presenting Slack as the only channel: generic "delivered to Slack" → "your chat (Slack, Matrix, …)"; Matrix's 👍/👎 **reactions** surfaced alongside Slack's buttons; Slack-specific setup/features kept but framed as "the Slack notifier". Screenshots (which are Slack) note "Matrix delivers the same".

Also: the ⚡ Instant recall payoff added to `reviewing-knowledge.md`, Matrix reactions credited in the README integrations table, an internal `dev/superpowers` spec link dropped.

Docs-only. Cross-checked against `confirm.go`, `curator.go`, `notify/`, and the outcome ledger's `(TriggerKey, user)` feedback key.