### PR TITLE
docs: fix 12 GitHub alerts that were rendering as plain blockquotes

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -4,7 +4,9 @@ RunLore is model-agnostic: you pick the model behind the investigation loop. Thi
 page shows how to benchmark several models against RunLore's own eval harness in
 **one command** and publish an honest comparison.
 
-> [!important] Run RunLore on *your* models
+> [!IMPORTANT]
+> **Run RunLore on *your* models**
+>
 > The comparison runs the **replay** eval suite (recorded incident evidence, no
 > live cluster) so it is reproducible and cheap. It measures the model+loop's
 > reasoning over fixed evidence — not a live cluster's flakiness. See the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,9 @@
 
 A navigable map of RunLore's configuration, organized by subsystem.
 
-> [!note] `values.yaml` is the authoritative reference
+> [!NOTE]
+> **`values.yaml` is the authoritative reference**
+>
 > The single source of truth for every key is the chart's
 > [`deploy/helm/runlore/values.yaml`](../deploy/helm/runlore/values.yaml) — every key carries an
 > inline rationale comment, and the whole `config:` block is rendered **verbatim** into the agent's
@@ -280,7 +282,9 @@ re-investigates instead of reusing it (see
 [learning-loop.md §6](learning-loop.md#6-the-feedback-edge--outcome-driven-decay-what-makes-it-learn)).
 This is the primary trust signal for incidents that have **no resolve channel** (GitOps failures).
 
-> [!important] Enabling this requires exposing the agent to Slack.
+> [!IMPORTANT]
+> **Enabling this requires exposing the agent to Slack.**
+>
 > Button clicks arrive as HTTPS callbacks on **`POST /slack/interactions`**, so that endpoint must be
 > reachable **from Slack's servers** (a public Interactivity *Request URL* on your Slack app — the same
 > endpoint and the same exposure approve-mode buttons use; if you already run `actions.mode: approve`

--- a/docs/prior-art.md
+++ b/docs/prior-art.md
@@ -43,7 +43,9 @@ Converged on one shape — *live model of prod → agentic RCA → evidence in S
 - **Incumbents:** Datadog, PagerDuty, Grafana, Dynatrace, New Relic, AWS, Google, ServiceNow.
 - **Memory/learning** (Cleric, Resolve, PagerDuty, Google) is **all closed**.
 
-> [!note] The market is frothy and under scrutiny
+> [!NOTE]
+> **The market is frothy and under scrutiny**
+>
 > Resolve.ai raised a $1B-headline Series A (Dec 2025) on ~$4M ARR; Gartner places agentic AI at the
 > "Peak of Inflated Expectations" (>40% of agentic projects predicted cancelled by 2027) and flags
 > "agent-washing." Pressure-test every "autonomous"/"%MTTR" claim against the vendor's own docs.

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -141,7 +141,9 @@ Slack / Stripe / Google / OpenAI-style / AWS key formats, `user:password@host` U
 **values under `data:`/`stringData:` of a `kind: Secret` manifest**, including one surfaced inside
 a `what_changed` git diff.
 
-> [!warning] Redaction is a mitigation, not a guarantee
+> [!WARNING]
+> **Redaction is a mitigation, not a guarantee**
+>
 > The ruleset is deliberately **high-precision**: it masks values while preserving structure (the
 > key name, the diff line) so the investigation can still reason — "the password field changed" —
 > without the secret. The cost of precision is recall. Things the regexes deliberately do **not**
@@ -223,7 +225,9 @@ attacker-influenceable. Each output surface neutralizes it for *its own* interpr
   an insecure parent `base_url`), embeddings, and every MCP server. Loopback and in-cluster hosts
   are exempt; the check is pure (no DNS) so validation stays deterministic.
 
-> [!note] Explicitly out of scope: dial-time DNS rebinding
+> [!NOTE]
+> **Explicitly out of scope: dial-time DNS rebinding**
+>
 > The redirect guard resolves the redirect target when deciding; it does not re-check at dial time,
 > and no client pins resolved IPs. Endpoints you put in the config are part of the **operator trust
 > boundary** — RunLore defends against a *legitimate* endpoint redirecting somewhere hostile, not

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -64,7 +64,9 @@ GitHub / Slack / AWS / Google / Stripe keys, `user:pass@host` URLs, `Authorizati
 generic `*(password|secret|api_key|token|…): <value>` pairs, and the values under a `kind: Secret`
 manifest's `data:`/`stringData:` block — including one surfaced inside a git diff.
 
-> [!warning] Redaction is a mitigation, not a guarantee
+> [!WARNING]
+> **Redaction is a mitigation, not a guarantee**
+>
 > The ruleset is deliberately high-precision, and the cost of precision is recall: unlabeled
 > high-entropy strings, bare AWS secret keys with no context cue, and base64 blobs *outside* a
 > `kind: Secret` `data:` block (the redactor never decodes base64) are **not** caught — see

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,9 @@ two diagnostic channels:
 - **Metrics** — `runlore_*` Prometheus series, exposed when `telemetry.metrics_enabled: true`. See
   [Observability](observability.md) for the full catalog and a Grafana dashboard.
 
-> [!note] Leader-only by design
+> [!NOTE]
+> **Leader-only by design**
+>
 > With `leader_election.enabled` (the chart default, 2 replicas) **only the leader investigates**. A
 > standby logs `msg="standby; another replica leads"`, reports `/readyz` 200 like the leader (readiness
 > is catalog warmth, not leadership), and **proxies** any webhook it receives to the leader — grep
@@ -145,7 +147,9 @@ Instant recall requires `catalog.instant_recall.enabled: true` **and** a confide
 
 ## Findings were investigated but never delivered to chat
 
-> [!warning] Delivery has no metric — logs only
+> [!WARNING]
+> **Delivery has no metric — logs only**
+>
 > There is currently **no** `runlore_*` counter for notifier delivery. A failed send logs
 > `msg="delivery failed" err=…` (the Slack/Matrix/webhook fan-out is best-effort and joins errors).
 > Successful sends are **not** logged. Grep `msg="delivery failed"` and `msg="deliver findings"`.

--- a/docs/upgrade-uninstall.md
+++ b/docs/upgrade-uninstall.md
@@ -13,7 +13,9 @@ helm upgrade runlore deploy/helm/runlore -n runlore -f values.yaml
 Your `values.yaml` is the source of truth; the entire agent config under `values.config` is rendered
 verbatim into the ConfigMap. Re-apply the same file (with your changes) on every upgrade.
 
-> [!warning] Expect ~20s of downtime during the agent's own upgrade (default strategy)
+> [!WARNING]
+> **Expect ~20s of downtime during the agent's own upgrade (default strategy)**
+>
 > The Deployment ships with **`strategy.type: Recreate`**: old pods are terminated **before** new
 > ones start, so the agent is briefly unavailable while the new version boots and wins the leader
 > lease. Set `updateStrategy: RollingUpdate` for near-zero-downtime upgrades (see below).
@@ -43,7 +45,9 @@ stops accepting new work, and lets the in-flight investigation complete.
 
 ## What persists across upgrades, restarts, and failover
 
-> [!important] State is **ephemeral by default**
+> [!IMPORTANT]
+> **State is ephemeral by default**
+>
 > `persistence.enabled` defaults to **`false`**, which backs the data directory with an `emptyDir` —
 > wiped on every pod restart, upgrade, and failover. For anything you want to survive, enable the PVC.
 
@@ -64,7 +68,9 @@ The **bleve search index is *not* persisted** — it is built in memory (`NewMem
 the catalog mirror at startup, so a restart simply re-indexes. Instant-recall quality is unaffected by
 losing the index; it depends on the catalog content, which lives in your Git repo.
 
-> [!note] If you run with `persistence.enabled: false`
+> [!NOTE]
+> **If you run with `persistence.enabled: false`**
+>
 > The outcome ledger and audit log are lost on every restart, and the catalog re-clones from scratch
 > on boot. That's fine for a quick trial, but for the **learning loop** to compound (outcome-weighted
 > recall decay) the outcome ledger must persist — enable the PVC for any real deployment.


