### PR TITLE
feat(recall): runner-up fallback past a low_outcome winner

### DIFF
--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -449,6 +449,14 @@ at Gate 3, triggers a fresh investigation, and can be **overturned** by a correc
 entry. Decay is **outcome/contradiction-driven, never pure mtime** — knowledge ages
 out because it stops working, not merely because it's old.
 
+A `low_outcome` rejection does not abandon recall outright: the gate walks a small,
+bounded set of further structurally-agreeing candidates (the runner-up fallback) —
+each held to the conservative solo bar (or, with the reranker, chosen by one final
+re-rank call over the remaining candidates) and to the same outcome gate. Only when
+every candidate is decayed does recall fall through to a full investigation, and the
+rejected entries are also excluded from the near-miss lead, so a decayed entry can
+neither answer nor steer the fresh investigation that replaces it.
+
 This is the answer to the hardest objection against KB-backed agents ("what happens
 when a confidently-worded wrong belief gets in?"): the loop has a mechanism to lose
 trust in it and overturn it.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -605,7 +605,7 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	}
 	// Thread verifyTotals so the (opt-in) reranker's tokens fold into the
 	// per-investigation cost — it runs on the verify tier, so it prices there.
-	entry, conf := li.Recall.lookupWithUsage(ctx, req, verifyTotals)
+	entry, conf, _ := li.Recall.lookupWithUsage(ctx, req, verifyTotals)
 	if entry == nil {
 		// Recall was consulted but no gate cleared: report the non-fire so a caller
 		// can distinguish it from a recall that fired and was later withdrawn.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -605,7 +605,7 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	}
 	// Thread verifyTotals so the (opt-in) reranker's tokens fold into the
 	// per-investigation cost — it runs on the verify tier, so it prices there.
-	entry, conf, _ := li.Recall.lookupWithUsage(ctx, req, verifyTotals)
+	entry, conf, outcomeRejected := li.Recall.lookupWithUsage(ctx, req, verifyTotals)
 	if entry == nil {
 		// Recall was consulted but no gate cleared: report the non-fire so a caller
 		// can distinguish it from a recall that fired and was later withdrawn.
@@ -616,8 +616,10 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 		// UNVERIFIED lead in the seed (below) instead of throwing away the exact
 		// vocabulary-match recall's enrichment found. Untrusted like alert text (same
 		// egress/ingress redaction) and, being inside this !IsAuto() block, disabled
-		// under auto exactly like instant recall.
-		nearMiss = li.Recall.nearMiss(ctx, req)
+		// under auto exactly like instant recall. Every path the outcome gate just
+		// rejected is excluded — a decayed entry must not resurface as a
+		// "possibly-related lead".
+		nearMiss = li.Recall.nearMissExcluding(ctx, req, outcomeRejected...)
 		if nearMiss != nil {
 			li.Log.Info("recall near-miss: surfacing an unverified related entry in the seed",
 				"title", req.Title, "entry", nearMiss.Path)
@@ -679,7 +681,7 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	// WRONG entry suppresses the lead that a merely-weak one would have surfaced, so
 	// the loop restarts from zero next to a catalog that may still hold something
 	// relevant. The refuted entry itself is excluded — verify just disproved it.
-	nearMiss = li.Recall.nearMissExcluding(ctx, req, entry.Path)
+	nearMiss = li.Recall.nearMissExcluding(ctx, req, append(outcomeRejected, entry.Path)...)
 	if nearMiss != nil {
 		li.Log.Info("recall near-miss after verify rejection: surfacing an unverified related entry in the seed",
 			"title", req.Title, "rejected", entry.Path, "entry", nearMiss.Path)

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/Smana/runlore/internal/catalog"
@@ -280,11 +281,41 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 // argument justified only the original winner, so a skipped-winner candidate gets
 // the same bar as a lone hit. Candidates arrive in lexical order, so the first one
 // below the bar ends the walk.
-func (r *Recall) outcomeFallback(ctx context.Context, req Request, agreeing []catalog.ScoredEntry, counts map[string]outcome.Aggregate, minScore, soloFloor float64, _ *providers.UsageTotals, rejected []string) (*catalog.Entry, float64, []string) {
+func (r *Recall) outcomeFallback(ctx context.Context, req Request, agreeing []catalog.ScoredEntry, counts map[string]outcome.Aggregate, minScore, soloFloor float64, totals *providers.UsageTotals, rejected []string) (*catalog.Entry, float64, []string) {
 	if r.Rerank != nil {
-		// Task 3 (reranker fallback) replaces this: without it, reranker mode keeps
-		// today's behavior — rejection falls through with no fallback.
-		return nil, 0, rejected
+		// The rank verdict names ONE candidate, so a fallback needs a second — and
+		// FINAL — rank call over the remaining candidates. Bounded by construction:
+		// low_outcome rejections are rare and each call is ~1-2k tokens on the
+		// verify tier. The same cost guard as the first call applies.
+		remaining := make([]catalog.ScoredEntry, 0, len(agreeing))
+		for _, cand := range agreeing {
+			if !slices.Contains(rejected, cand.Entry.Path) {
+				remaining = append(remaining, cand)
+			}
+		}
+		if len(remaining) == 0 || remaining[0].Score < r.Rerank.MinScore {
+			return nil, 0, rejected
+		}
+		k := r.Rerank.K
+		if k <= 0 || k > len(remaining) {
+			k = len(remaining)
+		}
+		matched, mconf, ok := r.Rerank.rank(ctx, req, remaining[:k], totals)
+		if !ok || mconf < r.Rerank.Threshold {
+			r.reject(ctx, "rerank_low_confidence")
+			return nil, 0, rejected
+		}
+		f, ok := r.outcomeGate(counts, matched.Path)
+		if !ok {
+			r.reject(ctx, "low_outcome")
+			return nil, 0, append(rejected, matched.Path)
+		}
+		conf := clampF(clampF(mconf, 0, 0.90)*f, 0, 0.90)
+		if r.Log != nil {
+			r.Log.Info("instant recall runner-up fired after outcome rejection (re-rank)",
+				"alert", req.Title, "entry_id", matched.Path, "rejected", rejected, "confidence", conf)
+		}
+		return &matched, conf, rejected
 	}
 	limit := min(len(agreeing), 1+maxOutcomeFallback)
 	for _, cand := range agreeing[1:limit] {

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -355,14 +355,16 @@ func (r *Recall) outcomeFallback(ctx context.Context, req Request, agreeing []ca
 // text, and (like instant recall) is gated off under actions.mode=auto by the
 // caller. nil-safe; nil ⇒ no agreeing candidate (nothing to inject).
 func (r *Recall) nearMiss(ctx context.Context, req Request) *catalog.Entry {
-	return r.nearMissExcluding(ctx, req, "")
+	return r.nearMissExcluding(ctx, req)
 }
 
-// nearMissExcluding is nearMiss with one entry skipped by path. The verify-rejection
-// path passes the entry verify has just refuted against live state: re-offering it as
-// a "possibly-related lead" would hand the model the very hypothesis that was proven
-// wrong. Every other candidate remains eligible.
-func (r *Recall) nearMissExcluding(ctx context.Context, req Request, exclude string) *catalog.Entry {
+// nearMissExcluding is nearMiss with entries skipped by path. The verify-rejection
+// path passes the entry verify has just refuted against live state — re-offering it
+// as a "possibly-related lead" would hand the model the very hypothesis that was
+// proven wrong — AND every path the outcome-decay gate (Gate 3) rejected this lookup:
+// a decayed entry must not resurface as a lead either. Every other candidate remains
+// eligible.
+func (r *Recall) nearMissExcluding(ctx context.Context, req Request, exclude ...string) *catalog.Entry {
 	if r == nil || r.Catalog == nil {
 		return nil
 	}
@@ -377,8 +379,14 @@ func (r *Recall) nearMissExcluding(ctx context.Context, req Request, exclude str
 	if err != nil || len(hits) == 0 {
 		return nil
 	}
+	skip := make(map[string]bool, len(exclude))
+	for _, p := range exclude {
+		if p != "" {
+			skip[p] = true
+		}
+	}
 	for _, h := range hits {
-		if exclude != "" && h.Entry.Path == exclude {
+		if skip[h.Entry.Path] {
 			continue
 		}
 		if nearMissEntryAgrees(req.Workload, h.Entry, r.RequireWorkloadMatch) != matchNone {

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -68,6 +68,12 @@ type Recall struct {
 // text alone.
 const recallCandidateK = 20
 
+// maxOutcomeFallback bounds how many ADDITIONAL structurally-agreeing candidates
+// the outcome-decay gate may consider after rejecting the winner (magnitude mode).
+// Small and fixed: each fallback candidate is held to the conservative solo bar,
+// so depth buys little beyond the first couple of runners-up.
+const maxOutcomeFallback = 2
+
 // buildRecallQuery constructs the BM25 query text for a recall lookup from a
 // Request. It is the single seam between "what the incident says" and "what the
 // lexical index is asked" — extracted so the retrieval quality can be measured
@@ -121,16 +127,19 @@ func buildRecallQuery(req Request) string {
 // thin wrapper over lookupWithUsage with no usage sink — kept for callers (and tests)
 // that don't thread the per-investigation token total.
 func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float64) {
-	return r.lookupWithUsage(ctx, req, nil)
+	e, conf, _ := r.lookupWithUsage(ctx, req, nil)
+	return e, conf
 }
 
 // lookupWithUsage is lookup plus an optional usage sink: when a Reranker runs, its
 // completion's token usage is accumulated into totals (nil ⇒ ignored) so the loop can
 // fold the reranker's cost into the per-investigation total. The gate logic is
-// identical to lookup — totals is a side channel, never a decision input.
-func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *providers.UsageTotals) (*catalog.Entry, float64) {
+// identical to lookup — totals is a side channel, never a decision input. The third
+// return lists the entry paths the outcome gate (Gate 3) rejected this lookup (nil
+// when none) so the caller's near-miss lead can exclude them.
+func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *providers.UsageTotals) (*catalog.Entry, float64, []string) {
 	if r == nil || r.Catalog == nil {
-		return nil, 0
+		return nil, 0, nil
 	}
 	query := buildRecallQuery(req)
 	// Mode select: hybrid (BM25+embedding, cosine-gated) when an embedder-backed
@@ -146,7 +155,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 		hits, err = r.Catalog.SearchScored(query, recallCandidateK)
 	}
 	if err != nil || len(hits) == 0 {
-		return nil, 0
+		return nil, 0, nil
 	}
 
 	// Structural pre-filter: keep candidates whose stored resource agrees with the
@@ -164,7 +173,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 			r.Metrics.RecallScore.Record(ctx, hits[0].Score) // best lexical score, for miss visibility
 		}
 		r.reject(ctx, "no_resource_match")
-		return nil, 0
+		return nil, 0, nil
 	}
 
 	winner := agreeing[0]
@@ -188,7 +197,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 		// investigation WITHOUT making the call (asserted by the cost-guard test).
 		if score < r.Rerank.MinScore {
 			r.reject(ctx, "rerank_no_signal")
-			return nil, 0
+			return nil, 0, nil
 		}
 		// Rank only the top-K structurally-agreeing candidates (bounded for cost). They
 		// are already in lexical order, so agreeing[:k] is the strongest few.
@@ -202,7 +211,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 		// the false-recall guard (a wrong or absent match is worse than no recall).
 		if !ok || mconf < r.Rerank.Threshold {
 			r.reject(ctx, "rerank_low_confidence")
-			return nil, 0
+			return nil, 0, nil
 		}
 		e = matched
 		// The reranker's confidence IS a calibrated match confidence — use it directly as
@@ -228,31 +237,77 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 		}
 		if !confident {
 			r.reject(ctx, "low_margin")
-			return nil, 0
+			return nil, 0, nil
 		}
 		e = winner.Entry
 		conf = deriveRecallConfidence(score, margin, strength)
 	}
-	// Outcome decay: bias confidence by the entry's resolution track record, and
-	// reject (re-investigate) an entry that recalls-but-never-resolves. Fail-safe —
-	// a rejected recall just falls through to a full investigation.
+	// Outcome decay (Gate 3), with a bounded runner-up fallback: a decayed winner
+	// must not disable instant recall while a healthy corrected entry sits right
+	// behind it. The winner is gated exactly as before; on a low_outcome rejection
+	// the fallback (outcomeFallback) considers a few further candidates under the
+	// SAME gate. The third return lists every outcome-rejected path so the caller's
+	// near-miss lead can exclude them — an entry the gate just rejected must not
+	// resurface as a "possibly-related lead".
 	if r.Outcome != nil {
-		if counts, err := r.Outcome.OpenCounts(); err == nil {
+		counts, cerr := r.Outcome.OpenCounts()
+		if cerr != nil {
+			if r.Log != nil {
+				r.Log.Warn("recall: outcome stats unavailable; skipping decay", "err", cerr)
+			}
+		} else {
 			f, ok := r.outcomeGate(counts, e.Path)
 			if !ok {
 				r.reject(ctx, "low_outcome")
-				return nil, 0
+				return r.outcomeFallback(ctx, req, agreeing, counts, minScore, soloFloor, totals, []string{e.Path})
 			}
 			conf = clampF(conf*f, 0, 0.90)
-		} else if r.Log != nil {
-			r.Log.Warn("recall: outcome stats unavailable; skipping decay", "err", err)
 		}
 	}
 	if r.Log != nil {
 		r.Log.Info("instant recall decision",
 			"alert", req.Title, "entry_id", e.Path, "score", score, "margin", margin, "confidence", conf)
 	}
-	return &e, conf
+	return &e, conf, nil
+}
+
+// outcomeFallback runs after the fire-gate winner was rejected by outcome decay
+// (Gate 3). It considers a BOUNDED number of further structurally-agreeing
+// candidates, each subject to the same outcome gate, and returns the first healthy
+// one — or (nil, 0, rejected) so the caller falls through to a full investigation
+// with the rejected paths reported. Magnitude mode holds every fallback candidate
+// to the CONSERVATIVE solo bar (soloFloor AND minScore): the margin-over-runner-up
+// argument justified only the original winner, so a skipped-winner candidate gets
+// the same bar as a lone hit. Candidates arrive in lexical order, so the first one
+// below the bar ends the walk.
+func (r *Recall) outcomeFallback(ctx context.Context, req Request, agreeing []catalog.ScoredEntry, counts map[string]outcome.Aggregate, minScore, soloFloor float64, _ *providers.UsageTotals, rejected []string) (*catalog.Entry, float64, []string) {
+	if r.Rerank != nil {
+		// Task 3 (reranker fallback) replaces this: without it, reranker mode keeps
+		// today's behavior — rejection falls through with no fallback.
+		return nil, 0, rejected
+	}
+	limit := min(len(agreeing), 1+maxOutcomeFallback)
+	for _, cand := range agreeing[1:limit] {
+		if cand.Score < soloFloor || cand.Score < minScore {
+			break // lexical order: nothing further clears the conservative bar
+		}
+		f, ok := r.outcomeGate(counts, cand.Entry.Path)
+		if !ok {
+			r.reject(ctx, "low_outcome")
+			rejected = append(rejected, cand.Entry.Path)
+			continue
+		}
+		strength := entryAgrees(req.Workload, cand.Entry, r.RequireWorkloadMatch)
+		// margin 0: a fallback candidate gets no decisive-winner bonus.
+		conf := clampF(deriveRecallConfidence(cand.Score, 0, strength)*f, 0, 0.90)
+		if r.Log != nil {
+			r.Log.Info("instant recall runner-up fired after outcome rejection",
+				"alert", req.Title, "entry_id", cand.Entry.Path, "rejected", rejected, "confidence", conf)
+		}
+		e := cand.Entry
+		return &e, conf, rejected
+	}
+	return nil, 0, rejected
 }
 
 // nearMiss returns the top STRUCTURALLY-AGREEING candidate for a request, or nil.

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -238,14 +238,12 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 	// a rejected recall just falls through to a full investigation.
 	if r.Outcome != nil {
 		if counts, err := r.Outcome.OpenCounts(); err == nil {
-			if agg, ok := counts[e.Path]; ok { // only entries with recall or feedback history
-				f := outcomeFactor(agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, r.OutcomePrior)
-				if f < r.OutcomeFloor {
-					r.reject(ctx, "low_outcome")
-					return nil, 0
-				}
-				conf = clampF(conf*f, 0, 0.90)
+			f, ok := r.outcomeGate(counts, e.Path)
+			if !ok {
+				r.reject(ctx, "low_outcome")
+				return nil, 0
 			}
+			conf = clampF(conf*f, 0, 0.90)
 		} else if r.Log != nil {
 			r.Log.Warn("recall: outcome stats unavailable; skipping decay", "err", err)
 		}
@@ -471,6 +469,21 @@ func clampF(v, lo, hi float64) float64 {
 		return hi
 	}
 	return v
+}
+
+// outcomeGate applies outcome decay (Gate 3) to ONE candidate entry, given the
+// OpenCounts snapshot the caller fetched once per lookup. It returns the decay
+// factor to multiply into the recall confidence, and ok=false when the entry's
+// track record falls below OutcomeFloor (the caller must not fire this entry).
+// Fail-safe: an entry with no recall/feedback history returns (1, true) —
+// absence of evidence never blocks a recall.
+func (r *Recall) outcomeGate(counts map[string]outcome.Aggregate, path string) (float64, bool) {
+	agg, ok := counts[path]
+	if !ok {
+		return 1, true
+	}
+	f := outcomeFactor(agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, r.OutcomePrior)
+	return f, f >= r.OutcomeFloor
 }
 
 // outcomeFactor decays a recall's confidence by its track record as the posterior

--- a/internal/investigate/recall_fallback_test.go
+++ b/internal/investigate/recall_fallback_test.go
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// twoEntryCatalog seeds two structurally-agreeing entries for apps/worker. The
+// "stale" entry repeats the query's symptom tokens so it outranks "fixed" on BM25
+// and is deterministically the winner; both clear the (low) fire thresholds.
+func twoEntryCatalog(t *testing.T) (*catalog.Catalog, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	stale := `---
+type: Incident
+title: worker OOMKilled memory limit drop OOMKilled memory
+description: apps/worker pods OOMKilled after memory limit drop
+resource: apps/worker
+---
+
+# Symptom
+apps/worker pods OOMKilled after a memory limit drop. OOMKilled memory limit drop.
+`
+	fixed := `---
+type: Incident
+title: worker OOMKilled corrected runbook
+description: raise the worker memory request and limit together
+resource: apps/worker
+---
+
+# Symptom
+apps/worker OOMKilled.
+`
+	for name, body := range map[string]string{"stale.md": stale, "fixed.md": fixed} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cat, err := catalog.New(dir)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	var stalePath, fixedPath string
+	for _, e := range cat.Entries() {
+		if e.Title == "worker OOMKilled corrected runbook" {
+			fixedPath = e.Path
+		} else {
+			stalePath = e.Path
+		}
+	}
+	return cat, stalePath, fixedPath
+}
+
+func fallbackReq() Request {
+	return Request{
+		Title:    "WorkerOOM",
+		Message:  "apps/worker pods OOMKilled after memory limit drop",
+		Workload: providers.Workload{Namespace: "apps", Name: "worker"},
+	}
+}
+
+func TestRunnerUpFiresWhenWinnerDecayed(t *testing.T) {
+	cat, stalePath, fixedPath := twoEntryCatalog(t)
+	r := &Recall{
+		Catalog: cat, MinScore: 0.001, SoloFloor: 0.001, MarginGap: 0.001,
+		Outcome: fakeOutcome{counts: map[string]outcome.Aggregate{
+			stalePath: {Recalls: 4, Resolved: 0}, // factor 1/6 < 0.5 → rejected
+			fixedPath: {Recalls: 3, Resolved: 3}, // healthy
+		}},
+		OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+	// Premise: the stale entry IS the winner (rejected first).
+	e, conf, rejected := r.lookupWithUsage(context.Background(), fallbackReq(), nil)
+	if e == nil {
+		t.Fatalf("runner-up must fire when the winner is outcome-rejected; got nil (rejected=%v)", rejected)
+	}
+	if e.Path != fixedPath {
+		t.Fatalf("fired %q, want the healthy runner-up %q", e.Path, fixedPath)
+	}
+	if conf <= 0 || conf > 0.90 {
+		t.Fatalf("runner-up confidence %v out of (0, 0.90]", conf)
+	}
+	if len(rejected) != 1 || rejected[0] != stalePath {
+		t.Fatalf("rejected paths = %v, want exactly the decayed winner %q", rejected, stalePath)
+	}
+}
+
+func TestRunnerUpMustClearConservativeSoloBar(t *testing.T) {
+	cat, stalePath, fixedPath := twoEntryCatalog(t)
+	// Solo floor set between the two BM25 scores: the winner clears it, the
+	// runner-up does not → the fallback must NOT fire the runner-up.
+	winnerScore, runnerScore := twoScores(t, cat, stalePath, fixedPath)
+	r := &Recall{
+		Catalog: cat, MinScore: 0.001, MarginGap: 0.001,
+		SoloFloor: (winnerScore + runnerScore) / 2,
+		Outcome: fakeOutcome{counts: map[string]outcome.Aggregate{
+			stalePath: {Recalls: 4, Resolved: 0},
+		}},
+		OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+	e, _, rejected := r.lookupWithUsage(context.Background(), fallbackReq(), nil)
+	if e != nil {
+		t.Fatalf("runner-up below the solo bar must not fire, got %q", e.Path)
+	}
+	if len(rejected) != 1 || rejected[0] != stalePath {
+		t.Fatalf("rejected = %v, want [%q]", rejected, stalePath)
+	}
+}
+
+func TestAllCandidatesDecayedReturnsAllRejected(t *testing.T) {
+	cat, stalePath, fixedPath := twoEntryCatalog(t)
+	r := &Recall{
+		Catalog: cat, MinScore: 0.001, SoloFloor: 0.001, MarginGap: 0.001,
+		Outcome: fakeOutcome{counts: map[string]outcome.Aggregate{
+			stalePath: {Recalls: 4, Resolved: 0},
+			fixedPath: {Recalls: 4, Resolved: 0},
+		}},
+		OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+	e, _, rejected := r.lookupWithUsage(context.Background(), fallbackReq(), nil)
+	if e != nil {
+		t.Fatalf("no candidate is healthy; recall must fall through, got %q", e.Path)
+	}
+	if len(rejected) != 2 {
+		t.Fatalf("both decayed candidates must be reported, got %v", rejected)
+	}
+}
+
+// twoScores returns the BM25 scores of the two seeded entries for the fixture
+// query, so thresholds can be pinned between them without hardcoding corpus-
+// dependent magnitudes.
+func twoScores(t *testing.T, cat *catalog.Catalog, stalePath, fixedPath string) (winner, runner float64) {
+	t.Helper()
+	hits, err := cat.SearchScored(buildRecallQuery(fallbackReq()), recallCandidateK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, h := range hits {
+		switch h.Entry.Path {
+		case stalePath:
+			winner = h.Score
+		case fixedPath:
+			runner = h.Score
+		}
+	}
+	if winner <= runner {
+		t.Fatalf("fixture premise broken: stale (winner) score %v must exceed fixed (runner-up) %v", winner, runner)
+	}
+	return winner, runner
+}

--- a/internal/investigate/recall_fallback_test.go
+++ b/internal/investigate/recall_fallback_test.go
@@ -134,6 +134,79 @@ func TestAllCandidatesDecayedReturnsAllRejected(t *testing.T) {
 	}
 }
 
+// scriptedRerankModel returns each queued rerank_match verdict in order and
+// counts calls — the fallback contract is "at most ONE extra rank call".
+type scriptedRerankModel struct {
+	calls    int
+	verdicts []string // raw rerank_match JSON args, consumed in order
+}
+
+func (m *scriptedRerankModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	i := m.calls
+	m.calls++
+	if i >= len(m.verdicts) {
+		return providers.CompletionResponse{}, nil // no tool call ⇒ no match
+	}
+	return providers.CompletionResponse{ToolCalls: []providers.ToolCall{{Name: rerankToolName, Args: m.verdicts[i]}}}, nil
+}
+
+func TestRerankFallbackReranksOnceWithoutRejected(t *testing.T) {
+	cat, stalePath, fixedPath := twoEntryCatalog(t)
+	model := &scriptedRerankModel{verdicts: []string{
+		`{"match":true,"entry_id":"` + stalePath + `","confidence":0.9}`,
+		`{"match":true,"entry_id":"` + fixedPath + `","confidence":0.85}`,
+	}}
+	r := &Recall{
+		Catalog: cat,
+		Rerank:  &Reranker{Model: model, Threshold: 0.7, K: 5, MinScore: 0.001},
+		Outcome: fakeOutcome{counts: map[string]outcome.Aggregate{
+			stalePath: {Recalls: 4, Resolved: 0},
+			fixedPath: {Recalls: 3, Resolved: 3},
+		}},
+		OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+	e, conf, rejected := r.lookupWithUsage(context.Background(), fallbackReq(), nil)
+	if e == nil || e.Path != fixedPath {
+		t.Fatalf("re-rank fallback must fire the healthy candidate %q, got %+v (rejected=%v)", fixedPath, e, rejected)
+	}
+	if model.calls != 2 {
+		t.Fatalf("exactly one extra rank call allowed, model saw %d calls", model.calls)
+	}
+	if conf <= 0 || conf > 0.90 {
+		t.Fatalf("confidence %v out of (0, 0.90]", conf)
+	}
+	if len(rejected) != 1 || rejected[0] != stalePath {
+		t.Fatalf("rejected = %v, want [%q]", rejected, stalePath)
+	}
+}
+
+func TestRerankFallbackStopsAfterSecondRejection(t *testing.T) {
+	cat, stalePath, fixedPath := twoEntryCatalog(t)
+	model := &scriptedRerankModel{verdicts: []string{
+		`{"match":true,"entry_id":"` + stalePath + `","confidence":0.9}`,
+		`{"match":true,"entry_id":"` + fixedPath + `","confidence":0.85}`,
+	}}
+	r := &Recall{
+		Catalog: cat,
+		Rerank:  &Reranker{Model: model, Threshold: 0.7, K: 5, MinScore: 0.001},
+		Outcome: fakeOutcome{counts: map[string]outcome.Aggregate{
+			stalePath: {Recalls: 4, Resolved: 0},
+			fixedPath: {Recalls: 4, Resolved: 0}, // second match also decayed
+		}},
+		OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+	e, _, rejected := r.lookupWithUsage(context.Background(), fallbackReq(), nil)
+	if e != nil {
+		t.Fatalf("second outcome rejection must end the fallback (no third call), got %q", e.Path)
+	}
+	if model.calls != 2 {
+		t.Fatalf("bounded at 2 rank calls total, model saw %d", model.calls)
+	}
+	if len(rejected) != 2 {
+		t.Fatalf("both rejected paths must be reported, got %v", rejected)
+	}
+}
+
 // twoScores returns the BM25 scores of the two seeded entries for the fixture
 // query, so thresholds can be pinned between them without hardcoding corpus-
 // dependent magnitudes.

--- a/internal/investigate/recall_fallback_test.go
+++ b/internal/investigate/recall_fallback_test.go
@@ -207,6 +207,24 @@ func TestRerankFallbackStopsAfterSecondRejection(t *testing.T) {
 	}
 }
 
+func TestNearMissExcludesOutcomeRejectedPaths(t *testing.T) {
+	cat, stalePath, fixedPath := twoEntryCatalog(t)
+	r := &Recall{Catalog: cat, MinScore: 0.001, SoloFloor: 0.001, MarginGap: 0.001}
+
+	// Excluding the top candidate surfaces the next agreeing one…
+	if nm := r.nearMissExcluding(context.Background(), fallbackReq(), stalePath); nm == nil || nm.Path != fixedPath {
+		t.Fatalf("near-miss with winner excluded = %+v, want %q", nm, fixedPath)
+	}
+	// …and excluding both surfaces nothing.
+	if nm := r.nearMissExcluding(context.Background(), fallbackReq(), stalePath, fixedPath); nm != nil {
+		t.Fatalf("near-miss with all candidates excluded must be nil, got %q", nm.Path)
+	}
+	// Zero exclusions (the nearMiss() path) still returns the top candidate.
+	if nm := r.nearMissExcluding(context.Background(), fallbackReq()); nm == nil {
+		t.Fatal("near-miss with no exclusions must return the top agreeing candidate")
+	}
+}
+
 // twoScores returns the BM25 scores of the two seeded entries for the fixture
 // query, so thresholds can be pinned between them without hardcoding corpus-
 // dependent magnitudes.


### PR DESCRIPTION
## Summary

A decayed/poisoned top candidate no longer disables instant recall when a healthy, structurally-agreeing runner-up exists — and outcome-rejected paths are excluded from the near-miss lead, so a decayed entry can neither answer nor steer the fresh investigation that replaces it.

Implements roadmap item **N3** from `dev/plans/2026-07-19-audit-roadmap.md`, per the implementation plan `dev/superpowers/plans/2026-07-19-recall-runner-up.md`.

## What changed

- **`outcomeGate` helper** (`internal/investigate/recall.go`): the Gate-3 outcome-decay check is extracted into a per-candidate helper fed by one `OpenCounts()` snapshot, so the winner and every fallback candidate are held to the exact same gate.
- **Magnitude-mode runner-up fallback**: on a `low_outcome` rejection of the fire-gate winner, the gate walks up to `maxOutcomeFallback` (2) further structurally-agreeing candidates in lexical order. Each must clear the CONSERVATIVE solo bar (`solo_floor` AND `min_score` — the margin-over-runner-up argument justified only the original winner) and the same outcome gate. The first healthy one fires with no decisive-winner margin bonus.
- **Reranker-mode fallback**: the rank verdict names a single entry, so the fallback makes exactly ONE additional — and final — re-rank call over the remaining (non-rejected) candidates, subject to the same threshold, cost guard, and outcome gate. A second `low_outcome` rejection ends recall.
- **Near-miss exclusion**: `lookupWithUsage` now reports the outcome-rejected entry paths; `tryRecall` threads them into `nearMissExcluding` (now variadic) on both the non-fire and verify-rejection paths, so a rejected entry cannot resurface as a "possibly-related lead".
- **Docs**: one paragraph in the outcome-decay section of `docs/learning-loop.md`.

## Fail-safe invariants (unchanged)

- Every recall rejection still falls through to a full investigation; every terminal fallback path returns nil.
- No fallback path can fire an entry that fails the outcome gate.
- The fallback is bounded: at most 2 extra candidates (magnitude) / exactly 1 extra re-rank call (reranker).
- Metrics vocabulary only extends `recall_rejections_total` (`low_outcome` per rejected candidate); no new instruments.

## Testing

- New `internal/investigate/recall_fallback_test.go`: runner-up fires past a decayed winner; runner-up below the conservative solo bar does not fire; all-decayed falls through with every rejection reported; reranker fallback re-ranks exactly once without the rejected entry; a second rejection ends the fallback; near-miss exclusion (single, multiple, and zero exclusions).
- Full gate green: `go build`, `go vet`, `go test ./...`, `gofmt -l` (empty), `golangci-lint run` (0 issues), `go test -race ./internal/investigate/...`.