### PR TITLE
feat(mcp): per-server remote-tool allowlist and paginated discovery

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -85,10 +85,12 @@ toolbox at startup:
 
 ```yaml
 mcp:
+  # require_allowlist: true                # fail closed: every server MUST list tools
   servers:
     - name: runbooks                       # tools appear as runbooks__<tool>
       url: https://mcp.internal.example/mcp # streamable-HTTP transport
       # token_env: RUNBOOKS_MCP_TOKEN       # optional bearer token (env-var name)
+      # tools: [search, get]                # exact-name allowlist; omit ⇒ all tools
 ```
 
 What to know:
@@ -98,7 +100,14 @@ What to know:
 - **Namespacing:** every remote tool is exposed to the model as `<server>__<tool>`, and
   the system prompt marks them as **external, untrusted-output, read-only** tools — a
   remote tool can inform an investigation, never perform an action (the action gate only
-  knows the built-in operations).
+  knows the built-in operations). Note the gate constrains RunLore's *own* write path — a
+  remote tool with server-side side effects is only prevented from being *called* by the
+  allowlist below.
+- **Allowlist:** `tools:` is an exact-name allowlist enforced at discovery — an un-listed
+  tool is never registered, so the model cannot call it. `mcp.require_allowlist: true`
+  refuses startup unless every server declares one (deny-by-default). Discovery follows
+  `tools/list` pagination (bounded at 16 pages), so the allowlist is applied to the
+  server's complete tool list.
 - **Failure isolation:** discovery happens at startup per server; an unreachable server
   is logged and skipped — it never blocks the agent or the other servers. Remote calls
   are not retried (they are not assumed idempotent).

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -48,6 +48,16 @@ additionally requires an authenticated webhook, a positive confidence
 threshold and rate cap, and a non-empty namespace allowlist (see
 [Configuration → actions](configuration.md#actions--the-autonomy-ladder-off-by-default)).
 
+## External MCP tools
+
+Remote MCP tools run outside RunLore's action gate: the gate stops RunLore from *executing* cluster
+operations, but a remote tool that mutates state server-side would do so the moment it is called.
+Treat every configured MCP server as part of your TCB. Two controls bound this: per-server
+`mcp.servers[].tools` allowlists (a tool not listed is never registered, so the model can never call
+it), and `mcp.require_allowlist: true` to refuse startup unless every server is allowlisted. Tool
+*output* remains untrusted data (redaction + no-instruction-following), and per-server discovery
+failures are isolated.
+
 ## Secret redaction at the LLM and egress boundaries
 
 Tool output and incident text flow to a model provider and, for findings, into your KB PR and chat.

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -307,8 +307,19 @@ func appendMCPTools(ctx context.Context, cfg *config.Config, log *slog.Logger, t
 			log.Warn("mcp: skipping server (tools/list failed)", "server", s.Name, "err", err)
 			continue
 		}
+		allowed := map[string]bool{}
+		for _, tn := range s.Tools {
+			allowed[tn] = true
+		}
+		advertised := map[string]bool{}
+		var skipped []string
 		added := 0
 		for _, rt := range remote {
+			advertised[rt.Name] = true
+			if len(allowed) > 0 && !allowed[rt.Name] {
+				skipped = append(skipped, rt.Name)
+				continue
+			}
 			tl := mcp.NewTool(c, rt)
 			if have[tl.Name()] {
 				log.Warn("mcp: skipping tool (name collision)", "server", s.Name, "tool", tl.Name())
@@ -317,6 +328,14 @@ func appendMCPTools(ctx context.Context, cfg *config.Config, log *slog.Logger, t
 			have[tl.Name()] = true
 			tools = append(tools, tl)
 			added++
+		}
+		if len(skipped) > 0 {
+			log.Info("mcp: tools excluded by allowlist", "server", s.Name, "skipped", skipped)
+		}
+		for tn := range allowed {
+			if !advertised[tn] {
+				log.Warn("mcp: allowlisted tool not advertised by server (typo?)", "server", s.Name, "tool", tn)
+			}
 		}
 		log.Info("mcp: registered server tools", "server", s.Name, "tools", added)
 	}

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -377,6 +377,44 @@ func TestAppendMCPToolsSkipsUnreachable(t *testing.T) {
 	}
 }
 
+// TestAppendMCPToolsAllowlist: with a tools allowlist, only listed remote tools
+// are registered; unlisted advertised tools never become investigate.Tools.
+func TestAppendMCPToolsAllowlist(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &req)
+		switch req.Method {
+		case "tools/list":
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]any{"tools": []map[string]any{
+					{"name": "query", "description": "d"},
+					{"name": "delete_everything", "description": "d"},
+				}}})
+		default:
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{}})
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{MCP: config.MCP{Servers: []config.MCPServer{
+		{Name: "kb", Endpoint: config.Endpoint{URL: srv.URL}, Tools: []string{"query", "not_advertised"}},
+	}}}
+	var tools []investigate.Tool
+	tools = appendMCPTools(context.Background(), cfg, slog.New(slog.NewTextHandler(io.Discard, nil)), tools)
+
+	var names []string
+	for _, tl := range tools {
+		names = append(names, tl.Name())
+	}
+	if len(names) != 1 || names[0] != "kb__query" {
+		t.Fatalf("want only kb__query (delete_everything filtered), got %v", names)
+	}
+}
+
 // TestBuildVerifyModel asserts the verify-model override wiring: nil when no
 // model.verify is configured (verify then runs on the main model), non-nil when an
 // override is present.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,12 +193,24 @@ type Cloud struct {
 // investigation loop may call. Empty Servers disables it (the default — MCP is opt-in).
 type MCP struct {
 	Servers []MCPServer `yaml:"servers"`
+
+	// RequireAllowlist refuses startup unless EVERY server declares a tools
+	// allowlist — deny-by-default for operators who treat remote MCP servers
+	// as untrusted. Default false: a listed server exposes all its tools,
+	// matching pre-allowlist behavior.
+	RequireAllowlist bool `yaml:"require_allowlist"`
 }
 
 // MCPServer is one external MCP server reachable over streamable-HTTP.
 type MCPServer struct {
 	Name     string `yaml:"name"` // identifier; namespaces its tools as name__tool
 	Endpoint `yaml:",inline"`
+
+	// Tools is an exact-name allowlist of remote tools to expose to the model
+	// (pre-namespacing names, as advertised by tools/list). Empty ⇒ every
+	// advertised tool (unless mcp.require_allowlist). Enforced at discovery:
+	// a tool outside the list is never registered, so it cannot be called.
+	Tools []string `yaml:"tools"`
 }
 
 // Network provider identifiers for config.network.provider. The network signal is
