### PR TITLE
feat(logs): Elasticsearch and OpenSearch logs providers

### DIFF
--- a/hack/integration/elasticsearch/README.md
+++ b/hack/integration/elasticsearch/README.md
@@ -1,0 +1,124 @@
+# Elasticsearch / OpenSearch logs providers — local verification
+
+Starts a single-node Elasticsearch 8.x AND a single-node OpenSearch 2.x, seeds both with the
+same ECS-shaped log documents (including a CrashLoopBackOff-style error burst), then exercises
+the three logs tools (`query_logs`, `logs_error_summary`, `discover_log_fields`) against each —
+first at the raw HTTP/DSL level (no LLM needed, proves the wire contract `internal/logs/
+elasticsearch` encodes is correct against a REAL cluster), then optionally end to end through
+`lore investigate` (needs a model configured).
+
+**This recipe was authored but has NOT been run end to end** — the sandbox this was written in has
+no Docker daemon available (`docker info` fails). Treat it as a reviewed-on-paper recipe, not a
+verified one, until someone with a working Docker runs it. The client's behavior IS verified —
+thoroughly, via `go test ./internal/logs/elasticsearch/...`, `./internal/logs/...`,
+`./internal/investigate/...`, and `./internal/app/...` against mocked ES/OpenSearch responses — but
+a mock can only be as correct as its author's understanding of the real wire format, which is
+exactly the assumption this recipe exists to close.
+
+## Run it
+
+1. Start both backends:
+
+   ```bash
+   cd hack/integration/elasticsearch
+   docker compose up -d
+   docker compose ps   # wait for both healthchecks to report healthy
+   ```
+
+2. Seed both with the same ECS-shaped documents:
+
+   ```bash
+   ./seed.sh http://localhost:9200   # Elasticsearch
+   ./seed.sh http://localhost:9201   # OpenSearch
+   ```
+
+   Each run prints the cluster health, confirms the index template applied, bulk-indexes 28
+   documents (a "logs-demo" index matching the `logs-*` pattern), and prints a total hit count —
+   expect `"value":28` (or a slightly different total on a re-seed against a non-empty index; the
+   script deletes the index first, so a fresh run always lands on 28).
+
+3. Detection — confirm `internal/logs.Detect` classifies each correctly:
+
+   ```bash
+   curl -s http://localhost:9200/ | grep -o '"number":"[^"]*"'        # Elasticsearch: version.number only
+   curl -s http://localhost:9201/ | grep -o '"distribution":"[^"]*"'  # OpenSearch: version.distribution: opensearch
+   ```
+
+4. Exercise the three tools' underlying requests directly — these are EXACTLY the requests
+   `internal/logs/elasticsearch.Client` issues (compare against `elasticsearch.go`'s `searchBody`/
+   `Hits`/`TopMessages`/`FieldNames`); run each against BOTH `:9200` and `:9201` and confirm
+   the responses are structurally identical (the whole premise this task rests on):
+
+   **`query_logs`** — `_search` with `query_string` + a `range` filter, newest-first, size-capped:
+
+   ```bash
+   curl -s -X POST "http://localhost:9200/logs-*/_search" -H 'Content-Type: application/json' -d '{
+     "query": {"bool": {"must": [{"query_string": {"query": "kubernetes.namespace:\"payments\" AND log.level:\"error\""}}]}},
+     "sort": [{"@timestamp": {"order": "desc"}}],
+     "size": 1000
+   }' | python3 -m json.tool | head -40
+   ```
+
+   Expect ~23 hits (3 baseline + 20 burst lines), newest first.
+
+   **`logs_error_summary`** — `date_histogram` split by `log.level`, PLUS the top-messages
+   fallback in action (the seeded index maps `message` as `text`-only, matching the real ECS
+   convention — see `seed.sh`'s comment):
+
+   ```bash
+   # date_histogram + terms sub-agg (the volume-over-time half)
+   curl -s -X POST "http://localhost:9200/logs-*/_search" -H 'Content-Type: application/json' -d '{
+     "size": 0,
+     "query": {"bool": {"must": [{"query_string": {"query": "kubernetes.namespace:\"payments\""}}]}},
+     "aggs": {"by_time": {"date_histogram": {"field": "@timestamp", "fixed_interval": "300s"},
+       "aggs": {"by_level": {"terms": {"field": "log.level", "size": 20}}}}}
+   }' | python3 -m json.tool
+
+   # top-messages terms agg on `message` — THIS MUST 400 with an
+   # illegal_argument_exception naming "Fielddata is disabled on text fields",
+   # proving the fallback in TopMessages actually triggers against a real
+   # cluster rather than only in the mocked test.
+   curl -s -X POST "http://localhost:9200/logs-*/_search" -H 'Content-Type: application/json' -d '{
+     "size": 0,
+     "query": {"bool": {"must": [{"query_string": {"query": "kubernetes.namespace:\"payments\""}}]}},
+     "aggs": {"top_messages": {"terms": {"field": "message", "size": 10}}}
+   }' | python3 -m json.tool
+   ```
+
+   **`discover_log_fields`** — `_field_caps`, present on both distributions:
+
+   ```bash
+   curl -s "http://localhost:9200/logs-*/_field_caps?fields=*" | python3 -m json.tool
+   ```
+
+   Confirm `kubernetes.namespace`/`kubernetes.pod.name`/`kubernetes.container.name`/`log.level` show
+   up as `keyword` (aggregatable), and `message` shows up as `text` (searchable, NOT aggregatable) —
+   the exact mapping shape the fallback logic above depends on.
+
+5. (Optional, needs a model configured) End-to-end through RunLore itself:
+
+   ```bash
+   go build -o /tmp/lore ./cmd/lore
+   /tmp/lore investigate --config hack/integration/elasticsearch/runlore.elasticsearch.yaml \
+     --alert CrashLoopBackOff --namespace payments --message "payments/api-0 crash-looping"
+   /tmp/lore investigate --config hack/integration/elasticsearch/runlore.opensearch.yaml \
+     --alert CrashLoopBackOff --namespace payments --message "payments/api-0 crash-looping"
+   ```
+
+   Confirm the findings cite the seeded `connection refused to postgres.payments.svc:5432` burst and
+   the `Back-off restarting failed container` line, on BOTH runs.
+
+6. `docker compose down -v` to stop and remove both containers.
+
+## Notes
+
+- `docker-compose.yml` disables both distributions' security plugins (plain HTTP, no auth) purely
+  for a quick throwaway local cluster — a real deployment always uses TLS + `token_env`, see the
+  docs page. RunLore's client never disables TLS verification; this recipe simply doesn't use TLS.
+- `seed.sh`'s index template maps `message` as `text` with NO `keyword` sub-field, deliberately
+  reproducing the real Elastic Common Schema convention (Filebeat's ECS template omits a keyword
+  multi-field for `message`). Without this explicit template, Elasticsearch's default DYNAMIC
+  mapping would auto-add `message.keyword` and mask the exact parity gap step 4 is meant to prove.
+- Port `9201` (not the default `9200`) is used for OpenSearch on the host side purely to let both
+  containers run side by side in one compose file; the containers themselves both listen on `9200`
+  internally.

--- a/hack/integration/elasticsearch/README.md
+++ b/hack/integration/elasticsearch/README.md
@@ -7,13 +7,33 @@ first at the raw HTTP/DSL level (no LLM needed, proves the wire contract `intern
 elasticsearch` encodes is correct against a REAL cluster), then optionally end to end through
 `lore investigate` (needs a model configured).
 
-**This recipe was authored but has NOT been run end to end** — the sandbox this was written in has
-no Docker daemon available (`docker info` fails). Treat it as a reviewed-on-paper recipe, not a
-verified one, until someone with a working Docker runs it. The client's behavior IS verified —
-thoroughly, via `go test ./internal/logs/elasticsearch/...`, `./internal/logs/...`,
-`./internal/investigate/...`, and `./internal/app/...` against mocked ES/OpenSearch responses — but
-a mock can only be as correct as its author's understanding of the real wire format, which is
-exactly the assumption this recipe exists to close.
+**Status: run against real backends** — Elasticsearch 8.15.0 and OpenSearch 2.17.0, the versions
+pinned in `docker-compose.yml`. All three tools returned identical results on both distributions.
+`internal/logs/elasticsearch/live_verify_test.go` is that harness, build-tagged `liveverify` so it
+never runs in CI:
+
+```bash
+ES_URL=http://localhost:9200 OS_URL=http://localhost:9201 \
+  go test -tags liveverify ./internal/logs/elasticsearch/ -run TestLive -v
+```
+
+The one thing the live run settled that no mock could: the text-field aggregation rejection is
+**not worded identically** on the two distributions — Elasticsearch prefixes it with
+`Fielddata is disabled on [message] in [logs-demo].`, OpenSearch does not. See
+`isTextFieldAggError`'s comment in `elasticsearch.go` for what the matcher therefore keys on.
+
+## Host prerequisite (Linux)
+
+Both images fail their bootstrap check and restart-loop unless the kernel mmap limit is raised.
+This is the single most common reason "it just doesn't start":
+
+```bash
+sudo sysctl -w vm.max_map_count=262144                                # this boot only
+echo 'vm.max_map_count=262144' | sudo tee /etc/sysctl.d/99-opensearch.conf   # persist
+```
+
+The symptom is `max virtual memory areas vm.max_map_count [65530] is too low` in
+`docker compose logs`, not a compose error — `docker compose ps` just shows a container restarting.
 
 ## Run it
 
@@ -32,10 +52,12 @@ exactly the assumption this recipe exists to close.
    ./seed.sh http://localhost:9201   # OpenSearch
    ```
 
-   Each run prints the cluster health, confirms the index template applied, bulk-indexes 28
+   Each run prints the cluster health, confirms the index template applied, bulk-indexes 30
    documents (a "logs-demo" index matching the `logs-*` pattern), and prints a total hit count —
-   expect `"value":28` (or a slightly different total on a re-seed against a non-empty index; the
-   script deletes the index first, so a fresh run always lands on 28).
+   expect `"value":30`. The script deletes the index first, so a re-seed always lands on 30 too.
+
+   That 30 is 5 baseline `checkout` lines + 3 baseline `payments` errors + the 20-line
+   CrashLoopBackOff burst + 1 `Back-off restarting` error + 1 `container restarted` warn.
 
 3. Detection — confirm `internal/logs.Detect` classifies each correctly:
 
@@ -59,7 +81,9 @@ exactly the assumption this recipe exists to close.
    }' | python3 -m json.tool | head -40
    ```
 
-   Expect ~23 hits (3 baseline + 20 burst lines), newest first.
+   Expect exactly 24 hits — 3 baseline `payments` errors + the 20-line burst + the 1
+   `Back-off restarting failed container` error; the `container restarted` line is a `warn` and is
+   correctly excluded. Newest first. (24 is what both real clusters returned.)
 
    **`logs_error_summary`** — `date_histogram` split by `log.level`, PLUS the top-messages
    fallback in action (the seeded index maps `message` as `text`-only, matching the real ECS
@@ -75,9 +99,13 @@ exactly the assumption this recipe exists to close.
    }' | python3 -m json.tool
 
    # top-messages terms agg on `message` — THIS MUST 400 with an
-   # illegal_argument_exception naming "Fielddata is disabled on text fields",
-   # proving the fallback in TopMessages actually triggers against a real
-   # cluster rather than only in the mocked test.
+   # illegal_argument_exception, proving the fallback in TopMessages actually
+   # triggers against a real cluster rather than only in the mocked test.
+   # NOTE the wording differs by distribution: Elasticsearch opens with
+   # "Fielddata is disabled on [message] in [logs-demo]." and OpenSearch does
+   # not. Both share "Text fields are not optimised …" and "set fielddata=true",
+   # which is what isTextFieldAggError keys on — do not match the ES-only
+   # sentence.
    curl -s -X POST "http://localhost:9200/logs-*/_search" -H 'Content-Type: application/json' -d '{
      "size": 0,
      "query": {"bool": {"must": [{"query_string": {"query": "kubernetes.namespace:\"payments\""}}]}},
@@ -115,6 +143,11 @@ exactly the assumption this recipe exists to close.
 - `docker-compose.yml` disables both distributions' security plugins (plain HTTP, no auth) purely
   for a quick throwaway local cluster — a real deployment always uses TLS + `token_env`, see the
   docs page. RunLore's client never disables TLS verification; this recipe simply doesn't use TLS.
+- For OpenSearch that means BOTH `DISABLE_SECURITY_PLUGIN=true` and
+  `DISABLE_INSTALL_DEMO_CONFIG=true`. Setting only the first leaves the entrypoint running
+  `install_demo_configuration.sh` on every start (demo TLS certs, and on 2.12+ a hard failure when
+  no `OPENSEARCH_INITIAL_ADMIN_PASSWORD` is set). With the demo config disabled, no admin password
+  is needed at all.
 - `seed.sh`'s index template maps `message` as `text` with NO `keyword` sub-field, deliberately
   reproducing the real Elastic Common Schema convention (Filebeat's ECS template omits a keyword
   multi-field for `message`). Without this explicit template, Elasticsearch's default DYNAMIC

--- a/hack/integration/elasticsearch/docker-compose.yml
+++ b/hack/integration/elasticsearch/docker-compose.yml
@@ -1,0 +1,45 @@
+# Local verification recipe for the `elasticsearch`/`opensearch` logs providers
+# (see website/content/docs/integrations/elasticsearch.md and opensearch.md).
+# Starts a single-node Elasticsearch AND a single-node OpenSearch, both with
+# security disabled (plain HTTP) — fine for a throwaway local test cluster;
+# RunLore's client always verifies TLS in a real deployment (see the docs
+# page), this recipe simply doesn't use TLS at all.
+#
+# Usage: see README.md in this directory.
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: "false"
+      xpack.security.http.ssl.enabled: "false"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  opensearch:
+    image: opensearchproject/opensearch:2.11.1
+    environment:
+      discovery.type: single-node
+      plugins.security.disabled: "true"
+      OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
+      # OpenSearch's default admin-password policy rejects weak passwords even
+      # with the security plugin disabled at the HTTP layer; set one anyway so
+      # startup never blocks on it.
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "RunLore-demo-1"
+    ports:
+      - "9201:9200"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30

--- a/hack/integration/elasticsearch/docker-compose.yml
+++ b/hack/integration/elasticsearch/docker-compose.yml
@@ -5,10 +5,23 @@
 # RunLore's client always verifies TLS in a real deployment (see the docs
 # page), this recipe simply doesn't use TLS at all.
 #
+# HOST PREREQUISITE — on Linux, BOTH images refuse to start unless the kernel's
+# mmap limit is raised; this is by far the most common "it just exits" report:
+#
+#   sudo sysctl -w vm.max_map_count=262144        # this boot only
+#   echo 'vm.max_map_count=262144' | sudo tee /etc/sysctl.d/99-opensearch.conf
+#
+# The failure is a bootstrap check in the container log ("max virtual memory
+# areas vm.max_map_count [65530] is too low"), not a compose error, so `docker
+# compose ps` just shows the container restarting.
+#
+# The image tags below are the versions this recipe was actually verified
+# against (see README.md), not floating latest.
+#
 # Usage: see README.md in this directory.
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
     environment:
       discovery.type: single-node
       xpack.security.enabled: "false"
@@ -23,15 +36,21 @@ services:
       retries: 30
 
   opensearch:
-    image: opensearchproject/opensearch:2.11.1
+    image: opensearchproject/opensearch:2.17.0
     environment:
       discovery.type: single-node
-      plugins.security.disabled: "true"
+      # DISABLE_SECURITY_PLUGIN + DISABLE_INSTALL_DEMO_CONFIG is the pair the
+      # OpenSearch image documents for a plain-HTTP dev node, and the pair this
+      # recipe was verified with. `plugins.security.disabled` alone is NOT
+      # enough: the entrypoint still runs install_demo_configuration.sh on every
+      # start, which generates demo TLS certs and (on 2.12+) fails the container
+      # outright when no admin password is supplied. Disabling the demo config
+      # is what makes OPENSEARCH_INITIAL_ADMIN_PASSWORD unnecessary here — the
+      # comment this replaced claimed the password was required on 2.11.1, which
+      # was simply wrong (that requirement landed in 2.12).
+      DISABLE_SECURITY_PLUGIN: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
       OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
-      # OpenSearch's default admin-password policy rejects weak passwords even
-      # with the security plugin disabled at the HTTP layer; set one anyway so
-      # startup never blocks on it.
-      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "RunLore-demo-1"
     ports:
       - "9201:9200"
     ulimits:

--- a/hack/integration/elasticsearch/runlore.elasticsearch.yaml
+++ b/hack/integration/elasticsearch/runlore.elasticsearch.yaml
@@ -1,0 +1,8 @@
+# Config for `lore investigate` against the Elasticsearch container started by
+# hack/integration/elasticsearch/docker-compose.yml. No auth (security plugin
+# disabled in the compose file) — a real deployment sets token_env/headers,
+# see website/content/docs/integrations/elasticsearch.md.
+logs:
+  url: http://localhost:9200
+  provider: elasticsearch
+  index: logs-*

--- a/hack/integration/elasticsearch/runlore.opensearch.yaml
+++ b/hack/integration/elasticsearch/runlore.opensearch.yaml
@@ -1,0 +1,8 @@
+# Config for `lore investigate` against the OpenSearch container started by
+# hack/integration/elasticsearch/docker-compose.yml. No auth (security plugin
+# disabled in the compose file) — a real deployment sets token_env/headers,
+# see website/content/docs/integrations/opensearch.md.
+logs:
+  url: http://localhost:9201
+  provider: opensearch
+  index: logs-*

--- a/hack/integration/elasticsearch/seed.sh
+++ b/hack/integration/elasticsearch/seed.sh
@@ -107,5 +107,14 @@ curl -sf -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
 
 echo
 echo "seeded ${BASE_URL}/${INDEX} — sanity check:"
-curl -sf -X POST "${BASE_URL}/${INDEX}/_search" -H 'Content-Type: application/json' \
-  -d '{"size":0,"query":{"match_all":{}}}' | grep -o '"value":[0-9]*' | head -1
+# `grep -o … | head -1` was the original here, and under `set -o pipefail` its
+# exit status was a coin flip: head closes the pipe the moment it has its line,
+# grep dies of SIGPIPE (141), pipefail promotes that to the pipeline's status,
+# and since this is the script's LAST command it became the script's status —
+# non-zero on a perfectly successful seed, depending only on whether grep had
+# already finished writing. `grep -m1` gives the same "first match only" with
+# nothing downstream to close the pipe. A missing match means the search itself
+# failed, which SHOULD be fatal, so it is deliberately left un-guarded.
+TOTAL="$(curl -sf -X POST "${BASE_URL}/${INDEX}/_search" -H 'Content-Type: application/json' \
+  -d '{"size":0,"query":{"match_all":{}}}')"
+printf '%s' "${TOTAL}" | grep -o -m1 '"value":[0-9]*'

--- a/hack/integration/elasticsearch/seed.sh
+++ b/hack/integration/elasticsearch/seed.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Seeds an Elasticsearch or OpenSearch instance (they speak an identical
+# _search/_bulk wire format) with ECS-shaped log documents for the
+# hack/integration/elasticsearch/ verification recipe: a handful of baseline
+# info/warn lines across two namespaces, plus a CrashLoopBackOff-style burst
+# of near-identical error lines from one pod — the shape logs_error_summary's
+# histogram + top-messages should surface as "baseline -> spike".
+#
+# The index template below maps `message` as `text` ONLY (no `keyword`
+# sub-field) — matching the REAL Elastic Common Schema convention (Filebeat's
+# ECS template omits a keyword multi-field for `message` on purpose, since log
+# lines are high-cardinality/long). Elasticsearch's default DYNAMIC mapping
+# would otherwise auto-add a `message.keyword` sub-field and mask the exact
+# parity gap this recipe exists to demonstrate: logs_error_summary's top
+# messages must fall back to client-side aggregation against this cluster.
+#
+# Usage:
+#   ./seed.sh http://localhost:9200   # Elasticsearch (docker-compose default)
+#   ./seed.sh http://localhost:9201   # OpenSearch (docker-compose default)
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:9200}"
+INDEX="logs-demo"
+
+echo "waiting for ${BASE_URL} to be healthy..."
+for _ in $(seq 1 60); do
+  if curl -sf "${BASE_URL}/_cluster/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+curl -sf "${BASE_URL}/_cluster/health?pretty"
+
+echo "putting index template (message: text-only, matching the real ECS convention)..."
+curl -sf -X PUT "${BASE_URL}/_index_template/logs-demo-template" \
+  -H 'Content-Type: application/json' -d '{
+  "index_patterns": ["logs-*"],
+  "template": {
+    "mappings": {
+      "properties": {
+        "@timestamp": {"type": "date"},
+        "message": {"type": "text"},
+        "log": {"properties": {"level": {"type": "keyword"}}},
+        "kubernetes": {
+          "properties": {
+            "namespace": {"type": "keyword"},
+            "pod": {"properties": {"name": {"type": "keyword"}}},
+            "container": {"properties": {"name": {"type": "keyword"}}}
+          }
+        }
+      }
+    }
+  }
+}' >/dev/null
+echo
+
+echo "deleting any previous ${INDEX} index (idempotent re-seed)..."
+curl -s -X DELETE "${BASE_URL}/${INDEX}" >/dev/null || true
+
+# now() minus an offset in whole seconds, RFC3339 UTC — bash+date, no deps.
+ts() { date -u -d "-$1 seconds" +"%Y-%m-%dT%H:%M:%S.000Z" 2>/dev/null || date -u -v-"$1"S +"%Y-%m-%dT%H:%M:%S.000Z"; }
+
+BULK_FILE="$(mktemp)"
+trap 'rm -f "$BULK_FILE"' EXIT
+
+add_doc() {
+  # add_doc <seconds-ago> <namespace> <pod> <container> <level> <message>
+  # Messages below are plain ASCII with no quotes/backslashes, so a bare
+  # printf substitution is safe — no JSON-escaping dependency needed.
+  local secs="$1" ns="$2" pod="$3" container="$4" level="$5" msg="$6"
+  cat >>"$BULK_FILE" <<EOF
+{"index":{"_index":"${INDEX}"}}
+{"@timestamp":"$(ts "$secs")","message":"${msg}","log":{"level":"${level}"},"kubernetes":{"namespace":"${ns}","pod":{"name":"${pod}"},"container":{"name":"${container}"}}}
+EOF
+}
+
+# Baseline traffic: a healthy checkout service, mostly info, occasional warn.
+add_doc 3600 checkout web-0 web info  "request completed in 42ms"
+add_doc 3300 checkout web-0 web info  "request completed in 51ms"
+add_doc 3000 checkout web-1 web warn  "slow downstream call: 890ms"
+add_doc 2700 checkout web-0 web info  "request completed in 38ms"
+add_doc 2400 checkout worker-0 worker info "processed batch of 25 orders"
+
+# A quiet baseline of errors from payments too, BEFORE the burst — this is the
+# "3/5m baseline" logs_error_summary's histogram should show, contrasted with
+# the spike below.
+add_doc 2100 payments api-0 api error "retrying database connection (attempt 1/5)"
+add_doc 1980 payments api-0 api error "retrying database connection (attempt 1/5)"
+add_doc 1860 payments api-0 api error "retrying database connection (attempt 1/5)"
+
+# The CrashLoopBackOff-style burst: payments/api-0 spinning against a
+# postgres it can't reach, ~20 near-identical lines within a couple of
+# minutes — the dominant message logs_error_summary's top-messages (or its
+# client-side fallback, since `message` is text-only here) should surface.
+for i in $(seq 1 20); do
+  secs=$((300 - i * 8))
+  add_doc "$secs" payments api-0 api error "connection refused to postgres.payments.svc:5432 (attempt ${i}/20)"
+done
+add_doc 40 payments api-0 api error "Back-off restarting failed container api in pod api-0_payments(a1b2c3)"
+add_doc 20 payments api-0 api warn  "container api restarted (restartCount=7)"
+
+echo "bulk-indexing $(grep -c '"index"' "$BULK_FILE") documents into ${INDEX}..."
+curl -sf -X POST "${BASE_URL}/_bulk" -H 'Content-Type: application/x-ndjson' --data-binary "@${BULK_FILE}" \
+  | grep -o '"errors":[a-z]*'
+
+curl -sf -X POST "${BASE_URL}/${INDEX}/_refresh" >/dev/null
+
+echo
+echo "seeded ${BASE_URL}/${INDEX} — sanity check:"
+curl -sf -X POST "${BASE_URL}/${INDEX}/_search" -H 'Content-Type: application/json' \
+  -d '{"size":0,"query":{"match_all":{}}}' | grep -o '"value":[0-9]*' | head -1

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/investigate"
 	"github.com/Smana/runlore/internal/logs"
