### PR TITLE
feat(demo): --notify delivers the replayed findings to real notifiers

### DIFF
--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -77,6 +77,7 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 	cfgPath := fs.String("config", "", "optional runlore.yaml; when omitted the demo uses a zero-config default model")
 	offline := fs.String("offline", "", "replay a recorded transcript instead of calling a model — no API key, no network (use \"default\" for the shipped one)")
 	record := fs.String("record", "", "record this run's model turns to a transcript file for later --offline replay")
+	deliver := fs.Bool("notify", false, "also DELIVER the findings through the notifiers in --config (Slack, Matrix, webhook), not just print them")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -198,6 +199,28 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 		return fmt.Errorf("the loop produced no findings")
 	}
 	demoPrintf(out, "\n== submit_findings ==\n%s\n", notify.Format(*result))
+
+	// --notify sends the SAME findings through the real notifiers. The demo already
+	// runs the real loop over recorded evidence; this makes the delivered artifact
+	// real too, so a Slack card can be produced without a cluster, an incident, or
+	// an API key.
+	//
+	// It is opt-in because the demo's whole promise is that it touches nothing.
+	// Posting to a webhook is the one thing here that leaves the machine.
+	if *deliver {
+		n, nerr := BuildNotifier(cfg, log)
+		if nerr != nil {
+			return fmt.Errorf("build notifiers for --notify: %w", nerr)
+		}
+		if n.Len() == 0 {
+			return fmt.Errorf("--notify needs at least one notifier configured in --config " +
+				"(notify.slack / notify.matrix / notify.webhook); none found")
+		}
+		if derr := n.Deliver(ctx, *result); derr != nil {
+			return fmt.Errorf("deliver findings: %w", derr)
+		}
+		demoPrintf(out, "\ndelivered to %d notifier(s)\n", n.Len())
+	}
 
 	if recorder != nil {
 		if err := recorder.Write(*record, time.Now().UTC().Format(time.RFC3339)); err != nil {

--- a/internal/app/demo_test.go
+++ b/internal/app/demo_test.go
@@ -5,6 +5,8 @@ package app
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -192,5 +194,40 @@ func TestShippedTranscriptToolsStillExist(t *testing.T) {
 		if !have[name] {
 			t.Errorf("shipped transcript calls tool %q, which no longer exists — re-record with `lore demo investigate --record %s`", name, demoDefaultTranscript)
 		}
+	}
+}
+
+// TestDemoNotifyRequiresAConfiguredNotifier pins --notify's failure mode.
+//
+// The demo's promise is that it touches nothing: no cluster, no API key, no
+// network. --notify is the single exception, so it must be impossible to ask for
+// delivery and silently get none — a demo that prints "done" while posting
+// nowhere is worse than one that refuses.
+func TestDemoNotifyRequiresAConfiguredNotifier(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "runlore.yaml")
+	// A model is configured but NO notify block.
+	if err := os.WriteFile(cfgPath, []byte(`
+model:
+  provider: openai
+  base_url: http://unused.invalid/v1
+  model: replay
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errOut bytes.Buffer
+	err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump",
+		"--offline", "testdata/demo-transcript.json",
+		"--config", cfgPath,
+		"--notify",
+	}, &out, &errOut, nil)
+	if err == nil {
+		t.Fatal("--notify with no notifier configured must fail, not silently deliver nothing")
+	}
+	if !strings.Contains(err.Error(), "notify") {
+		t.Errorf("the error must name what is missing so the user can fix it: %v", err)
 	}
 }


### PR DESCRIPTION
## What

```bash
lore demo investigate --offline default --config demo.yaml --notify
```

Sends the replayed investigation's findings through the configured notifiers, instead of only printing them.

## Why

The demo already runs the **real** loop over recorded evidence and renders a genuine verdict — but only to stdout via `notify.Format`. There was no way to see what RunLore actually posts to Slack without a cluster, a live incident, and an API key.

That gap had a real cost. Producing a Slack screenshot for the docs meant **injecting a fault into a live cluster** — today that meant scheduling an AWS Secrets Manager secret for deletion to break an ExternalSecret, twice, then restoring it. With `--notify`, the same card comes from a recorded transcript: no cluster, no incident, no key, and repeatable forever.

## Behaviour

Opt-in, deliberately. The demo's promise is that it touches nothing; posting to a webhook is the one thing here that leaves the machine.

It **fails loudly** when `--notify` is given with no notifier configured:

```
--notify needs at least one notifier configured in --config
(notify.slack / notify.matrix / notify.webhook); none found
```

A demo that prints success while posting nowhere is worse than one that refuses.

## Verified end to end

Against a real Slack workspace, replaying the shipped `harbor-chart-bump` transcript:

```
== submit_findings ==
… Resource: Deployment apps/harbor-core
✓ verified
7 model calls · 14034 in / 1537 out tokens (79% cached)

delivered to 1 notifier(s)
```

A full incident card arrived in Slack — same renderer, same blocks, same escaping as production.

## Test

`TestDemoNotifyRequiresAConfiguredNotifier` drives the real entrypoint through the existing writer seam with a model-but-no-notify config, and asserts it errors and names what is missing.

Mutation-tested: turning the empty-notifier case into a silent `return nil` fails the test.

## Follow-on

This is the right way to produce the assets for #413 (the screenshot-freshness guard) and the homepage demo section — both of which currently have no source of a card except a live incident.
