### PR TITLE
fix(metrics): measure what a recall spends instead of asserting what it saved

### DIFF
--- a/deploy/helm/runlore/templates/service.yaml
+++ b/deploy/helm/runlore/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     # Distinguishes the scrapeable metrics Service from the StatefulSet's headless
     # governing Service below. Both otherwise carry identical labels, so the
     # VMServiceScrape (which selects selectorLabels) matched BOTH and scraped every
-    # pod twice, doubling all counters (e.g. tokens-saved, hits).
+    # pod twice, doubling all counters (e.g. recall tokens-spent, hits).
     app.kubernetes.io/component: server
 spec:
   type: {{ .Values.service.type }}

--- a/deploy/observability/grafana/README.md
+++ b/deploy/observability/grafana/README.md
@@ -8,13 +8,15 @@ Panels are grouped into collapsible rows:
 
 | Row | Panels |
 | --- | --- |
-| **Overview** | Agent version (`runlore_build_info`), Active leaders (`sum(runlore_leader)`, green at exactly 1), Replicas reporting (`count(runlore_build_info)`) |
-| **Alert intake** | Received / coalesced / suppressed alert rates |
-| **Investigations** | Started/throttled/dropped rates; duration p50/p95/p99; completion rate by result |
-| **Tools & model** | Tool call rate by tool; tool error ratio; tool latency p95 by tool; model request rate by provider; model error ratio; model latency p95 by provider |
-| **Recall efficacy** | Recall hits/rejections + tokens actually spent by recall; BM25 recall-score heatmap |
-| **Learning loop** | Outcomes opened by kind + incidents resolved; resolution time p50/p95; recall outcome by result (pie); curation rate by kind/result |
-| **Cost** | Per-investigation token estimate p50/p95 vs measured tokens per delivered recall (the gap is the saving) |
+| **🧠 Learning loop — is it working?** | Recall fire-rate; recall precision; recall resolve-rate; recall token savings; invalid KB entries |
+| **🔎 Retrieve — instant recall** | Recall outcome by verify result; rejections by reason; recall vs fresh answer mix; BM25 recall-score heatmap |
+| **🧪 Capture & trust — outcome ledger** | Outcomes opened + incidents resolved; incident resolution time p50/p95; recall outcome by result (pie) |
+| **📝 Curate — knowledge growth** | Curation rate by kind & result; curation dedup-score heatmap |
+| **💸 Cost & efficiency** | Tokens per investigation, full loop vs recall short-circuit (the gap is the saving); per-investigation cost p50/p95 (USD); model cache hit ratio |
+| **🔬 Investigations** | Started/throttled/dropped rates; duration p50/p95/p99; completion rate by result |
+| **🛠 Tools & model** | Tool call rate by tool; tool error ratio; tool latency p95 by tool; model request rate by provider; model error ratio; model latency p95 by provider; output truncation rate |
+| **📥 Alert intake** | Received / coalesced / suppressed alert rates; coalesced batch-size heatmap |
+| **🖥 Fleet** | Agent version (`runlore_build_info`), Active leaders (`sum(runlore_leader)`, green at exactly 1), Replicas reporting (`count(runlore_build_info)`) |
 
 Units follow conventions: rates use `ops`/`reqps`, durations use `s`, ratios use `percentunit`, token counts use `short`.
 

--- a/deploy/observability/grafana/README.md
+++ b/deploy/observability/grafana/README.md
@@ -12,9 +12,9 @@ Panels are grouped into collapsible rows:
 | **Alert intake** | Received / coalesced / suppressed alert rates |
 | **Investigations** | Started/throttled/dropped rates; duration p50/p95/p99; completion rate by result |
 | **Tools & model** | Tool call rate by tool; tool error ratio; tool latency p95 by tool; model request rate by provider; model error ratio; model latency p95 by provider |
-| **Recall efficacy** | Recall hits/rejections + tokens-saved rate; BM25 recall-score heatmap |
+| **Recall efficacy** | Recall hits/rejections + tokens actually spent by recall; BM25 recall-score heatmap |
 | **Learning loop** | Outcomes opened by kind + incidents resolved; resolution time p50/p95; recall outcome by result (pie); curation rate by kind/result |
-| **Cost** | Per-investigation token estimate p50/p95 + tokens-saved rate |
+| **Cost** | Per-investigation token estimate p50/p95 vs measured tokens per delivered recall (the gap is the saving) |
 
 Units follow conventions: rates use `ops`/`reqps`, durations use `s`, ratios use `percentunit`, token counts use `short`.
 

--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -1256,7 +1256,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Per-investigation token estimate (p50 / p95, investigation loop only) against the provider-reported tokens a delivered recall short-circuit actually costs (reranker + adversarial verify). The GAP between the two is the saving — both sides measured, neither assumed.",
+      "description": "Per-investigation token estimate (p50 / p95, investigation loop only) against the provider-reported tokens a delivered recall short-circuit actually costs (reranker + adversarial verify). The GAP between the two is the saving. Note the asymmetry: the p50/p95 series are the pre-request chars/4 ESTIMATE (loop only, excludes verify), the recall series is provider-reported.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -255,7 +255,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Estimated model tokens NOT spent because a recall short-circuited a full investigation \u2014 the compounding payoff of the catalog.",
+      "description": "Model tokens a delivered recall short-circuit actually cost (reranker + adversarial verify), provider-reported. This is the measured COST, not an assumed saving \u2014 compare it against tokens/investigation in the \"Token cost: full loop vs recall\" panel to see the payoff.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -304,13 +304,13 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(runlore_recall_tokens_saved_total[$__range]))",
-          "legendFormat": "saved",
+          "expr": "sum(increase(runlore_recall_tokens_spent_total[$__range]))",
+          "legendFormat": "spent",
           "refId": "A",
           "instant": true
         }
       ],
-      "title": "Tokens saved by recall",
+      "title": "Tokens spent by recall",
       "type": "stat"
     },
     {
@@ -1256,7 +1256,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Per-investigation token estimate (p50 / p95) and estimated tokens saved per second via recall.",
+      "description": "Per-investigation token estimate (p50 / p95, investigation loop only) against the provider-reported tokens a delivered recall short-circuit actually costs (reranker + adversarial verify). The GAP between the two is the saving — both sides measured, neither assumed.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1304,20 +1304,7 @@
           },
           "unit": "short"
         },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "tokens saved /s"
-            },
-            "properties": [
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -1369,12 +1356,12 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(runlore_recall_tokens_saved_total[$__rate_interval]))",
-          "legendFormat": "tokens saved /s",
+          "expr": "sum(increase(runlore_recall_tokens_spent_total[$__rate_interval])) / clamp_min(sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__rate_interval])), 1)",
+          "legendFormat": "tokens/recall (measured)",
           "refId": "C"
         }
       ],
-      "title": "Token cost & savings",
+      "title": "Token cost: full loop vs recall",
       "type": "timeseries"
     },
     {

--- a/deploy/observability/grafana/runlore.json
+++ b/deploy/observability/grafana/runlore.json
@@ -255,7 +255,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Model tokens a delivered recall short-circuit actually cost (reranker + adversarial verify), provider-reported. This is the measured COST, not an assumed saving \u2014 compare it against tokens/investigation in the \"Token cost: full loop vs recall\" panel to see the payoff.",
+      "description": "Share of an investigation's model tokens that a delivered recall short-circuit avoids: 1 - (tokens per recall / tokens per full-loop investigation), both provider-reported over the dashboard range. MEASURED on both sides \u2014 not an assumed budget ceiling. Negative means a recall currently costs more than the loop it replaced (check the reranker and verify token counts). The \"Token cost: full loop vs recall\" panel shows the two raw means.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -266,12 +266,20 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
               }
             ]
           },
