### PR TITLE
feat(catalog): a second read-only catalog root for shared knowledge

### DIFF
--- a/deploy/helm/runlore/templates/_helpers.tpl
+++ b/deploy/helm/runlore/templates/_helpers.tpl
@@ -44,6 +44,30 @@ entry here — the mount by name is identical either way.
 */}}
 {{- define "runlore.podTemplate" -}}
 {{- $usesVolumeClaimTemplates := and (eq .Values.workloadKind "StatefulSet") .Values.persistence.enabled -}}
+{{- /*
+  The knowledge commons gets its own writable checkout. The mount path is READ FROM
+  config.catalog.commons.dir rather than duplicated as a chart value: a second knob
+  would be free to drift from the one the agent actually reads, and the failure mode
+  of that drift is silent — an empty commons root indexes as zero entries and looks
+  exactly like "no commons configured".
+
+  url is what enables the feature (matching armCommons, which no-ops without it), so
+  a dir set without a url renders nothing here and the agent's own validation is what
+  reports it. A url WITHOUT a dir cannot be defaulted safely — it would have to guess
+  a path, and guessing catalog.mountPath would let an upstream sync overwrite the
+  operator's own catalog — so fail rendering with the fix named.
+*/ -}}
+{{- $commons := (.Values.config.catalog | default dict).commons | default dict -}}
+{{- $commonsDir := "" -}}
+{{- if $commons.url -}}
+{{-   $commonsDir = $commons.dir | default "" -}}
+{{-   if not $commonsDir -}}
+{{-     fail "config.catalog.commons.url is set but config.catalog.commons.dir is empty — set it to a path OUTSIDE config.catalog.dir (e.g. /var/lib/runlore/commons); the two roots must not share a directory" -}}
+{{-   end -}}
+{{-   if eq $commonsDir (.Values.config.catalog.dir | default "") -}}
+{{-     fail "config.catalog.commons.dir must differ from config.catalog.dir — sharing one root lets an upstream commons sync overwrite the catalog you curate into" -}}
+{{-   end -}}
+{{- end -}}
 metadata:
   annotations:
     checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -159,6 +183,10 @@ spec:
         - name: catalog
           mountPath: {{ .Values.catalog.mountPath }}
         {{- end }}
+        {{- if $commonsDir }}
+        - name: commons
+          mountPath: {{ $commonsDir }}
+        {{- end }}
   volumes:
     - name: config
       configMap:
@@ -179,6 +207,15 @@ spec:
       {{- else }}
       emptyDir: {}
       {{- end }}
