### PR TITLE
fix(recall): close two fail-open paths in the instant-recall short-circuit

### DIFF
--- a/internal/investigate/commons_recall_test.go
+++ b/internal/investigate/commons_recall_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+)
+
+// TestCommonsEntryNeverFiresRecall pins the guarantee four separate surfaces
+// promise — the concepts docs, values-full.yaml, the config comment, and the
+// startup log line all state that a commons entry can never fire instant recall.
+// Until this test existed, none of them was enforced by code.
+//
+// The reasoning everywhere was "a resource-less entry can never agree with a
+// workload-carrying alert". True, but incomplete: resourceAgrees has a
+// matchScopeless tier for requests carrying NO workload at all — PagerDuty, a
+// generic webhook, Grafana without Kubernetes labels — and a resource-less
+// commons entry agrees with exactly those. A generic playbook could therefore
+// short-circuit a real incident with textbook advice, which is the one outcome
+// the commons was designed never to produce.
+//
+// The request here deliberately carries no workload. Every pre-existing commons
+// test used a workload-carrying request, so all of them passed with no guard at all.
+func TestCommonsEntryNeverFiresRecall(t *testing.T) {
+	own := t.TempDir()
+	commons := t.TempDir()
+	// A commons entry that matches the incident text as strongly as possible —
+	// if provenance is not checked, this is exactly what wins.
+	if err := os.WriteFile(filepath.Join(commons, "crashloop.md"), []byte(
+		"---\ntype: Playbook\ntitle: Pod in CrashLoopBackOff after a deploy\n"+
+			"description: container exits non-zero and is restarted with growing backoff\n"+
+			"tags: [crashloop, deploy, KubePodCrashLooping]\n---\n"+
+			"# Symptom\n\nCrashLoopBackOff after a deploy.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cat := catalog.NewEmpty()
+	cat.SetCommonsDir(commons)
+	if _, err := cat.ReloadContext(context.Background(), own); err != nil {
+		t.Fatal(err)
+	}
+	if cat.Len() != 1 {
+		t.Fatalf("fixture: want the commons entry indexed, got %d entries", cat.Len())
+	}
+
+	r := &Recall{Catalog: cat, MinScore: 0.01, SoloFloor: 0.01}
+	// A workload-LESS request: this is the scopeless tier, and it is the whole point.
+	req := Request{
+		Title:   "Pod in CrashLoopBackOff after a deploy",
+		Message: "container exits non-zero and is restarted with growing backoff",
+	}
+	entry, score := r.lookup(context.Background(), req)
+	if entry != nil {
+		t.Fatalf("a COMMONS entry fired instant recall on a workload-less request: path=%q commons=%v score=%.2f\n"+
+			"commons entries ground kb_search; they must never answer an incident",
+			entry.Path, entry.Commons, score)
+	}
+}

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -183,6 +183,23 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 	// active, so a retired entry can never fire on any path.
 	var agreeing []catalog.ScoredEntry
 	for _, h := range hits {
+		// Commons entries ground kb_search; they NEVER answer an incident on their own.
+		//
+		// This has to be a structural check, not an inference from resource-lessness.
+		// The reasoning everywhere else — "a resource-less entry can never agree with a
+		// workload-carrying alert" — is true but incomplete: resourceAgrees has a
+		// matchScopeless tier for requests that carry NO workload at all (PagerDuty, a
+		// generic webhook, Grafana without Kubernetes labels), and a resource-less
+		// commons entry agrees with exactly those. So a generic playbook could
+		// short-circuit a real incident with textbook advice, which is the single
+		// outcome the commons was designed never to produce.
+		//
+		// Enforced here rather than in resourceAgrees because it is a provenance rule,
+		// not a scoping rule: the entry is disqualified by WHERE IT CAME FROM, however
+		// well it matches.
+		if h.Entry.Commons {
+			continue
+		}
 		if !entryActive(h.Entry) {
 			continue
 		}

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -137,6 +137,26 @@ func (li *LoopInvestigator) verifyFindings(ctx context.Context, req Request, inv
 		li.Log.Warn("verify pass returned no usable verdicts; keeping findings as-is", "title", req.Title)
 		return inv, false
 	}
+	// Non-empty is not the same as "a review happened". applyVerdicts keeps any cause
+	// the reviewer did not mention, so a response whose indices all fall outside
+	// [0, len(RootCauses)) — {"verdicts":[{"index":7,"verdict":"reject"}]} against a
+	// one-cause investigation — reviewed NOTHING while returning verified=true. On the
+	// recall path that lets catalog text short-circuit an incident stamped
+	// `Verified: true`; on the full path it launders an unreviewed finding.
+	//
+	// Reachable exactly where this repo already documents flaky forced tool_choice
+	// (local OpenAI-compatible servers), which is when a fail-closed gate matters most.
+	covered := 0
+	for _, v := range verds {
+		if v.Index >= 0 && v.Index < len(inv.RootCauses) {
+			covered++
+		}
+	}
+	if covered == 0 {
+		li.Log.Warn("verify pass returned verdicts that reference no actual root cause; treating as unreviewed",
+			"title", req.Title, "verdicts", len(verds), "root_causes", len(inv.RootCauses))
+		return inv, false
+	}
 	return applyVerdicts(li, req, inv, verds), true
 }
 
@@ -156,27 +176,41 @@ func applyVerdicts(li *LoopInvestigator, req Request, inv providers.Investigatio
 	kept := make([]providers.Hypothesis, 0, len(inv.RootCauses))
 	for i, rc := range inv.RootCauses {
 		v, ok := byIndex[i]
+		// Normalize before comparing. The switch below has no fall-through for an
+		// unrecognized verdict, so "KEEP", "approve" or a stray space used to match
+		// no case at all and DROP the root cause silently — on the full-investigation
+		// path that discards a real, evidenced finding and forces the verdict to
+		// inconclusive, with nothing logged to say why.
+		verd := strings.ToLower(strings.TrimSpace(v.Verdict))
 		switch {
-		case !ok || v.Verdict == "keep":
+		case !ok || verd == "keep":
 			// A keep carrying a confidence may only lower the score, never raise
 			// it; a keep with no/zero confidence leaves the original untouched.
 			if ok && v.Confidence > 0 {
 				rc.Confidence = min(rc.Confidence, clamp01(v.Confidence))
 			}
 			kept = append(kept, rc)
-		case v.Verdict == "downgrade":
+		case verd == "downgrade":
 			if v.Confidence > 0 {
 				rc.Confidence = min(rc.Confidence, clamp01(v.Confidence))
 			} else {
 				rc.Confidence /= 2
 			}
 			kept = append(kept, rc)
-		case v.Verdict == "reject":
+		case verd == "reject":
 			// A rejected hypothesis is honesty about what was disproven, not an open
 			// question for a human — it belongs in RuledOut (with the disproving
 			// reason), not Unresolved.
 			inv.RuledOut = append(inv.RuledOut, fmt.Sprintf("%s — %s", rc.Summary, v.Reason))
 			li.Log.Info("verify: rejected root cause", "title", req.Title, "summary", rc.Summary, "reason", v.Reason)
+		default:
+			// An unrecognized verdict is a reviewer malfunction, not a judgement about
+			// the finding. Keep the cause — silently deleting evidence because the
+			// reviewer said something unparseable is the worst available answer — and
+			// log loudly enough that the malfunction is visible.
+			li.Log.Warn("verify: unrecognized verdict; keeping the root cause unchanged",
+				"title", req.Title, "verdict", v.Verdict, "summary", rc.Summary)
+			kept = append(kept, rc)
 		}
 	}
 	inv.RootCauses = kept

--- a/internal/investigate/verify_test.go
+++ b/internal/investigate/verify_test.go
@@ -398,3 +398,67 @@ func TestVerifyFindingsReportsVerifiedWhenNothingToReview(t *testing.T) {
 		t.Fatal("no root causes to review must report verified=true, not a failure")
 	}
 }
+
+// TestVerifyOutOfRangeVerdictsCountAsUnreviewed: a non-empty verdict list is not
+// the same as a review having happened. applyVerdicts KEEPS any cause the reviewer
+// did not mention, so verdicts whose indices all fall outside the root-cause range
+// used to review nothing while still returning verified=true.
+//
+// On the recall path that is the serious one: catalog text short-circuits a live
+// incident and the delivered investigation is stamped Verified: true. This is #395's
+// fail-closed gate one layer down — the gate fired, but on a review that never
+// touched a finding.
+//
+// Reachable exactly where this repo already documents flaky forced tool_choice
+// (local OpenAI-compatible servers), i.e. when fail-closed matters most.
+func TestVerifyOutOfRangeVerdictsCountAsUnreviewed(t *testing.T) {
+	li := &LoopInvestigator{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	inv := providers.Investigation{
+		Confidence: 0.8,
+		RootCauses: []providers.Hypothesis{{Summary: "oom", Confidence: 0.8}},
+	}
+
+	// Index 7 against a one-cause investigation: reviews nothing.
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitVerdictsName, Args: `{"verdicts":[{"index":7,"verdict":"reject"}]}`}}},
+	}}
+	li.Model = model
+	_, verified := li.verifyFindings(context.Background(), Request{Title: "x"}, inv, nil, nil)
+	if verified {
+		t.Fatal("verdicts that reference no actual root cause must NOT count as a review — " +
+			"otherwise recall short-circuits an incident on findings nothing reviewed, stamped Verified: true")
+	}
+
+	// Control: an in-range verdict IS a review. Without this, the assertion above
+	// would also pass if verifyFindings simply never returned true.
+	model2 := &scriptModel{responses: []providers.CompletionResponse{
+		{ToolCalls: []providers.ToolCall{{ID: "1", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"keep"}]}`}}},
+	}}
+	li.Model = model2
+	if _, ok := li.verifyFindings(context.Background(), Request{Title: "x"}, inv, nil, nil); !ok {
+		t.Fatal("an in-range verdict must count as a genuine review")
+	}
+}
+
+// TestApplyVerdictsKeepsOnUnrecognizedVerdict: the verdict switch had no default,
+// so a case variant ("KEEP") or a synonym ("approve") matched no branch and the
+// root cause was dropped — silently, with nothing logged. On the full-investigation
+// path that discards a real, evidenced finding and forces the verdict inconclusive.
+// An unparseable reviewer response is a reviewer malfunction, not a judgement about
+// the finding.
+func TestApplyVerdictsKeepsOnUnrecognizedVerdict(t *testing.T) {
+	li := &LoopInvestigator{Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	for _, v := range []string{"KEEP", " keep ", "Downgrade", "approve", "definitely-not-a-verdict"} {
+		t.Run(v, func(t *testing.T) {
+			inv := providers.Investigation{
+				Confidence: 0.8,
+				RootCauses: []providers.Hypothesis{{Summary: "oom", Confidence: 0.8, Evidence: []string{"OOMKilled"}}},
+			}
+			out := applyVerdicts(li, Request{}, inv, []verdict{{Index: 0, Verdict: v}})
+			if len(out.RootCauses) != 1 {
+				t.Fatalf("verdict %q dropped the root cause (kept %d) — an unparseable verdict must never delete evidence",
+					v, len(out.RootCauses))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pre-release review found two ways a cached answer could reach an on-call without the review that is supposed to stand in front of it. Both reproducible from a clean `main`.

## C1 — a commons entry could fire instant recall

**I asserted this was structurally impossible when #424 merged. It was not.**

Four surfaces promise it — the [concepts page](https://runlore.io/docs/concepts/knowledge-commons/), `values-full.yaml`, the `CatalogCommons` config comment, and the startup log line. None was enforced by code: `grep -rn Commons internal/investigate/` returned **zero** non-test hits.

The reasoning everywhere was *"a resource-less entry can never agree with a workload-carrying alert."* True, but incomplete. `resourceAgrees` has a `matchScopeless` tier for requests carrying **no workload at all** — PagerDuty, a generic webhook, Grafana without Kubernetes labels — and a resource-less commons entry agrees with exactly those:

```go
if reqW.Namespace == "" && reqW.Name == "" {
    if entryResource == "" && !requireWorkload {
        return matchScopeless
    }
```

So a generic textbook playbook could short-circuit a real incident — the one outcome the commons was designed never to produce.

Now filtered structurally in the candidate pre-filter. Deliberately **not** in `resourceAgrees`: this is a provenance rule, not a scoping rule — the entry is disqualified by *where it came from*, however well it matches.

Every pre-existing commons test used a workload-carrying request, so all of them passed with no guard at all. The new test uses a workload-less one:

```
--- FAIL: TestCommonsEntryNeverFiresRecall
    a COMMONS entry fired instant recall on a workload-less request:
    path="commons/crashloop.md" commons=true score=0.70
```

## C2 — a verify pass that reviewed nothing counted as a review

`verifyFindings` treated a non-empty verdict list as success. But `applyVerdicts` **keeps** any cause the reviewer did not mention, so:

```json
{"verdicts":[{"index":7,"verdict":"reject"}]}
```

against a one-cause investigation reviewed nothing and still returned `verified=true` — on the recall path, short-circuiting a live incident on catalog text, with the delivered investigation stamped `Verified: true`.

This is #395's fail-closed gate one layer down: the gate fired, on a review that never touched a finding. Reachable exactly where this repo already documents flaky forced `tool_choice` (local OpenAI-compatible servers) — i.e. when fail-closed matters most.

Now requires at least one verdict indexing a real root cause. The test includes a control asserting an in-range verdict still counts, so it can't pass by `verifyFindings` simply never returning true.

## Also — an unrecognized verdict silently deleted a root cause

The verdict switch had no `default`, so `"KEEP"`, `"approve"`, or a stray space matched no case and the cause was dropped with nothing logged. On the full-investigation path that discards a real, evidenced finding and forces the verdict to inconclusive.

Verdicts are now normalized (`ToLower`/`TrimSpace`) and an unrecognized one **keeps** the cause and warns — a reviewer malfunction is not a judgement about the finding.

## Verification

All three mutation-verified: removing each guard fails its test with the reproduction in the message. `go test -race` clean across `investigate`, `catalog`, `app`.