### PR TITLE
feat: Argo CD executor — approve-rung parity with Flux (M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,11 @@ between commits. It's usable today, but "stable" means different things across t
   notifier** (Slack in the eval) + **GitHub** for the knowledge base. This is the path the
   [nightly eval](CONTRIBUTING.md#nightly-eval-ci) and the [k3d e2e suite](CONTRIBUTING.md#end-to-end-on-k3d)
   exercise — run it with confidence.
-- **Argo CD is now end-to-end tested**, alongside Flux: the k3d suite reconfigures to the `argocd`
-  engine and drives an `Application Degraded` failure through a full investigation.
+- **Argo CD is now end-to-end tested**, alongside Flux — including the **`approve` rung**: the k3d
+  suite reconfigures to the `argocd` engine, drives an `Application Degraded` failure through a full
+  investigation, then human-approves a **pause-auto-sync** action that executes reversibly (the prior
+  `syncPolicy.automated` is preserved for resume). Both engines share the same reversible-only,
+  allowlisted action envelope.
 - **Functional but less exercised:** **Matrix**, **Gemini**, the **PagerDuty** webhook source, cloud
   integrations, and the network (Hubble) provider. They work and are unit-tested, but see less
   real-world mileage — expect rougher edges and please file issues.

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -130,9 +130,10 @@ subjects:
 {{- if .Values.rbac.allowActions }}
 {{- range .Values.rbac.actionNamespaces }}
 ---
-# Namespace-scoped execution rights (config.actions): patch Flux resources in THIS
-# namespace only — never cluster-wide — so the blast radius is bounded. The set
-# should mirror config.actions.allow.namespaces.
+# Namespace-scoped execution rights (config.actions): patch GitOps resources (Flux
+# Kustomizations/HelmReleases, Argo CD Applications) in THIS namespace only — never
+# cluster-wide — so the blast radius is bounded. The set should mirror
+# config.actions.allow.namespaces.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -146,6 +147,12 @@ rules:
     verbs: ["get", "patch"]
   - apiGroups: ["helm.toolkit.fluxcd.io"]
     resources: ["helmreleases"]
+    verbs: ["get", "patch"]
+  # Argo CD executor (config.gitops.engine: argocd): pause/resume auto-sync and
+  # refresh are merge patches on the Application; pause/resume also GET the app
+  # first to read/restore the prior sync policy, so the Role is self-contained.
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
     verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -363,10 +363,12 @@ serviceAccount:
 # read GitRepositories. Cluster-scoped because the informer watches all namespaces.
 rbac:
   create: true
-  # allowActions grants patch on Flux resources for rung-2 execution
+  # allowActions grants patch on GitOps resources (Flux Kustomizations/HelmReleases,
+  # Argo CD Applications) for rung-2 execution
   # (config.actions.mode: approve). Off by default — read-only without it.
   allowActions: false
-  # Namespaces where the agent may patch Flux resources (suspend/resume/reconcile).
+  # Namespaces where the agent may patch GitOps resources (suspend/resume/reconcile;
+  # for Argo CD this is where your Application objects live, e.g. argocd).
   # Granted as namespace-scoped Roles ONLY here — never cluster-wide — so the blast
   # radius is bounded. Mirror config.actions.allow.namespaces. Empty = no patch
   # rights at all (actions fail closed at the RBAC layer even if mode is enabled).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -241,6 +241,22 @@ Also records the human 👍/👎 ratings when `notify.slack.feedback_buttons` is
 - `allow` — the envelope: `reversible_only`, `namespaces` (allowlist — **empty permits nothing**),
   `protected_namespaces` (added to built-in `flux-system`/`kube-system` denies), `max_blast_radius`,
   `kinds`.
+- **Per-engine op semantics** — the executable ops (`suspend` / `resume` / `reconcile`) are
+  engine-neutral names; the executor for the configured `gitops.engine` translates them:
+
+  | op | Flux (`Kustomization` / `HelmRelease`) | Argo CD (`Application`) |
+  |---|---|---|
+  | `suspend` | sets `spec.suspend: true` | removes `spec.syncPolicy.automated` (pauses auto-sync); the prior value is preserved in the `runlore.io/paused-sync-automated` annotation |
+  | `resume` | sets `spec.suspend: false` | restores `spec.syncPolicy.automated` from that annotation (no-op if RunLore didn't pause it) |
+  | `reconcile` | `reconcile.fluxcd.io/requestedAt` annotation | `argocd.argoproj.io/refresh: normal` annotation |
+
+  All three are reversible with blast radius 1 in the server-authoritative op registry, so the same
+  policy envelope gates both engines identically. **Argo CD notes:** `Application` objects usually
+  live in the `argocd` namespace — add it (or your apps-in-any-namespace app namespaces) to
+  `actions.allow.namespaces` **and** the chart's `rbac.actionNamespaces`. If you set `allow.kinds`,
+  include `Application`. `argocd` is deliberately **not** a built-in protected namespace (unlike
+  `flux-system`): it is where the reversible pause lever lives; the empty-by-default namespace
+  allowlist is what bounds it.
 - `require_approval` + `approval_token_env`, `audit_log_path`, and `auto.*` (`dry_run`,
   `min_confidence`, `max_per_window`, `window`).
 - **Fail-closed validation:** `approve`/`auto` both require `approval_token_env` **and**

--- a/hack/e2e-local.sh
+++ b/hack/e2e-local.sh
@@ -742,7 +742,8 @@ kubectl wait --for=condition=Established crd/applications.argoproj.io --timeout=
 # Reconfigure to the argocd engine. The chart's Recreate strategy makes this
 # in-place update roll cleanly under leader election (old pods terminate first).
 helm upgrade runlore deploy/helm/runlore -n "$NS" --reuse-values \
-  --set replicaCount=1 --set-string config.gitops.engine=argocd >/dev/null
+  --set replicaCount=1 --set-string config.gitops.engine=argocd \
+  --set-string config.actions.mode=approve >/dev/null
 kubectl -n "$NS" rollout status deploy/runlore --timeout=120s
 wait_for_leader   # gate the argocd Application trigger on leadership settling (#284)
 sleep 3
@@ -750,7 +751,9 @@ kubectl apply -f - <<'YAML'
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata: { name: broken-argo, namespace: apps }
-spec: { source: { repoURL: "https://github.com/org/repo", path: apps } }
+spec:
+  source: { repoURL: "https://github.com/org/repo", path: apps }
+  syncPolicy: { automated: { prune: true, selfHeal: true } }
 YAML
 kubectl patch application broken-argo -n apps --subresource=status --type=merge -p \
   '{"status":{"health":{"status":"Degraded"},"sync":{"revision":"deadbeef","status":"OutOfSync"},"operationState":{"message":"image pull backoff"}}}'
@@ -758,6 +761,29 @@ sleep 6
 kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
 check "argocd engine active"          /tmp/runlore.log 'engine=argocd'
 check "argocd failure -> investigate" /tmp/runlore.log 'Application/broken-argo'
+
+# Rung 2 parity (M3): the mock proposed pausing auto-sync on the Application;
+# approve it via the token endpoint and verify the executor (a) removed
+# spec.syncPolicy.automated and (b) preserved the prior policy in the
+# runlore.io/paused-sync-automated annotation — the reversibility contract.
+check "argocd action queued for approval" /tmp/runlore.log 'actions registered for approval'
+APORT=18092; free_port "$APORT"
+kubectl -n "$NS" port-forward svc/runlore "$APORT:8080" >/tmp/runlore-argo-pf.log 2>&1 &
+APF=$!; sleep 3
+AID=$(curl -s -H "X-Approval-Token: e2e-secret" "localhost:$APORT/actions" | first_action_id) || true
+curl -s -o /dev/null -w "argo approve HTTP %{http_code}\n" -X POST \
+  -H "X-Approval-Token: e2e-secret" "localhost:$APORT/actions/$AID/approve" || true
+kill "$APF" 2>/dev/null || true; free_port "$APORT"
+sleep 3
+AUTOMATED=$(kubectl get application broken-argo -n apps -o jsonpath='{.spec.syncPolicy.automated}' 2>/dev/null || true)
+SAVED=$(kubectl get application broken-argo -n apps -o jsonpath='{.metadata.annotations.runlore\.io/paused-sync-automated}' 2>/dev/null || true)
+if [[ -z "$AUTOMATED" && "$SAVED" == *'"prune":true'* ]]; then
+  green "PASS: approved argocd action paused auto-sync and preserved the prior policy ($SAVED)"; PASS=$((PASS+1))
+else
+  red "FAIL: argocd pause (automated='$AUTOMATED' saved='$SAVED'; want automated removed + policy saved)"; FAIL=$((FAIL+1))
+fi
+kubectl -n "$NS" logs deploy/runlore > /tmp/runlore.log 2>&1
+check "argocd execution audit-logged" /tmp/runlore.log 'action approved and executed'
 
 step "RESULTS"
 echo "PASS=$PASS FAIL=$FAIL"

--- a/hack/e2e/mock/main.go
+++ b/hack/e2e/mock/main.go
@@ -136,7 +136,15 @@ func chatCompletions(w http.ResponseWriter, r *http.Request) {
 	case 4:
 		name, args = "network_drops", `{"namespace":"apps"}`
 	default:
-		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"],"actions":[{"description":"suspend the failing Kustomization to stop the reconcile loop","op":"suspend","reversible":true,"blast_radius":1,"target":{"kind":"Kustomization","name":"broken-app","namespace":"apps"}}]}`
+		// The action targets whichever GitOps object triggered THIS incident: the
+		// argocd e2e phase names Application/broken-argo in the incident text, the
+		// flux phases name broken-app. Sniffing the request body keeps the mock
+		// stateless across both engine phases.
+		actionJSON := `{"description":"suspend the failing Kustomization to stop the reconcile loop","op":"suspend","reversible":true,"blast_radius":1,"target":{"kind":"Kustomization","name":"broken-app","namespace":"apps"}}`
+		if strings.Contains(string(body), "broken-argo") {
+			actionJSON = `{"description":"pause auto-sync on the degraded Application to stop the flapping rollout","op":"suspend","reversible":true,"blast_radius":1,"target":{"kind":"Application","name":"broken-argo","namespace":"apps"}}`
+		}
+		name, args = "submit_findings", `{"confidence":0.9,"root_causes":[{"summary":"mock: chart bump broke harbor-db","confidence":0.9,"evidence":["pg_up=0"],"suggested_action":"flux rollback hr/harbor","reversible":true}],"unresolved":["mock unresolved"],"actions":[`+actionJSON+`]}`
 	}
 	log.Printf("MOCK chat/completions: toolResults=%d -> %s", toolResults, name)
 	writeToolCallSSE(w, fmt.Sprintf("c%d", toolResults), name, args)

--- a/internal/action/policy_test.go
+++ b/internal/action/policy_test.go
@@ -164,3 +164,30 @@ func TestReviewExecutableNeedsTargetKind(t *testing.T) {
 		t.Fatalf("withheld = %v, want the kind reason", withheld)
 	}
 }
+
+// TestReviewArgoApplicationParity locks in M3's central invariant: an
+// Application-targeted registry op passes the SAME server-authoritative
+// envelope as a Flux target — reversibility/blast derived from providers.Ops
+// (never the model's fields), no default kind restriction, namespace
+// allowlisted — with NO engine- or kind-specific branches in the gate.
+func TestReviewArgoApplicationParity(t *testing.T) {
+	p := New(config.ActionPolicy{Mode: config.ActionApprove, Allow: config.ActionAllow{
+		ReversibleOnly: true,
+		Namespaces:     []string{"argocd"},
+	}})
+	acts := []providers.Action{{
+		Name:        "pause-auto-sync",
+		Op:          "suspend",
+		Reversible:  false, // model-supplied lie — must be discarded
+		BlastRadius: 99,    // model-supplied lie — must be discarded
+		Target:      providers.Workload{Kind: "Application", Name: "web", Namespace: "argocd"},
+	}}
+	kept, withheld := p.Review(acts)
+	if len(withheld) != 0 || len(kept) != 1 {
+		t.Fatalf("kept=%d withheld=%v; want the Application action kept", len(kept), withheld)
+	}
+	if !kept[0].Reversible || kept[0].BlastRadius != 1 {
+		t.Fatalf("derived (reversible=%v, blast=%d); want (true, 1) from providers.Ops",
+			kept[0].Reversible, kept[0].BlastRadius)
+	}
+}

--- a/internal/app/action.go
+++ b/internal/app/action.go
@@ -60,7 +60,7 @@ func BuildApprovals(cfg *config.Config, exec action.Executor, aud audit.Auditor,
 		log.Warn("approval-gated actions disabled: no cluster executor available")
 		return nil
 	}
-	log.Info("rung-2 approval-gated actions enabled (Flux suspend/resume/reconcile)")
+	log.Info("rung-2 approval-gated actions enabled (GitOps suspend/resume/reconcile)")
 	return action.NewApprovals(exec, action.New(cfg.Actions), aud, log)
 }
 

--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -7,7 +7,10 @@ import (
 
 	"k8s.io/client-go/dynamic"
 
+	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/config"
+	argoexec "github.com/Smana/runlore/internal/executor/argocd"
+	fluxexec "github.com/Smana/runlore/internal/executor/flux"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/providers/gitops/argocd"
 	"github.com/Smana/runlore/internal/providers/gitops/flux"
@@ -34,6 +37,17 @@ func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) pro
 	}
 	log.Info("gitops engine", "engine", "flux")
 	return flux.New(flux.NewDynamicReader(dc), differ)