+    {{- end }}
+    {{- if $commonsDir }}
+    # Deliberately an emptyDir, never a PVC: the commons is a read-only mirror of an
+    # upstream repo, re-cloned on startup and re-synced on its own (much longer)
+    # interval. Nothing here is authored locally, so there is nothing to lose on
+    # restart — and keeping it off the persisted data path means an upstream sync can
+    # never dirty the volume the outcome ledger and audit log live on.
+    - name: commons
+      emptyDir: {}
     {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:

--- a/deploy/helm/runlore/values-full.yaml
+++ b/deploy/helm/runlore/values-full.yaml
@@ -218,6 +218,28 @@ config:
     instant_recall:
       enabled: true
 
+    # A SECOND, read-only catalog root: a shared corpus of generic playbooks that
+    # covers common failure classes, so kb_search returns something useful on day one
+    # before you have curated an entry of your own. Both roots are indexed together.
+    #
+    # Two properties are worth knowing before you enable it:
+    #   - Commons entries NEVER fire instant recall. They are resource-less by
+    #     construction (they describe a failure class, not one cluster's workload),
+    #     and recall's structural filter rejects a resource-less entry for any alert
+    #     that carries a workload. They ground kb_search, which applies no such filter.
+    #   - The curator never writes here. Drafted entries always land in your own
+    #     catalog repo; the commons is a mirror of upstream and stays pristine.
+    # On a scoring tie your own entry wins, so the commons can only ever be a floor.
+    #
+    # dir MUST differ from catalog.dir above — the chart refuses to render otherwise.
+    # It is mounted as an emptyDir and re-cloned on startup; nothing is authored here.
+    commons:
+      url: https://github.com/Smana/runlore-kb-commons
+      branch: main
+      interval: 24h                     # a shared corpus changes slowly; do not poll it like your own
+      dir: /var/lib/runlore/commons
+      # token_env: COMMONS_TOKEN        # only for a PRIVATE commons repo
+
   # The learning loop's memory: which diagnoses actually resolved the incident. It
   # weighs recall trust, and it is what recurrence_cooldown and the grooming sweeps
   # read. Keep it UNDER catalog.mountPath so it lands on the volume above.

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -224,6 +224,13 @@ config:
   #     api_key_env: OPENAI_API_KEY
   # catalog:
   #   dir: /var/lib/runlore/catalog
+  #   # A second, read-only root of generic playbooks so kb_search is useful before
+  #   # you have curated anything. Never fires instant recall (its entries are
+  #   # resource-less by design) and the curator never writes to it. dir must differ
+  #   # from catalog.dir. See values-full.yaml for the annotated version.
+  #   commons:
+  #     url: https://github.com/Smana/runlore-kb-commons
+  #     dir: /var/lib/runlore/commons
   #   instant_recall:
   #     enabled: true
   #     min_score: 1.0                 # similarity floor for the top hit (shipped default)

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -15,6 +15,49 @@ import (
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
+// armCommons points the catalog at the shared, read-only commons root and keeps it
+// synced, when catalog.commons is configured. No-op otherwise, so a deployment
+// without it behaves exactly as before.
+//
+// It is deliberately a single function called from BOTH catalog-construction paths.
+// Two hand-wired copies is how the investigator and reinvestigator ended up reading
+// different indexes (#414); one function makes divergence impossible.
+//
+// The commons syncer is separate from the operator's own: its own directory, its own
+// (much longer) interval, and a failure that logs rather than propagates. A shared
+// upstream corpus being briefly unavailable must never degrade the operator's own
+// catalog, which is the one an incident actually depends on.
+func armCommons(ctx context.Context, cfg *config.Config, cat *catalog.Catalog, log *slog.Logger) {
+	cc := cfg.Catalog.Commons
+	if cc.URL == "" || cc.Dir == "" {
+		return
+	}
+	cat.SetCommonsDir(cc.Dir)
+
+	var token catalog.TokenFunc
+	if cc.TokenEnv != "" {
+		if t := os.Getenv(cc.TokenEnv); t != "" {
+			token = func(context.Context) (string, error) { return t, nil }
+		}
+	}
+	syncer := &catalog.Syncer{URL: cc.URL, Branch: cc.Branch, Dir: cc.Dir, Token: token, Log: log}
+	go syncer.Run(ctx, cc.Interval.Std(), func(*catalog.SyncDelta) error {
+		// Full reload, not a delta: the delta describes the COMMONS checkout, while
+		// ReloadDelta mutates the index by the operator's own paths. Reloading the
+		// primary root re-reads the commons alongside it, which is both correct and
+		// cheap at this interval.
+		if _, err := cat.ReloadContext(ctx, cfg.Catalog.Dir); err != nil {
+			log.Warn("commons catalog reload failed; keeping the previous index", "dir", cc.Dir, "err", err)
+			return err
+		}
+		log.Info("commons catalog synced", "url", cc.URL, "entries", cat.Len())
+		return nil
+	})
+	log.Info("commons catalog enabled (read-only, never curated into)",
+		"url", cc.URL, "dir", cc.Dir, "interval", cc.Interval.Std(),
+		"note", "grounds kb_search; does NOT fire instant recall — commons entries are resource-less by design")
+}
+
 // BuildCatalog returns the kb_search backing store, or nil when no catalog is
 // configured. With a Git URL it starts a background syncer (running on every
 // replica, so a failover standby is already warm) that re-indexes after each pull;
@@ -99,6 +142,7 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			warnInvalid(cat)
 			return nil
 		})
+		armCommons(ctx, cfg, cat, log)
 		log.Info("catalog git-sync enabled", "url", cfg.Catalog.Git.URL, "dir", dir)
 		return cat
 	}
@@ -128,6 +172,10 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			}
 			cat = c
 		}
+		// Arm the commons BEFORE logging the count: armCommons triggers a reload that
+		// pulls the shared root in, so logging first would report a number that is
+		// already stale.
+		armCommons(ctx, cfg, cat, log)
 		log.Info("catalog loaded", "dir", cfg.Catalog.Dir, "entries", cat.Len())
 		warnInvalid(cat)
 		return cat

