### PR TITLE
fix(demo): scenarios carry an alert title, so a recalled card is not slug-titled

### DIFF
--- a/examples/scenarios/harbor-chart-bump.yaml
+++ b/examples/scenarios/harbor-chart-bump.yaml
@@ -4,6 +4,11 @@
 # loop can be watched end to end. Reuses the eval Case shape:
 #   lore demo investigate --scenario harbor-chart-bump
 name: harbor-chart-bump
+# The title a real trigger would carry. `name` is a slug for --scenario and report
+# labels; a full investigation replaces it with a title the model writes, but instant
+# recall short-circuits before the model, so without this the recalled card is titled
+# "harbor-chart-bump" where production would read the alertname.
+alert_title: HarborProbeFailure
 prompt: |
   HarborProbeFailure (critical, prod, namespace apps): harbor-core readiness probes
   are failing and the Service is returning 503s.

--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -303,10 +303,10 @@ func pickScenario(cases []eval.Case, id string) (eval.Case, error) {
 	}
 	var have []string
 	for _, c := range cases {
-		if c.DisplayName() == id {
+		if c.Name == id {
 			return c, nil
 		}
-		have = append(have, c.DisplayName())
+		have = append(have, c.Name)
 	}
 	return eval.Case{}, fmt.Errorf("scenario %q not found; available: %s", id, strings.Join(have, ", "))
 }

--- a/internal/app/demo_test.go
+++ b/internal/app/demo_test.go
@@ -263,3 +263,33 @@ func TestDemoCatalogWiresRecall(t *testing.T) {
 		t.Errorf("recall was never consulted despite --catalog:\n%s", errOut.String())
 	}
 }
+
+// TestDemoScenarioSelectorIsTheSlug pins --scenario to the case's name, not its
+// display title.
+//
+// alert_title exists so a recalled card reads "HarborProbeFailure" rather than a
+// file slug — recall short-circuits before the model, so it delivers the REQUEST
+// title verbatim. Routing DisplayName into the selector as well broke
+// `--scenario harbor-chart-bump` outright: the lookup started demanding the alert
+// title, and the error even advertised it as the available id.
+func TestDemoScenarioSelectorIsTheSlug(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump", // the slug, NOT "HarborProbeFailure"
+		"--offline", "testdata/demo-transcript.json",
+	}, &out, &errOut, nil)
+	if err != nil {
+		t.Fatalf("--scenario must select by slug: %v\nstderr:\n%s", err, errOut.String())
+	}
+	// And the incident the loop is handed carries the alert title, so a recalled
+	// card is labelled the way a real trigger would be.
+	//
+	// Anchored to the demo's own header, which is printed FROM DisplayName. A bare
+	// substring check passes vacuously: the scenario's prompt already contains
+	// "HarborProbeFailure", so it held even with alert_title removed entirely.
+	if !strings.Contains(out.String(), `investigating "HarborProbeFailure"`) {
+		t.Errorf("the request title must be the alert_title, or a recalled card is "+
+			"labelled with a file slug:\n%s", out.String())
+	}
+}

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -19,10 +19,20 @@ import (
 
 // Case is one replayable incident.
 type Case struct {
-	Name     string            `yaml:"name"`
-	Prompt   string            `yaml:"prompt"` // the incident description (seeds the loop)
-	Tools    map[string]string `yaml:"tools"`  // tool name -> recorded evidence the tool returns
-	Expected Expected          `yaml:"expected"`
+	Name string `yaml:"name"`
+	// AlertTitle is the incident title a REAL trigger would carry (e.g. the
+	// Alertmanager alertname). Optional; DisplayName falls back to Name.
+	//
+	// It matters because Name is a file-ish slug and the loop uses DisplayName as the
+	// Request title. A full investigation overwrites that with a title the model
+	// writes, so the slug never shows — but INSTANT RECALL short-circuits before the
+	// model runs, so it delivers a card titled "harbor-chart-bump" where production
+	// would read "HarborProbeFailure". Same reason recall's query is weaker: the
+	// slug is most of what buildRecallQuery gets.
+	AlertTitle string            `yaml:"alert_title,omitempty"`
+	Prompt     string            `yaml:"prompt"` // the incident description (seeds the loop)
+	Tools      map[string]string `yaml:"tools"`  // tool name -> recorded evidence the tool returns
+	Expected   Expected          `yaml:"expected"`
 	// GroundTruth is optional live-scenario ground truth carried into replay. When
 	// present it unlocks the richer scoring the model-comparison benchmark reports:
 	// data-source coverage (expected_sources) and blind LLM-judge rubric grading

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -149,8 +149,15 @@ func (c Case) FakeTools() []investigate.Tool {
 // unexported fields.
 func (c Case) Symptom() string { return c.Prompt }
 
-// DisplayName returns the case's name for demo/report labeling.
-func (c Case) DisplayName() string { return c.Name }
+// DisplayName returns the incident title for demo/report labeling: the case's
+// alert_title when set, else its name. See Case.AlertTitle for why the distinction
+// is load-bearing on the instant-recall path.
+func (c Case) DisplayName() string {
+	if c.AlertTitle != "" {
+		return c.AlertTitle
+	}
+	return c.Name
+}
 
 // AffectedWorkload returns the case's affected workload (zero when unset), so the demo
 // can seed the Request.Workload exactly as runOne does.


### PR DESCRIPTION
## The bug

A full investigation overwrites the request title with one the model writes, so the scenario slug never surfaced. **Instant recall short-circuits before the model**, so it delivers the request title verbatim:

```
🔍 harbor-chart-bump        ← was
🔍 HarborProbeFailure       ← now
```

The slug was only ever visible on the recall path — the path nothing exercised until `--catalog` landed in #418.

## The change

`Case` gains an optional `alert_title`; `DisplayName` prefers it and falls back to `Name`, so every existing scenario is unaffected. It also improves the recall QUERY, since `buildRecallQuery` feeds on the request title.

## Two mistakes I made writing this

Both caught by mutation testing, both worth recording.

**Routing `DisplayName()` into the scenario lookup broke `--scenario`.** `harbor-chart-bump` stopped resolving, and the error message helpfully advertised `HarborProbeFailure` as the available id. The slug stays the selector; `alert_title` is presentation only.

**The regression test was vacuous.** It asserted the output contained `HarborProbeFailure` — which the scenario's own `prompt` already contains (`incident: HarborProbeFailure (critical, prod…)`), so it passed with `alert_title` deleted entirely. It now anchors on `investigating \"HarborProbeFailure\"`, the line printed from `DisplayName`.

Both mutations now fail:

| mutation | result |
|---|---|
| route `DisplayName()` back into the selector | caught |
| drop `alert_title` from `DisplayName` | caught |

## Verified

Delivered to Slack: `🔍 HarborProbeFailure`, ⚡ recall banner, 1 model call against 7 for the full loop.

`go build` · `go test ./...` · `gofmt` · `golangci-lint` 0 issues.