### PR TITLE
feat(curate): retirement pass for decayed merged KB entries

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -378,6 +378,19 @@ mcp:
 - `recurrence_threshold` — open a knowledge-gap issue after this many unresolved occurrences of a
   pattern; **default `3`**. A knowledge-gap issue flags patterns RunLore keeps encountering without
   resolving — a signal to write a runbook.
+- `retirement` — the **opt-in** KB retirement pass: opens a human-reviewed *retire* PR that stamps
+  `status: retired` into a **merged** entry whose outcome track record has sustainably decayed. It
+  never merges or deletes (a human is the gate; the entry stays in git history), is idempotent, and
+  respects a human veto — a retire PR closed without merging is never re-proposed. Keys:
+  - `enabled` — **default `false`**. When off, the pass is not wired at all (default behavior
+    unchanged); the other defaults are only applied once enabled.
+  - `min_observations` — the sustained-decay bar: total observations (recalls + 👍 + 👎) an entry
+    must have before retirement is even considered, so a single bad recall can't retire it;
+    **default `3`**, must be `>= 1`.
+  - `floor` — retire when the entry's outcome factor drops below this; **default `0.5`**, must be in
+    `(0,1]`. Mirrors recall's `catalog.instant_recall.outcome_floor` so the two gates agree.
+  - `prior` — Beta prior strength `k` for the decay formula; **default `2.0`**. Mirrors recall's
+    `catalog.instant_recall.outcome_prior` — keep them equal unless deliberately tuning the gates apart.
 
 ### Other top-level keys
 `gitops.engine` (`flux` default · `argocd`), `cloud` (`provider: aws`, `region`, `cluster_name`),

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -400,6 +400,31 @@ ledger, so they stay source-neutral):
   KB PR so the reviewer sees the contest before merging; idempotent via a hidden
   per-trigger marker in the comment, no mutable store.
 
+Finally, an **opt-in** pass closes the *garbage-collection* half of the loop — the
+mirror image of curation, where decay existed but had no consequence beyond recall
+rejection:
+
+- **Retirement** (`curate.retirement.enabled`, default **off**) — opens a
+  human-reviewed *retire* PR for a **merged** catalog entry whose outcome factor stayed
+  below the trust floor across a **sustained** run of observations
+  (`min_observations`, default 3 — so a single bad recall, factor 0.33, can never retire
+  an entry). It uses the **same decay formula and floor as recall's Gate 3**
+  (`outcome.Aggregate.Factor`, the one definition both gates share), so the entry
+  proposed for retirement is exactly the one recall already rejects — every recurrence
+  was already paying a full investigation. The PR stamps `status: retired` into the
+  entry's YAML frontmatter (a surgical one-line edit that preserves the human's
+  formatting) and a human merges: retirement **never** merges or deletes, so a retired
+  entry stays in git history — it just stops being recallable. Idempotent and
+  **human-veto-aware** via a hidden per-entry marker in the PR body: an open retire PR
+  is never re-proposed, and a retire PR a human **closed without merging** is a
+  deliberate "keep it" that is never re-nagged (the same closed-unmerged-is-a-no
+  philosophy as the recurrence escalation above). Per-item error isolation: one flaky
+  entry never starves the rest of a run.
+  - **Seam (in progress).** This pass *writes* the `status: retired` frontmatter; the
+    catalog loader honoring it — so a retired entry actually stops being recalled — ships
+    as a separate change. Until then a merged retirement PR is inert but correct (the
+    entry is marked, the git history records the decision), with no dependency either way.
+
 ---
 
 ## 6. The feedback edge — outcome-driven decay (what makes it *learn*)

--- a/internal/app/curate.go
+++ b/internal/app/curate.go
@@ -86,6 +86,21 @@ func RunCurate(args []string) error {
 			// marker — no store, mirroring the other passes.
 			curate.Contested{Forge: forge, Ledger: ledger, KBRepo: cfg.Forge.KBRepo, Log: log},
 		)
+		// Retirement (opt-in) closes the garbage-collection half of the loop: it opens a
+		// human-reviewed "retire" PR for a MERGED entry whose outcome factor stayed below
+		// the trust floor across a sustained run of observations. It never merges and never
+		// deletes — a human is the load-bearing gate; the PR only stamps `status: retired`.
+		// Idempotent and human-veto-aware via a hidden per-entry PR-body marker (no store).
+		if cfg.Curate.Retirement.Enabled {
+			agent.Passes = append(agent.Passes, curate.Retirement{
+				Forge:           forge,
+				Stats:           ledger,
+				MinObservations: cfg.Curate.Retirement.MinObservations,
+				Floor:           cfg.Curate.Retirement.Floor,
+				Prior:           cfg.Curate.Retirement.Prior,
+				Log:             log,
+			})
+		}
 		// Warn loudly when the ledger this pod sees is absent/empty: outcome.New
 		// succeeds on a missing file, so the passes would otherwise run silently
 		// against zero episodes (a misconfigured mount, not "no work").

--- a/internal/app/curate_test.go
+++ b/internal/app/curate_test.go
@@ -11,7 +11,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Smana/runlore/internal/curate"
+	github "github.com/Smana/runlore/internal/forge/github"
 	"github.com/Smana/runlore/internal/outcome"
+)
+
+// The retirement pass is wired in RunCurate with *github.Client as its forge and
+// *outcome.Ledger as its stats source; pin both seams at compile time so a drift in
+// either interface fails here rather than in the wiring block.
+var (
+	_ curate.RetireForge = (*github.Client)(nil)
+	_ curate.RetireStats = (*outcome.Ledger)(nil)
 )
 
 // captureLog returns a logger writing JSON records into buf so a test can assert

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1142,6 +1142,21 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("catalog.instant_recall.rerank_min_score must be >= 0 (retrieval-score cost floor), got %g", ir.RerankMinScore)
 		}
 	}
