### PR TITLE
fix(notify): the card must state its own conclusion, not just the alert

### DIFF
--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -390,15 +390,32 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 		{"type": "header", "text": map[string]any{"type": "plain_text", "text": truncate(head, 150), "emoji": true}},
 	}
 
-	// 2. Verdict owns the second slot — the headline actionability call, ALONE.
-	// The header above already shows the full title (verbatim, or the alert
-	// name + scope) — restating it here duplicated up to its full word count
-	// before any NEW information reached a woken-up phone screen. Absent when
-	// the model omitted a verdict (old / recall investigations); confidence
-	// (2b, below) still renders either way, so the layout stays complete.
+	// 2. Verdict owns the second slot — the headline actionability call, plus the
+	// investigation's own title WHEN THE HEADER DID NOT ALREADY SHOW IT.
+	//
+	// The header shows the title verbatim only when the source named no alert.
+	// On the alert-driven path — Alertmanager, the primary trigger — it shows the
+	// ALERT NAME and scope instead, which is the question, not the answer. Dropping
+	// the title unconditionally therefore removed the agent's one-line conclusion
+	// from exactly the incidents it matters most for: "KubePodCrashLooping —
+	// prod/payments/api" is what woke the on-call; "api crash-looping after the
+	// payments/api chart bump" is what RunLore worked out.
+	//
+	// So it is restated only when it would not be a duplicate. Untrusted model
+	// output, hence escaped, and truncated to stay inside Slack's block limit.
+	// Absent when the model omitted a verdict (old / recall investigations);
+	// confidence (2b, below) renders either way, so the layout stays complete.
 	if vEmoji, label := verdictBadge(inv.Verdict); label != "" {
+		line := fmt.Sprintf("%s *%s*", vEmoji, label)
+		if inv.AlertName != "" && inv.Title != "" {
+			line += " — " + escapeMrkdwn(title)
+		}
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn",
-			"text": fmt.Sprintf("%s *%s*", vEmoji, label)}})
+			"text": truncate(line, 2900)}})
+	} else if inv.AlertName != "" && inv.Title != "" {
+		// No verdict to anchor it to, but the conclusion still has to appear.
+		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn",
+			"text": truncate(escapeMrkdwn(title), 2900)}})
 	}
 
 	// 2b. Confidence — shown exactly ONCE, here in the header area, whether or

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -293,11 +293,22 @@ func TestSlackSummaryLayout(t *testing.T) {
 			t.Fatalf("summary blocks missing %q:\n%s", want, s)
 		}
 	}
-	// Finding #1: the verdict line must carry the verdict ALONE — the header
-	// above already spelled out the title/alert name in full.
+	// Finding #1, as corrected: the verdict line carries the verdict plus the
+	// investigation's own title, because this fixture sets AlertName — so the
+	// header anchored on "HarborDown", the alert, and NOT on the title.
+	//
+	// The original assertion here was "the verdict line must carry the verdict
+	// ALONE — the header above already spelled out the title/alert name in full".
+	// That holds only when no alert named the investigation. With an alert, the
+	// header shows the question that woke the on-call and the title is the answer
+	// RunLore reached; suppressing it left the card never stating its conclusion.
+	// TestSlackCardShowsConclusionOnAlertPath pins both directions.
 	texts := mrkdwnTexts(blocks)
-	if strings.Contains(texts[0], "harbor is degraded") {
-		t.Fatalf("verdict block must not restate the title:\n%s", texts[0])
+	if !strings.Contains(texts[0], "harbor is degraded") {
+		t.Fatalf("verdict block must carry the title when the header anchored on the alert name:\n%s", texts[0])
+	}
+	if strings.Count(s, "harbor is degraded") != 1 {
+		t.Fatalf("the title must render exactly once on the card, got %d:\n%s", strings.Count(s, "harbor is degraded"), s)
 	}
 	// Finding #5: confidence and the agent identity must not repeat between the
 	// header area and the footer.
@@ -1035,4 +1046,68 @@ func TestSlackBotDeliverFeedbackButtons(t *testing.T) {
 			t.Fatalf("detail thread must not repeat the buttons, got: %s", b)
 		}
 	}
