### PR TITLE
fix(recall): the near-miss gate must be looser than the instant-recall gate

### DIFF
--- a/internal/investigate/nearmiss_gate_test.go
+++ b/internal/investigate/nearmiss_gate_test.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// The live Harbor incident, reduced to its structural core.
+//
+// The alert fires on the HelmRelease `tooling/harbor`. The entry that actually
+// explains it is filed on the pod `tooling/harbor-registry` — where the fault IS.
+// Both resources are correct; they are one step apart in the ownership chain.
+// resourceAgrees rejects the pair (rightly, for instant recall). The near-miss must
+// not.
+var (
+	harborAlert   = providers.Workload{Namespace: "tooling", Name: "harbor"}
+	harborIAMPath = "iam.md"
+)
+
+func harborIAMCatalog() fakeScored {
+	return fakeScored{hits: []catalog.ScoredEntry{{
+		Entry: catalog.Entry{
+			Title:    "Harbor Registry Down due to IAM Access Key Quota Limit",
+			Path:     harborIAMPath,
+			Resource: "tooling/harbor-registry",
+			Body:     "## Cause\nAccessKey/xplane-harbor hit AccessKeysPerUser: 2.\n\n## Resolution\nDelete an unused IAM access key.\n",
+		},
+		Score: 3.0,
+	}}}
+}
+
+func harborReq() Request {
+	return Request{
+		Title:       "HelmRelease/harbor InstallFailed",
+		Fingerprint: "fp-gate",
+		Workload:    harborAlert,
+		Labels:      map[string]string{"alertname": "HelmReleaseInstallFailed"},
+	}
+}
+
+// TestNearMissAdmitsSameNamespaceDifferentWorkload is the regression test. Before this
+// change the entry was invisible to BOTH instant recall and the near-miss, so a full
+// paid investigation ran beside a catalog that held the answer.
+func TestNearMissAdmitsSameNamespaceDifferentWorkload(t *testing.T) {
+	r := &Recall{
+		MinScore: 4.0, MarginGap: 2.0, SoloFloor: 4.0, // deliberately unreachable: we want the near-miss path
+		Catalog: harborIAMCatalog(),
+	}
+	nm := r.nearMiss(context.Background(), harborReq())
+	if nm == nil {
+		t.Fatal("near-miss must admit a same-namespace entry on a different workload: " +
+			"an alert on tooling/harbor and a past incident on tooling/harbor-registry are the same failure, one step apart in the ownership chain")
+	}
+	if nm.Path != harborIAMPath {
+		t.Fatalf("wrong near-miss entry: %s", nm.Path)
+	}
+}
+
+// TestInstantRecallStillRejectsDifferentWorkload is the SAFETY property, and the reason
+// this fix does not simply loosen resourceAgrees.
+//
+// Instant recall short-circuits the loop and presents the entry as the answer. It must
+// keep refusing a runbook from a different named workload — auto-applying a pod's
+// runbook to a HelmRelease alert would be wrong. Loosening the near-miss must not
+// loosen this.
+func TestInstantRecallStillRejectsDifferentWorkload(t *testing.T) {
+	r := &Recall{
+		MinScore: 0.1, MarginGap: 0.0, SoloFloor: 0.1, // wide open: only the STRUCTURAL gate can stop it
+		Catalog: harborIAMCatalog(),
+	}
+	entry, conf := r.lookup(context.Background(), harborReq())
+	if entry != nil {
+		t.Fatalf("instant recall must still reject a different-workload entry even with every confidence gate wide open "+
+			"(got %s @ %.2f) — a near-miss is a lead, recall is an answer", entry.Path, conf)
+	}
+}
+
+// TestNearMissHonoursRequireWorkloadMatch proves the looser tier is not forced on an
+// operator who has explicitly demanded exact structural agreement.
+func TestNearMissHonoursRequireWorkloadMatch(t *testing.T) {
+	r := &Recall{
+		MinScore: 4.0, MarginGap: 2.0, SoloFloor: 4.0,
+		RequireWorkloadMatch: true,
+		Catalog:              harborIAMCatalog(),
+	}
+	if nm := r.nearMiss(context.Background(), harborReq()); nm != nil {
+		t.Fatalf("require_workload_match: true must suppress the loosened near-miss tier, got %s", nm.Path)
+	}
+}
+
+// TestNearMissStopsAtTheNamespaceBoundary proves the new tier is scoped, not a
+// free-for-all: a hint from an unrelated namespace is noise, not a lead.
+func TestNearMissStopsAtTheNamespaceBoundary(t *testing.T) {
+	r := &Recall{
+		MinScore: 4.0, MarginGap: 2.0, SoloFloor: 4.0,
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{{
+			Entry: catalog.Entry{
+				Title:    "Some unrelated incident in another namespace",
+				Path:     "other.md",
+				Resource: "observability/vmagent",
+				Body:     "## Cause\nUnrelated.\n",
+			},
+			Score: 3.0,
+		}}},
+	}
+	if nm := r.nearMiss(context.Background(), harborReq()); nm != nil {
+		t.Fatalf("near-miss must not cross the namespace boundary, got %s", nm.Path)
+	}
+}
+
+// TestNearMissAgreesLadder pins the predicate itself, tier by tier, so a future edit to
+// resourceAgrees cannot silently change what a lead is allowed to be.
+func TestNearMissAgreesLadder(t *testing.T) {
+	w := providers.Workload{Namespace: "tooling", Name: "harbor"}
+	cases := []struct {
+		name          string
+		entryResource string
+		require       bool
+		want          matchStrength
+	}{
+		{"exact workload", "tooling/harbor", false, matchExact},
+		{"bare namespace entry", "tooling", false, matchNamespace},
+		{"same ns, different workload — the new tier", "tooling/harbor-registry", false, matchNamespace},
+		{"same ns, different workload, require_workload_match", "tooling/harbor-registry", true, matchNone},
+		{"different namespace", "observability/vmagent", false, matchNone},
+		{"resource-less entry, scoped request", "", false, matchNone},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nearMissAgrees(w, tc.entryResource, tc.require); got != tc.want {
+				t.Fatalf("nearMissAgrees(%q, require=%v) = %v, want %v", tc.entryResource, tc.require, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResourceAgreesUnchangedForDifferentWorkload pins the OTHER half of the contract:
+// the strict predicate must be untouched by this change.
+func TestResourceAgreesUnchangedForDifferentWorkload(t *testing.T) {
+	w := providers.Workload{Namespace: "tooling", Name: "harbor"}
+	if got := resourceAgrees(w, "tooling/harbor-registry", false); got != matchNone {
+		t.Fatalf("resourceAgrees must keep rejecting two distinct named workloads (it guards instant recall), got %v", got)
+	}
+}

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -297,12 +297,53 @@ func (r *Recall) nearMissExcluding(ctx context.Context, req Request, exclude str
 		if exclude != "" && h.Entry.Path == exclude {
 			continue
 		}
-		if resourceAgrees(req.Workload, h.Entry.Resource, r.RequireWorkloadMatch) != matchNone {
+		if nearMissAgrees(req.Workload, h.Entry.Resource, r.RequireWorkloadMatch) != matchNone {
 			e := h.Entry
 			return &e
 		}
 	}
 	return nil
+}
+
+// nearMissAgrees is the structural gate for a NEAR-MISS, and it is deliberately looser
+// than resourceAgrees.
+//
+// resourceAgrees guards INSTANT RECALL, which short-circuits the loop and presents a
+// catalog entry as the answer. Refusing two distinct named workloads there is correct
+// and must stay: auto-applying a pod's runbook to a HelmRelease alert would be wrong.
+//
+// A near-miss is not an answer. It is an UNVERIFIED lead, framed as such in the seed
+// ("verify against live state, do not assume it applies"), redacted like alert text,
+// and already disabled under actions.mode=auto. Judging it by the bar that protects an
+// auto-executed action throws away the catalog's value at exactly the moment it is
+// needed.
+//
+// The tier this adds is same-namespace/different-workload. Two named workloads in one
+// namespace are very often the SAME incident seen from different objects, one step
+// apart in the ownership chain: an alert on the HelmRelease `tooling/harbor` and a past
+// incident filed on the pod `tooling/harbor-registry` are the same failure. Under
+// resourceAgrees that pair is matchNone — so the entry is invisible to recall AND to
+// the near-miss, and a full paid investigation runs beside a catalog that holds the
+// answer. Observed live.
+//
+// requireWorkload is an explicit operator demand for exact agreement; it is honoured
+// here too, so an operator who has asked for strictness does not silently get this tier.
+func nearMissAgrees(reqW providers.Workload, entryResource string, requireWorkload bool) matchStrength {
+	if s := resourceAgrees(reqW, entryResource, requireWorkload); s != matchNone {
+		return s
+	}
+	if requireWorkload {
+		return matchNone
+	}
+	if reqW.Namespace == "" || entryResource == "" {
+		return matchNone
+	}
+	// Same namespace, different named workload — a lead, never an answer. The
+	// namespace boundary is the limit: a hint from an unrelated namespace is noise.
+	if strings.HasPrefix(entryResource, reqW.Namespace+"/") {
+		return matchNamespace
+	}
+	return matchNone
 }
 
 // reject records a rejection reason (nil-safe).


### PR DESCRIPTION
## The bug

A past incident filed **one step away in the ownership chain** is invisible to the catalog — to instant recall *and* to the near-miss. A full paid investigation then runs beside a KB that holds the answer.

`nearMiss` reuses `resourceAgrees`, the predicate that guards **instant recall**. That predicate refuses two distinct named workloads — and for recall that is *correct*: recall short-circuits the loop and presents the entry **as the answer**, so auto-applying a pod's runbook to a HelmRelease alert would be wrong.

But a near-miss is **not an answer**. It is an UNVERIFIED lead, framed as such in the seed (*"verify against live state, do not assume it applies"*), redacted like alert text, and already disabled under `actions.mode=auto`. Judging a hint by the bar that protects an auto-executed action throws the catalog away exactly when it is most useful.

## Observed live

Alert: `HelmRelease/harbor InstallFailed` → workload `tooling/harbor`.
The entry that explained it is filed on `tooling/harbor-registry` — the pod, where the fault **is**.

Both resources are correct. They are one step apart. `resourceAgrees` → `matchNone` → recall rejected (`no_resource_match`) → near-miss finds nothing → **the loop starts from zero.**

The codebase has been bitten by this class before. The pod-hash normalisation in `resourceAgrees` carries this comment:

> *"the recall is rejected (no_resource_match) and **a full paid investigation runs despite a perfect KB entry**"*

This is the same failure **one level up the ownership chain**.

## The fix

Adds `nearMissAgrees`: everything `resourceAgrees` admits, **plus same-namespace / different-workload**.

- The **namespace stays the boundary** — a hint from an unrelated namespace is noise, not a lead.
- `require_workload_match: true` still suppresses the new tier: an operator who asked for exact agreement does not silently get it.

## `resourceAgrees` is deliberately UNTOUCHED

Loosening it would be the tempting one-line fix — and it would loosen **instant recall**, which auto-applies runbooks. Two tests exist to fail if anyone tries:

- `TestInstantRecallStillRejectsDifferentWorkload` — every confidence gate wide open; only the *structural* gate may stop it
- `TestResourceAgreesUnchangedForDifferentWorkload`

## Tests

Mutation-checked **both ways**:

| mutation | caught by |
|---|---|
| revert `nearMiss` to the strict gate | `TestNearMissAdmitsSameNamespaceDifferentWorkload` |
| loosen `resourceAgrees` instead | both safety tests |

Plus `TestNearMissAgreesLadder` pins the predicate tier-by-tier. Full module suite + `go vet` clean.

## Relationship to the other PRs

- #316 — a verify-rejected recall must not *suppress* the near-miss (symmetry). Necessary, but on its own it surfaces nothing here, because this entry isn't a candidate at all.
- **This PR** makes the entry reachable as a *lead*.
- A third PR fixes the *write* side, so the entry is indexed under the resource the alert actually fires on — then it's reachable via the strict gate, which is better still.
