### PR TITLE
feat(catalog): parse OKF status/last_validated; recall honors retirement and age

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,6 +168,12 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   PagerDuty) can match only resource-less entries — the weakest tier, which always requires
   `solo_floor` + `min_score`, recalls with reduced confidence, and is disabled by
   `require_workload_match: true`.
+- `instant_recall.stale_after` — **opt-in** age down-weighting (a Go duration, e.g. `720h`; **`0`/unset
+  disables**, the default). A recalled entry whose `last_validated` (else `timestamp`) is older than
+  this has its delivered confidence taken **one** step down (×0.75). It **never rejects** — `confirm`
+  and `verify` remain the hard gates and the outcome floor keeps priority — it only stops an unvalidated,
+  years-old runbook looking as confident as a fresh one. A dateless or unparseable-date entry is exempt
+  (fail-safe). Retired/`draft` entries are filtered out of recall entirely (independent of this knob).
 - `instant_recall.rerank` (**ON by default when `instant_recall` is enabled**; set `false` to fall back to the legacy gate) — replaces the corpus-dependent BM25-magnitude
   fire gate (`solo_floor`/`margin_gap`) with an **LLM reranker** that scores the top-`rerank_k`
   structurally-agreeing candidates in **one cheap call** and short-circuits only on the reranker's

--- a/docs/design.md
+++ b/docs/design.md
@@ -261,9 +261,16 @@ only half emergent:
 - **Learned** (emergent from investigations): **incident patterns** ("this symptom → this cause →
   this fix"), captured via the loop above.
 
-To keep the catalog an asset and not a liability (frontier RCA is <50 % accurate, §10), entries carry
-**`status`**, **`confidence`**, and **`last_validated`**, and an outcome-driven decay down-weights
-knowledge that stops resolving incidents ([mechanics in learning-loop.md §6](learning-loop.md)).
+To keep the catalog an asset and not a liability (frontier RCA is <50 % accurate, §10), every entry
+carries lifecycle frontmatter that recall now **honours**: **`status`** — a `retired`/`draft` entry is
+indexed but never fires or leads (the seam the retirement pass writes to, learning-loop.md §5) — and
+**`last_validated`** — recall down-weights an entry no human has confirmed within a configurable
+horizon (`catalog.instant_recall.stale_after`; one confidence step, never a rejection). Both are
+fail-safe: an absent or unknown value reproduces the pre-field behaviour exactly. A third key,
+**`confidence`**, is *written* by the curator but deliberately **not read back** — recall derives trust
+from the live outcome track record (resolve rate + 👍/👎), and a static authored confidence would fight
+that dynamic signal. On top of these, an outcome-driven decay down-weights knowledge that stops
+resolving incidents ([mechanics in learning-loop.md §6](learning-loop.md)).
 Curation — the PR/issue review — is the **load-bearing** quality gate that separates this from opaque
 vendor "memory."
 

--- a/docs/learning-loop.md
+++ b/docs/learning-loop.md
@@ -420,10 +420,12 @@ rejection:
   deliberate "keep it" that is never re-nagged (the same closed-unmerged-is-a-no
   philosophy as the recurrence escalation above). Per-item error isolation: one flaky
   entry never starves the rest of a run.
-  - **Seam (in progress).** This pass *writes* the `status: retired` frontmatter; the
-    catalog loader honoring it — so a retired entry actually stops being recalled — ships
-    as a separate change. Until then a merged retirement PR is inert but correct (the
-    entry is marked, the git history records the decision), with no dependency either way.
+  - **Seam (now live).** Recall honours the `status: retired` frontmatter this pass
+    writes: a retired (or `draft`) entry is filtered at recall's structural pre-filter,
+    so it never fires and is never offered as a near-miss lead — while `kb_search`/`kb_get`
+    keep surfacing it (status-visible) for KB archaeology. A merged retirement PR is
+    therefore effective end-to-end. Fail-safe: an absent or unknown status is treated as
+    active (OKF §9 tolerance), so pre-retirement catalogs behave exactly as before.
 
 ---
 
@@ -473,6 +475,25 @@ poisoned** note that recalls-but-never-resolves decays below the floor, gets rej
 at Gate 3, triggers a fresh investigation, and can be **overturned** by a corrected
 entry. Decay is **outcome/contradiction-driven, never pure mtime** — knowledge ages
 out because it stops working, not merely because it's old.
+
+**Two orthogonal freshness signals sit alongside this outcome decay**, both applied at
+recall's structural pre-filter and both fail-safe (absent frontmatter reproduces the
+pre-field behaviour byte-for-byte):
+
+- **Status** — a `retired` or `draft` entry is dropped *before* the gate: it never
+  fires and is never offered as a near-miss lead, which is what makes the retirement
+  pass (§5) effective end-to-end. Any absent or unknown status is treated as active
+  (OKF §9 tolerance). The entry stays indexed, so `kb_search`/`kb_get` still surface it
+  — status-visible — for KB archaeology; recall is where the firing ban lives.
+- **Age** (`catalog.instant_recall.stale_after`, opt-in; `0` disables) — an entry whose
+  `last_validated` (else `timestamp`) predates the horizon has its delivered confidence
+  taken **one** multiplicative step down (0.75). This is deliberately *not* a rejection
+  and *not* a curve zoo: **age never rejects on its own** — the **confirm** step (Gate 1)
+  and the adversarial **verify** pass remain the hard gates against a genuinely drifted
+  answer, and the outcome floor (Gate 3) keeps priority (track record beats calendar).
+  Staleness only stops a five-year-old runbook looking as confident as yesterday's. A
+  dateless or unparseable-date entry is exempt. `last_validated` is stamped at entry
+  creation (= `timestamp`) and is the seam a future confirmation flow refreshes.
 
 A `low_outcome` rejection does not abandon recall outright: the gate walks a small,
 bounded set of further structurally-agreeing candidates (the runner-up fallback) —

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -35,13 +35,18 @@ git clone https://github.com/you/your-kb && lore mcp ./your-kb
 
 - **`kb_search`** — BM25 search over the catalog. Args: `query` (required),
   `k` (default 5, cap 20). Returns scored hits: `path`, `type`, `title`,
