### PR TITLE
feat: Grafana Loki logs backend behind LogsProvider (M1)

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -267,7 +267,11 @@ config:
   #   github_app: { app_id: 0, installation_id: 0, private_key_env: GITHUB_APP_PRIVATE_KEY }
   # Investigate signals (optional). metrics/logs enable query_metrics/query_logs.
   # metrics: { url: http://vmsingle.observability.svc:8429 }   # PromQL (VictoriaMetrics/Prometheus)
-  # logs:    { url: http://victorialogs.observability.svc:9428 }  # LogsQL (VictoriaLogs)
+  # Logs backend (query_logs / logs_error_summary / discover_log_fields). The provider is
+  # auto-detected (Loki answers /loki/api/v1/status/buildinfo; anything else = VictoriaLogs);
+  # pin it with `provider:` if the backend is unreachable at chart-install time.
+  # logs:    { url: http://victorialogs.observability.svc:9428 }                # VictoriaLogs (LogsQL)
+  # logs:    { url: http://loki-gateway.observability.svc:80, provider: loki }  # Grafana Loki (LogQL)
   # Network-flow signal (network_drops). PLUGGABLE + CNI-agnostic — no CNI assumed,
   # none default-on. Choose ONE provider (see docs/data-sources.md):
   # network:

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -10,7 +10,7 @@ assumed).
 |---|---|---|---|---|
 | GitOps "what changed" | `what_changed`, `gitops_*` | `GitOpsProvider` | Flux, ArgoCD | `gitops.engine` |
 | Metrics | `query_metrics`, `query_metrics_range` | `MetricsProvider` | VictoriaMetrics, Prometheus (PromQL) | `metrics.url` |
-| Logs | `query_logs` | `LogsProvider` | VictoriaLogs (LogsQL) | `logs.url` |
+| Logs | `query_logs`, `logs_error_summary`, `discover_log_fields` | `LogsProvider` | VictoriaLogs (LogsQL) · **Grafana Loki (LogQL)** | `logs.url` (+ optional `logs.provider`) |
 | **Network flows** | `network_drops` | `NetworkProvider` | **Cilium Hubble · AWS VPC Flow Logs · GCP Firewall Logs** | `network.provider` |
 | Cloud control plane | `cloud_*` | `CloudProvider` | AWS (CloudTrail + EC2/ASG/EKS) | `cloud.provider` |
 | Kubernetes | `pod_status`, `kube_events`, `controller_logs`, `pod_logs` | `KubeReader`/`LogReader` | client-go | (in-cluster) |
@@ -64,6 +64,51 @@ CNI-agnostic eBPF (Microsoft **Retina** exposes a Hubble-compatible flow API, so
 
 > Compatibility: the legacy `network: { url: ... }` shape (Hubble-only) is still accepted and
 > mapped to `provider: hubble` with a deprecation warning. Prefer the explicit `provider` form.
+
+## Logs backends
+
+The logs signal is pluggable behind `LogsProvider`: **VictoriaLogs** (LogsQL) and **Grafana
+Loki** (LogQL). All three log tools — `query_logs`, `logs_error_summary`,
+`discover_log_fields` — work on both; the model is told the right query language automatically.
+
+The provider is **auto-detected** at startup (Loki answers `/loki/api/v1/status/buildinfo`;
+VictoriaLogs does not) and **fails safe to VictoriaLogs**, so existing configs are untouched.
+Pin it with `provider:` when the backend is unreachable at startup or sits behind a proxy that
+confuses the probe.
+
+### `victorialogs` — VictoriaLogs (default)
+```yaml
+logs:
+  url: http://victorialogs.observability.svc:9428
+```
+
+### `loki` — Grafana Loki
+```yaml
+logs:
+  url: http://loki-gateway.observability.svc:80
+  provider: loki          # optional — auto-detected when omitted
+  # token_env: LOKI_TOKEN                 # bearer token, by env-var indirection
+  # headers: { X-Scope-OrgID: my-tenant } # multi-tenant Loki
+```
+
+Field-convention defaults differ per provider; override any of them via `logs.fields`:
+
+| `logs.fields` key | VictoriaLogs default | Loki default |
+|---|---|---|
+| `container_field` | `kubernetes.container_name` | `container` |
+| `namespace_field` | `kubernetes.pod_namespace` | `namespace` |
+| `pod_field` | `kubernetes.pod_name` | `pod` |
+| `level_field` | `log.level` | `detected_level` |
+| `unpack_pipe` | `unpack_json` | *(none — `detected_level` is structured metadata)* |
+
+> Loki parity notes: `logs_error_summary`'s histogram uses a LogQL metric query
+> (`sum by (detected_level) (count_over_time(…))`); its *top messages* are aggregated
+> client-side over the (capped, newest-first) query sample, so counts are per-sample rather
+> than corpus-wide. `discover_log_fields` merges stream labels (`/loki/api/v1/labels`) with
+> detected body fields (`/loki/api/v1/detected_fields`, Loki ≥ 3.0; older Loki degrades to
+> labels only). On Loki 2.x there is no `detected_level` — set
+> `logs: { fields: { level_field: level, unpack_pipe: logfmt } }` (or `json`) to match your
+> collector.
 
 ## Custom webhooks — any vendor, no code
 

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -19,6 +19,8 @@ import (
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/logs"
+	"github.com/Smana/runlore/internal/logs/loki"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/mcp"
 	"github.com/Smana/runlore/internal/metrics/prometheus"
@@ -139,32 +141,51 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	}
 	if cfg.Logs.URL != "" {
 		warnIfBackendUnreachable(ctx, log, "logs", cfg.Logs.URL)
-		// Resolve the OPTIONAL collector field convention once; an unset config yields
-		// the shipped defaults, so this is a no-op unless logs.fields is set.
-		lf := cfg.Logs.Fields.Resolved()
-		lg := victorialogs.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers).WithLevelField(lf.LevelField)
+		// Backend provider (M1): a config pin wins; otherwise probe once at startup,
+		// mirroring the metrics flavor detection above. Detection fails safe to
+		// VictoriaLogs — the provider RunLore shipped with — so an existing deployment
+		// (or an unreachable backend at startup) sees no behaviour change.
+		provider := cfg.Logs.Provider
+		if provider == "" {
+			provider = logs.Detect(ctx, cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers)
+		}
+		// Resolve the OPTIONAL collector field convention once, per provider; an unset
+		// config yields the provider's shipped defaults, so this is a no-op unless
+		// logs.fields is set.
+		lf := cfg.Logs.Fields.ResolvedFor(provider)
+		var lg providers.LogsProvider
+		dialect := investigate.DialectLogsQL
+		switch provider {
+		case config.LogsProviderLoki:
+			lg = loki.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers).WithLevelField(lf.LevelField)
+			dialect = investigate.DialectLogQL
+		default: // victorialogs — the shipped default
+			lg = victorialogs.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers).WithLevelField(lf.LevelField)
+		}
+		log.Info("logs backend provider", "provider", provider, "pinned", cfg.Logs.Provider != "")
+		flds := investigate.LogFields{
+			ContainerField: lf.ContainerField,
+			NamespaceField: lf.NamespaceField,
+			PodField:       lf.PodField,
+			LevelField:     lf.LevelField,
+			UnpackPipe:     lf.UnpackPipe,
+			Dialect:        dialect,
+		}
 		tools = append(tools,
 			// query_logs reads the same raw pod logs pod_logs does, so it shares the
 			// pod_log_namespaces allowlist (L2 confinement) and honours the field
 			// convention (L1). The incident namespace is injected per-investigation by
 			// the loop (scopeTools), exactly like pod_logs.
 			investigate.QueryLogsTool{
-				Logs: lg,
-				Fields: investigate.LogFields{
-					ContainerField: lf.ContainerField,
-					NamespaceField: lf.NamespaceField,
-					PodField:       lf.PodField,
-					LevelField:     lf.LevelField,
-					UnpackPipe:     lf.UnpackPipe,
-				},
+				Logs:              lg,
+				Fields:            flds,
 				AllowedNamespaces: cfg.Investigation.PodLogNamespaces,
 			},
-			// logs_error_summary (error volume histogram + top messages) and
-			// discover_log_fields (real field names) both degrade gracefully when the
-			// backend lacks the analytics/field capability, so they are safe to always
-			// register whenever a logs backend is configured.
-			investigate.LogsErrorSummaryTool{Logs: lg},
-			investigate.DiscoverLogFieldsTool{Logs: lg},
+			// logs_error_summary and discover_log_fields degrade gracefully when the
+			// backend lacks the analytics/field capability (both VictoriaLogs and Loki
+			// implement them), so they are safe to always register.
+			investigate.LogsErrorSummaryTool{Logs: lg, Fields: flds},
+			investigate.DiscoverLogFieldsTool{Logs: lg, Fields: flds},
 		)
 	}
 	// Network-flow data source (the network_drops tool). Pluggable and CNI-agnostic:

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -460,3 +460,55 @@ func TestWarnIfBackendUnreachable(t *testing.T) {
 	warnIfBackendUnreachable(context.Background(), log, "metrics", "")
 	warnIfBackendUnreachable(context.Background(), nil, "metrics", "http://127.0.0.1:1")
 }
