### PR TITLE
fix(chart): scope VMServiceScrape to the metrics Service (fix double-scrape)

### DIFF
--- a/deploy/helm/runlore/templates/service.yaml
+++ b/deploy/helm/runlore/templates/service.yaml
@@ -4,6 +4,11 @@ metadata:
   name: {{ include "runlore.fullname" . }}
   labels:
     {{- include "runlore.labels" . | nindent 4 }}
+    # Distinguishes the scrapeable metrics Service from the StatefulSet's headless
+    # governing Service below. Both otherwise carry identical labels, so the
+    # VMServiceScrape (which selects selectorLabels) matched BOTH and scraped every
+    # pod twice, doubling all counters (e.g. tokens-saved, hits).
+    app.kubernetes.io/component: server
 spec:
   type: {{ .Values.service.type }}
   selector:
@@ -25,6 +30,7 @@ metadata:
   name: {{ include "runlore.fullname" . }}-headless
   labels:
     {{- include "runlore.labels" . | nindent 4 }}
+    app.kubernetes.io/component: headless
 spec:
   clusterIP: None
   publishNotReadyAddresses: true

--- a/deploy/helm/runlore/templates/vmservicescrape.yaml
+++ b/deploy/helm/runlore/templates/vmservicescrape.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       {{- include "runlore.selectorLabels" . | nindent 6 }}
+      # Scope to the metrics Service only. The StatefulSet's headless governing
+      # Service carries the same selectorLabels, so without this discriminator the
+      # scrape matches both Services and every pod is scraped twice (doubled counters).
+      app.kubernetes.io/component: server
   endpoints:
     - port: http
       path: {{ .Values.vmServiceScrape.path | default "/metrics" }}


### PR DESCRIPTION
## Problem
StatefulSet mode (#263) adds a **headless governing Service** (`<name>-headless`) so pods get stable DNS. It carries the **same labels** as the main Service, and the VMServiceScrape selects `selectorLabels` (`app.kubernetes.io/name` + `instance`) — which both Services satisfy. So the scrape matches **both**, and every pod is scraped twice.

Effect: every counter is double-collected under two jobs (`job="runlore"` and `job="runlore-headless"`), so **absolute-count dashboard panels read 2×** — e.g. `Tokens saved by recall` showed ~400K instead of ~200K. Ratio panels (`precision`, `resolve-rate`, `fire-rate`) were unaffected since numerator and denominator both doubled.

## Fix
Add an `app.kubernetes.io/component` discriminator — `server` on the metrics Service, `headless` on the governing Service — and scope the VMServiceScrape selector to `component: server`. Only the metrics Service is scraped now.

## Verification
```
helm template … --set workloadKind=StatefulSet --set vmServiceScrape.enabled=true
```
→ metrics Service renders `component: server`, headless renders `component: headless`, and the VMServiceScrape selector includes `component: server`. `helm lint` clean.

Surfaced while validating the v0.9.0 build on a live cluster: the runlore Grafana dashboard's absolute-count SLIs (tokens saved) read double.