### PR TITLE
docs(source_repos): make the GitHub App access requirement explicit

### DIFF
--- a/website/content/docs/concepts/data-sources.md
+++ b/website/content/docs/concepts/data-sources.md
@@ -197,9 +197,17 @@ source_repos:
     - gitlab.com/acme/infra-modules  # or exact host/org/repo
 ```
 
-**Auth:** private **GitHub** repos reuse the forge GitHub App installation token — install
-the App on those repos with `contents: read`. Public repos need nothing. Private non-GitHub
-hosts are not supported yet.
+**Auth — the forge GitHub App must be granted access to each private source repo.**
+`source_diff` clones over HTTPS with the **forge GitHub App installation token** (the same
+App as `forge.github_app`), and that token attaches to *every* clone on the forge's host.
+For each **private GitHub** repo you list, the App must be **installed on that repo with
+`contents: read`** — otherwise the installation token is out of scope and the clone fails
+(`404`/`repository not found`), even though the URL looks right. Grant access in the App's
+settings (**Repository access → Only select repositories → add the repo**), or verify with
+`gh api /installation/repositories`. Keep that installation scope as tight as the allowlist.
+Public GitHub repos need no grant — an installation token can read any public repo regardless
+of scope. Entries on a non-forge host (e.g. `gitlab.com/...`) clone **anonymously** (the
+GitHub token is never sent off-host); private non-GitHub hosts are not supported yet.
 
 RunLore performs **read-only clones with no working-tree checkout** — bare mirrors when the
 mirror cache is enabled (the default), or a no-checkout clone per call when the cache is

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -526,11 +526,17 @@ source_repos:
 - `allow` — patterns the model may diff, `host/org/repo`-shaped with per-segment globs
   (`*` never crosses `/`). Matching is enforced server-side **before any network call** —
   the model can only make RunLore clone repos you listed, whatever it writes.
-- **Auth:** private **GitHub** repos reuse the forge GitHub App installation token (install
-  the App on those repos with `contents: read`). The token is confined to the forge's own
-  host — a repo on any other host (e.g. a `gitlab.com/...` entry) is cloned **anonymously**,
-  so the GitHub token is never transmitted off-host; public repos need nothing and private
-  non-GitHub hosts are not supported yet. Because the model chooses which allowlisted repo to
+- **Auth — grant the forge GitHub App access to each private source repo.** `source_diff`
+  clones with the **forge GitHub App installation token**, so for every **private GitHub**
+  repo in `allow` the App must be **installed on that repo with `contents: read`** — an
+  installation token is scoped to the repos the App is installed on, so a private repo that
+  is not granted fails to clone (`404`/`repository not found`) even though the entry is
+  correct. Add it under the App's **Repository access** (or check with
+  `gh api /installation/repositories`). The token is confined to the forge's own host — a
+  repo on any other host (e.g. a `gitlab.com/...` entry) is cloned **anonymously**, so the
+  GitHub token is never transmitted off-host; public GitHub repos need no grant (an
+  installation token reads any public repo regardless of scope) and private non-GitHub hosts
+  are not supported yet. Because the model chooses which allowlisted repo to
   diff, keep the allowlist **and** the App's installation scope no broader than the source you
   intend RunLore to read — a wide `github.com/org/*` glob plus an org-wide install lets the
   agent diff any repo in that org.


### PR DESCRIPTION
Redo of #376 against the new Hextra doc paths (`website/content/docs/…`).

## Summary
Validating #359 (source_diff) against a live cluster surfaced a doc gap: source_diff clones with the **forge GitHub App installation token**, scoped to the repos the App is installed on. A **private** source repo in `source_repos.allow` that isn't granted to the App fails to clone (`404 / repository not found`) despite a correct allowlist entry — and the old wording ("install the App … Public repos need nothing") didn't make that a clear, findable MUST.

## Changes
- `website/content/docs/concepts/data-sources.md` + `website/content/docs/configuration/configuration.md`: state the requirement as a MUST (install the App on each private GitHub source repo with `contents: read`), how to add it (Repository access) and verify (`gh api /installation/repositories`), the exact failure symptom, and clarify public GitHub repos read fine regardless of installation scope. Docs only.