+}
+
+// TestSlackCardShowsConclusionOnAlertPath pins the investigation's own title onto
+// the card for alert-triggered incidents.
+//
+// The header anchors on the ALERT NAME whenever the source supplied one, so on the
+// Alertmanager path — the primary trigger — it renders the question that woke the
+// on-call, not the answer RunLore reached. A layout change once dropped the title
+// on the reasoning that "the header already shows it", which is true only for the
+// alert-less path. The result was a card that never stated its own conclusion.
+func TestSlackCardShowsConclusionOnAlertPath(t *testing.T) {
+	const conclusion = "api crash-looping after the payments/api chart bump"
+
+	t.Run("alert named: header shows the alert, so the title must appear too", func(t *testing.T) {
+		inv := providers.Investigation{
+			Title:     conclusion,
+			AlertName: "KubePodCrashLooping",
+			Verdict:   providers.VerdictActionRequired,
+			Resource:  providers.Workload{Kind: "Deployment", Name: "api", Namespace: "payments"},
+		}
+		body := renderSlackBlocks(t, inv)
+		if !strings.Contains(body, conclusion) {
+			t.Errorf("the card never states its own conclusion — %q is absent:\n%s", conclusion, body)
+		}
+		if !strings.Contains(body, "KubePodCrashLooping") {
+			t.Errorf("the alert name should still anchor the header:\n%s", body)
+		}
+	})
+
+	t.Run("no alert: header IS the title, so it must not be repeated", func(t *testing.T) {
+		inv := providers.Investigation{
+			Title:    conclusion,
+			Verdict:  providers.VerdictActionRequired,
+			Resource: providers.Workload{Kind: "Deployment", Name: "api", Namespace: "payments"},
+		}
+		body := renderSlackBlocks(t, inv)
+		if n := strings.Count(body, conclusion); n != 1 {
+			t.Errorf("title should appear exactly once (header only), got %d:\n%s", n, body)
+		}
+	})
+
+	t.Run("no verdict: the conclusion still appears", func(t *testing.T) {
+		inv := providers.Investigation{
+			Title:     conclusion,
+			AlertName: "KubePodCrashLooping",
+			Resource:  providers.Workload{Kind: "Deployment", Name: "api", Namespace: "payments"},
+		}
+		body := renderSlackBlocks(t, inv)
+		if !strings.Contains(body, conclusion) {
+			t.Errorf("a verdict-less investigation still has a conclusion; %q is absent:\n%s", conclusion, body)
+		}
+	})
+}
+
+// renderSlackBlocks marshals just the summary blocks, so a title appearing only in
+// the detail thread or the push-notification fallback cannot satisfy the assertions
+// above — the card itself has to carry it.
+func renderSlackBlocks(t *testing.T, inv providers.Investigation) string {
+	t.Helper()
+	b, err := json.Marshal(summaryBlocks(inv))
+	if err != nil {
+		t.Fatalf("marshal summary blocks: %v", err)
+	}
+	return string(b)
 }


### PR DESCRIPTION
## What

Restores the investigation's own one-line title to the Slack card for **alert-triggered** incidents.

## Why

The header anchors on the alert name whenever the source supplied one. On the Alertmanager path — the primary trigger — it shows the question that woke the on-call, not the answer:

| | before this PR |
|---|---|
| Header | `🔍 KubePodCrashLooping — mycluster-0/payments/api` |
| Verdict | `🔥 Action required` |
| **Title** | *"api crash-looping after the payments/api chart bump"* — **absent** |

#399 reduced the verdict line to the verdict alone, on the reasoning that *"the header above already spelled out the title/alert name in full"*. That holds only for the alert-**less** path. With an alert, `title` was still computed at `slack.go:277` and used only in the `else` branch — so the card never stated its own conclusion on the incidents where the distinction matters most.

## After



Restated **only where it would not duplicate**: the alert-less path still shows the title once, in the header. Untrusted model output, so escaped and truncated as before. A verdict-less investigation (recall / older entries) still gets its conclusion.

**Everything else #399 did is untouched** — confidence promoted under the verdict, metadata demoted below the answer and next steps, `🤖 RunLore SRE agent` noise dropped.

## Tests

`TestSlackSummaryLayout` asserted the regression (`verdict block must not restate the title`), so that assertion is inverted with the reasoning recorded inline, plus a new `strings.Count == 1` check so the fix cannot swing into duplication.

`TestSlackCardShowsConclusionOnAlertPath` pins all three cases — alert named, no alert, no verdict. Mutation-tested: removing the fix reproduces `the card never states its own conclusion`.