### PR TITLE
fix(gitlab): stop retrying writes, report pagination truncation, correct the docs

### DIFF
--- a/internal/app/catalog_cmd.go
+++ b/internal/app/catalog_cmd.go
@@ -56,7 +56,7 @@ func RunCatalogSync(args []string) error {
 		if t := os.Getenv(env); t != "" {
 			token = func(context.Context) (string, error) { return t, nil }
 		}
-	} else if ft := BuildForgeTokenSource(cfg, log); ft != nil {
+	} else if ft := BuildKBTokenSource(cfg, log); ft != nil {
 		token = catalog.TokenFunc(ft)
 	}
 	syncer := &catalog.Syncer{URL: g.URL, Branch: g.Branch, Dir: dir, Token: token, Log: log}

--- a/internal/app/forge.go
+++ b/internal/app/forge.go
@@ -46,6 +46,19 @@ func BuildForgeTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
 // token_env at config-load time, but an operator can still forget to actually
 // set the env var when deploying, so this stays a warn-and-disable (not a
 // panic) exactly like BuildForgeTokenSource's own credential checks.
+func BuildGitLabTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
+	te := cfg.Forge.GitLab.TokenEnv
+	if te == "" {
+		return nil
+	}
+	tok := os.Getenv(te)
+	if tok == "" {
+		log.Warn("gitlab forge auth disabled: empty token env", "env", te)
+		return nil
+	}
+	return func(context.Context) (string, error) { return tok, nil }
+}
+
 // BuildKBTokenSource picks the credential for reading the KNOWLEDGE-BASE repo —
 // the catalog git-sync — by forge provider.
 //
@@ -67,17 +80,4 @@ func BuildKBTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
 		return BuildGitLabTokenSource(cfg, log)
 	}
 	return BuildForgeTokenSource(cfg, log)
-}
-
-func BuildGitLabTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
-	te := cfg.Forge.GitLab.TokenEnv
-	if te == "" {
-		return nil
-	}
-	tok := os.Getenv(te)
-	if tok == "" {
-		log.Warn("gitlab forge auth disabled: empty token env", "env", te)
-		return nil
-	}
-	return func(context.Context) (string, error) { return tok, nil }
 }

--- a/internal/app/forge.go
+++ b/internal/app/forge.go
@@ -46,6 +46,29 @@ func BuildForgeTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
 // token_env at config-load time, but an operator can still forget to actually
 // set the env var when deploying, so this stays a warn-and-disable (not a
 // panic) exactly like BuildForgeTokenSource's own credential checks.
+// BuildKBTokenSource picks the credential for reading the KNOWLEDGE-BASE repo —
+// the catalog git-sync — by forge provider.
+//
+// This is deliberately separate from BuildForgeTokenSource, which mints GitHub App
+// installation tokens and is correct for the GitHub-only paths (curate, sweeps, the
+// what-changed differ that clones source repos). Catalog sync is different: it reads
+// the same repo the curator writes to, so it must follow forge.provider.
+//
+// Before this existed, catalog sync fell back to the GitHub App identity on every
+// deployment. On GitLab that source is nil, so the syncer cloned ANONYMOUSLY: with a
+// private KB project, RunLore opened the merge request, a human merged it, and the
+// merged knowledge never came back into the catalog. The learning loop was severed at
+// the seam, silently — the log line explaining the fallback did not even fire, because
+// the token source was nil rather than wrong.
+//
+// catalog.git.token_env still wins over this; it is the explicit escape hatch.
+func BuildKBTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
+	if cfg.Forge.Provider == "gitlab" {
+		return BuildGitLabTokenSource(cfg, log)
+	}
+	return BuildForgeTokenSource(cfg, log)
+}
+
 func BuildGitLabTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
 	te := cfg.Forge.GitLab.TokenEnv
 	if te == "" {

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -49,7 +49,9 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		apiKey = os.Getenv(cfg.Model.APIKeyEnv)
 	}
 	model := BuildModel(cfg, apiKey)
