### PR TITLE
feat(server): investigation rate-limit default, payload cap, and auth backoff

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -152,7 +152,8 @@ config:
       #                         #   alertname or a standing 👎 on the trigger bypasses suppression)
       # correlation_labels: []  # group by label values instead of AM groupKey
     rate_limit:
-      max_per_window: 20        # cap investigations per window (window defaults to 1h); 0 = unlimited
+      max_per_window: 20        # cap investigations per window (window defaults to 1h);
+                                #   explicit 0 = unlimited; UNSET now defaults to 30
       # window: 1h
       # max_requeues: 3
     # recurrence_cooldown: 30m  # OPT-IN: skip re-investigating a trigger answered conclusively less

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,7 +109,7 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   on the trigger** (the feedback re-arm, see [learning-loop](learning-loop.md) — batched on the
   normal `debounce`, so a contested storm still collapses to one re-investigation). Suppressions log
   an INFO line and count in `runlore_alerts_suppressed_total`.
-- `rate_limit` — `max_per_window` (**0 = unlimited**), `window` (default **1h** when a budget is set),
+- `rate_limit` — `max_per_window` (**default 30**; an explicit **0 = unlimited**), `window` (default **1h**),
   `max_requeues`.
 - `recurrence_cooldown` — **opt-in (default 0 = off)** per-trigger suppression: skip re-investigating a
   trigger whose previous investigation completed less than this long ago, **concluded** (verdict ≠

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -115,6 +115,12 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
   webhook must not reach the LLM and bill the model) and also enforced by `config.Validate` under
   `actions.mode=auto`. It is warning-only for the model-less log-only investigator. Pair it with a
   restrictive NetworkPolicy.
+- **Failed-auth backoff.** Failed authentications on the control endpoints and the alert webhook are
+  rate-limited per remote host: after 10 consecutive failures the host is blocked for 1s, doubling up
+  to a 60s cap, and the block is checked before the token compare. A correct token always clears the
+  counter. Behind a shared NAT this can delay a legitimate caller for at most one block window during
+  a live attack. Tokens should be ≥128-bit random values (e.g. `openssl rand -hex 16`); the backoff
+  is a brake on weak tokens, not a substitute for a strong one.
 
 ## Tamper-evident audit log
 

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -183,11 +183,11 @@ func RunServe(version string, args []string) error {
 	}
 	queue := investigate.NewQueue(inv, log)
 	var rlStarts *ratelimit.Window
-	if rl := cfg.Investigation.RateLimit; rl.MaxPerWindow > 0 {
+	if rl := cfg.Investigation.RateLimit; rl.MaxPerWindow != nil && *rl.MaxPerWindow > 0 {
 		w := rl.Window.Std()
-		rlStarts = ratelimit.New(rl.MaxPerWindow, w)
+		rlStarts = ratelimit.New(*rl.MaxPerWindow, w)
 		log.Info("investigation rate limit configured",
-			"max_per_window", rl.MaxPerWindow, "window", w, "max_requeues", rl.MaxRequeues)
+			"max_per_window", *rl.MaxPerWindow, "window", w, "max_requeues", rl.MaxRequeues)
 	}
 	// Always wire metrics into the Queue so InvestigationsStarted emits even when
 	// rate-limiting is unconfigured (max_per_window == 0).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -348,7 +348,11 @@ type Coalesce struct {
 
 // RateLimit caps investigation starts per sliding window.
 type RateLimit struct {
-	MaxPerWindow int      `yaml:"max_per_window"` // 0 ⇒ unlimited
+	// MaxPerWindow caps investigation STARTS per Window. nil (unset) defaults to
+	// 30 (see applyDefaults) — a cost-DoS guard, since per-incident spend is
+	// bounded but the count of incidents was not. An EXPLICIT 0 preserves the
+	// pre-default unlimited behavior for configs that opted into it.
+	MaxPerWindow *int     `yaml:"max_per_window"`
 	Window       Duration `yaml:"window"`
 	MaxRequeues  int      `yaml:"max_requeues"` // drop a key after this many backoff requeues
 }
