### PR TITLE
feat(whatchanged): persistent per-repo git mirror with incremental fetch

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -379,6 +379,19 @@ mcp:
   pattern; **default `3`**. A knowledge-gap issue flags patterns RunLore keeps encountering without
   resolving — a signal to write a runbook.
 
+### `gitops.mirror` — persistent what_changed clone mirror
+`what_changed` diffs a GitOps source repo between two revisions. By default it now keeps a
+persistent **bare mirror** per repo and fetches incrementally, instead of a full clone on every
+call — repeated investigations on the same (mono)repo reuse one on-disk mirror. Full history is
+preserved (the history walks behind the `#239` fallback and time-window enumeration keep working).
+- `enabled` — **default `true`**. Set `false` to restore the legacy clone-per-call behavior
+  (the escape hatch). A mirror error at runtime already falls back to clone-per-call on its own, so
+  `what_changed` never gets *worse* because a mirror misbehaved.
+- `dir` — mirror root. **Default `<tmpdir>/runlore-mirrors`** (ephemeral: wiped on pod restart).
+  Point it at a **PersistentVolume** to keep mirrors warm across restarts.
+- `max` — maximum mirrors kept on disk; **default `10`**. When exceeded, the oldest-mtime mirror is
+  evicted. Must be `>= 0` (`0` = use the default).
+
 ### Other top-level keys
 `gitops.engine` (`flux` default · `argocd`), `cloud` (`provider: aws`, `region`, `cluster_name`),
 `network` (pluggable: `hubble` · `aws-vpc-flow-logs` · `gcp-firewall-logs`),

