### PR TITLE
fix(app): stop misdirecting GitLab operators on the Phase-2 grooming gap

### DIFF
--- a/internal/app/curate.go
+++ b/internal/app/curate.go
@@ -44,6 +44,17 @@ func RunCurate(args []string) error {
 	log := logging.FromConfig(os.Stderr, cfg.Logging.Format, cfg.Logging.Level)
 	tok := BuildForgeTokenSource(cfg, log)
 	if tok == nil {
+		// A GitLab-configured deployment always lands here, and NOT because the
+		// operator got their config wrong: BuildForgeTokenSource only mints GitHub
+		// App tokens, because Phase-2 grooming has no GitLab code path at all.
+		// Sending them off to configure a GitHub App — which they cannot have and
+		// would not help — is a wild goose chase, so name the real limitation.
+		// See website/content/docs/integrations/gitlab.md#not-yet-supported-on-gitlab.
+		if cfg.Forge.Provider == "gitlab" {
+			return fmt.Errorf("lore curate does not support GitLab yet (forge.provider: gitlab): " +
+				"the Learn loop works on GitLab, but the Phase-2 grooming passes are GitHub-only — " +
+				"review KB merge requests by hand for now")
+		}
 		return fmt.Errorf("curate requires a configured GitHub App (forge.github_app)")
 	}
 	// Same audit chain as the action executors (actions.audit_log_path); Nop when

--- a/internal/app/curate_test.go
+++ b/internal/app/curate_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -114,5 +115,40 @@ func TestBuildCurateAgentPassComposition(t *testing.T) {
 	agent = BuildCurateAgent(cfg, forge, ledger, discardLog())
 	if len(agent.Passes) != 7 {
 		t.Fatalf("full agent: want 7 passes (suppress dedup lifecycle queue recurrence contested retirement), got %d", len(agent.Passes))
+	}
+}
+
+// TestRunCurateGitLabNamesTheRealLimitation pins the error a GitLab operator gets.
+//
+// BuildForgeTokenSource only mints GitHub App tokens, so a GitLab-configured
+// deployment always fails this check — but NOT because anything is misconfigured:
+// Phase-2 grooming simply has no GitLab code path. The old message told them to go
+// configure a GitHub App, which they cannot have and which would not help. That is
+// a wild goose chase, so the message must name the real limitation instead.
+func TestRunCurateGitLabNamesTheRealLimitation(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "runlore.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+forge:
+  provider: gitlab
+  kb_repo: acme/kb
+  gitlab:
+    token_env: TEST_CURATE_GL_TOKEN
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunCurate([]string{"-config", cfgPath})
+	if err == nil {
+		t.Fatal("lore curate must fail for a GitLab-configured deployment")
+	}
+	msg := err.Error()
+	if strings.Contains(strings.ToLower(msg), "github app") {
+		t.Fatalf("must not send a GitLab operator after a GitHub App they cannot have: %q", msg)
+	}
+	for _, want := range []string{"GitLab", "grooming"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error must name the real limitation (missing %q): %q", want, msg)
+		}
 	}
 }

