### PR TITLE
docs(readme): claim first-mover OKF-producing agent positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,8 +221,9 @@ RunLore is **GitOps-engine-agnostic** (Flux + Argo CD), **metrics-backend-agnost
 (VictoriaMetrics + Prometheus), with pluggable logs and CNI-agnostic network signals. Change-aware RCA
 isn't unique — commercial tools (Komodor, Anyshift) diff changes too ([prior art](docs/prior-art.md)).
 The wedge is the **combination the open tools don't have**: that signal feeding an **open, portable
-catalog you own** ([OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible markdown,
-not a proprietary store), from an agent that's **honest about the sub-50% reality**:
+catalog you own** — [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)-compatible
+markdown, not a proprietary store; as far as we know RunLore is the **first agent that *produces*
+OKF entries from its own investigations** — from an agent that's **honest about the sub-50% reality**:
 
 - `unresolved` is a first-class answer;
 - an adversarial *verify* pass can only ever *lower* a finding's confidence, never raise it;


### PR DESCRIPTION
Part of the **v0.11.0** roadmap — Phase 1 (Visibility), item **V3** (README half; the external OKF-ecosystem listing PR is tracked separately).

## Change
Sharpens the OKF sentence in the "Why RunLore" section to claim the first-mover position: as far as we know, RunLore is the **first agent that *produces* OKF entries from its own investigations** — every investigation drafted as OKF-compatible markdown and opened as a PR in a Git knowledge base the user owns.

The claim keeps the honest **"as far as we know"** hedge (the project's honesty posture); if another agent-producer surfaces during OKF-listing review, soften to "among the first".

## Verification
- Docs-only, one file, one commit.
- Bold/italic markers balanced (4 pairs across the paragraph); the closing `**` on "catalog you own" preserved.

## Acceptance criteria
- [x] README states the OKF-producer claim, hedged with "as far as we know".
- [ ] Re-verify against the OKF ecosystem list at listing-PR time (handled with the external V3 listing).