### PR TITLE
feat(serve): warn at startup when the learning loop has no feedback edge

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -91,6 +91,58 @@ func WebhookAuthWarning(alertmanagerEnabled bool, webhookToken string, mode conf
 		"reachable beyond trusted networks (docs/security-model.md)"
 }
 
+// RecallDecayWarning decides the startup warning for a learning loop whose
+// feedback edge cannot be shown to accumulate ground truth, returning "" when no
+// warning is warranted.
+//
+// Instant recall's Gate 3 weighs a candidate entry by its recorded track record,
+// and is deliberately fail-safe: an entry the outcome ledger has never seen scores
+// factor 1 and fires (absence of evidence must never block a recall). The
+// corollary is that a ledger which never accumulates ground truth turns that gate
+// into a silent no-op for EVERY entry — and the retirement pass, which shares the
+// same factor and floor, into one that can never propose anything. Trust stops
+// being derived from whether the entry actually worked, which is the claim the
+// whole learning loop rests on.
+//
+// Ground truth reaches the ledger through two channels, and only one of them is
+// observable from here:
+//
+//   - Human 👍/👎 feedback — opt-in on both notifiers, so its state IS in this
+//     config.
+//   - Resolve events from the incident source — NOT determinable at startup.
+//     `sources` records which adapters are enabled, not whether they emit
+//     resolves, and Alertmanager's `send_resolved` lives in the operator's
+//     receiver config, which RunLore never reads. Resolvability is decided
+//     per event from the fingerprint at record time (see the ledger.Open call in
+//     investigate.go), a runtime fact this function cannot anticipate.
+//
+// So the warning names the risk it can actually establish — neither feedback
+// channel is on, leaving an unverifiable resolve channel as the only remaining
+// source of truth — and explicitly does not claim resolves never arrive. It stays
+// a warning, never a hard failure: a deployment whose Alertmanager does send
+// resolves is correctly configured.
+//
+// Silent when instant recall is off (nothing recalls, so there is no trust to
+// decay) or when outcome.ledger_path is unset (the operator turned the learning
+// loop off, which `lore curate` likewise reports as an info, not a warning).
+func RecallDecayWarning(cfg *config.Config) string {
+	if !cfg.Catalog.InstantRecall.Enabled || cfg.Outcome.LedgerPath == "" {
+		return ""
+	}
+	if cfg.Notify.Slack.FeedbackButtons || cfg.Notify.Matrix.FeedbackReactions {
+		return ""
+	}
+	return "instant recall is enabled with an outcome ledger, but no feedback channel is on " +
+		"(notify.slack.feedback_buttons and notify.matrix.feedback_reactions are both off): the only " +
+		"remaining way an entry can earn or lose trust is a resolved-alert webhook from your incident " +
+		"source, and whether yours sends those is not in this config — RunLore cannot tell from here. " +
+		"Where they do not arrive, recall confidence never moves and no entry is ever proposed for " +
+		"retirement: a knowledge entry that has stopped working keeps being recalled at full trust. " +
+		"Turn on notify.slack.feedback_buttons or notify.matrix.feedback_reactions, and keep " +
+		"outcome.ledger_path on a persistent volume so what it records survives a restart " +
+		"(docs/concepts/learning-loop.md)"
+}
+
 // RequirePagerDutyAuth is the PagerDuty analogue of RequireWebhookAuth. The
 // PagerDuty source authenticates /webhook/pagerduty with its own
 // X-PagerDuty-Signature verification (not the shared server.webhook_token_env

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/source"
 )
 
 // ModelProvider returns the configured model provider name (default "openai").
@@ -91,56 +92,115 @@ func WebhookAuthWarning(alertmanagerEnabled bool, webhookToken string, mode conf
 		"reachable beyond trusted networks (docs/security-model.md)"
 }
 
-// RecallDecayWarning decides the startup warning for a learning loop whose
-// feedback edge cannot be shown to accumulate ground truth, returning "" when no
-// warning is warranted.
+// ResolveCapableSource reports whether any ENABLED source could deliver a resolve
+// event at all. It reads the adapter CONTRACT, never a hardcoded list of names, so
+// it cannot drift from source.Registered(): a Webhook source's Decode returns
+// source.DecodeResult, which carries Resolved; a Watcher's Watch returns a channel
+// of investigation requests and has nowhere to put a resolution. A deployment whose
+// only enabled sources are watchers (GitOps failures) therefore PROVABLY has no
+// resolve channel — as does the re-investigate poller, which is not a source at all
+// and derives its own synthetic fingerprints.
 //
-// Instant recall's Gate 3 weighs a candidate entry by its recorded track record,
-// and is deliberately fail-safe: an entry the outcome ledger has never seen scores
-// factor 1 and fires (absence of evidence must never block a recall). The
-// corollary is that a ledger which never accumulates ground truth turns that gate
-// into a silent no-op for EVERY entry — and the retirement pass, which shares the
-// same factor and floor, into one that can never propose anything. Trust stops
-// being derived from whether the entry actually worked, which is the claim the
-// whole learning loop rests on.
+// "Capable", not "will": for an enabled webhook source, whether the operator wired
+// resolves through (Alertmanager's send_resolved, a custom mapping's `resolved`
+// field) stays outside RunLore's config and outside this answer.
+func ResolveCapableSource(built []source.Built) bool {
+	for _, b := range built {
+		if b.Desc.Kind == source.Webhook {
+			return true
+		}
+	}
+	return false
+}
+
+// RecallDecayWarning decides the startup warning for a learning loop whose feedback
+// edge cannot be shown to accumulate ground truth, returning "" when no warning is
+// warranted. resolveCapable comes from ResolveCapableSource and decides how much the
+// warning is entitled to claim.
 //
-// Ground truth reaches the ledger through two channels, and only one of them is
+// Instant recall's Gate 3 weighs a candidate entry by its recorded track record and
+// is deliberately fail-safe: an entry the outcome ledger has never seen scores factor
+// 1 and fires (absence of evidence must never block a recall). A ledger that
+// accumulates no ground truth therefore degrades that gate — and the retirement pass,
+// which shares the same factor and floor — but NOT uniformly, and that difference is
+// the whole reason there are two messages below.
+//
+// Ground truth reaches the ledger through three paths, only one of which is fully
 // observable from here:
 //