+}
+
+// BuildExecutor returns the rung-2/3 action executor for the configured GitOps
+// engine — the same engine switch as BuildGitOps, so the executor always
+// matches the provider that proposed the target (an Argo Application action
+// must never reach the Flux executor and vice versa).
+func BuildExecutor(cfg *config.Config, dc dynamic.Interface) action.Executor {
+	if GitopsEngine(cfg) == "argocd" {
+		return argoexec.New(dc)
+	}
+	return fluxexec.New(dc)
 }
 
 // GitOpsFromKube builds the GitOps provider from the ambient kubeconfig (best-effort).

--- a/internal/app/gitops_test.go
+++ b/internal/app/gitops_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/Smana/runlore/internal/config"
+	argoexec "github.com/Smana/runlore/internal/executor/argocd"
+	fluxexec "github.com/Smana/runlore/internal/executor/flux"
+)
+
+// TestBuildExecutorFollowsGitopsEngine pins the M3 wiring: the action executor
+// must track gitops.engine exactly as BuildGitOps does, or approve-rung actions
+// fail with "unsupported target kind" on one of the engines.
+func TestBuildExecutorFollowsGitopsEngine(t *testing.T) {
+	dc := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	cfg := &config.Config{}
+	if _, ok := BuildExecutor(cfg, dc).(*fluxexec.Executor); !ok {
+		t.Fatalf("default engine: got %T, want *flux.Executor", BuildExecutor(cfg, dc))
+	}
+
+	cfg.GitOps.Engine = "argocd"
+	if _, ok := BuildExecutor(cfg, dc).(*argoexec.Executor); !ok {
+		t.Fatalf("argocd engine: got %T, want *argocd.Executor", BuildExecutor(cfg, dc))
+	}
+}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/coalesce"
 	"github.com/Smana/runlore/internal/config"