-  `description`, `resource`, `tags`, `score`.
+  `description`, `resource`, `tags`, `score`, plus `status` and `last_validated`
+  when the entry carries them (omitted otherwise).
 - **`kb_get`** — one full entry (frontmatter + markdown body) by the
   bundle-relative `path` a search hit returned. Curated entries also carry their
   `timestamp` (last-change stamp) and `fingerprint` (dedup identity) so a client
-  can judge freshness; hand-written entries omit both. Lookups go through the
-  in-memory index, never the filesystem, so path traversal is structurally
-  impossible.
+  can judge freshness; hand-written entries omit both. The lifecycle fields
+  `status` (`retired`/`draft`/…) and `last_validated` are surfaced too when
+  present. **Retired entries stay searchable and fetchable by design** — a KB
+  consumer sees the lifecycle state and judges for itself; the "never fires" ban
+  lives in RunLore's own recall path, not in these read-only tools. Lookups go
+  through the in-memory index, never the filesystem, so path traversal is
+  structurally impossible.
 
 The catalog directory resolves from the positional argument first, then
 `catalog.dir` in the config. The catalog is indexed once at startup; re-run

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -64,11 +64,13 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 				RequireWorkloadMatch: cfg.Catalog.InstantRecall.RequireWorkloadMatch,
 				OutcomePrior:         cfg.Catalog.InstantRecall.OutcomePrior,
 				OutcomeFloor:         cfg.Catalog.InstantRecall.OutcomeFloor,
+				StaleAfter:           cfg.Catalog.InstantRecall.StaleAfter.Std(),
 			}
 			log.Info("instant recall enabled",
 				"min_score", cfg.Catalog.InstantRecall.MinScore,
 				"margin_gap", cfg.Catalog.InstantRecall.MarginGap, "solo_floor", cfg.Catalog.InstantRecall.SoloFloor,
-				"outcome_prior", cfg.Catalog.InstantRecall.OutcomePrior, "outcome_floor", cfg.Catalog.InstantRecall.OutcomeFloor)
+				"outcome_prior", cfg.Catalog.InstantRecall.OutcomePrior, "outcome_floor", cfg.Catalog.InstantRecall.OutcomeFloor,
+				"stale_after", cfg.Catalog.InstantRecall.StaleAfter.Std())
 			// LLM reranker (opt-in): replace the corpus-dependent BM25-magnitude fire gate
 			// with a CALIBRATED match-confidence gate. Route the one cheap call to the
 			// verify tier (cheaper/faster) when configured, else the main model — mirroring

--- a/internal/catalog/entry.go
+++ b/internal/catalog/entry.go
@@ -18,6 +18,15 @@ type Entry struct {
 	Tags          []string // frontmatter: tags
 	Timestamp     string   // frontmatter: timestamp (OKF-recommended, RFC3339; "" when absent)
 	Fingerprint   string   // frontmatter: fingerprint (curator.DupFingerprint identity; "" on hand-written entries)
-	Body          string   // markdown body (after frontmatter)
-	Path          string   // file path relative to the bundle root
+	// Status is frontmatter: status — the entry's lifecycle state ("", "active",
+	// "retired", "draft", or any foreign value). Recall treats anything other than
+	// retired/draft as active (OKF §9: consumers tolerate unknown vocabulary), so
+	// absent-or-unknown behaves exactly as before the field existed.
+	Status string
+	// LastValidated is frontmatter: last_validated — when a human last confirmed the
+	// entry still works (date or RFC3339; "" when absent). Kept as the raw string,
+	// like Timestamp: the loader stays tolerant, consumers parse.
+	LastValidated string
+	Body          string // markdown body (after frontmatter)
+	Path          string // file path relative to the bundle root
 }

--- a/internal/catalog/entry.go
+++ b/internal/catalog/entry.go
@@ -4,6 +4,25 @@
 // markdown files with YAML frontmatter) — the read half of RunLore's Learn pillar.
 package catalog
 