+	"github.com/Smana/runlore/internal/logs/elasticsearch"
 	"github.com/Smana/runlore/internal/logs/loki"
 	"github.com/Smana/runlore/internal/logs/victorialogs"
 	"github.com/Smana/runlore/internal/mcp"
@@ -164,6 +165,10 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		case config.LogsProviderLoki:
 			lg = loki.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers).WithLevelField(lf.LevelField)
 			dialect = investigate.DialectLogQL
+		case config.LogsProviderElasticsearch, config.LogsProviderOpenSearch:
+			lg = elasticsearch.NewWithAuth(cfg.Logs.URL, cfg.Logs.Index, cfg.Logs.TokenEnv, cfg.Logs.Headers).
+				WithLevelField(lf.LevelField).WithTimestampField(lf.TimestampField).WithMessageField(lf.MessageField)
+			dialect = investigate.DialectElastic
 		default: // victorialogs — the shipped default
 			lg = victorialogs.NewWithAuth(cfg.Logs.URL, cfg.Logs.TokenEnv, cfg.Logs.Headers).WithLevelField(lf.LevelField)
 		}

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -482,14 +482,25 @@ func TestLogsBackendSelection(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 	defer vlSrv.Close()
+	esSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, `{"version":{"number":"8.11.3"}}`)
+	}))
+	defer esSrv.Close()
 
 	tests := []struct {
 		name, url, pin, wantDialect string
 	}{
 		{"auto-detect loki", lokiSrv.URL, "", investigate.DialectLogQL},
 		{"auto-detect fail-safe victorialogs", vlSrv.URL, "", investigate.DialectLogsQL},
+		{"auto-detect elasticsearch", esSrv.URL, "", investigate.DialectElastic},
 		{"pinned loki skips probe", vlSrv.URL, "loki", investigate.DialectLogQL},
 		{"pinned victorialogs skips probe", lokiSrv.URL, "victorialogs", investigate.DialectLogsQL},
+		{"pinned elasticsearch skips probe", vlSrv.URL, "elasticsearch", investigate.DialectElastic},
+		{"pinned opensearch skips probe", vlSrv.URL, "opensearch", investigate.DialectElastic},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -523,3 +523,76 @@ func TestLogsBackendSelection(t *testing.T) {
 		})
 	}
 }
+
+// TestElasticFieldOverridesReachTheWire is the regression guard for the
+// `logs.fields` → Elasticsearch-client wiring in BuildModelAndTools. The client
+// package's own tests prove WithLevelField/WithMessageField/WithTimestampField
+// land in the request body when they are CALLED; only this test proves the app
+// layer still calls them. Before it existed, deleting
+// `.WithLevelField(...).WithMessageField(...)` from the elasticsearch branch of
+// BuildModelAndTools left the entire suite green while every operator override
+// of `logs.fields` silently stopped taking effect against a live cluster.
+//
+// It drives the real logs_error_summary tool end to end, so the assertions are
+// on the bytes an actual Elasticsearch would receive.
+func TestElasticFieldOverridesReachTheWire(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent-kubeconfig"))
+
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		bodies = append(bodies, body)
+		_, _ = io.WriteString(w, `{"aggregations":{"by_time":{"buckets":[]},"top_messages":{"buckets":[]}}}`)
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{Model: config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}}
+	cfg.Logs.URL = srv.URL
+	cfg.Logs.Provider = "elasticsearch"
+	cfg.Logs.Fields.LevelField = "severity"
+	cfg.Logs.Fields.MessageField = "log.message"
+	cfg.Logs.Fields.TimestampField = "event.created"
+
+	_, tools, _, _ := BuildModelAndTools(context.Background(), cfg, nil, nil, discardLog())
+	var summary investigate.Tool
+	for _, tool := range tools {
+		if tool.Name() == "logs_error_summary" {
+			summary = tool
+		}
+	}
+	if summary == nil {
+		t.Fatal("logs_error_summary not registered")
+	}
+	if _, err := summary.Call(context.Background(), `{"namespace":"apps","level":"error"}`); err != nil {
+		t.Fatalf("logs_error_summary: %v", err)
+	}
+
+	// Both aggregations go out as separate requests (Hits, then TopMessages);
+	// collect the three field names across whichever body carries each.
+	var gotLevel, gotMessage, gotTimestamp string
+	for _, body := range bodies {
+		aggs, _ := body["aggs"].(map[string]any)
+		if byTime, ok := aggs["by_time"].(map[string]any); ok {
+			dh, _ := byTime["date_histogram"].(map[string]any)
+			gotTimestamp, _ = dh["field"].(string)
+			sub, _ := byTime["aggs"].(map[string]any)
+			byLevel, _ := sub["by_level"].(map[string]any)
+			terms, _ := byLevel["terms"].(map[string]any)
+			gotLevel, _ = terms["field"].(string)
+		}
+		if tm, ok := aggs["top_messages"].(map[string]any); ok {
+			terms, _ := tm["terms"].(map[string]any)
+			gotMessage, _ = terms["field"].(string)
+		}
+	}
+	if gotLevel != "severity" {
+		t.Errorf("logs.fields.level_field did not reach by_level.terms.field: got %q, want %q", gotLevel, "severity")
+	}
+	if gotMessage != "log.message" {
+		t.Errorf("logs.fields.message_field did not reach top_messages.terms.field: got %q, want %q", gotMessage, "log.message")
+	}
+	if gotTimestamp != "event.created" {
+		t.Errorf("logs.fields.timestamp_field did not reach date_histogram.field: got %q, want %q", gotTimestamp, "event.created")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1433,6 +1433,36 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("logs.provider must be %q, %q, %q, %q, or empty (auto-detect); got %q",
 			LogsProviderVictoriaLogs, LogsProviderLoki, LogsProviderElasticsearch, LogsProviderOpenSearch, c.Logs.Provider)
 	}