+
+// TestLogsBackendSelection: logs.provider pins the backend; empty auto-detects
+// (Loki answers /loki/api/v1/status/buildinfo, VictoriaLogs 404s), failing safe
+// to victorialogs. The observable contract is the dialect carried on the
+// registered query_logs tool — LogQL means the Loki client + LogQL guidance.
+func TestLogsBackendSelection(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent-kubeconfig"))
+	log := discardLog()
+	base := config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}
+
+	lokiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			_, _ = io.WriteString(w, `{"version":"3.1.0"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer lokiSrv.Close()
+	vlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer vlSrv.Close()
+
+	tests := []struct {
+		name, url, pin, wantDialect string
+	}{
+		{"auto-detect loki", lokiSrv.URL, "", investigate.DialectLogQL},
+		{"auto-detect fail-safe victorialogs", vlSrv.URL, "", investigate.DialectLogsQL},
+		{"pinned loki skips probe", vlSrv.URL, "loki", investigate.DialectLogQL},
+		{"pinned victorialogs skips probe", lokiSrv.URL, "victorialogs", investigate.DialectLogsQL},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Model: base}
+			cfg.Logs.URL = tc.url
+			cfg.Logs.Provider = tc.pin
+			_, tools, _, _ := BuildModelAndTools(context.Background(), cfg, nil, nil, log)
+			found := false
+			for _, tool := range tools {
+				if qt, ok := tool.(investigate.QueryLogsTool); ok {
+					found = true
+					if qt.Fields.Dialect != tc.wantDialect {
+						t.Fatalf("dialect = %q, want %q", qt.Fields.Dialect, tc.wantDialect)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("query_logs not registered")
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,18 @@ const (
 	MetricsFlavorVictoriaMetric = "victoriametrics" // also accepts MetricsQL (PromQL superset)
 )
 
+// Logs backend providers for config.logs.provider. Unlike the metrics backends
+// (which share the Prometheus HTTP API and differ only in dialect), VictoriaLogs
+// and Loki have entirely different query APIs, so this selects the CLIENT, not a
+// flavor of one. Empty ⇒ auto-detect at startup (Loki answers
+// /loki/api/v1/status/buildinfo; VictoriaLogs does not), failing safe to
+// victorialogs — the provider RunLore shipped with — so an unreachable backend
+// at startup reproduces today's behaviour exactly.
+const (
+	LogsProviderVictoriaLogs = "victorialogs" // LogsQL over /select/logsql/* (shipped default)
+	LogsProviderLoki         = "loki"         // LogQL over /loki/api/v1/*
+)
+
 // MetricsConfig is the metrics backend endpoint plus an OPTIONAL flavor override.
 // The endpoint keys (url/token_env/headers) are inlined so the existing
 // `metrics: {url: …}` shape is unchanged; Flavor is a new opt-in sub-key. Empty
@@ -116,6 +128,11 @@ type MetricsConfig struct {
 // WITHOUT a code change. Empty Fields ⇒ the shipped VictoriaLogs/vector convention.
 type LogsConfig struct {
 	Endpoint `yaml:",inline"`
+
+	// Provider optionally pins the logs backend implementation instead of
+	// auto-detecting it: "loki" or "victorialogs" (see LogsProvider*). Empty ⇒
+	// probe once at startup, failing safe to victorialogs.
+	Provider string `yaml:"provider"`
 
 	Fields LogFields `yaml:"fields"`
 }
@@ -177,6 +194,41 @@ func (f LogFields) Resolved() LogFields {
 	if f.UnpackPipe == "" {
 		f.UnpackPipe = defaultLogUnpackPipe
 	}
+	return f
+}
+
+// Default log-field convention for Loki: the promtail/Grafana-Alloy stream-label
+// layout plus Loki 3.x's auto-detected severity (detected_level is structured
+// metadata, filterable WITHOUT a parser stage — hence no default unpack pipe).
+// An operator on Loki 2.x (no detected_level) overrides logs.fields, e.g.
+// {level_field: level, unpack_pipe: logfmt}.
+const (
+	defaultLokiContainerField = "container"
+	defaultLokiNamespaceField = "namespace"
+	defaultLokiPodField       = "pod"
+	defaultLokiLevelField     = "detected_level"
+)
+
+// ResolvedFor resolves the field convention for a specific logs provider:
+// Loki gets Loki-appropriate defaults; anything else (victorialogs, "") keeps
+// Resolved()'s shipped VictoriaLogs behaviour. Explicitly-set fields always win.
+func (f LogFields) ResolvedFor(provider string) LogFields {
+	if provider != LogsProviderLoki {
+		return f.Resolved()
+	}
+	if f.ContainerField == "" {
+		f.ContainerField = defaultLokiContainerField
+	}
+	if f.NamespaceField == "" {
+		f.NamespaceField = defaultLokiNamespaceField
+	}
+	if f.PodField == "" {
+		f.PodField = defaultLokiPodField
+	}
+	if f.LevelField == "" {
+		f.LevelField = defaultLokiLevelField
+	}
+	// UnpackPipe stays as-set (empty = no parser stage): detected_level needs none.
 	return f
 }
 
@@ -1226,6 +1278,14 @@ func (c *Config) Validate() error {
 		if r.MinObservations < 1 {
 			return fmt.Errorf("curate.retirement.min_observations must be >= 1 (the sustained-decay bar), got %d", r.MinObservations)
 		}
+	}
+	// logs.provider is a small enum; reject typos at startup rather than silently
+	// falling back to the wrong client against a live backend.
+	switch c.Logs.Provider {
+	case "", LogsProviderVictoriaLogs, LogsProviderLoki:
+	default:
+		return fmt.Errorf("logs.provider must be %q, %q, or empty (auto-detect); got %q",
+			LogsProviderVictoriaLogs, LogsProviderLoki, c.Logs.Provider)
 	}
 	switch c.Actions.Mode {
 	case "", ActionOff, ActionSuggest:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -722,3 +722,23 @@ func TestVectorCacheConfigDefaults(t *testing.T) {
 		t.Error("explicit enabled:false must disable")
 	}
 }
+
+// TestLogsProviderValidate: logs.provider is an enum — "" (auto-detect),
+// "victorialogs", "loki". Anything else must abort startup loudly (the Load
+// philosophy: a typo'd key never fails silently), because a silent fallback to
+// victorialogs against a Loki endpoint would break every logs tool at runtime.
+func TestLogsProviderValidate(t *testing.T) {
+	for _, ok := range []string{"", "victorialogs", "loki"} {
+		c := &Config{}
+		c.Logs.Provider = ok
+		if err := c.Validate(); err != nil {
+			t.Fatalf("provider %q must validate, got %v", ok, err)
+		}
+	}
+	c := &Config{}
+	c.Logs.Provider = "grafana"
+	err := c.Validate()
+	if err == nil || !strings.Contains(err.Error(), "logs.provider") {
+		t.Fatalf("unknown provider must fail with a logs.provider error, got %v", err)
+	}
+}

--- a/internal/config/logfields_test.go
+++ b/internal/config/logfields_test.go
@@ -58,3 +58,23 @@ fields:
 		t.Fatalf("fields.namespace_field not parsed: %+v", lc.Fields)
 	}
 }
+
+// TestLogFieldsResolvedForLoki: ResolvedFor(loki) fills the promtail/alloy
+// stream-label convention and Loki 3.x's parser-less detected_level severity,
+// and deliberately leaves UnpackPipe empty (no parser stage needed). Any
+// explicitly-set field wins. ResolvedFor(victorialogs) must equal Resolved().
+func TestLogFieldsResolvedForLoki(t *testing.T) {
+	got := LogFields{}.ResolvedFor(LogsProviderLoki)
+	want := LogFields{ContainerField: "container", NamespaceField: "namespace",
+		PodField: "pod", LevelField: "detected_level", UnpackPipe: ""}
+	if got != want {
+		t.Fatalf("loki defaults = %+v, want %+v", got, want)
+	}
+	over := LogFields{LevelField: "level", UnpackPipe: "logfmt"}.ResolvedFor(LogsProviderLoki)
+	if over.LevelField != "level" || over.UnpackPipe != "logfmt" || over.PodField != "pod" {
+		t.Fatalf("overrides must win, defaults fill the rest: %+v", over)
+	}
+	if (LogFields{}.ResolvedFor(LogsProviderVictoriaLogs)) != (LogFields{}.Resolved()) {
+		t.Fatalf("victorialogs resolution must be unchanged")
+	}
+}

--- a/internal/investigate/discover_tools.go
+++ b/internal/investigate/discover_tools.go
@@ -109,8 +109,9 @@ func (t DiscoverLogFieldsTool) Name() string { return "discover_log_fields" }
 func (t DiscoverLogFieldsTool) Description() string {
 	return "List the log FIELD NAMES that actually exist for a selector — use when query_logs returns 'no log lines " +
 		"matched' or you're unsure of the collector's schema (e.g. is it kubernetes.container_name or container?). " +
-		"Give a namespace/container (or a raw LogsQL query) and it returns the real field names with hit counts, so you " +
-		"can fix the query instead of guessing. since_minutes bounds the window (default 60)."
+		"Give a namespace/container (or a raw " + t.Fields.queryLang() + " query) and it returns the real field names " +
+		"(with hit counts where the backend reports them), so you can fix the query instead of guessing. " +
+		"since_minutes bounds the window (default 60)."
 }
 
 // Schema returns the JSON schema for the arguments.

--- a/internal/investigate/discover_tools.go
+++ b/internal/investigate/discover_tools.go
@@ -96,6 +96,10 @@ func (t DiscoverMetricsTool) Call(ctx context.Context, args string) (string, err
 // registered in internal/app/investigate.go (alongside query_logs).
 type DiscoverLogFieldsTool struct {
 	Logs providers.LogsProvider
+
+	// Fields is the OPTIONAL field convention + dialect (config.logs.*); the zero
+	// value keeps the shipped VictoriaLogs behaviour. The app layer sets it.
+	Fields LogFields
 }
 
 // Name returns the tool name.
@@ -114,7 +118,7 @@ func (t DiscoverLogFieldsTool) Schema() string {
 	return `{"type":"object","properties":{` +
 		`"container":{"type":"string","description":"kubernetes container name to scope to"},` +
 		`"namespace":{"type":"string","description":"kubernetes namespace to scope to"},` +
-		`"query":{"type":"string","description":"raw LogsQL; only if the structured fields are insufficient"},` +
+		`"query":{"type":"string","description":"raw ` + t.Fields.queryLang() + `; only if the structured fields are insufficient"},` +
 		`"since_minutes":{"type":"integer"}},"required":[]}`
 }
 
@@ -130,7 +134,7 @@ func (t DiscoverLogFieldsTool) Call(ctx context.Context, args string) (string, e
 		return "", fmt.Errorf("parse args: %w", err)
 	}
 	// Field discovery has no severity dimension, so build with an empty level.
-	query, err := buildLogsQL(in.Query, in.Container, in.Namespace, "")
+	query, err := buildLogsQLWith(in.Query, in.Container, in.Namespace, "", t.Fields)
 	if err != nil {
 		return "", err
 	}
@@ -156,7 +160,11 @@ func (t DiscoverLogFieldsTool) Call(ctx context.Context, args string) (string, e
 	var b strings.Builder
 	fmt.Fprintf(&b, "%d field(s) for %s:\n", len(names), query)
 	renderRows(&b, len(names), "more", func(i int) {
-		fmt.Fprintf(&b, "%s (×%d)\n", names[i].Name, names[i].Hits)
+		if names[i].Hits > 0 {
+			fmt.Fprintf(&b, "%s (×%d)\n", names[i].Name, names[i].Hits)
+			return
+		}
+		fmt.Fprintf(&b, "%s\n", names[i].Name) // Loki stream labels carry no hit count
 	})
 	return b.String(), nil
 }

--- a/internal/investigate/discover_tools_test.go
+++ b/internal/investigate/discover_tools_test.go
@@ -165,3 +165,22 @@ func TestDiscoverLogFieldsToolNoCapability(t *testing.T) {
 		t.Fatalf("want graceful note, got:\n%s", out)
 	}
 }
+
+// TestDiscoverLogFieldsOmitsZeroCounts: Loki stream labels carry Hits=0 (no
+// per-label hit count exists); the render must omit the count rather than
+// print a misleading "(×0)".
+func TestDiscoverLogFieldsOmitsZeroCounts(t *testing.T) {
+	tool := DiscoverLogFieldsTool{Logs: &fakeLogFields{fields: []providers.FieldCount{
+		{Name: "namespace"}, {Name: "level", Hits: 4},
+	}}}
+	out, err := tool.Call(context.Background(), `{"namespace":"apps"}`)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if strings.Contains(out, "(×0)") {
+		t.Fatalf("zero hits must render without a count:\n%s", out)
+	}
+	if !strings.Contains(out, "level (×4)") {
+		t.Fatalf("non-zero hits must keep the count:\n%s", out)
+	}
+}

--- a/internal/investigate/logs_summary_tool.go
+++ b/internal/investigate/logs_summary_tool.go
@@ -27,6 +27,10 @@ import (
 // registered in internal/app/investigate.go (alongside query_logs).
 type LogsErrorSummaryTool struct {
 	Logs providers.LogsProvider
+
+	// Fields is the OPTIONAL field convention + dialect (config.logs.*); the zero
+	// value keeps the shipped VictoriaLogs behaviour. The app layer sets it.
+	Fields LogFields
 }
 
 // Name returns the tool name.
@@ -47,7 +51,7 @@ func (t LogsErrorSummaryTool) Schema() string {
 		`"container":{"type":"string","description":"kubernetes container name to scope to"},` +
 		`"namespace":{"type":"string","description":"kubernetes namespace to scope to"},` +
 		`"level":{"type":"string","enum":["error","warn","info"],"description":"severity filter (default error)"},` +
-		`"query":{"type":"string","description":"raw LogsQL; only if the structured fields are insufficient"},` +
+		`"query":{"type":"string","description":"raw ` + t.Fields.queryLang() + `; only if the structured fields are insufficient"},` +
 		`"since_minutes":{"type":"integer"}},"required":[]}`
 }
 
@@ -69,7 +73,7 @@ func (t LogsErrorSummaryTool) Call(ctx context.Context, args string) (string, er
 	if in.Query == "" && level == "" {
 		level = "error"
 	}
-	query, err := buildLogsQL(in.Query, in.Container, in.Namespace, level)
+	query, err := buildLogsQLWith(in.Query, in.Container, in.Namespace, level, t.Fields)
 	if err != nil {
 		return "", err
 	}

--- a/internal/investigate/logs_summary_tool.go
+++ b/internal/investigate/logs_summary_tool.go
@@ -42,7 +42,8 @@ func (t LogsErrorSummaryTool) Description() string {
 		"'3/5m baseline → 412/5m SPIKE at 10:02') and the DOMINANT error messages with counts and first→last span, " +
 		"instead of a raw line dump. It answers 'is this spiking, and what is flooding the logs?' in one call; drill " +
 		"into query_logs only AFTER this to read specific lines. PREFER the structured params (container/namespace/level) " +
-		"and let the tool build the query; level defaults to error. since_minutes bounds the window (default 60)."
+		"and let the tool build the query (a raw `query` override, if used, is " + t.Fields.queryLang() + "); " +
+		"level defaults to error. since_minutes bounds the window (default 60)."
 }
 
 // Schema returns the JSON schema for the arguments.

--- a/internal/investigate/loki_e2e_test.go
+++ b/internal/investigate/loki_e2e_test.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/logs/loki"
+)
+
+// TestLokiToolsEndToEnd wires the three log tools to the real Loki client
+// against a fake Loki serving realistic fixtures — the parity proof that
+// query_logs, logs_error_summary, and discover_log_fields all work end-to-end
+// on a Loki backend (client normalization + dialect query building + renderer).
+func TestLokiToolsEndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("query")
+		switch {
+		case r.URL.Path == "/loki/api/v1/query_range" && strings.HasPrefix(q, "sum by"):
+			_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"matrix","result":[
+			  {"metric":{"detected_level":"error"},"values":[[1704103200,"3"],[1704103500,"412"]]}]}}`)
+		case r.URL.Path == "/loki/api/v1/query_range":
+			_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
+			  {"stream":{"namespace":"apps","pod":"harbor-db-0","container":"db"},
+			   "values":[["1750413600000000000","db connection refused"]]}]}}`)
+		case r.URL.Path == "/loki/api/v1/labels":
+			_, _ = io.WriteString(w, `{"status":"success","data":["namespace","pod","container"]}`)
+		case r.URL.Path == "/loki/api/v1/detected_fields":
+			_, _ = io.WriteString(w, `{"fields":[{"label":"level","type":"string","cardinality":4,"parsers":["logfmt"]}]}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	lg := loki.New(srv.URL)
+	flds := LogFields{Dialect: DialectLogQL}
+
+	out, err := QueryLogsTool{Logs: lg, Fields: flds}.Call(context.Background(),
+		`{"namespace":"apps","level":"error"}`)
+	if err != nil || !strings.Contains(out, "db connection refused") {
+		t.Fatalf("query_logs: %v\n%s", err, out)
+	}
+	// The renderer must find pod/container under the Loki stream-label names.
+	if !strings.Contains(out, "harbor-db-0/db") {
+		t.Fatalf("stream identity not derived from loki labels:\n%s", out)
+	}
+
+	out, err = LogsErrorSummaryTool{Logs: lg, Fields: flds}.Call(context.Background(),
+		`{"namespace":"apps"}`)
+	if err != nil || !strings.Contains(out, "412") || !strings.Contains(out, "top messages") {
+		t.Fatalf("logs_error_summary: %v\n%s", err, out)
+	}
+
+	out, err = DiscoverLogFieldsTool{Logs: lg, Fields: flds}.Call(context.Background(),
+		`{"namespace":"apps"}`)
+	if err != nil || !strings.Contains(out, "namespace") || !strings.Contains(out, "level (×4)") {
+		t.Fatalf("discover_log_fields: %v\n%s", err, out)
+	}
+}

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -398,6 +398,9 @@ func buildLogsQL(raw, container, namespace, level string) (string, error) {
 // recurring mistake) — the error guides a retry.
 func buildLogsQLWith(raw, container, namespace, level string, conv LogFields) (string, error) {
 	conv = conv.resolved()
+	if conv.Dialect == DialectLogQL {
+		return buildLogQL(raw, container, namespace, level, conv)
+	}
 	if raw != "" {
 		if strings.Contains(raw, "level=") {
 			return "", fmt.Errorf("invalid LogsQL: `level=` is Prometheus/Loki syntax. Filter severity with `| %s | %s:error` (after a stream selector), or use the container/namespace/level params", conv.UnpackPipe, conv.LevelField)
@@ -421,11 +424,57 @@ func buildLogsQLWith(raw, container, namespace, level string, conv LogFields) (s
 	return q, nil
 }
 
+// buildLogQL composes a valid LogQL (Grafana Loki) query from the resolved
+// field convention: `{container="…",namespace="…"}` plus an optional parser
+// pipe and a `| <level_field>="…"` label filter — detected_level needs no
+// parser on Loki 3.x, so the default pipe is empty. A raw query passes through
+// but must start with a stream selector, and LogsQL-isms (unpack_json, _msg —
+// the model's likely carry-over mistakes) are rejected with a correcting error,
+// mirroring the LogsQL branch's `level=` guard in spirit.
+func buildLogQL(raw, container, namespace, level string, conv LogFields) (string, error) {
+	if raw != "" {
+		if strings.Contains(raw, "unpack_json") || strings.Contains(raw, "_msg") {
+			return "", fmt.Errorf("invalid LogQL: unpack_json/_msg are VictoriaLogs LogsQL syntax. Parse with `| json` or `| logfmt` and filter severity with `| %s=\"error\"`, or use the container/namespace/level params", conv.LevelField)
+		}
+		if !strings.HasPrefix(strings.TrimSpace(raw), "{") {
+			return "", fmt.Errorf("invalid LogQL: a query starts with a stream selector, e.g. `{%s=\"apps\"}`", conv.NamespaceField)
+		}
+		return raw, nil
+	}
+	var sel []string
+	if container != "" {
+		sel = append(sel, fmt.Sprintf("%s=%q", conv.ContainerField, container))
+	}
+	if namespace != "" {
+		sel = append(sel, fmt.Sprintf("%s=%q", conv.NamespaceField, namespace))
+	}
+	if len(sel) == 0 {
+		return "", fmt.Errorf("provide a raw `query`, or `container`/`namespace` to build one")
+	}
+	q := "{" + strings.Join(sel, ",") + "}"
+	if level != "" {
+		if conv.UnpackPipe != "" {
+			q += " | " + conv.UnpackPipe
+		}
+		q += fmt.Sprintf(" | %s=%q", conv.LevelField, level)
+	}
+	return q, nil
+}
+
 // Name returns the tool name.
 func (t QueryLogsTool) Name() string { return "query_logs" }
 
 // Description returns the tool description.
 func (t QueryLogsTool) Description() string {
+	if t.Fields.Dialect == DialectLogQL {
+		return "Query logs with LogQL (Grafana Loki) over a recent window. " +
+			"PREFER the structured params (container/namespace/level) and let the tool build the query. " +
+			"If you write a raw `query`: it MUST start with a stream selector using Loki stream labels, " +
+			"e.g. `{namespace=\"apps\", container=\"x\"}`; filter severity with `| detected_level=\"error\"` " +
+			"(no parser needed) or parse first with `| json` / `| logfmt`. " +
+			"Do NOT use VictoriaLogs LogsQL syntax (unpack_json, _msg, field:value filters). " +
+			"Optional since_minutes bounds the window (default 60)."
+	}
 	return "Query logs with LogsQL (VictoriaLogs) over a recent window. " +
 		"PREFER the structured params (container/namespace/level) and let the tool build the query. " +
 		"If you write a raw `query`: stream labels use DOT notation (kubernetes.container_name, " +
@@ -441,7 +490,7 @@ func (t QueryLogsTool) Schema() string {
 		`"container":{"type":"string","description":"kubernetes container name to scope to"},` +
 		`"namespace":{"type":"string","description":"kubernetes namespace to scope to"},` +
 		`"level":{"type":"string","enum":["error","warn","info"],"description":"severity filter (unpacks JSON)"},` +
-		`"query":{"type":"string","description":"raw LogsQL; only if the structured fields are insufficient"},` +
+		`"query":{"type":"string","description":"raw ` + t.Fields.queryLang() + `; only if the structured fields are insufficient"},` +
 		`"since_minutes":{"type":"integer"}},"required":[]}`
 }
 

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -407,6 +407,20 @@ func buildLogsQLWith(raw, container, namespace, level string, conv LogFields) (s
 		}
 		return raw, nil
 	}
+	q, err := streamSelector(container, namespace, conv)
+	if err != nil {
+		return "", err
+	}
+	if level != "" {
+		q += " | " + conv.UnpackPipe + " | " + conv.LevelField + ":" + level
+	}
+	return q, nil
+}
+
+// streamSelector assembles the `{container="…",namespace="…"}` stream selector
+// shared by both dialect builders (LogsQL and LogQL use the identical label=value
+// form), or an error when neither field is given.
+func streamSelector(container, namespace string, conv LogFields) (string, error) {
 	var sel []string
 	if container != "" {
 		sel = append(sel, fmt.Sprintf("%s=%q", conv.ContainerField, container))
@@ -417,11 +431,7 @@ func buildLogsQLWith(raw, container, namespace, level string, conv LogFields) (s
 	if len(sel) == 0 {
 		return "", fmt.Errorf("provide a raw `query`, or `container`/`namespace` to build one")
 	}
-	q := "{" + strings.Join(sel, ",") + "}"
-	if level != "" {
-		q += " | " + conv.UnpackPipe + " | " + conv.LevelField + ":" + level
-	}
-	return q, nil
+	return "{" + strings.Join(sel, ",") + "}", nil
 }
 
 // buildLogQL composes a valid LogQL (Grafana Loki) query from the resolved
@@ -441,17 +451,10 @@ func buildLogQL(raw, container, namespace, level string, conv LogFields) (string
 		}
 		return raw, nil
 	}
-	var sel []string
-	if container != "" {
-		sel = append(sel, fmt.Sprintf("%s=%q", conv.ContainerField, container))
+	q, err := streamSelector(container, namespace, conv)
+	if err != nil {
+		return "", err
 	}
-	if namespace != "" {
-		sel = append(sel, fmt.Sprintf("%s=%q", conv.NamespaceField, namespace))
-	}
-	if len(sel) == 0 {
-		return "", fmt.Errorf("provide a raw `query`, or `container`/`namespace` to build one")
-	}
-	q := "{" + strings.Join(sel, ",") + "}"
 	if level != "" {
 		if conv.UnpackPipe != "" {
 			q += " | " + conv.UnpackPipe

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -443,8 +443,11 @@ func streamSelector(container, namespace string, conv LogFields) (string, error)
 // mirroring the LogsQL branch's `level=` guard in spirit.
 func buildLogQL(raw, container, namespace, level string, conv LogFields) (string, error) {
 	if raw != "" {
-		if strings.Contains(raw, "unpack_json") || strings.Contains(raw, "_msg") {
-			return "", fmt.Errorf("invalid LogQL: unpack_json/_msg are VictoriaLogs LogsQL syntax. Parse with `| json` or `| logfmt` and filter severity with `| %s=\"error\"`, or use the container/namespace/level params", conv.LevelField)
+		// Guard against carried-over VictoriaLogs syntax. `_msg:` (its message-field
+		// filter) is matched WITH the colon so a Loki label value or |= search string
+		// that merely contains "_msg" (e.g. auth_msg_worker) is not misrejected.
+		if strings.Contains(raw, "unpack_json") || strings.Contains(raw, "_msg:") {
+			return "", fmt.Errorf("invalid LogQL: unpack_json / _msg: are VictoriaLogs LogsQL syntax. Parse with `| json` or `| logfmt` and filter severity with `| %s=\"error\"`, or use the container/namespace/level params", conv.LevelField)
 		}
 		if !strings.HasPrefix(strings.TrimSpace(raw), "{") {
 			return "", fmt.Errorf("invalid LogQL: a query starts with a stream selector, e.g. `{%s=\"apps\"}`", conv.NamespaceField)
@@ -469,21 +472,9 @@ func (t QueryLogsTool) Name() string { return "query_logs" }
 
 // Description returns the tool description.
 func (t QueryLogsTool) Description() string {
-	if t.Fields.Dialect == DialectLogQL {
-		return "Query logs with LogQL (Grafana Loki) over a recent window. " +
-			"PREFER the structured params (container/namespace/level) and let the tool build the query. " +
-			"If you write a raw `query`: it MUST start with a stream selector using Loki stream labels, " +
-			"e.g. `{namespace=\"apps\", container=\"x\"}`; filter severity with `| detected_level=\"error\"` " +
-			"(no parser needed) or parse first with `| json` / `| logfmt`. " +
-			"Do NOT use VictoriaLogs LogsQL syntax (unpack_json, _msg, field:value filters). " +
-			"Optional since_minutes bounds the window (default 60)."
-	}
-	return "Query logs with LogsQL (VictoriaLogs) over a recent window. " +
+	return "Query logs with " + t.Fields.dialectLabel() + " over a recent window. " +
 		"PREFER the structured params (container/namespace/level) and let the tool build the query. " +
-		"If you write a raw `query`: stream labels use DOT notation (kubernetes.container_name, " +
-		"kubernetes.pod_namespace), NOT underscores; to filter by severity you MUST unpack JSON first, " +
-		"e.g. `{kubernetes.container_name=\"x\"} | unpack_json | log.level:error`. " +
-		"Do NOT use `level=error` — that is Prometheus/Loki syntax and is invalid LogsQL. " +
+		t.Fields.rawQueryGuidance() + " " +
 		"Optional since_minutes bounds the window (default 60)."
 }
 
@@ -492,7 +483,7 @@ func (t QueryLogsTool) Schema() string {
 	return `{"type":"object","properties":{` +
 		`"container":{"type":"string","description":"kubernetes container name to scope to"},` +
 		`"namespace":{"type":"string","description":"kubernetes namespace to scope to"},` +
-		`"level":{"type":"string","enum":["error","warn","info"],"description":"severity filter (unpacks JSON)"},` +
+		`"level":{"type":"string","enum":["error","warn","info"],"description":"severity filter (tool builds the dialect-correct filter)"},` +
 		`"query":{"type":"string","description":"raw ` + t.Fields.queryLang() + `; only if the structured fields are insufficient"},` +
 		`"since_minutes":{"type":"integer"}},"required":[]}`
 }

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -441,3 +441,72 @@ func TestQueryMetricsMetricsQLGuidance(t *testing.T) {
 		t.Fatalf("Prometheus range description must not mention MetricsQL")
 	}
 }
+
+// TestBuildLogQL: with Dialect=logql the same structured params compile to
+// valid LogQL, raw queries must start with a stream selector, and LogsQL-isms
+// are rejected with a correcting error so the model retries in-dialect.
+func TestBuildLogQL(t *testing.T) {
+	logql := LogFields{Dialect: DialectLogQL}
+	tests := []struct {
+		name, raw, container, namespace, level string
+		conv                                   LogFields
+		want                                   string
+		wantErr                                string
+	}{
+		{name: "structured selector + level", container: "harbor-core", namespace: "apps", level: "error", conv: logql,
+			want: `{container="harbor-core",namespace="apps"} | detected_level="error"`},
+		{name: "namespace only, no level", namespace: "apps", conv: logql,
+			want: `{namespace="apps"}`},
+		{name: "custom fields add parser pipe", container: "core", level: "error",
+			conv: LogFields{Dialect: DialectLogQL, LevelField: "level", UnpackPipe: "logfmt"},
+			want: `{container="core"} | logfmt | level="error"`},
+		{name: "raw passthrough", raw: `{namespace="apps"} |= "refused"`, conv: logql,
+			want: `{namespace="apps"} |= "refused"`},
+		{name: "raw LogsQL-ism rejected", raw: `{namespace="apps"} | unpack_json | log.level:error`, conv: logql,
+			wantErr: "LogsQL"},
+		{name: "raw without selector rejected", raw: `error`, conv: logql,
+			wantErr: "stream selector"},
+		{name: "nothing given", conv: logql, wantErr: "provide a raw"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildLogsQLWith(tc.raw, tc.container, tc.namespace, tc.level, tc.conv)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildLogsQLWith: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogToolDescriptionsDialect: on a Loki deployment the model must be told
+// LogQL — never LogsQL — in every tool description and schema, and vice versa.
+func TestLogToolDescriptionsDialect(t *testing.T) {
+	logql := LogFields{Dialect: DialectLogQL}
+	q := QueryLogsTool{Fields: logql}
+	if !strings.Contains(q.Description(), "LogQL (Grafana Loki)") || strings.Contains(q.Description(), "invalid LogsQL") {
+		t.Fatalf("LogQL description wrong: %s", q.Description())
+	}
+	if !strings.Contains(q.Schema(), "raw LogQL") {
+		t.Fatalf("LogQL schema wrong: %s", q.Schema())
+	}
+	if !strings.Contains(QueryLogsTool{}.Description(), "LogsQL (VictoriaLogs)") {
+		t.Fatalf("default description must stay LogsQL")
+	}
+	for _, tool := range []interface {
+		Description() string
+		Schema() string
+	}{LogsErrorSummaryTool{Fields: logql}, DiscoverLogFieldsTool{Fields: logql}} {
+		if strings.Contains(tool.Schema(), "LogsQL") {
+			t.Fatalf("loki-dialect schema must not mention LogsQL: %s", tool.Schema())
+		}
+	}
+}

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -464,6 +464,14 @@ func TestBuildLogQL(t *testing.T) {
 			want: `{namespace="apps"} |= "refused"`},
 		{name: "raw LogsQL-ism rejected", raw: `{namespace="apps"} | unpack_json | log.level:error`, conv: logql,
 			wantErr: "LogsQL"},
+		{name: "raw LogsQL _msg: filter rejected", raw: `{namespace="apps"} | _msg:error`, conv: logql,
+			wantErr: "LogsQL"},
+		// A valid LogQL query whose label value / line filter merely CONTAINS the
+		// substring "_msg" must NOT be misrejected (the guard anchors on "_msg:").
+		{name: "raw with _msg in label value passes", raw: `{container="auth_msg_worker"}`, conv: logql,
+			want: `{container="auth_msg_worker"}`},
+		{name: "raw with _msg in line filter passes", raw: `{namespace="apps"} |= "consume_msg failed"`, conv: logql,
+			want: `{namespace="apps"} |= "consume_msg failed"`},
 		{name: "raw without selector rejected", raw: `error`, conv: logql,
 			wantErr: "stream selector"},
 		{name: "nothing given", conv: logql, wantErr: "provide a raw"},
@@ -501,12 +509,22 @@ func TestLogToolDescriptionsDialect(t *testing.T) {
 	if !strings.Contains(QueryLogsTool{}.Description(), "LogsQL (VictoriaLogs)") {
 		t.Fatalf("default description must stay LogsQL")
 	}
+	// The Loki description must interpolate the CONFIGURED field names (not hardcoded
+	// detected_level/namespace), so a field override reaches the model verbatim.
+	custom := QueryLogsTool{Fields: LogFields{Dialect: DialectLogQL, LevelField: "lvl", NamespaceField: "ns"}}
+	if !strings.Contains(custom.Description(), `lvl="error"`) || !strings.Contains(custom.Description(), `ns="apps"`) {
+		t.Fatalf("Loki description must interpolate configured field names: %s", custom.Description())
+	}
+	// Every log tool's DESCRIPTION and SCHEMA must name LogQL — never LogsQL — on Loki.
 	for _, tool := range []interface {
 		Description() string
 		Schema() string
 	}{LogsErrorSummaryTool{Fields: logql}, DiscoverLogFieldsTool{Fields: logql}} {
 		if strings.Contains(tool.Schema(), "LogsQL") {
 			t.Fatalf("loki-dialect schema must not mention LogsQL: %s", tool.Schema())
+		}
+		if strings.Contains(tool.Description(), "LogsQL") {
+			t.Fatalf("loki-dialect description must not mention LogsQL: %s", tool.Description())
 		}
 	}
 }

--- a/internal/investigate/renderlog.go
+++ b/internal/investigate/renderlog.go
@@ -85,12 +85,41 @@ func (f LogFields) resolved() LogFields {
 	return f
 }
 
-// queryLang names the dialect for tool descriptions/schemas.
+// queryLang names the dialect (bare) for tool schemas ("raw LogQL"/"raw LogsQL").
 func (f LogFields) queryLang() string {
 	if f.Dialect == DialectLogQL {
 		return "LogQL"
 	}
 	return "LogsQL"
+}
+
+// dialectLabel names the dialect with its backend for tool descriptions — the
+// description-side counterpart of queryLang(), so both forms derive the dialect
+// from one place and no tool description can name the wrong one.
+func (f LogFields) dialectLabel() string {
+	if f.Dialect == DialectLogQL {
+		return "LogQL (Grafana Loki)"
+	}
+	return "LogsQL (VictoriaLogs)"
+}
+
+// rawQueryGuidance is the dialect- and field-aware instruction for a raw `query`
+// override, interpolated with the RESOLVED field names so an operator's
+// config.logs.fields overrides reach the model verbatim (rather than a hardcoded
+// `detected_level`/`namespace` a custom collector may not have). Shared by the
+// log tools' descriptions so the guidance and the query builder can't drift.
+func (f LogFields) rawQueryGuidance() string {
+	c := f.resolved()
+	if f.Dialect == DialectLogQL {
+		return fmt.Sprintf("If you write a raw `query`: it MUST start with a stream selector using Loki stream labels, "+
+			"e.g. `{%s=\"apps\", %s=\"x\"}`; filter severity with `| %s=\"error\"` (no parser needed) or parse first with `| json` / `| logfmt`. "+
+			"Do NOT use VictoriaLogs LogsQL syntax (unpack_json, _msg, field:value filters).",
+			c.NamespaceField, c.ContainerField, c.LevelField)
+	}
+	return fmt.Sprintf("If you write a raw `query`: stream labels use DOT notation (%s, %s), NOT underscores; "+
+		"to filter by severity you MUST unpack JSON first, e.g. `{%s=\"x\"} | %s | %s:error`. "+
+		"Do NOT use `level=error` — that is Prometheus/Loki syntax and is invalid LogsQL.",
+		c.ContainerField, c.NamespaceField, c.ContainerField, c.UnpackPipe, c.LevelField)
 }
 
 // logGroup is one distinct log message with its repeat count, the span over which

--- a/internal/investigate/renderlog.go
+++ b/internal/investigate/renderlog.go
@@ -22,7 +22,16 @@ type LogFields struct {
 	PodField       string // stream label for the pod name; "" ⇒ default
 	LevelField     string // severity field (after the unpack pipe); "" ⇒ default
 	UnpackPipe     string // LogsQL pipe promoting JSON body to fields; "" ⇒ default
+	Dialect        string // query dialect; "" ⇒ LogsQL (see Dialect*)
 }
+
+// Dialect values for LogFields.Dialect — which query language the configured
+// logs backend speaks. The zero value is LogsQL so every existing caller and
+// fake is untouched; the app layer sets DialectLogQL when the backend is Loki.
+const (
+	DialectLogsQL = ""      // VictoriaLogs LogsQL (shipped default)
+	DialectLogQL  = "logql" // Grafana Loki LogQL
+)
 
 // Shipped log-field defaults. These MUST stay byte-identical to the strings the code
 // hardcoded before logs.fields was configurable — they are the fallback that keeps
@@ -39,6 +48,25 @@ const (
 // result directly. An empty UnpackPipe restores the default pipe (disabling it is
 // out of scope for v1).
 func (f LogFields) resolved() LogFields {
+	if f.Dialect == DialectLogQL {
+		// Loki convention: promtail/alloy stream labels + Loki 3.x detected_level
+		// (structured metadata — no parser pipe by default). Mirrors
+		// config.LogFields.ResolvedFor (internal/config/config.go), which is the
+		// normal fill path; this is the in-package fallback for zero-field callers.
+		if f.ContainerField == "" {
+			f.ContainerField = "container"
+		}
+		if f.NamespaceField == "" {
+			f.NamespaceField = "namespace"
+		}
+		if f.PodField == "" {
+			f.PodField = "pod"
+		}
+		if f.LevelField == "" {
+			f.LevelField = "detected_level"
+		}
+		return f
+	}
 	if f.ContainerField == "" {
 		f.ContainerField = defaultContainerField
 	}
@@ -55,6 +83,14 @@ func (f LogFields) resolved() LogFields {
 		f.UnpackPipe = defaultUnpackPipe
 	}
 	return f
+}
+
+// queryLang names the dialect for tool descriptions/schemas.
+func (f LogFields) queryLang() string {
+	if f.Dialect == DialectLogQL {
+		return "LogQL"
+	}
+	return "LogsQL"
 }
 
 // logGroup is one distinct log message with its repeat count, the span over which

--- a/internal/logs/detect.go
+++ b/internal/logs/detect.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package logs hosts the backend-agnostic pieces of the logs data source; the
+// concrete clients live in the victorialogs and loki sub-packages.
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+)
+
+// Provider identifiers returned by Detect. They deliberately equal the
+// config.LogsProvider* string values (internal/config/config.go) — kept as
+// plain strings here so the probe does not depend on the config package.
+const (
+	ProviderVictoriaLogs = "victorialogs"
+	ProviderLoki         = "loki"
+)
+
+// Detect probes the logs backend once at startup to distinguish Grafana Loki
+// from VictoriaLogs, mirroring the metrics flavor probe
+// (internal/metrics/prometheus/prometheus.go DetectFlavor): a config pin
+// bypasses it (the caller checks logs.provider first), the probe is
+// best-effort, and ANY failure — unreachable backend, non-200, non-buildinfo
+// payload — FAILS SAFE to VictoriaLogs, the provider RunLore shipped with, so
+// existing deployments see no behaviour change. Loki is identified by a 200
+// JSON response with a version on /loki/api/v1/status/buildinfo, an endpoint
+// VictoriaLogs does not serve. The probe carries the same auth the real client
+// will use (a Loki behind auth must still be detectable); the token is read
+// from the environment here and never logged.
+func Detect(ctx context.Context, baseURL, tokenEnv string, headers map[string]string) string {
+	base := strings.TrimRight(baseURL, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/loki/api/v1/status/buildinfo", nil)
+	if err != nil {
+		return ProviderVictoriaLogs
+	}
+	if tokenEnv != "" {
+		if tok := os.Getenv(tokenEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := httpx.SecureClient(10 * time.Second).Do(req)
+	if err != nil {
+		return ProviderVictoriaLogs
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ProviderVictoriaLogs
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var bi struct {
+		Version string `json:"version"`
+	}
+	if json.Unmarshal(body, &bi) != nil || bi.Version == "" {
+		return ProviderVictoriaLogs // a 200 that is not buildinfo (proxy page) is not Loki
+	}
+	return ProviderLoki
+}

--- a/internal/logs/detect_test.go
+++ b/internal/logs/detect_test.go
@@ -35,7 +35,7 @@ func TestDetect(t *testing.T) {
 		t.Fatalf("404 must fail safe to victorialogs, got %q", got)
 	}
 
-	htmlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	htmlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `<html>welcome</html>`) // 200 but not buildinfo
 	}))
 	defer htmlSrv.Close()

--- a/internal/logs/detect_test.go
+++ b/internal/logs/detect_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package logs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestDetect mirrors the metrics flavor probe's contract
+// (internal/metrics/prometheus DetectFlavor): best-effort, one shot, FAIL SAFE
+// to the shipped default. Only a 200 buildinfo JSON with a version identifies
+// Loki; a 404 (VictoriaLogs), an unreachable backend, or a 200 that is not
+// buildinfo JSON (a proxy's HTML error page) all resolve to victorialogs.
+func TestDetect(t *testing.T) {
+	lokiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/loki/api/v1/status/buildinfo" {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"version":"3.1.0","revision":"935aee77ed","branch":"HEAD","goVersion":"go1.22"}`)
+	}))
+	defer lokiSrv.Close()
+	if got := Detect(context.Background(), lokiSrv.URL, "", nil); got != ProviderLoki {
+		t.Fatalf("buildinfo 200 must detect loki, got %q", got)
+	}
+
+	vlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r) // VictoriaLogs serves no /loki/api/v1/status/buildinfo
+	}))
+	defer vlSrv.Close()
+	if got := Detect(context.Background(), vlSrv.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("404 must fail safe to victorialogs, got %q", got)
+	}
+
+	htmlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `<html>welcome</html>`) // 200 but not buildinfo
+	}))
+	defer htmlSrv.Close()
+	if got := Detect(context.Background(), htmlSrv.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("non-JSON 200 must fail safe to victorialogs, got %q", got)
+	}
+
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close()
+	if got := Detect(context.Background(), down.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("unreachable must fail safe to victorialogs, got %q", got)
+	}
+}
+
+// TestDetectSendsAuth: a Loki behind auth must still be detectable.
+func TestDetectSendsAuth(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_DETECT_TOKEN", "s3cr3t")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"version":"3.1.0"}`)
+	}))
+	defer srv.Close()
+	if got := Detect(context.Background(), srv.URL, "RUNLORE_TEST_DETECT_TOKEN", map[string]string{"X-Scope-OrgID": "t"}); got != ProviderLoki {
+		t.Fatalf("got %q", got)
+	}
+	if gotAuth != "Bearer s3cr3t" {
+		t.Fatalf("probe must carry auth, got %q", gotAuth)
+	}
+}

