### PR TITLE
docs(dev): Later-wave plans, federation design, and roadmap status

### DIFF
--- a/dev/plans/2026-07-19-audit-roadmap.md
+++ b/dev/plans/2026-07-19-audit-roadmap.md
@@ -28,19 +28,20 @@ index with the KB, cap the bill — before widening integrations.
 | N8 | **Hybrid recall eval**: extend the retrieval eval to real embedding-backed hybrid, measure the cosine thresholds (currently self-described "placeholders"), and graduate hybrid from EXPERIMENTAL — or document why not | The eval already honestly shows BM25-only fires 0/11 and the reranker is load-bearing; hybrid is the designated successor and is currently unmeasured. Depends on N2 | `2026-07-19-hybrid-recall-eval.md` |
 | N9 | **MCP remote-tool allowlist**: opt-in per-server `tools:` allowlist (+ deny-by-default option), making "read-only extension layer" enforceable rather than prompt-promised | Security-conscious operators can safely connect third-party MCP servers — unlocks the extension story credibly | `2026-07-19-mcp-tool-allowlist.md` |
 
-## Later — strategic, when adoption pulls (roadmap only, no plans yet)
+> **STATUS 2026-07-20:** Now + Next SHIPPED — N1-N3 as PRs #328-#330, N4/N7/N9 as
+> #331-#333, N5/N6/N8 as #334-#336 (integrated main green after each wave). Hybrid
+> recall stays EXPERIMENTAL pending a live-endpoint measurement run (criteria in
+> `docs/configuration.md`). The Later horizon now has plans/specs (below).
 
-- **Config-only sources & notifiers** — the biggest adoption limiter (every new alert
-  source or channel needs Go). The registries exist; a generic *templated* webhook
-  source + notifier covers most vendors cheaply before per-vendor work. Unify
-  Slack/Matrix into the notify registry while there (two mechanisms for one concept
-  today). Builds on `2026-06-27-extensible-sources-notifiers-design.md`.
-- **Multi-KB federation** (org + team + vendor bundles with precedence) — wait for
-  multi-team pull.
-- **Persisted vectors / ANN / incremental indexing** — only when real KBs pass ~1-2k
-  entries; N2 buys the headroom first.
-- **A handful of `testing.B` benchmarks** on the paths above (embed reload, recall
-  query, ledger replay, clone/fetch) so the perf work has regression guardrails.
+## Later — strategic (plans/specs written 2026-07-20)
+
+| # | Item | Doc |
+|---|---|---|
+| L1 | Config-only **templated webhook source** (Grafana/Datadog/... without Go) | `plans/2026-07-20-templated-webhook-source.md` |
+| L2 | **Templated notifier** (Teams/Discord/... via Go templates). *Erratum:* the audit's "unify Slack/Matrix into the registry" was stale — construction is already registry-based; the typed-config vs `Extra`-map split is deliberate. The plan pins unified behavior with tests instead of migrating | `plans/2026-07-20-templated-notifier-registry.md` |
+| L3 | **Multi-KB federation** — DESIGN ONLY: merged index + per-source weights, `<source>/<path>` ledger identity, single writable KB; has open maintainer questions and a "when NOT to build" gate | `specs/2026-07-20-multi-kb-federation-design.md` |
+| L4 | **Persisted vector cache + incremental bleve indexing** (path-keyed doc IDs, SyncDelta, gob cache with model/dim invalidation); ANN stays a non-goal until ~1-2k entries | `plans/2026-07-20-persisted-vectors-incremental-index.md` |
+| L5 | **Hot-path benchmarks** (catalog reload cold/warm, recall query, ledger replay/compaction, ingest storm) — hermetic, not in the PR gate | `plans/2026-07-20-hotpath-benchmarks.md` |
 
 ## Deliberately not on the roadmap
 