+	// Retirement pass (opt-in): its knobs are only meaningful when enabled, and a
+	// disabled block is never validated. applyDefaults fills unset (0) values while
+	// enabled, so only an explicitly out-of-range setting reaches here. Floor is a
+	// calibrated posterior-mean success rate: it MUST match recall's outcome_floor
+	// range (0,1] — a floor >1 would retire everything, <=0 nothing. min_observations
+	// is the sustained-decay bar and must be >= 1 (a single bad recall must never retire).
+	if c.Curate.Retirement.Enabled {
+		r := c.Curate.Retirement
+		if r.Floor <= 0 || r.Floor > 1 {
+			return fmt.Errorf("curate.retirement.floor must be in (0,1] (a calibrated outcome factor, matching recall's outcome_floor), got %g", r.Floor)
+		}
+		if r.MinObservations < 1 {
+			return fmt.Errorf("curate.retirement.min_observations must be >= 1 (the sustained-decay bar), got %d", r.MinObservations)
+		}
+	}
 	switch c.Actions.Mode {
 	case "", ActionOff, ActionSuggest:
 		return nil // read-only-ish: nothing to execute
@@ -1184,6 +1199,21 @@ func (c *Config) Validate() error {
 type Curate struct {
 	StaleAfter          Duration `yaml:"stale_after"`          // close unprotected KB PRs idle longer than this; 0 disables (default 720h)
 	RecurrenceThreshold int      `yaml:"recurrence_threshold"` // open a knowledge-gap issue after this many unresolved occurrences of a pattern; 0 ⇒ default 3
+	// Retirement opens a human-reviewed "retire" PR for a merged catalog entry whose
+	// outcome factor stayed below Floor across at least MinObservations observations.
+	// Opt-in: the pass writes to the forge on a schedule, and retirement is a
+	// judgment call an operator must consciously enable. Prior/Floor default to the
+	// recall gate's outcome_prior/outcome_floor defaults (2.0 / 0.5) so the two
+	// gates agree unless deliberately tuned apart.
+	Retirement Retirement `yaml:"retirement"`
+}
+
+// Retirement configures the curate retirement pass (opt-in KB garbage collection).
+type Retirement struct {
+	Enabled         bool    `yaml:"enabled"`
+	MinObservations int     `yaml:"min_observations"` // sustained-decay bar (default 3)
+	Floor           float64 `yaml:"floor"`            // retire below this factor (default 0.5)
+	Prior           float64 `yaml:"prior"`            // Beta prior strength k (default 2.0)
 }
 
 // Forge holds git-forge authentication and the curation target repo.

--- a/internal/config/config_retirement_test.go
+++ b/internal/config/config_retirement_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestApplyDefaultsRetirementEnabled(t *testing.T) {
+	// Only retirement.enabled set — the three tuning knobs get the recall-gate defaults.
+	var c Config
+	c.Curate.Retirement.Enabled = true
+	applyDefaults(&c)
+	r := c.Curate.Retirement
+	if r.MinObservations != 3 {
+		t.Errorf("default MinObservations: got %d, want 3", r.MinObservations)
+	}
+	if r.Floor != 0.5 {
+		t.Errorf("default Floor: got %g, want 0.5", r.Floor)
+	}
+	if r.Prior != 2.0 {
+		t.Errorf("default Prior: got %g, want 2.0", r.Prior)
+	}
+
+	// Explicit values are respected, not overwritten.
+	var c2 Config
+	c2.Curate.Retirement = Retirement{Enabled: true, MinObservations: 5, Floor: 0.3, Prior: 4.0}
+	applyDefaults(&c2)
+	if r2 := c2.Curate.Retirement; r2.MinObservations != 5 || r2.Floor != 0.3 || r2.Prior != 4.0 {
+		t.Fatalf("explicit retirement tuning overwritten: %+v", r2)
+	}
+}
+
+func TestApplyDefaultsRetirementDisabled(t *testing.T) {
+	// Disabled (the default): the pass is opt-in, so no defaults are filled — the
+	// block stays at its zero value and never wires the pass in.
+	var c Config
+	applyDefaults(&c)
+	if r := c.Curate.Retirement; r.MinObservations != 0 || r.Floor != 0 || r.Prior != 0 {
+		t.Fatalf("defaults must not be applied while retirement is disabled: %+v", r)
+	}
+}
+
+func TestValidateRetirement(t *testing.T) {
+	valid := func() *Config {
+		c := &Config{}
+		c.Curate.Retirement = Retirement{Enabled: true, MinObservations: 3, Floor: 0.5, Prior: 2.0}
+		return c
+	}
+	if err := valid().Validate(); err != nil {
+		t.Fatalf("a valid retirement config must pass: %v", err)
+	}
+
+	floorHigh := valid()
+	floorHigh.Curate.Retirement.Floor = 1.5
+	if err := floorHigh.Validate(); err == nil || !strings.Contains(err.Error(), "curate.retirement.floor") {
+		t.Fatalf("floor > 1 must error on curate.retirement.floor, got %v", err)
+	}
+
+	floorLow := valid()
+	floorLow.Curate.Retirement.Floor = -0.1
+	if err := floorLow.Validate(); err == nil || !strings.Contains(err.Error(), "curate.retirement.floor") {
+		t.Fatalf("floor <= 0 must error on curate.retirement.floor, got %v", err)
+	}
+
+	minObs := valid()
+	minObs.Curate.Retirement.MinObservations = -1
+	if err := minObs.Validate(); err == nil || !strings.Contains(err.Error(), "curate.retirement.min_observations") {
+		t.Fatalf("min_observations < 1 must error, got %v", err)
+	}
+
+	// Disabled: an opt-out config is never validated, however nonsensical its knobs.
+	off := valid()
+	off.Curate.Retirement = Retirement{Enabled: false, Floor: 99, MinObservations: -5}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("a disabled retirement block must not be validated: %v", err)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -181,4 +181,20 @@ func applyDefaults(c *Config) {
 			}
 		}
 	}
+	// Retirement pass defaults (opt-in): only fill the tuning knobs once the pass is
+	// enabled, so a disabled block stays at its zero value and never wires the pass
+	// in. Prior/Floor mirror the recall gate's outcome_prior/outcome_floor defaults
+	// (2.0 / 0.5) so recall's fire gate and retirement agree on decay by default.
+	if c.Curate.Retirement.Enabled {
+		r := &c.Curate.Retirement
+		if r.MinObservations == 0 {
+			r.MinObservations = 3
+		}
+		if r.Floor == 0 {
+			r.Floor = 0.5
+		}
+		if r.Prior == 0 {
+			r.Prior = 2.0
+		}
+	}
 }

