### PR TITLE
fix(skill): kb-steward — correct forge-behavior claims found in review

### DIFF
--- a/internal/forge/github/skillcontract_test.go
+++ b/internal/forge/github/skillcontract_test.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// The kb-steward skill (plugins/kb-steward) restates facts about the PRs this
+// package opens. The pins live here — not in internal/catalog's
+// skillcontract_test.go — because they check unexported behavior (renderEntry's
+// output, the label sets) that only this package can see.
+
+const (
+	stewardSkillPath     = "../../../plugins/kb-steward/skills/kb-steward/SKILL.md"
+	stewardChecklistPath = "../../../plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md"
+)
+
+func readStewardDoc(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // G304: fixed in-repo doc paths
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+// The checklist's triage-allowances block states whether RunLore drafts carry
+// last_validated. Both possible claims are phrase-anchored on the field name so
+// unrelated prose (the authoring block also says "last_validated set to today")
+// cannot satisfy the pin.
+var (
+	stampedClaimRE = regexp.MustCompile("`last_validated` stamped at draft time")
+	absentClaimRE  = regexp.MustCompile("`last_validated` absent")
+)
+
+// TestChecklistMatchesRenderEntryLastValidated pins the checklist's claim about
+// last_validated on RunLore drafts to what renderEntry actually writes. The
+// truth is derived from the rendered output, not restated here: if the forge
+// stops (or starts) stamping the field, the required doc phrase flips and this
+// test fails until the checklist follows.
+func TestChecklistMatchesRenderEntryLastValidated(t *testing.T) {
+	out := renderEntry(providers.KBEntry{Type: "Incident", Title: "T", Body: "## body"})
+	stamped := strings.Contains(out, "last_validated:")
+
+	doc := readStewardDoc(t, stewardChecklistPath)
+	claimsStamped := stampedClaimRE.MatchString(doc)
+	claimsAbsent := absentClaimRE.MatchString(doc)
+
+	switch {
+	case !claimsStamped && !claimsAbsent:
+		t.Fatalf("checklist states no claim about last_validated on RunLore drafts; "+
+			"its triage-allowances block must say one of %q or %q", stampedClaimRE, absentClaimRE)
+	case claimsStamped && claimsAbsent:
+		t.Fatal("checklist claims both that drafts stamp last_validated and that it is absent — fix the doc")
+	case stamped && claimsAbsent:
+		t.Error("renderEntry stamps last_validated on every draft, but the checklist tells triagers it is absent — update the triage-allowances block")
+	case !stamped && claimsStamped:
+		t.Error("renderEntry no longer stamps last_validated, but the checklist tells triagers it does — update the triage-allowances block")
+	}
+}
+
+// TestLastValidatedClaimREs is the mutation test for the two matchers above:
+// each regex must fire on its own claim and stay quiet on the other, and the
+// authoring-block phrasing must satisfy neither.
+func TestLastValidatedClaimREs(t *testing.T) {
+	cases := []struct {
+		name, text            string
+		wantStamp, wantAbsent bool
+	}{
+		{"stamped claim", "- `last_validated` stamped at draft time: RunLore sets it", true, false},
+		{"absent claim", "- `last_validated` absent: RunLore drafts don't set it", false, true},
+		{"authoring block is neither", "- [ ] `last_validated` set to today", false, false},
+		{"bare field mention is neither", "suggest bumping `last_validated` when refining", false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := stampedClaimRE.MatchString(c.text); got != c.wantStamp {
+				t.Errorf("stampedClaimRE.MatchString(%q) = %v, want %v", c.text, got, c.wantStamp)
+			}
+			if got := absentClaimRE.MatchString(c.text); got != c.wantAbsent {
+				t.Errorf("absentClaimRE.MatchString(%q) = %v, want %v", c.text, got, c.wantAbsent)
+			}
+		})
+	}
+}
+
+// TestSkillNamesRealForgeLabels pins the label names the triage flow keys on to
+// the sets this package actually applies. The flow lists PRs with
+// `--label runlore` and tells retirement PRs apart by `runlore-retire`; rename
+// either label in code and the flow goes blind, so the rename must reach the
+// skill in the same change.
+func TestSkillNamesRealForgeLabels(t *testing.T) {
+	applied := map[string]bool{}
+	for _, l := range lifecycleLabels {
+		applied[l] = true
+	}
+	for _, l := range retireLabels {
+		applied[l] = true
+	}
+	for label, docPhrase := range map[string]string{
+		"runlore":        "--label runlore",
+		"runlore-retire": "`runlore-retire`",
+	} {
+		if !applied[label] {
+			t.Errorf("the forge no longer applies label %q — update the skill's triage flow to match", label)
+		}
+		if doc := readStewardDoc(t, stewardSkillPath); !strings.Contains(doc, docPhrase) {
+			t.Errorf("SKILL.md flow 3 must mention %q (the triage flow keys on label %q)", docPhrase, label)
+		}
+	}
+}

