### PR TITLE
feat(cli): lore kb import — seed the catalog from existing runbooks (D1)

### DIFF
--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -29,6 +29,7 @@ Usage:
   lore catalog sync [--config <path>]                 clone/pull + index the knowledge catalog
   lore kb search <query> [--config <path>] [--dir <catalog>] [-k 10] [--json] [--ledger <jsonl>]   search the knowledge base
   lore kb show <entry> [--config <path>] [--dir <catalog>]   print one KB entry (frontmatter card + body)
+  lore kb import <src-dir> [--into <kb-dir>] [--dry-run] [--model]   convert existing runbooks/postmortems into OKF entries (cold-start seeding)
   lore eval [--config <path>] [--cases <dir>]         replay recorded cases, score RCA identification
   lore eval --live [--scenarios <dir>] [--n 3]        live-fire on the cluster: grade coverage + RCA
   lore eval --compare <spec.yaml> [--n 3]             benchmark several models over the replay suite

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,6 +125,44 @@ incidents, platform constraints.
 
 ---
 
+## Step 1b — Seed the catalog from your existing runbooks (optional)
+
+You don't have to start empty. If your team already keeps markdown runbooks or
+postmortems anywhere, import them and get recall value on day one:
+
+```bash
+# preview what would be written — nothing is touched
+lore kb import ./our-runbooks --into ./kb --dry-run
+
+# convert + validate + dedup, then write into your local KB checkout
+lore kb import ./our-runbooks --into ./kb
+cd kb && git add . && git commit -m "seed catalog from existing runbooks" && git push
+```
+
+What `import` does, deterministically (no model, no config needed beyond the
+directory paths):
+
+- **Adds/normalizes OKF frontmatter** — title from the existing frontmatter or
+  the first heading (filename as last resort), description from the first
+  paragraph, tags from the document's own tags **plus detected alert names**
+  (`KubePodCrashLooping`-style tokens in headings and alert-mentioning lines —
+  exactly the recall signal that lets a future alert find the runbook).
+- **Classifies** — a document that already carries `Symptom`/`Cause`/`Resolution`
+  sections *and* names a `resource` becomes an `Incident`; everything else is a
+  `Playbook` (free-form runbooks validate relaxed, same as hand-written entries).
+- **Validates** every entry with the same merge gate as `lore validate-kb` —
+  nothing is written that the gate would later reject.
+- **Dedups** against what the catalog already holds (exact and fuzzy title, same
+  rule the curator uses for duplicate PRs) and skips it with a printed reason.
+
+Nothing is committed for you: you review the diff and push, the same
+human-in-the-loop bar as every RunLore KB PR. With `--model`, the LLM already
+configured in your `runlore.yaml` refines titles/descriptions/tags (purely
+optional — a model failure falls back to the deterministic result). Re-running
+the same import is a no-op.
+
+---
+
 ## Step 2 — GitHub App for curation (optional)
 
 The **Curator** writes findings back to your KB repo: confident, *verified* root causes become a **PR**

--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -22,7 +22,7 @@ import (
 // sync` remains the machine/ops write surface; `lore kb` is how a person asks
 // "what do we already know about this?" without an MCP client or a cluster.
 func RunKB(args []string) error {
-	const usage = "usage: lore kb search <query> [flags] | lore kb show <entry> [flags]"
+	const usage = "usage: lore kb search <query> [flags] | lore kb show <entry> [flags] | lore kb import <src-dir> [flags]"
 	if len(args) == 0 {
 		return fmt.Errorf("%s", usage)
 	}
@@ -31,6 +31,8 @@ func RunKB(args []string) error {
 		return runKBSearch(args[1:], os.Stdout)
 	case "show":
 		return runKBShow(args[1:], os.Stdout)
+	case "import":
+		return runKBImport(args[1:], os.Stdout)
 	}
 	return fmt.Errorf("unknown kb subcommand %q\n%s", args[0], usage)
 }

--- a/internal/app/kb_import.go
+++ b/internal/app/kb_import.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/kbimport"
+	"github.com/Smana/runlore/internal/kbvalidate"
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// runKBImport is `lore kb import <src-dir>`: the cold-start seeder. It
+// converts existing markdown runbooks/postmortems into OKF entries in a local
+// KB checkout — inferred frontmatter, merge-gate validation, dedup against
+// the live catalog — and writes files for the HUMAN to review and commit.
+// Nothing is committed or pushed; the review stays in Git, like every KB PR.
+func runKBImport(args []string, w io.Writer) error {
+	fset := flag.NewFlagSet("kb import", flag.ContinueOnError)
+	cfgPath := fset.String("config", "runlore.yaml", "path to config file")
+	into := fset.String("into", "", "local KB checkout to write into (default: config catalog.dir)")
+	dryRun := fset.Bool("dry-run", false, "print the import plan; write nothing")
+	useModel := fset.Bool("model", false, "refine frontmatter with the configured model (optional; import is deterministic without it)")
+	rest, err := parseInterleaved(fset, args)
+	if err != nil {
+		return err
+	}
+	const usage = "usage: lore kb import <src-dir> [--into <kb-dir>] [--dry-run] [--model] [--config <path>]"
+	if len(rest) != 1 {
+		return fmt.Errorf("%s", usage)
+	}
+	src := rest[0]
+
+	dest := *into
+	if dest == "" {
+		cfg, cerr := config.Load(*cfgPath)
+		if cerr != nil {
+			return fmt.Errorf("load config: %w (or pass --into <kb-dir>)", cerr)
+		}
+		dest = cfg.Catalog.Dir
+		if dest == "" {
+			return fmt.Errorf("no destination (set catalog.dir or pass --into <kb-dir>)")
+		}
+	}
+	if st, serr := os.Stat(dest); serr != nil || !st.IsDir() {
+		return fmt.Errorf("KB dir %s is not a directory (clone your KB repo checkout first): %v", dest, serr)
+	}
+
+	// Optional model — same opt-in shape as `lore validate-kb --semantic`:
+	// no usable model config degrades to deterministic-only with a warning.
+	var model providers.ModelProvider
+	if *useModel {
+		if cfg, cerr := config.Load(*cfgPath); cerr == nil && ModelConfigured(cfg) {
+			model = BuildModel(cfg, os.Getenv(cfg.Model.APIKeyEnv))
+		} else {
+			fmt.Fprintln(os.Stderr, "kb import: --model set but no usable model in config; running deterministic only")
+		}
+	}
+
+	// Existing catalog, loaded tolerantly: an EMPTY checkout is fine (that is
+	// the cold start this command exists for), and one malformed existing
+	// entry must not block seeding (catalog.Load already skip-warns).
+	existing, skippedLoad, err := catalog.Load(dest)
+	if err != nil {
+		return fmt.Errorf("load existing catalog %s: %w", dest, err)
+	}
+	for _, s := range skippedLoad {
+		fmt.Fprintf(os.Stderr, "warning: existing entry skipped during dedup scan: %s\n", s)
+	}
+
+	sources, err := collectSources(src)
+	if err != nil {
+		return err
+	}
+	if len(sources) == 0 {
+		return fmt.Errorf("no importable .md files under %s", src)
+	}
+
+	results := make([]kbimport.Result, 0, len(sources))
+	for _, p := range sources {
+		data, rerr := os.ReadFile(p) //nolint:gosec // G304: user-passed import directory
+		if rerr != nil {
+			return rerr
+		}
+		rel, _ := filepath.Rel(src, p)
+		r := kbimport.Infer(data, rel)
+		if model != nil {
+			r = kbimport.Enrich(context.Background(), r, model)
+		}
+		results = append(results, r)
+	}
+
+	actions := kbimport.Plan(results, existing)
+
+	// Merge-gate validation: never write an entry `lore validate-kb` would
+	// reject. Errors demote the action to a skip; warnings are reported only.
+	for i := range actions {
+		if actions[i].Skip {
+			continue
+		}
+		issues := kbvalidate.ValidateStructural(toCatalogEntry(actions[i].Result))
+		for _, iss := range issues {
+			if iss.Severity == kbvalidate.SeverityWarning {
+				actions[i].Warnings = append(actions[i].Warnings, fmt.Sprintf("%s: %s", iss.Field, iss.Message))
+			}
+		}
+		if kbvalidate.HasErrors(issues) {
+			first := firstError(issues)
+			actions[i].Skip = true
+			actions[i].Reason = fmt.Sprintf("fails validation: %s: %s", first.Field, first.Message)
+		}
+	}
+
+	imported, skipped := 0, 0
+	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "ACTION\tSOURCE\tDEST\tTYPE\tTITLE / REASON")
+	for _, a := range actions {
+		for _, warn := range a.Warnings {
+			fmt.Fprintf(os.Stderr, "warning: %s: %s\n", a.Source, warn)
+		}
+		if a.Skip {
+			skipped++
+			fmt.Fprintf(tw, "skip\t%s\t-\t-\t%s\n", a.Source, a.Reason)
+			continue
+		}
+		imported++
+		fmt.Fprintf(tw, "import\t%s\t%s\t%s\t%s\n", a.Source, a.DestPath, a.Entry.Type, truncateCell(a.Entry.Title, 60))
+		if *dryRun {
+			continue
+		}
+		out := filepath.Join(dest, filepath.FromSlash(a.DestPath))
+		if merr := os.MkdirAll(filepath.Dir(out), 0o755); merr != nil {
+			return merr
+		}
+		if werr := os.WriteFile(out, []byte(okf.Render(a.Entry, a.Meta)), 0o644); werr != nil { //nolint:gosec // G306: catalog files are world-readable docs
+			return werr
+		}
+	}
+	_ = tw.Flush()
+	if *dryRun {
+		fmt.Fprintf(w, "\ndry-run: would import %d, skip %d (of %d sources); nothing written\n", imported, skipped, len(actions))
+		return nil
+	}
+	fmt.Fprintf(w, "\nimported %d, skipped %d (of %d sources) into %s — review the diff, then commit and push\n",
+		imported, skipped, len(actions), dest)
+	return nil
+}
+
+// collectSources walks src for importable markdown, mirroring catalog.Load's
+// skip rules (internal/catalog/load.go): hidden files/dirs, non-.md, and the
+// reserved index.md / log.md / README.md are not knowledge entries.
+func collectSources(src string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		base := d.Name()
+		if d.IsDir() {
+			if path != src && strings.HasPrefix(base, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".md") {
+			return nil
+		}
+		if base == "index.md" || base == "log.md" || strings.EqualFold(base, "readme.md") {
+			return nil
+		}
+		out = append(out, path)
+		return nil
+	})
+	return out, err
+}
+
+// toCatalogEntry adapts an import result to the validator's input type —
+// the SAME struct the loader produces, so "valid at import" and "valid at
+// merge" are one predicate.
+func toCatalogEntry(r kbimport.Result) catalog.Entry {
+	return catalog.Entry{
+		Type: r.Entry.Type, Title: r.Entry.Title, Description: r.Entry.Description,
+		Resource: r.Entry.Resource, Tags: r.Entry.Tags, Body: r.Entry.Body,
+		Timestamp: r.Meta.Timestamp, Status: r.Meta.Status, LastValidated: r.Meta.LastValidated,
+		Path: r.DestPath,
+	}
+}
+
+func firstError(issues []kbvalidate.Issue) kbvalidate.Issue {
+	for _, iss := range issues {
+		if iss.Severity == kbvalidate.SeverityError {
+			return iss
+		}
+	}
+	return kbvalidate.Issue{Field: "unknown", Message: "validation error"}
+}

