### PR TITLE
fix(demo): --catalog demonstrates instant recall, not recall being withdrawn

### DIFF
--- a/examples/demo/harbor-chart-bump.recall.transcript.json
+++ b/examples/demo/harbor-chart-bump.recall.transcript.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T07:48:52Z",
+  "recorded_with": {
+    "provider": "openai",
+    "model": "glm-4.5-air"
+  },
+  "turns": [
+    {
+      "text": "",
+      "tool_calls": [
+        {
+          "ID": "call_recall_verify_0001",
+          "Name": "submit_verdicts",
+          "Args": "{\"verdicts\": [{\"index\": 0, \"verdict\": \"keep\", \"reason\": \"The recalled entry's cause still matches this incident: the chart bump enables a startup schema migration, the migration lock is held, and harbor-core cannot reach the database.\"}]}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 617,
+        "output_tokens": 92,
+        "cached_input_tokens": 574,
+        "cache_write_tokens": 0
+      }
+    }
+  ]
+}

--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -47,10 +47,21 @@ const demoDefaultTranscript = "examples/demo/harbor-chart-bump.transcript.json"
 // running that same scenario twice shows the loop closing: the first run reasons its
 // way to the cause, the second is answered from the entry the first one produced.
 //
-// That second run is the only offline way to see an INSTANT RECALL card. Recall
-// short-circuits before the model is ever called, so unlike a full investigation it
-// cannot be captured in a transcript — there are no model turns to record.
+// That second run is the only offline way to see an INSTANT RECALL card.
+//
+// Recall short-circuits before the LOOP, not before the MODEL: the adversarial
+// verify pass that stands in front of every recall is itself a model call. So the
+// recall path does have a turn to record — one submit_verdicts response — and it
+// needs its own transcript. Replaying the full-investigation transcript here fed
+// the verify pass the loop's first turn (a what_changed tool call), which is not a
+// verdict, so #395's fail-closed gate correctly WITHDREW the recall and the demo
+// showed a full investigation with its first step already consumed.
 const demoDefaultCatalog = "examples/demo/catalog"
+
+// demoRecallTranscript is replayed instead of demoDefaultTranscript when --catalog
+// is combined with --offline. It holds the single model turn the recall path makes:
+// the adversarial verify pass approving the cached answer.
+const demoRecallTranscript = "examples/demo/harbor-chart-bump.recall.transcript.json"
 
 // RunDemo dispatches the `lore demo <subcommand>` family. Today only `investigate` is
 // wired: a zero-cluster, full-loop demonstration of the real investigator against fake