--- a/plugins/kb-steward/skills/kb-steward/SKILL.md
+++ b/plugins/kb-steward/skills/kb-steward/SKILL.md
@@ -65,12 +65,13 @@ Target for a first sitting: 5–15 entries the SRE confirms are true.
 ## Flow 3 — PR triage
 
 1. List open KB PRs with their CI status in one call: `gh --repo <kb-remote>
-   pr list --label runlore --json number,title,statusCheckRollup`. Two
-   things that label won't tell you: **retirement PRs carry it too** — they
-   only flip an existing entry's frontmatter to `status: retired`, so judge
-   those on "is this entry really obsolete?", not against the entry checklist;
-   and labelling is best-effort in RunLore, so a KB PR can exist unlabelled.
-   If the count looks low, list without the label filter too.
+   pr list --label runlore --json number,title,labels,statusCheckRollup`. Two
+   things to read off the result: **retirement PRs are the ones also labelled
+   `runlore-retire`** — they only flip an existing entry's frontmatter to
+   `status: retired`, so judge those on "is this entry really obsolete?", not
+   against the entry checklist; and labelling is best-effort in RunLore, so a
+   KB PR can exist unlabelled. If the count looks low, list without the label
+   filter too.
 2. **Read CI before reading diffs.** Where the KB repo wires `lore
    validate-kb` in CI, a failing check in the rollup is a gate violation
    found for free — cite it instead of re-deriving it by hand.
@@ -92,11 +93,11 @@ Target for a first sitting: 5–15 entries the SRE confirms are true.
    benign churn, not knowledge).
 5. You recommend — the human merges. Never merge or close yourself unless
    explicitly told to.
-6. **Warn about merge order.** Every RunLore PR appends to the same lines of
-   `log.md` (and `index.md` when the catalog has one), so merging one open KB
-   PR invalidates the rest. Recommend closing the closables first, then
-   merging keepers one at a time, rebasing (or dropping the index/log hunks)
-   between each.
+6. **Warn about merge order.** Every RunLore entry PR appends to the same
+   lines of `log.md` (and `index.md` when the catalog has one), so merging one
+   invalidates the rest. Recommend closing the closables first, then merging
+   keepers one at a time, rebasing (or dropping the index/log hunks) between
+   each. Retirement PRs touch only their entry file — they merge in any order.
 7. If most of the queue is noise, say so and point at the config levers:
    `forge.skip_verdicts: ["no_action"]`, `forge.min_confidence`,
    `forge.dup_score` (see RunLore's docs/reviewing-knowledge.md).
@@ -106,9 +107,10 @@ Target for a first sitting: 5–15 entries the SRE confirms are true.
 1. Scan entries for: `status: draft` leftovers, missing/empty `tags` (they
    come in both inline `[a, b]` and block-list YAML forms — scan for both),
    `resource` values not shaped `namespace/name` (recall matches resources by
-   exact string, and a non-empty resource also disables the scopeless tier —
-   so a malformed or wildcard resource silently makes the entry unrecallable,
-   worse than none; fixing one changes recall semantics, so confirm with the
+   string equality — it forgives only pod-template-hash suffixes — and a
+   non-empty resource also disables the scopeless tier — so a malformed or
+   wildcard resource silently makes the entry unrecallable, worse than none;
+   fixing one changes recall semantics, so confirm with the
    SRE first), and `last_validated` (or `timestamp`) older than the
    deployment's `catalog.instant_recall.stale_after`. Read that value from
    the deployment's `runlore.yaml` if it is at hand; otherwise ask. Unset
@@ -159,11 +161,14 @@ after.**
    push and never substitute another remote. If the catalog was auto-detected
    (Setup step 1) rather than named by the user, there is no `<kb-remote>` to
    compare against — confirm it with them before the first push.
-5. **Push the branch, then open the PR:** `gh pr create --title <title> --body
-   <body> --base <default-branch>`. Pass all three explicitly — without them
-   `gh pr create` falls back to an interactive prompt, which blocks, and fails
-   outright when there is no terminal. Body: what was captured or changed and
-   why, with the entry list. No AI attribution.
+5. **Push the branch, then open the PR:** `gh pr create --head
+   kb-steward/<short-slug> --title <title> --body <body> --base
+   <default-branch>`. Pass all four explicitly — without title/body/base the
+   command falls back to an interactive prompt, which blocks, and fails
+   outright when there is no terminal; without `--head` it assumes the current
+   branch of the shell's working directory, which this flow never relies on.
+   Body: what was captured or changed and why, with the entry list. No AI
+   attribution.
 6. **Never merge, and never push to the default branch.** Nothing enters the KB
    without a human merge — the same rule RunLore itself follows. A solo
    maintainer may explicitly ask for a direct commit; comply and say so.

--- a/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
+++ b/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
@@ -18,15 +18,15 @@ what's worth a quick self-review pass.
 ## Run the real validator when you can
 
 **Match the version CI runs, not whatever is at hand.** The KB repo's CI
-workflow pins the validator (look for `go install …/cmd/lore@vX.Y.Z` under
-`.github/workflows/`); a PATH binary or a source build of a different version
-can green-light entries the pinned gate rejects, or fail entries the gate
-accepts — validation rules have changed across releases (e.g. `resource` was
-required on every type before it became Incident-only). Install exactly that
-version:
+workflow pins the validator (look for `go install …/cmd/lore@<ref>` under
+`.github/workflows/` — the pin may be a version tag or a bare commit SHA); a
+PATH binary or a source build of a different version can green-light entries
+the pinned gate rejects, or fail entries the gate accepts — validation rules
+have changed across releases (e.g. `resource` was required on every type
+before it became Incident-only). Install exactly that ref:
 
 ```
