### PR TITLE
feat(demo): --catalog shows the instant-recall half of the loop

### DIFF
--- a/examples/demo/catalog/harbor-core-migration-deadlock.md
+++ b/examples/demo/catalog/harbor-core-migration-deadlock.md
@@ -1,0 +1,37 @@
+---
+type: Incident
+title: harbor-core readiness fails after a chart bump — stuck database migration
+description: A Harbor chart upgrade runs a schema migration that deadlocks; harbor-core never passes readiness and the gateway returns 5xx until the migration lock is cleared.
+resource: apps/harbor-core
+tags: [harbor, helmrelease, migration, readiness, database, gitops]
+timestamp: 2026-06-28T09:14:00Z
+last_validated: 2026-07-19T08:02:00Z
+---
+
+# Symptom
+
+`HarborProbeFailure` fires for `apps/harbor-core`: readiness probes fail shortly after a
+HelmRelease chart bump. The pod stays Running — it never crash-loops — so pod status alone
+looks healthy while every request through the gateway returns 5xx.
+
+# Cause
+
+The new chart version ships a schema migration that acquires an exclusive lock and does not
+release it. `harbor-core` blocks on the migration at startup, so `/readyz` never succeeds.
+The pod is up, the container is fine, and the fault is entirely in the database session.
+
+# Resolution
+
+1. Confirm the migration is the blocker — `harbor-core` logs stop at the migration step with no
+   subsequent progress line.
+2. Clear the stale migration lock in the Harbor database.
+3. If the lock cannot be cleared safely, roll the HelmRelease back to the previous chart
+   revision; readiness recovers within a minute and the migration can be re-run off-peak.
+
+Rolling back is the reversible option and the one to prefer while the incident is live.
+
+# Notes
+
+Recurs on every chart bump that carries a migration. The tell is a **Running but never Ready**
+pod combined with a HelmRelease revision change in the same window — restarts stay at zero
+throughout, which is what distinguishes this from an ordinary crash-loop.

--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/catalog"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/eval"
 	"github.com/Smana/runlore/internal/investigate"
@@ -40,6 +41,16 @@ const (
 // user sees genuine model output with no key and no network. Re-record it with
 // `lore demo investigate --record <path>`.
 const demoDefaultTranscript = "examples/demo/harbor-chart-bump.transcript.json"
+
+// demoDefaultCatalog is the shipped one-entry knowledge catalog `--catalog default`
+// loads. It holds the CURATED result of the harbor-chart-bump investigation, so
+// running that same scenario twice shows the loop closing: the first run reasons its
+// way to the cause, the second is answered from the entry the first one produced.
+//
+// That second run is the only offline way to see an INSTANT RECALL card. Recall
+// short-circuits before the model is ever called, so unlike a full investigation it
+// cannot be captured in a transcript — there are no model turns to record.
+const demoDefaultCatalog = "examples/demo/catalog"
 
 // RunDemo dispatches the `lore demo <subcommand>` family. Today only `investigate` is
 // wired: a zero-cluster, full-loop demonstration of the real investigator against fake
@@ -78,6 +89,7 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 	offline := fs.String("offline", "", "replay a recorded transcript instead of calling a model — no API key, no network (use \"default\" for the shipped one)")
 	record := fs.String("record", "", "record this run's model turns to a transcript file for later --offline replay")
 	deliver := fs.Bool("notify", false, "also DELIVER the findings through the notifiers in --config (Slack, Matrix, webhook), not just print them")
+	catalogDir := fs.String("catalog", "", "knowledge-catalog directory to consult with INSTANT RECALL before investigating (use \"default\" for the shipped demo entry)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -175,11 +187,56 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 		tools = append(tools, tracingTool{inner: t, out: out})
 	}
 
+	// --catalog consults the knowledge base before investigating, through the SAME
+	// Recall gate production uses. When an entry matches strongly enough the loop
+	// short-circuits and the delivered card is a recall card — the "answered in
+	// seconds" half of the product, which no transcript can demonstrate.
+	var recall *investigate.Recall
+	if *catalogDir != "" {
+		dir := *catalogDir
+		if dir == "default" {
+			dir = demoDefaultCatalog
+		}
+		cat, cerr := catalog.New(dir)
+		if cerr != nil {
+			return fmt.Errorf("load demo catalog %s: %w", dir, cerr)
+		}
+		// Gate values, stated plainly because they are NOT production's.
+		//
+		// Production gates instant recall on the RERANKER's calibrated confidence; the
+		// BM25 SoloFloor (default 4.0) is the legacy fallback and is not reachable by
+		// raw BM25, whose scores run ~0.1-1.2 (see config.InstantRecall). The reranker
+		// needs a model, and this demo's whole point is that it needs neither model nor
+		// key — so an offline recall demo has to gate on BM25 at a reachable value.
+		//
+		// The alternative was to leave the thresholds at the zero-config defaults,
+		// which are 0 — meaning ANY hit fires. That is worse: it looks like a gate and
+		// is not one. These are explicit, and the demo prints them, so nobody mistakes
+		// this for the production bar.
+		const demoMinScore, demoSoloFloor = 0.02, 0.02
+		recall = &investigate.Recall{
+			Catalog:   cat,
+			MinScore:  demoMinScore,
+			SoloFloor: demoSoloFloor,
+			// Structural agreement is NOT relaxed: the entry must still name the
+			// incident's workload, which is the gate that stops a generic entry
+			// answering a specific incident. That one is production's.
+			RequireWorkloadMatch: cfg.Catalog.InstantRecall.RequireWorkloadMatch,
+			MarginGap:            cfg.Catalog.InstantRecall.MarginGap,
+			Log:                  log,
+		}
+		demoPrintf(out, "knowledge catalog: %d entr(ies) from %s\n", cat.Len(), dir)
+		demoPrintf(out, "   recall gate: BM25 min_score=%.2f solo_floor=%.2f — DEMO values, not production's.\n"+
+			"   production gates on the reranker's calibrated confidence, which needs a model.\n",
+			demoMinScore, demoSoloFloor)
+	}
+
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
 		Model:         model,
 		VerifyModel:   verifyModel,
 		Tools:         tools,
+		Recall:        recall,
 		Log:           log,
 		Verify:        true,
 		ModelProvider: cfg.Model.Provider,

--- a/internal/app/demo_test.go
+++ b/internal/app/demo_test.go
@@ -231,3 +231,35 @@ model:
 		t.Errorf("the error must name what is missing so the user can fix it: %v", err)
 	}
 }
