### PR TITLE
fix(eval): score must_contain over the claim, and make entity precision engage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,8 +115,10 @@ zero credentials.
 `lore eval` replays recorded incident cases through the investigation loop and reports the
 root-cause-identification rate — use it to measure (and guard against regressions in) RCA quality as
 the loop/prompt/tools evolve. A case (`examples/eval/*.yaml`) records the evidence each tool returns and
-the keywords the findings must contain; the loop runs against the **configured model** with that
-evidence, and each case is scored pass/fail.
+the keywords the **claim** must contain; the loop runs against the **configured model** with that
+evidence, and each case is scored pass/fail. Scoring reads the claim only — the title plus each
+hypothesis's summary and suggested action — never the replayed evidence, which the harness itself fed
+the model (see `Score` in `internal/eval/score.go`).
 
 ```bash
 lore eval --config runlore.yaml --cases examples/eval

--- a/examples/eval/gitops-broken-kustomization.yaml
+++ b/examples/eval/gitops-broken-kustomization.yaml
@@ -157,12 +157,26 @@ tools:
     \ at 2026-08-02T11:02:08Z\nflux Kustomization/observability-victoria-metrics-k8s-stack (sync): ..e0a8d21a91ac770f97266da0a0de53d27641f44e39d2abe64eb49790cf573482\
     \ at 2026-08-02T11:01:03Z\n…and 4 more changes (narrow with a workload name)\n"
 expected:
+  # Matched over the CLAIM only (title + hypothesis summary/action), so echoing the
+  # recorded ArtifactFailed events back is not enough — the agent has to blame them.
   must_contain:
   - kustomization
   - path
   min_confidence: 0.5
-  root_cause_entities: []
-  distractors: []
+  # The claim must blame the Kustomization and the path it points at. "does/not/exist"
+  # is the tail of ./this/path/does/not/exist, so it matches whether the claim quotes
+  # spec.path or the full /tmp/kustomization-<n>/... build path from the events.
+  root_cause_entities:
+  - eval-victim-broken
+  - does/not/exist
+  # monorepo-split: the ArtifactGenerator sitting at Ready=unknown in gitops_tree — the
+  # classic wrong blame here is the source rather than the bad path, and the source is
+  # in fact healthy. llm-platform: the newest thing in what_changed (a whole new,
+  # SUSPENDED Flux Kustomization added in the same sync) — the "blame the last change"
+  # trap. A correct claim about eval-victim-broken's path names neither.
+  distractors:
+  - monorepo-split
+  - llm-platform
 ground_truth:
   root_cause: Kustomization/eval-victim-broken references spec.path ./this/path/does/not/exist, which
     does not exist in the infra-artifact source, so the build fails and the Kustomization is Ready=False

--- a/examples/eval/gitops-broken-kustomization.yaml
+++ b/examples/eval/gitops-broken-kustomization.yaml
@@ -163,19 +163,23 @@ expected:
   - kustomization
   - path
   min_confidence: 0.5
-  # The claim must blame the Kustomization and the path it points at. "does/not/exist"
-  # is the tail of ./this/path/does/not/exist, so it matches whether the claim quotes
-  # spec.path or the full /tmp/kustomization-<n>/... build path from the events.
+  # The claim must blame the Kustomization by name. The bad path itself is already
+  # covered by must_contain: path — requiring the verbatim "does/not/exist" would score
+  # QUOTING STYLE rather than correctness, failing an equally correct claim that says
+  # "points at a directory that is missing from the artifact".
   root_cause_entities:
   - eval-victim-broken
-  - does/not/exist
-  # monorepo-split: the ArtifactGenerator sitting at Ready=unknown in gitops_tree — the
-  # classic wrong blame here is the source rather than the bad path, and the source is
-  # in fact healthy. llm-platform: the newest thing in what_changed (a whole new,
-  # SUSPENDED Flux Kustomization added in the same sync) — the "blame the last change"
-  # trap. A correct claim about eval-victim-broken's path names neither.
+  # llm-platform: the newest thing in what_changed — a whole new Flux Kustomization
+  # added in the same sync, and SUSPENDED, so it changed nothing in the cluster. It is
+  # the "blame the last change" trap, and nothing in the evidence invites a correct
+  # claim to mention it, not even to rule it out.
+  #
+  # monorepo-split (the ArtifactGenerator at Ready=unknown) was considered and REJECTED
+  # as a distractor: the missing path is missing *from that artifact*, so a correct
+  # claim may legitimately name the generator or the ExternalArtifact for context, or
+  # note that the source is healthy. claimText excludes ruled_out, so either phrasing
+  # would score as an over-claim on a right answer.
   distractors:
-  - monorepo-split
   - llm-platform
 ground_truth:
   root_cause: Kustomization/eval-victim-broken references spec.path ./this/path/does/not/exist, which

--- a/examples/eval/harbor-chart-bump.yaml
+++ b/examples/eval/harbor-chart-bump.yaml
@@ -20,18 +20,34 @@ tools:
     (no dropped flows)
 expected:
   # The agent should tie the failure to the chart bump's DB migration on harbor-db.
-  # All three keywords appear VERBATIM in the evidence above, so they only mean
-  # something because scoring matches the CLAIM (title + hypothesis summary/action),
-  # never the recorded tool output — see Score in internal/eval/score.go. They are all
-  # words a correct claim uses: "the harbor chart bump to 1.15 started a DB schema
-  # migration that harbor-db is still holding a lock on".
-  must_contain: [chart, migration, harbor-db]
+  # Scored over the CLAIM (title + each hypothesis's summary and suggested action),
+  # never the recorded tool output — see Score in internal/eval/score.go.
+  #
+  # must_contain and root_cause_entities are the SAME match (same haystack, same
+  # case-insensitive substring rule), so listing a term in both just requires it twice.
+  # The split below is editorial: "migration" is the mechanism, harbor-db is the entity
+  # blamed for it.
+  #
+  # "chart" is deliberately NOT required. It names the change VEHICLE, not the cause,
+  # and models routinely cite the bump as evidence rather than in the claim — the
+  # recorded answer in examples/demo/harbor-chart-bump.transcript.json, which the README
+  # showcases as a successful investigation, puts "Chart bump to 1.15.0 enabled DB
+  # schema migrations" in evidence[] and would fail this gate. "migration" + harbor-db
+  # pin the cause, and that answer names both in its claim.
+  must_contain: [migration]
   min_confidence: 0.5
   # harbor-db is what the migration actually stalls. harbor-core is deliberately NOT
   # required: it is the symptom (503s / failing probes), not the cause.
   root_cause_entities: [harbor-db]
-  # The network is this case's planted negative control: network_drops reports "(no
-  # dropped flows)", yet "connect: connection refused" invites a connectivity verdict
-  # anyway. Blaming it is the shallow wrong answer the evidence already excludes, and a
-  # correct claim (migration lock) has no reason to name it.
-  distractors: [network]
+  # no valid distractor: this case cannot detect over-claiming.
+  #
+  # A distractor must be an entity that appears in this case's own evidence AND that a
+  # correct claim has no reason to name — not even to DISMISS, because claimText
+  # excludes ruled_out, so a dismissal written into the summary scores as a blame.
+  # Every entity here fails that test: harbor-core is the cascade victim a correct claim
+  # names as the symptom; 1.14.2/1.15.0 and values.yaml are the change a correct claim
+  # cites; and "network" is actively invited by the network_drops tool plus "connect:
+  # connection refused", so a correct claim reasonably writes "…a symptom, not a network
+  # fault (no dropped flows)" — which would score as an over-claim. Admitting the gap
+  # beats shipping a distractor that fails right answers.
+  distractors: []

--- a/examples/eval/harbor-chart-bump.yaml
+++ b/examples/eval/harbor-chart-bump.yaml
@@ -20,5 +20,18 @@ tools:
     (no dropped flows)
 expected:
   # The agent should tie the failure to the chart bump's DB migration on harbor-db.
+  # All three keywords appear VERBATIM in the evidence above, so they only mean
+  # something because scoring matches the CLAIM (title + hypothesis summary/action),
+  # never the recorded tool output — see Score in internal/eval/score.go. They are all
+  # words a correct claim uses: "the harbor chart bump to 1.15 started a DB schema
+  # migration that harbor-db is still holding a lock on".
   must_contain: [chart, migration, harbor-db]
   min_confidence: 0.5
+  # harbor-db is what the migration actually stalls. harbor-core is deliberately NOT
+  # required: it is the symptom (503s / failing probes), not the cause.
+  root_cause_entities: [harbor-db]
+  # The network is this case's planted negative control: network_drops reports "(no
+  # dropped flows)", yet "connect: connection refused" invites a connectivity verdict
+  # anyway. Blaming it is the shallow wrong answer the evidence already excludes, and a
+  # correct claim (migration lock) has no reason to name it.
+  distractors: [network]

--- a/examples/eval/poisoned-recall-rejected.yaml
+++ b/examples/eval/poisoned-recall-rejected.yaml
@@ -55,14 +55,22 @@ expected:
   root_cause_entities:
   - eval-victim
   - v9.9.9
-  # configmap: the catalogued poisoned cause this scenario exists to reject (see
-  # ground_truth below) — a correct run never names a ConfigMap, because none is
-  # involved. "tracking label": workload_ownership reports "no GitOps tracking label on
-  # the top controller — owner unresolved", a real red herring in this evidence that
-  # has nothing to do with the pull failure.
-  distractors:
-  - configmap
-  - tracking label
+  # no valid distractor: this case cannot detect over-claiming.
+  #
+  # A distractor must be an entity that appears in this case's own evidence AND that a
+  # correct claim has no reason to name — not even to DISMISS, because claimText
+  # excludes ruled_out, so a dismissal written into the summary scores as a blame.
+  #
+  # "configmap" was listed here and is wrong twice over: this case ships no catalog_dir,
+  # so no poisoned entry is ever recalled, and the word appears nowhere in its evidence
+  # — it could only fire on a hallucination. (The ConfigMap belongs to the recall
+  # scenario in poisoned-recall-verify.yaml, which does seed the fixture; the
+  # ground_truth prose below describes the LIVE eval/scenarios variant of this case,
+  # not this replay one.) "tracking label" is worse: workload_ownership reports a real
+  # out-of-band drift with no GitOps tracking label, and that IS how the tag came to
+  # change — so the BETTER claim ("a manual edit set the tag and nothing reverted it,
+  # because there is no tracking label") would score as an over-claim.
+  distractors: []
 ground_truth:
   root_cause: The eval-victim Deployment image was changed to tag v9.9.9-does-not-exist, which cannot
     be pulled (ImagePullBackOff/ErrImagePull). This is the TRUE cause — NOT the catalogued "stale ConfigMap

--- a/examples/eval/poisoned-recall-rejected.yaml
+++ b/examples/eval/poisoned-recall-rejected.yaml
@@ -43,12 +43,26 @@ tools:
 
     '
 expected:
+  # Matched over the CLAIM only (title + hypothesis summary/action), so quoting the
+  # recorded ImagePullBackOff events back is not enough — the agent has to blame them.
   must_contain:
   - image
   - pull
   min_confidence: 0.5
-  root_cause_entities: []
-  distractors: []
+  # The claim must blame the workload and the tag that cannot be resolved. "v9.9.9" is
+  # the shortest distinctive form: it matches whether the claim quotes the bare tag or
+  # the full registry.k8s.io/pause:v9.9.9-does-not-exist reference.
+  root_cause_entities:
+  - eval-victim
+  - v9.9.9
+  # configmap: the catalogued poisoned cause this scenario exists to reject (see
+  # ground_truth below) — a correct run never names a ConfigMap, because none is
+  # involved. "tracking label": workload_ownership reports "no GitOps tracking label on
+  # the top controller — owner unresolved", a real red herring in this evidence that
+  # has nothing to do with the pull failure.
+  distractors:
+  - configmap
+  - tracking label
 ground_truth:
   root_cause: The eval-victim Deployment image was changed to tag v9.9.9-does-not-exist, which cannot
     be pulled (ImagePullBackOff/ErrImagePull). This is the TRUE cause — NOT the catalogued "stale ConfigMap

--- a/examples/eval/poisoned-recall-verify.yaml
+++ b/examples/eval/poisoned-recall-verify.yaml
@@ -58,5 +58,16 @@ expected:
   # failure — NOT the poisoned entry's fabricated ConfigMap drift. "image" + "pull"
   # both match "ImagePullBackOff"/"image pull" and would NOT appear in the poisoned
   # ConfigMap answer, so this also fails loudly if verify wrongly kept the recall.
+  # Matched over the CLAIM only, so echoing the recorded pod_status is not enough.
   must_contain: [image, pull]
   min_confidence: 0.5
+  # The claim must blame the workload and the tag that cannot be resolved. "v9.9.9" is
+  # the shortest distinctive form: it matches whether the claim quotes the bare tag or
+  # the full registry.k8s.io/pause:v9.9.9-does-not-exist reference.
+  root_cause_entities: [eval-victim, v9.9.9]
+  # The poisoned catalog entry's fabricated cause — the eval-victim-config ConfigMap's
+  # drifted APP_MODE key. Both spellings are listed because a kept recall may name the
+  # ConfigMap by kind or by name. Neither can appear in a correct claim: there is no
+  # ConfigMap in this incident at all, so a hit here means verify's rejection was
+  # undone somewhere downstream.
+  distractors: [eval-victim-config, configmap]

--- a/examples/eval/poisoned-recall-verify.yaml
+++ b/examples/eval/poisoned-recall-verify.yaml
@@ -65,9 +65,21 @@ expected:
   # the shortest distinctive form: it matches whether the claim quotes the bare tag or
   # the full registry.k8s.io/pause:v9.9.9-does-not-exist reference.
   root_cause_entities: [eval-victim, v9.9.9]
-  # The poisoned catalog entry's fabricated cause — the eval-victim-config ConfigMap's
-  # drifted APP_MODE key. Both spellings are listed because a kept recall may name the
-  # ConfigMap by kind or by name. Neither can appear in a correct claim: there is no
-  # ConfigMap in this incident at all, so a hit here means verify's rejection was
-  # undone somewhere downstream.
-  distractors: [eval-victim-config, configmap]
+  # eval-victim-config is the poisoned catalog entry's fabricated cause (its drifted
+  # APP_MODE key). It is the one distractor in the shipped set that survives the rule
+  # "must appear in this case's own evidence, and a correct claim must have no reason to
+  # name it — not even to DISMISS it" (claimText excludes ruled_out, so a dismissal in
+  # the summary would score as a blame):
+  #
+  #   - reachable: it is model-visible through the seeded catalog fixture, during
+  #     confirmRecall and the verify pass.
+  #   - safe: the fall-through investigation starts from a FRESH context that never
+  #     contains it — loop.go excludes the refuted entry from the near-miss and this
+  #     fixture holds exactly one entry — so a correct claim cannot name it even in
+  #     passing. A hit therefore means the recall was KEPT rather than withdrawn, which
+  #     is precisely the regression this case exists to catch.
+  #
+  # The generic spelling "configmap" was dropped: a correct suggested_action could
+  # reasonably mention a ConfigMap in passing, and it adds nothing — a kept recall
+  # delivers the entry's own text, which names eval-victim-config.
+  distractors: [eval-victim-config]

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -96,7 +96,7 @@ type CaseRecall struct {
 
 // Expected is the RCA scoring spec for a case.
 type Expected struct {
-	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the findings (recall, over claim text)
+	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the claim (recall, over claim text)
 	MinConfidence     float64  `yaml:"min_confidence"`      // confidence floor (0 = no floor)
 	RootCauseEntities []string `yaml:"root_cause_entities"` // entities that MUST be named as the cause (entity recall, over claim text)
 	Distractors       []string `yaml:"distractors"`         // plausible-but-wrong entities that must NOT be blamed (over-claim/FP); only evaluated when root_cause_entities is non-empty

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -96,7 +96,7 @@ type CaseRecall struct {
 
 // Expected is the RCA scoring spec for a case.
 type Expected struct {
-	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the findings (recall, over full findings text)
+	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the findings (recall, over claim text)
 	MinConfidence     float64  `yaml:"min_confidence"`      // confidence floor (0 = no floor)
 	RootCauseEntities []string `yaml:"root_cause_entities"` // entities that MUST be named as the cause (entity recall, over claim text)
 	Distractors       []string `yaml:"distractors"`         // plausible-but-wrong entities that must NOT be blamed (over-claim/FP); only evaluated when root_cause_entities is non-empty

--- a/internal/eval/case.go
+++ b/internal/eval/case.go
@@ -95,11 +95,18 @@ type CaseRecall struct {
 }
 
 // Expected is the RCA scoring spec for a case.
+//
+// MustContain and RootCauseEntities are NOT two independent gates: Score matches both
+// over the same haystack (the claim — see claimText) with the same case-insensitive
+// substring rule, so a term listed in both is simply required twice. The only
+// behavioural difference is that a non-empty RootCauseEntities switches ON the
+// Distractors over-claim penalty. Keep the split editorial — mechanism words in
+// MustContain, blamed entities in RootCauseEntities — and don't duplicate across them.
 type Expected struct {
 	MustContain       []string `yaml:"must_contain"`        // keywords that must appear in the claim (recall, over claim text)
 	MinConfidence     float64  `yaml:"min_confidence"`      // confidence floor (0 = no floor)
-	RootCauseEntities []string `yaml:"root_cause_entities"` // entities that MUST be named as the cause (entity recall, over claim text)
-	Distractors       []string `yaml:"distractors"`         // plausible-but-wrong entities that must NOT be blamed (over-claim/FP); only evaluated when root_cause_entities is non-empty
+	RootCauseEntities []string `yaml:"root_cause_entities"` // entities that MUST be named as the cause; same match as MustContain, and its presence is what enables Distractors
+	Distractors       []string `yaml:"distractors"`         // entities present in the case's own evidence that a correct claim has no reason to name — not even to dismiss, since claimText excludes ruled_out; only evaluated when root_cause_entities is non-empty
 }
 
 // Load reads every *.yaml / *.yml case in dir.

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -10,7 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -254,15 +257,32 @@ expected:
 	}
 }
 
-// TestShippedCasesScoreEntities guards the shipped gold set: entity scoring — recall
-// over root_cause_entities and the over-claim penalty over distractors — engages only
-// when root_cause_entities is non-empty (see Score), so a case that ships empty lists
-// is silently scored by keywords alone and the over-claim penalty never fires. It also
-// rejects a distractor that is a substring of one of the case's own entities, because
-// Score suppresses those as "explained by a correct claim" — such a distractor is dead
-// weight that looks like coverage.
+// noDistractorJustification is the marker a case must carry, as a YAML comment, to
+// ship an empty distractors list. A case that cannot detect over-claiming is an
+// acceptable outcome — a distractor a CORRECT claim might name is worse than none —
+// but it has to be on the record, so the gap reads as a decision and not an oversight.
+const noDistractorJustification = "no valid distractor:"
+
+// TestShippedCasesScoreEntities guards the shipped gold set on three counts.
+//
+// Entity scoring — recall over root_cause_entities and the over-claim penalty over
+// distractors — engages only when root_cause_entities is non-empty (see Score), so a
+// case that ships an empty list is silently scored by keywords alone.
+//
+// A distractor must be able to FIRE. Two ways it cannot: being a substring of one of
+// the case's own entities (Score suppresses those as "explained by a correct claim"),
+// or appearing nowhere in the evidence the model is actually shown — the prompt, the
+// recorded tool output, and any seeded catalog fixture. The second is the trap this
+// test was extended for: a distractor naming something the model never sees can only
+// fire on a hallucination, so it reads as over-claim coverage while providing none.
+//
+// It does NOT verify the other half of a good distractor — that a correct claim has no
+// reason to name it, not even to dismiss it, which claimText's exclusion of ruled_out
+// makes a real hazard. That half is a judgement call and lives in each case file's
+// comment.
 func TestShippedCasesScoreEntities(t *testing.T) {
-	cases, err := Load(filepath.Join("..", "..", "examples", "eval"))
+	dir := filepath.Join("..", "..", "examples", "eval")
+	cases, err := Load(dir)
 	if err != nil {
 		t.Fatalf("Load examples/eval: %v", err)
 	}
@@ -275,15 +295,79 @@ func TestShippedCasesScoreEntities(t *testing.T) {
 				t.Fatal("no root_cause_entities: entity scoring and the over-claim penalty never engage for this case")
 			}
 			if len(c.Expected.Distractors) == 0 {
-				t.Fatal("no distractors: this case cannot detect over-claiming")
+				if !strings.Contains(caseFileText(t, dir, c.Name), noDistractorJustification) {
+					t.Fatalf("empty distractors and no %q comment in the case file: this case cannot detect over-claiming, so state why", noDistractorJustification)
+				}
+				return
 			}
+			evidence := caseEvidence(t, dir, c)
 			for _, d := range c.Expected.Distractors {
 				if coveredByEntity(c.Expected.RootCauseEntities, d) {
 					t.Errorf("distractor %q is a substring of one of %v — Score suppresses it, so it can never fire", d, c.Expected.RootCauseEntities)
 				}
+				if !strings.Contains(evidence, strings.ToLower(d)) {
+					t.Errorf("distractor %q appears nowhere in this case's prompt, recorded tool output or catalog fixture — nothing can blame it but a hallucination, so it looks like over-claim coverage without being any", d)
+				}
 			}
 		})
 	}
+}
+
+// caseEvidence is everything this case puts in front of the model, lower-cased: the
+// seed prompt, every recorded tool output, and — when the case seeds a catalog fixture
+// — the entries in it, which instant recall and the verify pass do show the model.
+func caseEvidence(t *testing.T, dir string, c Case) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(c.Prompt)
+	for _, out := range c.Tools {
+		b.WriteString(" " + out)
+	}
+	if c.CatalogDir != "" {
+		entries, err := filepath.Glob(filepath.Join(dir, c.CatalogDir, "*"))
+		if err != nil {
+			t.Fatalf("glob catalog_dir %q: %v", c.CatalogDir, err)
+		}
+		if len(entries) == 0 {
+			t.Fatalf("catalog_dir %q holds no entries", c.CatalogDir)
+		}
+		for _, p := range entries {
+			data, err := os.ReadFile(p) //nolint:gosec // G304: path comes from the repo's own cases dir
+			if err != nil {
+				t.Fatalf("read catalog entry %s: %v", p, err)
+			}
+			b.Write(append([]byte(" "), data...))
+		}
+	}
+	return strings.ToLower(b.String())
+}
+
+// caseFileText returns the RAW YAML the named case was loaded from. The guard needs it
+// because the justification for an empty distractors list is a comment, which the
+// parser strips before it ever reaches a Case.
+func caseFileText(t *testing.T, dir, name string) string {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(dir, "*.y*ml"))
+	if err != nil {
+		t.Fatalf("glob %s: %v", dir, err)
+	}
+	for _, p := range paths {
+		data, err := os.ReadFile(p) //nolint:gosec // G304: path comes from the repo's own cases dir
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		var head struct {
+			Name string `yaml:"name"`
+		}
+		if err := yaml.Unmarshal(data, &head); err != nil {
+			t.Fatalf("parse %s: %v", p, err)
+		}
+		if head.Name == name || strings.TrimSuffix(filepath.Base(p), filepath.Ext(p)) == name {
+			return string(data)
+		}
+	}
+	t.Fatalf("no case file in %s declares name %q", dir, name)
+	return ""
 }
 
 // rateModel passes (names harbor-db) on its first passN Complete-pairs, then fails.

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -279,10 +278,8 @@ func TestShippedCasesScoreEntities(t *testing.T) {
 				t.Fatal("no distractors: this case cannot detect over-claiming")
 			}
 			for _, d := range c.Expected.Distractors {
-				for _, e := range c.Expected.RootCauseEntities {
-					if strings.Contains(strings.ToLower(e), strings.ToLower(d)) {
-						t.Errorf("distractor %q is a substring of required entity %q — Score suppresses it, so it can never fire", d, e)
-					}
+				if coveredByEntity(c.Expected.RootCauseEntities, d) {
+					t.Errorf("distractor %q is a substring of one of %v — Score suppresses it, so it can never fire", d, c.Expected.RootCauseEntities)
 				}
 			}
 		})

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -56,6 +57,79 @@ func TestScore(t *testing.T) {
 	}
 	if r := Score("c", inv, Expected{MustContain: []string{"chart"}, MinConfidence: 0.95}); r.Pass {
 		t.Fatalf("expected fail on confidence floor, got %+v", r)
+	}
+}
+
+// TestMustContainMatchesClaimNotEvidence pins the haystack must_contain is matched
+// over: the CLAIM (title + each hypothesis's summary and suggested action), never the
+// evidence the replay tools handed the model. Matching over the evidence made the
+// keyword gate self-fulfilling — an agent that merely quotes its own recorded input,
+// or that names the keyword only while RULING IT OUT, scored a pass.
+func TestMustContainMatchesClaimNotEvidence(t *testing.T) {
+	exp := Expected{MustContain: []string{"harbor-db"}, MinConfidence: 0.5}
+	tests := []struct {
+		name string
+		inv  providers.Investigation
+		want bool
+	}{
+		{
+			name: "named as the cause in the summary",
+			inv: providers.Investigation{Confidence: 0.8, RootCauses: []providers.Hypothesis{{
+				Summary: "the chart bump enabled a schema migration that stalled harbor-db",
+			}}},
+			want: true,
+		},
+		{
+			name: "named in the suggested action",
+			inv: providers.Investigation{Confidence: 0.8, RootCauses: []providers.Hypothesis{{
+				Summary:         "the chart bump enabled a blocking schema migration",
+				SuggestedAction: "clear the stale migration lock on harbor-db",
+			}}},
+			want: true,
+		},
+		{
+			name: "named in the title",
+			inv: providers.Investigation{
+				Confidence: 0.8,
+				Title:      "harbor-db stuck on a schema migration lock",
+				RootCauses: []providers.Hypothesis{{Summary: "the chart bump is the trigger"}},
+			},
+			want: true,
+		},
+		{
+			name: "only quoted back from the recorded evidence",
+			inv: providers.Investigation{Confidence: 0.8, RootCauses: []providers.Hypothesis{{
+				Summary:  "unclear, possibly a transient blip",
+				Evidence: []string{"harbor-db-0  FATAL: could not obtain migration lock"},
+			}}},
+			want: false,
+		},
+		{
+			name: "only named while ruling it out",
+			inv: providers.Investigation{
+				Confidence: 0.8,
+				RootCauses: []providers.Hypothesis{{Summary: "unclear, possibly a transient blip"}},
+				RuledOut:   []string{"harbor-db: its migration finished before the outage window"},
+			},
+			want: false,
+		},
+		{
+			name: "only listed as unresolved or a data gap",
+			inv: providers.Investigation{
+				Confidence: 0.8,
+				RootCauses: []providers.Hypothesis{{Summary: "unclear, possibly a transient blip"}},
+				Unresolved: []string{"whether harbor-db ever finished its migration"},
+				DataGaps:   []string{"no harbor-db logs before 09:00"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Score("c", tt.inv, exp); got.Pass != tt.want {
+				t.Fatalf("Pass = %v, want %v (missing: %v)", got.Pass, tt.want, got.Missing)
+			}
+		})
 	}
 }
 
@@ -178,6 +252,40 @@ expected:
 		len(cases[0].Expected.RootCauseEntities) != 2 ||
 		len(cases[0].Expected.Distractors) != 1 {
 		t.Fatalf("entity fields not parsed: %+v", cases[0].Expected)
+	}
+}
+
+// TestShippedCasesScoreEntities guards the shipped gold set: entity scoring — recall
+// over root_cause_entities and the over-claim penalty over distractors — engages only
+// when root_cause_entities is non-empty (see Score), so a case that ships empty lists
+// is silently scored by keywords alone and the over-claim penalty never fires. It also
+// rejects a distractor that is a substring of one of the case's own entities, because
+// Score suppresses those as "explained by a correct claim" — such a distractor is dead
+// weight that looks like coverage.
+func TestShippedCasesScoreEntities(t *testing.T) {
+	cases, err := Load(filepath.Join("..", "..", "examples", "eval"))
+	if err != nil {
+		t.Fatalf("Load examples/eval: %v", err)
+	}
+	if len(cases) == 0 {
+		t.Fatal("no shipped cases loaded")
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			if len(c.Expected.RootCauseEntities) == 0 {
+				t.Fatal("no root_cause_entities: entity scoring and the over-claim penalty never engage for this case")
+			}
+			if len(c.Expected.Distractors) == 0 {
+				t.Fatal("no distractors: this case cannot detect over-claiming")
+			}
+			for _, d := range c.Expected.Distractors {
+				for _, e := range c.Expected.RootCauseEntities {
+					if strings.Contains(strings.ToLower(e), strings.ToLower(d)) {
+						t.Errorf("distractor %q is a substring of required entity %q — Score suppresses it, so it can never fire", d, e)
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/internal/eval/recall_test.go
+++ b/internal/eval/recall_test.go
@@ -211,7 +211,10 @@ func TestShippedPoisonedRecallCaseFires(t *testing.T) {
 	}
 	model := &seqModel{resp: []providers.CompletionResponse{
 		verdict("reject"), // verify rejects the poisoned recall
-		findings("the image tag registry.k8s.io/pause:v9.9.9-does-not-exist cannot be pulled (ImagePullBackOff)"),
+		// A realistic CORRECT claim: it blames the workload and the unresolvable tag.
+		// Scoring reads the claim, not the replayed evidence, so a finding that merely
+		// quoted pod_status back would (rightly) no longer pass here.
+		findings("eval-victim cannot start: its image tag registry.k8s.io/pause:v9.9.9-does-not-exist cannot be pulled (ImagePullBackOff)"),
 		verdict("keep"), // verify keeps the fresh finding
 	}}
 	r := &Runner{Model: model, Log: discardLog()}

--- a/internal/eval/score.go
+++ b/internal/eval/score.go
@@ -39,40 +39,20 @@ type Result struct {
 // nothing is missing, no distractor was blamed, and confidence meets the floor.
 func Score(name string, inv providers.Investigation, exp Expected) Result {
 	claim := strings.ToLower(claimText(inv))
-	var missing []string
-	for _, kw := range exp.MustContain {
-		if !strings.Contains(claim, strings.ToLower(kw)) {
-			missing = append(missing, kw)
-		}
-	}
+	missing := notInClaim(claim, exp.MustContain)
 
 	var overClaimed []string
 	if len(exp.RootCauseEntities) > 0 {
-		for _, e := range exp.RootCauseEntities {
-			if !strings.Contains(claim, strings.ToLower(e)) {
-				missing = append(missing, e)
-			}
-		}
+		missing = append(missing, notInClaim(claim, exp.RootCauseEntities)...)
 		for _, d := range exp.Distractors {
-			dl := strings.ToLower(d)
-			if !strings.Contains(claim, dl) {
+			// coveredByEntity suppresses the penalty when the distractor is merely a
+			// substring of a legitimately-named entity: the hit is explained by a
+			// correct claim, not an over-claim.
+			if !strings.Contains(claim, strings.ToLower(d)) || coveredByEntity(exp.RootCauseEntities, d) {
 				continue
 			}
-			// Suppress the penalty when the distractor is merely a substring of a
-			// legitimately-named entity (e.g. distractor "apps/worker" inside the
-			// required "apps/worker-db"): the hit is explained by a correct claim,
-			// not an over-claim.
-			covered := false
-			for _, e := range exp.RootCauseEntities {
-				if strings.Contains(strings.ToLower(e), dl) {
-					covered = true
-					break
-				}
-			}
-			if !covered {
-				overClaimed = append(overClaimed, d)
-				missing = append(missing, "over-claimed: "+d)
-			}
+			overClaimed = append(overClaimed, d)
+			missing = append(missing, "over-claimed: "+d)
 		}
 	}
 
@@ -83,6 +63,33 @@ func Score(name string, inv providers.Investigation, exp Expected) Result {
 		Missing:     missing,
 		OverClaimed: overClaimed,
 	}
+}
+
+// notInClaim returns the terms absent from claim, which must already be lower-cased.
+// must_contain and root_cause_entities are matched identically — the same haystack,
+// the same case-insensitive substring rule — so the rule is stated once here.
+func notInClaim(claim string, terms []string) []string {
+	var missing []string
+	for _, t := range terms {
+		if !strings.Contains(claim, strings.ToLower(t)) {
+			missing = append(missing, t)
+		}
+	}
+	return missing
+}
+
+// coveredByEntity reports whether a distractor hit is already explained by a correctly
+// named entity — the distractor is merely a substring of one (e.g. distractor
+// "apps/worker" inside the required "apps/worker-db"). Score suppresses the over-claim
+// penalty in that case, so a distractor covered this way can never fire.
+func coveredByEntity(entities []string, distractor string) bool {
+	d := strings.ToLower(distractor)
+	for _, e := range entities {
+		if strings.Contains(strings.ToLower(e), d) {
+			return true
+		}
+	}
+	return false
 }
 
 // claimText is what the investigation BLAMED: the title plus each hypothesis's

--- a/internal/eval/score.go
+++ b/internal/eval/score.go
@@ -29,23 +29,25 @@ type Result struct {
 }
 
 // Score reports whether the investigation identifies the expected root cause.
-// Keyword recall (must_contain) is matched over the full findings text. Entity
-// scoring — recall over root_cause_entities and an over-claim penalty over
-// distractors — is matched over the CLAIM text only (what was blamed), and engages
-// only when root_cause_entities is set. A case passes when nothing is missing,
-// no distractor was blamed, and confidence meets the floor.
+// Everything is matched over the CLAIM text (what was blamed — see claimText):
+// keyword recall (must_contain), entity recall (root_cause_entities) and the
+// over-claim penalty (distractors). Matching must_contain over the full findings
+// text would make the gate self-fulfilling in a REPLAY eval — the tool output is
+// evidence the harness itself handed the model, so an agent that merely quotes it
+// back, or that names the keyword only while ruling it out, would score a pass.
+// Entity scoring engages only when root_cause_entities is set. A case passes when
+// nothing is missing, no distractor was blamed, and confidence meets the floor.
 func Score(name string, inv providers.Investigation, exp Expected) Result {
-	hay := strings.ToLower(investigationText(inv))
+	claim := strings.ToLower(claimText(inv))
 	var missing []string
 	for _, kw := range exp.MustContain {
-		if !strings.Contains(hay, strings.ToLower(kw)) {
+		if !strings.Contains(claim, strings.ToLower(kw)) {
 			missing = append(missing, kw)
 		}
 	}
 
 	var overClaimed []string
 	if len(exp.RootCauseEntities) > 0 {
-		claim := strings.ToLower(claimText(inv))
 		for _, e := range exp.RootCauseEntities {
 			if !strings.Contains(claim, strings.ToLower(e)) {
 				missing = append(missing, e)
@@ -85,7 +87,7 @@ func Score(name string, inv providers.Investigation, exp Expected) Result {
 
 // claimText is what the investigation BLAMED: the title plus each hypothesis's
 // summary and suggested action. It deliberately excludes Evidence and Unresolved
-// so entity matching means "named as a cause", not "mentioned while ruling out".
+// so matching means "named as a cause", not "mentioned while ruling out".
 func claimText(inv providers.Investigation) string {
 	var b strings.Builder
 	b.WriteString(inv.Title)
@@ -95,7 +97,9 @@ func claimText(inv providers.Investigation) string {
 	return b.String()
 }
 
-// investigationText flattens the findings into one searchable string.
+// investigationText flattens the findings into one searchable string. Used to show
+// the LLM judge the WHOLE answer (claim plus the evidence and caveats behind it);
+// deterministic scoring uses claimText instead — see Score.
 func investigationText(inv providers.Investigation) string {
 	var b strings.Builder
 	b.WriteString(inv.Title)


### PR DESCRIPTION
The published nightly eval scorecard reduces to keyword matching plus a confidence floor, while the two strongest scorers already in the code are switched off. This fixes both.

## 1. `must_contain` was matched over the evidence we handed the model

`Score()` matched `must_contain` over `investigationText()`, which flattens title + summaries + **Evidence** + Unresolved + RuledOut + DataGaps. Two consequences:

- a keyword landing in a *ruled out* line scored a pass;
- in a **replay** eval the tool output is evidence the harness itself fed the model, so an agent that merely quotes it back scored a pass.

Concretely, `harbor-chart-bump` requires `[chart, migration, harbor-db]` and all three appear verbatim in the recorded tool output that case replays.

`claimText()` — title + each hypothesis's summary and suggested action, deliberately excluding Evidence — already existed for entity scoring, with the comment *"named as a cause, not mentioned while ruling out"*. `must_contain` now uses it too, so both scorers share one haystack.

`investigationText` is kept: `judge.go` feeds it to the LLM judge, which legitimately needs the whole answer. Its doc comment now says why the two exist.

## 2. Entity precision (Track A) had never scored anything

Entity recall and the distractor over-claim penalty engage only when `root_cause_entities` is non-empty. Two shipped cases had no entity fields; two shipped `[]`. So the over-claim penalty that the learning-loop doc calls *"the dominant failure mode strong models exhibit"* was inert on every case.

All four cases now carry entities and distractors, each distractor a plausible-but-wrong entity that genuinely appears in that case's replayed evidence:

| case | entities | distractors |
|---|---|---|
| `harbor-chart-bump` | `harbor-db` | `network` |
| `gitops-broken-kustomization` | `eval-victim-broken`, `does/not/exist` | `monorepo-split`, `llm-platform` |
| `poisoned-recall-verify` | `eval-victim`, `v9.9.9` | `eval-victim-config`, `configmap` |
| `poisoned-recall-rejected` | `eval-victim`, `v9.9.9` | `configmap`, `tracking label` |

`harbor-core` is deliberately excluded from `harbor-chart-bump` — it is the symptom, not the cause, and requiring it would fire on a correct claim.

## Verification

An adversarial review pass over this branch found that the original claim here — "no `must_contain` list needed re-tuning" — was **wrong**, and the gold set has since been corrected. Recording what it found, because it is the more useful part of this PR:

The first check used *hand-written* correct answers. It missed the repo's **own recorded** one. `examples/demo/harbor-chart-bump.transcript.json` — the transcript the README presents as a successful investigation — put "chart" in its evidence, not its claim, so the harbor case **failed it**. A gate that rejects the project's own showcase answer is worse than the echo-pass it replaced.

The distractor rule is now explicit: a distractor must appear in the case's own model-visible evidence **and** a correct claim must have no reason to name it — *not even to dismiss it*, since `claimText` excludes `ruled_out`, so a dismissal written into the summary scores as a blame. Four distractors failed that rule and were dropped: `network` (the evidence actively invites "a symptom, not a network fault"), `monorepo-split` (naming the healthy generator for context is correct), `tracking label` (the out-of-band drift **is** how the tag changed — the penalised answer was the better one), and `configmap` on `poisoned-recall-rejected` (unreachable: that case seeds no catalog). `does/not/exist` was dropped from the entities as scoring quoting style rather than correctness.

Final gold set:

| case | `must_contain` | `root_cause_entities` | `distractors` |
|---|---|---|---|
| gitops-broken-kustomization | `kustomization`, `path` | `eval-victim-broken` | `llm-platform` |
| harbor-chart-bump | `migration` | `harbor-db` | empty, justified in-file |
| poisoned-recall-rejected | `image`, `pull` | `eval-victim`, `v9.9.9` | empty, justified in-file |
| poisoned-recall-verify | `image`, `pull` | `eval-victim`, `v9.9.9` | `eval-victim-config` |

Where no distractor survives the rule, the case says so rather than carrying an invented one — an honest "this case cannot detect over-claiming" beats a distractor that fails correct answers.

The recorded demo answer now scores `pass=true`. All 11 correct variants pass, including the three that previously failed; all 8 echo/over-claim variants still fail.

`TestShippedCasesScoreEntities` now also asserts each distractor is **reachable** — that its token appears somewhere in the case's own prompt, recorded tool output, or seeded catalog fixture. Mutation-tested 4/4: an unreachable distractor, a missing justification comment, empty entities, and a distractor that is a substring of its own entity all fail.

## Expected effect on the published number

The next nightly may score lower. That is the point — the gate now measures what the agent blamed rather than what it was handed.
