### PR TITLE
fix(coalesce): a standing 👎 bypasses the cooldown, and suppression is logged

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -148,7 +148,8 @@ config:
       # debounce: 30s           # flush batch quiet for this long
       # max_wait: 2m            # force flush even if still receiving alerts
       # max_batch: 50           # flush when batch reaches this size
-      # cooldown: 10m           # suppress re-alerts for a group after a flush
+      # cooldown: 10m           # suppress re-alerts for a group after a flush (a new critical
+      #                         #   alertname or a standing 👎 on the trigger bypasses suppression)
       # correlation_labels: []  # group by label values instead of AM groupKey
     rate_limit:
       max_per_window: 20        # cap investigations per window (window defaults to 1h); 0 = unlimited

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,8 +101,15 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   60s**; explicit `0` fires immediately on every `Ready=False`.
 
 ### `investigation` — loop bounds & noise control
-- `coalesce` — fold an alert storm into one investigation. Defaults when enabled: `debounce` **30s**,
-  `max_wait` **2m**, `max_batch` **50**, `cooldown` **10m**; `correlation_labels` group related alerts.
+- `coalesce` — fold an alert storm into one investigation. **Code default: disabled**; the **chart
+  ships `enabled: true`** (see `deploy/helm/runlore/values.yaml`) — same chart-vs-code split as
+  `incidents.dedup.window`. Defaults when enabled: `debounce` **30s**, `max_wait` **2m**, `max_batch`
+  **50**, `cooldown` **10m**; `correlation_labels` group related alerts. The `cooldown` suppresses
+  same-key re-fires after a flush, with two escape hatches: a **critical alert with an alertname not
+  yet seen** for the key flushes anyway (a new problem, not storm noise), and a **standing 👎 on the
+  trigger bypasses suppression** so the feedback re-arm (see `recurrence_cooldown` below) is never
+  silently deferred by this outer layer. Each suppression logs an INFO line
+  (`coalesce cooldown: suppressing alert`) and counts in `runlore_alerts_suppressed_total`.
 - `rate_limit` — `max_per_window` (**0 = unlimited**), `window` (default **1h** when a budget is set),
   `max_requeues`.
 - `recurrence_cooldown` — **opt-in (default 0 = off)** per-trigger suppression: skip re-investigating a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,12 +104,11 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
 - `coalesce` — fold an alert storm into one investigation. **Code default: disabled**; the **chart
   ships `enabled: true`** (see `deploy/helm/runlore/values.yaml`) — same chart-vs-code split as
   `incidents.dedup.window`. Defaults when enabled: `debounce` **30s**, `max_wait` **2m**, `max_batch`
-  **50**, `cooldown` **10m**; `correlation_labels` group related alerts. The `cooldown` suppresses
-  same-key re-fires after a flush, with two escape hatches: a **critical alert with an alertname not
-  yet seen** for the key flushes anyway (a new problem, not storm noise), and a **standing 👎 on the
-  trigger bypasses suppression** so the feedback re-arm (see `recurrence_cooldown` below) is never
-  silently deferred by this outer layer. Each suppression logs an INFO line
-  (`coalesce cooldown: suppressing alert`) and counts in `runlore_alerts_suppressed_total`.
+  **50**, `cooldown` **10m**; `correlation_labels` group related alerts. Two escape hatches open the
+  `cooldown`: an unseen critical alertname (a new problem — flushes immediately) and a **standing 👎
+  on the trigger** (the feedback re-arm, see [learning-loop](learning-loop.md) — batched on the
+  normal `debounce`, so a contested storm still collapses to one re-investigation). Suppressions log
+  an INFO line and count in `runlore_alerts_suppressed_total`.
 - `rate_limit` — `max_per_window` (**0 = unlimited**), `window` (default **1h** when a budget is set),
   `max_requeues`.
 - `recurrence_cooldown` — **opt-in (default 0 = off)** per-trigger suppression: skip re-investigating a

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -463,6 +463,18 @@ feedback does two jobs: it weighs *recalled knowledge* (the decay above) and it
 governs *when the agent may repeat itself* — both steered by the same single
 human 👍/👎 signal.
 
+The re-arm holds across the outer noise-control layers too — with one boundary.
+The **coalescer's cooldown** (`investigation.coalesce.cooldown`, 10m default when
+enabled) consults the same standing-👎 signal and lets a contested trigger through
+instead of absorbing it as storm noise, so the layers cannot silently defer the
+re-arm. **Fingerprint dedup** (`triggers.incidents.dedup.window`) is the exception:
+it keys on the Alertmanager fingerprint before feedback is ever consulted, so a
+*still-firing* alert re-sent with the same fingerprint inside the dedup window is
+dropped regardless of a standing 👎. Precisely: a 👎 re-arms investigation at the
+next occurrence that clears fingerprint dedup — a re-fire with a fresh fingerprint
+(changed label set) immediately, a same-fingerprint repeat once the dedup window
+(code default **0** = off; chart ships **30m**) has lapsed.
+
 ---
 
 ## 7. Compound — merged knowledge becomes everyone's, fast

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -467,7 +467,9 @@ The re-arm holds across the outer noise-control layers too — with one boundary
 The **coalescer's cooldown** (`investigation.coalesce.cooldown`, 10m default when
 enabled) consults the same standing-👎 signal and lets a contested trigger through
 instead of absorbing it as storm noise, so the layers cannot silently defer the
-re-arm. **Fingerprint dedup** (`triggers.incidents.dedup.window`) is the exception:
+re-arm. A contested re-fire takes the coalescer's normal batching path (flushed
+after `debounce`, not one flush per alert), so a contested *storm* still collapses
+to a single re-investigation. **Fingerprint dedup** (`triggers.incidents.dedup.window`) is the exception:
 it keys on the Alertmanager fingerprint before feedback is ever consulted, so a
 *still-firing* alert re-sent with the same fingerprint inside the dedup window is
 dropped regardless of a standing 👎. Precisely: a 👎 re-arms investigation at the

--- a/hack/e2e-local.sh
+++ b/hack/e2e-local.sh
@@ -155,6 +155,45 @@ check() { # check <desc> <logfile> <pattern>
   if grep -qE "$3" "$2"; then green "PASS: $1"; PASS=$((PASS+1)); else red "FAIL: $1 (pattern: $3)"; FAIL=$((FAIL+1)); fi
 }
 
