### PR TITLE
feat(outcome): confirming re-investigations recover a downvoted entry

### DIFF
--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -496,6 +496,18 @@ feedback does two jobs: it weighs *recalled knowledge* (the decay above) and it
 governs *when the agent may repeat itself* — both steered by the same single
 human 👍/👎 signal.
 
+**👎 recovery.** A standing 👎 forces re-investigation — and when that fresh
+investigation independently reaches the same conclusion (identical dedup
+fingerprint), the curator records a *confirmation* in the outcome ledger instead of
+silently deduping it away. Confirmations are recovery evidence at **half** the
+weight of a human observation: one 👎 needs two independent confirmations before
+the entry's outcome factor climbs back to the floor and recall fires again (a
+recall costs two model calls instead of a full investigation — this is what ends
+the re-investigation loop). The human override itself is untouched: the recurrence
+cooldown stays broken while the 👎 stands, and only the voter changing their vote
+clears it. The open KB PR's contested warning shows the confirmation count so the
+reviewer sees both signals.
+
 The re-arm holds across the outer noise-control layers too — with one boundary.
 The **coalescer's cooldown** (`investigation.coalesce.cooldown`, 10m default when
 enabled) consults the same standing-👎 signal and lets a contested trigger through

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -404,6 +404,10 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 	// pass onInvestigationComplete's `cur != nil` guard and panic on Curate.
 	var curOrNil investigationCurator
 	if cur != nil {
+		// Fingerprint-dedup matches become recovery evidence for contested entries
+		// (👎 recovery, N5). A disabled ledger (no outcome.ledger_path) no-ops inside
+		// Confirm, so this wiring is unconditional.
+		cur.Confirmations = ledger
 		curOrNil = cur
 	}
 	actions := action.New(cfg.Actions)

--- a/internal/curate/contested.go
+++ b/internal/curate/contested.go
@@ -116,6 +116,10 @@ func contestedComment(ct outcome.ContestedTrigger, marker string) string {
 		ct.Downs, pluralVote(ct.Downs), ct.TriggerKey)
 	b.WriteString("Responders contested the delivered diagnosis. Please review the Cause against the evidence before merging — merging makes it permanent, recallable knowledge.\n\n")
 	b.WriteString("Note: a standing 👎 also re-arms re-investigation (the recurrence cooldown no longer suppresses this trigger), so a fresher conclusion may follow on the next occurrence.\n\n")
+	if ct.Confirms > 0 {
+		fmt.Fprintf(&b, "Since the contest, %d fresh re-investigation%s independently reached this same conclusion (recorded as recovery evidence in the outcome ledger).\n\n",
+			ct.Confirms, pluralS(ct.Confirms))
+	}
 	b.WriteString(marker)
 	return b.String()
 }
@@ -125,6 +129,13 @@ func pluralVote(n int) string {
 		return "vote"
 	}
 	return "votes"
+}
+
+func pluralS(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
 }
 
 // contestedMarker is the hidden idempotency marker embedded in the posted

--- a/internal/curate/contested_test.go
+++ b/internal/curate/contested_test.go
@@ -85,6 +85,19 @@ func TestContestedCommentsOnOpenKBPR(t *testing.T) {
 	}
 }
 
+func TestContestedCommentRendersConfirmations(t *testing.T) {
+	ct := outcome.ContestedTrigger{TriggerKey: "trig-1", CuratedURL: "https://github.com/o/r/pull/7", Downs: 1, Confirms: 2}
+	body := contestedComment(ct, contestedMarker(ct.TriggerKey))
+	if !strings.Contains(body, "2 fresh re-investigations independently reached this same conclusion") {
+		t.Fatalf("comment must surface the confirmation count, got:\n%s", body)
+	}
+	// Zero confirmations: the line is absent (no noise on the common case).
+	ct.Confirms = 0
+	if body := contestedComment(ct, contestedMarker(ct.TriggerKey)); strings.Contains(body, "independently reached") {
+		t.Fatalf("no-confirmation comment must not mention confirmations, got:\n%s", body)
+	}
+}
+
 // TestContestedIdempotentWhenMarkerPresent: an existing comment carrying this
 // trigger's marker means the warning was already surfaced — never re-post, even
 // though the votes still stand on every later run.

--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -19,6 +20,15 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
 )
+
+// ConfirmationSink records that a FRESH investigation independently reached an
+// existing catalog entry's conclusion (identical DupFingerprint) — the recovery
+// evidence that lets a contested entry's outcome factor climb back (see
+// outcome.Ledger.Confirm, which satisfies this). Optional and nil-safe, like
+// Metrics: a curator without a ledger simply keeps today's behavior.
+type ConfirmationSink interface {
+	Confirm(entry, triggerKey, dupFP string, at time.Time) error
+}
 
 // Related-knowledge bounds: how many BM25 neighbors a drafted PR shows the
 // reviewer, and the noise floor below which a "neighbor" is lexical debris.
