### PR TITLE
fix(catalog): keep the commons indexed, default its interval, reject nested roots

### DIFF
--- a/deploy/helm/runlore/templates/_helpers.tpl
+++ b/deploy/helm/runlore/templates/_helpers.tpl
@@ -56,6 +56,12 @@ entry here — the mount by name is identical either way.
   reports it. A url WITHOUT a dir cannot be defaulted safely — it would have to guess
   a path, and guessing catalog.mountPath would let an upstream sync overwrite the
   operator's own catalog — so fail rendering with the fix named.
+
+  The two roots are checked for CONTAINMENT, not just equality: the loader walks
+  recursively, so a commons root nested under the catalog is indexed twice — once
+  as shared, once as the operator's own, unmarked and competing in the tie-break.
+  The agent validates this too; failing at render keeps a bad values file from
+  ever reaching a cluster.
 */ -}}
 {{- $commons := (.Values.config.catalog | default dict).commons | default dict -}}
 {{- $commonsDir := "" -}}
@@ -64,8 +70,13 @@ entry here — the mount by name is identical either way.
 {{-   if not $commonsDir -}}
 {{-     fail "config.catalog.commons.url is set but config.catalog.commons.dir is empty — set it to a path OUTSIDE config.catalog.dir (e.g. /var/lib/runlore/commons); the two roots must not share a directory" -}}
 {{-   end -}}
-{{-   if eq $commonsDir (.Values.config.catalog.dir | default "") -}}
+{{-   $catalogDir := clean (.Values.config.catalog.dir | default "") -}}
+{{-   $commonsClean := clean $commonsDir -}}
+{{-   if eq $commonsClean $catalogDir -}}
 {{-     fail "config.catalog.commons.dir must differ from config.catalog.dir — sharing one root lets an upstream commons sync overwrite the catalog you curate into" -}}
