### PR TITLE
test(catalog): make TestRunReloadsOnlyOnChange deterministic

### DIFF
--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -148,6 +148,7 @@ func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func() 
 		}
 	}
 	do()
+	// interval is ignored when tick is set (tests only); the sender paces the loop.
 	ticks := s.tick
 	if ticks == nil {
 		ticker := time.NewTicker(interval)

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -31,6 +31,12 @@ type Syncer struct {
 	Log    *slog.Logger
 
 	lastRev plumbing.Hash // last-synced HEAD; gates re-index on real change
+
+	// tick, when non-nil, supplies Run's poll ticks instead of a real time.Ticker —
+	// the seam that lets a test drive the loop cycle by cycle rather than sleeping and
+	// hoping a git clone finished in time (mirrors the incidentDebouncer's clock).
+	// Always nil in production.
+	tick <-chan time.Time
 }
 
 func (s *Syncer) auth(ctx context.Context) (*githttp.BasicAuth, error) {
@@ -142,13 +148,17 @@ func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func() 
 		}
 	}
 	do()
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+	ticks := s.tick
+	if ticks == nil {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		ticks = ticker.C
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-ticks:
 			do()
 		}
 	}

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -173,10 +173,17 @@ func TestSyncerCloneAndPull(t *testing.T) {
 // the first sync, then NOT again while upstream HEAD is unchanged, and again once a
 // new commit moves HEAD. The `if changed { onSync() }` gate is what prevents the
 // every-poll full index rebuild.
+//
+// It drives the poll ticks itself rather than sleeping. The previous version slept a
+// fixed 120ms and then asserted the initial sync had already fired — silently assuming
+// a real `git clone` completes within that window. On a loaded CI runner it does not,
+// and the test failed on changes that could not possibly affect it. Nothing here
+// depends on wall-clock time now.
 func TestRunReloadsOnlyOnChange(t *testing.T) {
 	src := initBareUpstream(t)
 	dir := t.TempDir()
-	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
+	tick := make(chan time.Time) // unbuffered — see waitCycle
+	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger(), tick: tick}
 
 	var calls atomic.Int32
 	ctx, cancel := context.WithCancel(context.Background())
@@ -184,19 +191,37 @@ func TestRunReloadsOnlyOnChange(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.Run(ctx, 15*time.Millisecond, func() error { calls.Add(1); return nil })
+		s.Run(ctx, time.Hour, func() error { calls.Add(1); return nil }) // interval unused: tick drives the loop
 	}()
 
-	// Several poll intervals with no upstream change → onSync fires exactly once
-	// (the initial sync), regardless of how many ticks elapse.
-	time.Sleep(120 * time.Millisecond)
-	if n := calls.Load(); n != 1 {
-		t.Fatalf("with no HEAD change onSync must fire exactly once, fired %d", n)
+	// Run only receives from the (unbuffered) tick channel between poll cycles, so a
+	// send that completes proves the PREVIOUS cycle has finished. That is the
+	// synchronisation point which replaces every sleep.
+	waitCycle := func() {
+		t.Helper()
+		select {
+		case tick <- time.Time{}:
+		case <-time.After(30 * time.Second): // a hang, not a timing assumption
+			t.Fatal("Run never came back for a tick — the poll loop is stuck")
+		}
 	}
 
-	// Move HEAD: the next poll detects the change and reloads once more.
+	// The first send is accepted only once the INITIAL sync has completed.
+	waitCycle()
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("initial sync must fire onSync exactly once, fired %d", n)
+	}
+
+	// That tick ran a poll against an unchanged upstream; the next send proves it ended.
+	waitCycle()
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("with no HEAD change onSync must not fire again, fired %d", n)
+	}
+
+	// Move HEAD: one poll observes it, a further send proves that poll completed.
 	commitToUpstream(t, src, "new.md", "# new")
-	time.Sleep(150 * time.Millisecond)
+	waitCycle()
+	waitCycle()
 	if n := calls.Load(); n != 2 {
 		t.Fatalf("a new upstream commit must trigger exactly one more onSync, total %d (want 2)", n)
 	}

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -218,7 +218,18 @@ func TestRunReloadsOnlyOnChange(t *testing.T) {
 		t.Fatalf("with no HEAD change onSync must not fire again, fired %d", n)
 	}
 
-	// Move HEAD: one poll observes it, a further send proves that poll completed.
+	// Move HEAD. BOTH sends below are load-bearing, and neither is redundant.
+	//
+	// Accepting a send starts the next poll immediately, so the poll begun by the send
+	// above is in flight RIGHT NOW and races this commit: it may fetch the new HEAD, or
+	// it may fetch just before the ref moves and see nothing. Either is fine — every
+	// error/no-change path in Sync returns before `s.lastRev = rev`, so a poll that
+	// misses the commit changes no state.
+	//
+	// The first send therefore only DRAINS that racing poll (proving it ended); it does
+	// not prove a post-commit poll ran. The second send proves the poll that started
+	// after the commit was already visible has completed. onSync fires on exactly one of
+	// the two — whichever first sees rev != lastRev — so the count is 2 either way.
 	commitToUpstream(t, src, "new.md", "# new")
 	waitCycle()
 	waitCycle()


### PR DESCRIPTION
A flaky test: it failed CI on a **README-only PR** (#311) and passed on rerun.

## Root cause, reproduced

The test slept a fixed 120ms, then asserted the initial sync had already fired. That silently assumes a real `git clone` completes inside the window. On a loaded runner it does not.

Reproduced deterministically by shrinking the sleep to 1ms:

```
--- FAIL: TestRunReloadsOnlyOnChange (0.00s)
    sync_test.go:194: with no HEAD change onSync must fire exactly once, fired 0
```

`fired 0` — the clone had not finished. That is exactly what a slow CI runner produces.

## Fix

Give `Syncer` a `tick` seam (`<-chan time.Time`, nil in production) so the test drives the poll loop itself, mirroring how `incidentDebouncer` already takes a `clock` in `internal/source`.

The channel is **unbuffered** and `Run` only receives from it *between* poll cycles — so a send that completes proves the previous cycle finished. That is a genuine synchronisation point, and it replaces every sleep. The only deadline left is a 30s guard against a genuinely stuck loop, which is a hang detector rather than a timing assumption.

The assertions are unchanged in substance and one is now sharper: the test can distinguish "initial sync fired" from "a later poll re-fired", which the sleep-based version conflated.

## Verification

- 100 runs under `-race` with `GOMAXPROCS=1` on a fully saturated machine: green.
- Full `internal/catalog` package green, `go vet` clean.
- Test runtime drops from ~300ms to ~33ms.