### PR TITLE
fix(notify): reorder the incident card so the answer leads, not the metadata

### DIFF
--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -29,7 +29,17 @@ func verdictBadge(v providers.Verdict) (emoji, label string) {
 }
 
 // Format renders an Investigation as a concise markdown-ish message used by all
-// notifiers.
+// notifiers (CLI, Matrix). Its ordering and de-duplication deliberately mirror
+// the Slack card (slack.go's summaryBlocks) — the two must never diverge in
+// what they claim: title → verdict, alone → confidence, shown exactly once
+// (+ recall disambiguation when a recalled entry's own confidence differs from
+// the delivered one) → seen-before/recall context → matched-known-runbook →
+// root causes (the "why", rendered in full — there is no thread to defer to
+// here) → honest limits (unresolved / ruled out / data gaps — kept, unlike the
+// Slack SUMMARY card: this single flat message has no thread for them to live
+// in instead) → suggested actions → trigger-time metadata (resource/alert
+// facts/started) — orienting detail, so it drops below the answer and the
+// action rather than leading with it → footer (verified / KB link / usage).
 //
 // Invariant: every literal this function emits (labels, separators, bullets)
 // avoids the three mrkdwn-meta chars & < >. The Slack fallback is
@@ -38,24 +48,20 @@ func verdictBadge(v providers.Verdict) (emoji, label string) {
 // *bold*; TestFormatScaffoldingHasNoMrkdwnMeta guards it.
 func Format(inv providers.Investigation) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "*Investigation* — confidence %.0f%%\n", inv.Confidence*100)
-	// The model verdict is the headline actionability call — show it right under
-	// confidence. Empty/unknown verdicts render nothing (never invent one).
+	// The title anchors the message the same way the Slack header does — without
+	// it, a CLI/Matrix reader has no idea which incident this text describes.
+	fmt.Fprintf(&b, "🔍 %s\n", displayTitle(inv.Title))
+	// The model verdict is the headline actionability call, alone — the title
+	// line above already named the incident.
 	if emoji, label := verdictBadge(inv.Verdict); label != "" {
 		fmt.Fprintf(&b, "%s Verdict: %s\n", emoji, label)
 	}
-	// Name the affected resource up front: it is the first thing an on-call needs
-	// (which workload is this about?) and it isn't otherwise in the shared text.
-	if ref := inv.Resource.Ref(); ref != "" {
-		fmt.Fprintf(&b, "Resource: %s\n", strings.TrimSpace(inv.Resource.Kind+" "+ref))
-	}
-	// Compact trigger-time metadata line, assembled from whatever the source
-	// stamped — omitted entirely for sources that carry none of it.
-	if meta := metadataLine(inv); meta != "" {
-		fmt.Fprintf(&b, "%s\n", meta)
-	}
-	if !inv.StartedAt.IsZero() {
-		fmt.Fprintf(&b, "Started: %s\n", inv.StartedAt.UTC().Format(time.RFC3339))
+	// Confidence — shown once. confidenceBadge is the SAME function Slack calls,
+	// so the two never headline different numbers for the same investigation.
+	emoji, level, pct := confidenceBadge(inv)
+	fmt.Fprintf(&b, "%s %s confidence · %d%%\n", emoji, level, pct)
+	if note := recallConfidenceNote(inv, pct); note != "" {
+		fmt.Fprintf(&b, "   (%s)\n", note)
 	}
 	// Seen-before block: only when this is a repeat of a known incident (a first
 	// sighting — Occurrences ≤ 1, or 0 = ledger disabled — prints nothing). When
@@ -166,12 +172,29 @@ func Format(inv providers.Investigation) string {
 			fmt.Fprintf(&b, "   • %s%s\n", a.Description, rev)
 		}
 	}
+	// Trigger-time metadata — resource, alert facts, incident start. Orienting
+	// detail, not the thing to lead with, so it sits below the answer (root
+	// causes) and the action (suggested steps) rather than above them, mirroring
+	// the Slack card's move.
+	if ref := inv.Resource.Ref(); ref != "" {
+		fmt.Fprintf(&b, "Resource: %s\n", strings.TrimSpace(inv.Resource.Kind+" "+ref))
+	}
+	if meta := metadataLine(inv); meta != "" {
+		fmt.Fprintf(&b, "%s\n", meta)
+	}
+	if !inv.StartedAt.IsZero() {
+		fmt.Fprintf(&b, "Started: %s\n", inv.StartedAt.UTC().Format(time.RFC3339))
+	}
+	// Footer — provenance: verification, the KB link, and the usage/cost summary.
+	// Appended ONLY to the shared delivery message — never to the curated KB body
+	// (the curator builds its own body and does not call Format), so cost never
+	// pollutes the knowledge base.
+	if inv.Verified {
+		b.WriteString("✓ verified\n")
+	}
 	if inv.CuratedURL != "" {
 		fmt.Fprintf(&b, "📚 Knowledge base: %s\n", inv.CuratedURL)
 	}
-	// Cost footer: a one-line usage summary for humans, appended ONLY to the shared
-	// delivery message — never to the curated KB body (the curator builds its own
-	// body and does not call Format), so cost never pollutes the knowledge base.
 	if foot := usageFooter(inv.Usage); foot != "" {
 		fmt.Fprintf(&b, "%s\n", foot)
 	}

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -313,6 +313,92 @@ func TestFormatProgress(t *testing.T) {
 	}
 }
 
