### PR TITLE
fix(release-chart): authenticate cosign to GHCR before signing

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -91,6 +91,18 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      # cosign uploads the signature to GHCR using its OWN registry auth (the docker
+      # config / keychain), NOT helm's `helm registry login` above — so without a docker
+      # login here cosign's signature push is unauthenticated and GHCR rejects it with
+      # "UNAUTHORIZED: User cannot be authenticated with the token provided". Populate the
+      # docker config so cosign can upload the signature layer.
+      - name: Log in to GHCR for cosign
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Sign chart (cosign keyless)
         run: cosign sign --yes "${{ steps.push.outputs.ref }}@${{ steps.push.outputs.digest }}"
 


### PR DESCRIPTION
## Problem

The first-ever run of `release-chart.yml` (a `workflow_dispatch` backfill of chart `0.10.0`, validating F1/#367) **published the chart but failed the job on signing**:

```
Error: signing [ghcr.io/smana/charts/runlore@sha256:a7903c71…]: signing digest:
failed to upload layer: POST https://ghcr.io/v2/smana/charts/runlore/blobs/uploads/:
UNAUTHORIZED: User cannot be authenticated with the token provided.
```

## Root cause

The workflow runs `helm registry login ghcr.io` (authenticates **helm**), but cosign uploads the signature using its **own** registry auth from the docker config, which was never populated. So the signature push goes out unauthenticated → 401. Keyless signing's Fulcio/OIDC side was fine (`id-token: write` is set) — this is purely the registry-push auth for the signature blob. The chart push itself succeeded (helm was logged in), so `oci://ghcr.io/smana/charts/runlore:0.10.0` is present and pullable; only the signature is missing.

This was latent because the workflow had never executed (no `v*` tag since #367 merged).

## Fix

Add a `docker/login-action` to GHCR (pinned to the same v4.4.0 SHA used in `build-image.yml`) before the cosign step, so cosign finds credentials in the docker config. `packages: write` is already granted on the job.

Verified the publish path works end-to-end (`helm pull` succeeded, digest `a7903c71`); this restores the signature step. A follow-up backfill dispatch after merge will produce a signed chart.