@@ -1084,6 +1096,19 @@ func (c *Config) Validate() error {
 		}
 		if err := checkSecureKeyEndpoint("mcp.servers["+s.Name+"].url", "mcp.servers["+s.Name+"].token_env", s.URL, s.TokenEnv); err != nil {
 			return err
+		}
+		seenTool := map[string]bool{}
+		for j, tn := range s.Tools {
+			if tn == "" || strings.ContainsAny(tn, " \t") {
+				return fmt.Errorf("mcp.servers[%s].tools[%d]: tool name must be non-empty without whitespace", s.Name, j)
+			}
+			if seenTool[tn] {
+				return fmt.Errorf("mcp.servers[%s].tools: duplicate tool name %q", s.Name, tn)
+			}
+			seenTool[tn] = true
+		}
+		if c.MCP.RequireAllowlist && len(s.Tools) == 0 {
+			return fmt.Errorf("mcp.require_allowlist: server %q declares no tools allowlist (add mcp.servers[%s].tools or disable require_allowlist)", s.Name, s.Name)
 		}
 	}
 	// Curation verdict gate: reject an unknown verdict in forge.skip_verdicts at

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -459,6 +459,50 @@ func TestValidateMCPServers(t *testing.T) {
 	}
 }
 
+func TestValidateMCPToolAllowlist(t *testing.T) {
+	base := func() *Config {
+		c := &Config{}
+		c.MCP.Servers = []MCPServer{{Name: "kb", Endpoint: Endpoint{URL: "https://mcp.example/mcp"}}}
+		return c
+	}
+	t.Run("empty tool name rejected", func(t *testing.T) {
+		c := base()
+		c.MCP.Servers[0].Tools = []string{""}
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "mcp.servers[kb].tools") {
+			t.Fatalf("want tools validation error, got %v", err)
+		}
+	})
+	t.Run("whitespace tool name rejected", func(t *testing.T) {
+		c := base()
+		c.MCP.Servers[0].Tools = []string{"a b"}
+		if err := c.Validate(); err == nil {
+			t.Fatal("want error for whitespace tool name")
+		}
+	})
+	t.Run("duplicate tool name rejected", func(t *testing.T) {
+		c := base()
+		c.MCP.Servers[0].Tools = []string{"query", "query"}
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "duplicate") {
+			t.Fatalf("want duplicate error, got %v", err)
+		}
+	})
+	t.Run("require_allowlist without tools fails closed", func(t *testing.T) {
+		c := base()
+		c.MCP.RequireAllowlist = true
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "require_allowlist") {
+			t.Fatalf("want require_allowlist error, got %v", err)
+		}
+	})
+	t.Run("require_allowlist with tools passes", func(t *testing.T) {
+		c := base()
+		c.MCP.RequireAllowlist = true
+		c.MCP.Servers[0].Tools = []string{"query"}
+		if err := c.Validate(); err != nil {
+			t.Fatalf("valid allowlisted config rejected: %v", err)
+		}
+	})
+}
+
 // TestValidateApproveRequiresAuditLog asserts approve mode is held to the same
 // audit requirement as auto: an executing rung that mutates the cluster must have
 // an audit_log_path (so the hash chain is verified fail-closed on open). Without