-          "unit": "short"
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -304,13 +312,12 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(runlore_recall_tokens_spent_total[$__range]))",
-          "legendFormat": "spent",
-          "refId": "A",
-          "instant": true
+          "expr": "1 - (\n  (sum(increase(runlore_recall_tokens_spent_total[$__range]))\n   / sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range]))\n   and sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range])) > 0)\n  /\n  ((\n       sum(increase(runlore_investigation_input_tokens_sum{result!=\"recall\"}[$__range]))\n     + sum(increase(runlore_investigation_output_tokens_sum{result!=\"recall\"}[$__range]))\n   )\n   / sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range]))\n   and sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range])) > 0)\n)",
+          "legendFormat": "savings",
+          "refId": "A"
         }
       ],
-      "title": "Tokens spent by recall",
+      "title": "Recall token savings",
       "type": "stat"
     },
     {
@@ -1256,7 +1263,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Per-investigation token estimate (p50 / p95, investigation loop only) against the provider-reported tokens a delivered recall short-circuit actually costs (reranker + adversarial verify). The GAP between the two is the saving. Note the asymmetry: the p50/p95 series are the pre-request chars/4 ESTIMATE (loop only, excludes verify), the recall series is provider-reported.",
+      "description": "Mean provider-reported tokens (input incl. cached + output) per investigation, split by whether a recall short-circuited it. The GAP between the two lines IS the saving \u2014 both are measured the same way, over the same window, per investigation. The full-loop line filters {result!=\"recall\"} so it excludes the very runs it is being compared against; without that filter it would contain them and the apparent saving would shrink as recall improved. A window with no investigations of a given kind reads as no-data, not zero.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1336,8 +1343,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "tokens/investigation p50",
+          "expr": "(\n    sum(increase(runlore_investigation_input_tokens_sum{result!=\"recall\"}[$__range]))\n  + sum(increase(runlore_investigation_output_tokens_sum{result!=\"recall\"}[$__range]))\n)\n/ sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range]))\nand sum(increase(runlore_investigation_input_tokens_count{result!=\"recall\"}[$__range])) > 0",
+          "legendFormat": "tokens/investigation (full loop)",
           "refId": "A"
         },
         {
@@ -1346,19 +1353,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[$__rate_interval])) by (le))",
-          "legendFormat": "tokens/investigation p95",
+          "expr": "sum(increase(runlore_recall_tokens_spent_total[$__range]))\n/ sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range]))\nand sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__range])) > 0",
+          "legendFormat": "tokens/recall (short-circuit)",
           "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(runlore_recall_tokens_spent_total[$__rate_interval])) / clamp_min(sum(increase(runlore_investigations_completed_total{result=\"recall\"}[$__rate_interval])), 1)",
-          "legendFormat": "tokens/recall (measured)",
-          "refId": "C"
         }
       ],
       "title": "Token cost: full loop vs recall",