--- a/internal/logs/loki/loki.go
+++ b/internal/logs/loki/loki.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -72,7 +73,10 @@ func (c *Client) WithLevelField(field string) *Client {
 	return c
 }
 
-var _ providers.LogsProvider = (*Client)(nil)
+var (
+	_ providers.LogsProvider = (*Client)(nil)
+	_ providers.LogStats     = (*Client)(nil)
+)
 
 // queryResponse is Loki's standard success envelope for /loki/api/v1/query_range.
 type queryResponse struct {
@@ -186,3 +190,130 @@ func (c *Client) setAuth(req *http.Request) {
 		req.Header.Set(k, v)
 	}
 }
+
+// matrixSeries is one series of a Loki metric-query (matrix) result.
+type matrixSeries struct {
+	Metric map[string]string `json:"metric"`
+	Values [][2]any          `json:"values"` // [unix seconds (float64), "count" (string)]
+}
+
+// Hits returns the per-step match count over the window, split by severity, by
+// wrapping the log query in the LogQL metric form
+// `sum by (<level>) (count_over_time(<q> [<step>]))` — the Loki analogue of
+// VictoriaLogs' /select/logsql/hits, powering the logs_error_summary histogram.
+// The level label defaults to detected_level (Loki 3.x structured metadata);
+// series without the label fold into one Level=="" bucket series, which the
+// renderer already handles. A step <= 0 defaults to one minute.
+func (c *Client) Hits(ctx context.Context, query string, w providers.TimeWindow, step time.Duration) ([]providers.Bucket, error) {
+	if step <= 0 {
+		step = time.Minute
+	}
+	stepStr := fmt.Sprintf("%ds", int(step.Seconds()))
+	metricQ := fmt.Sprintf("sum by (%s) (count_over_time(%s [%s]))", c.levelField, query, stepStr)
+	v := url.Values{"query": {metricQ}, "step": {stepStr}}
+	setWindow(v, w)
+	body, err := c.get(ctx, "/loki/api/v1/query_range", v)
+	if err != nil {
+		return nil, err
+	}
+	var resp queryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse loki response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("loki error: status %q", resp.Status)
+	}
+	var series []matrixSeries
+	if err := json.Unmarshal(resp.Data.Result, &series); err != nil {
+		return nil, fmt.Errorf("parse loki matrix: %w", err)
+	}
+	var out []providers.Bucket
+	for _, s := range series {
+		level := s.Metric[c.levelField]
+		for _, p := range s.Values {
+			ts, n := parsePoint(p)
+			out = append(out, providers.Bucket{Time: ts, Level: level, Count: n})
+		}
+	}
+	return out, nil
+}
+
+// parsePoint parses a Loki/Prometheus [unixSeconds, "value"] matrix point
+// (same wire shape as internal/metrics/prometheus/prometheus.go parsePoint,
+// narrowed to the int64 count Hits needs).
+func parsePoint(p [2]any) (time.Time, int64) {
+	var ts time.Time
+	if f, ok := p[0].(float64); ok {
+		ts = time.Unix(int64(f), 0).UTC()
+	}
+	var n int64
+	if s, ok := p[1].(string); ok {
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			n = int64(f)
+		}
+	}
+	return ts, n
+}
+
+// TopMessages returns up to k dominant messages over the window. LogQL cannot
+// group by message content (no `stats by (_msg)` equivalent; the /patterns
+// endpoint is experimental and needs the pattern ingester), so this aggregates
+// CLIENT-SIDE over the capped Query sample: numeric tokens collapse so
+// near-identical lines group (mirroring collapse_nums), counts/first/last are
+// per-sample (up to maxLines newest lines), which is enough to NAME what floods
+// the logs — the only question logs_error_summary asks of it. k <= 0 defaults
+// to 10.
+func (c *Client) TopMessages(ctx context.Context, query string, w providers.TimeWindow, k int) ([]providers.MsgCount, error) {
+	if k <= 0 {
+		k = 10
+	}
+	lines, err := c.Query(ctx, query, w)
+	if err != nil {
+		return nil, err
+	}
+	type agg struct {
+		msg         string
+		count       int64
+		first, last time.Time
+	}
+	byKey := map[string]int{}
+	var groups []agg
+	for _, l := range lines {
+		if l.Time.IsZero() && len(l.Fields) == 0 {
+			continue // the truncation sentinel is not a log message
+		}
+		key := collapseNums(l.Message)
+		i, ok := byKey[key]
+		if !ok {
+			byKey[key] = len(groups)
+			groups = append(groups, agg{msg: l.Message, count: 1, first: l.Time, last: l.Time})
+			continue
+		}
+		g := &groups[i]
+		g.count++
+		if !l.Time.IsZero() && (g.first.IsZero() || l.Time.Before(g.first)) {
+			g.first = l.Time
+		}
+		if !l.Time.IsZero() && l.Time.After(g.last) {
+			g.last = l.Time
+		}
+	}
+	sort.SliceStable(groups, func(i, j int) bool { return groups[i].count > groups[j].count })
+	if len(groups) > k {
+		groups = groups[:k]
+	}
+	out := make([]providers.MsgCount, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, providers.MsgCount{Message: g.msg, Count: g.count, First: g.first, Last: g.last})
+	}
+	return out, nil
+}
+
+// reNumToken / collapseNums mirror internal/investigate/renderlog.go (and
+// VictoriaLogs' collapse_nums pipe): free-standing digit runs collapse to "0" so
+// lines differing only by a numeric value share one grouping key. Duplicated
+// here (3 lines) rather than exported from investigate, which must not become a
+// dependency of a backend client.
+var reNumToken = regexp.MustCompile(`\d+`)
+
+func collapseNums(msg string) string { return reNumToken.ReplaceAllString(msg, "0") }