-	fluxexec "github.com/Smana/runlore/internal/executor/flux"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logging"
 	_ "github.com/Smana/runlore/internal/notify/templated" // self-registers the templated notifier
@@ -93,7 +92,7 @@ func RunServe(version string, args []string) error {
 	var (
 		gitops    providers.GitOpsProvider
 		clientset *kubernetes.Clientset
-		executor  action.Executor // rung-2 action executor (Flux), when a cluster is reachable
+		executor  action.Executor // rung-2/3 action executor for the configured GitOps engine, when a cluster is reachable
 	)
 	if restCfg, err := RestConfig(); err != nil {
 		log.Warn("no kube client; GitOps features + leader election disabled", "err", err)
@@ -102,7 +101,7 @@ func RunServe(version string, args []string) error {
 			log.Warn("dynamic client unavailable; GitOps features disabled", "err", derr)
 		} else {
 			gitops = BuildGitOps(cfg, dc, log)
-			executor = fluxexec.New(dc)
+			executor = BuildExecutor(cfg, dc)
 		}
 		if cs, cerr := kubernetes.NewForConfig(restCfg); cerr != nil {
 			log.Warn("clientset unavailable; leader election disabled", "err", cerr)

--- a/internal/executor/argocd/argocd.go
+++ b/internal/executor/argocd/argocd.go
@@ -79,11 +79,32 @@ func (e *Executor) Execute(ctx context.Context, a providers.Action) error {
 	}
 }
 
-// pauseAutoSync and resumeAutoSync are implemented in Tasks 3-4; stub them for
-// this task so the package compiles:
+// pauseAutoSync removes spec.syncPolicy.automated (Argo CD's "stop deploying
+// this" lever — the analogue of Flux spec.suspend), saving the prior automated
+// object into PausedPolicyAnnotation in the SAME patch so resume can restore it
+// exactly. An app with no automated policy (manual sync, or already paused) is
+// a no-op — idempotent like re-suspending in Flux, and it never clobbers a
+// previously saved policy.
 func (e *Executor) pauseAutoSync(ctx context.Context, a providers.Action) error {
-	return fmt.Errorf("not implemented")
+	u, err := e.get(ctx, a)
+	if err != nil {
+		return err
+	}
+	automated, found, _ := unstructured.NestedMap(u.Object, "spec", "syncPolicy", "automated")
+	if !found {
+		return nil // manual-sync or already paused: nothing to pause
+	}
+	saved, err := json.Marshal(automated)
+	if err != nil {
+		return fmt.Errorf("marshal prior sync policy: %w", err)
+	}
+	return e.patch(ctx, a, map[string]any{
+		"metadata": map[string]any{"annotations": map[string]any{PausedPolicyAnnotation: string(saved)}},
+		"spec":     map[string]any{"syncPolicy": map[string]any{"automated": nil}}, // merge-patch null deletes the key
+	})
 }
+
+// resumeAutoSync is implemented in Task 4; stub it so the package compiles.
 func (e *Executor) resumeAutoSync(ctx context.Context, a providers.Action) error {
 	return fmt.Errorf("not implemented")
 }

--- a/internal/executor/argocd/argocd.go
+++ b/internal/executor/argocd/argocd.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package argocd executes safe, reversible Argo CD operations on Application
+// CRs — the Argo half of the autonomy ladder's executable rungs, mirroring
+// internal/executor/flux. Ops map as: suspend = pause auto-sync (remove
+// spec.syncPolicy.automated, preserving the prior value in an annotation so
+// resume can restore it losslessly), resume = restore it, reconcile = the
+// self-cleaning argocd.argoproj.io/refresh annotation (the analogue of Flux's
+// requestedAt). It patches the Application custom resource directly via the
+// dynamic client — the same access path the argocd GitOps provider reads
+// through (internal/providers/gitops/argocd) — never the Argo API server.
+//
+// suspend/resume are GET-then-PATCH and deliberately not transactional: a
+// concurrent syncPolicy edit in the window can be overwritten. Accepted — the
+// approve rung is human-clicked and the Flux executor's blind patch carries
+// the same exposure.
+package argocd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// applicationGVR is the Argo CD Application resource — the same GVR the
+// read-side provider uses (internal/providers/gitops/argocd/dynamic.go).
+var applicationGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+
+// PausedPolicyAnnotation stores the JSON of spec.syncPolicy.automated at pause
+// time so resume restores the EXACT prior policy (prune/selfHeal/allowEmpty).
+// Removing automated without saving it would make the op registry's
+// Reversible=true derivation a lie.
+const PausedPolicyAnnotation = "runlore.io/paused-sync-automated"
+
+// refreshAnnotation asks the application controller to re-compare the app
+// against its source; the controller consumes (removes) it — self-cleaning.
+const refreshAnnotation = "argocd.argoproj.io/refresh"
+
+// Executor runs reversible Argo CD operations via the dynamic client.
+type Executor struct {
+	client dynamic.Interface
+}
+
+// New builds an Executor backed by a dynamic client.
+func New(client dynamic.Interface) *Executor { return &Executor{client: client} }
+
+// Execute applies the action's reversible Argo CD operation to its target.
+func (e *Executor) Execute(ctx context.Context, a providers.Action) error {
+	// providers.Ops is the canonical op allowlist shared with the action gate; an op
+	// absent there is never executed (keeps the gate and the executor from drifting).
+	if _, ok := providers.Ops[a.Op]; !ok {
+		return fmt.Errorf("unsupported op %q", a.Op)
+	}
+	if a.Target.Kind != "Application" {
+		return fmt.Errorf("unsupported target kind %q (want Application)", a.Target.Kind)
+	}
+	if a.Target.Name == "" || a.Target.Namespace == "" {
+		return fmt.Errorf("action target needs name and namespace")
+	}
+	switch a.Op {
+	case "suspend":
+		return e.pauseAutoSync(ctx, a)
+	case "resume":
+		return e.resumeAutoSync(ctx, a)
+	case "reconcile":
+		return e.patch(ctx, a, map[string]any{
+			"metadata": map[string]any{"annotations": map[string]any{refreshAnnotation: "normal"}},
+		})
+	default:
+		return fmt.Errorf("unsupported op %q (want suspend, resume, or reconcile)", a.Op)
+	}
+}
+
+// pauseAutoSync and resumeAutoSync are implemented in Tasks 3-4; stub them for
+// this task so the package compiles:
+func (e *Executor) pauseAutoSync(ctx context.Context, a providers.Action) error {
+	return fmt.Errorf("not implemented")
+}
+func (e *Executor) resumeAutoSync(ctx context.Context, a providers.Action) error {
+	return fmt.Errorf("not implemented")
+}
+
+// get fetches the target Application (needed by pause/resume to read the
+// current sync policy / saved annotation before patching).
+func (e *Executor) get(ctx context.Context, a providers.Action) (*unstructured.Unstructured, error) {
+	u, err := e.client.Resource(applicationGVR).Namespace(a.Target.Namespace).
+		Get(ctx, a.Target.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("argocd %s %s/%s: %w", a.Op, a.Target.Namespace, a.Target.Name, err)
+	}
+	return u, nil
+}
+
+// patch merge-patches the target Application. The patch is built as a map and
+// marshalled (never fmt.Sprintf) because pause embeds JSON inside a JSON
+// string value — hand-rolled escaping would be a bug factory.
+func (e *Executor) patch(ctx context.Context, a providers.Action, patch map[string]any) error {
+	b, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("marshal patch: %w", err)
+	}
+	if _, err := e.client.Resource(applicationGVR).Namespace(a.Target.Namespace).
+		Patch(ctx, a.Target.Name, types.MergePatchType, b, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("argocd %s %s/%s: %w", a.Op, a.Target.Namespace, a.Target.Name, err)
+	}
+	return nil
+}

--- a/internal/executor/argocd/argocd.go
+++ b/internal/executor/argocd/argocd.go
@@ -104,9 +104,32 @@ func (e *Executor) pauseAutoSync(ctx context.Context, a providers.Action) error 
 	})
 }
 