--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -21,6 +21,13 @@ import (
 // repos only.
 func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) providers.GitOpsProvider {
 	differ := &whatchanged.Differ{TokenSource: BuildForgeTokenSource(cfg, log)}
+	if cfg.GitOps.Mirror.IsEnabled() {
+		if mc, err := whatchanged.NewMirrorCache(cfg.GitOps.Mirror.Dir, cfg.GitOps.Mirror.Max); err != nil {
+			log.Warn("gitops: mirror cache unavailable; falling back to clone-per-call", "err", err)
+		} else {
+			differ.Mirrors = mc
+		}
+	}
 	if GitopsEngine(cfg) == "argocd" {
 		log.Info("gitops engine", "engine", "argocd")
 		return argocd.New(argocd.NewDynamicReader(dc), differ)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -574,8 +574,21 @@ type MatrixNotify struct {
 
 // GitOps selects the GitOps engine RunLore reads (what-changed + failure watch).
 type GitOps struct {
-	Engine string `yaml:"engine"` // "flux" (default) | "argocd"
+	Engine string       `yaml:"engine"` // "flux" (default) | "argocd"
+	Mirror GitOpsMirror `yaml:"mirror"` // persistent clone mirror for what_changed
 }
+
+// GitOpsMirror configures the persistent per-repo bare mirror backing
+// what_changed clones. Enabled by default (nil/true): a mirror only ever
+// falls back to the previous clone-per-call behavior on error.
+type GitOpsMirror struct {
+	Enabled *bool  `yaml:"enabled"` // nil/true ⇒ on; false ⇒ clone per call (legacy)
+	Dir     string `yaml:"dir"`     // mirror root; "" ⇒ <tmp>/runlore-mirrors (ephemeral; point at a PV to persist across restarts)
+	Max     int    `yaml:"max"`     // max mirrors kept (LRU by mtime); 0 ⇒ 10
+}
+
+// IsEnabled reports whether the mirror cache is on (nil ⇒ default on).
+func (m GitOpsMirror) IsEnabled() bool { return m.Enabled == nil || *m.Enabled }
 
 // TriggerPolicy decides what RunLore reacts to.
 type TriggerPolicy struct {
@@ -1005,6 +1018,11 @@ func (c *Config) Validate() error {
 	// negative reaches here). Validate fail-loud rather than silently never pinging.
 	if c.Investigation.ProgressUpdates.Enabled && c.Investigation.ProgressUpdates.EverySteps <= 0 {
 		return fmt.Errorf("investigation.progress_updates.every_steps must be > 0 when enabled, got %d", c.Investigation.ProgressUpdates.EverySteps)
+	}
+	// gitops.mirror.max caps the persistent what_changed mirror count; 0 means the
+	// applyDefaults value (10). A negative cap is always a misconfiguration.
+	if c.GitOps.Mirror.Max < 0 {
+		return fmt.Errorf("gitops.mirror.max must be >= 0 (0 = use the default 10), got %d", c.GitOps.Mirror.Max)
 	}
 	// Pricing rates must be non-negative (a negative rate would report a negative
 	// cost). Cover the main model and the verify override (which carries its own).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -628,3 +628,23 @@ func TestValidateMatrixFeedbackReactions(t *testing.T) {
 		t.Fatalf("feedback_reactions fully configured must validate clean, got: %v", err)
 	}
 }
+
+// TestGitOpsMirrorConfig covers the gitops.mirror block: zero-value defaults to
+// enabled (the Rerank *bool idiom), an explicit false disables, and a negative
+// max is rejected by Validate.
+func TestGitOpsMirrorConfig(t *testing.T) {
+	var m GitOpsMirror
+	if !m.IsEnabled() {
+		t.Fatal("zero-value mirror config must default to enabled")
+	}
+	off := false
+	m.Enabled = &off
+	if m.IsEnabled() {
+		t.Fatal("enabled:false must disable")
+	}
+	c := &Config{Model: Model{Provider: "anthropic"}} // minimal valid config
+	c.GitOps.Mirror.Max = -1
+	if err := c.Validate(); err == nil {
+		t.Fatal("negative gitops.mirror.max must fail validation")
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -63,6 +63,12 @@ func applyDefaults(c *Config) {
 		d := Duration(60 * time.Second)
 		c.Triggers.GitOpsFailures.Debounce = &d
 	}
+	// Persistent what_changed mirror cap: an unset (0) max keeps at most 10 bare
+	// mirrors on disk, evicting oldest-mtime first. NewMirrorCache applies the same
+	// default, but filling it here keeps the effective config observable.
+	if c.GitOps.Mirror.Max == 0 {
+		c.GitOps.Mirror.Max = 10
+	}
 	// Incident debounce default: same 60s hold, for the same reason — let a transient,
 	// self-resolving alert clear before burning a paid investigation on it. It also
 	// keeps that alert's `resolved` webhook out of the outcome ledger, where it would

--- a/internal/whatchanged/clonecache.go
+++ b/internal/whatchanged/clonecache.go
@@ -15,9 +15,10 @@ import (
 // it, each source repo is cloned at most once per call. It is request-scoped via the
 // context and OWNS the clones' lifetime — close() removes every temp dir it made.
 type cloneCache struct {
-	mu     sync.Mutex
-	clones map[string]*git.Repository // url -> reusable clone
-	dirs   []string                   // temp dirs to remove on close
+	mu      sync.Mutex
+	clones  map[string]*git.Repository // url -> reusable clone
+	dirs    []string                   // temp dirs to remove on close
+	closers []func()                   // release funcs for shared (mirror-backed) entries
 }
 
 type cloneCacheKey struct{}
@@ -57,11 +58,29 @@ func (c *cloneCache) put(url string, repo *git.Repository, dir string) (winner *
 	return repo, true
 }
 
+// putShared stores a repo the cache does NOT own on disk (a mirror-backed
+// clone); close calls release instead of removing anything. Same race
+// contract as put: if another entry won, kept=false and the caller must
+// release its own handle.
+func (c *cloneCache) putShared(url string, repo *git.Repository, release func()) (*git.Repository, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if existing, ok := c.clones[url]; ok {
+		return existing, false
+	}
+	c.clones[url] = repo
+	c.closers = append(c.closers, release)
+	return repo, true
+}
+
 func (c *cloneCache) close() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	for _, f := range c.closers {
+		f()
+	}
 	for _, d := range c.dirs {
 		_ = os.RemoveAll(d)
 	}
-	c.clones, c.dirs = nil, nil
+	c.clones, c.dirs, c.closers = nil, nil, nil
 }

--- a/internal/whatchanged/clonecache_test.go
+++ b/internal/whatchanged/clonecache_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"testing"
 
+	git "github.com/go-git/go-git/v5"
+
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -51,5 +53,23 @@ func TestNoCacheStillWorks(t *testing.T) {
 	})
 	if err != nil || len(dff.Files) == 0 {
 		t.Fatalf("uncached ForChange should still diff: %d files err=%v", len(dff.Files), err)
+	}
+}
+
+// TestPutSharedReleasesOnClose: a shared entry's release func runs on close,
+// and close removes no dir for it.
+func TestPutSharedReleasesOnClose(t *testing.T) {
+	ctx, done := WithCloneCache(context.Background())
+	cc := cacheFrom(ctx)
+	released := false
+	if _, kept := cc.putShared("u", &git.Repository{}, func() { released = true }); !kept {
+		t.Fatal("first putShared must keep")
+	}
+	if _, ok := cc.get("u"); !ok {
+		t.Fatal("shared entry must be gettable")
+	}
+	done()
+	if !released {
+		t.Fatal("release must run on close")
 	}
 }

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -35,6 +35,10 @@ type Differ struct {
 	// (~1h) installation token stays fresh across a long-running agent. nil
 	// disables auth (e.g. public or local repos).
 	TokenSource func(context.Context) (string, error)
+	// Mirrors, when set, backs clones with a persistent per-repo bare mirror
+	// (incremental fetch, shared across investigations). nil ⇒ full clone per
+	// call, exactly as before. Mirror errors fall back to clone-per-call.
+	Mirrors *MirrorCache
 }
 
 // Local diffs two revisions in an already-cloned repository at path. ctx bounds the
@@ -163,6 +167,19 @@ func (d *Differ) cloneToDisk(ctx context.Context, url string) (*git.Repository, 
 	if err != nil {
 		return nil, noop, err
 	}
+	if d.Mirrors != nil {
+		if repo, release, merr := d.Mirrors.Acquire(ctx, url, auth); merr == nil {
+			if cc != nil {
+				winner, kept := cc.putShared(url, repo, release)
+				if !kept {
+					release() // another goroutine won the race; drop our lock
+				}
+				return winner, noop, nil
+			}
+			return repo, release, nil
+		}
+		// fall through: a broken mirror must never break what_changed
+	}
 	dir, err := os.MkdirTemp("", "runlore-clone-")
 	if err != nil {
 		return nil, noop, fmt.Errorf("temp dir: %w", err)
@@ -211,9 +228,6 @@ func diffAgainstFirstParent(ctx context.Context, to *object.Commit, scope string
 // RemoteFromParent clones url and returns the path-scoped diff of the change
 // introduced by rev (rev against its first parent). A root commit (no parent)
 // yields an empty diff. ctx bounds the clone + patch.
-//
-// NOTE (perf): does a full (disk) clone per call. When the GitOpsProvider drives
-// this across many changes, add a per-repo clone cache here (see dev/plans note).
 func (d *Differ) RemoteFromParent(ctx context.Context, url, rev, scope string) (providers.Diff, error) {
 	repo, cleanup, err := d.cloneToDisk(ctx, url)
 	if err != nil {

--- a/internal/whatchanged/differ_bench_test.go
+++ b/internal/whatchanged/differ_bench_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package whatchanged
+
+import (
+	"context"
+	"testing"
+)
+
+// Hermetic benchmarks (local fixture repo, no network) contrasting the two
+// clone strategies behind what_changed. Run with:
+//
+//	go test ./internal/whatchanged/ -bench BenchmarkRemote -benchtime 5x -run '^$'
+func BenchmarkRemoteClonePerCall(b *testing.B) {
+	src, v1, v2 := buildRepo(b)
+	d := &Differ{}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.Remote(context.Background(), src, v1.String(), v2.String(), "apps/harbor"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRemoteMirror(b *testing.B) {
+	src, v1, v2 := buildRepo(b)
+	mc, err := NewMirrorCache(b.TempDir(), 10)
+	if err != nil {
+		b.Fatal(err)
+	}
+	d := &Differ{Mirrors: mc}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := d.Remote(context.Background(), src, v1.String(), v2.String(), "apps/harbor"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/whatchanged/differ_test.go
+++ b/internal/whatchanged/differ_test.go
@@ -67,6 +67,58 @@ func buildRepo(t *testing.T) (dir string, v1, v2 plumbing.Hash) {
 	return dir, v1, v2
 }
 
+// TestRemoteWithMirrorHistoryWalks: with Mirrors set, Remote,
+// RemoteLastPathChange and RevisionsInWindow all work off the bare mirror —
+// full history is preserved (the reason a shallow clone was rejected).
+func TestRemoteWithMirrorHistoryWalks(t *testing.T) {
+	src, v1, v2 := buildRepo(t)
+	mc, err := NewMirrorCache(t.TempDir(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &Differ{Mirrors: mc}
+	diff, err := d.Remote(context.Background(), src, v1.String(), v2.String(), "apps/harbor")
+	if err != nil {
+		t.Fatalf("Remote via mirror: %v", err)
+	}
+	if len(diff.Files) != 1 || diff.Files[0].Path != "apps/harbor/values.yaml" {
+		t.Fatalf("unexpected diff via mirror: %v", paths(diff.Files))
+	}
+	fb, err := d.RemoteLastPathChange(context.Background(), src, v2.String(), "apps/harbor")
+	if err != nil || len(fb.Files) == 0 {
+		t.Fatalf("lastPathChange via mirror: files=%d err=%v", len(fb.Files), err)
+	}
+	revs, err := d.RevisionsInWindow(context.Background(), src, v2.String(), "",
+		providers.TimeWindow{Start: time.Unix(0, 0), End: time.Unix(3000, 0)}, 10)
+	if err != nil || len(revs) != 2 {
+		t.Fatalf("revisionsInWindow via mirror: revs=%d err=%v", len(revs), err)
+	}
+	// The mirror, not a temp clone, must have been used: exactly one mirror dir.
+	entries, _ := os.ReadDir(mc.dir)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 mirror dir, got %d", len(entries))
+	}
+}
+
+// TestMirrorFallbackToClone: a broken mirror cache (unwritable dir) must not
+// break Remote — it silently falls back to clone-per-call.
+func TestMirrorFallbackToClone(t *testing.T) {
+	src, v1, v2 := buildRepo(t)
+	roDir := filepath.Join(t.TempDir(), "ro")
+	if err := os.MkdirAll(roDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	mc := &MirrorCache{dir: roDir, max: 10, entries: map[string]*mirrorEntry{}}
+	d := &Differ{Mirrors: mc}
+	diff, err := d.Remote(context.Background(), src, v1.String(), v2.String(), "apps/harbor")
+	if err != nil {
+		t.Fatalf("Remote should fall back to clone-per-call: %v", err)
+	}
+	if len(diff.Files) != 1 {
+		t.Fatalf("fallback diff wrong: %v", paths(diff.Files))
+	}
+}
+
 func TestLocalScoped(t *testing.T) {
 	dir, v1, v2 := buildRepo(t)
 	d, err := (&Differ{}).Local(context.Background(), dir, v1.String(), v2.String(), "apps/harbor")

--- a/internal/whatchanged/differ_test.go
+++ b/internal/whatchanged/differ_test.go
@@ -20,7 +20,7 @@ import (
 
 // buildRepo creates a temp git repo with two commits and returns the repo dir
 // and the two commit hashes. v1 adds two files; v2 changes both.
-func buildRepo(t *testing.T) (dir string, v1, v2 plumbing.Hash) {
+func buildRepo(t testing.TB) (dir string, v1, v2 plumbing.Hash) {
 	t.Helper()
 	dir = t.TempDir()
 	repo, err := git.PlainInit(dir, false)

--- a/internal/whatchanged/mirror.go
+++ b/internal/whatchanged/mirror.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	git "github.com/go-git/go-git/v5"
@@ -105,5 +106,47 @@ func mirrorKey(url string) string {
 	return hex.EncodeToString(h[:8])
 }
 
-// evictLocked makes room for one more mirror; implemented in the eviction task.
-func (m *MirrorCache) evictLocked(_ string) {}
+// evictLocked deletes oldest-mtime mirrors until fewer than max remain,
+// making room for the mirror about to be cloned at keep. A dir whose entry
+// read/write lock is currently held (an in-flight Acquire) is skipped —
+// never delete a mirror out from under a reader. Touches disk state only;
+// best-effort by design (an undeletable dir is skipped, not fatal).
+func (m *MirrorCache) evictLocked(keep string) {
+	entries, err := os.ReadDir(m.dir)
+	if err != nil || len(entries) < m.max {
+		return
+	}
+	type victim struct {
+		path string
+		mod  int64
+	}
+	var victims []victim
+	m.mu.Lock()
+	locked := map[string]bool{}
+	for _, e := range m.entries {
+		if e.path == keep {
+			continue
+		}
+		if e.lock.TryLock() {
+			e.lock.Unlock()
+		} else {
+			locked[e.path] = true
+		}
+	}
+	m.mu.Unlock()
+	for _, de := range entries {
+		p := filepath.Join(m.dir, de.Name())
+		if p == keep || locked[p] {
+			continue
+		}
+		info, err := de.Info()
+		if err != nil {
+			continue
+		}
+		victims = append(victims, victim{path: p, mod: info.ModTime().UnixNano()})
+	}
+	sort.Slice(victims, func(i, j int) bool { return victims[i].mod < victims[j].mod })
+	for i := 0; len(victims)-i > m.max-1 && i < len(victims); i++ {
+		_ = os.RemoveAll(victims[i].path)
+	}
+}

--- a/internal/whatchanged/mirror.go
+++ b/internal/whatchanged/mirror.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package whatchanged
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+)
+
+// MirrorCache keeps one persistent bare mirror per remote URL so repeated
+// what_changed calls fetch incrementally instead of re-cloning full history
+// (the differ.go clone-per-call NOTE). Safe for concurrent use: fetch runs
+// under a per-URL write lock, callers hold a read lock while diffing —
+// go-git never GCs packs, so the only torn state a concurrent fetch could
+// expose is a mid-update ref, which the lock excludes.
+type MirrorCache struct {
+	dir     string
+	max     int
+	mu      sync.Mutex // guards entries
+	entries map[string]*mirrorEntry
+}
+
+type mirrorEntry struct {
+	lock sync.RWMutex
+	path string
+}
+
+// NewMirrorCache creates the cache rooted at dir ("" ⇒ a runlore-mirrors dir
+// under os.TempDir()), keeping at most maxMirrors mirrors (<=0 ⇒ 10).
+func NewMirrorCache(dir string, maxMirrors int) (*MirrorCache, error) {
+	if dir == "" {
+		dir = filepath.Join(os.TempDir(), "runlore-mirrors")
+	}
+	if maxMirrors <= 0 {
+		maxMirrors = 10
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("mirror dir: %w", err)
+	}
+	return &MirrorCache{dir: dir, max: maxMirrors, entries: map[string]*mirrorEntry{}}, nil
+}
+
+// Acquire returns a repo backed by the persistent bare mirror for url, cloning
+// it on first use and fetching otherwise (so the triggering revision is
+// present). The returned release func MUST be called exactly once; the repo
+// must not be used after release. Errors are safe to fall back from.
+func (m *MirrorCache) Acquire(ctx context.Context, url string, auth transport.AuthMethod) (*git.Repository, func(), error) {
+	m.mu.Lock()
+	e, ok := m.entries[url]
+	if !ok {
+		e = &mirrorEntry{path: filepath.Join(m.dir, mirrorKey(url))}
+		m.entries[url] = e
+	}
+	m.mu.Unlock()
+
+	e.lock.Lock()
+	repo, err := m.syncLocked(ctx, e, url, auth)
+	if err != nil {
+		e.lock.Unlock()
+		return nil, nil, err
+	}
+	// Downgrade to a read lock for the caller's diffs. The gap between Unlock
+	// and RLock only lets another Acquire fetch first — harmless repetition.
+	e.lock.Unlock()
+	e.lock.RLock()
+	return repo, e.lock.RUnlock, nil
+}
+
+// syncLocked clones (first use) or fetches (steady state) under e.lock held
+// for writing. A failed first clone removes the half-created dir.
+func (m *MirrorCache) syncLocked(ctx context.Context, e *mirrorEntry, url string, auth transport.AuthMethod) (*git.Repository, error) {
+	if _, statErr := os.Stat(e.path); statErr != nil {
+		m.evictLocked(e.path)
+		repo, err := git.PlainCloneContext(ctx, e.path, true, &git.CloneOptions{URL: url, Auth: auth, Mirror: true})
+		if err != nil {
+			_ = os.RemoveAll(e.path)
+			return nil, fmt.Errorf("mirror clone %s: %w", url, err)
+		}
+		return repo, nil
+	}
+	repo, err := git.PlainOpen(e.path)
+	if err != nil {
+		return nil, fmt.Errorf("mirror open: %w", err)
+	}
+	// Mirror clones configure a +refs/*:refs/* refspec, so a plain fetch
+	// force-updates every ref (rewritten branches included).
+	if err := repo.FetchContext(ctx, &git.FetchOptions{Auth: auth}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		return nil, fmt.Errorf("mirror fetch %s: %w", url, err)
+	}
+	return repo, nil
+}
+
+// mirrorKey derives a filesystem-safe dir name from a remote URL.
+func mirrorKey(url string) string {
+	h := sha256.Sum256([]byte(url))
+	return hex.EncodeToString(h[:8])
+}
+
+// evictLocked makes room for one more mirror; implemented in the eviction task.
+func (m *MirrorCache) evictLocked(_ string) {}

--- a/internal/whatchanged/mirror_test.go
+++ b/internal/whatchanged/mirror_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package whatchanged
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// TestMirrorAcquireClonesOnce: first Acquire clones a bare mirror; a second
+// Acquire reuses the same on-disk dir (no re-clone) and still resolves commits.
+func TestMirrorAcquireClonesOnce(t *testing.T) {
+	src, v1, _ := buildRepo(t)
+	mc, err := NewMirrorCache(t.TempDir(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, release, err := mc.Acquire(context.Background(), src, nil)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if _, err := resolveCommit(repo, v1.String()); err != nil {
+		t.Fatalf("resolve v1 in mirror: %v", err)
+	}
+	release()
+	entries, _ := os.ReadDir(mc.dir)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 mirror dir, got %d", len(entries))
+	}
+	repo2, release2, err := mc.Acquire(context.Background(), src, nil)
+	if err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	defer release2()
+	if _, err := resolveCommit(repo2, v1.String()); err != nil {
+		t.Fatalf("resolve v1 on reuse: %v", err)
+	}
+}
+
+// TestMirrorAcquireFetchesNewCommits: a commit pushed to the source AFTER the
+// mirror was created is visible on the next Acquire (incremental fetch).
+func TestMirrorAcquireFetchesNewCommits(t *testing.T) {
+	src, _, _ := buildRepo(t)
+	mc, err := NewMirrorCache(t.TempDir(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, release, err := mc.Acquire(context.Background(), src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+	v3 := addCommit(t, src, "apps/harbor/values.yaml", "version: 1.16.0\n", "v3", 3000)
+	repo, release2, err := mc.Acquire(context.Background(), src, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release2()
+	if _, err := resolveCommit(repo, v3.String()); err != nil {
+		t.Fatalf("v3 not fetched into mirror: %v", err)
+	}
+}
+
+// TestMirrorAcquireConcurrent: N concurrent Acquire/release cycles on the same
+// URL race-cleanly (run with -race). Each goroutine must resolve a known SHA.
+func TestMirrorAcquireConcurrent(t *testing.T) {
+	src, v1, _ := buildRepo(t)
+	mc, err := NewMirrorCache(t.TempDir(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			repo, release, err := mc.Acquire(context.Background(), src, nil)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer release()
+			if _, err := resolveCommit(repo, v1.String()); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestMirrorAcquireBadURL: an unclonable URL returns an error and leaves no
+// half-created mirror dir behind.
+func TestMirrorAcquireBadURL(t *testing.T) {
+	mc, err := NewMirrorCache(t.TempDir(), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := mc.Acquire(context.Background(), filepath.Join(t.TempDir(), "nope"), nil); err == nil {
+		t.Fatal("want error for unclonable URL")
+	}
+	entries, _ := os.ReadDir(mc.dir)
+	if len(entries) != 0 {
+		t.Fatalf("want no leftover dirs, got %d", len(entries))
+	}
+}
+
+// addCommit writes one file into the fixture repo at dir and commits it with a
+// fixed timestamp, returning the new commit hash.
+func addCommit(t testing.TB, dir, rel, content, msg string, sec int64) plumbing.Hash {
+	t.Helper()
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(rel); err != nil {
+		t.Fatal(err)
+	}
+	h, err := wt.Commit(msg, &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@x", When: time.Unix(sec, 0)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}

--- a/internal/whatchanged/mirror_test.go
+++ b/internal/whatchanged/mirror_test.go
@@ -112,6 +112,43 @@ func TestMirrorAcquireBadURL(t *testing.T) {
 	}
 }
 
+// TestMirrorEviction: with max=2, acquiring a 3rd distinct repo evicts the
+// oldest-mtime mirror; the two newest survive.
+func TestMirrorEviction(t *testing.T) {
+	srcA, _, _ := buildRepo(t)
+	srcB, _, _ := buildRepo(t)
+	srcC, _, _ := buildRepo(t)
+	mc, err := NewMirrorCache(t.TempDir(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, src := range []string{srcA, srcB} {
+		_, release, err := mc.Acquire(context.Background(), src, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		release()
+	}
+	// Age A so it is the eviction victim regardless of clone timing.
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(filepath.Join(mc.dir, mirrorKey(srcA)), old, old); err != nil {
+		t.Fatal(err)
+	}
+	_, release, err := mc.Acquire(context.Background(), srcC, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+	if _, err := os.Stat(filepath.Join(mc.dir, mirrorKey(srcA))); !os.IsNotExist(err) {
+		t.Fatal("oldest mirror (A) should have been evicted")
+	}
+	for _, src := range []string{srcB, srcC} {
+		if _, err := os.Stat(filepath.Join(mc.dir, mirrorKey(src))); err != nil {
+			t.Fatalf("mirror for %s should survive: %v", src, err)
+		}
+	}
+}
+
 // addCommit writes one file into the fixture repo at dir and commits it with a
 // fixed timestamp, returning the new commit hash.
 func addCommit(t testing.TB, dir, rel, content, msg string, sec int64) plumbing.Hash {


### PR DESCRIPTION
## What

Replaces the full-history clone-per-`what_changed`-call with a **persistent per-repo bare mirror** that fetches incrementally and is shared across investigations (roadmap **N7**; the code previously TODO'd it at `differ.go:216`).

Implements `dev/superpowers/plans/2026-07-19-whatchanged-git-mirror.md` task-by-task (TDD, one commit per task).

## How

- **`MirrorCache`** (`internal/whatchanged/mirror.go`) keeps one bare `Mirror:true` clone per remote URL under a configurable dir, keyed by a SHA-256 URL hash. `Acquire` clones on first use, then `FetchContext` (force-updates every ref via the mirror refspec) on subsequent calls, so the triggering revision is always present.
- **Concurrency**: fetch runs under a per-URL **write** lock; the repo is handed back under a **read** lock so concurrent investigations can diff the same repo while a fetch on it is excluded. go-git never GCs packs, so SHA-addressed reads stay pack-safe; the only torn state a fetch exposes is a mid-update ref, which the lock excludes. Verified with a `-race` concurrent-Acquire test.
- **Fail-safe fallback**: any mirror error (clone, fetch, unwritable dir) silently falls back to the existing clone-per-call path — `what_changed` never gets *worse* because a mirror misbehaved. Covered by `TestMirrorFallbackToClone` (read-only mirror dir).
- **Eviction cap**: at most `max` mirrors on disk (default 10), oldest-mtime evicted first; a dir whose entry lock is held by an in-flight `Acquire` is skipped (never delete a mirror out from under a reader).
- **`cloneCache` layering preserved**: the request-scoped clone cache now supports mirror-backed *shared* entries via `putShared`, so a batch of diffs acquires the mirror once and releases the read lock on batch close (no dir removal for shared entries).
- **Full history preserved**: the `#239` last-path-change fallback and the G3 time-window revision walk both work off the bare mirror — proven by `TestRemoteWithMirrorHistoryWalks`.

## Config

New `gitops.mirror` block (documented in `docs/configuration.md`), enabled by default:

| key | default | meaning |
|-----|---------|---------|
| `enabled` | `true` | `false` restores legacy clone-per-call (escape hatch) |
| `dir` | `<tmpdir>/runlore-mirrors` | mirror root; point at a **PV** to persist across restarts |
| `max` | `10` | max mirrors kept (oldest-mtime evicted); must be `>= 0` |

`Validate` rejects a negative `max`; `applyDefaults` fills `0 => 10`. A mirror-cache init failure at startup logs a warning and leaves the differ on clone-per-call.

## Benchmarks

The repo's first `testing.B` — hermetic (local fixture repo, no network), contrasting the two strategies:

```
cpu: 12th Gen Intel(R) Core(TM) i9-12900HK
BenchmarkRemoteClonePerCall-20    5    9629398 ns/op
BenchmarkRemoteMirror-20          5    5921616 ns/op   (-benchtime 5x)
```

The mirror is ~38% faster in steady state on a *tiny* fixture; the gap understates real-repo wins where the avoided full clone dominates. (At `-benchtime 1x` the gap narrows to ~10.4ms vs ~10.0ms because the mirror pays its one-time clone on the first iteration.)

## Quality gate

`go build`/`go vet`/`go test ./...` pass, `gofmt -l .` empty, `golangci-lint run ./...` = `0 issues.`, and `go test -race ./internal/whatchanged/... ./internal/config/... ./internal/app/...` all green.
