### PR TITLE
fix(cloud): retry unscoped when a CloudTrail resource filter matches nothing

### DIFF
--- a/internal/investigate/cloud_tools.go
+++ b/internal/investigate/cloud_tools.go
@@ -25,8 +25,10 @@ func (t CloudWhatChangedTool) Name() string { return "cloud_what_changed" }
 func (t CloudWhatChangedTool) Description() string {
 	return "List recent MUTATING AWS control-plane events (CloudTrail) — ASG/EC2/EKS/RDS/SG changes, " +
 		"manual actions, and other infra changes invisible to GitOps. Use when no Git change explains " +
-		"the incident. Optional resource scopes to an instance-id/ASG/ARN; since_minutes default 90 " +
-		"(CloudTrail lags ~15m)."
+		"the incident. Optional resource is an EXACT CloudTrail ResourceName — a full ARN, instance-id, " +
+		"ASG name, or a resource's full path (e.g. a Secrets Manager secret's \"apps/team/name\") — never a " +
+		"service name or substring; OMIT it to see every mutating event, which is the right move when you do " +
+		"not know the exact identifier. since_minutes default 90 (CloudTrail lags ~15m)."
 }
 
 // Schema returns the JSON schema for the arguments.
@@ -49,14 +51,44 @@ func (t CloudWhatChangedTool) Call(ctx context.Context, args string) (string, er
 	}
 	end := time.Now()
 	start := end.Add(-time.Duration(since) * time.Minute)
-	changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{Name: in.Resource}, providers.TimeWindow{Start: start, End: end})
+	window := providers.TimeWindow{Start: start, End: end}
+	changes, err := t.Cloud.CloudChanges(ctx, providers.Selector{Name: in.Resource}, window)
 	if err != nil {
 		return "", err
 	}
+
+	// CloudTrail's ResourceName lookup is an EXACT match on the full AWS resource
+	// name or ARN — not a substring, not a service name. A guessed scope therefore
+	// returns zero events that are indistinguishable from "nothing changed", and the
+	// model reasonably concludes the control plane was quiet.
+	//
+	// That is not hypothetical. An AWS Secrets Manager secret was deleted, CloudTrail
+	// recorded it under ResourceName "apps/app-wizard/llm", and the investigation
+	// tried "secretsmanager", "secretsmanager.amazonaws.com" and "app-wizard" — all
+	// exact-match misses. It reported the deletion event as uncapturable and left
+	// "who deleted it" as an open question, with the answer sitting one unscoped
+	// lookup away.
+	//
+	// So a scoped miss retries unscoped rather than dead-ending. The banner says the
+	// filter was dropped, because silently widening a query the model asked to narrow
+	// would be worse than the dead end.
+	var widened bool
+	if len(changes) == 0 && in.Resource != "" {
+		all, aerr := t.Cloud.CloudChanges(ctx, providers.Selector{}, window)
+		if aerr == nil && len(all) > 0 {
+			changes, widened = all, true
+		}
+	}
+
 	if len(changes) == 0 {
 		return "no mutating AWS events in the window", nil
 	}
 	var b strings.Builder
