### PR TITLE
fix(recall): index entries by the resource the ALERT fired on, not only the fault locus

### DIFF
--- a/internal/catalog/entry.go
+++ b/internal/catalog/entry.go
@@ -6,13 +6,18 @@ package catalog
 
 // Entry is one OKF knowledge entry.
 type Entry struct {
-	Type        string   // frontmatter: type (Playbook, Incident, …)
-	Title       string   // frontmatter: title
-	Description string   // frontmatter: description
-	Resource    string   // frontmatter: resource
-	Tags        []string // frontmatter: tags
-	Timestamp   string   // frontmatter: timestamp (OKF-recommended, RFC3339; "" when absent)
-	Fingerprint string   // frontmatter: fingerprint (curator.DupFingerprint identity; "" on hand-written entries)
-	Body        string   // markdown body (after frontmatter)
-	Path        string   // file path relative to the bundle root
+	Type        string // frontmatter: type (Playbook, Incident, …)
+	Title       string // frontmatter: title
+	Description string // frontmatter: description
+	Resource    string // frontmatter: resource — the affected resource (where the fault was found)
+	// AlertResource is frontmatter: alert_resource — the resource the ORIGINATING ALERT
+	// fired on, when it differs from Resource. Empty on hand-written entries and on every
+	// entry curated before this field existed; the structural gate treats it as an
+	// ADDITIONAL way to agree, never a replacement, so those entries behave exactly as before.
+	AlertResource string
+	Tags          []string // frontmatter: tags
+	Timestamp     string   // frontmatter: timestamp (OKF-recommended, RFC3339; "" when absent)
+	Fingerprint   string   // frontmatter: fingerprint (curator.DupFingerprint identity; "" on hand-written entries)
+	Body          string   // markdown body (after frontmatter)
+	Path          string   // file path relative to the bundle root
 }

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -62,13 +62,14 @@ func parseEntry(root, path string) (Entry, error) {
 	}
 	fm, body := splitFrontmatter(data)
 	var meta struct {
-		Type        string   `yaml:"type"`
-		Title       string   `yaml:"title"`
-		Description string   `yaml:"description"`
-		Resource    string   `yaml:"resource"`
-		Tags        []string `yaml:"tags"`
-		Timestamp   string   `yaml:"timestamp"`
-		Fingerprint string   `yaml:"fingerprint"`
+		Type          string   `yaml:"type"`
+		Title         string   `yaml:"title"`
+		Description   string   `yaml:"description"`
+		Resource      string   `yaml:"resource"`
+		AlertResource string   `yaml:"alert_resource"`
+		Tags          []string `yaml:"tags"`
+		Timestamp     string   `yaml:"timestamp"`
+		Fingerprint   string   `yaml:"fingerprint"`
 	}
 	if len(fm) > 0 {
 		if err := yaml.Unmarshal(fm, &meta); err != nil {
@@ -78,7 +79,8 @@ func parseEntry(root, path string) (Entry, error) {
 	rel, _ := filepath.Rel(root, path)
 	return Entry{
 		Type: meta.Type, Title: meta.Title, Description: meta.Description,
-		Resource: meta.Resource, Tags: meta.Tags,
+		AlertResource: meta.AlertResource,
+		Resource:      meta.Resource, Tags: meta.Tags,
 		Timestamp: meta.Timestamp, Fingerprint: meta.Fingerprint,
 		Body: string(body), Path: rel,
 	}, nil

--- a/internal/curator/alert_resource_test.go
+++ b/internal/curator/alert_resource_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curator
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestDraftRecordsAlertResourceWhenDistinct is the write half of the fix.
+//
+// The alert fires on the HelmRelease tooling/harbor. The investigation correctly
+// refines that to the pod tooling/harbor-registry (preferDiscoveredResource lets the
+// discovered resource win) and the entry is filed under the pod. Without recording the
+// alert side, every later firing of that same alert arrives carrying tooling/harbor and
+// misses the entry it produced.
+func TestDraftRecordsAlertResourceWhenDistinct(t *testing.T) {
+	inv := providers.Investigation{
+		Title:         "Harbor Registry Down due to IAM Access Key Quota Limit",
+		Confidence:    0.95,
+		Resource:      providers.Workload{Namespace: "tooling", Name: "harbor-registry"}, // where the fault IS
+		AlertResource: providers.Workload{Namespace: "tooling", Name: "harbor"},          // where the ALERT fired
+		RootCauses:    []providers.Hypothesis{{Summary: "AccessKey hit AccessKeysPerUser: 2", Confidence: 0.95}},
+	}
+	e := draftKBEntry(inv)
+	if e.Resource != "tooling/harbor-registry" {
+		t.Fatalf("resource must stay the affected resource (the fault locus), got %q", e.Resource)
+	}
+	if e.AlertResource != "tooling/harbor" {
+		t.Fatalf("alert_resource must record the resource the ALERT fired on, got %q", e.AlertResource)
+	}
+}
+
+// TestDraftOmitsAlertResourceWhenSame proves it is not written as pure duplication: when
+// the investigation did not refine the alert's workload, there is nothing to add.
+func TestDraftOmitsAlertResourceWhenSame(t *testing.T) {
+	w := providers.Workload{Namespace: "tooling", Name: "harbor"}
+	e := draftKBEntry(providers.Investigation{
+		Title:         "Harbor HelmRelease InstallFailed",
+		Resource:      w,
+		AlertResource: w,
+		RootCauses:    []providers.Hypothesis{{Summary: "x", Confidence: 0.8}},
+	})
+	if e.AlertResource != "" {
+		t.Fatalf("alert_resource must be omitted when identical to resource, got %q", e.AlertResource)
+	}
+}
+
+// TestDraftOmitsAlertResourceWhenUnset covers non-alert sources (a GitOps failure, a
+// manual run) that carry no alert workload at all.
+func TestDraftOmitsAlertResourceWhenUnset(t *testing.T) {
+	e := draftKBEntry(providers.Investigation{
+		Title:      "Some GitOps failure",
+		Resource:   providers.Workload{Namespace: "flux-system", Name: "apps"},
+		RootCauses: []providers.Hypothesis{{Summary: "x", Confidence: 0.8}},
+	})
+	if e.AlertResource != "" {
+		t.Fatalf("alert_resource must be empty when the source carried no alert workload, got %q", e.AlertResource)
+	}
+}
+
+// TestDraftNormalizesAlertResourcePodHash proves the alert side gets the same CORE-681
+// pod-hash normalisation as resource: a pod-scoped alert arrives with the volatile
+// ReplicaSet suffix, which must never reach the frontmatter.
+func TestDraftNormalizesAlertResourcePodHash(t *testing.T) {
+	e := draftKBEntry(providers.Investigation{
+		Title:         "Registry down",
+		Resource:      providers.Workload{Namespace: "tooling", Name: "harbor"},
+		AlertResource: providers.Workload{Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"},
+		RootCauses:    []providers.Hypothesis{{Summary: "x", Confidence: 0.8}},
+	})
+	if e.AlertResource != "tooling/harbor-registry" {
+		t.Fatalf("alert_resource must be pod-hash normalised like resource, got %q", e.AlertResource)
+	}
+}

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -87,16 +87,40 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 		Title:       capTitle(inv.Title),
 		Description: firstLine(inv),
 		Resource:    normalizeResource(inv.Resource),
-		Tags:        entryTags(inv, typ),
-		Body:        b.String(),
-		Fingerprint: DupFingerprint(inv),
-		Confidence:  inv.Confidence,
-		Provenance:  refs,
+		// Only when the alert fired on a DIFFERENT resource than the one the
+		// investigation settled on. Equal values would be pure duplication; a
+		// difference is the whole point — it is the alert-side index that makes this
+		// entry reachable from the alert that produced it.
+		AlertResource: alertResourceIfDistinct(inv),
+		Tags:          entryTags(inv, typ),
+		Body:          b.String(),
+		Fingerprint:   DupFingerprint(inv),
+		Confidence:    inv.Confidence,
+		Provenance:    refs,
 		// Recurrence facts for the PR body's related-knowledge section — stamped
 		// on the Investigation BEFORE curation runs (see onInvestigationComplete).
 		Occurrences:    inv.Occurrences,
 		PrevCuratedURL: inv.PrevCuratedURL,
 	}
+}
+
+// alertResourceIfDistinct returns the normalized resource the ORIGINATING ALERT fired
+// on, or "" when it is the same as the affected resource (nothing to add) or unset.
+//
+// The investigation routinely refines the alert's workload to a deeper object:
+// preferDiscoveredResource lets a discovered resource win over the alert's. That is
+// right for the entry's human-facing "affected resource" — but recall matches an
+// INCOMING ALERT against the entry's resource, so an entry indexed only by the fault
+// locus is unreachable from the very alert that would surface it. Live: an alert on the
+// HelmRelease tooling/harbor, investigated down to the pod tooling/harbor-registry, was
+// filed under the pod — and every later firing of that same alert missed it
+// (no_resource_match) and paid for a full investigation instead.
+func alertResourceIfDistinct(inv providers.Investigation) string {
+	alert := normalizeResource(inv.AlertResource)
+	if alert == "" || alert == normalizeResource(inv.Resource) {
+		return ""
+	}
+	return alert
 }
 
 // normalizeResource renders the affected workload as its canonical namespace/name

--- a/internal/forge/github/alert_resource_roundtrip_test.go
+++ b/internal/forge/github/alert_resource_roundtrip_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestAlertResourceRoundTrips is the wire test: the two halves of this fix live in
+// different packages (curator writes, recall reads) and are unit-tested apart. If the
+// frontmatter key does not survive renderEntry → disk → catalog.Load, both halves pass
+// their own tests while the feature silently does nothing in production.
+func TestAlertResourceRoundTrips(t *testing.T) {
+	out := renderEntry(providers.KBEntry{
+		Type:          "Incident",
+		Title:         "Harbor Registry Down due to IAM Access Key Quota Limit",
+		Description:   "AccessKey/xplane-harbor hit AccessKeysPerUser: 2.",
+		Resource:      "tooling/harbor-registry",
+		AlertResource: "tooling/harbor",
+		Body:          "## Cause\nQuota.\n",
+	})
+	if !strings.Contains(out, "alert_resource: tooling/harbor") {
+		t.Fatalf("renderEntry must emit the alert_resource frontmatter key:\n%s", out)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "iam.md"), []byte(out), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, skipped, err := catalog.Load(dir)
+	if err != nil {
+		t.Fatalf("catalog.Load: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("entry was skipped by the loader: %v", skipped)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Resource != "tooling/harbor-registry" {
+		t.Fatalf("resource lost in round-trip: %q", e.Resource)
+	}
+	if e.AlertResource != "tooling/harbor" {
+		t.Fatalf("alert_resource lost in round-trip: %q — the curator writes it and recall reads it, "+
+			"but if it does not survive the file both halves pass their own tests while the fix does nothing", e.AlertResource)
+	}
+}
+
+// TestAlertResourceOmittedFromFrontmatterWhenEmpty proves the key is not written as a
+// dangling empty value on the overwhelming majority of entries (where the alert and the
+// fault are the same resource), which would churn every existing file for no reason.
+func TestAlertResourceOmittedFromFrontmatterWhenEmpty(t *testing.T) {
+	out := renderEntry(providers.KBEntry{
+		Type:     "Incident",
+		Title:    "Something",
+		Resource: "tooling/harbor",
+		Body:     "## Cause\nx\n",
+	})
+	if strings.Contains(out, "alert_resource") {
+		t.Fatalf("alert_resource must be omitted when empty (omitempty):\n%s", out)
+	}
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -412,13 +412,20 @@ func issueBody(inv providers.Investigation) string {
 // formatted) so a newline-bearing title/description from LLM output can't inject
 // extra frontmatter keys.
 type kbFrontmatter struct {
-	Type        string   `yaml:"type"`
-	Title       string   `yaml:"title"`
-	Description string   `yaml:"description"`
-	Resource    string   `yaml:"resource,omitempty"`
-	Tags        []string `yaml:"tags,omitempty"`
-	Timestamp   string   `yaml:"timestamp,omitempty"` // OKF-recommended; seed entries carry it, curated ones now do too
-	Fingerprint string   `yaml:"fingerprint,omitempty"`
+	Type        string `yaml:"type"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
+	Resource    string `yaml:"resource,omitempty"`
+	// alert_resource: the resource the ORIGINATING ALERT fired on, written only when it
+	// differs from resource (the fault locus). Recall matches an incoming alert against
+	// the entry's resource; an entry whose fault sits deeper than its alert — an alert
+	// on the HelmRelease tooling/harbor investigated down to the pod
+	// tooling/harbor-registry — is otherwise unreachable from the very alert that
+	// would surface it.
+	AlertResource string   `yaml:"alert_resource,omitempty"`
+	Tags          []string `yaml:"tags,omitempty"`
+	Timestamp     string   `yaml:"timestamp,omitempty"` // OKF-recommended; seed entries carry it, curated ones now do too
+	Fingerprint   string   `yaml:"fingerprint,omitempty"`
 	// Confidence + Provenance are OKF extension keys: frontmatter is for the
 	// fields you query/filter/index on, and these are exactly that (per-entry
 	// confidence floors, "what change caused this" lookups).
@@ -501,7 +508,8 @@ func renderEntry(e providers.KBEntry) string {
 	ts := time.Now().UTC().Format(time.RFC3339)
 	fm, _ := yaml.Marshal(kbFrontmatter{
 		Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource,
-		Tags: e.Tags, Timestamp: ts, Fingerprint: e.Fingerprint,
+		AlertResource: e.AlertResource,
+		Tags:          e.Tags, Timestamp: ts, Fingerprint: e.Fingerprint,
 		Confidence: e.Confidence, Provenance: e.Provenance,
 	})
 	var b strings.Builder

--- a/internal/investigate/alert_resource_stamp_test.go
+++ b/internal/investigate/alert_resource_stamp_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestLoopStampsAlertResourceFromRequest closes the wire between the Request and the
+// curated entry.
+//
+// The curator can only write alert_resource if the loop stamps it, and the curator's own
+// tests construct the Investigation by hand with the field already set — so nothing
+// exercised that hop. A mutation deleting `inv.AlertResource = req.Workload` from
+// stampRequestFacts passed the ENTIRE suite: both halves of the feature green, the wire
+// between them cut, and the fix silently doing nothing in production.
+func TestLoopStampsAlertResourceFromRequest(t *testing.T) {
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName,
+			Args: `{"confidence":0.8,"root_causes":[{"summary":"x","confidence":0.8}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	req := Request{
+		Title:       "HelmRelease/harbor InstallFailed",
+		Fingerprint: "fp-stamp",
+		Workload:    providers.Workload{Namespace: "tooling", Name: "harbor"},
+		Labels:      map[string]string{"alertname": "HelmReleaseInstallFailed"},
+	}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil {
+		t.Fatal("OnComplete not called")
+	}
+	if ref := got.AlertResource.Ref(); ref != "tooling/harbor" {
+		t.Fatalf("the loop must stamp AlertResource verbatim from the REQUEST (a trigger-time fact, "+
+			"like AlertName/Severity); got %q", ref)
+	}
+}
+
+// TestAlertResourceSurvivesResourceRefinement is the whole point of the field.
+//
+// preferDiscoveredResource lets a resource the investigation DISCOVERS win over the
+// alert's — that is right for the entry's human-facing "affected resource". But the
+// alert side must survive that overwrite untouched, or the entry is filed only under the
+// fault locus and becomes unreachable from the alert that produced it.
+func TestAlertResourceSurvivesResourceRefinement(t *testing.T) {
+	// The model names a DEEPER resource than the alert did: the pod, not the HelmRelease.
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName,
+			Args: `{"confidence":0.9,"resource":{"kind":"Pod","namespace":"tooling","name":"harbor-registry"},"root_causes":[{"summary":"IAM AccessKey quota","confidence":0.9}]}`}}},
+	}}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		OnComplete: func(inv providers.Investigation) { got = &inv },
+	}
+	req := Request{
+		Title:       "HelmRelease/harbor InstallFailed",
+		Fingerprint: "fp-refine",
+		Workload:    providers.Workload{Namespace: "tooling", Name: "harbor"},
+		Labels:      map[string]string{"alertname": "HelmReleaseInstallFailed"},
+	}
+	if err := li.Investigate(context.Background(), req); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got == nil {
+		t.Fatal("OnComplete not called")
+	}
+	// The alert side must be preserved regardless of how the investigation refined the
+	// affected resource — that is the index recall will arrive on next time.
+	if ref := got.AlertResource.Ref(); ref != "tooling/harbor" {
+		t.Fatalf("AlertResource must survive resource refinement (it is the index the NEXT alert arrives on); got %q", ref)
+	}
+}

--- a/internal/investigate/alert_resource_test.go
+++ b/internal/investigate/alert_resource_test.go
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// The live Harbor incident.
+//
+// The alert fires on the HelmRelease `tooling/harbor`. The investigation correctly
+// refines that to the pod `tooling/harbor-registry`, where the fault actually is, and
+// the entry is filed under the pod. Every LATER firing of that same alert then arrives
+// carrying `tooling/harbor` — and misses the entry it produced (no_resource_match),
+// paying for a full investigation beside a catalog that holds the answer.
+//
+// alert_resource is the alert-side index that closes the loop.
+func harborEntryFiledUnderThePod(alertResource string) catalog.Entry {
+	return catalog.Entry{
+		Title:         "Harbor Registry Down due to IAM Access Key Quota Limit",
+		Path:          "iam.md",
+		Resource:      "tooling/harbor-registry", // where the fault IS
+		AlertResource: alertResource,             // where the ALERT fired
+		Body:          "## Cause\nAccessKey/xplane-harbor hit AccessKeysPerUser: 2.\n\n## Resolution\nDelete an unused IAM access key.\n",
+	}
+}
+
+func harborAlertReq() Request {
+	return Request{
+		Title:       "HelmRelease/harbor InstallFailed",
+		Fingerprint: "fp-ar",
+		Workload:    providers.Workload{Namespace: "tooling", Name: "harbor"},
+		Labels:      map[string]string{"alertname": "HelmReleaseInstallFailed"},
+	}
+}
+
+// TestRecallReachesEntryViaAlertResource is the regression test: with alert_resource
+// recorded, the alert that PRODUCED the entry can now recall it.
+func TestRecallReachesEntryViaAlertResource(t *testing.T) {
+	r := &Recall{
+		MinScore: 1.0, MarginGap: 0.5, SoloFloor: 1.0,
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{{
+			Entry: harborEntryFiledUnderThePod("tooling/harbor"),
+			Score: 9.0,
+		}}},
+	}
+	entry, _ := r.lookup(context.Background(), harborAlertReq())
+	if entry == nil {
+		t.Fatal("an entry carrying alert_resource: tooling/harbor must be reachable from an alert on tooling/harbor, " +
+			"even though its affected resource is the deeper tooling/harbor-registry")
+	}
+	if entry.Path != "iam.md" {
+		t.Fatalf("wrong entry: %s", entry.Path)
+	}
+}
+
+// TestRecallMissesEntryWithoutAlertResource pins the BUG this fixes — the same entry,
+// with the field absent (every entry curated before this change), stays unreachable.
+// If this ever starts passing, the structural gate has been loosened somewhere else and
+// the fix is no longer doing the work.
+func TestRecallMissesEntryWithoutAlertResource(t *testing.T) {
+	r := &Recall{
+		MinScore: 0.1, MarginGap: 0.0, SoloFloor: 0.1, // wide open: only the STRUCTURAL gate can stop it
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{{
+			Entry: harborEntryFiledUnderThePod(""), // pre-existing entry: no alert_resource
+			Score: 9.0,
+		}}},
+	}
+	if entry, _ := r.lookup(context.Background(), harborAlertReq()); entry != nil {
+		t.Fatalf("without alert_resource the entry must remain structurally unreachable from tooling/harbor (got %s) — "+
+			"this is the bug alert_resource exists to fix, and the old behaviour must be preserved for entries that lack it", entry.Path)
+	}
+}
+
+// TestAlertResourceIsAdditiveNotAReplacement proves the entry stays reachable from its
+// OWN resource too. Indexing by the alert must not cost us the fault-locus index: an
+// alert firing directly on the pod (KubePodNotReady) must still hit the same entry.
+func TestAlertResourceIsAdditiveNotAReplacement(t *testing.T) {
+	r := &Recall{
+		MinScore: 1.0, MarginGap: 0.5, SoloFloor: 1.0,
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{{
+			Entry: harborEntryFiledUnderThePod("tooling/harbor"),
+			Score: 9.0,
+		}}},
+	}
+	podAlert := Request{
+		Title:       "KubePodNotReady",
+		Fingerprint: "fp-pod",
+		Workload:    providers.Workload{Namespace: "tooling", Name: "harbor-registry-59598dbd57-ltkzw"},
+		Labels:      map[string]string{"alertname": "KubePodNotReady"},
+	}
+	entry, _ := r.lookup(context.Background(), podAlert)
+	if entry == nil {
+		t.Fatal("alert_resource must be ADDITIVE: the entry must still be reachable from its own affected resource " +
+			"(pod-hash normalised), not only from the alert resource")
+	}
+}
+
+// TestEntryAgreesKeepsTheStrongerTier pins the predicate: when both resources agree at
+// different strengths, the stronger wins — a weaker alert-side match must never dilute
+// a stronger fault-side one (the tier feeds the confidence gate).
+func TestEntryAgreesKeepsTheStrongerTier(t *testing.T) {
+	w := providers.Workload{Namespace: "tooling", Name: "harbor-registry"}
+	e := catalog.Entry{
+		Resource:      "tooling/harbor-registry", // exact
+		AlertResource: "tooling",                 // bare namespace → weaker
+	}
+	if got := entryAgrees(w, e, false); got != matchExact {
+		t.Fatalf("entryAgrees must keep the STRONGER tier (exact), got %v", got)
+	}
+}
+
+// TestEntryAgreesUnchangedWhenNoAlertResource proves the predicate is a strict superset:
+// with AlertResource empty it must be byte-identical to resourceAgrees.
+func TestEntryAgreesUnchangedWhenNoAlertResource(t *testing.T) {
+	w := providers.Workload{Namespace: "tooling", Name: "harbor"}
+	for _, res := range []string{"tooling/harbor", "tooling", "tooling/harbor-registry", "observability/vmagent", ""} {
+		e := catalog.Entry{Resource: res}
+		if got, want := entryAgrees(w, e, false), resourceAgrees(w, res, false); got != want {
+			t.Fatalf("entryAgrees(resource=%q, no alert_resource) = %v, want resourceAgrees = %v", res, got, want)
+		}
+	}
+}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -1083,6 +1083,11 @@ func stampRequestFacts(inv *providers.Investigation, req Request) {
 	inv.Cluster = req.Labels["cluster"]
 	inv.Tenant = req.Labels["tenant"]
 	inv.AlertName = req.Labels["alertname"]
+	// The workload the ALERT fired on. Distinct from inv.Resource, which the loop
+	// overwrites with whatever deeper object the investigation discovered
+	// (preferDiscoveredResource). Recall reads by alert resource, so losing this is
+	// what makes a correctly-investigated entry unrecallable from its own alert.
+	inv.AlertResource = req.Workload
 	inv.StartedAt = req.At
 }
 