-//   - Human 👍/👎 feedback — opt-in on both notifiers, so its state IS in this
-//     config.
-//   - Resolve events from the incident source — NOT determinable at startup.
-//     `sources` records which adapters are enabled, not whether they emit
-//     resolves, and Alertmanager's `send_resolved` lives in the operator's
-//     receiver config, which RunLore never reads. Resolvability is decided
-//     per event from the fingerprint at record time (see the ledger.Open call in
-//     investigate.go), a runtime fact this function cannot anticipate.
+//   - Human 👍/👎 feedback — opt-in on both notifiers, so its state IS in this config.
+//   - Resolve events from the incident source. Whether a resolve can EVER arrive is
+//     determinable (ResolveCapableSource, off the registry's Kind); whether it
+//     actually does is not — Alertmanager's `send_resolved` lives in the operator's
+//     receiver config, which RunLore never reads.
+//   - Machine confirmations (outcome.Ledger.Confirm) — a FRESH investigation that
+//     re-derives an existing entry's DupFingerprint. Wired unconditionally on the
+//     serve path (cur.Confirmations in investigate.go), it needs no feedback channel
+//     and no resolve, and folds into the same Aggregate.Factor at confirmWeight. So
+//     the gate is never a no-op for literally every entry, and neither message claims
+//     it is: confirms are recovery evidence only — they can lift an entry, never sink
+//     one, and retirement ignores them (its observation count is recalls + votes).
 //
-// So the warning names the risk it can actually establish — neither feedback
-// channel is on, leaving an unverifiable resolve channel as the only remaining
-// source of truth — and explicitly does not claim resolves never arrive. It stays
-// a warning, never a hard failure: a deployment whose Alertmanager does send
-// resolves is correctly configured.
+// What actually happens when the resolve channel is silent depends on the FINGERPRINT,
+// and the two cases fail in OPPOSITE directions:
 //
-// Silent when instant recall is off (nothing recalls, so there is no trust to
-// decay) or when outcome.ledger_path is unset (the operator turned the learning
-// loop off, which `lore curate` likewise reports as an info, not a warning).
-func RecallDecayWarning(cfg *config.Config) string {
+//   - A synthetic fingerprint (GitOps failure, re-investigate poll) is recorded
+//     Resolvable=false, so applyOpenLocked never counts it. The entry never enters
+//     OpenCounts, outcomeGate returns (1, true), and it keeps firing at full trust
+//     however wrong it has become.
+//   - A REAL alert fingerprint is recorded Resolvable=true whether or not a resolve
+//     ever follows: resolvability is derived from the fingerprint prefix alone
+//     (`resolvable := !outcome.Derived(fp)` in investigate.go), never from
+//     send_resolved, which RunLore cannot see. Each recall increments Recalls while
+//     Resolved stays 0, the factor falls monotonically, and the entry is REJECTED
+//     once it crosses outcome_floor — one unresolved recall already suffices at the
+//     defaults (prior 2, floor 0.5 ⇒ factor 1/3). A rejected recall records nothing,
+//     so it stays there; and because retirement counts recalls, the frozen count
+//     never reaches min_observations either. The entry is neither used nor retired.
+//
+// A message naming only the first case would tell an Alertmanager operator the
+// opposite of what will happen to them, so both are named whenever both are possible.
+// The warning never hard-fails: a deployment whose source does send resolves is
+// correctly configured, and the hedged variant says so outright.
+//
+// Silent when instant recall is off (nothing recalls, so there is no trust to decay)
+// or when outcome.ledger_path is unset (the operator turned the learning loop off,
+// which `lore curate` likewise reports as an info, not a warning).
+func RecallDecayWarning(cfg *config.Config, resolveCapable bool) string {
 	if !cfg.Catalog.InstantRecall.Enabled || cfg.Outcome.LedgerPath == "" {
 		return ""
 	}
 	if cfg.Notify.Slack.FeedbackButtons || cfg.Notify.Matrix.FeedbackReactions {
 		return ""
 	}
-	return "instant recall is enabled with an outcome ledger, but no feedback channel is on " +
-		"(notify.slack.feedback_buttons and notify.matrix.feedback_reactions are both off): the only " +
-		"remaining way an entry can earn or lose trust is a resolved-alert webhook from your incident " +
-		"source, and whether yours sends those is not in this config — RunLore cannot tell from here. " +
-		"Where they do not arrive, recall confidence never moves and no entry is ever proposed for " +
-		"retirement: a knowledge entry that has stopped working keeps being recalled at full trust. " +
-		"Turn on notify.slack.feedback_buttons or notify.matrix.feedback_reactions, and keep " +
+	const fix = "Turn on notify.slack.feedback_buttons or notify.matrix.feedback_reactions, and keep " +
 		"outcome.ledger_path on a persistent volume so what it records survives a restart " +
 		"(docs/concepts/learning-loop.md)"
+	if !resolveCapable {
+		// No hedge is warranted here: every enabled source is a watcher, so no resolve
+		// can reach the ledger by construction and only the full-trust case is reachable.
+		return "instant recall is enabled with an outcome ledger, but nothing can write ground truth to " +
+			"it: no feedback channel is on (notify.slack.feedback_buttons and " +
+			"notify.matrix.feedback_reactions are both off) and no enabled source can deliver a resolve " +
+			"event at all — watcher sources (GitOps failures) and the re-investigate poller carry " +
+			"synthetic fingerprints no resolved-alert webhook can ever match. Recalled entries therefore " +
+			"stay at full trust indefinitely: outcome decay never rejects one and retirement never " +
+			"proposes one, so an entry that has stopped working keeps being recalled and nothing surfaces " +
+			"it for review. A human 👍/👎 is the only ground truth this deployment can accumulate. " + fix
+	}
+	return "instant recall is enabled with an outcome ledger, but no feedback channel is on " +
+		"(notify.slack.feedback_buttons and notify.matrix.feedback_reactions are both off), leaving a " +
+		"resolved-alert webhook from your incident source as the only ground truth that can move an " +
+		"entry's trust — and whether yours sends those is not in this config, so RunLore cannot tell " +
+		"from here. If they arrive, decay works and this line is safe to ignore. If they do not, trust " +
+		"goes wrong in BOTH directions. An entry recalled against a real alert fingerprint has the " +
+		"recall counted and the resolve never recorded, so its factor falls until it crosses " +
+		"catalog.instant_recall.outcome_floor and instant recall STOPS FIRING it — one unresolved " +
+		"recall already suffices at the defaults, and a rejected recall records nothing, so it stays " +
+		"there. An entry recalled from a source with no resolve channel (GitOps failures, " +
+		"re-investigate polls) never enters the ledger roll-up at all and keeps being recalled at full " +
+		"trust however stale it is. Neither reaches retirement, so nothing surfaces either failure for " +
+		"review. " + fix
 }
 
 // RequirePagerDutyAuth is the PagerDuty analogue of RequireWebhookAuth. The

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -3,10 +3,15 @@
 package app
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/source"
 )
 
 // TestRequireWebhookAuth asserts the serve-path fail-closed guard: a configured
@@ -117,22 +122,54 @@ func TestRequirePagerDutyAuth(t *testing.T) {
 	}
 }
 