+// TestFormatTitleOnce proves the CLI/Matrix text names the incident (a gap the
+// Slack card's header always covered but Format never did), and only once.
+func TestFormatTitleOnce(t *testing.T) {
+	out := Format(providers.Investigation{Title: "HarborRegistryDown", Confidence: 0.5})
+	if !strings.Contains(out, "🔍 HarborRegistryDown") {
+		t.Fatalf("expected the title on its own header-style line:\n%s", out)
+	}
+	if strings.Count(out, "HarborRegistryDown") != 1 {
+		t.Fatalf("title must render exactly once, got %d:\n%s", strings.Count(out, "HarborRegistryDown"), out)
+	}
+}
+
+// TestFormatConfidenceMatchesSlack proves Format and the Slack card headline
+// the SAME confidence number for the same investigation (both now call
+// confidenceBadge) — before this fix Format used the raw, un-maxed
+// inv.Confidence while Slack maxed it against the top root cause, so a model
+// that left the top-level field at 0 while ranking an 80%-confidence cause
+// would show "0%" on the terminal and "80%" on Slack for the same incident.
+func TestFormatConfidenceMatchesSlack(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "t",
+		Confidence: 0,                                                       // model left top-level at 0 …
+		RootCauses: []providers.Hypothesis{{Summary: "x", Confidence: 0.8}}, // … but the root cause is 80%
+	}
+	out := Format(inv)
+	if !strings.Contains(out, "confidence · 80%") {
+		t.Fatalf("Format must headline the maxed confidence (80%%), matching Slack:\n%s", out)
+	}
+	if strings.Contains(out, "confidence · 0%") {
+		t.Fatalf("Format must not show the raw, un-maxed 0%%:\n%s", out)
+	}
+}
+
+// TestFormatMetadataBelowAnswer proves the reordering: trigger-time metadata
+// (Resource/alert facts/Started) now renders AFTER the root causes, mirroring
+// the Slack card's move — orienting detail is not the thing to lead with.
+func TestFormatMetadataBelowAnswer(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "t",
+		Confidence: 0.8,
+		Resource:   providers.Workload{Kind: "Pod", Namespace: "ns", Name: "p"},
+		StartedAt:  time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC),
+		RootCauses: []providers.Hypothesis{{Summary: "the root cause", Confidence: 0.8}},
+	}
+	out := Format(inv)
+	whyIdx := strings.Index(out, "the root cause")
+	resourceIdx := strings.Index(out, "Resource:")
+	if whyIdx == -1 || resourceIdx == -1 || resourceIdx < whyIdx {
+		t.Fatalf("Resource (idx %d) must come AFTER the root cause (idx %d):\n%s", resourceIdx, whyIdx, out)
+	}
+}
+
+// TestFormatRecallConfidenceDisagreement mirrors
+// TestSlackRecallConfidenceDisagreement: the CLI/Matrix text must disclose a
+// recalled entry's own confidence when it diverges from the delivered one,
+// exactly like Slack — the two notifiers must never diverge in what they claim.
+func TestFormatRecallConfidenceDisagreement(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		Recalled:   true,
+		Confidence: 0.78,
+		RootCauses: []providers.Hypothesis{{Summary: "AccessKey hit IAM quota", Confidence: 0.95}},
+	}
+	out := Format(inv)
+	if !strings.Contains(out, "78%") {
+		t.Fatalf("delivered confidence (78%%) must headline:\n%s", out)
+	}
+	if !strings.Contains(out, "entry's own confidence 95%, adjusted to 78% by its track record") {
+		t.Fatalf("must disclose the entry's own confidence, labeled:\n%s", out)
+	}
+}
+
+// TestFormatVerifiedFooter proves the verify signal — visible on the Slack
+// card's footer — is also surfaced in the shared text, so CLI/Matrix readers
+// aren't missing information Slack users have.
+func TestFormatVerifiedFooter(t *testing.T) {
+	inv := providers.Investigation{Title: "t", Confidence: 0.8, Verified: true}
+	if out := Format(inv); !strings.Contains(out, "✓ verified") {
+		t.Fatalf("expected the verified marker:\n%s", out)
+	}
+	inv.Verified = false
+	if out := Format(inv); strings.Contains(out, "✓ verified") {
+		t.Fatalf("must omit the verified marker when Verified is false:\n%s", out)
+	}
+}
+
 // TestFormatUsageFooter covers the one-line cost footer: token summary always,
 // dollar figure only when priced, and omission when no model call was made.
 func TestFormatUsageFooter(t *testing.T) {

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -207,21 +207,25 @@ const (
 )
 
 // slackMessage builds the Slack payload: a verdict-first Block Kit summary
-// (header → verdict → metadata fields → why → next steps → ruled-out/data-gaps →
-// recurrence → confidence footer → approval buttons) followed by an optional
-// detail section (full evidence + the complete open-questions / data-gaps /
-// ruled-out lists). This is the single-message composition used by the webhook
-// path; threading is a later concern. The "text" field is fallbackText — the
-// one-line notification/accessibility summary.
+// (header → verdict, alone → confidence, shown once → seen-before/recall
+// context → matched-known-runbook → why, generous — it's the answer → suggested
+// next steps → metadata fields, now BELOW the answer/action → footer:
+// provenance only — verified, model calls, cost, the one view-entry link →
+// approval buttons) followed by an optional detail section (full evidence + the
+// complete open-questions / ruled-out / data-gap lists — ruled-out and
+// data-gaps render ONLY here, never in the summary, so a phone reader hits the
+// answer before any "Show more"). This is the single-message composition used
+// by the webhook path; threading is a later concern. The "text" field is
+// fallbackText — the one-line notification/accessibility summary.
 //
 // Escape invariant: the fallback is no longer escapeMrkdwn(Format(inv)) — it is
 // fallbackText, which escapes its one untrusted field (the model title) itself.
-// Every untrusted string interpolated into an mrkdwn block (title in the verdict
-// section, alert metadata + ChangeRef in the fields, evidence, ruled-out /
-// data-gap items, PrevCuratedURL inside the recurrence link) is passed through
-// escapeMrkdwn at the point of use. Headers are plain_text (never escaped) and
-// slackDate emits a raw <!date^…> token that is blocks-only — it must never enter
-// the escaped fallback text.
+// Every untrusted string interpolated into an mrkdwn block (the verdict/why
+// sections, alert metadata + ChangeRef in the fields, evidence, ruled-out
+// items, PrevCuratedURL inside the entry link) is passed through escapeMrkdwn
+// at the point of use. Headers are plain_text (never escaped) and slackDate
+// emits a raw <!date^…> token that is blocks-only — it must never enter the
+// escaped fallback text.
 func slackMessage(inv providers.Investigation) map[string]any {
 	return slackMessageWith(inv, false)
 }
@@ -339,14 +343,22 @@ var mrkdwnEscaper = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;")
 // escape-first approach of the Matrix notifier's mrkdwnToHTML.
 func escapeMrkdwn(s string) string { return mrkdwnEscaper.Replace(s) }
 
-// summaryBlocks renders the triage summary as Block Kit, top-down as an on-call
-// reads it: what/where (header) → verdict → key facts (fields) → seen-before KB
-// recall (when present) → matched-known-runbook (when a full loop reused a known
-// entry) → why → what to do → honest limits → recurrence → confidence footer →
-// approval buttons. The full
-// analysis (every hypothesis with all evidence, the complete open-questions /
-// data-gaps / ruled-out lists) lives in detailBlocks; slackMessage appends the
-// two for the single-message webhook path.
+// summaryBlocks renders the triage summary as Block Kit, optimized for a
+// woken-up on-call reading on a phone: everything actionable sits above the
+// first "Show more" collapse. Top-down: what/where (header) → verdict, alone →
+// the delivered confidence, shown exactly once → seen-before KB recall (when
+// present) → matched-known-runbook (when a full loop reused a known entry) →
+// why, rendered generously — it's the answer the reader came for → suggested
+// next steps → trigger-time metadata (resource/started/what-changed/
+// recurrence) — orienting detail, so it drops BELOW the answer and the
+// action, not above it → footer: provenance only (verified, model calls,
+// cost, the one "view entry" link) → approval buttons. Ruled-out and
+// data-gaps are deliberately absent from the summary — both are already
+// carried in full in detailBlocks' thread reply, so repeating them here would
+// only cost fold space the answer needs. The full analysis (every hypothesis
+// with all evidence, the complete open-questions / data-gaps / ruled-out
+// lists) lives in detailBlocks; slackMessage appends the two for the
+// single-message webhook path.
 func summaryBlocks(inv providers.Investigation) []map[string]any {
 	title := displayTitle(inv.Title)
 	emoji, level, pct := confidenceBadge(inv)
@@ -378,29 +390,37 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 		{"type": "header", "text": map[string]any{"type": "plain_text", "text": truncate(head, 150), "emoji": true}},
 	}
 
-	// 2. Verdict owns the second slot — the headline actionability call. When the
-	// model omitted a verdict (old / recall investigations) fall back to the
-	// confidence context line so the layout stays complete and readable.
+	// 2. Verdict owns the second slot — the headline actionability call, ALONE.
+	// The header above already shows the full title (verbatim, or the alert
+	// name + scope) — restating it here duplicated up to its full word count
+	// before any NEW information reached a woken-up phone screen. Absent when
+	// the model omitted a verdict (old / recall investigations); confidence
+	// (2b, below) still renders either way, so the layout stays complete.
 	if vEmoji, label := verdictBadge(inv.Verdict); label != "" {
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn",
-			"text": truncate(fmt.Sprintf("%s *%s* — %s", vEmoji, label, escapeMrkdwn(title)), 2900)}})
-	} else {
-		blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
-			{"type": "mrkdwn", "text": fmt.Sprintf("%s *%s confidence* · %d%%  ·  🤖 RunLore SRE agent", emoji, level, pct)}}})
+			"text": fmt.Sprintf("%s *%s*", vEmoji, label)}})
 	}
 
