### PR TITLE
docs: v0.11.0 roadmap — spec and implementation plan

### DIFF
--- a/dev/superpowers/plans/2026-07-23-d1-runbook-import.md
+++ b/dev/superpowers/plans/2026-07-23-d1-runbook-import.md
@@ -1,0 +1,1559 @@
+# D1 — Runbook/KB import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Solve the cold-start problem: `lore kb import <dir>` converts a directory of existing markdown runbooks/postmortems into OKF-compatible catalog entries — adding/normalizing YAML frontmatter with **deterministic heuristics** (title from the first heading or filename, tags from existing frontmatter plus detected alert-name patterns, `Incident` vs `Playbook` from the body's OKF sections), validating each entry with the **same merge gate** as `lore validate-kb`, **deduplicating** against the existing catalog (exact/fuzzy title, destination-path collision), and writing the results into a **local KB checkout for the user to review and commit**. `--dry-run` previews; an **optional** `--model` flag refines frontmatter with the already-configured LLM. **No new required config** — `--into` falls back to the existing `catalog.dir`, `--model` reuses the existing `model:` block.
+
+**Architecture:** One new pure package `internal/kbimport` (Infer → Plan → Enrich, all side-effect free), one new tiny package `internal/okf` that hosts the OKF entry serializer **extracted** from `internal/forge/github` (`renderEntry`/`slugify` at `internal/forge/github/github.go:509-568` become `okf.Render`/`okf.Slugify`; the forge delegates — this is also pre-work item M2/GitLab needs). The command reuses, not reinvents: `providers.KBEntry` (`internal/providers/providers.go:746`) is the entry struct; `kbvalidate.ValidateStructural` (`internal/kbvalidate/kbvalidate.go:105`) is the validator; `catalog.Load` (`internal/catalog/load.go:24`) reads the existing catalog for dedup; `curate`'s title-Jaccard (`internal/curate/dedup.go:113`) is the fuzzy-dup primitive; `curator.capTitle` (`internal/curator/draft.go:221`) is the title cap. Four tiny unexported helpers get exported first (Task 2). The CLI wiring follows the repo's actual pattern — **stdlib `flag` + a `switch` dispatcher, not cobra** (`cmd/lore/main.go:46`, `internal/app/kb_cmd.go:24` `RunKB`): a new `case "import"` under `lore kb`.
+
+**Tech Stack:** Go 1.x (module `github.com/Smana/runlore`), stdlib `flag`/`text/tabwriter`, `gopkg.in/yaml.v3` (already a dep, used by `catalog` and `forge/github`), table-driven `testing` with `t.TempDir()` (house style, see `cmd/lore/validate_test.go`). No new dependencies.
+
+---
+
+### Task 1: Extract the OKF entry serializer into `internal/okf`
+
+The forge's `renderEntry` (`internal/forge/github/github.go:509`), its `kbFrontmatter` struct (`github.go:414-439`), and `slugify` (`github.go:551`) are the only code in the repo that *writes* an OKF entry file. Import needs exactly that serializer, and the GitLab forge (roadmap M2) will too — extract it once. `okf.Render` takes an explicit `Meta` (timestamp/status/last_validated) instead of stamping `time.Now()` internally, and does **not** sanitize the body: the GitHub forge keeps calling `neutralizeImages` on LLM-authored bodies before rendering (that concern is forge-specific — an imported human runbook's `![](diagram.png)` must survive verbatim).
+
+**Files:**
+- Create: `internal/okf/okf.go`
+- Test: `internal/okf/okf_test.go`
+- Modify: `internal/forge/github/github.go`
+
+**Steps:**
+
+- [ ] Write the failing test `internal/okf/okf_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package okf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestRenderFrontmatterAndBody(t *testing.T) {
+	out := Render(providers.KBEntry{
+		Type: "Playbook", Title: "Redis failover", Description: "how to fail over redis",
+		Tags: []string{"imported", "playbook"}, Body: "# Redis failover\n\nsteps",
+	}, Meta{Timestamp: "2024-03-01"})
+	for _, want := range []string{
+		"---\n", "type: Playbook\n", "title: Redis failover\n",
+		"timestamp: \"2024-03-01\"", "tags:\n", "- imported\n",
+		"# Redis failover\n\nsteps\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("Render missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderOmitsEmptyMeta(t *testing.T) {
+	out := Render(providers.KBEntry{Type: "Playbook", Title: "T", Description: "d"}, Meta{})
+	for _, absent := range []string{"timestamp:", "status:", "last_validated:", "fingerprint:", "resource:"} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("empty %s must be omitted:\n%s", absent, out)
+		}
+	}
+}
+
+func TestRenderYAMLInjectionSafeTitle(t *testing.T) {
+	// Marshaled (not string-formatted), so a colon-bearing title can't inject keys.
+	out := Render(providers.KBEntry{Type: "Playbook", Title: "a: b\nresource: evil", Description: "d"}, Meta{})
+	if strings.Contains(out, "\nresource: evil\n") {
+		t.Fatalf("newline title must not inject a frontmatter key:\n%s", out)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Redis failover — March 2024!", "redis-failover-march-2024"},
+		{"  KubePodCrashLooping  ", "kubepodcrashlooping"},
+		{"---", ""},
+	}
+	for _, c := range cases {
+		if got := Slugify(c.in); got != c.want {
+			t.Errorf("Slugify(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+```
+
+- [ ] Run it: `go test ./internal/okf/ -v` — expected FAIL (package does not exist / `Render` undefined).
+- [ ] Create `internal/okf/okf.go` — the moved code, verbatim where possible:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Package okf serializes providers.KBEntry values as OKF markdown files
+// (YAML frontmatter + body). It is the single write-side counterpart of
+// catalog.Load: the GitHub forge and `lore kb import` both render through it,
+// so every entry RunLore writes parses back identically.
+package okf
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Meta carries the file-level frontmatter that is not part of a drafted
+// KBEntry: the forge stamps Timestamp at render time; import preserves the
+// source document's own timestamp/status/last_validated instead.
+type Meta struct {
+	Timestamp     string // OKF-recommended; RFC3339 or bare date
+	Status        string // lifecycle: "", active, retired, draft
+	LastValidated string // date a human last confirmed the entry works
+}
+
+// frontmatter is the YAML frontmatter of an OKF entry. Marshaled (not string-
+// formatted) so a newline-bearing title/description from LLM output can't
+// inject extra frontmatter keys. Keys mirror catalog.entryMeta (the loader).
+type frontmatter struct {
+	Type          string   `yaml:"type"`
+	Title         string   `yaml:"title"`
+	Description   string   `yaml:"description"`
+	Resource      string   `yaml:"resource,omitempty"`
+	AlertResource string   `yaml:"alert_resource,omitempty"`
+	Tags          []string `yaml:"tags,omitempty"`
+	Timestamp     string   `yaml:"timestamp,omitempty"`
+	Status        string   `yaml:"status,omitempty"`
+	LastValidated string   `yaml:"last_validated,omitempty"`
+	Fingerprint   string   `yaml:"fingerprint,omitempty"`
+	Confidence    float64  `yaml:"confidence,omitempty"`
+	Provenance    []string `yaml:"provenance,omitempty"`
+}
+
+// Render serializes a KBEntry as OKF markdown. The body is written verbatim —
+// callers that render untrusted (LLM-authored) bodies sanitize BEFORE calling
+// (the GitHub forge neutralizes image markdown); a human runbook being
+// imported must survive byte-for-byte.
+func Render(e providers.KBEntry, m Meta) string {
+	fm, _ := yaml.Marshal(frontmatter{
+		Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource,
+		AlertResource: e.AlertResource, Tags: e.Tags,
+		Timestamp: m.Timestamp, Status: m.Status, LastValidated: m.LastValidated,
+		Fingerprint: e.Fingerprint, Confidence: e.Confidence, Provenance: e.Provenance,
+	})
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.Write(fm)
+	b.WriteString("---\n\n")
+	b.WriteString(e.Body)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// Slugify lowercases s and collapses every non-[a-z0-9] run into one dash.
+// (Moved verbatim from internal/forge/github.)
+func Slugify(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+```
+
+- [ ] Run `go test ./internal/okf/ -v` — expected PASS. (Note: `timestamp: "2024-03-01"` — yaml.v3 quotes date-like strings; if the marshaler emits it unquoted, relax that one assertion to `timestamp: `.)
+- [ ] Delegate the forge: in `internal/forge/github/github.go`, delete the `kbFrontmatter` struct (lines 411-439) and the bodies of `renderEntry`/`slugify`, keeping thin wrappers so all existing tests (`github_test.go:361-430`, `alert_resource_roundtrip_test.go`) pass unchanged:
+
+```go
+// renderEntry serializes a KBEntry as OKF markdown (frontmatter + body).
+// The timestamp is stamped at render time (RFC3339 UTC, matching the seed
+// entries); last_validated stays unset — that field claims human confirmation.
+// The body is neutralized here (LLM/alert-authored, GitHub auto-renders it);
+// okf.Render itself writes bodies verbatim.
+func renderEntry(e providers.KBEntry) string {
+	e.Body = neutralizeImages(e.Body)
+	return okf.Render(e, okf.Meta{Timestamp: time.Now().UTC().Format(time.RFC3339)})
+}
+
+func slugify(s string) string { return okf.Slugify(s) }
+```
+
+  Add the `github.com/Smana/runlore/internal/okf` import; remove `gopkg.in/yaml.v3` from the import block if it is now unused in that file.
+- [ ] Run `go build ./... && go test ./internal/forge/github/ ./internal/okf/ -count=1` — expected PASS (the round-trip test `alert_resource_roundtrip_test.go` is the safety net for the extraction).
+- [ ] Commit: `refactor(okf): extract OKF entry serializer from the github forge`
+
+### Task 2: Export the four shared primitives import reuses
+
+Four unexported helpers become the import command's building blocks. Pure renames + one wrapper; the failing "test" for each is a new test file that calls the exported name (compile failure = RED).
+
+**Files:**
+- Modify: `internal/catalog/load.go` (+ call sites in package), `internal/kbvalidate/kbvalidate.go` (+ call sites), `internal/curator/draft.go` (+ call sites incl. `draft_test.go`), `internal/curate/dedup.go`
+- Test: `internal/catalog/load_test.go`, `internal/kbvalidate/kbvalidate_test.go`, `internal/curator/draft_test.go`, `internal/curate/dedup_test.go` (append to existing files)
+
+**Steps:**
+
+- [ ] Append the pinning tests (each fails to compile until the rename lands):
+
+```go
+// internal/catalog/load_test.go — append
+func TestSplitFrontmatterExported(t *testing.T) {
+	fm, body := SplitFrontmatter([]byte("---\ntitle: t\n---\nbody\n"))
+	if string(fm) != "title: t" || string(body) != "body\n" {
+		t.Fatalf("got fm=%q body=%q", fm, body)
+	}
+	fm, body = SplitFrontmatter([]byte("no frontmatter"))
+	if fm != nil || string(body) != "no frontmatter" {
+		t.Fatalf("frontmatterless input must pass through, got fm=%q body=%q", fm, body)
+	}
+}
+```
+
+```go
+// internal/kbvalidate/kbvalidate_test.go — append
+func TestSectionsExported(t *testing.T) {
+	secs := Sections("## Symptom\n\nx\n\n## Cause\n\ny\n")
+	if secs["symptom"] != "x" || secs["cause"] != "y" {
+		t.Fatalf("got %#v", secs)
+	}
+}
+```
+
+```go
+// internal/curator/draft_test.go — append
+func TestCapTitleExported(t *testing.T) {
+	if got := CapTitle("a\nb\tc"); got != "a b c" {
+		t.Fatalf("whitespace collapse: got %q", got)
+	}
+	long := strings.Repeat("word ", 40)
+	if capped := CapTitle(long); len(capped) > 120 {
+		t.Fatalf("must cap at 120 bytes, got %d", len(capped))
+	}
+}
+```
+
+```go
+// internal/curate/dedup_test.go — append
+func TestTitleJaccardExported(t *testing.T) {
+	if s := TitleJaccard("redis failover runbook", "redis failover runbook"); s != 1 {
+		t.Fatalf("identical titles must score 1, got %v", s)
+	}
+	if s := TitleJaccard("redis failover", "postgres vacuum tuning"); s >= 0.6 {
+		t.Fatalf("unrelated titles must stay under threshold, got %v", s)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/catalog/ ./internal/kbvalidate/ ./internal/curator/ ./internal/curate/ -run 'Exported' -v` — expected FAIL (undefined: `SplitFrontmatter`, `Sections`, `CapTitle`, `TitleJaccard`).
+- [ ] Rename `splitFrontmatter` → `SplitFrontmatter` in `internal/catalog/load.go:99` (update the call at `load.go:80`); keep its doc comment, note it is now shared with `kbimport`.
+- [ ] Rename `sections` → `Sections` in `internal/kbvalidate/kbvalidate.go:191` (update the call at `kbvalidate.go:172` and any test references).
+- [ ] Rename `capTitle` → `CapTitle` in `internal/curator/draft.go:221` (update the call at `draft.go:100` and every `capTitle` reference in `internal/curator/*_test.go`).
+- [ ] Add to `internal/curate/dedup.go`:
+
+```go
+// TitleJaccard scores two entry titles by Jaccard similarity over their
+// noise-filtered token sets — the same fuzzy-duplicate primitive Dedup uses
+// for markerless PRs, shared with `lore kb import` so "duplicate" means the
+// same thing at import time and at curation time. ≥0.6 is the house threshold.
+func TitleJaccard(a, b string) float64 {
+	return jaccard(titleTokens(a), titleTokens(b))
+}
+```
+
+- [ ] Run `go build ./... && go test ./internal/catalog/ ./internal/kbvalidate/ ./internal/curator/ ./internal/curate/ -count=1` — expected PASS.
+- [ ] Commit: `refactor: export SplitFrontmatter, Sections, CapTitle, TitleJaccard for kb import`
+
+### Task 3: `internal/kbimport` — deterministic frontmatter inference
+
+The pure core. `Infer` turns one source document into a `Result`: a `providers.KBEntry` + preserved `okf.Meta` + a computed destination path + warnings. Heuristics (all deterministic, no I/O, no clock):
+
+- **type** — a source frontmatter `type` already in the validator vocabulary (`{Incident, Playbook, Concept}`, `internal/kbvalidate/kbvalidate.go:42`) passes through; otherwise `Incident` iff the body already carries non-empty `Symptom`+`Cause`+`Resolution` sections (via `kbvalidate.Sections`) **and** a resource was found (Incident requires one, `kbvalidate.go:135-137`); else `Playbook` (validation is intentionally relaxed for free-form runbooks, `kbvalidate.go:170`). `Postmortem` etc. therefore map to Incident when well-formed — never emitted raw (it would fail the gate, same reasoning as `internal/curator/draft.go:176-179`).
+- **title** — frontmatter `title` → first `# `/`## ` heading → humanized filename stem; capped by `curator.CapTitle` (single line, ≤120 bytes — the gate at `kbvalidate.go:122`).
+- **description** — frontmatter `description` → first non-blank, non-heading, non-code-fence body line (leading list markers stripped), whitespace-collapsed, capped at 240 runes → falls back to the title (the gate requires non-empty, `kbvalidate.go:126`).
+- **tags** — `imported` + lowercased type (mirrors `curator.entryTags`, `draft.go:195`) + the source's own tags (lowercased, deduped) + detected **alert patterns**: CamelCase tokens with ≥2 humps (`KubePodCrashLooping`, `TargetDown`) found in headings or in lines mentioning "alert" — tags feed the BM25 corpus, so each detected alert name is exactly the recall signal that lets a future alert find the imported runbook. Capped at 10 total.
+- **resource** — frontmatter `resource` passthrough only, and only when whitespace-free (the gate, `kbvalidate.go:139`); never guessed.
+- **timestamp** — frontmatter `timestamp` or `date`, kept **raw** when `catalog.ParseEntryDate` (`internal/catalog/entry.go:13`) accepts it, dropped with a warning otherwise; `status`/`last_validated` pass through raw (the validator treats odd values as advisory warnings, `kbvalidate.go:151-162`).
+- **dest path** — `<type-lowercase>s/<slug>.md` (same type-directory convention as the forge's `entryPath`, `github.go:540-548`) with **no** fingerprint suffix: imported entries carry no fingerprint (hand-written, per `internal/catalog/entry.go:39`), and a stable path makes re-running import idempotent (second run dedups on "destination exists").
+- **body** — verbatim. Existing frontmatter is *replaced* by the normalized set (its recognized keys were absorbed; unrecognized keys are reported as a warning, not silently dropped).
+
+**Files:**
+- Create: `internal/kbimport/infer.go`
+- Test: `internal/kbimport/infer_test.go`
+
+**Steps:**
+
+- [ ] Write the failing table-driven test `internal/kbimport/infer_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestInfer(t *testing.T) {
+	cases := []struct {
+		name, source, data                    string
+		wantType, wantTitle, wantDesc, wantRes string
+		wantTags                              []string
+		wantDest, wantTimestamp               string
+	}{
+		{
+			name:   "bare runbook: title from H1, description from first paragraph, Playbook",
+			source: "runbooks/redis-failover.md",
+			data:   "# Redis failover\n\nHow to fail over the redis primary.\n\n## Steps\n\n- step one\n",
+			wantType: "Playbook", wantTitle: "Redis failover",
+			wantDesc: "How to fail over the redis primary.",
+			wantTags: []string{"imported", "playbook"},
+			wantDest: "playbooks/redis-failover.md",
+		},
+		{
+			name:   "no heading: title humanized from filename",
+			source: "notes/pg_vacuum-tuning.md",
+			data:   "Tune autovacuum before it falls behind.\n",
+			wantType: "Playbook", wantTitle: "pg vacuum tuning",
+			wantDesc: "Tune autovacuum before it falls behind.",
+			wantTags: []string{"imported", "playbook"},
+			wantDest: "playbooks/pg-vacuum-tuning.md",
+		},
+		{
+			name:   "postmortem with OKF sections + resource becomes Incident, date preserved",
+			source: "postmortems/2024-03-payments.md",
+			data: "---\ntitle: Payments API outage\ndate: 2024-03-14\ntags: [payments]\nresource: payments/api\ntype: postmortem\n---\n" +
+				"## Symptom\n\n5xx spike\n\n## Cause\n\nbad deploy\n\n## Resolution\n\nrollback\n",
+			wantType: "Incident", wantTitle: "Payments API outage",
+			wantDesc: "5xx spike", wantRes: "payments/api",
+			wantTags:      []string{"imported", "incident", "payments"},
+			wantDest:      "incidents/payments-api-outage.md",
+			wantTimestamp: "2024-03-14",
+		},
+		{
+			name:   "alert names in headings/alert lines become tags",
+			source: "runbooks/oom.md",
+			data:   "# KubeContainerOOMKilled\n\nAlert: fires alongside KubePodCrashLooping sometimes.\n",
+			wantType: "Playbook", wantTitle: "KubeContainerOOMKilled",
+			wantDesc: "Alert: fires alongside KubePodCrashLooping sometimes.",
+			wantTags: []string{"imported", "playbook", "kubecontaineroomkilled", "kubepodcrashlooping"},
+			wantDest: "playbooks/kubecontaineroomkilled.md",
+		},
+		{
+			name:   "valid existing type passes through untouched",
+			source: "concepts/slo.md",
+			data:   "---\ntype: Concept\ntitle: SLO policy\ndescription: how we set SLOs\n---\nbody\n",
+			wantType: "Concept", wantTitle: "SLO policy", wantDesc: "how we set SLOs",
+			wantTags: []string{"imported", "concept"},
+			wantDest: "concepts/slo-policy.md",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := Infer([]byte(c.data), c.source)
+			if r.Entry.Type != c.wantType {
+				t.Errorf("type = %q, want %q", r.Entry.Type, c.wantType)
+			}
+			if r.Entry.Title != c.wantTitle {
+				t.Errorf("title = %q, want %q", r.Entry.Title, c.wantTitle)
+			}
+			if r.Entry.Description != c.wantDesc {
+				t.Errorf("description = %q, want %q", r.Entry.Description, c.wantDesc)
+			}
+			if r.Entry.Resource != c.wantRes {
+				t.Errorf("resource = %q, want %q", r.Entry.Resource, c.wantRes)
+			}
+			if !reflect.DeepEqual(r.Entry.Tags, c.wantTags) {
+				t.Errorf("tags = %v, want %v", r.Entry.Tags, c.wantTags)
+			}
+			if r.DestPath != c.wantDest {
+				t.Errorf("dest = %q, want %q", r.DestPath, c.wantDest)
+			}
+			if r.Meta.Timestamp != c.wantTimestamp {
+				t.Errorf("timestamp = %q, want %q", r.Meta.Timestamp, c.wantTimestamp)
+			}
+			if r.Source != c.source {
+				t.Errorf("source = %q, want %q", r.Source, c.source)
+			}
+		})
+	}
+}
+
+func TestInferLongTitleCapped(t *testing.T) {
+	r := Infer([]byte("# "+strings.Repeat("verylongword ", 30)+"\n\nbody\n"), "x.md")
+	if len(r.Entry.Title) > 120 {
+		t.Fatalf("title must satisfy the 120-byte merge gate, got %d bytes", len(r.Entry.Title))
+	}
+}
+
+func TestInferUnparseableDateDropsWithWarning(t *testing.T) {
+	r := Infer([]byte("---\ntitle: t\ndate: last tuesday\n---\nbody\n"), "x.md")
+	if r.Meta.Timestamp != "" {
+		t.Fatalf("unparseable date must be dropped, got %q", r.Meta.Timestamp)
+	}
+	if len(r.Warnings) == 0 {
+		t.Fatal("dropping the date must warn")
+	}
+}
+```
+
+- [ ] Run `go test ./internal/kbimport/ -run TestInfer -v` — expected FAIL (package does not exist).
+- [ ] Create `internal/kbimport/infer.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kbimport converts existing markdown runbooks/postmortems into
+// OKF-compatible catalog entries — the cold-start answer: deterministic
+// frontmatter inference (Infer), dedup against the live catalog (Plan), and
+// an optional LLM refinement (Enrich). It is pure (no I/O, no clock); the
+// command layer in internal/app does the walking, validating, and writing.
+package kbimport
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/kbvalidate"
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Result is one source document converted to an importable entry.
+type Result struct {
+	Entry    providers.KBEntry // reuses the curator/forge entry struct — no parallel format
+	Meta     okf.Meta          // preserved source timestamp/status/last_validated
+	DestPath string            // bundle-relative destination, e.g. playbooks/redis-failover.md
+	Source   string            // source path, for reporting
+	Warnings []string
+}
+
+// sourceMeta is the tolerant superset of frontmatter keys recognized in a
+// source document. Unknown keys are collected via the raw map for a warning.
+type sourceMeta struct {
+	Type          string   `yaml:"type"`
+	Title         string   `yaml:"title"`
+	Description   string   `yaml:"description"`
+	Resource      string   `yaml:"resource"`
+	Tags          []string `yaml:"tags"`
+	Timestamp     string   `yaml:"timestamp"`
+	Date          string   `yaml:"date"` // common in postmortems; folded into timestamp
+	Status        string   `yaml:"status"`
+	LastValidated string   `yaml:"last_validated"`
+}
+
+var validTypes = map[string]bool{"Incident": true, "Playbook": true, "Concept": true}
+
+// Infer derives normalized OKF frontmatter for one markdown document, purely
+// from its existing frontmatter, headings, and content. Deterministic by
+// construction — same input, same entry — so imports are reviewable diffs,
+// not model output. It never fabricates: resource is passthrough-only, and a
+// document is an Incident only when it already carries the OKF evidence
+// sections the merge gate demands.
+func Infer(data []byte, source string) Result {
+	r := Result{Source: source}
+	fm, body := catalog.SplitFrontmatter(data)
+	var meta sourceMeta
+	if len(fm) > 0 {
+		if err := yaml.Unmarshal(fm, &meta); err != nil {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("unparseable frontmatter ignored: %v", err))
+		} else if extra := unknownKeys(fm); len(extra) > 0 {
+			r.Warnings = append(r.Warnings, "frontmatter keys not carried over: "+strings.Join(extra, ", "))
+		}
+	}
+	b := string(body)
+
+	title := inferTitle(meta.Title, b, source)
+	resource := strings.TrimSpace(meta.Resource)
+	if strings.ContainsAny(resource, " \t\r\n") {
+		r.Warnings = append(r.Warnings, fmt.Sprintf("resource %q dropped: must be whitespace-free (namespace/name)", resource))
+		resource = ""
+	}
+	typ := inferType(meta.Type, b, resource)
+
+	r.Entry = providers.KBEntry{
+		Type:        typ,
+		Title:       title,
+		Description: inferDescription(meta.Description, b, title),
+		Resource:    resource,
+		Tags:        inferTags(meta.Tags, b, typ),
+		Body:        b,
+	}
+	r.Meta = okf.Meta{Status: meta.Status, LastValidated: meta.LastValidated}
+	if ts := firstNonEmpty(meta.Timestamp, meta.Date); ts != "" {
+		if _, ok := catalog.ParseEntryDate(ts); ok {
+			r.Meta.Timestamp = ts
+		} else {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("unparseable date %q dropped (want RFC3339 or 2006-01-02)", ts))
+		}
+	}
+	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(typ), okf.Slugify(title))
+	return r
+}
+
+// inferType: a valid declared type wins; else Incident iff the body already
+// carries the gate's required sections (kbvalidate.requiredIncidentSections)
+// AND a resource (Incident requires one); else Playbook — the relaxed,
+// free-form-runbook type.
+func inferType(declared, body, resource string) string {
+	if validTypes[strings.TrimSpace(declared)] {
+		return strings.TrimSpace(declared)
+	}
+	secs := kbvalidate.Sections(body)
+	if resource != "" && secs["symptom"] != "" && secs["cause"] != "" && secs["resolution"] != "" {
+		return "Incident"
+	}
+	return "Playbook"
+}
+
+// inferTitle: frontmatter title → first #/## heading → humanized filename
+// stem. Always capped to the merge gate's single-line 120-byte budget.
+func inferTitle(declared, body, source string) string {
+	if t := curator.CapTitle(declared); t != "" {
+		return t
+	}
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		for _, p := range []string{"# ", "## "} {
+			if strings.HasPrefix(t, p) {
+				if h := curator.CapTitle(strings.TrimPrefix(t, p)); h != "" {
+					return h
+				}
+			}
+		}
+	}
+	stem := strings.TrimSuffix(filepath.Base(source), ".md")
+	return curator.CapTitle(strings.NewReplacer("-", " ", "_", " ").Replace(stem))
+}
+
+// descriptionMaxRunes bounds the inferred description; it only has to be
+// non-empty (the gate) and scannable in `lore kb search` output.
+const descriptionMaxRunes = 240
+
+// inferDescription: frontmatter description → first prose line of the body
+// (headings, code fences, and blank lines skipped; list/quote markers
+// stripped) → the title, so the gate's non-empty requirement always holds.
+func inferDescription(declared, body, title string) string {
+	if d := strings.TrimSpace(declared); d != "" {
+		return capRunes(strings.Join(strings.Fields(d), " "), descriptionMaxRunes)
+	}
+	inFence := false
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || t == "" || strings.HasPrefix(t, "#") || t == "---" {
+			continue
+		}
+		t = strings.TrimSpace(strings.TrimLeft(t, "-*> "))
+		if t != "" {
+			return capRunes(strings.Join(strings.Fields(t), " "), descriptionMaxRunes)
+		}
+	}
+	return title
+}
+
+// maxTags bounds the tag list; tags feed the BM25 corpus, and past ~10 the
+// extra ones are noise, not recall signal.
+const maxTags = 10
+
+// alertNameRe matches CamelCase tokens with ≥2 humps — the Prometheus
+// alert-name shape (KubePodCrashLooping, TargetDown). Only headings and
+// alert-mentioning lines are scanned, which keeps ordinary CamelCase prose
+// (product names) from flooding the tags.
+var alertNameRe = regexp.MustCompile(`\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+\b`)
+
+// inferTags mirrors curator.entryTags' shape (constant pair first, derived
+// signal after, deduped, lowercased): imported + type, then the source's own
+// tags, then detected alert-name patterns.
+func inferTags(declared []string, body, typ string) []string {
+	tags := []string{"imported", strings.ToLower(typ)}
+	seen := map[string]bool{tags[0]: true, tags[1]: true}
+	add := func(t string) {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t != "" && !seen[t] && len(tags) < maxTags {
+			seen[t] = true
+			tags = append(tags, t)
+		}
+	}
+	for _, t := range declared {
+		add(t)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "#") && !strings.Contains(strings.ToLower(t), "alert") {
+			continue
+		}
+		for _, m := range alertNameRe.FindAllString(t, -1) {
+			add(m)
+		}
+	}
+	return tags
+}
+
+// unknownKeys lists top-level frontmatter keys Infer does not carry over,
+// so the import report tells the user what was left behind.
+func unknownKeys(fm []byte) []string {
+	known := map[string]bool{
+		"type": true, "title": true, "description": true, "resource": true,
+		"tags": true, "timestamp": true, "date": true, "status": true, "last_validated": true,
+	}
+	var raw map[string]any
+	if yaml.Unmarshal(fm, &raw) != nil {
+		return nil
+	}
+	var out []string
+	for k := range raw {
+		if !known[k] {
+			out = append(out, k)
+		}
+	}
+	sortStrings(out)
+	return out
+}
+
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j] < s[j-1]; j-- {
+			s[j], s[j-1] = s[j-1], s[j]
+		}
+	}
+}
+
+func capRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return strings.TrimRight(string(r[:n]), " ") + "…"
+}
+
+func firstNonEmpty(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return strings.TrimSpace(a)
+	}
+	return strings.TrimSpace(b)
+}
+```
+
+  (If `sortStrings` trips the linter, use `sort.Strings` from stdlib instead — either is fine; prefer `sort.Strings`.)
+- [ ] Run `go test ./internal/kbimport/ -run TestInfer -v` — expected PASS. Check the import cycle is clean: `kbimport → {catalog, curator, kbvalidate, okf, providers}`; none of those import `kbimport` (verify with `go build ./...`).
+- [ ] Commit: `feat(kbimport): deterministic OKF frontmatter inference for existing runbooks`
+
+### Task 4: `internal/kbimport` — dedup plan against the existing catalog
+
+`Plan` decides, per inferred result and **in input order**, import vs skip. Skip reasons, checked in order:
+
+1. `source marked retired` — the source's own `status: retired` is respected (importing it as-is would add dead weight; the warning tells the user why).
+2. `destination exists: <path>` — an existing catalog entry already occupies `DestPath` (also what makes a re-run of the same import a clean no-op).
+3. `duplicate of <path>` — exact normalized-title match or `curate.TitleJaccard ≥ 0.6` (the same threshold `curate.Dedup` uses, `internal/curate/dedup.go:20`) against any existing entry title.
+4. `destination collides with <source> in this batch` — two sources slugging to the same path; first wins.
+
+**Files:**
+- Create: `internal/kbimport/plan.go`
+- Test: `internal/kbimport/plan_test.go`
+
+**Steps:**
+
+- [ ] Write the failing test `internal/kbimport/plan_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func res(title, dest, source string) Result {
+	return Result{
+		Entry:    providers.KBEntry{Type: "Playbook", Title: title, Description: title, Body: "body"},
+		DestPath: dest, Source: source,
+	}
+}
+
+func TestPlanDedup(t *testing.T) {
+	existing := []catalog.Entry{
+		{Path: "playbooks/redis-failover.md", Title: "Redis failover"},
+		{Path: "incidents/payments-outage.md", Title: "Payments API outage March 2024"},
+	}
+	retired := res("Old thing", "playbooks/old-thing.md", "old.md")
+	retired.Meta = okf.Meta{Status: "retired"}
+	in := []Result{
+		res("Postgres vacuum tuning", "playbooks/postgres-vacuum-tuning.md", "a.md"), // novel → import
+		res("Anything", "playbooks/redis-failover.md", "b.md"),                        // path taken → skip
+		res("Payments API outage — March 2024", "playbooks/payments-api-outage-march-2024.md", "c.md"), // fuzzy title dup → skip
+		retired, // retired at source → skip
+		res("Postgres vacuum tuning", "playbooks/postgres-vacuum-tuning.md", "e.md"), // batch collision → skip
+	}
+	got := Plan(in, existing)
+	if len(got) != len(in) {
+		t.Fatalf("Plan must return one action per result, got %d", len(got))
+	}
+	wantSkip := []struct {
+		skip   bool
+		reason string
+	}{
+		{false, ""},
+		{true, "destination exists"},
+		{true, "duplicate of incidents/payments-outage.md"},
+		{true, "retired"},
+		{true, "collides"},
+	}
+	for i, w := range wantSkip {
+		if got[i].Skip != w.skip {
+			t.Errorf("action %d (%s): skip = %v, want %v (reason %q)", i, in[i].Source, got[i].Skip, w.skip, got[i].Reason)
+		}
+		if w.reason != "" && !strings.Contains(got[i].Reason, w.reason) {
+			t.Errorf("action %d: reason %q must mention %q", i, got[i].Reason, w.reason)
+		}
+	}
+}
+```
+
+- [ ] Run `go test ./internal/kbimport/ -run TestPlanDedup -v` — expected FAIL (`Plan` undefined).
+- [ ] Create `internal/kbimport/plan.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/curate"
+)
+
+// Action is Plan's verdict on one inferred result.
+type Action struct {
+	Result
+	Skip   bool
+	Reason string // set when Skip
+}
+
+// dupThreshold matches curate.Dedup's default title-Jaccard threshold: a
+// duplicate at import time is the same notion as a duplicate at curation
+// time. Conservative both ways — a missed dup lands in review as a visible
+// extra file; a wrong skip loses knowledge silently, so we require ≥0.6.
+const dupThreshold = 0.6
+
+// Plan dedups inferred results against the existing catalog and against each
+// other, preserving input order. It only decides — the caller reports/writes.
+func Plan(results []Result, existing []catalog.Entry) []Action {
+	takenPath := map[string]string{} // dest path -> occupant (existing entry path or batch source)
+	for _, e := range existing {
+		takenPath[e.Path] = e.Path
+	}
+	out := make([]Action, 0, len(results))
+	for _, r := range results {
+		a := Action{Result: r}
+		switch {
+		case strings.EqualFold(strings.TrimSpace(r.Meta.Status), "retired"):
+			a.Skip, a.Reason = true, "source marked retired"
+		case existingPathTaken(takenPath, r.DestPath, existing):
+			a.Skip, a.Reason = true, fmt.Sprintf("destination exists: %s", r.DestPath)
+		default:
+			if dup, ok := duplicateOf(r.Entry.Title, existing); ok {
+				a.Skip, a.Reason = true, "duplicate of "+dup
+			} else if occ, taken := takenPath[r.DestPath]; taken {
+				a.Skip, a.Reason = true, fmt.Sprintf("destination %s collides with %s in this batch", r.DestPath, occ)
+			} else {
+				takenPath[r.DestPath] = r.Source
+			}
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// existingPathTaken reports whether dest is already an EXISTING catalog
+// entry's path (batch collisions are reported separately, with a clearer
+// message naming the other source).
+func existingPathTaken(taken map[string]string, dest string, existing []catalog.Entry) bool {
+	occ, ok := taken[dest]
+	return ok && occ == dest && isExisting(dest, existing)
+}
+
+func isExisting(path string, existing []catalog.Entry) bool {
+	for _, e := range existing {
+		if e.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// duplicateOf finds an existing entry whose title matches: exact after
+// whitespace/case normalization, or fuzzy at curate's own Jaccard threshold.
+func duplicateOf(title string, existing []catalog.Entry) (string, bool) {
+	norm := strings.ToLower(strings.Join(strings.Fields(title), " "))
+	for _, e := range existing {
+		if strings.ToLower(strings.Join(strings.Fields(e.Title), " ")) == norm {
+			return e.Path, true
+		}
+		if curate.TitleJaccard(title, e.Title) >= dupThreshold {
+			return e.Path, true
+		}
+	}
+	return "", false
+}
+```
+
+- [ ] Run `go test ./internal/kbimport/ -run TestPlanDedup -v` — expected PASS. (Simplification note for the implementer: if `existingPathTaken`'s double bookkeeping reads awkwardly, an equally correct shape is two maps — `existingPaths map[string]bool` and `batchPaths map[string]string` — checked in that order. Keep whichever version the test passes with and reads cleaner.)
+- [ ] Commit: `feat(kbimport): dedup import plan against the existing catalog`
+
+### Task 5: `internal/kbimport` — optional `--model` frontmatter enrichment
+
+`Enrich` mirrors `kbvalidate.ReviewSemantic` (`internal/kbvalidate/semantic.go:67`) exactly in spirit: a single forced tool call (`ToolChoice`, `providers.CompletionRequest` at `internal/providers/providers.go:782-793`), and it **never gates** — nil model, model error, missing tool call, or junk output all return the deterministic result untouched (plus a warning). The model may refine `title`, `description`, `tags`, and `type`; it may **not** invent `resource` (passthrough-only stays the rule) and the returned title is re-capped with `curator.CapTitle`. `DestPath` is recomputed from the (possibly new) type+title.
+
+**Files:**
+- Create: `internal/kbimport/enrich.go`
+- Test: `internal/kbimport/enrich_test.go`
+
+**Steps:**
+
+- [ ] Write the failing test `internal/kbimport/enrich_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeModel returns a canned response (or error) for the single Complete call.
+type fakeModel struct {
+	resp providers.CompletionResponse
+	err  error
+}
+
+func (f fakeModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	return f.resp, f.err
+}
+
+func TestEnrichAppliesModelFields(t *testing.T) {
+	r := res("pg vacuum tuning", "playbooks/pg-vacuum-tuning.md", "a.md")
+	m := fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{
+		Name: "submit_frontmatter",
+		Args: `{"title":"Postgres autovacuum tuning","description":"tune autovacuum thresholds before bloat","tags":["postgres","autovacuum"],"type":"Playbook"}`,
+	}}}}
+	got := Enrich(context.Background(), r, m)
+	if got.Entry.Title != "Postgres autovacuum tuning" {
+		t.Fatalf("title = %q", got.Entry.Title)
+	}
+	if got.Entry.Description != "tune autovacuum thresholds before bloat" {
+		t.Fatalf("description = %q", got.Entry.Description)
+	}
+	if got.DestPath != "playbooks/postgres-autovacuum-tuning.md" {
+		t.Fatalf("DestPath must follow the new title, got %q", got.DestPath)
+	}
+	want := map[string]bool{"imported": true, "playbook": true, "postgres": true, "autovacuum": true}
+	for _, tag := range got.Entry.Tags {
+		if !want[tag] {
+			t.Fatalf("unexpected tag %q in %v", tag, got.Entry.Tags)
+		}
+	}
+}
+
+func TestEnrichNeverGates(t *testing.T) {
+	r := res("pg vacuum tuning", "playbooks/pg-vacuum-tuning.md", "a.md")
+	for name, m := range map[string]providers.ModelProvider{
+		"nil model":    nil,
+		"model error":  fakeModel{err: errors.New("boom")},
+		"no tool call": fakeModel{resp: providers.CompletionResponse{Text: "prose"}},
+		"bad json":     fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{Name: "submit_frontmatter", Args: "{"}}}},
+		"invalid type": fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{Name: "submit_frontmatter", Args: `{"type":"Postmortem"}`}}}},
+	} {
+		got := Enrich(context.Background(), r, m)
+		if got.Entry.Title != r.Entry.Title || got.Entry.Type != r.Entry.Type || got.DestPath != r.DestPath {
+			t.Fatalf("%s: enrichment must fall back to the deterministic result, got %+v", name, got.Entry)
+		}
+	}
+}
+
+func TestEnrichNeverInventsResource(t *testing.T) {
+	r := res("t", "playbooks/t.md", "a.md")
+	m := fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{
+		Name: "submit_frontmatter", Args: `{"resource":"prod/db"}`,
+	}}}}
+	if got := Enrich(context.Background(), r, m); got.Entry.Resource != "" {
+		t.Fatalf("model must not set resource, got %q", got.Entry.Resource)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/kbimport/ -run TestEnrich -v` — expected FAIL (`Enrich` undefined).
+- [ ] Create `internal/kbimport/enrich.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const submitFrontmatterName = "submit_frontmatter"
+
+func submitFrontmatterSpec() providers.ToolSpec {
+	return providers.ToolSpec{
+		Name:        submitFrontmatterName,
+		Description: "Submit refined OKF frontmatter for the runbook being imported.",
+		Schema: `{
+  "type": "object",
+  "properties": {
+    "title": {"type": "string", "description": "concise, specific, one line"},
+    "description": {"type": "string", "description": "one-sentence summary of when this entry applies"},
+    "tags": {"type": "array", "items": {"type": "string"}, "description": "lowercase recall keywords incl. alert names"},
+    "type": {"type": "string", "enum": ["Incident", "Playbook", "Concept"]}
+  }
+}`,
+	}
+}
+
+const enrichSystemPrompt = `You refine YAML frontmatter for an SRE runbook being imported into a knowledge
+catalog. You are given the deterministic draft frontmatter and the document body.
+Improve title/description/tags only where the draft is weak; keep them faithful
+to the document — never invent facts. Answer ONLY via submit_frontmatter.`
+
+// Enrich optionally refines a Result's frontmatter with the configured model.
+// It NEVER gates (mirrors kbvalidate.ReviewSemantic): nil model, a model
+// error, a missing tool call, or unusable output all return r unchanged apart
+// from a warning — the deterministic Infer output is always a valid fallback.
+// The model cannot set resource (passthrough-only), the title is re-capped to
+// the merge gate's budget, and DestPath follows the refined type+title.
+func Enrich(ctx context.Context, r Result, m providers.ModelProvider) Result {
+	if m == nil {
+		return r
+	}
+	prompt := fmt.Sprintf("Draft frontmatter:\ntype: %s\ntitle: %s\ndescription: %s\ntags: %s\n\nDocument body:\n\n%s",
+		r.Entry.Type, r.Entry.Title, r.Entry.Description, strings.Join(r.Entry.Tags, ", "), r.Entry.Body)
+	resp, err := m.Complete(ctx, providers.CompletionRequest{
+		System:     enrichSystemPrompt,
+		Messages:   []providers.Message{{Role: "user", Content: prompt}},
+		Tools:      []providers.ToolSpec{submitFrontmatterSpec()},
+		ToolChoice: submitFrontmatterName,
+	})
+	if err != nil {
+		r.Warnings = append(r.Warnings, fmt.Sprintf("model enrichment skipped: %v", err))
+		return r
+	}
+	for _, tc := range resp.ToolCalls {
+		if tc.Name != submitFrontmatterName {
+			continue
+		}
+		var raw struct {
+			Title       string   `json:"title"`
+			Description string   `json:"description"`
+			Tags        []string `json:"tags"`
+			Type        string   `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(tc.Args), &raw); err != nil {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("model enrichment skipped: unparseable output: %v", err))
+			return r
+		}
+		return apply(r, raw.Title, raw.Description, raw.Tags, raw.Type)
+	}
+	r.Warnings = append(r.Warnings, "model enrichment skipped: model answered without calling submit_frontmatter")
+	return r
+}
+
+// apply merges model output over the deterministic result field by field,
+// keeping every invariant Infer established.
+func apply(r Result, title, description string, tags []string, typ string) Result {
+	if t := curator.CapTitle(title); t != "" {
+		r.Entry.Title = t
+	}
+	if d := strings.TrimSpace(description); d != "" {
+		r.Entry.Description = capRunes(strings.Join(strings.Fields(d), " "), descriptionMaxRunes)
+	}
+	if validTypes[strings.TrimSpace(typ)] {
+		// An Incident still needs a resource; without one, keep the inferred type.
+		if strings.TrimSpace(typ) != "Incident" || r.Entry.Resource != "" {
+			r.Entry.Type = strings.TrimSpace(typ)
+		}
+	}
+	if len(tags) > 0 {
+		r.Entry.Tags = inferTags(tags, "", r.Entry.Type) // rebuild: constant pair + model tags, deduped/capped
+	}
+	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(r.Entry.Type), slugOf(r.Entry.Title))
+	return r
+}
+```
+
+  and, in `infer.go`, factor the two `DestPath` computations through one helper so they can't drift:
+
+```go
+// slugOf is the single dest-path slug rule (Infer and Enrich share it).
+func slugOf(title string) string { return okf.Slugify(title) }
+```
+
+  (Update `Infer` to use `fmt.Sprintf("%ss/%s.md", strings.ToLower(typ), slugOf(title))`.)
+- [ ] Run `go test ./internal/kbimport/ -v` — expected PASS (all three test files).
+- [ ] Commit: `feat(kbimport): optional model enrichment of inferred frontmatter, never gating`
+
+### Task 6: `lore kb import` command — wiring, validation, dry-run, writes
+
+The command layer in `internal/app`: walk the source dir (same skip rules as `catalog.Load`, `internal/catalog/load.go:29-43` — hidden files/dirs, non-`.md`, `index.md`/`log.md`/`README.md`), Infer (+ Enrich when `--model`), Plan against `catalog.Load(--into)` (NOT `loadKBCatalog` — that helper errors on an *empty* catalog at `kb_cmd.go:57-59`, and a brand-new KB checkout legitimately has zero entries), then run each survivor through `kbvalidate.ValidateStructural` (skip-with-reason on any `SeverityError` — never write a file that would fail the repo's own merge gate), and finally either print the plan (`--dry-run`) or write files via `okf.Render`. Dispatch follows the existing pattern: a new `case "import"` in `app.RunKB` (`internal/app/kb_cmd.go:29-35`) — **stdlib flag, not cobra**, matching every other subcommand.
+
+**Files:**
+- Create: `internal/app/kb_import.go`
+- Test: `internal/app/kb_import_test.go` (unit level; the fixture e2e lands in Task 7)
+- Modify: `internal/app/kb_cmd.go` (dispatch + usage string), `cmd/lore/main.go` (usage const)
+
+**Steps:**
+
+- [ ] Write the failing unit test `internal/app/kb_import_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKBImportRequiresSrcAndDest(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runKBImport([]string{}, &buf); err == nil {
+		t.Fatal("missing source dir must error")
+	}
+	src := t.TempDir()
+	writeFile(t, src, "a.md", "# A\n\nbody\n")
+	if err := runKBImport([]string{src, "--config", filepath.Join(t.TempDir(), "nope.yaml")}, &buf); err == nil {
+		t.Fatal("no --into and no config catalog.dir must error")
+	}
+}
+
+func TestKBImportDryRunWritesNothing(t *testing.T) {
+	src, kb := t.TempDir(), t.TempDir()
+	writeFile(t, src, "redis-failover.md", "# Redis failover\n\nHow to fail over redis.\n")
+	var buf bytes.Buffer
+	if err := runKBImport([]string{src, "--into", kb, "--dry-run"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(kb, "playbooks", "redis-failover.md")); !os.IsNotExist(err) {
+		t.Fatal("--dry-run must not write files")
+	}
+	out := buf.String()
+	for _, want := range []string{"import", "playbooks/redis-failover.md", "Redis failover", "dry-run"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestKBImportSkipsReservedAndInvalid(t *testing.T) {
+	src, kb := t.TempDir(), t.TempDir()
+	writeFile(t, src, "README.md", "# not knowledge\n")
+	writeFile(t, src, "notes.txt", "not markdown")
+	// Declares Incident but has no resource/sections → fails the merge gate → skipped.
+	writeFile(t, src, "broken.md", "---\ntype: Incident\ntitle: broken\n---\nno sections\n")
+	writeFile(t, src, "ok.md", "# OK runbook\n\nA fine playbook.\n")
+	var buf bytes.Buffer
+	if err := runKBImport([]string{src, "--into", kb}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(kb, "playbooks", "ok-runbook.md")); err != nil {
+		t.Fatalf("valid entry must be written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(kb, "incidents", "broken.md")); !os.IsNotExist(err) {
+		t.Fatal("gate-failing entry must not be written")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "fails validation") {
+		t.Fatalf("skip reason must be reported:\n%s", out)
+	}
+	if strings.Contains(out, "README.md") {
+		t.Fatalf("reserved files must be silently ignored:\n%s", out)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/app/ -run TestKBImport -v` — expected FAIL (`runKBImport` undefined).
+- [ ] Create `internal/app/kb_import.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/kbimport"
+	"github.com/Smana/runlore/internal/kbvalidate"
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// runKBImport is `lore kb import <src-dir>`: the cold-start seeder. It
+// converts existing markdown runbooks/postmortems into OKF entries in a local
+// KB checkout — inferred frontmatter, merge-gate validation, dedup against
+// the live catalog — and writes files for the HUMAN to review and commit.
+// Nothing is committed or pushed; the review stays in Git, like every KB PR.
+func runKBImport(args []string, w io.Writer) error {
+	fset := flag.NewFlagSet("kb import", flag.ContinueOnError)
+	cfgPath := fset.String("config", "runlore.yaml", "path to config file")
+	into := fset.String("into", "", "local KB checkout to write into (default: config catalog.dir)")
+	dryRun := fset.Bool("dry-run", false, "print the import plan; write nothing")
+	useModel := fset.Bool("model", false, "refine frontmatter with the configured model (optional; import is deterministic without it)")
+	rest, err := parseInterleaved(fset, args)
+	if err != nil {
+		return err
+	}
+	const usage = "usage: lore kb import <src-dir> [--into <kb-dir>] [--dry-run] [--model] [--config <path>]"
+	if len(rest) != 1 {
+		return fmt.Errorf("%s", usage)
+	}
+	src := rest[0]
+
+	dest := *into
+	if dest == "" {
+		cfg, cerr := config.Load(*cfgPath)
+		if cerr != nil {
+			return fmt.Errorf("load config: %w (or pass --into <kb-dir>)", cerr)
+		}
+		dest = cfg.Catalog.Dir
+		if dest == "" {
+			return fmt.Errorf("no destination (set catalog.dir or pass --into <kb-dir>)")
+		}
+	}
+	if st, serr := os.Stat(dest); serr != nil || !st.IsDir() {
+		return fmt.Errorf("KB dir %s is not a directory (clone your KB repo checkout first): %v", dest, serr)
+	}
+
+	// Optional model — same opt-in shape as `lore validate-kb --semantic`:
+	// no usable model config degrades to deterministic-only with a warning.
+	var model providers.ModelProvider
+	if *useModel {
+		if cfg, cerr := config.Load(*cfgPath); cerr == nil && ModelConfigured(cfg) {
+			model = BuildModel(cfg, os.Getenv(cfg.Model.APIKeyEnv))
+		} else {
+			fmt.Fprintln(os.Stderr, "kb import: --model set but no usable model in config; running deterministic only")
+		}
+	}
+
+	// Existing catalog, loaded tolerantly: an EMPTY checkout is fine (that is
+	// the cold start this command exists for), and one malformed existing
+	// entry must not block seeding (catalog.Load already skip-warns).
+	existing, skippedLoad, err := catalog.Load(dest)
+	if err != nil {
+		return fmt.Errorf("load existing catalog %s: %w", dest, err)
+	}
+	for _, s := range skippedLoad {
+		fmt.Fprintf(os.Stderr, "warning: existing entry skipped during dedup scan: %s\n", s)
+	}
+
+	sources, err := collectSources(src)
+	if err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("no importable .md files under %s", src)
+	}
+
+	results := make([]kbimport.Result, 0, len(sources))
+	for _, p := range sources {
+		data, rerr := os.ReadFile(p) //nolint:gosec // G304: user-passed import directory
+		if rerr != nil {
+			return rerr
+		}
+		rel, _ := filepath.Rel(src, p)
+		r := kbimport.Infer(data, rel)
+		if model != nil {
+			r = kbimport.Enrich(context.Background(), r, model)
+		}
+		results = append(results, r)
+	}
+
+	actions := kbimport.Plan(results, existing)
+
+	// Merge-gate validation: never write an entry `lore validate-kb` would
+	// reject. Errors demote the action to a skip; warnings are reported only.
+	for i := range actions {
+		if actions[i].Skip {
+			continue
+		}
+		issues := kbvalidate.ValidateStructural(toCatalogEntry(actions[i].Result))
+		for _, iss := range issues {
+			if iss.Severity == kbvalidate.SeverityWarning {
+				actions[i].Warnings = append(actions[i].Warnings, fmt.Sprintf("%s: %s", iss.Field, iss.Message))
+			}
+		}
+		if kbvalidate.HasErrors(issues) {
+			first := firstError(issues)
+			actions[i].Skip = true
+			actions[i].Reason = fmt.Sprintf("fails validation: %s: %s", first.Field, first.Message)
+		}
+	}
+
+	imported, skipped := 0, 0
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "ACTION\tSOURCE\tDEST\tTYPE\tTITLE / REASON")
+	for _, a := range actions {
+		for _, warn := range a.Warnings {
+			fmt.Fprintf(os.Stderr, "warning: %s: %s\n", a.Source, warn)
+		}
+		if a.Skip {
+			skipped++
+			fmt.Fprintf(tw, "skip\t%s\t-\t-\t%s\n", a.Source, a.Reason)
+			continue
+		}
+		imported++
+		fmt.Fprintf(tw, "import\t%s\t%s\t%s\t%s\n", a.Source, a.DestPath, a.Entry.Type, truncateCell(a.Entry.Title, 60))
+		if *dryRun {
+			continue
+		}
+		out := filepath.Join(dest, filepath.FromSlash(a.DestPath))
+		if merr := os.MkdirAll(filepath.Dir(out), 0o755); merr != nil {
+			return merr
+		}
+		if werr := os.WriteFile(out, []byte(okf.Render(a.Entry, a.Meta)), 0o644); werr != nil { //nolint:gosec // G306: catalog files are world-readable docs
+			return werr
+		}
+	}
+	_ = tw.Flush()
+	if *dryRun {
+		fmt.Fprintf(w, "\ndry-run: would import %d, skip %d (of %d sources); nothing written\n", imported, skipped, len(actions))
+		return nil
+	}
+	fmt.Fprintf(w, "\nimported %d, skipped %d (of %d sources) into %s — review the diff, then commit and push\n",
+		imported, skipped, len(actions), dest)
+	return nil
+}
+
+// collectSources walks src for importable markdown, mirroring catalog.Load's
+// skip rules (internal/catalog/load.go): hidden files/dirs, non-.md, and the
+// reserved index.md / log.md / README.md are not knowledge entries.
+func collectSources(src string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		base := d.Name()
+		if d.IsDir() {
+			if path != src && strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".md") {
+			return nil
+		}
+		if base == "index.md" || base == "log.md" || strings.EqualFold(base, "readme.md") {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	return out, err
+}
+
+// toCatalogEntry adapts an import result to the validator's input type —
+// the SAME struct the loader produces, so "valid at import" and "valid at
+// merge" are one predicate.
+func toCatalogEntry(r kbimport.Result) catalog.Entry {
+	return catalog.Entry{
+		Type: r.Entry.Type, Title: r.Entry.Title, Description: r.Entry.Description,
+		Resource: r.Entry.Resource, Tags: r.Entry.Tags, Body: r.Entry.Body,
+		Timestamp: r.Meta.Timestamp, Status: r.Meta.Status, LastValidated: r.Meta.LastValidated,
+		Path: r.DestPath,
+	}
+}
+
+func firstError(issues []kbvalidate.Issue) kbvalidate.Issue {
+	for _, iss := range issues {
+		if iss.Severity == kbvalidate.SeverityError {
+			return iss
+		}
+	}
+	return kbvalidate.Issue{Field: "unknown", Message: "validation error"}
+}
+```
+
+- [ ] Wire the dispatcher — in `internal/app/kb_cmd.go`, extend `RunKB` (line 24):
+
+```go
+	const usage = "usage: lore kb search <query> [flags] | lore kb show <entry> [flags] | lore kb import <src-dir> [flags]"
+	...
+	case "import":
+		return runKBImport(args[1:], os.Stdout)
+```
+
+- [ ] Update the usage const in `cmd/lore/main.go` (after the `kb show` line, main.go:31):
+
+```
+  lore kb import <src-dir> [--into <kb-dir>] [--dry-run] [--model]   convert existing runbooks/postmortems into OKF entries (cold-start seeding)
+```
+
+- [ ] Run `go build ./... && go test ./internal/app/ -run TestKBImport -v` — expected PASS. Note the `dry-run` assertion needs the summary line to contain the literal `dry-run` — it does.
+- [ ] Run the full suite touched so far: `go test ./internal/... ./cmd/... -count=1` — expected PASS.
+- [ ] Commit: `feat(cli): lore kb import — seed the catalog from existing markdown runbooks`
+
+### Task 7: Fixture-based end-to-end test of the command
+
+Real fixture files under `internal/app/testdata/kbimport/`, exercised through `runKBImport` exactly as a user would: first run imports + dedups, output loads back through `catalog.Load` with **zero** `kbvalidate.WarnInvalid` findings (the round-trip guarantee), second run is a clean no-op (idempotence).
+
+**Files:**
+- Create: `internal/app/testdata/kbimport/redis-failover.md`, `internal/app/testdata/kbimport/2024-03-payments-outage.md`, `internal/app/testdata/kbimport/redis-failover-copy.md`, `internal/app/testdata/kbimport/README.md`
+- Test: append to `internal/app/kb_import_test.go`
+
+**Steps:**
+
+- [ ] Create the fixtures:
+
+`internal/app/testdata/kbimport/redis-failover.md`:
+
+```markdown
+# Redis failover
+
+How to fail over the redis primary when RedisDown fires.
+
+## Steps
+
+1. Confirm the primary is unreachable: `redis-cli -h redis-0 ping`.
+2. Promote the replica: `redis-cli -h redis-1 replicaof no one`.
+3. Repoint the service selector to the new primary.
+```
+
+`internal/app/testdata/kbimport/2024-03-payments-outage.md`:
+
+```markdown
+---
+title: Payments API outage
+date: 2024-03-14
+tags: [payments, sev1]
+resource: payments/api
+type: postmortem
+---
+
+## Symptom
+
+5xx spike on payments/api starting 09:12 UTC; PaymentsHighErrorRate alert fired.
+
+## Investigate
+
+- deploy 4a1f2c rolled out at 09:10
+- error logs: connection refused to payments-db
+
+## Cause
+
+1. deploy 4a1f2c dropped the DB connection-pool env var
+
+## Resolution
+
+- rollback to the previous release; re-add the env var before re-deploying
+```
+
+`internal/app/testdata/kbimport/redis-failover-copy.md` (dedup victim — near-identical title):
+
+```markdown
+# Redis failover runbook
+
+Older copy of the failover doc kept in another folder.
+```
+
+`internal/app/testdata/kbimport/README.md`:
+
+```markdown
+Team runbooks. Not itself a runbook.
+```
+
+- [ ] Append the e2e test to `internal/app/kb_import_test.go`:
+
+```go
+func TestKBImportEndToEnd(t *testing.T) {
+	kb := t.TempDir()
+	var buf bytes.Buffer
+	if err := runKBImport([]string{"testdata/kbimport", "--into", kb}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	// The bare runbook became a Playbook; the postmortem an Incident.
+	playbook, err := os.ReadFile(filepath.Join(kb, "playbooks", "redis-failover.md"))
+	if err != nil {
+		t.Fatalf("playbook not written: %v", err)
+	}
+	for _, want := range []string{"type: Playbook", "title: Redis failover", "- redisdown", "## Steps"} {
+		if !strings.Contains(string(playbook), want) {
+			t.Errorf("playbook missing %q:\n%s", want, playbook)
+		}
+	}
+	incident, err := os.ReadFile(filepath.Join(kb, "incidents", "payments-api-outage.md"))
+	if err != nil {
+		t.Fatalf("incident not written: %v", err)
+	}
+	for _, want := range []string{"type: Incident", "resource: payments/api", "2024-03-14", "- payments", "## Cause"} {
+		if !strings.Contains(string(incident), want) {
+			t.Errorf("incident missing %q:\n%s", want, incident)
+		}
+	}
+
+	// The near-duplicate title was skipped, the README ignored.
+	if !strings.Contains(buf.String(), "duplicate of") && !strings.Contains(buf.String(), "collides") {
+		t.Fatalf("redis-failover-copy.md must be skipped as a duplicate:\n%s", buf.String())
+	}
+
+	// Round-trip guarantee: everything written loads back and passes the gate.
+	entries, skipped, err := catalog.Load(kb)
+	if err != nil || len(skipped) > 0 {
+		t.Fatalf("written entries must parse: err=%v skipped=%v", err, skipped)
+	}
+	if n := kbvalidate.WarnInvalid(entries, func(p string, errs []kbvalidate.Issue) {
+		t.Errorf("invalid written entry %s: %v", p, errs)
+	}); n != 0 {
+		t.Fatalf("%d written entries fail the merge gate", n)
+	}
+
+	// Idempotence: a second run imports nothing.
+	var buf2 bytes.Buffer
+	if err := runKBImport([]string{"testdata/kbimport", "--into", kb}, &buf2); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf2.String(), "imported 0") {
+		t.Fatalf("re-run must be a no-op:\n%s", buf2.String())
+	}
+}
+```
+
+  Add `"github.com/Smana/runlore/internal/catalog"` and `"github.com/Smana/runlore/internal/kbvalidate"` to the test file's imports.
+- [ ] Run `go test ./internal/app/ -run TestKBImportEndToEnd -v` — first run expected FAIL only if any earlier task left a gap; drive it to PASS. Two assertions carry the design: the alert tag `- redisdown` (heuristic: "RedisDown" appears in a line mentioning "fires"… — note it appears in the *first paragraph* which also contains no "alert" keyword and is not a heading; if the tag is absent, the fixture's first line legitimately doesn't match the heuristic — change the fixture line to `How to fail over the redis primary when the RedisDown alert fires.` so the "alert"-mentioning-line rule applies) and `title: Payments API outage` map `date:` → `timestamp:` preservation.
+- [ ] Run everything: `go test ./... -count=1` — expected PASS.
+- [ ] Commit: `test(kbimport): fixture end-to-end coverage for lore kb import`
+
+### Task 8: Documentation
+
+One real docs addition where evaluators actually land: a Step 1b in `docs/getting-started.md` (between Step 1 "Create the knowledge-catalog repo", line 61, and Step 2, line 128). The CLI usage line was already added in Task 6.
+
+**Files:**
+- Modify: `docs/getting-started.md`
+
+**Steps:**
+
+- [ ] Insert this section immediately before the `## Step 2 — GitHub App for curation (optional)` heading:
+
+```markdown
+## Step 1b — Seed the catalog from your existing runbooks (optional)
+
+You don't have to start empty. If your team already keeps markdown runbooks or
+postmortems anywhere, import them and get recall value on day one:
+
+​```bash
+# preview what would be written — nothing is touched
+lore kb import ./our-runbooks --into ./kb --dry-run
+
+# convert + validate + dedup, then write into your local KB checkout
+lore kb import ./our-runbooks --into ./kb
+cd kb && git add . && git commit -m "seed catalog from existing runbooks" && git push
+​```
+
+What `import` does, deterministically (no model, no config needed beyond the
+directory paths):
+
+- **Adds/normalizes OKF frontmatter** — title from the existing frontmatter or
+  the first heading (filename as last resort), description from the first
+  paragraph, tags from the document's own tags **plus detected alert names**
+  (`KubePodCrashLooping`-style tokens in headings and alert-mentioning lines —
+  exactly the recall signal that lets a future alert find the runbook).
+- **Classifies** — a document that already carries `Symptom`/`Cause`/`Resolution`
+  sections *and* names a `resource` becomes an `Incident`; everything else is a
+  `Playbook` (free-form runbooks validate relaxed, same as hand-written entries).
+- **Validates** every entry with the same merge gate as `lore validate-kb` —
+  nothing is written that the gate would later reject.
+- **Dedups** against what the catalog already holds (exact and fuzzy title, same
+  rule the curator uses for duplicate PRs) and skips it with a printed reason.
+
+Nothing is committed for you: you review the diff and push, the same
+human-in-the-loop bar as every RunLore KB PR. With `--model`, the LLM already
+configured in your `runlore.yaml` refines titles/descriptions/tags (purely
+optional — a model failure falls back to the deterministic result). Re-running
+the same import is a no-op.
+​```
+```
+
+  (Strip the zero-width escapes around the inner code fences when editing — they are only here to keep this plan's own markdown intact. The final inserted section ends after "no-op.", with a blank line before `## Step 2`.)
+- [ ] Proofread the rendered section (`grep -n "Step 1b" docs/getting-started.md`), confirm the Step numbering flow reads naturally (1 → 1b → 2).
+- [ ] Commit: `docs: getting-started Step 1b — seed the catalog with lore kb import`
+
+---
+
+## Acceptance criteria
+
+- [ ] `lore kb import <src-dir> --into <kb-dir>` converts a directory of plain markdown runbooks/postmortems into OKF entries under `<type>s/<slug>.md` in the checkout, ready to `git add` — the command never commits, pushes, or touches a forge.
+- [ ] Frontmatter inference is deterministic: same input, same output; title/description/tags/type derived from headings + content per Task 3's rules; `resource` is passthrough-only (never guessed); source `date:`/`timestamp:` preserved when parseable by `catalog.ParseEntryDate`.
+- [ ] Every written entry passes `kbvalidate.ValidateStructural` with zero errors and parses back through `catalog.Load` (round-trip pinned by `TestKBImportEndToEnd`); gate-failing sources are skipped with a printed reason, never written.
+- [ ] Dedup: exact/fuzzy title match (via the exported `curate.TitleJaccard`, threshold 0.6), existing-path and in-batch path collisions, and `status: retired` sources are all skipped with reasons; re-running the same import reports `imported 0`.
+- [ ] `--dry-run` prints the full ACTION/SOURCE/DEST/TYPE table and writes nothing.
+- [ ] `--model` is optional and never gates: nil/unconfigured model, model error, or unusable output degrade to the deterministic result with a warning; the model can never set `resource` or an out-of-vocabulary `type`.
+- [ ] No new **required** config: destination falls back to the existing `catalog.dir`; the model comes from the existing `model:` block; both are overridable by flags only.
+- [ ] No parallel entry format: the command flows through `providers.KBEntry`, the extracted `okf.Render` (which the GitHub forge now also delegates to, existing forge tests green), `kbvalidate.ValidateStructural`, and `catalog.Load`.
+- [ ] `cmd/lore/main.go` usage and `docs/getting-started.md` Step 1b document the command; `go test ./... -count=1` and `go build ./...` pass on the branch.
+- [ ] Every commit uses a conventional message with **no** Co-Authored-By line.

--- a/dev/superpowers/plans/2026-07-23-d2-curator-automation.md
+++ b/dev/superpowers/plans/2026-07-23-d2-curator-automation.md
@@ -1,0 +1,1122 @@
+# D2 — Curator automation phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the KB-lifecycle sweeps production-ready *inside the serve pod*: the grooming passes (suppression of human-rejected entries, dedup, stale-close, queue promotion, recurrence escalation, contested warnings, retirement) run on a leader-only timer with **no CronJob, no shared-volume footgun, and no new required config** — defaulting to a **dry-run (log/audit-only) posture** so the first release observes before it acts. This answers the project's #1 adoption objection: PR fatigue from an ungroomed queue.
+
+**Architecture:** The pass library in `internal/curate/` is **already complete and tested** (see "Current state" below) — this plan does *not* rewrite it. The work is four seams around it: (1) a `curate.Guard` forge wrapper that gives every pass audit records + dry-run at a single choke point (mirroring `action.NewAuditedExecutor`, `internal/app/serve.go:129`); (2) one genuinely missing pass, `Suppress`, that closes re-drafted PRs for incidents a human already rejected via close-without-merge labels; (3) a `curate.Sweeper` ticker that runs the existing `curate.Agent` on an interval, started inside `startWork` in `RunServe` so it is **leader-only** and cancelled on leadership loss (`internal/app/serve.go:290-336`); (4) `curate.sweeps.{mode,interval}` config with defaults `dry-run`/`6h`, plus a shared `BuildCurateAgent` so the CLI (`lore curate`) and the in-server sweeper can never drift. The in-server sweeps use the **live** `*outcome.Ledger` the serve pod already holds (`internal/app/serve.go:174`), eliminating the CronJob's classic misconfiguration (ledger on an unshared volume — see `LogLedgerStartup`, `internal/app/curate.go:124`).
+
+**Tech Stack:** Go 1.x (stdlib `time.Ticker`, `log/slog`), existing packages `internal/curate`, `internal/audit` (hash-chained JSONL auditor), `internal/forge/github`, `internal/outcome`, `internal/config` (yaml.v3). Helm chart `deploy/helm/runlore`. No new dependencies.
+
+---
+
+## Current state (research findings — verified 2026-07-23 on branch `roadmap/v0.11.0`)
+
+Per-module status. **This item's "phase 2" passes are NOT skeletons** — they exist, are unit-tested, and are wired into the one-shot `lore curate` CLI. What is missing is scheduling, safety posture, auditability, and one pass.
+
+| Module | Status | Evidence |
+|---|---|---|
+| `internal/curate/curate.go` — `Pass`/`Agent` runner | **exists and tested** | `curate_test.go` (per-pass error isolation) |
+| `internal/curate/dedup.go` — duplicate-PR close (fingerprint-first, Jaccard fallback) | **exists and tested** | `dedup_test.go` (6 cases incl. protected labels) |
+| `internal/curate/lifecycle.go` — stale-close sweep (`stale_after`), protected labels | **exists and tested** | `lifecycle_test.go` |
+| `internal/curate/resolution.go` — `Queue` (solved→ready-to-merge) + `LedgerResolutionChecker` | **exists and tested** | `resolution_test.go` |
+| `internal/curate/recurrence.go` — knowledge-gap issues + closed-PR escalation | **exists and tested** | `recurrence_test.go` |
+| `internal/curate/suppression.go` — `ClosedPRSuppression` (derives suppressed fingerprints from closed-unmerged PRs, `wontfix`/`not-kb-worthy` vs `needs-work`) | **exists and tested** — but only *consulted by Recurrence*; nothing closes a **re-drafted open PR** for a suppressed fingerprint (the drafter's dedup checks only open PRs + merged entries, `internal/curator/curator.go:110-133`) | `suppression_test.go` |
+| `internal/curate/contested.go` — 👎 warnings on open KB PRs | **exists and tested** | `contested_test.go` |
+| `internal/curate/retirement.go` — retire-PR proposals for decayed entries, human-veto-aware | **exists and tested** | `retirement_test.go` |
+| `internal/forge/github` — `ListPRsByLabel`, `ListClosedUnmergedPRsByLabel`, `Comment`, `Close`, `ReplaceLabel`, `OpenIssue`, `OpenRetirePR`, `ListIssueCommentBodies`, `IsPROpen` | **exists and tested** | `github.go:241,258,285,305,351,363,101,315,339`, `retire.go:64`; `github_test.go`, `retire_test.go` |
+| `internal/app/curate.go` — `RunCurate` CLI wiring of all passes | **exists and tested** (compile-time seam pins at `curate_test.go:22-25`) | wiring block lines 59–107 |
+| Helm CronJob (`curate.cronjob.enabled`, default off) | **exists** | `deploy/helm/runlore/templates/cronjob.yaml`, `values.yaml:494-500` |
+| **In-server scheduler** (sweeps in the serve pod, leader-aware) | **missing — the D2 gap** | no `curate` reference anywhere in `internal/app/serve.go` |
+| **Dry-run / log-only mode** for the passes | **missing** | no dry-run flag or wrapper anywhere in `internal/curate` |
+| **Audit records** for automated forge actions | **missing** | `internal/audit` is only used by action executors (`internal/app/action.go:30`) |
+| **Suppression sweep** (close re-drafts of human-rejected entries) | **missing** (see suppression row above) | — |
+| `curate.*` config | `stale_after`, `recurrence_threshold`, `retirement.*` **exist, validated, defaulted** (`internal/config/config.go:1268-1287`, `:1221-1230`; `load.go:190-205`) — **no scheduling/mode keys** | `config_retirement_test.go`, `config_test.go:132-136` |
+| Leader election | **exists** — `startWork(workCtx)` runs leader-only loops; ticker precedent: `Reinvestigator.Poll` (`internal/investigate/reinvestigate.go:34-48`) started at `serve.go:315` | `serve.go:290-336`, `leader_identity.go` |
+
+**Locked design decisions:**
+
+- **Default posture: dry-run.** Sweeps auto-enable whenever forge credentials (`forge.github_app` + `forge.kb_repo`) already exist, but in `dry-run` mode they perform **zero forge writes** — every candidate action is slog-logged and audit-recorded (`Decision: dry-run`). Auto-writing to the user's repo on upgrade would violate least-surprise; auto-*observing* is safe and demonstrates value ("sweeps would have closed 7 stale PRs"). `mode: apply` is one config line. This satisfies "no new REQUIRED config": all keys default.
+- **Leader-only, flap-proof.** The sweeper starts inside `startWork` (cancelled with `workCtx` on leadership loss) and waits **one full interval before the first sweep**, so leader flaps can never stampede the forge with immediate re-sweeps.
+- **One write seam.** Dry-run + audit live in a `Guard` wrapper around the forge client, not in each pass — the passes stay untouched and their tests stay valid.
+- **CronJob stays** (documented as the alternative for users who want sweeps out of the serve pod); both paths share `BuildCurateAgent`, and every pass is idempotent, so running both is safe (just wasteful).
+
+---
+
+### Task 1: Config — `curate.sweeps.{mode,interval}` with dry-run/6h defaults and validation
+
+**Files:**
+- `internal/config/config.go` — add `Sweeps` field to `Curate` (struct at line 1268-1279), new `Sweeps` type + mode constants after `Retirement` (line 1281-1287), validation clause next to the retirement clause (after line 1230)
+- `internal/config/load.go` — default fill in `applyDefaults` (after the retirement block, line 190-205)
+- `internal/config/config_sweeps_test.go` — new
+
+**Steps:**
+
+- [ ] Write the failing test `internal/config/config_sweeps_test.go` (style: `config_retirement_test.go` — partial `Config` structs, `strings.Contains` on `Validate()` errors):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSweepsDefaults(t *testing.T) {
+	// Zero value ⇒ sweeps enabled in dry-run at 6h: safe-by-default, no required config.
+	var c Config
+	applyDefaults(&c)
+	if got := c.Curate.Sweeps.Interval.Std(); got != 6*time.Hour {
+		t.Fatalf("sweeps.interval default: want 6h, got %v", got)
+	}
+	if !c.Curate.Sweeps.Enabled() || !c.Curate.Sweeps.DryRun() {
+		t.Fatalf("zero-value sweeps must be enabled in dry-run, got mode=%q", c.Curate.Sweeps.Mode)
+	}
+}
+
+func TestSweepsModeParsesAndGates(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("curate:\n  sweeps:\n    mode: apply\n    interval: 1h\n"), &c); err != nil {
+		t.Fatal(err)
+	}
+	if c.Curate.Sweeps.DryRun() || !c.Curate.Sweeps.Enabled() {
+		t.Fatalf("mode: apply must be enabled and not dry-run, got %q", c.Curate.Sweeps.Mode)
+	}
+	if got := c.Curate.Sweeps.Interval.Std(); got != time.Hour {
+		t.Fatalf("interval: want 1h, got %v", got)
+	}
+	var off Config
+	if err := yaml.Unmarshal([]byte("curate:\n  sweeps:\n    mode: \"off\"\n"), &off); err != nil {
+		t.Fatal(err)
+	}
+	if off.Curate.Sweeps.Enabled() {
+		t.Fatal("mode: off must disable sweeps")
+	}
+}
+
+func TestSweepsValidation(t *testing.T) {
+	bad := Config{Curate: Curate{Sweeps: Sweeps{Mode: "sometimes"}}}
+	if err := bad.Validate(); err == nil || !strings.Contains(err.Error(), "curate.sweeps.mode") {
+		t.Fatalf("unknown mode must error on curate.sweeps.mode, got %v", err)
+	}
+	fast := Config{Curate: Curate{Sweeps: Sweeps{Interval: Duration(time.Minute)}}}
+	if err := fast.Validate(); err == nil || !strings.Contains(err.Error(), "curate.sweeps.interval") {
+		t.Fatalf("sub-10m interval must error on curate.sweeps.interval, got %v", err)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/config/ -run 'TestSweeps' -v` — expect **FAIL** (compile error: `unknown field Sweeps in struct literal of type Curate`)
+- [ ] Implement in `internal/config/config.go`. Add to the `Curate` struct (after the `Retirement` field, line 1278):
+
+```go
+	// Sweeps configures the in-server scheduled grooming loop (leader-only, run by
+	// the serve pod). Default mode is dry-run: candidates are logged and audited but
+	// no forge write happens until the operator sets mode: apply. mode: off disables
+	// the loop entirely (the opt-in CronJob remains the out-of-server alternative).
+	Sweeps Sweeps `yaml:"sweeps"`
+```
+
+  and after the `Retirement` type (line 1287):
+
+```go
+// Sweep modes: dry-run observes (log + audit, zero forge writes), apply acts,
+// off disables the in-server loop. Empty means dry-run — safe by default.
+const (
+	SweepOff    = "off"
+	SweepDryRun = "dry-run"
+	SweepApply  = "apply"
+)
+
+// Sweeps configures the in-server scheduled grooming sweeps.
+type Sweeps struct {
+	Mode     string   `yaml:"mode"`     // "" ⇒ dry-run | "apply" | "off"
+	Interval Duration `yaml:"interval"` // default 6h; the first sweep waits one full interval
+}
+
+// Enabled reports whether the in-server sweep loop should run at all.
+func (s Sweeps) Enabled() bool { return s.Mode != SweepOff }
+
+// DryRun reports whether sweeps must not write to the forge (the default posture).
+func (s Sweeps) DryRun() bool { return s.Mode == "" || s.Mode == SweepDryRun }
+```
+
+- [ ] Add the validation clause in `Validate()` (immediately after the retirement clause ending at line 1230):
+
+```go
+	// In-server sweeps: an unknown mode must fail loud (a typo like "apply" silently
+	// falling back to dry-run would mean the operator believes grooming is live when
+	// it is not), and a sub-10m interval would hammer the forge listing endpoints.
+	switch c.Curate.Sweeps.Mode {
+	case "", SweepOff, SweepDryRun, SweepApply:
+	default:
+		return fmt.Errorf("unknown curate.sweeps.mode %q (want off|dry-run|apply; empty = dry-run)", c.Curate.Sweeps.Mode)
+	}
+	if iv := c.Curate.Sweeps.Interval.Std(); iv != 0 && iv < 10*time.Minute {
+		return fmt.Errorf("curate.sweeps.interval must be >= 10m (forge-listing rate protection), got %v", iv)
+	}
+```
+
+  (`time` is already imported by `config.go` for `Duration`, line 813.)
+- [ ] Add the default in `applyDefaults` (`internal/config/load.go`, after the retirement block at line 205):
+
+```go
+	// In-server sweep interval: always filled (harmless when mode: off) so callers
+	// never see a zero interval.
+	if c.Curate.Sweeps.Interval == 0 {
+		c.Curate.Sweeps.Interval = Duration(6 * time.Hour)
+	}
+```
+
+- [ ] Run `go test ./internal/config/ -run 'TestSweeps' -v` — expect **PASS**; then `go test ./internal/config/` — expect **PASS** (no regression, incl. `shipped_configs_test.go` / `minimal_values_test.go`)
+- [ ] Commit: `feat(config): curate.sweeps mode+interval — dry-run/6h defaults, validated`
+
+---
+
+### Task 2: `curate.Guard` — one audited, dry-run-able seam for every forge write
+
+**Files:**
+- `internal/curate/guard.go` — new
+- `internal/curate/guard_test.go` — new
+- `internal/app/curate_test.go` — extend the compile-time pin block (lines 22-25)
+
+**Steps:**
+
+- [ ] Write the failing test `internal/curate/guard_test.go` (fake style: `dedup_test.go:16-38` `fakeForge`; the recording-auditor pattern is new but mirrors `fakeForge`):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Guard must satisfy every pass-facing forge surface, so one wrapper covers all passes.
+var (
+	_ Forge          = Guard{}
+	_ RetireForge    = Guard{}
+	_ ClosedPRLister = Guard{}
+	_ ContestedForge = Guard{}
+)
+
+// fakeGuarded extends the shared fakeForge with the wider GuardedForge surface.
+type fakeGuarded struct {
+	fakeForge
+	retired  []string
+	closeErr error
+}
+
+func (f *fakeGuarded) ListClosedUnmergedPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
+	return nil, nil
+}
+func (f *fakeGuarded) ListIssueCommentBodies(context.Context, int) ([]string, error) { return nil, nil }
+func (f *fakeGuarded) IsPROpen(context.Context, int) (bool, error)                   { return true, nil }
+func (f *fakeGuarded) OpenRetirePR(_ context.Context, entryPath, _ string) (providers.Ref, error) {
+	f.retired = append(f.retired, entryPath)
+	return providers.Ref{URL: "https://forge/pr/1"}, nil
+}
+func (f *fakeGuarded) Close(ctx context.Context, n int) error {
+	if f.closeErr != nil {
+		return f.closeErr
+	}
+	return f.fakeForge.Close(ctx, n)
+}
+
+// recAudit records audit entries in memory.
+type recAudit struct{ recs []audit.Record }
+
+func (r *recAudit) Log(rec audit.Record) error { r.recs = append(r.recs, rec); return nil }
+
+func discardLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestGuardDryRunSkipsWritesButAudits(t *testing.T) {
+	inner, aud := &fakeGuarded{}, &recAudit{}
+	g := Guard{Inner: inner, DryRun: true, Audit: aud, Log: discardLog()}
+	if err := g.Close(context.Background(), 7); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.OpenRetirePR(context.Background(), "entries/a.md", "body"); err != nil {
+		t.Fatal(err)
+	}
+	if len(inner.closed) != 0 || len(inner.retired) != 0 {
+		t.Fatalf("dry-run must not reach the forge: closed=%v retired=%v", inner.closed, inner.retired)
+	}
+	if len(aud.recs) != 2 || aud.recs[0].Decision != audit.DecisionDryRun || aud.recs[0].Actor != "curate" {
+		t.Fatalf("want 2 dry-run audit records with actor=curate, got %+v", aud.recs)
+	}
+	if aud.recs[0].Op != "kb.close" || aud.recs[0].Target != "pr/7" {
+		t.Fatalf("record[0] = %+v, want op kb.close target pr/7", aud.recs[0])
+	}
+}
+
+func TestGuardApplyExecutesAndAudits(t *testing.T) {
+	inner, aud := &fakeGuarded{}, &recAudit{}
+	g := Guard{Inner: inner, DryRun: false, Audit: aud, Log: discardLog()}
+	if err := g.Comment(context.Background(), 9, "back-ref\ndetails"); err != nil {
+		t.Fatal(err)
+	}
+	if len(inner.commented) != 1 || inner.commented[0] != 9 {
+		t.Fatalf("apply must reach the forge, got %v", inner.commented)
+	}
+	if len(aud.recs) != 1 || aud.recs[0].Decision != audit.DecisionExecuted || aud.recs[0].Reason != "back-ref" {
+		t.Fatalf("want 1 executed record with first-line reason, got %+v", aud.recs)
+	}
+}
+
+func TestGuardFailureIsAuditedAndPropagated(t *testing.T) {
+	boom := errors.New("forge 502")
+	inner, aud := &fakeGuarded{closeErr: boom}, &recAudit{}
+	g := Guard{Inner: inner, DryRun: false, Audit: aud, Log: discardLog()}
+	if err := g.Close(context.Background(), 3); !errors.Is(err, boom) {
+		t.Fatalf("error must propagate, got %v", err)
+	}
+	if len(aud.recs) != 1 || aud.recs[0].Decision != audit.DecisionFailed {
+		t.Fatalf("want a failed audit record, got %+v", aud.recs)
+	}
+}
+
+func TestGuardReadsPassThrough(t *testing.T) {
+	inner := &fakeGuarded{fakeForge: fakeForge{prs: []providers.CuratedIssue{{Number: 1}}}}
+	g := Guard{Inner: inner, DryRun: true, Log: discardLog()} // nil Audit must be safe
+	prs, err := g.ListPRsByLabel(context.Background(), "runlore")
+	if err != nil || len(prs) != 1 {
+		t.Fatalf("reads must pass through even in dry-run: %v %v", prs, err)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/curate/ -run TestGuard -v` — expect **FAIL** (`undefined: Guard`)
+- [ ] Implement `internal/curate/guard.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// GuardedForge is the union of every read and write the grooming passes perform —
+// the surface Guard wraps. *github.Client satisfies it (pinned in internal/app).
+type GuardedForge interface {
+	Forge
+	ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	ListIssueCommentBodies(ctx context.Context, number int) ([]string, error)
+	IsPROpen(ctx context.Context, number int) (bool, error)
+	OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error)
+}
+
+// Guard is the sweep-safety seam around the forge: reads pass through untouched;
+// every write is recorded in the audit chain and, in dry-run, logged instead of
+// executed. One wrapper gives every pass dry-run + audit without touching the
+// passes themselves — the KB mirror of action.NewAuditedExecutor.
+type Guard struct {
+	Inner  GuardedForge
+	DryRun bool
+	Audit  audit.Auditor // nil-safe: nil drops records (actions are still slog-logged)
+	Log    *slog.Logger
+}
+
+// Reads: pass-through (a dry-run sweep must still SEE the queue to report on it).
+
+func (g Guard) ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+	return g.Inner.ListPRsByLabel(ctx, label)
+}
+
+func (g Guard) ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+	return g.Inner.ListIssuesByLabel(ctx, label)
+}
+
+func (g Guard) ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+	return g.Inner.ListClosedUnmergedPRsByLabel(ctx, label)
+}
+
+func (g Guard) ListIssueCommentBodies(ctx context.Context, number int) ([]string, error) {
+	return g.Inner.ListIssueCommentBodies(ctx, number)
+}
+
+func (g Guard) IsPROpen(ctx context.Context, number int) (bool, error) {
+	return g.Inner.IsPROpen(ctx, number)
+}
+
+// Writes: audited, dry-run-able.
+
+func (g Guard) Comment(ctx context.Context, number int, body string) error {
+	return g.write("kb.comment", fmt.Sprintf("pr/%d", number), firstLine(body),
+		func() error { return g.Inner.Comment(ctx, number, body) })
+}
+
+func (g Guard) ReplaceLabel(ctx context.Context, number int, remove, add string) error {
+	return g.write("kb.relabel", fmt.Sprintf("pr/%d", number), fmt.Sprintf("%s -> %s", remove, add),
+		func() error { return g.Inner.ReplaceLabel(ctx, number, remove, add) })
+}
+
+func (g Guard) Close(ctx context.Context, number int) error {
+	return g.write("kb.close", fmt.Sprintf("pr/%d", number), "",
+		func() error { return g.Inner.Close(ctx, number) })
+}
+
+func (g Guard) OpenIssue(ctx context.Context, inv providers.Investigation) (providers.Ref, error) {
+	var ref providers.Ref
+	err := g.write("kb.open-issue", firstLine(inv.Title), "", func() error {
+		var ierr error
+		ref, ierr = g.Inner.OpenIssue(ctx, inv)
+		return ierr
+	})
+	return ref, err
+}
+
+func (g Guard) OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error) {
+	var ref providers.Ref
+	err := g.write("kb.retire-pr", entryPath, "", func() error {
+		var ierr error
+		ref, ierr = g.Inner.OpenRetirePR(ctx, entryPath, body)
+		return ierr
+	})
+	return ref, err
+}
+
+// write is the single choke point for every forge mutation a grooming pass performs.
+// Dry-run returns nil so a pass's comment-then-close sequencing (Lifecycle, Dedup,
+// Suppress) walks both steps and both are visible in the dry-run report.
+func (g Guard) write(op, target, reason string, do func() error) error {
+	if g.DryRun {
+		g.Log.Info("curate dry-run: skipped forge write", "op", op, "target", target, "detail", reason)
+		g.record(op, target, audit.DecisionDryRun, reason)
+		return nil
+	}
+	if err := do(); err != nil {
+		g.record(op, target, audit.DecisionFailed, err.Error())
+		return err
+	}
+	g.record(op, target, audit.DecisionExecuted, reason)
+	return nil
+}
+
+// record appends to the audit chain; a failed audit write must never abort the
+// sweep (the action itself already happened or was skipped) — warn and continue.
+func (g Guard) record(op, target string, d audit.Decision, reason string) {
+	if g.Audit == nil {
+		return
+	}
+	if err := g.Audit.Log(audit.Record{Actor: "curate", Op: op, Target: target, Decision: d, Reason: reason}); err != nil {
+		g.Log.Warn("curate audit write failed", "op", op, "target", target, "err", err)
+	}
+}
+
+// firstLine caps free text to a one-line hint for the audit Reason field (the full
+// body lives on the forge artifact itself).
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	const max = 120
+	if len(s) > max {
+		s = s[:max]
+	}
+	return s
+}
+```
+
+  Note: reuses `audit.Record`/`Decision*` from `internal/audit/audit.go:31-49`; `DecisionDryRun` already exists (line 33).
+- [ ] Run `go test ./internal/curate/ -run TestGuard -v` — expect **PASS**
+- [ ] Pin the union against the real client in `internal/app/curate_test.go` (extend the var block at lines 22-25):
+
+```go
+	_ curate.GuardedForge = (*github.Client)(nil)
+```
+
+- [ ] Run `go test ./internal/curate/ ./internal/app/` — expect **PASS**
+- [ ] Commit: `feat(curate): Guard — audited, dry-run-able seam for all forge writes`
+
+---
+
+### Task 3: `Suppress` pass — close re-drafts of human-rejected entries
+
+The suppression *source* exists (`ClosedPRSuppression`, `internal/curate/suppression.go:55-83`) and Recurrence uses it to escalate. The missing consumer: when a permanently-benign incident recurs, the curator drafts a **fresh PR** (its dedup checks only open PRs and merged entries — `internal/curator/curator.go:110-133`), so humans re-close the same rejection forever. `Suppress` closes such re-drafts with a back-reference to the human's original close, honoring the label taxonomy already in place (`wontfix`/`not-kb-worthy` suppress; `needs-work` is revise-and-resubmit and does not — `suppression.go:41-47`).
+
+**Files:**
+- `internal/curate/suppression.go` — append the `Suppress` pass
+- `internal/curate/suppression_test.go` — extend (reuses `fakeForge` from `dedup_test.go:16-38`, `fakeClosedPRs` + `body()` helper from `suppression_test.go:13-21`)
+
+**Steps:**
+
+- [ ] Write the failing tests (append to `internal/curate/suppression_test.go`):
+
+```go
+func TestSuppressClosesRedraftOfRejectedEntry(t *testing.T) {
+	// A human closed PR #7 (fp-web) without merging; the incident recurred and the
+	// curator re-drafted it as PR #12. The sweep must comment-then-close #12.
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 12, Title: "KB: apps/web DNS", Body: body("fp-web"), Labels: []string{"runlore"}},
+		{Number: 13, Title: "KB: unrelated", Body: body("fp-other"), Labels: []string{"runlore"}},
+	}}
+	src := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 7, Body: body("fp-web"), Labels: []string{"runlore", "wontfix"}},
+	}}}
+	s := Suppress{Forge: f, Source: src, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.closed) != 1 || f.closed[0] != 12 {
+		t.Fatalf("want close [12] only, got %v", f.closed)
+	}
+	if len(f.commented) != 1 || f.commented[0] != 12 {
+		t.Fatalf("want a back-ref comment on 12 before closing, got %v", f.commented)
+	}
+}
+
+func TestSuppressNeverTouchesProtectedOrMarkerless(t *testing.T) {
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 20, Body: body("fp-web"), Labels: []string{"runlore", "investigating"}}, // human-touched
+		{Number: 21, Body: "no marker here", Labels: []string{"runlore"}},                // legacy/hand-filed
+	}}
+	src := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 7, Body: body("fp-web"), Labels: []string{"runlore"}},
+	}}}
+	s := Suppress{Forge: f, Source: src, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.closed) != 0 || len(f.commented) != 0 {
+		t.Fatalf("protected/markerless PRs must be untouched: closed=%v commented=%v", f.closed, f.commented)
+	}
+}
+
+func TestSuppressRespectsNeedsWorkAsRevise(t *testing.T) {
+	// needs-work is accept-with-changes (suppression.go suppressReviseLabels): a
+	// re-draft after such a close is the RESUBMIT — it must stay open.
+	f := &fakeForge{prs: []providers.CuratedIssue{
+		{Number: 30, Body: body("fp-y"), Labels: []string{"runlore"}},
+	}}
+	src := ClosedPRSuppression{Forge: fakeClosedPRs{prs: []providers.CuratedIssue{
+		{Number: 8, Body: body("fp-y"), Labels: []string{"runlore", "needs-work"}},
+	}}}
+	s := Suppress{Forge: f, Source: src, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if err := s.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.closed) != 0 {
+		t.Fatalf("a needs-work resubmit must not be suppressed, got closed=%v", f.closed)
+	}
+}
+```
+
+  (Add `io`, `log/slog` to the test file's imports.)
+- [ ] Run `go test ./internal/curate/ -run TestSuppress -v` — expect **FAIL** (`undefined: Suppress`)
+- [ ] Implement — append to `internal/curate/suppression.go`:
+
+```go
+// Suppress closes open KB PRs that RE-DRAFT an entry a human already rejected
+// (closed without merging). The file-time drafter's dedup checks only OPEN PRs and
+// MERGED entries, so a recurring permanently-benign incident re-opens a fresh PR on
+// every recurrence — the core of PR fatigue. Suppress honors the human "no": it
+// closes the re-draft with a back-reference to the original close and its reason,
+// and leaves the "reconsider" path to Recurrence's threshold escalation (which
+// links, never reopens). Protected (human-touched) PRs are never closed, and the
+// comment-first / don't-close-on-comment-failure ordering mirrors Lifecycle.
+type Suppress struct {
+	Forge  Forge
+	Source SuppressionSource
+	Log    *slog.Logger
+}
+
+// Run closes every unprotected open KB PR whose DupFingerprint a human previously
+// rejected. Per-item forge failures are logged and skipped.
+func (s Suppress) Run(ctx context.Context) error {
+	prs, err := s.Forge.ListPRsByLabel(ctx, "runlore")
+	if err != nil {
+		return fmt.Errorf("suppress: list open KB PRs: %w", err)
+	}
+	// Fetch the (forge round-trip) suppression set lazily — only once an open,
+	// unprotected, markered PR could match it. Mirrors Recurrence's lazy fetch.
+	var suppressed map[string]SuppressedEntry
+	for _, pr := range prs {
+		fp := providers.ParseFingerprintMarker(pr.Body)
+		if fp == "" || isProtected(pr.Labels) {
+			continue
+		}
+		if suppressed == nil {
+			if suppressed, err = s.Source.Suppressed(ctx); err != nil {
+				return fmt.Errorf("suppress: load suppression set: %w", err)
+			}
+		}
+		se, ok := suppressed[fp]
+		if !ok {
+			continue
+		}
+		if err := s.Forge.Comment(ctx, pr.Number, suppressComment(se)); err != nil {
+			s.Log.Warn("suppress: comment failed; not closing", "pr", pr.Number, "err", err)
+			continue
+		}
+		if err := s.Forge.Close(ctx, pr.Number); err != nil {
+			s.Log.Warn("suppress: close failed", "pr", pr.Number, "err", err)
+			continue
+		}
+		s.Log.Info("suppress: closed re-draft of a human-rejected entry",
+			"pr", pr.Number, "prior_close", se.PRNumber, "reason", se.Reason)
+	}
+	return nil
+}
+
+// suppressComment explains the close and points at both the human decision and the
+// reconsider path (Recurrence escalates past the threshold — never a reopen).
+func suppressComment(se SuppressedEntry) string {
+	reason := ""
+	if se.Reason != "" {
+		reason = fmt.Sprintf(" (%s)", se.Reason)
+	}
+	return fmt.Sprintf("Closed by RunLore curate: a human already rejected this entry in #%d%s. "+
+		"If the incident keeps recurring, RunLore escalates via a knowledge-gap issue that links #%d — it never re-files PRs.",
+		se.PRNumber, reason, se.PRNumber)
+}
+```
+
+  (`isProtected` is `lifecycle.go:58`; `log/slog` needs adding to `suppression.go` imports.)
+- [ ] Run `go test ./internal/curate/ -run TestSuppress -v` — expect **PASS**; then `go test ./internal/curate/` — **PASS**
+- [ ] Commit: `feat(curate): Suppress pass — close re-drafts of human-rejected entries`
+
+---
+
+### Task 4: Shared `BuildCurateAgent` + CLI gains `--dry-run` and audit
+
+Extract the pass assembly duplicated between the CLI and the upcoming sweeper into one builder, wire `Suppress` in, and give `lore curate` the same Guard seam (default **apply** — unchanged CLI behavior — with an opt-in `--dry-run`).
+
+**Files:**
+- `internal/app/curate.go` — refactor `RunCurate` (lines 29-114); add `BuildCurateAgent`
+- `internal/app/curate_test.go` — add composition test
+
+**Steps:**
+
+- [ ] Write the failing test (append to `internal/app/curate_test.go`; `outcome`, `github`, `filepath` already imported — add `config`, `io`):
+
+```go
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestBuildCurateAgentPassComposition(t *testing.T) {
+	// Constructing a github.Client performs no I/O, so it is a safe stand-in.
+	forge := github.New("https://forge.invalid", "o", "r", "main", nil)
+
+	// No ledger: forge-only passes (Suppress, Dedup, Lifecycle).
+	agent := BuildCurateAgent(&config.Config{}, forge, nil, discardLogger())
+	if len(agent.Passes) != 3 {
+		t.Fatalf("no-ledger agent: want 3 passes, got %d", len(agent.Passes))
+	}
+
+	// Ledger + retirement enabled: all seven.
+	cfg := &config.Config{}
+	cfg.Curate.Retirement = config.Retirement{Enabled: true, MinObservations: 3, Floor: 0.5, Prior: 2.0}
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent = BuildCurateAgent(cfg, forge, ledger, discardLogger())
+	if len(agent.Passes) != 7 {
+		t.Fatalf("full agent: want 7 passes (suppress dedup lifecycle queue recurrence contested retirement), got %d", len(agent.Passes))
+	}
+}
+```
+
+- [ ] Run `go test ./internal/app/ -run TestBuildCurateAgent -v` — expect **FAIL** (`undefined: BuildCurateAgent`)
+- [ ] Implement `BuildCurateAgent` in `internal/app/curate.go` and refactor `RunCurate` to use it. The builder replaces the wiring block at lines 59-103:
+
+```go
+// BuildCurateAgent assembles the grooming passes over a (typically Guard-wrapped)
+// forge. ledger may be nil — the ledger-backed passes (Queue, Recurrence,
+// Contested, Retirement) are then skipped. Shared by the one-shot `lore curate`
+// CLI and the in-server sweeper so the two can never drift.
+func BuildCurateAgent(cfg *config.Config, forge curate.GuardedForge, ledger *outcome.Ledger, log *slog.Logger) curate.Agent {
+	agent := curate.Agent{Log: log, Passes: []curate.Pass{
+		// Suppress runs FIRST: a re-draft of a rejected entry must not survive long
+		// enough for Dedup to bless it as a cluster canonical.
+		curate.Suppress{Forge: forge, Source: curate.ClosedPRSuppression{Forge: forge}, Log: log},
+		curate.Dedup{Forge: forge, Log: log},
+		curate.Lifecycle{Forge: forge, StaleAfter: cfg.Curate.StaleAfter.Std(), Log: log},
+	}}
+	if ledger == nil {
+		return agent
+	}
+	agent.Passes = append(agent.Passes,
+		curate.Queue{Forge: forge, Checker: curate.LedgerResolutionChecker{Ledger: ledger}, Log: log},
+		curate.Recurrence{
+			Forge:      forge,
+			Ledger:     ledger,
+			Threshold:  cfg.Curate.RecurrenceThreshold,
+			Suppressed: curate.ClosedPRSuppression{Forge: forge},
+			Log:        log,
+		},
+		curate.Contested{Forge: forge, Ledger: ledger, KBRepo: cfg.Forge.KBRepo, Log: log},
+	)
+	if cfg.Curate.Retirement.Enabled {
+		agent.Passes = append(agent.Passes, curate.Retirement{
+			Forge:           forge,
+			Stats:           ledger,
+			MinObservations: cfg.Curate.Retirement.MinObservations,
+			Floor:           cfg.Curate.Retirement.Floor,
+			Prior:           cfg.Curate.Retirement.Prior,
+			Log:             log,
+		})
+	}
+	return agent
+}
+```
+
+  (Keep the existing explanatory comments from lines 63-93 attached to their passes — move, don't delete.)
+- [ ] Refactor `RunCurate` to: add the flag `dry := fs.Bool("dry-run", false, "log and audit what the passes would do without writing to the forge")` (after line 31); after building `forge` (line 55), open the auditor and wrap:
+
+```go
+	// Same audit chain as the action executors (actions.audit_log_path); Nop when
+	// unconfigured. Every forge write (or dry-run skip) below lands in it.
+	aud, auditClose, aerr := BuildAuditor(cfg, log)
+	if aerr != nil {
+		return aerr
+	}
+	defer auditClose()
+	guarded := curate.Guard{Inner: forge, DryRun: *dry, Audit: aud, Log: log}
+```
+
+  then open the ledger exactly as today (lines 64-68 → producing `ledger` or nil), keep both `LogLedgerStartup` calls (lines 107, 109), and end with:
+
+```go
+	log.Info("curate: grooming KB backlog", "repo", cfg.Forge.KBRepo, "dry_run", *dry)
+	BuildCurateAgent(cfg, guarded, ledger, log).Run(context.Background())
+	return nil
+```
+
+- [ ] Run `go test ./internal/app/ -run TestBuildCurateAgent -v` — expect **PASS**; then `go test ./internal/app/ ./internal/curate/` — **PASS**
+- [ ] Update the `curate` usage line in `cmd/lore/main.go:35` to `lore curate [--config <path>] [--dry-run]                groom the KB backlog (dedup/stale/suppress…)`
+- [ ] Commit: `refactor(app): shared BuildCurateAgent; lore curate gains --dry-run and audit`
+
+---
+
+### Task 5: `curate.Sweeper` — the interval scheduler
+
+**Files:**
+- `internal/curate/sweeper.go` — new
+- `internal/curate/sweeper_test.go` — new
+
+**Steps:**
+
+- [ ] Write the failing test `internal/curate/sweeper_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countPass counts Agent runs (each sweep runs every pass once).
+type countPass struct{ n atomic.Int32 }
+
+func (c *countPass) Run(context.Context) error { c.n.Add(1); return nil }
+
+func TestSweeperRunsOnIntervalAndStopsOnCancel(t *testing.T) {
+	p := &countPass{}
+	s := Sweeper{Agent: Agent{Passes: []Pass{p}, Log: discardLog()}, Interval: 5 * time.Millisecond, Log: discardLog()}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	deadline := time.After(2 * time.Second)
+	for p.n.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("sweeper did not sweep twice in time, got %d", p.n.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
+	cancel()
+	<-done // Run must return promptly on cancel
+}
+
+func TestSweeperNeverSweepsBeforeFirstInterval(t *testing.T) {
+	// Leadership flaps re-enter startWork; an immediate first sweep would stampede
+	// the forge listings on every flap. The first sweep waits one full interval.
+	p := &countPass{}
+	s := Sweeper{Agent: Agent{Passes: []Pass{p}, Log: discardLog()}, Interval: time.Hour, Log: discardLog()}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { s.Run(ctx); close(done) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	<-done
+	if got := p.n.Load(); got != 0 {
+		t.Fatalf("sweep before the first interval: got %d runs, want 0", got)
+	}
+}
+```
+
+  (`discardLog` comes from `guard_test.go` in the same package — Task 2.)
+- [ ] Run `go test ./internal/curate/ -run TestSweeper -v` — expect **FAIL** (`undefined: Sweeper`)
+- [ ] Implement `internal/curate/sweeper.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// DefaultSweepInterval is the fallback cadence when no interval is configured.
+// config.applyDefaults ships the same value; this guard only protects direct users.
+const DefaultSweepInterval = 6 * time.Hour
+
+// Sweeper runs the grooming Agent on a fixed interval until ctx is done — the
+// in-server counterpart of the `lore curate` CronJob. The first sweep happens one
+// FULL interval after start, never immediately: it is launched on every leadership
+// (re-)acquisition, and a flapping leader must not stampede the forge with
+// back-to-back listing storms. All passes are idempotent, so an occasional
+// double-run across a flap is safe, just wasteful.
+type Sweeper struct {
+	Agent    Agent
+	Interval time.Duration // <= 0 ⇒ DefaultSweepInterval
+	Log      *slog.Logger
+}
+
+// Run sweeps every Interval until ctx is cancelled.
+func (s Sweeper) Run(ctx context.Context) {
+	iv := s.Interval
+	if iv <= 0 {
+		iv = DefaultSweepInterval
+	}
+	t := time.NewTicker(iv)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		s.Log.Debug("curate sweep starting")
+		s.Agent.Run(ctx)
+	}
+}
+```
+
+  (Ticker-loop precedent: `Reinvestigator.Poll`, `internal/investigate/reinvestigate.go:34-48` — deliberately inverted here so the first run waits.)
+- [ ] Run `go test ./internal/curate/ -run TestSweeper -v` — expect **PASS**; `go test -race ./internal/curate/` — **PASS**
+- [ ] Commit: `feat(curate): Sweeper — flap-proof interval scheduler for grooming passes`
+
+---
+
+### Task 6: `BuildSweeper` + leader-only serve wiring
+
+**Files:**
+- `internal/app/sweep.go` — new
+- `internal/app/sweep_test.go` — new
+- `internal/app/serve.go` — start the sweeper inside `startWork` (insert after the Matrix feedback block, line 317-322)
+
+**Steps:**
+
+- [ ] Write the failing test `internal/app/sweep_test.go` (RSA test-key generation style: `internal/forge/github/auth_test.go:22-25`):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/config"
+)
+
+// forgeConfigured returns a Config with working GitHub App credentials (a real
+// throwaway key in an env var), the minimum BuildForgeTokenSource accepts.
+func forgeConfigured(t *testing.T) *config.Config {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemStr := string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+	t.Setenv("TEST_SWEEP_GH_KEY", pemStr)
+	cfg := &config.Config{}
+	cfg.Forge.KBRepo = "acme/kb"
+	cfg.Forge.GitHubApp = config.GitHubApp{AppID: 1, InstallationID: 2, PrivateKeyEnv: "TEST_SWEEP_GH_KEY"}
+	return cfg
+}
+
+func TestBuildSweeperNilWhenOff(t *testing.T) {
+	cfg := forgeConfigured(t)
+	cfg.Curate.Sweeps.Mode = config.SweepOff
+	if sw := BuildSweeper(cfg, nil, audit.Nop{}, discardLogger()); sw != nil {
+		t.Fatal("mode: off must not build a sweeper")
+	}
+}
+
+func TestBuildSweeperNilWithoutForge(t *testing.T) {
+	// No GitHub App / kb_repo: sweeps silently stay off — no new required config.
+	if sw := BuildSweeper(&config.Config{}, nil, audit.Nop{}, discardLogger()); sw != nil {
+		t.Fatal("unconfigured forge must not build a sweeper")
+	}
+}
+
+func TestBuildSweeperDefaultsToDryRunAgent(t *testing.T) {
+	cfg := forgeConfigured(t) // Mode unset ⇒ dry-run
+	sw := BuildSweeper(cfg, nil, audit.Nop{}, discardLogger())
+	if sw == nil {
+		t.Fatal("configured forge + default mode must build a sweeper")
+	}
+	if len(sw.Agent.Passes) != 3 {
+		t.Fatalf("nil ledger sweeper: want 3 forge-only passes, got %d", len(sw.Agent.Passes))
+	}
+}
+```
+
+- [ ] Run `go test ./internal/app/ -run TestBuildSweeper -v` — expect **FAIL** (`undefined: BuildSweeper`)
+- [ ] Implement `internal/app/sweep.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/curate"
+	"github.com/Smana/runlore/internal/outcome"
+
+	github "github.com/Smana/runlore/internal/forge/github"
+)
+
+// BuildSweeper assembles the in-server grooming sweeper, or nil when sweeps are
+// off (curate.sweeps.mode: off) or the KB forge is not configured. No new required
+// config: with forge credentials already present, sweeps default to DRY-RUN — the
+// operator flips curate.sweeps.mode: apply to let them act.
+func BuildSweeper(cfg *config.Config, ledger *outcome.Ledger, aud audit.Auditor, log *slog.Logger) *curate.Sweeper {
+	if !cfg.Curate.Sweeps.Enabled() {
+		return nil
+	}
+	tok := BuildForgeTokenSource(cfg, log)
+	if tok == nil || cfg.Forge.KBRepo == "" {
+		return nil // no forge, nothing to groom — sweeps are strictly additive
+	}
+	owner, repo, ok := strings.Cut(cfg.Forge.KBRepo, "/")
+	if !ok {
+		log.Warn("curate sweeps disabled: forge.kb_repo must be owner/name", "kb_repo", cfg.Forge.KBRepo)
+		return nil
+	}
+	base := cfg.Forge.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+	client := github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(tok))
+	guarded := curate.Guard{Inner: client, DryRun: cfg.Curate.Sweeps.DryRun(), Audit: aud, Log: log}
+	// The LIVE serve ledger: the ledger-backed passes see the same episodes the
+	// investigation loop records — no shared-volume mount to misconfigure (the
+	// CronJob's classic footgun; see LogLedgerStartup in curate.go).
+	var l *outcome.Ledger
+	if ledger != nil && ledger.Enabled() {
+		l = ledger
+	}
+	return &curate.Sweeper{
+		Agent:    BuildCurateAgent(cfg, guarded, l, log),
+		Interval: cfg.Curate.Sweeps.Interval.Std(),
+		Log:      log,
+	}
+}
+```
+
+- [ ] Run `go test ./internal/app/ -run TestBuildSweeper -v` — expect **PASS**
+- [ ] Wire into `RunServe`: in `internal/app/serve.go`, inside `startWork` (after the Matrix feedback block ending line 322), insert:
+
+```go
+		// In-server grooming sweeps (leader-only, like the pollers above, so one
+		// replica grooms): the same passes as `lore curate`, on a timer, over the
+		// live ledger. Cancelled with workCtx on leadership loss.
+		if sw := BuildSweeper(cfg, ledger, aud, log); sw != nil {
+			mode := config.SweepApply
+			if cfg.Curate.Sweeps.DryRun() {
+				mode = config.SweepDryRun
+				log.Info("curate sweeps in dry-run: candidates are logged (and audited when actions.audit_log_path is set) " +
+					"but nothing is written to the forge — set curate.sweeps.mode: apply to act, mode: off to silence")
+			}
+			log.Info("curate sweeps enabled", "mode", mode, "interval", cfg.Curate.Sweeps.Interval.Std())
+			go sw.Run(workCtx)
+		}
+```
+
+  (`aud` is built at line 121 and `ledger` at line 174, both before `startWork` is defined at line 290, so the closure captures them; `config` is already imported.)
+- [ ] Build + full app tests: `go build ./... && go test ./internal/app/` — expect **PASS**
+- [ ] Commit: `feat(app): in-server leader-only curate sweeps, dry-run by default`
+
+---### Task 7: Helm chart — document `curate.sweeps` in values.yaml
+
+No template changes: `config.curate.*` flows through the ConfigMap as-is. This is documentation of the new keys plus repositioning the CronJob as the alternative.
+
+**Files:**
+- `deploy/helm/runlore/values.yaml` — extend the `config.curate` block (lines 177-187) and the top-level `curate.cronjob` comment (lines 494-500)
+
+**Steps:**
+
+- [ ] In the `config:` section, replace the comment + block at lines 177-187 with:
+
+```yaml
+  # Phase-2 backlog groomer. `stale_after` drives the stale-close sweep; the Queue
+  # (promote solved→ready-to-merge on resolution) and Recurrence (open a
+  # knowledge-gap issue for repeatedly-unresolved patterns) passes also run when
+  # config.outcome.ledger_path is set (they read the outcome ledger).
+  curate:
+    stale_after: 720h          # close unprotected KB PRs idle longer than this; 0 disables
+    recurrence_threshold: 3    # open a knowledge-gap issue after this many unresolved occurrences; 0 ⇒ 3.
+                               # Also the trigger for escalating a closed-unmerged (human-rejected) KB
+                               # entry that keeps recurring: RunLore links the closed PR in a knowledge-gap
+                               # issue rather than reopening it.
+    # In-server scheduled sweeps (leader-only): the serve pod runs the grooming
+    # passes on a timer whenever the KB forge (forge.kb_repo + forge.github_app) is
+    # configured — no CronJob or shared ledger volume needed, and the ledger-backed
+    # passes read the pod's LIVE outcome ledger. Default mode is DRY-RUN: every
+    # candidate action is logged (and recorded in the actions.audit_log_path hash
+    # chain when set) but nothing is written to the forge until you set mode: apply.
+    sweeps:
+      mode: dry-run   # dry-run (default) | apply | "off" (quote off — YAML)
+      interval: 6h    # first sweep runs one full interval after startup; min 10m
+```
+
+- [ ] Update the top-level CronJob comment (line 494-496) to:
+
+```yaml
+# Phase-2 backlog groomer (lore curate) as a scheduled Job — the OUT-OF-SERVER
+# alternative to config.curate.sweeps (which the serve pod runs itself, leader-only,
+# dry-run by default). Prefer the in-server sweeps: the CronJob needs the outcome
+# ledger on a shared volume to run its ledger-backed passes. Both paths are
+# idempotent, so enabling both is safe, just redundant.
+curate:
+  cronjob:
+    enabled: false
+    schedule: "0 * * * *"   # hourly
+```
+
+- [ ] Verify the chart still renders and the ConfigMap carries the new keys:
+  `helm lint deploy/helm/runlore && helm template deploy/helm/runlore | yq 'select(.kind == "ConfigMap") | .data' | grep -A2 'sweeps'`
+- [ ] Run the shipped-config guard tests: `go test ./internal/config/ -run 'Shipped|Minimal'` — expect **PASS** (`shipped_configs_test.go` parses the chart's config block; `mode: dry-run` + `interval: 6h` must validate)
+- [ ] Commit: `chore(chart): document curate.sweeps (in-server grooming, dry-run default)`
+
+---
+
+### Task 8: Docs — learning-loop, reviewing-knowledge, configuration
+
+**Files:**
+- `docs/learning-loop.md` — §5 Phase-2 intro (line 360-361) + new Suppress bullet (after the Lifecycle bullet, ~line 370)
+- `docs/reviewing-knowledge.md` — §8 "the backlog groomer" (lines 233-240)
+- `docs/configuration.md` — `### curate` section (lines 446-465)
+
+**Steps:**
+
+- [ ] `docs/learning-loop.md`: replace the Phase-2 intro line (line 360-361) with:
+
+```markdown
+**Phase-2 grooming** (`internal/curate/`) keeps the backlog healthy on a schedule. It
+runs **inside the serve pod** (leader-only, every `curate.sweeps.interval`, default 6 h)
+whenever the KB forge is configured — **in dry-run by default**: candidates are logged and
+recorded in the action audit chain (`actions.audit_log_path`), and nothing touches the
+forge until you set `curate.sweeps.mode: apply`. The opt-in `lore curate` CronJob remains
+the out-of-server alternative (same passes, shared wiring — `--dry-run` there too).
+```
+
+- [ ] `docs/learning-loop.md`: after the **Lifecycle** bullet, add:
+
+```markdown
+- **Suppress** — close a PR that *re-drafts* an entry a human already rejected (closed
+  without merging). The drafter's dedup only checks open PRs and merged entries, so a
+  recurring permanently-benign incident would re-open a fresh PR forever. The close
+  carries a back-reference to the original human decision (and its `wontfix` /
+  `not-kb-worthy` label when present); a `needs-work` close is a revise-and-resubmit and
+  is never suppressed. Reconsideration stays with Recurrence's knowledge-gap escalation —
+  suppression never argues with a human, it just stops re-asking.
+```
+
+- [ ] `docs/reviewing-knowledge.md`: replace the first paragraph of §8 (lines 235-240) with:
+
+```markdown
+The backlog groomer keeps the PR queue tidy without you: it **suppresses** re-drafts of
+entries you already rejected, **dedups** near-identical PRs, **closes stale** unreviewed
+ones after a configurable age, **promotes** `solved`→`ready-to-merge` when the incident
+resolved, and opens a **`knowledge-gap`** issue when an unsolved pattern recurs. It only
+ever comments/labels/closes — it never merges.
+
+It runs automatically inside the serve pod (leader-only, every 6 h by default) — **in
+dry-run first**: check the logs for `curate dry-run: skipped forge write` lines (and the
+audit log for `"actor":"curate"` records) to see what it *would* do, then set
+`curate.sweeps.mode: apply` to let it act, or `mode: "off"` to silence it. Every
+automated action, applied or skipped, lands in the same tamper-evident audit chain as
+cluster actions when `actions.audit_log_path` is set. A `lore curate` CronJob remains
+available for out-of-server runs. See
+[getting-started](getting-started.md#step-7--the-learn-loop-kb-lifecycle--re-runs).
+```
+
+- [ ] `docs/configuration.md`: append to the `### curate` section (after the `retirement` keys, line 465):
+
+```markdown
+- `sweeps` — the **in-server** scheduled grooming loop (leader-only; the serve pod runs the same
+  passes as `lore curate` on a timer, over its live outcome ledger). Strictly additive: it only
+  starts when the KB forge (`forge.kb_repo` + `forge.github_app`) is configured. Keys:
+  - `mode` — `dry-run` (**default**, also when empty): log + audit every candidate action, write
+    nothing to the forge; `apply`: act; `off` (quote it in YAML): disable the loop. Unknown values
+    fail validation — a typo must not silently demote grooming to dry-run.
+  - `interval` — sweep cadence; **default `6h`**, must be `>= 10m`. The first sweep runs one full
+    interval after startup (leadership flaps never trigger immediate re-sweeps).
+
+  Every write (or dry-run skip) is appended to the `actions.audit_log_path` hash chain as
+  `actor: curate` with `op` `kb.close` / `kb.comment` / `kb.relabel` / `kb.open-issue` /
+  `kb.retire-pr` and decision `executed` / `dry-run` / `failed`.
+```
+
+- [ ] Full verification: `go build ./... && go test ./... && gofmt -l internal/ | (! grep .)` — expect **PASS**, no gofmt diffs
+- [ ] Commit: `docs: curator automation phase 2 — in-server sweeps, suppression, dry-run posture`
+
+---
+
+## Acceptance criteria
+
+- [ ] `go test ./...` passes and `go vet ./...` is clean on the branch
+- [ ] With `forge.kb_repo` + `forge.github_app` configured and **no other config change**, `lore serve` logs `curate sweeps enabled mode=dry-run interval=6h0m0s` on the leader, and the first sweep happens only after one full interval
+- [ ] In dry-run, a sweep against a backlog with a stale PR produces `curate dry-run: skipped forge write op=kb.close …` log lines and `{"actor":"curate","decision":"dry-run"}` audit records (when `actions.audit_log_path` is set) — and **zero forge mutations**
+- [ ] With `curate.sweeps.mode: apply`, the same actions execute and are audited as `executed`; failures audit as `failed` and never abort the sweep (per-item isolation preserved)
+- [ ] `curate.sweeps.mode: "off"` disables the loop; `mode: apply` (typo) fails config validation; `interval: 1m` fails validation
+- [ ] A re-drafted PR whose `DupFingerprint` matches a human close labelled `wontfix`/`not-kb-worthy` (or unlabelled) is commented + closed by `Suppress`; `needs-work` closes and protected labels (`solved`, `ready-to-merge`, `accepted`, `investigating`, `knowledge-gap`) are never touched
+- [ ] Only the leader sweeps: the sweeper goroutine lives inside `startWork` and stops when `workCtx` is cancelled (leadership loss / shutdown)
+- [ ] `lore curate --dry-run` performs zero forge writes and reports what it would do; plain `lore curate` behavior is unchanged (apply)
+- [ ] No new **required** config: a chart upgrade with existing values renders (`helm lint` + `shipped_configs` test pass) and changes nothing except dry-run log lines
+- [ ] Retirement remains opt-in (`curate.retirement.enabled`, default off) and, when enabled, its retire-PR opens are audited through the same Guard
+- [ ] `docs/learning-loop.md`, `docs/reviewing-knowledge.md`, `docs/configuration.md`, and `deploy/helm/runlore/values.yaml` document the sweeps, the dry-run-first posture, and the Suppress pass

--- a/dev/superpowers/plans/2026-07-23-f1-helm-oci.md
+++ b/dev/superpowers/plans/2026-07-23-f1-helm-oci.md
@@ -1,0 +1,376 @@
+# F1 — Publish Helm chart to GHCR (OCI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish `deploy/helm/runlore` to GHCR as an OCI artifact on every `v*` release tag so users can `helm install runlore oci://ghcr.io/smana/charts/runlore` without cloning the repo.
+
+**Architecture:** A new tag-triggered workflow (`.github/workflows/release-chart.yml`) packages and pushes the chart to `oci://ghcr.io/<owner>/charts` and cosign keyless-signs the pushed digest — the same trigger and supply-chain posture as `release-binaries.yml` (GoReleaser owns binaries + image; this workflow owns the chart). **No new versioning scheme is needed:** `release-please-config.json` already bumps `Chart.yaml` `version`/`appVersion` via `extra-files` in the release PR, so the chart version equals the tag by construction; the workflow enforces this with a guard step. Docs (`README.md`, `docs/getting-started.md`, `docs/upgrade-uninstall.md`) switch to the OCI install command, keeping the git-clone path as the documented dev alternative.
+
+**Tech Stack:** GitHub Actions (commit-pinned actions, per-job least-privilege permissions — repo house style), Helm ≥ 3.8 OCI support (`helm package` / `helm push`), cosign keyless (Fulcio OIDC), GHCR (`GITHUB_TOKEN` with `packages: write`).
+
+**Locked decisions:**
+
+| Decision | Choice | Why |
+|---|---|---|
+| Chart version bump | Existing release-please `extra-files` on `Chart.yaml` (no change) | Already in `release-please-config.json`; chart `version`/`appVersion` track every release since v0.1.0 |
+| Publish trigger | `push: tags: ['v*']` + `workflow_dispatch` | Mirrors `release-binaries.yml`; the tag is created by release-please's PAT so it fires downstream workflows. `workflow_dispatch` allows a one-time backfill publish of the current chart (0.10.0) from `main` right after merge, so the docs are never pointing at a missing artifact |
+| GHCR path | `oci://ghcr.io/smana/charts/runlore` (push target `oci://ghcr.io/<owner,lowercased>/charts`; Helm appends the chart name) | Keeps the chart out of the `ghcr.io/smana/runlore` image repo; owner lowercased at runtime like `build-image.yml` does |
+| Signing | cosign keyless on the pushed chart digest | Consistency with the release image + checksums signing in `release-binaries.yml` |
+| Separate workflow file (not a job in `release-binaries.yml`) | `.github/workflows/release-chart.yml` | A chart-publish failure must not appear as (or retrigger) a GoReleaser run; keeps `chart.yml` = validation, `release-chart.yml` = publish symmetry with `build-image.yml`/`release-binaries.yml` |
+
+---
+
+### Task 1: Tag-triggered chart publish workflow
+
+**Files:**
+- Create: `.github/workflows/release-chart.yml`
+
+- [ ] **Step 1: Verify the chart packages cleanly today (baseline check)**
+
+  Run:
+
+  ```bash
+  helm lint deploy/helm/runlore && helm package deploy/helm/runlore -d /tmp/f1-chart-dist
+  ```
+
+  Expected output ends with:
+
+  ```
+  1 chart(s) linted, 0 chart(s) failed
+  Successfully packaged chart and saved it to: /tmp/f1-chart-dist/runlore-0.10.0.tgz
+  ```
+
+  (The version is whatever `deploy/helm/runlore/Chart.yaml` says at execution time — 0.10.0 as of this plan.)
+
+- [ ] **Step 2: Prove the OCI push/pull roundtrip locally against a throwaway registry**
+
+  This is the closest local equivalent of the CI job (real `helm push` mechanics, real OCI pull-and-render):
+
+  ```bash
+  docker run -d --rm -p 5000:5000 --name f1-chartreg registry:2
+  helm push /tmp/f1-chart-dist/runlore-*.tgz oci://localhost:5000/charts --plain-http
+  helm template smoke oci://localhost:5000/charts/runlore --version "$(awk '/^version:/ {print $2}' deploy/helm/runlore/Chart.yaml)" --plain-http | head -5
+  docker stop f1-chartreg
+  ```
+
+  Expected: `helm push` prints `Pushed: localhost:5000/charts/runlore:0.10.0` followed by a `Digest: sha256:…` line (the CI job parses exactly this line), and `helm template` renders manifests starting with `---` / `# Source: runlore/templates/…`. If Docker is unavailable locally, note it and rely on Step 4's `actionlint` plus the post-merge verification at the end of this plan.
+
+- [ ] **Step 3: Write the workflow**
+
+  Create `.github/workflows/release-chart.yml` with exactly:
+
+  ```yaml
+  name: Release Chart
+
+  # Publishes deploy/helm/runlore to GHCR as an OCI artifact:
+  #   helm install runlore oci://ghcr.io/smana/charts/runlore
+  #
+  # Triggered by the v* tag (created by release-please via its PAT, same as
+  # release-binaries.yml). No separate chart versioning exists: release-please
+  # bumps Chart.yaml version/appVersion in the release PR (extra-files in
+  # release-please-config.json), so the chart version equals the tag by
+  # construction — the guard step below enforces it. GoReleaser owns the
+  # binaries and the container image; this workflow owns the chart artifact.
+  # workflow_dispatch exists for a one-time backfill publish of the current
+  # chart version from main (the guard only runs on tag refs).
+  on:
+    push:
+      tags: ['v*']
+    workflow_dispatch:
+
+  # Top-level least privilege; the job elevates only what it needs.
+  permissions:
+    contents: read
+
+  env:
+    CHART: deploy/helm/runlore
+
+  jobs:
+    publish:
+      name: Package, push and sign
+      runs-on: ubuntu-latest
+      permissions:
+        contents: read
+        # Push the chart OCI artifact to GHCR (GitHub Packages).
+        packages: write
+        # Keyless cosign signing of the pushed chart digest — the OIDC token
+        # identifies this workflow to Fulcio (same posture as the release image
+        # and checksums in release-binaries.yml).
+        id-token: write
+      steps:
+        - name: Checkout
+          uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+        - name: Install Helm
+          uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+        # Guard: on tag refs the chart version must equal the tag. release-please
+        # keeps them in lockstep, so a mismatch means a hand-crafted or re-pointed
+        # tag — refuse to publish a mislabeled chart. Skipped on workflow_dispatch
+        # from a branch (the backfill case).
+        - name: Verify chart version matches tag
+          if: startsWith(github.ref, 'refs/tags/')
+          run: |
+            set -euo pipefail
+            chart_version="$(awk '/^version:/ {print $2}' "$CHART/Chart.yaml")"
+            if [[ "v${chart_version}" != "${GITHUB_REF_NAME}" ]]; then
+              echo "Chart.yaml version v${chart_version} does not match tag ${GITHUB_REF_NAME}" >&2
+              exit 1
+            fi
+
+        - name: Log in to GHCR (helm registry)
+          env:
+            GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin <<< "$GHCR_TOKEN"
+
+        # helm lint also validates values.yaml against values.schema.json —
+        # cheap last-line defense even though chart.yml gates every chart change.
+        - name: Lint and package
+          run: |
+            set -euo pipefail
+            helm lint "$CHART"
+            helm package "$CHART" -d dist/
+
+        # ghcr/OCI refs must be lowercase; github.repository_owner can contain
+        # uppercase (e.g. "Smana") — same normalization as build-image.yml.
+        # Capture the pushed digest from helm's output for signing.
+        - name: Push chart to GHCR
+          id: push
+          run: |
+            set -euo pipefail
+            owner="${{ github.repository_owner }}"
+            repo="ghcr.io/${owner,,}/charts"
+            out="$(helm push dist/runlore-*.tgz "oci://${repo}" 2>&1)"
+            echo "$out"
+            digest="$(sed -n 's/^Digest: //p' <<< "$out")"
+            if [[ -z "$digest" ]]; then
+              echo "could not parse pushed digest from helm output" >&2
+              exit 1
+            fi
+            echo "ref=${repo}/runlore" >> "$GITHUB_OUTPUT"
+            echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+        - name: Install cosign
+          uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+        - name: Sign chart (cosign keyless)
+          run: cosign sign --yes "${{ steps.push.outputs.ref }}@${{ steps.push.outputs.digest }}"
+
+        - name: Publish summary
+          run: |
+            {
+              echo "## Helm chart published"
+              echo ""
+              echo '```bash'
+              echo "helm install runlore oci://${{ steps.push.outputs.ref }} --version <version> -n runlore --create-namespace -f values.yaml"
+              echo '```'
+              echo ""
+              echo "**Digest**: \`${{ steps.push.outputs.digest }}\`"
+              echo "**Signature**: cosign keyless (Fulcio, GitHub Actions OIDC)"
+            } >> "$GITHUB_STEP_SUMMARY"
+  ```
+
+- [ ] **Step 4: Lint the workflow**
+
+  ```bash
+  actionlint .github/workflows/release-chart.yml
+  ```
+
+  Expected output: nothing (exit code 0). If `actionlint` flags the `${owner,,}` bash-ism inside `${{ }}`-free run blocks it is a false positive only when shellcheck is misconfigured — the same construct already passes for `.github/workflows/build-image.yml`, so any new finding is real and must be fixed.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .github/workflows/release-chart.yml
+  git commit -m "ci: publish Helm chart to GHCR as an OCI artifact on release tags"
+  ```
+
+### Task 2: README install instructions
+
+**Files:**
+- Modify: `README.md` (lines 198–204, the install command + blockquote under "🚀 Getting started (production install)")
+
+- [ ] **Step 1: Confirm the current text (pre-edit verification)**
+
+  ```bash
+  grep -n "deploy/helm/runlore -n runlore" README.md
+  ```
+
+  Expected: one hit at the `helm install` fence (line 199 as of this plan). If it moved, adjust the edit anchor but keep the replacement text below verbatim.
+
+- [ ] **Step 2: Replace the install command and the "no OCI registry yet" note**
+
+  In `README.md`, replace this block:
+
+  ````markdown
+  ```bash
+  helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml
+  ```
+
+  > The chart ships **in this repo** (`git clone` first) — there is no `helm repo add` / OCI registry
+  > yet. A minimal starting point for `values.yaml` is
+  > [`deploy/helm/runlore/values-minimal.yaml`](deploy/helm/runlore/values-minimal.yaml).
+  ````
+
+  with:
+
+  ````markdown
+  ```bash
+  helm install runlore oci://ghcr.io/smana/charts/runlore -n runlore --create-namespace -f values.yaml
+  ```
+
+  > The chart is an **OCI artifact on GHCR** — no `git clone`, no `helm repo add`. It is published and
+  > cosign-signed on every release; pin a version with `--version X.Y.Z`. A minimal starting point for
+  > `values.yaml` is
+  > [`deploy/helm/runlore/values-minimal.yaml`](deploy/helm/runlore/values-minimal.yaml).
+  > Working from a clone (dev alternative):
+  > `helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml`.
+  ````
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -n "oci://ghcr.io/smana/charts/runlore" README.md && grep -cn "helm install runlore deploy/helm/runlore" README.md
+  ```
+
+  Expected: the OCI hit inside the fenced install command, and exactly `1` remaining clone-path occurrence (the dev alternative in the blockquote).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add README.md
+  git commit -m "docs(readme): install the Helm chart from GHCR (OCI), clone path as dev alternative"
+  ```
+
+### Task 3: Getting-started guide install instructions
+
+**Files:**
+- Modify: `docs/getting-started.md` (lines 386–395, the "### Install" section)
+
+- [ ] **Step 1: Confirm the current text (pre-edit verification)**
+
+  ```bash
+  grep -n -A5 "^### Install" docs/getting-started.md
+  ```
+
+  Expected: the `helm install runlore deploy/helm/runlore …` fence followed by the "A packaged chart repo is on the roadmap" blockquote (lines 386–395 as of this plan).
+
+- [ ] **Step 2: Replace the Install section body**
+
+  In `docs/getting-started.md`, replace:
+
+  ````markdown
+  ### Install
+
+  With the `values.yaml` above, deploy RunLore with a single command:
+
+  ```bash
+  helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml
+  ```
+
+  > The chart needs the `deploy/helm/runlore` directory from this repo. A packaged chart repo is on the
+  > roadmap; for now, `git clone` and install from the path (or `helm package` it yourself).
+  ````
+
+  with:
+
+  ````markdown
+  ### Install
+
+  With the `values.yaml` above, deploy RunLore with a single command — the chart is an OCI artifact
+  on GHCR, published on every release:
+
+  ```bash
+  helm install runlore oci://ghcr.io/smana/charts/runlore -n runlore --create-namespace -f values.yaml
+  ```
+
+  > Pin a version with `--version X.Y.Z` (the chart version tracks the RunLore release).
+  > **Dev alternative** — working from a clone of this repo, install from the chart path instead:
+  > `helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml`.
+
+  Every published chart is **cosign keyless-signed**. To verify before installing (optional):
+
+  ```bash
+  cosign verify ghcr.io/smana/charts/runlore:<version> \
+    --certificate-identity-regexp 'https://github.com/Smana/runlore/\.github/workflows/release-chart\.yml@.*' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com
+  ```
+  ````
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  grep -n "oci://ghcr.io/smana/charts/runlore" docs/getting-started.md && ! grep -n "packaged chart repo is on the" docs/getting-started.md
+  ```
+
+  Expected: the OCI hit in the Install fence; the roadmap-apology sentence is gone (second command exits 0 because grep finds nothing).
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add docs/getting-started.md
+  git commit -m "docs(getting-started): install the Helm chart from GHCR (OCI) with cosign verification"
+  ```
+
+### Task 4: Upgrade guide command
+
+**Files:**
+- Modify: `docs/upgrade-uninstall.md` (lines 7–11, the "## Upgrading" command)
+
+- [ ] **Step 1: Replace the upgrade command**
+
+  In `docs/upgrade-uninstall.md`, replace:
+
+  ````markdown
+  RunLore is a Helm release — upgrade like any other chart:
+
+  ```bash
+  helm upgrade runlore deploy/helm/runlore -n runlore -f values.yaml
+  ```
+  ````
+
+  with:
+
+  ````markdown
+  RunLore is a Helm release — upgrade like any other chart (the chart is an OCI artifact on GHCR;
+  from a clone of this repo, use the `deploy/helm/runlore` path instead):
+
+  ```bash
+  helm upgrade runlore oci://ghcr.io/smana/charts/runlore -n runlore -f values.yaml
+  ```
+  ````
+
+- [ ] **Step 2: Verify**
+
+  ```bash
+  grep -n "oci://ghcr.io/smana/charts/runlore" docs/upgrade-uninstall.md
+  ```
+
+  Expected: one hit inside the upgrade fence.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add docs/upgrade-uninstall.md
+  git commit -m "docs(upgrade): upgrade the Helm release from the GHCR OCI chart"
+  ```
+
+---
+
+## Post-merge verification (cannot be tested locally)
+
+CI publish mechanics were validated locally in Task 1 (actionlint + real `helm push` roundtrip against `registry:2`), but the GHCR/GITHUB_TOKEN/Fulcio path only exists in Actions. After the PR merges to `main`:
+
+1. **Backfill publish (closes the docs-vs-artifact gap):** trigger `Release Chart` via `workflow_dispatch` on `main` (maintainer action — agent `gh` access is read-only). This publishes the current chart (0.10.0) so the new install command works before v0.11.0 is tagged.
+2. Confirm the run summary shows the pushed ref + digest, then from any machine:
+   `helm template smoke oci://ghcr.io/smana/charts/runlore --version 0.10.0 | head` renders manifests.
+3. **Package visibility:** in GitHub → Packages, set the new `charts/runlore` package to **Public** and link it to the repo (first push creates it private by default — one-time maintainer action; the pull in item 2 fails with 403 until this is done).
+4. On the next release tag (v0.11.0), confirm the guard passes and the chart lands as `ghcr.io/smana/charts/runlore:0.11.0`, and `cosign verify` (command in `docs/getting-started.md`) succeeds against it.
+
+## Acceptance criteria
+
+- [ ] `helm install runlore oci://ghcr.io/smana/charts/runlore -n runlore --create-namespace -f values.yaml` works without cloning the repo (after the post-merge backfill publish + package made public).
+- [ ] Every `v*` tag automatically publishes `ghcr.io/smana/charts/runlore:<version>` with the chart version equal to the tag (guard enforced), cosign keyless-signed.
+- [ ] No new versioning scheme: chart version bumps stay owned by release-please `extra-files` (zero changes to `release-please-config.json`).
+- [ ] `README.md` and `docs/getting-started.md` lead with the OCI install; the git-clone path remains documented as the dev alternative; `docs/upgrade-uninstall.md` upgrade command uses the OCI ref.
+- [ ] `actionlint` passes on the new workflow; `helm lint` + local `registry:2` push/template roundtrip succeed.

--- a/dev/superpowers/plans/2026-07-23-f2-eval-scorecard.md
+++ b/dev/superpowers/plans/2026-07-23-f2-eval-scorecard.md
@@ -1,0 +1,1092 @@
+# F2 — Public eval scorecard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the nightly replay-eval results public and reproducible. Every night the existing `.github/workflows/eval.yaml` run publishes a **scorecard** — per-scenario pass/fail, recall outcomes, confidence calibration, the model used, the date, and the estimated cost — to a dedicated `eval-scorecard` branch in this repo, and the README carries a live pass-rate badge linking to it. Failures publish exactly like passes: in a market where vendors claim 92–94% accuracy against an independent <50% ITBench-AA ceiling, honest reproducible numbers are the credibility wedge.
+
+**Architecture:** The publishing mechanism (locked in): **an orphan `eval-scorecard` branch in the same repo, force-free pushed by the existing nightly workflow.** No gh-pages setup, no nightly PR noise on `main`, no external services beyond shields.io (already used by four README badges), and no new required user config. The branch carries three files: `scorecard.md` (browsable per-scenario table + calibration + history), `badge.json` (shields.io *endpoint* schema, served raw via `raw.githubusercontent.com`), and `history.jsonl` (append-only, one line per run, capped at 365). The data flows in three stages: (1) the replay campaign report (`*-replay.json`, written today by `lore eval -report-dir`) is **extended in place** — the `internal/eval.Campaign` JSON gains provenance (`at`, `model`, tokens, `cost_usd`) and per-case recall telemetry (`Result.RecallFired`/`RecallShortCircuit` are currently *dropped* by `aggregateCase`; they get aggregated); (2) a new pure renderer `internal/eval/scorecard.go` turns that report + the prior history into the three published files, exposed as a new keyless subcommand `lore eval scorecard -report <json> -dir <out>`; (3) a new workflow step (job permission `contents: write`) runs the renderer into a git worktree of the `eval-scorecard` branch and pushes. Cost comes from wrapping the model in the already-existing `eval.CountingModel` (today only used by `--compare`) plus the already-existing optional `config.Model.Pricing` rates, which we add to the checked-in `eval/ci.runlore.yaml` — repo-side config, nothing new required from users.
+
+**Tech Stack:** Go 1.x (stdlib only — `encoding/json`, `strings`, `bytes`, `flag`), existing packages `internal/eval` / `internal/app` / `internal/config` / `internal/providers`, GitHub Actions (`git worktree` + orphan branch push with the default `GITHUB_TOKEN`), shields.io endpoint badge.
+
+---
+
+## Reference: current state (verified 2026-07-23)
+
+- Nightly workflow `.github/workflows/eval.yaml` runs `./lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7 -report-dir eval/reports`, uploads `eval/reports/` as an artifact. Workflow permission is `contents: read`. Skips loudly when `RUNLORE_EVAL_API_KEY` is absent.
+- `internal/app/eval.go: RunEval` writes `eval/reports/<stamp>-replay.json` via `Campaign.JSON()` **after** printing results and **before** returning `eval.GateError` — so a gate failure still writes the report (good: honest publishing works without changes to control flow).
+- `internal/eval/eval.go`: `Campaign.JSON()` emits `{n, pass_rate, reached, total, cases:[{name, runs, pass_rate, reached, flaky, confidence, missing, over_claimed}]}` via a local `row` struct that relies on field-order conversion `row(a)` — adding fields to `CaseAggregate` breaks that conversion, so the marshal moves to an explicit `Report` type.
+- `Result` (score.go) has `RecallFired` / `RecallShortCircuit`, set by `runOne` from the `RecallDecision`; `aggregateCase` drops them today.
+- `eval.CountingModel` (compare_run.go) wraps a `providers.ModelProvider` and sums `providers.Usage` — reusable as-is.
+- `config.Pricing` (config.go: `input_usd_per_mtok`, `output_usd_per_mtok`, `cached_input_usd_per_mtok`) exists, optional, validated non-negative. The cost formula to mirror is `internal/investigate/cost.go:cost()` (cached input bills at the cached rate, remainder at the input rate).
+- `evalMinPassRate = 0.7` (stats.go) is the shared k-of-n bar and the CI gate.
+- README badges live at lines 12–16; the docs link row is the `🔒 [Security model]…` paragraph; CONTRIBUTING has a "Nightly eval (CI)" section.
+- Repo commit rule: conventional messages, **never** a `Co-Authored-By` line.
+
+---
+
+### Task 1: Extend the replay report — provenance + recall telemetry (`internal/eval`)
+
+**Files:**
+- `internal/eval/replay_report.go` (new)
+- `internal/eval/replay_report_test.go` (new)
+- `internal/eval/eval.go` (modify: `CaseAggregate` fields, `aggregateCase` → pure `aggregateResults`, `Campaign.JSON` becomes a thin wrapper, delete the `row` struct)
+
+**Steps:**
+
+- [ ] Write the failing tests in `internal/eval/replay_report_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestCampaignReportCarriesProvenance(t *testing.T) {
+	camp := Campaign{N: 5, Aggregates: []CaseAggregate{
+		{Name: "harbor-chart-bump", Runs: 5, PassRate: 1, Reached: true, Confidence: 0.82},
+	}}
+	cost := 0.42
+	rep := camp.Report("2026-07-23T06:00:00Z", "anthropic/claude-haiku-4-5-20251001",
+		providers.Usage{InputTokens: 120000, OutputTokens: 9000}, &cost)
+	b, err := rep.JSON()
+	if err != nil {
+		t.Fatalf("JSON: %v", err)
+	}
+	var got Report
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.At != "2026-07-23T06:00:00Z" || got.Model != "anthropic/claude-haiku-4-5-20251001" {
+		t.Fatalf("provenance not carried: %+v", got)
+	}
+	if got.InputTokens != 120000 || got.OutputTokens != 9000 || got.CostUSD == nil || *got.CostUSD != 0.42 {
+		t.Fatalf("usage/cost not carried: %+v", got)
+	}
+	if got.N != 5 || got.Total != 1 || got.Reached != 1 || got.PassRate != 1.0 {
+		t.Fatalf("campaign header wrong: %+v", got)
+	}
+}
+
+func TestCaseAggregateCountsRecall(t *testing.T) {
+	c := Case{Name: "recall-case", CatalogDir: "kb", ExpectRecall: "short_circuit"}
+	results := []Result{
+		{Pass: true, Confidence: 0.9, RecallFired: true, RecallShortCircuit: true},
+		{Pass: true, Confidence: 0.8, RecallFired: true},
+		{Pass: false, Confidence: 0.4},
+	}
+	a := aggregateResults(c, results)
+	if !a.HasRecall || a.ExpectRecall != "short_circuit" {
+		t.Fatalf("recall case identity not carried: %+v", a)
+	}
+	if a.RecallFired != 2 || a.RecallShortCircuit != 1 {
+		t.Fatalf("want fired=2 short-circuit=1, got %+v", a)
+	}
+	// Existing fold semantics must survive the refactor: 2/3 ≈ 0.67 < 0.7 ⇒ not reached, flaky.
+	if a.Reached || !a.Flaky || a.Runs != 3 {
+		t.Fatalf("k-of-n fold broken by refactor: %+v", a)
+	}
+}
+
+func TestEstimateCostUSD(t *testing.T) {
+	u := providers.Usage{InputTokens: 2_000_000, CachedInputTokens: 1_000_000, OutputTokens: 200_000}
+	// 1M uncached × $1 + 1M cached × $0.10 + 0.2M out × $5 = $2.10
+	got := EstimateCostUSD(u, 1.0, 0.10, 5.0)
+	if got < 2.099 || got > 2.101 {
+		t.Fatalf("want $2.10, got %v", got)
+	}
+}
+```
+
+- [ ] Run: `go test ./internal/eval/ -run 'TestCampaignReportCarriesProvenance|TestCaseAggregateCountsRecall|TestEstimateCostUSD'` — expect compile failure: `undefined: Report`, `undefined: aggregateResults`, `undefined: EstimateCostUSD`, unknown fields `HasRecall`/`ExpectRecall`/`RecallFired`/`RecallShortCircuit`.
+- [ ] Create `internal/eval/replay_report.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"encoding/json"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Report is the serializable replay-campaign report — the `*-replay.json` schema
+// the nightly eval writes and `lore eval scorecard` consumes. It is a strict
+// superset of the pre-v0.11 Campaign.JSON schema: every existing key is
+// unchanged; provenance (at/model/tokens/cost) and per-case recall telemetry
+// are additive, so old reports still parse.
+type Report struct {
+	At           string       `json:"at,omitempty"`    // run timestamp (RFC3339, UTC)
+	Model        string       `json:"model,omitempty"` // "<provider>/<model>" disclosure
+	N            int          `json:"n"`
+	PassRate     float64      `json:"pass_rate"`
+	Reached      int          `json:"reached"`
+	Total        int          `json:"total"`
+	InputTokens  int          `json:"input_tokens,omitempty"`
+	OutputTokens int          `json:"output_tokens,omitempty"`
+	CostUSD      *float64     `json:"cost_usd,omitempty"` // present only when config.model.pricing is set
+	Cases        []ReportCase `json:"cases"`
+}
+
+// ReportCase is one case's k-of-n verdict in the report.
+type ReportCase struct {
+	Name        string   `json:"name"`
+	Runs        int      `json:"runs"`
+	PassRate    float64  `json:"pass_rate"`
+	Reached     bool     `json:"reached"`
+	Flaky       bool     `json:"flaky"`
+	Confidence  float64  `json:"confidence"`
+	Missing     []string `json:"missing,omitempty"`
+	OverClaimed []string `json:"over_claimed,omitempty"`
+
+	// Recall telemetry (cases with a catalog fixture only).
+	HasRecall          bool   `json:"has_recall,omitempty"`
+	ExpectRecall       string `json:"expect_recall,omitempty"`
+	RecallFired        int    `json:"recall_fired_runs,omitempty"`
+	RecallShortCircuit int    `json:"recall_short_circuit_runs,omitempty"`
+}
+
+// Report projects the campaign plus its provenance into the serializable report.
+func (c Campaign) Report(at, model string, usage providers.Usage, costUSD *float64) Report {
+	rep := Report{
+		At: at, Model: model, N: c.N,
+		PassRate: c.PassRate(), Reached: c.ReachedCases(), Total: len(c.Aggregates),
+		InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens, CostUSD: costUSD,
+	}
+	for _, a := range c.Aggregates {
+		rep.Cases = append(rep.Cases, ReportCase{
+			Name: a.Name, Runs: a.Runs, PassRate: a.PassRate, Reached: a.Reached, Flaky: a.Flaky,
+			Confidence: a.Confidence, Missing: a.Missing, OverClaimed: a.OverClaimed,
+			HasRecall: a.HasRecall, ExpectRecall: a.ExpectRecall,
+			RecallFired: a.RecallFired, RecallShortCircuit: a.RecallShortCircuit,
+		})
+	}
+	return rep
+}
+
+// JSON renders the indented machine-readable report.
+func (rep Report) JSON() ([]byte, error) {
+	return json.MarshalIndent(rep, "", "  ")
+}
+
+// EstimateCostUSD prices a usage total: cached input tokens bill at the cached
+// rate and the non-cached remainder at the input rate (InputTokens INCLUDES
+// cached — mirrors internal/investigate's cost()). Rates are USD per MILLION tokens.
+func EstimateCostUSD(u providers.Usage, inputUSDPerMTok, cachedUSDPerMTok, outputUSDPerMTok float64) float64 {
+	uncached := u.InputTokens - u.CachedInputTokens
+	if uncached < 0 {
+		uncached = 0
+	}
+	return float64(uncached)/1e6*inputUSDPerMTok +
+		float64(u.CachedInputTokens)/1e6*cachedUSDPerMTok +
+		float64(u.OutputTokens)/1e6*outputUSDPerMTok
+}
+```
+
+- [ ] In `internal/eval/eval.go`, add the four recall fields to `CaseAggregate` (after `OverClaimed`):
+
+```go
+	// Recall telemetry aggregated over the repeats (cases with a catalog fixture only):
+	// HasRecall marks the case as recall-exercising, ExpectRecall echoes its assertion,
+	// and the counters say in how many of the N repeats recall fired / short-circuited.
+	HasRecall          bool
+	ExpectRecall       string
+	RecallFired        int
+	RecallShortCircuit int
+```
+
+- [ ] In `internal/eval/eval.go`, replace the body of `aggregateCase` with a run-collect loop plus a pure, testable fold (replace the whole existing `aggregateCase` function):
+
+```go
+func (r *Runner) aggregateCase(ctx context.Context, c Case, n int) CaseAggregate {
+	results := make([]Result, 0, n)
+	for i := 0; i < n; i++ {
+		results = append(results, r.runOne(ctx, c))
+	}
+	return aggregateResults(c, results)
+}
+
+// aggregateResults folds the repeats of one case into its k-of-n aggregate. Pure —
+// separated from the runner so the fold (including recall counting) is unit-testable.
+func aggregateResults(c Case, results []Result) CaseAggregate {
+	confs := make([]float64, 0, len(results))
+	missSet := map[string]struct{}{}
+	ocSet := map[string]struct{}{}
+	passes, fired, shortCircuits := 0, 0, 0
+	for _, res := range results {
+		if res.Pass {
+			passes++
+		}
+		if res.RecallFired {
+			fired++
+		}
+		if res.RecallShortCircuit {
+			shortCircuits++
+		}
+		confs = append(confs, res.Confidence)
+		for _, m := range res.Missing {
+			missSet[m] = struct{}{}
+		}
+		for _, o := range res.OverClaimed {
+			ocSet[o] = struct{}{}
+		}
+	}
+	rate := float64(passes) / float64(len(results))
+	return CaseAggregate{
+		Name:        c.Name,
+		Runs:        len(results),
+		PassRate:    rate,
+		Reached:     rate >= evalMinPassRate,
+		Flaky:       rate > 1-evalMinPassRate && rate < evalMinPassRate,
+		Confidence:  medianFloat(confs),
+		Missing:     sortedSet(missSet),
+		OverClaimed: sortedSet(ocSet),
+		HasRecall:          c.CatalogDir != "",
+		ExpectRecall:       c.ExpectRecall,
+		RecallFired:        fired,
+		RecallShortCircuit: shortCircuits,
+	}
+}
+```
+
+- [ ] In `internal/eval/eval.go`, replace the whole `Campaign.JSON` method (including its local `row` struct, which breaks once `CaseAggregate` gains fields) with a thin wrapper:
+
+```go
+// JSON renders the campaign as an indented report without provenance. Kept for
+// callers that have no model/usage context; the nightly eval uses
+// Campaign.Report(...).JSON() so the published report carries provenance.
+func (c Campaign) JSON() ([]byte, error) {
+	return c.Report("", "", providers.Usage{}, nil).JSON()
+}
+```
+
+- [ ] Run: `go test ./internal/eval/` — expect `ok` (the new tests pass; `TestCampaignJSON` and `TestReplayKOfNRepeats` still pass because the schema is a superset and the fold semantics are unchanged).
+- [ ] Run: `go build ./... && go vet ./internal/eval/` — expect clean.
+- [ ] Commit: `feat(eval): replay report carries provenance and recall telemetry`
+
+---
+
+### Task 2: Wire usage counting + pricing into `lore eval` (`internal/app`)
+
+**Files:**
+- `internal/app/eval.go` (modify `RunEval`, add `evalCostUSD` helper)
+- `internal/app/eval_cost_test.go` (new)
+- `eval/ci.runlore.yaml` (add optional `pricing:` block)
+
+**Steps:**
+
+- [ ] Write the failing test in `internal/app/eval_cost_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestEvalCostUSDFromPricing(t *testing.T) {
+	cfg := &config.Config{}
+	if got := evalCostUSD(cfg, providers.Usage{InputTokens: 1_000_000}); got != nil {
+		t.Fatalf("unpriced config must yield nil (omit cost, do not claim $0), got %v", *got)
+	}
+	cfg.Model.Pricing = &config.Pricing{
+		InputUSDPerMTok: 1.0, OutputUSDPerMTok: 5.0, CachedInputUSDPerMTok: 0.10,
+	}
+	got := evalCostUSD(cfg, providers.Usage{
+		InputTokens: 2_000_000, CachedInputTokens: 1_000_000, OutputTokens: 200_000,
+	})
+	// 1M uncached × $1 + 1M cached × $0.10 + 0.2M out × $5 = $2.10
+	if got == nil || *got < 2.099 || *got > 2.101 {
+		t.Fatalf("want ≈$2.10, got %v", got)
+	}
+}
+```
+
+- [ ] Run: `go test ./internal/app/ -run TestEvalCostUSDFromPricing` — expect compile failure: `undefined: evalCostUSD`.
+- [ ] Add the helper to `internal/app/eval.go`:
+
+```go
+// evalCostUSD estimates the campaign cost from the optional config pricing; nil
+// when unpriced so the report omits cost_usd instead of claiming $0.00.
+func evalCostUSD(cfg *config.Config, u providers.Usage) *float64 {
+	p := cfg.Model.Pricing
+	if p == nil {
+		return nil
+	}
+	c := eval.EstimateCostUSD(u, p.InputUSDPerMTok, p.CachedInputUSDPerMTok, p.OutputUSDPerMTok)
+	return &c
+}
+```
+
+  (add `"github.com/Smana/runlore/internal/providers"` to the file's imports.)
+- [ ] Run: `go test ./internal/app/ -run TestEvalCostUSDFromPricing` — expect `ok`.
+- [ ] In `RunEval` (replay path), wrap the model so tokens are counted. Replace:
+
+```go
+	runner := &eval.Runner{Model: BuildModel(cfg, apiKey), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+```
+
+  with:
+
+```go
+	counting := &eval.CountingModel{Inner: BuildModel(cfg, apiKey)}
+	runner := &eval.Runner{Model: counting, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+```
+
+- [ ] In the `if *reportDir != ""` block of `RunEval`, build the provenance-carrying report. Replace:
+
+```go
+		if b, err := camp.JSON(); err != nil {
+```
+
+  with:
+
+```go
+		usage := counting.Total()
+		rep := camp.Report(st, cfg.Model.Provider+"/"+cfg.Model.Model, usage, evalCostUSD(cfg, usage))
+		if b, err := rep.JSON(); err != nil {
+```
+
+  (the `st` stamp variable already exists two lines above; no other change to the block.)
+- [ ] Append the optional pricing block to `eval/ci.runlore.yaml` (via `yq` or Edit; final file content):
+
+```yaml
+# Minimal config for the nightly CI eval (replay mode).
+# Only the model block is needed — replay scenarios supply their own evidence.
+# Set the repo secret RUNLORE_EVAL_API_KEY to the API key for this provider.
+model:
+  provider: anthropic
+  model: claude-haiku-4-5-20251001
+  api_key_env: RUNLORE_EVAL_API_KEY
+  # Optional: token rates (USD per MILLION tokens) so the published scorecard
+  # reports an honest per-run cost. claude-haiku-4-5 list prices, 2026-07
+  # (same figures as eval/compare.example.yaml). Wrong rates only skew the
+  # cost figure, never the pass/fail scoring.
+  pricing:
+    input_usd_per_mtok: 1.00
+    output_usd_per_mtok: 5.00
+    cached_input_usd_per_mtok: 0.10
+```
+
+- [ ] Run: `go build ./... && go test ./internal/app/ ./internal/eval/` — expect `ok` for both.
+- [ ] Local dry-run that the config still loads: `go run ./cmd/lore eval -config eval/ci.runlore.yaml -cases examples/eval -report-dir /tmp/f2-dryrun 2>&1 | head -3` — without `RUNLORE_EVAL_API_KEY` set this must fail with a model/API-key error (e.g. missing key), **not** a config-parse error mentioning `pricing`.
+- [ ] Commit: `feat(eval): count tokens and price the nightly replay report`
+
+---
+
+### Task 3: Scorecard renderer — markdown, badge, history (`internal/eval/scorecard.go`)
+
+**Files:**
+- `internal/eval/scorecard.go` (new)
+- `internal/eval/scorecard_test.go` (new)
+
+**Steps:**
+
+- [ ] Write the failing tests in `internal/eval/scorecard_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"strings"
+	"testing"
+)
+
+func scorecardFixtureReport() Report {
+	cost := 0.16
+	return Report{
+		At: "2026-07-23T06:00:00Z", Model: "anthropic/claude-haiku-4-5-20251001",
+		N: 5, PassRate: 0.5, Reached: 1, Total: 2,
+		InputTokens: 120000, OutputTokens: 9000, CostUSD: &cost,
+		Cases: []ReportCase{
+			{Name: "harbor-chart-bump", Runs: 5, PassRate: 1, Reached: true, Confidence: 0.82},
+			{Name: "poisoned-recall-verify", Runs: 5, PassRate: 0.4, Flaky: true, Confidence: 0.75,
+				HasRecall: true, ExpectRecall: "withdrawn", RecallFired: 5,
+				Missing: []string{"expect_recall=withdrawn but recall short_circuit"}},
+		},
+	}
+}
+
+func TestBadgeJSON(t *testing.T) {
+	b := string(BadgeJSON(scorecardFixtureReport()))
+	if !strings.Contains(b, `"schemaVersion":1`) {
+		t.Fatalf("not a shields endpoint doc: %s", b)
+	}
+	if !strings.Contains(b, `"message":"1/2 scenarios · 50%"`) {
+		t.Fatalf("badge message wrong: %s", b)
+	}
+	if !strings.Contains(b, `"color":"yellow"`) { // 0.5 is in [0.5, 0.7) ⇒ yellow
+		t.Fatalf("badge color wrong: %s", b)
+	}
+	green := scorecardFixtureReport()
+	green.PassRate, green.Reached = 1.0, 2
+	if g := string(BadgeJSON(green)); !strings.Contains(g, `"color":"brightgreen"`) {
+		t.Fatalf("1.0 should be brightgreen: %s", g)
+	}
+}
+
+func TestAppendHistoryDedupesAndCaps(t *testing.T) {
+	e := HistoryFromReport(scorecardFixtureReport())
+	out, entries, err := AppendHistory(nil, e)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("first append: %v / %d entries", err, len(entries))
+	}
+	// Re-appending the same run (same At) must be idempotent.
+	out2, entries2, err := AppendHistory(out, e)
+	if err != nil || len(entries2) != 1 || string(out2) != string(out) {
+		t.Fatalf("dedupe on At failed: %v / %d entries", err, len(entries2))
+	}
+	// Cap: appending beyond maxHistory drops the oldest.
+	long := out
+	for i := 0; i < maxHistory+10; i++ {
+		e.At = "2026-07-23T06:00:00Z" + strings.Repeat("x", i+1) // unique At per line
+		long, entries, err = AppendHistory(long, e)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(entries) != maxHistory {
+		t.Fatalf("want cap %d, got %d", maxHistory, len(entries))
+	}
+}
+
+func TestScorecardMarkdown(t *testing.T) {
+	rep := scorecardFixtureReport()
+	_, entries, err := AppendHistory(nil, HistoryFromReport(rep))
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := ScorecardMarkdown(rep, entries)
+	for _, want := range []string{
+		"# RunLore nightly eval scorecard",
+		"lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7", // reproduce command
+		"anthropic/claude-haiku-4-5-20251001",                                              // model disclosure
+		"**1/2 scenarios reached (50%)**",
+		"est. cost $0.16",
+		"| harbor-chart-bump | ✅ PASS |",
+		"| poisoned-recall-verify | ⚠️ FLAKY |",
+		"fired 5/5 · short-circuit 0/5 (expect: withdrawn)", // recall outcome column
+		"## Confidence calibration",
+		"poisoned-recall-verify", // 0.75 ≥ 0.70 and not reached ⇒ confidently wrong
+		"## History",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("scorecard missing %q in:\n%s", want, md)
+		}
+	}
+}
+```
+
+- [ ] Run: `go test ./internal/eval/ -run 'TestBadgeJSON|TestAppendHistory|TestScorecardMarkdown'` — expect compile failure (`undefined: BadgeJSON` etc.).
+- [ ] Create `internal/eval/scorecard.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Scorecard rendering: turns the nightly replay report (Report) into the public
+// artifacts published on the eval-scorecard branch — a browsable scorecard.md, a
+// shields.io endpoint badge.json, and an append-only history.jsonl. Pure functions
+// over bytes so the whole pipeline is testable without CI.
+package eval
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const (
+	maxHistory   = 365 // history.jsonl cap: one nightly line/day ≈ one year
+	historyShown = 30  // history rows rendered in scorecard.md (newest first)
+
+	// Calibration bands for the scorecard summary. confidentWrongFloor deliberately
+	// matches evalMinPassRate's spirit: a missed case the model was ≥70% sure about
+	// is the "confident and wrong" failure mode published benchmarks care about.
+	confidentWrongFloor = 0.70
+	underConfidentCeil  = 0.50
+)
+
+// HistoryEntry is one nightly run in the scorecard history (one JSONL line).
+type HistoryEntry struct {
+	At           string   `json:"at"`
+	Model        string   `json:"model,omitempty"`
+	N            int      `json:"n"`
+	PassRate     float64  `json:"pass_rate"`
+	Reached      int      `json:"reached"`
+	Total        int      `json:"total"`
+	InputTokens  int      `json:"input_tokens,omitempty"`
+	OutputTokens int      `json:"output_tokens,omitempty"`
+	CostUSD      *float64 `json:"cost_usd,omitempty"`
+}
+
+// HistoryFromReport projects a replay report onto its one-line history record.
+func HistoryFromReport(rep Report) HistoryEntry {
+	return HistoryEntry{
+		At: rep.At, Model: rep.Model, N: rep.N,
+		PassRate: rep.PassRate, Reached: rep.Reached, Total: rep.Total,
+		InputTokens: rep.InputTokens, OutputTokens: rep.OutputTokens, CostUSD: rep.CostUSD,
+	}
+}
+
+// AppendHistory appends e to the JSONL history, replacing any line with the same
+// At (so re-publishing one run is idempotent) and capping the log at maxHistory
+// entries (oldest dropped). Returns the new JSONL bytes and the entries oldest-first.
+func AppendHistory(existing []byte, e HistoryEntry) ([]byte, []HistoryEntry, error) {
+	var entries []HistoryEntry
+	for _, line := range bytes.Split(existing, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var h HistoryEntry
+		if err := json.Unmarshal(line, &h); err != nil {
+			return nil, nil, fmt.Errorf("parse history line %q: %w", line, err)
+		}
+		if h.At == e.At {
+			continue // same run re-rendered: its fresh line replaces the old one
+		}
+		entries = append(entries, h)
+	}
+	entries = append(entries, e)
+	if len(entries) > maxHistory {
+		entries = entries[len(entries)-maxHistory:]
+	}
+	var out bytes.Buffer
+	for _, h := range entries {
+		b, err := json.Marshal(h)
+		if err != nil {
+			return nil, nil, err
+		}
+		out.Write(b)
+		out.WriteByte('\n')
+	}
+	return out.Bytes(), entries, nil
+}
+
+// BadgeJSON renders the shields.io "endpoint" badge document
+// (https://shields.io/badges/endpoint-badge) for the README pass-rate badge.
+// Color bands: ≥90% brightgreen, ≥ the 70% CI gate green, ≥50% yellow, else red.
+func BadgeJSON(rep Report) []byte {
+	color := "red"
+	switch {
+	case rep.PassRate >= 0.9:
+		color = "brightgreen"
+	case rep.PassRate >= evalMinPassRate:
+		color = "green"
+	case rep.PassRate >= 0.5:
+		color = "yellow"
+	}
+	b, _ := json.Marshal(map[string]any{
+		"schemaVersion": 1,
+		"label":         "nightly eval",
+		"message":       fmt.Sprintf("%d/%d scenarios · %.0f%%", rep.Reached, rep.Total, rep.PassRate*100),
+		"color":         color,
+	})
+	return b
+}
+
+// ScorecardMarkdown renders the browsable public scorecard: reproduce command,
+// provenance (model, date, cost), per-scenario table with recall outcomes, a
+// confidence-calibration summary, and the run history.
+func ScorecardMarkdown(rep Report, history []HistoryEntry) string {
+	var b strings.Builder
+	b.WriteString("# RunLore nightly eval scorecard\n\n")
+	b.WriteString("Auto-published by [`.github/workflows/eval.yaml`](https://github.com/Smana/runlore/blob/main/.github/workflows/eval.yaml) — ")
+	b.WriteString("the replay eval scores the model+loop over recorded incident evidence (no live cluster), so anyone can reproduce it:\n\n")
+	b.WriteString("```\nlore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7\n```\n\n")
+
+	fmt.Fprintf(&b, "**Latest run:** %s", rep.At)
+	if rep.Model != "" {
+		fmt.Fprintf(&b, " · model `%s`", rep.Model)
+	}
+	fmt.Fprintf(&b, " · **%d/%d scenarios reached (%.0f%%)** · n=%d runs/case, k-of-n bar %.0f%%",
+		rep.Reached, rep.Total, rep.PassRate*100, rep.N, evalMinPassRate*100)
+	if rep.CostUSD != nil {
+		fmt.Fprintf(&b, " · est. cost $%.2f (%s in / %s out tokens)",
+			*rep.CostUSD, compactTokens(rep.InputTokens), compactTokens(rep.OutputTokens))
+	} else if rep.InputTokens+rep.OutputTokens > 0 {
+		fmt.Fprintf(&b, " · %s in / %s out tokens", compactTokens(rep.InputTokens), compactTokens(rep.OutputTokens))
+	}
+	b.WriteString("\n\n## Scenarios (latest run)\n\n")
+	b.WriteString("| scenario | result | pass-rate | median confidence | recall | notes |\n")
+	b.WriteString("|---|---|---|---|---|---|\n")
+	for _, c := range rep.Cases {
+		fmt.Fprintf(&b, "| %s | %s | %.0f%% (n=%d) | %.2f | %s | %s |\n",
+			c.Name, resultCell(c), c.PassRate*100, c.Runs, c.Confidence, recallCell(c), notesCell(c))
+	}
+
+	b.WriteString("\n## Confidence calibration\n\n")
+	var confidentWrong, underConfident []string
+	for _, c := range rep.Cases {
+		if !c.Reached && c.Confidence >= confidentWrongFloor {
+			confidentWrong = append(confidentWrong, c.Name)
+		}
+		if c.Reached && c.Confidence < underConfidentCeil {
+			underConfident = append(underConfident, c.Name)
+		}
+	}
+	fmt.Fprintf(&b, "- **Confidently wrong** (missed with median confidence ≥ %.2f): %s\n", confidentWrongFloor, nameList(confidentWrong))
+	fmt.Fprintf(&b, "- **Underconfident** (reached with median confidence < %.2f): %s\n", underConfidentCeil, nameList(underConfident))
+
+	b.WriteString("\n## History\n\n")
+	fmt.Fprintf(&b, "Newest first, last %d shown — the full log is [`history.jsonl`](history.jsonl). ", historyShown)
+	b.WriteString("Runs below the CI gate publish here exactly like green ones.\n\n")
+	b.WriteString("| date | model | reached | pass-rate | est. cost |\n|---|---|---|---|---|\n")
+	shown := history
+	if len(shown) > historyShown {
+		shown = shown[len(shown)-historyShown:]
+	}
+	for i := len(shown) - 1; i >= 0; i-- {
+		h := shown[i]
+		cost := "—"
+		if h.CostUSD != nil {
+			cost = fmt.Sprintf("$%.2f", *h.CostUSD)
+		}
+		fmt.Fprintf(&b, "| %s | %s | %d/%d | %.0f%% | %s |\n", h.At, h.Model, h.Reached, h.Total, h.PassRate*100, cost)
+	}
+	return b.String()
+}
+
+func resultCell(c ReportCase) string {
+	switch {
+	case c.Reached:
+		return "✅ PASS"
+	case c.Flaky:
+		return "⚠️ FLAKY"
+	default:
+		return "❌ MISS"
+	}
+}
+
+func recallCell(c ReportCase) string {
+	if !c.HasRecall {
+		return "—"
+	}
+	s := fmt.Sprintf("fired %d/%d · short-circuit %d/%d", c.RecallFired, c.Runs, c.RecallShortCircuit, c.Runs)
+	if c.ExpectRecall != "" {
+		s += fmt.Sprintf(" (expect: %s)", c.ExpectRecall)
+	}
+	return s
+}
+
+func notesCell(c ReportCase) string {
+	if len(c.Missing) == 0 {
+		return "—"
+	}
+	return strings.Join(c.Missing, ", ")
+}
+
+func nameList(names []string) string {
+	if len(names) == 0 {
+		return "none"
+	}
+	return fmt.Sprintf("%d — %s", len(names), strings.Join(names, ", "))
+}
+
+// compactTokens renders a token count as 1.2M / 84.0k / 512 for the summary line.
+func compactTokens(n int) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1e6)
+	case n >= 1_000:
+		return fmt.Sprintf("%.1fk", float64(n)/1e3)
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}
+```
+
+- [ ] Run: `go test ./internal/eval/` — expect `ok`.
+- [ ] Run: `go vet ./internal/eval/ && go build ./...` — expect clean.
+- [ ] Commit: `feat(eval): scorecard renderer — markdown, shields badge, history jsonl`
+
+---
+
+### Task 4: `lore eval scorecard` subcommand (keyless renderer CLI)
+
+**Files:**
+- `internal/app/eval_scorecard.go` (new)
+- `internal/app/eval_scorecard_test.go` (new)
+- `internal/app/eval.go` (modify: dispatch the subcommand before config load)
+- `cmd/lore/main.go` (modify: usage string)
+
+**Steps:**
+
+- [ ] Write the failing test in `internal/app/eval_scorecard_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const scorecardReportFixture = `{
+  "at": "2026-07-23T06:00:00Z",
+  "model": "anthropic/claude-haiku-4-5-20251001",
+  "n": 5, "pass_rate": 0.5, "reached": 1, "total": 2,
+  "input_tokens": 120000, "output_tokens": 9000, "cost_usd": 0.16,
+  "cases": [
+    {"name": "harbor-chart-bump", "runs": 5, "pass_rate": 1, "reached": true, "flaky": false, "confidence": 0.82},
+    {"name": "poisoned-recall-verify", "runs": 5, "pass_rate": 0.4, "reached": false, "flaky": true, "confidence": 0.75,
+     "has_recall": true, "expect_recall": "withdrawn", "recall_fired_runs": 5, "recall_short_circuit_runs": 0,
+     "missing": ["expect_recall=withdrawn but recall short_circuit"]}
+  ]
+}`
+
+func TestRunEvalScorecard(t *testing.T) {
+	dir := t.TempDir()
+	report := filepath.Join(dir, "2026-07-23T06-00-00Z-replay.json")
+	if err := os.WriteFile(report, []byte(scorecardReportFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "scorecard")
+	if err := RunEvalScorecard([]string{"-report", report, "-dir", out}); err != nil {
+		t.Fatalf("RunEvalScorecard: %v", err)
+	}
+	// Re-running on the same report must be idempotent (same At ⇒ 1 history line).
+	if err := RunEvalScorecard([]string{"-report", report, "-dir", out}); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	md, err := os.ReadFile(filepath.Join(out, "scorecard.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"**1/2 scenarios reached (50%)**", "⚠️ FLAKY", "expect: withdrawn"} {
+		if !strings.Contains(string(md), want) {
+			t.Fatalf("scorecard.md missing %q", want)
+		}
+	}
+	badge, err := os.ReadFile(filepath.Join(out, "badge.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(badge), `"message":"1/2 scenarios · 50%"`) {
+		t.Fatalf("badge.json wrong: %s", badge)
+	}
+	hist, err := os.ReadFile(filepath.Join(out, "history.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lines := strings.Count(strings.TrimSpace(string(hist)), "\n") + 1; lines != 1 {
+		t.Fatalf("want 1 history line after idempotent re-run, got %d:\n%s", lines, hist)
+	}
+}
+
+func TestRunEvalScorecardRejectsMissingReport(t *testing.T) {
+	if err := RunEvalScorecard([]string{"-dir", t.TempDir()}); err == nil {
+		t.Fatal("want error when -report is missing")
+	}
+}
+```
+
+- [ ] Run: `go test ./internal/app/ -run TestRunEvalScorecard` — expect compile failure: `undefined: RunEvalScorecard`.
+- [ ] Create `internal/app/eval_scorecard.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Smana/runlore/internal/eval"
+)
+
+// RunEvalScorecard renders the public scorecard artifacts (scorecard.md,
+// badge.json, history.jsonl) from a replay report. Keyless and config-free: it
+// only reads the report JSON and the output dir's existing history, so CI can run
+// it after the eval and anyone can run it locally on a downloaded report artifact.
+func RunEvalScorecard(args []string) error {
+	fs := flag.NewFlagSet("eval scorecard", flag.ContinueOnError)
+	report := fs.String("report", "", "path to a *-replay.json report (required)")
+	dir := fs.String("dir", "scorecard", "output directory (scorecard.md, badge.json, history.jsonl)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *report == "" {
+		return fmt.Errorf("eval scorecard: -report <replay.json> is required")
+	}
+	data, err := os.ReadFile(*report) //nolint:gosec // G304: operator-supplied report path
+	if err != nil {
+		return err
+	}
+	var rep eval.Report
+	if err := json.Unmarshal(data, &rep); err != nil {
+		return fmt.Errorf("parse report %s: %w", *report, err)
+	}
+	if rep.Total == 0 {
+		return fmt.Errorf("report %s has no cases — refusing to publish an empty scorecard", *report)
+	}
+	if err := os.MkdirAll(*dir, 0o750); err != nil {
+		return err
+	}
+	histPath := filepath.Join(*dir, "history.jsonl")
+	existing, err := os.ReadFile(histPath) //nolint:gosec // G304: path derived from operator-supplied -dir
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	hist, entries, err := eval.AppendHistory(existing, eval.HistoryFromReport(rep))
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(histPath, hist, 0o644); err != nil { //nolint:gosec // published artifact, world-readable
+		return err
+	}
+	md := eval.ScorecardMarkdown(rep, entries)
+	if err := os.WriteFile(filepath.Join(*dir, "scorecard.md"), []byte(md), 0o644); err != nil { //nolint:gosec
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(*dir, "badge.json"), eval.BadgeJSON(rep), 0o644); err != nil { //nolint:gosec
+		return err
+	}
+	fmt.Printf("scorecard: %s (badge.json, history.jsonl alongside)\n", filepath.Join(*dir, "scorecard.md"))
+	return nil
+}
+```
+
+- [ ] In `internal/app/eval.go`, dispatch the subcommand at the very top of `RunEval` (before the flag set, so it needs no config/model):
+
+```go
+	if len(args) > 0 && args[0] == "scorecard" {
+		return RunEvalScorecard(args[1:])
+	}
+```
+
+- [ ] In `cmd/lore/main.go`, add one usage line directly after the `lore eval --compare …` line:
+
+```go
+  lore eval scorecard -report <replay.json> -dir <out>  render the public scorecard (markdown + badge + history) from a replay report
+```
+
+- [ ] Run: `go test ./internal/app/ -run 'TestRunEvalScorecard|TestRunEvalScorecardRejectsMissingReport'` — expect `ok`.
+- [ ] Local end-to-end dry-run (this is the CI step's exact renderer path, run on a fixture since CI's model call can't run locally):
+
+```bash
+go build -o /tmp/lore ./cmd/lore
+cat > /tmp/f2-fixture-replay.json <<'EOF'
+{
+  "at": "2026-07-23T06:00:00Z",
+  "model": "anthropic/claude-haiku-4-5-20251001",
+  "n": 5, "pass_rate": 0.5, "reached": 1, "total": 2,
+  "input_tokens": 120000, "output_tokens": 9000, "cost_usd": 0.16,
+  "cases": [
+    {"name": "harbor-chart-bump", "runs": 5, "pass_rate": 1, "reached": true, "flaky": false, "confidence": 0.82},
+    {"name": "poisoned-recall-verify", "runs": 5, "pass_rate": 0.4, "reached": false, "flaky": true, "confidence": 0.75,
+     "has_recall": true, "expect_recall": "withdrawn", "recall_fired_runs": 5, "recall_short_circuit_runs": 0,
+     "missing": ["expect_recall=withdrawn but recall short_circuit"]}
+  ]
+}
+EOF
+/tmp/lore eval scorecard -report /tmp/f2-fixture-replay.json -dir /tmp/f2-scorecard
+cat /tmp/f2-scorecard/badge.json
+head -20 /tmp/f2-scorecard/scorecard.md
+```
+
+  Expected: prints `scorecard: /tmp/f2-scorecard/scorecard.md …`; `badge.json` is `{"color":"yellow","label":"nightly eval","message":"1/2 scenarios · 50%","schemaVersion":1}`; the markdown shows the header, the reproduce command, and the two-row scenario table.
+- [ ] Run: `go build ./... && go test ./...` — expect all `ok`.
+- [ ] Commit: `feat(cli): lore eval scorecard subcommand renders the public scorecard`
+
+---
+
+### Task 5: Nightly workflow publishes to the `eval-scorecard` branch
+
+**Files:**
+- `.github/workflows/eval.yaml` (modify: job permission + one publish step)
+
+**Steps:**
+
+- [ ] In `.github/workflows/eval.yaml`, replace the workflow-level permission comment/block:
+
+```yaml
+# Least privilege: the workflow only reads the repo; the replay-eval job elevates
+# to contents:write solely to push the public scorecard to the eval-scorecard
+# branch (never to main).
+permissions:
+  contents: read
+```
+
+  and add a job-level override right under `replay-eval:`:
+
+```yaml
+jobs:
+  replay-eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write   # push the scorecard to the eval-scorecard branch only
+```
+
+- [ ] Append the publish step at the end of the job (after `upload report`). `always()` is deliberate: a run that fails the 70% gate still wrote its report, and honest publishing of red runs is the point. The `github.ref` guard keeps branch-dispatched runs from overwriting the published numbers:
+
+```yaml
+      - name: publish scorecard (eval-scorecard branch)
+        # always(): a gate failure (score < 70%) must publish exactly like a pass —
+        # the scorecard's value is honesty. Guarded to main so a workflow_dispatch
+        # from a feature branch can't overwrite the published numbers, and to
+        # has_key so a skipped run publishes nothing.
+        if: always() && steps.guard.outputs.has_key == 'true' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          REPORT=$(ls -t eval/reports/*-replay.json 2>/dev/null | head -1 || true)
+          if [ -z "$REPORT" ]; then
+            echo "::warning title=Scorecard skipped::no replay report found (eval crashed before writing one)"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          OUT="$RUNNER_TEMP/scorecard-branch"
+          if git fetch origin eval-scorecard; then
+            git worktree add -B eval-scorecard "$OUT" origin/eval-scorecard
+          else
+            git worktree add --detach "$OUT"
+            git -C "$OUT" checkout --orphan eval-scorecard
+            git -C "$OUT" rm -rf --quiet . || true
+          fi
+          ./lore eval scorecard -report "$REPORT" -dir "$OUT"
+          git -C "$OUT" add -A
+          git -C "$OUT" commit -m "chore(eval): nightly scorecard $(date -u +%Y-%m-%d)" || { echo "no changes to publish"; exit 0; }
+          git -C "$OUT" push origin eval-scorecard
+```
+
+- [ ] Local verification (CI can't run here — no API key, no push rights):
+  - `yq '.jobs.replay-eval.permissions.contents' .github/workflows/eval.yaml` → `write`
+  - `yq '.jobs.replay-eval.steps[-1].name' .github/workflows/eval.yaml` → `publish scorecard (eval-scorecard branch)`
+  - `actionlint .github/workflows/eval.yaml` if `actionlint` is installed (skip cleanly if not).
+- [ ] Local dry-run of the branch-publish git choreography (simulates the orphan-branch first run against a scratch repo, using the Task 4 fixture):
+
+```bash
+go build -o /tmp/lore ./cmd/lore
+T=$(mktemp -d) && git -C "$T" init -q -b main && git -C "$T" commit -q --allow-empty -m init
+OUT="$T/scorecard-branch"
+git -C "$T" worktree add --detach "$OUT"
+git -C "$OUT" checkout --orphan eval-scorecard
+git -C "$OUT" rm -rf --quiet . 2>/dev/null || true
+/tmp/lore eval scorecard -report /tmp/f2-fixture-replay.json -dir "$OUT"
+git -C "$OUT" add -A && git -C "$OUT" commit -q -m "chore(eval): nightly scorecard test"
+git -C "$OUT" ls-tree --name-only eval-scorecard
+```
+
+  Expected final output: `badge.json`, `history.jsonl`, `scorecard.md` — three files, one orphan commit.
+- [ ] **Post-merge verification note (cannot run pre-merge):** after the PR merges to `main`, the maintainer triggers `eval` via *Run workflow* (workflow_dispatch on `main`; the `RUNLORE_EVAL_API_KEY` secret must be set, otherwise the run skips loudly and publishes nothing). Then confirm: (1) branch `eval-scorecard` exists with the three files, (2) `https://raw.githubusercontent.com/Smana/runlore/eval-scorecard/badge.json` serves the shields document, (3) the README badge renders (it shows shields' "invalid" placeholder until this first publish — expected and harmless).
+- [ ] Commit: `ci(eval): publish nightly scorecard to the eval-scorecard branch`
+
+---
+
+### Task 6: Link it — README badge + docs
+
+**Files:**
+- `README.md` (modify: badge row, honesty bullet, docs link row)
+- `CONTRIBUTING.md` (modify: "Nightly eval (CI)" section)
+- `docs/benchmarking.md` (modify: cross-link)
+
+**Steps:**
+
+- [ ] In `README.md`, insert the badge directly after the CI badge line (line 12). Old:
+
+```markdown
+[![CI](https://github.com/Smana/runlore/actions/workflows/ci.yaml/badge.svg)](https://github.com/Smana/runlore/actions/workflows/ci.yaml)
+```
+
+  New:
+
+```markdown
+[![CI](https://github.com/Smana/runlore/actions/workflows/ci.yaml/badge.svg)](https://github.com/Smana/runlore/actions/workflows/ci.yaml)
+[![Nightly eval](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2FSmana%2Frunlore%2Feval-scorecard%2Fbadge.json)](https://github.com/Smana/runlore/blob/eval-scorecard/scorecard.md)
+```
+
+- [ ] In `README.md`, extend the honesty bullet. Old:
+
+```markdown
+- every claim is checked by a shipped eval harness.
+```
+
+  New:
+
+```markdown
+- every claim is checked by a shipped eval harness, and the nightly results are
+  [published — pass, fail, model, and cost included](https://github.com/Smana/runlore/blob/eval-scorecard/scorecard.md).
+```
+
+- [ ] In the `README.md` docs link row, extend the benchmarking link. Old:
+
+```markdown
+📊 [Benchmarking models](docs/benchmarking.md) · 🛠 [Contributing](CONTRIBUTING.md)
+```
+
+  New:
+
+```markdown
+📊 [Benchmarking models](docs/benchmarking.md) · 🧮 [Nightly eval scorecard](https://github.com/Smana/runlore/blob/eval-scorecard/scorecard.md) · 🛠 [Contributing](CONTRIBUTING.md)
+```
+
+- [ ] In `CONTRIBUTING.md`, extend the "Nightly eval (CI)" section. After the paragraph ending `…then uploads the JSON report as a build artifact.` add:
+
+```markdown
+The run then **publishes a public scorecard** to the
+[`eval-scorecard`](https://github.com/Smana/runlore/tree/eval-scorecard) branch:
+`scorecard.md` (per-scenario pass/fail, recall outcomes, confidence calibration,
+model, date, estimated cost), `badge.json` (the README's shields.io endpoint
+badge), and `history.jsonl` (one line per run, capped at a year). Publishing is
+deliberately unconditional on the gate: a night below 70% is published exactly
+like a green one. Render the same artifacts locally from any report:
+
+    lore eval scorecard -report eval/reports/<stamp>-replay.json -dir /tmp/scorecard
+
+The per-run cost figure comes from the optional `pricing:` rates in
+`eval/ci.runlore.yaml`; token totals are always reported, the dollar estimate
+only when rates are set.
+```
+
+- [ ] In `docs/benchmarking.md`, add after the intro paragraph (the one ending `…publish an honest comparison.`):
+
+```markdown
+> RunLore's own nightly numbers are public: the replay eval publishes a
+> per-scenario scorecard — pass/fail, recall outcomes, confidence calibration,
+> model, date, and cost — to the
+> [`eval-scorecard` branch](https://github.com/Smana/runlore/blob/eval-scorecard/scorecard.md)
+> on every run, red or green.
+```
+
+- [ ] Verify: `grep -c "eval-scorecard" README.md CONTRIBUTING.md docs/benchmarking.md` — expect `README.md:3` (or more), `CONTRIBUTING.md:1`+, `docs/benchmarking.md:1`+. Render-check the README badge line has balanced brackets: `grep "Nightly eval" README.md`.
+- [ ] Run: `go build ./... && go test ./...` — expect all `ok` (docs-only task; catches accidental stray edits).
+- [ ] Commit: `docs: link the public nightly eval scorecard (README badge, contributing, benchmarking)`
+
+---
+
+## Acceptance criteria
+
+- [ ] `eval/reports/*-replay.json` written by `lore eval` now carries `at`, `model` (`provider/model`), `input_tokens`, `output_tokens`, `cost_usd` (when `pricing:` is set), and per-case `has_recall` / `expect_recall` / `recall_fired_runs` / `recall_short_circuit_runs` — verified by `go test ./internal/eval/` and `go test ./internal/app/`.
+- [ ] Pre-v0.11 report keys are unchanged (superset schema); `TestCampaignJSON` passes unmodified.
+- [ ] `lore eval scorecard -report <json> -dir <out>` produces `scorecard.md`, `badge.json` (shields endpoint schema with correct message and color bands), and `history.jsonl`; re-running on the same report is idempotent (deduped on `at`); history is capped at 365 entries.
+- [ ] `scorecard.md` contains: the exact reproduce command, model + date + cost disclosure, a per-scenario table (PASS/FLAKY/MISS, pass-rate, median confidence, recall outcome, missing notes), a confidence-calibration section (confidently-wrong / underconfident case lists), and a history table (newest first, ≤30 rows).
+- [ ] `.github/workflows/eval.yaml`: job has `permissions: contents: write`; the publish step runs on `always()` (failed gates publish too), only with the API key present and only on `refs/heads/main`; it pushes to the `eval-scorecard` branch and **never** to `main`; a missing report degrades to a `::warning::`, exit 0.
+- [ ] README shows the nightly-eval badge (shields endpoint → `raw.githubusercontent.com/...eval-scorecard/badge.json`) linking to `scorecard.md` on the `eval-scorecard` branch; CONTRIBUTING and docs/benchmarking.md document the mechanism and the local render command.
+- [ ] No new **required** config: `pricing:` in `eval/ci.runlore.yaml` is optional repo-side config (its absence only omits the dollar figure), user-facing `runlore.yaml` needs nothing new, and the scorecard subcommand needs no config file, model, or API key.
+- [ ] `go build ./... && go test ./... && go vet ./...` all pass.
+- [ ] Post-merge (maintainer): one `workflow_dispatch` of `eval` on `main` creates the `eval-scorecard` branch and the README badge goes live (shows shields "invalid" until that first run — documented, expected).

--- a/dev/superpowers/plans/2026-07-23-m1-loki-backend.md
+++ b/dev/superpowers/plans/2026-07-23-m1-loki-backend.md
@@ -1,0 +1,1604 @@
+# M1 — Loki logs backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Grafana Loki as a second logs backend behind the existing pluggable `providers.LogsProvider` interface (`internal/providers/providers.go:258`), at feature parity with the VictoriaLogs provider where Loki's API allows: `query_logs`, `logs_error_summary`, and `discover_log_fields` all work against Loki (LogQL via `/loki/api/v1/query_range`, `/loki/api/v1/labels`, `/loki/api/v1/detected_fields`). Provider selection follows the metrics flavor pattern (`internal/metrics/prometheus/prometheus.go:96` `DetectFlavor`): a new **optional** `logs.provider` key pins the backend; empty auto-detects at startup by probing `/loki/api/v1/status/buildinfo`, **failing safe to VictoriaLogs** so every existing deployment is untouched. No new required config; unset `logs` stays disabled exactly as today.
+
+**Architecture:**
+- **New package `internal/logs/loki`** — a `loki.Client` mirroring `internal/logs/victorialogs/victorialogs.go` shape-for-shape: same constructor pair (`New` / `NewWithAuth`), same `WithLevelField` option, same `httpx.SecureClient` (`internal/httpx/client.go:27`), same auth-by-env-indirection. It satisfies `providers.LogsProvider` plus the optional `providers.LogStats` (`providers.go:307`) and `providers.LogFields` (`providers.go:288`) capabilities, so all three tools light up without any tool-side special-casing.
+- **New file `internal/logs/detect.go`** (package `logs`) — the one-shot startup probe, mirroring `DetectFlavor`'s "config pin wins; probe is best-effort; fail safe to the shipped default" contract.
+- **Query mediation:** today the model writes raw **LogsQL** or (preferred) structured params that `buildLogsQLWith` (`internal/investigate/query_tools.go:399`) compiles into LogsQL. The same mediation gains a **dialect**: `investigate.LogFields` (`internal/investigate/renderlog.go:19`) grows a `Dialect` field (`""` = LogsQL, unchanged zero value; `"logql"` = Loki). `buildLogsQLWith` dispatches to a new `buildLogQL` that compiles the SAME structured params into valid LogQL, and the raw-query guard flips: instead of rejecting `level=` (the LogsQL guard at `query_tools.go:402`), the LogQL path rejects LogsQL-isms (`unpack_json`, `_msg`) and non-selector-first queries, with correcting errors. Tool `Description()`/`Schema()` become dialect-aware so the model is told LogQL, never LogsQL, on a Loki deployment.
+- **Field convention:** `config.LogFields.Resolved()` (`internal/config/config.go:164`) keeps its VictoriaLogs defaults; a new `ResolvedFor(provider)` resolves Loki-appropriate defaults (`container`/`namespace`/`pod` stream labels, `detected_level` severity, **no** unpack pipe — Loki 3.x auto-detects level as structured metadata). Operators override via the existing `logs.fields` keys — no new required config.
+- **Parity notes (where Loki's API differs):** `Hits` maps to a LogQL metric wrapper `sum by (<level>) (count_over_time(<q> [<step>]))`; `TopMessages` has no LogQL equivalent of `stats by (_msg)` and is aggregated **client-side** over the capped `Query` sample; `FieldNames` merges stream labels (`/loki/api/v1/labels`) with body fields (`/loki/api/v1/detected_fields`, whose count is a value *cardinality*, not a hit count — the discover tool renders the number only when > 0).
+- **Wiring:** the `cfg.Logs.URL != ""` block in `BuildModelAndTools` (`internal/app/investigate.go:140-169`) switches on the resolved provider and passes the dialect-carrying `investigate.LogFields` to all three tools (`LogsErrorSummaryTool` and `DiscoverLogFieldsTool` gain a `Fields` field; zero value keeps today's behaviour).
+
+**Tech Stack:** Go (stdlib `net/http`, `encoding/json`), `internal/httpx` secure client, `httptest` fakes with real Loki JSON fixtures for tests, yaml config via existing strict loader (`internal/config/load.go:16`). No new dependencies.
+
+---
+
+### Task 1: Config — `logs.provider` key, validation, Loki field defaults
+
+**Files:**
+- Modify: `internal/config/config.go` (LogsConfig at :117, LogFields defaults at :149, Validate at :1013)
+- Test: `internal/config/config_test.go`, `internal/config/logfields_test.go`
+
+**Steps:**
+
+- [ ] Write the failing validation test in `internal/config/config_test.go`:
+
+```go
+// TestLogsProviderValidate: logs.provider is an enum — "" (auto-detect),
+// "victorialogs", "loki". Anything else must abort startup loudly (the Load
+// philosophy: a typo'd key never fails silently), because a silent fallback to
+// victorialogs against a Loki endpoint would break every logs tool at runtime.
+func TestLogsProviderValidate(t *testing.T) {
+	for _, ok := range []string{"", "victorialogs", "loki"} {
+		c := &Config{}
+		c.Logs.Provider = ok
+		if err := c.Validate(); err != nil {
+			t.Fatalf("provider %q must validate, got %v", ok, err)
+		}
+	}
+	c := &Config{}
+	c.Logs.Provider = "grafana"
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "logs.provider") {
+		t.Fatalf("unknown provider must fail with a logs.provider error, got %v", err)
+	}
+}
+```
+
+- [ ] Write the failing Loki-defaults test in `internal/config/logfields_test.go`:
+
+```go
+// TestLogFieldsResolvedForLoki: ResolvedFor(loki) fills the promtail/alloy
+// stream-label convention and Loki 3.x's parser-less detected_level severity,
+// and deliberately leaves UnpackPipe empty (no parser stage needed). Any
+// explicitly-set field wins. ResolvedFor(victorialogs) must equal Resolved().
+func TestLogFieldsResolvedForLoki(t *testing.T) {
+	got := LogFields{}.ResolvedFor(LogsProviderLoki)
+	want := LogFields{ContainerField: "container", NamespaceField: "namespace",
+		PodField: "pod", LevelField: "detected_level", UnpackPipe: ""}
+	if got != want {
+		t.Fatalf("loki defaults = %+v, want %+v", got, want)
+	}
+	over := LogFields{LevelField: "level", UnpackPipe: "logfmt"}.ResolvedFor(LogsProviderLoki)
+	if over.LevelField != "level" || over.UnpackPipe != "logfmt" || over.PodField != "pod" {
+		t.Fatalf("overrides must win, defaults fill the rest: %+v", over)
+	}
+	if LogFields{}.ResolvedFor(LogsProviderVictoriaLogs) != (LogFields{}.Resolved()) {
+		t.Fatalf("victorialogs resolution must be unchanged")
+	}
+}
+```
+
+- [ ] Run `go test ./internal/config/ -run 'TestLogsProviderValidate|TestLogFieldsResolvedForLoki' -count=1` — expect **FAIL** (compile error: `Provider`, `LogsProviderLoki`, `ResolvedFor` undefined).
+- [ ] Implement in `internal/config/config.go`. Add the provider constants next to the `MetricsFlavor*` block (:93-96):
+
+```go
+// Logs backend providers for config.logs.provider. Unlike the metrics backends
+// (which share the Prometheus HTTP API and differ only in dialect), VictoriaLogs
+// and Loki have entirely different query APIs, so this selects the CLIENT, not a
+// flavor of one. Empty ⇒ auto-detect at startup (Loki answers
+// /loki/api/v1/status/buildinfo; VictoriaLogs does not), failing safe to
+// victorialogs — the provider RunLore shipped with — so an unreachable backend
+// at startup reproduces today's behaviour exactly.
+const (
+	LogsProviderVictoriaLogs = "victorialogs" // LogsQL over /select/logsql/* (shipped default)
+	LogsProviderLoki         = "loki"         // LogQL over /loki/api/v1/*
+)
+```
+
+- [ ] Add the `Provider` key to `LogsConfig` (:117):
+
+```go
+type LogsConfig struct {
+	Endpoint `yaml:",inline"`
+
+	// Provider optionally pins the logs backend implementation instead of
+	// auto-detecting it: "loki" or "victorialogs" (see LogsProvider*). Empty ⇒
+	// probe once at startup, failing safe to victorialogs.
+	Provider string `yaml:"provider"`
+
+	Fields LogFields `yaml:"fields"`
+}
+```
+
+- [ ] Add the Loki default constants next to the VictoriaLogs ones (:149-155) and `ResolvedFor` next to `Resolved()` (:164):
+
+```go
+// Default log-field convention for Loki: the promtail/Grafana-Alloy stream-label
+// layout plus Loki 3.x's auto-detected severity (detected_level is structured
+// metadata, filterable WITHOUT a parser stage — hence no default unpack pipe).
+// An operator on Loki 2.x (no detected_level) overrides logs.fields, e.g.
+// {level_field: level, unpack_pipe: logfmt}.
+const (
+	defaultLokiContainerField = "container"
+	defaultLokiNamespaceField = "namespace"
+	defaultLokiPodField       = "pod"
+	defaultLokiLevelField     = "detected_level"
+)
+
+// ResolvedFor resolves the field convention for a specific logs provider:
+// Loki gets Loki-appropriate defaults; anything else (victorialogs, "") keeps
+// Resolved()'s shipped VictoriaLogs behaviour. Explicitly-set fields always win.
+func (f LogFields) ResolvedFor(provider string) LogFields {
+	if provider != LogsProviderLoki {
+		return f.Resolved()
+	}
+	if f.ContainerField == "" {
+		f.ContainerField = defaultLokiContainerField
+	}
+	if f.NamespaceField == "" {
+		f.NamespaceField = defaultLokiNamespaceField
+	}
+	if f.PodField == "" {
+		f.PodField = defaultLokiPodField
+	}
+	if f.LevelField == "" {
+		f.LevelField = defaultLokiLevelField
+	}
+	// UnpackPipe stays as-set (empty = no parser stage): detected_level needs none.
+	return f
+}
+```
+
+- [ ] Add the enum check inside `Config.Validate()` (:1013, before the final `return nil`):
+
+```go
+	// logs.provider is a small enum; reject typos at startup rather than silently
+	// falling back to the wrong client against a live backend.
+	switch c.Logs.Provider {
+	case "", LogsProviderVictoriaLogs, LogsProviderLoki:
+	default:
+		return fmt.Errorf("logs.provider must be %q, %q, or empty (auto-detect); got %q",
+			LogsProviderVictoriaLogs, LogsProviderLoki, c.Logs.Provider)
+	}
+```
+
+- [ ] Run `go test ./internal/config/ -count=1` — expect **PASS** (including the existing `shipped_configs_test.go` / `minimal_values_test.go`, which prove no new key is required).
+- [ ] Commit: `feat(config): add logs.provider key with validation and Loki field defaults`
+
+---
+
+### Task 2: Loki client — `Query` over `/loki/api/v1/query_range`
+
+**Files:**
+- Create: `internal/logs/loki/loki.go`
+- Test: `internal/logs/loki/loki_test.go`
+
+**Steps:**
+
+- [ ] Create `internal/logs/loki/loki_test.go` with the failing core tests (style mirrors `internal/logs/victorialogs/victorialogs_test.go`):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package loki
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestQuery(t *testing.T) {
+	var gotPath, gotQuery, gotLimit, gotDirection string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("query")
+		gotLimit = r.URL.Query().Get("limit")
+		gotDirection = r.URL.Query().Get("direction")
+		_, _ = io.WriteString(w, `{
+		  "status": "success",
+		  "data": {
+		    "resultType": "streams",
+		    "result": [
+		      {
+		        "stream": {"namespace": "apps", "pod": "harbor-db-0", "container": "db", "detected_level": "error"},
+		        "values": [
+		          ["1750413601000000000", "retrying"],
+		          ["1750413600000000000", "db connection refused"]
+		        ]
+		      }
+		    ]
+		  }
+		}`)
+	}))
+	defer srv.Close()
+
+	res, err := New(srv.URL).Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotPath != "/loki/api/v1/query_range" {
+		t.Fatalf("path=%q", gotPath)
+	}
+	if gotQuery != `{namespace="apps"}` {
+		t.Fatalf("query=%q", gotQuery)
+	}
+	if gotLimit != "1000" || gotDirection != "backward" {
+		t.Fatalf("limit=%q direction=%q, want 1000/backward", gotLimit, gotDirection)
+	}
+	if len(res) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(res))
+	}
+	// Newest first, matching the VictoriaLogs provider's ordering contract.
+	if res[0].Message != "retrying" || res[1].Message != "db connection refused" {
+		t.Fatalf("order/messages wrong: %+v", res)
+	}
+	// Nanosecond epoch parsed; stream labels become LogLine.Fields (so the
+	// renderer's streamIdentity finds pod/container under the Loki names).
+	if res[1].Time.UTC().Format("2006-01-02T15:04:05Z") != "2026-06-20T10:00:00Z" {
+		t.Fatalf("time not parsed from ns epoch: %v", res[1].Time)
+	}
+	if res[0].Fields["pod"] != "harbor-db-0" || res[0].Fields["container"] != "db" {
+		t.Fatalf("stream labels not mapped to fields: %+v", res[0].Fields)
+	}
+}
+
+func TestQueryAuthHeaders(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_LOKI_TOKEN", "s3cr3t")
+	var gotAuth, gotTenant string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotTenant = r.Header.Get("X-Scope-OrgID")
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[]}}`)
+	}))
+	defer srv.Close()
+
+	c := NewWithAuth(srv.URL, "RUNLORE_TEST_LOKI_TOKEN", map[string]string{"X-Scope-OrgID": "tenant-b"})
+	if _, err := c.Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "Bearer s3cr3t" || gotTenant != "tenant-b" {
+		t.Fatalf("auth not applied: auth=%q tenant=%q", gotAuth, gotTenant)
+	}
+}
+
+// TestQueryTruncation: Loki has no offset pagination; the client sends
+// limit=maxLines once and appends the shared TruncationLine sentinel when the
+// server returned exactly the limit (more likely matched upstream).
+func TestQueryTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
+		  {"stream":{"namespace":"apps"},"values":[
+		    ["1750413602000000000","a"],["1750413601000000000","b"],["1750413600000000000","c"]]}]}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	c.maxLines = 3
+	res, err := c.Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res) != 4 || !strings.Contains(res[3].Message, "results truncated at 3") {
+		t.Fatalf("want 3 lines + sentinel, got %d: %+v", len(res), res)
+	}
+}
+
+// TestQueryErrorPaths: backend down, non-200, JSON error status, and malformed
+// body must each surface as an error (never a silent empty result), so the tool
+// call fails visibly and the loop records a data gap instead of "no logs".
+func TestQueryErrorPaths(t *testing.T) {
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close() // connection refused
+	if _, err := New(down.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil {
+		t.Fatalf("backend down must error")
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "too many outstanding requests", http.StatusTooManyRequests)
+	}))
+	defer bad.Close()
+	if _, err := New(bad.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil ||
+		!strings.Contains(err.Error(), "429") {
+		t.Fatalf("non-200 must error with the status, got %v", err)
+	}
+
+	malformed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":`)
+	}))
+	defer malformed.Close()
+	if _, err := New(malformed.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil {
+		t.Fatalf("malformed body must error")
+	}
+
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[]}}`)
+	}))
+	defer empty.Close()
+	res, err := New(empty.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{})
+	if err != nil || len(res) != 0 {
+		t.Fatalf("empty result must be (nil, nil), got %v / %v", res, err)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/logs/loki/ -count=1` — expect **FAIL** (package does not exist).
+- [ ] Create `internal/logs/loki/loki.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Package loki implements providers.LogsProvider against Grafana Loki, querying
+// with LogQL over /loki/api/v1/* and normalizing the streams response into log
+// lines. It mirrors internal/logs/victorialogs: same construction/auth shape,
+// same optional LogStats/LogFields capabilities, same truncation sentinel.
+package loki
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Client queries a Grafana Loki backend.
+type Client struct {
+	baseURL    string
+	tokenEnv   string            // env var holding a bearer token; empty ⇒ no auth
+	headers    map[string]string // static extra request headers (e.g. X-Scope-OrgID)
+	maxLines   int               // per-query line cap (Loki `limit` param)
+	levelField string            // severity label Hits splits by; "" ⇒ defaultLevelField
+	http       *http.Client
+}
+
+// defaultMaxLines bounds the number of lines Query returns. Loki has no offset
+// pagination (a timestamp-cursor walk is deferred), so this is sent as the
+// server-side `limit` and doubles as the truncation-sentinel threshold.
+const defaultMaxLines = 1000
+
+// defaultLevelField is the severity label Hits groups by: Loki 3.x attaches
+// detected_level as structured metadata to every entry (no parser stage
+// needed). Overridable via WithLevelField (config.logs.fields.level_field) for
+// Loki 2.x or a collector with its own level label.
+const defaultLevelField = "detected_level"
+
+// New builds a client for a Loki base URL, unauthenticated.
+func New(baseURL string) *Client {
+	return NewWithAuth(baseURL, "", nil)
+}
+
+// NewWithAuth builds a client that adds optional auth to every request; the
+// semantics are identical to victorialogs.NewWithAuth (token read from the env
+// at request-build time, never logged).
+func NewWithAuth(baseURL, tokenEnv string, headers map[string]string) *Client {
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		tokenEnv:   tokenEnv,
+		headers:    headers,
+		maxLines:   defaultMaxLines,
+		levelField: defaultLevelField,
+		http:       httpx.SecureClient(30 * time.Second),
+	}
+}
+
+// WithLevelField overrides the severity label Hits splits by. Empty is a no-op
+// so an unset config keeps the default; returns the client for chaining.
+func (c *Client) WithLevelField(field string) *Client {
+	if field != "" {
+		c.levelField = field
+	}
+	return c
+}
+
+var (
+	_ providers.LogsProvider = (*Client)(nil)
+	_ providers.LogStats     = (*Client)(nil)
+	_ providers.LogFields    = (*Client)(nil)
+)
+
+// queryResponse is Loki's standard success envelope for /loki/api/v1/query_range.
+type queryResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string          `json:"resultType"`
+		Result     json.RawMessage `json:"result"`
+	} `json:"data"`
+}
+
+// streamResult is one log stream: its label set plus [ns-epoch, line] entries.
+type streamResult struct {
+	Stream map[string]string `json:"stream"`
+	Values [][2]string       `json:"values"`
+}
+
+// Query runs a LogQL query over the window and returns normalized log lines,
+// newest first (matching the VictoriaLogs provider's ordering). It sends one
+// request with limit=maxLines and direction=backward; when the server returns
+// exactly the limit, more entries likely matched and the shared truncation
+// sentinel is appended (providers.TruncationLine).
+func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow) (providers.LogResult, error) {
+	v := url.Values{
+		"query":     {query},
+		"limit":     {strconv.Itoa(c.maxLines)},
+		"direction": {"backward"},
+	}
+	setWindow(v, w)
+	body, err := c.get(ctx, "/loki/api/v1/query_range", v)
+	if err != nil {
+		return nil, err
+	}
+	var resp queryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse loki response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("loki error: status %q", resp.Status)
+	}
+	if resp.Data.ResultType != "streams" {
+		return nil, fmt.Errorf("unexpected loki resultType %q (Query expects a log selector, not a metric query)", resp.Data.ResultType)
+	}
+	var streams []streamResult
+	if err := json.Unmarshal(resp.Data.Result, &streams); err != nil {
+		return nil, fmt.Errorf("parse loki streams: %w", err)
+	}
+	var out providers.LogResult
+	for _, s := range streams {
+		for _, e := range s.Values {
+			ll := providers.LogLine{Message: e[1], Fields: make(map[string]string, len(s.Stream))}
+			if ns, err := strconv.ParseInt(e[0], 10, 64); err == nil {
+				ll.Time = time.Unix(0, ns).UTC()
+			}
+			for k, val := range s.Stream {
+				ll.Fields[k] = val
+			}
+			out = append(out, ll)
+		}
+	}
+	// Entries arrive grouped per stream; order newest-first ACROSS streams so the
+	// renderer and the VictoriaLogs provider agree on what "first lines" means.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Time.After(out[j].Time) })
+	if len(out) >= c.maxLines {
+		out = out[:c.maxLines]
+		out = append(out, providers.TruncationLine(int64(c.maxLines)))
+	}
+	return out, nil
+}
+
+// setWindow adds the optional RFC3339 start/end bounds (Loki accepts RFC3339
+// alongside ns epochs; RFC3339 matches the VictoriaLogs client for symmetry).
+func setWindow(v url.Values, w providers.TimeWindow) {
+	if !w.Start.IsZero() {
+		v.Set("start", w.Start.UTC().Format(time.RFC3339))
+	}
+	if !w.End.IsZero() {
+		v.Set("end", w.End.UTC().Format(time.RFC3339))
+	}
+}
+
+// get performs an authenticated GET against a Loki endpoint and returns the raw
+// body; any non-200 becomes an error carrying the status and body (mirrors
+// victorialogs.postForm error shape, so tool-visible errors read the same).
+func (c *Client) get(ctx context.Context, path string, v url.Values) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path+"?"+v.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("logs query: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+// setAuth applies the optional bearer token and static headers (identical
+// semantics to the VictoriaLogs client: token read here, never logged).
+func (c *Client) setAuth(req *http.Request) {
+	if c.tokenEnv != "" {
+		if tok := os.Getenv(c.tokenEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+}
+
+// reNumToken / collapseNums mirror internal/investigate/renderlog.go:83-92 (and
+// VictoriaLogs' collapse_nums pipe): free-standing digit runs collapse to "0" so
+// lines differing only by a numeric value share one grouping key. Duplicated
+// here (3 lines) rather than exported from investigate, which must not become a
+// dependency of a backend client.
+var reNumToken = regexp.MustCompile(`\d+`)
+
+func collapseNums(msg string) string { return reNumToken.ReplaceAllString(msg, "0") }
+```
+
+- [ ] Run `go test ./internal/logs/loki/ -count=1` — expect **PASS** (`collapseNums` is unused until Task 3; if `go vet`/lint flags it, move the two `collapseNums` lines into Task 3 instead — do NOT suppress).
+- [ ] Run `go build ./...` — expect clean.
+- [ ] Commit: `feat(logs): add Loki client — LogQL query_range with normalization, cap sentinel, auth`
+
+---
+
+### Task 3: Loki analytics — `Hits` + `TopMessages` (providers.LogStats)
+
+**Files:**
+- Modify: `internal/logs/loki/loki.go`
+- Test: `internal/logs/loki/loki_test.go`
+
+**Steps:**
+
+- [ ] Add the failing tests:
+
+```go
+func TestHits(t *testing.T) {
+	var gotQuery, gotStep string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("query")
+		gotStep = r.URL.Query().Get("step")
+		_, _ = io.WriteString(w, `{
+		  "status": "success",
+		  "data": {
+		    "resultType": "matrix",
+		    "result": [
+		      {"metric": {"detected_level": "error"}, "values": [[1704103200, "3"], [1704103500, "412"]]},
+		      {"metric": {"detected_level": "warn"},  "values": [[1704103200, "1"]]}
+		    ]
+		  }
+		}`)
+	}))
+	defer srv.Close()
+
+	buckets, err := New(srv.URL).Hits(context.Background(), `{namespace="apps"} | detected_level="error"`,
+		providers.TimeWindow{}, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("Hits: %v", err)
+	}
+	// The log query must be wrapped in the LogQL metric form, split by the level label.
+	want := `sum by (detected_level) (count_over_time({namespace="apps"} | detected_level="error" [300s]))`
+	if gotQuery != want {
+		t.Fatalf("metric query = %q, want %q", gotQuery, want)
+	}
+	if gotStep != "300s" {
+		t.Fatalf("step=%q, want 300s", gotStep)
+	}
+	if len(buckets) != 3 {
+		t.Fatalf("want 3 buckets, got %d: %+v", len(buckets), buckets)
+	}
+	var sawSpike bool
+	for _, b := range buckets {
+		if b.Level == "error" && b.Count == 412 && !b.Time.IsZero() {
+			sawSpike = true
+		}
+	}
+	if !sawSpike {
+		t.Fatalf("missing error=412 bucket: %+v", buckets)
+	}
+}
+
+// TestTopMessages: LogQL has no `stats by (message)`, so dominant messages are
+// aggregated CLIENT-SIDE over the capped Query sample, with numeric tokens
+// collapsed (mirroring VictoriaLogs' collapse_nums) so "took 12ms"/"took 907ms"
+// fold into one message. Counts are per-sample, not corpus-wide.
+func TestTopMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
+		  {"stream":{"namespace":"apps"},"values":[
+		    ["1750413603000000000","connection refused to 10.0.0.7"],
+		    ["1750413602000000000","connection refused to 10.0.0.9"],
+		    ["1750413601000000000","connection refused to 10.0.0.9"],
+		    ["1750413600000000000","timeout waiting for db"]]}]}}`)
+	}))
+	defer srv.Close()
+
+	msgs, err := New(srv.URL).TopMessages(context.Background(), `{namespace="apps"}`, providers.TimeWindow{}, 10)
+	if err != nil {
+		t.Fatalf("TopMessages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("want 2 grouped messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Count != 3 || !strings.Contains(msgs[0].Message, "connection refused") {
+		t.Fatalf("dominant message wrong: %+v", msgs[0])
+	}
+	if !msgs[0].First.Before(msgs[0].Last) {
+		t.Fatalf("first→last span not tracked: %+v", msgs[0])
+	}
+	if msgs[1].Message != "timeout waiting for db" || msgs[1].Count != 1 {
+		t.Fatalf("second message wrong: %+v", msgs[1])
+	}
+}
+
+func TestHitsErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "parse error: unexpected token", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL).Hits(context.Background(), `{a="b"}`, providers.TimeWindow{}, time.Minute); err == nil ||
+		!strings.Contains(err.Error(), "400") {
+		t.Fatalf("bad request must error with status, got %v", err)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/logs/loki/ -run 'TestHits|TestTopMessages' -count=1` — expect **FAIL** (`Hits`/`TopMessages` undefined; add `"time"` to test imports).
+- [ ] Implement in `internal/logs/loki/loki.go`:
+
+```go
+// matrixSeries is one series of a Loki metric-query (matrix) result.
+type matrixSeries struct {
+	Metric map[string]string `json:"metric"`
+	Values [][2]any          `json:"values"` // [unix seconds (float64), "count" (string)]
+}
+
+// Hits returns the per-step match count over the window, split by severity, by
+// wrapping the log query in the LogQL metric form
+// `sum by (<level>) (count_over_time(<q> [<step>]))` — the Loki analogue of
+// VictoriaLogs' /select/logsql/hits, powering the logs_error_summary histogram.
+// The level label defaults to detected_level (Loki 3.x structured metadata);
+// series without the label fold into one Level=="" bucket series, which the
+// renderer already handles. A step <= 0 defaults to one minute.
+func (c *Client) Hits(ctx context.Context, query string, w providers.TimeWindow, step time.Duration) ([]providers.Bucket, error) {
+	if step <= 0 {
+		step = time.Minute
+	}
+	stepStr := fmt.Sprintf("%ds", int(step.Seconds()))
+	metricQ := fmt.Sprintf("sum by (%s) (count_over_time(%s [%s]))", c.levelField, query, stepStr)
+	v := url.Values{"query": {metricQ}, "step": {stepStr}}
+	setWindow(v, w)
+	body, err := c.get(ctx, "/loki/api/v1/query_range", v)
+	if err != nil {
+		return nil, err
+	}
+	var resp queryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse loki response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("loki error: status %q", resp.Status)
+	}
+	var series []matrixSeries
+	if err := json.Unmarshal(resp.Data.Result, &series); err != nil {
+		return nil, fmt.Errorf("parse loki matrix: %w", err)
+	}
+	var out []providers.Bucket
+	for _, s := range series {
+		level := s.Metric[c.levelField]
+		for _, p := range s.Values {
+			ts, n := parsePoint(p)
+			out = append(out, providers.Bucket{Time: ts, Level: level, Count: n})
+		}
+	}
+	return out, nil
+}
+
+// parsePoint parses a Loki/Prometheus [unixSeconds, "value"] matrix point
+// (same wire shape as internal/metrics/prometheus/prometheus.go:322 parsePoint,
+// narrowed to the int64 count Hits needs).
+func parsePoint(p [2]any) (time.Time, int64) {
+	var ts time.Time
+	if f, ok := p[0].(float64); ok {
+		ts = time.Unix(int64(f), 0).UTC()
+	}
+	var n int64
+	if s, ok := p[1].(string); ok {
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			n = int64(f)
+		}
+	}
+	return ts, n
+}
+
+// TopMessages returns up to k dominant messages over the window. LogQL cannot
+// group by message content (no `stats by (_msg)` equivalent; the /patterns
+// endpoint is experimental and needs the pattern ingester), so this aggregates
+// CLIENT-SIDE over the capped Query sample: numeric tokens collapse so
+// near-identical lines group (mirroring collapse_nums), counts/first/last are
+// per-sample (up to maxLines newest lines), which is enough to NAME what floods
+// the logs — the only question logs_error_summary asks of it. k <= 0 defaults
+// to 10.
+func (c *Client) TopMessages(ctx context.Context, query string, w providers.TimeWindow, k int) ([]providers.MsgCount, error) {
+	if k <= 0 {
+		k = 10
+	}
+	lines, err := c.Query(ctx, query, w)
+	if err != nil {
+		return nil, err
+	}
+	type agg struct {
+		msg         string
+		count       int64
+		first, last time.Time
+	}
+	byKey := map[string]int{}
+	var groups []agg
+	for _, l := range lines {
+		if l.Time.IsZero() && len(l.Fields) == 0 {
+			continue // the truncation sentinel is not a log message
+		}
+		key := collapseNums(l.Message)
+		i, ok := byKey[key]
+		if !ok {
+			byKey[key] = len(groups)
+			groups = append(groups, agg{msg: l.Message, count: 1, first: l.Time, last: l.Time})
+			continue
+		}
+		g := &groups[i]
+		g.count++
+		if !l.Time.IsZero() && (g.first.IsZero() || l.Time.Before(g.first)) {
+			g.first = l.Time
+		}
+		if !l.Time.IsZero() && l.Time.After(g.last) {
+			g.last = l.Time
+		}
+	}
+	sort.SliceStable(groups, func(i, j int) bool { return groups[i].count > groups[j].count })
+	if len(groups) > k {
+		groups = groups[:k]
+	}
+	out := make([]providers.MsgCount, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, providers.MsgCount{Message: g.msg, Count: g.count, First: g.first, Last: g.last})
+	}
+	return out, nil
+}
+```
+
+- [ ] Run `go test ./internal/logs/loki/ -count=1` — expect **PASS**.
+- [ ] Commit: `feat(logs): Loki analytics — level-split hits histogram and client-side top messages`
+
+---
+
+### Task 4: Loki field discovery — `FieldNames` (providers.LogFields)
+
+**Files:**
+- Modify: `internal/logs/loki/loki.go`
+- Test: `internal/logs/loki/loki_test.go`
+
+**Steps:**
+
+- [ ] Add the failing tests:
+
+```go
+// TestFieldNames: discovery merges STREAM labels (/loki/api/v1/labels — the
+// selector building blocks the model needs first) with detected body fields
+// (/loki/api/v1/detected_fields, Loki 3.x). Hits carries the detected field's
+// value CARDINALITY (Loki reports no per-field hit count); stream labels carry 0
+// and the discover tool renders the number only when > 0.
+func TestFieldNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/loki/api/v1/labels":
+			if q := r.URL.Query().Get("query"); q != `{namespace="apps"}` {
+				t.Errorf("labels query=%q", q)
+			}
+			_, _ = io.WriteString(w, `{"status":"success","data":["namespace","pod","container"]}`)
+		case "/loki/api/v1/detected_fields":
+			_, _ = io.WriteString(w, `{"fields":[
+			  {"label":"level","type":"string","cardinality":4,"parsers":["logfmt"]},
+			  {"label":"duration","type":"duration","cardinality":99,"parsers":["logfmt"]}]}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	fields, err := New(srv.URL).FieldNames(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("FieldNames: %v", err)
+	}
+	if len(fields) != 5 {
+		t.Fatalf("want 3 labels + 2 detected fields, got %d: %+v", len(fields), fields)
+	}
+	if fields[0].Name != "namespace" || fields[0].Hits != 0 {
+		t.Fatalf("stream labels must come first with Hits=0: %+v", fields[0])
+	}
+	if fields[3].Name != "level" || fields[3].Hits != 4 {
+		t.Fatalf("detected field must carry cardinality as Hits: %+v", fields[3])
+	}
+}
+
+// TestFieldNamesOldLoki: a Loki without detected_fields (pre-3.0 returns 404)
+// still answers discovery with the stream labels alone — degrade, don't fail.
+func TestFieldNamesOldLoki(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/labels" {
+			_, _ = io.WriteString(w, `{"status":"success","data":["namespace","pod"]}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	fields, err := New(srv.URL).FieldNames(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("FieldNames must degrade to labels-only, got %v", err)
+	}
+	if len(fields) != 2 || fields[0].Name != "namespace" {
+		t.Fatalf("labels-only result wrong: %+v", fields)
+	}
+}
+
+// TestFieldNamesBothDown: when neither endpoint answers, the error must surface.
+func TestFieldNamesBothDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL).FieldNames(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil {
+		t.Fatalf("both endpoints failing must error")
+	}
+}
+```
+
+- [ ] Run `go test ./internal/logs/loki/ -run TestFieldNames -count=1` — expect **FAIL**.
+- [ ] Implement in `internal/logs/loki/loki.go`:
+
+```go
+// FieldNames lists the field names present in the logs matching query over the
+// window — the log-schema discovery path (providers.LogFields). Loki splits the
+// answer across two endpoints, so both are merged: STREAM labels from
+// /loki/api/v1/labels (query-scoped; these are what a selector is built from,
+// so they come first, Hits=0 — Loki reports no per-label hit count) and parsed
+// body fields from /loki/api/v1/detected_fields (Loki 3.x; Hits carries the
+// reported value cardinality). A missing detected_fields endpoint (older Loki)
+// degrades to labels-only; only both failing is an error.
+func (c *Client) FieldNames(ctx context.Context, query string, w providers.TimeWindow) ([]providers.FieldCount, error) {
+	var out []providers.FieldCount
+
+	lv := url.Values{"query": {query}}
+	setWindow(lv, w)
+	labelsBody, labelsErr := c.get(ctx, "/loki/api/v1/labels", lv)
+	if labelsErr == nil {
+		var resp struct {
+			Status string   `json:"status"`
+			Data   []string `json:"data"`
+		}
+		if err := json.Unmarshal(labelsBody, &resp); err != nil {
+			return nil, fmt.Errorf("parse loki labels: %w", err)
+		}
+		for _, name := range resp.Data {
+			out = append(out, providers.FieldCount{Name: name})
+		}
+	}
+
+	dv := url.Values{"query": {query}}
+	setWindow(dv, w)
+	dfBody, dfErr := c.get(ctx, "/loki/api/v1/detected_fields", dv)
+	if dfErr != nil {
+		if labelsErr == nil {
+			return out, nil // older Loki: stream labels alone still answer discovery
+		}
+		return nil, dfErr
+	}
+	var resp struct {
+		Fields []struct {
+			Label       string `json:"label"`
+			Cardinality int64  `json:"cardinality"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(dfBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse loki detected_fields: %w", err)
+	}
+	for _, f := range resp.Fields {
+		out = append(out, providers.FieldCount{Name: f.Label, Hits: f.Cardinality})
+	}
+	return out, nil
+}
+```
+
+- [ ] Run `go test ./internal/logs/loki/ -count=1` — expect **PASS**.
+- [ ] Commit: `feat(logs): Loki field discovery via labels and detected_fields`
+
+---
+
+### Task 5: Provider auto-detect — `internal/logs/detect.go`
+
+**Files:**
+- Create: `internal/logs/detect.go`
+- Test: `internal/logs/detect_test.go`
+
+**Steps:**
+
+- [ ] Create `internal/logs/detect_test.go` with the failing test:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDetect mirrors the metrics flavor probe's contract
+// (internal/metrics/prometheus DetectFlavor): best-effort, one shot, FAIL SAFE
+// to the shipped default. Only a 200 buildinfo JSON with a version identifies
+// Loki; a 404 (VictoriaLogs), an unreachable backend, or a 200 that is not
+// buildinfo JSON (a proxy's HTML error page) all resolve to victorialogs.
+func TestDetect(t *testing.T) {
+	lokiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/loki/api/v1/status/buildinfo" {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"version":"3.1.0","revision":"935aee77ed","branch":"HEAD","goVersion":"go1.22"}`)
+	}))
+	defer lokiSrv.Close()
+	if got := Detect(context.Background(), lokiSrv.URL, "", nil); got != ProviderLoki {
+		t.Fatalf("buildinfo 200 must detect loki, got %q", got)
+	}
+
+	vlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r) // VictoriaLogs serves no /loki/api/v1/status/buildinfo
+	}))
+	defer vlSrv.Close()
+	if got := Detect(context.Background(), vlSrv.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("404 must fail safe to victorialogs, got %q", got)
+	}
+
+	htmlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `<html>welcome</html>`) // 200 but not buildinfo
+	}))
+	defer htmlSrv.Close()
+	if got := Detect(context.Background(), htmlSrv.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("non-JSON 200 must fail safe to victorialogs, got %q", got)
+	}
+
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close()
+	if got := Detect(context.Background(), down.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("unreachable must fail safe to victorialogs, got %q", got)
+	}
+}
+
+// TestDetectSendsAuth: a Loki behind auth must still be detectable.
+func TestDetectSendsAuth(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_DETECT_TOKEN", "s3cr3t")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"version":"3.1.0"}`)
+	}))
+	defer srv.Close()
+	if got := Detect(context.Background(), srv.URL, "RUNLORE_TEST_DETECT_TOKEN", map[string]string{"X-Scope-OrgID": "t"}); got != ProviderLoki {
+		t.Fatalf("got %q", got)
+	}
+	if gotAuth != "Bearer s3cr3t" {
+		t.Fatalf("probe must carry auth, got %q", gotAuth)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/logs/ -count=1` — expect **FAIL** (no package).
+- [ ] Create `internal/logs/detect.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Package logs hosts the backend-agnostic pieces of the logs data source; the
+// concrete clients live in the victorialogs and loki sub-packages.
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+)
+
+// Provider identifiers returned by Detect. They deliberately equal the
+// config.LogsProvider* string values (internal/config/config.go) — kept as
+// plain strings here so the probe does not depend on the config package.
+const (
+	ProviderVictoriaLogs = "victorialogs"
+	ProviderLoki         = "loki"
+)
+
+// Detect probes the logs backend once at startup to distinguish Grafana Loki
+// from VictoriaLogs, mirroring the metrics flavor probe
+// (internal/metrics/prometheus/prometheus.go DetectFlavor): a config pin
+// bypasses it (the caller checks logs.provider first), the probe is
+// best-effort, and ANY failure — unreachable backend, non-200, non-buildinfo
+// payload — FAILS SAFE to VictoriaLogs, the provider RunLore shipped with, so
+// existing deployments see no behaviour change. Loki is identified by a 200
+// JSON response with a version on /loki/api/v1/status/buildinfo, an endpoint
+// VictoriaLogs does not serve. The probe carries the same auth the real client
+// will use (a Loki behind auth must still be detectable); the token is read
+// from the environment here and never logged.
+func Detect(ctx context.Context, baseURL, tokenEnv string, headers map[string]string) string {
+	base := strings.TrimRight(baseURL, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/loki/api/v1/status/buildinfo", nil)
+	if err != nil {
+		return ProviderVictoriaLogs
+	}
+	if tokenEnv != "" {
+		if tok := os.Getenv(tokenEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := httpx.SecureClient(10 * time.Second).Do(req)
+	if err != nil {
+		return ProviderVictoriaLogs
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ProviderVictoriaLogs
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var bi struct {
+		Version string `json:"version"`
+	}
+	if json.Unmarshal(body, &bi) != nil || bi.Version == "" {
+		return ProviderVictoriaLogs // a 200 that is not buildinfo (proxy page) is not Loki
+	}
+	return ProviderLoki
+}
+```
+
+- [ ] Run `go test ./internal/logs/ -count=1` — expect **PASS**.
+- [ ] Commit: `feat(logs): auto-detect loki vs victorialogs at startup, failing safe to victorialogs`
+
+---
+
+### Task 6: Investigate — LogQL dialect for the three log tools
+
+**Files:**
+- Modify: `internal/investigate/renderlog.go` (LogFields at :19, resolved at :41)
+- Modify: `internal/investigate/query_tools.go` (buildLogsQL :389, buildLogsQLWith :399, QueryLogsTool Description/Schema :428-446)
+- Modify: `internal/investigate/logs_summary_tool.go` (struct :28, Schema :45, Call :72)
+- Modify: `internal/investigate/discover_tools.go` (struct :97, Schema :113, Call :133, render :157-160)
+- Test: `internal/investigate/query_tools_test.go`, `internal/investigate/discover_tools_test.go`, `internal/investigate/loki_e2e_test.go` (new)
+
+**Steps:**
+
+- [ ] Add the failing query-builder tests to `internal/investigate/query_tools_test.go`:
+
+```go
+// TestBuildLogQL: with Dialect=logql the same structured params compile to
+// valid LogQL, raw queries must start with a stream selector, and LogsQL-isms
+// are rejected with a correcting error so the model retries in-dialect.
+func TestBuildLogQL(t *testing.T) {
+	logql := LogFields{Dialect: DialectLogQL}
+	tests := []struct {
+		name, raw, container, namespace, level string
+		conv                                   LogFields
+		want                                   string
+		wantErr                                string
+	}{
+		{name: "structured selector + level", container: "harbor-core", namespace: "apps", level: "error", conv: logql,
+			want: `{container="harbor-core",namespace="apps"} | detected_level="error"`},
+		{name: "namespace only, no level", namespace: "apps", conv: logql,
+			want: `{namespace="apps"}`},
+		{name: "custom fields add parser pipe", container: "core", level: "error",
+			conv: LogFields{Dialect: DialectLogQL, LevelField: "level", UnpackPipe: "logfmt"},
+			want: `{container="core"} | logfmt | level="error"`},
+		{name: "raw passthrough", raw: `{namespace="apps"} |= "refused"`, conv: logql,
+			want: `{namespace="apps"} |= "refused"`},
+		{name: "raw LogsQL-ism rejected", raw: `{namespace="apps"} | unpack_json | log.level:error`, conv: logql,
+			wantErr: "LogsQL"},
+		{name: "raw without selector rejected", raw: `error`, conv: logql,
+			wantErr: "stream selector"},
+		{name: "nothing given", conv: logql, wantErr: "provide a raw"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildLogsQLWith(tc.raw, tc.container, tc.namespace, tc.level, tc.conv)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildLogsQLWith: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogToolDescriptionsDialect: on a Loki deployment the model must be told
+// LogQL — never LogsQL — in every tool description and schema, and vice versa.
+func TestLogToolDescriptionsDialect(t *testing.T) {
+	logql := LogFields{Dialect: DialectLogQL}
+	q := QueryLogsTool{Fields: logql}
+	if !strings.Contains(q.Description(), "LogQL (Grafana Loki)") || strings.Contains(q.Description(), "invalid LogsQL") {
+		t.Fatalf("LogQL description wrong: %s", q.Description())
+	}
+	if !strings.Contains(q.Schema(), "raw LogQL") {
+		t.Fatalf("LogQL schema wrong: %s", q.Schema())
+	}
+	if !strings.Contains(QueryLogsTool{}.Description(), "LogsQL (VictoriaLogs)") {
+		t.Fatalf("default description must stay LogsQL")
+	}
+	for _, tool := range []interface {
+		Description() string
+		Schema() string
+	}{LogsErrorSummaryTool{Fields: logql}, DiscoverLogFieldsTool{Fields: logql}} {
+		if strings.Contains(tool.Schema(), "LogsQL") {
+			t.Fatalf("loki-dialect schema must not mention LogsQL: %s", tool.Schema())
+		}
+	}
+}
+```
+
+- [ ] Add the failing render test to `internal/investigate/discover_tools_test.go` (a fake returning a `FieldCount` with `Hits: 0` must render without `(×0)` — Loki stream labels carry no count):
+
+```go
+// TestDiscoverLogFieldsOmitsZeroCounts: Loki stream labels carry Hits=0 (no
+// per-label hit count exists); the render must omit the count rather than
+// print a misleading "(×0)".
+func TestDiscoverLogFieldsOmitsZeroCounts(t *testing.T) {
+	tool := DiscoverLogFieldsTool{Logs: fakeLogFields{fields: []providers.FieldCount{
+		{Name: "namespace"}, {Name: "level", Hits: 4},
+	}}}
+	out, err := tool.Call(context.Background(), `{"namespace":"apps"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if strings.Contains(out, "(×0)") {
+		t.Fatalf("zero hits must render without a count:\n%s", out)
+	}
+	if !strings.Contains(out, "level (×4)") {
+		t.Fatalf("non-zero hits must keep the count:\n%s", out)
+	}
+}
+```
+
+(Adapt the `fakeLogFields` fake at `internal/investigate/discover_tools_test.go:115` to accept a `fields []providers.FieldCount` member if it doesn't already.)
+
+- [ ] Run `go test ./internal/investigate/ -run 'TestBuildLogQL|TestLogToolDescriptionsDialect|TestDiscoverLogFieldsOmitsZeroCounts' -count=1` — expect **FAIL** (`DialectLogQL` undefined, etc.).
+- [ ] Implement the dialect in `internal/investigate/renderlog.go` — extend `LogFields` (:19) and `resolved()` (:41):
+
+```go
+// Dialect values for LogFields.Dialect — which query language the configured
+// logs backend speaks. The zero value is LogsQL so every existing caller and
+// fake is untouched; the app layer sets DialectLogQL when the backend is Loki.
+const (
+	DialectLogsQL = ""      // VictoriaLogs LogsQL (shipped default)
+	DialectLogQL  = "logql" // Grafana Loki LogQL
+)
+```
+
+Add to the `LogFields` struct: `Dialect string // query dialect; "" ⇒ LogsQL (see Dialect*)`. In `resolved()`, branch first:
+
+```go
+func (f LogFields) resolved() LogFields {
+	if f.Dialect == DialectLogQL {
+		// Loki convention: promtail/alloy stream labels + Loki 3.x detected_level
+		// (structured metadata — no parser pipe by default). Mirrors
+		// config.LogFields.ResolvedFor (internal/config/config.go), which is the
+		// normal fill path; this is the in-package fallback for zero-field callers.
+		if f.ContainerField == "" {
+			f.ContainerField = "container"
+		}
+		if f.NamespaceField == "" {
+			f.NamespaceField = "namespace"
+		}
+		if f.PodField == "" {
+			f.PodField = "pod"
+		}
+		if f.LevelField == "" {
+			f.LevelField = "detected_level"
+		}
+		return f
+	}
+	// ... existing VictoriaLogs default fills, unchanged ...
+}
+```
+
+Also add the shared language label helper (used by descriptions/schemas):
+
+```go
+// queryLang names the dialect for tool descriptions/schemas.
+func (f LogFields) queryLang() string {
+	if f.Dialect == DialectLogQL {
+		return "LogQL"
+	}
+	return "LogsQL"
+}
+```
+
+- [ ] Implement the builder dispatch in `internal/investigate/query_tools.go`. In `buildLogsQLWith` (:399), after `conv = conv.resolved()`, insert:
+
+```go
+	if conv.Dialect == DialectLogQL {
+		return buildLogQL(raw, container, namespace, level, conv)
+	}
+```
+
+and add below it:
+
+```go
+// buildLogQL composes a valid LogQL (Grafana Loki) query from the resolved
+// field convention: `{container="…",namespace="…"}` plus an optional parser
+// pipe and a `| <level_field>="…"` label filter — detected_level needs no
+// parser on Loki 3.x, so the default pipe is empty. A raw query passes through
+// but must start with a stream selector, and LogsQL-isms (unpack_json, _msg —
+// the model's likely carry-over mistakes) are rejected with a correcting error,
+// mirroring the LogsQL branch's `level=` guard in spirit.
+func buildLogQL(raw, container, namespace, level string, conv LogFields) (string, error) {
+	if raw != "" {
+		if strings.Contains(raw, "unpack_json") || strings.Contains(raw, "_msg") {
+			return "", fmt.Errorf("invalid LogQL: unpack_json/_msg are VictoriaLogs LogsQL syntax. Parse with `| json` or `| logfmt` and filter severity with `| %s=\"error\"`, or use the container/namespace/level params", conv.LevelField)
+		}
+		if !strings.HasPrefix(strings.TrimSpace(raw), "{") {
+			return "", fmt.Errorf("invalid LogQL: a query starts with a stream selector, e.g. `{%s=\"apps\"}`", conv.NamespaceField)
+		}
+		return raw, nil
+	}
+	var sel []string
+	if container != "" {
+		sel = append(sel, fmt.Sprintf("%s=%q", conv.ContainerField, container))
+	}
+	if namespace != "" {
+		sel = append(sel, fmt.Sprintf("%s=%q", conv.NamespaceField, namespace))
+	}
+	if len(sel) == 0 {
+		return "", fmt.Errorf("provide a raw `query`, or `container`/`namespace` to build one")
+	}
+	q := "{" + strings.Join(sel, ",") + "}"
+	if level != "" {
+		if conv.UnpackPipe != "" {
+			q += " | " + conv.UnpackPipe
+		}
+		q += fmt.Sprintf(" | %s=%q", conv.LevelField, level)
+	}
+	return q, nil
+}
+```
+
+- [ ] Make `QueryLogsTool.Description()` (:428) dialect-aware:
+
+```go
+func (t QueryLogsTool) Description() string {
+	if t.Fields.Dialect == DialectLogQL {
+		return "Query logs with LogQL (Grafana Loki) over a recent window. " +
+			"PREFER the structured params (container/namespace/level) and let the tool build the query. " +
+			"If you write a raw `query`: it MUST start with a stream selector using Loki stream labels, " +
+			"e.g. `{namespace=\"apps\", container=\"x\"}`; filter severity with `| detected_level=\"error\"` " +
+			"(no parser needed) or parse first with `| json` / `| logfmt`. " +
+			"Do NOT use VictoriaLogs LogsQL syntax (unpack_json, _msg, field:value filters). " +
+			"Optional since_minutes bounds the window (default 60)."
+	}
+	return "Query logs with LogsQL (VictoriaLogs) over a recent window. " +
+		// ... existing text, unchanged ...
+}
+```
+
+and `Schema()` (:439): replace the literal `"raw LogsQL; only if the structured fields are insufficient"` with `"raw "+t.Fields.queryLang()+"; only if the structured fields are insufficient"` (build the schema string with `fmt.Sprintf` or concatenation — keep the rest byte-identical).
+
+- [ ] Give `LogsErrorSummaryTool` (logs_summary_tool.go:28) and `DiscoverLogFieldsTool` (discover_tools.go:97) a `Fields LogFields` member (doc comment: "OPTIONAL field convention + dialect (config.logs.*); the zero value keeps the shipped VictoriaLogs behaviour"), switch their `Call` bodies from `buildLogsQL(...)` (logs_summary_tool.go:72, discover_tools.go:133) to `buildLogsQLWith(..., t.Fields)`, and make their `Schema()` "raw LogsQL" strings use `t.Fields.queryLang()` the same way.
+- [ ] Apply the zero-count render fix in `DiscoverLogFieldsTool.Call` (discover_tools.go:157-160):
+
+```go
+	renderRows(&b, len(names), "more", func(i int) {
+		if names[i].Hits > 0 {
+			fmt.Fprintf(&b, "%s (×%d)\n", names[i].Name, names[i].Hits)
+			return
+		}
+		fmt.Fprintf(&b, "%s\n", names[i].Name) // Loki stream labels carry no hit count
+	})
+```
+
+- [ ] Run `go test ./internal/investigate/ -count=1` — expect **PASS** (existing LogsQL tests must be untouched: zero `Dialect` keeps the old behaviour byte-for-byte).
+- [ ] Add the end-to-end parity test `internal/investigate/loki_e2e_test.go` — the three REAL tools against the REAL Loki client and one httptest fake Loki (this is the "three investigation tools work against Loki" proof):
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/logs/loki"
+)
+
+// TestLokiToolsEndToEnd wires the three log tools to the real Loki client
+// against a fake Loki serving realistic fixtures — the parity proof that
+// query_logs, logs_error_summary, and discover_log_fields all work end-to-end
+// on a Loki backend (client normalization + dialect query building + renderer).
+func TestLokiToolsEndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("query")
+		switch {
+		case r.URL.Path == "/loki/api/v1/query_range" && strings.HasPrefix(q, "sum by"):
+			_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"matrix","result":[
+			  {"metric":{"detected_level":"error"},"values":[[1704103200,"3"],[1704103500,"412"]]}]}}`)
+		case r.URL.Path == "/loki/api/v1/query_range":
+			_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
+			  {"stream":{"namespace":"apps","pod":"harbor-db-0","container":"db"},
+			   "values":[["1750413600000000000","db connection refused"]]}]}}`)
+		case r.URL.Path == "/loki/api/v1/labels":
+			_, _ = io.WriteString(w, `{"status":"success","data":["namespace","pod","container"]}`)
+		case r.URL.Path == "/loki/api/v1/detected_fields":
+			_, _ = io.WriteString(w, `{"fields":[{"label":"level","type":"string","cardinality":4,"parsers":["logfmt"]}]}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	lg := loki.New(srv.URL)
+	flds := LogFields{Dialect: DialectLogQL}
+
+	out, err := QueryLogsTool{Logs: lg, Fields: flds}.Call(context.Background(),
+		`{"namespace":"apps","level":"error"}`)
+	if err != nil || !strings.Contains(out, "db connection refused") {
+		t.Fatalf("query_logs: %v\n%s", err, out)
+	}
+	// The renderer must find pod/container under the Loki stream-label names.
+	if !strings.Contains(out, "harbor-db-0/db") {
+		t.Fatalf("stream identity not derived from loki labels:\n%s", out)
+	}
+
+	out, err = LogsErrorSummaryTool{Logs: lg, Fields: flds}.Call(context.Background(),
+		`{"namespace":"apps"}`)
+	if err != nil || !strings.Contains(out, "412") || !strings.Contains(out, "top messages") {
+		t.Fatalf("logs_error_summary: %v\n%s", err, out)
+	}
+
+	out, err = DiscoverLogFieldsTool{Logs: lg, Fields: flds}.Call(context.Background(),
+		`{"namespace":"apps"}`)
+	if err != nil || !strings.Contains(out, "namespace") || !strings.Contains(out, "level (×4)") {
+		t.Fatalf("discover_log_fields: %v\n%s", err, out)
+	}
+}
+```
+
+- [ ] Run `go test ./internal/investigate/ -run TestLokiToolsEndToEnd -count=1` — expect **PASS** (fix normalization/render mismatches now, while the whole stack is in view).
+- [ ] Commit: `feat(investigate): LogQL dialect for the log tools — query building, guards, descriptions`
+
+---
+
+### Task 7: App wiring — provider selection in `BuildModelAndTools`
+
+**Files:**
+- Modify: `internal/app/investigate.go` (the `cfg.Logs.URL != ""` block at :140-169)
+- Test: `internal/app/investigate_test.go`
+
+**Steps:**
+
+- [ ] Add the failing selection test to `internal/app/investigate_test.go` (style matches `TestDiscoveryToolsGatedByProvider` at :90; `httptest`/`io` may need importing):
+
+```go
+// TestLogsBackendSelection: logs.provider pins the backend; empty auto-detects
+// (Loki answers /loki/api/v1/status/buildinfo, VictoriaLogs 404s), failing safe
+// to victorialogs. The observable contract is the dialect carried on the
+// registered query_logs tool — LogQL means the Loki client + LogQL guidance.
+func TestLogsBackendSelection(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent-kubeconfig"))
+	log := discardLog()
+	base := config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}
+
+	lokiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			_, _ = io.WriteString(w, `{"version":"3.1.0"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer lokiSrv.Close()
+	vlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer vlSrv.Close()
+
+	tests := []struct {
+		name, url, pin, wantDialect string
+	}{
+		{"auto-detect loki", lokiSrv.URL, "", investigate.DialectLogQL},
+		{"auto-detect fail-safe victorialogs", vlSrv.URL, "", investigate.DialectLogsQL},
+		{"pinned loki skips probe", vlSrv.URL, "loki", investigate.DialectLogQL},
+		{"pinned victorialogs skips probe", lokiSrv.URL, "victorialogs", investigate.DialectLogsQL},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Model: base}
+			cfg.Logs.URL = tc.url
+			cfg.Logs.Provider = tc.pin
+			_, tools, _, _ := BuildModelAndTools(context.Background(), cfg, nil, nil, log)
+			found := false
+			for _, tool := range tools {
+				if qt, ok := tool.(investigate.QueryLogsTool); ok {
+					found = true
+					if qt.Fields.Dialect != tc.wantDialect {
+						t.Fatalf("dialect = %q, want %q", qt.Fields.Dialect, tc.wantDialect)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("query_logs not registered")
+			}
+		})
+	}
+}
+```
+
+- [ ] Run `go test ./internal/app/ -run TestLogsBackendSelection -count=1` — expect **FAIL** (dialect always `""` — Loki never selected).
+- [ ] Replace the logs block in `internal/app/investigate.go` (:140-169) with:
+
+```go
+	if cfg.Logs.URL != "" {
+		warnIfBackendUnreachable(ctx, log, "logs", cfg.Logs.URL)
+		// Backend provider (M1): a config pin wins; otherwise probe once at startup,
+		// mirroring the metrics flavor detection above. Detection fails safe to
+		// VictoriaLogs — the provider RunLore shipped with — so an existing deployment
+		// (or an unreachable backend at startup) sees no behaviour change.
+		provider := cfg.Logs.Provider
+		if provider == "" {
+			provider = logs.Detect(ctx, cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers)
+		}
+		// Resolve the OPTIONAL collector field convention once, per provider; an unset
+		// config yields the provider's shipped defaults, so this is a no-op unless
+		// logs.fields is set.
+		lf := cfg.Logs.Fields.ResolvedFor(provider)
+		var lg providers.LogsProvider
+		dialect := investigate.DialectLogsQL
+		switch provider {
+		case config.LogsProviderLoki:
+			lg = loki.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers).WithLevelField(lf.LevelField)
+			dialect = investigate.DialectLogQL
+		default: // victorialogs — the shipped default
+			lg = victorialogs.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers).WithLevelField(lf.LevelField)
+		}
+		log.Info("logs backend provider", "provider", provider, "pinned", cfg.Logs.Provider != "")
+		flds := investigate.LogFields{
+			ContainerField: lf.ContainerField,
+			NamespaceField: lf.NamespaceField,
+			PodField:       lf.PodField,
+			LevelField:     lf.LevelField,
+			UnpackPipe:     lf.UnpackPipe,
+			Dialect:        dialect,
+		}
+		tools = append(tools,
+			// query_logs reads the same raw pod logs pod_logs does, so it shares the
+			// pod_log_namespaces allowlist (L2 confinement) and honours the field
+			// convention (L1). The incident namespace is injected per-investigation by
+			// the loop (scopeTools), exactly like pod_logs.
+			investigate.QueryLogsTool{
+				Logs:              lg,
+				Fields:            flds,
+				AllowedNamespaces: cfg.Investigation.PodLogNamespaces,
+			},
+			// logs_error_summary and discover_log_fields degrade gracefully when the
+			// backend lacks the analytics/field capability (both VictoriaLogs and Loki
+			// implement them), so they are safe to always register.
+			investigate.LogsErrorSummaryTool{Logs: lg, Fields: flds},
+			investigate.DiscoverLogFieldsTool{Logs: lg, Fields: flds},
+		)
+	}
+```
+
+Add the imports `"github.com/Smana/runlore/internal/logs"` and `"github.com/Smana/runlore/internal/logs/loki"` (the `victorialogs` import at :22 stays).
+
+- [ ] Run `go test ./internal/app/ -count=1` — expect **PASS**, including the pre-existing `TestDiscoveryToolsGatedByProvider` (:90), whose unreachable `http://logs:9428` URL now takes the auto-detect path and must still resolve to VictoriaLogs via the fail-safe.
+- [ ] Run the full suite: `go test ./... -count=1` and `go vet ./...` — expect **PASS/clean**.
+- [ ] Commit: `feat(app): wire Grafana Loki logs backend behind logs.provider with startup auto-detect`
+
+---
+
+### Task 8: Docs — data-sources.md, Helm values comment
+
+**Files:**
+- Modify: `docs/data-sources.md` (table row :13; new section after :66)
+- Modify: `deploy/helm/runlore/values.yaml` (:270)
+
+**Steps:**
+
+- [ ] Update the table row at `docs/data-sources.md:13` to:
+
+```markdown
+| Logs | `query_logs`, `logs_error_summary`, `discover_log_fields` | `LogsProvider` | VictoriaLogs (LogsQL) · **Grafana Loki (LogQL)** | `logs.url` (+ optional `logs.provider`) |
+```
+
+- [ ] Insert this section after the "Adding another provider" network subsection (after `docs/data-sources.md:66`, before "## Custom webhooks"):
+
+```markdown
+## Logs backends
+
+The logs signal is pluggable behind `LogsProvider`: **VictoriaLogs** (LogsQL) and **Grafana
+Loki** (LogQL). All three log tools — `query_logs`, `logs_error_summary`,
+`discover_log_fields` — work on both; the model is told the right query language automatically.
+
+The provider is **auto-detected** at startup (Loki answers `/loki/api/v1/status/buildinfo`;
+VictoriaLogs does not) and **fails safe to VictoriaLogs**, so existing configs are untouched.
+Pin it with `provider:` when the backend is unreachable at startup or sits behind a proxy that
+confuses the probe.
+
+### `victorialogs` — VictoriaLogs (default)
+```yaml
+logs:
+  url: http://victorialogs.observability.svc:9428
+```
+
+### `loki` — Grafana Loki
+```yaml
+logs:
+  url: http://loki-gateway.observability.svc:80
+  provider: loki          # optional — auto-detected when omitted
+  # token_env: LOKI_TOKEN                 # bearer token, by env-var indirection
+  # headers: { X-Scope-OrgID: my-tenant } # multi-tenant Loki
+```
+
+Field-convention defaults differ per provider; override any of them via `logs.fields`:
+
+| `logs.fields` key | VictoriaLogs default | Loki default |
+|---|---|---|
+| `container_field` | `kubernetes.container_name` | `container` |
+| `namespace_field` | `kubernetes.pod_namespace` | `namespace` |
+| `pod_field` | `kubernetes.pod_name` | `pod` |
+| `level_field` | `log.level` | `detected_level` |
+| `unpack_pipe` | `unpack_json` | *(none — `detected_level` is structured metadata)* |
+
+> Loki parity notes: `logs_error_summary`'s histogram uses a LogQL metric query
+> (`sum by (detected_level) (count_over_time(…))`); its *top messages* are aggregated
+> client-side over the (capped, newest-first) query sample, so counts are per-sample rather
+> than corpus-wide. `discover_log_fields` merges stream labels (`/loki/api/v1/labels`) with
+> detected body fields (`/loki/api/v1/detected_fields`, Loki ≥ 3.0; older Loki degrades to
+> labels only). On Loki 2.x there is no `detected_level` — set
+> `logs: { fields: { level_field: level, unpack_pipe: logfmt } }` (or `json`) to match your
+> collector.
+```
+
+- [ ] Replace the logs comment line in `deploy/helm/runlore/values.yaml` (:270) with:
+
+```yaml
+  # Logs backend (query_logs / logs_error_summary / discover_log_fields). The provider is
+  # auto-detected (Loki answers /loki/api/v1/status/buildinfo; anything else = VictoriaLogs);
+  # pin it with `provider:` if the backend is unreachable at chart-install time.
+  # logs:    { url: http://victorialogs.observability.svc:9428 }                # VictoriaLogs (LogsQL)
+  # logs:    { url: http://loki-gateway.observability.svc:80, provider: loki }  # Grafana Loki (LogQL)
+```
+
+- [ ] Run `go test ./internal/config/ -run TestShipped -count=1` (shipped-config/values tests must still parse the chart values) and `helm lint deploy/helm/runlore` if available locally — expect **PASS**.
+- [ ] Commit: `docs: document the Grafana Loki logs backend (data-sources, chart values)`
+
+---
+
+## Acceptance criteria
+
+- [ ] `internal/logs/loki` implements `providers.LogsProvider`, `providers.LogStats`, and `providers.LogFields` (compile-time asserted with `var _ =` like `victorialogs.go:77-83`), against `/loki/api/v1/query_range`, `/loki/api/v1/labels`, and `/loki/api/v1/detected_fields`.
+- [ ] All three tools (`query_logs`, `logs_error_summary`, `discover_log_fields`) work end-to-end against a fake Loki (`internal/investigate/loki_e2e_test.go` passes).
+- [ ] `logs.provider` accepts `""`/`victorialogs`/`loki` and rejects anything else at startup; empty auto-detects via the buildinfo probe and **fails safe to victorialogs** (unreachable, 404, and non-JSON-200 cases all covered by tests).
+- [ ] No new required config: a config with only `logs.url` set keeps working against VictoriaLogs byte-for-byte (zero `Dialect`, `Resolved()` defaults, existing `internal/investigate` and `internal/app` tests unmodified except the new ones); unset `logs` still registers no log tools.
+- [ ] On a Loki deployment the model is told **LogQL** in every log-tool description/schema, raw LogsQL-isms get a correcting error, and structured params compile to valid LogQL (`buildLogQL` tests).
+- [ ] Error paths covered: Loki down, non-200, malformed response, empty results (empty ⇒ the tools' existing `noLogLinesMatched` / "no fields found" messages, never a crash).
+- [ ] Loki-specific parity gaps are explicit in code comments and docs: no offset pagination (single capped request + `TruncationLine`), client-side `TopMessages` (per-sample counts), `detected_fields` cardinality-as-count (rendered only when > 0), Loki 2.x `detected_level` caveat.
+- [ ] `docs/data-sources.md` and `deploy/helm/runlore/values.yaml` document both backends with working YAML examples.
+- [ ] `go test ./... -count=1` and `go vet ./...` pass; every commit uses a conventional message with **no** Co-Authored-By line.

--- a/dev/superpowers/plans/2026-07-23-m2-gitlab-forge.md
+++ b/dev/superpowers/plans/2026-07-23-m2-gitlab-forge.md
@@ -1,0 +1,1892 @@
+# M2 — GitLab forge Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitLab — gitlab.com **and self-hosted GitLab** (the strategic case: sovereignty-conscious EU teams run their own instance) — as a knowledge-base forge alongside GitHub. The curator opens **merge requests** with drafted OKF entries, comments on open MRs for duplicate incidents, closes MRs (dedup/lifecycle), opens knowledge-gap issues, and the catalog syncs/clones the KB repo over GitLab auth. Auth is a **project access token** (the simplest self-hosted-friendly path — no instance-admin setup), referenced from a Kubernetes Secret by env-var name, exactly like the GitHub App private key. **No new required config for existing GitHub users**: `forge.provider` defaults to `github`.
+
+**Architecture:** A new `internal/forge/gitlab` package mirrors `internal/forge/github` — a plain REST client over `httpx.SecureClient` (internal/httpx/client.go:27), implementing the **same consumer interfaces**: `providers.CurationForge` (internal/providers/providers.go:529-533), `providers.ReinvestForge` (providers.go:548-556), `curate.Forge` (internal/curate/forge.go:16-23), `curate.ContestedForge` (internal/curate/contested.go:21-25), and `curate.RetireForge` (internal/curate/retirement.go:25-28). The forge-agnostic OKF rendering that today lives inside the github package (`renderEntry`, `prBody`, `slugify`, `neutralizeImages`, bundle `updateIndex`/`updateLog`, retire `setStatusRetired`) is first extracted into a shared root package `internal/forge` (package `forge`) so GitLab never re-implements security-relevant text handling. App wiring gains one seam — `app.BuildForgeClient` — that returns the provider-selected client; `app.BuildForgeTokenSource` (internal/app/forge.go:21) gains a GitLab branch returning the static project token, which transparently feeds catalog git-sync (internal/app/catalog.go:79-82) and source-diff clone auth (internal/app/gitops.go:23) because both use git basic-auth with username `x-access-token` + token password (internal/catalog/sync.go:62, internal/whatchanged/differ.go:143) — GitLab accepts **any non-blank username** with a project-access-token password, so zero changes are needed there.
+
+**Tech Stack:** Go stdlib `net/http` + `internal/httpx` (no new dependency), GitLab REST API v4 (`PRIVATE-TOKEN` header auth), `httptest` fakes with real GitLab JSON for tests, go-git for the (unchanged) clone paths, Helm chart values comments + docs.
+
+**Locked decisions:**
+
+| Decision | Choice | Why |
+|---|---|---|
+| Client library | **Plain REST via `internal/httpx`** — NOT `gitlab.com/gitlab-org/api/client-go` | The repo's dependency posture is strict: go.mod has **no** GitHub SDK either — `internal/forge/github` is hand-rolled REST over `httpx.SecureClient`. We need ~12 endpoints; the official client would add a large transitive tree for JSON we can decode in a struct literal. Mirroring the github package also keeps the two forges reviewable side by side. |
+| Auth | **Project access token** in an env var (`forge.gitlab.token_env`), `PRIVATE-TOKEN` header | Per-project, role-scoped, expiring, creatable by a project Maintainer on ANY self-hosted instance (a GitLab "Application"/OAuth flow needs instance-level setup — hostile to the self-hosted case). Matches design.md §14: "Non-GitHub hosts (GitLab, self-hosted) fall back to a scoped access token" (docs/design.md:523). |
+| Provider selection | `forge.provider: gitlab` (default `""` ⇒ `github`) | One explicit key; empty keeps every existing GitHub config byte-identical in behavior (simplicity constraint: no new required config). |
+| KB repo addressing | `forge.kb_repo` holds the **full GitLab project path** (`group/subgroup/project`, nested groups allowed) | GitLab's REST `:id` accepts the URL-encoded path; no numeric project-ID hunting for users. GitHub keeps its `owner/name` split (the `strings.Cut` stays in the GitHub arm only). |
+| Closed-unmerged listing | `GET /merge_requests?state=closed&labels=…` | GitLab MR states are `opened/closed/merged/locked` — `closed` **is** closed-without-merge (merged is a separate state), so the rejection-suppression set needs no search API, unlike GitHub (internal/forge/github/github.go:285-302). |
+| iid namespace split | Per-client artifact-kind memo + MR-endpoint probe fallback | GitHub shares ONE number space between issues and PRs; GitLab numbers MRs and issues independently, but every consumer interface passes a bare `int`. Verified call-flow: every mutation site learns the number from a listing or `IsPROpen` **on the same client** first (curate/dedup.go:31→56/60, lifecycle.go:35→45/49, resolution.go:32→50, contested.go:75→91/100, reinvestigate.go:51→77/82, curator.go:176→125), so the memo is always primed in practice; the probe is a safety net. |
+| Git clone auth | Reuse the shared forge token via the existing `x-access-token` basic-auth | GitLab ignores the username when the password is a valid token — `catalog.Syncer.auth` and `whatchanged.Differ.auth` work unmodified. |
+
+**Out of scope (state in the PR description):** mixed-host setups (KB on GitLab + *private* source repos on GitHub get no GitHub token — public source repos still diff fine); GitLab webhooks (RunLore polls the forge outbound, same as GitHub — providers.go:548-550); GitLab CI templates.
+
+---
+
+### Task 1: Extract forge-agnostic OKF rendering into `internal/forge` (package `forge`)
+
+The github package owns ~300 lines of pure, host-independent text handling that the GitLab client must reuse, not duplicate — including the security-relevant `neutralizeImages` (github.go:372-388) and the YAML-marshal frontmatter injection guard (github.go:411-439). This is a behavior-preserving move; the existing github test suite is the net.
+
+**Files:**
+- Create: `internal/forge/render.go`, `internal/forge/bundle.go`, `internal/forge/retire.go`
+- Modify: `internal/forge/github/github.go`, `internal/forge/github/bundle.go`, `internal/forge/github/retire.go`, `internal/curate/retirement.go`, `internal/curate/retirement_test.go`
+- Test: existing `internal/forge/github/*_test.go`, `internal/curate/retirement_test.go` (unchanged assertions)
+
+- [ ] **Step 1: Baseline — record the green suite**
+
+  ```bash
+  go test ./internal/forge/... ./internal/curate/ ./internal/curator/
+  ```
+
+  Expected: `ok` for all three (this is the refactor's before/after contract).
+
+- [ ] **Step 2: Create `internal/forge/render.go`** — move these, verbatim bodies, exported names, receiver-free:
+
+  | New name (package `forge`) | Moved from |
+  |---|---|
+  | `func Slugify(s string) string` | github.go:551-568 `slugify` |
+  | `func EntryPath(e providers.KBEntry, slug string, now int64) string` | github.go:540-549 `entryPath` |
+  | `func NeutralizeImages(s string) string` (+ `imageRe`) | github.go:372-388 |
+  | `type kbFrontmatter` (stays unexported) | github.go:414-439 |
+  | `func RenderEntry(e providers.KBEntry) string` | github.go:509-531 `renderEntry` |
+  | `func IssueTitle(inv providers.Investigation) string` | github.go:390-395 `issueTitle` |
+  | `func IssueBody(inv providers.Investigation) string` | github.go:397-409 `issueBody` |
+  | `func PRBody(e providers.KBEntry, blobURL func(path string) string) string` | github.go:446-460 `(c *Client) prBody` — the ONE signature change: `c.blobURL` becomes the `blobURL` parameter |
+  | `func relatedSection(e providers.KBEntry, blobURL func(string) string) string` (unexported helper of PRBody) | github.go:465-484 `(c *Client) relatedSection`, same parameterization |
+  | `var LifecycleLabels = []string{"runlore", "triggered"}` | github.go:98 `lifecycleLabels` |
+  | `var RetireLabels = []string{"runlore", "runlore-retire"}` | retire.go:55 `retireLabels` |
+
+  File header: `// SPDX-License-Identifier: Apache-2.0` + package doc:
+
+  ```go
+  // Package forge holds the forge-agnostic half of RunLore's git-forge clients:
+  // OKF entry/PR-body rendering, bundle (index.md/log.md) maintenance, and the
+  // retirement frontmatter stamp. Host clients (github, gitlab) own transport,
+  // auth, and endpoint mapping; everything that decides WHAT text reaches a
+  // forge-rendered surface lives here exactly once — including the untrusted-
+  // markdown image neutralization, which must never fork between hosts.
+  package forge
+  ```
+
+- [ ] **Step 3: Create `internal/forge/bundle.go`** — move verbatim:
+  - `func UpdateIndex(existing []byte, e providers.KBEntry, entryPath string) []byte` ← github/bundle.go:51-81 `updateIndex`
+  - `func UpdateLog(existing []byte, e providers.KBEntry, entryPath, date string) []byte` ← github/bundle.go:85-113 `updateLog`
+
+- [ ] **Step 4: Create `internal/forge/retire.go`** — move verbatim:
+  - `var ErrAlreadyRetired = errors.New("entry already retired on base branch")` ← github/retire.go:19
+  - `func SetStatusRetired(content []byte) (out []byte, already bool, err error)` ← github/retire.go:28-50 `setStatusRetired`
+
+- [ ] **Step 5: Delegate from the github package** (import `forge "github.com/Smana/runlore/internal/forge"`). Replace each moved definition with a thin binding so every internal call site and test compiles unchanged:
+
+  ```go
+  // github.go — moved to the shared forge package; bound here so call sites/tests are unchanged.
+  var (
+      slugify           = forge.Slugify
+      entryPath         = forge.EntryPath
+      neutralizeImages  = forge.NeutralizeImages
+      renderEntry       = forge.RenderEntry
+      issueTitle        = forge.IssueTitle
+      issueBody         = forge.IssueBody
+      lifecycleLabels   = forge.LifecycleLabels
+  )
+
+  func (c *Client) prBody(e providers.KBEntry) string { return forge.PRBody(e, c.blobURL) }
+  ```
+
+  ```go
+  // bundle.go
+  var (
+      updateIndex = forge.UpdateIndex
+      updateLog   = forge.UpdateLog
+  )
+  ```
+
+  ```go
+  // retire.go
+  // ErrAlreadyRetired aliases the shared sentinel so errors.Is works across packages.
+  var ErrAlreadyRetired = forge.ErrAlreadyRetired
+
+  var setStatusRetired = forge.SetStatusRetired
+
+  var retireLabels = forge.RetireLabels
+  ```
+
+  Delete the moved bodies (and `imageRe`, `kbFrontmatter`, `relatedSection`) from the github package. Keep `(c *Client) blobURL` (github.go:495-507) — it is host-specific.
+
+- [ ] **Step 6: Point `internal/curate` at the shared sentinel** — in `internal/curate/retirement.go:107` and `internal/curate/retirement_test.go:140`, replace `github.ErrAlreadyRetired` with `forge.ErrAlreadyRetired` and swap the import from `internal/forge/github` to `internal/forge`. (The github alias in Step 5 keeps both spellings `errors.Is`-equal, but curate should not import a host package for a host-neutral sentinel.)
+
+- [ ] **Step 7: Verify the net**
+
+  ```bash
+  go build ./... && go test ./internal/forge/... ./internal/curate/ ./internal/curator/ ./internal/app/
+  ```
+
+  Expected: all `ok`, zero test edits beyond the two import/identifier swaps in Step 6.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add internal/forge internal/curate
+  git commit -m "refactor(forge): extract forge-agnostic OKF rendering into internal/forge"
+  ```
+
+### Task 2: Config — `forge.provider` + `forge.gitlab` keys, validation
+
+**Files:**
+- Modify: `internal/config/config.go` (Forge struct at line 1290, Validate at line 1013)
+- Test: `internal/config/config_test.go` (append)
+
+- [ ] **Step 1: Write the failing test** — append to `internal/config/config_test.go`:
+
+  ```go
+  // writeForgeCfg loads a config whose only block is forge — provider selection
+  // must be validatable without any other subsystem configured.
+  func writeForgeCfg(t *testing.T, forgeYAML string) (*Config, error) {
+      t.Helper()
+      p := filepath.Join(t.TempDir(), "runlore.yaml")
+      if err := os.WriteFile(p, []byte("forge:\n"+forgeYAML), 0o600); err != nil {
+          t.Fatal(err)
+      }
+      return Load(p)
+  }
+
+  func TestForgeProviderValidation(t *testing.T) {
+      t.Run("unknown provider rejected", func(t *testing.T) {
+          _, err := writeForgeCfg(t, "  provider: bitbucket\n")
+          if err == nil || !strings.Contains(err.Error(), "forge.provider") {
+              t.Fatalf("want forge.provider error, got %v", err)
+          }
+      })
+      t.Run("gitlab requires token_env", func(t *testing.T) {
+          _, err := writeForgeCfg(t, "  provider: gitlab\n  kb_repo: group/runlore-kb\n")
+          if err == nil || !strings.Contains(err.Error(), "forge.gitlab.token_env") {
+              t.Fatalf("want token_env error, got %v", err)
+          }
+      })
+      t.Run("gitlab full config valid, nested project path allowed", func(t *testing.T) {
+          cfg, err := writeForgeCfg(t, strings.Join([]string{
+              "  provider: gitlab",
+              "  kb_repo: group/subgroup/runlore-kb",
+              "  base_branch: main",
+              "  gitlab:",
+              "    base_url: https://gitlab.example.com",
+              "    token_env: GITLAB_TOKEN",
+          }, "\n")+"\n")
+          if err != nil {
+              t.Fatalf("valid gitlab forge rejected: %v", err)
+          }
+          if cfg.Forge.GitLab.BaseURL != "https://gitlab.example.com" || cfg.Forge.GitLab.TokenEnv != "GITLAB_TOKEN" {
+              t.Fatalf("gitlab block not parsed: %+v", cfg.Forge.GitLab)
+          }
+      })
+      t.Run("empty provider stays valid (github default, existing configs untouched)", func(t *testing.T) {
+          if _, err := writeForgeCfg(t, "  kb_repo: owner/name\n"); err != nil {
+              t.Fatalf("github-default forge rejected: %v", err)
+          }
+      })
+  }
+  ```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+  ```bash
+  go test ./internal/config/ -run TestForgeProviderValidation
+  ```
+
+  Expected: `FAIL github.com/Smana/runlore/internal/config [build failed]` — `cfg.Forge.GitLab` and `Provider` are undefined (Load's `KnownFields(true)` at internal/config/load.go:24 would also reject the new YAML keys).
+
+- [ ] **Step 3: Implement.** In `internal/config/config.go`, extend `Forge` (line 1290) and add `GitLabForge` after `GitHubApp` (line 1314):
+
+  ```go
+  // Forge holds git-forge authentication and the curation target repo.
+  type Forge struct {
+      // Provider selects the forge kind: "github" (default when empty) or "gitlab"
+      // (gitlab.com or self-hosted via gitlab.base_url). Existing GitHub configs
+      // need no change — the empty default preserves their exact behavior.
+      Provider      string      `yaml:"provider"`
+      GitHubApp     GitHubApp   `yaml:"github_app"`
+      GitLab        GitLabForge `yaml:"gitlab"`
+      KBRepo        string      `yaml:"kb_repo"`        // GitHub: "owner/name". GitLab: full project path ("group/sub/project")
+      BaseBranch    string      `yaml:"base_branch"`    // PR/MR target branch (default "main")
+      GitHubAPIURL  string      `yaml:"github_api_url"` // override for GHES/tests (default https://api.github.com)
+      DupScore      float64     `yaml:"dup_score"`      // file-time catalog BM25 dedup threshold (default 5.0)
+      MinConfidence float64     `yaml:"min_confidence"` // file-time quality gate: min overall confidence (default 0.75)
+      // ... SkipVerdicts unchanged (keep the existing field + comment, config.go:1297-1302)
+      SkipVerdicts []string `yaml:"skip_verdicts"`
+  }
+
+  // GitLabForge holds GitLab forge settings (gitlab.com or self-hosted). Auth is a
+  // project access token — per-project, role-scoped, expiring; the self-hosted-
+  // friendly counterpart of the GitHub App — referenced from a Secret by env-var
+  // name, never inlined (same *_env convention as github_app.private_key_env).
+  type GitLabForge struct {
+      BaseURL  string `yaml:"base_url"`  // default https://gitlab.com; self-hosted: https://gitlab.example.com
+      TokenEnv string `yaml:"token_env"` // env var holding the project access token
+  }
+  ```
+
+  In `Validate()` (config.go:1013), next to the `forge.skip_verdicts` gate at config.go:1159-1166, add:
+
+  ```go
+  // Forge provider gate: an unknown provider or a GitLab selection without its
+  // token env must fail at startup, not as a silent GitHub fallback that then
+  // 401s against the wrong host.
+  switch c.Forge.Provider {
+  case "", "github", "gitlab":
+  default:
+      return fmt.Errorf("forge.provider: unknown provider %q (want github|gitlab)", c.Forge.Provider)
+  }
+  if c.Forge.Provider == "gitlab" && c.Forge.GitLab.TokenEnv == "" {
+      return fmt.Errorf("forge.provider gitlab requires forge.gitlab.token_env (the env var holding the project access token)")
+  }
+  ```
+
+- [ ] **Step 4: Run — expect PASS**
+
+  ```bash
+  go test ./internal/config/
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/config
+  git commit -m "feat(config): forge.provider + forge.gitlab keys for the GitLab forge"
+  ```
+
+### Task 3: GitLab client core — `New`/`do`, auth header, error mapping, `OpenIssue`
+
+**Files:**
+- Create: `internal/forge/gitlab/gitlab.go`
+- Test: `internal/forge/gitlab/gitlab_test.go`
+
+- [ ] **Step 1: Write the failing tests** — create `internal/forge/gitlab/gitlab_test.go` (mirrors `internal/forge/github/github_test.go` style: httptest fake, real JSON, request assertions):
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package gitlab
+
+  import (
+      "context"
+      "encoding/json"
+      "net/http"
+      "net/http/httptest"
+      "strings"
+      "testing"
+
+      "github.com/Smana/runlore/internal/providers"
+  )
+
+  func staticToken() func(context.Context) (string, error) {
+      return func(context.Context) (string, error) { return "glpat-tok", nil }
+  }
+
+  func TestOpenIssue(t *testing.T) {
+      var gotAuth, gotPath string
+      var gotBody map[string]any
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          // EscapedPath, not Path: the project path is %2F-encoded in the URL and
+          // the client must NOT send a literal slash (GitLab would 404 the route).
+          gotAuth, gotPath = r.Header.Get("PRIVATE-TOKEN"), r.URL.EscapedPath()
+          _ = json.NewDecoder(r.Body).Decode(&gotBody)
+          w.WriteHeader(http.StatusCreated)
+          _, _ = w.Write([]byte(`{"id":83,"iid":7,"project_id":42,"title":"Boom","state":"opened",
+            "labels":["runlore","triggered"],
+            "web_url":"https://gitlab.example.com/platform/runlore-kb/-/issues/7"}`))
+      }))
+      defer srv.Close()
+
+      c := New(srv.URL, "platform/runlore-kb", "main", staticToken())
+      ref, err := c.OpenIssue(context.Background(), providers.Investigation{Title: "Boom", Confidence: 0.4,
+          RootCauses: []providers.Hypothesis{{Summary: "db down"}}})
+      if err != nil {
+          t.Fatalf("OpenIssue: %v", err)
+      }
+      if gotAuth != "glpat-tok" || gotPath != "/api/v4/projects/platform%2Frunlore-kb/issues" {
+          t.Fatalf("auth=%q path=%q", gotAuth, gotPath)
+      }
+      if title, _ := gotBody["title"].(string); title != "Boom" {
+          t.Fatalf("title=%v", gotBody["title"])
+      }
+      if labels, _ := gotBody["labels"].(string); labels != "runlore,triggered" {
+          t.Fatalf("labels=%v (GitLab takes a comma-joined string at creation)", gotBody["labels"])
+      }
+      if ref.URL != "https://gitlab.example.com/platform/runlore-kb/-/issues/7" {
+          t.Fatalf("ref=%s", ref.URL)
+      }
+  }
+
+  func TestDoMapsErrorStatuses(t *testing.T) {
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          switch r.Header.Get("PRIVATE-TOKEN") {
+          case "expired":
+              w.WriteHeader(http.StatusUnauthorized)
+              _, _ = w.Write([]byte(`{"message":"401 Unauthorized"}`))
+          case "wrong-project":
+              w.WriteHeader(http.StatusNotFound)
+              _, _ = w.Write([]byte(`{"message":"404 Project Not Found"}`))
+          default: // duplicate MR for the same source branch
+              w.WriteHeader(http.StatusConflict)
+              _, _ = w.Write([]byte(`{"message":["Another open merge request already exists for this source branch: !12"]}`))
+          }
+      }))
+      defer srv.Close()
+
+      mk := func(tok string) *Client {
+          return New(srv.URL, "g/p", "main", func(context.Context) (string, error) { return tok, nil })
+      }
+      _, err := mk("expired").OpenIssue(context.Background(), providers.Investigation{Title: "x"})
+      if err == nil || !strings.Contains(err.Error(), "status 401") || !strings.Contains(err.Error(), "forge.gitlab.token_env") {
+          t.Fatalf("401 must name the token env knob, got: %v", err)
+      }
+      _, err = mk("wrong-project").OpenIssue(context.Background(), providers.Investigation{Title: "x"})
+      if err == nil || !strings.Contains(err.Error(), "status 404") || !strings.Contains(err.Error(), "forge.kb_repo") {
+          t.Fatalf("404 must point at the project path knob, got: %v", err)
+      }
+      _, err = mk("ok").OpenIssue(context.Background(), providers.Investigation{Title: "x"})
+      if err == nil || !strings.Contains(err.Error(), "status 409") || !strings.Contains(err.Error(), "Another open merge request") {
+          t.Fatalf("409 must surface GitLab's conflict message, got: %v", err)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+  Expected: `FAIL github.com/Smana/runlore/internal/forge/gitlab [build failed]` (`undefined: New`, `undefined: Client`).
+
+- [ ] **Step 3: Implement** — create `internal/forge/gitlab/gitlab.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  // Package gitlab is RunLore's GitLab forge client (curation + re-investigation)
+  // over the GitLab REST API v4, authenticated with a project access token. It
+  // serves gitlab.com AND self-hosted GitLab (baseURL override) and satisfies the
+  // same consumer surfaces as the GitHub client: providers.CurationForge /
+  // providers.ReinvestForge / curate.Forge / curate.ContestedForge /
+  // curate.RetireForge.
+  //
+  // One structural difference from GitHub is load-bearing everywhere here:
+  // GitHub shares a single number space between issues and PRs; GitLab numbers
+  // merge requests and issues independently (MR !5 and issue #5 are different
+  // artifacts). The consumer interfaces pass a bare int, so this client keeps a
+  // per-artifact kind memo — see kindOf.
+  package gitlab
+
+  import (
+      "bytes"
+      "context"
+      "encoding/json"
+      "errors"
+      "fmt"
+      "io"
+      "net/http"
+      "net/url"
+      "strings"
+      "sync"
+      "time"
+
+      forge "github.com/Smana/runlore/internal/forge"
+      "github.com/Smana/runlore/internal/httpx"
+      "github.com/Smana/runlore/internal/providers"
+  )
+
+  // TokenFunc returns a valid token. In production this is a static project
+  // access token read from the env once; the indirection matches the GitHub
+  // client's TokenFunc so app wiring stays uniform across providers.
+  type TokenFunc func(ctx context.Context) (string, error)
+
+  // DefaultBaseURL is public gitlab.com. Override for self-hosted GitLab
+  // (e.g. https://gitlab.example.com) or tests. Unlike the GitHub client's
+  // DefaultBaseURL, this is the WEB host — the client appends /api/v4 itself,
+  // so config stays "the URL you open in a browser".
+  const DefaultBaseURL = "https://gitlab.com"
+
+  type artifactKind int
+
+  const (
+      kindUnknown artifactKind = iota
+      kindMR
+      kindIssue
+  )
+
+  // Client is a GitLab forge client scoped to one project.
+  type Client struct {
+      baseURL    string // https://host, no /api/v4 suffix
+      project    string // full project path ("group/sub/repo"); URL-encoded on use
+      baseBranch string
+      token      TokenFunc
+      http       *http.Client
+
+      mu    sync.Mutex
+      kinds map[int]artifactKind // iid → namespace memo; see kindOf
+  }
+
+  var (
+      _ providers.CurationForge = (*Client)(nil)
+      _ providers.ReinvestForge = (*Client)(nil)
+  )
+
+  // New builds a client. baseURL may be empty (defaults to DefaultBaseURL);
+  // project is the FULL project path (nested groups allowed); baseBranch is the
+  // MR target (e.g. "main").
+  func New(baseURL, project, baseBranch string, token TokenFunc) *Client {
+      if baseURL == "" {
+          baseURL = DefaultBaseURL
+      }
+      return &Client{
+          baseURL: strings.TrimRight(baseURL, "/"), project: project,
+          baseBranch: baseBranch, token: token,
+          http:  httpx.SecureClient(30 * time.Second),
+          kinds: make(map[int]artifactKind),
+      }
+  }
+
+  // proj is the URL-encoded project path used as the :id in every API route.
+  func (c *Client) proj() string { return url.PathEscape(c.project) }
+
+  func (c *Client) base() string {
+      if c.baseBranch == "" {
+          return "main"
+      }
+      return c.baseBranch
+  }
+
+  // statusError carries the HTTP status so callers can branch on 404 (kindOf's
+  // MR-endpoint probe, getFile's optional bundle files) without string-matching.
+  type statusError struct {
+      status int
+      msg    string
+  }
+
+  func (e *statusError) Error() string { return e.msg }
+
+  func isNotFound(err error) bool {
+      var se *statusError
+      return errors.As(err, &se) && se.status == http.StatusNotFound
+  }
+
+  // do performs an authenticated JSON request and decodes the response into out
+  // (if non-nil). Non-2xx maps to a statusError whose message names the config
+  // knob to check — a 401 against a self-hosted instance must say "rotate the
+  // token", not just echo a status code.
+  func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+      tok, err := c.token(ctx)
+      if err != nil {
+          return fmt.Errorf("token: %w", err)
+      }
+      var rdr io.Reader
+      if body != nil {
+          b, err := json.Marshal(body)
+          if err != nil {
+              return err
+          }
+          rdr = bytes.NewReader(b)
+      }
+      req, err := http.NewRequestWithContext(ctx, method, c.baseURL+"/api/v4"+path, rdr)
+      if err != nil {
+          return err
+      }
+      req.Header.Set("PRIVATE-TOKEN", tok)
+      if body != nil {
+          req.Header.Set("Content-Type", "application/json")
+      }
+      resp, err := c.http.Do(req)
+      if err != nil {
+          return err
+      }
+      defer func() { _ = resp.Body.Close() }()
+      data, _ := io.ReadAll(resp.Body)
+      if resp.StatusCode/100 != 2 {
+          hint := ""
+          switch resp.StatusCode {
+          case http.StatusUnauthorized:
+              hint = " (token rejected — check forge.gitlab.token_env: expired, revoked, or missing the api scope)"
+          case http.StatusForbidden:
+              hint = " (token lacks permission — the project access token needs the Developer role)"
+          case http.StatusNotFound:
+              hint = " (not found — check forge.kb_repo is the full project path and the token's project can see it)"
+          }
+          return &statusError{status: resp.StatusCode,
+              msg: fmt.Sprintf("gitlab %s %s: status %d%s: %s", method, path, resp.StatusCode, hint, string(data[:min(len(data), 512)]))}
+      }
+      if out != nil {
+          return json.Unmarshal(data, out)
+      }
+      return nil
+  }
+
+  func (c *Client) remember(iid int, k artifactKind) {
+      c.mu.Lock()
+      c.kinds[iid] = k
+      c.mu.Unlock()
+  }
+
+  // OpenIssue files an issue describing the investigation. Unlike GitHub, labels
+  // are set at creation (comma-joined) — no follow-up labelling call.
+  func (c *Client) OpenIssue(ctx context.Context, inv providers.Investigation) (providers.Ref, error) {
+      body := map[string]any{
+          "title":       forge.IssueTitle(inv),
+          "description": forge.IssueBody(inv),
+          "labels":      strings.Join(forge.LifecycleLabels, ","),
+      }
+      var out struct {
+          IID    int    `json:"iid"`
+          WebURL string `json:"web_url"`
+      }
+      if err := c.do(ctx, http.MethodPost, "/projects/"+c.proj()+"/issues", body, &out); err != nil {
+          return providers.Ref{}, err
+      }
+      c.remember(out.IID, kindIssue)
+      return providers.Ref{URL: out.WebURL}, nil
+  }
+  ```
+
+  (The two `var _` interface pins will not compile until Tasks 4-6 add the remaining methods — for THIS task only, comment out the `providers.ReinvestForge` pin and re-enable it in Task 6. `providers.CurationForge` pins in Task 6 too; keep both commented with a `// TODO(M2 Task 6): re-enable` marker so the suite stays runnable per-task.)
+
+- [ ] **Step 4: Run — expect PASS**
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/forge/gitlab
+  git commit -m "feat(forge): GitLab client core — project-token auth, error mapping, OpenIssue"
+  ```
+
+### Task 4: Listings — open MRs/issues by label, closed-unmerged MRs, pagination
+
+**Files:**
+- Modify: `internal/forge/gitlab/gitlab.go`
+- Test: `internal/forge/gitlab/gitlab_test.go` (append)
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+  ```go
+  func TestListPRsByLabel(t *testing.T) {
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          if r.URL.EscapedPath() != "/api/v4/projects/g%2Fp/merge_requests" ||
+              r.URL.Query().Get("labels") != "runlore" || r.URL.Query().Get("state") != "opened" {
+              t.Fatalf("unexpected request: %s?%s", r.URL.EscapedPath(), r.URL.RawQuery)
+          }
+          // GitLab labels are a plain string array; description is the MR body.
+          _, _ = w.Write([]byte(`[
+            {"iid":48,"title":"KB: HarborRegistryDown","description":"b <!-- runlore-fingerprint: abc123 -->",
+             "labels":["runlore","triggered"],"state":"opened","updated_at":"2026-06-01T12:00:00Z",
+             "web_url":"https://gitlab.example.com/g/p/-/merge_requests/48"}
+          ]`))
+      }))
+      defer srv.Close()
+
+      c := New(srv.URL, "g/p", "main", staticToken())
+      prs, err := c.ListPRsByLabel(context.Background(), "runlore")
+      if err != nil {
+          t.Fatalf("ListPRsByLabel: %v", err)
+      }
+      if len(prs) != 1 || prs[0].Number != 48 || prs[0].Title != "KB: HarborRegistryDown" {
+          t.Fatalf("want MR !48, got %+v", prs)
+      }
+      if len(prs[0].Labels) != 2 || prs[0].Labels[0] != "runlore" {
+          t.Fatalf("labels not parsed: %+v", prs[0].Labels)
+      }
+      if prs[0].UpdatedAt.IsZero() {
+          t.Fatalf("updated_at not parsed: %+v", prs[0])
+      }
+      if got := providers.ParseFingerprintMarker(prs[0].Body); got != "abc123" {
+          t.Fatalf("description must map to CuratedIssue.Body (fingerprint dedup reads it), got %q", got)
+      }
+  }
+
+  func TestListIssuesByLabel(t *testing.T) {
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          if r.URL.EscapedPath() != "/api/v4/projects/g%2Fp/issues" || r.URL.Query().Get("state") != "opened" {
+              t.Fatalf("unexpected request: %s?%s", r.URL.EscapedPath(), r.URL.RawQuery)
+          }
+          _, _ = w.Write([]byte(`[
+            {"iid":39,"title":"Knowledge gap: harbor cascades","description":"b","labels":["runlore"],
+             "state":"opened","updated_at":"2026-06-02T08:00:00Z"}
+          ]`))
+      }))
+      defer srv.Close()
+
+      c := New(srv.URL, "g/p", "main", staticToken())
+      issues, err := c.ListIssuesByLabel(context.Background(), "runlore")
+      if err != nil {
+          t.Fatalf("ListIssuesByLabel: %v", err)
+      }
+      if len(issues) != 1 || issues[0].Number != 39 {
+          t.Fatalf("want issue #39, got %+v", issues)
+      }
+  }
+
+  func TestListClosedUnmergedPRsByLabel(t *testing.T) {
+      // GitLab MR states are opened/closed/merged/locked — state=closed IS the
+      // closed-without-merge (human-rejected) set; no search API needed.
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          if r.URL.Query().Get("state") != "closed" || r.URL.Query().Get("labels") != "runlore" {
+              t.Fatalf("unexpected query: %s", r.URL.RawQuery)
+          }
+          _, _ = w.Write([]byte(`[
+            {"iid":50,"title":"KB: rejected entry","description":"b","labels":["runlore","not-kb-worthy"],
+             "state":"closed","updated_at":"2026-06-01T12:00:00Z"}
+          ]`))
+      }))
+      defer srv.Close()
+
+      c := New(srv.URL, "g/p", "main", staticToken())
+      prs, err := c.ListClosedUnmergedPRsByLabel(context.Background(), "runlore")
+      if err != nil {
+          t.Fatalf("ListClosedUnmergedPRsByLabel: %v", err)
+      }
+      if len(prs) != 1 || prs[0].Number != 50 || prs[0].Labels[1] != "not-kb-worthy" {
+          t.Fatalf("want closed MR !50, got %+v", prs)
+      }
+  }
+
+  func TestListPRsByLabelPaginates(t *testing.T) {
+      // Page 1 returns a full page (100) → the client must fetch page 2. Same
+      // silent-truncation guard as the GitHub client (github.go:193-211).
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          switch r.URL.Query().Get("page") {
+          case "1":
+              items := make([]string, 100)
+              for i := range items {
+                  items[i] = fmt.Sprintf(`{"iid":%d,"title":"KB: t%d","labels":["runlore"],"state":"opened"}`, i+1, i+1)
+              }
+              _, _ = w.Write([]byte(`[` + strings.Join(items, ",") + `]`))
+          case "2":
+              _, _ = w.Write([]byte(`[{"iid":101,"title":"KB: t101","labels":["runlore"],"state":"opened"}]`))
+          default:
+              _, _ = w.Write([]byte(`[]`))
+          }
+      }))
+      defer srv.Close()
+
+      c := New(srv.URL, "g/p", "main", staticToken())
+      prs, err := c.ListPRsByLabel(context.Background(), "runlore")
+      if err != nil {
+          t.Fatalf("ListPRsByLabel: %v", err)
+      }
+      if len(prs) != 101 || prs[100].Number != 101 {
+          t.Fatalf("pagination lost items: got %d", len(prs))
+      }
+  }
+  ```
+
+  (Add `"fmt"` to the test imports.)
+
+- [ ] **Step 2: Run — expect FAIL** (`undefined: (*Client).ListPRsByLabel` etc.)
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+- [ ] **Step 3: Implement** — append to `gitlab.go`:
+
+  ```go
+  // rawItem is one entry from the MR or issue collection endpoints. GitLab keeps
+  // the two collections separate (no pull_request-marker filtering, unlike
+  // GitHub's shared issues endpoint) and serves labels as a plain string array.
+  type rawItem struct {
+      IID         int       `json:"iid"`
+      Title       string    `json:"title"`
+      Description string    `json:"description"`
+      Labels      []string  `json:"labels"`
+      State       string    `json:"state"`
+      UpdatedAt   time.Time `json:"updated_at"`
+  }
+
+  func (ri rawItem) curated() providers.CuratedIssue {
+      return providers.CuratedIssue{Number: ri.IID, Title: ri.Title, Body: ri.Description,
+          Labels: ri.Labels, UpdatedAt: ri.UpdatedAt}
+  }
+
+  // listAll fetches ALL pages of a collection endpoint (GitLab caps a page at 100).
+  // Without the loop the curate passes would be blind past the first 100 — the
+  // same silent-truncation hazard the GitHub client guards against.
+  func (c *Client) listAll(ctx context.Context, base string) ([]rawItem, error) {
+      var all []rawItem
+      for page := 1; ; page++ {
+          var raw []rawItem
+          if err := c.do(ctx, http.MethodGet, fmt.Sprintf("%s&per_page=100&page=%d", base, page), nil, &raw); err != nil {
+              return nil, err
+          }
+          all = append(all, raw...)
+          if len(raw) < 100 { // last page (a full page is exactly 100)
+              break
+          }
+      }
+      return all, nil
+  }
+
+  func (c *Client) listCurated(ctx context.Context, base string, kind artifactKind) ([]providers.CuratedIssue, error) {
+      raw, err := c.listAll(ctx, base)
+      if err != nil {
+          return nil, err
+      }
+      out := make([]providers.CuratedIssue, 0, len(raw))
+      for _, ri := range raw {
+          c.remember(ri.IID, kind)
+          out = append(out, ri.curated())
+      }
+      return out, nil
+  }
+
+  // ListPRsByLabel returns all open merge requests carrying the label.
+  func (c *Client) ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+      return c.listCurated(ctx,
+          fmt.Sprintf("/projects/%s/merge_requests?state=opened&labels=%s", c.proj(), url.QueryEscape(label)), kindMR)
+  }
+
+  // ListIssuesByLabel returns all open issues carrying the label. GitLab's issues
+  // endpoint returns only issues — no PR filtering needed.
+  func (c *Client) ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+      return c.listCurated(ctx,
+          fmt.Sprintf("/projects/%s/issues?state=opened&labels=%s", c.proj(), url.QueryEscape(label)), kindIssue)
+  }
+
+  // ListClosedUnmergedPRsByLabel returns closed-but-not-merged MRs carrying the
+  // label — the KB entries a human deliberately rejected (drives the curate
+  // suppression set). GitLab models "merged" as its own MR state, so
+  // state=closed is exactly the closed-unmerged set: server-side filtering with
+  // no search API and no MergedAt backstop needed.
+  func (c *Client) ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error) {
+      return c.listCurated(ctx,
+          fmt.Sprintf("/projects/%s/merge_requests?state=closed&labels=%s", c.proj(), url.QueryEscape(label)), kindMR)
+  }
+  ```
+
+- [ ] **Step 4: Run — expect PASS**
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/forge/gitlab
+  git commit -m "feat(forge): GitLab listings — open MRs/issues, closed-unmerged MRs, pagination"
+  ```
+
+### Task 5: Comment / Close / ReplaceLabel / notes / IsPROpen across the split iid namespaces
+
+**Files:**
+- Modify: `internal/forge/gitlab/gitlab.go`
+- Test: `internal/forge/gitlab/gitlab_test.go` (append)
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+  ```go
+  // fakeProject wires a minimal stateful GitLab: MR !48 exists and is open,
+  // issue #39 exists; note posts and updates are recorded per namespace.
+  func fakeProject(t *testing.T) (*httptest.Server, *[]string) {
+      t.Helper()
+      var calls []string
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          p := r.URL.EscapedPath()
+          calls = append(calls, r.Method+" "+p)
+          switch {
+          case p == "/api/v4/projects/g%2Fp/merge_requests/48" && r.Method == http.MethodGet:
+              _, _ = w.Write([]byte(`{"iid":48,"state":"opened","title":"KB: X"}`))
+          case p == "/api/v4/projects/g%2Fp/merge_requests/39" && r.Method == http.MethodGet:
+              w.WriteHeader(http.StatusNotFound) // 39 is an issue, not an MR
+              _, _ = w.Write([]byte(`{"message":"404 Not found"}`))
+          case strings.HasPrefix(p, "/api/v4/projects/g%2Fp/merge_requests/48/notes"):
+              if r.Method == http.MethodGet {
+                  _, _ = w.Write([]byte(`[
+                    {"id":301,"body":"human review comment","system":false},
+                    {"id":302,"body":"added runlore label","system":true},
+                    {"id":303,"body":"dup notice <!-- runlore-contested: k1 -->","system":false}
+                  ]`))
+                  return
+              }
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"id":304,"body":"posted"}`))
+          case strings.HasPrefix(p, "/api/v4/projects/g%2Fp/issues/39/notes"):
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"id":305,"body":"posted"}`))
+          case p == "/api/v4/projects/g%2Fp/merge_requests/48" && r.Method == http.MethodPut:
+              _, _ = w.Write([]byte(`{"iid":48,"state":"closed"}`))
+          case p == "/api/v4/projects/g%2Fp/issues/39" && r.Method == http.MethodPut:
+              _, _ = w.Write([]byte(`{"iid":39,"state":"opened"}`))
+          default:
+              t.Fatalf("unexpected request: %s %s", r.Method, p)
+          }
+      }))
+      return srv, &calls
+  }
+
+  func TestIsPROpenAndNamespaceMemo(t *testing.T) {
+      srv, calls := fakeProject(t)
+      defer srv.Close()
+      c := New(srv.URL, "g/p", "main", staticToken())
+
+      open, err := c.IsPROpen(context.Background(), 48)
+      if err != nil || !open {
+          t.Fatalf("IsPROpen(48)=%v,%v want true", open, err)
+      }
+      // The memo learned 48 is an MR: the follow-up Comment must go straight to
+      // MR notes with NO second probe GET.
+      if err := c.Comment(context.Background(), 48, "coalesce"); err != nil {
+          t.Fatalf("Comment(48): %v", err)
+      }
+      probes := 0
+      for _, cl := range *calls {
+          if cl == "GET /api/v4/projects/g%2Fp/merge_requests/48" {
+              probes++
+          }
+      }
+      if probes != 1 {
+          t.Fatalf("want exactly 1 MR probe (IsPROpen), got %d: %v", probes, *calls)
+      }
+  }
+
+  func TestCommentFallsBackToIssueNamespace(t *testing.T) {
+      // An unknown iid probes the MR endpoint; a 404 there means "issue" —
+      // the comment lands on /issues/39/notes.
+      srv, calls := fakeProject(t)
+      defer srv.Close()
+      c := New(srv.URL, "g/p", "main", staticToken())
+      if err := c.Comment(context.Background(), 39, "reinvestigated"); err != nil {
+          t.Fatalf("Comment(39): %v", err)
+      }
+      want := "POST /api/v4/projects/g%2Fp/issues/39/notes"
+      found := false
+      for _, cl := range *calls {
+          if cl == want {
+              found = true
+          }
+      }
+      if !found {
+          t.Fatalf("comment did not reach the issue namespace: %v", *calls)
+      }
+  }
+
+  func TestListIssueCommentBodiesSkipsSystemNotes(t *testing.T) {
+      srv, _ := fakeProject(t)
+      defer srv.Close()
+      c := New(srv.URL, "g/p", "main", staticToken())
+      bodies, err := c.ListIssueCommentBodies(context.Background(), 48)
+      if err != nil {
+          t.Fatalf("ListIssueCommentBodies: %v", err)
+      }
+      // System notes (label/state churn) are noise for marker scans; the hidden
+      // idempotency marker in note 303 must survive.
+      if len(bodies) != 2 || !strings.Contains(bodies[1], "runlore-contested: k1") {
+          t.Fatalf("bodies=%q", bodies)
+      }
+  }
+
+  func TestReplaceLabelAndClose(t *testing.T) {
+      var gotMRUpdate map[string]any
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          p := r.URL.EscapedPath()
+          switch {
+          case p == "/api/v4/projects/g%2Fp/merge_requests/48" && r.Method == http.MethodGet:
+              _, _ = w.Write([]byte(`{"iid":48,"state":"opened"}`))
+          case p == "/api/v4/projects/g%2Fp/merge_requests/48" && r.Method == http.MethodPut:
+              _ = json.NewDecoder(r.Body).Decode(&gotMRUpdate)
+              _, _ = w.Write([]byte(`{"iid":48,"state":"opened"}`))
+          default:
+              t.Fatalf("unexpected request: %s %s", r.Method, p)
+          }
+      }))
+      defer srv.Close()
+      c := New(srv.URL, "g/p", "main", staticToken())
+
+      if err := c.ReplaceLabel(context.Background(), 48, "solved", "ready-to-merge"); err != nil {
+          t.Fatalf("ReplaceLabel: %v", err)
+      }
+      if gotMRUpdate["remove_labels"] != "solved" || gotMRUpdate["add_labels"] != "ready-to-merge" {
+          t.Fatalf("label update body=%v", gotMRUpdate)
+      }
+      if err := c.Close(context.Background(), 48); err != nil {
+          t.Fatalf("Close: %v", err)
+      }
+      if gotMRUpdate["state_event"] != "close" {
+          t.Fatalf("close body=%v", gotMRUpdate)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run — expect FAIL** (`undefined: (*Client).IsPROpen` etc.)
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+- [ ] **Step 3: Implement** — append to `gitlab.go`:
+
+  ```go
+  // mrState fetches an MR's state ("opened"/"closed"/"merged"/"locked").
+  func (c *Client) mrState(ctx context.Context, iid int) (string, error) {
+      var out struct {
+          State string `json:"state"`
+      }
+      if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/projects/%s/merge_requests/%d", c.proj(), iid), nil, &out); err != nil {
+          return "", err
+      }
+      return out.State, nil
+  }
+
+  // IsPROpen reports whether iid is an OPEN merge request. It hits the MR
+  // endpoint only, so an issue iid 404s instead of passing — the same
+  // cannot-be-fooled contract as the GitHub client (github.go:335-347).
+  func (c *Client) IsPROpen(ctx context.Context, number int) (bool, error) {
+      st, err := c.mrState(ctx, number)
+      if err != nil {
+          return false, err
+      }
+      c.remember(number, kindMR)
+      return st == "opened", nil
+  }
+
+  // kindOf resolves which iid namespace a number belongs to. Every consumer flow
+  // learns the number from a listing or IsPROpen on this same client before
+  // mutating it (dedup/lifecycle/queue list MRs first; reinvestigate lists
+  // issues first; contested calls IsPROpen first), so this is a memo read in
+  // practice. An unknown iid is resolved by probing the MR endpoint — 404 there
+  // means "not an MR", i.e. issue — and memoized.
+  func (c *Client) kindOf(ctx context.Context, iid int) (artifactKind, error) {
+      c.mu.Lock()
+      k := c.kinds[iid]
+      c.mu.Unlock()
+      if k != kindUnknown {
+          return k, nil
+      }
+      if _, err := c.mrState(ctx, iid); err != nil {
+          if !isNotFound(err) {
+              return kindUnknown, err
+          }
+          c.remember(iid, kindIssue)
+          return kindIssue, nil
+      }
+      c.remember(iid, kindMR)
+      return kindMR, nil
+  }
+
+  // nsPath is the REST collection for the iid's namespace.
+  func (c *Client) nsPath(ctx context.Context, iid int) (string, error) {
+      k, err := c.kindOf(ctx, iid)
+      if err != nil {
+          return "", err
+      }
+      if k == kindIssue {
+          return "issues", nil
+      }
+      return "merge_requests", nil
+  }
+
+  // Comment posts a note on an issue or MR.
+  func (c *Client) Comment(ctx context.Context, number int, body string) error {
+      ns, err := c.nsPath(ctx, number)
+      if err != nil {
+          return err
+      }
+      return c.do(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/%s/%d/notes", c.proj(), ns, number),
+          map[string]any{"body": body}, nil)
+  }
+
+  // ListIssueCommentBodies fetches ALL pages of an issue/MR's note bodies.
+  // System notes (label churn, state events — GitLab auto-notes) are skipped:
+  // callers scan bodies for hidden idempotency markers, and only human/bot
+  // comments carry them; pagination matters for the same
+  // marker-past-page-1-would-repost-forever reason as GitHub (github.go:315-333).
+  func (c *Client) ListIssueCommentBodies(ctx context.Context, number int) ([]string, error) {
+      ns, err := c.nsPath(ctx, number)
+      if err != nil {
+          return nil, err
+      }
+      var out []string
+      for page := 1; ; page++ {
+          var raw []struct {
+              Body   string `json:"body"`
+              System bool   `json:"system"`
+          }
+          path := fmt.Sprintf("/projects/%s/%s/%d/notes?per_page=100&page=%d", c.proj(), ns, number, page)
+          if err := c.do(ctx, http.MethodGet, path, nil, &raw); err != nil {
+              return nil, err
+          }
+          for _, r := range raw {
+              if r.System {
+                  continue
+              }
+              out = append(out, r.Body)
+          }
+          if len(raw) < 100 { // last page (a full page is exactly 100)
+              break
+          }
+      }
+      return out, nil
+  }
+
+  // ReplaceLabel removes one label and adds another in a single update call
+  // (GitLab's add_labels/remove_labels params — no separate label endpoints).
+  // Either side may be empty; removing an absent label is a server-side no-op,
+  // matching the GitHub client's best-effort removal.
+  func (c *Client) ReplaceLabel(ctx context.Context, number int, remove, add string) error {
+      if remove == "" && add == "" {
+          return nil
+      }
+      ns, err := c.nsPath(ctx, number)
+      if err != nil {
+          return err
+      }
+      body := map[string]any{}
+      if remove != "" {
+          body["remove_labels"] = remove
+      }
+      if add != "" {
+          body["add_labels"] = add
+      }
+      return c.do(ctx, http.MethodPut, fmt.Sprintf("/projects/%s/%s/%d", c.proj(), ns, number), body, nil)
+  }
+
+  // Close closes an issue or MR via its namespace's state_event.
+  func (c *Client) Close(ctx context.Context, number int) error {
+      ns, err := c.nsPath(ctx, number)
+      if err != nil {
+          return err
+      }
+      return c.do(ctx, http.MethodPut, fmt.Sprintf("/projects/%s/%s/%d", c.proj(), ns, number),
+          map[string]any{"state_event": "close"}, nil)
+  }
+  ```
+
+  Re-enable the `var _ providers.ReinvestForge = (*Client)(nil)` pin from Task 3.
+
+- [ ] **Step 4: Run — expect PASS**
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/forge/gitlab
+  git commit -m "feat(forge): GitLab comment/label/close across the split iid namespaces"
+  ```
+
+### Task 6: `OpenPR` — branch, OKF entry file, bundle maintenance, MR
+
+**Files:**
+- Create: `internal/forge/gitlab/files.go` (files API + bundle)
+- Modify: `internal/forge/gitlab/gitlab.go` (OpenPR, blobURL, interface pins)
+- Test: `internal/forge/gitlab/openpr_test.go`
+
+- [ ] **Step 1: Write the failing test** — create `internal/forge/gitlab/openpr_test.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package gitlab
+
+  import (
+      "context"
+      "encoding/base64"
+      "encoding/json"
+      "net/http"
+      "net/http/httptest"
+      "strings"
+      "testing"
+
+      "github.com/Smana/runlore/internal/providers"
+  )
+
+  func TestOpenPR(t *testing.T) {
+      var branchQuery string
+      var fileBody, mrBody map[string]any
+      var filePath string
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          p := r.URL.EscapedPath()
+          switch {
+          case p == "/api/v4/projects/g%2Fp/repository/branches" && r.Method == http.MethodPost:
+              branchQuery = r.URL.RawQuery
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"name":"runlore/kb-harbor-registry-down-1753272000","commit":{"id":"deadbeef"}}`))
+          case strings.HasPrefix(p, "/api/v4/projects/g%2Fp/repository/files/") && r.Method == http.MethodGet:
+              // bundle probe: neither index.md nor log.md exists in this repo
+              w.WriteHeader(http.StatusNotFound)
+              _, _ = w.Write([]byte(`{"message":"404 File Not Found"}`))
+          case strings.HasPrefix(p, "/api/v4/projects/g%2Fp/repository/files/incidents%2F") && r.Method == http.MethodPost:
+              filePath = p
+              _ = json.NewDecoder(r.Body).Decode(&fileBody)
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"file_path":"incidents/harbor-registry-down-abc12345.md","branch":"runlore/kb-harbor-registry-down-1753272000"}`))
+          case strings.HasPrefix(p, "/api/v4/projects/g%2Fp/repository/files/log.md") && r.Method == http.MethodPost:
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"file_path":"log.md"}`))
+          case p == "/api/v4/projects/g%2Fp/merge_requests" && r.Method == http.MethodPost:
+              _ = json.NewDecoder(r.Body).Decode(&mrBody)
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"id":900,"iid":5,"state":"opened",
+                "title":"KB: Harbor registry down",
+                "web_url":"https://gitlab.example.com/g/p/-/merge_requests/5"}`))
+          default:
+              t.Fatalf("unexpected request: %s %s", r.Method, p)
+          }
+      }))
+      defer srv.Close()
+
+      c := New(srv.URL, "g/p", "main", staticToken())
+      ref, err := c.OpenPR(context.Background(), providers.KBEntry{
+          Type: "Incident", Title: "Harbor registry down",
+          Description: "registry pods crashloop on bad secret",
+          Resource:    "tooling/harbor-registry",
+          Body:        "## Cause\nbad secret ![beacon](https://evil/x)\n",
+          Fingerprint: "abc12345ffff",
+          Related: []providers.RelatedEntry{{Path: "incidents/old.md", Title: "Old harbor incident", Score: 6.2}},
+      })
+      if err != nil {
+          t.Fatalf("OpenPR: %v", err)
+      }
+      if ref.URL != "https://gitlab.example.com/g/p/-/merge_requests/5" {
+          t.Fatalf("ref=%s", ref.URL)
+      }
+      // Branch off main, under runlore/.
+      if !strings.Contains(branchQuery, "ref=main") || !strings.Contains(branchQuery, "branch=runlore%2Fkb-harbor-registry-down-") {
+          t.Fatalf("branch query=%q", branchQuery)
+      }
+      // Entry path: type dir + slug + 8-char fingerprint, URL-encoded in the route.
+      if !strings.HasSuffix(filePath, "incidents%2Fharbor-registry-down-abc12345.md") {
+          t.Fatalf("file path=%q", filePath)
+      }
+      // File content is base64 OKF markdown with the image neutralized.
+      raw, _ := base64.StdEncoding.DecodeString(fileBody["content"].(string))
+      if !strings.HasPrefix(string(raw), "---\n") || strings.Contains(string(raw), "](https://evil/x)") {
+          t.Fatalf("entry content unsafe or not OKF: %q", raw)
+      }
+      if fileBody["encoding"] != "base64" {
+          t.Fatalf("encoding=%v", fileBody["encoding"])
+      }
+      // MR: labels at creation, description carries the related-knowledge blob link.
+      if mrBody["labels"] != "runlore,triggered" || mrBody["target_branch"] != "main" {
+          t.Fatalf("mr body=%v", mrBody)
+      }
+      if !strings.Contains(mrBody["description"].(string), "/g/p/-/blob/main/incidents/old.md") {
+          t.Fatalf("related blob URL missing: %v", mrBody["description"])
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run — expect FAIL** (`undefined: (*Client).OpenPR`)
+
+  ```bash
+  go test ./internal/forge/gitlab/ -run TestOpenPR
+  ```
+
+- [ ] **Step 3: Implement the files API** — create `internal/forge/gitlab/files.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package gitlab
+
+  // Repository-files API + OKF bundle maintenance. GitLab needs no blob SHA for
+  // updates (the branch head is the implicit precondition), so this is simpler
+  // than the GitHub contents API — but the best-effort contract is identical:
+  // a bundle-maintenance failure must never lose the entry MR.
+
+  import (
+      "context"
+      "encoding/base64"
+      "fmt"
+      "net/http"
+      "net/url"
+      "strings"
+      "time"
+
+      forge "github.com/Smana/runlore/internal/forge"
+      "github.com/Smana/runlore/internal/providers"
+  )
+
+  func (c *Client) filePath(path string) string {
+      return fmt.Sprintf("/projects/%s/repository/files/%s", c.proj(), url.PathEscape(path))
+  }
+
+  // getFile reads a file's content at ref. A 404 is not an error: found=false
+  // says "the bundle doesn't have this file" (same contract as the GitHub
+  // client's getFile, github/bundle.go:115-153).
+  func (c *Client) getFile(ctx context.Context, path, ref string) (data []byte, found bool, err error) {
+      var out struct {
+          Content string `json:"content"` // base64
+      }
+      if err := c.do(ctx, http.MethodGet, c.filePath(path)+"?ref="+url.QueryEscape(ref), nil, &out); err != nil {
+          if isNotFound(err) {
+              return nil, false, nil
+          }
+          return nil, false, err
+      }
+      raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(out.Content, "\n", ""))
+      if err != nil {
+          return nil, false, err
+      }
+      return raw, true, nil
+  }
+
+  // createFile writes a NEW file on branch (POST); updateFile overwrites an
+  // existing one (PUT). GitLab 400s a POST for an existing path and a PUT for a
+  // missing one, so the caller must know which it holds (getFile tells it).
+  func (c *Client) createFile(ctx context.Context, path, branch, message string, content []byte) error {
+      return c.writeFile(ctx, http.MethodPost, path, branch, message, content)
+  }
+
+  func (c *Client) updateFile(ctx context.Context, path, branch, message string, content []byte) error {
+      return c.writeFile(ctx, http.MethodPut, path, branch, message, content)
+  }
+
+  func (c *Client) writeFile(ctx context.Context, method, path, branch, message string, content []byte) error {
+      return c.do(ctx, method, c.filePath(path), map[string]any{
+          "branch":         branch,
+          "encoding":       "base64",
+          "content":        base64.StdEncoding.EncodeToString(content),
+          "commit_message": message,
+      }, nil)
+  }
+
+  // maintainBundle updates index.md (only when the bundle already has one — its
+  // structure is the owner's choice) and creates/appends log.md on the MR
+  // branch. Best-effort by contract: the caller ignores the returned error
+  // beyond logging (same as the GitHub client, github/bundle.go:26-46).
+  func (c *Client) maintainBundle(ctx context.Context, e providers.KBEntry, entryPath, branch string) error {
+      date := time.Now().UTC().Format("2006-01-02")
+
+      idx, found, err := c.getFile(ctx, "index.md", branch)
+      if err != nil {
+          return fmt.Errorf("read index.md: %w", err)
+      }
+      if found {
+          if err := c.updateFile(ctx, "index.md", branch, "runlore: index "+e.Title,
+              forge.UpdateIndex(idx, e, entryPath)); err != nil {
+              return err
+          }
+      }
+
+      logMD, logFound, err := c.getFile(ctx, "log.md", branch)
+      if err != nil {
+          return fmt.Errorf("read log.md: %w", err)
+      }
+      put := c.createFile
+      if logFound {
+          put = c.updateFile
+      }
+      return put(ctx, "log.md", branch, "runlore: log "+e.Title, forge.UpdateLog(logMD, e, entryPath, date))
+  }
+  ```
+
+- [ ] **Step 4: Implement `OpenPR` + `blobURL`** — append to `gitlab.go`:
+
+  ```go
+  // createBranch creates branch off ref (GitLab takes both as query params).
+  func (c *Client) createBranch(ctx context.Context, branch, ref string) error {
+      return c.do(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/repository/branches?branch=%s&ref=%s",
+          c.proj(), url.QueryEscape(branch), url.QueryEscape(ref)), nil, nil)
+  }
+
+  // openMR opens a merge request with labels set at creation.
+  func (c *Client) openMR(ctx context.Context, branch, title, description string, labels []string) (providers.Ref, error) {
+      var out struct {
+          IID    int    `json:"iid"`
+          WebURL string `json:"web_url"`
+      }
+      if err := c.do(ctx, http.MethodPost, "/projects/"+c.proj()+"/merge_requests", map[string]any{
+          "source_branch": branch,
+          "target_branch": c.base(),
+          "title":         title,
+          "description":   description,
+          "labels":        strings.Join(labels, ","),
+      }, &out); err != nil {
+          return providers.Ref{}, err
+      }
+      c.remember(out.IID, kindMR)
+      return providers.Ref{URL: out.WebURL}, nil
+  }
+
+  // OpenPR drafts the KB entry on a new branch and opens a merge request —
+  // step-for-step the GitHub OpenPR flow (github.go:113-159), minus the
+  // separate labelling call (labels ride the MR-create body).
+  func (c *Client) OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref, error) {
+      slug := forge.Slugify(e.Title)
+      now := time.Now().Unix()
+      branch := fmt.Sprintf("runlore/kb-%s-%d", slug, now)
+      path := forge.EntryPath(e, slug, now)
+
+      // 1. create the branch off the base.
+      if err := c.createBranch(ctx, branch, c.base()); err != nil {
+          return providers.Ref{}, err
+      }
+      // 2. write the OKF file on the branch.
+      if err := c.createFile(ctx, path, branch, "runlore: draft KB entry "+e.Title,
+          []byte(forge.RenderEntry(e))); err != nil {
+          return providers.Ref{}, err
+      }
+      // 3. bundle maintenance — best-effort, must not lose the entry MR.
+      _ = c.maintainBundle(ctx, e, path, branch)
+      // 4. open the MR (labels at creation).
+      return c.openMR(ctx, branch, "KB: "+e.Title, forge.PRBody(e, c.blobURL), forge.LifecycleLabels)
+  }
+
+  // blobURL is the web URL of a catalog file on the base branch:
+  // https://<host>/<project>/-/blob/<branch>/<path>. GitLab web routes use the
+  // literal (un-encoded) project path with the /-/ separator.
+  func (c *Client) blobURL(path string) string {
+      return fmt.Sprintf("%s/%s/-/blob/%s/%s", c.baseURL, c.project, c.base(), path)
+  }
+  ```
+
+  Re-enable the `var _ providers.CurationForge = (*Client)(nil)` pin from Task 3.
+
+- [ ] **Step 5: Run — expect PASS**
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add internal/forge/gitlab
+  git commit -m "feat(forge): GitLab OpenPR — branch, OKF entry file, bundle maintenance, MR"
+  ```
+
+### Task 7: `OpenRetirePR`
+
+**Files:**
+- Create: `internal/forge/gitlab/retire.go`
+- Test: `internal/forge/gitlab/retire_test.go`
+
+- [ ] **Step 1: Write the failing test** — create `internal/forge/gitlab/retire_test.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package gitlab
+
+  import (
+      "context"
+      "encoding/base64"
+      "encoding/json"
+      "errors"
+      "net/http"
+      "net/http/httptest"
+      "strings"
+      "testing"
+
+      forge "github.com/Smana/runlore/internal/forge"
+      "github.com/Smana/runlore/internal/curate"
+  )
+
+  // Compile-time: the GitLab client serves every curate pass the GitHub client does.
+  var (
+      _ curate.Forge          = (*Client)(nil)
+      _ curate.ContestedForge = (*Client)(nil)
+      _ curate.RetireForge    = (*Client)(nil)
+  )
+
+  func retireServer(t *testing.T, entryB64 string) (*httptest.Server, *map[string]any) {
+      t.Helper()
+      var putBody map[string]any
+      srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+          p := r.URL.EscapedPath()
+          switch {
+          case p == "/api/v4/projects/g%2Fp/repository/files/incidents%2Fa.md" && r.Method == http.MethodGet:
+              _, _ = w.Write([]byte(`{"file_name":"a.md","content":"` + entryB64 + `","encoding":"base64","ref":"main"}`))
+          case p == "/api/v4/projects/g%2Fp/repository/branches" && r.Method == http.MethodPost:
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"name":"runlore/retire-incidents-a-md-1753272000"}`))
+          case p == "/api/v4/projects/g%2Fp/repository/files/incidents%2Fa.md" && r.Method == http.MethodPut:
+              _ = json.NewDecoder(r.Body).Decode(&putBody)
+              _, _ = w.Write([]byte(`{"file_path":"incidents/a.md"}`))
+          case p == "/api/v4/projects/g%2Fp/merge_requests" && r.Method == http.MethodPost:
+              w.WriteHeader(http.StatusCreated)
+              _, _ = w.Write([]byte(`{"iid":9,"web_url":"https://gitlab.example.com/g/p/-/merge_requests/9"}`))
+          default:
+              t.Fatalf("unexpected request: %s %s", r.Method, p)
+          }
+      }))
+      return srv, &putBody
+  }
+
+  func TestOpenRetirePR(t *testing.T) {
+      entry := "---\ntype: Incident\ntitle: A\n---\n\nbody\n"
+      srv, putBody := retireServer(t, base64.StdEncoding.EncodeToString([]byte(entry)))
+      defer srv.Close()
+
+      c := New(srv.URL, "g/p", "main", staticToken())
+      ref, err := c.OpenRetirePR(context.Background(), "incidents/a.md", "track record <!-- runlore-retire: incidents/a.md -->")
+      if err != nil {
+          t.Fatalf("OpenRetirePR: %v", err)
+      }
+      if ref.URL != "https://gitlab.example.com/g/p/-/merge_requests/9" {
+          t.Fatalf("ref=%s", ref.URL)
+      }
+      raw, _ := base64.StdEncoding.DecodeString((*putBody)["content"].(string))
+      if !strings.Contains(string(raw), "status: retired") {
+          t.Fatalf("frontmatter not stamped: %q", raw)
+      }
+  }
+
+  func TestOpenRetirePRAlreadyRetired(t *testing.T) {
+      entry := "---\nstatus: retired\ntype: Incident\ntitle: A\n---\n\nbody\n"
+      srv, _ := retireServer(t, base64.StdEncoding.EncodeToString([]byte(entry)))
+      defer srv.Close()
+
+      c := New(srv.URL, "g/p", "main", staticToken())
+      _, err := c.OpenRetirePR(context.Background(), "incidents/a.md", "b")
+      if !errors.Is(err, forge.ErrAlreadyRetired) {
+          t.Fatalf("want ErrAlreadyRetired (curate treats it as done-skip), got %v", err)
+      }
+  }
+  ```
+
+- [ ] **Step 2: Run — expect FAIL** (`undefined: (*Client).OpenRetirePR`)
+
+  ```bash
+  go test ./internal/forge/gitlab/ -run TestOpenRetirePR
+  ```
+
+- [ ] **Step 3: Implement** — create `internal/forge/gitlab/retire.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package gitlab
+
+  import (
+      "context"
+      "fmt"
+      "time"
+
+      forge "github.com/Smana/runlore/internal/forge"
+      "github.com/Smana/runlore/internal/providers"
+  )
+
+  // OpenRetirePR opens a human-reviewed MR that stamps status:retired into an
+  // existing catalog entry's frontmatter. It never merges and never deletes — a
+  // human is the load-bearing gate. Returns forge.ErrAlreadyRetired when the
+  // entry is already retired on the base branch (the curate pass treats it as a
+  // done-skip); a missing entry file surfaces as an error (entry deleted → the
+  // pass logs and skips it). Mirrors github/retire.go:64-126.
+  func (c *Client) OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error) {
+      raw, found, err := c.getFile(ctx, entryPath, c.base())
+      if err != nil {
+          return providers.Ref{}, err
+      }
+      if !found {
+          return providers.Ref{}, fmt.Errorf("gitlab: entry %s not found on %s", entryPath, c.base())
+      }
+      stamped, already, err := forge.SetStatusRetired(raw)
+      if err != nil {
+          return providers.Ref{}, fmt.Errorf("%s: %w", entryPath, err)
+      }
+      if already {
+          return providers.Ref{}, forge.ErrAlreadyRetired
+      }
+      branch := fmt.Sprintf("runlore/retire-%s-%d", forge.Slugify(entryPath), time.Now().Unix())
+      if err := c.createBranch(ctx, branch, c.base()); err != nil {
+          return providers.Ref{}, err
+      }
+      if err := c.updateFile(ctx, entryPath, branch, "runlore: retire "+entryPath, stamped); err != nil {
+          return providers.Ref{}, err
+      }
+      return c.openMR(ctx, branch, "KB retire: "+entryPath, body, forge.RetireLabels)
+  }
+  ```
+
+- [ ] **Step 4: Run the whole package — expect PASS (interface pins prove full parity)**
+
+  ```bash
+  go test ./internal/forge/gitlab/
+  ```
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/forge/gitlab
+  git commit -m "feat(forge): GitLab OpenRetirePR — status:retired stamp behind a human-gated MR"
+  ```
+
+### Task 8: App wiring — provider-selected forge client + token source
+
+**Files:**
+- Modify: `internal/app/forge.go`, `internal/app/curator.go`, `internal/app/curate.go`, `internal/app/investigate.go` (line 403)
+- Test: `internal/app/forge_test.go` (create)
+
+- [ ] **Step 1: Write the failing test** — create `internal/app/forge_test.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package app
+
+  import (
+      "bytes"
+      "context"
+      "log/slog"
+      "testing"
+
+      "github.com/Smana/runlore/internal/config"
+      gitlab "github.com/Smana/runlore/internal/forge/gitlab"
+      github "github.com/Smana/runlore/internal/forge/github"
+  )
+
+  func testLogger() *slog.Logger {
+      return slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+  }
+
+  func TestBuildForgeClientGitLab(t *testing.T) {
+      t.Setenv("GITLAB_TOKEN_TEST", "glpat-x")
+      cfg := &config.Config{}
+      cfg.Forge.Provider = "gitlab"
+      cfg.Forge.KBRepo = "group/sub/runlore-kb" // nested path: must NOT be owner/name-split
+      cfg.Forge.GitLab.TokenEnv = "GITLAB_TOKEN_TEST"
+
+      fc := BuildForgeClient(cfg, testLogger())
+      if fc == nil {
+          t.Fatal("gitlab forge not built")
+      }
+      if _, ok := fc.(*gitlab.Client); !ok {
+          t.Fatalf("want *gitlab.Client, got %T", fc)
+      }
+      tok := BuildForgeTokenSource(cfg, testLogger())
+      if tok == nil {
+          t.Fatal("gitlab token source not built (catalog git-sync + source-diff need it)")
+      }
+      if got, _ := tok(context.Background()); got != "glpat-x" {
+          t.Fatalf("token=%q", got)
+      }
+  }
+
+  func TestBuildForgeClientGitHubDefaultUnchanged(t *testing.T) {
+      // Empty provider = github; without App credentials the forge stays off —
+      // byte-identical behavior to today for every existing config.
+      cfg := &config.Config{}
+      cfg.Forge.KBRepo = "owner/name"
+      if fc := BuildForgeClient(cfg, testLogger()); fc != nil {
+          t.Fatalf("forge must stay disabled without github_app, got %T", fc)
+      }
+      t.Setenv("GH_APP_KEY_TEST", testRSAPEM(t))
+      cfg.Forge.GitHubApp = config.GitHubApp{AppID: 1, InstallationID: 2, PrivateKeyEnv: "GH_APP_KEY_TEST"}
+      fc := BuildForgeClient(cfg, testLogger())
+      if _, ok := fc.(*github.Client); !ok {
+          t.Fatalf("want *github.Client, got %T", fc)
+      }
+  }
+
+  // testRSAPEM generates a throwaway PKCS#1 RSA key PEM for the GitHub arm.
+  func testRSAPEM(t *testing.T) string {
+      t.Helper()
+      key, err := rsa.GenerateKey(rand.Reader, 2048)
+      if err != nil {
+          t.Fatal(err)
+      }
+      return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}))
+  }
+  ```
+
+  (Add `"crypto/rand"`, `"crypto/rsa"`, `"crypto/x509"`, `"encoding/pem"` to imports.)
+
+- [ ] **Step 2: Run — expect FAIL** (`undefined: BuildForgeClient`)
+
+  ```bash
+  go test ./internal/app/ -run TestBuildForgeClient
+  ```
+
+- [ ] **Step 3: Implement** — rewrite `internal/app/forge.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package app
+
+  import (
+      "context"
+      "log/slog"
+      "os"
+      "strings"
+
+      "github.com/Smana/runlore/internal/config"
+      "github.com/Smana/runlore/internal/providers"
+
+      github "github.com/Smana/runlore/internal/forge/github"
+      gitlab "github.com/Smana/runlore/internal/forge/gitlab"
+  )
+
+  // ForgeToken yields the forge git/API credential: a minted GitHub App
+  // installation token, or a static GitLab project access token.
+  type ForgeToken func(context.Context) (string, error)
+
+  // BuildForgeTokenSource builds the credential shared by the curator (issues/
+  // PRs/MRs), catalog git-sync (clone auth), and source-diff clones — one
+  // identity for both forge writes and git reads. Returns nil when no forge
+  // auth is configured.
+  //
+  // The GitLab token needs no minting/refresh: it is a static project access
+  // token read once from the env. It works as the git HTTP password with ANY
+  // non-blank username, so catalog.Syncer.auth (catalog/sync.go:62) and
+  // whatchanged.Differ.auth (whatchanged/differ.go:143) — both of which send
+  // username "x-access-token" — need no change.
+  func BuildForgeTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
+      if cfg.Forge.Provider == "gitlab" {
+          env := cfg.Forge.GitLab.TokenEnv
+          if env == "" {
+              return nil // unreachable after config.Validate, kept for direct callers
+          }
+          tok := os.Getenv(env)
+          if tok == "" {
+              log.Warn("forge auth disabled: empty gitlab token env", "env", env)
+              return nil
+          }
+          return func(context.Context) (string, error) { return tok, nil }
+      }
+      ga := cfg.Forge.GitHubApp
+      if ga.AppID == 0 || ga.InstallationID == 0 || ga.PrivateKeyEnv == "" {
+          return nil
+      }
+      pemData := os.Getenv(ga.PrivateKeyEnv)
+      if pemData == "" {
+          log.Warn("forge auth disabled: empty private key env", "env", ga.PrivateKeyEnv)
+          return nil
+      }
+      key, err := github.ParsePrivateKey(pemData)
+      if err != nil {
+          log.Warn("forge auth disabled: bad private key", "err", err)
+          return nil
+      }
+      return github.NewAppTokenSource(cfg.Forge.GitHubAPIURL, ga.AppID, ga.InstallationID, key).Token
+  }
+
+  // ForgeClient is the full forge surface the app wires — the union of the
+  // consumer interfaces (providers.CurationForge, providers.ReinvestForge,
+  // curate.Forge, curate.ContestedForge, curate.RetireForge). Implemented by
+  // *github.Client and *gitlab.Client.
+  type ForgeClient interface {
+      OpenIssue(ctx context.Context, inv providers.Investigation) (providers.Ref, error)
+      OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref, error)
+      OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error)
+      ListIssuesByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+      ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+      ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+      ListIssueCommentBodies(ctx context.Context, number int) ([]string, error)
+      IsPROpen(ctx context.Context, number int) (bool, error)
+      Comment(ctx context.Context, number int, body string) error
+      ReplaceLabel(ctx context.Context, number int, remove, add string) error
+      Close(ctx context.Context, number int) error
+  }
+
+  var (
+      _ ForgeClient = (*github.Client)(nil)
+      _ ForgeClient = (*gitlab.Client)(nil)
+  )
+
+  // BuildForgeClient returns the provider-selected forge client, or nil when the
+  // forge is not configured. forge.provider empty/"github" keeps the exact
+  // pre-M2 GitHub behavior (owner/name split, App token); "gitlab" takes
+  // kb_repo as the FULL project path (nested groups allowed).
+  func BuildForgeClient(cfg *config.Config, log *slog.Logger) ForgeClient {
+      if cfg.Forge.KBRepo == "" {
+          return nil
+      }
+      tok := BuildForgeTokenSource(cfg, log)
+      if tok == nil {
+          return nil
+      }
+      base := cfg.Forge.BaseBranch
+      if base == "" {
+          base = "main"
+      }
+      if cfg.Forge.Provider == "gitlab" {
+          return gitlab.New(cfg.Forge.GitLab.BaseURL, cfg.Forge.KBRepo, base, gitlab.TokenFunc(tok))
+      }
+      owner, repo, ok := strings.Cut(cfg.Forge.KBRepo, "/")
+      if !ok {
+          log.Warn("forge disabled: kb_repo must be owner/name", "kb_repo", cfg.Forge.KBRepo)
+          return nil
+      }
+      return github.New(cfg.Forge.GitHubAPIURL, owner, repo, base, github.TokenFunc(tok))
+  }
+  ```
+
+- [ ] **Step 4: Rewire the three construction sites** (each currently builds `github.New` directly):
+
+  1. `internal/app/curator.go` — `BuildCurator` (lines 21-61): change the signature from `(cfg, token ForgeToken, cat, metrics, log)` to `(cfg *config.Config, client ForgeClient, cat *catalog.Catalog, metrics *telemetry.Metrics, log *slog.Logger)`; delete the `strings.Cut`/`base`/`github.New` block (lines 24-35, 54) and gate on `client == nil || cfg.Forge.KBRepo == ""`; assign `cur.Forge = client`. Update the caller at `internal/app/investigate.go:403` to `BuildCurator(cfg, BuildForgeClient(cfg, log), cat, metrics, log)`.
+  2. `internal/app/curator.go` — `BuildReinvestigator` (lines 66-104): replace lines 67-75 with `client := BuildForgeClient(cfg, log); if client == nil { return nil }` and pass `client` as `Forge` (it satisfies `providers.ReinvestForge`).
+  3. `internal/app/curate.go` — `RunCurate` (lines 43-55): replace the token/Cut/`github.New` block with:
+
+     ```go
+     forge := BuildForgeClient(cfg, log)
+     if forge == nil {
+         return fmt.Errorf("curate requires a configured forge (forge.github_app, or forge.provider: gitlab with forge.gitlab.token_env)")
+     }
+     ```
+
+     and drop the now-unused `strings` + `github` imports.
+
+- [ ] **Step 5: Full suite — expect PASS**
+
+  ```bash
+  go build ./... && go test ./internal/app/ ./internal/curate/ ./internal/curator/ ./internal/investigate/ ./internal/config/ ./internal/forge/...
+  ```
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add internal/app
+  git commit -m "feat(app): wire the GitLab forge — provider-selected client and token source"
+  ```
+
+### Task 9: Chart values + docs (getting-started GitLab section, configuration.md, design.md)
+
+**Files:**
+- Modify: `deploy/helm/runlore/values.yaml` (lines 264-267), `docs/getting-started.md` (lines 39-40, after line 164, lines 173-180, lines 337-346), `docs/configuration.md` (§ `forge`, line 283), `docs/design.md` (lines 127, 333, 523)
+
+- [ ] **Step 1: values.yaml — document the GitLab alternative.** Replace the current forge comment block (values.yaml:264-267):
+
+  ```yaml
+  # forge:
+  #   kb_repo: owner/name
+  #   base_branch: main
+  #   github_app: { app_id: 0, installation_id: 0, private_key_env: GITHUB_APP_PRIVATE_KEY }
+  ```
+
+  with:
+
+  ```yaml
+  # forge:
+  #   kb_repo: owner/name
+  #   base_branch: main
+  #   github_app: { app_id: 0, installation_id: 0, private_key_env: GITHUB_APP_PRIVATE_KEY }
+  #   # GitLab instead of GitHub (gitlab.com or self-hosted). Auth is a project
+  #   # access token referenced from the Secret by env name — same pattern as the
+  #   # GitHub App key. kb_repo becomes the FULL project path (nested groups OK).
+  #   # provider: gitlab
+  #   # kb_repo: group/subgroup/runlore-kb
+  #   # gitlab: { base_url: https://gitlab.example.com, token_env: GITLAB_TOKEN }
+  ```
+
+  Verify the chart still lints: `helm lint deploy/helm/runlore` → `1 chart(s) linted, 0 chart(s) failed` (the `config` block is schema-free — values.schema.json marks it `additionalProperties: true`).
+
+- [ ] **Step 2: getting-started.md — add Step 2b.** Insert the following section between the end of Step 2 (after line 164, before the `---` at line 166):
+
+  ````markdown
+
+  ## Step 2b — GitLab instead of GitHub (optional)
+
+  RunLore's forge is pluggable: if your knowledge base lives on **GitLab** — gitlab.com or a
+  **self-hosted GitLab instance** (the common choice for sovereignty-conscious teams) — the curator
+  opens **merge requests** instead of pull requests, and everything else in the Learn loop works the
+  same: lifecycle labels, duplicate-incident comments on open MRs, stale/duplicate MR closes, and
+  catalog git-sync over the same credential.
+
+  Auth is a **project access token**: per-project, role-scoped, and expiring — the
+  self-hosted-friendly counterpart of the GitHub App (no instance-admin or OAuth-application setup).
+
+  ### Create the token
+
+  1. In the KB project: **Settings → Access tokens → Add new token.**
+  2. Role: **Developer** (push non-protected branches, open/close MRs and issues, comment).
+  3. Scopes: **`api`** (REST writes: branches, entry files, MRs, issues, notes) and
+     **`read_repository`** (catalog git-sync clone).
+  4. Set an expiry you can operate with (GitLab warns project maintainers before it lapses) and note
+     the token value — you only see it once.
+
+  > RunLore pushes branches under `runlore/*`. If your project protects wildcard branches, allow
+  > Developers to push `runlore/*` (Settings → Repository → Protected branches), or raise the token
+  > role to Maintainer.
+
+  ### Configure
+
+  Add the token to the credentials Secret (step 3), e.g. `--from-literal=GITLAB_TOKEN='glpat-…'`,
+  then select the provider in your `values.yaml` `config:` block:
+
+  ```yaml
+  config:
+    forge:
+      provider: gitlab
+      kb_repo: platform/runlore-kb            # FULL project path — nested groups work: group/sub/project
+      base_branch: main
+      gitlab:
+        base_url: https://gitlab.example.com  # omit for gitlab.com
+        token_env: GITLAB_TOKEN
+  ```
+
+  The same token authenticates the **catalog git-sync** clone of a private KB repo — no separate
+  `catalog.git.token_env` needed (the same shared-identity behavior as the GitHub App).
+
+  ### Security notes
+
+  - A project access token is **confined to the one KB project** — it cannot reach anything else.
+  - It is referenced by env-var name (`token_env`) and lives only in the `Secret` — never in
+    `values.yaml`. Rotate it on its expiry cadence.
+  - RunLore's writes remain confined to the forge; it has **no cluster-mutating permissions**.
+  ````
+
+- [ ] **Step 3: getting-started.md — cross-references.**
+  - Line 39 (`- A **GitHub App** for curation — [step 2](...)`): append to the bullet: `On GitLab, a **project access token** replaces the App — [step 2b](#step-2b--gitlab-instead-of-github-optional).`
+  - Step 3 Secret example (lines 173-180): add the line `  --from-literal=GITLAB_TOKEN='glpat-...' \` with a trailing comment removed (keep the "Only include the keys you use" note at line 187 doing the explaining).
+  - Step 4 values example, forge block (lines 337-346): after the `github_app:` sub-block, add the comment lines:
+
+    ```yaml
+      # On GitLab (gitlab.com or self-hosted) use instead — see step 2b:
+      # provider: gitlab
+      # gitlab: { base_url: https://gitlab.example.com, token_env: GITLAB_TOKEN }
+    ```
+
+- [ ] **Step 4: configuration.md — extend the `forge` section (line 283).** After the existing first paragraph (`kb_repo … private_key_env`), add:
+
+  ```markdown
+  `provider` selects the forge kind: `github` (default when omitted — existing configs are
+  untouched) or `gitlab`. With `gitlab`, `kb_repo` is the **full project path** (nested groups
+  allowed, e.g. `group/subgroup/runlore-kb`) and the `gitlab` block applies: `base_url` (default
+  `https://gitlab.com`; set your host for self-hosted) and `token_env` (**required** — the env var
+  holding a project access token with the `api` + `read_repository` scopes, Developer role). The
+  curator then opens **merge requests**; closed-unmerged MRs drive the same rejection-suppression
+  set as on GitHub. The token also authenticates catalog git-sync clones (shared identity, like
+  the GitHub App).
+  ```
+
+- [ ] **Step 5: design.md — retire the "later" markers.**
+  - Line 127: `└─► GitHub (now) / GitLab (later)` → `└─► GitHub / GitLab`.
+  - Line 333 (providers table): move GitLab from the "later" column to built-in: `| Issue | \`IssueProvider\` | **GitHub** (App auth), **GitLab** (project access token) | — |` (match the table's existing column layout when editing).
+  - Line 523-524: replace `Non-GitHub hosts (GitLab, self-hosted) fall back to a scoped access token / deploy key — auth is per-host.` with `GitLab (gitlab.com or self-hosted) is built in via a project access token (\`forge.provider: gitlab\`) — auth stays per-host.`
+
+- [ ] **Step 6: Verify docs + full suite**
+
+  ```bash
+  grep -n "provider: gitlab" deploy/helm/runlore/values.yaml docs/getting-started.md docs/configuration.md \
+    && helm lint deploy/helm/runlore && go build ./... && go test ./...
+  ```
+
+  Expected: hits in all three files, chart lints, suite green.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add deploy/helm/runlore/values.yaml docs/getting-started.md docs/configuration.md docs/design.md
+  git commit -m "docs+chart: GitLab forge — project-token setup, provider config, values example"
+  ```
+
+---
+
+## Acceptance criteria
+
+- [ ] `internal/forge/gitlab.Client` compiles against **all five** consumer interfaces (compile-time pins in the gitlab tests): `providers.CurationForge`, `providers.ReinvestForge`, `curate.Forge`, `curate.ContestedForge`, `curate.RetireForge` — MR create with the drafted OKF entry file on a `runlore/*` branch, comment on open MRs (duplicate incidents), close MRs/issues, label lifecycle transitions, closed-unmerged listing, knowledge-gap issues, retire MRs.
+- [ ] Works against **self-hosted GitLab**: `forge.gitlab.base_url` overrides the host everywhere (API routes and blob links), verified by every test using an `httptest` base URL.
+- [ ] Catalog git-sync and source-diff clone the KB/source repos over the GitLab project token with **zero changes** to `internal/catalog/sync.go` and `internal/whatchanged/differ.go` (any-username basic auth), wired through `BuildForgeTokenSource`.
+- [ ] **No new required config for GitHub users**: an empty `forge.provider` is byte-identical to today's behavior (`TestBuildForgeClientGitHubDefaultUnchanged`), and `go test ./...` passes with zero edits to existing GitHub forge tests (Task 1 refactor is delegation-only).
+- [ ] Config validation fails fast on `forge.provider: gitlab` without `forge.gitlab.token_env`, and on unknown providers; nested project paths are accepted.
+- [ ] Error paths are actionable: 401 names `forge.gitlab.token_env`, 404 names `forge.kb_repo`, 409 surfaces GitLab's duplicate-MR message (tested).
+- [ ] Shared OKF rendering (image neutralization, frontmatter marshaling, bundle index/log, retire stamp) lives **once** in `internal/forge` and is exercised by both host clients.
+- [ ] Docs shipped: getting-started **Step 2b** (token creation, scopes/role, Secret, config), `configuration.md` forge section, chart `values.yaml` example, design.md "later" markers retired.
+- [ ] `go build ./... && go test ./... && helm lint deploy/helm/runlore` all green at the final commit.

--- a/dev/superpowers/plans/2026-07-23-m3-argocd-executor.md
+++ b/dev/superpowers/plans/2026-07-23-m3-argocd-executor.md
@@ -1,0 +1,1022 @@
+# M3 — Argo CD executor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Argo CD users parity with Flux on the "approve" autonomy rung. Today `internal/app/serve.go:105` wires `fluxexec.New(dc)` unconditionally, so under `gitops.engine: argocd` every approved action fails with `unsupported target kind "Application"` (`internal/executor/flux/flux.go:44-46`) — the approve rung silently does nothing for Argo users. This plan adds an `internal/executor/argocd` package implementing the reversible Argo CD equivalents of the three registry ops — **suspend** = pause auto-sync (remove `spec.syncPolicy.automated`, preserving the prior value in an annotation), **resume** = restore it, **reconcile** = the `argocd.argoproj.io/refresh` annotation — selected per-engine by a new `app.BuildExecutor`, so the existing server-authoritative policy gates (reversible-only, blast-radius, kind allowlist, namespace allowlist — `internal/action/policy.go:59-101`) apply identically with **zero policy-code changes**.
+
+**Architecture:**
+
+- **Op names are reused, not added.** `providers.Ops` (`internal/providers/providers.go:177-181`) stays exactly `{suspend, resume, reconcile}`, each `{Reversible: true, Blast: 1}`. The op vocabulary is engine-neutral; the executor selected for the configured engine translates it. This means: the model-facing `submit_findings` op enum (registry-derived via `opEnumJSON()`, `internal/investigate/tools.go:99-107`) needs no change; `deriveSafety` (`internal/action/safety.go:19-30`) derives the same reversibility/blast for an `Application` target as for a `Kustomization`; and the approve/auto exec-boundary re-checks (`internal/action/approvals.go:110-115`, `internal/action/auto.go:111-121`) work untouched.
+- **Access path matches the provider.** The read-side Argo provider talks to the Kubernetes API directly — Application CRs via a dynamic client (`internal/providers/gitops/argocd/dynamic.go:21,39-41`), never the Argo API server. The executor does the same: merge-patches on the `argoproj.io/v1alpha1 applications` GVR, mirroring `internal/executor/flux/flux.go:62-65`. No new credentials, no new config keys (the RunLore simplicity constraint).
+- **Suspend must be lossless.** `spec.syncPolicy.automated` is an object (`{prune, selfHeal, allowEmpty}` flags, or `{}`); deleting it loses the prior value, which would make the registry's `Reversible: true` derivation a lie. The executor GETs the Application first, marshals the current `automated` object into the `runlore.io/paused-sync-automated` annotation, then removes `automated` in the same merge patch. Resume reads the annotation back, restores `automated`, and deletes the annotation. A manual-sync app (no `automated`) is a no-op on suspend; an app RunLore never paused is a no-op on resume (never invent a sync policy).
+- **Reconcile = refresh annotation, not `.operation`.** `argocd.argoproj.io/refresh: "normal"` is consumed (removed) by the application controller — self-cleaning, the exact analogue of Flux's `reconcile.fluxcd.io/requestedAt` (`internal/executor/flux/flux.go:58`). Patching `.operation` (a declarative sync) was rejected: a direct CR write bypasses the Argo API server's in-flight-operation guard and can clobber a running sync.
+- **Already engine-agnostic — verified, no changes needed:**
+  - **Audit:** every execution is audited at the single `Execute` seam by `NewAuditedExecutor` (`internal/action/executor.go:39-54`); the record carries `Op` + `Target` as strings (`internal/action/auto.go:147-149`) — kind-agnostic. Task 5 adds one parity test proving an `Application` target flows through.
+  - **Slack approval buttons:** the block builder renders only `a.Description` and `a.ApprovalID` (`internal/notify/slack.go:550-563`) — resource-kind-agnostic, so **no notifier change is needed**; Argo actions get Approve/Reject buttons for free.
+  - **F2 unobserved-target guard:** matches on server-observed *names*, not kinds (`internal/investigate/observedresources.go:66-79,119-148`); the failure trigger seeds the `Application` workload, so trigger-subject actions pass.
+  - **Kind allowlist:** `actions.allow.kinds` is empty by default = all kinds allowed (`internal/action/policy.go:71`); operators who set it must add `Application` — a docs item, not code.
+- **Protected namespaces:** `builtinProtectedNamespaces` stays `{flux-system, kube-system}` (`internal/action/safety.go:13`). `argocd` is deliberately NOT added: Argo `Application` objects (the pause lever for *user* apps) conventionally live there, so protecting it would neuter the feature; the opt-in `actions.allow.namespaces` allowlist (empty = nothing) plus `rbac.actionNamespaces` bound the blast radius instead. Documented in Task 9.
+
+**Tech Stack:** Go 1.24+, client-go `dynamic.Interface` + `types.MergePatchType`, `k8s.io/client-go/dynamic/fake` for unit tests (same as `internal/executor/flux/flux_test.go:18-29`), Helm chart RBAC (`deploy/helm/runlore/templates/rbac.yaml`), bash k3d/kind e2e (`hack/e2e-local.sh` step 11) with the scripted mock model (`hack/e2e/mock/main.go`).
+
+**Locked decisions:**
+
+| Decision | Choice | Why |
+|---|---|---|
+| Op vocabulary | Reuse `suspend`/`resume`/`reconcile`; no new `providers.Ops` entries | Registry stays the single source of truth; model schema (`opEnumJSON`), policy derivations, and both exec-boundary re-checks work unchanged. Blast stays 1 = one GitOps object (an `Application` fans out to many workloads exactly like a `Kustomization` does — same existing convention) |
+| Suspend mechanism | Remove `spec.syncPolicy.automated`, save prior JSON in `runlore.io/paused-sync-automated` annotation | Works on every Argo CD version. `spec.syncPolicy.automated.enabled: false` (lossless toggle) only exists on Argo CD ≥ 3.0 — rejected for version compatibility |
+| Reconcile mechanism | `argocd.argoproj.io/refresh: "normal"` annotation | Self-cleaning (controller removes it), mirrors Flux `requestedAt`; `.operation` patch rejected (bypasses in-flight-operation guard) |
+| Access path | Direct CR merge-patch via dynamic client | Same path the argocd provider already reads through (`dynamic.go:39-41`); no Argo API server session/token |
+| Executor selection | New `app.BuildExecutor(cfg, dc)` beside `BuildGitOps` (`internal/app/gitops.go:22-37`) | One engine switch, mirrored; `serve.go` stays a one-liner |
+| Suspend GET-then-PATCH race | Accepted (non-transactional) | Approve rung is human-clicked, low concurrency; the Flux executor's blind patch has the same exposure. Documented in the package comment |
+| `argocd` namespace | NOT builtin-protected | See Architecture; allowlist is opt-in and empty-by-default anyway |
+
+---
+
+### Task 1: Engine-neutral op surface + Application policy-parity test
+
+**Files:**
+- Modify: `internal/providers/providers.go` (registry comment, lines 172-176)
+- Modify: `internal/investigate/tools.go` (op description string, line 87)
+- Modify: `internal/app/action.go` (log line, line 63)
+- Test: `internal/action/policy_test.go` (append)
+
+- [ ] **Step 1: Write the parity characterization test**
+
+  Append to `internal/action/policy_test.go` (package `action`; `config` and `providers` are already imported there):
+
+  ```go
+  // TestReviewArgoApplicationParity locks in M3's central invariant: an
+  // Application-targeted registry op passes the SAME server-authoritative
+  // envelope as a Flux target — reversibility/blast derived from providers.Ops
+  // (never the model's fields), no default kind restriction, namespace
+  // allowlisted — with NO engine- or kind-specific branches in the gate.
+  func TestReviewArgoApplicationParity(t *testing.T) {
+  	p := New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{
+  		ReversibleOnly: true,
+  		Namespaces:     []string{"argocd"},
+  	}})
+  	acts := []providers.Action{{
+  		Name:        "pause-auto-sync",
+  		Op:          "suspend",
+  		Reversible:  false, // model-supplied lie — must be discarded
+  		BlastRadius: 99,    // model-supplied lie — must be discarded
+  		Target:      providers.Workload{Kind: "Application", Name: "web", Namespace: "argocd"},
+  	}}
+  	kept, withheld := p.Review(acts)
+  	if len(withheld) != 0 || len(kept) != 1 {
+  		t.Fatalf("kept=%d withheld=%v; want the Application action kept", len(kept), withheld)
+  	}
+  	if !kept[0].Reversible || kept[0].BlastRadius != 1 {
+  		t.Fatalf("derived (reversible=%v, blast=%d); want (true, 1) from providers.Ops",
+  			kept[0].Reversible, kept[0].BlastRadius)
+  	}
+  }
+  ```
+
+- [ ] **Step 2: Run it — expected PASS immediately (deliberate exception to fail-first)**
+
+  ```bash
+  go test ./internal/action/ -run TestReviewArgoApplicationParity -v
+  ```
+
+  Expected: `--- PASS: TestReviewArgoApplicationParity`. This is a *characterization* test: the invariant already holds because the gate is registry-derived and kind-agnostic (`policy.go:59-82`, `safety.go:19-30`). It exists to fail loudly if anyone adds engine special-casing during the rest of this plan. Every other task in this plan follows strict fail-first TDD.
+
+- [ ] **Step 3: Make the three Flux-specific strings engine-neutral**
+
+  In `internal/providers/providers.go`, replace the `Ops` doc comment (lines 172-176) with:
+
+  ```go
+  // Ops is the canonical registry of executable remediation operations and their
+  // server-authoritative safety metadata. The action gate (internal/action) derives
+  // reversibility/blast from this — never from model output — and the per-engine
+  // executors (internal/executor/flux, internal/executor/argocd) run only ops
+  // listed here. Op names are engine-neutral; the executor for the configured
+  // gitops.engine translates them (Flux: spec.suspend / requestedAt annotation;
+  // Argo CD: pause/restore spec.syncPolicy.automated / refresh annotation). One
+  // entry per op is the single source of truth that keeps the gate and the
+  // executors from drifting.
+  ```
+
+  In `internal/investigate/tools.go:87`, change the schema description
+  `"executable op (Flux); omit for a suggestion only"` →
+  `"executable GitOps op (Flux or Argo CD); omit for a suggestion only"`.
+
+  In `internal/app/action.go:63`, change
+  `log.Info("rung-2 approval-gated actions enabled (Flux suspend/resume/reconcile)")` →
+  `log.Info("rung-2 approval-gated actions enabled (GitOps suspend/resume/reconcile)")`
+  (the e2e grep at `hack/e2e-local.sh:346` matches on `'approval-gated actions enabled'`, so it stays green).
+
+- [ ] **Step 4: Verify nothing broke**
+
+  ```bash
+  go test ./internal/action/ ./internal/investigate/ ./internal/app/ ./internal/providers/
+  ```
+
+  Expected: all PASS (the tools.go string is a description field; no test asserts its exact text — if one does, update it in the same commit).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/providers/providers.go internal/investigate/tools.go internal/app/action.go internal/action/policy_test.go
+  git commit -m "refactor(action): engine-neutral op surface + Application policy-parity test"
+  ```
+
+---
+
+### Task 2: `internal/executor/argocd` — scaffold, validation, reconcile (refresh)
+
+**Files:**
+- Create: `internal/executor/argocd/argocd.go`
+- Test: `internal/executor/argocd/argocd_test.go`
+
+- [ ] **Step 1: Write the failing tests (new package — fails to build first)**
+
+  Create `internal/executor/argocd/argocd_test.go`, mirroring `internal/executor/flux/flux_test.go:18-38`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package argocd
+
+  import (
+  	"context"
+  	"testing"
+
+  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+  	"k8s.io/apimachinery/pkg/runtime"
+  	"k8s.io/apimachinery/pkg/runtime/schema"
+  	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+  	"github.com/Smana/runlore/internal/providers"
+  )
+
+  // app builds a minimal Application named web in argocd. automated == nil means
+  // spec.syncPolicy is absent entirely (a manual-sync app); a non-nil (possibly
+  // empty) map becomes spec.syncPolicy.automated. ann, when non-nil, becomes
+  // metadata.annotations.
+  func app(automated map[string]any, ann map[string]any) *unstructured.Unstructured {
+  	meta := map[string]any{"name": "web", "namespace": "argocd"}
+  	if ann != nil {
+  		meta["annotations"] = ann
+  	}
+  	spec := map[string]any{"project": "default"}
+  	if automated != nil {
+  		spec["syncPolicy"] = map[string]any{"automated": automated}
+  	}
+  	return &unstructured.Unstructured{Object: map[string]any{
+  		"apiVersion": "argoproj.io/v1alpha1",
+  		"kind":       "Application",
+  		"metadata":   meta,
+  		"spec":       spec,
+  	}}
+  }
+
+  func newClient(objs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+  	gvrToListKind := map[schema.GroupVersionResource]string{applicationGVR: "ApplicationList"}
+  	rs := make([]runtime.Object, len(objs))
+  	for i, o := range objs {
+  		rs[i] = o
+  	}
+  	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, rs...)
+  }
+
+  func get(t *testing.T, c *dynamicfake.FakeDynamicClient) *unstructured.Unstructured {
+  	t.Helper()
+  	u, err := c.Resource(applicationGVR).Namespace("argocd").Get(context.Background(), "web", metav1.GetOptions{})
+  	if err != nil {
+  		t.Fatal(err)
+  	}
+  	return u
+  }
+
+  func action(op string) providers.Action {
+  	return providers.Action{Op: op, Target: providers.Workload{Kind: "Application", Name: "web", Namespace: "argocd"}}
+  }
+
+  func TestReconcileSetsRefreshAnnotation(t *testing.T) {
+  	c := newClient(app(map[string]any{"prune": true}, nil))
+  	if err := New(c).Execute(context.Background(), action("reconcile")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	if v := get(t, c).GetAnnotations()["argocd.argoproj.io/refresh"]; v != "normal" {
+  		t.Fatalf("refresh annotation = %q, want %q", v, "normal")
+  	}
+  }
+
+  func TestUnsupported(t *testing.T) {
+  	e := New(newClient(app(nil, nil)))
+  	if err := e.Execute(context.Background(), providers.Action{Op: "delete",
+  		Target: providers.Workload{Kind: "Application", Name: "web", Namespace: "argocd"}}); err == nil {
+  		t.Fatal("expected error for unsupported op")
+  	}
+  	if err := e.Execute(context.Background(), providers.Action{Op: "suspend",
+  		Target: providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "argocd"}}); err == nil {
+  		t.Fatal("expected error for unsupported kind")
+  	}
+  	if err := e.Execute(context.Background(), providers.Action{Op: "suspend",
+  		Target: providers.Workload{Kind: "Application", Name: "web"}}); err == nil {
+  		t.Fatal("expected error for missing namespace")
+  	}
+  }
+  ```
+
+- [ ] **Step 2: Run — expected FAIL (build error)**
+
+  ```bash
+  go test ./internal/executor/argocd/ -v
+  ```
+
+  Expected FAIL: build errors — `undefined: applicationGVR`, `undefined: New` (only the test file exists; the package has no production source yet).
+
+- [ ] **Step 3: Implement the scaffold + reconcile**
+
+  Create `internal/executor/argocd/argocd.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  // Package argocd executes safe, reversible Argo CD operations on Application
+  // CRs — the Argo half of the autonomy ladder's executable rungs, mirroring
+  // internal/executor/flux. Ops map as: suspend = pause auto-sync (remove
+  // spec.syncPolicy.automated, preserving the prior value in an annotation so
+  // resume can restore it losslessly), resume = restore it, reconcile = the
+  // self-cleaning argocd.argoproj.io/refresh annotation (the analogue of Flux's
+  // requestedAt). It patches the Application custom resource directly via the
+  // dynamic client — the same access path the argocd GitOps provider reads
+  // through (internal/providers/gitops/argocd) — never the Argo API server.
+  //
+  // suspend/resume are GET-then-PATCH and deliberately not transactional: a
+  // concurrent syncPolicy edit in the window can be overwritten. Accepted — the
+  // approve rung is human-clicked and the Flux executor's blind patch carries
+  // the same exposure.
+  package argocd
+
+  import (
+  	"context"
+  	"encoding/json"
+  	"fmt"
+
+  	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+  	"k8s.io/apimachinery/pkg/runtime/schema"
+  	"k8s.io/apimachinery/pkg/types"
+  	"k8s.io/client-go/dynamic"
+
+  	"github.com/Smana/runlore/internal/providers"
+  )
+
+  // applicationGVR is the Argo CD Application resource — the same GVR the
+  // read-side provider uses (internal/providers/gitops/argocd/dynamic.go).
+  var applicationGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+
+  // PausedPolicyAnnotation stores the JSON of spec.syncPolicy.automated at pause
+  // time so resume restores the EXACT prior policy (prune/selfHeal/allowEmpty).
+  // Removing automated without saving it would make the op registry's
+  // Reversible=true derivation a lie.
+  const PausedPolicyAnnotation = "runlore.io/paused-sync-automated"
+
+  // refreshAnnotation asks the application controller to re-compare the app
+  // against its source; the controller consumes (removes) it — self-cleaning.
+  const refreshAnnotation = "argocd.argoproj.io/refresh"
+
+  // Executor runs reversible Argo CD operations via the dynamic client.
+  type Executor struct {
+  	client dynamic.Interface
+  }
+
+  // New builds an Executor backed by a dynamic client.
+  func New(client dynamic.Interface) *Executor { return &Executor{client: client} }
+
+  // Execute applies the action's reversible Argo CD operation to its target.
+  func (e *Executor) Execute(ctx context.Context, a providers.Action) error {
+  	// providers.Ops is the canonical op allowlist shared with the action gate; an op
+  	// absent there is never executed (keeps the gate and the executor from drifting).
+  	if _, ok := providers.Ops[a.Op]; !ok {
+  		return fmt.Errorf("unsupported op %q", a.Op)
+  	}
+  	if a.Target.Kind != "Application" {
+  		return fmt.Errorf("unsupported target kind %q (want Application)", a.Target.Kind)
+  	}
+  	if a.Target.Name == "" || a.Target.Namespace == "" {
+  		return fmt.Errorf("action target needs name and namespace")
+  	}
+  	switch a.Op {
+  	case "suspend":
+  		return e.pauseAutoSync(ctx, a)
+  	case "resume":
+  		return e.resumeAutoSync(ctx, a)
+  	case "reconcile":
+  		return e.patch(ctx, a, map[string]any{
+  			"metadata": map[string]any{"annotations": map[string]any{refreshAnnotation: "normal"}},
+  		})
+  	default:
+  		return fmt.Errorf("unsupported op %q (want suspend, resume, or reconcile)", a.Op)
+  	}
+  }
+
+  // pauseAutoSync and resumeAutoSync are implemented in Tasks 3-4; stub them for
+  // this task so the package compiles:
+  func (e *Executor) pauseAutoSync(ctx context.Context, a providers.Action) error {
+  	return fmt.Errorf("not implemented")
+  }
+  func (e *Executor) resumeAutoSync(ctx context.Context, a providers.Action) error {
+  	return fmt.Errorf("not implemented")
+  }
+
+  // get fetches the target Application (needed by pause/resume to read the
+  // current sync policy / saved annotation before patching).
+  func (e *Executor) get(ctx context.Context, a providers.Action) (*unstructured.Unstructured, error) {
+  	u, err := e.client.Resource(applicationGVR).Namespace(a.Target.Namespace).
+  		Get(ctx, a.Target.Name, metav1.GetOptions{})
+  	if err != nil {
+  		return nil, fmt.Errorf("argocd %s %s/%s: %w", a.Op, a.Target.Namespace, a.Target.Name, err)
+  	}
+  	return u, nil
+  }
+
+  // patch merge-patches the target Application. The patch is built as a map and
+  // marshalled (never fmt.Sprintf) because pause embeds JSON inside a JSON
+  // string value — hand-rolled escaping would be a bug factory.
+  func (e *Executor) patch(ctx context.Context, a providers.Action, patch map[string]any) error {
+  	b, err := json.Marshal(patch)
+  	if err != nil {
+  		return fmt.Errorf("marshal patch: %w", err)
+  	}
+  	if _, err := e.client.Resource(applicationGVR).Namespace(a.Target.Namespace).
+  		Patch(ctx, a.Target.Name, types.MergePatchType, b, metav1.PatchOptions{}); err != nil {
+  		return fmt.Errorf("argocd %s %s/%s: %w", a.Op, a.Target.Namespace, a.Target.Name, err)
+  	}
+  	return nil
+  }
+  ```
+
+  (The `unstructured` import becomes used in Task 3; if the compiler flags it now, keep it referenced by `get`'s return type — it already is.)
+
+- [ ] **Step 4: Run — expected PASS**
+
+  ```bash
+  go test ./internal/executor/argocd/ -run 'TestReconcileSetsRefreshAnnotation|TestUnsupported' -v
+  ```
+
+  Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/executor/argocd/
+  git commit -m "feat(executor): argocd executor scaffold — validation + reconcile via refresh annotation"
+  ```
+
+---
+
+### Task 3: suspend — pause auto-sync, preserving the prior policy
+
+**Files:**
+- Modify: `internal/executor/argocd/argocd.go` (replace the `pauseAutoSync` stub)
+- Test: `internal/executor/argocd/argocd_test.go` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+  Append to `internal/executor/argocd/argocd_test.go`:
+
+  ```go
+  func TestSuspendPausesAutoSyncAndStoresPriorPolicy(t *testing.T) {
+  	c := newClient(app(map[string]any{"prune": true, "selfHeal": true}, nil))
+  	if err := New(c).Execute(context.Background(), action("suspend")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	u := get(t, c)
+  	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "syncPolicy", "automated"); found {
+  		t.Fatal("spec.syncPolicy.automated still present; auto-sync not paused")
+  	}
+  	// json.Marshal orders map keys alphabetically, so this is deterministic.
+  	if v := u.GetAnnotations()[PausedPolicyAnnotation]; v != `{"prune":true,"selfHeal":true}` {
+  		t.Fatalf("saved policy annotation = %q, want the prior automated object", v)
+  	}
+  }
+
+  func TestSuspendManualSyncAppIsNoop(t *testing.T) {
+  	c := newClient(app(nil, nil)) // no syncPolicy at all: manual sync
+  	if err := New(c).Execute(context.Background(), action("suspend")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	if v, ok := get(t, c).GetAnnotations()[PausedPolicyAnnotation]; ok {
+  		t.Fatalf("no-op suspend must not invent a saved policy (got %q)", v)
+  	}
+  }
+
+  func TestSuspendAlreadyPausedPreservesSavedPolicy(t *testing.T) {
+  	// Paused earlier: automated absent, annotation holds the real prior policy.
+  	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `{"prune":true}`}))
+  	if err := New(c).Execute(context.Background(), action("suspend")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	if v := get(t, c).GetAnnotations()[PausedPolicyAnnotation]; v != `{"prune":true}` {
+  		t.Fatalf("double-suspend clobbered the saved policy: %q", v)
+  	}
+  }
+  ```
+
+- [ ] **Step 2: Run — expected FAIL**
+
+  ```bash
+  go test ./internal/executor/argocd/ -run TestSuspend -v
+  ```
+
+  Expected FAIL: all three with `Execute: not implemented` (the Task 2 stub).
+
+- [ ] **Step 3: Implement `pauseAutoSync`**
+
+  Replace the stub in `internal/executor/argocd/argocd.go`:
+
+  ```go
+  // pauseAutoSync removes spec.syncPolicy.automated (Argo CD's "stop deploying
+  // this" lever — the analogue of Flux spec.suspend), saving the prior automated
+  // object into PausedPolicyAnnotation in the SAME patch so resume can restore it
+  // exactly. An app with no automated policy (manual sync, or already paused) is
+  // a no-op — idempotent like re-suspending in Flux, and it never clobbers a
+  // previously saved policy.
+  func (e *Executor) pauseAutoSync(ctx context.Context, a providers.Action) error {
+  	u, err := e.get(ctx, a)
+  	if err != nil {
+  		return err
+  	}
+  	automated, found, _ := unstructured.NestedMap(u.Object, "spec", "syncPolicy", "automated")
+  	if !found {
+  		return nil // manual-sync or already paused: nothing to pause
+  	}
+  	saved, err := json.Marshal(automated)
+  	if err != nil {
+  		return fmt.Errorf("marshal prior sync policy: %w", err)
+  	}
+  	return e.patch(ctx, a, map[string]any{
+  		"metadata": map[string]any{"annotations": map[string]any{PausedPolicyAnnotation: string(saved)}},
+  		"spec":     map[string]any{"syncPolicy": map[string]any{"automated": nil}}, // merge-patch null deletes the key
+  	})
+  }
+  ```
+
+- [ ] **Step 4: Run — expected PASS**
+
+  ```bash
+  go test ./internal/executor/argocd/ -v
+  ```
+
+  Expected: all tests PASS (including Task 2's).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/executor/argocd/
+  git commit -m "feat(executor): argocd suspend pauses auto-sync preserving the prior sync policy"
+  ```
+
+---
+
+### Task 4: resume — restore the saved sync policy
+
+**Files:**
+- Modify: `internal/executor/argocd/argocd.go` (replace the `resumeAutoSync` stub)
+- Test: `internal/executor/argocd/argocd_test.go` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+  Append to `internal/executor/argocd/argocd_test.go`:
+
+  ```go
+  func TestResumeRestoresSavedPolicyAndClearsAnnotation(t *testing.T) {
+  	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `{"prune":true,"selfHeal":true}`}))
+  	if err := New(c).Execute(context.Background(), action("resume")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	u := get(t, c)
+  	automated, found, _ := unstructured.NestedMap(u.Object, "spec", "syncPolicy", "automated")
+  	if !found {
+  		t.Fatal("spec.syncPolicy.automated not restored")
+  	}
+  	if automated["prune"] != true || automated["selfHeal"] != true {
+  		t.Fatalf("restored policy = %v, want prune+selfHeal true", automated)
+  	}
+  	if _, ok := u.GetAnnotations()[PausedPolicyAnnotation]; ok {
+  		t.Fatal("saved-policy annotation not removed after resume")
+  	}
+  }
+
+  func TestResumeRestoresEmptyAutomatedObject(t *testing.T) {
+  	// automated: {} is valid Argo config (auto-sync with default flags) and must
+  	// round-trip distinctly from "no automated at all".
+  	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `{}`}))
+  	if err := New(c).Execute(context.Background(), action("resume")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	if _, found, _ := unstructured.NestedMap(get(t, c).Object, "spec", "syncPolicy", "automated"); !found {
+  		t.Fatal("empty automated object not restored")
+  	}
+  }
+
+  func TestResumeWithoutPriorPauseIsNoop(t *testing.T) {
+  	c := newClient(app(nil, nil)) // RunLore never paused this app
+  	if err := New(c).Execute(context.Background(), action("resume")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	if _, found, _ := unstructured.NestedMap(get(t, c).Object, "spec", "syncPolicy", "automated"); found {
+  		t.Fatal("resume invented an auto-sync policy on an app RunLore never paused")
+  	}
+  }
+
+  func TestResumeCorruptSavedPolicyErrors(t *testing.T) {
+  	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `not-json`}))
+  	if err := New(c).Execute(context.Background(), action("resume")); err == nil {
+  		t.Fatal("expected error for unreadable saved policy (must not guess a policy)")
+  	}
+  }
+  ```
+
+- [ ] **Step 2: Run — expected FAIL**
+
+  ```bash
+  go test ./internal/executor/argocd/ -run TestResume -v
+  ```
+
+  Expected FAIL: all four with `Execute: not implemented`.
+
+- [ ] **Step 3: Implement `resumeAutoSync`**
+
+  Replace the stub:
+
+  ```go
+  // resumeAutoSync restores spec.syncPolicy.automated from PausedPolicyAnnotation
+  // and removes the annotation in the same patch. An app with no saved policy is
+  // a no-op: RunLore never paused it, and inventing an auto-sync policy an
+  // operator never configured would be a mutation outside the op's contract. A
+  // saved policy that no longer parses is an ERROR, not a guess.
+  func (e *Executor) resumeAutoSync(ctx context.Context, a providers.Action) error {
+  	u, err := e.get(ctx, a)
+  	if err != nil {
+  		return err
+  	}
+  	saved, ok := u.GetAnnotations()[PausedPolicyAnnotation]
+  	if !ok {
+  		return nil // never paused by RunLore: nothing to restore
+  	}
+  	var automated map[string]any
+  	if err := json.Unmarshal([]byte(saved), &automated); err != nil {
+  		return fmt.Errorf("argocd resume %s/%s: saved sync policy unreadable: %w",
+  			a.Target.Namespace, a.Target.Name, err)
+  	}
+  	if automated == nil {
+  		automated = map[string]any{} // JSON "null" round-trips to the empty automated object
+  	}
+  	return e.patch(ctx, a, map[string]any{
+  		"metadata": map[string]any{"annotations": map[string]any{PausedPolicyAnnotation: nil}},
+  		"spec":     map[string]any{"syncPolicy": map[string]any{"automated": automated}},
+  	})
+  }
+  ```
+
+- [ ] **Step 4: Run — expected PASS**
+
+  ```bash
+  go test ./internal/executor/argocd/ -v
+  ```
+
+  Expected: all tests in the package PASS.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/executor/argocd/
+  git commit -m "feat(executor): argocd resume restores the saved sync policy"
+  ```
+
+---
+
+### Task 5: audited-execution parity test (audit entries for Argo targets)
+
+The audit seam is already engine-agnostic — `NewAuditedExecutor` wraps any `action.Executor` and records `Op` + `Target` strings (`internal/action/executor.go:39-54`, record shape `internal/action/auto.go:147-149`, target format `internal/action/auto.go:170-172`). This task proves it composes with the new executor and that an `Application` execution lands in the audit trail exactly like a Flux one — no production change expected.
+
+**Files:**
+- Test: `internal/executor/argocd/audit_test.go` (create — `internal/action` does not import `internal/executor/*`, so no import cycle)
+
+- [ ] **Step 1: Write the test**
+
+  Create `internal/executor/argocd/audit_test.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package argocd
+
+  import (
+  	"context"
+  	"testing"
+
+  	"github.com/Smana/runlore/internal/action"
+  	"github.com/Smana/runlore/internal/audit"
+  )
+
+  // recorder captures audit records in memory.
+  type recorder struct{ records []audit.Record }
+
+  func (r *recorder) Log(rec audit.Record) error { r.records = append(r.records, rec); return nil }
+
+  // TestAuditedExecutionRecordsApplicationTarget proves the audit seam
+  // (action.NewAuditedExecutor) is engine-agnostic in practice: an executed
+  // Argo CD pause is recorded with the approver actor and the Application
+  // target, byte-identical in shape to a Flux record.
+  func TestAuditedExecutionRecordsApplicationTarget(t *testing.T) {
+  	c := newClient(app(map[string]any{"prune": true}, nil))
+  	rec := &recorder{}
+  	exec := action.NewAuditedExecutor(New(c), rec)
+  	ctx := action.ContextWithActor(context.Background(), "approve:slack:U_TEST")
+  	if err := exec.Execute(ctx, action2("suspend")); err != nil {
+  		t.Fatalf("Execute: %v", err)
+  	}
+  	if len(rec.records) != 1 {
+  		t.Fatalf("audit records = %d, want 1", len(rec.records))
+  	}
+  	r := rec.records[0]
+  	if r.Actor != "approve:slack:U_TEST" || r.Op != "suspend" ||
+  		r.Target != "Application/argocd/web" || r.Decision != audit.DecisionExecuted {
+  		t.Fatalf("record = %+v, want executed suspend on Application/argocd/web by the approver", r)
+  	}
+  }
+  ```
+
+  Note: the test file lives in package `argocd`, where `action(op string)` (Task 2 helper) collides with the imported `action` package — rename the Task 2 helper to `action2` (or `mkAction`) across `argocd_test.go` in this step, or alias the import (`act "github.com/Smana/runlore/internal/action"`). Pick ONE and apply consistently; the snippet above assumes the helper was renamed to `action2`.
+
+- [ ] **Step 2: Run — expected FAIL first iff the recorder shape is wrong, else PASS**
+
+  ```bash
+  go test ./internal/executor/argocd/ -run TestAuditedExecutionRecordsApplicationTarget -v
+  ```
+
+  This is a wiring-verification test: expected PASS once it compiles (the seam already exists; verify `audit.Auditor`'s method set against `internal/audit/audit.go` if the compile fails — the `recorder` must satisfy it exactly).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add internal/executor/argocd/
+  git commit -m "test(executor): audited-execution parity for argocd Application targets"
+  ```
+
+---
+
+### Task 6: engine-aware executor selection
+
+**Files:**
+- Modify: `internal/app/gitops.go` (add `BuildExecutor` beside `BuildGitOps`, lines 22-37)
+- Modify: `internal/app/serve.go` (lines 96 and 105)
+- Test: `internal/app/gitops_test.go` (create — no such file exists today)
+
+- [ ] **Step 1: Write the failing test**
+
+  Create `internal/app/gitops_test.go`:
+
+  ```go
+  // SPDX-License-Identifier: Apache-2.0
+
+  package app
+
+  import (
+  	"testing"
+
+  	dynamicfake "k8s.io/client-go/dynamic/fake"
+  	"k8s.io/apimachinery/pkg/runtime"
+
+  	"github.com/Smana/runlore/internal/config"
+  	argoexec "github.com/Smana/runlore/internal/executor/argocd"
+  	fluxexec "github.com/Smana/runlore/internal/executor/flux"
+  )
+
+  // TestBuildExecutorFollowsGitopsEngine pins the M3 wiring: the action executor
+  // must track gitops.engine exactly as BuildGitOps does, or approve-rung actions
+  // fail with "unsupported target kind" on one of the engines.
+  func TestBuildExecutorFollowsGitopsEngine(t *testing.T) {
+  	dc := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+  	cfg := &config.Config{}
+  	if _, ok := BuildExecutor(cfg, dc).(*fluxexec.Executor); !ok {
+  		t.Fatalf("default engine: got %T, want *flux.Executor", BuildExecutor(cfg, dc))
+  	}
+
+  	cfg.GitOps.Engine = "argocd"
+  	if _, ok := BuildExecutor(cfg, dc).(*argoexec.Executor); !ok {
+  		t.Fatalf("argocd engine: got %T, want *argocd.Executor", BuildExecutor(cfg, dc))
+  	}
+  }
+  ```
+
+- [ ] **Step 2: Run — expected FAIL**
+
+  ```bash
+  go test ./internal/app/ -run TestBuildExecutorFollowsGitopsEngine -v
+  ```
+
+  Expected FAIL: build error `undefined: BuildExecutor`.
+
+- [ ] **Step 3: Implement `BuildExecutor` and rewire `serve.go`**
+
+  In `internal/app/gitops.go`, add (imports: `"github.com/Smana/runlore/internal/action"`, `argoexec "github.com/Smana/runlore/internal/executor/argocd"`, `fluxexec "github.com/Smana/runlore/internal/executor/flux"`):
+
+  ```go
+  // BuildExecutor returns the rung-2/3 action executor for the configured GitOps
+  // engine — the same engine switch as BuildGitOps, so the executor always
+  // matches the provider that proposed the target (an Argo Application action
+  // must never reach the Flux executor and vice versa).
+  func BuildExecutor(cfg *config.Config, dc dynamic.Interface) action.Executor {
+  	if GitopsEngine(cfg) == "argocd" {
+  		return argoexec.New(dc)
+  	}
+  	return fluxexec.New(dc)
+  }
+  ```
+
+  In `internal/app/serve.go`:
+  - line 96: comment `// rung-2 action executor (Flux), when a cluster is reachable` → `// rung-2/3 action executor for the configured GitOps engine, when a cluster is reachable`
+  - line 105: `executor = fluxexec.New(dc)` → `executor = BuildExecutor(cfg, dc)`
+  - remove the now-unused `fluxexec` import at serve.go:25 (`goimports` will do it).
+
+- [ ] **Step 4: Run — expected PASS + full build**
+
+  ```bash
+  go test ./internal/app/ -run TestBuildExecutorFollowsGitopsEngine -v && go build ./... && go vet ./...
+  ```
+
+  Expected: PASS, clean build, clean vet.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add internal/app/gitops.go internal/app/gitops_test.go internal/app/serve.go
+  git commit -m "feat(app): select the rung-2/3 action executor by gitops engine"
+  ```
+
+---
+
+### Task 7: chart RBAC — Application get/patch in the namespaced actions Role
+
+**Files:**
+- Modify: `deploy/helm/runlore/templates/rbac.yaml` (actions Role, lines 130-149)
+- Modify: `deploy/helm/runlore/values.yaml` (comments, lines 366-372)
+
+- [ ] **Step 1: Baseline — prove the grant is missing today**
+
+  ```bash
+  helm template runlore deploy/helm/runlore --set rbac.allowActions=true \
+    --set 'rbac.actionNamespaces={apps}' \
+    | yq eval-all 'select(.kind == "Role" and (.metadata.name | test("-actions$"))) | .rules[].apiGroups[]' -
+  ```
+
+  Expected output (FAIL state — no `argoproj.io`):
+
+  ```
+  kustomize.toolkit.fluxcd.io
+  helm.toolkit.fluxcd.io
+  ```
+
+- [ ] **Step 2: Add the rule**
+
+  In `deploy/helm/runlore/templates/rbac.yaml`, update the actions-Role header comment (line 133) from `patch Flux resources in THIS` to `patch GitOps resources (Flux Kustomizations/HelmReleases, Argo CD Applications) in THIS`, and append after the `helmreleases` rule (line 149):
+
+  ```yaml
+    # Argo CD executor (config.gitops.engine: argocd): pause/resume auto-sync and
+    # refresh are merge patches on the Application; pause/resume also GET the app
+    # first to read/restore the prior sync policy, so the Role is self-contained.
+    - apiGroups: ["argoproj.io"]
+      resources: ["applications"]
+      verbs: ["get", "patch"]
+  ```
+
+  In `deploy/helm/runlore/values.yaml`:
+  - line 366: `# allowActions grants patch on Flux resources for rung-2 execution` → `# allowActions grants patch on GitOps resources (Flux Kustomizations/HelmReleases, Argo CD Applications) for rung-2 execution`
+  - line 369: `# Namespaces where the agent may patch Flux resources (suspend/resume/reconcile).` → `# Namespaces where the agent may patch GitOps resources (suspend/resume/reconcile; for Argo CD this is where your Application objects live, e.g. argocd).`
+
+- [ ] **Step 3: Verify**
+
+  Re-run the Step 1 command. Expected output now includes `argoproj.io`:
+
+  ```
+  kustomize.toolkit.fluxcd.io
+  helm.toolkit.fluxcd.io
+  argoproj.io
+  ```
+
+  Also run `helm lint deploy/helm/runlore` — expected `1 chart(s) linted, 0 chart(s) failed`.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add deploy/helm/runlore/templates/rbac.yaml deploy/helm/runlore/values.yaml
+  git commit -m "feat(chart): grant Application get/patch in the namespaced actions Role"
+  ```
+
+---
+
+### Task 8: k3d e2e — drive the approve rung against an Argo CD Application
+
+**Files:**
+- Modify: `hack/e2e/mock/main.go` (the `submit_findings` case, lines 126-140)
+- Modify: `hack/e2e-local.sh` (step 11, lines 723-760; `hack/e2e-k3d.sh` is a thin wrapper and needs no change)
+
+- [ ] **Step 1: Teach the mock model to propose an Application action for the Argo incident**
+
+  In `hack/e2e/mock/main.go`, replace the `default:` case of the `switch toolResults` (line 138-139) with:
+
+  ```go
+  	default:
+  		// The action targets whichever GitOps object triggered THIS incident: the
+  		// argocd e2e phase names Application/broken-argo in the incident text, the
+  		// flux phases name broken-app. Sniffing the request body keeps the mock
+  		// stateless across both engine phases.
+  		actionJSON := `{"description":"suspend the failing Kustomization to stop the reconcile loop","op":"suspend","reversible":true,"blast_radius":1,"target":{"kind":"Kustomization","name":"broken-app","namespace":"apps"}}`
+  		if strings.Contains(string(body), "broken-argo") {
+  			actionJSON = `{"description":"pause auto-sync on the degraded Application to stop the flapping rollout","op":"suspend","reversible":true,"blast_radius":1,"target":{"kind":"Application","name":"broken-argo","namespace":"apps"}}`
+  		}
+  		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"],"actions":[`+actionJSON+`]}`
+  	}
+  ```
+
+  Compile check:
+
+  ```bash
+  go vet -tags e2e ./hack/e2e/mock/
+  ```
+
+  Expected: clean (`strings` is already imported at main.go:20).
+
+- [ ] **Step 2: Extend e2e step 11**
+
+  In `hack/e2e-local.sh`:
+
+  (a) The step-11 `helm upgrade` (lines 744-745) switches back to the approve rung — M3's target — by adding one flag:
+
+  ```bash
+  helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
+    --set replicaCount=1 --set-string config.gitops.engine=argocd \
+    --set-string config.actions.mode=approve >/dev/null
+  ```
+
+  (b) The `broken-argo` manifest (lines 749-754) gains an auto-sync policy to pause:
+
+  ```bash
+  kubectl apply -f - <<'YAML'
+  apiVersion: argoproj.io/v1alpha1
+  kind: Application
+  metadata: { name: broken-argo, namespace: apps }
+  spec:
+    source: { repoURL: "https://github.com/org/repo", path: apps }
+    syncPolicy: { automated: { prune: true, selfHeal: true } }
+  YAML
+  ```
+
+  (c) After the two existing argocd checks (line 759-760), append:
+
+  ```bash
+  # Rung 2 parity (M3): the mock proposed pausing auto-sync on the Application;
+  # approve it via the token endpoint and verify the executor (a) removed
+  # spec.syncPolicy.automated and (b) preserved the prior policy in the
+  # runlore.io/paused-sync-automated annotation — the reversibility contract.
+  check "argocd action queued for approval" /tmp/runlore.log 'actions registered for approval'
+  APORT=18092; free_port "$APORT"
+  kubectl -n "$NS" port-forward svc/runlore "$APORT:8080" >/tmp/runlore-argo-pf.log 2>&1 &
+  APF=$!; sleep 3
+  AID=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$APORT/actions" | first_action_id) || true
+  curl -s -o /dev/null -w "argo approve HTTP %{http_code}\n" -X POST \
+    -H "X-Approval-Token: e2e-secret" "localhost:$APORT/actions/$AID/approve" || true
+  kill "$APF" 2>/dev/null || true; free_port "$APORT"
+  sleep 3
+  AUTOMATED=$(kubectl get application broken-argo -n apps -o jsonpath='{.spec.syncPolicy.automated}' 2>/dev/null || true)
+  SAVED=$(kubectl get application broken-argo -n apps -o jsonpath='{.metadata.annotations.runlore\.io/paused-sync-automated}' 2>/dev/null || true)
+  if [[ -z "$AUTOMATED" && "$SAVED" == *'"prune":true'* ]]; then
+    green "PASS: approved argocd action paused auto-sync and preserved the prior policy ($SAVED)"; PASS=$((PASS+1))
+  else
+    red "FAIL: argocd pause (automated='$AUTOMATED' saved='$SAVED'; want automated removed + policy saved)"; FAIL=$((FAIL+1))
+  fi
+  kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+  check "argocd execution audit-logged" /tmp/runlore.log 'action approved and executed'
+  ```
+
+  Notes for the implementer: `first_action_id` is defined earlier in the script (lines 527-529) and is in scope here; `config.actions.allow.namespaces={apps}` and `rbac.actionNamespaces={apps}` were set at install (lines 287-288) and `broken-argo` lives in `apps`, so no allowlist change is needed; the F2 observed-target guard passes because the failure trigger seeds `Application/broken-argo` as observed (`internal/investigate/observedresources.go:38-44`).
+
+- [ ] **Step 3: Syntax-check the script**
+
+  ```bash
+  bash -n hack/e2e-local.sh && shellcheck hack/e2e-local.sh || true
+  ```
+
+  Expected: `bash -n` silent; triage any NEW shellcheck findings in the added block only.
+
+- [ ] **Step 4: Run the suite (requires docker + k3d; ~10 min)**
+
+  ```bash
+  hack/e2e-k3d.sh
+  ```
+
+  Expected: `ALL FEATURES VERIFIED` with the two new PASS lines (`approved argocd action paused auto-sync…`, `argocd execution audit-logged`) and every pre-existing check still green (the flux phases run first and must be unaffected by the mock change — the body-sniff only fires on `broken-argo`). If no docker is available locally, state so and rely on the e2e-k3d CI workflow on the PR.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add hack/e2e/mock/main.go hack/e2e-local.sh
+  git commit -m "test(e2e): drive the approve rung against an Argo CD Application"
+  ```
+
+---
+
+### Task 9: docs — README status + configuration.md per-engine op semantics
+
+**Files:**
+- Modify: `README.md` (project-status bullet, lines 241-242)
+- Modify: `docs/configuration.md` (actions section, after the `allow` bullet at lines 241-243)
+
+- [ ] **Step 1: README project-status bullet**
+
+  Replace lines 241-242 of `README.md`:
+
+  ```markdown
+  - **Argo CD is now end-to-end tested**, alongside Flux: the k3d suite reconfigures to the `argocd`
+    engine and drives an `Application Degraded` failure through a full investigation.
+  ```
+
+  with:
+
+  ```markdown
+  - **Argo CD is now end-to-end tested**, alongside Flux — including the **`approve` rung**: the k3d
+    suite reconfigures to the `argocd` engine, drives an `Application Degraded` failure through a full
+    investigation, then human-approves a **pause-auto-sync** action that executes reversibly (the prior
+    `syncPolicy.automated` is preserved for resume). Both engines share the same reversible-only,
+    allowlisted action envelope.
+  ```
+
+- [ ] **Step 2: configuration.md — per-engine op semantics**
+
+  In `docs/configuration.md`, insert a new bullet directly after the `allow` bullet (after line 243), before `require_approval`:
+
+  ```markdown
+  - **Per-engine op semantics** — the executable ops (`suspend` / `resume` / `reconcile`) are
+    engine-neutral names; the executor for the configured `gitops.engine` translates them:
+
+    | op | Flux (`Kustomization` / `HelmRelease`) | Argo CD (`Application`) |
+    |---|---|---|
+    | `suspend` | sets `spec.suspend: true` | removes `spec.syncPolicy.automated` (pauses auto-sync); the prior value is preserved in the `runlore.io/paused-sync-automated` annotation |
+    | `resume` | sets `spec.suspend: false` | restores `spec.syncPolicy.automated` from that annotation (no-op if RunLore didn't pause it) |
+    | `reconcile` | `reconcile.fluxcd.io/requestedAt` annotation | `argocd.argoproj.io/refresh: normal` annotation |
+
+    All three are reversible with blast radius 1 in the server-authoritative op registry, so the same
+    policy envelope gates both engines identically. **Argo CD notes:** `Application` objects usually
+    live in the `argocd` namespace — add it (or your apps-in-any-namespace app namespaces) to
+    `actions.allow.namespaces` **and** the chart's `rbac.actionNamespaces`. If you set `allow.kinds`,
+    include `Application`. `argocd` is deliberately **not** a built-in protected namespace (unlike
+    `flux-system`): it is where the reversible pause lever lives; the empty-by-default namespace
+    allowlist is what bounds it.
+  ```
+
+- [ ] **Step 3: Sanity-check rendering and cross-references**
+
+  ```bash
+  grep -n "paused-sync-automated" README.md docs/configuration.md internal/executor/argocd/argocd.go deploy/helm/runlore/values.yaml
+  ```
+
+  Expected: the annotation name is byte-identical everywhere it appears.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add README.md docs/configuration.md
+  git commit -m "docs: document Argo CD approve-rung parity and per-engine op semantics"
+  ```
+
+---
+
+### Final verification
+
+- [ ] Full test suite + vet + build:
+
+  ```bash
+  go build ./... && go vet ./... && go test ./...
+  ```
+
+  Expected: everything green.
+
+- [ ] `helm lint deploy/helm/runlore` — clean.
+- [ ] Do NOT tag, release, or merge — per the roadmap staging pattern the branch/PR is handed to the maintainer for review.
+
+---
+
+## Acceptance criteria
+
+- [ ] `internal/executor/argocd` exists, mirrors the flux executor's shape (dynamic client, `providers.Ops`-gated, merge patches), and only accepts `Application` targets with name + namespace.
+- [ ] `suspend` on an auto-synced Application removes `spec.syncPolicy.automated` AND stores the prior object in the `runlore.io/paused-sync-automated` annotation in the same patch; manual-sync and already-paused apps are safe no-ops that never clobber a saved policy.
+- [ ] `resume` restores the exact saved policy (including the empty `{}` object), removes the annotation, no-ops when RunLore never paused the app, and errors (not guesses) on a corrupt saved policy.
+- [ ] `reconcile` sets `argocd.argoproj.io/refresh: normal` — the self-cleaning analogue of Flux `requestedAt`.
+- [ ] `providers.Ops` gained NO new entries; the policy gate (`internal/action/policy.go`) gained NO engine/kind branches; `TestReviewArgoApplicationParity` proves an Application target flows through the reversible-only + blast-radius + kind + namespace gates unchanged.
+- [ ] `app.BuildExecutor` selects the executor by `gitops.engine`, `serve.go:105` uses it, and a unit test pins both branches.
+- [ ] Executed Argo actions are audited at the `NewAuditedExecutor` seam with the `Application/<ns>/<name>` target (unit test) — no audit-code changes.
+- [ ] Slack approve/reject buttons required NO changes (kind-agnostic block builder, `internal/notify/slack.go:550-563`) — verified, documented in this plan.
+- [ ] Chart's namespaced actions Role grants `argoproj.io/applications` `get, patch`; `helm template` proves it.
+- [ ] k3d e2e step 11 approves a pause-auto-sync action on `broken-argo` and asserts (a) `automated` removed, (b) prior policy saved in the annotation, (c) the execution is audit-logged — all pre-existing flux checks still pass.
+- [ ] README status bullet + `docs/configuration.md` actions section document the parity, the per-engine op table, and the Argo namespace/kinds allowlist guidance.
+- [ ] No new required config keys (simplicity constraint); no commit carries a Co-Authored-By line.

--- a/dev/superpowers/plans/2026-07-23-v1-prior-art-refresh.md
+++ b/dev/superpowers/plans/2026-07-23-v1-prior-art-refresh.md
@@ -1,0 +1,146 @@
+# V1 — Prior-art refresh (July 2026 landscape) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update `docs/prior-art.md` so its competitive claims match the July-2026 landscape: Komodor's Klaudia Memory launch, Aurora's real feature set, the Tracer-Cloud "opensre" name collision, Datadog's pricing collapse, and the ITBench-AA numbers.
+
+**Architecture:** Docs-only. One file modified, edits grouped into one commit. Every claim below was verified against primary sources during the 2026-07-23 competitive analysis; source URLs are embedded in the text so future refreshes can re-verify.
+
+**Tech Stack:** Markdown.
+
+---
+
+### Task 1: Update the open-source table (Aurora, OpenSRE collision)
+
+**Files:**
+- Modify: `docs/prior-art.md` (OSS table, lines ~11–18)
+
+- [ ] **Step 1: Replace the Aurora row**
+
+Replace the current one-line Aurora row:
+
+```markdown
+| **Aurora** (Arvo AI) | Hybrid RAG over docs; auto-generates postmortems. | Postmortems, not runbook self-update. | The RAG angle. We borrow hybrid retrieval. |
+```
+
+with:
+
+```markdown
+| [**Aurora**](https://github.com/Arvo-AI/aurora) (Arvo AI, Apache-2.0) | LangGraph agents running kubectl/aws/az/gcloud in sandboxed pods; **deployment diffs + Terraform/IaC analysis** as RCA input; RAG knowledge base "that grows over time" (Postgres + Weaviate + Memgraph); "Actions": auto-postmortems, **fix PRs**, Slack. Aggressive comparison-marketing vs Holmes/k8sgpt. | **Yes** — auto-ingested RAG KB. But locked in its databases: no review gate, no git export, no outcome signal. | **The fastest-moving OSS threat.** It has diffs, a KB, and PR machinery — combining them into knowledge-PRs is one feature away. Our structural answer: user-owned markdown, human review, outcome weighting. |
+```
+
+- [ ] **Step 2: Add the name-collision note to the OpenSRE row**
+
+Append to the end of the OpenSRE row's last cell (after "…rejected at recall time."):
+
+```markdown
+*(Naming hazard: the unrelated [Tracer-Cloud "opensre"](https://github.com/tracer-cloud/opensre) framework (~9k stars) absorbs most of the "OpenSRE" search traffic — don't confuse the two, and expect evaluators to.)*
+```
+
+- [ ] **Step 3: Render-check the table**
+
+Run: `grep -c '^|' docs/prior-art.md` and preview the file (any markdown previewer). Expected: table still renders, same column count per row.
+
+### Task 2: Update the change-aware and commercial sections (Klaudia Memory, Datadog pricing)
+
+**Files:**
+- Modify: `docs/prior-art.md` (sections "Change-aware RCA" and "Commercial", lines ~22–52)
+
+- [ ] **Step 1: Replace the Komodor bullet**
+
+Replace:
+
+```markdown
+- **Komodor** — workload-scoped **manifest-diff RCA** with Argo CD/Flux integration; Gartner 2026
+  "Representative Vendor". The closest commercial analogue to our diff spine.
+```
+
+with:
+
+```markdown
+- **Komodor** — workload-scoped **manifest-diff RCA** with Argo CD/Flux integration (the only
+  commercial vendor with explicit Flux support); Gartner 2026 "Representative Vendor". As of
+  [**Klaudia Memory** (2026-07-21)](https://komodor.com/platform/klaudia-ai-powered-troubleshooting/)
+  it also keeps persistent incident memory — the closest commercial analogue to RunLore overall,
+  now on both the diff spine *and* the learning loop. Its memory is closed and non-exportable;
+  ours is the differentiator that remains.
+```
+
+- [ ] **Step 2: Update the Datadog bullet**
+
+Replace:
+
+```markdown
+- **Datadog Change Tracking** — commit-level deploy correlation (no file-level source diff).
+```
+
+with:
+
+```markdown
+- **Datadog Change Tracking** — commit-level deploy correlation via APM deployment SHAs (`git log`
+  between deployments; no GitOps-revision semantics). Bits AI SRE went GA Dec 2025 with closed
+  investigation memory; its effective per-investigation price dropped ~75% in 2026 (from $25 to
+  ~$6.50 via pooled ["AI Credits"](https://www.nobs.tech/blog/datadog-bits-ai-pricing-ai-credits-governance)) —
+  per-investigation economics are racing to the bottom, which favors a BYO-model OSS entrant.
+```
+
+- [ ] **Step 3: Update the commercial memory line**
+
+Replace:
+
+```markdown
+- **Memory/learning** (Cleric, Resolve, PagerDuty, Google) is **all closed**.
+```
+
+with:
+
+```markdown
+- **Memory/learning** is now the specialists' *whole pitch* (Cleric "first self-learning AI SRE",
+  Komodor Klaudia Memory, NeuBird's vector-DB KB, AWS "Learned Skills", New Relic Knowledge) —
+  and **all of it is closed and non-exportable, without exception**. Portability + review is the
+  unoccupied position, not "learning".
+```
+
+### Task 3: Update the eval-reality section with ITBench-AA
+
+**Files:**
+- Modify: `docs/prior-art.md` (section "The eval reality", lines ~53–57)
+
+- [ ] **Step 1: Replace the section body**
+
+Replace:
+
+```markdown
+**ITBench** (IBM/ICML 2025) — frontier models identify the root cause **< 50%** of the time and fully
+resolve only **~11–14%** of real K8s incidents. Treat sub-50% as the baseline; design for failure; make
+honest uncertainty a feature, not a footnote.
+```
+
+with:
+
+```markdown
+**ITBench** (IBM/ICML 2025) — frontier models identify the root cause **< 50%** of the time and fully
+resolve only **~11–14%** of real K8s incidents. The successor
+[**ITBench-AA**](https://artificialanalysis.ai/evaluations/itbench-aa) (Artificial Analysis + IBM,
+May 2026) confirms it: the best frontier model scores **47%** on agentic IT tasks, with "confusing
+symptoms for root causes" the classic failure — while vendors market 92–94% accuracy. Treat sub-50%
+as the baseline; design for failure; make honest uncertainty a feature, not a footnote — and publish
+reproducible numbers (see the eval scorecard) where vendors publish claims.
+```
+
+- [ ] **Step 2: Proofread and commit**
+
+Read the full file once for flow and date consistency ("mid-2026" in the intro can stay).
+
+```bash
+git add docs/prior-art.md
+git commit -m "docs(prior-art): refresh to July 2026 — Klaudia Memory, Aurora, opensre collision, Datadog pricing, ITBench-AA"
+```
+
+## Acceptance criteria
+
+- [ ] `docs/prior-art.md` names Klaudia Memory with its date and draws the "closed vs portable memory" conclusion.
+- [ ] Aurora's row reflects diffs + RAG KB + fix PRs and names it the fastest-moving OSS threat.
+- [ ] The Tracer-Cloud "opensre" collision is noted.
+- [ ] Datadog pricing reflects the AI-Credits era; ITBench-AA numbers are cited with a source link.
+- [ ] No stale claim contradicts the 2026-07-23 competitive analysis.

--- a/dev/superpowers/plans/2026-07-23-v2-awesome-lists.md
+++ b/dev/superpowers/plans/2026-07-23-v2-awesome-lists.md
@@ -1,0 +1,65 @@
+# V2 — Awesome-list listings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Get RunLore listed on the two category awesome-lists it is currently absent from: `last9/awesome-sre-agents` and `agamm/awesome-ai-sre`.
+
+**Architecture:** Two small PRs on external repos. Not release-bound — can go out immediately. Forks and PRs must come from the maintainer's **personal** GitHub account (the agent's `gh` is a work account with read-only access to Smana repos; use `gh auth switch` or the web UI).
+
+**Tech Stack:** GitHub forks/PRs, Markdown.
+
+---
+
+### Task 1: PR to last9/awesome-sre-agents
+
+**Files:**
+- Modify (in fork): `README.md` of `last9/awesome-sre-agents`
+
+- [ ] **Step 1: Check the list's entry format and section layout**
+
+Open https://github.com/last9/awesome-sre-agents and note: which section fits (open-source agents), the exact entry format (link + one-line description, alphabetical or append), and the CONTRIBUTING rules if present.
+
+- [ ] **Step 2: Fork, branch, add the entry**
+
+Draft entry (adapt punctuation/casing to the list's house style, keep under one line):
+
+```markdown
+- [RunLore](https://github.com/Smana/runlore) - Open-source, self-hosted SRE agent that investigates Kubernetes incidents (GitOps-exact "what changed" diffs for Flux/Argo CD) and writes what it learns as PR-reviewed markdown into a Git knowledge base you own, with outcome-weighted instant recall. Read-only by default, model-agnostic.
+```
+
+- [ ] **Step 3: Open the PR**
+
+PR title: `Add RunLore`. PR body (one paragraph):
+
+```text
+Adds RunLore — an Apache-2.0, self-hosted SRE agent (single Go binary, runs in-cluster).
+Distinguishing traits vs the agents already listed: it learns from its own investigations into a
+PR-reviewed, user-owned Git knowledge base (OKF-compatible markdown), weights recall by real-world
+resolve rate, and anchors RCA on GitOps-revision-exact diffs (Flux + Argo CD). Ships a public eval
+harness. Disclosure: I'm the author.
+```
+
+- [ ] **Step 4: Record the PR URL in the roadmap issue** (tracking only; merge is not in our control)
+
+### Task 2: PR to agamm/awesome-ai-sre
+
+**Files:**
+- Modify (in fork): `README.md` of `agamm/awesome-ai-sre`
+
+- [ ] **Step 1: Check the list's entry format and section layout**
+
+Open https://github.com/agamm/awesome-ai-sre — same checks as Task 1 Step 1. This list separates open-source vs commercial; RunLore goes in open-source.
+
+- [ ] **Step 2: Fork, branch, add the entry**
+
+Same draft entry as Task 1 Step 2, adapted to this list's style.
+
+- [ ] **Step 3: Open the PR** — same title/body pattern as Task 1 Step 3 (keep the author disclosure).
+
+- [ ] **Step 4: Record the PR URL in the roadmap issue**
+
+## Acceptance criteria
+
+- [ ] One PR open (or merged) on each list, entry accurate and in house style, author disclosure included.
+- [ ] PR URLs recorded on the V2 roadmap issue.
+- [ ] If a list maintainer requests changes, follow up within a week (these PRs are cheap goodwill).

--- a/dev/superpowers/plans/2026-07-23-v3-okf-listing.md
+++ b/dev/superpowers/plans/2026-07-23-v3-okf-listing.md
@@ -1,0 +1,68 @@
+# V3 — OKF ecosystem listing + README positioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Claim the first-mover position as the first SRE agent that *produces* OKF entries: get RunLore listed in the OKF ecosystem, and state the claim in RunLore's own README.
+
+**Architecture:** One external contribution (OKF ecosystem/tools listing) + one small README edit in this repo. The external part is not release-bound. External PRs from the maintainer's personal account (agent `gh` is read-only on the relevant repos).
+
+**Tech Stack:** GitHub PRs, Markdown.
+
+---
+
+### Task 1: Find the right OKF listing surface and submit
+
+**Files:**
+- Modify (in fork): the OKF ecosystem/tools list source (locate first — see Step 1)
+
+- [ ] **Step 1: Locate the canonical listing surface**
+
+Check, in order: (a) https://okf.md/tools/ — find its source repo (footer/GitHub link); (b) `GoogleCloudPlatform/knowledge-catalog` — look for an ECOSYSTEM/ADOPTERS/tools file or a "who's using OKF" section in the README/docs. Pick whichever accepts community entries (both if both do).
+
+- [ ] **Step 2: Draft the entry**
+
+Adapt to the target's format; the substance:
+
+```markdown
+- [RunLore](https://github.com/Smana/runlore) — open-source SRE agent that **produces** OKF entries:
+  every incident investigation is drafted as an OKF-compatible markdown entry and opened as a PR in
+  a Git knowledge base the user owns; merged entries are re-indexed for instant recall, weighted by
+  real-world resolve rate. (Producer + consumer.)
+```
+
+- [ ] **Step 3: Open the PR** with the author disclosure, and record the URL on the V3 roadmap issue.
+
+### Task 2: State the claim in RunLore's README
+
+**Files:**
+- Modify: `README.md` (the "Why RunLore" section, the OKF-linking sentence around line 226)
+
+- [ ] **Step 1: Sharpen the OKF sentence**
+
+Replace (in the paragraph starting "The wedge is the **combination**…"):
+
+```markdown
+catalog you own ([OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible markdown,
+not a proprietary store), from an agent that's **honest about the sub-50% reality**:
+```
+
+with:
+
+```markdown
+catalog you own — [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible
+markdown, not a proprietary store; as far as we know RunLore is the **first agent that *produces*
+OKF entries from its own investigations** — from an agent that's **honest about the sub-50% reality**:
+```
+
+- [ ] **Step 2: Proofread and commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): claim first-mover OKF-producing agent positioning"
+```
+
+## Acceptance criteria
+
+- [ ] RunLore appears (PR open or merged) on at least one OKF ecosystem/tools listing, described as a producer.
+- [ ] README states the OKF-producer claim, hedged with "as far as we know" (honesty posture).
+- [ ] Claim is re-verified against the OKF ecosystem list at PR time (if another agent-producer appeared meanwhile, soften to "among the first").

--- a/dev/superpowers/plans/2026-07-23-v4-readme-surfacing.md
+++ b/dev/superpowers/plans/2026-07-23-v4-readme-surfacing.md
@@ -1,0 +1,56 @@
+# V4 — README: surface the hidden strengths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make three currently code-only differentiators visible to a first-time README reader: the recall trust gates (outcome decay + margin gate + verify-on-recall), and the MCP server/client. (`source_diff` is already surfaced at README lines 40–41 — out of scope here.)
+
+**Architecture:** Docs-only, one file, one commit. Additions are deliberately compact — the README is already long; each addition earns its place by being a differentiator no competitor can claim.
+
+**Tech Stack:** Markdown.
+
+---
+
+### Task 1: Add "why a recall can be trusted" to the learning-loop section
+
+**Files:**
+- Modify: `README.md` (learning-loop section, after the paragraph ending "…knowledge that keeps failing decays." around line 107)
+
+- [ ] **Step 1: Insert the trust-gates paragraph**
+
+Insert after "…knowledge that keeps failing decays.":
+
+```markdown
+An instant recall is never a blind cache hit — three gates stand in front of it: the entry must
+**structurally match** the incident (same workload/resource, retrieval score above a floor), it must
+**win by a clear margin** over the runner-up entry (ambiguous matches fall through to a full
+investigation), and its confidence is **weighted by its real-world track record** — an entry that
+keeps resolving incidents gains trust, one that keeps failing decays toward re-investigation.
+Even then, the recalled finding goes through the same adversarial verify pass as a fresh one; the
+shipped eval suite includes a poisoned-entry scenario proving a bad entry is rejected at recall time.
+```
+
+- [ ] **Step 2: Render-check** — preview the README; the paragraph sits between the decay sentence and the "→ How the learning loop works" link line.
+
+### Task 2: Add MCP to the integrations table
+
+**Files:**
+- Modify: `README.md` (integrations table, lines ~145–156)
+
+- [ ] **Step 1: Add the row** (after the "Knowledge base (git forge)" row):
+
+```markdown
+| **MCP** | Server — query your KB from Claude Code / any MCP client · Client — wire external MCP tool servers into investigations (allowlist-gated) | `mcp.*` |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): surface recall trust gates and MCP server/client"
+```
+
+## Acceptance criteria
+
+- [ ] A README reader learns the three recall gates and the verify-on-recall behavior without reading code.
+- [ ] MCP server + client appear in the integrations table with the `mcp.*` config pointer.
+- [ ] No duplication with docs/learning-loop.md phrasing (README stays the summary; the doc keeps the detail).

--- a/dev/superpowers/specs/2026-07-23-v0.11.0-roadmap-design.md
+++ b/dev/superpowers/specs/2026-07-23-v0.11.0-roadmap-design.md
@@ -1,0 +1,78 @@
+# v0.11.0 roadmap — design
+
+**Date:** 2026-07-23
+**Status:** proposed (this PR carries the spec and the per-item plans only; implementation follows later, item by item)
+
+## Context
+
+A competitive analysis (July 2026) of the AI-SRE landscape — OSS (HolmesGPT, k8sgpt, kagent,
+OpenSRE, Aurora) and commercial (Komodor/Klaudia Memory, Cleric, Resolve, NeuBird, Datadog Bits,
+Azure SRE Agent, …) — concluded:
+
+- RunLore's core differentiator **still holds and is unique**: a user-owned, PR-reviewed,
+  outcome-weighted knowledge catalog in plain markdown/OKF. No OSS or commercial tool ships that
+  combination; every commercial "memory" is closed and non-exportable.
+- Each pillar is eroding individually: Komodor announced **Klaudia Memory** (2026-07-21),
+  **Aurora (Arvo AI)** has deployment diffs + a growing RAG KB + fix-PR machinery, and "learning"
+  is now a commodity marketing word.
+- The bottleneck is **distribution and day-one value**, not features: RunLore is absent from the
+  category's awesome-lists and the OKF ecosystem lists, the Helm chart requires `git clone`,
+  the eval results are not public, and the catalog only pays off after incidents accumulate.
+
+This roadmap turns the analysis into one release: **v0.11.0**.
+
+## Decisions
+
+1. **Single milestone.** All eleven items target the next release, `v0.11.0`. No intermediate
+   release; the tag/release decision stays with the maintainer.
+2. **Ordered phases inside the milestone.** The four analysis themes become the tackle-one-by-one
+   sequence: Visibility → Get found → Value on day one → Meet users where they are.
+3. **Staging pattern.** Each item is prepared on its own branch/PR; the maintainer reviews and
+   merges. Nothing is merged or released by the agent (same pattern as the staged v0.9.0).
+4. **Tracking.** GitHub milestone `v0.11.0` + one issue per item. Issue bodies derive from each
+   plan's *Goal / Acceptance criteria* sections. Milestone and issues are created manually by the
+   maintainer (agent `gh` access to this repo is read-only).
+5. **External items are not release-bound.** V2/V3 (listing PRs on third-party repos) can go out
+   immediately and merely get tracked in the milestone.
+6. **Scope guard.** Explicitly excluded, per the analysis and the project's simplicity constraint
+   (no new *required* config, no second binary, no UI): web UI, new observability toolsets beyond
+   the planned ones, autonomy-ladder expansion, and anything competing with HolmesGPT on toolset
+   breadth or with funded vendors on autonomy ceiling.
+
+## Work queue
+
+| Phase | ID | Item | Type | Plan |
+|---|---|---|---|---|
+| 1 · Visibility | V1 | Refresh `docs/prior-art.md` to the July-2026 landscape | docs | [plan](../plans/2026-07-23-v1-prior-art-refresh.md) |
+| 1 · Visibility | V2 | Listing PRs to `last9/awesome-sre-agents` and `agamm/awesome-ai-sre` | external | [plan](../plans/2026-07-23-v2-awesome-lists.md) |
+| 1 · Visibility | V3 | OKF ecosystem listing + "OKF-producing agent" README positioning | external + docs | [plan](../plans/2026-07-23-v3-okf-listing.md) |
+| 1 · Visibility | V4 | README: surface `source_diff`, outcome decay, recall margin gate, MCP server | docs | [plan](../plans/2026-07-23-v4-readme-surfacing.md) |
+| 2 · Get found | F1 | Publish the Helm chart to GHCR as an OCI artifact | code/CI | [plan](../plans/2026-07-23-f1-helm-oci.md) |
+| 2 · Get found | F2 | Public eval scorecard from the nightly eval | code/CI | [plan](../plans/2026-07-23-f2-eval-scorecard.md) |
+| 3 · Day-one value | D1 | Runbook/KB import — seed the catalog from existing markdown | code | [plan](../plans/2026-07-23-d1-runbook-import.md) |
+| 3 · Day-one value | D2 | Curator automation phase 2 — lifecycle sweeps production-ready | code | [plan](../plans/2026-07-23-d2-curator-automation.md) |
+| 4 · Meet users | M1 | Loki logs backend | code | [plan](../plans/2026-07-23-m1-loki-backend.md) |
+| 4 · Meet users | M2 | GitLab forge for the knowledge base | code | [plan](../plans/2026-07-23-m2-gitlab-forge.md) |
+| 4 · Meet users | M3 | Argo CD executor — approve-rung parity with Flux | code | [plan](../plans/2026-07-23-m3-argocd-executor.md) |
+
+### Ordering rationale
+
+Visibility items are near-free and compound with time, so they come first. "Get found" (F1/F2)
+precedes "day-one value" because the OCI chart and the public scorecard are what convert an
+evaluator who arrives through the listings. Integrations (M1–M3) come last: each serves a
+*segment* of users, while D1/D2 serve every user.
+
+### Known risk
+
+Eleven items in one release is large for a solo-maintained project. The mitigations are built into
+the decisions above: external items ship immediately regardless of the release, every item lands
+independently mergeable, and the release cut is a judgement call the maintainer can take early if
+the milestone drags.
+
+## Positioning changes carried by this release (summary)
+
+- Lead with **ownership, review, and outcome-weighting** — not "it learns" (now a commodity claim).
+- Claim **first-mover on OKF production**: no other agent writes its learnings as OKF entries.
+- Keep the honest-evals stance and make it verifiable (F2): independent benchmarks (ITBench-AA)
+  put frontier models below 50% on agentic IT tasks while vendors claim 92–94%; publishing
+  reproducible numbers is a wedge no competitor is likely to follow.


### PR DESCRIPTION
  ## What

  Docs only — no code changes. This PR adds the **v0.11.0 roadmap**: one design spec and eleven
  per-item implementation plans under `dev/superpowers/`. Implementation comes later, item by item,
  each on its own branch/PR.

  ## Why

  A competitive analysis of the AI-SRE landscape (July 2026, OSS + commercial) concluded that
  RunLore's core differentiator — a user-owned, PR-reviewed, outcome-weighted knowledge catalog —
  is still unique, but each pillar is eroding (Komodor shipped "Klaudia Memory" on 2026-07-21;
  Aurora has diffs + a RAG KB + fix-PR machinery), and the real bottleneck is **distribution and
  day-one value**, not features. This roadmap turns that analysis into the next release.

  ## The work queue (all target v0.11.0, in order)

  | Phase | Items |
  |---|---|
  | 1 · Visibility | V1 prior-art refresh · V2 awesome-list PRs · V3 OKF ecosystem listing · V4 README recall-gates/MCP surfacing |
  | 2 · Get found | F1 Helm chart on GHCR (OCI) · F2 public eval scorecard |
  | 3 · Day-one value | D1 `lore kb import` (cold-start) · D2 curator sweeps in-server |
  | 4 · Meet users | M1 Loki logs backend · M2 GitLab forge · M3 Argo CD executor |

  Full rationale, decisions, and scope guard in
  [`dev/superpowers/specs/2026-07-23-v0.11.0-roadmap-design.md`](dev/superpowers/specs/2026-07-23-v0.11.0-roadmap-design.md);
  each item links to a self-contained plan in `dev/superpowers/plans/`.

  ## Review pointers

  A few decisions the plans lock in that deserve a deliberate look:

  - **F1**: publish on tag to `oci://ghcr.io/smana/charts/runlore`, cosign-signed; requires a
    one-time manual step to make the GHCR package public.
  - **F2**: scorecard publishes to an orphan `eval-scorecard` branch, on failure nights too.
  - **D1**: extracts the forge entry renderer into a shared `internal/okf` package (reused by M2).
  - **D2**: sweeps default to **dry-run**; one config key flips them to apply mode.
  - **M3**: the `argocd` namespace is deliberately *not* added to the built-in protected set —
    users allowlist it explicitly (security-posture call to confirm).

  ## Next steps after merge

  Create the `v0.11.0` milestone + one issue per item (bodies = each plan's Goal + Acceptance
  criteria), then tackle the queue top-down starting with V1.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)