--- a/internal/logs/loki/loki.go
+++ b/internal/logs/loki/loki.go
@@ -94,6 +94,24 @@ type streamResult struct {
 	Values [][2]string       `json:"values"`
 }
 
+// queryRange performs a /loki/api/v1/query_range request and returns the
+// status-checked envelope; callers unmarshal resp.Data.Result into their own
+// shape (streams for Query, matrix for Hits).
+func (c *Client) queryRange(ctx context.Context, v url.Values) (queryResponse, error) {
+	body, err := c.get(ctx, "/loki/api/v1/query_range", v)
+	if err != nil {
+		return queryResponse{}, err
+	}
+	var resp queryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return queryResponse{}, fmt.Errorf("parse loki response: %w", err)
+	}
+	if resp.Status != "success" {
+		return queryResponse{}, fmt.Errorf("loki error: status %q", resp.Status)
+	}
+	return resp, nil
+}
+
 // Query runs a LogQL query over the window and returns normalized log lines,
 // newest first (matching the VictoriaLogs provider's ordering). It sends one
 // request with limit=maxLines and direction=backward; when the server returns
@@ -106,16 +124,9 @@ func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow
 		"direction": {"backward"},
 	}
 	setWindow(v, w)
-	body, err := c.get(ctx, "/loki/api/v1/query_range", v)
+	resp, err := c.queryRange(ctx, v)
 	if err != nil {
 		return nil, err
-	}
-	var resp queryResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("parse loki response: %w", err)
-	}
-	if resp.Status != "success" {
-		return nil, fmt.Errorf("loki error: status %q", resp.Status)
 	}
 	if resp.Data.ResultType != "streams" {
 		return nil, fmt.Errorf("unexpected loki resultType %q (Query expects a log selector, not a metric query)", resp.Data.ResultType)
@@ -127,12 +138,12 @@ func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow
 	var out providers.LogResult
 	for _, s := range streams {
 		for _, e := range s.Values {
-			ll := providers.LogLine{Message: e[1], Fields: make(map[string]string, len(s.Stream))}
+			// All lines in one stream share the same label set; alias it rather than
+			// copying per line (up to maxLines allocations avoided). Fields is
+			// read-only downstream (renderer's streamIdentity / conv.PodField lookup).
+			ll := providers.LogLine{Message: e[1], Fields: s.Stream}
 			if ns, err := strconv.ParseInt(e[0], 10, 64); err == nil {
 				ll.Time = time.Unix(0, ns).UTC()
-			}
-			for k, val := range s.Stream {
-				ll.Fields[k] = val
 			}
 			out = append(out, ll)
 		}
@@ -213,16 +224,9 @@ func (c *Client) Hits(ctx context.Context, query string, w providers.TimeWindow,
 	metricQ := fmt.Sprintf("sum by (%s) (count_over_time(%s [%s]))", c.levelField, query, stepStr)
 	v := url.Values{"query": {metricQ}, "step": {stepStr}}
 	setWindow(v, w)
-	body, err := c.get(ctx, "/loki/api/v1/query_range", v)
+	resp, err := c.queryRange(ctx, v)
 	if err != nil {
 		return nil, err
-	}
-	var resp queryResponse
-	if err := json.Unmarshal(body, &resp); err != nil {
-		return nil, fmt.Errorf("parse loki response: %w", err)
-	}
-	if resp.Status != "success" {
-		return nil, fmt.Errorf("loki error: status %q", resp.Status)
 	}
 	var series []matrixSeries
 	if err := json.Unmarshal(resp.Data.Result, &series); err != nil {

--- a/internal/logs/loki/loki.go
+++ b/internal/logs/loki/loki.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package loki implements providers.LogsProvider against Grafana Loki, querying
+// with LogQL over /loki/api/v1/* and normalizing the streams response into log
+// lines. It mirrors internal/logs/victorialogs: same construction/auth shape,
+// same optional LogStats/LogFields capabilities, same truncation sentinel.
+package loki
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Client queries a Grafana Loki backend.
+type Client struct {
+	baseURL    string
+	tokenEnv   string            // env var holding a bearer token; empty ⇒ no auth
+	headers    map[string]string // static extra request headers (e.g. X-Scope-OrgID)
+	maxLines   int               // per-query line cap (Loki `limit` param)
+	levelField string            // severity label Hits splits by; "" ⇒ defaultLevelField
+	http       *http.Client
+}
+
+// defaultMaxLines bounds the number of lines Query returns. Loki has no offset
+// pagination (a timestamp-cursor walk is deferred), so this is sent as the
+// server-side `limit` and doubles as the truncation-sentinel threshold.
+const defaultMaxLines = 1000
+
+// defaultLevelField is the severity label Hits groups by: Loki 3.x attaches
+// detected_level as structured metadata to every entry (no parser stage
+// needed). Overridable via WithLevelField (config.logs.fields.level_field) for
+// Loki 2.x or a collector with its own level label.
+const defaultLevelField = "detected_level"
+
+// New builds a client for a Loki base URL, unauthenticated.
+func New(baseURL string) *Client {
+	return NewWithAuth(baseURL, "", nil)
+}
+
+// NewWithAuth builds a client that adds optional auth to every request; the
+// semantics are identical to victorialogs.NewWithAuth (token read from the env
+// at request-build time, never logged).
+func NewWithAuth(baseURL, tokenEnv string, headers map[string]string) *Client {
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		tokenEnv:   tokenEnv,
+		headers:    headers,
+		maxLines:   defaultMaxLines,
+		levelField: defaultLevelField,
+		http:       httpx.SecureClient(30 * time.Second),
+	}
+}
+
+// WithLevelField overrides the severity label Hits splits by. Empty is a no-op
+// so an unset config keeps the default; returns the client for chaining.
+func (c *Client) WithLevelField(field string) *Client {
+	if field != "" {
+		c.levelField = field
+	}
+	return c
+}
+
+var _ providers.LogsProvider = (*Client)(nil)
+
+// queryResponse is Loki's standard success envelope for /loki/api/v1/query_range.
+type queryResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string          `json:"resultType"`
+		Result     json.RawMessage `json:"result"`
+	} `json:"data"`
+}
+
+// streamResult is one log stream: its label set plus [ns-epoch, line] entries.
+type streamResult struct {
+	Stream map[string]string `json:"stream"`
+	Values [][2]string       `json:"values"`
+}
+
+// Query runs a LogQL query over the window and returns normalized log lines,
+// newest first (matching the VictoriaLogs provider's ordering). It sends one
+// request with limit=maxLines and direction=backward; when the server returns
+// exactly the limit, more entries likely matched and the shared truncation
+// sentinel is appended (providers.TruncationLine).
+func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow) (providers.LogResult, error) {
+	v := url.Values{
+		"query":     {query},
+		"limit":     {strconv.Itoa(c.maxLines)},
+		"direction": {"backward"},
+	}
+	setWindow(v, w)
+	body, err := c.get(ctx, "/loki/api/v1/query_range", v)
+	if err != nil {
+		return nil, err
+	}
+	var resp queryResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parse loki response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("loki error: status %q", resp.Status)
+	}
+	if resp.Data.ResultType != "streams" {
+		return nil, fmt.Errorf("unexpected loki resultType %q (Query expects a log selector, not a metric query)", resp.Data.ResultType)
+	}
+	var streams []streamResult
+	if err := json.Unmarshal(resp.Data.Result, &streams); err != nil {
+		return nil, fmt.Errorf("parse loki streams: %w", err)
+	}
+	var out providers.LogResult
+	for _, s := range streams {
+		for _, e := range s.Values {
+			ll := providers.LogLine{Message: e[1], Fields: make(map[string]string, len(s.Stream))}
+			if ns, err := strconv.ParseInt(e[0], 10, 64); err == nil {
+				ll.Time = time.Unix(0, ns).UTC()
+			}
+			for k, val := range s.Stream {
+				ll.Fields[k] = val
+			}
+			out = append(out, ll)
+		}
+	}
+	// Entries arrive grouped per stream; order newest-first ACROSS streams so the
+	// renderer and the VictoriaLogs provider agree on what "first lines" means.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Time.After(out[j].Time) })
+	if len(out) >= c.maxLines {
+		out = out[:c.maxLines]
+		out = append(out, providers.TruncationLine(int64(c.maxLines)))
+	}
+	return out, nil
+}
+
+// setWindow adds the optional RFC3339 start/end bounds (Loki accepts RFC3339
+// alongside ns epochs; RFC3339 matches the VictoriaLogs client for symmetry).
+func setWindow(v url.Values, w providers.TimeWindow) {
+	if !w.Start.IsZero() {
+		v.Set("start", w.Start.UTC().Format(time.RFC3339))
+	}
+	if !w.End.IsZero() {
+		v.Set("end", w.End.UTC().Format(time.RFC3339))
+	}
+}
+
+// get performs an authenticated GET against a Loki endpoint and returns the raw
+// body; any non-200 becomes an error carrying the status and body (mirrors
+// victorialogs.postForm error shape, so tool-visible errors read the same).
+func (c *Client) get(ctx context.Context, path string, v url.Values) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path+"?"+v.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("logs query: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+// setAuth applies the optional bearer token and static headers (identical
+// semantics to the VictoriaLogs client: token read here, never logged).
+func (c *Client) setAuth(req *http.Request) {
+	if c.tokenEnv != "" {
+		if tok := os.Getenv(c.tokenEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+}

--- a/internal/logs/loki/loki.go
+++ b/internal/logs/loki/loki.go
@@ -76,6 +76,7 @@ func (c *Client) WithLevelField(field string) *Client {
 var (
 	_ providers.LogsProvider = (*Client)(nil)
 	_ providers.LogStats     = (*Client)(nil)
+	_ providers.LogFields    = (*Client)(nil)
 )
 
 // queryResponse is Loki's standard success envelope for /loki/api/v1/query_range.
@@ -317,3 +318,54 @@ func (c *Client) TopMessages(ctx context.Context, query string, w providers.Time
 var reNumToken = regexp.MustCompile(`\d+`)
 
 func collapseNums(msg string) string { return reNumToken.ReplaceAllString(msg, "0") }
+
+// FieldNames lists the field names present in the logs matching query over the
+// window — the log-schema discovery path (providers.LogFields). Loki splits the
+// answer across two endpoints, so both are merged: STREAM labels from
+// /loki/api/v1/labels (query-scoped; these are what a selector is built from,
+// so they come first, Hits=0 — Loki reports no per-label hit count) and parsed
+// body fields from /loki/api/v1/detected_fields (Loki 3.x; Hits carries the
+// reported value cardinality). A missing detected_fields endpoint (older Loki)
+// degrades to labels-only; only both failing is an error.
+func (c *Client) FieldNames(ctx context.Context, query string, w providers.TimeWindow) ([]providers.FieldCount, error) {
+	var out []providers.FieldCount
+
+	lv := url.Values{"query": {query}}
+	setWindow(lv, w)
+	labelsBody, labelsErr := c.get(ctx, "/loki/api/v1/labels", lv)
+	if labelsErr == nil {
+		var resp struct {
+			Status string   `json:"status"`
+			Data   []string `json:"data"`
+		}
+		if err := json.Unmarshal(labelsBody, &resp); err != nil {
+			return nil, fmt.Errorf("parse loki labels: %w", err)
+		}
+		for _, name := range resp.Data {
+			out = append(out, providers.FieldCount{Name: name})
+		}
+	}
+
+	dv := url.Values{"query": {query}}
+	setWindow(dv, w)
+	dfBody, dfErr := c.get(ctx, "/loki/api/v1/detected_fields", dv)
+	if dfErr != nil {
+		if labelsErr == nil {
+			return out, nil // older Loki: stream labels alone still answer discovery
+		}
+		return nil, dfErr
+	}
+	var resp struct {
+		Fields []struct {
+			Label       string `json:"label"`
+			Cardinality int64  `json:"cardinality"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(dfBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse loki detected_fields: %w", err)
+	}
+	for _, f := range resp.Fields {
+		out = append(out, providers.FieldCount{Name: f.Label, Hits: f.Cardinality})
+	}
+	return out, nil
+}

--- a/internal/logs/loki/loki_test.go
+++ b/internal/logs/loki/loki_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -143,5 +144,90 @@ func TestQueryErrorPaths(t *testing.T) {
 	res, err := New(empty.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{})
 	if err != nil || len(res) != 0 {
 		t.Fatalf("empty result must be (nil, nil), got %v / %v", res, err)
+	}
+}
+
+func TestHits(t *testing.T) {
+	var gotQuery, gotStep string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query().Get("query")
+		gotStep = r.URL.Query().Get("step")
+		_, _ = io.WriteString(w, `{
+		  "status": "success",
+		  "data": {
+		    "resultType": "matrix",
+		    "result": [
+		      {"metric": {"detected_level": "error"}, "values": [[1704103200, "3"], [1704103500, "412"]]},
+		      {"metric": {"detected_level": "warn"},  "values": [[1704103200, "1"]]}
+		    ]
+		  }
+		}`)
+	}))
+	defer srv.Close()
+
+	buckets, err := New(srv.URL).Hits(context.Background(), `{namespace="apps"} | detected_level="error"`,
+		providers.TimeWindow{}, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("Hits: %v", err)
+	}
+	// The log query must be wrapped in the LogQL metric form, split by the level label.
+	want := `sum by (detected_level) (count_over_time({namespace="apps"} | detected_level="error" [300s]))`
+	if gotQuery != want {
+		t.Fatalf("metric query = %q, want %q", gotQuery, want)
+	}
+	if gotStep != "300s" {
+		t.Fatalf("step=%q, want 300s", gotStep)
+	}
+	if len(buckets) != 3 {
+		t.Fatalf("want 3 buckets, got %d: %+v", len(buckets), buckets)
+	}
+	var sawSpike bool
+	for _, b := range buckets {
+		if b.Level == "error" && b.Count == 412 && !b.Time.IsZero() {
+			sawSpike = true
+		}
+	}
+	if !sawSpike {
+		t.Fatalf("missing error=412 bucket: %+v", buckets)
+	}
+}
+
+func TestTopMessages(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
+		  {"stream":{"namespace":"apps"},"values":[
+		    ["1750413603000000000","connection refused to 10.0.0.7"],
+		    ["1750413602000000000","connection refused to 10.0.0.9"],
+		    ["1750413601000000000","connection refused to 10.0.0.9"],
+		    ["1750413600000000000","timeout waiting for db"]]}]}}`)
+	}))
+	defer srv.Close()
+
+	msgs, err := New(srv.URL).TopMessages(context.Background(), `{namespace="apps"}`, providers.TimeWindow{}, 10)
+	if err != nil {
+		t.Fatalf("TopMessages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("want 2 grouped messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Count != 3 || !strings.Contains(msgs[0].Message, "connection refused") {
+		t.Fatalf("dominant message wrong: %+v", msgs[0])
+	}
+	if !msgs[0].First.Before(msgs[0].Last) {
+		t.Fatalf("first→last span not tracked: %+v", msgs[0])
+	}
+	if msgs[1].Message != "timeout waiting for db" || msgs[1].Count != 1 {
+		t.Fatalf("second message wrong: %+v", msgs[1])
+	}
+}
+
+func TestHitsErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "parse error: unexpected token", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL).Hits(context.Background(), `{a="b"}`, providers.TimeWindow{}, time.Minute); err == nil ||
+		!strings.Contains(err.Error(), "400") {
+		t.Fatalf("bad request must error with status, got %v", err)
 	}
 }

--- a/internal/logs/loki/loki_test.go
+++ b/internal/logs/loki/loki_test.go
@@ -231,3 +231,73 @@ func TestHitsErrorPath(t *testing.T) {
 		t.Fatalf("bad request must error with status, got %v", err)
 	}
 }
+
+// TestFieldNames: discovery merges STREAM labels (/loki/api/v1/labels — the
+// selector building blocks the model needs first) with detected body fields
+// (/loki/api/v1/detected_fields, Loki 3.x). Hits carries the detected field's
+// value CARDINALITY (Loki reports no per-field hit count); stream labels carry 0
+// and the discover tool renders the number only when > 0.
+func TestFieldNames(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/loki/api/v1/labels":
+			if q := r.URL.Query().Get("query"); q != `{namespace="apps"}` {
+				t.Errorf("labels query=%q", q)
+			}
+			_, _ = io.WriteString(w, `{"status":"success","data":["namespace","pod","container"]}`)
+		case "/loki/api/v1/detected_fields":
+			_, _ = io.WriteString(w, `{"fields":[
+			  {"label":"level","type":"string","cardinality":4,"parsers":["logfmt"]},
+			  {"label":"duration","type":"duration","cardinality":99,"parsers":["logfmt"]}]}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	fields, err := New(srv.URL).FieldNames(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("FieldNames: %v", err)
+	}
+	if len(fields) != 5 {
+		t.Fatalf("want 3 labels + 2 detected fields, got %d: %+v", len(fields), fields)
+	}
+	if fields[0].Name != "namespace" || fields[0].Hits != 0 {
+		t.Fatalf("stream labels must come first with Hits=0: %+v", fields[0])
+	}
+	if fields[3].Name != "level" || fields[3].Hits != 4 {
+		t.Fatalf("detected field must carry cardinality as Hits: %+v", fields[3])
+	}
+}
+
+// TestFieldNamesOldLoki: a Loki without detected_fields (pre-3.0 returns 404)
+// still answers discovery with the stream labels alone — degrade, don't fail.
+func TestFieldNamesOldLoki(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/labels" {
+			_, _ = io.WriteString(w, `{"status":"success","data":["namespace","pod"]}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	fields, err := New(srv.URL).FieldNames(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("FieldNames must degrade to labels-only, got %v", err)
+	}
+	if len(fields) != 2 || fields[0].Name != "namespace" {
+		t.Fatalf("labels-only result wrong: %+v", fields)
+	}
+}
+
+// TestFieldNamesBothDown: when neither endpoint answers, the error must surface.
+func TestFieldNamesBothDown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL).FieldNames(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil {
+		t.Fatalf("both endpoints failing must error")
+	}
+}

--- a/internal/logs/loki/loki_test.go
+++ b/internal/logs/loki/loki_test.go
@@ -92,7 +92,7 @@ func TestQueryAuthHeaders(t *testing.T) {
 // limit=maxLines once and appends the shared TruncationLine sentinel when the
 // server returned exactly the limit (more likely matched upstream).
 func TestQueryTruncation(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
 		  {"stream":{"namespace":"apps"},"values":[
 		    ["1750413602000000000","a"],["1750413601000000000","b"],["1750413600000000000","c"]]}]}}`)
@@ -120,7 +120,7 @@ func TestQueryErrorPaths(t *testing.T) {
 		t.Fatalf("backend down must error")
 	}
 
-	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "too many outstanding requests", http.StatusTooManyRequests)
 	}))
 	defer bad.Close()
@@ -129,7 +129,7 @@ func TestQueryErrorPaths(t *testing.T) {
 		t.Fatalf("non-200 must error with the status, got %v", err)
 	}
 
-	malformed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	malformed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":`)
 	}))
 	defer malformed.Close()