+{{-   end -}}
+{{-   if or (hasPrefix (printf "%s/" $catalogDir) $commonsClean) (hasPrefix (printf "%s/" $commonsClean) $catalogDir) -}}
+{{-     fail (printf "config.catalog.commons.dir (%s) and config.catalog.dir (%s) must not contain one another — the loader walks recursively, so a nested root is indexed twice" $commonsClean $catalogDir) -}}
 {{-   end -}}
 {{- end -}}
 metadata:

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -27,7 +27,7 @@ import (
 // (much longer) interval, and a failure that logs rather than propagates. A shared
 // upstream corpus being briefly unavailable must never degrade the operator's own
 // catalog, which is the one an incident actually depends on.
-func armCommons(ctx context.Context, cfg *config.Config, cat *catalog.Catalog, log *slog.Logger) {
+func armCommons(ctx context.Context, cfg *config.Config, cat *catalog.Catalog, primaryDir string, log *slog.Logger) {
 	cc := cfg.Catalog.Commons
 	if cc.URL == "" || cc.Dir == "" {
 		return
@@ -46,7 +46,7 @@ func armCommons(ctx context.Context, cfg *config.Config, cat *catalog.Catalog, l
 		// ReloadDelta mutates the index by the operator's own paths. Reloading the
 		// primary root re-reads the commons alongside it, which is both correct and
 		// cheap at this interval.
-		if _, err := cat.ReloadContext(ctx, cfg.Catalog.Dir); err != nil {
+		if _, err := cat.ReloadContext(ctx, primaryDir); err != nil {
 			log.Warn("commons catalog reload failed; keeping the previous index", "dir", cc.Dir, "err", err)
 			return err
 		}
@@ -142,7 +142,7 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 			warnInvalid(cat)
 			return nil
 		})
-		armCommons(ctx, cfg, cat, log)
+		armCommons(ctx, cfg, cat, dir, log)
 		log.Info("catalog git-sync enabled", "url", cfg.Catalog.Git.URL, "dir", dir)
 		return cat
 	}
@@ -175,7 +175,7 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 		// Arm the commons BEFORE logging the count: armCommons triggers a reload that
 		// pulls the shared root in, so logging first would report a number that is
 		// already stale.
-		armCommons(ctx, cfg, cat, log)
+		armCommons(ctx, cfg, cat, cfg.Catalog.Dir, log)
 		log.Info("catalog loaded", "dir", cfg.Catalog.Dir, "entries", cat.Len())
 		warnInvalid(cat)
 		return cat

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -230,7 +230,16 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 // ANY index mutation fails: an incremental error must never leave a wrong
 // index behind.
 func (c *Catalog) ReloadDelta(ctx context.Context, dir string, delta *SyncDelta) ([]string, error) {
-	if delta == nil || !c.ready.Load() {
+	// A configured commons forces the full path. The delta describes the OPERATOR's
+	// root only, while the incremental swap replaces c.entries/pathIdx wholesale with
+	// what Load(dir) returned — so the commons docs stayed in the live bleve index but
+	// vanished from pathIdx, and SearchScored dropped them while they still consumed
+	// top-k slots. Every sync after the first silently un-indexed the entire shared
+	// corpus until the commons syncer's own (much slower) tick healed it.
+	c.mu.RLock()
+	hasCommons := c.commonsDir != ""
+	c.mu.RUnlock()
+	if delta == nil || !c.ready.Load() || hasCommons {
 		return c.ReloadContext(ctx, dir)
 	}
 	entries, skipped, err := Load(dir)

--- a/internal/catalog/commons_test.go
+++ b/internal/catalog/commons_test.go
@@ -159,3 +159,45 @@ func TestSameFilenameInBothRootsDoesNotCollide(t *testing.T) {
 		t.Errorf("search for the commons entry resolved to the USER's entry — the doc IDs collided: %+v", theirs[0])
 	}
 }
+
+// TestIncrementalSyncKeepsTheCommonsIndexed: ReloadDelta replaced entries and
+// pathIdx wholesale with what Load(operatorRoot) returned, while the delta only
+// ever describes the operator's root. The commons documents stayed in the live
+// bleve index but vanished from pathIdx, so SearchScored dropped them — and they
+// still consumed top-k slots, so searches also returned fewer results than asked
+// for. Every operator sync after the first silently un-indexed the whole shared
+// corpus until the commons syncer's own much slower tick healed it.
+func TestIncrementalSyncKeepsTheCommonsIndexed(t *testing.T) {
+	own := t.TempDir()
+	commons := t.TempDir()
+	writeEntry(t, own, "mine.md", "---\ntype: Incident\ntitle: My own outage\ndescription: mine\nresource: apps/web\n---\nbody\n")
+	writeEntry(t, commons, "generic.md", "---\ntype: Playbook\ntitle: Generic crashloop playbook\ndescription: generic\n---\nbody\n")
+
+	cat := NewEmpty()
+	cat.SetCommonsDir(commons)
+	if _, err := cat.ReloadContext(context.Background(), own); err != nil {
+		t.Fatal(err)
+	}
+	if cat.Len() != 2 {
+		t.Fatalf("fixture: want both roots indexed, got %d", cat.Len())
+	}
+
+	// An incremental sync of the OPERATOR's root only — the normal steady state.
+	writeEntry(t, own, "second.md", "---\ntype: Incident\ntitle: Another outage\ndescription: second\nresource: apps/api\n---\nbody\n")
+	if _, err := cat.ReloadDelta(context.Background(), own, &SyncDelta{Changed: []string{"second.md"}}); err != nil {
+		t.Fatal(err)
+	}
+	if cat.Len() != 3 {
+		t.Fatalf("after an incremental sync the catalog has %d entries, want 3 — the commons was dropped", cat.Len())
+	}
+	hits, _ := cat.SearchScored("generic crashloop playbook", 5)
+	found := false
+	for _, h := range hits {
+		if h.Entry.Commons {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the commons entry is no longer searchable after an incremental sync of the operator's own root; hits=%d", len(hits))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/url"
 	"path"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -1422,8 +1423,20 @@ func (c *Config) Validate() error {
 		// sync write into their checkout — and, with git-sync enabled, fight the
 		// mirror on every reconcile. Distinct roots is the whole basis of the
 		// read-only guarantee.
-		if cc.Dir == c.Catalog.Dir {
-			return fmt.Errorf("catalog.commons.dir must differ from catalog.dir (both are %q): the shared catalog is a SEPARATE, read-only root and must not share the operator's checkout", cc.Dir)
+		// Cleaned + containment, not string equality. Load walks recursively, so
+		// commons.dir: /var/lib/runlore/catalog/commons under catalog.dir:
+		// /var/lib/runlore/catalog passed the old check and then indexed every commons
+		// entry TWICE — once prefixed and marked, once as the operator's own, unmarked
+		// and competing in the tie-break as a local entry. It also did exactly what the
+		// error says it prevents: an upstream sync writing inside the operator's mirror.
+		// A trailing slash slipped through for the same reason.
+		own := filepath.Clean(c.Catalog.Dir)
+		com := filepath.Clean(cc.Dir)
+		if own == com {
+			return fmt.Errorf("catalog.commons.dir must differ from catalog.dir (both resolve to %q): the shared catalog is a SEPARATE, read-only root and must not share the operator's checkout", com)
+		}
+		if within(com, own) || within(own, com) {
+			return fmt.Errorf("catalog.commons.dir (%q) and catalog.dir (%q) must not contain one another: the loader walks recursively, so a nested root is indexed twice — once as shared, once as the operator's own", com, own)
 		}
 	}
 	// Instant-recall reranker (opt-in): its knobs are only meaningful when enabled.
@@ -1631,4 +1644,17 @@ type GitHubApp struct {
 	InstallationID int64  `yaml:"installation_id"`
 	PrivateKeyRef  string `yaml:"private_key_ref"` // Secret name/key (e.g. via External Secrets)
 	PrivateKeyEnv  string `yaml:"private_key_env"` // v1: env var holding the PEM private key
+}
+
+// within reports whether child is inside parent. Compared on cleaned, separator-
+// terminated paths so /a/b is not treated as inside /a/bc.
+func within(child, parent string) bool {
+	if parent == "" || child == "" {
+		return false
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -881,3 +881,57 @@ func TestCommonsCatalogValidation(t *testing.T) {
 		}
 	})
 }
+
+// TestCommonsIntervalDefaultsToTheDocumentedRate: the commons syncer polls a
+// SHARED, public upstream repo, and its documented default is 24h. Nothing filled
+// it, so an unset interval reached Syncer.Run as 0 and fell through to the
+// syncer's generic 5-minute fallback — 288x the documented rate against someone
+// else's GitHub repo — while the startup log printed "interval=0s".
+func TestCommonsIntervalDefaultsToTheDocumentedRate(t *testing.T) {
+	c := &Config{}
+	c.Catalog.Dir = "/var/lib/runlore/catalog"
+	c.Catalog.Commons.URL = "https://github.com/Smana/runlore-kb-commons"
+	c.Catalog.Commons.Dir = "/var/lib/runlore/commons"
+	ApplyDefaults(c)
+	if got := c.Catalog.Commons.Interval.Std(); got != 24*time.Hour {
+		t.Fatalf("commons interval = %v, want 24h (the documented default; 0 falls through to the syncer's 5m)", got)
+	}
+	if c.Catalog.Commons.Branch != "main" {
+		t.Fatalf("commons branch = %q, want main", c.Catalog.Commons.Branch)
+	}
+}
+
+// TestCommonsDirMustNotNestInsideCatalogDir: the loader walks recursively, so a
+// commons root nested under the operator's catalog is indexed TWICE — once
+// prefixed and marked as shared, once as the operator's own, unmarked and
+// competing in the tie-break as a local entry. Exact string equality missed it,
+// and missed a trailing slash too.
+func TestCommonsDirMustNotNestInsideCatalogDir(t *testing.T) {
+	for _, tc := range []struct{ name, own, commons string }{
+		{"commons nested in catalog", "/var/lib/runlore/catalog", "/var/lib/runlore/catalog/commons"},
+		{"catalog nested in commons", "/var/lib/runlore/commons/own", "/var/lib/runlore/commons"},
+		{"trailing slash", "/var/lib/runlore/catalog", "/var/lib/runlore/catalog/"},
+		{"unclean path", "/var/lib/runlore/catalog", "/var/lib/runlore/catalog/../catalog"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{}
+			c.Catalog.Dir = tc.own
+			c.Catalog.Commons.URL = "https://example.com/kb"
+			c.Catalog.Commons.Dir = tc.commons
+			ApplyDefaults(c)
+			if err := c.Validate(); err == nil {
+				t.Fatalf("want a validation error for catalog.dir=%q commons.dir=%q — a shared root must never overlap the operator's own", tc.own, tc.commons)
+			}
+		})
+	}
+
+	// Control: genuinely separate roots must still validate.
+	c := &Config{}
+	c.Catalog.Dir = "/var/lib/runlore/catalog"
+	c.Catalog.Commons.URL = "https://example.com/kb"
+	c.Catalog.Commons.Dir = "/var/lib/runlore/commons"
+	ApplyDefaults(c)
+	if err := c.Validate(); err != nil {
+		t.Fatalf("separate roots must validate, got: %v", err)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -160,6 +160,19 @@ func ApplyDefaults(c *Config) {
 	// Instant-recall trust defaults: when enabled without explicit tuning, keep the
 	// margin and solo gates active. A zero margin_gap/solo_floor would degrade recall
 	// to a bare similarity threshold — the exact brittleness this feature removes.
+	// The commons syncer polls a SHARED, public upstream repo. Its documented default
+	// is 24h ("a shared corpus changes slowly"), but nothing filled it — so an unset
+	// interval reached Syncer.Run as 0 and fell through to the syncer's generic 5m
+	// fallback: 288x the documented rate against someone else's GitHub repo, with the
+	// startup log cheerfully printing "interval=0s".
+	if c.Catalog.Commons.URL != "" {
+		if c.Catalog.Commons.Interval.Std() == 0 {
+			c.Catalog.Commons.Interval = Duration(24 * time.Hour)
+		}
+		if c.Catalog.Commons.Branch == "" {
+			c.Catalog.Commons.Branch = "main"
+		}
+	}
 	if c.Catalog.InstantRecall.Enabled {
 		ir := &c.Catalog.InstantRecall
 		if ir.MinScore == 0 {


### PR DESCRIPTION
Four commons defects from the pre-release review. All four failed silently.

## Every incremental sync un-indexed the entire commons

`ReloadDelta` replaced `entries` and `pathIdx` wholesale with what `Load(operatorRoot)` returned — but the delta only ever describes the **operator's** root. The commons documents stayed in the live bleve index while vanishing from `pathIdx`, so `SearchScored` dropped them *and* they still consumed top-`k` slots, meaning searches also returned fewer results than requested.

This fired on every operator KB sync after the first, healing only on the commons syncer's own (24h) tick, then breaking again on the next sync.

```
--- FAIL: TestIncrementalSyncKeepsTheCommonsIndexed
    after an incremental sync the catalog has 2 entries, want 3 — the commons was dropped
```

## `commons.interval` documented 24h, ran at 5 minutes

Nothing defaulted it, so an unset interval reached `Syncer.Run` as `0` and fell through to the syncer's generic 5-minute fallback — **288× the documented rate against a shared public GitHub repo** — while startup logged `interval=0s`. Defaulted in `ApplyDefaults` so the effective value is the one logged.

## A nested commons root validated clean and was indexed twice

The check was exact string equality:

```go
if cc.Dir == c.Catalog.Dir {
```

So `commons.dir: /var/lib/runlore/catalog/commons` under `catalog.dir: /var/lib/runlore/catalog` passed — and `Load` walks recursively, so every commons entry was indexed **twice**: once prefixed and marked as shared, once as the operator's own, unmarked and competing in the tie-break as a local entry. It also did exactly what the error message claims to prevent: an upstream sync writing inside the operator's mirror. A trailing slash slipped through identically.

Now compares `filepath.Clean`ed paths and rejects containment in either direction. **The chart carried the same weak check** and now refuses to render on both, verified across the separate / equal / nested cases.

## `armCommons` reloaded the undefaulted root

`BuildCatalog` defaults `catalog.dir` locally, but `armCommons`' sync callback reloaded `cfg.Catalog.Dir` — the *undefaulted* value. With `catalog.git.url` set and `catalog.dir` omitted (a shape `BuildCatalog` explicitly supports), `Load("")` errored every interval and the commons was never indexed at all. The resolved dir is now passed in — the same "two notions of the same thing" divergence #414 was about.

All three code guards mutation-verified.