-	forgeTok := BuildForgeTokenSource(cfg, log)
+	// Catalog sync reads the KB repo, so it follows forge.provider — not the
+	// GitHub-App-only source used by the curate/sweep/differ paths.
+	forgeTok := BuildKBTokenSource(cfg, log)
 	var tools []investigate.Tool
 	if gp != nil {
 		tools = append(tools, investigate.WhatChangedTool{GitOps: gp})

--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -49,6 +50,24 @@ type Client struct {
 	baseBranch  string
 	token       TokenFunc
 	http        *http.Client
+	// Log reports pagination degradation. Optional: nil means the warnings are
+	// dropped, which keeps New's signature stable for callers that don't have a
+	// logger. WithLogger attaches one.
+	log *slog.Logger
+}
+
+// WithLogger attaches a logger used to report silent-degradation cases (see
+// listPaged). Returns the receiver so it can be chained onto New.
+func (c *Client) WithLogger(l *slog.Logger) *Client {
+	c.log = l
+	return c
+}
+
+// warn logs when a logger is attached, and is a no-op otherwise.
+func (c *Client) warn(msg string, args ...any) {
+	if c.log != nil {
+		c.log.Warn(msg, args...)
+	}
 }
 
 // DefaultBaseURL is the public gitlab.com instance root. Override for a
@@ -145,7 +164,24 @@ func (c *Client) request(ctx context.Context, method, path string, body any) ([]
 			return nil, nil, err
 		}
 	}