@@ -42,8 +52,9 @@ type Curator struct {
 	// SkipVerdicts holds verdicts that must NOT draft a KB PR (e.g. no_action).
 	// A nil/empty map draws no distinction — every verdict is eligible, preserving
 	// pre-gate behaviour.
-	SkipVerdicts map[providers.Verdict]bool
-	Log          *slog.Logger
+	SkipVerdicts  map[providers.Verdict]bool
+	Confirmations ConfirmationSink // optional; nil-safe — dedup matches are recovery evidence
+	Log           *slog.Logger
 }
 
 // Curate applies the three-step gate. It returns the created PR ref, or an empty
@@ -80,8 +91,18 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 	// threshold to tune), then catalog BM25 (observe the top-hit score on every
 	// check), then open PRs
 	if ff, ok := c.Catalog.(fingerprintFinder); ok {
-		if e, found := ff.FindFingerprint(DupFingerprint(inv)); found {
+		fp := DupFingerprint(inv)
+		if e, found := ff.FindFingerprint(fp); found {
 			c.Log.Info("finding matches a catalog entry's fingerprint; not filing", "entry", e.Title, "path", e.Path)
+			// Recovery evidence: a fresh investigation independently re-derived this
+			// entry's conclusion — exactly what a standing 👎 forces. Recalls never
+			// reach here (Curate returns on inv.Recalled above). Best-effort: a sink
+			// error is logged, never blocks the (artifact-free) dedup outcome.
+			if c.Confirmations != nil {
+				if err := c.Confirmations.Confirm(e.Path, inv.TriggerKey, fp, time.Now()); err != nil {
+					c.Log.Warn("confirmation record failed", "entry", e.Path, "err", err)
+				}
+			}
 			return providers.Ref{}, nil
 		}
 	}

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -208,15 +209,17 @@ func TestCurateCatalogDuplicateDropsSilently(t *testing.T) {
 
 // fakeFingerprinted is a catalog fake with NO BM25 hits but an exact fingerprint
 // match — proving the deterministic dedup path is independent of the BM25
-// threshold.
+// threshold. path is the matched entry's catalog Path (the confirmation-record
+// attribution target); "" for callers that only assert the drop.
 type fakeFingerprinted struct {
 	fakeScored
-	fp string
+	fp   string
+	path string
 }
 
 func (f fakeFingerprinted) FindFingerprint(fp string) (catalog.Entry, bool) {
 	if fp != "" && fp == f.fp {
-		return catalog.Entry{Title: "already merged", Fingerprint: fp}, true
+		return catalog.Entry{Title: "already merged", Path: f.path, Fingerprint: fp}, true
 	}
 	return catalog.Entry{}, false
 }
@@ -384,6 +387,70 @@ func TestCurateDupStillSkipsWithMultiHits(t *testing.T) {
 	}
 	if ref.URL != "" || f.openedPR != nil {
 		t.Fatal("duplicate finding must not open a PR")
+	}
+}
+
+// recordingSink is a ConfirmationSink that records each Confirm call verbatim.
+type recordingSink struct{ calls []string }
+
+func (s *recordingSink) Confirm(entry, triggerKey, dupFP string, _ time.Time) error {
+	s.calls = append(s.calls, entry+"|"+triggerKey+"|"+dupFP)
+	return nil
+}
+
+// fingerprintMatchingInvestigation is a novel, high-quality finding whose
+// DupFingerprint the dedup curator's fake catalog matches, so Curate reaches the
+// fingerprint-dedup branch (past the recall + quality gates).
+func fingerprintMatchingInvestigation() providers.Investigation {
+	inv := goodFinding()
+	inv.Resource = providers.Workload{Namespace: "apps", Name: "web"}
+	inv.TriggerKey = "trig-1"
+	return inv
+}
+
+// newFingerprintDedupCurator builds a curator whose fake catalog returns a
+// fingerprint match (Path "kb/e.md") for fingerprintMatchingInvestigation — the
+// arrangement the confirmation tests share.
+func newFingerprintDedupCurator(t *testing.T) *Curator {
+	t.Helper()
+	cat := fakeFingerprinted{fp: DupFingerprint(fingerprintMatchingInvestigation()), path: "kb/e.md"}
+	return newCurator(&fakeForge{}, cat)
+}
+
+func TestFingerprintDedupRecordsConfirmation(t *testing.T) {
+	sink := &recordingSink{}
+	c := newFingerprintDedupCurator(t)
+	c.Confirmations = sink
+	inv := fingerprintMatchingInvestigation()
+
+	ref, err := c.Curate(context.Background(), inv)
+	if err != nil || ref.URL != "" {
+		t.Fatalf("dedup branch must still file nothing: ref=%v err=%v", ref, err)
+	}
+	if len(sink.calls) != 1 {
+		t.Fatalf("exactly one confirmation must be recorded, got %v", sink.calls)
+	}
+}
+
+func TestRecalledFindingNeverConfirms(t *testing.T) {
+	sink := &recordingSink{}
+	c := newFingerprintDedupCurator(t)
+	c.Confirmations = sink
+	inv := fingerprintMatchingInvestigation()
+	inv.Recalled = true // Curate early-returns before the dedup branch
+
+	if _, err := c.Curate(context.Background(), inv); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.calls) != 0 {
+		t.Fatalf("a recall must NEVER record recovery evidence, got %v", sink.calls)
+	}
+}
+
+func TestNilSinkIsSafe(t *testing.T) {
+	c := newFingerprintDedupCurator(t) // Confirmations left nil
+	if _, err := c.Curate(context.Background(), fingerprintMatchingInvestigation()); err != nil {
+		t.Fatalf("nil sink must be a no-op, got %v", err)
 	}
 }
 

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -576,20 +576,29 @@ func (r *Recall) outcomeGate(counts map[string]outcome.Aggregate, path string) (
 	if !ok {
 		return 1, true
 	}
-	f := outcomeFactor(agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, r.OutcomePrior)
+	f := outcomeFactor(agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, agg.Confirms, r.OutcomePrior)
 	return f, f >= r.OutcomeFloor
 }
 
 // outcomeFactor decays a recall's confidence by its track record as the posterior
 // mean of a symmetric Beta(k/2, k/2) prior over the success rate:
 //
