### PR TITLE
docs(kb-steward): fix stale doc links before release

### DIFF
--- a/plugins/kb-steward/.claude-plugin/plugin.json
+++ b/plugins/kb-steward/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "version": "0.10.0",
   "description": "Interviews SREs and turns platform knowledge into recall-grade OKF entries for a RunLore knowledge catalog",
   "author": { "name": "Smaine Kahlouch" },
-  "homepage": "https://github.com/Smana/runlore/blob/main/docs/kb-steward.md",
+  "homepage": "https://runlore.io/docs/reference/kb-steward/",
   "repository": "https://github.com/Smana/runlore",
   "license": "Apache-2.0",
   "keywords": ["runlore", "sre", "knowledge-base", "okf"]

--- a/plugins/kb-steward/skills/kb-steward/SKILL.md
+++ b/plugins/kb-steward/skills/kb-steward/SKILL.md
@@ -100,7 +100,7 @@ Target for a first sitting: 5–15 entries the SRE confirms are true.
    each. Retirement PRs touch only their entry file — they merge in any order.
 7. If most of the queue is noise, say so and point at the config levers:
    `forge.skip_verdicts: ["no_action"]`, `forge.min_confidence`,
-   `forge.dup_score` (see RunLore's docs/reviewing-knowledge.md).
+   `forge.dup_score` (see https://runlore.io/docs/concepts/reviewing-knowledge/).
 
 ## Flow 4 — Maintenance
 


### PR DESCRIPTION
The kb-steward skill + plugin manifest still pointed at the old `docs/*.md` files (migrated to the Hugo site). Repointed both to runlore.io. Drift-guard tests + `claude plugin validate` pass.