--- a/internal/app/commons_wiring_test.go
+++ b/internal/app/commons_wiring_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestEveryCatalogPathArmsCommons guards against the two construction paths
+// diverging.
+//
+// BuildCatalog returns a catalog from two places — the git-sync branch and the
+// plain-directory branch — and each must arm the commons root. Wiring only one
+// means the commons silently works or doesn't depending on whether the operator
+// happens to use git-sync, with no error either way.
+//
+// That is not a hypothetical failure mode in this package: the investigator and the
+// reinvestigator each hand-wired a Recall, drifted, and left the reinvestigate path
+// running without the outcome gate (#414). Same shape, so the same guard.
+func TestEveryCatalogPathArmsCommons(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "catalog.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse catalog.go: %v", err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == "BuildCatalog" {
+			fn = fd
+			break
+		}
+	}
+	if fn == nil || fn.Body == nil {
+		t.Fatal("BuildCatalog not found — this guard is inert")
+	}
+
+	// Count the `return cat` statements (each is a construction path) and the
+	// armCommons calls. They must match.
+	var returnsCat, armCalls int
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.ReturnStmt:
+			for _, r := range v.Results {
+				if id, ok := r.(*ast.Ident); ok && id.Name == "cat" {
+					returnsCat++
+				}
+			}
+		case *ast.CallExpr:
+			if id, ok := v.Fun.(*ast.Ident); ok && id.Name == "armCommons" {
+				armCalls++
+			}
+		}
+		return true
+	})
+
+	if returnsCat == 0 {
+		t.Fatal("no `return cat` found in BuildCatalog — the shape changed and this guard is inert")
+	}
+	if armCalls != returnsCat {
+		t.Errorf("BuildCatalog has %d catalog-returning paths but only %d armCommons calls — "+
+			"a path that skips it leaves the commons silently absent, with no error",
+			returnsCat, armCalls)
+	}
+}

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -41,10 +42,23 @@ type Catalog struct {
 	// across reloads — the prerequisite for incremental Index/Delete), so search
 	// hits resolve IDs through it instead of parsing positions.
 	pathIdx map[string]int
+	// dir is the operator's own catalog root, recorded on each Reload so
+	// WriteRootFor can answer where the curator may write. commonsDir is the
+	// optional shared upstream root (SetCommonsDir); empty disables it.
+	dir        string
+	commonsDir string
 	// Log, when set (wiring time, before the first Reload), surfaces non-fatal
 	// reload degradations — an embed failure that leaves hybrid BM25-only. Nil-safe.
 	Log *slog.Logger
 }
+
+// commonsPathPrefix namespaces commons entries' Path values.
+//
+// Path is relative to its OWN root, so the same filename in both roots collides:
+// pathIdx would resolve one to the other, and bleve — which keys documents by Path —
+// would index the second over the first, silently losing an entry. Prefixing keeps
+// the two corpora distinct in both structures.
+const commonsPathPrefix = "commons/"
 
 // pathIndex maps each entry's Path to its slice position — the resolution table
 // for path-keyed bleve doc IDs. Built alongside every entries swap.
@@ -112,6 +126,35 @@ func NewEmpty() *Catalog {
 	return &Catalog{index: idx, pathIdx: map[string]int{}}
 }
 
