### PR TITLE
feat(kb-steward): capture a precise change-anchor in Cause

### DIFF
--- a/plugins/kb-steward/skills/kb-steward/SKILL.md
+++ b/plugins/kb-steward/skills/kb-steward/SKILL.md
@@ -59,7 +59,10 @@ Target for a first sitting: 5–15 entries the SRE confirms are true.
 3. Near-duplicate check: search the catalog for the resource and alert/title
    keywords. Prefer updating + revalidating an existing entry.
 4. Draft one Incident entry (`## Symptom` / `## Cause` / `## Investigate` /
-   `## Resolution`); add a Playbook only if the procedure generalizes.
+   `## Resolution`); add a Playbook only if the procedure generalizes. **Anchor
+   `## Cause` to the precise change** when there is one — the offending commit/PR
+   (RunLore's `source_diff` surfaces it behind a version bump), the exact image/
+   chart version, or the GitOps revision — not just "a deploy went out".
 5. Checklist + secret scan, then the git flow.
 
 ## Flow 3 — PR triage

--- a/plugins/kb-steward/skills/kb-steward/references/interview-guides.md
+++ b/plugins/kb-steward/skills/kb-steward/references/interview-guides.md
@@ -101,8 +101,11 @@ happens after resolution; diagnosis is RunLore's (or the human's) job.
    `resource` stays the actually-faulty workload.
 2. **Impact & timeline** — start, detection, mitigation, resolution times;
    blast radius.
-3. **What changed** — deploys, config, infra around onset? Git SHAs or
-   releases if known.
+3. **What changed** — deploys, config, infra around onset? Capture the
+   **precise change-anchor** when known: the offending commit or PR (RunLore's
+   `source_diff` pins this behind an image/chart bump), the exact version, or the
+   GitOps revision. A specific anchor is far stronger recall + repair signal than
+   "a deploy went out".
 4. **Root cause — with pushback.** Don't accept the first answer:
    - "Is that the cause, or the first symptom you noticed?"
    - "If you rolled only that back, would it recur?"


### PR DESCRIPTION
Post-incident capture (Flow 2 + interview guide) now nudges the steward to anchor `## Cause` to the precise change — the offending commit/PR (surfaced by RunLore's `source_diff`), exact version, or GitOps revision. Light-touch; okf-format/checklist untouched, drift guards + `claude plugin validate` pass.