+
+// TestDemoCatalogWiresRecall pins that --catalog actually consults the knowledge
+// base through the real Recall gate.
+//
+// The shipped entry names the harbor-chart-bump scenario's workload, so recall
+// reaches its decision — which the demo prints. What it must NOT do is quietly run
+// a full investigation while claiming a catalog was loaded.
+func TestDemoCatalogWiresRecall(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump",
+		"--offline", "testdata/demo-transcript.json",
+		"--catalog", "../../examples/demo/catalog",
+	}, &out, &errOut, nil)
+	if err != nil {
+		t.Fatalf("demo with --catalog: %v\nstderr:\n%s", err, errOut.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "knowledge catalog: 1 entr") {
+		t.Errorf("the shipped demo catalog must load exactly one entry:\n%s", got)
+	}
+	// The demo's recall gate is NOT production's, and saying so is the point — a
+	// reader must not mistake a permissive BM25 floor for the real bar.
+	if !strings.Contains(got, "DEMO values, not production's") {
+		t.Errorf("the demo must disclose that its recall gate is not production's:\n%s", got)
+	}
+	// The gate itself must have been consulted, not skipped.
+	if !strings.Contains(errOut.String(), "instant recall") {
+		t.Errorf("recall was never consulted despite --catalog:\n%s", errOut.String())
+	}
+}


### PR DESCRIPTION
Follow-on to #417. That made the demo able to *deliver* a card; this makes it able to produce the **other** card.

## What

```bash
lore demo investigate --scenario harbor-chart-bump --offline default              # reason it out
lore demo investigate --scenario harbor-chart-bump --catalog default --notify     # recall it
```

`--catalog default` loads a shipped one-entry catalog holding the **curated result** of the harbor-chart-bump investigation. Running the same scenario twice shows the loop closing — which is the product thesis and had no offline demonstration at all.

Delivered card:

```
⚡ Instant recall — answered from your knowledge base, no investigation was run
   Known cause: … a schema migration acquires an exclusive lock and does not release it …
   Validated resolution: … clear the stale lock, or roll the HelmRelease back …
   Knowledge-base entry: harbor-core-migration-deadlock.md
✓ verified
1 model calls · 617 in / 1216 out tokens
```

**1 model call against 7** for the full loop — the "answered in seconds" claim, concrete.

## Two things stated rather than hidden

**The recall gate is not production's.** Production gates on the reranker's *calibrated confidence*; the BM25 `SoloFloor` (default 4.0) is a legacy fallback that raw BM25 — scoring ~0.1–1.2 — cannot reach, and the reranker needs a model. So the demo gates on BM25 at an explicit value **which it prints**:

```
recall gate: BM25 min_score=0.02 solo_floor=0.02 — DEMO values, not production's.
production gates on the reranker's calibrated confidence, which needs a model.
```

The alternative was leaving the zero-config defaults, which are `0` — meaning *any* hit fires. That is worse: it looks like a gate and is not one.

**Structural workload agreement is NOT relaxed.** The entry must still name the incident's workload. That gate is production's, and it is the one that stops a generic entry answering a specific incident.

## A recall card cannot be produced fully offline — by design

Attempting it surfaced the trust gate doing its job:

```
instant recall (catalog hit; skipping the loop)   confidence=0.90
verify pass returned no usable verdicts
instant recall verify unavailable; running full investigation
  instead of delivering it unreviewed
```

The adversarial verify pass is a real model call. With no transcript turn to replay it, the fail-closed gate from #395 refuses to serve an unreviewed cached answer. Disabling `Verify` would have produced a card the product would never actually send, so the demo needs a key for that one call.

## On the confidence reading

The delivered card reads **35%**, not a flattering number. That is honest output, not a bug: a one-entry corpus makes BM25 degenerate (IDF has nothing to discriminate against), and the verify pass is appropriately skeptical of a thin recall. Raising it would mean faking the catalog or weakening verify.

Worth knowing before using this card as a marketing asset — the *shape* is exactly production's, the confidence number is a demo artifact.

## Tests

`TestDemoCatalogWiresRecall` asserts the entry loads, the gate disclosure prints, and recall is genuinely consulted. Mutation-tested: dropping the disclosure fails; unwiring `Recall` from the loop fails.