--- a/internal/app/sweep.go
+++ b/internal/app/sweep.go
@@ -21,7 +21,17 @@ func BuildSweeper(cfg *config.Config, ledger *outcome.Ledger, aud audit.Auditor,
 	}
 	tok := BuildForgeTokenSource(cfg, log)
 	if tok == nil || cfg.Forge.KBRepo == "" {
-		return nil // no forge, nothing to groom — sweeps are strictly additive
+		// Say so out loud. Reaching here means the operator EXPLICITLY asked for
+		// sweeps (Sweeps.Enabled() is true just above), so returning nil in silence
+		// is indistinguishable from sweeps running and finding nothing to groom —
+		// the backlog quietly rots and the logs never mention it. The very next
+		// branch already warns on its failure; this one was the odd one out.
+		//
+		// A GitLab deployment lands here every time (grooming is GitHub-only), which
+		// is the case most likely to be mistaken for "working".
+		log.Warn("curate sweeps disabled: no usable KB forge — Phase-2 grooming is GitHub-only",
+			"provider", forgeProviderName(cfg), "kb_repo", cfg.Forge.KBRepo)
+		return nil
 	}
 	guarded, err := buildGuardedForge(cfg, tok, cfg.Curate.Sweeps.DryRun(), aud, log)
 	if err != nil {

--- a/internal/app/sweep_test.go
+++ b/internal/app/sweep_test.go
@@ -3,10 +3,12 @@
 package app
 
 import (
+	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/audit"
@@ -52,5 +54,46 @@ func TestBuildSweeperDefaultsToDryRunAgent(t *testing.T) {
 	}
 	if len(sw.Agent.Passes) != 3 {
 		t.Fatalf("nil ledger sweeper: want 3 forge-only passes, got %d", len(sw.Agent.Passes))
+	}
+}
+
+// TestBuildSweeperWarnsWhenForgeUnusable pins the anti-silence contract. Reaching
+// the nil return means the operator explicitly enabled sweeps, so returning nil
+// without a word is indistinguishable from sweeps running and grooming nothing —
+// the backlog rots and the logs never say why. A GitLab deployment hits this path
+// on every start, since Phase-2 grooming is GitHub-only.
+func TestBuildSweeperWarnsWhenForgeUnusable(t *testing.T) {
+	// provider is written straight onto the config; "" exercises the empty-default
+	// path, which must still report as "github" in the log.
+	for _, tc := range []struct {
+		name         string
+		provider     string
+		wantProvider string
+	}{
+		{"gitlab provider has no grooming code path", "gitlab", "gitlab"},
+		{"github with no app credentials", "", "github"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Forge.Provider = tc.provider
+			cfg.Forge.KBRepo = "acme/kb"
+			cfg.Curate.Sweeps.Mode = config.SweepApply
+
+			var buf bytes.Buffer
+			if sw := BuildSweeper(cfg, nil, audit.Nop{}, captureLog(&buf)); sw != nil {
+				t.Fatal("an unusable forge must not build a sweeper")
+			}
+			rec := lastRecord(t, &buf)
+			if rec["level"] != "WARN" {
+				t.Fatalf("disabling sweeps must WARN, got level %v", rec["level"])
+			}
+			msg, _ := rec["msg"].(string)
+			if !strings.Contains(msg, "curate sweeps disabled") {
+				t.Fatalf("log message must name what was disabled, got %q", msg)
+			}
+			if rec["provider"] != tc.wantProvider {
+				t.Fatalf("log must name the forge provider: got %v want %q", rec["provider"], tc.wantProvider)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Follow-up to #404. Two silent-or-misleading failures a GitLab operator hits — the same class as the misroute #404 fixed: the system knows exactly what is wrong and either says something else, or says nothing.

## 1. `lore curate` sent them after a GitHub App

`internal/app/curate.go` told a GitLab operator to configure `forge.github_app`. They cannot have one, and it would not help: `BuildForgeTokenSource` only mints GitHub App tokens because Phase-2 grooming has **no GitLab code path at all**. The message sent them hunting a misconfiguration that does not exist.

It now names the real limitation and points at the docs section #404 added.

## 2. `BuildSweeper` disabled sweeps in total silence

`internal/app/sweep.go` returned `nil` without a word. Reaching that branch means the operator **explicitly enabled sweeps**, so silence is indistinguishable from sweeps running and finding nothing to groom — the KB backlog rots, stale MRs are never closed, and nothing in the logs says why. A GitLab deployment takes that path on every start.

The very next branch in the same function already warned on its failure; this one was the odd one out. It now warns, naming the provider and `kb_repo`.

**Neither change implements GitLab grooming** — that stays out of scope. They make its absence legible.

## Verification

`go build ./...` clean · `go test ./...` 57/57 packages · `golangci-lint run ./...` 0 issues.

Both guards **mutation-tested** — defect re-introduced, covering test confirmed failing, mutation reverted:

```
sweeps silently disabled:          CAUGHT (test fails)
misleading GitHub App message:     CAUGHT (test fails)
```

Tests: `TestBuildSweeperWarnsWhenForgeUnusable` (2 sub-cases, incl. the empty-provider default), `TestRunCurateGitLabNamesTheRealLimitation`.