### PR TITLE
refactor: collapse duplicated fallback and probe logic across the release surface

### DIFF
--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -105,10 +106,7 @@ func BuildCurator(cfg *config.Config, cat *catalog.Catalog, metrics *telemetry.M
 // forgeProviderName returns the effective forge provider name for logging
 // ("github" when Provider is left at its empty default).
 func forgeProviderName(cfg *config.Config) string {
-	if cfg.Forge.Provider == "" {
-		return "github"
-	}
-	return cfg.Forge.Provider
+	return cmp.Or(cfg.Forge.Provider, "github")
 }
 
 // BuildReinvestigator returns a poller that re-runs KB issues labelled

--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -149,15 +149,14 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 	case transcript != nil:
 		model, verifyModel = replay.New(transcript), nil
 	default:
-		if apiKeyEnv != "" && os.Getenv(apiKeyEnv) == "" {
+		// An empty apiKeyEnv is the keyless case (e.g. a local vLLM base_url):
+		// os.Getenv("") is "", which BuildModel takes as "no credential".
+		apiKey := os.Getenv(apiKeyEnv)
+		if apiKeyEnv != "" && apiKey == "" {
 			return fmt.Errorf("the demo needs a model API key: set %s to your key "+
 				"(or point --config at a runlore.yaml with a configured model, or run with "+
 				"--offline default to replay a recorded investigation with no key at all). "+
 				"Everything else runs against built-in fake providers — no cluster required", apiKeyEnv)
-		}
-		apiKey := ""
-		if apiKeyEnv != "" {
-			apiKey = os.Getenv(apiKeyEnv)
 		}
 		model = BuildModel(cfg, apiKey)
 		if *record != "" {
@@ -339,11 +338,10 @@ func (t tracingTool) Call(ctx context.Context, args string) (string, error) {
 // oneLineArgs flattens a JSON args blob to a single line for the step trace ("{}" for
 // the common empty-object case reads as no-args).
 func oneLineArgs(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" || s == "{}" {
+	if t := strings.TrimSpace(s); t == "" || t == "{}" {
 		return ""
 	}
-	return strings.Join(strings.Fields(s), " ")
+	return oneLineIndent(s)
 }
 
 // oneLineIndent flattens whitespace-heavy multi-line tool output / incident text to a

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -594,7 +594,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, deps *Deps, appr
 		log.Info("interim progress updates enabled", "every_steps", progressEverySteps)
 	}
 	// Per-investigation cost reporting (optional). The verify override inherits the
-	// main pricing when it sets none (whole-struct or() inherit), so a cheaper verify
+	// main pricing when it sets none (whole-struct inherit), so a cheaper verify
 	// model is costed correctly.
 	mainPricing := toPricing(cfg.Model.Pricing)
 	verifyPricing := mainPricing

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"cmp"
 	"context"
 	"flag"
 	"fmt"
@@ -35,11 +36,7 @@ func RunInvestigate(args []string) error {
 		return fmt.Errorf("provide --alert and/or --message")
 	}
 	explicit := *cfgPath != ""
-	path := *cfgPath
-	if path == "" {
-		path = defaultConfigPath
-	}
-	cfg, err := resolveInvestigateConfig(path, explicit)
+	cfg, err := resolveInvestigateConfig(cmp.Or(*cfgPath, defaultConfigPath), explicit)
 	if err != nil {
 		return err
 	}

--- a/internal/app/investigate_config.go
+++ b/internal/app/investigate_config.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -65,7 +66,7 @@ func configFromEnv() (*config.Config, error) {
 	case os.Getenv(envOpenAIBaseURL) != "":
 		m := config.Model{
 			BaseURL: os.Getenv(envOpenAIBaseURL),
-			Model:   or(os.Getenv(envOpenAIModel), defaultOpenAIModel),
+			Model:   cmp.Or(os.Getenv(envOpenAIModel), defaultOpenAIModel),
 		}
 		// Keyless is a first-class case here: an in-cluster vLLM or a local Ollama
 		// needs no credential, and demanding one would break the most private setup.
@@ -87,12 +88,4 @@ func configFromEnv() (*config.Config, error) {
 	}
 	config.ApplyDefaults(cfg)
 	return cfg, nil
-}
-
-// or returns a when non-empty, else b.
-func or(a, b string) string {
-	if a != "" {
-		return a
-	}
-	return b
 }

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -6,6 +6,7 @@
 package app
 
 import (
+	"cmp"
 	"os"
 
 	"github.com/Smana/runlore/internal/config"
@@ -72,13 +73,11 @@ func BuildVerifyModel(cfg *config.Config) providers.ModelProvider {
 	if v == nil {
 		return nil
 	}
-	apiKey := ""
-	if keyEnv := or(v.APIKeyEnv, cfg.Model.APIKeyEnv); keyEnv != "" {
-		apiKey = os.Getenv(keyEnv)
-	}
-	return NewModelClient(or(v.Provider, cfg.Model.Provider),
-		or(v.BaseURL, cfg.Model.BaseURL), or(v.Model, cfg.Model.Model), apiKey,
-		verifyMaxTokens(cfg), or(v.Effort, cfg.Model.Effort), or(v.Thinking, cfg.Model.Thinking))
+	// os.Getenv("") is "", so an unset key env on both sides is the keyless case.
+	apiKey := os.Getenv(cmp.Or(v.APIKeyEnv, cfg.Model.APIKeyEnv))
+	return NewModelClient(cmp.Or(v.Provider, cfg.Model.Provider),
+		cmp.Or(v.BaseURL, cfg.Model.BaseURL), cmp.Or(v.Model, cfg.Model.Model), apiKey,
+		verifyMaxTokens(cfg), cmp.Or(v.Effort, cfg.Model.Effort), cmp.Or(v.Thinking, cfg.Model.Thinking))
 }
 
 // BuildJudgeModel builds the (stronger) grader model from --judge-* flags, falling

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@
 package config
 
 import (
+	"cmp"
 	"fmt"
 	"net"
 	"net/url"
@@ -192,15 +193,42 @@ type LogFields struct {
 }
 
 // Default log-field convention: the VictoriaLogs + vector kubernetes-metadata
-// layout RunLore shipped with. Each Resolved default MUST equal one of these so an
-// unset config reproduces the previous hardcoded behaviour exactly.
-const (
-	defaultLogContainerField = "kubernetes.container_name"
-	defaultLogNamespaceField = "kubernetes.pod_namespace"
-	defaultLogPodField       = "kubernetes.pod_name"
-	defaultLogLevelField     = "log.level"
-	defaultLogUnpackPipe     = "unpack_json"
-)
+// layout RunLore shipped with. These values MUST NOT change — an unset config
+// has to reproduce the previous hardcoded behaviour exactly.
+var defaultLogFields = LogFields{
+	ContainerField: "kubernetes.container_name",
+	NamespaceField: "kubernetes.pod_namespace",
+	PodField:       "kubernetes.pod_name",
+	LevelField:     "log.level",
+	UnpackPipe:     "unpack_json",
+}
+
+// Default log-field convention for Loki: the promtail/Grafana-Alloy stream-label
+// layout plus Loki 3.x's auto-detected severity (detected_level is structured
+// metadata, filterable WITHOUT a parser stage — hence no default unpack pipe, so
+// UnpackPipe stays as-set here, empty meaning no parser stage).
+// An operator on Loki 2.x (no detected_level) overrides logs.fields, e.g.
+// {level_field: level, unpack_pipe: logfmt}.
+var defaultLokiFields = LogFields{
+	ContainerField: "container",
+	NamespaceField: "namespace",
+	PodField:       "pod",
+	LevelField:     "detected_level",
+}
+
+// Default log-field convention for Elasticsearch/OpenSearch: the ECS
+// (Elastic Common Schema) layout Filebeat and most ECS-compliant collectors
+// ship. Both distributions get the SAME defaults — they are the same wire
+// format under a fork, not two different conventions. UnpackPipe has no default
+// (and stays unused): these backends have no parser-pipe concept.
+var defaultECSFields = LogFields{
+	ContainerField: "kubernetes.container.name",
+	NamespaceField: "kubernetes.namespace",
+	PodField:       "kubernetes.pod.name",
+	LevelField:     "log.level",
+	TimestampField: "@timestamp",
+	MessageField:   "message",
+}
 
 // Resolved returns the field convention with every unset value filled from the
 // shipped defaults, so callers can use the result without repeating the fallbacks.
@@ -210,48 +238,8 @@ const (
 // they had a fully-zero struct. To keep the "any override" case simple, an empty
 // UnpackPipe here falls back to the default; disabling it is out of scope for v1.
 func (f LogFields) Resolved() LogFields {
-	if f.ContainerField == "" {
-		f.ContainerField = defaultLogContainerField
-	}
-	if f.NamespaceField == "" {
-		f.NamespaceField = defaultLogNamespaceField
-	}
-	if f.PodField == "" {
-		f.PodField = defaultLogPodField
-	}
-	if f.LevelField == "" {
-		f.LevelField = defaultLogLevelField
-	}
-	if f.UnpackPipe == "" {
-		f.UnpackPipe = defaultLogUnpackPipe
-	}
-	return f
+	return f.withDefaults(defaultLogFields)
 }
-
-// Default log-field convention for Loki: the promtail/Grafana-Alloy stream-label
-// layout plus Loki 3.x's auto-detected severity (detected_level is structured
-// metadata, filterable WITHOUT a parser stage — hence no default unpack pipe).
-// An operator on Loki 2.x (no detected_level) overrides logs.fields, e.g.
-// {level_field: level, unpack_pipe: logfmt}.
-const (
-	defaultLokiContainerField = "container"
-	defaultLokiNamespaceField = "namespace"
-	defaultLokiPodField       = "pod"
-	defaultLokiLevelField     = "detected_level"
-)
-
-// Default log-field convention for Elasticsearch/OpenSearch: the ECS
-// (Elastic Common Schema) layout Filebeat and most ECS-compliant collectors
-// ship. Both distributions get the SAME defaults — they are the same wire
-// format under a fork, not two different conventions.
-const (
-	defaultECSContainerField = "kubernetes.container.name"
-	defaultECSNamespaceField = "kubernetes.namespace"
-	defaultECSPodField       = "kubernetes.pod.name"
-	defaultECSLevelField     = "log.level"
-	defaultECSTimestampField = "@timestamp"
-	defaultECSMessageField   = "message"
-)
 
 // ResolvedFor resolves the field convention for a specific logs provider: Loki
 // gets Loki-appropriate defaults, Elasticsearch/OpenSearch get ECS defaults;
@@ -260,51 +248,26 @@ const (
 func (f LogFields) ResolvedFor(provider string) LogFields {
 	switch provider {
 	case LogsProviderLoki:
-		return f.resolvedForLoki()
+		return f.withDefaults(defaultLokiFields)
 	case LogsProviderElasticsearch, LogsProviderOpenSearch:
-		return f.resolvedForECS()
+		return f.withDefaults(defaultECSFields)
 	default:
 		return f.Resolved()
 	}
 }
 
-func (f LogFields) resolvedForLoki() LogFields {
-	if f.ContainerField == "" {
-		f.ContainerField = defaultLokiContainerField
-	}
-	if f.NamespaceField == "" {
-		f.NamespaceField = defaultLokiNamespaceField
-	}
-	if f.PodField == "" {
-		f.PodField = defaultLokiPodField
-	}
-	if f.LevelField == "" {
-		f.LevelField = defaultLokiLevelField
-	}
-	// UnpackPipe stays as-set (empty = no parser stage): detected_level needs none.
-	return f
-}
-
-func (f LogFields) resolvedForECS() LogFields {
-	if f.ContainerField == "" {
-		f.ContainerField = defaultECSContainerField
-	}
-	if f.NamespaceField == "" {
-		f.NamespaceField = defaultECSNamespaceField
-	}
-	if f.PodField == "" {
-		f.PodField = defaultECSPodField
-	}
-	if f.LevelField == "" {
-		f.LevelField = defaultECSLevelField
-	}
-	if f.TimestampField == "" {
-		f.TimestampField = defaultECSTimestampField
-	}
-	if f.MessageField == "" {
-		f.MessageField = defaultECSMessageField
-	}
-	// UnpackPipe stays unused: Elasticsearch/OpenSearch have no parser-pipe concept.
+// withDefaults fills every unset field of f from d and returns the result, so a
+// convention only has to declare the values it defines: a field d leaves empty
+// (Loki/ECS have no UnpackPipe, VictoriaLogs no timestamp/message field) is left
+// exactly as the operator set it.
+func (f LogFields) withDefaults(d LogFields) LogFields {
+	f.ContainerField = cmp.Or(f.ContainerField, d.ContainerField)
+	f.NamespaceField = cmp.Or(f.NamespaceField, d.NamespaceField)
+	f.PodField = cmp.Or(f.PodField, d.PodField)
+	f.LevelField = cmp.Or(f.LevelField, d.LevelField)
+	f.UnpackPipe = cmp.Or(f.UnpackPipe, d.UnpackPipe)
+	f.TimestampField = cmp.Or(f.TimestampField, d.TimestampField)
+	f.MessageField = cmp.Or(f.MessageField, d.MessageField)
 	return f
 }
 

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -3,6 +3,7 @@
 package eval
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -152,12 +153,7 @@ func (c Case) Symptom() string { return c.Prompt }
 // DisplayName returns the incident title for demo/report labeling: the case's
 // alert_title when set, else its name. See Case.AlertTitle for why the distinction
 // is load-bearing on the instant-recall path.
-func (c Case) DisplayName() string {
-	if c.AlertTitle != "" {
-		return c.AlertTitle
-	}
-	return c.Name
-}
+func (c Case) DisplayName() string { return cmp.Or(c.AlertTitle, c.Name) }
 
 // AffectedWorkload returns the case's affected workload (zero when unset), so the demo
 // can seed the Request.Workload exactly as runOne does.

--- a/internal/investigate/renderlog.go
+++ b/internal/investigate/renderlog.go
@@ -3,6 +3,7 @@
 package investigate
 
 import (
+	"cmp"
 	"fmt"
 	"regexp"
 	"strings"
@@ -36,73 +37,59 @@ const (
 	DialectElastic = "query_string" // Elasticsearch/OpenSearch Lucene query_string
 )
 
-// Shipped log-field defaults. These MUST stay byte-identical to the strings the code
-// hardcoded before logs.fields was configurable — they are the fallback that keeps
-// the maintainer's test cluster working when the config is unset.
-const (
-	defaultContainerField = "kubernetes.container_name"
-	defaultNamespaceField = "kubernetes.pod_namespace"
-	defaultPodField       = "kubernetes.pod_name"
-	defaultLevelField     = "log.level"
-	defaultUnpackPipe     = "unpack_json"
+// Shipped log-field defaults, one convention per dialect. These MUST stay
+// byte-identical to the strings the code hardcoded before logs.fields was
+// configurable — they are the fallback that keeps the maintainer's test cluster
+// working when the config is unset. Each MIRRORS the matching branch of
+// config.LogFields.ResolvedFor (internal/config/config.go), which is the normal
+// fill path; these are the in-package fallback for zero-field callers.
+//
+// A convention declares only what it defines: Loki's detected_level is structured
+// metadata needing no parser stage, and Elasticsearch/OpenSearch have no
+// parser-pipe concept at all, so neither sets UnpackPipe — resolved() then leaves
+// it exactly as the caller had it.
+var (
+	// VictoriaLogs + vector kubernetes-metadata layout (the shipped default).
+	defaultLogsQLFields = LogFields{
+		ContainerField: "kubernetes.container_name",
+		NamespaceField: "kubernetes.pod_namespace",
+		PodField:       "kubernetes.pod_name",
+		LevelField:     "log.level",
+		UnpackPipe:     "unpack_json",
+	}
+	// Loki convention: promtail/alloy stream labels + Loki 3.x detected_level.
+	defaultLogQLFields = LogFields{
+		ContainerField: "container",
+		NamespaceField: "namespace",
+		PodField:       "pod",
+		LevelField:     "detected_level",
+	}
+	// ECS (Elastic Common Schema), shared by Elasticsearch and OpenSearch.
+	defaultElasticFields = LogFields{
+		ContainerField: "kubernetes.container.name",
+		NamespaceField: "kubernetes.namespace",
+		PodField:       "kubernetes.pod.name",
+		LevelField:     "log.level",
+	}
 )
 
-// resolved fills every unset field from the shipped default so callers can use the
-// result directly. An empty UnpackPipe restores the default pipe (disabling it is
-// out of scope for v1).
+// resolved fills every unset field from the shipped default for f.Dialect so
+// callers can use the result directly. An empty UnpackPipe restores the LogsQL
+// default pipe (disabling it is out of scope for v1); the other two dialects
+// define no pipe, so it stays as-set there.
 func (f LogFields) resolved() LogFields {
-	if f.Dialect == DialectLogQL {
-		// Loki convention: promtail/alloy stream labels + Loki 3.x detected_level
-		// (structured metadata — no parser pipe by default). Mirrors
-		// config.LogFields.ResolvedFor (internal/config/config.go), which is the
-		// normal fill path; this is the in-package fallback for zero-field callers.
-		if f.ContainerField == "" {
-			f.ContainerField = "container"
-		}
-		if f.NamespaceField == "" {
-			f.NamespaceField = "namespace"
-		}
-		if f.PodField == "" {
-			f.PodField = "pod"
-		}
-		if f.LevelField == "" {
-			f.LevelField = "detected_level"
-		}
-		return f
+	d := defaultLogsQLFields
+	switch f.Dialect {
+	case DialectLogQL:
+		d = defaultLogQLFields
+	case DialectElastic:
+		d = defaultElasticFields
 	}
-	if f.Dialect == DialectElastic {
-		// ECS (Elastic Common Schema) convention, shared by Elasticsearch and
-		// OpenSearch. Mirrors config.LogFields.ResolvedFor's ECS branch; this is
-		// the in-package fallback for zero-field callers.
-		if f.ContainerField == "" {
-			f.ContainerField = "kubernetes.container.name"
-		}
-		if f.NamespaceField == "" {
-			f.NamespaceField = "kubernetes.namespace"
-		}
-		if f.PodField == "" {
-			f.PodField = "kubernetes.pod.name"
-		}
-		if f.LevelField == "" {
-			f.LevelField = "log.level"
-		}
-		return f
-	}
-	if f.ContainerField == "" {
-		f.ContainerField = defaultContainerField
-	}
-	if f.NamespaceField == "" {
-		f.NamespaceField = defaultNamespaceField
-	}
-	if f.PodField == "" {
-		f.PodField = defaultPodField
-	}
-	if f.LevelField == "" {
-		f.LevelField = defaultLevelField
-	}
-	if f.UnpackPipe == "" {
-		f.UnpackPipe = defaultUnpackPipe
-	}
+	f.ContainerField = cmp.Or(f.ContainerField, d.ContainerField)
+	f.NamespaceField = cmp.Or(f.NamespaceField, d.NamespaceField)
+	f.PodField = cmp.Or(f.PodField, d.PodField)
+	f.LevelField = cmp.Or(f.LevelField, d.LevelField)
+	f.UnpackPipe = cmp.Or(f.UnpackPipe, d.UnpackPipe)
 	return f
 }
 

--- a/internal/logs/detect.go
+++ b/internal/logs/detect.go
@@ -64,27 +64,38 @@ func Detect(ctx context.Context, baseURL, tokenEnv string, headers map[string]st
 	return ProviderVictoriaLogs
 }
 
-// detectLoki probes /loki/api/v1/status/buildinfo, returning ProviderLoki on a
-// recognised response and "" (not a fail-safe default — Detect owns that) on
-// any failure, so Detect can try the next probe.
-func detectLoki(ctx context.Context, base, tokenEnv string, headers map[string]string) string {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/loki/api/v1/status/buildinfo", nil)
+// probeBody issues one probe GET and returns the (bounded) response body, or nil
+// on ANY failure — a malformed URL, a transport error, or a non-200. Every probe
+// is best-effort by contract: nil means "not this backend", never an error to
+// propagate, so the caller returns "" and Detect moves to the next probe (or its
+// fail-safe default). The read is capped at 4 KiB: the documents parsed here are
+// small, and an unbounded read of an arbitrary operator-supplied endpoint is not.
+func probeBody(ctx context.Context, url, tokenEnv string, headers map[string]string) []byte {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return ""
+		return nil
 	}
 	applyProbeAuth(req, tokenEnv, headers)
 	resp, err := httpx.SecureClient(10 * time.Second).Do(req)
 	if err != nil {
-		return ""
+		return nil
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		return ""
+		return nil
 	}
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return body
+}
+
+// detectLoki probes /loki/api/v1/status/buildinfo, returning ProviderLoki on a
+// recognised response and "" (not a fail-safe default — Detect owns that) on
+// any failure, so Detect can try the next probe.
+func detectLoki(ctx context.Context, base, tokenEnv string, headers map[string]string) string {
 	var bi struct {
 		Version string `json:"version"`
 	}
+	body := probeBody(ctx, base+"/loki/api/v1/status/buildinfo", tokenEnv, headers)
 	if json.Unmarshal(body, &bi) != nil || bi.Version == "" {
 		return "" // a 200 that is not buildinfo (proxy page) is not Loki
 	}
@@ -95,26 +106,13 @@ func detectLoki(ctx context.Context, base, tokenEnv string, headers map[string]s
 // OpenSearch serve at their root), returning ProviderOpenSearch or
 // ProviderElasticsearch on a recognised response, "" on any failure.
 func detectElastic(ctx context.Context, base, tokenEnv string, headers map[string]string) string {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/", nil)
-	if err != nil {
-		return ""
-	}
-	applyProbeAuth(req, tokenEnv, headers)
-	resp, err := httpx.SecureClient(10 * time.Second).Do(req)
-	if err != nil {
-		return ""
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return ""
-	}
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	var root struct {
 		Version struct {
 			Number       string `json:"number"`
 			Distribution string `json:"distribution"`
 		} `json:"version"`
 	}
+	body := probeBody(ctx, base+"/", tokenEnv, headers)
 	if json.Unmarshal(body, &root) != nil || root.Version.Number == "" {
 		return "" // a 200 that carries no version.number (e.g. VictoriaLogs' HTML root) is neither
 	}

--- a/internal/logs/elasticsearch/elasticsearch.go
+++ b/internal/logs/elasticsearch/elasticsearch.go
@@ -261,27 +261,24 @@ func flattenJSON(prefix string, v any, out map[string]string) {
 
 // searchBody builds the shared `_search` request body: a query_string query
 // (or match_all when query is empty) plus an optional range filter on
-// timestampField for the window bounds. A size >= 0 is sent verbatim, INCLUDING
-// size:0 — that is the value Hits/TopMessages pass to say "aggregation buckets
-// only, return no hits", and omitting the key there would make ES fall back to
-// its default of 10 hits per aggregation request. Only a negative size omits the
-// key (no caller does today). sortDesc
-// adds the newest-first sort Query needs; Hits/TopMessages don't (they read
-// only aggregations, so sorting individual hits is pointless cost).
+// timestampField for the window bounds. size is ALWAYS sent, including size:0 —
+// that is the value Hits/TopMessages pass to say "aggregation buckets only,
+// return no hits", and omitting the key there would make ES fall back to its
+// default of 10 hits per aggregation request. sortDesc adds the newest-first
+// sort Query needs; Hits/TopMessages don't (they read only aggregations, so
+// sorting individual hits is pointless cost).
 func (c *Client) searchBody(query string, w providers.TimeWindow, size int, sortDesc bool) map[string]any {
-	must := []map[string]any{}
+	match := map[string]any{"match_all": map[string]any{}}
 	if query != "" {
-		must = append(must, map[string]any{"query_string": map[string]any{"query": query}})
-	} else {
-		must = append(must, map[string]any{"match_all": map[string]any{}})
+		match = map[string]any{"query_string": map[string]any{"query": query}}
 	}
-	boolQ := map[string]any{"must": must}
+	boolQ := map[string]any{"must": []map[string]any{match}}
 	if rangeFilter := c.rangeFilter(w); rangeFilter != nil {
 		boolQ["filter"] = []map[string]any{rangeFilter}
 	}
-	body := map[string]any{"query": map[string]any{"bool": boolQ}}
-	if size >= 0 {
-		body["size"] = size
+	body := map[string]any{
+		"query": map[string]any{"bool": boolQ},
+		"size":  size,
 	}
 	if sortDesc {
 		// unmapped_type keeps a rolling logs-* pattern searchable when an OLDER index
@@ -399,10 +396,10 @@ func shardFailure(body []byte, indexPattern string) (bool, string) {
 	return true, reason
 }
 
-// search POSTs a `_search` (or `_field_caps` via searchGet) request body and
-// returns the raw response body + HTTP status WITHOUT interpreting the status —
-// TopMessages needs the raw (status, body) pair to distinguish a genuine error
-// from the specific text-field aggregation rejection it falls back on.
+// search POSTs a `_search` request body and returns the raw response body + HTTP
+// status WITHOUT interpreting the status — TopMessages needs the raw (status,
+// body) pair to distinguish a genuine error from the specific text-field
+// aggregation rejection it falls back on.
 func (c *Client) search(ctx context.Context, body map[string]any) ([]byte, int, error) {
 	buf, err := json.Marshal(body)
 	if err != nil {
@@ -663,10 +660,13 @@ func (c *Client) topMessagesClientSide(ctx context.Context, query string, w prov
 		}
 		g := &groups[i]
 		g.count++
-		if !l.Time.IsZero() && (g.first.IsZero() || l.Time.Before(g.first)) {
+		if l.Time.IsZero() {
+			continue // an undated line still counts, but cannot move the span
+		}
+		if g.first.IsZero() || l.Time.Before(g.first) {
 			g.first = l.Time
 		}
-		if !l.Time.IsZero() && l.Time.After(g.last) {
+		if l.Time.After(g.last) {
 			g.last = l.Time
 		}
 	}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -24,14 +24,15 @@ func init() {
 	Register(Descriptor{
 		Name: "slack",
 		Build: func(d Deps) (providers.Notifier, error) {
+			sl := d.Cfg.Notify.Slack
 			// Bot token (chat.postMessage) takes precedence over an incoming webhook.
-			if sl := d.Cfg.Notify.Slack; sl.BotTokenEnv != "" && sl.Channel != "" {
+			if sl.BotTokenEnv != "" && sl.Channel != "" {
 				if tok := os.Getenv(sl.BotTokenEnv); tok != "" {
 					b := NewSlackBot(tok, sl.Channel)
 					b.FeedbackButtons = sl.FeedbackButtons
 					return b, nil
 				}
-			} else if sl := d.Cfg.Notify.Slack; sl.WebhookURLEnv != "" {
+			} else if sl.WebhookURLEnv != "" {
 				if url := os.Getenv(sl.WebhookURLEnv); url != "" {
 					s := NewSlack(url)
 					s.FeedbackButtons = sl.FeedbackButtons
@@ -684,9 +685,7 @@ func confidenceBadge(inv providers.Investigation) (emoji, level string, pct int)
 	c := inv.Confidence
 	if !inv.Recalled {
 		for _, rc := range inv.RootCauses {
-			if rc.Confidence > c {
-				c = rc.Confidence
-			}
+			c = max(c, rc.Confidence)
 		}
 	}
 	pct = int(c*100 + 0.5)
@@ -727,23 +726,18 @@ func recallConfidenceNote(inv providers.Investigation, deliveredPct int) string 
 // short line, exactly once, not woven into prose. "" when there is nothing to
 // link (a fresh, uncurated investigation with no recall/match context).
 func entryLink(inv providers.Investigation) string {
-	url := inv.CuratedURL
-	if url == "" {
-		url = inv.PrevCuratedURL
-	}
+	url := cmp.Or(inv.CuratedURL, inv.PrevCuratedURL)
 	if url == "" && inv.MatchedKnowledge != nil {
 		url = inv.MatchedKnowledge.URL
 	}
 	if url != "" {
 		return fmt.Sprintf("📚 <%s|view entry>", escapeMrkdwn(url))
 	}
-	path := ""
+	var path string
 	if inv.Prior != nil {
 		path = inv.Prior.EntryPath
 	}
-	if path == "" {
-		path = inv.RecalledEntry
-	}
+	path = cmp.Or(path, inv.RecalledEntry)
 	if path == "" && inv.MatchedKnowledge != nil {
 		path = inv.MatchedKnowledge.Path
 	}

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -17,6 +17,7 @@ package okf
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -56,8 +57,7 @@ func UpdateIndex(existing []byte, e providers.KBEntry, entryPath string) []byte 
 	for end > start+1 && strings.TrimSpace(lines[end-1]) == "" {
 		end--
 	}
-	out := append(append(append([]string{}, lines[:end]...), line), lines[end:]...)
-	return []byte(strings.Join(out, "\n") + "\n")
+	return []byte(strings.Join(slices.Insert(lines, end, line), "\n") + "\n")
 }
 
 // UpdateLog records the entry in an OKF log: flat date-grouped entries, newest
@@ -79,8 +79,7 @@ func UpdateLog(existing []byte, e providers.KBEntry, entryPath, date string) []b
 		}
 		// Today's heading exists (it is the newest — logs are newest-first):
 		// slot the line right under it.
-		out := append(append(append([]string{}, lines[:i+1]...), "", line), lines[i+1:]...)
-		return []byte(strings.Join(out, "\n") + "\n")
+		return []byte(strings.Join(slices.Insert(lines, i+1, "", line), "\n") + "\n")
 	}
 	// New (newest) date: insert the heading after the H1 title, before older dates.
 	at := len(lines)
@@ -90,6 +89,5 @@ func UpdateLog(existing []byte, e providers.KBEntry, entryPath, date string) []b
 			break
 		}
 	}
-	out := append(append(append([]string{}, lines[:at]...), heading, "", line, ""), lines[at:]...)
-	return []byte(strings.Join(out, "\n") + "\n")
+	return []byte(strings.Join(slices.Insert(lines, at, heading, "", line, ""), "\n") + "\n")
 }

--- a/internal/source/grafana/grafana.go
+++ b/internal/source/grafana/grafana.go
@@ -14,6 +14,7 @@ package grafana
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 
 	"gopkg.in/yaml.v3"
@@ -133,23 +134,15 @@ func mergedNode(user yaml.Node) (yaml.Node, error) {
 // wholesale-replaced when the user sets it. This is what makes "every field
 // stays overridable" true without forcing an all-or-nothing block.
 func mergeMaps(defaults, user map[string]any) map[string]any {
-	out := make(map[string]any, len(defaults)+len(user))
-	for k, v := range defaults {
-		out[k] = v
-	}
+	out := maps.Clone(defaults)
 	for k, v := range user {
-		if dm, ok := out[k].(map[string]any); ok {
-			if um, ok := v.(map[string]any); ok {
-				merged := make(map[string]any, len(dm)+len(um))
-				for kk, vv := range dm {
-					merged[kk] = vv
-				}
-				for kk, vv := range um {
-					merged[kk] = vv
-				}
-				out[k] = merged
-				continue
-			}
+		dm, defaultIsMap := out[k].(map[string]any)
+		um, userIsMap := v.(map[string]any)
+		if defaultIsMap && userIsMap {
+			merged := maps.Clone(dm)
+			maps.Copy(merged, um)
+			out[k] = merged
+			continue
 		}
 		out[k] = v
 	}


### PR DESCRIPTION
A simplification pass over the non-test Go added since v0.11.0. **−86 net lines**, no behaviour change, no test files touched — the tests encode the behaviour being preserved, so leaving them untouched is the evidence.

## What was collapsed

| File | Change | Δ |
|---|---|---|
| `internal/config/config.go` | `Resolved`/`resolvedForLoki`/`resolvedForECS` were three near-identical runs of `if f.X == "" { f.X = defaultX }` → per-convention default tables + one fill site | **−53** |
| `internal/investigate/renderlog.go` | Same shape, same fix (`resolved()`: 50 lines of three parallel branches → 15) | **−48** |
| `internal/app/{investigate_config,model}.go` | Dropped the hand-rolled `or(a, b string)` in favour of `cmp.Or`, already the repo idiom | **−13** |
| `internal/logs/elasticsearch/elasticsearch.go` | Unreachable `if size >= 0` branch; an if/else appending one element either way; a doubled guard; a stale doc reference to `searchGet`, a function that doesn't exist | **−13** |
| `internal/source/grafana/grafana.go` | `mergeMaps`' three hand-rolled copy loops nested four deep → `maps.Clone`/`maps.Copy` | **−10** |
| `internal/notify/slack.go` | Doubled config read; hand-rolled max; two two-branch fallback chains | **−9** |
| `internal/logs/detect.go` | Extracted `probeBody` — `detectLoki`/`detectElastic` ran an identical 15-line best-effort GET | −14 duplicated |
| `internal/okf/bundle.go` | Triple-nested `append(append(append(...)))` → `slices.Insert` | **−5** |

## What was deliberately left alone

This is the more useful half. I had suggested ES/OpenSearch and GitHub/GitLab as the likely copy-paste concentrations. **Both were wrong**, and the pass says so:

- **ES vs OpenSearch** — there is no duplication: `internal/logs/elasticsearch` is already *one* client for both. The only real divergence (the text-field aggregation rejection wording) is handled by matching the two tokens both distributions share, and the file carries an explicit "DO NOT simplify this to a single substring" warning with the verbatim ES 8.15 and OpenSearch 2.17 strings.
- **GitHub vs GitLab forge** — looks parallel, isn't. `bundle.go` already shares its markdown surgery via `internal/okf`. `CommentOnPR`/`CommentOnIssue` are split *on purpose*: GitLab's MR and issue iid sequences are independent, so a merged `Comment(number)` silently misroutes. Merging any of it would be the regression.
- **`config.withDefaults` vs `investigate.resolved`** — still two copies of the ECS/Loki default strings, kept because `internal/investigate` documents a hard no-config-import boundary and the strings must stay byte-identical.
- **`loadKBCatalog`** — the commons and non-commons branches share ~6 lines but emit deliberately different error text naming both roots.

## Verification

Rebased onto current `main` (after #430–#434) with no conflicts, and the fixes landed in these same files survive intact. `go build`, `go vet`, `gofmt -l`, `go test ./...` all clean; `golangci-lint run ./...` → `0 issues`.