--- a/internal/curate/retirement.go
+++ b/internal/curate/retirement.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/Smana/runlore/internal/forge/github"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// retireLabel is the forge label the retirement pass lists on for idempotency and
+// human-veto detection — the same label OpenRetirePR stamps on the PRs it opens.
+const retireLabel = "runlore-retire"
+
+// RetireForge is the forge surface the Retirement pass needs (consumer-side, like
+// ContestedForge — widening the shared Forge would bloat every other pass's fake).
+type RetireForge interface {
+	ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error)
+}
+
+// RetireStats is the ledger view the pass needs: the per-entry outcome roll-up.
+type RetireStats interface {
+	OpenCounts() (map[string]outcome.Aggregate, error)
+}
+
+// Retirement opens a human-reviewed "retire" PR for a merged catalog entry whose
+// outcome track record has decayed below the trust floor and stayed there across
+// at least MinObservations observations — closing the garbage-collection half of
+// the learning loop. It never merges and never deletes: a human is the load-bearing
+// gate, and the PR only stamps `status: retired` frontmatter (the entry stays in
+// git history). Ledger-driven and idempotent like the other passes — a hidden
+// per-entry marker in the PR body is the "already proposed" record, and a
+// closed-unmerged retire PR carrying the marker is a human veto that is never
+// re-nagged. Opt-in (see config): retirement is a judgment call an operator enables.
+type Retirement struct {
+	Forge           RetireForge
+	Stats           RetireStats
+	MinObservations int     // sustained-decay bar: total observations before retirement is considered
+	Floor           float64 // retire when Factor(Prior) < Floor
+	Prior           float64 // k — must equal recall's outcome_prior so both gates agree
+	Log             *slog.Logger
+}
+
+// Run proposes one retire PR per sustained-decay candidate. Per-item forge failures
+// are logged and skipped so one flaky entry never starves the rest.
+func (p Retirement) Run(ctx context.Context) error {
+	counts, err := p.Stats.OpenCounts()
+	if err != nil {
+		return fmt.Errorf("retirement: open counts: %w", err)
+	}
+	// Candidate = an entry whose decay is BOTH deep (Factor < Floor) and sustained
+	// (>= MinObservations observations) — a single bad recall must never retire an
+	// entry. Sorted for deterministic logs and tests.
+	var candidates []string
+	for path, agg := range counts {
+		obs := agg.Recalls + agg.FeedbackUp + agg.FeedbackDown
+		if obs < p.MinObservations {
+			continue
+		}
+		if agg.Factor(p.Prior) >= p.Floor {
+			continue
+		}
+		candidates = append(candidates, path)
+	}
+	if len(candidates) == 0 {
+		return nil // nothing decayed enough: zero forge calls
+	}
+	slices.Sort(candidates)
+
+	// One listing of each retire-PR set per run (the Contested per-run-cache
+	// pattern): open PRs give idempotency, closed-unmerged PRs give the human veto.
+	openPRs, err := p.Forge.ListPRsByLabel(ctx, retireLabel)
+	if err != nil {
+		return fmt.Errorf("retirement: list open retire PRs: %w", err)
+	}
+	closedPRs, err := p.Forge.ListClosedUnmergedPRsByLabel(ctx, retireLabel)
+	if err != nil {
+		return fmt.Errorf("retirement: list closed-unmerged retire PRs: %w", err)
+	}
+	openBodies := bodiesOf(openPRs)
+	vetoedBodies := bodiesOf(closedPRs)
+
+	for _, path := range candidates {
+		agg := counts[path]
+		marker := retireMarker(path)
+		if anyContains(openBodies, marker) {
+			continue // already proposed on an open PR — the marker is the idempotency record
+		}
+		if anyContains(vetoedBodies, marker) {
+			// A human closed a retire PR for this entry without merging: a deliberate
+			// "keep it". Never re-propose (the ClosedPRSuppression philosophy).
+			p.Log.Debug("retirement: entry has a human-vetoed retire PR; skipping", "entry", path)
+			continue
+		}
+		factor := agg.Factor(p.Prior)
+		if _, err := p.Forge.OpenRetirePR(ctx, path, retireBody(path, agg, factor, p.Floor, marker)); err != nil {
+			if errors.Is(err, github.ErrAlreadyRetired) {
+				p.Log.Debug("retirement: entry already retired on base branch; skipping", "entry", path)
+				continue
+			}
+			p.Log.Warn("retirement: open retire PR failed", "entry", path, "err", err)
+			continue // per-item isolation: one flaky entry never starves the rest
+		}
+		p.Log.Info("retirement: proposed retiring decayed entry", "entry", path, "factor", factor,
+			"recalls", agg.Recalls, "resolved", agg.Resolved, "up", agg.FeedbackUp, "down", agg.FeedbackDown)
+	}
+	return nil
+}
+
+// retireBody renders the reviewer-facing retirement proposal. It is honest about
+// the recall side effect (the entry is already rejected at the same floor) and
+// about the veto path (close to keep). The invisible marker (last, like
+// contestedComment) makes re-runs idempotent and encodes the human veto.
+func retireBody(path string, agg outcome.Aggregate, factor, floor float64, marker string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**RunLore proposes retiring `%s`** — its outcome track record decayed below the trust floor.\n\n", path)
+	fmt.Fprintf(&b, "| recalls | resolved | 👍 | 👎 | factor | floor |\n|---|---|---|---|---|---|\n| %d | %d | %d | %d | %.2f | %.2f |\n\n",
+		agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, factor, floor)
+	b.WriteString("Recall already rejects this entry at the same floor, so every recurrence pays a full investigation; ")
+	b.WriteString("merging this PR retires the entry (`status: retired` — it stops being recallable but stays in git history). ")
+	b.WriteString("Close this PR to keep the entry: RunLore will not propose it again.\n\n")
+	b.WriteString(marker)
+	return b.String()
+}
+
+// retireMarker is the hidden idempotency/veto marker embedded in a retire PR body:
+// one per entry path. The path is hashed rather than embedded verbatim so a path
+// with "--"/">" sequences can never break out of the HTML comment.
+func retireMarker(entryPath string) string {
+	sum := sha256.Sum256([]byte(entryPath))
+	return fmt.Sprintf("<!-- runlore:retire:%x -->", sum[:8])
+}
+
+// bodiesOf projects the PR bodies for marker scanning.
+func bodiesOf(prs []providers.CuratedIssue) []string {
+	bodies := make([]string, 0, len(prs))
+	for _, pr := range prs {
+		bodies = append(bodies, pr.Body)
+	}
+	return bodies
+}