+	// logs.index goes straight into the request PATH
+	// (internal/logs/elasticsearch.Client.indexPath). The client escapes it, so a
+	// malformed value can no longer change the request's shape — but escaping
+	// turns a typo into a puzzling 4xx from Elasticsearch mid-investigation
+	// ("no such index [a%2Fb]") rather than a startup failure naming the config
+	// key. Reject the malformed shapes here instead, loudly and once.
+	if idx := c.Logs.Index; idx != "" {
+		// Elasticsearch itself forbids all of these in an index name; `/` and `?`
+		// additionally used to be the path/query-string injections. `*` (wildcard),
+		// `,` (multi-index list) and `:` (cross-cluster `remote:index`) are all
+		// legal index-EXPRESSION syntax and deliberately allowed.
+		if i := strings.IndexAny(idx, "/\\?\"<>|# \t\n\r"); i >= 0 {
+			return fmt.Errorf("logs.index %q contains %q, which Elasticsearch/OpenSearch forbid in an index name (allowed: lowercase letters, digits, - _ + . and the `*` wildcard; separate multiple patterns with `,`)", idx, string(idx[i]))
+		}
+		// `,` IS legal — it is the multi-index list separator (logs-app-*,logs-infra-*)
+		// — but an empty element in that list is a typo (a trailing or doubled comma).
+		for _, part := range strings.Split(idx, ",") {
+			if part == "" {
+				return fmt.Errorf("logs.index %q has an empty pattern in its comma-separated list", idx)
+			}
+			// ES rejects a name starting with -, _ or +; a leading `-` in particular
+			// is its EXCLUSION syntax and silently matches nothing on its own.
+			if strings.HasPrefix(part, "-") || strings.HasPrefix(part, "_") || strings.HasPrefix(part, "+") {
+				return fmt.Errorf("logs.index pattern %q must not start with -, _ or + (Elasticsearch reserves those; a leading `-` is exclusion syntax)", part)
+			}
+		}
+		if idx != strings.ToLower(idx) {
+			return fmt.Errorf("logs.index %q must be lowercase (Elasticsearch/OpenSearch index names are), got mixed case", idx)
+		}
+	}
 	switch c.Actions.Mode {
 	case "", ActionOff, ActionSuggest:
 		return nil // read-only-ish: nothing to execute

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,15 +99,21 @@ const (
 )
 
 // Logs backend providers for config.logs.provider. Unlike the metrics backends
-// (which share the Prometheus HTTP API and differ only in dialect), VictoriaLogs
-// and Loki have entirely different query APIs, so this selects the CLIENT, not a
-// flavor of one. Empty ⇒ auto-detect at startup (Loki answers
-// /loki/api/v1/status/buildinfo; VictoriaLogs does not), failing safe to
+// (which share the Prometheus HTTP API and differ only in dialect), these
+// backends have entirely different query APIs, so this selects the CLIENT, not
+// a flavor of one. Empty ⇒ auto-detect at startup (internal/logs.Detect: Loki
+// answers /loki/api/v1/status/buildinfo; Elasticsearch/OpenSearch answer GET /
+// with a version document; VictoriaLogs answers neither), failing safe to
 // victorialogs — the provider RunLore shipped with — so an unreachable backend
-// at startup reproduces today's behaviour exactly.
+// at startup reproduces today's behaviour exactly. These values MUST equal
+// internal/logs.Provider* exactly (see that package's comment) — they are also
+// the ids internal/docsguard reflects a docs/integrations page's
+// `integration: {kind: logs, id: ...}` claim against.
 const (
-	LogsProviderVictoriaLogs = "victorialogs" // LogsQL over /select/logsql/* (shipped default)
-	LogsProviderLoki         = "loki"         // LogQL over /loki/api/v1/*
+	LogsProviderVictoriaLogs  = "victorialogs"  // LogsQL over /select/logsql/* (shipped default)
+	LogsProviderLoki          = "loki"          // LogQL over /loki/api/v1/*
+	LogsProviderElasticsearch = "elasticsearch" // classic _search DSL (Lucene query_string) over /<index>/_search
+	LogsProviderOpenSearch    = "opensearch"    // same _search DSL as Elasticsearch — a fork, not a different API
 )
 
 // MetricsConfig is the metrics backend endpoint plus an OPTIONAL flavor override.
@@ -133,9 +139,15 @@ type LogsConfig struct {
 	Endpoint `yaml:",inline"`
 
 	// Provider optionally pins the logs backend implementation instead of
-	// auto-detecting it: "loki" or "victorialogs" (see LogsProvider*). Empty ⇒
-	// probe once at startup, failing safe to victorialogs.
+	// auto-detecting it: "loki", "elasticsearch", "opensearch", or
+	// "victorialogs" (see LogsProvider*). Empty ⇒ probe once at startup,
+	// failing safe to victorialogs.
 	Provider string `yaml:"provider"`
+
+	// Index is the Elasticsearch/OpenSearch index pattern to search (e.g.
+	// "logs-*"). Ignored by victorialogs/loki. Empty ⇒ "logs-*" (the
+	// Filebeat/ECS convention).
+	Index string `yaml:"index"`
 
 	Fields LogFields `yaml:"fields"`
 }
@@ -160,7 +172,22 @@ type LogFields struct {
 	// UnpackPipe is the LogsQL pipe that promotes JSON body fields to top-level
 	// fields so LevelField becomes filterable. Default: unpack_json. Set to a
 	// different pipe (or leave empty to disable) if your logs are already flat.
+	// Elasticsearch/OpenSearch have no parser-pipe concept — ignored for them.
 	UnpackPipe string `yaml:"unpack_pipe"`
+
+	// TimestampField is the Elasticsearch/OpenSearch field the range filter,
+	// sort, and date_histogram aggregation key on. Ignored by victorialogs/loki
+	// (both have a built-in time concept, no configurable field name). Default:
+	// @timestamp (the ECS convention).
+	TimestampField string `yaml:"timestamp_field"`
+
+	// MessageField is the Elasticsearch/OpenSearch field TopMessages
+	// aggregates over. Ignored by victorialogs/loki. Default: message (the ECS
+	// convention) — which ships `text`-only with no keyword sub-field by
+	// default, so TopMessages transparently falls back to client-side
+	// aggregation unless this is pointed at an aggregatable field (e.g. a
+	// `message.keyword` multi-field your index template adds).
+	MessageField string `yaml:"message_field"`
 }
 
 // Default log-field convention: the VictoriaLogs + vector kubernetes-metadata
@@ -212,13 +239,35 @@ const (
 	defaultLokiLevelField     = "detected_level"
 )
 
-// ResolvedFor resolves the field convention for a specific logs provider:
-// Loki gets Loki-appropriate defaults; anything else (victorialogs, "") keeps
-// Resolved()'s shipped VictoriaLogs behaviour. Explicitly-set fields always win.
+// Default log-field convention for Elasticsearch/OpenSearch: the ECS
+// (Elastic Common Schema) layout Filebeat and most ECS-compliant collectors
+// ship. Both distributions get the SAME defaults — they are the same wire
+// format under a fork, not two different conventions.
+const (
+	defaultECSContainerField = "kubernetes.container.name"
+	defaultECSNamespaceField = "kubernetes.namespace"
+	defaultECSPodField       = "kubernetes.pod.name"
+	defaultECSLevelField     = "log.level"
+	defaultECSTimestampField = "@timestamp"
+	defaultECSMessageField   = "message"
+)
+
+// ResolvedFor resolves the field convention for a specific logs provider: Loki
+// gets Loki-appropriate defaults, Elasticsearch/OpenSearch get ECS defaults;
+// anything else (victorialogs, "") keeps Resolved()'s shipped VictoriaLogs
+// behaviour. Explicitly-set fields always win.
 func (f LogFields) ResolvedFor(provider string) LogFields {
-	if provider != LogsProviderLoki {
+	switch provider {
+	case LogsProviderLoki:
+		return f.resolvedForLoki()
+	case LogsProviderElasticsearch, LogsProviderOpenSearch:
+		return f.resolvedForECS()
+	default:
 		return f.Resolved()
 	}
+}
+
+func (f LogFields) resolvedForLoki() LogFields {
 	if f.ContainerField == "" {
 		f.ContainerField = defaultLokiContainerField
 	}
@@ -232,6 +281,29 @@ func (f LogFields) ResolvedFor(provider string) LogFields {
 		f.LevelField = defaultLokiLevelField
 	}
 	// UnpackPipe stays as-set (empty = no parser stage): detected_level needs none.
+	return f
+}
+
+func (f LogFields) resolvedForECS() LogFields {
+	if f.ContainerField == "" {
+		f.ContainerField = defaultECSContainerField
+	}
+	if f.NamespaceField == "" {
+		f.NamespaceField = defaultECSNamespaceField
+	}
+	if f.PodField == "" {
+		f.PodField = defaultECSPodField
+	}
+	if f.LevelField == "" {
+		f.LevelField = defaultECSLevelField
+	}
+	if f.TimestampField == "" {
+		f.TimestampField = defaultECSTimestampField
+	}
+	if f.MessageField == "" {
+		f.MessageField = defaultECSMessageField
+	}
+	// UnpackPipe stays unused: Elasticsearch/OpenSearch have no parser-pipe concept.
 	return f
 }
 
@@ -1356,10 +1428,10 @@ func (c *Config) Validate() error {
 	// logs.provider is a small enum; reject typos at startup rather than silently
 	// falling back to the wrong client against a live backend.
 	switch c.Logs.Provider {
-	case "", LogsProviderVictoriaLogs, LogsProviderLoki:
+	case "", LogsProviderVictoriaLogs, LogsProviderLoki, LogsProviderElasticsearch, LogsProviderOpenSearch:
 	default:
-		return fmt.Errorf("logs.provider must be %q, %q, or empty (auto-detect); got %q",
-			LogsProviderVictoriaLogs, LogsProviderLoki, c.Logs.Provider)
+		return fmt.Errorf("logs.provider must be %q, %q, %q, %q, or empty (auto-detect); got %q",
+			LogsProviderVictoriaLogs, LogsProviderLoki, LogsProviderElasticsearch, LogsProviderOpenSearch, c.Logs.Provider)
 	}
 	switch c.Actions.Mode {
 	case "", ActionOff, ActionSuggest:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -743,6 +743,7 @@ func TestLogsProviderValidate(t *testing.T) {
 	}
 }
 
+
 // TestValidateForgeProviderGitLab pins the fail-closed contract for the GitLab
 // forge provider: a missing token_env, and an obviously-invalid kb_repo, both
 // abort Validate rather than let `serve` come up with curation silently
@@ -791,5 +792,46 @@ func TestValidateForgeProviderGitLab(t *testing.T) {
 	def := &Config{}
 	if err := def.Validate(); err != nil {
 		t.Fatalf("an empty forge.provider must validate clean (defaults to github), got: %v", err)
+	}
+}
+// TestLogsIndexValidate: logs.index is interpolated into the Elasticsearch
+// request PATH. The client escapes it so a malformed value can no longer change
+// the request's SHAPE, but escaping alone turns a typo into a puzzling 4xx from
+// the cluster mid-investigation instead of a startup failure naming the config
+// key — the "fails closed and loudly" contract every other key here honours.
+func TestLogsIndexValidate(t *testing.T) {
+	for _, ok := range []string{
+		"",                        // unset ⇒ the logs-* default
+		"logs-*",                  // the shipped default, spelled out
+		"logs-app-*,logs-infra-*", // multi-index list
+		"filebeat-8.11.3-2026.08.02",
+		"remote_cluster:logs-*", // cross-cluster search
+		".ds-logs-generic-default",
+	} {
+		c := &Config{}
+		c.Logs.Index = ok
+		if err := c.Validate(); err != nil {
+			t.Fatalf("logs.index %q must validate, got %v", ok, err)
+		}
+	}
+	for _, bad := range []struct{ index, want string }{
+		{"a/b", "forbid"},             // used to add a path segment
+		{"logs-*?pretty", "forbid"},   // used to land in the query string
+		{"logs *", "forbid"},          // whitespace
+		{"logs-#1", "forbid"},         // fragment
+		{"logs-app-*,", "empty"},      // trailing comma in the list
+		{"logs-app-*,,x", "empty"},    // doubled comma
+		{"-logs-*", "must not start"}, // ES exclusion syntax; matches nothing
+		{"_logs", "must not start"},   // ES-reserved
+		{"Logs-*", "must be lowercase"}} {
+		c := &Config{}
+		c.Logs.Index = bad.index
+		err := c.Validate()
+		if err == nil {
+			t.Fatalf("logs.index %q must be rejected at startup", bad.index)
+		}
+		if !strings.Contains(err.Error(), "logs.index") || !strings.Contains(err.Error(), bad.want) {
+			t.Fatalf("logs.index %q: error must name the key and the reason %q, got %v", bad.index, bad.want, err)
+		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -728,7 +728,7 @@ func TestVectorCacheConfigDefaults(t *testing.T) {
 // philosophy: a typo'd key never fails silently), because a silent fallback to
 // victorialogs against a Loki endpoint would break every logs tool at runtime.
 func TestLogsProviderValidate(t *testing.T) {
-	for _, ok := range []string{"", "victorialogs", "loki"} {
+	for _, ok := range []string{"", "victorialogs", "loki", "elasticsearch", "opensearch"} {
 		c := &Config{}
 		c.Logs.Provider = ok
 		if err := c.Validate(); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -743,7 +743,6 @@ func TestLogsProviderValidate(t *testing.T) {
 	}
 }
 
-
 // TestValidateForgeProviderGitLab pins the fail-closed contract for the GitLab
 // forge provider: a missing token_env, and an obviously-invalid kb_repo, both
 // abort Validate rather than let `serve` come up with curation silently
@@ -794,6 +793,7 @@ func TestValidateForgeProviderGitLab(t *testing.T) {
 		t.Fatalf("an empty forge.provider must validate clean (defaults to github), got: %v", err)
 	}
 }
+
 // TestLogsIndexValidate: logs.index is interpolated into the Elasticsearch
 // request PATH. The client escapes it so a malformed value can no longer change
 // the request's SHAPE, but escaping alone turns a typo into a puzzling 4xx from

--- a/internal/config/logfields_test.go
+++ b/internal/config/logfields_test.go
@@ -78,3 +78,47 @@ func TestLogFieldsResolvedForLoki(t *testing.T) {
 		t.Fatalf("victorialogs resolution must be unchanged")
 	}
 }
+
+// TestLogFieldsResolvedForECS: ResolvedFor(elasticsearch) and
+// ResolvedFor(opensearch) both fill the SAME ECS (Elastic Common Schema)
+// convention — the two distributions speak an identical wire format, so they
+// must not drift into two different defaults. TimestampField/MessageField are
+// ECS-specific fields with no VictoriaLogs/Loki analogue. Any explicitly-set
+// field wins over the default.
+func TestLogFieldsResolvedForECS(t *testing.T) {
+	want := LogFields{
+		ContainerField: "kubernetes.container.name",
+		NamespaceField: "kubernetes.namespace",
+		PodField:       "kubernetes.pod.name",
+		LevelField:     "log.level",
+		TimestampField: "@timestamp",
+		MessageField:   "message",
+	}
+	for _, provider := range []string{LogsProviderElasticsearch, LogsProviderOpenSearch} {
+		got := LogFields{}.ResolvedFor(provider)
+		if got != want {
+			t.Fatalf("%s defaults = %+v, want %+v", provider, got, want)
+		}
+	}
+	over := LogFields{LevelField: "severity", MessageField: "log.message"}.ResolvedFor(LogsProviderElasticsearch)
+	if over.LevelField != "severity" || over.MessageField != "log.message" || over.TimestampField != "@timestamp" {
+		t.Fatalf("overrides must win, defaults fill the rest: %+v", over)
+	}
+}
+
+// TestLogsConfigIndexField confirms `logs.index` parses at the top level
+// (Elasticsearch/OpenSearch-specific, ignored by victorialogs/loki).
+func TestLogsConfigIndexField(t *testing.T) {
+	const y = `
+url: https://es:9200
+provider: elasticsearch
+index: logs-*
+`
+	var lc LogsConfig
+	if err := yaml.Unmarshal([]byte(y), &lc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if lc.Index != "logs-*" {
+		t.Fatalf("index not parsed: %+v", lc)
+	}
+}

--- a/internal/docsguard/integration_pages_test.go
+++ b/internal/docsguard/integration_pages_test.go
@@ -12,7 +12,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/Smana/runlore/internal/logs"
 	"github.com/Smana/runlore/internal/notify"
 	_ "github.com/Smana/runlore/internal/notify/templated" // self-registers the "templated" notifier
 	_ "github.com/Smana/runlore/internal/notify/webhook"   // self-registers the "webhook" notifier
@@ -73,10 +72,17 @@ func TestIntegrationPagesMatchRegistries(t *testing.T) {
 
 	pages := loadIntegrationPages(t, dir)
 
+	// Read the ids out of detect.go itself rather than restating them here; see
+	// logsProviderIDs for why a hand-written copy is the bug this guard is for.
+	logsIDs, err := logsProviderIDs(root)
+	if err != nil {
+		t.Fatalf("resolve logs provider ids: %v", err)
+	}
+
 	registries := map[string]reflectedRegistry{
 		"source":   {source: "source.Registered()", ids: idSet(sourceNames())},
 		"notifier": {source: "notify.Registered()", ids: idSet(notifierNames())},
-		"logs":     {source: "internal/logs/detect.go provider constants", ids: idSet([]string{logs.ProviderVictoriaLogs, logs.ProviderLoki})},
+		"logs":     {source: "internal/logs/detect.go provider constants", ids: idSet(logsIDs)},
 	}
 
 	// Direction 1: every page claiming a reflected kind must resolve to a

--- a/internal/docsguard/logs_providers.go
+++ b/internal/docsguard/logs_providers.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// logsProviderIDs returns the value of every `Provider*` constant declared in
+// internal/logs/detect.go, read from the source file itself.
+//
+// Why parse rather than list them: Go cannot enumerate a package's constants at
+// runtime, so the obvious implementation is a hand-written slice — and that is
+// what this replaced. The slice named detect.go as its source while being an
+// independent copy of it, so adding a provider left the guard silently
+// asserting against a stale set: the new provider's page was rejected as "not
+// registered" even though it was, and (worse, in the other direction) deleting
+// a provider constant left the guard still demanding its page.
+//
+// That is the same drift this whole package exists to catch, reproduced inside
+// the catcher. Reading the real declaration is the only version that cannot
+// disagree with it.
+func logsProviderIDs(root string) ([]string, error) {
+	path := filepath.Join(root, "internal", "logs", "detect.go")
+	f, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	var ids []string
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if !strings.HasPrefix(name.Name, "Provider") || i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				v, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					return nil, fmt.Errorf("%s: unquote %s: %w", path, name.Name, err)
+				}
+				ids = append(ids, v)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("%s: no Provider* string constants found — the declaration "+
+			"shape changed and this guard is now inert", path)
+	}
+	return ids, nil
+}

--- a/internal/investigate/logs_summary_tool.go
+++ b/internal/investigate/logs_summary_tool.go
@@ -104,7 +104,16 @@ func (t LogsErrorSummaryTool) Call(ctx context.Context, args string) (string, er
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "query: %s (last %dm)\n", query, since)
-	b.WriteString(renderHitsHistogram(buckets, step))
+	// Symmetric with the top-messages branch below. Without this, a histogram
+	// that failed on its own renders as simply absent — and "no histogram" is
+	// indistinguishable from "no matching lines" to the model reading this,
+	// which is the silently-partial failure the shard-failure check exists to
+	// prevent, moved one layer up.
+	if hErr != nil {
+		fmt.Fprintf(&b, "histogram: unavailable (%v)\n", hErr)
+	} else {
+		b.WriteString(renderHitsHistogram(buckets, step))
+	}
 	if mErr != nil {
 		fmt.Fprintf(&b, "top messages: unavailable (%v)\n", mErr)
 	} else {

--- a/internal/investigate/logs_summary_tool_test.go
+++ b/internal/investigate/logs_summary_tool_test.go
@@ -4,6 +4,7 @@ package investigate
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,8 @@ type fakeLogStats struct {
 	buckets  []providers.Bucket
 	msgs     []providers.MsgCount
 	gotQuery string
+	hitsErr  error
+	msgsErr  error
 }
 
 func (f *fakeLogStats) Query(context.Context, string, providers.TimeWindow) (providers.LogResult, error) {
@@ -23,10 +26,10 @@ func (f *fakeLogStats) Query(context.Context, string, providers.TimeWindow) (pro
 }
 func (f *fakeLogStats) Hits(_ context.Context, query string, _ providers.TimeWindow, _ time.Duration) ([]providers.Bucket, error) {
 	f.gotQuery = query
-	return f.buckets, nil
+	return f.buckets, f.hitsErr
 }
 func (f *fakeLogStats) TopMessages(context.Context, string, providers.TimeWindow, int) ([]providers.MsgCount, error) {
-	return f.msgs, nil
+	return f.msgs, f.msgsErr
 }
 
 func TestLogsErrorSummaryTool(t *testing.T) {
@@ -113,3 +116,66 @@ func TestSimilarRuns(t *testing.T) {
 		}
 	}
 }
+
+// TestLogsErrorSummaryPartialFailuresAreDisclosed pins BOTH degradation paths.
+//
+// The Elasticsearch client deliberately returns an error from Hits when a search
+// reports failed shards, on the reasoning that a silently-short histogram
+// understates the very spike this tool exists to find. That reasoning only holds
+// if the missing half is DISCLOSED — an absent histogram is otherwise
+// indistinguishable from "no matching lines" to the model reading the output.
+//
+// The two branches were asymmetric when this test was written: TopMessages'
+// failure was reported, Hits' was swallowed.
+func TestLogsErrorSummaryPartialFailuresAreDisclosed(t *testing.T) {
+	base := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	buckets := []providers.Bucket{{Time: base, Level: "error", Count: 7}}
+	msgs := []providers.MsgCount{{Message: "connection refused", Count: 7, First: base, Last: base}}
+
+	for _, tc := range []struct {
+		name         string
+		f            *fakeLogStats
+		wantContains string
+		wantAbsent   string
+	}{
+		{
+			name:         "histogram fails, top messages survive",
+			f:            &fakeLogStats{msgs: msgs, hitsErr: errPartial},
+			wantContains: "histogram: unavailable",
+			wantAbsent:   "top messages: unavailable",
+		},
+		{
+			name:         "top messages fail, histogram survives",
+			f:            &fakeLogStats{buckets: buckets, msgsErr: errPartial},
+			wantContains: "top messages: unavailable",
+			wantAbsent:   "histogram: unavailable",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := (LogsErrorSummaryTool{Logs: tc.f}).Call(context.Background(), `{"namespace":"apps"}`)
+			if err != nil {
+				t.Fatalf("one side failing must still return output, got err: %v", err)
+			}
+			if !strings.Contains(out, tc.wantContains) {
+				t.Errorf("the failed half is not disclosed to the model.\nwant substring %q in:\n%s", tc.wantContains, out)
+			}
+			if strings.Contains(out, tc.wantAbsent) {
+				t.Errorf("the surviving half was reported as unavailable.\nunexpected %q in:\n%s", tc.wantAbsent, out)
+			}
+			if !strings.Contains(out, errPartial.Error()) {
+				t.Errorf("the REASON is missing — %q must reach the model:\n%s", errPartial.Error(), out)
+			}
+		})
+	}
+}
+
+// TestLogsErrorSummaryBothFailing keeps the existing hard-failure contract: when
+// neither half is available there is nothing to disclose, so the tool errors.
+func TestLogsErrorSummaryBothFailing(t *testing.T) {
+	f := &fakeLogStats{hitsErr: errPartial, msgsErr: errPartial}
+	if _, err := (LogsErrorSummaryTool{Logs: f}).Call(context.Background(), `{"namespace":"apps"}`); err == nil {
+		t.Fatal("both halves failing must return an error, not an empty-looking summary")
+	}
+}
+
+var errPartial = errors.New("logs histogram is incomplete: 2 of 5 shards failed")

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -478,6 +478,19 @@ func buildLogQL(raw, container, namespace, level string, conv LogFields) (string
 // `{label="value"}` stream selector, or `unpack_json`/`_msg:`, the model's
 // likely mistakes coming from the other two dialects), mirroring the LogsQL
 // `level=` guard and the LogQL VictoriaLogs-ism guard in spirit.
+//
+// SECURITY — the `%q` verbs below are load-bearing; do NOT "tidy" them into
+// `%s` with hand-written quotes. Container and namespace names reach this
+// function from tool arguments the model chose, which in a multi-tenant cluster
+// can be attacker-influenced (a pod name, a namespace label). Go's %q escaping
+// happens to be EXACTLY Lucene's quoted-phrase escaping: `"` → `\"` and `\` →
+// `\\`, which is the only pair Lucene recognises inside a phrase. So a value
+// like `api" OR *:* OR "` stays one literal phrase instead of becoming three
+// clauses that widen the query across every tenant's logs. Swapping in
+// `%s` with manual quotes silently reopens that — TestBuildElasticQueryEscaping
+// pins the exact payloads. (Control characters are the one cosmetic difference:
+// %q renders them as `\n`/`\x00`, which Lucene reads as the escaped literal
+// character — harmless, and it still cannot terminate the phrase.)
 func buildElasticQuery(raw, container, namespace, level string, conv LogFields) (string, error) {
 	if raw != "" {
 		if strings.Contains(raw, "unpack_json") || strings.Contains(raw, "_msg:") || strings.HasPrefix(strings.TrimSpace(raw), "{") {

--- a/internal/investigate/query_tools.go
+++ b/internal/investigate/query_tools.go
@@ -401,6 +401,9 @@ func buildLogsQLWith(raw, container, namespace, level string, conv LogFields) (s
 	if conv.Dialect == DialectLogQL {
 		return buildLogQL(raw, container, namespace, level, conv)
 	}
+	if conv.Dialect == DialectElastic {
+		return buildElasticQuery(raw, container, namespace, level, conv)
+	}
 	if raw != "" {
 		if strings.Contains(raw, "level=") {
 			return "", fmt.Errorf("invalid LogsQL: `level=` is Prometheus/Loki syntax. Filter severity with `| %s | %s:error` (after a stream selector), or use the container/namespace/level params", conv.UnpackPipe, conv.LevelField)
@@ -465,6 +468,39 @@ func buildLogQL(raw, container, namespace, level string, conv LogFields) (string
 		q += fmt.Sprintf(" | %s=%q", conv.LevelField, level)
 	}
 	return q, nil
+}
+
+// buildElasticQuery composes a valid Elasticsearch/OpenSearch Lucene
+// query_string expression from the resolved ECS field convention:
+// `<field>:"value" AND <field>:"value"` — the SAME classic `_search` DSL both
+// distributions speak (internal/logs/elasticsearch). A raw query passes through
+// but is rejected when it looks like carried-over LogsQL/LogQL syntax (a
+// `{label="value"}` stream selector, or `unpack_json`/`_msg:`, the model's
+// likely mistakes coming from the other two dialects), mirroring the LogsQL
+// `level=` guard and the LogQL VictoriaLogs-ism guard in spirit.
+func buildElasticQuery(raw, container, namespace, level string, conv LogFields) (string, error) {
+	if raw != "" {
+		if strings.Contains(raw, "unpack_json") || strings.Contains(raw, "_msg:") || strings.HasPrefix(strings.TrimSpace(raw), "{") {
+			return "", fmt.Errorf("invalid Elasticsearch query_string: that looks like LogsQL/LogQL syntax. "+
+				"Use Lucene query_string syntax, e.g. `%s:%q AND %s:%q`, or use the container/namespace/level params",
+				conv.NamespaceField, "apps", conv.LevelField, "error")
+		}
+		return raw, nil
+	}
+	var clauses []string
+	if container != "" {
+		clauses = append(clauses, fmt.Sprintf("%s:%q", conv.ContainerField, container))
+	}
+	if namespace != "" {
+		clauses = append(clauses, fmt.Sprintf("%s:%q", conv.NamespaceField, namespace))
+	}
+	if len(clauses) == 0 {
+		return "", fmt.Errorf("provide a raw `query`, or `container`/`namespace` to build one")
+	}
+	if level != "" {
+		clauses = append(clauses, fmt.Sprintf("%s:%q", conv.LevelField, level))
+	}
+	return strings.Join(clauses, " AND "), nil
 }
 
 // Name returns the tool name.

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -609,3 +609,79 @@ func TestLogToolDescriptionsDialect(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildElasticQueryEscaping pins query-INJECTION safety, not formatting.
+// buildElasticQuery interpolates with `%q`, whose Go escaping coincides exactly
+// with Lucene's quoted-phrase escaping (`"` → `\"`, `\` → `\\`) — nothing here
+// asserted that, so a cosmetic refactor to `%s` with hand-written quotes would
+// have passed the whole suite while letting an attacker-chosen namespace or pod
+// name break out of the phrase and widen the query across every tenant's logs
+// in a multi-tenant cluster.
+func TestBuildElasticQueryEscaping(t *testing.T) {
+	elastic := LogFields{Dialect: DialectElastic}
+	for _, tc := range []struct {
+		name, container, namespace, want string
+	}{
+		{
+			name:      "quote-and-clause breakout attempt",
+			namespace: `api" OR *:* OR "`,
+			want:      `kubernetes.namespace:"api\" OR *:* OR \""`,
+		},
+		{
+			name:      "trailing backslash cannot escape the closing quote",
+			namespace: `api\`,
+			want:      `kubernetes.namespace:"api\\"`,
+		},
+		{
+			name:      "backslash-quote cannot smuggle a real quote through",
+			namespace: `api\"`,
+			want:      `kubernetes.namespace:"api\\\""`,
+		},
+		{
+			name:      "wildcard and boolean operators stay literal inside the phrase",
+			namespace: `api* AND kubernetes.namespace:kube-system`,
+			want:      `kubernetes.namespace:"api* AND kubernetes.namespace:kube-system"`,
+		},
+		{
+			name:      "the container field is interpolated the same way",
+			container: `web" OR *:*`,
+			want:      `kubernetes.container.name:"web\" OR *:*"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildLogsQLWith("", tc.container, tc.namespace, "", elastic)
+			if err != nil {
+				t.Fatalf("buildLogsQLWith: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got  %s\nwant %s", got, tc.want)
+			}
+			// Independently of the exact bytes: the value must not be able to
+			// terminate its phrase early, which is the property that actually
+			// prevents injection.
+			if !valueStaysInsideOnePhrase(got) {
+				t.Fatalf("value escaped its quoted phrase: %s", got)
+			}
+		})
+	}
+}
+
+// valueStaysInsideOnePhrase walks a single `field:"value"` clause under LUCENE's
+// escaping rules (a backslash escapes the next character inside a phrase) and
+// reports whether the closing quote is the last byte — i.e. whether the
+// interpolated value could inject trailing clauses.
+func valueStaysInsideOnePhrase(clause string) bool {
+	open := strings.Index(clause, `"`)
+	if open < 0 {
+		return false
+	}
+	for i := open + 1; i < len(clause); i++ {
+		switch clause[i] {
+		case '\\':
+			i++ // the escaped character is literal, whatever it is
+		case '"':
+			return i == len(clause)-1
+		}
+	}
+	return false
+}

--- a/internal/investigate/query_tools_test.go
+++ b/internal/investigate/query_tools_test.go
@@ -495,6 +495,87 @@ func TestBuildLogQL(t *testing.T) {
 	}
 }
 
+// TestBuildElasticQuery: with Dialect=DialectElastic the same structured
+// params compile to a Lucene query_string expression, and raw queries carrying
+// LogsQL/LogQL-isms (the model's likely carry-over mistakes) are rejected with
+// a correcting error so the model retries in-dialect.
+func TestBuildElasticQuery(t *testing.T) {
+	elastic := LogFields{Dialect: DialectElastic}
+	tests := []struct {
+		name, raw, container, namespace, level string
+		conv                                   LogFields
+		want                                   string
+		wantErr                                string
+	}{
+		{name: "structured selector + level", container: "harbor-core", namespace: "apps", level: "error", conv: elastic,
+			want: `kubernetes.container.name:"harbor-core" AND kubernetes.namespace:"apps" AND log.level:"error"`},
+		{name: "namespace only, no level", namespace: "apps", conv: elastic,
+			want: `kubernetes.namespace:"apps"`},
+		{name: "custom fields", container: "core", level: "error",
+			conv: LogFields{Dialect: DialectElastic, ContainerField: "kubernetes.container_name", LevelField: "severity"},
+			want: `kubernetes.container_name:"core" AND severity:"error"`},
+		{name: "raw passthrough", raw: `message:"connection refused" AND log.level:"error"`, conv: elastic,
+			want: `message:"connection refused" AND log.level:"error"`},
+		{name: "raw LogsQL-ism rejected (unpack_json)", raw: `{namespace="apps"} | unpack_json | log.level:error`, conv: elastic,
+			wantErr: "LogsQL/LogQL"},
+		{name: "raw LogsQL _msg: filter rejected", raw: `_msg:"error"`, conv: elastic,
+			wantErr: "LogsQL/LogQL"},
+		{name: "raw LogQL stream selector rejected", raw: `{namespace="apps"} |= "refused"`, conv: elastic,
+			wantErr: "LogsQL/LogQL"},
+		{name: "nothing given", conv: elastic, wantErr: "provide a raw"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildLogsQLWith(tc.raw, tc.container, tc.namespace, tc.level, tc.conv)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildLogsQLWith: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLogToolDescriptionsDialectElastic mirrors TestLogToolDescriptionsDialect
+// for the Elasticsearch/OpenSearch dialect: the model must be told
+// "Elasticsearch query_string" / "Lucene query_string (Elasticsearch/OpenSearch)"
+// — never LogsQL or LogQL — in every log tool's description and schema.
+func TestLogToolDescriptionsDialectElastic(t *testing.T) {
+	elastic := LogFields{Dialect: DialectElastic}
+	q := QueryLogsTool{Fields: elastic}
+	if !strings.Contains(q.Description(), "Lucene query_string (Elasticsearch/OpenSearch)") || strings.Contains(q.Description(), "invalid LogsQL") {
+		t.Fatalf("elastic description wrong: %s", q.Description())
+	}
+	if !strings.Contains(q.Schema(), "raw Elasticsearch query_string") {
+		t.Fatalf("elastic schema wrong: %s", q.Schema())
+	}
+	// The description must interpolate the CONFIGURED field names (not
+	// hardcoded kubernetes.namespace/log.level), so a field override reaches
+	// the model verbatim.
+	custom := QueryLogsTool{Fields: LogFields{Dialect: DialectElastic, LevelField: "severity", NamespaceField: "ns"}}
+	if !strings.Contains(custom.Description(), `severity:"error"`) || !strings.Contains(custom.Description(), `ns:"apps"`) {
+		t.Fatalf("elastic description must interpolate configured field names: %s", custom.Description())
+	}
+	for _, tool := range []interface {
+		Description() string
+		Schema() string
+	}{LogsErrorSummaryTool{Fields: elastic}, DiscoverLogFieldsTool{Fields: elastic}} {
+		if strings.Contains(tool.Schema(), "LogsQL") || strings.Contains(tool.Schema(), "raw LogQL") {
+			t.Fatalf("elastic-dialect schema must not mention the other dialects: %s", tool.Schema())
+		}
+		if strings.Contains(tool.Description(), "LogsQL") {
+			t.Fatalf("elastic-dialect description must not mention LogsQL: %s", tool.Description())
+		}
+	}
+}
+
 // TestLogToolDescriptionsDialect: on a Loki deployment the model must be told
 // LogQL — never LogsQL — in every tool description and schema, and vice versa.
 func TestLogToolDescriptionsDialect(t *testing.T) {

--- a/internal/investigate/renderlog.go
+++ b/internal/investigate/renderlog.go
@@ -27,10 +27,13 @@ type LogFields struct {
 
 // Dialect values for LogFields.Dialect — which query language the configured
 // logs backend speaks. The zero value is LogsQL so every existing caller and
-// fake is untouched; the app layer sets DialectLogQL when the backend is Loki.
+// fake is untouched; the app layer sets DialectLogQL when the backend is Loki,
+// DialectElastic when it is Elasticsearch/OpenSearch (both speak the same
+// Lucene query_string dialect — one value covers both).
 const (
-	DialectLogsQL = ""      // VictoriaLogs LogsQL (shipped default)
-	DialectLogQL  = "logql" // Grafana Loki LogQL
+	DialectLogsQL  = ""             // VictoriaLogs LogsQL (shipped default)
+	DialectLogQL   = "logql"        // Grafana Loki LogQL
+	DialectElastic = "query_string" // Elasticsearch/OpenSearch Lucene query_string
 )
 
 // Shipped log-field defaults. These MUST stay byte-identical to the strings the code
@@ -67,6 +70,24 @@ func (f LogFields) resolved() LogFields {
 		}
 		return f
 	}
+	if f.Dialect == DialectElastic {
+		// ECS (Elastic Common Schema) convention, shared by Elasticsearch and
+		// OpenSearch. Mirrors config.LogFields.ResolvedFor's ECS branch; this is
+		// the in-package fallback for zero-field callers.
+		if f.ContainerField == "" {
+			f.ContainerField = "kubernetes.container.name"
+		}
+		if f.NamespaceField == "" {
+			f.NamespaceField = "kubernetes.namespace"
+		}
+		if f.PodField == "" {
+			f.PodField = "kubernetes.pod.name"
+		}
+		if f.LevelField == "" {
+			f.LevelField = "log.level"
+		}
+		return f
+	}
 	if f.ContainerField == "" {
 		f.ContainerField = defaultContainerField
 	}
@@ -87,8 +108,11 @@ func (f LogFields) resolved() LogFields {
 
 // queryLang names the dialect (bare) for tool schemas ("raw LogQL"/"raw LogsQL").
 func (f LogFields) queryLang() string {
-	if f.Dialect == DialectLogQL {
+	switch f.Dialect {
+	case DialectLogQL:
 		return "LogQL"
+	case DialectElastic:
+		return "Elasticsearch query_string"
 	}
 	return "LogsQL"
 }
@@ -97,8 +121,11 @@ func (f LogFields) queryLang() string {
 // description-side counterpart of queryLang(), so both forms derive the dialect
 // from one place and no tool description can name the wrong one.
 func (f LogFields) dialectLabel() string {
-	if f.Dialect == DialectLogQL {
+	switch f.Dialect {
+	case DialectLogQL:
 		return "LogQL (Grafana Loki)"
+	case DialectElastic:
+		return "Lucene query_string (Elasticsearch/OpenSearch)"
 	}
 	return "LogsQL (VictoriaLogs)"
 }
@@ -110,11 +137,17 @@ func (f LogFields) dialectLabel() string {
 // log tools' descriptions so the guidance and the query builder can't drift.
 func (f LogFields) rawQueryGuidance() string {
 	c := f.resolved()
-	if f.Dialect == DialectLogQL {
+	switch f.Dialect {
+	case DialectLogQL:
 		return fmt.Sprintf("If you write a raw `query`: it MUST start with a stream selector using Loki stream labels, "+
 			"e.g. `{%s=\"apps\", %s=\"x\"}`; filter severity with `| %s=\"error\"` (no parser needed) or parse first with `| json` / `| logfmt`. "+
 			"Do NOT use VictoriaLogs LogsQL syntax (unpack_json, _msg, field:value filters).",
 			c.NamespaceField, c.ContainerField, c.LevelField)
+	case DialectElastic:
+		return fmt.Sprintf("If you write a raw `query`: it is a Lucene query_string expression, e.g. `%s:\"apps\" AND %s:\"error\"`; "+
+			"combine clauses with AND/OR/NOT, quote exact values, and use * for a wildcard. "+
+			"Do NOT use VictoriaLogs LogsQL or Grafana LogQL syntax (no `{label=\"value\"}` selectors, no `|` pipes).",
+			c.NamespaceField, c.LevelField)
 	}
 	return fmt.Sprintf("If you write a raw `query`: stream labels use DOT notation (%s, %s), NOT underscores; "+
 		"to filter by severity you MUST unpack JSON first, e.g. `{%s=\"x\"} | %s | %s:error`. "+

--- a/internal/logs/detect.go
+++ b/internal/logs/detect.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package logs hosts the backend-agnostic pieces of the logs data source; the
-// concrete clients live in the victorialogs and loki sub-packages.
+// concrete clients live in the victorialogs, loki, and elasticsearch sub-packages.
 package logs
 
 import (
@@ -18,29 +18,116 @@ import (
 
 // Provider identifiers returned by Detect. They deliberately equal the
 // config.LogsProvider* string values (internal/config/config.go) — kept as
-// plain strings here so the probe does not depend on the config package.
+// plain strings here so the probe does not depend on the config package. They
+// are also the ids internal/docsguard reflects a docs/integrations page's
+// `integration: {kind: logs, id: ...}` claim against, so a rename here must be
+// mirrored on the matching page.
 const (
-	ProviderVictoriaLogs = "victorialogs"
-	ProviderLoki         = "loki"
+	ProviderVictoriaLogs  = "victorialogs"
+	ProviderLoki          = "loki"
+	ProviderElasticsearch = "elasticsearch"
+	ProviderOpenSearch    = "opensearch"
 )
 
-// Detect probes the logs backend once at startup to distinguish Grafana Loki
-// from VictoriaLogs, mirroring the metrics flavor probe
-// (internal/metrics/prometheus/prometheus.go DetectFlavor): a config pin
+// Detect probes the logs backend once at startup to distinguish Grafana Loki,
+// Elasticsearch, and OpenSearch from VictoriaLogs, mirroring the metrics flavor
+// probe (internal/metrics/prometheus/prometheus.go DetectFlavor): a config pin
 // bypasses it (the caller checks logs.provider first), the probe is
-// best-effort, and ANY failure — unreachable backend, non-200, non-buildinfo
+// best-effort, and ANY failure — unreachable backend, non-200, unrecognised
 // payload — FAILS SAFE to VictoriaLogs, the provider RunLore shipped with, so
-// existing deployments see no behaviour change. Loki is identified by a 200
-// JSON response with a version on /loki/api/v1/status/buildinfo, an endpoint
-// VictoriaLogs does not serve. The probe carries the same auth the real client
-// will use (a Loki behind auth must still be detectable); the token is read
-// from the environment here and never logged.
+// existing deployments see no behaviour change.
+//
+// Two independent probes run in order, the first hit wins:
+//  1. Loki: a 200 JSON response with a version on
+//     /loki/api/v1/status/buildinfo, an endpoint the others do not serve.
+//  2. Elasticsearch/OpenSearch: a 200 JSON response on GET / (the cluster info
+//     document both distributions serve at their root) carrying a non-empty
+//     version.number. version.distribution == "opensearch" identifies
+//     OpenSearch (the field OpenSearch itself adds so clients can tell the two
+//     apart); its absence (plain Elasticsearch) identifies Elasticsearch.
+//
+// Neither probe fires on a real VictoriaLogs backend: its root path serves an
+// HTML welcome page (no version.number to parse) and it has no
+// /loki/api/v1/status/buildinfo endpoint (404).
+//
+// Both probes carry the same auth the real client will use (a backend behind
+// auth must still be detectable); the token is read from the environment here
+// and never logged.
 func Detect(ctx context.Context, baseURL, tokenEnv string, headers map[string]string) string {
 	base := strings.TrimRight(baseURL, "/")
+	if p := detectLoki(ctx, base, tokenEnv, headers); p != "" {
+		return p
+	}
+	if p := detectElastic(ctx, base, tokenEnv, headers); p != "" {
+		return p
+	}
+	return ProviderVictoriaLogs
+}
+
+// detectLoki probes /loki/api/v1/status/buildinfo, returning ProviderLoki on a
+// recognised response and "" (not a fail-safe default — Detect owns that) on
+// any failure, so Detect can try the next probe.
+func detectLoki(ctx context.Context, base, tokenEnv string, headers map[string]string) string {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/loki/api/v1/status/buildinfo", nil)
 	if err != nil {
-		return ProviderVictoriaLogs
+		return ""
 	}
+	applyProbeAuth(req, tokenEnv, headers)
+	resp, err := httpx.SecureClient(10 * time.Second).Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var bi struct {
+		Version string `json:"version"`
+	}
+	if json.Unmarshal(body, &bi) != nil || bi.Version == "" {
+		return "" // a 200 that is not buildinfo (proxy page) is not Loki
+	}
+	return ProviderLoki
+}
+
+// detectElastic probes GET / (the cluster info document both Elasticsearch and
+// OpenSearch serve at their root), returning ProviderOpenSearch or
+// ProviderElasticsearch on a recognised response, "" on any failure.
+func detectElastic(ctx context.Context, base, tokenEnv string, headers map[string]string) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/", nil)
+	if err != nil {
+		return ""
+	}
+	applyProbeAuth(req, tokenEnv, headers)
+	resp, err := httpx.SecureClient(10 * time.Second).Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var root struct {
+		Version struct {
+			Number       string `json:"number"`
+			Distribution string `json:"distribution"`
+		} `json:"version"`
+	}
+	if json.Unmarshal(body, &root) != nil || root.Version.Number == "" {
+		return "" // a 200 that carries no version.number (e.g. VictoriaLogs' HTML root) is neither
+	}
+	if root.Version.Distribution == "opensearch" {
+		return ProviderOpenSearch
+	}
+	return ProviderElasticsearch
+}
+
+// applyProbeAuth carries the same auth the real client will use, so a backend
+// behind auth is still detectable. The token is read from the environment here
+// (probe-time) and never logged.
+func applyProbeAuth(req *http.Request, tokenEnv string, headers map[string]string) {
 	if tokenEnv != "" {
 		if tok := os.Getenv(tokenEnv); tok != "" {
 			req.Header.Set("Authorization", "Bearer "+tok)
@@ -49,20 +136,4 @@ func Detect(ctx context.Context, baseURL, tokenEnv string, headers map[string]st
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
-	resp, err := httpx.SecureClient(10 * time.Second).Do(req)
-	if err != nil {
-		return ProviderVictoriaLogs
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return ProviderVictoriaLogs
-	}
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	var bi struct {
-		Version string `json:"version"`
-	}
-	if json.Unmarshal(body, &bi) != nil || bi.Version == "" {
-		return ProviderVictoriaLogs // a 200 that is not buildinfo (proxy page) is not Loki
-	}
-	return ProviderLoki
 }

--- a/internal/logs/detect_test.go
+++ b/internal/logs/detect_test.go
@@ -28,7 +28,7 @@ func TestDetect(t *testing.T) {
 	}
 
 	vlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.NotFound(w, r) // VictoriaLogs serves no /loki/api/v1/status/buildinfo
+		http.NotFound(w, r) // VictoriaLogs serves no /loki/api/v1/status/buildinfo and no ES-shaped root
 	}))
 	defer vlSrv.Close()
 	if got := Detect(context.Background(), vlSrv.URL, "", nil); got != ProviderVictoriaLogs {
@@ -36,7 +36,7 @@ func TestDetect(t *testing.T) {
 	}
 
 	htmlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = io.WriteString(w, `<html>welcome</html>`) // 200 but not buildinfo
+		_, _ = io.WriteString(w, `<html>welcome</html>`) // 200 but not buildinfo/ES root — VictoriaLogs' real root page
 	}))
 	defer htmlSrv.Close()
 	if got := Detect(context.Background(), htmlSrv.URL, "", nil); got != ProviderVictoriaLogs {
@@ -64,5 +64,121 @@ func TestDetectSendsAuth(t *testing.T) {
 	}
 	if gotAuth != "Bearer s3cr3t" {
 		t.Fatalf("probe must carry auth, got %q", gotAuth)
+	}
+}
+
+// TestDetectElasticsearch: a plain `version.number` with no `distribution`
+// field (real Elasticsearch's root response shape) identifies Elasticsearch.
+func TestDetectElasticsearch(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			http.NotFound(w, r)
+			return
+		}
+		gotPath = r.URL.Path
+		_, _ = io.WriteString(w, `{
+			"name": "es01",
+			"cluster_name": "docker-cluster",
+			"version": {
+				"number": "8.11.3",
+				"build_flavor": "default",
+				"build_type": "docker",
+				"lucene_version": "9.7.0"
+			},
+			"tagline": "You Know, for Search"
+		}`)
+	}))
+	defer srv.Close()
+	if got := Detect(context.Background(), srv.URL, "", nil); got != ProviderElasticsearch {
+		t.Fatalf("ES root response must detect elasticsearch, got %q", got)
+	}
+	if gotPath != "/" {
+		t.Fatalf("ES probe must hit root, got path %q", gotPath)
+	}
+}
+
+// TestDetectOpenSearch: `version.distribution: opensearch` (the field
+// OpenSearch adds precisely so clients can tell the two apart) identifies
+// OpenSearch rather than Elasticsearch.
+func TestDetectOpenSearch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, `{
+			"name": "os01",
+			"cluster_name": "opensearch-cluster",
+			"version": {
+				"distribution": "opensearch",
+				"number": "2.11.0",
+				"build_type": "tar",
+				"lucene_version": "9.7.0"
+			},
+			"tagline": "The OpenSearch Project: https://opensearch.org/"
+		}`)
+	}))
+	defer srv.Close()
+	if got := Detect(context.Background(), srv.URL, "", nil); got != ProviderOpenSearch {
+		t.Fatalf("OpenSearch root response must detect opensearch, got %q", got)
+	}
+}
+
+// TestDetectElasticAuth: the ES/OpenSearch probe carries the same auth as the
+// Loki probe — a backend behind auth must still be detectable.
+func TestDetectElasticAuth(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_DETECT_ES_TOKEN", "es-s3cr3t")
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"version":{"number":"8.11.3"}}`)
+	}))
+	defer srv.Close()
+	if got := Detect(context.Background(), srv.URL, "RUNLORE_TEST_DETECT_ES_TOKEN", nil); got != ProviderElasticsearch {
+		t.Fatalf("got %q", got)
+	}
+	if gotAuth != "Bearer es-s3cr3t" {
+		t.Fatalf("ES probe must carry auth, got %q", gotAuth)
+	}
+}
+
+// TestDetectElasticFailSafe: a non-200 and an unrecognised 200 payload on the
+// ES/OpenSearch root probe must still fail safe to victorialogs — the SAME
+// guarantee TestDetect already pins for the Loki probe, verified explicitly
+// against the second probe so neither one can regress it independently.
+func TestDetectElasticFailSafe(t *testing.T) {
+	// Non-200 on both probes.
+	errSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer errSrv.Close()
+	if got := Detect(context.Background(), errSrv.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("503 on both probes must fail safe to victorialogs, got %q", got)
+	}
+
+	// 200 but no version.number at all (an unrelated JSON API, or VictoriaLogs'
+	// own /select endpoints answering something JSON-shaped at root).
+	unrecognisedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/loki/api/v1/status/buildinfo" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, `{"status":"ok"}`)
+	}))
+	defer unrecognisedSrv.Close()
+	if got := Detect(context.Background(), unrecognisedSrv.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("unrecognised 200 payload must fail safe to victorialogs, got %q", got)
+	}
+
+	// Unreachable.
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close()
+	if got := Detect(context.Background(), down.URL, "", nil); got != ProviderVictoriaLogs {
+		t.Fatalf("unreachable must fail safe to victorialogs, got %q", got)
 	}
 }

--- a/internal/logs/elasticsearch/elasticsearch.go
+++ b/internal/logs/elasticsearch/elasticsearch.go
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package elasticsearch implements providers.LogsProvider against Elasticsearch
+// and OpenSearch, querying with the classic `_search` DSL — the one dialect both
+// ES 8.x and OpenSearch 2.x speak, so one client serves both distributions. It
+// mirrors internal/logs/loki: same construction/auth shape, same optional
+// LogStats/LogFields capabilities, same truncation sentinel. The one genuine
+// dialect difference — a `terms` aggregation over the ECS `message` field,
+// which ships `text`-only (no keyword sub-field) by default — is handled by
+// falling back to client-side aggregation; see TopMessages.
+package elasticsearch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Client queries an Elasticsearch or OpenSearch backend over the classic
+// `_search` DSL. The distribution (which only matters for startup detection,
+// internal/logs.Detect) is irrelevant here: both speak an identical request/
+// response envelope for _search, _field_caps, and aggregations.
+type Client struct {
+	baseURL        string
+	index          string            // index pattern, e.g. "logs-*"
+	tokenEnv       string            // env var holding a bearer token; empty ⇒ no auth
+	headers        map[string]string // static extra request headers (e.g. an API-key header)
+	maxLines       int               // per-query hit cap (the `size` parameter)
+	levelField     string            // severity field Hits/TopMessages split by; "" ⇒ defaultLevelField
+	timestampField string            // field the range filter/sort/date_histogram use; "" ⇒ defaultTimestampField
+	messageField   string            // field TopMessages aggregates over; "" ⇒ defaultMessageField
+	http           *http.Client
+}
+
+// defaultIndex is the ECS/Filebeat convention index pattern, used when
+// config.logs.index is left unset.
+const defaultIndex = "logs-*"
+
+// defaultMaxLines bounds the number of hits Query returns (the `size` param,
+// and the truncation-sentinel threshold), matching victorialogs/loki.
+const defaultMaxLines = 1000
+
+// ECS field-convention defaults (Filebeat/ECS-shaped documents, the collector
+// convention RunLore documents for this backend). Overridable via
+// WithLevelField/WithTimestampField/WithMessageField (config.logs.fields).
+const (
+	defaultLevelField     = "log.level"
+	defaultTimestampField = "@timestamp"
+	defaultMessageField   = "message"
+)
+
+// New builds a client for an Elasticsearch/OpenSearch base URL, unauthenticated.
+// An empty index defaults to "logs-*".
+func New(baseURL, index string) *Client {
+	return NewWithAuth(baseURL, index, "", nil)
+}
+
+// NewWithAuth builds a client that adds optional auth to every request; the
+// semantics are identical to loki.NewWithAuth / victorialogs.NewWithAuth (token
+// read from the env at request-build time, never logged).
+func NewWithAuth(baseURL, index, tokenEnv string, headers map[string]string) *Client {
+	if index == "" {
+		index = defaultIndex
+	}
+	return &Client{
+		baseURL:        strings.TrimRight(baseURL, "/"),
+		index:          index,
+		tokenEnv:       tokenEnv,
+		headers:        headers,
+		maxLines:       defaultMaxLines,
+		levelField:     defaultLevelField,
+		timestampField: defaultTimestampField,
+		messageField:   defaultMessageField,
+		http:           httpx.SecureClient(30 * time.Second),
+	}
+}
+
+// WithLevelField overrides the severity field Hits splits by (config.logs.fields.level_field).
+// Empty is a no-op so an unset config keeps the default; returns the client for chaining.
+func (c *Client) WithLevelField(field string) *Client {
+	if field != "" {
+		c.levelField = field
+	}
+	return c
+}
+
+// WithTimestampField overrides the field the range filter, sort, and
+// date_histogram key on (config.logs.fields.timestamp_field). Empty is a no-op.
+func (c *Client) WithTimestampField(field string) *Client {
+	if field != "" {
+		c.timestampField = field
+	}
+	return c
+}
+
+// WithMessageField overrides the field TopMessages aggregates over
+// (config.logs.fields.message_field). Empty is a no-op.
+func (c *Client) WithMessageField(field string) *Client {
+	if field != "" {
+		c.messageField = field
+	}
+	return c
+}
+
+var (
+	_ providers.LogsProvider = (*Client)(nil)
+	// Optional analytics/discovery capabilities — consumers type-assert for these.
+	_ providers.LogStats  = (*Client)(nil)
+	_ providers.LogFields = (*Client)(nil)
+)
+
+// Query runs a Lucene query_string query over the window and returns
+// normalized log lines, newest first (matching VictoriaLogs/Loki ordering). It
+// sends one `_search` request with size=maxLines and sort desc on the
+// timestamp field; when the server returns exactly the cap, more hits likely
+// matched and the shared truncation sentinel is appended.
+func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow) (providers.LogResult, error) {
+	body := c.searchBody(query, w, c.maxLines, true)
+	respBody, err := c.doSearch(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Hits struct {
+			Hits []struct {
+				Source map[string]any `json:"_source"`
+			} `json:"hits"`
+		} `json:"hits"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse elasticsearch response: %w", err)
+	}
+	var out providers.LogResult
+	for _, h := range resp.Hits.Hits {
+		out = append(out, c.sourceToLine(h.Source))
+	}
+	if len(resp.Hits.Hits) >= c.maxLines {
+		out = append(out, providers.TruncationLine(int64(c.maxLines)))
+	}
+	return out, nil
+}
+
+// sourceToLine flattens one hit's ECS-nested `_source` document into a
+// providers.LogLine: dot-notation Fields (kubernetes.pod.name, log.level, ...,
+// matching the convention query_logs' field selectors use), Message pulled
+// from messageField, and Time parsed from timestampField.
+func (c *Client) sourceToLine(source map[string]any) providers.LogLine {
+	flat := map[string]string{}
+	flattenJSON("", source, flat)
+	ll := providers.LogLine{Message: flat[c.messageField], Fields: flat}
+	if ts := flat[c.timestampField]; ts != "" {
+		if t, err := time.Parse(time.RFC3339, ts); err == nil {
+			ll.Time = t
+		} else if t, err := time.Parse("2006-01-02T15:04:05.999Z07:00", ts); err == nil {
+			ll.Time = t
+		}
+	}
+	return ll
+}
+
+// flattenJSON walks a decoded JSON value and writes leaf scalars into out,
+// keyed by their dot-notation path (kubernetes.pod.name), so an ECS document's
+// nested objects become the SAME flat field-name convention VictoriaLogs/Loki
+// already expose via stream labels. Arrays are stringified whole (rare in log
+// documents, and none of the three tools need per-element access). Explicit
+// JSON null is skipped rather than rendered as the literal "<nil>".
+func flattenJSON(prefix string, v any, out map[string]string) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, vv := range t {
+			key := k
+			if prefix != "" {
+				key = prefix + "." + k
+			}
+			flattenJSON(key, vv, out)
+		}
+	case nil:
+		// skip
+	case string:
+		out[prefix] = t
+	default:
+		out[prefix] = fmt.Sprint(t)
+	}
+}
+
+// searchBody builds the shared `_search` request body: a query_string query
+// (or match_all when query is empty) plus an optional range filter on
+// timestampField for the window bounds. size <= 0 omits the size key (used by
+// Hits/TopMessages, which want size:0 — hits only from aggregations). sortDesc
+// adds the newest-first sort Query needs; Hits/TopMessages don't (they read
+// only aggregations, so sorting individual hits is pointless cost).
+func (c *Client) searchBody(query string, w providers.TimeWindow, size int, sortDesc bool) map[string]any {
+	must := []map[string]any{}
+	if query != "" {
+		must = append(must, map[string]any{"query_string": map[string]any{"query": query}})
+	} else {
+		must = append(must, map[string]any{"match_all": map[string]any{}})
+	}
+	boolQ := map[string]any{"must": must}
+	if rangeFilter := c.rangeFilter(w); rangeFilter != nil {
+		boolQ["filter"] = []map[string]any{rangeFilter}
+	}
+	body := map[string]any{"query": map[string]any{"bool": boolQ}}
+	if size >= 0 {
+		body["size"] = size
+	}
+	if sortDesc {
+		body["sort"] = []map[string]any{{c.timestampField: map[string]any{"order": "desc"}}}
+	}
+	return body
+}
+
+// rangeFilter returns the range clause bounding the window on timestampField,
+// or nil when the window has neither bound set.
+func (c *Client) rangeFilter(w providers.TimeWindow) map[string]any {
+	r := map[string]any{}
+	if !w.Start.IsZero() {
+		r["gte"] = w.Start.UTC().Format(time.RFC3339)
+	}
+	if !w.End.IsZero() {
+		r["lte"] = w.End.UTC().Format(time.RFC3339)
+	}
+	if len(r) == 0 {
+		return nil
+	}
+	return map[string]any{"range": map[string]any{c.timestampField: r}}
+}
+
+// search POSTs a `_search` (or `_field_caps` via searchGet) request body and
+// returns the raw response body + HTTP status WITHOUT interpreting the status —
+// TopMessages needs the raw (status, body) pair to distinguish a genuine error
+// from the specific text-field aggregation rejection it falls back on.
+func (c *Client) search(ctx context.Context, body map[string]any) ([]byte, int, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("encode search body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/"+c.index+"/_search", bytes.NewReader(buf))
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("logs query: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(resp.Body)
+	return respBody, resp.StatusCode, nil
+}
+
+// doSearch runs search and turns a non-200 into an error (the common case;
+// only TopMessages needs the raw status to special-case one specific 400).
+func (c *Client) doSearch(ctx context.Context, body map[string]any) ([]byte, error) {
+	respBody, status, err := c.search(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("logs status %d: %s", status, string(respBody))
+	}
+	return respBody, nil
+}
+
+// Hits returns the per-step match count over the window, split by severity,
+// via a `date_histogram` aggregation (keyed on timestampField) with a `terms`
+// sub-aggregation on levelField — the Elasticsearch/OpenSearch analogue of
+// VictoriaLogs' /select/logsql/hits and Loki's count_over_time wrapper,
+// powering the logs_error_summary histogram. A step <= 0 defaults to one
+// minute. size:0 on the outer search — only the aggregation buckets are read,
+// no individual hits are fetched.
+func (c *Client) Hits(ctx context.Context, query string, w providers.TimeWindow, step time.Duration) ([]providers.Bucket, error) {
+	if step <= 0 {
+		step = time.Minute
+	}
+	body := c.searchBody(query, w, 0, false)
+	body["aggs"] = map[string]any{
+		"by_time": map[string]any{
+			"date_histogram": map[string]any{
+				"field":          c.timestampField,
+				"fixed_interval": fmt.Sprintf("%ds", int(step.Seconds())),
+			},
+			"aggs": map[string]any{
+				"by_level": map[string]any{
+					"terms": map[string]any{"field": c.levelField, "size": 20},
+				},
+			},
+		},
+	}
+	respBody, err := c.doSearch(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Aggregations struct {
+			ByTime struct {
+				Buckets []struct {
+					Key     int64 `json:"key"` // epoch millis
+					ByLevel struct {
+						Buckets []struct {
+							Key      string `json:"key"`
+							DocCount int64  `json:"doc_count"`
+						} `json:"buckets"`
+					} `json:"by_level"`
+				} `json:"buckets"`
+			} `json:"by_time"`
+		} `json:"aggregations"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse elasticsearch aggregation: %w", err)
+	}
+	var out []providers.Bucket
+	for _, tb := range resp.Aggregations.ByTime.Buckets {
+		ts := time.UnixMilli(tb.Key).UTC()
+		for _, lb := range tb.ByLevel.Buckets {
+			out = append(out, providers.Bucket{Time: ts, Level: lb.Key, Count: lb.DocCount})
+		}
+	}
+	return out, nil
+}
+
+// isTextFieldAggError reports whether an Elasticsearch/OpenSearch error
+// response is the specific "aggregating over a text-only field" rejection —
+// the wording ES emits verbatim (OpenSearch, forked from ES 7.10, kept it) when
+// a terms aggregation targets a field mapped `text` with no keyword sub-field,
+// which is exactly how ECS ships the `message` field by default. Any OTHER 400
+// (a malformed query, a missing index) must NOT match, so a real failure still
+// surfaces as an error instead of being silently swallowed into the fallback.
+func isTextFieldAggError(status int, body []byte) bool {
+	if status != http.StatusBadRequest {
+		return false
+	}
+	s := strings.ToLower(string(body))
+	return strings.Contains(s, "fielddata") && strings.Contains(s, "text field")
+}
+
+// TopMessages returns up to k dominant messages over the window. It FIRST
+// tries a server-side `terms` aggregation on messageField (cheap and
+// corpus-wide when the field is aggregatable — e.g. an operator added a
+// `message.keyword` multi-field and pointed logs.fields.message_field at it).
+// When the server rejects that specific aggregation because the field is
+// `text`-only (see isTextFieldAggError) — the default for ECS's `message`
+// field — it falls back to CLIENT-SIDE aggregation over the capped Query
+// sample, identical in spirit to loki.Client.TopMessages: numeric tokens
+// collapse so near-identical lines group, counts/first/last are per-sample
+// (up to maxLines newest lines) rather than corpus-wide. Any OTHER error
+// propagates rather than triggering the fallback. k <= 0 defaults to 10.
+func (c *Client) TopMessages(ctx context.Context, query string, w providers.TimeWindow, k int) ([]providers.MsgCount, error) {
+	if k <= 0 {
+		k = 10
+	}
+	body := c.searchBody(query, w, 0, false)
+	body["aggs"] = map[string]any{
+		"top_messages": map[string]any{
+			"terms": map[string]any{"field": c.messageField, "size": k},
+			"aggs": map[string]any{
+				"first_seen": map[string]any{"min": map[string]any{"field": c.timestampField}},
+				"last_seen":  map[string]any{"max": map[string]any{"field": c.timestampField}},
+			},
+		},
+	}
+	respBody, status, err := c.search(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		if isTextFieldAggError(status, respBody) {
+			return c.topMessagesClientSide(ctx, query, w, k)
+		}
+		return nil, fmt.Errorf("logs status %d: %s", status, string(respBody))
+	}
+	var resp struct {
+		Aggregations struct {
+			TopMessages struct {
+				Buckets []struct {
+					Key       string  `json:"key"`
+					DocCount  int64   `json:"doc_count"`
+					FirstSeen aggStat `json:"first_seen"`
+					LastSeen  aggStat `json:"last_seen"`
+				} `json:"buckets"`
+			} `json:"top_messages"`
+		} `json:"aggregations"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("parse elasticsearch aggregation: %w", err)
+	}
+	out := make([]providers.MsgCount, 0, len(resp.Aggregations.TopMessages.Buckets))
+	for _, b := range resp.Aggregations.TopMessages.Buckets {
+		out = append(out, providers.MsgCount{
+			Message: b.Key, Count: b.DocCount,
+			First: b.FirstSeen.parsed(), Last: b.LastSeen.parsed(),
+		})
+	}
+	return out, nil
+}
+
+// aggStat is a min/max metric aggregation's result: a numeric epoch-millis
+// value plus ES/OpenSearch's own formatted echo of it (value_as_string), which
+// parsed() prefers since it needs no epoch math.
+type aggStat struct {
+	Value         float64 `json:"value"`
+	ValueAsString string  `json:"value_as_string"`
+}
+
+func (a aggStat) parsed() time.Time {
+	if a.ValueAsString != "" {
+		if t, err := time.Parse(time.RFC3339, a.ValueAsString); err == nil {
+			return t
+		}
+		if t, err := time.Parse("2006-01-02T15:04:05.999Z07:00", a.ValueAsString); err == nil {
+			return t
+		}
+	}
+	if a.Value != 0 {
+		return time.UnixMilli(int64(a.Value)).UTC()
+	}
+	return time.Time{}
+}
+
+// topMessagesClientSide is the fallback path TopMessages takes when the
+// message field can't be aggregated server-side: run the capped, newest-first
+// Query and group client-side, exactly like loki.Client.TopMessages.
+func (c *Client) topMessagesClientSide(ctx context.Context, query string, w providers.TimeWindow, k int) ([]providers.MsgCount, error) {
+	lines, err := c.Query(ctx, query, w)
+	if err != nil {
+		return nil, err
+	}
+	type agg struct {
+		msg         string
+		count       int64
+		first, last time.Time
+	}
+	byKey := map[string]int{}
+	var groups []agg
+	for _, l := range lines {
+		if l.Time.IsZero() && len(l.Fields) == 0 {
+			continue // the truncation sentinel is not a log message
+		}
+		key := collapseNums(l.Message)
+		i, ok := byKey[key]
+		if !ok {
+			byKey[key] = len(groups)
+			groups = append(groups, agg{msg: l.Message, count: 1, first: l.Time, last: l.Time})
+			continue
+		}
+		g := &groups[i]
+		g.count++
+		if !l.Time.IsZero() && (g.first.IsZero() || l.Time.Before(g.first)) {
+			g.first = l.Time
+		}
+		if !l.Time.IsZero() && l.Time.After(g.last) {
+			g.last = l.Time
+		}
+	}
+	sort.SliceStable(groups, func(i, j int) bool { return groups[i].count > groups[j].count })
+	if len(groups) > k {
+		groups = groups[:k]
+	}
+	out := make([]providers.MsgCount, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, providers.MsgCount{Message: g.msg, Count: g.count, First: g.first, Last: g.last})
+	}
+	return out, nil
+}
+
+// reNumToken / collapseNums mirror internal/investigate/renderlog.go and
+// loki.Client's own copy: free-standing digit runs collapse to "0" so lines
+// differing only by a numeric value share one grouping key. Duplicated here (3
+// lines) rather than exported from investigate, which must not become a
+// dependency of a backend client — the same call loki.go makes.
+var reNumToken = regexp.MustCompile(`\d+`)
+
+func collapseNums(msg string) string { return reNumToken.ReplaceAllString(msg, "0") }
+
+// FieldNames lists the field names present in the configured index pattern via
+// `_field_caps` — present on both ES 8.x and OpenSearch 2.x — the log-schema
+// discovery path so a query_logs that assumed the wrong collector field names
+// can be corrected. UNLIKE VictoriaLogs'/Loki's discovery, field_caps has no
+// query/window scope (it is a MAPPING introspection endpoint, not a data
+// query) and reports no per-field hit count, so every FieldCount.Hits is 0 and
+// the query/window arguments are accepted for interface parity but unused —
+// documented as a parity caveat on the docs page. Results are sorted
+// alphabetically for determinism (field_caps has no frequency signal to order
+// by).
+func (c *Client) FieldNames(ctx context.Context, _ string, _ providers.TimeWindow) ([]providers.FieldCount, error) {
+	v := url.Values{"fields": {"*"}}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/"+c.index+"/_field_caps?"+v.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setAuth(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("logs query: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+	}
+	var fc struct {
+		Fields map[string]json.RawMessage `json:"fields"`
+	}
+	if err := json.Unmarshal(body, &fc); err != nil {
+		return nil, fmt.Errorf("parse field_caps: %w", err)
+	}
+	names := make([]string, 0, len(fc.Fields))
+	for name := range fc.Fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]providers.FieldCount, 0, len(names))
+	for _, name := range names {
+		out = append(out, providers.FieldCount{Name: name})
+	}
+	return out, nil
+}
+
+// setAuth applies the optional bearer token and static headers to req — the
+// SAME semantics as loki.Client.setAuth / victorialogs.Client.setAuth: token
+// read from the environment here, never logged. For an Elasticsearch/
+// OpenSearch API key (Authorization: ApiKey <base64>) rather than a bearer
+// token, set headers.Authorization explicitly instead of token_env — it is
+// applied AFTER the bearer header, so it wins.
+func (c *Client) setAuth(req *http.Request) {
+	if c.tokenEnv != "" {
+		if tok := os.Getenv(c.tokenEnv); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+	}
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+}

--- a/internal/logs/elasticsearch/elasticsearch.go
+++ b/internal/logs/elasticsearch/elasticsearch.go
@@ -21,7 +21,9 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Smana/runlore/internal/httpx"
@@ -42,6 +44,18 @@ type Client struct {
 	timestampField string            // field the range filter/sort/date_histogram use; "" ⇒ defaultTimestampField
 	messageField   string            // field TopMessages aggregates over; "" ⇒ defaultMessageField
 	http           *http.Client
+
+	// msgFieldNotAggregatable is a sticky, one-shot latch: once the backend has
+	// told us messageField cannot be aggregated server-side, TopMessages stops
+	// re-asking. Without it the DEFAULT configuration (ECS `message` is
+	// text-only, no keyword sub-field) burns a guaranteed-failing round trip on
+	// EVERY logs_error_summary call — and each one also lands in the cluster's
+	// own error log, which looks like a RunLore bug to whoever reads it.
+	// Whether the field is aggregatable is a property of the index MAPPING, so
+	// the answer cannot change under a running process without an operator
+	// reindexing and restarting; latching it is safe. atomic (not a bare bool)
+	// because the investigation loop runs tools concurrently against one Client.
+	msgFieldNotAggregatable atomic.Bool
 }
 
 // defaultIndex is the ECS/Filebeat convention index pattern, used when
@@ -149,7 +163,24 @@ func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow
 	if len(resp.Hits.Hits) >= c.maxLines {
 		out = append(out, providers.TruncationLine(int64(c.maxLines)))
 	}
+	// A 200 with failed shards is a PARTIAL view (see shardFailure). Say so in
+	// band rather than dropping the lines: the same reasoning as the truncation
+	// sentinel — the model must know the view is incomplete, and a returned
+	// error here would throw away hits that are perfectly good evidence.
+	if partial, reason := shardFailure(respBody); partial {
+		out = append(out, partialLine(reason))
+	}
 	return out, nil
+}
+
+// partialLine is the shard-failure sibling of providers.TruncationLine: a
+// Time-less, Fields-less sentinel so it can never be mistaken for a real log
+// entry (and so the client-side aggregation in topMessagesClientSide skips it
+// by the same test it already uses for the truncation sentinel).
+func partialLine(reason string) providers.LogLine {
+	return providers.LogLine{
+		Message: fmt.Sprintf("… partial results: %s — some indices in the pattern could not be searched; this view is incomplete", reason),
+	}
 }
 
 // sourceToLine flattens one hit's ECS-nested `_source` document into a
@@ -160,14 +191,39 @@ func (c *Client) sourceToLine(source map[string]any) providers.LogLine {
 	flat := map[string]string{}
 	flattenJSON("", source, flat)
 	ll := providers.LogLine{Message: flat[c.messageField], Fields: flat}
-	if ts := flat[c.timestampField]; ts != "" {
-		if t, err := time.Parse(time.RFC3339, ts); err == nil {
-			ll.Time = t
-		} else if t, err := time.Parse("2006-01-02T15:04:05.999Z07:00", ts); err == nil {
-			ll.Time = t
-		}
+	if t, ok := parseESTime(flat[c.timestampField]); ok {
+		ll.Time = t
 	}
 	return ll
+}
+
+// parseESTime decodes the two on-the-wire shapes an Elasticsearch/OpenSearch
+// `date` field can reach us in.
+//
+//  1. RFC 3339 / ISO-8601 ("2026-08-02T10:00:01.000Z") — the default
+//     strict_date_optional_time rendering, and by far the common case. Go's
+//     time.Parse accepts the fractional second against the plain RFC3339 layout,
+//     so no second layout is needed (an earlier ".999Z07:00" fallback here was
+//     dead code).
+//  2. Bare epoch MILLISECONDS ("1785664800000"). A `date` mapping may be
+//     declared `"format": "epoch_millis"`, in which case `_source` carries a JSON
+//     NUMBER, not a string. That is legal ES, and before this was handled every
+//     LogLine.Time silently came back zero: no error anywhere, but the timeline
+//     render and the client-side fallback's first→last spans all collapsed.
+//     epoch_millis is the only numeric date format ES applies by default;
+//     epoch_second needs an explicit mapping and is deliberately not guessed at,
+//     since the two are indistinguishable from the value alone.
+func parseESTime(ts string) (time.Time, bool) {
+	if ts == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, ts); err == nil {
+		return t, true
+	}
+	if ms, err := strconv.ParseInt(ts, 10, 64); err == nil {
+		return time.UnixMilli(ms).UTC(), true
+	}
+	return time.Time{}, false
 }
 
 // flattenJSON walks a decoded JSON value and writes leaf scalars into out,
@@ -190,6 +246,14 @@ func flattenJSON(prefix string, v any, out map[string]string) {
 		// skip
 	case string:
 		out[prefix] = t
+	case float64:
+		// encoding/json decodes EVERY JSON number into float64, and fmt.Sprint on
+		// a float64 switches to scientific notation past ~7 significant digits —
+		// so `event.duration: 123456789` would reach the model as "1.23456789e+08"
+		// and an epoch-millis `@timestamp` as "1.7856648e+12", which parseESTime
+		// could never decode. 'f' with precision -1 prints the shortest form that
+		// round-trips, keeping integral values integral.
+		out[prefix] = strconv.FormatFloat(t, 'f', -1, 64)
 	default:
 		out[prefix] = fmt.Sprint(t)
 	}
@@ -197,8 +261,11 @@ func flattenJSON(prefix string, v any, out map[string]string) {
 
 // searchBody builds the shared `_search` request body: a query_string query
 // (or match_all when query is empty) plus an optional range filter on
-// timestampField for the window bounds. size <= 0 omits the size key (used by
-// Hits/TopMessages, which want size:0 — hits only from aggregations). sortDesc
+// timestampField for the window bounds. A size >= 0 is sent verbatim, INCLUDING
+// size:0 — that is the value Hits/TopMessages pass to say "aggregation buckets
+// only, return no hits", and omitting the key there would make ES fall back to
+// its default of 10 hits per aggregation request. Only a negative size omits the
+// key (no caller does today). sortDesc
 // adds the newest-first sort Query needs; Hits/TopMessages don't (they read
 // only aggregations, so sorting individual hits is pointless cost).
 func (c *Client) searchBody(query string, w providers.TimeWindow, size int, sortDesc bool) map[string]any {
@@ -238,6 +305,64 @@ func (c *Client) rangeFilter(w providers.TimeWindow) map[string]any {
 	return map[string]any{"range": map[string]any{c.timestampField: r}}
 }
 
+// indexPath renders the configured index pattern as ONE percent-escaped URL
+// path segment. Pasting it in raw let an operator's config silently change the
+// request's SHAPE rather than its target: `index: "a/b"` added a path segment
+// (hitting a different endpoint entirely), and `index: "logs-*?pretty"` moved
+// everything after the `?` into the query string. Escaping is the fix, but two
+// characters are restored afterwards because they are both legal unescaped in a
+// path segment (RFC 3986 sub-delims) and load-bearing to Elasticsearch: `*` is
+// the index wildcard `logs-*` itself, and `,` is its multi-index list separator
+// (`logs-app-*,logs-infra-*`). Escaping THOSE would depend on the server
+// percent-decoding the path to keep working; escaping `/`, `?`, `#`, and
+// whitespace — the actual injections — does not.
+func (c *Client) indexPath() string {
+	esc := url.PathEscape(c.index)
+	esc = strings.ReplaceAll(esc, "%2A", "*")
+	esc = strings.ReplaceAll(esc, "%2C", ",")
+	return esc
+}
+
+// shardFailure reports whether a HTTP 200 `_search` response is only PARTIALLY
+// complete, and a short reason if so.
+//
+// Elasticsearch does not fail a search that some shards could not serve: it
+// returns 200 with `_shards.failed > 0` and whatever the surviving shards
+// produced. The realistic trigger here is mapping drift across a rolling
+// `logs-*` pattern — the index template gained a `message.keyword` sub-field
+// partway through, so a `terms` aggregation on it succeeds on the newer indices
+// and is rejected on the older ones. The aggregation then comes back looking
+// perfectly well-formed while covering only part of the window, and
+// logs_error_summary would report those counts as complete. Callers must treat
+// a true here as "this answer is not the whole answer".
+func shardFailure(body []byte) (bool, string) {
+	var resp struct {
+		Shards struct {
+			Total      int `json:"total"`
+			Successful int `json:"successful"`
+			Failed     int `json:"failed"`
+			Failures   []struct {
+				Index  string `json:"index"`
+				Reason struct {
+					Type   string `json:"type"`
+					Reason string `json:"reason"`
+				} `json:"reason"`
+			} `json:"failures"`
+		} `json:"_shards"`
+	}
+	// A body that does not parse is not this function's problem — the caller
+	// unmarshals it properly right after and reports the real error.
+	if err := json.Unmarshal(body, &resp); err != nil || resp.Shards.Failed == 0 {
+		return false, ""
+	}
+	reason := fmt.Sprintf("%d of %d shards failed", resp.Shards.Failed, resp.Shards.Total)
+	if len(resp.Shards.Failures) > 0 {
+		f := resp.Shards.Failures[0]
+		reason += fmt.Sprintf(" (%s on %s: %s)", f.Reason.Type, f.Index, f.Reason.Reason)
+	}
+	return true, reason
+}
+
 // search POSTs a `_search` (or `_field_caps` via searchGet) request body and
 // returns the raw response body + HTTP status WITHOUT interpreting the status —
 // TopMessages needs the raw (status, body) pair to distinguish a genuine error
@@ -247,7 +372,7 @@ func (c *Client) search(ctx context.Context, body map[string]any) ([]byte, int, 
 	if err != nil {
 		return nil, 0, fmt.Errorf("encode search body: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/"+c.index+"/_search", bytes.NewReader(buf))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/"+c.indexPath()+"/_search", bytes.NewReader(buf))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -304,6 +429,14 @@ func (c *Client) Hits(ctx context.Context, query string, w providers.TimeWindow,
 	if err != nil {
 		return nil, err
 	}
+	// Unlike Query, []Bucket has no channel for an in-band notice, and a
+	// silently-short histogram is worse than no histogram: it understates the
+	// very spike logs_error_summary exists to find. Fail loudly instead — the
+	// caller (internal/investigate/logs_summary_tool.go) degrades gracefully,
+	// still rendering top messages and surfacing this reason.
+	if partial, reason := shardFailure(respBody); partial {
+		return nil, fmt.Errorf("logs histogram is incomplete: %s", reason)
+	}
 	var resp struct {
 		Aggregations struct {
 			ByTime struct {
@@ -333,12 +466,32 @@ func (c *Client) Hits(ctx context.Context, query string, w providers.TimeWindow,
 }
 
 // isTextFieldAggError reports whether an Elasticsearch/OpenSearch error
-// response is the specific "aggregating over a text-only field" rejection —
-// the wording ES emits verbatim (OpenSearch, forked from ES 7.10, kept it) when
-// a terms aggregation targets a field mapped `text` with no keyword sub-field,
-// which is exactly how ECS ships the `message` field by default. Any OTHER 400
-// (a malformed query, a missing index) must NOT match, so a real failure still
-// surfaces as an error instead of being silently swallowed into the fallback.
+// response is the specific "aggregating over a text-only field" rejection a
+// terms aggregation gets when its target field is mapped `text` with no keyword
+// sub-field — exactly how ECS ships `message` by default.
+//
+// DO NOT "simplify" this to a single, more literal substring. The rejection
+// wording is NOT identical across the two distributions; it was captured
+// verbatim from both (see live_verify_test.go):
+//
+//	ES 8.15.0:        "Fielddata is disabled on [message] in [logs-demo]. Text
+//	                   fields are not optimised for operations that require
+//	                   per-document field data … Please use a keyword field
+//	                   instead. Alternatively, set fielddata=true on [message] …"
+//	OpenSearch 2.17.0: "Text fields are not optimised for operations that require
+//	                   per-document field data … Alternatively, set
+//	                   fielddata=true on [message] …"
+//
+// The `Fielddata is disabled on [x] in [y].` sentence is ELASTICSEARCH-ONLY —
+// matching on it would silently break the fallback on OpenSearch, turning every
+// logs_error_summary there into a hard error. What both wordings do share, and
+// all this therefore keys on, is two lowercased tokens: "fielddata" (from
+// `set fielddata=true`) and "text field" (a substring of "Text fields are not
+// optimised"). Both were confirmed present in both distributions' real output.
+//
+// Any OTHER 400 (a malformed query, a missing index) must NOT match, so a real
+// failure still surfaces as an error instead of being silently swallowed into
+// the fallback — TestTopMessagesRealErrorPropagates pins that.
 func isTextFieldAggError(status int, body []byte) bool {
 	if status != http.StatusBadRequest {
 		return false
@@ -362,6 +515,12 @@ func (c *Client) TopMessages(ctx context.Context, query string, w providers.Time
 	if k <= 0 {
 		k = 10
 	}
+	// Sticky: a previous call already learned this field is not aggregatable, so
+	// skip straight to the fallback instead of re-issuing a request we know the
+	// backend will reject (and log as an error on its side).
+	if c.msgFieldNotAggregatable.Load() {
+		return c.topMessagesClientSide(ctx, query, w, k)
+	}
 	body := c.searchBody(query, w, 0, false)
 	body["aggs"] = map[string]any{
 		"top_messages": map[string]any{
@@ -378,9 +537,24 @@ func (c *Client) TopMessages(ctx context.Context, query string, w providers.Time
 	}
 	if status != http.StatusOK {
 		if isTextFieldAggError(status, respBody) {
+			// Latch it: the mapping will not change under this process.
+			c.msgFieldNotAggregatable.Store(true)
 			return c.topMessagesClientSide(ctx, query, w, k)
 		}
 		return nil, fmt.Errorf("logs status %d: %s", status, string(respBody))
+	}
+	// A 200 whose shards partly failed (see shardFailure) — the mapping-drift
+	// case, where only the OLDER indices in the pattern lack the aggregatable
+	// sub-field. The buckets that came back parse perfectly and would be
+	// reported as the definitive top messages while covering only part of the
+	// window. Take the client-side path instead: a plain `_search` over a `text`
+	// field is not what the shards choked on, so the fallback gets a COMPLETE
+	// (if sample-capped) answer. Deliberately NOT latched — unlike the mapping
+	// rejection above, a shard failure can be transient (a node briefly out),
+	// and permanently downgrading a working aggregation over one blip would be
+	// the wrong trade.
+	if partial, _ := shardFailure(respBody); partial {
+		return c.topMessagesClientSide(ctx, query, w, k)
 	}
 	var resp struct {
 		Aggregations struct {
@@ -416,13 +590,8 @@ type aggStat struct {
 }
 
 func (a aggStat) parsed() time.Time {
-	if a.ValueAsString != "" {
-		if t, err := time.Parse(time.RFC3339, a.ValueAsString); err == nil {
-			return t
-		}
-		if t, err := time.Parse("2006-01-02T15:04:05.999Z07:00", a.ValueAsString); err == nil {
-			return t
-		}
+	if t, ok := parseESTime(a.ValueAsString); ok {
+		return t
 	}
 	if a.Value != 0 {
 		return time.UnixMilli(int64(a.Value)).UTC()
@@ -497,7 +666,7 @@ func collapseNums(msg string) string { return reNumToken.ReplaceAllString(msg, "
 // by).
 func (c *Client) FieldNames(ctx context.Context, _ string, _ providers.TimeWindow) ([]providers.FieldCount, error) {
 	v := url.Values{"fields": {"*"}}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/"+c.index+"/_field_caps?"+v.Encode(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/"+c.indexPath()+"/_field_caps?"+v.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/logs/elasticsearch/elasticsearch_test.go
+++ b/internal/logs/elasticsearch/elasticsearch_test.go
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearch
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// esSearchResponse and osSearchResponse are near-identical (OpenSearch forked
+// from Elasticsearch 7.10 and kept the same wire envelope for _search); the two
+// fixtures differ in the cosmetic metadata a real cluster of each distribution
+// actually returns, so a test run against BOTH proves the client isn't
+// accidentally keyed on Elasticsearch-only quirks.
+const esSearchResponse = `{
+  "took": 3, "timed_out": false,
+  "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+  "hits": {
+    "total": {"value": 2, "relation": "eq"},
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "logs-2026.08.02", "_id": "a1", "_score": null,
+        "_source": {
+          "@timestamp": "2026-08-02T10:00:01.000Z",
+          "message": "connection refused",
+          "log": {"level": "error"},
+          "kubernetes": {"namespace": "apps", "pod": {"name": "harbor-db-0"}, "container": {"name": "db"}}
+        }
+      },
+      {
+        "_index": "logs-2026.08.02", "_id": "a2", "_score": null,
+        "_source": {
+          "@timestamp": "2026-08-02T10:00:00.000Z",
+          "message": "retrying",
+          "log": {"level": "warn"},
+          "kubernetes": {"namespace": "apps", "pod": {"name": "harbor-db-0"}, "container": {"name": "db"}}
+        }
+      }
+    ]
+  }
+}`
+
+const osSearchResponse = `{
+  "took": 5, "timed_out": false,
+  "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+  "hits": {
+    "total": {"value": 2, "relation": "eq"},
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "logs-000001", "_id": "b1", "_score": null,
+        "_source": {
+          "@timestamp": "2026-08-02T10:00:01.000Z",
+          "message": "connection refused",
+          "log": {"level": "error"},
+          "kubernetes": {"namespace": "apps", "pod": {"name": "harbor-db-0"}, "container": {"name": "db"}}
+        }
+      },
+      {
+        "_index": "logs-000001", "_id": "b2", "_score": null,
+        "_source": {
+          "@timestamp": "2026-08-02T10:00:00.000Z",
+          "message": "retrying",
+          "log": {"level": "warn"},
+          "kubernetes": {"namespace": "apps", "pod": {"name": "harbor-db-0"}, "container": {"name": "db"}}
+        }
+      }
+    ]
+  }
+}`
+
+func TestQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{{"elasticsearch", esSearchResponse}, {"opensearch", osSearchResponse}} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath, gotMethod string
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotMethod = r.Method
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+
+			res, err := New(srv.URL, "logs-*").Query(context.Background(), `kubernetes.namespace:"apps"`, providers.TimeWindow{})
+			if err != nil {
+				t.Fatalf("Query: %v", err)
+			}
+			if gotMethod != http.MethodPost {
+				t.Fatalf("method=%q, want POST", gotMethod)
+			}
+			if gotPath != "/logs-*/_search" {
+				t.Fatalf("path=%q", gotPath)
+			}
+			qs, _ := gotBody["query"].(map[string]any)
+			boolQ, _ := qs["bool"].(map[string]any)
+			must, _ := boolQ["must"].([]any)
+			if len(must) != 1 {
+				t.Fatalf("expected one must clause, got %+v", boolQ)
+			}
+			qstr, _ := must[0].(map[string]any)["query_string"].(map[string]any)
+			if qstr["query"] != `kubernetes.namespace:"apps"` {
+				t.Fatalf("query_string.query = %v", qstr["query"])
+			}
+			sort, _ := gotBody["sort"].([]any)
+			if len(sort) != 1 {
+				t.Fatalf("expected a sort clause, got %+v", gotBody["sort"])
+			}
+			sortField, _ := sort[0].(map[string]any)["@timestamp"].(map[string]any)
+			if sortField["order"] != "desc" {
+				t.Fatalf("must sort newest-first, got %+v", sort)
+			}
+			if len(res) != 2 {
+				t.Fatalf("want 2 lines, got %d: %+v", len(res), res)
+			}
+			// Newest first, matching VictoriaLogs/Loki ordering.
+			if res[0].Message != "connection refused" || res[1].Message != "retrying" {
+				t.Fatalf("order/messages wrong: %+v", res)
+			}
+			if res[0].Time.UTC().Format(time.RFC3339) != "2026-08-02T10:00:01Z" {
+				t.Fatalf("time not parsed: %v", res[0].Time)
+			}
+			// ECS-nested _source fields flatten to DOT-NOTATION keys matching the
+			// field-convention names, so streamIdentity/query_logs field filters work.
+			if res[0].Fields["kubernetes.pod.name"] != "harbor-db-0" || res[0].Fields["kubernetes.container.name"] != "db" {
+				t.Fatalf("flattened fields wrong: %+v", res[0].Fields)
+			}
+			if res[0].Fields["log.level"] != "error" {
+				t.Fatalf("level field not flattened: %+v", res[0].Fields)
+			}
+		})
+	}
+}
+
+func TestQuerySizeCapAndSort(t *testing.T) {
+	var gotSize float64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotSize, _ = body["size"].(float64)
+		_, _ = io.WriteString(w, esSearchResponse)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "logs-*")
+	c.maxLines = 2
+	res, err := c.Query(context.Background(), "*", providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotSize != 2 {
+		t.Fatalf("size=%v, want 2 (the maxLines cap)", gotSize)
+	}
+	// Server returned exactly maxLines hits -> truncation sentinel appended.
+	if len(res) != 3 || !strings.Contains(res[2].Message, "results truncated at 2") {
+		t.Fatalf("want 2 lines + sentinel, got %d: %+v", len(res), res)
+	}
+}
+
+func TestQueryTimeWindowRangeFilter(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":0},"hits":[]}}`)
+	}))
+	defer srv.Close()
+	start := time.Date(2026, 8, 2, 9, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 8, 2, 10, 0, 0, 0, time.UTC)
+	if _, err := New(srv.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{Start: start, End: end}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	qs, _ := gotBody["query"].(map[string]any)
+	boolQ, _ := qs["bool"].(map[string]any)
+	filter, _ := boolQ["filter"].([]any)
+	if len(filter) != 1 {
+		t.Fatalf("expected a range filter, got %+v", boolQ)
+	}
+	rangeClause, _ := filter[0].(map[string]any)["range"].(map[string]any)
+	ts, _ := rangeClause["@timestamp"].(map[string]any)
+	if ts["gte"] != start.Format(time.RFC3339) || ts["lte"] != end.Format(time.RFC3339) {
+		t.Fatalf("range filter = %+v", ts)
+	}
+}
+
+func TestQueryAuthHeaders(t *testing.T) {
+	t.Setenv("RUNLORE_TEST_ES_TOKEN", "s3cr3t")
+	var gotAuth, gotTenant string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotTenant = r.Header.Get("X-Tenant")
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":0},"hits":[]}}`)
+	}))
+	defer srv.Close()
+	c := NewWithAuth(srv.URL, "logs-*", "RUNLORE_TEST_ES_TOKEN", map[string]string{"X-Tenant": "team-a"})
+	if _, err := c.Query(context.Background(), "*", providers.TimeWindow{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotAuth != "Bearer s3cr3t" || gotTenant != "team-a" {
+		t.Fatalf("auth not applied: auth=%q tenant=%q", gotAuth, gotTenant)
+	}
+}
+
+func TestQueryErrorPaths(t *testing.T) {
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	down.Close()
+	if _, err := New(down.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{}); err == nil {
+		t.Fatalf("backend down must error")
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"illegal_argument_exception"}`, http.StatusBadRequest)
+	}))
+	defer bad.Close()
+	if _, err := New(bad.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{}); err == nil ||
+		!strings.Contains(err.Error(), "400") {
+		t.Fatalf("non-200 must error with the status, got %v", err)
+	}
+
+	malformed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"hits":{"hits":`)
+	}))
+	defer malformed.Close()
+	if _, err := New(malformed.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{}); err == nil {
+		t.Fatalf("malformed body must error")
+	}
+
+	empty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":0},"hits":[]}}`)
+	}))
+	defer empty.Close()
+	res, err := New(empty.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{})
+	if err != nil || len(res) != 0 {
+		t.Fatalf("empty result must be (nil, nil), got %v / %v", res, err)
+	}
+}
+
+func TestQueryDefaultIndex(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":0},"hits":[]}}`)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL, "").Query(context.Background(), "*", providers.TimeWindow{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if gotPath != "/logs-*/_search" {
+		t.Fatalf("empty index must default to logs-*, got path %q", gotPath)
+	}
+}
+
+// TestHits: date_histogram split by the level field. Each (time bucket, level
+// sub-bucket) pair becomes one providers.Bucket.
+func TestHits(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{
+		  "aggregations": {
+		    "by_time": {
+		      "buckets": [
+		        {"key_as_string": "2026-08-02T10:00:00.000Z", "key": 1785664800000, "doc_count": 5,
+		         "by_level": {"buckets": [{"key": "error", "doc_count": 3}, {"key": "warn", "doc_count": 2}]}},
+		        {"key_as_string": "2026-08-02T10:05:00.000Z", "key": 1785665100000, "doc_count": 412,
+		         "by_level": {"buckets": [{"key": "error", "doc_count": 412}]}}
+		      ]
+		    }
+		  }
+		}`)
+	}))
+	defer srv.Close()
+
+	buckets, err := New(srv.URL, "logs-*").Hits(context.Background(), `log.level:"error"`, providers.TimeWindow{}, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("Hits: %v", err)
+	}
+	aggs, _ := gotBody["aggs"].(map[string]any)
+	byTime, _ := aggs["by_time"].(map[string]any)
+	dh, _ := byTime["date_histogram"].(map[string]any)
+	if dh["field"] != "@timestamp" || dh["fixed_interval"] != "300s" {
+		t.Fatalf("date_histogram = %+v", dh)
+	}
+	sub, _ := byTime["aggs"].(map[string]any)
+	byLevel, _ := sub["by_level"].(map[string]any)
+	terms, _ := byLevel["terms"].(map[string]any)
+	if terms["field"] != "log.level" {
+		t.Fatalf("by_level terms field = %v", terms["field"])
+	}
+	if len(buckets) != 3 {
+		t.Fatalf("want 3 (time,level) buckets, got %d: %+v", len(buckets), buckets)
+	}
+	var sawSpike bool
+	for _, b := range buckets {
+		if b.Level == "error" && b.Count == 412 && !b.Time.IsZero() {
+			sawSpike = true
+		}
+	}
+	if !sawSpike {
+		t.Fatalf("missing error=412 bucket: %+v", buckets)
+	}
+}
+
+func TestHitsErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "parse_exception", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL, "logs-*").Hits(context.Background(), "*", providers.TimeWindow{}, time.Minute); err == nil ||
+		!strings.Contains(err.Error(), "400") {
+		t.Fatalf("bad request must error with status, got %v", err)
+	}
+}
+
+// TestTopMessages: the happy path where the message field IS aggregatable
+// (e.g. a keyword sub-field configured) — server-side terms aggregation wins,
+// no client-side fallback triggered.
+func TestTopMessages(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{
+		  "aggregations": {
+		    "top_messages": {
+		      "buckets": [
+		        {"key": "connection refused", "doc_count": 388,
+		         "first_seen": {"value": 1785664800000, "value_as_string": "2026-08-02T10:00:00.000Z"},
+		         "last_seen":  {"value": 1785665100000, "value_as_string": "2026-08-02T10:05:00.000Z"}},
+		        {"key": "timeout waiting for db", "doc_count": 12,
+		         "first_seen": {"value": 1785664800000, "value_as_string": "2026-08-02T10:00:00.000Z"},
+		         "last_seen":  {"value": 1785664800000, "value_as_string": "2026-08-02T10:00:00.000Z"}}
+		      ]
+		    }
+		  }
+		}`)
+	}))
+	defer srv.Close()
+
+	msgs, err := New(srv.URL, "logs-*").TopMessages(context.Background(), `log.level:"error"`, providers.TimeWindow{}, 10)
+	if err != nil {
+		t.Fatalf("TopMessages: %v", err)
+	}
+	aggs, _ := gotBody["aggs"].(map[string]any)
+	tm, _ := aggs["top_messages"].(map[string]any)
+	terms, _ := tm["terms"].(map[string]any)
+	if terms["field"] != "message" {
+		t.Fatalf("terms field = %v", terms["field"])
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("want 2 messages, got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Message != "connection refused" || msgs[0].Count != 388 {
+		t.Fatalf("dominant message wrong: %+v", msgs[0])
+	}
+	if !msgs[0].First.Before(msgs[0].Last) {
+		t.Fatalf("first->last span not tracked: %+v", msgs[0])
+	}
+}
+
+// TestTopMessagesFallsBackWhenMessageFieldIsTextOnly: the parity caveat this
+// task exists to prove. ECS `message` ships as a plain `text` field with no
+// keyword sub-field by default, so Elasticsearch/OpenSearch reject a terms
+// aggregation on it with a 400 "Fielddata is disabled on text fields"
+// illegal_argument_exception. On exactly that signature, TopMessages falls
+// back to client-side aggregation over the capped, newest-first Query sample
+// (mirroring loki.Client.TopMessages) instead of surfacing the error.
+func TestTopMessagesFallsBackWhenMessageFieldIsTextOnly(t *testing.T) {
+	var aggAttempts, plainSearches int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if aggs, ok := body["aggs"].(map[string]any); ok {
+			if _, ok := aggs["top_messages"]; ok {
+				aggAttempts++
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, `{
+				  "error": {
+				    "type": "search_phase_execution_exception",
+				    "reason": "all shards failed",
+				    "caused_by": {
+				      "type": "illegal_argument_exception",
+				      "reason": "Fielddata is disabled on text fields by default. Set fielddata=true on [message] in order to load fielddata in memory by uninverting the inverted index. Note that this can however use significant memory."
+				    }
+				  },
+				  "status": 400
+				}`)
+				return
+			}
+		}
+		plainSearches++
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":4},"hits":[
+		  {"_source":{"@timestamp":"2026-08-02T10:00:03.000Z","message":"connection refused to 10.0.0.7"}},
+		  {"_source":{"@timestamp":"2026-08-02T10:00:02.000Z","message":"connection refused to 10.0.0.9"}},
+		  {"_source":{"@timestamp":"2026-08-02T10:00:01.000Z","message":"connection refused to 10.0.0.9"}},
+		  {"_source":{"@timestamp":"2026-08-02T10:00:00.000Z","message":"timeout waiting for db"}}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	msgs, err := New(srv.URL, "logs-*").TopMessages(context.Background(), "*", providers.TimeWindow{}, 10)
+	if err != nil {
+		t.Fatalf("TopMessages must degrade, not error: %v", err)
+	}
+	if aggAttempts != 1 || plainSearches != 1 {
+		t.Fatalf("want exactly one aggregation attempt then one fallback search, got agg=%d plain=%d", aggAttempts, plainSearches)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("want 2 grouped messages (numeric tokens collapsed), got %d: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Count != 3 || !strings.Contains(msgs[0].Message, "connection refused") {
+		t.Fatalf("dominant message wrong: %+v", msgs[0])
+	}
+	if msgs[1].Message != "timeout waiting for db" || msgs[1].Count != 1 {
+		t.Fatalf("second message wrong: %+v", msgs[1])
+	}
+}
+
+// TestTopMessagesRealErrorPropagates: a genuine failure (not the text-field
+// aggregation-rejection signature) must surface as an error, never be silently
+// swallowed as if it were the text-only fallback case.
+func TestTopMessagesRealErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"type":"parse_exception","reason":"bad query"}}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL, "logs-*").TopMessages(context.Background(), "*", providers.TimeWindow{}, 10); err == nil {
+		t.Fatalf("a non-text-field 400 must error, not silently fall back")
+	}
+}
+
+// TestFieldNames: discover_log_fields via _field_caps, present on both ES 8.x
+// and OpenSearch 2.x. field_caps carries no per-field hit count (unlike
+// VictoriaLogs' field_names), so every FieldCount.Hits is 0 — documented as a
+// parity caveat.
+func TestFieldNames(t *testing.T) {
+	var gotPath, gotFields string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotFields = r.URL.Query().Get("fields")
+		_, _ = io.WriteString(w, `{
+		  "indices": ["logs-2026.08.02"],
+		  "fields": {
+		    "kubernetes.namespace": {"keyword": {"type": "keyword", "searchable": true, "aggregatable": true}},
+		    "kubernetes.pod.name":  {"keyword": {"type": "keyword", "searchable": true, "aggregatable": true}},
+		    "message": {"text": {"type": "text", "searchable": true, "aggregatable": false}}
+		  }
+		}`)
+	}))
+	defer srv.Close()
+
+	fields, err := New(srv.URL, "logs-*").FieldNames(context.Background(), `kubernetes.namespace:"apps"`, providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("FieldNames: %v", err)
+	}
+	if gotPath != "/logs-*/_field_caps" {
+		t.Fatalf("path=%q", gotPath)
+	}
+	if gotFields != "*" {
+		t.Fatalf("fields param=%q, want *", gotFields)
+	}
+	if len(fields) != 3 {
+		t.Fatalf("want 3 fields, got %d: %+v", len(fields), fields)
+	}
+	// Deterministic (alphabetical) order, since field_caps carries no frequency
+	// signal to sort by.
+	if fields[0].Name != "kubernetes.namespace" || fields[0].Hits != 0 {
+		t.Fatalf("fields[0] = %+v", fields[0])
+	}
+}
+
+func TestFieldNamesErrorPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "index_not_found_exception", http.StatusNotFound)
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL, "logs-*").FieldNames(context.Background(), "*", providers.TimeWindow{}); err == nil {
+		t.Fatalf("404 must error")
+	}
+}
+
+// TestWithLevelFieldAndTimestampField: overrides reach both the query builder
+// (via the caller, not tested here) and the client's own request bodies.
+func TestWithLevelFieldAndTimestampField(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":0},"hits":[]}}`)
+	}))
+	defer srv.Close()
+	c := New(srv.URL, "logs-*").WithLevelField("severity").WithTimestampField("event.created")
+	if _, err := c.Query(context.Background(), "*", providers.TimeWindow{}); err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	sort, _ := gotBody["sort"].([]any)
+	if _, ok := sort[0].(map[string]any)["event.created"]; !ok {
+		t.Fatalf("custom timestamp field not used for sort: %+v", sort)
+	}
+}