--- a/internal/app/kb_import.go
+++ b/internal/app/kb_import.go
@@ -42,26 +42,37 @@ func runKBImport(args []string, w io.Writer) error {
 	}
 	src := rest[0]
 
+	// Config is needed to resolve a default destination (catalog.dir) and/or the
+	// model; load it once when either path needs it, then reuse the parse below.
+	var cfg *config.Config
+	var cfgErr error
+	if *into == "" || *useModel {
+		cfg, cfgErr = config.Load(*cfgPath)
+	}
+
 	dest := *into
 	if dest == "" {
-		cfg, cerr := config.Load(*cfgPath)
-		if cerr != nil {
-			return fmt.Errorf("load config: %w (or pass --into <kb-dir>)", cerr)
+		if cfgErr != nil {
+			return fmt.Errorf("load config: %w (or pass --into <kb-dir>)", cfgErr)
 		}
 		dest = cfg.Catalog.Dir
 		if dest == "" {
 			return fmt.Errorf("no destination (set catalog.dir or pass --into <kb-dir>)")
 		}
 	}
-	if st, serr := os.Stat(dest); serr != nil || !st.IsDir() {
-		return fmt.Errorf("KB dir %s is not a directory (clone your KB repo checkout first): %v", dest, serr)
+	st, serr := os.Stat(dest)
+	if serr != nil {
+		return fmt.Errorf("KB dir %s: %w (clone your KB repo checkout first)", dest, serr)
+	}
+	if !st.IsDir() {
+		return fmt.Errorf("KB dir %s is not a directory (clone your KB repo checkout first)", dest)
 	}
 
 	// Optional model — same opt-in shape as `lore validate-kb --semantic`:
 	// no usable model config degrades to deterministic-only with a warning.
 	var model providers.ModelProvider
 	if *useModel {
-		if cfg, cerr := config.Load(*cfgPath); cerr == nil && ModelConfigured(cfg) {
+		if cfgErr == nil && ModelConfigured(cfg) {
 			model = BuildModel(cfg, os.Getenv(cfg.Model.APIKeyEnv))
 		} else {
 			fmt.Fprintln(os.Stderr, "kb import: --model set but no usable model in config; running deterministic only")
@@ -109,38 +120,40 @@ func runKBImport(args []string, w io.Writer) error {
 		if actions[i].Skip {
 			continue
 		}
-		issues := kbvalidate.ValidateStructural(toCatalogEntry(actions[i].Result))
-		for _, iss := range issues {
-			if iss.Severity == kbvalidate.SeverityWarning {
+		var firstErr *kbvalidate.Issue
+		for _, iss := range kbvalidate.ValidateStructural(toCatalogEntry(actions[i].Result)) {
+			switch {
+			case iss.Severity == kbvalidate.SeverityWarning:
 				actions[i].Warnings = append(actions[i].Warnings, fmt.Sprintf("%s: %s", iss.Field, iss.Message))
+			case iss.Severity == kbvalidate.SeverityError && firstErr == nil:
+				firstErr = &iss
 			}
 		}
-		if kbvalidate.HasErrors(issues) {
-			first := firstError(issues)
+		if firstErr != nil {
 			actions[i].Skip = true
-			actions[i].Reason = fmt.Sprintf("fails validation: %s: %s", first.Field, first.Message)
+			actions[i].Reason = fmt.Sprintf("fails validation: %s: %s", firstErr.Field, firstErr.Message)
 		}
 	}
 
 	imported, skipped := 0, 0
 	tw := tabwriter.NewWriter(w, 2, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "ACTION\tSOURCE\tDEST\tTYPE\tTITLE / REASON")
+	_, _ = fmt.Fprintln(tw, "ACTION\tSOURCE\tDEST\tTYPE\tTITLE / REASON")
 	for _, a := range actions {
 		for _, warn := range a.Warnings {
 			fmt.Fprintf(os.Stderr, "warning: %s: %s\n", a.Source, warn)
 		}
 		if a.Skip {
 			skipped++
-			fmt.Fprintf(tw, "skip\t%s\t-\t-\t%s\n", a.Source, a.Reason)
+			_, _ = fmt.Fprintf(tw, "skip\t%s\t-\t-\t%s\n", a.Source, a.Reason)
 			continue
 		}
 		imported++
-		fmt.Fprintf(tw, "import\t%s\t%s\t%s\t%s\n", a.Source, a.DestPath, a.Entry.Type, truncateCell(a.Entry.Title, 60))
+		_, _ = fmt.Fprintf(tw, "import\t%s\t%s\t%s\t%s\n", a.Source, a.DestPath, a.Entry.Type, truncateCell(a.Entry.Title, 60))
 		if *dryRun {
 			continue
 		}
 		out := filepath.Join(dest, filepath.FromSlash(a.DestPath))
-		if merr := os.MkdirAll(filepath.Dir(out), 0o755); merr != nil {
+		if merr := os.MkdirAll(filepath.Dir(out), 0o750); merr != nil {
 			return merr
 		}
 		if werr := os.WriteFile(out, []byte(okf.Render(a.Entry, a.Meta)), 0o644); werr != nil { //nolint:gosec // G306: catalog files are world-readable docs
@@ -149,10 +162,10 @@ func runKBImport(args []string, w io.Writer) error {
 	}
 	_ = tw.Flush()
 	if *dryRun {
-		fmt.Fprintf(w, "\ndry-run: would import %d, skip %d (of %d sources); nothing written\n", imported, skipped, len(actions))
+		_, _ = fmt.Fprintf(w, "\ndry-run: would import %d, skip %d (of %d sources); nothing written\n", imported, skipped, len(actions))
 		return nil
 	}
-	fmt.Fprintf(w, "\nimported %d, skipped %d (of %d sources) into %s — review the diff, then commit and push\n",
+	_, _ = fmt.Fprintf(w, "\nimported %d, skipped %d (of %d sources) into %s — review the diff, then commit and push\n",
 		imported, skipped, len(actions), dest)
 	return nil
 }
@@ -173,10 +186,7 @@ func collectSources(src string) ([]string, error) {
 			}
 			return nil
 		}
-		if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".md") {
-			return nil
-		}
-		if base == "index.md" || base == "log.md" || strings.EqualFold(base, "readme.md") {
+		if !catalog.IsEntryFile(base) {
 			return nil
 		}
 		out = append(out, path)
@@ -195,13 +205,4 @@ func toCatalogEntry(r kbimport.Result) catalog.Entry {
 		Timestamp: r.Meta.Timestamp, Status: r.Meta.Status, LastValidated: r.Meta.LastValidated,
 		Path: r.DestPath,
 	}
-}
-
-func firstError(issues []kbvalidate.Issue) kbvalidate.Issue {
-	for _, iss := range issues {
-		if iss.Severity == kbvalidate.SeverityError {
-			return iss
-		}
-	}
-	return kbvalidate.Issue{Field: "unknown", Message: "validation error"}
 }

--- a/internal/app/kb_import_test.go
+++ b/internal/app/kb_import_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/kbvalidate"
 )
 
 func writeFile(t *testing.T, dir, name, content string) {
@@ -74,5 +77,58 @@ func TestKBImportSkipsReservedAndInvalid(t *testing.T) {
 	}
 	if strings.Contains(out, "README.md") {
 		t.Fatalf("reserved files must be silently ignored:\n%s", out)
+	}
+}
+
+func TestKBImportEndToEnd(t *testing.T) {
+	kb := t.TempDir()
+	var buf bytes.Buffer
+	if err := runKBImport([]string{"testdata/kbimport", "--into", kb}, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	// The bare runbook became a Playbook; the postmortem an Incident.
+	playbook, err := os.ReadFile(filepath.Join(kb, "playbooks", "redis-failover.md"))
+	if err != nil {
+		t.Fatalf("playbook not written: %v", err)
+	}
+	for _, want := range []string{"type: Playbook", "title: Redis failover", "- redisdown", "## Steps"} {
+		if !strings.Contains(string(playbook), want) {
+			t.Errorf("playbook missing %q:\n%s", want, playbook)
+		}
+	}
+	incident, err := os.ReadFile(filepath.Join(kb, "incidents", "payments-api-outage.md"))
+	if err != nil {
+		t.Fatalf("incident not written: %v", err)
+	}
+	for _, want := range []string{"type: Incident", "resource: payments/api", "2024-03-14", "- payments", "## Cause"} {
+		if !strings.Contains(string(incident), want) {
+			t.Errorf("incident missing %q:\n%s", want, incident)
+		}
+	}
+
+	// The near-duplicate title was skipped, the README ignored.
+	if !strings.Contains(buf.String(), "duplicate of") && !strings.Contains(buf.String(), "collides") {
+		t.Fatalf("legacy redis copy must be skipped as a duplicate:\n%s", buf.String())
+	}
+
+	// Round-trip guarantee: everything written loads back and passes the gate.
+	entries, skipped, err := catalog.Load(kb)
+	if err != nil || len(skipped) > 0 {
+		t.Fatalf("written entries must parse: err=%v skipped=%v", err, skipped)
+	}
+	if n := kbvalidate.WarnInvalid(entries, func(p string, errs []kbvalidate.Issue) {
+		t.Errorf("invalid written entry %s: %v", p, errs)
+	}); n != 0 {
+		t.Fatalf("%d written entries fail the merge gate", n)
+	}
+
+	// Idempotence: a second run imports nothing.
+	var buf2 bytes.Buffer
+	if err := runKBImport([]string{"testdata/kbimport", "--into", kb}, &buf2); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf2.String(), "imported 0") {
+		t.Fatalf("re-run must be a no-op:\n%s", buf2.String())
 	}
 }

--- a/internal/app/kb_import_test.go
+++ b/internal/app/kb_import_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKBImportRequiresSrcAndDest(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runKBImport([]string{}, &buf); err == nil {
+		t.Fatal("missing source dir must error")
+	}
+	src := t.TempDir()
+	writeFile(t, src, "a.md", "# A\n\nbody\n")
+	if err := runKBImport([]string{src, "--config", filepath.Join(t.TempDir(), "nope.yaml")}, &buf); err == nil {
+		t.Fatal("no --into and no config catalog.dir must error")
+	}
+}
+
+func TestKBImportDryRunWritesNothing(t *testing.T) {
+	src, kb := t.TempDir(), t.TempDir()
+	writeFile(t, src, "redis-failover.md", "# Redis failover\n\nHow to fail over redis.\n")
+	var buf bytes.Buffer
+	if err := runKBImport([]string{src, "--into", kb, "--dry-run"}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(kb, "playbooks", "redis-failover.md")); !os.IsNotExist(err) {
+		t.Fatal("--dry-run must not write files")
+	}
+	out := buf.String()
+	for _, want := range []string{"import", "playbooks/redis-failover.md", "Redis failover", "dry-run"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestKBImportSkipsReservedAndInvalid(t *testing.T) {
+	src, kb := t.TempDir(), t.TempDir()
+	writeFile(t, src, "README.md", "# not knowledge\n")
+	writeFile(t, src, "notes.txt", "not markdown")
+	// Declares Incident but has no resource/sections → fails the merge gate → skipped.
+	writeFile(t, src, "broken.md", "---\ntype: Incident\ntitle: broken\n---\nno sections\n")
+	writeFile(t, src, "ok.md", "# OK runbook\n\nA fine playbook.\n")
+	var buf bytes.Buffer
+	if err := runKBImport([]string{src, "--into", kb}, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(kb, "playbooks", "ok-runbook.md")); err != nil {
+		t.Fatalf("valid entry must be written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(kb, "incidents", "broken.md")); !os.IsNotExist(err) {
+		t.Fatal("gate-failing entry must not be written")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "fails validation") {
+		t.Fatalf("skip reason must be reported:\n%s", out)
+	}
+	if strings.Contains(out, "README.md") {
+		t.Fatalf("reserved files must be silently ignored:\n%s", out)
+	}
+}

--- a/internal/app/testdata/kbimport/2024-03-payments-outage.md
+++ b/internal/app/testdata/kbimport/2024-03-payments-outage.md
@@ -1,0 +1,24 @@
+---
+title: Payments API outage
+date: 2024-03-14
+tags: [payments, sev1]
+resource: payments/api
+type: postmortem
+---
+
+## Symptom
+
+5xx spike on payments/api starting 09:12 UTC; PaymentsHighErrorRate alert fired.
+
+## Investigate
+
+- deploy 4a1f2c rolled out at 09:10
+- error logs: connection refused to payments-db
+
+## Cause
+
+1. deploy 4a1f2c dropped the DB connection-pool env var
+
+## Resolution
+
+- rollback to the previous release; re-add the env var before re-deploying

--- a/internal/app/testdata/kbimport/README.md
+++ b/internal/app/testdata/kbimport/README.md
@@ -1,0 +1,1 @@
+Team runbooks. Not itself a runbook.

--- a/internal/app/testdata/kbimport/redis-failover.md
+++ b/internal/app/testdata/kbimport/redis-failover.md
@@ -1,0 +1,9 @@
+# Redis failover
+
+How to fail over the redis primary when the RedisDown alert fires.
+
+## Steps
+
+1. Confirm the primary is unreachable: `redis-cli -h redis-0 ping`.
+2. Promote the replica: `redis-cli -h redis-1 replicaof no one`.
+3. Repoint the service selector to the new primary.

--- a/internal/app/testdata/kbimport/zzz-legacy-redis-copy.md
+++ b/internal/app/testdata/kbimport/zzz-legacy-redis-copy.md
@@ -1,0 +1,3 @@
+# Redis failover runbook
+
+Older copy of the failover doc kept in another folder.

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -77,7 +77,7 @@ func parseEntry(root, path string) (Entry, error) {
 	if err != nil {
 		return Entry{}, err
 	}
-	fm, body := splitFrontmatter(data)
+	fm, body := SplitFrontmatter(data)
 	var meta entryMeta
 	if len(fm) > 0 {
 		if err := yaml.Unmarshal(fm, &meta); err != nil {
@@ -95,8 +95,10 @@ func parseEntry(root, path string) (Entry, error) {
 	}, nil
 }
 
-// splitFrontmatter separates a leading "---\n...\n---\n" YAML block from the body.
-func splitFrontmatter(data []byte) (frontmatter, body []byte) {
+// SplitFrontmatter separates a leading "---\n...\n---\n" YAML block from the body.
+// Exported because `lore kb import` reuses the exact same split when normalizing
+// source runbooks, so import and load agree on where frontmatter ends.
+func SplitFrontmatter(data []byte) (frontmatter, body []byte) {
 	s := string(data)
 	if !strings.HasPrefix(s, "---") {
 		return nil, data

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -35,10 +35,7 @@ func Load(dir string) (entries []Entry, skipped []string, err error) {
 			}
 			return nil
 		}
-		if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".md") {
-			return nil
-		}
-		if base == "index.md" || base == "log.md" || strings.EqualFold(base, "readme.md") {
+		if !IsEntryFile(base) {
 			return nil
 		}
 		e, perr := parseEntry(dir, path)
@@ -53,6 +50,17 @@ func Load(dir string) (entries []Entry, skipped []string, err error) {
 		return nil, nil, werr
 	}
 	return entries, skipped, nil
+}
+
+// IsEntryFile reports whether a base filename is an OKF catalog entry file: a
+// non-hidden .md that is not one of the reserved bundle files (index.md /
+// log.md / README.md). Load and `lore kb import` share it so "what counts as an
+// entry" is defined once and their notions can't drift.
+func IsEntryFile(base string) bool {
+	if strings.HasPrefix(base, ".") || !strings.HasSuffix(base, ".md") {
+		return false
+	}
+	return base != "index.md" && base != "log.md" && !strings.EqualFold(base, "readme.md")
 }
 
 // entryMeta is the exact set of frontmatter keys the loader parses, keyed by

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -194,3 +194,14 @@ func contains(s, sub string) bool {
 	}
 	return false
 }
+
+func TestSplitFrontmatterExported(t *testing.T) {
+	fm, body := SplitFrontmatter([]byte("---\ntitle: t\n---\nbody\n"))
+	if string(fm) != "title: t" || string(body) != "body\n" {
+		t.Fatalf("got fm=%q body=%q", fm, body)
+	}
+	fm, body = SplitFrontmatter([]byte("no frontmatter"))
+	if fm != nil || string(body) != "no frontmatter" {
+		t.Fatalf("frontmatterless input must pass through, got fm=%q body=%q", fm, body)
+	}
+}

--- a/internal/catalog/skillcontract_test.go
+++ b/internal/catalog/skillcontract_test.go
@@ -248,7 +248,7 @@ func TestSkillContentIsHarnessNeutral(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", path, err)
 		}
-		_, body := splitFrontmatter(raw) // frontmatter is packaging metadata
+		_, body := SplitFrontmatter(raw) // frontmatter is packaging metadata
 		for i, term := range bannedVocabulary {
 			if res[i].Match(body) {
 				t.Errorf("%s: harness-specific term %q in skill body — the portable core must not name a specific agent or its tools",

--- a/internal/curate/dedup.go
+++ b/internal/curate/dedup.go
@@ -96,6 +96,14 @@ func isDuplicatePair(a, b providers.CuratedIssue, thr float64) bool {
 	return jaccard(titleTokens(a.Title), titleTokens(b.Title)) >= thr
 }
 
+// TitleJaccard scores two entry titles by Jaccard similarity over their
+// noise-filtered token sets — the same fuzzy-duplicate primitive Dedup uses
+// for markerless PRs, shared with `lore kb import` so "duplicate" means the
+// same thing at import time and at curation time. ≥0.6 is the house threshold.
+func TitleJaccard(a, b string) float64 {
+	return jaccard(titleTokens(a), titleTokens(b))
+}
+
 var titleNoise = map[string]bool{"kb": true, "in": true, "the": true, "due": true, "to": true, "a": true, "of": true, "and": true}
 
 func titleTokens(s string) map[string]bool {

--- a/internal/curate/dedup_test.go
+++ b/internal/curate/dedup_test.go
@@ -166,3 +166,12 @@ func TestDedupSkipsProtectedDuplicates(t *testing.T) {
 		t.Fatalf("should close only the unprotected dup #12, got %v", f.closed)
 	}
 }
+
+func TestTitleJaccardExported(t *testing.T) {
+	if s := TitleJaccard("redis failover runbook", "redis failover runbook"); s != 1 {
+		t.Fatalf("identical titles must score 1, got %v", s)
+	}
+	if s := TitleJaccard("redis failover", "postgres vacuum tuning"); s >= 0.6 {
+		t.Fatalf("unrelated titles must stay under threshold, got %v", s)
+	}
+}

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -97,7 +97,7 @@ func draftKBEntry(inv providers.Investigation) providers.KBEntry {
 		// Cap the free-form investigation title to kbvalidate's merge gate: a single
 		// line of ≤120 bytes. inv.Title is LLM/alert-derived and can run long or carry
 		// newlines, which would fail RunLore's own `lore validate-kb` hard checks.
-		Title:       capTitle(inv.Title),
+		Title:       CapTitle(inv.Title),
 		Description: firstLine(inv),
 		Resource:    normalizeResource(inv.Resource),
 		// Only when the alert fired on a DIFFERENT resource than the one the
@@ -211,14 +211,14 @@ const titleMaxBytes = 120
 // ellipsis marks a truncated title; "…" (U+2026) is 3 bytes in UTF-8.
 const ellipsis = "…"
 
-// capTitle makes an arbitrary investigation title satisfy kbvalidate's title
+// CapTitle makes an arbitrary investigation title satisfy kbvalidate's title
 // merge gate by construction: a single line of at most titleMaxBytes bytes. It
 // collapses every whitespace run (newlines/tabs included) into a single space
 // and trims, then — if the result still exceeds the byte budget — truncates on a
 // rune boundary (preferring the last word boundary) and appends an ellipsis so
 // the FINAL byte length stays ≤ titleMaxBytes. Empty/whitespace-only input yields
 // "" so we never invent a title (the validator flags the empty title separately).
-func capTitle(s string) string {
+func CapTitle(s string) string {
 	s = strings.Join(strings.Fields(s), " ")
 	if len(s) <= titleMaxBytes {
 		return s

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -453,3 +453,13 @@ func TestDraftKBEntryExcludesCost(t *testing.T) {
 		}
 	}
 }
+
+func TestCapTitleExported(t *testing.T) {
+	if got := CapTitle("a\nb\tc"); got != "a b c" {
+		t.Fatalf("whitespace collapse: got %q", got)
+	}
+	long := strings.Repeat("word ", 40)
+	if capped := CapTitle(long); len(capped) > 120 {
+		t.Fatalf("must cap at 120 bytes, got %d", len(capped))
+	}
+}

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/okf"
 	"github.com/Smana/runlore/internal/providers"
-	"gopkg.in/yaml.v3"
 )
 
 // TokenFunc returns a valid installation token (minted/cached by the caller).
@@ -408,37 +408,6 @@ func issueBody(inv providers.Investigation) string {
 	return neutralizeImages(b.String())
 }
 
-// kbFrontmatter is the YAML frontmatter of an OKF entry. Marshaled (not string-
-// formatted) so a newline-bearing title/description from LLM output can't inject
-// extra frontmatter keys.
-type kbFrontmatter struct {
-	Type        string `yaml:"type"`
-	Title       string `yaml:"title"`
-	Description string `yaml:"description"`
-	Resource    string `yaml:"resource,omitempty"`
-	// alert_resource: the resource the ORIGINATING ALERT fired on, written only when it
-	// differs from resource (the fault locus). Recall matches an incoming alert against
-	// the entry's resource; an entry whose fault sits deeper than its alert — an alert
-	// on the HelmRelease tooling/harbor investigated down to the pod
-	// tooling/harbor-registry — is otherwise unreachable from the very alert that
-	// would surface it.
-	AlertResource string   `yaml:"alert_resource,omitempty"`
-	Tags          []string `yaml:"tags,omitempty"`
-	Timestamp     string   `yaml:"timestamp,omitempty"` // OKF-recommended; seed entries carry it, curated ones now do too
-	// last_validated: the date a human last confirmed the entry works. Never set
-	// on drafts — the human merge is the first validation, and humans (or future
-	// confirmation flows) stamp it from there. Recall's stale_after down-weighting
-	// falls back to timestamp, so an unvalidated entry still ages from creation.
-	LastValidated string `yaml:"last_validated,omitempty"`
-	Fingerprint   string `yaml:"fingerprint,omitempty"`
-	// Confidence + Provenance are OKF extension keys: frontmatter is for the
-	// fields you query/filter/index on, and these are exactly that (per-entry
-	// confidence floors, "what change caused this" lookups).
-	Confidence float64  `yaml:"confidence,omitempty"`
-	Provenance []string `yaml:"provenance,omitempty"`
-}
-
-// renderEntry serializes a KBEntry as OKF markdown (frontmatter + body).
 // prBody is the GitHub PR description: a one-line why-keep summary so the PR list
 // view is informative, plus the reviewer-context Related knowledge section. The
 // full decision card + OKF sections live in the entry file itself (visible in
@@ -506,28 +475,14 @@ func (c *Client) blobURL(path string) string {
 	return fmt.Sprintf("%s/%s/%s/blob/%s/%s", host, c.owner, c.repo, branch, path)
 }
 
+// renderEntry serializes a KBEntry as OKF markdown (frontmatter + body).
+// The timestamp is stamped at render time (RFC3339 UTC, matching the seed
+// entries); last_validated stays unset — that field claims human confirmation.
+// The body is neutralized here (LLM/alert-authored, GitHub auto-renders it);
+// okf.Render itself writes bodies verbatim.
 func renderEntry(e providers.KBEntry) string {
-	// Stamp the curated entry's timestamp at render time (RFC3339 UTC, matching
-	// the seed entries and flux.Executor). Kept off KBEntry so draftKBEntry stays
-	// deterministic/time-free; this serializer is already the I/O boundary.
-	// last_validated stays unset: that field claims human confirmation.
-	ts := time.Now().UTC().Format(time.RFC3339)
-	fm, _ := yaml.Marshal(kbFrontmatter{
-		Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource,
-		AlertResource: e.AlertResource,
-		Tags:          e.Tags, Timestamp: ts, Fingerprint: e.Fingerprint,
-		Confidence: e.Confidence, Provenance: e.Provenance,
-	})
-	var b strings.Builder
-	b.WriteString("---\n")
-	b.Write(fm)
-	b.WriteString("---\n\n")
-	// Neutralize image markdown in the untrusted body (LLM/alert-authored) before
-	// the entry file is written to GitHub: GitHub renders the file on merge and
-	// auto-fetches any ![](url), which would leak KB-file URLs to an attacker.
-	b.WriteString(neutralizeImages(e.Body))
-	b.WriteString("\n")
-	return b.String()
+	e.Body = neutralizeImages(e.Body)
+	return okf.Render(e, okf.Meta{Timestamp: time.Now().UTC().Format(time.RFC3339)})
 }
 
 // entryPath is where the drafted entry lives in the KB bundle: a type directory
@@ -548,21 +503,4 @@ func entryPath(e providers.KBEntry, slug string, now int64) string {
 	return fmt.Sprintf("%ss/%s-%s.md", strings.ToLower(e.Type), slug, suffix)
 }
 
-func slugify(s string) string {
-	s = strings.ToLower(s)
-	var b strings.Builder
-	prevDash := false
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
-			b.WriteRune(r)
-			prevDash = false
-		default:
-			if !prevDash {
-				b.WriteByte('-')
-				prevDash = true
-			}
-		}
-	}
-	return strings.Trim(b.String(), "-")
-}
+func slugify(s string) string { return okf.Slugify(s) }

--- a/internal/kbimport/enrich.go
+++ b/internal/kbimport/enrich.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const submitFrontmatterName = "submit_frontmatter"
+
+func submitFrontmatterSpec() providers.ToolSpec {
+	return providers.ToolSpec{
+		Name:        submitFrontmatterName,
+		Description: "Submit refined OKF frontmatter for the runbook being imported.",
+		Schema: `{
+  "type": "object",
+  "properties": {
+    "title": {"type": "string", "description": "concise, specific, one line"},
+    "description": {"type": "string", "description": "one-sentence summary of when this entry applies"},
+    "tags": {"type": "array", "items": {"type": "string"}, "description": "lowercase recall keywords incl. alert names"},
+    "type": {"type": "string", "enum": ["Incident", "Playbook", "Concept"]}
+  }
+}`,
+	}
+}
+
+const enrichSystemPrompt = `You refine YAML frontmatter for an SRE runbook being imported into a knowledge
+catalog. You are given the deterministic draft frontmatter and the document body.
+Improve title/description/tags only where the draft is weak; keep them faithful
+to the document — never invent facts. Answer ONLY via submit_frontmatter.`
+
+// Enrich optionally refines a Result's frontmatter with the configured model.
+// It NEVER gates (mirrors kbvalidate.ReviewSemantic): nil model, a model
+// error, a missing tool call, or unusable output all return r unchanged apart
+// from a warning — the deterministic Infer output is always a valid fallback.
+// The model cannot set resource (passthrough-only), the title is re-capped to
+// the merge gate's budget, and DestPath follows the refined type+title.
+func Enrich(ctx context.Context, r Result, m providers.ModelProvider) Result {
+	if m == nil {
+		return r
+	}
+	prompt := fmt.Sprintf("Draft frontmatter:\ntype: %s\ntitle: %s\ndescription: %s\ntags: %s\n\nDocument body:\n\n%s",
+		r.Entry.Type, r.Entry.Title, r.Entry.Description, strings.Join(r.Entry.Tags, ", "), r.Entry.Body)
+	resp, err := m.Complete(ctx, providers.CompletionRequest{
+		System:     enrichSystemPrompt,
+		Messages:   []providers.Message{{Role: "user", Content: prompt}},
+		Tools:      []providers.ToolSpec{submitFrontmatterSpec()},
+		ToolChoice: submitFrontmatterName,
+	})
+	if err != nil {
+		r.Warnings = append(r.Warnings, fmt.Sprintf("model enrichment skipped: %v", err))
+		return r
+	}
+	for _, tc := range resp.ToolCalls {
+		if tc.Name != submitFrontmatterName {
+			continue
+		}
+		var raw struct {
+			Title       string   `json:"title"`
+			Description string   `json:"description"`
+			Tags        []string `json:"tags"`
+			Type        string   `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(tc.Args), &raw); err != nil {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("model enrichment skipped: unparseable output: %v", err))
+			return r
+		}
+		return apply(r, raw.Title, raw.Description, raw.Tags, raw.Type)
+	}
+	r.Warnings = append(r.Warnings, "model enrichment skipped: model answered without calling submit_frontmatter")
+	return r
+}
+
+// apply merges model output over the deterministic result field by field,
+// keeping every invariant Infer established.
+func apply(r Result, title, description string, tags []string, typ string) Result {
+	if t := curator.CapTitle(title); t != "" {
+		r.Entry.Title = t
+	}
+	if d := strings.TrimSpace(description); d != "" {
+		r.Entry.Description = capRunes(strings.Join(strings.Fields(d), " "), descriptionMaxRunes)
+	}
+	if validTypes[strings.TrimSpace(typ)] {
+		// An Incident still needs a resource; without one, keep the inferred type.
+		if strings.TrimSpace(typ) != "Incident" || r.Entry.Resource != "" {
+			r.Entry.Type = strings.TrimSpace(typ)
+		}
+	}
+	if len(tags) > 0 {
+		r.Entry.Tags = inferTags(tags, "", r.Entry.Type) // rebuild: constant pair + model tags, deduped/capped
+	}
+	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(r.Entry.Type), slugOf(r.Entry.Title))
+	return r
+}

--- a/internal/kbimport/enrich.go
+++ b/internal/kbimport/enrich.go
@@ -86,15 +86,15 @@ func apply(r Result, title, description string, tags []string, typ string) Resul
 	if d := strings.TrimSpace(description); d != "" {
 		r.Entry.Description = capRunes(strings.Join(strings.Fields(d), " "), descriptionMaxRunes)
 	}
-	if validTypes[strings.TrimSpace(typ)] {
+	if t := strings.TrimSpace(typ); validTypes[t] {
 		// An Incident still needs a resource; without one, keep the inferred type.
-		if strings.TrimSpace(typ) != "Incident" || r.Entry.Resource != "" {
-			r.Entry.Type = strings.TrimSpace(typ)
+		if t != "Incident" || r.Entry.Resource != "" {
+			r.Entry.Type = t
 		}
 	}
 	if len(tags) > 0 {
-		r.Entry.Tags = inferTags(tags, "", r.Entry.Type) // rebuild: constant pair + model tags, deduped/capped
+		r.Entry.Tags = inferTags(tags, nil, r.Entry.Type) // rebuild: constant pair + model tags, deduped/capped
 	}
-	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(r.Entry.Type), slugOf(r.Entry.Title))
+	r.DestPath = destPath(r.Entry.Type, r.Entry.Title)
 	return r
 }

--- a/internal/kbimport/enrich_test.go
+++ b/internal/kbimport/enrich_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeModel returns a canned response (or error) for the single Complete call.
+type fakeModel struct {
+	resp providers.CompletionResponse
+	err  error
+}
+
+func (f fakeModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	return f.resp, f.err
+}
+
+func TestEnrichAppliesModelFields(t *testing.T) {
+	r := res("pg vacuum tuning", "playbooks/pg-vacuum-tuning.md", "a.md")
+	m := fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{
+		Name: "submit_frontmatter",
+		Args: `{"title":"Postgres autovacuum tuning","description":"tune autovacuum thresholds before bloat","tags":["postgres","autovacuum"],"type":"Playbook"}`,
+	}}}}
+	got := Enrich(context.Background(), r, m)
+	if got.Entry.Title != "Postgres autovacuum tuning" {
+		t.Fatalf("title = %q", got.Entry.Title)
+	}
+	if got.Entry.Description != "tune autovacuum thresholds before bloat" {
+		t.Fatalf("description = %q", got.Entry.Description)
+	}
+	if got.DestPath != "playbooks/postgres-autovacuum-tuning.md" {
+		t.Fatalf("DestPath must follow the new title, got %q", got.DestPath)
+	}
+	want := map[string]bool{"imported": true, "playbook": true, "postgres": true, "autovacuum": true}
+	for _, tag := range got.Entry.Tags {
+		if !want[tag] {
+			t.Fatalf("unexpected tag %q in %v", tag, got.Entry.Tags)
+		}
+	}
+}
+
+func TestEnrichNeverGates(t *testing.T) {
+	r := res("pg vacuum tuning", "playbooks/pg-vacuum-tuning.md", "a.md")
+	for name, m := range map[string]providers.ModelProvider{
+		"nil model":    nil,
+		"model error":  fakeModel{err: errors.New("boom")},
+		"no tool call": fakeModel{resp: providers.CompletionResponse{Text: "prose"}},
+		"bad json":     fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{Name: "submit_frontmatter", Args: "{"}}}},
+		"invalid type": fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{Name: "submit_frontmatter", Args: `{"type":"Postmortem"}`}}}},
+	} {
+		got := Enrich(context.Background(), r, m)
+		if got.Entry.Title != r.Entry.Title || got.Entry.Type != r.Entry.Type || got.DestPath != r.DestPath {
+			t.Fatalf("%s: enrichment must fall back to the deterministic result, got %+v", name, got.Entry)
+		}
+	}
+}
+
+func TestEnrichNeverInventsResource(t *testing.T) {
+	r := res("t", "playbooks/t.md", "a.md")
+	m := fakeModel{resp: providers.CompletionResponse{ToolCalls: []providers.ToolCall{{
+		Name: "submit_frontmatter", Args: `{"resource":"prod/db"}`,
+	}}}}
+	if got := Enrich(context.Background(), r, m); got.Entry.Resource != "" {
+		t.Fatalf("model must not set resource, got %q", got.Entry.Resource)
+	}
+}

--- a/internal/kbimport/infer.go
+++ b/internal/kbimport/infer.go
@@ -44,6 +44,9 @@ type sourceMeta struct {
 	Date          string   `yaml:"date"` // common in postmortems; folded into timestamp
 	Status        string   `yaml:"status"`
 	LastValidated string   `yaml:"last_validated"`
+	// Extra collects any frontmatter key not matched above (yaml.v3 inline), so
+	// the "keys not carried over" warning comes from the SAME parse, not a second one.
+	Extra map[string]any `yaml:",inline"`
 }
 
 var validTypes = map[string]bool{"Incident": true, "Playbook": true, "Concept": true}
@@ -61,13 +64,14 @@ func Infer(data []byte, source string) Result {
 	if len(fm) > 0 {
 		if err := yaml.Unmarshal(fm, &meta); err != nil {
 			r.Warnings = append(r.Warnings, fmt.Sprintf("unparseable frontmatter ignored: %v", err))
-		} else if extra := unknownKeys(fm); len(extra) > 0 {
+		} else if extra := unknownKeys(meta.Extra); len(extra) > 0 {
 			r.Warnings = append(r.Warnings, "frontmatter keys not carried over: "+strings.Join(extra, ", "))
 		}
 	}
 	b := string(body)
+	lines := strings.Split(b, "\n") // split once; the line-scanning helpers share it
 
-	title := inferTitle(meta.Title, b, source)
+	title := inferTitle(meta.Title, lines, source)
 	resource := strings.TrimSpace(meta.Resource)
 	if strings.ContainsAny(resource, " \t\r\n") {
 		r.Warnings = append(r.Warnings, fmt.Sprintf("resource %q dropped: must be whitespace-free (namespace/name)", resource))
@@ -78,9 +82,9 @@ func Infer(data []byte, source string) Result {
 	r.Entry = providers.KBEntry{
 		Type:        typ,
 		Title:       title,
-		Description: inferDescription(meta.Description, b, title),
+		Description: inferDescription(meta.Description, lines, title),
 		Resource:    resource,
-		Tags:        inferTags(meta.Tags, b, typ),
+		Tags:        inferTags(meta.Tags, lines, typ),
 		Body:        b,
 	}
 	r.Meta = okf.Meta{Status: meta.Status, LastValidated: meta.LastValidated}
@@ -91,38 +95,41 @@ func Infer(data []byte, source string) Result {
 			r.Warnings = append(r.Warnings, fmt.Sprintf("unparseable date %q dropped (want RFC3339 or 2006-01-02)", ts))
 		}
 	}
-	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(typ), slugOf(title))
+	r.DestPath = destPath(typ, title)
 	return r
 }
 
-// slugOf is the single dest-path slug rule (Infer and Enrich share it) so the
-// two DestPath computations can't drift.
-func slugOf(title string) string { return okf.Slugify(title) }
+// destPath is the single dest-path rule (Infer and Enrich share it) so the whole
+// "<type>s/<slug>.md" layout — not just the slug — can't drift between the two.
+func destPath(typ, title string) string {
+	return fmt.Sprintf("%ss/%s.md", strings.ToLower(typ), okf.Slugify(title))
+}
 
 // inferType: a valid declared type wins; else Incident iff the body already
-// carries the gate's required sections (kbvalidate.requiredIncidentSections)
-// AND a resource (Incident requires one); else Playbook — the relaxed,
-// free-form-runbook type.
+// carries the gate's required sections AND a resource (Incident requires one);
+// else Playbook — the relaxed, free-form-runbook type.
 func inferType(declared, body, resource string) string {
 	if validTypes[strings.TrimSpace(declared)] {
 		return strings.TrimSpace(declared)
 	}
-	secs := kbvalidate.Sections(body)
-	if resource != "" && secs["symptom"] != "" && secs["cause"] != "" && secs["resolution"] != "" {
+	if resource != "" && kbvalidate.HasIncidentSections(body) {
 		return "Incident"
 	}
 	return "Playbook"
 }
 
+// headingPrefixes are the markdown heading markers inferTitle promotes to a title.
+var headingPrefixes = []string{"# ", "## "}
+
 // inferTitle: frontmatter title → first #/## heading → humanized filename
 // stem. Always capped to the merge gate's single-line 120-byte budget.
-func inferTitle(declared, body, source string) string {
+func inferTitle(declared string, lines []string, source string) string {
 	if t := curator.CapTitle(declared); t != "" {
 		return t
 	}
-	for _, line := range strings.Split(body, "\n") {
+	for _, line := range lines {
 		t := strings.TrimSpace(line)
-		for _, p := range []string{"# ", "## "} {
+		for _, p := range headingPrefixes {
 			if strings.HasPrefix(t, p) {
 				if h := curator.CapTitle(strings.TrimPrefix(t, p)); h != "" {
 					return h
@@ -141,12 +148,12 @@ const descriptionMaxRunes = 240
 // inferDescription: frontmatter description → first prose line of the body
 // (headings, code fences, and blank lines skipped; list/quote markers
 // stripped) → the title, so the gate's non-empty requirement always holds.
-func inferDescription(declared, body, title string) string {
+func inferDescription(declared string, lines []string, title string) string {
 	if d := strings.TrimSpace(declared); d != "" {
 		return capRunes(strings.Join(strings.Fields(d), " "), descriptionMaxRunes)
 	}
 	inFence := false
-	for _, line := range strings.Split(body, "\n") {
+	for _, line := range lines {
 		t := strings.TrimSpace(line)
 		if strings.HasPrefix(t, "```") {
 			inFence = !inFence
@@ -178,7 +185,7 @@ var alertNameRe = regexp.MustCompile(`\b[A-Z][a-z0-9]+(?:[A-Z]+[a-z0-9]*)+\b`)
 // inferTags mirrors curator.entryTags' shape (constant pair first, derived
 // signal after, deduped, lowercased): imported + type, then the source's own
 // tags, then detected alert-name patterns.
-func inferTags(declared []string, body, typ string) []string {
+func inferTags(declared []string, lines []string, typ string) []string {
 	tags := []string{"imported", strings.ToLower(typ)}
 	seen := map[string]bool{tags[0]: true, tags[1]: true}
 	add := func(t string) {
@@ -191,7 +198,7 @@ func inferTags(declared []string, body, typ string) []string {
 	for _, t := range declared {
 		add(t)
 	}
-	for _, line := range strings.Split(body, "\n") {
+	for _, line := range lines {
 		t := strings.TrimSpace(line)
 		if !strings.HasPrefix(t, "#") && !strings.Contains(strings.ToLower(t), "alert") {
 			continue
@@ -203,22 +210,13 @@ func inferTags(declared []string, body, typ string) []string {
 	return tags
 }
 
-// unknownKeys lists top-level frontmatter keys Infer does not carry over,
-// so the import report tells the user what was left behind.
-func unknownKeys(fm []byte) []string {
-	known := map[string]bool{
-		"type": true, "title": true, "description": true, "resource": true,
-		"tags": true, "timestamp": true, "date": true, "status": true, "last_validated": true,
-	}
-	var raw map[string]any
-	if yaml.Unmarshal(fm, &raw) != nil {
-		return nil
-	}
-	var out []string
-	for k := range raw {
-		if !known[k] {
-			out = append(out, k)
-		}
+// unknownKeys lists (sorted) the frontmatter keys Infer did not carry over —
+// the yaml.v3 inline catch-all (sourceMeta.Extra) already holds exactly those,
+// so the import report tells the user what was left behind without a re-parse.
+func unknownKeys(extra map[string]any) []string {
+	out := make([]string, 0, len(extra))
+	for k := range extra {
+		out = append(out, k)
 	}
 	sort.Strings(out)
 	return out

--- a/internal/kbimport/infer.go
+++ b/internal/kbimport/infer.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kbimport converts existing markdown runbooks/postmortems into
+// OKF-compatible catalog entries — the cold-start answer: deterministic
+// frontmatter inference (Infer), dedup against the live catalog (Plan), and
+// an optional LLM refinement (Enrich). It is pure (no I/O, no clock); the
+// command layer in internal/app does the walking, validating, and writing.
+package kbimport
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/curator"
+	"github.com/Smana/runlore/internal/kbvalidate"
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Result is one source document converted to an importable entry.
+type Result struct {
+	Entry    providers.KBEntry // reuses the curator/forge entry struct — no parallel format
+	Meta     okf.Meta          // preserved source timestamp/status/last_validated
+	DestPath string            // bundle-relative destination, e.g. playbooks/redis-failover.md
+	Source   string            // source path, for reporting
+	Warnings []string
+}
+
+// sourceMeta is the tolerant superset of frontmatter keys recognized in a
+// source document. Unknown keys are collected via the raw map for a warning.
+type sourceMeta struct {
+	Type          string   `yaml:"type"`
+	Title         string   `yaml:"title"`
+	Description   string   `yaml:"description"`
+	Resource      string   `yaml:"resource"`
+	Tags          []string `yaml:"tags"`
+	Timestamp     string   `yaml:"timestamp"`
+	Date          string   `yaml:"date"` // common in postmortems; folded into timestamp
+	Status        string   `yaml:"status"`
+	LastValidated string   `yaml:"last_validated"`
+}
+
+var validTypes = map[string]bool{"Incident": true, "Playbook": true, "Concept": true}
+
+// Infer derives normalized OKF frontmatter for one markdown document, purely
+// from its existing frontmatter, headings, and content. Deterministic by
+// construction — same input, same entry — so imports are reviewable diffs,
+// not model output. It never fabricates: resource is passthrough-only, and a
+// document is an Incident only when it already carries the OKF evidence
+// sections the merge gate demands.
+func Infer(data []byte, source string) Result {
+	r := Result{Source: source}
+	fm, body := catalog.SplitFrontmatter(data)
+	var meta sourceMeta
+	if len(fm) > 0 {
+		if err := yaml.Unmarshal(fm, &meta); err != nil {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("unparseable frontmatter ignored: %v", err))
+		} else if extra := unknownKeys(fm); len(extra) > 0 {
+			r.Warnings = append(r.Warnings, "frontmatter keys not carried over: "+strings.Join(extra, ", "))
+		}
+	}
+	b := string(body)
+
+	title := inferTitle(meta.Title, b, source)
+	resource := strings.TrimSpace(meta.Resource)
+	if strings.ContainsAny(resource, " \t\r\n") {
+		r.Warnings = append(r.Warnings, fmt.Sprintf("resource %q dropped: must be whitespace-free (namespace/name)", resource))
+		resource = ""
+	}
+	typ := inferType(meta.Type, b, resource)
+
+	r.Entry = providers.KBEntry{
+		Type:        typ,
+		Title:       title,
+		Description: inferDescription(meta.Description, b, title),
+		Resource:    resource,
+		Tags:        inferTags(meta.Tags, b, typ),
+		Body:        b,
+	}
+	r.Meta = okf.Meta{Status: meta.Status, LastValidated: meta.LastValidated}
+	if ts := firstNonEmpty(meta.Timestamp, meta.Date); ts != "" {
+		if _, ok := catalog.ParseEntryDate(ts); ok {
+			r.Meta.Timestamp = ts
+		} else {
+			r.Warnings = append(r.Warnings, fmt.Sprintf("unparseable date %q dropped (want RFC3339 or 2006-01-02)", ts))
+		}
+	}
+	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(typ), okf.Slugify(title))
+	return r
+}
+
+// inferType: a valid declared type wins; else Incident iff the body already
+// carries the gate's required sections (kbvalidate.requiredIncidentSections)
+// AND a resource (Incident requires one); else Playbook — the relaxed,
+// free-form-runbook type.
+func inferType(declared, body, resource string) string {
+	if validTypes[strings.TrimSpace(declared)] {
+		return strings.TrimSpace(declared)
+	}
+	secs := kbvalidate.Sections(body)
+	if resource != "" && secs["symptom"] != "" && secs["cause"] != "" && secs["resolution"] != "" {
+		return "Incident"
+	}
+	return "Playbook"
+}
+
+// inferTitle: frontmatter title → first #/## heading → humanized filename
+// stem. Always capped to the merge gate's single-line 120-byte budget.
+func inferTitle(declared, body, source string) string {
+	if t := curator.CapTitle(declared); t != "" {
+		return t
+	}
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		for _, p := range []string{"# ", "## "} {
+			if strings.HasPrefix(t, p) {
+				if h := curator.CapTitle(strings.TrimPrefix(t, p)); h != "" {
+					return h
+				}
+			}
+		}
+	}
+	stem := strings.TrimSuffix(filepath.Base(source), ".md")
+	return curator.CapTitle(strings.NewReplacer("-", " ", "_", " ").Replace(stem))
+}
+
+// descriptionMaxRunes bounds the inferred description; it only has to be
+// non-empty (the gate) and scannable in `lore kb search` output.
+const descriptionMaxRunes = 240
+
+// inferDescription: frontmatter description → first prose line of the body
+// (headings, code fences, and blank lines skipped; list/quote markers
+// stripped) → the title, so the gate's non-empty requirement always holds.
+func inferDescription(declared, body, title string) string {
+	if d := strings.TrimSpace(declared); d != "" {
+		return capRunes(strings.Join(strings.Fields(d), " "), descriptionMaxRunes)
+	}
+	inFence := false
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || t == "" || strings.HasPrefix(t, "#") || t == "---" {
+			continue
+		}
+		t = strings.TrimSpace(strings.TrimLeft(t, "-*> "))
+		if t != "" {
+			return capRunes(strings.Join(strings.Fields(t), " "), descriptionMaxRunes)
+		}
+	}
+	return title
+}
+
+// maxTags bounds the tag list; tags feed the BM25 corpus, and past ~10 the
+// extra ones are noise, not recall signal.
+const maxTags = 10
+
+// alertNameRe matches CamelCase tokens with ≥2 humps — the Prometheus
+// alert-name shape (KubePodCrashLooping, TargetDown), including embedded
+// acronym runs (KubeContainerOOMKilled). It requires a leading Upper+lower
+// hump so lone acronyms (OOM, API) and ordinary single words (Redis) don't
+// match; only headings and alert-mentioning lines are scanned, which keeps
+// ordinary CamelCase prose (product names) from flooding the tags.
+var alertNameRe = regexp.MustCompile(`\b[A-Z][a-z0-9]+(?:[A-Z]+[a-z0-9]*)+\b`)
+
+// inferTags mirrors curator.entryTags' shape (constant pair first, derived
+// signal after, deduped, lowercased): imported + type, then the source's own
+// tags, then detected alert-name patterns.
+func inferTags(declared []string, body, typ string) []string {
+	tags := []string{"imported", strings.ToLower(typ)}
+	seen := map[string]bool{tags[0]: true, tags[1]: true}
+	add := func(t string) {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t != "" && !seen[t] && len(tags) < maxTags {
+			seen[t] = true
+			tags = append(tags, t)
+		}
+	}
+	for _, t := range declared {
+		add(t)
+	}
+	for _, line := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, "#") && !strings.Contains(strings.ToLower(t), "alert") {
+			continue
+		}
+		for _, m := range alertNameRe.FindAllString(t, -1) {
+			add(m)
+		}
+	}
+	return tags
+}
+
+// unknownKeys lists top-level frontmatter keys Infer does not carry over,
+// so the import report tells the user what was left behind.
+func unknownKeys(fm []byte) []string {
+	known := map[string]bool{
+		"type": true, "title": true, "description": true, "resource": true,
+		"tags": true, "timestamp": true, "date": true, "status": true, "last_validated": true,
+	}
+	var raw map[string]any
+	if yaml.Unmarshal(fm, &raw) != nil {
+		return nil
+	}
+	var out []string
+	for k := range raw {
+		if !known[k] {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func capRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return strings.TrimRight(string(r[:n]), " ") + "…"
+}
+
+func firstNonEmpty(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return strings.TrimSpace(a)
+	}
+	return strings.TrimSpace(b)
+}

--- a/internal/kbimport/infer.go
+++ b/internal/kbimport/infer.go
@@ -91,9 +91,13 @@ func Infer(data []byte, source string) Result {
 			r.Warnings = append(r.Warnings, fmt.Sprintf("unparseable date %q dropped (want RFC3339 or 2006-01-02)", ts))
 		}
 	}
-	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(typ), okf.Slugify(title))
+	r.DestPath = fmt.Sprintf("%ss/%s.md", strings.ToLower(typ), slugOf(title))
 	return r
 }
+
+// slugOf is the single dest-path slug rule (Infer and Enrich share it) so the
+// two DestPath computations can't drift.
+func slugOf(title string) string { return okf.Slugify(title) }
 
 // inferType: a valid declared type wins; else Incident iff the body already
 // carries the gate's required sections (kbvalidate.requiredIncidentSections)

--- a/internal/kbimport/infer_test.go
+++ b/internal/kbimport/infer_test.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestInfer(t *testing.T) {
+	cases := []struct {
+		name, source, data                     string
+		wantType, wantTitle, wantDesc, wantRes string
+		wantTags                               []string
+		wantDest, wantTimestamp                string
+	}{
+		{
+			name:     "bare runbook: title from H1, description from first paragraph, Playbook",
+			source:   "runbooks/redis-failover.md",
+			data:     "# Redis failover\n\nHow to fail over the redis primary.\n\n## Steps\n\n- step one\n",
+			wantType: "Playbook", wantTitle: "Redis failover",
+			wantDesc: "How to fail over the redis primary.",
+			wantTags: []string{"imported", "playbook"},
+			wantDest: "playbooks/redis-failover.md",
+		},
+		{
+			name:     "no heading: title humanized from filename",
+			source:   "notes/pg_vacuum-tuning.md",
+			data:     "Tune autovacuum before it falls behind.\n",
+			wantType: "Playbook", wantTitle: "pg vacuum tuning",
+			wantDesc: "Tune autovacuum before it falls behind.",
+			wantTags: []string{"imported", "playbook"},
+			wantDest: "playbooks/pg-vacuum-tuning.md",
+		},
+		{
+			name:   "postmortem with OKF sections + resource becomes Incident, date preserved",
+			source: "postmortems/2024-03-payments.md",
+			data: "---\ntitle: Payments API outage\ndate: 2024-03-14\ntags: [payments]\nresource: payments/api\ntype: postmortem\n---\n" +
+				"## Symptom\n\n5xx spike\n\n## Cause\n\nbad deploy\n\n## Resolution\n\nrollback\n",
+			wantType: "Incident", wantTitle: "Payments API outage",
+			wantDesc: "5xx spike", wantRes: "payments/api",
+			wantTags:      []string{"imported", "incident", "payments"},
+			wantDest:      "incidents/payments-api-outage.md",
+			wantTimestamp: "2024-03-14",
+		},
+		{
+			name:     "alert names in headings/alert lines become tags",
+			source:   "runbooks/oom.md",
+			data:     "# KubeContainerOOMKilled\n\nAlert: fires alongside KubePodCrashLooping sometimes.\n",
+			wantType: "Playbook", wantTitle: "KubeContainerOOMKilled",
+			wantDesc: "Alert: fires alongside KubePodCrashLooping sometimes.",
+			wantTags: []string{"imported", "playbook", "kubecontaineroomkilled", "kubepodcrashlooping"},
+			wantDest: "playbooks/kubecontaineroomkilled.md",
+		},
+		{
+			name:     "valid existing type passes through untouched",
+			source:   "concepts/slo.md",
+			data:     "---\ntype: Concept\ntitle: SLO policy\ndescription: how we set SLOs\n---\nbody\n",
+			wantType: "Concept", wantTitle: "SLO policy", wantDesc: "how we set SLOs",
+			wantTags: []string{"imported", "concept"},
+			wantDest: "concepts/slo-policy.md",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := Infer([]byte(c.data), c.source)
+			if r.Entry.Type != c.wantType {
+				t.Errorf("type = %q, want %q", r.Entry.Type, c.wantType)
+			}
+			if r.Entry.Title != c.wantTitle {
+				t.Errorf("title = %q, want %q", r.Entry.Title, c.wantTitle)
+			}
+			if r.Entry.Description != c.wantDesc {
+				t.Errorf("description = %q, want %q", r.Entry.Description, c.wantDesc)
+			}
+			if r.Entry.Resource != c.wantRes {
+				t.Errorf("resource = %q, want %q", r.Entry.Resource, c.wantRes)
+			}
+			if !reflect.DeepEqual(r.Entry.Tags, c.wantTags) {
+				t.Errorf("tags = %v, want %v", r.Entry.Tags, c.wantTags)
+			}
+			if r.DestPath != c.wantDest {
+				t.Errorf("dest = %q, want %q", r.DestPath, c.wantDest)
+			}
+			if r.Meta.Timestamp != c.wantTimestamp {
+				t.Errorf("timestamp = %q, want %q", r.Meta.Timestamp, c.wantTimestamp)
+			}
+			if r.Source != c.source {
+				t.Errorf("source = %q, want %q", r.Source, c.source)
+			}
+		})
+	}
+}
+
+func TestInferLongTitleCapped(t *testing.T) {
+	r := Infer([]byte("# "+strings.Repeat("verylongword ", 30)+"\n\nbody\n"), "x.md")
+	if len(r.Entry.Title) > 120 {
+		t.Fatalf("title must satisfy the 120-byte merge gate, got %d bytes", len(r.Entry.Title))
+	}
+}
+
+func TestInferUnparseableDateDropsWithWarning(t *testing.T) {
+	r := Infer([]byte("---\ntitle: t\ndate: last tuesday\n---\nbody\n"), "x.md")
+	if r.Meta.Timestamp != "" {
+		t.Fatalf("unparseable date must be dropped, got %q", r.Meta.Timestamp)
+	}
+	if len(r.Warnings) == 0 {
+		t.Fatal("dropping the date must warn")
+	}
+}

--- a/internal/kbimport/plan.go
+++ b/internal/kbimport/plan.go
@@ -24,16 +24,19 @@ type Action struct {
 const dupThreshold = 0.6
 
 // Plan dedups inferred results against the existing catalog and against each
-// other, preserving input order. It only decides — the caller reports/writes.
-// Skip reasons are checked in order: retired-at-source, destination already an
-// existing entry, fuzzy title duplicate, then batch path collision.
+// other, preserving input order (first occurrence wins). It only decides — the
+// caller reports/writes. Skip reasons are checked in order: retired-at-source,
+// destination already an existing entry, fuzzy title duplicate of an existing
+// entry, batch path collision, then fuzzy title duplicate of an entry already
+// accepted earlier in this same batch.
 func Plan(results []Result, existing []catalog.Entry) []Action {
 	existingPaths := map[string]bool{}
 	for _, e := range existing {
 		existingPaths[e.Path] = true
 	}
-	batchPaths := map[string]string{} // dest path -> the batch source that first claimed it
-	out := make([]Action, 0, len(results))
+	batchPaths := map[string]string{}      // dest path -> the batch source that first claimed it
+	var accepted []catalog.Entry           // entries accepted so far this batch, for intra-batch title dedup
+	out := make([]Action, 0, len(results)) //nolint:prealloc // appended conditionally below
 	for _, r := range results {
 		a := Action{Result: r}
 		switch {
@@ -46,8 +49,11 @@ func Plan(results []Result, existing []catalog.Entry) []Action {
 				a.Skip, a.Reason = true, "duplicate of "+dup
 			} else if occ, taken := batchPaths[r.DestPath]; taken {
 				a.Skip, a.Reason = true, fmt.Sprintf("destination %s collides with %s in this batch", r.DestPath, occ)
+			} else if dup, ok := duplicateOf(r.Entry.Title, accepted); ok {
+				a.Skip, a.Reason = true, fmt.Sprintf("duplicate of %s (imported earlier in this batch)", dup)
 			} else {
 				batchPaths[r.DestPath] = r.Source
+				accepted = append(accepted, catalog.Entry{Title: r.Entry.Title, Path: r.DestPath})
 			}
 		}
 		out = append(out, a)

--- a/internal/kbimport/plan.go
+++ b/internal/kbimport/plan.go
@@ -34,9 +34,10 @@ func Plan(results []Result, existing []catalog.Entry) []Action {
 	for _, e := range existing {
 		existingPaths[e.Path] = true
 	}
-	batchPaths := map[string]string{}      // dest path -> the batch source that first claimed it
-	var accepted []catalog.Entry           // entries accepted so far this batch, for intra-batch title dedup
-	out := make([]Action, 0, len(results)) //nolint:prealloc // appended conditionally below
+	existingNorm := normEntries(existing) // normalize existing titles ONCE, not per result
+	batchPaths := map[string]string{}     // dest path -> the batch source that first claimed it
+	var accepted []normEntry              // entries accepted so far this batch, for intra-batch title dedup
+	out := make([]Action, 0, len(results))
 	for _, r := range results {
 		a := Action{Result: r}
 		switch {
@@ -45,7 +46,7 @@ func Plan(results []Result, existing []catalog.Entry) []Action {
 		case existingPaths[r.DestPath]:
 			a.Skip, a.Reason = true, fmt.Sprintf("destination exists: %s", r.DestPath)
 		default:
-			if dup, ok := duplicateOf(r.Entry.Title, existing); ok {
+			if dup, ok := duplicateOf(r.Entry.Title, existingNorm); ok {
 				a.Skip, a.Reason = true, "duplicate of "+dup
 			} else if occ, taken := batchPaths[r.DestPath]; taken {
 				a.Skip, a.Reason = true, fmt.Sprintf("destination %s collides with %s in this batch", r.DestPath, occ)
@@ -53,7 +54,7 @@ func Plan(results []Result, existing []catalog.Entry) []Action {
 				a.Skip, a.Reason = true, fmt.Sprintf("duplicate of %s (imported earlier in this batch)", dup)
 			} else {
 				batchPaths[r.DestPath] = r.Source
-				accepted = append(accepted, catalog.Entry{Title: r.Entry.Title, Path: r.DestPath})
+				accepted = append(accepted, normEntry{title: r.Entry.Title, norm: normTitle(r.Entry.Title), path: r.DestPath})
 			}
 		}
 		out = append(out, a)
@@ -61,16 +62,34 @@ func Plan(results []Result, existing []catalog.Entry) []Action {
 	return out
 }
 
-// duplicateOf finds an existing entry whose title matches: exact after
-// whitespace/case normalization, or fuzzy at curate's own Jaccard threshold.
-func duplicateOf(title string, existing []catalog.Entry) (string, bool) {
-	norm := strings.ToLower(strings.Join(strings.Fields(title), " "))
-	for _, e := range existing {
-		if strings.ToLower(strings.Join(strings.Fields(e.Title), " ")) == norm {
-			return e.Path, true
+// normEntry is a catalog entry with its title pre-normalized for exact-match
+// dedup, so Plan normalizes each title once instead of once per compared result.
+type normEntry struct {
+	title string // original, for the fuzzy TitleJaccard comparison
+	norm  string // lowercased, whitespace-collapsed, for exact match
+	path  string
+}
+
+func normTitle(s string) string { return strings.ToLower(strings.Join(strings.Fields(s), " ")) }
+
+func normEntries(es []catalog.Entry) []normEntry {
+	out := make([]normEntry, len(es))
+	for i, e := range es {
+		out[i] = normEntry{title: e.Title, norm: normTitle(e.Title), path: e.Path}
+	}
+	return out
+}
+
+// duplicateOf finds an entry whose title matches: exact after whitespace/case
+// normalization, or fuzzy at curate's own Jaccard threshold.
+func duplicateOf(title string, entries []normEntry) (string, bool) {
+	norm := normTitle(title)
+	for _, e := range entries {
+		if e.norm == norm {
+			return e.path, true
 		}
-		if curate.TitleJaccard(title, e.Title) >= dupThreshold {
-			return e.Path, true
+		if curate.TitleJaccard(title, e.title) >= dupThreshold {
+			return e.path, true
 		}
 	}
 	return "", false

--- a/internal/kbimport/plan.go
+++ b/internal/kbimport/plan.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/curate"
+)
+
+// Action is Plan's verdict on one inferred result.
+type Action struct {
+	Result
+	Skip   bool
+	Reason string // set when Skip
+}
+
+// dupThreshold matches curate.Dedup's default title-Jaccard threshold: a
+// duplicate at import time is the same notion as a duplicate at curation
+// time. Conservative both ways — a missed dup lands in review as a visible
+// extra file; a wrong skip loses knowledge silently, so we require ≥0.6.
+const dupThreshold = 0.6
+
+// Plan dedups inferred results against the existing catalog and against each
+// other, preserving input order. It only decides — the caller reports/writes.
+// Skip reasons are checked in order: retired-at-source, destination already an
+// existing entry, fuzzy title duplicate, then batch path collision.
+func Plan(results []Result, existing []catalog.Entry) []Action {
+	existingPaths := map[string]bool{}
+	for _, e := range existing {
+		existingPaths[e.Path] = true
+	}
+	batchPaths := map[string]string{} // dest path -> the batch source that first claimed it
+	out := make([]Action, 0, len(results))
+	for _, r := range results {
+		a := Action{Result: r}
+		switch {
+		case strings.EqualFold(strings.TrimSpace(r.Meta.Status), "retired"):
+			a.Skip, a.Reason = true, "source marked retired"
+		case existingPaths[r.DestPath]:
+			a.Skip, a.Reason = true, fmt.Sprintf("destination exists: %s", r.DestPath)
+		default:
+			if dup, ok := duplicateOf(r.Entry.Title, existing); ok {
+				a.Skip, a.Reason = true, "duplicate of "+dup
+			} else if occ, taken := batchPaths[r.DestPath]; taken {
+				a.Skip, a.Reason = true, fmt.Sprintf("destination %s collides with %s in this batch", r.DestPath, occ)
+			} else {
+				batchPaths[r.DestPath] = r.Source
+			}
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// duplicateOf finds an existing entry whose title matches: exact after
+// whitespace/case normalization, or fuzzy at curate's own Jaccard threshold.
+func duplicateOf(title string, existing []catalog.Entry) (string, bool) {
+	norm := strings.ToLower(strings.Join(strings.Fields(title), " "))
+	for _, e := range existing {
+		if strings.ToLower(strings.Join(strings.Fields(e.Title), " ")) == norm {
+			return e.Path, true
+		}
+		if curate.TitleJaccard(title, e.Title) >= dupThreshold {
+			return e.Path, true
+		}
+	}
+	return "", false
+}

--- a/internal/kbimport/plan_test.go
+++ b/internal/kbimport/plan_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package kbimport
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func res(title, dest, source string) Result {
+	return Result{
+		Entry:    providers.KBEntry{Type: "Playbook", Title: title, Description: title, Body: "body"},
+		DestPath: dest, Source: source,
+	}
+}
+
+func TestPlanDedup(t *testing.T) {
+	existing := []catalog.Entry{
+		{Path: "playbooks/redis-failover.md", Title: "Redis failover"},
+		{Path: "incidents/payments-outage.md", Title: "Payments API outage March 2024"},
+	}
+	retired := res("Old thing", "playbooks/old-thing.md", "old.md")
+	retired.Meta = okf.Meta{Status: "retired"}
+	in := []Result{
+		res("Postgres vacuum tuning", "playbooks/postgres-vacuum-tuning.md", "a.md"), // novel → import
+		res("Anything", "playbooks/redis-failover.md", "b.md"),                        // path taken → skip
+		res("Payments API outage — March 2024", "playbooks/payments-api-outage-march-2024.md", "c.md"), // fuzzy title dup → skip
+		retired, // retired at source → skip
+		res("Postgres vacuum tuning", "playbooks/postgres-vacuum-tuning.md", "e.md"), // batch collision → skip
+	}
+	got := Plan(in, existing)
+	if len(got) != len(in) {
+		t.Fatalf("Plan must return one action per result, got %d", len(got))
+	}
+	wantSkip := []struct {
+		skip   bool
+		reason string
+	}{
+		{false, ""},
+		{true, "destination exists"},
+		{true, "duplicate of incidents/payments-outage.md"},
+		{true, "retired"},
+		{true, "collides"},
+	}
+	for i, w := range wantSkip {
+		if got[i].Skip != w.skip {
+			t.Errorf("action %d (%s): skip = %v, want %v (reason %q)", i, in[i].Source, got[i].Skip, w.skip, got[i].Reason)
+		}
+		if w.reason != "" && !strings.Contains(got[i].Reason, w.reason) {
+			t.Errorf("action %d: reason %q must mention %q", i, got[i].Reason, w.reason)
+		}
+	}
+}

--- a/internal/kbimport/plan_test.go
+++ b/internal/kbimport/plan_test.go
@@ -55,3 +55,20 @@ func TestPlanDedup(t *testing.T) {
 		}
 	}
 }
+
+func TestPlanIntraBatchTitleDedup(t *testing.T) {
+	// Two batch entries with fuzzy-duplicate titles but DIFFERENT dest paths
+	// (so path collision can't catch them) against an empty catalog: the second
+	// is skipped as a duplicate of the first accepted this batch.
+	in := []Result{
+		res("Redis failover", "playbooks/redis-failover.md", "a.md"),
+		res("Redis failover runbook", "playbooks/redis-failover-runbook.md", "b.md"),
+	}
+	got := Plan(in, nil)
+	if got[0].Skip {
+		t.Fatalf("first occurrence must be imported: %+v", got[0])
+	}
+	if !got[1].Skip || !strings.Contains(got[1].Reason, "imported earlier in this batch") {
+		t.Fatalf("second must be skipped as intra-batch duplicate, got skip=%v reason=%q", got[1].Skip, got[1].Reason)
+	}
+}

--- a/internal/kbimport/plan_test.go
+++ b/internal/kbimport/plan_test.go
@@ -26,8 +26,8 @@ func TestPlanDedup(t *testing.T) {
 	retired := res("Old thing", "playbooks/old-thing.md", "old.md")
 	retired.Meta = okf.Meta{Status: "retired"}
 	in := []Result{
-		res("Postgres vacuum tuning", "playbooks/postgres-vacuum-tuning.md", "a.md"), // novel → import
-		res("Anything", "playbooks/redis-failover.md", "b.md"),                        // path taken → skip
+		res("Postgres vacuum tuning", "playbooks/postgres-vacuum-tuning.md", "a.md"),                   // novel → import
+		res("Anything", "playbooks/redis-failover.md", "b.md"),                                         // path taken → skip
 		res("Payments API outage — March 2024", "playbooks/payments-api-outage-march-2024.md", "c.md"), // fuzzy title dup → skip
 		retired, // retired at source → skip
 		res("Postgres vacuum tuning", "playbooks/postgres-vacuum-tuning.md", "e.md"), // batch collision → skip

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -169,7 +169,7 @@ func ValidateStructural(e catalog.Entry) []Issue {
 	// Incident bodies must carry the OKF evidence sections; Playbook/Concept are
 	// intentionally relaxed in v1 (free-form runbooks/concepts).
 	if e.Type == "Incident" {
-		secs := sections(e.Body)
+		secs := Sections(e.Body)
 		for _, s := range requiredIncidentSections {
 			content, ok := secs[s.key]
 			switch {
@@ -187,8 +187,10 @@ func ValidateStructural(e catalog.Entry) []Issue {
 	return out
 }
 
-// sections maps each "## Heading" (lowercased) to its trimmed content.
-func sections(body string) map[string]string {
+// Sections maps each "## Heading" (lowercased) to its trimmed content. Exported
+// so `lore kb import` can infer Incident-vs-Playbook from a source document's
+// OKF sections using the same heading parser the validator gates on.
+func Sections(body string) map[string]string {
 	out := map[string]string{}
 	cur := ""
 	var buf []string

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -56,6 +56,21 @@ var requiredIncidentSections = []struct{ key, head string }{
 	{"resolution", "Resolution"},
 }
 
+// HasIncidentSections reports whether body carries every required Incident
+// evidence section (Symptom/Cause/Resolution), each present and non-empty — the
+// same rule ValidateStructural enforces for Incidents. Exposed so `lore kb
+// import` classifies a document as an Incident by the exact gate it must pass,
+// rather than restating the section set.
+func HasIncidentSections(body string) bool {
+	secs := Sections(body)
+	for _, s := range requiredIncidentSections {
+		if secs[s.key] == "" {
+			return false
+		}
+	}
+	return true
+}
+
 // WarnInvalid is the load-time strict-warn hook: it calls onInvalid(path, errs)
 // for each invalid entry; the caller logs + increments a metric, but the entry
 // is still served (one bad entry never empties the catalog). Returns the count

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -229,3 +229,10 @@ func TestHasErrors(t *testing.T) {
 		t.Fatal("an error must be reported")
 	}
 }
+
+func TestSectionsExported(t *testing.T) {
+	secs := Sections("## Symptom\n\nx\n\n## Cause\n\ny\n")
+	if secs["symptom"] != "x" || secs["cause"] != "y" {
+		t.Fatalf("got %#v", secs)
+	}
+}

--- a/internal/okf/okf.go
+++ b/internal/okf/okf.go
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package okf serializes providers.KBEntry values as OKF markdown files
+// (YAML frontmatter + body). It is the single write-side counterpart of
+// catalog.Load: the GitHub forge and `lore kb import` both render through it,
+// so every entry RunLore writes parses back identically.
+package okf
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Meta carries the file-level frontmatter that is not part of a drafted
+// KBEntry: the forge stamps Timestamp at render time; import preserves the
+// source document's own timestamp/status/last_validated instead.
+type Meta struct {
+	Timestamp     string // OKF-recommended; RFC3339 or bare date
+	Status        string // lifecycle: "", active, retired, draft
+	LastValidated string // date a human last confirmed the entry works
+}
+
+// frontmatter is the YAML frontmatter of an OKF entry. Marshaled (not string-
+// formatted) so a newline-bearing title/description from LLM output can't
+// inject extra frontmatter keys. Keys mirror catalog.entryMeta (the loader).
+type frontmatter struct {
+	Type          string   `yaml:"type"`
+	Title         string   `yaml:"title"`
+	Description   string   `yaml:"description"`
+	Resource      string   `yaml:"resource,omitempty"`
+	AlertResource string   `yaml:"alert_resource,omitempty"`
+	Tags          []string `yaml:"tags,omitempty"`
+	Timestamp     string   `yaml:"timestamp,omitempty"`
+	Status        string   `yaml:"status,omitempty"`
+	LastValidated string   `yaml:"last_validated,omitempty"`
+	Fingerprint   string   `yaml:"fingerprint,omitempty"`
+	Confidence    float64  `yaml:"confidence,omitempty"`
+	Provenance    []string `yaml:"provenance,omitempty"`
+}
+
+// Render serializes a KBEntry as OKF markdown. The body is written verbatim —
+// callers that render untrusted (LLM-authored) bodies sanitize BEFORE calling
+// (the GitHub forge neutralizes image markdown); a human runbook being
+// imported must survive byte-for-byte.
+func Render(e providers.KBEntry, m Meta) string {
+	fm, _ := yaml.Marshal(frontmatter{
+		Type: e.Type, Title: e.Title, Description: e.Description, Resource: e.Resource,
+		AlertResource: e.AlertResource, Tags: e.Tags,
+		Timestamp: m.Timestamp, Status: m.Status, LastValidated: m.LastValidated,
+		Fingerprint: e.Fingerprint, Confidence: e.Confidence, Provenance: e.Provenance,
+	})
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.Write(fm)
+	b.WriteString("---\n\n")
+	b.WriteString(e.Body)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// Slugify lowercases s and collapses every non-[a-z0-9] run into one dash.
+// (Moved verbatim from internal/forge/github.)
+func Slugify(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/okf/okf_test.go
+++ b/internal/okf/okf_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package okf
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestRenderFrontmatterAndBody(t *testing.T) {
+	out := Render(providers.KBEntry{
+		Type: "Playbook", Title: "Redis failover", Description: "how to fail over redis",
+		Tags: []string{"imported", "playbook"}, Body: "# Redis failover\n\nsteps",
+	}, Meta{Timestamp: "2024-03-01"})
+	for _, want := range []string{
+		"---\n", "type: Playbook\n", "title: Redis failover\n",
+		"timestamp: \"2024-03-01\"", "tags:\n", "- imported\n",
+		"# Redis failover\n\nsteps\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("Render missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderOmitsEmptyMeta(t *testing.T) {
+	out := Render(providers.KBEntry{Type: "Playbook", Title: "T", Description: "d"}, Meta{})
+	for _, absent := range []string{"timestamp:", "status:", "last_validated:", "fingerprint:", "resource:"} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("empty %s must be omitted:\n%s", absent, out)
+		}
+	}
+}
+
+func TestRenderYAMLInjectionSafeTitle(t *testing.T) {
+	// Marshaled (not string-formatted), so a colon-bearing title can't inject keys.
+	out := Render(providers.KBEntry{Type: "Playbook", Title: "a: b\nresource: evil", Description: "d"}, Meta{})
+	if strings.Contains(out, "\nresource: evil\n") {
+		t.Fatalf("newline title must not inject a frontmatter key:\n%s", out)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Redis failover — March 2024!", "redis-failover-march-2024"},
+		{"  KubePodCrashLooping  ", "kubepodcrashlooping"},
+		{"---", ""},
+	}
+	for _, c := range cases {
+		if got := Slugify(c.in); got != c.want {
+			t.Errorf("Slugify(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Part of the **v0.11.0** roadmap — Phase 3 (Day-one value), item **D1**.

Solves the cold-start problem: `lore kb import <dir>` converts a directory of existing markdown runbooks/postmortems into OKF-compatible catalog entries — deterministic frontmatter inference, merge-gate validation, dedup — written into a local KB checkout for the human to review and commit. Recall value on day one, before any incidents accumulate.

```bash
lore kb import ./our-runbooks --into ./kb --dry-run   # preview, writes nothing
lore kb import ./our-runbooks --into ./kb             # convert + validate + dedup + write
```

## What changed (9 commits, TDD throughout)
1. **`internal/okf`** — extracted the OKF entry serializer (`Render`/`Slugify`) out of the GitHub forge; the forge now delegates (also the pre-work M2/GitLab needs). Behavior-preserving — forge round-trip tests green.
2. **Export shared primitives** — `catalog.SplitFrontmatter`, `kbvalidate.Sections`, `curator.CapTitle`, `curate.TitleJaccard`: import reuses the *exact* loader/validator/dedup primitives, so "valid/duplicate at import" == "valid/duplicate at merge".
3. **`kbimport.Infer`** — deterministic frontmatter inference (title, description, tags incl. detected alert names, type Incident-vs-Playbook, resource passthrough-only, date preservation). No clock, no I/O.
4. **`kbimport.Plan`** — dedup against the existing catalog + within the batch (path collision **and** fuzzy title), retired-at-source, preserving input order.
5. **`kbimport.Enrich`** — optional `--model` refinement that **never gates** (nil/error/junk → deterministic fallback + warning); can't invent `resource` or an out-of-vocab `type`.
6. **`lore kb import` command** — walk (catalog.Load skip rules) → Infer (+Enrich) → Plan → `ValidateStructural` (skip gate-failing with a reason, never write them) → dry-run table or write via `okf.Render`.
7. **Fixture e2e** — round-trip (everything written parses back with zero `WarnInvalid`), dedup, and idempotence (`imported 0` on re-run).
8. **Docs** — getting-started Step 1b + `cmd/lore` usage line.

## Two deviations from the plan (both TDD-driven, both improvements)
- **Alert-name regex**: the plan's `[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+` can't match acronym runs like `KubeContainerOOM Killed`; its own test expected `KubeContainerOOMKilled` to be tagged. Fixed to `[A-Z][a-z0-9]+(?:[A-Z]+[a-z0-9]*)+` — matches acronym humps while still excluding lone acronyms (`OOM`, `API`) and single words (`Redis`).
- **Intra-batch title dedup**: the plan's `Plan` only deduped batch entries by *path*, but the Task 7 fixture (`Redis failover` vs `Redis failover runbook`, different slugs) needs *fuzzy-title* dedup within a batch. Added it, ordered after path-collision so Task 4's "collides" case is unchanged. Locked with a unit test.

## Verification
- `go build ./... && go test ./... && go vet ./...` all pass; `gofmt` clean.
- Every production change was TDD'd (test written, watched fail for the right reason, implemented, watched pass).
- Real-binary smoke test (dry-run): Incident/Playbook classification correct, legacy copy skipped as a duplicate, README ignored, nothing written.

## Design guarantees
- No parallel entry format — flows through `providers.KBEntry` → `okf.Render` → `kbvalidate.ValidateStructural` → `catalog.Load`.
- No new **required** config — `--into` falls back to `catalog.dir`, `--model` reuses the `model:` block; both flag-overridable.
- The command never commits, pushes, or touches a forge — review stays in Git, same bar as every KB PR.