### PR TITLE
ci: publish a semver-tagged image on release

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,105 @@
+# Publish a SEMVER-TAGGED image on release.
+#
+# WHY THIS EXISTS AS A SEPARATE WORKFLOW
+# --------------------------------------
+# build-image.yml only ever pushes a rolling `:main` tag, and its trigger is
+# `push: branches: [main]` behind a path filter (**.go, go.mod, go.sum, Dockerfile,
+# ...). Two consequences, both silent:
+#
+#   * a release-please commit ("chore(main): release X.Y.Z") touches CHANGELOG and
+#     version files and NO Go code — so the path filter skips it, and the image
+#     build never runs for the very commit the release tag points at;
+#   * there is no `tags:` trigger, so pushing the git tag builds nothing either.
+#
+# Net effect: git tag vX.Y.Z exists, image vX.Y.Z does NOT. Anything pinning the
+# image by release tag gets ImagePullBackOff / NotFound. This bit a real cluster:
+# a GitOps deployment pinned ghcr.io/smana/runlore:v0.9.0 and the agent sat dead in
+# ImagePullBackOff, so no alert was ever investigated.
+#
+# Adding `tags:` to build-image.yml's existing trigger would NOT be safe: GitHub
+# applies a `paths:` filter to tag pushes too, so the release tag would keep being
+# filtered out. Hence a dedicated workflow with no path filter.
+name: Release Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  # Lets you backfill an image for a tag that predates this workflow.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to build and publish (e.g. v0.9.0)'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/runlore
+
+concurrency:
+  group: release-image-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and publish ${{ github.event.inputs.tag || github.ref_name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout the tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # ghcr/OCI refs must be lowercase, but github.repository_owner can carry
+      # uppercase (e.g. "Smana"). Emit both the vX.Y.Z tag and :latest.
+      - name: Compute image refs
+        id: ref
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          case "$TAG" in
+            v*) ;;
+            *) echo "::error::tag '$TAG' must start with 'v'"; exit 1 ;;
+          esac
+          echo "tags=${IMAGE,,}:${TAG},${IMAGE,,}:latest" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "primary=${IMAGE,,}:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          # VERSION lands in runlore_build_info and the dashboard's version panel;
+          # without it the Dockerfile defaults to "dev".
+          build-args: |
+            VERSION=${{ steps.ref.outputs.version }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.ref.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Fail loudly if the tag somehow isn't pullable — the whole point of this
+      # workflow is that "the git tag exists" must imply "the image tag exists".
+      - name: Verify the published tag is pullable
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${{ steps.ref.outputs.primary }}" >/dev/null
+          echo "✅ ${{ steps.ref.outputs.primary }} is published and pullable"


### PR DESCRIPTION
## The bug

A git tag `vX.Y.Z` does **not** currently produce an image `ghcr.io/smana/runlore:vX.Y.Z`.

The registry holds **244 tags and zero semver tags**. Anything pinning the image by release tag gets `NotFound`.

**This is not theoretical.** A GitOps deployment pinned `ghcr.io/smana/runlore:v0.9.0`. The StatefulSet sat in `ImagePullBackOff` from the moment the cluster was built, the HelmRelease never installed, and the agent investigated **exactly zero alerts**. Nothing failed loudly — the git tag existed, the chart existed, the release notes existed. Only the image was missing.

## Two independent causes, both in `build-image.yml`

1. Its trigger is `push: branches: [main]` behind a **path filter** (`**.go`, `go.mod`, `go.sum`, `Dockerfile`, …). A release-please commit (`chore(main): release 0.9.0`) touches CHANGELOG and version files and **no Go code** — so the filter skips the build for the very commit the release tag points at.
2. There is **no `tags:` trigger**, so pushing the tag builds nothing either. The workflow only ever pushes a rolling `:main`.

## Why not just add `tags:` to `build-image.yml`

GitHub applies a `paths:` filter to **tag pushes too**, so the release tag would keep being filtered out. Hence a dedicated workflow with no path filter.

## What this adds

`release-image.yml`:
- triggers on `push: tags: ['v*']`
- also `workflow_dispatch`, so an image can be **backfilled** for a tag that predates this workflow (e.g. `v0.9.0`)
- checks out the tag and builds with `VERSION=<tag>`, so `runlore_build_info` and the dashboard version panel report the release instead of `dev`
- pushes `:vX.Y.Z` **and** `:latest`
- **verifies the published tag is pullable**, so "the git tag exists" cannot silently diverge from "the image tag exists" again

## Note

Platform stays `linux/amd64`, matching `build-image.yml`. Worth flagging separately: the image has **never** been multi-arch, despite being described as such downstream.

## After merge

Run the workflow via `workflow_dispatch` with `tag: v0.9.0` to backfill the missing image.