--- a/internal/logs/elasticsearch/elasticsearch_test.go
+++ b/internal/logs/elasticsearch/elasticsearch_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -504,5 +505,505 @@ func TestWithLevelFieldAndTimestampField(t *testing.T) {
 	sort, _ := gotBody["sort"].([]any)
 	if _, ok := sort[0].(map[string]any)["event.created"]; !ok {
 		t.Fatalf("custom timestamp field not used for sort: %+v", sort)
+	}
+}
+
+// TestLevelFieldOverrideReachesTheWire pins WithLevelField on the request body
+// of the ONE request that actually emits a level field. Query does not (it only
+// sorts and range-filters on the timestamp), so asserting the override there —
+// as this file used to — proves nothing: deleting `.WithLevelField(...)` from
+// internal/app/investigate.go's Elasticsearch branch kept the whole suite green.
+// Hits' `by_level` terms aggregation is where the config key has to land.
+func TestLevelFieldOverrideReachesTheWire(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"aggregations":{"by_time":{"buckets":[]}}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "logs-*").WithLevelField("severity").WithTimestampField("event.created")
+	if _, err := c.Hits(context.Background(), "*", providers.TimeWindow{}, time.Minute); err != nil {
+		t.Fatalf("Hits: %v", err)
+	}
+	aggs, _ := gotBody["aggs"].(map[string]any)
+	byTime, _ := aggs["by_time"].(map[string]any)
+	dh, _ := byTime["date_histogram"].(map[string]any)
+	if dh["field"] != "event.created" {
+		t.Fatalf("timestamp override missing from date_histogram: %+v", dh)
+	}
+	sub, _ := byTime["aggs"].(map[string]any)
+	byLevel, _ := sub["by_level"].(map[string]any)
+	terms, _ := byLevel["terms"].(map[string]any)
+	if terms["field"] != "severity" {
+		t.Fatalf("level override did not reach by_level.terms.field: got %v, want \"severity\"", terms["field"])
+	}
+}
+
+// TestMessageFieldOverrideReachesTheWire: WithMessageField had no test at all.
+// It is what lets an operator point at an aggregatable multi-field
+// (`message.keyword`) and skip the client-side fallback entirely, so losing the
+// wiring would silently downgrade every logs_error_summary to sample-scoped
+// counts with nothing failing.
+func TestMessageFieldOverrideReachesTheWire(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_, _ = io.WriteString(w, `{"aggregations":{"top_messages":{"buckets":[]}}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "logs-*").WithMessageField("log.message")
+	if _, err := c.TopMessages(context.Background(), "*", providers.TimeWindow{}, 10); err != nil {
+		t.Fatalf("TopMessages: %v", err)
+	}
+	aggs, _ := gotBody["aggs"].(map[string]any)
+	tm, _ := aggs["top_messages"].(map[string]any)
+	terms, _ := tm["terms"].(map[string]any)
+	if terms["field"] != "log.message" {
+		t.Fatalf("message override did not reach top_messages.terms.field: got %v, want \"log.message\"", terms["field"])
+	}
+}
+
+// TestMessageFieldOverrideDrivesTheFallbackSource: the message-field override
+// must also decide which key the CLIENT-SIDE fallback reads out of `_source`.
+// A wired aggregation with an unwired fallback would return k empty messages.
+func TestMessageFieldOverrideDrivesTheFallbackSource(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if aggs, ok := body["aggs"].(map[string]any); ok {
+			if _, ok := aggs["top_messages"]; ok {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, esTextFieldRejection)
+				return
+			}
+		}
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":1},"hits":[
+		  {"_source":{"@timestamp":"2026-08-02T10:00:03.000Z","log":{"message":"connection refused"}}}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	msgs, err := New(srv.URL, "logs-*").WithMessageField("log.message").
+		TopMessages(context.Background(), "*", providers.TimeWindow{}, 10)
+	if err != nil {
+		t.Fatalf("TopMessages: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].Message != "connection refused" {
+		t.Fatalf("fallback did not read the overridden message field: %+v", msgs)
+	}
+}
+
+// esTextFieldRejection / osTextFieldRejection are the two distributions' REAL
+// wording for the text-field aggregation rejection, captured verbatim from
+// Elasticsearch 8.15.0 and OpenSearch 2.17.0 during the live verification run
+// (see live_verify_test.go). They are NOT the same string: the
+// "Fielddata is disabled on [x] in [y]." sentence is Elasticsearch-only. Both
+// fixtures exist so a future "simplification" of isTextFieldAggError to a single
+// literal substring fails here rather than in production on OpenSearch.
+const esTextFieldRejection = `{
+  "error": {
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed",
+    "caused_by": {
+      "type": "illegal_argument_exception",
+      "reason": "Fielddata is disabled on [message] in [logs-demo]. Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [message] in order to load field data by uninverting the inverted index. Note that this can use significant memory."
+    }
+  },
+  "status": 400
+}`
+
+const osTextFieldRejection = `{
+  "error": {
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed",
+    "caused_by": {
+      "type": "illegal_argument_exception",
+      "reason": "Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [message] in order to load field data by uninverting the inverted index. Note that this can use significant memory."
+    }
+  },
+  "status": 400
+}`
+
+// TestIsTextFieldAggErrorBothDistributions: the fallback's ONLY trigger, pinned
+// against both real wordings plus the negatives it must not swallow.
+func TestIsTextFieldAggErrorBothDistributions(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"elasticsearch 8.15 wording", 400, esTextFieldRejection, true},
+		{"opensearch 2.17 wording (no `Fielddata is disabled` prefix)", 400, osTextFieldRejection, true},
+		{"a different 400 must propagate", 400, `{"error":{"type":"parse_exception","reason":"bad query"}}`, false},
+		{"the same wording on a non-400 is not this case", 500, esTextFieldRejection, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isTextFieldAggError(tc.status, []byte(tc.body)); got != tc.want {
+				t.Fatalf("isTextFieldAggError = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTopMessagesLatchesTheDoomedAggregation: ECS `message` is text-only by
+// DEFAULT, so the server-side aggregation is not an optimistic edge case — it is
+// the path every single logs_error_summary takes, and every one of those wrote a
+// guaranteed-400 into the cluster's error log before falling back. The rejection
+// is a property of the index mapping, so it is learned once and latched; the
+// second call must go straight to the fallback.
+func TestTopMessagesLatchesTheDoomedAggregation(t *testing.T) {
+	var aggAttempts, plainSearches int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if aggs, ok := body["aggs"].(map[string]any); ok {
+			if _, ok := aggs["top_messages"]; ok {
+				aggAttempts++
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, osTextFieldRejection)
+				return
+			}
+		}
+		plainSearches++
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":1},"hits":[
+		  {"_source":{"@timestamp":"2026-08-02T10:00:03.000Z","message":"connection refused"}}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "logs-*")
+	for i := 1; i <= 3; i++ {
+		msgs, err := c.TopMessages(context.Background(), "*", providers.TimeWindow{}, 10)
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		if len(msgs) != 1 {
+			t.Fatalf("call %d returned %d messages, want 1", i, len(msgs))
+		}
+	}
+	if aggAttempts != 1 {
+		t.Fatalf("the doomed aggregation must be attempted ONCE, not once per call: got %d attempts", aggAttempts)
+	}
+	if plainSearches != 3 {
+		t.Fatalf("every call must still return results via the fallback: got %d fallback searches, want 3", plainSearches)
+	}
+}
+
+// TestTopMessagesLatchIsConcurrencySafe: the investigation loop runs tools in
+// parallel against ONE Client, so the latch has to be race-free (it is an
+// atomic, not a bare bool). Meaningful under `go test -race`.
+func TestTopMessagesLatchIsConcurrencySafe(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if aggs, ok := body["aggs"].(map[string]any); ok {
+			if _, ok := aggs["top_messages"]; ok {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = io.WriteString(w, esTextFieldRejection)
+				return
+			}
+		}
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":1},"hits":[
+		  {"_source":{"@timestamp":"2026-08-02T10:00:03.000Z","message":"connection refused"}}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "logs-*")
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := c.TopMessages(context.Background(), "*", providers.TimeWindow{}, 10); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent TopMessages: %v", err)
+	}
+}
+
+// shardFailureResponse is a HTTP 200 that is only PARTIALLY complete: over a
+// rolling `logs-*` pattern whose index template gained `message.keyword`
+// partway through, the terms aggregation succeeds on the newer indices and is
+// rejected on the older ones. Elasticsearch does NOT fail the search — it
+// returns 200, `_shards.failed > 0`, and whatever the surviving shards produced.
+const shardFailureResponse = `{
+  "took": 7, "timed_out": false,
+  "_shards": {
+    "total": 4, "successful": 2, "skipped": 0, "failed": 2,
+    "failures": [
+      {"shard": 0, "index": "logs-2026.06.01", "node": "n1",
+       "reason": {"type": "illegal_argument_exception",
+                  "reason": "Fielddata is disabled on [message] in [logs-2026.06.01]. Text fields are not optimised for operations that require per-document field data. Alternatively, set fielddata=true on [message]."}}
+    ]
+  },
+  "hits": {"total": {"value": 400, "relation": "eq"}, "hits": []},
+  "aggregations": {
+    "top_messages": {
+      "buckets": [
+        {"key": "only the NEW indices saw this", "doc_count": 9,
+         "first_seen": {"value": 1785664800000, "value_as_string": "2026-08-02T10:00:00.000Z"},
+         "last_seen":  {"value": 1785665100000, "value_as_string": "2026-08-02T10:05:00.000Z"}}
+      ]
+    }
+  }
+}`
+
+// TestTopMessagesPartialAggregationFallsBack: a partially-failing aggregation
+// parses perfectly and would be reported to the model as the definitive top
+// messages while covering only part of the window. It must not pass silently —
+// the client-side fallback (a plain _search over a text field, which is not what
+// the shards choked on) gets a complete answer instead.
+func TestTopMessagesPartialAggregationFallsBack(t *testing.T) {
+	var aggAttempts, plainSearches int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if aggs, ok := body["aggs"].(map[string]any); ok {
+			if _, ok := aggs["top_messages"]; ok {
+				aggAttempts++
+				// HTTP 200 — the whole point of this finding.
+				_, _ = io.WriteString(w, shardFailureResponse)
+				return
+			}
+		}
+		plainSearches++
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":2},"hits":[
+		  {"_source":{"@timestamp":"2026-08-02T10:00:03.000Z","message":"connection refused to 10.0.0.7"}},
+		  {"_source":{"@timestamp":"2026-08-02T10:00:02.000Z","message":"connection refused to 10.0.0.9"}}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	msgs, err := New(srv.URL, "logs-*").TopMessages(context.Background(), "*", providers.TimeWindow{}, 10)
+	if err != nil {
+		t.Fatalf("TopMessages: %v", err)
+	}
+	if aggAttempts != 1 || plainSearches != 1 {
+		t.Fatalf("want one aggregation attempt then one fallback search, got agg=%d plain=%d", aggAttempts, plainSearches)
+	}
+	if len(msgs) != 1 || msgs[0].Count != 2 {
+		t.Fatalf("expected the COMPLETE client-side answer, got %+v", msgs)
+	}
+	if strings.Contains(msgs[0].Message, "only the NEW indices") {
+		t.Fatalf("silently-partial aggregation buckets were reported as complete: %+v", msgs)
+	}
+}
+
+// TestTopMessagesPartialFailureIsNotLatched: unlike the mapping rejection, a
+// shard failure can be transient (a node briefly out). Permanently downgrading a
+// working corpus-wide aggregation over one blip would be the wrong trade, so the
+// next call must try server-side again.
+func TestTopMessagesPartialFailureIsNotLatched(t *testing.T) {
+	var aggAttempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if aggs, ok := body["aggs"].(map[string]any); ok {
+			if _, ok := aggs["top_messages"]; ok {
+				aggAttempts++
+				if aggAttempts == 1 {
+					_, _ = io.WriteString(w, shardFailureResponse)
+					return
+				}
+				_, _ = io.WriteString(w, `{
+				  "_shards": {"total": 4, "successful": 4, "failed": 0},
+				  "aggregations": {"top_messages": {"buckets": [
+				    {"key": "recovered", "doc_count": 42,
+				     "first_seen": {"value": 1785664800000, "value_as_string": "2026-08-02T10:00:00.000Z"},
+				     "last_seen":  {"value": 1785665100000, "value_as_string": "2026-08-02T10:05:00.000Z"}}
+				  ]}}
+				}`)
+				return
+			}
+		}
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":1},"hits":[
+		  {"_source":{"@timestamp":"2026-08-02T10:00:03.000Z","message":"fallback line"}}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "logs-*")
+	if _, err := c.TopMessages(context.Background(), "*", providers.TimeWindow{}, 10); err != nil {
+		t.Fatalf("first TopMessages: %v", err)
+	}
+	msgs, err := c.TopMessages(context.Background(), "*", providers.TimeWindow{}, 10)
+	if err != nil {
+		t.Fatalf("second TopMessages: %v", err)
+	}
+	if aggAttempts != 2 {
+		t.Fatalf("a transient shard failure must not latch: got %d aggregation attempts, want 2", aggAttempts)
+	}
+	if len(msgs) != 1 || msgs[0].Message != "recovered" {
+		t.Fatalf("the recovered server-side aggregation should be used: %+v", msgs)
+	}
+}
+
+// TestHitsPartialAggregationErrors: []providers.Bucket has no channel for an
+// in-band notice, and a silently-short histogram understates the very spike
+// logs_error_summary exists to find — so a partial result fails loudly. The
+// caller (internal/investigate/logs_summary_tool.go) degrades gracefully.
+func TestHitsPartialAggregationErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{
+		  "_shards": {"total": 4, "successful": 2, "skipped": 0, "failed": 2},
+		  "aggregations": {"by_time": {"buckets": [
+		    {"key": 1785664800000, "doc_count": 5, "by_level": {"buckets": [{"key": "error", "doc_count": 3}]}}
+		  ]}}
+		}`)
+	}))
+	defer srv.Close()
+	_, err := New(srv.URL, "logs-*").Hits(context.Background(), "*", providers.TimeWindow{}, time.Minute)
+	if err == nil {
+		t.Fatal("a 200 with failed shards must not be reported as a complete histogram")
+	}
+	if !strings.Contains(err.Error(), "2 of 4 shards failed") {
+		t.Fatalf("error must name the partiality, got %v", err)
+	}
+}
+
+// TestQueryPartialResultsAreFlagged: Query keeps the hits (they are real
+// evidence) but appends a Time-less/Fields-less sentinel, the same mechanism the
+// truncation cap uses, so the model is told the view is incomplete.
+func TestQueryPartialResultsAreFlagged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{
+		  "_shards": {"total": 4, "successful": 3, "skipped": 0, "failed": 1,
+		    "failures": [{"shard": 0, "index": "logs-2026.06.01",
+		      "reason": {"type": "query_shard_exception", "reason": "no mapping found"}}]},
+		  "hits": {"total": {"value": 1}, "hits": [
+		    {"_source": {"@timestamp": "2026-08-02T10:00:01.000Z", "message": "connection refused"}}
+		  ]}
+		}`)
+	}))
+	defer srv.Close()
+	res, err := New(srv.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("want the hit plus a partiality sentinel, got %d: %+v", len(res), res)
+	}
+	last := res[len(res)-1]
+	if !strings.Contains(last.Message, "partial results") || !strings.Contains(last.Message, "1 of 4 shards failed") {
+		t.Fatalf("partiality sentinel missing or unhelpful: %q", last.Message)
+	}
+	if !last.Time.IsZero() || len(last.Fields) != 0 {
+		t.Fatalf("the sentinel must not look like a real log entry: %+v", last)
+	}
+}
+
+// TestQueryEpochMillisTimestamp: a `date` field may be MAPPED as epoch_millis,
+// in which case `_source` carries a JSON NUMBER. Before this was handled,
+// encoding/json's float64 plus fmt.Sprint produced "1.7856648e+12", time.Parse
+// failed, and EVERY LogLine.Time came back zero — no error anywhere, but the
+// timeline render and the fallback's first→last spans all silently collapsed.
+func TestQueryEpochMillisTimestamp(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"hits":{"total":{"value":1},"hits":[
+		  {"_source":{"@timestamp":1785664801000,"message":"connection refused","event":{"duration":123456789}}}
+		]}}`)
+	}))
+	defer srv.Close()
+	res, err := New(srv.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("want 1 line, got %d", len(res))
+	}
+	if got := res[0].Time.UTC().Format(time.RFC3339); got != "2026-08-02T10:00:01Z" {
+		t.Fatalf("epoch-millis timestamp not parsed: Time=%v (%q)", res[0].Time, got)
+	}
+	// Large JSON numbers must not reach the model in scientific notation.
+	if got := res[0].Fields["event.duration"]; got != "123456789" {
+		t.Fatalf("numeric field rendered as %q, want %q", got, "123456789")
+	}
+	if got := res[0].Fields["@timestamp"]; got != "1785664801000" {
+		t.Fatalf("epoch-millis field rendered as %q", got)
+	}
+}
+
+// TestFlattenJSONNumbers pins the number rendering directly, including the
+// fractional case that must NOT be turned into an integer.
+func TestFlattenJSONNumbers(t *testing.T) {
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(`{
+	  "event": {"duration": 123456789, "ratio": 0.5},
+	  "http": {"response": {"status_code": 503, "bytes": 1785664801000}},
+	  "ok": true, "nothing": null
+	}`), &doc); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	flat := map[string]string{}
+	flattenJSON("", doc, flat)
+	for k, want := range map[string]string{
+		"event.duration":            "123456789",
+		"event.ratio":               "0.5",
+		"http.response.status_code": "503",
+		"http.response.bytes":       "1785664801000",
+		"ok":                        "true",
+	} {
+		if got := flat[k]; got != want {
+			t.Errorf("flat[%q] = %q, want %q", k, got, want)
+		}
+	}
+	if _, ok := flat["nothing"]; ok {
+		t.Errorf("explicit JSON null must be skipped, got %q", flat["nothing"])
+	}
+}
+
+// TestIndexPathIsEscaped: the index pattern is operator-controlled config
+// pasted into a URL path. Unescaped, `a/b` added a path SEGMENT (targeting a
+// different endpoint entirely) and `logs-*?pretty` moved everything after the
+// `?` into the query string. `*` and `,` must survive unescaped — they are
+// legal path-segment sub-delims and load-bearing to Elasticsearch (index
+// wildcard, multi-index list).
+func TestIndexPathIsEscaped(t *testing.T) {
+	for _, tc := range []struct {
+		index    string
+		wantPath string
+		wantRaw  string
+	}{
+		{"logs-*", "/logs-*/_search", ""},
+		{"logs-app-*,logs-infra-*", "/logs-app-*,logs-infra-*/_search", ""},
+		{"a/b", "/a%2Fb/_search", ""},
+		{"logs-*?pretty", "/logs-*%3Fpretty/_search", ""},
+	} {
+		t.Run(tc.index, func(t *testing.T) {
+			// Assert on the RAW request line, not r.URL.Path: net/http's server
+			// percent-decodes Path before a handler sees it, which would hide the
+			// very escaping under test (a%2Fb reads back as a/b there).
+			var gotURI, gotRawQuery string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotURI = r.RequestURI
+				gotRawQuery = r.URL.RawQuery
+				_, _ = io.WriteString(w, `{"hits":{"total":{"value":0},"hits":[]}}`)
+			}))
+			defer srv.Close()
+			if _, err := New(srv.URL, tc.index).Query(context.Background(), "*", providers.TimeWindow{}); err != nil {
+				t.Fatalf("Query: %v", err)
+			}
+			if gotURI != tc.wantPath {
+				t.Fatalf("request URI = %q, want %q", gotURI, tc.wantPath)
+			}
+			if gotRawQuery != tc.wantRaw {
+				t.Fatalf("index leaked into the query string: RawQuery=%q", gotRawQuery)
+			}
+			// Exactly one index segment before /_search — nothing the operator
+			// wrote can add another.
+			if strings.Count(strings.Trim(gotURI, "/"), "/") != 1 {
+				t.Fatalf("request URI has extra path segments: %q", gotURI)
+			}
+		})
 	}
 }

