### PR TITLE
test(bench): hot-path regression benchmarks

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -126,3 +126,20 @@ grading → aggregation → report writing with no API key and no network. Run i
 ```bash
 go test ./internal/app/ -run TestRunEvalCompareOffline
 ```
+
+## Go micro-benchmarks (hot paths)
+
+Hermetic `testing.B` benchmarks guard the hot paths the 2026-07-19 audit named:
+no network, deterministic fixtures, safe to run anywhere. They are deliberately
+NOT part of the CI gate (numbers on shared runners are noise); run them locally
+when touching these packages and compare against your own baseline:
+
+    go test ./internal/whatchanged/ -bench BenchmarkRemote -benchtime 5x -run '^$'
+    go test ./internal/catalog/     -bench Benchmark       -benchtime 5x -run '^$'
+    go test ./internal/outcome/     -bench BenchmarkLedger -benchtime 5x -run '^$'
+    go test ./internal/trigger/ ./internal/coalesce/ -bench . -benchtime 5x -run '^$'
+
+What each guards: clone-vs-mirror (`whatchanged`), BM25 rebuild and cold-vs-warm
+embed cache + BM25/hybrid query cost (`catalog`), cold-start replay, one
+compaction cycle, and the O(1) OpenCounts read (`outcome`), and per-alert
+admission under storm (`trigger`, `coalesce`).

--- a/internal/catalog/catalog_bench_test.go
+++ b/internal/catalog/catalog_bench_test.go
@@ -142,3 +142,32 @@ func BenchmarkReloadEmbedWarmCache(b *testing.B) {
 		}
 	}
 }