+# webhook_post posts an Alertmanager payload through a port-forward and prints
+# the HTTP status, labelled so interleaved step output stays attributable.
+webhook_post() { # webhook_post <label> <port> <json-payload>
+  curl -s -o /dev/null -w "$1 webhook HTTP %{http_code}\n" \
+    -XPOST "http://localhost:$2/webhook/alertmanager" \
+    -H "Authorization: Bearer e2e-webhook" -H "Content-Type: application/json" \
+    -d "$3" || true
+}
+
+# scrape_metric prints the integer value of a runlore_-prefixed metric from the
+# OTel /metrics exposition. Capture-then-awk (never curl|awk directly): awk's
+# early exit would SIGPIPE-kill curl (exit 23), which pipefail+set-e turn into a
+# spurious abort when the matched metric lands early in the output. The prefix
+# match tolerates the _total / _total_total suffix variants of the exporter.
+scrape_metric() { # scrape_metric <port> <metric-name-without-runlore_>
+  local b; b=$(curl -sf "http://localhost:$1/metrics" 2>/dev/null || true)
+  echo "$b" | awk -v p="^runlore_$2" '$0 ~ p {print int($NF); exit}'
+}
+
+# slack_interact posts a signed Slack block-action interaction (HMAC over
+# v0:ts:body with the chart-installed e2e-slack-secret) as user U_E2E.
+slack_interact() { # slack_interact <port> <action_id> <value>
+  python3 - "$1" "$2" "$3" <<'PY'
+import sys, hmac, hashlib, time, json, urllib.parse, urllib.request
+port, action_id, value = sys.argv[1], sys.argv[2], sys.argv[3]
+payload = json.dumps({"user": {"id": "U_E2E", "username": "e2e"},
+                      "actions": [{"action_id": action_id, "value": value}]})
+body = "payload=" + urllib.parse.quote(payload)
+ts = str(int(time.time()))
+sig = "v0=" + hmac.new(b"e2e-slack-secret", f"v0:{ts}:{body}".encode(), hashlib.sha256).hexdigest()
+req = urllib.request.Request(f"http://localhost:{port}/slack/interactions", data=body.encode(),
+    headers={"X-Slack-Request-Timestamp": ts, "X-Slack-Signature": sig, "Content-Type": "application/x-www-form-urlencoded"})
+try:
+    print("slack interaction HTTP", urllib.request.urlopen(req).status)
+except Exception as e:
+    print("slack interaction error:", e)
+PY
+}
+
 step "1/8 create $PROVIDER cluster"
 provider_delete_cluster
 provider_create_cluster
@@ -312,13 +351,7 @@ step "7b/13 LEARNING LOOP: outcome ledger capture (open) + resolve closes the lo
 LLPORT=18086; free_port "$LLPORT"
 kubectl -n "$NS" port-forward svc/runlore "$LLPORT:8080" >/tmp/runlore-ll-pf.log 2>&1 &
 LLPF=$!; sleep 3
-# prefix-match tolerates the _total / _total_total suffix variants of the OTel exporter.
-# Capture to a var first (|| true), then echo|awk — a direct `curl|awk '…exit}'`
-# lets awk close the pipe early, SIGPIPE-killing curl (exit 23) which pipefail+set-e
-# turn into a spurious abort when the matched metric lands early in the output. Mirrors
-# the set-e-safe metric() helper below.
-llmetric() { local b; b=$(curl -sf "http://localhost:$LLPORT/metrics" 2>/dev/null || true); echo "$b" | awk -v p="^runlore_$1" '$0 ~ p {print int($NF); exit}'; }
-OPENED=$(llmetric outcomes_opened); OPENED=${OPENED:-0}
+OPENED=$(scrape_metric "$LLPORT" outcomes_opened); OPENED=${OPENED:-0}
 if [[ "$OPENED" -ge 1 ]]; then green "PASS: outcome ledger recorded an investigation open (capture; opened=$OPENED)"; PASS=$((PASS+1))
 else red "FAIL: no outcome 'open' recorded (capture; opened=$OPENED)"; FAIL=$((FAIL+1)); fi
 
