### PR TITLE
chore(security): pin Hubble TLS floor to 1.2; drop redundant shift conversion

### DIFF
--- a/internal/httpx/retry.go
+++ b/internal/httpx/retry.go
@@ -83,7 +83,9 @@ func retryDelay(attempt int, resp *http.Response) time.Duration {
 	if attempt-1 >= 63 {
 		return maxDelay
 	}
-	d := baseBackoff << uint(attempt-1)
+	// Signed shift counts are legal since Go 1.13; the guards above bound
+	// attempt-1 to [0,62], so no uint conversion (and no gosec G115) is needed.
+	d := baseBackoff << (attempt - 1)
 	if d <= 0 || d > maxDelay {
 		return maxDelay
 	}

--- a/internal/network/hubble/hubble.go
+++ b/internal/network/hubble/hubble.go
@@ -42,12 +42,16 @@ func New(addr string, tlsEnabled bool, opts ...grpc.DialOption) *Client {
 
 var _ providers.NetworkProvider = (*Client)(nil)
 
+// tlsConfig is the client TLS configuration for Hubble Relay dials. MinVersion
+// is pinned to TLS 1.2 — the zero-value tls.Config would accept TLS 1.0/1.1.
+func tlsConfig() *tls.Config { return &tls.Config{MinVersion: tls.VersionTLS12} }
+
 // Drops returns DROPPED flows touching the selector within the window.
 func (c *Client) Drops(ctx context.Context, sel providers.Selector, w providers.TimeWindow) (providers.LogResult, error) {
 	// Select transport credentials: insecure/plaintext (the DEFAULT) or TLS.
 	var transportCreds grpc.DialOption
 	if c.tlsMode {
-		transportCreds = grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{}))
+		transportCreds = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig()))
 	} else {
 		transportCreds = grpc.WithTransportCredentials(insecure.NewCredentials())
 	}

--- a/internal/network/hubble/hubble_test.go
+++ b/internal/network/hubble/hubble_test.go
@@ -4,6 +4,7 @@ package hubble
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"strings"
 	"testing"
@@ -199,4 +200,12 @@ func TestDropsTLSSelected(t *testing.T) {
 		t.Fatalf("TLS-mode Drops (with insecure override): %v", err)
 	}
 	_ = res // result is empty (no flows registered); we only care about no panic/error
+}
+
+// The TLS client config must pin a modern floor: the zero-value tls.Config
+// accepts TLS 1.0/1.1, which no Hubble relay needs and gosec (G402) rejects.
+func TestTLSConfigMinVersion(t *testing.T) {
+	if got := tlsConfig().MinVersion; got < tls.VersionTLS12 {
+		t.Fatalf("tlsConfig MinVersion = %#x, want >= TLS 1.2 (%#x)", got, tls.VersionTLS12)
+	}
 }


### PR DESCRIPTION
Fixes the two gosec findings (G402, G115) surfaced by golangci-lint v2.6.2. Details in the commit message.