+import "time"
+
+// ParseEntryDate parses an OKF entry date: RFC3339 or bare date (2006-01-02).
+// Empty input returns the zero time and ok=false, distinct from malformed. It is
+// the single date grammar shared by kbvalidate (advisory warnings) and recall
+// (age down-weighting), so both accept exactly the same values.
+func ParseEntryDate(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
 // Entry is one OKF knowledge entry.
 type Entry struct {
 	Type        string // frontmatter: type (Playbook, Incident, …)

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -70,6 +70,8 @@ func parseEntry(root, path string) (Entry, error) {
 		Tags          []string `yaml:"tags"`
 		Timestamp     string   `yaml:"timestamp"`
 		Fingerprint   string   `yaml:"fingerprint"`
+		Status        string   `yaml:"status"`
+		LastValidated string   `yaml:"last_validated"`
 	}
 	if len(fm) > 0 {
 		if err := yaml.Unmarshal(fm, &meta); err != nil {
@@ -82,6 +84,7 @@ func parseEntry(root, path string) (Entry, error) {
 		AlertResource: meta.AlertResource,
 		Resource:      meta.Resource, Tags: meta.Tags,
 		Timestamp: meta.Timestamp, Fingerprint: meta.Fingerprint,
+		Status: meta.Status, LastValidated: meta.LastValidated,
 		Body: string(body), Path: rel,
 	}, nil
 }

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -98,6 +98,33 @@ body
 	}
 }
 
+// TestLoadParsesStatusAndLastValidated: the lifecycle fields (status, last_validated)
+// are parsed into the Entry and an unknown frontmatter key (okf_version) never errors —
+// yaml.Unmarshal without KnownFields ignores it, pinned here so it stays true.
+func TestLoadParsesStatusAndLastValidated(t *testing.T) {
+	dir := t.TempDir()
+	entry := `---
+type: Incident
+title: retired one
+status: retired
+last_validated: 2026-01-10
+okf_version: "0.1"
+---
+Body.
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte(entry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, skipped, err := Load(dir)
+	if err != nil || len(skipped) != 0 || len(entries) != 1 {
+		t.Fatalf("entries=%d skipped=%v err=%v", len(entries), skipped, err)
+	}
+	e := entries[0]
+	if e.Status != "retired" || e.LastValidated != "2026-01-10" {
+		t.Errorf("Status=%q LastValidated=%q, want retired / 2026-01-10", e.Status, e.LastValidated)
+	}
+}
+
 func TestLoadSkipsMalformedEntry(t *testing.T) {
 	dir := t.TempDir()
 	writeEntry(t, dir, "good.md", "---\ntype: Playbook\ntitle: Good\ndescription: fine\n---\nbody\n")

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -166,6 +166,26 @@ func TestLoadSkipsHidden(t *testing.T) {
 	}
 }
 
+// TestParseEntryDate pins the one date grammar shared by kbvalidate and recall:
+// RFC3339 and bare date parse; empty and garbage report ok=false (distinct from a
+// zero-but-valid time).
+func TestParseEntryDate(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"2026-01-10T00:00:00Z", true},
+		{"2026-01-10", true},
+		{"", false},
+		{"not-a-date", false},
+	}
+	for _, tc := range tests {
+		if _, ok := ParseEntryDate(tc.in); ok != tc.want {
+			t.Errorf("ParseEntryDate(%q) ok=%v, want %v", tc.in, ok, tc.want)
+		}
+	}
+}
+
 func contains(s, sub string) bool {
 	for i := 0; i+len(sub) <= len(s); i++ {
 		if s[i:i+len(sub)] == sub {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -415,6 +415,11 @@ type InstantRecall struct {
 	OutcomePrior         float64 `yaml:"outcome_prior"`          // Beta prior strength for outcome decay
 	OutcomeFloor         float64 `yaml:"outcome_floor"`          // reject a recall when the outcome factor drops below this
 
+	// StaleAfter down-weights a recall whose last_validated/timestamp is older than
+	// this; 0 disables. One 0.75 confidence step, never a rejection — confirm/verify
+	// stay the hard gates. An unset horizon plus dateless entries = today's behavior.
+	StaleAfter Duration `yaml:"stale_after"`
+
 	// Rerank adds an LLM reranking stage to the recall short-circuit: it ranks the
 	// top-K structurally-agreeing candidates against the incident with ONE cheap
 	// model call and gates the fire on the reranker's CALIBRATED match confidence

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,6 +109,24 @@ catalog:
 	}
 }
 
+func TestInstantRecallStaleAfterParse(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("catalog:\n  instant_recall:\n    enabled: true\n    stale_after: 720h\n"), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := c.Catalog.InstantRecall.StaleAfter.Std(); got != 720*time.Hour {
+		t.Fatalf("instant_recall.stale_after: want 720h, got %v", got)
+	}
+	// Absent ⇒ zero ⇒ age down-weighting disabled (recall honours 0 as off).
+	var z Config
+	if err := yaml.Unmarshal([]byte("catalog:\n  instant_recall:\n    enabled: true\n"), &z); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if z.Catalog.InstantRecall.StaleAfter.Std() != 0 {
+		t.Fatalf("absent instant_recall.stale_after must be 0, got %v", z.Catalog.InstantRecall.StaleAfter.Std())
+	}
+}
+
 func TestCurateStaleAfterParse(t *testing.T) {
 	var c Config
 	if err := yaml.Unmarshal([]byte("curate:\n  stale_after: 720h\n"), &c); err != nil {

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -425,7 +425,11 @@ type kbFrontmatter struct {
 	AlertResource string   `yaml:"alert_resource,omitempty"`
 	Tags          []string `yaml:"tags,omitempty"`
 	Timestamp     string   `yaml:"timestamp,omitempty"` // OKF-recommended; seed entries carry it, curated ones now do too
-	Fingerprint   string   `yaml:"fingerprint,omitempty"`
+	// last_validated: stamped at entry creation (= timestamp); refreshed by humans
+	// or by future confirmation flows (see the downvote-recovery plan). Recall's
+	// stale_after down-weighting reads it — a never-revalidated entry ages visibly.
+	LastValidated string `yaml:"last_validated,omitempty"`
+	Fingerprint   string `yaml:"fingerprint,omitempty"`
 	// Confidence + Provenance are OKF extension keys: frontmatter is for the
 	// fields you query/filter/index on, and these are exactly that (per-entry
 	// confidence floors, "what change caused this" lookups).
@@ -509,7 +513,7 @@ func renderEntry(e providers.KBEntry) string {
 	fm, _ := yaml.Marshal(kbFrontmatter{
 		Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource,
 		AlertResource: e.AlertResource,
-		Tags:          e.Tags, Timestamp: ts, Fingerprint: e.Fingerprint,
+		Tags:          e.Tags, Timestamp: ts, LastValidated: ts, Fingerprint: e.Fingerprint,
 		Confidence: e.Confidence, Provenance: e.Provenance,
 	})
 	var b strings.Builder

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -389,6 +389,32 @@ func TestRenderEntryIncludesTimestamp(t *testing.T) {
 	}
 }
 
+// TestRenderEntryStampsLastValidated: last_validated is stamped at entry creation
+// (= the timestamp), so recall's stale_after down-weighting has a freshness date to
+// read and a never-revalidated entry ages visibly. It must be a parseable RFC3339
+// value equal to the timestamp.
+func TestRenderEntryStampsLastValidated(t *testing.T) {
+	out := renderEntry(providers.KBEntry{Type: "Incident", Title: "T", Body: "## body"})
+	extract := func(key string) string {
+		i := strings.Index(out, key)
+		if i < 0 {
+			t.Fatalf("frontmatter missing %q:\n%s", key, out)
+		}
+		line := out[i+len(key):]
+		if j := strings.IndexByte(line, '\n'); j >= 0 {
+			line = line[:j]
+		}
+		return strings.Trim(strings.TrimSpace(line), `"`)
+	}
+	lv := extract("last_validated: ")
+	if _, err := time.Parse(time.RFC3339, lv); err != nil {
+		t.Fatalf("last_validated %q is not RFC3339: %v", lv, err)
+	}
+	if ts := extract("timestamp: "); lv != ts {
+		t.Fatalf("last_validated %q must equal timestamp %q at creation", lv, ts)
+	}
+}
+
 // TestRenderEntryIncludesConfidenceAndProvenance: confidence and change
 // provenance are queryable OKF extension frontmatter keys (frontmatter is for
 // the fields you filter/index on), omitted when unset.

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -162,9 +162,15 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 	// Structural pre-filter: keep candidates whose stored resource agrees with the
 	// alert's workload, preserving lexical order. Pre-filtering (rather than checking
 	// only the top hit) lets a structurally-correct entry win even when wrong-workload