-GOBIN=/tmp go install github.com/Smana/runlore/cmd/lore@<pinned-version>
+GOBIN=/tmp go install github.com/Smana/runlore/cmd/lore@<pinned-ref>
 /tmp/lore validate-kb <catalog-dir>
 ```
 
@@ -80,8 +80,10 @@ PR, the allowances and generator artifacts below apply.
 
 Allowances — expected on RunLore drafts, not refine-blockers:
 
-- `last_validated` absent: RunLore drafts don't set it — the human merge is
-  the validation. Suggest adding it only when the PR needs refining anyway.
+- `last_validated` stamped at draft time: RunLore sets it equal to `timestamp`
+  when it renders the entry, so on a draft it marks creation, not a human
+  validation — the human merge is that. Don't flag it; when refining a keeper
+  anyway, bump it to the review date.
 - `fingerprint` (parsed — RunLore's dedup identity; see okf-format.md),
   `confidence` / `provenance` (unparsed extension fields): all expected on
   drafts — leave them alone.
@@ -122,8 +124,11 @@ interview. Search the draft for and redact:
 - credentials embedded in URLs (`scheme://user:PASSWORD@host`)
 - kubeconfig blobs and base64 strings longer than ~40 chars of unclear origin
 
-(This mirrors the shapes RunLore's own redaction handles — `internal/redact`
-in the RunLore repo is the fuller list if you need to check one.)
+(This list overlaps RunLore's own redaction — `internal/redact` in the RunLore
+repo — but neither contains the other: this one adds shapes typical of human
+pastes (kubeconfigs, service-account JSON, `glpat-…`, long base64) that redact
+deliberately skips, while redact also covers machine-collected shapes, like
+`kind: Secret` data blocks, that don't turn up in interviews.)
 
 Replace with `<redacted>`. If a secret already reached git or chat via the
 user's paste, tell them so they can rotate it.

--- a/plugins/kb-steward/skills/kb-steward/references/okf-format.md
+++ b/plugins/kb-steward/skills/kb-steward/references/okf-format.md
@@ -38,11 +38,12 @@ does not parse them — never rely on them for recall.
   `concepts/` (a write-side convention matching RunLore's own PRs — the
   loader itself reads every directory).
 - Filename: `<kebab-title-slug>-<short-suffix>.md`. RunLore uses the first 8
-  fingerprint chars as suffix; for hand-written entries any short stable
-  suffix works (e.g. the date `20260721`). The suffix keeps two entries
-  sharing a title from colliding.
-- Reserved names the loader SKIPS: `index.md`, `log.md`, any `readme.md`,
-  dotfiles, and hidden directories. Never put knowledge in those files.
+  fingerprint chars as suffix (a timestamp when a draft has no fingerprint);
+  for hand-written entries any short stable suffix works (e.g. the date
+  `20260721`). The suffix keeps two entries sharing a title from colliding.
+- Reserved names the loader SKIPS: `index.md`, `log.md` (exact, lowercase),
+  `readme.md` in any letter case, dotfiles, and hidden directories. Never put
+  knowledge in those files.
 
 ## Body requirements (merge gate)
 


### PR DESCRIPTION
A claim-by-claim review of the kb-steward skill against the codebase (loader, validator, recall, forge) confirmed almost everything, and surfaced the fixes below. Every claim already covered by a drift-guard test held; the one outright-false claim sat exactly where no guard reached.

## Doc fixes

- **`last_validated` triage allowance was false.** The checklist told reviewers RunLore drafts don't set it; `renderEntry` stamps it on every draft, equal to `timestamp` (`internal/forge/github/github.go` — locked by `TestRenderEntryStampsLastValidated`). The allowance now says the stamp marks creation, not human validation, and to bump it to the review date when refining a keeper anyway. Note the underlying tension is resolved doc-follows-code here: `okf-format.md` defines the field as "date a human last confirmed" — if we'd rather the forge stop self-stamping drafts, that's a follow-up code change and this text flips back (the new guard will force it to).
- **Flow 3 identifies retirement PRs by label.** They carry `runlore-retire` (`retire.go: retireLabels`) — cheaper and more reliable than recognizing them from the diff; `labels` added to the `pr list --json` fields.
- **Merge-order warning scoped to entry PRs.** Retirement PRs never touch `log.md`/`index.md` (`OpenRetirePR` writes only the entry file), so they merge in any order.
- **Git flow step 5 gains `--head`.** `gh pr create` defaults the head to the cwd repo's current branch — the very thing the flow's preamble forbids relying on.
- **Secret-scan pointer corrected.** `internal/redact` is not a superset of the scan list (no `glpat-`, kubeconfig, SA-JSON, long-base64 rules — the last deliberately); neither list contains the other, and the text now says so.
- **Smaller accuracy fixes:** recall's resource matching is normalized (pod-template-hash suffixes forgiven), not raw exact-string; the CI validator pin may be a commit SHA (runlore-kb's `validate-kb.yml` pins one today), not only `@vX.Y.Z`; the draft filename suffix falls back to a timestamp when there is no fingerprint; `index.md`/`log.md` are skipped case-sensitively while `readme.md` is any-case.

## New drift guards (`internal/forge/github/skillcontract_test.go`)

- `TestChecklistMatchesRenderEntryLastValidated` derives the truth from `renderEntry`'s actual output and requires the checklist to state the matching claim — flip the forge behavior and the required phrase flips. `TestLastValidatedClaimREs` mutation-tests the matchers.
- `TestSkillNamesRealForgeLabels` pins the label names the triage flow keys on (`runlore`, `runlore-retire`) to `lifecycleLabels`/`retireLabels`.

They live in this package (not `internal/catalog`'s `skillcontract_test.go`) because they check unexported behavior only this package sees.

Full gate green: build, vet, `go test ./...`, gofmt, golangci-lint (0 issues).