### PR TITLE
fix(recall): one catalog, one recall gate — serve built both twice

### DIFF
--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
 
@@ -114,16 +115,16 @@ func forgeProviderName(cfg *config.Config) string {
 // BuildReinvestigator returns a poller that re-runs KB issues labelled
 // "reinvestigate" and posts the fresh findings back, or nil when the forge isn't
 // configured. RunLore polls the forge (outbound) — it has no inbound webhooks.
-func BuildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, metrics *telemetry.Metrics, log *slog.Logger) *investigate.Reinvestigator {
+func BuildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) *investigate.Reinvestigator {
 	client := buildForge(cfg, log)
 	if client == nil {
 		return nil
 	}
 	model, tools, recall, _ := BuildModelAndTools(ctx, cfg, gp, metrics, log)
-	if recall != nil {
-		recall.Metrics = metrics
-		recall.Log = log
-	}
+	// Same wiring as the investigator, including the outcome ledger — a
+	// re-investigation must not fire recall on an entry a normal investigation
+	// would have rejected on its outcome history.
+	wireRecall(recall, metrics, ledger, log)
 	run := func(ctx context.Context, req investigate.Request) (providers.Investigation, error) {
 		var res providers.Investigation
 		var got bool

--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/curator"
 	"github.com/Smana/runlore/internal/investigate"
-	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
 
@@ -115,16 +114,21 @@ func forgeProviderName(cfg *config.Config) string {
 // BuildReinvestigator returns a poller that re-runs KB issues labelled
 // "reinvestigate" and posts the fresh findings back, or nil when the forge isn't
 // configured. RunLore polls the forge (outbound) — it has no inbound webhooks.
-func BuildReinvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) *investigate.Reinvestigator {
+func BuildReinvestigator(cfg *config.Config, deps *Deps, metrics *telemetry.Metrics, log *slog.Logger) *investigate.Reinvestigator {
 	client := buildForge(cfg, log)
 	if client == nil {
 		return nil
 	}
-	model, tools, recall, _ := BuildModelAndTools(ctx, cfg, gp, metrics, log)
-	// Same wiring as the investigator, including the outcome ledger — a
-	// re-investigation must not fire recall on an entry a normal investigation
-	// would have rejected on its outcome history.
-	wireRecall(recall, metrics, ledger, log)
+	if deps == nil {
+		// No model: there is nothing to re-investigate WITH. Previously this built a
+		// second model/catalog anyway and produced an investigator that could not run.
+		log.Info("reinvestigate poller disabled: no model configured")
+		return nil
+	}
+	// The SAME model, tools, recall and catalog the investigator uses — not a second
+	// copy. See Deps: a second catalog means a second git-sync goroutine on the same
+	// directory, and an index that disagrees with the investigator's.
+	model, tools, recall := deps.Model, deps.Tools, deps.Recall
 	run := func(ctx context.Context, req investigate.Request) (providers.Investigation, error) {
 		var res providers.Investigation
 		var got bool

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -497,16 +497,47 @@ func wireRecall(r *investigate.Recall, metrics *telemetry.Metrics, ledger *outco
 	}
 }
 
-// BuildInvestigator returns the LLM ReAct investigator when a model is configured,
-// otherwise the read-only LogInvestigator. It also returns the catalog (nil when
-// no model is configured or no catalog is wired).
-func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, approvals *action.Approvals, auto *action.Auto, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) (investigate.Investigator, *catalog.Catalog, error) {
+// Deps are the investigation dependencies that must be built ONCE per process and
+// shared by every consumer.
+//
+// The catalog is why this type exists. When catalog.git is configured, building one
+// starts a background Syncer goroutine that git-clones and pulls into
+// catalog.dir — and on a failed clone it os.RemoveAll's that directory. serve used
+// to build the catalog twice (once for the investigator, once for the
+// reinvestigator), so two syncers ran concurrently against the SAME path, either
+// able to delete the checkout from under the other mid-pull. Live pods showed both:
+// two "catalog git-sync enabled" lines and two "catalog synced" 4ms apart.
+//
+// It also meant the reinvestigator searched a DIFFERENT index than the
+// investigator, so a freshly curated entry was visible to one and not the other.
+type Deps struct {
+	Model   providers.ModelProvider
+	Tools   []investigate.Tool
+	Recall  *investigate.Recall // nil when instant recall is disabled
+	Catalog *catalog.Catalog    // nil when no catalog is configured
+}
+
+// BuildDeps assembles the shared dependencies, or nil when no model is configured
+// (in which case there is nothing to investigate WITH, and callers fall back to
+// their read-only paths). Call it once; pass the result everywhere.
+func BuildDeps(ctx context.Context, cfg *config.Config, gp providers.GitOpsProvider, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) *Deps {
 	if !ModelConfigured(cfg) {
-		log.Info("no model configured; using log-only investigator")
-		return investigate.LogInvestigator{Log: log}, nil, nil
+		return nil
 	}
 	model, tools, recall, cat := BuildModelAndTools(ctx, cfg, gp, metrics, log)
 	wireRecall(recall, metrics, ledger, log)
+	return &Deps{Model: model, Tools: tools, Recall: recall, Catalog: cat}
+}
+
+// BuildInvestigator returns the LLM ReAct investigator when a model is configured,
+// otherwise the read-only LogInvestigator. It also returns the catalog (nil when
+// no model is configured or no catalog is wired).
+func BuildInvestigator(ctx context.Context, cfg *config.Config, deps *Deps, approvals *action.Approvals, auto *action.Auto, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) (investigate.Investigator, *catalog.Catalog, error) {
+	if deps == nil {
+		log.Info("no model configured; using log-only investigator")
+		return investigate.LogInvestigator{Log: log}, nil, nil
+	}
+	model, tools, recall, cat := deps.Model, deps.Tools, deps.Recall, deps.Catalog
 	log.Info("using LLM investigator", "provider", ModelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
 	notifier, err := BuildNotifier(cfg, log)
 	if err != nil {

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -471,6 +471,32 @@ func kbMatchScore(recall *investigate.Recall) float64 {
 // still allowing legitimately slow queries (log scans, range PromQL) to finish.
 const defaultToolTimeout = 60 * time.Second
 
+// wireRecall attaches the runtime dependencies BuildModelAndTools cannot supply,
+// for every path that builds a Recall.
+//
+// It exists because there is more than one such path — the investigator and the
+// reinvestigator — and each used to wire these by hand. They diverged: the
+// reinvestigate path set Metrics and Log but left Outcome nil, and Recall
+// documents `nil ⇒ no outcome decay`. So a KB entry whose recorded outcomes
+// should have suppressed it stayed suppressed for a normal investigation and
+// could still fire instant recall on a re-investigation — the same
+// confidently-wrong-answer failure the outcome gate exists to prevent.
+//
+// One function, so a field added here reaches every path by construction.
+// TestWireRecallIsTheOnlyPlaceRecallDepsAreSet keeps it that way.
+func wireRecall(r *investigate.Recall, metrics *telemetry.Metrics, ledger *outcome.Ledger, log *slog.Logger) {
+	if r == nil {
+		return
+	}
+	r.Metrics = metrics
+	r.Log = log
+	// *outcome.Ledger satisfies OutcomeStats; a nil ledger disables decay, which is
+	// correct when the operator disabled the ledger and wrong when we simply forgot.
+	if ledger != nil {
+		r.Outcome = ledger
+	}
+}
+
 // BuildInvestigator returns the LLM ReAct investigator when a model is configured,
 // otherwise the read-only LogInvestigator. It also returns the catalog (nil when
 // no model is configured or no catalog is wired).
@@ -480,11 +506,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, gp providers.Git
 		return investigate.LogInvestigator{Log: log}, nil, nil
 	}
 	model, tools, recall, cat := BuildModelAndTools(ctx, cfg, gp, metrics, log)
-	if recall != nil {
-		recall.Metrics = metrics
-		recall.Log = log
-		recall.Outcome = ledger // outcome-driven decay (serve path); *outcome.Ledger satisfies OutcomeStats
-	}
+	wireRecall(recall, metrics, ledger, log)
 	log.Info("using LLM investigator", "provider", ModelProvider(cfg), "model", cfg.Model.Model, "tools", len(tools))
 	notifier, err := BuildNotifier(cfg, log)
 	if err != nil {

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -229,7 +229,11 @@ func TestBuildInvestigatorSelectsImplementation(t *testing.T) {
 
 	t.Run("no model -> LogInvestigator", func(t *testing.T) {
 		cfg := &config.Config{} // no model configured
-		inv, cat, err := BuildInvestigator(context.Background(), cfg, nil, nil, nil, nil, nil, log)
+		deps := BuildDeps(context.Background(), cfg, nil, nil, nil, log)
+		if deps != nil {
+			t.Fatal("BuildDeps must return nil when no model is configured")
+		}
+		inv, cat, err := BuildInvestigator(context.Background(), cfg, deps, nil, nil, nil, nil, log)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -243,7 +247,8 @@ func TestBuildInvestigatorSelectsImplementation(t *testing.T) {
 
 	t.Run("model -> LoopInvestigator", func(t *testing.T) {
 		cfg := &config.Config{Model: config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}}
-		inv, _, err := BuildInvestigator(context.Background(), cfg, nil, nil, nil, nil, nil, log)
+		deps := BuildDeps(context.Background(), cfg, nil, nil, nil, log)
+		inv, _, err := BuildInvestigator(context.Background(), cfg, deps, nil, nil, nil, nil, log)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -256,7 +261,8 @@ func TestBuildInvestigatorSelectsImplementation(t *testing.T) {
 		// Unset tool_timeout (0) ⇒ the 60s default is applied at construction, mirroring
 		// the other investigation defaults.
 		cfg := &config.Config{Model: config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}}
-		inv, _, err := BuildInvestigator(context.Background(), cfg, nil, nil, nil, nil, nil, log)
+		deps := BuildDeps(context.Background(), cfg, nil, nil, nil, log)
+		inv, _, err := BuildInvestigator(context.Background(), cfg, deps, nil, nil, nil, nil, log)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -270,7 +276,8 @@ func TestBuildInvestigatorSelectsImplementation(t *testing.T) {
 
 		// Explicit tool_timeout flows through unchanged.
 		cfg.Investigation.ToolTimeout = config.Duration(5 * time.Second)
-		inv2, _, err := BuildInvestigator(context.Background(), cfg, nil, nil, nil, nil, nil, log)
+		deps2 := BuildDeps(context.Background(), cfg, nil, nil, nil, log)
+		inv2, _, err := BuildInvestigator(context.Background(), cfg, deps2, nil, nil, nil, nil, log)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -236,7 +236,7 @@ func RunServe(version string, args []string) error {
 			"max_batch", cc.MaxBatch, "cooldown", cc.Cooldown.Std())
 	}
 
-	reinv := BuildReinvestigator(ctx, cfg, gitops, metrics, log)
+	reinv := BuildReinvestigator(ctx, cfg, gitops, metrics, ledger, log)
 
 	// failureDedup is created ONCE (process scope), not per leadership term, so it
 	// survives leader flaps: the gitops informer's initial-LIST replay of every

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -179,7 +179,10 @@ func RunServe(version string, args []string) error {
 		log.Info("outcome ledger enabled", "path", cfg.Outcome.LedgerPath, "max_events", maxEvents)
 	}
 
-	inv, cat, err := BuildInvestigator(ctx, cfg, gitops, approvals, auto, metrics, ledger, log)
+	// Built ONCE and shared: a second Deps means a second catalog, hence a second
+	// git-sync goroutine racing the first on the same on-disk checkout.
+	deps := BuildDeps(ctx, cfg, gitops, metrics, ledger, log)
+	inv, cat, err := BuildInvestigator(ctx, cfg, deps, approvals, auto, metrics, ledger, log)
 	if err != nil {
 		return fmt.Errorf("build investigator: %w", err)
 	}
@@ -236,7 +239,7 @@ func RunServe(version string, args []string) error {
 			"max_batch", cc.MaxBatch, "cooldown", cc.Cooldown.Std())
 	}
 
-	reinv := BuildReinvestigator(ctx, cfg, gitops, metrics, ledger, log)
+	reinv := BuildReinvestigator(cfg, deps, metrics, log)
 
 	// failureDedup is created ONCE (process scope), not per leadership term, so it
 	// survives leader flaps: the gitops informer's initial-LIST replay of every

--- a/internal/app/wire_recall_test.go
+++ b/internal/app/wire_recall_test.go
@@ -118,3 +118,80 @@ func TestWireRecallIsTheOnlyPlaceRecallDepsAreSet(t *testing.T) {
 		t.Fatal("no source file mentioning Recall was parsed — this guard is inert")
 	}
 }
+
+// TestOnlyKnownCallersBuildACatalog guards the shared-catalog invariant.
+//
+// Building a catalog is not pure construction: with catalog.git configured it starts
+// a background Syncer goroutine that clones and pulls into catalog.dir, and
+// os.RemoveAll's that directory when a clone fails. Two catalogs in one process mean
+// two syncers racing on one checkout — either able to delete it under the other —
+// plus two indexes that can disagree about whether a freshly curated entry exists.
+//
+// serve did exactly that: BuildInvestigator and BuildReinvestigator each called
+// BuildModelAndTools, which builds a catalog. Live pods logged two
+// "catalog git-sync enabled" lines and two "catalog synced" 4ms apart.
+//
+// The guard is on BuildModelAndTools, not BuildCatalog: the regression re-appears by
+// calling the WRAPPER twice, which an earlier version of this test missed entirely
+// (the mutation reintroducing the bug passed). The allowlist is explicit so a fourth
+// caller has to justify itself here rather than quietly doubling the syncers.
+func TestOnlyKnownCallersBuildACatalog(t *testing.T) {
+	allowed := map[string]string{
+		"BuildDeps":      "the one serve-path builder; every serve consumer shares its result",
+		"RunEvalLive":    "`lore eval`, a separate one-shot process",
+		"RunInvestigate": "`lore investigate`, a separate one-shot process",
+	}
+
+	files, err := filepath.Glob(filepath.Join(".", "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	fset := token.NewFileSet()
+	found := 0
+
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path) //nolint:gosec // test-owned path in this package
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(src), "BuildModelAndTools") &&
+			!strings.Contains(string(src), "BuildCatalog") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Name.Name == "BuildModelAndTools" {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				id, ok := call.Fun.(*ast.Ident)
+				if !ok || (id.Name != "BuildModelAndTools" && id.Name != "BuildCatalog") {
+					return true
+				}
+				found++
+				if _, ok := allowed[fn.Name.Name]; !ok {
+					t.Errorf("%s: %s calls %s, which builds a catalog — share the one from "+
+						"BuildDeps instead, or a second git-sync goroutine races the first on "+
+						"the same on-disk checkout",
+						filepath.Base(path), fn.Name.Name, id.Name)
+				}
+				return true
+			})
+		}
+	}
+
+	if found == 0 {
+		t.Fatal("no catalog-building call found — it was renamed and this guard is inert")
+	}
+}

--- a/internal/app/wire_recall_test.go
+++ b/internal/app/wire_recall_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// TestWireRecallSetsEveryRuntimeDependency pins what a Recall must be given.
+//
+// Recall documents `Outcome OutcomeStats // optional; nil ⇒ no outcome decay`, so
+// an unset ledger silently removes one of the three recall gates rather than
+// failing. That is invisible at runtime: recall still fires, just without the
+// outcome-weighted confidence that would have suppressed a poorly-performing
+// entry.
+func TestWireRecallSetsEveryRuntimeDependency(t *testing.T) {
+	r := &investigate.Recall{}
+	ledger := &outcome.Ledger{}
+	log := slog.New(slog.DiscardHandler)
+	m := (*telemetry.Metrics)(nil)
+
+	wireRecall(r, m, ledger, log)
+
+	if r.Outcome == nil {
+		t.Error("Outcome is nil — recall runs without the outcome-weighted gate")
+	}
+	if r.Log == nil {
+		t.Error("Log is nil — recall decisions go unrecorded")
+	}
+
+	// A nil ledger is a legitimate configuration (the operator disabled it), so it
+	// must not panic and must leave decay off rather than inventing a ledger.
+	r2 := &investigate.Recall{}
+	wireRecall(r2, m, nil, log)
+	if r2.Outcome != nil {
+		t.Error("a nil ledger must leave Outcome nil, not synthesize one")
+	}
+
+	wireRecall(nil, m, ledger, log) // must not panic
+}
+
+// TestWireRecallIsTheOnlyPlaceRecallDepsAreSet is the guard that matters.
+//
+// The bug this fixes was not a wrong value — it was a SECOND place that wired a
+// Recall by hand and set one fewer field than the first. Both compiled, both ran,
+// and only one had the outcome gate. Centralizing the wiring only helps if it
+// stays centralized, so this fails when any other function in the package assigns
+// Recall's runtime fields directly.
+func TestWireRecallIsTheOnlyPlaceRecallDepsAreSet(t *testing.T) {
+	const guarded = "wireRecall"
+	fields := map[string]bool{"Outcome": true, "Metrics": true, "Log": true}
+
+	files, err := filepath.Glob(filepath.Join(".", "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	fset := token.NewFileSet()
+	inspected := 0
+
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path) //nolint:gosec // test-owned path in this package
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		// Only files that mention Recall at all can contain the assignment.
+		if !strings.Contains(string(src), "Recall") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		inspected++
+
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Name.Name == guarded || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				as, ok := n.(*ast.AssignStmt)
+				if !ok {
+					return true
+				}
+				for _, lhs := range as.Lhs {
+					sel, ok := lhs.(*ast.SelectorExpr)
+					if !ok || !fields[sel.Sel.Name] {
+						continue
+					}
+					id, ok := sel.X.(*ast.Ident)
+					if !ok || !strings.Contains(strings.ToLower(id.Name), "recall") {
+						continue
+					}
+					t.Errorf("%s: %s sets %s.%s directly — route it through %s() so every "+
+						"path that builds a Recall gets the same dependencies",
+						filepath.Base(path), fn.Name.Name, id.Name, sel.Sel.Name, guarded)
+				}
+				return true
+			})
+		}
+	}
+
+	if inspected == 0 {
+		t.Fatal("no source file mentioning Recall was parsed — this guard is inert")
+	}
+}


### PR DESCRIPTION
Two defects with one root cause: `serve` built the investigation dependencies **twice**, and the two copies had diverged.

`BuildInvestigator` and `BuildReinvestigator` each called `BuildModelAndTools`.

## 1. The reinvestigate path skipped the outcome gate

Each call site wired `Recall`'s optional dependencies by hand, and they drifted apart:

| | `Metrics` | `Log` | `Outcome` |
|---|---|---|---|
| `BuildInvestigator` | ✅ | ✅ | ✅ `= ledger` |
| `BuildReinvestigator` | ✅ | ✅ | **nil** |

`Recall` documents `Outcome OutcomeStats // optional; nil ⇒ no outcome decay`.

So a KB entry whose recorded outcomes should suppress it — rejected by humans, never actually resolved the incident — **was** suppressed on a normal investigation, and could still fire instant recall on a **re-investigation**. A confidently-wrong cached answer served straight past the gate built to stop it.

It fails open and silently: recall still fires, still logs, still reports a confidence. It is simply missing one of its three gates. Same shape as the trust-gate fail-open in #395 — the dangerous failures here are the ones that keep answering.

## 2. Two git syncers racing on one checkout

Building a catalog is not pure construction. With `catalog.git` configured it starts a background `Syncer` goroutine that clones and pulls into `catalog.dir` — and `os.RemoveAll`s that directory when a clone fails (`sync.go:129`).

Two catalogs therefore meant **two syncers against the same path**, either able to delete the checkout under the other mid-pull. The live deployment shows it:

```
catalog.dir: /var/lib/runlore/catalog    catalog.git.interval: 5m

$ kubectl logs -n runlore runlore-1 | grep -c 'catalog git-sync enabled'
2
16:40:36.151  catalog synced  entries=14
16:40:36.155  catalog synced  entries=14
```

It also meant the reinvestigator searched a **different index** than the investigator, so a freshly curated entry was visible to one and not the other.

## The fix

`Deps` carries the model, tools, recall and catalog. `serve` builds it once and hands the same pointer to both consumers. `wireRecall` is the single place a `Recall`'s runtime dependencies are attached.

`BuildReinvestigator` with no model now returns `nil` and logs why, instead of building a second catalog to feed an investigator that could not run.

## Guards, and two rounds of getting them wrong

- `TestWireRecallIsTheOnlyPlaceRecallDepsAreSet` — AST check; fails if any other function assigns `Outcome`/`Metrics`/`Log` on a Recall. The bug was never a wrong *value*, it was a second hand-wired copy setting one fewer field.
- `TestOnlyKnownCallersBuildACatalog` — allowlists `BuildDeps`, `RunEvalLive` and `RunInvestigate` (the latter two are separate one-shot processes).

Both needed correcting after mutation testing:

| attempt | mutation | result |
|---|---|---|
| guard watched `BuildCatalog` | reintroduce the second `BuildModelAndTools` call | **passed — missed the real bug** |
| guard watched the wrapper | same mutation | caught |
| … file filter required `BuildModelAndTools` | direct `BuildCatalog` call in `serve.go` | **passed — file skipped** |
| … filter admits either name | same mutation | caught |

Final state, all four mutations caught:

```
restore hand-wiring in BuildReinvestigator   caught
drop Outcome from wireRecall                 caught
second BuildModelAndTools call               caught
direct BuildCatalog call from RunServe       caught
```

`go build` · `go test ./...` · `gofmt` · `golangci-lint` 0 issues.
