### PR TITLE
fix(cli): lore kb search reads the commons, not just your own catalog

### DIFF
--- a/internal/app/kb_cmd.go
+++ b/internal/app/kb_cmd.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -38,10 +39,22 @@ func RunKB(args []string) error {
 }
 
 // loadKBCatalog opens the catalog for the read commands: an explicit --dir
-// wins; otherwise config catalog.dir. The CLI never clones — a git-synced
-// catalog is materialized by `lore catalog sync` (or a running agent), so the
-// error message points there instead of failing cryptically.
+// wins; otherwise config catalog.dir PLUS the commons root when one is
+// configured. The CLI never clones — a git-synced catalog (either root) is
+// materialized by `lore catalog sync` or a running agent, so the error message
+// points there instead of failing cryptically.
+//
+// The commons must be honoured here, not just in BuildCatalog. Its whole purpose
+// is that an operator has knowledge on day one, before curating anything — so the
+// empty-own-catalog case is the one it exists for, and `lore kb search` is the
+// most natural way someone checks whether it worked. Reading only catalog.dir
+// answered "your catalog is empty" while 22 indexed entries sat one root over.
+//
+// An explicit --dir still means exactly that directory: it is the escape hatch for
+// pointing at an arbitrary checkout, and silently folding in a configured commons
+// would make it lie.
 func loadKBCatalog(cfgPath, dir string) (*catalog.Catalog, error) {
+	commonsDir := ""
 	if dir == "" {
 		cfg, err := config.Load(cfgPath)
 		if err != nil {
@@ -51,13 +64,33 @@ func loadKBCatalog(cfgPath, dir string) (*catalog.Catalog, error) {
 		if dir == "" {
 			return nil, fmt.Errorf("no catalog configured (set catalog.dir or pass --dir <catalog>)")
 		}
+		// url is what enables the commons (matching armCommons, which no-ops
+		// without it), and dir is where a sync already put it on disk.
+		if cfg.Catalog.Commons.URL != "" {
+			commonsDir = cfg.Catalog.Commons.Dir
+		}
 	}
-	cat, err := catalog.New(dir)
-	if err != nil {
-		return nil, fmt.Errorf("load catalog %s: %w (for a git-synced catalog, run `lore catalog sync` first)", dir, err)
+	if commonsDir == "" {
+		cat, err := catalog.New(dir)
+		if err != nil {
+			return nil, fmt.Errorf("load catalog %s: %w (for a git-synced catalog, run `lore catalog sync` first)", dir, err)
+		}
+		if cat.Len() == 0 {
+			return nil, fmt.Errorf("catalog %s has no entries (for a git-synced catalog, run `lore catalog sync` first)", dir)
+		}
+		return cat, nil
+	}
+
+	// Both roots: SetCommonsDir before the load, since ReloadContext is what reads
+	// the commons alongside the primary root. No syncer — this is a short-lived
+	// read command and the CLI never clones.
+	cat := catalog.NewEmpty()
+	cat.SetCommonsDir(commonsDir)
+	if _, err := cat.ReloadContext(context.Background(), dir); err != nil {
+		return nil, fmt.Errorf("load catalog %s (commons %s): %w (for a git-synced catalog, run `lore catalog sync` first)", dir, commonsDir, err)
 	}
 	if cat.Len() == 0 {
-		return nil, fmt.Errorf("catalog %s has no entries (for a git-synced catalog, run `lore catalog sync` first)", dir)
+		return nil, fmt.Errorf("catalog %s and commons %s are both empty (for a git-synced catalog, run `lore catalog sync` first)", dir, commonsDir)
 	}
 	return cat, nil
 }

--- a/internal/app/kb_cmd_test.go
+++ b/internal/app/kb_cmd_test.go
@@ -317,3 +317,79 @@ func TestKBShowAmbiguousBasename(t *testing.T) {
 		}
 	}
 }
+
+// TestKBSearchReadsCommonsWithEmptyOwnCatalog is the regression this whole
+// feature exists to prevent. The commons ships knowledge for operators who have
+// curated NOTHING yet, so an empty own-catalog is its designed state — and
+// `lore kb search` is the most natural way someone verifies it worked.
+//
+// loadKBCatalog used to call catalog.New(catalog.dir) directly, bypassing the
+// commons wiring that BuildCatalog does. The CLI answered "catalog has no
+// entries" while a fully-indexed commons root sat one directory over: the same
+// two-hand-wired-paths divergence as #414, in a different file.
+func TestKBSearchReadsCommonsWithEmptyOwnCatalog(t *testing.T) {
+	own := t.TempDir() // deliberately empty — the day-one state
+	commons := t.TempDir()
+	writeEntryFile(t, commons, "playbooks/pod-unschedulable.md",
+		"---\ntype: Playbook\ntitle: Pod stuck Pending, scheduler finds no node\n"+
+			"description: FailedScheduling with insufficient cpu or an untolerated taint\n"+
+			"tags: [scheduling, pending, FailedScheduling]\n---\n# Symptom\n\nPending with FailedScheduling.\n")
+
+	cfg := filepath.Join(t.TempDir(), "runlore.yaml")
+	if err := os.WriteFile(cfg, []byte(
+		"catalog:\n  dir: "+own+"\n  commons:\n    url: https://github.com/Smana/runlore-kb-commons\n"+
+			"    dir: "+commons+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := runKBSearch([]string{"--config", cfg, "pod", "pending", "FailedScheduling"}, &out); err != nil {
+		t.Fatalf("search with an empty own-catalog must fall back to the commons, got: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "pod-unschedulable.md") {
+		t.Errorf("commons entry not returned:\n%s", got)
+	}
+	// Provenance must be visible: a reader has to be able to tell shared knowledge
+	// from their own at a glance, because the two warrant different trust.
+	if !strings.Contains(got, "commons/") {
+		t.Errorf("commons entries must be visibly marked as such in the ENTRY column:\n%s", got)
+	}
+}
+
+// TestKBSearchExplicitDirIgnoresCommons: --dir is the escape hatch for pointing
+// at an arbitrary checkout. Folding a configured commons into it would make the
+// flag lie about what it read.
+func TestKBSearchExplicitDirIgnoresCommons(t *testing.T) {
+	own := writeKBFixture(t)
+	commons := t.TempDir()
+	writeEntryFile(t, commons, "playbooks/only-in-commons.md",
+		"---\ntype: Playbook\ntitle: Crashloop web configmap generic playbook\n"+
+			"description: crashloop web configmap\ntags: [crashloop]\n---\n# Symptom\n\ncrashloop web configmap\n")
+
+	cfg := filepath.Join(t.TempDir(), "runlore.yaml")
+	if err := os.WriteFile(cfg, []byte(
+		"catalog:\n  dir: "+own+"\n  commons:\n    url: https://github.com/Smana/runlore-kb-commons\n"+
+			"    dir: "+commons+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out strings.Builder
+	if err := runKBSearch([]string{"--config", cfg, "--dir", own, "crashloop", "web", "configmap"}, &out); err != nil {
+		t.Fatalf("runKBSearch: %v", err)
+	}
+	if strings.Contains(out.String(), "only-in-commons") {
+		t.Errorf("--dir must read exactly that directory, not a configured commons:\n%s", out.String())
+	}
+}
+
+func writeEntryFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Found while demonstrating S6's own verification item — *"an investigation against an empty user KB visibly cites a commons entry — demonstrated, not assumed."* The demonstration failed.

## The bug

`loadKBCatalog` called `catalog.New(cfg.Catalog.Dir)` directly, bypassing the commons wiring that `BuildCatalog` does via `armCommons`. With a configured commons and an empty own-catalog:

```console
$ lore kb search "pod stuck Pending FailedScheduling insufficient cpu untolerated taint" --config runlore.yaml
kb: catalog /…/empty-user-catalog has no entries (for a git-synced catalog, run `lore catalog sync` first)
```

…while 22 indexed commons entries sat one root over. After the fix, same command, same config:

```console
SCORE  ENTRY                                               TITLE
0.68   commons/playbooks/pod-unschedulable.md              Pod stuck Pending because the scheduler finds no suitable no…
0.25   commons/playbooks/volume-node-affinity-conflict.md  Pod unschedulable with volume node affinity conflict
0.10   commons/playbooks/pvc-pending-unbound.md            PersistentVolumeClaim stuck Pending and never bound
```

Verified against the **live** `Smana/runlore-kb-commons` repo, not a fixture.

## Why it matters more than a CLI papercut

An empty own-catalog is the commons' **designed** state — it exists precisely for operators who have curated nothing yet. And `lore kb search` is the most natural way someone verifies that enabling it worked. The first thing they would have seen is a message telling them it hadn't.

Same shape as #414: two hand-wired paths to the same thing, quietly drifting. The agent's `kb_search` tool was correct throughout — only the CLI read surface was blind, which is why nothing caught it.

## Scope

`--dir` still means exactly that directory. It is the escape hatch for pointing at an arbitrary checkout, and silently folding in a configured commons would make the flag lie. No syncer is started: these are short-lived read commands, the CLI never clones, and it indexes whatever a sync or a running agent already materialized.

## Tests

Two, both mutation-verified:

| Mutation | Caught by |
|---|---|
| Revert to the `catalog.New`-only path | `ReadsCommonsWithEmptyOwnCatalog` — reproduces the original error verbatim |
| Let `--dir` fold in the commons | `ExplicitDirIgnoresCommons` — surfaces `commons/playbooks/only-in-commons.md` |
| Drop the `commons/` path prefix | `ReadsCommonsWithEmptyOwnCatalog` — provenance assertion fires |

The provenance assertion is deliberate: a reader has to tell shared knowledge from their own at a glance, because the two warrant different trust.