### PR TITLE
feat(curate): earn last_validated from a resolved recall

### DIFF
--- a/deploy/helm/runlore/values-full.yaml
+++ b/deploy/helm/runlore/values-full.yaml
@@ -276,11 +276,18 @@ config:
       enabled: true
       min_interval: 720h # at most one confirmation PR per entry per month
       max_open: 5 # never leave more than this many waiting on a reviewer
-      # floor/prior default to 0.5 / 2.0 — the SAME outcome gate recall's Gate 3 and
-      # the retirement pass use. Keeping them equal is what makes the two passes
-      # complementary rather than contradictory: strictly below the floor is
-      # retirement's territory, at or above it is this pass's, so one sweep can never
-      # propose retiring and revalidating the same entry.
+      # floor/prior are left unset on purpose: they INHERIT curate.retirement's (which
+      # default to 0.5 / 2.0 — the same outcome gate recall's Gate 3 uses), and setting
+      # them to two different values while both passes are enabled is rejected at load.
+      # Equality is what makes the passes complementary rather than contradictory:
+      # strictly below the floor is retirement's territory, at or above it is this
+      # pass's, so one sweep can never propose retiring and revalidating one entry.
+      #
+      # Sizing note: max_open bounds the REVIEW queue, not the forge reads. Every sweep
+      # still costs one read per candidate whose entry is already fresh — the anti-spam
+      # check reads the file on the base branch, which is what lets a merged stamp
+      # silence the next sweep with no state to keep. On a large catalog raise
+      # curate.sweeps.interval rather than lowering max_open.
 
   metrics:
     url: http://vmsingle.observability.svc:8429

--- a/deploy/helm/runlore/values-full.yaml
+++ b/deploy/helm/runlore/values-full.yaml
@@ -255,6 +255,33 @@ config:
       installation_id: 7654321
       private_key_env: GITHUB_APP_PRIVATE_KEY
 
+  # Phase-2 grooming. The chart's values.yaml already ships stale_after,
+  # recurrence_threshold and the in-server sweeps (DRY-RUN by default — nothing below
+  # reaches the forge until you set curate.sweeps.mode: apply there). What is added
+  # here is the one grooming pass a production install has to decide for itself.
+  curate:
+    # How a catalog entry EARNS freshness. RunLore leaves `last_validated` unset when
+    # it drafts an entry — the field claims a HUMAN confirmed the entry works, and a
+    # fresh draft has no such confirmation — so without this pass an entry's freshness
+    # can only ever decay from its creation date. When an entry is recalled for a live
+    # incident and that incident then RESOLVES, this opens a human-reviewed PR stamping
+    # `last_validated` with the resolve date: a one-line frontmatter edit, no status or
+    # content change, and merging it IS the confirmation. RunLore never writes it.
+    #
+    # It changes what an on-call reader sees only once catalog.instant_recall.stale_after
+    # is set — that age gate is the thing that reads `last_validated`. With no
+    # stale_after there is no staleness down-weight, and so nothing for this pass to
+    # keep an entry ahead of.
+    revalidation:
+      enabled: true
+      min_interval: 720h # at most one confirmation PR per entry per month
+      max_open: 5 # never leave more than this many waiting on a reviewer
+      # floor/prior default to 0.5 / 2.0 — the SAME outcome gate recall's Gate 3 and
+      # the retirement pass use. Keeping them equal is what makes the two passes
+      # complementary rather than contradictory: strictly below the floor is
+      # retirement's territory, at or above it is this pass's, so one sweep can never
+      # propose retiring and revalidating the same entry.
+
   metrics:
     url: http://vmsingle.observability.svc:8429
   logs:

--- a/internal/app/curate.go
+++ b/internal/app/curate.go
@@ -109,7 +109,7 @@ func buildGuardedForge(cfg *config.Config, tok ForgeToken, dryRun bool, aud audi
 
 // BuildCurateAgent assembles the grooming passes over a (typically Guard-wrapped)
 // forge. ledger may be nil — the ledger-backed passes (Queue, Recurrence,
-// Contested, Retirement) are then skipped. Shared by the one-shot `lore curate`
+// Contested, Retirement, Revalidation) are then skipped. Shared by the one-shot `lore curate`
 // CLI and the in-server sweeper so the two can never drift.
 //
 // StaleAfter is honoured as-is: 0/unset disables the lifecycle sweep (Lifecycle.Run
@@ -159,6 +159,24 @@ func BuildCurateAgent(cfg *config.Config, forge curate.GuardedForge, ledger *out
 			Floor:           cfg.Curate.Retirement.Floor,
 			Prior:           cfg.Curate.Retirement.Prior,
 			Log:             log,
+		})
+	}
+	// Revalidation (opt-in) is retirement's mirror image: it proposes CONFIRMING a
+	// merged entry that was recalled for a live incident which then resolved, by
+	// stamping `last_validated` — the field the forge deliberately leaves unset at
+	// draft time because it claims human confirmation. Merging the PR is that
+	// confirmation; RunLore only brings the evidence. Sharing the retirement floor
+	// keeps the two disjoint (below the floor is retirement's, at or above it is
+	// this pass's), so one sweep can never propose both for the same entry.
+	if cfg.Curate.Revalidation.Enabled {
+		agent.Passes = append(agent.Passes, curate.Revalidation{
+			Forge:       forge,
+			Stats:       ledger,
+			MinInterval: cfg.Curate.Revalidation.MinInterval.Std(),
+			MaxOpen:     cfg.Curate.Revalidation.MaxOpen,
+			Floor:       cfg.Curate.Revalidation.Floor,
+			Prior:       cfg.Curate.Revalidation.Prior,
+			Log:         log,
 		})
 	}
 	return agent

--- a/internal/app/curate.go
+++ b/internal/app/curate.go
@@ -109,8 +109,8 @@ func buildGuardedForge(cfg *config.Config, tok ForgeToken, dryRun bool, aud audi
 
 // BuildCurateAgent assembles the grooming passes over a (typically Guard-wrapped)
 // forge. ledger may be nil — the ledger-backed passes (Queue, Recurrence,
-// Contested, Retirement, Revalidation) are then skipped. Shared by the one-shot `lore curate`
-// CLI and the in-server sweeper so the two can never drift.
+// Contested, Retirement, Revalidation) are then skipped. Shared by the one-shot
+// `lore curate` CLI and the in-server sweeper so the two can never drift.
 //
 // StaleAfter is honoured as-is: 0/unset disables the lifecycle sweep (Lifecycle.Run
 // returns early). The Helm chart ships config.curate.stale_after: 720h, so scheduled

--- a/internal/app/curate_test.go
+++ b/internal/app/curate_test.go
@@ -18,13 +18,15 @@ import (
 	"github.com/Smana/runlore/internal/outcome"
 )
 
-// The retirement pass is wired in RunCurate with *github.Client as its forge and
-// *outcome.Ledger as its stats source; pin both seams at compile time so a drift in
-// either interface fails here rather than in the wiring block.
+// The retirement and revalidation passes are wired in RunCurate with
+// *github.Client as their forge and *outcome.Ledger as their stats source; pin
+// every seam at compile time so a drift in any of them fails here rather than in
+// the wiring block.
 var (
-	_ curate.RetireForge  = (*github.Client)(nil)
-	_ curate.RetireStats  = (*outcome.Ledger)(nil)
-	_ curate.GuardedForge = (*github.Client)(nil)
+	_ curate.RetireForge     = (*github.Client)(nil)
+	_ curate.RevalidateForge = (*github.Client)(nil)
+	_ curate.EntryStats      = (*outcome.Ledger)(nil)
+	_ curate.GuardedForge    = (*github.Client)(nil)
 )
 
 // captureLog returns a logger writing JSON records into buf so a test can assert
@@ -115,6 +117,38 @@ func TestBuildCurateAgentPassComposition(t *testing.T) {
 	agent = BuildCurateAgent(cfg, forge, ledger, discardLog())
 	if len(agent.Passes) != 7 {
 		t.Fatalf("full agent: want 7 passes (suppress dedup lifecycle queue recurrence contested retirement), got %d", len(agent.Passes))
+	}
+}
+
+// TestBuildCurateAgentWiresRevalidation pins the opt-in wiring of the
+// revalidation pass, including that its knobs come from config rather than from
+// the pass's zero value (a MaxOpen of 0 would silently propose nothing).
+func TestBuildCurateAgentWiresRevalidation(t *testing.T) {
+	forge := github.New("https://forge.invalid", "o", "r", "main", nil)
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Default (disabled): the ledger-backed set stops at Contested.
+	cfg := &config.Config{}
+	if n := len(BuildCurateAgent(cfg, forge, ledger, discardLog()).Passes); n != 6 {
+		t.Fatalf("revalidation must be opt-in: want 6 passes, got %d", n)
+	}
+
+	cfg.Curate.Revalidation = config.Revalidation{
+		Enabled: true, MinInterval: config.Duration(168 * time.Hour), MaxOpen: 3, Floor: 0.5, Prior: 2.0,
+	}
+	passes := BuildCurateAgent(cfg, forge, ledger, discardLog()).Passes
+	if len(passes) != 7 {
+		t.Fatalf("want 7 passes with revalidation enabled, got %d", len(passes))
+	}
+	p, ok := passes[6].(curate.Revalidation)
+	if !ok {
+		t.Fatalf("last pass = %T, want curate.Revalidation", passes[6])
+	}
+	if p.MinInterval != 168*time.Hour || p.MaxOpen != 3 || p.Floor != 0.5 || p.Prior != 2.0 {
+		t.Fatalf("revalidation knobs not wired from config: %+v", p)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1451,6 +1451,27 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("curate.revalidation.max_open must be >= 1 (the reviewer-queue bound), got %d", r.MaxOpen)
 		}
 	}
+	// With BOTH passes on, their calibration must be identical. They partition
+	// entries by comparing one outcome factor against one floor — retirement
+	// strictly below it, revalidation at or above — so the disjointness they claim
+	// is a property of the arithmetic, not a rule either pass enforces. Unequal
+	// floors leave a band where both fire; unequal priors compute different factors
+	// from the same ledger. Either way one entry can be proposed for retirement AND
+	// revalidation in a single sweep. Leaving revalidation's knobs unset inherits
+	// retirement's (ApplyDefaults), so reaching here means two values were set apart
+	// deliberately.
+	if c.Curate.Retirement.Enabled && c.Curate.Revalidation.Enabled {
+		if ret, rev := c.Curate.Retirement.Floor, c.Curate.Revalidation.Floor; ret != rev {
+			return fmt.Errorf("curate.revalidation.floor (%g) must equal curate.retirement.floor (%g): "+
+				"the two passes gate on opposite sides of the same outcome factor, so unequal floors leave a band where "+
+				"one entry is proposed for retirement and revalidation at once — omit curate.revalidation.floor to inherit", rev, ret)
+		}
+		if ret, rev := c.Curate.Retirement.Prior, c.Curate.Revalidation.Prior; ret != rev {
+			return fmt.Errorf("curate.revalidation.prior (%g) must equal curate.retirement.prior (%g): "+
+				"a different prior computes a different factor from the same ledger, so the two passes would disagree about "+
+				"the same entry's track record — omit curate.revalidation.prior to inherit", rev, ret)
+		}
+	}
 	// In-server sweeps: an unknown mode must fail loud (a typo like "apply" silently
 	// falling back to dry-run would mean the operator believes grooming is live when
 	// it is not), and a sub-10m interval would hammer the forge listing endpoints.
@@ -1585,9 +1606,20 @@ type Revalidation struct {
 	// MaxOpen bounds how many revalidation PRs may await review at once (default
 	// 5), counting the ones earlier sweeps left open. It is what keeps the first
 	// sweep on a mature catalog from proposing every long-confirmed entry at once.
-	MaxOpen int     `yaml:"max_open"`
-	Floor   float64 `yaml:"floor"` // revalidate at/above this factor (default 0.5, the retirement boundary)
-	Prior   float64 `yaml:"prior"` // Beta prior strength k (default 2.0)
+	//
+	// Note that each sweep still costs one forge read per candidate whose entry is
+	// already fresh: the anti-spam check reads the file on the base branch, which is
+	// where the answer actually lives, so a merged stamp silences the next sweep
+	// with no state to keep. Raise curate.sweeps.interval, not MaxOpen, if a large
+	// catalog makes that read budget uncomfortable.
+	MaxOpen int `yaml:"max_open"`
+	// Floor and Prior are the decay calibration, and they must match
+	// curate.retirement's: the two passes partition entries by comparing one factor
+	// against one floor, so they only stay disjoint while both read the same
+	// numbers. Leave them unset to inherit retirement's (falling back to the recall
+	// gate's 0.5 / 2.0); setting them to different values is a config error.
+	Floor float64 `yaml:"floor"` // revalidate at/above this factor (inherits curate.retirement.floor; else 0.5)
+	Prior float64 `yaml:"prior"` // Beta prior strength k (inherits curate.retirement.prior; else 2.0)
 }
 
 // Sweep modes: dry-run observes (log + audit, zero forge writes), apply acts,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1434,6 +1434,23 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("curate.retirement.min_observations must be >= 1 (the sustained-decay bar), got %d", r.MinObservations)
 		}
 	}
+	// Revalidation pass (opt-in): validated on exactly the terms retirement is,
+	// because the two gate on opposite sides of the SAME factor — a floor outside
+	// (0,1] here would break that complementarity as well as being meaningless.
+	// ApplyDefaults fills unset (0) values while enabled, so only an explicitly
+	// out-of-range setting reaches here.
+	if c.Curate.Revalidation.Enabled {
+		r := c.Curate.Revalidation
+		if r.Floor <= 0 || r.Floor > 1 {
+			return fmt.Errorf("curate.revalidation.floor must be in (0,1] (a calibrated outcome factor, matching curate.retirement.floor), got %g", r.Floor)
+		}
+		if r.MinInterval.Std() <= 0 {
+			return fmt.Errorf("curate.revalidation.min_interval must be > 0 (the anti-spam bar between two stamps of one entry), got %v", r.MinInterval.Std())
+		}
+		if r.MaxOpen < 1 {
+			return fmt.Errorf("curate.revalidation.max_open must be >= 1 (the reviewer-queue bound), got %d", r.MaxOpen)
+		}
+	}
 	// In-server sweeps: an unknown mode must fail loud (a typo like "apply" silently
 	// falling back to dry-run would mean the operator believes grooming is live when
 	// it is not), and a sub-10m interval would hammer the forge listing endpoints.
@@ -1532,6 +1549,13 @@ type Curate struct {
 	// recall gate's outcome_prior/outcome_floor defaults (2.0 / 0.5) so the two
 	// gates agree unless deliberately tuned apart.
 	Retirement Retirement `yaml:"retirement"`
+	// Revalidation is retirement's mirror image: it opens a human-reviewed PR
+	// stamping `last_validated` on a merged entry that was recalled for a live
+	// incident which then resolved. Opt-in for the same reason as Retirement (it
+	// opens PRs against the operator's repo on a schedule), and its Prior/Floor
+	// default to the same recall-gate values so an entry can never be proposed
+	// for retirement and revalidation at once.
+	Revalidation Revalidation `yaml:"revalidation"`
 	// Sweeps configures the in-server scheduled grooming loop (leader-only, run by
 	// the serve pod). Default mode is dry-run: candidates are logged and audited but
 	// no forge write happens until the operator sets mode: apply. mode: off disables
@@ -1545,6 +1569,25 @@ type Retirement struct {
 	MinObservations int     `yaml:"min_observations"` // sustained-decay bar (default 3)
 	Floor           float64 `yaml:"floor"`            // retire below this factor (default 0.5)
 	Prior           float64 `yaml:"prior"`            // Beta prior strength k (default 2.0)
+}
+
+// Revalidation configures the curate revalidation pass (opt-in KB freshness
+// confirmation) — the seam that lets `last_validated` be EARNED rather than only
+// decay. Set catalog.instant_recall.stale_after well above MinInterval, or the
+// pass cannot keep a working entry ahead of the age gate it exists to answer.
+type Revalidation struct {
+	Enabled bool `yaml:"enabled"`
+	// MinInterval is the anti-spam bar: the candidate date must be at least this
+	// much newer than the entry's recorded freshness (default 720h — at most one
+	// confirmation PR per entry per month). Lower means fresher stamps and more
+	// review load.
+	MinInterval Duration `yaml:"min_interval"`
+	// MaxOpen bounds how many revalidation PRs may await review at once (default
+	// 5), counting the ones earlier sweeps left open. It is what keeps the first
+	// sweep on a mature catalog from proposing every long-confirmed entry at once.
+	MaxOpen int     `yaml:"max_open"`
+	Floor   float64 `yaml:"floor"` // revalidate at/above this factor (default 0.5, the retirement boundary)
+	Prior   float64 `yaml:"prior"` // Beta prior strength k (default 2.0)
 }
 
 // Sweep modes: dry-run observes (log + audit, zero forge writes), apply acts,

--- a/internal/config/config_revalidation_test.go
+++ b/internal/config/config_revalidation_test.go
@@ -90,6 +90,77 @@ func TestValidateRevalidation(t *testing.T) {
 	}
 }
 