-// resumeAutoSync is implemented in Task 4; stub it so the package compiles.
+// resumeAutoSync restores spec.syncPolicy.automated from PausedPolicyAnnotation
+// and removes the annotation in the same patch. An app with no saved policy is
+// a no-op: RunLore never paused it, and inventing an auto-sync policy an
+// operator never configured would be a mutation outside the op's contract. A
+// saved policy that no longer parses is an ERROR, not a guess.
 func (e *Executor) resumeAutoSync(ctx context.Context, a providers.Action) error {
-	return fmt.Errorf("not implemented")
+	u, err := e.get(ctx, a)
+	if err != nil {
+		return err
+	}
+	saved, ok := u.GetAnnotations()[PausedPolicyAnnotation]
+	if !ok {
+		return nil // never paused by RunLore: nothing to restore
+	}
+	var automated map[string]any
+	if err := json.Unmarshal([]byte(saved), &automated); err != nil {
+		return fmt.Errorf("argocd resume %s/%s: saved sync policy unreadable: %w",
+			a.Target.Namespace, a.Target.Name, err)
+	}
+	if automated == nil {
+		automated = map[string]any{} // JSON "null" round-trips to the empty automated object
+	}
+	return e.patch(ctx, a, map[string]any{
+		"metadata": map[string]any{"annotations": map[string]any{PausedPolicyAnnotation: nil}},
+		"spec":     map[string]any{"syncPolicy": map[string]any{"automated": automated}},
+	})
 }
 
 // get fetches the target Application (needed by pause/resume to read the

