### PR TITLE
fix(config): run the env and demo paths through the whole of Load's contract

### DIFF
--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -374,9 +374,16 @@ func demoConfig(path string) (cfg *config.Config, keyEnv string, err error) {
 		}
 		return loaded, loaded.Model.APIKeyEnv, nil
 	}
-	return &config.Config{Model: config.Model{
+	// ApplyDefaults, not a bare struct. Without it Investigation.Timeout stays 0 and
+	// the loop arms no deadline at all (loop.go only sets one when Timeout > 0), so
+	// `lore demo investigate` with a real key ran unbounded while the same command
+	// with --config got the defaulted 10m. Same bug class the investigate path fixed
+	// by routing configFromEnv through ApplyDefaults.
+	cfg = &config.Config{Model: config.Model{
 		Provider:  demoDefaultProvider,
 		Model:     demoDefaultModel,
 		APIKeyEnv: demoDefaultKeyEnv,
-	}}, demoDefaultKeyEnv, nil
+	}}
+	config.ApplyDefaults(cfg)
+	return cfg, demoDefaultKeyEnv, nil
 }

--- a/internal/app/demo_test.go
+++ b/internal/app/demo_test.go
@@ -293,3 +293,32 @@ func TestDemoScenarioSelectorIsTheSlug(t *testing.T) {
 			"labelled with a file slug:\n%s", out.String())
 	}
 }
+
+// TestDemoConfigGetsInvestigationDefaults: demoConfig's zero-config path returned
+// a bare struct, so Investigation.Timeout stayed 0 — and the loop only arms a
+// deadline when Timeout > 0. `lore demo investigate` with a real key therefore ran
+// UNBOUNDED, while the same command with --config got the defaulted 10m. Asserted
+// as equality with the file path rather than merely non-zero, so the two cannot
+// drift apart again.
+func TestDemoConfigGetsInvestigationDefaults(t *testing.T) {
+	envCfg, _, err := demoConfig("")
+	if err != nil {
+		t.Fatalf("demoConfig: %v", err)
+	}
+	if envCfg.Investigation.Timeout.Std() == 0 {
+		t.Fatal("the zero-config demo path must get ApplyDefaults' timeout — 0 means the loop arms no deadline at all")
+	}
+
+	path := filepath.Join(t.TempDir(), "runlore.yaml")
+	if err := os.WriteFile(path, []byte("model:\n  provider: openai\n  model: m\n  api_key_env: K\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fileCfg, _, err := demoConfig(path)
+	if err != nil {
+		t.Fatalf("demoConfig(file): %v", err)
+	}
+	if envCfg.Investigation.Timeout.Std() != fileCfg.Investigation.Timeout.Std() {
+		t.Fatalf("zero-config timeout %v != file-config timeout %v — the two paths must default identically",
+			envCfg.Investigation.Timeout.Std(), fileCfg.Investigation.Timeout.Std())
+	}
+}

--- a/internal/app/investigate_config.go
+++ b/internal/app/investigate_config.go
@@ -86,6 +86,14 @@ func configFromEnv() (*config.Config, error) {
 			envOpenAIBaseURL, envOpenAIKey, envOpenAIModel, envAnthropicKey, defaultConfigPath)
 	}
 	config.ApplyDefaults(cfg)
+	// Validate too, not just default. Load's contract is defaults THEN validation, and
+	// the checks that only live in Validate include checkSecureKeyEndpoint — so
+	// OPENAI_BASE_URL=http://gpu.public.example/v1 with an API key was rejected when it
+	// came from a YAML file and accepted when synthesized from the environment, sending
+	// the key in cleartext over the public internet.
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("environment-derived config is invalid: %w", err)
+	}
 	return cfg, nil
 }
 

--- a/internal/app/investigate_config_test.go
+++ b/internal/app/investigate_config_test.go
@@ -189,3 +189,25 @@ func TestDisabledToolsSilentWhenWired(t *testing.T) {
 		t.Errorf("disabledTools() = %v, want none", got)
 	}
 }
+
+// TestConfigFromEnvIsValidated: ApplyDefaults and Validate are both halves of
+// Load's contract, and the env path only ran the first. checkSecureKeyEndpoint
+// lives in Validate, so an API key aimed at a plaintext public endpoint was
+// rejected from a YAML file and accepted from the environment — sending the
+// credential in cleartext over the public internet.
+func TestConfigFromEnvIsValidated(t *testing.T) {
+	t.Setenv(envOpenAIBaseURL, "http://gpu.public.example/v1")
+	t.Setenv(envOpenAIKey, "sk-secret")
+	t.Setenv(envOpenAIModel, "gpt-4o")
+	if _, err := configFromEnv(); err == nil {
+		t.Fatal("an API key sent to a plaintext public endpoint must be rejected on the env path, " +
+			"exactly as it is when the same settings come from runlore.yaml")
+	}
+
+	// Control: the same shape over TLS is fine, so the assertion above is not just
+	// "configFromEnv always errors".
+	t.Setenv(envOpenAIBaseURL, "https://gpu.public.example/v1")
+	if _, err := configFromEnv(); err != nil {
+		t.Fatalf("a TLS endpoint must still be accepted: %v", err)
+	}
+}


### PR DESCRIPTION
`Load`'s contract is **ApplyDefaults then Validate**. Two paths that construct a `Config` without going through `Load` each ran only part of it.

## `configFromEnv` skipped `Validate`, so the cleartext-API-key check never fired

`checkSecureKeyEndpoint` lives in `Validate`, not `ApplyDefaults`. So:

```bash
OPENAI_BASE_URL=http://gpu.public.example/v1 OPENAI_API_KEY=sk-… lore investigate
```

was **rejected** when those settings came from `runlore.yaml` and **silently accepted** when synthesized from the environment — sending the credential in cleartext over the public internet.

The zero-config path exists precisely so a first investigation needs no YAML authoring, which makes it the path least likely to have been read by anyone before they used it.

## `demoConfig` skipped `ApplyDefaults`, so the demo ran with no deadline

It returned a bare struct, so `Investigation.Timeout` stayed `0` — and the loop only arms a deadline when `Timeout > 0`. `lore demo investigate` with a real key ran **unbounded**, while the same command with `--config` got the defaulted 10m.

This is the same bug the investigate path already fixed by routing `configFromEnv` through `ApplyDefaults`. The demo was the copy that didn't get the fix.

## Tests

Both assert **equality with the file-loaded path** rather than merely non-zero/non-nil, so the two cannot drift apart again — and both carry a control case (a TLS endpoint that must still be accepted; a file-loaded config to compare against) so neither can pass by the function simply always erroring.

Mutation-verified: removing either call fails its test with the reproduction in the message.