### PR TITLE
fix(redact): decode Secret data values and scrub them payload-wide

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -411,9 +411,10 @@ KB git repo  ──syncer──►  local mirror  ──build──►  index:  
   high-precision — PEM private keys, JWTs, GitHub / Slack / AWS / Google / Stripe keys,
   `user:pass@host` URLs, `Authorization` headers, and generic `*secret*/*token*/*password*: <value>`
   pairs, plus the values under a `kind: Secret` manifest's `data:`/`stringData:` block (including
-  inside a git diff) — masking the *value* while keeping surrounding structure so the agent can still
+  inside a git diff; the values are also base64-decoded and scrubbed from the whole payload) —
+  masking the *value* while keeping surrounding structure so the agent can still
   reason ("the password field changed"). Redaction is a **mitigation, not a guarantee**: unlabeled
-  high-entropy strings and base64 blobs outside a `Secret` manifest are not caught (see the
+  high-entropy strings and base64 blobs with no `Secret` manifest in the payload are not caught (see the
   [LLM security architecture](security-architecture.md)). Defense-in-depth still applies — the RBAC
   scoping above limits what tool output can contain, and **self-hosting the model** (in-cluster
   vLLM/Ollama) keeps data in-boundary regardless. If you run a public KB repo or untrusted-tenant

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -154,9 +154,10 @@ a `what_changed` git diff.
 >   and base64 log blob;
 > - **unlabeled high-entropy strings** — a password sitting in free prose with no recognizable
 >   prefix and no key label;
-> - **base64 blobs outside a `kind: Secret` `data:` block** — the redactor masks Secret-manifest
->   values wholesale but never *decodes* base64 to inspect contents, so a secret copied base64-encoded
->   into a log line or ConfigMap is not detected;
+> - **base64 blobs whose `kind: Secret` manifest is not in the same payload** — when the manifest
+>   IS present, its `data:` values are decoded and both the blob and the plaintext are scrubbed
+>   payload-wide; without it there is no ground truth, and a lone blob is indistinguishable from a
+>   git SHA or a benign base64 log blob, so it is not decoded speculatively;
 > - secrets under a key name outside the sensitive-keyword vocabulary.
 >
 > If you run a public KB repo or untrusted-tenant namespaces, the strongest mitigation is

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -62,14 +62,18 @@ Tool output and incident text flow to a model provider and, for findings, into y
 Coverage (high-precision, masks the value while keeping structure): PEM private keys, JWTs,
 GitHub / Slack / AWS / Google / Stripe keys, `user:pass@host` URLs, `Authorization` headers,
 generic `*(password|secret|api_key|token|…): <value>` pairs, and the values under a `kind: Secret`
-manifest's `data:`/`stringData:` block — including one surfaced inside a git diff.
+manifest's `data:`/`stringData:` block — including one surfaced inside a git diff. A masked
+Secret value is also **learned**: its base64 blob is decoded and both forms are scrubbed from the
+**whole payload**, so the same secret quoted decoded in a log line or encoded in an event does not
+outlive the manifest that names it.
 
 > [!WARNING]
 > **Redaction is a mitigation, not a guarantee**
 >
 > The ruleset is deliberately high-precision, and the cost of precision is recall: unlabeled
-> high-entropy strings, bare AWS secret keys with no context cue, and base64 blobs *outside* a
-> `kind: Secret` `data:` block (the redactor never decodes base64) are **not** caught — see
+> high-entropy strings, bare AWS secret keys with no context cue, and base64 blobs whose `kind:
+> Secret` manifest is **not in the same payload** (decoding happens only with the manifest as
+> ground truth — a lone blob is indistinguishable from a SHA or log blob) are **not** caught — see
 > [LLM security architecture §2](security-architecture.md#2-secret-redaction-three-boundaries-one-chokepoint)
 > for the full list. If you run a **public KB repo** or **untrusted-tenant namespaces**, treat this
 > as a gating concern — and prefer **self-hosting the model** (in-cluster vLLM/Ollama), which keeps

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -13,7 +13,9 @@
 package redact
 
 import (
+	"encoding/base64"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -73,7 +75,8 @@ func Secrets(s string) string {
 	for _, r := range rules {
 		s = r.re.ReplaceAllString(s, r.repl)
 	}
-	return k8sSecretData(s)
+	s, learned := k8sSecretData(s)
+	return scrubLearned(s, learned)
 }
 
 // diffPrefixRE matches an optional git-diff line marker ("+ ", "- ", or a single
@@ -95,8 +98,10 @@ var kindSecretRE = regexp.MustCompile(`^kind:\s*["']?Secret["']?\s*$`)
 var kindAnyRE = regexp.MustCompile(`^kind:\s*\S`)
 
 // dataKeyRE matches a `data:` or `stringData:` mapping key (no inline value),
-// capturing its indentation. Anchored after diff-marker stripping.
-var dataKeyRE = regexp.MustCompile(`^(\s*)(?:data|stringData):\s*$`)
+// capturing its indentation and which of the two it is (data: values are
+// base64, stringData: values are plaintext). Anchored after diff-marker
+// stripping.
+var dataKeyRE = regexp.MustCompile(`^(\s*)(data|stringData):\s*$`)
 
 // dataEntryRE matches a `  key: value` mapping entry inside a data block,
 // capturing indentation, the "key:" portion, and the value. Block scalars
@@ -110,12 +115,17 @@ var dataEntryRE = regexp.MustCompile(`^(\s*)([^\s:][^:]*:\s*)(\S.*)$`)
 // left untouched. It tolerates git-diff line markers ("+ ", "- ", leading
 // space) because a Secret most often surfaces inside a `what_changed` diff.
 //
+// Every masked value is also LEARNED (second return): the raw token and, for a
+// base64 `data:` value, its decoded plaintext. The caller scrubs those literals
+// from the whole payload — the same secret quoted decoded in a log line or
+// encoded in an event must not outlive the manifest that names it.
+//
 // A data block ends at: a dedent to a column <= the data key's indent, a new
 // top-level key, a `kind:` line, or a YAML document separator ("---"). The pass
 // is idempotent: once a value is the mask string it stays the mask string.
-func k8sSecretData(s string) string {
+func k8sSecretData(s string) (string, []string) {
 	if !strings.Contains(s, "kind:") {
-		return s
+		return s, nil
 	}
 	// Preserve a trailing-newline / no-trailing-newline shape exactly.
 	lines := strings.Split(s, "\n")
@@ -123,6 +133,8 @@ func k8sSecretData(s string) string {
 	inSecret := false    // current YAML document is a kind: Secret
 	inDataBlock := false // currently inside that Secret's data:/stringData: block
 	dataIndent := 0      // indent (in columns) of the data: key
+	stringData := false  // the current block is stringData: (plaintext values)
+	var learned []string // secret literals to scrub payload-wide
 
 	for i, raw := range lines {
 		m := diffPrefixRE.FindStringSubmatch(raw)
@@ -162,6 +174,7 @@ func k8sSecretData(s string) string {
 				if entry := dataEntryRE.FindStringSubmatch(body); entry != nil {
 					val := strings.TrimRight(entry[3], " ")
 					if val != mask {
+						learned = append(learned, learnSecretValues(val, stringData)...)
 						lines[i] = prefix + entry[1] + entry[2] + mask
 					}
 				}
@@ -173,10 +186,60 @@ func k8sSecretData(s string) string {
 		if dk := dataKeyRE.FindStringSubmatch(body); dk != nil {
 			inDataBlock = true
 			dataIndent = leadingSpaces(dk[1])
+			stringData = dk[2] == "stringData"
 			continue
 		}
 	}
-	return strings.Join(lines, "\n")
+	return strings.Join(lines, "\n"), learned
+}
+
+// minLearnedSecretLen is the floor for payload-wide scrubbing of a learned
+// secret literal. Below it, the risk flips: masking every occurrence of a short
+// common value ("prod", "true") would blind the model to benign evidence, while
+// real secrets this short are rare. The block value itself is masked regardless.
+const minLearnedSecretLen = 6
+
+// learnSecretValues extracts the literals to scrub payload-wide from one
+// data-block value: the raw token (surrounding quotes stripped) and, for a
+// base64 `data:` value, its decoded plaintext. stringData values are plaintext
+// by definition — no decode step.
+func learnSecretValues(val string, stringData bool) []string {
+	tok := strings.Trim(val, `"'`)
+	if !stringData {
+		// data: values are single base64 tokens; drop anything after whitespace
+		// (a trailing YAML comment) so the decode sees only the blob.
+		if f := strings.Fields(tok); len(f) > 0 {
+			tok = strings.Trim(f[0], `"'`)
+		}
+	}
+	var out []string
+	if len(tok) >= minLearnedSecretLen && tok != mask {
+		out = append(out, tok)
+	}
+	if !stringData {
+		dec, err := base64.StdEncoding.DecodeString(tok)
+		if err != nil {
+			dec, err = base64.RawStdEncoding.DecodeString(tok)
+		}
+		if err == nil && len(dec) >= minLearnedSecretLen {
+			out = append(out, string(dec))
+		}
+	}
+	return out
+}
+
+// scrubLearned masks every occurrence of the learned secret literals in s.
+// Longest first, so a literal containing another is masked whole rather than
+// left as a recognizable fragment around an inner mask.
+func scrubLearned(s string, learned []string) string {
+	if len(learned) == 0 {
+		return s
+	}
+	sort.Slice(learned, func(i, j int) bool { return len(learned[i]) > len(learned[j]) })
+	for _, lit := range learned {
+		s = strings.ReplaceAll(s, lit, mask)
+	}
+	return s
 }
 
 // leadingSpaces counts leading space/tab characters (column-ish indent). Tabs

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -3,6 +3,7 @@
 package redact
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 )
@@ -51,6 +52,64 @@ func TestSecretsMasks(t *testing.T) {
 				t.Fatalf("not idempotent: %q -> %q", out, again)
 			}
 		})
+	}
+}
+
+// A Secret's data: values are KNOWN secrets — masking them in the block is not
+// enough (REDACT-B64): the same material elsewhere in the payload, decoded in a
+// log line or base64-encoded in an event, must be scrubbed too. This is the
+// tractable half of the disclosed "never decodes base64" gap: with the manifest
+// in the payload, we have ground truth and can scrub with full precision.
+func TestSecretsKnownSecretScrubbedPayloadWide(t *testing.T) {
+	plain := "hunter2-stallion"
+	blob := base64.StdEncoding.EncodeToString([]byte(plain))
+	in := "kind: Secret\nmetadata:\n  name: db\ndata:\n  pw: " + blob + "\n  quoted: \"" + blob + "\"\n---\n" +
+		"log line: login failed for " + plain + " on db-0\n" +
+		"event: mounted value " + blob + " into pod\n"
+	out := Secrets(in)
+	if strings.Contains(out, plain) {
+		t.Fatalf("decoded data: value survived elsewhere in the payload:\n%s", out)
+	}
+	if strings.Contains(out, blob) {
+		t.Fatalf("base64 data: value survived elsewhere in the payload:\n%s", out)
+	}
+	for _, keep := range []string{"login failed for", "on db-0", "mounted value", "into pod"} {
+		if !strings.Contains(out, keep) {
+			t.Fatalf("structure %q should survive, got:\n%s", keep, out)
+		}
+	}
+	if again := Secrets(out); again != out {
+		t.Fatalf("not idempotent:\n%s\n->\n%s", out, again)
+	}
+}
+
+// stringData: values are plaintext secrets by position — the same payload-wide
+// scrub applies without a decode step.
+func TestSecretsStringDataValueScrubbedPayloadWide(t *testing.T) {
+	plain := "plaintext-cred-77"
+	in := "kind: Secret\nstringData:\n  cred: " + plain + "\n---\nmsg says " + plain + " was used\n"
+	out := Secrets(in)
+	if strings.Contains(out, plain) {
+		t.Fatalf("stringData value survived elsewhere in the payload:\n%s", out)
+	}
+	if !strings.Contains(out, "msg says") || !strings.Contains(out, "was used") {
+		t.Fatalf("structure should survive, got:\n%s", out)
+	}
+}
+
+// Precision guard: a decoded value shorter than the learning floor ("prod",
+// "true") is NOT scrubbed payload-wide — masking every occurrence of a short
+// common word would blind the model to benign evidence. The block value itself
+// is still masked.
+func TestSecretsShortDecodedValueNotScrubbedGlobally(t *testing.T) {
+	blob := base64.StdEncoding.EncodeToString([]byte("prod")) // cHJvZA==
+	in := "kind: Secret\ndata:\n  env: " + blob + "\n---\nnamespace prod is healthy\n"
+	out := Secrets(in)
+	if !strings.Contains(out, "env: [REDACTED]") {
+		t.Fatalf("block value must still be masked, got:\n%s", out)
+	}
+	if !strings.Contains(out, "namespace prod is healthy") {
+		t.Fatalf("short decoded value must not be scrubbed globally, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
Closes the REDACT-B64 audit finding (2026-06-29). Details in the commit message; security docs updated to state the remaining lone-blob boundary precisely.