-	// 3. Metadata fields — the trigger-time facts an on-call scans first.
-	if fields := metadataFields(inv); len(fields) > 0 {
-		blocks = append(blocks, map[string]any{"type": "section", "fields": fields})
+	// 2b. Confidence — shown exactly ONCE, here in the header area, whether or
+	// not a verdict rendered above. It never repeats in the footer (provenance
+	// only, block 8) and the agent identity isn't restated here either — the
+	// Slack app's own name/icon already says who posted this. A recalled
+	// investigation's own top-hypothesis confidence can legitimately differ
+	// from this DELIVERED number (see confidenceBadge); when it does,
+	// recallConfidenceNote spells out both so the reader never has to
+	// reconcile two bare, seemingly-contradictory percentages alone.
+	confText := fmt.Sprintf("%s *%s confidence* · %d%%", emoji, level, pct)
+	if note := recallConfidenceNote(inv, pct); note != "" {
+		confText += "\n_" + note + "_"
 	}
+	blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
+		{"type": "mrkdwn", "text": confText}}})
 
-	// 3b. Prior knowledge — on a recurring incident with a merged KB entry, quote
+	// 3. Prior knowledge — on a recurring incident with a merged KB entry, quote
 	// what the KB already says (cause + human-reviewed resolution + track record)
 	// before the current analysis: history frames how the on-call reads what
 	// follows, with zero clicks. The entry excerpts are untrusted (model prose,
-	// human edits) and escaped; when this block renders, the legacy Recurrence
-	// field and the previously-investigated context pointer are suppressed —
-	// count, date and link all live here.
+	// human edits) and escaped.
 	if p := inv.Prior; p != nil {
 		var s strings.Builder
 		// Two shapes share this block. A RECALL short-circuited the loop: without an
@@ -420,48 +440,35 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 		if p.Resolution != "" {
 			fmt.Fprintf(&s, "\n*%s:* %s", resLabel, escapeMrkdwn(p.Resolution))
 		}
-		foot := make([]string, 0, 2)
-		switch {
-		case inv.PrevCuratedURL != "":
-			label := "previous entry"
-			if inv.Recalled {
-				label = "knowledge-base entry"
-			}
-			foot = append(foot, fmt.Sprintf("<%s|%s>", escapeMrkdwn(inv.PrevCuratedURL), label))
-		case inv.Recalled && p.EntryPath != "":
-			foot = append(foot, fmt.Sprintf("`%s`", escapeMrkdwn(p.EntryPath)))
-		}
+		// The entry itself (filename or link) is deliberately NOT inlined here —
+		// it is the single most-clickable thing on the card, and a section this
+		// long is exactly what Slack's client collapses/truncates mid-word
+		// behind "Show more". It lives once, in the footer (entryLink), on its
+		// own short line that is never truncated.
 		if p.Recalls > 0 {
-			foot = append(foot, fmt.Sprintf("resolve rate %d/%d", p.Resolved, p.Recalls))
-		}
-		if len(foot) > 0 {
-			fmt.Fprintf(&s, "\n%s", strings.Join(foot, " · "))
+			fmt.Fprintf(&s, "\nresolve rate %d/%d", p.Resolved, p.Recalls)
 		}
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
 	}
 
