### PR TITLE
fix(eval): satisfy revive and staticcheck on the F2 scorecard code

### DIFF
--- a/internal/eval/replay_report.go
+++ b/internal/eval/replay_report.go
@@ -52,12 +52,7 @@ func (c Campaign) Report(at, model string, usage providers.Usage, costUSD *float
 		InputTokens: usage.InputTokens, OutputTokens: usage.OutputTokens, CostUSD: costUSD,
 	}
 	for _, a := range c.Aggregates {
-		rep.Cases = append(rep.Cases, ReportCase{
-			Name: a.Name, Runs: a.Runs, PassRate: a.PassRate, Reached: a.Reached, Flaky: a.Flaky,
-			Confidence: a.Confidence, Missing: a.Missing, OverClaimed: a.OverClaimed,
-			HasRecall: a.HasRecall, ExpectRecall: a.ExpectRecall,
-			RecallFired: a.RecallFired, RecallShortCircuit: a.RecallShortCircuit,
-		})
+		rep.Cases = append(rep.Cases, ReportCase(a))
 	}
 	return rep
 }

--- a/internal/eval/scorecard.go
+++ b/internal/eval/scorecard.go
@@ -4,6 +4,7 @@
 // artifacts published on the eval-scorecard branch — a browsable scorecard.md, a
 // shields.io endpoint badge.json, and an append-only history.jsonl. Pure functions
 // over bytes so the whole pipeline is testable without CI.
+
 package eval
 
 import (


### PR DESCRIPTION
Main went red on `golangci-lint` right after the v0.11.0 roadmap merges. Two issues, both in the F2 scorecard code (#368), were masked on the feature branch: govulncheck ran first in the `build` job and failed on the (now-fixed) `golang.org/x/net` vuln, aborting the job before golangci-lint executed. With govulncheck green on main, the linter ran for the first time and flagged:

- `internal/eval/scorecard.go:3` — revive `package-comments`: the file comment sat directly above `package eval`, making it a second package-doc comment (`case.go` holds the canonical `// Package eval …`). Detached with a blank line.
- `internal/eval/replay_report.go:55` — staticcheck `S1016`: `ReportCase` and `CaseAggregate` have identical fields; replaced the field-by-field literal with a `ReportCase(a)` conversion.

Behavior-preserving. Verified locally: `go build`, `go test ./internal/eval/...`, and `golangci-lint run ./internal/eval/...` (v2.12.2) all clean.