+// SetCommonsDir points the catalog at a SECOND, read-only root loaded alongside the
+// operator's own. Empty (the default) means no commons root and byte-for-byte the
+// previous behaviour.
+//
+// It is a separate directory, never a subdirectory of the user's KB: the commons is
+// synced from an upstream repo, and letting it share a root with the git-sync mirror
+// would let an upstream change dirty the operator's own checkout.
+func (c *Catalog) SetCommonsDir(dir string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.commonsDir = dir
+}
+
+// WriteRootFor returns the directory the curator may write this entry into, or ""
+// when the entry is not writable.
+//
+// A commons entry is never writable: the corpus is upstream and shared, so a local
+// curation writing into it would both corrupt the shared view and be silently
+// reverted by the next sync. Returning "" — rather than the commons path — is what
+// makes that a structural property instead of a rule someone has to remember.
+func (c *Catalog) WriteRootFor(e Entry) string {
+	if e.Commons {
+		return ""
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.dir
+}
+
 // Reload rebuilds the index from dir and swaps it in atomically. The new index is
 // built outside the lock so concurrent Search is only blocked for the swap. It
 // returns the list of skipped (unparseable) entry paths so the caller can warn;
@@ -129,6 +172,30 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
+	// Append the commons root, marked. Loaded AFTER the user's own entries so a
+	// path collision resolves to the operator's copy, and so the stable order the
+	// tie-break relies on puts their entries first.
+	c.mu.RLock()
+	commonsDir := c.commonsDir
+	c.mu.RUnlock()
+	if commonsDir != "" {
+		cEntries, cSkipped, cErr := Load(commonsDir)
+		if cErr != nil {
+			// A broken commons root must not take the operator's own KB down with
+			// it: their entries are the ones an incident depends on.
+			if c.Log != nil {
+				c.Log.Warn("commons catalog failed to load; continuing with the local catalog only",
+					"dir", commonsDir, "err", cErr)
+			}
+		} else {
+			for i := range cEntries {
+				cEntries[i].Commons = true
+				cEntries[i].Path = commonsPathPrefix + cEntries[i].Path
+			}
+			entries = append(entries, cEntries...)
+			skipped = append(skipped, cSkipped...)
+		}
+	}
 	idx, err := buildIndex(entries)
 	if err != nil {
 		return nil, err
@@ -136,6 +203,7 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 	vectors, cache := c.embedWithCache(ctx, entries)
 	c.mu.Lock()
 	old := c.index
+	c.dir = dir
 	c.index, c.entries, c.vectors, c.pathIdx = idx, entries, vectors, pathIndex(entries)
 	if cache != nil {
 		c.vecCache = cache
@@ -341,5 +409,18 @@ func (c *Catalog) SearchScored(query string, k int) ([]ScoredEntry, error) {
 		}
 		out = append(out, ScoredEntry{Entry: c.entries[i], Score: hit.Score})
 	}
+	// Provenance breaks ties: at equal relevance the operator's OWN entry outranks a
+	// shipped generic one. A commons entry beating their own runbook on a coin-flip
+	// of index order is the wrong default — theirs describes this platform, the
+	// commons describes a failure class.
+	//
+	// Stable, and keyed only on equal scores, so it never reorders a genuine
+	// relevance difference.
+	sort.SliceStable(out, func(a, b int) bool {
+		if out[a].Score != out[b].Score {
+			return out[a].Score > out[b].Score
+		}
+		return !out[a].Entry.Commons && out[b].Entry.Commons
+	})
 	return out, nil
 }

--- a/internal/catalog/commons_test.go
+++ b/internal/catalog/commons_test.go
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"testing"
+)
+
+// writeOKF drops a minimal, valid OKF entry into dir, on top of the package's
+// existing raw writeEntry helper.
+func writeOKF(t *testing.T, dir, name, title, body string) {
+	t.Helper()
+	writeEntry(t, dir, name,
+		"---\ntype: Playbook\ntitle: "+title+"\ndescription: "+title+"\ntags: [test]\n---\n\n"+body+"\n")
+}
+
+// TestCommonsRootIsIndexedAlongsideTheUsersOwn pins the point of a commons
+// catalog: an adopter with an empty KB still gets something back from kb_search.
+func TestCommonsRootIsIndexedAlongsideTheUsersOwn(t *testing.T) {
+	own, commons := t.TempDir(), t.TempDir()
+	writeOKF(t, own, "mine.md", "payments checkout latency", "our own runbook for checkout latency")
+	writeOKF(t, commons, "shared.md", "crashloopbackoff after deploy", "generic guidance for a crash-looping pod")
+
+	c := NewEmpty()
+	c.SetCommonsDir(commons)
+	if _, err := c.ReloadContext(context.Background(), own); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := c.Len(); got != 2 {
+		t.Fatalf("both roots must be indexed, got %d entries", got)
+	}
+
+	hits, err := c.Search("crashloopbackoff", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("a commons entry must be findable by search — that is the whole point")
+	}
+	if !hits[0].Commons {
+		t.Errorf("the commons entry must be MARKED as commons, or an on-call cannot tell "+
+			"generic advice from their platform's recorded truth: %+v", hits[0])
+	}
+
+	// And the user's own entry must not be marked.
+	mine, err := c.Search("checkout latency", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mine) == 0 || mine[0].Commons {
+		t.Errorf("the user's own entry must not be flagged commons: %+v", mine)
+	}
+}
+
+// TestUsersOwnEntryWinsATie is the important one: your platform's recorded truth
+// outranks generic advice whenever the two score equally.
+func TestUsersOwnEntryWinsATie(t *testing.T) {
+	own, commons := t.TempDir(), t.TempDir()
+	// Byte-identical bodies and titles => identical BM25 scores. The ONLY thing
+	// that can order them is provenance.
+	const same = "readiness probe failing after a deploy"
+	writeOKF(t, own, "a.md", same, same)
+	writeOKF(t, commons, "b.md", same, same)
+
+	c := NewEmpty()
+	c.SetCommonsDir(commons)
+	if _, err := c.ReloadContext(context.Background(), own); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	hits, err := c.SearchScored(same, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hits) < 2 {
+		t.Fatalf("want both entries, got %d", len(hits))
+	}
+	if hits[0].Score != hits[1].Score {
+		t.Skipf("bleve did not score them identically (%v vs %v) — tie-break untested here",
+			hits[0].Score, hits[1].Score)
+	}
+	if hits[0].Entry.Commons {
+		t.Error("at equal score the user's OWN entry must rank first; a shipped generic " +
+			"entry outranking the operator's own runbook is the wrong default")
+	}
+}
+
+// TestCommonsEntriesAreNotWritable proves the curator cannot write into the
+// commons root. Entries are read-only by construction: the commons is a shared,
+// upstream corpus, and a local curation writing into it would both corrupt the
+// shared view and silently diverge from upstream on the next sync.
+func TestCommonsEntriesAreNotWritable(t *testing.T) {
+	own, commons := t.TempDir(), t.TempDir()
+	writeOKF(t, commons, "shared.md", "dns resolution failure", "generic dns guidance")
+
+	c := NewEmpty()
+	c.SetCommonsDir(commons)
+	if _, err := c.ReloadContext(context.Background(), own); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	hits, err := c.Search("dns resolution", 5)
+	if err != nil || len(hits) == 0 {
+		t.Fatalf("setup: commons entry not found (%v)", err)
+	}
+	if got := c.WriteRootFor(hits[0]); got != "" {
+		t.Errorf("a commons entry must have NO writable root, got %q — the curator would "+
+			"otherwise write into a corpus it does not own", got)
+	}
+	// A user-owned entry still resolves to the writable root.
+	writeOKF(t, own, "mine.md", "payments latency", "our runbook")
+	if _, err := c.ReloadContext(context.Background(), own); err != nil {
+		t.Fatal(err)
+	}
+	mine, _ := c.Search("payments latency", 5)
+	if len(mine) == 0 || c.WriteRootFor(mine[0]) != own {
+		t.Errorf("a user entry must resolve to the writable root %q, got %q", own, c.WriteRootFor(mine[0]))
+	}
+}
+
+// TestSameFilenameInBothRootsDoesNotCollide pins the path namespacing.
+//
+// Entry.Path is relative to its OWN root, so "crashloop.md" in the user's KB and
+// "crashloop.md" in the commons produce the same Path. pathIdx is keyed by Path and
+// bleve keys its documents by Path, so without a prefix the second entry overwrites
+// the first in both structures — one entry silently disappears, and every search hit
+// for the survivor resolves to the wrong entry.
+//
+// The earlier tests all used distinct filenames, so they passed with the prefix
+// removed. This is the one that fails.
+func TestSameFilenameInBothRootsDoesNotCollide(t *testing.T) {
+	own, commons := t.TempDir(), t.TempDir()
+	const name = "crashloop.md"
+	writeOKF(t, own, name, "our checkout service crashloops on rollout", "team-specific rollout guidance")
+	writeOKF(t, commons, name, "generic crashloopbackoff after deploy", "generic guidance")
+
+	c := NewEmpty()
+	c.SetCommonsDir(commons)
+	if _, err := c.ReloadContext(context.Background(), own); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := c.Len(); got != 2 {
+		t.Fatalf("same filename in both roots must yield TWO entries, got %d — one was "+
+			"overwritten by the other", got)
+	}
+
+	// Both must be independently retrievable, and each must resolve to itself.
+	ours, err := c.Search("checkout service rollout", 5)
+	if err != nil || len(ours) == 0 {
+		t.Fatalf("the user's entry is unreachable (%v)", err)
+	}
+	if ours[0].Commons {
+		t.Errorf("search for the user's entry resolved to the COMMONS entry — the doc IDs collided: %+v", ours[0])
+	}
+	theirs, err := c.Search("generic crashloopbackoff", 5)
+	if err != nil || len(theirs) == 0 {
+		t.Fatalf("the commons entry is unreachable (%v)", err)
+	}
+	if !theirs[0].Commons {
+		t.Errorf("search for the commons entry resolved to the USER's entry — the doc IDs collided: %+v", theirs[0])
+	}
+}

