### PR TITLE
fix(eval): distinguish an errored eval run from a genuine zero score

### DIFF
--- a/internal/app/eval_scorecard.go
+++ b/internal/app/eval_scorecard.go
@@ -37,6 +37,19 @@ func RunEvalScorecard(args []string) error {
 	if rep.Total == 0 {
 		return fmt.Errorf("report %s has no cases — refusing to publish an empty scorecard", *report)
 	}
+	// An ERRORED run (eval.Report.Errored: every case failed before anything could be
+	// scored) is PUBLISHED, labelled — not refused like the empty report above. The
+	// two look alike and are not. A report with no cases is malformed and carries no
+	// information, so writing it would replace the last real numbers with a blank. An
+	// errored run is well-formed and does carry information — the provider was
+	// unavailable on this date — and refusing it would leave the branch showing the
+	// previous green run, making a broken provider indistinguishable from a nightly
+	// that never fired. That silence is the failure mode the scorecard exists to
+	// prevent, so the run publishes with a grey badge, an "ERRORED" summary and an
+	// `errored` history line instead of as a 0% score.
+	if rep.Errored() {
+		fmt.Printf("scorecard: run %s ERRORED — no case produced a scoreable result; publishing it labelled, not as a 0%% score\n", rep.At)
+	}
 	if err := os.MkdirAll(*dir, 0o750); err != nil {
 		return err
 	}

--- a/internal/app/eval_scorecard_test.go
+++ b/internal/app/eval_scorecard_test.go
@@ -61,6 +61,64 @@ func TestRunEvalScorecard(t *testing.T) {
 	}
 }
 