--- a/internal/logs/elasticsearch/live_verify_test.go
+++ b/internal/logs/elasticsearch/live_verify_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build liveverify
+
+// Live verification against REAL Elasticsearch and OpenSearch backends.
+//
+// Everything else in this package tests against mocked responses, and a mock is only
+// as correct as its author's understanding of the wire format — which is exactly the
+// assumption this file exists to close. Build-tagged so it never runs in CI.
+//
+//	ES_URL=http://localhost:9200 OS_URL=http://localhost:9201 \
+//	  go test -tags liveverify ./internal/logs/elasticsearch/ -run TestLive -v
+package elasticsearch
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+func TestLiveBothDistributions(t *testing.T) {
+	for _, tc := range []struct{ name, env string }{
+		{"elasticsearch", "ES_URL"},
+		{"opensearch", "OS_URL"},
+	} {
+		base := os.Getenv(tc.env)
+		if base == "" {
+			t.Fatalf("%s is unset — this test is meaningless without a real backend", tc.env)
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			c := New(base, "logs-*")
+			ctx := context.Background()
+			// The seeded documents are stamped around now; a wide window keeps this
+			// from being a clock-skew test.
+			w := providers.TimeWindow{
+				Start: time.Now().Add(-24 * time.Hour),
+				End:   time.Now().Add(1 * time.Hour),
+			}
+			const q = `kubernetes.namespace:"payments" AND log.level:"error"`
+
+			// query_logs
+			lines, err := c.Query(ctx, q, w)
+			if err != nil {
+				t.Fatalf("Query: %v", err)
+			}
+			if len(lines) == 0 {
+				t.Fatal("Query returned no lines against a seeded index")
+			}
+			first := lines[0]
+			t.Logf("query_logs: %d lines; newest = %s | %s",
+				len(lines), first.Time.Format(time.RFC3339), first.Message)
+			t.Logf("           fields = %v", first.Fields)
+			if first.Time.Before(lines[len(lines)-1].Time) {
+				t.Error("results are not newest-first")
+			}
+			if first.Time.IsZero() {
+				t.Error("timestamp did not parse — every LogLine.Time would be zero")
+			}
+			// The ECS field mapping is the whole point of the defaults; if namespace
+			// and pod do not survive into Fields, the model gets untethered log lines.
+			if first.Fields["kubernetes.namespace"] == "" || first.Fields["kubernetes.pod.name"] == "" {
+				t.Errorf("ECS mapping lost namespace/pod: %v", first.Fields)
+			}
+
+			// logs_error_summary — histogram
+			buckets, err := c.Hits(ctx, q, w, time.Minute)
+			if err != nil {
+				t.Fatalf("Hits: %v", err)
+			}
+			var total int64
+			for _, b := range buckets {
+				total += b.Count
+			}
+			t.Logf("logs_error_summary histogram: %d buckets, %d hits", len(buckets), total)
+			if total == 0 {
+				t.Error("histogram counted nothing against a seeded index")
+			}
+
+			// logs_error_summary — top messages. ECS maps `message` as text-only, so
+			// the server-side terms aggregation MUST be rejected and the client-side
+			// fallback must carry it. isTextFieldAggError is the fallback's ONLY
+			// trigger, and the rejection wording is NOT identical across the two
+			// distributions — this assertion is the reason this file exists.
+			msgs, err := c.TopMessages(ctx, q, w, 5)
+			if err != nil {
+				t.Fatalf("TopMessages: %v — the text-field fallback did not trigger", err)
+			}
+			if len(msgs) == 0 {
+				t.Fatal("TopMessages returned nothing — the fallback did not carry")
+			}
+			t.Logf("logs_error_summary top messages (via client-side fallback): %d distinct", len(msgs))
+			for _, m := range msgs {
+				t.Logf("    %4d  %s", m.Count, m.Message)
+			}
+
+			// discover_log_fields
+			fields, err := c.FieldNames(ctx, "", w)
+			if err != nil {
+				t.Fatalf("FieldNames: %v", err)
+			}
+			if len(fields) == 0 {
+				t.Fatal("FieldNames returned nothing")
+			}
+			var sawTimestamp, sawNamespace bool
+			for _, f := range fields {
+				switch f.Name {
+				case "@timestamp":
+					sawTimestamp = true
+				case "kubernetes.namespace":
+					sawNamespace = true
+				}
+			}
+			t.Logf("discover_log_fields: %d fields", len(fields))
+			if !sawTimestamp || !sawNamespace {
+				t.Errorf("expected @timestamp and kubernetes.namespace among the %d fields", len(fields))
+			}
+		})
+	}
+}

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -70,13 +70,30 @@ var rules = []rule{
 	{regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`), mask},
 	// Credentials in a URL: scheme://user:PASSWORD@host → mask the password.
 	{regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:@/]+:)[^\s@/]+(@)`), `${1}[REDACTED]${2}`},