--- a/internal/executor/argocd/argocd_test.go
+++ b/internal/executor/argocd/argocd_test.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// app builds a minimal Application named web in argocd. automated == nil means
+// spec.syncPolicy is absent entirely (a manual-sync app); a non-nil (possibly
+// empty) map becomes spec.syncPolicy.automated. ann, when non-nil, becomes
+// metadata.annotations.
+func app(automated map[string]any, ann map[string]any) *unstructured.Unstructured {
+	meta := map[string]any{"name": "web", "namespace": "argocd"}
+	if ann != nil {
+		meta["annotations"] = ann
+	}
+	spec := map[string]any{"project": "default"}
+	if automated != nil {
+		spec["syncPolicy"] = map[string]any{"automated": automated}
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Application",
+		"metadata":   meta,
+		"spec":       spec,
+	}}
+}
+
+func newClient(objs ...*unstructured.Unstructured) *dynamicfake.FakeDynamicClient {
+	gvrToListKind := map[schema.GroupVersionResource]string{applicationGVR: "ApplicationList"}
+	rs := make([]runtime.Object, len(objs))
+	for i, o := range objs {
+		rs[i] = o
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, rs...)
+}
+
+func get(t *testing.T, c *dynamicfake.FakeDynamicClient) *unstructured.Unstructured {
+	t.Helper()
+	u, err := c.Resource(applicationGVR).Namespace("argocd").Get(context.Background(), "web", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}
+
+func action(op string) providers.Action {
+	return providers.Action{Op: op, Target: providers.Workload{Kind: "Application", Name: "web", Namespace: "argocd"}}
+}
+
+func TestReconcileSetsRefreshAnnotation(t *testing.T) {
+	c := newClient(app(map[string]any{"prune": true}, nil))
+	if err := New(c).Execute(context.Background(), action("reconcile")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if v := get(t, c).GetAnnotations()["argocd.argoproj.io/refresh"]; v != "normal" {
+		t.Fatalf("refresh annotation = %q, want %q", v, "normal")
+	}
+}
+
+func TestUnsupported(t *testing.T) {
+	e := New(newClient(app(nil, nil)))
+	if err := e.Execute(context.Background(), providers.Action{Op: "delete",
+		Target: providers.Workload{Kind: "Application", Name: "web", Namespace: "argocd"}}); err == nil {
+		t.Fatal("expected error for unsupported op")
+	}
+	if err := e.Execute(context.Background(), providers.Action{Op: "suspend",
+		Target: providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "argocd"}}); err == nil {
+		t.Fatal("expected error for unsupported kind")
+	}
+	if err := e.Execute(context.Background(), providers.Action{Op: "suspend",
+		Target: providers.Workload{Kind: "Application", Name: "web"}}); err == nil {
+		t.Fatal("expected error for missing namespace")
+	}
+}

--- a/internal/executor/argocd/argocd_test.go
+++ b/internal/executor/argocd/argocd_test.go
@@ -83,3 +83,39 @@ func TestUnsupported(t *testing.T) {
 		t.Fatal("expected error for missing namespace")
 	}
 }
