### PR TITLE
feat(gitops): watch HelmReleases for autonomous failure detection

### DIFF
--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -23,6 +23,7 @@ const fluxSystemNamespace = "flux-system"
 // Flux CRD resources (v1).
 var (
 	kustomizationGVR = schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}
+	helmReleaseGVR   = schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}
 	gitRepositoryGVR = schema.GroupVersionResource{Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "gitrepositories"}
 	eventsGVR        = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
 )
@@ -31,7 +32,7 @@ var (
 var kindToGVR = map[string]schema.GroupVersionResource{
 	"Kustomization":    kustomizationGVR,
 	"GitRepository":    gitRepositoryGVR,
-	"HelmRelease":      {Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"},
+	"HelmRelease":      helmReleaseGVR,
 	"OCIRepository":    {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "ocirepositories"},
 	"HelmRepository":   {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmrepositories"},
 	"HelmChart":        {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmcharts"},
@@ -254,22 +255,23 @@ func readyTransitionTime(u *unstructured.Unstructured) time.Time {
 	return time.Time{}
 }
 
-// WatchKustomizations watches all Kustomizations via a dynamic informer (list-watch
-// with reconnection + periodic resync) and forwards each add/update as a
-// KustomizationEvent. The channel closes when ctx is done.
-func (r *dynamicReader) WatchKustomizations(ctx context.Context) (<-chan KustomizationEvent, error) {
-	factory := dynamicinformer.NewDynamicSharedInformerFactory(r.client, 10*time.Minute)
-	informer := factory.ForResource(kustomizationGVR).Informer()
+// watchResource watches a Flux GVR via a dynamic informer (list-watch with
+// reconnection + periodic resync) and forwards each add/update, mapped by conv,
+// on the returned buffered channel. Sends never block the informer (dropped under
+// backpressure); the channel closes when ctx is done. Shared by the Kustomization
+// and HelmRelease failure watchers so both get identical watch semantics.
+func watchResource[T any](ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, conv func(*unstructured.Unstructured) T) (<-chan T, error) {
+	factory := dynamicinformer.NewDynamicSharedInformerFactory(client, 10*time.Minute)
+	informer := factory.ForResource(gvr).Informer()
 
-	out := make(chan KustomizationEvent, 128)
+	out := make(chan T, 128)
 	send := func(obj any) {
 		u, ok := obj.(*unstructured.Unstructured)
 		if !ok {
 			return
 		}
-		ev := KustomizationEvent{Kustomization: kustomizationFromUnstructured(u)}
 		select {
-		case out <- ev:
+		case out <- conv(u):
 		case <-ctx.Done():
 		default: // never block the informer; drop under backpressure
 		}
@@ -287,6 +289,25 @@ func (r *dynamicReader) WatchKustomizations(ctx context.Context) (<-chan Kustomi
 		<-ctx.Done()
 	}()
 	return out, nil
+}
+
+// WatchKustomizations watches all Kustomizations and forwards each add/update as a
+// KustomizationEvent. The channel closes when ctx is done.
+func (r *dynamicReader) WatchKustomizations(ctx context.Context) (<-chan KustomizationEvent, error) {
+	return watchResource(ctx, r.client, kustomizationGVR, func(u *unstructured.Unstructured) KustomizationEvent {
+		return KustomizationEvent{Kustomization: kustomizationFromUnstructured(u)}
+	})
+}
+
+// WatchHelmReleases watches all HelmReleases and forwards each add/update as a
+// HelmReleaseEvent. The channel closes when ctx is done. A HelmRelease that never
+// installs or upgrades (image pull failures, failed hooks, exhausted retries) goes
+// Ready=False without any Kustomization flipping, so it is invisible to the
+// Kustomization watch — this closes that gap (runlore#306).
+func (r *dynamicReader) WatchHelmReleases(ctx context.Context) (<-chan HelmReleaseEvent, error) {
+	return watchResource(ctx, r.client, helmReleaseGVR, func(u *unstructured.Unstructured) HelmReleaseEvent {
+		return HelmReleaseEvent{HelmRelease: helmReleaseFromUnstructured(u)}
+	})
 }
 
 // kustomizationFromUnstructured maps an unstructured Kustomization object to the
@@ -316,5 +337,18 @@ func kustomizationFromUnstructured(u *unstructured.Unstructured) kustomization {
 		ReadyReason:     readyReason,
 		ReadyMessage:    readyMessage,
 		ReadyTime:       readyTransitionTime(u),
+	}
+}
+
+// helmReleaseFromUnstructured maps an unstructured HelmRelease to the minimal
+// helmRelease type the failure watcher needs (identity + Ready condition).
+func helmReleaseFromUnstructured(u *unstructured.Unstructured) helmRelease {
+	status, reason, message := readyCondition(u)
+	return helmRelease{
+		Name:         u.GetName(),
+		Namespace:    u.GetNamespace(),
+		ReadyStatus:  status,
+		ReadyReason:  reason,
+		ReadyMessage: message,
 	}
 }

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +47,22 @@ type KustomizationEvent struct {
 	Kustomization kustomization
 }
 
+// helmRelease is the minimal Flux HelmRelease data the failure watcher needs: its
+// identity and Ready condition. Unlike kustomization it carries no source/path/
+// revision — a HelmRelease failure is reported for investigation, not Git-diffed
+// through the Kustomization Change path.
+type helmRelease struct {
+	Name, Namespace string
+	ReadyStatus     string // status.conditions[type=Ready].status ("True"/"False"/"Unknown")
+	ReadyReason     string
+	ReadyMessage    string
+}
+
+// HelmReleaseEvent is a single watch event for a HelmRelease.
+type HelmReleaseEvent struct {
+	HelmRelease helmRelease
+}
+
 // Reader is the cluster-read surface the provider depends on. The dynamic
 // client-go implementation lives in dynamic.go; tests use a fake.
 type Reader interface {
@@ -56,6 +73,10 @@ type Reader interface {
 	// ExternalArtifact, used to find a failing Kustomization's HEAD.
 	SourceRevision(ctx context.Context, kind, namespace, name string) (string, error)
 	WatchKustomizations(ctx context.Context) (<-chan KustomizationEvent, error)
+	// WatchHelmReleases watches all Flux HelmReleases (runlore#306): a stuck/failed
+	// HelmRelease goes Ready=False without any Kustomization flipping, so it is
+	// invisible to WatchKustomizations.
+	WatchHelmReleases(ctx context.Context) (<-chan HelmReleaseEvent, error)
 	// GetResource fetches one object by kind/namespace/name (kinds in kindToGVR).
 	GetResource(ctx context.Context, kind, namespace, name string) (*unstructured.Unstructured, error)
 	// ListEvents returns recent Event lines for an involved object.
@@ -255,22 +276,44 @@ func (p *Provider) Diff(ctx context.Context, c providers.Change) (providers.Diff
 	return p.differ.ForChange(ctx, c)
 }
 
-// WatchFailures watches Flux Kustomizations and emits a FailureEvent whenever one
-// is Ready=False (a failed/blocked reconcile). The returned channel closes when
-// the watch ends or ctx is done.
+// WatchFailures watches Flux Kustomizations AND HelmReleases and emits a
+// FailureEvent whenever one is Ready=False (a failed/blocked reconcile). Both are
+// watched because a HelmRelease can fail on its own (image pull, failed hook,
+// exhausted install retries) without any Kustomization flipping — that class of
+// failure was previously invisible to the autonomous gitops-watch (runlore#306).
+// The two streams are merged onto one channel, which closes when both watches end
+// or ctx is done.
 func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureEvent, error) {
-	src, err := p.reader.WatchKustomizations(ctx)
+	ksrc, err := p.reader.WatchKustomizations(ctx)
 	if err != nil {
 		return nil, err
 	}
+	hsrc, err := p.reader.WatchHelmReleases(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	out := make(chan providers.FailureEvent)
+	// emit sends fe unless ctx is cancelled; returns false to stop the caller loop.
+	emit := func(fe providers.FailureEvent) bool {
+		select {
+		case out <- fe:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Kustomization failures.
 	go func() {
-		defer close(out)
+		defer wg.Done()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case ev, ok := <-src:
+			case ev, ok := <-ksrc:
 				if !ok {
 					return
 				}
@@ -278,19 +321,46 @@ func (p *Provider) WatchFailures(ctx context.Context) (<-chan providers.FailureE
 				if k.ReadyStatus != "False" {
 					continue
 				}
-				fe := providers.FailureEvent{
+				if !emit(providers.FailureEvent{
 					Workload: providers.Workload{Kind: "Kustomization", Name: k.Name, Namespace: k.Namespace},
 					Engine:   providers.EngineFlux,
 					Reason:   k.ReadyReason,
 					Message:  k.ReadyMessage,
-				}
-				select {
-				case out <- fe:
-				case <-ctx.Done():
+				}) {
 					return
 				}
 			}
 		}
+	}()
+	// HelmRelease failures (runlore#306).
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-hsrc:
+				if !ok {
+					return
+				}
+				h := ev.HelmRelease
+				if h.ReadyStatus != "False" {
+					continue
+				}
+				if !emit(providers.FailureEvent{
+					Workload: providers.Workload{Kind: "HelmRelease", Name: h.Name, Namespace: h.Namespace},
+					Engine:   providers.EngineFlux,
+					Reason:   h.ReadyReason,
+					Message:  h.ReadyMessage,
+				}) {
+					return
+				}
+			}
+		}
+	}()
+	go func() {
+		wg.Wait()
+		close(out)
 	}()
 	return out, nil
 }

--- a/internal/providers/gitops/flux/flux_test.go
+++ b/internal/providers/gitops/flux/flux_test.go
@@ -61,6 +61,11 @@ func (f fakeReader) WatchKustomizations(context.Context) (<-chan KustomizationEv
 	close(ch)
 	return ch, nil
 }
+func (f fakeReader) WatchHelmReleases(context.Context) (<-chan HelmReleaseEvent, error) {
+	ch := make(chan HelmReleaseEvent)
+	close(ch)
+	return ch, nil
+}
 func (f fakeReader) GetResource(context.Context, string, string, string) (*unstructured.Unstructured, error) {
 	return nil, fmt.Errorf("not implemented")
 }
@@ -329,15 +334,26 @@ func TestProviderChangesSelector(t *testing.T) {
 	}
 }
 
-// streamReader is a fakeReader that also serves a fixed watch stream.
+// streamReader is a fakeReader that also serves fixed Kustomization and
+// HelmRelease watch streams.
 type streamReader struct {
 	fakeReader
-	events []KustomizationEvent
+	events   []KustomizationEvent
+	hrEvents []HelmReleaseEvent
 }
 
 func (s streamReader) WatchKustomizations(_ context.Context) (<-chan KustomizationEvent, error) {
 	ch := make(chan KustomizationEvent, len(s.events))
 	for _, e := range s.events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (s streamReader) WatchHelmReleases(_ context.Context) (<-chan HelmReleaseEvent, error) {
+	ch := make(chan HelmReleaseEvent, len(s.hrEvents))
+	for _, e := range s.hrEvents {
 		ch <- e
 	}
 	close(ch)
@@ -366,6 +382,66 @@ func TestWatchFailures(t *testing.T) {
 	if e.Engine != providers.EngineFlux || e.Workload.Name != "bad" || e.Workload.Kind != "Kustomization" ||
 		e.Reason != "BuildFailed" || e.Message != "boom" {
 		t.Fatalf("unexpected failure event: %+v", e)
+	}
+}
+
+// TestWatchFailuresHelmReleases proves runlore#306: a HelmRelease going Ready=False
+// (with no Kustomization involved) surfaces as a FailureEvent{Kind:"HelmRelease"},
+// while True/Unknown HelmReleases are ignored.
+func TestWatchFailuresHelmReleases(t *testing.T) {
+	r := streamReader{hrEvents: []HelmReleaseEvent{
+		{HelmRelease: helmRelease{Name: "ok", Namespace: "apps", ReadyStatus: "True"}},
+		{HelmRelease: helmRelease{Name: "broken", Namespace: "tooling", ReadyStatus: "False", ReadyReason: "InstallFailed", ReadyMessage: "image pull backoff"}},
+		{HelmRelease: helmRelease{Name: "installing", Namespace: "apps", ReadyStatus: "Unknown"}},
+	}}
+	p := New(r, &whatchanged.Differ{})
+	ch, err := p.WatchFailures(context.Background())
+	if err != nil {
+		t.Fatalf("WatchFailures: %v", err)
+	}
+	var got []providers.FailureEvent
+	for e := range ch {
+		got = append(got, e)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 HelmRelease failure event (only Ready=False), got %d: %+v", len(got), got)
+	}
+	e := got[0]
+	if e.Engine != providers.EngineFlux || e.Workload.Kind != "HelmRelease" || e.Workload.Name != "broken" ||
+		e.Workload.Namespace != "tooling" || e.Reason != "InstallFailed" || e.Message != "image pull backoff" {
+		t.Fatalf("unexpected HelmRelease failure event: %+v", e)
+	}
+}
+
+// TestWatchFailuresMerged proves the Kustomization and HelmRelease watches are
+// merged onto one stream: a failing Kustomization and a failing HelmRelease both
+// surface, each carrying its own Kind.
+func TestWatchFailuresMerged(t *testing.T) {
+	r := streamReader{
+		events: []KustomizationEvent{
+			{Kustomization: kustomization{Name: "bad-ks", Namespace: "apps", ReadyStatus: "False", ReadyReason: "BuildFailed"}},
+		},
+		hrEvents: []HelmReleaseEvent{
+			{HelmRelease: helmRelease{Name: "bad-hr", Namespace: "tooling", ReadyStatus: "False", ReadyReason: "InstallFailed"}},
+		},
+	}
+	p := New(r, &whatchanged.Differ{})
+	ch, err := p.WatchFailures(context.Background())
+	if err != nil {
+		t.Fatalf("WatchFailures: %v", err)
+	}
+	byKind := map[string]providers.FailureEvent{}
+	for e := range ch {
+		byKind[e.Workload.Kind] = e
+	}
+	if len(byKind) != 2 {
+		t.Fatalf("want failures for both kinds, got %d: %+v", len(byKind), byKind)
+	}
+	if k := byKind["Kustomization"]; k.Workload.Name != "bad-ks" {
+		t.Fatalf("Kustomization failure: %+v", k)
+	}
+	if h := byKind["HelmRelease"]; h.Workload.Name != "bad-hr" {
+		t.Fatalf("HelmRelease failure: %+v", h)
 	}
 }
 


### PR DESCRIPTION
Closes #306.

## Problem
The autonomous gitops-failure watcher only informed on Flux **Kustomizations** (`WatchKustomizations`). A HelmRelease that fails on its own — image-pull error, failed hook, exhausted install retries — goes `Ready=False` without any Kustomization flipping, so it never triggered an investigation. It reached RunLore only if a separate Alertmanager alert fired, and pre-1.0 `FluxReconciliationFailure` is typically `warning`-severity, which a critical-only trigger policy filters out.

Observed live on a real cluster: `headlamp` and `tailscale-operator` HelmReleases sat `Ready=False` for 15–30 min producing **zero** autonomous investigations.

## Change
- Add a HelmRelease dynamic informer and merge it with the Kustomization stream in `Provider.WatchFailures`, emitting `FailureEvent{Kind:"HelmRelease"}` on `Ready=False`.
- Extract a generic `watchResource[T]` helper so both watches share identical list-watch + backpressure semantics (no duplicated informer boilerplate; `WatchKustomizations` behaviour is unchanged).
- The failure-debouncer, cascade filter, and recall path are engine-agnostic and work unchanged for the new Kind (`helmrelease://ns/name` recall identity, `HelmRelease/<name>` investigation title).

## Tests
- `TestWatchFailuresHelmReleases` — a `Ready=False` HelmRelease surfaces as `FailureEvent{Kind:"HelmRelease"}`; `True`/`Unknown` are ignored.
- `TestWatchFailuresMerged` — a failing Kustomization and a failing HelmRelease both surface on the merged stream, each with its own Kind.
- Existing `TestWatchFailures` unchanged and passing.

`gofmt`/`go build ./...`/`go vet`/`go test ./internal/providers/gitops/flux/...` all green.

## Release
Carries `Release-As: 0.9.0` so merging cuts the **0.9.0** release (the existing release-please PR proposes 0.8.1 because pre-1.0 `feat:` defaults to a patch bump). Drop the footer if you'd rather ship this in a later tag.