--- a/internal/curate/retirement_test.go
+++ b/internal/curate/retirement_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/forge/github"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func quietLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// fakeRetireForge records every call so tests can assert exactly which entries were
+// proposed for retirement (and that empty candidate sets make zero calls).
+type fakeRetireForge struct {
+	open, closed       []providers.CuratedIssue
+	openErr, closedErr error
+	retireErr          map[string]error // per-path OpenRetirePR error injection
+
+	listOpen, listClosed int
+	proposed             []string          // entryPaths passed to OpenRetirePR, in call order
+	bodies               map[string]string // entryPath -> body
+}
+
+func (f *fakeRetireForge) ListPRsByLabel(_ context.Context, _ string) ([]providers.CuratedIssue, error) {
+	f.listOpen++
+	return f.open, f.openErr
+}
+
+func (f *fakeRetireForge) ListClosedUnmergedPRsByLabel(_ context.Context, _ string) ([]providers.CuratedIssue, error) {
+	f.listClosed++
+	return f.closed, f.closedErr
+}
+
+func (f *fakeRetireForge) OpenRetirePR(_ context.Context, entryPath, body string) (providers.Ref, error) {
+	f.proposed = append(f.proposed, entryPath)
+	if f.bodies == nil {
+		f.bodies = map[string]string{}
+	}
+	f.bodies[entryPath] = body
+	if err := f.retireErr[entryPath]; err != nil {
+		return providers.Ref{}, err
+	}
+	return providers.Ref{URL: "https://github.com/o/r/pull/1"}, nil
+}
+
+type mapStats map[string]outcome.Aggregate
+
+func (m mapStats) OpenCounts() (map[string]outcome.Aggregate, error) { return m, nil }
+
+// *github.Client must satisfy the consumer-side RetireForge interface.
+var _ RetireForge = (*github.Client)(nil)
+
+func newRetirement(forge RetireForge, stats RetireStats) Retirement {
+	return Retirement{
+		Forge:           forge,
+		Stats:           stats,
+		MinObservations: 3,
+		Floor:           0.5,
+		Prior:           2.0,
+		Log:             quietLogger(),
+	}
+}
+
+func TestRetirement(t *testing.T) {
+	t.Run("retires only sustained-decay entries, in sorted order", func(t *testing.T) {
+		stats := mapStats{
+			"incidents/decayed-recalls.md": {Recalls: 3},                  // factor 0.20, obs 3 -> retire
+			"incidents/decayed-votes.md":   {Recalls: 2, FeedbackDown: 1}, // factor 0.20, obs 3 -> retire
+			"incidents/one-bad-recall.md":  {Recalls: 1},                  // factor 0.33 but obs 1 -> keep
+			"incidents/two-unresolved.md":  {Recalls: 2},                  // factor 0.25 but obs 2 -> keep
+			"incidents/healthy.md":         {Recalls: 4, Resolved: 4},     // factor 0.83 -> keep
+		}
+		forge := &fakeRetireForge{}
+		if err := newRetirement(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		want := []string{"incidents/decayed-recalls.md", "incidents/decayed-votes.md"}
+		if !slices.Equal(forge.proposed, want) {
+			t.Fatalf("proposed=%v, want %v", forge.proposed, want)
+		}
+		// Body carries the marker, the factor, and honest reviewer-facing language.
+		body := forge.bodies["incidents/decayed-recalls.md"]
+		marker := retireMarker("incidents/decayed-recalls.md")
+		if !strings.Contains(body, marker) {
+			t.Errorf("body missing marker:\n%s", body)
+		}
+		if !strings.Contains(body, "0.20") {
+			t.Errorf("body missing factor 0.20:\n%s", body)
+		}
+		if !strings.Contains(body, "merging this PR retires the entry") {
+			t.Errorf("body missing veto-honest phrasing:\n%s", body)
+		}
+	})
+
+	t.Run("idempotent: an open retire PR with the marker is skipped", func(t *testing.T) {
+		path := "incidents/decayed-recalls.md"
+		stats := mapStats{path: {Recalls: 3}}
+		forge := &fakeRetireForge{
+			open: []providers.CuratedIssue{{Number: 7, Body: "proposal\n" + retireMarker(path)}},
+		}
+		if err := newRetirement(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(forge.proposed) != 0 {
+			t.Fatalf("expected no new PR, got %v", forge.proposed)
+		}
+		if forge.listOpen != 1 {
+			t.Fatalf("ListPRsByLabel called %d times, want exactly 1 per run", forge.listOpen)
+		}
+	})
+
+	t.Run("human veto: a closed-unmerged retire PR with the marker is never re-nagged", func(t *testing.T) {
+		path := "incidents/decayed-recalls.md"
+		stats := mapStats{path: {Recalls: 3}}
+		forge := &fakeRetireForge{
+			closed: []providers.CuratedIssue{{Number: 9, Body: "rejected\n" + retireMarker(path)}},
+		}
+		if err := newRetirement(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(forge.proposed) != 0 {
+			t.Fatalf("human veto ignored: proposed %v", forge.proposed)
+		}
+	})
+
+	t.Run("ErrAlreadyRetired is a done-skip, the rest still run", func(t *testing.T) {
+		stats := mapStats{
+			"incidents/a.md": {Recalls: 3},
+			"incidents/b.md": {Recalls: 3},
+		}
+		forge := &fakeRetireForge{retireErr: map[string]error{"incidents/a.md": github.ErrAlreadyRetired}}
+		if err := newRetirement(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run should not surface ErrAlreadyRetired: %v", err)
+		}
+		if !slices.Equal(forge.proposed, []string{"incidents/a.md", "incidents/b.md"}) {
+			t.Fatalf("both entries must be attempted, got %v", forge.proposed)
+		}
+	})
+
+	t.Run("per-item error isolation: one flaky entry never starves the rest", func(t *testing.T) {
+		stats := mapStats{
+			"incidents/a.md": {Recalls: 3},
+			"incidents/b.md": {Recalls: 3},
+		}
+		forge := &fakeRetireForge{retireErr: map[string]error{"incidents/a.md": errors.New("forge boom")}}
+		if err := newRetirement(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("a per-item error must not fail the run: %v", err)
+		}
+		if !slices.Equal(forge.proposed, []string{"incidents/a.md", "incidents/b.md"}) {
+			t.Fatalf("both entries must be attempted, got %v", forge.proposed)
+		}
+	})
+
+	t.Run("empty candidate set makes zero forge calls", func(t *testing.T) {
+		stats := mapStats{"incidents/healthy.md": {Recalls: 4, Resolved: 4}}
+		forge := &fakeRetireForge{}
+		if err := newRetirement(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if forge.listOpen != 0 || forge.listClosed != 0 || len(forge.proposed) != 0 {
+			t.Fatalf("no candidates must mean zero forge calls: listOpen=%d listClosed=%d proposed=%v",
+				forge.listOpen, forge.listClosed, forge.proposed)
+		}
+	})
+}

--- a/internal/forge/github/retire.go
+++ b/internal/forge/github/retire.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"fmt"
+	"strings"
+)
+
+// setStatusRetired stamps `status: retired` into an OKF entry's YAML frontmatter,
+// editing ONLY the status line — human formatting, key order and comments are
+// preserved (this file is a human-authored artifact under review; a re-marshal
+// would produce an unreadable retirement diff). Scanning is fence-bounded so a
+// "status:" string in the markdown body is never touched. already=true means the
+// entry is retired on the base branch and no PR is needed. A file without a
+// frontmatter block errors: retirement must never write blind.
+func setStatusRetired(content []byte) (out []byte, already bool, err error) {
+	s := string(content)
+	if !strings.HasPrefix(s, "---\n") {
+		return nil, false, fmt.Errorf("entry has no YAML frontmatter block")
+	}
+	rest := s[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil, false, fmt.Errorf("entry frontmatter block is unterminated")
+	}
+	fm, body := rest[:end], rest[end:]
+	lines := strings.Split(fm, "\n")
+	for i, ln := range lines {
+		if key, val, ok := strings.Cut(ln, ":"); ok && strings.TrimSpace(key) == "status" {
+			if strings.TrimSpace(val) == "retired" {
+				return content, true, nil
+			}
+			lines[i] = "status: retired"
+			return []byte("---\n" + strings.Join(lines, "\n") + body), false, nil
+		}
+	}
+	return []byte("---\nstatus: retired\n" + fm + body), false, nil
+}

--- a/internal/forge/github/retire.go
+++ b/internal/forge/github/retire.go
@@ -3,9 +3,20 @@
 package github
 
 import (
+	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
 )
+
+// ErrAlreadyRetired signals the entry already carries status:retired on the base
+// branch, so no retirement PR is needed. The curate pass treats it as done-skip.
+var ErrAlreadyRetired = errors.New("entry already retired on base branch")
 
 // setStatusRetired stamps `status: retired` into an OKF entry's YAML frontmatter,
 // editing ONLY the status line — human formatting, key order and comments are
@@ -36,4 +47,80 @@ func setStatusRetired(content []byte) (out []byte, already bool, err error) {
 		}
 	}
 	return []byte("---\nstatus: retired\n" + fm + body), false, nil
+}
+
+// retireLabels mark a PR proposed by the curate retirement pass — "runlore" for
+// the shared forge namespace, "runlore-retire" for the pass's idempotency and
+// human-veto listings.
+var retireLabels = []string{"runlore", "runlore-retire"}
+
+// OpenRetirePR opens a human-reviewed PR that stamps status:retired into an
+// existing catalog entry's frontmatter. It never merges and never deletes — a
+// human is the load-bearing gate. body carries the reviewer-facing track record
+// and the hidden idempotency marker (authored by the caller). Returns
+// ErrAlreadyRetired when the entry is already retired on the base branch (no PR
+// opened); a 404 on the entry file surfaces as an error (entry deleted → the pass
+// logs and skips it).
+func (c *Client) OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error) {
+	// 1. fetch the entry on the base branch: its content and blob sha.
+	var file struct {
+		Content string `json:"content"`
+		SHA     string `json:"sha"`
+	}
+	if err := c.do(ctx, http.MethodGet,
+		fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s", c.owner, c.repo, entryPath, c.baseBranch), nil, &file); err != nil {
+		return providers.Ref{}, err
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(file.Content, "\n", ""))
+	if err != nil {
+		return providers.Ref{}, fmt.Errorf("decode %s: %w", entryPath, err)
+	}
+	stamped, already, err := setStatusRetired(raw)
+	if err != nil {
+		return providers.Ref{}, fmt.Errorf("%s: %w", entryPath, err)
+	}
+	if already {
+		return providers.Ref{}, ErrAlreadyRetired
+	}
+
+	// 2. base ref SHA.
+	var ref struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", c.owner, c.repo, c.baseBranch), nil, &ref); err != nil {
+		return providers.Ref{}, err
+	}
+	// 3. create the retire branch.
+	branch := fmt.Sprintf("runlore/retire-%s-%d", slugify(entryPath), time.Now().Unix())
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/git/refs", c.owner, c.repo),
+		map[string]any{"ref": "refs/heads/" + branch, "sha": ref.Object.SHA}, nil); err != nil {
+		return providers.Ref{}, err
+	}
+	// 4. update the entry file in place — the file sha makes this an update, not a create.
+	if err := c.do(ctx, http.MethodPut, fmt.Sprintf("/repos/%s/%s/contents/%s", c.owner, c.repo, entryPath),
+		map[string]any{
+			"message": "runlore: retire " + entryPath,
+			"content": base64.StdEncoding.EncodeToString(stamped),
+			"branch":  branch,
+			"sha":     file.SHA,
+		}, nil); err != nil {
+		return providers.Ref{}, err
+	}
+	// 5. open the PR.
+	var out struct {
+		HTMLURL string `json:"html_url"`
+		Number  int    `json:"number"`
+	}
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/pulls", c.owner, c.repo),
+		map[string]any{"title": "KB retire: " + entryPath, "head": branch, "base": c.baseBranch, "body": body}, &out); err != nil {
+		return providers.Ref{}, err
+	}
+	// 6. label the PR. Best-effort: a labelling failure must not lose the PR (same
+	// contract as OpenPR), so the error is intentionally ignored.
+	if out.Number != 0 {
+		_ = c.addLabels(ctx, out.Number, retireLabels)
+	}
+	return providers.Ref{URL: out.HTMLURL}, nil
 }