-	// entries score higher on symptom tokens.
+	// entries score higher on symptom tokens. Inactive entries (retired/draft) are
+	// dropped here — filtering once at the single candidate source means the winner
+	// AND every outcomeFallback runner-up (which walk this same slice) are guaranteed
+	// active, so a retired entry can never fire on any path.
 	var agreeing []catalog.ScoredEntry
 	for _, h := range hits {
+		if !entryActive(h.Entry) {
+			continue
+		}
 		if entryAgrees(req.Workload, h.Entry, r.RequireWorkloadMatch) != matchNone {
 			agreeing = append(agreeing, h)
 		}
@@ -389,12 +395,25 @@ func (r *Recall) nearMissExcluding(ctx context.Context, req Request, exclude ...
 		if skip[h.Entry.Path] {
 			continue
 		}
+		// A retired/draft entry is not a lead: an entry retired for being wrong must
+		// not be re-injected as a "possibly-related" hint any more than it may fire.
+		if !entryActive(h.Entry) {
+			continue
+		}
 		if nearMissEntryAgrees(req.Workload, h.Entry, r.RequireWorkloadMatch) != matchNone {
 			e := h.Entry
 			return &e
 		}
 	}
 	return nil
+}
+
+// entryActive reports whether an entry may participate in recall. Only the two
+// known inactive states are excluded — an absent or foreign status stays active
+// (OKF §9 tolerance), so pre-status catalogs behave byte-for-byte as before.
+func entryActive(e catalog.Entry) bool {
+	s := strings.TrimSpace(strings.ToLower(e.Status))
+	return s != "retired" && s != "draft"
 }
 
 // nearMissAgrees is the structural gate for a NEAR-MISS, and it is deliberately looser

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/outcome"
@@ -59,6 +60,14 @@ type Recall struct {
 	OutcomePrior float64      // k — Beta prior strength for decay (e.g. 2.0)
 	OutcomeFloor float64      // reject the recall when the outcome factor drops below this (e.g. 0.5)
 
+	// StaleAfter down-weights (never rejects) a recall whose freshness date
+	// (last_validated, else timestamp) is older than this horizon. 0 ⇒ disabled, so
+	// a catalog with no dates and an unset horizon behaves byte-for-byte as before.
+	StaleAfter time.Duration
+	// Now is an injectable clock for the age gate (the Lifecycle.Now pattern); nil ⇒
+	// time.Now. Tests set a fixed clock; production leaves it nil.
+	Now func() time.Time
+
 	Metrics *telemetry.Metrics // optional; nil-safe — instruments are no-op when provider is unset
 	Log     *slog.Logger       // optional; nil-safe — log line omitted when unset
 }
@@ -74,6 +83,12 @@ const recallCandidateK = 20
 // Small and fixed: each fallback candidate is held to the conservative solo bar,
 // so depth buys little beyond the first couple of runners-up.
 const maxOutcomeFallback = 2
+
+// staleFactor is the single multiplicative step applied to a recalled entry's
+// confidence when it is older than Recall.StaleAfter. One step-down, no curve zoo:
+// staleness only lowers delivered confidence, it never rejects (confirm/verify stay
+// the hard gates).
+const staleFactor = 0.75
 
 // buildRecallQuery constructs the BM25 query text for a recall lookup from a
 // Request. It is the single seam between "what the incident says" and "what the
@@ -269,6 +284,29 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 				return r.outcomeFallback(ctx, req, agreeing, counts, minScore, soloFloor, totals, []string{e.Path})
 			}
 			conf = clampF(conf*f, 0, 0.90)
