### PR TITLE
feat(source): register Grafana Alerting as a first-class webhook source

### DIFF
--- a/hack/integration/grafana/README.md
+++ b/hack/integration/grafana/README.md
@@ -1,0 +1,61 @@
+# Grafana source — local verification
+
+Runs a real Grafana with a provisioned alert rule and contact point wired to a `lore serve`
+running on the host, end to end: fire the rule, confirm an investigation starts with the right
+namespace/workload; let it resolve, confirm a resolution is recorded rather than a second
+investigation.
+
+No cluster, no Prometheus — the rule queries Grafana's built-in **TestData** datasource with the
+`predictable_pulse` scenario, which alternates firing/resolved on its own (20s high, 20s low), so
+no manual "make it fire" step is needed.
+
+## Run it
+
+1. Start `lore serve` on the host, keyless (no LLM configured — this only proves ingestion,
+   trigger-policy admission and the investigation *starting*, same scope as `hack/demo-trigger-policy.sh`):
+
+   ```bash
+   export GRAFANA_WEBHOOK_TOKEN=demo-token
+   go build -o /tmp/lore ./cmd/lore
+   /tmp/lore serve --config hack/integration/grafana/runlore.config.yaml --addr :8080
+   ```
+
+2. In another terminal, start Grafana:
+
+   ```bash
+   cd hack/integration/grafana
+   GRAFANA_WEBHOOK_TOKEN=demo-token docker compose up
+   ```
+
+3. Watch the `lore serve` logs. Within ~20s of Grafana starting, the `HighCPU` rule's TestData
+   query crosses its threshold and Grafana POSTs a `firing` alert to `/webhook/grafana`. Confirm:
+   - the log line shows an admitted/investigating request
+   - `namespace=payments`, `workload=api-0` (from `labels.namespace` / `labels.pod`)
+   - the title is `HighCPU` (Grafana's auto-injected `alertname` label = the rule title)
+
+4. ~20s later the TestData value drops back below threshold and Grafana POSTs a `resolved` alert
+   for the same series. Confirm the log records a **resolution** (outcome ledger), not a second
+   investigation.
+
+5. `docker compose down` to stop Grafana; `Ctrl-C` the `lore serve` process.
+
+## Verify by hand instead of waiting on the pulse
+
+Grafana UI at `http://localhost:3000` (anonymous Admin access is enabled for this recipe) →
+**Alerting → Alert rules → RunLore Demo → HighCPU** shows the rule's current state and evaluation
+history. To control it deterministically rather than waiting on the pulse, edit the rule's query
+(scenario `csv_content` with a fixed value above/below 50) and save — Grafana re-evaluates on the
+next `interval` (10s).
+
+## Notes
+
+- `authorization_credentials: ${GRAFANA_WEBHOOK_TOKEN}` in `provisioning/alerting/contactpoints.yml`
+  is expanded by Grafana from the container's own `GRAFANA_WEBHOOK_TOKEN` env var (set in
+  `docker-compose.yml`) — keep it equal to the value exported for `lore serve` in step 1.
+- `extra_hosts: host.docker.internal:host-gateway` in `docker-compose.yml` makes the container
+  reach the host's `lore serve`; this is Linux Docker's equivalent of Docker Desktop's built-in
+  `host.docker.internal`.
+- This recipe was authored but has **not been run end to end** — the sandbox this was written in
+  has no Docker daemon available (docker CLI present, `dockerd` not running, no passwordless sudo
+  to start it). Treat it as a reviewed-on-paper recipe, not a verified one, until someone with a
+  working Docker runs it.

--- a/hack/integration/grafana/README.md
+++ b/hack/integration/grafana/README.md
@@ -30,6 +30,9 @@ no manual "make it fire" step is needed.
 3. Watch the `lore serve` logs. Within ~20s of Grafana starting, the `HighCPU` rule's TestData
    query crosses its threshold and Grafana POSTs a `firing` alert to `/webhook/grafana`. Confirm:
    - the log line shows an admitted/investigating request