-	// 3c. Existing-KB match — a full investigation whose kb_search matched a known
+	// 4. Existing-KB match — a full investigation whose kb_search matched a known
 	// runbook/entry at clear-match strength. Make it VISIBLE that RunLore already had
 	// knowledge for this incident: the live gap was a 95%-confidence kb_search hit that
 	// the on-call could not see. Suppressed when Prior is set — the recurrence block
 	// above already says "seen before" with richer context, so don't double-render.
-	// Title/path are untrusted (entry frontmatter) and escaped; a derived URL renders
-	// as a link, else the bare path shows inline as code.
+	// Title is untrusted (entry frontmatter) and escaped; path/URL are not inlined
+	// here — same reasoning as the Prior block above — entryLink surfaces the
+	// reference once, in the footer.
 	if mk := inv.MatchedKnowledge; mk != nil && inv.Prior == nil {
-		var s strings.Builder
-		fmt.Fprintf(&s, "📚 *Matches known runbook:* %s", escapeMrkdwn(mk.Title))
-		switch {
-		case mk.URL != "":
-			fmt.Fprintf(&s, " (<%s|%s>)", escapeMrkdwn(mk.URL), escapeMrkdwn(mk.Path))
-		case mk.Path != "":
-			fmt.Fprintf(&s, " (`%s`)", escapeMrkdwn(mk.Path))
-		}
-		s.WriteString(" — RunLore has prior knowledge for this incident.")
-		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
+		text := fmt.Sprintf("📚 *Matches known runbook:* %s — RunLore has prior knowledge for this incident.",
+			escapeMrkdwn(mk.Title))
+		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(text, 2900)}})
 	}
 
-	// 4. Top root cause: the single most-likely why, with up to three evidence
-	// bullets. Deeper hypotheses and full evidence move to the detail section.
+	// 5. Top root cause: the single most-likely why — the answer the reader came
+	// for, so it gets the full 2900-char block budget like every other section
+	// (nothing here is capped tighter), with up to three evidence bullets.
+	// Deeper hypotheses and full evidence move to the detail section.
 	if len(inv.RootCauses) > 0 {
 		rc := inv.RootCauses[0]
 		var s strings.Builder
@@ -475,12 +482,16 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 		}
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
 		if n := len(inv.RootCauses) - 1; n > 0 {
+			word := "hypotheses"
+			if n == 1 {
+				word = "hypothesis"
+			}
 			blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
-				{"type": "mrkdwn", "text": fmt.Sprintf("_…%d more hypotheses below_", n)}}})
+				{"type": "mrkdwn", "text": fmt.Sprintf("_…%d more %s below_", n, word)}}})
 		}
 	}
 
-	// 5. Suggested next steps — the resolution guide (per-root-cause suggestions +
+	// 6. Suggested next steps — the resolution guide (per-root-cause suggestions +
 	// policy actions, de-duplicated, reversibility-flagged), capped at three.
 	if steps := nextSteps(inv); len(steps) > 0 {
 		var s strings.Builder
@@ -497,56 +508,36 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 			map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
 	}
 
-	// 6. Ruled out — honest limits, capped at three (the full list is in the detail
-	// section). Each item is untrusted and escaped.
-	if len(inv.RuledOut) > 0 {
-		var s strings.Builder
-		s.WriteString("❌ *Ruled out:*")
-		for i, r := range inv.RuledOut {
-			if i >= 3 {
-				fmt.Fprintf(&s, "\n• _…%d more_", len(inv.RuledOut)-i)
-				break
-			}
-			fmt.Fprintf(&s, "\n• %s", escapeMrkdwn(r))
-		}
-		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
+	// 7. Metadata fields — trigger-time facts (resource, started, what-changed,
+	// recurrence counter). Orienting detail, not the thing to lead with, so it
+	// sits BELOW the answer (5) and the action (6) rather than above them.
+	if fields := metadataFields(inv); len(fields) > 0 {
+		blocks = append(blocks, map[string]any{"type": "section", "fields": fields})
 	}
 
-	// 7. Data gaps — signals we could not obtain, as a compact context line.
-	if len(inv.DataGaps) > 0 {
-		escaped := make([]string, len(inv.DataGaps))
-		for i, d := range inv.DataGaps {
-			escaped[i] = escapeMrkdwn(d)
-		}
-		blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
-			{"type": "mrkdwn", "text": truncate("⚠️ Data gaps: "+strings.Join(escaped, " · "), 2900)}}})
-	}
-
-	// 8. Recurrence pointer to the previous investigation's conclusion. The link is
-	// formatter-constructed; escaping the URL inside it is what Slack's docs
-	// prescribe (a raw & / < / > would corrupt the link).
-	if inv.PrevCuratedURL != "" && inv.Prior == nil {
-		blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
-			{"type": "mrkdwn", "text": fmt.Sprintf("🔁 Previously investigated — <%s|previous conclusion>", escapeMrkdwn(inv.PrevCuratedURL))}}})
-	}
-
-	// 9. Confidence footer — verdict owns the top, so confidence, verification, the
-	// agent tag, the KB link, and the usage one-liner all live at the bottom.
-	foot := []string{fmt.Sprintf("%s %s confidence · %d%%", emoji, level, pct)}
+	// 8. Footer — provenance only: verified, model calls/cost, and the single
+	// link to view the entry (this investigation's own curated entry, or — on
+	// a recall/seen-before card with nothing freshly curated — the prior/
+	// recalled/matched entry; see entryLink). Confidence and the agent identity
+	// are NOT repeated here: confidence already owns the header (2b), and the
+	// Slack app's own identity already says who posted this — showing either
+	// twice reads as the card disagreeing with itself, not reinforcing it.
+	var foot []string
 	if inv.Verified {
 		foot = append(foot, "✓ verified")
 	}
