### PR TITLE
feat(demo): a real root cause in one command — no cluster, no API key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,9 @@ jobs:
         with:
           version: v2.12.2
       - name: shellcheck
-        # -S warning: gate on real bugs (warning/error), not style/info nits — keeps
-        # the gate meaningful without a repo-wide style pass. Preinstalled on the
-        # ubuntu-latest runner image.
-        run: shellcheck -S warning hack/*.sh website/static/install.sh
+        # Default severity, deliberately: install.sh is fetched and executed by users
+        # over the network, so it is the last script in this repo that should sit
+        # behind a lowered gate. The one pre-existing info-level note that blocked the
+        # default was fixed rather than muted.
+        # Preinstalled on the ubuntu-latest runner image.
+        run: shellcheck hack/*.sh website/static/install.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,3 +43,8 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12.2
+      - name: shellcheck
+        # -S warning: gate on real bugs (warning/error), not style/info nits — keeps
+        # the gate meaningful without a repo-wide style pass. Preinstalled on the
+        # ubuntu-latest runner image.
+        run: shellcheck -S warning hack/*.sh website/static/install.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,16 +14,21 @@ go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint r
 - Linter config: [`.golangci.yml`](.golangci.yml) (golangci-lint **v2**). CI runs the same gate
   ([`.github/workflows/ci.yaml`](.github/workflows/ci.yaml)).
 
-## Try it — mock alert, end to end
+## Try it
 
 ```bash
-hack/demo.sh
+hack/demo.sh                 # a real investigation on recorded evidence (no cluster, no key)
+hack/demo-trigger-policy.sh  # fires mocked Alertmanager alerts through the trigger policy
 ```
 
-Builds `lore`, runs `lore serve`, and fires the mocked Alertmanager batch in
-[`examples/alertmanager-webhook.json`](examples/alertmanager-webhook.json) through the trigger
-policy — printing the investigate/skip decision per alert (covers match, dedup, severity/environment
-filters, ignore-list, and resolved-drop). That JSON shape is what Alertmanager/VMAlert POST.
+`hack/demo.sh` replays a recorded model transcript through the real investigation loop and
+renders a real verdict card — no cluster, no API key, no network.
+
+`hack/demo-trigger-policy.sh` builds `lore`, runs `lore serve`, and fires the mocked Alertmanager
+batch in [`examples/alertmanager-webhook.json`](examples/alertmanager-webhook.json) through the
+trigger policy — printing the investigate/skip decision per alert (covers match, dedup,
+severity/environment filters, ignore-list, and resolved-drop). That JSON shape is what
+Alertmanager/VMAlert POST.
 
 ## Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,8 @@ into a real cluster's catalog and `RUNLORE_POISON_READY` set, or it SKIPs.
 ## Quick local demo (no cluster)
 
 ```bash
-hack/demo.sh    # fires mocked Alertmanager alerts through the trigger policy
+hack/demo.sh                 # a real investigation on recorded evidence (no cluster, no key)
+hack/demo-trigger-policy.sh  # fires mocked Alertmanager alerts through the trigger policy
 ```
 
 ## Submitting a change

--- a/README.md
+++ b/README.md
@@ -170,31 +170,49 @@ additive. Full setup detail in **[Data sources](https://runlore.io/docs/concepts
 
 ## ⚡ Try it in one minute — no cluster, no keys
 
-Before you wire up a cluster, see the front of the pipeline for yourself. This runs `lore serve`
-locally with a keyless demo config and fires a batch of mocked Alertmanager alerts at it — no
-Kubernetes, no LLM, no credentials. You only need Go and `curl`:
+Before you wire up a cluster, watch RunLore investigate a real incident and reach a real root
+cause — no Kubernetes, no LLM key, no network. You only need Go:
 
 ```bash
 hack/demo.sh
 ```
 
-It builds the binary, starts the server, POSTs [`examples/alertmanager-webhook.json`](examples/alertmanager-webhook.json)
-to the webhook, and prints the **trigger policy** deciding which alerts become incidents:
+It builds the binary and replays a transcript recorded once against a live model through the
+**real investigation loop**: the same ReAct tool calls, verify pass, and verdict-card renderer
+that run in production, over fake (but realistic) evidence:
 
 ```text
-=== trigger-policy decisions ===
-msg=incident alert=HarborProbeFailure severity=critical namespace=apps investigate=true  reason="matched trigger policy"
-msg=incident alert=HarborProbeFailure severity=critical namespace=apps investigate=false reason="deduplicated (still-firing)"
-msg=incident alert=NoisyWarn        severity=warning  namespace=apps investigate=false reason="filtered by trigger policy"
-msg=incident alert=StagingCrit      severity=critical namespace=apps investigate=false reason="filtered by trigger policy"
-msg=incident alert=Watchdog         severity=critical namespace=apps investigate=false reason="filtered by trigger policy"
+== RunLore demo: investigating "harbor-chart-bump" (recorded model turns, fake providers, no cluster) ==
+   model turns recorded 2026-08-02T07:48:52Z with openai/glm-4.5-air
+
+incident: HarborProbeFailure (critical, prod, namespace apps): harbor-core readiness probes
+are failing and the Service is returning 503s.
+
+→ what_changed()
+  flux Kustomization/apps aaa111..bbb222 --- apps/harbor/values.yaml - tag: 1.14.2 + tag: 1.15.0 …
+→ query_metrics()
+  up{job="harbor-core"} = 0 kube_pod_container_status_restarts_total{pod="harbor-db-0"} = 7
+→ query_logs()
+  harbor-db-0 FATAL: could not obtain migration lock; another migration is in progress …
+
+== submit_findings ==
+*Investigation* — confidence 90%
+🔥 Verdict: Action required
+Resource: Deployment apps/harbor-core
+1. *Database migration deadlock preventing harbor-db pod from starting, causing harbor-core
+   connection failures* (90%)
+   • harbor-db-0 FATAL: could not obtain migration lock; another migration is in progress
+   • Chart bump to 1.15.0 enabled DB schema migrations
+   → suggested: Investigate and resolve the migration deadlock in harbor-db pod, then restart
+     the database to clear the lock (reversible)
 ```
 
-That's one alert admitted (critical + prod), the rest correctly deduped, severity-filtered,
-environment-filtered, and ignore-listed — the exact gate that controls noise and LLM cost in
-production. The demo stops there: a full investigation (root cause → chat → PR) needs a real cluster,
-an LLM, and a knowledge base, which is the production install below. To exercise every feature
-end-to-end on a throwaway cluster, `hack/e2e-k3d.sh` spins one up with [k3d](https://k3d.io/).
+That is a genuine root cause, not canned copy — recorded once against a live model, replayed
+forever with zero key and zero network. Wiring a cluster below gets you this over live evidence,
+with chat and knowledge-base write-back. Curious about the filter that decides what gets
+investigated in the first place? `hack/demo-trigger-policy.sh` fires mocked Alertmanager alerts
+through the trigger policy. To exercise every feature end-to-end on a throwaway cluster,
+`hack/e2e-k3d.sh` spins one up with [k3d](https://k3d.io/).
 
 ## 🚀 Getting started (production install)
 

--- a/cmd/lore/main.go
+++ b/cmd/lore/main.go
@@ -24,6 +24,7 @@ const usage = `lore — the RunLore SRE agent
 
 Usage:
   lore investigate --alert <name> [--namespace <ns>] [--message <text>]   investigate on-demand, print findings
+  lore demo investigate --offline default                watch a REAL recorded investigation — no cluster, no API key, no network
   lore demo investigate [--scenario <name>]           watch a full investigation against fake providers (no cluster; needs a model API key)
   lore serve [--config <path>] [--addr <addr>]        run the in-cluster agent (react to incidents)
   lore catalog sync [--config <path>]                 clone/pull + index the knowledge catalog

--- a/examples/demo/harbor-chart-bump.transcript.json
+++ b/examples/demo/harbor-chart-bump.transcript.json
@@ -1,0 +1,114 @@
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T07:48:52Z",
+  "recorded_with": {
+    "provider": "openai",
+    "model": "glm-4.5-air"
+  },
+  "turns": [
+    {
+      "text": "\nI'll investigate this incident step by step. Let me start by gathering evidence about recent changes and the current state of the harbor-core workload.\n",
+      "tool_calls": [
+        {
+          "ID": "call_f43af4dffff94251a3869de6",
+          "Name": "what_changed",
+          "Args": "{}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 2052,
+        "output_tokens": 184,
+        "cached_input_tokens": 43,
+        "cache_write_tokens": 0
+      }
+    },
+    {
+      "text": "\n",
+      "tool_calls": [
+        {
+          "ID": "call_3946acefa9ff402eb6415f5a",
+          "Name": "query_metrics",
+          "Args": "{}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 2150,
+        "output_tokens": 78,
+        "cached_input_tokens": 2054,
+        "cache_write_tokens": 0
+      }
+    },
+    {
+      "text": "\n",
+      "tool_calls": [
+        {
+          "ID": "call_59c4ddb122404f9f929826ee",
+          "Name": "query_logs",
+          "Args": "{}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 2197,
+        "output_tokens": 10,
+        "cached_input_tokens": 2152,
+        "cache_write_tokens": 0
+      }
+    },
+    {
+      "text": "\n",
+      "tool_calls": [
+        {
+          "ID": "call_a527eafc88ee4aa79d2a8ea9",
+          "Name": "network_drops",
+          "Args": "{}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 2251,
+        "output_tokens": 11,
+        "cached_input_tokens": 2206,
+        "cache_write_tokens": 0
+      }
+    },
+    {
+      "usage": {
+        "input_tokens": 2271,
+        "output_tokens": 34,
+        "cached_input_tokens": 2261,
+        "cache_write_tokens": 0
+      }
+    },
+    {
+      "text": "\n",
+      "tool_calls": [
+        {
+          "ID": "call_e9c73ae5b5044e3fb75b885e",
+          "Name": "submit_findings",
+          "Args": "{\"title\":\"Harbor Core Readiness Probe Failure Due to Database Migration Deadlock\",\"affected_resource\":{\"kind\": \"Deployment\", \"name\": \"harbor-core\", \"namespace\": \"apps\"},\"verdict\":\"action_required\",\"confidence\":0.9,\"root_causes\":[{\"summary\": \"Database migration deadlock preventing harbor-db pod from starting, causing harbor-core connection failures\", \"confidence\": 0.9, \"evidence\": [\"harbor-db-0 FATAL: could not obtain migration lock; another migration is in progress\", \"harbor-core dial tcp harbor-db:5432: connect: connection refused\", \"harbor-db-0 has 7 restarts\", \"Chart bump to 1.15.0 enabled DB schema migrations\"], \"suggested_action\": \"Investigate and resolve the migration deadlock in harbor-db pod, then restart the database to clear the lock\", \"reversible\": true}],\"unresolved\":[\"Exact cause of the migration deadlock (stuck migration, resource contention, or other)\", \"Data integrity concerns after clearing migration lock\"],\"data_gaps\":[\"Detailed database pod logs showing the specific migration that's stuck\", \"Database resource usage metrics to check for resource contention\"],\"ruled_out\":[\"Network connectivity issues - no network drops detected\", \"Resource constraints - no evidence of insufficient cpu/memory in logs\"]}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 2307,
+        "output_tokens": 765,
+        "cached_input_tokens": 2273,
+        "cache_write_tokens": 0
+      }
+    },
+    {
+      "tool_calls": [
+        {
+          "ID": "call_b5b7cc43e3f84c9eaf60a4f7",
+          "Name": "submit_verdicts",
+          "Args": "{\"verdicts\":[{\"index\": 0, \"verdict\": \"keep\", \"confidence\": 0.90, \"reason\": \"Strong causal evidence: chart bump enabled DB migrations, migration lock error prevents pod startup, connection failures confirmed, and 7 restarts show persistence of the issue.\"}]}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 806,
+        "output_tokens": 455,
+        "cached_input_tokens": 43,
+        "cache_write_tokens": 0
+      }
+    }
+  ]
+}

--- a/hack/demo-trigger-policy.sh
+++ b/hack/demo-trigger-policy.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Trigger-policy demo: run `lore serve` and fire mocked Alertmanager alerts through
+# the trigger policy, showing which alerts become incidents (match, dedup,
+# wrong-severity, wrong-environment, ignore-list, resolved).
+#
+# This shows the FILTER, not the investigation. For the investigation — a real root
+# cause, keyless — run hack/demo.sh.
+#
+# Usage: hack/demo-trigger-policy.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ADDR=":18080"
+BIN="$(mktemp -d)/lore"
+CFG="$ROOT/hack/demo.config.yaml"   # committed + parse-tested (internal/config)
+LOG="$(mktemp)"
+
+go build -o "$BIN" "$ROOT/cmd/lore"
+
+"$BIN" serve --config "$CFG" --addr "$ADDR" > "$LOG" 2>&1 &
+SRV=$!
+trap 'kill "$SRV" 2>/dev/null || true' EXIT
+
+# Wait for the server, then fire the mock alerts.
+curl -s --retry-connrefused --retry 10 --retry-delay 1 -o /dev/null "http://localhost${ADDR}/healthz"
+curl -s -o /dev/null -w 'webhook HTTP %{http_code}\n' \
+  -XPOST "http://localhost${ADDR}/webhook/alertmanager" \
+  --data @"$ROOT/examples/alertmanager-webhook.json"
+
+echo "=== trigger-policy decisions ==="
+grep "msg=incident" "$LOG"

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -1,30 +1,16 @@
 #!/usr/bin/env bash
-# Demo: run `lore serve` and fire mocked Alertmanager alerts through the trigger policy.
+# Demo: a REAL RunLore investigation, on recorded evidence, with no cluster, no API
+# key and no network. The model turns are replayed from a transcript recorded once
+# against a live model (examples/demo/*.transcript.json); the tools, the
+# investigation loop and the rendered verdict card are the production code paths.
 #
-# The Alertmanager webhook JSON is the mock "event". examples/alertmanager-webhook.json
-# exercises every policy path: match, dedup (repeated fingerprint), wrong-severity,
-# wrong-environment, ignore-list, and a resolved alert (dropped before the decision).
-#
+# Requires: Go. Nothing else.
 # Usage: hack/demo.sh
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-ADDR=":18080"
 BIN="$(mktemp -d)/lore"
-CFG="$ROOT/hack/demo.config.yaml"   # committed + parse-tested (internal/config)
-LOG="$(mktemp)"
 
 go build -o "$BIN" "$ROOT/cmd/lore"
-
-"$BIN" serve --config "$CFG" --addr "$ADDR" > "$LOG" 2>&1 &
-SRV=$!
-trap 'kill "$SRV" 2>/dev/null || true' EXIT
-
-# Wait for the server, then fire the mock alerts.
-curl -s --retry-connrefused --retry 10 --retry-delay 1 -o /dev/null "http://localhost${ADDR}/healthz"
-curl -s -o /dev/null -w 'webhook HTTP %{http_code}\n' \
-  -XPOST "http://localhost${ADDR}/webhook/alertmanager" \
-  --data @"$ROOT/examples/alertmanager-webhook.json"
-
-echo "=== trigger-policy decisions ==="
-grep "msg=incident" "$LOG"
+cd "$ROOT"          # the transcript + scenario paths are repo-relative
+"$BIN" demo investigate --offline default

--- a/hack/e2e-local.sh
+++ b/hack/e2e-local.sh
@@ -40,7 +40,7 @@ step()  { printf '\n\033[1;36m== %s ==\033[0m\n' "$*"; }
 free_port() {
   local pid
   pid=$(ss -ltnp 2>/dev/null | grep ":$1 " | grep -oP 'pid=\K[0-9]+' | head -1) || true
-  [[ -n "$pid" ]] && kill "$pid" 2>/dev/null || true
+  if [[ -n "$pid" ]]; then kill "$pid" 2>/dev/null || true; fi
 }
 
 # ---------------------------------------------------------------------------
@@ -140,7 +140,7 @@ provider_host() {
 # ---------------------------------------------------------------------------
 
 cleanup() {
-  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null || true
+  if [[ -n "$MOCK_PID" ]]; then kill "$MOCK_PID" 2>/dev/null || true; fi
   free_port "$MOCK_PORT"; free_port 9998
   if [[ "$KEEP" == "0" ]]; then
     provider_delete_cluster

--- a/hack/e2e-local.sh
+++ b/hack/e2e-local.sh
@@ -789,4 +789,9 @@ step "RESULTS"
 echo "PASS=$PASS FAIL=$FAIL"
 echo "--- runlore.log (tail) ---"; tail -n 15 /tmp/runlore.log
 echo "--- mock.log (tail) ---";   tail -n 15 /tmp/runlore-mock.log
-[[ "$FAIL" == "0" ]] && green "ALL FEATURES VERIFIED" || { red "$FAIL CHECK(S) FAILED"; exit 1; }
+if [[ "$FAIL" == "0" ]]; then
+  green "ALL FEATURES VERIFIED"
+else
+  red "$FAIL CHECK(S) FAILED"
+  exit 1
+fi

--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -88,31 +88,20 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 	if len(cases) == 0 {
 		return fmt.Errorf("no scenarios found in %s", *scenariosDir)
 	}
-	c, err := pickScenario(cases, *scenario)
-	if err != nil {
-		return err
-	}
 
 	cfg, apiKeyEnv, err := demoConfig(*cfgPath)
 	if err != nil {
 		return err
 	}
 
-	// Resolve the model. Three paths, in precedence order:
-	//   1. a test-injected model (the existing seam) — used verbatim;
-	//   2. --offline — replay a recorded transcript: no key, no network;
-	//   3. the live model built from config, optionally wrapped by --record.
-	//
-	// Paths 1 and 2 both answer the verify turns from the SAME model (verifyModel is
-	// nil), because a transcript is one ordered stream. --record forces the same
-	// shape, so what is recorded is exactly what will later replay.
-	verifyModel := BuildVerifyModel(cfg)
+	// --offline replays a transcript, so load it before picking the scenario: with no
+	// explicit --scenario, the transcript's OWN Scenario field is the default. Without
+	// this, an omitted --scenario would fall back to the first scenario in the
+	// directory, which need not be the one the transcript was recorded against — the
+	// demo would then announce one incident and replay tool calls for another.
+	scenarioID := *scenario
 	var transcript *replay.Transcript
-	var recorder *replay.Recorder
-	switch {
-	case model != nil:
-		verifyModel = nil // the injected model answers verify turns itself
-	case *offline != "":
+	if model == nil && *offline != "" {
 		path := *offline
 		if path == "default" {
 			path = demoDefaultTranscript
@@ -121,7 +110,31 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 		if err != nil {
 			return err
 		}
-		transcript, model, verifyModel = t, replay.New(t), nil
+		transcript = t
+		if scenarioID == "" {
+			scenarioID = t.Scenario
+		}
+	}
+	c, err := pickScenario(cases, scenarioID)
+	if err != nil {
+		return err
+	}
+
+	// Resolve the model. Three paths, in precedence order:
+	//   1. a test-injected model (the existing seam) — used verbatim;
+	//   2. --offline — replay the transcript loaded above: no key, no network;
+	//   3. the live model built from config, optionally wrapped by --record.
+	//
+	// Paths 1 and 2 both answer the verify turns from the SAME model (verifyModel is
+	// nil), because a transcript is one ordered stream. --record forces the same
+	// shape, so what is recorded is exactly what will later replay.
+	verifyModel := BuildVerifyModel(cfg)
+	var recorder *replay.Recorder
+	switch {
+	case model != nil:
+		verifyModel = nil // the injected model answers verify turns itself
+	case transcript != nil:
+		model, verifyModel = replay.New(transcript), nil
 	default:
 		if apiKeyEnv != "" && os.Getenv(apiKeyEnv) == "" {
 			return fmt.Errorf("the demo needs a model API key: set %s to your key "+

--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -9,11 +9,13 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/eval"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logging"
+	"github.com/Smana/runlore/internal/model/replay"
 	"github.com/Smana/runlore/internal/notify"
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -32,6 +34,12 @@ const (
 	demoDefaultModel    = "claude-sonnet-4-5"
 	demoDefaultKeyEnv   = "ANTHROPIC_API_KEY"
 )
+
+// demoDefaultTranscript is the recorded transcript `--offline` replays when no path
+// is given: a REAL investigation captured once against a live model, so a first-time
+// user sees genuine model output with no key and no network. Re-record it with
+// `lore demo investigate --record <path>`.
+const demoDefaultTranscript = "examples/demo/harbor-chart-bump.transcript.json"
 
 // RunDemo dispatches the `lore demo <subcommand>` family. Today only `investigate` is
 // wired: a zero-cluster, full-loop demonstration of the real investigator against fake
@@ -67,6 +75,8 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 	scenario := fs.String("scenario", "", "scenario id to run (default: the first in --scenarios)")
 	scenariosDir := fs.String("scenarios", demoDefaultScenarios, "directory of curated scenario fixtures")
 	cfgPath := fs.String("config", "", "optional runlore.yaml; when omitted the demo uses a zero-config default model")
+	offline := fs.String("offline", "", "replay a recorded transcript instead of calling a model — no API key, no network (use \"default\" for the shipped one)")
+	record := fs.String("record", "", "record this run's model turns to a transcript file for later --offline replay")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -88,14 +98,35 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 		return err
 	}
 
-	// Build the real model unless the test injected one. When building it, insist on a
-	// model API key first (the one thing the demo genuinely needs) and fail with clear,
-	// friendly guidance rather than a stack trace or a hang on the first model call.
+	// Resolve the model. Three paths, in precedence order:
+	//   1. a test-injected model (the existing seam) — used verbatim;
+	//   2. --offline — replay a recorded transcript: no key, no network;
+	//   3. the live model built from config, optionally wrapped by --record.
+	//
+	// Paths 1 and 2 both answer the verify turns from the SAME model (verifyModel is
+	// nil), because a transcript is one ordered stream. --record forces the same
+	// shape, so what is recorded is exactly what will later replay.
 	verifyModel := BuildVerifyModel(cfg)
-	if model == nil {
+	var transcript *replay.Transcript
+	var recorder *replay.Recorder
+	switch {
+	case model != nil:
+		verifyModel = nil // the injected model answers verify turns itself
+	case *offline != "":
+		path := *offline
+		if path == "default" {
+			path = demoDefaultTranscript
+		}
+		t, err := replay.Load(path)
+		if err != nil {
+			return err
+		}
+		transcript, model, verifyModel = t, replay.New(t), nil
+	default:
 		if apiKeyEnv != "" && os.Getenv(apiKeyEnv) == "" {
 			return fmt.Errorf("the demo needs a model API key: set %s to your key "+
-				"(or point --config at a runlore.yaml with a configured model). "+
+				"(or point --config at a runlore.yaml with a configured model, or run with "+
+				"--offline default to replay a recorded investigation with no key at all). "+
 				"Everything else runs against built-in fake providers — no cluster required", apiKeyEnv)
 		}
 		apiKey := ""
@@ -103,14 +134,23 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 			apiKey = os.Getenv(apiKeyEnv)
 		}
 		model = BuildModel(cfg, apiKey)
-	} else {
-		verifyModel = nil // the scripted test model answers verify turns itself
+		if *record != "" {
+			recorder = replay.NewRecorder(model,
+				replay.Recorded{Provider: cfg.Model.Provider, Model: cfg.Model.Model}, c.DisplayName())
+			model, verifyModel = recorder, nil // record one ordered stream, replayable as-is
+		}
 	}
 
 	log := logging.FromConfig(errOut, cfg.Logging.Format, cfg.Logging.Level)
 	ctx := context.Background()
 
-	demoPrintf(out, "== RunLore demo: investigating %q (fake providers, no cluster) ==\n\n", c.DisplayName())
+	if transcript != nil {
+		demoPrintf(out, "== RunLore demo: investigating %q (recorded model turns, fake providers, no cluster) ==\n", c.DisplayName())
+		demoPrintf(out, "   model turns recorded %s with %s/%s\n\n",
+			transcript.RecordedAt, transcript.RecordedWith.Provider, transcript.RecordedWith.Model)
+	} else {
+		demoPrintf(out, "== RunLore demo: investigating %q (fake providers, no cluster) ==\n\n", c.DisplayName())
+	}
 	demoPrintf(out, "incident: %s\n\n", oneLineIndent(c.Symptom()))
 
 	// Wrap each fake tool so every ReAct step (tool name + short args + truncated
@@ -145,6 +185,13 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 		return fmt.Errorf("the loop produced no findings")
 	}
 	demoPrintf(out, "\n== submit_findings ==\n%s\n", notify.Format(*result))
+
+	if recorder != nil {
+		if err := recorder.Write(*record, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("write transcript: %w", err)
+		}
+		demoPrintf(out, "\ntranscript written to %s — replay it with `lore demo investigate --offline %s`\n", *record, *record)
+	}
 	return nil
 }
 

--- a/internal/app/demo_test.go
+++ b/internal/app/demo_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Smana/runlore/internal/eval"
+	"github.com/Smana/runlore/internal/model/replay"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -113,6 +115,41 @@ func TestDemoOfflineThroughSeam(t *testing.T) {
 	}
 }
 
+// TestDemoOfflineDefaultsScenarioToTranscript is the regression guard for the bug
+// where `--offline` with no `--scenario` fell back to pickScenario's default: the
+// FIRST scenario in the directory (alphabetically, "crashloop-after-deploy"), not the
+// scenario the shipped transcript was actually recorded against ("harbor-chart-bump").
+// That mismatch made the demo announce one incident while replaying tool calls and a
+// verdict for a completely different one — exactly what a first-time visitor sees.
+// This replays the real shipped transcript with NO --scenario and asserts the
+// rendered incident is the transcript's own scenario, not the directory's first entry.
+func TestDemoOfflineDefaultsScenarioToTranscript(t *testing.T) {
+	tr, err := replay.Load("../../" + demoDefaultTranscript)
+	if err != nil {
+		t.Fatalf("load shipped transcript: %v", err)
+	}
+	if tr.Scenario != "harbor-chart-bump" {
+		t.Fatalf("test assumes the shipped transcript is scenario %q, got %q — update the assertions below", "harbor-chart-bump", tr.Scenario)
+	}
+
+	var out, errOut bytes.Buffer
+	err = runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--offline", "../../" + demoDefaultTranscript,
+	}, &out, &errOut, nil)
+	if err != nil {
+		t.Fatalf("demo --offline with no --scenario: %v\nstderr:\n%s", err, errOut.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "HarborProbeFailure") {
+		t.Errorf("expected the transcript's own scenario (harbor-chart-bump) announced, got:\n%s", got)
+	}
+	if strings.Contains(got, "CheckoutPodCrashLoop") {
+		t.Errorf("demo announced the directory's first scenario (crashloop-after-deploy) instead of the transcript's own, got:\n%s", got)
+	}
+}
+
 // TestDemoOfflineNeedsNoAPIKey proves the key check is skipped on the offline path —
 // the whole point of --offline.
 func TestDemoOfflineNeedsNoAPIKey(t *testing.T) {
@@ -124,5 +161,36 @@ func TestDemoOfflineNeedsNoAPIKey(t *testing.T) {
 		"--offline", "testdata/demo-transcript.json",
 	}, &out, &errOut, nil); err != nil {
 		t.Fatalf("offline demo must not require a key, got: %v", err)
+	}
+}
+
+// TestShippedTranscriptToolsStillExist is the DRIFT GUARD over the fixture the demo
+// actually ships. Every tool the transcript calls must still be registered by the
+// demo's fixture tools; a renamed or removed tool fails CI here instead of breaking
+// the demo silently for every new visitor.
+func TestShippedTranscriptToolsStillExist(t *testing.T) {
+	tr, err := replay.Load("../../" + demoDefaultTranscript)
+	if err != nil {
+		t.Fatalf("load shipped transcript: %v", err)
+	}
+	cases, err := eval.Load("../../examples/scenarios")
+	if err != nil {
+		t.Fatalf("load scenarios: %v", err)
+	}
+	c, err := pickScenario(cases, tr.Scenario)
+	if err != nil {
+		t.Fatalf("the transcript's scenario %q is gone: %v", tr.Scenario, err)
+	}
+	have := map[string]bool{
+		// Loop-control tools are answered by the loop itself, not the fixture set.
+		"submit_findings": true, "submit_verdicts": true,
+	}
+	for _, tool := range c.FakeTools() {
+		have[tool.Name()] = true
+	}
+	for _, name := range tr.ToolNames() {
+		if !have[name] {
+			t.Errorf("shipped transcript calls tool %q, which no longer exists — re-record with `lore demo investigate --record %s`", name, demoDefaultTranscript)
+		}
 	}
 }

--- a/internal/app/demo_test.go
+++ b/internal/app/demo_test.go
@@ -86,3 +86,43 @@ func TestRunDemoInvestigateUnknownScenario(t *testing.T) {
 		t.Errorf("error should name the missing scenario and list the available ones, got: %v", err)
 	}
 }
+
+// TestDemoOfflineThroughSeam is the funnel guarantee: with NO api key and NO network,
+// `demo investigate --offline` drives the real loop over the real fixture tools and
+// renders the real verdict card. This is what hack/demo.sh shows a first-time
+// visitor. It asserts through the same writer seam the existing end-to-end test uses.
+func TestDemoOfflineThroughSeam(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump",
+		"--offline", "testdata/demo-transcript.json",
+	}, &out, &errOut, nil)
+	if err != nil {
+		t.Fatalf("demo --offline: %v\nstderr:\n%s", err, errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{"→ what_changed", "submit_findings", "migration"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q, got:\n%s", want, got)
+		}
+	}
+	// Provenance: a replayed card must say it is replayed, and name the model.
+	if !strings.Contains(got, "recorded") {
+		t.Errorf("output must disclose that the model turns are recorded, got:\n%s", got)
+	}
+}
+
+// TestDemoOfflineNeedsNoAPIKey proves the key check is skipped on the offline path —
+// the whole point of --offline.
+func TestDemoOfflineNeedsNoAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	var out, errOut bytes.Buffer
+	if err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump",
+		"--offline", "testdata/demo-transcript.json",
+	}, &out, &errOut, nil); err != nil {
+		t.Fatalf("offline demo must not require a key, got: %v", err)
+	}
+}

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -106,7 +106,10 @@ func disabledTools(cfg *config.Config) []string {
 	if cfg.Logs.URL == "" {
 		off = append(off, "logs (query_logs)")
 	}
-	if cfg.Catalog.Dir == "" && cfg.Catalog.Git.URL == "" {
+	// Reuse the enablement helper rather than restating its condition: the notice
+	// must name exactly what the tool wiring actually gates on, and two copies of
+	// that rule would eventually disagree.
+	if !CatalogConfigured(cfg) {
 		off = append(off, "knowledge catalog (kb_search, instant recall)")
 	}
 	return off

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/Smana/runlore/internal/action"
-	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logging"
 	"github.com/Smana/runlore/internal/notify"
@@ -19,7 +18,7 @@ import (
 // RunInvestigate runs a single on-demand investigation and prints the findings.
 func RunInvestigate(args []string) error {
 	fs := flag.NewFlagSet("investigate", flag.ContinueOnError)
-	cfgPath := fs.String("config", "runlore.yaml", "path to config file")
+	cfgPath := fs.String("config", "", "path to config file (default: ./runlore.yaml if present, else the environment)")
 	alert := fs.String("alert", "", "alert/symptom name to investigate")
 	namespace := fs.String("namespace", "", "namespace of the affected workload")
 	message := fs.String("message", "", "free-text symptom description")
@@ -29,7 +28,12 @@ func RunInvestigate(args []string) error {
 	if *alert == "" && *message == "" {
 		return fmt.Errorf("provide --alert and/or --message")
 	}
-	cfg, err := config.Load(*cfgPath)
+	explicit := *cfgPath != ""
+	path := *cfgPath
+	if path == "" {
+		path = defaultConfigPath
+	}
+	cfg, err := resolveInvestigateConfig(path, explicit)
 	if err != nil {
 		return err
 	}

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -7,8 +7,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Smana/runlore/internal/action"
+	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logging"
 	"github.com/Smana/runlore/internal/notify"
@@ -22,6 +24,10 @@ func RunInvestigate(args []string) error {
 	alert := fs.String("alert", "", "alert/symptom name to investigate")
 	namespace := fs.String("namespace", "", "namespace of the affected workload")
 	message := fs.String("message", "", "free-text symptom description")
+	modelName := fs.String("model", "", "override the model name")
+	baseURL := fs.String("base-url", "", "override the OpenAI-compatible endpoint")
+	metricsURL := fs.String("metrics-url", "", "PromQL endpoint — enables query_metrics")
+	logsURL := fs.String("logs-url", "", "logs endpoint — enables query_logs")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -37,8 +43,26 @@ func RunInvestigate(args []string) error {
 	if err != nil {
 		return err
 	}
+	// Flags override the resolved config. They are how a user points the CLI at their
+	// stack without writing a file.
+	if *modelName != "" {
+		cfg.Model.Model = *modelName
+	}
+	if *baseURL != "" {
+		cfg.Model.BaseURL = *baseURL
+	}
+	if *metricsURL != "" {
+		cfg.Metrics.URL = *metricsURL
+	}
+	if *logsURL != "" {
+		cfg.Logs.URL = *logsURL
+	}
 	if !ModelConfigured(cfg) {
 		return fmt.Errorf("investigate requires a configured model (set config.model)")
+	}
+	if off := disabledTools(cfg); len(off) > 0 {
+		fmt.Fprintf(os.Stderr, "note: running without %s — pass --metrics-url/--logs-url or a --config to enable them\n",
+			strings.Join(off, ", "))
 	}
 	// Progress logs go to stderr; the findings go to stdout.
 	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
@@ -69,4 +93,21 @@ func RunInvestigate(args []string) error {
 	}
 	fmt.Println(notify.Format(*result))
 	return nil
+}
+
+// disabledTools names the investigation signals this run will NOT have, so a thin
+// answer is explainable rather than mysterious. The CLI deliberately degrades
+// instead of demanding a full stack — but silence about it would look like a bug.
+func disabledTools(cfg *config.Config) []string {
+	var off []string
+	if cfg.Metrics.URL == "" {
+		off = append(off, "metrics (query_metrics)")
+	}
+	if cfg.Logs.URL == "" {
+		off = append(off, "logs (query_logs)")
+	}
+	if cfg.Catalog.Dir == "" && cfg.Catalog.Git.URL == "" {
+		off = append(off, "knowledge catalog (kb_search, instant recall)")
+	}
+	return off
 }

--- a/internal/app/investigate_config.go
+++ b/internal/app/investigate_config.go
@@ -54,7 +54,13 @@ func resolveInvestigateConfig(path string, explicit bool) (*config.Config, error
 // configFromEnv synthesizes a minimal, model-only config from the environment. Every
 // data source stays unset, so each disables its own tool — no cluster, no Flux, no
 // KB repo, no forge and no notifier are required to get an answer.
+//
+// The returned config is run through config.ApplyDefaults before it is handed back,
+// same as one read by config.Load — otherwise fields like Investigation.Timeout
+// would stay at their zero value here while a loaded config gets ApplyDefaults'
+// 10m, and an environment-only investigation would run with no deadline at all.
 func configFromEnv() (*config.Config, error) {
+	var cfg *config.Config
 	switch {
 	case os.Getenv(envOpenAIBaseURL) != "":
 		m := config.Model{
@@ -66,19 +72,21 @@ func configFromEnv() (*config.Config, error) {
 		if os.Getenv(envOpenAIKey) != "" {
 			m.APIKeyEnv = envOpenAIKey
 		}
-		return &config.Config{Model: m}, nil
+		cfg = &config.Config{Model: m}
 	case os.Getenv(envAnthropicKey) != "":
-		return &config.Config{Model: config.Model{
+		cfg = &config.Config{Model: config.Model{
 			Provider:  "anthropic",
 			Model:     defaultAnthropicModel,
 			APIKeyEnv: envAnthropicKey,
-		}}, nil
+		}}
 	default:
 		return nil, fmt.Errorf(
 			"no model configured: set %s (+ optional %s / %s) for an OpenAI-compatible endpoint, "+
 				"or %s for Anthropic — or write a %s and pass it with --config",
 			envOpenAIBaseURL, envOpenAIKey, envOpenAIModel, envAnthropicKey, defaultConfigPath)
 	}
+	config.ApplyDefaults(cfg)
+	return cfg, nil
 }
 
 // or returns a when non-empty, else b.

--- a/internal/app/investigate_config.go
+++ b/internal/app/investigate_config.go
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// defaultConfigPath is the config `lore investigate` looks for when --config is not
+// given. Its ABSENCE is not an error: the CLI is the laptop-to-value front door, and
+// requiring a YAML file before the first answer is the friction this removes.
+const defaultConfigPath = "runlore.yaml"
+
+// Env vars the zero-config path reads, in precedence order. They are the names the
+// ecosystem already uses, so a user who has run any OpenAI-compatible or Anthropic
+// tool already has them exported.
+const (
+	envOpenAIBaseURL = "OPENAI_BASE_URL"
+	envOpenAIKey     = "OPENAI_API_KEY"
+	envOpenAIModel   = "OPENAI_MODEL"
+	envAnthropicKey  = "ANTHROPIC_API_KEY"
+
+	// defaultOpenAIModel / defaultAnthropicModel are used when the endpoint is known
+	// but the model name is not. A local vLLM/Ollama commonly serves one model, and
+	// naming it wrongly fails loudly at the first call rather than silently.
+	defaultOpenAIModel    = "gpt-4o-mini"
+	defaultAnthropicModel = "claude-sonnet-5"
+)
+
+// resolveInvestigateConfig loads the config for a one-off investigation.
+//
+//	explicit=true  (--config was given): a missing file is an ERROR. Falling back
+//	               would run against a different model than the user asked for.
+//	explicit=false (default path): a missing file falls back to the environment.
+func resolveInvestigateConfig(path string, explicit bool) (*config.Config, error) {
+	cfg, err := config.Load(path)
+	switch {
+	case err == nil:
+		return cfg, nil
+	case explicit:
+		return nil, err
+	case !errors.Is(err, fs.ErrNotExist):
+		// The file exists but is broken — never paper over that with env guesses.
+		return nil, err
+	}
+	return configFromEnv()
+}
+
+// configFromEnv synthesizes a minimal, model-only config from the environment. Every
+// data source stays unset, so each disables its own tool — no cluster, no Flux, no
+// KB repo, no forge and no notifier are required to get an answer.
+func configFromEnv() (*config.Config, error) {
+	switch {
+	case os.Getenv(envOpenAIBaseURL) != "":
+		m := config.Model{
+			BaseURL: os.Getenv(envOpenAIBaseURL),
+			Model:   or(os.Getenv(envOpenAIModel), defaultOpenAIModel),
+		}
+		// Keyless is a first-class case here: an in-cluster vLLM or a local Ollama
+		// needs no credential, and demanding one would break the most private setup.
+		if os.Getenv(envOpenAIKey) != "" {
+			m.APIKeyEnv = envOpenAIKey
+		}
+		return &config.Config{Model: m}, nil
+	case os.Getenv(envAnthropicKey) != "":
+		return &config.Config{Model: config.Model{
+			Provider:  "anthropic",
+			Model:     defaultAnthropicModel,
+			APIKeyEnv: envAnthropicKey,
+		}}, nil
+	default:
+		return nil, fmt.Errorf(
+			"no model configured: set %s (+ optional %s / %s) for an OpenAI-compatible endpoint, "+
+				"or %s for Anthropic — or write a %s and pass it with --config",
+			envOpenAIBaseURL, envOpenAIKey, envOpenAIModel, envAnthropicKey, defaultConfigPath)
+	}
+}
+
+// or returns a when non-empty, else b.
+func or(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/app/investigate_config_test.go
+++ b/internal/app/investigate_config_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Smana/runlore/internal/config"
 )
 
 // TestResolveFromOpenAIEnv: with no runlore.yaml, an OpenAI-compatible endpoint in the
@@ -156,5 +158,34 @@ func TestConfigFromEnvGetsInvestigationDefaults(t *testing.T) {
 	if envCfg.Investigation.Timeout != fileCfg.Investigation.Timeout {
 		t.Errorf("env-synthesized timeout = %v, want the loaded-config default %v",
 			envCfg.Investigation.Timeout, fileCfg.Investigation.Timeout)
+	}
+}
+
+// TestDisabledToolsNamesWhatIsOff: a thin answer must be explainable. When metrics,
+// logs and the catalog are unset, the command says so once on stderr rather than
+// leaving the user wondering why the agent never looked at their dashboards.
+func TestDisabledToolsNamesWhatIsOff(t *testing.T) {
+	cfg := &config.Config{Model: config.Model{Model: "m", BaseURL: "http://x/v1"}}
+	got := disabledTools(cfg)
+	joined := strings.Join(got, " ")
+	for _, want := range []string{"metrics", "logs", "knowledge catalog"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("disabledTools() = %v, must mention %q", got, want)
+		}
+	}
+}
+
+// TestDisabledToolsSilentWhenWired: nothing to warn about when everything is set.
+// Note the shapes: config.MetricsConfig and config.LogsConfig embed config.Endpoint
+// inline (config.go:116, :131, :76), so URL is set through the embedded struct.
+func TestDisabledToolsSilentWhenWired(t *testing.T) {
+	cfg := &config.Config{
+		Model:   config.Model{Model: "m", BaseURL: "http://x/v1"},
+		Metrics: config.MetricsConfig{Endpoint: config.Endpoint{URL: "http://vm:8429"}},
+		Logs:    config.LogsConfig{Endpoint: config.Endpoint{URL: "http://vl:9428"}},
+		Catalog: config.Catalog{Dir: "/kb"},
+	}
+	if got := disabledTools(cfg); len(got) != 0 {
+		t.Errorf("disabledTools() = %v, want none", got)
 	}
 }

--- a/internal/app/investigate_config_test.go
+++ b/internal/app/investigate_config_test.go
@@ -100,3 +100,61 @@ func TestExistingConfigWins(t *testing.T) {
 		t.Errorf("model = %q, want the file's value", cfg.Model.Model)
 	}
 }
+
+// TestMalformedDefaultConfigIsError: a runlore.yaml that EXISTS at the default path
+// but fails to parse (here: an unknown key, rejected by config.Load's
+// KnownFields(true)) must be a hard error — never papered over by falling back to
+// environment synthesis. Silently synthesizing here would run the investigation
+// against a guessed model while hiding the operator's broken file from them. Valid
+// model env vars are set precisely so a bug that ignores the parse error and falls
+// through to configFromEnv would otherwise succeed unnoticed.
+func TestMalformedDefaultConfigIsError(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	if err := os.WriteFile(filepath.Join(dir, defaultConfigPath), []byte(
+		"model:\n  not_a_real_field: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err == nil {
+		t.Fatal("a malformed default config must be an error, not silently replaced by env synthesis")
+	}
+}
+
+// TestConfigFromEnvGetsInvestigationDefaults: the synthesized (zero-config) path
+// must reach config.ApplyDefaults exactly as a loaded one does. Without this, a
+// zero-config investigation runs with Investigation.Timeout == 0, and
+// LoopInvestigator.Investigate only applies a deadline when Timeout > 0 — i.e. no
+// deadline at all, while the identical command with a minimal runlore.yaml gets the
+// defaulted 10m. This test pins that the two construction paths cannot diverge.
+func TestConfigFromEnvGetsInvestigationDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+	envCfg, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err != nil {
+		t.Fatalf("resolve (env): %v", err)
+	}
+	if envCfg.Investigation.Timeout == 0 {
+		t.Fatal("zero-config path: Investigation.Timeout must be defaulted (non-zero), got 0 (no per-investigation deadline)")
+	}
+
+	// A minimal, real runlore.yaml with the same model settings must produce the
+	// SAME defaulted timeout — the two paths are not allowed to disagree.
+	fileDir := t.TempDir()
+	filePath := filepath.Join(fileDir, "runlore.yaml")
+	if err := os.WriteFile(filePath, []byte(
+		"model:\n  provider: anthropic\n  model: claude-sonnet-5\n  api_key_env: ANTHROPIC_API_KEY\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fileCfg, err := resolveInvestigateConfig(filePath, true)
+	if err != nil {
+		t.Fatalf("resolve (file): %v", err)
+	}
+	if envCfg.Investigation.Timeout != fileCfg.Investigation.Timeout {
+		t.Errorf("env-synthesized timeout = %v, want the loaded-config default %v",
+			envCfg.Investigation.Timeout, fileCfg.Investigation.Timeout)
+	}
+}

--- a/internal/app/investigate_config_test.go
+++ b/internal/app/investigate_config_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveFromOpenAIEnv: with no runlore.yaml, an OpenAI-compatible endpoint in the
+// environment is enough to investigate. This is the laptop-to-value path — no config
+// ceremony before the first answer.
+func TestResolveFromOpenAIEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("OPENAI_BASE_URL", "http://localhost:8000/v1")
+	t.Setenv("OPENAI_MODEL", "qwen3-30b")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	cfg, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cfg.Model.BaseURL != "http://localhost:8000/v1" {
+		t.Errorf("base_url = %q, want the env value", cfg.Model.BaseURL)
+	}
+	if cfg.Model.Model != "qwen3-30b" {
+		t.Errorf("model = %q, want the env value", cfg.Model.Model)
+	}
+	// Keyless is legitimate here: a local vLLM/Ollama needs no key.
+	if cfg.Model.APIKeyEnv != "" && os.Getenv(cfg.Model.APIKeyEnv) != "" {
+		t.Errorf("expected keyless, got api_key_env=%q", cfg.Model.APIKeyEnv)
+	}
+}
+
+// TestResolveFromAnthropicEnv: the other zero-config path.
+func TestResolveFromAnthropicEnv(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+	cfg, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cfg.Model.Provider != "anthropic" {
+		t.Errorf("provider = %q, want anthropic", cfg.Model.Provider)
+	}
+	if cfg.Model.APIKeyEnv != "ANTHROPIC_API_KEY" {
+		t.Errorf("api_key_env = %q, want ANTHROPIC_API_KEY", cfg.Model.APIKeyEnv)
+	}
+}
+
+// TestResolveWithNoEnvExplainsBothPaths: the error a first-time user hits must tell
+// them exactly what to set, not just that something is missing.
+func TestResolveWithNoEnvExplainsBothPaths(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	_, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err == nil {
+		t.Fatal("expected an error with no config and no env")
+	}
+	for _, want := range []string{"OPENAI_BASE_URL", "ANTHROPIC_API_KEY", "runlore.yaml"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestExplicitMissingConfigStillErrors: silence here would hide a typo'd --config
+// path behind a surprise zero-config run against the wrong model.
+func TestExplicitMissingConfigStillErrors(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	_, err := resolveInvestigateConfig(filepath.Join(t.TempDir(), "typo.yaml"), true)
+	if err == nil {
+		t.Fatal("an explicitly named missing config must be an error")
+	}
+}
+
+// TestExistingConfigWins: a real runlore.yaml is an explicit statement of intent and
+// must never be silently replaced by environment guesses.
+func TestExistingConfigWins(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	if err := os.WriteFile(filepath.Join(dir, defaultConfigPath), []byte(
+		"model:\n  base_url: http://from-file:8000/v1\n  model: from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cfg.Model.Model != "from-file" {
+		t.Errorf("model = %q, want the file's value", cfg.Model.Model)
+	}
+}

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -72,12 +72,6 @@ func BuildVerifyModel(cfg *config.Config) providers.ModelProvider {
 	if v == nil {
 		return nil
 	}
-	or := func(a, b string) string {
-		if a != "" {
-			return a
-		}
-		return b
-	}
 	apiKey := ""
 	if keyEnv := or(v.APIKeyEnv, cfg.Model.APIKeyEnv); keyEnv != "" {
 		apiKey = os.Getenv(keyEnv)

--- a/internal/app/testdata/demo-transcript.json
+++ b/internal/app/testdata/demo-transcript.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T00:00:00Z",
+  "recorded_with": {"provider": "test", "model": "fixture"},
+  "turns": [
+    {"tool_calls": [{"id": "1", "name": "what_changed", "args": "{\"namespace\":\"apps\"}"}],
+     "usage": {"input_tokens": 4211, "output_tokens": 96}},
+    {"tool_calls": [{"id": "2", "name": "submit_findings", "args": "{\"confidence\":0.8,\"root_causes\":[{\"summary\":\"chart 1.15 bump enabled a DB migration on harbor-db that blocks harbor-core\",\"confidence\":0.8}]}"}],
+     "usage": {"input_tokens": 5310, "output_tokens": 402}},
+    {"tool_calls": [{"id": "3", "name": "submit_verdicts", "args": "{\"verdicts\":[{\"index\":0,\"verdict\":\"keep\",\"confidence\":0.8}]}"}],
+     "usage": {"input_tokens": 900, "output_tokens": 40}}
+  ]
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -372,7 +372,7 @@ type Investigation struct {
 	MaxSteps                  int       `yaml:"max_steps"`                    // 0 ⇒ loop default (20)
 	MaxToolOutputBytes        int       `yaml:"max_tool_output_bytes"`        // unset/0 ⇒ bounded default (32768); -1 ⇒ unlimited
 	MaxTokensPerInvestigation int       `yaml:"max_tokens_per_investigation"` // unset/0 ⇒ bounded default (100000); -1 ⇒ unlimited
-	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via applyDefaults
+	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via ApplyDefaults
 	ToolTimeout               Duration  `yaml:"tool_timeout"`                 // per-TOOL-call timeout so one hung tool can't eat the budget; 0 ⇒ default (60s) at construction
 
 	// RecurrenceCooldown (opt-in, 0 = off) suppresses re-investigating a trigger
@@ -411,7 +411,7 @@ type Investigation struct {
 // fails the investigation.
 type ProgressUpdates struct {
 	Enabled    bool `yaml:"enabled"`
-	EverySteps int  `yaml:"every_steps"` // emit a ping every N steps; 0 ⇒ default 5 (applyDefaults). Must be > 0 when enabled.
+	EverySteps int  `yaml:"every_steps"` // emit a ping every N steps; 0 ⇒ default 5 (ApplyDefaults). Must be > 0 when enabled.
 }
 
 // Coalesce folds correlated incidents into one investigation.
@@ -427,7 +427,7 @@ type Coalesce struct {
 // RateLimit caps investigation starts per sliding window.
 type RateLimit struct {
 	// MaxPerWindow caps investigation STARTS per Window. nil (unset) defaults to
-	// 30 (see applyDefaults) — a cost-DoS guard, since per-incident spend is
+	// 30 (see ApplyDefaults) — a cost-DoS guard, since per-incident spend is
 	// bounded but the count of incidents was not. An EXPLICIT 0 preserves the
 	// pre-default unlimited behavior for configs that opted into it.
 	MaxPerWindow *int     `yaml:"max_per_window"`
@@ -709,14 +709,14 @@ type TriggerPolicy struct {
 // Debounce fires immediately on every Ready=False (the original behavior).
 type GitOpsFailureTrigger struct {
 	// Debounce is a pointer so an unset key (nil ⇒ 60s default, applied in
-	// applyDefaults) is distinguishable from an explicit `debounce: 0` (fire
+	// ApplyDefaults) is distinguishable from an explicit `debounce: 0` (fire
 	// immediately). A plain Duration can't tell the two apart — both are the zero
 	// value — which is why `debounce: 0` used to be silently clobbered to 60s.
 	Debounce *Duration `yaml:"debounce"`
 }
 
 // DebounceWindow is the GitOps-failure debounce window. nil (unset) reads as 0
-// here, but applyDefaults fills an unset trigger with 60s; an explicit 0
+// here, but ApplyDefaults fills an unset trigger with 60s; an explicit 0
 // means fire immediately on every Ready=False.
 func (g GitOpsFailureTrigger) DebounceWindow() time.Duration {
 	if g.Debounce == nil {
@@ -741,7 +741,7 @@ type IncidentTrigger struct {
 	// (which batches the survivors afterwards) and `dedup` (which still suppresses
 	// re-fires before the hold begins).
 	//
-	// A pointer, so an unset key (nil ⇒ 60s default, applied in applyDefaults) is
+	// A pointer, so an unset key (nil ⇒ 60s default, applied in ApplyDefaults) is
 	// distinguishable from an explicit `debounce: 0` (investigate immediately, on
 	// every fire) — mirroring gitops_failures.debounce.
 	//
@@ -757,7 +757,7 @@ type IncidentTrigger struct {
 	// sequence whose firing already passed into the investigation queue still burns
 	// a full paid investigation.
 	//
-	// A pointer, so an unset key (nil ⇒ true, applied in applyDefaults) is
+	// A pointer, so an unset key (nil ⇒ true, applied in ApplyDefaults) is
 	// distinguishable from an explicit `cancel_queued_on_resolve: false` — mirroring
 	// Debounce.
 	//
@@ -778,7 +778,7 @@ type IncidentTrigger struct {
 }
 
 // DebounceWindow is the incident debounce hold. nil (unset) reads as 0 here, but
-// applyDefaults fills an unset trigger with 60s; an explicit 0 means investigate
+// ApplyDefaults fills an unset trigger with 60s; an explicit 0 means investigate
 // immediately on every fire. NOTE: the hold never applies to a critical alert —
 // see investigate.Request.IsCritical and source.incidentDebouncer.Hold.
 func (t IncidentTrigger) DebounceWindow() time.Duration {
@@ -789,7 +789,7 @@ func (t IncidentTrigger) DebounceWindow() time.Duration {
 }
 
 // CancelQueuedOnResolveEnabled reports whether a queued investigation is dropped
-// when its alert resolves first. nil (unset) reads as false here, but applyDefaults
+// when its alert resolves first. nil (unset) reads as false here, but ApplyDefaults
 // fills an unset trigger with true; an explicit `false` is left untouched. Mirrors
 // DebounceWindow.
 func (t IncidentTrigger) CancelQueuedOnResolveEnabled() bool {
@@ -1119,13 +1119,13 @@ func (c *Config) Validate() error {
 		}
 	}
 	// Interim progress updates: a non-positive cadence while enabled is a
-	// misconfiguration (applyDefaults fills an unset 0 with 5, so only an explicit
+	// misconfiguration (ApplyDefaults fills an unset 0 with 5, so only an explicit
 	// negative reaches here). Validate fail-loud rather than silently never pinging.
 	if c.Investigation.ProgressUpdates.Enabled && c.Investigation.ProgressUpdates.EverySteps <= 0 {
 		return fmt.Errorf("investigation.progress_updates.every_steps must be > 0 when enabled, got %d", c.Investigation.ProgressUpdates.EverySteps)
 	}
 	// gitops.mirror.max caps the persistent what_changed mirror count; 0 means the
-	// applyDefaults value (10). A negative cap is always a misconfiguration.
+	// ApplyDefaults value (10). A negative cap is always a misconfiguration.
 	if c.GitOps.Mirror.Max < 0 {
 		return fmt.Errorf("gitops.mirror.max must be >= 0 (0 = use the default 10), got %d", c.GitOps.Mirror.Max)
 	}
@@ -1146,7 +1146,7 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
-	// Reject a negative rate-limit budget: applyDefaults fills an unset nil with 30,
+	// Reject a negative rate-limit budget: ApplyDefaults fills an unset nil with 30,
 	// so only an explicit negative reaches here — fail loud rather than silently
 	// treating it as unlimited.
 	if mpw := c.Investigation.RateLimit.MaxPerWindow; mpw != nil && *mpw < 0 {
@@ -1269,7 +1269,7 @@ func (c *Config) Validate() error {
 		}
 	}
 	// Instant-recall reranker (opt-in): its knobs are only meaningful when enabled.
-	// applyDefaults fills unset (0) values, so only an explicitly out-of-range setting
+	// ApplyDefaults fills unset (0) values, so only an explicitly out-of-range setting
 	// reaches here — fail loud rather than silently gating on a nonsensical threshold.
 	// A threshold in (0,1] is a calibrated PROBABILITY (the reranker returns 0.0–1.0);
 	// a value >1 or <=0 could never fire (or always fire), defeating the gate.
@@ -1286,7 +1286,7 @@ func (c *Config) Validate() error {
 		}
 	}
 	// Retirement pass (opt-in): its knobs are only meaningful when enabled, and a
-	// disabled block is never validated. applyDefaults fills unset (0) values while
+	// disabled block is never validated. ApplyDefaults fills unset (0) values while
 	// enabled, so only an explicitly out-of-range setting reaches here. Floor is a
 	// calibrated posterior-mean success rate: it MUST match recall's outcome_floor
 	// range (0,1] — a floor >1 would retire everything, <=0 nothing. min_observations

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -14,7 +14,7 @@ func TestApplyDefaultsCoalesceEnabled(t *testing.T) {
 	// Only coalesce.enabled set — all numeric fields should get safe defaults.
 	var c Config
 	c.Investigation.Coalesce.Enabled = true
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	co := c.Investigation.Coalesce
 	if co.Debounce.Std() != 30*time.Second {
 		t.Fatalf("default Debounce: got %v, want 30s", co.Debounce.Std())
@@ -34,7 +34,7 @@ func TestApplyDefaultsRateLimitWindow(t *testing.T) {
 	var c Config
 	n := 10
 	c.Investigation.RateLimit.MaxPerWindow = &n
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.RateLimit.Window.Std() != time.Hour {
 		t.Fatalf("default Window: got %v, want 1h", c.Investigation.RateLimit.Window.Std())
 	}
@@ -43,14 +43,14 @@ func TestApplyDefaultsRateLimitWindow(t *testing.T) {
 func TestApplyDefaultsInvestigationTimeout(t *testing.T) {
 	// Unset ⇒ a 10m per-investigation deadline is applied (active out of the box).
 	var c Config
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.Timeout.Std() != 10*time.Minute {
 		t.Fatalf("default investigation Timeout: got %v, want 10m", c.Investigation.Timeout.Std())
 	}
 	// Explicit value is respected, not overwritten.
 	var c2 Config
 	c2.Investigation.Timeout = Duration(2 * time.Minute)
-	applyDefaults(&c2)
+	ApplyDefaults(&c2)
 	if c2.Investigation.Timeout.Std() != 2*time.Minute {
 		t.Fatalf("explicit Timeout overwritten: got %v, want 2m", c2.Investigation.Timeout.Std())
 	}
@@ -60,14 +60,14 @@ func TestApplyDefaultsToolTimeout(t *testing.T) {
 	// Unset ⇒ 60s default is applied so cfg.Investigation.ToolTimeout is non-zero
 	// after Load(); BuildInvestigator's 0→60s guard then becomes a no-op safety net.
 	var c Config
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.ToolTimeout.Std() != 60*time.Second {
 		t.Fatalf("default ToolTimeout: got %v, want 60s", c.Investigation.ToolTimeout.Std())
 	}
 	// Explicit value is respected, not overwritten.
 	var c2 Config
 	c2.Investigation.ToolTimeout = Duration(30 * time.Second)
-	applyDefaults(&c2)
+	ApplyDefaults(&c2)
 	if c2.Investigation.ToolTimeout.Std() != 30*time.Second {
 		t.Fatalf("explicit ToolTimeout overwritten: got %v, want 30s", c2.Investigation.ToolTimeout.Std())
 	}
@@ -97,7 +97,7 @@ func TestApplyDefaultsInstantRecall(t *testing.T) {
 	// enabled with no tuning → margin/solo gates and decay knobs default to active values.
 	var c Config
 	c.Catalog.InstantRecall.Enabled = true
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	ir := c.Catalog.InstantRecall
 	if ir.MinScore != 1.0 || ir.MarginGap != 1.0 || ir.SoloFloor != 4.0 {
 		t.Fatalf("instant-recall defaults not applied: %+v", ir)
@@ -113,7 +113,7 @@ func TestApplyDefaultsRecallDecayExplicit(t *testing.T) {
 	c.Catalog.InstantRecall.Enabled = true
 	c.Catalog.InstantRecall.OutcomePrior = 5.0
 	c.Catalog.InstantRecall.OutcomeFloor = 0.3
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	ir := c.Catalog.InstantRecall
 	if ir.OutcomePrior != 5.0 || ir.OutcomeFloor != 0.3 {
 		t.Fatalf("explicit recall-decay values overwritten: %+v", ir)
@@ -147,7 +147,7 @@ func TestApplyDefaultsRecallRerank(t *testing.T) {
 	// the stable, corpus-independent values (nothing to set for it to work).
 	var c Config
 	c.Catalog.InstantRecall.Enabled = true // Rerank unset ⇒ ON
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	ir := c.Catalog.InstantRecall
 	if ir.RerankThreshold != 0.7 || ir.RerankK != 5 || ir.RerankMinScore != 0.1 {
 		t.Fatalf("rerank defaults not applied under the default-on path: %+v", ir)
@@ -156,7 +156,7 @@ func TestApplyDefaultsRecallRerank(t *testing.T) {
 	var off Config
 	off.Catalog.InstantRecall.Enabled = true
 	off.Catalog.InstantRecall.Rerank = rerankPtr(false)
-	applyDefaults(&off)
+	ApplyDefaults(&off)
 	if off.Catalog.InstantRecall.RerankThreshold != 0 || off.Catalog.InstantRecall.RerankK != 0 {
 		t.Fatalf("rerank knobs must stay zero when rerank is explicitly off: %+v", off.Catalog.InstantRecall)
 	}
@@ -165,7 +165,7 @@ func TestApplyDefaultsRecallRerank(t *testing.T) {
 	ex.Catalog.InstantRecall.Enabled = true
 	ex.Catalog.InstantRecall.RerankThreshold = 0.85
 	ex.Catalog.InstantRecall.RerankK = 3
-	applyDefaults(&ex)
+	ApplyDefaults(&ex)
 	if ex.Catalog.InstantRecall.RerankThreshold != 0.85 || ex.Catalog.InstantRecall.RerankK != 3 {
 		t.Fatalf("explicit rerank values overwritten: %+v", ex.Catalog.InstantRecall)
 	}
@@ -179,7 +179,7 @@ func TestValidateRecallRerank(t *testing.T) {
 	}
 	// Defaulted config validates.
 	ok := base()
-	applyDefaults(&ok)
+	ApplyDefaults(&ok)
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("defaulted rerank config must validate, got %v", err)
 	}
@@ -198,7 +198,7 @@ func TestValidateRecallRerank(t *testing.T) {
 	c.Catalog.InstantRecall.RerankThreshold = 0.7
 	c.Catalog.InstantRecall.RerankK = 0 // explicit-but-would-default; force via a post-default check
 	c.Catalog.InstantRecall.RerankMinScore = 0.1
-	// applyDefaults would fill K=5, so exercise Validate directly with an out-of-range K.
+	// ApplyDefaults would fill K=5, so exercise Validate directly with an out-of-range K.
 	c.Catalog.InstantRecall.RerankK = -1
 	if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "rerank_k") {
 		t.Fatalf("rerank_k -1 must be rejected, got %v", err)
@@ -227,7 +227,7 @@ func TestApplyDefaultsDoesNotOverride(t *testing.T) {
 	c.Investigation.Coalesce.Enabled = true
 	c.Investigation.Coalesce.Debounce = Duration(5 * time.Second)
 	c.Investigation.Coalesce.MaxBatch = 3
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.Coalesce.Debounce.Std() != 5*time.Second {
 		t.Fatalf("explicit Debounce overwritten: got %v", c.Investigation.Coalesce.Debounce.Std())
 	}
@@ -295,7 +295,7 @@ func TestApplyDefaultsProgressUpdates(t *testing.T) {
 	// Enabled without an explicit cadence ⇒ default 5.
 	var c Config
 	c.Investigation.ProgressUpdates.Enabled = true
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.ProgressUpdates.EverySteps != 5 {
 		t.Fatalf("default every_steps: got %d, want 5", c.Investigation.ProgressUpdates.EverySteps)
 	}
@@ -303,20 +303,20 @@ func TestApplyDefaultsProgressUpdates(t *testing.T) {
 	var c2 Config
 	c2.Investigation.ProgressUpdates.Enabled = true
 	c2.Investigation.ProgressUpdates.EverySteps = 3
-	applyDefaults(&c2)
+	ApplyDefaults(&c2)
 	if c2.Investigation.ProgressUpdates.EverySteps != 3 {
 		t.Fatalf("explicit every_steps overwritten: got %d, want 3", c2.Investigation.ProgressUpdates.EverySteps)
 	}
 	// Disabled ⇒ left at 0 (unused).
 	var c3 Config
-	applyDefaults(&c3)
+	ApplyDefaults(&c3)
 	if c3.Investigation.ProgressUpdates.EverySteps != 0 {
 		t.Fatalf("disabled every_steps must stay 0, got %d", c3.Investigation.ProgressUpdates.EverySteps)
 	}
 }
 
 func TestValidateProgressUpdatesEverySteps(t *testing.T) {
-	// Enabled with a negative cadence is rejected (applyDefaults fills unset 0 with 5,
+	// Enabled with a negative cadence is rejected (ApplyDefaults fills unset 0 with 5,
 	// so only an explicit negative reaches Validate).
 	var c Config
 	c.Investigation.ProgressUpdates.Enabled = true
@@ -361,7 +361,7 @@ func TestValidatePricingNonNegative(t *testing.T) {
 func TestApplyDefaultsResourceCaps(t *testing.T) {
 	// Unset (zero) → bounded defaults are applied (match the Helm chart values.yaml).
 	var c Config
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.MaxToolOutputBytes != 32768 {
 		t.Fatalf("default MaxToolOutputBytes: got %d, want 32768", c.Investigation.MaxToolOutputBytes)
 	}
@@ -378,7 +378,7 @@ func TestApplyDefaultsResourceCapsUnlimited(t *testing.T) {
 	var c Config
 	c.Investigation.MaxToolOutputBytes = -1
 	c.Investigation.MaxTokensPerInvestigation = -1
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.MaxToolOutputBytes != 0 {
 		t.Fatalf("-1 MaxToolOutputBytes must map to 0 (unlimited sentinel), got %d", c.Investigation.MaxToolOutputBytes)
 	}
@@ -393,7 +393,7 @@ func TestApplyDefaultsResourceCapsExplicit(t *testing.T) {
 	var c Config
 	c.Investigation.MaxToolOutputBytes = 16384
 	c.Investigation.MaxTokensPerInvestigation = 50000
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if c.Investigation.MaxToolOutputBytes != 16384 {
 		t.Fatalf("explicit MaxToolOutputBytes overwritten: got %d, want 16384", c.Investigation.MaxToolOutputBytes)
 	}

--- a/internal/config/config_retirement_test.go
+++ b/internal/config/config_retirement_test.go
@@ -11,7 +11,7 @@ func TestApplyDefaultsRetirementEnabled(t *testing.T) {
 	// Only retirement.enabled set — the three tuning knobs get the recall-gate defaults.
 	var c Config
 	c.Curate.Retirement.Enabled = true
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	r := c.Curate.Retirement
 	if r.MinObservations != 3 {
 		t.Errorf("default MinObservations: got %d, want 3", r.MinObservations)
@@ -26,7 +26,7 @@ func TestApplyDefaultsRetirementEnabled(t *testing.T) {
 	// Explicit values are respected, not overwritten.
 	var c2 Config
 	c2.Curate.Retirement = Retirement{Enabled: true, MinObservations: 5, Floor: 0.3, Prior: 4.0}
-	applyDefaults(&c2)
+	ApplyDefaults(&c2)
 	if r2 := c2.Curate.Retirement; r2.MinObservations != 5 || r2.Floor != 0.3 || r2.Prior != 4.0 {
 		t.Fatalf("explicit retirement tuning overwritten: %+v", r2)
 	}
@@ -36,7 +36,7 @@ func TestApplyDefaultsRetirementDisabled(t *testing.T) {
 	// Disabled (the default): the pass is opt-in, so no defaults are filled — the
 	// block stays at its zero value and never wires the pass in.
 	var c Config
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if r := c.Curate.Retirement; r.MinObservations != 0 || r.Floor != 0 || r.Prior != 0 {
 		t.Fatalf("defaults must not be applied while retirement is disabled: %+v", r)
 	}

--- a/internal/config/config_sweeps_test.go
+++ b/internal/config/config_sweeps_test.go
@@ -13,7 +13,7 @@ import (
 func TestSweepsDefaults(t *testing.T) {
 	// Zero value ⇒ sweeps enabled in dry-run at 6h: safe-by-default, no required config.
 	var c Config
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if got := c.Curate.Sweeps.Interval.Std(); got != 6*time.Hour {
 		t.Fatalf("sweeps.interval default: want 6h, got %v", got)
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -25,17 +25,23 @@ func Load(path string) (*Config, error) {
 	if err := dec.Decode(&c); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
-	applyDefaults(&c)
+	ApplyDefaults(&c)
 	if err := c.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 	return &c, nil
 }
 
-// applyDefaults fills in safe zero-value defaults for optional fields so that a
+// ApplyDefaults fills in safe zero-value defaults for optional fields so that a
 // minimal config (e.g. coalesce.enabled: true with no sub-fields) is valid and
 // predictable without requiring every field to be spelled out.
-func applyDefaults(c *Config) {
+//
+// Exported so that a *Config built OUTSIDE Load — e.g. a config synthesized
+// in-process from environment variables for the zero-config CLI path — can be
+// brought to the same defaulted state as one read from a runlore.yaml. There must
+// be exactly one place that knows these values; a second copy (even a "just the
+// timeout" one) would drift the moment either side changes.
+func ApplyDefaults(c *Config) {
 	// Coalesce defaults: when enabled without explicit tuning, choose conservative
 	// values that reduce storm noise without introducing too much investigation lag.
 	if c.Investigation.Coalesce.Enabled {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -12,7 +12,7 @@ import (
 
 // loadDoc writes doc to a temp runlore.yaml and Loads it — i.e. it exercises the real
 // entry point, defaults included. Tests that assert a DEFAULT must go through Load:
-// a bare &Config{} skips applyDefaults and would silently pin the zero value instead.
+// a bare &Config{} skips ApplyDefaults and would silently pin the zero value instead.
 func loadDoc(t *testing.T, doc string) *Config {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "runlore.yaml")
@@ -172,7 +172,7 @@ triggers:
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	// An explicit `debounce: 0` must survive applyDefaults (not be clobbered to the
+	// An explicit `debounce: 0` must survive ApplyDefaults (not be clobbered to the
 	// 60s default for an unset window), so the trigger fires immediately.
 	if c.Triggers.GitOpsFailures.Debounce == nil {
 		t.Fatal("explicit debounce:0 should be non-nil (distinguishable from unset)")
@@ -213,7 +213,7 @@ sources:
   alertmanager: {}
 `)
 	if c.Triggers.Incidents.CancelQueuedOnResolve == nil {
-		t.Fatal("unset cancel_queued_on_resolve must be defaulted (non-nil) by applyDefaults")
+		t.Fatal("unset cancel_queued_on_resolve must be defaulted (non-nil) by ApplyDefaults")
 	}
 	if !c.Triggers.Incidents.CancelQueuedOnResolveEnabled() {
 		t.Fatal("cancel_queued_on_resolve must default to TRUE")
@@ -325,7 +325,7 @@ sources:
   alertmanager: {}
 `)
 	if c.Investigation.RateLimit.MaxPerWindow == nil {
-		t.Fatal("unset max_per_window must be defaulted (non-nil) by applyDefaults")
+		t.Fatal("unset max_per_window must be defaulted (non-nil) by ApplyDefaults")
 	}
 	if got := *c.Investigation.RateLimit.MaxPerWindow; got != 30 {
 		t.Fatalf("unset max_per_window must default to 30, got %d", got)

--- a/internal/curate/sweeper.go
+++ b/internal/curate/sweeper.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DefaultSweepInterval is the fallback cadence when no interval is configured.
-// config.applyDefaults ships the same value; this guard only protects direct users.
+// config.ApplyDefaults ships the same value; this guard only protects direct users.
 const DefaultSweepInterval = 6 * time.Hour
 
 // Sweeper runs the grooming Agent on a fixed interval until ctx is done — the

--- a/internal/investigate/recalleval_test.go
+++ b/internal/investigate/recalleval_test.go
@@ -11,7 +11,7 @@ package investigate
 // which is exactly how the live "recall never fires on KubePodNotReady" gap went
 // unnoticed: a generic alertname + terse annotation is a ~2-token BM25 query
 // against a differently-worded runbook, scoring ~0.096 live — far below the
-// production solo_floor of 4.0 (config.applyDefaults).
+// production solo_floor of 4.0 (config.ApplyDefaults).
 //
 // This harness closes that hole. It builds a REAL catalog.Catalog (real bleve
 // BM25, no fake scorer) over a fixture KB modeled on the live runlore-kb, feeds it
@@ -42,7 +42,7 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// --- production thresholds (mirror config.applyDefaults InstantRecall defaults) ---
+// --- production thresholds (mirror config.ApplyDefaults InstantRecall defaults) ---
 // Kept as named constants so the harness gates EXACTLY as production does — no
 // test ever tunes these down to force a fire (the whole point is to measure the
 // real gap).
@@ -712,7 +712,7 @@ func TestRecallEvalGitOpsRetrievable(t *testing.T) {
 
 // --- reranker: the calibrated-confidence fire gate, measured on the REAL corpus ---
 //
-// The default reranker knobs, mirrored from config.applyDefaults. The threshold is the
+// The default reranker knobs, mirrored from config.ApplyDefaults. The threshold is the
 // crux: unlike prodSoloFloor (4.0, an ABSOLUTE BM25 magnitude that only fits a
 // hand-tuned corpus) it is a corpus-INDEPENDENT calibrated confidence, so the SAME
 // default fires across corpora.

--- a/internal/model/replay/record.go
+++ b/internal/model/replay/record.go
@@ -29,6 +29,9 @@ func NewRecorder(inner providers.ModelProvider, meta Recorded, scenario string) 
 	return &Recorder{inner: inner, meta: meta, scenario: scenario}
 }
 
+// compile-time assertion: the recorder is substitutable for the live model it wraps.
+var _ providers.ModelProvider = (*Recorder)(nil)
+
 // Complete delegates and captures the response. A failed call is NOT captured: a
 // transcript must contain only turns that really happened, or replay would diverge
 // from the live run it claims to reproduce.

--- a/internal/model/replay/record.go
+++ b/internal/model/replay/record.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Recorder decorates a live model, capturing every completion so the run can be
+// replayed later with no key. It is the only writer of transcripts — regenerating a
+// demo fixture is `--record`, never hand-editing JSON.
+type Recorder struct {
+	inner    providers.ModelProvider
+	meta     Recorded
+	scenario string
+
+	mu    sync.Mutex
+	turns []Turn
+}
+
+// NewRecorder wraps inner, tagging the capture with the model that produced it.
+func NewRecorder(inner providers.ModelProvider, meta Recorded, scenario string) *Recorder {
+	return &Recorder{inner: inner, meta: meta, scenario: scenario}
+}
+
+// Complete delegates and captures the response. A failed call is NOT captured: a
+// transcript must contain only turns that really happened, or replay would diverge
+// from the live run it claims to reproduce.
+func (r *Recorder) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	resp, err := r.inner.Complete(ctx, req)
+	if err != nil {
+		return resp, err
+	}
+	r.mu.Lock()
+	r.turns = append(r.turns, Turn{Text: resp.Text, ToolCalls: resp.ToolCalls, Usage: resp.Usage})
+	r.mu.Unlock()
+	return resp, nil
+}
+
+// Write serializes the captured turns to path. recordedAt is passed in rather than
+// read from the clock so callers stay testable.
+func (r *Recorder) Write(path, recordedAt string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.turns) == 0 {
+		return fmt.Errorf("nothing recorded — refusing to write an empty transcript to %s", path)
+	}
+	t := Transcript{
+		Version: 1, Scenario: r.scenario, RecordedAt: recordedAt,
+		RecordedWith: r.meta, Turns: r.turns,
+	}
+	data, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal transcript: %w", err)
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}

--- a/internal/model/replay/record_test.go
+++ b/internal/model/replay/record_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package replay_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/model/replay"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeModel returns a fixed sequence of completions, standing in for a live model
+// during the recorder test (no network, no key).
+type fakeModel struct {
+	responses []providers.CompletionResponse
+	i         int
+}
+
+func (f *fakeModel) Complete(context.Context, providers.CompletionRequest) (providers.CompletionResponse, error) {
+	r := f.responses[f.i]
+	f.i++
+	return r, nil
+}
+
+// TestRecordRoundTrip: what the recorder writes must replay identically. This is the
+// guarantee that makes `--record` trustworthy — a re-recorded fixture behaves exactly
+// like the live run it captured.
+func TestRecordRoundTrip(t *testing.T) {
+	live := &fakeModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: "what_changed", Args: `{"namespace":"harbor"}`}},
+			Usage: providers.Usage{InputTokens: 100, OutputTokens: 20}},
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: "submit_findings", Args: `{"confidence":0.9}`}},
+			Usage: providers.Usage{InputTokens: 300, OutputTokens: 80}},
+	}}
+
+	rec := replay.NewRecorder(live, replay.Recorded{Provider: "anthropic", Model: "claude-sonnet-5"}, "harbor-chart-bump")
+	for i := 0; i < 2; i++ {
+		if _, err := rec.Complete(context.Background(), providers.CompletionRequest{}); err != nil {
+			t.Fatalf("record turn %d: %v", i+1, err)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "transcript.json")
+	if err := rec.Write(path, "2026-08-02T09:14:00Z"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	tr, err := replay.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if tr.Scenario != "harbor-chart-bump" || tr.RecordedWith.Model != "claude-sonnet-5" {
+		t.Errorf("provenance lost: %+v", tr)
+	}
+	if len(tr.Turns) != 2 {
+		t.Fatalf("turns = %d, want 2", len(tr.Turns))
+	}
+
+	p := replay.New(tr)
+	for i, want := range []string{"what_changed", "submit_findings"} {
+		got, err := p.Complete(context.Background(), providers.CompletionRequest{})
+		if err != nil {
+			t.Fatalf("replay turn %d: %v", i+1, err)
+		}
+		if got.ToolCalls[0].Name != want {
+			t.Errorf("replay turn %d = %q, want %q", i+1, got.ToolCalls[0].Name, want)
+		}
+	}
+}
+
+// TestWriteRefusesEmpty: writing a transcript with no captured turns would ship a
+// fixture that breaks the demo on first use. Fail at write time instead.
+func TestWriteRefusesEmpty(t *testing.T) {
+	rec := replay.NewRecorder(&fakeModel{}, replay.Recorded{}, "none")
+	err := rec.Write(filepath.Join(t.TempDir(), "empty.json"), "2026-08-02T09:14:00Z")
+	if err == nil {
+		t.Fatal("expected an error writing a transcript with no turns")
+	}
+}

--- a/internal/model/replay/record_test.go
+++ b/internal/model/replay/record_test.go
@@ -51,7 +51,7 @@ func TestRecordRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload: %v", err)
 	}
-	if tr.Scenario != "harbor-chart-bump" || tr.RecordedWith.Model != "claude-sonnet-5" {
+	if tr.Scenario != "harbor-chart-bump" || tr.RecordedWith.Model != "claude-sonnet-5" || tr.RecordedAt != "2026-08-02T09:14:00Z" {
 		t.Errorf("provenance lost: %+v", tr)
 	}
 	if len(tr.Turns) != 2 {

--- a/internal/model/replay/replay.go
+++ b/internal/model/replay/replay.go
@@ -88,8 +88,8 @@ type Provider struct {
 // New wraps a loaded transcript as a model provider.
 func New(t *Transcript) *Provider { return &Provider{t: t} }
 
-// Transcript exposes the replayed transcript so callers can render its provenance.
-func (p *Provider) Transcript() *Transcript { return p.t }
+// compile-time assertion: the replay provider satisfies the model interface.
+var _ providers.ModelProvider = (*Provider)(nil)
 
 // Complete returns the next recorded turn, ignoring the request entirely — the
 // transcript is a fixed script, not a function of the prompt.

--- a/internal/model/replay/replay.go
+++ b/internal/model/replay/replay.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package replay serves a recorded LLM transcript as a providers.ModelProvider.
+//
+// It exists so `lore demo investigate --offline` can show a REAL root cause with no
+// API key and no network: the model turns are replayed from a transcript recorded
+// once against a live model, while the tools, the investigation loop and the
+// rendered verdict card remain the production code paths. Only the model is canned.
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Transcript is a recorded investigation: the ordered assistant turns a live model
+// produced for one scenario, plus the provenance a reader needs to judge them.
+type Transcript struct {
+	Version      int      `json:"version"`
+	Scenario     string   `json:"scenario"`
+	RecordedAt   string   `json:"recorded_at"`
+	RecordedWith Recorded `json:"recorded_with"`
+	Turns        []Turn   `json:"turns"`
+}
+
+// Recorded names the model that produced the transcript. It is rendered with the
+// demo output so a replayed card never passes itself off as a fresh live run.
+type Recorded struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// Turn is one recorded assistant completion.
+type Turn struct {
+	Text      string               `json:"text,omitempty"`
+	ToolCalls []providers.ToolCall `json:"tool_calls,omitempty"`
+	Usage     providers.Usage      `json:"usage"`
+}
+
+// Load reads and validates a transcript. A missing file, malformed JSON, or an
+// empty turn list fails here — where the error can name the file — rather than
+// midway through a demo the user is watching.
+func Load(path string) (*Transcript, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: operator-supplied transcript path
+	if err != nil {
+		return nil, fmt.Errorf("read transcript: %w", err)
+	}
+	var t Transcript
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("parse transcript %s: %w", path, err)
+	}
+	if len(t.Turns) == 0 {
+		return nil, fmt.Errorf("transcript %s has no turns", path)
+	}
+	return &t, nil
+}
+
+// ToolNames returns the distinct tool names the transcript calls, in first-seen
+// order. The demo wiring asserts every one still exists, so renaming a tool fails
+// CI instead of shipping a broken demo.
+func (t *Transcript) ToolNames() []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, turn := range t.Turns {
+		for _, tc := range turn.ToolCalls {
+			if !seen[tc.Name] {
+				seen[tc.Name] = true
+				names = append(names, tc.Name)
+			}
+		}
+	}
+	return names
+}
+
+// Provider replays a transcript's turns in order. Safe for concurrent use because
+// the loop may call from more than one goroutine, though today it does not.
+type Provider struct {
+	t  *Transcript
+	mu sync.Mutex
+	i  int
+}
+
+// New wraps a loaded transcript as a model provider.
+func New(t *Transcript) *Provider { return &Provider{t: t} }
+
+// Transcript exposes the replayed transcript so callers can render its provenance.
+func (p *Provider) Transcript() *Transcript { return p.t }
+
+// Complete returns the next recorded turn, ignoring the request entirely — the
+// transcript is a fixed script, not a function of the prompt.
+//
+// Running past the end is an ERROR, deliberately. The loop asking for one more turn
+// than was recorded means the fixture no longer matches the code driving it, and the
+// only correct response is to say so and name the fix.
+func (p *Provider) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.i >= len(p.t.Turns) {
+		return providers.CompletionResponse{}, fmt.Errorf(
+			"transcript exhausted after %d turns (the loop asked for another) — re-record with `lore demo investigate --record <path>`",
+			len(p.t.Turns))
+	}
+	turn := p.t.Turns[p.i]
+	p.i++
+	return providers.CompletionResponse{
+		Text:      turn.Text,
+		ToolCalls: turn.ToolCalls,
+		Usage:     turn.Usage,
+	}, nil
+}

--- a/internal/model/replay/replay_test.go
+++ b/internal/model/replay/replay_test.go
@@ -4,6 +4,8 @@ package replay_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -84,10 +86,26 @@ func TestToolNames(t *testing.T) {
 	}
 }
 
-// TestLoadRejectsEmptyTranscript: an empty turns list would fail later, deep in the
-// loop, with a confusing message. Fail at load with a clear one instead.
-func TestLoadRejectsEmptyTranscript(t *testing.T) {
+// TestLoadRejectsMissingFile: a missing file fails at load so the error can name
+// the file, rather than later midway through a demo.
+func TestLoadRejectsMissingFile(t *testing.T) {
 	if _, err := replay.Load("testdata/does-not-exist.json"); err == nil {
 		t.Fatal("expected an error for a missing transcript")
+	}
+}
+
+// TestLoadRejectsEmptyTranscript: a transcript with no turns would fail later,
+// mid-demo, with a confusing error. Fail at load, naming the file.
+func TestLoadRejectsEmptyTranscript(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.json")
+	if err := os.WriteFile(path, []byte(`{"version":1,"scenario":"x","turns":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := replay.Load(path)
+	if err == nil {
+		t.Fatal("expected an error for a transcript with no turns")
+	}
+	if !strings.Contains(err.Error(), "no turns") {
+		t.Errorf("error should say the transcript has no turns, got: %v", err)
 	}
 }

--- a/internal/model/replay/replay_test.go
+++ b/internal/model/replay/replay_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package replay_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/model/replay"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestReplayReturnsTurnsInOrder is the core contract: the provider ignores the
+// request and hands back the recorded assistant turns in the order they were
+// recorded, usage included (the demo's cost footer reads it).
+func TestReplayReturnsTurnsInOrder(t *testing.T) {
+	tr, err := replay.Load("testdata/two-turns.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p := replay.New(tr)
+
+	first, err := p.Complete(context.Background(), providers.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if len(first.ToolCalls) != 1 || first.ToolCalls[0].Name != "what_changed" {
+		t.Fatalf("turn 1 tool calls = %+v, want one what_changed", first.ToolCalls)
+	}
+	if first.Usage.InputTokens != 4211 || first.Usage.OutputTokens != 96 {
+		t.Errorf("turn 1 usage = %+v, want 4211 in / 96 out", first.Usage)
+	}
+
+	second, err := p.Complete(context.Background(), providers.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	if len(second.ToolCalls) != 1 || second.ToolCalls[0].Name != "submit_findings" {
+		t.Fatalf("turn 2 tool calls = %+v, want one submit_findings", second.ToolCalls)
+	}
+}
+
+// TestReplayExhaustionIsLoud: running past the recorded turns must fail with an
+// actionable error naming the fix. Returning an empty completion would produce a
+// demo that silently ends with no findings — the exact failure mode a first-time
+// user cannot diagnose.
+func TestReplayExhaustionIsLoud(t *testing.T) {
+	tr, err := replay.Load("testdata/two-turns.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p := replay.New(tr)
+	for i := 0; i < 2; i++ {
+		if _, err := p.Complete(context.Background(), providers.CompletionRequest{}); err != nil {
+			t.Fatalf("turn %d: %v", i+1, err)
+		}
+	}
+	_, err = p.Complete(context.Background(), providers.CompletionRequest{})
+	if err == nil {
+		t.Fatal("expected an error past the end of the transcript")
+	}
+	if !strings.Contains(err.Error(), "exhausted") || !strings.Contains(err.Error(), "--record") {
+		t.Errorf("error must say it is exhausted and how to fix it, got: %v", err)
+	}
+}
+
+// TestToolNames exposes the recorded tool names so the demo wiring can assert they
+// all still exist (the drift guard in Task 3).
+func TestToolNames(t *testing.T) {
+	tr, err := replay.Load("testdata/two-turns.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := tr.ToolNames()
+	want := map[string]bool{"what_changed": true, "submit_findings": true}
+	if len(got) != len(want) {
+		t.Fatalf("ToolNames() = %v, want %d distinct names", got, len(want))
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Errorf("unexpected tool name %q", n)
+		}
+	}
+}
+
+// TestLoadRejectsEmptyTranscript: an empty turns list would fail later, deep in the
+// loop, with a confusing message. Fail at load with a clear one instead.
+func TestLoadRejectsEmptyTranscript(t *testing.T) {
+	if _, err := replay.Load("testdata/does-not-exist.json"); err == nil {
+		t.Fatal("expected an error for a missing transcript")
+	}
+}

--- a/internal/model/replay/testdata/two-turns.json
+++ b/internal/model/replay/testdata/two-turns.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T09:14:00Z",
+  "recorded_with": {"provider": "anthropic", "model": "claude-sonnet-5"},
+  "turns": [
+    {
+      "text": "",
+      "tool_calls": [{"id": "1", "name": "what_changed", "args": "{\"namespace\":\"harbor\"}"}],
+      "usage": {"input_tokens": 4211, "output_tokens": 96}
+    },
+    {
+      "text": "",
+      "tool_calls": [{"id": "2", "name": "submit_findings", "args": "{\"confidence\":0.86}"}],
+      "usage": {"input_tokens": 5310, "output_tokens": 402}
+    }
+  ]
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -868,15 +868,10 @@ func (r CompletionResponse) Refused() bool {
 
 // Usage is the provider-reported token accounting for one completion.
 type Usage struct {
-	InputTokens  int // total prompt/input tokens billed, INCLUDING any served from cache (normalized across providers)
-	OutputTokens int // generated/output tokens in the reply
-	// CachedInputTokens is the subset of InputTokens that was a cache READ (Anthropic
-	// cache_read_input_tokens, OpenAI prompt_tokens_details.cached_tokens, Gemini
-	// cachedContentTokenCount) — the saving. 0 when the provider reports none.
-	CachedInputTokens int
-	// CacheWriteTokens is input tokens WRITTEN to the cache this request (Anthropic
-	// cache_creation_input_tokens, billed ~1.25x). 0 for providers that don't report it.
-	CacheWriteTokens int
+	InputTokens       int `json:"input_tokens"`        // total prompt/input tokens billed, INCLUDING any served from cache (normalized across providers)
+	OutputTokens      int `json:"output_tokens"`       // generated/output tokens in the reply
+	CachedInputTokens int `json:"cached_input_tokens"` // subset of InputTokens that was a cache READ (Anthropic cache_read_input_tokens, OpenAI prompt_tokens_details.cached_tokens, Gemini cachedContentTokenCount) — the saving. 0 when the provider reports none.
+	CacheWriteTokens  int `json:"cache_write_tokens"`  // input tokens WRITTEN to the cache this request (Anthropic cache_creation_input_tokens, billed ~1.25x). 0 for providers that don't report it.
 }
 
 // ToolCall is a model request to invoke a tool.

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -868,10 +868,15 @@ func (r CompletionResponse) Refused() bool {
 
 // Usage is the provider-reported token accounting for one completion.
 type Usage struct {
-	InputTokens       int `json:"input_tokens"`        // total prompt/input tokens billed, INCLUDING any served from cache (normalized across providers)
-	OutputTokens      int `json:"output_tokens"`       // generated/output tokens in the reply
-	CachedInputTokens int `json:"cached_input_tokens"` // subset of InputTokens that was a cache READ (Anthropic cache_read_input_tokens, OpenAI prompt_tokens_details.cached_tokens, Gemini cachedContentTokenCount) — the saving. 0 when the provider reports none.
-	CacheWriteTokens  int `json:"cache_write_tokens"`  // input tokens WRITTEN to the cache this request (Anthropic cache_creation_input_tokens, billed ~1.25x). 0 for providers that don't report it.
+	InputTokens  int `json:"input_tokens"`  // total prompt/input tokens billed, INCLUDING any served from cache (normalized across providers)
+	OutputTokens int `json:"output_tokens"` // generated/output tokens in the reply
+	// CachedInputTokens is the subset of InputTokens that was a cache READ (Anthropic
+	// cache_read_input_tokens, OpenAI prompt_tokens_details.cached_tokens, Gemini
+	// cachedContentTokenCount) — the saving. 0 when the provider reports none.
+	CachedInputTokens int `json:"cached_input_tokens"`
+	// CacheWriteTokens is input tokens WRITTEN to the cache this request (Anthropic
+	// cache_creation_input_tokens, billed ~1.25x). 0 for providers that don't report it.
+	CacheWriteTokens int `json:"cache_write_tokens"`
 }
 
 // ToolCall is a model request to invoke a tool.

--- a/website/content/docs/reference/cli.md
+++ b/website/content/docs/reference/cli.md
@@ -1,0 +1,144 @@
+---
+title: CLI
+weight: 5
+---
+
+`lore` is a single static binary: a demo you can run with no key and no cluster, a
+one-off investigator for your own stack, and the same engine that runs continuously
+as [`lore serve`]({{< relref "/docs/getting-started.md" >}}). This page covers the CLI
+front door — install, the two zero-ceremony commands, and how each one degrades
+when something isn't configured.
+
+## Install
+
+```bash
+curl -fsSL https://runlore.io/install.sh | sh
+```
+
+The script downloads the release archive for your OS/arch from the GitHub release,
+**verifies its SHA-256 against the published `checksums.txt` before extracting
+anything**, and installs `lore` to `/usr/local/bin` — falling back to `~/.local/bin`
+(no `sudo`, ever) if that isn't writable. It's a small, readable POSIX shell script;
+audit it yourself at
+[`website/static/install.sh`](https://github.com/Smana/runlore/blob/main/website/static/install.sh).
+
+Environment variables:
+
+| Variable | Effect |
+|---|---|
+| `LORE_VERSION` | pin a release tag, e.g. `v0.11.0` (default: the latest release) |
+| `LORE_INSTALL_DIR` | install target (default: `/usr/local/bin`, falls back to `~/.local/bin`) |
+
+**Prefer not to pipe a script into a shell?** Build from source instead — no
+third-party trust beyond the Go toolchain and the module graph:
+
+```bash
+go install github.com/Smana/runlore/cmd/lore@latest
+```
+
+**Verify the release signature (optional).** Every release is keyless-signed with
+[cosign](https://github.com/sigstore/cosign) in CI (`id-token: write`, no long-lived
+key) — the installer prints this command, or run it yourself:
+
+```bash
+cosign verify-blob --bundle checksums.txt.bundle \
+  --certificate-identity-regexp 'https://github.com/Smana/runlore/.github/workflows/release-binaries.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt
+```
+
+Verifying `checksums.txt` transitively covers every archive it lists.
+
+## `lore demo investigate --offline default`
+
+The fastest way to see RunLore reach a real root cause — **no API key, no network,
+no cluster**:
+
+```bash
+lore demo investigate --offline default
+```
+
+This replays a **recorded transcript** of a genuine investigation
+(`examples/demo/harbor-chart-bump.transcript.json`) through the real production
+loop — the same ReAct tool calls, verify pass, and verdict-card renderer that run
+in `lore serve` — over fake (but realistic) evidence for a Harbor chart-bump
+incident. Nothing about the reasoning is scripted for the demo: the model turns
+were captured once against a live model and are replayed byte-for-byte.
+
+The card discloses its own provenance so you know exactly what you're looking at:
+
+```text
+== RunLore demo: investigating "harbor-chart-bump" (recorded model turns, fake providers, no cluster) ==
+   model turns recorded 2026-08-02T07:48:52Z with openai/glm-4.5-air
+```
+
+That line is not decoration — it's the honesty mechanism. A recording ages: model
+behavior on the same evidence can drift release to release, so the date and model
+tell you exactly how current the transcript is, rather than implying it's live.
+Re-record it yourself against your own model with `--record`:
+
+```bash
+lore demo investigate --record my-transcript.json   # needs a model key; runs live
+lore demo investigate --offline my-transcript.json  # replays it back, keyless
+```
+
+Without `--offline`, `lore demo investigate [--scenario <name>]` runs the same
+loop **live** against fake providers — it still needs no cluster, but it does need
+a model key (`ANTHROPIC_API_KEY` by default, or `--config` pointing at a
+`runlore.yaml`).
+
+## `lore investigate`
+
+`lore investigate --alert <name> [--message <text>] [--namespace <ns>]` runs one
+on-demand investigation against **your** stack and prints the findings — no
+`runlore.yaml` required. With no `--config`, it reads its model from the
+environment, in this order:
+
+| Source | Effect |
+|---|---|
+| `OPENAI_BASE_URL` (+ optional `OPENAI_API_KEY`, `OPENAI_MODEL`) | any OpenAI-compatible endpoint — keyless if the endpoint itself needs no credential (e.g. a local vLLM/Ollama) |
+| `ANTHROPIC_API_KEY` | native Anthropic, checked if no `OPENAI_BASE_URL` is set |
+| neither | `investigate` exits with an error naming both options |
+
+A `./runlore.yaml`, if present, is read automatically; `--config <path>` points at
+one explicitly (and a missing explicit path is a hard error — the flag is a promise,
+not a hint).
+
+Flags override whatever the config resolved to, so you can point the CLI at your
+stack without writing a file at all:
+
+| Flag | Overrides |
+|---|---|
+| `--model` | the model name |
+| `--base-url` | the OpenAI-compatible endpoint |
+| `--metrics-url` | PromQL endpoint — enables the `query_metrics` tool |
+| `--logs-url` | logs endpoint — enables the `query_logs` tool |
+
+### What degrades, and what that notice means
+
+`investigate` never refuses to run just because a signal is missing — it runs on
+whatever's configured and says so on stderr:
+
+```text
+note: running without metrics (query_metrics), logs (query_logs), knowledge catalog (kb_search, instant recall) — pass --metrics-url/--logs-url or a --config to enable them
+```
+
+| Unset | Disables |
+|---|---|
+| `--metrics-url` / `config.metrics.url` | `query_metrics` (PromQL evidence) |
+| `--logs-url` / `config.logs.url` | `query_logs` (log evidence) |
+| a configured catalog (`config.catalog`) | `kb_search` and instant recall (knowledge-base grounding) |
+
+**This notice means "under-configured," not "broken."** The investigation still
+runs to completion and still reaches a verdict — just over whatever evidence is
+available. Treat the notice as a checklist for widening the picture, not as an
+error to work around.
+
+## When to move to `lore serve`
+
+The CLI is for a one-off look — a specific alert, right now, from your terminal.
+Once you want RunLore reacting to incidents continuously, delivering to chat, and
+writing what it learns back to a knowledge-base repo as pull requests, the same
+engine runs in-cluster as `lore serve`, deployed via Helm. See
+[Getting Started]({{< relref "/docs/getting-started.md" >}}) for the full production
+install — GitOps engine wiring, the GitHub App for curation, credentials, and a
+complete `values.yaml` reference.

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# RunLore installer — downloads the released `lore` binary for this OS/arch,
+# verifies its SHA-256 against the published checksums, and installs it.
+#
+#   curl -fsSL https://runlore.io/install.sh | sh
+#
+# Environment:
+#   LORE_VERSION      pin a release tag, e.g. v0.11.0 (default: latest)
+#   LORE_INSTALL_DIR  install target (default: /usr/local/bin, else ~/.local/bin)
+#
+# This script is auditable at
+# https://github.com/Smana/runlore/blob/main/website/static/install.sh
+# It never runs sudo, never sends telemetry, and only ever writes to the
+# chosen install dir and a temp dir it cleans up on exit.
+set -eu
+
+REPO="Smana/runlore"
+VERSION="${LORE_VERSION:-latest}"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+arch=$(uname -m)
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *) echo "unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+case "$os" in
+  linux|darwin) ;;
+  *) echo "unsupported OS: $os — build from source with 'go install github.com/Smana/runlore/cmd/lore@latest'" >&2; exit 1 ;;
+esac
+
+# macOS has no sha256sum; shasum -a 256 is the equivalent everywhere Apple ships.
+if ! command -v sha256sum >/dev/null 2>&1; then
+  sha256sum() { shasum -a 256 "$@"; }
+fi
+
+if [ "$VERSION" = "latest" ]; then
+  VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+  [ -n "$VERSION" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
+fi
+
+# Matches .goreleaser.yaml: project_name=runlore, name_template
+# {{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}, tar.gz. Note the archive is named
+# for the PROJECT (runlore) while the binary inside is `lore`.
+archive="runlore_${VERSION#v}_${os}_${arch}.tar.gz"
+base="https://github.com/$REPO/releases/download/$VERSION"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "downloading $archive ($VERSION)"
+curl -fsSL "$base/$archive" -o "$tmp/$archive"
+curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt"
+
+# Verify BEFORE extracting. A checksum mismatch means a corrupted or tampered
+# download, and extracting it anyway would defeat the point of checking — abort
+# with nothing installed rather than silently trusting the bytes.
+( cd "$tmp" && grep " $archive\$" checksums.txt | sha256sum -c - >/dev/null ) \
+  || { echo "checksum verification FAILED for $archive — aborting, nothing installed" >&2; exit 1; }
+
+tar -xzf "$tmp/$archive" -C "$tmp" lore
+
+# Pick an install dir that needs no elevated privileges. This script never
+# invokes sudo: if the preferred/requested dir can't be written to, it falls
+# back to a per-user directory instead of asking for root.
+requested="${LORE_INSTALL_DIR:-/usr/local/bin}"
+dir="$requested"
+mkdir -p "$dir" 2>/dev/null || true
+if [ ! -w "$dir" ]; then
+  dir="$HOME/.local/bin"
+  mkdir -p "$dir"
+  echo "note: $requested is not writable — installing to $dir instead" >&2
+fi
+install -m 0755 "$tmp/lore" "$dir/lore"
+
+echo "installed $("$dir/lore" version) to $dir/lore"
+case ":$PATH:" in
+  *":$dir:"*) ;;
+  *) echo "note: $dir is not on your PATH — add it, e.g. export PATH=\"$dir:\$PATH\"" ;;
+esac
+echo
+echo "Try it with no cluster and no API key:"
+echo "  lore demo investigate --offline default"
+echo
+echo "Verify the release signature (optional):"
+echo "  cosign verify-blob --bundle checksums.txt.bundle \\"
+echo "    --certificate-identity-regexp 'https://github.com/$REPO/.github/workflows/release-binaries.yml@.*' \\"
+echo "    --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt"

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -53,7 +53,47 @@ echo "downloading $archive ($VERSION)"
 curl -fsSL "$base/$archive" -o "$tmp/$archive"
 curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt"
 
-# Verify BEFORE extracting. A checksum mismatch means a corrupted or tampered
+# Verify the SIGNATURE on checksums.txt first, when cosign is available.
+#
+# Why this matters: the checksum alone only proves the archive arrived intact.
+# checksums.txt is fetched from the same origin as the archive, so anyone able to
+# replace one can replace the other, and the hash would match a malicious build
+# perfectly. The cosign bundle is signed by the release workflow's short-lived
+# Fulcio identity and recorded in Rekor — that is the part an attacker holding
+# the release assets cannot forge.
+#
+# cosign is NOT required: most machines running a one-line installer won't have
+# it, and demanding it would push people toward downloading the binary by hand
+# with no verification at all. When it is missing we say so plainly rather than
+# implying a guarantee we did not check. When it IS present, verification is
+# mandatory — a failure aborts. LORE_SKIP_COSIGN=1 opts out deliberately.
+if [ "${LORE_SKIP_COSIGN:-0}" = "1" ]; then
+  echo "note: signature verification skipped (LORE_SKIP_COSIGN=1) — checksum only."
+elif command -v cosign >/dev/null 2>&1; then
+  if ! curl -fsSL "$base/checksums.txt.bundle" -o "$tmp/checksums.txt.bundle"; then
+    echo "cosign is installed but $VERSION publishes no checksums.txt.bundle." >&2
+    echo "Aborting rather than silently downgrading to checksum-only verification." >&2
+    echo "Re-run with LORE_SKIP_COSIGN=1 to install anyway." >&2
+    exit 1
+  fi
+  if cosign verify-blob \
+      --bundle "$tmp/checksums.txt.bundle" \
+      --certificate-identity-regexp "https://github.com/$REPO/\.github/workflows/release-binaries\.yml@.*" \
+      --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+      "$tmp/checksums.txt" >/dev/null 2>&1; then
+    echo "signature verified: checksums.txt (cosign, keyless)"
+  else
+    echo "SIGNATURE VERIFICATION FAILED for checksums.txt — aborting, nothing installed" >&2
+    exit 1
+  fi
+else
+  echo "note: cosign not found — verifying the checksum only. That proves the"
+  echo "      download is intact, not that it is the release we published."
+  echo "      Install cosign (https://docs.sigstore.dev/cosign/installation/) to"
+  echo "      verify the signature too."
+fi
+
+# Verify the checksum BEFORE extracting. A mismatch means a corrupted or tampered
 # download, and extracting it anyway would defeat the point of checking — abort
 # with nothing installed rather than silently trusting the bytes.
 ( cd "$tmp" && grep " $archive\$" checksums.txt | sha256sum -c - >/dev/null ) \


### PR DESCRIPTION
Implements **S1** of the improvement-report decomposition: fix the funnel. The report's judgement was that a stranger currently cannot make RunLore produce a root cause without provisioning five things first, and that closing that gap is worth more than any feature.

## What changes for a first-time visitor

```
$ hack/demo.sh
== RunLore demo: investigating "harbor-chart-bump" (recorded model turns, fake providers, no cluster) ==
   model turns recorded 2026-08-02T07:48:52Z with openai/glm-4.5-air

incident: HarborProbeFailure (critical, prod, namespace apps): harbor-core readiness probes failing…
→ what_changed()  flux Kustomization/apps aaa111..bbb222   tag: 1.14.2 → 1.15.0
→ query_logs()    harbor-db-0 FATAL: could not obtain migration lock…
```

No cluster, no API key, no network — verified by running it with every model key stripped from the environment. Previously `hack/demo.sh` printed trigger-policy log lines, which is the least differentiated part of the product.

## How

- **`internal/model/replay`** — a `providers.ModelProvider` that replays a recorded transcript. The tools, the loop, the verify pass and the rendered card are all production code; only the model is canned. `--record` captures a new transcript from a live model; exhaustion is a loud, actionable error rather than a silent empty completion.
- **`lore investigate` now runs with no `runlore.yaml`**, synthesizing a model config from `OPENAI_BASE_URL`/`OPENAI_API_KEY`/`OPENAI_MODEL` or `ANTHROPIC_API_KEY`, plus `--model`/`--base-url`/`--metrics-url`/`--logs-url`. An explicitly-passed `--config` that is missing — or that exists but fails to parse — stays a hard error; only `fs.ErrNotExist` on the default path falls back.
- **`install.sh`** at `runlore.io/install.sh`, with a first-class CLI reference page.
- The trigger-policy demo moves to `hack/demo-trigger-policy.sh`, unchanged.

## Things found while building this

**The zero-config path had no investigation timeout.** `applyDefaults` was unexported and ran only inside `config.Load`, so a synthesized config left `Investigation.Timeout` at 0 — and `loop.go` only sets a deadline when it is non-zero. A first-time user's investigation could run unbounded. Fixed by exporting `ApplyDefaults` and calling it from both construction paths, pinned by a test asserting the two agree.

**The demo announced one incident and diagnosed another.** With no `--scenario`, `pickScenario` returned the *first* scenario in the directory while the transcript replayed a different one. Now it defaults to the transcript's own scenario.

**glm-4.6 was the intended model and was rejected.** It stalls indefinitely on forced `tool_choice` (#391), so its verify pass never completes. The shipped transcript is recorded on glm-4.5-air, which completes the full loop.

## Verification

- `hack/demo.sh` run with all model keys unset: real card, stderr clean.
- `install.sh` tested against a locally-served release archive: installs, and the installed binary renders the card. A tampered archive aborts with nothing installed; a nonexistent version fails cleanly.
- Signature verification added: when `cosign` is present, `checksums.txt` is verified against its bundle before use. Tested against the published v0.11.0 release — valid bundle passes, tampered file rejected. `LORE_SKIP_COSIGN=1` opts out deliberately; absence of cosign is stated plainly rather than implying a guarantee.
- CI shellcheck now covers `install.sh` **at default severity** — the pre-existing note that blocked it was fixed rather than muted.
- Dedicated security review: no HIGH or MEDIUM findings. The checksum-bypass paths were tested empirically on both GNU coreutils and macOS `shasum`.

## Known gap, deliberately out of scope

`website/content/docs/getting-started.md:19` still describes the old `hack/demo.sh` behaviour. That page is rewritten wholesale by S2.