### PR TITLE
feat(notify): config-only templated notifier

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -347,6 +347,41 @@ attributes nothing). Startup fails loud unless `homeserver`/`room_id`/`access_to
 `outcome.ledger_path` are set. Use an **invite-only room** — any room member can vote (see
 [security-model.md](security-model.md#the-feedback-channels--exposure--trust-model)).
 
+### Generic templated notifier (`notify.templated`)
+
+Deliver findings to **any** webhook-speaking service — Microsoft Teams, Discord,
+ntfy, incident.io — with one config block and no Go. Each instance renders a Go
+`text/template` over the delivery payload (the same fields the `notify.webhook`
+JSON carries) and POSTs it. Findings are secret-redacted **before** any notifier
+runs, so templates only ever see redacted data. A template that fails to parse
+refuses startup; a template that fails at delivery time is logged and skipped
+without blocking other channels. Rendered bodies are capped at 256 KiB.
+
+Worked example — Microsoft Teams (Incoming Webhook / MessageCard):
+
+    notify:
+      templated:
+        - name: teams
+          url_env: RUNLORE_TEAMS_WEBHOOK_URL
+          template: |
+            {
+              "@type": "MessageCard", "@context": "https://schema.org/extensions",
+              "summary": {{ toJSON .Title }},
+              "themeColor": "d63333",
+              "title": {{ toJSON (printf "[%s] %s (%.0f%%)" .Verdict .Title (mulPct .Confidence)) }},
+              "text": {{ toJSON .Text }}
+            }
+
+Template functions: `toJSON` (escaping-correct JSON splicing — always use it for
+values inside JSON bodies) and `mulPct` (×100 for percent display).
+
+**Two config surfaces, one registry.** Built-in notifiers (`notify.slack`,
+`notify.matrix`) use typed config blocks with startup validation; drop-in
+notifiers (`notify.webhook`, `notify.templated`) live under the same `notify:`
+key as self-describing blocks. Both build through the same registry — the split
+is deliberate: type-checked config for the built-ins, zero-code extensibility
+for everything else.
+
 ### `server` — the HTTP listener
 Only `webhook_token_env` (the bearer token for the incident webhook). The listen address is the
 `--addr` CLI flag (`:8080` in the chart), **not** a config key. TLS is terminated externally

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -25,7 +25,8 @@ import (
 	fluxexec "github.com/Smana/runlore/internal/executor/flux"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logging"
-	_ "github.com/Smana/runlore/internal/notify/webhook" // self-registers the generic outgoing-webhook notifier
+	_ "github.com/Smana/runlore/internal/notify/templated" // self-registers the templated notifier
+	_ "github.com/Smana/runlore/internal/notify/webhook"   // self-registers the generic outgoing-webhook notifier
 	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/ratelimit"

--- a/internal/notify/payload.go
+++ b/internal/notify/payload.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Payload is the exported delivery payload: the single definition of what an
+// outbound notification carries. The webhook notifier marshals it as-is; the
+// templated notifier exposes it as the template dot. Field set and json tags
+// are the webhook notifier's original wire format — do not change tags without
+// a compatibility note, external consumers parse them.
+type Payload struct {
+	Title            string          `json:"title"`
+	Confidence       float64         `json:"confidence"`
+	Namespace        string          `json:"namespace,omitempty"`
+	Resource         string          `json:"resource,omitempty"`
+	CuratedURL       string          `json:"curated_url,omitempty"`
+	Text             string          `json:"text"`
+	Verdict          string          `json:"verdict,omitempty"`
+	Severity         string          `json:"severity,omitempty"`
+	Cluster          string          `json:"cluster,omitempty"`
+	Environment      string          `json:"environment,omitempty"`
+	Tenant           string          `json:"tenant,omitempty"`
+	AlertName        string          `json:"alert_name,omitempty"`
+	StartedAt        string          `json:"started_at,omitempty"` // RFC3339; "" when unknown
+	Occurrences      int             `json:"occurrences,omitempty"`
+	PrevCuratedURL   string          `json:"prev_curated_url,omitempty"`
+	RuledOut         []string        `json:"ruled_out,omitempty"`
+	DataGaps         []string        `json:"data_gaps,omitempty"`
+	Prior            *PriorPayload   `json:"prior,omitempty"`
+	MatchedKnowledge *MatchedPayload `json:"matched_knowledge,omitempty"`
+}
+
+// MatchedPayload mirrors providers.MatchedEntry for delivery consumers: the
+// pre-existing KB entry this investigation's kb_search matched at clear-match
+// strength (distinct from prior, which reports recurrence).
+type MatchedPayload struct {
+	Path  string  `json:"path,omitempty"`
+	Title string  `json:"title,omitempty"`
+	URL   string  `json:"url,omitempty"`
+	Score float64 `json:"score,omitempty"`
+}
+
+// PriorPayload mirrors providers.PriorKnowledge for delivery consumers: what the
+// merged KB entry said last time this incident fired.
+type PriorPayload struct {
+	Cause      string `json:"cause,omitempty"`
+	Resolution string `json:"resolution,omitempty"`
+	EntryPath  string `json:"entry_path,omitempty"`
+	Recalls    int    `json:"recalls,omitempty"`
+	Resolved   int    `json:"resolved,omitempty"`
+}
+
+// NewPayload maps an (already-redacted) Investigation to the delivery payload.
+// Matched knowledge is surfaced only when Prior is nil so the structured field
+// never disagrees with the rendered Text (Prior already covers "seen before").
+func NewPayload(inv providers.Investigation) Payload {
+	startedAt := ""
+	if !inv.StartedAt.IsZero() {
+		startedAt = inv.StartedAt.UTC().Format(time.RFC3339)
+	}
+	var prior *PriorPayload
+	if p := inv.Prior; p != nil {
+		prior = &PriorPayload{Cause: p.Cause, Resolution: p.Resolution, EntryPath: p.EntryPath, Recalls: p.Recalls, Resolved: p.Resolved}
+	}
+	var matched *MatchedPayload
+	if mk := inv.MatchedKnowledge; mk != nil && inv.Prior == nil {
+		matched = &MatchedPayload{Path: mk.Path, Title: mk.Title, URL: mk.URL, Score: mk.Score}
+	}
+	return Payload{
+		Title: inv.Title, Confidence: inv.Confidence,
+		Namespace: inv.Resource.Namespace, Resource: inv.Resource.Name,
+		CuratedURL: inv.CuratedURL, Text: Format(inv), Verdict: string(inv.Verdict),
+		Severity: inv.Severity, Cluster: inv.Cluster, Environment: inv.Environment,
+		Tenant: inv.Tenant, AlertName: inv.AlertName, StartedAt: startedAt,
+		Occurrences: inv.Occurrences, PrevCuratedURL: inv.PrevCuratedURL,
+		RuledOut: inv.RuledOut, DataGaps: inv.DataGaps,
+		Prior: prior, MatchedKnowledge: matched,
+	}
+}

--- a/internal/notify/payload_test.go
+++ b/internal/notify/payload_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestNewPayloadMapping(t *testing.T) {
+	inv := providers.Investigation{
+		Title:            "CrashLoopBackOff payments",
+		Confidence:       0.72,
+		Resource:         providers.Workload{Namespace: "payments", Name: "api"},
+		Verdict:          providers.VerdictActionSuggested,
+		StartedAt:        time.Date(2026, 7, 20, 10, 0, 0, 0, time.UTC),
+		Prior:            &providers.PriorKnowledge{Cause: "bad rollout", Resolution: "rollback", EntryPath: "e.md", Recalls: 3, Resolved: 2},
+		MatchedKnowledge: &providers.MatchedEntry{Path: "m.md", Title: "seen", URL: "u", Score: 0.9},
+	}
+	p := NewPayload(inv)
+	if p.Title != inv.Title || p.Namespace != "payments" || p.Resource != "api" {
+		t.Errorf("identity fields: %+v", p)
+	}
+	if p.StartedAt != "2026-07-20T10:00:00Z" {
+		t.Errorf("StartedAt = %q, want RFC3339", p.StartedAt)
+	}
+	if p.Prior == nil || p.Prior.Cause != "bad rollout" || p.Prior.Recalls != 3 {
+		t.Errorf("Prior = %+v", p.Prior)
+	}
+	// The shared Format-text guard: matched knowledge is suppressed when Prior is set,
+	// so the structured field never disagrees with the rendered text (webhook.go:98-104).
+	if p.MatchedKnowledge != nil {
+		t.Errorf("MatchedKnowledge must be nil when Prior != nil, got %+v", p.MatchedKnowledge)
+	}
+	if p.Text == "" {
+		t.Error("Text must carry Format(inv)")
+	}
+
+	inv.Prior = nil
+	if q := NewPayload(inv); q.MatchedKnowledge == nil || q.MatchedKnowledge.Path != "m.md" {
+		t.Errorf("MatchedKnowledge must surface when Prior == nil, got %+v", q.MatchedKnowledge)
+	}
+	if q := NewPayload(providers.Investigation{}); q.StartedAt != "" {
+		t.Errorf("zero StartedAt must render empty, got %q", q.StartedAt)
+	}
+}

--- a/internal/notify/registry_roundtrip_test.go
+++ b/internal/notify/registry_roundtrip_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/notify"
+	_ "github.com/Smana/runlore/internal/notify/templated" // self-register the templated notifier
+	_ "github.com/Smana/runlore/internal/notify/webhook"   // self-register the webhook notifier
+)
+
+// TestBuildEnabledRoundTripAllNotifiers pins the unified registry: every notifier
+// — the built-ins (notify.slack, notify.matrix) with their existing typed config
+// keys verbatim, and the drop-ins (notify.webhook, notify.templated) under the
+// inline Extra map — is constructed through the same BuildEnabled path from one
+// YAML document. It is the guarantee the unification can never silently regress.
+func TestBuildEnabledRoundTripAllNotifiers(t *testing.T) {
+	t.Setenv("RT_SLACK", "https://hooks.slack.example/x")
+	t.Setenv("RT_MATRIX_TOK", "syt_x")
+	t.Setenv("RT_WEBHOOK", "https://sink.example/w")
+	t.Setenv("RT_TEAMS", "https://teams.example/hook")
+	y := `
+notify:
+  slack:
+    webhook_url_env: RT_SLACK
+  matrix:
+    homeserver: https://m.example
+    room_id: "!r:m.example"
+    access_token_env: RT_MATRIX_TOK
+  webhook:
+    url_env: RT_WEBHOOK
+  templated:
+    - name: teams
+      url_env: RT_TEAMS
+      template: '{"text": {{ toJSON .Title }}}'
+`
+	var cfg config.Config
+	if err := yaml.Unmarshal([]byte(y), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	m, err := notify.BuildEnabled(notify.Deps{Cfg: &cfg, Log: slog.New(slog.DiscardHandler)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := m.Len(); got != 4 {
+		t.Errorf("BuildEnabled built %d notifiers, want 4 (slack, matrix, webhook, templated)", got)
+	}
+}

--- a/internal/notify/templated/templated.go
+++ b/internal/notify/templated/templated.go
@@ -9,9 +9,12 @@
 package templated
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"text/template"
@@ -23,6 +26,11 @@ import (
 	"github.com/Smana/runlore/internal/notify"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+// maxBody caps a rendered template. Oversize is an error, not a truncation —
+// a truncated JSON/XML body is garbage to the receiver; failing loudly beats
+// posting it.
+const maxBody = 256 << 10
 
 var funcs = template.FuncMap{
 	// toJSON is the escaping-correct way to splice a value into a JSON body.
@@ -57,11 +65,45 @@ type Notifier struct {
 
 var _ providers.Notifier = (*Notifier)(nil)
 
-// Deliver is filled in by the delivery step (render, cap, POST). It is declared
-// here so *Notifier satisfies providers.Notifier and the notifier can
-// self-register at parse time.
-func (n *Notifier) Deliver(context.Context, providers.Investigation) error {
-	return fmt.Errorf("templated: delivery not implemented")
+// Deliver renders and POSTs every enabled instance; a failing instance is
+// reported but never blocks its siblings (errors are joined, mirroring
+// notify.Multi one level down).
+func (n *Notifier) Deliver(ctx context.Context, inv providers.Investigation) error {
+	p := notify.NewPayload(inv)
+	var errs []error
+	for _, in := range n.instances {
+		if err := n.deliverOne(ctx, in, p); err != nil {
+			errs = append(errs, fmt.Errorf("templated %q: %w", in.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (n *Notifier) deliverOne(ctx context.Context, in instance, p notify.Payload) error {
+	var buf bytes.Buffer
+	if err := in.tmpl.Execute(&buf, p); err != nil {
+		return fmt.Errorf("execute template: %w", err)
+	}
+	if buf.Len() > maxBody {
+		return fmt.Errorf("rendered body %d bytes exceeds cap %d", buf.Len(), maxBody)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, in.url, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", in.contentType)
+	if in.token != "" {
+		req.Header.Set("Authorization", "Bearer "+in.token)
+	}
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+	return nil
 }
 
 // build decodes and validates the notify.templated block. Schema/template

--- a/internal/notify/templated/templated.go
+++ b/internal/notify/templated/templated.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package templated is a config-only generic notifier: it renders a
+// user-supplied Go text/template over notify.Payload and POSTs the result to
+// any endpoint (Teams, Discord, ntfy, incident.io, …). One YAML block per
+// target — no Go, no rebuild. The Investigation is already secret-redacted
+// before any notifier runs (investigate.redactInvestigation), so templates
+// only ever see redacted data.
+package templated
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"text/template"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/notify"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+var funcs = template.FuncMap{
+	// toJSON is the escaping-correct way to splice a value into a JSON body.
+	"toJSON": func(v any) (string, error) {
+		b, err := json.Marshal(v)
+		return string(b), err
+	},
+	"mulPct": func(f float64) float64 { return f * 100 },
+}
+
+type instanceCfg struct {
+	Name        string `yaml:"name"`
+	URLEnv      string `yaml:"url_env"`
+	TokenEnv    string `yaml:"token_env"`
+	ContentType string `yaml:"content_type"`
+	Template    string `yaml:"template"`
+}
+
+type instance struct {
+	name        string
+	url         string
+	token       string
+	contentType string
+	tmpl        *template.Template
+}
+
+// Notifier fans one delivery out to every configured template instance.
+type Notifier struct {
+	instances []instance
+	client    *http.Client
+}
+
+var _ providers.Notifier = (*Notifier)(nil)
+
+// Deliver is filled in by the delivery step (render, cap, POST). It is declared
+// here so *Notifier satisfies providers.Notifier and the notifier can
+// self-register at parse time.
+func (n *Notifier) Deliver(context.Context, providers.Investigation) error {
+	return fmt.Errorf("templated: delivery not implemented")
+}
+
+// build decodes and validates the notify.templated block. Schema/template
+// errors are returned (⇒ BuildEnabled fails ⇒ serve refuses to start); an
+// instance whose url_env is unset is silently disabled (webhook parity).
+func build(node yaml.Node) (*Notifier, error) {
+	var cfgs []instanceCfg
+	if err := node.Decode(&cfgs); err != nil {
+		return nil, fmt.Errorf("templated: %w", err)
+	}
+	seen := map[string]bool{}
+	var ins []instance
+	for i, c := range cfgs {
+		if c.Name == "" || c.URLEnv == "" || c.Template == "" {
+			return nil, fmt.Errorf("templated[%d]: name, url_env and template are required", i)
+		}
+		if seen[c.Name] {
+			return nil, fmt.Errorf("templated: duplicate instance name %q", c.Name)
+		}
+		seen[c.Name] = true
+		tmpl, err := template.New(c.Name).Funcs(funcs).Parse(c.Template)
+		if err != nil {
+			return nil, fmt.Errorf("templated %q: parse template: %w", c.Name, err)
+		}
+		url := os.Getenv(c.URLEnv)
+		if url == "" {
+			continue // env unset ⇒ this instance is disabled
+		}
+		ct := c.ContentType
+		if ct == "" {
+			ct = "application/json"
+		}
+		token := ""
+		if c.TokenEnv != "" {
+			token = os.Getenv(c.TokenEnv)
+		}
+		ins = append(ins, instance{name: c.Name, url: url, token: token, contentType: ct, tmpl: tmpl})
+	}
+	if len(ins) == 0 {
+		return nil, nil // nothing enabled
+	}
+	return &Notifier{instances: ins, client: httpx.SecureClient(10 * time.Second)}, nil
+}
+
+func init() {
+	notify.Register(notify.Descriptor{
+		Name: "templated",
+		Build: func(d notify.Deps) (providers.Notifier, error) {
+			node, ok := d.Cfg.Notify.Extra["templated"]
+			if !ok {
+				return nil, nil
+			}
+			n, err := build(node)
+			if err != nil || n == nil {
+				return nil, err // typed-nil guard: never return (*Notifier)(nil) as a non-nil interface
+			}
+			return n, nil
+		},
+	})
+}

--- a/internal/notify/templated/templated_test.go
+++ b/internal/notify/templated/templated_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package templated
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func decodeExtra(t *testing.T, y string) yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(y), &n); err != nil {
+		t.Fatal(err)
+	}
+	return *n.Content[0] // unwrap the document node
+}
+
+func TestBuildParsesInstances(t *testing.T) {
+	t.Setenv("T_URL", "https://example.com/hook")
+	node := decodeExtra(t, `
+- name: teams
+  url_env: T_URL
+  template: '{"text": {{ toJSON .Title }}}'
+`)
+	n, err := build(node)
+	if err != nil || n == nil || len(n.instances) != 1 {
+		t.Fatalf("n=%+v err=%v", n, err)
+	}
+	if got := n.instances[0].contentType; got != "application/json" {
+		t.Errorf("default content_type = %q", got)
+	}
+}
+
+func TestBuildFailsClosedOnBadConfig(t *testing.T) {
+	t.Setenv("T_URL", "https://example.com/hook")
+	for name, y := range map[string]string{
+		"parse error":    "- {name: a, url_env: T_URL, template: '{{ .Title }'}",
+		"missing name":   "- {url_env: T_URL, template: ok}",
+		"missing url":    "- {name: a, template: ok}",
+		"missing tmpl":   "- {name: a, url_env: T_URL}",
+		"duplicate name": "- {name: a, url_env: T_URL, template: ok}\n- {name: a, url_env: T_URL, template: ok}",
+	} {
+		if _, err := build(decodeExtra(t, y)); err == nil {
+			t.Errorf("%s: want error, got nil", name)
+		}
+	}
+}
+
+func TestBuildDisablesInstanceOnUnsetEnv(t *testing.T) {
+	node := decodeExtra(t, "- {name: a, url_env: T_UNSET_NEVER, template: ok}")
+	n, err := build(node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != nil {
+		t.Errorf("all instances env-disabled ⇒ nil notifier, got %+v", n)
+	}
+}

--- a/internal/notify/templated/templated_test.go
+++ b/internal/notify/templated/templated_test.go
@@ -3,9 +3,16 @@
 package templated
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/providers"
 )
 
 func decodeExtra(t *testing.T, y string) yaml.Node {
@@ -56,5 +63,62 @@ func TestBuildDisablesInstanceOnUnsetEnv(t *testing.T) {
 	}
 	if n != nil {
 		t.Errorf("all instances env-disabled ⇒ nil notifier, got %+v", n)
+	}
+}
+
+func testNotifier(t *testing.T, tmplBody, url string) *Notifier {
+	t.Helper()
+	t.Setenv("T_URL", url)
+	n, err := build(decodeExtra(t, "- name: teams\n  url_env: T_URL\n  token_env: T_TOK\n  template: '"+tmplBody+"'"))
+	if err != nil || n == nil {
+		t.Fatalf("build: n=%v err=%v", n, err)
+	}
+	return n
+}
+
+func TestDeliverRendersAndPosts(t *testing.T) {
+	t.Setenv("T_TOK", "sekret")
+	var gotBody, gotCT, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody, gotCT, gotAuth = string(b), r.Header.Get("Content-Type"), r.Header.Get("Authorization")
+	}))
+	defer srv.Close()
+	n := testNotifier(t, `{"text": {{ toJSON .Title }}}`, srv.URL)
+	inv := providers.Investigation{Title: `quote " and \ slash`}
+	if err := n.Deliver(context.Background(), inv); err != nil {
+		t.Fatal(err)
+	}
+	if gotBody != `{"text": "quote \" and \\ slash"}` {
+		t.Errorf("body = %s", gotBody) // toJSON must escape — raw splice would be JSON injection
+	}
+	if gotCT != "application/json" || gotAuth != "Bearer sekret" {
+		t.Errorf("ct=%q auth=%q", gotCT, gotAuth)
+	}
+}
+
+func TestDeliverExecErrorFailsLoudWithoutPost(t *testing.T) {
+	posted := false
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { posted = true }))
+	defer srv.Close()
+	n := testNotifier(t, `{{ .NoSuchField }}`, srv.URL) // parses fine, fails at exec
+	if err := n.Deliver(context.Background(), providers.Investigation{Title: "x"}); err == nil {
+		t.Error("want exec error")
+	}
+	if posted {
+		t.Error("exec error must not POST")
+	}
+}
+
+func TestDeliverNon2xxAndSizeCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(500) }))
+	defer srv.Close()
+	if err := testNotifier(t, `ok`, srv.URL).Deliver(context.Background(), providers.Investigation{}); err == nil {
+		t.Error("want non-2xx error")
+	}
+	big := testNotifier(t, `{{ .Title }}`, srv.URL)
+	inv := providers.Investigation{Title: strings.Repeat("A", maxBody+1)}
+	if err := big.Deliver(context.Background(), inv); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("want size-cap error, got %v", err)
 	}
 }

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -42,87 +42,14 @@ func New(url string) *Notifier {
 
 var _ providers.Notifier = (*Notifier)(nil)
 
-// payload is the JSON body sent to the webhook endpoint.
-type payload struct {
-	Title            string          `json:"title"`
-	Confidence       float64         `json:"confidence"`
-	Namespace        string          `json:"namespace,omitempty"`
-	Resource         string          `json:"resource,omitempty"`
-	CuratedURL       string          `json:"curated_url,omitempty"`
-	Text             string          `json:"text"`
-	Verdict          string          `json:"verdict,omitempty"`
-	Severity         string          `json:"severity,omitempty"`
-	Cluster          string          `json:"cluster,omitempty"`
-	Environment      string          `json:"environment,omitempty"`
-	Tenant           string          `json:"tenant,omitempty"`
-	AlertName        string          `json:"alert_name,omitempty"`
-	StartedAt        string          `json:"started_at,omitempty"` // RFC3339; "" when unknown
-	Occurrences      int             `json:"occurrences,omitempty"`
-	PrevCuratedURL   string          `json:"prev_curated_url,omitempty"`
-	RuledOut         []string        `json:"ruled_out,omitempty"`
-	DataGaps         []string        `json:"data_gaps,omitempty"`
-	Prior            *priorPayload   `json:"prior,omitempty"`
-	MatchedKnowledge *matchedPayload `json:"matched_knowledge,omitempty"`
-}
-
-// matchedPayload mirrors providers.MatchedEntry for webhook consumers: the
-// pre-existing KB entry this investigation's kb_search matched at clear-match
-// strength (distinct from prior, which reports recurrence).
-type matchedPayload struct {
-	Path  string  `json:"path,omitempty"`
-	Title string  `json:"title,omitempty"`
-	URL   string  `json:"url,omitempty"`
-	Score float64 `json:"score,omitempty"`
-}
-
-// priorPayload mirrors providers.PriorKnowledge for webhook consumers: what the
-// merged KB entry said last time this incident fired.
-type priorPayload struct {
-	Cause      string `json:"cause,omitempty"`
-	Resolution string `json:"resolution,omitempty"`
-	EntryPath  string `json:"entry_path,omitempty"`
-	Recalls    int    `json:"recalls,omitempty"`
-	Resolved   int    `json:"resolved,omitempty"`
-}
+// payload aliases the exported notify.Payload so the delivery wire format has a
+// single definition (notify.Payload) while the webhook tests keep decoding into
+// the package-local name.
+type payload = notify.Payload
 
 // Deliver marshals the investigation to JSON and POSTs it to the configured URL.
 func (n *Notifier) Deliver(ctx context.Context, inv providers.Investigation) error {
-	startedAt := ""
-	if !inv.StartedAt.IsZero() {
-		startedAt = inv.StartedAt.UTC().Format(time.RFC3339)
-	}
-	var prior *priorPayload
-	if p := inv.Prior; p != nil {
-		prior = &priorPayload{Cause: p.Cause, Resolution: p.Resolution, EntryPath: p.EntryPath, Recalls: p.Recalls, Resolved: p.Resolved}
-	}
-	// Existing-KB match, mirroring the shared Format text's guard: surface it only when
-	// Prior is nil, so the structured field never disagrees with the payload's `text`
-	// (Prior/recurrence already covers the "seen before" case — don't double-signal).
-	var matched *matchedPayload
-	if mk := inv.MatchedKnowledge; mk != nil && inv.Prior == nil {
-		matched = &matchedPayload{Path: mk.Path, Title: mk.Title, URL: mk.URL, Score: mk.Score}
-	}
-	body, err := json.Marshal(payload{
-		Title:            inv.Title,
-		Confidence:       inv.Confidence,
-		Namespace:        inv.Resource.Namespace,
-		Resource:         inv.Resource.Name,
-		CuratedURL:       inv.CuratedURL,
-		Text:             notify.Format(inv),
-		Verdict:          string(inv.Verdict),
-		Severity:         inv.Severity,
-		Cluster:          inv.Cluster,
-		Environment:      inv.Environment,
-		Tenant:           inv.Tenant,
-		AlertName:        inv.AlertName,
-		StartedAt:        startedAt,
-		Occurrences:      inv.Occurrences,
-		PrevCuratedURL:   inv.PrevCuratedURL,
-		RuledOut:         inv.RuledOut,
-		DataGaps:         inv.DataGaps,
-		Prior:            prior,
-		MatchedKnowledge: matched,
-	})
+	body, err := json.Marshal(notify.NewPayload(inv))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What this unlocks

A **config-only generic templated notifier** (`notify.templated`): deliver findings to *any* webhook-speaking service — Microsoft Teams, Discord, ntfy, incident.io — by writing one YAML block with a Go `text/template` body. No Go, no rebuild, no `config.Config` change (instances live under the existing inline `notify.Extra` catch-all).

Worked example — Microsoft Teams (Incoming Webhook / MessageCard):

```yaml
notify:
  templated:
    - name: teams
      url_env: RUNLORE_TEAMS_WEBHOOK_URL
      template: |
        {
          "@type": "MessageCard", "@context": "https://schema.org/extensions",
          "summary": {{ toJSON .Title }},
          "themeColor": "d63333",
          "title": {{ toJSON (printf "[%s] %s (%.0f%%)" .Verdict .Title (mulPct .Confidence)) }},
          "text": {{ toJSON .Text }}
        }
```

Two template funcs only: `toJSON` (escaping-correct JSON splicing) and `mulPct` (×100 for percent display). Egress goes through `httpx.SecureClient` (same SSRF guard as the webhook notifier); optional `token_env` becomes `Authorization: Bearer <value>`; `content_type` defaults to `application/json`. Rendered bodies are capped at **256 KiB** — oversize is a loud error, never a truncation. No new dependencies (stdlib `text/template`).

**Fail-safe semantics:**
- Template **parse** error ⇒ `Build` returns an error ⇒ `BuildEnabled` wraps it ⇒ `serve` refuses to start.
- Template **exec** error (or non-2xx) ⇒ that instance's delivery fails loudly and is logged, but siblings still deliver (`errors.Join`, mirroring `notify.Multi` one level down).
- `url_env` unset ⇒ that instance is silently disabled (webhook parity).
- No re-redaction: every notifier already receives a secret-redacted Investigation, stated in the docs.

## The frozen Payload contract

Task 1 extracts the webhook notifier's private JSON payload into an exported **`notify.Payload`** (with `NewPayload(inv)`) — now the single definition of what a delivery carries: the webhook notifier marshals it as-is, the templated notifier exposes it as the template dot. The JSON tags are the webhook notifier's **original wire format, frozen verbatim** — every pre-existing `webhook_test.go` test passes **unchanged** (the diff on `internal/notify/webhook/` is only the type removal + the `NewPayload` call; the local `payload` name is retained as a type alias to `notify.Payload` so the tests' decode targets keep working).

## The registry round-trip pin

A new pin (`internal/notify/registry_roundtrip_test.go`) builds **slack + matrix + webhook + templated from one YAML document** through `BuildEnabled` and asserts all four are constructed — the built-ins under their existing typed keys (`notify.slack`, `notify.matrix`) **verbatim**, the drop-ins under the inline `Extra` map. This is the guarantee the unified notifier registry can never silently regress.

## Erratum vs the original audit finding

The audit that motivated this suggested Slack/Matrix construction still needed unifying. In fact **Slack and Matrix were already registry-constructed** — they self-register via `init()` + `Register`, and `app.BuildNotifier` is just `BuildEnabled`. The only remaining asymmetry is the *config surface* (built-ins get typed blocks; drop-ins use the inline `Extra` map), which is a deliberate design, not debt. So **no migration was needed**: this PR pins the already-unified behavior with the round-trip test and documents the two surfaces.

## Verification

`go build ./... && go vet ./... && go test ./...`, `gofmt -l .` (empty), `golangci-lint run ./...` (`0 issues.`), and `go test -race ./internal/notify/... ./internal/config/... ./internal/app/...` all green.

## References

- Plan: `dev/superpowers/plans/2026-07-20-templated-notifier-registry.md`
- Roadmap: L2 (templated notifier / registry pinning)
