### PR TITLE
feat(catalog): let the knowledge commons pin a tag or commit instead of tracking a branch

### DIFF
--- a/deploy/helm/runlore/values-full.yaml
+++ b/deploy/helm/runlore/values-full.yaml
@@ -236,6 +236,18 @@ config:
     commons:
       url: https://github.com/Smana/runlore-kb-commons
       branch: main
+      # ref: v1.2.0                     # PIN the corpus — comment out `branch` above to use it
+      #
+      # branch and ref are mutually exclusive (the agent refuses to start with both).
+      #   branch: upstream edits reach kb_search at the next interval — you get shared
+      #           fixes without doing anything, from a repo you do not control.
+      #   ref:    a tag or a full 40-character commit id. The corpus is frozen until
+      #           you bump it, so you can read the upstream diff before it grounds an
+      #           investigation. Polling a pin costs nothing (nothing can move), and
+      #           you stop receiving upstream corrections until you move it yourself.
+      # Neither is the safe choice in the abstract — pick the one that matches how
+      # much you want to review. What pinning does NOT change: commons entries are
+      # read-only, never curated into, and can never fire instant recall.
       interval: 24h                     # a shared corpus changes slowly; do not poll it like your own
       dir: /var/lib/runlore/commons
       # token_env: COMMONS_TOKEN        # only for a PRIVATE commons repo

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -231,6 +231,11 @@ config:
   #   commons:
   #     url: https://github.com/Smana/runlore-kb-commons
   #     dir: /var/lib/runlore/commons
+  #     # Tracks branch `main` by default: upstream edits reach kb_search within a
+  #     # day, from a repo you do not control. Set `ref: v1.2.0` instead (a tag or a
+  #     # full commit id; mutually exclusive with branch) to freeze the corpus until
+  #     # you have reviewed what changed. Trade: reviewed updates vs shared fixes for
+  #     # free. Polling a pinned ref is a no-op.
   #   instant_recall:
   #     enabled: true
   #     min_score: 1.0                 # similarity floor for the top hit (shipped default)

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	git "github.com/go-git/go-git/v5"
@@ -17,11 +16,9 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
-)
 
-// tagRefPrefix is the fully-qualified namespace of a tag. Together with a bare
-// object id it spells the two IMMUTABLE revisions a Syncer accepts — see Syncer.Branch.
-const tagRefPrefix = "refs/tags/"
+	"github.com/Smana/runlore/internal/gitrev"
+)
 
 // pinRefSpecs is what a pin fetch asks for: every branch and every tag. A pin may
 // name any commit in the repository, so narrowing this would make "bump the pin"
@@ -29,27 +26,6 @@ const tagRefPrefix = "refs/tags/"
 var pinRefSpecs = []gitcfg.RefSpec{
 	"+refs/heads/*:refs/remotes/origin/*",
 	"+refs/tags/*:refs/tags/*",
-}
-
-// isObjectID reports whether s is a full-length git object id (SHA-1 40 hex chars,
-// SHA-256 64). Abbreviations are deliberately NOT accepted: they are ambiguous, and
-// a 7-character hex string is as likely to be a tag name as a commit.
-//
-// internal/config carries the same rule for the operator-facing side of the same
-// contract (config.isObjectID). Keep the two in step: config decides what may be
-// written, this decides what the resulting string means.
-func isObjectID(s string) bool {
-	if len(s) != 40 && len(s) != 64 {
-		return false
-	}
-	for _, r := range s {
-		switch {
-		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
-		default:
-			return false
-		}
-	}
-	return true
 }
 
 // SyncDelta names the repo-relative paths that changed between two synced
