### PR TITLE
fix(forge): stop stamping last_validated on drafted entries

### DIFF
--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -425,9 +425,10 @@ type kbFrontmatter struct {
 	AlertResource string   `yaml:"alert_resource,omitempty"`
 	Tags          []string `yaml:"tags,omitempty"`
 	Timestamp     string   `yaml:"timestamp,omitempty"` // OKF-recommended; seed entries carry it, curated ones now do too
-	// last_validated: stamped at entry creation (= timestamp); refreshed by humans
-	// or by future confirmation flows (see the downvote-recovery plan). Recall's
-	// stale_after down-weighting reads it — a never-revalidated entry ages visibly.
+	// last_validated: the date a human last confirmed the entry works. Never set
+	// on drafts — the human merge is the first validation, and humans (or future
+	// confirmation flows) stamp it from there. Recall's stale_after down-weighting
+	// falls back to timestamp, so an unvalidated entry still ages from creation.
 	LastValidated string `yaml:"last_validated,omitempty"`
 	Fingerprint   string `yaml:"fingerprint,omitempty"`
 	// Confidence + Provenance are OKF extension keys: frontmatter is for the
@@ -506,14 +507,15 @@ func (c *Client) blobURL(path string) string {
 }
 
 func renderEntry(e providers.KBEntry) string {
-	// Stamp the curated entry at render time (RFC3339 UTC, matching the seed
-	// entries and flux.Executor). Kept off KBEntry so draftKBEntry stays
+	// Stamp the curated entry's timestamp at render time (RFC3339 UTC, matching
+	// the seed entries and flux.Executor). Kept off KBEntry so draftKBEntry stays
 	// deterministic/time-free; this serializer is already the I/O boundary.
+	// last_validated stays unset: that field claims human confirmation.
 	ts := time.Now().UTC().Format(time.RFC3339)
 	fm, _ := yaml.Marshal(kbFrontmatter{
 		Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource,
 		AlertResource: e.AlertResource,
-		Tags:          e.Tags, Timestamp: ts, LastValidated: ts, Fingerprint: e.Fingerprint,
+		Tags:          e.Tags, Timestamp: ts, Fingerprint: e.Fingerprint,
 		Confidence: e.Confidence, Provenance: e.Provenance,
 	})
 	var b strings.Builder

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -389,29 +389,26 @@ func TestRenderEntryIncludesTimestamp(t *testing.T) {
 	}
 }
 
-// TestRenderEntryStampsLastValidated: last_validated is stamped at entry creation
-// (= the timestamp), so recall's stale_after down-weighting has a freshness date to
-// read and a never-revalidated entry ages visibly. It must be a parseable RFC3339
-// value equal to the timestamp.
-func TestRenderEntryStampsLastValidated(t *testing.T) {
+// TestRenderEntryOmitsLastValidated: last_validated means "a human confirmed this
+// works" (okf-format.md), and a draft has not been confirmed by anyone — the human
+// merge is the validation. The forge must leave it unset; recall's stale_after
+// down-weighting falls back to timestamp, so a never-revalidated entry still ages
+// from creation exactly as before.
+func TestRenderEntryOmitsLastValidated(t *testing.T) {
 	out := renderEntry(providers.KBEntry{Type: "Incident", Title: "T", Body: "## body"})
-	extract := func(key string) string {
-		i := strings.Index(out, key)
-		if i < 0 {
-			t.Fatalf("frontmatter missing %q:\n%s", key, out)
-		}
-		line := out[i+len(key):]
-		if j := strings.IndexByte(line, '\n'); j >= 0 {
-			line = line[:j]
-		}
-		return strings.Trim(strings.TrimSpace(line), `"`)
+	if strings.Contains(out, "last_validated:") {
+		t.Fatalf("draft frontmatter must not claim human validation:\n%s", out)
 	}
-	lv := extract("last_validated: ")
-	if _, err := time.Parse(time.RFC3339, lv); err != nil {
-		t.Fatalf("last_validated %q is not RFC3339: %v", lv, err)
+	i := strings.Index(out, "timestamp: ")
+	if i < 0 {
+		t.Fatalf("frontmatter missing timestamp:\n%s", out)
 	}
-	if ts := extract("timestamp: "); lv != ts {
-		t.Fatalf("last_validated %q must equal timestamp %q at creation", lv, ts)
+	ts := out[i+len("timestamp: "):]
+	if j := strings.IndexByte(ts, '\n'); j >= 0 {
+		ts = ts[:j]
+	}
+	if _, err := time.Parse(time.RFC3339, strings.Trim(strings.TrimSpace(ts), `"`)); err != nil {
+		t.Fatalf("timestamp %q is not RFC3339: %v", ts, err)
 	}
 }
 

--- a/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
+++ b/plugins/kb-steward/skills/kb-steward/references/entry-quality-checklist.md
@@ -80,10 +80,11 @@ PR, the allowances and generator artifacts below apply.
 
 Allowances — expected on RunLore drafts, not refine-blockers:
 
-- `last_validated` stamped at draft time: RunLore sets it equal to `timestamp`
-  when it renders the entry, so on a draft it marks creation, not a human
-  validation — the human merge is that. Don't flag it; when refining a keeper
-  anyway, bump it to the review date.
+- `last_validated` absent: RunLore drafts leave it unset — the field claims
+  human confirmation, and the human merge is the first validation. Don't flag
+  it; when refining a keeper anyway, set it to the review date. (Drafts from
+  builds that predate this rule carry it equal to `timestamp` — creation, not
+  validation; read it accordingly.)
 - `fingerprint` (parsed — RunLore's dedup identity; see okf-format.md),
   `confidence` / `provenance` (unparsed extension fields): all expected on
   drafts — leave them alone.


### PR DESCRIPTION
Resolves the design tension left open by #355 in the direction of the field's documented meaning: `last_validated` is "the date a human last confirmed the entry works" (okf-format.md), but `renderEntry` stamped it at render time on every draft — an unmerged draft claiming a human validation it never had. The forge now leaves it unset; the human merge is the first validation, and humans (or future confirmation flows) stamp it from there.

No recall-behavior change: `stale_after` freshness falls back to `timestamp` (`recall.go`), which carried the identical value at creation, so never-validated entries age exactly as before. The `kbFrontmatter` field already had `omitempty`, so the line simply disappears from drafts.

`TestRenderEntryStampsLastValidated` becomes `TestRenderEntryOmitsLastValidated` (TDD: flipped first, watched it fail). The `TestChecklistMatchesRenderEntryLastValidated` drift guard from #355 then failed exactly as designed — code flipped, so the required checklist phrase flipped — and the triage allowance returns to the "absent" claim, with a note on reading drafts from older builds that still carry the stamp.

Full gate green: build, vet, `go test ./...`, gofmt, golangci-lint (0 issues).