### PR TITLE
fix(logs): a zero-match index pattern is not silence

### DIFF
--- a/internal/logs/elasticsearch/elasticsearch.go
+++ b/internal/logs/elasticsearch/elasticsearch.go
@@ -167,7 +167,7 @@ func (c *Client) Query(ctx context.Context, query string, w providers.TimeWindow
 	// band rather than dropping the lines: the same reasoning as the truncation
 	// sentinel — the model must know the view is incomplete, and a returned
 	// error here would throw away hits that are perfectly good evidence.
-	if partial, reason := shardFailure(respBody); partial {
+	if partial, reason := shardFailure(respBody, c.index); partial {
 		out = append(out, partialLine(reason))
 	}
 	return out, nil
@@ -284,8 +284,20 @@ func (c *Client) searchBody(query string, w providers.TimeWindow, size int, sort
 		body["size"] = size
 	}
 	if sortDesc {
-		body["sort"] = []map[string]any{{c.timestampField: map[string]any{"order": "desc"}}}
+		// unmapped_type keeps a rolling logs-* pattern searchable when an OLDER index
+		// in it has no mapping for the timestamp field. Without it ES rejects the whole
+		// search with "No mapping found for [@timestamp] in order to sort on" — a dead
+		// end mid-incident, and one that looks like a RunLore bug rather than a mapping
+		// gap.
+		body["sort"] = []map[string]any{{c.timestampField: map[string]any{"order": "desc", "unmapped_type": "date"}}}
 	}
+	// NOT projected with _source, deliberately. size:1000 does pull complete ECS
+	// documents (2-5 KB each) when the renderer reads only a handful of fields, so the
+	// saving would be real — but the pod/container field NAMES are operator-configured
+	// in internal/investigate (logs.fields.*), and this client does not know them. A
+	// projection built from what the client knows would silently drop the fields the
+	// renderer groups by whenever an operator has customised them. Worth doing once
+	// the conventions are threaded through; not worth risking blank pod columns for.
 	return body
 }
 
@@ -335,9 +347,9 @@ func (c *Client) indexPath() string {
 // perfectly well-formed while covering only part of the window, and
 // logs_error_summary would report those counts as complete. Callers must treat
 // a true here as "this answer is not the whole answer".
-func shardFailure(body []byte) (bool, string) {
+func shardFailure(body []byte, indexPattern string) (bool, string) {
 	var resp struct {
-		Shards struct {
+		Shards *struct {
 			Total      int `json:"total"`
 			Successful int `json:"successful"`
 			Failed     int `json:"failed"`
@@ -352,7 +364,31 @@ func shardFailure(body []byte) (bool, string) {
 	}
 	// A body that does not parse is not this function's problem — the caller
 	// unmarshals it properly right after and reports the real error.
-	if err := json.Unmarshal(body, &resp); err != nil || resp.Shards.Failed == 0 {
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return false, ""
+	}
+	// An index PATTERN that matches nothing is a 200, not a 404: allow_no_indices
+	// defaults to true for wildcards, so `POST /logs-*/_search` against a cluster
+	// with no logs-* index returns {"_shards":{"total":0,...},"hits":{"hits":[]}}.
+	//
+	// Without this, zero shards reads as zero hits and the model is told the workload
+	// logged nothing — when in fact RunLore never looked at an index. A wrong
+	// logs.index is the single most likely misconfiguration for this provider (an ILM
+	// rollover to logs-app-*, a data-stream naming scheme, a typo'd prefix), and
+	// config validation only checks character legality, not that the pattern resolves.
+	//
+	// _shards.total == 0 is the unambiguous signal: can-match skipping increments
+	// `skipped`, it does not reduce `total`.
+	// A POINTER, so an absent _shards object (a stub server, a proxy that rewrote
+	// the envelope) is distinguishable from a present one reporting zero. Only a
+	// _shards that IS there and says total:0 means "the pattern resolved to nothing".
+	if resp.Shards == nil {
+		return false, ""
+	}
+	if resp.Shards.Total == 0 {
+		return true, fmt.Sprintf("index pattern %q matched no indices — check logs.index", indexPattern)
+	}
+	if resp.Shards.Failed == 0 {
 		return false, ""
 	}
 	reason := fmt.Sprintf("%d of %d shards failed", resp.Shards.Failed, resp.Shards.Total)
@@ -434,7 +470,7 @@ func (c *Client) Hits(ctx context.Context, query string, w providers.TimeWindow,
 	// very spike logs_error_summary exists to find. Fail loudly instead — the
 	// caller (internal/investigate/logs_summary_tool.go) degrades gracefully,
 	// still rendering top messages and surfacing this reason.
-	if partial, reason := shardFailure(respBody); partial {
+	if partial, reason := shardFailure(respBody, c.index); partial {
 		return nil, fmt.Errorf("logs histogram is incomplete: %s", reason)
 	}
 	var resp struct {
@@ -553,7 +589,7 @@ func (c *Client) TopMessages(ctx context.Context, query string, w providers.Time
 	// rejection above, a shard failure can be transient (a node briefly out),
 	// and permanently downgrading a working aggregation over one blip would be
 	// the wrong trade.
-	if partial, _ := shardFailure(respBody); partial {
+	if partial, _ := shardFailure(respBody, c.index); partial {
 		return c.topMessagesClientSide(ctx, query, w, k)
 	}
 	var resp struct {
@@ -680,17 +716,67 @@ func (c *Client) FieldNames(ctx context.Context, _ string, _ providers.TimeWindo
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
 	}
+	// Decode the capability object rather than skipping it: it carries
+	// metadata_field, which is how ES marks its own plumbing (_id, _index, _seq_no,
+	// _version, _routing, _ignored). Those are not fields an operator can filter logs
+	// on, and left in they crowd out the ones that matter — see the ordering note below.
 	var fc struct {
-		Fields map[string]json.RawMessage `json:"fields"`
+		Indices []string `json:"indices"`
+		Fields  map[string]map[string]struct {
+			MetadataField bool `json:"metadata_field"`
+		} `json:"fields"`
 	}
 	if err := json.Unmarshal(body, &fc); err != nil {
 		return nil, fmt.Errorf("parse field_caps: %w", err)
 	}
+	// An index pattern matching nothing answers 200 with an empty field map — the
+	// same zero-shard case shardFailure handles for _search. Returning an empty slice
+	// here made discover_log_fields print "nothing matched; widen the selector",
+	// pointing the model at the selector when the index pattern is the cause. This
+	// tool is the designated recovery path for a failed query_logs, so misdirecting
+	// here costs an investigation.
+	if len(fc.Fields) == 0 {
+		return nil, fmt.Errorf("index pattern %q matched no fields — the pattern likely resolves to no indices; check logs.index", c.index)
+	}
 	names := make([]string, 0, len(fc.Fields))
-	for name := range fc.Fields {
-		names = append(names, name)
+	for name, caps := range fc.Fields {
+		meta := false
+		for _, cap := range caps {
+			if cap.MetadataField {
+				meta = true
+				break
+			}
+		}
+		if !meta {
+			names = append(names, name)
+		}
 	}
 	sort.Strings(names)
+	// Surface the CONFIGURED fields first. Alphabetical order alone puts @timestamp
+	// and the ECS agent.*/cloud.*/data_stream.* families ahead of message, log.level
+	// and kubernetes.*, and renderRows caps output at 50 rows — so on a typical ECS +
+	// k8s mapping the model asked "what fields exist?" and got back ES plumbing and
+	// cloud metadata, with the ones it needs past the cut.
+	priority := []string{c.timestampField, c.levelField, c.messageField}
+	rank := make(map[string]int, len(priority))
+	for i, f := range priority {
+		if f != "" {
+			if _, dup := rank[f]; !dup {
+				rank[f] = i
+			}
+		}
+	}
+	sort.SliceStable(names, func(a, b int) bool {
+		ra, oka := rank[names[a]]
+		rb, okb := rank[names[b]]
+		if oka != okb {
+			return oka
+		}
+		if oka && okb {
+			return ra < rb
+		}
+		return false // stable: preserves the alphabetical order established above
+	})
 	out := make([]providers.FieldCount, 0, len(names))
 	for _, name := range names {
 		out = append(out, providers.FieldCount{Name: name})

--- a/internal/logs/elasticsearch/elasticsearch_test.go
+++ b/internal/logs/elasticsearch/elasticsearch_test.go
@@ -472,10 +472,53 @@ func TestFieldNames(t *testing.T) {
 	if len(fields) != 3 {
 		t.Fatalf("want 3 fields, got %d: %+v", len(fields), fields)
 	}
-	// Deterministic (alphabetical) order, since field_caps carries no frequency
-	// signal to sort by.
-	if fields[0].Name != "kubernetes.namespace" || fields[0].Hits != 0 {
-		t.Fatalf("fields[0] = %+v", fields[0])
+	// CONFIGURED fields lead, then alphabetical for the rest.
+	//
+	// field_caps carries no frequency signal, so alphabetical was the only ordering
+	// available — but renderRows caps output at 50 rows, and on a real ECS + k8s
+	// mapping (60-90 fields) pure alphabetical puts @timestamp and the
+	// agent.*/cloud.*/data_stream.* families first and pushes message, log.level and
+	// kubernetes.* past the cut. The model asks "what fields exist?" to recover from
+	// a failed query_logs and gets back ES plumbing and cloud metadata.
+	if fields[0].Name != "message" {
+		t.Fatalf("the configured message field must lead, got fields[0] = %+v (all: %+v)", fields[0], fields)
+	}
+	rest := []string{fields[1].Name, fields[2].Name}
+	if rest[0] != "kubernetes.namespace" || rest[1] != "kubernetes.pod.name" {
+		t.Fatalf("non-configured fields must stay alphabetical, got %v", rest)
+	}
+}
+
+// TestQueryZeroMatchingIndicesIsNotSilence: an index PATTERN that matches nothing
+// answers 200, not 404 — allow_no_indices defaults to true for wildcards. Without
+// a check on _shards.total, zero shards read as zero hits and query_logs told the
+// model "no log lines matched", i.e. the workload logged nothing. It didn't:
+// RunLore never looked at an index. A wrong logs.index is the most likely
+// misconfiguration for this provider, and config validation only checks that the
+// pattern is character-legal, not that it resolves.
+func TestQueryZeroMatchingIndicesIsNotSilence(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"took":1,"_shards":{"total":0,"successful":0,"skipped":0,"failed":0},"hits":{"total":{"value":0},"hits":[]}}`))
+	}))
+	defer srv.Close()
+
+	lines, err := New(srv.URL, "logs-*").Query(context.Background(), "x", providers.TimeWindow{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	var joined string
+	for _, l := range lines {
+		joined += l.Message
+	}
+	if !strings.Contains(joined, "matched no indices") {
+		t.Fatalf("a pattern resolving to zero indices must say so, not read as silence; got %+v", lines)
+	}
+
+	// FieldNames is the designated recovery path — it must not repeat the lie by
+	// returning an empty slice, which renders as "widen the selector".
+	_, ferr := New(srv.URL, "logs-*").FieldNames(context.Background(), "", providers.TimeWindow{})
+	if ferr == nil {
+		t.Fatal("FieldNames on a zero-match pattern must error, not return an empty field list")
 	}
 }
 


### PR DESCRIPTION
Pre-release review of the Elasticsearch/OpenSearch provider.

## The Critical one

An index **pattern** matching nothing answers **200, not 404** — `allow_no_indices` defaults to true for wildcards:

```json
{"took":1,"_shards":{"total":0,"successful":0,"skipped":0,"failed":0},
 "hits":{"total":{"value":0},"hits":[]}}
```

`shardFailure` only inspected `_shards.failed`, so zero shards read as zero hits and `query_logs` reported **"no log lines matched"** — telling the model the workload logged nothing. It didn't: RunLore never looked at an index.

A wrong `logs.index` is the single most likely misconfiguration for this provider (ILM rollover to `logs-app-*`, a data-stream naming scheme, a typo'd prefix), and config validation only checks the pattern is *character-legal*, not that it *resolves*.

`_shards.total == 0` is unambiguous — can-match skipping increments `skipped`, it doesn't reduce `total`. Decoded through a **pointer** so an absent `_shards` envelope stays distinguishable from a present one reporting zero.

**The recovery path repeated the same lie.** `FieldNames` returned an empty slice, which `discover_log_fields` renders as *"nothing matched; widen the selector"* — aiming the model at the selector when the index pattern is the cause. It's the designated recovery for a failed `query_logs`, so misdirecting there costs an investigation. Now errors, naming the pattern.

## Also fixed

**`discover_log_fields` returned the wrong 50 fields.** `_field_caps?fields=*` includes ES metadata fields (`_id`, `_index`, `_seq_no`, …) marked `metadata_field: true`, which the client never inspected. With alphabetical order and `renderRows`' 50-row cap, a typical ECS + k8s mapping put `@timestamp` and the `agent.*`/`cloud.*`/`data_stream.*` families first and pushed `message`, `log.level` and `kubernetes.*` past the cut. Metadata dropped; configured fields lead.

**Sort had no `unmapped_type`.** On a rolling `logs-*` where an older index lacks the timestamp mapping, ES rejects the entire search — a dead end mid-incident that looks like a RunLore bug.

## Deliberately not done

The review suggested a `_source` projection (10× wire/heap saving on `size:1000`). **Skipped.** The pod/container field *names* are operator-configured in `internal/investigate` (`logs.fields.*`) and this client doesn't know them — a projection built from what the client knows would silently blank the pod column for anyone who customised them. Left a comment for when the conventions are threaded through; a real optimization isn't worth a silent rendering regression.

## Tests

`TestQueryErrorPaths` **pinned the buggy behaviour** (`empty result must be (nil, nil)`) and now has a companion zero-shard case. `TestFieldNames`' alphabetical assertion updated to state the new contract. Both new guards mutation-verified — removing either fails with the reproduction in the message.