-//	factor = (resolved + up + k/2) / (recalls + up + down + k)
+//	factor = (resolved + up + confirmWeight·confirms + k/2) /
+//	         (recalls + up + down + confirmWeight·confirms + k)
 //
 // Human 👍/👎 feedback (up/down) are extra Bernoulli observations in the SAME
 // posterior — a 👍 is one success, a 👎 one failure, each weighing exactly like a
 // resolved/unresolved recall. That is deliberate: feedback is the only ground
 // truth non-resolvable sources (GitOps failures) can ever accumulate, since their
 // recalls are excluded from resolve-based decay (see outcome.applyOpenLocked).
+//
+// confirms are machine confirmations — fresh investigations that independently
+// re-derived a contested entry's conclusion — folded in as recovery evidence at
+// HALF a human observation (confirmWeight): a standing 👎 forces re-investigation,
+// and two such confirmations bring a single-👎 entry back to the floor, so a human
+// still outranks any single machine confirmation. The single definition of the
+// formula lives on outcome.Aggregate.Factor; this thin delegate keeps the recall
+// gate and the curate retirement pass reading the same decay.
 //
 // k is the total pseudo-observation count (the prior strength). With the default
 // k=2 this is the documented Beta(1,1) posterior (resolved+up+1)/(recalls+up+down+2):
@@ -599,8 +608,8 @@ func (r *Recall) outcomeGate(counts map[string]outcome.Aggregate, path string) (
 // Always in (0, 1) for k > 0, resolved ≤ recalls and non-negative votes. Entries
 // with no recall or feedback history never reach this gate (they are absent from
 // OpenCounts), so a brand-new entry is not punished by the 0.5 prior mean.
-func outcomeFactor(recalls, resolved, up, down int, k float64) float64 {
-	return outcome.Aggregate{Recalls: recalls, Resolved: resolved, FeedbackUp: up, FeedbackDown: down}.Factor(k)
+func outcomeFactor(recalls, resolved, up, down, confirms int, k float64) float64 {
+	return outcome.Aggregate{Recalls: recalls, Resolved: resolved, FeedbackUp: up, FeedbackDown: down, Confirms: confirms}.Factor(k)
 }
 
 // deriveRecallConfidence turns the match signals into an explainable confidence,

--- a/internal/investigate/recall_decay_integration_test.go
+++ b/internal/investigate/recall_decay_integration_test.go
@@ -87,3 +87,45 @@ apps/worker pods are OOMKilled shortly after a values change lowered the memory 
 		t.Fatalf("fixture invalid: outcomeFactor(4,0,0,0,0,2)=%v is not below the 0.5 floor", f)
 	}
 }
