### PR TITLE
feat(catalog): persisted vector cache and incremental index updates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,6 +214,15 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`.
   3. Zero negative-case fires at the shipped default gates, **live** regime included.
   4. The embedding vector cache (content-hash, chunked batches) merged so reload cost no longer scales
      with corpus size — **done** (N2, PR #328).
+- `instant_recall.vector_cache` — **on by default** (only effective with `hybrid` + `model.embeddings`).
+  Persists the hybrid embedding cache to disk so a **restart or HA failover re-embeds nothing** (the
+  in-memory content-hash cache already spares unchanged entries within a process lifetime; this carries
+  it across process lifetimes). `enabled` (**`true`**; set `false` to keep the cache in-memory only) and
+  `dir` (cache directory, default `<tmp>/runlore-veccache` — **ephemeral**; point it at a PersistentVolume
+  to keep it across pod restarts, the same pattern as `gitops.mirror.dir`). Fail-safe by contract: every
+  failure mode — missing, corrupt, or written by a **different embedding model/dimension** — is a WARN +
+  cold re-embed, never an error, so a stale cache can never serve wrong vectors. Cache files are
+  **pod-local** (each replica maintains its own).
 - The **"📚 Matches known runbook"** notification block (stamped when a *full* investigation's
   `kb_search` finds a pre-existing entry) uses `solo_floor` as its visibility bar, so it tracks
   the same corpus/query-dependent BM25 scale recall runs in: a cluster that tunes `solo_floor`

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -66,7 +66,7 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			log.Info("catalog git-sync using the forge GitHub App identity")
 		}
 		syncer := &catalog.Syncer{URL: cfg.Catalog.Git.URL, Branch: cfg.Catalog.Git.Branch, Dir: dir, Token: token, Log: log}
-		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func() error {
+		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func(_ *catalog.SyncDelta) error {
 			skipped, err := cat.Reload(dir)
 			if err != nil {
 				log.Warn("catalog reload failed", "dir", dir, "err", err)

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -66,8 +66,8 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			log.Info("catalog git-sync using the forge GitHub App identity")
 		}
 		syncer := &catalog.Syncer{URL: cfg.Catalog.Git.URL, Branch: cfg.Catalog.Git.Branch, Dir: dir, Token: token, Log: log}
-		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func(_ *catalog.SyncDelta) error {
-			skipped, err := cat.Reload(dir)
+		go syncer.Run(ctx, cfg.Catalog.Git.Interval.Std(), func(delta *catalog.SyncDelta) error {
+			skipped, err := cat.ReloadDelta(ctx, dir, delta)
 			if err != nil {
 				log.Warn("catalog reload failed", "dir", dir, "err", err)
 				return err

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
@@ -44,6 +45,19 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 		embedder = embed.New(e.BaseURL, e.Model, key)
 		log.Info("hybrid recall: embeddings endpoint configured", "base_url", e.BaseURL, "model", e.Model)
 	}
+	// armVecCache persists the embedding cache across restarts (default on with
+	// hybrid). Only called where embedder != nil, so cfg.Model.Embeddings is set.
+	armVecCache := func(cat *catalog.Catalog) {
+		vc := cfg.Catalog.InstantRecall.VectorCache
+		if !vc.IsEnabled() {
+			return
+		}
+		vdir := vc.Dir
+		if vdir == "" {
+			vdir = filepath.Join(os.TempDir(), "runlore-veccache")
+		}
+		cat.EnableVectorCache(filepath.Join(vdir, "vectors.gob"), cfg.Model.Embeddings.Model)
+	}
 	if cfg.Catalog.Git.URL != "" {
 		dir := cfg.Catalog.Dir
 		if dir == "" {
@@ -53,6 +67,7 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 		cat.Log = log
 		if embedder != nil {
 			cat.SetEmbedder(embedder)
+			armVecCache(cat)
 		}
 		// Auth precedence: explicit token_env, else the shared forge GitHub App
 		// identity (one credential for both curation writes and catalog reads).
@@ -95,6 +110,7 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			cat = catalog.NewEmpty()
 			cat.Log = log
 			cat.SetEmbedder(embedder)
+			armVecCache(cat)
 			if _, err := cat.ReloadContext(ctx, cfg.Catalog.Dir); err != nil {
 				log.Warn("catalog disabled", "dir", cfg.Catalog.Dir, "err", err)
 				return nil

--- a/internal/app/catalog_cmd.go
+++ b/internal/app/catalog_cmd.go
@@ -60,7 +60,7 @@ func RunCatalogSync(args []string) error {
 		token = catalog.TokenFunc(ft)
 	}
 	syncer := &catalog.Syncer{URL: g.URL, Branch: g.Branch, Dir: dir, Token: token, Log: log}
-	if _, err := syncer.Sync(context.Background()); err != nil {
+	if _, _, err := syncer.Sync(context.Background()); err != nil {
 		return fmt.Errorf("sync: %w", err)
 	}
 	cat, err := catalog.New(dir)

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -32,6 +32,10 @@ type Catalog struct {
 	// current corpus on each successful embed pass so deleted entries are evicted.
 	// Guarded by mu.
 	vecCache map[string][]float32
+	// vecCachePath/vecCacheModel arm disk persistence of vecCache (EnableVectorCache).
+	// Empty path ⇒ in-memory only. Set once at wiring time, before the first Reload.
+	vecCachePath  string
+	vecCacheModel string
 	// pathIdx maps Entry.Path → position in entries; maintained in lockstep with
 	// entries under mu. It exists because bleve docs are keyed by Path (stable
 	// across reloads — the prerequisite for incremental Index/Delete), so search
@@ -50,6 +54,33 @@ func pathIndex(entries []Entry) map[string]int {
 		m[e.Path] = i
 	}
 	return m
+}
+
+// EnableVectorCache persists the embedding cache at path, keyed to the given
+// embedding-model identifier: the file is loaded now (before the first reload —
+// a warm cache means a restart embeds nothing) and rewritten after each
+// successful embed pass. Any load problem is a cold start, never an error.
+func (c *Catalog) EnableVectorCache(path, model string) {
+	c.vecCachePath, c.vecCacheModel = path, model
+	if warm := loadVecCache(path, model, c.Log); warm != nil {
+		c.mu.Lock()
+		c.vecCache = warm
+		c.mu.Unlock()
+		if c.Log != nil {
+			c.Log.Info("vector cache loaded from disk", "path", path, "vectors", len(warm))
+		}
+	}
+}
+
+// persistVecCache is the post-reload save hook: only a successful, complete
+// embed pass (vectors non-nil ⇒ all-or-nothing invariant held) writes the file.
+func (c *Catalog) persistVecCache(vectors [][]float32, cache map[string][]float32) {
+	if c.vecCachePath == "" || vectors == nil || cache == nil {
+		return
+	}
+	if err := saveVecCache(c.vecCachePath, c.vecCacheModel, cache); err != nil && c.Log != nil {
+		c.Log.Warn("vector cache save failed; next restart re-embeds", "path", c.vecCachePath, "err", err)
+	}
 }
 
 // Searcher is the read surface used by the kb_search tool.
@@ -117,6 +148,7 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 	if old != nil {
 		_ = old.Close()
 	}
+	c.persistVecCache(vectors, cache)
 	c.ready.Store(true)
 	return skipped, nil
 }
@@ -180,6 +212,7 @@ func (c *Catalog) ReloadDelta(ctx context.Context, dir string, delta *SyncDelta)
 		c.vecCache = cache
 	}
 	c.mu.Unlock()
+	c.persistVecCache(vectors, cache)
 	return skipped, nil
 }
 

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,9 +32,24 @@ type Catalog struct {
 	// current corpus on each successful embed pass so deleted entries are evicted.
 	// Guarded by mu.
 	vecCache map[string][]float32
+	// pathIdx maps Entry.Path → position in entries; maintained in lockstep with
+	// entries under mu. It exists because bleve docs are keyed by Path (stable
+	// across reloads — the prerequisite for incremental Index/Delete), so search
+	// hits resolve IDs through it instead of parsing positions.
+	pathIdx map[string]int
 	// Log, when set (wiring time, before the first Reload), surfaces non-fatal
 	// reload degradations — an embed failure that leaves hybrid BM25-only. Nil-safe.
 	Log *slog.Logger
+}
+
+// pathIndex maps each entry's Path to its slice position — the resolution table
+// for path-keyed bleve doc IDs. Built alongside every entries swap.
+func pathIndex(entries []Entry) map[string]int {
+	m := make(map[string]int, len(entries))
+	for i, e := range entries {
+		m[e.Path] = i
+	}
+	return m
 }
 
 // Searcher is the read surface used by the kb_search tool.
@@ -64,7 +78,7 @@ func New(dir string) (*Catalog, error) {
 // NewEmpty returns a catalog with no entries — used before the first git sync.
 func NewEmpty() *Catalog {
 	idx, _ := bleve.NewMemOnly(newIndexMapping())
-	return &Catalog{index: idx}
+	return &Catalog{index: idx, pathIdx: map[string]int{}}
 }
 
 // Reload rebuilds the index from dir and swaps it in atomically. The new index is
@@ -91,7 +105,7 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 	vectors, cache := c.embedWithCache(ctx, entries)
 	c.mu.Lock()
 	old := c.index
-	c.index, c.entries, c.vectors = idx, entries, vectors
+	c.index, c.entries, c.vectors, c.pathIdx = idx, entries, vectors, pathIndex(entries)
 	if cache != nil {
 		c.vecCache = cache
 	}
@@ -112,13 +126,13 @@ func buildIndex(entries []Entry) (bleve.Index, error) {
 	if err != nil {
 		return nil, fmt.Errorf("new index: %w", err)
 	}
-	for i, e := range entries {
+	for _, e := range entries {
 		doc := map[string]any{
 			"title": e.Title,
 			"text":  entryText(e),
 		}
-		if err := idx.Index(strconv.Itoa(i), doc); err != nil {
-			return nil, fmt.Errorf("index entry %d: %w", i, err)
+		if err := idx.Index(e.Path, doc); err != nil {
+			return nil, fmt.Errorf("index entry %s: %w", e.Path, err)
 		}
 	}
 	return idx, nil
@@ -220,8 +234,8 @@ func (c *Catalog) SearchScored(query string, k int) ([]ScoredEntry, error) {
 	}
 	out := make([]ScoredEntry, 0, len(res.Hits))
 	for _, hit := range res.Hits {
-		i, err := strconv.Atoi(hit.ID)
-		if err != nil || i < 0 || i >= len(c.entries) {
+		i, ok := c.pathIdx[hit.ID]
+		if !ok {
 			continue
 		}
 		out = append(out, ScoredEntry{Entry: c.entries[i], Score: hit.Score})

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -121,21 +121,89 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 	return skipped, nil
 }
 
+// ReloadDelta refreshes the catalog for a known set of changed/removed paths,
+// mutating the live index (bleve is safe for concurrent search+index) instead
+// of rebuilding it. Entries, vectors, and the embed cache still refresh from a
+// full Load walk — files are cheap; only the bleve analysis pass is not — so
+// slice/vector/pathIdx consistency is trivially preserved. Falls back to a
+// full ReloadContext when the delta is nil (unknown), the catalog is cold, or
+// ANY index mutation fails: an incremental error must never leave a wrong
+// index behind.
+func (c *Catalog) ReloadDelta(ctx context.Context, dir string, delta *SyncDelta) ([]string, error) {
+	if delta == nil || !c.ready.Load() {
+		return c.ReloadContext(ctx, dir)
+	}
+	entries, skipped, err := Load(dir)
+	if err != nil {
+		return nil, err
+	}
+	vectors, cache := c.embedWithCache(ctx, entries)
+	loaded := pathIndex(entries)
+
+	// Mutate the live index outside c.mu: concurrent searches resolve hits via
+	// pathIdx, so a just-indexed unknown path is skipped and a just-deleted one
+	// simply stops matching — momentary staleness, never a wrong entry.
+	c.mu.RLock()
+	idx := c.index
+	c.mu.RUnlock()
+	incremental := func() error {
+		for _, p := range delta.Removed {
+			if err := idx.Delete(p); err != nil {
+				return fmt.Errorf("delete %s: %w", p, err)
+			}
+		}
+		for _, p := range delta.Changed {
+			i, ok := loaded[p]
+			if !ok {
+				// Changed upstream but skipped by Load (now unparseable, or a
+				// reserved/non-.md name): drop any stale doc.
+				if err := idx.Delete(p); err != nil {
+					return fmt.Errorf("delete stale %s: %w", p, err)
+				}
+				continue
+			}
+			if err := idx.Index(p, docFor(entries[i])); err != nil {
+				return fmt.Errorf("index %s: %w", p, err)
+			}
+		}
+		return nil
+	}
+	if err := incremental(); err != nil {
+		if c.Log != nil {
+			c.Log.Warn("catalog incremental re-index failed; rebuilding fully", "err", err)
+		}
+		return c.ReloadContext(ctx, dir)
+	}
+	c.mu.Lock()
+	c.entries, c.vectors, c.pathIdx = entries, vectors, loaded
+	if cache != nil {
+		c.vecCache = cache
+	}
+	c.mu.Unlock()
+	return skipped, nil
+}
+
 func buildIndex(entries []Entry) (bleve.Index, error) {
 	idx, err := bleve.NewMemOnly(newIndexMapping())
 	if err != nil {
 		return nil, fmt.Errorf("new index: %w", err)
 	}
 	for _, e := range entries {
-		doc := map[string]any{
-			"title": e.Title,
-			"text":  entryText(e),
-		}
-		if err := idx.Index(e.Path, doc); err != nil {
+		if err := idx.Index(e.Path, docFor(e)); err != nil {
 			return nil, fmt.Errorf("index entry %s: %w", e.Path, err)
 		}
 	}
 	return idx, nil
+}
+
+// docFor is the single bleve document shape per entry — shared by the full
+// buildIndex pass and the incremental ReloadDelta re-index so both views index
+// identical content.
+func docFor(e Entry) map[string]any {
+	return map[string]any{
+		"title": e.Title,
+		"text":  entryText(e),
+	}
 }
 
 // entryText is the single corpus text per entry — used for BOTH the BM25 doc and the

--- a/internal/catalog/catalog_test.go
+++ b/internal/catalog/catalog_test.go
@@ -2,7 +2,48 @@
 
 package catalog
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSearchResolvesPathKeyedDocs(t *testing.T) {
+	dir := t.TempDir()
+	for name, title := range map[string]string{
+		"a.md": "cilium agent crashloop",
+		"b.md": "postgres disk pressure",
+	} {
+		entry := "---\ntype: Incident\ntitle: " + title + "\n---\nBody.\n"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(entry), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hits, err := c.SearchScored("cilium crashloop", 5)
+	if err != nil || len(hits) == 0 {
+		t.Fatalf("hits=%v err=%v", hits, err)
+	}
+	if hits[0].Entry.Path != "a.md" {
+		t.Errorf("top hit path = %q, want a.md", hits[0].Entry.Path)
+	}
+	// The doc ID space is now paths: deleting by path must remove the doc.
+	c.mu.Lock()
+	err = c.index.Delete("a.md")
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("delete by path: %v", err)
+	}
+	hits, _ = c.SearchScored("cilium crashloop", 5)
+	for _, h := range hits {
+		if h.Entry.Path == "a.md" {
+			t.Error("deleted doc still returned")
+		}
+	}
+}
 
 func TestCatalogSearch(t *testing.T) {
 	dir := t.TempDir()
@@ -96,15 +137,15 @@ func TestSearchLiftsResourceTerm(t *testing.T) {
 	// term ("harbor-core") lives ONLY in Resource here — not in title/desc/tags/
 	// body — so the entry can only rank first if Resource is indexed.
 	entries := []Entry{
-		{Title: "Pod restart loop", Description: "container keeps restarting", Resource: "tooling/harbor-core", Body: "the pod will not become ready"},
-		{Title: "Network policy drops", Description: "connectivity timeouts", Resource: "apps/web", Body: "default-deny blocks traffic"},
+		{Path: "a.md", Title: "Pod restart loop", Description: "container keeps restarting", Resource: "tooling/harbor-core", Body: "the pod will not become ready"},
+		{Path: "b.md", Title: "Network policy drops", Description: "connectivity timeouts", Resource: "apps/web", Body: "default-deny blocks traffic"},
 	}
 	idx, err := buildIndex(entries)
 	if err != nil {
 		t.Fatalf("buildIndex: %v", err)
 	}
 	defer func() { _ = idx.Close() }()
-	c := &Catalog{index: idx, entries: entries}
+	c := &Catalog{index: idx, entries: entries, pathIdx: pathIndex(entries)}
 	hits, err := c.SearchScored("harbor-core", 2)
 	if err != nil {
 		t.Fatalf("search: %v", err)
@@ -137,15 +178,15 @@ func TestBuildIndexScores(t *testing.T) {
 	// magnitudes — TF-IDF also length-normalizes, so magnitude-based BM25-vs-TFIDF
 	// discrimination is brittle; the helper assertion above is the reliable guard.
 	entries := []Entry{
-		{Title: "OOMKilled pod", Body: "container exceeded its memory limit"},
-		{Title: "Image pull failure", Body: "registry returned forbidden"},
+		{Path: "a.md", Title: "OOMKilled pod", Body: "container exceeded its memory limit"},
+		{Path: "b.md", Title: "Image pull failure", Body: "registry returned forbidden"},
 	}
 	idx, err := buildIndex(entries)
 	if err != nil {
 		t.Fatalf("buildIndex: %v", err)
 	}
 	defer func() { _ = idx.Close() }()
-	c := &Catalog{index: idx, entries: entries}
+	c := &Catalog{index: idx, entries: entries, pathIdx: pathIndex(entries)}
 	hits, err := c.SearchScored("memory limit", 2)
 	if err != nil {
 		t.Fatalf("search: %v", err)

--- a/internal/catalog/delta_test.go
+++ b/internal/catalog/delta_test.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// writeTitledEntry writes a minimal valid OKF entry whose body embeds the title,
+// so a search for the title's terms ranks it. (The package's existing writeEntry
+// helper writes verbatim content; this one wraps a title in frontmatter.)
+func writeTitledEntry(t *testing.T, dir, name, title string) {
+	t.Helper()
+	entry := "---\ntype: Incident\ntitle: " + title + "\n---\nBody about " + title + ".\n"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(entry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// searchTitles returns the top-k result titles for q — the comparable view used
+// by the parity property below.
+func searchTitles(t *testing.T, c *Catalog, q string) []string {
+	t.Helper()
+	hits, err := c.SearchScored(q, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = h.Entry.Title
+	}
+	return out
+}
+
+// TestReloadDeltaMatchesFullRebuild pins the core property: an incremental
+// reload must be indistinguishable from a from-scratch load of the same dir.
+func TestReloadDeltaMatchesFullRebuild(t *testing.T) {
+	dir := t.TempDir()
+	writeTitledEntry(t, dir, "a.md", "cilium agent crashloop")
+	writeTitledEntry(t, dir, "b.md", "postgres disk pressure")
+	writeTitledEntry(t, dir, "c.md", "dns resolution flaking")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutate: modify a, delete b, add d.
+	writeTitledEntry(t, dir, "a.md", "cilium agent oomkilled")
+	if err := os.Remove(filepath.Join(dir, "b.md")); err != nil {
+		t.Fatal(err)
+	}
+	writeTitledEntry(t, dir, "d.md", "ingress certificate expired")
+
+	skipped, err := c.ReloadDelta(context.Background(), dir,
+		&SyncDelta{Changed: []string{"a.md", "d.md"}, Removed: []string{"b.md"}})
+	if err != nil || len(skipped) != 0 {
+		t.Fatalf("delta reload: skipped=%v err=%v", skipped, err)
+	}
+
+	fresh, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != fresh.Len() {
+		t.Fatalf("Len: delta=%d fresh=%d", c.Len(), fresh.Len())
+	}
+	for _, q := range []string{"cilium oomkilled", "postgres disk", "certificate expired", "dns flaking"} {
+		if got, want := searchTitles(t, c, q), searchTitles(t, fresh, q); !slices.Equal(got, want) {
+			t.Errorf("query %q: delta=%v fresh=%v", q, got, want)
+		}
+	}
+}
+
+// TestReloadDeltaChangedEntryNowUnparseable: a changed file that fails to parse
+// is skipped by Load — its stale doc must not linger in the index.
+func TestReloadDeltaChangedEntryNowUnparseable(t *testing.T) {
+	dir := t.TempDir()
+	writeTitledEntry(t, dir, "a.md", "cilium agent crashloop")
+	writeTitledEntry(t, dir, "b.md", "postgres disk pressure")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.md"), []byte("---\ntitle: [broken\n---\nx"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	skipped, err := c.ReloadDelta(context.Background(), dir, &SyncDelta{Changed: []string{"a.md"}})
+	if err != nil || len(skipped) != 1 {
+		t.Fatalf("skipped=%v err=%v, want exactly the broken entry skipped", skipped, err)
+	}
+	for _, title := range searchTitles(t, c, "cilium crashloop") {
+		if title == "cilium agent crashloop" {
+			t.Error("stale doc for now-unparseable entry still indexed")
+		}
+	}
+}
+
+// TestReloadDeltaNilFallsBackToFull: nil delta must behave exactly like
+// ReloadContext (the first-sync / diff-error path).
+func TestReloadDeltaNilFallsBackToFull(t *testing.T) {
+	dir := t.TempDir()
+	writeTitledEntry(t, dir, "a.md", "cilium agent crashloop")
+	c, err := New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTitledEntry(t, dir, "b.md", "postgres disk pressure")
+	if _, err := c.ReloadDelta(context.Background(), dir, nil); err != nil {
+		t.Fatal(err)
+	}
+	if c.Len() != 2 {
+		t.Errorf("Len=%d, want 2 after nil-delta full reload", c.Len())
+	}
+}

--- a/internal/catalog/hybrid.go
+++ b/internal/catalog/hybrid.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
-	"strconv"
 
 	"github.com/blevesearch/bleve/v2"
 
@@ -135,15 +134,15 @@ func (c *Catalog) SearchHybrid(ctx context.Context, query string, k int) ([]Scor
 	sort.SliceStable(ranked, func(a, b int) bool { return cos[ranked[a]] > cos[ranked[b]] })
 	cosIDs := make([]string, len(ranked))
 	for i, idx := range ranked {
-		cosIDs[i] = strconv.Itoa(idx)
+		cosIDs[i] = c.entries[idx].Path
 	}
 	// Fuse the two rankings to select the candidate pool, then order that pool by
 	// cosine (the gate score).
 	pool := embed.FuseRRF(0, bm25IDs, cosIDs)
 	out := make([]ScoredEntry, 0, len(pool))
 	for _, f := range pool {
-		i, cerr := strconv.Atoi(f.ID)
-		if cerr != nil || i < 0 || i >= len(c.entries) {
+		i, ok := c.pathIdx[f.ID]
+		if !ok {
 			continue
 		}
 		out = append(out, ScoredEntry{Entry: c.entries[i], Score: cos[i]})

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -13,8 +13,17 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
+
+// SyncDelta names the repo-relative paths that changed between two synced
+// revisions. A nil *SyncDelta means "unknown" — the caller must do a full
+// reload. Renames contribute the old name to Removed and the new to Changed.
+type SyncDelta struct {
+	Changed []string // added or modified
+	Removed []string // deleted (or rename sources)
+}
 
 // TokenFunc returns a git credential (e.g. a GitHub App installation token or a
 // read-scoped PAT). Used as the basic-auth password with username x-access-token.
@@ -60,12 +69,51 @@ func (s *Syncer) branch() string {
 	return s.Branch
 }
 
+// diffPaths lists the paths that differ between two commits. Any failure
+// returns nil — "unknown", never fatal: the delta is an optimization and the
+// caller falls back to a full reload.
+func (s *Syncer) diffPaths(repo *git.Repository, from, to plumbing.Hash) *SyncDelta {
+	fromC, err := repo.CommitObject(from)
+	if err != nil {
+		return nil
+	}
+	toC, err := repo.CommitObject(to)
+	if err != nil {
+		return nil
+	}
+	fromT, err := fromC.Tree()
+	if err != nil {
+		return nil
+	}
+	toT, err := toC.Tree()
+	if err != nil {
+		return nil
+	}
+	changes, err := object.DiffTree(fromT, toT)
+	if err != nil {
+		return nil
+	}
+	d := &SyncDelta{}
+	for _, ch := range changes {
+		if ch.To.Name != "" {
+			d.Changed = append(d.Changed, ch.To.Name)
+		}
+		if ch.From.Name != "" && ch.From.Name != ch.To.Name {
+			d.Removed = append(d.Removed, ch.From.Name)
+		}
+	}
+	return d
+}
+
 // Sync clones the repo if the mirror is absent, otherwise fast-forwards it, and
 // reports whether HEAD moved since the previous sync (true on the first sync).
-func (s *Syncer) Sync(ctx context.Context) (bool, error) {
+// The returned *SyncDelta names the changed/removed paths between the previous
+// and new revision; it is nil ("unknown") on the first sync or any diff error,
+// which the caller must treat as a full reload.
+func (s *Syncer) Sync(ctx context.Context) (bool, *SyncDelta, error) {
 	auth, err := s.auth(ctx)
 	if err != nil {
-		return false, fmt.Errorf("auth: %w", err)
+		return false, nil, fmt.Errorf("auth: %w", err)
 	}
 	ref := plumbing.NewBranchReferenceName(s.branch())
 	clone := func() (*git.Repository, error) {
@@ -86,22 +134,22 @@ func (s *Syncer) Sync(ctx context.Context) (bool, error) {
 	var repo *git.Repository
 	if _, statErr := os.Stat(filepath.Join(s.Dir, ".git")); statErr != nil {
 		if repo, err = clone(); err != nil {
-			return false, err
+			return false, nil, err
 		}
 	} else if repo, err = git.PlainOpen(s.Dir); err != nil {
 		// A present-but-unreadable mirror (e.g. an earlier clone killed mid-write)
 		// would otherwise error on every Pull forever — discard it and re-clone.
 		s.Log.Warn("catalog mirror unreadable; re-cloning", "dir", s.Dir, "err", err)
 		if rmErr := os.RemoveAll(s.Dir); rmErr != nil {
-			return false, fmt.Errorf("remove corrupt mirror: %w", rmErr)
+			return false, nil, fmt.Errorf("remove corrupt mirror: %w", rmErr)
 		}
 		if repo, err = clone(); err != nil {
-			return false, err
+			return false, nil, err
 		}
 	} else {
 		wt, werr := repo.Worktree()
 		if werr != nil {
-			return false, werr
+			return false, nil, werr
 		}
 		perr := wt.PullContext(ctx, &git.PullOptions{
 			ReferenceName: ref,
@@ -110,28 +158,32 @@ func (s *Syncer) Sync(ctx context.Context) (bool, error) {
 			Force:         true,
 		})
 		if perr != nil && !errors.Is(perr, git.NoErrAlreadyUpToDate) {
-			return false, perr
+			return false, nil, perr
 		}
 	}
 	head, err := repo.Head()
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	rev := head.Hash()
 	changed := rev != s.lastRev
+	var delta *SyncDelta
+	if changed && s.lastRev != (plumbing.Hash{}) {
+		delta = s.diffPaths(repo, s.lastRev, rev)
+	}
 	s.lastRev = rev
-	return changed, nil
+	return changed, delta, nil
 }
 
 // Run does an initial sync then re-syncs every interval, calling onSync after each
 // success. It returns when ctx is done. interval <= 0 defaults to 5m.
-func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func() error) {
+func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func(*SyncDelta) error) {
 	if interval <= 0 {
 		interval = 5 * time.Minute
 	}
 	do := func() {
 		prev := s.lastRev
-		changed, err := s.Sync(ctx)
+		changed, delta, err := s.Sync(ctx)
 		if err != nil {
 			s.Log.Warn("catalog git sync failed", "url", s.URL, "err", err)
 			return
@@ -139,7 +191,7 @@ func (s *Syncer) Run(ctx context.Context, interval time.Duration, onSync func() 
 		if !changed {
 			return
 		}
-		if err := onSync(); err != nil {
+		if err := onSync(delta); err != nil {
 			// Re-index failed: roll back to the previous synced revision so the next
 			// tick retries it, instead of sticking the catalog on a stale/empty index
 			// until upstream HEAD next moves. (Sync already advanced lastRev.)

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -16,6 +18,43 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
+
+func TestSyncReportsDelta(t *testing.T) {
+	src := initBareUpstream(t)
+	commitToUpstream(t, src, "a.md", "alpha v1")
+	commitToUpstream(t, src, "b.md", "beta v1")
+	s := &Syncer{URL: src, Dir: t.TempDir(), Log: testLogger()}
+
+	// First sync: change reported, delta unknown (nil) — full reload territory.
+	changed, delta, err := s.Sync(context.Background())
+	if err != nil || !changed {
+		t.Fatalf("first sync: changed=%v err=%v", changed, err)
+	}
+	if delta != nil {
+		t.Fatalf("first sync delta = %+v, want nil (unknown)", delta)
+	}
+
+	// Modify one file, add one: delta lists exactly those, nothing removed.
+	commitToUpstream(t, src, "a.md", "alpha v2")
+	commitToUpstream(t, src, "c.md", "gamma v1")
+	changed, delta, err = s.Sync(context.Background())
+	if err != nil || !changed || delta == nil {
+		t.Fatalf("second sync: changed=%v delta=%v err=%v", changed, delta, err)
+	}
+	sort.Strings(delta.Changed)
+	if want := []string{"a.md", "c.md"}; !slices.Equal(delta.Changed, want) {
+		t.Errorf("Changed = %v, want %v", delta.Changed, want)
+	}
+	if len(delta.Removed) != 0 {
+		t.Errorf("Removed = %v, want empty", delta.Removed)
+	}
+
+	// No upstream movement: no change, no delta.
+	changed, delta, err = s.Sync(context.Background())
+	if err != nil || changed || delta != nil {
+		t.Errorf("idle sync: changed=%v delta=%v err=%v", changed, delta, err)
+	}
+}
 
 // initBareUpstream creates a local (non-bare) git repo with one initial commit
 // and returns its path. The Syncer can clone from it via a local file path.
@@ -57,7 +96,7 @@ func TestSyncReportsChangeOnClone(t *testing.T) {
 	src := initBareUpstream(t)
 	dir := t.TempDir()
 	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
-	changed, err := s.Sync(context.Background())
+	changed, _, err := s.Sync(context.Background())
 	if err != nil {
 		t.Fatalf("Sync: %v", err)
 	}
@@ -70,10 +109,10 @@ func TestSyncNoChangeOnRepeatedPull(t *testing.T) {
 	src := initBareUpstream(t)
 	dir := t.TempDir()
 	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
-	if _, err := s.Sync(context.Background()); err != nil {
+	if _, _, err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("first Sync: %v", err)
 	}
-	changed, err := s.Sync(context.Background())
+	changed, _, err := s.Sync(context.Background())
 	if err != nil {
 		t.Fatalf("second Sync: %v", err)
 	}
@@ -86,11 +125,11 @@ func TestSyncReportsChangeAfterNewCommit(t *testing.T) {
 	src := initBareUpstream(t)
 	dir := t.TempDir()
 	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
-	if _, err := s.Sync(context.Background()); err != nil {
+	if _, _, err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("first Sync: %v", err)
 	}
 	commitToUpstream(t, src, "runbooks/new.md", "# new")
-	changed, err := s.Sync(context.Background())
+	changed, _, err := s.Sync(context.Background())
 	if err != nil {
 		t.Fatalf("third Sync: %v", err)
 	}
@@ -130,7 +169,7 @@ func TestSyncRecoversFromCorruptMirror(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
-	if _, err := s.Sync(context.Background()); err != nil {
+	if _, _, err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync should recover by re-cloning a corrupt mirror, got: %v", err)
 	}
 	if es, _, _ := Load(dir); len(es) != 1 {
@@ -152,7 +191,7 @@ func TestSyncerCloneAndPull(t *testing.T) {
 	s := &Syncer{URL: src, Branch: "main", Dir: mirror, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
 
 	// First Sync clones.
-	if _, err := s.Sync(context.Background()); err != nil {
+	if _, _, err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("clone sync: %v", err)
 	}
 	if es, _, _ := Load(mirror); len(es) != 1 || es[0].Title != "First" {
@@ -161,7 +200,7 @@ func TestSyncerCloneAndPull(t *testing.T) {
 
 	// A new commit (e.g. a merged curation PR) appears upstream; Sync fast-forwards.
 	commit(t, repo, src, "second.md", "---\ntitle: Second\n---\ny")
-	if _, err := s.Sync(context.Background()); err != nil {
+	if _, _, err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("pull sync: %v", err)
 	}
 	if es, _, _ := Load(mirror); len(es) != 2 {
@@ -191,7 +230,7 @@ func TestRunReloadsOnlyOnChange(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		s.Run(ctx, time.Hour, func() error { calls.Add(1); return nil }) // interval unused: tick drives the loop
+		s.Run(ctx, time.Hour, func(*SyncDelta) error { calls.Add(1); return nil }) // interval unused: tick drives the loop
 	}()
 
 	// Run only receives from the (unbuffered) tick channel between poll cycles, so a

--- a/internal/catalog/veccache.go
+++ b/internal/catalog/veccache.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"encoding/gob"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// vecCacheFile is the on-disk shape of the persisted embedding cache. gob over
+// JSON: map[string][]float32 in one stdlib call, ~1/10th the bytes, and no
+// human ever reads this file. The header makes staleness detectable — a cache
+// written by a different embedding model (or dimensionality) must never be
+// served, so any mismatch discards the whole file and the corpus re-embeds.
+type vecCacheFile struct {
+	Version int
+	Model   string
+	Dim     int
+	Vectors map[string][]float32
+}
+
+const vecCacheVersion = 1
+
+// loadVecCache reads a persisted cache, returning nil (cold start) on ANY
+// problem: absent, unreadable, corrupt, version/model/dimension mismatch.
+// Fail-safe by contract — the cache is an optimization, never a correctness
+// input. log is nil-safe.
+func loadVecCache(path, model string, log *slog.Logger) map[string][]float32 {
+	f, err := os.Open(path) //nolint:gosec // G304: operator-configured cache path
+	if err != nil {
+		return nil // absent is the common cold-start case; not worth a warn
+	}
+	defer func() { _ = f.Close() }()
+	var vf vecCacheFile
+	if err := gob.NewDecoder(f).Decode(&vf); err != nil {
+		if log != nil {
+			log.Warn("vector cache unreadable; re-embedding from scratch", "path", path, "err", err)
+		}
+		return nil
+	}
+	if vf.Version != vecCacheVersion || vf.Model != model || vf.Dim <= 0 {
+		if log != nil {
+			log.Warn("vector cache stale (version/model changed); re-embedding from scratch",
+				"path", path, "cache_model", vf.Model, "model", model)
+		}
+		return nil
+	}
+	for _, v := range vf.Vectors {
+		if len(v) != vf.Dim {
+			if log != nil {
+				log.Warn("vector cache dimension-incoherent; re-embedding from scratch", "path", path)
+			}
+			return nil
+		}
+	}
+	return vf.Vectors
+}
+
+// saveVecCache writes the cache atomically (temp + rename, the ledger's
+// pattern) so an interrupted write can never leave a torn file for the next
+// startup to trip over. Empty caches are not persisted.
+func saveVecCache(path, model string, cache map[string][]float32) error {
+	if len(cache) == 0 {
+		return nil
+	}
+	dim := 0
+	for _, v := range cache {
+		dim = len(v)
+		break
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".veccache-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op after a successful rename
+	if err := gob.NewEncoder(tmp).Encode(vecCacheFile{
+		Version: vecCacheVersion, Model: model, Dim: dim, Vectors: cache,
+	}); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename cache into place: %w", err)
+	}
+	return nil
+}

--- a/internal/catalog/veccache_test.go
+++ b/internal/catalog/veccache_test.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVecCacheRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	in := map[string][]float32{"k1": {1, 0}, "k2": {0.5, 0.5}}
+	if err := saveVecCache(path, "bge-m3", in); err != nil {
+		t.Fatal(err)
+	}
+	out := loadVecCache(path, "bge-m3", nil)
+	if len(out) != 2 || out["k1"][0] != 1 || out["k2"][1] != 0.5 {
+		t.Fatalf("round trip = %v", out)
+	}
+	// No temp residue from the atomic write.
+	matches, _ := filepath.Glob(filepath.Join(filepath.Dir(path), ".veccache-*"))
+	if len(matches) != 0 {
+		t.Errorf("temp files left behind: %v", matches)
+	}
+}
+
+// A model swap must never serve stale vectors: the whole cache is discarded.
+func TestVecCacheModelMismatchDiscards(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	if err := saveVecCache(path, "bge-m3", map[string][]float32{"k": {1}}); err != nil {
+		t.Fatal(err)
+	}
+	if out := loadVecCache(path, "text-embedding-3-small", nil); out != nil {
+		t.Fatalf("model mismatch returned %v, want nil (cold start)", out)
+	}
+}
+
+func TestVecCacheCorruptFileColdStarts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	if err := os.WriteFile(path, []byte("not gob at all"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if out := loadVecCache(path, "bge-m3", nil); out != nil {
+		t.Fatalf("corrupt file returned %v, want nil", out)
+	}
+	if out := loadVecCache(filepath.Join(t.TempDir(), "absent.gob"), "bge-m3", nil); out != nil {
+		t.Fatalf("absent file returned %v, want nil", out)
+	}
+}
+
+// Dimension coherence: a cache whose vectors disagree with the recorded Dim is
+// corrupt — discard, don't serve.
+func TestVecCacheDimMismatchDiscards(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.gob")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gob.NewEncoder(f).Encode(vecCacheFile{
+		Version: vecCacheVersion, Model: "bge-m3", Dim: 3,
+		Vectors: map[string][]float32{"k": {1, 0}}, // len 2 ≠ Dim 3
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	if out := loadVecCache(path, "bge-m3", nil); out != nil {
+		t.Fatalf("dim mismatch returned %v, want nil", out)
+	}
+}
+
+// End-to-end: a second catalog with the same cache file embeds NOTHING on its
+// first reload — the restart/HA-failover win this feature exists for.
+func TestVecCachePersistsAcrossCatalogs(t *testing.T) {
+	dir := t.TempDir()
+	writeTitledEntry(t, dir, "a.md", "cilium agent crashloop")
+	writeTitledEntry(t, dir, "b.md", "postgres disk pressure")
+	cachePath := filepath.Join(t.TempDir(), "vectors.gob")
+
+	first := NewEmpty()
+	emb1 := &countingEmbedder{}
+	first.SetEmbedder(emb1)
+	first.EnableVectorCache(cachePath, "fake-model")
+	if _, err := first.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if len(emb1.calls) == 0 || !first.HasVectors() {
+		t.Fatalf("first catalog: calls=%d hasVectors=%v", len(emb1.calls), first.HasVectors())
+	}
+
+	second := NewEmpty()
+	emb2 := &countingEmbedder{}
+	second.SetEmbedder(emb2)
+	second.EnableVectorCache(cachePath, "fake-model")
+	if _, err := second.ReloadContext(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	if len(emb2.calls) != 0 {
+		t.Errorf("second catalog embedded %d batches, want 0 (cache warm from disk)", len(emb2.calls))
+	}
+	if !second.HasVectors() {
+		t.Error("second catalog has no vectors despite warm cache")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -453,6 +453,13 @@ type InstantRecall struct {
 	Hybrid          bool    `yaml:"hybrid"`            // enable hybrid (cosine-gated) recall
 	HybridMinScore  float64 `yaml:"hybrid_min_score"`  // cosine floor for the top hit (default 0.80)
 	HybridMarginGap float64 `yaml:"hybrid_margin_gap"` // cosine margin over the runner-up (default 0.05)
+
+	// VectorCache persists hybrid recall's per-entry embedding cache to disk so
+	// a restart or HA failover re-embeds nothing (the in-memory cache already
+	// spares unchanged entries WITHIN a process lifetime). Only meaningful when
+	// hybrid is on. Default on: persistence only ever helps, and every failure
+	// mode (corrupt/stale/missing file) degrades to a cold re-embed.
+	VectorCache VectorCache `yaml:"vector_cache"`
 }
 
 // RerankEnabled reports whether the instant-recall LLM reranker should run. It is
@@ -611,6 +618,16 @@ type GitOpsMirror struct {
 
 // IsEnabled reports whether the mirror cache is on (nil ⇒ default on).
 func (m GitOpsMirror) IsEnabled() bool { return m.Enabled == nil || *m.Enabled }
+
+// VectorCache configures on-disk persistence of the hybrid-recall embedding
+// cache. Enabled by default (nil/true).
+type VectorCache struct {
+	Enabled *bool  `yaml:"enabled"`
+	Dir     string `yaml:"dir"` // cache dir; "" ⇒ <tmp>/runlore-veccache (ephemeral; point at a PV to persist across restarts)
+}
+
+// IsEnabled reports whether cache persistence is on (nil ⇒ default on).
+func (v VectorCache) IsEnabled() bool { return v.Enabled == nil || *v.Enabled }
 
 // TriggerPolicy decides what RunLore reacts to.
 type TriggerPolicy struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -710,3 +710,15 @@ func TestGitOpsMirrorConfig(t *testing.T) {
 		t.Fatal("negative gitops.mirror.max must fail validation")
 	}
 }
+
+func TestVectorCacheConfigDefaults(t *testing.T) {
+	var vc VectorCache
+	if !vc.IsEnabled() {
+		t.Error("zero-value vector_cache must be enabled (persistence only ever helps)")
+	}
+	off := false
+	vc = VectorCache{Enabled: &off}
+	if vc.IsEnabled() {
+		t.Error("explicit enabled:false must disable")
+	}
+}


### PR DESCRIPTION
## What & why

Two disk/CPU costs on the catalog hot path are removed, both fail-safe to today's behaviour.

- **Restart / HA failover no longer re-embeds the corpus.** The N2 content-hash embedding cache (which already spares unchanged entries *within* a process lifetime) is now gob-persisted to disk after every successful embed pass and loaded before the first reload. A standby that takes over, or a pod that restarts, warms its vectors from the file and embeds nothing.
- **A KB HEAD move re-indexes only the changed entries.** RunLore merges its own curation PRs, so every merge used to re-analyze the whole corpus through bleve. The syncer now reports a `SyncDelta` (changed/removed repo-relative paths via `object.DiffTree` between the previous and new HEAD) and `Catalog.ReloadDelta` applies it as targeted `Index`/`Delete` mutations on the live index.

## How it stays safe

- **Doc IDs are now `Entry.Path`** (stable across reloads) with a `pathIdx` resolution map — the prerequisite for incremental mutation. Pure refactor; search results are byte-identical (pinned by a parity property test: a delta reload must be indistinguishable from a from-scratch load of the same dir).
- **`SyncDelta` nil ⇒ full reload.** First sync, or any diff error, yields a nil delta, which always means a full `ReloadContext`. The rollback-on-reindex-failure semantics in `Run` are preserved (a rolled-back rev re-diffs on the next tick, so the retried delta covers both moves).
- **Any incremental mutation error ⇒ full-rebuild fallback** in the same call. An incremental error can never leave a wrong or partial index behind.
- **Cache invalidation contract.** The gob file carries a `{Version, Model, Dim}` header. Missing, corrupt, or written by a different embedding model/dimension ⇒ WARN + cold start, never an error — the cache is an optimization, never a correctness input. Writes are atomic (temp + fsync + rename). Cache files are pod-local (each replica owns its own).
- The N2 all-or-nothing `HasVectors` invariant is untouched.

## Config

`catalog.instant_recall.vector_cache` follows the `gitops.mirror` three-state idiom — **on by default** (only effective with `hybrid` + `model.embeddings`). `dir` defaults to an ephemeral tmp path; point it at a PersistentVolume to persist across restarts. `enabled: false` keeps the cache in-memory only.

## Non-goal

No ANN / vector index — brute-force cosine over the in-RAM corpus stays until real catalogs exceed ~1–2k entries (below that an ANN structure costs more in build time and code than the linear scan it replaces). Persisting the bleve index itself is also out of scope; the expensive step was the embeddings, and that is what persistence targets.

## References

- Plan: `dev/superpowers/plans/2026-07-20-persisted-vectors-incremental-index.md`
- Roadmap: L4 (`dev/plans/2026-07-19-audit-roadmap.md`)
- Builds on the N2 embedding-cache + chunked-batches foundation (PR #328)

## Test evidence

`go build ./... && go vet ./... && go test ./...` pass, `gofmt -l .` empty, `golangci-lint run ./...` → `0 issues.`, and `go test -race ./internal/catalog/... ./internal/embed/... ./internal/config/... ./internal/app/...` all `ok`.