### PR TITLE
docs: correct the instant-recall cost claim to the configuration we ship

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,17 @@ tokens.
 
 **Next time — an instant recall.** Once that entry is merged, the same incident — even under a
 *different, generic alert* — is answered straight from your knowledge base: **no investigation, no new
-PR**, just the known cause, the human-reviewed resolution, and the entry it came from. An order of
-magnitude cheaper (a single model call below, against a full ReAct loop), delivered in seconds. Once
-the entry has a track record, its resolve rate is shown alongside — and it weighs whether recall is
-trusted enough to fire at all.
+PR**, just the known cause, the human-reviewed resolution, and the entry it came from. Several times
+cheaper, delivered in seconds: as shipped a recall is **two** model calls — the LLM reranker that
+picks the entry, then the adversarial verify pass — against the **7 calls and ~15.6k tokens** the
+same incident's full investigation took on the recorded transcript
+([`examples/demo/harbor-chart-bump.transcript.json`](examples/demo/harbor-chart-bump.transcript.json)).
+The card below shows a *single* call because the offline `--catalog` demo turns the reranker off (it
+would need a model key); the shipped default pays both. Once the entry has a track record, its
+resolve rate is shown alongside — and it weighs whether recall is trusted enough to fire at all.
 
 <div align="center">
-<img src="assets/recall-notification.png" alt="RunLore Slack notification — an instant recall: an ⚡ Instant recall banner reading 'answered from your knowledge base, no investigation was run', the known cause, a citation of the knowledge-base entry harbor-core-migration-deadlock.md, and a single model call at 93% cached tokens" width="760" />
+<img src="assets/recall-notification.png" alt="RunLore Slack notification — an instant recall: an ⚡ Instant recall banner reading 'answered from your knowledge base, no investigation was run', the known cause, a citation of the knowledge-base entry harbor-core-migration-deadlock.md, and a cost footer showing this offline demo's single model call at 93% cached tokens" width="760" />
 </div>
 
 ## How it works
@@ -126,10 +130,10 @@ investigation), and its confidence is **weighted by its real-world track record*
 keeps resolving incidents gains trust, one that keeps failing decays toward re-investigation.
 Even then, the recalled finding goes through the same adversarial verify pass as a fresh one — and if
 that pass can't run (e.g. a model outage), recall fails closed and falls through to a full