-	resp, err := httpx.DoWithRetry(ctx, c.http, 3, func() (*http.Request, error) {
+	// Retry ONLY idempotent requests. DoWithRetry retries on a network error, 429
+	// and 5xx — all of which can fire AFTER the server has already applied a write.
+	// A proxy returning 504 on a landed POST /repository/commits means the retry
+	// re-sends it with start_branch against a branch that now exists, GitLab answers
+	// 400 "A branch called ... already exists", and OpenPR reports failure for a
+	// commit that succeeded: the drafted entry sits on an orphan branch with no MR
+	// and the operator is told curation failed. POST .../notes duplicates a comment
+	// the same way.
+	//
+	// GETs are where the retry actually earns its keep anyway — the paginated list
+	// calls are the request-hungry path that meets rate limiting. Retrying writes
+	// safely needs a pre-flight "does this branch already exist" check, which is a
+	// larger change than the win justifies.
+	attempts := 3
+	if method != http.MethodGet {
+		attempts = 1
+	}
+	resp, err := httpx.DoWithRetry(ctx, c.http, attempts, func() (*http.Request, error) {
 		var rdr io.Reader
 		if raw != nil {
 			rdr = bytes.NewReader(raw)
@@ -167,7 +203,15 @@ func (c *Client) request(ctx context.Context, method, path string, body any) ([]
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
-		return nil, resp.Header, &statusError{method: method, path: path, status: resp.StatusCode, body: string(data[:min(len(data), 512)])}
+		// The body is server-controlled and lands in logs and operator-facing errors.
+		// A server that echoes the credential back — a debug endpoint, a chatty proxy,
+		// a misconfigured auth layer — would otherwise get it laundered straight into
+		// our error text. Strip it rather than trusting the far end not to reflect it.
+		body := string(data[:min(len(data), 512)])
+		if tok != "" {
+			body = strings.ReplaceAll(body, tok, "[REDACTED]")
+		}
+		return nil, resp.Header, &statusError{method: method, path: path, status: resp.StatusCode, body: body}
 	}
 	return data, resp.Header, nil
 }
@@ -303,10 +347,25 @@ func (c *Client) listPaged(ctx context.Context, resource, state, label string) (
 		// on the last page. Absent (a proxy that strips it, or keyset pagination)
 		// is treated as "done" too: under-fetching one page is recoverable, an
 		// endless loop is not.
-		if strings.TrimSpace(hdr.Get("X-Next-Page")) == "" {
-			break
+		next := strings.TrimSpace(hdr.Get("X-Next-Page"))
+		if next == "" {
+			// Distinguish "genuinely the last page" from "the cursor was stripped".
+			// GitLab sets X-Next-Page to "" on the last page, so an ABSENT header on
+			// a FULL page means something between us and GitLab dropped it — and we
+			// are about to under-read. That matters: this list feeds the curator's
+			// dedup, so reading a truncated backlog makes RunLore file a duplicate
+			// merge request on every recurrence, forever, with nothing erroring.
+			if _, present := hdr[http.CanonicalHeaderKey("X-Next-Page")]; !present && len(raw) == perPage {
+				c.warn("gitlab pagination cursor absent on a full page — the merge-request backlog may be truncated, which makes duplicate-MR detection unreliable",
+					"resource", resource, "page", page, "per_page", perPage)
+			}
+			return all, nil
 		}
 	}
+	// Fell out of the loop: the page cap fired rather than the cursor running out,
+	// so this list is definitively incomplete. Same dedup consequence as above.
+	c.warn("gitlab pagination hit the page cap — the merge-request backlog is truncated, so duplicate-MR detection is reading a partial list",
+		"resource", resource, "max_pages", maxListPages, "items", len(all))
 	return all, nil
 }
 

--- a/internal/forge/gitlab/gitlab_test.go
+++ b/internal/forge/gitlab/gitlab_test.go
@@ -109,9 +109,23 @@ func TestOpenPR(t *testing.T) {
 		t.Fatalf("ref = %q", ref.URL)
 	}
 
-	// branch creation is folded into the commit call via start_branch
-	if commitBody["branch"] == "" || commitBody["start_branch"] != "main" {
-		t.Fatalf("commit body missing branch/start_branch: %+v", commitBody)
+	// Branch creation is folded into the commit call via start_branch.
+	//
+	// Asserted as a typed string, not `commitBody["branch"] == ""`: that compares an
+	// `any` against a string, so a MISSING key (nil) is not equal to "" and the check
+	// silently passes. The property that actually matters is that the entry lands on a
+	// fresh runlore branch — a regression setting branch: c.baseBranch would commit the
+	// draft straight to main, bypassing the review gate that is the whole point of the
+	// forge write surface.
+	branch, _ := commitBody["branch"].(string)
+	if !strings.HasPrefix(branch, "runlore/kb-") {
+		t.Fatalf("commit must target a fresh runlore/kb-* branch, got %q (body: %+v)", branch, commitBody)
+	}
+	if branch == "main" || branch == commitBody["start_branch"] {
+		t.Fatalf("entry must never be committed to the base branch, got branch=%q start_branch=%v", branch, commitBody["start_branch"])
+	}
+	if commitBody["start_branch"] != "main" {
+		t.Fatalf("commit must branch from the configured base, got start_branch=%v", commitBody["start_branch"])
 	}
 	actions, ok := commitBody["actions"].([]any)
 	if !ok || len(actions) == 0 {
@@ -776,5 +790,60 @@ func TestOpenPRSurvivesBundleReadFailure(t *testing.T) {
 	}
 	if len(actions) != 1 {
 		t.Fatalf("want the entry action alone when bundle reads fail, got %+v", actions)
+	}
+}
+
+// TestWritesAreNotRetried: DoWithRetry retries on network errors, 429 and 5xx —
+// all of which can fire AFTER the server already applied a write. A proxy
+// returning 504 on a landed POST /repository/commits used to make RunLore re-send
+// it with start_branch against a branch that now exists; GitLab answers 400
+// "A branch called ... already exists" and OpenPR reports failure for a commit
+// that SUCCEEDED, leaving the drafted entry on an orphan branch with no MR.
+func TestWritesAreNotRetried(t *testing.T) {
+	var posts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isBundleRead(r) {
+			bundleAbsent(w)
+			return
+		}
+		if r.Method == http.MethodPost {
+			posts++
+		}
+		w.WriteHeader(http.StatusBadGateway) // retryable status
+		_, _ = w.Write([]byte(`{"message":"gateway"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "o/r", "main", staticToken("tok"))
+	_, _ = c.OpenPR(context.Background(), providers.KBEntry{Type: "Incident", Title: "db outage", Body: "## body"})
+	if posts != 1 {
+		t.Fatalf("a write must be attempted exactly once, got %d attempts — retrying a POST risks applying it twice", posts)
+	}
+}
+
+// TestTokenNeverAppearsInErrors: statusError embeds the response body, which is
+// server-controlled. Nothing else pins that the credential stays out of errors
+// that get logged and surfaced to operators.
+func TestTokenNeverAppearsInErrors(t *testing.T) {
+	const secret = "glpat-SUPERSECRETVALUE1234"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isBundleRead(r) {
+			bundleAbsent(w)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		// A hostile/naive server echoing the credential back must not get it
+		// laundered into our error text.
+		_, _ = w.Write([]byte(`{"message":"401 Unauthorized for token ` + secret + `"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "o/r", "main", staticToken(secret))
+	_, err := c.OpenPR(context.Background(), providers.KBEntry{Type: "Incident", Title: "db outage", Body: "## body"})
+	if err == nil {
+		t.Fatal("want an error from a 401")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("the token leaked into an error operators will see and log:\n%s", err.Error())
 	}
 }

--- a/website/content/docs/integrations/forge/gitlab.md
+++ b/website/content/docs/integrations/forge/gitlab.md
@@ -82,9 +82,13 @@ curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
   with curation silently disabled.
 - TLS verification is always on; there is no `insecure_skip_verify` escape hatch. A self-signed
   instance needs a certificate your cluster's trust store already accepts.
-- Tested against **GitLab 16.x and 17.x** (self-managed) and gitlab.com; the API surface RunLore uses
-  (Commits, Merge Requests, Issues, Notes) has been stable across the v4 API for years, so earlier
-  16.x/15.x installs are likely fine too, just not part of the tested matrix.
+- **Not yet verified against a live GitLab instance.** The provider is built against the GitLab v4
+  REST API (Commits, Merge Requests, Issues, Notes), whose surface has been stable for years, and it
+  is covered by tests that assert the exact requests it sends — but no one has yet run it end to end
+  against a real self-managed instance or gitlab.com. If you are the first, please
+  [tell us what you find](https://github.com/Smana/runlore/issues). The most likely rough edges are a
+  reverse proxy normalising the `%2F` in an encoded project path, and the role you need to commit to
+  a protected default branch.
 - RunLore's writes are confined to the forge — it has **no cluster-mutating permissions**.
 
 ## Not yet supported on GitLab
@@ -98,7 +102,7 @@ investigation and posts the findings back, and `index.md`/`log.md` stay in step 
 | What | Behaviour on GitLab |
 |------|--------------------|
 | `lore curate` (the backlog-grooming CLI: dedup, lifecycle, queue, recurrence, contested, retirement passes) | **Fails to start**, with a message naming a GitHub App — it has no GitLab code path |
-| In-server sweeps (`curate.sweeps.mode: apply`) | **Silently disabled** — no sweeper is built, and nothing in the logs says so |
+| In-server sweeps (`curate.sweeps.mode: apply`) | **Disabled, and it says so.** No sweeper is built, and startup logs `curate sweeps disabled: no usable KB forge — Phase-2 grooming is GitHub-only` |
 | Source-repo diff cloning for private repos (`gitops` source cloning) | GitHub-App auth only — unrelated to which forge hosts the KB, but it bites the same operator |
 
 Concretely: nothing prunes the KB backlog, stale merge requests are never closed, and entries are


### PR DESCRIPTION
Pre-release review findings for the GitLab forge provider, ahead of v0.12.0.

## The one that isn't a bug

The integration page claimed:

> Tested against **GitLab 16.x and 17.x** (self-managed) and gitlab.com

**Nobody has ever run this provider against a live GitLab instance.** Every test drives an `httptest` mock. That sentence tells an operator the integration was validated end-to-end against two major versions when nothing was — and this project's whole differentiator is publishing an honest scorecard. Replaced with what's true, including the two rough edges most likely to bite first (a reverse proxy normalising `%2F` in the encoded project path; the role needed to commit to a protected default branch).

## Code fixes

| Issue | Failure mode |
|---|---|
| **Every write was retried** | `DoWithRetry` retries on 5xx/429/network — all can fire *after* the write landed. A 504 on a landed `POST /repository/commits` made the retry re-send with `start_branch` against a now-existing branch → GitLab 400 → `OpenPR` reports failure for a commit that **succeeded**, entry stranded on an orphan branch with no MR. Retry now scoped to `GET`. |
| **Pagination degraded silently** | Page cap firing, and a proxy stripping `X-Next-Page`, both returned a truncated list with no error and no log. That list feeds the curator's dedup → **duplicate MR on every recurrence, forever**. Both now warn; stripped-cursor is distinguished from a genuine last page by header presence on a full page. |
| **Catalog sync ignored the GitLab token** | Fell back to the GitHub App identity, which is nil on GitLab → private KB project cloned **anonymously**. RunLore opens the MR, a human merges it, and the knowledge never comes back. The learning loop severed at the seam — and the log line explaining the fallback didn't even fire, because the source was nil rather than wrong. |
| **Token laundered into errors** | `statusError` embeds the server-controlled body verbatim; a server echoing the credential got it into logs. Now stripped. |

`BuildKBTokenSource` is deliberately separate from `BuildForgeTokenSource`, which stays GitHub-App-only for the paths that genuinely are GitHub-only (curate, sweeps, the what-changed differ).

## Test fixes — both mutation-verified

**`TestOpenPR` would have passed a commit straight to `main`.** It compared `commitBody["branch"]` (an `any`) against `""`, so a missing key passed; and the MR assertion compared it against `source_branch`, which passes when both are `"main"`. A regression setting `branch: c.baseBranch` — committing the draft directly to the base branch, bypassing the review gate that is the entire point of the forge write surface — was **green**. Now asserts a typed `runlore/kb-*` prefix:

```
--- FAIL: TestOpenPR
    commit must target a fresh runlore/kb-* branch, got "main"
```

**`TestTokenNeverAppearsInErrors` failed when written.** The leak was real, not hypothetical — that's why the redaction is in this PR rather than filed as a nit.

Docs also corrected where they contradicted #410: the sweeps row still said "nothing in the logs says so" after #410 added exactly that log line.