+// webhookSource / watcherSource are the two adapter shapes ResolveCapableSource
+// distinguishes. Only Desc.Kind is read, so the Impl may be nil.
+var (
+	webhookSource = source.Built{Desc: source.Descriptor{Name: "alertmanager", Kind: source.Webhook}}
+	watcherSource = source.Built{Desc: source.Descriptor{Name: "gitops", Kind: source.Watcher}}
+)
+
+// TestResolveCapableSource pins the capability read to the adapter CONTRACT rather
+// than to a list of source names. A Webhook source's Decode returns a DecodeResult
+// carrying Resolved; a Watcher's Watch returns a request channel with nowhere to put
+// a resolution — so "can a resolve ever arrive?" is answerable from Kind alone, and
+// stays answerable when a new source registers.
+func TestResolveCapableSource(t *testing.T) {
+	tests := []struct {
+		name  string
+		built []source.Built
+		want  bool
+	}{
+		{"no sources at all → nothing can resolve", nil, false},
+		{"watcher only (GitOps failures) → nothing can resolve", []source.Built{watcherSource}, false},
+		{"webhook only → a resolve is possible", []source.Built{webhookSource}, true},
+		{"webhook + watcher → a resolve is possible", []source.Built{watcherSource, webhookSource}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveCapableSource(tc.built); got != tc.want {
+				t.Errorf("ResolveCapableSource(%v) = %v, want %v", tc.built, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestRecallDecayWarning covers the (instant recall × outcome ledger × feedback
 // channel) matrix behind the learning loop's feedback edge.
 //
-// Gate 3 (outcome decay) is fail-safe: an entry absent from the ledger's
-// OpenCounts returns factor 1 and fires. That is correct — absence of evidence
-// must never block a recall — but it means a ledger that never accumulates ground
-// truth turns the gate into a silent no-op for EVERY entry, and the retirement
-// pass (same factor, same floor) into one that can never propose anything.
+// Gate 3 (outcome decay) is fail-safe: an entry absent from the ledger's OpenCounts
+// returns factor 1 and fires. That is correct — absence of evidence must never block
+// a recall — but it means a ledger that accumulates no ground truth stops deriving
+// trust from whether an entry actually worked, and the retirement pass (same factor,
+// same floor) loses the evidence it proposes on.
 //
-// Ground truth reaches the ledger through exactly two channels, and human
-// feedback is the only one this process can observe from its own config. So the
-// warning fires on the one combination that is knowably at risk: recall on, a
-// ledger configured to hold the evidence, and neither feedback channel enabled.
-// Recall off ⇒ nothing recalls, so there is no trust to decay. Ledger unset ⇒ the
-// operator turned the learning loop off deliberately (the `lore curate` precedent
-// treats that as an info, not a warning), so nagging about it would be noise.
+// Human feedback is the one ground-truth path fully readable from this config, so the
+// warning fires on the combination that is knowably at risk: recall on, a ledger
+// configured to hold the evidence, and neither feedback channel enabled. Recall off ⇒
+// nothing recalls, so there is no trust to decay. Ledger unset ⇒ the operator turned
+// the learning loop off deliberately (the `lore curate` precedent treats that as an
+// info, not a warning), so nagging about it would be noise. The predicate is
+// independent of resolveCapable — that only decides the WORDING.
 func TestRecallDecayWarning(t *testing.T) {
 	const ledger = "/var/lib/runlore/catalog/outcomes.jsonl"
 	tests := []struct {
@@ -143,7 +180,7 @@ func TestRecallDecayWarning(t *testing.T) {
 		matrix     bool
 		wantWarn   bool
 	}{
-		{"recall + ledger + no feedback → warns (the edge is inert)", true, ledger, false, false, true},
+		{"recall + ledger + no feedback → warns (the edge is unverifiable)", true, ledger, false, false, true},
 		{"recall + ledger + slack buttons → silent", true, ledger, true, false, false},
 		{"recall + ledger + matrix reactions → silent", true, ledger, false, true, false},
 		{"recall + ledger + both channels → silent", true, ledger, true, true, false},
@@ -154,77 +191,212 @@ func TestRecallDecayWarning(t *testing.T) {
 		{"no recall + no ledger → silent", false, "", false, false, false},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := &config.Config{}
-			cfg.Catalog.InstantRecall.Enabled = tc.recall
-			cfg.Outcome.LedgerPath = tc.ledgerPath
-			cfg.Notify.Slack.FeedbackButtons = tc.slack
-			cfg.Notify.Matrix.FeedbackReactions = tc.matrix
+		for _, capable := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s [resolve_capable=%v]", tc.name, capable), func(t *testing.T) {
+				cfg := &config.Config{}
+				cfg.Catalog.InstantRecall.Enabled = tc.recall
+				cfg.Outcome.LedgerPath = tc.ledgerPath
+				cfg.Notify.Slack.FeedbackButtons = tc.slack
+				cfg.Notify.Matrix.FeedbackReactions = tc.matrix
 
-			got := RecallDecayWarning(cfg)
-			if (got != "") != tc.wantWarn {
-				t.Fatalf("RecallDecayWarning(recall=%v, ledger=%q, slack=%v, matrix=%v) = %q, wantWarn = %v",
-					tc.recall, tc.ledgerPath, tc.slack, tc.matrix, got, tc.wantWarn)
-			}
-			if !tc.wantWarn {
-				return
-			}
-			// The message has to be actionable: name both fixes (a feedback channel,
-			// and persisting the ledger) and the doc that explains the edge.
-			for _, want := range []string{
-				"notify.slack.feedback_buttons",
-				"notify.matrix.feedback_reactions",
-				"outcome.ledger_path",
-				"persistent volume",
-				"docs/concepts/learning-loop.md",
-			} {
-				if !strings.Contains(got, want) {
-					t.Errorf("warning is missing the fix pointer %q: %q", want, got)
+				got := RecallDecayWarning(cfg, capable)
+				if (got != "") != tc.wantWarn {
+					t.Fatalf("RecallDecayWarning(recall=%v, ledger=%q, slack=%v, matrix=%v, capable=%v) = %q, wantWarn = %v",
+						tc.recall, tc.ledgerPath, tc.slack, tc.matrix, capable, got, tc.wantWarn)
 				}
-			}
-			// …and it has to state the CONSEQUENCE an operator cares about, not the
-			// mechanism: a stale entry keeps being trusted.
-			if !strings.Contains(got, "full trust") {
-				t.Errorf("warning does not state the operator-visible consequence: %q", got)
-			}
-		})
+				if !tc.wantWarn {
+					return
+				}
+				// The message has to be actionable: name both fixes (a feedback channel,
+				// and persisting the ledger) and the doc that explains the edge.
+				for _, want := range []string{
+					"notify.slack.feedback_buttons",
+					"notify.matrix.feedback_reactions",
+					"outcome.ledger_path",
+					"persistent volume",
+					"docs/concepts/learning-loop.md",
+				} {
+					if !strings.Contains(got, want) {
+						t.Errorf("warning is missing the fix pointer %q: %q", want, got)
+					}
+				}
+			})
+		}
 	}
 }
 
-// TestRecallDecayWarningDoesNotAssertTheResolveChannelIsDead is the honesty guard.
+// TestRecallDecayWarningStatesWhatActuallyHappens is a DRIFT GUARD over the real
+// ledger: it MEASURES what a silent resolve channel does to an entry, then requires
+// the warning to say that and not its opposite.
 //
-// Nothing in RunLore's configuration says whether the incident source actually
-// emits resolves: `sources` records enablement only, and Alertmanager's
-// `send_resolved` lives in the operator's receiver config, which RunLore never
-// reads. (internal/app/investigate.go decides resolvability per event, from the
-// fingerprint — a runtime fact, not a startup one.) So the warning may say the
-// resolve channel is the only one LEFT, and that we cannot see it from here; it
-// must not claim resolves never arrive. A deployment whose Alertmanager does send
-// them is fine, and telling that operator their loop is broken would be a lie
-// that trains them to ignore the line.
-func TestRecallDecayWarningDoesNotAssertTheResolveChannelIsDead(t *testing.T) {
+// This exists because the first version of the warning claimed one consequence —
+// "keeps being recalled at full trust" — for both fingerprint shapes, and that is
+// only true for one of them. The measurement below is the evidence:
+//
+//   - a REAL alert fingerprint is recorded Resolvable=true (resolvability comes from
+//     outcome.Derived(fp), never from send_resolved), so Recalls climbs while Resolved
+//     stays 0 and the factor drops UNDER the default floor after a single recall. The
+//     entry stops being recalled. Telling that operator their entry keeps firing at
+//     full trust is precisely backwards.
+//   - a DERIVED fingerprint (GitOps, re-investigate) is Resolvable=false and never
+//     enters OpenCounts at all, so outcomeGate's fail-safe returns factor 1: that one
+//     really does keep firing at full trust.
+//
+// The keyword assertions are only as good as the measurement they hang off, which is
+// the point: if the resolvable rule, the Factor formula or the defaults change so that
+// a real fingerprint no longer decays, the MEASUREMENT half fails first and forces
+// whoever changed it to revisit the prose.
+func TestRecallDecayWarningStatesWhatActuallyHappens(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Catalog.InstantRecall.Enabled = true
+	cfg.Outcome.LedgerPath = "/var/lib/runlore/catalog/outcomes.jsonl"
+	config.ApplyDefaults(cfg)
+	prior, floor := cfg.Catalog.InstantRecall.OutcomePrior, cfg.Catalog.InstantRecall.OutcomeFloor
+
+	led, err := outcome.New(filepath.Join(t.TempDir(), "outcomes.jsonl"))
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	now := time.Now()
+	open := func(fp, entry string) {
+		t.Helper()
+		resolvable := !outcome.Derived(fp) // exactly what investigate.go stamps
+		if err := led.Open(outcome.Event{
+			Fingerprint: fp, Kind: "recall", Entry: entry,
+			Resolvable: &resolvable, At: now, StartedAt: now.Add(-time.Minute),
+		}); err != nil {
+			t.Fatalf("open %s: %v", fp, err)
+		}
+	}
+
+	// A real alert fingerprint, recalled once, never resolved.
+	const realEntry = "kb/real.md"
+	open("a1b2c3d4e5f6a7b8", realEntry)
+	counts, err := led.OpenCounts()
+	if err != nil {
+		t.Fatalf("open counts: %v", err)
+	}
+	agg, seen := counts[realEntry]
+	if !seen {
+		t.Fatalf("a resolvable recall must enter OpenCounts; got %v", counts)
+	}
+	factor := agg.Factor(prior)
+	if factor >= floor {
+		t.Fatalf("MEASUREMENT CHANGED: one unresolved recall now scores %.4f, at or above the "+
+			"floor %.2f (prior %.1f) — the warning's 'stops firing' claim may no longer hold; "+
+			"re-measure before editing the prose", factor, floor, prior)
+	}
+
+	// A derived fingerprint, recalled once: never counted, so never decays.
+	const derivedEntry = "kb/gitops.md"
+	open(outcome.DeriveFingerprint(outcome.GitOpsFingerprintPrefix, "ns/app|Failed"), derivedEntry)
+	counts, err = led.OpenCounts()
+	if err != nil {
+		t.Fatalf("open counts: %v", err)
+	}
+	if _, seen := counts[derivedEntry]; seen {
+		t.Fatalf("MEASUREMENT CHANGED: a derived-fingerprint recall now enters OpenCounts — the "+
+			"warning's 'full trust' claim may no longer hold; got %v", counts[derivedEntry])
+	}
+
+	// Now hold the prose to both measured outcomes. Both are reachable wherever a
+	// webhook source is enabled (a deployment may run Alertmanager AND the GitOps
+	// watcher), so the hedged variant must name both.
+	hedged := RecallDecayWarning(cfg, true)
+	if hedged == "" {
+		t.Fatal("expected the warning to fire for recall + ledger + no feedback")
+	}
+	for _, want := range []string{
+		"outcome_floor", // the decay-to-rejection case, measured above
+		"STOPS FIRING",
+		"full trust", // the derived-fingerprint case, also measured above
+	} {
+		if !strings.Contains(hedged, want) {
+			t.Errorf("hedged warning must state the measured consequence %q: %q", want, hedged)
+		}
+	}
+	// The failure this guard was written for: naming ONLY the benign case. A message
+	// that says trust never moves is the opposite of the measurement above.
+	lower := strings.ToLower(hedged)
+	for _, forbidden := range []string{
+		"confidence never moves",
+		"trust never moves",
+		"never decays",
+		"no entry is ever proposed for retirement: a knowledge entry that has stopped working keeps being recalled at full trust",
+	} {
+		if strings.Contains(lower, forbidden) {
+			t.Errorf("warning claims %q, contradicting the measured decay-to-rejection case: %q", forbidden, hedged)
+		}
+	}
+
+	// With no webhook source enabled, the decay case is UNREACHABLE — every
+	// fingerprint is derived — so the strong variant must not threaten the operator
+	// with a rejection that cannot happen to them.
+	strong := RecallDecayWarning(cfg, false)
+	if !strings.Contains(strong, "full trust") {
+		t.Errorf("watcher-only warning must state the full-trust consequence: %q", strong)
+	}
+	if strings.Contains(strong, "STOPS FIRING") || strings.Contains(strong, "outcome_floor") {
+		t.Errorf("watcher-only warning must not threaten a floor rejection that cannot occur "+
+			"without a resolvable fingerprint: %q", strong)
+	}
+}
+
+// TestRecallDecayWarningHedgesOnlyWhereItMust splits the honesty question in two.
+//
+// Where a webhook source IS enabled, whether resolves actually arrive is unknowable:
+// Alertmanager's `send_resolved` lives in the operator's receiver config, which
+// RunLore never reads, and a custom mapping's `resolved` field is per-instance. The
+// message may say the resolve channel is the only one LEFT and that we cannot see it;
+// it must not claim resolves never arrive. Telling a correctly-configured operator
+// their loop is broken is the lie that trains people to ignore the line.
+//
+// Where NO webhook source is enabled the opposite applies: a watcher's Watch returns
+// investigation requests only, so no resolve can arrive by construction. Hedging there
+// understates a fact RunLore can prove, and hedged warnings get ignored too.
+func TestRecallDecayWarningHedgesOnlyWhereItMust(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Catalog.InstantRecall.Enabled = true
 	cfg.Outcome.LedgerPath = "/var/lib/runlore/catalog/outcomes.jsonl"
 
-	got := RecallDecayWarning(cfg)
-	if got == "" {
-		t.Fatal("expected the warning to fire for recall + ledger + no feedback")
+	hedged := RecallDecayWarning(cfg, true)
+	if !strings.Contains(hedged, "cannot tell from here") {
+		t.Errorf("with a webhook source enabled the warning must hedge on the resolve channel "+
+			"it cannot observe: %q", hedged)
 	}
-	if !strings.Contains(got, "cannot tell from here") {
-		t.Errorf("warning must hedge on the resolve channel it cannot observe: %q", got)
+	if !strings.Contains(hedged, "safe to ignore") {
+		t.Errorf("the hedged warning must tell an operator whose source DOES resolve that they "+
+			"are fine, or it reads as a false alarm: %q", hedged)
 	}
-	// Phrasings that would state the unobservable as fact.
-	lower := strings.ToLower(got)
+	// Phrasings that would state the unobservable as fact. These target claims about
+	// whether resolves ARRIVE, which is what RunLore cannot see. They deliberately do
+	// NOT forbid "no resolve channel": that describes GitOps/re-investigate sources,
+	// whose synthetic fingerprints no resolve can match by construction — a proven
+	// fact, and one the message needs. A blunter blacklist ("no resolve") rejected the
+	// true statement along with the false ones.
+	lower := strings.ToLower(hedged)
 	for _, forbidden := range []string{
-		"no resolve",
-		"never resolve",
-		"resolves never",
+		"resolves never arrive",
+		"no resolves arrive",
+		"sends no resolves",
+		"does not send resolves",
+		"your source will not",
 		"will stay empty",
 	} {
 		if strings.Contains(lower, forbidden) {
-			t.Errorf("warning asserts %q, which this process cannot determine: %q", forbidden, got)
+			t.Errorf("warning asserts %q, which this process cannot determine: %q", forbidden, hedged)
 		}
+	}
+
+	// The watcher-only variant is entitled to assert it, and should: the hedge would
+	// be false modesty about something the source contract settles.
+	strong := RecallDecayWarning(cfg, false)
+	if strings.Contains(strong, "cannot tell from here") {
+		t.Errorf("with no webhook source enabled, resolvability IS determinable — the warning "+
+			"must not hedge: %q", strong)
+	}
+	if !strings.Contains(strong, "no enabled source can deliver a resolve event") {
+		t.Errorf("watcher-only warning must state the proven fact it rests on: %q", strong)
 	}
 }
 

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -117,6 +117,116 @@ func TestRequirePagerDutyAuth(t *testing.T) {
 	}
 }
 
+// TestRecallDecayWarning covers the (instant recall × outcome ledger × feedback
+// channel) matrix behind the learning loop's feedback edge.
+//
+// Gate 3 (outcome decay) is fail-safe: an entry absent from the ledger's
+// OpenCounts returns factor 1 and fires. That is correct — absence of evidence
+// must never block a recall — but it means a ledger that never accumulates ground
+// truth turns the gate into a silent no-op for EVERY entry, and the retirement
+// pass (same factor, same floor) into one that can never propose anything.
+//
+// Ground truth reaches the ledger through exactly two channels, and human
+// feedback is the only one this process can observe from its own config. So the
+// warning fires on the one combination that is knowably at risk: recall on, a
+// ledger configured to hold the evidence, and neither feedback channel enabled.
+// Recall off ⇒ nothing recalls, so there is no trust to decay. Ledger unset ⇒ the
+// operator turned the learning loop off deliberately (the `lore curate` precedent
+// treats that as an info, not a warning), so nagging about it would be noise.
+func TestRecallDecayWarning(t *testing.T) {
+	const ledger = "/var/lib/runlore/catalog/outcomes.jsonl"
+	tests := []struct {
+		name       string
+		recall     bool
+		ledgerPath string
+		slack      bool
+		matrix     bool
+		wantWarn   bool
+	}{
+		{"recall + ledger + no feedback → warns (the edge is inert)", true, ledger, false, false, true},
+		{"recall + ledger + slack buttons → silent", true, ledger, true, false, false},
+		{"recall + ledger + matrix reactions → silent", true, ledger, false, true, false},
+		{"recall + ledger + both channels → silent", true, ledger, true, true, false},
+		{"recall + no ledger → silent (learning loop off by choice)", true, "", false, false, false},
+		{"recall + no ledger + slack buttons → silent", true, "", true, false, false},
+		{"no recall + ledger + no feedback → silent (nothing recalls)", false, ledger, false, false, false},
+		{"no recall + ledger + both channels → silent", false, ledger, true, true, false},
+		{"no recall + no ledger → silent", false, "", false, false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Catalog.InstantRecall.Enabled = tc.recall
+			cfg.Outcome.LedgerPath = tc.ledgerPath
+			cfg.Notify.Slack.FeedbackButtons = tc.slack
+			cfg.Notify.Matrix.FeedbackReactions = tc.matrix
+
+			got := RecallDecayWarning(cfg)
+			if (got != "") != tc.wantWarn {
+				t.Fatalf("RecallDecayWarning(recall=%v, ledger=%q, slack=%v, matrix=%v) = %q, wantWarn = %v",
+					tc.recall, tc.ledgerPath, tc.slack, tc.matrix, got, tc.wantWarn)
+			}
+			if !tc.wantWarn {
+				return
+			}
+			// The message has to be actionable: name both fixes (a feedback channel,
+			// and persisting the ledger) and the doc that explains the edge.
+			for _, want := range []string{
+				"notify.slack.feedback_buttons",
+				"notify.matrix.feedback_reactions",
+				"outcome.ledger_path",
+				"persistent volume",
+				"docs/concepts/learning-loop.md",
+			} {
+				if !strings.Contains(got, want) {
+					t.Errorf("warning is missing the fix pointer %q: %q", want, got)
+				}
+			}
+			// …and it has to state the CONSEQUENCE an operator cares about, not the
+			// mechanism: a stale entry keeps being trusted.
+			if !strings.Contains(got, "full trust") {
+				t.Errorf("warning does not state the operator-visible consequence: %q", got)
+			}
+		})
+	}
+}
+
+// TestRecallDecayWarningDoesNotAssertTheResolveChannelIsDead is the honesty guard.
+//
+// Nothing in RunLore's configuration says whether the incident source actually
+// emits resolves: `sources` records enablement only, and Alertmanager's
+// `send_resolved` lives in the operator's receiver config, which RunLore never
+// reads. (internal/app/investigate.go decides resolvability per event, from the
+// fingerprint — a runtime fact, not a startup one.) So the warning may say the
+// resolve channel is the only one LEFT, and that we cannot see it from here; it
+// must not claim resolves never arrive. A deployment whose Alertmanager does send
+// them is fine, and telling that operator their loop is broken would be a lie
+// that trains them to ignore the line.
+func TestRecallDecayWarningDoesNotAssertTheResolveChannelIsDead(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Catalog.InstantRecall.Enabled = true
+	cfg.Outcome.LedgerPath = "/var/lib/runlore/catalog/outcomes.jsonl"
+
+	got := RecallDecayWarning(cfg)
+	if got == "" {
+		t.Fatal("expected the warning to fire for recall + ledger + no feedback")
+	}
+	if !strings.Contains(got, "cannot tell from here") {
+		t.Errorf("warning must hedge on the resolve channel it cannot observe: %q", got)
+	}
+	// Phrasings that would state the unobservable as fact.
+	for _, forbidden := range []string{
+		"no resolve",
+		"never resolve",
+		"resolves never",
+		"will stay empty",
+	} {
+		if strings.Contains(strings.ToLower(got), forbidden) {
+			t.Errorf("warning asserts %q, which this process cannot determine: %q", forbidden, got)
+		}
+	}
+}
+
 // TestModelProvider locks in the provider-name normalization: anthropic/gemini
 // pass through; everything else (including "" and unknown) defaults to "openai".
 func TestModelProvider(t *testing.T) {

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -215,13 +215,14 @@ func TestRecallDecayWarningDoesNotAssertTheResolveChannelIsDead(t *testing.T) {
 		t.Errorf("warning must hedge on the resolve channel it cannot observe: %q", got)
 	}
 	// Phrasings that would state the unobservable as fact.
+	lower := strings.ToLower(got)
 	for _, forbidden := range []string{
 		"no resolve",
 		"never resolve",
 		"resolves never",
 		"will stay empty",
 	} {
-		if strings.Contains(strings.ToLower(got), forbidden) {
+		if strings.Contains(lower, forbidden) {
 			t.Errorf("warning asserts %q, which this process cannot determine: %q", forbidden, got)
 		}
 	}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -178,6 +178,14 @@ func RunServe(version string, args []string) error {
 	if cfg.Outcome.LedgerPath != "" {
 		log.Info("outcome ledger enabled", "path", cfg.Outcome.LedgerPath, "max_events", maxEvents)
 	}
+	// A ledger that never accumulates ground truth leaves instant recall's outcome
+	// gate a no-op for every entry (it is fail-safe by design, so it degrades to
+	// "allow") and the retirement pass with nothing to propose — silently. Say it
+	// once here, at startup, rather than per investigation. See RecallDecayWarning
+	// for what this can and cannot establish about the two ground-truth channels.
+	if msg := RecallDecayWarning(cfg); msg != "" {
+		log.Warn(msg)
+	}
 
 	// Built ONCE and shared: a second Deps means a second catalog, hence a second
 	// git-sync goroutine racing the first on the same on-disk checkout.

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -178,15 +178,6 @@ func RunServe(version string, args []string) error {
 	if cfg.Outcome.LedgerPath != "" {
 		log.Info("outcome ledger enabled", "path", cfg.Outcome.LedgerPath, "max_events", maxEvents)
 	}
-	// A ledger that never accumulates ground truth leaves instant recall's outcome
-	// gate a no-op for every entry (it is fail-safe by design, so it degrades to
-	// "allow") and the retirement pass with nothing to propose — silently. Say it
-	// once here, at startup, rather than per investigation. See RecallDecayWarning
-	// for what this can and cannot establish about the two ground-truth channels.
-	if msg := RecallDecayWarning(cfg); msg != "" {
-		log.Warn(msg)
-	}
-
 	// Built ONCE and shared: a second Deps means a second catalog, hence a second
 	// git-sync goroutine racing the first on the same on-disk checkout.
 	deps := BuildDeps(ctx, cfg, gitops, metrics, ledger, log)
@@ -279,6 +270,22 @@ func RunServe(version string, args []string) error {
 	built, err := source.BuildEnabled(source.Deps{Cfg: cfg, GitOps: gitops, Log: log, Raw: cfg.Sources})
 	if err != nil {
 		return fmt.Errorf("build sources: %w", err)
+	}
+	// A ledger that accumulates no ground truth degrades instant recall's outcome gate
+	// and the retirement pass — in opposite directions depending on the fingerprint,
+	// and silently either way. Raised HERE rather than beside the ledger construction
+	// above because the honest wording depends on `built`: with no webhook source
+	// enabled, no resolve can arrive by construction and the warning drops its hedge.
+	// Once, at startup — the condition is pure config, so anywhere on the incident path
+	// would repeat the same paragraph per alert. See RecallDecayWarning for what this
+	// can and cannot establish about the three ground-truth paths.
+	// resolve_capable_source is the one fact here a machine wants that the prose cannot
+	// give it: which of the two variants fired, without substring-matching a paragraph.
+	// The feedback flags are not worth emitting — the warning only exists when both are
+	// off — and the ledger path is already on the startup line above.
+	resolveCapable := ResolveCapableSource(built)
+	if msg := RecallDecayWarning(cfg, resolveCapable); msg != "" {
+		log.Warn(msg, "resolve_capable_source", resolveCapable)
 	}
 	// The queue (not alertEnq, which may be the coalescer) is wired as the
 	// pipeline's Canceller; the pipeline only calls it when

--- a/internal/app/serve_guard_test.go
+++ b/internal/app/serve_guard_test.go
@@ -70,15 +70,14 @@ func TestServeGuardFailClosed(t *testing.T) {
 // warning about it would be noise. `lore curate` already has its own ledger
 // startup report (LogLedgerStartup).
 func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
-	const guarded = "RecallDecayWarning"
-	allowed := map[string]bool{"RunServe": true}
+	const guarded, caller = "RecallDecayWarning", "RunServe"
 
 	files, err := filepath.Glob(filepath.Join(".", "*.go"))
 	if err != nil {
 		t.Fatalf("glob: %v", err)
 	}
 	fset := token.NewFileSet()
-	calls := map[string]int{}
+	callerCalls := 0
 
 	for _, path := range files {
 		if strings.HasSuffix(path, "_test.go") {
@@ -109,8 +108,9 @@ func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
 				if !ok || id.Name != guarded {
 					return true
 				}
-				calls[fn.Name.Name]++
-				if !allowed[fn.Name.Name] {
+				if fn.Name.Name == caller {
+					callerCalls++
+				} else {
 					t.Errorf("%s: %s calls %s — it must be raised once on the serve startup path, "+
 						"not per investigation", filepath.Base(path), fn.Name.Name, guarded)
 				}
@@ -119,8 +119,8 @@ func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
 		}
 	}
 
-	if calls["RunServe"] != 1 {
-		t.Fatalf("RunServe must call %s exactly once (got %d) — otherwise the startup warning "+
-			"is either absent or duplicated", guarded, calls["RunServe"])
+	if callerCalls != 1 {
+		t.Fatalf("%s must call %s exactly once (got %d) — otherwise the startup warning "+
+			"is either absent or duplicated", caller, guarded, callerCalls)
 	}
 }

--- a/internal/app/serve_guard_test.go
+++ b/internal/app/serve_guard_test.go
@@ -56,21 +56,43 @@ func TestServeGuardFailClosed(t *testing.T) {
 	})
 }
 
-// TestRecallDecayWarningIsEmittedOnceAtStartup pins WHERE the warning is raised.
+// TestRecallDecayWarningIsEmittedOnceAtStartup pins that the warning is RAISED —
+// computed, and actually logged — exactly once, on the serve startup path.
 //
-// The condition is pure config, so it is equally true on every incident — which is
-// exactly the failure mode to prevent. Called from the investigation path (or from
-// wireRecall, or the recall gate) it would repeat the same paragraph on every
-// alert and be muted within a day. It belongs on the serve startup path, once,
-// next to the other startup config warnings.
+// The condition is pure config, so it is equally true on every incident. Called from
+// the investigation path (or from wireRecall, or the recall gate) it would repeat the
+// same paragraph on every alert and be muted within a day. It belongs on the serve
+// startup path, once, next to the other startup config warnings.
+//
+// Counting call sites is NOT enough, and an earlier version of this guard that did
+// only that waved through both of the ways this has actually broken:
+//
+//   - `_ = RecallDecayWarning(cfg)` — computed and thrown away. This is the exact
+//     state an interrupted edit left on this branch: one call inside RunServe, guard
+//     green, warning never printed.
+//   - the call moved into a FuncLit that RunServe merely DEFINES (e.g. the per-alert
+//     `resolve` closure) — still lexically inside RunServe, so the count stayed 1,
+//     while the warning fired once per resolved alert.
+//
+// So the guard asserts three things about the single call site: it sits directly in
+// caller's own body and not in a nested function literal; its result is bound to a
+// real variable (not `_`); and that variable reaches a `.Warn(...)` call in the same
+// statement. Go's unused-variable rule covers the rest — `msg := f()` with msg unused
+// does not compile — so binding plus a Warn is the whole contract.
+//
+// KNOWN, ACCEPTED FALSE POSITIVE: extracting the call into a helper that RunServe
+// then calls once fails here, even though it is behaviour-preserving. That is the
+// deliberate trade — a pin that costs an occasional refactor an explicit update is
+// worth far more than one that green-lights a silent regression. Widen `caller` if
+// the helper is genuinely the better structure.
 //
 // `lore investigate` is deliberately NOT a caller: that one-shot CLI never wires a
 // ledger into Recall at all (see wireRecall — only the serve path calls it), so
 // outcome decay is off there by construction rather than by misconfiguration, and
-// warning about it would be noise. `lore curate` already has its own ledger
-// startup report (LogLedgerStartup).
+// warning about it would be noise. `lore curate` already has its own ledger startup
+// report (LogLedgerStartup).
 func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
-	const guarded, caller = "RecallDecayWarning", "RunServe"
+	const guarded, caller, raiser = "RecallDecayWarning", "RunServe", "Warn"
 
 	files, err := filepath.Glob(filepath.Join(".", "*.go"))
 	if err != nil {
@@ -99,7 +121,15 @@ func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
 			if !ok || fn.Body == nil || fn.Name.Name == guarded {
 				continue
 			}
+			// stack tracks the ancestry of the node being visited, so a call site can be
+			// judged by WHERE it sits, not merely by which function declares it.
+			var stack []ast.Node
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if n == nil {
+					stack = stack[:len(stack)-1]
+					return false
+				}
+				stack = append(stack, n)
 				call, ok := n.(*ast.CallExpr)
 				if !ok {
 					return true
@@ -108,12 +138,24 @@ func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
 				if !ok || id.Name != guarded {
 					return true
 				}
-				if fn.Name.Name == caller {
-					callerCalls++
-				} else {
-					t.Errorf("%s: %s calls %s — it must be raised once on the serve startup path, "+
-						"not per investigation", filepath.Base(path), fn.Name.Name, guarded)
+				if fn.Name.Name != caller {
+					t.Errorf("%s: %s calls %s — it must be raised on the serve startup path (%s), "+
+						"not from a helper or any other function",
+						filepath.Base(path), fn.Name.Name, guarded, caller)
+					return true
 				}
+				callerCalls++
+				// Lexically inside RunServe is not the same as running at startup: a
+				// FuncLit here is a closure RunServe hands to the incident path.
+				for _, anc := range stack[:len(stack)-1] {
+					if _, isLit := anc.(*ast.FuncLit); isLit {
+						t.Errorf("%s: %s calls %s inside a function literal — that runs whenever the "+
+							"closure runs (per alert / per resolve), not once at startup",
+							filepath.Base(path), caller, guarded)
+						return true
+					}
+				}
+				assertWarningIsRaised(t, filepath.Base(path), outermostStmt(stack), guarded, raiser)
 				return true
 			})
 		}
@@ -122,5 +164,81 @@ func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
 	if callerCalls != 1 {
 		t.Fatalf("%s must call %s exactly once (got %d) — otherwise the startup warning "+
 			"is either absent or duplicated", caller, guarded, callerCalls)
+	}
+}
+
+// outermostStmt returns the top-level statement of the enclosing function body that
+// contains the visited node — stack[0] is the *ast.BlockStmt body itself, so the next
+// statement down is the one whose whole subtree (an `if` with its init AND its body)
+// must be inspected together. Nil if the stack holds no statement.
+func outermostStmt(stack []ast.Node) ast.Stmt {
+	for _, n := range stack[1:] {
+		if s, ok := n.(ast.Stmt); ok {
+			return s
+		}
+	}
+	return nil
+}
+
+// assertWarningIsRaised checks the guarded call's result is bound to a real variable
+// and that the variable is passed to a `.Warn(...)` call within the same statement —
+// i.e. the warning is emitted, not computed and dropped. Go rejects an unused local,
+// so `_ = f()` and a bare `f()` are the only ways to discard the result, and both are
+// caught here.
+func assertWarningIsRaised(t *testing.T, file string, stmt ast.Stmt, guarded, raiser string) {
+	t.Helper()
+	if stmt == nil {
+		t.Errorf("%s: could not locate the statement calling %s", file, guarded)
+		return
+	}
+	bound := ""
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, rhs := range as.Rhs {
+			call, isCall := rhs.(*ast.CallExpr)
+			if !isCall {
+				continue
+			}
+			if id, isIdent := call.Fun.(*ast.Ident); !isIdent || id.Name != guarded {
+				continue
+			}
+			if i < len(as.Lhs) {
+				if lhs, isIdent := as.Lhs[i].(*ast.Ident); isIdent && lhs.Name != "_" {
+					bound = lhs.Name
+				}
+			}
+		}
+		return true
+	})
+	if bound == "" {
+		t.Errorf("%s: the result of %s is discarded (assigned to `_`, or called as a bare "+
+			"statement) — it must be bound and logged, or the warning is computed and never printed",
+			file, guarded)
+		return
+	}
+	raised := false
+	ast.Inspect(stmt, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != raiser {
+			return true
+		}
+		for _, arg := range call.Args {
+			if id, isIdent := arg.(*ast.Ident); isIdent && id.Name == bound {
+				raised = true
+			}
+		}
+		return true
+	})
+	if !raised {
+		t.Errorf("%s: %s is bound to %q but never passed to a .%s(...) call in the same "+
+			"statement — the warning is computed and never raised",
+			file, guarded, bound, raiser)
 	}
 }

--- a/internal/app/serve_guard_test.go
+++ b/internal/app/serve_guard_test.go
@@ -14,6 +14,12 @@ package app
 // on the serve path only (not in config.Validate) because `lore investigate`
 // legitimately needs a model without a webhook.
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/config"
@@ -48,4 +54,73 @@ func TestServeGuardFailClosed(t *testing.T) {
 			t.Fatalf("RequireWebhookAuth must accept when no model is configured: %v", err)
 		}
 	})
+}
+
+// TestRecallDecayWarningIsEmittedOnceAtStartup pins WHERE the warning is raised.
+//
+// The condition is pure config, so it is equally true on every incident — which is
+// exactly the failure mode to prevent. Called from the investigation path (or from
+// wireRecall, or the recall gate) it would repeat the same paragraph on every
+// alert and be muted within a day. It belongs on the serve startup path, once,
+// next to the other startup config warnings.
+//
+// `lore investigate` is deliberately NOT a caller: that one-shot CLI never wires a
+// ledger into Recall at all (see wireRecall — only the serve path calls it), so
+// outcome decay is off there by construction rather than by misconfiguration, and
+// warning about it would be noise. `lore curate` already has its own ledger
+// startup report (LogLedgerStartup).
+func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
+	const guarded = "RecallDecayWarning"
+	allowed := map[string]bool{"RunServe": true}
+
+	files, err := filepath.Glob(filepath.Join(".", "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	fset := token.NewFileSet()
+	calls := map[string]int{}
+
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path) //nolint:gosec // test-owned path in this package
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if !strings.Contains(string(src), guarded) {
+			continue
+		}
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Name.Name == guarded {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				id, ok := call.Fun.(*ast.Ident)
+				if !ok || id.Name != guarded {
+					return true
+				}
+				calls[fn.Name.Name]++
+				if !allowed[fn.Name.Name] {
+					t.Errorf("%s: %s calls %s — it must be raised once on the serve startup path, "+
+						"not per investigation", filepath.Base(path), fn.Name.Name, guarded)
+				}
+				return true
+			})
+		}
+	}
+
+	if calls["RunServe"] != 1 {
+		t.Fatalf("RunServe must call %s exactly once (got %d) — otherwise the startup warning "+
+			"is either absent or duplicated", guarded, calls["RunServe"])
+	}
 }