--- a/dev/superpowers/plans/2026-07-20-hotpath-benchmarks.md
+++ b/dev/superpowers/plans/2026-07-20-hotpath-benchmarks.md
@@ -1,0 +1,543 @@
+# Hot-Path Benchmarks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the audit's four hot paths (catalog reload/embed, recall query, outcome-ledger replay/read, ingest chokepoint) `testing.B` regression guardrails — the repo's only benchmarks today are the two clone-strategy ones in `internal/whatchanged/differ_bench_test.go` (PR #332).
+
+**Architecture:** One `*_bench_test.go` file per package, mirroring the established `differ_bench_test.go` style: SPDX line 1, a package-level doc comment stating the exact run command, hermetic fixtures built by a `testing.TB` helper (temp dirs, deterministic inputs, no network), `b.ResetTimer()` after setup. No benchmark enters the CI gate; a docs section records how to run them locally (adding a bench job to the nightly workflows was considered and rejected — `eval.yaml` is an API-key-gated LLM eval and `ci.yaml` is the PR gate; neither fits without new machinery. YAGNI).
+
+**Tech Stack:** Go (toolchain go1.26.5) `testing.B` only; existing packages `internal/{catalog,outcome,trigger,coalesce,investigate}`.
+
+## Global Constraints
+
+- Quality gate before every commit: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — `0 issues`, `gofmt -l` empty; plus `go test -race` on touched packages.
+- SPDX header `// SPDX-License-Identifier: Apache-2.0` line 1 of every new `.go` file.
+- Conventional Commits; **no co-author trailer**.
+- **Hermetic only**: no network, all fixtures under `b.TempDir()`/in-memory, deterministic inputs (no randomness, no wall-clock dependence in measured code paths).
+- Every benchmark carries a doc comment naming the regression it guards.
+- **Wave-B independence:** this plan compiles against main `0045916` and uses only stable APIs. The deterministic embedder is REPLICATED here (~15 lines) rather than reused from PR #334 — that branch's `bowEmbedder` is an unexported type in `internal/investigate`'s test files, unreachable from `internal/catalog` even after merge. PR #335 may extend `outcome.Event`/`Aggregate` (a `confirm` kind); Task 3 writes only `open`/`resolve` events, which are stable. PR (N6) adds optional frontmatter fields; Task 1's fixture entries omit them, which must keep behaving identically (that PR's own constraint). If any wave-B PR merges first, expect zero conflicts; note surprises in the final report.
+
+---
+
+### Task 1: Catalog fixture + reload benchmarks
+
+**Files:**
+- Create: `internal/catalog/catalog_bench_test.go`
+
+**Interfaces:**
+- Consumes: `NewEmpty()`, `(*Catalog).Reload(dir)`, `(*Catalog).ReloadContext(ctx, dir)`, `(*Catalog).SetEmbedder(e)` (`catalog.go:65,74,82,37`), `Embedder` (`hybrid.go:21`: `Embed(ctx context.Context, texts []string) ([][]float32, error)`).
+- Produces (used by Task 2): `writeBenchCorpus(tb testing.TB, n int) string` (returns the corpus dir), `benchEmbedder{}` (deterministic `Embedder`), `warmCatalog(tb testing.TB, dir string, hybrid bool) *Catalog`.
+
+- [ ] **Step 1: Write the file with fixture helpers + three reload benchmarks**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Hermetic hot-path benchmarks for the catalog (audit 2026-07-19, roadmap Later
+// wave). Fixtures are ~200 synthetic OKF entries. Run with:
+//
+//	go test ./internal/catalog/ -bench Benchmark -benchtime 5x -run '^$'
+
+const benchCorpusSize = 200
+
+// writeBenchCorpus writes n deterministic OKF entries and returns the dir.
+// Each entry shares common vocabulary ("failure", "rollout") and carries unique
+// tokens (svc-i, ns-i%10) so BM25 and the bag-of-words vectors both discriminate.
+func writeBenchCorpus(tb testing.TB, n int) string {
+	tb.Helper()
+	dir := tb.TempDir()
+	for i := 0; i < n; i++ {
+		body := fmt.Sprintf(`---
+type: Incident
+title: svc-%d rollout failure in ns-%d
+description: HelmRelease svc-%d upgrade failed with probe timeouts
+resource: ns-%d/deployment/svc-%d
+tags: [rollout, svc-%d]
+---
+The svc-%d deployment in ns-%d failed its rollout: readiness probes timed out
+after the config change. Resolution: revert the values change and reconcile.
+`, i, i%10, i, i%10, i, i, i, i%10)
+		p := filepath.Join(dir, fmt.Sprintf("entry-%03d.md", i))
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// benchEmbedder is a minimal deterministic bag-of-words embedder (fnv token
+// buckets, L2-normalized). Replicates the shape of the eval's embedder; kept
+// local because that one is unexported test code in another package.
+type benchEmbedder struct{}
+
+func (benchEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	const dims = 256
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, dims)
+		start := -1
+		for j := 0; j <= len(t); j++ {
+			if j < len(t) && (t[j] >= 'a' && t[j] <= 'z' || t[j] >= '0' && t[j] <= '9') {
+				if start < 0 {
+					start = j
+				}
+				continue
+			}
+			if start >= 0 {
+				h := fnv.New32a()
+				_, _ = h.Write([]byte(t[start:j]))
+				v[h.Sum32()%dims]++
+				start = -1
+			}
+		}
+		var norm float64
+		for _, x := range v {
+			norm += float64(x) * float64(x)
+		}
+		if norm > 0 {
+			n := float32(math.Sqrt(norm))
+			for k := range v {
+				v[k] /= n
+			}
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+// warmCatalog returns a loaded catalog over dir; hybrid additionally wires the
+// deterministic embedder and builds vectors.
+func warmCatalog(tb testing.TB, dir string, hybrid bool) *Catalog {
+	tb.Helper()
+	c := NewEmpty()
+	if hybrid {
+		c.SetEmbedder(benchEmbedder{})
+	}
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		tb.Fatal(err)
+	}
+	if hybrid && !c.HasVectors() {
+		tb.Fatal("bench: vectors not built")
+	}
+	return c
+}
+
+// BenchmarkReloadBM25 guards the cost of a full BM25 index rebuild — the price
+// paid on every KB HEAD move regardless of embeddings.
+func BenchmarkReloadBM25(b *testing.B) {
+	dir := writeBenchCorpus(b, benchCorpusSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := NewEmpty()
+		if _, err := c.Reload(dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkReloadEmbedColdCache guards the worst-case reload: index rebuild plus
+// embedding the ENTIRE corpus with an empty vector cache (first boot, cache loss).
+func BenchmarkReloadEmbedColdCache(b *testing.B) {
+	dir := writeBenchCorpus(b, benchCorpusSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := NewEmpty()
+		c.SetEmbedder(benchEmbedder{})
+		if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkReloadEmbedWarmCache guards the steady-state reload after PR #328:
+// unchanged entries must hit the content-hash cache, so a warm reload should sit
+// close to BenchmarkReloadBM25, far below the cold-cache cost. A collapse of this
+// gap means the cache regressed.
+func BenchmarkReloadEmbedWarmCache(b *testing.B) {
+	dir := writeBenchCorpus(b, benchCorpusSize)
+	c := warmCatalog(b, dir, true) // warm the vecCache once, unmeasured
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Prove the benchmarks compile and run**
+
+Run: `go test ./internal/catalog/ -bench BenchmarkReload -benchtime 1x -run '^$'`
+Expected: three `BenchmarkReload*` lines with ns/op, exit 0. Sanity: warm-cache ns/op noticeably below cold-cache.
+
+- [ ] **Step 3: Full package tests still green**
+
+Run: `go test ./internal/catalog/`
+Expected: `ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/catalog/catalog_bench_test.go
+git commit -m "bench(catalog): reload benchmarks — BM25 rebuild, cold vs warm embed cache"
+```
+
+---
+
+### Task 2: Recall query benchmarks
+
+**Files:**
+- Modify: `internal/catalog/catalog_bench_test.go` (append)
+
+**Interfaces:**
+- Consumes: Task 1's `writeBenchCorpus`/`warmCatalog`; `(*Catalog).SearchScored(query string, k int)` (`catalog.go:208`), `(*Catalog).SearchHybrid(ctx, query string, k int)` (`hybrid.go:109`).
+
+- [ ] **Step 1: Append the two query benchmarks**
+
+```go
+// benchQuery mimics an enriched recall query (symptom + namespace + workload +
+// alertname vocabulary) against the fixture corpus.
+const benchQuery = "svc-42 rollout failure probe timeout ns-2 deployment"
+
+// BenchmarkSearchScored guards the BM25 recall lookup — the per-incident hot
+// path when hybrid is off.
+func BenchmarkSearchScored(b *testing.B) {
+	c := warmCatalog(b, writeBenchCorpus(b, benchCorpusSize), false)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.SearchScored(benchQuery, 20); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSearchHybrid guards the hybrid recall lookup: query embed + BM25 +
+// the brute-force cosine scan over the whole corpus (audit perf finding #3 —
+// this is the O(n) path that caps KB size until an ANN lands).
+func BenchmarkSearchHybrid(b *testing.B) {
+	c := warmCatalog(b, writeBenchCorpus(b, benchCorpusSize), true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.SearchHybrid(context.Background(), benchQuery, 20); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Prove they run**
+
+Run: `go test ./internal/catalog/ -bench BenchmarkSearch -benchtime 5x -run '^$'`
+Expected: two benchmark lines, exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/catalog/catalog_bench_test.go
+git commit -m "bench(catalog): recall query benchmarks — BM25 and hybrid cosine scan"
+```
+
+---
+
+### Task 3: Outcome-ledger benchmarks
+
+**Files:**
+- Create: `internal/outcome/ledger_bench_test.go`
+
+**Interfaces:**
+- Consumes: `Event` (exported, JSON tags — `ledger.go:61`), `NewWithMaxEvents(path string, maxEvents int)` (`ledger.go:319`; per its doc `0` disables compaction), `(*Ledger).OpenCounts()` (`ledger.go:989`). Fixture writes JSONL directly via `json.Marshal(Event{...})` + `os.WriteFile` — the exact pattern `ledger_test.go:166-169` already uses.
+
+- [ ] **Step 1: Write the file**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package outcome
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Hermetic ledger benchmarks (audit 2026-07-19, roadmap Later wave). The fixture
+// is a 10k-event JSONL written directly (no fsync-per-append), the same shape
+// ledger_test.go builds for corruption tests. Run with:
+//
+//	go test ./internal/outcome/ -bench BenchmarkLedger -benchtime 5x -run '^$'
+
+const benchEventPairs = 5000 // 5000 open + 5000 resolve = 10k events
+
+// writeBenchLedger writes nPairs open("recall")/resolve pairs across 50 entries
+// and returns the file path. Deterministic timestamps; resolves always after
+// their opens so pairing takes the fast path.
+func writeBenchLedger(tb testing.TB, nPairs int) string {
+	tb.Helper()
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	for i := 0; i < nPairs; i++ {
+		fp := fmt.Sprintf("fp-%d", i)
+		open, err := json.Marshal(Event{
+			Event: "open", Fingerprint: fp, Kind: "recall",
+			Entry: fmt.Sprintf("entry-%02d.md", i%50),
+			At:    t0.Add(time.Duration(i) * time.Minute),
+		})
+		if err != nil {
+			tb.Fatal(err)
+		}
+		res, err := json.Marshal(Event{
+			Event: "resolve", Fingerprint: fp,
+			At: t0.Add(time.Duration(i)*time.Minute + 30*time.Second),
+		})
+		if err != nil {
+			tb.Fatal(err)
+		}
+		buf.Write(open)
+		buf.WriteByte('\n')
+		buf.Write(res)
+		buf.WriteByte('\n')
+	}
+	p := filepath.Join(tb.TempDir(), "ledger.jsonl")
+	if err := os.WriteFile(p, buf.Bytes(), 0o600); err != nil {
+		tb.Fatal(err)
+	}
+	return p
+}
+
+// BenchmarkLedgerReplay guards cold-start replay cost of a 10k-event file with
+// compaction disabled — the "6-month-old ledger with max_events: 0" audit case.
+func BenchmarkLedgerReplay(b *testing.B) {
+	p := writeBenchLedger(b, benchEventPairs)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := NewWithMaxEvents(p, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLedgerCompactedLoad guards one replay+compaction cycle: loading 10k
+// events over a 1k bound rewrites the file with a checkpoint. Each iteration
+// copies the fixture to a fresh path (compaction mutates it), unmeasured.
+func BenchmarkLedgerCompactedLoad(b *testing.B) {
+	src := writeBenchLedger(b, benchEventPairs)
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dir := b.TempDir()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		p := filepath.Join(dir, fmt.Sprintf("ledger-%d.jsonl", i))
+		if err := os.WriteFile(p, raw, 0o600); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if _, err := NewWithMaxEvents(p, 1000); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLedgerOpenCounts guards the recall hot-path read: OpenCounts must
+// stay an O(entries) copy of the incrementally-maintained aggregate, never a
+// file re-read (the audit confirmed this design — this pins it).
+func BenchmarkLedgerOpenCounts(b *testing.B) {
+	l, err := NewWithMaxEvents(writeBenchLedger(b, benchEventPairs), 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := l.OpenCounts(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Prove they run**
+
+Run: `go test ./internal/outcome/ -bench BenchmarkLedger -benchtime 1x -run '^$'`
+Expected: three benchmark lines, exit 0. Sanity: OpenCounts ns/op orders of magnitude below Replay.
+
+- [ ] **Step 3: Full package tests still green**
+
+Run: `go test ./internal/outcome/`
+Expected: `ok`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/outcome/ledger_bench_test.go
+git commit -m "bench(outcome): ledger replay, compaction cycle, and OpenCounts read"
+```
+
+---
+
+### Task 4: Ingest-chokepoint benchmarks
+
+**Files:**
+- Create: `internal/trigger/dedup_bench_test.go`
+- Create: `internal/coalesce/coalescer_bench_test.go`
+
+**Interfaces:**
+- Consumes: `trigger.NewDeduper(window time.Duration)` / `(*Deduper).Seen(key string) bool` (`dedup.go:20,27`); `coalesce.New(cfg Config, out func([]investigate.Request)) *Coalescer` / `(*Coalescer).Add(r investigate.Request)` (`coalescer.go:68,172`), `Config{Debounce, MaxWait, MaxBatch, Cooldown, CorrelationLabels}` (`coalescer.go:23`), `investigate.Request{Title, Message, Labels, GroupKey, Fingerprint, At}` (`investigate.go:44`).
+
+- [ ] **Step 1: Write `internal/trigger/dedup_bench_test.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package trigger
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// BenchmarkDeduperSeenStorm guards the ingest chokepoint under an alert storm
+// with many DISTINCT fingerprints: Seen currently evicts by scanning the whole
+// map under the mutex on every call (audit perf finding — demoted, but pinned
+// here so a regression, or the eventual amortized-sweep fix, is visible).
+// Run: go test ./internal/trigger/ -bench . -benchtime 5x -run '^$'
+func BenchmarkDeduperSeenStorm(b *testing.B) {
+	d := NewDeduper(10 * time.Minute)
+	keys := make([]string, 5000)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("fp-%d", i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.Seen(keys[i%len(keys)])
+	}
+}
+```
+
+- [ ] **Step 2: Write `internal/coalesce/coalescer_bench_test.go`**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package coalesce
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/investigate"
+)
+
+// BenchmarkCoalescerAdd guards per-alert admission cost at the coalescer: key
+// derivation + batch bookkeeping under the mutex, across 1000 live correlation
+// keys. Debounce is far in the future so nothing flushes mid-measurement.
+// Run: go test ./internal/coalesce/ -bench . -benchtime 5x -run '^$'
+func BenchmarkCoalescerAdd(b *testing.B) {
+	c := New(Config{Debounce: time.Hour, MaxWait: 2 * time.Hour, MaxBatch: 1 << 20},
+		func([]investigate.Request) {})
+	reqs := make([]investigate.Request, 1000)
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range reqs {
+		reqs[i] = investigate.Request{
+			Title:       fmt.Sprintf("HighErrorRate-%d", i),
+			Message:     "error budget burn",
+			Labels:      map[string]string{"namespace": fmt.Sprintf("ns-%d", i)},
+			GroupKey:    fmt.Sprintf("group-%d", i),
+			Fingerprint: fmt.Sprintf("fp-%d", i),
+			At:          at,
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Add(reqs[i%len(reqs)])
+	}
+}
+```
+
+If `Add` on the current code requires more Request fields to take the batch path (compile or panic says so), set exactly the missing fields to deterministic values — do not restructure the benchmark.
+
+- [ ] **Step 3: Prove both run**
+
+Run: `go test ./internal/trigger/ ./internal/coalesce/ -bench . -benchtime 1x -run '^$'`
+Expected: two benchmark lines, exit 0.
+
+- [ ] **Step 4: Package tests still green**
+
+Run: `go test ./internal/trigger/ ./internal/coalesce/`
+Expected: both `ok`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/trigger/dedup_bench_test.go internal/coalesce/coalescer_bench_test.go
+git commit -m "bench(ingest): deduper storm scan and coalescer admission"
+```
+
+---
+
+### Task 5: Document the suite (no CI change)
+
+**Files:**
+- Modify: `docs/benchmarking.md` (append a section; read the file first and match its heading style — it currently covers the LLM/eval side)
+
+- [ ] **Step 1: Append the section**
+
+```markdown
+## Go micro-benchmarks (hot paths)
+
+Hermetic `testing.B` benchmarks guard the hot paths the 2026-07-19 audit named:
+no network, deterministic fixtures, safe to run anywhere. They are deliberately
+NOT part of the CI gate (numbers on shared runners are noise); run them locally
+when touching these packages and compare against your own baseline:
+
+    go test ./internal/whatchanged/ -bench BenchmarkRemote -benchtime 5x -run '^$'
+    go test ./internal/catalog/     -bench Benchmark       -benchtime 5x -run '^$'
+    go test ./internal/outcome/     -bench BenchmarkLedger -benchtime 5x -run '^$'
+    go test ./internal/trigger/ ./internal/coalesce/ -bench . -benchtime 5x -run '^$'
+
+What each guards: clone-vs-mirror (`whatchanged`), BM25 rebuild and cold-vs-warm
+embed cache + BM25/hybrid query cost (`catalog`), cold-start replay, one
+compaction cycle, and the O(1) OpenCounts read (`outcome`), and per-alert
+admission under storm (`trigger`, `coalesce`).
+```
+
+- [ ] **Step 2: Full quality gate**
+
+Run: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...`
+Expected: build/vet/tests clean, `gofmt -l` empty, `0 issues.`
+Then: `go test -race ./internal/catalog/... ./internal/outcome/... ./internal/trigger/... ./internal/coalesce/...`
+Expected: all `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/benchmarking.md
+git commit -m "docs(benchmarking): document the Go hot-path benchmark suite"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: audit hot paths → Task 1 (reload/embed), Task 2 (recall query), Task 3 (ledger), Task 4 (ingest); CI decision documented in Task 5 (rejected, with rationale). ✓
+- No placeholders; every step carries complete code and exact commands. ✓
+- Type consistency: `writeBenchCorpus`/`warmCatalog`/`benchEmbedder` defined in Task 1, consumed in Task 2 with identical signatures; all external symbols verified against main `0045916` (`Embed(ctx, []string)`, `NewWithMaxEvents(path, int)`, `Event` JSON shape from `ledger_test.go:166`, `Config`/`Add`/`Request` fields). ✓

--- a/dev/superpowers/plans/2026-07-20-persisted-vectors-incremental-index.md
+++ b/dev/superpowers/plans/2026-07-20-persisted-vectors-incremental-index.md
@@ -1,0 +1,977 @@
+# Persisted Vectors + Incremental Index Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist the N2 content-hash vector cache to disk (restarts/HA failovers stop re-embedding the whole corpus) and make the bleve index update incrementally from the git-sync diff instead of rebuilding wholesale on every KB HEAD move.
+
+**Architecture:** Three seams, all fail-safe to today's behavior. (1) Doc IDs switch from slice positions to `Entry.Path` (stable across reloads) with a `pathIdx` map for hit resolution — the prerequisite for incremental updates. (2) `Syncer.Sync` reports a `SyncDelta` (changed/removed repo-relative paths via `object.DiffTree` between the previous and new HEAD); `Catalog.ReloadDelta` applies it as targeted `Index`/`Delete` mutations on the live index (bleve is concurrency-safe), falling back to the existing full `ReloadContext` whenever the delta is nil, the catalog is cold, or any mutation errors. (3) The in-memory `vecCache` gains a gob-encoded disk file with a `{Version, Model, Dim}` header, loaded before the first reload and rewritten (temp+fsync+rename, the ledger's pattern) after each successful embed pass; any load problem — missing, corrupt, model or dimension mismatch — is a WARN + cold start, never an error.
+
+**Tech Stack:** Go (toolchain go1.26.5); stdlib `encoding/gob` (compact binary for `map[string][]float32`, one-shot encode/decode, no new dependencies — JSON of float32 corpora is ~10× the bytes and parse cost for a file no human reads); existing `go-git/v5` (`plumbing/object.DiffTree`); bleve v2 MemOnly.
+
+## Global Constraints
+
+- Quality gate before every commit: `go build ./... && go vet ./... && go test ./... && gofmt -l .` (empty) and `golangci-lint run ./...` → `0 issues.`; plus `go test -race ./internal/catalog/... ./internal/app/... ./internal/config/...` before the final push.
+- SPDX header `// SPDX-License-Identifier: Apache-2.0` as line 1 of every new `.go` file.
+- Conventional Commits; **no co-author / AI-attribution trailers**.
+- **Fail-safe:** cache problems ⇒ cold start (re-embed, WARN); incremental problems ⇒ full rebuild — never a wrong or partial index/vector set. The all-or-nothing `HasVectors` invariant from N2 (PR #328) is untouched.
+- **No new dependencies** (`go.mod` unchanged).
+- **Hash-key stability is NOT assumed:** if N6 (okf-staleness) merges first, `Entry` gains `Status`/`LastValidated` and `entryText` may change shape — every cached key then misses once and the corpus re-embeds one time (harmless by design). Read `entryText` as it exists when you execute; never hard-code its field list in tests (derive expected hashes by calling it).
+- The cache file is **pod-local** (leader and standbys each maintain their own; they already each run the syncer). Do not attempt file sharing/locking across replicas.
+- Sibling-work note: wave-B PRs (#334 eval, #335 outcome, N6 staleness) may land before this; none touch `sync.go`/`hybrid.go` structurally. Rebase, expect only line drift.
+
+## File Structure
+
+- `internal/catalog/catalog.go` — path-keyed doc IDs, `pathIdx`, `ReloadDelta`, cache save hook
+- `internal/catalog/hybrid.go` — path IDs in the cosine ranking / RRF fusion
+- `internal/catalog/sync.go` — `SyncDelta`, `diffPaths`, `Sync` third return, `Run` passes the delta
+- `internal/catalog/veccache.go` (new) — gob load/save with header validation
+- `internal/catalog/{catalog,hybrid,sync,veccache,delta}_test.go` — per-task tests
+- `internal/config/config.go` + `internal/config/load.go` — `instant_recall.vector_cache {enabled, dir}`
+- `internal/app/catalog.go` — wiring: `EnableVectorCache` + delta-aware sync closure
+- `docs/configuration.md` — the new knob + PV note
+
+---
+
+### Task 1: Path-keyed doc IDs + `pathIdx` (pure refactor)
+
+**Files:**
+- Modify: `internal/catalog/catalog.go` (`buildIndex`, `Catalog` struct, `NewEmpty`, `ReloadContext`, `SearchScored`)
+- Modify: `internal/catalog/hybrid.go` (`SearchHybrid` cosine-ID space, pool resolution)
+- Test: `internal/catalog/catalog_test.go` (extend)
+
+**Interfaces:**
+- Produces: bleve doc ID = `Entry.Path`; `Catalog.pathIdx map[string]int` (guarded by `mu`, always parallel to `entries`); helper `pathIndex(entries []Entry) map[string]int`. Consumed by Tasks 3 (incremental Index/Delete by path) — nothing outside the package sees a change.
+
+- [ ] **Step 1: Write the failing test** (in `catalog_test.go`, matching its existing `t.TempDir()`+`os.WriteFile` style):
+
+```go
+func TestSearchResolvesPathKeyedDocs(t *testing.T) {
+	dir := t.TempDir()
+	for name, title := range map[string]string{
+		"a.md": "cilium agent crashloop",
+		"b.md": "postgres disk pressure",
+	} {
+		entry := "---\ntype: Incident\ntitle: " + title + "\n---\nBody.\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(entry), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := c.SearchScored("cilium crashloop", 5)
+	if err != nil || len(hits) == 0 {
+		t.Fatalf("hits=%v err=%v", hits, err)
+	}
+	if hits[0].Entry.Path != "a.md" {
+		t.Errorf("top hit path = %q, want a.md", hits[0].Entry.Path)
+	}
+	// The doc ID space is now paths: deleting by path must remove the doc.
+	c.mu.Lock()
+	err = c.index.Delete("a.md")
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("delete by path: %v", err)
+	}
+	hits, _ = c.SearchScored("cilium crashloop", 5)
+	for _, h := range hits {
+		if h.Entry.Path == "a.md" {
+			t.Error("deleted doc still returned")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/catalog/ -run TestSearchResolvesPathKeyedDocs -v`
+Expected: FAIL — `deleted doc still returned` (Delete("a.md") is a no-op against numeric IDs; the doc was indexed as "0").
+
+- [ ] **Step 3: Implement.** `catalog.go`:
+
+Add the field and helper:
+
+```go
+	// pathIdx maps Entry.Path → position in entries; maintained in lockstep with
+	// entries under mu. It exists because bleve docs are keyed by Path (stable
+	// across reloads — the prerequisite for incremental Index/Delete), so search
+	// hits resolve IDs through it instead of parsing positions.
+	pathIdx map[string]int
+```
+
+```go
+func pathIndex(entries []Entry) map[string]int {
+	m := make(map[string]int, len(entries))
+	for i, e := range entries {
+		m[e.Path] = i
+	}
+	return m
+}
+```
+
+`buildIndex` — key by path:
+
+```go
+	for _, e := range entries {
+		doc := map[string]any{
+			"title": e.Title,
+			"text":  entryText(e),
+		}
+		if err := idx.Index(e.Path, doc); err != nil {
+			return nil, fmt.Errorf("index entry %s: %w", e.Path, err)
+		}
+	}
+```
+
+`NewEmpty`: `return &Catalog{index: idx, pathIdx: map[string]int{}}`.
+
+`ReloadContext` swap: `c.index, c.entries, c.vectors, c.pathIdx = idx, entries, vectors, pathIndex(entries)`.
+
+`SearchScored` hit resolution:
+
+```go
+	for _, hit := range res.Hits {
+		i, ok := c.pathIdx[hit.ID]
+		if !ok {
+			continue
+		}
+		out = append(out, ScoredEntry{Entry: c.entries[i], Score: hit.Score})
+	}
+```
+
+Drop the now-unused `strconv` import from `catalog.go`.
+
+`hybrid.go` — the two rankings must share the path ID space for RRF to fuse them:
+
+```go
+	cosIDs := make([]string, len(ranked))
+	for i, idx := range ranked {
+		cosIDs[i] = c.entries[idx].Path
+	}
+```
+
+and pool resolution:
+
+```go
+	for _, f := range pool {
+		i, ok := c.pathIdx[f.ID]
+		if !ok {
+			continue
+		}
+		out = append(out, ScoredEntry{Entry: c.entries[i], Score: cos[i]})
+	}
+```
+
+Drop the now-unused `strconv` import from `hybrid.go`.
+
+- [ ] **Step 4: Run the full package** — this is a refactor; every existing test must pass unchanged.
+
+Run: `go test ./internal/catalog/ ./internal/investigate/ ./internal/kbmcp/ -count=1`
+Expected: all `ok` (recall/eval/kbmcp consume entries, never doc IDs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/catalog/catalog.go internal/catalog/hybrid.go internal/catalog/catalog_test.go
+git commit -m "refactor(catalog): key bleve docs by entry path
+
+Positional doc IDs can't survive an incremental update (any
+insert/remove shifts every ID). Path-keyed docs + a pathIdx resolution
+map keep IDs stable across reloads — the prerequisite for delta
+indexing. Pure refactor: search results are byte-identical."
+```
+
+---
+
+### Task 2: `SyncDelta` — the syncer reports changed/removed paths
+
+**Files:**
+- Modify: `internal/catalog/sync.go` (`Sync` third return, `diffPaths`, `Run` onSync signature)
+- Modify: `internal/app/catalog.go` (closure signature only — mechanical, keeps compiling; real delta use arrives in Task 3)
+- Test: `internal/catalog/sync_test.go` (extend; reuse `initBareUpstream`/`commitToUpstream` helpers verbatim)
+
+**Interfaces:**
+- Produces: `type SyncDelta struct { Changed, Removed []string }` (repo-relative paths; a rename contributes its old name to Removed and new name to Changed); `Sync(ctx) (changed bool, delta *SyncDelta, err error)` — **delta nil means "unknown, do a full reload"** (first sync, or any diff error); `Run(ctx, interval, onSync func(*SyncDelta) error)`.
+- Consumes: `s.lastRev` (existing), `object.DiffTree`.
+
+- [ ] **Step 1: Write the failing test** (in `sync_test.go`):
+
+```go
+func TestSyncReportsDelta(t *testing.T) {
+	src := initBareUpstream(t)
+	commitToUpstream(t, src, "a.md", "alpha v1")
+	commitToUpstream(t, src, "b.md", "beta v1")
+	s := &Syncer{URL: src, Dir: t.TempDir(), Log: testLogger()}
+
+	// First sync: change reported, delta unknown (nil) — full reload territory.
+	changed, delta, err := s.Sync(context.Background())
+	if err != nil || !changed {
+		t.Fatalf("first sync: changed=%v err=%v", changed, err)
+	}
+	if delta != nil {
+		t.Fatalf("first sync delta = %+v, want nil (unknown)", delta)
+	}
+
+	// Modify one file, add one: delta lists exactly those, nothing removed.
+	commitToUpstream(t, src, "a.md", "alpha v2")
+	commitToUpstream(t, src, "c.md", "gamma v1")
+	changed, delta, err = s.Sync(context.Background())
+	if err != nil || !changed || delta == nil {
+		t.Fatalf("second sync: changed=%v delta=%v err=%v", changed, delta, err)
+	}
+	sort.Strings(delta.Changed)
+	if want := []string{"a.md", "c.md"}; !slices.Equal(delta.Changed, want) {
+		t.Errorf("Changed = %v, want %v", delta.Changed, want)
+	}
+	if len(delta.Removed) != 0 {
+		t.Errorf("Removed = %v, want empty", delta.Removed)
+	}
+
+	// No upstream movement: no change, no delta.
+	changed, delta, err = s.Sync(context.Background())
+	if err != nil || changed || delta != nil {
+		t.Errorf("idle sync: changed=%v delta=%v err=%v", changed, delta, err)
+	}
+}
+```
+
+(Add `"slices"` and `"sort"` to the test imports if absent. If `commitToUpstream` can't overwrite an existing file, read its body — it writes via the worktree — and adjust only if it errors; the existing helper writes+`Add`+`Commit`, which handles modification fine.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/catalog/ -run TestSyncReportsDelta -v`
+Expected: FAIL to compile — `s.Sync` returns 2 values, test wants 3.
+
+- [ ] **Step 3: Implement.** `sync.go`:
+
+```go
+// SyncDelta names the repo-relative paths that changed between two synced
+// revisions. A nil *SyncDelta means "unknown" — the caller must do a full
+// reload. Renames contribute the old name to Removed and the new to Changed.
+type SyncDelta struct {
+	Changed []string // added or modified
+	Removed []string // deleted (or rename sources)
+}
+```
+
+New import: `"github.com/go-git/go-git/v5/plumbing/object"`.
+
+```go
+// diffPaths lists the paths that differ between two commits. Any failure
+// returns nil — "unknown", never fatal: the delta is an optimization and the
+// caller falls back to a full reload.
+func (s *Syncer) diffPaths(repo *git.Repository, from, to plumbing.Hash) *SyncDelta {
+	fromC, err := repo.CommitObject(from)
+	if err != nil {
+		return nil
+	}
+	toC, err := repo.CommitObject(to)
+	if err != nil {
+		return nil
+	}
+	fromT, err := fromC.Tree()
+	if err != nil {
+		return nil
+	}
+	toT, err := toC.Tree()
+	if err != nil {
+		return nil
+	}
+	changes, err := object.DiffTree(fromT, toT)
+	if err != nil {
+		return nil
+	}
+	d := &SyncDelta{}
+	for _, ch := range changes {
+		if ch.To.Name != "" {
+			d.Changed = append(d.Changed, ch.To.Name)
+		}
+		if ch.From.Name != "" && ch.From.Name != ch.To.Name {
+			d.Removed = append(d.Removed, ch.From.Name)
+		}
+	}
+	return d
+}
+```
+
+`Sync` — change the tail (after `head, err := repo.Head()` succeeds) and the two earlier `return false, ...` error sites to three values (`return false, nil, err` / `return false, nil, fmt.Errorf(...)` — every early return gains a `nil` delta):
+
+```go
+	rev := head.Hash()
+	changed := rev != s.lastRev
+	var delta *SyncDelta
+	if changed && s.lastRev != (plumbing.Hash{}) {
+		delta = s.diffPaths(repo, s.lastRev, rev)
+	}
+	s.lastRev = rev
+	return changed, delta, nil
+```
+
+`Run` — signature `onSync func(*SyncDelta) error`; inside `do`:
+
+```go
+		changed, delta, err := s.Sync(ctx)
+		...
+		if err := onSync(delta); err != nil {
+```
+
+(the rollback-on-reindex-failure logic is untouched — after a rollback the next `Sync` diffs from the rolled-back rev, so the retried delta covers both moves).
+
+`internal/app/catalog.go` — mechanical for now (Task 3 uses the delta):
+
+```go
+		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func(_ *catalog.SyncDelta) error {
+```
+
+Also update the existing `Run`-based test `TestRunReloadsOnlyOnChange` callback signature (`func(*SyncDelta) error`).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/catalog/ ./internal/app/ -count=1`
+Expected: all `ok`, including the new `TestSyncReportsDelta`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/catalog/sync.go internal/catalog/sync_test.go internal/app/catalog.go
+git commit -m "feat(catalog): git sync reports a changed/removed path delta
+
+Sync already knows exactly which revisions moved; DiffTree turns that
+into the path list an incremental re-index needs. nil delta = unknown
+(first sync or any diff error) and always means full reload — the
+delta is an optimization, never a correctness input."
+```
+
+---
+
+### Task 3: `Catalog.ReloadDelta` — incremental Index/Delete with full-rebuild fallback
+
+**Files:**
+- Modify: `internal/catalog/catalog.go` (`ReloadDelta`, extract `docFor(e Entry)`)
+- Modify: `internal/app/catalog.go` (sync closure calls `ReloadDelta`)
+- Test: `internal/catalog/delta_test.go` (new, SPDX line 1)
+
+**Interfaces:**
+- Consumes: `SyncDelta` (Task 2), path-keyed docs + `pathIdx` (Task 1), `embedWithCache` (existing).
+- Produces: `ReloadDelta(ctx context.Context, dir string, delta *SyncDelta) ([]string, error)` — same contract as `ReloadContext` (returns skipped paths); routes to `ReloadContext` when `delta == nil` or the catalog is cold; on ANY incremental mutation error, falls back to a full rebuild in the same call.
+
+- [ ] **Step 1: Write the failing tests** (`internal/catalog/delta_test.go`, `// SPDX-License-Identifier: Apache-2.0` line 1, package `catalog`):
+
+```go
+func writeEntry(t *testing.T, dir, name, title string) {
+	t.Helper()
+	entry := "---\ntype: Incident\ntitle: " + title + "\n---\nBody about " + title + ".\n"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(entry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// searchTitles returns the top-k result titles for q — the comparable view used
+// by the parity property below.
+func searchTitles(t *testing.T, c *Catalog, q string) []string {
+	t.Helper()
+	hits, err := c.SearchScored(q, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = h.Entry.Title
+	}
+	return out
+}
+
+// TestReloadDeltaMatchesFullRebuild pins the core property: an incremental
+// reload must be indistinguishable from a from-scratch load of the same dir.
+func TestReloadDeltaMatchesFullRebuild(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "a.md", "cilium agent crashloop")
+	writeEntry(t, dir, "b.md", "postgres disk pressure")
+	writeEntry(t, dir, "c.md", "dns resolution flaking")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutate: modify a, delete b, add d.
+	writeEntry(t, dir, "a.md", "cilium agent oomkilled")
+	if err := os.Remove(filepath.Join(dir, "b.md")); err != nil {
+		t.Fatal(err)
+	}
+	writeEntry(t, dir, "d.md", "ingress certificate expired")
+
+	skipped, err := c.ReloadDelta(context.Background(), dir,
+		&SyncDelta{Changed: []string{"a.md", "d.md"}, Removed: []string{"b.md"}})
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("delta reload: skipped=%v err=%v", skipped, err)
+	}
+
+	fresh, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != fresh.Len() {
+		t.Fatalf("Len: delta=%d fresh=%d", c.Len(), fresh.Len())
+	}
+	for _, q := range []string{"cilium oomkilled", "postgres disk", "certificate expired", "dns flaking"} {
+		if got, want := searchTitles(t, c, q), searchTitles(t, fresh, q); !slices.Equal(got, want) {
+			t.Errorf("query %q: delta=%v fresh=%v", q, got, want)
+		}
+	}
+}
+
+// TestReloadDeltaChangedEntryNowUnparseable: a changed file that fails to parse
+// is skipped by Load — its stale doc must not linger in the index.
+func TestReloadDeltaChangedEntryNowUnparseable(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "a.md", "cilium agent crashloop")
+	writeEntry(t, dir, "b.md", "postgres disk pressure")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("---\ntitle: [broken\n---\nx"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	skipped, err := c.ReloadDelta(context.Background(), dir, &SyncDelta{Changed: []string{"a.md"}})
+	if err != nil || len(skipped) != 1 {
+		t.Fatalf("skipped=%v err=%v, want exactly the broken entry skipped", skipped, err)
+	}
+	for _, title := range searchTitles(t, c, "cilium crashloop") {
+		if title == "cilium agent crashloop" {
+			t.Error("stale doc for now-unparseable entry still indexed")
+		}
+	}
+}
+
+// TestReloadDeltaNilFallsBackToFull: nil delta must behave exactly like
+// ReloadContext (the first-sync / diff-error path).
+func TestReloadDeltaNilFallsBackToFull(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "a.md", "cilium agent crashloop")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeEntry(t, dir, "b.md", "postgres disk pressure")
+	if _, err := c.ReloadDelta(context.Background(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != 2 {
+		t.Errorf("Len=%d, want 2 after nil-delta full reload", c.Len())
+	}
+}
+```
+
+(Imports: `context`, `os`, `path/filepath`, `slices`, `testing`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/catalog/ -run TestReloadDelta -v`
+Expected: FAIL to compile — `c.ReloadDelta undefined`.
+
+- [ ] **Step 3: Implement.** `catalog.go` — extract the doc shape (used by both `buildIndex` and `ReloadDelta`):
+
+```go
+func docFor(e Entry) map[string]any {
+	return map[string]any{
+		"title": e.Title,
+		"text":  entryText(e),
+	}
+}
+```
+
+(`buildIndex`'s loop body becomes `if err := idx.Index(e.Path, docFor(e)); ...`.)
+
+```go
+// ReloadDelta refreshes the catalog for a known set of changed/removed paths,
+// mutating the live index (bleve is safe for concurrent search+index) instead
+// of rebuilding it. Entries, vectors, and the embed cache still refresh from a
+// full Load walk — files are cheap; only the bleve analysis pass is not — so
+// slice/vector/pathIdx consistency is trivially preserved. Falls back to a
+// full ReloadContext when the delta is nil (unknown), the catalog is cold, or
+// ANY index mutation fails: an incremental error must never leave a wrong
+// index behind.
+func (c *Catalog) ReloadDelta(ctx context.Context, dir string, delta *SyncDelta) ([]string, error) {
+	if delta == nil || !c.ready.Load() {
+		return c.ReloadContext(ctx, dir)
+	}
+	entries, skipped, err := Load(dir)
+	if err != nil {
+		return nil, err
+	}
+	vectors, cache := c.embedWithCache(ctx, entries)
+	loaded := pathIndex(entries)
+
+	// Mutate the live index outside c.mu: concurrent searches resolve hits via
+	// pathIdx, so a just-indexed unknown path is skipped and a just-deleted one
+	// simply stops matching — momentary staleness, never a wrong entry.
+	c.mu.RLock()
+	idx := c.index
+	c.mu.RUnlock()
+	incremental := func() error {
+		for _, p := range delta.Removed {
+			if err := idx.Delete(p); err != nil {
+				return fmt.Errorf("delete %s: %w", p, err)
+			}
+		}
+		for _, p := range delta.Changed {
+			i, ok := loaded[p]
+			if !ok {
+				// Changed upstream but skipped by Load (now unparseable, or a
+				// reserved/non-.md name): drop any stale doc.
+				if err := idx.Delete(p); err != nil {
+					return fmt.Errorf("delete stale %s: %w", p, err)
+				}
+				continue
+			}
+			if err := idx.Index(p, docFor(entries[i])); err != nil {
+				return fmt.Errorf("index %s: %w", p, err)
+			}
+		}
+		return nil
+	}
+	if err := incremental(); err != nil {
+		if c.Log != nil {
+			c.Log.Warn("catalog incremental re-index failed; rebuilding fully", "err", err)
+		}
+		return c.ReloadContext(ctx, dir)
+	}
+	c.mu.Lock()
+	c.entries, c.vectors, c.pathIdx = entries, vectors, loaded
+	if cache != nil {
+		c.vecCache = cache
+	}
+	c.mu.Unlock()
+	return skipped, nil
+}
+```
+
+`internal/app/catalog.go` — the sync closure uses the delta:
+
+```go
+		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func(delta *catalog.SyncDelta) error {
+			skipped, err := cat.ReloadDelta(ctx, dir, delta)
+```
+
+(the rest of the closure body — warn on skipped, entries log line, degraded metric, `warnInvalid` — is unchanged).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/catalog/ ./internal/app/ -count=1 -race`
+Expected: all `ok`, including the three new tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/catalog/catalog.go internal/catalog/delta_test.go internal/app/catalog.go
+git commit -m "feat(catalog): incremental re-index from the git-sync delta
+
+A one-entry KB merge no longer re-analyzes the whole corpus: removed
+paths are Delete()d and changed paths re-Index()ed on the live bleve
+index, with a full rebuild whenever the delta is unknown or any
+mutation errors. Pinned by a delta-vs-fresh-rebuild parity test."
+```
+
+---
+
+### Task 4: Persisted vector cache (gob, atomic write, header-validated load)
+
+**Files:**
+- Create: `internal/catalog/veccache.go`
+- Modify: `internal/catalog/catalog.go` (`vecCachePath`/`vecCacheModel` fields, `EnableVectorCache`, save hook in `ReloadContext` + `ReloadDelta`)
+- Test: `internal/catalog/veccache_test.go` (new, SPDX line 1)
+
+**Interfaces:**
+- Produces: `(c *Catalog) EnableVectorCache(path, model string)` — call at wiring time, before the first reload; loads the file into `vecCache` (any problem = WARN + empty) and arms saving after every successful embed pass. Unexported `loadVecCache(path, model string, log *slog.Logger) map[string][]float32` and `saveVecCache(path, model string, cache map[string][]float32) error`.
+- File format: gob-encoded `vecCacheFile{Version, Model string, Dim int, Vectors map[string][]float32}`; `vecCacheVersion = 1`.
+
+- [ ] **Step 1: Write the failing tests** (`internal/catalog/veccache_test.go`, SPDX line 1, package `catalog`):
+
+```go
+func TestVecCacheRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	in := map[string][]float32{"k1": {1, 0}, "k2": {0.5, 0.5}}
+	if err := saveVecCache(path, "bge-m3", in); err != nil {
+		t.Fatal(err)
+	}
+	out := loadVecCache(path, "bge-m3", nil)
+	if len(out) != 2 || out["k1"][0] != 1 || out["k2"][1] != 0.5 {
+		t.Fatalf("round trip = %v", out)
+	}
+	// No temp residue from the atomic write.
+	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(path), ".veccache-*"))
+	if len(matches) != 0 {
+		t.Errorf("temp files left behind: %v", matches)
+	}
+}
+
+// A model swap must never serve stale vectors: the whole cache is discarded.
+func TestVecCacheModelMismatchDiscards(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	if err := saveVecCache(path, "bge-m3", map[string][]float32{"k": {1}}); err != nil {
+		t.Fatal(err)
+	}
+	if out := loadVecCache(path, "text-embedding-3-small", nil); out != nil {
+		t.Fatalf("model mismatch returned %v, want nil (cold start)", out)
+	}
+}
+
+func TestVecCacheCorruptFileColdStarts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	if err := os.WriteFile(path, []byte("not gob at all"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out := loadVecCache(path, "bge-m3", nil); out != nil {
+		t.Fatalf("corrupt file returned %v, want nil", out)
+	}
+	if out := loadVecCache(filepath.Join(t.TempDir(), "absent.gob"), "bge-m3", nil); out != nil {
+		t.Fatalf("absent file returned %v, want nil", out)
+	}
+}
+
+// Dimension coherence: a cache whose vectors disagree with the recorded Dim is
+// corrupt — discard, don't serve.
+func TestVecCacheDimMismatchDiscards(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gob.NewEncoder(f).Encode(vecCacheFile{
+		Version: vecCacheVersion, Model: "bge-m3", Dim: 3,
+		Vectors: map[string][]float32{"k": {1, 0}}, // len 2 ≠ Dim 3
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	if out := loadVecCache(path, "bge-m3", nil); out != nil {
+		t.Fatalf("dim mismatch returned %v, want nil", out)
+	}
+}
+
+// End-to-end: a second catalog with the same cache file embeds NOTHING on its
+// first reload — the restart/HA-failover win this feature exists for.
+func TestVecCachePersistsAcrossCatalogs(t *testing.T) {
+	dir := t.TempDir()
+	writeEntry(t, dir, "a.md", "cilium agent crashloop")
+	writeEntry(t, dir, "b.md", "postgres disk pressure")
+	cachePath := filepath.Join(t.TempDir(), "vectors.gob")
+
+	first := NewEmpty()
+	emb1 := &countingEmbedder{}
+	first.SetEmbedder(emb1)
+	first.EnableVectorCache(cachePath, "fake-model")
+	if _, err := first.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if emb1.calls == 0 || !first.HasVectors() {
+		t.Fatalf("first catalog: calls=%d hasVectors=%v", emb1.calls, first.HasVectors())
+	}
+
+	second := NewEmpty()
+	emb2 := &countingEmbedder{}
+	second.SetEmbedder(emb2)
+	second.EnableVectorCache(cachePath, "fake-model")
+	if _, err := second.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if emb2.calls != 0 {
+		t.Errorf("second catalog embedded %d batches, want 0 (cache warm from disk)", emb2.calls)
+	}
+	if !second.HasVectors() {
+		t.Error("second catalog has no vectors despite warm cache")
+	}
+}
+```
+
+(Reuse the existing `countingEmbedder` from `hybrid_test.go` — same package. Check its field name for the call counter (`calls` at `hybrid_test.go:98`'s receiver) and match it; if its vectors are per-text deterministic, nothing else is needed. Imports: `context`, `encoding/gob`, `os`, `path/filepath`, `testing`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/catalog/ -run TestVecCache -v`
+Expected: FAIL to compile — `saveVecCache`/`loadVecCache`/`EnableVectorCache`/`vecCacheFile` undefined.
+
+- [ ] **Step 3: Implement.** New `internal/catalog/veccache.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"encoding/gob"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// vecCacheFile is the on-disk shape of the persisted embedding cache. gob over
+// JSON: map[string][]float32 in one stdlib call, ~1/10th the bytes, and no
+// human ever reads this file. The header makes staleness detectable — a cache
+// written by a different embedding model (or dimensionality) must never be
+// served, so any mismatch discards the whole file and the corpus re-embeds.
+type vecCacheFile struct {
+	Version int
+	Model   string
+	Dim     int
+	Vectors map[string][]float32
+}
+
+const vecCacheVersion = 1
+
+// loadVecCache reads a persisted cache, returning nil (cold start) on ANY
+// problem: absent, unreadable, corrupt, version/model/dimension mismatch.
+// Fail-safe by contract — the cache is an optimization, never a correctness
+// input. log is nil-safe.
+func loadVecCache(path, model string, log *slog.Logger) map[string][]float32 {
+	f, err := os.Open(path) //nolint:gosec // G304: operator-configured cache path
+	if err != nil {
+		return nil // absent is the common cold-start case; not worth a warn
+	}
+	defer func() { _ = f.Close() }()
+	var vf vecCacheFile
+	if err := gob.NewDecoder(f).Decode(&vf); err != nil {
+		if log != nil {
+			log.Warn("vector cache unreadable; re-embedding from scratch", "path", path, "err", err)
+		}
+		return nil
+	}
+	if vf.Version != vecCacheVersion || vf.Model != model || vf.Dim <= 0 {
+		if log != nil {
+			log.Warn("vector cache stale (version/model changed); re-embedding from scratch",
+				"path", path, "cache_model", vf.Model, "model", model)
+		}
+		return nil
+	}
+	for _, v := range vf.Vectors {
+		if len(v) != vf.Dim {
+			if log != nil {
+				log.Warn("vector cache dimension-incoherent; re-embedding from scratch", "path", path)
+			}
+			return nil
+		}
+	}
+	return vf.Vectors
+}
+
+// saveVecCache writes the cache atomically (temp + rename, the ledger's
+// pattern) so an interrupted write can never leave a torn file for the next
+// startup to trip over. Empty caches are not persisted.
+func saveVecCache(path, model string, cache map[string][]float32) error {
+	if len(cache) == 0 {
+		return nil
+	}
+	dim := 0
+	for _, v := range cache {
+		dim = len(v)
+		break
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".veccache-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+	if err := gob.NewEncoder(tmp).Encode(vecCacheFile{
+		Version: vecCacheVersion, Model: model, Dim: dim, Vectors: cache,
+	}); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename cache into place: %w", err)
+	}
+	return nil
+}
+```
+
+`catalog.go` — fields on `Catalog` (below `vecCache`):
+
+```go
+	// vecCachePath/vecCacheModel arm disk persistence of vecCache (EnableVectorCache).
+	// Empty path ⇒ in-memory only. Set once at wiring time, before the first Reload.
+	vecCachePath  string
+	vecCacheModel string
+```
+
+```go
+// EnableVectorCache persists the embedding cache at path, keyed to the given
+// embedding-model identifier: the file is loaded now (before the first reload —
+// a warm cache means a restart embeds nothing) and rewritten after each
+// successful embed pass. Any load problem is a cold start, never an error.
+func (c *Catalog) EnableVectorCache(path, model string) {
+	c.vecCachePath, c.vecCacheModel = path, model
+	if warm := loadVecCache(path, model, c.Log); warm != nil {
+		c.mu.Lock()
+		c.vecCache = warm
+		c.mu.Unlock()
+		if c.Log != nil {
+			c.Log.Info("vector cache loaded from disk", "path", path, "vectors", len(warm))
+		}
+	}
+}
+
+// persistVecCache is the post-reload save hook: only a successful, complete
+// embed pass (vectors non-nil ⇒ all-or-nothing invariant held) writes the file.
+func (c *Catalog) persistVecCache(vectors [][]float32, cache map[string][]float32) {
+	if c.vecCachePath == "" || vectors == nil || cache == nil {
+		return
+	}
+	if err := saveVecCache(c.vecCachePath, c.vecCacheModel, cache); err != nil && c.Log != nil {
+		c.Log.Warn("vector cache save failed; next restart re-embeds", "path", c.vecCachePath, "err", err)
+	}
+}
+```
+
+Hook it into **both** reload paths, after their `c.mu.Unlock()` (the local `vectors`/`cache` are this reload's — no lock needed):
+
+- `ReloadContext`: add `c.persistVecCache(vectors, cache)` right before `c.ready.Store(true)`.
+- `ReloadDelta`: add `c.persistVecCache(vectors, cache)` after its unlock, before `return skipped, nil`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/catalog/ -count=1 -race`
+Expected: all `ok`, including the five new `TestVecCache*` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/catalog/veccache.go internal/catalog/veccache_test.go internal/catalog/catalog.go
+git commit -m "feat(catalog): persist the embedding cache across restarts
+
+A restart or HA failover re-embedded the entire corpus; now the
+content-hash cache is gob-persisted (atomic temp+rename) after each
+successful embed pass and loaded before the first reload. The header
+pins version+model+dimension: any mismatch, corruption, or absence is
+a WARN + cold start — the cache is never a correctness input."
+```
+
+---
+
+### Task 5: Config knob + wiring + docs
+
+**Files:**
+- Modify: `internal/config/config.go` (`VectorCache` struct on `InstantRecall`), `internal/config/load.go` (no default needed — zero value is correct)
+- Modify: `internal/app/catalog.go` (wire `EnableVectorCache` in both catalog paths)
+- Modify: `docs/configuration.md`
+- Test: `internal/config/config_test.go` or a focused sibling file; `internal/app` compile coverage via existing tests
+
+**Interfaces:**
+- Produces: `cfg.Catalog.InstantRecall.VectorCache` with `IsEnabled()` (nil ⇒ on, mirroring `GitOpsMirror`); effective only when hybrid+embeddings are configured.
+
+- [ ] **Step 1: Write the failing test** (alongside the existing instant-recall config tests):
+
+```go
+func TestVectorCacheConfigDefaults(t *testing.T) {
+	var vc VectorCache
+	if !vc.IsEnabled() {
+		t.Error("zero-value vector_cache must be enabled (persistence only ever helps)")
+	}
+	off := false
+	vc = VectorCache{Enabled: &off}
+	if vc.IsEnabled() {
+		t.Error("explicit enabled:false must disable")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/config/ -run TestVectorCacheConfig -v`
+Expected: FAIL to compile — `VectorCache` undefined.
+
+- [ ] **Step 3: Implement.** `config.go`, appended to `InstantRecall` (after the Hybrid fields):
+
+```go
+	// VectorCache persists hybrid recall's per-entry embedding cache to disk so
+	// a restart or HA failover re-embeds nothing (the in-memory cache already
+	// spares unchanged entries WITHIN a process lifetime). Only meaningful when
+	// hybrid is on. Default on: persistence only ever helps, and every failure
+	// mode (corrupt/stale/missing file) degrades to a cold re-embed.
+	VectorCache VectorCache `yaml:"vector_cache"`
+```
+
+and next to `GitOpsMirror` (same three-state idiom):
+
+```go
+// VectorCache configures on-disk persistence of the hybrid-recall embedding
+// cache. Enabled by default (nil/true).
+type VectorCache struct {
+	Enabled *bool  `yaml:"enabled"`
+	Dir     string `yaml:"dir"` // cache dir; "" ⇒ <tmp>/runlore-veccache (ephemeral; point at a PV to persist across restarts)
+}
+
+// IsEnabled reports whether cache persistence is on (nil ⇒ default on).
+func (v VectorCache) IsEnabled() bool { return v.Enabled == nil || *v.Enabled }
+```
+
+`internal/app/catalog.go` — immediately after each `cat.SetEmbedder(embedder)` call (both the git-sync and static-dir paths), arm persistence:
+
+```go
+		if embedder != nil {
+			cat.SetEmbedder(embedder)
+			if vc := cfg.Catalog.InstantRecall.VectorCache; vc.IsEnabled() {
+				vdir := vc.Dir
+				if vdir == "" {
+					vdir = filepath.Join(os.TempDir(), "runlore-veccache")
+				}
+				cat.EnableVectorCache(filepath.Join(vdir, "vectors.gob"), cfg.Model.Embeddings.Model)
+			}
+		}
+```
+
+(add `"path/filepath"` to the imports; the static-dir branch already guards `embedder != nil` — arm inside it the same way).
+
+`docs/configuration.md` — in the instant-recall/hybrid section, one row/paragraph:
+
+```markdown
+| `catalog.instant_recall.vector_cache.enabled` | `true` | Persist the hybrid embedding cache to disk so restarts/failovers re-embed nothing. Every failure mode (missing/corrupt/model-changed file) is a cold re-embed, never an error. |
+| `catalog.instant_recall.vector_cache.dir` | `<tmp>/runlore-veccache` | Cache directory. Ephemeral by default — point it at a PersistentVolume to keep it across pod restarts (same pattern as `gitops.mirror.dir`). |
+```
+
+- [ ] **Step 4: Run the gate**
+
+Run: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...`
+Expected: build/vet/tests clean, `gofmt -l` empty, `0 issues.`
+Run: `go test -race ./internal/catalog/... ./internal/app/... ./internal/config/... -count=1`
+Expected: all `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go internal/app/catalog.go docs/configuration.md
+git commit -m "feat(config): vector_cache persistence knob, wired and documented
+
+Default on whenever hybrid embeddings are configured; dir defaults to
+an ephemeral tmp path with a documented PV upgrade, mirroring
+gitops.mirror. Explicit enabled:false keeps the cache in-memory only."
+```
+
+---
+
+## Non-goals (say why, so nobody "helpfully" adds them)
+
+- **ANN / vector index**: brute-force cosine over the in-RAM corpus stays. Revisit only when real catalogs exceed ~1–2k entries (the audit's criterion) — below that, an ANN structure costs more in build time and code than the linear scan it replaces.
+- **Benchmarks**: regression benchmarks for reload/search belong to the Later-wave benchmark item (L5), not here.
+- **Cross-replica cache sharing / file locking**: each pod owns its cache file; the failure mode of not sharing is one redundant embed pass per replica, which the chunked client absorbs.
+- **Persisting the bleve index itself**: bleve's on-disk formats bring compaction/upgrade concerns; the index rebuilds in-memory from the (already-local) git mirror in well under a second at current corpus sizes. The expensive network step was the embeddings — that is what persistence targets.
+
+## Execution notes
+
+- Tasks are strictly ordered: 1 → 2 → 3 → 4 → 5 (each consumes the previous task's symbols).
+- If N6 (okf-staleness) has merged by execution time, `Entry` carries `Status`/`LastValidated` and `entryText` may include more fields — nothing in this plan changes, but expect `TestReloadEmbedsOnlyChangedEntries`-style tests to exercise the new shape; derive hashes by calling `entryText`, never by re-implementing it.
+- One worktree, one PR: `feat/persisted-vectors-incremental-index`, PR title `feat(catalog): persisted embedding cache and incremental re-index`.

--- a/dev/superpowers/plans/2026-07-20-templated-notifier-registry.md
+++ b/dev/superpowers/plans/2026-07-20-templated-notifier-registry.md
@@ -1,0 +1,726 @@
+# Templated Notifier + Registry Pinning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A config-only generic templated notifier — POST findings to any chat/webhook endpoint (Teams, Discord, ntfy, incident.io…) with a user-supplied Go `text/template` body — plus tests that pin the already-unified notifier registry so it can never regress.
+
+**Architecture:** Extract webhook's private JSON payload into an exported `notify.Payload` (single definition of "what a delivery carries"), then add a self-registering `internal/notify/templated` package modeled on `internal/notify/webhook`: config lives under the existing inline `notify.Extra` catch-all (`config.go:551` — ZERO config-struct changes), template parse errors surface through `BuildEnabled`'s error return and therefore fail serve startup, template execution errors fail only that instance's delivery (the existing `Multi.Deliver` at `slack.go:742-751` already logs-and-joins per-notifier errors). Redaction needs no new seam: every notifier receives an already-redacted Investigation (`redactInvestigation`, `internal/investigate/loop.go:965`, reflective walk at `:1007`) — state this in docs, do not re-redact.
+
+**Fact check that reshaped scope (vs the audit finding):** Slack and Matrix construction is ALREADY registry-based — `slack.go:23-44` and `matrix.go:24-37` self-register via `init()` + `Register`, and `app.BuildNotifier` (`internal/app/notify.go:17`) is just `BuildEnabled`. The remaining asymmetry is the *config surface only*: built-ins get typed blocks (`notify.slack`, `notify.matrix`), drop-ins use the inline `Extra` map — that is a deliberate design (typed validation for built-ins, zero-config-edit extensibility for drop-ins), not debt. So Task 4 PINS the unified behavior with round-trip tests and documents the two surfaces; it does not migrate anything.
+
+**Tech Stack:** Go (toolchain go1.26.5); stdlib `text/template` only (no new dependencies); existing `internal/{notify,providers,httpx,config,app}`.
+
+## Global Constraints
+
+- Quality gate before every commit: `go build ./... && go vet ./... && go test ./... && gofmt -l .` (empty) and `golangci-lint run ./...` → `0 issues.`; plus `go test -race ./internal/notify/... ./internal/config/... ./internal/app/...` before the final push.
+- SPDX header `// SPDX-License-Identifier: Apache-2.0` as line 1 of every new `.go` file.
+- Conventional Commits; **no co-author trailer**, no AI attribution anywhere.
+- **Zero user-visible config breakage**: `notify.slack`, `notify.matrix`, `notify.webhook` keys keep working verbatim; the webhook notifier's JSON body must be byte-identical after the Task-1 refactor (existing `webhook_test.go` passes unchanged).
+- No new third-party dependencies. Egress via `httpx.SecureClient` only (SSRF guard parity with webhook, `webhook.go:40`).
+- Fail-safe bias: unset env var ⇒ instance disabled (webhook parity, `webhook.go:171-174`); template PARSE error ⇒ startup failure; template EXEC error ⇒ that delivery fails loudly but siblings still deliver (`Multi` isolation).
+
+---
+
+### Task 1: Export the delivery payload as `notify.Payload`
+
+**Files:**
+- Create: `internal/notify/payload.go`
+- Create: `internal/notify/payload_test.go`
+- Modify: `internal/notify/webhook/webhook.go` (delete local payload types, use `notify.NewPayload`)
+
+**Interfaces:**
+- Consumes: `providers.Investigation`, `notify.Format` (same package).
+- Produces: `notify.Payload` / `notify.PriorPayload` / `notify.MatchedPayload` structs (json tags copied VERBATIM from `webhook.go:46-86`) and `func NewPayload(inv providers.Investigation) Payload` carrying the exact mapping currently inlined in `webhook.Deliver` (`webhook.go:89-125`): RFC3339 `StartedAt` ("" when zero), `Prior` nil-guard, `MatchedKnowledge` surfaced only when `Prior == nil`, `Text: Format(inv)`. Tasks 2-3 template over this struct.
+
+- [ ] **Step 1: Write the failing test** — `internal/notify/payload_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestNewPayloadMapping(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "CrashLoopBackOff payments",
+		Confidence: 0.72,
+		Resource:   providers.ResourceRef{Namespace: "payments", Name: "api"},
+		Verdict:    providers.VerdictActionSuggested,
+		StartedAt:  time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC),
+		Prior:      &providers.PriorKnowledge{Cause: "bad rollout", Resolution: "rollback", EntryPath: "e.md", Recalls: 3, Resolved: 2},
+		MatchedKnowledge: &providers.MatchedEntry{Path: "m.md", Title: "seen", URL: "u", Score: 0.9},
+	}
+	p := NewPayload(inv)
+	if p.Title != inv.Title || p.Namespace != "payments" || p.Resource != "api" {
+		t.Errorf("identity fields: %+v", p)
+	}
+	if p.StartedAt != "2026-07-20T10:00:00Z" {
+		t.Errorf("StartedAt = %q, want RFC3339", p.StartedAt)
+	}
+	if p.Prior == nil || p.Prior.Cause != "bad rollout" || p.Prior.Recalls != 3 {
+		t.Errorf("Prior = %+v", p.Prior)
+	}
+	// The shared Format-text guard: matched knowledge is suppressed when Prior is set,
+	// so the structured field never disagrees with the rendered text (webhook.go:98-104).
+	if p.MatchedKnowledge != nil {
+		t.Errorf("MatchedKnowledge must be nil when Prior != nil, got %+v", p.MatchedKnowledge)
+	}
+	if p.Text == "" {
+		t.Error("Text must carry Format(inv)")
+	}
+
+	inv.Prior = nil
+	if q := NewPayload(inv); q.MatchedKnowledge == nil || q.MatchedKnowledge.Path != "m.md" {
+		t.Errorf("MatchedKnowledge must surface when Prior == nil, got %+v", q.MatchedKnowledge)
+	}
+	if q := NewPayload(providers.Investigation{}); q.StartedAt != "" {
+		t.Errorf("zero StartedAt must render empty, got %q", q.StartedAt)
+	}
+}
+```
+
+(Verify the exact field names of `providers.PriorKnowledge`, `providers.MatchedEntry`, `providers.ResourceRef`, and the verdict constant against `internal/providers/providers.go` before running — the mapping in `webhook.go:89-125` is authoritative; adjust the literal, not the contract.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/notify/ -run TestNewPayloadMapping -v`
+Expected: FAIL — `undefined: NewPayload`
+
+- [ ] **Step 3: Implement** — `internal/notify/payload.go`: move the three structs from `webhook.go:46-86` verbatim (exported: `Payload`, `PriorPayload`, `MatchedPayload`; keep every json tag identical) and lift the mapping from `webhook.Deliver`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Payload is the exported delivery payload: the single definition of what an
+// outbound notification carries. The webhook notifier marshals it as-is; the
+// templated notifier exposes it as the template dot. Field set and json tags
+// are the webhook notifier's original wire format — do not change tags without
+// a compatibility note, external consumers parse them.
+type Payload struct {
+	Title            string          `json:"title"`
+	Confidence       float64         `json:"confidence"`
+	Namespace        string          `json:"namespace,omitempty"`
+	Resource         string          `json:"resource,omitempty"`
+	CuratedURL       string          `json:"curated_url,omitempty"`
+	Text             string          `json:"text"`
+	Verdict          string          `json:"verdict,omitempty"`
+	Severity         string          `json:"severity,omitempty"`
+	Cluster          string          `json:"cluster,omitempty"`
+	Environment      string          `json:"environment,omitempty"`
+	Tenant           string          `json:"tenant,omitempty"`
+	AlertName        string          `json:"alert_name,omitempty"`
+	StartedAt        string          `json:"started_at,omitempty"` // RFC3339; "" when unknown
+	Occurrences      int             `json:"occurrences,omitempty"`
+	PrevCuratedURL   string          `json:"prev_curated_url,omitempty"`
+	RuledOut         []string        `json:"ruled_out,omitempty"`
+	DataGaps         []string        `json:"data_gaps,omitempty"`
+	Prior            *PriorPayload   `json:"prior,omitempty"`
+	MatchedKnowledge *MatchedPayload `json:"matched_knowledge,omitempty"`
+}
+
+// MatchedPayload mirrors providers.MatchedEntry (see webhook package docs).
+type MatchedPayload struct {
+	Path  string  `json:"path,omitempty"`
+	Title string  `json:"title,omitempty"`
+	URL   string  `json:"url,omitempty"`
+	Score float64 `json:"score,omitempty"`
+}
+
+// PriorPayload mirrors providers.PriorKnowledge (see webhook package docs).
+type PriorPayload struct {
+	Cause      string `json:"cause,omitempty"`
+	Resolution string `json:"resolution,omitempty"`
+	EntryPath  string `json:"entry_path,omitempty"`
+	Recalls    int    `json:"recalls,omitempty"`
+	Resolved   int    `json:"resolved,omitempty"`
+}
+
+// NewPayload maps an (already-redacted) Investigation to the delivery payload.
+// Matched knowledge is surfaced only when Prior is nil so the structured field
+// never disagrees with the rendered Text (Prior already covers "seen before").
+func NewPayload(inv providers.Investigation) Payload {
+	startedAt := ""
+	if !inv.StartedAt.IsZero() {
+		startedAt = inv.StartedAt.UTC().Format(time.RFC3339)
+	}
+	var prior *PriorPayload
+	if p := inv.Prior; p != nil {
+		prior = &PriorPayload{Cause: p.Cause, Resolution: p.Resolution, EntryPath: p.EntryPath, Recalls: p.Recalls, Resolved: p.Resolved}
+	}
+	var matched *MatchedPayload
+	if mk := inv.MatchedKnowledge; mk != nil && inv.Prior == nil {
+		matched = &MatchedPayload{Path: mk.Path, Title: mk.Title, URL: mk.URL, Score: mk.Score}
+	}
+	return Payload{
+		Title: inv.Title, Confidence: inv.Confidence,
+		Namespace: inv.Resource.Namespace, Resource: inv.Resource.Name,
+		CuratedURL: inv.CuratedURL, Text: Format(inv), Verdict: string(inv.Verdict),
+		Severity: inv.Severity, Cluster: inv.Cluster, Environment: inv.Environment,
+		Tenant: inv.Tenant, AlertName: inv.AlertName, StartedAt: startedAt,
+		Occurrences: inv.Occurrences, PrevCuratedURL: inv.PrevCuratedURL,
+		RuledOut: inv.RuledOut, DataGaps: inv.DataGaps,
+		Prior: prior, MatchedKnowledge: matched,
+	}
+}
+```
+
+Then in `internal/notify/webhook/webhook.go`: delete the local `payload`/`priorPayload`/`matchedPayload` types and the mapping block; `Deliver` becomes:
+
+```go
+// Deliver marshals the investigation to JSON and POSTs it to the configured URL.
+func (n *Notifier) Deliver(ctx context.Context, inv providers.Investigation) error {
+	body, err := json.Marshal(notify.NewPayload(inv))
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return &deliverError{status: resp.StatusCode}
+	}
+	return nil
+}
+```
+
+Drop now-unused imports (`time` stays only if still used).
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/notify/... -v -run 'TestNewPayloadMapping|TestWebhook'`
+Expected: PASS, including every pre-existing webhook test UNCHANGED (byte-identical wire format is the point).
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+git add internal/notify/payload.go internal/notify/payload_test.go internal/notify/webhook/webhook.go
+git commit -m "refactor(notify): export the delivery payload as notify.Payload"
+```
+
+---
+
+### Task 2: Templated notifier — config, parse-at-startup, registry
+
+**Files:**
+- Create: `internal/notify/templated/templated.go`
+- Create: `internal/notify/templated/templated_test.go`
+- Modify: `internal/app/serve.go:28` area (add blank import below the webhook one)
+
+**Interfaces:**
+- Consumes: `notify.Register`, `notify.Deps`, `notify.Payload`, `d.Cfg.Notify.Extra["templated"]` (`config.go:551` inline map — no config-struct change), `httpx.SecureClient`.
+- Produces: package `templated`; `Notifier` (unexported instances inside); config schema:
+
+```yaml
+notify:
+  templated:
+    - name: teams                    # required, unique per instance; appears in logs/errors
+      url_env: RUNLORE_TEAMS_URL     # required; env var holding the endpoint URL (unset ⇒ instance disabled)
+      token_env: RUNLORE_TEAMS_TOKEN # optional; sent as "Authorization: Bearer <value>"
+      content_type: application/json # optional; default application/json
+      template: |                    # required; Go text/template over notify.Payload
+        {"text": {{ toJSON (printf "[%s] %s — %.0f%%" .Verdict .Title (mulPct .Confidence)) }}}
+```
+
+Template funcs: exactly two — `toJSON` (marshal any value to a JSON fragment; the escaping-correct way to splice text into JSON bodies) and `mulPct` (×100 for percent display). Parse errors and schema errors (missing/duplicate name, missing url_env/template) return an error from `Build`, which `BuildEnabled` wraps (`registry.go:47-48`) and `app.BuildNotifier` propagates — serve startup fails, satisfying "template parse errors fail config validation at startup".
+
+- [ ] **Step 1: Write the failing tests** — `internal/notify/templated/templated_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package templated
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func decodeExtra(t *testing.T, y string) yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(y), &n); err != nil {
+		t.Fatal(err)
+	}
+	return *n.Content[0] // unwrap the document node
+}
+
+func TestBuildParsesInstances(t *testing.T) {
+	t.Setenv("T_URL", "https://example.com/hook")
+	node := decodeExtra(t, `
+- name: teams
+  url_env: T_URL
+  template: '{"text": {{ toJSON .Title }}}'
+`)
+	n, err := build(node)
+	if err != nil || n == nil || len(n.instances) != 1 {
+		t.Fatalf("n=%+v err=%v", n, err)
+	}
+	if got := n.instances[0].contentType; got != "application/json" {
+		t.Errorf("default content_type = %q", got)
+	}
+}
+
+func TestBuildFailsClosedOnBadConfig(t *testing.T) {
+	t.Setenv("T_URL", "https://example.com/hook")
+	for name, y := range map[string]string{
+		"parse error":    "- {name: a, url_env: T_URL, template: '{{ .Title }'}",
+		"missing name":   "- {url_env: T_URL, template: ok}",
+		"missing url":    "- {name: a, template: ok}",
+		"missing tmpl":   "- {name: a, url_env: T_URL}",
+		"duplicate name": "- {name: a, url_env: T_URL, template: ok}\n- {name: a, url_env: T_URL, template: ok}",
+	} {
+		if _, err := build(decodeExtra(t, y)); err == nil {
+			t.Errorf("%s: want error, got nil", name)
+		}
+	}
+}
+
+func TestBuildDisablesInstanceOnUnsetEnv(t *testing.T) {
+	node := decodeExtra(t, "- {name: a, url_env: T_UNSET_NEVER, template: ok}")
+	n, err := build(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != nil {
+		t.Errorf("all instances env-disabled ⇒ nil notifier, got %+v", n)
+	}
+	_ = strings.TrimSpace // keep imports honest if unused later
+}
+```
+
+(Drop the trailing `strings` line if `strings` ends up genuinely used/unused — the gate's lint decides.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/notify/templated/ -v`
+Expected: FAIL — `undefined: build`
+
+- [ ] **Step 3: Implement** — `internal/notify/templated/templated.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Package templated is a config-only generic notifier: it renders a
+// user-supplied Go text/template over notify.Payload and POSTs the result to
+// any endpoint (Teams, Discord, ntfy, incident.io, …). One YAML block per
+// target — no Go, no rebuild. The Investigation is already secret-redacted
+// before any notifier runs (investigate.redactInvestigation), so templates
+// only ever see redacted data.
+package templated
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/template"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/notify"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// maxBody caps a rendered template. Oversize is an error, not a truncation —
+// a truncated JSON/XML body is garbage to the receiver; failing loudly beats
+// posting it.
+const maxBody = 256 << 10
+
+var funcs = template.FuncMap{
+	// toJSON is the escaping-correct way to splice a value into a JSON body.
+	"toJSON": func(v any) (string, error) {
+		b, err := json.Marshal(v)
+		return string(b), err
+	},
+	"mulPct": func(f float64) float64 { return f * 100 },
+}
+
+type instanceCfg struct {
+	Name        string `yaml:"name"`
+	URLEnv      string `yaml:"url_env"`
+	TokenEnv    string `yaml:"token_env"`
+	ContentType string `yaml:"content_type"`
+	Template    string `yaml:"template"`
+}
+
+type instance struct {
+	name        string
+	url         string
+	token       string
+	contentType string
+	tmpl        *template.Template
+}
+
+// Notifier fans one delivery out to every configured template instance.
+type Notifier struct {
+	instances []instance
+	client    *http.Client
+}
+
+var _ providers.Notifier = (*Notifier)(nil)
+
+// build decodes and validates the notify.templated block. Schema/template
+// errors are returned (⇒ BuildEnabled fails ⇒ serve refuses to start); an
+// instance whose url_env is unset is silently disabled (webhook parity).
+func build(node yaml.Node) (*Notifier, error) {
+	var cfgs []instanceCfg
+	if err := node.Decode(&cfgs); err != nil {
+		return nil, fmt.Errorf("templated: %w", err)
+	}
+	seen := map[string]bool{}
+	var ins []instance
+	for i, c := range cfgs {
+		if c.Name == "" || c.URLEnv == "" || c.Template == "" {
+			return nil, fmt.Errorf("templated[%d]: name, url_env and template are required", i)
+		}
+		if seen[c.Name] {
+			return nil, fmt.Errorf("templated: duplicate instance name %q", c.Name)
+		}
+		seen[c.Name] = true
+		tmpl, err := template.New(c.Name).Funcs(funcs).Parse(c.Template)
+		if err != nil {
+			return nil, fmt.Errorf("templated %q: parse template: %w", c.Name, err)
+		}
+		url := os.Getenv(c.URLEnv)
+		if url == "" {
+			continue // env unset ⇒ this instance is disabled
+		}
+		ct := c.ContentType
+		if ct == "" {
+			ct = "application/json"
+		}
+		token := ""
+		if c.TokenEnv != "" {
+			token = os.Getenv(c.TokenEnv)
+		}
+		ins = append(ins, instance{name: c.Name, url: url, token: token, contentType: ct, tmpl: tmpl})
+	}
+	if len(ins) == 0 {
+		return nil, nil // nothing enabled
+	}
+	return &Notifier{instances: ins, client: httpx.SecureClient(10 * time.Second)}, nil
+}
+
+func init() {
+	notify.Register(notify.Descriptor{
+		Name: "templated",
+		Build: func(d notify.Deps) (providers.Notifier, error) {
+			node, ok := d.Cfg.Notify.Extra["templated"]
+			if !ok {
+				return nil, nil
+			}
+			n, err := build(node)
+			if err != nil || n == nil {
+				return nil, err // typed-nil guard: never return (*Notifier)(nil) as a non-nil interface
+			}
+			return n, nil
+		},
+	})
+}
+```
+
+NOTE the typed-nil guard in `init`: `build` returns `*Notifier`; returning it directly when nil would hand `BuildEnabled` a non-nil interface wrapping a nil pointer.
+
+Check the exact `Notify.Extra` value type in `config.go:551` — if it is `map[string]yaml.Node` (not pointers), the `Build` closure body above is correct as written; mirror how `webhook.go:160-166` decodes.
+
+Add the blank import in `internal/app/serve.go` directly under line 28:
+
+```go
+	_ "github.com/Smana/runlore/internal/notify/templated" // self-registers the templated notifier
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/notify/templated/ -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+git add internal/notify/templated/ internal/app/serve.go
+git commit -m "feat(notify): templated notifier — parse-at-startup config and registry entry"
+```
+
+---
+
+### Task 3: Templated delivery — render, cap, POST
+
+**Files:**
+- Modify: `internal/notify/templated/templated.go` (add `Deliver`)
+- Modify: `internal/notify/templated/templated_test.go`
+
+**Interfaces:**
+- Consumes: `notify.NewPayload` (Task 1), `instance`/`Notifier` (Task 2).
+- Produces: `(*Notifier).Deliver(ctx, inv) error` — renders each instance's template over `notify.NewPayload(inv)`, caps at `maxBody`, POSTs with the instance's content-type and optional bearer; per-instance errors are joined (one bad instance never blocks the others — mirroring `Multi.Deliver`'s isolation one level down).
+
+- [ ] **Step 1: Write the failing tests** (append to `templated_test.go`; add imports `context`, `net/http`, `net/http/httptest`, `github.com/Smana/runlore/internal/providers`):
+
+```go
+func testNotifier(t *testing.T, tmplBody, url string) *Notifier {
+	t.Helper()
+	t.Setenv("T_URL", url)
+	n, err := build(decodeExtra(t, "- name: teams\n  url_env: T_URL\n  token_env: T_TOK\n  template: '"+tmplBody+"'"))
+	if err != nil || n == nil {
+		t.Fatalf("build: n=%v err=%v", n, err)
+	}
+	return n
+}
+
+func TestDeliverRendersAndPosts(t *testing.T) {
+	t.Setenv("T_TOK", "sekret")
+	var gotBody, gotCT, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody, gotCT, gotAuth = string(b), r.Header.Get("Content-Type"), r.Header.Get("Authorization")
+	}))
+	defer srv.Close()
+	n := testNotifier(t, `{"text": {{ toJSON .Title }}}`, srv.URL)
+	inv := providers.Investigation{Title: `quote " and \ slash`}
+	if err := n.Deliver(context.Background(), inv); err != nil {
+		t.Fatal(err)
+	}
+	if gotBody != `{"text": "quote \" and \\ slash"}` {
+		t.Errorf("body = %s", gotBody) // toJSON must escape — raw splice would be JSON injection
+	}
+	if gotCT != "application/json" || gotAuth != "Bearer sekret" {
+		t.Errorf("ct=%q auth=%q", gotCT, gotAuth)
+	}
+}
+
+func TestDeliverExecErrorFailsLoudWithoutPost(t *testing.T) {
+	posted := false
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { posted = true }))
+	defer srv.Close()
+	n := testNotifier(t, `{{ .NoSuchField }}`, srv.URL) // parses fine, fails at exec
+	if err := n.Deliver(context.Background(), providers.Investigation{Title: "x"}); err == nil {
+		t.Error("want exec error")
+	}
+	if posted {
+		t.Error("exec error must not POST")
+	}
+}
+
+func TestDeliverNon2xxAndSizeCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, *http.Request) { w.WriteHeader(500) }))
+	defer srv.Close()
+	if err := testNotifier(t, `ok`, srv.URL).Deliver(context.Background(), providers.Investigation{}); err == nil {
+		t.Error("want non-2xx error")
+	}
+	big := testNotifier(t, `{{ .Title }}`, srv.URL)
+	inv := providers.Investigation{Title: strings.Repeat("A", maxBody+1)}
+	if err := big.Deliver(context.Background(), inv); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("want size-cap error, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/notify/templated/ -run TestDeliver -v`
+Expected: FAIL — `n.Deliver undefined`
+
+- [ ] **Step 3: Implement** (append to `templated.go`):
+
+```go
+// Deliver renders and POSTs every enabled instance; a failing instance is
+// reported but never blocks its siblings (errors are joined, mirroring
+// notify.Multi one level down).
+func (n *Notifier) Deliver(ctx context.Context, inv providers.Investigation) error {
+	p := notify.NewPayload(inv)
+	var errs []error
+	for _, in := range n.instances {
+		if err := n.deliverOne(ctx, in, p); err != nil {
+			errs = append(errs, fmt.Errorf("templated %q: %w", in.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (n *Notifier) deliverOne(ctx context.Context, in instance, p notify.Payload) error {
+	var buf bytes.Buffer
+	if err := in.tmpl.Execute(&buf, p); err != nil {
+		return fmt.Errorf("execute template: %w", err)
+	}
+	if buf.Len() > maxBody {
+		return fmt.Errorf("rendered body %d bytes exceeds cap %d", buf.Len(), maxBody)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, in.url, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", in.contentType)
+	if in.token != "" {
+		req.Header.Set("Authorization", "Bearer "+in.token)
+	}
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+	return nil
+}
+```
+
+(httptest servers listen on 127.0.0.1 — if `httpx.SecureClient`'s public-origin SSRF guard rejects loopback, mirror how `webhook_test.go` already solves this for its own httptest deliveries; that test file is the authoritative pattern. If it swaps the client, add the same seam here: an unexported `client` field is already in place.)
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/notify/templated/ -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+git add internal/notify/templated/
+git commit -m "feat(notify): templated delivery — render, cap, and post"
+```
+
+---
+
+### Task 4: Registry pinning + docs (Teams example)
+
+**Files:**
+- Modify: `internal/notify/registry_test.go` (round-trip pins)
+- Modify: `docs/configuration.md` (templated section + Teams example + the two config surfaces)
+
+**Interfaces:**
+- Consumes: everything above; `config.Config` YAML loading (mirror how existing config tests build a `*config.Config` — reuse the package's established fixture idiom, do not invent one).
+
+- [ ] **Step 1: Write the failing test** (append to `internal/notify/registry_test.go`; this is the "unification can never regress" pin — construction for slack, matrix, webhook AND templated all flows through `BuildEnabled`, with the existing `notify.slack`/`notify.matrix` keys working verbatim):
+
+```go
+func TestBuildEnabledRoundTripAllNotifiers(t *testing.T) {
+	t.Setenv("RT_SLACK", "https://hooks.slack.example/x")
+	t.Setenv("RT_MATRIX_TOK", "syt_x")
+	t.Setenv("RT_WEBHOOK", "https://sink.example/w")
+	t.Setenv("RT_TEAMS", "https://teams.example/hook")
+	y := `
+notify:
+  slack:
+    webhook_url_env: RT_SLACK
+  matrix:
+    homeserver: https://m.example
+    room_id: "!r:m.example"
+    access_token_env: RT_MATRIX_TOK
+  webhook:
+    url_env: RT_WEBHOOK
+  templated:
+    - name: teams
+      url_env: RT_TEAMS
+      template: '{"text": {{ toJSON .Title }}}'
+`
+	var cfg config.Config
+	if err := yaml.Unmarshal([]byte(y), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	m, err := BuildEnabled(Deps{Cfg: &cfg, Log: slog.New(slog.DiscardHandler)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.Len(); got != 4 {
+		t.Errorf("BuildEnabled built %d notifiers, want 4 (slack, matrix, webhook, templated)", got)
+	}
+}
+```
+
+Notes for the implementer: (a) this test lives in package `notify`, so importing `internal/notify/webhook` or `.../templated` for their `init()` side effects needs blank imports — if that creates an import cycle (webhook imports notify), move this test to `internal/notify/registry_roundtrip_test.go` with `package notify_test` and import notify, webhook, templated, config; (b) if `Multi` has no `Len()`, add the trivial accessor `func (m *Multi) Len() int { return len(m.notifiers) }` next to `NewMulti` (same package) rather than exporting the slice; (c) mirror the yaml/slog idioms of the surrounding tests (check `slog.DiscardHandler` availability in this Go version — the existing tests show the package's chosen pattern; copy it).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/notify/... -run TestBuildEnabledRoundTripAllNotifiers -v`
+Expected: FAIL (missing `Len` and/or blank imports), then PASS after wiring exactly that.
+
+- [ ] **Step 3: Implement the minimal pieces** (`Len()` accessor + blank imports / test relocation per Step-1 notes) and re-run to PASS.
+
+- [ ] **Step 4: Docs** — `docs/configuration.md`, in the notify section, add:
+
+```markdown
+### Generic templated notifier (`notify.templated`)
+
+Deliver findings to **any** webhook-speaking service — Microsoft Teams, Discord,
+ntfy, incident.io — with one config block and no Go. Each instance renders a Go
+`text/template` over the delivery payload (the same fields the `notify.webhook`
+JSON carries) and POSTs it. Findings are secret-redacted **before** any notifier
+runs, so templates only ever see redacted data. A template that fails to parse
+refuses startup; a template that fails at delivery time is logged and skipped
+without blocking other channels. Rendered bodies are capped at 256 KiB.
+
+Worked example — Microsoft Teams (Incoming Webhook / MessageCard):
+
+    notify:
+      templated:
+        - name: teams
+          url_env: RUNLORE_TEAMS_WEBHOOK_URL
+          template: |
+            {
+              "@type": "MessageCard", "@context": "https://schema.org/extensions",
+              "summary": {{ toJSON .Title }},
+              "themeColor": "d63333",
+              "title": {{ toJSON (printf "[%s] %s (%.0f%%)" .Verdict .Title (mulPct .Confidence)) }},
+              "text": {{ toJSON .Text }}
+            }
+
+Template functions: `toJSON` (escaping-correct JSON splicing — always use it for
+values inside JSON bodies) and `mulPct` (×100 for percent display).
+
+**Two config surfaces, one registry.** Built-in notifiers (`notify.slack`,
+`notify.matrix`) use typed config blocks with startup validation; drop-in
+notifiers (`notify.webhook`, `notify.templated`) live under the same `notify:`
+key as self-describing blocks. Both build through the same registry — the split
+is deliberate: type-checked config for the built-ins, zero-code extensibility
+for everything else.
+```
+
+- [ ] **Step 5: Full gate + race + commit**
+
+```bash
+go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+go test -race ./internal/notify/... ./internal/config/... ./internal/app/...
+git add internal/notify/ docs/configuration.md
+git commit -m "test(notify): pin registry round-trip for all notifiers; document templated delivery"
+```
+
+---
+
+## Self-review checklist (run before opening the PR)
+
+1. **Wire-format freeze:** `git diff main -- internal/notify/webhook/` shows only the payload-type removal and the `NewPayload` call — every pre-existing webhook test passes unchanged.
+2. **Startup-fail proof:** `TestBuildFailsClosedOnBadConfig` covers parse + schema errors; confirm manually that `BuildEnabled` wraps them (`notify "templated": …`) so `lore serve` refuses to start.
+3. **No new deps:** `git diff main -- go.mod` is empty.
+4. **Placeholder scan:** no TBD/TODO/"similar to Task N" anywhere in the diff.
+5. **Registry pin honest:** the round-trip test genuinely exercises `notify.slack`/`notify.matrix` keys verbatim (zero user-visible change is asserted, not assumed).

--- a/dev/superpowers/plans/2026-07-20-templated-webhook-source.md
+++ b/dev/superpowers/plans/2026-07-20-templated-webhook-source.md
@@ -1,0 +1,1163 @@
+# Templated Generic Webhook Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A config-only `custom` webhook source: operators map any vendor's alert JSON (Grafana, Datadog, OpsGenie, …) to investigation requests via dot-path field extraction — no Go, no recompile.
+
+**Architecture:** One new self-registered source adapter (`internal/source/custom`) following the registry pattern (`source.Register` in `init()`, config under `sources.custom`, nil-from-Build = disabled). N named *instances* share one wildcard route `/webhook/custom/{instance}`; the core's `Built.Handler` stamps the path wildcard into a sanitized synthetic header (`X-Runlore-Instance`) so the unchanged `Decode(body, header)` / `Authenticate(body, header)` interfaces can dispatch per instance. Field extraction is a dependency-free dot-path subset (`a.b[2].c`). Auth mirrors PagerDuty: per-instance bearer token (env-indirected), falling back to the shared `server.webhook_token_env` bearer, open-with-startup-guards when neither is set (`RequireWebhookAuth` already refuses model-configured + shared-token-empty; `mode=auto` fails closed in Build). Bad mappings fail at startup (Build error aborts), never silently at ingest. The `MaxRequestsPerPayload` cost cap applies automatically — it lives in the core `Handler`.
+
+**Tech Stack:** Go (toolchain go1.26.5); stdlib + `gopkg.in/yaml.v3` only (no new dependencies); existing `internal/source` registry/pipeline, `internal/investigate.Request`, `internal/curator.IncidentKey`.
+
+## Global Constraints
+
+- Quality gate before every commit: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...` — `0 issues.`, `gofmt -l` empty; plus `go test -race ./internal/source/... ./internal/investigate/...` before the final push.
+- SPDX header `// SPDX-License-Identifier: Apache-2.0` as line 1 of every new `.go` file.
+- Conventional Commits; **no co-author trailer, no AI attribution**.
+- **No new third-party dependencies** (the dot-path extractor is hand-rolled; NO JSONPath library).
+- Fail-safe: a malformed instance config aborts startup with a precise error; at ingest, a single bad event is skipped, never the whole payload; unknown `{instance}` ⇒ 401/400, never a panic.
+- Config stores env-var **names**, never secret values (`token_env`, repo-wide pattern).
+- The `X-Runlore-Instance` header must be attacker-proof: the core **deletes** any client-supplied value before stamping the path value (Task 3).
+
+## File Structure
+
+```
+internal/source/custom/path.go        dot-path parse + extract + scalar coercion (pure)
+internal/source/custom/path_test.go
+internal/source/custom/config.go      instance config decode + startup validation
+internal/source/custom/config_test.go
+internal/source/custom/custom.go      Source (Decode + init registration + Build)
+internal/source/custom/custom_test.go
+internal/source/custom/auth.go        Authenticate (per-instance → shared → open)
+internal/source/custom/auth_test.go
+internal/source/webhook.go            (modify) InstanceHeader const + stamp in Handler
+internal/source/webhook_test.go       (modify) header-stamp + forged-header tests
+internal/investigate/investigate.go   (modify) SourceCustom constant
+docs/data-sources.md                  (modify) Custom webhooks section, 2 worked examples
+```
+
+---
+
+### Task 1: Dot-path extractor
+
+**Files:**
+- Create: `internal/source/custom/path.go`
+- Test: `internal/source/custom/path_test.go`
+
+**Interfaces:**
+- Produces: `parsePath(s string) (path, error)` where `type path []step`, `type step struct { key string; idx int; isIdx bool }`; `(p path) lookup(doc any) (any, bool)`; `coerce(v any) (string, bool)` — string/bool/float64/int coerced to string, objects/arrays/nil refuse. Later tasks call `parsePath` at config time and `lookup`+`coerce` at decode time.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import "testing"
+
+func TestParseAndLookup(t *testing.T) {
+	doc := map[string]any{
+		"alerts": []any{
+			map[string]any{"labels": map[string]any{"alertname": "HighCPU", "code": float64(503), "firing": true}},
+		},
+		"title": "root",
+	}
+	cases := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"title", "root", true},
+		{"alerts[0].labels.alertname", "HighCPU", true},
+		{"alerts[0].labels.code", "503", true},
+		{"alerts[0].labels.firing", "true", true},
+		{"alerts[1].labels.alertname", "", false}, // index out of range
+		{"alerts[0].labels.missing", "", false},
+		{"alerts", "", false}, // array leaf refuses coercion
+	}
+	for _, c := range cases {
+		p, err := parsePath(c.path)
+		if err != nil {
+			t.Fatalf("parsePath(%q): %v", c.path, err)
+		}
+		v, found := p.lookup(doc)
+		got, coerced := "", false
+		if found {
+			got, coerced = coerce(v)
+		}
+		if (found && coerced) != c.ok || got != c.want {
+			t.Errorf("%q: got (%q,%v), want (%q,%v)", c.path, got, found && coerced, c.want, c.ok)
+		}
+	}
+}
+
+func TestParsePathRejectsMalformed(t *testing.T) {
+	for _, bad := range []string{"", "a[", "a[x]", "a[-1]", "a..b", "[0]", "a["} {
+		if _, err := parsePath(bad); err == nil {
+			t.Errorf("parsePath(%q): want error, got nil", bad)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestParse' -v`
+Expected: FAIL — `undefined: parsePath` (package doesn't compile yet)
+
+- [ ] **Step 3: Implement**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Package custom is the config-only generic webhook source: operators map any
+// vendor's alert JSON to investigation requests with dot-path field extraction
+// (sources.custom.instances.<name>), no Go required.
+package custom
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// step is one segment of a dot-path: a map key, optionally followed by one
+// array index (`labels`, `alerts[0]`).
+type step struct {
+	key   string
+	idx   int
+	isIdx bool
+}
+
+type path []step
+
+// parsePath parses the supported dot-path subset: dot-separated map keys, each
+// optionally suffixed with a single non-negative `[n]` index. Deliberately NOT
+// JSONPath (no wildcards, filters, recursion) — YAGNI, zero dependencies.
+func parsePath(s string) (path, error) {
+	if s == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	var out path
+	for _, seg := range strings.Split(s, ".") {
+		if seg == "" {
+			return nil, fmt.Errorf("path %q: empty segment", s)
+		}
+		key, rest := seg, ""
+		if i := strings.IndexByte(seg, '['); i >= 0 {
+			key, rest = seg[:i], seg[i:]
+		}
+		if key == "" {
+			return nil, fmt.Errorf("path %q: segment %q lacks a key before '['", s, seg)
+		}
+		st := step{key: key}
+		if rest != "" {
+			if !strings.HasSuffix(rest, "]") {
+				return nil, fmt.Errorf("path %q: unterminated index in %q", s, seg)
+			}
+			n, err := strconv.Atoi(rest[1 : len(rest)-1])
+			if err != nil || n < 0 {
+				return nil, fmt.Errorf("path %q: bad index in %q", s, seg)
+			}
+			st.idx, st.isIdx = n, true
+		}
+		out = append(out, st)
+	}
+	return out, nil
+}
+
+// lookup walks doc (json.Unmarshal-into-any shapes: map[string]any / []any).
+func (p path) lookup(doc any) (any, bool) {
+	cur := doc
+	for _, st := range p {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[st.key]
+		if !ok {
+			return nil, false
+		}
+		if st.isIdx {
+			arr, ok := cur.([]any)
+			if !ok || st.idx >= len(arr) {
+				return nil, false
+			}
+			cur = arr[st.idx]
+		}
+	}
+	return cur, true
+}
+
+// coerce renders a scalar leaf as a string; composite values refuse (a mapping
+// that lands on an object is a config mistake surfaced by absence, not garbage).
+func coerce(v any) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case bool:
+		return strconv.FormatBool(t), true
+	case float64: // encoding/json numbers
+		return strconv.FormatFloat(t, 'g', -1, 64), true
+	case int:
+		return strconv.Itoa(t), true
+	default:
+		return "", false
+	}
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/source/custom/ -run 'TestParse' -v`
+Expected: PASS (both tests)
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./internal/source/...
+git add internal/source/custom/path.go internal/source/custom/path_test.go
+git commit -m "feat(source): dot-path extractor for the generic webhook source"
+```
+
+---
+
+### Task 2: Instance config — decode + startup validation
+
+**Files:**
+- Create: `internal/source/custom/config.go`
+- Test: `internal/source/custom/config_test.go`
+
+**Interfaces:**
+- Consumes: `parsePath` (Task 1).
+- Produces: `type instanceCfg struct` (yaml tags below), `type instance struct` (compiled form: parsed paths + token), `parseConfig(node yaml.Node) (map[string]*instance, error)` — called by `Build` (Task 5). Compiled `instance` fields: `fields map[string]path` (keys = the field names below), `items path` (nil = single event at root), `resolvedValue string`, `labels path`, `defaults map[string]string`, `severityMap map[string]string`, `tokenEnv string`.
+
+Config shape (documented in Task 6):
+
+```yaml
+sources:
+  custom:
+    instances:
+      grafana:
+        token_env: GRAFANA_WEBHOOK_TOKEN   # optional; falls back to server.webhook_token_env
+        items: alerts                      # optional; absent = whole body is one event
+        fields:                            # dot-paths, relative to one event
+          title: labels.alertname          # REQUIRED
+          message: annotations.summary
+          severity: labels.severity
+          namespace: labels.namespace
+          workload_kind: labels.kind
+          workload_name: labels.pod
+          environment: labels.env
+          fingerprint: fingerprint
+          resolved: status                 # value compared to resolved_value
+        resolved_value: resolved           # default "resolved"
+        labels: labels                     # optional; object of scalar labels
+        defaults: { severity: warning }    # applied when the path yields nothing
+        severity_map: { P1: critical }     # value normalization after extraction
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func mustNode(t *testing.T, y string) yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(y), &n); err != nil {
+		t.Fatal(err)
+	}
+	return *n.Content[0] // unwrap the document node
+}
+
+func TestParseConfigValid(t *testing.T) {
+	n := mustNode(t, `
+instances:
+  grafana:
+    items: alerts
+    fields: {title: labels.alertname, severity: labels.severity, resolved: status}
+    severity_map: {P1: critical}
+    defaults: {environment: prod}
+`)
+	insts, err := parseConfig(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := insts["grafana"]
+	if g == nil || g.items == nil || g.resolvedValue != "resolved" {
+		t.Fatalf("compiled instance wrong: %+v", g)
+	}
+	if _, ok := g.fields["title"]; !ok {
+		t.Fatal("title path not compiled")
+	}
+}
+
+func TestParseConfigRejects(t *testing.T) {
+	cases := []struct{ name, yml, wantErr string }{
+		{"missing title", `
+instances:
+  a: {fields: {severity: s}}`, "fields.title is required"},
+		{"bad path", `
+instances:
+  a: {fields: {title: "x["}}`, "unterminated index"},
+		{"unknown instance key", `
+instances:
+  a: {fields: {title: t}, itms: alerts}`, "unknown key"},
+		{"no instances", `instances: {}`, "at least one instance"},
+	}
+	for _, c := range cases {
+		_, err := parseConfig(mustNode(t, c.yml))
+		if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+			t.Errorf("%s: err=%v, want containing %q", c.name, err, c.wantErr)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestParseConfig' -v`
+Expected: FAIL — `undefined: parseConfig`
+
+- [ ] **Step 3: Implement**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// instanceCfg is the raw yaml shape of one sources.custom.instances entry.
+type instanceCfg struct {
+	TokenEnv      string            `yaml:"token_env"`
+	Items         string            `yaml:"items"`
+	Fields        map[string]string `yaml:"fields"`
+	ResolvedValue string            `yaml:"resolved_value"`
+	Labels        string            `yaml:"labels"`
+	Defaults      map[string]string `yaml:"defaults"`
+	SeverityMap   map[string]string `yaml:"severity_map"`
+}
+
+type rootCfg struct {
+	Instances map[string]instanceCfg `yaml:"instances"`
+}
+
+// fieldNames is the closed set of extractable Request fields.
+var fieldNames = map[string]bool{
+	"title": true, "message": true, "severity": true, "namespace": true,
+	"workload_kind": true, "workload_name": true, "environment": true,
+	"fingerprint": true, "resolved": true,
+}
+
+// instanceKeys is the closed set of per-instance config keys, for the loud
+// unknown-key check (mirrors source.BuildEnabled's typo philosophy: a typo'd
+// key must abort startup, not silently disable a mapping).
+var instanceKeys = map[string]bool{
+	"token_env": true, "items": true, "fields": true, "resolved_value": true,
+	"labels": true, "defaults": true, "severity_map": true,
+}
+
+// instance is the compiled (validated, path-parsed) form used at decode time.
+type instance struct {
+	fields        map[string]path
+	items         path // nil = single event at body root
+	resolvedValue string
+	labels        path // nil = none
+	defaults      map[string]string
+	severityMap   map[string]string
+	tokenEnv      string
+	token         string // resolved at Build; see auth.go
+}
+
+// parseConfig compiles the sources.custom block. Every error aborts startup —
+// a bad mapping must never silently drop alerts at ingest.
+func parseConfig(node yaml.Node) (map[string]*instance, error) {
+	// Loud unknown-key check per instance (node-level, since instanceCfg's plain
+	// Decode is not strict).
+	var rawRoot struct {
+		Instances map[string]map[string]yaml.Node `yaml:"instances"`
+	}
+	if err := node.Decode(&rawRoot); err != nil {
+		return nil, fmt.Errorf("decode sources.custom: %w", err)
+	}
+	for name, keys := range rawRoot.Instances {
+		for k := range keys {
+			if !instanceKeys[k] {
+				return nil, fmt.Errorf("sources.custom.instances.%s: unknown key %q", name, k)
+			}
+		}
+	}
+
+	var c rootCfg
+	if err := node.Decode(&c); err != nil {
+		return nil, fmt.Errorf("decode sources.custom: %w", err)
+	}
+	if len(c.Instances) == 0 {
+		return nil, fmt.Errorf("sources.custom: at least one instance is required")
+	}
+	out := make(map[string]*instance, len(c.Instances))
+	names := make([]string, 0, len(c.Instances))
+	for n := range c.Instances {
+		names = append(names, n)
+	}
+	sort.Strings(names) // deterministic error order
+	for _, name := range names {
+		ic := c.Instances[name]
+		if ic.Fields["title"] == "" {
+			return nil, fmt.Errorf("sources.custom.instances.%s: fields.title is required", name)
+		}
+		inst := &instance{
+			fields:        map[string]path{},
+			resolvedValue: ic.ResolvedValue,
+			defaults:      ic.Defaults,
+			severityMap:   ic.SeverityMap,
+			tokenEnv:      ic.TokenEnv,
+		}
+		if inst.resolvedValue == "" {
+			inst.resolvedValue = "resolved"
+		}
+		for f, p := range ic.Fields {
+			if !fieldNames[f] {
+				return nil, fmt.Errorf("sources.custom.instances.%s: unknown field %q", name, f)
+			}
+			cp, err := parsePath(p)
+			if err != nil {
+				return nil, fmt.Errorf("sources.custom.instances.%s: fields.%s: %w", name, f, err)
+			}
+			inst.fields[f] = cp
+		}
+		if ic.Items != "" {
+			cp, err := parsePath(ic.Items)
+			if err != nil {
+				return nil, fmt.Errorf("sources.custom.instances.%s: items: %w", name, err)
+			}
+			inst.items = cp
+		}
+		if ic.Labels != "" {
+			cp, err := parsePath(ic.Labels)
+			if err != nil {
+				return nil, fmt.Errorf("sources.custom.instances.%s: labels: %w", name, err)
+			}
+			inst.labels = cp
+		}
+		out[name] = inst
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/source/custom/ -run 'TestParseConfig' -v`
+Expected: PASS
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./internal/source/...
+git add internal/source/custom/config.go internal/source/custom/config_test.go
+git commit -m "feat(source): sources.custom instance config with startup validation"
+```
+
+---
+
+### Task 3: Core — stamp the path wildcard into a sanitized header
+
+**Files:**
+- Modify: `internal/source/webhook.go` (Handler, ~line 38; new exported const)
+- Test: `internal/source/webhook_test.go` (append)
+
+**Interfaces:**
+- Produces: `source.InstanceHeader = "X-Runlore-Instance"`. Handler guarantees: the header equals `r.PathValue("instance")` — client-supplied values are ALWAYS deleted first (anti-spoofing), and it is absent for routes without the wildcard. Tasks 4/5 read it in `Decode`/`Authenticate`.
+
+- [ ] **Step 1: Write the failing tests** (append to `webhook_test.go`; helpers `webhookBuilt`, `capEnq`, `matchAllCfg`, `fakeDecoder`, `oneRequestResult` already exist there)
+
+```go
+// headerCapture records the header Decode saw.
+type headerCapture struct {
+	got    http.Header
+	result DecodeResult
+}
+
+func (h *headerCapture) Decode(_ []byte, hdr http.Header) (DecodeResult, error) {
+	h.got = hdr.Clone()
+	return h.result, nil
+}
+
+func TestHandlerStampsInstanceHeader(t *testing.T) {
+	cap := &headerCapture{result: oneRequestResult()}
+	b := Built{Desc: Descriptor{Name: "custom", Kind: Webhook, Path: "/webhook/custom/{instance}"}, Impl: cap}
+	pipe := NewPipeline(matchAllCfg(), &capEnq{}, nil, nil)
+
+	mux := http.NewServeMux()
+	MountWebhooks(mux, []Built{b}, nil, pipe, nil)
+	// A forged client value must be OVERWRITTEN by the path value.
+	req := httptest.NewRequest(http.MethodPost, "/webhook/custom/grafana", strings.NewReader(`{}`))
+	req.Header.Set(InstanceHeader, "forged")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if got := cap.got.Get(InstanceHeader); got != "grafana" {
+		t.Fatalf("InstanceHeader = %q, want %q", got, "grafana")
+	}
+}
+
+func TestHandlerScrubsInstanceHeaderOnPlainRoutes(t *testing.T) {
+	cap := &headerCapture{result: oneRequestResult()}
+	b := webhookBuilt(fakeDecoder{result: oneRequestResult()})
+	b.Impl = cap
+	pipe := NewPipeline(matchAllCfg(), &capEnq{}, nil, nil)
+
+	mux := http.NewServeMux()
+	MountWebhooks(mux, []Built{b}, nil, pipe, nil)
+	req := httptest.NewRequest(http.MethodPost, "/webhook/test", strings.NewReader(`{}`))
+	req.Header.Set(InstanceHeader, "forged")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if got := cap.got.Get(InstanceHeader); got != "" {
+		t.Fatalf("InstanceHeader = %q, want scrubbed", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/source/ -run 'TestHandlerStampsInstance|TestHandlerScrubs' -v`
+Expected: FAIL — `undefined: InstanceHeader`
+
+- [ ] **Step 3: Implement.** In `webhook.go`, above `MaxRequestsPerPayload`:
+
+```go
+// InstanceHeader carries the {instance} path wildcard to Decode/Authenticate,
+// whose signatures only see (body, header). The core owns it: any client-sent
+// value is deleted before the path value is stamped, so adapters may trust it.
+const InstanceHeader = "X-Runlore-Instance"
+```
+
+In `Handler`'s returned func, FIRST lines of the closure (before the shared-auth check, so `Authenticate` sees it too):
+
+```go
+		// Anti-spoofing: the instance header is core-owned. Delete any client
+		// value, then stamp the route wildcard (empty for non-wildcard routes).
+		r.Header.Del(InstanceHeader)
+		if v := r.PathValue("instance"); v != "" {
+			r.Header.Set(InstanceHeader, v)
+		}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/source/ -v`
+Expected: PASS (new tests + all existing handler tests unchanged)
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./internal/source/...
+git add internal/source/webhook.go internal/source/webhook_test.go
+git commit -m "feat(source): core-owned X-Runlore-Instance header from the route wildcard"
+```
+
+---
+
+### Task 4: Decode — events → Requests/Resolutions
+
+**Files:**
+- Modify: `internal/investigate/investigate.go` (add `SourceCustom` constant next to `SourcePagerDuty`, ~line 36)
+- Create: `internal/source/custom/custom.go` (Source + Decode; registration comes in Task 5)
+- Test: `internal/source/custom/custom_test.go`
+
+**Interfaces:**
+- Consumes: `instance` (Task 2), `path.lookup`/`coerce` (Task 1), `source.InstanceHeader` (Task 3), `curator.IncidentKey(alertname, namespace, kind, name, cluster string) string`, `investigate.Request` (fields verified against `internal/investigate/investigate.go:44-66`), `source.DecodeResult`/`source.Resolution`.
+- Produces: `type Source struct { instances map[string]*instance }` implementing `source.WebhookSource`. Instance name goes in the `IncidentKey` cluster slot (PagerDuty precedent: its service takes that slot) and as label `instance`.
+
+- [ ] **Step 1: Add the constant** in `internal/investigate/investigate.go` after `SourcePagerDuty`:
+
+```go
+	// SourceCustom means the investigation was triggered by a generic
+	// (config-mapped) vendor webhook — sources.custom.
+	SourceCustom Source = "custom"
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Smana/runlore/internal/investigate"
+)
+
+func grafanaInstance(t *testing.T) *Source {
+	t.Helper()
+	insts, err := parseConfig(mustNode(t, `
+instances:
+  grafana:
+    items: alerts
+    fields:
+      title: labels.alertname
+      message: annotations.summary
+      severity: labels.severity
+      namespace: labels.namespace
+      workload_name: labels.pod
+      fingerprint: fingerprint
+      resolved: status
+    labels: labels
+    severity_map: {P1: critical}
+    defaults: {environment: prod, severity: warning}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Source{instances: insts}
+}
+
+func hdr(instance string) http.Header {
+	h := http.Header{}
+	h.Set("X-Runlore-Instance", instance)
+	return h
+}
+
+const grafanaBody = `{"alerts":[
+  {"status":"firing","fingerprint":"fp1","labels":{"alertname":"HighCPU","severity":"P1","namespace":"payments","pod":"api-0"},"annotations":{"summary":"CPU is high"}},
+  {"status":"resolved","fingerprint":"fp2","labels":{"alertname":"OldAlert"}},
+  {"status":"firing","labels":{"alertname":"NoSeverity"}}
+]}`
+
+func TestDecodeGrafanaShape(t *testing.T) {
+	s := grafanaInstance(t)
+	res, err := s.Decode([]byte(grafanaBody), hdr("grafana"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 2 || len(res.Resolved) != 1 {
+		t.Fatalf("got %d requests / %d resolved, want 2 / 1", len(res.Requests), len(res.Resolved))
+	}
+	r := res.Requests[0]
+	if r.Source != investigate.SourceCustom || r.Title != "HighCPU" || r.Message != "CPU is high" {
+		t.Errorf("request basics wrong: %+v", r)
+	}
+	if r.Severity != "critical" { // P1 through severity_map
+		t.Errorf("severity = %q, want critical (mapped)", r.Severity)
+	}
+	if r.Workload.Namespace != "payments" || r.Workload.Name != "api-0" {
+		t.Errorf("workload wrong: %+v", r.Workload)
+	}
+	if r.Environment != "prod" { // default applied
+		t.Errorf("environment = %q, want prod (default)", r.Environment)
+	}
+	if r.Fingerprint != "fp1" || r.TriggerKey == "" || r.Labels["instance"] != "grafana" || r.Labels["alertname"] != "HighCPU" {
+		t.Errorf("identity fields wrong: %+v", r)
+	}
+	if res.Resolved[0].Fingerprint != "fp2" {
+		t.Errorf("resolution fingerprint = %q", res.Resolved[0].Fingerprint)
+	}
+	if res.Requests[1].Severity != "warning" { // default when path yields nothing
+		t.Errorf("default severity not applied: %q", res.Requests[1].Severity)
+	}
+}
+
+func TestDecodeSingleEventAtRoot(t *testing.T) {
+	insts, err := parseConfig(mustNode(t, `
+instances:
+  datadog:
+    fields: {title: title, message: body, severity: alert_type}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Source{instances: insts}
+	res, err := s.Decode([]byte(`{"title":"[Triggered] disk","body":"disk full","alert_type":"error"}`), hdr("datadog"))
+	if err != nil || len(res.Requests) != 1 {
+		t.Fatalf("res=%+v err=%v", res, err)
+	}
+	if res.Requests[0].Title != "[Triggered] disk" || res.Requests[0].Severity != "error" {
+		t.Errorf("request wrong: %+v", res.Requests[0])
+	}
+}
+
+func TestDecodeUnknownInstanceErrors(t *testing.T) {
+	s := grafanaInstance(t)
+	if _, err := s.Decode([]byte(`{}`), hdr("nope")); err == nil {
+		t.Fatal("want error for unknown instance")
+	}
+	if _, err := s.Decode([]byte(`{}`), http.Header{}); err == nil {
+		t.Fatal("want error for missing instance header")
+	}
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run 'TestDecode' -v`
+Expected: FAIL — `undefined: Source`
+
+- [ ] **Step 4: Implement**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/source"
+)
+
+// Source is the generic webhook source adapter. One Source serves every
+// configured instance; the core-stamped source.InstanceHeader selects which
+// mapping applies to a delivery (see source.Built.Handler).
+type Source struct {
+	instances map[string]*instance
+}
+
+// Decode maps one delivery through the instance's field paths. A single
+// non-conforming event is skipped (fail-safe: one junk element must not void a
+// batch); an unknown instance is an error (→ 400) — it means a route/config
+// mismatch, not vendor noise.
+func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error) {
+	name := h.Get(source.InstanceHeader)
+	inst, ok := s.instances[name]
+	if !ok {
+		return source.DecodeResult{}, fmt.Errorf("custom: unknown instance %q", name)
+	}
+	var doc any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return source.DecodeResult{}, fmt.Errorf("custom/%s: decode body: %w", name, err)
+	}
+
+	events := []any{doc}
+	if inst.items != nil {
+		v, ok := inst.items.lookup(doc)
+		if !ok {
+			return source.DecodeResult{}, fmt.Errorf("custom/%s: items path yields nothing", name)
+		}
+		arr, ok := v.([]any)
+		if !ok {
+			return source.DecodeResult{}, fmt.Errorf("custom/%s: items path is not an array", name)
+		}
+		events = arr
+	}
+
+	var out source.DecodeResult
+	for _, ev := range events {
+		get := func(field string) string {
+			p, ok := inst.fields[field]
+			if !ok {
+				return inst.defaults[field]
+			}
+			v, found := p.lookup(ev)
+			if !found {
+				return inst.defaults[field]
+			}
+			s, ok := coerce(v)
+			if !ok {
+				return inst.defaults[field]
+			}
+			return s
+		}
+
+		fingerprint := get("fingerprint")
+		if get("resolved") == inst.resolvedValue {
+			if fingerprint != "" { // a resolution without identity cannot be attributed
+				out.Resolved = append(out.Resolved, source.Resolution{Fingerprint: fingerprint, At: time.Now()})
+			}
+			continue
+		}
+		title := get("title")
+		if title == "" {
+			continue // fail-safe: skip the event, keep the batch
+		}
+		severity := get("severity")
+		if mapped, ok := inst.severityMap[severity]; ok {
+			severity = mapped
+		}
+		labels := map[string]string{"instance": name}
+		if inst.labels != nil {
+			if v, found := inst.labels.lookup(ev); found {
+				if m, ok := v.(map[string]any); ok {
+					for k, lv := range m {
+						if s, ok := coerce(lv); ok {
+							labels[k] = s
+						}
+					}
+				}
+			}
+		}
+		ns, kind, wname := get("namespace"), get("workload_kind"), get("workload_name")
+		var fps []string
+		if fingerprint != "" {
+			fps = []string{fingerprint}
+		}
+		out.Requests = append(out.Requests, investigate.Request{
+			Source:       investigate.SourceCustom,
+			Title:        title,
+			Severity:     severity,
+			Environment:  get("environment"),
+			Workload:     providers.Workload{Namespace: ns, Kind: kind, Name: wname},
+			Reason:       severity,
+			Message:      get("message"),
+			Labels:       labels,
+			At:           time.Now(),
+			Fingerprint:  fingerprint,
+			Fingerprints: fps,
+			// Instance takes the cluster slot (PagerDuty precedent: its service
+			// does) so two vendors reporting the same workload stay distinct.
+			TriggerKey: curator.IncidentKey(title, ns, kind, wname, name),
+		})
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS (all tasks so far)
+
+- [ ] **Step 6: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./internal/source/... ./internal/investigate/...
+git add internal/investigate/investigate.go internal/source/custom/custom.go internal/source/custom/custom_test.go
+git commit -m "feat(source): generic webhook Decode — config-mapped events to requests"
+```
+
+---
+
+### Task 5: Auth + registration
+
+**Files:**
+- Create: `internal/source/custom/auth.go`
+- Test: `internal/source/custom/auth_test.go`
+- Modify: `internal/source/custom/custom.go` (append `init()` + `osGetenv` var)
+
+**Interfaces:**
+- Consumes: `source.Register`/`Descriptor`/`Deps` (registry.go:78-102), `config.ActionAuto` (PagerDuty Build precedent at `internal/source/pagerduty/pagerduty.go:191-217`), `Deps.Cfg.Server.WebhookTokenEnv`.
+- Produces: `Source` also implements `source.Authenticator` — which SKIPS the core's shared auth, so the fallback re-implements it: per-instance `token_env` if set, else the shared `server.webhook_token_env` value (resolved once at Build), else open. Registration: `Name: "custom"`, `Kind: source.Webhook`, `Admission: source.MatchGated`, `Path: "/webhook/custom/{instance}"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"net/http"
+	"testing"
+)
+
+func authSource(t *testing.T, instToken, sharedToken string) *Source {
+	t.Helper()
+	s := grafanaInstance(t)
+	s.instances["grafana"].token = instToken
+	s.shared = sharedToken
+	return s
+}
+
+func bearer(instance, tok string) http.Header {
+	h := hdr(instance)
+	if tok != "" {
+		h.Set("Authorization", "Bearer "+tok)
+	}
+	return h
+}
+
+func TestAuthenticate(t *testing.T) {
+	cases := []struct {
+		name                 string
+		instToken, shared    string
+		instance, presented  string
+		want                 bool
+	}{
+		{"instance token ok", "sec1", "shared", "grafana", "sec1", true},
+		{"instance token wrong", "sec1", "shared", "grafana", "shared", false}, // instance token set: shared no longer accepted
+		{"fallback to shared", "", "shared", "grafana", "shared", true},
+		{"fallback wrong", "", "shared", "grafana", "bad", false},
+		{"both empty = open", "", "", "grafana", "", true},
+		{"unknown instance fails closed", "sec1", "shared", "nope", "sec1", false},
+	}
+	for _, c := range cases {
+		s := authSource(t, c.instToken, c.shared)
+		if got := s.Authenticate(nil, bearer(c.instance, c.presented)); got != c.want {
+			t.Errorf("%s: Authenticate = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/source/custom/ -run TestAuthenticate -v`
+Expected: FAIL — `s.shared undefined` / `undefined: (*Source).Authenticate`
+
+- [ ] **Step 3: Implement.** `auth.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/Smana/runlore/internal/source"
+)
+
+// Authenticate verifies a delivery's bearer token. Implementing
+// source.Authenticator skips the core's shared webhook auth, so the ladder is
+// re-established here explicitly: the instance's own token when configured
+// (shared no longer accepted — tighter, per-vendor secrets), else the shared
+// server.webhook_token_env value resolved at Build, else open (mirroring the
+// alertmanager source; app.RequireWebhookAuth still refuses to start a
+// model-configured server with an empty shared token, and Build fails closed
+// under actions.mode=auto below).
+func (s *Source) Authenticate(_ []byte, h http.Header) bool {
+	inst, ok := s.instances[h.Get(source.InstanceHeader)]
+	if !ok {
+		return false // unknown instance: fail closed before Decode
+	}
+	want := inst.token
+	if want == "" {
+		want = s.shared
+	}
+	if want == "" {
+		return true
+	}
+	const prefix = "Bearer "
+	got := h.Get("Authorization")
+	return strings.HasPrefix(got, prefix) &&
+		subtle.ConstantTimeCompare([]byte(strings.TrimPrefix(got, prefix)), []byte(want)) == 1
+}
+```
+
+Append to `custom.go`: add the `shared string` field to `Source`, and:
+
+```go
+// osGetenv is a package-level indirection for os.Getenv (PagerDuty precedent;
+// tests set real env vars via t.Setenv).
+var osGetenv = os.Getenv
+
+func init() {
+	source.Register(source.Descriptor{
+		Name: "custom",
+		Kind: source.Webhook, Admission: source.MatchGated, Path: "/webhook/custom/{instance}",
+		Build: func(d source.Deps) (any, error) {
+			node, ok := d.Raw["custom"]
+			if !ok {
+				return nil, nil // disabled: no sources.custom key
+			}
+			insts, err := parseConfig(node)
+			if err != nil {
+				return nil, err
+			}
+			shared := ""
+			if d.Cfg != nil && d.Cfg.Server.WebhookTokenEnv != "" {
+				shared = osGetenv(d.Cfg.Server.WebhookTokenEnv)
+			}
+			for name, inst := range insts {
+				if inst.tokenEnv != "" {
+					inst.token = osGetenv(inst.tokenEnv)
+					if inst.token == "" {
+						return nil, fmt.Errorf("sources.custom.instances.%s: token_env %q is empty", name, inst.tokenEnv)
+					}
+				}
+				// Fail closed under mode=auto: an unattended executor must not
+				// accept unauthenticated vendor webhooks (PagerDuty precedent).
+				if d.Cfg != nil && d.Cfg.Actions.Mode == config.ActionAuto && inst.token == "" && shared == "" {
+					return nil, fmt.Errorf("actions.mode=auto requires a token for sources.custom.instances.%s (token_env or server.webhook_token_env)", name)
+				}
+			}
+			return &Source{instances: insts, shared: shared}, nil
+		},
+	})
+}
+```
+
+(Add `"os"` and `"github.com/Smana/runlore/internal/config"` to custom.go's imports. Check the exact `ActionAuto` constant name in `internal/config` — PagerDuty's Build at `pagerduty.go:211` uses `config.ActionAuto`; mirror it.)
+
+- [ ] **Step 4: Write + run the Build tests** (append to `auth_test.go`)
+
+```go
+func TestBuildFailClosedUnderAuto(t *testing.T) {
+	// Registered descriptor is package-global; drive Build via source.BuildEnabled
+	// in an integration test OR call the registered Build through Registered().
+	// Simplest: look it up.
+	var build func(source.Deps) (any, error)
+	for _, d := range source.Registered() {
+		if d.Name == "custom" {
+			build = d.Build
+		}
+	}
+	if build == nil {
+		t.Fatal("custom source not registered")
+	}
+	raw := map[string]yaml.Node{"custom": mustNode(t, `
+instances:
+  a: {fields: {title: t}}
+`)}
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionAuto
+	if _, err := build(source.Deps{Cfg: cfg, Raw: raw}); err == nil {
+		t.Fatal("want fail-closed error under mode=auto with no token")
+	}
+	// And with a token it builds.
+	t.Setenv("CUSTOM_TOK", "s3cret")
+	raw["custom"] = mustNode(t, `
+instances:
+  a: {token_env: CUSTOM_TOK, fields: {title: t}}
+`)
+	impl, err := build(source.Deps{Cfg: cfg, Raw: raw})
+	if err != nil || impl == nil {
+		t.Fatalf("build with token: impl=%v err=%v", impl, err)
+	}
+}
+```
+
+(Imports for auth_test.go: add `"github.com/Smana/runlore/internal/config"`, `"github.com/Smana/runlore/internal/source"`, `"gopkg.in/yaml.v3"`.)
+
+Run: `go test ./internal/source/custom/ -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Gate + commit**
+
+```bash
+go build ./... && go vet ./... && gofmt -l . && golangci-lint run ./internal/source/...
+git add internal/source/custom/auth.go internal/source/custom/auth_test.go internal/source/custom/custom.go
+git commit -m "feat(source): register the custom webhook source with per-instance bearer auth"
+```
+
+**Wiring check (no code expected):** `app/serve.go:266` builds every registered source via `source.BuildEnabled(... Raw: cfg.Sources)` and `MountWebhooks` mounts all Webhook-kind descriptors — a registered adapter needs NO app edits. Verify by grepping that nothing enumerates source names: `grep -rn '"alertmanager"\|"pagerduty"' internal/app/` — the only hits must be auth-guard helpers (`RequirePagerDutyAuth`), not mount lists. If a hit enumerates sources for mounting, stop and reassess (plan assumption broken).
+
+---
+
+### Task 6: Docs — worked Grafana + Datadog examples
+
+**Files:**
+- Modify: `docs/data-sources.md` (new section after the sources table)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Add the section.** Content (adjust heading depth to the file's existing structure):
+
+```markdown
+## Custom webhooks — any vendor, no code
+
+The `custom` source maps ANY vendor's alert JSON to investigations with dot-path
+field extraction — config only. Each named instance gets its own endpoint
+`POST /webhook/custom/<instance>` and its own optional bearer token
+(`token_env`, falling back to `server.webhook_token_env`). Field paths are
+dot-separated with optional `[n]` indexes (`alerts[0].labels.alertname`); a
+missing path falls back to `defaults`. `severity_map` normalizes vendor
+severities to yours. A payload with `items` set is a batch (path to the event
+array); without it the whole body is one event. Events whose `resolved` path
+equals `resolved_value` (default `"resolved"`) record a resolution for the
+outcome ledger instead of triggering an investigation (requires `fingerprint`).
+The per-delivery request cap and 1MiB body cap apply as for every webhook
+source. A typo'd instance key, an unparseable path, or a missing `fields.title`
+aborts startup — mappings never fail silently at ingest.
+
+### Grafana Alerting
+
+```yaml
+sources:
+  custom:
+    instances:
+      grafana:
+        token_env: GRAFANA_WEBHOOK_TOKEN
+        items: alerts
+        fields:
+          title: labels.alertname
+          message: annotations.summary
+          severity: labels.severity
+          namespace: labels.namespace
+          workload_name: labels.pod
+          fingerprint: fingerprint
+          resolved: status
+        labels: labels
+        defaults: { environment: prod }
+```
+
+Point a Grafana webhook contact point at
+`https://<runlore>/webhook/custom/grafana` with an `Authorization: Bearer …`
+custom header.
+
+### Datadog (custom webhook payload)
+
+Datadog webhooks POST a single flat JSON you define with template variables:
+
+```json
+{"title": "$EVENT_TITLE", "text": "$TEXT_ONLY_MSG", "alert_type": "$ALERT_TYPE",
+ "alert_status": "$ALERT_TRANSITION", "aggreg_key": "$AGGREG_KEY"}
+```
+
+```yaml
+sources:
+  custom:
+    instances:
+      datadog:
+        token_env: DATADOG_WEBHOOK_TOKEN
+        fields:
+          title: title
+          message: text
+          severity: alert_type
+          fingerprint: aggreg_key
+          resolved: alert_status
+        resolved_value: Recovered
+        severity_map: { error: critical }
+```
+
+Requests without a Kubernetes workload recall only resource-less entries (the
+scopeless tier) — same as PagerDuty.
+```
+
+- [ ] **Step 2: Full gate + race + commit + push**
+
+```bash
+go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...
+go test -race ./internal/source/... ./internal/investigate/...
+git add docs/data-sources.md
+git commit -m "docs(data-sources): custom webhook source with Grafana and Datadog examples"
+```
+
+Expected: `0 issues.`, empty gofmt, all packages ok (including `-race`).
+
+---
+
+## Self-Review Notes (already applied)
+
+- **Spec coverage:** config-only ✓ (registry, no app edits — verified `BuildEnabled`/`MountWebhooks` are name-agnostic, wiring check in Task 5) · dot-path subset, no dependency ✓ · per-instance token env with shared fallback ✓ · startup-fail validation incl. loud unknown keys ✓ · payload cap applies (core Handler, nothing to do) ✓ · Grafana + Datadog docs ✓.
+- **Anti-spoofing:** `InstanceHeader` is deleted-then-stamped by the core (Task 3) — adapters may trust it; tested with a forged header on both wildcard and plain routes.
+- **Type consistency:** `parsePath/lookup/coerce` (T1) ← config.go (T2) ← custom.go (T4); `Source{instances, shared}` shared by T4/T5; `hdr`/`mustNode`/`grafanaInstance` helpers defined once (T2/T4) and reused in T5 tests.
+- **Known judgment calls for the implementer:** the exact `config.ActionAuto` constant and `Server.WebhookTokenEnv` field names must be confirmed against `internal/config` at implementation time (both verified present today via the PagerDuty adapter and `server.go`); `matchAllCfg`/`capEnq` live in `webhook_test.go` (package `source`) and are reusable from Task 3's tests only (same package) — the `custom` package tests are self-contained by design.
+```

--- a/dev/superpowers/specs/2026-07-20-multi-kb-federation-design.md
+++ b/dev/superpowers/specs/2026-07-20-multi-kb-federation-design.md
@@ -1,0 +1,174 @@
+# Multi-KB Federation — Design
+
+| | |
+|---|---|
+| **Status** | Draft `v0.1` — awaiting maintainer review; **do not plan/implement until the adoption triggers in §9 fire** |
+| **Date** | 2026-07-20 |
+| **Scope** | One RunLore instance reading N knowledge bases — an org-wide KB, a team KB, read-only vendor runbook bundles — with one writable KB for curation/retirement, stable cross-KB entry identity for the outcome loop, and zero config breakage for single-KB deployments. |
+| **Author** | Claude (audit Later-wave L3), for Smana's review |
+| **Related** | `2026-07-19-audit-roadmap.md` (Later horizon); `internal/catalog` (single `Dir`/`Git` today); `internal/outcome` ledger keyed by entry path; N4 retirement (`internal/curate/retirement.go`); N6 staleness (`status`/`last_validated`); N2 vector cache (content-hash, survives federation rebuilds) |
+
+---
+
+## 1. Why this exists
+
+Today the catalog is exactly one source: `config.Catalog{Dir, Git}` feeds one
+`BuildCatalog` → one `*catalog.Catalog` (`internal/app/catalog.go:21-120`), one
+`Syncer`, one bleve index. A multi-team org wants layering: a **team KB** (their
+incidents), an **org KB** (platform-wide constraints and patterns), and **vendor
+bundles** (e.g. an upstream OKF runbook set for an ingress controller) — consumed
+read-only, never curated into.
+
+Federation is NOT about serving many consumers (MCP `kb_search`/`kb_get` already
+does that). It is about one agent *reading* many KBs while the learning loop keeps
+working: recall must rank across all of them, outcome decay must attribute to the
+right entry, and the write path (curation, retirement) must know where PRs go.
+
+The hard problem is **identity**, not search: the outcome ledger keys aggregates by
+the entry's bundle-relative path (`event.Entry`, `OpenCounts() map[string]Aggregate`,
+`internal/outcome/ledger.go:67,989`). Two KBs can both contain `runbooks/oom.md`;
+without namespacing, their track records merge silently and decay poisons the wrong
+entry.
+
+## 2. Decisions (recommended; alternatives in §-notes)
+
+| # | Decision | Rationale |
+|---|---|---|
+| F1 | **Config = ordered `catalog.sources` list; legacy keys become an implicit `default` source** | Zero breakage (§8); names are the identity namespace. |
+| F2 | **One merged index + ranked pool; per-source `weight` multiplier; NO strict tiers** | BM25 scores are not comparable across separate indexes — per-KB indexes would need cross-index score normalization, which is exactly the corpus-dependent-magnitude trap the reranker was built to escape. One pool composes with every existing gate unchanged. |
+| F3 | **Entry identity = `<source>/<path>`; ledger reads legacy bare paths as `default/<path>`** | Stable across federation; single-KB history survives with a read-shim, no data migration. |
+| F4 | **Exactly one `writable: true` source; curator + retirement target it; validated at startup** | One write path keeps curation the load-bearing gate; per-rule routing is YAGNI. |
+| F5 | **Decayed read-only entries are suppressed by the outcome gate (already per-instance), never by PR** | Retirement pass filters to the writable source; the recall decay floor needs no write access — this is where per-KB-scoped outcome identity earns its keep. |
+| F6 | **Same-fingerprint cross-KB duplicate: index the writable KB's copy, skip others (log it)** | Deterministic winner when an org forks a vendor runbook; margin-gate self-suppression between near-identical entries is avoided. |
+
+## 3. Config shape (F1)
+
+```yaml
+catalog:
+  sources:
+    - name: team            # required, unique, [a-z0-9-], stable — becomes the ID prefix
+      git: {url: ..., branch: main, interval: 5m, token_env: TEAM_KB_TOKEN}
+      writable: true        # exactly one source; curation + retirement PRs go here
+    - name: org
+      git: {url: ..., token_env: ORG_KB_TOKEN}
+    - name: vendor-ingress
+      dir: /var/lib/runlore/bundles/ingress   # mounted read-only bundle
+      weight: 0.9           # optional retrieval-score multiplier, default 1.0
+  instant_recall: {...}     # unchanged, instance-wide
+```
+
+- `sources` and the legacy `dir`/`git` keys are mutually exclusive (config error).
+- Legacy keys ⇒ one implicit source `{name: default, writable: true}` — the whole
+  federation machinery runs with N=1 and is behaviorally identical (§8).
+- `weight` applies to the retrieval score (BM25 or cosine) BEFORE ranking/fusion;
+  it never touches the fire gates' thresholds (a weighted-down entry can still fire
+  if it wins the pool). Alternative considered — per-source confidence caps:
+  rejected, overlaps with outcome decay's job.
+- Deliberately absent (YAGNI until asked): per-source namespace eligibility
+  scoping, per-source recall thresholds, >1 writable source.
+
+## 4. Recall semantics (F2)
+
+One merged pool: `Load` walks every source into a single entry slice (each entry
+stamped `Source`), one bleve index, one vector slice. `SearchScored`/`SearchHybrid`
+are unchanged except the per-source weight multiplication at scoring time. All
+existing gates — structural agreement, reranker/margin, outcome decay (per
+namespaced ID), N3 runner-up fallback, N6 status/age — apply unchanged, which is
+the point: federation adds a dimension to *retrieval*, not new gate logic.
+
+Shadowing emerges from the loop, not from static tiers: if a team entry and an org
+entry both agree structurally, the one with the better track record survives the
+outcome gate; static tier precedence (alternative considered) would freeze that
+judgment at config time and required a cross-KB fingerprint contract we don't have.
+The ONE static rule is F6: byte-identical intent (same `fingerprint` frontmatter)
+indexes only the writable copy.
+
+## 5. Outcome & feedback identity (F3) — the critical seam
+
+- `catalog.Entry` gains `Source string`; `Entry.ID() = Source + "/" + Path`.
+- Every ledger consumer switches from `Path` to `ID()`: the recall gate's
+  `counts[e.Path]` lookup, open-event stamping, feedback attribution, retirement
+  candidacy, kbmcp result identity.
+- Ledger load shims legacy events: a bare `entry` (no `/`-prefixed known source —
+  disambiguated by a one-time check against configured source names) is read as
+  `default/<path>`. New events are always written namespaced. Single-KB users who
+  later federate keep their entire trust history (their source IS `default`).
+- Feedback (👍/👎) and N5 confirms attribute through `byTrigger` exactly as today —
+  the credited value is now the namespaced ID. No schema change beyond the string's
+  content; checkpoint/compaction untouched.
+
+## 6. Write path (F4) and retirement on read-only KBs (F5)
+
+- `Curator.Forge` and `Retirement.Forge` stay single-valued, bound to the writable
+  source's repo. Config validation: `sources` requires exactly one `writable: true`
+  (the implicit `default` is writable).
+- Retirement candidacy filters `OpenCounts` to `writable-source/` IDs. A decayed
+  vendor entry gets no PR — and needs none: the outcome gate already rejects it at
+  recall time on this instance, scoped to this instance's ledger. Surface it
+  (`kb_readonly_entry_decayed` log + metric) so the operator can report upstream.
+- N6 read-side staleness (`status: retired`, age step-down) applies to every source
+  as-is — a vendor bundle that ships `status: retired` is honored with zero code.
+
+## 7. Index, memory, reload (interacts with N2)
+
+- **One merged index** (F2). Per-source `Syncer`s (git sources) and static dirs each
+  own a local mirror dir; any source's HEAD move (or startup) triggers ONE merged
+  rebuild, debounced (e.g. 10s) so simultaneous syncs coalesce.
+- The N2 content-hash vector cache makes merged rebuilds cheap: a change in one
+  source re-embeds only that source's changed entries — the cache is keyed by entry
+  text, source-agnostic, and survives federation unchanged.
+- Memory is the same corpus total as today (no duplication); `Ready()` stays
+  all-or-nothing on the first successful merged build, per-source failures degrade
+  to "index what loaded" with the existing skip/warn pattern (one bad bundle never
+  empties the catalog).
+
+## 8. Migration & compatibility
+
+- Single-KB configs: byte-identical behavior, no config edit, ledger read-shim
+  covers history. The only observable change is namespaced entry IDs in NEW ledger
+  events and logs.
+- `lore kb` / kbmcp: results gain a `source` field (additive).
+- Rollback: turning federation off (back to legacy keys) keeps `default/` history;
+  non-default sources' ledger history becomes inert (correct — those entries are
+  gone from the index).
+
+## 9. When NOT to build this
+
+Do not build on speculation. Triggers (any one):
+1. A real multi-team adopter asks for org/team layering (issue/discussion, not a
+   hypothetical).
+2. A vendor/community OKF bundle worth consuming read-only actually exists.
+3. The maintainer's own deployment needs a second KB.
+
+Until then this spec is a parking orbit: the identity work (§5) is the only part
+worth doing early IF the ledger is being touched for other reasons, because the
+legacy-path shim gets harder the longer bare paths accumulate. Counter-argument to
+building early: N=1 federation is pure added complexity in the hottest, most
+safety-critical path (recall). Single-maintainer scope says wait.
+
+## 10. Phased breakdown (for later plan-writing)
+
+- **P1 — identity groundwork** (shippable dark): `Entry.Source` + `ID()`,
+  namespaced ledger keys + legacy read-shim, `catalog.sources` parsing/validation
+  (exactly-one-writable, unique names, mutual exclusion with legacy keys), merged
+  load from N static dirs. Single-source behavior proven byte-identical by test.
+- **P2 — git federation**: per-source Syncers, debounced merged reload, per-source
+  sync metrics/logs, per-source auth.
+- **P3 — loop polish**: `weight` in scoring, F6 fingerprint dedup at index time,
+  retirement source-filter + readonly-decay surfacing, kbmcp `source` field, docs.
+
+## 11. Open questions for the maintainer
+
+1. Default `weight` for read-only/vendor sources — 1.0 (neutral, recommended) or a
+   built-in haircut (e.g. 0.9) reflecting "not our incidents"?
+2. F6 dedup: writable-copy-wins is deterministic — but should a NEWER vendor copy
+   ever win (upstream fixed their runbook)? Recommended: no; the org copy was a
+   deliberate fork, surface a "vendor copy changed" log instead.
+3. Should a 👎 on a vendor entry be visible upstream somehow (issue template link in
+   the notification)? Out of scope here; noting the ask.
+4. Per-source namespace eligibility (`sources[].namespaces:` — a team KB only
+   eligible for its namespaces): defer to demand, or is this actually the FIRST
+   thing a multi-team org asks for? If the latter, it belongs in P1's config shape
+   as a reserved key.
+5. Bound on N (source count)? Recommended: soft-cap 8 with a startup warning;
+   merged-index memory is the real limit, not the loop.


### PR DESCRIPTION
## Summary

Docs only. Adds the audit roadmap's **Later horizon** working docs and marks N1-N9 shipped (#328-#336) in `dev/plans/2026-07-19-audit-roadmap.md`.

| # | Doc | Kind |
|---|---|---|
| L1 | `dev/superpowers/plans/2026-07-20-templated-webhook-source.md` | plan — config-only vendor alert ingestion (dot-path extractor, per-instance auth ladder, Grafana/Datadog examples) |
| L2 | `dev/superpowers/plans/2026-07-20-templated-notifier-registry.md` | plan — exported `notify.Payload` + self-registering templated notifier (Teams example) |
| L3 | `dev/superpowers/specs/2026-07-20-multi-kb-federation-design.md` | **design only** — merged index + per-source weights, `<source>/<path>` ledger identity, single writable KB; open questions for the maintainer; not scheduled for execution |
| L4 | `dev/superpowers/plans/2026-07-20-persisted-vectors-incremental-index.md` | plan — gob vector cache with model/dim invalidation, SyncDelta-driven incremental bleve updates |
| L5 | `dev/superpowers/plans/2026-07-20-hotpath-benchmarks.md` | plan — hermetic benchmarks; deliberately NOT in the PR gate |

## Erratum recorded

The audit's "unify Slack/Matrix into the notify registry" item was based on a stale reading: construction is already registry-based (`init()` self-registration); the typed-config vs `Extra`-map split is deliberate. L2's plan pins the unified behavior with a round-trip test instead of performing a pointless migration.

All referenced symbols were verified against current main by the plan authors. Execution: L1/L2/L4/L5 run as four parallel worktree PRs after this merges; L3 awaits maintainer answers.