+// TestRevalidationInheritsRetirementCalibration pins the derivation that keeps the
+// two passes disjoint: an operator who tunes retirement's floor must not silently
+// get a revalidation pass still gating on 0.5, which would leave a band where one
+// entry is proposed for both.
+func TestRevalidationInheritsRetirementCalibration(t *testing.T) {
+	var c Config
+	c.Curate.Retirement = Retirement{Enabled: true, Floor: 0.7, Prior: 3.0}
+	c.Curate.Revalidation.Enabled = true // floor/prior left unset
+	ApplyDefaults(&c)
+	if r := c.Curate.Revalidation; r.Floor != 0.7 || r.Prior != 3.0 {
+		t.Fatalf("revalidation must inherit retirement's calibration, got floor=%g prior=%g", r.Floor, r.Prior)
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("an inherited pair must validate: %v", err)
+	}
+
+	// With no retirement block the recall gate's own defaults still apply.
+	var off Config
+	off.Curate.Revalidation.Enabled = true
+	ApplyDefaults(&off)
+	if r := off.Curate.Revalidation; r.Floor != 0.5 || r.Prior != 2.0 {
+		t.Fatalf("with no retirement block the recall-gate defaults must apply, got floor=%g prior=%g", r.Floor, r.Prior)
+	}
+}
+
+// TestValidateRejectsDivergentDecayCalibration is the enforcement half. The
+// disjointness the docs assert is arithmetic, not a rule either pass applies, so
+// two deliberately different values must fail loud rather than open an overlap
+// band at runtime.
+func TestValidateRejectsDivergentDecayCalibration(t *testing.T) {
+	both := func(retFloor, revFloor, retPrior, revPrior float64) *Config {
+		c := &Config{}
+		c.Curate.Retirement = Retirement{Enabled: true, MinObservations: 3, Floor: retFloor, Prior: retPrior}
+		c.Curate.Revalidation = Revalidation{
+			Enabled: true, MinInterval: Duration(720 * time.Hour), MaxOpen: 5, Floor: revFloor, Prior: revPrior,
+		}
+		return c
+	}
+	if err := both(0.5, 0.5, 2.0, 2.0).Validate(); err != nil {
+		t.Fatalf("a matched pair must validate: %v", err)
+	}
+	cases := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		// 0.6 vs 0.4 is the overlap band made concrete: an entry at factor 0.5 is
+		// below retirement's floor AND at-or-above revalidation's, so both propose it.
+		{"unequal floors", both(0.6, 0.4, 2.0, 2.0), "curate.revalidation.floor"},
+		{"unequal priors", both(0.5, 0.5, 2.0, 4.0), "curate.revalidation.prior"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want an error naming %s, got %v", tc.want, err)
+			}
+			if !strings.Contains(err.Error(), "inherit") {
+				t.Errorf("the error must tell the operator how to fix it, got %q", err)
+			}
+		})
+	}
+
+	// Only one pass on: there is no pair to reconcile, however odd the other block.
+	solo := both(0.9, 0.2, 5.0, 1.0)
+	solo.Curate.Retirement.Enabled = false
+	if err := solo.Validate(); err != nil {
+		t.Fatalf("with retirement disabled there is no pair to reconcile: %v", err)
+	}
+}
+
 // TestRevalidationLoadsFromYAML pins the YAML key names — the pass is configured
 // entirely through them, and a renamed field would silently leave it disabled.
 func TestRevalidationLoadsFromYAML(t *testing.T) {

--- a/internal/config/config_revalidation_test.go
+++ b/internal/config/config_revalidation_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyDefaultsRevalidationEnabled(t *testing.T) {
+	// Only revalidation.enabled set — every tuning knob gets its default, and the
+	// decay knobs mirror recall's outcome gate (and retirement's) so all three agree.
+	var c Config
+	c.Curate.Revalidation.Enabled = true
+	ApplyDefaults(&c)
+	r := c.Curate.Revalidation
+	if r.MinInterval.Std() != 720*time.Hour {
+		t.Errorf("default MinInterval: got %v, want 720h", r.MinInterval.Std())
+	}
+	if r.MaxOpen != 5 {
+		t.Errorf("default MaxOpen: got %d, want 5", r.MaxOpen)
+	}
+	if r.Floor != 0.5 {
+		t.Errorf("default Floor: got %g, want 0.5", r.Floor)
+	}
+	if r.Prior != 2.0 {
+		t.Errorf("default Prior: got %g, want 2.0", r.Prior)
+	}
+
+	// Explicit values are respected, not overwritten.
+	var c2 Config
+	c2.Curate.Revalidation = Revalidation{
+		Enabled: true, MinInterval: Duration(48 * time.Hour), MaxOpen: 1, Floor: 0.3, Prior: 4.0,
+	}
+	ApplyDefaults(&c2)
+	if r2 := c2.Curate.Revalidation; r2.MinInterval.Std() != 48*time.Hour || r2.MaxOpen != 1 || r2.Floor != 0.3 || r2.Prior != 4.0 {
+		t.Fatalf("explicit revalidation tuning overwritten: %+v", r2)
+	}
+}
+
+func TestApplyDefaultsRevalidationDisabled(t *testing.T) {
+	// Disabled (the default): the pass is opt-in, so no defaults are filled — the
+	// block stays at its zero value and never wires the pass in.
+	var c Config
+	ApplyDefaults(&c)
+	if r := c.Curate.Revalidation; r.MinInterval != 0 || r.MaxOpen != 0 || r.Floor != 0 || r.Prior != 0 {
+		t.Fatalf("defaults must not be applied while revalidation is disabled: %+v", r)
+	}
+}
+
+func TestValidateRevalidation(t *testing.T) {
+	valid := func() *Config {
+		c := &Config{}
+		c.Curate.Revalidation = Revalidation{
+			Enabled: true, MinInterval: Duration(720 * time.Hour), MaxOpen: 5, Floor: 0.5, Prior: 2.0,
+		}
+		return c
+	}
+	if err := valid().Validate(); err != nil {
+		t.Fatalf("a valid revalidation config must pass: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		set  func(*Revalidation)
+		want string
+	}{
+		{"floor above 1", func(r *Revalidation) { r.Floor = 1.5 }, "curate.revalidation.floor"},
+		{"floor at or below 0", func(r *Revalidation) { r.Floor = -0.1 }, "curate.revalidation.floor"},
+		{"negative interval", func(r *Revalidation) { r.MinInterval = Duration(-time.Hour) }, "curate.revalidation.min_interval"},
+		{"max_open below 1", func(r *Revalidation) { r.MaxOpen = 0 }, "curate.revalidation.max_open"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := valid()
+			tc.set(&c.Curate.Revalidation)
+			err := c.Validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want an error naming %s, got %v", tc.want, err)
+			}
+		})
+	}
+
+	// Disabled: an opt-out config is never validated, however nonsensical its knobs.
+	off := valid()
+	off.Curate.Revalidation = Revalidation{Enabled: false, Floor: 99, MaxOpen: -5}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("a disabled revalidation block must not be validated: %v", err)
+	}
+}
+
+// TestRevalidationLoadsFromYAML pins the YAML key names — the pass is configured
+// entirely through them, and a renamed field would silently leave it disabled.
+func TestRevalidationLoadsFromYAML(t *testing.T) {
+	c := loadDoc(t, `
+curate:
+  revalidation:
+    enabled: true
+    min_interval: 168h
+    max_open: 3
+    floor: 0.6
+    prior: 3.0
+`)
+	r := c.Curate.Revalidation
+	if !r.Enabled || r.MinInterval.Std() != 168*time.Hour || r.MaxOpen != 3 || r.Floor != 0.6 || r.Prior != 3.0 {
+		t.Fatalf("revalidation block not decoded: %+v", r)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -223,10 +223,17 @@ func ApplyDefaults(c *Config) {
 		}
 	}
 	// Revalidation pass defaults (opt-in), filled on the same terms as retirement's.
-	// Floor/Prior mirror the recall gate AND retirement, which is what makes the two
-	// passes complementary rather than overlapping: retirement fires strictly below
-	// the floor, revalidation at or above it. MinInterval caps one entry to one
-	// confirmation PR a month; MaxOpen caps the whole review queue.
+	// MinInterval caps one entry to one confirmation PR a month; MaxOpen caps the
+	// whole review queue.
+	//
+	// Floor/Prior INHERIT retirement's (already defaulted just above) rather than
+	// restating the constants, because the disjointness the two passes claim is
+	// arithmetic, not editorial: retirement fires strictly below the floor and
+	// revalidation at or above it, which partitions entries only while both read the
+	// SAME number. Deriving one from the other means an operator who tunes
+	// retirement gets a still-coherent pair by default instead of a silent overlap
+	// band. Retirement's own default backstops the case where it is disabled or
+	// unset, so an unconfigured revalidation still lands on the recall gate's 0.5/2.0.
 	if c.Curate.Revalidation.Enabled {
 		r := &c.Curate.Revalidation
 		if r.MinInterval == 0 {
@@ -236,7 +243,13 @@ func ApplyDefaults(c *Config) {
 			r.MaxOpen = 5
 		}
 		if r.Floor == 0 {
+			r.Floor = c.Curate.Retirement.Floor
+		}
+		if r.Floor == 0 {
 			r.Floor = 0.5
+		}
+		if r.Prior == 0 {
+			r.Prior = c.Curate.Retirement.Prior
 		}
 		if r.Prior == 0 {
 			r.Prior = 2.0

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -222,6 +222,26 @@ func ApplyDefaults(c *Config) {
 			r.Prior = 2.0
 		}
 	}
+	// Revalidation pass defaults (opt-in), filled on the same terms as retirement's.
+	// Floor/Prior mirror the recall gate AND retirement, which is what makes the two
+	// passes complementary rather than overlapping: retirement fires strictly below
+	// the floor, revalidation at or above it. MinInterval caps one entry to one
+	// confirmation PR a month; MaxOpen caps the whole review queue.
+	if c.Curate.Revalidation.Enabled {
+		r := &c.Curate.Revalidation
+		if r.MinInterval == 0 {
+			r.MinInterval = Duration(720 * time.Hour)
+		}
+		if r.MaxOpen == 0 {
+			r.MaxOpen = 5
+		}
+		if r.Floor == 0 {
+			r.Floor = 0.5
+		}
+		if r.Prior == 0 {
+			r.Prior = 2.0
+		}
+	}
 	// In-server sweep interval: always filled (harmless when mode: off) so callers
 	// never see a zero interval.
 	if c.Curate.Sweeps.Interval == 0 {

--- a/internal/curate/dedup.go
+++ b/internal/curate/dedup.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sort"
 	"strings"
 
@@ -32,6 +33,15 @@ func (d Dedup) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("list PRs: %w", err)
 	}
+	// Retire/revalidate proposals are not dedup candidates, as canonical or as
+	// duplicate. Dedup collapses duplicate DRAFTS of one entry; those are proposals
+	// about DISTINCT entries that already exist. They carry no DupFingerprint, so
+	// they would fall through to the title-Jaccard fallback — which on "KB
+	// revalidate: <path>" titles measures path similarity rather than subject
+	// similarity, and scores two unrelated entries filed under one directory well
+	// above the threshold. Closing one is also unrecoverable: the pass that opened
+	// it reads its own closed proposal back as a human veto (see entryEditLabels).
+	prs = slices.DeleteFunc(prs, func(pr providers.CuratedIssue) bool { return isEntryEditProposal(pr.Labels) })
 	sort.Slice(prs, func(i, j int) bool { return prs[i].Number < prs[j].Number })
 	canonicalOf := map[int]int{} // dup PR number -> canonical PR number
 	for i := range prs {

--- a/internal/curate/guard.go
+++ b/internal/curate/guard.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/Smana/runlore/internal/audit"
 	"github.com/Smana/runlore/internal/providers"
@@ -15,12 +16,13 @@ import (
 // GuardedForge is the union of every read and write the grooming passes perform —
 // the surface Guard wraps. Composed from the pass role interfaces so it stays in
 // sync with them by construction (RetireForge adds ListClosedUnmergedPRsByLabel +
-// OpenRetirePR; ContestedForge adds ListIssueCommentBodies + IsPROpen; overlapping
-// methods across the embedded sets are legal since Go 1.14). *github.Client
-// satisfies it (pinned in internal/app).
+// OpenRetirePR; RevalidateForge adds OpenRevalidatePR; ContestedForge adds
+// ListIssueCommentBodies + IsPROpen; overlapping methods across the embedded sets
+// are legal since Go 1.14). *github.Client satisfies it (pinned in internal/app).
 type GuardedForge interface {
 	Forge
 	RetireForge
+	RevalidateForge
 	ContestedForge
 }
 
@@ -99,6 +101,23 @@ func (g Guard) OpenRetirePR(ctx context.Context, entryPath, body string) (provid
 	err := g.write("kb.retire-pr", entryPath, "", func() error {
 		var ierr error
 		ref, ierr = g.Inner.OpenRetirePR(ctx, entryPath, body)
+		return ierr
+	})
+	return ref, err
+}
+
+// OpenRevalidatePR opens a revalidate PR for a still-working entry (audited;
+// skipped in dry-run). The audited reason is the date under proposal — the one
+// fact a reviewer of the audit chain needs. Note that a dry-run reports every
+// CANDIDATE: the "already fresh enough" check lives behind the forge call
+// (ErrRecentlyValidated), which dry-run never makes, so the report is a superset
+// of what an apply run would open — the same over-report retirement's
+// ErrAlreadyRetired has.
+func (g Guard) OpenRevalidatePR(ctx context.Context, entryPath string, validated time.Time, minGap time.Duration, body string) (providers.Ref, error) {
+	var ref providers.Ref
+	err := g.write("kb.revalidate-pr", entryPath, validated.UTC().Format(time.DateOnly), func() error {
+		var ierr error
+		ref, ierr = g.Inner.OpenRevalidatePR(ctx, entryPath, validated, minGap, body)
 		return ierr
 	})
 	return ref, err

--- a/internal/curate/guard.go
+++ b/internal/curate/guard.go
@@ -4,12 +4,14 @@ package curate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/forge/github"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -108,11 +110,16 @@ func (g Guard) OpenRetirePR(ctx context.Context, entryPath, body string) (provid
 
 // OpenRevalidatePR opens a revalidate PR for a still-working entry (audited;
 // skipped in dry-run). The audited reason is the date under proposal — the one
-// fact a reviewer of the audit chain needs. Note that a dry-run reports every
-// CANDIDATE: the "already fresh enough" check lives behind the forge call
-// (ErrRecentlyValidated), which dry-run never makes, so the report is a superset
-// of what an apply run would open — the same over-report retirement's
-// ErrAlreadyRetired has.
+// fact a reviewer of the audit chain needs.
+//
+// What a dry-run reports is NOT what an apply run would open, and it errs in BOTH
+// directions, so do not size review load from it. The "already fresh enough" check
+// lives behind the forge call (ErrRecentlyValidated), which a dry-run never makes,
+// so a reported candidate may already be fresh — an over-report. But a dry-run
+// returns nil, which SPENDS the pass's open-PR budget, so the report also stops at
+// max_open, while an apply run skips fresh entries for free and walks further down
+// the candidate list — an under-report. Read it as "these entries are in scope",
+// not "these PRs will open".
 func (g Guard) OpenRevalidatePR(ctx context.Context, entryPath string, validated time.Time, minGap time.Duration, body string) (providers.Ref, error) {
 	var ref providers.Ref
 	err := g.write("kb.revalidate-pr", entryPath, validated.UTC().Format(time.DateOnly), func() error {
@@ -133,11 +140,30 @@ func (g Guard) write(op, target, reason string, do func() error) error {
 		return nil
 	}
 	if err := do(); err != nil {
-		g.record(op, target, audit.DecisionFailed, err.Error())
+		g.record(op, target, doneSkipOrFailed(err), err.Error())
 		return err
 	}
 	g.record(op, target, audit.DecisionExecuted, reason)
 	return nil
+}
+
+// doneSkipOrFailed classifies a forge error for the audit chain. The entry-edit
+// stamps return sentinels meaning "the forge looked and no edit was warranted" —
+// nothing was attempted and nothing failed — so recording them as failures writes
+// a claim into an append-only chain that is simply untrue. Nor is it a rare
+// mislabel: for revalidation the done-skip IS the steady state, because every
+// healthy entry is a candidate on every sweep and nearly all of them are already
+// fresh. The chain would fill with "failed" records describing a pass working
+// exactly as designed, and drown the records that mean something.
+func doneSkipOrFailed(err error) audit.Decision {
+	switch {
+	case errors.Is(err, github.ErrRecentlyValidated),
+		errors.Is(err, github.ErrEntryInactive),
+		errors.Is(err, github.ErrAlreadyRetired):
+		return audit.DecisionSkipped
+	default:
+		return audit.DecisionFailed
+	}
 }
 
 // record appends to the audit chain; a failed audit write must never abort the

--- a/internal/curate/guard_test.go
+++ b/internal/curate/guard_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Smana/runlore/internal/audit"
 	"github.com/Smana/runlore/internal/providers"
@@ -13,17 +14,19 @@ import (
 
 // Guard must satisfy every pass-facing forge surface, so one wrapper covers all passes.
 var (
-	_ Forge          = Guard{}
-	_ RetireForge    = Guard{}
-	_ ClosedPRLister = Guard{}
-	_ ContestedForge = Guard{}
+	_ Forge           = Guard{}
+	_ RetireForge     = Guard{}
+	_ RevalidateForge = Guard{}
+	_ ClosedPRLister  = Guard{}
+	_ ContestedForge  = Guard{}
 )
 
 // fakeGuarded extends the shared fakeForge with the wider GuardedForge surface.
 type fakeGuarded struct {
 	fakeForge
-	retired  []string
-	closeErr error
+	retired     []string
+	revalidated []string
+	closeErr    error
 }
 
 func (f *fakeGuarded) ListClosedUnmergedPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
@@ -34,6 +37,10 @@ func (f *fakeGuarded) IsPROpen(context.Context, int) (bool, error)              
 func (f *fakeGuarded) OpenRetirePR(_ context.Context, entryPath, _ string) (providers.Ref, error) {
 	f.retired = append(f.retired, entryPath)
 	return providers.Ref{URL: "https://forge/pr/1"}, nil
+}
+func (f *fakeGuarded) OpenRevalidatePR(_ context.Context, entryPath string, _ time.Time, _ time.Duration, _ string) (providers.Ref, error) {
+	f.revalidated = append(f.revalidated, entryPath)
+	return providers.Ref{URL: "https://forge/pr/2"}, nil
 }
 func (f *fakeGuarded) Close(ctx context.Context, n int) error {
 	if f.closeErr != nil {
@@ -56,14 +63,23 @@ func TestGuardDryRunSkipsWritesButAudits(t *testing.T) {
 	if _, err := g.OpenRetirePR(context.Background(), "entries/a.md", "body"); err != nil {
 		t.Fatal(err)
 	}
-	if len(inner.closed) != 0 || len(inner.retired) != 0 {
-		t.Fatalf("dry-run must not reach the forge: closed=%v retired=%v", inner.closed, inner.retired)
+	validated := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	if _, err := g.OpenRevalidatePR(context.Background(), "entries/b.md", validated, time.Hour, "body"); err != nil {
+		t.Fatal(err)
 	}
-	if len(aud.recs) != 2 || aud.recs[0].Decision != audit.DecisionDryRun || aud.recs[0].Actor != "curate" {
-		t.Fatalf("want 2 dry-run audit records with actor=curate, got %+v", aud.recs)
+	if len(inner.closed) != 0 || len(inner.retired) != 0 || len(inner.revalidated) != 0 {
+		t.Fatalf("dry-run must not reach the forge: closed=%v retired=%v revalidated=%v",
+			inner.closed, inner.retired, inner.revalidated)
+	}
+	if len(aud.recs) != 3 || aud.recs[0].Decision != audit.DecisionDryRun || aud.recs[0].Actor != "curate" {
+		t.Fatalf("want 3 dry-run audit records with actor=curate, got %+v", aud.recs)
 	}
 	if aud.recs[0].Op != "kb.close" || aud.recs[0].Target != "pr/7" {
 		t.Fatalf("record[0] = %+v, want op kb.close target pr/7", aud.recs[0])
+	}
+	// The revalidation record names the entry AND the date under proposal.
+	if r := aud.recs[2]; r.Op != "kb.revalidate-pr" || r.Target != "entries/b.md" || r.Reason != "2026-08-03" {
+		t.Fatalf("record[2] = %+v, want op kb.revalidate-pr target entries/b.md reason 2026-08-03", r)
 	}
 }
 

--- a/internal/curate/guard_test.go
+++ b/internal/curate/guard_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Smana/runlore/internal/audit"
+	"github.com/Smana/runlore/internal/forge/github"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -24,9 +25,10 @@ var (
 // fakeGuarded extends the shared fakeForge with the wider GuardedForge surface.
 type fakeGuarded struct {
 	fakeForge
-	retired     []string
-	revalidated []string
-	closeErr    error
+	retired       []string
+	revalidated   []string
+	closeErr      error
+	revalidateErr error
 }
 
 func (f *fakeGuarded) ListClosedUnmergedPRsByLabel(context.Context, string) ([]providers.CuratedIssue, error) {
@@ -39,6 +41,9 @@ func (f *fakeGuarded) OpenRetirePR(_ context.Context, entryPath, _ string) (prov
 	return providers.Ref{URL: "https://forge/pr/1"}, nil
 }
 func (f *fakeGuarded) OpenRevalidatePR(_ context.Context, entryPath string, _ time.Time, _ time.Duration, _ string) (providers.Ref, error) {
+	if f.revalidateErr != nil {
+		return providers.Ref{}, f.revalidateErr
+	}
 	f.revalidated = append(f.revalidated, entryPath)
 	return providers.Ref{URL: "https://forge/pr/2"}, nil
 }
@@ -106,6 +111,38 @@ func TestGuardFailureIsAuditedAndPropagated(t *testing.T) {
 	}
 	if len(aud.recs) != 1 || aud.recs[0].Decision != audit.DecisionFailed {
 		t.Fatalf("want a failed audit record, got %+v", aud.recs)
+	}
+}
+
+// TestGuardAuditsDoneSkipsAsSkippedNotFailed pins the disposition of the entry-edit
+// sentinels. They mean the forge looked and no edit was warranted — nothing was
+// attempted, so nothing failed. It matters beyond tidiness: for revalidation the
+// done-skip is the STEADY state (every healthy entry is a candidate every sweep,
+// and nearly all are already fresh), so mislabelling it would fill an append-only
+// chain with "failed" records describing a pass working exactly as designed.
+func TestGuardAuditsDoneSkipsAsSkippedNotFailed(t *testing.T) {
+	skips := []error{github.ErrRecentlyValidated, github.ErrEntryInactive, github.ErrAlreadyRetired}
+	for _, sentinel := range skips {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			inner, aud := &fakeGuarded{revalidateErr: sentinel}, &recAudit{}
+			g := Guard{Inner: inner, Audit: aud, Log: discardLog()}
+			_, err := g.OpenRevalidatePR(context.Background(), "entries/a.md", time.Now(), time.Hour, "body")
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("the sentinel must still reach the pass, got %v", err)
+			}
+			if len(aud.recs) != 1 || aud.recs[0].Decision != audit.DecisionSkipped {
+				t.Fatalf("want one skipped record, got %+v", aud.recs)
+			}
+		})
+	}
+	// A genuine forge error is still a failure.
+	inner, aud := &fakeGuarded{revalidateErr: errors.New("forge 502")}, &recAudit{}
+	g := Guard{Inner: inner, Audit: aud, Log: discardLog()}
+	if _, err := g.OpenRevalidatePR(context.Background(), "entries/a.md", time.Now(), time.Hour, "body"); err == nil {
+		t.Fatal("want the forge error to propagate")
+	}
+	if len(aud.recs) != 1 || aud.recs[0].Decision != audit.DecisionFailed {
+		t.Fatalf("a real forge error must stay a failure, got %+v", aud.recs)
 	}
 }
 

--- a/internal/curate/lifecycle.go
+++ b/internal/curate/lifecycle.go
@@ -14,6 +14,29 @@ import (
 // for merge — auto-closing it would discard that editorial work.
 var protectedLabels = []string{"solved", "ready-to-merge", "accepted", "investigating", "knowledge-gap"}
 
+// entryEditLabels mark the lifecycle proposals the decay-driven passes open —
+// Retirement's retire PRs and Revalidation's revalidate PRs. RunLore must never
+// close one itself, by ANY pass.
+//
+// Those passes keep no store: an entry's history is reconstructed from the forge
+// on every run, where a still-open proposal means "already asked" and a
+// CLOSED-UNMERGED one means "a human declined — never ask again". Nothing in that
+// signal distinguishes a reviewer's close from RunLore's own housekeeping, so a
+// stale-sweep or dedup close is read straight back as a permanent veto, and the
+// entry is never proposed again for a decision no human ever made. Excluding them
+// keeps the veto meaning exactly what it claims. The cost is that an unreviewed
+// proposal stays open indefinitely; Revalidation's MaxOpen is what bounds that
+// queue instead, and closing one by hand is then a real veto rather than an
+// accident.
+var entryEditLabels = []string{retireLabel, revalidateLabel}
+
+// isEntryEditProposal reports whether a PR is a retire/revalidate proposal about
+// an EXISTING merged entry rather than a draft of a new one.
+func isEntryEditProposal(labels []string) bool {
+	_, ok := firstLabelIn(labels, entryEditLabels)
+	return ok
+}
+
 // Lifecycle closes stale, unprotected KB artifacts — those with no forge activity
 // within StaleAfter. A PR whose age is unknown (zero UpdatedAt) is never closed.
 type Lifecycle struct {
@@ -37,6 +60,9 @@ func (l Lifecycle) Run(ctx context.Context) error {
 		return err
 	}
 	for _, pr := range prs {
+		if isEntryEditProposal(pr.Labels) {
+			continue // only a human may close one of these — see entryEditLabels
+		}
 		if isProtected(pr.Labels) || pr.UpdatedAt.IsZero() || now().Sub(pr.UpdatedAt) <= l.StaleAfter {
 			continue
 		}

--- a/internal/curate/retirement.go
+++ b/internal/curate/retirement.go
@@ -28,8 +28,11 @@ type RetireForge interface {
 	OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error)
 }
 
-// RetireStats is the ledger view the pass needs: the per-entry outcome roll-up.
-type RetireStats interface {
+// EntryStats is the ledger view the decay-driven passes need: the per-entry
+// outcome roll-up. Retirement and Revalidation share it deliberately — they gate
+// on opposite sides of the SAME aggregate, so reading it through one interface is
+// what keeps them from ever disagreeing about an entry's track record.
+type EntryStats interface {
 	OpenCounts() (map[string]outcome.Aggregate, error)
 }
 
@@ -44,7 +47,7 @@ type RetireStats interface {
 // re-nagged. Opt-in (see config): retirement is a judgment call an operator enables.
 type Retirement struct {
 	Forge           RetireForge
-	Stats           RetireStats
+	Stats           EntryStats
 	MinObservations int     // sustained-decay bar: total observations before retirement is considered
 	Floor           float64 // retire when Factor(Prior) < Floor
 	Prior           float64 // k — must equal recall's outcome_prior so both gates agree

--- a/internal/curate/retirement.go
+++ b/internal/curate/retirement.go
@@ -137,11 +137,17 @@ func retireBody(path string, agg outcome.Aggregate, factor, floor float64, marke
 }
 
 // retireMarker is the hidden idempotency/veto marker embedded in a retire PR body:
-// one per entry path. The path is hashed rather than embedded verbatim so a path
-// with "--"/">" sequences can never break out of the HTML comment.
-func retireMarker(entryPath string) string {
+// one per entry path. See entryMarker for the shared construction.
+func retireMarker(entryPath string) string { return entryMarker("retire", entryPath) }
+
+// entryMarker renders the hidden per-entry marker the decay-driven passes embed in
+// the PR bodies they open and scan back for idempotency and the human veto. The
+// path is hashed rather than embedded verbatim so a path with "--"/">" sequences
+// can never break out of the HTML comment; kind keeps one pass's markers from ever
+// matching another's.
+func entryMarker(kind, entryPath string) string {
 	sum := sha256.Sum256([]byte(entryPath))
-	return fmt.Sprintf("<!-- runlore:retire:%x -->", sum[:8])
+	return fmt.Sprintf("<!-- runlore:%s:%x -->", kind, sum[:8])
 }
 
 // bodiesOf projects the PR bodies for marker scanning.

--- a/internal/curate/retirement_test.go
+++ b/internal/curate/retirement_test.go
@@ -59,7 +59,7 @@ func (m mapStats) OpenCounts() (map[string]outcome.Aggregate, error) { return m,
 // *github.Client must satisfy the consumer-side RetireForge interface.
 var _ RetireForge = (*github.Client)(nil)
 
-func newRetirement(forge RetireForge, stats RetireStats) Retirement {
+func newRetirement(forge RetireForge, stats EntryStats) Retirement {
 	return Retirement{
 		Forge:           forge,
 		Stats:           stats,

--- a/internal/curate/revalidation.go
+++ b/internal/curate/revalidation.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/forge/github"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// revalidateLabel is the forge label the revalidation pass lists on for
+// idempotency and human-veto detection — the same label OpenRevalidatePR stamps
+// on the PRs it opens.
+const revalidateLabel = "runlore-revalidate"
+
+// DefaultMaxOpenRevalidations is the fallback reviewer-queue bound when none is
+// configured. config.ApplyDefaults ships the same value; this guard only protects
+// direct users of the package — and it matters more here than a missing interval
+// would, because an unset bound computes a budget of zero and would silently make
+// the whole pass a no-op.
+const DefaultMaxOpenRevalidations = 5
+
+// RevalidateForge is the forge surface the Revalidation pass needs (consumer-side,
+// like RetireForge — widening the shared Forge would bloat every other pass's fake).
+type RevalidateForge interface {
+	ListPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	ListClosedUnmergedPRsByLabel(ctx context.Context, label string) ([]providers.CuratedIssue, error)
+	OpenRevalidatePR(ctx context.Context, entryPath string, validated time.Time, minGap time.Duration, body string) (providers.Ref, error)
+}
+
+// Revalidation is the mirror image of Retirement: where retirement proposes
+// letting go of an entry whose track record decayed, this proposes CONFIRMING one
+// whose track record held — opening a human-reviewed PR that stamps
+// `last_validated` with the date a recall of that entry was followed by the
+// incident actually clearing.
+//
+// It exists because `last_validated` could previously only decay. The forge
+// leaves it unset when it drafts an entry (renderEntry: "that field claims human
+// confirmation", and a fresh draft has none), and nothing ever wrote it
+// afterwards — so with catalog.instant_recall.stale_after configured, every
+// entry's delivered confidence stepped down permanently from its creation date
+// and could only be restored by hand-editing YAML. This pass is how the field is
+// earned instead.
+//
+// The evidence bar is ONE resolved recall, and the pass is deliberately not
+// apologetic about that. A resolved recall is not a bare coincidence: the entry
+// won recall's structural and margin gates, was confirmed against LIVE cluster
+// state, survived the adversarial verify pass, was delivered as the answer, and
+// the incident then cleared. That is a far denser chain of checks than
+// retirement's evidence (an alert simply failing to clear), which is why
+// retirement needs MinObservations to distinguish signal from noise and this pass
+// does not. The asymmetry is also one of consequence: retirement REMOVES
+// knowledge, while this only proposes a date — and the field claims HUMAN
+// confirmation, which merging the PR is precisely the act of giving. RunLore's
+// job here is only to bring honest evidence to a reviewer; the human remains the
+// thing that makes the claim true.
+//
+// Interaction with Retirement: the two are DISJOINT BY CONSTRUCTION, not by a
+// cross-pass check that could drift. Retirement fires strictly below the trust
+// floor (Factor < Floor), this one only at or above it, both using
+// outcome.Aggregate.Factor with the same prior/floor recall's Gate 3 uses. So an
+// entry can never be proposed for both in one sweep, and where they meet
+// RETIREMENT WINS: an entry recall already refuses to fire has not earned a
+// "still valid" stamp, whatever a stale resolve in its history says.
+//
+// Like the other passes it never merges, never writes directly, is idempotent via
+// a hidden per-entry marker in the PR body, treats a closed-unmerged PR carrying
+// that marker as a permanent human veto, and isolates per-item forge failures.
+// Opt-in (see config): it opens PRs against the operator's repo.
+type Revalidation struct {
+	Forge RevalidateForge
+	Stats EntryStats
+	// MinInterval is the anti-spam bar: the candidate date must be at least this
+	// much newer than the entry's recorded freshness (last_validated, else
+	// timestamp — recall's own age-gate fallback) or no PR is opened. Evaluated
+	// against the file on the base branch by the forge, so a merged revalidation
+	// silences the next sweep with no state to keep.
+	MinInterval time.Duration
+	// MaxOpen bounds how many revalidation PRs may be waiting on a human at once.
+	// It is a reviewer-queue bound, not a per-run one: outstanding PRs from earlier
+	// sweeps count against it, so the queue drains as it is reviewed instead of
+	// growing every interval.
+	MaxOpen int
+	Floor   float64 // revalidate only at/above this factor — the retirement boundary
+	Prior   float64 // k — must equal recall's outcome_prior so all three gates agree
+	Log     *slog.Logger
+}
+
+// Run proposes one revalidation PR per confirmed, still-trusted candidate.
+// Per-item forge failures are logged and skipped so one flaky entry never starves
+// the rest.
+func (p Revalidation) Run(ctx context.Context) error {
+	counts, err := p.Stats.OpenCounts()
+	if err != nil {
+		return fmt.Errorf("revalidation: open counts: %w", err)
+	}
+	// Candidate = an entry with a resolved recall on record (LastConfirmed is the
+	// date of the newest one) that recall still trusts. Sorted for deterministic
+	// logs, tests, and — with MaxOpen — a stable queue that advances as PRs are
+	// merged or vetoed rather than shuffling every run.
+	var candidates []string
+	for path, agg := range counts {
+		if agg.Resolved == 0 || agg.LastConfirmed.IsZero() {
+			continue // no resolved recall: nothing was confirmed
+		}
+		if agg.Factor(p.Prior) < p.Floor {
+			continue // a retirement candidate; see the disjointness note above
+		}
+		candidates = append(candidates, path)
+	}
+	if len(candidates) == 0 {
+		return nil // nothing confirmed: zero forge calls
+	}
+	slices.Sort(candidates)
+
+	// One listing of each revalidate-PR set per run (the Contested per-run-cache
+	// pattern): open PRs give idempotency AND the queue depth, closed-unmerged PRs
+	// give the human veto.
+	openPRs, err := p.Forge.ListPRsByLabel(ctx, revalidateLabel)
+	if err != nil {
+		return fmt.Errorf("revalidation: list open revalidate PRs: %w", err)
+	}
+	closedPRs, err := p.Forge.ListClosedUnmergedPRsByLabel(ctx, revalidateLabel)
+	if err != nil {
+		// Fail the run rather than propose blind: without the veto listing every
+		// declined entry would be re-nagged.
+		return fmt.Errorf("revalidation: list closed-unmerged revalidate PRs: %w", err)
+	}
+	openBodies := bodiesOf(openPRs)
+	vetoedBodies := bodiesOf(closedPRs)
+
+	maxOpen := p.MaxOpen
+	if maxOpen <= 0 {
+		maxOpen = DefaultMaxOpenRevalidations
+	}
+	budget := maxOpen - len(openPRs)
+	if budget <= 0 {
+		p.Log.Info("revalidation: review queue full; proposing nothing this sweep",
+			"open", len(openPRs), "max_open", maxOpen, "candidates", len(candidates))
+		return nil
+	}
+
+	for _, path := range candidates {
+		if budget == 0 {
+			p.Log.Info("revalidation: open-PR budget spent; remaining candidates wait for the next sweep",
+				"max_open", maxOpen)
+			return nil
+		}
+		agg := counts[path]
+		marker := revalidateMarker(path)
+		if anyContains(openBodies, marker) {
+			continue // already proposed on an open PR — the marker is the idempotency record
+		}
+		if anyContains(vetoedBodies, marker) {
+			// A human closed a revalidation PR for this entry without merging: a
+			// deliberate "I am not confirming this". Never re-propose (the
+			// ClosedPRSuppression philosophy). The marker is keyed on the entry
+			// path alone, NOT on the date, precisely so the veto is permanent — a
+			// date-keyed marker would turn every veto into a monthly re-ask.
+			p.Log.Debug("revalidation: entry has a human-vetoed revalidate PR; skipping", "entry", path)
+			continue
+		}
+		factor := agg.Factor(p.Prior)
+		body := revalidateBody(path, agg, factor, marker)
+		if _, err := p.Forge.OpenRevalidatePR(ctx, path, agg.LastConfirmed, p.MinInterval, body); err != nil {
+			// Both sentinels mean "no PR was warranted", so neither is a failure and
+			// neither spends the review-queue budget.
+			switch {
+			case errors.Is(err, github.ErrRecentlyValidated):
+				p.Log.Debug("revalidation: entry validated recently enough; skipping", "entry", path)
+			case errors.Is(err, github.ErrEntryInactive):
+				p.Log.Debug("revalidation: entry is retired or draft; skipping", "entry", path)
+			default:
+				p.Log.Warn("revalidation: open revalidate PR failed", "entry", path, "err", err)
+			}
+			continue // per-item isolation: one flaky entry never starves the rest
+		}
+		budget--
+		p.Log.Info("revalidation: proposed confirming a still-working entry", "entry", path,
+			"validated", agg.LastConfirmed, "factor", factor, "recalls", agg.Recalls, "resolved", agg.Resolved)
+	}
+	return nil
+}
+
+// revalidateBody renders the reviewer-facing confirmation proposal. It states the
+// evidence, is explicit that MERGING is the human confirmation the field claims
+// (RunLore cannot supply it), and spells out the veto path (close to decline).
+// The invisible marker goes last, like retireBody/contestedComment.
+func revalidateBody(path string, agg outcome.Aggregate, factor float64, marker string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "**RunLore proposes stamping `last_validated: %s` on `%s`** — it was recalled for a live incident, and that incident then resolved.\n\n",
+		agg.LastConfirmed.UTC().Format(time.DateOnly), path)
+	fmt.Fprintf(&b, "| recalls | resolved | 👍 | 👎 | factor | last resolved |\n|---|---|---|---|---|---|\n| %d | %d | %d | %d | %.2f | %s |\n\n",
+		agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, factor, agg.LastConfirmed.UTC().Format(time.DateOnly))
+	b.WriteString("`last_validated` claims a HUMAN confirmed the entry still works, and RunLore cannot give that — merging this PR is the confirmation. ")
+	b.WriteString("It refreshes the entry against `catalog.instant_recall.stale_after`, so a note that keeps working stops looking older than it is (nothing else changes: no status, no content). ")
+	b.WriteString("Close this PR to decline: RunLore will not propose it again.\n\n")
+	b.WriteString(marker)
+	return b.String()
+}
+
+// revalidateMarker is the hidden idempotency/veto marker embedded in a revalidate
+// PR body: one per entry path. The path is hashed rather than embedded verbatim so
+// a path with "--"/">" sequences can never break out of the HTML comment.
+func revalidateMarker(entryPath string) string {
+	sum := sha256.Sum256([]byte(entryPath))
+	return fmt.Sprintf("<!-- runlore:revalidate:%x -->", sum[:8])
+}

--- a/internal/curate/revalidation.go
+++ b/internal/curate/revalidation.go
@@ -4,7 +4,6 @@ package curate
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -150,7 +149,7 @@ func (p Revalidation) Run(ctx context.Context) error {
 	}
 
 	for _, path := range candidates {
-		if budget == 0 {
+		if budget <= 0 {
 			p.Log.Info("revalidation: open-PR budget spent; remaining candidates wait for the next sweep",
 				"max_open", maxOpen)
 			return nil
@@ -209,9 +208,5 @@ func revalidateBody(path string, agg outcome.Aggregate, factor float64, marker s
 }
 
 // revalidateMarker is the hidden idempotency/veto marker embedded in a revalidate
-// PR body: one per entry path. The path is hashed rather than embedded verbatim so
-// a path with "--"/">" sequences can never break out of the HTML comment.
-func revalidateMarker(entryPath string) string {
-	sum := sha256.Sum256([]byte(entryPath))
-	return fmt.Sprintf("<!-- runlore:revalidate:%x -->", sum[:8])
-}
+// PR body: one per entry path. See entryMarker for why the path is hashed.
+func revalidateMarker(entryPath string) string { return entryMarker("revalidate", entryPath) }

--- a/internal/curate/revalidation_test.go
+++ b/internal/curate/revalidation_test.go
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/forge/github"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// confirmedAt is the resolve time every healthy fixture below carries.
+var confirmedAt = time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+// fakeRevalidateForge records every call so tests can assert exactly which entries
+// were proposed (and that empty candidate sets make zero forge calls).
+type fakeRevalidateForge struct {
+	open, closed       []providers.CuratedIssue
+	openErr, closedErr error
+	prErr              map[string]error // per-path OpenRevalidatePR error injection
+
+	listOpen, listClosed int
+	proposed             []string             // entryPaths passed to OpenRevalidatePR, in call order
+	dates                map[string]time.Time // entryPath -> stamped date
+	gaps                 map[string]time.Duration
+	bodies               map[string]string
+}
+
+func (f *fakeRevalidateForge) ListPRsByLabel(_ context.Context, _ string) ([]providers.CuratedIssue, error) {
+	f.listOpen++
+	return f.open, f.openErr
+}
+
+func (f *fakeRevalidateForge) ListClosedUnmergedPRsByLabel(_ context.Context, _ string) ([]providers.CuratedIssue, error) {
+	f.listClosed++
+	return f.closed, f.closedErr
+}
+
+func (f *fakeRevalidateForge) OpenRevalidatePR(_ context.Context, entryPath string, validated time.Time, minGap time.Duration, body string) (providers.Ref, error) {
+	f.proposed = append(f.proposed, entryPath)
+	if f.dates == nil {
+		f.dates, f.gaps, f.bodies = map[string]time.Time{}, map[string]time.Duration{}, map[string]string{}
+	}
+	f.dates[entryPath], f.gaps[entryPath], f.bodies[entryPath] = validated, minGap, body
+	if err := f.prErr[entryPath]; err != nil {
+		return providers.Ref{}, err
+	}
+	return providers.Ref{URL: "https://github.com/o/r/pull/1"}, nil
+}
+
+// *github.Client must satisfy the consumer-side RevalidateForge interface.
+var _ RevalidateForge = (*github.Client)(nil)
+
+func newRevalidation(forge RevalidateForge, stats EntryStats) Revalidation {
+	return Revalidation{
+		Forge:       forge,
+		Stats:       stats,
+		MinInterval: 720 * time.Hour,
+		MaxOpen:     5,
+		Floor:       0.5,
+		Prior:       2.0,
+		Log:         quietLogger(),
+	}
+}
+
+func TestRevalidation(t *testing.T) {
+	t.Run("proposes only confirmed, still-trusted entries, in sorted order", func(t *testing.T) {
+		stats := mapStats{
+			// factor 0.83, one resolved recall on record -> propose
+			"incidents/works.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+			// factor 0.67 (>= floor) with a resolve -> propose
+			"incidents/mixed.md": {Recalls: 3, Resolved: 2, FeedbackUp: 1, LastConfirmed: confirmedAt},
+			// never resolved: 👍 votes alone are not the evidence this pass acts on
+			"incidents/votes-only.md": {Recalls: 1, FeedbackUp: 3},
+			// factor 0.20 -> a RETIREMENT candidate, never a revalidation one
+			"incidents/decayed.md": {Recalls: 5, Resolved: 1, LastConfirmed: confirmedAt},
+			// no recall history at all
+			"incidents/never-recalled.md": {},
+		}
+		forge := &fakeRevalidateForge{}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		want := []string{"incidents/mixed.md", "incidents/works.md"}
+		if !slices.Equal(forge.proposed, want) {
+			t.Fatalf("proposed=%v, want %v", forge.proposed, want)
+		}
+		// The date stamped is the resolve time — the evidence's own date, not "now".
+		if got := forge.dates["incidents/works.md"]; !got.Equal(confirmedAt) {
+			t.Errorf("stamped date=%v, want the ledger's LastConfirmed %v", got, confirmedAt)
+		}
+		if got := forge.gaps["incidents/works.md"]; got != 720*time.Hour {
+			t.Errorf("minGap=%v, want the configured MinInterval", got)
+		}
+		body := forge.bodies["incidents/works.md"]
+		for _, want := range []string{
+			revalidateMarker("incidents/works.md"), // idempotency + veto record
+			"2026-08-03",                           // the date under review
+			"0.83",                                 // the track record behind it
+			"Close this PR",                        // the veto is spelled out
+		} {
+			if !strings.Contains(body, want) {
+				t.Errorf("body missing %q:\n%s", want, body)
+			}
+		}
+	})
+
+	t.Run("an entry below the floor is left to retirement", func(t *testing.T) {
+		// Disjointness is the contract: retirement fires strictly below the floor,
+		// revalidation at or above it, so one sweep can never propose both.
+		stats := mapStats{"incidents/decayed.md": {Recalls: 5, Resolved: 1, LastConfirmed: confirmedAt}}
+		forge := &fakeRevalidateForge{}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(forge.proposed) != 0 {
+			t.Fatalf("a below-floor entry must never be revalidated, got %v", forge.proposed)
+		}
+	})
+
+	t.Run("idempotent: an open revalidate PR with the marker is skipped", func(t *testing.T) {
+		path := "incidents/works.md"
+		stats := mapStats{path: {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt}}
+		forge := &fakeRevalidateForge{
+			open: []providers.CuratedIssue{{Number: 7, Body: "proposal\n" + revalidateMarker(path)}},
+		}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(forge.proposed) != 0 {
+			t.Fatalf("expected no new PR, got %v", forge.proposed)
+		}
+		if forge.listOpen != 1 {
+			t.Fatalf("ListPRsByLabel called %d times, want exactly 1 per run", forge.listOpen)
+		}
+	})
+
+	t.Run("human veto: a closed-unmerged revalidate PR is never re-nagged", func(t *testing.T) {
+		path := "incidents/works.md"
+		stats := mapStats{path: {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt}}
+		forge := &fakeRevalidateForge{
+			closed: []providers.CuratedIssue{{Number: 9, Body: "declined\n" + revalidateMarker(path)}},
+		}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(forge.proposed) != 0 {
+			t.Fatalf("human veto ignored: proposed %v", forge.proposed)
+		}
+	})
+
+	t.Run("forge done-skips do not consume the open-PR budget", func(t *testing.T) {
+		stats := mapStats{
+			"incidents/a.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+			"incidents/b.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+		}
+		forge := &fakeRevalidateForge{prErr: map[string]error{"incidents/a.md": github.ErrRecentlyValidated}}
+		p := newRevalidation(forge, stats)
+		p.MaxOpen = 1 // budget for exactly one NEW PR
+		if err := p.Run(context.Background()); err != nil {
+			t.Fatalf("Run should not surface ErrRecentlyValidated: %v", err)
+		}
+		if !slices.Equal(forge.proposed, []string{"incidents/a.md", "incidents/b.md"}) {
+			t.Fatalf("a skipped entry must not spend the budget, got %v", forge.proposed)
+		}
+	})
+
+	t.Run("an inactive entry is a done-skip, the rest still run", func(t *testing.T) {
+		stats := mapStats{
+			"incidents/a.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+			"incidents/b.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+		}
+		forge := &fakeRevalidateForge{prErr: map[string]error{"incidents/a.md": github.ErrEntryInactive}}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run should not surface ErrEntryInactive: %v", err)
+		}
+		if !slices.Equal(forge.proposed, []string{"incidents/a.md", "incidents/b.md"}) {
+			t.Fatalf("both entries must be attempted, got %v", forge.proposed)
+		}
+	})
+
+	t.Run("per-item error isolation: one flaky entry never starves the rest", func(t *testing.T) {
+		stats := mapStats{
+			"incidents/a.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+			"incidents/b.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+		}
+		forge := &fakeRevalidateForge{prErr: map[string]error{"incidents/a.md": errors.New("forge boom")}}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("a per-item error must not fail the run: %v", err)
+		}
+		if !slices.Equal(forge.proposed, []string{"incidents/a.md", "incidents/b.md"}) {
+			t.Fatalf("both entries must be attempted, got %v", forge.proposed)
+		}
+	})
+
+	t.Run("empty candidate set makes zero forge calls", func(t *testing.T) {
+		stats := mapStats{"incidents/never-resolved.md": {Recalls: 1}}
+		forge := &fakeRevalidateForge{}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if forge.listOpen != 0 || forge.listClosed != 0 || len(forge.proposed) != 0 {
+			t.Fatalf("no candidates must mean zero forge calls: listOpen=%d listClosed=%d proposed=%v",
+				forge.listOpen, forge.listClosed, forge.proposed)
+		}
+	})
+
+	t.Run("a listing error fails the run rather than proposing blind", func(t *testing.T) {
+		stats := mapStats{"incidents/works.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt}}
+		forge := &fakeRevalidateForge{closedErr: errors.New("forge 502")}
+		if err := newRevalidation(forge, stats).Run(context.Background()); err == nil {
+			t.Fatal("want an error when the veto listing is unavailable")
+		}
+		if len(forge.proposed) != 0 {
+			t.Fatalf("no PR may be opened without the veto listing, got %v", forge.proposed)
+		}
+	})
+}
+
+// TestRevalidationOpenPRBudget pins the reviewer-queue bound. Enabling the pass on
+// a mature catalog can surface dozens of long-confirmed entries at once; without a
+// cap the first sweep would open a PR for every one of them.
+func TestRevalidationOpenPRBudget(t *testing.T) {
+	stats := mapStats{
+		"incidents/a.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+		"incidents/b.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+		"incidents/c.md": {Recalls: 4, Resolved: 4, LastConfirmed: confirmedAt},
+	}
+
+	t.Run("caps new PRs at MaxOpen", func(t *testing.T) {
+		forge := &fakeRevalidateForge{}
+		p := newRevalidation(forge, stats)
+		p.MaxOpen = 2
+		if err := p.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if !slices.Equal(forge.proposed, []string{"incidents/a.md", "incidents/b.md"}) {
+			t.Fatalf("proposed=%v, want the first two candidates only", forge.proposed)
+		}
+	})
+
+	t.Run("an unset MaxOpen falls back to the default instead of proposing nothing", func(t *testing.T) {
+		// A zero bound computes a budget of zero, which would silently make the
+		// whole pass a no-op for a direct (non-config) user of the package.
+		forge := &fakeRevalidateForge{}
+		p := newRevalidation(forge, stats)
+		p.MaxOpen = 0
+		if err := p.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(forge.proposed) != 3 {
+			t.Fatalf("proposed=%v, want all three under the default bound of %d",
+				forge.proposed, DefaultMaxOpenRevalidations)
+		}
+	})
+
+	t.Run("already-outstanding PRs count against the budget", func(t *testing.T) {
+		// Two unrelated revalidate PRs are already waiting on a human: the queue is
+		// full, so this run adds nothing however many candidates it found.
+		forge := &fakeRevalidateForge{open: []providers.CuratedIssue{{Number: 1}, {Number: 2}}}
+		p := newRevalidation(forge, stats)
+		p.MaxOpen = 2
+		if err := p.Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(forge.proposed) != 0 {
+			t.Fatalf("a full review queue must open nothing, got %v", forge.proposed)
+		}
+	})
+}

--- a/internal/curate/selfveto_test.go
+++ b/internal/curate/selfveto_test.go
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package curate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// The retire/revalidate passes keep no store. They reconstruct an entry's history
+// from the forge on every run, and the ONE thing that makes a closed-unmerged
+// proposal meaningful is that only a human can produce it: it is read back as
+// "a human declined — never ask again". A close by RunLore's own housekeeping is
+// byte-for-byte the same signal, so it becomes a permanent veto for a decision
+// nobody made.
+//
+// The tests below pin that distinction at both places curate can close a PR.
+// Each arms the hazard first and asserts it IS armed, so the guard cannot pass
+// vacuously, and each keeps a control PR that must still be closed — proving the
+// exclusion is targeted rather than a disabled pass.
+
+const (
+	crashloop = "runbooks/kubernetes/pod-crashloop.md"
+	pending   = "runbooks/kubernetes/pod-pending.md"
+	oomkilled = "runbooks/kubernetes/pod-oomkilled.md"
+)
+
+// entryEditProposals is the fixture both tests share: two revalidate proposals for
+// DISTINCT entries filed under one directory, plus a retire proposal.
+func entryEditProposals(updated time.Time) []providers.CuratedIssue {
+	return []providers.CuratedIssue{
+		{Number: 10, Title: "KB revalidate: " + crashloop, UpdatedAt: updated,
+			Labels: []string{"runlore", revalidateLabel}, Body: revalidateMarker(crashloop)},
+		{Number: 11, Title: "KB revalidate: " + pending, UpdatedAt: updated,
+			Labels: []string{"runlore", revalidateLabel}, Body: revalidateMarker(pending)},
+		{Number: 12, Title: "KB retire: " + oomkilled, UpdatedAt: updated,
+			Labels: []string{"runlore", retireLabel}, Body: retireMarker(oomkilled)},
+	}
+}
+
+func TestDedupNeverClosesAnEntryEditProposal(t *testing.T) {
+	// Arm the hazard: these two titles differ only in the entry FILENAME, so the
+	// markerless title-Jaccard fallback scores them as near-identical even though
+	// they concern unrelated entries.
+	score := jaccard(titleTokens("KB revalidate: "+crashloop), titleTokens("KB revalidate: "+pending))
+	if score < 0.6 {
+		t.Fatalf("fixture titles score %.2f, below Dedup's default threshold — this test "+
+			"no longer exercises the hazard it exists to pin", score)
+	}
+
+	prs := entryEditProposals(time.Time{})
+	// Control: two genuine duplicate KB drafts, which Dedup must still collapse.
+	prs = append(prs,
+		providers.CuratedIssue{Number: 20, Title: "KB: Kustomization DependencyNotReady missing GitRepository"},
+		providers.CuratedIssue{Number: 21, Title: "KB: Kustomization DependencyNotReady due to missing GitRepository"},
+	)
+	f := &fakeForge{prs: prs}
+	if err := (Dedup{Forge: f, Log: discardLog()}).Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, n := range []int{10, 11, 12} {
+		if containsInt(f.closed, n) {
+			t.Errorf("Dedup closed entry-edit proposal #%d — that close is indistinguishable "+
+				"from a human veto and permanently silences the entry (closed=%v)", n, f.closed)
+		}
+	}
+	if len(f.closed) != 1 || f.closed[0] != 21 {
+		t.Fatalf("the duplicate KB draft #21 must still close, got %v", f.closed)
+	}
+}
+
+func TestLifecycleNeverClosesAnEntryEditProposal(t *testing.T) {
+	now := lifecycleNow()
+	const staleAfter = 30 * 24 * time.Hour
+	updated := now.Add(-40 * 24 * time.Hour)
+	// Arm the hazard: the proposals are past the staleness horizon, so only the
+	// exclusion keeps them open. The shipped chart makes this the DEFAULT collision
+	// — curate.stale_after and curate.revalidation.min_interval are both 720h.
+	if now.Sub(updated) <= staleAfter {
+		t.Fatalf("fixture PRs are not stale, so this test no longer exercises the hazard")
+	}
+
+	prs := entryEditProposals(updated)
+	// Control: an ordinary stale KB draft, which the sweep must still close.
+	prs = append(prs, providers.CuratedIssue{Number: 20, Labels: []string{"runlore"}, UpdatedAt: updated})
+	f := &fakeForge{prs: prs}
+	l := Lifecycle{Forge: f, StaleAfter: staleAfter, Now: func() time.Time { return now }, Log: discardLog()}
+	if err := l.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, n := range []int{10, 11, 12} {
+		if containsInt(f.closed, n) {
+			t.Errorf("the stale sweep closed entry-edit proposal #%d — a slow reviewer would "+
+				"become a permanent veto (closed=%v)", n, f.closed)
+		}
+	}
+	if len(f.closed) != 1 || f.closed[0] != 20 {
+		t.Fatalf("the ordinary stale KB draft #20 must still close, got %v", f.closed)
+	}
+}
+
+// TestEntryEditProposalDetectionIsLabelExact is the mutation guard for the
+// predicate itself: it must fire on each pass label and stay quiet on the shared
+// "runlore" namespace label, which every KB draft also carries — keying on that
+// would disable Dedup and the stale sweep wholesale.
+func TestEntryEditProposalDetectionIsLabelExact(t *testing.T) {
+	cases := []struct {
+		name   string
+		labels []string
+		want   bool
+	}{
+		{"retire proposal", []string{"runlore", retireLabel}, true},
+		{"revalidate proposal", []string{"runlore", revalidateLabel}, true},
+		{"ordinary KB draft", []string{"runlore"}, false},
+		{"protected KB draft", []string{"runlore", "ready-to-merge"}, false},
+		{"no labels", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isEntryEditProposal(tc.labels); got != tc.want {
+				t.Errorf("isEntryEditProposal(%v) = %v, want %v", tc.labels, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/docsguard/learning_loop_test.go
+++ b/internal/docsguard/learning_loop_test.go
@@ -91,30 +91,85 @@ func TestLastValidatedClaimREsFlip(t *testing.T) {
 // curateBlocks maps the config-key prefixes the learning-loop page cites to the
 // struct that actually defines them, so a renamed YAML tag fails here rather than
 // silently leaving a reader configuring a key that no longer exists.
-var curateBlocks = map[string]any{
-	"curate.retirement.":   config.Retirement{},
-	"curate.revalidation.": config.Revalidation{},
+// curateBlocks maps each `curate.<block>.` prefix to the struct that defines it,
+// DERIVED from config.Curate's own yaml tags rather than hand-listed. A
+// hand-listed map only ever covers the blocks someone remembered: the page also
+// cites curate.sweeps.* keys, which an earlier alternation of just
+// (retirement|revalidation) skipped while the "did I check anything?" backstop
+// stayed green — so the guard read as full coverage and was a subset.
+func curateBlocks() map[string]reflect.Type {
+	out := map[string]reflect.Type{}
+	rt := reflect.TypeOf(config.Curate{})
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		if f.Type.Kind() != reflect.Struct {
+			continue // a scalar knob like stale_after, not a block of keys
+		}
+		if tag, _, _ := strings.Cut(f.Tag.Get("yaml"), ","); tag != "" && tag != "-" {
+			out["curate."+tag+"."] = f.Type
+		}
+	}
+	return out
 }
 
-var curateKeyRE = regexp.MustCompile(`curate\.(retirement|revalidation)\.([a-z_]+)`)
+var curateKeyRE = regexp.MustCompile(`curate\.([a-z_]+)\.([a-z_]+)`)
 
-// TestLearningLoopCitesRealCurateKeys checks every `curate.retirement.*` /
-// `curate.revalidation.*` key the page names against the yaml tags of the config
-// structs, in both directions of trust: the key must exist, and the guard must
-// have found keys to check at all.
+// TestLearningLoopCitesRealCurateKeys checks every `curate.<block>.<key>` the page
+// names against the yaml tags of the struct that defines the block, in both
+// directions of trust: the block and the key must exist, and the guard must have
+// found something to check at all.
 func TestLearningLoopCitesRealCurateKeys(t *testing.T) {
 	doc := readDoc(t, learningLoopPath)
+	blocks := curateBlocks()
 	var checked int
 	for _, m := range curateKeyRE.FindAllStringSubmatch(doc, -1) {
-		prefix, key := "curate."+m[1]+".", m[2]
-		if !yamlTags(curateBlocks[prefix])[key] {
-			t.Errorf("learning-loop.md cites %s%s, which is not a yaml key of %T — fix the page or the config struct",
-				prefix, key, curateBlocks[prefix])
-		}
+		block, key := m[1], m[2]
 		checked++
+		rt, ok := blocks["curate."+block+"."]
+		if !ok {
+			t.Errorf("learning-loop.md cites curate.%s.%s, but config.Curate declares no %q block — "+
+				"fix the page or the config struct", block, key, block)
+			continue
+		}
+		if !yamlTags(rt)[key] {
+			t.Errorf("learning-loop.md cites curate.%s.%s, which is not a yaml key of %s — "+
+				"fix the page or the config struct", block, key, rt)
+		}
 	}
 	if checked == 0 {
-		t.Fatal("no curate.retirement/revalidation keys found in learning-loop.md — this guard is now inert")
+		t.Fatal("no curate.<block>.<key> citations found in learning-loop.md — this guard is now inert")
+	}
+}
+
+// TestCurateBlockDerivationIsComplete is the mutation guard for the derivation
+// above. It must find EVERY struct block on config.Curate — the whole point of
+// deriving it — and yamlTags must accept only keys a block really declares.
+func TestCurateBlockDerivationIsComplete(t *testing.T) {
+	blocks := curateBlocks()
+	for _, want := range []string{"curate.retirement.", "curate.revalidation.", "curate.sweeps."} {
+		if _, ok := blocks[want]; !ok {
+			t.Errorf("derivation missed %s — keys under it would go unchecked", want)
+		}
+	}
+	rt := reflect.TypeOf(config.Curate{})
+	var wantBlocks int
+	for i := range rt.NumField() {
+		if rt.Field(i).Type.Kind() == reflect.Struct {
+			wantBlocks++
+		}
+	}
+	if len(blocks) != wantBlocks {
+		t.Errorf("derived %d blocks from %d struct fields on config.Curate — a block is being dropped",
+			len(blocks), wantBlocks)
+	}
+	// Both directions on the tag lookup, so a yamlTags that answered "yes" (or
+	// "no") to everything cannot pass.
+	sweeps := yamlTags(blocks["curate.sweeps."])
+	if !sweeps["mode"] || !sweeps["interval"] {
+		t.Error("yamlTags missed a key config.Sweeps declares")
+	}
+	if sweeps["schedule"] || sweeps["Mode"] {
+		t.Error("yamlTags accepted a key config.Sweeps does not declare")
 	}
 }
 
@@ -163,10 +218,9 @@ func shortDuration(d time.Duration) string {
 	return d.String()
 }
 
-// yamlTags returns the set of yaml key names declared by v's struct fields.
-func yamlTags(v any) map[string]bool {
+// yamlTags returns the set of yaml key names declared by a struct type's fields.
+func yamlTags(rt reflect.Type) map[string]bool {
 	out := map[string]bool{}
-	rt := reflect.TypeOf(v)
 	for i := range rt.NumField() {
 		tag, _, _ := strings.Cut(rt.Field(i).Tag.Get("yaml"), ",")
 		if tag != "" && tag != "-" {

--- a/internal/docsguard/learning_loop_test.go
+++ b/internal/docsguard/learning_loop_test.go
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/forge/github"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+const learningLoopPath = "../../website/content/docs/concepts/learning-loop.md"
+
+// The learning-loop page's §6 states, in one direction or the other, whether a
+// RunLore-drafted entry carries `last_validated`. It matters because the whole
+// freshness story hangs off it: if drafts stamped the field, the revalidation
+// pass would have nothing to earn and the age gate would key on a date no human
+// ever confirmed. The page ALREADY shipped the wrong claim once ("stamped at
+// entry creation (= timestamp)") while the drafter left it unset, so both
+// possible claims are phrase-anchored here and the truth is read out of the
+// forge client itself.
+var (
+	unsetClaimRE   = regexp.MustCompile("`last_validated` is unset when RunLore drafts an entry")
+	stampedClaimRE = regexp.MustCompile("`last_validated` is stamped at entry creation")
+)
+
+// TestLearningLoopLastValidatedClaimMatchesTheDrafter pins §6's claim to what the
+// forge client actually writes. The truth is DERIVED, not restated: a real
+// OpenPR is driven against a stub GitHub API and the drafted entry's frontmatter
+// is inspected, so making renderEntry stamp the field flips the required doc
+// phrase and fails this test until the page follows.
+func TestLearningLoopLastValidatedClaimMatchesTheDrafter(t *testing.T) {
+	stamped := strings.Contains(draftedEntry(t), "last_validated:")
+
+	doc := readDoc(t, learningLoopPath)
+	claimsUnset := unsetClaimRE.MatchString(doc)
+	claimsStamped := stampedClaimRE.MatchString(doc)
+
+	switch {
+	case !claimsUnset && !claimsStamped:
+		t.Fatalf("learning-loop.md §6 states no claim about last_validated on RunLore drafts; "+
+			"it must say one of %q or %q", unsetClaimRE, stampedClaimRE)
+	case claimsUnset && claimsStamped:
+		t.Fatal("learning-loop.md claims both that drafts leave last_validated unset and that they stamp it — fix the page")
+	case stamped && claimsUnset:
+		t.Error("the forge now stamps last_validated on every draft, but learning-loop.md §6 says it is unset — " +
+			"update §6 (and reconsider the revalidation pass, which exists to earn that field)")
+	case !stamped && claimsStamped:
+		t.Error("the forge leaves last_validated unset on drafts, but learning-loop.md §6 says it is stamped at creation — update §6")
+	}
+}
+
+// TestLastValidatedClaimREsFlip is the mutation test for the two matchers above:
+// each must fire on its own claim, stay quiet on the other, and neither may be
+// satisfied by the page's other prose about the field (the §5 revalidation
+// paragraph and the age-gate bullet both name it).
+func TestLastValidatedClaimREsFlip(t *testing.T) {
+	cases := []struct {
+		name, text           string
+		wantUnset, wantStamp bool
+	}{
+		{"unset claim", "**`last_validated` is unset when RunLore drafts an entry** — the field claims", true, false},
+		{"stamped claim", "`last_validated` is stamped at entry creation (= `timestamp`)", false, true},
+		{"age-gate bullet is neither", "an entry whose `last_validated` (else `timestamp`) predates the horizon", false, false},
+		{"revalidation paragraph is neither", "proposing to stamp `last_validated` with that resolve date", false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := unsetClaimRE.MatchString(c.text); got != c.wantUnset {
+				t.Errorf("unsetClaimRE.MatchString(%q) = %v, want %v", c.text, got, c.wantUnset)
+			}
+			if got := stampedClaimRE.MatchString(c.text); got != c.wantStamp {
+				t.Errorf("stampedClaimRE.MatchString(%q) = %v, want %v", c.text, got, c.wantStamp)
+			}
+		})
+	}
+}
+
+// curateBlocks maps the config-key prefixes the learning-loop page cites to the
+// struct that actually defines them, so a renamed YAML tag fails here rather than
+// silently leaving a reader configuring a key that no longer exists.
+var curateBlocks = map[string]any{
+	"curate.retirement.":   config.Retirement{},
+	"curate.revalidation.": config.Revalidation{},
+}
+
+var curateKeyRE = regexp.MustCompile(`curate\.(retirement|revalidation)\.([a-z_]+)`)
+
+// TestLearningLoopCitesRealCurateKeys checks every `curate.retirement.*` /
+// `curate.revalidation.*` key the page names against the yaml tags of the config
+// structs, in both directions of trust: the key must exist, and the guard must
+// have found keys to check at all.
+func TestLearningLoopCitesRealCurateKeys(t *testing.T) {
+	doc := readDoc(t, learningLoopPath)
+	var checked int
+	for _, m := range curateKeyRE.FindAllStringSubmatch(doc, -1) {
+		prefix, key := "curate."+m[1]+".", m[2]
+		if !yamlTags(curateBlocks[prefix])[key] {
+			t.Errorf("learning-loop.md cites %s%s, which is not a yaml key of %T — fix the page or the config struct",
+				prefix, key, curateBlocks[prefix])
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("no curate.retirement/revalidation keys found in learning-loop.md — this guard is now inert")
+	}
+}
+
+// TestLearningLoopStatesRevalidationDefaults pins §5's two quoted anti-spam knobs
+// to reality on BOTH axes: the key NAME comes from the struct's yaml tag and the
+// VALUE from ApplyDefaults, so a rename and a retuning each fail here. They are
+// the numbers an operator budgets review time against, so a silent change to
+// either is exactly the drift this package exists to catch.
+func TestLearningLoopStatesRevalidationDefaults(t *testing.T) {
+	var c config.Config
+	c.Curate.Revalidation.Enabled = true
+	config.ApplyDefaults(&c)
+	r := c.Curate.Revalidation
+
+	doc := readDoc(t, learningLoopPath)
+	for _, want := range []string{
+		fmt.Sprintf("`%s` (default **%s**)", tagOf(r, "MinInterval"), shortDuration(r.MinInterval.Std())),
+		fmt.Sprintf("`%s` (default **%d**)", tagOf(r, "MaxOpen"), r.MaxOpen),
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("learning-loop.md §5 must state the shipped knob verbatim as %q — "+
+				"the key or its default changed underneath the page", want)
+		}
+	}
+}
+
+// tagOf returns the yaml key one struct field is serialized under, failing loudly
+// if the field is gone (a rename must not silently make the guard check nothing).
+func tagOf(v any, field string) string {
+	f, ok := reflect.TypeOf(v).FieldByName(field)
+	if !ok {
+		panic("docsguard: no field " + field + " on " + reflect.TypeOf(v).String())
+	}
+	tag, _, _ := strings.Cut(f.Tag.Get("yaml"), ",")
+	return tag
+}
+
+// shortDuration renders a duration the way an operator writes it in YAML and the
+// way the docs quote it ("720h"), dropping the zero minute/second tail that
+// time.Duration.String() always appends. Only the whole-hours shape is folded —
+// a sub-hour default keeps its exact string rather than being mangled.
+func shortDuration(d time.Duration) string {
+	if s := d.String(); strings.HasSuffix(s, "h0m0s") {
+		return strings.TrimSuffix(s, "0m0s")
+	}
+	return d.String()
+}
+
+// yamlTags returns the set of yaml key names declared by v's struct fields.
+func yamlTags(v any) map[string]bool {
+	out := map[string]bool{}
+	rt := reflect.TypeOf(v)
+	for i := range rt.NumField() {
+		tag, _, _ := strings.Cut(rt.Field(i).Tag.Get("yaml"), ",")
+		if tag != "" && tag != "-" {
+			out[tag] = true
+		}
+	}
+	return out
+}
+
+// readDoc reads a documentation page, failing the test if it is missing.
+func readDoc(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path) //nolint:gosec // G304: fixed in-repo doc path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+// draftedEntry drives the REAL github.Client.OpenPR against a stub GitHub API and
+// returns the OKF markdown it wrote for the entry — the drafter's actual output,
+// which is the only honest source for what a fresh draft's frontmatter contains.
+// Only the FIRST contents PUT is captured: that is the entry itself, before the
+// best-effort bundle maintenance writes index.md/log.md.
+func draftedEntry(t *testing.T) string {
+	t.Helper()
+	var entry string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if entry == "" {
+			raw, _ := base64.StdEncoding.DecodeString(body["content"].(string))
+			entry = string(raw)
+		}
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"html_url":"https://forge/pr/1","number":1}`))
+	})
+	mux.HandleFunc("POST /repos/o/r/issues/1/labels", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := github.New(srv.URL, "o", "r", "main", func(context.Context) (string, error) { return "tok", nil })
+	if _, err := c.OpenPR(context.Background(), providers.KBEntry{
+		Type: "Incident", Title: "Drift guard", Description: "d", Body: "## Symptom\nx",
+	}); err != nil {
+		t.Fatalf("OpenPR against the stub forge: %v", err)
+	}
+	if entry == "" {
+		// Guard the guard: no captured PUT means OpenPR changed shape and this
+		// test would otherwise "pass" by inspecting an empty string.
+		t.Fatal("OpenPR wrote no entry file — this guard is now inert")
+	}
+	return entry
+}

--- a/internal/docsguard/recall_decay_test.go
+++ b/internal/docsguard/recall_decay_test.go
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// ledgerSourcePath is the Go file whose two doc comments state the same
+// exclusion rule the learning-loop page states — a third site drifts as easily
+// as the first, and all three drifted together once already.
+const ledgerSourcePath = "../outcome/ledger.go"
+
+// The three sites below all describe WHICH incident sources are excluded from
+// resolve-based recall decay. They shipped a claim the code never implemented:
+// that an Alertmanager receiver with send_resolved off is excluded. It cannot be —
+// the exclusion is read off the fingerprint (`resolvable := !outcome.Derived(fp)`)
+// and send_resolved lives in the operator's receiver config, which RunLore never
+// reads. The claim mattered: an operator reading it would expect a frozen entry,
+// while the shipped code decays that entry below the floor and stops recalling it.
+//
+// So both directions of the claim are phrase-anchored here and the truth is
+// MEASURED — by driving a real outcome.Ledger through both fingerprint shapes and
+// the real recall gate over the result. If someone ever does implement the
+// exclusion (a heuristic over recalls-with-no-resolves), the measurement flips and
+// these guards demand the opposite prose instead of quietly passing.
+var (
+	pageExcludesAlertmanagerRE = regexp.MustCompile("Alertmanager without `send_resolved`")
+	pageCountsAlertmanagerRE   = regexp.MustCompile(`\*\*An Alertmanager alert is never in that excluded set\*\*`)
+	ledgerExcludesAlertmanager = regexp.MustCompile(`Alertmanager with send_resolved off\)`)
+	ledgerCountsAlertmanagerRE = regexp.MustCompile(`Alertmanager receiver with send_resolved off`)
+	// The second error in the same sentence: an excluded entry was said to sit at
+	// the prior forever. It never enters the roll-up at all, so the gate's fail-safe
+	// applies instead — a strictly MORE trusting value than the prior.
+	pagePriorFreezeRE = regexp.MustCompile(`frozen at the prior`)
+)
+
+// recallDecayFacts is what driving the real ledger + the real recall gate says
+// about the two fingerprint shapes. Every field is measured, never asserted.
+type recallDecayFacts struct {
+	prior, floor float64 // the shipped catalog.instant_recall defaults
+	realAgg      outcome.Aggregate
+	realCounted  bool    // a REAL alert fingerprint's recall entered OpenCounts
+	realFactor   float64 // its decay factor after ONE unresolved recall
+	priorMean    float64 // Factor of an empty aggregate — what "frozen at the prior" meant
+	derivedNames []string
+	derived      map[string]bool // synthetic prefix -> did its recall enter OpenCounts
+}
+
+// measureRecallDecay records ONE unresolved recall per fingerprint shape in a real
+// outcome.Ledger, exactly the way the delivery path does (internal/app/investigate.go
+// stamps Resolvable from `!outcome.Derived(fp)`), then reads the roll-up back. This is
+// the half that must fail first: a change to the Derived rule or to Aggregate.Factor
+// moves these numbers before any prose is consulted.
+func measureRecallDecay(t *testing.T) recallDecayFacts {
+	t.Helper()
+	var c config.Config
+	c.Catalog.InstantRecall.Enabled = true
+	config.ApplyDefaults(&c)
+	ir := c.Catalog.InstantRecall
+
+	l, err := outcome.New(filepath.Join(t.TempDir(), "outcomes.jsonl"))
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	const realEntry = "real-alert.md"
+	openUnresolvedRecall(t, l, realFingerprint, realEntry)
+
+	f := recallDecayFacts{
+		prior: ir.OutcomePrior, floor: ir.OutcomeFloor,
+		priorMean: outcome.Aggregate{}.Factor(ir.OutcomePrior),
+		derived:   map[string]bool{},
+	}
+	for _, prefix := range []string{outcome.GitOpsFingerprintPrefix, outcome.ReinvestigateFingerprintPrefix} {
+		entry := prefix + "entry.md"
+		f.derivedNames = append(f.derivedNames, prefix)
+		openUnresolvedRecall(t, l, outcome.DeriveFingerprint(prefix, "apps/worker|HealthCheckFailed"), entry)
+		f.derived[prefix] = entryOf(t, l, entry)
+	}
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	f.realAgg, f.realCounted = counts[realEntry]
+	f.realFactor = f.realAgg.Factor(f.prior)
+	return f
+}
+
+// realFingerprint is an Alertmanager-shaped fingerprint: the 16 hex chars
+// Alertmanager sends, carrying none of the synthetic prefixes.
+const realFingerprint = "9f2a7b1c4d5e6f70"
+
+// openUnresolvedRecall appends one recall open and NO resolve, deriving the
+// Resolvable flag the way the delivery path does rather than hard-coding it.
+func openUnresolvedRecall(t *testing.T, l *outcome.Ledger, fp, entry string) {
+	t.Helper()
+	resolvable := !outcome.Derived(fp)
+	if err := l.Open(outcome.Event{
+		Fingerprint: fp, Kind: "recall", Entry: entry, Resolvable: &resolvable, At: time.Now(),
+	}); err != nil {
+		t.Fatalf("ledger.Open(%s): %v", fp, err)
+	}
+}
+
+// entryOf reports whether an entry made it into the roll-up recall decay reads.
+func entryOf(t *testing.T, l *outcome.Ledger, entry string) bool {
+	t.Helper()
+	counts, err := l.OpenCounts()
+	if err != nil {
+		t.Fatalf("OpenCounts: %v", err)
+	}
+	_, ok := counts[entry]
+	return ok
+}
+
+// TestRecallDecayExclusionIsFingerprintShaped measures which sources resolve-based
+// decay actually excludes, then holds all three prose sites to the measurement in
+// both directions. The measured premise comes first on purpose: a rewrite of the
+// `resolvable` rule fails here before any doc phrase is looked at.
+func TestRecallDecayExclusionIsFingerprintShaped(t *testing.T) {
+	f := measureRecallDecay(t)
+
+	// The synthetic shapes are excluded — that half of the claim was always true.
+	for _, prefix := range f.derivedNames {
+		if f.derived[prefix] {
+			t.Errorf("a %q recall entered the decay roll-up: the synthetic fingerprints are "+
+				"supposed to be excluded, so every doc site describing the exclusion is now wrong", prefix)
+		}
+	}
+	// And the half that was not: a real alert fingerprint is counted regardless of
+	// whether a resolve ever follows, because nothing in the ledger can see
+	// send_resolved.
+	if !f.realCounted {
+		t.Fatalf("a real alert fingerprint's recall no longer enters the decay roll-up (agg %+v) — "+
+			"if the send_resolved exclusion was implemented, the three sites below must be "+
+			"rewritten to claim it, not left silently correct-by-accident", f.realAgg)
+	}
+	if f.realAgg.Recalls != 1 || f.realAgg.Resolved != 0 {
+		t.Fatalf("fixture drifted: one unresolved recall produced %+v, want Recalls=1 Resolved=0", f.realAgg)
+	}
+
+	for _, site := range []struct {
+		name, path       string
+		excludes, counts *regexp.Regexp
+	}{
+		{"learning-loop.md §6", learningLoopPath, pageExcludesAlertmanagerRE, pageCountsAlertmanagerRE},
+		{"outcome/ledger.go", ledgerSourcePath, ledgerExcludesAlertmanager, ledgerCountsAlertmanagerRE},
+	} {
+		prose := flattenProse(readDoc(t, site.path))
+		if site.excludes.MatchString(prose) {
+			t.Errorf("%s lists an Alertmanager receiver with send_resolved off among the sources "+
+				"excluded from resolve-based decay, but a real alert fingerprint IS counted (%+v, "+
+				"factor %.3f) — the exclusion is drawn on the fingerprint and RunLore never reads "+
+				"send_resolved", site.name, f.realAgg, f.realFactor)
+		}
+		if !site.counts.MatchString(prose) {
+			t.Errorf("%s no longer states that an Alertmanager alert is NOT excluded from decay "+
+				"(want %v) — that is the claim the measurement supports, and dropping it is how "+
+				"the wrong one came back last time", site.name, site.counts)
+		}
+		// Both sites must still name the pair that IS excluded, so a rewrite cannot
+		// leave the exclusion undescribed.
+		for _, want := range []string{"GitOps", "reinvestigate"} {
+			if !strings.Contains(strings.ToLower(prose), strings.ToLower(want)) {
+				t.Errorf("%s no longer names %q as an excluded source", site.name, want)
+			}
+		}
+	}
+	// ledger.go carries the claim in TWO comments (Event.Resolvable and
+	// applyOpenLocked); one of them silently losing it is exactly how three sites
+	// drift into two.
+	if n := len(ledgerCountsAlertmanagerRE.FindAllString(flattenProse(readDoc(t, ledgerSourcePath)), -1)); n < 2 {
+		t.Errorf("outcome/ledger.go states the Alertmanager case in %d place(s), want both "+
+			"Event.Resolvable and applyOpenLocked", n)
+	}
+}
+
+// TestLearningLoopQuotesTheMeasuredDecayNumbers pins §6's three numbers to the values
+// the real ledger and the shipped defaults produce. They are the numbers an operator
+// reasons about — "how many unresolved recalls until my entry stops firing?" — so a
+// retuned prior/floor or a reworked Factor must not leave the page quoting the old ones.
+func TestLearningLoopQuotesTheMeasuredDecayNumbers(t *testing.T) {
+	f := measureRecallDecay(t)
+	if f.realFactor >= f.floor {
+		t.Fatalf("one unresolved recall now yields factor %.3f, at or above the %g floor — §6 says "+
+			"ONE recall already stops the entry firing; rewrite it for the new calibration", f.realFactor, f.floor)
+	}
+	page := flattenProse(readDoc(t, learningLoopPath))
+	for _, want := range []string{
+		fmt.Sprintf("lands the entry at **%.3f**", f.realFactor),
+		fmt.Sprintf("`outcome_floor` of **%g**", f.floor),
+		fmt.Sprintf("**not** the %g prior mean", f.priorMean),
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("learning-loop.md §6 must state the measured value verbatim as %q", want)
+		}
+	}
+}
+
+// TestRecallDecayGateFailSafeIsFullTrustNotThePrior measures what the REAL recall gate
+// does with each fingerprint shape, over the real Catalog + Recall + Ledger stack.
+//
+// It is the half of §6 the ledger alone cannot show. An excluded entry never enters the
+// roll-up, so the gate never computes a factor for it and takes its fail-safe branch
+// (absence of evidence must never block a recall). "Frozen at the prior" would mean
+// 0.5 — which the floor could still reject — so the two are told apart by raising the
+// floor ABOVE every factor the formula can ever return: a gate that still fires is one
+// that never consulted a factor at all.
+func TestRecallDecayGateFailSafeIsFullTrustNotThePrior(t *testing.T) {
+	f := measureRecallDecay(t)
+
+	// The formula's own ceiling: Factor is a posterior mean and never reaches 1, so a
+	// floor above 1 rejects every entry the roll-up knows about.
+	if ceiling := (outcome.Aggregate{Recalls: 1000, Resolved: 1000}).Factor(f.prior); ceiling >= 1 {
+		t.Fatalf("Aggregate.Factor now reaches %v ≥ 1; the above-the-ceiling floor below no longer discriminates", ceiling)
+	}
+	unreachableFloor := 1.0000001
+
+	derivedFP := outcome.DeriveFingerprint(outcome.GitOpsFingerprintPrefix, "apps/worker|HealthCheckFailed")
+	if !recallFires(t, derivedFP, unreachableFloor) {
+		t.Errorf("a recall whose only history is an excluded (synthetic) fingerprint was rejected at "+
+			"floor %v — it should never reach a factor at all, so §6's claim of the 1.0 fail-safe "+
+			"(and not the %g prior) is now wrong", unreachableFloor, f.priorMean)
+	}
+	if recallFires(t, realFingerprint, f.floor) {
+		t.Errorf("a recall with ONE unresolved real-fingerprint history (factor %.3f) still fires at "+
+			"the shipped floor %g — §6 says instant recall stops firing it", f.realFactor, f.floor)
+	}
+	page := flattenProse(readDoc(t, learningLoopPath))
+	if pagePriorFreezeRE.MatchString(page) {
+		t.Errorf("learning-loop.md §6 still says an excluded entry's trust is frozen at the prior; "+
+			"it never enters the roll-up, so the gate hands it the fail-safe, not the %g prior mean", f.priorMean)
+	}
+	if !strings.Contains(page, "which is **1.0**") {
+		t.Error("learning-loop.md §6 must state the gate's fail-safe value for an excluded entry as **1.0**")
+	}
+}
+
+// recallFires drives the REAL instant-recall gate: a one-entry catalog, a real
+// outcome.Ledger holding one unresolved recall under the given fingerprint, and the
+// exported LoopInvestigator entry point. It reports whether the gate fired. The
+// magnitude gates are tuned low (a one-entry corpus scores small) so the only gate
+// that can reject here is outcome decay — proven by the ledger-less baseline, which
+// must fire.
+func recallFires(t *testing.T, fp string, floor float64) bool {
+	t.Helper()
+	cat := decayGuardCatalog(t)
+	entry := cat.Entries()[0].Path
+	if !runRecall(t, cat, nil, floor) {
+		t.Fatalf("baseline recall with no ledger history must fire at floor %v; the fixture no longer "+
+			"clears the structural/margin gates, so this guard would measure nothing", floor)
+	}
+	l, err := outcome.New(filepath.Join(t.TempDir(), "outcomes.jsonl"))
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	openUnresolvedRecall(t, l, fp, entry)
+	return runRecall(t, cat, l, floor)
+}
+
+// runRecall runs one investigation and reports whether instant recall fired.
+func runRecall(t *testing.T, cat *catalog.Catalog, stats investigate.OutcomeStats, floor float64) bool {
+	t.Helper()
+	var fired bool
+	li := &investigate.LoopInvestigator{
+		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Model:    silentModel{},
+		MaxSteps: 1,
+		Recall: &investigate.Recall{
+			Catalog: cat, MinScore: 0.001, SoloFloor: 0.001, MarginGap: 0.001,
+			Outcome: stats, OutcomePrior: 2.0, OutcomeFloor: floor,
+		},
+		OnRecall: func(d investigate.RecallDecision) { fired = d.Fired },
+	}
+	if stats == nil {
+		li.Recall.Outcome = nil
+	}
+	// A rejected recall falls through to the ReAct loop, which needs a model; the
+	// stub concludes nothing, so the run ends without a finding. Only the recall
+	// decision is read, and it is emitted before the loop starts.
+	if err := li.Investigate(context.Background(), investigate.Request{
+		Title:    "WorkerOOM",
+		Message:  "apps/worker pods OOMKilled after memory limit drop",
+		Workload: providers.Workload{Namespace: "apps", Name: "worker"},
+	}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	return fired
+}
+
+// silentModel is a ModelProvider that concludes nothing — enough for the
+// fall-through path a rejected recall takes, without a network call.
+type silentModel struct{}
+
+func (silentModel) Complete(context.Context, providers.CompletionRequest) (providers.CompletionResponse, error) {
+	return providers.CompletionResponse{Text: "inconclusive"}, nil
+}
+
+// decayGuardCatalog is a one-entry catalog whose stored resource agrees with the
+// request workload, so the structural and margin gates pass and outcome decay is
+// the only gate under measurement.
+func decayGuardCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	dir := t.TempDir()
+	const entry = `---
+type: Incident
+title: worker OOMKilled after memory limit drop
+description: apps/worker pods OOMKilled; raise the container memory limit
+resource: apps/worker
+tags: [oom, memory, worker]
+---
+
+# Symptom
+apps/worker pods are OOMKilled shortly after a values change lowered the memory limit.
+`
+	if err := os.WriteFile(filepath.Join(dir, "worker-oom.md"), []byte(entry), 0o600); err != nil {
+		t.Fatalf("seed catalog entry: %v", err)
+	}
+	cat, err := catalog.New(dir)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	return cat
+}
+
+// goCommentPrefixRE strips the leading "// " of a Go comment continuation line.
+var goCommentPrefixRE = regexp.MustCompile(`(?m)^[ \t]*// ?`)
+
+// flattenProse collapses a page or a Go source file into single-spaced text, so a
+// phrase anchor survives re-wrapping: a doc comment's "\n\t// " continuation and a
+// markdown paragraph's hard wrap both become one space. Without it every anchor
+// would also be pinning where the author happened to break the line — and the
+// claims these guards check have already been re-wrapped more than once.
+func flattenProse(s string) string {
+	return strings.Join(strings.Fields(goCommentPrefixRE.ReplaceAllString(s, " ")), " ")
+}
+
+// TestRecallDecayClaimREsFlip is the mutation test for the anchors above: each must
+// fire on the wording that actually shipped, stay quiet on the wording that replaced
+// it, and neither may be satisfied by the page's other prose about resolve channels.
+// Inputs are pre-flattened, mirroring how the guards read their files.
+func TestRecallDecayClaimREsFlip(t *testing.T) {
+	const (
+		shippedPageClaim = "sources with no resolve channel (**GitOps failures**, reinvestigate polls, " +
+			"Alertmanager without `send_resolved`) are deliberately excluded from resolve-based decay, " +
+			"so without feedback their entries' trust is frozen at the prior forever."
+		correctedPageClaim = "**An Alertmanager alert is never in that excluded set** — not even when its " +
+			"receiver has `send_resolved` off. Resolvability is read off the fingerprint alone."
+		shippedLedgerClaim = "false for sources that never emit one (GitOps, reinvestigate, or " +
+			"Alertmanager with send_resolved off). A pointer for a three-state distinction:"
+		correctedLedgerClaim = "An Alertmanager receiver with send_resolved off is NOT excluded and cannot be: " +
+			"send_resolved lives in the operator's receiver config, which RunLore never reads."
+		unrelated = "false for sources that never emit one (GitOps, reinvestigate) — no resolved-alert " +
+			"webhook can ever match a synthetic fingerprint."
+	)
+	cases := []struct {
+		name, text                                       string
+		pageExcl, pageCount, ledgerExcl, ledgerCount, fr bool
+	}{
+		{name: "shipped page claim", text: shippedPageClaim, pageExcl: true, fr: true},
+		{name: "corrected page claim", text: correctedPageClaim, pageCount: true},
+		{name: "shipped ledger claim", text: shippedLedgerClaim, ledgerExcl: true},
+		{name: "corrected ledger claim", text: correctedLedgerClaim, ledgerCount: true},
+		{name: "unrelated exclusion prose is neither", text: unrelated},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			flat := flattenProse(c.text)
+			for _, got := range []struct {
+				name string
+				re   *regexp.Regexp
+				want bool
+			}{
+				{"pageExcludesAlertmanagerRE", pageExcludesAlertmanagerRE, c.pageExcl},
+				{"pageCountsAlertmanagerRE", pageCountsAlertmanagerRE, c.pageCount},
+				{"ledgerExcludesAlertmanager", ledgerExcludesAlertmanager, c.ledgerExcl},
+				{"ledgerCountsAlertmanagerRE", ledgerCountsAlertmanagerRE, c.ledgerCount},
+				{"pagePriorFreezeRE", pagePriorFreezeRE, c.fr},
+			} {
+				if m := got.re.MatchString(flat); m != got.want {
+					t.Errorf("%s.MatchString(%q) = %v, want %v", got.name, flat, m, got.want)
+				}
+			}
+		})
+	}
+}
+
+// TestFlattenProseJoinsWrappedClaims is the mutation test for the normalizer the
+// anchors depend on: a claim split across a wrapped Go doc comment and one split
+// across a markdown paragraph must both come back as one line, or every phrase
+// anchor above silently stops matching the moment an editor re-wraps a sentence.
+func TestFlattenProseJoinsWrappedClaims(t *testing.T) {
+	const wrappedComment = "\t// false for sources that never emit one (GitOps, reinvestigate, or\n" +
+		"\t// Alertmanager with send_resolved off). A pointer"
+	if got, want := flattenProse(wrappedComment),
+		"false for sources that never emit one (GitOps, reinvestigate, or Alertmanager with send_resolved off). A pointer"; got != want {
+		t.Errorf("flattenProse(wrapped comment) = %q, want %q", got, want)
+	}
+	const wrappedMarkdown = "channel (**GitOps failures**, reinvestigate polls, Alertmanager without\n`send_resolved`)\nare excluded"
+	if got, want := flattenProse(wrappedMarkdown),
+		"channel (**GitOps failures**, reinvestigate polls, Alertmanager without `send_resolved`) are excluded"; got != want {
+		t.Errorf("flattenProse(wrapped markdown) = %q, want %q", got, want)
+	}
+	// A markdown link must survive: stripping "//" unconditionally would eat it.
+	if got, want := flattenProse("see https://example.test/x for more"), "see https://example.test/x for more"; got != want {
+		t.Errorf("flattenProse(url) = %q, want %q", got, want)
+	}
+}

--- a/internal/forge/github/entryedit.go
+++ b/internal/forge/github/entryedit.go
@@ -113,3 +113,73 @@ func frontmatterBlock(content []byte) (lines []string, rest string, err error) {
 	}
 	return strings.Split(body[:end], "\n"), body[end:], nil
 }
+
+// frontmatterValue reads one frontmatter line as key, scalar and trailing comment.
+// ok is false for a line carrying no key at all. Both stamps hand-parse the block
+// (a re-marshal would reformat a human-authored artifact under review), so this is
+// the single place that decides what the value of a line actually is.
+func frontmatterValue(line string) (key, scalar, comment string, ok bool) {
+	k, afterColon, ok := strings.Cut(line, ":")
+	if !ok {
+		return "", "", "", false
+	}
+	scalar, comment = scalarAndComment(afterColon)
+	return strings.TrimSpace(k), scalar, comment, true
+}
+
+// scalarAndComment splits the text after a key's colon into its scalar and any
+// trailing comment, the comment carrying the whitespace that separated the two so
+// a surgical edit can re-emit it unchanged.
+//
+// A YAML reader does not see a comment as part of a value, and neither may we. A
+// perfectly legal `last_validated: 2026-07-20  # confirmed by alice` otherwise
+// parses as an unreadable date: the entry looks like it has nothing on record, so
+// the anti-spam gate never fires, the entry is restamped on every sweep, and the
+// human's note is destroyed each time.
+//
+// A '#' opens a comment only when it follows whitespace (or opens the value) AND
+// sits outside quotes — `foo#bar` is the scalar "foo#bar", and a '#' inside a
+// quoted scalar is data.
+func scalarAndComment(afterColon string) (scalar, comment string) {
+	var quote byte
+	for i := range len(afterColon) {
+		c := afterColon[i]
+		switch {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == '#' && (i == 0 || afterColon[i-1] == ' ' || afterColon[i-1] == '\t'):
+			sep := i
+			for sep > 0 && (afterColon[sep-1] == ' ' || afterColon[sep-1] == '\t') {
+				sep--
+			}
+			return afterColon[:sep], afterColon[sep:]
+		}
+	}
+	return afterColon, ""
+}
+
+// unquoteScalar strips the surrounding quotes yaml.Marshal adds to a scalar
+// (okf.Render emits `last_validated: "2026-08-03T10:00:00Z"`), so a hand-parsed
+// value means what a YAML reader would say it means.
+func unquoteScalar(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && (s[0] == '"' || s[0] == '\'') && s[len(s)-1] == s[0] {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// inactiveStatus reports whether a raw frontmatter status scalar names one of the
+// two states recall refuses to fire (investigate's entryActive). It reads the
+// value exactly as a YAML reader would — quotes stripped, case-insensitive —
+// because `status: "retired"` is retired to everything that loads the catalog,
+// and a stamp that disagreed would edit an entry recall has already written off.
+// An absent or foreign status stays active, per OKF §9 tolerance.
+func inactiveStatus(scalar string) bool {
+	s := strings.ToLower(unquoteScalar(scalar))
+	return s == "retired" || s == "draft"
+}

--- a/internal/forge/github/entryedit.go
+++ b/internal/forge/github/entryedit.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// entryEdit describes one surgical, human-reviewed frontmatter edit to a MERGED
+// catalog entry: fetch the entry on the base branch, run stamp over its bytes,
+// and open a PR carrying the result. Retirement (`status: retired`) and
+// revalidation (`last_validated: <date>`) are the two instances; they differ
+// only in the stamp and the PR's naming, so the six-call GitHub dance lives here
+// once rather than being copy-pasted per pass — the two can never drift apart on
+// branch naming, sha handling, or best-effort labelling.
+type entryEdit struct {
+	path         string                       // entry path on the base branch
+	stamp        func([]byte) ([]byte, error) // the frontmatter edit; a sentinel error means "nothing to do"
+	branchPrefix string                       // "retire" | "revalidate"
+	commitVerb   string                       // commit-message verb
+	titlePrefix  string                       // PR title prefix
+	labels       []string                     // labels applied best-effort after the PR opens
+	body         string                       // reviewer-facing body (carries the caller's hidden marker)
+}
+
+// openEntryEditPR performs the fetch → stamp → branch → commit → PR → label
+// sequence for one entryEdit. It never merges and never deletes: the PR is the
+// proposal and a human is the load-bearing gate. A stamp sentinel (already
+// retired, recently validated, inactive entry) is returned verbatim so the
+// caller's pass can treat it as a done-skip; a 404 on the entry file surfaces as
+// an error (entry deleted → the pass logs and skips it).
+func (c *Client) openEntryEditPR(ctx context.Context, e entryEdit) (providers.Ref, error) {
+	// 1. fetch the entry on the base branch: its content and blob sha.
+	var file struct {
+		Content string `json:"content"`
+		SHA     string `json:"sha"`
+	}
+	if err := c.do(ctx, http.MethodGet,
+		fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s", c.owner, c.repo, e.path, c.baseBranch), nil, &file); err != nil {
+		return providers.Ref{}, err
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(file.Content, "\n", ""))
+	if err != nil {
+		return providers.Ref{}, fmt.Errorf("decode %s: %w", e.path, err)
+	}
+	stamped, err := e.stamp(raw)
+	if err != nil {
+		return providers.Ref{}, fmt.Errorf("%s: %w", e.path, err)
+	}
+
+	// 2. base ref SHA.
+	var ref struct {
+		Object struct {
+			SHA string `json:"sha"`
+		} `json:"object"`
+	}
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", c.owner, c.repo, c.baseBranch), nil, &ref); err != nil {
+		return providers.Ref{}, err
+	}
+	// 3. create the edit branch.
+	branch := fmt.Sprintf("runlore/%s-%s-%d", e.branchPrefix, slugify(e.path), time.Now().Unix())
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/git/refs", c.owner, c.repo),
+		map[string]any{"ref": "refs/heads/" + branch, "sha": ref.Object.SHA}, nil); err != nil {
+		return providers.Ref{}, err
+	}
+	// 4. update the entry file in place — the file sha makes this an update, not a create.
+	if err := c.do(ctx, http.MethodPut, fmt.Sprintf("/repos/%s/%s/contents/%s", c.owner, c.repo, e.path),
+		map[string]any{
+			"message": "runlore: " + e.commitVerb + " " + e.path,
+			"content": base64.StdEncoding.EncodeToString(stamped),
+			"branch":  branch,
+			"sha":     file.SHA,
+		}, nil); err != nil {
+		return providers.Ref{}, err
+	}
+	// 5. open the PR.
+	var out struct {
+		HTMLURL string `json:"html_url"`
+		Number  int    `json:"number"`
+	}
+	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/pulls", c.owner, c.repo),
+		map[string]any{"title": e.titlePrefix + e.path, "head": branch, "base": c.baseBranch, "body": e.body}, &out); err != nil {
+		return providers.Ref{}, err
+	}
+	// 6. label the PR. Best-effort: a labelling failure must not lose the PR (same
+	// contract as OpenPR), so the error is intentionally ignored.
+	if out.Number != 0 {
+		_ = c.addLabels(ctx, out.Number, e.labels)
+	}
+	return providers.Ref{URL: out.HTMLURL}, nil
+}
+
+// frontmatterBlock splits an OKF entry into its frontmatter lines and the
+// remainder (everything from the closing fence on, returned verbatim so a
+// surgical edit can rejoin the file byte-for-byte). A file without a
+// frontmatter block errors: a frontmatter stamp must never write blind.
+func frontmatterBlock(content []byte) (lines []string, rest string, err error) {
+	s := string(content)
+	if !strings.HasPrefix(s, "---\n") {
+		return nil, "", fmt.Errorf("entry has no YAML frontmatter block")
+	}
+	body := s[len("---\n"):]
+	end := strings.Index(body, "\n---")
+	if end < 0 {
+		return nil, "", fmt.Errorf("entry frontmatter block is unterminated")
+	}
+	return strings.Split(body[:end], "\n"), body[end:], nil
+}

--- a/internal/forge/github/entryedit.go
+++ b/internal/forge/github/entryedit.go
@@ -19,13 +19,13 @@ import (
 // revalidation (`last_validated: <date>`) are the two instances; they differ
 // only in the stamp and the PR's naming, so the six-call GitHub dance lives here
 // once rather than being copy-pasted per pass — the two can never drift apart on
-// branch naming, sha handling, or best-effort labelling.
+// branch naming, sha handling, or labelling.
 type entryEdit struct {
 	path        string                       // entry path on the base branch
 	stamp       func([]byte) ([]byte, error) // the frontmatter edit; a sentinel error means "nothing to do"
 	verb        string                       // "retire" | "revalidate": names the branch AND the commit
 	titlePrefix string                       // PR title prefix
-	labels      []string                     // labels applied best-effort after the PR opens
+	labels      []string                     // applied after the PR opens; a failure here IS an error (step 6)
 	body        string                       // reviewer-facing body (carries the caller's hidden marker)
 }
 
@@ -89,10 +89,21 @@ func (c *Client) openEntryEditPR(ctx context.Context, e entryEdit) (providers.Re
 		map[string]any{"title": e.titlePrefix + e.path, "head": branch, "base": c.baseBranch, "body": e.body}, &out); err != nil {
 		return providers.Ref{}, err
 	}
-	// 6. label the PR. Best-effort: a labelling failure must not lose the PR (same
-	// contract as OpenPR), so the error is intentionally ignored.
+	// 6. label the PR. NOT best-effort, unlike OpenPR: for these proposals the label
+	// is the only index that exists. The pass finds its own open PRs, its human
+	// vetoes and its queue depth by listing on it, so an unlabelled proposal is
+	// invisible — the hidden marker in its body is never scanned, it never counts
+	// against max_open, and the next sweep opens another one for the same entry,
+	// every sweep, without bound. Silently arming that loop is worse than failing
+	// loudly, so the error carries the PR's URL: the PR really is open, and a human
+	// must label or close it. The pass isolates this per entry, so one such failure
+	// never starves the rest of the sweep.
 	if out.Number != 0 {
-		_ = c.addLabels(ctx, out.Number, e.labels)
+		if err := c.addLabels(ctx, out.Number, e.labels); err != nil {
+			return providers.Ref{}, fmt.Errorf(
+				"%s is open but UNLABELLED, so the %s pass cannot see it — label or close it by hand: %w",
+				out.HTMLURL, e.verb, err)
+		}
 	}
 	return providers.Ref{URL: out.HTMLURL}, nil
 }

--- a/internal/forge/github/entryedit.go
+++ b/internal/forge/github/entryedit.go
@@ -21,21 +21,21 @@ import (
 // once rather than being copy-pasted per pass — the two can never drift apart on
 // branch naming, sha handling, or best-effort labelling.
 type entryEdit struct {
-	path         string                       // entry path on the base branch
-	stamp        func([]byte) ([]byte, error) // the frontmatter edit; a sentinel error means "nothing to do"
-	branchPrefix string                       // "retire" | "revalidate"
-	commitVerb   string                       // commit-message verb
-	titlePrefix  string                       // PR title prefix
-	labels       []string                     // labels applied best-effort after the PR opens
-	body         string                       // reviewer-facing body (carries the caller's hidden marker)
+	path        string                       // entry path on the base branch
+	stamp       func([]byte) ([]byte, error) // the frontmatter edit; a sentinel error means "nothing to do"
+	verb        string                       // "retire" | "revalidate": names the branch AND the commit
+	titlePrefix string                       // PR title prefix
+	labels      []string                     // labels applied best-effort after the PR opens
+	body        string                       // reviewer-facing body (carries the caller's hidden marker)
 }
 
 // openEntryEditPR performs the fetch → stamp → branch → commit → PR → label
 // sequence for one entryEdit. It never merges and never deletes: the PR is the
 // proposal and a human is the load-bearing gate. A stamp sentinel (already
-// retired, recently validated, inactive entry) is returned verbatim so the
-// caller's pass can treat it as a done-skip; a 404 on the entry file surfaces as
-// an error (entry deleted → the pass logs and skips it).
+// retired, recently validated, inactive entry) is wrapped with the entry path and
+// returned, so `errors.Is` still identifies it and the caller's pass can treat it
+// as a done-skip; a 404 on the entry file surfaces as an error (entry deleted →
+// the pass logs and skips it).
 func (c *Client) openEntryEditPR(ctx context.Context, e entryEdit) (providers.Ref, error) {
 	// 1. fetch the entry on the base branch: its content and blob sha.
 	var file struct {
@@ -65,7 +65,7 @@ func (c *Client) openEntryEditPR(ctx context.Context, e entryEdit) (providers.Re
 		return providers.Ref{}, err
 	}
 	// 3. create the edit branch.
-	branch := fmt.Sprintf("runlore/%s-%s-%d", e.branchPrefix, slugify(e.path), time.Now().Unix())
+	branch := fmt.Sprintf("runlore/%s-%s-%d", e.verb, slugify(e.path), time.Now().Unix())
 	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/git/refs", c.owner, c.repo),
 		map[string]any{"ref": "refs/heads/" + branch, "sha": ref.Object.SHA}, nil); err != nil {
 		return providers.Ref{}, err
@@ -73,7 +73,7 @@ func (c *Client) openEntryEditPR(ctx context.Context, e entryEdit) (providers.Re
 	// 4. update the entry file in place — the file sha makes this an update, not a create.
 	if err := c.do(ctx, http.MethodPut, fmt.Sprintf("/repos/%s/%s/contents/%s", c.owner, c.repo, e.path),
 		map[string]any{
-			"message": "runlore: " + e.commitVerb + " " + e.path,
+			"message": "runlore: " + e.verb + " " + e.path,
 			"content": base64.StdEncoding.EncodeToString(stamped),
 			"branch":  branch,
 			"sha":     file.SHA,

--- a/internal/forge/github/entryedit_test.go
+++ b/internal/forge/github/entryedit_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import "testing"
+
+// TestScalarAndComment is the mutation guard for the frontmatter value reader both
+// stamps depend on. Getting it wrong is not cosmetic: a comment read as part of the
+// value makes a perfectly good date unparseable, which the revalidation stamp reads
+// as "nothing on record" — so the anti-spam gate never fires and the entry is
+// restamped on every sweep. Reading a comment where there is none is the mirror
+// failure: it would truncate real data.
+func TestScalarAndComment(t *testing.T) {
+	cases := []struct {
+		name, in, scalar, comment string
+	}{
+		{"no comment", " 2026-07-20", " 2026-07-20", ""},
+		{"comment after a space", " 2026-07-20 # confirmed by alice", " 2026-07-20", " # confirmed by alice"},
+		{"comment after several spaces", " 2026-07-20   # note", " 2026-07-20", "   # note"},
+		{"comment after a tab", " 2026-07-20\t# note", " 2026-07-20", "\t# note"},
+		// A '#' glued to the value is part of it — YAML only opens a comment
+		// after whitespace.
+		{"hash with no leading space is data", " ns#1", " ns#1", ""},
+		{"hash inside a double-quoted scalar is data", ` "alert #42 fired"`, ` "alert #42 fired"`, ""},
+		{"hash inside a single-quoted scalar is data", ` 'alert #42'`, ` 'alert #42'`, ""},
+		{"comment after a quoted scalar still splits", ` "2026-07-20" # note`, ` "2026-07-20"`, " # note"},
+		{"whole value is a comment", " # nothing here", "", " # nothing here"},
+		{"empty value", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			scalar, comment := scalarAndComment(tc.in)
+			if scalar != tc.scalar || comment != tc.comment {
+				t.Errorf("scalarAndComment(%q) = (%q, %q), want (%q, %q)",
+					tc.in, scalar, comment, tc.scalar, tc.comment)
+			}
+			// The split must be lossless, or a "surgical" edit silently drops bytes.
+			if scalar+comment != tc.in {
+				t.Errorf("split is lossy: %q + %q != %q", scalar, comment, tc.in)
+			}
+		})
+	}
+}
+
+// TestInactiveStatus pins the reading of `status` to what a YAML reader — and
+// therefore recall's entryActive — sees. A stamp that disagreed would edit an entry
+// the catalog has already written off.
+func TestInactiveStatus(t *testing.T) {
+	inactive := []string{" retired", " draft", ` "retired"`, ` 'draft'`, " Retired", " DRAFT", "  retired  "}
+	for _, s := range inactive {
+		if !inactiveStatus(s) {
+			t.Errorf("inactiveStatus(%q) = false, want true", s)
+		}
+	}
+	// An absent or foreign status stays active (OKF §9 tolerance), so pre-status
+	// catalogs behave exactly as before.
+	active := []string{"", " active", " published", " retiring", " drafted"}
+	for _, s := range active {
+		if inactiveStatus(s) {
+			t.Errorf("inactiveStatus(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestFrontmatterValue pins the key/value split the stamps scan with.
+func TestFrontmatterValue(t *testing.T) {
+	key, scalar, comment, ok := frontmatterValue(`last_validated: "2026-07-20T08:00:00Z" # kept`)
+	if !ok || key != "last_validated" || scalar != ` "2026-07-20T08:00:00Z"` || comment != " # kept" {
+		t.Fatalf("got key=%q scalar=%q comment=%q ok=%v", key, scalar, comment, ok)
+	}
+	// An RFC3339 value contains colons; only the FIRST one separates the key.
+	if _, s, _, _ := frontmatterValue("timestamp: 2026-07-20T08:00:00Z"); s != " 2026-07-20T08:00:00Z" {
+		t.Errorf("scalar=%q, want the whole value past the first colon", s)
+	}
+	if _, _, _, ok := frontmatterValue("a line with no colon"); ok {
+		t.Error("a keyless line must report ok=false")
+	}
+}

--- a/internal/forge/github/retire.go
+++ b/internal/forge/github/retire.go
@@ -4,12 +4,8 @@ package github
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
-	"fmt"
-	"net/http"
 	"strings"
-	"time"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -26,27 +22,20 @@ var ErrAlreadyRetired = errors.New("entry already retired on base branch")
 // entry is retired on the base branch and no PR is needed. A file without a
 // frontmatter block errors: retirement must never write blind.
 func setStatusRetired(content []byte) (out []byte, already bool, err error) {
-	s := string(content)
-	if !strings.HasPrefix(s, "---\n") {
-		return nil, false, fmt.Errorf("entry has no YAML frontmatter block")
+	lines, rest, err := frontmatterBlock(content)
+	if err != nil {
+		return nil, false, err
 	}
-	rest := s[len("---\n"):]
-	end := strings.Index(rest, "\n---")
-	if end < 0 {
-		return nil, false, fmt.Errorf("entry frontmatter block is unterminated")
-	}
-	fm, body := rest[:end], rest[end:]
-	lines := strings.Split(fm, "\n")
 	for i, ln := range lines {
 		if key, val, ok := strings.Cut(ln, ":"); ok && strings.TrimSpace(key) == "status" {
 			if strings.TrimSpace(val) == "retired" {
 				return content, true, nil
 			}
 			lines[i] = "status: retired"
-			return []byte("---\n" + strings.Join(lines, "\n") + body), false, nil
+			return []byte("---\n" + strings.Join(lines, "\n") + rest), false, nil
 		}
 	}
-	return []byte("---\nstatus: retired\n" + fm + body), false, nil
+	return []byte("---\nstatus: retired\n" + strings.Join(lines, "\n") + rest), false, nil
 }
 
 // retireLabels mark a PR proposed by the curate retirement pass — "runlore" for
@@ -62,65 +51,22 @@ var retireLabels = []string{"runlore", "runlore-retire"}
 // opened); a 404 on the entry file surfaces as an error (entry deleted → the pass
 // logs and skips it).
 func (c *Client) OpenRetirePR(ctx context.Context, entryPath, body string) (providers.Ref, error) {
-	// 1. fetch the entry on the base branch: its content and blob sha.
-	var file struct {
-		Content string `json:"content"`
-		SHA     string `json:"sha"`
-	}
-	if err := c.do(ctx, http.MethodGet,
-		fmt.Sprintf("/repos/%s/%s/contents/%s?ref=%s", c.owner, c.repo, entryPath, c.baseBranch), nil, &file); err != nil {
-		return providers.Ref{}, err
-	}
-	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(file.Content, "\n", ""))
-	if err != nil {
-		return providers.Ref{}, fmt.Errorf("decode %s: %w", entryPath, err)
-	}
-	stamped, already, err := setStatusRetired(raw)
-	if err != nil {
-		return providers.Ref{}, fmt.Errorf("%s: %w", entryPath, err)
-	}
-	if already {
-		return providers.Ref{}, ErrAlreadyRetired
-	}
-
-	// 2. base ref SHA.
-	var ref struct {
-		Object struct {
-			SHA string `json:"sha"`
-		} `json:"object"`
-	}
-	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/git/ref/heads/%s", c.owner, c.repo, c.baseBranch), nil, &ref); err != nil {
-		return providers.Ref{}, err
-	}
-	// 3. create the retire branch.
-	branch := fmt.Sprintf("runlore/retire-%s-%d", slugify(entryPath), time.Now().Unix())
-	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/git/refs", c.owner, c.repo),
-		map[string]any{"ref": "refs/heads/" + branch, "sha": ref.Object.SHA}, nil); err != nil {
-		return providers.Ref{}, err
-	}
-	// 4. update the entry file in place — the file sha makes this an update, not a create.
-	if err := c.do(ctx, http.MethodPut, fmt.Sprintf("/repos/%s/%s/contents/%s", c.owner, c.repo, entryPath),
-		map[string]any{
-			"message": "runlore: retire " + entryPath,
-			"content": base64.StdEncoding.EncodeToString(stamped),
-			"branch":  branch,
-			"sha":     file.SHA,
-		}, nil); err != nil {
-		return providers.Ref{}, err
-	}
-	// 5. open the PR.
-	var out struct {
-		HTMLURL string `json:"html_url"`
-		Number  int    `json:"number"`
-	}
-	if err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/%s/pulls", c.owner, c.repo),
-		map[string]any{"title": "KB retire: " + entryPath, "head": branch, "base": c.baseBranch, "body": body}, &out); err != nil {
-		return providers.Ref{}, err
-	}
-	// 6. label the PR. Best-effort: a labelling failure must not lose the PR (same
-	// contract as OpenPR), so the error is intentionally ignored.
-	if out.Number != 0 {
-		_ = c.addLabels(ctx, out.Number, retireLabels)
-	}
-	return providers.Ref{URL: out.HTMLURL}, nil
+	return c.openEntryEditPR(ctx, entryEdit{
+		path: entryPath,
+		stamp: func(raw []byte) ([]byte, error) {
+			out, already, err := setStatusRetired(raw)
+			if err != nil {
+				return nil, err
+			}
+			if already {
+				return nil, ErrAlreadyRetired
+			}
+			return out, nil
+		},
+		branchPrefix: "retire",
+		commitVerb:   "retire",
+		titlePrefix:  "KB retire: ",
+		labels:       retireLabels,
+		body:         body,
+	})
 }

--- a/internal/forge/github/retire.go
+++ b/internal/forge/github/retire.go
@@ -27,13 +27,18 @@ func setStatusRetired(content []byte) (out []byte, already bool, err error) {
 		return nil, false, err
 	}
 	for i, ln := range lines {
-		if key, val, ok := strings.Cut(ln, ":"); ok && strings.TrimSpace(key) == "status" {
-			if strings.TrimSpace(val) == "retired" {
-				return content, true, nil
-			}
-			lines[i] = "status: retired"
-			return []byte("---\n" + strings.Join(lines, "\n") + rest), false, nil
+		key, scalar, comment, ok := frontmatterValue(ln)
+		if !ok || key != "status" {
+			continue
 		}
+		// Read the value as a YAML reader would: `status: "retired"` and
+		// `status: Retired` are both already retired to everything that loads the
+		// catalog, so a PR for either would propose a no-op.
+		if strings.ToLower(unquoteScalar(scalar)) == "retired" {
+			return content, true, nil
+		}
+		lines[i] = "status: retired" + comment // keep any note the author left on the line
+		return []byte("---\n" + strings.Join(lines, "\n") + rest), false, nil
 	}
 	return []byte("---\nstatus: retired\n" + strings.Join(lines, "\n") + rest), false, nil
 }

--- a/internal/forge/github/retire.go
+++ b/internal/forge/github/retire.go
@@ -63,10 +63,9 @@ func (c *Client) OpenRetirePR(ctx context.Context, entryPath, body string) (prov
 			}
 			return out, nil
 		},
-		branchPrefix: "retire",
-		commitVerb:   "retire",
-		titlePrefix:  "KB retire: ",
-		labels:       retireLabels,
-		body:         body,
+		verb:        "retire",
+		titlePrefix: "KB retire: ",
+		labels:      retireLabels,
+		body:        body,
 	})
 }

--- a/internal/forge/github/retire_test.go
+++ b/internal/forge/github/retire_test.go
@@ -45,6 +45,37 @@ func TestSetStatusRetired(t *testing.T) {
 			t.Errorf("content changed on already-retired entry")
 		}
 	})
+	// A status value must mean what a YAML reader says it means. `status: "retired"`
+	// and `status: Retired` are already retired to everything that loads the
+	// catalog, so proposing a retire PR for either would propose a no-op — and
+	// rewriting the line would show a reviewer a diff that changes nothing.
+	for _, in := range []string{
+		"---\nstatus: \"retired\"\ntype: Incident\n---\nbody\n",
+		"---\nstatus: 'retired'\ntype: Incident\n---\nbody\n",
+		"---\nstatus: Retired\ntype: Incident\n---\nbody\n",
+		"---\nstatus: retired # gone since 2025\ntype: Incident\n---\nbody\n",
+	} {
+		t.Run("already retired: "+strings.SplitN(in, "\n", 3)[1], func(t *testing.T) {
+			out, already, err := setStatusRetired([]byte(in))
+			if err != nil || !already {
+				t.Fatalf("err=%v already=%v", err, already)
+			}
+			if string(out) != in {
+				t.Errorf("content changed on an already-retired entry:\n%s", out)
+			}
+		})
+	}
+	t.Run("retiring keeps the author's note on the status line", func(t *testing.T) {
+		in := "---\ntype: Incident\nstatus: active  # reviewed 2026-01\n---\nbody\n"
+		out, already, err := setStatusRetired([]byte(in))
+		if err != nil || already {
+			t.Fatalf("err=%v already=%v", err, already)
+		}
+		want := "---\ntype: Incident\nstatus: retired  # reviewed 2026-01\n---\nbody\n"
+		if string(out) != want {
+			t.Errorf("got:\n%s\nwant:\n%s", out, want)
+		}
+	})
 	t.Run("no frontmatter is an error, never a blind write", func(t *testing.T) {
 		if _, _, err := setStatusRetired([]byte("just a body\n")); err == nil {
 			t.Fatal("want error on missing frontmatter")

--- a/internal/forge/github/revalidate.go
+++ b/internal/forge/github/revalidate.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Sentinels the revalidation stamp returns instead of an edit. Both mean "no PR
+// is warranted here", and the curate pass treats them as done-skips (like
+// ErrAlreadyRetired) rather than failures.
+var (
+	// ErrRecentlyValidated signals the entry's recorded freshness is already
+	// within minGap of the candidate date, so restamping it would be noise. This
+	// is the anti-spam rule, and it is deliberately evaluated against the FILE on
+	// the base branch rather than against anything the pass remembers: the file
+	// is where the answer actually lives, so a merged revalidation immediately
+	// stops the next sweep from re-proposing, with no store to keep in sync.
+	ErrRecentlyValidated = errors.New("entry validated too recently to restamp")
+	// ErrEntryInactive signals the entry is retired or draft. Recall never fires
+	// such an entry, so it can never earn a confirmation, and proposing to stamp
+	// one "still valid" would directly contradict the retirement pass.
+	ErrEntryInactive = errors.New("entry is retired or draft")
+)
+
+// lastValidatedLayout is the grammar the stamp is written in: a bare UTC date.
+// `last_validated` means "the day a human last confirmed this entry works" (see
+// okf.Meta), so day granularity IS the field's resolution — and a bare date
+// keeps the one-line diff a reviewer reads legible, needs no YAML quoting, and
+// parses back through catalog.ParseEntryDate, the single date grammar recall's
+// age gate and kbvalidate share.
+const lastValidatedLayout = "2006-01-02"
+
+// revalidateLabels mark a PR proposed by the curate revalidation pass — "runlore"
+// for the shared forge namespace, "runlore-revalidate" for the pass's idempotency
+// and human-veto listings.
+var revalidateLabels = []string{"runlore", "runlore-revalidate"}
+
+// setLastValidated stamps `last_validated: <date>` into an OKF entry's YAML
+// frontmatter, editing ONLY that line (inserting it when absent) — human
+// formatting, key order and comments are preserved, because the entry is a
+// human-authored artifact under review and a re-marshal would produce an
+// unreadable confirmation diff. Scanning is fence-bounded, so a "last_validated:"
+// string in the markdown body is never touched.
+//
+// It returns ErrRecentlyValidated when the entry's freshness on record is already
+// within minGap of at, and ErrEntryInactive for a retired/draft entry. A file
+// without a frontmatter block errors: the stamp must never write blind.
+func setLastValidated(content []byte, at time.Time, minGap time.Duration) ([]byte, error) {
+	lines, rest, err := frontmatterBlock(content)
+	if err != nil {
+		return nil, err
+	}
+	stamp := "last_validated: " + at.UTC().Format(lastValidatedLayout)
+	validatedAt := -1             // index of the existing last_validated line, -1 when absent
+	var validated, stamped string // the two recorded dates, raw scalars
+	for i, ln := range lines {
+		key, val, ok := strings.Cut(ln, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "status":
+			// The same two inactive states recall filters on (investigate's
+			// entryActive); an absent or foreign status stays active, per OKF §9
+			// tolerance, so pre-status catalogs are revalidated like any other.
+			if s := strings.ToLower(strings.TrimSpace(val)); s == "retired" || s == "draft" {
+				return nil, ErrEntryInactive
+			}
+		case "last_validated":
+			validatedAt, validated = i, val
+		case "timestamp":
+			stamped = val
+		}
+	}
+	// Freshness on record is last_validated, else timestamp — recall's own age-gate
+	// fallback, so what this pass refreshes is exactly what that gate reads. An
+	// absent or unparseable date means nothing is on record: there is a fact to
+	// establish, so stamp it (which also repairs the unparseable value).
+	recorded := stamped
+	if validatedAt >= 0 {
+		recorded = validated
+	}
+	if t, ok := catalog.ParseEntryDate(unquoteScalar(recorded)); ok && at.Sub(t) < minGap {
+		// Also the never-write-backwards guard: a date in the FUTURE (a human
+		// stamped it by hand) yields a negative gap and is left alone.
+		return nil, ErrRecentlyValidated
+	}
+	if validatedAt >= 0 {
+		lines[validatedAt] = stamp
+		return []byte("---\n" + strings.Join(lines, "\n") + rest), nil
+	}
+	return []byte("---\n" + stamp + "\n" + strings.Join(lines, "\n") + rest), nil
+}
+
+// unquoteScalar strips the surrounding quotes yaml.Marshal adds to a date-shaped
+// scalar (okf.Render emits `last_validated: "2026-08-03T10:00:00Z"`), so the
+// hand-parsed value matches what a YAML reader would see.
+func unquoteScalar(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && (s[0] == '"' || s[0] == '\'') && s[len(s)-1] == s[0] {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// OpenRevalidatePR opens a human-reviewed PR that stamps `last_validated:
+// <validated>` into an existing catalog entry's frontmatter — the confirmation
+// half of the freshness loop. It never merges: `last_validated` claims HUMAN
+// confirmation, and merging this PR is precisely that act, which is why RunLore
+// can propose the date but must not write it. body carries the reviewer-facing
+// evidence and the hidden idempotency marker (authored by the caller). Returns
+// ErrRecentlyValidated / ErrEntryInactive when no PR is warranted (no PR opened).
+func (c *Client) OpenRevalidatePR(ctx context.Context, entryPath string, validated time.Time, minGap time.Duration, body string) (providers.Ref, error) {
+	return c.openEntryEditPR(ctx, entryEdit{
+		path:         entryPath,
+		stamp:        func(raw []byte) ([]byte, error) { return setLastValidated(raw, validated, minGap) },
+		branchPrefix: "revalidate",
+		commitVerb:   "revalidate",
+		titlePrefix:  "KB revalidate: ",
+		labels:       revalidateLabels,
+		body:         body,
+	})
+}

--- a/internal/forge/github/revalidate.go
+++ b/internal/forge/github/revalidate.go
@@ -58,8 +58,8 @@ func setLastValidated(content []byte, at time.Time, minGap time.Duration) ([]byt
 		return nil, err
 	}
 	stamp := "last_validated: " + at.UTC().Format(lastValidatedLayout)
-	validatedAt := -1             // index of the existing last_validated line, -1 when absent
-	var validated, stamped string // the two recorded dates, raw scalars
+	validatedAt := -1                     // index of the existing last_validated line, -1 when absent
+	var validatedVal, timestampVal string // the two recorded dates, raw scalars
 	for i, ln := range lines {
 		key, val, ok := strings.Cut(ln, ":")
 		if !ok {
@@ -74,18 +74,18 @@ func setLastValidated(content []byte, at time.Time, minGap time.Duration) ([]byt
 				return nil, ErrEntryInactive
 			}
 		case "last_validated":
-			validatedAt, validated = i, val
+			validatedAt, validatedVal = i, val
 		case "timestamp":
-			stamped = val
+			timestampVal = val
 		}
 	}
 	// Freshness on record is last_validated, else timestamp — recall's own age-gate
 	// fallback, so what this pass refreshes is exactly what that gate reads. An
 	// absent or unparseable date means nothing is on record: there is a fact to
 	// establish, so stamp it (which also repairs the unparseable value).
-	recorded := stamped
+	recorded := timestampVal
 	if validatedAt >= 0 {
-		recorded = validated
+		recorded = validatedVal
 	}
 	if t, ok := catalog.ParseEntryDate(unquoteScalar(recorded)); ok && at.Sub(t) < minGap {
 		// Also the never-write-backwards guard: a date in the FUTURE (a human
@@ -119,12 +119,11 @@ func unquoteScalar(s string) string {
 // ErrRecentlyValidated / ErrEntryInactive when no PR is warranted (no PR opened).
 func (c *Client) OpenRevalidatePR(ctx context.Context, entryPath string, validated time.Time, minGap time.Duration, body string) (providers.Ref, error) {
 	return c.openEntryEditPR(ctx, entryEdit{
-		path:         entryPath,
-		stamp:        func(raw []byte) ([]byte, error) { return setLastValidated(raw, validated, minGap) },
-		branchPrefix: "revalidate",
-		commitVerb:   "revalidate",
-		titlePrefix:  "KB revalidate: ",
-		labels:       revalidateLabels,
-		body:         body,
+		path:        entryPath,
+		stamp:       func(raw []byte) ([]byte, error) { return setLastValidated(raw, validated, minGap) },
+		verb:        "revalidate",
+		titlePrefix: "KB revalidate: ",
+		labels:      revalidateLabels,
+		body:        body,
 	})
 }

--- a/internal/forge/github/revalidate.go
+++ b/internal/forge/github/revalidate.go
@@ -59,24 +59,25 @@ func setLastValidated(content []byte, at time.Time, minGap time.Duration) ([]byt
 	}
 	stamp := "last_validated: " + at.UTC().Format(lastValidatedLayout)
 	validatedAt := -1                     // index of the existing last_validated line, -1 when absent
-	var validatedVal, timestampVal string // the two recorded dates, raw scalars
+	var validatedVal, timestampVal string // the two recorded dates, as scalars
+	var validatedComment string           // any trailing comment on that line, kept across the restamp
 	for i, ln := range lines {
-		key, val, ok := strings.Cut(ln, ":")
+		key, scalar, comment, ok := frontmatterValue(ln)
 		if !ok {
 			continue
 		}
-		switch strings.TrimSpace(key) {
+		switch key {
 		case "status":
 			// The same two inactive states recall filters on (investigate's
 			// entryActive); an absent or foreign status stays active, per OKF §9
 			// tolerance, so pre-status catalogs are revalidated like any other.
-			if s := strings.ToLower(strings.TrimSpace(val)); s == "retired" || s == "draft" {
+			if inactiveStatus(scalar) {
 				return nil, ErrEntryInactive
 			}
 		case "last_validated":
-			validatedAt, validatedVal = i, val
+			validatedAt, validatedVal, validatedComment = i, scalar, comment
 		case "timestamp":
-			timestampVal = val
+			timestampVal = scalar
 		}
 	}
 	// Freshness on record is last_validated, else timestamp — recall's own age-gate
@@ -93,21 +94,14 @@ func setLastValidated(content []byte, at time.Time, minGap time.Duration) ([]byt
 		return nil, ErrRecentlyValidated
 	}
 	if validatedAt >= 0 {
-		lines[validatedAt] = stamp
+		// Keep whatever note the author wrote beside the date. It is theirs, the
+		// reviewer sees it next to the new value in the diff, and silently deleting
+		// it on a routine restamp would be the pass editing prose it has no business
+		// touching.
+		lines[validatedAt] = stamp + validatedComment
 		return []byte("---\n" + strings.Join(lines, "\n") + rest), nil
 	}
 	return []byte("---\n" + stamp + "\n" + strings.Join(lines, "\n") + rest), nil
-}
-
-// unquoteScalar strips the surrounding quotes yaml.Marshal adds to a date-shaped
-// scalar (okf.Render emits `last_validated: "2026-08-03T10:00:00Z"`), so the
-// hand-parsed value matches what a YAML reader would see.
-func unquoteScalar(s string) string {
-	s = strings.TrimSpace(s)
-	if len(s) >= 2 && (s[0] == '"' || s[0] == '\'') && s[len(s)-1] == s[0] {
-		return s[1 : len(s)-1]
-	}
-	return s
 }
 
 // OpenRevalidatePR opens a human-reviewed PR that stamps `last_validated:

--- a/internal/forge/github/revalidate_test.go
+++ b/internal/forge/github/revalidate_test.go
@@ -264,6 +264,40 @@ func TestOpenRevalidatePR(t *testing.T) {
 		}
 	})
 
+	// The label is the only index a revalidate PR has: the pass finds its own open
+	// proposals, its human vetoes and its queue depth by listing on it. An
+	// unlabelled PR is invisible, so the next sweep would open another for the same
+	// entry — every sweep, without bound. That must fail loudly, naming the PR a
+	// human now has to deal with.
+	t.Run("a labelling failure is an error naming the orphaned PR", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{"content": wrapBase64([]byte(entry)), "sha": "s"})
+		})
+		mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{}`)) })
+		mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{}`)) })
+		mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/42","number":42}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/issues/42/labels", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		_, err := c.OpenRevalidatePR(context.Background(), "incidents/t.md", at, minGap, "body")
+		if err == nil {
+			t.Fatal("an unlabelled proposal is invisible to the pass; that must not pass silently")
+		}
+		if !strings.Contains(err.Error(), "https://github.com/o/r/pull/42") {
+			t.Errorf("the error must name the PR a human has to label or close, got %q", err)
+		}
+	})
+
 	t.Run("404 on the entry file errors with no further calls", func(t *testing.T) {
 		var calls []string
 		mux := http.NewServeMux()

--- a/internal/forge/github/revalidate_test.go
+++ b/internal/forge/github/revalidate_test.go
@@ -66,6 +66,32 @@ func TestSetLastValidated(t *testing.T) {
 			want: "---\nlast_validated: 2026-08-03\ntype: Incident\ntitle: t\n---\nbody\n",
 		},
 		{
+			// A trailing YAML comment is not part of the value. Reading it as one
+			// made the date unparseable, which reads as "nothing on record" — so the
+			// anti-spam gate never fired, the entry was restamped on EVERY sweep,
+			// and the author's note was destroyed each time.
+			name:    "a trailing comment does not hide a last_validated inside minGap",
+			in:      "---\ntype: Incident\nlast_validated: 2026-07-20 # confirmed by alice\n---\nbody\n",
+			skipErr: ErrRecentlyValidated,
+		},
+		{
+			name: "a genuine restamp keeps the author's note beside the date",
+			in:   "---\ntype: Incident\nlast_validated: 2025-01-02  # confirmed by alice\n---\nbody\n",
+			want: "---\ntype: Incident\nlast_validated: 2026-08-03  # confirmed by alice\n---\nbody\n",
+		},
+		{
+			name:    "a commented timestamp is still the freshness fallback",
+			in:      "---\ntype: Incident\ntimestamp: 2026-07-25 # drafted here\n---\nbody\n",
+			skipErr: ErrRecentlyValidated,
+		},
+		{
+			// A '#' inside a quoted scalar is data, and a '#' with no leading
+			// whitespace does not open a comment either.
+			name: "a hash inside a quoted value is not a comment",
+			in:   "---\ntitle: \"alert #42 fired\"\ntype: Incident\n---\nbody\n",
+			want: "---\nlast_validated: 2026-08-03\ntitle: \"alert #42 fired\"\ntype: Incident\n---\nbody\n",
+		},
+		{
 			name: "an unparseable last_validated is repaired, not trusted",
 			in:   "---\ntype: Incident\nlast_validated: someday\n---\nbody\n",
 			want: "---\ntype: Incident\nlast_validated: 2026-08-03\n---\nbody\n",
@@ -80,6 +106,19 @@ func TestSetLastValidated(t *testing.T) {
 		{
 			name:    "a draft entry is never revalidated",
 			in:      "---\ntype: Incident\nstatus: Draft\ntimestamp: 2020-01-02\n---\nbody\n",
+			skipErr: ErrEntryInactive,
+		},
+		{
+			// `status: "retired"` is retired to everything that LOADS the catalog,
+			// so the stamp must agree — otherwise RunLore proposes confirming an
+			// entry recall already refuses to fire.
+			name:    "a quoted retired status is still inactive",
+			in:      "---\ntype: Incident\nstatus: \"retired\"\ntimestamp: 2020-01-02\n---\nbody\n",
+			skipErr: ErrEntryInactive,
+		},
+		{
+			name:    "a quoted draft status carrying a comment is still inactive",
+			in:      "---\ntype: Incident\nstatus: 'draft' # not ready yet\ntimestamp: 2020-01-02\n---\nbody\n",
 			skipErr: ErrEntryInactive,
 		},
 		{

--- a/internal/forge/github/revalidate_test.go
+++ b/internal/forge/github/revalidate_test.go
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// at is the candidate validation date every case below stamps with.
+var at = time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+
+const minGap = 720 * time.Hour // 30d, the shipped default
+
+func TestSetLastValidated(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string // "" ⇒ expect skipErr instead
+		skipErr error
+	}{
+		{
+			name: "no last_validated and an old timestamp inserts the field",
+			in:   "---\ntype: Incident\ntimestamp: 2025-01-02\n---\nbody\n",
+			want: "---\nlast_validated: 2026-08-03\ntype: Incident\ntimestamp: 2025-01-02\n---\nbody\n",
+		},
+		{
+			name: "an older last_validated is replaced in place, nothing else moves",
+			in:   "---\ntype: Incident\nlast_validated: 2025-01-02\ntitle: t\n---\nbody\n",
+			want: "---\ntype: Incident\nlast_validated: 2026-08-03\ntitle: t\n---\nbody\n",
+		},
+		{
+			// The anti-spam rule: a stamp inside minGap is noise, not news.
+			name:    "a last_validated inside minGap is a done-skip",
+			in:      "---\ntype: Incident\nlast_validated: 2026-07-20\n---\nbody\n",
+			skipErr: ErrRecentlyValidated,
+		},
+		{
+			// okf.Render quotes an RFC3339 scalar; the reader must see through it.
+			name:    "a quoted RFC3339 last_validated inside minGap is a done-skip",
+			in:      "---\ntype: Incident\nlast_validated: \"2026-07-20T08:00:00Z\"\n---\nbody\n",
+			skipErr: ErrRecentlyValidated,
+		},
+		{
+			name:    "a future last_validated is never written backwards",
+			in:      "---\ntype: Incident\nlast_validated: 2027-01-01\n---\nbody\n",
+			skipErr: ErrRecentlyValidated,
+		},
+		{
+			// A freshly drafted entry carries no last_validated but a recent
+			// timestamp: recall's own freshness fallback, so no PR is warranted.
+			name:    "a recent timestamp with no last_validated is a done-skip",
+			in:      "---\ntype: Incident\ntimestamp: \"2026-07-25T08:00:00Z\"\n---\nbody\n",
+			skipErr: ErrRecentlyValidated,
+		},
+		{
+			name: "a dateless entry has nothing on record, so it is stamped",
+			in:   "---\ntype: Incident\ntitle: t\n---\nbody\n",
+			want: "---\nlast_validated: 2026-08-03\ntype: Incident\ntitle: t\n---\nbody\n",
+		},
+		{
+			name: "an unparseable last_validated is repaired, not trusted",
+			in:   "---\ntype: Incident\nlast_validated: someday\n---\nbody\n",
+			want: "---\ntype: Incident\nlast_validated: 2026-08-03\n---\nbody\n",
+		},
+		{
+			// Recall never fires a retired/draft entry, so it can never earn a
+			// confirmation; proposing one would contradict the retirement pass.
+			name:    "a retired entry is never revalidated",
+			in:      "---\ntype: Incident\nstatus: retired\ntimestamp: 2020-01-02\n---\nbody\n",
+			skipErr: ErrEntryInactive,
+		},
+		{
+			name:    "a draft entry is never revalidated",
+			in:      "---\ntype: Incident\nstatus: Draft\ntimestamp: 2020-01-02\n---\nbody\n",
+			skipErr: ErrEntryInactive,
+		},
+		{
+			name: "an explicitly active entry is stamped like any other",
+			in:   "---\ntype: Incident\nstatus: active\ntimestamp: 2020-01-02\n---\nbody\n",
+			want: "---\nlast_validated: 2026-08-03\ntype: Incident\nstatus: active\ntimestamp: 2020-01-02\n---\nbody\n",
+		},
+		{
+			// Fence-bounded scanning: prose in the body must never be mistaken
+			// for frontmatter (the setStatusRetired property, kept).
+			name: "last_validated in the BODY does not fool the fence scan",
+			in:   "---\ntype: Incident\n---\nlast_validated: 2026-08-01 appears in prose\n",
+			want: "---\nlast_validated: 2026-08-03\ntype: Incident\n---\nlast_validated: 2026-08-01 appears in prose\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := setLastValidated([]byte(tc.in), at, minGap)
+			if tc.skipErr != nil {
+				if !errors.Is(err, tc.skipErr) {
+					t.Fatalf("err=%v, want %v", err, tc.skipErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("setLastValidated: %v", err)
+			}
+			if string(out) != tc.want {
+				t.Errorf("got:\n%q\nwant:\n%q", out, tc.want)
+			}
+		})
+	}
+
+	t.Run("no frontmatter is an error, never a blind write", func(t *testing.T) {
+		if _, err := setLastValidated([]byte("just a body\n"), at, minGap); err == nil {
+			t.Fatal("want an error on missing frontmatter")
+		}
+	})
+	t.Run("unterminated frontmatter is an error", func(t *testing.T) {
+		if _, err := setLastValidated([]byte("---\ntype: Incident\n"), at, minGap); err == nil {
+			t.Fatal("want an error on unterminated frontmatter")
+		}
+	})
+}
+
+// TestSetLastValidatedRoundTrips pins the stamped value to the ONE date grammar
+// recall's age gate reads: a stamp recall cannot parse would silently leave the
+// entry exempt from staleness, which looks like success and is not.
+func TestSetLastValidatedRoundTrips(t *testing.T) {
+	out, err := setLastValidated([]byte("---\ntype: Incident\n---\nbody\n"), at, minGap)
+	if err != nil {
+		t.Fatalf("setLastValidated: %v", err)
+	}
+	// Feed the stamped file straight back in with a candidate one day later: the
+	// value we just wrote must be readable, hence a done-skip.
+	if _, err := setLastValidated(out, at.Add(24*time.Hour), minGap); !errors.Is(err, ErrRecentlyValidated) {
+		t.Fatalf("the stamped date did not parse back: err=%v", err)
+	}
+}
+
+func TestOpenRevalidatePR(t *testing.T) {
+	const entry = "---\ntype: Incident\ntitle: t\ntimestamp: 2020-01-02\n---\nbody\n"
+
+	t.Run("opens a last_validated PR carrying the file sha", func(t *testing.T) {
+		var calls []string
+		var putBody, prBody, labelBody map[string]any
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "GET contents "+r.PathValue("path"))
+			_ = json.NewEncoder(w).Encode(map[string]any{"content": wrapBase64([]byte(entry)), "sha": "filesha123"})
+		})
+		mux.HandleFunc("GET /repos/o/r/git/ref/heads/main", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "GET baseref")
+			_, _ = w.Write([]byte(`{"object":{"sha":"basesha"}}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/git/refs", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "POST refs")
+			_, _ = w.Write([]byte(`{}`))
+		})
+		mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "PUT contents "+r.PathValue("path"))
+			_ = json.NewDecoder(r.Body).Decode(&putBody)
+			_, _ = w.Write([]byte(`{}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "POST pulls")
+			_ = json.NewDecoder(r.Body).Decode(&prBody)
+			_, _ = w.Write([]byte(`{"html_url":"https://github.com/o/r/pull/42","number":42}`))
+		})
+		mux.HandleFunc("POST /repos/o/r/issues/42/labels", func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, "POST labels")
+			_ = json.NewDecoder(r.Body).Decode(&labelBody)
+			_, _ = w.Write([]byte(`[]`))
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		ref, err := c.OpenRevalidatePR(context.Background(), "incidents/t.md", at, minGap, "body with marker")
+		if err != nil {
+			t.Fatalf("OpenRevalidatePR: %v", err)
+		}
+		if ref.URL != "https://github.com/o/r/pull/42" {
+			t.Fatalf("ref=%s", ref.URL)
+		}
+		if len(calls) != 6 || calls[0] != "GET contents incidents/t.md" || calls[len(calls)-1] != "POST labels" {
+			t.Fatalf("unexpected call sequence: %v", calls)
+		}
+		raw, _ := base64.StdEncoding.DecodeString(putBody["content"].(string))
+		if !strings.HasPrefix(string(raw), "---\nlast_validated: 2026-08-03\n") {
+			t.Errorf("PUT content not stamped:\n%s", raw)
+		}
+		if putBody["sha"] != "filesha123" {
+			t.Errorf("PUT sha=%v, want filesha123", putBody["sha"])
+		}
+		if title, _ := prBody["title"].(string); !strings.Contains(title, "incidents/t.md") {
+			t.Errorf("PR title=%q, want it to name the entry", title)
+		}
+		gotLabels, _ := labelBody["labels"].([]any)
+		if len(gotLabels) != 2 || gotLabels[0] != "runlore" || gotLabels[1] != "runlore-revalidate" {
+			t.Errorf("labels=%v, want [runlore runlore-revalidate]", labelBody["labels"])
+		}
+	})
+
+	t.Run("a recently validated entry short-circuits after the first GET", func(t *testing.T) {
+		var calls []string
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "GET contents")
+			fresh := "---\ntype: Incident\nlast_validated: 2026-07-25\n---\nbody\n"
+			_ = json.NewEncoder(w).Encode(map[string]any{"content": wrapBase64([]byte(fresh)), "sha": "s"})
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		_, err := c.OpenRevalidatePR(context.Background(), "incidents/t.md", at, minGap, "body")
+		if !errors.Is(err, ErrRecentlyValidated) {
+			t.Fatalf("err=%v, want ErrRecentlyValidated", err)
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected only the contents GET, got %v", calls)
+		}
+	})
+
+	t.Run("404 on the entry file errors with no further calls", func(t *testing.T) {
+		var calls []string
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, _ *http.Request) {
+			calls = append(calls, "GET contents")
+			w.WriteHeader(http.StatusNotFound)
+		})
+		srv := httptest.NewServer(mux)
+		defer srv.Close()
+
+		c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+		if _, err := c.OpenRevalidatePR(context.Background(), "incidents/gone.md", at, minGap, "body"); err == nil {
+			t.Fatal("want an error on a 404 contents GET")
+		}
+		if len(calls) != 1 {
+			t.Fatalf("expected only the contents GET, got %v", calls)
+		}
+	})
+}

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -92,9 +92,15 @@ type Event struct {
 	User string `json:"user,omitempty"`
 
 	// Resolvable is set on an open when we know whether a ground-truth resolve signal
-	// can ever arrive for it: true for sources with a resolve channel (Alertmanager,
-	// PagerDuty), false for sources that never emit one (GitOps, reinvestigate, or
-	// Alertmanager with send_resolved off). A pointer for a three-state distinction:
+	// can ever arrive for it. The answer is read off the FINGERPRINT and nothing else
+	// (`resolvable := !outcome.Derived(fp)` on the delivery path): true for every real
+	// alert fingerprint (Alertmanager, PagerDuty), false only for the synthetic ids of
+	// sources that emit no fingerprint at all — GitOps and reinvestigate, and only
+	// those (see Derived). An Alertmanager receiver with send_resolved off is NOT
+	// excluded and cannot be: send_resolved lives in the operator's receiver config,
+	// which RunLore never reads, so there is no signal to condition on — such an open
+	// is counted like any other and its entry decays (see applyOpenLocked).
+	// A pointer for a three-state distinction:
 	// nil ⇒ the field is absent, i.e. a LEGACY open written before this field existed —
 	// those came from Alertmanager/PagerDuty and are treated as resolvable. Only a
 	// non-resolvable recall open is excluded from recall decay (see applyOpenLocked).
@@ -592,12 +598,23 @@ func (l *Ledger) Reload() error {
 // counts as resolved. Must be called with mu held (or during single-threaded New).
 func (l *Ledger) applyOpenLocked(e Event) {
 	// A recall open counts toward decay ONLY when it is resolvable — i.e. a resolve
-	// signal for it can actually arrive. A non-resolvable recall (GitOps, reinvestigate,
-	// or Alertmanager with send_resolved off) neither builds nor erodes trust: counting
-	// it toward Recalls with no possible Resolved would decay a CORRECT entry's
-	// resolve-rate forever, on evidence the source can never provide. So decay is only
-	// learned where a ground-truth resolve signal exists. Episodes()/Occurrences() still
-	// include EVERY open regardless of resolvability, so recurrence counting is unaffected.
+	// signal for it can actually arrive. A non-resolvable recall (GitOps or
+	// reinvestigate — the synthetic fingerprints, and only those) neither builds nor
+	// erodes trust: counting it toward Recalls with no possible Resolved would decay a
+	// CORRECT entry's resolve-rate forever, on evidence the source can never provide.
+	// So decay is only learned where a ground-truth resolve signal exists.
+	//
+	// The exclusion is drawn on the fingerprint, so it cannot cover an Alertmanager
+	// receiver with send_resolved off (RunLore never reads that config): those opens
+	// ARE counted, and if the resolve never arrives the entry decays instead — one
+	// unresolved recall reaches Factor 1/3 at the shipped defaults (prior 2, floor
+	// 0.5), which the recall gate rejects. The two cases therefore fail in OPPOSITE
+	// directions: an excluded entry never enters agg at all, so the gate's fail-safe
+	// keeps it at full trust; a counted one is rejected and, recording nothing further,
+	// stays below the floor with its observation count frozen.
+	//
+	// Episodes()/Occurrences() still include EVERY open regardless of resolvability,
+	// so recurrence counting is unaffected.
 	counted := e.Kind == "recall" && e.Entry != "" && e.resolvable()
 	if counted {
 		a := l.agg[e.Entry]

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -460,7 +460,7 @@ func TestDeriveFingerprintStableAndPrefixed(t *testing.T) {
 func boolPtr(b bool) *bool { return &b }
 
 // TestNonResolvableRecallOpenNotCountedButInEpisodes pins Defect 2: a recall open from
-// a source with NO resolve channel (Resolvable=false — GitOps / send_resolved off) must
+// a source with NO resolve channel (Resolvable=false — GitOps / reinvestigate) must
 // NOT increment Recalls (so a correct entry's resolve-rate can't decay on evidence that
 // can never arrive), yet it MUST still appear in Episodes so recurrence counting keeps
 // working.

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -444,9 +444,9 @@ ledger, so they stay source-neutral):
   KB PR so the reviewer sees the contest before merging; idempotent via a hidden
   per-trigger marker in the comment, no mutable store.
 
-Finally, an **opt-in** pass closes the *garbage-collection* half of the loop — the
-mirror image of curation, where decay existed but had no consequence beyond recall
-rejection:
+Finally, two **opt-in** passes act on an entry's own track record rather than on the
+PR backlog — the *garbage-collection* half of the loop, where decay existed but had no
+consequence beyond recall rejection, and its mirror image:
 
 - **Retirement** (`curate.retirement.enabled`, default **off**) — opens a
   human-reviewed *retire* PR for a **merged** catalog entry whose outcome factor stayed
@@ -470,6 +470,34 @@ rejection:
     keep surfacing it (status-visible) for KB archaeology. A merged retirement PR is
     therefore effective end-to-end. Fail-safe: an absent or unknown status is treated as
     active (OKF §9 tolerance), so pre-retirement catalogs behave exactly as before.
+- **Revalidation** (`curate.revalidation.enabled`, default **off**) — the mirror
+  image: it opens a human-reviewed *revalidate* PR for a **merged** entry that was
+  recalled for a live incident which then **resolved**, proposing to stamp
+  `last_validated` with that resolve date. This is the seam that lets the field be
+  *earned*: before it, freshness could only decay (§6). One resolved recall is the
+  whole evidence bar — deliberately, because it is a far denser chain of checks than
+  retirement's evidence: the entry won recall's gates, was confirmed against **live
+  cluster state**, survived the adversarial **verify** pass, was delivered as the
+  answer, and the incident then cleared. Retirement needs `min_observations` to tell
+  a bad recall from noise; a confirmation does not. The PR makes a **one-line
+  frontmatter edit** and nothing else — no status change, no content change — and,
+  as with retirement, a human merges: `last_validated` claims *human* confirmation,
+  and merging **is** that act, so RunLore can bring the evidence but must never
+  write the field itself. Anti-spam is two-layered: a candidate date must be at
+  least `min_interval` (default **720h**) newer than what the entry already records,
+  checked against the file on the base branch so a merged stamp silences the next
+  sweep with no state to keep; and `max_open` (default **5**) bounds how many
+  revalidation PRs may await review at once, counting ones earlier sweeps left open
+  — so enabling the pass on a mature catalog drains a queue instead of flooding one.
+  Idempotent and **human-veto-aware** through the same hidden per-entry marker, and
+  the marker is keyed on the entry *path*, never the date, precisely so a decline
+  stays declined rather than returning monthly.
+  - **Retirement wins where they meet.** Both passes read the same aggregate and
+    the same `outcome.Aggregate.Factor`, and they are **disjoint by construction**:
+    retirement fires strictly *below* the trust floor, revalidation only *at or
+    above* it. So one sweep can never propose retiring and revalidating the same
+    entry, and an entry recall already refuses to fire is never stamped "still
+    valid", whatever a stale resolve in its history says.
 
 ---
 
@@ -536,8 +564,17 @@ pre-field behaviour byte-for-byte):
   and the adversarial **verify** pass remain the hard gates against a genuinely drifted
   answer, and the outcome floor (Gate 3) keeps priority (track record beats calendar).
   Staleness only stops a five-year-old runbook looking as confident as yesterday's. A
-  dateless or unparseable-date entry is exempt. `last_validated` is stamped at entry
-  creation (= `timestamp`) and is the seam a future confirmation flow refreshes.
+  dateless or unparseable-date entry is exempt.
+
+  **`last_validated` is unset when RunLore drafts an entry** — the field claims a
+  *human* confirmed the entry works, and a fresh draft has none, so the drafter has
+  no honest value to write (`renderEntry`, `internal/forge/github`). Freshness
+  therefore falls back to `timestamp` until the field is **earned**, which is what
+  the opt-in **revalidation pass** (§5) is for: when a recall of the entry is
+  followed by the incident actually resolving, it opens a PR proposing that resolve
+  date, and **a human merging that PR is the confirmation the field claims**. Until
+  then an entry can only get older; with the pass enabled, a note that keeps working
+  keeps its freshness.
 
 A `low_outcome` rejection does not abandon recall outright: the gate walks a small,
 bounded set of further structurally-agreeing candidates (the runner-up fallback) —

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -539,13 +539,33 @@ confidence  =  clamp( base_confidence × factor , 0 , 0.90 )
 
 Human 👍/👎 votes are **extra Bernoulli observations in the same posterior** — a 👍 is
 one success, a 👎 one failure, each weighing exactly like a resolved/unresolved recall.
-That matters most where the resolve signal *cannot exist*: sources with no resolve
-channel (**GitOps failures**, reinvestigate polls, Alertmanager without `send_resolved`)
-are deliberately excluded from resolve-based decay, so without feedback their entries'
-trust is frozen at the prior forever. A human's explicit 👎 (a Slack click or a Matrix
-reaction) is the only ground truth those paths can ever accumulate — and it is a
-judgment on the *diagnosis itself*, which an
-alert merely clearing never proves.
+That matters most where the resolve signal *cannot exist*.
+
+**What is excluded from resolve-based decay is decided by the fingerprint, and by
+nothing else.** RunLore mints a synthetic id for an incident that carries no external
+alert fingerprint, and exactly those two shapes are excluded: **GitOps failures**
+(`gitops:…`) and **re-investigate polls** (`reinvestigate:…`). Such a recall is still
+recorded for recurrence, but it never enters the `OpenCounts` roll-up — so Gate 3 never
+computes a factor for it at all and falls through to its fail-safe (*absence of evidence
+must never block a recall*), which is **1.0**: full trust, **not** the 0.5 prior mean.
+An entry recalled only from those sources therefore keeps firing at full confidence
+however wrong it has become, and retirement never surfaces it either, because an entry
+the roll-up has never seen is not a candidate. A human's explicit 👎 (a Slack click or a
+Matrix reaction) is the only ground truth those paths can ever accumulate — and it is a
+judgment on the *diagnosis itself*, which an alert merely clearing never proves.
+
+**An Alertmanager alert is never in that excluded set** — not even when its receiver has
+`send_resolved` off. Resolvability is read off the fingerprint alone
+(`resolvable := !outcome.Derived(fp)`), never off `send_resolved`, which lives in the
+operator's receiver config: RunLore never reads it, and has no startup or per-event
+signal it could condition on. A real alert fingerprint is always recorded resolvable, so
+when the resolve never comes the failure runs the **opposite** way from the synthetic
+case. Every recall increments `recalls` while `resolved` stays 0, and the factor drops
+at once: **one** unresolved recall already lands the entry at **0.333**, below the
+shipped `outcome_floor` of **0.5**, and Gate 3 stops firing it. A rejected recall
+records nothing further, so it stays there — and retirement does not rescue it either,
+because the observation count freezes at 1, below `min_observations`. Neither failure
+mode is self-correcting; a 👍/👎 channel is the one thing that closes both.
 
 ```mermaid
 stateDiagram-v2

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -491,13 +491,32 @@ consequence beyond recall rejection, and its mirror image:
   — so enabling the pass on a mature catalog drains a queue instead of flooding one.
   Idempotent and **human-veto-aware** through the same hidden per-entry marker, and
   the marker is keyed on the entry *path*, never the date, precisely so a decline
-  stays declined rather than returning monthly.
+  stays declined rather than returning monthly. That veto is also why **no other
+  pass may close a retire or revalidate PR**: these passes keep no store, so a
+  closed-unmerged proposal *is* the record of a human declining, and RunLore closing
+  its own proposal — as a stale artifact, or as a title-similar "duplicate" — would
+  be indistinguishable from that. Both the stale sweep and dedup skip them; the
+  queue bound above is what keeps an unreviewed backlog finite instead.
   - **Retirement wins where they meet.** Both passes read the same aggregate and
-    the same `outcome.Aggregate.Factor`, and they are **disjoint by construction**:
-    retirement fires strictly *below* the trust floor, revalidation only *at or
-    above* it. So one sweep can never propose retiring and revalidating the same
-    entry, and an entry recall already refuses to fire is never stamped "still
-    valid", whatever a stale resolve in its history says.
+    the same `outcome.Aggregate.Factor`, and within one sweep they are **disjoint by
+    construction**: retirement fires strictly *below* the trust floor, revalidation
+    only *at or above* it. So one sweep can never propose retiring and revalidating
+    the same entry, and an entry recall already refuses to fire is never stamped
+    "still valid", whatever a stale resolve in its history says.
+
+    That construction is arithmetic, not a rule either pass applies, so it holds
+    only while both read the **same** floor and prior. `curate.revalidation.floor`
+    and `curate.revalidation.prior` therefore *inherit* `curate.retirement`'s when
+    left unset, and setting them to different values while both passes are enabled
+    is rejected at config load — unequal floors would otherwise leave a band where
+    both passes fire on one entry.
+
+    **Across sweeps the guarantee is weaker, by design.** An entry whose factor
+    recovers after a retire PR was already opened can pick up a revalidate PR while
+    that retire PR is still open. Nothing suppresses it, because both proposals are
+    then honest: the track record really did decay, and it really has recovered. A
+    reviewer holding both decides which one the entry deserves — merging the retire
+    PR makes the revalidation moot, since a retired entry is refused outright.
 
 ---
 


### PR DESCRIPTION
A catalog entry can lose freshness but has never been able to regain it. Nothing in the codebase writes `last_validated` after an entry is created.

- `renderEntry` deliberately leaves it unset: *"last_validated stays unset — that field claims human confirmation."*
- Recall's age gate reads `LastValidated`, falling back to `Timestamp`. So with `stale_after` configured, **every entry's delivered confidence steps down permanently from its creation date** and can only be restored by a human hand-editing YAML.
- `learning-loop.md` §6 claimed *"`last_validated` is stamped at entry creation (= `timestamp`) and is the seam a future confirmation flow refreshes."* The first half contradicted the code. This PR builds the second half.

The ledger already records the justifying signal — a recall of a specific entry, followed by that incident resolving.

## The pass

A **revalidation** pass, the mirror image of retirement and modelled directly on it: opt-in and default off, a surgical one-line frontmatter edit that preserves the human's formatting, idempotent via a hidden per-entry marker, human-veto-aware (a closed-unmerged PR is a deliberate "no" and is never re-nagged), never merges, per-item error isolation.

**Evidence bar: one resolved recall.** Retirement needs `min_observations` because its evidence is thin — an alert merely failing to clear. A resolved recall is a much denser chain: the entry won recall's structural and margin/rerank gates, was confirmed against live cluster state, survived the adversarial verify pass, was delivered as the answer, and the incident then cleared. The asymmetry is also one of consequence — retirement *removes* knowledge, this only *proposes a date*. And since the field claims **human** confirmation, merging the PR is precisely the act of giving it; RunLore's job is only to bring honest evidence to a reviewer.

**Anti-spam, three layers:**

| layer | mechanism | default |
|---|---|---|
| per-entry rate | candidate date must be `min_interval` newer than the entry's `last_validated` (else `timestamp`) | `720h` |
| reviewer queue | `max_open` bounds *outstanding* revalidation PRs, counting ones earlier sweeps left open | `5` |
| idempotency | hidden per-entry marker in the PR body | — |

The interval check runs **inside the forge**, against the file on the base branch (`ErrRecentlyValidated`, mirroring `ErrAlreadyRetired`), so a merged stamp silences the next sweep with no mutable store to keep in sync. `max_open` exists because the first sweep on a mature catalog would otherwise propose every long-confirmed entry at once; it drains as PRs are reviewed, and makes guaranteed progress since merges and vetoes both remove candidates permanently.

**Retirement interaction — corrected during review.** The original claim was "disjoint by construction, retirement wins." A review pass showed it holds *only* when the two passes' floors and priors happen to match: `Validate` range-checked each independently and `ApplyDefaults` filled them separately, so `retirement.floor: 0.6` with `revalidation.floor: 0.4` gives an entry at factor 0.5 **both** a retire PR and a revalidate PR in the same sweep. It is now enforced rather than asserted — `curate.revalidation.floor`/`prior` inherit `curate.retirement`'s (falling back to 0.5/2.0 when retirement is off), and `Validate` rejects explicitly unequal values while both passes are enabled. At the boundary the split is exact. The weaker per-sweep caveat is now stated in the docs rather than papered over: an entry that got a retire PR in sweep *N* and recovers by sweep *N+k* can get a revalidate PR while the retire PR is still open.

**`renderEntry` is unchanged — confirmed, not overturned.** A draft has no human confirmation, so there is no honest value to write at creation. The existing comment's reasoning was already right; this pass is what earns the field.

## Docs guard

`internal/docsguard/learning_loop_test.go` derives the truth by driving the **real** `github.Client.OpenPR` against a stub API and inspecting the drafted frontmatter, rather than restating the claim.

Four deliberate mutations, each confirmed to fail and then reverted:

1. `renderEntry` stamps `last_validated` → fails ("the forge now stamps… but §6 says it is unset")
2. `min_interval` default 720h→168h → fails
3. yaml tag `max_open`→`max_open_prs` → **initially slipped through.** The guard was reworked to derive the key name from the struct tag by reflection, after which it fails.
4. §6 reverted to the original false claim verbatim → fails — i.e. the guard would have caught the original bug

Plus `TestLastValidatedClaimREsFlip`, a mutation test on the two phrase regexes: each fires on its own claim and stays quiet on the other and on the page's other prose about the field.

## Refactor

The six-call retire/revalidate GitHub dance is now one `openEntryEditPR` in `internal/forge/github/entryedit.go`. `setStatusRetired` keeps its signature and every existing retire test passes untouched.

## Scope notes

`internal/app/curate.go` needed a minimal diff — `sweeper.go` is only a ticker, and the pass list is assembled in `BuildCurateAgent`, shared by the `lore curate` CronJob and the in-server sweeper. It is one `if cfg.Curate.Revalidation.Enabled { … }` block plus two doc-comment words.

`learning-loop.md` §5 and §6 only; §3 is owned by another PR in flight.

## Follow-ups

- `configuration.md` and `values.yaml` are owned by other in-flight PRs, so `curate.revalidation` is documented in `values-full.yaml` only. Worth a follow-up once those land.
- The `plugins/kb-steward` triage skill lists `runlore-retire` but not a `runlore-revalidate` label.


---

## Review round: two self-veto bugs

An adversarial review found the pass would have sabotaged itself on its first apply sweep. Both are fixed, each with a regression test that **arms its own hazard and asserts it is armed** — the Dedup test fails if the fixture titles ever score below the similarity bar, the Lifecycle test fails if the fixture is not past the horizon — and each keeps a control PR that must still be closed, so the exclusion cannot degrade into a disabled pass.

**`Dedup` closed revalidate PRs as duplicates of each other.** They carry the `runlore` label and no `DupFingerprint` marker, so `isDuplicatePair` fell through to title-Jaccard — and `KB revalidate: <path>` titles score 0.75–0.80 against each other. The loser was commented and closed, which the pass then read as *"a human closed this without merging: a deliberate 'I am not confirming this'"* and never re-proposed. With `max_open: 5` deliberately keeping several similarly-titled PRs open at once, this fired on the first sweep and permanently vetoed roughly four of every five entries proposed.

**`Lifecycle`'s stale sweep closed them too**, same permanent-veto outcome — and the chart ships `stale_after: 720h`, exactly the `min_interval` this branch ships, with Lifecycle running *before* Revalidation in the same sweep. A slow reviewer became a permanent decline.

Both passes now exclude entry-edit proposals. Documented trade: an unreviewed proposal stays open indefinitely, `max_open` is the bound, and a hand-close becomes a real veto.

## Other review fixes

- **Quoted `status` bypassed the inactive check** — `status: "retired"` read as active, so RunLore would propose stamping "still valid" on an entry recall refuses to fire. Now read exactly as `investigate.entryActive` does, at both sites including the pre-existing one in `setStatusRetired`.
- **A trailing YAML comment defeated the anti-spam gate** — `last_validated: 2026-07-20 # note` failed `ParseEntryDate`, read as "nothing on record", and got restamped every sweep while destroying the comment. Frontmatter values now split scalar-from-comment losslessly, and both stamps re-emit the comment.
- **Done-skips were audited as `DecisionFailed`** — for revalidation the done-skip is the *steady state*, so the audit chain filled with FAILED records where nothing failed. They map to `DecisionSkipped`.
- **An `addLabels` failure silently orphaned a PR into an unbounded loop** — the label is the only index for these proposals (idempotency, veto and budget all list on it), so an unlabelled PR was invisible and the next sweep opened another, forever. It is an error now. `OpenPR` keeps best-effort, correctly: a KB draft is found by its fingerprint marker, not a label.
- **The dry-run comment described the relationship backwards** — it claimed a superset of what an apply run would open; it is neither superset nor subset, so an operator sizing review load got a misleading number.
- **The docs guard's key list was hand-maintained** and silently missed `curate.sweeps.*`. It now reflects over `config.Curate`'s fields, and an unknown block is an error rather than a skip.