@@ -82,7 +58,8 @@ type Syncer struct {
 	// It is one field rather than two because a syncer follows exactly one revision;
 	// the operator-facing surface (catalog.commons.branch vs .ref) is where the two
 	// intentions are kept apart, and config.ApplyDefaults normalises a `ref` into the
-	// spellings above. Same contract, read from its two ends.
+	// spellings above. Same contract, read from its two ends — and from one shared
+	// definition, internal/gitrev, so neither end can drift away from the other.
 	Branch string
 	Dir    string
 	Token  TokenFunc // nil / empty => anonymous (public repo)
@@ -121,7 +98,7 @@ func (s *Syncer) branch() string {
 // pin returns the immutable revision this syncer is frozen at, and whether it is
 // pinned at all. An unpinned syncer tracks branch().
 func (s *Syncer) pin() (plumbing.Revision, bool) {
-	if strings.HasPrefix(s.Branch, tagRefPrefix) || isObjectID(s.Branch) {
+	if gitrev.IsPinned(s.Branch) {
 		return plumbing.Revision(s.Branch), true
 	}
 	return "", false
@@ -138,7 +115,7 @@ func (s *Syncer) cloneOptions(auth *githttp.BasicAuth) *git.CloneOptions {
 	case !pinned:
 		o.ReferenceName = plumbing.NewBranchReferenceName(s.branch())
 		o.SingleBranch = true
-	case strings.HasPrefix(string(rev), tagRefPrefix):
+	case gitrev.IsTagRef(string(rev)):
 		o.ReferenceName = plumbing.ReferenceName(rev)
 		o.SingleBranch = true
 	}

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -9,13 +9,48 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	git "github.com/go-git/go-git/v5"
+	gitcfg "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 )
+
+// tagRefPrefix is the fully-qualified namespace of a tag. Together with a bare
+// object id it spells the two IMMUTABLE revisions a Syncer accepts — see Syncer.Branch.
+const tagRefPrefix = "refs/tags/"
+
+// pinRefSpecs is what a pin fetch asks for: every branch and every tag. A pin may
+// name any commit in the repository, so narrowing this would make "bump the pin"
+// work for some revisions and silently not for others.
+var pinRefSpecs = []gitcfg.RefSpec{
+	"+refs/heads/*:refs/remotes/origin/*",
+	"+refs/tags/*:refs/tags/*",
+}
+
+// isObjectID reports whether s is a full-length git object id (SHA-1 40 hex chars,
+// SHA-256 64). Abbreviations are deliberately NOT accepted: they are ambiguous, and
+// a 7-character hex string is as likely to be a tag name as a commit.
+//
+// internal/config carries the same rule for the operator-facing side of the same
+// contract (config.isObjectID). Keep the two in step: config decides what may be
+// written, this decides what the resulting string means.
+func isObjectID(s string) bool {
+	if len(s) != 40 && len(s) != 64 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
 
 // SyncDelta names the repo-relative paths that changed between two synced
 // revisions. A nil *SyncDelta means "unknown" — the caller must do a full
@@ -33,7 +68,21 @@ type TokenFunc func(ctx context.Context) (string, error)
 // onSync after each successful sync so the reader can re-index. This closes the
 // read/write loop: the curator's merged PRs flow back into what the agent searches.
 type Syncer struct {
-	URL    string
+	URL string
+	// Branch is the revision the mirror follows. A bare name is a BRANCH and is
+	// tracked: every poll pulls whatever upstream moved it to. Two spellings instead
+	// PIN the mirror to an immutable revision that no upstream push can change:
+	//
+	//	refs/tags/<name>       a tag
+	//	<40- or 64-char hex>   a commit id
+	//
+	// Anything unqualified stays a branch, so every configuration written before
+	// pinning existed resolves down the identical path, byte for byte.
+	//
+	// It is one field rather than two because a syncer follows exactly one revision;
+	// the operator-facing surface (catalog.commons.branch vs .ref) is where the two
+	// intentions are kept apart, and config.ApplyDefaults normalises a `ref` into the
+	// spellings above. Same contract, read from its two ends.
 	Branch string
 	Dir    string
 	Token  TokenFunc // nil / empty => anonymous (public repo)
@@ -67,6 +116,78 @@ func (s *Syncer) branch() string {
 		return "main"
 	}
 	return s.Branch
+}
+
+// pin returns the immutable revision this syncer is frozen at, and whether it is
+// pinned at all. An unpinned syncer tracks branch().
+func (s *Syncer) pin() (plumbing.Revision, bool) {
+	if strings.HasPrefix(s.Branch, tagRefPrefix) || isObjectID(s.Branch) {
+		return plumbing.Revision(s.Branch), true
+	}
+	return "", false
+}
+
+// cloneOptions selects what the initial clone fetches. A branch and a tag are both
+// refs, so both stay the cheap single-ref clone this syncer has always done. A bare
+// commit id is not a ref and cannot be a clone target at all, so that case clones
+// the repository's refs and checkoutPin moves HEAD onto the commit afterwards.
+func (s *Syncer) cloneOptions(auth *githttp.BasicAuth) *git.CloneOptions {
+	o := &git.CloneOptions{URL: s.URL, Auth: auth}
+	rev, pinned := s.pin()
+	switch {
+	case !pinned:
+		o.ReferenceName = plumbing.NewBranchReferenceName(s.branch())
+		o.SingleBranch = true
+	case strings.HasPrefix(string(rev), tagRefPrefix):
+		o.ReferenceName = plumbing.ReferenceName(rev)
+		o.SingleBranch = true
+	}
+	return o
+}
+
+// checkoutPin puts the mirror on the pinned revision, fetching ONLY when the mirror
+// has never seen it — a fresh commit-id pin, or an operator who reviewed upstream,
+// bumped the pin and restarted onto the checkout they already had.
+//
+// A pin cannot move, so the steady state (the mirror is already there) costs one
+// local resolve and no network at all. That is what keeps a periodic poll on a
+// pinned corpus free rather than re-cloning on every tick; the poll is kept, not
+// skipped, because it is also what retries a failed re-index and re-materialises a
+// checkout that went missing.
+//
+// A pin the repository does not contain is an error, never a silent fallback: the
+// operator named a revision and must not end up quietly indexing a different one.
+func (s *Syncer) checkoutPin(ctx context.Context, repo *git.Repository, auth *githttp.BasicAuth, rev plumbing.Revision) error {
+	hash, err := repo.ResolveRevision(rev)
+	if err != nil {
+		ferr := repo.FetchContext(ctx, &git.FetchOptions{
+			Auth:     auth,
+			RefSpecs: pinRefSpecs,
+			Tags:     git.AllTags,
+			Force:    true,
+		})
+		if ferr != nil && !errors.Is(ferr, git.NoErrAlreadyUpToDate) {
+			return fmt.Errorf("fetch for pinned revision %s: %w", rev, ferr)
+		}
+		if hash, err = repo.ResolveRevision(rev); err != nil {
+			return fmt.Errorf("pinned revision %s not found in %s: %w", rev, s.URL, err)
+		}
+	}
+	// ResolveRevision (rather than a raw ref lookup) peels an annotated tag, so hash
+	// is a COMMIT and comparable to HEAD, which always is one. Checkout would peel a
+	// tag object on its own; what the peel buys is that the comparison below can
+	// actually short-circuit, instead of re-checking out the same tree every poll.
+	if head, herr := repo.Head(); herr == nil && head.Hash() == *hash {
+		return nil
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+	if err := wt.Checkout(&git.CheckoutOptions{Hash: *hash, Force: true}); err != nil {
+		return fmt.Errorf("checkout pinned revision %s: %w", rev, err)
+	}
+	return nil
 }
 
 // diffPaths lists the paths that differ between two commits. Any failure
@@ -105,27 +226,55 @@ func (s *Syncer) diffPaths(repo *git.Repository, from, to plumbing.Hash) *SyncDe
 	return d
 }
 
-// Sync clones the repo if the mirror is absent, otherwise fast-forwards it, and
-// reports whether HEAD moved since the previous sync (true on the first sync).
-// The returned *SyncDelta names the changed/removed paths between the previous
-// and new revision; it is nil ("unknown") on the first sync or any diff error,
-// which the caller must treat as a full reload.
+// Sync clones the repo if the mirror is absent, otherwise brings it to the wanted
+// revision, and reports whether HEAD moved since the previous sync (true on the
+// first sync). The returned *SyncDelta names the changed/removed paths between the
+// previous and new revision; it is nil ("unknown") on the first sync or any diff
+// error, which the caller must treat as a full reload.
+//
+// A pinned Syncer (see Branch) differs in exactly one place — how an existing
+// mirror is advanced. Clone, corrupt-mirror recovery and the HEAD-gated change
+// detection below are shared, deliberately: pinning changes which revision the
+// mirror lands on, not how the syncer decides something moved. A pin therefore
+// reports changed=true once, then changed=false forever, and Run's re-index gate
+// does the rest with no special case of its own.
 func (s *Syncer) Sync(ctx context.Context) (bool, *SyncDelta, error) {
 	auth, err := s.auth(ctx)
 	if err != nil {
 		return false, nil, fmt.Errorf("auth: %w", err)
 	}
-	ref := plumbing.NewBranchReferenceName(s.branch())
-	clone := func() (*git.Repository, error) {
-		repo, cerr := git.PlainCloneContext(ctx, s.Dir, false, &git.CloneOptions{
-			URL:           s.URL,
-			ReferenceName: ref,
+	pinRev, pinned := s.pin()
+	// advance brings an EXISTING mirror to the wanted revision: a pull for a tracked
+	// branch, a (normally network-free) checkout for a pin.
+	advance := func(repo *git.Repository) error {
+		if pinned {
+			return s.checkoutPin(ctx, repo, auth, pinRev)
+		}
+		wt, werr := repo.Worktree()
+		if werr != nil {
+			return werr
+		}
+		perr := wt.PullContext(ctx, &git.PullOptions{
+			ReferenceName: plumbing.NewBranchReferenceName(s.branch()),
 			SingleBranch:  true,
 			Auth:          auth,
+			Force:         true,
 		})
+		if perr != nil && !errors.Is(perr, git.NoErrAlreadyUpToDate) {
+			return perr
+		}
+		return nil
+	}
+	clone := func() (*git.Repository, error) {
+		repo, cerr := git.PlainCloneContext(ctx, s.Dir, false, s.cloneOptions(auth))
+		if cerr == nil && pinned {
+			// A tag clone already landed on the pin and this is a no-op; a commit-id
+			// clone landed on the default branch and still has to move.
+			cerr = s.checkoutPin(ctx, repo, auth, pinRev)
+		}
 		if cerr != nil {
 			// Drop the partial checkout so an interrupted/failed clone can't leave a
-			// half-written .git that wedges every future Pull — the next tick re-clones.
+			// half-written .git that wedges every future sync — the next tick re-clones.
 			_ = os.RemoveAll(s.Dir)
 			return nil, cerr
 		}
@@ -146,20 +295,8 @@ func (s *Syncer) Sync(ctx context.Context) (bool, *SyncDelta, error) {
 		if repo, err = clone(); err != nil {
 			return false, nil, err
 		}
-	} else {
-		wt, werr := repo.Worktree()
-		if werr != nil {
-			return false, nil, werr
-		}
-		perr := wt.PullContext(ctx, &git.PullOptions{
-			ReferenceName: ref,
-			SingleBranch:  true,
-			Auth:          auth,
-			Force:         true,
-		})
-		if perr != nil && !errors.Is(perr, git.NoErrAlreadyUpToDate) {
-			return false, nil, perr
-		}
+	} else if err = advance(repo); err != nil {
+		return false, nil, err
 	}
 	head, err := repo.Head()
 	if err != nil {

--- a/internal/catalog/sync.go
+++ b/internal/catalog/sync.go
@@ -20,12 +20,13 @@ import (
 	"github.com/Smana/runlore/internal/gitrev"
 )
 
-// pinRefSpecs is what a pin fetch asks for: every branch and every tag. A pin may
-// name any commit in the repository, so narrowing this would make "bump the pin"
-// work for some revisions and silently not for others.
+// pinRefSpecs is what a pin fetch asks for: every branch. A pin may name any commit
+// in the repository, so narrowing this would make "bump the pin" work for some
+// revisions and silently not for others. Tags are NOT listed here: the fetch below
+// sets Tags: git.AllTags, and go-git appends +refs/tags/*:refs/tags/* itself for
+// that mode — spelling it out again just fetched the same refspec twice.
 var pinRefSpecs = []gitcfg.RefSpec{
 	"+refs/heads/*:refs/remotes/origin/*",
-	"+refs/tags/*:refs/tags/*",
 }
 
 // SyncDelta names the repo-relative paths that changed between two synced

--- a/internal/catalog/sync_pinned_test.go
+++ b/internal/catalog/sync_pinned_test.go
@@ -21,36 +21,15 @@ import (
 // commit, so anything that checks it out has to peel it first.
 func tagUpstream(t *testing.T, src, tag string) plumbing.Hash {
 	t.Helper()
-	repo, err := git.PlainOpen(src)
-	if err != nil {
-		t.Fatalf("tagUpstream: open: %v", err)
-	}
-	head, err := repo.Head()
-	if err != nil {
-		t.Fatalf("tagUpstream: head: %v", err)
-	}
-	_, err = repo.CreateTag(tag, head.Hash(), &git.CreateTagOptions{
+	head := upstreamHead(t, src)
+	_, err := openUpstream(t, src).CreateTag(tag, head, &git.CreateTagOptions{
 		Tagger:  &object.Signature{Name: "t", Email: "t@example.com", When: time.Unix(1_700_000_000, 0)},
 		Message: tag,
 	})
 	if err != nil {
 		t.Fatalf("tagUpstream: tag %s: %v", tag, err)
 	}
-	return head.Hash()
-}
-
-// upstreamHead returns the current HEAD commit of the upstream repo at src.
-func upstreamHead(t *testing.T, src string) plumbing.Hash {
-	t.Helper()
-	repo, err := git.PlainOpen(src)
-	if err != nil {
-		t.Fatalf("upstreamHead: open: %v", err)
-	}
-	head, err := repo.Head()
-	if err != nil {
-		t.Fatalf("upstreamHead: head: %v", err)
-	}
-	return head.Hash()
+	return head
 }
 
 func exists(t *testing.T, path string) bool {
@@ -213,9 +192,7 @@ func TestSyncPinnedFetchesARevisionTheMirrorHasNotSeen(t *testing.T) {
 func TestSyncPinnedRecoversFromCorruptMirror(t *testing.T) {
 	src, _ := pinnedUpstream(t)
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("garbage"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	plantCorruptMirror(t, dir)
 	s := &Syncer{URL: src, Branch: "refs/tags/v1.0.0", Dir: dir, Log: testLogger()}
 	if _, _, err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("a corrupt mirror must be discarded and re-cloned at the pin, got: %v", err)
@@ -272,23 +249,15 @@ func TestRunRetriesReindexOnAPinnedRevision(t *testing.T) {
 			return nil
 		})
 	}()
-	waitCycle := func() {
-		t.Helper()
-		select {
-		case tick <- time.Time{}:
-		case <-time.After(30 * time.Second):
-			t.Fatal("Run never came back for a tick — the poll loop is stuck")
-		}
-	}
-	waitCycle() // accepted only once the initial (failing) sync finished
+	waitCycle(t, tick) // accepted only once the initial (failing) sync finished
 	if n := calls.Load(); n != 1 {
 		t.Fatalf("initial sync fired onSync %d times, want 1", n)
 	}
-	waitCycle() // drains the retry poll started by the send above
+	waitCycle(t, tick) // drains the retry poll started by the send above
 	if n := calls.Load(); n != 2 {
 		t.Fatalf("a failed re-index must be retried on the next tick even though the pin cannot move, fired %d", n)
 	}
-	waitCycle() // the retry succeeded; nothing may fire again
+	waitCycle(t, tick) // the retry succeeded; nothing may fire again
 	if n := calls.Load(); n != 2 {
 		t.Fatalf("after a successful re-index a pinned poll must not re-index again, fired %d", n)
 	}

--- a/internal/catalog/sync_pinned_test.go
+++ b/internal/catalog/sync_pinned_test.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// tagUpstream puts an ANNOTATED tag on the current upstream HEAD and returns the
+// commit it names. Annotated is what real releases use, and it is the case that
+// breaks a naive implementation: the tag ref resolves to a tag OBJECT, not to the
+// commit, so anything that checks it out has to peel it first.
+func tagUpstream(t *testing.T, src, tag string) plumbing.Hash {
+	t.Helper()
+	repo, err := git.PlainOpen(src)
+	if err != nil {
+		t.Fatalf("tagUpstream: open: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("tagUpstream: head: %v", err)
+	}
+	_, err = repo.CreateTag(tag, head.Hash(), &git.CreateTagOptions{
+		Tagger:  &object.Signature{Name: "t", Email: "t@example.com", When: time.Unix(1_700_000_000, 0)},
+		Message: tag,
+	})
+	if err != nil {
+		t.Fatalf("tagUpstream: tag %s: %v", tag, err)
+	}
+	return head.Hash()
+}
+
+// upstreamHead returns the current HEAD commit of the upstream repo at src.
+func upstreamHead(t *testing.T, src string) plumbing.Hash {
+	t.Helper()
+	repo, err := git.PlainOpen(src)
+	if err != nil {
+		t.Fatalf("upstreamHead: open: %v", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("upstreamHead: head: %v", err)
+	}
+	return head.Hash()
+}
+
+func exists(t *testing.T, path string) bool {
+	t.Helper()
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// pinnedUpstream builds an upstream with a v1.0.0 tag, then moves on past it:
+//
+//	init.md, tagged.md   <- refs/tags/v1.0.0
+//	later.md             <- main
+//
+// The pinned mirror must hold the first two and never the third.
+func pinnedUpstream(t *testing.T) (src string, tagged plumbing.Hash) {
+	t.Helper()
+	src = initBareUpstream(t)
+	commitToUpstream(t, src, "tagged.md", "# tagged")
+	tagged = tagUpstream(t, src, "v1.0.0")
+	commitToUpstream(t, src, "later.md", "# later")
+	return src, tagged
+}
+
+// TestSyncPinnedTagChecksOutThatRevision: the whole point of the option. The
+// mirror must hold the tagged tree, not whatever the default branch moved on to.
+func TestSyncPinnedTagChecksOutThatRevision(t *testing.T) {
+	src, tagged := pinnedUpstream(t)
+	dir := t.TempDir()
+	s := &Syncer{URL: src, Branch: "refs/tags/v1.0.0", Dir: dir, Log: testLogger()}
+
+	changed, _, err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if !changed {
+		t.Fatal("the first sync must report changed=true so the catalog indexes it")
+	}
+	if !exists(t, filepath.Join(dir, "tagged.md")) {
+		t.Error("the tagged revision's content is missing from the mirror")
+	}
+	if exists(t, filepath.Join(dir, "later.md")) {
+		t.Error("a commit made AFTER the pinned tag reached the mirror — the pin did not hold")
+	}
+	if es, _, _ := Load(dir); len(es) != 2 {
+		t.Errorf("indexed %d entries, want 2 (init.md + tagged.md)", len(es))
+	}
+	if s.lastRev != tagged {
+		t.Errorf("lastRev = %s, want the commit the annotated tag names (%s) — an unpeeled tag object breaks the delta", s.lastRev, tagged)
+	}
+}
+
+// TestSyncPinnedCommitChecksOutThatRevision: same guarantee via a bare object id,
+// which cannot be a clone target at all and has to be checked out after the fetch.
+func TestSyncPinnedCommitChecksOutThatRevision(t *testing.T) {
+	src := initBareUpstream(t)
+	commitToUpstream(t, src, "pinned.md", "# pinned")
+	want := upstreamHead(t, src)
+	commitToUpstream(t, src, "later.md", "# later")
+
+	dir := t.TempDir()
+	s := &Syncer{URL: src, Branch: want.String(), Dir: dir, Log: testLogger()}
+	changed, _, err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if !changed {
+		t.Fatal("the first sync must report changed=true")
+	}
+	if !exists(t, filepath.Join(dir, "pinned.md")) {
+		t.Error("the pinned commit's content is missing from the mirror")
+	}
+	if exists(t, filepath.Join(dir, "later.md")) {
+		t.Error("a later commit reached the mirror — the pin did not hold")
+	}
+	if s.lastRev != want {
+		t.Errorf("lastRev = %s, want %s", s.lastRev, want)
+	}
+}
+
+// TestSyncPinnedRevisionIgnoresUpstreamMovement: upstream keeps committing; the
+// pinned mirror reports no change and re-indexes nothing. Without this the option
+// would be cosmetic — the operator would still get unreviewed upstream edits.
+func TestSyncPinnedRevisionIgnoresUpstreamMovement(t *testing.T) {
+	src, _ := pinnedUpstream(t)
+	dir := t.TempDir()
+	s := &Syncer{URL: src, Branch: "refs/tags/v1.0.0", Dir: dir, Log: testLogger()}
+	if _, _, err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+
+	commitToUpstream(t, src, "even-later.md", "# even later")
+	changed, delta, err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if changed || delta != nil {
+		t.Fatalf("a pinned sync must never move: changed=%v delta=%+v", changed, delta)
+	}
+	if exists(t, filepath.Join(dir, "even-later.md")) {
+		t.Error("an upstream commit made after the pin reached the mirror")
+	}
+}
+
+// TestSyncPinnedPollTouchesNoRemote: a pin cannot move, so re-checking it must not
+// cost a fetch every interval. Proven by making the remote unreachable (the local
+// upstream is renamed away) and requiring the poll to still succeed — any network
+// call would fail there.
+func TestSyncPinnedPollTouchesNoRemote(t *testing.T) {
+	src, _ := pinnedUpstream(t)
+	dir := t.TempDir()
+	s := &Syncer{URL: src, Branch: "refs/tags/v1.0.0", Dir: dir, Log: testLogger()}
+	if _, _, err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+
+	if err := os.Rename(src, src+".gone"); err != nil {
+		t.Fatalf("rename upstream: %v", err)
+	}
+	changed, _, err := s.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("a pinned poll must resolve locally, but it reached for the remote: %v", err)
+	}
+	if changed {
+		t.Fatal("a pinned poll must report changed=false")
+	}
+}
+
+// TestSyncPinnedFetchesARevisionTheMirrorHasNotSeen: the operator bumps the pin
+// after reviewing what upstream changed, and the process restarts onto the mirror
+// it already has. The new tag is not in that checkout, so the syncer has to fetch
+// before it can honour the pin.
+func TestSyncPinnedFetchesARevisionTheMirrorHasNotSeen(t *testing.T) {
+	src, _ := pinnedUpstream(t)
+	dir := t.TempDir()
+	if _, _, err := (&Syncer{URL: src, Branch: "refs/tags/v1.0.0", Dir: dir, Log: testLogger()}).Sync(context.Background()); err != nil {
+		t.Fatalf("v1 Sync: %v", err)
+	}
+
+	commitToUpstream(t, src, "v2-only.md", "# v2")
+	want := tagUpstream(t, src, "v2.0.0")
+
+	bumped := &Syncer{URL: src, Branch: "refs/tags/v2.0.0", Dir: dir, Log: testLogger()}
+	changed, _, err := bumped.Sync(context.Background())
+	if err != nil {
+		t.Fatalf("bumped Sync: %v", err)
+	}
+	if !changed {
+		t.Fatal("moving the pin must report changed=true so the catalog re-indexes")
+	}
+	if bumped.lastRev != want {
+		t.Errorf("lastRev = %s, want %s", bumped.lastRev, want)
+	}
+	if !exists(t, filepath.Join(dir, "v2-only.md")) {
+		t.Error("the bumped pin's content is missing — the syncer never fetched the new tag")
+	}
+}
+
+// TestSyncPinnedRecoversFromCorruptMirror: the wedge fix has to hold on the pinned
+// path too — its clone options differ, so it is a genuinely separate code path.
+func TestSyncPinnedRecoversFromCorruptMirror(t *testing.T) {
+	src, _ := pinnedUpstream(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := &Syncer{URL: src, Branch: "refs/tags/v1.0.0", Dir: dir, Log: testLogger()}
+	if _, _, err := s.Sync(context.Background()); err != nil {
+		t.Fatalf("a corrupt mirror must be discarded and re-cloned at the pin, got: %v", err)
+	}
+	if !exists(t, filepath.Join(dir, "tagged.md")) {
+		t.Error("recovery clone did not land on the pinned revision")
+	}
+}
+
+// TestSyncPinnedRevisionNotFoundFails: a typo'd pin must surface as an error, not
+// as a mirror quietly sitting on the default branch. Fail closed — the operator
+// asked for a specific revision and must not silently get a different one.
+//
+// Both rows are needed and they fail in different places: a missing tag is a ref,
+// so the clone itself cannot find it; a missing commit id is not a ref, so the
+// clone succeeds and only the post-fetch resolve can catch it.
+func TestSyncPinnedRevisionNotFoundFails(t *testing.T) {
+	for _, tc := range []struct{ name, rev string }{
+		{"tag", "refs/tags/v9.9.9"},
+		{"commit id", "0123456789abcdef0123456789abcdef01234567"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src, _ := pinnedUpstream(t)
+			dir := t.TempDir()
+			s := &Syncer{URL: src, Branch: tc.rev, Dir: dir, Log: testLogger()}
+			if _, _, err := s.Sync(context.Background()); err == nil {
+				t.Fatal("a pin that does not exist upstream must fail the sync")
+			}
+			if exists(t, filepath.Join(dir, "tagged.md")) {
+				t.Error("a failed pin left a checkout behind; the catalog would index a revision nobody asked for")
+			}
+		})
+	}
+}
+
+// TestRunRetriesReindexOnAPinnedRevision: Run rolls lastRev back when the re-index
+// fails so the next tick retries. With a pin, HEAD never moves again — if the retry
+// leaned on upstream movement the catalog would stay empty forever.
+func TestRunRetriesReindexOnAPinnedRevision(t *testing.T) {
+	src, _ := pinnedUpstream(t)
+	tick := make(chan time.Time)
+	s := &Syncer{URL: src, Branch: "refs/tags/v1.0.0", Dir: t.TempDir(), Log: testLogger(), tick: tick}
+
+	var calls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.Run(ctx, time.Hour, func(*SyncDelta) error {
+			if calls.Add(1) == 1 {
+				return context.DeadlineExceeded // first re-index fails
+			}
+			return nil
+		})
+	}()
+	waitCycle := func() {
+		t.Helper()
+		select {
+		case tick <- time.Time{}:
+		case <-time.After(30 * time.Second):
+			t.Fatal("Run never came back for a tick — the poll loop is stuck")
+		}
+	}
+	waitCycle() // accepted only once the initial (failing) sync finished
+	if n := calls.Load(); n != 1 {
+		t.Fatalf("initial sync fired onSync %d times, want 1", n)
+	}
+	waitCycle() // drains the retry poll started by the send above
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("a failed re-index must be retried on the next tick even though the pin cannot move, fired %d", n)
+	}
+	waitCycle() // the retry succeeded; nothing may fire again
+	if n := calls.Load(); n != 2 {
+		t.Fatalf("after a successful re-index a pinned poll must not re-index again, fired %d", n)
+	}
+	cancel()
+	<-done
+}

--- a/internal/catalog/sync_test.go
+++ b/internal/catalog/sync_test.go
@@ -71,14 +71,53 @@ func initBareUpstream(t *testing.T) string {
 	return src
 }
 
+// openUpstream opens the test upstream repo at src.
+func openUpstream(t *testing.T, src string) *git.Repository {
+	t.Helper()
+	repo, err := git.PlainOpen(src)
+	if err != nil {
+		t.Fatalf("open upstream %s: %v", src, err)
+	}
+	return repo
+}
+
+// upstreamHead returns the current HEAD commit of the upstream repo at src.
+func upstreamHead(t *testing.T, src string) plumbing.Hash {
+	t.Helper()
+	head, err := openUpstream(t, src).Head()
+	if err != nil {
+		t.Fatalf("upstream %s head: %v", src, err)
+	}
+	return head.Hash()
+}
+
+// plantCorruptMirror writes a `.git` that PlainOpen cannot read while Stat still
+// sees it — the "an earlier clone was killed mid-write" state Sync has to recover
+// from rather than erroring on every future poll forever.
+func plantCorruptMirror(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("garbage"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// waitCycle hands Run one poll tick. Run only receives from the (unbuffered) tick
+// channel BETWEEN poll cycles, so a send that completes proves the previous cycle
+// has finished. That is the synchronisation point which replaces every sleep.
+func waitCycle(t *testing.T, tick chan<- time.Time) {
+	t.Helper()
+	select {
+	case tick <- time.Time{}:
+	case <-time.After(30 * time.Second): // a hang, not a timing assumption
+		t.Fatal("Run never came back for a tick — the poll loop is stuck")
+	}
+}
+
 // commitToUpstream opens the repo at src, writes a file (creating parent dirs
 // as needed), and commits it.
 func commitToUpstream(t *testing.T, src, name, content string) {
 	t.Helper()
-	repo, err := git.PlainOpen(src)
-	if err != nil {
-		t.Fatalf("commitToUpstream: open: %v", err)
-	}
+	repo := openUpstream(t, src)
 	if dir := filepath.Dir(filepath.Join(src, name)); dir != src {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			t.Fatalf("commitToUpstream: mkdir: %v", err)
@@ -164,10 +203,7 @@ func commit(t *testing.T, repo *git.Repository, dir, name, content string) {
 func TestSyncRecoversFromCorruptMirror(t *testing.T) {
 	src := initBareUpstream(t)
 	dir := t.TempDir()
-	// Plant a corrupt mirror: a `.git` that PlainOpen cannot read (Stat still sees it).
-	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("garbage"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	plantCorruptMirror(t, dir)
 	s := &Syncer{URL: src, Branch: "main", Dir: dir, Log: testLogger()}
 	if _, _, err := s.Sync(context.Background()); err != nil {
 		t.Fatalf("Sync should recover by re-cloning a corrupt mirror, got: %v", err)
@@ -233,26 +269,14 @@ func TestRunReloadsOnlyOnChange(t *testing.T) {
 		s.Run(ctx, time.Hour, func(*SyncDelta) error { calls.Add(1); return nil }) // interval unused: tick drives the loop
 	}()
 
-	// Run only receives from the (unbuffered) tick channel between poll cycles, so a
-	// send that completes proves the PREVIOUS cycle has finished. That is the
-	// synchronisation point which replaces every sleep.
-	waitCycle := func() {
-		t.Helper()
-		select {
-		case tick <- time.Time{}:
-		case <-time.After(30 * time.Second): // a hang, not a timing assumption
-			t.Fatal("Run never came back for a tick — the poll loop is stuck")
-		}
-	}
-
 	// The first send is accepted only once the INITIAL sync has completed.
-	waitCycle()
+	waitCycle(t, tick)
 	if n := calls.Load(); n != 1 {
 		t.Fatalf("initial sync must fire onSync exactly once, fired %d", n)
 	}
 
 	// That tick ran a poll against an unchanged upstream; the next send proves it ended.
-	waitCycle()
+	waitCycle(t, tick)
 	if n := calls.Load(); n != 1 {
 		t.Fatalf("with no HEAD change onSync must not fire again, fired %d", n)
 	}
@@ -270,8 +294,8 @@ func TestRunReloadsOnlyOnChange(t *testing.T) {
 	// after the commit was already visible has completed. onSync fires on exactly one of
 	// the two — whichever first sees rev != lastRev — so the count is 2 either way.
 	commitToUpstream(t, src, "new.md", "# new")
-	waitCycle()
-	waitCycle()
+	waitCycle(t, tick)
+	waitCycle(t, tick)
 	if n := calls.Load(); n != 2 {
 		t.Fatalf("a new upstream commit must trigger exactly one more onSync, total %d (want 2)", n)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -561,10 +561,35 @@ func isHex(s string) bool {
 	return true
 }
 
+// A `branch` key means "track whatever upstream moves this to", so a pinned
+// spelling under one promises an operator the opposite of what it delivers. These
+// say what to write INSTEAD; the rule itself is rejectPinnedBranch, stated once.
+const (
+	commonsBranchRemedy = "use catalog.commons.ref to pin a tag or a commit — branch tracks a moving branch"
+	// The operator's OWN catalog shares the syncer with the commons, so a pinned
+	// spelling there would work — and that is the problem. Pinning is for a corpus you
+	// do not control; this one you do.
+	catalogGitBranchRemedy = "your own catalog is deliberately not pinnable, because the curator opens PRs against it and a frozen read root leaves \"merged\" and \"in use\" diverging forever with no signal. Only catalog.commons (a repo you do not control) can be pinned, with `ref`"
+)
+
+// rejectPinnedBranch fails when the value of a `branch` key names an immutable
+// revision. Neither branch key can honour one today either (both clone
+// refs/heads/refs/tags/…), so no configuration that works is broken by catching it
+// at load instead of at clone.
+func rejectPinnedBranch(key, branch, remedy string) error {
+	if !gitrev.IsPinned(branch) {
+		return nil
+	}
+	return fmt.Errorf("%s = %q names an immutable revision: %s", key, branch, remedy)
+}
+
 // validateCommonsRevision fails closed on any way of asking for two revisions at
 // once, or for a "pin" that is not actually immutable. Every case here would
 // otherwise leave an operator believing their corpus is frozen while it moves —
 // the precise belief the option exists to make true.
+//
+// The commons is where the two keys really differ: it has the `ref` escape hatch
+// that catalog.git deliberately does not.
 func validateCommonsRevision(cc CatalogCommons) error {
 	// Both keys set. ApplyDefaults folds a ref into an EMPTY branch only, so the two
 	// being non-empty and disagreeing is exactly "the operator wrote both".
@@ -573,12 +598,7 @@ func validateCommonsRevision(cc CatalogCommons) error {
 	}
 	switch {
 	case cc.Ref == "":
-		// A pinned spelling under `branch` would freeze the corpus while the key says
-		// it tracks one. It cannot work today either (it clones refs/heads/refs/tags/…),
-		// so no configuration that works is broken by rejecting it at load.
-		if gitrev.IsPinned(cc.Branch) {
-			return fmt.Errorf("catalog.commons.branch = %q names an immutable revision; use catalog.commons.ref to pin a tag or commit — branch tracks a moving branch", cc.Branch)
-		}
+		return rejectPinnedBranch("catalog.commons.branch", cc.Branch, commonsBranchRemedy)
 	case strings.HasPrefix(cc.Ref, "refs/") && !gitrev.IsTagRef(cc.Ref):
 		// refs/heads/main under `ref` is the dangerous one: the syncer would treat any
 		// qualified ref as a pin and never fetch again, silently freezing the commons
@@ -588,18 +608,6 @@ func validateCommonsRevision(cc CatalogCommons) error {
 		return fmt.Errorf("catalog.commons.ref = %q looks like an abbreviated commit id; pin the full 40-character SHA (abbreviations are ambiguous)", cc.Ref)
 	}
 	return nil
-}
-
-// validateCatalogGitRevision keeps the operator's OWN catalog on a tracked branch.
-// It shares the syncer with the commons, so a pinned spelling here would work —
-// and that is the problem: the curator opens PRs against this repo, so a frozen
-// read root makes "merged" and "in use" diverge forever with no signal. Pinning is
-// for a corpus you do not control; this one you do.
-func validateCatalogGitRevision(g CatalogGit) error {
-	if g.URL == "" || !gitrev.IsPinned(g.Branch) {
-		return nil
-	}
-	return fmt.Errorf("catalog.git.branch = %q names an immutable revision, but your own catalog is deliberately not pinnable: the curator's merged PRs must reach the index. Only catalog.commons (a repo you do not control) can be pinned with `ref`", g.Branch)
 }
 
 // Outcome configures the learning-loop outcome ledger.
@@ -1452,8 +1460,10 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("notify.matrix.feedback_reactions requires outcome.ledger_path: ratings are recorded in the outcome ledger")
 		}
 	}
-	if err := validateCatalogGitRevision(c.Catalog.Git); err != nil {
-		return err
+	if g := c.Catalog.Git; g.URL != "" {
+		if err := rejectPinnedBranch("catalog.git.branch", g.Branch, catalogGitBranchRemedy); err != nil {
+			return err
+		}
 	}
 	// Commons catalog (opt-in): a second, read-only root. Fail closed on a
 	// misconfiguration rather than degrading to a silently-absent corpus.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Smana/runlore/internal/gitrev"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/sourcerepo"
 )
@@ -542,20 +543,10 @@ type CatalogCommons struct {
 	TokenEnv string `yaml:"token_env"`
 }
 
-// tagRefPrefix is the fully-qualified namespace of a git tag.
-const tagRefPrefix = "refs/tags/"
-
-// isObjectID reports whether s is a full-length git object id (SHA-1 40 hex chars,
-// SHA-256 64). Abbreviations are rejected on purpose: they are ambiguous, and this
-// is a trust knob — "the corpus my agent reads" deserves an unambiguous name.
-func isObjectID(s string) bool {
-	if len(s) != 40 && len(s) != 64 {
-		return false
-	}
-	return isHex(s)
-}
-
-// isHex reports whether s is non-empty and made only of hex digits.
+// isHex reports whether s is non-empty and made only of hex digits. It backs the
+// "did you mean a commit id?" diagnostic below, and so must also fire on the
+// abbreviations gitrev.IsObjectID rejects — odd lengths included, which is why it
+// is not encoding/hex.
 func isHex(s string) bool {
 	if s == "" {
 		return false
@@ -570,25 +561,6 @@ func isHex(s string) bool {
 	return true
 }
 
-// isPinnedRevision reports whether s spells an IMMUTABLE revision. This is the
-// operator-facing half of a contract shared with internal/catalog: the syncer takes
-// a single revision string and tells a pin from a branch by exactly this rule
-// (catalog.Syncer.pin). Config decides what may be written; the syncer decides what
-// the written string means. Change one and the other must follow.
-func isPinnedRevision(s string) bool {
-	return strings.HasPrefix(s, tagRefPrefix) || isObjectID(s)
-}
-
-// pinnedRevision spells a `ref` the way git spells it, which is what makes the pin
-// legible to the syncer without a second field on the wire. A bare name is a tag —
-// the only kind of immutable revision that has a name.
-func pinnedRevision(ref string) string {
-	if isPinnedRevision(ref) {
-		return ref
-	}
-	return tagRefPrefix + ref
-}
-
 // validateCommonsRevision fails closed on any way of asking for two revisions at
 // once, or for a "pin" that is not actually immutable. Every case here would
 // otherwise leave an operator believing their corpus is frozen while it moves —
@@ -596,7 +568,7 @@ func pinnedRevision(ref string) string {
 func validateCommonsRevision(cc CatalogCommons) error {
 	// Both keys set. ApplyDefaults folds a ref into an EMPTY branch only, so the two
 	// being non-empty and disagreeing is exactly "the operator wrote both".
-	if cc.Ref != "" && cc.Branch != "" && cc.Branch != pinnedRevision(cc.Ref) {
+	if cc.Ref != "" && cc.Branch != "" && cc.Branch != gitrev.QualifyTag(cc.Ref) {
 		return fmt.Errorf("catalog.commons: set either branch (%q, tracks a moving branch) or ref (%q, pins an immutable revision), not both", cc.Branch, cc.Ref)
 	}
 	switch {
@@ -604,15 +576,15 @@ func validateCommonsRevision(cc CatalogCommons) error {
 		// A pinned spelling under `branch` would freeze the corpus while the key says
 		// it tracks one. It cannot work today either (it clones refs/heads/refs/tags/…),
 		// so no configuration that works is broken by rejecting it at load.
-		if isPinnedRevision(cc.Branch) {
+		if gitrev.IsPinned(cc.Branch) {
 			return fmt.Errorf("catalog.commons.branch = %q names an immutable revision; use catalog.commons.ref to pin a tag or commit — branch tracks a moving branch", cc.Branch)
 		}
-	case strings.HasPrefix(cc.Ref, "refs/") && !strings.HasPrefix(cc.Ref, tagRefPrefix):
+	case strings.HasPrefix(cc.Ref, "refs/") && !gitrev.IsTagRef(cc.Ref):
 		// refs/heads/main under `ref` is the dangerous one: the syncer would treat any
 		// qualified ref as a pin and never fetch again, silently freezing the commons
 		// on whatever the branch pointed at the day it was cloned.
-		return fmt.Errorf("catalog.commons.ref = %q is not an immutable revision (only %s… or a full commit id can be pinned); use catalog.commons.branch to track a branch", cc.Ref, tagRefPrefix)
-	case isHex(cc.Ref) && len(cc.Ref) >= 7 && !isObjectID(cc.Ref):
+		return fmt.Errorf("catalog.commons.ref = %q is not an immutable revision (only %s… or a full commit id can be pinned); use catalog.commons.branch to track a branch", cc.Ref, gitrev.TagRefPrefix)
+	case isHex(cc.Ref) && len(cc.Ref) >= 7 && !gitrev.IsObjectID(cc.Ref):
 		return fmt.Errorf("catalog.commons.ref = %q looks like an abbreviated commit id; pin the full 40-character SHA (abbreviations are ambiguous)", cc.Ref)
 	}
 	return nil
@@ -624,7 +596,7 @@ func validateCommonsRevision(cc CatalogCommons) error {
 // read root makes "merged" and "in use" diverge forever with no signal. Pinning is
 // for a corpus you do not control; this one you do.
 func validateCatalogGitRevision(g CatalogGit) error {
-	if g.URL == "" || !isPinnedRevision(g.Branch) {
+	if g.URL == "" || !gitrev.IsPinned(g.Branch) {
 		return nil
 	}
 	return fmt.Errorf("catalog.git.branch = %q names an immutable revision, but your own catalog is deliberately not pinnable: the curator's merged PRs must reach the index. Only catalog.commons (a repo you do not control) can be pinned with `ref`", g.Branch)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -515,8 +515,24 @@ type Catalog struct {
 // rather than one cluster's workload. They ground kb_search, which applies no such
 // filter. That is genuine day-one value; claiming recall would not be.
 type CatalogCommons struct {
-	URL      string   `yaml:"url"`      // shared catalog repo; empty disables the commons root
-	Branch   string   `yaml:"branch"`   // default "main"
+	URL string `yaml:"url"` // shared catalog repo; empty disables the commons root
+	// Branch tracks a MOVING branch: whatever upstream pushes there reaches the index
+	// at the next interval. Default "main".
+	//
+	// After ApplyDefaults it carries the effective revision handed to the syncer,
+	// which is a tag ref or a commit id when Ref pinned it — a syncer follows exactly
+	// one revision and there is no honest way to hand it two.
+	Branch string `yaml:"branch"`
+	// Ref pins the commons to an IMMUTABLE revision — a tag name (`v1.2.0`, also
+	// accepted fully qualified as `refs/tags/v1.2.0`) or a full 40-character commit
+	// id — instead of tracking a branch. Mutually exclusive with Branch.
+	//
+	// The commons is synced from a repository the operator does not own, and its
+	// entries reach the model mid-incident through kb_search. Pinning is how an
+	// operator reviews what upstream changed before it grounds an investigation, at
+	// the cost of not receiving shared fixes until they bump the pin. Both are
+	// legitimate trades; tracking a branch stays the default.
+	Ref      string   `yaml:"ref"`
 	Interval Duration `yaml:"interval"` // re-sync period (default 24h — a shared corpus changes slowly)
 	// Dir is where the commons is checked out. It MUST differ from catalog.dir: the
 	// two are separate corpora, and sharing a root would let an upstream sync dirty
@@ -524,6 +540,94 @@ type CatalogCommons struct {
 	Dir string `yaml:"dir"`
 	// TokenEnv names an env var holding a read token for a private commons repo.
 	TokenEnv string `yaml:"token_env"`
+}
+
+// tagRefPrefix is the fully-qualified namespace of a git tag.
+const tagRefPrefix = "refs/tags/"
+
+// isObjectID reports whether s is a full-length git object id (SHA-1 40 hex chars,
+// SHA-256 64). Abbreviations are rejected on purpose: they are ambiguous, and this
+// is a trust knob — "the corpus my agent reads" deserves an unambiguous name.
+func isObjectID(s string) bool {
+	if len(s) != 40 && len(s) != 64 {
+		return false
+	}
+	return isHex(s)
+}
+
+// isHex reports whether s is non-empty and made only of hex digits.
+func isHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isPinnedRevision reports whether s spells an IMMUTABLE revision. This is the
+// operator-facing half of a contract shared with internal/catalog: the syncer takes
+// a single revision string and tells a pin from a branch by exactly this rule
+// (catalog.Syncer.pin). Config decides what may be written; the syncer decides what
+// the written string means. Change one and the other must follow.
+func isPinnedRevision(s string) bool {
+	return strings.HasPrefix(s, tagRefPrefix) || isObjectID(s)
+}
+
+// pinnedRevision spells a `ref` the way git spells it, which is what makes the pin
+// legible to the syncer without a second field on the wire. A bare name is a tag —
+// the only kind of immutable revision that has a name.
+func pinnedRevision(ref string) string {
+	if isPinnedRevision(ref) {
+		return ref
+	}
+	return tagRefPrefix + ref
+}
+
+// validateCommonsRevision fails closed on any way of asking for two revisions at
+// once, or for a "pin" that is not actually immutable. Every case here would
+// otherwise leave an operator believing their corpus is frozen while it moves —
+// the precise belief the option exists to make true.
+func validateCommonsRevision(cc CatalogCommons) error {
+	// Both keys set. ApplyDefaults folds a ref into an EMPTY branch only, so the two
+	// being non-empty and disagreeing is exactly "the operator wrote both".
+	if cc.Ref != "" && cc.Branch != "" && cc.Branch != pinnedRevision(cc.Ref) {
+		return fmt.Errorf("catalog.commons: set either branch (%q, tracks a moving branch) or ref (%q, pins an immutable revision), not both", cc.Branch, cc.Ref)
+	}
+	switch {
+	case cc.Ref == "":
+		// A pinned spelling under `branch` would freeze the corpus while the key says
+		// it tracks one. It cannot work today either (it clones refs/heads/refs/tags/…),
+		// so no configuration that works is broken by rejecting it at load.
+		if isPinnedRevision(cc.Branch) {
+			return fmt.Errorf("catalog.commons.branch = %q names an immutable revision; use catalog.commons.ref to pin a tag or commit — branch tracks a moving branch", cc.Branch)
+		}
+	case strings.HasPrefix(cc.Ref, "refs/") && !strings.HasPrefix(cc.Ref, tagRefPrefix):
+		// refs/heads/main under `ref` is the dangerous one: the syncer would treat any
+		// qualified ref as a pin and never fetch again, silently freezing the commons
+		// on whatever the branch pointed at the day it was cloned.
+		return fmt.Errorf("catalog.commons.ref = %q is not an immutable revision (only %s… or a full commit id can be pinned); use catalog.commons.branch to track a branch", cc.Ref, tagRefPrefix)
+	case isHex(cc.Ref) && len(cc.Ref) >= 7 && !isObjectID(cc.Ref):
+		return fmt.Errorf("catalog.commons.ref = %q looks like an abbreviated commit id; pin the full 40-character SHA (abbreviations are ambiguous)", cc.Ref)
+	}
+	return nil
+}
+
+// validateCatalogGitRevision keeps the operator's OWN catalog on a tracked branch.
+// It shares the syncer with the commons, so a pinned spelling here would work —
+// and that is the problem: the curator opens PRs against this repo, so a frozen
+// read root makes "merged" and "in use" diverge forever with no signal. Pinning is
+// for a corpus you do not control; this one you do.
+func validateCatalogGitRevision(g CatalogGit) error {
+	if g.URL == "" || !isPinnedRevision(g.Branch) {
+		return nil
+	}
+	return fmt.Errorf("catalog.git.branch = %q names an immutable revision, but your own catalog is deliberately not pinnable: the curator's merged PRs must reach the index. Only catalog.commons (a repo you do not control) can be pinned with `ref`", g.Branch)
 }
 
 // Outcome configures the learning-loop outcome ledger.
@@ -1376,11 +1480,17 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("notify.matrix.feedback_reactions requires outcome.ledger_path: ratings are recorded in the outcome ledger")
 		}
 	}
+	if err := validateCatalogGitRevision(c.Catalog.Git); err != nil {
+		return err
+	}
 	// Commons catalog (opt-in): a second, read-only root. Fail closed on a
 	// misconfiguration rather than degrading to a silently-absent corpus.
 	if cc := c.Catalog.Commons; cc.URL != "" {
 		if cc.Dir == "" {
 			return fmt.Errorf("catalog.commons.url is set but catalog.commons.dir is empty: the shared catalog needs its own checkout directory")
+		}
+		if err := validateCommonsRevision(cc); err != nil {
+			return err
 		}
 		// Sharing a directory with the operator's own catalog would let an upstream
 		// sync write into their checkout — and, with git-sync enabled, fight the

--- a/internal/config/config_commons_test.go
+++ b/internal/config/config_commons_test.go
@@ -3,8 +3,6 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -126,22 +124,14 @@ func TestCatalogGitBranchRejectsAPinnedSpelling(t *testing.T) {
 // TestCommonsRefLoadsFromYAML: the key has to survive the strict decoder
 // (KnownFields) — a struct field nobody can spell in runlore.yaml is dead weight.
 func TestCommonsRefLoadsFromYAML(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "runlore.yaml")
-	const doc = `
+	c := loadDoc(t, `
 catalog:
   dir: /var/lib/runlore/catalog
   commons:
     url: https://github.com/Smana/runlore-kb-commons
     ref: v1.2.0
     dir: /var/lib/runlore/commons
-`
-	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	c, err := Load(path)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
+`)
 	if got := c.Catalog.Commons.Branch; got != "refs/tags/v1.2.0" {
 		t.Fatalf("effective commons revision = %q, want refs/tags/v1.2.0", got)
 	}

--- a/internal/config/config_commons_test.go
+++ b/internal/config/config_commons_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// commonsCfg builds the smallest valid config with the commons enabled.
+func commonsCfg(branch, ref string) *Config {
+	c := &Config{}
+	c.Catalog.Dir = "/var/lib/runlore/catalog"
+	c.Catalog.Commons.URL = "https://github.com/Smana/runlore-kb-commons"
+	c.Catalog.Commons.Dir = "/var/lib/runlore/commons"
+	c.Catalog.Commons.Branch = branch
+	c.Catalog.Commons.Ref = ref
+	return c
+}
+
+// TestCommonsRefNormalisesToAPinnedRevision locks the contract between the config
+// surface (branch | ref) and the single revision the syncer receives. The syncer
+// tells a pin from a branch by the SPELLING of that string — refs/tags/<name> or a
+// full object id — so what ApplyDefaults writes here is load-bearing, not cosmetic.
+// The catalog-side half of the contract is TestSyncPinnedTagChecksOutThatRevision
+// and friends in internal/catalog/sync_pinned_test.go.
+func TestCommonsRefNormalisesToAPinnedRevision(t *testing.T) {
+	const sha = "1a2b3c4d5e6f70819293a4b5c6d7e8f901234567" // 40 hex
+	for _, tc := range []struct {
+		name, branch, ref, want string
+	}{
+		{"unset tracks main", "", "", "main"},
+		{"explicit branch is untouched", "release", "", "release"},
+		{"bare ref is a tag", "", "v1.2.0", "refs/tags/v1.2.0"},
+		{"qualified tag ref passes through", "", "refs/tags/v1.2.0", "refs/tags/v1.2.0"},
+		{"full commit id passes through", "", sha, sha},
+		{"uppercase commit id passes through", "", strings.ToUpper(sha), strings.ToUpper(sha)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := commonsCfg(tc.branch, tc.ref)
+			ApplyDefaults(c)
+			if got := c.Catalog.Commons.Branch; got != tc.want {
+				t.Fatalf("effective commons revision = %q, want %q", got, tc.want)
+			}
+			if err := c.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
+	}
+}
+
+// TestCommonsBranchAndRefAreMutuallyExclusive: the two keys mean opposite things
+// (track a moving branch / freeze an immutable revision). Silently preferring one
+// would leave an operator who pinned a ref believing their corpus is frozen while
+// it tracks main — the exact failure the option exists to prevent.
+func TestCommonsBranchAndRefAreMutuallyExclusive(t *testing.T) {
+	c := commonsCfg("main", "v1.2.0")
+	ApplyDefaults(c)
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("branch + ref together must be rejected, not silently resolved")
+	}
+	for _, want := range []string{"catalog.commons", "branch", "ref"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+}
+
+// TestCommonsRefRejectsUnpinnableSpellings: a value that is not an immutable
+// revision must fail loudly at load. refs/heads/main under `ref` is the dangerous
+// one — the syncer would treat any qualified ref as a pin and never fetch again,
+// so the commons would silently freeze on whatever main pointed at that day.
+func TestCommonsRefRejectsUnpinnableSpellings(t *testing.T) {
+	for _, tc := range []struct{ name, ref string }{
+		{"branch ref", "refs/heads/main"},
+		{"remote branch ref", "refs/remotes/origin/main"},
+		{"abbreviated commit id", "1a2b3c4"},
+		{"half a commit id", "1a2b3c4d5e6f7081"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := commonsCfg("", tc.ref)
+			ApplyDefaults(c)
+			if err := c.Validate(); err == nil {
+				t.Fatalf("catalog.commons.ref = %q must be rejected", tc.ref)
+			}
+		})
+	}
+}
+
+// TestCommonsBranchRejectsAPinnedSpelling keeps the two keys honest in the other
+// direction: `branch: refs/tags/v1` would pin the corpus while the key says it
+// tracks a branch. It cannot work today either (it clones refs/heads/refs/tags/v1),
+// so nothing that works is broken by failing it at load instead of at clone.
+func TestCommonsBranchRejectsAPinnedSpelling(t *testing.T) {
+	for _, branch := range []string{"refs/tags/v1.2.0", "1a2b3c4d5e6f70819293a4b5c6d7e8f901234567"} {
+		c := commonsCfg(branch, "")
+		ApplyDefaults(c)
+		if err := c.Validate(); err == nil {
+			t.Fatalf("catalog.commons.branch = %q must be rejected in favour of ref", branch)
+		}
+	}
+}
+
+// TestCatalogGitBranchRejectsAPinnedSpelling: the operator's OWN catalog is
+// deliberately not pinnable — the curator opens PRs against it, and a frozen read
+// root would make "merged" and "in use" diverge forever with no signal. The syncer
+// is shared, so a pinned spelling there would silently freeze the learning loop.
+func TestCatalogGitBranchRejectsAPinnedSpelling(t *testing.T) {
+	c := &Config{}
+	c.Catalog.Dir = "/var/lib/runlore/catalog"
+	c.Catalog.Git.URL = "https://github.com/acme/runlore-kb"
+	c.Catalog.Git.Branch = "refs/tags/v1.2.0"
+	ApplyDefaults(c)
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("catalog.git.branch must reject a pinned revision spelling")
+	}
+	if !strings.Contains(err.Error(), "catalog.git.branch") {
+		t.Errorf("error %q does not name catalog.git.branch", err)
+	}
+}
+
+// TestCommonsRefLoadsFromYAML: the key has to survive the strict decoder
+// (KnownFields) — a struct field nobody can spell in runlore.yaml is dead weight.
+func TestCommonsRefLoadsFromYAML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "runlore.yaml")
+	const doc = `
+catalog:
+  dir: /var/lib/runlore/catalog
+  commons:
+    url: https://github.com/Smana/runlore-kb-commons
+    ref: v1.2.0
+    dir: /var/lib/runlore/commons
+`
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := c.Catalog.Commons.Branch; got != "refs/tags/v1.2.0" {
+		t.Fatalf("effective commons revision = %q, want refs/tags/v1.2.0", got)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/gitrev"
 )
 
 // Load reads, strictly parses, and validates a RunLore config file. Unknown keys
@@ -179,7 +181,7 @@ func ApplyDefaults(c *Config) {
 		// reject, instead of silently preferring one of the two.
 		switch {
 		case cc.Ref != "" && cc.Branch == "":
-			cc.Branch = pinnedRevision(cc.Ref)
+			cc.Branch = gitrev.QualifyTag(cc.Ref)
 		case cc.Ref == "" && cc.Branch == "":
 			cc.Branch = "main"
 		}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -165,12 +165,23 @@ func ApplyDefaults(c *Config) {
 	// interval reached Syncer.Run as 0 and fell through to the syncer's generic 5m
 	// fallback: 288x the documented rate against someone else's GitHub repo, with the
 	// startup log cheerfully printing "interval=0s".
-	if c.Catalog.Commons.URL != "" {
-		if c.Catalog.Commons.Interval.Std() == 0 {
-			c.Catalog.Commons.Interval = Duration(24 * time.Hour)
+	if cc := &c.Catalog.Commons; cc.URL != "" {
+		if cc.Interval.Std() == 0 {
+			cc.Interval = Duration(24 * time.Hour)
 		}
-		if c.Catalog.Commons.Branch == "" {
-			c.Catalog.Commons.Branch = "main"
+		// branch and ref are two operator intentions — track a moving branch, or pin an
+		// immutable revision — but a syncer follows exactly ONE revision. Collapse them
+		// here, into git's own spelling, so the pin travels on the wire that already
+		// exists rather than on a second field the syncer would have to reconcile.
+		//
+		// The fold deliberately refuses to overwrite a branch the operator set: that
+		// leaves a conflicting pair intact for Validate (which runs after this) to
+		// reject, instead of silently preferring one of the two.
+		switch {
+		case cc.Ref != "" && cc.Branch == "":
+			cc.Branch = pinnedRevision(cc.Ref)
+		case cc.Ref == "" && cc.Branch == "":
+			cc.Branch = "main"
 		}
 	}
 	if c.Catalog.InstantRecall.Enabled {

--- a/internal/gitrev/gitrev.go
+++ b/internal/gitrev/gitrev.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gitrev spells the single rule that tells an IMMUTABLE git revision from
+// a moving branch.
+//
+// It is a package of its own because two packages read the same string from
+// opposite ends: internal/config decides what an operator may WRITE
+// (catalog.commons.branch vs .ref), internal/catalog decides what the string that
+// reaches the syncer MEANS. Held apart, the two copies were identical and nothing
+// observed both — a rule that accepted a SHA-256 or upper-case id on the config
+// side while the syncer read it as a branch name would have passed every test in
+// both suites and left a corpus the operator believes is frozen tracking main.
+//
+// A leaf package rather than one importing the other: internal/config is what
+// every component reads, and pointing it at internal/catalog would drag the search
+// index (bleve) and go-git into packages that have no business linking them.
+package gitrev
+
+import (
+	"encoding/hex"
+	"strings"
+)
+
+// TagRefPrefix is the fully-qualified namespace of a git tag.
+const TagRefPrefix = "refs/tags/"
+
+// IsTagRef reports whether s is a fully-qualified tag ref (refs/tags/<name>).
+func IsTagRef(s string) bool {
+	return strings.HasPrefix(s, TagRefPrefix)
+}
+
+// IsObjectID reports whether s is a full-length git object id (SHA-1, 40 hex
+// chars; SHA-256, 64). Abbreviations are deliberately NOT accepted: they are
+// ambiguous, and a 7-character hex string is as likely to be a tag name as a
+// commit.
+func IsObjectID(s string) bool {
+	if len(s) != 40 && len(s) != 64 {
+		return false
+	}
+	// Both accepted lengths are even, so DecodeString's odd-length rejection can
+	// never fire here; what is left is exactly "every character is a hex digit",
+	// upper or lower case.
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+// IsPinned reports whether s names a revision that no upstream push can move.
+// Anything else — a bare name, refs/heads/…, an abbreviated id — tracks.
+func IsPinned(s string) bool {
+	return IsTagRef(s) || IsObjectID(s)
+}
+
+// QualifyTag spells a pin the way git spells it, which is what lets a pin travel
+// on the single revision string a syncer already takes rather than on a second
+// field. Anything already immutable passes through; a bare name is a tag — the
+// only kind of immutable revision that has one.
+func QualifyTag(ref string) string {
+	if IsPinned(ref) {
+		return ref
+	}
+	return TagRefPrefix + ref
+}

--- a/internal/gitrev/gitrev_test.go
+++ b/internal/gitrev/gitrev_test.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gitrev
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	sha1Hex   = "1a2b3c4d5e6f70819293a4b5c6d7e8f901234567"                         // 40
+	sha256Hex = "1a2b3c4d5e6f70819293a4b5c6d7e8f9012345671a2b3c4d5e6f708192939495" // 64
+)
+
+// TestRevisionSpellings is the one corpus both ends of the contract are read
+// against: internal/config decides what an operator may write, internal/catalog
+// decides what the written string means, and both now answer from the functions
+// exercised here. Every row is a spelling an operator can actually type.
+func TestRevisionSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		name                     string
+		s                        string
+		tagRef, objectID, pinned bool
+		qualified                string
+	}{
+		{name: "empty", s: "", qualified: "refs/tags/"},
+		{name: "bare branch name", s: "main", qualified: "refs/tags/main"},
+		{name: "branch ref", s: "refs/heads/main", qualified: "refs/tags/refs/heads/main"},
+		{name: "remote branch ref", s: "refs/remotes/origin/main", qualified: "refs/tags/refs/remotes/origin/main"},
+		{name: "bare tag name", s: "v1.2.0", qualified: "refs/tags/v1.2.0"},
+		{name: "tag ref", s: "refs/tags/v1.2.0", tagRef: true, pinned: true, qualified: "refs/tags/v1.2.0"},
+		{name: "sha-1 id", s: sha1Hex, objectID: true, pinned: true, qualified: sha1Hex},
+		// Upper case is what `git rev-parse` output pasted from some tools looks like,
+		// and a rule that accepts it in config but reads it as a branch name in the
+		// syncer is the failure this package exists to make impossible.
+		{name: "sha-1 id upper case", s: strings.ToUpper(sha1Hex), objectID: true, pinned: true, qualified: strings.ToUpper(sha1Hex)},
+		{name: "sha-1 id mixed case", s: "1A2b3C4d5E6f70819293A4b5C6d7E8f901234567", objectID: true, pinned: true, qualified: "1A2b3C4d5E6f70819293A4b5C6d7E8f901234567"},
+		// SHA-256 object ids: git repositories can be created with them today, and a
+		// 64-hex pin that only one side recognises would be cloned as refs/heads/<64 hex>.
+		{name: "sha-256 id", s: sha256Hex, objectID: true, pinned: true, qualified: sha256Hex},
+		{name: "sha-256 id upper case", s: strings.ToUpper(sha256Hex), objectID: true, pinned: true, qualified: strings.ToUpper(sha256Hex)},
+		// Abbreviations and near-misses are ambiguous, so they are tag names.
+		{name: "abbreviated id", s: "1a2b3c4", qualified: "refs/tags/1a2b3c4"},
+		{name: "half an id", s: "1a2b3c4d5e6f7081", qualified: "refs/tags/1a2b3c4d5e6f7081"},
+		{name: "one char short of sha-1", s: sha1Hex[:39], qualified: "refs/tags/" + sha1Hex[:39]},
+		{name: "one char past sha-1", s: sha1Hex + "8", qualified: "refs/tags/" + sha1Hex + "8"},
+		{name: "one char short of sha-256", s: sha256Hex[:63], qualified: "refs/tags/" + sha256Hex[:63]},
+		{name: "40 chars but not hex", s: strings.Repeat("g", 40), qualified: "refs/tags/" + strings.Repeat("g", 40)},
+		{name: "40 chars with a separator", s: "1a2b3c4d5e6f70819293a4b5c6d7e8f9012345-7", qualified: "refs/tags/1a2b3c4d5e6f70819293a4b5c6d7e8f9012345-7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTagRef(tc.s); got != tc.tagRef {
+				t.Errorf("IsTagRef(%q) = %v, want %v", tc.s, got, tc.tagRef)
+			}
+			if got := IsObjectID(tc.s); got != tc.objectID {
+				t.Errorf("IsObjectID(%q) = %v, want %v", tc.s, got, tc.objectID)
+			}
+			if got := IsPinned(tc.s); got != tc.pinned {
+				t.Errorf("IsPinned(%q) = %v, want %v", tc.s, got, tc.pinned)
+			}
+			if got := QualifyTag(tc.s); got != tc.qualified {
+				t.Errorf("QualifyTag(%q) = %q, want %q", tc.s, got, tc.qualified)
+			}
+		})
+	}
+}

--- a/website/content/docs/concepts/knowledge-commons.md
+++ b/website/content/docs/concepts/knowledge-commons.md
@@ -93,3 +93,36 @@ means an upstream sync cannot dirty the volume holding your outcome ledger and a
 `commons.dir` must differ from `catalog.dir`. Both the agent's config validation and the
 Helm chart refuse to start with a shared root, because one directory serving both corpora
 would let an upstream sync overwrite the entries you curate.
+
+### Tracking a branch, or pinning a revision
+
+`commons.branch` tracks a moving branch: an upstream edit reaches `kb_search` at the next
+interval. Shared corrections arrive without you doing anything — which is the point of a
+commons, and also means the corpus moves without you looking.
+
+`commons.ref` is the other side of that trade. Pin a tag or a full 40-character commit id
+and the corpus is frozen until you move it, so you can read the upstream diff before it
+grounds an investigation:
+
+```yaml
+catalog:
+  commons:
+    url: https://github.com/Smana/runlore-kb-commons
+    ref: v1.2.0                      # a tag name, or a full commit id
+    dir: /var/lib/runlore/commons
+```
+
+`branch` and `ref` are mutually exclusive — setting both fails at startup rather than
+quietly picking one. A pinned revision cannot move, so the periodic sync becomes a local
+no-op rather than a fetch, and the index is rebuilt only on startup or when you move the
+pin. Your own `catalog.git` repo is deliberately not pinnable: the curator opens PRs
+against it, and freezing it would leave "merged" and "in use" permanently apart.
+
+Be precise about what pinning buys, because an unpinned commons is not a hazard you are
+patching. The properties that keep a shared corpus in its place hold either way: its
+entries are read-only, the curator never writes to them, yours win ties, and none of them
+can fire instant recall. What an upstream edit can still influence is what `kb_search`
+puts in front of the model mid-investigation — evidence is still gathered, the verdict is
+still reached against your cluster, but the prompt was shaped by someone else's most
+recent commit. Pinning narrows that to changes you have read. It cannot judge them for
+you: a pin you bump without reading the diff buys exactly nothing.


### PR DESCRIPTION
The commons is a second, read-only catalog root synced from a **repository the operator does not control**, and its entries are put in front of the model mid-incident by `kb_search`. Today that sync can only track a branch — `plumbing.NewBranchReferenceName(...)` with `SingleBranch: true` — and the documented configuration is `branch: main` with `interval: 24h`. So upstream edits reach an operator's incident-response grounding within a day, unreviewed.

**The blast radius is genuinely bounded, and the docs say so rather than overclaiming**: commons entries are read-only, the curator can never write to them, they lose scoring ties to the operator's own entries, and a provenance check bars them from firing instant recall — pinned or not. What pinning narrows is only what `kb_search` puts in front of the model. The doc states plainly that it cannot judge a diff you did not read.

## Config surface: two keys, one wire

`catalog.commons.ref` is added **alongside** `branch` rather than overloading it. They mean opposite things — track a moving branch, or freeze an immutable revision — and overloading would turn `branch: v1.2.0` (a typo that fails loudly at clone time today) into a silent pin.

`ApplyDefaults` collapses the pair into the single revision the syncer already receives, spelled the way git spells it: `refs/tags/<name>`, or a bare 40/64-char object id. The syncer classifies by that spelling.

Ambiguity is **rejected, not resolved**: `ApplyDefaults` refuses to fold into a branch the operator set, leaving the conflicting pair intact for `Validate` to reject. Also rejected — `ref: refs/heads/main` (would be treated as a pin and silently freeze), abbreviated commit ids, and a pinned spelling written under `branch`.

## Backward compatibility

`branch: main` → unqualified → the existing branch path (`NewBranchReferenceName` + `SingleBranch` + `PullContext`), byte for byte. Only `refs/tags/…` or a full object id selects the pinned path, and neither is reachable from any config that works today. Every pre-existing `sync_test.go` test passes untouched.

## go-git

- **Tag pin** — stays a cheap single-ref clone; go-git lands HEAD detached on the peeled commit.
- **Commit-id pin** — not a ref, so it cannot be a clone target: clone the repo's refs, then check out the hash.
- **Existing mirror** — `checkoutPin` resolves the pin *locally* first. Already there, return, no network. That is the no-op, verified behaviourally by renaming the upstream away and requiring the poll to still succeed. Only a pin the mirror has never seen fetches.
- Clone, corrupt-mirror recovery, HEAD-gated change detection, delta and `lastRev` bookkeeping are all **shared**. Pinning branches in exactly one place — `advance()` — so a pin reports `changed=true` once then `false` forever and `Run`'s re-index gate needs no special case. The rollback-on-reindex-failure retry still works under a pin (mutation-tested), which is why the poll is kept rather than skipped.
- A pin absent from the repo fails the sync rather than leaving the mirror on some other revision.

## Scope: the operator's own catalog is deliberately not extended

`catalog.git` is the repo the curator opens PRs against. Pinning it would freeze the read side of the learning loop, so "merged" and "in use" diverge forever with no signal. The trust argument for pinning — a repo you do not control — simply does not apply.

But because the syncer is shared, a pinned spelling under `catalog.git.branch` *would* now work. `Validate` rejects it with that explanation. That is the only scope beyond commons, ~6 lines, and it exists to stop a silent freeze the shared syncer would otherwise permit.

## Mutation testing — 11/11 caught

`pin()` never pins · pinned poll always fetches · missing pin falls back instead of failing · no fetch for an unseen pin · `Run` drops the re-index rollback · `ApplyDefaults` silently prefers ref over branch · bare ref not qualified as a tag · `branch` accepts a pinned spelling · `catalog.git.branch` accepts a pin · `ref` accepts `refs/heads/*` · `ref` accepts an abbreviated id.

Two survived the first pass and both were real:

1. *Missing pin falls back* survived because the only not-found case was a tag, which fails at clone time and never reaches `checkoutPin`. Fixed with a table-driven test using a well-formed-but-absent commit id, which does reach it.
2. *Annotated tag not peeled* survived and is **behaviour-equivalent** — go-git's `Checkout` peels tag objects itself, so the peel only decides whether the poll short-circuits or redundantly re-checks-out the same tree. Not a broken variant; the code comment had overclaimed and was corrected.

End-to-end: uncommenting `ref:` next to `branch: main` in `values-full.yaml` makes `TestValuesProfilesConfigPassesStrictLoader` fail with the mutual-exclusion error, so the shipped chart values really do go through the strict loader. `helm lint` clean.

## Reviewer note — the one design smell

The `refs/tags/` + object-id rule is **duplicated** in `internal/config` (`isPinnedRevision`) and `internal/catalog` (`Syncer.pin`), cross-referenced in both doc comments and pinned by tests at both ends.

The cleaner shape is a `Syncer.Ref` field plus a one-line change at `internal/app/catalog.go:43`, moving the reconciliation up a layer. That file was excluded from this change's scope — and independently, four other open branches currently touch it, so taking it here would have created real conflicts. Extracting the predicate to a shared leaf package is the other option; having `internal/config` import `internal/catalog` for an 8-line predicate is not, since it would drag bleve into config's dependency graph.

Worth deciding, but not a correctness issue: both ends are tested and both mutations above cover the duplication.

## Left undone

`values.schema.json` is untouched — the chart's `config:` block is `additionalProperties: true` and validates nothing under `catalog.commons`. The top-of-page config snippet in `knowledge-commons.md` still shows only `branch: main`; it sits outside the "Operational notes" section this PR was scoped to.