@@ -137,7 +137,7 @@ func TestQueryErrorPaths(t *testing.T) {
 		t.Fatalf("malformed body must error")
 	}
 
-	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[]}}`)
 	}))
 	defer empty.Close()
@@ -193,7 +193,7 @@ func TestHits(t *testing.T) {
 }
 
 func TestTopMessages(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
 		  {"stream":{"namespace":"apps"},"values":[
 		    ["1750413603000000000","connection refused to 10.0.0.7"],
@@ -222,7 +222,7 @@ func TestTopMessages(t *testing.T) {
 }
 
 func TestHitsErrorPath(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "parse error: unexpected token", http.StatusBadRequest)
 	}))
 	defer srv.Close()

--- a/internal/logs/loki/loki_test.go
+++ b/internal/logs/loki/loki_test.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package loki
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestQuery(t *testing.T) {
+	var gotPath, gotQuery, gotLimit, gotDirection string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("query")
+		gotLimit = r.URL.Query().Get("limit")
+		gotDirection = r.URL.Query().Get("direction")
+		_, _ = io.WriteString(w, `{
+		  "status": "success",
+		  "data": {
+		    "resultType": "streams",
+		    "result": [
+		      {
+		        "stream": {"namespace": "apps", "pod": "harbor-db-0", "container": "db", "detected_level": "error"},
+		        "values": [
+		          ["1750413601000000000", "retrying"],
+		          ["1750413600000000000", "db connection refused"]
+		        ]
+		      }
+		    ]
+		  }
+		}`)
+	}))
+	defer srv.Close()
+
+	res, err := New(srv.URL).Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotPath != "/loki/api/v1/query_range" {
+		t.Fatalf("path=%q", gotPath)
+	}
+	if gotQuery != `{namespace="apps"}` {
+		t.Fatalf("query=%q", gotQuery)
+	}
+	if gotLimit != "1000" || gotDirection != "backward" {
+		t.Fatalf("limit=%q direction=%q, want 1000/backward", gotLimit, gotDirection)
+	}
+	if len(res) != 2 {
+		t.Fatalf("want 2 lines, got %d", len(res))
+	}
+	// Newest first, matching the VictoriaLogs provider's ordering contract.
+	if res[0].Message != "retrying" || res[1].Message != "db connection refused" {
+		t.Fatalf("order/messages wrong: %+v", res)
+	}
+	// Nanosecond epoch parsed; stream labels become LogLine.Fields (so the
+	// renderer's streamIdentity finds pod/container under the Loki names).
+	if res[1].Time.UTC().Format("2006-01-02T15:04:05Z") != "2025-06-20T10:00:00Z" {
+		t.Fatalf("time not parsed from ns epoch: %v", res[1].Time)
+	}
+	if res[0].Fields["pod"] != "harbor-db-0" || res[0].Fields["container"] != "db" {
+		t.Fatalf("stream labels not mapped to fields: %+v", res[0].Fields)
+	}
+}
+
+func TestQueryAuthHeaders(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_LOKI_TOKEN", "s3cr3t")
+	var gotAuth, gotTenant string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotTenant = r.Header.Get("X-Scope-OrgID")
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[]}}`)
+	}))
+	defer srv.Close()
+
+	c := NewWithAuth(srv.URL, "RUNLORE_TEST_LOKI_TOKEN", map[string]string{"X-Scope-OrgID": "tenant-b"})
+	if _, err := c.Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "Bearer s3cr3t" || gotTenant != "tenant-b" {
+		t.Fatalf("auth not applied: auth=%q tenant=%q", gotAuth, gotTenant)
+	}
+}
+
+// TestQueryTruncation: Loki has no offset pagination; the client sends
+// limit=maxLines once and appends the shared TruncationLine sentinel when the
+// server returned exactly the limit (more likely matched upstream).
+func TestQueryTruncation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[
+		  {"stream":{"namespace":"apps"},"values":[
+		    ["1750413602000000000","a"],["1750413601000000000","b"],["1750413600000000000","c"]]}]}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL)
+	c.maxLines = 3
+	res, err := c.Query(context.Background(), `{namespace="apps"}`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res) != 4 || !strings.Contains(res[3].Message, "results truncated at 3") {
+		t.Fatalf("want 3 lines + sentinel, got %d: %+v", len(res), res)
+	}
+}
+
+// TestQueryErrorPaths: backend down, non-200, JSON error status, and malformed
+// body must each surface as an error (never a silent empty result), so the tool
+// call fails visibly and the loop records a data gap instead of "no logs".
+func TestQueryErrorPaths(t *testing.T) {
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close() // connection refused
+	if _, err := New(down.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil {
+		t.Fatalf("backend down must error")
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "too many outstanding requests", http.StatusTooManyRequests)
+	}))
+	defer bad.Close()
+	if _, err := New(bad.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil ||
+		!strings.Contains(err.Error(), "429") {
+		t.Fatalf("non-200 must error with the status, got %v", err)
+	}
+
+	malformed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":`)
+	}))
+	defer malformed.Close()
+	if _, err := New(malformed.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil {
+		t.Fatalf("malformed body must error")
+	}
+
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"status":"success","data":{"resultType":"streams","result":[]}}`)
+	}))
+	defer empty.Close()
+	res, err := New(empty.URL).Query(context.Background(), `{a="b"}`, providers.TimeWindow{})
+	if err != nil || len(res) != 0 {
+		t.Fatalf("empty result must be (nil, nil), got %v / %v", res, err)
+	}
+}


### PR DESCRIPTION
Part of the **v0.11.0** roadmap — Phase 4 (Meet users), item **M1**.

Adds **Grafana Loki** as a second logs backend behind the pluggable `providers.LogsProvider`, at feature parity with VictoriaLogs where Loki's API allows. All three log tools — `query_logs`, `logs_error_summary`, `discover_log_fields` — work on both backends; the model is told the right query language automatically. **No new required config**: an unset or VictoriaLogs config is byte-for-byte unchanged.

## What changed (9 commits, TDD)
1. **Config** — optional `logs.provider` enum (`""`/`victorialogs`/`loki`, validated) + Loki field defaults (`ResolvedFor`).
2. **Loki client** (`internal/logs/loki`) mirroring the VictoriaLogs client shape-for-shape: `Query` over `/loki/api/v1/query_range` (streams → newest-first log lines, cap sentinel, auth by env-indirection).
3. **Analytics** (`providers.LogStats`) — `Hits` via the LogQL metric form `sum by (detected_level) (count_over_time(… [step]))`; `TopMessages` aggregated **client-side** over the capped sample (LogQL has no `stats by (_msg)`), numeric tokens collapsed.
4. **Field discovery** (`providers.LogFields`) — `FieldNames` merges stream labels (`/labels`) with detected body fields (`/detected_fields`, Loki 3.x; degrades to labels-only on older Loki).
5. **Auto-detect** (`internal/logs/detect.go`) — probes `/loki/api/v1/status/buildinfo` once at startup, **fails safe to VictoriaLogs** on any non-Loki signal (404, unreachable, non-JSON-200).
6. **LogQL dialect** in `internal/investigate` — the three tools get a `Dialect`; `buildLogQL` compiles the same structured params to valid LogQL, raw LogsQL-isms (`unpack_json`/`_msg`) get a correcting error, tool descriptions/schemas say **LogQL** on a Loki deployment. End-to-end parity test wires the real tools to the real client against a fake Loki.
7. **App wiring** — `BuildModelAndTools` selects the client by resolved provider (pin wins, else probe) and passes the dialect-carrying `LogFields` to all three tools.
8. **Docs** — `data-sources.md` Logs-backends section (per-provider field defaults + parity notes) and chart `values.yaml`.

## Loki parity gaps (explicit in code + docs)
- No offset pagination → single capped request + shared `TruncationLine`.
- `TopMessages` counts are per-sample, not corpus-wide.
- `detected_fields` reports value *cardinality*, rendered as a count only when > 0 (stream labels carry none).
- Loki 2.x has no `detected_level` → documented `logs.fields` override.

## Verification
- Full quality gate green: `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` (empty), **golangci-lint `0 issues`**, `helm lint` clean.
- Each layer TDD'd (test written, watched fail for the right reason, implemented, watched pass). Existing VictoriaLogs tests unmodified — zero `Dialect` keeps the old behaviour byte-for-byte.

## Minor deviations from the plan
- Fixed a test fixture typo: the ns-epoch `1750413600000000000` decodes to **2025**-06-20, not 2026 — corrected the assertion to match (the client's parsing was already correct).
- Added the `LogStats`/`LogFields` interface assertions in their own tasks (once the methods exist) rather than all up front, so each intermediate commit compiles.