### PR TITLE
fix(tools): name the lever when pod_logs is denied by RBAC

### DIFF
--- a/internal/investigate/podlogs_tool.go
+++ b/internal/investigate/podlogs_tool.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -97,6 +99,22 @@ func (t PodLogsTool) Call(ctx context.Context, args string) (string, error) {
 	}
 	lines, err := t.Logs.PodLogs(ctx, providers.PodLogQuery{Namespace: in.Namespace, LabelSelector: in.Selector, SinceMinutes: since, Previous: in.Previous})
 	if err != nil {
+		// An RBAC denial here is EXPECTED and configuration-driven, not a fault: the
+		// app layer always permits the incident's own namespace, while pods/log RBAC
+		// is granted only over rbac.controllerLogNamespaces — deliberately, because
+		// pod logs carry secrets and are streamed to an external model.
+		//
+		// Surfacing the raw Kubernetes "is forbidden" here left the model to invent a
+		// reason. It reported "the runlore serviceaccount lacks pods/log RBAC in the
+		// tooling namespace", which reads to an operator like a misconfiguration to
+		// chase rather than a policy with a named lever. Say which lever.
+		if apierrors.IsForbidden(err) {
+			return fmt.Sprintf("pod logs for namespace %q are not readable: pods/log RBAC is granted only "+
+				"over the configured controller-log namespaces, because pod logs may carry secrets and are "+
+				"sent to the model. This is a deliberate boundary, not a fault — an operator widens it by "+
+				"adding %q to rbac.controllerLogNamespaces. Use kube_events, pod_status or query_logs "+
+				"(collector-side, redacted) instead.", in.Namespace, in.Namespace), nil
+		}
 		return "", err
 	}
 	if len(lines) == 0 {

--- a/internal/investigate/podlogs_tool_test.go
+++ b/internal/investigate/podlogs_tool_test.go
@@ -4,8 +4,12 @@ package investigate
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -130,5 +134,52 @@ func TestPodLogsToolRejectsOutOfAllowlistNamespace(t *testing.T) {
 	}
 	if !strings.Contains(out, "pod_log_namespaces") {
 		t.Fatalf("rejection should point at the pod_log_namespaces allowlist, got: %q", out)
+	}
+}
+
+// fakeForbiddenLogs returns the RBAC denial the Kubernetes API produces when
+// pods/log is not granted for the requested namespace.
+type fakeForbiddenLogs struct{}
+
+func (fakeForbiddenLogs) Query(context.Context, string, providers.TimeWindow) (providers.LogResult, error) {
+	return nil, nil
+}
+
+func (fakeForbiddenLogs) PodLogs(_ context.Context, q providers.PodLogQuery) (providers.LogResult, error) {
+	return nil, apierrors.NewForbidden(
+		schema.GroupResource{Resource: "pods/log"}, "",
+		errors.New(`User "system:serviceaccount:runlore:runlore" cannot get resource "pods/log" in API group "" in the namespace "`+q.Namespace+`"`))
+}
+
+// TestPodLogsForbiddenNamesTheLever pins the RBAC-denial message.
+//
+// The app layer always permits the INCIDENT's own namespace, while pods/log RBAC is
+// granted only over the controller-log namespaces — deliberately, since pod logs
+// carry secrets and are streamed to an external model. So a denial here is the
+// normal, configured outcome for any incident outside those namespaces.
+//
+// Returning the raw Kubernetes error left the model to invent a reason: a real
+// investigation reported "the runlore serviceaccount lacks pods/log RBAC in the
+// tooling namespace", which reads to an operator like a misconfiguration to chase
+// rather than a policy with a named lever. It must name the lever, and it must not
+// fail the tool call — an expected denial is not an error.
+func TestPodLogsForbiddenNamesTheLever(t *testing.T) {
+	tool := PodLogsTool{Logs: fakeForbiddenLogs{}, IncidentNamespace: "tooling"}
+	out, err := tool.Call(context.Background(), `{"namespace":"tooling","selector":"app=harbor"}`)
+	if err != nil {
+		t.Fatalf("an expected RBAC denial must not fail the tool call: %v", err)
+	}
+	for _, want := range []string{"tooling", "rbac.controllerLogNamespaces", "deliberate"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("denial message must contain %q so the operator can act on it:\n%s", want, out)
+		}
+	}
+	// It must not read as a defect in RunLore.
+	if strings.Contains(strings.ToLower(out), "lacks") {
+		t.Errorf("message frames a deliberate boundary as a missing grant:\n%s", out)
+	}
+	// It must point at what DOES work, so the investigation recovers.
+	if !strings.Contains(out, "kube_events") && !strings.Contains(out, "query_logs") {
+		t.Errorf("message must name a usable alternative:\n%s", out)
 	}
 }


### PR DESCRIPTION
## The data gap this removes

A real investigation reported:

> Could not read harbor-registry container logs directly (**pod_logs forbidden: the runlore serviceaccount lacks pods/log RBAC in the tooling namespace**)

That reads like a misconfiguration to chase. It isn't one.

## What is actually happening

`pod_logs` has two independent gates:

| gate | scope |
|---|---|
| app layer (`namespaceAllowed`) | the incident's **own** namespace + `investigation.pod_log_namespaces` |
| Kubernetes RBAC | **only** `rbac.controllerLogNamespaces` (default `[flux-system]`) |

The app layer always permits the incident's own namespace, so the call proceeds — and Kubernetes then denies it. That is the **designed** outcome for any incident outside the controller-log namespaces, and the chart says why:

> pod logs may carry secrets/PII and tool output is sent to an external LLM

So a `tooling` incident will *always* hit this. The raw `is forbidden` gave the model nothing to work with, so it guessed at a cause and framed a deliberate boundary as a missing grant — "**lacks** pods/log RBAC".

## The fix

The denial now:

- names the lever — an operator widens it by adding the namespace to `rbac.controllerLogNamespaces`
- says plainly it is a boundary, not a fault
- names what still works (`kube_events`, `pod_status`, `query_logs` — collector-side and redacted) so the loop recovers instead of dead-ending
- **stops failing the tool call**: an expected denial is a result, not an error

Nothing about the security boundary changes. `pods/log` stays off cluster-wide.

## Test

`TestPodLogsForbiddenNamesTheLever` drives a real `apierrors.NewForbidden` through the tool with `IncidentNamespace` set — the production path, where the app layer allows and RBAC denies. It asserts the namespace and the knob are named, that the call does not error, that a usable alternative is offered, and that the message does not say "lacks".

Mutation-tested: disabling the translation restores the raw `pods/log is forbidden: User "system:serviceaccount:runlore:runlore" cannot get resource "pods/log"…` and fails.

## Not fixed here, for the record

The same investigation also said Flux `gotk_reconcile_condition` and `kube_pod_container_status_waiting_reason` "did not match (metric names may differ in this cluster)". I checked both against the live VictoriaMetrics:

- `kube_pod_container_status_waiting_reason` — **210 series exist**. kube-state-metrics only emits it while a container is actually waiting, so an instant query returns nothing when the cluster is healthy. The observation was right; the stated reason was a guess, and wrong.
- `gotk_reconcile_condition` — **genuinely absent**; only `gotk_event_*` is scraped. That is a cluster scrape-config gap, not a RunLore one.

`query_metrics` already tells the model to `use discover_metrics … to list what this workload actually exports`, and a `discover_metrics` tool is registered — the model had a way to check and speculated instead. Worth a separate change to `data_gaps` guidance rather than smuggling a prompt edit in here.