--- a/internal/catalog/entry.go
+++ b/internal/catalog/entry.go
@@ -48,4 +48,16 @@ type Entry struct {
 	LastValidated string
 	Body          string // markdown body (after frontmatter)
 	Path          string // file path relative to the bundle root
+	// Commons marks an entry loaded from the shared upstream catalog
+	// (catalog.commons) rather than the operator's own KB.
+	//
+	// It is provenance, and it is load-bearing in three places: search orders a
+	// user's own entry ABOVE a commons entry at equal score, the curator refuses
+	// to write into the commons root, and every surface that shows the entry says
+	// where it came from — an on-call must never mistake shipped generic advice
+	// for their platform's recorded truth.
+	//
+	// False for every entry loaded the original way, so a deployment without a
+	// commons root behaves exactly as before.
+	Commons bool
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -527,9 +527,39 @@ type LeaderElection struct {
 // a mounted Dir (e.g. a ConfigMap) or a Git repo to sync (which closes the
 // read/write loop — the curator's merged PRs flow back into what the agent reads).
 type Catalog struct {
-	Dir           string        `yaml:"dir"` // OKF bundle path (mounted ConfigMap, or the git-sync mirror)
-	Git           CatalogGit    `yaml:"git"`
-	InstantRecall InstantRecall `yaml:"instant_recall"`
+	Dir           string         `yaml:"dir"` // OKF bundle path (mounted ConfigMap, or the git-sync mirror)
+	Git           CatalogGit     `yaml:"git"`
+	Commons       CatalogCommons `yaml:"commons"`
+	InstantRecall InstantRecall  `yaml:"instant_recall"`
+}
+
+// CatalogCommons is an optional SECOND, read-only catalog root synced from a shared
+// upstream repo and indexed alongside the operator's own.
+//
+// Off by default. Adopting someone else's corpus is a choice, not something that
+// should happen on an upgrade — and the entries it carries are generic by design,
+// so they must never be mistaken for the platform's own recorded truth. Three
+// properties follow from that and are enforced, not documented:
+//
+//   - every commons entry is MARKED as such wherever it surfaces;
+//   - at equal relevance the operator's own entry ranks first;
+//   - the curator can never write into the commons root (catalog.WriteRootFor).
+//
+// What it does NOT do is fire instant recall. Recall applies a structural filter —
+// a resource-less entry never agrees with a workload-carrying alert — and commons
+// entries are resource-less by construction because they describe a failure class
+// rather than one cluster's workload. They ground kb_search, which applies no such
+// filter. That is genuine day-one value; claiming recall would not be.
+type CatalogCommons struct {
+	URL      string   `yaml:"url"`      // shared catalog repo; empty disables the commons root
+	Branch   string   `yaml:"branch"`   // default "main"
+	Interval Duration `yaml:"interval"` // re-sync period (default 24h — a shared corpus changes slowly)
+	// Dir is where the commons is checked out. It MUST differ from catalog.dir: the
+	// two are separate corpora, and sharing a root would let an upstream sync dirty
+	// the operator's own checkout.
+	Dir string `yaml:"dir"`
+	// TokenEnv names an env var holding a read token for a private commons repo.
+	TokenEnv string `yaml:"token_env"`
 }
 
 // Outcome configures the learning-loop outcome ledger.
@@ -1380,6 +1410,20 @@ func (c *Config) Validate() error {
 		}
 		if c.Outcome.LedgerPath == "" {
 			return fmt.Errorf("notify.matrix.feedback_reactions requires outcome.ledger_path: ratings are recorded in the outcome ledger")
+		}
+	}
+	// Commons catalog (opt-in): a second, read-only root. Fail closed on a
+	// misconfiguration rather than degrading to a silently-absent corpus.
+	if cc := c.Catalog.Commons; cc.URL != "" {
+		if cc.Dir == "" {
+			return fmt.Errorf("catalog.commons.url is set but catalog.commons.dir is empty: the shared catalog needs its own checkout directory")
+		}
+		// Sharing a directory with the operator's own catalog would let an upstream
+		// sync write into their checkout — and, with git-sync enabled, fight the
+		// mirror on every reconcile. Distinct roots is the whole basis of the
+		// read-only guarantee.
+		if cc.Dir == c.Catalog.Dir {
+			return fmt.Errorf("catalog.commons.dir must differ from catalog.dir (both are %q): the shared catalog is a SEPARATE, read-only root and must not share the operator's checkout", cc.Dir)
 		}
 	}
 	// Instant-recall reranker (opt-in): its knobs are only meaningful when enabled.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -835,3 +835,49 @@ func TestLogsIndexValidate(t *testing.T) {
 		}
 	}
 }