+// erroredReportFixture is the 2026-08-02 nightly as it was actually written: the
+// provider returned nothing, so every case failed at the model boundary and no
+// tokens were billed.
+const erroredReportFixture = `{
+  "at": "2026-08-02T08:12:29Z",
+  "model": "anthropic/claude-haiku-4-5-20251001",
+  "n": 5, "pass_rate": 0, "reached": 0, "total": 2, "cost_usd": 0,
+  "cases": [
+    {"name": "harbor-chart-bump", "runs": 5, "pass_rate": 0, "reached": false, "confidence": 0,
+     "missing": ["investigation error: 401 authentication_error: invalid x-api-key"]},
+    {"name": "poisoned-recall-verify", "runs": 5, "pass_rate": 0, "reached": false, "confidence": 0,
+     "missing": ["investigation error: 401 authentication_error: invalid x-api-key"]}
+  ]
+}`
+
+// TestRunEvalScorecardPublishesErroredRunLabelled pins the publish-not-refuse
+// decision: an errored run still reaches the branch (a silent refusal would make a
+// broken provider look like a nightly that never ran), but none of the three
+// artifacts may present it as a 0% score.
+func TestRunEvalScorecardPublishesErroredRunLabelled(t *testing.T) {
+	dir := t.TempDir()
+	report := filepath.Join(dir, "2026-08-02T08-12-29Z-replay.json")
+	if err := os.WriteFile(report, []byte(erroredReportFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "scorecard")
+	if err := RunEvalScorecard([]string{"-report", report, "-dir", out}); err != nil {
+		t.Fatalf("an errored run must still publish, got: %v", err)
+	}
+
+	md, err := os.ReadFile(filepath.Join(out, "scorecard.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(md), "ERRORED") {
+		t.Fatalf("scorecard.md does not say the run errored:\n%s", md)
+	}
+	if strings.Contains(string(md), "scenarios reached (0%)") {
+		t.Fatalf("scorecard.md still publishes a pass-rate for a run that never ran:\n%s", md)
+	}
+
+	badge, err := os.ReadFile(filepath.Join(out, "badge.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(badge), `"color":"lightgrey"`) || strings.Contains(string(badge), "0%") {
+		t.Fatalf("badge.json still reads as a zero score: %s", badge)
+	}
+
+	hist, err := os.ReadFile(filepath.Join(out, "history.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(hist), `"errored":true`) {
+		t.Fatalf("history.jsonl does not carry the label durably: %s", hist)
+	}
+}
+
 func TestRunEvalScorecardRejectsMissingReport(t *testing.T) {
 	if err := RunEvalScorecard([]string{"-dir", t.TempDir()}); err == nil {
 		t.Fatal("want error when -report is missing")

--- a/internal/eval/compare_run.go
+++ b/internal/eval/compare_run.go
@@ -112,7 +112,7 @@ func (cr *ComparisonRunner) runOnce(ctx context.Context, c Case) ComparedRun {
 	}
 	req := investigate.Request{Source: investigate.SourceAlert, Title: c.Name, Message: c.Prompt}
 	if err := li.Investigate(ctx, req); err != nil {
-		return ComparedRun{Result: Result{Name: c.Name, Missing: []string{"investigation error: " + err.Error()}}}
+		return ComparedRun{Result: Result{Name: c.Name, Missing: []string{noteInvestigationError + err.Error()}}}
 	}
 	if !done {
 		return ComparedRun{Result: Result{Name: c.Name, Missing: []string{"no findings (loop did not submit)"}}}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -23,6 +23,16 @@ type Runner struct {
 	Log   *slog.Logger
 }
 
+// Run-error notes: the two Result.Missing entries that mean a repeat never produced
+// an answer to score at all, as opposed to answering something that was then judged
+// wrong. Report.Errored keys on these prefixes to tell a broken run apart from a
+// genuine zero, so producer and consumer share these constants instead of matching
+// literals across files — the coupling is a compiler edge, not a string coincidence.
+const (
+	noteInvestigationError  = "investigation error: "
+	noteCatalogFixtureError = "catalog fixture load error: "
+)
+
 func (r *Runner) runOne(ctx context.Context, c Case) Result {
 	tools := make([]investigate.Tool, 0, len(c.Tools))
 	for name, output := range c.Tools {
@@ -35,7 +45,7 @@ func (r *Runner) runOne(ctx context.Context, c Case) Result {
 	if c.CatalogDir != "" {
 		cat, err := catalog.New(filepath.Join(c.dir, c.CatalogDir))
 		if err != nil {
-			return Result{Name: c.Name, Missing: []string{"catalog fixture load error: " + err.Error()}}
+			return Result{Name: c.Name, Missing: []string{noteCatalogFixtureError + err.Error()}}
 		}
 		rc := c.recallConfig()
 		recall = &investigate.Recall{
@@ -64,7 +74,7 @@ func (r *Runner) runOne(ctx context.Context, c Case) Result {
 	}
 	req := investigate.Request{Source: investigate.SourceAlert, Title: c.Name, Message: c.Prompt, Workload: c.workload()}
 	if err := li.Investigate(ctx, req); err != nil {
-		return Result{Name: c.Name, Missing: []string{"investigation error: " + err.Error()}}
+		return Result{Name: c.Name, Missing: []string{noteInvestigationError + err.Error()}}
 	}
 	if !done {
 		return Result{Name: c.Name, Missing: []string{"no findings (loop did not submit)"}}

--- a/internal/eval/scorecard.go
+++ b/internal/eval/scorecard.go
@@ -38,6 +38,14 @@ type HistoryEntry struct {
 	InputTokens  int      `json:"input_tokens,omitempty"`
 	OutputTokens int      `json:"output_tokens,omitempty"`
 	CostUSD      *float64 `json:"cost_usd,omitempty"`
+
+	// Errored records that this run produced no scoreable result at all (see
+	// Report.Errored) so the label is durable: the history is re-rendered into the
+	// scorecard table on every publish, long after the report it came from is gone.
+	// omitempty keeps the field absent on ordinary runs, and absence unmarshals to
+	// false — exactly right for the lines written before this field existed, which
+	// were all real runs.
+	Errored bool `json:"errored,omitempty"`
 }
 
 // HistoryFromReport projects a replay report onto its one-line history record.
@@ -46,7 +54,59 @@ func HistoryFromReport(rep Report) HistoryEntry {
 		At: rep.At, Model: rep.Model, N: rep.N,
 		PassRate: rep.PassRate, Reached: rep.Reached, Total: rep.Total,
 		InputTokens: rep.InputTokens, OutputTokens: rep.OutputTokens, CostUSD: rep.CostUSD,
+		Errored: rep.Errored(),
 	}
+}
+
+// runErrorMarkers are the prefixes Runner.runOne records in a case's Missing when a
+// repeat never produced an answer to score at all: the provider call failed, or the
+// case's catalog fixture would not load. They are the only POSITIVE evidence that a
+// case did not run — every other Missing note (a keyword the findings lacked, an
+// over-claimed distractor, "no findings (loop did not submit)") means the model did
+// answer and the answer was judged.
+var runErrorMarkers = []string{"investigation error: ", "catalog fixture load error: "}
+
+// Errored reports whether this run produced no evidence about the model whatsoever:
+// every case failed before anything could be scored. Such a run's 0% is an artefact
+// of a broken run, not a measurement, and publishing it as a pass-rate would make a
+// public claim about the model that the run cannot support.
+//
+// The predicate keys on the run-error markers rather than on "spent nothing".
+// Result.Usage documents zero tokens as UNKNOWN, never as free — a provider that
+// reports no usage is ordinary — so a token-only test would label a genuine 0% from
+// such a provider an outage, which is the same lie in the other direction. Spending
+// nothing is kept only as a NECESSARY condition: it rules out a partial outage where
+// some repeats did reach the model, and whatever they scored is real data. Per-case
+// PassRate carries the same duty for providers that report no usage at all — any
+// passing repeat means something was genuinely scored.
+//
+// The conjunction is deliberately asymmetric. A provider that dies after billing
+// some tokens fails the token test and renders as today's plain 0%: the predicate
+// can only ever under-label, never claim "errored" about a run that measured
+// something.
+func (rep Report) Errored() bool {
+	if len(rep.Cases) == 0 || rep.Reached > 0 || rep.InputTokens > 0 || rep.OutputTokens > 0 {
+		return false
+	}
+	for _, c := range rep.Cases {
+		if c.PassRate > 0 || !erroredCase(c) {
+			return false
+		}
+	}
+	return true
+}
+
+// erroredCase reports whether a case carries a marker proving at least one of its
+// repeats never reached a scoreable answer.
+func erroredCase(c ReportCase) bool {
+	for _, m := range c.Missing {
+		for _, marker := range runErrorMarkers {
+			if strings.HasPrefix(m, marker) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // AppendHistory appends e to the JSONL history, replacing any line with the same
@@ -87,9 +147,16 @@ func AppendHistory(existing []byte, e HistoryEntry) ([]byte, []HistoryEntry, err
 // BadgeJSON renders the shields.io "endpoint" badge document
 // (https://shields.io/badges/endpoint-badge) for the README pass-rate badge.
 // Color bands: ≥90% brightgreen, ≥ the 70% CI gate green, ≥50% yellow, else red.
+// An errored run gets no band at all — see below.
 func BadgeJSON(rep Report) []byte {
+	message := fmt.Sprintf("%d/%d scenarios · %.0f%%", rep.Reached, rep.Total, rep.PassRate*100)
 	color := "red"
 	switch {
+	case rep.Errored():
+		// Grey is shields' convention for "no result", and the message drops the
+		// pass-rate entirely: a red "0/2 · 0%" reads as "the model scored zero", which
+		// is a claim about a third party that an outage cannot support.
+		message, color = "errored · no model response", "lightgrey"
 	case rep.PassRate >= 0.9:
 		color = "brightgreen"
 	case rep.PassRate >= evalMinPassRate:
@@ -100,7 +167,7 @@ func BadgeJSON(rep Report) []byte {
 	b, _ := json.Marshal(map[string]any{
 		"schemaVersion": 1,
 		"label":         "nightly eval",
-		"message":       fmt.Sprintf("%d/%d scenarios · %.0f%%", rep.Reached, rep.Total, rep.PassRate*100),
+		"message":       message,
 		"color":         color,
 	})
 	return b
@@ -122,44 +189,71 @@ func ScorecardMarkdown(rep Report, history []HistoryEntry, inUSD, cachedUSD, out
 	b.WriteString("the replay eval scores the model+loop over recorded incident evidence (no live cluster), so anyone can reproduce it:\n\n")
 	b.WriteString("```\nlore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7\n```\n\n")
 
+	errored := rep.Errored()
 	fmt.Fprintf(&b, "**Latest run:** %s", rep.At)
 	if rep.Model != "" {
 		fmt.Fprintf(&b, " · model `%s`", rep.Model)
 	}
-	fmt.Fprintf(&b, " · **%d/%d scenarios reached (%.0f%%)** · n=%d runs/case, k-of-n bar %.0f%%",
-		rep.Reached, rep.Total, rep.PassRate*100, rep.N, evalMinPassRate*100)
-	if rep.CostUSD != nil {
-		fmt.Fprintf(&b, " · est. cost $%.2f (%s in / %s out tokens)",
-			*rep.CostUSD, compactTokens(rep.InputTokens), compactTokens(rep.OutputTokens))
-	} else if rep.InputTokens+rep.OutputTokens > 0 {
-		fmt.Fprintf(&b, " · %s in / %s out tokens", compactTokens(rep.InputTokens), compactTokens(rep.OutputTokens))
+	if errored {
+		// No pass-rate, and no cost either: a $0.00 next to an outage reads as "the
+		// run was free" when it means "nothing ever ran".
+		fmt.Fprintf(&b, " · **⚠️ ERRORED — no result** · n=%d runs/case\n\n", rep.N)
+		b.WriteString("Every case failed before the model returned an answer, so nothing was scored and " +
+			"nothing was spent. This run is published as **errored** rather than as 0% on purpose: a 0% " +
+			"would be a measurement of the model, and this run measured nothing. The errors are in the table below.\n\n")
+	} else {
+		fmt.Fprintf(&b, " · **%d/%d scenarios reached (%.0f%%)** · n=%d runs/case, k-of-n bar %.0f%%",
+			rep.Reached, rep.Total, rep.PassRate*100, rep.N, evalMinPassRate*100)
+		if rep.CostUSD != nil {
+			fmt.Fprintf(&b, " · est. cost $%.2f (%s in / %s out tokens)",
+				*rep.CostUSD, compactTokens(rep.InputTokens), compactTokens(rep.OutputTokens))
+		} else if rep.InputTokens+rep.OutputTokens > 0 {
+			fmt.Fprintf(&b, " · %s in / %s out tokens", compactTokens(rep.InputTokens), compactTokens(rep.OutputTokens))
+		}
+		b.WriteString("\n\n")
 	}
-	b.WriteString("\n\n## Scenarios (latest run)\n\n")
-	b.WriteString("| scenario | result | pass-rate | median confidence | recall | notes |\n")
-	b.WriteString("|---|---|---|---|---|---|\n")
-	for _, c := range rep.Cases {
-		fmt.Fprintf(&b, "| %s | %s | %.0f%% (n=%d) | %.2f | %s | %s |\n",
-			c.Name, resultCell(c), c.PassRate*100, c.Runs, c.Confidence, recallCell(c), notesCell(c))
+	b.WriteString("## Scenarios (latest run)\n\n")
+	if errored {
+		// The usual columns would be all zeros here — a 0% pass-rate and a 0.00 median
+		// confidence for a case the model never saw are fabricated precision. The error
+		// is the only thing this run actually observed, so it is the only thing shown.
+		b.WriteString("| scenario | result | error |\n|---|---|---|\n")
+		for _, c := range rep.Cases {
+			fmt.Fprintf(&b, "| %s | 🚫 ERRORED | %s |\n", c.Name, notesCell(c))
+		}
+	} else {
+		b.WriteString("| scenario | result | pass-rate | median confidence | recall | notes |\n")
+		b.WriteString("|---|---|---|---|---|---|\n")
+		for _, c := range rep.Cases {
+			fmt.Fprintf(&b, "| %s | %s | %.0f%% (n=%d) | %.2f | %s | %s |\n",
+				c.Name, resultCell(c), c.PassRate*100, c.Runs, c.Confidence, recallCell(c), notesCell(c))
+		}
 	}
 
 	b.WriteString(costSection(rep, inUSD, cachedUSD, outUSD))
 
-	b.WriteString("\n## Confidence calibration\n\n")
-	var confidentWrong, underConfident []string
-	for _, c := range rep.Cases {
-		if !c.Reached && c.Confidence >= confidentWrongFloor {
-			confidentWrong = append(confidentWrong, c.Name)
+	// Calibration is skipped on an errored run: with every confidence at zero the two
+	// bullets would both read "none", which a reader takes as "the model was neither
+	// overconfident nor underconfident" — another finding this run never observed.
+	if !errored {
+		b.WriteString("\n## Confidence calibration\n\n")
+		var confidentWrong, underConfident []string
+		for _, c := range rep.Cases {
+			if !c.Reached && c.Confidence >= confidentWrongFloor {
+				confidentWrong = append(confidentWrong, c.Name)
+			}
+			if c.Reached && c.Confidence < underConfidentCeil {
+				underConfident = append(underConfident, c.Name)
+			}
 		}
-		if c.Reached && c.Confidence < underConfidentCeil {
-			underConfident = append(underConfident, c.Name)
-		}
+		fmt.Fprintf(&b, "- **Confidently wrong** (missed with median confidence ≥ %.2f): %s\n", confidentWrongFloor, nameList(confidentWrong))
+		fmt.Fprintf(&b, "- **Underconfident** (reached with median confidence < %.2f): %s\n", underConfidentCeil, nameList(underConfident))
 	}
-	fmt.Fprintf(&b, "- **Confidently wrong** (missed with median confidence ≥ %.2f): %s\n", confidentWrongFloor, nameList(confidentWrong))
-	fmt.Fprintf(&b, "- **Underconfident** (reached with median confidence < %.2f): %s\n", underConfidentCeil, nameList(underConfident))
 
 	b.WriteString("\n## History\n\n")
 	fmt.Fprintf(&b, "Newest first, last %d shown — the full log is [`history.jsonl`](history.jsonl). ", historyShown)
-	b.WriteString("Runs below the CI gate publish here exactly like green ones.\n\n")
+	b.WriteString("Runs below the CI gate publish here exactly like green ones. ")
+	b.WriteString("A run that reached no answer to score at all is labelled in the pass-rate column instead of scored — it is not a 0%.\n\n")
 	b.WriteString("| date | model | reached | pass-rate | est. cost |\n|---|---|---|---|---|\n")
 	shown := history
 	if len(shown) > historyShown {
@@ -167,6 +261,12 @@ func ScorecardMarkdown(rep Report, history []HistoryEntry, inUSD, cachedUSD, out
 	}
 	for i := len(shown) - 1; i >= 0; i-- {
 		h := shown[i]
+		if h.Errored {
+			// Every score column is withheld, not zeroed: this row must not be
+			// comparable with the real ones stacked above and below it.
+			fmt.Fprintf(&b, "| %s | %s | — | ⚠️ errored | — |\n", h.At, h.Model)
+			continue
+		}
 		cost := "—"
 		if h.CostUSD != nil {
 			cost = fmt.Sprintf("$%.2f", *h.CostUSD)
@@ -281,11 +381,17 @@ func recallCell(c ReportCase) string {
 	return s
 }
 
+// notesCell renders a case's Missing notes into one markdown table cell. The notes
+// are freeform — on the errored path they carry a verbatim provider error string —
+// so a raw "|" would split the row into phantom columns and a raw newline would end
+// it early, silently corrupting the published table.
 func notesCell(c ReportCase) string {
 	if len(c.Missing) == 0 {
 		return "—"
 	}
-	return strings.Join(c.Missing, ", ")
+	s := strings.Join(c.Missing, ", ")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(s)
 }
 
 func nameList(names []string) string {

--- a/internal/eval/scorecard.go
+++ b/internal/eval/scorecard.go
@@ -216,8 +216,18 @@ func BadgeJSON(rep Report) []byte {
 func ScorecardMarkdown(rep Report, history []HistoryEntry, inUSD, cachedUSD, outUSD float64) string {
 	var b strings.Builder
 	b.WriteString("# RunLore nightly eval scorecard\n\n")
-	b.WriteString("Auto-published by [`.github/workflows/eval.yaml`](https://github.com/Smana/runlore/blob/main/.github/workflows/eval.yaml) — ")
-	b.WriteString("the replay eval scores the model+loop over recorded incident evidence (no live cluster), so anyone can reproduce it:\n\n")
+	// Two things, deliberately: which workflow wrote this file, and the command that
+	// reproduces it. What the eval IS — replay over fixed evidence, no live cluster,
+	// what the pass-rate does and does not mean — is stated by the repo-authored
+	// framing in website/content/eval.md, which wraps this block on the published
+	// page. Saying it here too put the same claim on one page twice, tens of rendered
+	// lines apart, and the framing is the copy a human edits.
+	//
+	// The reproduce command stays because it is not framing: it belongs next to the
+	// numbers it reproduces, and it is the one thing the framing loses — the
+	// placeholder that carries it lives BETWEEN the scorecard markers and is
+	// overwritten by this block on every publish.
+	b.WriteString("Auto-published by [`.github/workflows/eval.yaml`](https://github.com/Smana/runlore/blob/main/.github/workflows/eval.yaml). Reproduce it yourself:\n\n")
 	b.WriteString("```\nlore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7\n```\n\n")
 
 	errored := rep.Errored()
@@ -291,7 +301,10 @@ func ScorecardMarkdown(rep Report, history []HistoryEntry, inUSD, cachedUSD, out
 	// and hack/check-anchors.sh only grades in-page fragments.
 	fmt.Fprintf(&b, "Newest first, last %d shown — the full log is "+
 		"[`history.jsonl`](https://github.com/Smana/runlore/blob/eval-scorecard/history.jsonl). ", historyShown)
-	b.WriteString("Runs below the CI gate publish here exactly like green ones. ")
+	// Only the legend for the column the reader is looking at. "Runs below the CI
+	// gate publish here exactly like green ones" used to sit here and now lives in
+	// website/content/eval.md's framing, which says it in the page's own voice — the
+	// errored label is the one thing in this table the framing does not explain.
 	b.WriteString("A run that reached no answer to score at all is labelled in the pass-rate column instead of scored — it is not a 0%.\n\n")
 	b.WriteString("| date | model | reached | pass-rate | est. cost |\n|---|---|---|---|---|\n")
 	shown := history

--- a/internal/eval/scorecard.go
+++ b/internal/eval/scorecard.go
@@ -64,7 +64,7 @@ func HistoryFromReport(rep Report) HistoryEntry {
 // case did not run — every other Missing note (a keyword the findings lacked, an
 // over-claimed distractor, "no findings (loop did not submit)") means the model did
 // answer and the answer was judged.
-var runErrorMarkers = []string{"investigation error: ", "catalog fixture load error: "}
+var runErrorMarkers = []string{noteInvestigationError, noteCatalogFixtureError}
 
 // Errored reports whether this run produced no evidence about the model whatsoever:
 // every case failed before anything could be scored. Such a run's 0% is an artefact
@@ -383,17 +383,21 @@ func recallCell(c ReportCase) string {
 	return s
 }
 
+// cellEscaper makes a freeform note safe inside one markdown table cell: a raw "|"
+// would split the row into phantom columns and a raw newline would end it early,
+// silently corrupting the published table. One replacer, built once — Replacer never
+// rescans its own output, so the "\|" emitted for a pipe cannot be re-matched, and
+// "\r\n" wins over the lone "\r"/"\n" because it is listed first.
+var cellEscaper = strings.NewReplacer("|", `\|`, "\r\n", " ", "\n", " ", "\r", " ")
+
 // notesCell renders a case's Missing notes into one markdown table cell. The notes
 // are freeform — on the errored path they carry a verbatim provider error string —
-// so a raw "|" would split the row into phantom columns and a raw newline would end
-// it early, silently corrupting the published table.
+// so they are escaped before they reach the table.
 func notesCell(c ReportCase) string {
 	if len(c.Missing) == 0 {
 		return "—"
 	}
-	s := strings.Join(c.Missing, ", ")
-	s = strings.ReplaceAll(s, "|", `\|`)
-	return strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ").Replace(s)
+	return cellEscaper.Replace(strings.Join(c.Missing, ", "))
 }
 
 func nameList(names []string) string {

--- a/internal/eval/scorecard.go
+++ b/internal/eval/scorecard.go
@@ -279,8 +279,10 @@ func ScorecardMarkdown(rep Report, history []HistoryEntry, inUSD, cachedUSD, out
 // costSection renders the cost-per-investigation comparison: what a full
 // investigation costs against what an instant recall costs, on this run's model at
 // this run's prices. It is the single most concrete claim the learning loop makes —
-// recall is roughly an order of magnitude cheaper — and publishing it turns an
-// assertion into a measurement.
+// that recall is substantially cheaper than investigating afresh — and publishing it
+// turns an assertion into a measurement. Deliberately no ratio in this comment: the
+// point of the table is that the run supplies the number, so asserting one here would
+// be exactly the guess this section exists to replace.
 //
 // Returns "" when prices are unset or the report carries no per-case token data;
 // a fabricated or zeroed cost would be worse than no cost at all.

--- a/internal/eval/scorecard.go
+++ b/internal/eval/scorecard.go
@@ -282,7 +282,15 @@ func ScorecardMarkdown(rep Report, history []HistoryEntry, inUSD, cachedUSD, out
 	}
 
 	b.WriteString("\n## History\n\n")
-	fmt.Fprintf(&b, "Newest first, last %d shown — the full log is [`history.jsonl`](history.jsonl). ", historyShown)
+	// Absolute, not `](history.jsonl)`. This file is read in two places: as the blob
+	// on the eval-scorecard branch, where a sibling-relative href resolves, and
+	// spliced into https://runlore.io/eval, where the same href resolves to
+	// /eval/history.jsonl and 404s. The blob URL is correct in both, and it is the
+	// only href the generator emits that is not already absolute. Nothing would have
+	// caught the relative form either: Hugo's refLinksErrorLevel only grades `relref`
+	// and hack/check-anchors.sh only grades in-page fragments.
+	fmt.Fprintf(&b, "Newest first, last %d shown — the full log is "+
+		"[`history.jsonl`](https://github.com/Smana/runlore/blob/eval-scorecard/history.jsonl). ", historyShown)
 	b.WriteString("Runs below the CI gate publish here exactly like green ones. ")
 	b.WriteString("A run that reached no answer to score at all is labelled in the pass-rate column instead of scored — it is not a 0%.\n\n")
 	b.WriteString("| date | model | reached | pass-rate | est. cost |\n|---|---|---|---|---|\n")

--- a/internal/eval/scorecard.go
+++ b/internal/eval/scorecard.go
@@ -84,6 +84,11 @@ var runErrorMarkers = []string{noteInvestigationError, noteCatalogFixtureError}
 // some tokens fails the token test and renders as today's plain 0%: the predicate
 // can only ever under-label, never claim "errored" about a run that measured
 // something.
+//
+// The last gap the token and pass-rate tests leave open is a partial outage on a
+// silent-usage provider where every repeat that DID get through was judged wrong:
+// no tokens to see, no passing repeat to see. erroredCase closes it by reading the
+// whole Missing set rather than looking for one marker in it — see there.
 func (rep Report) Errored() bool {
 	if len(rep.Cases) == 0 || rep.Reached > 0 || rep.InputTokens > 0 || rep.OutputTokens > 0 {
 		return false
@@ -96,14 +101,40 @@ func (rep Report) Errored() bool {
 	return true
 }
 
-// erroredCase reports whether a case carries a marker proving at least one of its
-// repeats never reached a scoreable answer.
+// erroredCase reports whether EVERY note this case left behind is a run-error
+// marker — i.e. nothing in the case's record came from judging an answer.
+//
+// "Every", not "any", is the load-bearing word. CaseAggregate.Missing is the UNION
+// over the repeats, so a partial outage leaves the outage marker sitting next to
+// the notes the surviving repeats earned ("ImagePullBackOff", "over-claimed: …",
+// "no findings (loop did not submit)"). Matching one marker anywhere in that set
+// would call such a case "never ran" while it is holding the evidence that it did
+// — over-labelling, the one direction Errored must never take. A wholly errored
+// case cannot contain a non-marker note: runOne returns at the failure with that
+// single note and never reaches Score.
+//
+// An EMPTY Missing is not errored either, and the emptiness check is not
+// redundant with the loop: a case that answered correctly but below the confidence
+// floor fails with nothing missing at all, and "no notes" is the absence of
+// evidence, not evidence of absence.
 func erroredCase(c ReportCase) bool {
+	if len(c.Missing) == 0 {
+		return false
+	}
 	for _, m := range c.Missing {
-		for _, marker := range runErrorMarkers {
-			if strings.HasPrefix(m, marker) {
-				return true
-			}
+		if !isRunErrorNote(m) {
+			return false
+		}
+	}
+	return true
+}
+
+// isRunErrorNote reports whether a single Missing note is one runOne writes when a
+// repeat never reached a scoreable answer.
+func isRunErrorNote(note string) bool {
+	for _, marker := range runErrorMarkers {
+		if strings.HasPrefix(note, marker) {
+			return true
 		}
 	}
 	return false

--- a/internal/eval/scorecard_test.go
+++ b/internal/eval/scorecard_test.go
@@ -220,10 +220,10 @@ func TestScorecardMarkdownGenuineZeroStillRendersAsFailure(t *testing.T) {
 	}
 }
 
-// TestHistoryErroredIsDurableAndBackwardCompatible: the flag must survive a
-// round-trip through history.jsonl (so past errored runs stay labelled on every
-// future re-render), and lines written before the field existed must degrade to
-// "not errored" rather than to a guess.
+// TestHistoryErroredIsDurable: the flag must survive a round-trip through
+// history.jsonl (so past errored runs stay labelled on every future re-render), and
+// lines written before the field existed must degrade to "not errored" rather than
+// to a guess.
 func TestHistoryErroredIsDurable(t *testing.T) {
 	legacy := []byte(`{"at":"2026-07-23T06:00:00Z","model":"anthropic/claude-haiku-4-5-20251001","n":5,"pass_rate":0.5,"reached":1,"total":2,"cost_usd":0.16}` + "\n")
 	out, entries, err := AppendHistory(legacy, HistoryFromReport(erroredFixtureReport()))

--- a/internal/eval/scorecard_test.go
+++ b/internal/eval/scorecard_test.go
@@ -87,6 +87,32 @@ func TestReportErrored(t *testing.T) {
 		noSubmit.Cases[i].Missing = []string{"no findings (loop did not submit)"}
 	}
 
+	// The hardest partial outage: a silent-usage provider, and the repeats that DID
+	// get through were all judged wrong. CaseAggregate unions Missing across the
+	// repeats, so the case carries the outage marker AND the note the survivor
+	// earned. Neither the token test nor the per-case pass-rate test sees the
+	// survivor — the notes are the only trace it left, and a run that scored one
+	// answer is a measurement, thin as it is.
+	partialSilent := erroredFixtureReport()
+	partialSilent.CostUSD = nil
+	partialSilent.Cases[0].Missing = append(partialSilent.Cases[0].Missing, "ImagePullBackOff")
+	partialSilent.Cases[1].Missing = append(partialSilent.Cases[1].Missing, "over-claimed: apps/web")
+
+	// Same shape, but the survivor reached the model and never submitted.
+	partialNoSubmit := erroredFixtureReport()
+	partialNoSubmit.CostUSD = nil
+	for i := range partialNoSubmit.Cases {
+		partialNoSubmit.Cases[i].Missing = append(partialNoSubmit.Cases[i].Missing, "no findings (loop did not submit)")
+	}
+
+	// A correct answer below the confidence floor: Score sets Pass=false with an
+	// EMPTY Missing. No note at all is not evidence that nothing ran.
+	confFloorOnly := erroredFixtureReport()
+	confFloorOnly.CostUSD = nil
+	for i := range confFloorOnly.Cases {
+		confFloorOnly.Cases[i].Missing = nil
+	}
+
 	// One case errored, the other genuinely missed: the run still measured something.
 	oneCaseOnly := erroredFixtureReport()
 	oneCaseOnly.Cases[1].Missing = []string{"ImagePullBackOff"}
@@ -111,7 +137,10 @@ func TestReportErrored(t *testing.T) {
 		{"genuine 0% from a silent-usage provider", silentUsage, false},
 		{"partial outage (tokens were spent)", partialOutage, false},
 		{"partial outage (a case had passing repeats)", somePassed, false},
+		{"partial outage (silent usage, every survivor judged wrong)", partialSilent, false},
+		{"partial outage (silent usage, survivor never submitted)", partialNoSubmit, false},
 		{"model answered but never submitted", noSubmit, false},
+		{"failed on the confidence floor with nothing missing", confFloorOnly, false},
 		{"only one case errored", oneCaseOnly, false},
 		{"green run", scorecardFixtureReport(), false},
 		{"no cases at all", empty, false},

--- a/internal/eval/scorecard_test.go
+++ b/internal/eval/scorecard_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -223,6 +224,52 @@ func TestScorecardMarkdownErrored(t *testing.T) {
 		if strings.Contains(md, forbidden) {
 			t.Fatalf("errored scorecard must not render %q in:\n%s", forbidden, md)
 		}
+	}
+}
+
+// markdownLink matches an inline markdown link's href — `[text](href)` — including
+// the ones whose text is code-fenced, which is how this generator writes them.
+var markdownLink = regexp.MustCompile(`\]\(([^)\s]+)`)
+
+// TestScorecardMarkdownEmitsNoRelativeLinks pins the one property a relative href
+// violates. scorecard.md is read in two places with different bases: as the blob on
+// the eval-scorecard branch, and spliced into website/content/eval.md as
+// https://runlore.io/eval. `](history.jsonl)` resolved on the first and 404'd on the
+// second for as long as the page existed, because neither guard covers it — Hugo's
+// refLinksErrorLevel grades `relref` and hack/check-anchors.sh grades in-page
+// fragments, and a plain relative link is neither.
+//
+// So the assertion is over EVERY href the renderer emits, not over the one that was
+// wrong: the next section added to this file gets graded the day it is written.
+func TestScorecardMarkdownEmitsNoRelativeLinks(t *testing.T) {
+	// Rates are set so costSection actually renders for the fixture that carries
+	// per-case tokens — an unrendered section proves nothing about its links.
+	for _, tc := range []struct {
+		name string
+		rep  Report
+	}{
+		{"green run", scorecardFixtureReport()},
+		{"errored run", erroredFixtureReport()},
+		{"genuine zero, with the cost table", genuineZeroReport()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, entries, err := AppendHistory(nil, HistoryFromReport(tc.rep))
+			if err != nil {
+				t.Fatal(err)
+			}
+			md := ScorecardMarkdown(tc.rep, entries, 3, 0.3, 15)
+			hrefs := markdownLink.FindAllStringSubmatch(md, -1)
+			if len(hrefs) == 0 {
+				t.Fatalf("no links found — the scan is broken, not the output:\n%s", md)
+			}
+			for _, m := range hrefs {
+				href := m[1]
+				if strings.HasPrefix(href, "https://") || strings.HasPrefix(href, "http://") || strings.HasPrefix(href, "#") {
+					continue
+				}
+				t.Errorf("relative href %q: it resolves under the eval-scorecard blob but 404s under https://runlore.io/eval — emit an absolute URL", href)
+			}
+		})
 	}
 }
 

--- a/internal/eval/scorecard_test.go
+++ b/internal/eval/scorecard_test.go
@@ -3,8 +3,13 @@
 package eval
 
 import (
+	"context"
+	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
 )
 
 func scorecardFixtureReport() Report {
@@ -19,6 +24,248 @@ func scorecardFixtureReport() Report {
 				HasRecall: true, ExpectRecall: "withdrawn", RecallFired: 5,
 				Missing: []string{"expect_recall=withdrawn but recall short_circuit"}},
 		},
+	}
+}
+
+// erroredFixtureReport is the shape the 2026-08-02 published run actually took: the
+// provider answered nothing, so every case failed at the model boundary, no repeat
+// was ever scored and no tokens were billed. Its 0% is an artefact of the outage.
+func erroredFixtureReport() Report {
+	zero := 0.0
+	return Report{
+		At: "2026-08-02T08:12:29Z", Model: "anthropic/claude-haiku-4-5-20251001",
+		N: 5, PassRate: 0, Reached: 0, Total: 2, CostUSD: &zero,
+		Cases: []ReportCase{
+			{Name: "harbor-chart-bump", Runs: 5,
+				Missing: []string{"investigation error: 401 authentication_error: invalid x-api-key"}},
+			{Name: "poisoned-recall-verify", Runs: 5, HasRecall: true, ExpectRecall: "withdrawn",
+				Missing: []string{"investigation error: 401 authentication_error: invalid x-api-key"}},
+		},
+	}
+}
+
+// genuineZeroReport is a real 0%: every case ran, the model answered, every answer
+// was wrong. It must never be labelled errored — the run IS a measurement.
+func genuineZeroReport() Report {
+	cost := 0.14
+	return Report{
+		At: "2026-08-01T06:00:00Z", Model: "anthropic/claude-haiku-4-5-20251001",
+		N: 5, PassRate: 0, Reached: 0, Total: 2,
+		InputTokens: 118000, OutputTokens: 7400, CostUSD: &cost,
+		Cases: []ReportCase{
+			{Name: "harbor-chart-bump", Runs: 5, Confidence: 0.81,
+				Missing: []string{"ImagePullBackOff"}, InputTokens: 59000, OutputTokens: 3700},
+			{Name: "poisoned-recall-verify", Runs: 5, Confidence: 0.64,
+				Missing: []string{"over-claimed: apps/web"}, InputTokens: 59000, OutputTokens: 3700},
+		},
+	}
+}
+
+func TestReportErrored(t *testing.T) {
+	// Same genuine 0%, but from a provider that reports no usage at all. This is the
+	// case a "spent nothing" predicate would mislabel as an outage.
+	silentUsage := genuineZeroReport()
+	silentUsage.InputTokens, silentUsage.OutputTokens = 0, 0
+	silentUsage.CostUSD = nil
+	for i := range silentUsage.Cases {
+		silentUsage.Cases[i].InputTokens, silentUsage.Cases[i].OutputTokens = 0, 0
+	}
+
+	// A partial outage: some repeats did reach the model, so a real (if bad) score
+	// exists underneath and the run is not "no result".
+	partialOutage := erroredFixtureReport()
+	partialOutage.InputTokens, partialOutage.OutputTokens = 61000, 3200
+
+	// Same, but the survivor is visible only per-case (silent-usage provider): one
+	// case had passing repeats, so something WAS scored.
+	somePassed := erroredFixtureReport()
+	somePassed.Cases[0].PassRate = 0.4
+
+	// The model answered but never called submit — a model failure, not an outage.
+	noSubmit := erroredFixtureReport()
+	for i := range noSubmit.Cases {
+		noSubmit.Cases[i].Missing = []string{"no findings (loop did not submit)"}
+	}
+
+	// One case errored, the other genuinely missed: the run still measured something.
+	oneCaseOnly := erroredFixtureReport()
+	oneCaseOnly.Cases[1].Missing = []string{"ImagePullBackOff"}
+
+	// A case whose catalog fixture would not load never reached the model either.
+	fixtureBroken := erroredFixtureReport()
+	for i := range fixtureBroken.Cases {
+		fixtureBroken.Cases[i].Missing = []string{"catalog fixture load error: open fixtures: no such file or directory"}
+	}
+
+	empty := erroredFixtureReport()
+	empty.Cases = nil
+
+	tests := []struct {
+		name string
+		rep  Report
+		want bool
+	}{
+		{"provider answered nothing", erroredFixtureReport(), true},
+		{"catalog fixture never loaded", fixtureBroken, true},
+		{"genuine 0% with tokens", genuineZeroReport(), false},
+		{"genuine 0% from a silent-usage provider", silentUsage, false},
+		{"partial outage (tokens were spent)", partialOutage, false},
+		{"partial outage (a case had passing repeats)", somePassed, false},
+		{"model answered but never submitted", noSubmit, false},
+		{"only one case errored", oneCaseOnly, false},
+		{"green run", scorecardFixtureReport(), false},
+		{"no cases at all", empty, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rep.Errored(); got != tc.want {
+				t.Fatalf("Errored() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestErroredRunFromRealRunner pins the predicate to the real failure path rather
+// than to a hand-written fixture: it replays the SHIPPED example cases through the
+// real Runner against a model that always errors (a provider outage), and asserts
+// the projected report is recognised as errored. If Runner.runOne ever changes the
+// note it records for a failed investigation, this fails — the fixture-based table
+// above would not.
+func TestErroredRunFromRealRunner(t *testing.T) {
+	cases, err := Load(filepath.Join("..", "..", "examples", "eval"))
+	if err != nil {
+		t.Fatalf("Load examples/eval: %v", err)
+	}
+	r := &Runner{
+		Model: &alwaysErrModel{err: errors.New("401 authentication_error: invalid x-api-key")},
+		Log:   discardLog(),
+	}
+	camp := r.RunN(context.Background(), cases, 1)
+	rep := camp.Report("2026-08-02T08:12:29Z", "anthropic/claude-haiku-4-5-20251001", providers.Usage{}, nil)
+	if rep.Total == 0 {
+		t.Fatal("expected the shipped cases to load")
+	}
+	if !rep.Errored() {
+		t.Fatalf("a campaign where every case failed at the model boundary must be errored; report: %+v", rep)
+	}
+}
+
+func TestBadgeJSONErrored(t *testing.T) {
+	b := string(BadgeJSON(erroredFixtureReport()))
+	if !strings.Contains(b, `"color":"lightgrey"`) {
+		t.Fatalf("errored run must not wear a score colour: %s", b)
+	}
+	if !strings.Contains(b, "errored") {
+		t.Fatalf("badge must say the run errored: %s", b)
+	}
+	for _, forbidden := range []string{"0/2", "0%"} {
+		if strings.Contains(b, forbidden) {
+			t.Fatalf("errored badge must not publish a pass-rate (%q): %s", forbidden, b)
+		}
+	}
+	// A genuine 0% keeps reading as a genuine 0%.
+	g := string(BadgeJSON(genuineZeroReport()))
+	if !strings.Contains(g, `"message":"0/2 scenarios · 0%"`) || !strings.Contains(g, `"color":"red"`) {
+		t.Fatalf("a real 0%% must still render as a red 0/2: %s", g)
+	}
+}
+
+func TestScorecardMarkdownErrored(t *testing.T) {
+	rep := erroredFixtureReport()
+	_, entries, err := AppendHistory(nil, HistoryFromReport(rep))
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := ScorecardMarkdown(rep, entries, 3, 0.3, 15)
+	for _, want := range []string{
+		"ERRORED",
+		"401 authentication_error", // the error itself is disclosed
+		"| 2026-08-02T08:12:29Z | anthropic/claude-haiku-4-5-20251001 | — | ⚠️ errored | — |", // history row
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("errored scorecard missing %q in:\n%s", want, md)
+		}
+	}
+	for _, forbidden := range []string{
+		"scenarios reached (0%)", // summary must not publish a pass-rate
+		"❌ MISS",                 // a case that never ran did not "miss"
+		"est. cost $0.00",        // a zero cost here means "nothing ran", not "it was free"
+	} {
+		if strings.Contains(md, forbidden) {
+			t.Fatalf("errored scorecard must not render %q in:\n%s", forbidden, md)
+		}
+	}
+}
+
+func TestScorecardMarkdownGenuineZeroStillRendersAsFailure(t *testing.T) {
+	rep := genuineZeroReport()
+	_, entries, err := AppendHistory(nil, HistoryFromReport(rep))
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := ScorecardMarkdown(rep, entries, 0, 0, 0)
+	for _, want := range []string{
+		"**0/2 scenarios reached (0%)**",
+		"| harbor-chart-bump | ❌ MISS |",
+		"| 2026-08-01T06:00:00Z | anthropic/claude-haiku-4-5-20251001 | 0/2 | 0% | $0.14 |",
+	} {
+		if !strings.Contains(md, want) {
+			t.Fatalf("a real 0%% must still render as a real failure, missing %q in:\n%s", want, md)
+		}
+	}
+	// The History section explains the `errored` label unconditionally, so assert on
+	// the labels themselves rather than on the word.
+	if strings.Contains(md, "ERRORED") || strings.Contains(md, "⚠️ errored") {
+		t.Fatalf("a real 0%% must not be labelled errored:\n%s", md)
+	}
+}
+
+// TestHistoryErroredIsDurableAndBackwardCompatible: the flag must survive a
+// round-trip through history.jsonl (so past errored runs stay labelled on every
+// future re-render), and lines written before the field existed must degrade to
+// "not errored" rather than to a guess.
+func TestHistoryErroredIsDurable(t *testing.T) {
+	legacy := []byte(`{"at":"2026-07-23T06:00:00Z","model":"anthropic/claude-haiku-4-5-20251001","n":5,"pass_rate":0.5,"reached":1,"total":2,"cost_usd":0.16}` + "\n")
+	out, entries, err := AppendHistory(legacy, HistoryFromReport(erroredFixtureReport()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(entries))
+	}
+	if entries[0].Errored {
+		t.Fatal("a legacy line with no errored field must degrade to not-errored")
+	}
+	if !entries[1].Errored {
+		t.Fatal("the errored run must be recorded as errored")
+	}
+	if !strings.Contains(string(out), `"errored":true`) {
+		t.Fatalf("the flag must be persisted to history.jsonl:\n%s", out)
+	}
+	// Absence is the default: the legacy line must not grow a false flag.
+	if strings.Contains(string(out), `"errored":false`) {
+		t.Fatalf("non-errored lines must stay clean:\n%s", out)
+	}
+	// Re-parsing the written log keeps both labels — this is what "durable" means.
+	_, reparsed, err := AppendHistory(out, HistoryFromReport(genuineZeroReport()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reparsed[0].Errored || !reparsed[1].Errored || reparsed[2].Errored {
+		t.Fatalf("labels did not survive the round-trip: %+v", reparsed)
+	}
+}
+
+// TestNotesCellEscapesTableBreakers: Missing carries freeform provider error text on
+// the errored path, and a raw pipe or newline would split the markdown row into
+// phantom columns (or end it early), silently corrupting the published table.
+func TestNotesCellEscapesTableBreakers(t *testing.T) {
+	got := notesCell(ReportCase{Missing: []string{"investigation error: 429 rate_limit | retry\nafter 60s"}})
+	if strings.Contains(got, "|") && !strings.Contains(got, `\|`) {
+		t.Fatalf("pipe not escaped: %q", got)
+	}
+	if strings.ContainsAny(got, "\n\r") {
+		t.Fatalf("newline not flattened: %q", got)
 	}
 }
 


### PR DESCRIPTION
The public scorecard publishes a run in which **no model call ever succeeded** as if it were a benchmark result about a third-party model.

The live `eval-scorecard` branch's `history.jsonl` opens with:

```json
{"at":"2026-08-02T08:12:29Z","model":"anthropic/claude-haiku-4-5-20251001",
 "n":5,"pass_rate":0,"reached":0,"total":2,"cost_usd":0}
```

Zero input tokens, zero output tokens, zero cost — the provider never returned anything. But the History table on https://runlore.io/eval renders it as `claude-haiku-4-5 · 0/2 · 0%`, a public claim about another vendor's root-cause-analysis ability that the run does not support.

"Publish red exactly like green" is right and is kept. It just needs a companion distinction: **ran and failed is not the same as never ran.**

## The predicate

The obvious test — `Reached == 0 && InputTokens == 0 && OutputTokens == 0` — was rejected. `score.go` documents `Result.Usage` explicitly: *"Zero means the provider reported nothing — treated downstream as unknown, never as free."* A provider that never reports usage is ordinary, so a token-only test would publish a genuine 0% from such a provider as an outage: the same lie in the other direction.

`Report.Errored()` instead keys on **positive evidence that no answer was ever produced** — the markers `Runner.runOne` writes into `Missing` (`"investigation error: "`, `"catalog fixture load error: "`). Everything else in `Missing` — a missing keyword, an over-claimed distractor, `"no findings (loop did not submit)"` — means the model *did* answer and was judged.

Zero spend and zero per-case pass-rate are kept as **necessary** conditions: the first rules out a partial outage where some repeats reached the model (their score is real data), the second does the same job for silent-usage providers where the token check cannot see the survivors.

The conjunction is asymmetric on purpose: a provider that dies *after* billing tokens fails the token test and renders as today's plain 0% — under-labelled, never over-labelled.

## Publish, don't refuse

Justified in a comment beside the existing `Total == 0` refusal. A report with no cases is malformed and carries no information — writing it would replace the last real numbers with a blank. An errored run *is* well-formed and does carry information (the provider was unavailable on this date); refusing it would leave the branch showing the previous green run, making a broken provider indistinguishable from a nightly that never fired. That silence is the exact failure mode the scorecard exists to prevent.

## Rendered output (verified end-to-end through `lore eval scorecard`)

- `badge.json` — `{"color":"lightgrey","message":"errored · no model response"}`, no pass-rate in the text at all.
- `scorecard.md` — summary reads `⚠️ ERRORED — no result`; the scenario table is replaced with a `scenario | result | error` table showing the verbatim provider error (all-zero pass-rate and confidence columns would be fabricated precision); the confidence-calibration section is suppressed, since both bullets would read "none" and a reader takes that as a finding.
- `history.jsonl` — `"errored":true`. `omitempty` keeps ordinary lines byte-identical and a legacy line unmarshals to `false`; the existing green line re-renders exactly as before.

## Mutation testing

All six mutations are caught: token-only predicate, dropped token conjunct, dropped per-case pass-rate check, dropped empty-cases guard, markers matching anything, and marker-string drift. The last is caught by `TestErroredRunFromRealRunner`, which replays the shipped `examples/eval` cases through the real `Runner` against an always-erroring model — so if `eval.go` renames its error note, the guard fails rather than silently ceasing to work.

## Beyond the brief

`notesCell` now escapes `|` and flattens newlines: the errored path puts a verbatim provider error into a markdown table cell, and a raw pipe would split the row into phantom columns.

## Note for after merge

The already-published `history.jsonl` line has no `errored` field, so the live page keeps showing `0/2 · 0%` until it is either backfilled on the orphan branch or the row ages out. Worth a separate decision — old lines are never rewritten by the generator.