### PR TITLE
ci: publish Helm chart to GHCR as an OCI artifact (F1)

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,108 @@
+name: Release Chart
+
+# Publishes deploy/helm/runlore to GHCR as an OCI artifact:
+#   helm install runlore oci://ghcr.io/smana/charts/runlore
+#
+# Triggered by the v* tag (created by release-please via its PAT, same as
+# release-binaries.yml). No separate chart versioning exists: release-please
+# bumps Chart.yaml version/appVersion in the release PR (extra-files in
+# release-please-config.json), so the chart version equals the tag by
+# construction — the guard step below enforces it. GoReleaser owns the
+# binaries and the container image; this workflow owns the chart artifact.
+# workflow_dispatch exists for a one-time backfill publish of the current
+# chart version from main (the guard only runs on tag refs).
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+# Top-level least privilege; the job elevates only what it needs.
+permissions:
+  contents: read
+
+env:
+  CHART: deploy/helm/runlore
+
+jobs:
+  publish:
+    name: Package, push and sign
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Push the chart OCI artifact to GHCR (GitHub Packages).
+      packages: write
+      # Keyless cosign signing of the pushed chart digest — the OIDC token
+      # identifies this workflow to Fulcio (same posture as the release image
+      # and checksums in release-binaries.yml).
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      # Guard: on tag refs the chart version must equal the tag. release-please
+      # keeps them in lockstep, so a mismatch means a hand-crafted or re-pointed
+      # tag — refuse to publish a mislabeled chart. Skipped on workflow_dispatch
+      # from a branch (the backfill case).
+      - name: Verify chart version matches tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          chart_version="$(awk '/^version:/ {print $2}' "$CHART/Chart.yaml")"
+          if [[ "v${chart_version}" != "${GITHUB_REF_NAME}" ]]; then
+            echo "Chart.yaml version v${chart_version} does not match tag ${GITHUB_REF_NAME}" >&2
+            exit 1
+          fi
+
+      - name: Log in to GHCR (helm registry)
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin <<< "$GHCR_TOKEN"
+
+      # helm lint also validates values.yaml against values.schema.json —
+      # cheap last-line defense even though chart.yml gates every chart change.
+      - name: Lint and package
+        run: |
+          set -euo pipefail
+          helm lint "$CHART"
+          helm package "$CHART" -d dist/
+
+      # ghcr/OCI refs must be lowercase; github.repository_owner can contain
+      # uppercase (e.g. "Smana") — same normalization as build-image.yml.
+      # Capture the pushed digest from helm's output for signing.
+      - name: Push chart to GHCR
+        id: push
+        run: |
+          set -euo pipefail
+          owner="${{ github.repository_owner }}"
+          repo="ghcr.io/${owner,,}/charts"
+          out="$(helm push dist/runlore-*.tgz "oci://${repo}" 2>&1)"
+          echo "$out"
+          digest="$(sed -n 's/^Digest: //p' <<< "$out")"
+          if [[ -z "$digest" ]]; then
+            echo "could not parse pushed digest from helm output" >&2
+            exit 1
+          fi
+          echo "ref=${repo}/runlore" >> "$GITHUB_OUTPUT"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign chart (cosign keyless)
+        run: cosign sign --yes "${{ steps.push.outputs.ref }}@${{ steps.push.outputs.digest }}"
+
+      - name: Publish summary
+        run: |
+          {
+            echo "## Helm chart published"
+            echo ""
+            echo '```bash'
+            echo "helm install runlore oci://${{ steps.push.outputs.ref }} --version <version> -n runlore --create-namespace -f values.yaml"
+            echo '```'
+            echo ""
+            echo "**Digest**: \`${{ steps.push.outputs.digest }}\`"
+            echo "**Signature**: cosign keyless (Fulcio, GitHub Actions OIDC)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -196,12 +196,15 @@ Wire your credentials into a Kubernetes `Secret`, point the chart at them via a 
 (GitOps engine, LLM endpoint, KB repo, notification), and install:
 
 ```bash
-helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml
+helm install runlore oci://ghcr.io/smana/charts/runlore -n runlore --create-namespace -f values.yaml
 ```
 
-> The chart ships **in this repo** (`git clone` first) — there is no `helm repo add` / OCI registry
-> yet. A minimal starting point for `values.yaml` is
+> The chart is an **OCI artifact on GHCR** — no `git clone`, no `helm repo add`. It is published and
+> cosign-signed on every release; pin a version with `--version X.Y.Z`. A minimal starting point for
+> `values.yaml` is
 > [`deploy/helm/runlore/values-minimal.yaml`](deploy/helm/runlore/values-minimal.yaml).
+> Working from a clone (dev alternative):
+> `helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml`.
 
 Then point a source at RunLore — for example, route your Alertmanager alerts to
 `http://runlore.runlore.svc:8080/webhook/alertmanager` — and it starts investigating immediately.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -385,14 +385,24 @@ config:
 
 ### Install
 
-With the `values.yaml` above, deploy RunLore with a single command:
+With the `values.yaml` above, deploy RunLore with a single command — the chart is an OCI artifact
+on GHCR, published on every release:
 
 ```bash
-helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml
+helm install runlore oci://ghcr.io/smana/charts/runlore -n runlore --create-namespace -f values.yaml
 ```
 
-> The chart needs the `deploy/helm/runlore` directory from this repo. A packaged chart repo is on the
-> roadmap; for now, `git clone` and install from the path (or `helm package` it yourself).
+> Pin a version with `--version X.Y.Z` (the chart version tracks the RunLore release).
+> **Dev alternative** — working from a clone of this repo, install from the chart path instead:
+> `helm install runlore deploy/helm/runlore -n runlore --create-namespace -f values.yaml`.
+
+Every published chart is **cosign keyless-signed**. To verify before installing (optional):
+
+```bash
+cosign verify ghcr.io/smana/charts/runlore:<version> \
+  --certificate-identity-regexp 'https://github.com/Smana/runlore/\.github/workflows/release-chart\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
 
 ---
 

--- a/docs/upgrade-uninstall.md
+++ b/docs/upgrade-uninstall.md
@@ -4,10 +4,11 @@ How to upgrade RunLore in place, what survives a restart, and how to remove it c
 
 ## Upgrading
 
-RunLore is a Helm release — upgrade like any other chart:
+RunLore is a Helm release — upgrade like any other chart (the chart is an OCI artifact on GHCR;
+from a clone of this repo, use the `deploy/helm/runlore` path instead):
 
 ```bash
-helm upgrade runlore deploy/helm/runlore -n runlore -f values.yaml
+helm upgrade runlore oci://ghcr.io/smana/charts/runlore -n runlore -f values.yaml
 ```
 
 Your `values.yaml` is the source of truth; the entire agent config under `values.config` is rendered


### PR DESCRIPTION
Part of the **v0.11.0** roadmap — Phase 2 (Get found), item **F1**.

Lets users install without cloning the repo:

```bash
helm install runlore oci://ghcr.io/smana/charts/runlore -n runlore --create-namespace -f values.yaml
```

## Changes
- **New workflow** `.github/workflows/release-chart.yml` — on every `v*` tag (and `workflow_dispatch` for backfill): guards that `Chart.yaml` version equals the tag, `helm push`es the chart to `oci://ghcr.io/<owner>/charts`, and **cosign keyless-signs** the pushed digest. Same trigger + supply-chain posture as `release-binaries.yml`; GoReleaser keeps owning the binaries + image, this workflow owns the chart.
- **Docs switch to OCI install** — `README.md`, `docs/getting-started.md` (with an optional `cosign verify` snippet), `docs/upgrade-uninstall.md`. The `git clone` path stays documented as the dev alternative.
- **No new versioning scheme** — chart version stays owned by release-please `extra-files` on `Chart.yaml` (zero changes to `release-please-config.json`).

## Verification (local)
- `helm lint` + `helm package` — clean (chart 0.10.0).
- Real OCI push/pull roundtrip against a throwaway `registry:2`: `helm push` prints `Pushed:`/`Digest:` (the exact lines the job parses) and `helm template` renders manifests.
- `actionlint` on the new workflow — exit 0.
- Action SHA pins match the repo's existing pins (checkout v7.0.0, setup-helm v5.0.1, cosign-installer v4.1.2).

## Post-merge — maintainer actions (cannot be automated; GHCR/Fulcio path only exists in Actions)
1. **Backfill**: trigger `Release Chart` via `workflow_dispatch` on `main` to publish the current chart (0.10.0), so the new install command works before v0.11.0 is tagged.
2. **Make public**: in GitHub → Packages, set `charts/runlore` to **Public** and link it to the repo (first push creates it private; pulls 403 until then).
3. On the next tag (v0.11.0), confirm the guard passes, the chart lands as `ghcr.io/smana/charts/runlore:0.11.0`, and `cosign verify` succeeds.