### PR TITLE
fix(outcome): bound early-resolve pairing by investigation start, not age

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -624,6 +624,11 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 				Verdict:        string(found.Verdict),
 				Resolvable:     &resolvable,
 				At:             now,
+				// When the investigation BEGAN (`now` above is its COMPLETION). The gap is the
+				// enqueue→open latency — queue wait behind the single worker, rate-limit
+				// backoff, then the run — and it is the exact window in which a resolve may
+				// legitimately land before this open (see outcome.resolvesSince).
+				StartedAt: found.InvestigationStartedAt,
 			}); err != nil {
 				log.Warn("outcome ledger open failed", "fingerprint", fp, "err", err)
 			}

--- a/internal/app/oncomplete_test.go
+++ b/internal/app/oncomplete_test.go
@@ -37,10 +37,12 @@ func (s stubCurator) Curate(context.Context, providers.Investigation) (providers
 
 // openLine is the subset of a ledger open event the recurrence pointers read back.
 type openLine struct {
-	Event      string `json:"event"`
-	TriggerKey string `json:"trigger_key"`
-	CuratedURL string `json:"curated_url"`
-	Verdict    string `json:"verdict"`
+	Event      string    `json:"event"`
+	TriggerKey string    `json:"trigger_key"`
+	CuratedURL string    `json:"curated_url"`
+	Verdict    string    `json:"verdict"`
+	At         time.Time `json:"at"`
+	StartedAt  time.Time `json:"started_at"`
 }
 
 // lastOpen scans the JSONL ledger file and returns the last "open" event.
@@ -347,5 +349,76 @@ func TestOnCompletePriorKnowledgeSkips(t *testing.T) {
 		if sink.got.Prior != nil {
 			t.Errorf("%s: Prior = %+v, want nil", c.label, sink.got.Prior)
 		}
+	}
+}
+
+// TestOnCompleteRecordsInvestigationStartTime pins the plumbing that makes
+// resolve-before-open pairing exact, end to end.
+//
+// The ledger open is stamped at investigation COMPLETION, so it cannot by itself say
+// when the run began — yet that start time is precisely what separates a resolve that
+// landed WHILE this investigation ran (legitimate: the incident cleared mid-run, so its
+// webhook beat the open to the ledger) from one that predates it entirely (a bygone,
+// uninvestigated episode of the same fingerprint, which must never credit Resolved).
+// The gap is not small: a request waits behind debounce, coalescing, the single
+// sequential worker and rate-limit backoff before the loop even starts.
+//
+// So the completion pipeline must carry the loop's start time onto the open. This test
+// proves both that it is persisted (started_at on the JSONL line) and that it actually
+// governs the credit — the outcome ledger is what the learning loop trusts.
+func TestOnCompleteRecordsInvestigationStartTime(t *testing.T) {
+	started := time.Now().Add(-90 * time.Minute) // a long/queued investigation
+	for _, tc := range []struct {
+		label        string
+		resolvedAt   time.Time
+		wantResolved int
+	}{
+		// Cleared mid-investigation: the resolve is buffered, then pairs with this open.
+		{"resolve lands during the investigation", started.Add(time.Minute), 1},
+		// Self-resolved before the run began (e.g. while still queued): must not credit.
+		{"resolve predates the investigation", started.Add(-time.Minute), 0},
+	} {
+		t.Run(tc.label, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "outcomes.jsonl")
+			ledger, err := outcome.New(path)
+			if err != nil {
+				t.Fatalf("new ledger: %v", err)
+			}
+			notifier := notify.NewMulti(discardLog(), &captureNotifier{})
+
+			// The resolve webhook arrives before the open is recorded ⇒ buffered.
+			if _, _, err := ledger.Resolve("f1", tc.resolvedAt); err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			found := providers.Investigation{
+				Title:                  "recalled incident",
+				Fingerprint:            "f1",
+				Fingerprints:           []string{"f1"},
+				TriggerKey:             "k",
+				Recalled:               true,
+				RecalledEntry:          "x.md",
+				InvestigationStartedAt: started,
+			}
+			onInvestigationComplete(context.Background(), found, ledger, nil, nil, notifier, nil, nil, nil, discardLog())
+
+			// The start time must reach the durable open — without it the ledger falls back
+			// to the legacy age bound and this pairing decision silently changes.
+			line := lastOpen(t, path)
+			if !line.StartedAt.Equal(started) {
+				t.Fatalf("open must persist started_at: got %v, want %v", line.StartedAt, started)
+			}
+			if !line.At.After(line.StartedAt) {
+				t.Fatalf("open is stamped at completion, so at (%v) must follow started_at (%v)", line.At, line.StartedAt)
+			}
+
+			counts, err := ledger.OpenCounts()
+			if err != nil {
+				t.Fatalf("OpenCounts: %v", err)
+			}
+			if got := counts["x.md"]; got.Recalls != 1 || got.Resolved != tc.wantResolved {
+				t.Fatalf("want recalls=1 resolved=%d, got recalls=%d resolved=%d",
+					tc.wantResolved, got.Recalls, got.Resolved)
+			}
+		})
 	}
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -253,6 +253,15 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	// it — no path loses a delivery.
 	finish := func(inv providers.Investigation) {
 		setUsage(&inv)
+		// Stamp when THIS investigation began (the same `start` the duration metric uses —
+		// one clock read, one truth). The outcome ledger's open is stamped at COMPLETION, so
+		// the open alone cannot say how long the run took nor how long it waited in the
+		// queue; the start time is what lets the ledger tell a resolve that landed DURING
+		// this investigation (legitimate, pairs) from one that predates it (a bygone episode,
+		// must not credit). Stamped here because finish is the single terminal-delivery
+		// chokepoint — every exit (happy path, recall short-circuit, timeout, refusal, budget
+		// kill, max-steps) routes through it, so no delivered investigation can miss it.
+		inv.InvestigationStartedAt = start
 		li.recordUsageMetrics(ctx, inv.Usage)
 		li.deliver(req, inv)
 	}

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -275,6 +275,7 @@ func TestLoopStampsAlertMetadata(t *testing.T) {
 		At:          start,
 		Labels:      map[string]string{"alertname": "BackupJobsMissing", "cluster": "sanofi-003", "tenant": "sanofi-003"},
 	}