+
+// TestCommonsCatalogValidation pins the fail-closed cases for the shared catalog.
+//
+// Both are silent-degradation bugs otherwise: a missing dir leaves the commons
+// simply absent (an operator who configured it sees nothing and no error), and a
+// shared dir lets an upstream sync write into the operator's own checkout — which
+// with git-sync enabled means the two fight on every reconcile.
+func TestCommonsCatalogValidation(t *testing.T) {
+	base := func() *Config {
+		c := &Config{}
+		c.Catalog.Dir = "/var/lib/runlore/catalog"
+		c.Catalog.Commons.URL = "https://github.com/Smana/runlore-kb-commons"
+		return c
+	}
+
+	t.Run("url without dir is rejected", func(t *testing.T) {
+		c := base()
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "catalog.commons.dir") {
+			t.Fatalf("want a commons.dir error, got: %v", err)
+		}
+	})
+
+	t.Run("dir equal to catalog.dir is rejected", func(t *testing.T) {
+		c := base()
+		c.Catalog.Commons.Dir = c.Catalog.Dir
+		if err := c.Validate(); err == nil || !strings.Contains(err.Error(), "must differ") {
+			t.Fatalf("want a distinct-directory error, got: %v", err)
+		}
+	})
+
+	t.Run("distinct dir validates", func(t *testing.T) {
+		c := base()
+		c.Catalog.Commons.Dir = "/var/lib/runlore/commons"
+		if err := c.Validate(); err != nil {
+			t.Fatalf("a well-formed commons config must validate: %v", err)
+		}
+	})
+
+	t.Run("absent commons is unaffected", func(t *testing.T) {
+		c := &Config{}
+		c.Catalog.Dir = "/var/lib/runlore/catalog"
+		if err := c.Validate(); err != nil {
+			t.Fatalf("no commons configured must stay valid: %v", err)
+		}
+	})
+}

