### PR TITLE
fix(skill): kb-steward — write-path findings from second field test

### DIFF
--- a/plugins/kb-steward/skills/kb-steward/SKILL.md
+++ b/plugins/kb-steward/skills/kb-steward/SKILL.md
@@ -82,7 +82,9 @@ Target for a first sitting: 5–15 entries the SRE confirms are true.
    workloads) into the keeper as a refine suggestion, and recommend closing
    the rest. A fault the catalog already documents needs no keeper at all —
    recommend closing the whole group and updating/revalidating the existing
-   entry instead.
+   entry instead. That update is itself steward work: deliver it via the git
+   flow, and name the superseded RunLore PRs in the PR body so the human can
+   close them once it merges.
 4. Per keeper (and per singleton PR): run the proposed entry through the
    checklist — see its *Triaging agent-drafted entries* section for what does
    and doesn't apply to RunLore drafts; then recommend one of merge / refine
@@ -137,7 +139,10 @@ after.**
    branch. If the tree is already dirty, stop and tell the user.
 2. **Write the entries, then validate** — see the checklist's *Run the real
    validator* section. Fix what it reports on the files you wrote; report,
-   don't silently fix, failures in entries you didn't touch.
+   don't silently fix, failures in entries you didn't touch. Edit an existing
+   entry's frontmatter surgically (string replacement) — round-tripping the
+   YAML through a formatter (`yq -i` re-indents RunLore's 4-space lists to 2)
+   churns lines you didn't touch and makes the PR harder to review.
 3. **Stage only the paths you wrote** (`git add <path>` per file) — never `git
    add -A` or `git add .`, which sweeps the user's unrelated dirty work into
    the KB PR. Then commit.

--- a/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
+++ b/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
@@ -31,8 +31,12 @@ failures in entries you didn't touch may surface — report those, don't
 silently fix them; and `--semantic` (an LLM advisory) needs a configured
 model, so plain `validate-kb` is what you want.
 
-No binary available? Then the gate block below is the fallback — check it by
-hand. Expect that often: the skill runs wherever the SRE is, which is not
+Not on PATH, but the RunLore source repo is at hand? Build it — a real verdict
+still beats the hand-check: `go build -o /tmp/lore ./cmd/lore` from the repo
+root, then run `/tmp/lore validate-kb`.
+
+No binary and no source? Then the gate block below is the fallback — check it
+by hand. Expect that often: the skill runs wherever the SRE is, which is not
 necessarily next to a RunLore install.
 
 ## Gate (what `lore validate-kb` rejects)
@@ -85,10 +89,10 @@ Generator artifacts — include fixes for these in any refine recommendation:
   repetition adds no recall signal (recall indexes one corpus per entry —
   okf-format.md); trim the body copies to what each section uniquely says.
 - Required sections present but empty (a gate item above) — `## Resolution`
-  especially, when the investigation ended with no action taken; this is a
-  RunLore draft-side defect worth fixing upstream. A keeper needs real
-  content, usually recoverable from the entry's own `## Unresolved` notes or
-  the alert's runbook.
+  especially, on drafts from RunLore builds older than the no-action fix
+  (Smana/runlore#350; fixed drafts emit an explicit "No action suggested"
+  line instead). A keeper needs real content, usually recoverable from the
+  entry's own `## Unresolved` notes or the alert's runbook.
 
 ## Secret scan (always, before writing the file)
 


### PR DESCRIPTION
Live run of the git flow (steward PR on a real catalog) surfaced three gaps:

- validator: build lore from source when the repo is at hand, instead of falling back to the hand-check
- frontmatter edits: surgical string replacement, not yq round-trips (re-indents RunLore's 4-space lists and churns the diff)
- Flow 3: the update-existing-entry outcome is itself steward work — deliver via the git flow and name superseded RunLore PRs in the PR body

Also updates the empty-Resolution generator artifact now that the upstream no-action fix (#350) is merged. Boundary, dirty-tree, and remote-mismatch pressure tests all passed unchanged — no rule edits needed there.