+		}
+	}
+	// Age down-weight: an entry no human has validated within StaleAfter carries its
+	// years visibly. One multiplicative step — never a rejection: confirm and verify
+	// remain the hard gates against a genuinely drifted answer, this only stops a
+	// five-year-old runbook looking as confident as yesterday's. Freshness is
+	// last_validated, else timestamp; a dateless or unparseable entry is exempt
+	// (fail-safe: absent fields = pre-staleness behavior). It follows outcome decay so
+	// the track-record floor rejection keeps priority (track record beats calendar).
+	if r.StaleAfter > 0 {
+		now := time.Now
+		if r.Now != nil {
+			now = r.Now
+		}
+		fresh := e.LastValidated
+		if fresh == "" {
+			fresh = e.Timestamp
+		}
+		if t, ok := catalog.ParseEntryDate(fresh); ok && now().Sub(t) > r.StaleAfter {
+			conf = clampF(conf*staleFactor, 0, 0.90)
+			if r.Log != nil {
+				r.Log.Info("recall: stale entry down-weighted", "entry_id", e.Path, "validated", fresh, "stale_after", r.StaleAfter)
+			}
 		}
 	}
 	if r.Log != nil {

--- a/internal/investigate/recall_stale_test.go
+++ b/internal/investigate/recall_stale_test.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/catalog"
+)
+
+// staleRecall builds a lone-strong-hit recall (fires for okReq) with a fixed clock
+// and controllable freshness dates, so an age down-weight can be observed against a
+// StaleAfter:0 control.
+func staleRecall(lastValidated, timestamp string, staleAfter time.Duration, now time.Time) *Recall {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web", LastValidated: lastValidated, Timestamp: timestamp}, Score: 6.0},
+	})
+	r.StaleAfter = staleAfter
+	r.Now = func() time.Time { return now }
+	return r
+}
+
+var staleNow = time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)
+
+const thirtyDays = 30 * 24 * time.Hour
+
+// TestRecallStaleDownWeights: an entry whose last_validated predates StaleAfter is
+// still fired (age never rejects), but its confidence is a single 0.75 step below
+// the same lookup with StaleAfter disabled.
+func TestRecallStaleDownWeights(t *testing.T) {
+	stale := staleRecall("2024-07-20", "", thirtyDays, staleNow) // ~2y old > 30d
+	ctrl := staleRecall("2024-07-20", "", 0, staleNow)           // age off
+	eS, confS := stale.lookup(context.Background(), okReq())
+	eC, confC := ctrl.lookup(context.Background(), okReq())
+	if eS == nil || eC == nil {
+		t.Fatal("a stale entry must still FIRE — age never rejects on its own")
+	}
+	if math.Abs(confS-confC*staleFactor) > 1e-9 {
+		t.Fatalf("stale confidence = %v, want control*%v = %v", confS, staleFactor, confC*staleFactor)
+	}
+}
+
+// TestRecallStaleFallsBackToTimestamp: with no last_validated, freshness comes from
+// the entry timestamp.
+func TestRecallStaleFallsBackToTimestamp(t *testing.T) {
+	stale := staleRecall("", "2024-07-20T00:00:00Z", thirtyDays, staleNow)
+	ctrl := staleRecall("", "2024-07-20T00:00:00Z", 0, staleNow)
+	_, confS := stale.lookup(context.Background(), okReq())
+	_, confC := ctrl.lookup(context.Background(), okReq())
+	if math.Abs(confS-confC*staleFactor) > 1e-9 {
+		t.Fatalf("timestamp-fallback stale confidence = %v, want %v", confS, confC*staleFactor)
+	}
+}
+
+// TestRecallFreshWithinHorizonUntouched: a recently-validated entry is not
+// down-weighted.
+func TestRecallFreshWithinHorizonUntouched(t *testing.T) {
+	fresh := staleRecall("2026-07-10", "", thirtyDays, staleNow) // 10d < 30d
+	ctrl := staleRecall("2026-07-10", "", 0, staleNow)
+	_, confS := fresh.lookup(context.Background(), okReq())
+	_, confC := ctrl.lookup(context.Background(), okReq())
+	if confS != confC {
+		t.Fatalf("a fresh entry must not be down-weighted: %v != %v", confS, confC)
+	}
+}
+
+// TestRecallStaleNoDatesUntouched: a dateless entry is exempt (fail-safe = absent
+// fields reproduce pre-staleness behavior).
+func TestRecallStaleNoDatesUntouched(t *testing.T) {
+	none := staleRecall("", "", thirtyDays, staleNow)
+	ctrl := staleRecall("", "", 0, staleNow)
+	_, confS := none.lookup(context.Background(), okReq())
+	_, confC := ctrl.lookup(context.Background(), okReq())
+	if confS != confC {
+		t.Fatalf("a dateless entry must not be down-weighted: %v != %v", confS, confC)
+	}
+}
+
+// TestRecallStaleUnparseableDateExempt: an unparseable freshness date is treated as
+// no age signal (never an error), so the entry is not down-weighted.
+func TestRecallStaleUnparseableDateExempt(t *testing.T) {
+	bad := staleRecall("not-a-date", "", thirtyDays, staleNow)
+	ctrl := staleRecall("not-a-date", "", 0, staleNow)
+	_, confS := bad.lookup(context.Background(), okReq())
+	_, confC := ctrl.lookup(context.Background(), okReq())
+	if confS != confC {
+		t.Fatalf("an unparseable date must be exempt: %v != %v", confS, confC)
+	}
+}
+
+// TestRecallStaleNilClockUsesNow: an unset Now falls back to the real clock. A
+// last_validated far in the past with a tiny horizon is down-weighted relative to
+// the StaleAfter:0 control.
+func TestRecallStaleNilClockUsesNow(t *testing.T) {
+	stale := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web", LastValidated: "2000-01-01"}, Score: 6.0},
+	})
+	stale.StaleAfter = time.Hour // nil Now ⇒ time.Now
+	ctrl := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web", LastValidated: "2000-01-01"}, Score: 6.0},
+	})
+	eS, confS := stale.lookup(context.Background(), okReq())
+	_, confC := ctrl.lookup(context.Background(), okReq())
+	if eS == nil {
+		t.Fatal("a stale entry must still fire under the real clock")
+	}
+	if confS >= confC {
+		t.Fatalf("real-clock stale confidence %v must be below the un-aged %v", confS, confC)
+	}
+}