--- a/website/content/docs/concepts/knowledge-commons.md
+++ b/website/content/docs/concepts/knowledge-commons.md
@@ -1,0 +1,95 @@
+---
+title: Knowledge Commons
+weight: 55
+---
+
+A fresh RunLore deployment has an empty catalog. `kb_search` returns nothing, and it stays
+that way until you have investigated enough incidents to curate entries of your own. The
+**knowledge commons** fills that gap: a shared, read-only corpus of generic playbooks —
+`CrashLoopBackOff`, `ImagePullBackOff`, unbound PVCs, stuck cert-manager challenges,
+unschedulable pods — that covers failure *classes* every Kubernetes platform hits.
+
+It is a **second catalog root**, indexed alongside your own. Enable it and the investigation
+loop has something to ground on from day one.
+
+```yaml
+catalog:
+  dir: /var/lib/runlore/catalog
+  commons:
+    url: https://github.com/Smana/runlore-kb-commons
+    branch: main
+    interval: 24h
+    dir: /var/lib/runlore/commons    # MUST differ from catalog.dir
+```
+
+## Two roots, four rules
+
+The commons is deliberately not just "more entries in your catalog". Four properties hold,
+and each one exists to stop a specific failure:
+
+**Both roots are indexed together.** `kb_search` searches one index covering both. There is
+no separate tool and no flag to remember mid-incident.
+
+**Commons entries are marked.** Every entry carries its provenance, so a citation tells you
+whether the knowledge came from your cluster's history or from the shared corpus. Those
+deserve different amounts of trust and you should be able to tell them apart at a glance.
+
+**Your entry wins ties.** When a commons entry and one of your own score equally, yours
+ranks first. Knowledge written from your actual incidents beats a generic description of the
+same failure class, so the commons can only ever act as a floor — never as competition.
+
+**The curator never writes to it.** Drafted entries always land in your own catalog repo.
+The commons directory is a mirror of an upstream repository and stays pristine; there is no
+configuration that makes it writable.
+
+## Why commons entries never fire instant recall
+
+This is the property most worth understanding before you enable it.
+
+[Instant recall]({{< relref "learning-loop.md" >}}) short-circuits the LLM loop entirely when the catalog
+already holds a trustworthy answer. Before any scoring happens, it applies a **structural
+filter**: an entry's `resource` must agree with the alert's workload. An entry with no
+`resource` can only agree with a request that itself carries no workload — and real
+Kubernetes alerts carry a namespace and a workload.
+
+Commons entries are resource-less by construction. They describe a failure class, not one
+cluster's workload, so there is no honest `resource` to give them. The consequence follows
+directly: **a commons entry can never fire instant recall.**
+
+That is the correct behaviour, not a limitation to work around. Instant recall answers an
+incident without looking at it. Doing that from a generic playbook would mean asserting that
+*your* `CrashLoopBackOff` has the same cause as the textbook one — which is exactly the
+confidently-wrong answer that makes cached knowledge worse than none.
+
+What commons entries do instead is ground `kb_search`, which applies no structural filter.
+The model finds and cites them mid-loop, where they belong: telling the investigation which
+command to run next and which readings distinguish one cause from another. The evidence
+still gets gathered; the playbook just makes gathering it faster.
+
+To get instant recall you need entries scoped to your workloads (`resource:
+<namespace>/<name>`). Those are the ones RunLore drafts for you from your own incidents.
+
+## Scope discipline
+
+Every commons entry ends with a `# Not covered` section naming the adjacent failure classes
+it does **not** explain — the OOM playbook says it does not cover node memory pressure, the
+scheduling playbook says it does not cover volume node affinity conflicts.
+
+This is load-bearing rather than decorative. A generic playbook is most dangerous at its
+edges, where it looks applicable and is not, so each entry states its own boundary instead
+of leaving the model to infer one.
+
+## Operational notes
+
+The commons syncs on its own schedule, separate from your catalog's: its own directory, a
+much longer interval (a shared corpus changes slowly), and a sync failure that logs rather
+than propagates. An upstream repository being briefly unreachable must never degrade the
+catalog an incident actually depends on.
+
+Its checkout is an `emptyDir` — re-cloned on startup, never persisted. Nothing is authored
+there, so there is nothing to lose on restart, and keeping it off the persisted data path
+means an upstream sync cannot dirty the volume holding your outcome ledger and audit log.
+
+`commons.dir` must differ from `catalog.dir`. Both the agent's config validation and the
+Helm chart refuse to start with a shared root, because one directory serving both corpora
+would let an upstream sync overwrite the entries you curate.


