### PR TITLE
fix(notify): stop the card asserting a cause it never established

### DIFF
--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -407,13 +407,21 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 	// confidence (2b, below) renders either way, so the layout stays complete.
 	if vEmoji, label := verdictBadge(inv.Verdict); label != "" {
 		line := fmt.Sprintf("%s *%s*", vEmoji, label)
-		if inv.AlertName != "" && inv.Title != "" {
+		if inv.AlertName != "" && inv.Title != "" && !strings.EqualFold(strings.TrimSpace(inv.Title), strings.TrimSpace(inv.AlertName)) {
 			line += " — " + escapeMrkdwn(title)
 		}
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn",
 			"text": truncate(line, 2900)}})
-	} else if inv.AlertName != "" && inv.Title != "" {
+	} else if inv.AlertName != "" && inv.Title != "" && !strings.EqualFold(strings.TrimSpace(inv.Title), strings.TrimSpace(inv.AlertName)) {
 		// No verdict to anchor it to, but the conclusion still has to appear.
+		//
+		// Both branches skip when Title is just the alert name again. inv.Title falls
+		// back to req.Title (loop.go), and for Alertmanager and Grafana req.Title IS
+		// labels.alertname — and every synthesised terminal result (non-convergence,
+		// budget, timeout, refusal) sets Title: req.Title unconditionally. Without this
+		// the header and the conclusion line print the same string twice, which is
+		// #399's original finding, on precisely the inconclusive cards where restating
+		// the alert as the answer misleads most.
 		blocks = append(blocks, map[string]any{"type": "section", "text": map[string]any{"type": "mrkdwn",
 			"text": truncate(escapeMrkdwn(title), 2900)}})
 	}
@@ -605,13 +613,20 @@ func metadataFields(inv providers.Investigation) []map[string]any {
 		add("Resource", escapeMrkdwn(strings.TrimSpace(inv.Resource.Kind+" "+ref)))
 	}
 	add("Started", slackDate(inv.StartedAt))
+	// Only rendered when the investigation actually established a change. change_ref
+	// is OPTIONAL in submit_findings, and WhatChangedTool is only registered when a
+	// GitOps provider is configured — so in a deployment without Flux/Argo the field
+	// is empty on every card, and on a recall card no investigation ran at all.
+	//
+	// The previous else-branch printed "No Git change identified — likely
+	// infrastructure-induced" in exactly those cases. An absent optional field is not
+	// evidence of absence, and "likely infrastructure-induced" is an inference the
+	// investigation never made: the same speculation-from-silence that #420 forbade on
+	// the prompt side. Operationally it points a woken-up on-call AWAY from the recent
+	// deploy, which is the first thing they should check.
 	if len(inv.RootCauses) > 0 {
 		if ch := inv.RootCauses[0].ChangeRef; ch != "" {
 			add("What changed", truncate(escapeMrkdwn(ch), 200))
-		} else {
-			// "none" reads as a missing field on a woken-up phone screen; say what
-			// was actually established instead — no change was implicated.
-			add("What changed", "No Git change identified — likely infrastructure-induced")
 		}
 	}
 	if inv.Occurrences > 1 && inv.Prior == nil {

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -401,20 +401,71 @@ func TestSlackHypothesisPluralization(t *testing.T) {
 	}
 }
 