--- a/internal/investigate/recall_status_test.go
+++ b/internal/investigate/recall_status_test.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// TestRecallSkipsRetiredEntry: a retired entry that would otherwise be the
+// structurally-agreeing winner is filtered before the gate, so — when it is the
+// only candidate — the recall falls through with no_resource_match, exactly as if
+// the entry were absent. This is what makes the retirement pass effective.
+func TestRecallSkipsRetiredEntry(t *testing.T) {
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web", Status: "retired"}, Score: 6.0},
+	})
+	r.Metrics = telemetry.NewMetrics()
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("a retired entry must never fire")
+	}
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if !strings.Contains(rec.Body.String(), `reason="no_resource_match"`) {
+		t.Fatalf("a retired sole candidate must reject as no_resource_match:\n%s", rec.Body.String())
+	}
+}
+
+// TestRecallSkipsDraftEntry: a draft entry is inactive too — it never fires.
+func TestRecallSkipsDraftEntry(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web", Status: "draft"}, Score: 6.0},
+	})
+	if e, _ := r.lookup(context.Background(), okReq()); e != nil {
+		t.Fatal("a draft entry must never fire")
+	}
+}
+
+// TestRecallSkipsRetiredWinnerFiresActiveRunnerUp: with a retired entry filtered
+// out, an active same-workload candidate below it becomes the lone agreeing hit and
+// fires (clearing the solo bar). The retired entry is simply invisible to recall.
+func TestRecallSkipsRetiredWinnerFiresActiveRunnerUp(t *testing.T) {
+	r := recallWith([]catalog.ScoredEntry{
+		{Entry: catalog.Entry{Title: "OOM", Path: "retired.md", Resource: "apps/web", Status: "retired"}, Score: 9.0},
+		{Entry: catalog.Entry{Title: "OOM fixed", Path: "active.md", Resource: "apps/web"}, Score: 6.0},
+	})
+	e, _ := r.lookup(context.Background(), okReq())
+	if e == nil {
+		t.Fatal("the active runner-up must fire once the retired winner is filtered")
+	}
+	if e.Path != "active.md" {
+		t.Fatalf("fired %q, want the active entry active.md", e.Path)
+	}
+}
+
+// TestRecallForeignAndEmptyStatusFire pins the OKF §9 tolerance invariant: an
+// absent status and any foreign status value fire exactly as before the field
+// existed (only retired/draft are inactive).
+func TestRecallForeignAndEmptyStatusFire(t *testing.T) {
+	for _, status := range []string{"", "active", "SomeForeignState"} {
+		r := recallWith([]catalog.ScoredEntry{
+			{Entry: catalog.Entry{Title: "OOM", Path: "a.md", Resource: "apps/web", Status: status}, Score: 6.0},
+		})
+		if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+			t.Fatalf("status=%q must fire exactly as today", status)
+		}
+	}
+}
+
+// TestRecallRetiredRunnerUpNeverFiresInFallback: even on the outcome-decay fallback
+// path, a retired candidate must never be fired. The winner (stale) is outcome-
+// rejected; the only other agreeing candidate is retired, so the fallback filters it
+// out and the recall falls through — the retired entry never resurfaces.
+func TestRecallRetiredRunnerUpNeverFiresInFallback(t *testing.T) {
+	r := &Recall{
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Path: "stale.md", Resource: "apps/web"}, Score: 9.0},
+			{Entry: catalog.Entry{Path: "retired.md", Resource: "apps/web", Status: "retired"}, Score: 6.0},
+		}},
+		MinScore: 1.5, SoloFloor: 4.0, MarginGap: 1.0,
+		Outcome: fakeOutcome{counts: map[string]outcome.Aggregate{
+			"stale.md": {Recalls: 4, Resolved: 0}, // factor 1/6 < 0.5 → rejected winner
+		}},
+		OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+	e, _, rejected := r.lookupWithUsage(context.Background(), okReq(), nil)
+	if e != nil {
+		t.Fatalf("a retired runner-up must never fire in the fallback, got %q", e.Path)
+	}
+	if len(rejected) != 1 || rejected[0] != "stale.md" {
+		t.Fatalf("rejected = %v, want exactly the decayed winner stale.md", rejected)
+	}
+}
+
+// TestNearMissNeverReturnsRetired: a retired entry must not resurface as an
+// unverified near-miss lead either — an entry retired for being wrong is not a hint.
+func TestNearMissNeverReturnsRetired(t *testing.T) {
+	r := &Recall{
+		MinScore: 4.0, MarginGap: 2.0, SoloFloor: 4.0, // gate unreachable: exercise the near-miss path
+		Catalog: fakeScored{hits: []catalog.ScoredEntry{
+			{Entry: catalog.Entry{Title: "old", Path: "old.md", Resource: "apps/web", Status: "retired"}, Score: 6.0},
+		}},
+	}
+	if nm := r.nearMiss(context.Background(), Request{Title: "x", Workload: providers.Workload{Namespace: "apps", Name: "web"}}); nm != nil {
+		t.Fatalf("a retired entry must not be offered as a near-miss lead, got %q", nm.Path)
+	}
+}