-	// HTTP auth header tokens — keep the scheme, mask the credential. ApiKey is
-	// Elasticsearch/OpenSearch's own auth scheme (Authorization: ApiKey <base64
-	// id:key>) — the documented workaround for an ES API key, which (unlike a
-	// bearer token) has no recognizable prefix of its own to match on.
+	// HTTP auth header tokens — keep the scheme, mask the credential.
 	{regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{12,}`), `${1}[REDACTED]`},
 	{regexp.MustCompile(`(?i)(basic\s+)[A-Za-z0-9+/=]{8,}`), `${1}[REDACTED]`},
-	{regexp.MustCompile(`(?i)(apikey\s+)[A-Za-z0-9+/=]{8,}`), `${1}[REDACTED]`},
+	// ApiKey is Elasticsearch/OpenSearch's own auth scheme (Authorization: ApiKey
+	// <base64 id:key>) — the documented workaround for an ES API key, which
+	// (unlike a bearer token) has no recognizable prefix of its own to match on.
+	//
+	// Two rules, deliberately, because "apikey" is also an ordinary English-ish
+	// word that shows up in prose all over log lines, runbooks and findings. A
+	// single `(?i)(apikey\s+)[A-Za-z0-9+/=]{8,}` rule masked ANY 8+ character
+	// word following it — "apikey rotation policy" became "apikey [REDACTED]
+	// policy" and "see the ApiKey documentation page" became "ApiKey [REDACTED]
+	// page". Planting spurious [REDACTED] markers in a finding is not a safe
+	// failure: it makes the investigation output look like it leaked a secret and
+	// destroys otherwise-correct text.
+	//
+	//  1. With the Authorization-header context, ANY credential shape is masked —
+	//     "Authorization: ApiKey <x>" is never prose.
+	//  2. Bare "ApiKey <x>" (a header dump with the key stripped, a curl snippet)
+	//     only when the token is unmistakably a base64 credential: 20+ characters
+	//     from the base64 alphabet. A real ES API key is ~50-60; the longest words
+	//     that trip rule 1's old form ("documentation", 13) fall well short.
+	{regexp.MustCompile(`(?i)(authorization"?\s*[:=]?\s*"?apikey\s+)[A-Za-z0-9._~+/=-]{8,}`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(\bapikey\s+)[A-Za-z0-9+/]{20,}={0,2}`), `${1}[REDACTED]`},
 	// Sensitive key = value / key: value (the value is masked, the key kept). An
 	// env-var-style prefix (DB_SECRET, OPENAI_API_KEY) is allowed before the keyword.
 	{regexp.MustCompile(`(?i)([\w.\-]*(?:password|passwd|secret|api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|token|credentials?|dsn|connection[_-]?string)"?\s*[:=]\s*"?)([^\s"',}]+)`), `${1}[REDACTED]`},

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -70,9 +70,13 @@ var rules = []rule{
 	{regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`), mask},
 	// Credentials in a URL: scheme://user:PASSWORD@host → mask the password.
 	{regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:@/]+:)[^\s@/]+(@)`), `${1}[REDACTED]${2}`},
