### PR TITLE
fix(curator): emit honest Resolution content on no-action verdicts

### DIFF
--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -58,9 +58,22 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 
 	// --- Resolution (suggested, reversible-first) ---
 	b.WriteString("\n## Resolution\n\n")
+	actions := 0
 	for _, rc := range inv.RootCauses {
 		if rc.SuggestedAction != "" {
 			fmt.Fprintf(&b, "- %s (reversible=%t)\n", rc.SuggestedAction, rc.Reversible)
+			actions++
+		}
+	}
+	if actions == 0 {
+		// A no-action verdict leaves every SuggestedAction empty, but kbvalidate
+		// rejects an Incident whose `## Resolution` section is present and empty —
+		// the draft would fail RunLore's own merge gate. Say the honest thing
+		// (OKF: an explicit unknown beats a fabricated action) instead.
+		if len(inv.Unresolved) > 0 {
+			b.WriteString("- No action suggested by the investigation — see `## Unresolved`.\n")
+		} else {
+			b.WriteString("- No action suggested by the investigation.\n")
 		}
 	}
 	if len(inv.Unresolved) > 0 {

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -399,6 +399,30 @@ func TestDraftKBEntryCarriesRecurrenceFacts(t *testing.T) {
 	}
 }
 
+// TestDraftKBEntryNoSuggestedActionPassesResolutionGate proves a draft survives
+// RunLore's own merge gate when the investigation ends with nothing to do (a
+// no-action / organic-growth verdict): kbvalidate rejects an Incident whose
+// `## Resolution` section is present but empty, so the draft must carry honest
+// resolution content instead of a bare header.
+func TestDraftKBEntryNoSuggestedActionPassesResolutionGate(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "VMSingle memory at 82% of limit",
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{
+			Summary:    "organic active-series growth from pod churn",
+			Evidence:   []string{"tsid cache 24.5M -> 29.7M over 4h"},
+			Confidence: 0.8,
+			// No SuggestedAction: the investigation found nothing to act on.
+		}},
+	}
+	e := draftKBEntry(inv)
+	for _, iss := range kbvalidate.ValidateStructural(toCatalogEntry(e)) {
+		if iss.Field == "resolution" && iss.Severity == kbvalidate.SeverityError {
+			t.Fatalf("drafted entry fails its own merge gate (%s):\n%s", iss.Message, e.Body)
+		}
+	}
+}
+
 // toCatalogEntry mirrors a drafted KBEntry into the catalog.Entry shape that
 // kbvalidate.ValidateStructural consumes, so tests can run the real merge gate.
 func toCatalogEntry(e providers.KBEntry) catalog.Entry {


### PR DESCRIPTION
  ## Summary

  `draftKBEntry` writes the `## Resolution` header unconditionally but bullets only
  when a root cause carries a `SuggestedAction`, so a no-action verdict (organic
  growth, benign churn) drafts an Incident whose Resolution section is present but
  empty — which `kbvalidate` rejects. RunLore was opening KB PRs that fail its own
  `lore validate-kb` CI gate (observed on 4 of 17 open PRs in a live KB queue).

  Now, when no action was suggested, the draft emits an explicit
  `- No action suggested by the investigation` line (pointing at `## Unresolved`
  when present) — honest content instead of a fabricated action, gate-passing by
  construction like `capTitle` already is for titles.

  ## Linked issue

  Closes #348

  ## How was it verified?

  New test `TestDraftKBEntryNoSuggestedActionPassesResolutionGate` runs the drafted
  entry through the real gate (`kbvalidate.ValidateStructural`); it failed against
  the old code (bare header, gate error) and passes with the fix.
  `go build` / `go vet` / `go test -race ./internal/curator/` / `gofmt -l` /
  `golangci-lint run` all clean locally.

  ## Checklist

  - [x] `go build ./...` passes
  - [x] `go vet ./...` passes
  - [x] `go test ./...` passes (`-race` where goroutines are involved)
  - [x] `gofmt -l .` prints nothing
  - [x] `golangci-lint run ./...` reports 0 issues
  - [x] Test added first (TDD) — the failing test came before the implementation
  - [ ] Docs updated (README / `docs/`) — n/a, no behavior/config surface change
  - [x] Respects **read-only-first**: no new cluster writes; the only writes are to Git via reviewed PRs

fixes https://github.com/Smana/runlore/issues/349