### PR DESCRIPTION
## The bug

**Every alert in `docs/` has been rendering as a plain blockquote.** Twelve of them, across seven files, none of which have ever displayed as a callout on GitHub.

They all use Obsidian's callout syntax — a title on the marker line:

```markdown
> [!note] Leader-only by design
> The reconciler runs on the leader only…
```

**GitHub has no custom-title syntax.** Anything after the marker on that line kills the alert: the block degrades to a plain blockquote and the marker renders as literal body text — readers see `[!note] Leader-only by design` as prose.

The failure is silent. No build error, no lint warning; the repo has no markdown linter and nothing in CI renders GFM. It only shows up when a human looks at the page on github.com.

## The non-obvious part

**The lowercase is not the problem.** GitHub's parser is case-insensitive, despite the docs only ever showing `[!NOTE]`. I verified all four permutations against the real renderer:

| Markdown | Renders as an alert? |
|---|---|
| `> [!note] Title` | ❌ plain blockquote |
| `> [!NOTE] Title` | ❌ **also** a plain blockquote |
| `> [!note]` alone | ✅ yes |
| `> [!NOTE]` alone | ✅ yes |

So the intuitive fix — "just uppercase the marker" — would have left every one of them broken.

## The fix

Marker alone on its line; title moved into the body as its first bolded line.

```markdown
> [!NOTE]
> **Leader-only by design**
>
> The reconciler runs on the leader only…
```

Titles containing code spans and italics are preserved; `State is **ephemeral by default**` is flattened to a single bold span rather than producing `****`.

## Verification

Each file was piped through GitHub's own GFM engine rather than eyeballed:

```bash
jq -Rs '{text:., mode:"gfm"}' "$f" | gh api /markdown --input -
```

```
  OK   docs/benchmarking.md             1/1 alerts render
  OK   docs/configuration.md            2/2 alerts render
  OK   docs/prior-art.md                1/1 alerts render
  OK   docs/security-architecture.md    2/2 alerts render
  OK   docs/security-model.md           1/1 alerts render
  OK   docs/troubleshooting.md          2/2 alerts render
  OK   docs/upgrade-uninstall.md        3/3 alerts render

residual same-line-title alerts: 0
```

## Deliberately not touched

`eval/scenarios/manifests/poisoned-recall-entry.md` and `examples/eval/fixtures/poisoned-recall/eval-victim-configmap.md` also carry same-line-title `[!WARNING]` markers, but they are **poisoned eval fixtures** — test data consumed as text, not rendered documentation. Changing their content risks changing what the eval measures.

Docs-only. No code change.