@@ -117,7 +128,14 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 	if model == nil && *offline != "" {
 		path := *offline
 		if path == "default" {
-			path = demoDefaultTranscript
+			// With a catalog loaded, recall fires and the ONLY model call is the
+			// verify pass — a different transcript from the full loop's. An explicit
+			// --offline <path> still wins; this only resolves the "default" alias.
+			if *catalogDir != "" {
+				path = demoRecallTranscript
+			} else {
+				path = demoDefaultTranscript
+			}
 		}
 		t, err := replay.Load(path)
 		if err != nil {

--- a/internal/app/demo_test.go
+++ b/internal/app/demo_test.go
@@ -243,7 +243,7 @@ func TestDemoCatalogWiresRecall(t *testing.T) {
 	err := runDemoInvestigateWithModel([]string{
 		"--scenarios", "../../examples/scenarios",
 		"--scenario", "harbor-chart-bump",
-		"--offline", "testdata/demo-transcript.json",
+		"--offline", "testdata/demo-recall-transcript.json",
 		"--catalog", "../../examples/demo/catalog",
 	}, &out, &errOut, nil)
 	if err != nil {
@@ -258,9 +258,46 @@ func TestDemoCatalogWiresRecall(t *testing.T) {
 	if !strings.Contains(got, "DEMO values, not production's") {
 		t.Errorf("the demo must disclose that its recall gate is not production's:\n%s", got)
 	}
-	// The gate itself must have been consulted, not skipped.
-	if !strings.Contains(errOut.String(), "instant recall") {
-		t.Errorf("recall was never consulted despite --catalog:\n%s", errOut.String())
+	// The gate must have FIRED and the recall must have been DELIVERED — not merely
+	// consulted.
+	//
+	// Asserting on "instant recall" in stderr proved nothing: that string is also a
+	// substring of the WITHDRAWAL line ("instant recall verify unavailable; running
+	// full investigation instead of delivering it unreviewed"). The demo spent its
+	// entire life demonstrating recall being withdrawn, and this test read as coverage.
+	if strings.Contains(errOut.String(), "verify unavailable") {
+		t.Errorf("recall was withdrawn rather than delivered — the demo is supposed to SHOW a recall card:\n%s", errOut.String())
+	}
+	if !strings.Contains(got, "Instant recall") {
+		t.Errorf("no instant-recall card was delivered:\n%s", got)
+	}
+	// A delivered recall skips the loop entirely, so no tool step may be printed.
+	if strings.Contains(got, "→ ") {
+		t.Errorf("recall short-circuits the loop, so no tool steps may run:\n%s", got)
+	}
+}
+
+// TestDemoOfflineWithoutCatalogRunsTheWholeLoop is the control for
+// TestDemoCatalogWiresRecall: without --catalog the SAME scenario must run the full
+// investigation, first tool step included.
+//
+// It exists because the recall bug was visible here as a side effect: the verify
+// pass consumed the transcript's first turn, so the fall-through investigation
+// started at turn 2 and silently lost its opening what_changed step. A trace that
+// is complete in one mode and truncated in the other is the cheap signal that the
+// transcript and the code path have drifted apart.
+func TestDemoOfflineWithoutCatalogRunsTheWholeLoop(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := runDemoInvestigateWithModel([]string{
+		"--scenarios", "../../examples/scenarios",
+		"--scenario", "harbor-chart-bump",
+		"--offline", "testdata/demo-transcript.json",
+	}, &out, &errOut, nil)
+	if err != nil {
+		t.Fatalf("demo without --catalog: %v\nstderr:\n%s", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), "→ ") {
+		t.Errorf("without a catalog the full loop must run and print its tool steps:\n%s", out.String())
 	}
 }
 

--- a/internal/app/testdata/demo-recall-transcript.json
+++ b/internal/app/testdata/demo-recall-transcript.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "scenario": "harbor-chart-bump",
+  "recorded_at": "2026-08-02T00:00:00Z",
+  "recorded_with": {
+    "provider": "test",
+    "model": "fixture"
+  },
+  "turns": [
+    {
+      "text": "",
+      "tool_calls": [
+        {
+          "ID": "call_verify_0001",
+          "Name": "submit_verdicts",
+          "Args": "{\"verdicts\": [{\"index\": 0, \"verdict\": \"keep\", \"reason\": \"the recalled cause still matches this incident\"}]}"
+        }
+      ],
+      "usage": {
+        "input_tokens": 100,
+        "output_tokens": 20,
+        "cached_input_tokens": 90,
+        "cache_write_tokens": 0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
`lore demo investigate --offline default --catalog default` — the headline keyless demonstration of the learning loop closing — never showed a recall card. It showed the fail-closed gate correctly **refusing** one, then a full investigation missing its first step:

```
instant recall (catalog hit; skipping the loop) ... confidence=0.90
verify pass returned no usable verdicts; keeping findings as-is
instant recall verify unavailable; running full investigation instead of delivering it unreviewed
→ query_metrics()      ← what_changed is GONE
```

## Cause

A wrong assumption, recorded in `demo.go`'s own comment:

> Recall short-circuits before the model is ever called, so unlike a full investigation it cannot be captured in a transcript — there are no model turns to record.

Recall short-circuits before the **loop**, not before the **model**. The adversarial verify pass that stands in front of every recall *is* a model call. So the replay provider answered it with the transcript's first **loop** turn — a `what_changed` tool call, not a verdict. #395's gate did exactly the right thing with that, and the fall-through investigation then started at turn 2, silently losing its opening step.

## Fix

The recall path does have a turn to record: one `submit_verdicts` response. `--catalog` combined with `--offline default` now replays `examples/demo/harbor-chart-bump.recall.transcript.json`. An explicit `--offline <path>` still wins — only the `default` alias resolves differently.

After:

```
⚡ Instant recall — answered from your knowledge base, no investigation was run
   • instant recall: matched knowledge-base entry "harbor-core-migration-deadlock.md"
```

No tool steps, no withdrawal. And plain `--offline default` still prints its full four-step trace, `what_changed` included.

## The test read as coverage

`TestDemoCatalogWiresRecall` asserted stderr contained `"instant recall"` — which is **also a substring of the withdrawal line** (`instant recall verify unavailable; …`). It passed for the feature's entire life while the feature was broken.

It now asserts the withdrawal line is **absent**, that a recall card was delivered, and that **no tool step ran** (a delivered recall skips the loop entirely).

Added `TestDemoOfflineWithoutCatalogRunsTheWholeLoop` as its control: the same scenario *without* `--catalog` must still print its tool steps. A trace complete in one mode and truncated in the other is the cheap signal that the transcript and the code path have drifted apart — which is exactly how this bug was visible all along.

Mutation-verified: reverting the transcript selection reproduces `verify unavailable`.