-	foot = append(foot, "🤖 RunLore SRE agent")
-	if inv.CuratedURL != "" {
-		foot = append(foot, fmt.Sprintf("📚 <%s|view entry>", escapeMrkdwn(inv.CuratedURL)))
+	if link := entryLink(inv); link != "" {
+		foot = append(foot, link)
 	}
 	if u := usageFooter(inv.Usage); u != "" {
 		foot = append(foot, u) // trusted scaffolding — digits/labels only, no mrkdwn meta
 	}
-	blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
-		{"type": "mrkdwn", "text": truncate(strings.Join(foot, "  ·  "), 2900)}}})
+	if len(foot) > 0 {
+		blocks = append(blocks, map[string]any{"type": "context", "elements": []map[string]any{
+			{"type": "mrkdwn", "text": truncate(strings.Join(foot, "  ·  "), 2900)}}})
+	}
 
-	// 10. Interactive Approve/Reject for any action awaiting approval (rung-2).
+	// 9. Interactive Approve/Reject for any action awaiting approval (rung-2).
 	for _, a := range inv.Actions {
 		if a.ApprovalID == "" {
 			continue
@@ -601,7 +592,9 @@ func metadataFields(inv providers.Investigation) []map[string]any {
 		if ch := inv.RootCauses[0].ChangeRef; ch != "" {
 			add("What changed", truncate(escapeMrkdwn(ch), 200))
 		} else {
-			add("What changed", "none")
+			// "none" reads as a missing field on a woken-up phone screen; say what
+			// was actually established instead — no change was implicated.
+			add("What changed", "No Git change identified — likely infrastructure-induced")
 		}
 	}
 	if inv.Occurrences > 1 && inv.Prior == nil {
@@ -660,15 +653,23 @@ func appendListSection(blocks []map[string]any, header string, items []string) [
 	return append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn", "text": truncate(s.String(), 2900)}})
 }
 
-// confidenceBadge returns a visual confidence indicator. The headline confidence
-// is the max of the overall score and the top root cause's — models frequently
-// leave the top-level field at 0 while ranking a high-confidence root cause, and
-// showing "0%" next to an 80% root cause reads as broken.
+// confidenceBadge returns the DELIVERED headline confidence. For most
+// investigations this is the max of the overall score and the top root
+// cause's — models frequently leave the top-level field at 0 while ranking a
+// high-confidence root cause, and showing "0%" next to an 80% root cause reads
+// as broken. A RECALLED investigation is the one exception: inv.Confidence
+// there is a deliberately computed, outcome-weighted number (the recall
+// pipeline's own match confidence, decayed by the entry's track record) and
+// must render AS-IS — maxing it against the top hypothesis's raw match
+// confidence would silently hide a bad track record behind the larger number.
+// See recallConfidenceNote for how the two are disclosed when they diverge.
 func confidenceBadge(inv providers.Investigation) (emoji, level string, pct int) {
 	c := inv.Confidence
-	for _, rc := range inv.RootCauses {
-		if rc.Confidence > c {
-			c = rc.Confidence
+	if !inv.Recalled {
+		for _, rc := range inv.RootCauses {
+			if rc.Confidence > c {
+				c = rc.Confidence
+			}
 		}
 	}
 	pct = int(c*100 + 0.5)
@@ -680,6 +681,59 @@ func confidenceBadge(inv providers.Investigation) (emoji, level string, pct int)
 	default:
 		return "🔴", "Low", pct
 	}
+}
+
+// recallConfidenceNote discloses a recalled entry's own match confidence
+// (the top hypothesis's, before outcome/track-record weighting) when it
+// differs, post-rounding, from the delivered confidence confidenceBadge
+// headlines — so the two never sit on the card as two bare percentages that
+// look like a contradiction. Returns "" when there is nothing to disambiguate
+// (not a recall, no root cause, or the two already round to the same number).
+func recallConfidenceNote(inv providers.Investigation, deliveredPct int) string {
+	if !inv.Recalled || len(inv.RootCauses) == 0 {
+		return ""
+	}
+	ownPct := int(inv.RootCauses[0].Confidence*100 + 0.5)
+	if ownPct == deliveredPct {
+		return ""
+	}
+	return fmt.Sprintf("entry's own confidence %d%%, adjusted to %d%% by its track record", ownPct, deliveredPct)
+}
+
+// entryLink resolves the single "view entry" reference for the footer: this
+// investigation's own curated entry when it produced one, else the
+// previous/recalled entry's link, else — only when no URL is derivable — the
+// bare catalog path as inline code. Centralising it here is what fixes a card
+// that inlined a truncated entry filename mid-sentence: a KB entry path is the
+// single most-clickable thing on the card, and Slack's client can collapse or
+// truncate a long paragraph mid-word — so the reference belongs on its own
+// short line, exactly once, not woven into prose. "" when there is nothing to
+// link (a fresh, uncurated investigation with no recall/match context).
+func entryLink(inv providers.Investigation) string {
+	url := inv.CuratedURL
+	if url == "" {
+		url = inv.PrevCuratedURL
+	}
+	if url == "" && inv.MatchedKnowledge != nil {
+		url = inv.MatchedKnowledge.URL
+	}
+	if url != "" {
+		return fmt.Sprintf("📚 <%s|view entry>", escapeMrkdwn(url))
+	}
+	path := ""
+	if inv.Prior != nil {
+		path = inv.Prior.EntryPath
+	}
+	if path == "" {
+		path = inv.RecalledEntry
+	}
+	if path == "" && inv.MatchedKnowledge != nil {
+		path = inv.MatchedKnowledge.Path
+	}
+	if path == "" {
+		return ""
+	}
+	return fmt.Sprintf("📚 `%s`", escapeMrkdwn(path))
 }
 
 // nextSteps collects the actionable remediations (root-cause suggestions + policy

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -254,8 +254,9 @@ func TestSlackBlocksLayout(t *testing.T) {
 
 // TestSlackSummaryLayout proves the verdict-first summary: the header anchors on
 // the alert name, the second block is the verdict section (NOT the old top
-// confidence context line), the metadata fields carry cluster + recurrence, and
-// confidence has moved to the footer.
+// confidence context line), confidence follows immediately in the header area,
+// and the metadata fields (cluster + recurrence) land AFTER the answer/action —
+// never before them.
 func TestSlackSummaryLayout(t *testing.T) {
 	inv := providers.Investigation{
 		Title:       "harbor is degraded",
@@ -280,12 +281,164 @@ func TestSlackSummaryLayout(t *testing.T) {
 	if blocks[1]["type"] != "section" {
 		t.Fatalf("block[1] must be the verdict section, not %v (old top confidence line must be gone)", blocks[1]["type"])
 	}
+	// Confidence immediately follows the verdict — it owns the header area, not
+	// the footer.
+	if blocks[2]["type"] != "context" {
+		t.Fatalf("block[2] must be the confidence context line, not %v", blocks[2]["type"])
+	}
 	raw, _ := json.Marshal(blocks)
 	s := string(raw)
 	for _, want := range []string{"HarborDown", "No action needed", "*Cluster:*", "*Recurrence:*", "confidence", "view entry"} {
 		if !contains(s, want) {
 			t.Fatalf("summary blocks missing %q:\n%s", want, s)
 		}
+	}
+	// Finding #1: the verdict line must carry the verdict ALONE — the header
+	// above already spelled out the title/alert name in full.
+	texts := mrkdwnTexts(blocks)
+	if strings.Contains(texts[0], "harbor is degraded") {
+		t.Fatalf("verdict block must not restate the title:\n%s", texts[0])
+	}
+	// Finding #5: confidence and the agent identity must not repeat between the
+	// header area and the footer.
+	if strings.Count(s, "80%") != 1 {
+		t.Fatalf("confidence (80%%) must render exactly once, got %d times:\n%s", strings.Count(s, "80%"), s)
+	}
+	if strings.Contains(s, "RunLore SRE agent") {
+		t.Fatalf("agent self-identification must not render on the card:\n%s", s)
+	}
+	// Finding: metadata (Why comes first, then metadata fields — "Resource" et al
+	// drop below the answer/action). The "fields" block must come after the "Why"
+	// section.
+	whyIdx, fieldsIdx := -1, -1
+	for i, b := range blocks {
+		if _, ok := b["fields"]; ok {
+			fieldsIdx = i
+		}
+		if txt, ok := b["text"].(map[string]any); ok {
+			if s, _ := txt["text"].(string); strings.HasPrefix(s, "*Why:*") {
+				whyIdx = i
+			}
+		}
+	}
+	if whyIdx == -1 || fieldsIdx == -1 || fieldsIdx < whyIdx {
+		t.Fatalf("metadata fields (idx %d) must come AFTER Why (idx %d)", fieldsIdx, whyIdx)
+	}
+}
+
+// TestSlackSummaryOmitsRuledOutAndDataGaps proves findings #2/#3: an
+// investigation with root causes, ruled-out hypotheses and data gaps renders
+// NEITHER list in the summary card (both are already carried in full in the
+// threaded detail — see TestSlackDetailBlocksCarriesRuledOutAndDataGaps) — the
+// summary's fold space goes to Why and Suggested next steps instead.
+func TestSlackSummaryOmitsRuledOutAndDataGaps(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "t",
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{Summary: "cause", Confidence: 0.8, SuggestedAction: "do x"}},
+		RuledOut:   []string{"network partition"},
+		DataGaps:   []string{"disk metrics unavailable"},
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	for _, absent := range []string{"Ruled out", "Data gaps", "network partition", "disk metrics unavailable"} {
+		if strings.Contains(txt, absent) {
+			t.Errorf("summary must not render %q — it belongs only in the thread\n%s", absent, txt)
+		}
+	}
+}
+
+// TestSlackDetailBlocksCarriesRuledOutAndDataGaps proves the thread reply still
+// carries the full Ruled-out and Data-gaps lists (nothing is lost — it just
+// isn't duplicated in the summary).
+func TestSlackDetailBlocksCarriesRuledOutAndDataGaps(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "t",
+		RootCauses: []providers.Hypothesis{{Summary: "cause"}},
+		RuledOut:   []string{"network partition"},
+		DataGaps:   []string{"disk metrics unavailable"},
+	}
+	txt := blocksText(t, detailBlocks(inv))
+	for _, want := range []string{"*❌ Ruled out:*", "network partition", "*⚠️ Data gaps:*", "disk metrics unavailable"} {
+		if !strings.Contains(txt, want) {
+			t.Errorf("detail thread missing %q\n%s", want, txt)
+		}
+	}
+}
+
+// TestSlackHypothesisPluralization proves finding #7: "1 more hypothesis" is
+// singular, not "1 more hypotheses".
+func TestSlackHypothesisPluralization(t *testing.T) {
+	inv := providers.Investigation{
+		Title: "t",
+		RootCauses: []providers.Hypothesis{
+			{Summary: "top cause", Confidence: 0.8},
+			{Summary: "second cause", Confidence: 0.5},
+		},
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "1 more hypothesis below") {
+		t.Errorf("expected singular 'hypothesis' for a count of 1:\n%s", txt)
+	}
+	if strings.Contains(txt, "1 more hypotheses") {
+		t.Errorf("must not use the plural for a count of 1:\n%s", txt)
+	}
+
+	inv.RootCauses = append(inv.RootCauses, providers.Hypothesis{Summary: "third cause"})
+	txt = blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "2 more hypotheses below") {
+		t.Errorf("expected plural 'hypotheses' for a count of 2:\n%s", txt)
+	}
+}
+
+// TestSlackWhatChangedNone proves finding #7: an empty ChangeRef renders an
+// informative clause, not the bare word "none" (which reads as a missing
+// field on a woken-up phone screen).
+func TestSlackWhatChangedNone(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "t",
+		RootCauses: []providers.Hypothesis{{Summary: "infra fault"}}, // no ChangeRef
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	if strings.Contains(txt, "*What changed:*\nnone") {
+		t.Errorf("must not render the bare placeholder \"none\":\n%s", txt)
+	}
+	if !strings.Contains(txt, "No Git change") {
+		t.Errorf("expected an informative clause in place of \"none\":\n%s", txt)
+	}
+}
+
+// TestSlackRecallConfidenceDisagreement proves finding #4: when a recalled
+// entry's own (top-hypothesis) confidence differs from the delivered,
+// outcome-weighted confidence, the card discloses BOTH, labeled — never two
+// bare, seemingly-contradictory percentages — and the number renders exactly
+// once outside that explicit disclosure.
+func TestSlackRecallConfidenceDisagreement(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "HarborRegistryDown",
+		Recalled:   true,
+		Confidence: 0.78,                                                                           // outcome-weighted delivered confidence
+		RootCauses: []providers.Hypothesis{{Summary: "AccessKey hit IAM quota", Confidence: 0.95}}, // entry's own match confidence
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "78%") {
+		t.Errorf("delivered confidence (78%%) must headline the card:\n%s", txt)
+	}
+	if !strings.Contains(txt, "entry's own confidence 95%, adjusted to 78% by its track record") {
+		t.Errorf("must disclose the entry's own confidence and label it:\n%s", txt)
+	}
+	// The bare "95%" must never appear on its own — it only ever appears inside
+	// the disambiguating sentence above.
+	if strings.Count(txt, "95%") != 1 {
+		t.Errorf("own confidence (95%%) must appear exactly once (inside the disclosure), got %d:\n%s",
+			strings.Count(txt, "95%"), txt)
+	}
+
+	// When the two agree (post-rounding), no disclosure renders — nothing to
+	// disambiguate.
+	inv.RootCauses[0].Confidence = 0.78
+	txt = blocksText(t, summaryBlocks(inv))
+	if strings.Contains(txt, "entry's own confidence") {
+		t.Errorf("must not disclose anything when the two confidences agree:\n%s", txt)
 	}
 }
 
@@ -416,12 +569,11 @@ func TestSlackBlocksEscapeUntrustedText(t *testing.T) {
 			SuggestedAction: "restart & verify",
 			Reversible:      true,
 		}},
-		Unresolved:     []string{"why <img> appears in logs"},
-		RuledOut:       []string{"disproven by <script> in logs"},
-		DataGaps:       []string{"metrics <unavailable> for db"},
-		Actions:        []providers.Action{{Description: "scale down <deploy>", ApprovalID: "a1"}},
-		CuratedURL:     "https://github.com/o/r/issues/9",
-		PrevCuratedURL: "https://kb.example/prev?a=1&b=2",
+		Unresolved: []string{"why <img> appears in logs"},
+		RuledOut:   []string{"disproven by <script> in logs"},
+		DataGaps:   []string{"metrics <unavailable> for db"},
+		Actions:    []providers.Action{{Description: "scale down <deploy>", ApprovalID: "a1"}},
+		CuratedURL: "https://github.com/o/r/issues/9",
 	}
 	joined := strings.Join(mrkdwnTexts(append(summaryBlocks(inv), detailBlocks(inv)...)), "\n")
 
@@ -436,17 +588,14 @@ func TestSlackBlocksEscapeUntrustedText(t *testing.T) {
 		"restart &amp; verify", // SuggestedAction, surfaced in next steps
 		"why &lt;img&gt; appears in logs",
 		"scale down &lt;deploy&gt;",
-		"disproven by &lt;script&gt; in logs", // RuledOut item
-		"metrics &lt;unavailable&gt; for db",  // DataGaps item
-		"https://kb.example/prev?a=1&amp;b=2", // PrevCuratedURL, escaped inside the recurrence link
+		// RuledOut/DataGaps no longer render in the SUMMARY (findings #2/#3) —
+		// both are only in detailBlocks, which is included in `joined` above.
+		"disproven by &lt;script&gt; in logs",
+		"metrics &lt;unavailable&gt; for db",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("blocks missing escaped untrusted text %q:\n%s", want, joined)
 		}
-	}
-	// The recurrence URL must not survive with a raw ampersand (would split the link).
-	if strings.Contains(joined, "prev?a=1&b=2") {
-		t.Fatalf("PrevCuratedURL kept a raw & inside the link:\n%s", joined)
 	}
 	// Formatter-emitted markup must keep working: bold rank, code confidence,
 	// reversibility italics, and the KB link the formatter constructs itself.