### PR DESCRIPTION
RunLore's headline claim is that a knowledge entry's trust is **derived from its real-world resolve rate**. In a default deployment that edge can be silently inert, and nothing tells the operator.

## Why it is silent

Instant recall's Gate 3 weighs a candidate by its recorded track record, and is deliberately fail-safe: an entry the outcome ledger has never seen scores factor 1 and fires — absence of evidence must never block a recall.

The corollary is that a ledger which never accumulates ground truth turns that gate into a no-op for **every** entry, and turns the retirement pass — which shares the same factor and floor — into one that can never propose anything. Trust stops being derived from whether the entry actually worked.

Ground truth reaches the ledger through two channels, and both are off in the shipped defaults:

- **Human 👍/👎 feedback** — opt-in on both notifiers (`notify.slack.feedback_buttons`, `notify.matrix.feedback_reactions`).
- **Resolve events** — GitOps failures and reinvestigate polls are excluded from resolve-based decay by construction (`outcome.Derived` / `Event.Resolvable`).

Additionally the chart ships `persistence.enabled: false`, so whatever does accumulate sits on an `emptyDir` and is wiped on restart.

## What this adds

One startup warning on the `serve` path, next to the existing `WebhookAuthWarning`, when instant recall is enabled with an outcome ledger and neither feedback channel is on.

