### PR TITLE
docs: preserve the improvement-report specs and plans

### DIFF
--- a/docs/superpowers/plans/2026-08-02-s1-funnel-demo-cli.md
+++ b/docs/superpowers/plans/2026-08-02-s1-funnel-demo-cli.md
@@ -1,0 +1,1441 @@
+# S1 — Funnel: keyless demo + CLI front door — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A stranger with no API key and no cluster sees a real RunLore root cause in under a minute, and can then run `lore investigate` against their own cluster without writing a config file.
+
+**Architecture:** A new `internal/model/replay` package implements `providers.ModelProvider` by replaying a recorded JSON transcript of assistant turns. `lore demo investigate --offline` wires it into the *existing* demo path — real fake providers, real loop, real `notify.Format` card — so only the model is canned. `--record` captures a fresh transcript from a live model. Separately, `lore investigate` gains a zero-config path that synthesizes a model config from environment variables when no `runlore.yaml` exists, and degrades gracefully when sources are absent.
+
+**Tech Stack:** Go 1.x (see `go.mod`), stdlib only for the new package (`encoding/json`, `sync`), POSIX `sh` for `install.sh`, Hugo/Hextra for the docs page.
+
+**Spec:** [`docs/superpowers/specs/2026-08-02-s1-funnel-demo-cli-design.md`](../specs/2026-08-02-s1-funnel-demo-cli-design.md)
+
+## Global Constraints
+
+- Every new `.go` file starts with `// SPDX-License-Identifier: Apache-2.0`.
+- `golangci-lint run` must pass; the repo's config is `.golangci.yml` (revive package-comments and staticcheck are enabled — every new package needs a package comment).
+- No new third-party dependencies.
+- Credentials are read by env-var indirection only, never inlined, never logged.
+- Errors are lower-case, no trailing punctuation, wrapped with `%w` where a cause exists.
+- Comments explain *why*, matching the density of surrounding code — this codebase comments heavily and deliberately.
+- Commit messages follow Conventional Commits (`feat:`, `fix:`, `docs:`, `test:`, `chore:`); release-please parses them.
+- **Never** add co-author trailers or AI attribution to commits or PRs.
+
+---
+
+### Task 1: The replay model provider
+
+**Files:**
+- Create: `internal/model/replay/replay.go`
+- Create: `internal/model/replay/replay_test.go`
+- Create: `internal/model/replay/testdata/two-turns.json`
+
+**Interfaces:**
+- Consumes: `providers.ModelProvider`, `providers.CompletionResponse`, `providers.ToolCall`, `providers.Usage` (`internal/providers/providers.go:495`, `:822`, `:883`, `:870`).
+- Produces:
+  - `type Transcript struct { Version int; Scenario string; RecordedAt string; RecordedWith Recorded; Turns []Turn }`
+  - `type Recorded struct { Provider string; Model string }`
+  - `type Turn struct { Text string; ToolCalls []providers.ToolCall; Usage providers.Usage }`
+  - `func Load(path string) (*Transcript, error)`
+  - `func New(t *Transcript) *Provider`
+  - `func (p *Provider) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error)`
+  - `func (t *Transcript) ToolNames() []string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/model/replay/testdata/two-turns.json`:
+
+```json
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T09:14:00Z",
+  "recorded_with": {"provider": "anthropic", "model": "claude-sonnet-5"},
+  "turns": [
+    {
+      "text": "",
+      "tool_calls": [{"id": "1", "name": "what_changed", "args": "{\"namespace\":\"harbor\"}"}],
+      "usage": {"input_tokens": 4211, "output_tokens": 96}
+    },
+    {
+      "text": "",
+      "tool_calls": [{"id": "2", "name": "submit_findings", "args": "{\"confidence\":0.86}"}],
+      "usage": {"input_tokens": 5310, "output_tokens": 402}
+    }
+  ]
+}
+```
+
+Create `internal/model/replay/replay_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package replay_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/model/replay"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestReplayReturnsTurnsInOrder is the core contract: the provider ignores the
+// request and hands back the recorded assistant turns in the order they were
+// recorded, usage included (the demo's cost footer reads it).
+func TestReplayReturnsTurnsInOrder(t *testing.T) {
+	tr, err := replay.Load("testdata/two-turns.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p := replay.New(tr)
+
+	first, err := p.Complete(context.Background(), providers.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if len(first.ToolCalls) != 1 || first.ToolCalls[0].Name != "what_changed" {
+		t.Fatalf("turn 1 tool calls = %+v, want one what_changed", first.ToolCalls)
+	}
+	if first.Usage.InputTokens != 4211 || first.Usage.OutputTokens != 96 {
+		t.Errorf("turn 1 usage = %+v, want 4211 in / 96 out", first.Usage)
+	}
+
+	second, err := p.Complete(context.Background(), providers.CompletionRequest{})
+	if err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	if len(second.ToolCalls) != 1 || second.ToolCalls[0].Name != "submit_findings" {
+		t.Fatalf("turn 2 tool calls = %+v, want one submit_findings", second.ToolCalls)
+	}
+}
+
+// TestReplayExhaustionIsLoud: running past the recorded turns must fail with an
+// actionable error naming the fix. Returning an empty completion would produce a
+// demo that silently ends with no findings — the exact failure mode a first-time
+// user cannot diagnose.
+func TestReplayExhaustionIsLoud(t *testing.T) {
+	tr, err := replay.Load("testdata/two-turns.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	p := replay.New(tr)
+	for i := 0; i < 2; i++ {
+		if _, err := p.Complete(context.Background(), providers.CompletionRequest{}); err != nil {
+			t.Fatalf("turn %d: %v", i+1, err)
+		}
+	}
+	_, err = p.Complete(context.Background(), providers.CompletionRequest{})
+	if err == nil {
+		t.Fatal("expected an error past the end of the transcript")
+	}
+	if !strings.Contains(err.Error(), "exhausted") || !strings.Contains(err.Error(), "--record") {
+		t.Errorf("error must say it is exhausted and how to fix it, got: %v", err)
+	}
+}
+
+// TestToolNames exposes the recorded tool names so the demo wiring can assert they
+// all still exist (the drift guard in Task 3).
+func TestToolNames(t *testing.T) {
+	tr, err := replay.Load("testdata/two-turns.json")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := tr.ToolNames()
+	want := map[string]bool{"what_changed": true, "submit_findings": true}
+	if len(got) != len(want) {
+		t.Fatalf("ToolNames() = %v, want %d distinct names", got, len(want))
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Errorf("unexpected tool name %q", n)
+		}
+	}
+}
+
+// TestLoadRejectsEmptyTranscript: an empty turns list would fail later, deep in the
+// loop, with a confusing message. Fail at load with a clear one instead.
+func TestLoadRejectsEmptyTranscript(t *testing.T) {
+	if _, err := replay.Load("testdata/does-not-exist.json"); err == nil {
+		t.Fatal("expected an error for a missing transcript")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/model/replay/ -v`
+Expected: FAIL — `no required module provides package github.com/Smana/runlore/internal/model/replay`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/model/replay/replay.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+// Package replay serves a recorded LLM transcript as a providers.ModelProvider.
+//
+// It exists so `lore demo investigate --offline` can show a REAL root cause with no
+// API key and no network: the model turns are replayed from a transcript recorded
+// once against a live model, while the tools, the investigation loop and the
+// rendered verdict card remain the production code paths. Only the model is canned.
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Transcript is a recorded investigation: the ordered assistant turns a live model
+// produced for one scenario, plus the provenance a reader needs to judge them.
+type Transcript struct {
+	Version      int      `json:"version"`
+	Scenario     string   `json:"scenario"`
+	RecordedAt   string   `json:"recorded_at"`
+	RecordedWith Recorded `json:"recorded_with"`
+	Turns        []Turn   `json:"turns"`
+}
+
+// Recorded names the model that produced the transcript. It is rendered with the
+// demo output so a replayed card never passes itself off as a fresh live run.
+type Recorded struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// Turn is one recorded assistant completion.
+type Turn struct {
+	Text      string               `json:"text,omitempty"`
+	ToolCalls []providers.ToolCall `json:"tool_calls,omitempty"`
+	Usage     providers.Usage      `json:"usage,omitzero"`
+}
+
+// Load reads and validates a transcript. A missing file, malformed JSON, or an
+// empty turn list fails here — where the error can name the file — rather than
+// midway through a demo the user is watching.
+func Load(path string) (*Transcript, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: operator-supplied transcript path
+	if err != nil {
+		return nil, fmt.Errorf("read transcript: %w", err)
+	}
+	var t Transcript
+	if err := json.Unmarshal(data, &t); err != nil {
+		return nil, fmt.Errorf("parse transcript %s: %w", path, err)
+	}
+	if len(t.Turns) == 0 {
+		return nil, fmt.Errorf("transcript %s has no turns", path)
+	}
+	return &t, nil
+}
+
+// ToolNames returns the distinct tool names the transcript calls, in first-seen
+// order. The demo wiring asserts every one still exists, so renaming a tool fails
+// CI instead of shipping a broken demo.
+func (t *Transcript) ToolNames() []string {
+	seen := map[string]bool{}
+	var names []string
+	for _, turn := range t.Turns {
+		for _, tc := range turn.ToolCalls {
+			if !seen[tc.Name] {
+				seen[tc.Name] = true
+				names = append(names, tc.Name)
+			}
+		}
+	}
+	return names
+}
+
+// Provider replays a transcript's turns in order. Safe for concurrent use because
+// the loop may call from more than one goroutine, though today it does not.
+type Provider struct {
+	t  *Transcript
+	mu sync.Mutex
+	i  int
+}
+
+// New wraps a loaded transcript as a model provider.
+func New(t *Transcript) *Provider { return &Provider{t: t} }
+
+// Transcript exposes the replayed transcript so callers can render its provenance.
+func (p *Provider) Transcript() *Transcript { return p.t }
+
+// Complete returns the next recorded turn, ignoring the request entirely — the
+// transcript is a fixed script, not a function of the prompt.
+//
+// Running past the end is an ERROR, deliberately. The loop asking for one more turn
+// than was recorded means the fixture no longer matches the code driving it, and the
+// only correct response is to say so and name the fix.
+func (p *Provider) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.i >= len(p.t.Turns) {
+		return providers.CompletionResponse{}, fmt.Errorf(
+			"transcript exhausted after %d turns (the loop asked for another) — re-record with `lore demo investigate --record <path>`",
+			len(p.t.Turns))
+	}
+	turn := p.t.Turns[p.i]
+	p.i++
+	return providers.CompletionResponse{
+		Text:      turn.Text,
+		ToolCalls: turn.ToolCalls,
+		Usage:     turn.Usage,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/model/replay/ -v`
+Expected: PASS — all four tests.
+
+If `omitzero` is rejected by the toolchain's Go version, use `json:"usage"` instead — the field is always written by the recorder, so omission is not needed.
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run ./internal/model/replay/...`
+Expected: no issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/model/replay/
+git commit -m "feat(demo): replay a recorded LLM transcript as a model provider"
+```
+
+---
+
+### Task 2: The recorder
+
+**Files:**
+- Create: `internal/model/replay/record.go`
+- Create: `internal/model/replay/record_test.go`
+
+**Interfaces:**
+- Consumes: `replay.Transcript`, `replay.Turn`, `providers.ModelProvider` (Task 1).
+- Produces:
+  - `func NewRecorder(inner providers.ModelProvider, meta Recorded, scenario string) *Recorder`
+  - `func (r *Recorder) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error)`
+  - `func (r *Recorder) Write(path, recordedAt string) error`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/model/replay/record_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package replay_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/model/replay"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeModel returns a fixed sequence of completions, standing in for a live model
+// during the recorder test (no network, no key).
+type fakeModel struct {
+	responses []providers.CompletionResponse
+	i         int
+}
+
+func (f *fakeModel) Complete(context.Context, providers.CompletionRequest) (providers.CompletionResponse, error) {
+	r := f.responses[f.i]
+	f.i++
+	return r, nil
+}
+
+// TestRecordRoundTrip: what the recorder writes must replay identically. This is the
+// guarantee that makes `--record` trustworthy — a re-recorded fixture behaves exactly
+// like the live run it captured.
+func TestRecordRoundTrip(t *testing.T) {
+	live := &fakeModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: "what_changed", Args: `{"namespace":"harbor"}`}},
+			Usage: providers.Usage{InputTokens: 100, OutputTokens: 20}},
+		{ToolCalls: []providers.ToolCall{{ID: "2", Name: "submit_findings", Args: `{"confidence":0.9}`}},
+			Usage: providers.Usage{InputTokens: 300, OutputTokens: 80}},
+	}}
+
+	rec := replay.NewRecorder(live, replay.Recorded{Provider: "anthropic", Model: "claude-sonnet-5"}, "harbor-chart-bump")
+	for i := 0; i < 2; i++ {
+		if _, err := rec.Complete(context.Background(), providers.CompletionRequest{}); err != nil {
+			t.Fatalf("record turn %d: %v", i+1, err)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "transcript.json")
+	if err := rec.Write(path, "2026-08-02T09:14:00Z"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	tr, err := replay.Load(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if tr.Scenario != "harbor-chart-bump" || tr.RecordedWith.Model != "claude-sonnet-5" {
+		t.Errorf("provenance lost: %+v", tr)
+	}
+	if len(tr.Turns) != 2 {
+		t.Fatalf("turns = %d, want 2", len(tr.Turns))
+	}
+
+	p := replay.New(tr)
+	for i, want := range []string{"what_changed", "submit_findings"} {
+		got, err := p.Complete(context.Background(), providers.CompletionRequest{})
+		if err != nil {
+			t.Fatalf("replay turn %d: %v", i+1, err)
+		}
+		if got.ToolCalls[0].Name != want {
+			t.Errorf("replay turn %d = %q, want %q", i+1, got.ToolCalls[0].Name, want)
+		}
+	}
+}
+
+// TestWriteRefusesEmpty: writing a transcript with no captured turns would ship a
+// fixture that breaks the demo on first use. Fail at write time instead.
+func TestWriteRefusesEmpty(t *testing.T) {
+	rec := replay.NewRecorder(&fakeModel{}, replay.Recorded{}, "none")
+	err := rec.Write(filepath.Join(t.TempDir(), "empty.json"), "2026-08-02T09:14:00Z")
+	if err == nil {
+		t.Fatal("expected an error writing a transcript with no turns")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/model/replay/ -run 'TestRecord|TestWrite' -v`
+Expected: FAIL — `undefined: replay.NewRecorder`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/model/replay/record.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Recorder decorates a live model, capturing every completion so the run can be
+// replayed later with no key. It is the only writer of transcripts — regenerating a
+// demo fixture is `--record`, never hand-editing JSON.
+type Recorder struct {
+	inner    providers.ModelProvider
+	meta     Recorded
+	scenario string
+
+	mu    sync.Mutex
+	turns []Turn
+}
+
+// NewRecorder wraps inner, tagging the capture with the model that produced it.
+func NewRecorder(inner providers.ModelProvider, meta Recorded, scenario string) *Recorder {
+	return &Recorder{inner: inner, meta: meta, scenario: scenario}
+}
+
+// Complete delegates and captures the response. A failed call is NOT captured: a
+// transcript must contain only turns that really happened, or replay would diverge
+// from the live run it claims to reproduce.
+func (r *Recorder) Complete(ctx context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	resp, err := r.inner.Complete(ctx, req)
+	if err != nil {
+		return resp, err
+	}
+	r.mu.Lock()
+	r.turns = append(r.turns, Turn{Text: resp.Text, ToolCalls: resp.ToolCalls, Usage: resp.Usage})
+	r.mu.Unlock()
+	return resp, nil
+}
+
+// Write serializes the captured turns to path. recordedAt is passed in rather than
+// read from the clock so callers stay testable.
+func (r *Recorder) Write(path, recordedAt string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.turns) == 0 {
+		return fmt.Errorf("nothing recorded — refusing to write an empty transcript to %s", path)
+	}
+	t := Transcript{
+		Version: 1, Scenario: r.scenario, RecordedAt: recordedAt,
+		RecordedWith: r.meta, Turns: r.turns,
+	}
+	data, err := json.MarshalIndent(t, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal transcript: %w", err)
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/model/replay/ -v`
+Expected: PASS — all six tests.
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run ./internal/model/replay/...`
+Expected: no issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/model/replay/record.go internal/model/replay/record_test.go
+git commit -m "feat(demo): record a live investigation to a replayable transcript"
+```
+
+---
+
+### Task 3: Wire `--offline` and `--record` into `lore demo investigate`
+
+**Files:**
+- Modify: `internal/app/demo.go:56-149`
+- Create: `internal/app/testdata/demo-transcript.json`
+- Modify: `internal/app/demo_test.go` (append tests)
+
+**Interfaces:**
+- Consumes: `replay.Load`, `replay.New`, `replay.NewRecorder`, `replay.Recorded`, `(*Recorder).Write`, `(*Transcript).ToolNames` (Tasks 1–2); the existing `runDemoInvestigateWithModel` seam (`demo.go:64`).
+- Produces: `--offline <path>` and `--record <path>` flags on `lore demo investigate`; `demoDefaultTranscript` constant pointing at the shipped fixture.
+
+**Note on the verify pass:** `demo.go:107` already sets `verifyModel = nil` whenever a model is injected, so verify turns draw from the same model. Replay and record both inherit that, which is why one ordered channel is correct.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/app/testdata/demo-transcript.json` — a hand-authored fixture for the *unit* test only (Task 4 records the real one the demo ships with). The tool calls mirror the proven script in `demo_test.go:39`:
+
+```json
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T00:00:00Z",
+  "recorded_with": {"provider": "test", "model": "fixture"},
+  "turns": [
+    {"tool_calls": [{"id": "1", "name": "what_changed", "args": "{\"namespace\":\"apps\"}"}],
+     "usage": {"input_tokens": 4211, "output_tokens": 96}},
+    {"tool_calls": [{"id": "2", "name": "submit_findings", "args": "{\"confidence\":0.8,\"root_causes\":[{\"summary\":\"chart 1.15 bump enabled a DB migration on harbor-db that blocks harbor-core\",\"confidence\":0.8}]}"}],
+     "usage": {"input_tokens": 5310, "output_tokens": 402}},
+    {"tool_calls": [{"id": "3", "name": "submit_verdicts", "args": "{\"verdicts\":[{\"index\":0,\"verdict\":\"keep\",\"confidence\":0.8}]}"}],
+     "usage": {"input_tokens": 900, "output_tokens": 40}}
+  ]
+}
+```
+
+Append to `internal/app/demo_test.go`:
+
+```go
+// TestDemoOfflineThroughSeam is the funnel guarantee: with NO api key and NO network,
+// `demo investigate --offline` drives the real loop over the real fixture tools and
+// renders the real verdict card. This is what hack/demo.sh shows a first-time
+// visitor. It asserts through the same writer seam the existing end-to-end test uses.
+func TestDemoOfflineThroughSeam(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump",
+		"--offline", "testdata/demo-transcript.json",
+	}, &out, &errOut, nil)
+	if err != nil {
+		t.Fatalf("demo --offline: %v\nstderr:\n%s", err, errOut.String())
+	}
+	got := out.String()
+	for _, want := range []string{"→ what_changed", "submit_findings", "migration"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q, got:\n%s", want, got)
+		}
+	}
+	// Provenance: a replayed card must say it is replayed, and name the model.
+	if !strings.Contains(got, "recorded") {
+		t.Errorf("output must disclose that the model turns are recorded, got:\n%s", got)
+	}
+}
+
+// TestDemoOfflineNeedsNoAPIKey proves the key check is skipped on the offline path —
+// the whole point of --offline.
+func TestDemoOfflineNeedsNoAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	var out, errOut bytes.Buffer
+	if err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump",
+		"--offline", "testdata/demo-transcript.json",
+	}, &out, &errOut, nil); err != nil {
+		t.Fatalf("offline demo must not require a key, got: %v", err)
+	}
+}
+
+```
+
+Add the import `"github.com/Smana/runlore/internal/model/replay"` to `demo_test.go` if the tests reference it.
+
+> The drift guard over the **shipped** transcript lives in Task 4, alongside the fixture it reads. Every task here ends green.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/ -run 'TestDemoOffline|TestShippedTranscript' -v`
+Expected: FAIL — `flag provided but not defined: -offline`
+
+- [ ] **Step 3: Write the implementation**
+
+In `internal/app/demo.go`, add the constant beside the existing defaults:
+
+```go
+// demoDefaultTranscript is the recorded transcript `--offline` replays when no path
+// is given: a REAL investigation captured once against a live model, so a first-time
+// user sees genuine model output with no key and no network. Re-record it with
+// `lore demo investigate --record <path>`.
+const demoDefaultTranscript = "examples/demo/harbor-chart-bump.transcript.json"
+```
+
+Add the flags in `runDemoInvestigateWithModel` after the existing ones:
+
+```go
+	offline := fs.String("offline", "", "replay a recorded transcript instead of calling a model — no API key, no network (use \"default\" for the shipped one)")
+	record := fs.String("record", "", "record this run's model turns to a transcript file for later --offline replay")
+```
+
+Replace the model-resolution block (`demo.go:91-108`) with:
+
+```go
+	// Resolve the model. Three paths, in precedence order:
+	//   1. a test-injected model (the existing seam) — used verbatim;
+	//   2. --offline — replay a recorded transcript: no key, no network;
+	//   3. the live model built from config, optionally wrapped by --record.
+	//
+	// Paths 1 and 2 both answer the verify turns from the SAME model (verifyModel is
+	// nil), because a transcript is one ordered stream. --record forces the same
+	// shape, so what is recorded is exactly what will later replay.
+	verifyModel := BuildVerifyModel(cfg)
+	var transcript *replay.Transcript
+	var recorder *replay.Recorder
+	switch {
+	case model != nil:
+		verifyModel = nil // the injected model answers verify turns itself
+	case *offline != "":
+		path := *offline
+		if path == "default" {
+			path = demoDefaultTranscript
+		}
+		t, err := replay.Load(path)
+		if err != nil {
+			return err
+		}
+		transcript, model, verifyModel = t, replay.New(t), nil
+	default:
+		if apiKeyEnv != "" && os.Getenv(apiKeyEnv) == "" {
+			return fmt.Errorf("the demo needs a model API key: set %s to your key "+
+				"(or point --config at a runlore.yaml with a configured model, or run with "+
+				"--offline default to replay a recorded investigation with no key at all). "+
+				"Everything else runs against built-in fake providers — no cluster required", apiKeyEnv)
+		}
+		apiKey := ""
+		if apiKeyEnv != "" {
+			apiKey = os.Getenv(apiKeyEnv)
+		}
+		model = BuildModel(cfg, apiKey)
+		if *record != "" {
+			recorder = replay.NewRecorder(model,
+				replay.Recorded{Provider: cfg.Model.Provider, Model: cfg.Model.Model}, "")
+			model, verifyModel = recorder, nil // record one ordered stream, replayable as-is
+		}
+	}
+```
+
+Update the header print (`demo.go:113`) to disclose provenance:
+
+```go
+	if transcript != nil {
+		demoPrintf(out, "== RunLore demo: investigating %q (recorded model turns, fake providers, no cluster) ==\n", c.DisplayName())
+		demoPrintf(out, "   model turns recorded %s with %s/%s\n\n",
+			transcript.RecordedAt, transcript.RecordedWith.Provider, transcript.RecordedWith.Model)
+	} else {
+		demoPrintf(out, "== RunLore demo: investigating %q (fake providers, no cluster) ==\n\n", c.DisplayName())
+	}
+	demoPrintf(out, "incident: %s\n\n", oneLineIndent(c.Symptom()))
+```
+
+After the findings are printed (`demo.go:147`), flush the recording:
+
+```go
+	if recorder != nil {
+		if err := recorder.Write(*record, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("write transcript: %w", err)
+		}
+		demoPrintf(out, "\ntranscript written to %s — replay it with `lore demo investigate --offline %s`\n", *record, *record)
+	}
+```
+
+The recorder needs the scenario name, which is known only after `pickScenario`. Move the recorder construction to just after `c` is resolved, or set it via the existing struct — simplest is to pass `c.DisplayName()` by constructing the recorder after `pickScenario`:  move the whole `switch` block to *after* the `c, err := pickScenario(...)` call (it already is — `pickScenario` runs at `demo.go:81`, before `demoConfig` at `:86`), and use `replay.NewRecorder(model, meta, c.DisplayName())`.
+
+Add `"time"` and `"github.com/Smana/runlore/internal/model/replay"` to the imports.
+
+Update the usage string in `cmd/lore/main.go:31`:
+
+```
+  lore demo investigate --offline default                watch a REAL recorded investigation — no cluster, no API key, no network
+  lore demo investigate [--scenario <name>]           watch a full investigation against fake providers (no cluster; needs a model API key)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/app/ -run TestDemo -v`
+Expected: PASS — `TestDemoOfflineThroughSeam`, `TestDemoOfflineNeedsNoAPIKey`, and the pre-existing demo tests.
+
+Run: `go test ./internal/app/ && golangci-lint run ./internal/app/...`
+Expected: PASS, no lint issues. **This task ends green** — nothing is left failing for a later task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/app/demo.go internal/app/demo_test.go internal/app/testdata/ cmd/lore/main.go
+git commit -m "feat(demo): --offline replays a recorded investigation, --record captures one"
+```
+
+---
+
+### Task 4: Record the shipped transcript and rewrite `hack/demo.sh`
+
+**Files:**
+- Create: `examples/demo/harbor-chart-bump.transcript.json` (generated, committed)
+- Rewrite: `hack/demo.sh`
+- Create: `hack/demo-trigger-policy.sh` (the old `demo.sh`, moved)
+- Modify: `CONTRIBUTING.md:181`, `AGENTS.md:20`, `README.md:178`
+
+**Interfaces:**
+- Consumes: `--record` / `--offline` from Task 3; `demoDefaultTranscript`.
+- Produces: a committed transcript at the path `demoDefaultTranscript` names; `hack/demo.sh` as the verdict-card demo.
+
+> **This task needs the maintainer's API key.** Recording is a one-time human step; everything after it is keyless forever.
+
+- [ ] **Step 1: Record the transcript**
+
+```bash
+mkdir -p examples/demo
+export ANTHROPIC_API_KEY=<your key>
+go run ./cmd/lore demo investigate \
+  --scenario harbor-chart-bump \
+  --record examples/demo/harbor-chart-bump.transcript.json
+```
+
+Expected: the demo runs live, prints a verdict card, and reports `transcript written to examples/demo/harbor-chart-bump.transcript.json`.
+
+- [ ] **Step 2: Verify the recording replays**
+
+Run:
+```bash
+unset ANTHROPIC_API_KEY
+go run ./cmd/lore demo investigate --offline default
+```
+Expected: the same verdict card, prefixed by `recorded model turns, fake providers, no cluster` and the provenance line. No network call to any model.
+
+Read the card. **If the recorded root cause is weak or wrong, re-record** (models vary run to run) — this fixture is the first thing a stranger sees.
+
+- [ ] **Step 3: Write the drift guard over the shipped transcript**
+
+The fixture now exists, so the guard that reads it belongs here. Append to `internal/app/demo_test.go`:
+
+```go
+// TestShippedTranscriptToolsStillExist is the DRIFT GUARD over the fixture the demo
+// actually ships. Every tool the transcript calls must still be registered by the
+// demo's fixture tools; a renamed or removed tool fails CI here instead of breaking
+// the demo silently for every new visitor.
+func TestShippedTranscriptToolsStillExist(t *testing.T) {
+	tr, err := replay.Load("../../" + demoDefaultTranscript)
+	if err != nil {
+		t.Fatalf("load shipped transcript: %v", err)
+	}
+	cases, err := eval.Load("../../examples/scenarios")
+	if err != nil {
+		t.Fatalf("load scenarios: %v", err)
+	}
+	c, err := pickScenario(cases, tr.Scenario)
+	if err != nil {
+		t.Fatalf("the transcript's scenario %q is gone: %v", tr.Scenario, err)
+	}
+	have := map[string]bool{
+		// Loop-control tools are answered by the loop itself, not the fixture set.
+		"submit_findings": true, "submit_verdicts": true,
+	}
+	for _, tool := range c.FakeTools() {
+		have[tool.Name()] = true
+	}
+	for _, name := range tr.ToolNames() {
+		if !have[name] {
+			t.Errorf("shipped transcript calls tool %q, which no longer exists — re-record with `lore demo investigate --record %s`", name, demoDefaultTranscript)
+		}
+	}
+}
+```
+
+Add the imports `"github.com/Smana/runlore/internal/eval"` and `"github.com/Smana/runlore/internal/model/replay"` to `demo_test.go` if not already present.
+
+Run: `go test ./internal/app/ -run TestShippedTranscriptToolsStillExist -v`
+Expected: PASS.
+
+- [ ] **Step 3b: Mutation-test the guard**
+
+Temporarily rename `what_changed` to `what_changed_XX` inside `examples/demo/harbor-chart-bump.transcript.json`. Run the test.
+Expected: FAIL naming the missing tool and printing the re-record command. Revert the edit and re-run to confirm PASS.
+
+- [ ] **Step 4: Move the old demo aside**
+
+```bash
+git mv hack/demo.sh hack/demo-trigger-policy.sh
+```
+
+Edit the header comment of `hack/demo-trigger-policy.sh` to:
+
+```bash
+#!/usr/bin/env bash
+# Trigger-policy demo: run `lore serve` and fire mocked Alertmanager alerts through
+# the trigger policy, showing which alerts become incidents (match, dedup,
+# wrong-severity, wrong-environment, ignore-list, resolved).
+#
+# This shows the FILTER, not the investigation. For the investigation — a real root
+# cause, keyless — run hack/demo.sh.
+#
+# Usage: hack/demo-trigger-policy.sh
+```
+
+- [ ] **Step 5: Write the new `hack/demo.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Demo: a REAL RunLore investigation, on recorded evidence, with no cluster, no API
+# key and no network. The model turns are replayed from a transcript recorded once
+# against a live model (examples/demo/*.transcript.json); the tools, the
+# investigation loop and the rendered verdict card are the production code paths.
+#
+# Requires: Go. Nothing else.
+# Usage: hack/demo.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$(mktemp -d)/lore"
+
+go build -o "$BIN" "$ROOT/cmd/lore"
+cd "$ROOT"          # the transcript + scenario paths are repo-relative
+"$BIN" demo investigate --offline default
+```
+
+- [ ] **Step 6: Run it**
+
+Run: `hack/demo.sh`
+Expected: a verdict card on stdout within ~60s (mostly `go build`), no network access to a model endpoint.
+
+- [ ] **Step 7: Update the references**
+
+- `CONTRIBUTING.md:181` — change the annotation to two lines:
+  ```
+  hack/demo.sh                 # a real investigation on recorded evidence (no cluster, no key)
+  hack/demo-trigger-policy.sh  # fires mocked Alertmanager alerts through the trigger policy
+  ```
+- `AGENTS.md:20` — same rename.
+- `README.md:178` — update the quickstart block so it advertises the verdict card rather than the policy log lines, and keep the existing anchor `#-try-it-in-one-minute--no-cluster-no-keys` intact (Getting Started links to it).
+
+- [ ] **Step 8: Shellcheck**
+
+Run: `shellcheck hack/demo.sh hack/demo-trigger-policy.sh`
+Expected: no findings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add examples/demo/ hack/demo.sh hack/demo-trigger-policy.sh CONTRIBUTING.md AGENTS.md README.md
+git commit -m "feat(demo): hack/demo.sh shows a real root cause, keyless"
+```
+
+---
+
+### Task 5: Zero-config `lore investigate`
+
+**Files:**
+- Modify: `internal/app/investigate_cmd.go:20-40`
+- Create: `internal/app/investigate_config.go`
+- Create: `internal/app/investigate_config_test.go`
+
+**Interfaces:**
+- Consumes: `config.Config`, `config.Model`, `config.Load` (`internal/config/load.go:16`).
+- Produces:
+  - `func resolveInvestigateConfig(path string, explicit bool) (*config.Config, error)`
+  - `const defaultConfigPath = "runlore.yaml"`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/app/investigate_config_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolveFromOpenAIEnv: with no runlore.yaml, an OpenAI-compatible endpoint in the
+// environment is enough to investigate. This is the laptop-to-value path — no config
+// ceremony before the first answer.
+func TestResolveFromOpenAIEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("OPENAI_BASE_URL", "http://localhost:8000/v1")
+	t.Setenv("OPENAI_MODEL", "qwen3-30b")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	cfg, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cfg.Model.BaseURL != "http://localhost:8000/v1" {
+		t.Errorf("base_url = %q, want the env value", cfg.Model.BaseURL)
+	}
+	if cfg.Model.Model != "qwen3-30b" {
+		t.Errorf("model = %q, want the env value", cfg.Model.Model)
+	}
+	// Keyless is legitimate here: a local vLLM/Ollama needs no key.
+	if cfg.Model.APIKeyEnv != "" && os.Getenv(cfg.Model.APIKeyEnv) != "" {
+		t.Errorf("expected keyless, got api_key_env=%q", cfg.Model.APIKeyEnv)
+	}
+}
+
+// TestResolveFromAnthropicEnv: the other zero-config path.
+func TestResolveFromAnthropicEnv(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+	cfg, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cfg.Model.Provider != "anthropic" {
+		t.Errorf("provider = %q, want anthropic", cfg.Model.Provider)
+	}
+	if cfg.Model.APIKeyEnv != "ANTHROPIC_API_KEY" {
+		t.Errorf("api_key_env = %q, want ANTHROPIC_API_KEY", cfg.Model.APIKeyEnv)
+	}
+}
+
+// TestResolveWithNoEnvExplainsBothPaths: the error a first-time user hits must tell
+// them exactly what to set, not just that something is missing.
+func TestResolveWithNoEnvExplainsBothPaths(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	_, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err == nil {
+		t.Fatal("expected an error with no config and no env")
+	}
+	for _, want := range []string{"OPENAI_BASE_URL", "ANTHROPIC_API_KEY", "runlore.yaml"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestExplicitMissingConfigStillErrors: silence here would hide a typo'd --config
+// path behind a surprise zero-config run against the wrong model.
+func TestExplicitMissingConfigStillErrors(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	_, err := resolveInvestigateConfig(filepath.Join(t.TempDir(), "typo.yaml"), true)
+	if err == nil {
+		t.Fatal("an explicitly named missing config must be an error")
+	}
+}
+
+// TestExistingConfigWins: a real runlore.yaml is an explicit statement of intent and
+// must never be silently replaced by environment guesses.
+func TestExistingConfigWins(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	if err := os.WriteFile(filepath.Join(dir, defaultConfigPath), []byte(
+		"model:\n  base_url: http://from-file:8000/v1\n  model: from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := resolveInvestigateConfig(defaultConfigPath, false)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if cfg.Model.Model != "from-file" {
+		t.Errorf("model = %q, want the file's value", cfg.Model.Model)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/ -run TestResolve -v`
+Expected: FAIL — `undefined: resolveInvestigateConfig`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/app/investigate_config.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// defaultConfigPath is the config `lore investigate` looks for when --config is not
+// given. Its ABSENCE is not an error: the CLI is the laptop-to-value front door, and
+// requiring a YAML file before the first answer is the friction this removes.
+const defaultConfigPath = "runlore.yaml"
+
+// Env vars the zero-config path reads, in precedence order. They are the names the
+// ecosystem already uses, so a user who has run any OpenAI-compatible or Anthropic
+// tool already has them exported.
+const (
+	envOpenAIBaseURL = "OPENAI_BASE_URL"
+	envOpenAIKey     = "OPENAI_API_KEY"
+	envOpenAIModel   = "OPENAI_MODEL"
+	envAnthropicKey  = "ANTHROPIC_API_KEY"
+
+	// defaultOpenAIModel / defaultAnthropicModel are used when the endpoint is known
+	// but the model name is not. A local vLLM/Ollama commonly serves one model, and
+	// naming it wrongly fails loudly at the first call rather than silently.
+	defaultOpenAIModel    = "gpt-4o-mini"
+	defaultAnthropicModel = "claude-sonnet-5"
+)
+
+// resolveInvestigateConfig loads the config for a one-off investigation.
+//
+//	explicit=true  (--config was given): a missing file is an ERROR. Falling back
+//	               would run against a different model than the user asked for.
+//	explicit=false (default path): a missing file falls back to the environment.
+func resolveInvestigateConfig(path string, explicit bool) (*config.Config, error) {
+	cfg, err := config.Load(path)
+	switch {
+	case err == nil:
+		return cfg, nil
+	case explicit:
+		return nil, err
+	case !errors.Is(err, fs.ErrNotExist):
+		// The file exists but is broken — never paper over that with env guesses.
+		return nil, err
+	}
+	return configFromEnv()
+}
+
+// configFromEnv synthesizes a minimal, model-only config from the environment. Every
+// data source stays unset, so each disables its own tool — no cluster, no Flux, no
+// KB repo, no forge and no notifier are required to get an answer.
+func configFromEnv() (*config.Config, error) {
+	switch {
+	case os.Getenv(envOpenAIBaseURL) != "":
+		m := config.Model{
+			BaseURL: os.Getenv(envOpenAIBaseURL),
+			Model:   or(os.Getenv(envOpenAIModel), defaultOpenAIModel),
+		}
+		// Keyless is a first-class case here: an in-cluster vLLM or a local Ollama
+		// needs no credential, and demanding one would break the most private setup.
+		if os.Getenv(envOpenAIKey) != "" {
+			m.APIKeyEnv = envOpenAIKey
+		}
+		return &config.Config{Model: m}, nil
+	case os.Getenv(envAnthropicKey) != "":
+		return &config.Config{Model: config.Model{
+			Provider:  "anthropic",
+			Model:     defaultAnthropicModel,
+			APIKeyEnv: envAnthropicKey,
+		}}, nil
+	default:
+		return nil, fmt.Errorf(
+			"no model configured: set %s (+ optional %s / %s) for an OpenAI-compatible endpoint, "+
+				"or %s for Anthropic — or write a %s and pass it with --config",
+			envOpenAIBaseURL, envOpenAIKey, envOpenAIModel, envAnthropicKey, defaultConfigPath)
+	}
+}
+
+// or returns a when non-empty, else b.
+func or(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}
+```
+
+If `internal/app` already defines an `or` helper (check `model.go:75`), reuse it and drop this copy.
+
+- [ ] **Step 4: Wire it into the command**
+
+In `internal/app/investigate_cmd.go`, replace lines 22 and 32–35:
+
+```go
+	cfgPath := fs.String("config", "", "path to config file (default: ./runlore.yaml if present, else the environment)")
+```
+
+and
+
+```go
+	explicit := *cfgPath != ""
+	path := *cfgPath
+	if path == "" {
+		path = defaultConfigPath
+	}
+	cfg, err := resolveInvestigateConfig(path, explicit)
+	if err != nil {
+		return err
+	}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/app/ -run 'TestResolve|TestExplicit|TestExisting' -v`
+Expected: PASS — all five.
+
+Run: `go test ./internal/app/`
+Expected: PASS — the whole package, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/app/investigate_config.go internal/app/investigate_config_test.go internal/app/investigate_cmd.go
+git commit -m "feat(cli): lore investigate runs with no runlore.yaml, from the environment"
+```
+
+---
+
+### Task 6: Investigate flags and a graceful-degradation notice
+
+**Files:**
+- Modify: `internal/app/investigate_cmd.go`
+- Modify: `internal/app/investigate_config_test.go` (append)
+
+**Interfaces:**
+- Consumes: `resolveInvestigateConfig` (Task 5); `BuildModelAndTools` (`investigate_cmd.go:44`).
+- Produces: `--model`, `--base-url`, `--metrics-url`, `--logs-url` flags; `func disabledTools(cfg *config.Config) []string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/app/investigate_config_test.go`:
+
+```go
+// TestDisabledToolsNamesWhatIsOff: a thin answer must be explainable. When metrics,
+// logs and the catalog are unset, the command says so once on stderr rather than
+// leaving the user wondering why the agent never looked at their dashboards.
+func TestDisabledToolsNamesWhatIsOff(t *testing.T) {
+	cfg := &config.Config{Model: config.Model{Model: "m", BaseURL: "http://x/v1"}}
+	got := disabledTools(cfg)
+	joined := strings.Join(got, " ")
+	for _, want := range []string{"metrics", "logs", "knowledge catalog"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("disabledTools() = %v, must mention %q", got, want)
+		}
+	}
+}
+
+// TestDisabledToolsSilentWhenWired: nothing to warn about when everything is set.
+// Note the shapes: config.MetricsConfig and config.LogsConfig embed config.Endpoint
+// inline (config.go:116, :131, :76), so URL is set through the embedded struct.
+func TestDisabledToolsSilentWhenWired(t *testing.T) {
+	cfg := &config.Config{
+		Model:   config.Model{Model: "m", BaseURL: "http://x/v1"},
+		Metrics: config.MetricsConfig{Endpoint: config.Endpoint{URL: "http://vm:8429"}},
+		Logs:    config.LogsConfig{Endpoint: config.Endpoint{URL: "http://vl:9428"}},
+		Catalog: config.Catalog{Dir: "/kb"},
+	}
+	if got := disabledTools(cfg); len(got) != 0 {
+		t.Errorf("disabledTools() = %v, want none", got)
+	}
+}
+```
+
+Add `"github.com/Smana/runlore/internal/config"` to the test imports.
+
+Field reference, already verified — do not re-derive: `Config.Metrics` is `MetricsConfig`, `Config.Logs` is `LogsConfig`, both embedding `Endpoint` (which carries `URL`); `Config.Catalog` is `Catalog` with `Dir` and `Git.URL` (`config.go:456`, `:540`). *Reading* `cfg.Metrics.URL` works through the embedding; *constructing* one needs the nested literal above.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/ -run TestDisabledTools -v`
+Expected: FAIL — `undefined: disabledTools`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `internal/app/investigate_cmd.go`:
+
+```go
+// disabledTools names the investigation signals this run will NOT have, so a thin
+// answer is explainable rather than mysterious. The CLI deliberately degrades
+// instead of demanding a full stack — but silence about it would look like a bug.
+func disabledTools(cfg *config.Config) []string {
+	var off []string
+	if cfg.Metrics.URL == "" {
+		off = append(off, "metrics (query_metrics)")
+	}
+	if cfg.Logs.URL == "" {
+		off = append(off, "logs (query_logs)")
+	}
+	if cfg.Catalog.Dir == "" && cfg.Catalog.Git.URL == "" {
+		off = append(off, "knowledge catalog (kb_search, instant recall)")
+	}
+	return off
+}
+```
+
+Add the flags beside the existing ones:
+
+```go
+	modelName := fs.String("model", "", "override the model name")
+	baseURL := fs.String("base-url", "", "override the OpenAI-compatible endpoint")
+	metricsURL := fs.String("metrics-url", "", "PromQL endpoint — enables query_metrics")
+	logsURL := fs.String("logs-url", "", "logs endpoint — enables query_logs")
+```
+
+Apply them after the config resolves, and emit the notice:
+
+```go
+	// Flags override the resolved config. They are how a user points the CLI at their
+	// stack without writing a file.
+	if *modelName != "" {
+		cfg.Model.Model = *modelName
+	}
+	if *baseURL != "" {
+		cfg.Model.BaseURL = *baseURL
+	}
+	if *metricsURL != "" {
+		cfg.Metrics.URL = *metricsURL
+	}
+	if *logsURL != "" {
+		cfg.Logs.URL = *logsURL
+	}
+	if off := disabledTools(cfg); len(off) > 0 {
+		fmt.Fprintf(os.Stderr, "note: running without %s — pass --metrics-url/--logs-url or a --config to enable them\n",
+			strings.Join(off, ", "))
+	}
+```
+
+Add `"strings"` to the imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/app/ -run TestDisabledTools -v`
+Expected: PASS.
+
+Run: `go test ./internal/app/ && golangci-lint run ./internal/app/...`
+Expected: PASS, no lint issues.
+
+- [ ] **Step 5: Manual smoke (needs a cluster + a key)**
+
+```bash
+export ANTHROPIC_API_KEY=<key>
+go run ./cmd/lore investigate --alert KubePodCrashLooping --namespace default
+```
+Expected: the note on stderr naming the disabled signals, then a rendered verdict card. No `runlore.yaml` present, no Flux, no KB, no notifier.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/app/investigate_cmd.go internal/app/investigate_config_test.go
+git commit -m "feat(cli): investigate flags for model/metrics/logs plus a degradation notice"
+```
+
+---
+
+### Task 7: `install.sh` and the CLI docs page
+
+**Files:**
+- Create: `website/static/install.sh`
+- Create: `website/content/docs/reference/cli.md`
+- Modify: `.github/workflows/ci.yaml` (extend the shellcheck step)
+
+**Interfaces:**
+- Consumes: the goreleaser archive naming in `.goreleaser.yaml:31` and the `checksums.txt` it publishes.
+- Produces: `curl -fsSL https://runlore.io/install.sh | sh`.
+
+- [ ] **Step 1: Confirm the archive naming**
+
+Run: `sed -n '8,48p' .goreleaser.yaml`
+
+Already verified — the script below is written against it, so this step is a confirmation, not a discovery:
+
+| Setting | Value | Consequence |
+|---|---|---|
+| `project_name` | `runlore` (`.goreleaser.yaml:10`) | the archive is **`runlore_…`**, not `lore_…` |
+| `binary` | `lore` (`:15`) | the file *inside* the archive is `lore` |
+| `name_template` | `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}` (`:34`) | `runlore_0.11.0_linux_amd64` |
+| `formats` | `tar.gz`, zip on Windows (`:37`) | `.tar.gz` for linux/darwin |
+| `checksum.name_template` | `checksums.txt` (`:47`) | the verification file's name |
+
+`.Version` is the tag **without** the leading `v`, which is why the script strips it.
+
+- [ ] **Step 2: Write `website/static/install.sh`**
+
+```sh
+#!/bin/sh
+# RunLore installer — downloads the released `lore` binary for this OS/arch,
+# verifies its SHA-256 against the published checksums, and installs it.
+#
+#   curl -fsSL https://runlore.io/install.sh | sh
+#
+# Environment:
+#   LORE_VERSION      pin a release tag (default: latest)
+#   LORE_INSTALL_DIR  install target (default: /usr/local/bin, else ~/.local/bin)
+#
+# This script is auditable at
+# https://github.com/Smana/runlore/blob/main/website/static/install.sh
+# It never runs sudo for you and never sends anything anywhere.
+set -eu
+
+REPO="Smana/runlore"
+VERSION="${LORE_VERSION:-latest}"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+arch=$(uname -m)
+case "$arch" in
+  x86_64|amd64) arch="amd64" ;;
+  aarch64|arm64) arch="arm64" ;;
+  *) echo "unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+case "$os" in
+  linux|darwin) ;;
+  *) echo "unsupported OS: $os — build from source with 'go install github.com/Smana/runlore/cmd/lore@latest'" >&2; exit 1 ;;
+esac
+
+if [ "$VERSION" = "latest" ]; then
+  VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+  [ -n "$VERSION" ] || { echo "could not resolve the latest release tag" >&2; exit 1; }
+fi
+
+# Matches .goreleaser.yaml: project_name=runlore, name_template
+# {{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}, tar.gz. Note the archive is named
+# for the PROJECT (runlore) while the binary inside is `lore`.
+archive="runlore_${VERSION#v}_${os}_${arch}.tar.gz"
+base="https://github.com/$REPO/releases/download/$VERSION"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "downloading $archive ($VERSION)"
+curl -fsSL "$base/$archive" -o "$tmp/$archive"
+curl -fsSL "$base/checksums.txt" -o "$tmp/checksums.txt"
+
+# Verify before extracting. A checksum mismatch means a corrupted or tampered
+# download, and extracting it anyway would defeat the point of checking.
+( cd "$tmp" && grep " $archive\$" checksums.txt | sha256sum -c - ) \
+  || { echo "checksum verification FAILED for $archive" >&2; exit 1; }
+
+tar -xzf "$tmp/$archive" -C "$tmp" lore
+
+dir="${LORE_INSTALL_DIR:-/usr/local/bin}"
+if [ ! -w "$dir" ]; then
+  dir="$HOME/.local/bin"
+  mkdir -p "$dir"
+  echo "note: /usr/local/bin is not writable — installing to $dir"
+fi
+install -m 0755 "$tmp/lore" "$dir/lore"
+
+echo "installed $("$dir/lore" version) to $dir/lore"
+echo
+echo "Try it with no cluster and no API key:"
+echo "  lore demo investigate --offline default"
+echo
+echo "Verify the release signature (optional):"
+echo "  cosign verify-blob --bundle checksums.txt.bundle \\"
+echo "    --certificate-identity-regexp 'https://github.com/$REPO/.github/workflows/release-binaries.yml@.*' \\"
+echo "    --certificate-oidc-issuer https://token.actions.githubusercontent.com checksums.txt"
+```
+
+On macOS `sha256sum` is absent — add a shim right before the verification block:
+
+```sh
+if ! command -v sha256sum >/dev/null 2>&1; then
+  sha256sum() { shasum -a 256 "$@"; }
+fi
+```
+
+- [ ] **Step 3: Test the script**
+
+```bash
+shellcheck website/static/install.sh
+sh website/static/install.sh   # with LORE_INSTALL_DIR set to a temp dir
+```
+
+Run:
+```bash
+LORE_INSTALL_DIR=$(mktemp -d) sh website/static/install.sh
+```
+Expected: downloads, verifies the checksum, prints `installed lore <version>`. Then run the printed `lore demo investigate --offline default` — it must produce the verdict card.
+
+Test the failure path by editing the archive name to a nonexistent one: expected a clean `curl` error, not a partial install.
+
+- [ ] **Step 4: Write the CLI docs page**
+
+Create `website/content/docs/reference/cli.md` with front matter `title: CLI` and `weight: 5`, covering:
+
+- **Install** — the `curl | sh` one-liner, `LORE_VERSION`/`LORE_INSTALL_DIR`, the `go install github.com/Smana/runlore/cmd/lore@latest` alternative for readers who prefer not to pipe a script to a shell, and the cosign verification command.
+- **`lore demo investigate --offline default`** — what it replays, that the model turns are recorded (with the provenance line explained), and that no key or network is needed.
+- **`lore investigate`** — the zero-config env vars (`OPENAI_BASE_URL`/`OPENAI_API_KEY`/`OPENAI_MODEL`, `ANTHROPIC_API_KEY`), the flags from Task 6, and a table of what each unset source disables.
+- **When to move to `lore serve`** — one paragraph pointing at Getting Started tier 3.
+
+Use `{{< relref >}}` for internal links (`refLinksErrorLevel: ERROR` fails the build on a bad one) and absolute GitHub URLs for repo files.
+
+- [ ] **Step 5: Build the site**
+
+Run: `cd website && hugo --gc --minify`
+Expected: build succeeds, no unresolved refs.
+
+- [ ] **Step 6: Extend the shellcheck CI step**
+
+In `.github/workflows/ci.yaml`, find the step that shellchecks `hack/*.sh` and add `website/static/install.sh` to its target list. If no such step exists, add one:
+
+```yaml
+      - name: shellcheck
+        run: shellcheck hack/*.sh website/static/install.sh
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add website/static/install.sh website/content/docs/reference/cli.md .github/workflows/ci.yaml
+git commit -m "feat(cli): install.sh plus a first-class CLI reference page"
+```
+
+---
+
+## Final verification
+
+- [ ] `go build ./... && go test ./... && golangci-lint run` — all clean
+- [ ] `hack/demo.sh` on a shell with **no** `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` prints a verdict card
+- [ ] `cd website && hugo --gc --minify` builds
+- [ ] `shellcheck hack/*.sh website/static/install.sh` clean
+- [ ] Run the security review on the branch diff (`/security-review`), paying attention to `install.sh` (download verification, no privilege escalation, no credential handling) and the transcript loader (untrusted-path reads)
+- [ ] Open the PR — English title and description, no AI attribution, no co-author trailers
+</content>

--- a/docs/superpowers/plans/2026-08-02-s2-getting-started-integrations.md
+++ b/docs/superpowers/plans/2026-08-02-s2-getting-started-integrations.md
@@ -1,0 +1,264 @@
+# S2 — Getting Started restructure + integrations browser — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn a 624-line page that presents the hardest path as the only path into three escalating tiers, and give every integration a page worth landing on.
+
+**Architecture:** Getting Started becomes Try → Investigate → Learn, each independently complete. Tier 3 documents exactly one opinionated stack (Prometheus + GitHub + an OpenAI-compatible LLM + Slack); every other option moves to a new `/docs/integrations/` section with one short page per integration. A reflection test over the runtime registries keeps that section from drifting out of sync with the code.
+
+**Tech Stack:** Hugo + Hextra (`website/`), Go (the drift guard), Helm values profiles.
+
+**Spec:** [`docs/superpowers/specs/2026-08-02-s2-getting-started-integrations-design.md`](../specs/2026-08-02-s2-getting-started-integrations-design.md) — **read its "Amendments from wave-1 execution" section**, which carries five findings this plan depends on.
+
+## Global Constraints
+
+- **Use `/usr/bin/hugo`** — the `hugo` on PATH is mise-global 0.139.0 and cannot build this site (`hugo.yaml` sets `hugoVersion.min: 0.146.0`; Hextra needs the `try` func). `/usr/bin/hugo` is v0.164.0.
+- Internal links use `{{< relref >}}`; `refLinksErrorLevel: ERROR` fails the build on a bad ref. Repo files use absolute GitHub URLs — `relref` cannot reach outside `content/`.
+- Every new `.go` file starts with `// SPDX-License-Identifier: Apache-2.0`; `golangci-lint run` must pass; no new third-party dependencies.
+- Comments explain *why*; this codebase comments heavily and deliberately.
+- **Do not weaken any published claim to make a page shorter.** Where a caveat exists it moves, it does not vanish.
+- Conventional Commits. **Never** add a co-author trailer or any AI attribution.
+
+## Wave-1 facts this plan depends on (verified, do not re-derive)
+
+- `hack/demo.sh` now replays a recorded investigation and renders a real verdict card with **no cluster, no API key, no network**. The trigger-policy demo moved to `hack/demo-trigger-policy.sh`.
+- `lore investigate` runs with **no `runlore.yaml`**, synthesizing from `OPENAI_BASE_URL`/`OPENAI_API_KEY`/`OPENAI_MODEL` or `ANTHROPIC_API_KEY`; flags `--model`, `--base-url`, `--metrics-url`, `--logs-url`; and it prints a stderr notice naming disabled signals.
+- `install.sh` is served at `runlore.io/install.sh` and verifies the release checksum (plus the cosign signature when cosign is present).
+- **glm-4.6 stalls on forced `tool_choice`** (#391) — breaks verify, the recall reranker, the eval judge. **glm-4.5-air works.**
+- **Gemini 3.x is unusable** (#392) — the client omits `thought_signature`; investigations fail on turn 2. Gemini 2.5 works.
+- The nightly scorecard is live at `runlore.io/eval`.
+
+---
+
+### Task 1: The `/docs/integrations/` section scaffold and its drift guard
+
+**Files:**
+- Create: `website/content/docs/integrations/_index.md`
+- Create: `internal/notify/registry.go` — add `Registered()` (mirroring `internal/source`)
+- Create: `internal/docsguard/integration_pages_test.go`
+- Create: `internal/docsguard/doc.go`
+
+**Interfaces:**
+- Consumes: `source.Registered() []source.Descriptor` (`internal/source/registry.go:108`), the logs provider constants in `internal/logs/detect.go`.
+- Produces: `notify.Registered() []notify.Descriptor`; the `integration:` front-matter contract every page in Task 2/3 must satisfy.
+
+- [ ] **Step 1: Add `notify.Registered()`**
+
+`internal/source/registry.go:108` already exposes `Registered()`. `internal/notify/registry.go` has `Register` but no accessor. Add the mirror image, with a comment saying why it exists (a docs guard needs to enumerate what is wired):
+
+```go
+// Registered returns every registered notifier descriptor, sorted by name.
+// It exists so a docs drift guard can enumerate what is actually wired rather
+// than trusting a hand-maintained list — the same reason source.Registered does.
+func Registered() []Descriptor { ... }
+```
+
+Match `source.Registered`'s shape exactly (read it first — sorted? copy-on-return?).
+
+- [ ] **Step 2: Write the failing guard**
+
+Create `internal/docsguard/integration_pages_test.go`. It walks `website/content/docs/integrations/**.md`, parses each page's `integration:` front matter (`kind` + `id`), and asserts **both directions**:
+
+- every registered source / notifier / logs provider has a page;
+- every page whose `kind` is one of those three resolves to something registered.
+
+Pages whose `kind` is not a registered kind (`llm`, `cloud`, `network`, `mcp` — no runtime registry to reflect over) are ignored, so the guard never produces a false failure on them. Say that in a comment.
+
+Run it: `go test ./internal/docsguard/`
+Expected: FAIL — no pages exist yet.
+
+- [ ] **Step 3: Write the section index**
+
+`website/content/docs/integrations/_index.md` with `title: Integrations`, `weight: 15` (directly under Getting Started at 10), and five `hextra/feature-grid` card grids: **Triggers · LLM providers · Data sources · Notifications · Forge**. Cards link to the pages Tasks 2–3 create.
+
+Add a short lead paragraph stating the rule that makes this section coherent: *presence is enablement* — a key under `sources.<name>` turns that source on, and an unset data source simply disables its tool.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/notify/registry.go internal/docsguard/ website/content/docs/integrations/_index.md
+git commit -m "feat(docs): integrations section scaffold with a registry-reflection drift guard"
+```
+
+(The guard stays red until Task 3 completes. That is expected and stated in the commit body — this is the one task in this plan that lands red, because splitting a guard from the thing it guards across two commits is worse than a short red window. If you would rather it be green, write the guard in Task 3 instead and say so in your report.)
+
+---
+
+### Task 2: Integration pages — triggers, notifications, forge
+
+**Files:** create under `website/content/docs/integrations/`:
+`alertmanager.md`, `gitops.md`, `pagerduty.md`, `custom-webhook.md`, `slack.md`, `matrix.md`, `webhook.md`, `templated.md`, `github.md`
+
+**Interfaces:** each page carries front matter `title`, `weight`, and `integration: {kind: <source|notifier|forge>, id: <registered id>}`.
+
+- [ ] **Step 1: Confirm the registered ids**
+
+```bash
+grep -rn "Register(Descriptor{" -A 3 internal/source/*.go internal/source/*/*.go | grep -i "name" | head
+grep -rn "Register(Descriptor{" -A 3 internal/notify/*.go internal/notify/*/*.go | grep -i "name" | head
+```
+The `id` in front matter must equal the registered name exactly, or the guard fails. Use what you find, not what this plan guesses.
+
+- [ ] **Step 2: Write the pages**
+
+One template, deliberately short — a reader should be able to wire an integration from this page alone:
+
+```markdown
+---
+title: Grafana Loki
+weight: 30
+integration: {kind: logs, id: loki}
+---
+
+**What it gives you** — one sentence naming the tools this enables.
+
+## Minimal config
+```yaml
+# the smallest block that works
+```
+
+## Verify it locally
+Exact commands. Include a container recipe where one applies.
+
+## Notes
+Gotchas, field defaults, parity caveats.
+
+## Reference
+Deep link into configuration.md / data-sources.md via {{< relref >}}.
+```
+
+Source the content by **moving** it out of `getting-started.md` and `data-sources.md` rather than paraphrasing — those texts are already accurate and reviewed. Where you move a caveat, it must survive intact.
+
+- [ ] **Step 3: Build and commit**
+
+```bash
+cd website && /usr/bin/hugo --gc --minify
+git commit -m "docs(integrations): trigger, notification and forge pages"
+```
+
+---
+
+### Task 3: Integration pages — LLM providers and data sources
+
+**Files:** create under `website/content/docs/integrations/`:
+`openai-compatible.md`, `anthropic.md`, `gemini.md`, `local-keyless.md`,
+`prometheus.md`, `victorialogs.md`, `loki.md`, `kubernetes.md`, `hubble.md`,
+`aws-vpc-flow-logs.md`, `gcp-firewall-logs.md`, `aws-cloud.md`, `source-repos.md`, `mcp.md`
+
+- [ ] **Step 1: The LLM pages must carry verified compatibility, not just config**
+
+This is the substantive part. Two providers are broken against RunLore and a reader wiring one up will hit it within minutes:
+
+- **`openai-compatible.md`** must state that the endpoint has to support **forced `tool_choice`** (the named-function form). That single capability separates a working endpoint from a broken one: RunLore uses it for the adversarial verify pass, the recall reranker, the eval judge, KB semantic validation and `kb import --model`. Name **glm-4.6 as a known-broken example** (it emits one `reasoning_content` delta then stalls indefinitely — [#391]) and **glm-4.5-air as verified working**.
+- **`gemini.md`** must state that **Gemini 3.x does not work** — the client omits the `thought_signature` that Gemini 3 requires on function-call parts, so investigations fail with a 400 on the second turn ([#392]) — and that **Gemini 2.5 works**.
+
+Link the issues. Do not soften these into "may not work"; they were reproduced.
+
+- [ ] **Step 2: Write the data-source pages**
+
+Move content from `data-sources.md`, preserving its caveats — particularly the Loki parity notes (`logs_error_summary` client-side aggregation, `detected_level` absence on Loki 2.x) and the IP-based caveat on the AWS/GCP network providers.
+
+- [ ] **Step 3: The guard must now pass**
+
+Run: `go test ./internal/docsguard/ -v`
+Expected: PASS.
+
+Then **mutation-test it**: add a fake descriptor to one registry, confirm the guard fails naming the missing page, revert. Report both outcomes.
+
+- [ ] **Step 4: Build and commit**
+
+---
+
+### Task 4: Rewrite Getting Started into three tiers
+
+**Files:** rewrite `website/content/docs/getting-started.md`
+
+- [ ] **Step 1: Tier 1 — Try (no cluster, no keys)**
+
+Opens the page, above the prerequisites. `curl -fsSL https://runlore.io/install.sh | sh` (or `go install`), then `lore demo investigate --offline default`. Show the real card. State that the model turns are recorded and the card discloses when and with which model.
+
+**This replaces the current `getting-started.md:19-22` block**, which still describes the old `hack/demo.sh` (`lore serve` + mocked Alertmanager + "just Go + curl"). That text is now factually wrong.
+
+- [ ] **Step 2: Tier 2 — Investigate (kubeconfig + one API key)**
+
+`lore investigate --alert "<symptom>" --namespace <ns>` with **no config file**. Document the env vars, the four flags, and the stderr degradation notice — explaining that it means *under-configured*, not *broken*.
+
+- [ ] **Step 3: Tier 3 — Learn (the full loop)**
+
+Keep the existing step numbering so inbound anchors survive. Document exactly one stack: **Prometheus + GitHub + an OpenAI-compatible LLM + Slack**. Every other option becomes a one-line pointer into `/docs/integrations/`.
+
+Fix the two §9 bugs here:
+- Flux/Argo CD moves from **Required** to **Recommended** (the README's framing is the correct one and matches the code — an unset source disables its tool).
+- `../deploy/helm/runlore/values-minimal.yaml` and any other repo-relative link become absolute GitHub URLs.
+
+- [ ] **Step 4: Build, link-check, commit**
+
+```bash
+cd website && /usr/bin/hugo --gc --minify
+grep -rn "](\.\./" website/content/docs/getting-started.md   # must return nothing
+```
+
+---
+
+### Task 5: Values profiles
+
+**Files:**
+- Modify: `deploy/helm/runlore/values-minimal.yaml` (trim to ~15 lines)
+- Create: `deploy/helm/runlore/values-standard.yaml`, `values-full.yaml`
+- Modify: `internal/config/minimal_values_test.go`
+
+- [ ] **Step 1: Extend the schema test first**
+
+`internal/config/minimal_values_test.go` validates one profile against `values.schema.json`. Generalize it to a table over all three, so a profile that drifts from the schema fails CI. Run it — it should fail on the two files that do not exist yet.
+
+- [ ] **Step 2: Write the profiles**
+
+| Profile | Contains |
+|---|---|
+| `values-minimal` | image, model, one notifier. Investigate + notify. **~15 lines.** |
+| `values-standard` | + catalog git-sync, forge/GitHub App, webhook token, metrics + logs |
+| `values-full` | + HA, persistence, NetworkPolicy, actions ladder, cloud, network flows, instant recall |
+
+- [ ] **Step 3: Point Getting Started at them**
+
+Tier 3 shows `values-minimal` **inline** (it is short enough), links `values-standard`, and links `values-full` rather than inlining ~180 lines.
+
+- [ ] **Step 4: Run the tests and commit**
+
+---
+
+### Task 6: Cross-link and retire stale references
+
+**Files:** `website/content/docs/concepts/data-sources.md`, `website/content/docs/configuration/configuration.md`, `README.md`, `CONTRIBUTING.md`
+
+- [ ] **Step 1: Leave forwarding pointers**
+
+Where content moved out of `data-sources.md`, leave a one-line pointer to the integration page rather than a gap. `configuration.md` stays the exhaustive key reference every integration page deep-links into — do not trim it.
+
+- [ ] **Step 2: Sweep for stale text**
+
+```bash
+grep -rn "hack/demo.sh" --include="*.md" . | grep -v CHANGELOG
+grep -rn "Required" website/content/docs/getting-started.md | head
+```
+Every hit must describe current behaviour.
+
+- [ ] **Step 3: Add the Hugo version note**
+
+Every website task in wave 1 hit the stale-`hugo` failure. Add a line to `CONTRIBUTING.md`: the site needs Hugo ≥ 0.146.0 (Hextra uses the `try` template func); an older binary fails with `function "try" not defined`.
+
+- [ ] **Step 4: Final build and commit**
+
+---
+
+## Final verification
+
+- [ ] `cd website && /usr/bin/hugo --gc --minify` builds clean
+- [ ] `go test ./... && golangci-lint run` clean
+- [ ] The drift guard fails when an integration is added without a page (proven by mutation, reverted)
+- [ ] No `](../` repo-relative link remains in `getting-started.md`
+- [ ] The first `values.yaml` a reader sees is ≤ 20 lines
+- [ ] Tier 1 requires no cluster and no key; tier 2 requires no config file
+- [ ] `/docs/integrations/` lists every registered trigger, LLM, data source, notifier and forge
+- [ ] Open the PR — English title and description, no AI attribution, no co-author trailers
+</content>

--- a/docs/superpowers/plans/2026-08-02-s3-proof-assets.md
+++ b/docs/superpowers/plans/2026-08-02-s3-proof-assets.md
@@ -1,0 +1,920 @@
+# S3 — Proof assets — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make RunLore's honesty positioning verifiable — a live public eval scorecard on runlore.io, a published cost-per-investigation figure, and recall claims that survive a hostile reader opening the test that produced them.
+
+**Architecture:** Per-case token attribution is added to the eval runner by snapshotting the existing `CountingModel` around each sequential run, which lets the scorecard renderer split cost between full investigations and instant recalls. The `/eval` page is built by `docs.yml` fetching `scorecard.md` from the `eval-scorecard` orphan branch at build time, triggered by a `repository_dispatch` the nightly eval fires. The recall documentation gains the corpus and methodology caveats, pinned by a test that parses the published table and compares it to the live measurement.
+
+**Tech Stack:** Go 1.x, GitHub Actions, Hugo/Hextra, `ossf/scorecard-action`.
+
+**Spec:** [`docs/superpowers/specs/2026-08-02-s3-proof-assets-design.md`](../specs/2026-08-02-s3-proof-assets-design.md)
+
+## Global Constraints
+
+- Every new `.go` file starts with `// SPDX-License-Identifier: Apache-2.0`.
+- `golangci-lint run` must pass (`.golangci.yml`).
+- No new third-party Go dependencies.
+- **No published number may be hand-written where it can be computed.** Every figure this plan adds to a doc is either rendered from data or pinned by a test.
+- GitHub Actions must be pinned by commit SHA where the surrounding workflow already does so — match the file you are editing.
+- Workflow permissions stay least-privilege; do not widen a job's `permissions` block beyond what the new step needs.
+- Conventional Commits. **Never** add co-author trailers or AI attribution.
+
+---
+
+### Task 1: Per-case token attribution in the eval report
+
+**Files:**
+- Modify: `internal/eval/compare_run.go:17-42` (add a snapshot accessor)
+- Modify: `internal/eval/score.go:12-24` (add `Usage` to `Result`)
+- Modify: `internal/eval/eval.go:20-23, 25, 218-224` (Runner captures per-run usage)
+- Modify: `internal/eval/eval.go:151-168` (`CaseAggregate` gains median tokens)
+- Modify: `internal/eval/replay_report.go:30-45` (`ReportCase` gains tokens)
+- Create: `internal/eval/usage_attribution_test.go`
+
+**Interfaces:**
+- Consumes: `providers.Usage` (`providers.go:870`), `eval.CountingModel` (`compare_run.go:17`), `eval.Runner` (`eval.go:20`).
+- Produces:
+  - `type UsageCounter interface { Total() providers.Usage }`
+  - `Result.Usage providers.Usage`
+  - `CaseAggregate.InputTokens int`, `CaseAggregate.OutputTokens int` (median over repeats)
+  - `ReportCase.InputTokens int`, `ReportCase.OutputTokens int` (JSON: `input_tokens`, `output_tokens`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/eval/usage_attribution_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// TestAggregateMediansUsage: per-case token counts are the MEDIAN across repeats,
+// matching how confidence is already aggregated. The median is what a published
+// cost figure should quote — one expensive outlier must not set the headline number.
+func TestAggregateMediansUsage(t *testing.T) {
+	results := []Result{
+		{Name: "c", Pass: true, Confidence: 0.8, Usage: providers.Usage{InputTokens: 100, OutputTokens: 10}},
+		{Name: "c", Pass: true, Confidence: 0.8, Usage: providers.Usage{InputTokens: 300, OutputTokens: 30}},
+		{Name: "c", Pass: true, Confidence: 0.8, Usage: providers.Usage{InputTokens: 200, OutputTokens: 20}},
+	}
+	agg := aggregateResults(Case{Name: "c"}, results)
+	if agg.InputTokens != 200 {
+		t.Errorf("median input tokens = %d, want 200", agg.InputTokens)
+	}
+	if agg.OutputTokens != 20 {
+		t.Errorf("median output tokens = %d, want 20", agg.OutputTokens)
+	}
+}
+
+// TestAggregateUsageZeroWhenUnreported: a provider that reports no usage must yield
+// zero, never a fabricated estimate. Zero renders as "unknown" downstream.
+func TestAggregateUsageZeroWhenUnreported(t *testing.T) {
+	agg := aggregateResults(Case{Name: "c"}, []Result{{Name: "c", Pass: true}})
+	if agg.InputTokens != 0 || agg.OutputTokens != 0 {
+		t.Errorf("usage = %d/%d, want 0/0 when the provider reports none", agg.InputTokens, agg.OutputTokens)
+	}
+}
+
+// countingStub implements UsageCounter with a scripted running total, standing in for
+// CountingModel so the snapshot arithmetic is testable without a model.
+type countingStub struct{ totals []providers.Usage; i int }
+
+func (c *countingStub) Total() providers.Usage {
+	u := c.totals[c.i]
+	if c.i < len(c.totals)-1 {
+		c.i++
+	}
+	return u
+}
+
+// TestUsageDeltaIsPerRun: the runner attributes each run only the tokens that run
+// spent, by differencing the cumulative counter before and after.
+func TestUsageDeltaIsPerRun(t *testing.T) {
+	before := providers.Usage{InputTokens: 1000, OutputTokens: 100}
+	after := providers.Usage{InputTokens: 1350, OutputTokens: 140}
+	got := usageDelta(before, after)
+	if got.InputTokens != 350 || got.OutputTokens != 40 {
+		t.Errorf("usageDelta = %+v, want 350 in / 40 out", got)
+	}
+}
+
+// TestReportCarriesPerCaseTokens: the tokens must survive projection into the report,
+// because that JSON is what the published scorecard renders from.
+func TestReportCarriesPerCaseTokens(t *testing.T) {
+	camp := Campaign{N: 1, Aggregates: []CaseAggregate{
+		{Name: "c", Runs: 1, Reached: true, InputTokens: 4200, OutputTokens: 380},
+	}}
+	rep := camp.Report("2026-08-02T00:00:00Z", "anthropic/claude-haiku-4-5", providers.Usage{}, nil)
+	if len(rep.Cases) != 1 {
+		t.Fatalf("cases = %d, want 1", len(rep.Cases))
+	}
+	if rep.Cases[0].InputTokens != 4200 || rep.Cases[0].OutputTokens != 380 {
+		t.Errorf("report case tokens = %d/%d, want 4200/380",
+			rep.Cases[0].InputTokens, rep.Cases[0].OutputTokens)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/eval/ -run 'TestAggregateMediansUsage|TestUsageDelta|TestReportCarries' -v`
+Expected: FAIL — `unknown field Usage in struct literal of type Result`
+
+- [ ] **Step 3: Write the implementation**
+
+In `internal/eval/score.go`, add to `Result` (after `RecallShortCircuit`):
+
+```go
+	// Usage is the provider-reported token spend of THIS run, attributed by the
+	// runner differencing its cumulative counter. Zero means the provider reported
+	// nothing — treated downstream as unknown, never as free.
+	Usage providers.Usage
+```
+
+In `internal/eval/compare_run.go`, add the interface beside `CountingModel`:
+
+```go
+// UsageCounter is the "how many tokens so far" capability the runner needs to
+// attribute spend per case. CountingModel implements it; a plain model does not, and
+// the runner simply records zero usage in that case.
+type UsageCounter interface {
+	Total() providers.Usage
+}
+
+// compile-time assertion: the counting wrapper satisfies the capability.
+var _ UsageCounter = (*CountingModel)(nil)
+```
+
+In `internal/eval/eval.go`, add the delta helper:
+
+```go
+// usageDelta returns the spend between two cumulative snapshots. The counter only
+// grows, so a negative result is impossible; clamping is unnecessary.
+func usageDelta(before, after providers.Usage) providers.Usage {
+	return providers.Usage{
+		InputTokens:       after.InputTokens - before.InputTokens,
+		OutputTokens:      after.OutputTokens - before.OutputTokens,
+		CachedInputTokens: after.CachedInputTokens - before.CachedInputTokens,
+		CacheWriteTokens:  after.CacheWriteTokens - before.CacheWriteTokens,
+	}
+}
+```
+
+Wrap `runOne` in `aggregateCase` so each run is measured. `RunN` → `aggregateCase` → `runOne` is strictly sequential (`eval.go:207-224`), which is what makes snapshot differencing correct here:
+
+```go
+func (r *Runner) aggregateCase(ctx context.Context, c Case, n int) CaseAggregate {
+	results := make([]Result, 0, n)
+	counter, counted := r.Model.(UsageCounter)
+	for i := 0; i < n; i++ {
+		var before providers.Usage
+		if counted {
+			before = counter.Total()
+		}
+		res := r.runOne(ctx, c)
+		if counted {
+			// Sequential by construction (RunN → aggregateCase → runOne), so the
+			// delta over this window is exactly this run's spend.
+			res.Usage = usageDelta(before, counter.Total())
+		}
+		results = append(results, res)
+	}
+	return aggregateResults(c, results)
+}
+```
+
+In `CaseAggregate`, add:
+
+```go
+	// InputTokens / OutputTokens are the MEDIAN provider-reported spend per run for
+	// this case — the basis of the published cost-per-investigation figure. Zero when
+	// the model does not report usage.
+	InputTokens  int
+	OutputTokens int
+```
+
+In `aggregateResults`, collect and median them alongside the existing confidence median (reuse the same median helper the function already uses for `confs` — find it and use it; do not write a second one):
+
+```go
+	ins := make([]float64, 0, len(results))
+	outs := make([]float64, 0, len(results))
+	for _, res := range results {
+		ins = append(ins, float64(res.Usage.InputTokens))
+		outs = append(outs, float64(res.Usage.OutputTokens))
+	}
+```
+
+and set `InputTokens: int(median(ins))`, `OutputTokens: int(median(outs))` in the returned aggregate, matching the existing median function's name.
+
+In `internal/eval/replay_report.go`, add to `ReportCase`:
+
+```go
+	// Per-case token spend (median over the repeats) — what the scorecard's
+	// cost-per-investigation table is computed from.
+	InputTokens  int `json:"input_tokens,omitempty"`
+	OutputTokens int `json:"output_tokens,omitempty"`
+```
+
+`Campaign.Report` projects with `ReportCase(a)` — a direct conversion, so the new fields must appear in **the same order and with the same names and types** in both structs for the conversion to keep compiling. Add them at the end of both.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/ -v`
+Expected: PASS — the new tests and every existing one.
+
+- [ ] **Step 5: Lint**
+
+Run: `golangci-lint run ./internal/eval/...`
+Expected: no issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/eval/
+git commit -m "feat(eval): attribute token spend per case for cost reporting"
+```
+
+---
+
+### Task 2: Cost-per-investigation section in the scorecard
+
+**Files:**
+- Modify: `internal/eval/scorecard.go:110-165`
+- Create: `internal/eval/scorecard_cost_test.go`
+- Modify: `eval/ci.runlore.yaml` (add `model.pricing`)
+
+**Interfaces:**
+- Consumes: `ReportCase.InputTokens/OutputTokens` (Task 1), `ReportCase.RecallShortCircuit` (`replay_report.go:44`), `Report.CostUSD`, `EstimateCostUSD` (`replay_report.go:68`), `Report.Model`.
+- Produces: `func costSection(rep Report, inUSD, cachedUSD, outUSD float64) string`, rendered inside `ScorecardMarkdown`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/eval/scorecard_cost_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package eval
+
+import (
+	"strings"
+	"testing"
+)
+
+func costReport() Report {
+	return Report{
+		At: "2026-08-02T06:00:00Z", Model: "anthropic/claude-haiku-4-5", N: 5,
+		Reached: 2, Total: 2, PassRate: 1,
+		Cases: []ReportCase{
+			// A full investigation: no recall short-circuit, high token spend.
+			{Name: "gitops-bad-image-tag", Runs: 5, Reached: true,
+				InputTokens: 96000, OutputTokens: 3200},
+			// An instant recall: short-circuited, an order of magnitude cheaper.
+			{Name: "known-pattern-recall", Runs: 5, Reached: true, HasRecall: true,
+				RecallShortCircuit: 5, InputTokens: 4100, OutputTokens: 260},
+		},
+	}
+}
+
+// TestCostSectionSplitsRecallFromFullLoop is the report's asked-for comparison: a
+// full investigation next to an instant recall, priced. It is the number no
+// competitor publishes.
+func TestCostSectionSplitsRecallFromFullLoop(t *testing.T) {
+	got := costSection(costReport(), 1.00, 0.10, 5.00)
+	if !strings.Contains(got, "full investigation") {
+		t.Errorf("missing the full-investigation row:\n%s", got)
+	}
+	if !strings.Contains(got, "instant recall") {
+		t.Errorf("missing the instant-recall row:\n%s", got)
+	}
+	// 96000 in @ $1/MTok + 3200 out @ $5/MTok = 0.096 + 0.016 = $0.112
+	if !strings.Contains(got, "0.11") {
+		t.Errorf("full-investigation cost not rendered:\n%s", got)
+	}
+	// The model must be named next to the figure — a naked price is unfalsifiable.
+	if !strings.Contains(got, "claude-haiku-4-5") {
+		t.Errorf("cost figures must name the model:\n%s", got)
+	}
+}
+
+// TestCostSectionOmittedWithoutPrices: no prices configured means no cost section at
+// all. Rendering "$0.00" would be a lie.
+func TestCostSectionOmittedWithoutPrices(t *testing.T) {
+	if got := costSection(costReport(), 0, 0, 0); got != "" {
+		t.Errorf("expected no cost section without prices, got:\n%s", got)
+	}
+}
+
+// TestCostSectionOmittedWithoutTokens: an old report carrying no per-case tokens must
+// not render an empty or zeroed table.
+func TestCostSectionOmittedWithoutTokens(t *testing.T) {
+	rep := costReport()
+	for i := range rep.Cases {
+		rep.Cases[i].InputTokens, rep.Cases[i].OutputTokens = 0, 0
+	}
+	if got := costSection(rep, 1.00, 0.10, 5.00); got != "" {
+		t.Errorf("expected no cost section without token data, got:\n%s", got)
+	}
+}
+
+// TestScorecardIncludesCostSection wires it end to end through the renderer.
+func TestScorecardIncludesCostSection(t *testing.T) {
+	rep := costReport()
+	c := 0.5
+	rep.CostUSD = &c
+	md := ScorecardMarkdown(rep, nil)
+	if !strings.Contains(md, "Cost per investigation") {
+		t.Errorf("scorecard missing the cost section:\n%s", md)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/eval/ -run TestCost -v`
+Expected: FAIL — `undefined: costSection`
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `internal/eval/scorecard.go`:
+
+```go
+// costSection renders the cost-per-investigation comparison: what a full
+// investigation costs against what an instant recall costs, on this run's model at
+// this run's prices. It is the single most concrete claim the learning loop makes —
+// recall is roughly an order of magnitude cheaper — and publishing it turns an
+// assertion into a measurement.
+//
+// Returns "" when prices are unset or the report carries no per-case token data;
+// a fabricated or zeroed cost would be worse than no cost at all.
+func costSection(rep Report, inUSD, cachedUSD, outUSD float64) string {
+	if inUSD == 0 && outUSD == 0 {
+		return ""
+	}
+	var full, recall []ReportCase
+	for _, c := range rep.Cases {
+		if c.InputTokens == 0 && c.OutputTokens == 0 {
+			continue // no usage reported for this case
+		}
+		if c.RecallShortCircuit > 0 {
+			recall = append(recall, c)
+		} else {
+			full = append(full, c)
+		}
+	}
+	if len(full) == 0 && len(recall) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("\n## Cost per investigation\n\n")
+	fmt.Fprintf(&b, "Median provider-reported tokens per case on `%s`, priced at $%.2f/MTok in · $%.2f/MTok out. ",
+		rep.Model, inUSD, outUSD)
+	b.WriteString("Replay evidence, so tool latency and live-cluster variance are excluded.\n\n")
+	b.WriteString("| path | cases | median in tok | median out tok | est. cost |\n|---|---|---|---|---|\n")
+	row := func(label string, cs []ReportCase) {
+		if len(cs) == 0 {
+			return
+		}
+		ins := make([]float64, 0, len(cs))
+		outs := make([]float64, 0, len(cs))
+		for _, c := range cs {
+			ins = append(ins, float64(c.InputTokens))
+			outs = append(outs, float64(c.OutputTokens))
+		}
+		mi, mo := median(ins), median(outs)
+		cost := EstimateCostUSD(
+			providers.Usage{InputTokens: int(mi), OutputTokens: int(mo)},
+			inUSD, cachedUSD, outUSD)
+		fmt.Fprintf(&b, "| %s | %d | %s | %s | $%.3f |\n",
+			label, len(cs), compactTokens(int(mi)), compactTokens(int(mo)), cost)
+	}
+	row("full investigation", full)
+	row("instant recall", recall)
+	return b.String()
+}
+```
+
+Use the package's existing median helper (the one `aggregateResults` uses — check its name and signature in `internal/eval/stats.go` and call it, do not duplicate). Add `"github.com/Smana/runlore/internal/providers"` to the imports if absent.
+
+Call it from `ScorecardMarkdown`, right after the Scenarios table and before "Confidence calibration".
+
+The prices must reach the renderer without `internal/eval` taking a dependency on
+`internal/config`, so the signature takes three floats rather than a `*config.Pricing`:
+
+```go
+func ScorecardMarkdown(rep Report, history []HistoryEntry, inUSD, cachedUSD, outUSD float64) string
+```
+
+Update both call sites: `internal/app/eval_scorecard.go:57` and `internal/eval/scorecard_test.go` (pass `0, 0, 0` in existing tests — they assert on sections the cost block does not touch).
+
+`RunEvalScorecard` reads a report from disk and has no config, and `Report` carries only the *total* `CostUSD` — not the rates behind it. So the rates travel **in the report**. Add three fields to `Report` in `internal/eval/replay_report.go`:
+
+```go
+	// Token rates (USD per MTok) this run was priced at, carried so the published
+	// scorecard can show a per-path cost breakdown without re-reading any config.
+	InputUSDPerMTok       float64 `json:"input_usd_per_mtok,omitempty"`
+	CachedInputUSDPerMTok float64 `json:"cached_input_usd_per_mtok,omitempty"`
+	OutputUSDPerMTok      float64 `json:"output_usd_per_mtok,omitempty"`
+```
+
+Set them in `internal/app/eval.go` next to `evalCostUSD(cfg, usage)`:
+
+```go
+		rep := camp.Report(st, cfg.Model.Provider+"/"+cfg.Model.Model, usage, evalCostUSD(cfg, usage))
+		if p := cfg.Model.Pricing; p != nil {
+			rep.InputUSDPerMTok = p.InputUSDPerMTok
+			rep.CachedInputUSDPerMTok = p.CachedInputUSDPerMTok
+			rep.OutputUSDPerMTok = p.OutputUSDPerMTok
+		}
+```
+
+and read them in `RunEvalScorecard`:
+
+```go
+	md := eval.ScorecardMarkdown(rep, entries, rep.InputUSDPerMTok, rep.CachedInputUSDPerMTok, rep.OutputUSDPerMTok)
+```
+
+Confirm the exact `config.Pricing` field names at `internal/config/config.go:592` before writing this — use what is there.
+
+- [ ] **Step 4: Configure prices for the nightly**
+
+Add to `eval/ci.runlore.yaml` under `model:` the `pricing:` block with the rates for the model the nightly runs. `config.Model.Pricing` already exists (`config.go:586`), so this is a supported key, not a schema change. Use the current published rates for that model and add a comment naming the date they were checked.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/eval/ ./internal/app/ -v`
+Expected: PASS.
+
+- [ ] **Step 6: Render a scorecard locally to eyeball it**
+
+Run:
+```bash
+go run ./cmd/lore eval scorecard -report eval/reports/<any *-replay.json> -dir /tmp/sc
+cat /tmp/sc/scorecard.md
+```
+Expected: renders. (Existing reports predate per-case tokens, so the cost section will be correctly *absent* — that is the `TestCostSectionOmittedWithoutTokens` behaviour, proven live.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/eval/ internal/app/eval.go internal/app/eval_scorecard.go eval/ci.runlore.yaml
+git commit -m "feat(eval): publish cost per investigation, split by recall vs full loop"
+```
+
+---
+
+### Task 3: Recall-claim honesty pass and its drift guard
+
+**Files:**
+- Modify: `website/content/docs/concepts/learning-loop.md:139-146`
+- Modify: `README.md` (the learning-loop recall paragraph)
+- Create: `internal/investigate/recall_doc_claims_test.go`
+
+**Interfaces:**
+- Consumes: the measurement helpers `computeFire`, `computeFireReranked`, `scriptedReranker`, `rerankTargets`, `evalCases`, `writeEvalCatalog` from `internal/investigate/recalleval_test.go` (same package, test-only).
+- Produces: `TestRecallDocClaimsMatchMeasurement`.
+
+**Why this task exists:** `learning-loop.md:146` publishes `rerank on → 11/11 (1.00), precision 1.00, 0/2` as "measured on the eval harness". `recalleval_test.go:831` supplies `scriptedReranker{accept: rerankTargets(cases), conf: 0.9}` — a stand-in that accepts the correct target by construction. The row measures the gate's plumbing and the corpus's structural agreement, not a model's reranking judgment. Disclose it before a reader finds it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/investigate/recall_doc_claims_test.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// docClaimsPath is the published page whose numbers this test pins.
+const docClaimsPath = "../../website/content/docs/concepts/learning-loop.md"
+
+// TestRecallDocClaimsMatchMeasurement is a DRIFT GUARD over the real parse target:
+// it reads the numbers published in learning-loop.md and compares them to the values
+// the measurement actually produces right now. Editing the prose without re-measuring
+// (or changing the engine without updating the prose) fails here.
+//
+// It also asserts the METHODOLOGY caveat is present. The rerank-on row is measured
+// with a scripted reranker that accepts the correct target by construction, so the
+// row measures the fire gate, not model judgment — a page that quotes the number
+// without saying so overstates it.
+func TestRecallDocClaimsMatchMeasurement(t *testing.T) {
+	raw, err := os.ReadFile(docClaimsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", docClaimsPath, err)
+	}
+	doc := string(raw)
+
+	cat := writeEvalCatalog(t)
+	cases := evalCases()
+	off := computeFire(t, cat, cases)
+	on := computeFireReranked(t, cat, cases, &scriptedReranker{accept: rerankTargets(cases), conf: 0.9})
+
+	// | rerank **off** | 0/11 (0.00) | — | 0/2 |
+	offRow := regexp.MustCompile(`rerank \*\*off\*\* \| (\d+)/(\d+)`)
+	m := offRow.FindStringSubmatch(doc)
+	if m == nil {
+		t.Fatalf("could not find the rerank-off row in %s — did the table change shape?", docClaimsPath)
+	}
+	assertInt(t, "rerank-off fired", m[1], off.fired)
+	assertInt(t, "label positives", m[2], off.labelPositives)
+
+	// | rerank **on** | **11/11 (1.00)** | **1.00** | **0/2** |
+	onRow := regexp.MustCompile(`rerank \*\*on\*\* \| \*\*(\d+)/(\d+)`)
+	m = onRow.FindStringSubmatch(doc)
+	if m == nil {
+		t.Fatalf("could not find the rerank-on row in %s", docClaimsPath)
+	}
+	assertInt(t, "rerank-on fired", m[1], on.fired)
+	assertInt(t, "label positives (on)", m[2], on.labelPositives)
+
+	// The methodology caveat must accompany the number.
+	for _, want := range []string{"scripted", "not a model"} {
+		if !contains(doc, want) {
+			t.Errorf("learning-loop.md must state the methodology caveat containing %q, "+
+				"otherwise the rerank-on row reads as measured model accuracy", want)
+		}
+	}
+}
+
+func assertInt(t *testing.T, what, got string, want int) {
+	t.Helper()
+	n, err := strconv.Atoi(got)
+	if err != nil {
+		t.Fatalf("%s: %q is not a number", what, got)
+	}
+	if n != want {
+		t.Errorf("%s: doc says %d, measurement says %d — the published number is stale", what, n, want)
+	}
+}
+
+func contains(hay, needle string) bool {
+	return len(hay) >= len(needle) && regexp.MustCompile(`(?i)`+regexp.QuoteMeta(needle)).MatchString(hay)
+}
+```
+
+Check the helper names against `internal/investigate/recalleval_test.go:824-841` before running — use the exact identifiers that exist (`computeFire`, `computeFireReranked`, `scriptedReranker`, `rerankTargets`, `evalCases`, `writeEvalCatalog`, and the field names `fired` / `labelPositives`).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/investigate/ -run TestRecallDocClaims -v`
+Expected: FAIL on the methodology caveat — the words are not in the page yet.
+
+- [ ] **Step 3: Update the documentation**
+
+In `website/content/docs/concepts/learning-loop.md`, replace the sentence introducing the table (around line 139) and add a caveat paragraph immediately after it:
+
+```markdown
+> Measured on the eval harness at default thresholds (`recalleval_test.go`,
+> `TestRecallEvalRerankFireRate`) over **11 label-derived positives and 2 negatives**:
+>
+> | | fire-rate (label positives) | precision | negatives fired |
+> |---|---|---|---|
+> | rerank **off** | 0/11 (0.00) | — | 0/2 |
+> | rerank **on** | **11/11 (1.00)** | **1.00** | **0/2** |
+>
+> **What this does and does not measure.** The rerank-**on** row uses a *scripted*
+> reranker — a stand-in that returns the correct candidate at fixed confidence. So the
+> row measures the **fire gate and the corpus's structural agreement**, not a model's
+> reranking accuracy: it proves that when the reranker is right, the calibrated gate
+> fires at the default threshold, which BM25-magnitude gating never did. It is **not a
+> model benchmark**. For what a real model achieves on real incidents, the honest
+> reference point is ITBench: frontier models identify the root cause **< 50%** of the
+> time (see [Benchmarking]({{< relref "/docs/reference/benchmarking.md" >}})). The
+> corpus here is small and hand-built; treat these numbers as a regression guard on the
+> gate, not as a field measurement.
+```
+
+Apply the same one-line caveat wherever `README.md` quotes recall performance: state the corpus size and that the fire-rate figure measures the gate.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/investigate/ -run TestRecallDocClaims -v`
+Expected: PASS.
+
+- [ ] **Step 5: Mutation-test the guard**
+
+Edit `learning-loop.md` changing `0/11` to `1/11`. Run the test.
+Expected: FAIL — `rerank-off fired: doc says 1, measurement says 0`. Revert.
+
+Then delete the word `scripted` from the caveat. Run the test.
+Expected: FAIL on the methodology assertion. Restore.
+
+- [ ] **Step 6: Build the site and commit**
+
+```bash
+cd website && hugo --gc --minify && cd ..
+git add website/content/docs/concepts/learning-loop.md README.md internal/investigate/recall_doc_claims_test.go
+git commit -m "docs(recall): state the corpus and the scripted-reranker caveat, pinned by a test"
+```
+
+---
+
+### Task 4: The `/eval` page and its publishing pipeline
+
+**Files:**
+- Modify: `.github/workflows/eval.yaml` (append a dispatch step)
+- Modify: `.github/workflows/docs.yml` (trigger, fetch, render)
+- Create: `website/content/eval.md` (the placeholder, overwritten at build time)
+- Modify: `website/content/docs/reference/benchmarking.md:10-14`
+- Modify: `README.md:16` (badge link target)
+- Modify: `.gitignore` (ignore the generated page body if the render writes a temp file)
+
+**Interfaces:**
+- Consumes: the `eval-scorecard` branch layout written by `eval.yaml:80-110` (`scorecard.md`, `badge.json`, `history.jsonl`).
+- Produces: `https://runlore.io/eval`.
+
+- [ ] **Step 1: Write the placeholder page**
+
+Create `website/content/eval.md`:
+
+```markdown
+---
+title: Eval scorecard
+---
+
+# RunLore nightly eval scorecard
+
+*No nightly scorecard has been published yet.*
+
+The nightly replay eval publishes a per-scenario scorecard — pass/fail, recall
+outcomes, confidence calibration, model, date and cost — on every run, red or green.
+When a run has published, this page shows it.
+
+Reproduce it yourself:
+
+```
+lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7
+```
+
+See [`.github/workflows/eval.yaml`](https://github.com/Smana/runlore/blob/main/.github/workflows/eval.yaml).
+```
+
+This file is committed so the site always builds and the link is never dead; the workflow overwrites it when a scorecard exists.
+
+- [ ] **Step 2: Add the fetch-and-render step to `docs.yml`**
+
+Extend the `on:` block:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [scorecard-updated]
+```
+
+Insert a step after `Install Hugo Extended` and before `Build`:
+
+```yaml
+      # Pull the published scorecard from the eval-scorecard orphan branch and render
+      # it as /eval. The branch is the nightly's publishing target; copying it in at
+      # build time keeps main free of generated numbers. A missing branch is NOT a
+      # failure — the committed placeholder stands in, so the docs deploy and the
+      # link stay alive either way.
+      - name: Render the eval scorecard page
+        run: |
+          set -euo pipefail
+          if ! git fetch --depth=1 origin eval-scorecard 2>/dev/null; then
+            echo "::notice title=Eval scorecard::branch not published yet — keeping the placeholder"
+            exit 0
+          fi
+          published=$(git log -1 --format=%cI FETCH_HEAD)
+          {
+            echo "---"
+            echo "title: Eval scorecard"
+            echo "---"
+            echo
+            echo "*Published ${published} from the [\`eval-scorecard\`](https://github.com/Smana/runlore/tree/eval-scorecard) branch.*"
+            echo
+            git show FETCH_HEAD:scorecard.md
+          } > website/content/eval.md
+```
+
+The checkout step already uses `fetch-depth: 0`, so the fetch works without extra configuration.
+
+- [ ] **Step 3: Add the dispatch step to `eval.yaml`**
+
+Append after the `publish scorecard (eval-scorecard branch)` step:
+
+```yaml
+      # Tell the docs site to rebuild so /eval shows the fresh numbers. Without this
+      # the page would only refresh when someone happens to push to website/.
+      - name: trigger docs rebuild
+        if: always() && steps.guard.outputs.has_key == 'true' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f event_type=scorecard-updated
+```
+
+The job already declares `contents: write`, which is the permission `POST /repos/{owner}/{repo}/dispatches` requires — do not widen it further.
+
+- [ ] **Step 4: Repoint the references**
+
+- `website/content/docs/reference/benchmarking.md:10-14` — replace the blockquote's link to the branch with a link to `/eval`:
+  ```markdown
+  > RunLore's own nightly numbers are public: the replay eval publishes a
+  > per-scenario scorecard — pass/fail, recall outcomes, confidence calibration,
+  > model, date, and cost — on every run, red or green.
+  > **→ [The nightly scorecard](/eval)**
+  ```
+- `README.md:16` — keep the badge *image* (it reads `badge.json` from the branch, which is what makes it update without a site rebuild) and change only its **link target** to `https://runlore.io/eval`.
+
+- `website/content/_index.md` — this PR creates `/eval`, so it also owns the homepage line pointing at it. Add immediately after the hero buttons (currently `_index.md:27`):
+
+  ```markdown
+  <p class="rl-eyebrow"><a href="/eval">The only SRE agent that publishes its own nightly eval scorecard</a> — per scenario, red or green.</p>
+  ```
+
+  If the S4 positioning branch has already merged, the hero copy around it will differ — insert the line after whatever the last `hero-button` shortcode is, and do not otherwise touch the hero.
+
+- [ ] **Step 5: Verify the workflows parse**
+
+Run: `gh workflow view docs.yml` and `gh workflow view eval.yaml`
+Expected: both render without a parse error. Alternatively run `actionlint` if available.
+
+Test the render step's logic locally:
+```bash
+git fetch --depth=1 origin eval-scorecard || echo "branch absent — placeholder path taken"
+```
+Expected (today): the branch is absent, so the placeholder path is exercised — which is exactly the case that must not break the build.
+
+- [ ] **Step 6: Build the site**
+
+Run: `cd website && hugo --gc --minify`
+Expected: builds, `/eval` renders the placeholder.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/docs.yml .github/workflows/eval.yaml website/content/eval.md website/content/docs/reference/benchmarking.md README.md
+git commit -m "feat(eval): publish the nightly scorecard as a page on runlore.io"
+```
+
+---
+
+### Task 5: ADOPTERS, OpenSSF Scorecard, SBOM verification
+
+**Files:**
+- Create: `ADOPTERS.md`
+- Create: `.github/workflows/scorecard.yml`
+- Modify: `README.md` (badge row + an adopters ask)
+- Modify: `SECURITY.md` (state the supply-chain artifacts)
+
+- [ ] **Step 1: Write `ADOPTERS.md`**
+
+```markdown
+# Adopters
+
+Teams and organizations running RunLore. Adding yourself helps other teams judge
+whether it fits their platform — and helps us prioritize what to build next.
+
+**To add yourself:** open a PR adding a row. Anything you are comfortable sharing is
+enough; the "how" column is the most useful part for other readers.
+
+| Organization | Since | How they use RunLore | Contact |
+|---|---|---|---|
+| [Ogenki](https://ogenki.io) | 2026-06 | Alertmanager → investigation → curated KB PRs on a self-hosted GitOps platform | [@Smana](https://github.com/Smana) |
+
+*Running RunLore but not ready to be listed publicly? Say hello in a
+[discussion](https://github.com/Smana/runlore/discussions) — anonymized feedback is
+just as valuable.*
+```
+
+- [ ] **Step 2: Add the OpenSSF Scorecard workflow**
+
+Create `.github/workflows/scorecard.yml`:
+
+```yaml
+# OpenSSF Scorecard — a weekly automated assessment of this repo's supply-chain
+# posture (branch protection, pinned dependencies, signed releases, SAST…). Results
+# publish to the Security tab; the badge in the README links to the public report.
+name: OpenSSF Scorecard
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "30 5 * * 1"      # Mondays 05:30 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload the SARIF result to the Security tab
+      id-token: write          # publish the signed result to the public API
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@<sha>   # v7.0.0 — match the SHA used in ci.yaml
+        with:
+          persist-credentials: false
+      - uses: ossf/scorecard-action@<sha>   # pin to the latest release SHA
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - uses: github/codeql-action/upload-sarif@<sha>
+        with:
+          sarif_file: results.sarif
+```
+
+Resolve each `<sha>` with `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` and pin it, matching how `ci.yaml` pins its actions. Do not leave a placeholder.
+
+- [ ] **Step 3: Add the badges and the adopters ask to the README**
+
+In the badge block (`README.md:14-20`) add, keeping the existing style:
+
+```markdown
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Smana/runlore/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Smana/runlore)
+```
+
+Add a short "Who's using RunLore" line near the bottom of the README linking `ADOPTERS.md` and inviting entries.
+
+- [ ] **Step 4: Verify the SBOM actually ships**
+
+Run:
+```bash
+sed -n '44,60p' .goreleaser.yaml
+gh release view $(git describe --tags --abbrev=0) --json assets --jq '.assets[].name'
+```
+Expected: the `sboms:` config produces `*.sbom.json` (or similar) assets on the release. If they are present, document it in `SECURITY.md` under a "Supply chain" heading: cosign keyless signing of binaries, checksums bundle, SBOMs per artifact, signed OCI chart, and how to verify each. If they are **not** present, fix the goreleaser config so they are — the point of this task is that the claim is true.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ADOPTERS.md .github/workflows/scorecard.yml README.md SECURITY.md
+git commit -m "docs: ADOPTERS.md, OpenSSF Scorecard badge, and the supply-chain posture"
+```
+
+---
+
+### Task 6: Bootstrap the scorecard branch — maintainer step
+
+**Files:** none in the repo.
+
+> **This task is the owner's to perform.** Nothing in Tasks 1–5 depends on it, but the acceptance criteria do: until the secret exists, the badge stays broken and `/eval` shows the placeholder.
+
+- [ ] **Step 1: Add the secret**
+
+```bash
+gh secret set RUNLORE_EVAL_API_KEY --body "<anthropic api key>"
+gh secret list          # confirm it appears
+```
+
+- [ ] **Step 2: Run the nightly on demand**
+
+```bash
+gh workflow run eval.yaml
+gh run watch
+```
+Expected: the run takes minutes (not 30 seconds — a 30-second "success" means the guard still sees no key), the `publish scorecard` step pushes, and the `trigger docs rebuild` step dispatches.
+
+- [ ] **Step 3: Verify the chain end to end**
+
+```bash
+git ls-remote --heads origin | grep eval-scorecard      # branch now exists
+gh run list --workflow=docs.yml -L 1                    # a repository_dispatch run fired
+curl -sI https://runlore.io/eval | head -1              # 200
+```
+Then open the README on GitHub and confirm the **Nightly eval** badge renders numbers rather than "invalid".
+
+- [ ] **Step 4: Read the published scorecard**
+
+Open `https://runlore.io/eval`. Confirm the per-scenario table, the calibration section, the cost-per-investigation table (Task 2), and the history are all present and the numbers are plausible. **If the run is red, publish it anyway** — that is the design, and the value of the asset is that it publishes red runs too.
+
+---
+
+## Final verification
+
+- [ ] `go build ./... && go test ./... && golangci-lint run` — all clean
+- [ ] `cd website && hugo --gc --minify` builds with and without the `eval-scorecard` branch present
+- [ ] The drift guard fails on an edited number and on a removed caveat (both mutations tried and reverted)
+- [ ] `/eval` reachable; README badge resolves; `benchmarking.md` link resolves
+- [ ] `ADOPTERS.md` linked from the README; OpenSSF badge renders; SBOM assets confirmed on the latest release
+- [ ] Run `/security-review` on the branch diff — the new workflow permissions and the `repository_dispatch` call are the parts to scrutinize
+- [ ] Open the PR — English title and description, no AI attribution, no co-author trailers
+</content>

--- a/docs/superpowers/plans/2026-08-02-s4-positioning.md
+++ b/docs/superpowers/plans/2026-08-02-s4-positioning.md
@@ -1,0 +1,396 @@
+# S4 — Positioning — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lead with the position RunLore actually owns — portable, Git-owned, human-reviewed incident knowledge — and put the competitive comparison where people search for it.
+
+**Architecture:** Content-only. The homepage hero, its social card and the site metadata are rewritten around knowledge ownership; the competitive research already in `prior-art.md` is projected into three standalone `/compare/<tool>` pages built for search intent, with `prior-art.md` remaining the sourced research they cite. MCP is promoted from a configuration subsection to the stated answer for toolset breadth.
+
+**Tech Stack:** Hugo + Hextra (`website/`), SVG → PNG export for the social card.
+
+**Spec:** [`docs/superpowers/specs/2026-08-02-s4-positioning-design.md`](../specs/2026-08-02-s4-positioning-design.md)
+
+## Global Constraints
+
+- **Every competitive claim must be sourced and dated.** A statement about another project carries a link to that project's own documentation or repository. No claim from memory.
+- Every compare page carries `last_verified: 2026-08-02` in its front matter and renders that date on the page.
+- Internal links use `{{< relref >}}`; `hugo.yaml` sets `refLinksErrorLevel: ERROR`, so a bad ref fails the build.
+- The headline copy is fixed by the spec — use it verbatim:
+  **H1:** `Your incident knowledge, in your Git. Not in a vendor's database.`
+- Do not touch the hero flow diagram SVG in `_index.md:30` — it already terminates in the OKF knowledge base, which is now the headline claim.
+- Conventional Commits. **Never** add co-author trailers or AI attribution.
+
+---
+
+### Task 1: Homepage hero and site metadata
+
+**Files:**
+- Modify: `website/content/_index.md:1-41`
+- Modify: `website/hugo.yaml:57` (`params.description`)
+
+**Interfaces:**
+- Consumes: Hextra shortcodes already in use — `hextra/hero-badge`, `hextra/hero-headline`, `hextra/hero-subtitle`, `hextra/hero-button`, `hextra/feature-grid`, `hextra/feature-card`.
+- Produces: the new hero copy that Task 2's social card must match.
+
+- [ ] **Step 1: Rewrite the front matter and hero**
+
+In `website/content/_index.md`, replace the `description` front-matter value and the headline/subtitle blocks:
+
+```yaml
+description: "Your incident knowledge, in your Git — not in a vendor's database. RunLore investigates alerts like the other agents do, then writes what it learned to a repo you own, as a pull request a human merges. Portable markdown, provenance-tracked, read-only by default, your models, one Go binary."
+```
+
+```markdown
+{{< hextra/hero-headline >}}
+  Your incident knowledge, in your Git. Not in a vendor's database.
+{{< /hextra/hero-headline >}}
+
+{{< hextra/hero-subtitle >}}
+  RunLore investigates alerts like the other agents do — then writes what it
+  learned to a repo you own, as a pull request a human merges. Portable markdown,
+  provenance-tracked, trust that decays when it stops working. Read-only by
+  default, your models, one Go binary.
+{{< /hextra/hero-subtitle >}}
+```
+
+The subtitle's first clause names the category immediately, so a reader who arrived looking for "an SRE agent" is not left guessing before the differentiation lands.
+
+- [ ] **Step 2: Reorder the feature cards to follow the claim**
+
+Replace the `feature-grid` block (`_index.md:32-41`) so the ownership card leads:
+
+```markdown
+{{< hextra/feature-grid cols="2" >}}
+  {{< hextra/feature-card icon="academic-cap" title="Knowledge you own"
+    subtitle="Every investigation opens a pull request in a Git repo you control. A human merges it. The result is portable markdown with full provenance — exportable, greppable, and yours if you stop using RunLore tomorrow." >}}
+  {{< hextra/feature-card icon="shield-check" title="Read-only by default"
+    subtitle="Reads your cluster, metrics, logs and network flows. Its only writes go to Git, via reviewed PRs — and it would rather say “I don’t know” than guess." >}}
+  {{< hextra/feature-card icon="cube-transparent" title="GitOps-native provenance"
+    subtitle="Turns “what changed?” into an exact Git answer — the rendered-manifest diff of the revisions Flux or Argo CD reconciled. That provenance is what makes the knowledge trustworthy." >}}
+  {{< hextra/feature-card icon="chip" title="Your models · one Go binary"
+    subtitle="A single self-hosted Go binary running in your cluster on your own model providers. Any OpenAI-compatible endpoint, or native Anthropic. No lock-in, your data. Point it at any MCP server for tools it doesn’t ship." >}}
+{{< /hextra/feature-grid >}}
+```
+
+> **Not in scope here:** the "publishes its own eval scorecard" line above the fold belongs to S3, which creates `/eval`. Adding it from this PR would ship a dead link if this branch merges first. Do not add it.
+
+- [ ] **Step 3: Update the site-wide description**
+
+In `website/hugo.yaml:57`, replace `params.description` with the same sentence used in the front matter.
+
+- [ ] **Step 4: Build and review**
+
+Run: `cd website && hugo --gc --minify && hugo server -D`
+Open `http://localhost:1313/` and read the page top to bottom. Check: does the H1 → subtitle → cards → diagram sequence tell one coherent story? Is the category clear within the first two lines?
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/content/_index.md website/hugo.yaml
+git commit -m "docs(website): lead with knowledge ownership, not investigation speed"
+```
+
+---
+
+### Task 2: Regenerate the social card
+
+**Files:**
+- Modify: `website/static/images/og-card.svg`
+- Regenerate: `website/static/images/og-card.png`
+
+**Interfaces:**
+- Consumes: the H1 copy from Task 1.
+- Produces: a 1200×630 PNG at the same path (`hugo.yaml:60` and `_index.md:5` reference `images/og-card.png`, so neither changes).
+
+**Why:** `og-card.svg` hard-codes `The SRE agent that speeds up investigations` and `…and learns from your context`. Every shared link would keep advertising the headline Task 1 just replaced.
+
+- [ ] **Step 1: Read the current card**
+
+Run: `cat website/static/images/og-card.svg`
+Note the exact `<text>` elements, their `x`/`y`/`font-size`/`class` attributes, and the 1200×630 canvas. Keep the layout, gradient, and logo untouched — only the copy changes.
+
+- [ ] **Step 2: Edit the copy**
+
+Replace the two headline text elements. The new headline is longer than the old one, so it needs two lines:
+
+- line 1: `Your incident knowledge, in your Git.`
+- line 2: `Not in a vendor's database.`
+- subtitle: `Investigates incidents · curates what it learns to a repo you own`
+
+Reduce the headline `font-size` as needed so neither line exceeds roughly 1080px of the 1200px canvas, and adjust the two `y` values so the block stays vertically centered against the logo. Keep `runlore.io` and the `Free & open source · Apache-2.0` footer as they are.
+
+Use a typographic apostrophe (`’`) in `vendor’s` to match the rest of the site's copy, and escape nothing else — SVG text does not need entity escaping for that character in UTF-8.
+
+- [ ] **Step 3: Export the PNG**
+
+Try, in order of preference, whichever is available:
+
+```bash
+# Inkscape (best text rendering fidelity)
+inkscape website/static/images/og-card.svg \
+  --export-type=png --export-filename=website/static/images/og-card.png \
+  --export-width=1200 --export-height=630
+
+# or rsvg-convert
+rsvg-convert -w 1200 -h 630 website/static/images/og-card.svg \
+  -o website/static/images/og-card.png
+
+# or ImageMagick
+magick -background none -density 144 website/static/images/og-card.svg \
+  -resize 1200x630 website/static/images/og-card.png
+```
+
+- [ ] **Step 4: Verify the render**
+
+Run: `file website/static/images/og-card.png`
+Expected: `PNG image data, 1200 x 630`.
+
+Open the PNG and read it. Confirm: no clipped text, no overlap with the logo, both headline lines legible at thumbnail size (social previews render small — view it at ~25% zoom to check).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/static/images/og-card.svg website/static/images/og-card.png
+git commit -m "docs(website): social card matches the new headline"
+```
+
+---
+
+### Task 3: The `/compare` section and the HolmesGPT page
+
+**Files:**
+- Create: `website/content/compare/_index.md`
+- Create: `website/content/compare/holmesgpt.md`
+- Modify: `website/hugo.yaml:31-45` (menu)
+
+**Interfaces:**
+- Consumes: the sourced research in `website/content/docs/concepts/prior-art.md` (HolmesGPT row, "Where RunLore is different", the ITBench figures).
+- Produces: the page structure Task 4's two pages copy exactly.
+
+- [ ] **Step 1: Create the section index**
+
+Create `website/content/compare/_index.md`:
+
+```markdown
+---
+title: Compare
+weight: 5
+---
+
+How RunLore differs from the tools it is most often weighed against — and when you
+should pick one of them instead.
+
+Every page states what the other tool does better **first**, cites the project's own
+documentation, and carries the date the claims were last checked. If something here
+is out of date or wrong, [open an issue](https://github.com/Smana/runlore/issues) —
+a wrong claim about someone else's project is the most expensive kind of mistake we
+can make.
+
+{{< hextra/feature-grid cols="3" >}}
+  {{< hextra/feature-card link="holmesgpt/" title="RunLore vs HolmesGPT" subtitle="The strongest OSS investigation agent. Broader toolset, no learning loop." >}}
+  {{< hextra/feature-card link="k8sgpt/" title="RunLore vs k8sgpt" subtitle="A deterministic detector with LLM explanations, not an investigation loop." >}}
+  {{< hextra/feature-card link="aurora/" title="RunLore vs Aurora" subtitle="Diffs, a RAG knowledge base and fix PRs — but the knowledge stays in its databases." >}}
+{{< /hextra/feature-grid >}}
+
+The long-form research behind these pages — including the commercial landscape and the
+eval reality — is in [Prior art]({{< relref "/docs/concepts/prior-art.md" >}}).
+```
+
+- [ ] **Step 2: Write the HolmesGPT page**
+
+Create `website/content/compare/holmesgpt.md` with front matter:
+
+```yaml
+---
+title: RunLore vs HolmesGPT
+description: "HolmesGPT has the broader toolset; RunLore keeps what it learns in a Git repo you own. An honest, sourced comparison."
+last_verified: 2026-08-02
+---
+```
+
+Body sections, in this order:
+
+1. **One-paragraph summary.** HolmesGPT is the strongest open-source investigation agent and the one to beat on breadth. RunLore does not try to out-toolset it. The difference is what happens *after* the investigation.
+
+2. **What HolmesGPT does better** — first, and specifically. Source each from prior-art's HolmesGPT row and the project's own docs:
+   - ~60 toolsets spanning Datadog, New Relic, Splunk, Sentry, Elasticsearch/OpenSearch, VictoriaMetrics and more.
+   - CNCF Sandbox project with 2,205 contributors versus RunLore's 3 — a materially different bus factor and support surface.
+   - Approval-gated remediation with signed approval tickets since v0.34.
+   - Mature, widely deployed, backed by Robusta.
+
+3. **What RunLore does that HolmesGPT does not.**
+   - HolmesGPT is stateless: human-authored runbooks, every incident starts from zero (its commercial parent sells the intelligence layer). RunLore curates each verified finding into a PR against a Git repo you own; a merged entry answers the same incident instantly next time.
+   - Flux support and revision-exact "what changed" — HolmesGPT has an Argo CD toolset but no Flux and no rendered-diff-between-reconciled-revisions.
+   - A published nightly eval scorecard.
+
+4. **At a glance** — a table with columns `| | RunLore | HolmesGPT |` and rows: investigation breadth, learning loop, knowledge portability, human review gate, GitOps what-changed, autonomy ceiling, published eval numbers, project maturity, MCP client. Every cell either links a source or states "not documented".
+
+5. **Toolset breadth, honestly** — RunLore's native tool set is narrower by design. Any MCP server closes a specific gap; link `{{< relref "/docs/configuration/mcp.md" >}}`.
+
+6. **Pick HolmesGPT instead if…** — you need a specific vendor toolset today, you want a CNCF-governed project with a large contributor base, or you do not want a knowledge-review workflow at all.
+
+7. **Sources** — a bulleted list of every URL cited, each with "checked 2026-08-02".
+
+Render the verification date in the body, e.g.:
+
+```markdown
+*Claims about HolmesGPT last checked {{< param "last_verified" >}} against the project's own documentation.*
+```
+
+If that shortcode does not resolve page front matter in this Hextra version, write the date literally and keep it in sync with the front matter.
+
+- [ ] **Step 3: Add Compare to the menu**
+
+In `website/hugo.yaml`, add to `menu.main`, keeping weights ordered:
+
+```yaml
+    - name: Compare
+      pageRef: /compare
+      weight: 2
+```
+
+and bump the existing GitHub (2) and Search (3) entries to 3 and 4.
+
+- [ ] **Step 4: Verify every external link resolves**
+
+Run:
+```bash
+grep -oE 'https?://[^ )"]+' website/content/compare/holmesgpt.md | sort -u | \
+  while read -r u; do printf '%s %s\n' "$(curl -sIo /dev/null -w '%{http_code}' -L --max-time 15 "$u")" "$u"; done
+```
+Expected: every line starts `200`. A `404` on a competitor's documentation is a credibility bug — fix the link or drop the claim.
+
+- [ ] **Step 5: Build**
+
+Run: `cd website && hugo --gc --minify`
+Expected: builds; `/compare/` and `/compare/holmesgpt/` render; the menu shows Compare.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add website/content/compare/ website/hugo.yaml
+git commit -m "docs(website): /compare section with the HolmesGPT comparison"
+```
+
+---
+
+### Task 4: The k8sgpt and Aurora comparisons
+
+**Files:**
+- Create: `website/content/compare/k8sgpt.md`
+- Create: `website/content/compare/aurora.md`
+
+**Interfaces:**
+- Consumes: the page structure from Task 3 — same seven sections, same front matter keys (`title`, `description`, `last_verified`), same at-a-glance table shape.
+
+- [ ] **Step 1: Write the k8sgpt page**
+
+Same structure as Task 3. Substance, sourced from prior-art's k8sgpt row and the project's docs:
+
+- **What k8sgpt does better:** CNCF project since 2023 with ~7.8k stars and a far larger community; deterministic analyzers that need no LLM at all for many checks; trivial to adopt (`k8sgpt analyze`); `Result`-as-CRD fits a Kubernetes-native workflow.
+- **What RunLore does that k8sgpt does not:** k8sgpt is a *detector* with optional LLM explanation, not a multi-step investigation loop — it does not correlate metrics, logs, network flows and GitOps history into a ranked, evidence-backed root cause; it has no memory; it does not curate knowledge.
+- **Pick k8sgpt instead if…** you want fast deterministic cluster analysis without an LLM in the path, or you want the lightest possible thing to run.
+- Note honestly that the two are complementary rather than mutually exclusive.
+
+- [ ] **Step 2: Write the Aurora page**
+
+Same structure. Substance, sourced from prior-art's Aurora row:
+
+- **What Aurora does better:** commercial backing from Arvo AI and a funded team; sandboxed execution of `kubectl`/`aws`/`az`/`gcloud`; Terraform/IaC analysis as an RCA input, which RunLore does not have; auto-postmortems and fix PRs.
+- **What RunLore does that Aurora does not:** Aurora's knowledge base is auto-ingested RAG locked in Postgres + Weaviate + Memgraph — no review gate, no Git export, no outcome signal. RunLore's is human-reviewed markdown in a repo you own, with trust that decays on real-world resolve-rate, and an eval scenario proving a poisoned entry is rejected at recall time.
+- **Be scrupulously fair here.** Aurora is Apache-2.0 and moving fast; prior-art calls it "the fastest-moving OSS threat". State that plainly rather than downplaying it.
+- **Pick Aurora instead if…** you want IaC-level analysis, sandboxed command execution, or commercial support.
+
+- [ ] **Step 3: Verify external links on both pages**
+
+Run the same link check as Task 3 Step 4 against each file.
+Expected: all `200`.
+
+- [ ] **Step 4: Cross-check the claims**
+
+Open each cited source and confirm the specific claim it is attached to. Any claim you cannot verify from a public page must be **deleted**, not softened — an unverifiable statement about a competitor is exactly the failure mode these pages exist to avoid.
+
+- [ ] **Step 5: Build and commit**
+
+```bash
+cd website && hugo --gc --minify && cd ..
+git add website/content/compare/
+git commit -m "docs(website): k8sgpt and Aurora comparisons"
+```
+
+---
+
+### Task 5: Promote MCP and cross-link prior art
+
+**Files:**
+- Modify: `README.md` (add an MCP section)
+- Modify: `website/content/docs/concepts/prior-art.md` (link out to the compare pages)
+- Modify: `website/content/docs/configuration/mcp.md` (front matter description for search)
+
+**Interfaces:**
+- Consumes: `/compare/*` from Tasks 3–4; `website/content/docs/configuration/mcp.md`.
+
+- [ ] **Step 1: Add the MCP section to the README**
+
+Place it after the integration/data-source discussion, phrased as the answer to toolset breadth:
+
+```markdown
+## No native integration? Point RunLore at any MCP server
+
+RunLore ships a **narrow, deliberate native tool set** — cluster, metrics, logs, network
+flows, GitOps history, cloud control plane, knowledge search. It does not try to match the
+~60 vendor toolsets of the largest OSS agent, and it shouldn't.
+
+Instead it ships an **MCP client**: point it at any Model Context Protocol server and those
+tools join the investigation loop, governed by the same allowlist and the same read-only
+posture as everything else. Whatever your stack has that RunLore doesn't, MCP closes it.
+
+RunLore is also an MCP **server** — `lore mcp` exposes what-changed and knowledge search to
+Claude Code, HolmesGPT, or any other MCP client.
+
+→ [MCP configuration](https://runlore.io/docs/configuration/mcp/)
+```
+
+- [ ] **Step 2: Cross-link prior art and the compare pages**
+
+At the top of `website/content/docs/concepts/prior-art.md`, after the intro paragraph, add:
+
+```markdown
+> Looking for a head-to-head? See [RunLore vs HolmesGPT]({{< relref "/compare/holmesgpt.md" >}}),
+> [vs k8sgpt]({{< relref "/compare/k8sgpt.md" >}}), and [vs Aurora]({{< relref "/compare/aurora.md" >}}).
+> This page is the underlying research — the full landscape, including the commercial
+> vendors and the eval reality.
+```
+
+- [ ] **Step 3: Give the MCP page a search-facing description**
+
+Add to `website/content/docs/configuration/mcp.md`'s front matter:
+
+```yaml
+description: "Point RunLore at any MCP server to add tools it doesn't ship natively — and expose RunLore's own what-changed and knowledge search to any MCP client."
+```
+
+- [ ] **Step 4: Build**
+
+Run: `cd website && hugo --gc --minify`
+Expected: builds with no unresolved refs (`refLinksErrorLevel: ERROR` catches any typo in the new `relref`s).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md website/content/docs/concepts/prior-art.md website/content/docs/configuration/mcp.md
+git commit -m "docs: lead with MCP as the answer to toolset breadth"
+```
+
+---
+
+## Final verification
+
+- [ ] `cd website && hugo --gc --minify` builds clean
+- [ ] Every external URL on the three compare pages returns 200, and every claim traces to a source you personally opened
+- [ ] `og-card.png` is 1200×630, shows the new headline, and is legible at thumbnail size
+- [ ] The homepage reads coherently top to bottom: category named in the first two lines, then the differentiation
+- [ ] **Compare** appears in the top-level menu and all three pages are reachable from it
+- [ ] `grep -rn "speeds up investigations" website/ README.md` returns nothing — the old headline is fully retired
+- [ ] Open the PR — English title and description, no AI attribution, no co-author trailers. Note in the description that the `/eval` link on the homepage depends on S3
+</content>

--- a/docs/superpowers/plans/2026-08-02-s5-integrations.md
+++ b/docs/superpowers/plans/2026-08-02-s5-integrations.md
@@ -1,0 +1,176 @@
+# S5 — Integrations (GitLab forge · Grafana Alerting · Elasticsearch/OpenSearch) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the three integration gaps that sit directly across RunLore's stated audience — lock-in-averse, sovereignty-conscious, self-hosting teams — without widening the maintenance surface the improvement report warns about.
+
+**Architecture:** Three independent additions behind existing interfaces, **one PR each**, each verified against a real backend before merge. GitLab implements `providers.CurationForge` + `ReinvestForge` over the v4 API. Grafana becomes a first-class `source.Descriptor` built on the proven custom-webhook mapper. Elasticsearch/OpenSearch becomes a third `LogsProvider` behind the same three log tools.
+
+**Tech Stack:** Go 1.x, stdlib HTTP; Docker for the local verification backends.
+
+**Spec:** [`docs/superpowers/specs/2026-08-02-s5-integrations-design.md`](../specs/2026-08-02-s5-integrations-design.md)
+
+## Global Constraints
+
+- Every new `.go` file starts with `// SPDX-License-Identifier: Apache-2.0`.
+- `golangci-lint run` must pass; **no new third-party dependencies** — the GitLab and Elasticsearch clients are stdlib `net/http`, matching how `internal/forge/github` and `internal/logs/loki` are written.
+- **Credentials by env-var indirection only.** Config stores the env var *name* (`token_env`), never the value — the pattern every existing integration follows. New secrets must reach `internal/redact`.
+- **TLS verification stays on.** Do not add an `insecure_skip_verify` escape hatch.
+- Config validation **fails closed and loudly** at startup: a missing credential or malformed target aborts `serve` rather than silently disabling the feature.
+- Every integration ships a page under `website/content/docs/integrations/` — `internal/docsguard` fails CI otherwise, in both directions.
+- Comments explain *why*; this codebase comments heavily and deliberately.
+- Conventional Commits. **Never** add a co-author trailer or any AI attribution.
+
+## Verified context — do not re-derive
+
+- `providers.CurationForge` is three methods: `OpenPR(ctx, KBEntry) (Ref, error)`, `ListPRsByLabel(ctx, label) ([]CuratedIssue, error)`, `Comment(ctx, number, body) error`. `ReinvestForge` adds `ListIssuesByLabel` and `ReplaceLabel`. Both in `internal/providers/providers.go`.
+- `internal/providers/curationforge_test.go` holds the compile-time assertion pattern: `var _ providers.CurationForge = (*github.Client)(nil)`.
+- `internal/logs/detect.go` probes the backend once at startup and **fails safe to VictoriaLogs**. Its provider constants are the ids `internal/docsguard` reflects over.
+- The `custom` source already implements dot-path extraction, `items` batching, `severity_map`, resolved-event handling and per-instance tokens — with startup-time mapping validation. Grafana reuses it rather than reimplementing it.
+- `hack/e2e-local.sh` is the existing pattern for container-backed local verification.
+
+---
+
+### Task 1: GitLab forge
+
+**Files:**
+- Create: `internal/forge/gitlab/gitlab.go`, `gitlab_test.go`
+- Modify: `internal/config/config.go` (a `Forge.Provider` selector + a `GitLab` block), `internal/app/forge.go` (wiring)
+- Modify: `internal/providers/curationforge_test.go` (add the assertion)
+- Create: `website/content/docs/integrations/gitlab.md`
+
+**Interfaces:**
+- Consumes: `providers.CurationForge`, `providers.ReinvestForge`, `providers.KBEntry`, `providers.Ref`, `providers.CuratedIssue`.
+- Produces: `gitlab.New(cfg) *Client` satisfying both forge interfaces.
+
+- [ ] **Step 1: Read the GitHub client first**
+
+`internal/forge/github/github.go` is ~500 lines and already solves every problem you are about to meet: dedup via a hidden fingerprint marker in the body, label lifecycle, comment coalescing, retry/backoff. **Mirror its structure.** Read it before writing anything, and note in your report where you deliberately diverged.
+
+- [ ] **Step 2: Write the failing tests**
+
+`gitlab_test.go`, driven by an in-process `httptest` mock GitLab API. Cover the full curation lifecycle:
+- `OpenPR` creates a branch, commits the entry, opens a merge request, applies labels
+- `ListPRsByLabel` returns open MRs carrying a label
+- `Comment` posts a note
+- `ReplaceLabel` transitions a label
+- the fingerprint marker round-trips through an MR description so dedup works
+- a 429 or 5xx is retried; a 404 is not
+
+Run: `go test ./internal/forge/gitlab/ -v` → FAIL (package does not exist).
+
+- [ ] **Step 3: Implement**
+
+Map the GitHub concepts onto GitLab v4: PR → merge request, PR comment → note, branch+commit → the Commits API. Auth is a **project or group access token** sent as the `PRIVATE-TOKEN` header — GitLab has no GitHub-App equivalent, and OAuth apps are the wrong shape for a bot.
+
+`base_url` is optional (omit for gitlab.com); `kb_repo` carries the project path and must be URL-encoded into the API path (`%2F`), which is the single most common GitLab-client bug.
+
+- [ ] **Step 4: Config + wiring**
+
+```yaml
+forge:
+  provider: gitlab          # github (default) | gitlab
+  kb_repo: your-group/runlore-kb
+  base_branch: main
+  gitlab:
+    base_url: https://gitlab.example.com   # omit for gitlab.com
+    token_env: GITLAB_TOKEN
+```
+
+Validation fails closed: `provider: gitlab` with no `token_env`, or a `kb_repo` that is not a valid project path, aborts `serve`. Add the token to `internal/redact`.
+
+- [ ] **Step 5: Verify against a real GitLab project**
+
+**This step needs the maintainer** — it requires a real project and token. Run one end-to-end pass: trigger an investigation, confirm the MR appears with the right labels and body, confirm a second occurrence *comments* rather than opening a duplicate, and confirm `reinvestigate` round-trips. Paste the MR URL into the report.
+
+- [ ] **Step 6: Docs page, tests, lint, commit**
+
+`gitlab.md` with front matter `integration: {kind: forge, id: gitlab}`, a minimal config that **parses under `config.Load`** (`internal/docsguard/minimal_config_test.go` enforces this), the token scope (`api` on a project or group access token), and the minimum GitLab version tested.
+
+---
+
+### Task 2: Grafana Alerting as a first-class source
+
+**Files:**
+- Create: `internal/source/grafana/grafana.go`, `grafana_test.go`
+- Create: `website/content/docs/integrations/grafana.md`
+- Create: `hack/integration/grafana/docker-compose.yml` + a provisioned alert rule
+
+**Interfaces:**
+- Consumes: the `custom` source's mapping machinery (`internal/source/custom`), `source.Register(Descriptor)`.
+- Produces: a registered source named `grafana` serving `POST /webhook/grafana`.
+
+- [ ] **Step 1: Write the failing test**
+
+The defining test: **the built-in mapping must equal the one currently documented** in `data-sources.md` (now `website/content/docs/integrations/custom-webhook.md`) — `items: alerts`, `title: labels.alertname`, `message: annotations.summary`, `severity: labels.severity`, `namespace: labels.namespace`, `workload_name: labels.pod`, `fingerprint: fingerprint`, `resolved: status`, `labels: labels`.
+
+Assert it as a table, so a change to the default is a visible test diff rather than a silent behaviour change.
+
+Also test: a batch payload with several alerts; a resolved event recording a resolution rather than triggering an investigation; `token_env` falling back to `server.webhook_token_env`; every field remaining overridable.
+
+- [ ] **Step 2: Implement as a thin wrapper**
+
+Register a `source.Descriptor` named `grafana` that delegates to the custom mapper with the defaults baked in. **Do not reimplement extraction** — the point is that Grafana users stop hand-copying nine field paths, not that Grafana gets its own parser. It inherits the 1MiB body cap, per-delivery request cap and startup mapping validation for free.
+
+- [ ] **Step 3: Verify against a real Grafana**
+
+`hack/integration/grafana/` — compose file with Grafana and a provisioned alert rule whose contact point posts to a local `lore serve`. Fire the rule; confirm an investigation starts with the right namespace and workload. Resolve it; confirm a resolution is recorded rather than a second investigation.
+
+- [ ] **Step 4: Docs page, tests, lint, commit**
+
+---
+
+### Task 3: Elasticsearch / OpenSearch logs
+
+**Files:**
+- Create: `internal/logs/elasticsearch/elasticsearch.go`, `elasticsearch_test.go`
+- Modify: `internal/logs/detect.go` (extend the probe), `internal/config/config.go`, `internal/app/` wiring
+- Create: `website/content/docs/integrations/elasticsearch.md`
+- Create: `hack/integration/elasticsearch/docker-compose.yml` + a seeding script
+
+**Interfaces:**
+- Consumes: `providers.LogsProvider` (`Query`), plus the optional `LogFields` and `LogStats` capabilities.
+- Produces: a `logs` provider registered under the id added to `internal/logs/detect.go`.
+
+- [ ] **Step 1: Read the Loki client**
+
+`internal/logs/loki` is the closest sibling and already solves field-convention defaults, token/header auth, and the capability type-assertions. Mirror it.
+
+- [ ] **Step 2: Write the failing tests**
+
+Mock `_search` responses covering all three tools on **both** distributions:
+
+| Tool | Mechanism |
+|---|---|
+| `query_logs` | `_search` with `query_string` + a `range` filter on the timestamp field, newest-first, size-capped |
+| `logs_error_summary` | `date_histogram` split by the level field; top messages from a `terms` aggregation, falling back to client-side aggregation when the field is `text`-only |
+| `discover_log_fields` | `_field_caps` (present on ES 8 and OpenSearch 2) |
+
+Plus: detection distinguishes OpenSearch (`version.distribution: opensearch`) from Elasticsearch, and **anything unrecognised still fails safe to VictoriaLogs** — that existing guarantee must not regress.
+
+- [ ] **Step 3: Implement**
+
+Use the classic `_search` DSL, the one dialect both ES 8.x and OpenSearch 2.x speak. ES|QL would fork the implementation.
+
+ECS field defaults (`kubernetes.namespace`, `kubernetes.pod.name`, `kubernetes.container.name`, `log.level`, `@timestamp`), all overridable through the existing `logs.fields` block. Tell the model the right query language for this provider, exactly as LogsQL and LogQL already do.
+
+- [ ] **Step 4: Verify against real containers**
+
+`hack/integration/elasticsearch/` — single-node ES **and** OpenSearch, a seeding script writing ECS-shaped documents including a CrashLoopBackOff-style error burst, then all three tools exercised against both. Paste the output.
+
+- [ ] **Step 5: Docs page, tests, lint, commit**
+
+Document the parity caveats honestly, the way the Loki page does — particularly the top-messages fallback when the message field is `text`-only.
+
+---
+
+## Final verification
+
+- [ ] `go test ./... && golangci-lint run` clean
+- [ ] `go test ./internal/docsguard/` — all three new pages present and their configs parse
+- [ ] Each integration verified against a **real** backend, with output in its report
+- [ ] Credentials env-indirected, redacted, and absent from logs
+- [ ] Existing GitHub / Alertmanager / VictoriaLogs / Loki behaviour unchanged — proven by their suites passing untouched
+- [ ] A per-PR security pass on each integration (token handling, TLS, redaction, NetworkPolicy egress)
+- [ ] Three separate PRs, English titles and descriptions, no AI attribution
+</content>

--- a/docs/superpowers/plans/2026-08-02-s6-seed-catalog-distribution.md
+++ b/docs/superpowers/plans/2026-08-02-s6-seed-catalog-distribution.md
@@ -1,0 +1,149 @@
+# S6 — Commons seed catalog + distribution artifacts — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Kill the cold start. On day one a new adopter's catalog is empty, `kb_search` returns nothing, and RunLore is a slower HolmesGPT — for exactly the feature it is sold on.
+
+**Architecture:** A set of generic, vendor-neutral OKF entries authored in-repo first as one reviewable PR, then split into a standalone `runlore-kb-commons` repository whose contribution barrier is a markdown pull request. An opt-in `catalog.commons` second source indexes it alongside the user's own catalog, with the user's entries always winning ties and the curator never writing to it.
+
+**Spec:** [`docs/superpowers/specs/2026-08-02-s6-seed-catalog-distribution-design.md`](../specs/2026-08-02-s6-seed-catalog-distribution-design.md)
+
+## The claim this plan makes — and the one it refuses to make
+
+The improvement report says a commons catalog *"eliminates the cold start — day-1 instant recall value."* **That is false as the engine stands, and this plan does not repeat it.**
+
+Instant recall applies a structural filter: a resource-less entry cannot match a workload-carrying incident (`internal/investigate/recall_test.go:427` — *"scopeless request vs named entry → none"*; `nearmiss_gate_test.go:131`). Generic commons entries carry no `resource` by nature, and real alerts almost always carry a namespace and workload. **Commons entries will not fire instant recall.**
+
+What they *will* do is ground investigations: `kb_search` (`internal/investigate/kbsearch_tool.go`) applies **no** structural filter, so the model can find and cite any commons entry mid-loop. That is real day-one value — a better-reasoned investigation with citable prior art — and it is what this plan claims.
+
+Instant recall stays earned by *your own* scoped entries. That is the correct trust boundary anyway, and every doc line this plan writes must say so.
+
+## Global Constraints
+
+- Every entry passes `lore validate-kb` — the same merge gate a curated PR faces.
+- **No entry may make a wrong diagnosis plausible.** The poisoned-entry eval scenario exists precisely because a bad entry is worse than a missing one. Every entry states what it does *not* cover.
+- No vendor-specific paths, cluster names, or org names.
+- Commons entries are visibly marked as commons wherever they surface, so an on-call always knows whether they are reading their platform's truth or generic advice.
+- SPDX header on new `.go` files; `golangci-lint` clean; no new third-party dependencies.
+- Conventional Commits. **Never** add a co-author trailer or any AI attribution.
+
+---
+
+### Task 1: Author the commons entries
+
+**Files:** create `examples/kb-commons/*.md` (15–25 entries) + `examples/kb-commons/index.md`
+**Also:** a CI step running `lore validate-kb examples/kb-commons`
+
+- [ ] **Step 1: Read the format contract first**
+
+`plugins/kb-steward/skills/kb-steward/references/okf-format.md` is the field-by-field contract, and `examples/runbooks/helmrelease-upgrade-failure.md` is a worked example. Read both before writing an entry.
+
+- [ ] **Step 2: Write the entries**
+
+`type: Playbook`, no `resource` (they are platform-wide by construction), each with real `Symptom` / `Checks` / `Cause` / `Resolution` sections.
+
+| Area | Entries |
+|---|---|
+| GitOps | HelmRelease upgrade failure · HelmRelease terminal state · Kustomization build failure · Argo CD `Application` Degraded · Argo CD OutOfSync stuck |
+| Workloads | CrashLoopBackOff after deploy · OOMKilled · readiness-probe failure · image pull backoff · init-container failure |
+| Storage | PVC unbound · volume node-affinity conflict · disk-pressure eviction |
+| Networking | DNS resolution failure · NetworkPolicy denial · Service has no endpoints |
+| Certificates | cert-manager order/challenge stuck · expiring certificate |
+| Nodes | node NotReady · memory pressure · scheduler `Unschedulable` |
+
+**Tags carry the alert names that fire for each** (`KubePodCrashLooping`, `KubePersistentVolumeFillingUp`, …). `lore kb import` and `data-sources.md` both establish that alert-name tokens are the recall signal that lets an alert find a runbook — an entry without them is much harder to retrieve.
+
+- [ ] **Step 3: Validate and add the CI gate**
+
+```bash
+go run ./cmd/lore validate-kb examples/kb-commons
+```
+Add the same command to `.github/workflows/ci.yaml` so an entry that would fail the merge gate cannot land.
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 2: `catalog.commons` — a second, read-only catalog source
+
+**Files:**
+- Modify: `internal/catalog/catalog.go`, `load.go` (multi-root loading + provenance)
+- Modify: `internal/config/config.go` (the `commons` block)
+- Modify: `internal/app/catalog.go` (wiring)
+- Modify: `deploy/helm/runlore/values.yaml` + templates
+- Create: `website/content/docs/integrations/kb-commons.md`
+
+**Interfaces:**
+- Consumes: `catalog.New(dir)` (single-root today), `catalog.Load(dir)`, `catalog.Entry`.
+- Produces: `catalog.Entry.Commons bool`; a `catalog.commons` config block.
+
+- [ ] **Step 1: Write the failing tests**
+
+Three properties, each a test:
+1. **Both roots are indexed** — an entry from either is findable by `kb_search`.
+2. **The user's entry wins a tie** — with two entries at equal score, the non-commons one ranks first. This is the important one: your platform's truth beats generic advice, always.
+3. **The curator can never write to the commons root** — assert the write path rejects a commons-rooted target.
+
+- [ ] **Step 2: Implement**
+
+`catalog.New` takes one dir today. Add multi-root loading with a provenance flag on each entry. Keep the commons in a **separate directory** from the git-sync mirror so it can never dirty the user's checkout:
+
+```yaml
+catalog:
+  dir: /var/lib/runlore/catalog          # your KB, unchanged
+  commons:
+    url: https://github.com/Smana/runlore-kb-commons
+    branch: main
+    interval: 24h                         # commons changes slowly
+    dir: /var/lib/runlore/commons         # separate mount
+```
+
+Off by default — adopting a shared catalog is a choice, not something that happens on upgrade.
+
+- [ ] **Step 3: Mark commons entries where they surface**
+
+`kb_search` results and any notification citing one must show it is commons, not the user's own. An on-call must never mistake generic advice for their platform's recorded truth.
+
+- [ ] **Step 4: Chart wiring, docs page, tests, commit**
+
+The docs page must state plainly that commons entries **ground investigations via `kb_search`** and **do not fire instant recall**, and why (the structural filter). Do not let this page repeat the report's overclaim.
+
+---
+
+### Task 3: The standalone repository
+
+> **Requires the maintainer** for repo creation, or explicit delegation.
+
+- [ ] **Step 1: Create `Smana/runlore-kb-commons`** — public, Apache-2.0.
+- [ ] **Step 2: Seed it** from `examples/kb-commons/`, preserving history where practical.
+- [ ] **Step 3: Add `CONTRIBUTING.md`** — what a good entry looks like, the OKF field contract, the no-vendor-specifics rule, and a pointer to the `kb-steward` skill, which already exists and applies directly.
+- [ ] **Step 4: Add validation CI** running `lore validate-kb` on every PR.
+- [ ] **Step 5: Delete `examples/kb-commons/`** from this repo and repoint the CI gate, README and Getting Started at the new repo. **One source of truth** — the in-repo copy was a seed, not a fork.
+
+---
+
+### Task 4: Distribution artifacts — prepared, not submitted
+
+**Files:** create `dev/distribution/{awesome-sre-agents,cncf-landscape,artifact-hub}.md`
+
+- [ ] **Step 1: Write each artifact**
+
+Exact submission-ready content plus where it goes and the upstream contribution rules it must satisfy:
+- the `last9/awesome-sre-agents` list entry;
+- the `cncf/landscape` `landscape.yml` block, with the required logo asset prepared;
+- the Artifact Hub repository metadata for the existing GHCR OCI chart.
+
+- [ ] **Step 2: Do NOT submit them.** These are public actions under the maintainer's name. Stage them and stop.
+
+---
+
+## Final verification
+
+- [ ] 15–25 entries, every one passing `lore validate-kb` in CI, each carrying alert-name tags
+- [ ] An investigation against an **empty** user KB visibly cites a commons entry — demonstrated, not assumed
+- [ ] A user entry beats a commons entry at equal score — proven by test
+- [ ] The curator cannot write to the commons root — proven by test
+- [ ] `catalog.commons` is off by default
+- [ ] Docs claim "grounds investigations from day one" and explicitly state that instant recall stays earned by your own scoped entries
+- [ ] `dev/distribution/` holds submission-ready artifacts, unsubmitted
+</content>

--- a/docs/superpowers/specs/2026-08-02-improvement-report-decomposition.md
+++ b/docs/superpowers/specs/2026-08-02-improvement-report-decomposition.md
@@ -1,0 +1,66 @@
+# Decomposition — RunLore improvement report (28 July 2026)
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorming)
+- **Owner:** Smaine Kahlouch
+- **Input:** `runlore-improvement-report.pdf` (9 pages, prepared 28 July 2026)
+
+## Why this document exists
+
+The report spans six independent workstreams — funnel, docs IA, proof assets, positioning,
+integrations, and a strategic content bet. It is far too large for one spec. This page is the
+index: what each sub-project owns, what it depends on, and the order they ship in. **Each
+sub-project has its own spec, its own plan, and its own PR set.**
+
+## Report claims verified against the repo (2026-08-02)
+
+Three of the report's findings are stale or imprecise. They are corrected here so no spec
+inherits a wrong premise.
+
+| Report claim | Verified state | Effect |
+|---|---|---|
+| §9.1 README contradicts Getting Started on `helm repo add` / OCI | **Stale** — `README.md:216` already states "OCI artifact on GHCR — no `helm repo add`" | Dropped from S2 |
+| §5.1 "logs support is VictoriaLogs only" | **Stale** — Loki shipped in `c744a8b` (`internal/logs/loki`) | S5 integration list shortened |
+| §2.1 "the demo prints trigger-policy log lines" | **True of `hack/demo.sh`**, but `lore demo investigate` already renders a real verdict card — it just requires an API key. The keyless mock exists only in `internal/app/eval_compare_test.go` | S1 reframed: the gap is *keyless*, not *missing* |
+| §9.3 eval scorecard link 404s | **Confirmed and worse** — `RUNLORE_EVAL_API_KEY` is unset, so every nightly run since the workflow landed took the graceful-skip path (26–32s "success"). The `eval-scorecard` branch **does not exist on the remote**; the README badge and the benchmarking link are both dead | S3 |
+| §9.2 Flux/Argo CD listed as Required | **Confirmed** — `getting-started.md:28` vs README "GitOps isn't required" | S2 |
+| §9.4 site-relative repo links | **Confirmed** — `getting-started.md:243`, `benchmarking.md:38` | S2 |
+| §9.5 ~120-line `values.yaml` as the golden path | **Confirmed** — the annotated block runs `getting-started.md:247–425` | S2 |
+| §6 a commons catalog gives "day-1 instant recall value" | **Wrong as the engine stands** — instant recall's structural filter rejects a resource-less entry against a workload-carrying incident (`recall_test.go:427`, `nearmiss_gate_test.go:131`). `kb_search` has no such filter, so commons entries *do* ground investigations | S6 reframed |
+
+## Sub-projects
+
+| # | Spec | Owns | Depends on |
+|---|---|---|---|
+| S1 | [`s1-funnel-demo-cli`](2026-08-02-s1-funnel-demo-cli-design.md) | Keyless recorded-transcript demo, zero-config `lore investigate`, `install.sh` | — |
+| S2 | [`s2-getting-started-integrations`](2026-08-02-s2-getting-started-integrations-design.md) | Three-tier Getting Started, `/docs/integrations` section, values profiles, §9 bugs | S1 (tier 1 is S1's demo) |
+| S3 | [`s3-proof-assets`](2026-08-02-s3-proof-assets-design.md) | Eval scorecard resurrection + `/eval` page, cost table, recall caveats, ADOPTERS, OpenSSF | — (needs a repo secret from the owner) |
+| S4 | [`s4-positioning`](2026-08-02-s4-positioning-design.md) | Homepage rewrite, three `/compare/*` pages, MCP promotion | — |
+| S5 | [`s5-integrations`](2026-08-02-s5-integrations-design.md) | GitLab forge, Grafana Alerting source, Elasticsearch/OpenSearch logs | S2 (each adds an integration page) |
+| S6 | [`s6-seed-catalog-distribution`](2026-08-02-s6-seed-catalog-distribution-design.md) | Commons OKF catalog + `runlore-kb-commons` repo, distribution artifacts | — |
+
+## Sequencing
+
+**Wave 1 (parallel, one worktree + one PR each):** S1, S3, S4.
+These touch disjoint files — Go CLI + `hack/`, CI workflows + eval, website homepage + new
+`/compare` section.
+
+**Wave 2:** S2 (needs S1 to exist before it can lead with it), S5 (three separate PRs, each
+locally verified), S6 (content authoring, then the new repo).
+
+**Final gate:** a `/security-review` pass across the whole set, *plus* a per-PR security pass on
+every new integration in S5 (token handling, TLS defaults, redaction, NetworkPolicy egress) and
+on `install.sh` in S1.
+
+## Explicitly out of scope
+
+Deferred per the report's own advice or the owner's direction:
+
+- **Microsoft Teams notifier** — dropped by the owner.
+- **OpenTelemetry traces** — the report calls it a 2027 bet; expensive, not funnel-blocking.
+- **Azure / GCP "what changed"** — AWS covers the likely early adopters.
+- **CNCF Sandbox application** — needs a second maintainer first (report §8.1); Q1 2027 target.
+- **Conference CFPs, blog cadence, CNCF Slack channel** — owner-driven, not repository work.
+- **Submitting** the distribution PRs to third-party repos — S6 prepares them; the owner submits.
+</content>
+</invoke>

--- a/docs/superpowers/specs/2026-08-02-s1-funnel-demo-cli-design.md
+++ b/docs/superpowers/specs/2026-08-02-s1-funnel-demo-cli-design.md
@@ -1,0 +1,191 @@
+# Design — S1: Funnel, keyless demo + CLI front door
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorming)
+- **Owner:** Smaine Kahlouch
+- **Source:** improvement report §2.1, §2.2 — "the single change most likely to move your star count"
+- **Index:** [decomposition](2026-08-02-improvement-report-decomposition.md)
+
+## Problem
+
+A stranger cannot make RunLore produce a root cause without provisioning things first.
+
+- `hack/demo.sh` is advertised as "try it in one minute". It runs `lore serve` against a keyless
+  config, POSTs `examples/alertmanager-webhook.json`, and greps `msg=incident` out of the log. What
+  it shows is **trigger-policy filtering decisions** — the least differentiated part of the product.
+- `lore demo investigate` *does* render the real verdict card (`notify.Format`), against real fake
+  providers, through the real loop. But `demo.go:96` refuses to start without `ANTHROPIC_API_KEY`
+  (or a `--config` naming a configured model). So the good demo is gated behind a credential.
+- `lore investigate` — the laptop-to-value path, the equivalent of `holmes ask` — is mentioned only
+  in `CONTRIBUTING.md` and has no docs page. Worse, it is **unusable without a config file**:
+  `RunInvestigate` calls `config.Load("runlore.yaml")` unconditionally and `config.Load` fails on a
+  missing file (`load.go:17`).
+- There is no install path. `.goreleaser.yaml` ships `archives:` only — no tap, no script, no
+  documented one-liner.
+
+The keyless plumbing already exists: `internal/app/eval_compare_test.go:28` is a keyless,
+offline, OpenAI-compatible mock that drives the whole loop. It lives in a `_test.go` file, so no
+user can reach it.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Keyless demo mechanism | **Recorded transcript replay** | A scripted mock emits canned strings ("mock: chart bump broke harbor-db") — it reads as a toy. A recorded transcript replays *genuine model output* over real fixture evidence, so the first thing a stranger sees is a real RCA |
+| Transcript regeneration | `--record` flag on the same command | Keeps the fixture reproducible by the maintainer; no hidden generation script |
+| Replay fidelity | Replay the **model turns only**; tools execute for real against the existing fake providers | The trace a user watches is real tool I/O, not a recorded log |
+| `hack/demo.sh` | Becomes the verdict-card demo | Report §2.1. The trigger-policy demo moves to `hack/demo-trigger-policy.sh` (still referenced from `CONTRIBUTING.md`) |
+| `lore investigate` config | Zero-config path when `runlore.yaml` is absent | An explicit `--config` that is missing still hard-errors — silence there would hide a typo |
+| Install channel | `install.sh` (curl \| sh), owner's choice | Plus a one-line `go install` alternative in the docs for readers who won't pipe a script to a shell |
+| Checksum verification | On by default in `install.sh` | The release already publishes `checksums.txt` + a cosign bundle; a security-conscious audience will read this script |
+
+## Scope
+
+### In scope
+
+1. `internal/model/replay` — a `providers.ModelProvider` that replays a recorded transcript.
+2. Transcript fixture for one curated scenario, committed under `examples/demo/`.
+3. `lore demo investigate --offline` (replay) and `--record <path>` (capture).
+4. Zero-config `lore investigate`: env-derived model, ambient kubeconfig, graceful degradation.
+5. `--metrics-url` / `--logs-url` / `--model` / `--base-url` flags on `investigate`.
+6. `install.sh` + hosting it at `runlore.io/install.sh`.
+7. `hack/demo.sh` rewrite; `hack/demo-trigger-policy.sh` extraction.
+8. `website/content/docs/reference/cli.md` — the CLI reference page (S2 restructures Getting
+   Started to lead with it; S1 only ships the page).
+9. Drift guards (below).
+
+### Non-goals (YAGNI)
+
+- Homebrew tap / winget / nfpms packages (owner deselected).
+- Recording transcripts for every scenario — one good one beats five thin ones.
+- A TUI, colored output beyond what `notify.Format` already does, or an HTML card export.
+- Making `lore serve` keyless — the in-cluster path legitimately needs a model.
+
+## Design
+
+### The replay provider
+
+`providers.ModelProvider` is a single non-streaming method
+(`providers.go:495`), which makes replay trivial:
+
+```go
+// internal/model/replay
+type Provider struct {
+    turns []providers.CompletionResponse
+    i     int
+    mu    sync.Mutex
+}
+
+func (p *Provider) Complete(ctx context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error)
+```
+
+Turns are returned in recorded order and the request is ignored. Exhaustion is a **loud** error:
+`transcript exhausted after N turns (the loop asked for one more — re-record with
+'lore demo investigate --record')`. Silently returning an empty completion would produce a demo
+that ends with no findings and no explanation.
+
+### Transcript format
+
+**One ordered channel.** `demo.go:107` already sets `verifyModel = nil` whenever a model is
+injected, so the verify pass draws from the same model as the loop — the existing
+`demo_test.go:39` script proves it (turn 3 is `submit_verdicts`). Replay inherits that shape rather
+than inventing a second channel:
+
+```json
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T09:14:00Z",
+  "recorded_with": {"provider": "anthropic", "model": "claude-sonnet-5"},
+  "turns": [
+    {"text": "", "tool_calls": [{"id": "1", "name": "what_changed", "args": "{\"namespace\":\"harbor\"}"}],
+     "usage": {"input_tokens": 4211, "output_tokens": 96}}
+  ]
+}
+```
+
+`usage` is preserved so the demo's cost footer shows the real token counts from the recorded run —
+the footer is part of what the report says sells the product.
+
+### Recording
+
+`--record <path>` wraps the model in a decorator that appends each `CompletionResponse` to `turns`
+and writes the file on completion. Recording forces the verify pass onto the same model (exactly as
+replay does), so the recorded call sequence and the replayed one are identical by construction. The
+decorator lives beside the replay provider (`internal/model/replay/record.go`) and is the only place
+that writes transcripts.
+
+### Wiring
+
+`runDemoInvestigateWithModel` already has a model seam used by tests. `--offline` resolves the model
+to a `replay.Provider` and sets `verifyModel` from the transcript's verify channel, then everything
+downstream — fake providers, `tracingTool`, the loop, `notify.Format` — is untouched production
+code.
+
+### Zero-config `lore investigate`
+
+```
+--config given explicitly + missing  → hard error (unchanged)
+--config absent + ./runlore.yaml present → load it (unchanged)
+--config absent + ./runlore.yaml absent  → synthesize from env
+```
+
+Synthesis order:
+
+| Env | Result |
+|---|---|
+| `OPENAI_BASE_URL` (+ optional `OPENAI_API_KEY`, `OPENAI_MODEL`) | OpenAI-compatible provider, keyless when no key is set (local vLLM/Ollama) |
+| `ANTHROPIC_API_KEY` | native Anthropic |
+| neither | error naming both paths and the `--model`/`--base-url` flags |
+
+Flags override the synthesized config, never a loaded file (a file is an explicit statement of
+intent). Kube access comes from the ambient kubeconfig; **every unset source disables its tool** —
+no KB, no forge, no notifier, no Flux required. The command warns once on stderr listing which
+tools are disabled, so a thin result is explainable rather than mysterious.
+
+### `install.sh`
+
+Detects `uname -s`/`uname -m` → the goreleaser archive name, resolves the latest tag from the
+GitHub releases API (`LORE_VERSION` env pins it), downloads the archive **and** `checksums.txt`,
+verifies the SHA-256, extracts to `$LORE_INSTALL_DIR` (default `/usr/local/bin`, falling back to
+`~/.local/bin` when not writable). It prints the cosign verification command rather than requiring
+cosign. Served from the website as `static/install.sh` so `curl -fsSL https://runlore.io/install.sh`
+works, with the GitHub raw URL documented as the auditable source.
+
+## Testing
+
+| Test | Guards |
+|---|---|
+| `TestDemoOfflineRendersVerdictCard` | `--offline` produces a card containing the recorded root cause, with no network and no env keys set |
+| `TestReplayExhaustionIsLoud` | asking for turn N+1 returns the re-record error, not an empty completion |
+| `TestTranscriptToolNamesExist` | **drift guard**: every tool name in the committed transcript is a tool the demo actually registers — a renamed tool fails CI instead of producing a broken demo |
+| `TestRecordRoundTrip` | record → replay reproduces the same turns byte-for-byte |
+| `TestInvestigateZeroConfig` | env-only synthesis produces a valid config for both provider paths; explicit missing `--config` still errors |
+| `TestInvestigateDegradesGracefully` | with no kube/KB/forge/notifier, the command still runs and reports which tools were disabled |
+| `shellcheck hack/*.sh` + `install.sh` | already in CI for `hack/`; extend to `install.sh` |
+
+The drift guard is mutation-tested during implementation: rename a tool in the transcript, confirm
+CI goes red, revert.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| The transcript goes stale as the prompt/tool set evolves | The tool-name drift guard fails CI on rename; `--record` makes regeneration a one-liner. Regeneration is a documented step in `CONTRIBUTING.md` |
+| A replayed demo misrepresents current model quality | The card footer names the recorded model and date, from the transcript's `recorded_with` |
+| `install.sh` becomes an attack surface | Checksum verification on by default, no `sudo` inside the script, the source URL documented, and it goes through the S1 security pass |
+| Zero-config `investigate` silently produces a weak answer | The one-time stderr warning lists disabled tools |
+
+## Acceptance criteria
+
+1. On a machine with only Go and no API keys, `hack/demo.sh` prints a real verdict card in under
+   60 seconds, with no outbound LLM call.
+2. `curl -fsSL https://runlore.io/install.sh | sh` installs a working `lore` on Linux and macOS,
+   amd64 and arm64, verifying the checksum.
+3. `lore investigate --alert KubePodCrashLooping --namespace apps` works against a live cluster with
+   only `OPENAI_BASE_URL`/`ANTHROPIC_API_KEY` set and **no** `runlore.yaml`, no Flux, no KB repo, no
+   GitHub App, no notifier.
+4. `website/content/docs/reference/cli.md` documents install, both commands, and the degradation
+   rules; the docs link-check passes.
+5. `go test ./...`, `golangci-lint`, and the security pass are clean.
+</content>

--- a/docs/superpowers/specs/2026-08-02-s2-getting-started-integrations-design.md
+++ b/docs/superpowers/specs/2026-08-02-s2-getting-started-integrations-design.md
@@ -1,0 +1,212 @@
+# Design — S2: Getting Started restructure + integrations browser
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorming)
+- **Owner:** Smaine Kahlouch
+- **Source:** improvement report §2.3, §9.2, §9.4, §9.5 + owner correction
+- **Depends on:** [S1](2026-08-02-s1-funnel-demo-cli-design.md) (tier 1 is S1's keyless demo)
+- **Index:** [decomposition](2026-08-02-improvement-report-decomposition.md)
+
+## Problem
+
+`getting-started.md` is 624 lines and presents the **hardest** path as the only path.
+
+- Prerequisites open with "**Required:** a Kubernetes cluster running Flux or Argo CD" — which the
+  README directly contradicts ("GitOps isn't required: every data source is pluggable"). Report §9.2.
+- The production path needs a cluster **+** Flux/Argo **+** an LLM endpoint **+** a GitHub App **+** a
+  KB repo **+** a notifier. Six multiplicative prerequisites; at 70% retention per step that is 12%.
+- Step 4's "complete production-style example" `values.yaml` runs ~180 lines (`getting-started.md:247–425`).
+  It is presented as the golden path. Report §9.5.
+- Two links point at repo paths through Hugo, so they render as broken site URLs:
+  `getting-started.md:243` (`../deploy/helm/runlore/values-minimal.yaml`) and `benchmarking.md:38`
+  (`../eval/compare.example.yaml`). Report §9.4.
+- Every non-default integration — Loki, Matrix, PagerDuty, Hubble, AWS, GCP, Gemini, Anthropic,
+  custom webhooks — is inlined as commented YAML inside that one page. There is no way to *browse*
+  what RunLore integrates with, and nothing for a search engine to rank for "runlore loki".
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Page structure | Three escalating tiers, each independently complete and useful | Report §2.3 — a reader who stops at tier 1 still got value |
+| Tier-3 stack | **Prometheus + GitHub + OpenAI-compatible LLM + Slack only** | Owner's correction. One opinionated path is followable; a matrix of options is not |
+| Everything else | Moves to `/docs/integrations/` | Owner's correction |
+| Integrations IA | Section index with card grids + **one page per integration** | Owner's choice. Each integration gets a landing page worth ranking |
+| Values profiles | `values-minimal.yaml` / `values-standard.yaml` / `values-full.yaml`, all schema-validated in CI | Report §9.5. The chart's own `values.yaml` stays the chart default — it is not an example |
+| GitOps prerequisite | `Required` → `Recommended` | The README's framing is the correct one for adoption, and it matches the code (an unset source disables its tool) |
+| Repo links | Absolute GitHub URLs | The site is not the repo; `relref` cannot reach files outside `content/` |
+| Doc/code drift | A reflection test over the real registries | Owner's standing preference: pin docs that restate code facts with a reflection test, then mutation-test the guard |
+
+## Scope
+
+### In scope
+
+1. Rewrite `website/content/docs/getting-started.md` into three tiers.
+2. New `/docs/integrations/` section: `_index.md` with five card grids + 23 integration pages
+   (S5 adds 3 more: Grafana, Elasticsearch, GitLab).
+3. `deploy/helm/runlore/values-standard.yaml` and `values-full.yaml`; trim `values-minimal.yaml`
+   to the ~15-line shape the report asks for.
+4. Extend `internal/config/minimal_values_test.go` to validate all three profiles against
+   `values.schema.json`.
+5. Fix report §9.2 and §9.4.
+6. `internal/docsguard` — the integration-page coverage test.
+7. Sidebar weights so Integrations sits directly under Getting Started.
+
+### Non-goals (YAGNI)
+
+- Rewriting `configuration.md` — it stays the exhaustive key reference every integration page
+  deep-links into.
+- Per-integration screenshots.
+- Translating any page.
+- Merging or splitting the Concepts / Operations / Security sections.
+
+## Design
+
+### The three tiers
+
+| Tier | Needs | Gets | Where |
+|---|---|---|---|
+| **1 · Try** | Go **or** `curl \| sh` | A real RCA on recorded evidence, keyless, ~60s | Top of Getting Started, above prerequisites |
+| **2 · Investigate** | kubeconfig + one API key | `lore investigate` against your live cluster, output in the terminal | Second section |
+| **3 · Learn** | Helm + KB repo + GitHub App + Slack | The full loop — the differentiator | The rest of the page |
+
+Tier 1 and 2 are S1's deliverables; this spec only places and documents them. Tier 3 keeps the
+existing step numbering so external links survive, but every non-standard-stack option is replaced
+with a one-line pointer into `/docs/integrations/`.
+
+### Tier 3's `values.yaml`
+
+The page shows **`values-minimal.yaml` (~15 lines) first**, then a collapsed/linked
+`values-standard.yaml` for the KB + curation loop, and links `values-full.yaml` rather than
+inlining it. Profiles:
+
+| Profile | Contains |
+|---|---|
+| `values-minimal` | image, model, one notifier. Investigate + notify. No KB, no curation |
+| `values-standard` | + catalog git-sync, forge/GitHub App, webhook token, metrics + logs URLs |
+| `values-full` | + HA, persistence, network policy, actions ladder, cloud, network flows, instant recall |
+
+### `/docs/integrations/`
+
+Index page: five `hextra/feature-grid` card grids — **Triggers · LLM providers · Data sources ·
+Notifications · Forge** — each card linking to its own page.
+
+| Group | Pages (at S2 merge) | Added by S5 |
+|---|---|---|
+| Triggers | alertmanager, gitops, pagerduty, custom-webhook | grafana |
+| LLM providers | openai-compatible, anthropic, gemini, local-keyless (vLLM/Ollama) | — |
+| Data sources | prometheus-victoriametrics, victorialogs, loki, kubernetes, hubble, aws-vpc-flow-logs, gcp-firewall-logs, aws-cloud, source-repos, mcp | elasticsearch |
+| Notifications | slack, matrix, webhook, templated | — |
+| Forge | github | gitlab |
+
+Every page follows one template, deliberately short:
+
+```markdown
+---
+title: Grafana Loki
+weight: 30
+integration: {kind: logs, id: loki}     # consumed by the drift guard
+---
+
+**What it gives you** — which tools this enables, in one sentence.
+
+## Minimal config          # the smallest block that works
+## Verify it locally       # the exact commands, incl. a container recipe where relevant
+## Notes                   # gotchas, field defaults, parity caveats
+## Reference               # deep link into configuration.md / data-sources.md
+```
+
+The "Verify it locally" block is what makes the owner's *test each integration locally* rule
+durable: the recipe an integration ships with is the recipe a user follows.
+
+### The drift guard
+
+`internal/docsguard/integration_pages_test.go` reflects over the **real** parse targets, not a
+hand-maintained list:
+
+- `source.Registered()` → one page per registered source descriptor.
+- `notify.Registered()` → one page per notifier (this spec adds `Registered()` to
+  `internal/notify/registry.go`, mirroring `internal/source`).
+- The logs provider constants in `internal/logs/detect.go` → one page each.
+
+It asserts both directions: every registered integration has a page, and every page's
+`integration:` front-matter id resolves to something registered. A new notifier without a docs page
+fails CI; a page for a deleted provider fails CI. The guard is mutation-tested during
+implementation — add a fake registry entry, confirm red, revert.
+
+The guard covers exactly what has a runtime registry — sources, notifiers, logs providers. LLM,
+cloud, network and MCP pages have no equivalent registry to reflect over and are therefore
+maintained by hand; the guard ignores pages whose `integration.kind` is not one of the three
+registered kinds, so it never produces a false failure on them.
+
+## Testing
+
+| Test | Guards |
+|---|---|
+| `TestIntegrationPagesCoverRegistries` | the drift guard, both directions |
+| `TestShippedValuesProfilesValidate` | all three profiles parse and satisfy `values.schema.json` |
+| `hugo --gc --minify` in `docs-check.yml` | `refLinksErrorLevel: ERROR` already fails the build on any unresolved `relref` |
+| Link check | no site-relative link resolves to a repo path |
+| Manual | read tier 1 → tier 3 top to bottom on a clean browser; each tier stands alone |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| 22 thin pages read as filler | Each carries a *working* minimal config and a *runnable* local verification — content a dense reference page cannot give |
+| Restructure breaks inbound links to Getting Started anchors | Keep existing step anchors; add new ones rather than renaming |
+| The integrations section drifts from the code | The reflection guard, mutation-tested |
+| Tier 3 gets thinner and loses production guidance | `values-full.yaml` + the Harden-for-production section stay; only *options* move out, not *guidance* |
+
+## Amendments from wave-1 execution (added 2026-08-02, after S1/S3/S4 shipped)
+
+Five things surfaced during wave 1 that S2 must incorporate. They were not knowable when this
+spec was written.
+
+1. **`getting-started.md:19-22` is now factually wrong.** It describes `hack/demo.sh` as running
+   `lore serve` with mocked Alertmanager alerts through the trigger policy ("just Go + `curl`").
+   S1 replaced that: `hack/demo.sh` now replays a recorded investigation and renders a real
+   verdict card, and the trigger-policy demo moved to `hack/demo-trigger-policy.sh`. Two S1
+   reviewers flagged this as correctly out of S1's scope and explicitly S2's to fix. **Tier 1 of
+   the new Getting Started is exactly this command**, so the rewrite fixes it by construction —
+   but do not leave the old wording anywhere.
+
+2. **The LLM integration pages must carry verified compatibility, not just config.** Two providers
+   are broken against RunLore, both found by running them:
+   - **glm-4.6** stalls indefinitely on forced `tool_choice` ([#391]) — it emits one
+     `reasoning_content` delta and never completes. This silently degrades the adversarial verify
+     pass, the recall reranker, the eval judge, KB semantic validation and `kb import --model`.
+     **glm-4.5-air** answers the identical request in ~5s and is the verified-working choice.
+   - **Gemini 3.x** is unusable ([#392]) — the client never replays `thought_signature` on
+     functionCall parts, so investigations fail with a 400 on the *second* turn. Gemini 2.5 works.
+   A "Verify it locally" block that does not surface these would send readers straight into them.
+   The openai-compatible page should state the forced-`tool_choice` requirement explicitly, since
+   that is the capability that separates a working endpoint from a broken one.
+
+3. **`lore investigate` changed underneath tier 2.** It now runs with no `runlore.yaml`,
+   synthesizing config from `OPENAI_BASE_URL`/`OPENAI_API_KEY`/`OPENAI_MODEL` or
+   `ANTHROPIC_API_KEY`, and accepts `--model`/`--base-url`/`--metrics-url`/`--logs-url`. It also
+   prints a stderr notice naming which signals are disabled. Tier 2 should lead with the
+   zero-config form — it is now genuinely one command — and explain the notice, so a thin answer
+   reads as under-configured rather than as the product being weak.
+
+4. **The eval scorecard is live.** `runlore.io/eval` renders the published nightly and the README
+   badge is green. Anywhere Getting Started or the integrations pages gesture at "how good is
+   it", link `/eval` rather than describing it.
+
+5. **Hugo version floor.** `hugo.yaml` requires ≥ 0.146.0 and Hextra needs the `try` template
+   func. A stale `hugo` on PATH fails with `function "try" not defined`. Worth a line in
+   CONTRIBUTING or the docs-contribution notes, since every website task in wave 1 hit it.
+
+## Acceptance criteria
+
+1. Getting Started opens with a keyless tier-1 path; nothing above it requires a cluster.
+2. Prerequisites list Flux/Argo CD under **Recommended**, and the page no longer contradicts the README.
+3. No site-relative link points at a repo path.
+4. The first `values.yaml` a reader sees is ≤ 20 lines.
+5. `/docs/integrations/` lists every registered trigger, LLM, data source, notifier and forge, each
+   linking to its own page with a runnable local-verification recipe.
+6. `TestIntegrationPagesCoverRegistries` fails when an integration is added without a page (proven
+   by mutation, reverted).
+7. `hugo` builds clean; `go test ./...` and `golangci-lint` pass.
+</content>

--- a/docs/superpowers/specs/2026-08-02-s3-proof-assets-design.md
+++ b/docs/superpowers/specs/2026-08-02-s3-proof-assets-design.md
@@ -1,0 +1,175 @@
+# Design — S3: Proof assets
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorming)
+- **Owner:** Smaine Kahlouch
+- **Source:** improvement report §4, §9.3
+- **Requires from the owner:** the `RUNLORE_EVAL_API_KEY` repo secret
+- **Index:** [decomposition](2026-08-02-improvement-report-decomposition.md)
+
+## Problem
+
+RunLore's positioning is honesty, and the assets that would prove it are either invisible or
+broken.
+
+**The scorecard is dead.** `README.md` carries a shields endpoint badge pointing at
+`eval-scorecard/badge.json`, and `benchmarking.md:13` calls the nightly numbers public. Verified
+2026-08-02: `RUNLORE_EVAL_API_KEY` is **not set** (`gh secret list` returns only
+`RELEASE_PLEASE_TOKEN`), so every nightly run takes the graceful-skip path — 26–32 second
+"successes" with a `::warning::` annotation. The `eval-scorecard` branch **does not exist on the
+remote**. The badge renders broken and the link 404s. The publishing machinery in `eval.yaml:80–110`
+is complete and correct; it has simply never had a key.
+
+**The headline recall metric overstates itself.** `learning-loop.md:146` presents
+`rerank on → 11/11 (1.00), precision 1.00, 0/2 negatives` as "measured on the eval harness". But
+`recalleval_test.go:831` injects `scriptedReranker{accept: rerankTargets(cases), conf: 0.9}` — a
+stand-in that accepts the correct target by construction. The row measures the **fire gate's
+plumbing and the corpus's structural agreement**, not a model's reranking judgment. A hostile
+reader who opens the test will find that in two minutes, and it will cost more credibility than the
+number buys.
+
+**No cost figure is published,** though the data exists: `providers.Usage` is provider-reported and
+already summed by the eval runner's `CountingModel`, and the Slack footer already shows it.
+
+**No `ADOPTERS.md`, no OpenSSF Scorecard badge.** SBOMs already ship (`.goreleaser.yaml:48`); they
+just need verifying and mentioning.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Scorecard fix | Owner sets the secret; I bootstrap the branch from one committed run | The page must not be empty on day one, and the nightly must keep it fresh afterwards |
+| `/eval` page source | `docs.yml` fetches `scorecard.md` from the `eval-scorecard` branch at build time | The scorecard lives on an orphan branch by design; copying it into `main` would fight the nightly |
+| Rebuild trigger | `eval.yaml` fires a `repository_dispatch`; `docs.yml` listens | Otherwise the page only refreshes when someone pushes to `website/` |
+| Missing-branch behaviour | Render a "not yet published" page, never fail the build | A broken docs deploy is worse than a candid placeholder |
+| Recall numbers | State the corpus **and** the scripted-reranker caveat in RunLore's own voice | The project's entire positioning is honesty about sub-50% reality; applying it to its own headline metric is the credible move |
+| Numbers in prose | Pinned by a reflection test against the computed values | Owner's standing preference for doc/code drift guards |
+| Cost table | Extend `lore eval scorecard` with a cost section | Keeps one publishing path; a separate command would drift |
+
+## Scope
+
+### In scope
+
+1. Bootstrap the `eval-scorecard` branch (one real run, committed) and confirm the badge resolves.
+2. `/eval` page on runlore.io, fed from the branch at build time, with a placeholder fallback.
+3. `repository_dispatch` wiring: `eval.yaml` → `docs.yml`.
+4. Cost-per-investigation section in the scorecard (full loop vs instant recall).
+5. Recall-metric honesty pass in `learning-loop.md` + `README.md`, with a drift guard.
+6. `ADOPTERS.md` + a README ask.
+7. OpenSSF Scorecard workflow + badge; verify SBOMs are attached to releases.
+
+### Non-goals (YAGNI)
+
+- Replacing the scripted reranker in `recalleval_test.go` with a live model — that would make a
+  unit test cost money and flake. The fix is disclosure, not re-measurement.
+- A live-fire nightly (`--live` needs a cluster).
+- Historical charting of the scorecard beyond the `history.jsonl` the renderer already writes.
+- A public dashboard app.
+
+## Design
+
+### `/eval` page pipeline
+
+```
+eval.yaml (nightly, key present)
+  → lore eval scorecard -report … -dir <worktree>
+  → push eval-scorecard branch                     [already implemented]
+  → POST /repos/Smana/runlore/dispatches {event_type: scorecard-updated}   [new]
+
+docs.yml
+  on: push(website/**) | workflow_dispatch | repository_dispatch(scorecard-updated)   [new]
+  → git fetch origin eval-scorecard --depth=1                                          [new]
+  → render website/content/eval.md from scorecard.md + front matter                    [new]
+  → hugo build
+```
+
+The render step prepends Hugo front matter (`title: Eval scorecard`, `layout`, a "last published"
+line derived from the branch's commit date) to the fetched markdown. If the fetch fails, it writes a
+short placeholder explaining that no nightly has published yet and linking the workflow — honest,
+and it keeps `benchmarking.md`'s link alive either way.
+
+`benchmarking.md:13` and the README badge's **link target** are repointed at `/eval`, so the site is
+the canonical surface and the branch is an implementation detail. The badge *image* keeps reading
+`badge.json` from the branch — that is what makes it update without a site rebuild.
+
+### Cost section
+
+Pricing already exists end-to-end: `config.Model.Pricing` (`config.go:586`) feeds
+`evalCostUSD(cfg, usage)` (`eval.go:135`) into `Report.CostUSD`. Setting `model.pricing` in
+`eval/ci.runlore.yaml` is therefore all the configuration this needs.
+
+What is missing is **per-case** token attribution — the report carries only campaign totals
+(`replay_report.go:23`). Since `Runner.RunN` is strictly sequential (`eval.go:207–224`), a
+before/after snapshot of `CountingModel.Total()` around each `runOne` yields that run's usage
+exactly. The rendered scorecard then gains:
+
+| | median in tok | median out tok | est. cost |
+|---|---|---|---|
+| full investigation | … | … | $X |
+| instant recall | … | … | $Y |
+
+The recall/loop discriminator already exists: `ReportCase.RecallShortCircuit`
+(`replay_report.go:44`) counts the repeats answered from the catalog. Cases with a non-zero count
+are the recall rows; the rest are full-loop rows.
+
+Cost is rendered **only** when prices are configured, and the model + date are stated alongside, so
+the figure is never a naked number.
+
+### Recall-metric honesty pass
+
+The `learning-loop.md` table keeps its numbers and gains, in the same blockquote:
+
+- what the corpus is — label positives, negatives, and the fixture catalog they are scored against;
+- that rerank-**on** is measured with a **scripted reranker**, so the row measures the gate and the
+  corpus's structural agreement, **not** a model's reranking accuracy;
+- a pointer to the ITBench sub-50% baseline already cited in `benchmarking.md`, so the reader has
+  the field number next to the fixture number.
+
+`README.md`'s recall claims get the same one-line caveat.
+
+**Drift guard** — `TestRecallDocClaimsMatchMeasurement` parses the markdown table in
+`learning-loop.md` and asserts each cell equals the value computed by the same code path
+`TestRecallEvalRerankFireRate` measures. Editing the prose without editing the measurement (or the
+reverse) fails CI. Mutation-tested during implementation: change one cell, confirm red, revert.
+
+### ADOPTERS + OpenSSF
+
+`ADOPTERS.md` with a table (organization, since, how they use it, contact-optional) seeded with the
+maintainer's own usage, plus a README line asking for entries. OpenSSF Scorecard via
+`ossf/scorecard-action` on a weekly schedule publishing to the security tab, with the badge added to
+the README badge row. SBOM: confirm `.goreleaser.yaml:48`'s `sboms:` block attaches `*.sbom` to the
+GitHub release, then say so in `SECURITY.md` (the report's point is that this work is already done
+and unmarketed).
+
+## Testing
+
+| Test | Guards |
+|---|---|
+| `TestRecallDocClaimsMatchMeasurement` | doc numbers can't drift from the measurement |
+| `TestScorecardCostSection` | cost rows render only with prices, and the recall/loop split is correct |
+| `TestScorecardPlaceholder` | the docs build succeeds with no `eval-scorecard` branch |
+| Manual | one nightly run end-to-end after the secret lands: branch pushed → dispatch fired → `/eval` shows the fresh numbers → badge green |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| The first published scorecard is red | That is the point — `eval.yaml` already publishes on `always()`. A red scorecard published on schedule is the asset; a hidden one is not |
+| Nightly eval cost | Replay only, 13 scenarios × n=5, on a cheap model; the existing `ci.runlore.yaml` governs it |
+| Disclosing the scripted reranker weakens the claim | It converts an attackable claim into a defensible one, and is on-brand. The real fire-rate story (0/11 → 11/11 at default thresholds) survives intact — what changes is what the reader thinks it measures |
+| `repository_dispatch` needs elevated permissions | The job already has `contents: write`; the dispatch is scoped to the same repo |
+
+## Acceptance criteria
+
+1. The `eval-scorecard` branch exists, the README badge resolves, and `benchmarking.md`'s link
+   reaches a live page.
+2. `runlore.io/eval` renders the current scorecard, and updates automatically within one nightly
+   cycle of a new run.
+3. The docs build passes with the branch absent.
+4. The scorecard shows a dated, model-attributed cost-per-investigation table splitting full loop
+   from instant recall.
+5. `learning-loop.md` states the corpus and the scripted-reranker caveat; the drift guard fails on
+   an edited number (proven by mutation, reverted).
+6. `ADOPTERS.md` exists and is linked from the README; the OpenSSF badge renders; SBOM presence is
+   verified and documented.
+</content>

--- a/docs/superpowers/specs/2026-08-02-s4-positioning-design.md
+++ b/docs/superpowers/specs/2026-08-02-s4-positioning-design.md
@@ -1,0 +1,157 @@
+# Design — S4: Positioning
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorming)
+- **Owner:** Smaine Kahlouch
+- **Source:** improvement report §3
+- **Index:** [decomposition](2026-08-02-improvement-report-decomposition.md)
+
+## Problem
+
+RunLore leads with the commodity and buries the wedge.
+
+`website/content/_index.md:16` reads **"The SRE agent that speeds up investigations"**. RunLore's
+own `prior-art.md` states the opposite in plain terms: *"the autonomous alert → RCA → Slack runtime
+is a commodity, and change-diff RCA is no longer unique."* The headline is the commodity, stated as
+the headline.
+
+The unoccupied position — and prior-art proves nobody else holds it — is **portability plus human
+review**: every commercial tool that learns keeps the knowledge; every open tool that is portable
+doesn't learn. That claim appears nowhere above the fold.
+
+Three supporting problems:
+
+- **The competitive comparison is filed as "prior art"** — an academic label nobody searches. People
+  search *"runlore vs holmesgpt"*. Aurora publishes comparison content against this space and it
+  works for them.
+- **The eval scorecard** — "the only SRE agent that publishes its own eval scorecard" — sits on page
+  four of the docs (S3 makes it real; S4 makes it visible).
+- **MCP is buried under Configuration.** RunLore cannot out-toolset HolmesGPT's ~60 toolsets and
+  shouldn't try, but it ships an MCP client. *"No native integration? Point RunLore at any MCP
+  server"* converts the narrowest weakness into a one-line answer.
+
+The social card (`website/static/images/og-card.svg`, shipped 2026-08-02) hard-codes the old
+headline, so every share link would keep advertising it.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| H1 direction | **Knowledge ownership** — "Your incident knowledge, in your Git. Not in a vendor's database." | Owner's choice. It is the claim prior-art shows is unoccupied |
+| Comparison URLs | Three standalone pages at `/compare/<tool>` | Matches search intent; one combined page gives one URL to rank instead of three |
+| Competitors covered | HolmesGPT, k8sgpt, Aurora | Owner's choice — including the commercial vendor already marketing against this space |
+| Tone | Factual, sourced, dated, with an explicit "pick them instead if…" on every page | A comparison that never concedes anything is read as marketing and believed by nobody |
+| `prior-art.md` | Stays, as the research source the three pages cite | It is genuinely good research; it is just not a landing page |
+| Staleness | `last_verified` front matter on each compare page + a docs-check reminder | Competitor facts rot fast, and a wrong claim about a competitor is the most expensive kind |
+
+## Scope
+
+### In scope
+
+1. Rewrite the homepage hero (H1, subtitle, feature cards, meta description).
+2. Regenerate `og-card.svg` → `og-card.png` with the new headline.
+3. `content/compare/_index.md` + `/compare/holmesgpt`, `/compare/k8sgpt`, `/compare/aurora`.
+4. Add **Compare** to the site's top-level menu.
+5. Promote the eval scorecard above the fold (hero-adjacent link to `/eval`, once S3 lands).
+6. Promote MCP: README section, `/docs/integrations/` card, and a homepage feature card line.
+7. Repoint `prior-art.md` to cite the compare pages, and vice versa.
+
+### Non-goals (YAGNI)
+
+- Rewriting the README's body (its framing is already the correct one — the site is what lags).
+- A pricing page, a "customers" section, or testimonials.
+- Benchmarks *of* competitors — the compare pages state documented capabilities, they do not
+  run other people's tools and grade them.
+- Redesigning the theme, colors, or the hero diagram (the diagram already shows the OKF KB).
+
+## Design
+
+### Homepage hero
+
+```
+H1   Your incident knowledge, in your Git. Not in a vendor's database.
+
+Sub  RunLore investigates alerts like the other agents do — then writes what it
+     learned to a repo you own, as a pull request a human merges. Portable
+     markdown, provenance-tracked, trust that decays when it stops working.
+     Read-only by default, your models, one Go binary.
+```
+
+The four feature cards reorder to follow the claim: **Knowledge you own** → **Read-only by default**
+→ **GitOps-native** → **Your models, one binary**. The `description` front matter and the
+`params.description` in `hugo.yaml` are updated to match, since they feed search results and the
+social card. `og-card.svg` gets the new headline and is re-exported to PNG at the same dimensions
+and path, so no `images:` front matter changes.
+
+The hero keeps the existing flow diagram — it already terminates in the OKF knowledge base, which is
+now the headline claim rather than a footnote.
+
+### Compare pages
+
+One shared structure so the three read as a set:
+
+```markdown
+---
+title: RunLore vs HolmesGPT
+last_verified: 2026-08-02
+---
+
+One-paragraph honest summary.
+
+## At a glance          # table: capability × RunLore / them, sourced
+## What they do better  # first, and specifically
+## What RunLore does that they don't
+## Pick them instead if…
+## Sources              # links + the date each was checked
+```
+
+Substance per page:
+
+| Page | RunLore's claim | The honest concession |
+|---|---|---|
+| HolmesGPT | Portable Git-owned knowledge; human-reviewed curation; published eval scorecard | ~60 toolsets vs RunLore's narrower set; CNCF Sandbox; 2,205 contributors vs 3 |
+| k8sgpt | Investigation loop with evidence + memory, not one-shot analysis | Far larger community, CNCF Sandbox since 2023, simpler to adopt |
+| Aurora | Knowledge is exportable markdown in your repo, not a vendor RAG store; self-hosted, your models | Commercial support, a funded team, a broader integration surface |
+
+Every capability row links to the competitor's own documentation, so a reader can check the claim
+without trusting us. The "at a glance" tables are written from published docs only, and the
+`last_verified` date is rendered on the page.
+
+MCP appears on all three pages as the toolset-breadth answer: RunLore's native tool set is narrower
+by design, and any MCP server closes a specific gap.
+
+### MCP promotion
+
+`configuration/mcp.md` stays the reference. What changes is reach: a README section under the
+integration list, a card on the `/docs/integrations/` index (S2), a line in the compare pages, and
+one homepage feature-card sentence.
+
+## Testing
+
+| Test | Guards |
+|---|---|
+| `hugo --gc --minify` in `docs-check.yml` | `refLinksErrorLevel: ERROR` catches every broken internal ref |
+| External link check on the compare pages | a competitor doc URL that 404s is a credibility bug |
+| Manual | og-card renders correctly in a social-preview validator at 1200×630 |
+| Manual | homepage reads coherently top to bottom against the new H1 |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Comparison pages read as attack marketing | "What they do better" comes *first* on every page, and every claim is sourced and dated |
+| Competitor facts go stale | `last_verified` rendered on the page; refresh is a standing item alongside `prior-art.md` |
+| A vendor disputes a claim | Only published documentation is cited, with links; corrections are a PR away |
+| The new H1 confuses readers who came for "SRE agent" | The subtitle's first clause is "RunLore investigates alerts like the other agents do" — the category is stated immediately, then differentiated |
+
+## Acceptance criteria
+
+1. The homepage H1 states knowledge ownership; the subtitle names the category in its first clause.
+2. `og-card.png` shows the new headline; the meta description matches.
+3. `/compare/holmesgpt`, `/compare/k8sgpt`, `/compare/aurora` exist, each with a sourced at-a-glance
+   table, a "what they do better" section, and a rendered `last_verified` date.
+4. **Compare** is reachable from the top-level menu.
+5. MCP is presented as the toolset-breadth answer in the README, the integrations index, and each
+   compare page.
+6. `hugo` builds clean; every external link on the compare pages resolves.
+</content>

--- a/docs/superpowers/specs/2026-08-02-s5-integrations-design.md
+++ b/docs/superpowers/specs/2026-08-02-s5-integrations-design.md
@@ -1,0 +1,190 @@
+# Design — S5: Integrations (GitLab forge · Grafana Alerting · Elasticsearch/OpenSearch)
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorming)
+- **Owner:** Smaine Kahlouch
+- **Source:** improvement report §5 (ranked by adoption unlocked per unit of work)
+- **Depends on:** [S2](2026-08-02-s2-getting-started-integrations-design.md) — each integration adds a page to `/docs/integrations/`
+- **Index:** [decomposition](2026-08-02-improvement-report-decomposition.md)
+
+## Problem
+
+RunLore's stated audience is lock-in-averse, sovereignty-conscious, self-hosting teams. Three gaps
+sit directly across that audience:
+
+1. **The forge is GitHub-only.** `internal/forge/` contains exactly one implementation. A team that
+   self-hosts GitLab — the archetype of the stated audience — cannot use the learning loop at all,
+   because curation is the loop. No OSS competitor covers this.
+2. **Grafana Alerting is a config exercise.** Many teams never touch Alertmanager directly. RunLore
+   *can* ingest Grafana today, but only by hand-writing a nine-field `custom` webhook mapping
+   (`data-sources.md:133`). That is a documented workaround presented as an integration.
+3. **Elasticsearch/OpenSearch logs are unsupported.** Logs are VictoriaLogs + Loki
+   (`internal/logs/`). ES/OpenSearch is the enterprise long tail.
+
+Two report items are deliberately excluded: **Microsoft Teams** (dropped by the owner) and
+**OpenTelemetry traces** (the report itself calls it a 2027 bet).
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Shipping unit | **One PR per integration** | Each is independently reviewable, revertable, and locally verifiable |
+| Local verification | Mandatory before merge, and **documented on the integration's page** | Owner's rule. A recipe that ships with the integration is a recipe users can follow |
+| GitLab auth | Project/group **access token** via `token_env` | Works identically on gitlab.com and self-hosted. GitLab has no GitHub-App equivalent; OAuth apps are the wrong shape for a bot |
+| GitLab test strategy | In-process mock GitLab API for the suite, **plus one real end-to-end pass** on a live project before merge | A 4GB `gitlab-ce` container in CI buys fidelity nobody will wait for; the real pass buys it once, where it counts |
+| Grafana source | Promote to a **first-class `sources.grafana`** built on the existing custom-mapping machinery | Reuses proven code; users get `sources: {grafana: {}}` instead of nine hand-copied field paths |
+| ES/OpenSearch query API | Classic `_search` DSL (`query_string` + aggregations) | The one dialect both Elasticsearch 8.x and OpenSearch 2.x speak. ES\|QL would fork the implementation |
+| ES/OpenSearch detection | Extend the existing `logs.Detect` probe | Same fail-safe shape already proven for Loki |
+
+## Scope
+
+### In scope
+
+1. `internal/forge/gitlab` — `CurationForge` + `ReinvestForge`, config, wiring, docs page.
+2. `sources.grafana` — first-class trigger source, config, wiring, docs page.
+3. `internal/logs/elasticsearch` — `LogsProvider` + `LogFields` + `LogStats`, detection, docs page.
+4. `hack/integration/<name>/` — the compose/manifest each local verification uses.
+5. A security pass per PR (token handling, TLS defaults, redaction, NetworkPolicy egress).
+
+### Non-goals (YAGNI)
+
+- Microsoft Teams, OpenTelemetry traces, Azure/GCP "what changed".
+- GitLab **source-repo** cloning for `source_diff` on private GitLab hosts — `data-sources.md:209`
+  already documents that non-forge hosts clone anonymously. Making the GitLab token available to
+  `source_diff` is a natural follow-up, not this spec.
+- Gitea/Forgejo (the same interface makes it cheap later).
+- ES\|QL, Elastic Agent-specific schemas beyond ECS defaults.
+
+## Design
+
+### 1 · GitLab forge
+
+`providers.CurationForge` is three methods (`OpenPR`, `ListPRsByLabel`, `Comment`) and
+`ReinvestForge` adds `ListIssuesByLabel` + `ReplaceLabel` — a small surface, all HTTP.
+
+Config, additive and backwards-compatible (`forge.github_app` stays the default path):
+
+```yaml
+forge:
+  provider: gitlab                  # github (default) | gitlab
+  kb_repo: your-group/runlore-kb    # project path, same field as GitHub's owner/name
+  base_branch: main
+  gitlab:
+    base_url: https://gitlab.example.com   # omit for gitlab.com
+    token_env: GITLAB_TOKEN                # project or group access token
+```
+
+Mapping: PR → **merge request**, PR comment → **note**, labels → labels (GitLab supports them on
+both MRs and issues), branch push → the Commits API (create a branch, commit the drafted entry). The
+existing fingerprint marker in the MR description keeps dedup working unchanged — it is plain HTML
+comment text.
+
+Token scope documented as **`api`** on a project (or group) access token, with the least-privilege
+note that a *group* token is only needed when the KB repo may move. The token is read by env
+indirection like every other credential, never inlined, and added to the redaction set.
+
+Validation fails closed at startup: `provider: gitlab` without `token_env`, or with a `kb_repo` that
+isn't a valid project path, aborts `serve` rather than silently disabling curation.
+
+**Local verification:** an in-process `httptest` mock covering the full curation lifecycle
+(open MR → dedup list → comment → label transition → retire), then one manual pass against a real
+GitLab project: trigger an investigation, confirm the MR appears with the right labels and body,
+comment coalescing works on a second occurrence, and `reinvestigate` round-trips.
+
+### 2 · Grafana Alerting as a first-class source
+
+The `custom` source already does the work: dot-path extraction, batch `items`, `severity_map`,
+resolved-event handling, per-instance tokens. What is missing is a **named default**.
+
+```yaml
+sources:
+  grafana:
+    token_env: GRAFANA_WEBHOOK_TOKEN   # optional; falls back to server.webhook_token_env
+```
+
+registers `POST /webhook/grafana` with the mapping currently documented at `data-sources.md:133`
+baked in as the default (`items: alerts`, `title: labels.alertname`, `message:
+annotations.summary`, `severity: labels.severity`, `namespace: labels.namespace`, `workload_name:
+labels.pod`, `fingerprint: fingerprint`, `resolved: status`, `labels: labels`). Every field stays
+overridable for teams whose Grafana rules use different labels — the default is a starting point,
+not a cage.
+
+Implemented as a `source.Descriptor` registered like the others, delegating to the custom mapper, so
+it inherits the 1MiB body cap, per-delivery request cap, and startup mapping validation.
+
+**Local verification:** `hack/integration/grafana/` — a compose file with Grafana + a provisioned
+alert rule and a contact point pointing at a local `lore serve`. Fire the rule, confirm an
+investigation starts with the right namespace/workload; resolve it, confirm the resolution is
+recorded rather than a second investigation.
+
+### 3 · Elasticsearch / OpenSearch logs
+
+Third implementation behind `LogsProvider`, plus the two optional capabilities the other backends
+implement (`LogFields`, `LogStats`), so all three log tools work identically:
+
+| Tool | ES/OpenSearch mechanism |
+|---|---|
+| `query_logs` | `_search` with `query_string` + a `range` filter on the timestamp field, newest-first, size-capped |
+| `logs_error_summary` | `date_histogram` aggregation split by the level field; top messages from a `terms` aggregation over the normalized message keyword, falling back to client-side aggregation when the field is `text`-only |
+| `discover_log_fields` | `_field_caps` (present on both ES 8 and OpenSearch 2) |
+
+Config, mirroring Loki's shape exactly:
+
+```yaml
+logs:
+  url: https://es.observability.svc:9200
+  provider: elasticsearch      # elasticsearch | opensearch — optional, auto-detected
+  index: logs-*                # index pattern (default logs-*)
+  token_env: ES_TOKEN          # bearer / API key
+  # basic_auth_env: ES_BASIC   # user:pass, for clusters that only speak basic auth
+```
+
+ECS field defaults (`kubernetes.namespace`, `kubernetes.pod.name`,
+`kubernetes.container.name`, `log.level`, `@timestamp`), all overridable through the existing
+`logs.fields` block — the same escape hatch Loki and VictoriaLogs use.
+
+Detection extends `logs.Detect`: `GET /` returns `version.distribution: opensearch` for OpenSearch
+and a plain `version.number` for Elasticsearch; anything else keeps the existing fail-safe to
+VictoriaLogs. TLS verification stays **on** by default; a `insecure_skip_verify` escape hatch is
+deliberately *not* added.
+
+The query-language hint given to the model is set per provider, exactly as LogsQL/LogQL are today,
+so the model writes Lucene `query_string` syntax against ES.
+
+**Local verification:** `hack/integration/elasticsearch/` — single-node ES and OpenSearch
+containers, a seeding script writing ECS-shaped log documents (including a CrashLoopBackOff-style
+error burst), then all three tools exercised against both.
+
+## Testing
+
+| Integration | Tests |
+|---|---|
+| GitLab | mock-API lifecycle tests; config validation (missing token, bad project path, gitlab.com vs self-hosted base URL); redaction of the token; `providers.CurationForge`/`ReinvestForge` compile-time assertions like `curationforge_test.go` already does for GitHub; one manual real-project pass |
+| Grafana | mapping-default test asserting the built-in mapping equals the documented one; batch payload; resolved-event path; token fallback to `server.webhook_token_env`; container-based manual pass |
+| Elasticsearch | mock-`_search` tests for all three tools on both distributions; detection tests incl. fail-safe; field-override tests; container-based manual pass on ES **and** OpenSearch |
+| All three | the S2 integration-page drift guard fails until each ships its docs page |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| GitLab API differences between self-hosted versions | Target the v4 API surface that has been stable for years (MRs, notes, labels, commits); state the minimum tested GitLab version on the docs page |
+| The one manual GitLab pass rots | The mock suite covers the contract; the manual pass is re-run when the docs page's "tested against" version is bumped |
+| Grafana rule labels vary wildly between teams | Every mapped field stays overridable; the docs page shows both the default and an override example |
+| ES vs OpenSearch divergence | Restricted to the classic `_search` DSL both speak; both are exercised in the manual pass |
+| `logs_error_summary` top-messages fidelity on `text`-only message fields | Same client-side-aggregation caveat Loki already documents, stated on the page rather than hidden |
+| Three integrations widen the maintenance surface the report warns about (§8.2) | Each is behind a config key that is off by default, and each ships with its own tests and local recipe |
+
+## Acceptance criteria
+
+Per integration (three separate PRs):
+
+1. Works end-to-end in a real local environment, by the recipe published on its docs page.
+2. Config validation fails closed and loudly on a missing credential or a malformed target.
+3. Credentials are env-indirected, never logged, and covered by redaction.
+4. `/docs/integrations/<name>` exists with minimal config, local verification, notes, and a
+   reference deep-link; the S2 drift guard passes.
+5. `go test ./...`, `golangci-lint`, and a per-PR security pass are clean.
+6. Nothing about existing GitHub / Alertmanager / VictoriaLogs / Loki behaviour changes — proven by
+   the existing suites staying green without edits.
+</content>

--- a/docs/superpowers/specs/2026-08-02-s6-seed-catalog-distribution-design.md
+++ b/docs/superpowers/specs/2026-08-02-s6-seed-catalog-distribution-design.md
@@ -1,0 +1,173 @@
+# Design — S6: Commons seed catalog + distribution artifacts
+
+- **Date:** 2026-08-02
+- **Status:** Approved (brainstorming)
+- **Owner:** Smaine Kahlouch
+- **Source:** improvement report §6 (the strategic product bet) and §7 (distribution)
+- **Index:** [decomposition](2026-08-02-improvement-report-decomposition.md)
+
+## Problem
+
+**The cold start.** RunLore's differentiator only pays off *after* a team has had several incidents
+and merged several PRs. On day one the catalog is empty, `kb_search` returns nothing, and RunLore is
+a slower, less-integrated HolmesGPT. That is a brutal cold start for the exact feature the project
+sells.
+
+**A contribution surface that requires Go.** The repo is ~98% Go with 3 contributors. Markdown
+runbooks are contributable by any SRE who reads the blog; Go internals are not.
+
+**A moat only this architecture can have.** Komodor, Cleric, NeuBird and Datadog keep learned
+knowledge closed and non-exportable — by construction they cannot ship a community catalog. Aurora's
+RAG store is locked in Postgres/Weaviate/Memgraph. Only portable markdown-in-Git enables a commons.
+
+**Distribution is cheap and entirely unspent.** RunLore is absent from `last9/awesome-sre-agents`,
+has no Artifact Hub listing despite publishing an OCI chart, and no CNCF landscape entry.
+
+### A correction to the report's premise
+
+The report claims a commons catalog *"eliminates the cold start — day-1 instant recall value, which
+is currently zero."* **That is not true as the engine stands.** Instant recall applies a structural
+filter: a resource-less entry cannot match a workload-carrying incident
+(`internal/investigate/recall_test.go:427` — *"scopeless request vs named entry → none"*;
+`nearmiss_gate_test.go:131`). Generic commons entries carry no `resource` by nature, and real alerts
+almost always carry a namespace and workload. So commons entries will **not** fire instant recall.
+
+What they *will* do is ground investigations: `kb_search`
+(`internal/investigate/kbsearch_tool.go`) applies **no** structural filter, so the model can find and
+cite any commons entry mid-loop. That is real, day-one value — a better-reasoned investigation with
+citable prior art — and it is what this spec claims. Instant recall stays earned by *your own*
+scoped entries, which is the correct trust boundary anyway.
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Where the entries are authored | **In this repo first**, then split to a standalone repo | Owner's choice. One reviewable PR for the content, then the repo once the shape settles |
+| Standalone repo | `Smana/runlore-kb-commons`, created via `gh` | The report's contribution-surface argument only works with a repo whose barrier to entry is a markdown PR |
+| Value claim | "grounds investigations from day one", **not** "day-1 instant recall" | See the correction above. Claiming recall value we cannot deliver would be the exact dishonesty this project campaigns against |
+| Chart seeding | Two PRs: content + `lore kb import` path first; `catalog.commons` git source second | The first needs no engine change and delivers value immediately; the second needs multi-root indexing (`catalog.New` takes one dir today) |
+| Precedence | A user's own entry always outranks a commons entry on a tie | Your platform's truth beats generic advice, always |
+| Curation writes | Never to the commons dir | The curator writes to the KB repo you own; commons is read-only input |
+| Distribution PRs | **Prepared, not submitted** | Owner's choice — they are public actions under the owner's name |
+
+## Scope
+
+### In scope
+
+1. 15–25 commons OKF entries authored in-repo under `examples/kb-commons/`, CI-validated.
+2. `Smana/runlore-kb-commons` created and seeded from the settled content, with `CONTRIBUTING.md`
+   and a validation workflow.
+3. `catalog.commons` — an optional second catalog source, indexed alongside the user's, with
+   commons-loses-ties precedence.
+4. Chart wiring so the commons can be enabled with one value.
+5. Distribution artifacts staged in `dev/distribution/`: the `awesome-sre-agents` entry, the
+   `cncf/landscape` YAML block, the Artifact Hub listing file, each with submission instructions.
+
+### Non-goals (YAGNI)
+
+- Submitting the distribution PRs (owner does this).
+- A curation path that writes *back* to the commons repo — human PRs only, by design.
+- Changing the instant-recall structural filter to admit resource-less entries. It is a real
+  question, but it trades precision for coverage and must be settled with eval evidence, in its own
+  spec, with the poisoned-entry scenario as the gate. **Flagged as a follow-up.**
+- Vector/embedding distribution of the commons — plain markdown indexed locally.
+
+## Design
+
+### The entries
+
+Generic, vendor-neutral failure modes an SRE meets everywhere, `type: Playbook`, no `resource`
+(they are platform-wide by construction), each with real `Symptom` / `Checks` / `Cause` /
+`Resolution` sections and alert-name tags so retrieval can find them from an alert:
+
+| Area | Entries |
+|---|---|
+| GitOps | HelmRelease upgrade failure · HelmRelease terminal state · Kustomization build failure · Argo CD `Application` Degraded · Argo CD OutOfSync stuck |
+| Workloads | CrashLoopBackOff after deploy · OOMKilled · readiness-probe failure · image pull backoff · init-container failure |
+| Storage | PVC unbound · volume node-affinity conflict · disk pressure eviction |
+| Networking | DNS resolution failure · NetworkPolicy denial · Service has no endpoints |
+| Certificates | cert-manager order/challenge stuck · expiring certificate |
+| Nodes | node NotReady · memory pressure · scheduler `Unschedulable` |
+
+Tags carry the alert names that fire for each (`KubePodCrashLooping`, `KubePersistentVolumeFillingUp`,
+…) — `data-sources.md` and `lore kb import` both establish that alert-name tokens are the recall
+signal that lets an alert find a runbook.
+
+Quality bar: every entry must pass `lore validate-kb`, cite no vendor-specific paths, and state
+what it does **not** cover. An entry that would make a wrong diagnosis plausible is worse than no
+entry — the poisoned-entry eval scenario exists precisely because of this.
+
+### `catalog.commons`
+
+```yaml
+catalog:
+  dir: /var/lib/runlore/catalog          # your KB (unchanged)
+  commons:
+    url: https://github.com/Smana/runlore-kb-commons
+    branch: main
+    interval: 24h                         # commons changes slowly
+    dir: /var/lib/runlore/commons         # separate mount — never mixed with your mirror
+```
+
+Kept in a **separate directory** from the git-sync mirror so it can never dirty the user's checkout.
+`catalog.New` takes a single dir today, so this adds multi-root loading: entries are loaded from both
+roots and carry a provenance flag. Precedence rule: on equal score, the user's entry wins; commons
+entries are visually marked as commons in `kb_search` results and in any notification that cites
+them, so an on-call always knows whether they are reading their platform's truth or generic advice.
+The curator's write path is unchanged and never targets the commons root.
+
+Chart: `catalog.commons.enabled` renders the extra volume + the config block. Off by default —
+adopting a shared catalog is a choice, not something that happens to you on upgrade.
+
+### The standalone repo
+
+`Smana/runlore-kb-commons`, public, Apache-2.0, containing the entries, an `index.md` human listing,
+`CONTRIBUTING.md` (what a good entry looks like, the OKF field contract, the "no vendor specifics"
+rule), and a CI workflow running `lore validate-kb` on every PR. The `kb-steward` skill already
+exists and applies directly — the repo's contribution guide points at it.
+
+RunLore's README and `/docs/integrations/` gain a link, and Getting Started's step 1b mentions it as
+an alternative to starting empty.
+
+### Distribution artifacts
+
+`dev/distribution/` holds one file per target, each containing the exact content to submit and where
+to submit it: the `awesome-sre-agents` list entry, the `cncf/landscape` `landscape.yml` block (with
+the required logo asset prepared), and the Artifact Hub repository metadata for the existing GHCR
+OCI chart. Each names the upstream contribution rules it must satisfy.
+
+## Testing
+
+| Test | Guards |
+|---|---|
+| `lore validate-kb examples/kb-commons` in CI | every entry passes the same merge gate as a curated PR |
+| `TestCommonsEntriesHaveAlertTags` | each entry carries at least one alert-name tag, so retrieval can reach it |
+| `TestCommonsPrecedence` | a user entry and a commons entry at equal score resolve in the user's favour |
+| `TestCommonsNeverWritten` | the curator's write path cannot target the commons root |
+| Manual | with commons enabled and an empty user KB, an investigation cites a commons entry; with a competing user entry, it cites the user's |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Generic entries mislead an investigation | Every entry states its limits; the adversarial verify pass and the poisoned-entry scenario already guard this path; commons entries are visibly marked |
+| A commons entry contradicts a team's platform | User entries win ties and are marked distinctly; the whole feature is opt-in |
+| The commons repo attracts no contributors and looks dead | 20 solid seeded entries are useful on their own; the repo's value does not depend on inbound PRs |
+| Splitting the content into a second repo doubles maintenance | The in-repo copy is a **seed, not a fork**. Sequence: PR1 authors the entries under `examples/kb-commons/` with CI validation; PR2 creates and seeds `runlore-kb-commons`, moves validation to that repo's CI, and deletes `examples/kb-commons/` — leaving exactly one source of truth |
+| Scope creep into changing recall's structural filter | Explicitly out of scope and flagged as its own spec, gated on eval evidence |
+
+## Acceptance criteria
+
+1. 15–25 entries exist, every one passing `lore validate-kb` in CI, each carrying alert-name tags —
+   under `examples/kb-commons/` after PR1, in the standalone repo after PR2.
+2. `Smana/runlore-kb-commons` exists, public, seeded, with a contribution guide and validation CI;
+   `examples/kb-commons/` is gone and nothing references it.
+3. `catalog.commons` indexes the commons alongside a user catalog; user entries win ties; the
+   curator can never write there; the feature is off by default.
+4. An investigation against an **empty** user KB visibly cites a commons entry — demonstrated
+   manually and covered by a test.
+5. Docs claim "grounds investigations from day one" and explicitly state that instant recall stays
+   earned by your own scoped entries.
+6. `dev/distribution/` contains submission-ready artifacts for awesome-sre-agents, the CNCF
+   landscape, and Artifact Hub — unsubmitted.
+</content>


### PR DESCRIPTION
## Why

The six specs and six plans behind today's work existed **only on a local, unpushed branch**. Everything they describe has merged — S1–S5, the three integrations, the drift guards, the security fixes — but the design record never did. It was one branch delete from gone, on a day when a runaway agent deleted ten branches.

`docs/improvement-report-specs` is stale relative to `main` by **216 files**, so merging it wholesale would revert live work. Only `docs/superpowers/` is taken here — 13 files, no code.

## Contents

| | |
|---|---|
| Specs | decomposition index + S1–S6 designs |
| Plans | S1–S6 implementation plans |

## Worth reading before S6 is built

S6 is the one workstream still unbuilt, and its plan **refuses the improvement report's headline claim** — that a commons catalog delivers "day-1 instant recall value".

It cannot. Recall applies a structural filter before scoring:

```go
if entryResource == "" || reqW.Namespace == "" {
    return matchNone
}
```

A resource-less entry never agrees with a workload-carrying alert — pinned by `recall_test.go:427` (`scopeless request vs named entry -> none`). Generic commons entries are resource-less by construction, and real alerts almost always carry a namespace and workload.

So the plan claims what is true instead: commons entries **ground investigations via `kb_search`**, which applies no structural filter. That is real day-one value. Instant recall stays earned by your own scoped entries — which is the correct trust boundary anyway.