+
+func TestSuspendPausesAutoSyncAndStoresPriorPolicy(t *testing.T) {
+	c := newClient(app(map[string]any{"prune": true, "selfHeal": true}, nil))
+	if err := New(c).Execute(context.Background(), action("suspend")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	u := get(t, c)
+	if _, found, _ := unstructured.NestedMap(u.Object, "spec", "syncPolicy", "automated"); found {
+		t.Fatal("spec.syncPolicy.automated still present; auto-sync not paused")
+	}
+	// json.Marshal orders map keys alphabetically, so this is deterministic.
+	if v := u.GetAnnotations()[PausedPolicyAnnotation]; v != `{"prune":true,"selfHeal":true}` {
+		t.Fatalf("saved policy annotation = %q, want the prior automated object", v)
+	}
+}
+
+func TestSuspendManualSyncAppIsNoop(t *testing.T) {
+	c := newClient(app(nil, nil)) // no syncPolicy at all: manual sync
+	if err := New(c).Execute(context.Background(), action("suspend")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if v, ok := get(t, c).GetAnnotations()[PausedPolicyAnnotation]; ok {
+		t.Fatalf("no-op suspend must not invent a saved policy (got %q)", v)
+	}
+}
+
+func TestSuspendAlreadyPausedPreservesSavedPolicy(t *testing.T) {
+	// Paused earlier: automated absent, annotation holds the real prior policy.
+	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `{"prune":true}`}))
+	if err := New(c).Execute(context.Background(), action("suspend")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if v := get(t, c).GetAnnotations()[PausedPolicyAnnotation]; v != `{"prune":true}` {
+		t.Fatalf("double-suspend clobbered the saved policy: %q", v)
+	}
+}

