### PR TITLE
fix(eval): repin the nightly to glm-4.5-air so the public scorecard stops reporting 0%

### DIFF
--- a/eval/ci.runlore.yaml
+++ b/eval/ci.runlore.yaml
@@ -2,14 +2,19 @@
 # Only the model block is needed — replay scenarios supply their own evidence.
 # Set the repo secret RUNLORE_EVAL_API_KEY to the API key for this provider.
 model:
-  provider: anthropic
-  model: claude-haiku-4-5-20251001
+  provider: openai
+  base_url: https://api.z.ai/api/paas/v4   # GLM, OpenAI-compatible
+  model: glm-4.5-air
   api_key_env: RUNLORE_EVAL_API_KEY
-  # Optional: token rates (USD per MILLION tokens) so the published scorecard
-  # reports an honest per-run cost. claude-haiku-4-5 list prices, 2026-07
-  # (same figures as eval/compare.example.yaml). Wrong rates only skew the
+  # glm-4.5-air list prices (USD per MILLION tokens), checked 2026-08-02, so the
+  # published scorecard reports an honest per-run cost. Wrong rates only skew the
   # cost figure, never the pass/fail scoring.
+  #
+  # cached_input is set equal to the input rate rather than to a real cache
+  # discount, which we have not confirmed for this model. That can only ever
+  # OVERstate the published cost — the safe direction for a number whose whole
+  # value is that a skeptic can check it.
   pricing:
-    input_usd_per_mtok: 1.00
-    output_usd_per_mtok: 5.00
-    cached_input_usd_per_mtok: 0.10
+    input_usd_per_mtok: 0.20
+    output_usd_per_mtok: 1.10
+    cached_input_usd_per_mtok: 0.20


### PR DESCRIPTION
## Why this is urgent

The first nightly eval published at 08:12 UTC today and the public badge now reads:

```json
{"color":"red","label":"nightly eval","message":"0/2 scenarios · 0%"}
```

That 0% is **not** a model result. `eval/ci.runlore.yaml` is pinned to `anthropic/claude-haiku-4-5-20251001`, but the `RUNLORE_EVAL_API_KEY` secret holds a GLM key, so every call failed:

```
investigation error: model: messages status 401: authentication_error: invalid x-api-key   (x5)
```

The README renders that badge, and the scorecard page attributes the 0% to a model this project does not use. Publishing red runs is correct and stays — but this red is an infrastructure mismatch, indistinguishable to a reader from a genuine failure.

## What this changes

Repins the nightly to the provider the key actually belongs to, with that model's own token rates:

- `provider: openai` + `base_url: https://api.z.ai/api/paas/v4` (GLM's OpenAI-compatible endpoint)
- `model: glm-4.5-air`
- pricing `0.20 / 1.10` per MTok

`cached_input` is set equal to the input rate rather than a cache discount we have not confirmed for this model, so the published cost can only ever overstate — the safe direction for a figure whose value is that a skeptic can check it.

## Why glm-4.5-air and not glm-4.6

`glm-4.6` stalls indefinitely on forced `tool_choice` (#391), which the eval judge's `submit_grade` call depends on, so it cannot grade a run. `glm-4.5-air` answers the identical forced-tool request in ~5s and completes the full investigation loop including the adversarial verify pass — verified end-to-end.

## Before merging

Confirm `RUNLORE_EVAL_API_KEY` holds the **GLM** key (the 401s indicate it does). After merge, trigger the workflow manually rather than waiting for the 06:00 UTC schedule:

```
gh workflow run eval.yaml
```

## Note

Split out of the larger `feat/proof-assets` branch so the public badge is corrected now rather than at the end of that work.