@@ -327,7 +360,7 @@ else red "FAIL: no outcome 'open' recorded (capture; opened=$OPENED)"; FAIL=$((F
 RESOLVE_JSON='{"alerts":[{"status":"resolved","labels":{"alertname":"HarborProbeFailure","severity":"critical","namespace":"apps"},"startsAt":"2026-06-20T03:14:00Z","fingerprint":"fp1"}]}'
 curl -s -o /dev/null -w "resolve webhook HTTP %{http_code}\n" -XPOST "http://localhost:$LLPORT/webhook/alertmanager" -H "Authorization: Bearer e2e-webhook" -H "Content-Type: application/json" -d "$RESOLVE_JSON" || true
 sleep 4
-RESOLVED=$(llmetric incidents_resolved); RESOLVED=${RESOLVED:-0}
+RESOLVED=$(scrape_metric "$LLPORT" incidents_resolved); RESOLVED=${RESOLVED:-0}
 kill "$LLPF" 2>/dev/null || true; free_port "$LLPORT"
 if [[ "$RESOLVED" -ge 1 ]]; then green "PASS: open→resolve loop closed (a resolve matched an open; resolved=$RESOLVED)"; PASS=$((PASS+1))
 else red "FAIL: resolve did not match an open (resolved=$RESOLVED)"; FAIL=$((FAIL+1)); fi
@@ -341,9 +374,13 @@ check "curate grooming the backlog"                     /tmp/runlore-curate.log 
 
 step "8/13 storm: 40 same-groupKey alerts coalesce into 1 investigation"
 # Enable coalescing (MaxBatch=40 flushes synchronously) + OTel metrics exposition.
+# The short debounce and feedback_buttons serve step 8b (one rollout for both
+# steps): the storm flushes on MaxBatch, so debounce doesn't affect step 8.
 helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
   --set "config.investigation.coalesce.enabled=true" \
   --set "config.investigation.coalesce.max_batch=40" \
+  --set-string "config.investigation.coalesce.debounce=5s" \
+  --set "config.notify.slack.feedback_buttons=true" \
   --set "config.telemetry.metrics_enabled=true" \
   --set replicaCount=1 >/dev/null
 kubectl -n "$NS" rollout status deploy/runlore --timeout=90s >/dev/null
@@ -368,11 +405,7 @@ alerts = [
 ]
 print(json.dumps({'groupKey': 'storm-group-key', 'alerts': alerts}))
 ")
-curl -s -o /dev/null -w "storm webhook HTTP %{http_code}\n" \
-  -XPOST "http://localhost:$STORM_PORT/webhook/alertmanager" \
-  -H "Authorization: Bearer e2e-webhook" \
-  -H "Content-Type: application/json" \
-  -d "$STORM_PAYLOAD" || true
+webhook_post storm "$STORM_PORT" "$STORM_PAYLOAD"
 sleep 6   # allow MaxBatch flush + investigation to start
 
 METRICS=$(curl -sf "http://localhost:$STORM_PORT/metrics" 2>/dev/null || true)
@@ -409,15 +442,12 @@ step "8b/13 LEARNING LOOP: standing 👎 re-arms through the coalesce cooldown (
 # re-arm silently absorbed by the coalescer's cooldown for up to 10m, with no log
 # line. Prove the fixed contract end-to-end: an uncontested re-fire inside the
 # cooldown is absorbed (and VISIBLY — an INFO line, not just a metric), a 👎
-# recorded via the signed Slack interaction endpoint re-arms the very next
-# re-fire, and the bypass itself is log-visible.
-helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
-  --set config.notify.slack.feedback_buttons=true \
-  --set replicaCount=1 >/dev/null
-kubectl -n "$NS" rollout status deploy/runlore --timeout=90s >/dev/null
-wait_for_leader
-sleep 3
-
+# recorded via the signed Slack interaction endpoint re-arms the next re-fire
+# through the buffer path (contested repeats batch on the 5s debounce set at the
+# step-8 install — a contested storm still collapses to ONE re-investigation),
+# and the bypass itself is log-visible. Same pod as step 8, so every log grep is
+# scoped to this step's correlation key (rearm-gk) — the storm's own suppression
+# lines are in the same log.
 REARM_PORT=18087; free_port "$REARM_PORT"
 kubectl -n "$NS" port-forward svc/runlore "$REARM_PORT:8080" >/tmp/runlore-rearm-pf.log 2>&1 &
 REARM_PF=$!; sleep 3
@@ -425,24 +455,21 @@ REARM_PF=$!; sleep 3
 # Fresh fingerprints per fire clear the chart's 30m fingerprint dedup — this step
 # tests the COALESCER layer, whose key (same groupKey) and alertname stay constant.
 rearm_fire() { # rearm_fire <fingerprint>
-  curl -s -o /dev/null -w "rearm webhook HTTP %{http_code}\n" \
-    -XPOST "http://localhost:$REARM_PORT/webhook/alertmanager" \
-    -H "Authorization: Bearer e2e-webhook" -H "Content-Type: application/json" \
-    -d "{\"groupKey\":\"rearm-gk\",\"alerts\":[{\"status\":\"firing\",\"labels\":{\"alertname\":\"RearmTest\",\"severity\":\"critical\",\"namespace\":\"prod\"},\"startsAt\":\"2026-01-01T00:00:00Z\",\"fingerprint\":\"$1\"}]}" || true
+  webhook_post rearm "$REARM_PORT" \
+    "{\"groupKey\":\"rearm-gk\",\"alerts\":[{\"status\":\"firing\",\"labels\":{\"alertname\":\"RearmTest\",\"severity\":\"critical\",\"namespace\":\"prod\"},\"startsAt\":\"2026-01-01T00:00:00Z\",\"fingerprint\":\"$1\"}]}"
 }
-rearm_metric() { local b; b=$(curl -sf "http://localhost:$REARM_PORT/metrics" 2>/dev/null || true); echo "$b" | awk -v p="^runlore_$1" '$0 ~ p {print int($NF); exit}'; }
 
 # (1) First fire: critical fast-path flushes -> investigation arms the cooldown.
 rearm_fire rearm-fp-1
 sleep 6
-S0=$(rearm_metric investigations_started); S0=${S0:-0}
+S0=$(scrape_metric "$REARM_PORT" investigations_started); S0=${S0:-0}
 
 # (2) Uncontested re-fire inside the cooldown: absorbed, and log-visible (#288 B).
 rearm_fire rearm-fp-2
 sleep 4
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
-check "coalesce cooldown suppression is log-visible" /tmp/runlore.log 'coalesce cooldown: suppressing alert'
-S1=$(rearm_metric investigations_started); S1=${S1:-0}
+check "coalesce cooldown suppression is log-visible" /tmp/runlore.log 'coalesce cooldown: suppressing alert.*rearm-gk'
+S1=$(scrape_metric "$REARM_PORT" investigations_started); S1=${S1:-0}
 if [[ "$S1" == "$S0" && "$S0" -ge 1 ]]; then
   green "PASS: uncontested re-fire absorbed by the coalesce cooldown (started stays $S0)"; PASS=$((PASS+1))
 else red "FAIL: uncontested re-fire not absorbed (started $S0 -> $S1)"; FAIL=$((FAIL+1)); fi
@@ -450,37 +477,23 @@ else red "FAIL: uncontested re-fire not absorbed (started $S0 -> $S1)"; FAIL=$((
 # (3) Standing 👎 on the trigger: signed Slack interaction, value = the TriggerKey
 # (curator.IncidentKey(alertname, ns, kind, name, cluster), lowercased — the same
 # value the delivered message's feedback buttons carry).
-python3 - "$REARM_PORT" <<'PY'
-import sys, hmac, hashlib, time, json, urllib.parse, urllib.request
-port = sys.argv[1]
-payload = json.dumps({"user": {"id": "U_E2E", "username": "e2e"},
-                      "actions": [{"action_id": "runlore_feedback_down", "value": "rearmtest|prod|||"}]})
-body = "payload=" + urllib.parse.quote(payload)
-ts = str(int(time.time()))
-sig = "v0=" + hmac.new(b"e2e-slack-secret", f"v0:{ts}:{body}".encode(), hashlib.sha256).hexdigest()
-req = urllib.request.Request(f"http://localhost:{port}/slack/interactions", data=body.encode(),
-    headers={"X-Slack-Request-Timestamp": ts, "X-Slack-Signature": sig, "Content-Type": "application/x-www-form-urlencoded"})
-try:
-    print("slack feedback HTTP", urllib.request.urlopen(req).status)
-except Exception as e:
-    print("slack feedback error:", e)
-PY
+slack_interact "$REARM_PORT" runlore_feedback_down "rearmtest|prod|||"
 sleep 2
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "👎 recorded in the outcome ledger" /tmp/runlore.log 'slack feedback recorded.*rating=down'
 
-# (4) Same re-fire again: the standing 👎 must bypass the cooldown (#288 A). Poll —
-# the single-worker queue may still be busy with investigation #1.
+# (4) Same re-fire again: the standing 👎 must bypass the cooldown (#288 A) into
+# the buffer path — flushed by the sweep after the 5s debounce, investigated
+# after that. Poll: debounce + sweep tick + a possibly busy single-worker queue.
 rearm_fire rearm-fp-3
-S2="$S1"
 for _ in $(seq 1 15); do
-  S2=$(rearm_metric investigations_started); S2=${S2:-0}
+  S2=$(scrape_metric "$REARM_PORT" investigations_started); S2=${S2:-0}
   [[ "$S2" -gt "$S1" ]] && break
   sleep 2
 done
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 kill "$REARM_PF" 2>/dev/null || true; free_port "$REARM_PORT"
-check "👎 bypass is log-visible" /tmp/runlore.log 'standing 👎 bypasses coalesce cooldown'
+check "👎 bypass is log-visible" /tmp/runlore.log 'standing 👎 bypasses coalesce cooldown.*rearm-gk'
 if [[ "$S2" -gt "$S1" ]]; then
   green "PASS: standing 👎 re-armed through the coalesce cooldown (started $S1 -> $S2)"; PASS=$((PASS+1))
 else red "FAIL: standing 👎 did not re-arm investigation (started stuck at $S2)"; FAIL=$((FAIL+1)); fi
@@ -515,20 +528,7 @@ curl -s -o /dev/null -w "token approve HTTP %{http_code}\n" -X POST -H "X-Approv
 # (b) Signed Slack interaction → approve another pending action (HMAC over v0:ts:body).
 ID2=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | first_action_id) || true
 if [[ -n "$ID2" ]]; then
-  python3 - "$ID2" "$PORT" <<'PY'
-import sys, hmac, hashlib, time, json, urllib.parse, urllib.request
-aid, port = sys.argv[1], sys.argv[2]
-payload = json.dumps({"user": {"id": "U_E2E", "username": "e2e"}, "actions": [{"action_id": "runlore_approve", "value": aid}]})
-body = "payload=" + urllib.parse.quote(payload)
-ts = str(int(time.time()))
-sig = "v0=" + hmac.new(b"e2e-slack-secret", f"v0:{ts}:{body}".encode(), hashlib.sha256).hexdigest()
-req = urllib.request.Request(f"http://localhost:{port}/slack/interactions", data=body.encode(),
-    headers={"X-Slack-Request-Timestamp": ts, "X-Slack-Signature": sig, "Content-Type": "application/x-www-form-urlencoded"})
-try:
-    print("slack interaction HTTP", urllib.request.urlopen(req).status)
-except Exception as e:
-    print("slack interaction error:", e)
-PY
+  slack_interact "$PORT" runlore_approve "$ID2"
 fi
 kill "$PF" 2>/dev/null || true; free_port "$PORT"
 sleep 3

--- a/hack/e2e-local.sh
+++ b/hack/e2e-local.sh
@@ -403,6 +403,88 @@ else
   FAIL=$((FAIL+1))
 fi
 
+step "8b/13 LEARNING LOOP: standing 👎 re-arms through the coalesce cooldown (#288)"
+# The suppression layers stack dedup -> coalescer -> recurrence gate, and only the
+# innermost consults the ledger; #288 saw a standing 👎's documented immediate
+# re-arm silently absorbed by the coalescer's cooldown for up to 10m, with no log
+# line. Prove the fixed contract end-to-end: an uncontested re-fire inside the
+# cooldown is absorbed (and VISIBLY — an INFO line, not just a metric), a 👎
+# recorded via the signed Slack interaction endpoint re-arms the very next
+# re-fire, and the bypass itself is log-visible.
+helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
+  --set config.notify.slack.feedback_buttons=true \
+  --set replicaCount=1 >/dev/null
+kubectl -n "$NS" rollout status deploy/runlore --timeout=90s >/dev/null
+wait_for_leader
+sleep 3
+
+REARM_PORT=18087; free_port "$REARM_PORT"
+kubectl -n "$NS" port-forward svc/runlore "$REARM_PORT:8080" >/tmp/runlore-rearm-pf.log 2>&1 &
+REARM_PF=$!; sleep 3
+
+# Fresh fingerprints per fire clear the chart's 30m fingerprint dedup — this step
+# tests the COALESCER layer, whose key (same groupKey) and alertname stay constant.
+rearm_fire() { # rearm_fire <fingerprint>
+  curl -s -o /dev/null -w "rearm webhook HTTP %{http_code}\n" \
+    -XPOST "http://localhost:$REARM_PORT/webhook/alertmanager" \
+    -H "Authorization: Bearer e2e-webhook" -H "Content-Type: application/json" \
+    -d "{\"groupKey\":\"rearm-gk\",\"alerts\":[{\"status\":\"firing\",\"labels\":{\"alertname\":\"RearmTest\",\"severity\":\"critical\",\"namespace\":\"prod\"},\"startsAt\":\"2026-01-01T00:00:00Z\",\"fingerprint\":\"$1\"}]}" || true
+}
+rearm_metric() { local b; b=$(curl -sf "http://localhost:$REARM_PORT/metrics" 2>/dev/null || true); echo "$b" | awk -v p="^runlore_$1" '$0 ~ p {print int($NF); exit}'; }
+
+# (1) First fire: critical fast-path flushes -> investigation arms the cooldown.
+rearm_fire rearm-fp-1
+sleep 6
+S0=$(rearm_metric investigations_started); S0=${S0:-0}
+
+# (2) Uncontested re-fire inside the cooldown: absorbed, and log-visible (#288 B).
+rearm_fire rearm-fp-2
+sleep 4
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "coalesce cooldown suppression is log-visible" /tmp/runlore.log 'coalesce cooldown: suppressing alert'
+S1=$(rearm_metric investigations_started); S1=${S1:-0}
+if [[ "$S1" == "$S0" && "$S0" -ge 1 ]]; then
+  green "PASS: uncontested re-fire absorbed by the coalesce cooldown (started stays $S0)"; PASS=$((PASS+1))
+else red "FAIL: uncontested re-fire not absorbed (started $S0 -> $S1)"; FAIL=$((FAIL+1)); fi
+
+# (3) Standing 👎 on the trigger: signed Slack interaction, value = the TriggerKey
+# (curator.IncidentKey(alertname, ns, kind, name, cluster), lowercased — the same
+# value the delivered message's feedback buttons carry).
+python3 - "$REARM_PORT" <<'PY'
+import sys, hmac, hashlib, time, json, urllib.parse, urllib.request
+port = sys.argv[1]
+payload = json.dumps({"user": {"id": "U_E2E", "username": "e2e"},
+                      "actions": [{"action_id": "runlore_feedback_down", "value": "rearmtest|prod|||"}]})
+body = "payload=" + urllib.parse.quote(payload)
+ts = str(int(time.time()))
+sig = "v0=" + hmac.new(b"e2e-slack-secret", f"v0:{ts}:{body}".encode(), hashlib.sha256).hexdigest()
+req = urllib.request.Request(f"http://localhost:{port}/slack/interactions", data=body.encode(),
+    headers={"X-Slack-Request-Timestamp": ts, "X-Slack-Signature": sig, "Content-Type": "application/x-www-form-urlencoded"})
+try:
+    print("slack feedback HTTP", urllib.request.urlopen(req).status)
+except Exception as e:
+    print("slack feedback error:", e)
+PY
+sleep 2
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "👎 recorded in the outcome ledger" /tmp/runlore.log 'slack feedback recorded.*rating=down'
+
+# (4) Same re-fire again: the standing 👎 must bypass the cooldown (#288 A). Poll —
+# the single-worker queue may still be busy with investigation #1.
+rearm_fire rearm-fp-3
+S2="$S1"
+for _ in $(seq 1 15); do
+  S2=$(rearm_metric investigations_started); S2=${S2:-0}
+  [[ "$S2" -gt "$S1" ]] && break
+  sleep 2
+done
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+kill "$REARM_PF" 2>/dev/null || true; free_port "$REARM_PORT"
+check "👎 bypass is log-visible" /tmp/runlore.log 'standing 👎 bypasses coalesce cooldown'
+if [[ "$S2" -gt "$S1" ]]; then
+  green "PASS: standing 👎 re-armed through the coalesce cooldown (started $S1 -> $S2)"; PASS=$((PASS+1))
+else red "FAIL: standing 👎 did not re-arm investigation (started stuck at $S2)"; FAIL=$((FAIL+1)); fi
+
 step "9/13 GitOps failure trigger (informer on a real API server)"
 kubectl create ns apps >/dev/null 2>&1 || true
 kubectl apply -f - <<'YAML'
@@ -421,11 +503,17 @@ check "gitops failure -> investigate" /tmp/runlore.log 'source=gitops-failure|Ku
 PORT=18090; free_port "$PORT"
 kubectl -n "$NS" port-forward svc/runlore "$PORT:8080" >/tmp/runlore-pf.log 2>&1 &
 PF=$!; sleep 3
+# first_action_id extracts the first pending action ID from the /actions JSON.
+# python3 (already a script dependency), not `grep -oP` — BSD grep on macOS has
+# no -P, which silently yielded an empty ID and failed the approval assertions.
+first_action_id() {
+  python3 -c 'import sys, re; m = re.search(r"\"ID\":\"([^\"]+)\"", sys.stdin.read()); print(m.group(1) if m else "")'
+}
 # (a) Token endpoint → execute (suspends broken-app).
-ID=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | grep -oP '"ID":"\K[^"]+' | head -1) || true
+ID=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | first_action_id) || true
 curl -s -o /dev/null -w "token approve HTTP %{http_code}\n" -X POST -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions/$ID/approve" || true
 # (b) Signed Slack interaction → approve another pending action (HMAC over v0:ts:body).
-ID2=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | grep -oP '"ID":"\K[^"]+' | head -1) || true
+ID2=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$PORT/actions" | first_action_id) || true
 if [[ -n "$ID2" ]]; then
   python3 - "$ID2" "$PORT" <<'PY'
 import sys, hmac, hashlib, time, json, urllib.parse, urllib.request

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -396,7 +396,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	// non-zero cooldown; Enabled() guards the disabled-ledger edge regardless.
 	var recurrence *investigate.RecurrenceGate
 	if d := cfg.Investigation.RecurrenceCooldown.Std(); d > 0 && ledger.Enabled() {
-		recurrence = &investigate.RecurrenceGate{Outcome: ledger, Cooldown: d, Log: log}
+		recurrence = &investigate.RecurrenceGate{Outcome: ledger, Cooldown: d}
 		log.Info("recurrence cooldown enabled", "cooldown", d)
 	}
 	// Per-tool timeout: default to 60s when unset (0) so one hung tool can't eat the

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -224,6 +224,14 @@ func RunServe(version string, args []string) error {
 			CorrelationLabels: cc.CorrelationLabels,
 		}, out)
 		cz.Metrics = metrics