--- a/internal/executor/argocd/argocd_test.go
+++ b/internal/executor/argocd/argocd_test.go
@@ -119,3 +119,50 @@ func TestSuspendAlreadyPausedPreservesSavedPolicy(t *testing.T) {
 		t.Fatalf("double-suspend clobbered the saved policy: %q", v)
 	}
 }
+
+func TestResumeRestoresSavedPolicyAndClearsAnnotation(t *testing.T) {
+	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `{"prune":true,"selfHeal":true}`}))
+	if err := New(c).Execute(context.Background(), action("resume")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	u := get(t, c)
+	automated, found, _ := unstructured.NestedMap(u.Object, "spec", "syncPolicy", "automated")
+	if !found {
+		t.Fatal("spec.syncPolicy.automated not restored")
+	}
+	if automated["prune"] != true || automated["selfHeal"] != true {
+		t.Fatalf("restored policy = %v, want prune+selfHeal true", automated)
+	}
+	if _, ok := u.GetAnnotations()[PausedPolicyAnnotation]; ok {
+		t.Fatal("saved-policy annotation not removed after resume")
+	}
+}
+
+func TestResumeRestoresEmptyAutomatedObject(t *testing.T) {
+	// automated: {} is valid Argo config (auto-sync with default flags) and must
+	// round-trip distinctly from "no automated at all".
+	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `{}`}))
+	if err := New(c).Execute(context.Background(), action("resume")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, found, _ := unstructured.NestedMap(get(t, c).Object, "spec", "syncPolicy", "automated"); !found {
+		t.Fatal("empty automated object not restored")
+	}
+}
+
+func TestResumeWithoutPriorPauseIsNoop(t *testing.T) {
+	c := newClient(app(nil, nil)) // RunLore never paused this app
+	if err := New(c).Execute(context.Background(), action("resume")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, found, _ := unstructured.NestedMap(get(t, c).Object, "spec", "syncPolicy", "automated"); found {
+		t.Fatal("resume invented an auto-sync policy on an app RunLore never paused")
+	}
+}
+
+func TestResumeCorruptSavedPolicyErrors(t *testing.T) {
+	c := newClient(app(nil, map[string]any{PausedPolicyAnnotation: `not-json`}))
+	if err := New(c).Execute(context.Background(), action("resume")); err == nil {
+		t.Fatal("expected error for unreadable saved policy (must not guess a policy)")
+	}
+}

--- a/internal/executor/argocd/audit_test.go
+++ b/internal/executor/argocd/audit_test.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package argocd
+
+import (
+	"context"
+	"testing"
+
+	act "github.com/Smana/runlore/internal/action"
+	"github.com/Smana/runlore/internal/audit"
+)
+
+// recorder captures audit records in memory.
+type recorder struct{ records []audit.Record }
+
+func (r *recorder) Log(rec audit.Record) error { r.records = append(r.records, rec); return nil }
+
+// TestAuditedExecutionRecordsApplicationTarget proves the audit seam
+// (action.NewAuditedExecutor) is engine-agnostic in practice: an executed
+// Argo CD pause is recorded with the approver actor and the Application
+// target, byte-identical in shape to a Flux record.
+func TestAuditedExecutionRecordsApplicationTarget(t *testing.T) {
+	c := newClient(app(map[string]any{"prune": true}, nil))
+	rec := &recorder{}
+	exec := act.NewAuditedExecutor(New(c), rec)
+	ctx := act.ContextWithActor(context.Background(), "approve:slack:U_TEST")
+	if err := exec.Execute(ctx, action("suspend")); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(rec.records) != 1 {
+		t.Fatalf("audit records = %d, want 1", len(rec.records))
+	}
+	r := rec.records[0]
+	if r.Actor != "approve:slack:U_TEST" || r.Op != "suspend" ||
+		r.Target != "Application/argocd/web" || r.Decision != audit.DecisionExecuted {
+		t.Fatalf("record = %+v, want executed suspend on Application/argocd/web by the approver", r)
+	}
+}

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -84,7 +84,7 @@ func submitFindingsSpec() providers.ToolSpec {
 "ruled_out":{"type":"array","items":{"type":"string"},"description":"hypotheses you considered and REJECTED, one line each naming the disproving evidence"},
 "data_gaps":{"type":"array","items":{"type":"string"},"description":"signals you could not obtain (tool errors, missing metrics, truncated output) that limited the investigation - data limitations, NOT questions for a human"},
 "actions":{"type":"array","description":"proposed remediations; prefer reversible, low-blast-radius","items":{"type":"object","properties":{
-"description":{"type":"string"},"op":{"type":"string","enum":` + opEnumJSON() + `,"description":"executable op (Flux); omit for a suggestion only"},
+"description":{"type":"string"},"op":{"type":"string","enum":` + opEnumJSON() + `,"description":"executable GitOps op (Flux or Argo CD); omit for a suggestion only"},
 "reversible":{"type":"boolean"},"blast_radius":{"type":"integer"},
 "target":{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}}},
 "required":["description"]}}},"required":["root_causes","verdict"]}`,

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -171,9 +171,13 @@ type OpSafety struct {
 
 // Ops is the canonical registry of executable remediation operations and their
 // server-authoritative safety metadata. The action gate (internal/action) derives
-// reversibility/blast from this — never from model output — and the executor
-// (internal/executor/flux) runs only ops listed here. One entry per op is the
-// single source of truth that keeps the gate and the executor from drifting.
+// reversibility/blast from this — never from model output — and the per-engine
+// executors (internal/executor/flux, internal/executor/argocd) run only ops
+// listed here. Op names are engine-neutral; the executor for the configured
+// gitops.engine translates them (Flux: spec.suspend / requestedAt annotation;
+// Argo CD: pause/restore spec.syncPolicy.automated / refresh annotation). One
+// entry per op is the single source of truth that keeps the gate and the
+// executors from drifting.
 var Ops = map[string]OpSafety{
 	"suspend":   {Reversible: true, Blast: 1},
 	"resume":    {Reversible: true, Blast: 1},


### PR DESCRIPTION
Part of the **v0.11.0** roadmap — Phase 4 (Meet users), item **M3**.

Gives Argo CD users parity with Flux on the **approve** autonomy rung. Today `serve.go` wires `fluxexec.New(dc)` unconditionally, so under `gitops.engine: argocd` every approved action fails with `unsupported target kind "Application"` — the approve rung silently does nothing for Argo users. This adds an `internal/executor/argocd` package and selects it per-engine, with **zero policy-code changes**.

## What changed (9 commits, TDD)
1. **Engine-neutral op surface** — `providers.Ops` stays `{suspend, resume, reconcile}`; only three Flux-specific doc/description strings became engine-neutral. A parity characterization test (`TestReviewArgoApplicationParity`) locks that an `Application` target flows through the reversible-only + blast + kind + namespace gates unchanged — and fails loudly if anyone adds engine special-casing.
2. **`internal/executor/argocd`** — mirrors the Flux executor (dynamic client, `providers.Ops`-gated, merge patches):
   - **suspend** = remove `spec.syncPolicy.automated`, saving the prior object in the `runlore.io/paused-sync-automated` annotation *in the same patch* (lossless → the registry's `Reversible: true` isn't a lie). Manual-sync / already-paused apps are safe no-ops.
   - **resume** = restore the saved policy (incl. empty `{}`), clear the annotation; no-op if RunLore never paused it; **error, not guess**, on a corrupt saved policy.
   - **reconcile** = `argocd.argoproj.io/refresh: normal` (self-cleaning; the analogue of Flux `requestedAt`). `.operation` patch was rejected — it bypasses the API server's in-flight-operation guard.
3. **`app.BuildExecutor`** — one engine switch beside `BuildGitOps`; `serve.go` selects the executor by `gitops.engine`. Unit test pins both branches.
4. **Audit parity** — proven that an executed Argo action lands in the `NewAuditedExecutor` audit chain as `Application/<ns>/<name>` — no audit-code change.
5. **Chart RBAC** — the namespaced actions Role grants `argoproj.io/applications` `get, patch` (`helm template` proves it).
6. **e2e** — step 11 now approves a pause-auto-sync action on `broken-argo` and asserts `automated` removed + prior policy saved + execution audit-logged.
7. **Docs** — README status bullet + a per-engine op-semantics table in configuration.md.

## Verified engine-agnostic, no change needed (per plan)
- Slack approve/reject buttons (kind-agnostic block builder) — Argo actions get buttons for free.
- The F2 unobserved-target guard (matches names, not kinds) and the kind allowlist (empty = all).
- `argocd` is deliberately **not** a built-in protected namespace — it's where the reversible pause lever lives; the empty-by-default namespace allowlist bounds it.

## Verification
- Full quality gate green: `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` (empty), **golangci-lint `0 issues`**, `helm lint` clean.
- Every production change TDD'd (fail-first except the two deliberate characterization/parity tests, flagged as such).
- Mock (`go vet -tags e2e`) and e2e script (`bash -n`) syntax-verified.

## Deferred to CI
The full **k3d e2e** (`hack/e2e-k3d.sh`, ~10 min) is CI-gated on this PR — the script + mock changes are made and syntax-checked, but I didn't run the whole suite locally. The two new PASS lines to watch: `approved argocd action paused auto-sync…` and `argocd execution audit-logged`; all pre-existing Flux phases must stay green (the mock body-sniff only fires on `broken-argo`).

## No new required config
`gitops.engine` already exists; no new keys. Argo users add `argocd` (or their app namespaces) to `actions.allow.namespaces` + `rbac.actionNamespaces` — a docs item, not code.