@@ -454,6 +603,17 @@ func TestSlackBlocksEscapeUntrustedText(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("blocks missing formatter-emitted markup %q:\n%s", want, joined)
 		}
+	}
+}
+
+// TestEntryLinkEscapesURL proves entryLink escapes its untrusted URL sources
+// (PrevCuratedURL, MatchedKnowledge.URL) — the single footer "view entry" link
+// (finding #6) must never let a hostile & split or corrupt the mrkdwn link.
+func TestEntryLinkEscapesURL(t *testing.T) {
+	got := entryLink(providers.Investigation{PrevCuratedURL: "https://kb.example/prev?a=1&b=2"})
+	want := "📚 <https://kb.example/prev?a=1&amp;b=2|view entry>"
+	if got != want {
+		t.Errorf("entryLink(PrevCuratedURL) = %q, want %q", got, want)
 	}
 }
 
@@ -599,15 +759,17 @@ func TestSlackSummaryBlocksPriorKnowledge(t *testing.T) {
 		"📚 *Seen before ×3*",
 		"*Prior cause:* ConfigMap truncated &lt;v5.4&gt;", // untrusted entry text is escaped
 		"*Prior resolution:* revert &amp; pin 5.3.2",
-		"previous entry",   // link label
-		"resolve rate 3/3", // track record
+		"resolve rate 3/3",              // track record
+		"<https://kb/pr/12|view entry>", // the entry link now lives once, in the footer
 	} {
 		if !strings.Contains(txt, want) {
 			t.Errorf("summary blocks missing %q\n%s", want, txt)
 		}
 	}