-investigation rather than serving the answer unreviewed. That trade isn't free: the fallback is a
-full ReAct loop instead of one model call, and it lands exactly when the verify endpoint is already
-unhealthy — worth knowing ahead of an incident, not during one. The shipped eval suite includes a
-poisoned-entry scenario proving a bad entry is rejected at recall time.
+investigation rather than serving the answer unreviewed. That trade isn't free: you pay the
+reranker's call and the failed verify call and *then* a full ReAct loop, and it lands exactly when
+the verify endpoint is already unhealthy — worth knowing ahead of an incident, not during one. The
+shipped eval suite includes a poisoned-entry scenario proving a bad entry is rejected at recall time.
 
 → **[How the learning loop works](https://runlore.io/docs/concepts/learning-loop/)** · **[Reviewing & approving knowledge](https://runlore.io/docs/concepts/reviewing-knowledge/)**
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ keeps resolving incidents gains trust, one that keeps failing decays toward re-i
 Even then, the recalled finding goes through the same adversarial verify pass as a fresh one — and if
 that pass can't run (e.g. a model outage), recall fails closed and falls through to a full
 investigation rather than serving the answer unreviewed. That trade isn't free: you pay the
-reranker's call and the failed verify call and *then* a full ReAct loop, and it lands exactly when
+reranker's call, the failed verify call, and *then* a full ReAct loop, and it lands exactly when
 the verify endpoint is already unhealthy — worth knowing ahead of an incident, not during one. The
 shipped eval suite includes a poisoned-entry scenario proving a bad entry is rejected at recall time.
 

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -238,10 +238,16 @@ config:
   #     solo_floor: 4.0                # confident bar when there is only one hit
   #     require_workload_match: false  # true = exact namespace+workload; false = namespace-level agreement is enough
   #     # LLM reranker (ON by default when instant_recall is enabled): replaces the
-  #     # (solo_floor/margin_gap) with a CALIBRATED, corpus-independent match-confidence
-  #     # gate. One cheap call ranks the top-K structurally-agreeing candidates; fires only
-  #     # when the reranker's 0-1 confidence clears rerank_threshold. Routes to model.verify
-  #     # (cheaper/faster) when configured. Default off ⇒ the magnitude gate is unchanged.
+  #     # BM25-magnitude gate (solo_floor/margin_gap) with a CALIBRATED, corpus-independent
+  #     # match-confidence gate. One cheap call ranks the top-K structurally-agreeing
+  #     # candidates; fires only when the reranker's 0-1 confidence clears rerank_threshold.
+  #     # Routes to model.verify (cheaper/faster) when configured.
+  #     # COST: the call sits IN FRONT of the short-circuit, so it is paid whenever a
+  #     # structurally-agreeing candidate clears rerank_min_score — including the incidents
+  #     # that then fall through to a full investigation. At the default 0.1 (real enriched
+  #     # BM25 scores run ~0.1-1.2) that guard rarely trips, so budget one extra model call
+  #     # on nearly every investigation. Measure it: provider="rerank" on
+  #     # runlore_model_requests_total.
   #     # rerank: false                # DEFAULT is on; set false to fall back to the legacy BM25-magnitude gate
   #     rerank_threshold: 0.7          # calibrated match-confidence bar to short-circuit (probability; no per-corpus tuning)
   #     rerank_k: 5                    # candidates ranked in the one call (bounded for cost)

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -246,8 +246,8 @@ config:
   #     # structurally-agreeing candidate clears rerank_min_score — including the incidents
   #     # that then fall through to a full investigation. At the default 0.1 (real enriched
   #     # BM25 scores run ~0.1-1.2) that guard rarely trips, so budget one extra model call
-  #     # on nearly every investigation. Measure it: provider="rerank" on
-  #     # runlore_model_requests_total.
+  #     # on nearly every investigation that surfaces such a candidate. Measure it:
+  #     # provider="rerank" on runlore_model_requests_total.
   #     # rerank: false                # DEFAULT is on; set false to fall back to the legacy BM25-magnitude gate
   #     rerank_threshold: 0.7          # calibrated match-confidence bar to short-circuit (probability; no per-corpus tuning)
   #     rerank_k: 5                    # candidates ranked in the one call (bounded for cost)

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -36,8 +36,8 @@ images:
     <figcaption><strong>An investigation.</strong> The verdict first, then the evidence behind it — plus what it ruled out, what it still doesn&rsquo;t know, and next steps it will <em>not</em> apply for you.</figcaption>
   </figure>
   <figure class="rl-shot">
-    <img src="/images/recall-notification.png" width="1336" height="1346" loading="lazy" alt="RunLore Slack notification showing an instant recall: an ⚡ Instant recall banner reading 'answered from your knowledge base, no investigation was run', the known cause, the citation of the knowledge-base entry harbor-core-migration-deadlock.md, and a single model call at 93% cached tokens." />
-    <figcaption><strong>The same failure, next time.</strong> Answered straight from the entry you merged &mdash; one model call, no investigation, and it cites the entry so you can check it.</figcaption>
+    <img src="/images/recall-notification.png" width="1336" height="1346" loading="lazy" alt="RunLore Slack notification showing an instant recall: an ⚡ Instant recall banner reading 'answered from your knowledge base, no investigation was run', the known cause, the citation of the knowledge-base entry harbor-core-migration-deadlock.md, and a cost footer showing this offline demo's single model call at 93% cached tokens." />
+    <figcaption><strong>The same failure, next time.</strong> Answered straight from the entry you merged &mdash; no investigation, and it cites the entry so you can check it. As shipped that is two model calls (the reranker, then the adversarial verify pass) against the seven the same incident's full investigation took; the card shows one because the offline demo turns the reranker off.</figcaption>
   </figure>
 </div>
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -37,7 +37,7 @@ images:
   </figure>
   <figure class="rl-shot">
     <img src="/images/recall-notification.png" width="1336" height="1346" loading="lazy" alt="RunLore Slack notification showing an instant recall: an ⚡ Instant recall banner reading 'answered from your knowledge base, no investigation was run', the known cause, the citation of the knowledge-base entry harbor-core-migration-deadlock.md, and a cost footer showing this offline demo's single model call at 93% cached tokens." />
-    <figcaption><strong>The same failure, next time.</strong> Answered straight from the entry you merged &mdash; no investigation, and it cites the entry so you can check it. As shipped that is two model calls (the reranker, then the adversarial verify pass) against the seven the same incident's full investigation took; the card shows one because the offline demo turns the reranker off.</figcaption>
+    <figcaption><strong>The same failure, next time.</strong> Answered straight from the entry you merged &mdash; no investigation, and it cites the entry so you can check it. As shipped that is two model calls (the reranker, then the adversarial verify pass) against the seven the same incident&rsquo;s full investigation took; the card shows one because the offline demo turns the reranker off.</figcaption>
   </figure>
 </div>
 

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -157,18 +157,19 @@ then the answer is confirmed against live state and re-reviewed.
 > gate, not as a field measurement.
 >
 > **Cost & false-recall discipline.** The reranker runs *before* the "free"
-> short-circuit, so it is bounded: one call, `rerank_k` candidates, and only when
-> retrieval already surfaced a plausible candidate (a trivial `rerank_min_score` cost
-> guard — no call otherwise). It routes to `model.verify` (cheaper/faster) when
-> configured, costs ~1–2k tokens, and saves the ~100k of a full investigation when it
-> fires. A reranker that hallucinates a match is worse than no recall, so it fails
-> **safe**: it only ranks candidates that already passed the structural filter, ignores
-> any `entry_id` it did not offer, and treats a "no match", a low confidence, or a
-> model error as a fall-through to a full investigation (the negative cases fire on
-> **zero** entries). Everything downstream is unchanged — the recalled answer still
-> goes through live-state **confirm** and the adversarial **verify** pass. The reranker
-> is a *retrieval-time* decision ("which candidate + confident enough to short-circuit"),
-> **not** a second verify.
+> short-circuit, so its call is paid on every incident that reaches it — the ones that
+> then fall through to a full investigation included: one call over `rerank_k`
+> candidates, skipped only when the top score is under `rerank_min_score` (default
+> **0.1**, the bottom of the ~0.1–1.2 band real scores occupy, so it rarely skips). It
+> routes to `model.verify` (cheaper/faster) when configured, costs ~1–2k tokens, and
+> saves the ~100k of a full investigation when it fires. A reranker that hallucinates a
+> match is worse than no recall, so it fails **safe**: it only ranks candidates that
+> already passed the structural filter, ignores any `entry_id` it did not offer, and
+> treats a "no match", a low confidence, or a model error as a fall-through to a full
+> investigation (the negative cases fire on **zero** entries). Everything downstream is
+> unchanged — the recalled answer still goes through live-state **confirm** and the
+> adversarial **verify** pass. The reranker is a *retrieval-time* decision ("which
+> candidate + confident enough to short-circuit"), **not** a second verify.
 
 ```mermaid
 flowchart TD
@@ -241,15 +242,14 @@ Then two safety backstops before the recalled answer is delivered:
   precisely when things are already going wrong: **cost/load amplification** — a
   recall that would have cost two model calls (the reranker, which is on by default,
   then verify) now costs those two *plus* a full ReAct loop, up to `MaxSteps`
-  (default 20) model calls plus tool calls — the reranker's call and the failed
-  verify call are already spent when the fall-through starts, and it all arrives
-  exactly when the verify endpoint is unhealthy; and a **slow-verify timeout
-  interaction** — the
-  investigation's overall `Timeout` bounds the whole run *including* the failed verify
-  call, so if verify fails by exhausting that deadline rather than erroring fast, the
-  fall-through inherits an already-spent budget and the user gets a synthetic timeout
-  result where they previously got the recalled answer. Worth knowing before an
-  on-call incident, not discovering during one.
+  (default 20) model calls plus tool calls — both already spent when the fall-through
+  starts, and all of it arriving exactly when the verify endpoint is unhealthy; and a
+  **slow-verify timeout interaction** — the investigation's overall `Timeout` bounds
+  the whole run *including* the failed verify call, so if verify fails by exhausting
+  that deadline rather than erroring fast, the fall-through inherits an already-spent
+  budget and the user gets a synthetic timeout result where they previously got the
+  recalled answer. Worth knowing before an on-call incident, not discovering during
+  one.
 
 **Confidence is derived, never asserted** (`deriveRecallConfidence`,
 `outcomeFactor`): it's a function of the BM25 score, the margin, the structural-match

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -122,8 +122,9 @@ then the answer is confirmed against live state and re-reviewed.
 > The cosine thresholds are conservative placeholders; tune them against the
 > instant-recall eval before relying on them.
 
-> **LLM reranker (on by default) — the principled fire gate.** With `instant_recall.rerank`
-> set, Gate 2 (the BM25-magnitude margin) is **replaced** by a calibrated
+> **LLM reranker (on by default) — the principled fire gate.** Unless
+> `instant_recall.rerank` is explicitly set to `false`, Gate 2 (the BM25-magnitude
+> margin) is **replaced** by a calibrated
 > match-confidence gate. Query enrichment fixed retrieval *ranking* — on the real
 > corpus the correct runbook now ranks #1 (Recall@1 = 1.00, MRR 1.00) — but the
 > short-circuit still gated on the **absolute** BM25 magnitude (`solo_floor`), and an
@@ -162,9 +163,11 @@ then the answer is confirmed against live state and re-reviewed.
 > candidates, skipped only when the top score is under `rerank_min_score` (default
 > **0.1**, the bottom of the ~0.1–1.2 band real scores occupy, so it rarely skips). It
 > routes to `model.verify` (cheaper/faster) when configured, costs ~1–2k tokens, and
-> saves the ~100k of a full investigation when it fires. A reranker that hallucinates a
-> match is worse than no recall, so it fails **safe**: it only ranks candidates that
-> already passed the structural filter, ignores any `entry_id` it did not offer, and
+> buys back a whole investigation when it fires — the recorded demo transcript's came to
+> 7 calls / ~15.6k tokens, and `max_tokens_per_investigation` caps a run at 100k. A
+> reranker that hallucinates a match is worse than no recall, so it fails **safe**: it
+> only ranks candidates that already passed the structural filter, ignores any
+> `entry_id` it did not offer, and
 > treats a "no match", a low confidence, or a model error as a fall-through to a full
 > investigation (the negative cases fire on **zero** entries). Everything downstream is
 > unchanged — the recalled answer still goes through live-state **confirm** and the
@@ -242,8 +245,9 @@ Then two safety backstops before the recalled answer is delivered:
   precisely when things are already going wrong: **cost/load amplification** — a
   recall that would have cost two model calls (the reranker, which is on by default,
   then verify) now costs those two *plus* a full ReAct loop, up to `MaxSteps`
-  (default 20) model calls plus tool calls — both already spent when the fall-through
-  starts, and all of it arriving exactly when the verify endpoint is unhealthy; and a
+  (default 20) model calls plus tool calls and its own closing verify — the first two
+  already spent when the fall-through starts, and all of it arriving exactly when the
+  verify endpoint is unhealthy; and a
   **slow-verify timeout interaction** — the investigation's overall `Timeout` bounds
   the whole run *including* the failed verify call, so if verify fails by exhausting
   that deadline rather than erroring fast, the fall-through inherits an already-spent

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -239,9 +239,12 @@ Then two safety backstops before the recalled answer is delivered:
 
   Failing closed here is the correct trade, but it is not free, and both costs land
   precisely when things are already going wrong: **cost/load amplification** — a
-  recall that would have cost one model call now costs a full ReAct loop, up to
-  `MaxSteps` (default 20) model calls plus tool calls, arriving exactly when the
-  verify endpoint is unhealthy; and a **slow-verify timeout interaction** — the
+  recall that would have cost two model calls (the reranker, which is on by default,
+  then verify) now costs those two *plus* a full ReAct loop, up to `MaxSteps`
+  (default 20) model calls plus tool calls — the reranker's call and the failed
+  verify call are already spent when the fall-through starts, and it all arrives
+  exactly when the verify endpoint is unhealthy; and a **slow-verify timeout
+  interaction** — the
   investigation's overall `Timeout` bounds the whole run *including* the failed verify
   call, so if verify fails by exhausting that deadline rather than erroring fast, the
   fall-through inherits an already-spent budget and the user gets a synthetic timeout

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -196,6 +196,24 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   still goes through live-state confirm + the adversarial verify pass, exactly as before — the reranker
   is a *retrieval-time* "which candidate + confident enough to short-circuit" decision, not a second
   verify.
+
+  **What it costs in steady state** (budget for this before enabling). The reranker sits *in front of*
+  the short-circuit, so the call is spent on every incident that reaches it — **including the ones
+  that do not fire**: a `match=false`, a confidence under `rerank_threshold`, or a model error has
+  already paid for the call before falling through to the full investigation. The only thing that
+  prevents the call is `rerank_min_score`, and its default **0.1** sits at the *bottom* of the
+  ~0.1–1.2 band real enriched BM25 scores occupy, so it skips the call only when retrieval surfaced
+  essentially nothing. In practice, then, enabling instant recall adds **one model call to the floor
+  cost of nearly every investigation that has a structurally-agreeing candidate**, and buys back the
+  ~100k of a full investigation on the subset that fires. A fired recall is consequently **two** model
+  calls — rerank, then the verify pass (`Verify: true` is unconditional) — not one.
+  **Measure it, don't estimate it:** the reranker's traffic carries `provider="rerank"` on
+  `runlore_model_requests_total` and `runlore_model_request_duration_seconds`, so
+  `runlore_model_requests_total{provider="rerank"}` against `runlore_recall_hits_total` and
+  `runlore_recall_rejections_total{reason="rerank_low_confidence"}` gives you calls-paid vs
+  recalls-fired on your own corpus (see [Observability]({{< relref "/docs/operations/observability.md" >}})).
+  If the ratio is bad, raise `rerank_min_score` toward your corpus's real score regime — that trades
+  recall coverage for calls not made.
 - `instant_recall.hybrid` (**EXPERIMENTAL**, off by default; needs `model.embeddings`) — switches recall
   to fused **BM25 + embedding** retrieval, gated on **cosine** similarity (`hybrid_min_score` default
   **0.80**, `hybrid_margin_gap` default **0.05**) instead of the BM25 magnitude. *Provenance:* the hybrid

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -189,8 +189,9 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   **5** (candidates ranked per call; bounded for cost), `rerank_min_score` **0.1** (trivial
   retrieval-score floor below which the paid call is skipped — the cost guard). The call routes to
   **`model.verify`** when configured (cheaper/faster), else the main model. It costs ~1–2k tokens and
-  saves the ~100k of a full investigation when it fires. False-recall guards: it only ever ranks
-  candidates that already passed the structural filter, ignores any `entry_id` it did not offer
+  buys back a whole investigation when it fires — the recorded demo transcript's came to 7 calls /
+  ~15.6k tokens, and `max_tokens_per_investigation` caps a run at 100k. False-recall guards: it only
+  ever ranks candidates that already passed the structural filter, ignores any `entry_id` it did not offer
   (hallucination guard), and fails **safe** on a "no match", a low confidence, or a model error (fall
   through to a full investigation). Off ⇒ the BM25-magnitude gate is unchanged. The recalled answer
   still goes through live-state confirm + the adversarial verify pass, exactly as before — the reranker
@@ -200,18 +201,24 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   **What it costs in steady state** (budget for this before enabling). The reranker sits *in front of*
   the short-circuit, so the call is spent on every incident that reaches it — **including the ones
   that do not fire**: a `match=false`, a confidence under `rerank_threshold`, or a model error has
-  already paid for the call before falling through to the full investigation. The only thing that
-  prevents the call is `rerank_min_score`, and its default **0.1** sits at the *bottom* of the
-  ~0.1–1.2 band real enriched BM25 scores occupy, so it skips the call only when retrieval surfaced
-  essentially nothing. In practice, then, enabling instant recall adds **one model call to the floor
+  already paid for the call before falling through to the full investigation — as has a `low_outcome`
+  rejection, which is decided *after* the ranking. A candidate that fails retrieval or the structural
+  filter never reaches the reranker at all; past that point the last guard is `rerank_min_score`, and
+  its default **0.1** sits at the *bottom* of the ~0.1–1.2 band real enriched BM25 scores occupy, so
+  it skips the call only when retrieval surfaced essentially nothing.
+  In practice, then, enabling instant recall adds **one model call to the floor
   cost of nearly every investigation that has a structurally-agreeing candidate**, and buys back a
   full investigation on the subset that fires. A fired recall is consequently **two** model calls —
-  rerank, then the verify pass (always on; no setting disables it) — not one.
+  rerank, then the verify pass (always on; no config key disables it — `model.verify` only *routes*
+  it to a cheaper tier) — not one. The one exception is the runner-up path: when outcome decay
+  rejects the ranked winner, a second (and final) ranking call runs over the remaining candidates, so
+  a recall that fires from the fallback costs **three**.
   **Measure it, don't estimate it:** the reranker's traffic carries `provider="rerank"` on
   `runlore_model_requests_total` and `runlore_model_request_duration_seconds`, so
   `runlore_model_requests_total{provider="rerank"}` against `runlore_recall_hits_total` and
-  `runlore_recall_rejections_total{reason="rerank_low_confidence"}` gives you calls-paid vs
-  recalls-fired on your own corpus (see [Observability]({{< relref "/docs/operations/observability.md" >}})).
+  `runlore_recall_rejections_total{reason=~"rerank_low_confidence|low_outcome"}` gives you calls-paid
+  vs recalls-fired on your own corpus; `reason="no_resource_match"` tells you whether the reranker is
+  being reached at all (see [Observability]({{< relref "/docs/operations/observability.md" >}})).
   If the ratio is bad, raise `rerank_min_score` toward your corpus's real score regime — that trades
   recall coverage for calls not made.
 - `instant_recall.hybrid` (**EXPERIMENTAL**, off by default; needs `model.embeddings`) — switches recall

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -204,9 +204,9 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   prevents the call is `rerank_min_score`, and its default **0.1** sits at the *bottom* of the
   ~0.1–1.2 band real enriched BM25 scores occupy, so it skips the call only when retrieval surfaced
   essentially nothing. In practice, then, enabling instant recall adds **one model call to the floor
-  cost of nearly every investigation that has a structurally-agreeing candidate**, and buys back the
-  ~100k of a full investigation on the subset that fires. A fired recall is consequently **two** model
-  calls — rerank, then the verify pass (`Verify: true` is unconditional) — not one.
+  cost of nearly every investigation that has a structurally-agreeing candidate**, and buys back a
+  full investigation on the subset that fires. A fired recall is consequently **two** model calls —
+  rerank, then the verify pass (always on; no setting disables it) — not one.
   **Measure it, don't estimate it:** the reranker's traffic carries `provider="rerank"` on
   `runlore_model_requests_total` and `runlore_model_request_duration_seconds`, so
   `runlore_model_requests_total{provider="rerank"}` against `runlore_recall_hits_total` and

--- a/website/content/docs/operations/troubleshooting.md
+++ b/website/content/docs/operations/troubleshooting.md
@@ -136,13 +136,22 @@ Instant recall requires `catalog.instant_recall.enabled: true` **and** a confide
   candidates were rejected:
   | `reason` | meaning | lever |
   |---|---|---|
-  | `no_resource_match` | top hit didn't match the incident's workload | `instant_recall.require_workload_match` |
-  | `low_margin` | top hit too close to the runner-up (ambiguous) | `instant_recall.margin_gap` (default 1.0) |
+  | `no_resource_match` | no candidate's stored resource agreed with the incident's workload — the reranker was never reached | `instant_recall.require_workload_match` |
+  | `rerank_no_signal` | retrieval surfaced nothing plausible, so the paid ranking call was skipped | `instant_recall.rerank_min_score` (default 0.1) |
+  | `rerank_low_confidence` | the reranker returned no match, a confidence under the bar, or an error | `instant_recall.rerank_threshold` (default 0.7) |
+  | `low_margin` | **legacy gate only** (`rerank: false`) — top hit too close to the runner-up | `instant_recall.margin_gap` (default 1.0) |
   | `low_outcome` | the entry's real-world resolve-rate decayed below the floor | `instant_recall.outcome_floor` (default 0.5) |
-- `runlore_recall_score` (BM25 at the decision point) sitting below `instant_recall.min_score`
-  (default 1.0) ⇒ the catalog has no strong match yet. Recall **compounds** — it improves as merged
-  PRs accrete. A cold catalog legitimately won't recall.
-- Decision detail is logged at `msg="instant recall decision"` with `score`, `margin`, `confidence`.
+- **Check which gate is live before tuning anything.** The LLM reranker is **on by default** once
+  instant recall is enabled, and it *replaces* the BM25-magnitude gate — so on a default install
+  `min_score`, `margin_gap` and `solo_floor` play no part in the fire decision and tuning them
+  changes nothing. They apply only under `instant_recall.rerank: false`.
+- `runlore_recall_score` (BM25 at the decision point) is still recorded under the reranker, but there
+  it only *ranks* candidates: a score too low to spend a call on shows up as `rerank_no_signal`
+  against `rerank_min_score` (default 0.1), not against `min_score`. Either way a cold catalog
+  legitimately won't recall — recall **compounds** as merged PRs accrete.
+- Decision detail is logged at `msg="instant recall decision"` with `score`, `margin`, `confidence`;
+  under the reranker the fire decision itself is logged at `msg="recall reranker decision"` with
+  `match`, `entry_id`, `confidence` and the model's own one-line `reason`.
 - A recalled answer that fails the adversarial verify pass falls through to a full investigation:
   `msg="instant recall rejected by verify; running full investigation"`.
 


### PR DESCRIPTION
The published instant-recall cost claim describes a configuration RunLore does not ship, and the shipped Helm values contradict themselves about the same feature.

## 1. "A single model call" is the demo's configuration

The README and the homepage both say a recall is *"a single model call"* / *"one model call"*. That figure comes from `examples/demo/harbor-chart-bump.recall.transcript.json`, which has exactly one turn — the verify call. But the offline demo **deliberately disables the reranker** and prints so itself (`internal/app/demo.go`: *"production gates on the reranker's calibrated confidence, which needs a model"*).

As shipped the reranker is on (`RerankEnabled() = Enabled && (Rerank == nil || *Rerank)`) and verify is unconditional (`Verify: true`). A default instant recall is **two** model calls.

Verified from the repo's own fixtures:

| path | calls | in | out |
|---|---|---|---|
| full investigation | 7 | 14,034 | 1,537 |
| recall, offline demo config | 1 | 617 | 92 (93.0% cached — the alt-text is accurate for *that* run) |

**No ratio is published.** Reconstructing the rerank prompt from the actual constants gives roughly 0.75k input at K=1 and ~1.3k at K=5, so the shipped pair lands near 1.4–2.0k in — but that is an estimate, not a recorded fixture. The README now states only the two measured facts (2 calls, against 7 calls / ~15.6k tokens) and lets the reader divide. "Several times cheaper" is the only qualitative claim left.

## 2. `values.yaml` contradicted itself

The rerank block said *"ON by default when instant_recall is enabled"* and, four lines later, *"Default off ⇒ the magnitude gate is unchanged."* The false line is removed (the fallback instruction already lives on the `# rerank: false` knob below). The broken sentence *"replaces the (solo_floor/margin_gap)"* now names its noun: the BM25-magnitude gate.

## 3. The fail-closed cost note predated the reranker

`learning-loop.md` §3 said a verify outage turns *"one model call"* into a full ReAct loop. It is now two calls — reranker, then the failed verify — *plus* the loop, both already spent when the fall-through starts. Diff is confined to §3; §5/§6 are owned by another PR in flight.

## 4. Undisclosed steady-state cost

`rerank_min_score` defaults to `0.1` while real enriched BM25 scores run ~0.1–1.2 by the project's own measurement, so the cost guard rarely trips: essentially every incident with a structurally-agreeing candidate pays a rerank call, **including the ones that fall through to a full investigation**. Enabling instant recall therefore raises the floor cost of nearly every investigation by one call, and nothing said so.

`configuration.md` gains a "What it costs in steady state" paragraph with the measurement recipe — `runlore_model_requests_total{provider="rerank"}` against `runlore_recall_hits_total` and `runlore_recall_rejections_total{reason="rerank_low_confidence"}` — and names raising `rerank_min_score` as the tuning lever.

## Checks

Go gate green (`docsguard` included, nothing tripped). `docs-check.yml` satisfied with the CI-pinned Hugo 0.156.0: 85 pages build clean, `hack/check-anchors.sh` reports 381 anchors OK, screenshot-freshness passes on the existing acknowledgement.

## Flagged, not fixed

The `~100k of a full investigation` figure appears in `configuration.md`, `learning-loop.md` §3 and `rerank.go`, and was left alone in all three — nothing in the repo sources it, and the only recorded investigation is 15.6k, ~6x smaller. It may well be right for a tool-heavy real incident, but it is the next claim worth grounding.