-// TestSlackWhatChangedNone proves finding #7: an empty ChangeRef renders an
-// informative clause, not the bare word "none" (which reads as a missing
-// field on a woken-up phone screen).
-func TestSlackWhatChangedNone(t *testing.T) {
+// TestSlackWhatChangedOmittedWhenUnknown: an absent ChangeRef renders NO
+// "What changed" field at all.
+//
+// This test previously asserted the opposite — that the card printed
+// "No Git change identified — likely infrastructure-induced". That was a
+// fabricated conclusion. change_ref is OPTIONAL in submit_findings, and
+// WhatChangedTool is only registered when a GitOps provider is configured, so in
+// a deployment without Flux/Argo the clause fired on EVERY card, and on recall
+// cards where no investigation ran at all. An empty optional field is not
+// evidence of absence, and "likely infrastructure-induced" is an inference the
+// investigation never made — it points a woken-up on-call away from the recent
+// deploy, the first thing they should check.
+//
+// The fixture's own "infra fault" summary shows the unsound inference had been
+// baked into the test as well as the renderer.
+func TestSlackWhatChangedOmittedWhenUnknown(t *testing.T) {
 	inv := providers.Investigation{
 		Title:      "t",
-		RootCauses: []providers.Hypothesis{{Summary: "infra fault"}}, // no ChangeRef
+		RootCauses: []providers.Hypothesis{{Summary: "some cause"}}, // no ChangeRef
 	}
 	txt := blocksText(t, summaryBlocks(inv))
-	if strings.Contains(txt, "*What changed:*\nnone") {
-		t.Errorf("must not render the bare placeholder \"none\":\n%s", txt)
+	if strings.Contains(txt, "What changed") {
+		t.Errorf("the card must not render a \"What changed\" field when the investigation never established one:\n%s", txt)
 	}
-	if !strings.Contains(txt, "No Git change") {
-		t.Errorf("expected an informative clause in place of \"none\":\n%s", txt)
+	if strings.Contains(txt, "infrastructure-induced") {
+		t.Errorf("the card must not infer a cause from an absent optional field:\n%s", txt)
+	}
+
+	// Control: when the investigation DID establish a change, it is rendered.
+	inv.RootCauses[0].ChangeRef = "apps/harbor/values.yaml: tag 1.14.2 -> 1.15.0"
+	txt = blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "What changed") || !strings.Contains(txt, "1.15.0") {
+		t.Errorf("an established change must still be rendered:\n%s", txt)
+	}
+}
+
+// TestSlackCardDoesNotRestateTheAlertAsItsConclusion: inv.Title falls back to
+// req.Title, and for Alertmanager and Grafana req.Title IS labels.alertname —
+// and every synthesised terminal result (non-convergence, budget, timeout,
+// refusal) sets Title: req.Title unconditionally. Without a guard the header and
+// the verdict line print the same string twice, which is #399's original finding
+// and #409's stated failure, on precisely the inconclusive cards where restating
+// the alert as the answer misleads most.
+func TestSlackCardDoesNotRestateTheAlertAsItsConclusion(t *testing.T) {
+	inv := providers.Investigation{
+		AlertName:  "KubePodCrashLooping",
+		Title:      "KubePodCrashLooping", // the loop's fallback: same string
+		Verdict:    "action_required",
+		Confidence: 0.8,
+	}
+	txt := blocksText(t, summaryBlocks(inv))
+	// The header and the *Alert:* metadata field are both legitimate occurrences.
+	// The defect is specifically the VERDICT line appending it as the conclusion.
+	if strings.Contains(txt, "Action required*\u0026mdash;") || strings.Contains(txt, `Action required* \u2014 KubePodCrashLooping`) {
+		t.Errorf("the verdict line restated the alert name as the card's own conclusion:\n%s", txt)
+	}
+	if strings.Contains(txt, "*Action required* — KubePodCrashLooping") {
+		t.Errorf("the verdict line restated the alert name as the card's own conclusion:\n%s", txt)
+	}
+
+	// Control: a genuine conclusion distinct from the alert IS shown.
+	inv.Title = "Harbor chart bump deadlocked the DB migration"
+	txt = blocksText(t, summaryBlocks(inv))
+	if !strings.Contains(txt, "Harbor chart bump deadlocked") {
+		t.Errorf("a real conclusion must still be rendered alongside the verdict:\n%s", txt)
 	}
 }
 


### PR DESCRIPTION
Two pre-release review findings, both on the requirement the release's own card refactors (#399, #409) set out to satisfy.

## The card fabricated a causal conclusion

```go
} else {
    add("What changed", "No Git change identified — likely infrastructure-induced")
}
```

`change_ref` is **optional** in `submit_findings`, and `WhatChangedTool` is only registered when a GitOps provider is configured. So in a deployment without Flux or Argo this fired on **every card**, and on recall cards where no investigation ran at all — producing a card whose only metadata was a confident claim about Git.

An empty optional field is not evidence of absence, and *"likely infrastructure-induced"* is an inference nothing made — the same speculation-from-silence that **#420 just forbade on the prompt side**. Operationally it points a woken-up on-call *away* from the recent deploy, which is the first thing they should check.

The field is now absent when unknown.

## The alert name was restated as the card's own conclusion

#409 guarded on `inv.AlertName != "" && inv.Title != ""`. But `inv.Title` falls back to `req.Title`, and for Alertmanager and Grafana `req.Title` **is** `labels.alertname` — and every synthesised terminal result (non-convergence, budget, timeout, refusal) sets `Title: req.Title` unconditionally:

```
🔍 KubePodCrashLooping — prod/payments/api
🔥 *Action required* — KubePodCrashLooping     ← the alert, again, as the answer
```

That is #399's original finding ("the title was printed twice") and #409's own stated failure, back on precisely the inconclusive cards where restating the alert as the conclusion misleads most. `TestSlackSummaryLayout` couldn't catch it because its fixture uses a Title distinct from its AlertName.

Both branches now skip when the two are equal.

## Tests

`TestSlackWhatChangedNone` **pinned the fabricated string**, with the unsound inference baked into its own fixture (`Summary: "infra fault"`). Replaced with a test that pins absence plus a control proving an established change still renders — so it can't pass by the field never rendering.

`TestSlackCardDoesNotRestateTheAlertAsItsConclusion` added with the same shape. Note it asserts on the *verdict line* specifically: the header and the `*Alert:*` metadata field are both legitimate occurrences of the alert name.

Both mutation-verified — restoring either defect fails its test.

## Not in this PR

The review also found that `mrkdwnTexts` (the escaping test helper) never reads `b["fields"]`, so **10 of 16** escaping mutations survive the suite. None is a live defect — the escaping is correct today — but they are unguarded regressions, and this codebase has shipped that regression once already (#412). That is a test-harness change worth its own PR rather than bundling here.