+	before := time.Now()
 	if err := li.Investigate(context.Background(), req); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
@@ -289,6 +290,19 @@ func TestLoopStampsAlertMetadata(t *testing.T) {
 	}
 	if !got.StartedAt.Equal(start) {
 		t.Fatalf("StartedAt not stamped: got %v want %v", got.StartedAt, start)
+	}
+	// InvestigationStartedAt is a DIFFERENT clock from StartedAt: when RunLore began the
+	// run, not when the incident began. The outcome ledger's open is stamped at
+	// COMPLETION, so this is the only record of when the run started — and it is what
+	// bounds resolve-before-open pairing (outcome.resolvesSince). Left unstamped, every
+	// new open would silently fall back to the legacy age bound, so pin it here: it must
+	// fall inside the Investigate call, and must NOT be the incident's start time.
+	if got.InvestigationStartedAt.Before(before) || got.InvestigationStartedAt.After(time.Now()) {
+		t.Fatalf("InvestigationStartedAt must be stamped with the loop's start: got %v, want within [%v, now]",
+			got.InvestigationStartedAt, before)
+	}
+	if got.InvestigationStartedAt.Equal(got.StartedAt) {
+		t.Fatal("InvestigationStartedAt must be the RUN's start, not the INCIDENT's start (req.At)")
 	}
 }
 

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -69,6 +69,16 @@ type Event struct {
 	Resource string    `json:"resource,omitempty"`
 	At       time.Time `json:"at"`
 
+	// StartedAt is, on an open, the wall-clock time the INVESTIGATION BEGAN — whereas At
+	// stamps its COMPLETION. The gap between the two is unbounded in practice (queue wait
+	// on the single-worker queue, rate-limit backoff, coalesce/debounce, then the run
+	// itself), which is exactly why it must be recorded rather than approximated: it is
+	// the interval during which a resolve can legitimately land BEFORE the open it belongs
+	// to, and so the exact bound on resolve-before-open pairing (see resolvesSince).
+	// Zero on a legacy open written before this field existed, and on resolve/feedback/
+	// checkpoint lines; omitempty keeps the append-only file compatible with old readers.
+	StartedAt time.Time `json:"started_at,omitempty"`
+
 	// Recurrence fields (written by the delivery path). Kept omitempty so the
 	// append-only file stays backward/forward compatible with older readers.
 	TriggerKey string `json:"trigger_key,omitempty"` // groups recurrences of the same alert; keys the byTrigger index
@@ -158,6 +168,15 @@ type Ledger struct {
 	// webhooks. Kept so the (otherwise silent) defensive drop is observable.
 	droppedResolves int
 
+	// staleResolves counts buffered resolves discarded at PAIRING time because they
+	// predate the open's investigation (see resolvesSince) — a resolve from a bygone,
+	// uninvestigated episode of the same fingerprint. A distinct signal from
+	// droppedResolves (a buffer overflow, not a pairing decision), and kept for the same
+	// reason: without it the discard is entirely silent, yet it is the one that decides
+	// whether an entry gets a resolve credit. Checkpointed like droppedResolves so
+	// compaction does not lose it.
+	staleResolves int
+
 	// maxEvents bounds the JSONL before loadLocked compacts it (0 disables). corruptLines
 	// records how many lines the last load could not parse (so the skip is observable, not
 	// silent). log carries a logger for those warnings; never nil after New.
@@ -187,6 +206,7 @@ type checkpointData struct {
 	PendingResolves map[string][]time.Time       `json:"pending_resolves,omitempty"`
 	Votes           map[string]feedbackVoteJSON  `json:"votes,omitempty"`
 	DroppedResolves int                          `json:"dropped_resolves,omitempty"`
+	StaleResolves   int                          `json:"stale_resolves,omitempty"`
 }
 
 type triggerAggJSON struct {
@@ -236,34 +256,57 @@ type feedbackVote struct {
 // pair with a real open, and dropping it leaves the brief-window pairing intact.
 const maxPendingResolvesPerFingerprint = 64
 
-// maxEarlyResolveAge bounds how far a buffered resolve may predate the open it pairs
-// with. A resolve is buffered whenever no open is pending for its fingerprint — which
-// includes resolves for alerts that were never investigated at all (suppressed by dedup
-// or by the trigger policy). Unbounded, such a resolve pairs with the NEXT open for the
-// same fingerprint and credits Resolved++ at open time, before the new incident has
-// produced anything: a flapping alert would bank a resolve credit on every suppressed
-// cycle for the next recall to cash in, inflating an entry's resolve rate on evidence
-// that has nothing to do with it. That is a manufactured post hoc, not merely an
-// unverified one.
+// legacyMaxEarlyResolveAge bounds how far a buffered resolve may predate an open that
+// carries NO StartedAt — i.e. ONLY an open written before Event.StartedAt existed, replayed
+// from a pre-upgrade ledger file. Every open written from now on carries its investigation's
+// start time, and resolvesSince gates on that exactly, so this fallback governs nothing but
+// history.
 //
-// Only a resolve that lands while the investigation is still running can legitimately
-// precede its open (the open is stamped at completion). An investigation is bounded by
-// investigation.timeout, 10m by default, so an hour is a generous six-fold margin;
-// beyond it, the resolve belongs to a bygone episode and must not pair.
-const maxEarlyResolveAge = time.Hour
+// It is deliberately generous rather than accurate, because for a legacy open the
+// information needed to be accurate was never recorded: the open is stamped at COMPLETION,
+// so the true bound is the enqueue→open latency, which the event does not carry. An hour is
+// the pragmatic compromise that still discards the pathological case this guards (a resolve
+// from a bygone episode, hours or days old, crediting the NEXT open for the fingerprint).
+const legacyMaxEarlyResolveAge = time.Hour
 
-// freshResolves drops buffered resolves too old to belong to an open stamped at openAt.
-// Returned in arrival order; reuses the backing array, so the caller must replace the
-// slice it passed in.
-func freshResolves(rs []time.Time, openAt time.Time) []time.Time {
-	cutoff := openAt.Add(-maxEarlyResolveAge)
+// resolvesSince drops the buffered resolves that CANNOT belong to open e, and reports how
+// many it dropped. Survivors are returned in arrival order; it reuses the backing array, so
+// the caller must replace the slice it passed in.
+//
+// The rule is exact, not heuristic: a resolve can only legitimately precede the open it
+// belongs to if it landed while that investigation was still RUNNING (the open is stamped
+// at completion, so a resolve arriving mid-investigation is recorded first). A resolve that
+// arrived BEFORE the investigation even began belongs to some earlier episode — the alert
+// fired, cleared, and was never investigated (suppressed by dedup or the trigger policy), or
+// self-resolved while the request sat in the queue. Pairing with such a resolve credits
+// Resolved++ at open time, before the new incident has produced anything: a flapping alert
+// would bank a resolve credit on every suppressed cycle for the next recall to cash in,
+// inflating an entry's resolve rate on evidence that has nothing to do with it — a
+// MANUFACTURED post hoc, not merely an unverified one.
+//
+// Gating on StartedAt rather than on the resolve's AGE is what makes this exact. The age of
+// a legitimate early resolve is bounded by the whole ENQUEUE→OPEN latency — debounce,
+// coalesce wait, the wait behind a single sequential worker, rate-limit backoff (a 1h window
+// by default), and only then the investigation itself — which no fixed hour-scale constant
+// can bound. An age bound therefore drops LEGITIMATE resolves off a backlogged queue and
+// permanently deflates a correct entry's resolve rate. The start time is the real boundary,
+// and the event carries it.
+func resolvesSince(rs []time.Time, e Event) (kept []time.Time, dropped int) {
+	// A legacy open (no StartedAt recorded) has no exact boundary to gate on; fall back to
+	// the age bound it was written under.
+	cutoff := e.StartedAt
+	if cutoff.IsZero() {
+		cutoff = e.At.Add(-legacyMaxEarlyResolveAge)
+	}
 	out := rs[:0]
 	for _, at := range rs {
-		if !at.Before(cutoff) {
-			out = append(out, at)
+		if at.Before(cutoff) {
+			dropped++
+			continue
 		}
+		out = append(out, at)
 	}
-	return out
+	return out, dropped
 }
 
 // New opens (replaying) the ledger at path with the default compaction bound
@@ -328,6 +371,7 @@ func (l *Ledger) resetStateLocked() {
 	l.byTrigger = map[string]triggerAgg{}
 	l.votes = map[string]feedbackVote{}
 	l.droppedResolves = 0
+	l.staleResolves = 0
 }
 
 // foldLocked folds one replayed event into the derived state. Open/resolve maintain the
@@ -386,6 +430,7 @@ func (l *Ledger) seedCheckpointLocked(cd *checkpointData) {
 		l.pendingOpens[fp] = stack
 	}
 	l.droppedResolves += cd.DroppedResolves
+	l.staleResolves += cd.StaleResolves
 }
 
 // compactLocked rewrites the ledger file as [checkpoint][recent tail]: it folds the
@@ -423,6 +468,7 @@ func (l *Ledger) snapshotCheckpointLocked() *checkpointData {
 		OpenIndex:       l.open,
 		PendingResolves: l.pendingResolves,
 		DroppedResolves: l.droppedResolves,
+		StaleResolves:   l.staleResolves,
 	}
 	if len(l.byTrigger) > 0 {
 		cd.ByTrigger = make(map[string]triggerAggJSON, len(l.byTrigger))
@@ -541,13 +587,21 @@ func (l *Ledger) applyOpenLocked(e Event) {
 		l.agg[e.Entry] = a
 	}
 	// Order-independent pairing: a resolve that arrived before this open is buffered;
-	// pair with the earliest such resolve (FIFO), matching Episodes(). Resolves too old
-	// to belong to this open are discarded first — see maxEarlyResolveAge.
+	// pair with the earliest such resolve (FIFO), matching Episodes(). Resolves that
+	// predate this open's investigation cannot belong to it and are discarded first —
+	// see resolvesSince.
 	if rs := l.pendingResolves[e.Fingerprint]; len(rs) > 0 {
-		rs = freshResolves(rs, e.At)
-		if len(rs) > 0 {
-			at := rs[0]
-			l.pendingResolves[e.Fingerprint] = rs[1:]
+		kept, stale := resolvesSince(rs, e)
+		if stale > 0 {
+			// Count + log: the discard decides whether an entry gets a resolve credit, so
+			// it must never be silent (cf. droppedResolves).
+			l.staleResolves += stale
+			l.log.Debug("outcome ledger: discarded buffered resolves predating the investigation",
+				"count", stale, "fingerprint", e.Fingerprint, "started_at", e.StartedAt, "opened_at", e.At)
+		}
+		if len(kept) > 0 {
+			at := kept[0]
+			l.pendingResolves[e.Fingerprint] = kept[1:]
 			if counted {
 				l.creditResolveLocked(e.Entry, at)
 			}
@@ -854,14 +908,16 @@ func (l *Ledger) Episodes() ([]Episode, error) {
 				OpenedAt:       e.At,
 			})
 			i := len(out) - 1
-			// Same pairing rule as applyOpenLocked, kept in lockstep: discard buffered
-			// resolves too old to belong to this open (see maxEarlyResolveAge), then pair
-			// with the earliest survivor.
+			// Same pairing rule as applyOpenLocked, kept in lockstep: discard the buffered
+			// resolves that predate this open's investigation (see resolvesSince), then pair
+			// with the earliest survivor. The drop count is deliberately ignored here — this
+			// is a read-only replay off the file, and folding it into the ledger's counter
+			// would re-count the same discards on every Episodes() call.
 			if rs := pendingResolves[e.Fingerprint]; len(rs) > 0 {
-				rs = freshResolves(rs, e.At)
-				if len(rs) > 0 {
-					resolveAt(i, rs[0]) // pair with the earliest buffered (early) resolve
-					pendingResolves[e.Fingerprint] = rs[1:]
+				kept, _ := resolvesSince(rs, e)
+				if len(kept) > 0 {
+					resolveAt(i, kept[0]) // pair with the earliest buffered (early) resolve
+					pendingResolves[e.Fingerprint] = kept[1:]
 					continue
 				}
 				delete(pendingResolves, e.Fingerprint)

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -236,6 +236,36 @@ type feedbackVote struct {
 // pair with a real open, and dropping it leaves the brief-window pairing intact.
 const maxPendingResolvesPerFingerprint = 64
 
+// maxEarlyResolveAge bounds how far a buffered resolve may predate the open it pairs
+// with. A resolve is buffered whenever no open is pending for its fingerprint — which
+// includes resolves for alerts that were never investigated at all (suppressed by dedup
+// or by the trigger policy). Unbounded, such a resolve pairs with the NEXT open for the
+// same fingerprint and credits Resolved++ at open time, before the new incident has
+// produced anything: a flapping alert would bank a resolve credit on every suppressed
+// cycle for the next recall to cash in, inflating an entry's resolve rate on evidence
+// that has nothing to do with it. That is a manufactured post hoc, not merely an
+// unverified one.
+//
+// Only a resolve that lands while the investigation is still running can legitimately
+// precede its open (the open is stamped at completion). An investigation is bounded by
+// investigation.timeout, 10m by default, so an hour is a generous six-fold margin;
+// beyond it, the resolve belongs to a bygone episode and must not pair.
+const maxEarlyResolveAge = time.Hour
+
+// freshResolves drops buffered resolves too old to belong to an open stamped at openAt.
+// Returned in arrival order; reuses the backing array, so the caller must replace the
+// slice it passed in.
+func freshResolves(rs []time.Time, openAt time.Time) []time.Time {
+	cutoff := openAt.Add(-maxEarlyResolveAge)
+	out := rs[:0]
+	for _, at := range rs {
+		if !at.Before(cutoff) {
+			out = append(out, at)
+		}
+	}
+	return out
+}
+
 // New opens (replaying) the ledger at path with the default compaction bound
 // (DefaultMaxEvents). An empty path returns a disabled, no-op ledger (the feature is off).
 func New(path string) (*Ledger, error) {
@@ -511,14 +541,20 @@ func (l *Ledger) applyOpenLocked(e Event) {
 		l.agg[e.Entry] = a
 	}
 	// Order-independent pairing: a resolve that arrived before this open is buffered;
-	// pair with the earliest such resolve (FIFO), matching Episodes().
+	// pair with the earliest such resolve (FIFO), matching Episodes(). Resolves too old
+	// to belong to this open are discarded first — see maxEarlyResolveAge.
 	if rs := l.pendingResolves[e.Fingerprint]; len(rs) > 0 {
-		at := rs[0]
-		l.pendingResolves[e.Fingerprint] = rs[1:]
-		if counted {
-			l.creditResolveLocked(e.Entry, at)
+		rs = freshResolves(rs, e.At)
+		if len(rs) > 0 {
+			at := rs[0]
+			l.pendingResolves[e.Fingerprint] = rs[1:]
+			if counted {
+				l.creditResolveLocked(e.Entry, at)
+			}
+			return
 		}
-		return
+		// Every buffered resolve was stale: this open is genuinely unresolved so far.
+		delete(l.pendingResolves, e.Fingerprint)
 	}
 	l.pendingOpens[e.Fingerprint] = append(l.pendingOpens[e.Fingerprint], pendingOpen{entry: e.Entry, counted: counted})
 }
@@ -818,10 +854,17 @@ func (l *Ledger) Episodes() ([]Episode, error) {
 				OpenedAt:       e.At,
 			})
 			i := len(out) - 1
+			// Same pairing rule as applyOpenLocked, kept in lockstep: discard buffered
+			// resolves too old to belong to this open (see maxEarlyResolveAge), then pair
+			// with the earliest survivor.
 			if rs := pendingResolves[e.Fingerprint]; len(rs) > 0 {
-				resolveAt(i, rs[0]) // pair with the earliest buffered (early) resolve
-				pendingResolves[e.Fingerprint] = rs[1:]
-				continue
+				rs = freshResolves(rs, e.At)
+				if len(rs) > 0 {
+					resolveAt(i, rs[0]) // pair with the earliest buffered (early) resolve
+					pendingResolves[e.Fingerprint] = rs[1:]
+					continue
+				}
+				delete(pendingResolves, e.Fingerprint)
 			}
 			pendingOpens[e.Fingerprint] = append(pendingOpens[e.Fingerprint], i)
 		case "resolve":

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1385,6 +1385,10 @@ func TestContestedTriggersNilAndDisabled(t *testing.T) {
 // Only a resolve that landed while the investigation was running can legitimately
 // precede its open (see TestEpisodesResolveBeforeOpenPairs, 1s apart). Anything older
 // belongs to a bygone episode and must not pair.
+//
+// This open carries NO StartedAt, so it exercises the LEGACY path: an open written
+// before started_at existed falls back to the legacyMaxEarlyResolveAge age bound, and
+// a day-old resolve is far outside it.
 func TestStaleBufferedResolveDoesNotCreditLaterOpen(t *testing.T) {
 	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
 	stale := time.Unix(9000, 0)
@@ -1409,5 +1413,151 @@ func TestStaleBufferedResolveDoesNotCreditLaterOpen(t *testing.T) {
 	}
 	if len(eps) != 1 || eps[0].Resolved {
 		t.Fatalf("stale resolve must not resolve the episode on replay: got %+v", eps)
+	}
+}
+
+// assertPairing checks the cache (OpenCounts) and the replay (Episodes) agree on
+// whether the single recall open for entry was credited as resolved. The two paths
+// implement the same pairing rule and are kept in lockstep by design, so every
+// early-resolve test asserts on BOTH — a divergence is itself the bug.
+func assertPairing(t *testing.T, l *Ledger, entry string, wantResolved bool) {
+	t.Helper()
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	want := 0
+	if wantResolved {
+		want = 1
+	}
+	if got := counts[entry]; got.Recalls != 1 || got.Resolved != want {
+		t.Fatalf("cache: want recalls=1 resolved=%d, got recalls=%d resolved=%d",
+			want, got.Recalls, got.Resolved)
+	}
+	eps, err := l.Episodes()
+	if err != nil {
+		t.Fatalf("Episodes: %v", err)
+	}
+	if len(eps) != 1 {
+		t.Fatalf("want exactly 1 episode, got %+v", eps)
+	}
+	if eps[0].Resolved != wantResolved {
+		t.Fatalf("replay disagrees with cache: episode Resolved=%v, want %v (cache said %v)",
+			eps[0].Resolved, wantResolved, wantResolved)
+	}
+}
+
+// TestResolveDuringLongInvestigationCreditsOpen is the regression test for the bound
+// that replaced a wall-clock age with the investigation's actual start time.
+//
+// The open is stamped at investigation COMPLETION, so the interval a buffered resolve
+// must survive to pair with it is the whole ENQUEUE→OPEN latency: debounce + coalesce
+// wait + QUEUE WAIT + rate-limit backoff + the investigation itself. The queue is a
+// single sequential worker and the rate-limit window defaults to 1h, so a backlogged
+// queue blows past any fixed hour-scale age bound trivially.
+//
+// Here the alert cleared 30m into an investigation that took 2h end-to-end (mostly
+// queued), so its resolve landed 90 MINUTES before the open. It is a LEGITIMATE
+// resolve for exactly this open — it arrived after the investigation started — and
+// dropping it would permanently deflate a CORRECT entry's resolve rate. An age bound
+// of 1h drops it; the StartedAt gate keeps it.
+func TestResolveDuringLongInvestigationCreditsOpen(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	started := time.Unix(50000, 0)
+	resolvedAt := started.Add(30 * time.Minute) // cleared while the investigation ran
+	openAt := started.Add(2 * time.Hour)        // …which only completed 90m later
+
+	_, _, _ = l.Resolve("fp", resolvedAt) // no open pending yet ⇒ buffered
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", StartedAt: started, At: openAt})
+
+	assertPairing(t, l, "x.md", true)
+}
+
+// TestResolveBeforeInvestigationStartDoesNotCredit pins the other side of the gate:
+// a resolve that arrived BEFORE the investigation began cannot belong to its open. The
+// alert self-resolved while the request was still QUEUED, so nothing this investigation
+// did caused the resolve — crediting it would manufacture a post hoc.
+//
+// Note the age bound this replaced would have PAIRED this one (the resolve is only
+// minutes old at open time), which is precisely why the age was never the right axis.
+func TestResolveBeforeInvestigationStartDoesNotCredit(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	started := time.Unix(50000, 0)
+	resolvedAt := started.Add(-5 * time.Minute) // self-resolved while still queued
+	openAt := started.Add(3 * time.Minute)
+
+	_, _, _ = l.Resolve("fp", resolvedAt)
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", StartedAt: started, At: openAt})
+
+	assertPairing(t, l, "x.md", false)
+}
+
+// TestEarlyResolveDropIsCounted checks the discard is OBSERVABLE, not silent: a
+// resolve dropped at pairing time is counted (staleResolves) and survives compaction
+// through the checkpoint, exactly like the pendingResolves-bound drop counter.
+func TestEarlyResolveDropIsCounted(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "o.jsonl")
+	l, _ := New(p) // no compaction while writing
+	started := time.Unix(60000, 0)
+
+	// Two resolves that predate the investigation's start: both must be discarded.
+	_, _, _ = l.Resolve("fp", started.Add(-2*time.Hour))
+	_, _, _ = l.Resolve("fp", started.Add(-time.Hour))
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", StartedAt: started, At: started.Add(time.Minute)})
+
+	l.mu.Lock()
+	stale, dropped := l.staleResolves, l.droppedResolves
+	l.mu.Unlock()
+	if stale != 2 {
+		t.Fatalf("discarded early resolves must be counted: staleResolves = %d, want 2", stale)
+	}
+	if dropped != 0 {
+		t.Fatalf("the pendingResolves-bound counter is a distinct signal and must not move: droppedResolves = %d, want 0", dropped)
+	}
+	assertPairing(t, l, "x.md", false)
+
+	// The counter is checkpointed like droppedResolves: pad the ledger so the events
+	// above are absorbed into a compaction checkpoint, then reload and confirm the
+	// count was not lost with them.
+	for i := 0; i < 20; i++ {
+		fp := fmt.Sprintf("pad%d", i)
+		_ = l.Open(Event{Fingerprint: fp, Kind: "fresh", At: started.Add(time.Duration(i+10) * time.Minute)})
+		_, _, _ = l.Resolve(fp, started.Add(time.Duration(i+11)*time.Minute))
+	}
+	c, err := NewWithMaxEvents(p, 5) // reload triggers compaction
+	if err != nil {
+		t.Fatalf("NewWithMaxEvents: %v", err)
+	}
+	c.mu.Lock()
+	got := c.staleResolves
+	c.mu.Unlock()
+	if got != 2 {
+		t.Fatalf("staleResolves must survive compaction: got %d, want 2", got)
+	}
+}
+
+// TestLegacyOpenWithoutStartedAtUsesAgeBound pins the backward-compatibility path.
+// A ledger written before started_at existed has opens with a ZERO StartedAt; gating
+// those on it directly would drop EVERY buffered resolve (all resolves postdate the
+// zero time... in fact none do — every real resolve is AFTER year 1, so a zero gate
+// would credit everything). Legacy opens therefore keep the old age bound: a resolve
+// inside legacyMaxEarlyResolveAge still pairs, one outside it does not.
+func TestLegacyOpenWithoutStartedAtUsesAgeBound(t *testing.T) {
+	t0 := time.Unix(70000, 0)
+	for _, tc := range []struct {
+		name         string
+		age          time.Duration // how far the resolve predates the open
+		wantResolved bool
+	}{
+		{"within the legacy bound", legacyMaxEarlyResolveAge / 2, true},
+		{"outside the legacy bound", 2 * legacyMaxEarlyResolveAge, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+			_, _, _ = l.Resolve("fp", t0.Add(-tc.age))
+			// No StartedAt — a legacy open.
+			_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0})
+			assertPairing(t, l, "x.md", tc.wantResolved)
+		})
 	}
 }

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1371,3 +1371,43 @@ func TestContestedTriggersNilAndDisabled(t *testing.T) {
 		t.Fatalf("disabled ledger must yield nil, got %+v", got)
 	}
 }
+
+// TestStaleBufferedResolveDoesNotCreditLaterOpen guards the resolve-before-open
+// buffer against a manufactured post hoc. A resolve is buffered whenever no open is
+// pending for its fingerprint — which includes resolves for alerts that were never
+// investigated at all (suppressed by dedup, or by the trigger policy). Left unbounded,
+// that stale resolve pairs with the NEXT open for the same fingerprint and credits
+// Resolved++ at open time, before the new incident has produced anything. A flapping
+// alert with a stable fingerprint would bank a resolve credit on every suppressed
+// cycle, and the next real recall would cash them in — inflating an entry's resolve
+// rate on evidence that has nothing to do with it.
+//
+// Only a resolve that landed while the investigation was running can legitimately
+// precede its open (see TestEpisodesResolveBeforeOpenPairs, 1s apart). Anything older
+// belongs to a bygone episode and must not pair.
+func TestStaleBufferedResolveDoesNotCreditLaterOpen(t *testing.T) {
+	l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+	stale := time.Unix(9000, 0)
+	// A resolve for an alert that was never investigated: nothing is pending, so it buffers.
+	_, _, _ = l.Resolve("fp", stale)
+	// A day later the same alert fires for real and a recall investigation opens.
+	_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: stale.Add(24 * time.Hour)})
+
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	if got := counts["x.md"]; got.Recalls != 1 || got.Resolved != 0 {
+		t.Fatalf("stale resolve must not credit the open: want recalls=1 resolved=0, got recalls=%d resolved=%d",
+			got.Recalls, got.Resolved)
+	}
+
+	// The replay path must agree with the cache — the two are kept in lockstep by design.
+	eps, err := l.Episodes()
+	if err != nil {
+		t.Fatalf("Episodes: %v", err)
+	}
+	if len(eps) != 1 || eps[0].Resolved {
+		t.Fatalf("stale resolve must not resolve the episode on replay: got %+v", eps)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -639,20 +639,28 @@ type Investigation struct {
 	Resource   Workload // the workload the investigation identified as affected; defaults to the originating alert workload when none was named (stored on curated entries for structural recall)
 	// Trigger-time facts stamped verbatim from the Request for the notification's
 	// metadata block. The model never sees or sets them; empty for sources that lack them.
-	Severity      string      // alert severity label at trigger time
-	Environment   string      // deployment environment (prod/staging/…)
-	Cluster       string      // alert "cluster" label
-	Tenant        string      // alert "tenant" label
-	AlertName     string      // triggering alert name (labels["alertname"]); "" for non-alert sources
-	StartedAt     time.Time   // incident start (alert startsAt / failure time)
-	Actions       []Action    // proposed remediations (autonomy ladder; never executed at rung "suggest")
-	CuratedURL    string      // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
-	Fingerprint   string      // originating alert fingerprint; for outcome-ledger attribution
-	Fingerprints  []string    // coalesced batch fingerprints; one outcome open is recorded per entry
-	TriggerKey    string      // deterministic incident identity set at trigger time (alerts: host-invariant per-class key from curator.IncidentKey; GitOps: failing resource+condition). curator.DupFingerprint prefers it so reworded re-investigations (#137) AND the same alert on a different pod/node (CORE-681) still dedupe
-	RecalledEntry string      // when Recalled: the catalog entry Path that was matched
-	Verified      bool        // true when the adversarial verify pass ran and a root cause survived it
-	Usage         UsageTotals // per-investigation model token/cost accounting (loop + verify); surfaced to humans + metrics, never written to the curated KB body
+	Severity    string    // alert severity label at trigger time
+	Environment string    // deployment environment (prod/staging/…)
+	Cluster     string    // alert "cluster" label
+	Tenant      string    // alert "tenant" label
+	AlertName   string    // triggering alert name (labels["alertname"]); "" for non-alert sources
+	StartedAt   time.Time // incident start (alert startsAt / failure time)
+	// InvestigationStartedAt is when RUNLORE began investigating — distinct from StartedAt,
+	// which is when the INCIDENT began. The two can be far apart: a request waits out
+	// debounce/coalescing, then queues behind the single sequential worker and any
+	// rate-limit backoff before the loop starts. Stamped by the loop at its delivery
+	// chokepoint (never by the model) and carried onto the outcome-ledger open, where it is
+	// the exact bound on resolve-before-open pairing (see outcome.resolvesSince) — the open
+	// itself is stamped at COMPLETION, so without this the pairing window is unknowable.
+	InvestigationStartedAt time.Time
+	Actions                []Action    // proposed remediations (autonomy ladder; never executed at rung "suggest")
+	CuratedURL             string      // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
+	Fingerprint            string      // originating alert fingerprint; for outcome-ledger attribution
+	Fingerprints           []string    // coalesced batch fingerprints; one outcome open is recorded per entry
+	TriggerKey             string      // deterministic incident identity set at trigger time (alerts: host-invariant per-class key from curator.IncidentKey; GitOps: failing resource+condition). curator.DupFingerprint prefers it so reworded re-investigations (#137) AND the same alert on a different pod/node (CORE-681) still dedupe
+	RecalledEntry          string      // when Recalled: the catalog entry Path that was matched
+	Verified               bool        // true when the adversarial verify pass ran and a root cause survived it
+	Usage                  UsageTotals // per-investigation model token/cost accounting (loop + verify); surfaced to humans + metrics, never written to the curated KB body
 	// Recurrence facts stamped at completion from the outcome ledger's per-TriggerKey
 	// index (never seen by the model). They describe PRIOR investigations of the same
 	// TriggerKey; this run's own open is recorded after they are read.


### PR DESCRIPTION
## The bug

`applyResolveLocked` buffers a resolve whenever no open is pending for its fingerprint — including resolves for alerts that were **never investigated at all** (suppressed by `dedup`, or filtered by the trigger policy). `applyOpenLocked` then pairs that buffered resolve with the **next** open for the same fingerprint and credits `Resolved++`.

Since recall confidence derives from the resolve rate (`outcomeFactor`), this **manufactures** a post hoc correlation: an entry's trust rises on evidence that has nothing to do with it.

## Why the first cut of this PR was wrong

It bounded the pairing by **age** (`maxEarlyResolveAge = 1h`), reasoning that an investigation is capped by `investigation.timeout` (10m default), so an hour is a six-fold margin.

**That measures the wrong interval, and it fails in both directions.**

The open is stamped at investigation **completion**, so the window a buffered resolve must survive is the whole **enqueue→open** latency: debounce + coalesce wait + **queue wait** + rate-limit backoff + the investigation itself. The queue is a **single sequential worker** (`investigate.go`, `q.process` called inline), and the rate-limit window defaults to **1h**. A backlogged queue blows past any fixed margin.

Reverting to the age bound makes both new tests fail:

```
--- FAIL: TestResolveDuringLongInvestigationCreditsOpen
    cache: want recalls=1 resolved=1, got recalls=1 resolved=0
--- FAIL: TestResolveBeforeInvestigationStartDoesNotCredit
    cache: want recalls=1 resolved=0, got recalls=1 resolved=1
```

- **Too strict:** a legitimate resolve that landed 90 minutes into a queued investigation is **dropped** — permanently deflating a *correct* entry's resolve rate, since Alertmanager never re-sends a resolve for an already-resolved fingerprint.
- **Too loose:** a resolve that **predated the investigation entirely** was still **credited**, so long as it was under an hour old. The original bug, unfixed.

## The fix: gate on the start time, not an age

The intent was always *"only a resolve that lands while the investigation is still **running** can legitimately precede its open."* That is not an age — it is a **start time**. Recording it makes the gate exact and the magic constant disappear.

- `Event.StartedAt` (`started_at,omitempty`) records when the investigation **began** (vs `At`, stamped at completion). Sourced from the `start` that already feeds the `InvestigationDuration` metric — no second clock read.
- `resolvesSince` drops any buffered resolve arriving **before** `StartedAt`, then pairs with the earliest survivor (FIFO). Applied on **both** pairing paths, which the code keeps in lockstep by design: `applyOpenLocked` (live cache) and `Episodes()` (disk replay).
- This is coherent with the queue, which already cancels a queued investigation whose incident resolves first: a resolve predating `StartedAt` genuinely has no open to belong to.

**Backward compatible.** Pre-upgrade events carry no `started_at`; a zero value falls back to the old 1h bound (`legacyMaxEarlyResolveAge`, documented as legacy-only). New events always carry one.

**The drop is no longer silent.** A new `staleResolves` counter (sibling to `droppedResolves` — buffer overflow and a pairing decision are different phenomena, and conflating them would pollute `TestPendingResolvesBounded`'s signal) plus a Debug log, persisted through compaction/checkpoint.

## Tests

- `TestResolveDuringLongInvestigationCreditsOpen` — a resolve 90 min before the open, but **after** `StartedAt`, still credits. Fails on the age bound.
- `TestResolveBeforeInvestigationStartDoesNotCredit` — a resolve predating `StartedAt` does not credit. Also fails on the age bound.
- `TestEarlyResolveDropIsCounted` (incl. survival through compaction), `TestLegacyOpenWithoutStartedAtUsesAgeBound`.
- Every new test asserts the **cache and the replay agree**, via a shared `assertPairing` helper.
- Kept green: `TestStaleBufferedResolveDoesNotCreditLaterOpen`, `TestEpisodesResolveBeforeOpenPairs`, `TestPendingResolvesBounded`.

Full suite green under `-race`, `go vet` clean, `golangci-lint` 0 issues.