--- a/internal/kbmcp/kbmcp.go
+++ b/internal/kbmcp/kbmcp.go
@@ -46,11 +46,11 @@ type searchHit struct {
 // dedup identity) — surfaced so clients can judge freshness and identity; both
 // are absent on hand-written entries.
 type fullEntry struct {
-	Path        string   `json:"path"`
-	Type        string   `json:"type"`
-	Title       string   `json:"title"`
-	Description string   `json:"description,omitempty"`
-	Resource    string   `json:"resource,omitempty"`
+	Path          string   `json:"path"`
+	Type          string   `json:"type"`
+	Title         string   `json:"title"`
+	Description   string   `json:"description,omitempty"`
+	Resource      string   `json:"resource,omitempty"`
 	Tags          []string `json:"tags,omitempty"`
 	Timestamp     string   `json:"timestamp,omitempty"`
 	Fingerprint   string   `json:"fingerprint,omitempty"`

--- a/internal/kbmcp/kbmcp.go
+++ b/internal/kbmcp/kbmcp.go
@@ -33,7 +33,12 @@ type searchHit struct {
 	Description string   `json:"description,omitempty"`
 	Resource    string   `json:"resource,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
-	Score       float64  `json:"score"`
+	// Status is the entry's lifecycle state (retired/draft/… ; omitted when active/
+	// absent). Retired entries stay searchable BY DESIGN — the consumer sees the
+	// state and judges; recall is where the firing ban lives, not here.
+	Status        string  `json:"status,omitempty"`
+	LastValidated string  `json:"last_validated,omitempty"`
+	Score         float64 `json:"score"`
 }
 
 // fullEntry is the kb_get result shape: the whole entry, body included.
@@ -46,10 +51,12 @@ type fullEntry struct {
 	Title       string   `json:"title"`
 	Description string   `json:"description,omitempty"`
 	Resource    string   `json:"resource,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	Timestamp   string   `json:"timestamp,omitempty"`
-	Fingerprint string   `json:"fingerprint,omitempty"`
-	Body        string   `json:"body"`
+	Tags          []string `json:"tags,omitempty"`
+	Timestamp     string   `json:"timestamp,omitempty"`
+	Fingerprint   string   `json:"fingerprint,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	LastValidated string   `json:"last_validated,omitempty"`
+	Body          string   `json:"body"`
 }
 
 // Tools returns the KB tool set backed by cat, ready for mcp.Server.AddTool.
@@ -117,7 +124,9 @@ func search(cat *catalog.Catalog, args json.RawMessage) (string, error) {
 		hits = append(hits, searchHit{
 			Path: s.Entry.Path, Type: s.Entry.Type, Title: s.Entry.Title,
 			Description: s.Entry.Description, Resource: s.Entry.Resource,
-			Tags: s.Entry.Tags, Score: s.Score,
+			Tags:   s.Entry.Tags,
+			Status: s.Entry.Status, LastValidated: s.Entry.LastValidated,
+			Score: s.Score,
 		})
 	}
 	out, err := json.MarshalIndent(hits, "", "  ")
@@ -147,7 +156,8 @@ func get(cat *catalog.Catalog, args json.RawMessage) (string, error) {
 		out, err := json.MarshalIndent(fullEntry{
 			Path: e.Path, Type: e.Type, Title: e.Title, Description: e.Description,
 			Resource: e.Resource, Tags: e.Tags,
-			Timestamp: e.Timestamp, Fingerprint: e.Fingerprint, Body: e.Body,
+			Timestamp: e.Timestamp, Fingerprint: e.Fingerprint,
+			Status: e.Status, LastValidated: e.LastValidated, Body: e.Body,
 		}, "", "  ")
 		if err != nil {
 			return "", fmt.Errorf("kb_get encode: %w", err)

--- a/internal/kbmcp/kbmcp_test.go
+++ b/internal/kbmcp/kbmcp_test.go
@@ -203,3 +203,75 @@ func TestKBGetRejectsBadPaths(t *testing.T) {
 		}
 	}
 }
+
+// TestKBSurfacesStatus: retired/draft entries stay searchable and fetchable BY
+// DESIGN — MCP consumers doing KB archaeology see the lifecycle state and judge for
+// themselves; recall is where the firing ban lives. status/last_validated are
+// surfaced when present, omitted (not "") when absent.
+func TestKBSurfacesStatus(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "retired.md", `---
+type: Incident
+title: retired harbor incident
+description: superseded runbook
+resource: tooling/harbor
+status: retired
+last_validated: 2026-01-10
+---
+Old body.
+`)
+	writeEntry(t, dir, "active.md", `---
+type: Playbook
+title: active playbook current guidance
+description: current guidance
+---
+Body.
+`)
+	c, err := catalog.New(dir)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	handler := func(name string) func(context.Context, json.RawMessage) (string, error) {
+		for _, tl := range Tools(c) {
+			if tl.Name == name {
+				return tl.Handler
+			}
+		}
+		t.Fatalf("tool %q not registered", name)
+		return nil
+	}
+
+	// kb_search surfaces the retired status (retired knowledge stays findable).
+	out, err := handler("kb_search")(context.Background(), json.RawMessage(`{"query":"retired harbor incident"}`))
+	if err != nil {
+		t.Fatalf("kb_search: %v", err)
+	}
+	if !strings.Contains(out, `"status": "retired"`) {
+		t.Fatalf("kb_search must surface the retired status:\n%s", out)
+	}
+
+	// kb_get surfaces status + last_validated.
+	out, err = handler("kb_get")(context.Background(), json.RawMessage(`{"path":"retired.md"}`))
+	if err != nil {
+		t.Fatalf("kb_get: %v", err)
+	}
+	var e struct {
+		Status        string `json:"status"`
+		LastValidated string `json:"last_validated"`
+	}
+	if err := json.Unmarshal([]byte(out), &e); err != nil {
+		t.Fatalf("kb_get output is not JSON: %v\n%s", err, out)
+	}
+	if e.Status != "retired" || e.LastValidated != "2026-01-10" {
+		t.Fatalf("status/last_validated not surfaced: %+v", e)
+	}
+
+	// An entry without the fields omits the keys entirely (not "").
+	out, err = handler("kb_get")(context.Background(), json.RawMessage(`{"path":"active.md"}`))
+	if err != nil {
+		t.Fatalf("kb_get active.md: %v", err)
+	}
+	if strings.Contains(out, `"status"`) || strings.Contains(out, `"last_validated"`) {
+		t.Fatalf("absent status/last_validated must be omitted:\n%s", out)
+	}
+}

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -8,6 +8,7 @@
 package kbvalidate
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/Smana/runlore/internal/catalog"
@@ -134,6 +135,23 @@ func ValidateStructural(e catalog.Entry) []Issue {
 
 	if len(e.Tags) == 0 {
 		addWarn("tags", "frontmatter `tags` is empty")
+	}
+
+	// Lifecycle fields are ADVISORY: an odd status or an unparseable date is a
+	// warning, never an error — one strange entry must never fail the merge gate,
+	// and recall's fail-safe already treats an unknown status as active and an
+	// unparseable date as no-age-penalty.
+	if s := strings.TrimSpace(e.Status); s != "" {
+		switch s {
+		case "active", "retired", "draft":
+		default:
+			addWarn("status", fmt.Sprintf("unknown status %q (known: active, retired, draft); treated as active", s))
+		}
+	}
+	if e.LastValidated != "" {
+		if _, ok := catalog.ParseEntryDate(e.LastValidated); !ok {
+			addWarn("last_validated", fmt.Sprintf("unparseable date %q (want RFC3339 or 2006-01-02); age down-weighting will ignore it", e.LastValidated))
+		}
 	}
 
 	if strings.TrimSpace(e.Body) == "" {

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -155,6 +155,51 @@ func TestWarnInvalidToleratesForeignTypes(t *testing.T) {
 	}
 }
 
+// TestValidateStatusAndLastValidated: the lifecycle fields are ADVISORY at the
+// merge gate — an odd status or an unparseable date is a warning, never an error
+// (one strange entry never fails the gate). Valid vocabulary and dates warn about
+// nothing.
+func TestValidateStatusAndLastValidated(t *testing.T) {
+	// (a) unknown status → warning on `status`, and HasErrors stays false.
+	e := validIncident()
+	e.Status = "bogus"
+	issues := ValidateStructural(e)
+	if HasErrors(issues) {
+		t.Fatalf("unknown status must not be an error: %+v", issues)
+	}
+	if !has(issues, SeverityWarning, "status") {
+		t.Fatalf("expected a warning on status, got %+v", issues)
+	}
+
+	// (b) unparseable last_validated → warning on `last_validated`, never an error.
+	e = validIncident()
+	e.LastValidated = "not-a-date"
+	issues = ValidateStructural(e)
+	if HasErrors(issues) {
+		t.Fatalf("bad last_validated must not be an error: %+v", issues)
+	}
+	if !has(issues, SeverityWarning, "last_validated") {
+		t.Fatalf("expected a warning on last_validated, got %+v", issues)
+	}
+
+	// (c) known statuses (incl. empty) + a valid date → no lifecycle warning at all.
+	for _, s := range []string{"", "active", "retired", "draft"} {
+		e = validIncident()
+		e.Status = s
+		e.LastValidated = "2026-01-10"
+		issues = ValidateStructural(e)
+		if has(issues, SeverityWarning, "status") || has(issues, SeverityWarning, "last_validated") {
+			t.Fatalf("status=%q with a valid date must not warn: %+v", s, issues)
+		}
+	}
+	// An RFC3339 last_validated is equally valid.
+	e = validIncident()
+	e.LastValidated = "2026-01-10T09:30:00Z"
+	if has(ValidateStructural(e), SeverityWarning, "last_validated") {
+		t.Fatal("RFC3339 last_validated must not warn")
+	}
+}
+
 func TestHasErrors(t *testing.T) {
 	if HasErrors([]Issue{{Severity: SeverityWarning, Field: "tags"}}) {
 		t.Fatal("warnings-only must not count as errors")


### PR DESCRIPTION
## The missing time dimension

`docs/design.md` §Learn has long promised that catalog entries carry `status`, `confidence`, and `last_validated` — but the loader dropped `status`/`last_validated` on the floor (audit N6), so a KB entry had no *time dimension*: a five-year-old runbook nobody has revalidated fired with exactly the confidence of yesterday's, and a `retired` entry was still fully recallable. This PR parses those two fields and makes recall honor them, closing the design drift.

## What each field does

- **`status`** (`internal/catalog`): parsed as a raw string. Recall now filters `retired`/`draft` entries at the structural pre-filter — they **never fire and never surface as a near-miss lead** — while `kb_search`/`kb_get` keep indexing and surfacing them (status-visible) for KB archaeology. Anything other than `retired`/`draft` (absent, `active`, or a foreign value) stays active (OKF §9 tolerance).
- **`last_validated`** (`internal/catalog`): when a human last confirmed the entry works. Recall applies a single multiplicative confidence step-down (×0.75) when the entry's freshness date (`last_validated`, else `timestamp`) is older than a configurable horizon `catalog.instant_recall.stale_after` (Go duration; `0`/unset disables). **Age never rejects** — `confirm` and `verify` stay the hard gates, and the outcome floor keeps priority (track record beats calendar); staleness only lowers *delivered* confidence. It is stamped at entry creation (= `timestamp`) so a never-revalidated entry ages visibly.
- **`confidence`**: documented as a write-side extension key the curator emits but recall deliberately does **not** read back — recall derives trust from the live outcome track record, and a static authored confidence would fight that dynamic signal.

## Design

- **Loader-parses-everything, recall-filters.** The index still contains every entry (retired knowledge stays discoverable over MCP, status visible); "must not fire" semantics live only in the recall path. One date grammar (`catalog.ParseEntryDate`, shared with kbvalidate) and one status predicate (`entryActive`).
- **Fail-safe by construction, pinned by tests.** Absent frontmatter reproduces today's behavior byte-for-byte; unknown status ⇒ active; malformed status/date ⇒ load-time **advisory warning**, never an error (one odd entry never empties the catalog); `stale_after: 0` ⇒ off; a dateless/unparseable-date entry is exempt from age down-weighting.

## The N4 seam, now live end-to-end

PR #333 shipped the retirement pass that *writes* `status: retired` frontmatter but noted the loader honoring it was a separate change. This PR is that change: a merged retirement PR is now effective — recall drops the retired entry at its pre-filter, on the winner, the outcome-decay runner-up fallback, and the near-miss lead alike. `docs/learning-loop.md` §5's "Seam (in progress)" is updated to "now live", and §6 gains the two orthogonal freshness signals (status filter + `stale_after` step-down) with the confirm/verify backstop argument.

## Docs drift closed

`design.md` §Learn (status/last_validated now match reality; confidence explained as write-side-only), `learning-loop.md` §5+§6, `configuration.md` (`catalog.instant_recall.stale_after`), `mcp.md` (new `status`/`last_validated` result fields; retired-entries-stay-searchable rationale).

## Reference

- Plan: `dev/superpowers/plans/2026-07-19-okf-staleness.md`
- Roadmap: closes audit item **N6** (unparsed OKF frontmatter); makes the **N4** retirement seam effective. N5 (revalidation stamping on confirmation) is named as a future seam, not built here.