-	// The new block replaces the old pointers: no duplicate recurrence renders.
-	for _, absent := range []string{"Previously investigated", "*Recurrence:*"} {
+	// The new block replaces the old pointers: no duplicate recurrence renders,
+	// and the entry link is never inlined mid-prose (finding #6) — it lives only
+	// in the footer.
+	for _, absent := range []string{"Previously investigated", "*Recurrence:*", "previous entry"} {
 		if strings.Contains(txt, absent) {
 			t.Errorf("summary blocks must not still render %q when Prior is set\n%s", absent, txt)
 		}
@@ -635,8 +797,8 @@ func TestSlackSummaryBlocksRecall(t *testing.T) {
 		"no investigation was run",
 		"*Known cause:* AccessKey hit IAM quota",
 		"*Validated resolution:* delete an unused access key",
-		"`harbor-registry-down.md`", // entry path shown inline when no curated URL
 		"resolve rate 3/3",
+		"📚 `harbor-registry-down.md`", // entry path shown once, in the footer, when no curated URL
 	} {
 		if !strings.Contains(txt, want) {
 			t.Errorf("recall summary missing %q\n%s", want, txt)
@@ -647,11 +809,21 @@ func TestSlackSummaryBlocksRecall(t *testing.T) {
 			t.Errorf("recall block must not use the fresh-recurrence framing %q\n%s", absent, txt)
 		}
 	}
+	// The bare path must never appear INLINE in the recall block's prose
+	// (finding #6 — it is the most-clickable thing on the card, and Slack can
+	// truncate a long section mid-word); it belongs only in the footer.
+	texts := mrkdwnTexts(summaryBlocks(inv)) // [confidence ctx, prior block, footer]
+	if len(texts) < 2 || strings.Contains(texts[1], "harbor-registry-down.md") {
+		t.Errorf("entry path must not be inlined in the prior/recall block, got blocks: %v", texts)
+	}
 	// With a curated URL, the entry links instead of showing the bare path.
 	inv.PrevCuratedURL = "https://kb/pr/42"
 	txt = blocksText(t, summaryBlocks(inv))
-	if !strings.Contains(txt, "knowledge-base entry") {
+	if !strings.Contains(txt, "<https://kb/pr/42|view entry>") {
 		t.Errorf("recall with curated URL must link the knowledge-base entry\n%s", txt)
+	}
+	if strings.Contains(txt, "harbor-registry-down.md") {
+		t.Errorf("a resolvable URL must replace the bare path, not add to it\n%s", txt)
 	}
 }
 
@@ -663,8 +835,13 @@ func TestSlackSummaryBlocksRecurrenceWithoutPrior(t *testing.T) {
 		PrevCuratedURL: "https://kb/pr/12",
 	}
 	txt := blocksText(t, summaryBlocks(inv))
-	if !strings.Contains(txt, "Previously investigated") {
-		t.Errorf("legacy recurrence pointer missing without Prior\n%s", txt)
+	// The previous-conclusion pointer now lives in the footer's single entry
+	// link (finding #6), not as its own "Previously investigated" line.
+	if !strings.Contains(txt, "<https://kb/pr/12|view entry>") {
+		t.Errorf("footer entry link missing without Prior\n%s", txt)
+	}
+	if strings.Contains(txt, "Previously investigated") {
+		t.Errorf("the legacy inline pointer must be gone (superseded by the footer link)\n%s", txt)
 	}
 	if strings.Contains(txt, "Seen before") {
 		t.Errorf("Seen-before block must not render without Prior\n%s", txt)
@@ -684,18 +861,18 @@ func TestSlackSummaryBlocksPriorKnowledgePartial(t *testing.T) {
 	}{
 		{
 			label: "cause only", prior: &providers.PriorKnowledge{Cause: "c"}, prevURL: "https://kb/pr/1",
-			want:   []string{"*Prior cause:* c", "previous entry"},
+			want:   []string{"*Prior cause:* c", "<https://kb/pr/1|view entry>"},
 			absent: []string{"*Prior resolution:*", "resolve rate"},
 		},
 		{
 			label: "resolution only", prior: &providers.PriorKnowledge{Resolution: "r"}, prevURL: "https://kb/pr/1",
-			want:   []string{"*Prior resolution:* r", "previous entry"},
+			want:   []string{"*Prior resolution:* r", "<https://kb/pr/1|view entry>"},
 			absent: []string{"*Prior cause:*", "resolve rate"},
 		},
 		{
 			label: "track record without link", prior: &providers.PriorKnowledge{Cause: "c", Recalls: 2, Resolved: 1},
 			want:   []string{"*Prior cause:* c", "resolve rate 1/2"},
-			absent: []string{"previous entry"},
+			absent: []string{"view entry"},
 		},
 	}
 	for _, c := range cases {
@@ -744,16 +921,20 @@ func TestSlackSummaryBlocksMatchedKnowledge(t *testing.T) {
 	}
 }
 
-// TestSlackSummaryBlocksMatchedKnowledgeURL: when a web URL is derivable it renders
-// as a link (label = path) instead of an inline code path.
+// TestSlackSummaryBlocksMatchedKnowledgeURL: when a web URL is derivable it
+// renders as a link in the footer (finding #6 — never inlined as a path) instead
+// of an inline code path.
 func TestSlackSummaryBlocksMatchedKnowledgeURL(t *testing.T) {
 	inv := providers.Investigation{
 		Title: "t", Confidence: 0.8,
 		MatchedKnowledge: &providers.MatchedEntry{Title: "Runbook", Path: "runbooks/h.md", URL: "https://kb/runbooks/h.md", Score: 5},
 	}
 	txt := blocksText(t, summaryBlocks(inv))
-	if !strings.Contains(txt, "<https://kb/runbooks/h.md|runbooks/h.md>") {
+	if !strings.Contains(txt, "<https://kb/runbooks/h.md|view entry>") {
 		t.Errorf("expected a linked entry, got\n%s", txt)
+	}
+	if strings.Contains(txt, "runbooks/h.md|runbooks/h.md") {
+		t.Errorf("must not use the path as the link label:\n%s", txt)
 	}
 }
 


### PR DESCRIPTION
The Slack incident card led with metadata, so the reader had to scroll past provenance to reach the thing they opened it for — the root cause. Reordered so the answer leads.

## Verification

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all clean.