+   - `source=grafana` — **not** `source=custom`, even though the mapping is the custom mapper
+     underneath (`sources.grafana` claims its own `investigate.Source`, so its incidents never
+     coalesce with a same-titled one from a `sources.custom` instance)
    - `namespace=payments`, `workload=api-0` (from `labels.namespace` / `labels.pod`)
    - the title is `HighCPU` (Grafana's auto-injected `alertname` label = the rule title)
 

--- a/hack/integration/grafana/docker-compose.yml
+++ b/hack/integration/grafana/docker-compose.yml
@@ -1,0 +1,28 @@
+# Local verification recipe for the `grafana` source (see
+# website/content/docs/integrations/grafana.md). Starts a real Grafana with a
+# provisioned alert rule and contact point wired to a `lore serve` running on
+# the host — no Prometheus/VictoriaMetrics needed, the rule queries the
+# built-in TestData datasource so it fires and resolves on a fixed pulse.
+#
+# Usage: see README.md in this directory.
+services:
+  grafana:
+    image: grafana/grafana:11.3.0
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      # Read by provisioning/alerting/contactpoints.yml via Grafana's
+      # provisioning-file env expansion — keep this in sync with the
+      # `token_env` value in runlore.config.yaml.
+      GRAFANA_WEBHOOK_TOKEN: ${GRAFANA_WEBHOOK_TOKEN:-demo-token}
+    volumes:
+      - ./provisioning:/etc/grafana/provisioning:ro
+    extra_hosts:
+      # Linux Docker has no host.docker.internal by default; this makes the
+      # contact point's http://host.docker.internal:8080 reach the `lore serve`
+      # process running on the host (also works out of the box on Docker
+      # Desktop for macOS/Windows).
+      - "host.docker.internal:host-gateway"

--- a/hack/integration/grafana/provisioning/alerting/contactpoints.yml
+++ b/hack/integration/grafana/provisioning/alerting/contactpoints.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: runlore
+    receivers:
+      - uid: runlore-webhook
+        type: webhook
+        disableResolveMessage: false # a resolved alert must reach RunLore too
+        settings:
+          url: http://host.docker.internal:8080/webhook/grafana
+          httpMethod: POST
+          authorization_scheme: Bearer
+          authorization_credentials: ${GRAFANA_WEBHOOK_TOKEN}

--- a/hack/integration/grafana/provisioning/alerting/policies.yml
+++ b/hack/integration/grafana/provisioning/alerting/policies.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: runlore
+    group_by: ["alertname"]
+    group_wait: 0s
+    group_interval: 10s
+    repeat_interval: 1h

--- a/hack/integration/grafana/provisioning/alerting/rules.yml
+++ b/hack/integration/grafana/provisioning/alerting/rules.yml
@@ -21,15 +21,25 @@ groups:
             model:
               refId: A
               # Predictable Pulse alternates onValue/offValue every
-              # step*onCount / step*offCount seconds, with no manual action
-              # needed to both fire AND resolve the rule — 20s high (100),
-              # then 20s low (0), on repeat.
+              # timeStep*onCount / timeStep*offCount seconds, with no manual
+              # action needed to both fire AND resolve the rule — 20s high
+              # (100), then 20s low (0), on repeat.
+              #
+              # The settings MUST nest under `pulseWave` and the interval key
+              # MUST be `timeStep`: Grafana's TestData backend decodes
+              # model.pulseWave into a PulseWaveQuery{TimeStep,OnCount,
+              # OffCount,OnValue,OffValue} (pkg/tsdb/grafana-testdata-datasource/
+              # scenarios.go). Flat `step:`/`onCount:` keys at model level are
+              # silently ignored — the scenario then runs with a zero timeStep
+              # and returns no usable series, so the rule never crosses 50 and
+              # goes to execErrState instead.
               scenarioId: predictable_pulse
-              step: 10
-              onCount: 2
-              onValue: 100
-              offCount: 2
-              offValue: 0
+              pulseWave:
+                timeStep: 10
+                onCount: 2
+                offCount: 2
+                onValue: 100
+                offValue: 0
           - refId: B
             datasourceUid: __expr__
             model:

--- a/hack/integration/grafana/provisioning/alerting/rules.yml
+++ b/hack/integration/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,60 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: runlore-demo
+    folder: RunLore Demo
+    interval: 10s
+    rules:
+      - uid: runlore-demo-highcpu
+        title: HighCPU
+        # No `for:` delay — fires on the first breaching evaluation, so the
+        # webhook round-trip to RunLore is visible within one `interval`.
+        for: 0s
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: testdata
+            relativeTimeRange:
+              from: 600
+              to: 0
+            model:
+              refId: A
+              # Predictable Pulse alternates onValue/offValue every
+              # step*onCount / step*offCount seconds, with no manual action
+              # needed to both fire AND resolve the rule — 20s high (100),
+              # then 20s low (0), on repeat.
+              scenarioId: predictable_pulse
+              step: 10
+              onCount: 2
+              onValue: 100
+              offCount: 2
+              offValue: 0
+          - refId: B
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              expression: A
+              reducer: last
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [50]
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          # fields.message: annotations.summary
+          summary: CPU is high on api-0
+        labels:
+          # Grafana injects `alertname: <rule title>` automatically — no need
+          # to set it here. These map to fields.severity / .namespace / .workload_name.
+          severity: critical
+          namespace: payments
+          pod: api-0

--- a/hack/integration/grafana/provisioning/datasources/testdata.yml
+++ b/hack/integration/grafana/provisioning/datasources/testdata.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: TestData
+    type: testdata
+    uid: testdata
+    access: proxy
+    isDefault: true

--- a/hack/integration/grafana/runlore.config.yaml
+++ b/hack/integration/grafana/runlore.config.yaml
@@ -1,0 +1,11 @@
+# Config for `lore serve` in the hack/integration/grafana/ local verification
+# recipe — committed + parse-tested (internal/config, see
+# TestShippedExampleConfigsLoad).
+sources:
+  grafana:
+    token_env: GRAFANA_WEBHOOK_TOKEN
+triggers:
+  incidents:
+    match:
+      severity: [critical, warning]
+    dedup: { window: 30m }

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/Smana/runlore/internal/source/alertmanager" // self-registers the alertmanager webhook source
 	_ "github.com/Smana/runlore/internal/source/custom"       // self-registers the config-mapped generic webhook source
 	_ "github.com/Smana/runlore/internal/source/gitops"       // self-registers the gitops-failure watcher source
+	_ "github.com/Smana/runlore/internal/source/grafana"      // self-registers the Grafana Alerting webhook source
 	"github.com/Smana/runlore/internal/source/pagerduty"
 	"github.com/Smana/runlore/internal/telemetry"
 	"github.com/Smana/runlore/internal/trigger"

--- a/internal/config/shipped_configs_test.go
+++ b/internal/config/shipped_configs_test.go
@@ -37,20 +37,24 @@ func repoRoot(t *testing.T) string {
 // the list.
 func TestShippedExampleConfigsLoad(t *testing.T) {
 	root := repoRoot(t)
-	shipped := []string{
-		filepath.Join(root, "hack", "demo.config.yaml"),
+	shipped := []struct {
+		path      string
+		wantMount string // sources.<name> that must be wired for the config to serve its purpose
+	}{
+		{filepath.Join(root, "hack", "demo.config.yaml"), "alertmanager"},
+		{filepath.Join(root, "hack", "integration", "grafana", "runlore.config.yaml"), "grafana"},
 	}
-	for _, path := range shipped {
-		t.Run(filepath.Base(path), func(t *testing.T) {
-			if _, err := os.Stat(path); err != nil {
+	for _, s := range shipped {
+		t.Run(filepath.Base(s.path), func(t *testing.T) {
+			if _, err := os.Stat(s.path); err != nil {
 				t.Fatalf("shipped config missing: %v", err)
 			}
-			c, err := Load(path)
+			c, err := Load(s.path)
 			if err != nil {
 				t.Fatalf("shipped config must load under the strict loader: %v", err)
 			}
-			if _, ok := c.Sources["alertmanager"]; !ok {
-				t.Errorf("expected sources.alertmanager to be wired (the demo fires alertmanager webhooks)")
+			if _, ok := c.Sources[s.wantMount]; !ok {
+				t.Errorf("expected sources.%s to be wired", s.wantMount)
 			}
 		})
 	}

--- a/internal/docsguard/integration_pages_test.go
+++ b/internal/docsguard/integration_pages_test.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/Smana/runlore/internal/source/alertmanager" // self-registers the "alertmanager" source
 	_ "github.com/Smana/runlore/internal/source/custom"       // self-registers the "custom" source
 	_ "github.com/Smana/runlore/internal/source/gitops"       // self-registers the "gitops" source
+	_ "github.com/Smana/runlore/internal/source/grafana"      // self-registers the "grafana" source
 	_ "github.com/Smana/runlore/internal/source/pagerduty"    // self-registers the "pagerduty" source
 	// notify's own package (imported above) self-registers "slack" and "matrix"
 	// directly via their own init() funcs — no blank import needed for those two.

--- a/internal/docsguard/source_imports_test.go
+++ b/internal/docsguard/source_imports_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/source"
+)
+
+// TestEverySourcePackageIsImportedHere guards the guard's own inputs.
+//
+// TestIntegrationPagesMatchRegistries reflects over source.Registered(), which is
+// populated by each source package's init() — and init() only runs for packages
+// this test binary actually imports. Those imports are the hand-written blank
+// import block at the top of integration_pages_test.go.
+//
+// So a new source added without its blank import is INVISIBLE to the page guard.
+// One direction of that still fails loudly (a page claiming an unregistered id is
+// rejected), but the other passes in silence: the source ships with no docs page
+// at all and nothing complains, which is precisely the gap the page guard exists
+// to close. That is not hypothetical — internal/source/grafana was added on a
+// branch that predated this package and arrived with no import here.
+//
+// Counting the packages on disk is the cross-check the import list cannot perform
+// on itself. It deliberately reads the directory rather than a second list: a
+// list would need the same maintenance as the imports, and would drift with them.
+func TestEverySourcePackageIsImportedHere(t *testing.T) {
+	dir := filepath.Join(repoRoot(t), "internal", "source")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	var onDisk []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue // registry.go, webhook.go et al — the framework, not a source
+		}
+		onDisk = append(onDisk, e.Name())
+	}
+	if len(onDisk) == 0 {
+		t.Fatalf("no source packages found under %s — the layout changed and this guard is inert", dir)
+	}
+
+	registered := map[string]bool{}
+	for _, d := range source.Registered() {
+		registered[d.Name] = true
+	}
+
+	for _, pkg := range onDisk {
+		if !registered[pkg] {
+			t.Errorf("internal/source/%s exists but is not registered in this test binary — add\n"+
+				"\t_ \"github.com/Smana/runlore/internal/source/%s\"\n"+
+				"to the blank-import block in integration_pages_test.go, or the page guard silently "+
+				"skips this source and it can ship with no docs page", pkg, pkg)
+		}
+	}
+	t.Logf("%d source packages on disk, all registered", len(onDisk))
+}

--- a/internal/investigate/investigate.go
+++ b/internal/investigate/investigate.go
@@ -37,6 +37,13 @@ const (
 	// SourceCustom means the investigation was triggered by a generic
 	// (config-mapped) vendor webhook — sources.custom.
 	SourceCustom Source = "custom"
+	// SourceGrafana means the investigation was triggered by Grafana Alerting —
+	// sources.grafana. It delegates extraction to the same mapper as
+	// SourceCustom but MUST keep its own value: Source is part of the
+	// workqueue's coalescing key (see keyOf), so sharing "custom" would make a
+	// Grafana incident silently coalesce with a same-titled one from a
+	// sources.custom instance on the same workload.
+	SourceGrafana Source = "grafana"
 )
 
 // SeverityCritical is the paging-grade alert severity. It is the ONE spelling

--- a/internal/source/custom/config.go
+++ b/internal/source/custom/config.go
@@ -7,7 +7,67 @@ import (
 	"sort"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/investigate"
 )
+
+// Option tunes Build/parseConfig for an adapter that delegates to this mapper
+// but exposes its OWN config surface (internal/source/grafana). Passing no
+// options yields plain `sources.custom` behaviour, byte for byte — the custom
+// source's own registration passes none.
+type Option func(*options)
+
+// options is the resolved form of the Option list.
+type options struct {
+	// block names the config key the whole mapping block was read from, for
+	// errors that are not about one instance ("at least one instance is
+	// required", decode failures).
+	block string
+	// instancePath renders the operator-facing config path of ONE instance's
+	// keys. It is a function rather than a prefix string because the two
+	// callers disagree on shape: `custom` multiplexes named instances
+	// (sources.custom.instances.<name>) while an adapter compiles a single
+	// synthetic instance under a flat key (sources.grafana) whose name the
+	// operator never typed and must therefore never see in an error.
+	instancePath func(name string) string
+	// src is stamped on every investigate.Request this mapping produces. It is
+	// part of investigate's workqueue coalescing key, so an adapter MUST claim
+	// its own value or its incidents silently coalesce with same-titled ones
+	// from a plain custom instance.
+	src investigate.Source
+}
+
+// resolveOptions applies opts over the `sources.custom` defaults.
+func resolveOptions(opts []Option) options {
+	o := options{
+		block:        "sources.custom",
+		instancePath: func(name string) string { return "sources.custom.instances." + name },
+		src:          investigate.SourceCustom,
+	}
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}
+
+// WithConfigPath makes every startup error name path — the key the OPERATOR
+// actually wrote — instead of the synthetic
+// `sources.custom.instances.<name>` this mapper compiles the mapping under.
+// Without it a typo under `sources.grafana` fails closed loudly but points at
+// a path that does not exist in the operator's file.
+func WithConfigPath(path string) Option {
+	return func(o *options) {
+		o.block = path
+		o.instancePath = func(string) string { return path }
+	}
+}
+
+// WithSource stamps s on every investigate.Request instead of
+// investigate.SourceCustom, so an adapter's investigations stay distinct from
+// a custom instance's in the workqueue's coalescing key (and in logs).
+func WithSource(s investigate.Source) Option {
+	return func(o *options) { o.src = s }
+}
 
 // instanceCfg is the raw yaml shape of one sources.custom.instances entry.
 type instanceCfg struct {
@@ -48,34 +108,38 @@ type instance struct {
 	defaults      map[string]string
 	severityMap   map[string]string
 	tokenEnv      string
-	token         string // resolved at Build; see auth.go
+	token         string             // resolved at Build; see auth.go
+	src           investigate.Source // stamped on every Request; see options.src
 }
 
 // parseConfig compiles the sources.custom block. Every error aborts startup —
-// a bad mapping must never silently drop alerts at ingest.
-func parseConfig(node yaml.Node) (map[string]*instance, error) {
+// a bad mapping must never silently drop alerts at ingest. opts (see Option)
+// only change how errors NAME the config and which source the compiled
+// mapping claims; the mapping semantics are identical either way.
+func parseConfig(node yaml.Node, opts ...Option) (map[string]*instance, error) {
+	o := resolveOptions(opts)
 	// Loud unknown-key check per instance (node-level, since instanceCfg's plain
 	// Decode is not strict).
 	var rawRoot struct {
 		Instances map[string]map[string]yaml.Node `yaml:"instances"`
 	}
 	if err := node.Decode(&rawRoot); err != nil {
-		return nil, fmt.Errorf("decode sources.custom: %w", err)
+		return nil, fmt.Errorf("decode %s: %w", o.block, err)
 	}
 	for name, keys := range rawRoot.Instances {
 		for k := range keys {
 			if !instanceKeys[k] {
-				return nil, fmt.Errorf("sources.custom.instances.%s: unknown key %q", name, k)
+				return nil, fmt.Errorf("%s: unknown key %q", o.instancePath(name), k)
 			}
 		}
 	}
 
 	var c rootCfg
 	if err := node.Decode(&c); err != nil {
-		return nil, fmt.Errorf("decode sources.custom: %w", err)
+		return nil, fmt.Errorf("decode %s: %w", o.block, err)
 	}
 	if len(c.Instances) == 0 {
-		return nil, fmt.Errorf("sources.custom: at least one instance is required")
+		return nil, fmt.Errorf("%s: at least one instance is required", o.block)
 	}
 	out := make(map[string]*instance, len(c.Instances))
 	names := make([]string, 0, len(c.Instances))
@@ -85,8 +149,9 @@ func parseConfig(node yaml.Node) (map[string]*instance, error) {
 	sort.Strings(names) // deterministic error order
 	for _, name := range names {
 		ic := c.Instances[name]
+		where := o.instancePath(name)
 		if ic.Fields["title"] == "" {
-			return nil, fmt.Errorf("sources.custom.instances.%s: fields.title is required", name)
+			return nil, fmt.Errorf("%s: fields.title is required", where)
 		}
 		inst := &instance{
 			fields:        map[string]path{},
@@ -94,31 +159,32 @@ func parseConfig(node yaml.Node) (map[string]*instance, error) {
 			defaults:      ic.Defaults,
 			severityMap:   ic.SeverityMap,
 			tokenEnv:      ic.TokenEnv,
+			src:           o.src,
 		}
 		if inst.resolvedValue == "" {
 			inst.resolvedValue = "resolved"
 		}
 		for f, p := range ic.Fields {
 			if !fieldNames[f] {
-				return nil, fmt.Errorf("sources.custom.instances.%s: unknown field %q", name, f)
+				return nil, fmt.Errorf("%s: unknown field %q", where, f)
 			}
 			cp, err := parsePath(p)
 			if err != nil {
-				return nil, fmt.Errorf("sources.custom.instances.%s: fields.%s: %w", name, f, err)
+				return nil, fmt.Errorf("%s: fields.%s: %w", where, f, err)
 			}
 			inst.fields[f] = cp
 		}
 		if ic.Items != "" {
 			cp, err := parsePath(ic.Items)
 			if err != nil {
-				return nil, fmt.Errorf("sources.custom.instances.%s: items: %w", name, err)
+				return nil, fmt.Errorf("%s: items: %w", where, err)
 			}
 			inst.items = cp
 		}
 		if ic.Labels != "" {
 			cp, err := parsePath(ic.Labels)
 			if err != nil {
-				return nil, fmt.Errorf("sources.custom.instances.%s: labels: %w", name, err)
+				return nil, fmt.Errorf("%s: labels: %w", where, err)
 			}
 			inst.labels = cp
 		}

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"time"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/investigate"
@@ -126,6 +128,38 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 	return out, nil
 }
 
+// Build compiles a `sources.custom`-shaped yaml.Node (its `instances:` map)
+// into a ready Source: parses and validates every instance's field mapping,
+// resolves each instance's token (and the shared server.webhook_token_env
+// fallback), and enforces actions.mode=auto's fail-closed token requirement.
+// Exported so an adapter that delegates to this mapper with baked-in
+// defaults (internal/source/grafana) reuses the same validation and
+// token-resolution path instead of re-implementing it.
+func Build(node yaml.Node, cfg *config.Config) (*Source, error) {
+	insts, err := parseConfig(node)
+	if err != nil {
+		return nil, err
+	}
+	shared := ""
+	if cfg != nil && cfg.Server.WebhookTokenEnv != "" {
+		shared = osGetenv(cfg.Server.WebhookTokenEnv)
+	}
+	for name, inst := range insts {
+		if inst.tokenEnv != "" {
+			inst.token = osGetenv(inst.tokenEnv)
+			if inst.token == "" {
+				return nil, fmt.Errorf("sources.custom.instances.%s: token_env %q is empty", name, inst.tokenEnv)
+			}
+		}
+		// Fail closed under mode=auto: an unattended executor must not
+		// accept unauthenticated vendor webhooks (PagerDuty precedent).
+		if cfg != nil && cfg.Actions.Mode == config.ActionAuto && inst.token == "" && shared == "" {
+			return nil, fmt.Errorf("actions.mode=auto requires a token for sources.custom.instances.%s (token_env or server.webhook_token_env)", name)
+		}
+	}
+	return &Source{instances: insts, shared: shared}, nil
+}
+
 func init() {
 	source.Register(source.Descriptor{
 		Name: "custom",
@@ -135,28 +169,7 @@ func init() {
 			if !ok {
 				return nil, nil // disabled: no sources.custom key
 			}
-			insts, err := parseConfig(node)
-			if err != nil {
-				return nil, err
-			}
-			shared := ""
-			if d.Cfg != nil && d.Cfg.Server.WebhookTokenEnv != "" {
-				shared = osGetenv(d.Cfg.Server.WebhookTokenEnv)
-			}
-			for name, inst := range insts {
-				if inst.tokenEnv != "" {
-					inst.token = osGetenv(inst.tokenEnv)
-					if inst.token == "" {
-						return nil, fmt.Errorf("sources.custom.instances.%s: token_env %q is empty", name, inst.tokenEnv)
-					}
-				}
-				// Fail closed under mode=auto: an unattended executor must not
-				// accept unauthenticated vendor webhooks (PagerDuty precedent).
-				if d.Cfg != nil && d.Cfg.Actions.Mode == config.ActionAuto && inst.token == "" && shared == "" {
-					return nil, fmt.Errorf("actions.mode=auto requires a token for sources.custom.instances.%s (token_env or server.webhook_token_env)", name)
-				}
-			}
-			return &Source{instances: insts, shared: shared}, nil
+			return Build(node, d.Cfg)
 		},
 	})
 }

--- a/internal/source/custom/custom.go
+++ b/internal/source/custom/custom.go
@@ -109,7 +109,10 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 			fps = []string{fingerprint}
 		}
 		out.Requests = append(out.Requests, investigate.Request{
-			Source:       investigate.SourceCustom,
+			// Per-instance (see WithSource), not a package constant: Source is
+			// part of investigate's workqueue coalescing key, so an adapter
+			// delegating here must be able to claim its own value.
+			Source:       inst.src,
 			Title:        title,
 			Severity:     severity,
 			Environment:  get("environment"),
@@ -134,9 +137,13 @@ func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error)
 // fallback), and enforces actions.mode=auto's fail-closed token requirement.
 // Exported so an adapter that delegates to this mapper with baked-in
 // defaults (internal/source/grafana) reuses the same validation and
-// token-resolution path instead of re-implementing it.
-func Build(node yaml.Node, cfg *config.Config) (*Source, error) {
-	insts, err := parseConfig(node)
+// token-resolution path instead of re-implementing it. Such an adapter passes
+// WithConfigPath/WithSource so startup errors name the key the operator really
+// wrote and its investigations stay distinct from a custom instance's; with no
+// options this is exactly the plain `sources.custom` build.
+func Build(node yaml.Node, cfg *config.Config, opts ...Option) (*Source, error) {
+	o := resolveOptions(opts)
+	insts, err := parseConfig(node, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -145,16 +152,17 @@ func Build(node yaml.Node, cfg *config.Config) (*Source, error) {
 		shared = osGetenv(cfg.Server.WebhookTokenEnv)
 	}
 	for name, inst := range insts {
+		where := o.instancePath(name)
 		if inst.tokenEnv != "" {
 			inst.token = osGetenv(inst.tokenEnv)
 			if inst.token == "" {
-				return nil, fmt.Errorf("sources.custom.instances.%s: token_env %q is empty", name, inst.tokenEnv)
+				return nil, fmt.Errorf("%s: token_env %q is empty", where, inst.tokenEnv)
 			}
 		}
 		// Fail closed under mode=auto: an unattended executor must not
 		// accept unauthenticated vendor webhooks (PagerDuty precedent).
 		if cfg != nil && cfg.Actions.Mode == config.ActionAuto && inst.token == "" && shared == "" {
-			return nil, fmt.Errorf("actions.mode=auto requires a token for sources.custom.instances.%s (token_env or server.webhook_token_env)", name)
+			return nil, fmt.Errorf("actions.mode=auto requires a token for %s (token_env or server.webhook_token_env)", where)
 		}
 	}
 	return &Source{instances: insts, shared: shared}, nil

--- a/internal/source/custom/options_test.go
+++ b/internal/source/custom/options_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package custom
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+)
+
+// TestDefaultErrorsStillNameTheCustomPath is the other half of the
+// config-path guard in internal/source/grafana: making an adapter's errors
+// name its own key must not change what a PLAIN sources.custom instance
+// reports. A typo under sources.custom.instances.a still has to say exactly
+// that — the operator's own path.
+func TestDefaultErrorsStillNameTheCustomPath(t *testing.T) {
+	cases := []struct{ name, yml string }{
+		{"unknown key", `
+instances:
+  a: {fields: {title: t}, feilds: x}`},
+		{"missing title", `
+instances:
+  a: {fields: {severity: s}}`},
+		{"bad field path", `
+instances:
+  a: {fields: {title: "x["}}`},
+		{"bad items path", `
+instances:
+  a: {fields: {title: t}, items: "x["}`},
+		{"bad labels path", `
+instances:
+  a: {fields: {title: t}, labels: "x["}`},
+	}
+	for _, c := range cases {
+		_, err := parseConfig(mustNode(t, c.yml))
+		if err == nil {
+			t.Errorf("%s: want an error, got nil", c.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "sources.custom.instances.a") {
+			t.Errorf("%s: error %q must name sources.custom.instances.a", c.name, err)
+		}
+	}
+}
+
+// TestDefaultBuildErrorsNameTheCustomPath covers the two messages built in
+// Build rather than parseConfig (token_env resolution and the mode=auto
+// fail-closed check).
+func TestDefaultBuildErrorsNameTheCustomPath(t *testing.T) {
+	node := mustNode(t, `
+instances:
+  a: {token_env: CUSTOM_TOK_DEFINITELY_UNSET, fields: {title: t}}
+`)
+	_, err := Build(node, &config.Config{})
+	if err == nil || !strings.Contains(err.Error(), "sources.custom.instances.a: token_env") {
+		t.Errorf("empty token_env error = %v, want it to name sources.custom.instances.a", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionAuto
+	_, err = Build(mustNode(t, `
+instances:
+  a: {fields: {title: t}}
+`), cfg)
+	if err == nil || !strings.Contains(err.Error(), "sources.custom.instances.a") {
+		t.Errorf("mode=auto fail-closed error = %v, want it to name sources.custom.instances.a", err)
+	}
+}
+
+// TestWithConfigPathAndSource pins the two knobs an adapter relies on, at the
+// package that owns them: errors name the adapter's key (never the synthetic
+// custom path), and requests carry the adapter's source.
+func TestWithConfigPathAndSource(t *testing.T) {
+	_, err := parseConfig(mustNode(t, `
+instances:
+  grafana: {fields: {title: t}, feilds: x}
+`), WithConfigPath("sources.grafana"))
+	if err == nil {
+		t.Fatal("want an unknown-key error")
+	}
+	if !strings.Contains(err.Error(), "sources.grafana") || strings.Contains(err.Error(), "sources.custom") {
+		t.Errorf("error = %q, want it to name sources.grafana and never sources.custom", err)
+	}
+
+	insts, err := parseConfig(mustNode(t, `
+instances:
+  grafana: {fields: {title: t}}
+`), WithSource(investigate.SourceGrafana))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := insts["grafana"].src; got != investigate.SourceGrafana {
+		t.Errorf("compiled source = %q, want %q", got, investigate.SourceGrafana)
+	}
+
+	// No options at all: unchanged sources.custom semantics.
+	insts, err = parseConfig(mustNode(t, `
+instances:
+  a: {fields: {title: t}}
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := insts["a"].src; got != investigate.SourceCustom {
+		t.Errorf("default compiled source = %q, want %q", got, investigate.SourceCustom)
+	}
+}

--- a/internal/source/grafana/grafana.go
+++ b/internal/source/grafana/grafana.go
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package grafana registers the "grafana" webhook source: Grafana Alerting's
+// firing/resolved contact-point payload, mapped to investigations by
+// delegating to the custom source's field-extraction mapper
+// (internal/source/custom) with the documented default field paths baked
+// in. It does not parse alert JSON itself — dot-path extraction, `items`
+// batching, severity_map, resolved-event handling, per-instance tokens, the
+// body cap and startup mapping validation all stay custom's job. The point
+// is that Grafana users stop hand-copying nine field paths into
+// sources.custom.instances.*, not that Grafana gets its own parser. Every
+// default stays overridable via sources.grafana's own keys.
+package grafana
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/source"
+	"github.com/Smana/runlore/internal/source/custom"
+)
+
+// instanceName is the fixed synthetic custom-instance key the merged mapping
+// is compiled under, and the X-Runlore-Instance value stamped on every
+// delegated call. Grafana has one mapping per RunLore deployment — the
+// route is /webhook/grafana with no {instance} wildcard — unlike `custom`,
+// which multiplexes several instances behind /webhook/custom/{instance}.
+const instanceName = "grafana"
+
+// defaultFields is the built-in Grafana → investigation field mapping. It
+// must equal the table documented at
+// website/content/docs/integrations/grafana.md — TestDefaultMappingMatchesDocs
+// pins the two together so a change to either shows up as a visible test
+// diff rather than a silent behaviour change.
+var defaultFields = map[string]string{
+	"title":         "labels.alertname",
+	"message":       "annotations.summary",
+	"severity":      "labels.severity",
+	"namespace":     "labels.namespace",
+	"workload_name": "labels.pod",
+	"fingerprint":   "fingerprint",
+	"resolved":      "status",
+}
+
+const (
+	defaultItems  = "alerts" // Grafana's contact-point payload batches alerts under "alerts"
+	defaultLabels = "labels"
+)
+
+// Source wraps a custom.Source pre-compiled with Grafana's baked-in mapping.
+// All extraction, batching, severity mapping, resolved-event handling and
+// per-instance auth live in custom.Source (see internal/source/custom); this
+// type only fixes the delegated call's instance selector to instanceName,
+// since /webhook/grafana carries no {instance} path wildcard for the core to
+// stamp one from.
+type Source struct {
+	inner *custom.Source
+}
+
+// Decode implements source.WebhookSource by delegating to the compiled
+// custom mapping.
+func (s *Source) Decode(body []byte, h http.Header) (source.DecodeResult, error) {
+	return s.inner.Decode(body, withInstance(h))
+}
+
+// Authenticate implements source.Authenticator, mirroring custom.Source: the
+// delegated instance's own token_env (falling back to the shared
+// server.webhook_token_env) gates the request before Decode ever runs.
+func (s *Source) Authenticate(body []byte, h http.Header) bool {
+	return s.inner.Authenticate(body, withInstance(h))
+}
+
+// withInstance stamps the fixed instance name the merged mapping was
+// compiled under, so custom.Source's instance lookup resolves regardless of
+// what the core did (or, on this wildcard-less route, did not) set on the
+// inbound request.
+func withInstance(h http.Header) http.Header {
+	h2 := h.Clone()
+	h2.Set(source.InstanceHeader, instanceName)
+	return h2
+}
+
+// mergedNode renders the baked-in defaults overlaid by the user's
+// sources.grafana block as the `instances: {grafana: ...}` yaml.Node
+// custom.Build expects. It never inspects mapping semantics itself (dot
+// paths, items, severity_map, ...) — assembling the config is all this
+// function does; compiling and validating it stays custom's job.
+func mergedNode(user yaml.Node) (yaml.Node, error) {
+	var userMap map[string]any
+	if err := user.Decode(&userMap); err != nil {
+		return yaml.Node{}, fmt.Errorf("decode sources.grafana: %w", err)
+	}
+
+	fields := make(map[string]any, len(defaultFields))
+	for k, v := range defaultFields {
+		fields[k] = v
+	}
+	defaults := map[string]any{
+		"items":  defaultItems,
+		"labels": defaultLabels,
+		"fields": fields,
+	}
+	merged := mergeMaps(defaults, userMap)
+	outer := map[string]any{"instances": map[string]any{instanceName: merged}}
+
+	// Round-trip through YAML text (rather than yaml.Node.Encode) to build the
+	// node custom.Build expects — the same approach internal/source/custom's
+	// own tests use (mustNode) to build a yaml.Node from a Go value.
+	b, err := yaml.Marshal(outer)
+	if err != nil {
+		return yaml.Node{}, fmt.Errorf("marshal merged sources.grafana: %w", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		return yaml.Node{}, fmt.Errorf("reparse merged sources.grafana: %w", err)
+	}
+	return *doc.Content[0], nil
+}
+
+// mergeMaps overlays user onto defaults. A key present as a map on both
+// sides is merged key-by-key — so overriding fields.workload_name leaves
+// every other default field path in place — while every other key is
+// wholesale-replaced when the user sets it. This is what makes "every field
+// stays overridable" true without forcing an all-or-nothing block.
+func mergeMaps(defaults, user map[string]any) map[string]any {
+	out := make(map[string]any, len(defaults)+len(user))
+	for k, v := range defaults {
+		out[k] = v
+	}
+	for k, v := range user {
+		if dm, ok := out[k].(map[string]any); ok {
+			if um, ok := v.(map[string]any); ok {
+				merged := make(map[string]any, len(dm)+len(um))
+				for kk, vv := range dm {
+					merged[kk] = vv
+				}
+				for kk, vv := range um {
+					merged[kk] = vv
+				}
+				out[k] = merged
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func init() {
+	source.Register(source.Descriptor{
+		Name: "grafana",
+		Kind: source.Webhook, Admission: source.MatchGated, Path: "/webhook/grafana",
+		Build: func(d source.Deps) (any, error) {
+			node, ok := d.Raw["grafana"]
+			if !ok {
+				return nil, nil // disabled: no sources.grafana key
+			}
+			n, err := mergedNode(node)
+			if err != nil {
+				return nil, fmt.Errorf("sources.grafana: %w", err)
+			}
+			inner, err := custom.Build(n, d.Cfg)
+			if err != nil {
+				return nil, fmt.Errorf("sources.grafana: %w", err)
+			}
+			return &Source{inner: inner}, nil
+		},
+	})
+}

--- a/internal/source/grafana/grafana.go
+++ b/internal/source/grafana/grafana.go
@@ -18,6 +18,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/source"
 	"github.com/Smana/runlore/internal/source/custom"
 )
@@ -77,7 +78,14 @@ func (s *Source) Authenticate(body []byte, h http.Header) bool {
 // what the core did (or, on this wildcard-less route, did not) set on the
 // inbound request.
 func withInstance(h http.Header) http.Header {
+	// http.Header(nil).Clone() returns a nil Header, and Set on a nil map
+	// panics. Built.Handler always hands us a non-nil header so this is
+	// unreachable in the server, but Decode/Authenticate are exported and a
+	// direct caller passing nil must not take the process down.
 	h2 := h.Clone()
+	if h2 == nil {
+		h2 = http.Header{}
+	}
 	h2.Set(source.InstanceHeader, instanceName)
 	return h2
 }
@@ -159,11 +167,21 @@ func init() {
 			}
 			n, err := mergedNode(node)
 			if err != nil {
-				return nil, fmt.Errorf("sources.grafana: %w", err)
+				return nil, err // mergedNode's errors already name sources.grafana
 			}
-			inner, err := custom.Build(n, d.Cfg)
+			// WithConfigPath: the mapping is compiled under the synthetic
+			// instance name "grafana", a path (sources.custom.instances.grafana)
+			// that appears nowhere in the operator's file — startup errors must
+			// name the key they actually wrote. WithSource: keep Grafana
+			// investigations out of sources.custom's workqueue coalescing key.
+			// Both errors are returned unwrapped for the same reason: the core
+			// already prefixes `source "grafana": `, and custom now names the
+			// config path itself.
+			inner, err := custom.Build(n, d.Cfg,
+				custom.WithConfigPath("sources.grafana"),
+				custom.WithSource(investigate.SourceGrafana))
 			if err != nil {
-				return nil, fmt.Errorf("sources.grafana: %w", err)
+				return nil, err
 			}
 			return &Source{inner: inner}, nil
 		},

--- a/internal/source/grafana/grafana_test.go
+++ b/internal/source/grafana/grafana_test.go
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package grafana
+
+import (
+	"net/http"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/source"
+)
+
+// TestDefaultMappingMatchesDocs is the defining test: the built-in mapping
+// must equal, field for field, the table documented at
+// website/content/docs/integrations/grafana.md (carried forward from the
+// hand-written example that used to live at
+// website/content/docs/integrations/custom-webhook.md). A change to either
+// side must show up here as a visible diff — never a silent behaviour change.
+func TestDefaultMappingMatchesDocs(t *testing.T) {
+	documented := map[string]string{
+		"title":         "labels.alertname",
+		"message":       "annotations.summary",
+		"severity":      "labels.severity",
+		"namespace":     "labels.namespace",
+		"workload_name": "labels.pod",
+		"fingerprint":   "fingerprint",
+		"resolved":      "status",
+	}
+	if len(defaultFields) != len(documented) {
+		t.Fatalf("defaultFields has %d entries, documented table has %d", len(defaultFields), len(documented))
+	}
+	for field, path := range documented {
+		if got := defaultFields[field]; got != path {
+			t.Errorf("fields.%s = %q, documented default is %q", field, got, path)
+		}
+	}
+	if defaultItems != "alerts" {
+		t.Errorf("items = %q, documented default is %q", defaultItems, "alerts")
+	}
+	if defaultLabels != "labels" {
+		t.Errorf("labels = %q, documented default is %q", defaultLabels, "labels")
+	}
+}
+
+// mustNode parses y as a YAML document and unwraps it to the root content
+// node, mirroring internal/source/custom's own test helper.
+func mustNode(t *testing.T, y string) yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	if err := yaml.Unmarshal([]byte(y), &n); err != nil {
+		t.Fatal(err)
+	}
+	return *n.Content[0]
+}
+
+// buildFor drives the registered "grafana" descriptor's Build func directly,
+// the same way internal/source/custom's own TestBuildFailClosedUnderAuto
+// does, so these tests exercise the actual registration path rather than a
+// look-alike.
+func buildFor(t *testing.T, grafanaYAML string, cfg *config.Config) (*Source, error) {
+	t.Helper()
+	var build func(source.Deps) (any, error)
+	for _, d := range source.Registered() {
+		if d.Name == "grafana" {
+			build = d.Build
+		}
+	}
+	if build == nil {
+		t.Fatal("grafana source not registered")
+	}
+	raw := map[string]yaml.Node{}
+	if grafanaYAML != "" {
+		raw["grafana"] = mustNode(t, grafanaYAML)
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	impl, err := build(source.Deps{Cfg: cfg, Raw: raw})
+	if err != nil {
+		return nil, err
+	}
+	if impl == nil {
+		return nil, nil
+	}
+	s, ok := impl.(*Source)
+	if !ok {
+		t.Fatalf("Build returned %T, want *Source", impl)
+	}
+	return s, nil
+}
+
+const batchBody = `{"alerts":[
+  {"status":"firing","fingerprint":"fp1","labels":{"alertname":"HighCPU","severity":"critical","namespace":"payments","pod":"api-0"},"annotations":{"summary":"CPU is high"}},
+  {"status":"firing","fingerprint":"fp2","labels":{"alertname":"DiskFull","severity":"warning","namespace":"billing","pod":"billing-2"},"annotations":{"summary":"disk almost full"}},
+  {"status":"resolved","fingerprint":"fp3","labels":{"alertname":"OldAlert"}}
+]}`
+
+func TestDecodeBatch(t *testing.T) {
+	s, err := buildFor(t, `{}`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.Decode([]byte(batchBody), http.Header{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 2 {
+		t.Fatalf("got %d requests, want 2", len(res.Requests))
+	}
+	r0 := res.Requests[0]
+	if r0.Source != investigate.SourceCustom || r0.Title != "HighCPU" || r0.Message != "CPU is high" {
+		t.Errorf("request[0] basics wrong: %+v", r0)
+	}
+	if r0.Workload.Namespace != "payments" || r0.Workload.Name != "api-0" {
+		t.Errorf("request[0] workload wrong: %+v", r0.Workload)
+	}
+	if r0.Severity != "critical" || r0.Fingerprint != "fp1" {
+		t.Errorf("request[0] severity/fingerprint wrong: %+v", r0)
+	}
+	r1 := res.Requests[1]
+	if r1.Title != "DiskFull" || r1.Workload.Namespace != "billing" || r1.Workload.Name != "billing-2" {
+		t.Errorf("request[1] wrong: %+v", r1)
+	}
+}
+
+// TestDecodeResolvedRecordsResolution: a resolved event must record a
+// resolution, not trigger a second investigation.
+func TestDecodeResolvedRecordsResolution(t *testing.T) {
+	s, err := buildFor(t, `{}`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.Decode([]byte(batchBody), http.Header{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Resolved) != 1 {
+		t.Fatalf("got %d resolutions, want 1", len(res.Resolved))
+	}
+	if res.Resolved[0].Fingerprint != "fp3" {
+		t.Errorf("resolution fingerprint = %q, want fp3", res.Resolved[0].Fingerprint)
+	}
+	// The resolved alert must not also appear as a firing request.
+	for _, r := range res.Requests {
+		if r.Fingerprint == "fp3" {
+			t.Errorf("resolved alert fp3 also produced an investigation request: %+v", r)
+		}
+	}
+}
+
+func TestTokenEnvFallsBackToServerWebhookTokenEnv(t *testing.T) {
+	t.Setenv("SHARED_TOK", "s3cret")
+	cfg := &config.Config{}
+	cfg.Server.WebhookTokenEnv = "SHARED_TOK"
+	cfg.Actions.Mode = config.ActionAuto // fail-closed path: must accept the shared token
+
+	s, err := buildFor(t, `{}`, cfg) // no token_env of its own
+	if err != nil {
+		t.Fatalf("build should succeed via the shared token fallback: %v", err)
+	}
+	h := http.Header{}
+	h.Set("Authorization", "Bearer s3cret")
+	if !s.Authenticate([]byte(`{}`), h) {
+		t.Error("Authenticate should accept the shared server.webhook_token_env token")
+	}
+	h.Set("Authorization", "Bearer wrong")
+	if s.Authenticate([]byte(`{}`), h) {
+		t.Error("Authenticate should reject a token that does not match")
+	}
+}
+
+func TestTokenEnvOverridesShared(t *testing.T) {
+	t.Setenv("GRAFANA_TOK", "g3cret")
+	t.Setenv("SHARED_TOK", "shared")
+	cfg := &config.Config{}
+	cfg.Server.WebhookTokenEnv = "SHARED_TOK"
+
+	s, err := buildFor(t, `{token_env: GRAFANA_TOK}`, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := http.Header{}
+	h.Set("Authorization", "Bearer g3cret")
+	if !s.Authenticate(nil, h) {
+		t.Error("Authenticate should accept the instance's own token_env value")
+	}
+	h.Set("Authorization", "Bearer shared")
+	if s.Authenticate(nil, h) {
+		t.Error("an instance token_env set should stop the shared token from being accepted")
+	}
+}
+
+// TestFieldOverride: every field stays overridable — a single overridden
+// field path must apply, and every other field must keep its default.
+func TestFieldOverride(t *testing.T) {
+	s, err := buildFor(t, `
+fields:
+  workload_name: labels.deployment
+`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := `{"alerts":[{"status":"firing","fingerprint":"fp1","labels":{"alertname":"HighCPU","severity":"critical","namespace":"payments","deployment":"api"},"annotations":{"summary":"CPU is high"}}]}`
+	res, err := s.Decode([]byte(body), http.Header{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 1 {
+		t.Fatalf("got %d requests, want 1", len(res.Requests))
+	}
+	r := res.Requests[0]
+	if r.Workload.Name != "api" {
+		t.Errorf("overridden workload_name path not applied: %+v", r.Workload)
+	}
+	// Every other default field must still resolve.
+	if r.Title != "HighCPU" || r.Severity != "critical" || r.Workload.Namespace != "payments" || r.Message != "CPU is high" {
+		t.Errorf("overriding one field broke the others: %+v", r)
+	}
+}
+
+// TestItemsOverride: overriding items (the batch path) must also work —
+// not just leaf field paths.
+func TestItemsOverride(t *testing.T) {
+	s, err := buildFor(t, `items: data.alerts`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := `{"data":{"alerts":[{"status":"firing","fingerprint":"fp1","labels":{"alertname":"X","severity":"warning","namespace":"ns","pod":"p"},"annotations":{"summary":"m"}}]}}`
+	res, err := s.Decode([]byte(body), http.Header{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Requests) != 1 || res.Requests[0].Title != "X" {
+		t.Fatalf("items override not applied: %+v", res)
+	}
+}
+
+func TestDisabledWithoutConfigKey(t *testing.T) {
+	s, err := buildFor(t, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != nil {
+		t.Error("no sources.grafana key should leave the source disabled (nil)")
+	}
+}
+
+func TestUnknownKeyRejected(t *testing.T) {
+	if _, err := buildFor(t, `bogus_key: nope`, nil); err == nil {
+		t.Fatal("a typo'd sources.grafana key should abort startup, not build silently")
+	}
+}

--- a/internal/source/grafana/grafana_test.go
+++ b/internal/source/grafana/grafana_test.go
@@ -3,45 +3,108 @@
 package grafana
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/source"
+	"github.com/Smana/runlore/internal/source/custom"
 )
 
+// grafanaDocPath is the PUBLISHED page this guard parses. Relative to this
+// package directory, which is where `go test` runs.
+//
+// The guard lives here rather than in internal/docsguard (the repo's home for
+// this drift class) only because that package does not exist on this branch —
+// it arrives with the sibling docs branch. Move it there once they merge.
+const grafanaDocPath = "../../../website/content/docs/integrations/grafana.md"
+
+// mappingRow matches one row of the published "Built-in mapping" table:
+//
+//	| `title` | `labels.alertname` | the alert rule's name |
+//
+// The header row (`| Field | Path | …`) has no backticks and does not match.
+var mappingRow = regexp.MustCompile("(?m)^\\|\\s*`([a-z_]+)`\\s*\\|\\s*`([^`]+)`\\s*\\|")
+
+// docMapping parses the mapping table out of the real grafana.md. It is
+// deliberately scoped to the "## Built-in mapping" section so a table added
+// elsewhere on the page can never feed the guard, and it fails loudly when it
+// parses nothing — a guard that silently compares against an empty table is
+// worse than no guard.
+func docMapping(t *testing.T) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(grafanaDocPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", grafanaDocPath, err)
+	}
+	const heading = "## Built-in mapping"
+	doc := string(raw)
+	i := strings.Index(doc, heading)
+	if i < 0 {
+		t.Fatalf("%s has no %q section — the published mapping table moved or was renamed", grafanaDocPath, heading)
+	}
+	sec := doc[i+len(heading):]
+	if j := strings.Index(sec, "\n## "); j >= 0 {
+		sec = sec[:j]
+	}
+	rows := mappingRow.FindAllStringSubmatch(sec, -1)
+	if len(rows) == 0 {
+		t.Fatalf("parsed 0 rows out of %s's %q table — did the table change shape?", grafanaDocPath, heading)
+	}
+	out := make(map[string]string, len(rows))
+	for _, m := range rows {
+		out[m[1]] = m[2]
+	}
+	return out
+}
+
 // TestDefaultMappingMatchesDocs is the defining test: the built-in mapping
-// must equal, field for field, the table documented at
-// website/content/docs/integrations/grafana.md (carried forward from the
-// hand-written example that used to live at
-// website/content/docs/integrations/custom-webhook.md). A change to either
-// side must show up here as a visible diff — never a silent behaviour change.
+// must equal, field for field, the table PUBLISHED at
+// website/content/docs/integrations/grafana.md. It parses the real markdown
+// rather than a transcription of it — a transcription only pins a constant
+// against a second constant, so editing the published table (say
+// workload_name from labels.pod to labels.deployment) would leave the test
+// green and the docs lying.
 func TestDefaultMappingMatchesDocs(t *testing.T) {
-	documented := map[string]string{
-		"title":         "labels.alertname",
-		"message":       "annotations.summary",
-		"severity":      "labels.severity",
-		"namespace":     "labels.namespace",
-		"workload_name": "labels.pod",
-		"fingerprint":   "fingerprint",
-		"resolved":      "status",
+	documented := docMapping(t)
+
+	// items and labels ride in the same table but are not field paths.
+	if got := documented["items"]; got != defaultItems {
+		t.Errorf("items = %q, %s documents %q", defaultItems, grafanaDocPath, got)
 	}
-	if len(defaultFields) != len(documented) {
-		t.Fatalf("defaultFields has %d entries, documented table has %d", len(defaultFields), len(documented))
+	if got := documented["labels"]; got != defaultLabels {
+		t.Errorf("labels = %q, %s documents %q", defaultLabels, grafanaDocPath, got)
 	}
+	delete(documented, "items")
+	delete(documented, "labels")
+
+	// Both directions: a row the code does not implement, and a default the
+	// page does not document, are equally a lie.
 	for field, path := range documented {
-		if got := defaultFields[field]; got != path {
-			t.Errorf("fields.%s = %q, documented default is %q", field, got, path)
+		got, ok := defaultFields[field]
+		if !ok {
+			t.Errorf("%s documents fields.%s = %q, but defaultFields has no such field", grafanaDocPath, field, path)
+			continue
+		}
+		if got != path {
+			t.Errorf("fields.%s = %q, %s documents %q", field, got, grafanaDocPath, path)
 		}
 	}
-	if defaultItems != "alerts" {
-		t.Errorf("items = %q, documented default is %q", defaultItems, "alerts")
-	}
-	if defaultLabels != "labels" {
-		t.Errorf("labels = %q, documented default is %q", defaultLabels, "labels")
+	for field, path := range defaultFields {
+		if _, ok := documented[field]; !ok {
+			t.Errorf("defaultFields has fields.%s = %q, which %s does not document", field, path, grafanaDocPath)
+		}
 	}
 }
 
@@ -111,7 +174,7 @@ func TestDecodeBatch(t *testing.T) {
 		t.Fatalf("got %d requests, want 2", len(res.Requests))
 	}
 	r0 := res.Requests[0]
-	if r0.Source != investigate.SourceCustom || r0.Title != "HighCPU" || r0.Message != "CPU is high" {
+	if r0.Source != investigate.SourceGrafana || r0.Title != "HighCPU" || r0.Message != "CPU is high" {
 		t.Errorf("request[0] basics wrong: %+v", r0)
 	}
 	if r0.Workload.Namespace != "payments" || r0.Workload.Name != "api-0" {
@@ -251,5 +314,154 @@ func TestDisabledWithoutConfigKey(t *testing.T) {
 func TestUnknownKeyRejected(t *testing.T) {
 	if _, err := buildFor(t, `bogus_key: nope`, nil); err == nil {
 		t.Fatal("a typo'd sources.grafana key should abort startup, not build silently")
+	}
+}
+
+// TestStartupErrorsNameTheOperatorsConfigPath: failing closed is only half the
+// requirement — the message has to name a path the operator can find in their
+// own file. `grafana` compiles its mapping as a synthetic custom instance
+// called "grafana", so an unguarded delegation reports
+// `sources.custom.instances.grafana`, which appears nowhere in a config that
+// only has `sources.grafana`.
+func TestStartupErrorsNameTheOperatorsConfigPath(t *testing.T) {
+	cases := []struct{ name, yml string }{
+		{"unknown key", `feilds: {title: labels.alertname}`},
+		{"unparseable field path", `fields: {title: "x["}`},
+		{"unparseable items path", `items: "x["`},
+		{"unparseable labels path", `labels: "x["`},
+		{"empty token_env", `token_env: GRAFANA_TOK_DEFINITELY_UNSET`},
+	}
+	for _, c := range cases {
+		_, err := buildFor(t, c.yml, nil)
+		if err == nil {
+			t.Errorf("%s: want a startup error, got nil", c.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "sources.grafana") {
+			t.Errorf("%s: error %q must name sources.grafana", c.name, err)
+		}
+		if strings.Contains(err.Error(), "sources.custom") {
+			t.Errorf("%s: error %q names sources.custom, a path the operator never wrote", c.name, err)
+		}
+	}
+}
+
+// TestFailClosedErrorNamesGrafana covers the actions.mode=auto message, which
+// is built in custom.Build rather than parseConfig.
+func TestFailClosedErrorNamesGrafana(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Actions.Mode = config.ActionAuto
+	_, err := buildFor(t, `{}`, cfg) // no token anywhere: must fail closed
+	if err == nil {
+		t.Fatal("mode=auto with no token must fail closed")
+	}
+	if !strings.Contains(err.Error(), "sources.grafana") || strings.Contains(err.Error(), "sources.custom") {
+		t.Errorf("fail-closed error %q must name sources.grafana, not sources.custom", err)
+	}
+}
+
+// spyInvestigator records what the queue dispatched.
+type spyInvestigator struct {
+	mu   sync.Mutex
+	got  []investigate.Request
+	done chan struct{}
+}
+
+func (s *spyInvestigator) Investigate(_ context.Context, r investigate.Request) error {
+	s.mu.Lock()
+	s.got = append(s.got, r)
+	s.mu.Unlock()
+	s.done <- struct{}{}
+	return nil
+}
+
+// TestGrafanaDoesNotCoalesceWithCustom is the reason grafana claims its own
+// investigate.Source. investigate.keyOf coalesces on
+// {Source, Namespace, Name, Title}: an operator running BOTH
+// sources.custom.instances.datadog and sources.grafana, each firing "HighCPU"
+// on payments/api-0, would have the second incident silently swallowed by the
+// first if both stamped Source="custom".
+//
+// Both requests are enqueued BEFORE Run so they sit in the queue together —
+// that is what makes the coalescing observable; enqueuing against a running
+// queue could dispatch the first before the second arrives and pass either way.
+func TestGrafanaDoesNotCoalesceWithCustom(t *testing.T) {
+	g, err := buildFor(t, `{}`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gres, err := g.Decode([]byte(`{"alerts":[{"status":"firing","fingerprint":"gfp","labels":{"alertname":"HighCPU","severity":"critical","namespace":"payments","pod":"api-0"},"annotations":{"summary":"CPU is high"}}]}`), http.Header{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The same incident, reported by a plain sources.custom instance.
+	c, err := custom.Build(mustNode(t, `
+instances:
+  datadog:
+    fields: {title: alertname, severity: severity, namespace: namespace, workload_name: pod}
+`), &config.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ch := http.Header{}
+	ch.Set(source.InstanceHeader, "datadog")
+	cres, err := c.Decode([]byte(`{"alertname":"HighCPU","severity":"critical","namespace":"payments","pod":"api-0"}`), ch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gres.Requests) != 1 || len(cres.Requests) != 1 {
+		t.Fatalf("want 1 request from each source, got %d / %d", len(gres.Requests), len(cres.Requests))
+	}
+	if gres.Requests[0].Source != investigate.SourceGrafana {
+		t.Errorf("grafana request stamped Source=%q, want %q", gres.Requests[0].Source, investigate.SourceGrafana)
+	}
+	if cres.Requests[0].Source != investigate.SourceCustom {
+		t.Errorf("custom request stamped Source=%q, want %q — sources.custom's behaviour must not change",
+			cres.Requests[0].Source, investigate.SourceCustom)
+	}
+
+	spy := &spyInvestigator{done: make(chan struct{}, 4)}
+	q := investigate.NewQueue(spy, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	q.Enqueue(gres.Requests[0])
+	q.Enqueue(cres.Requests[0])
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go q.Run(ctx)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-spy.done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("only one investigation dispatched: the Grafana and custom incidents coalesced into a single queue key")
+		}
+	}
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	seen := map[investigate.Source]bool{}
+	for _, r := range spy.got {
+		seen[r.Source] = true
+	}
+	if !seen[investigate.SourceGrafana] || !seen[investigate.SourceCustom] {
+		t.Errorf("both sources must reach the investigator, saw %v", seen)
+	}
+}
+
+// TestDecodeNilHeader: Decode/Authenticate are exported, and
+// http.Header(nil).Clone() returns nil — Set on which panics. Unreachable from
+// Built.Handler, but a panic in a webhook path is never acceptable.
+func TestDecodeNilHeader(t *testing.T) {
+	s, err := buildFor(t, `{}`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.Decode([]byte(batchBody), nil)
+	if err != nil {
+		t.Fatalf("Decode with a nil header: %v", err)
+	}
+	if len(res.Requests) != 2 {
+		t.Errorf("got %d requests, want 2", len(res.Requests))
+	}
+	if !s.Authenticate(nil, nil) { // no token configured for this build: open
+		t.Error("Authenticate with a nil header should not panic and should stay open when no token is set")
 	}
 }

--- a/website/content/docs/concepts/data-sources.md
+++ b/website/content/docs/concepts/data-sources.md
@@ -153,28 +153,10 @@ aborts startup — mappings never fail silently at ingest.
 
 ### Grafana Alerting
 
-```yaml
-sources:
-  custom:
-    instances:
-      grafana:
-        token_env: GRAFANA_WEBHOOK_TOKEN
-        items: alerts
-        fields:
-          title: labels.alertname
-          message: annotations.summary
-          severity: labels.severity
-          namespace: labels.namespace
-          workload_name: labels.pod
-          fingerprint: fingerprint
-          resolved: status
-        labels: labels
-        defaults: { environment: prod }
-```
-
-Point a Grafana webhook contact point at
-`https://<runlore>/webhook/custom/grafana` with an `Authorization: Bearer …`
-custom header.
+Grafana Alerting is a **first-class source**, not a hand-written `custom` mapping: `sources.grafana`
+registers its own `POST /webhook/grafana` endpoint with this exact field mapping baked in as the
+default (every field stays overridable). See [Grafana Alerting]({{< relref "/docs/integrations/grafana.md" >}})
+for the minimal config and the full mapping table.
 
 ### Datadog (custom webhook payload)
 

--- a/website/content/docs/integrations/grafana.md
+++ b/website/content/docs/integrations/grafana.md
@@ -10,7 +10,7 @@ investigations, without hand-copying nine dot-path field mappings into `sources.
 `grafana` is a thin wrapper: it registers `POST /webhook/grafana` and delegates every byte of
 extraction — dot-path field lookup, `alerts` batching, severity mapping, resolved-event handling,
 the 1MiB body cap, the per-delivery request cap and startup mapping validation — to the same
-[custom webhook mapper]({{< relref "/docs/concepts/data-sources.md#custom-webhooks-any-vendor-no-code" >}})
+[custom webhook mapper]({{< relref "/docs/concepts/data-sources.md#custom-webhooks--any-vendor-no-code" >}})
 that powers `sources.custom`, with the field paths below baked in as defaults.
 
 ## Minimal config
@@ -52,7 +52,7 @@ sources:
 ```
 
 The same goes for `items`, `labels`, `defaults`, and `severity_map` — see
-[Data sources → Custom webhooks]({{< relref "/docs/concepts/data-sources.md#custom-webhooks-any-vendor-no-code" >}})
+[Data sources → Custom webhooks]({{< relref "/docs/concepts/data-sources.md#custom-webhooks--any-vendor-no-code" >}})
 for the full key reference, since it is the same mapper underneath.
 
 ## Verify it locally
@@ -86,7 +86,7 @@ investigation).
 
 ## Reference
 
-- [Data sources → Custom webhooks]({{< relref "/docs/concepts/data-sources.md#custom-webhooks-any-vendor-no-code" >}})
+- [Data sources → Custom webhooks]({{< relref "/docs/concepts/data-sources.md#custom-webhooks--any-vendor-no-code" >}})
   — the mapper `grafana` delegates to; full key reference for `items`, `fields`, `defaults`,
   `severity_map`, `resolved_value`.
 - [Configuration → `sources`]({{< relref "/docs/configuration/configuration.md#sources--what-wakes-runlore" >}}).

--- a/website/content/docs/integrations/grafana.md
+++ b/website/content/docs/integrations/grafana.md
@@ -1,0 +1,92 @@
+---
+title: Grafana Alerting
+weight: 25
+integration: {kind: source, id: grafana}
+---
+
+**What it gives you** — Grafana Alerting's firing/resolved contact-point webhook turns into
+investigations, without hand-copying nine dot-path field mappings into `sources.custom`.
+
+`grafana` is a thin wrapper: it registers `POST /webhook/grafana` and delegates every byte of
+extraction — dot-path field lookup, `alerts` batching, severity mapping, resolved-event handling,
+the 1MiB body cap, the per-delivery request cap and startup mapping validation — to the same
+[custom webhook mapper]({{< relref "/docs/concepts/data-sources.md#custom-webhooks-any-vendor-no-code" >}})
+that powers `sources.custom`, with the field paths below baked in as defaults.
+
+## Minimal config
+
+```yaml
+sources:
+  grafana:
+    token_env: GRAFANA_WEBHOOK_TOKEN   # optional; falls back to server.webhook_token_env
+```
+
+That's it — `sources.grafana: {}` alone also works (no token, or the shared
+`server.webhook_token_env`).
+
+Point a Grafana webhook contact point at `https://<runlore>/webhook/grafana` with an
+`Authorization: Bearer …` custom header carrying the token.
+
+## Built-in mapping
+
+| Field | Path | Grafana payload meaning |
+|---|---|---|
+| `items` | `alerts` | the contact-point payload batches alerts under `alerts` |
+| `title` | `labels.alertname` | the alert rule's name |
+| `message` | `annotations.summary` | the rule's summary annotation |
+| `severity` | `labels.severity` | your `severity` label |
+| `namespace` | `labels.namespace` | your `namespace` label |
+| `workload_name` | `labels.pod` | your `pod` label |
+| `fingerprint` | `fingerprint` | Grafana's per-series identity, used for dedup and resolution |
+| `resolved` | `status` | `"resolved"` records a resolution instead of an investigation |
+| `labels` | `labels` | every alert label rides along on the investigation's `Labels` |
+
+**Every field stays overridable.** A rule set that doesn't label pods, or uses a different label
+name, just overrides that one key — the rest of the mapping stays default:
+
+```yaml
+sources:
+  grafana:
+    fields:
+      workload_name: labels.deployment   # this cluster labels by deployment, not pod
+```
+
+The same goes for `items`, `labels`, `defaults`, and `severity_map` — see
+[Data sources → Custom webhooks]({{< relref "/docs/concepts/data-sources.md#custom-webhooks-any-vendor-no-code" >}})
+for the full key reference, since it is the same mapper underneath.
+
+## Verify it locally
+
+```bash
+curl -s -o /dev/null -w 'webhook HTTP %{http_code}\n' \
+  -XPOST "http://localhost:8080/webhook/grafana" \
+  -H 'Authorization: Bearer <GRAFANA_WEBHOOK_TOKEN value>' \
+  -H 'Content-Type: application/json' \
+  --data '{"alerts":[{"status":"firing","fingerprint":"abc123","labels":{"alertname":"HighLatency","severity":"critical","namespace":"shop","pod":"shop-api-abc"},"annotations":{"summary":"p99 latency above SLO"}}]}'
+```
+
+`hack/integration/grafana/` runs a real Grafana instance with a provisioned alert rule and contact
+point wired to a local `lore serve`, for an end-to-end pass (fire the rule, confirm an
+investigation starts; resolve it, confirm a resolution is recorded instead of a second
+investigation).
+
+## Notes
+
+- **Presence enables it** — `sources.grafana: {}` is all it takes; there is no separate
+  `enabled: true` flag.
+- One mapping per RunLore deployment: unlike `sources.custom`, which multiplexes several named
+  instances behind `/webhook/custom/{instance}`, `grafana` serves a single fixed endpoint.
+- `token_env` (optional) replaces the shared `server.webhook_token_env` for this endpoint; when
+  unset it falls back to the shared token, else the endpoint is open. This **fails closed** once a
+  model is configured or under `actions.mode=auto`.
+- Requests without a Kubernetes workload recall only resource-less entries (the scopeless tier) —
+  same as PagerDuty.
+- A typo'd key, an unparseable path, or a missing `fields.title` aborts startup — mappings never
+  fail silently at ingest.
+
+## Reference
+
+- [Data sources → Custom webhooks]({{< relref "/docs/concepts/data-sources.md#custom-webhooks-any-vendor-no-code" >}})
+  — the mapper `grafana` delegates to; full key reference for `items`, `fields`, `defaults`,
+  `severity_map`, `resolved_value`.
+- [Configuration → `sources`]({{< relref "/docs/configuration/configuration.md#sources--what-wakes-runlore" >}}).


### PR DESCRIPTION
Makes Grafana Alerting a first-class trigger source rather than something an operator has to shim into the generic webhook.

- Registers Grafana Alerting as its own webhook source.
- Names the operator's config path explicitly and claims Grafana's own source identifier.

## Verification

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all clean.