--- a/internal/docsguard/metric_names_test.go
+++ b/internal/docsguard/metric_names_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// dashboardPath and observabilityDoc are the two published surfaces that quote
+// RunLore metric names back at operators. Both are hand-maintained; neither is
+// compiled, imported, or executed by anything, so a rename in internal/telemetry
+// leaves them silently pointing at series the agent no longer emits.
+const (
+	dashboardPath      = "deploy/observability/grafana/runlore.json"
+	observabilityDoc   = "website/content/docs/operations/observability.md"
+	metricNamePattern  = `runlore_[a-z0-9_]+`
+	histogramSuffixBkt = "_bucket"
+)
+
+var metricNameRE = regexp.MustCompile(metricNamePattern)
+
+// TestPublishedMetricNamesExist pins every `runlore_*` series the Grafana dashboard
+// queries and the observability docs tabulate to a name the agent can actually emit.
+//
+// This is the guard the recall_tokens_saved_total → recall_tokens_spent_total rename
+// needed and did not have. That rename was carried out by hand-grepping the tree, and
+// the grep missed a reference: a chart-template comment naming the retired series
+// survived into the rendered manifest. Nothing failed, because nothing checks these
+// files against the instrument set — the dashboard is JSON, the doc table is Markdown,
+// and a PromQL selector for a series that does not exist is not an error anywhere. It
+// renders an empty panel, which looks exactly like "no incidents yet".
+//
+// The source of truth is the REAL exporter output, not a parse of metrics.go: this
+// records on every instrument in the set (found by reflection, so a new instrument is
+// covered the day it is added) and scrapes the same Prometheus handler /metrics serves.
+// What comes back is precisely what a dashboard can query — including the _bucket/_sum/
+// _count expansions the OTel Prometheus exporter derives from a histogram, which a
+// source parse would have to reimplement and get wrong.
+func TestPublishedMetricNamesExist(t *testing.T) {
+	emitted := emittedSeries(t)
+
+	for _, tc := range []struct {
+		name  string
+		path  string
+		found func(t *testing.T, body []byte) map[string][]string
+	}{
+		{name: "grafana_dashboard", path: dashboardPath, found: dashboardMetricRefs},
+		{name: "observability_docs", path: observabilityDoc, found: markdownMetricRefs},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join(repoRoot(t), tc.path))
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.path, err)
+			}
+			refs := tc.found(t, body)
+			if len(refs) == 0 {
+				t.Fatalf("no runlore_* metric names found in %s — the file moved or its shape changed, and this guard is inert", tc.path)
+			}
+			for _, name := range sortedKeys(refs) {
+				if seriesExists(emitted, name) {
+					continue
+				}
+				t.Errorf("%s references %q, which no instrument emits.\n"+
+					"  seen in: %s\n"+
+					"  Either the metric was renamed in internal/telemetry/metrics.go and this file was "+
+					"not updated, or the name is a typo. A panel querying a non-existent series renders "+
+					"empty, which is indistinguishable from a healthy idle agent.",
+					tc.path, name, strings.Join(refs[name], ", "))
+			}
+		})
+	}
+}
+
+// seriesExists accepts either an exact exported series or a histogram FAMILY name.
+// Prometheus never exposes a bare histogram name — only name_bucket/_sum/_count — but
+// the docs table names the family (`runlore_investigation_input_tokens`), which is the
+// conventional way to document one and is what an operator types to find it.
+func seriesExists(emitted map[string]bool, name string) bool {
+	return emitted[name] || emitted[name+histogramSuffixBkt]
+}
+
+// emittedSeries records on every instrument in the set and returns the series names the
+// Prometheus exporter actually publishes. Instruments are discovered by reflecting over
+// telemetry.Metrics rather than listed here: a hand-written list is a second thing to
+// maintain, and it would rot in exactly the direction this guard exists to catch — a new
+// metric added, never listed, so the docs can omit or misname it with impunity.
+func emittedSeries(t *testing.T) map[string]bool {
+	t.Helper()
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+
+	handler, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
+	ctx := context.Background()
+	m := telemetry.NewMetrics()
+	v := reflect.ValueOf(m).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		// The SDK backs counters and histograms with the SAME concrete type, whose Add and
+		// Record are literally the same call — so an instrument satisfies both interfaces
+		// regardless of how it was constructed, and which case matches here is arbitrary.
+		// Only the int64/float64 split is real. What this switch genuinely rejects is an
+		// instrument offering NEITHER method: an async/observable gauge, which is never
+		// recorded synchronously and so would silently contribute nothing to the scrape.
+		switch inst := v.Field(i).Interface().(type) {
+		case metric.Int64Counter:
+			inst.Add(ctx, 1)
+		case metric.Float64Histogram:
+			inst.Record(ctx, 1)
+		default:
+			t.Fatalf("telemetry.Metrics.%s is a %T, which cannot be recorded synchronously — "+
+				"it contributes no series to the scrape, so every doc reference to it would pass "+
+				"this guard vacuously. Emit it explicitly before the scrape below.",
+				v.Type().Field(i).Name, v.Field(i).Interface())
+		}
+	}
+	// The async gauges live outside the struct (registered at startup, not constructed).
+	if err := telemetry.RegisterRuntimeGauges("0.0.0-test", func() bool { return true }); err != nil {
+		t.Fatalf("register runtime gauges: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/metrics returned %d", rec.Code)
+	}
+
+	emitted := map[string]bool{}
+	families := map[string]bool{}
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		name := line
+		if i := strings.IndexAny(name, "{ "); i >= 0 {
+			name = name[:i]
+		}
+		emitted[name] = true
+		if strings.HasPrefix(name, "runlore_") {
+			families[strings.TrimSuffix(strings.TrimSuffix(strings.TrimSuffix(name, "_bucket"), "_sum"), "_count")] = true
+		}
+	}
+
+	// Completeness. The loop above is only useful if every instrument it touched actually
+	// reached the scrape; if one silently did not, its name is absent from `emitted` and
+	// every doc reference to it fails as "no instrument emits this" — a confusing false
+	// alarm — or, worse, a future instrument records under a name nothing checks. One
+	// family per struct field, plus the two async gauges, is the whole contract.
+	if want := v.NumField() + 2; len(families) != want {
+		t.Fatalf("scraped %d runlore_* metric families, want %d (%d telemetry.Metrics fields + build_info + leader) — "+
+			"an instrument did not reach /metrics, or a new one appeared outside the struct.\nscraped: %v",
+			len(families), want, v.NumField(), sortedSet(families))
+	}
+	return emitted
+}
+
+func sortedSet(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// dashboardMetricRefs pulls every runlore_* name out of the dashboard's PromQL. It walks
+// the decoded JSON for "expr" keys rather than regexing the raw file, so a metric name
+// that appears only in a panel title or description is not mistaken for a query.
+func dashboardMetricRefs(t *testing.T, body []byte) map[string][]string {
+	t.Helper()
+	var doc any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		t.Fatalf("parse dashboard JSON: %v", err)
+	}
+	refs := map[string][]string{}
+	var walk func(node any, where string)
+	walk = func(node any, where string) {
+		switch n := node.(type) {
+		case map[string]any:
+			title, _ := n["title"].(string)
+			if title != "" {
+				where = title
+			}
+			for k, val := range n {
+				if k == "expr" {
+					if expr, ok := val.(string); ok {
+						for _, name := range metricNameRE.FindAllString(expr, -1) {
+							refs[name] = appendUnique(refs[name], "panel "+where)
+						}
+					}
+					continue
+				}
+				walk(val, where)
+			}
+		case []any:
+			for _, item := range n {
+				walk(item, where)
+			}
+		}
+	}
+	walk(doc, "(dashboard root)")
+	return refs
+}
+
+// markdownMetricRefs pulls every runlore_* name out of the whole doc — the metric table
+// AND the PromQL recipes in prose. The recipes are the part most worth pinning: a metric
+// table entry that goes stale is a wrong label, but a recipe that goes stale is an
+// operator computing a number they will believe.
+func markdownMetricRefs(_ *testing.T, body []byte) map[string][]string {
+	refs := map[string][]string{}
+	for i, line := range strings.Split(string(body), "\n") {
+		for _, name := range metricNameRE.FindAllString(line, -1) {
+			refs[name] = appendUnique(refs[name], "line "+strconv.Itoa(i+1))
+		}
+	}
+	return refs
+}
+
+func appendUnique(in []string, s string) []string {
+	for _, existing := range in {
+		if existing == s {
+			return in
+		}
+	}
+	return append(in, s)
+}
+
+func sortedKeys(m map[string][]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -137,11 +137,6 @@ func (c *tokenCalibration) heuristicTarget(target int) int {
 // overBudget reports whether est exceeds budget. budget <= 0 means unlimited.
 func overBudget(est, budget int) bool { return budget > 0 && est > budget }
 
-// defaultRecallTokensSavedEstimate is a conservative proxy used when
-// MaxTokensPerInvestigation is unconfigured (0): ~50k tokens ≈ a medium-depth
-// investigation (system prompt + ~20 tool turns).
-const defaultRecallTokensSavedEstimate = 50_000
-
 // budgetNudge is the single-use message injected once when the token estimate
 // exceeds MaxTokensPerInvestigation, prompting the model to wrap up now.
 const budgetNudge = "⚠️ token budget reached — call submit_findings now with your best current hypotheses and the evidence gathered so far."

--- a/internal/investigate/cost.go
+++ b/internal/investigate/cost.go
@@ -5,6 +5,9 @@ package investigate
 import (
 	"context"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -69,15 +72,26 @@ func (li *LoopInvestigator) aggregateUsage(loop, verify providers.UsageTotals) p
 
 // recordUsageMetrics emits the per-investigation token totals (and estimated cost
 // when priced) to telemetry. Nil-safe: a no-op when metrics are disabled.
-func (li *LoopInvestigator) recordUsageMetrics(ctx context.Context, u providers.UsageTotals) {
+//
+// result carries the SAME completion label investigations_completed_total uses (the
+// caller sets it before every finish), so `{result="recall"}` selects exactly the
+// delivered recall short-circuits and `{result!="recall"}` exactly the investigations
+// that ran the full loop. Without it these histograms mixed both populations with no
+// way to tell them apart, and the "recall saving" was a subtraction whose subtrahend
+// silently contained its own minuend: the more work recall short-circuited, the more
+// recall runs dragged the per-investigation quantiles down, so the measured saving
+// shrank precisely as recall got better. One label turns that subtraction into a
+// filter.
+func (li *LoopInvestigator) recordUsageMetrics(ctx context.Context, u providers.UsageTotals, result string) {
 	if li.Metrics == nil {
 		return
 	}
-	li.Metrics.InvestigationModelCalls.Record(ctx, int64(u.ModelCalls))
-	li.Metrics.InvestigationInputTokens.Record(ctx, int64(u.InputTokens))
-	li.Metrics.InvestigationOutputTokens.Record(ctx, int64(u.OutputTokens))
-	li.Metrics.InvestigationCachedInputTokens.Record(ctx, int64(u.CachedInputTokens))
+	attrs := metric.WithAttributes(attribute.String("result", result))
+	li.Metrics.InvestigationModelCalls.Record(ctx, int64(u.ModelCalls), attrs)
+	li.Metrics.InvestigationInputTokens.Record(ctx, int64(u.InputTokens), attrs)
+	li.Metrics.InvestigationOutputTokens.Record(ctx, int64(u.OutputTokens), attrs)
+	li.Metrics.InvestigationCachedInputTokens.Record(ctx, int64(u.CachedInputTokens), attrs)
 	if u.Priced {
-		li.Metrics.InvestigationCostUSD.Record(ctx, u.CostUSD)
+		li.Metrics.InvestigationCostUSD.Record(ctx, u.CostUSD, attrs)
 	}
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -725,12 +725,28 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 		}
 		m.RecallHits.Add(ctx, 1, metric.WithAttributes(attribute.String("result", recallResult)))
 		if len(rec.RootCauses) > 0 {
-			// Tokens are only "saved" when the recall actually short-circuits the loop.
-			saved := int64(li.MaxTokensPerInvestigation)
-			if saved == 0 {
-				saved = defaultRecallTokensSavedEstimate // conservative proxy when budget is unconfigured
-			}
-			m.RecallTokensSaved.Add(ctx, saved)
+			// Record what this short-circuit COST, not a guess at what it saved. The
+			// previous counter added MaxTokensPerInvestigation — the configured budget
+			// CEILING (100k by default), which is not an observation of anything: the
+			// repo's own recorded full investigation
+			// (examples/demo/harbor-chart-bump.transcript.json) is 7 model calls totalling
+			// 14,034 in / 1,537 out, so the series overstated the saving by >6x. It also never
+			// subtracted the recall's own spend, which under the shipped defaults is TWO
+			// model calls (the LLM reranker + the adversarial verify pass), not zero.
+			//
+			// Measuring beats asserting, and there is nothing to estimate here: both of
+			// those calls have already accumulated into verifyTotals by this point, so the
+			// real number is in hand. Emitting the actual spend lets a dashboard difference
+			// it against the InvestigationInputTokens/InvestigationOutputTokens histograms
+			// recordUsageMetrics already emits for full investigations — a saving derived
+			// from two measurements instead of one constant. Cached input is included
+			// (providers.Usage.InputTokens already counts it), matching those histograms.
+			//
+			// Only on a delivered short-circuit: a recall the verify pass refutes falls
+			// through to a full investigation, and its tokens are reported there as part of
+			// that investigation's own totals.
+			spent := int64(verifyTotals.InputTokens + verifyTotals.OutputTokens)
+			m.RecallTokensSpent.Add(ctx, spent)
 		}
 	}
 	if len(rec.RootCauses) > 0 {

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -287,7 +287,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// chokepoint — every exit (happy path, recall short-circuit, timeout, refusal, budget
 		// kill, max-steps) routes through it, so no delivered investigation can miss it.
 		inv.InvestigationStartedAt = start
-		li.recordUsageMetrics(ctx, inv.Usage)
+		// Every caller sets `result` BEFORE calling finish, so the usage histograms carry
+		// the same completion label the deferred completion metric records — which is what
+		// lets a dashboard read a recall's cost and a full loop's off the same instrument
+		// instead of differencing one out of a total that already contains it.
+		li.recordUsageMetrics(ctx, inv.Usage, result)
 		li.deliver(req, inv)
 	}
 	defer func() {

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -725,28 +725,17 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 		}
 		m.RecallHits.Add(ctx, 1, metric.WithAttributes(attribute.String("result", recallResult)))
 		if len(rec.RootCauses) > 0 {
-			// Record what this short-circuit COST, not a guess at what it saved. The
-			// previous counter added MaxTokensPerInvestigation — the configured budget
-			// CEILING (100k by default), which is not an observation of anything: the
-			// repo's own recorded full investigation
-			// (examples/demo/harbor-chart-bump.transcript.json) is 7 model calls totalling
-			// 14,034 in / 1,537 out, so the series overstated the saving by >6x. It also never
-			// subtracted the recall's own spend, which under the shipped defaults is TWO
-			// model calls (the LLM reranker + the adversarial verify pass), not zero.
+			// What this short-circuit COST, measured — not a guess at what it saved. By
+			// here verifyTotals holds every model call the recall path made (the opt-in
+			// reranker plus the adversarial verify pass), so the real number is already in
+			// hand: a dashboard differences it against the per-investigation token
+			// histograms recordUsageMetrics emits to size what recall avoided. Cached input
+			// is included (providers.Usage.InputTokens already counts it), matching those
+			// histograms.
 			//
-			// Measuring beats asserting, and there is nothing to estimate here: both of
-			// those calls have already accumulated into verifyTotals by this point, so the
-			// real number is in hand. Emitting the actual spend lets a dashboard difference
-			// it against the InvestigationInputTokens/InvestigationOutputTokens histograms
-			// recordUsageMetrics already emits for full investigations — a saving derived
-			// from two measurements instead of one constant. Cached input is included
-			// (providers.Usage.InputTokens already counts it), matching those histograms.
-			//
-			// Only on a delivered short-circuit: a recall the verify pass refutes falls
-			// through to a full investigation, and its tokens are reported there as part of
-			// that investigation's own totals.
-			spent := int64(verifyTotals.InputTokens + verifyTotals.OutputTokens)
-			m.RecallTokensSpent.Add(ctx, spent)
+			// Delivered short-circuits only: a recall the verify pass refutes falls through
+			// to a full investigation, which reports these tokens in its own totals.
+			m.RecallTokensSpent.Add(ctx, int64(verifyTotals.InputTokens+verifyTotals.OutputTokens))
 		}
 	}
 	if len(rec.RootCauses) > 0 {

--- a/internal/investigate/recall_tokens_test.go
+++ b/internal/investigate/recall_tokens_test.go
@@ -196,12 +196,26 @@ func TestRecallTokensSpentNotRecordedOnFallThrough(t *testing.T) {
 				Score: 5.0,
 			}}},
 		},
