### PR TITLE
fix(kbvalidate): title-limit error says bytes, the unit it measures

### DIFF
--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -120,7 +120,7 @@ func ValidateStructural(e catalog.Entry) []Issue {
 	case strings.ContainsAny(e.Title, "\r\n"):
 		addErr("title", "title must be a single line")
 	case len(e.Title) > maxTitleLen:
-		addErr("title", fmt.Sprintf("title must be at most %d characters", maxTitleLen))
+		addErr("title", fmt.Sprintf("title must be at most %d bytes", maxTitleLen))
 	}
 
 	if strings.TrimSpace(e.Description) == "" {

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -103,6 +103,27 @@ func TestValidateStructural(t *testing.T) {
 	}
 }
 
+// TestTitleLimitErrorMentionsBytes pins the unit in the error message to the
+// unit the check measures. The limit is enforced with len() — bytes — and the
+// skill docs tell authors "bytes, not characters"; for the title below (61
+// characters, 122 bytes) a message counting "characters" would be a lie.
+func TestTitleLimitErrorMentionsBytes(t *testing.T) {
+	e := validIncident()
+	e.Title = strings.Repeat("é", 61)
+	var msg string
+	for _, i := range ValidateStructural(e) {
+		if i.Severity == SeverityError && i.Field == "title" {
+			msg = i.Message
+		}
+	}
+	if msg == "" {
+		t.Fatal("no title error for a 122-byte title")
+	}
+	if !strings.Contains(msg, "bytes") || strings.Contains(msg, "characters") {
+		t.Errorf("title-limit error %q must state the measured unit (bytes), not characters", msg)
+	}
+}
+
 func TestWarnInvalid(t *testing.T) {
 	good := validIncident()
 	good.Path = "good.md"


### PR DESCRIPTION
Found while reviewing the kb-steward skill against the code: `ValidateStructural` enforces the title limit with `len()` — bytes — but the error message said "at most 120 characters". A title of 61 accented characters (122 bytes) is rejected while being well under 120 characters, so the message misdiagnoses the failure for exactly the titles the byte limit exists to catch. The skill docs already state "bytes, not characters"; this aligns the message and pins it with a test using such a title.