+
+// benchQuery mimics an enriched recall query (symptom + namespace + workload +
+// alertname vocabulary) against the fixture corpus.
+const benchQuery = "svc-42 rollout failure probe timeout ns-2 deployment"
+
+// BenchmarkSearchScored guards the BM25 recall lookup — the per-incident hot
+// path when hybrid is off.
+func BenchmarkSearchScored(b *testing.B) {
+	c := warmCatalog(b, writeBenchCorpus(b, benchCorpusSize), false)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.SearchScored(benchQuery, 20); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSearchHybrid guards the hybrid recall lookup: query embed + BM25 +
+// the brute-force cosine scan over the whole corpus (audit perf finding #3 —
+// this is the O(n) path that caps KB size until an ANN lands).
+func BenchmarkSearchHybrid(b *testing.B) {
+	c := warmCatalog(b, writeBenchCorpus(b, benchCorpusSize), true)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.SearchHybrid(context.Background(), benchQuery, 20); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/catalog/catalog_bench_test.go
+++ b/internal/catalog/catalog_bench_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Hermetic hot-path benchmarks for the catalog (audit 2026-07-19, roadmap Later
+// wave). Fixtures are ~200 synthetic OKF entries. Run with:
+//
+//	go test ./internal/catalog/ -bench Benchmark -benchtime 5x -run '^$'
+
+const benchCorpusSize = 200
+
+// writeBenchCorpus writes n deterministic OKF entries and returns the dir.
+// Each entry shares common vocabulary ("failure", "rollout") and carries unique
+// tokens (svc-i, ns-i%10) so BM25 and the bag-of-words vectors both discriminate.
+func writeBenchCorpus(tb testing.TB, n int) string {
+	tb.Helper()
+	dir := tb.TempDir()
+	for i := 0; i < n; i++ {
+		body := fmt.Sprintf(`---
+type: Incident
+title: svc-%d rollout failure in ns-%d
+description: HelmRelease svc-%d upgrade failed with probe timeouts
+resource: ns-%d/deployment/svc-%d
+tags: [rollout, svc-%d]
+---
+The svc-%d deployment in ns-%d failed its rollout: readiness probes timed out
+after the config change. Resolution: revert the values change and reconcile.
+`, i, i%10, i, i%10, i, i, i, i%10)
+		p := filepath.Join(dir, fmt.Sprintf("entry-%03d.md", i))
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// benchEmbedder is a minimal deterministic bag-of-words embedder (fnv token
+// buckets, L2-normalized). Replicates the shape of the eval's embedder; kept
+// local because that one is unexported test code in another package.
+type benchEmbedder struct{}
+
+func (benchEmbedder) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	const dims = 256
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v := make([]float32, dims)
+		start := -1
+		for j := 0; j <= len(t); j++ {
+			if j < len(t) && (t[j] >= 'a' && t[j] <= 'z' || t[j] >= '0' && t[j] <= '9') {
+				if start < 0 {
+					start = j
+				}
+				continue
+			}
+			if start >= 0 {
+				h := fnv.New32a()
+				_, _ = h.Write([]byte(t[start:j]))
+				v[h.Sum32()%dims]++
+				start = -1
+			}
+		}
+		var norm float64
+		for _, x := range v {
+			norm += float64(x) * float64(x)
+		}
+		if norm > 0 {
+			n := float32(math.Sqrt(norm))
+			for k := range v {
+				v[k] /= n
+			}
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+// warmCatalog returns a loaded catalog over dir; hybrid additionally wires the
+// deterministic embedder and builds vectors.
+func warmCatalog(tb testing.TB, dir string, hybrid bool) *Catalog {
+	tb.Helper()
+	c := NewEmpty()
+	if hybrid {
+		c.SetEmbedder(benchEmbedder{})
+	}
+	if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+		tb.Fatal(err)
+	}
+	if hybrid && !c.HasVectors() {
+		tb.Fatal("bench: vectors not built")
+	}
+	return c
+}
+
+// BenchmarkReloadBM25 guards the cost of a full BM25 index rebuild — the price
+// paid on every KB HEAD move regardless of embeddings.
+func BenchmarkReloadBM25(b *testing.B) {
+	dir := writeBenchCorpus(b, benchCorpusSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := NewEmpty()
+		if _, err := c.Reload(dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkReloadEmbedColdCache guards the worst-case reload: index rebuild plus
+// embedding the ENTIRE corpus with an empty vector cache (first boot, cache loss).
+func BenchmarkReloadEmbedColdCache(b *testing.B) {
+	dir := writeBenchCorpus(b, benchCorpusSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := NewEmpty()
+		c.SetEmbedder(benchEmbedder{})
+		if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkReloadEmbedWarmCache guards the steady-state reload after PR #328:
+// unchanged entries must hit the content-hash cache, so a warm reload should sit
+// close to BenchmarkReloadBM25, far below the cold-cache cost. A collapse of this
+// gap means the cache regressed.
+func BenchmarkReloadEmbedWarmCache(b *testing.B) {
+	dir := writeBenchCorpus(b, benchCorpusSize)
+	c := warmCatalog(b, dir, true) // warm the vecCache once, unmeasured
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.ReloadContext(context.Background(), dir); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/coalesce/coalescer_bench_test.go
+++ b/internal/coalesce/coalescer_bench_test.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package coalesce
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/investigate"
+)
+
+// BenchmarkCoalescerAdd guards per-alert admission cost at the coalescer: key
+// derivation + batch bookkeeping under the mutex, across 1000 live correlation
+// keys. Debounce is far in the future so nothing flushes mid-measurement.
+// Run: go test ./internal/coalesce/ -bench . -benchtime 5x -run '^$'
+func BenchmarkCoalescerAdd(b *testing.B) {
+	c := New(Config{Debounce: time.Hour, MaxWait: 2 * time.Hour, MaxBatch: 1 << 20},
+		func([]investigate.Request) {})
+	reqs := make([]investigate.Request, 1000)
+	at := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range reqs {
+		reqs[i] = investigate.Request{
+			Title:       fmt.Sprintf("HighErrorRate-%d", i),
+			Message:     "error budget burn",
+			Labels:      map[string]string{"namespace": fmt.Sprintf("ns-%d", i)},
+			GroupKey:    fmt.Sprintf("group-%d", i),
+			Fingerprint: fmt.Sprintf("fp-%d", i),
+			At:          at,
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Add(reqs[i%len(reqs)])
+	}
+}

--- a/internal/outcome/ledger_bench_test.go
+++ b/internal/outcome/ledger_bench_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package outcome
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Hermetic ledger benchmarks (audit 2026-07-19, roadmap Later wave). The fixture
+// is a 10k-event JSONL written directly (no fsync-per-append), the same shape
+// ledger_test.go builds for corruption tests. Run with:
+//
+//	go test ./internal/outcome/ -bench BenchmarkLedger -benchtime 5x -run '^$'
+
+const benchEventPairs = 5000 // 5000 open + 5000 resolve = 10k events
+
+// writeBenchLedger writes nPairs open("recall")/resolve pairs across 50 entries
+// and returns the file path. Deterministic timestamps; resolves always after
+// their opens so pairing takes the fast path.
+func writeBenchLedger(tb testing.TB, nPairs int) string {
+	tb.Helper()
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var buf bytes.Buffer
+	for i := 0; i < nPairs; i++ {
+		fp := fmt.Sprintf("fp-%d", i)
+		open, err := json.Marshal(Event{
+			Event: "open", Fingerprint: fp, Kind: "recall",
+			Entry: fmt.Sprintf("entry-%02d.md", i%50),
+			At:    t0.Add(time.Duration(i) * time.Minute),
+		})
+		if err != nil {
+			tb.Fatal(err)
+		}
+		res, err := json.Marshal(Event{
+			Event: "resolve", Fingerprint: fp,
+			At: t0.Add(time.Duration(i)*time.Minute + 30*time.Second),
+		})
+		if err != nil {
+			tb.Fatal(err)
+		}
+		buf.Write(open)
+		buf.WriteByte('\n')
+		buf.Write(res)
+		buf.WriteByte('\n')
+	}
+	p := filepath.Join(tb.TempDir(), "ledger.jsonl")
+	if err := os.WriteFile(p, buf.Bytes(), 0o600); err != nil {
+		tb.Fatal(err)
+	}
+	return p
+}
+
+// BenchmarkLedgerReplay guards cold-start replay cost of a 10k-event file with
+// compaction disabled — the "6-month-old ledger with max_events: 0" audit case.
+func BenchmarkLedgerReplay(b *testing.B) {
+	p := writeBenchLedger(b, benchEventPairs)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := NewWithMaxEvents(p, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLedgerCompactedLoad guards one replay+compaction cycle: loading 10k
+// events over a 1k bound rewrites the file with a checkpoint. Each iteration
+// copies the fixture to a fresh path (compaction mutates it), unmeasured.
+func BenchmarkLedgerCompactedLoad(b *testing.B) {
+	src := writeBenchLedger(b, benchEventPairs)
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		b.Fatal(err)
+	}
+	dir := b.TempDir()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		p := filepath.Join(dir, fmt.Sprintf("ledger-%d.jsonl", i))
+		if err := os.WriteFile(p, raw, 0o600); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+		if _, err := NewWithMaxEvents(p, 1000); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkLedgerOpenCounts guards the recall hot-path read: OpenCounts must
+// stay an O(entries) copy of the incrementally-maintained aggregate, never a
+// file re-read (the audit confirmed this design — this pins it).
+func BenchmarkLedgerOpenCounts(b *testing.B) {
+	l, err := NewWithMaxEvents(writeBenchLedger(b, benchEventPairs), 0)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := l.OpenCounts(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/trigger/dedup_bench_test.go
+++ b/internal/trigger/dedup_bench_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package trigger
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// BenchmarkDeduperSeenStorm guards the ingest chokepoint under an alert storm
+// with many DISTINCT fingerprints: Seen currently evicts by scanning the whole
+// map under the mutex on every call (audit perf finding — demoted, but pinned
+// here so a regression, or the eventual amortized-sweep fix, is visible).
+// Run: go test ./internal/trigger/ -bench . -benchtime 5x -run '^$'
+func BenchmarkDeduperSeenStorm(b *testing.B) {
+	d := NewDeduper(10 * time.Minute)
+	keys := make([]string, 5000)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("fp-%d", i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d.Seen(keys[i%len(keys)])
+	}
+}


### PR DESCRIPTION
## What

Adds `testing.B` regression guardrails for the four hot paths the 2026-07-19
architecture audit named. Before this the repo had only the two clone-strategy
benchmarks in `internal/whatchanged/differ_bench_test.go` (#332).

All benchmarks are **hermetic**: no network, fixtures under `b.TempDir()` /
in-memory, deterministic inputs, `b.ResetTimer()` after setup. Each carries a
doc comment naming the regression it guards, mirroring the established
`differ_bench_test.go` style (SPDX line 1, package-level run command).

## What each benchmark guards

| Benchmark | Package | Guards |
|---|---|---|
| `BenchmarkReloadBM25` | `catalog` | Full BM25 index rebuild on every KB HEAD move |
| `BenchmarkReloadEmbedColdCache` | `catalog` | Worst-case reload: rebuild + embed the whole corpus, empty vector cache (first boot / cache loss) |
| `BenchmarkReloadEmbedWarmCache` | `catalog` | Steady-state reload — the **#328 content-hash cache win**; unchanged entries must hit the cache instead of re-embedding |
| `BenchmarkSearchScored` | `catalog` | BM25 recall lookup (hybrid off) |
| `BenchmarkSearchHybrid` | `catalog` | Hybrid recall: query embed + BM25 + the **O(n) brute-force cosine scan** over the whole corpus (audit perf finding #3 — caps KB size until an ANN lands) |
| `BenchmarkLedgerReplay` | `outcome` | Cold-start replay of a 10k-event ledger with compaction disabled (the "6-month-old ledger, `max_events: 0`" case) |
| `BenchmarkLedgerCompactedLoad` | `outcome` | One replay+compaction cycle (10k events over a 1k bound → checkpoint rewrite) |
| `BenchmarkLedgerOpenCounts` | `outcome` | The recall hot-path read stays an O(entries) aggregate copy, never a file re-read |
| `BenchmarkDeduperSeenStorm` | `trigger` | Ingest chokepoint under an alert storm of distinct fingerprints (`Seen` scans the whole map under the mutex per call) |
| `BenchmarkCoalescerAdd` | `coalesce` | Per-alert admission cost: key derivation + batch bookkeeping under the mutex, across 1000 live correlation keys |

## Numbers (12th Gen i9-12900HK, `-benchtime=1x`)

```
catalog  BenchmarkReloadBM25              67327473 ns/op
catalog  BenchmarkReloadEmbedColdCache    51800451 ns/op
catalog  BenchmarkReloadEmbedWarmCache    45976382 ns/op
catalog  BenchmarkSearchScored              715986 ns/op
catalog  BenchmarkSearchHybrid              660644 ns/op
outcome  BenchmarkLedgerReplay            17056734 ns/op
outcome  BenchmarkLedgerCompactedLoad     21808550 ns/op
outcome  BenchmarkLedgerOpenCounts            3063 ns/op
trigger  BenchmarkDeduperSeenStorm            1080 ns/op
coalesce BenchmarkCoalescerAdd                3213 ns/op
```

Sanity ordering holds: `OpenCounts` (~3µs) sits ~4 orders of magnitude below
`Replay` (~17ms), confirming the O(1)-read design; hybrid search adds the query
embed + cosine scan on top of the BM25 lookup. Note the fnv stub embedder is
near-free versus markdown-parse + BM25 indexing, so the warm/cold reload gap is
modest on this fixture — with a real (network) embedder the gap the cache saves
is what the benchmark is set up to expose.

## Why CI stays untouched

No benchmark enters the gate. Benchmark numbers on shared CI runners are noise,
and neither existing nightly workflow fits: `eval.yaml` is an API-key-gated LLM
eval and `ci.yaml` is the PR gate — adding a bench job to either needs new
machinery for no signal (YAGNI). Instead `docs/benchmarking.md` gains a
**"Go micro-benchmarks (hot paths)"** section with local run instructions and a
one-line map of what each guards, so contributors run them against their own
baseline when touching these packages.

## Verification

`go build`, `go vet`, `go test ./...`, `gofmt -l .` (empty), `golangci-lint run`
(`0 issues.`), and `go test -race` on all four touched packages — all green.

Plan: `dev/superpowers/plans/2026-07-20-hotpath-benchmarks.md` (roadmap L5).