+
+// TestRecallRecoversAfterConfirmations pins the 👎 recovery contract end to end
+// over the real Recall gate: one standing 👎 rejects the recall; one machine
+// confirmation still rejects (human outranks a single confirm); the second
+// confirmation recovers it.
+func TestRecallRecoversAfterConfirmations(t *testing.T) {
+	dir := t.TempDir()
+	entry := `---
+type: Incident
+title: worker OOMKilled after memory limit drop
+description: apps/worker pods OOMKilled; raise the container memory limit
+resource: apps/worker
+---
+
+# Symptom
+apps/worker pods are OOMKilled shortly after a values change lowered the memory limit.
+`
+	if err := os.WriteFile(filepath.Join(dir, "worker-oom.md"), []byte(entry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := catalog.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := cat.Entries()[0].Path
+	req := Request{Title: "WorkerOOM", Message: "apps/worker pods OOMKilled after memory limit drop",
+		Workload: providers.Workload{Namespace: "apps", Name: "worker"}}
+	newRecall := func(agg outcome.Aggregate) *Recall {
+		return &Recall{Catalog: cat, MinScore: 0.001, SoloFloor: 0.001, MarginGap: 0.001,
+			Outcome:      fakeOutcome{counts: map[string]outcome.Aggregate{path: agg}},
+			OutcomePrior: 2.0, OutcomeFloor: 0.5}
+	}
+	if e, _ := newRecall(outcome.Aggregate{FeedbackDown: 1}).lookup(context.Background(), req); e != nil {
+		t.Fatal("one standing 👎 must reject the recall")
+	}
+	if e, _ := newRecall(outcome.Aggregate{FeedbackDown: 1, Confirms: 1}).lookup(context.Background(), req); e != nil {
+		t.Fatal("one machine confirmation must NOT overcome a human 👎")
+	}
+	if e, _ := newRecall(outcome.Aggregate{FeedbackDown: 1, Confirms: 2}).lookup(context.Background(), req); e == nil {
+		t.Fatal("two confirmations must recover the recall (factor back at the floor)")
+	}
+}

--- a/internal/investigate/recall_decay_integration_test.go
+++ b/internal/investigate/recall_decay_integration_test.go
@@ -83,7 +83,7 @@ apps/worker pods are OOMKilled shortly after a values change lowered the memory 
 
 	// Guard the sub-floor premise under both formulas, so the fixture stays valid if the
 	// parallel outcomeFactor change lands.
-	if f := outcomeFactor(4, 0, 0, 0, 2.0); f >= 0.5 {
-		t.Fatalf("fixture invalid: outcomeFactor(4,0,0,0,2)=%v is not below the 0.5 floor", f)
+	if f := outcomeFactor(4, 0, 0, 0, 0, 2.0); f >= 0.5 {
+		t.Fatalf("fixture invalid: outcomeFactor(4,0,0,0,0,2)=%v is not below the 0.5 floor", f)
 	}
 }

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -220,37 +220,51 @@ func TestRecalledInvestigationStampsAlertMetadata(t *testing.T) {
 func TestOutcomeFactor(t *testing.T) {
 	const k = 2.0 // default prior strength; k=2 ⇒ documented Beta(1,1): (resolved+up+1)/(recalls+up+down+2)
 	cases := []struct {
-		recalls, resolved, up, down int
-		want                        float64
+		recalls, resolved, up, down, confirms int
+		want                                  float64
 	}{
 		// resolved=0, recalls 0..3 — a never-resolving entry decays fast.
-		{0, 0, 0, 0, 0.5},       // (0+1)/(0+2) — prior mean; never reaches the gate in practice
-		{1, 0, 0, 0, 1.0 / 3.0}, // (0+1)/(1+2) ≈ 0.333 — already below the 0.5 floor at the 1st recall
-		{2, 0, 0, 0, 0.25},      // (0+1)/(2+2)
-		{3, 0, 0, 0, 0.2},       // (0+1)/(3+2)
-		{6, 0, 0, 0, 0.125},     // (0+1)/(6+2)
+		{0, 0, 0, 0, 0, 0.5},       // (0+1)/(0+2) — prior mean; never reaches the gate in practice
+		{1, 0, 0, 0, 0, 1.0 / 3.0}, // (0+1)/(1+2) ≈ 0.333 — already below the 0.5 floor at the 1st recall
+		{2, 0, 0, 0, 0, 0.25},      // (0+1)/(2+2)
+		{3, 0, 0, 0, 0, 0.2},       // (0+1)/(3+2)
+		{6, 0, 0, 0, 0, 0.125},     // (0+1)/(6+2)
 		// mixed resolve records.
-		{3, 1, 0, 0, 0.4},       // (1+1)/(3+2)
-		{3, 2, 0, 0, 0.6},       // (2+1)/(3+2)
-		{4, 2, 0, 0, 0.5},       // (2+1)/(4+2) — exactly at the floor
-		{5, 5, 0, 0, 6.0 / 7.0}, // (5+1)/(5+2) ≈ 0.857 — always-resolving asymptotes to 1, never exceeds it
+		{3, 1, 0, 0, 0, 0.4},       // (1+1)/(3+2)
+		{3, 2, 0, 0, 0, 0.6},       // (2+1)/(3+2)
+		{4, 2, 0, 0, 0, 0.5},       // (2+1)/(4+2) — exactly at the floor
+		{5, 5, 0, 0, 0, 6.0 / 7.0}, // (5+1)/(5+2) ≈ 0.857 — always-resolving asymptotes to 1, never exceeds it
 		// human feedback — extra Bernoulli observations in the same posterior. The
 		// zero-recall rows are the non-resolvable-source case (GitOps): feedback is
 		// the ONLY evidence such entries can ever accumulate.
-		{0, 0, 2, 0, 0.75},      // (0+2+1)/(0+2+2) — two 👍, no resolves: trust builds
-		{0, 0, 0, 2, 0.25},      // (0+0+1)/(0+2+2) — two 👎: below the 0.5 floor, recall rejected
-		{0, 0, 0, 1, 1.0 / 3.0}, // one 👎 weighs exactly like one unresolved recall
-		{3, 2, 1, 1, 4.0 / 7.0}, // (2+1+1)/(3+1+1+2) — feedback blends with resolves
-		{5, 5, 0, 3, 0.6},       // (5+0+1)/(5+0+3+2) — 👎 erode even a perfect resolve record
+		{0, 0, 2, 0, 0, 0.75},      // (0+2+1)/(0+2+2) — two 👍, no resolves: trust builds
+		{0, 0, 0, 2, 0, 0.25},      // (0+0+1)/(0+2+2) — two 👎: below the 0.5 floor, recall rejected
+		{0, 0, 0, 1, 0, 1.0 / 3.0}, // one 👎 weighs exactly like one unresolved recall
+		{3, 2, 1, 1, 0, 4.0 / 7.0}, // (2+1+1)/(3+1+1+2) — feedback blends with resolves
+		{5, 5, 0, 3, 0, 0.6},       // (5+0+1)/(5+0+3+2) — 👎 erode even a perfect resolve record
+		// Recovery contract (k=2, floor 0.5 in prod): a machine confirmation is half a
+		// Bernoulli success (confirmWeight 0.5) in the same posterior.
+		{0, 0, 0, 1, 0, 1.0 / 3.0}, // one 👎 alone: rejected
+		{0, 0, 0, 1, 1, 1.5 / 3.5}, // one confirm: STILL rejected (human wins)
+		{0, 0, 0, 1, 2, 2.0 / 4.0}, // two confirms: exactly at the floor → recovered
+		{0, 0, 0, 0, 2, 2.0 / 3.0}, // confirms alone build trust gently
 	}
 	for _, c := range cases {
-		got := outcomeFactor(c.recalls, c.resolved, c.up, c.down, k)
+		got := outcomeFactor(c.recalls, c.resolved, c.up, c.down, c.confirms, k)
 		if math.Abs(got-c.want) > 1e-9 {
-			t.Errorf("outcomeFactor(%d,%d,%d,%d,%v) = %v, want %v", c.recalls, c.resolved, c.up, c.down, k, got, c.want)
+			t.Errorf("outcomeFactor(%d,%d,%d,%d,%d,%v) = %v, want %v", c.recalls, c.resolved, c.up, c.down, c.confirms, k, got, c.want)
 		}
 		if got > 1.0 {
 			t.Errorf("factor must be <= 1.0, got %v", got)
 		}
+	}
+	// The recovery threshold is exactly the floor: rejection is strictly f < floor,
+	// so factor == 0.5 passes. One 👎 + two confirms is the minimum recovery.
+	if f := outcomeFactor(0, 0, 0, 1, 2, 2.0); f < 0.5 {
+		t.Fatalf("one down + two confirms = %v, must reach the 0.5 floor", f)
+	}
+	if f := outcomeFactor(0, 0, 0, 1, 1, 2.0); f >= 0.5 {
+		t.Fatalf("one down + ONE confirm = %v, must stay below the floor (human outranks one machine confirm)", f)
 	}
 }
 

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -981,17 +981,31 @@ type Aggregate struct {
 	Confirms int
 }
 
+// confirmWeight is how much of one human observation a machine confirmation is
+// worth in the Beta posterior. Half: a fresh investigation re-deriving the same
+// conclusion is real evidence, but a human 👎 must outrank any SINGLE machine
+// confirmation — with k=2 and floor 0.5, one 👎 needs TWO confirmations to recover.
+const confirmWeight = 0.5
+
 // Factor is the entry's outcome-decay factor: the posterior mean of a symmetric
-// Beta(k/2, k/2) prior over the success rate, folding resolves and human votes
-// into one trust signal:
+// Beta(k/2, k/2) prior over the success rate, folding resolves, human votes, and
+// machine confirmations into one trust signal:
 //
-//	factor = (Resolved + FeedbackUp + k/2) / (Recalls + FeedbackUp + FeedbackDown + k)
+//	factor = (Resolved + FeedbackUp + confirmWeight·Confirms + k/2) /
+//	         (Recalls + FeedbackUp + FeedbackDown + confirmWeight·Confirms + k)
+//
+// Confirms are recovery evidence at HALF the weight of a human observation
+// (confirmWeight): a fresh re-investigation independently reaching an entry's
+// conclusion counts as a partial success, but a human 👎 still outranks any single
+// confirmation — one 👎 needs two confirmations to climb back to the floor.
 //
 // It is THE single definition of decay — recall's fire gate and the curate
-// retirement pass both consume it, so they can never drift apart. See
+// retirement pass both consume it, so they can never drift apart (a
+// confirm-recovered entry therefore also exits retirement candidacy). See
 // investigate's gate docs for the full statistical rationale.
 func (a Aggregate) Factor(k float64) float64 {
-	return (float64(a.Resolved+a.FeedbackUp) + k/2) / (float64(a.Recalls+a.FeedbackUp+a.FeedbackDown) + k)
+	c := confirmWeight * float64(a.Confirms)
+	return (float64(a.Resolved+a.FeedbackUp) + c + k/2) / (float64(a.Recalls+a.FeedbackUp+a.FeedbackDown) + c + k)
 }
 
 // OpenCounts rolls recall episodes up per catalog entry (fresh investigations

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -59,7 +59,7 @@ func Derived(fp string) bool {
 
 // Event is one ledger line: an investigation opened, or an incident resolved.
 type Event struct {
-	Event          string `json:"event"`                     // "open" | "resolve"
+	Event          string `json:"event"`                     // "open" | "resolve" | "feedback" | "checkpoint" | "confirm"
 	Fingerprint    string `json:"fingerprint"`               // Alertmanager fingerprint (stable firing↔resolved)
 	DupFingerprint string `json:"dup_fingerprint,omitempty"` // curator dedup fingerprint (resource+cause); the curated-PR resolution join key
 
@@ -163,6 +163,11 @@ type Ledger struct {
 	// OutcomeFloor. Folded on replay like agg; checkpointed on compaction.
 	votes map[string]feedbackVote
 
+	// triggerConfirms counts confirmations per TriggerKey — the ContestedTriggers
+	// join that lets the curate Contested pass tell a reviewer "N re-investigations
+	// reached this same conclusion". Rebuilt on load, checkpointed on compaction.
+	triggerConfirms map[string]int
+
 	// droppedResolves counts orphan resolves discarded by the pendingResolves bound
 	// (see maxPendingResolvesPerFingerprint) — spurious duplicate/replayed resolve
 	// webhooks. Kept so the (otherwise silent) defensive drop is observable.
@@ -205,6 +210,7 @@ type checkpointData struct {
 	PendingOpens    map[string][]pendingOpenJSON `json:"pending_opens,omitempty"`
 	PendingResolves map[string][]time.Time       `json:"pending_resolves,omitempty"`
 	Votes           map[string]feedbackVoteJSON  `json:"votes,omitempty"`
+	TriggerConfirms map[string]int               `json:"trigger_confirms,omitempty"`
 	DroppedResolves int                          `json:"dropped_resolves,omitempty"`
 	StaleResolves   int                          `json:"stale_resolves,omitempty"`
 }
@@ -370,6 +376,7 @@ func (l *Ledger) resetStateLocked() {
 	l.pendingResolves = map[string][]time.Time{}
 	l.byTrigger = map[string]triggerAgg{}
 	l.votes = map[string]feedbackVote{}
+	l.triggerConfirms = map[string]int{}
 	l.droppedResolves = 0
 	l.staleResolves = 0
 }
@@ -391,6 +398,8 @@ func (l *Ledger) foldLocked(e Event) {
 		l.applyResolveLocked(e.Fingerprint, e.At)
 	case "feedback":
 		l.applyFeedbackLocked(e)
+	case "confirm":
+		l.applyConfirmLocked(e)
 	case "checkpoint":
 		l.seedCheckpointLocked(e.Checkpoint)
 	}
@@ -421,6 +430,9 @@ func (l *Ledger) seedCheckpointLocked(cd *checkpointData) {
 	}
 	for k, v := range cd.Votes {
 		l.votes[k] = feedbackVote{rating: v.Rating, entry: v.Entry}
+	}
+	for k, v := range cd.TriggerConfirms {
+		l.triggerConfirms[k] = v
 	}
 	for fp, opens := range cd.PendingOpens {
 		stack := make([]pendingOpen, 0, len(opens))
@@ -480,6 +492,12 @@ func (l *Ledger) snapshotCheckpointLocked() *checkpointData {
 		cd.Votes = make(map[string]feedbackVoteJSON, len(l.votes))
 		for k, v := range l.votes {
 			cd.Votes[k] = feedbackVoteJSON{Rating: v.rating, Entry: v.entry}
+		}
+	}
+	if len(l.triggerConfirms) > 0 {
+		cd.TriggerConfirms = make(map[string]int, len(l.triggerConfirms))
+		for k, v := range l.triggerConfirms {
+			cd.TriggerConfirms[k] = v
 		}
 	}
 	if len(l.pendingOpens) > 0 {
@@ -836,6 +854,7 @@ type ContestedTrigger struct {
 	CuratedURL string    // KB link of the newest open (never "")
 	Downs      int       // standing 👎 votes, per-user latest-wins
 	Last       time.Time // when the trigger's newest investigation happened
+	Confirms   int       // machine confirmations recorded for this trigger since (recovery evidence)
 }
 
 // ContestedTriggers returns every trigger with at least one standing 👎 vote and
@@ -870,7 +889,7 @@ func (l *Ledger) ContestedTriggers() []ContestedTrigger {
 		if a.curatedURL == "" {
 			continue // no KB artifact to warn a reviewer on
 		}
-		out = append(out, ContestedTrigger{TriggerKey: trigger, CuratedURL: a.curatedURL, Downs: n, Last: a.last})
+		out = append(out, ContestedTrigger{TriggerKey: trigger, CuratedURL: a.curatedURL, Downs: n, Last: a.last, Confirms: l.triggerConfirms[trigger]})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].TriggerKey < out[j].TriggerKey })
 	return out
@@ -955,6 +974,11 @@ type Aggregate struct {
 	FeedbackUp    int // human "the diagnosis was right" votes — success observations for decay
 	FeedbackDown  int // human "the diagnosis was wrong" votes — failure observations for decay
 	LastConfirmed time.Time
+	// Confirms counts machine confirmations: fresh investigations that independently
+	// reached this entry's conclusion (same DupFingerprint) — the recovery evidence a
+	// standing 👎 forces into existence. Weighted at half a human observation in
+	// Factor (confirmWeight); see Ledger.Confirm.
+	Confirms int
 }
 
 // Factor is the entry's outcome-decay factor: the posterior mean of a symmetric
@@ -1045,6 +1069,46 @@ func (l *Ledger) applyFeedbackLocked(e Event) {
 	}
 	l.votes[key] = feedbackVote{rating: e.Kind, entry: entry}
 	l.creditFeedbackLocked(entry, e.Kind, +1)
+}
+
+// Confirm appends a machine confirmation: a FRESH investigation independently
+// reached the same deterministic identity (DupFingerprint) as an existing catalog
+// entry — exactly the re-derivation a standing 👎 forces. It is folded as recovery
+// evidence into the entry's aggregate (at confirmWeight, see Aggregate.Factor) and
+// into the per-trigger confirmation count the Contested curate pass surfaces.
+// entry must be non-empty (an unattributable confirm is a caller bug); triggerKey
+// may be empty (human `lore investigate` has none — entry credit still applies).
+// Recalls must never reach this: only the curator's fingerprint-dedup branch calls
+// it, and Curate returns before that branch for recalled findings.
+func (l *Ledger) Confirm(entry, triggerKey, dupFP string, at time.Time) error {
+	if entry == "" {
+		return fmt.Errorf("confirm: empty entry path")
+	}
+	if !l.enabled() {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e := Event{Event: "confirm", Entry: entry, TriggerKey: triggerKey, DupFingerprint: dupFP, At: at}
+	if err := l.appendLocked(e); err != nil {
+		return err // durable-first: leave the fold untouched, like Open/Feedback
+	}
+	l.applyConfirmLocked(e)
+	return nil
+}
+
+// applyConfirmLocked folds one confirm event into the per-entry aggregate and the
+// per-trigger index. Must be called with mu held (or during single-threaded load).
+func (l *Ledger) applyConfirmLocked(e Event) {
+	if e.Entry == "" {
+		return // malformed replayed line: never folded
+	}
+	a := l.agg[e.Entry]
+	a.Confirms++
+	l.agg[e.Entry] = a
+	if e.TriggerKey != "" {
+		l.triggerConfirms[e.TriggerKey]++
+	}
 }
 
 // creditFeedbackLocked adjusts entry's feedback counter for rating by delta; a

--- a/internal/outcome/ledger_confirm_test.go
+++ b/internal/outcome/ledger_confirm_test.go
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package outcome
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestConfirmFoldsIntoAggregateAndTriggerIndex(t *testing.T) {
+	l, err := New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now()
+	if err := l.Confirm("kb/worker-oom.md", "trig-1", "fp-abc", at); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Confirm("kb/worker-oom.md", "trig-1", "fp-abc", at.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := counts["kb/worker-oom.md"].Confirms; got != 2 {
+		t.Fatalf("Aggregate.Confirms = %d, want 2", got)
+	}
+}
+
+func TestConfirmSurvivesReload(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ledger.jsonl")
+	l, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Confirm("kb/e.md", "trig-1", "fp", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	// A fresh ledger over the same file replays the confirm line.
+	l2, err := New(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts, _ := l2.OpenCounts()
+	if got := counts["kb/e.md"].Confirms; got != 1 {
+		t.Fatalf("replayed Confirms = %d, want 1", got)
+	}
+}
+
+func TestConfirmSurvivesCompactionCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ledger.jsonl")
+	l, err := NewWithMaxEvents(path, 5) // tiny cap forces compaction on reload
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now()
+	if err := l.Confirm("kb/e.md", "trig-1", "fp", at); err != nil {
+		t.Fatal(err)
+	}
+	// Push the confirm past the compaction horizon with filler opens.
+	for i := 0; i < 10; i++ {
+		if err := l.Open(Event{Fingerprint: DeriveFingerprint(GitOpsFingerprintPrefix, string(rune('a'+i))), Kind: "fresh", At: at.Add(time.Duration(i) * time.Second)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Reload triggers compaction (file > maxEvents): the confirm is folded into the
+	// checkpoint. Its contribution must survive into a THIRD load that only ever
+	// sees the checkpoint.
+	l2, err := NewWithMaxEvents(path, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts, _ := l2.OpenCounts()
+	if got := counts["kb/e.md"].Confirms; got != 1 {
+		t.Fatalf("post-compaction Confirms = %d, want 1 (lost by the checkpoint)", got)
+	}
+	l3, err := NewWithMaxEvents(path, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts3, _ := l3.OpenCounts()
+	if got := counts3["kb/e.md"].Confirms; got != 1 {
+		t.Fatalf("checkpoint-only Confirms = %d, want 1", got)
+	}
+}
+
+func TestContestedTriggersCarryConfirmCount(t *testing.T) {
+	l, err := New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now()
+	// An open with a KB link makes the trigger contest-eligible…
+	if err := l.Open(Event{Fingerprint: "fp1", Kind: "fresh", TriggerKey: "trig-1", CuratedURL: "https://github.com/o/r/pull/7", At: at}); err != nil {
+		t.Fatal(err)
+	}
+	// …a standing 👎 contests it, and a confirmation is recorded against it.
+	if err := l.Feedback("trig-1", "down", "U1", at.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Confirm("kb/e.md", "trig-1", "fp-dup", at.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	cts := l.ContestedTriggers()
+	if len(cts) != 1 {
+		t.Fatalf("ContestedTriggers = %v, want exactly one", cts)
+	}
+	if cts[0].Confirms != 1 {
+		t.Fatalf("ContestedTrigger.Confirms = %d, want 1", cts[0].Confirms)
+	}
+}
+
+func TestConfirmDisabledLedgerAndEmptyEntry(t *testing.T) {
+	disabled, err := New("") // path "" ⇒ disabled ledger, mirroring Feedback's no-op contract
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := disabled.Confirm("kb/e.md", "t", "fp", time.Now()); err != nil {
+		t.Fatalf("disabled ledger must no-op, got %v", err)
+	}
+	if err := disabled.Confirm("", "t", "fp", time.Now()); err == nil {
+		t.Fatal("empty entry path must be an error (an unattributable confirm is a bug)")
+	}
+}


### PR DESCRIPTION
## Problem — the permanent full-cost re-investigation loop

Today a single mistaken 👎 costs forever. A standing 👎 (a) rejects recall via the
outcome-decay gate and (b) bypasses the recurrence cooldown
(`TriggerRecurrence.Contested()`), so **every** recurrence runs a full paid
investigation. When that fresh investigation reaches the *same* RCA, the curator's
catalog-fingerprint dedup produces no artifact and records nothing — the entry is
never vindicated nor superseded, so the loop never converges. One wrong click →
unbounded model spend.

## What this does

Closes the loop with a new append-only ledger event kind, `"confirm"`, so the
re-derivation a standing 👎 forces becomes **recovery evidence** — while a human 👎
still outranks any single machine confirmation.

- **`outcome` — the `confirm` event.** `Ledger.Confirm(entry, triggerKey, dupFP, at)`
  appends and folds a confirmation into `Aggregate.Confirms` (per-entry) and a
  per-`TriggerKey` index. Durable-first (append before fold, mirroring `Feedback`),
  nil/disabled-safe, and it round-trips compaction checkpoints (new
  `trigger_confirms` checkpoint field; `Aggregate.Confirms` rides along in the
  serialized aggregate). Old binaries ignore the unknown kind by the documented
  forward-compat property of `foldLocked`.

- **Weighting contract (`confirmWeight = 0.5`).** A machine confirmation is half a
  Bernoulli observation in the same Beta posterior. With the defaults (k=2, floor
  0.5): one standing 👎 alone → 1/3 (rejected); +1 confirmation → 1.5/3.5 ≈ 0.43
  (**still** rejected — a human outranks one machine confirmation); +2 confirmations
  → 2/4 = 0.5 (recovered, since rejection is strictly `f < floor`).

- **Curator hook.** The fingerprint-dedup match (reachable **only** by fresh
  investigations — recalls early-return at the top of `Curate`) reports the match
  through a new nil-safe `ConfirmationSink`. The app wires `*outcome.Ledger` to it.

- **Reviewer signal.** The curate Contested pass renders the confirmation count on
  the open KB PR's warning, so the reviewer sees both the standing 👎 and the machine
  re-confirmations.

`TriggerRecurrence.Contested()` is deliberately **unchanged**: the human override on
the cooldown stands until the voter changes their vote. But once the factor recovers,
recall fires again and each recurrence costs a recall (2 model calls), not a full
investigation — which is what ends the cost loop without weakening the human signal.

## Retirement interplay

The Beta-posterior decay formula lives in a single place, `outcome.Aggregate.Factor(k)`
(consolidated by #333). The `confirmWeight` weighting was applied **there**, so both
consumers of `Factor` — recall's fire gate and the new `curate.Retirement` pass — read
the same decay from one definition. A desirable consequence: a confirm-recovered entry's
factor climbs back above the floor, so it naturally **exits retirement candidacy** too,
with no extra wiring.

## Invariants pinned by tests

- `confirm` survives reload and the compaction checkpoint (`TestConfirmSurvivesReload`,
  `TestConfirmSurvivesCompactionCheckpoint`).
- feedback-vote-then-confirm ordering surfaces on the contested trigger
  (`TestContestedTriggersCarryConfirmCount`).
- **No** recovery credit for recalls — only fresh investigations
  (`TestRecalledFindingNeverConfirms`).
- Human 👎 outweighs a single machine confirmation (`TestOutcomeFactor` floor pins +
  end-to-end `TestRecallRecoversAfterConfirmations`).

## Adaptation note (plan drift)

The plan was written against `c9646bd`; two file locations had since drifted, so the
semantic contract was applied to the current code:
- #333 moved the decay formula to `outcome.Aggregate.Factor(k)`; the `confirmWeight`
  contract was applied **inside** `Factor` (single definition), and
  `investigate.outcomeFactor` remains a thin delegate that now threads `Confirms`.
- #329 refactored `recall.go` (the delegation call site is inside `outcomeGate`); the
  call site was rebased accordingly.

Plan: `dev/superpowers/plans/2026-07-19-downvote-recovery.md`. Roadmap: **N5**.
