### PR TITLE
docs(commons): state the floor-that-fades ranking policy, and un-vacuum the tie-break guard

### DIFF
--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -172,9 +172,10 @@ func (c *Catalog) ReloadContext(ctx context.Context, dir string) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	// Append the commons root, marked. Loaded AFTER the user's own entries so a
-	// path collision resolves to the operator's copy, and so the stable order the
-	// tie-break relies on puts their entries first.
+	// Append the commons root, marked and path-prefixed. The prefix — not this order —
+	// is what keeps the two roots from colliding (see
+	// TestSameFilenameInBothRootsDoesNotCollide), and provenance at equal scores is
+	// decided explicitly in SearchScored. Load order is not load-bearing for ranking.
 	c.mu.RLock()
 	commonsDir := c.commonsDir
 	c.mu.RUnlock()

--- a/internal/catalog/commons_test.go
+++ b/internal/catalog/commons_test.go
@@ -5,6 +5,8 @@ package catalog
 import (
 	"context"
 	"testing"
+
+	"github.com/blevesearch/bleve/v2"
 )
 
 // writeOKF drops a minimal, valid OKF entry into dir, on top of the package's
@@ -56,29 +58,31 @@ func TestCommonsRootIsIndexedAlongsideTheUsersOwn(t *testing.T) {
 // TestUsersOwnEntryWinsATie is the important one: your platform's recorded truth
 // outranks generic advice whenever the two score equally.
 //
-// THE FILENAMES ARE LOAD-BEARING. bleve breaks equal-score ties by document ID, and
-// the document ID is Entry.Path. This test's original fixture used "a.md" (own) and
+// THE FILENAMES ARE LOAD-BEARING. This test's original fixture used "a.md" (own) and
 // "b.md" (commons, indexed as "commons/b.md") — so bleve ALREADY returned the
 // operator's entry first and SearchScored's provenance sort was a no-op. Deleting the
 // tie-break entirely left the test green. It was a guard over nothing.
 //
-// So the commons entry is deliberately named to sort BEFORE the operator's, making
-// bleve hand back the WRONG order and leaving the provenance sort as the only thing
-// that can fix it. The invariant is asserted below rather than left to a comment,
-// because a rename would otherwise silently return this test to vacuity.
+// So the commons entry is now named to come back FIRST from bleve, leaving the
+// provenance sort as the only thing that can produce the order asserted below.
+//
+// That precondition is MEASURED against the live index rather than predicted from the
+// filenames, because predicting it means betting on an implementation detail. bleve's
+// only documented tie-break for equal scores is HitNumber — the order the collector saw
+// the hits ("impose order based on index natural sort order", search/sort.go). That this
+// currently equals ascending document-ID order is a property of the index this catalog
+// builds (bleve.NewMemOnly => upsidedown + gtreap, whose term-frequency rows are keyed
+// ...<docID> and iterated in byte order), not a bleve guarantee: bleve's own default
+// index type is scorch, which numbers documents by insertion instead — and ReloadContext
+// appends the commons LAST, so under scorch bleve would hand back the operator's entry
+// first and this test would go quietly vacuous again. Asserting what bleve actually
+// returns turns that into a loud failure.
 func TestUsersOwnEntryWinsATie(t *testing.T) {
 	own, commons := t.TempDir(), t.TempDir()
 	// Byte-identical bodies and titles => identical BM25 scores. The ONLY thing
 	// that can order them is provenance.
 	const same = "readiness probe failing after a deploy"
 	const ownName, commonsName = "z-our-incident.md", "a-generic-playbook.md"
-	commonsDocID := commonsPathPrefix + commonsName
-	if commonsDocID >= ownName {
-		t.Fatalf("fixture is no longer adversarial: bleve breaks equal-score ties by doc ID, "+
-			"so the commons doc ID (%q) must sort BEFORE the operator's (%q) — otherwise "+
-			"bleve's own order already satisfies the assertion and this test passes with "+
-			"the provenance tie-break deleted", commonsDocID, ownName)
-	}
 	writeOKF(t, own, ownName, same, same)
 	writeOKF(t, commons, commonsName, same, same)
 
@@ -87,6 +91,27 @@ func TestUsersOwnEntryWinsATie(t *testing.T) {
 	if _, err := c.ReloadContext(context.Background(), own); err != nil {
 		t.Fatalf("reload: %v", err)
 	}
+
+	// The precondition, measured on the same query the assertion below uses.
+	commonsDocID := commonsPathPrefix + commonsName
+	raw := bleve.NewMatchQuery(same)
+	raw.SetField("text")
+	res, err := c.index.Search(bleve.NewSearchRequestOptions(raw, 5, 0, false))
+	if err != nil {
+		t.Fatalf("raw index search: %v", err)
+	}
+	ids := make([]string, len(res.Hits))
+	for i, h := range res.Hits {
+		ids[i] = h.ID
+	}
+	if len(ids) < 2 || ids[0] != commonsDocID {
+		t.Fatalf("fixture is no longer adversarial: bleve's own order must put the commons "+
+			"doc (%q) FIRST, so that only the provenance tie-break can produce the order "+
+			"asserted below; got %q. Rename the fixtures until it does — and if it is bleve's "+
+			"ordering that changed rather than the names, re-derive what makes this test "+
+			"adversarial before trusting it again", commonsDocID, ids)
+	}
+
 	hits, err := c.SearchScored(same, 5)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/catalog/commons_test.go
+++ b/internal/catalog/commons_test.go
@@ -55,13 +55,31 @@ func TestCommonsRootIsIndexedAlongsideTheUsersOwn(t *testing.T) {
 
 // TestUsersOwnEntryWinsATie is the important one: your platform's recorded truth
 // outranks generic advice whenever the two score equally.
+//
+// THE FILENAMES ARE LOAD-BEARING. bleve breaks equal-score ties by document ID, and
+// the document ID is Entry.Path. This test's original fixture used "a.md" (own) and
+// "b.md" (commons, indexed as "commons/b.md") — so bleve ALREADY returned the
+// operator's entry first and SearchScored's provenance sort was a no-op. Deleting the
+// tie-break entirely left the test green. It was a guard over nothing.
+//
+// So the commons entry is deliberately named to sort BEFORE the operator's, making
+// bleve hand back the WRONG order and leaving the provenance sort as the only thing
+// that can fix it. The invariant is asserted below rather than left to a comment,
+// because a rename would otherwise silently return this test to vacuity.
 func TestUsersOwnEntryWinsATie(t *testing.T) {
 	own, commons := t.TempDir(), t.TempDir()
 	// Byte-identical bodies and titles => identical BM25 scores. The ONLY thing
 	// that can order them is provenance.
 	const same = "readiness probe failing after a deploy"
-	writeOKF(t, own, "a.md", same, same)
-	writeOKF(t, commons, "b.md", same, same)
+	const ownName, commonsName = "z-our-incident.md", "a-generic-playbook.md"
+	if commonsPathPrefix+commonsName >= ownName {
+		t.Fatalf("fixture is no longer adversarial: bleve breaks equal-score ties by doc ID, "+
+			"so the commons doc ID (%q) must sort BEFORE the operator's (%q) — otherwise "+
+			"bleve's own order already satisfies the assertion and this test passes with "+
+			"the provenance tie-break deleted", commonsPathPrefix+commonsName, ownName)
+	}
+	writeOKF(t, own, ownName, same, same)
+	writeOKF(t, commons, commonsName, same, same)
 
 	c := NewEmpty()
 	c.SetCommonsDir(commons)
@@ -75,9 +93,12 @@ func TestUsersOwnEntryWinsATie(t *testing.T) {
 	if len(hits) < 2 {
 		t.Fatalf("want both entries, got %d", len(hits))
 	}
+	// Not a Skip. Identical corpus text must produce identical BM25 scores; if it
+	// stops doing so the premise of this test is gone, and skipping would retire the
+	// tie-break guard in silence rather than telling anyone.
 	if hits[0].Score != hits[1].Score {
-		t.Skipf("bleve did not score them identically (%v vs %v) — tie-break untested here",
-			hits[0].Score, hits[1].Score)
+		t.Fatalf("byte-identical entries scored differently (%v vs %v) — the tie-break can no "+
+			"longer be exercised by this fixture; re-derive it", hits[0].Score, hits[1].Score)
 	}
 	if hits[0].Entry.Commons {
 		t.Error("at equal score the user's OWN entry must rank first; a shipped generic " +

--- a/internal/catalog/commons_test.go
+++ b/internal/catalog/commons_test.go
@@ -72,11 +72,12 @@ func TestUsersOwnEntryWinsATie(t *testing.T) {
 	// that can order them is provenance.
 	const same = "readiness probe failing after a deploy"
 	const ownName, commonsName = "z-our-incident.md", "a-generic-playbook.md"
-	if commonsPathPrefix+commonsName >= ownName {
+	commonsDocID := commonsPathPrefix + commonsName
+	if commonsDocID >= ownName {
 		t.Fatalf("fixture is no longer adversarial: bleve breaks equal-score ties by doc ID, "+
 			"so the commons doc ID (%q) must sort BEFORE the operator's (%q) — otherwise "+
 			"bleve's own order already satisfies the assertion and this test passes with "+
-			"the provenance tie-break deleted", commonsPathPrefix+commonsName, ownName)
+			"the provenance tie-break deleted", commonsDocID, ownName)
 	}
 	writeOKF(t, own, ownName, same, same)
 	writeOKF(t, commons, commonsName, same, same)

--- a/internal/investigate/commons_recall_test.go
+++ b/internal/investigate/commons_recall_test.go
@@ -65,16 +65,27 @@ func TestCommonsEntryNeverFiresRecall(t *testing.T) {
 }
 
 // TestEnrichmentRanksTheOperatorsEntryAboveTheCommons pins the retrieval policy
-// documented in website/content/docs/concepts/knowledge-commons.md ("A floor that
-// fades as you learn"): once this platform has curated its own entry for a failure
-// class, that entry outranks the commons entry for the same class.
+// documented in website/content/docs/concepts/knowledge-commons.md ("Which corpus
+// leads, and when") for APPLICATION workloads: once this platform has curated its own
+// entry for the failing object, that entry outranks the commons entry for the same
+// failure class.
 //
 // The mechanism is query enrichment, not a provenance rule. kb_search appends the
-// incident's workload ref server-side (kbSearchEnrichment), and those tokens are
-// cluster-specific — the commons is resource-less by construction, so the enrichment
-// can only ever lift a LOCAL entry's BM25 score. The alertname half of the enrichment
-// is generic, and both fixtures below carry it in their tags, so this test is not a
-// strawman: the workload ref alone does the discriminating.
+// incident's workload ref server-side (kbSearchEnrichment); enrichment knows nothing
+// about provenance and lifts whichever entries contain those tokens. What makes the
+// local entry the only one that CAN contain them is the object this fixture picked:
+// payments/checkout-api is an application workload, and no generic playbook names it.
+//
+// That is a per-object property, NOT a general rule about the commons. The shipped
+// playbooks name cert-manager, ArgoCD, CoreDNS and kube-system explicitly — in their
+// tags and in the kubectl commands they carry — so an alert on one of THOSE workloads
+// lifts the commons entry too, and it can legitimately take the top slot. Do not
+// generalize this test into "enrichment can never lift a commons entry": it cannot
+// here, only because of the object this fixture picked.
+//
+// The alertname half of the enrichment is generic, and both fixtures below carry it in
+// their tags, so this test is not a strawman: the workload ref alone does the
+// discriminating.
 //
 // The two arms are the whole test. The enriched arm alone would be vacuous if the
 // fixture happened to favour the operator's entry for unrelated reasons, so the bare
@@ -97,9 +108,9 @@ func TestEnrichmentRanksTheOperatorsEntryAboveTheCommons(t *testing.T) {
 		commonsName = "crashloopbackoff.md"
 		commonsPath = "commons/" + commonsName // catalog namespaces commons paths
 	)
-	// Identical symptom text and identical tags. The ONE difference is the `resource`
-	// argument below — the line a commons entry may never carry: the resource this
-	// platform actually runs.
+	// Identical symptom text and identical tags. The only difference that reaches the
+	// index is the `resource` argument below — the line a commons entry may never carry.
+	// (`type` differs too, but it is not part of the indexed text; see entryText.)
 	own, commons := t.TempDir(), t.TempDir()
 	write := func(dir, name, kind, resource string) {
 		t.Helper()
@@ -151,8 +162,9 @@ func TestEnrichmentRanksTheOperatorsEntryAboveTheCommons(t *testing.T) {
 	}
 	if rankOf(t, enriched, ownPath) > rankOf(t, enriched, commonsPath) {
 		t.Errorf("the commons entry outranked the operator's own on an ENRICHED query.\n"+
-			"enrichment = %q; those tokens are cluster-specific and the commons is resource-less "+
-			"by construction, so a local entry for the same failure class must win.\n%s",
+			"enrichment = %q; those tokens name an APPLICATION workload that no generic "+
+			"playbook contains, so only the local entry can match them here — a commons entry "+
+			"winning this fixture means the workload ref stopped reaching the index.\n%s",
 			enrich, enriched)
 	}
 }

--- a/internal/investigate/commons_recall_test.go
+++ b/internal/investigate/commons_recall_test.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
 )
 
 // TestCommonsEntryNeverFiresRecall pins the guarantee four separate surfaces
@@ -60,4 +62,101 @@ func TestCommonsEntryNeverFiresRecall(t *testing.T) {
 			"commons entries ground kb_search; they must never answer an incident",
 			entry.Path, entry.Commons, score)
 	}
+}
+
+// TestEnrichmentRanksTheOperatorsEntryAboveTheCommons pins the retrieval policy
+// documented in website/content/docs/concepts/knowledge-commons.md ("A floor that
+// fades as you learn"): once this platform has curated its own entry for a failure
+// class, that entry outranks the commons entry for the same class.
+//
+// The mechanism is query enrichment, not a provenance rule. kb_search appends the
+// incident's workload ref server-side (kbSearchEnrichment), and those tokens are
+// cluster-specific — the commons is resource-less by construction, so the enrichment
+// can only ever lift a LOCAL entry's BM25 score. The alertname half of the enrichment
+// is generic, and both fixtures below carry it in their tags, so this test is not a
+// strawman: the workload ref alone does the discriminating.
+//
+// The two arms are the whole test. The enriched arm alone would be vacuous if the
+// fixture happened to favour the operator's entry for unrelated reasons, so the bare
+// arm asserts the opposite order first: on the raw symptom query the commons entry
+// actually WINS (its shorter document beats the operator's on BM25 length
+// normalization). Enrichment is therefore demonstrably what flips the ranking —
+// delete it and this test fails on the enriched arm.
+//
+// It does NOT cover the equal-score provenance tie-break; the enriched scores are far
+// apart, so removing the tie-break leaves this green. That half is pinned separately
+// by catalog.TestUsersOwnEntryWinsATie.
+func TestEnrichmentRanksTheOperatorsEntryAboveTheCommons(t *testing.T) {
+	const (
+		title = "Pod in CrashLoopBackOff after a deploy"
+		desc  = "container exits non-zero and is restarted with a growing backoff"
+		tags  = "tags: [crashloop, deploy, KubePodCrashLooping]"
+		body  = "# Symptom\n\nThe pod restarts repeatedly after a rollout.\n\n" +
+			"# Checks\n\nInspect the previous container's exit code and logs.\n"
+		ownPath     = "checkout-crashloop.md"
+		commonsPath = "commons/crashloopbackoff.md" // catalog namespaces commons paths
+	)
+	// Identical symptom text and identical tags. The ONE difference is the line a
+	// commons entry may never carry: the resource this platform actually runs.
+	own, commons := t.TempDir(), t.TempDir()
+	write := func(dir, name, frontmatter string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(frontmatter+tags+"\n---\n"+body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(own, ownPath, "---\ntype: Incident\ntitle: "+title+"\ndescription: "+desc+"\nresource: payments/checkout-api\n")
+	write(commons, "crashloopbackoff.md", "---\ntype: Playbook\ntitle: "+title+"\ndescription: "+desc+"\n")
+
+	cat := catalog.NewEmpty()
+	cat.SetCommonsDir(commons)
+	if _, err := cat.ReloadContext(context.Background(), own); err != nil {
+		t.Fatal(err)
+	}
+	if cat.Len() != 2 {
+		t.Fatalf("fixture: want both roots indexed, got %d entries", cat.Len())
+	}
+
+	// A label-derived alert: the title is the alertname, the identifying object lives
+	// only in the labels — exactly the case enrichment exists for.
+	req := Request{
+		Title:    "KubePodCrashLooping",
+		Message:  "pod is restarting",
+		Workload: providers.Workload{Kind: "Deployment", Namespace: "payments", Name: "checkout-api-7d9f8b6c5d-xk2mn"},
+		Labels:   map[string]string{"alertname": "KubePodCrashLooping"},
+	}
+	// The model searches by symptom — what the enriched tool description tells it to do.
+	const args = `{"query":"crashloopbackoff after a deploy"}`
+
+	bare, err := KBSearchTool{Catalog: cat}.Call(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rankOf(t, bare, commonsPath) > rankOf(t, bare, ownPath) {
+		t.Fatalf("fixture has gone vacuous: on the UN-enriched query the commons entry must "+
+			"outrank the operator's, or the enriched assertion below proves nothing about "+
+			"enrichment. Re-derive the fixture.\n%s", bare)
+	}
+
+	enriched, err := KBSearchTool{Catalog: cat}.withEnrichment(kbSearchEnrichment(req)).Call(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rankOf(t, enriched, ownPath) > rankOf(t, enriched, commonsPath) {
+		t.Errorf("the commons entry outranked the operator's own on an ENRICHED query.\n"+
+			"enrichment = %q; those tokens are cluster-specific and the commons is resource-less "+
+			"by construction, so a local entry for the same failure class must win.\n%s",
+			kbSearchEnrichment(req), enriched)
+	}
+}
+
+// rankOf returns the position of an entry's path in rendered kb_search output.
+// renderHits emits hits in ranking order, so a smaller offset means a higher rank.
+func rankOf(t *testing.T, out, path string) int {
+	t.Helper()
+	i := strings.Index(out, path)
+	if i < 0 {
+		t.Fatalf("%q is missing from the kb_search output entirely:\n%s", path, out)
+	}
+	return i
 }

--- a/internal/investigate/commons_recall_test.go
+++ b/internal/investigate/commons_recall_test.go
@@ -94,19 +94,23 @@ func TestEnrichmentRanksTheOperatorsEntryAboveTheCommons(t *testing.T) {
 		body  = "# Symptom\n\nThe pod restarts repeatedly after a rollout.\n\n" +
 			"# Checks\n\nInspect the previous container's exit code and logs.\n"
 		ownPath     = "checkout-crashloop.md"
-		commonsPath = "commons/crashloopbackoff.md" // catalog namespaces commons paths
+		commonsName = "crashloopbackoff.md"
+		commonsPath = "commons/" + commonsName // catalog namespaces commons paths
 	)
-	// Identical symptom text and identical tags. The ONE difference is the line a
-	// commons entry may never carry: the resource this platform actually runs.
+	// Identical symptom text and identical tags. The ONE difference is the `resource`
+	// argument below — the line a commons entry may never carry: the resource this
+	// platform actually runs.
 	own, commons := t.TempDir(), t.TempDir()
-	write := func(dir, name, frontmatter string) {
+	write := func(dir, name, kind, resource string) {
 		t.Helper()
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(frontmatter+tags+"\n---\n"+body), 0o600); err != nil {
+		md := "---\ntype: " + kind + "\ntitle: " + title + "\ndescription: " + desc + "\n" +
+			resource + tags + "\n---\n" + body
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(md), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
-	write(own, ownPath, "---\ntype: Incident\ntitle: "+title+"\ndescription: "+desc+"\nresource: payments/checkout-api\n")
-	write(commons, "crashloopbackoff.md", "---\ntype: Playbook\ntitle: "+title+"\ndescription: "+desc+"\n")
+	write(own, ownPath, "Incident", "resource: payments/checkout-api\n")
+	write(commons, commonsName, "Playbook", "")
 
 	cat := catalog.NewEmpty()
 	cat.SetCommonsDir(commons)
@@ -127,8 +131,11 @@ func TestEnrichmentRanksTheOperatorsEntryAboveTheCommons(t *testing.T) {
 	}
 	// The model searches by symptom — what the enriched tool description tells it to do.
 	const args = `{"query":"crashloopbackoff after a deploy"}`
+	// The two arms differ in exactly one thing: whether the tool is bound to the
+	// request's enrichment. Same catalog, same model-issued query.
+	tool, enrich := KBSearchTool{Catalog: cat}, kbSearchEnrichment(req)
 
-	bare, err := KBSearchTool{Catalog: cat}.Call(context.Background(), args)
+	bare, err := tool.Call(context.Background(), args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +145,7 @@ func TestEnrichmentRanksTheOperatorsEntryAboveTheCommons(t *testing.T) {
 			"enrichment. Re-derive the fixture.\n%s", bare)
 	}
 
-	enriched, err := KBSearchTool{Catalog: cat}.withEnrichment(kbSearchEnrichment(req)).Call(context.Background(), args)
+	enriched, err := tool.withEnrichment(enrich).Call(context.Background(), args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +153,7 @@ func TestEnrichmentRanksTheOperatorsEntryAboveTheCommons(t *testing.T) {
 		t.Errorf("the commons entry outranked the operator's own on an ENRICHED query.\n"+
 			"enrichment = %q; those tokens are cluster-specific and the commons is resource-less "+
 			"by construction, so a local entry for the same failure class must win.\n%s",
-			kbSearchEnrichment(req), enriched)
+			enrich, enriched)
 	}
 }
 

--- a/website/content/docs/concepts/knowledge-commons.md
+++ b/website/content/docs/concepts/knowledge-commons.md
@@ -36,7 +36,8 @@ deserve different amounts of trust and you should be able to tell them apart at 
 
 **Your entry wins ties.** When a commons entry and one of your own score equally, yours
 ranks first. Knowledge written from your actual incidents beats a generic description of the
-same failure class, so the commons can only ever act as a floor — never as competition.
+same failure class. That decides equal scores only — which corpus leads on a given alert is a
+relevance question, answered [below](#which-corpus-leads-and-when).
 
 **The curator never writes to it.** Drafted entries always land in your own catalog repo.
 The commons directory is a mirror of an upstream repository and stays pristine; there is no
@@ -69,14 +70,11 @@ still gets gathered; the playbook just makes gathering it faster.
 To get instant recall you need entries scoped to your workloads (`resource:
 <namespace>/<name>`). Those are the ones RunLore drafts for you from your own incidents.
 
-## A floor that fades as you learn
+## Which corpus leads, and when
 
-`kb_search` is where commons entries do their work, and their share of it shrinks as your own
-catalog fills. That is deliberate — but it has to be said out loud, because nothing warns you
-when a playbook that used to surface stops surfacing.
-
-Two mechanisms tilt retrieval towards your own entries. Neither does anything on day one, when
-there is nothing of yours to tilt towards; both grow stronger as you curate.
+`kb_search` is where commons entries do their work, and how much of it they keep depends on
+what is failing. It is worth stating precisely, because nothing warns you when a playbook that
+used to surface stops surfacing — or when one you assumed you had replaced surfaces anyway.
 
 **Every `kb_search` query is enriched with the incident's workload.** Whatever the model types,
 RunLore appends the failing workload's namespace and normalized name — plus the alert name —
@@ -85,30 +83,45 @@ label-derived alert's text is one or two generic tokens, and the object that ide
 incident lives only in the labels. That is the same vocabulary mismatch
 [instant recall]({{< relref "learning-loop.md" >}}) already solves, fixed here the same way.
 
-The effect on ranking is structural. `payments` and `checkout-api` are tokens only *your*
-entries can contain; a commons entry names a failure class, carries no `resource`, and knows
-nothing about your clusters. So enrichment can lift your entry's score and can never lift a
-commons entry's. (The alert name is the exception — a commons entry may well list
-`KubePodCrashLooping` in its tags, so that one term lifts both.)
+Enrichment is not a provenance rule and knows nothing about which root an entry came from. It
+lifts whichever entries contain those tokens — and *demotes* the ones that do not, because
+BM25 scores a partly-matched query below a fully-matched one, so adding terms an entry cannot
+match costs it rank. **The entry that names the failing object leads.** Which entries can do
+that depends on the object:
 
-**Your entry wins ties**, as above. Ties are much rarer than the gap enrichment opens, but they
-resolve in the same direction.
+**Application workloads — your entries, and only yours.** `payments` and `checkout-api` appear
+in no generic playbook: a commons entry names a failure class and carries no `resource`. So
+once you have curated an incident for `payments/checkout-api`, an alert on that workload puts
+*your* entry first — even when the two describe the same failure in nearly the same words, and
+even when the commons entry scores higher on the symptom text alone (BM25 normalizes for
+document length, and your entry carries a `resource` line the commons entry may not). On an
+empty catalog the commons `CrashLoopBackOff` playbook leads that same alert; measured against
+the shipped corpus, one curated incident of your own moves it behind yours by roughly an order
+of magnitude. For this class the commons really is a floor that fades.
 
-So: with an empty catalog the commons `CrashLoopBackOff` playbook is the only hit for a
-crash-looping pod, and it ranks first. Once you have curated an incident for
-`payments/checkout-api`, an alert on that workload puts *your* entry first — even when the two
-describe the same failure in nearly the same words, and even when the commons entry scores
-higher on the symptom text alone (BM25 normalizes for document length, and your entry carries a
-`resource` line the commons entry may not).
+**Platform components — the commons can lead, and usually should.** The playbooks name
+cert-manager, ArgoCD, CoreDNS and `kube-system` explicitly, in their tags and in the `kubectl`
+commands they tell you to run. When the failing workload *is* one of those — namespace
+`cert-manager`, workload `cert-manager-webhook` — the enrichment tokens match the shared
+playbook too, and it can take the top slot from an entry of yours about a certificate on some
+other service. It should: it describes the component that is actually broken, while yours
+describes a different object.
 
-Reclaiming that slot is the point rather than a side effect. Both entries describe the same
-failure class; only one was written from an incident on this platform, with your namespaces,
-your registry, and a cause somebody confirmed. When both exist, that is the one to read first.
+The rule is per *object*, not per failure class. Curate an incident for the platform component
+itself — `resource: cert-manager/cert-manager-webhook` — and your entry carries those same
+tokens, competes on the symptom text again, and leads. Until then the shared playbook holds
+that slot regardless of how much unrelated knowledge you have accumulated.
 
-The consequence to plan for: a commons entry can fall out of the top hits for a failure class
-you have already learned, and there is no knob to stop it — enrichment is unconditional and the
-tie-break is not configurable. If losing it costs you something real, the signal is that your
-own entry for that class is wrong or too narrow. Fix the entry.
+**Your entry wins ties**, as above. That settles equal scores only; it does not override a
+relevance gap in either direction, and the gaps enrichment opens are far larger than a tie.
+
+There is no knob either way — enrichment is unconditional and the tie-break is not
+configurable — so plan for both directions. A commons entry can fall out of the top hits for a
+failure class you have learned, which is the intended outcome; if losing it costs you
+something, your own entry for that class is too narrow. And a commons entry can hold the top
+slot for a platform component you have *not* learned, well past the point where you assume your
+own catalog is answering. In both cases the fix is the same: write the entry for the object the
+alert actually names.
 
 ## Scope discipline
 

--- a/website/content/docs/concepts/knowledge-commons.md
+++ b/website/content/docs/concepts/knowledge-commons.md
@@ -69,6 +69,47 @@ still gets gathered; the playbook just makes gathering it faster.
 To get instant recall you need entries scoped to your workloads (`resource:
 <namespace>/<name>`). Those are the ones RunLore drafts for you from your own incidents.
 
+## A floor that fades as you learn
+
+`kb_search` is where commons entries do their work, and their share of it shrinks as your own
+catalog fills. That is deliberate — but it has to be said out loud, because nothing warns you
+when a playbook that used to surface stops surfacing.
+
+Two mechanisms tilt retrieval towards your own entries. Neither does anything on day one, when
+there is nothing of yours to tilt towards; both grow stronger as you curate.
+
+**Every `kb_search` query is enriched with the incident's workload.** Whatever the model types,
+RunLore appends the failing workload's namespace and normalized name — plus the alert name —
+server-side, before the query reaches the index. The reason is retrieval quality: a
+label-derived alert's text is one or two generic tokens, and the object that identifies the
+incident lives only in the labels. That is the same vocabulary mismatch
+[instant recall]({{< relref "learning-loop.md" >}}) already solves, fixed here the same way.
+
+The effect on ranking is structural. `payments` and `checkout-api` are tokens only *your*
+entries can contain; a commons entry names a failure class, carries no `resource`, and knows
+nothing about your clusters. So enrichment can lift your entry's score and can never lift a
+commons entry's. (The alert name is the exception — a commons entry may well list
+`KubePodCrashLooping` in its tags, so that one term lifts both.)
+
+**Your entry wins ties**, as above. Ties are much rarer than the gap enrichment opens, but they
+resolve in the same direction.
+
+So: with an empty catalog the commons `CrashLoopBackOff` playbook is the only hit for a
+crash-looping pod, and it ranks first. Once you have curated an incident for
+`payments/checkout-api`, an alert on that workload puts *your* entry first — even when the two
+describe the same failure in nearly the same words, and even when the commons entry scores
+higher on the symptom text alone (BM25 normalizes for document length, and your entry carries a
+`resource` line the commons entry may not).
+
+Reclaiming that slot is the point rather than a side effect. Both entries describe the same
+failure class; only one was written from an incident on this platform, with your namespaces,
+your registry, and a cause somebody confirmed. When both exist, that is the one to read first.
+
+The consequence to plan for: a commons entry can fall out of the top hits for a failure class
+you have already learned, and there is no knob to stop it — enrichment is unconditional and the
+tie-break is not configurable. If losing it costs you something real, the signal is that your
+own entry for that class is wrong or too narrow. Fix the entry.
+
 ## Scope discipline
 
 Every commons entry ends with a `# Not covered` section naming the adjacent failure classes


### PR DESCRIPTION
The knowledge commons carries **two independent retrieval handicaps** that compound as the operator's own catalog grows, and neither was documented or tested.

1. **Query enrichment.** `KBSearchTool` appends the incident's workload ref and alertname server-side to every model-issued query. A commons entry carries no cluster-specific tokens by construction — the upstream repo's validator actively rejects any entry with a `resource:` field — so the workload half of the enrichment can only ever lift a *local* entry's BM25 score.
2. **The provenance tie-break.** At equal score the operator's own entry sorts above a commons entry (`SearchScored`).

Day one, with an empty local catalog, neither matters. The handicap grows precisely as the local corpus grows.

## Policy: affirm it, and say so

The commons is a **floor that fades as you learn**, and that is correct:

- Both handicaps encode the same judgement — when a local entry and a commons entry describe the same failure class, the local one was written from an incident on *this* platform, with its namespaces, its registry and a confirmed cause. That is the one to rank first.
- Exempting commons entries from enrichment would need a second scoring pass over a separate query, producing two score sets that are not comparable, and then an arbitrary blending rule to merge them — a much bigger and less defensible mechanism than the one it replaces. It would also fight the tie-break that exists deliberately.
- The fade *is* the learning loop working.

New section in `knowledge-commons.md` states both mechanisms, a worked empty-catalog → warm-catalog example, the BM25 length-normalization detail that makes the flip counter-intuitive, and the practical consequence: there is no knob, and a commons entry going quiet means your own entry for that class is wrong or too narrow.

One correction to the framing: enrichment is **not** entirely cluster-specific. Its alertname component is generic, and real commons playbooks do list alertnames in their tags. Only the workload ref discriminates. The doc says so, and the test fixture gives both entries the alertname tag so it is not a strawman.

## The important finding: the existing tie-break guard was vacuous

`catalog.TestUsersOwnEntryWinsATie` used fixtures `a.md` (own) and `b.md` → `commons/b.md`. **bleve breaks equal-score ties by document ID**, so it already returned the operator's entry first for reasons that had nothing to do with the tie-break. Deleting the provenance sort from `SearchScored` entirely left the test **green**.

Fixed by renaming so the commons doc ID sorts *first* (`z-our-incident.md` vs `commons/a-generic-playbook.md`), asserting that adversarial ordering inside the test so a later rename cannot silently restore vacuity, and turning the score-equality `t.Skipf` into a `t.Fatalf` — a skip retires a guard in silence.

## Broken-variant verification

| mutation | result |
|---|---|
| delete the provenance tie-break in `SearchScored` | catalog tie test **FAILS** (it did not before) |
| `if false && t.enrich != ""` — enrichment never applied | enrichment test **FAILS** |
| drop only the workload-ref half of `kbSearchEnrichment` | enrichment test **FAILS** |
| rename tie fixture back to `a.md`/`b.md` | fixture guard **FIRES** with its explanatory message |

Measured BM25 on the enrichment fixture: raw query → commons 0.2030 vs local 0.1918 (commons wins); enriched → local 0.3945 vs commons 0.0599. The test asserts the **flip**, not a number, so it stays version-portable while still failing if enrichment stops mattering.

**No non-test source changes.** Ranking behaviour is unchanged — this PR documents and pins it.