+		cz.Log = log
+		// A standing 👎 must bypass the coalescer's cooldown, or the recurrence
+		// gate's "👎 re-arms investigation immediately" promise is silently deferred
+		// by up to Cooldown at this outer layer (#288). Recurrence is a zero value
+		// for a disabled ledger, so the bypass is inert without outcome.ledger_path.
+		cz.Contested = func(triggerKey string) bool {
+			return ledger.Recurrence(triggerKey).FeedbackDown > 0
+		}
 		log.Info("investigation coalescer enabled",
 			"debounce", cc.Debounce.Std(), "max_wait", cc.MaxWait.Std(),
 			"max_batch", cc.MaxBatch, "cooldown", cc.Cooldown.Std())

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -225,13 +225,10 @@ func RunServe(version string, args []string) error {
 		}, out)
 		cz.Metrics = metrics
 		cz.Log = log
-		// A standing 👎 must bypass the coalescer's cooldown, or the recurrence
-		// gate's "👎 re-arms investigation immediately" promise is silently deferred
-		// by up to Cooldown at this outer layer (#288). Recurrence is a zero value
-		// for a disabled ledger, so the bypass is inert without outcome.ledger_path.
-		cz.Contested = func(triggerKey string) bool {
-			return ledger.Recurrence(triggerKey).FeedbackDown > 0
-		}
+		// Same ledger view as the recurrence gate, so the two layers cannot diverge
+		// on what "contested" means (#288). Recurrence is a zero value for a
+		// disabled ledger, so the bypass is inert without outcome.ledger_path.
+		cz.Outcome = ledger
 		log.Info("investigation coalescer enabled",
 			"debounce", cc.Debounce.Std(), "max_wait", cc.MaxWait.Std(),
 			"max_batch", cc.MaxBatch, "cooldown", cc.Cooldown.Std())

