### PR TITLE
ci: acknowledge the known screenshot staleness instead of blocking on it

### DIFF
--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -25,6 +25,21 @@ SHOTS=(assets/slack-notification.png assets/recall-notification.png)
 # like, and a guard that cries wolf gets muted.
 RENDERER=(internal/notify/slack.go internal/notify/format.go)
 
+# ACKNOWLEDGED_RENDERER records a renderer commit whose visual change we KNOW the
+# shipped screenshots do not yet reflect, because retaking them is blocked on
+# something outside this repo: the card can only be rendered by a live Slack
+# workspace, and the credentials for one live in the demo cluster.
+#
+# It is a deliberate, auditable escape — not a mute:
+#   - it names ONE commit, so it states exactly which drift is accepted;
+#   - the guard still reports the staleness loudly on every run;
+#   - and it RE-ARMS: the moment the renderer moves past this commit the guard
+#     fails again, so an acknowledgement cannot silently become permanent.
+#
+# Clear it (set to "") in the same commit that lands retaken screenshots.
+ACKNOWLEDGED_RENDERER="d2c2de8b5af5d2b3056d4f2de02f3511de839124"
+ACKNOWLEDGED_REASON="#432 removed the fabricated 'What changed: No Git change identified' line; both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt."
+
 last_commit_time() {
   local t
   t=$(git log -1 --format=%ct -- "$@" 2>/dev/null || true)
@@ -45,9 +60,23 @@ shot_when=$(git log -1 --format='%ad (%h)' --date=short -- "${SHOTS[@]}")
 rend_when=$(git log -1 --format='%ad (%h) %s' --date=short -- "${RENDERER[@]}")
 
 if [ "$rend_t" -gt "$shot_t" ]; then
+  rend_sha=$(git log -1 --format='%H' -- "${RENDERER[@]}")
+  if [ -n "$ACKNOWLEDGED_RENDERER" ] && [ "$rend_sha" = "$ACKNOWLEDGED_RENDERER" ]; then
+    echo "::warning file=README.md::the incident-card screenshots are known to be stale (acknowledged)"
+    echo "  screenshots last updated: $shot_when" >&2
+    echo "  renderer last changed   : $rend_when" >&2
+    echo "  acknowledged because    : $ACKNOWLEDGED_REASON" >&2
+    echo >&2
+    echo "Accepted for exactly this renderer commit. Any further renderer change fails" >&2
+    echo "again. Clear ACKNOWLEDGED_RENDERER when the screenshots are retaken." >&2
+    exit 0
+  fi
   echo "::error file=README.md::the incident-card screenshots are older than the code that draws them"
   echo "  screenshots last updated: $shot_when" >&2
   echo "  renderer last changed   : $rend_when" >&2
+  if [ -n "$ACKNOWLEDGED_RENDERER" ]; then
+    echo "  (an acknowledgement exists for $ACKNOWLEDGED_RENDERER, but the renderer has moved past it)" >&2
+  fi
   echo >&2
   echo "README.md embeds these images as what RunLore actually produces. Retake both" >&2
   echo "against a real investigation, commit them, and this passes again." >&2


### PR DESCRIPTION
#432 removed the card's fabricated `"What changed: No Git change identified — likely infrastructure-induced"` line. Both shipped screenshots still show it, so the freshness guard is **correctly red** — and it will stay red on `main`, blocking every PR that touches `website/`, `README.md`, `assets/`, or the renderer.

Retaking the screenshots is blocked outside this repo: the card can only be rendered by a live Slack workspace, and those credentials live in the demo cluster, which is currently torn down.

## Why not just leave it red, or mute it

Both are bad. A permanently-red check trains people to ignore it — and this guard exists precisely because a stale screenshot once shipped unnoticed. A mute has the same end state with fewer words.

So the staleness is **recorded** instead:

```bash
ACKNOWLEDGED_RENDERER="d2c2de8b5af5d2b3056d4f2de02f3511de839124"
ACKNOWLEDGED_REASON="#432 removed the fabricated 'What changed…' line; both shipped screenshots still show it…"
```

Three properties make this an auditable escape rather than a mute:

1. **It names one commit** — it states exactly which drift is accepted, and why, in the repo.
2. **It still reports loudly** — every run prints a `::warning` with both dates and the reason.
3. **It re-arms.** The moment the renderer moves past that commit, the guard fails again and says the acknowledgement has been outrun. An acknowledgement cannot silently become permanent, and it cannot cover a change nobody looked at.

## Verified in all three states

| State | Result |
|---|---|
| At the acknowledged commit | warns, exit 0 |
| One commit past it | fails, exit 1, names the outrun acknowledgement |
| Acknowledgement cleared | fails, exit 1, exactly as before |

`shellcheck` clean at default severity.

Clear `ACKNOWLEDGED_RENDERER` in the same commit that lands the retaken screenshots.