-	// HTTP auth header tokens — keep the scheme, mask the credential.
+	// HTTP auth header tokens — keep the scheme, mask the credential. ApiKey is
+	// Elasticsearch/OpenSearch's own auth scheme (Authorization: ApiKey <base64
+	// id:key>) — the documented workaround for an ES API key, which (unlike a
+	// bearer token) has no recognizable prefix of its own to match on.
 	{regexp.MustCompile(`(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{12,}`), `${1}[REDACTED]`},
 	{regexp.MustCompile(`(?i)(basic\s+)[A-Za-z0-9+/=]{8,}`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)(apikey\s+)[A-Za-z0-9+/=]{8,}`), `${1}[REDACTED]`},
 	// Sensitive key = value / key: value (the value is masked, the key kept). An
 	// env-var-style prefix (DB_SECRET, OPENAI_API_KEY) is allowed before the keyword.
 	{regexp.MustCompile(`(?i)([\w.\-]*(?:password|passwd|secret|api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|token|credentials?|dsn|connection[_-]?string)"?\s*[:=]\s*"?)([^\s"',}]+)`), `${1}[REDACTED]`},

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -41,6 +41,7 @@ func TestSecretsMasks(t *testing.T) {
 		{"secret env", "DB_SECRET=s3cr3t-value-xyz", "s3cr3t-value-xyz", ""},
 		{"url creds", "postgres://app:sup3rs3cret@db.svc:5432/x", "sup3rs3cret", "postgres://app:"},
 		{"bearer", "Authorization: Bearer abcDEF123456ghiJKL789", "abcDEF123456ghiJKL789", "Bearer"},
+		{"elasticsearch apikey auth header", "Authorization: ApiKey VnVhQ2ZHY0JDZGJrUW0=", "VnVhQ2ZHY0JDZGJrUW0=", "ApiKey"},
 		{"private key", "k:\n-----BEGIN RSA PRIVATE KEY-----\nMIIBwetcetc\n-----END RSA PRIVATE KEY-----\n", "MIIBwetcetc", ""},
 	}
 	for _, tc := range cases {

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -143,6 +143,12 @@ func TestSecretsKeepsBenign(t *testing.T) {
 		"this is task-management, disk-usage and ask-me-anything",
 		// "ya29." substring inside a larger word must not match.
 		"the library libya29things is fine",
+		// "apikey" is an ordinary word in prose. A rule matching any 8+ char word
+		// after it planted [REDACTED] into findings that had leaked nothing —
+		// "apikey rotation policy" -> "apikey [REDACTED] policy".
+		"apikey rotation policy is documented in the runbook",
+		"see the ApiKey documentation page for the header format",
+		"the apikey settings were unchanged",
 	}
 	for _, s := range benign {
 		if got := Secrets(s); got != s {
@@ -168,5 +174,48 @@ func TestAWSSecretRequiresCue(t *testing.T) {
 	noCue := "blob value " + val + " end"
 	if got := Secrets(noCue); got != noCue {
 		t.Fatalf("40-char value without AWS cue must survive, got %q", got)
+	}
+}
+
+// TestApiKeyRedactionRequiresCredentialShape pins BOTH halves of the ApiKey
+// rule split: the Authorization-header form masks any credential shape, the
+// bare form only fires on something that is unmistakably a base64 credential,
+// and prose is left completely alone. The original single rule
+// (`(?i)(apikey\s+)[A-Za-z0-9+/=]{8,}`) redacted the prose cases too, which is
+// not a safe failure — it makes a clean finding read as if it leaked a secret.
+func TestApiKeyRedactionRequiresCredentialShape(t *testing.T) {
+	redacted := []struct{ name, in, gone string }{
+		{"authorization header, short credential",
+			"Authorization: ApiKey VnVhQ2ZHY0JDZGJrUW0=", "VnVhQ2ZHY0JDZGJrUW0="},
+		{"authorization header, lowercase scheme",
+			"authorization: apikey VnVhQ2ZHY0JDZGJrUW0=", "VnVhQ2ZHY0JDZGJrUW0="},
+		{"quoted YAML header value",
+			`headers: {Authorization: "ApiKey VnVhQ2ZHY0JDZGJrUW0="}`, "VnVhQ2ZHY0JDZGJrUW0="},
+		{"bare ApiKey with a real ES-sized base64 credential",
+			"curl -H 'ApiKey ZFpUZW04SUJKSTZ4cVAwWVBXcXo6ekJTSHhCUlJTWkc0T29UMGJn'",
+			"ZFpUZW04SUJKSTZ4cVAwWVBXcXo6ekJTSHhCUlJTWkc0T29UMGJn"},
+	}
+	for _, tc := range redacted {
+		t.Run(tc.name, func(t *testing.T) {
+			out := Secrets(tc.in)
+			if strings.Contains(out, tc.gone) {
+				t.Fatalf("credential survived redaction: %q -> %q", tc.in, out)
+			}
+			if !strings.Contains(out, "[REDACTED") {
+				t.Fatalf("expected a redaction marker, got %q", out)
+			}
+		})
+	}
+
+	// Prose: the two strings the reviewer reproduced, plus neighbours.
+	for _, s := range []string{
+		"apikey rotation policy",
+		"see the ApiKey documentation page",
+		"APIKEY provisioning happens at bootstrap",
+		"apikey lifecycle",
+	} {
+		if got := Secrets(s); got != s {
+			t.Errorf("prose was over-redacted:\n  in:  %q\n  out: %q", s, got)
+		}
 	}
 }

--- a/website/content/docs/concepts/data-sources.md
+++ b/website/content/docs/concepts/data-sources.md
@@ -13,7 +13,7 @@ assumed).
 |---|---|---|---|---|
 | GitOps "what changed" | `what_changed`, `gitops_*` | `GitOpsProvider` | Flux, ArgoCD | `gitops.engine` |
 | Metrics | `query_metrics`, `query_metrics_range` | `MetricsProvider` | VictoriaMetrics, Prometheus (PromQL) | `metrics.url` |
-| Logs | `query_logs`, `logs_error_summary`, `discover_log_fields` | `LogsProvider` | VictoriaLogs (LogsQL) · Grafana Loki (LogQL) | `logs.url` (+ optional `logs.provider`) |
+| Logs | `query_logs`, `logs_error_summary`, `discover_log_fields` | `LogsProvider` | VictoriaLogs (LogsQL) · Grafana Loki (LogQL) · Elasticsearch/OpenSearch (`_search` DSL) | `logs.url` (+ optional `logs.provider`) |
 | Network flows | `network_drops` | `NetworkProvider` | Cilium Hubble · AWS VPC Flow Logs · GCP Firewall Logs | `network.provider` |
 | Cloud control plane | `cloud_*` | `CloudProvider` | AWS (CloudTrail + EC2/ASG/EKS) | `cloud.provider` |
 | Kubernetes | `pod_status`, `kube_events`, `controller_logs`, `pod_logs` | `KubeReader`/`LogReader` | client-go | (in-cluster) |
@@ -86,14 +86,17 @@ CNI-agnostic eBPF (Microsoft **Retina** exposes a Hubble-compatible flow API, so
 
 ## Logs backends
 
-The logs signal is pluggable behind `LogsProvider`: **VictoriaLogs** (LogsQL) and **Grafana
-Loki** (LogQL). All three log tools — `query_logs`, `logs_error_summary`,
-`discover_log_fields` — work on both; the model is told the right query language automatically.
+The logs signal is pluggable behind `LogsProvider`: **VictoriaLogs** (LogsQL), **Grafana
+Loki** (LogQL), and **Elasticsearch/OpenSearch** (the classic `_search` DSL, identical on both
+distributions). All three log tools — `query_logs`, `logs_error_summary`,
+`discover_log_fields` — work on all of them; the model is told the right query language
+automatically.
 
 The provider is **auto-detected** at startup (Loki answers `/loki/api/v1/status/buildinfo`;
-VictoriaLogs does not) and **fails safe to VictoriaLogs**, so existing configs are untouched.
-Pin it with `provider:` when the backend is unreachable at startup or sits behind a proxy that
-confuses the probe.
+Elasticsearch/OpenSearch answer `GET /` with a version document, `distribution: opensearch`
+identifying OpenSearch specifically; VictoriaLogs answers neither) and **fails safe to
+VictoriaLogs**, so existing configs are untouched. Pin it with `provider:` when the backend is
+unreachable at startup or sits behind a proxy that confuses the probe.
 
 ### `victorialogs` — VictoriaLogs (default)
 
@@ -116,15 +119,29 @@ logs:
 
 **Wire it:** [Grafana Loki]({{< relref "/docs/integrations/loki.md" >}})
 
+### `elasticsearch` / `opensearch` — Elasticsearch and OpenSearch
+```yaml
+logs:
+  url: https://elasticsearch.observability.svc:9200
+  provider: elasticsearch      # or opensearch — optional, auto-detected when omitted
+  index: logs-*                # index pattern
+  # token_env: ES_TOKEN                 # bearer / API key, by env-var indirection
+```
+Both distributions speak the identical classic `_search` DSL, so one client serves both.
+
+**Wire it:** [Elasticsearch]({{< relref "/docs/integrations/elasticsearch.md" >}}) · [OpenSearch]({{< relref "/docs/integrations/opensearch.md" >}})
+
 Field-convention defaults differ per provider; override any of them via `logs.fields`:
 
-| `logs.fields` key | VictoriaLogs default | Loki default |
-|---|---|---|
-| `container_field` | `kubernetes.container_name` | `container` |
-| `namespace_field` | `kubernetes.pod_namespace` | `namespace` |
-| `pod_field` | `kubernetes.pod_name` | `pod` |
-| `level_field` | `log.level` | `detected_level` |
-| `unpack_pipe` | `unpack_json` | *(none — `detected_level` is structured metadata)* |
+| `logs.fields` key | VictoriaLogs default | Loki default | Elasticsearch/OpenSearch default (ECS) |
+|---|---|---|---|
+| `container_field` | `kubernetes.container_name` | `container` | `kubernetes.container.name` |
+| `namespace_field` | `kubernetes.pod_namespace` | `namespace` | `kubernetes.namespace` |
+| `pod_field` | `kubernetes.pod_name` | `pod` | `kubernetes.pod.name` |
+| `level_field` | `log.level` | `detected_level` | `log.level` |
+| `unpack_pipe` | `unpack_json` | *(none — `detected_level` is structured metadata)* | *(not applicable)* |
+| `timestamp_field` | *(not applicable)* | *(not applicable)* | `@timestamp` |
+| `message_field` | *(not applicable)* | *(not applicable)* | `message` |
 
 > Loki parity notes: `logs_error_summary`'s histogram uses a LogQL metric query
 > (`sum by (detected_level) (count_over_time(…))`); its *top messages* are aggregated
@@ -134,6 +151,13 @@ Field-convention defaults differ per provider; override any of them via `logs.fi
 > labels only). On Loki 2.x there is no `detected_level` — set
 > `logs: { fields: { level_field: level, unpack_pipe: logfmt } }` (or `json`) to match your
 > collector.
+
+> Elasticsearch/OpenSearch parity notes: `logs_error_summary`'s top messages fall back to
+> **client-side aggregation** when `message_field` is a `text`-only field — the ECS default, since
+> `message` ships with no `keyword` sub-field. `discover_log_fields` uses `_field_caps`, a mapping
+> introspection endpoint with no query/window scope and no per-field hit count — broader but less
+> precise than VictoriaLogs'/Loki's query-scoped discovery. See the integration pages linked above
+> for the full detail.
 
 ## Custom webhooks — any vendor, no code
 

--- a/website/content/docs/integrations/elasticsearch.md
+++ b/website/content/docs/integrations/elasticsearch.md
@@ -74,7 +74,17 @@ kubectl -n runlore logs deploy/runlore | grep -E 'tool=query_logs|tool=logs_erro
   first→last spans are then **per-sample, not corpus-wide**, the same caveat Loki's client-side
   fallback carries. If your index template adds an aggregatable multi-field (commonly
   `message.keyword`), point `logs.fields.message_field` at it to get the corpus-wide, server-side
-  path instead.
+  path instead. RunLore learns the rejection once per process and goes straight to the fallback
+  afterwards, so the default configuration does not repeat a request the cluster will always refuse.
+  (OpenSearch's wording for the same rejection differs slightly — RunLore matches the part both
+  distributions emit, verified against real clusters of each.)
+- **Partial results are flagged, never silently reported as complete.** Elasticsearch answers a
+  search some shards could not serve with HTTP 200 and `_shards.failed > 0` — typically when a
+  rolling `logs-*` pattern spans a mapping change, so a `terms` aggregation succeeds on the newer
+  indices and is rejected on the older ones. `query_logs` appends an explicit "partial results"
+  line, `logs_error_summary`'s top messages switch to the client-side path (which is unaffected),
+  and its histogram reports the partiality as an error rather than showing a chart that understates
+  the spike.
 - **`discover_log_fields` lists the INDEX'S MAPPED fields, not fields present only in matching
   documents.** It uses `_field_caps`, a mapping-introspection endpoint with no query/window scope —
   broader than VictoriaLogs'/Loki's discovery (which is scoped to what a query actually matched), and

--- a/website/content/docs/integrations/elasticsearch.md
+++ b/website/content/docs/integrations/elasticsearch.md
@@ -1,0 +1,95 @@
+---
+title: Elasticsearch
+weight: 40
+integration: {kind: logs, id: elasticsearch}
+---
+
+**What it gives you** — the same `query_logs`, `logs_error_summary` and `discover_log_fields` tools,
+speaking Lucene `query_string` over the classic `_search` DSL instead of LogsQL/LogQL, auto-detected
+at startup. See [OpenSearch]({{< relref "opensearch.md" >}}) for the same client against an
+OpenSearch cluster — the two speak an identical `_search`/`_field_caps` wire format.
+
+## Minimal config
+
+```yaml
+logs:
+  url: https://elasticsearch.observability.svc:9200
+  provider: elasticsearch      # optional — auto-detected when omitted
+  index: logs-*                # index pattern
+```
+
+Authenticated:
+
+```yaml
+logs:
+  url: https://elasticsearch.observability.svc:9200
+  provider: elasticsearch
+  index: logs-*
+  token_env: ES_TOKEN                     # bearer token, by env-var indirection
+  # headers: { Authorization: "ApiKey <base64 id:key>" }  # ES API key instead of a bearer token
+```
+
+A `headers.Authorization` entry is applied AFTER `token_env`, so it wins — use it for an
+Elasticsearch [API key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html)
+(`Authorization: ApiKey <base64>`) rather than a bearer token.
+
+## Verify it locally
+
+```bash
+curl -sk -X POST "https://elasticsearch.observability.svc:9200/logs-*/_search" \
+  -H 'Content-Type: application/json' -d '{"size":1,"query":{"match_all":{}}}'
+```
+
+Then fire a test incident and confirm the logs tools appear among what the model called:
+
+```bash
+kubectl -n runlore logs deploy/runlore | grep -E 'tool=query_logs|tool=logs_error_summary|tool=discover_log_fields'
+```
+
+## Notes
+
+- **Presence enables it** — `logs.url` set is all it takes; `provider: elasticsearch` is optional (the
+  startup probe hits `GET /`, which both Elasticsearch and VictoriaLogs answer, but only
+  Elasticsearch/OpenSearch return a `version.number` in the response body — VictoriaLogs' root page is
+  HTML). Pin it explicitly when the backend is unreachable at startup or sits behind a proxy that
+  confuses the probe — an unreachable/ambiguous probe fails safe to VictoriaLogs, not to Elasticsearch.
+- **TLS verification is always on** — there is no `insecure_skip_verify` escape hatch. Point `logs.url`
+  at a certificate the runtime trusts (a cluster CA bundle, or a properly-issued cert behind an
+  ingress) rather than disabling verification.
+- The ECS (Elastic Common Schema) field convention is assumed by default: `container_field:
+  kubernetes.container.name`, `namespace_field: kubernetes.namespace`, `pod_field:
+  kubernetes.pod.name`, `level_field: log.level`, `timestamp_field: @timestamp`, `message_field:
+  message`. Override any of them under `logs.fields` if your index template labels differently.
+  `unpack_pipe` is ignored — Elasticsearch has no parser-pipe concept (documents are already
+  structured).
+
+**Parity notes — read before relying on Elasticsearch for these three tools:**
+
+- **`logs_error_summary`'s top messages fall back to client-side aggregation when the message field
+  is `text`-only** — and by default, it is. ECS ships `message` as a plain `text` field with no
+  `keyword` sub-field, so Elasticsearch/OpenSearch reject a `terms` aggregation on it
+  (`illegal_argument_exception: Fielddata is disabled on text fields`). RunLore tries the server-side
+  aggregation first (cheap and corpus-wide when it succeeds) and, on exactly that rejection, falls
+  back to aggregating over the capped, newest-first `query_logs` sample instead — counts and
+  first→last spans are then **per-sample, not corpus-wide**, the same caveat Loki's client-side
+  fallback carries. If your index template adds an aggregatable multi-field (commonly
+  `message.keyword`), point `logs.fields.message_field` at it to get the corpus-wide, server-side
+  path instead.
+- **`discover_log_fields` lists the INDEX'S MAPPED fields, not fields present only in matching
+  documents.** It uses `_field_caps`, a mapping-introspection endpoint with no query/window scope —
+  broader than VictoriaLogs'/Loki's discovery (which is scoped to what a query actually matched), and
+  it reports no per-field hit count (every result shows no `×N` frequency), unlike VictoriaLogs'
+  `field_names`.
+- The error-volume histogram (`date_histogram` + a `terms` sub-aggregation on `level_field`) IS
+  corpus-wide and server-side — `log.level` ships as a `keyword`-typed field under ECS, so it
+  aggregates without the `message` field's restriction.
+
+## Reference
+
+- [Configuration → Other top-level keys]({{< relref "/docs/configuration/configuration.md#other-top-level-keys" >}})
+  for the full `logs` key reference.
+- [Data sources]({{< relref "/docs/concepts/data-sources.md" >}}) — the provider table across every
+  signal.
+- [VictoriaLogs]({{< relref "victorialogs.md" >}}) — the fail-safe default this auto-detect falls
+  back to.
+- [OpenSearch]({{< relref "opensearch.md" >}}) — the same client, same DSL, same parity notes.

--- a/website/content/docs/integrations/opensearch.md
+++ b/website/content/docs/integrations/opensearch.md
@@ -1,0 +1,84 @@
+---
+title: OpenSearch
+weight: 50
+integration: {kind: logs, id: opensearch}
+---
+
+**What it gives you** — the same `query_logs`, `logs_error_summary` and `discover_log_fields` tools as
+[Elasticsearch]({{< relref "elasticsearch.md" >}}), speaking the identical Lucene `query_string` over
+the classic `_search` DSL: OpenSearch forked from Elasticsearch 7.10 and kept the same wire format, so
+RunLore ships ONE client for both — this page only covers what differs (auth conventions and
+detection), not a second implementation.
+
+## Minimal config
+
+```yaml
+logs:
+  url: https://opensearch.observability.svc:9200
+  provider: opensearch      # optional — auto-detected when omitted
+  index: logs-*             # index pattern
+```
+
+Authenticated:
+
+```yaml
+logs:
+  url: https://opensearch.observability.svc:9200
+  provider: opensearch
+  index: logs-*
+  token_env: OPENSEARCH_TOKEN   # bearer token, by env-var indirection
+```
+
+## Verify it locally
+
+```bash
+curl -sk -X POST "https://opensearch.observability.svc:9200/logs-*/_search" \
+  -H 'Content-Type: application/json' -d '{"size":1,"query":{"match_all":{}}}'
+```
+
+Then fire a test incident and confirm the logs tools appear among what the model called:
+
+```bash
+kubectl -n runlore logs deploy/runlore | grep -E 'tool=query_logs|tool=logs_error_summary|tool=discover_log_fields'
+```
+
+## Notes
+
+- **Presence enables it** — `logs.url` set is all it takes; `provider: opensearch` is optional. The
+  startup probe hits `GET /`: OpenSearch's response carries `version.distribution: opensearch`, the
+  field OpenSearch itself adds so a client can tell it apart from Elasticsearch at the same endpoint
+  shape — its absence (a plain `version.number`) means Elasticsearch instead. Pin the provider
+  explicitly when the backend is unreachable at startup or sits behind a proxy that confuses the
+  probe — an unreachable/ambiguous probe fails safe to VictoriaLogs, not to OpenSearch.
+- **TLS verification is always on** — there is no `insecure_skip_verify` escape hatch.
+- Same ECS field convention as Elasticsearch: `container_field: kubernetes.container.name`,
+  `namespace_field: kubernetes.namespace`, `pod_field: kubernetes.pod.name`, `level_field:
+  log.level`, `timestamp_field: @timestamp`, `message_field: message`, all overridable under
+  `logs.fields`.
+- OpenSearch's own auth plugins (Basic auth, or its own API-key flow) map onto the same knobs:
+  `token_env` sends a bearer token; for HTTP Basic auth against OpenSearch's security plugin, set
+  `headers: { Authorization: "Basic <base64 user:pass>" }` instead (applied after `token_env`, so it
+  wins).
+
+**Parity notes — identical to Elasticsearch, read before relying on OpenSearch for these three
+tools:**
+
+- **`logs_error_summary`'s top messages fall back to client-side aggregation when the message field
+  is `text`-only** — the default for ECS's `message` field on OpenSearch too (it rejects the same
+  `terms` aggregation with the same `illegal_argument_exception` wording ES does). Point
+  `logs.fields.message_field` at an aggregatable multi-field (e.g. `message.keyword`) to get the
+  corpus-wide, server-side path instead of the per-sample fallback.
+- **`discover_log_fields` lists the INDEX'S MAPPED fields** via `_field_caps` (present on OpenSearch
+  2.x), not fields scoped to a query's matches, and reports no per-field hit count.
+- The error-volume histogram is corpus-wide and server-side (`log.level` is `keyword`-typed under
+  ECS).
+
+## Reference
+
+- [Configuration → Other top-level keys]({{< relref "/docs/configuration/configuration.md#other-top-level-keys" >}})
+  for the full `logs` key reference.
+- [Data sources]({{< relref "/docs/concepts/data-sources.md" >}}) — the provider table across every
+  signal.
+- [VictoriaLogs]({{< relref "victorialogs.md" >}}) — the fail-safe default this auto-detect falls
+  back to.
+- [Elasticsearch]({{< relref "elasticsearch.md" >}}) — the same client, same DSL, full parity detail.

--- a/website/content/docs/integrations/opensearch.md
+++ b/website/content/docs/integrations/opensearch.md
@@ -64,12 +64,19 @@ kubectl -n runlore logs deploy/runlore | grep -E 'tool=query_logs|tool=logs_erro
 tools:**
 
 - **`logs_error_summary`'s top messages fall back to client-side aggregation when the message field
-  is `text`-only** — the default for ECS's `message` field on OpenSearch too (it rejects the same
-  `terms` aggregation with the same `illegal_argument_exception` wording ES does). Point
-  `logs.fields.message_field` at an aggregatable multi-field (e.g. `message.keyword`) to get the
-  corpus-wide, server-side path instead of the per-sample fallback.
+  is `text`-only** — the default for ECS's `message` field on OpenSearch too: it rejects the same
+  `terms` aggregation with the same `illegal_argument_exception`. The rejection *message* is
+  slightly different (OpenSearch omits the `Fielddata is disabled on [field] in [index].` sentence
+  Elasticsearch opens with); RunLore matches on the part both emit, verified against real clusters
+  of each. Point `logs.fields.message_field` at an aggregatable multi-field (e.g. `message.keyword`)
+  to get the corpus-wide, server-side path instead of the per-sample fallback.
 - **`discover_log_fields` lists the INDEX'S MAPPED fields** via `_field_caps` (present on OpenSearch
   2.x), not fields scoped to a query's matches, and reports no per-field hit count.
+- **Partial results are flagged, never silently reported as complete.** OpenSearch answers a search
+  some shards could not serve with HTTP 200 and `_shards.failed > 0` — typically when a rolling
+  `logs-*` pattern spans a mapping change. `query_logs` appends an explicit "partial results" line,
+  `logs_error_summary`'s top messages switch to the client-side path, and its histogram reports the
+  partiality as an error rather than showing a short bar chart.
 - The error-volume histogram is corpus-wide and server-side (`log.level` is `keyword`-typed under
   ECS).
 


### PR DESCRIPTION
## What

A third `LogsProvider` behind the same three log tools, serving **both** Elasticsearch 8.x and OpenSearch 2.x from one client over the classic `_search` DSL — the one dialect both speak. ES|QL would have forked the implementation.

- `query_logs` — `_search` with `query_string` + a `range` filter, newest-first, size-capped
- `logs_error_summary` — `date_histogram` split by level, top messages from a `terms` agg with a client-side fallback
- `discover_log_fields` — `_field_caps`

ECS field defaults (`kubernetes.namespace`, `kubernetes.pod.name`, `kubernetes.container.name`, `log.level`, `@timestamp`), all overridable through the existing `logs.fields` block. No new dependencies — stdlib `net/http`, mirroring `internal/logs/loki`.

## Verified against real backends, not only mocks

Run against **Elasticsearch 8.15.0 and OpenSearch 2.17.0**, seeded by this repo's own `seed.sh`:

| | Elasticsearch | OpenSearch |
|---|---|---|
| `query_logs` | 24 lines, newest-first, ECS namespace/pod intact | identical |
| `logs_error_summary` | 7 buckets / 24 hits; 3 messages via fallback | identical |
| `discover_log_fields` | 24 fields | 22 fields |

The harness is committed as `live_verify_test.go` (build tag `liveverify`, never runs in CI).

### What the live run falsified

The code claimed OpenSearch keeps Elasticsearch's text-field rejection wording verbatim. **It does not:**

| | Reason string |
|---|---|
| ES 8.15 | `Fielddata is disabled on [message] in [logs-demo]. Text fields are not optimised for…` |
| OpenSearch 2.17 | `Text fields are not optimised for…` — no prefix |

`isTextFieldAggError` survives only because it keys on `fielddata` + `text field`, both present in each. Anyone "simplifying" it to match the `Fielddata is disabled` prefix would silently break OpenSearch — so the comment now says which tokens are load-bearing and why. `opensearch.md` carried the same false claim and is corrected.

## Review findings fixed

- **Sticky latch** — ECS `message` is text-only by default, so *every* `logs_error_summary` call was burning a guaranteed-failing round trip (and writing an error to the customer's own ES log). Now once per process. Live runtime dropped 0.80s → 0.33s.
- **Partial results** — a 200 with `_shards.failed > 0` was parsed as if complete. `Query` now appends a partial-results sentinel; `Hits` fails loudly, because a silently-short histogram understates the very spike the tool exists to find.
- **A failed histogram read as `hits: none`** — i.e. "no errors in this window", the opposite of the truth, and a calm reading during an incident. Both degradation branches are now symmetric and pinned by a test whose mutation reproduces that output.
- Query escaping was accidentally correct and unpinned — now a table test with `api" OR *:* OR "` and friends, since a pod name is attacker-influenceable in a multi-tenant cluster.
- ECS field overrides reached the wire but nothing asserted it; deleting the wiring passed the whole suite. Now mutation-tested.
- Epoch-millis timestamps silently zeroed every `LogLine.Time`; numbers rendered as `1.23456789e+08`.
- The `apikey` redaction rule masked prose (`"apikey rotation policy"` → `"apikey [REDACTED] policy"`).

**The fail-safe-to-VictoriaLogs guarantee is intact** — driven against 12 malformed/wrong-shape probe responses, all resolving to `victorialogs`.