### PR TITLE
fix(skill): kb-steward — harden Flow 3 PR triage from first field test

### DIFF
--- a/plugins/kb-steward/skills/kb-steward/SKILL.md
+++ b/plugins/kb-steward/skills/kb-steward/SKILL.md
@@ -64,19 +64,38 @@ Target for a first sitting: 5–15 entries the SRE confirms are true.
 
 ## Flow 3 — PR triage
 
-1. List open KB PRs: `gh --repo <kb-remote> pr list --label runlore`. Two
+1. List open KB PRs with their CI status in one call: `gh --repo <kb-remote>
+   pr list --label runlore --json number,title,statusCheckRollup`. Two
    things that label won't tell you: **retirement PRs carry it too** — they
    only flip an existing entry's frontmatter to `status: retired`, so judge
    those on "is this entry really obsolete?", not against the entry checklist;
    and labelling is best-effort in RunLore, so a KB PR can exist unlabelled.
    If the count looks low, list without the label filter too.
-2. Per new-entry PR: run the proposed entry through the checklist; scan the
-   catalog for near-duplicates; then recommend one of merge / refine (offer the
-   concrete frontmatter or body fix) / close (say why: duplicate, benign churn,
-   not knowledge).
-3. You recommend — the human merges. Never merge or close yourself unless
+2. **Read CI before reading diffs.** Where the KB repo wires `lore
+   validate-kb` in CI, a failing check in the rollup is a gate violation
+   found for free — cite it instead of re-deriving it by hand.
+3. **Cluster the queue before judging single PRs.** RunLore files the same
+   fault repeatedly — under different alert names, on sibling pods, or hours
+   apart — so group the open PRs by underlying fault (same resource family +
+   same cause). Per group: pick the best-evidenced entry as the keeper, fold
+   the siblings' extra recall signal (other alert names, other affected
+   workloads) into the keeper as a refine suggestion, and recommend closing
+   the rest. A fault the catalog already documents needs no keeper at all —
+   recommend closing the whole group and updating/revalidating the existing
+   entry instead.
+4. Per keeper (and per singleton PR): run the proposed entry through the
+   checklist — see its *Triaging agent-drafted entries* section for what does
+   and doesn't apply to RunLore drafts; then recommend one of merge / refine
+   (offer the concrete frontmatter or body fix) / close (say why: duplicate,
+   benign churn, not knowledge).
+5. You recommend — the human merges. Never merge or close yourself unless
    explicitly told to.
-4. If most of the queue is noise, say so and point at the config levers:
+6. **Warn about merge order.** Every RunLore PR appends to the same lines of
+   `log.md` (and `index.md` when the catalog has one), so merging one open KB
+   PR invalidates the rest. Recommend closing the closables first, then
+   merging keepers one at a time, rebasing (or dropping the index/log hunks)
+   between each.
+7. If most of the queue is noise, say so and point at the config levers:
    `forge.skip_verdicts: ["no_action"]`, `forge.min_confidence`,
    `forge.dup_score` (see RunLore's docs/reviewing-knowledge.md).
 

--- a/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
+++ b/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
@@ -62,6 +62,34 @@ necessarily next to a RunLore install.
       adding a twin
 - [ ] scopeless (no `resource`) only for genuinely platform-wide knowledge
 
+## Triaging agent-drafted entries (PR triage)
+
+The two blocks above are written for authoring. When reviewing a RunLore-drafted
+PR, the allowances and generator artifacts below apply.
+
+Allowances — expected on RunLore drafts, not refine-blockers:
+
+- `last_validated` absent: RunLore drafts don't set it — the human merge is
+  the validation. Suggest adding it only when the PR needs refining anyway.
+- `fingerprint` (parsed — RunLore's dedup identity; see okf-format.md),
+  `confidence` / `provenance` (unparsed extension fields): all expected on
+  drafts — leave them alone.
+- The near-duplicate check is already satisfied by the triage flow's
+  group-level dedupe — don't re-search the catalog per keeper.
+
+Generator artifacts — include fixes for these in any refine recommendation:
+
+- Title ending in `…` (the generator caps titles at the 120-byte gate).
+  Rewrite to a scoped title that fits without the ellipsis.
+- The description pasted verbatim into `## Decision` and `## Cause`. The
+  repetition adds no recall signal (recall indexes one corpus per entry —
+  okf-format.md); trim the body copies to what each section uniquely says.
+- Required sections present but empty (a gate item above) — `## Resolution`
+  especially, when the investigation ended with no action taken; this is a
+  RunLore draft-side defect worth fixing upstream. A keeper needs real
+  content, usually recoverable from the entry's own `## Unresolved` notes or
+  the alert's runbook.
+
 ## Secret scan (always, before writing the file)
 
 You are the only scanner in this path — RunLore redacts what *it* collects


### PR DESCRIPTION
  ## Summary

  First field test of kb-steward's Flow 3 (17-PR queue, 12 near-duplicates) exposed
  gaps: no CI-first step, no queue clustering, no warning that RunLore PRs mutually
  conflict on `log.md`/`index.md`, and checklist ambiguity for agent-drafted entries.
  This adds those steps to Flow 3 and a "Triaging agent-drafted entries" checklist
  section (allowances vs generator artifacts), with claims verified against
  `draft.go` / `bundle.go` / `load.go`.

  ## Linked issue

  n/a (the empty-`## Resolution` generator defect noted in the checklist is #N)

  ## How was it verified?

  Docs-only. Baseline run without the guidance hit all six failure modes; a fresh
  agent given the updated text followed every new behavior on a synthetic 6-PR
  scenario. Go gates unaffected (no code touched)