-		OnComplete: func(providers.Investigation) {},
 	}
+	var delivered providers.Investigation
+	li.OnComplete = func(inv providers.Investigation) { delivered = inv }
 	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
 	if got, ok := read("runlore_recall_tokens_spent_total"); ok {
 		t.Fatalf("runlore_recall_tokens_spent_total = %d on a verify-rejected recall; it must only count delivered short-circuits", got)
+	}
+	// …and the other half of "not double-counted": the refuted recall's tokens are not
+	// DROPPED either, they are carried by the full investigation that ran instead. Both
+	// halves have to hold — skipping the counter would otherwise be indistinguishable
+	// from losing the spend entirely, and the recall's 960 tokens were really paid.
+	const (
+		refutedRecall = 900 + 60   // the verify pass that refuted the recalled entry
+		fullLoop      = 2000 + 100 // the fall-through loop's own submit_findings turn
+		loopVerify    = 300 + 20   // …and the verify pass over its findings
+	)
+	if got, want := delivered.Usage.InputTokens+delivered.Usage.OutputTokens, refutedRecall+fullLoop+loopVerify; got != want {
+		t.Fatalf("delivered usage = %d tokens, want %d — the refuted recall's %d tokens must still be billed to the full investigation that replaced it (in %d / out %d)",
+			got, want, refutedRecall, delivered.Usage.InputTokens, delivered.Usage.OutputTokens)
 	}
 }