--- a/internal/investigate/realkb_alert_resource_test.go
+++ b/internal/investigate/realkb_alert_resource_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Replayed against the REAL catalog, not a fixture.
+//
+// testdata/realkb holds the two Harbor entries copied verbatim off a running RunLore's
+// catalog PVC — real frontmatter, real bodies, written by RunLore itself.
+//
+// Production, 2026-07-13: alert HelmRelease/harbor InstallFailed (workload
+// tooling/harbor). The catalog held the entry that explained it —
+// harbor-registry-down-due-to-iam-access-key-quota-limit.md — but filed under
+// `resource: tooling/harbor-registry`, where the fault IS. The structural gate compares
+// against the resource the ALERT carries, so the entry was not even a candidate
+// (no_resource_match) and a full paid investigation ran beside the answer.
+func TestRealKBAlertResourceMakesTheEntryACandidate(t *testing.T) {
+	const (
+		dirReal = "testdata/realkb"
+		iamFile = "harbor-registry-down-due-to-iam-access-key-quota-limit.md"
+		capFile = "harbor-helmrelease-terminal-failed.md"
+	)
+	alert := providers.Workload{Namespace: "tooling", Name: "harbor"}
+
+	src, err := os.ReadFile(filepath.Join(dirReal, iamFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// BEFORE: the real entry, exactly as RunLore wrote it. Unreachable.
+	before, _, err := catalog.Load(dirReal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range before {
+		if !strings.Contains(e.Path, "iam-access-key-quota") {
+			continue
+		}
+		if e.AlertResource != "" {
+			t.Fatalf("the real entry should carry no alert_resource yet, got %q", e.AlertResource)
+		}
+		if got := entryAgrees(alert, e, false); got != matchNone {
+			t.Fatalf("the real entry must be structurally unreachable from tooling/harbor without alert_resource "+
+				"(that is the bug); got %v", got)
+		}
+	}
+
+	// AFTER: with the alert-side index the curator now writes.
+	patched := strings.Replace(string(src),
+		"resource: tooling/harbor-registry",
+		"resource: tooling/harbor-registry\nalert_resource: tooling/harbor", 1)
+	if patched == string(src) {
+		t.Fatal("failed to patch the real entry's frontmatter")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, iamFile), []byte(patched), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	capBody, err := os.ReadFile(filepath.Join(dirReal, capFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, capFile), capBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, skipped, err := catalog.Load(dir)
+	if err != nil {
+		t.Fatalf("catalog.Load: %v", err)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("loader skipped an entry: %v — alert_resource must not break parsing of a real entry", skipped)
+	}
+	var iam catalog.Entry
+	for _, e := range entries {
+		if strings.Contains(e.Path, "iam-access-key-quota") {
+			iam = e
+		}
+	}
+	if iam.AlertResource != "tooling/harbor" {
+		t.Fatalf("alert_resource did not parse off the real entry: %q", iam.AlertResource)
+	}
+	if got := entryAgrees(alert, iam, false); got == matchNone {
+		t.Fatal("with alert_resource recorded, the real IAM entry must become a recall CANDIDATE for the real alert — " +
+			"this is what stops the next firing paying for a full investigation beside the answer")
+	}
+}

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -155,7 +155,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 	// entries score higher on symptom tokens.
 	var agreeing []catalog.ScoredEntry
 	for _, h := range hits {
-		if resourceAgrees(req.Workload, h.Entry.Resource, r.RequireWorkloadMatch) != matchNone {
+		if entryAgrees(req.Workload, h.Entry, r.RequireWorkloadMatch) != matchNone {
 			agreeing = append(agreeing, h)
 		}
 	}
@@ -213,7 +213,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 		// Gate — margin among the structurally-agreeing candidates: a clear winner for
 		// this workload, not merely the top lexical hit. A lone agreeing hit must clear
 		// both the solo floor and the min score.
-		strength := resourceAgrees(req.Workload, winner.Entry.Resource, r.RequireWorkloadMatch)
+		strength := entryAgrees(req.Workload, winner.Entry, r.RequireWorkloadMatch)
 		margin = score
 		confident := score >= soloFloor && score >= minScore
 		if len(agreeing) > 1 {
@@ -297,7 +297,7 @@ func (r *Recall) nearMissExcluding(ctx context.Context, req Request, exclude str
 		if exclude != "" && h.Entry.Path == exclude {
 			continue
 		}
-		if nearMissAgrees(req.Workload, h.Entry.Resource, r.RequireWorkloadMatch) != matchNone {
+		if nearMissEntryAgrees(req.Workload, h.Entry, r.RequireWorkloadMatch) != matchNone {
 			e := h.Entry
 			return &e
 		}
@@ -328,6 +328,20 @@ func (r *Recall) nearMissExcluding(ctx context.Context, req Request, exclude str
 //
 // requireWorkload is an explicit operator demand for exact agreement; it is honoured
 // here too, so an operator who has asked for strictness does not silently get this tier.
+// nearMissEntryAgrees is where the three recall fixes compose: a near-miss is judged by
+// the LOOSE gate (nearMissAgrees — it is a lead, not an answer) applied to BOTH resources
+// an entry carries (the fault locus, and the resource the originating alert fired on).
+// The stronger tier wins.
+func nearMissEntryAgrees(reqW providers.Workload, e catalog.Entry, requireWorkload bool) matchStrength {
+	best := nearMissAgrees(reqW, e.Resource, requireWorkload)
+	if e.AlertResource != "" {
+		if s := nearMissAgrees(reqW, e.AlertResource, requireWorkload); s > best {
+			best = s
+		}
+	}
+	return best
+}
+
 func nearMissAgrees(reqW providers.Workload, entryResource string, requireWorkload bool) matchStrength {
 	if s := resourceAgrees(reqW, entryResource, requireWorkload); s != matchNone {
 		return s
@@ -367,6 +381,28 @@ const (
 	matchNamespace
 	matchExact
 )
+
+// entryAgrees reports how strongly an alert's workload agrees with an ENTRY, matching
+// on EITHER resource the entry carries and keeping the stronger tier:
+//
+//   - Resource      — where the fault was FOUND (the investigation's conclusion)
+//   - AlertResource — where the ALERT that produced the entry FIRED (when different)
+//
+// Recall arrives with an alert's workload and nothing else. An entry indexed only by
+// its fault locus is therefore unreachable from the alert that would surface it, even
+// though that alert is exactly what produced it. Matching on either closes the loop
+// without weakening anything: AlertResource is an ADDITIONAL way to agree, never a
+// replacement, so hand-written entries and every entry curated before this field
+// existed (AlertResource == "") behave precisely as they did.
+func entryAgrees(reqW providers.Workload, e catalog.Entry, requireWorkload bool) matchStrength {
+	best := resourceAgrees(reqW, e.Resource, requireWorkload)
+	if e.AlertResource != "" {
+		if s := resourceAgrees(reqW, e.AlertResource, requireWorkload); s > best {
+			best = s
+		}
+	}
+	return best
+}
 
 // resourceAgrees reports how strongly the alert's workload agrees with an entry's
 // stored resource. requireWorkload demands an exact namespace+name match — which

--- a/internal/investigate/testdata/realkb/harbor-helmrelease-terminal-failed.md
+++ b/internal/investigate/testdata/realkb/harbor-helmrelease-terminal-failed.md
@@ -1,0 +1,57 @@
+---
+type: Incident
+title: Harbor HelmRelease stuck InstallFailed after a cluster capacity shortage
+description: Harbor never finished installing; its HelmRelease is terminal-failed (timeout waiting for Deployments/StatefulSets) because the cluster could not schedule the pods in time, and Flux exhausted its install retries.
+resource: tooling/harbor
+tags:
+    - runlore
+    - incident
+    - flux
+    - helmrelease
+    - harbor
+    - capacity
+    - karpenter
+---
+
+## Symptom
+
+The `tooling/harbor` HelmRelease is `Ready=False / InstallFailed` and never recovers on its own. This
+is an instance of [[helmrelease-terminal-failed-exhausted-retries]], triggered by the cluster-wide
+capacity shortage in [[karpenter-ec2nodeclass-ami-not-found]] — not by any application change.
+
+## Cause
+
+Confidence: high (verified against live state).
+
+1. **The Harbor install timed out while the cluster had no schedulable capacity, then Flux exhausted
+   its retries and left the HelmRelease terminal-failed.**
+   - evidence: `kubectl -n tooling get hr harbor` → `InstallFailed: timeout waiting for: [Deployment/harbor-nginx, harbor-registry, harbor-core, harbor-portal, harbor-jobservice, StatefulSet/harbor-trivy ... 'InProgress']`.
+   - evidence: `helm -n tooling history harbor` → a single revision, `status: failed`, timestamped in the cluster's capacity-shortage window (Karpenter could not provision nodes, so the pods sat Pending past the Helm wait).
+   - evidence: `harbor-core` shows ~37 restarts — it crash-looped waiting on its dependencies (harbor DB / valkey) which were themselves Pending during the shortage.
+   - **Not** caused by the `crds-actions-runner-controller` change an earlier automated pass guessed: that was correlation (a recent cluster change) with no read diff and no causal link to Harbor — rejected on review.
+
+## Resolution
+
+The capacity root is already fixed (Karpenter EC2NodeClass AMI corrected — see
+[[karpenter-ec2nodeclass-ami-not-found]]). With nodes available, clear the terminal HelmRelease so
+Flux re-installs cleanly:
+
+```
+# only the failed release exists (no good revision to roll back to)
+helm -n tooling uninstall harbor          # StatefulSet PVCs persist
+flux -n tooling reconcile helmrelease harbor --reset   # clears exhausted retry counters → fresh install
+```
+
+`--reset` is the key step: without it Flux refuses to retry ("exceeded maximum retries: cannot
+install release") even though capacity is now available. Verify with `kubectl -n tooling get hr harbor`
+→ `Ready=True` and the harbor Deployments/StatefulSet becoming Ready.
+
+> This is a shared, multi-component production release — run the uninstall/reset deliberately
+> (human-approved), not as part of a blind bulk sweep.
+
+## Prevention
+
+- Raise `spec.install.timeout` for large multi-component charts so transient scheduling delays don't
+  burn all retries.
+- Keep autoscaling healthy: a single capacity root (a broken Karpenter NodeClass) knocks out many
+  HelmReleases at once via simultaneous install timeouts.

--- a/internal/investigate/testdata/realkb/harbor-registry-down-due-to-iam-access-key-quota-limit.md
+++ b/internal/investigate/testdata/realkb/harbor-registry-down-due-to-iam-access-key-quota-limit.md
@@ -1,0 +1,41 @@
+---
+type: Incident
+title: Harbor Registry Down due to IAM Access Key Quota Limit
+description: 'The Crossplane resource `AccessKey/xplane-harbor` has hit an AWS IAM quota limit (`AccessKeysPerUser: 2`), preventing it from creating the credentials required by the Harbor registry.'
+resource: tooling/harbor-registry
+tags:
+    - runlore
+    - incident
+timestamp: "2026-06-28T13:07:56Z"
+fingerprint: 2d6bd8279304b3e17a5d5e35a55fb0c115ffbeabde820af8cdd2494a4141a60b
+---
+
+## Decision
+
+- **why keep:** The Crossplane resource `AccessKey/xplane-harbor` has hit an AWS IAM quota limit (`AccessKeysPerUser: 2`), preventing it from creating the credentials required by the Harbor registry.
+- **confidence:** 95%
+
+## Symptom
+
+Harbor Registry Down due to IAM Access Key Quota Limit
+
+## Investigate
+
+- pod_status shows harbor-registry pod failing with 'CreateContainerConfigError: couldn\'t find key username in Secret tooling/xplane-harbor-access-key'
+- kube_events for the 'tooling' namespace shows a persistent Warning on the 'AccessKey/xplane-harbor' resource: 'LimitExceeded: Cannot exceed quota for AccessKeysPerUser: 2'
+- The failed Crossplane 'AccessKey' resource is responsible for creating the Secret used by the 'harbor-registry' pod.
+- The knowledge base article 'HarborRegistryDown' describes this exact failure scenario.
+
+## Cause
+
+1. **The Crossplane resource `AccessKey/xplane-harbor` has hit an AWS IAM quota limit (`AccessKeysPerUser: 2`), preventing it from creating the credentials required by the Harbor registry.** (95%)
+
+## Resolution
+
+- An administrator with AWS access should navigate to the IAM user associated with the Crossplane provider and delete an old or unused access key. This will allow Crossplane to create the new key required by Harbor. After the key is deleted, the `AccessKey/xplane-harbor` resource should be reconciled. (reversible=false)
+
+## Unresolved
+
+- The name of the specific IAM user that has reached its access key quota. This needs to be identified in the AWS console.
+- Which of the two existing access keys is safe to delete.
+

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -637,6 +637,14 @@ type Investigation struct {
 	Confidence float64
 	Recalled   bool     // true when produced by instant recall (a KB cache hit); the curator skips re-curating it
 	Resource   Workload // the workload the investigation identified as affected; defaults to the originating alert workload when none was named (stored on curated entries for structural recall)
+	// AlertResource is the workload the ORIGINATING ALERT fired on, stamped verbatim
+	// from the Request and never touched by the model. It is NOT Resource: Resource is
+	// where the fault was FOUND, which the investigation routinely refines to a deeper
+	// object (an alert on the HelmRelease tooling/harbor resolving to the pod
+	// tooling/harbor-registry). Recall, however, matches by the resource an ALERT
+	// carries — so an entry indexed only by the fault locus is unreachable from the
+	// alert that would surface it. Persisting both is what closes that gap.
+	AlertResource Workload
 	// Trigger-time facts stamped verbatim from the Request for the notification's
 	// metadata block. The model never sees or sets them; empty for sources that lack them.
 	Severity    string    // alert severity label at trigger time
@@ -740,11 +748,15 @@ type KBEntry struct {
 	Title       string
 	Description string
 	Resource    string
-	Tags        []string
-	Body        string   // markdown
-	Fingerprint string   // deterministic dedup fingerprint (see curator.DupFingerprint)
-	Confidence  float64  // overall investigation confidence; queryable extension frontmatter (0 = unset)
-	Provenance  []string // distinct causing-change refs; queryable extension frontmatter
+	// AlertResource is the resource the originating ALERT fired on, when it differs
+	// from Resource (the fault locus). Recall matches by alert resource; without this
+	// an entry whose fault sits deeper than its alert is permanently unrecallable.
+	AlertResource string
+	Tags          []string
+	Body          string   // markdown
+	Fingerprint   string   // deterministic dedup fingerprint (see curator.DupFingerprint)
+	Confidence    float64  // overall investigation confidence; queryable extension frontmatter (0 = unset)
+	Provenance    []string // distinct causing-change refs; queryable extension frontmatter
 	// Reviewer context, rendered in the PR BODY only — never in the committed
 	// entry file (renderEntry ignores these), so the catalog and validator are
 	// untouched. Related is the draft-time BM25 neighborhood; the recurrence


### PR DESCRIPTION
## The bug

An entry is filed under **where the fault was**. Recall arrives with **where the alert fired**. When the investigation refines one into the other — which is its *job* — the entry becomes **permanently unreachable from the very alert that produced it**.

```
alert HelmRelease/harbor InstallFailed   → workload  tooling/harbor
investigation refines to the pod         → resource: tooling/harbor-registry
entry filed under the pod
next firing of that same alert           → no_resource_match → full paid investigation
```

**Observed live**, on an entry whose diagnosis was exactly right. RunLore wrote the answer down and then could not find it.

The loop lets a *discovered* resource win over the alert's (`preferDiscoveredResource`) — right for the entry's human-facing "affected resource". But the alert's workload is then **dropped**: `Investigation` carries trigger-time facts stamped verbatim from the Request (`AlertName`, `Severity`, `Cluster`, `Tenant`, `StartedAt`) and the alert's **workload is not among them**. The structural gate matches an incoming alert against `entry.resource`.

This is the same failure class as the pod-hash normalisation already in `resourceAgrees` —

> *"the recall is rejected (no_resource_match) and a full paid investigation runs despite a perfect KB entry"*

— **one level up the ownership chain**. Normalisation cannot fix it: these are genuinely different objects, both correctly named.

## The fix

Adds `alert_resource`: the resource the **originating alert** fired on, written only when it differs from `resource`.

- `providers.Investigation.AlertResource` — a **trigger-time fact**, stamped verbatim from the Request beside `AlertName`/`Severity`. The model never sees or sets it, and `preferDiscoveredResource` cannot touch it.
- The curator writes it **only when distinct** (equal values are duplication), with the same CORE-681 pod-hash normalisation as `resource`.
- `entryAgrees` matches on **either** resource and keeps the **stronger** tier.

## Strictly additive

`AlertResource` is another way to **agree**, never a replacement. Hand-written entries and every entry curated before this field existed (`AlertResource == ""`) behave **exactly** as they did — pinned by `TestEntryAgreesUnchangedWhenNoAlertResource`.

## Tests — and a hole mutation testing found

Mutation-checked at all three hops:

| mutation | caught by |
|---|---|
| gate ignores `AlertResource` | `TestRecallReachesEntryViaAlertResource` |
| curator stops writing it | `TestDraftRecordsAlertResourceWhenDistinct` |
| loop stops stamping it | `TestLoopStampsAlertResourceFromRequest` |

**That last mutation initially passed everything.** The curator tests build the `Investigation` by hand with the field pre-set, so nothing exercised the Request → Investigation hop: both halves green, the wire between them cut, the feature silently doing nothing. `TestLoopStampsAlertResourceFromRequest` and `TestAlertResourceSurvivesResourceRefinement` close it.

`TestAlertResourceRoundTrips` covers the other silent-nothing failure — the write and read halves live in **different packages**, so the frontmatter key is proven to survive `renderEntry → disk → catalog.Load` rather than being asserted twice in isolation.

Full module suite (46 pkgs) + `go vet` clean.

## Relationship to the other PRs

- #316 — a verify-rejected recall must not *suppress* the near-miss (symmetry fix)
- #317 — the near-miss gate must be looser than the instant-recall gate (makes such an entry reachable as a *lead*)
- **This PR** — makes it reachable via the **strict** gate, which is better: it can be recalled as an *answer*, not just hinted at.

They are independent and complementary. This one is the root cause; #316/#317 are the safety net for entries already written (there will always be some, including every hand-written one).
