### PR TITLE
docs(website): put the eval scorecard in the top nav

### DIFF
--- a/website/hugo.yaml
+++ b/website/hugo.yaml
@@ -30,13 +30,20 @@ menu:
     - name: Compare
       pageRef: /compare
       weight: 2
-    - name: GitHub
+    # The nightly scorecard is the project's main evidence that its claims are
+    # checkable, and it publishes reds as readily as greens. It had exactly two
+    # inbound links and no nav entry, which made the one page a skeptic wants
+    # the hardest one to find.
+    - name: Eval
+      pageRef: /eval
       weight: 3
+    - name: GitHub
+      weight: 4
       url: "https://github.com/Smana/runlore"
       params:
         icon: github
     - name: Search
-      weight: 4
+      weight: 5
       params:
         type: search
 


### PR DESCRIPTION
## What

Adds an **Eval** entry to the site's top navigation, between Compare and GitHub.

## Why

`runlore.io/eval` is where the nightly scorecard lands — per scenario, pass/fail, recall outcomes, confidence calibration, model, date and cost, published red or green. It is the project's main evidence that its claims are checkable rather than asserted.

It had exactly two inbound links: the homepage eyebrow line and one line in `docs/reference/benchmarking.md`. It was not in the nav at all. The one page a skeptic wants was the hardest one on the site to find.

## Not changed

The README badge already renders `badge.json` from the `eval-scorecard` branch and already links to this page — that part was already in place. This closes the gap on the site itself.