--- a/internal/mcp/client.go
+++ b/internal/mcp/client.go
@@ -70,23 +70,37 @@ func (c *Client) Initialize(ctx context.Context) error {
 	return nil
 }
 
-// ListTools returns the server's advertised tools. Retries up to 3 times on transient failures.
+// maxToolListPages bounds tools/list cursor-following so a misbehaving server
+// can't spin discovery forever. 16 pages of any sane page size covers real
+// servers by orders of magnitude.
+const maxToolListPages = 16
+
+// ListTools returns the server's advertised tools, following nextCursor
+// pagination (bounded) so callers — including allowlist enforcement — see the
+// COMPLETE list. Each page retries up to 3 times on transient failures.
 func (c *Client) ListTools(ctx context.Context) ([]RemoteTool, error) {
-	raw, err := c.rpc(ctx, "tools/list", map[string]any{}, 3)
-	if err != nil {
-		return nil, err
+	var all []RemoteTool
+	params := map[string]any{}
+	for page := 0; page < maxToolListPages; page++ {
+		raw, err := c.rpc(ctx, "tools/list", params, 3)
+		if err != nil {
+			return nil, err
+		}
+		var res struct {
+			Tools      []RemoteTool `json:"tools"`
+			NextCursor string       `json:"nextCursor"`
+		}
+		if err := json.Unmarshal(raw, &res); err != nil {
+			return nil, fmt.Errorf("mcp tools/list decode: %w", err)
+		}
+		all = append(all, res.Tools...)
+		if res.NextCursor == "" {
+			return all, nil
+		}
+		params = map[string]any{"cursor": res.NextCursor}
 	}
-	var res struct {
-		Tools      []RemoteTool `json:"tools"`
-		NextCursor string       `json:"nextCursor"`
-	}
-	if err := json.Unmarshal(raw, &res); err != nil {
-		return nil, fmt.Errorf("mcp tools/list decode: %w", err)
-	}
-	if res.NextCursor != "" {
-		c.log.Warn("mcp: tools/list returned a nextCursor; pagination unsupported, list may be truncated", "server", c.name)
-	}
-	return res.Tools, nil
+	c.log.Warn("mcp: tools/list exceeded the page cap; list may be truncated", "server", c.name, "pages", maxToolListPages)
+	return all, nil
 }
 
 // CallTool invokes a remote tool and returns its concatenated text content. An MCP

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -186,3 +186,68 @@ func TestListToolsRetriesOn5xx(t *testing.T) {
 		t.Fatalf("expected 2 requests (1 failure + 1 success), got %d", calls)
 	}
 }