--- a/internal/forge/github/retire_test.go
+++ b/internal/forge/github/retire_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSetStatusRetired(t *testing.T) {
+	t.Run("inserts status after the opening fence", func(t *testing.T) {
+		in := "---\ntype: Incident\ntitle: t\n---\nbody\n"
+		out, already, err := setStatusRetired([]byte(in))
+		if err != nil || already {
+			t.Fatalf("err=%v already=%v", err, already)
+		}
+		want := "---\nstatus: retired\ntype: Incident\ntitle: t\n---\nbody\n"
+		if string(out) != want {
+			t.Errorf("got:\n%s\nwant:\n%s", out, want)
+		}
+	})
+	t.Run("replaces an existing status line in place", func(t *testing.T) {
+		in := "---\ntype: Incident\nstatus: active\ntitle: t\n---\nbody\n"
+		out, already, err := setStatusRetired([]byte(in))
+		if err != nil || already {
+			t.Fatalf("err=%v already=%v", err, already)
+		}
+		if !strings.Contains(string(out), "\nstatus: retired\n") || strings.Contains(string(out), "active") {
+			t.Errorf("status not replaced in place:\n%s", out)
+		}
+	})
+	t.Run("already retired reports already, content unchanged", func(t *testing.T) {
+		in := "---\nstatus: retired\ntype: Incident\n---\nbody\n"
+		out, already, err := setStatusRetired([]byte(in))
+		if err != nil || !already {
+			t.Fatalf("err=%v already=%v", err, already)
+		}
+		if string(out) != in {
+			t.Errorf("content changed on already-retired entry")
+		}
+	})
+	t.Run("no frontmatter is an error, never a blind write", func(t *testing.T) {
+		if _, _, err := setStatusRetired([]byte("just a body\n")); err == nil {
+			t.Fatal("want error on missing frontmatter")
+		}
+	})
+	t.Run("status in the BODY does not fool the fence scan", func(t *testing.T) {
+		in := "---\ntype: Incident\n---\nstatus: retired appears in prose\n"
+		out, already, err := setStatusRetired([]byte(in))
+		if err != nil || already {
+			t.Fatalf("err=%v already=%v", err, already)
+		}
+		if !strings.HasPrefix(string(out), "---\nstatus: retired\n") {
+			t.Errorf("status not inserted into frontmatter:\n%s", out)
+		}
+	})
+}

