### PR TITLE
fix(helm): skip controller_logs RBAC for a missing namespace instead of failing install

### DIFF
--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -90,6 +90,7 @@ subjects:
     name: {{ include "runlore.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- range .Values.rbac.controllerLogNamespaces }}
+{{- if or (not $.Values.rbac.skipMissingControllerLogNamespaces) (lookup "v1" "Namespace" "" .) }}
 ---
 # controller_logs: read RAW gitops controller pod logs in THIS namespace only
 # (flux-system for Flux, argocd for ArgoCD — set via rbac.controllerLogNamespaces) —
@@ -124,6 +125,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "runlore.serviceAccountName" $ }}
     namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- if .Values.rbac.allowActions }}
 {{- range .Values.rbac.actionNamespaces }}

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -390,6 +390,18 @@ rbac:
   # explicitly, keep it a superset of this list or pod_logs is blocked at the app layer.
   controllerLogNamespaces:
     - flux-system
+  # skipMissingControllerLogNamespaces: skip the per-namespace controller_logs
+  # Role/RoleBinding for any controllerLogNamespaces entry that does not exist at
+  # install time, instead of failing the whole release with `namespaces "<ns>" not
+  # found`. Default true so a bare `helm install` — or one that runs before Flux/
+  # Argo CD is installed — succeeds; the RBAC is created the moment the namespace
+  # (and thus the GitOps controllers whose logs it grants) exists, via `helm upgrade`.
+  # Relies on Helm's `lookup`, which has cluster access during a real install/upgrade
+  # (including Flux's helm-controller) but NOT during client-side rendering
+  # (`helm template`, Argo CD's diff) — there every namespace reads as missing and the
+  # Role is skipped. If you render client-side (e.g. deploy via Argo CD) and guarantee
+  # the namespace exists, set this false to keep the RBAC deterministic.
+  skipMissingControllerLogNamespaces: true
 
 # Default-deny NetworkPolicy: restrict ingress to the webhook/health port and egress
 # to DNS + HTTPS + the Kubernetes API. Tighten egress to your model/git/observability


### PR DESCRIPTION
Fixes #343.

## Problem

The chart renders a namespaced `controller_logs` `Role` + `RoleBinding` in each `rbac.controllerLogNamespaces` entry (default `[flux-system]`). Kubernetes requires the target namespace to exist, so a bare `helm install` on any cluster without `flux-system` failed:

```
Error: INSTALLATION FAILED: namespaces "flux-system" not found
```

— even though the agent boots fine. Surfaced during v0.10.0 release validation. Pre-existing, not a v0.10.0 regression.

## Fix

Guard each `controller_logs` Role/RoleBinding with a `lookup` on namespace existence, gated by a new `rbac.skipMissingControllerLogNamespaces` (default `true`):

- **Missing namespace → skipped**, not a failed release. The RBAC is created on the next `helm upgrade` once the namespace (and the GitOps controllers whose logs it grants) exists.
- `lookup` has cluster access during a real install/upgrade — including Flux's helm-controller — but **not** during client-side rendering (`helm template`, Argo CD diff), where every namespace reads as missing. Set the value `false` to keep the RBAC deterministic when you render client-side (e.g. deploy via Argo CD) and guarantee the namespace exists.

Default `[flux-system]` and the Flux install path are unchanged; the e2e (which pre-creates `flux-system`) is unaffected.

## Verification (k3d)

| Scenario | Before | After |
|---|---|---|
| install, **no** `flux-system` | `INSTALLATION FAILED` | `STATUS: deployed`, Role skipped, pods 2/2 |
| create `flux-system` + `helm upgrade` | — | Role + RoleBinding created (lookup finds it) |
| `helm template` default (offline) | Roles render | Roles skipped (base RBAC intact) |
| `--set rbac.skipMissingControllerLogNamespaces=false` | — | deterministic legacy render |

`helm lint` clean; `helm template | kubeconform -strict` → 10/10 valid.