**No gate behaviour changes.** `outcomeGate` and the retirement pass are untouched.

## What the warning deliberately does not claim

The resolve channel is **not determinable at startup** and the warning does not pretend otherwise:

- `sources` records which adapters are enabled, never whether they emit resolves;
- Alertmanager's `send_resolved` lives in the operator's receiver config, which RunLore never reads;
- resolvability is decided per event from the fingerprint at record time — a runtime fact.

Inferring it from the enabled-source set would mean hardcoding a resolve-capable source list in `internal/app` that would drift from `source.Registered()`, and the chart default enables `alertmanager` anyway, so the inference would not have fired on the broken default install. Doing it properly needs a `Resolves` capability on `source.Descriptor` — a sensible follow-up, out of scope here.

So the warning names the risk it can establish, hedges explicitly on the channel it cannot see, and stays a warning rather than a hard failure: a deployment whose Alertmanager does send resolves is correctly configured.

Silent when instant recall is off (nothing recalls, so there is no trust to decay) and when `outcome.ledger_path` is unset (a deliberate opt-out, which `lore curate` likewise reports as info, not warning).

## Tests

- `TestRecallDecayWarning` — 9-row table over recall x ledger x slack x matrix, plus fix-pointer and consequence assertions.
- `TestRecallDecayWarningDoesNotAssertTheResolveChannelIsDead` — honesty guard requiring the hedge and rejecting over-claiming phrasings.
- `TestRecallDecayWarningIsEmittedOnceAtStartup` — AST guard that `RunServe` calls it exactly once and nothing else calls it, which is what enforces "not per investigation".

All four guards were mutation-tested and each caught its regression: call removed, call moved into `wireRecall`, feedback check dropped, and the message hardened into the false claim.