### PR TITLE
feat(catalog): content-hash embedding cache, chunked batches, loud degradation

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -82,6 +82,7 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_incident_resolution_seconds` | histogram | — | open→resolve duration |
 | `runlore_curations_total` | counter | `kind`, `result` | curation outcomes (`opened`/`coalesced`/`error`) |
 | `runlore_curation_dedup_score` | histogram | — | catalog top-hit BM25 score at the dedup decision |
+| `runlore_catalog_embed_degraded_total` | counter | — | catalog reloads that left hybrid recall without vectors (embed failure — recall degrades to BM25-only until the next successful sync) |
 
 ## Grafana dashboard
 

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -50,6 +50,7 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			dir = "/var/lib/runlore/catalog"
 		}
 		cat := catalog.NewEmpty()
+		cat.Log = log
 		if embedder != nil {
 			cat.SetEmbedder(embedder)
 		}
@@ -75,6 +76,11 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 				log.Warn("catalog entries skipped (unparseable)", "count", len(skipped), "files", skipped)
 			}
 			log.Info("catalog synced", "url", cfg.Catalog.Git.URL, "entries", cat.Len())
+			if embedder != nil && !cat.HasVectors() {
+				if metrics != nil {
+					metrics.CatalogEmbedDegraded.Add(ctx, 1)
+				}
+			}
 			warnInvalid(cat)
 			return nil
 		})
@@ -87,10 +93,16 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			// Embed on load: NewEmpty + SetEmbedder + ReloadContext (catalog.New can't
 			// attach an embedder before its internal Reload).
 			cat = catalog.NewEmpty()
+			cat.Log = log
 			cat.SetEmbedder(embedder)
 			if _, err := cat.ReloadContext(ctx, cfg.Catalog.Dir); err != nil {
 				log.Warn("catalog disabled", "dir", cfg.Catalog.Dir, "err", err)
 				return nil
+			}
+			if embedder != nil && !cat.HasVectors() {
+				if metrics != nil {
+					metrics.CatalogEmbedDegraded.Add(ctx, 1)
+				}
 			}
 		} else {
 			c, err := catalog.New(cfg.Catalog.Dir)

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -5,6 +5,7 @@ package catalog
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -26,6 +27,15 @@ type Catalog struct {
 	vectors  [][]float32
 	embedder Embedder
 	ready    atomic.Bool // set on first successful Reload; gates readyz on catalog warmth
+	// vecCache maps sha256(entryText) → embedding, carried ACROSS reloads so a KB
+	// sync only embeds entries whose text actually changed (RunLore merges its own
+	// PRs — without this, every merge re-embeds the whole corpus). Rebuilt from the
+	// current corpus on each successful embed pass so deleted entries are evicted.
+	// Guarded by mu.
+	vecCache map[string][]float32
+	// Log, when set (wiring time, before the first Reload), surfaces non-fatal
+	// reload degradations — an embed failure that leaves hybrid BM25-only. Nil-safe.
+	Log *slog.Logger
 }
 
 // Searcher is the read surface used by the kb_search tool.
@@ -78,15 +88,13 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	var vectors [][]float32
-	if c.embedder != nil {
-		if v, verr := embedEntries(ctx, c.embedder, entries); verr == nil {
-			vectors = v
-		}
-	}
+	vectors, cache := c.embedWithCache(ctx, entries)
 	c.mu.Lock()
 	old := c.index
 	c.index, c.entries, c.vectors = idx, entries, vectors
+	if cache != nil {
+		c.vecCache = cache
+	}
 	c.mu.Unlock()
 	// Release the previous index's resources. Search holds the read lock for the
 	// whole query, so by the time the swap above acquired the write lock no query

--- a/internal/catalog/hybrid.go
+++ b/internal/catalog/hybrid.go
@@ -4,6 +4,8 @@ package catalog
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strconv"
@@ -41,15 +43,55 @@ func (c *Catalog) HasVectors() bool {
 	return len(c.vectors) > 0 && len(c.vectors) == len(c.entries)
 }
 
-func embedEntries(ctx context.Context, e Embedder, entries []Entry) ([][]float32, error) {
-	if len(entries) == 0 {
+// embedWithCache returns one vector per entry plus the refreshed cache, reusing
+// cached vectors for unchanged texts and embedding only the missing subset (the
+// client already chunks oversized batches). The hybrid invariant is
+// ALL-OR-NOTHING — on any embed failure it returns (nil, previous cache):
+// vectors drop for this reload (HasVectors goes false, recall degrades to BM25 —
+// never a partial vector set that would silently exclude new entries from the
+// cosine ranking), while the surviving cache makes the next attempt embed only
+// what is still missing. nil embedder or empty corpus → (nil, nil).
+func (c *Catalog) embedWithCache(ctx context.Context, entries []Entry) ([][]float32, map[string][]float32) {
+	if c.embedder == nil || len(entries) == 0 {
 		return nil, nil
 	}
-	texts := make([]string, len(entries))
-	for i, en := range entries {
-		texts[i] = entryText(en)
+	c.mu.RLock()
+	prev := c.vecCache
+	c.mu.RUnlock()
+
+	keys := make([]string, len(entries))
+	vectors := make([][]float32, len(entries))
+	var missTexts []string
+	var missIdx []int
+	for i, e := range entries {
+		text := entryText(e)
+		sum := sha256.Sum256([]byte(text))
+		keys[i] = hex.EncodeToString(sum[:])
+		if v, ok := prev[keys[i]]; ok {
+			vectors[i] = v
+			continue
+		}
+		missTexts = append(missTexts, text)
+		missIdx = append(missIdx, i)
 	}
-	return e.Embed(ctx, texts)
+	if len(missTexts) > 0 {
+		vecs, err := c.embedder.Embed(ctx, missTexts)
+		if err != nil {
+			if c.Log != nil {
+				c.Log.Warn("catalog embed failed; hybrid recall degrades to BM25-only until the next successful sync",
+					"missing", len(missTexts), "entries", len(entries), "err", err)
+			}
+			return nil, prev
+		}
+		for j, v := range vecs {
+			vectors[missIdx[j]] = v
+		}
+	}
+	cache := make(map[string][]float32, len(entries))
+	for i, k := range keys {
+		cache[k] = vectors[i]
+	}
+	return vectors, cache
 }
 
 // SearchHybrid combines lexical and semantic retrieval for instant recall. It pools

--- a/internal/catalog/hybrid_test.go
+++ b/internal/catalog/hybrid_test.go
@@ -4,7 +4,10 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -80,6 +83,95 @@ func TestSearchHybridFallsBackWithoutEmbedder(t *testing.T) {
 	}
 	if len(hits) == 0 || !strings.Contains(hits[0].Entry.Title, "Network") {
 		t.Fatalf("BM25 fallback should surface the Network entry, got %+v", hits)
+	}
+}
+
+// countingEmbedder records every Embed call so tests can assert exactly which
+// texts were sent (the cache's whole point: unchanged entries are never re-sent).
+type countingEmbedder struct {
+	calls [][]string
+	fail  bool
+}
+
+func (f *countingEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	f.calls = append(f.calls, append([]string(nil), texts...))
+	if f.fail {
+		return nil, errors.New("embed boom")
+	}
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{float32(len(texts[i])), 1}
+	}
+	return out, nil
+}
+
+func writeHybridEntry(t *testing.T, dir, name, title, body string) {
+	t.Helper()
+	md := "---\ntype: Incident\ntitle: " + title + "\ndescription: d\nresource: ns/app\n---\n\n" + body + "\n"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(md), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReloadEmbedsOnlyChangedEntries: reload #1 embeds the full corpus; editing
+// ONE entry and reloading embeds exactly that one; an unchanged reload embeds
+// nothing. Deleted entries are evicted from the cache.
+func TestReloadEmbedsOnlyChangedEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeHybridEntry(t, dir, "a.md", "Alpha incident", "alpha body")
+	writeHybridEntry(t, dir, "b.md", "Beta incident", "beta body")
+
+	emb := &countingEmbedder{}
+	c := NewEmpty()
+	c.SetEmbedder(emb)
+
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if len(emb.calls) != 1 || len(emb.calls[0]) != 2 {
+		t.Fatalf("first reload: calls=%v, want one call with 2 texts", emb.calls)
+	}
+	if !c.HasVectors() {
+		t.Fatal("first reload: HasVectors=false, want true")
+	}
+
+	// Edit ONE entry → only its text is re-embedded.
+	writeHybridEntry(t, dir, "b.md", "Beta incident", "beta body EDITED")
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if len(emb.calls) != 2 || len(emb.calls[1]) != 1 {
+		t.Fatalf("edited reload: calls=%v, want second call with exactly 1 text", emb.calls)
+	}
+	if !strings.Contains(emb.calls[1][0], "EDITED") {
+		t.Fatalf("edited reload embedded the wrong text: %q", emb.calls[1][0])
+	}
+	if !c.HasVectors() {
+		t.Fatal("edited reload: HasVectors=false, want true")
+	}
+
+	// Unchanged reload → zero embed traffic.
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if len(emb.calls) != 2 {
+		t.Fatalf("unchanged reload: calls=%d, want 2 (no new embed call)", len(emb.calls))
+	}
+
+	// Delete an entry → cache must not pin it forever: re-adding it later re-embeds.
+	if err := os.Remove(filepath.Join(dir, "a.md")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	writeHybridEntry(t, dir, "a.md", "Alpha incident", "alpha body")
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	last := emb.calls[len(emb.calls)-1]
+	if len(last) != 1 || !strings.Contains(last[0], "alpha") {
+		t.Fatalf("re-added entry not re-embedded after eviction: %v", emb.calls)
 	}
 }
 

--- a/internal/catalog/hybrid_test.go
+++ b/internal/catalog/hybrid_test.go
@@ -3,9 +3,11 @@
 package catalog
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -172,6 +174,53 @@ func TestReloadEmbedsOnlyChangedEntries(t *testing.T) {
 	last := emb.calls[len(emb.calls)-1]
 	if len(last) != 1 || !strings.Contains(last[0], "alpha") {
 		t.Fatalf("re-added entry not re-embedded after eviction: %v", emb.calls)
+	}
+}
+
+// TestReloadEmbedFailureKeepsCacheAndWarns pins the failure contract: a failed
+// embed drops vectors (all-or-nothing → BM25-only), logs a WARN, KEEPS the cache
+// from prior successful reloads, and the retry embeds only the missing subset.
+func TestReloadEmbedFailureKeepsCacheAndWarns(t *testing.T) {
+	dir := t.TempDir()
+	writeHybridEntry(t, dir, "a.md", "Alpha incident", "alpha body")
+
+	emb := &countingEmbedder{}
+	var logBuf bytes.Buffer
+	c := NewEmpty()
+	c.SetEmbedder(emb)
+	c.Log = slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if !c.HasVectors() {
+		t.Fatal("setup: HasVectors=false after successful reload")
+	}
+
+	// Add a new entry, then fail its embed.
+	writeHybridEntry(t, dir, "b.md", "Beta incident", "beta body")
+	emb.fail = true
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatalf("reload must stay non-fatal on embed failure: %v", err)
+	}
+	if c.HasVectors() {
+		t.Fatal("failed embed: HasVectors=true, want false (all-or-nothing)")
+	}
+	if !strings.Contains(logBuf.String(), "hybrid recall degrades to BM25-only") {
+		t.Fatalf("no WARN logged on embed failure; log=%q", logBuf.String())
+	}
+
+	// Retry succeeds and embeds ONLY the new entry — the cache survived the failure.
+	emb.fail = false
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	last := emb.calls[len(emb.calls)-1]
+	if len(last) != 1 || !strings.Contains(last[0], "beta") {
+		t.Fatalf("retry after failure re-embedded %d texts (%v), want only the missing 'beta' entry", len(last), last)
+	}
+	if !c.HasVectors() {
+		t.Fatal("retry: HasVectors=false, want true")
 	}
 }
 

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -58,11 +58,33 @@ type embedResponse struct {
 	} `json:"data"`
 }
 
+// maxEmbedBatch bounds the inputs per /embeddings request. Providers cap the
+// batch (OpenAI ~2048; many vLLM/Ollama deployments far less), and one oversized
+// request would fail the WHOLE corpus embed — chunking keeps a growing KB
+// embeddable and each request well under every common cap.
+const maxEmbedBatch = 256
+
 // Embed returns one vector per input text, in input order. Empty input → nil.
+// Large inputs are transparently split into maxEmbedBatch-sized requests; any
+// failing chunk fails the whole call (callers rely on all-or-nothing).
 func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
 	}
+	out := make([][]float32, 0, len(texts))
+	for start := 0; start < len(texts); start += maxEmbedBatch {
+		end := min(start+maxEmbedBatch, len(texts))
+		vecs, err := c.embedBatch(ctx, texts[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("inputs %d-%d: %w", start, end-1, err)
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+// embedBatch performs one bounded /embeddings request (the pre-chunking Embed body).
+func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	body, err := json.Marshal(embedRequest{Model: c.model, Input: texts})
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -8,7 +8,11 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -71,6 +75,103 @@ func TestEmbedNon2xxOmitsBody(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "502") || !strings.Contains(err.Error(), "req-9") {
 		t.Fatalf("error should carry status + request-id: %v", err)
+	}
+}
+
+// TestEmbedChunksLargeBatches proves Embed splits oversized input into bounded
+// per-request batches while preserving input order across chunk boundaries.
+func TestEmbedChunksLargeBatches(t *testing.T) {
+	const n = 600 // 256 + 256 + 88
+	var mu sync.Mutex
+	var batchSizes []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode: %v", err)
+		}
+		mu.Lock()
+		batchSizes = append(batchSizes, len(req.Input))
+		mu.Unlock()
+		// Echo each input's numeric suffix back as its vector so the test can
+		// verify global ordering end-to-end ("t42" → [42]).
+		type datum struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		}
+		out := struct {
+			Data []datum `json:"data"`
+		}{}
+		for i, s := range req.Input {
+			v, err := strconv.Atoi(strings.TrimPrefix(s, "t"))
+			if err != nil {
+				t.Errorf("unexpected input %q", s)
+			}
+			out.Data = append(out.Data, datum{Index: i, Embedding: []float32{float32(v)}})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	defer srv.Close()
+
+	texts := make([]string, n)
+	for i := range texts {
+		texts[i] = "t" + strconv.Itoa(i)
+	}
+	c := New(srv.URL, "test-model", "")
+	got, err := c.Embed(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d vectors, want %d", len(got), n)
+	}
+	for i, v := range got {
+		if len(v) != 1 || v[0] != float32(i) {
+			t.Fatalf("vector %d = %v, want [%d] (order broken across chunks)", i, v, i)
+		}
+	}
+	wantSizes := []int{256, 256, 88}
+	if !slices.Equal(batchSizes, wantSizes) {
+		t.Fatalf("batch sizes = %v, want %v", batchSizes, wantSizes)
+	}
+}
+
+// TestEmbedChunkFailurePropagates proves a failure in a later chunk fails the
+// whole call (no partial result).
+func TestEmbedChunkFailurePropagates(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) > 1 { // first chunk OK, second chunk 500s
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		type datum struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		}
+		out := struct {
+			Data []datum `json:"data"`
+		}{}
+		for i := range req.Input {
+			out.Data = append(out.Data, datum{Index: i, Embedding: []float32{1}})
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	defer srv.Close()
+
+	texts := make([]string, 300) // 2 chunks
+	for i := range texts {
+		texts[i] = "x"
+	}
+	c := New(srv.URL, "test-model", "")
+	if _, err := c.Embed(context.Background(), texts); err == nil {
+		t.Fatal("want error when a chunk fails, got nil")
 	}
 }
 

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -64,6 +64,7 @@ type Metrics struct {
 	ModelCachedInputTokens  metric.Int64Counter     // input tokens served from cache (label: provider)
 	Curations               metric.Int64Counter     // curation outcomes (label: kind, result)
 	CatalogInvalidEntries   metric.Int64Counter     // structurally-invalid entries found at catalog load
+	CatalogEmbedDegraded    metric.Int64Counter     // catalog reloads that left hybrid recall without vectors (embed failure — recall silently BM25-only until it clears)
 }
 
 // NewMetrics builds the instrument set from the global meter provider.
@@ -126,6 +127,7 @@ func NewMetrics() *Metrics {
 		ModelCachedInputTokens:  ctr("model_cached_input_tokens_total", "LLM input tokens served from cache (label: provider)"),
 		Curations:               ctr("curations_total", "curation outcomes written to the forge (label: kind, result)"),
 		CatalogInvalidEntries:   ctr("catalog_invalid_entries_total", "structurally-invalid entries surfaced at catalog load"),
+		CatalogEmbedDegraded:    ctr("catalog_embed_degraded_total", "catalog reloads that left hybrid recall without vectors (embed failure)"),
 	}
 }
 


### PR DESCRIPTION
Implements roadmap item N2 from `dev/plans/2026-07-19-audit-roadmap.md`, per the implementation plan at `dev/superpowers/plans/2026-07-19-embed-cache-chunking.md`.

## What changed

- **Reloads now embed only changed entries.** `Catalog` carries a `vecCache` (`sha256(entryText)` → vector) across reloads: `ReloadContext` reuses cached vectors for unchanged entries and sends only the missing subset to the embedder. An unchanged git-sync reload produces zero embed traffic; editing one KB entry embeds exactly that one. The cache is rebuilt from the current corpus on each successful pass, so deleted entries are evicted.
- **The embed request is chunked.** `embed.Client.Embed` (public signature unchanged) now splits input into bounded batches of 256 per `/embeddings` request, preserving global input order; any failing chunk fails the whole call. One oversized request can no longer fail the entire corpus embed as the KB grows.
- **Embed failure is loud, not silent.** A failed embed pass now logs a WARN via the new nil-safe `Catalog.Log` (`hybrid recall degrades to BM25-only until the next successful sync`) and increments the new `runlore_catalog_embed_degraded_total` counter (wired in both the git-sync and static-dir paths). The cache survives the failure, so the retry embeds only what is still missing.

## Invariant preserved

`HasVectors()` stays **all-or-nothing**: one vector per entry or none. On embed failure the reload still swaps in the new index with vectors dropped (recall degrades to BM25-only) — never a partial vector set that would silently exclude new entries from the cosine ranking. BM25-only catalogs (no embedder) are byte-for-byte unaffected.

## Tests

- `TestEmbedChunksLargeBatches` / `TestEmbedChunkFailurePropagates` — batch sizes 256/256/88 for 600 inputs, order preserved across chunks, later-chunk failure propagates.
- `TestReloadEmbedsOnlyChangedEntries` — full corpus on first reload, exactly one text after a single edit, zero calls on an unchanged reload, eviction of deleted entries.
- `TestReloadEmbedFailureKeepsCacheAndWarns` — pins the failure contract: `HasVectors()==false`, WARN logged, cache survives, retry embeds only the missing entry.

Full gate green: `go build ./... && go vet ./... && go test ./...`, `gofmt -l .` empty, `golangci-lint run ./...` → `0 issues.`, `go test -race` on embed/catalog/telemetry/app.