### PR DESCRIPTION
Adds `catalog.commons` — a second catalog root, indexed alongside the operator's own, holding a shared corpus of generic playbooks. Pairs with #423, which ships the bundle itself.

## Four enforced properties

| Property | Why it exists |
|---|---|
| Both roots indexed together | `kb_search` searches one index; no second tool to remember mid-incident |
| Commons entries carry provenance (`Commons bool`) | A citation must tell you whether the knowledge came from your cluster's history or a shared corpus — those deserve different trust |
| Your entry wins scoring ties | Knowledge from your actual incidents beats a generic description of the same class; the commons is a floor, never competition |
| The curator cannot write to commons | `WriteRootFor` returns `""` for a commons entry, so drafts always land in your own repo and the mirror stays pristine |

Each is covered by a test, and each test was mutation-verified — inverting the tie-break, dropping the provenance flag, and pointing `WriteRootFor` at the commons root each fail with the expected message.

## Never fires instant recall

Worth stating plainly, because it is the property that decides whether this feature is safe. Commons entries are resource-less by construction — they describe a failure class, not one cluster's workload — and `resourceAgrees` rejects a resource-less entry for any request carrying a namespace. So recall structurally cannot fire on them.

That is the correct behaviour. Instant recall answers an incident *without looking at it*; doing that from a generic playbook would assert that your `CrashLoopBackOff` has the textbook cause. Commons entries ground `kb_search` instead, which applies no structural filter — they speed up evidence-gathering rather than replacing it.

## Fails closed

Config validation rejects an empty `commons.dir` and a `commons.dir` equal to `catalog.dir`. The chart repeats both as render-time `fail`s, so a bad values file never reaches a cluster.

`armCommons` is a single function called from **both** `BuildCatalog` return paths, with an AST test counting `return cat` sites against `armCommons` calls. Two hand-wired copies is precisely how the investigator and reinvestigator ended up reading different indexes in #414.

## Chart

The mount path is derived from `config.catalog.commons.dir` rather than duplicated as a chart value — a second knob would be free to drift from what the agent reads, and that drift is silent (an empty commons root looks exactly like no commons at all). The checkout is an `emptyDir`, deliberately not the persisted data path, so an upstream sync can never dirty the volume holding the outcome ledger and audit log.

Verified by rendering four cases: commons off (no volume), commons on (volume + mount at `dir`), url without dir (fails), and `dir == catalog.dir` (fails).