+	if widened {
+		fmt.Fprintf(&b, "resource %q matched no CloudTrail events — ResourceName is an exact match on the "+
+			"full AWS resource name or ARN (e.g. a secret's full path \"apps/team/name\"), not a service or "+
+			"substring. Showing ALL mutating events in the window instead:\n", in.Resource)
+	}
 	renderRows(&b, len(changes), "more", func(i int) {
 		c := changes[i]
 		fmt.Fprintf(&b, "%s %s %s/%s\n", c.When.Format(time.RFC3339), c.ManagedBy, c.Workload.Kind, c.Workload.Name)

--- a/internal/investigate/cloud_tools_test.go
+++ b/internal/investigate/cloud_tools_test.go
@@ -57,3 +57,82 @@ func TestCloudResourceHealthTool(t *testing.T) {
 		t.Fatalf("expected empty message, got %s", empty)
 	}
 }
+
+// exactMatchCloud models CloudTrail's real LookupEvents semantics: a ResourceName
+// attribute is an EXACT match, so any scope other than the resource's full name
+// returns nothing, while an unscoped lookup returns every mutating event.
+type exactMatchCloud struct {
+	resourceName string             // the only scope that matches
+	changes      []providers.Change // returned when the scope matches, or unscoped
+	scopedCalls  []string           // every Selector.Name the tool asked for, in order
+}
+
+func (f *exactMatchCloud) CloudChanges(_ context.Context, sel providers.Selector, _ providers.TimeWindow) ([]providers.Change, error) {
+	f.scopedCalls = append(f.scopedCalls, sel.Name)
+	if sel.Name == "" || sel.Name == f.resourceName {
+		return f.changes, nil
+	}
+	return nil, nil
+}
+func (f *exactMatchCloud) ResourceHealth(context.Context, providers.Selector, providers.TimeWindow) (providers.LogResult, error) {
+	return nil, nil
+}
+
+// TestCloudWhatChangedWidensOnScopedMiss pins the fallback.
+//
+// A guessed resource scope returns zero events, which is indistinguishable from "the
+// control plane was quiet" — so the model concludes nothing changed. That happened on
+// a real incident: an AWS Secrets Manager secret was deleted, CloudTrail recorded it
+// under ResourceName "apps/app-wizard/llm", and the investigation tried
+// "secretsmanager", "secretsmanager.amazonaws.com" and "app-wizard". All three missed,
+// and it reported the deletion as uncapturable while the answer sat one unscoped
+// lookup away.
+func TestCloudWhatChangedWidensOnScopedMiss(t *testing.T) {
+	deletion := providers.Change{
+		When: time.Unix(1700000000, 0).UTC(), ManagedBy: "secretsmanager.amazonaws.com",
+		Workload: providers.Workload{Kind: "secretsmanager.amazonaws.com", Name: "DeleteSecret"},
+		Source:   providers.SourceRef{Path: "DeleteSecret by smana"},
+	}
+
+	t.Run("scoped miss falls back to unscoped and says so", func(t *testing.T) {
+		cloud := &exactMatchCloud{resourceName: "apps/app-wizard/llm", changes: []providers.Change{deletion}}
+		out, err := (CloudWhatChangedTool{Cloud: cloud}).Call(context.Background(), `{"resource":"secretsmanager"}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "DeleteSecret") {
+			t.Errorf("the deletion event must survive a bad resource scope:\n%s", out)
+		}
+		if !strings.Contains(out, "exact match") {
+			t.Errorf("the model must be told WHY its filter missed, or it will guess again:\n%s", out)
+		}
+		if len(cloud.scopedCalls) != 2 || cloud.scopedCalls[0] != "secretsmanager" || cloud.scopedCalls[1] != "" {
+			t.Errorf("want a scoped call then an unscoped retry, got %q", cloud.scopedCalls)
+		}
+	})
+
+	t.Run("a matching scope is not widened", func(t *testing.T) {
+		cloud := &exactMatchCloud{resourceName: "apps/app-wizard/llm", changes: []providers.Change{deletion}}
+		out, err := (CloudWhatChangedTool{Cloud: cloud}).Call(context.Background(), `{"resource":"apps/app-wizard/llm"}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(out, "exact match") {
+			t.Errorf("a scope that matched must not be reported as widened:\n%s", out)
+		}
+		if len(cloud.scopedCalls) != 1 {
+			t.Errorf("a matching scope must not trigger a second lookup, got %q", cloud.scopedCalls)
+		}
+	})
+
+	t.Run("genuinely quiet window still reports quiet", func(t *testing.T) {
+		cloud := &exactMatchCloud{resourceName: "apps/app-wizard/llm"} // no changes at all
+		out, err := (CloudWhatChangedTool{Cloud: cloud}).Call(context.Background(), `{"resource":"whatever"}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "no mutating AWS events") {
+			t.Errorf("an empty window must not be dressed up as a widened result:\n%s", out)
+		}
+	})
+}


### PR DESCRIPTION
## The gap, from a real investigation

An AWS Secrets Manager secret was deleted. RunLore got the root cause right —

> 🔥 **Action required** — ExternalSecret app-wizard-llm failing: AWS Secrets Manager secret marked for deletion

— and suggested the correct fix (`restore-secret`, 7–30 day window). But it stopped at **50% confidence**, and its own data-gap said why:

> `cloud_what_changed` did not capture the AWS Secrets Manager deletion event — tried resource filters `secretsmanager`, `secretsmanager.amazonaws.com`, and `app-wizard` over a 3-hour window; all returned 'no mutating AWS events'. **The tool may not monitor Secrets Manager CloudTrail events**

It does. CloudTrail had the event the whole time:

```
Time  2026-08-02T19:39:10+02:00
Name  DeleteSecret
User  smana
Res   apps/app-wizard/llm
```

## Why all three filters missed

`LookupEvents` accepts one attribute. With a resource name, the tool scopes by `ResourceName` — which is an **exact match** on the full resource name or ARN. `secretsmanager` and `secretsmanager.amazonaws.com` are event *sources*; `app-wizard` is a substring. None equals `apps/app-wizard/llm`.

A zero-result scoped lookup is then indistinguishable from a quiet control plane, so the investigation concluded the deletion was uncapturable and left **"who or what marked the secret for deletion"** as an open question for a human — with the answer one unscoped lookup away.

## The fix

A scoped miss retries **unscoped** and states that the filter was dropped:

```
resource "secretsmanager" matched no CloudTrail events — ResourceName is an exact match on
the full AWS resource name or ARN (e.g. a secret's full path "apps/team/name"), not a service
or substring. Showing ALL mutating events in the window instead:
```

The banner is not optional: silently widening a query the model asked to narrow would be worse than the dead end, because the model would attribute unrelated events to its filter.

The tool description now also says what `resource` must be, and that **omitting it is the right move when the exact identifier is unknown** — the case that caused this.

## Tests

`exactMatchCloud` models CloudTrail's real semantics (only the exact name matches; unscoped returns everything) and records every `Selector.Name` requested:

| case | assertion |
|---|---|
| scoped miss | the `DeleteSecret` survives, the banner explains why, exactly two lookups (scoped then unscoped) |
| scope that matches | **not** widened, exactly one lookup |
| genuinely quiet window | still reports "no mutating AWS events" — an empty result is never dressed up as a widened one |

Mutation-tested: disabling the retry, and widening without the banner, each fail.

## Not addressed here

The same investigation could not read `pod_logs` in `apps` (allowlist is `[flux-system]`) — that is [#415](https://github.com/Smana/runlore/pull/415), which makes the denial legible rather than granting access.