@@ -1011,6 +1015,12 @@ func (c *Config) Validate() error {
 		if err := validatePricing("model.verify.pricing", v.Pricing); err != nil {
 			return err
 		}
+	}
+	// Reject a negative rate-limit budget: applyDefaults fills an unset nil with 30,
+	// so only an explicit negative reaches here — fail loud rather than silently
+	// treating it as unlimited.
+	if mpw := c.Investigation.RateLimit.MaxPerWindow; mpw != nil && *mpw < 0 {
+		return fmt.Errorf("investigation.rate_limit.max_per_window must be >= 0 (0 = unlimited), got %d", *mpw)
 	}
 	// Reject a negative per-tool timeout: time.ParseDuration accepts negative values
 	// which silently disable the feature (fails the > 0 guard in runTool) rather than

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -32,7 +32,8 @@ func TestApplyDefaultsCoalesceEnabled(t *testing.T) {
 
 func TestApplyDefaultsRateLimitWindow(t *testing.T) {
 	var c Config
-	c.Investigation.RateLimit.MaxPerWindow = 10
+	n := 10
+	c.Investigation.RateLimit.MaxPerWindow = &n
 	applyDefaults(&c)
 	if c.Investigation.RateLimit.Window.Std() != time.Hour {
 		t.Fatalf("default Window: got %v, want 1h", c.Investigation.RateLimit.Window.Std())
@@ -270,8 +271,8 @@ telemetry:
 	if c.Investigation.Coalesce.Debounce.Std() != 30*time.Second {
 		t.Fatalf("debounce: got %v", c.Investigation.Coalesce.Debounce.Std())
 	}
-	if c.Investigation.RateLimit.MaxPerWindow != 20 {
-		t.Fatalf("max_per_window: got %d", c.Investigation.RateLimit.MaxPerWindow)
+	if c.Investigation.RateLimit.MaxPerWindow == nil || *c.Investigation.RateLimit.MaxPerWindow != 20 {
+		t.Fatalf("max_per_window: got %v", c.Investigation.RateLimit.MaxPerWindow)
 	}
 	if c.Investigation.RateLimit.MaxRequeues != 10 {
 		t.Fatalf("max_requeues: got %d", c.Investigation.RateLimit.MaxRequeues)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -86,9 +86,16 @@ func applyDefaults(c *Config) {
 		b := true
 		c.Triggers.Incidents.CancelQueuedOnResolve = &b
 	}
-	// Rate-limit window default: 1h when a per-window budget is set but no window
-	// is given (a zero window would silently allow unlimited investigations).
-	if c.Investigation.RateLimit.MaxPerWindow > 0 && c.Investigation.RateLimit.Window == 0 {
+	// Investigation rate limit: UNSET defaults to 30/h (cost-DoS guard — the count
+	// of investigations was unbounded out of the box; the Helm chart already ships
+	// an explicit 20). An explicit 0 keeps the documented unlimited meaning.
+	if c.Investigation.RateLimit.MaxPerWindow == nil {
+		n := 30
+		c.Investigation.RateLimit.MaxPerWindow = &n
+	}
+	// Rate-limit window default: 1h when a per-window budget is in effect but no
+	// window is given (a zero window would silently allow unlimited investigations).
+	if *c.Investigation.RateLimit.MaxPerWindow > 0 && c.Investigation.RateLimit.Window == 0 {
 		c.Investigation.RateLimit.Window = Duration(time.Hour)
 	}
 	// Per-investigation deadline: bound a whole investigation (recall + every model/

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -5,6 +5,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -311,5 +312,76 @@ triggers:
 	}
 	if c.Triggers.Incidents.Debounce.Std() != 5*time.Minute {
 		t.Fatalf("explicit debounce: got %v, want 5m", c.Triggers.Incidents.Debounce.Std())
+	}
+}
+
+// TestRateLimitDefaultsOn pins the cost-DoS default: an UNSET
+// investigation.rate_limit.max_per_window defaults to 30 per 1h window. An
+// unbounded default let any token-holding caller (or a misfiring Alertmanager)
+// run up the model bill — per-incident cost was capped, count was not.
+func TestRateLimitDefaultsOn(t *testing.T) {
+	c := loadDoc(t, `
+sources:
+  alertmanager: {}
+`)
+	if c.Investigation.RateLimit.MaxPerWindow == nil {
+		t.Fatal("unset max_per_window must be defaulted (non-nil) by applyDefaults")
+	}
+	if got := *c.Investigation.RateLimit.MaxPerWindow; got != 30 {
+		t.Fatalf("unset max_per_window must default to 30, got %d", got)
+	}
+	if c.Investigation.RateLimit.Window != Duration(time.Hour) {
+		t.Fatalf("defaulted budget must also default window to 1h, got %v", c.Investigation.RateLimit.Window)
+	}
+}
+
+// TestRateLimitExplicitZeroStaysUnlimited pins backward compatibility: a deployed
+// `max_per_window: 0` keeps its documented unlimited meaning after the default flip.
+func TestRateLimitExplicitZeroStaysUnlimited(t *testing.T) {
+	c := loadDoc(t, `
+sources:
+  alertmanager: {}
+investigation:
+  rate_limit:
+    max_per_window: 0
+`)
+	if c.Investigation.RateLimit.MaxPerWindow == nil {
+		t.Fatal("explicit 0 should be non-nil (distinguishable from unset)")
+	}
+	if got := *c.Investigation.RateLimit.MaxPerWindow; got != 0 {
+		t.Fatalf("explicit max_per_window: 0 must stay 0 (unlimited), got %d", got)
+	}
+}
+
+// TestRateLimitExplicitValueKept pins that an operator's value survives defaulting.
+func TestRateLimitExplicitValueKept(t *testing.T) {
+	c := loadDoc(t, `
+sources:
+  alertmanager: {}
+investigation:
+  rate_limit:
+    max_per_window: 7
+`)
+	if got := *c.Investigation.RateLimit.MaxPerWindow; got != 7 {
+		t.Fatalf("explicit max_per_window: 7 must be kept, got %d", got)
+	}
+}
+
+// TestRateLimitNegativeRejected pins fail-loud validation: a negative budget is a
+// misconfiguration, not a request for unlimited.
+func TestRateLimitNegativeRejected(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "runlore.yaml")
+	doc := `
+sources:
+  alertmanager: {}
+investigation:
+  rate_limit:
+    max_per_window: -1
+`
+	if err := os.WriteFile(p, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(p); err == nil || !strings.Contains(err.Error(), "max_per_window") {
+		t.Fatalf("negative max_per_window must fail Load, got err=%v", err)
 	}
 }

--- a/internal/server/authguard.go
+++ b/internal/server/authguard.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// authGuard throttles repeated FAILED authentications per remote host with an
+// exponential, capped block — bounding brute-force attempts on the shared-token
+// endpoints. Invariants:
+//
+//   - Only consecutive failures count; success() clears the host, so a correct
+//     token is never punished for a NAT-mate's noise — except DURING a live
+//     block window (≤ maxBlock), the accepted trade-off: without a pre-compare
+//     block, backoff would slow nothing.
+//   - blocked() is consulted BEFORE the token compare — a blocked host learns
+//     nothing, not even timing.
+//   - The map is bounded: past maxHosts, expired entries are swept; if all are
+//     live, the new host goes untracked. Fail open on memory, never on auth.
+type authGuard struct {
+	mu    sync.Mutex
+	hosts map[string]*hostState
+	now   func() time.Time
+}
+
+type hostState struct {
+	fails      int
+	blockUntil time.Time
+}
+
+const (
+	failThreshold = 10               // consecutive failures before the first block
+	baseBlock     = 1 * time.Second  // first block; doubles per further failure
+	maxBlock      = 60 * time.Second // hard cap — a lockout is never permanent
+	maxHosts      = 4096             // guard-map bound
+)
+
+func newAuthGuard() *authGuard {
+	return &authGuard{hosts: map[string]*hostState{}, now: time.Now}
+}
+
+// blocked reports whether host is inside a live block window.
+func (g *authGuard) blocked(host string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	st, ok := g.hosts[host]
+	return ok && g.now().Before(st.blockUntil)
+}
+
+// fail records one failed authentication, arming/extending the block once
+// failThreshold consecutive failures accumulate.
+func (g *authGuard) fail(host string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	st, ok := g.hosts[host]
+	if !ok {
+		if len(g.hosts) >= maxHosts {
+			g.sweepLocked()
+		}
+		if len(g.hosts) >= maxHosts {
+			return
+		}
+		st = &hostState{}
+		g.hosts[host] = st
+	}
+	st.fails++
+	if st.fails >= failThreshold {
+		d := baseBlock << uint(st.fails-failThreshold)
+		if d <= 0 || d > maxBlock { // <= 0 catches shift overflow
+			d = maxBlock
+		}
+		st.blockUntil = g.now().Add(d)
+	}
+}
+
+// success clears host — a correct token ends any backoff immediately.
+func (g *authGuard) success(host string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	delete(g.hosts, host)
+}
+
+// sweepLocked drops entries with no live block (expired or never armed).
+func (g *authGuard) sweepLocked() {
+	now := g.now()
+	for h, st := range g.hosts {
+		if !now.Before(st.blockUntil) {
+			delete(g.hosts, h)
+		}
+	}
+}
+
+// remoteHost extracts the host half of an "ip:port" http RemoteAddr.
+func remoteHost(remoteAddr string) string {
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return h
+	}
+	return remoteAddr
+}

--- a/internal/server/authguard_test.go
+++ b/internal/server/authguard_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func guardAt(now *time.Time) *authGuard {
+	g := newAuthGuard()
+	g.now = func() time.Time { return *now }
+	return g
+}
+
+func TestAuthGuardBlocksAfterThreshold(t *testing.T) {
+	now := time.Unix(0, 0)
+	g := guardAt(&now)
+	for i := 0; i < failThreshold-1; i++ {
+		g.fail("10.0.0.1")
+		if g.blocked("10.0.0.1") {
+			t.Fatalf("blocked after only %d failures (threshold %d)", i+1, failThreshold)
+		}
+	}
+	g.fail("10.0.0.1")
+	if !g.blocked("10.0.0.1") {
+		t.Fatal("must block after reaching the failure threshold")
+	}
+	if g.blocked("10.0.0.2") {
+		t.Fatal("other hosts must be unaffected")
+	}
+}
+
+func TestAuthGuardBlockExpiresAndIsCapped(t *testing.T) {
+	now := time.Unix(0, 0)
+	g := guardAt(&now)
+	for i := 0; i < failThreshold; i++ {
+		g.fail("10.0.0.1")
+	}
+	now = now.Add(baseBlock + time.Millisecond)
+	if g.blocked("10.0.0.1") {
+		t.Fatal("first block must expire after baseBlock")
+	}
+	// Pile on failures: the block must never exceed maxBlock.
+	for i := 0; i < 100; i++ {
+		g.fail("10.0.0.1")
+	}
+	now = now.Add(maxBlock + time.Millisecond)
+	if g.blocked("10.0.0.1") {
+		t.Fatal("block must be capped at maxBlock — lockouts are never permanent")
+	}
+}
+
+func TestAuthGuardSuccessResets(t *testing.T) {
+	now := time.Unix(0, 0)
+	g := guardAt(&now)
+	for i := 0; i < failThreshold-1; i++ {
+		g.fail("10.0.0.1")
+	}
+	g.success("10.0.0.1")
+	g.fail("10.0.0.1")
+	if g.blocked("10.0.0.1") {
+		t.Fatal("success must reset the consecutive-failure count")
+	}
+}
+
+func TestAuthGuardMapBounded(t *testing.T) {
+	now := time.Unix(0, 0)
+	g := guardAt(&now)
+	for i := 0; i < maxHosts+100; i++ {
+		g.fail(fmt.Sprintf("10.0.%d.%d", i/256, i%256))
+	}
+	g.mu.Lock()
+	n := len(g.hosts)
+	g.mu.Unlock()
+	if n > maxHosts {
+		t.Fatalf("guard map must stay bounded at %d, got %d", maxHosts, n)
+	}
+}
+
+func TestRemoteHost(t *testing.T) {
+	if got := remoteHost("192.0.2.1:1234"); got != "192.0.2.1" {
+		t.Fatalf("want 192.0.2.1, got %q", got)
+	}
+	if got := remoteHost("no-port"); got != "no-port" {
+		t.Fatalf("want passthrough for portless addr, got %q", got)
+	}
+}
+
+func testServerWithGuard(token string) *Server {
+	return &Server{
+		token: token,
+		guard: newAuthGuard(),
+		log:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// TestAuthorizedBackoff pins the end-to-end behavior: enough wrong tokens from
+// one host block it — and, during the (≤60s) block window, even the RIGHT token
+// is rejected without being compared. That last property is the point: a
+// blocked host learns nothing.
+func TestAuthorizedBackoff(t *testing.T) {
+	s := testServerWithGuard("secret")
+	bad := httptest.NewRequest(http.MethodPost, "/actions/x/approve", nil)
+	bad.Header.Set("X-Approval-Token", "wrong")
+	for i := 0; i < failThreshold; i++ {
+		if s.authorized(bad) {
+			t.Fatal("wrong token must never authorize")
+		}
+	}
+	good := httptest.NewRequest(http.MethodPost, "/actions/x/approve", nil)
+	good.Header.Set("X-Approval-Token", "secret")
+	if s.authorized(good) {
+		t.Fatal("correct token must be rejected while the host is blocked")
+	}
+}
+
+// TestAuthorizedSuccessResetsGuard pins that a correct token BEFORE the
+// threshold clears the failure count (no creeping lockout for fat fingers).
+func TestAuthorizedSuccessResetsGuard(t *testing.T) {
+	s := testServerWithGuard("secret")
+	bad := httptest.NewRequest(http.MethodPost, "/actions/x/approve", nil)
+	bad.Header.Set("X-Approval-Token", "wrong")
+	for i := 0; i < failThreshold-1; i++ {
+		s.authorized(bad)
+	}
+	good := httptest.NewRequest(http.MethodPost, "/actions/x/approve", nil)
+	good.Header.Set("X-Approval-Token", "secret")
+	if !s.authorized(good) {
+		t.Fatal("correct token below threshold must authorize")
+	}
+	if s.guard.blocked(remoteHost(good.RemoteAddr)) {
+		t.Fatal("success must have cleared the guard")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,6 +37,7 @@ type Server struct {
 	slackSecret  string            // Slack signing secret; verifies interactive button clicks
 	webhookToken string            // optional bearer token required on POST /webhook/alertmanager
 	approvers    map[string]bool   // Slack user IDs permitted to approve actions (empty = none)
+	guard        *authGuard        // failed-auth backoff for the shared-token endpoints
 
 	metrics http.Handler // optional; GET /metrics (OTel Prometheus exposition)
 	log     *slog.Logger
@@ -93,6 +94,7 @@ func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pip
 		approvals: acts.Approvals, pauser: acts.Pauser, feedback: acts.Feedback,
 		token: acts.Token, slackSecret: acts.SlackSecret,
 		webhookToken: acts.WebhookToken, approvers: approvers, metrics: metricsHandler, log: log,
+		guard: newAuthGuard(),
 	}
 	mux := http.NewServeMux()
 	// work marks a route as work-bearing: on a follower the request is proxied
@@ -187,12 +189,23 @@ func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 // authorized enforces the approval token (constant-time compare). It FAILS
 // CLOSED: with no token configured the control endpoints are denied, never open.
 // (main refuses to start with actions enabled and an empty token, so a running
-// rung-2/3 server always has one.)
+// rung-2/3 server always has one.) Repeated failures from one host arm an
+// exponential backoff (see authGuard) — checked BEFORE the compare.
 func (s *Server) authorized(r *http.Request) bool {
+	host := remoteHost(r.RemoteAddr)
+	if s.guard.blocked(host) {
+		s.log.Warn("auth backoff engaged; rejecting without compare", "host", host)
+		return false
+	}
 	if s.token == "" {
 		return false
 	}
-	return subtle.ConstantTimeCompare([]byte(r.Header.Get("X-Approval-Token")), []byte(s.token)) == 1
+	if subtle.ConstantTimeCompare([]byte(r.Header.Get("X-Approval-Token")), []byte(s.token)) == 1 {
+		s.guard.success(host)
+		return true
+	}
+	s.guard.fail(host)
+	return false
 }
 
 func (s *Server) handleListActions(w http.ResponseWriter, r *http.Request) {
@@ -438,15 +451,25 @@ func (s *Server) Handler() http.Handler {
 
 // webhookAuthorized checks the optional alert-webhook bearer token (constant-time).
 // When no token is configured the webhook is open — Validate forbids that once
-// actions.mode=auto, so an auto-executing server always authenticates it.
+// actions.mode=auto, so an auto-executing server always authenticates it. With a
+// token configured, repeated failures from one host arm the same backoff as the
+// control endpoints.
 func (s *Server) webhookAuthorized(r *http.Request) bool {
 	if s.webhookToken == "" {
 		return true
 	}
-	const prefix = "Bearer "
-	h := r.Header.Get("Authorization")
-	if !strings.HasPrefix(h, prefix) {
+	host := remoteHost(r.RemoteAddr)
+	if s.guard.blocked(host) {
+		s.log.Warn("webhook auth backoff engaged; rejecting without compare", "host", host)
 		return false
 	}
-	return subtle.ConstantTimeCompare([]byte(strings.TrimPrefix(h, prefix)), []byte(s.webhookToken)) == 1
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if strings.HasPrefix(h, prefix) &&
+		subtle.ConstantTimeCompare([]byte(strings.TrimPrefix(h, prefix)), []byte(s.webhookToken)) == 1 {
+		s.guard.success(host)
+		return true
+	}
+	s.guard.fail(host)
+	return false
 }

--- a/internal/source/webhook.go
+++ b/internal/source/webhook.go
@@ -18,6 +18,15 @@ type Authenticator interface {
 	Authenticate(body []byte, h http.Header) bool
 }
 
+// MaxRequestsPerPayload bounds how many investigation requests one webhook
+// delivery may enqueue (cost-DoS guard): the 1MiB body cap still admits ~1k
+// alerts, and distinct alertnames bypass dedup — each would bill a model
+// investigation. Resolutions are EXEMPT (cheap, and dropping one would corrupt
+// outcome tracking). Truncation over rejection: Alertmanager re-delivers on
+// repeat_interval, so a truncated legitimate batch self-heals; a 4xx loses all
+// of it. Not configurable until someone needs it (YAGNI).
+const MaxRequestsPerPayload = 100
+
 // Handler builds the HTTP handler for a webhook source: shared auth, body cap,
 // decode, and ingest. auth (may be nil) authenticates the request via the shared
 // bearer token; a source implementing Authenticator authenticates itself from the
@@ -50,6 +59,13 @@ func (b Built) Handler(auth func(*http.Request) bool, bodyCap int64, pipe *Pipel
 		if derr != nil {
 			http.Error(w, "bad payload", http.StatusBadRequest)
 			return
+		}
+		if len(res.Requests) > MaxRequestsPerPayload {
+			if pipe.log != nil {
+				pipe.log.Warn("webhook payload cap engaged; truncating requests",
+					"source", b.Desc.Name, "decoded", len(res.Requests), "cap", MaxRequestsPerPayload)
+			}
+			res.Requests = res.Requests[:MaxRequestsPerPayload]
 		}
 		pipe.Ingest(r.Context(), b.Desc.Admission, res)
 		w.WriteHeader(http.StatusAccepted)

--- a/internal/source/webhook_test.go
+++ b/internal/source/webhook_test.go
@@ -3,6 +3,7 @@
 package source
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -223,4 +224,36 @@ func TestHandlerAdmissionIntegration(t *testing.T) {
 		t.Fatalf("want 1 enqueued, got %d", len(enq.reqs))
 	}
 	_ = time.Now() // keep import used
+}
+
+// TestHandlerPayloadRequestCap pins the per-delivery cost guard: one webhook
+// payload can enqueue at most MaxRequestsPerPayload investigation requests. The
+// 1MiB body cap alone still admits ~1k alerts; distinct alertnames each bill an
+// investigation, so the count must be bounded at the door. Truncation (not 4xx)
+// is deliberate: Alertmanager re-delivers on repeat_interval, so a legitimate
+// mega-batch self-heals, while a rejected delivery would lose ALL its alerts.
+func TestHandlerPayloadRequestCap(t *testing.T) {
+	enq := &capEnq{}
+	pipe := NewPipeline(matchAllCfg(), enq, nil, nil)
+	var res DecodeResult
+	for i := 0; i < MaxRequestsPerPayload+50; i++ {
+		res.Requests = append(res.Requests, investigate.Request{
+			Title:       fmt.Sprintf("storm-%d", i),
+			Severity:    "critical",
+			Workload:    providers.Workload{Namespace: "default", Name: fmt.Sprintf("app-%d", i)},
+			Fingerprint: fmt.Sprintf("fp-%d", i),
+		})
+	}
+	b := webhookBuilt(fakeDecoder{result: res})
+	h := b.Handler(nil, 1<<20, pipe)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/test", strings.NewReader(`{}`))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("want 202 (truncate, not reject), got %d", rec.Code)
+	}
+	if len(enq.reqs) != MaxRequestsPerPayload {
+		t.Fatalf("want %d enqueued (cap), got %d", MaxRequestsPerPayload, len(enq.reqs))
+	}
 }


### PR DESCRIPTION
Implements roadmap item **N1** (Cost-DoS guards) from `dev/plans/2026-07-19-audit-roadmap.md`, following the plan at `dev/superpowers/plans/2026-07-19-cost-dos-guards.md`. Three independent guards that bound the model bill and the auth-guessing surface.

## DEFAULT BEHAVIOR CHANGE (release notes)

**An unset `investigation.rate_limit.max_per_window` now defaults to 30 investigations per 1h window.** Previously, unset meant unlimited — any token-holding caller (or a misfiring Alertmanager) could run up the model bill: per-incident cost was capped, the count of incidents was not.

- **An explicit `max_per_window: 0` keeps its documented unlimited meaning** — deployed configs that opted into unlimited are unaffected.
- The Helm chart already ships an explicit `20`, so chart deployments see no change.
- Negative values are now rejected at config load (fail-loud, not silently unlimited).
- Mechanically: `RateLimit.MaxPerWindow` becomes `*int` (same nil-vs-set pattern as `CancelQueuedOnResolve`), defaulted in `applyDefaults`; the `ratelimit.Window` wiring in `serve.go` is unchanged beyond the deref.

## Guard 2 — per-payload request cap (`internal/source`)

One webhook delivery can enqueue at most **100** investigation requests (`source.MaxRequestsPerPayload`). The 1MiB body cap alone still admits ~1k alerts, and distinct alertnames bypass dedup — each would bill a model investigation. Trade-off: **truncate, not reject** — Alertmanager re-delivers on `repeat_interval`, so a truncated legitimate mega-batch self-heals, while a 4xx would lose all of its alerts. Resolutions are exempt (cheap, and dropping one would corrupt outcome tracking). Truncation logs a WARN.

## Guard 3 — failed-auth backoff (`internal/server`)

A new `authGuard` throttles repeated **failed** authentications per remote host on the token-gated control endpoints and the alert webhook: after 10 consecutive failures the host is blocked for 1s, doubling per further failure up to a **60s cap** — never permanent. The block is checked **before** the token compare (a blocked host learns nothing, not even timing); tokens are still compared with `subtle.ConstantTimeCompare`. A correct token always clears the counter, so backoff cannot lock out an operator with the right token — except during a live block window (≤60s), the accepted NAT trade-off. The guard map is bounded at 4096 hosts and fails open on memory pressure, never on auth. Documented in `docs/security-model.md`.

## Testing

TDD throughout (red → green per task). Full gate green at HEAD: `go build`, `go vet`, `go test ./...`, `gofmt -l` (empty), `golangci-lint run` (0 issues), and `go test -race` on `internal/config`, `internal/server`, `internal/source`, `internal/app`.