+
+// TestListToolsPagination: two pages joined via nextCursor; the second request
+// must echo the cursor back in params.
+func TestListToolsPagination(t *testing.T) {
+	var gotCursors []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Params struct {
+				Cursor string `json:"cursor"`
+			} `json:"params"`
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &req)
+		if req.Method != "tools/list" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": map[string]any{}})
+			return
+		}
+		gotCursors = append(gotCursors, req.Params.Cursor)
+		if req.Params.Cursor == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID,
+				"result": map[string]any{"tools": []map[string]any{{"name": "a"}}, "nextCursor": "p2"}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]any{"tools": []map[string]any{{"name": "b"}}}})
+	}))
+	defer srv.Close()
+	c := NewClient("s", srv.URL, "", nil, nil)
+	tools, err := c.ListTools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 2 || tools[0].Name != "a" || tools[1].Name != "b" {
+		t.Fatalf("want [a b], got %+v", tools)
+	}
+	if len(gotCursors) != 2 || gotCursors[1] != "p2" {
+		t.Fatalf("cursor not echoed: %v", gotCursors)
+	}
+}
+
+// TestListToolsPageCap: a server that never stops paginating is cut off at the
+// page cap and still returns what was collected.
+func TestListToolsPageCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &req)
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID,
+			"result": map[string]any{"tools": []map[string]any{{"name": "x"}}, "nextCursor": "again"}})
+	}))
+	defer srv.Close()
+	c := NewClient("s", srv.URL, "", nil, nil)
+	tools, err := c.ListTools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != maxToolListPages {
+		t.Fatalf("want %d tools (one per capped page), got %d", maxToolListPages, len(tools))
+	}
+}


### PR DESCRIPTION
## What & why

The outbound MCP client's system prompt promises remote tools are a **read-only extension layer**, but nothing enforced it: every tool a server advertised was registered and reachable by the model. This makes that promise **enforceable** with a per-server tool allowlist plus a fail-closed mode, and fixes `tools/list` pagination so the allowlist is applied to the *complete* advertised list (roadmap item N9).

## Enforced vs prompt-promised — before / after

| | Before | After |
|---|---|---|
| Un-listed remote tool | Always registered, callable by the model | Never adapted, never registered — the model can't call it |
| Server tool surface | Everything `tools/list` returns (first page only) | `tools:` exact-name allowlist, applied to the full paginated list |
| Trust posture | Implicit "trust every server" | Optional deny-by-default via `require_allowlist` |

Absent/empty `tools:` preserves today's behavior (all advertised tools). Namespacing (`<server>__<tool>`), built-ins-win collision handling, and per-server failure isolation are untouched.

## `require_allowlist` fail-closed mode

`mcp.require_allowlist: true` refuses startup (config validation error) unless **every** server declares a non-empty `tools:` list — for operators who treat remote MCP servers as untrusted. Default `false`.

## Pagination fix — and why the allowlist needs it

`ListTools` previously read only the first page and merely logged a warning on a `nextCursor`. A deny-by-default allowlist operating on a silently truncated list is unsound: an allowlisted tool on page 2 would vanish, and (worse for a future allow-all default) the completeness guarantee would be fiction. `ListTools` now follows `nextCursor`, bounded at **16 pages** (`maxToolListPages`) so a misbehaving server can't spin discovery forever; on overrun it warns and returns what it collected.

## Enforcement point

Filtering happens at discovery in `appendMCPTools` (`internal/app/investigate.go`): a tool outside the allowlist is never adapted into an `investigate.Tool`. One aggregated INFO logs the skipped tools; a WARN flags allowlisted-but-not-advertised names (typo guard).

## Docs

- `docs/mcp.md` — config example gains `require_allowlist` and `tools:`; new **Allowlist** bullet; the namespacing bullet now states the action gate constrains RunLore's *own* write path, not a remote tool's server-side side effects.
- `docs/security-model.md` — new **External MCP tools** section: remote tools run outside the action gate, treat each server as part of your TCB, the two controls that bound it.

## Tests

- `config`: empty/whitespace/duplicate tool names rejected; `require_allowlist` fails closed without tools, passes with.
- `mcp`: two-page `nextCursor` join (cursor echoed); never-terminating server capped at 16 pages.
- `app`: allowlist filters an unlisted advertised tool (`delete_everything`) while registering the listed one.

## Reference

Plan: `dev/superpowers/plans/2026-07-19-mcp-tool-allowlist.md` · Roadmap item **N9**.