--- a/internal/forge/github/retire_test.go
+++ b/internal/forge/github/retire_test.go
@@ -3,6 +3,12 @@
 package github
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -52,6 +58,125 @@ func TestSetStatusRetired(t *testing.T) {
 		}
 		if !strings.HasPrefix(string(out), "---\nstatus: retired\n") {
 			t.Errorf("status not inserted into frontmatter:\n%s", out)
+		}
+	})
+}
+
+// wrapBase64 mimics GitHub's contents API, which returns base64 wrapped at 60
+// chars with newlines — the decode path must strip them before decoding.
+func wrapBase64(b []byte) string {
+	s := base64.StdEncoding.EncodeToString(b)
+	var out strings.Builder
+	for i := 0; i < len(s); i += 60 {
+		end := min(i+60, len(s))
+		out.WriteString(s[i:end])
+		out.WriteByte('\n')
+	}
+	return out.String()
+}
+
+func TestOpenRetirePR(t *testing.T) {
+	const entry = "---\ntype: Incident\ntitle: t\n---\nbody\n"
+
+	t.Run("opens a status:retired PR carrying the file sha", func(t *testing.T) {
+		var calls []string
+		var putBody map[string]any
+		var labelBody map[string]any
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "GET contents "+r.PathValue("path"))
+			_ = json.NewEncoder(w).Encode(map[string]any{"content": wrapBase64([]byte(entry)), "sha": "filesha123"})
+		})
+		mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "GET baseref")
+			_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "POST refs")
+			_, _ = w.Write([]byte(`{}`))
+		})
+		mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "PUT contents "+r.PathValue("path"))
+			_ = json.NewDecoder(r.Body).Decode(&putBody)
+			_, _ = w.Write([]byte(`{}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "POST pulls")
+			_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/42","number":42}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/issues/42/labels", func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "POST labels")
+			_ = json.NewDecoder(r.Body).Decode(&labelBody)
+			_, _ = w.Write([]byte(`[]`))
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		ref, err := c.OpenRetirePR(context.Background(), "incidents/t.md", "body with marker")
+		if err != nil {
+			t.Fatalf("OpenRetirePR: %v", err)
+		}
+		if ref.URL != "https://github.com/o/r/pull/42" {
+			t.Fatalf("ref=%s", ref.URL)
+		}
+		// All six calls, PR opened before labels.
+		if len(calls) != 6 || calls[0] != "GET contents incidents/t.md" || calls[len(calls)-1] != "POST labels" {
+			t.Fatalf("unexpected call sequence: %v", calls)
+		}
+		// (a) PUT content is the stamped file.
+		raw, _ := base64.StdEncoding.DecodeString(putBody["content"].(string))
+		if !strings.HasPrefix(string(raw), "---\nstatus: retired\n") {
+			t.Errorf("PUT content not stamped:\n%s", raw)
+		}
+		// (b) PUT carries the file sha from the first GET (makes it an update).
+		if putBody["sha"] != "filesha123" {
+			t.Errorf("PUT sha=%v, want filesha123", putBody["sha"])
+		}
+		// Labels applied.
+		gotLabels, _ := labelBody["labels"].([]any)
+		if len(gotLabels) != 2 || gotLabels[0] != "runlore" || gotLabels[1] != "runlore-retire" {
+			t.Errorf("labels=%v, want [runlore runlore-retire]", labelBody["labels"])
+		}
+	})
+
+	t.Run("already retired short-circuits after the first GET", func(t *testing.T) {
+		var calls []string
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "GET contents")
+			retired := "---\nstatus: retired\ntype: Incident\n---\nbody\n"
+			_ = json.NewEncoder(w).Encode(map[string]any{"content": wrapBase64([]byte(retired)), "sha": "s"})
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		_, err := c.OpenRetirePR(context.Background(), "incidents/t.md", "body")
+		if !errors.Is(err, ErrAlreadyRetired) {
+			t.Fatalf("err=%v, want ErrAlreadyRetired", err)
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected only the contents GET, got %v", calls)
+		}
+	})
+
+	t.Run("404 on the entry file errors with no further calls", func(t *testing.T) {
+		var calls []string
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "GET contents")
+			w.WriteHeader(http.StatusNotFound)
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		if _, err := c.OpenRetirePR(context.Background(), "incidents/gone.md", "body"); err == nil {
+			t.Fatal("want error on 404 contents GET")
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected only the contents GET, got %v", calls)
 		}
 	})
 }

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -600,7 +600,7 @@ func (r *Recall) outcomeGate(counts map[string]outcome.Aggregate, path string) (
 // with no recall or feedback history never reach this gate (they are absent from
 // OpenCounts), so a brand-new entry is not punished by the 0.5 prior mean.
 func outcomeFactor(recalls, resolved, up, down int, k float64) float64 {
-	return (float64(resolved+up) + k/2) / (float64(recalls+up+down) + k)
+	return outcome.Aggregate{Recalls: recalls, Resolved: resolved, FeedbackUp: up, FeedbackDown: down}.Factor(k)
 }
 
 // deriveRecallConfidence turns the match signals into an explainable confidence,

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -957,6 +957,19 @@ type Aggregate struct {
 	LastConfirmed time.Time
 }
 
+// Factor is the entry's outcome-decay factor: the posterior mean of a symmetric
+// Beta(k/2, k/2) prior over the success rate, folding resolves and human votes
+// into one trust signal:
+//
+//	factor = (Resolved + FeedbackUp + k/2) / (Recalls + FeedbackUp + FeedbackDown + k)
+//
+// It is THE single definition of decay — recall's fire gate and the curate
+// retirement pass both consume it, so they can never drift apart. See
+// investigate's gate docs for the full statistical rationale.
+func (a Aggregate) Factor(k float64) float64 {
+	return (float64(a.Resolved+a.FeedbackUp) + k/2) / (float64(a.Recalls+a.FeedbackUp+a.FeedbackDown) + k)
+}
+
 // OpenCounts rolls recall episodes up per catalog entry (fresh investigations
 // carry no entry). It is the input to recall decay: resolve-rate ≈
 // (Resolved+k)/(Recalls+k), and runs on the recall hot path once per incident

--- a/internal/outcome/ledger_factor_test.go
+++ b/internal/outcome/ledger_factor_test.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package outcome
+
+import "testing"
+
+func TestAggregateFactor(t *testing.T) {
+	cases := []struct {
+		name string
+		agg  Aggregate
+		k    float64
+		want float64
+	}{
+		{"no history is the prior mean", Aggregate{}, 2.0, 0.5},
+		{"single unresolved recall decays fast", Aggregate{Recalls: 1}, 2.0, 1.0 / 3.0},
+		{"single downvote decays identically", Aggregate{FeedbackDown: 1}, 2.0, 1.0 / 3.0},
+		{"resolving entry climbs", Aggregate{Recalls: 4, Resolved: 4}, 2.0, 5.0 / 6.0},
+		{"upvotes count as successes", Aggregate{FeedbackUp: 2}, 2.0, 3.0 / 4.0},
+	}
+	for _, c := range cases {
+		if got := c.agg.Factor(c.k); got != c.want {
+			t.Errorf("%s: Factor(%v) = %v, want %v", c.name, c.k, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What this does

Adds an opt-in **`curate` Retirement pass** that closes the garbage-collection half of the learning loop (roadmap **N4**). It opens a human-reviewed *retire* PR for a **merged** catalog entry whose outcome track record has sustainably decayed below the trust floor, stamping `status: retired` into the entry's YAML frontmatter. A human merges — curation stays the load-bearing gate; nothing is auto-deleted, and the entry stays in git history.

## The sustained-decay bar

A candidate is an entry that is decayed **both deeply and durably**:

- `Factor(prior) < floor` — the entry's Beta-posterior outcome factor is below the trust floor, **and**
- `recalls + 👍 + 👎 >= min_observations` — the decay is *sustained*, so a single bad recall (factor 0.33) can never retire an entry.

Retirement uses the **same decay formula and floor as recall's Gate 3**: the decay definition moved to a single `outcome.Aggregate.Factor` method that both recall's fire gate and this pass consume, so they can never drift apart. The entry proposed for retirement is exactly the one recall already rejects — every recurrence was already paying a full investigation.

## Opt-in config (`curate.retirement`)

| key | default | meaning |
|---|---|---|
| `enabled` | `false` | when off the pass is not wired at all — default behavior unchanged |
| `min_observations` | `3` | sustained-decay bar; must be `>= 1` |
| `floor` | `0.5` | retire below this factor; must be in `(0,1]`; mirrors recall's `outcome_floor` |
| `prior` | `2.0` | Beta prior strength `k`; mirrors recall's `outcome_prior` |

Defaults are only applied once `enabled`; `Validate` rejects an out-of-range `floor` or `min_observations`.

## Human-veto semantics

The pass is idempotent and human-veto-aware via a hidden per-entry marker in the PR body (no mutable store):

- An **open** retire PR carrying the marker is never re-proposed (idempotency).
- A retire PR a human **closed without merging** is a deliberate "keep it" and is never re-nagged (same closed-unmerged-is-a-no philosophy as the recurrence escalation).
- `ErrAlreadyRetired` (entry already retired on base) is a done-skip; any other per-entry forge error is logged and skipped (per-item isolation — one flaky entry never starves the rest).

The frontmatter edit is surgical (one line, fence-bounded), never a re-marshal, so the retirement diff stays readable and human formatting is preserved.

## Seam with N6

This PR **writes** `status: retired` frontmatter. The catalog loader/recall **honoring** `status` (so a retired entry actually stops being recalled) ships separately as roadmap item **N6** (`dev/superpowers/plans/2026-07-19-okf-staleness.md`). Until then a merged retirement PR is inert but correct — the entry is marked and the decision is recorded in git history. No dependency either way.

## Plan

Implemented task-by-task per `dev/superpowers/plans/2026-07-19-kb-retirement.md` (TDD, one commit per task).

- `refactor(outcome)`: single `Aggregate.Factor` decay definition
- `feat(forge)`: `setStatusRetired` frontmatter stamping helper
- `feat(forge)`: `OpenRetirePR` — status:retired PR against an existing entry
- `feat(curate)`: the Retirement pass
- `feat(curate)`: opt-in config + wiring + docs