--- a/internal/investigate/recall_tokens_test.go
+++ b/internal/investigate/recall_tokens_test.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// meteredInstruments installs a REAL SDK meter provider backed by a manual reader and
+// returns the instrument set bound to it, plus a reader that sums an int64 counter by
+// its exported series name (0, false when the series was never recorded). The provider
+// is global, so the returned instruments must be used by exactly one test at a time
+// (no t.Parallel here) and the cleanup restores the no-op provider.
+func meteredInstruments(t *testing.T) (*telemetry.Metrics, func(series string) (int64, bool)) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	return telemetry.NewMetrics(), func(series string) (int64, bool) {
+		var rm metricdata.ResourceMetrics
+		if err := reader.Collect(context.Background(), &rm); err != nil {
+			t.Fatalf("collect metrics: %v", err)
+		}
+		for _, sm := range rm.ScopeMetrics {
+			for _, md := range sm.Metrics {
+				if md.Name != series {
+					continue
+				}
+				sum, ok := md.Data.(metricdata.Sum[int64])
+				if !ok {
+					t.Fatalf("series %q is not an int64 sum (%T)", series, md.Data)
+				}
+				var total int64
+				for _, dp := range sum.DataPoints {
+					total += dp.Value
+				}
+				return total, true
+			}
+		}
+		return 0, false
+	}
+}
+
+// TestRecallTokensSpentTracksObservedUsage pins the recall cost metric to what the
+// recall ACTUALLY spent, not to the configured budget ceiling.
+//
+// The regression it guards: the counter used to record MaxTokensPerInvestigation (the
+// ceiling — 100k by default, ~7x a real investigation's observed spend) and never
+// subtracted the recall's own model calls, so the series asserted a saving nobody
+// measured. Both cases below configure a 100_000 ceiling precisely so a metric that
+// still reads the ceiling cannot pass.
+//
+// The rerank case matters because a fired recall under the SHIPPED defaults is two
+// model calls, not one — the LLM reranker plus the adversarial verify pass — and both
+// land in the same verifyTotals the short-circuit prices from.
+func TestRecallTokensSpentTracksObservedUsage(t *testing.T) {
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+	keepVerdict := `{"verdicts":[{"index":0,"verdict":"keep","confidence":0.8}]}`
+
+	tests := []struct {
+		name string
+		// build wires an investigator whose recall fires and short-circuits, with the
+		// instrument set under test attached to both the loop and the Recall.
+		build func(m *telemetry.Metrics) (*LoopInvestigator, Request)
+		// want is the sum of the provider-reported input+output tokens of every model
+		// call the recall path makes.
+		want int64
+	}{
+		{
+			// Verify only (no reranker): one model call, the adversarial review of the
+			// recalled entry.
+			name: "verify_only",
+			build: func(m *telemetry.Metrics) (*LoopInvestigator, Request) {
+				verify := &scriptModel{responses: []providers.CompletionResponse{{
+					ToolCalls: []providers.ToolCall{{ID: "v1", Name: submitVerdictsName, Args: keepVerdict}},
+					Usage:     providers.Usage{InputTokens: 900, OutputTokens: 60},
+				}}}
+				li := &LoopInvestigator{
+					Model:                     verify,
+					Verify:                    true,
+					MaxTokensPerInvestigation: 100_000,
+					Log:                       discard,
+					Metrics:                   m,
+					Recall: &Recall{
+						MinScore: 2.0, Metrics: m,
+						Catalog: fakeScored{hits: []catalog.ScoredEntry{{
+							Entry: catalog.Entry{Title: "Known incident", Description: "chart bump", Path: "known.md", Resource: "tooling/harbor"},
+							Score: 5.0,
+						}}},
+					},
+					OnComplete: func(providers.Investigation) {},
+				}
+				return li, Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}
+			},
+			want: 960,
+		},
+		{
+			// The shipped default: reranker ON, verify ON — TWO model calls, so a metric
+			// that prices only the verify pass under-reports the recall's cost.
+			name: "rerank_and_verify",
+			build: func(m *telemetry.Metrics) (*LoopInvestigator, Request) {
+				reranker := &countingReranker{resp: providers.CompletionResponse{
+					ToolCalls: []providers.ToolCall{{ID: "rr", Name: rerankToolName, Args: `{"match":true,"entry_id":"web.md","confidence":0.85}`}},
+					Usage:     providers.Usage{InputTokens: 1200, OutputTokens: 40},
+				}}
+				verify := &scriptModel{responses: []providers.CompletionResponse{{
+					ToolCalls: []providers.ToolCall{{ID: "v1", Name: submitVerdictsName, Args: keepVerdict}},
+					Usage:     providers.Usage{InputTokens: 900, OutputTokens: 60},
+				}}}
+				r := rerankRecall(reranker, []catalog.ScoredEntry{webHit("web.md", 0.6)})
+				r.Metrics = m
+				li := &LoopInvestigator{
+					Model:                     verify,
+					Verify:                    true,
+					MaxTokensPerInvestigation: 100_000,
+					Log:                       discard,
+					Metrics:                   m,
+					Recall:                    r,
+					OnComplete:                func(providers.Investigation) {},
+				}
+				return li, okReq()
+			},
+			want: 2200,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, read := meteredInstruments(t)
+			li, req := tc.build(m)
+			var delivered providers.Investigation
+			prev := li.OnComplete
+			li.OnComplete = func(inv providers.Investigation) {
+				delivered = inv
+				prev(inv)
+			}
+			if err := li.Investigate(context.Background(), req); err != nil {
+				t.Fatalf("Investigate: %v", err)
+			}
+			// Premise: the recall really did short-circuit the loop.
+			if !delivered.Recalled {
+				t.Fatalf("premise failed — the recall must short-circuit for this metric to be recorded: %+v", delivered)
+			}
+			got, ok := read("runlore_recall_tokens_spent_total")
+			if !ok {
+				t.Fatal("runlore_recall_tokens_spent_total was never recorded on a delivered recall short-circuit")
+			}
+			if got != tc.want {
+				t.Fatalf("runlore_recall_tokens_spent_total = %d, want %d (the recall's observed input+output tokens, NOT the %d budget ceiling)",
+					got, tc.want, li.MaxTokensPerInvestigation)
+			}
+			// The recall's spend is a strict subset of the per-investigation usage the
+			// short-circuit already reports, so a dashboard can difference the two.
+			if delivered.Usage.InputTokens+delivered.Usage.OutputTokens != int(tc.want) {
+				t.Fatalf("delivered usage = in %d / out %d; the counter must be the same observed spend (%d)",
+					delivered.Usage.InputTokens, delivered.Usage.OutputTokens, tc.want)
+			}
+		})
+	}
+}
+
+// TestRecallTokensSpentNotRecordedOnFallThrough keeps the counter scoped to recalls
+// that were actually DELIVERED: a recall the adversarial verify pass refutes falls
+// through to a full investigation, and its tokens are already carried in that
+// investigation's own usage totals. Counting them here too would double-count them
+// and make the series stop meaning "what a short-circuit costs".
+func TestRecallTokensSpentNotRecordedOnFallThrough(t *testing.T) {
+	m, read := meteredInstruments(t)
+	model := &scriptModel{responses: []providers.CompletionResponse{
+		// verify the recalled entry → reject it entirely (falls through).
+		{ToolCalls: []providers.ToolCall{{ID: "v1", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"reject","reason":"correlation only"}]}`}},
+			Usage: providers.Usage{InputTokens: 900, OutputTokens: 60}},
+		// the fall-through loop concludes on its own.
+		{ToolCalls: []providers.ToolCall{{ID: "f1", Name: submitFindingsName, Args: `{"confidence":0.8,"root_causes":[{"summary":"freshly investigated","confidence":0.8}]}`}},
+			Usage: providers.Usage{InputTokens: 2000, OutputTokens: 100}},
+		// …and verifies it.
+		{ToolCalls: []providers.ToolCall{{ID: "v2", Name: submitVerdictsName, Args: `{"verdicts":[{"index":0,"verdict":"keep","confidence":0.8}]}`}},
+			Usage: providers.Usage{InputTokens: 300, OutputTokens: 20}},
+	}}
+	li := &LoopInvestigator{
+		Model:                     model,
+		Verify:                    true,
+		MaxTokensPerInvestigation: 100_000,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Metrics:                   m,
+		Recall: &Recall{
+			MinScore: 2.0, Metrics: m,
+			Catalog: fakeScored{hits: []catalog.ScoredEntry{{
+				Entry: catalog.Entry{Title: "Stale entry", Description: "no longer applies", Path: "stale.md", Resource: "tooling/harbor"},
+				Score: 5.0,
+			}}},
+		},
+		OnComplete: func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got, ok := read("runlore_recall_tokens_spent_total"); ok {
+		t.Fatalf("runlore_recall_tokens_spent_total = %d on a verify-rejected recall; it must only count delivered short-circuits", got)
+	}
+}

--- a/internal/investigate/recall_tokens_test.go
+++ b/internal/investigate/recall_tokens_test.go
@@ -100,7 +100,6 @@ func TestRecallTokensSpentTracksObservedUsage(t *testing.T) {
 							Score: 5.0,
 						}}},
 					},
-					OnComplete: func(providers.Investigation) {},
 				}
 				return li, Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}
 			},
@@ -128,7 +127,6 @@ func TestRecallTokensSpentTracksObservedUsage(t *testing.T) {
 					Log:                       discard,
 					Metrics:                   m,
 					Recall:                    r,
-					OnComplete:                func(providers.Investigation) {},
 				}
 				return li, okReq()
 			},
@@ -141,11 +139,7 @@ func TestRecallTokensSpentTracksObservedUsage(t *testing.T) {
 			m, read := meteredInstruments(t)
 			li, req := tc.build(m)
 			var delivered providers.Investigation
-			prev := li.OnComplete
-			li.OnComplete = func(inv providers.Investigation) {
-				delivered = inv
-				prev(inv)
-			}
+			li.OnComplete = func(inv providers.Investigation) { delivered = inv }
 			if err := li.Investigate(context.Background(), req); err != nil {
 				t.Fatalf("Investigate: %v", err)
 			}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -34,13 +34,26 @@ type Metrics struct {
 	HistorySummarizations      metric.Int64Counter // compaction events whose elided batch was replaced by a model digest
 	HistorySummarizeFallbacks  metric.Int64Counter // summarize-mode compactions that fell back to plain elision (summarizer error/refusal/truncation)
 	RecallHits                 metric.Int64Counter // KB cache hits, labelled by verify result
-	RecallTokensSpent          metric.Int64Counter // tokens a DELIVERED recall short-circuit actually spent (reranker + adversarial verify) — a measurement, not a saving estimate; difference it against InvestigationInputTokens/InvestigationOutputTokens to size what recall avoided
+	RecallTokensSpent          metric.Int64Counter // tokens a DELIVERED recall short-circuit actually spent (reranker + adversarial verify) — a measurement, not a saving estimate; see the recall-saving recipe below
 	RecallRejections           metric.Int64Counter // recalls rejected before short-circuit (label: reason)
 	CoalesceBatchSize          metric.Int64Histogram
 	InvestigationTokens        metric.Int64Histogram
 	// Per-investigation model usage totals (loop + verify), recorded once at
 	// delivery — the actual provider-reported spend, distinct from the pre-request
-	// InvestigationTokens estimate.
+	// InvestigationTokens estimate. All carry the `result` label, with the same
+	// vocabulary as InvestigationsCompleted.
+	//
+	// THE RECALL-SAVING RECIPE (the one true form — the observability docs and the Grafana
+	// "Cost & efficiency" row state this same one). Compare two means, both measured:
+	//
+	//	recall:    recall_tokens_spent_total / investigations_completed_total{result="recall"}
+	//	full loop: (investigation_input_tokens_sum + investigation_output_tokens_sum){result!="recall"}
+	//	           / investigation_input_tokens_count{result!="recall"}
+	//
+	// The GAP between them is the saving. The `result` filter is load-bearing: unfiltered,
+	// these histograms cover recall short-circuits too, so the full-loop term would contain
+	// the very runs being subtracted from it and the measured saving would shrink as recall
+	// got better. Never difference the counter out of an unfiltered total.
 	InvestigationModelCalls        metric.Int64Histogram
 	InvestigationInputTokens       metric.Int64Histogram
 	InvestigationOutputTokens      metric.Int64Histogram
@@ -104,11 +117,11 @@ func NewMetrics() *Metrics {
 		CoalesceBatchSize:          hist("coalesce_batch_size", "incidents per flushed batch"),
 		InvestigationTokens:        hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),
 
-		InvestigationModelCalls:        hist("investigation_model_calls", "model completions per investigation (loop + verify)"),
-		InvestigationInputTokens:       hist("investigation_input_tokens", "provider-reported input tokens per investigation, including cached (loop + verify)"),
-		InvestigationOutputTokens:      hist("investigation_output_tokens", "provider-reported output tokens per investigation (loop + verify)"),
-		InvestigationCachedInputTokens: hist("investigation_cached_input_tokens", "input tokens served from cache per investigation (loop + verify)"),
-		InvestigationCostUSD:           histF("investigation_cost_usd", "estimated per-investigation cost in USD (only when model.pricing is configured)"),
+		InvestigationModelCalls:        hist("investigation_model_calls", "model completions per investigation (loop + verify; label: result)"),
+		InvestigationInputTokens:       hist("investigation_input_tokens", "provider-reported input tokens per investigation, including cached (loop + verify; label: result)"),
+		InvestigationOutputTokens:      hist("investigation_output_tokens", "provider-reported output tokens per investigation (loop + verify; label: result)"),
+		InvestigationCachedInputTokens: hist("investigation_cached_input_tokens", "input tokens served from cache per investigation (loop + verify; label: result)"),
+		InvestigationCostUSD:           histF("investigation_cost_usd", "estimated per-investigation cost in USD (only when model.pricing is configured; label: result)"),
 		RecallScore:                    histF("recall_score", "BM25 score at the recall decision point"),
 		CurationDedupScore:             histF("curation_dedup_score", "catalog top-hit BM25 score at the curation dedup decision"),
 		OutcomesOpened:                 ctr("outcomes_opened_total", "investigations recorded in the outcome ledger (label: kind)"),

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -34,10 +34,17 @@ type Metrics struct {
 	HistorySummarizations      metric.Int64Counter // compaction events whose elided batch was replaced by a model digest
 	HistorySummarizeFallbacks  metric.Int64Counter // summarize-mode compactions that fell back to plain elision (summarizer error/refusal/truncation)
 	RecallHits                 metric.Int64Counter // KB cache hits, labelled by verify result
-	RecallTokensSaved          metric.Int64Counter // estimated tokens saved by a recall short-circuit
-	RecallRejections           metric.Int64Counter // recalls rejected before short-circuit (label: reason)
-	CoalesceBatchSize          metric.Int64Histogram
-	InvestigationTokens        metric.Int64Histogram
+	// RecallTokensSpent is what a DELIVERED recall short-circuit actually cost:
+	// provider-reported input (incl. cached) + output tokens across the LLM reranker
+	// and the adversarial verify pass. It is a measurement, not a saving estimate —
+	// difference it against the InvestigationInputTokens / InvestigationOutputTokens
+	// histograms to size what recall avoided. It replaces recall_tokens_saved_total,
+	// which asserted a saving equal to the configured budget CEILING (>6x a real
+	// investigation's observed spend) and never subtracted the recall's own cost.
+	RecallTokensSpent   metric.Int64Counter
+	RecallRejections    metric.Int64Counter // recalls rejected before short-circuit (label: reason)
+	CoalesceBatchSize   metric.Int64Histogram
+	InvestigationTokens metric.Int64Histogram
 	// Per-investigation model usage totals (loop + verify), recorded once at
 	// delivery — the actual provider-reported spend, distinct from the pre-request
 	// InvestigationTokens estimate.
@@ -99,7 +106,7 @@ func NewMetrics() *Metrics {
 		HistorySummarizations:      ctr("history_summarizations_total", "compaction events whose elided batch was replaced by a model-produced digest"),
 		HistorySummarizeFallbacks:  ctr("history_summarize_fallbacks_total", "summarize-mode compactions that fell back to plain elision (summarizer error/refusal/truncation)"),
 		RecallHits:                 ctr("recall_hits_total", "KB instant-recall short-circuits (label: result)"),
-		RecallTokensSaved:          ctr("recall_tokens_saved_total", "estimated tokens saved by recall short-circuits"),
+		RecallTokensSpent:          ctr("recall_tokens_spent_total", "model tokens (input incl. cached + output) actually spent by delivered recall short-circuits: the LLM reranker plus the adversarial verify pass"),
 		RecallRejections:           ctr("recall_rejections_total", "recalls rejected before short-circuit (label: reason)"),
 		CoalesceBatchSize:          hist("coalesce_batch_size", "incidents per flushed batch"),
 		InvestigationTokens:        hist("investigation_tokens_estimated", "per-investigation token estimate (investigation loop only; excludes the adversarial verify phase)"),

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -34,17 +34,10 @@ type Metrics struct {
 	HistorySummarizations      metric.Int64Counter // compaction events whose elided batch was replaced by a model digest
 	HistorySummarizeFallbacks  metric.Int64Counter // summarize-mode compactions that fell back to plain elision (summarizer error/refusal/truncation)
 	RecallHits                 metric.Int64Counter // KB cache hits, labelled by verify result
-	// RecallTokensSpent is what a DELIVERED recall short-circuit actually cost:
-	// provider-reported input (incl. cached) + output tokens across the LLM reranker
-	// and the adversarial verify pass. It is a measurement, not a saving estimate —
-	// difference it against the InvestigationInputTokens / InvestigationOutputTokens
-	// histograms to size what recall avoided. It replaces recall_tokens_saved_total,
-	// which asserted a saving equal to the configured budget CEILING (>6x a real
-	// investigation's observed spend) and never subtracted the recall's own cost.
-	RecallTokensSpent   metric.Int64Counter
-	RecallRejections    metric.Int64Counter // recalls rejected before short-circuit (label: reason)
-	CoalesceBatchSize   metric.Int64Histogram
-	InvestigationTokens metric.Int64Histogram
+	RecallTokensSpent          metric.Int64Counter // tokens a DELIVERED recall short-circuit actually spent (reranker + adversarial verify) — a measurement, not a saving estimate; difference it against InvestigationInputTokens/InvestigationOutputTokens to size what recall avoided
+	RecallRejections           metric.Int64Counter // recalls rejected before short-circuit (label: reason)
+	CoalesceBatchSize          metric.Int64Histogram
+	InvestigationTokens        metric.Int64Histogram
 	// Per-investigation model usage totals (loop + verify), recorded once at
 	// delivery — the actual provider-reported spend, distinct from the pre-request
 	// InvestigationTokens estimate.

--- a/internal/telemetry/metrics_extra_test.go
+++ b/internal/telemetry/metrics_extra_test.go
@@ -36,6 +36,7 @@ func TestNewInstrumentsExposeContractNames(t *testing.T) {
 	m.ModelRequests.Add(ctx, 1, metric.WithAttributes(attribute.String("provider", "anthropic"), attribute.String("result", "ok")))
 	m.ModelRequestDuration.Record(ctx, 0.9, metric.WithAttributes(attribute.String("provider", "anthropic")))
 	m.Curations.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", "pr"), attribute.String("result", "opened")))
+	m.RecallTokensSpent.Add(ctx, 2200)
 
 	if err := RegisterRuntimeGauges("1.2.3", func() bool { return true }); err != nil {
 		t.Fatalf("register gauges: %v", err)
@@ -54,6 +55,9 @@ func TestNewInstrumentsExposeContractNames(t *testing.T) {
 		"runlore_model_requests_total",
 		"runlore_model_request_duration_seconds",
 		"runlore_curations_total",
+		// The recall cost series the Grafana "Cost & efficiency" row differences
+		// against the per-investigation token histograms.
+		"runlore_recall_tokens_spent_total",
 		"runlore_build_info",
 		"runlore_leader",
 	}
@@ -61,6 +65,11 @@ func TestNewInstrumentsExposeContractNames(t *testing.T) {
 		if !strings.Contains(body, name) {
 			t.Errorf("missing series %q in /metrics output", name)
 		}
+	}
+	// The retired series asserted a saving equal to the configured budget ceiling; it
+	// must not come back alongside its measured replacement.
+	if strings.Contains(body, "runlore_recall_tokens_saved_total") {
+		t.Error("runlore_recall_tokens_saved_total is retired — recall cost is now measured, not asserted")
 	}
 	// build_info must carry the version label, and leader must read 1 here.
 	if !strings.Contains(body, `version="1.2.3"`) {

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -76,7 +76,7 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | Metric | Type | Labels | Meaning |
 |---|---|---|---|
 | `runlore_recall_hits_total` | counter | `result` | instant-recall short-circuits |
-| `runlore_recall_tokens_saved_total` | counter | — | estimated tokens saved by recall |
+| `runlore_recall_tokens_spent_total` | counter | — | tokens a **delivered** recall short-circuit actually cost (LLM reranker + adversarial verify). It is a measurement, not a saving estimate: difference it against `runlore_investigation_input_tokens` + `runlore_investigation_output_tokens` to size what recall avoided |
 | `runlore_recall_rejections_total` | counter | `reason` | recalls rejected before short-circuit |
 | `runlore_recall_score` | histogram | — | BM25 score at the recall decision |
 | `runlore_outcomes_opened_total` | counter | `kind` | investigations recorded as open |

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -70,13 +70,23 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_tool_call_duration_seconds` | histogram | `tool` | per-tool latency |
 | `runlore_model_requests_total` | counter | `provider`, `result` | LLM completion requests (`ok`/`error`) |
 | `runlore_model_request_duration_seconds` | histogram | `provider` | LLM completion latency |
-| `runlore_investigation_tokens_estimated` | histogram | — | per-investigation token estimate |
+| `runlore_investigation_tokens_estimated` | histogram | — | per-investigation token estimate (pre-request `chars/4` heuristic, investigation loop only — excludes the adversarial verify phase). This is what the `RunloreInvestigationCostHigh` alert watches |
+| `runlore_investigation_model_calls` | histogram | `result` | model completions per investigation (loop + verify) |
+| `runlore_investigation_input_tokens` | histogram | `result` | provider-reported input tokens per investigation, including cached (loop + verify) |
+| `runlore_investigation_output_tokens` | histogram | `result` | provider-reported output tokens per investigation (loop + verify) |
+| `runlore_investigation_cached_input_tokens` | histogram | `result` | input tokens served from cache per investigation (loop + verify) |
+| `runlore_investigation_cost_usd` | histogram | `result` | estimated per-investigation cost in USD (only when `model.pricing` is configured) |
+
+The five usage histograms carry the same `result` values as
+`runlore_investigations_completed_total`, so `{result="recall"}` selects exactly the
+investigations a recall short-circuited and `{result!="recall"}` exactly those that ran
+the full loop. That split is what makes the recall saving measurable — see below.
 
 ### Recall, learning loop & curation
 | Metric | Type | Labels | Meaning |
 |---|---|---|---|
 | `runlore_recall_hits_total` | counter | `result` | instant-recall short-circuits |
-| `runlore_recall_tokens_spent_total` | counter | — | tokens a **delivered** recall short-circuit actually cost (LLM reranker + adversarial verify). It is a measurement, not a saving estimate: difference it against `runlore_investigation_input_tokens` + `runlore_investigation_output_tokens` to size what recall avoided |
+| `runlore_recall_tokens_spent_total` | counter | — | tokens a **delivered** recall short-circuit actually cost (LLM reranker + adversarial verify). A measurement, not a saving estimate — see [Measuring the recall saving](#measuring-the-recall-saving) |
 | `runlore_recall_rejections_total` | counter | `reason` | recalls rejected before short-circuit |
 | `runlore_recall_score` | histogram | — | BM25 score at the recall decision |
 | `runlore_outcomes_opened_total` | counter | `kind` | investigations recorded as open |
@@ -86,6 +96,37 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_curations_total` | counter | `kind`, `result` | curation outcomes (`opened`/`coalesced`/`error`) |
 | `runlore_curation_dedup_score` | histogram | — | catalog top-hit BM25 score at the dedup decision |
 | `runlore_catalog_embed_degraded_total` | counter | — | catalog reloads that left hybrid recall without vectors (embed failure — recall degrades to BM25-only until the next successful sync) |
+
+### Measuring the recall saving
+
+RunLore never asserts a saving — it measures both sides and lets you subtract them.
+Compare two means, both provider-reported, both per investigation:
+
+```promql
+# what a delivered recall short-circuit costs
+sum(increase(runlore_recall_tokens_spent_total[$__range]))
+  / sum(increase(runlore_investigations_completed_total{result="recall"}[$__range]))
+
+# what an investigation that ran the full loop costs
+(
+    sum(increase(runlore_investigation_input_tokens_sum{result!="recall"}[$__range]))
+  + sum(increase(runlore_investigation_output_tokens_sum{result!="recall"}[$__range]))
+)
+  / sum(increase(runlore_investigation_input_tokens_count{result!="recall"}[$__range]))
+```
+
+The **gap between the two is the saving**. `$__range` is the Grafana range variable —
+substitute a window (`[24h]`) to run these in Prometheus directly. The dashboard plots
+exactly these two series in **💸 Cost & efficiency**, and the **🧠 Learning loop** row
+reduces them to one number, `1 - recall/full-loop`, as the "Recall token savings" stat.
+
+> [!WARNING]
+> **The `{result!="recall"}` filter is load-bearing.**
+>
+> Unfiltered, these histograms cover recall short-circuits too — so the "full loop" term
+> would contain the very runs you are subtracting from it, and the measured saving would
+> *shrink* as recall got better. Never difference `recall_tokens_spent_total` out of an
+> unfiltered per-investigation total.
 
 ## Grafana dashboard
 


### PR DESCRIPTION
`recall_tokens_saved_total` overstated the saving by roughly 7x and never subtracted what the recall itself cost.

```go
saved := int64(li.MaxTokensPerInvestigation)   // the BUDGET CEILING, default 100k
if saved == 0 { saved = defaultRecallTokensSavedEstimate }  // 50k, also invented
m.RecallTokensSaved.Add(ctx, saved)
```

Two defects. `MaxTokensPerInvestigation` is a ceiling, not observed spend — the repo's own recorded full investigation (`examples/demo/harbor-chart-bump.transcript.json`) is 7 calls totalling 14,034 in / 1,537 out, so the metric claimed ~100k saved where a real full loop cost ~15k. And it never subtracted the recall's own cost, which under the shipped defaults is **two** model calls (the LLM reranker, on by default, plus the unconditional verify pass) — both already accumulated in the `verifyTotals` pointer `tryRecall` receives.

## Measure, don't estimate

`recall_tokens_saved_total` → **`runlore_recall_tokens_spent_total`**, recording the provider-reported `InputTokens + OutputTokens` of the recall's actual model calls.

The alternative — keep the name and subtract a "realistic full investigation" baseline — needs a baseline, and there is no defensible one. The only datum in the repo is a single transcript from one scenario on one model; hard-coding it swaps one fabricated constant for another and goes stale the moment the tool set or model changes. Measuring has zero unknowns: `recordUsageMetrics` already emits `investigation_input_tokens` / `investigation_output_tokens` for full investigations, so the saving becomes a difference of two measurements rather than an assertion. That also matches how this codebase already treats confidence and cost.

The recording **site** is unchanged — delivered short-circuits only. A verify-refuted recall falls through and its tokens are already reported inside that full investigation's own totals, so counting them here would double-count.

**No gate logic changed.** `recall.go`, `tryRecall`'s decisions and the `RecallHits` result labelling are untouched.

## Consumers updated

| file | change |
|---|---|
| `internal/telemetry/metrics.go` | new series name + doc comment explaining it is a measurement and how to difference it |
| `deploy/observability/grafana/runlore.json` | panel 104 → "Tokens spent by recall"; panel 61's third series is now measured tokens per delivered recall on the **same** axis as tokens/investigation, so the visible gap *is* the saving; the now-pointless right-axis override removed |
| `deploy/observability/grafana/README.md`, `docs/operations/observability.md` | descriptions and the metric-reference row |

`defaultRecallTokensSavedEstimate` had no remaining caller and is deleted. `deploy/observability/alerts/` has no recall references.

## Tests

`recall_tokens_test.go` is table-driven end-to-end through `Investigate` against a **real** SDK meter on a manual reader — it reads the exported series back rather than asserting on a mock. Both rows set `MaxTokensPerInvestigation: 100_000` so a metric still reading the ceiling cannot pass.

Mutation-tested, all three caught:

| mutation | result |
|---|---|
| revert to `MaxTokensPerInvestigation` | FAIL (`= 100000, want 960/2200`) |
| price only part of the usage (drops the reranker) | FAIL (`= 60/100`) |
| drop the delivered-only guard | FAIL (`= 960` on a verify-rejected recall) |

`metrics_extra_test.go` asserts the old series name does **not** reappear.

## Note

This is a breaking rename, not an alias — an operator with a saved query on the old series loses it. That is intended (the old series was wrong), but it is worth a line in the release notes whenever the next release is cut.