--- a/internal/coalesce/add_test.go
+++ b/internal/coalesce/add_test.go
@@ -3,6 +3,9 @@
 package coalesce
 
 import (
+	"bytes"
+	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,6 +101,102 @@ func TestAddNewCriticalDuringCooldownFlushes(t *testing.T) {
 	c.Add(second) // PodNotReady again → suppressed
 	if len(s.batches) != 2 {
 		t.Fatalf("repeat critical alertname during cooldown must be suppressed, batches=%d", len(s.batches))
+	}
+}
+
+// A standing 👎 on the incoming trigger must bypass the cooldown suppression:
+// the human said "that diagnosis is wrong", so the very next occurrence must
+// reach the recurrence gate (which re-arms on the same signal) instead of being
+// silently absorbed by a layer that knows nothing about feedback (#288).
+func TestAddContestedTriggerBypassesCooldown(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
+	c.Contested = func(triggerKey string) bool { return triggerKey == "tk-1" }
+
+	first := inc("X", "ns", "warning", "GK")
+	first.TriggerKey = "tk-1"
+	c.Add(first) // MaxBatch=1 → flush, seeds cooldown
+	now = now.Add(time.Minute)
+	c.Add(first) // within cooldown BUT contested → must not be suppressed
+	if len(s.batches) != 2 {
+		t.Fatalf("a contested trigger during cooldown must bypass suppression, batches=%d", len(s.batches))
+	}
+}
+
+// An uncontested trigger stays suppressed during cooldown even with the
+// Contested callback wired — the escape hatch is per-trigger, not global.
+func TestAddUncontestedTriggerStaysSuppressed(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
+	var asked []string
+	c.Contested = func(triggerKey string) bool { asked = append(asked, triggerKey); return false }
+
+	first := inc("X", "ns", "warning", "GK")
+	first.TriggerKey = "tk-1"
+	c.Add(first) // flush, seeds cooldown
+	now = now.Add(time.Minute)
+	c.Add(first) // within cooldown, callback says no standing 👎 → suppressed
+	if len(s.batches) != 1 {
+		t.Fatalf("an uncontested trigger during cooldown must stay suppressed, batches=%d", len(s.batches))
+	}
+	if len(asked) != 1 || asked[0] != "tk-1" {
+		t.Fatalf("the ledger must be consulted with the incoming TriggerKey, asked=%v", asked)
+	}
+}
+
+// A request without a TriggerKey never consults the ledger — there is nothing
+// to look up a standing 👎 by, so the cooldown suppresses as before.
+func TestAddEmptyTriggerKeySkipsContestedLookup(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
+	c.Contested = func(string) bool { t.Fatal("Contested must not be called for an empty TriggerKey"); return true }
+
+	c.Add(inc("X", "ns", "warning", "GK")) // flush, seeds cooldown (no TriggerKey)
+	now = now.Add(time.Minute)
+	c.Add(inc("X", "ns", "warning", "GK")) // within cooldown → suppressed, no lookup
+	if len(s.batches) != 1 {
+		t.Fatalf("empty-TriggerKey repeat must stay suppressed, batches=%d", len(s.batches))
+	}
+}
+
+// Cooldown suppression must be visible in logs: an `investigate=true` incident
+// line followed by silence is undiagnosable from logs alone (#288). The line is
+// symmetrical to the recurrence gate's "recurrence cooldown: suppressing".
+func TestAddCooldownSuppressionLogs(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
+	var buf bytes.Buffer
+	c.Log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	c.Add(inc("X", "ns", "warning", "GK")) // flush, seeds cooldown
+	now = now.Add(time.Minute)
+	c.Add(inc("X", "ns", "warning", "GK")) // within cooldown → suppressed + logged
+	if got := buf.String(); !strings.Contains(got, "coalesce cooldown: suppressing alert") {
+		t.Fatalf("cooldown suppression must emit a log line, got: %q", got)
+	}
+}
+
+// The contested bypass is equally log-visible, so a re-investigation that
+// "should have been suppressed" is explainable from logs.
+func TestAddContestedBypassLogs(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
+	c.Contested = func(string) bool { return true }
+	var buf bytes.Buffer
+	c.Log = slog.New(slog.NewTextHandler(&buf, nil))
+
+	first := inc("X", "ns", "warning", "GK")
+	first.TriggerKey = "tk-1"
+	c.Add(first)
+	now = now.Add(time.Minute)
+	c.Add(first) // contested → bypass + logged
+	if got := buf.String(); !strings.Contains(got, "standing 👎 bypasses coalesce cooldown") {
+		t.Fatalf("contested bypass must emit a log line, got: %q", got)
 	}
 }
 

--- a/internal/coalesce/add_test.go
+++ b/internal/coalesce/add_test.go
@@ -10,8 +10,26 @@ import (
 	"time"
 
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+// recurrenceStub adapts a func to investigate.RecurrenceStats for wiring test
+// ledger views into Coalescer.Outcome.
+type recurrenceStub func(triggerKey string) outcome.TriggerRecurrence
+
+func (f recurrenceStub) Recurrence(k string) outcome.TriggerRecurrence { return f(k) }
+
+// contestedFor returns a stub whose Recurrence reports a standing 👎 for
+// exactly the given TriggerKey.
+func contestedFor(key string) recurrenceStub {
+	return func(k string) outcome.TriggerRecurrence {
+		if k == key {
+			return outcome.TriggerRecurrence{FeedbackDown: 1}
+		}
+		return outcome.TriggerRecurrence{}
+	}
+}
 
 type sink struct{ batches [][]investigate.Request }
 
@@ -112,7 +130,7 @@ func TestAddContestedTriggerBypassesCooldown(t *testing.T) {
 	now := time.Unix(0, 0)
 	s := &sink{}
 	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
-	c.Contested = func(triggerKey string) bool { return triggerKey == "tk-1" }
+	c.Outcome = contestedFor("tk-1")
 
 	first := inc("X", "ns", "warning", "GK")
 	first.TriggerKey = "tk-1"
@@ -125,13 +143,16 @@ func TestAddContestedTriggerBypassesCooldown(t *testing.T) {
 }
 
 // An uncontested trigger stays suppressed during cooldown even with the
-// Contested callback wired — the escape hatch is per-trigger, not global.
+// ledger view wired — the escape hatch is per-trigger, not global.
 func TestAddUncontestedTriggerStaysSuppressed(t *testing.T) {
 	now := time.Unix(0, 0)
 	s := &sink{}
 	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
 	var asked []string
-	c.Contested = func(triggerKey string) bool { asked = append(asked, triggerKey); return false }
+	c.Outcome = recurrenceStub(func(k string) outcome.TriggerRecurrence {
+		asked = append(asked, k)
+		return outcome.TriggerRecurrence{} // no standing 👎
+	})
 
 	first := inc("X", "ns", "warning", "GK")
 	first.TriggerKey = "tk-1"
@@ -152,13 +173,52 @@ func TestAddEmptyTriggerKeySkipsContestedLookup(t *testing.T) {
 	now := time.Unix(0, 0)
 	s := &sink{}
 	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
-	c.Contested = func(string) bool { t.Fatal("Contested must not be called for an empty TriggerKey"); return true }
+	c.Outcome = recurrenceStub(func(string) outcome.TriggerRecurrence {
+		t.Fatal("the ledger must not be consulted for an empty TriggerKey")
+		return outcome.TriggerRecurrence{}
+	})
 
 	c.Add(inc("X", "ns", "warning", "GK")) // flush, seeds cooldown (no TriggerKey)
 	now = now.Add(time.Minute)
 	c.Add(inc("X", "ns", "warning", "GK")) // within cooldown → suppressed, no lookup
 	if len(s.batches) != 1 {
 		t.Fatalf("empty-TriggerKey repeat must stay suppressed, batches=%d", len(s.batches))
+	}
+}
+
+// A contested CRITICAL repeat must take the buffer path, not the critical
+// fast-path: the "never delay the first look at a critical page" invariant is
+// about the FIRST look, and a contested repeat is by definition not that. If it
+// flushed immediately, a 40-alert contested storm would fan out to 40
+// investigations — the bypass would defeat the very storm collapse the
+// coalescer exists for. Buffered, the storm collapses to ONE re-investigation
+// per debounce window.
+func TestAddContestedCriticalStormCollapses(t *testing.T) {
+	now := time.Unix(0, 0)
+	s := &sink{}
+	c := newAt(Config{Debounce: time.Minute, MaxBatch: 100, Cooldown: 10 * time.Minute}, s, &now)
+	c.Outcome = contestedFor("tk-1")
+
+	first := inc("X", "ns", "critical", "GK")
+	first.TriggerKey = "tk-1"
+	c.Add(first) // first look: critical fast-path → flush #1, arms cooldown
+	if len(s.batches) != 1 {
+		t.Fatalf("first critical must flush immediately, batches=%d", len(s.batches))
+	}
+	for i := 0; i < 5; i++ { // contested critical storm within the cooldown
+		now = now.Add(time.Second)
+		c.Add(first)
+	}
+	if len(s.batches) != 1 {
+		t.Fatalf("contested critical repeats must buffer, not flush per alert, batches=%d", len(s.batches))
+	}
+	if len(c.pending) != 1 {
+		t.Fatalf("contested repeats must be buffered under their key, pending=%d", len(c.pending))
+	}
+	now = now.Add(2 * time.Minute) // past Debounce → sweep flushes the batch
+	c.sweep()
+	if len(s.batches) != 2 || len(s.batches[1]) != 5 {
+		t.Fatalf("storm must collapse to ONE re-investigation batch of 5, batches=%v", len(s.batches))
 	}
 }
 
@@ -186,7 +246,7 @@ func TestAddContestedBypassLogs(t *testing.T) {
 	now := time.Unix(0, 0)
 	s := &sink{}
 	c := newAt(Config{Debounce: time.Minute, MaxBatch: 1, Cooldown: 10 * time.Minute}, s, &now)
-	c.Contested = func(string) bool { return true }
+	c.Outcome = contestedFor("tk-1")
 	var buf bytes.Buffer
 	c.Log = slog.New(slog.NewTextHandler(&buf, nil))
 

--- a/internal/coalesce/coalescer.go
+++ b/internal/coalesce/coalescer.go
@@ -8,6 +8,7 @@ package coalesce
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
@@ -48,6 +49,15 @@ type Coalescer struct {
 	now     func() time.Time
 	out     func([]investigate.Request) // flush sink (build a Request + enqueue)
 	Metrics *telemetry.Metrics          // optional; nil-safe OTel counters
+	Log     *slog.Logger                // optional; nil-safe
+
+	// Contested reports whether a TriggerKey has standing 👎 feedback (wired to
+	// the outcome ledger). A contested trigger bypasses the cooldown suppression:
+	// the recurrence gate re-arms on a standing 👎, and this outer layer must not
+	// silently defer that re-arm for up to Cooldown (#288). Consulted only when
+	// suppression would otherwise happen, so the ledger stays off the common path.
+	// Optional; nil means no bypass.
+	Contested func(triggerKey string) bool
 
 	mu      sync.Mutex
 	pending map[string]*batch
@@ -164,15 +174,25 @@ func (c *Coalescer) Add(r investigate.Request) {
 	var flush []investigate.Request
 	c.mu.Lock()
 	now := c.now()
+	// An investigation for this key already fired within the cooldown — suppress
+	// the rest of the storm. This is checked before the critical fast-path so a
+	// storm of critical alerts collapses to one investigation (the first) plus
+	// suppressions, rather than one investigation per alert. Two exceptions:
+	// newCriticalDuringCooldown lets a critical with an alertname not yet seen for
+	// this key through (a genuinely new problem, not storm noise), and a standing
+	// 👎 on the trigger bypasses suppression so the human's re-arm reaches the
+	// recurrence gate at the very next occurrence instead of being deferred here.
+	suppress := c.withinCooldown(k, now) && !c.newCriticalDuringCooldown(k, r)
+	// Contested (a ledger lookup with its own lock, no call cycles back here) is
+	// consulted under mu but only when suppression would otherwise happen.
+	bypass := suppress && c.Contested != nil && r.TriggerKey != "" && c.Contested(r.TriggerKey)
 	switch {
-	case c.withinCooldown(k, now) && !c.newCriticalDuringCooldown(k, r):
-		// An investigation for this key already fired within the cooldown — suppress
-		// the rest of the storm. This is checked before the critical fast-path so a
-		// storm of critical alerts collapses to one investigation (the first) plus
-		// suppressions, rather than one investigation per alert. The exception
-		// (newCriticalDuringCooldown) lets a critical with an alertname not yet seen
-		// for this key through, since that is a genuinely new problem, not storm noise.
+	case suppress && !bypass:
 		c.mu.Unlock()
+		if l := c.Log; l != nil {
+			l.Info("coalesce cooldown: suppressing alert",
+				"key", k, "title", r.Title, "trigger_key", r.TriggerKey, "cooldown", c.cfg.Cooldown)
+		}
 		if m := c.Metrics; m != nil {
 			m.AlertsSuppressed.Add(context.Background(), 1)
 		}
@@ -207,6 +227,12 @@ func (c *Coalescer) Add(r investigate.Request) {
 		}
 	}
 	c.mu.Unlock()
+	if bypass {
+		if l := c.Log; l != nil {
+			l.Info("standing 👎 bypasses coalesce cooldown",
+				"key", k, "title", r.Title, "trigger_key", r.TriggerKey)
+		}
+	}
 	if flush != nil {
 		c.emit(flush)
 	}

--- a/internal/coalesce/coalescer.go
+++ b/internal/coalesce/coalescer.go
@@ -51,13 +51,13 @@ type Coalescer struct {
 	Metrics *telemetry.Metrics          // optional; nil-safe OTel counters
 	Log     *slog.Logger                // optional; nil-safe
 
-	// Contested reports whether a TriggerKey has standing 👎 feedback (wired to
-	// the outcome ledger). A contested trigger bypasses the cooldown suppression:
-	// the recurrence gate re-arms on a standing 👎, and this outer layer must not
-	// silently defer that re-arm for up to Cooldown (#288). Consulted only when
-	// suppression would otherwise happen, so the ledger stays off the common path.
-	// Optional; nil means no bypass.
-	Contested func(triggerKey string) bool
+	// Outcome is the same per-TriggerKey ledger view the recurrence gate reads
+	// (*outcome.Ledger satisfies it). A contested trigger (standing 👎) bypasses
+	// the cooldown suppression into the buffer path: the recurrence gate re-arms
+	// on that signal, and this outer layer must not silently defer the re-arm for
+	// up to Cooldown (#288). Consulted only when suppression would otherwise
+	// happen, so the ledger stays off the common path. Optional; nil = no bypass.
+	Outcome investigate.RecurrenceStats
 
 	mu      sync.Mutex
 	pending map[string]*batch
@@ -177,15 +177,11 @@ func (c *Coalescer) Add(r investigate.Request) {
 	// An investigation for this key already fired within the cooldown — suppress
 	// the rest of the storm. This is checked before the critical fast-path so a
 	// storm of critical alerts collapses to one investigation (the first) plus
-	// suppressions, rather than one investigation per alert. Two exceptions:
-	// newCriticalDuringCooldown lets a critical with an alertname not yet seen for
-	// this key through (a genuinely new problem, not storm noise), and a standing
-	// 👎 on the trigger bypasses suppression so the human's re-arm reaches the
-	// recurrence gate at the very next occurrence instead of being deferred here.
+	// suppressions, rather than one investigation per alert. Two escape hatches:
+	// a critical with an alertname not yet seen for this key (a genuinely new
+	// problem, not storm noise), and a contested trigger (see Outcome).
 	suppress := c.withinCooldown(k, now) && !c.newCriticalDuringCooldown(k, r)
-	// Contested (a ledger lookup with its own lock, no call cycles back here) is
-	// consulted under mu but only when suppression would otherwise happen.
-	bypass := suppress && c.Contested != nil && r.TriggerKey != "" && c.Contested(r.TriggerKey)
+	bypass := suppress && c.contested(r)
 	switch {
 	case suppress && !bypass:
 		c.mu.Unlock()
@@ -197,13 +193,17 @@ func (c *Coalescer) Add(r investigate.Request) {
 			m.AlertsSuppressed.Add(context.Background(), 1)
 		}
 		return
-	case r.IsCritical():
+	case r.IsCritical() && !bypass:
 		// Critical (first for this key, or a new alertname during cooldown): flush
 		// immediately with no debounce wait, draining any pending batch. Same-key
 		// same-alertname criticals fall into the cooldown case above and are suppressed.
 		// The predicate is investigate.Request.IsCritical, shared with the incident
 		// debouncer's identical carve-out (source.incidentDebouncer.Hold) so the two
 		// waits enforce "never delay the first look at a critical page" identically.
+		// A BYPASSED critical takes the buffer path below instead: the no-delay
+		// invariant is about the FIRST look, and a contested repeat is by definition
+		// not that — flushing per alert would fan a contested storm out to one
+		// investigation per alert, defeating the collapse this package exists for.
 		flush = []investigate.Request{r}
 		if b, ok := c.pending[k]; ok {
 			flush = make([]investigate.Request, 0, len(b.incidents)+1)
@@ -262,6 +262,14 @@ func (c *Coalescer) emit(batch []investigate.Request) {
 func (c *Coalescer) withinCooldown(k string, now time.Time) bool {
 	cd, ok := c.recent[k]
 	return ok && c.cfg.Cooldown > 0 && now.Sub(cd.last) < c.cfg.Cooldown
+}
+
+// contested reports whether r's trigger carries standing 👎 feedback — the
+// cooldown's second escape hatch, symmetric with newCriticalDuringCooldown.
+// The ledger lookup happens under mu (it has its own lock, no call cycles back
+// here) but only on the would-suppress path, never on the common path.
+func (c *Coalescer) contested(r investigate.Request) bool {
+	return c.Outcome != nil && r.TriggerKey != "" && c.Outcome.Recurrence(r.TriggerKey).Contested()
 }
 
 // newCriticalDuringCooldown reports whether inc is a critical alert whose

--- a/internal/investigate/recurrence.go
+++ b/internal/investigate/recurrence.go
@@ -3,7 +3,6 @@
 package investigate
 
 import (
-	"log/slog"
 	"time"
 
 	"github.com/Smana/runlore/internal/outcome"
@@ -46,7 +45,6 @@ type RecurrenceStats interface {
 type RecurrenceGate struct {
 	Outcome  RecurrenceStats
 	Cooldown time.Duration // 0 disables the gate (default: off, opt-in)
-	Log      *slog.Logger  // optional; nil-safe
 }
 
 // suppress reports whether req should be suppressed, returning the prior
@@ -66,7 +64,7 @@ func (g *RecurrenceGate) suppress(req Request, now time.Time) (outcome.TriggerRe
 	default:
 		return r, false // inconclusive or pre-verdict: retry, we owe a real answer
 	}
-	if r.FeedbackDown > 0 {
+	if r.Contested() {
 		return r, false // a human contested the diagnosis: cooldown broken
 	}
 	return r, true

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -798,6 +798,13 @@ type TriggerRecurrence struct {
 	FeedbackDown int // LIVE 👎 votes for this trigger, after per-user dedup
 }
 
+// Contested reports whether the trigger carries standing 👎 feedback — the ONE
+// definition of "a human contests this diagnosis" shared by every suppression
+// layer that must yield to it (the recurrence gate and the coalescer's cooldown,
+// #288). Layers consulting different notions of contested-ness is exactly the
+// divergence that issue was about; add nuance here, not at the call sites.
+func (r TriggerRecurrence) Contested() bool { return r.FeedbackDown > 0 }
+
 // Recurrence returns the trigger's recurrence snapshot. FeedbackDown counts the
 // votes map's current "down" entries for the key — O(live votes), which stays
 // small (one entry per trigger×user) and off the recall hot path (read once per


### PR DESCRIPTION
Fixes #288.

## Problem

Found during live EKS validation (#288): the suppression layers stack as **dedup (fingerprint) → coalescer (correlation key) → recurrence gate (TriggerKey)**, and only the innermost consults the outcome ledger. So:

- **A** — the documented promise "*a standing 👎 re-arms investigation immediately*" (learning-loop.md, #270) was silently deferred for up to `coalesce.cooldown` (10m default, `enabled: true` in the chart) by a layer that knows nothing about feedback.
- **B** — coalescer cooldown suppression emitted **no log line** (only the `AlertsSuppressed` metric), so an `investigate=true` incident line followed by silence was undiagnosable from logs.

## Fix

- The coalescer gains an `Outcome investigate.RecurrenceStats` field — the **same ledger view the recurrence gate reads**, wired symmetrically in `serve.go` (`cz.Outcome = ledger`). "Standing 👎 = contested" is defined exactly once, as `outcome.TriggerRecurrence.Contested()`, consumed by both layers so they cannot diverge (the divergence was the whole point of #288). The ledger is consulted **only when cooldown suppression would otherwise happen** (off the common path). Inert without `outcome.ledger_path`. **No new config.**
- A contested trigger bypasses suppression into the **buffer path** (not the critical fast-path): the "never delay the first look at a critical page" invariant is about the *first* look, and a contested repeat is by definition not that. Bypassed repeats batch on the normal `debounce`, so a contested 40-alert storm collapses to **one** re-investigation instead of fanning out to 40 (`TestAddContestedCriticalStormCollapses`). A fresh or new-alertname critical still flushes immediately.
- Cooldown suppression now logs `"coalesce cooldown: suppressing alert"` (key, title, trigger_key, cooldown) at INFO, symmetrical to the recurrence gate's line; the contested bypass logs `"standing 👎 bypasses coalesce cooldown"`.
- Docs:
  - `configuration.md` — the `coalesce` bullet now notes the **chart-vs-code default split** (`enabled: true` in the chart, disabled in code — same treatment `dedup.window` got in #275) and documents the cooldown's two escape hatches + observability.
  - `learning-loop.md` — states precisely where the 👎 re-arm holds and the one remaining honest boundary: **fingerprint dedup** keys on the Alertmanager fingerprint before feedback is ever consulted, so a same-fingerprint repeat inside `dedup.window` (code default 0; chart ships 30m) is still dropped; a fresh-fingerprint re-fire re-arms immediately.
  - chart `values.yaml` cooldown comment mentions the bypasses.

## Tests

TDD (red → green): `TestAddContestedTriggerBypassesCooldown`, `TestAddContestedCriticalStormCollapses`, `TestAddUncontestedTriggerStaysSuppressed`, `TestAddEmptyTriggerKeySkipsContestedLookup`, `TestAddCooldownSuppressionLogs`, `TestAddContestedBypassLogs`. Full gate: `go build ./... && go vet ./... && go test ./... && gofmt -l .` clean, `golangci-lint run` clean on touched packages, `go test -race` on touched packages.

**e2e**: new step 8b in `hack/e2e-local.sh` replays the #288 sequence on a real k3d cluster — critical alert arms the coalesce cooldown → uncontested re-fire (fresh fingerprint, same groupKey) absorbed **and log-visible** → standing 👎 recorded through the signed `/slack/interactions` endpoint (value = TriggerKey) → the next re-fire bypasses the cooldown through the buffer path (bypass log line + `investigations_started` 1→2). Full suite run locally after every commit: **PASS=54 FAIL=0**. Also fixes a harness portability bug the run surfaced (step 9's `grep -oP` action-ID extraction fails on BSD grep/macOS → python3, already a script dependency) and dedupes three copied shell blocks into shared helpers (`webhook_post`, `scrape_metric`, `slack_interact`).

## Follow-ups from self-review (commit 3)

- Reviewing the first commit surfaced a storm-amplification edge: the bypass originally sent contested criticals through the immediate-flush fast-path, so a contested storm fanned out to N investigations. Fixed by routing bypassed repeats through the buffer path (see Fix above).
- Dead `RecurrenceGate.Log` field removed (set at the wiring site, never read).