### PR TITLE
fix(security): close four hardening gaps found while reviewing the eval scorecard

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -41,19 +41,24 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: "0.156.0"
+      # Keep in step with docs.yml — same release, same pin. See the note there for
+      # why the checksum is pinned alongside the version.
+      HUGO_SHA256: "28111b85cd44c258c0cc59da00ae2210c12a55749b7fd77e7421ab963b7adcda"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
 
       - name: Install Hugo Extended
         run: |
+          set -euo pipefail
           wget -O /tmp/hugo.deb \
             "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          echo "${HUGO_SHA256}  /tmp/hugo.deb" | sha256sum -c -
           sudo dpkg -i /tmp/hugo.deb
 
       - name: Build the site (broken internal refs fail here)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,21 +27,29 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     env:
       HUGO_VERSION: "0.156.0"
+      # Pins the ARTIFACT, not just its name: a release asset can be replaced under
+      # an unchanged tag, and this .deb is installed as root on the one runner in
+      # this repo that holds pages:write + id-token:write. Bump it together with
+      # HUGO_VERSION — the value is the hugo_extended_<version>_linux-amd64.deb line
+      # of the release's hugo_<version>_checksums.txt.
+      HUGO_SHA256: "28111b85cd44c258c0cc59da00ae2210c12a55749b7fd77e7421ab963b7adcda"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: stable
       - name: Install Hugo Extended
         run: |
+          set -euo pipefail
           wget -O /tmp/hugo.deb \
             "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          echo "${HUGO_SHA256}  /tmp/hugo.deb" | sha256sum -c -
           sudo dpkg -i /tmp/hugo.deb
       - name: Configure Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       # Pull the published scorecard from the eval-scorecard orphan branch and splice
       # it into /eval. The branch is the nightly's publishing target; copying it in at
       # build time keeps main free of generated numbers.
@@ -139,9 +147,9 @@ jobs:
         # baseURL comes from hugo.yaml (https://runlore.io/) — do NOT override with
         # configure-pages' output, which resolves to http:// and yields http canonical URLs.
         run: hugo --minify --gc
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/public
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -37,7 +37,7 @@ RENDERER=(internal/notify/slack.go internal/notify/format.go)
 #     fails again, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_RENDERER="e4b802769aa1f276c9322860a36f6f5de4d75458"
+ACKNOWLEDGED_RENDERER="a97b1df68c58cc4663d86f42ee160ca5f9f5a638"
 ACKNOWLEDGED_REASON="The VISUAL drift is still #432's: it removed the fabricated 'What changed: No Git change identified' line and both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt. The named commit is newer only because a security fix (webhook URL sanitised out of an error log) touched slack.go without changing a pixel — RENDERER cannot tell visual edits from non-visual ones, so it re-armed on a no-op."
 
 last_commit_time() {

--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -37,8 +37,8 @@ RENDERER=(internal/notify/slack.go internal/notify/format.go)
 #     fails again, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_RENDERER="d2c2de8b5af5d2b3056d4f2de02f3511de839124"
-ACKNOWLEDGED_REASON="#432 removed the fabricated 'What changed: No Git change identified' line; both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt."
+ACKNOWLEDGED_RENDERER="e4b802769aa1f276c9322860a36f6f5de4d75458"
+ACKNOWLEDGED_REASON="The VISUAL drift is still #432's: it removed the fabricated 'What changed: No Git change identified' line and both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt. The named commit is newer only because a security fix (webhook URL sanitised out of an error log) touched slack.go without changing a pixel — RENDERER cannot tell visual edits from non-visual ones, so it re-armed on a no-op."
 
 last_commit_time() {
   local t

--- a/internal/app/kb_import.go
+++ b/internal/app/kb_import.go
@@ -171,8 +171,10 @@ func runKBImport(args []string, w io.Writer) error {
 }
 
 // collectSources walks src for importable markdown, mirroring catalog.Load's
-// skip rules (internal/catalog/load.go): hidden files/dirs, non-.md, and the
-// reserved index.md / log.md / README.md are not knowledge entries.
+// skip rules (internal/catalog/load.go): non-regular files, hidden files/dirs,
+// non-.md, and the reserved index.md / log.md / README.md are not knowledge
+// entries. The mirroring is the contract — importing a file the loader would
+// refuse writes an entry into the KB that the catalog then declines to serve.
 func collectSources(src string) ([]string, error) {
 	var out []string
 	err := filepath.WalkDir(src, func(path string, d fs.DirEntry, werr error) error {
@@ -184,6 +186,11 @@ func collectSources(src string) ([]string, error) {
 			if path != src && strings.HasPrefix(base, ".") {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+		// Same reason as the loader: a symlink is not a knowledge entry, and the
+		// os.ReadFile that follows would follow it out of src.
+		if !d.Type().IsRegular() {
 			return nil
 		}
 		if !catalog.IsEntryFile(base) {

--- a/internal/catalog/load.go
+++ b/internal/catalog/load.go
@@ -35,6 +35,19 @@ func Load(dir string) (entries []Entry, skipped []string, err error) {
 			}
 			return nil
 		}
+		// Only regular files are entries. A catalog is synced from a Git repo — the
+		// shipped default points at a third-party public commons — and a mode-120000
+		// tree entry clones into a real symlink. WalkDir does not follow symlinks, but
+		// a symlink to a FILE arrives here with IsDir()==false, and os.ReadFile below
+		// DOES follow it: a relative target (go-billy only rewrites absolute ones into
+		// the clone root) reads the ServiceAccount token or /proc/self/environ into
+		// Entry.Body, into the search corpus, and back out through kb_get. Checking the
+		// type rather than resolving the target also covers fifos and device nodes,
+		// which would make the read block or allocate forever, and leaves no TOCTOU
+		// window between a path check and the open.
+		if !d.Type().IsRegular() {
+			return nil
+		}
 		if !IsEntryFile(base) {
 			return nil
 		}

--- a/internal/catalog/load_test.go
+++ b/internal/catalog/load_test.go
@@ -46,6 +46,54 @@ Ready=False after a chart bump.
 	}
 }
 
+// TestLoadIgnoresSymlinkedEntries: a catalog is SYNCED FROM A GIT REPO — the shipped
+// default even points at a third-party public commons repo — and a git tree can carry
+// a mode-120000 entry, which clones into a real symlink. WalkDir does not follow
+// symlinks, but a symlink to a FILE arrives with IsDir()==false, so it used to sail
+// through the name check into os.ReadFile, which does follow it. A relative target
+// escapes the checkout (go-billy rewrites only ABSOLUTE targets into the clone root),
+// so one merged PR adding what reads as an ordinary new .md in a GitHub diff could
+// pull the ServiceAccount token or /proc/self/environ — the model API key, the forge
+// token — into Entry.Body, into the search corpus, and back out through kb_get.
+//
+// Guarded by file TYPE, not by resolving the target: a target check would still admit
+// a link to another file inside the catalog while inviting a TOCTOU between the check
+// and the read, and it would not cover a fifo or device node, which make os.ReadFile
+// block or allocate without end. Nothing that is not a regular file is ever an entry.
+func TestLoadIgnoresSymlinkedEntries(t *testing.T) {
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "token")
+	if err := os.WriteFile(secret, []byte("---\ntype: Playbook\ntitle: Stolen\ndescription: d\n---\nSUPER-SECRET-TOKEN\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	writeEntry(t, dir, "real-entry.md", "---\ntype: Playbook\ntitle: Real\ndescription: d\n---\nbody\n")
+	// Both spellings a hostile repo could use: an absolute target, and the relative
+	// one go-billy leaves untouched.
+	if err := os.Symlink(secret, filepath.Join(dir, "exfil-abs.md")); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+	rel, err := filepath.Rel(dir, secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(rel, filepath.Join(dir, "exfil-rel.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, _, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want only the regular file indexed, got %d: %+v", len(entries), entries)
+	}
+	if contains(entries[0].Body, "SUPER-SECRET-TOKEN") {
+		t.Fatalf("a symlink pulled a file from outside the catalog into the corpus: %+v", entries[0])
+	}
+}
+
 // TestLoadSkipsRepoRootDocs: a catalog served from a Git repository carries the
 // conventional repo documents, and none of them are knowledge. This is a real
 // regression, not a hypothetical: the public commons repo has a CONTRIBUTING.md,

--- a/internal/eval/coverage.go
+++ b/internal/eval/coverage.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/redact"
 )
 
 // toolSource maps each investigation tool to its data-source group. submit_findings
@@ -68,11 +69,25 @@ func (t recordingTool) Name() string        { return t.inner.Name() }
 func (t recordingTool) Description() string { return t.inner.Description() }
 func (t recordingTool) Schema() string      { return t.inner.Schema() }
 
+// Call delegates, records, and returns the inner result UNCHANGED — the loop
+// applies its own redaction to the copy the model sees.
+//
+// What is recorded is redacted here, because this decorator sits inside the
+// loop: investigate applies redact.Secrets to a tool's return value only after
+// the tool has returned, so the recorder would otherwise hold the raw cluster
+// evidence. `lore eval --live --record` then writes that to disk as a replayable
+// case (app.RunEvalLive → eval.WriteCase), which a human may later promote into
+// the tracked fixture corpus — putting a live cluster secret in git. Recording
+// is an egress just like the model call is, so it gets the same treatment.
+//
+// The recorded error text is redacted too: backends build their errors from the
+// upstream response body ("logs status 401: …"), which can carry the credential
+// the request was rejected for.
 func (t recordingTool) Call(ctx context.Context, args string) (string, error) {
 	out, err := t.inner.Call(ctx, args)
-	c := Call{Name: t.inner.Name(), Args: args, Output: out}
+	c := Call{Name: t.inner.Name(), Args: args, Output: redact.Secrets(out)}
 	if err != nil {
-		c.Err = err.Error()
+		c.Err = redact.Secrets(err.Error())
 	}
 	t.rec.record(c)
 	return out, err

--- a/internal/eval/coverage_test.go
+++ b/internal/eval/coverage_test.go
@@ -5,6 +5,7 @@ package eval
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/investigate"
@@ -48,6 +49,62 @@ func TestRecordingToolRecordsError(t *testing.T) {
 	}
 	if c := rec.Calls(); len(c) != 1 || c[0].Err == "" {
 		t.Fatalf("error not recorded: %+v", c)
+	}
+}
+
+// TestRecordingToolRedactsBeforeRecording pins the ordering that matters for
+// `lore eval --live --record`: the recorder sits INSIDE the investigation loop,
+// which applies redact.Secrets to a tool's return value only after the tool has
+// returned. Without redacting here, the recorder holds the raw cluster evidence
+// and WriteCase persists it to disk as a replayable case — a file a human may
+// later promote into the tracked fixture corpus, at which point the secret is in
+// git. Anything leaving the process gets the same redaction the model's copy does.
+func TestRecordingToolRedactsBeforeRecording(t *testing.T) {
+	const secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+	raw := "kind: Secret\ndata:\n  password: c3VwM3JzM2NyZXQ=\n" +
+		"controller log: authenticating with " + secret + "\n"
+
+	rec := &Recorder{}
+	rt := recordingTool{inner: fakeTool{name: "controller_logs", out: raw}, rec: rec}
+
+	// The loop still receives the tool's own output — the recorder must not change
+	// what the investigation reasons over (the loop redacts that copy itself).
+	out, err := rt.Call(context.Background(), "{}")
+	if err != nil || out != raw {
+		t.Fatalf("delegate must return the tool's output unchanged: out=%q err=%v", out, err)
+	}
+
+	calls := rec.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("want 1 recorded call, got %+v", calls)
+	}
+	for _, leak := range []string{secret, "c3VwM3JzM2NyZXQ="} {
+		if strings.Contains(calls[0].Output, leak) {
+			t.Errorf("recorded output would be written to disk un-redacted: %q\n -> %q", leak, calls[0].Output)
+		}
+	}
+	// Structure survives, so a recorded case is still a usable replay fixture.
+	if !strings.Contains(calls[0].Output, "kind: Secret") {
+		t.Errorf("redaction must preserve structure, got %q", calls[0].Output)
+	}
+}
+
+// TestRecordingToolRedactsRecordedError: a tool error is persisted into the case
+// too (and surfaces in the report), and backends build their errors from the
+// upstream response body — "logs status 401: {...}" can carry the credential the
+// request was rejected for.
+func TestRecordingToolRedactsRecordedError(t *testing.T) {
+	const secret = "ghp_abcdefghijklmnopqrstuvwxyz0123456789"
+	rec := &Recorder{}
+	rt := recordingTool{
+		inner: fakeTool{name: "query_logs", err: errors.New("logs status 401: bad token " + secret)},
+		rec:   rec,
+	}
+	if _, err := rt.Call(context.Background(), "{}"); err == nil {
+		t.Fatal("want error propagated")
+	}
+	if c := rec.Calls(); len(c) != 1 || strings.Contains(c[0].Err, secret) {
+		t.Errorf("recorded error must be redacted: %+v", c)
 	}
 }
 

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -84,7 +84,11 @@ func (c *Client) do(ctx context.Context, method, path string, body, out any) err
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("github %s %s: status %d: %s", method, path, resp.StatusCode, string(data[:min(len(data), 512)]))
+		// The body is server-controlled and lands in logs and operator-facing
+		// errors; httpx.SafeErrorBody strips the credential it was sent with and
+		// caps the length. Same reasoning (and the same helper) as the GitLab
+		// client — and the App installation token it launders is live for an hour.
+		return fmt.Errorf("github %s %s: status %d: %s", method, path, resp.StatusCode, httpx.SafeErrorBody(data, tok))
 	}
 	if out != nil {
 		return json.Unmarshal(data, out)

--- a/internal/forge/github/github_test.go
+++ b/internal/forge/github/github_test.go
@@ -15,8 +15,12 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-func staticToken(string) func(context.Context) (string, error) {
-	return func(context.Context) (string, error) { return "tok", nil }
+// staticToken is a TokenFunc that always mints tok. It used to IGNORE its
+// argument and hand back the literal "tok" regardless — harmless while every
+// caller passed "tok", and a trap for any test that cares which credential the
+// client actually sent (see TestTokenNeverAppearsInErrors).
+func staticToken(tok string) func(context.Context) (string, error) {
+	return func(context.Context) (string, error) { return tok, nil }
 }
 
 func TestOpenIssue(t *testing.T) {
@@ -583,5 +587,35 @@ func TestRenderEntryNeutralizeImages(t *testing.T) {
 	// The neutralized form must be present so reviewers still know there was an image ref.
 	if !strings.Contains(rendered, "`[image: beacon]`") {
 		t.Errorf("renderEntry missing neutralized image label:\n%s", rendered)
+	}
+}
+
+// TestTokenNeverAppearsInErrors is the GitHub half of the guard the GitLab
+// client already carries: do() embeds the response body in its error, the body
+// is server-controlled, and the error is logged and shown to operators. A debug
+// endpoint, a chatty proxy or a misconfigured auth layer that echoes the
+// Authorization credential back would otherwise get it laundered straight into
+// our own error text — and the App installation token it launders is live for
+// an hour.
+func TestTokenNeverAppearsInErrors(t *testing.T) {
+	const secret = "ghs_INSTALLATIONTOKEN1234567890abcdef"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials for ` + secret + `"}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken(secret))
+	_, err := c.OpenIssue(context.Background(), providers.Investigation{Title: "Boom"})
+	if err == nil {
+		t.Fatal("want an error from a 401")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("the token leaked into an error operators will see and log:\n%s", err.Error())
+	}
+	// The rest of the body must survive — it is how an operator tells a bad
+	// credential from a missing scope.
+	if !strings.Contains(err.Error(), "Bad credentials") {
+		t.Fatalf("stripping must not swallow the diagnostic body:\n%s", err.Error())
 	}
 }

--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -203,14 +203,10 @@ func (c *Client) request(ctx context.Context, method, path string, body any) ([]
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
-		// The body is server-controlled and lands in logs and operator-facing errors.
-		// A server that echoes the credential back — a debug endpoint, a chatty proxy,
-		// a misconfigured auth layer — would otherwise get it laundered straight into
-		// our error text. Strip it rather than trusting the far end not to reflect it.
-		body := string(data[:min(len(data), 512)])
-		if tok != "" {
-			body = strings.ReplaceAll(body, tok, "[REDACTED]")
-		}
+		// The body is server-controlled and lands in logs and operator-facing
+		// errors; httpx.SafeErrorBody strips the credential it was sent with and
+		// caps the length. Shared with the GitHub client — see its doc comment.
+		body := httpx.SafeErrorBody(data, tok)
 		return nil, resp.Header, &statusError{method: method, path: path, status: resp.StatusCode, body: body}
 	}
 	return data, resp.Header, nil

--- a/internal/httpx/body.go
+++ b/internal/httpx/body.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpx
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// maxToolOutputDefault mirrors the default of investigation.max_tool_output_bytes
+// (internal/config/load.go, deploy/helm/runlore/values.yaml): the most text one
+// tool result may put in front of the model.
+const maxToolOutputDefault = 32 << 10
+
+// MaxResponseBytes bounds how much of a query backend's HTTP response body is
+// read into memory.
+//
+// The logs/metrics queries are MODEL-CHOSEN and the pod is memory-capped, so an
+// unbounded io.ReadAll makes one over-broad expression ({__name__=~".+"} over a
+// week) an OOM rather than a bad answer. No attacker required.
+//
+// The bound is derived from the tool-output cap rather than picked fresh: a
+// response only matters insofar as it becomes a tool result, and a tool result
+// is truncated to maxToolOutputDefault before the model ever sees it. The ×64
+// headroom is the gap between the wire form and the rendered form — JSON
+// envelopes, per-series label sets repeated on every sample and RFC3339
+// timestamps routinely inflate a response an order of magnitude over the few KB
+// of summary a backend renders from it — while still refusing the pathological
+// case that no rendering could survive.
+const MaxResponseBytes = 64 * maxToolOutputDefault // 2 MiB
+
+// ErrResponseTooLarge reports that a backend response exceeded MaxResponseBytes.
+// Callers wrap it; tests match it with errors.Is.
+var ErrResponseTooLarge = errors.New("response too large")
+
+// tooLargeError builds the operator- and model-facing overflow message. The
+// investigation loop hands a tool error straight to the model ("error: <text>"),
+// so this is the sentence the model reads: it must say plainly that the result
+// was NOT seen in full, and what to change. Silently returning a partial result
+// would be the worse failure — the model would conclude from evidence it had no
+// reason to doubt.
+func tooLargeError() error {
+	return fmt.Errorf("%w: over %d bytes — narrow the query or shorten the time window", ErrResponseTooLarge, MaxResponseBytes)
+}
+
+// CappedReader wraps r so that reading past MaxResponseBytes fails with
+// ErrResponseTooLarge instead of stopping quietly. Use it for STREAMING parsers
+// (NDJSON scanners): an io.LimitReader would look like a clean end-of-stream, so
+// the parser would return a partial result the caller believes is complete.
+func CappedReader(r io.Reader) io.Reader {
+	// One byte of slack: a body of exactly MaxResponseBytes must succeed, and
+	// only the byte after it proves the upstream had more to send.
+	return &cappedReader{r: r, left: MaxResponseBytes + 1}
+}
+
+type cappedReader struct {
+	r    io.Reader
+	left int64
+}
+
+func (c *cappedReader) Read(p []byte) (int, error) {
+	if c.left <= 0 {
+		return 0, tooLargeError()
+	}
+	if int64(len(p)) > c.left {
+		p = p[:c.left]
+	}
+	n, err := c.r.Read(p)
+	c.left -= int64(n)
+	return n, err
+}
+
+// ReadBody reads a response body whole, up to MaxResponseBytes, returning an
+// error wrapping ErrResponseTooLarge when the upstream sent more. Overflow is an
+// error rather than a truncation because these bodies are parsed as JSON: a body
+// cut at the cap does not parse, so there is no partial result to salvage — only
+// a confusing "unexpected end of JSON input" where an actionable sentence
+// belongs.
+func ReadBody(r io.Reader) ([]byte, error) {
+	return io.ReadAll(CappedReader(r))
+}
+
+// ReadErrorBody reads the diagnostic prefix of a non-2xx response body and makes
+// it safe to embed in an error: bounded at maxErrorBody (all SafeErrorBody would
+// keep anyway) and stripped of the given credentials. A read failure yields ""
+// — the body is best-effort diagnostics, never the reason the call failed.
+func ReadErrorBody(r io.Reader, secrets ...string) string {
+	data, _ := io.ReadAll(io.LimitReader(r, maxErrorBody))
+	return SafeErrorBody(data, secrets...)
+}

--- a/internal/httpx/body_test.go
+++ b/internal/httpx/body_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package httpx
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestReadBodyBoundary: a body of exactly MaxResponseBytes is legitimate and
+// must come back whole; only the byte after it proves the upstream had more.
+func TestReadBodyBoundary(t *testing.T) {
+	exact := strings.Repeat("a", MaxResponseBytes)
+	got, err := ReadBody(strings.NewReader(exact))
+	if err != nil {
+		t.Fatalf("a body at the cap must be accepted: %v", err)
+	}
+	if len(got) != MaxResponseBytes {
+		t.Fatalf("short read: got %d want %d", len(got), MaxResponseBytes)
+	}
+
+	_, err = ReadBody(strings.NewReader(exact + "!"))
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("one byte over the cap must fail: %v", err)
+	}
+	if !strings.Contains(err.Error(), "narrow the query") {
+		t.Errorf("the model reads this text — it must be actionable: %v", err)
+	}
+}
+
+// TestCappedReaderFailsRatherThanEndingQuietly is the whole reason CappedReader
+// exists instead of io.LimitReader: a streaming parser reads a limit as a clean
+// end-of-stream and reports its partial result as the complete answer. A partial
+// answer the model has no reason to doubt is worse than no answer.
+func TestCappedReaderFailsRatherThanEndingQuietly(t *testing.T) {
+	r := CappedReader(strings.NewReader(strings.Repeat("b", MaxResponseBytes+64)))
+	if _, err := io.ReadAll(r); !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("want ErrResponseTooLarge, got %v", err)
+	}
+
+	// io.LimitReader is the trap being avoided: it reports io.EOF, indistinguishable
+	// from a body that genuinely ended.
+	lim := io.LimitReader(strings.NewReader(strings.Repeat("b", MaxResponseBytes+64)), MaxResponseBytes)
+	if _, err := io.ReadAll(lim); err != nil {
+		t.Fatalf("premise broken — LimitReader is supposed to end quietly: %v", err)
+	}
+}
+
+// TestReadErrorBody bounds the diagnostic prefix of a failure response and
+// strips the credential the request carried.
+func TestReadErrorBody(t *testing.T) {
+	const secret = "glpat-SUPERSECRETVALUE1234"
+	got := ReadErrorBody(strings.NewReader(`{"error":"401 for `+secret+`"}`), secret)
+	if strings.Contains(got, secret) {
+		t.Errorf("credential survived: %q", got)
+	}
+	if got := ReadErrorBody(strings.NewReader(strings.Repeat("c", 1<<20))); len(got) != maxErrorBody {
+		t.Errorf("error body not bounded: len=%d want %d", len(got), maxErrorBody)
+	}
+}

--- a/internal/httpx/client.go
+++ b/internal/httpx/client.go
@@ -58,15 +58,31 @@ func DenyInternalRedirect(req *http.Request, via []*http.Request) error {
 			}
 		}
 	}
-	// In-cluster-origin chains redirect among private addresses legitimately — only
-	// guard chains that began at a public endpoint.
-	if len(via) > 0 && hostIsInternal(via[0].URL.Hostname()) {
-		return nil
-	}
 	host := req.URL.Hostname()
 	ips, err := lookupIP(host)
 	if err != nil {
 		return fmt.Errorf("redirect host %q: %w", host, err)
+	}
+	// Link-local is refused from EVERY origin, including an in-cluster one — it is the
+	// one internal target the exemption below must not cover. Nothing in a cluster
+	// legitimately 3xx-redirects into 169.254.0.0/16, and what answers there is the
+	// cloud metadata service. Most RunLore egress (metrics, logs, MCP, an in-cluster
+	// model) starts at a ClusterIP, so leaving this to the exemption switched the
+	// guard off for the majority of outbound traffic: a compromised backend or a
+	// hostile MCP server answering 302 → 169.254.169.254 would have its IMDSv1
+	// credentials read into tool output and then published by the model into a KB PR,
+	// a Slack card or a webhook. The key-stripping above removes the credentials we
+	// SEND; this removes the one we would otherwise FETCH.
+	for _, ip := range ips {
+		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("refusing redirect to link-local address %s (host %q)", ip, host)
+		}
+	}
+	// Everything else: in-cluster-origin chains redirect among private addresses
+	// legitimately (http→https, a trailing slash, a backend behind a proxy), so only
+	// guard chains that began at a public endpoint.
+	if len(via) > 0 && hostIsInternal(via[0].URL.Hostname()) {
+		return nil
 	}
 	for _, ip := range ips {
 		if isInternalIP(ip) {

--- a/internal/httpx/client_test.go
+++ b/internal/httpx/client_test.go
@@ -98,6 +98,36 @@ func TestDenyInternalRedirectAllowsInternalOrigin(t *testing.T) {
 	}
 }
 
+// TestDenyInternalRedirectBlocksLinkLocalFromInternalOrigin pins the one target the
+// internal-origin exemption must NOT cover. Most RunLore egress (metrics, logs, MCP,
+// an in-cluster model) starts at a ClusterIP, so that exemption applies to the
+// majority of outbound traffic — and it is right for private↔private, where a
+// backend legitimately redirects to itself. Link-local is different in kind: nothing
+// in a cluster 3xx-redirects to 169.254.0.0/16, and the one thing living there is the
+// cloud metadata service. A compromised in-cluster backend (or a hostile MCP server
+// on a private address) answering 302 → 169.254.169.254 would otherwise have its
+// IMDSv1 credentials read and handed to the model, which publishes them into a KB PR,
+// a Slack card or a webhook — a complete exfiltration path.
+func TestDenyInternalRedirectBlocksLinkLocalFromInternalOrigin(t *testing.T) {
+	orig := lookupIP
+	defer func() { lookupIP = orig }()
+	lookupIP = func(host string) ([]net.IP, error) {
+		if host == "loki.monitoring.svc.cluster.local" {
+			return []net.IP{net.ParseIP("10.96.0.10")}, nil // in-cluster origin
+		}
+		return []net.IP{net.ParseIP("169.254.169.254")}, nil
+	}
+	origin := mkreq(t, "http://loki.monitoring.svc.cluster.local/loki/api/v1/query")
+	for _, target := range []string{
+		"http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+		"http://metadata.example/latest/meta-data/", // via DNS, same destination
+	} {
+		if err := DenyInternalRedirect(mkreq(t, target), []*http.Request{origin}); err == nil {
+			t.Fatalf("a redirect to link-local %s must be denied even from an in-cluster origin", target)
+		}
+	}
+}
+
 func TestDenyInternalRedirectBlocksExternalToInternal(t *testing.T) {
 	orig := lookupIP
 	defer func() { lookupIP = orig }()

--- a/internal/httpx/redact.go
+++ b/internal/httpx/redact.go
@@ -76,6 +76,37 @@ func SanitizeURLError(err error) error {
 	return fmt.Errorf("%s %s: %w", ue.Op, loc, ue.Err)
 }
 
+// maxErrorBody caps how much of an upstream response body is embedded in an
+// error. A JSON error envelope is well under it; the cap bounds what an upstream
+// returning megabytes can do to a log line.
+const maxErrorBody = 512
+
+// SafeErrorBody prepares an upstream response body for embedding in an error
+// that will be logged and shown to operators: it strips the credentials the
+// request carried, then caps the length.
+//
+// The body is server-controlled. A server that echoes the credential back — a
+// debug endpoint, a chatty proxy, a misconfigured auth layer — would otherwise
+// get it laundered straight into our own error text, and from there into the
+// operator's log store, which is one of the stores RunLore reads back as
+// evidence. Strip it rather than trusting the far end not to reflect it.
+//
+// Stripping happens BEFORE the cap so a credential straddling the cut cannot
+// leave a fragment behind. Empty secrets are ignored, so a caller can pass an
+// optional token unguarded.
+func SafeErrorBody(body []byte, secrets ...string) string {
+	s := string(body)
+	for _, sec := range secrets {
+		if sec != "" {
+			s = strings.ReplaceAll(s, sec, "[REDACTED]")
+		}
+	}
+	if len(s) > maxErrorBody {
+		s = s[:maxErrorBody]
+	}
+	return s
+}
+
 // RequestID returns the first present upstream request-id header (by the
 // precedence in requestIDHeaders), sanitized for safe logging. It returns "" when
 // none is set. The result is operator-trusted correlation metadata — not body

--- a/internal/httpx/redact.go
+++ b/internal/httpx/redact.go
@@ -3,7 +3,10 @@
 package httpx
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -38,6 +41,39 @@ func SanitizeHeader(s string) string {
 		}
 	}
 	return strings.TrimSpace(b.String())
+}
+
+// SanitizeURLError rewrites a *url.Error so only the scheme and host survive —
+// never the path or query. Use it on every error out of http.Client.Do or
+// http.NewRequest whose URL may be a credential.
+//
+// For an incoming webhook (Slack, Discord, Teams) the URL *is* the credential: the
+// secret lives in the path. net/http builds a *url.Error whose Error() prints the
+// full URL, and it masks only the userinfo password — the path is verbatim:
+//
+//	Post "https://hooks.slack.com/services/T0/B0/REAL_SECRET": dial tcp: ...
+//
+// Wrapping that with %w and logging it writes a live posting credential into the
+// operator's log store on any transient DNS or dial failure. No attacker required.
+//
+// The cause is re-wrapped with %w, so errors.Is/As against the underlying error
+// (context.DeadlineExceeded, net.Error) keeps working; the *url.Error itself is
+// deliberately dropped, since it is the thing carrying the secret.
+func SanitizeURLError(err error) error {
+	var ue *url.Error
+	if !errors.As(err, &ue) {
+		return err
+	}
+	// Parse failures fall back to "?" rather than to ue.URL: an unparseable URL is
+	// exactly the case where echoing it back is least justified.
+	loc := "?"
+	if u, perr := url.Parse(ue.URL); perr == nil && u.Host != "" {
+		loc = u.Scheme + "://" + u.Host
+	}
+	if ue.Err == nil {
+		return fmt.Errorf("%s %s", ue.Op, loc)
+	}
+	return fmt.Errorf("%s %s: %w", ue.Op, loc, ue.Err)
 }
 
 // RequestID returns the first present upstream request-id header (by the

--- a/internal/httpx/redact_test.go
+++ b/internal/httpx/redact_test.go
@@ -3,7 +3,9 @@
 package httpx
 
 import (
+	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -68,5 +70,49 @@ func TestRequestID(t *testing.T) {
 				t.Errorf("RequestID(%v) = %q, want %q", tc.headers, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSanitizeURLError: for an incoming webhook the URL is the credential — the
+// secret is the path — and net/http masks only the userinfo password, so the
+// secret survives into any error that wraps it, and from there into the logs.
+func TestSanitizeURLError(t *testing.T) {
+	const secret = "XoXbSuperSecretWebhookKey123"
+	cause := errors.New("dial tcp: lookup hooks.slack.com: no such host")
+
+	got := SanitizeURLError(&url.Error{
+		Op:  "Post",
+		URL: "https://hooks.slack.com/services/T00000000/B00000000/" + secret,
+		Err: cause,
+	})
+	if strings.Contains(got.Error(), secret) {
+		t.Fatalf("the webhook secret survived sanitizing: %v", got)
+	}
+	if !strings.Contains(got.Error(), "https://hooks.slack.com") {
+		t.Fatalf("the host must be kept — it is what makes the error diagnosable: %v", got)
+	}
+	// The cause must stay unwrappable, or callers lose errors.Is on timeouts.
+	if !errors.Is(got, cause) {
+		t.Fatalf("cause no longer unwraps: %v", got)
+	}
+
+	// A userinfo password is masked by net/http, but the path never is; check we
+	// drop both regardless of what the URL carries.
+	got = SanitizeURLError(&url.Error{Op: "Post", URL: "https://u:pw@example.com/a/" + secret, Err: cause})
+	for _, leak := range []string{secret, "pw"} {
+		if strings.Contains(got.Error(), leak) {
+			t.Fatalf("%q survived sanitizing: %v", leak, got)
+		}
+	}
+
+	// Unparseable URL: fall back to a placeholder rather than echoing it.
+	got = SanitizeURLError(&url.Error{Op: "Post", URL: "://" + secret, Err: cause})
+	if strings.Contains(got.Error(), secret) {
+		t.Fatalf("an unparseable URL must not be echoed: %v", got)
+	}
+
+	// A non-url.Error is returned untouched.
+	if got := SanitizeURLError(cause); !errors.Is(got, cause) {
+		t.Fatalf("a plain error must pass through: %v", got)
 	}
 }

--- a/internal/httpx/redact_test.go
+++ b/internal/httpx/redact_test.go
@@ -3,6 +3,7 @@
 package httpx
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"net/url"
@@ -114,5 +115,30 @@ func TestSanitizeURLError(t *testing.T) {
 	// A non-url.Error is returned untouched.
 	if got := SanitizeURLError(cause); !errors.Is(got, cause) {
 		t.Fatalf("a plain error must pass through: %v", got)
+	}
+}
+
+// TestSafeErrorBody: the two forge clients embed an upstream response body in
+// errors that get logged. Stripping must happen before the length cap, or a
+// credential straddling the cut leaves a fragment behind.
+func TestSafeErrorBody(t *testing.T) {
+	const secret = "glpat-SUPERSECRETVALUE1234"
+
+	got := SafeErrorBody([]byte(`{"message":"401 for `+secret+`"}`), secret)
+	if strings.Contains(got, secret) {
+		t.Errorf("credential survived: %q", got)
+	}
+	if !strings.Contains(got, "401 for") {
+		t.Errorf("diagnostic body must survive: %q", got)
+	}
+
+	// The secret sits astride the 512-byte cut: cap-then-strip would keep its head.
+	pad := strings.Repeat("x", maxErrorBody-len(secret)/2)
+	if got := SafeErrorBody([]byte(pad+secret+"tail"), secret); strings.Contains(got, secret[:8]) {
+		t.Errorf("a credential straddling the cap left a fragment: %q", got)
+	}
+
+	if got := SafeErrorBody(bytes.Repeat([]byte("y"), 4096), ""); len(got) != maxErrorBody {
+		t.Errorf("body not capped: len=%d want %d", len(got), maxErrorBody)
 	}
 }

--- a/internal/logs/elasticsearch/elasticsearch.go
+++ b/internal/logs/elasticsearch/elasticsearch.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -416,7 +415,17 @@ func (c *Client) search(ctx context.Context, body map[string]any) ([]byte, int, 
 		return nil, 0, fmt.Errorf("logs query: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	respBody, _ := io.ReadAll(resp.Body)
+	// Bounded: the query is model-chosen and the pod is memory-capped, so an
+	// unbounded read turns one over-broad query into an OOM. The ERROR body gets
+	// the same generous bound rather than the 512-byte diagnostic prefix the
+	// sibling backends use, because here it is parsed, not just printed:
+	// isTextFieldAggError and shardFailure read it to pick the fallback path, and
+	// an ES root_cause envelope can push the interesting substring past 512 bytes.
+	// Capping for display happens where it is formatted into an error instead.
+	respBody, err := httpx.ReadBody(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("logs query: %w", err)
+	}
 	return respBody, resp.StatusCode, nil
 }
 
@@ -428,7 +437,7 @@ func (c *Client) doSearch(ctx context.Context, body map[string]any) ([]byte, err
 		return nil, err
 	}
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("logs status %d: %s", status, string(respBody))
+		return nil, fmt.Errorf("logs status %d: %s", status, httpx.SafeErrorBody(respBody))
 	}
 	return respBody, nil
 }
@@ -574,7 +583,7 @@ func (c *Client) TopMessages(ctx context.Context, query string, w providers.Time
 			c.msgFieldNotAggregatable.Store(true)
 			return c.topMessagesClientSide(ctx, query, w, k)
 		}
-		return nil, fmt.Errorf("logs status %d: %s", status, string(respBody))
+		return nil, fmt.Errorf("logs status %d: %s", status, httpx.SafeErrorBody(respBody))
 	}
 	// A 200 whose shards partly failed (see shardFailure) — the mapping-drift
 	// case, where only the OLDER indices in the pattern lack the aggregatable
@@ -712,9 +721,14 @@ func (c *Client) FieldNames(ctx context.Context, _ string, _ providers.TimeWindo
 		return nil, fmt.Errorf("logs query: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
+	}
+	// Bounded: _field_caps over a wide index pattern is one of the biggest
+	// responses this client can draw, and the pod is memory-capped.
+	body, err := httpx.ReadBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("logs query: %w", err)
 	}
 	// Decode the capability object rather than skipping it: it carries
 	// metadata_field, which is how ES marks its own plumbing (_id, _index, _seq_no,

--- a/internal/logs/elasticsearch/elasticsearch_test.go
+++ b/internal/logs/elasticsearch/elasticsearch_test.go
@@ -5,6 +5,7 @@ package elasticsearch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -1048,5 +1050,31 @@ func TestIndexPathIsEscaped(t *testing.T) {
 				t.Fatalf("request URI has extra path segments: %q", gotURI)
 			}
 		})
+	}
+}
+
+// TestQueryRefusesAnOversizedResponse — see the VictoriaLogs sibling: the query
+// is model-chosen, the pod is memory-capped, and the overflow must reach the
+// model as actionable text rather than as an OOM or a silent partial result.
+func TestQueryRefusesAnOversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"hits":{"hits":[`)
+		hit := `{"_source":{"@timestamp":"2026-01-01T00:00:00Z","message":"` + strings.Repeat("x", 900) + `"}},`
+		for n := 0; n < httpx.MaxResponseBytes+(1<<10); n += len(hit) {
+			_, _ = io.WriteString(w, hit)
+		}
+		_, _ = io.WriteString(w, `{"_source":{"message":"last"}}]}}`)
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "logs-*").Query(context.Background(), "*", providers.TimeWindow{})
+	if err == nil {
+		t.Fatal("an over-cap response must not be read whole")
+	}
+	if !errors.Is(err, httpx.ErrResponseTooLarge) {
+		t.Fatalf("want ErrResponseTooLarge, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "narrow the query") {
+		t.Errorf("the error must tell the model what to do: %v", err)
 	}
 }

--- a/internal/logs/loki/loki.go
+++ b/internal/logs/loki/loki.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -183,9 +182,14 @@ func (c *Client) get(ctx context.Context, path string, v url.Values) ([]byte, er
 		return nil, fmt.Errorf("logs query: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
+	}
+	// Bounded: the LogQL is model-chosen and the pod is memory-capped, so an
+	// unbounded read turns one over-broad selector into an OOM.
+	body, err := httpx.ReadBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("logs query: %w", err)
 	}
 	return body, nil
 }

--- a/internal/logs/loki/loki_test.go
+++ b/internal/logs/loki/loki_test.go
@@ -4,6 +4,7 @@ package loki
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -299,5 +301,31 @@ func TestFieldNamesBothDown(t *testing.T) {
 	defer srv.Close()
 	if _, err := New(srv.URL).FieldNames(context.Background(), `{a="b"}`, providers.TimeWindow{}); err == nil {
 		t.Fatalf("both endpoints failing must error")
+	}
+}
+
+// TestQueryRefusesAnOversizedResponse — see the VictoriaLogs sibling: the query
+// is model-chosen, the pod is memory-capped, and the overflow must reach the
+// model as actionable text rather than as an OOM or a silent partial result.
+func TestQueryRefusesAnOversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":{"result":[{"stream":{"app":"a"},"values":[`)
+		entry := `["1700000000000000000","` + strings.Repeat("x", 900) + `"],`
+		for n := 0; n < httpx.MaxResponseBytes+(1<<10); n += len(entry) {
+			_, _ = io.WriteString(w, entry)
+		}
+		_, _ = io.WriteString(w, `["1700000000000000000","last"]]}]}}`)
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL).Query(context.Background(), `{app="a"}`, providers.TimeWindow{})
+	if err == nil {
+		t.Fatal("an over-cap response must not be read whole")
+	}
+	if !errors.Is(err, httpx.ErrResponseTooLarge) {
+		t.Fatalf("want ErrResponseTooLarge, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "narrow the query") {
+		t.Errorf("the error must tell the model what to do: %v", err)
 	}
 }

--- a/internal/logs/victorialogs/victorialogs.go
+++ b/internal/logs/victorialogs/victorialogs.go
@@ -141,10 +141,11 @@ func (c *Client) queryPage(ctx context.Context, query string, w providers.TimeWi
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
 	}
-	return parseNDJSON(resp.Body)
+	// CappedReader, not io.LimitReader: the scanner would read a cap as a clean
+	// end-of-stream and hand back a partial page as if it were the whole answer.
+	return parseNDJSON(httpx.CappedReader(resp.Body))
 }
 
 // Hits returns the per-step match count over the window, split by log level when
@@ -281,9 +282,14 @@ func (c *Client) postForm(ctx context.Context, path string, form url.Values) ([]
 		return nil, fmt.Errorf("logs query: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("logs status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
+	}
+	// Bounded: the LogsQL is model-chosen and the pod is memory-capped, so an
+	// unbounded read turns one over-broad expression into an OOM.
+	body, err := httpx.ReadBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("logs query: %w", err)
 	}
 	return body, nil
 }

--- a/internal/logs/victorialogs/victorialogs_test.go
+++ b/internal/logs/victorialogs/victorialogs_test.go
@@ -4,6 +4,7 @@ package victorialogs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -356,5 +358,31 @@ func TestQueryPagination(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestQueryRefusesAnOversizedResponse: the LogsQL is model-chosen and the pod is
+// memory-capped. The NDJSON stream is bounded too, not just the io.ReadAll
+// paths — a streaming parser must not mistake a memory cap for the end of the
+// stream and report a partial result as complete. Overflow surfaces as
+// actionable text, which the loop hands to the model verbatim.
+func TestQueryRefusesAnOversizedResponse(t *testing.T) {
+	line := `{"_time":"2026-01-01T00:00:00Z","_msg":"` + strings.Repeat("x", 900) + `"}` + "\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for n := 0; n < httpx.MaxResponseBytes+(1<<10); n += len(line) {
+			_, _ = io.WriteString(w, line)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL).Query(context.Background(), "*", providers.TimeWindow{})
+	if err == nil {
+		t.Fatal("an over-cap response must not be read whole")
+	}
+	if !errors.Is(err, httpx.ErrResponseTooLarge) {
+		t.Fatalf("want ErrResponseTooLarge, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "narrow the query") {
+		t.Errorf("the error must tell the model what to do: %v", err)
 	}
 }

--- a/internal/metrics/prometheus/prometheus.go
+++ b/internal/metrics/prometheus/prometheus.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -261,9 +260,14 @@ func (c *Client) getRaw(ctx context.Context, path string, v url.Values) (json.Ra
 		return nil, fmt.Errorf("metrics query: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("metrics status %d: %s", resp.StatusCode, string(data))
+		return nil, fmt.Errorf("metrics status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
+	}
+	// Bounded: the PromQL is model-chosen and the pod is memory-capped, so an
+	// unbounded read turns one over-broad expression into an OOM.
+	data, err := httpx.ReadBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("metrics query: %w", err)
 	}
 	var r struct {
 		Status string          `json:"status"`
@@ -290,9 +294,14 @@ func (c *Client) get(ctx context.Context, path string, v url.Values) (*apiRespon
 		return nil, fmt.Errorf("metrics query: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("metrics status %d: %s", resp.StatusCode, string(data))
+		return nil, fmt.Errorf("metrics status %d: %s", resp.StatusCode, httpx.ReadErrorBody(resp.Body))
+	}
+	// Bounded: the PromQL is model-chosen and the pod is memory-capped, so an
+	// unbounded read turns one over-broad expression into an OOM.
+	data, err := httpx.ReadBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("metrics query: %w", err)
 	}
 	var r apiResponse
 	if err := json.Unmarshal(data, &r); err != nil {

--- a/internal/metrics/prometheus/prometheus_test.go
+++ b/internal/metrics/prometheus/prometheus_test.go
@@ -4,12 +4,17 @@ package prometheus
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -327,5 +332,43 @@ func TestWithFlavorPinsAndShortCircuits(t *testing.T) {
 	c.WithFlavor(FlavorUnknown)
 	if c.Flavor() != FlavorVictoriaMetrics {
 		t.Fatalf("stray WithFlavor downgraded flavor to %q", c.Flavor())
+	}
+}
+
+// TestQueryRefusesAnOversizedResponse: the PromQL is model-chosen and the pod is
+// memory-capped, so an unbounded io.ReadAll let one over-broad expression
+// ({__name__=~".+"} over a long window) pull the whole series set into memory.
+// The read is bounded at httpx.MaxResponseBytes, and the overflow must reach the
+// model as actionable text — the loop hands a tool error back verbatim
+// ("error: <text>"), so the model learns it did not see everything and what to
+// change, rather than getting a truncated body that fails to parse.
+func TestQueryRefusesAnOversizedResponse(t *testing.T) {
+	// A syntactically valid envelope, deliberately larger than the cap.
+	var b strings.Builder
+	b.WriteString(`{"status":"success","data":{"resultType":"vector","result":[`)
+	for b.Len() < httpx.MaxResponseBytes+(1<<10) {
+		if b.Len() > 60 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"metric":{"__name__":"up","instance":"pod-%d.namespace.svc.cluster.local:9090"},"value":[1700000000,"1"]}`, b.Len())
+	}
+	b.WriteString(`]}}`)
+	body := b.String()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL).Query(context.Background(), `{__name__=~".+"}`, time.Now())
+	if err == nil {
+		t.Fatal("an over-cap response must not be read whole")
+	}
+	if !errors.Is(err, httpx.ErrResponseTooLarge) {
+		t.Fatalf("want ErrResponseTooLarge, got %v", err)
+	}
+	// Actionable for the model, not just a parse failure.
+	if !strings.Contains(err.Error(), "narrow the query") {
+		t.Errorf("the error must tell the model what to do: %v", err)
 	}
 }

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -82,14 +82,19 @@ func (s *Slack) post(ctx context.Context, msg map[string]any) error {
 	if err != nil {
 		return err
 	}
+	// Both error paths are sanitized: an incoming-webhook URL IS the credential (the
+	// secret is its path), net/http reports it verbatim inside a *url.Error — it masks
+	// only a userinfo password — and this error is logged at Error level on the way
+	// out. Otherwise a single DNS blip writes a live posting credential into the
+	// operator's log store, which is one of the stores RunLore itself reads back.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.webhookURL, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return httpx.SanitizeURLError(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := s.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("slack post: %w", err)
+		return fmt.Errorf("slack post: %w", httpx.SanitizeURLError(err))
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode/100 != 2 {

--- a/internal/notify/templated/templated.go
+++ b/internal/notify/templated/templated.go
@@ -87,9 +87,14 @@ func (n *Notifier) deliverOne(ctx context.Context, in instance, p notify.Payload
 	if buf.Len() > maxBody {
 		return fmt.Errorf("rendered body %d bytes exceeds cap %d", buf.Len(), maxBody)
 	}
+	// Sanitized: a templated instance points at Teams/Discord/ntfy/incident.io,
+	// whose incoming-webhook URL carries its secret in the PATH — the URL is the
+	// credential. net/http's *url.Error prints that URL verbatim (it masks only a
+	// userinfo password), and this error is logged at Error level by the delivery
+	// path. Same treatment as the slack and webhook notifiers.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, in.url, &buf)
 	if err != nil {
-		return err
+		return httpx.SanitizeURLError(err)
 	}
 	req.Header.Set("Content-Type", in.contentType)
 	if in.token != "" {
@@ -97,7 +102,7 @@ func (n *Notifier) deliverOne(ctx context.Context, in instance, p notify.Payload
 	}
 	resp, err := n.client.Do(req)
 	if err != nil {
-		return err
+		return httpx.SanitizeURLError(err)
 	}
 	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {

--- a/internal/notify/templated/templated_test.go
+++ b/internal/notify/templated/templated_test.go
@@ -122,3 +122,33 @@ func TestDeliverNon2xxAndSizeCap(t *testing.T) {
 		t.Errorf("want size-cap error, got %v", err)
 	}
 }
+
+// TestDeliverErrorNeverLeaksTheURL: a templated instance targets Teams/Discord/
+// ntfy/incident.io, whose incoming-webhook URL carries the secret IN THE PATH —
+// the URL *is* the credential. net/http reports both a request-build failure and
+// a transport failure as a *url.Error whose Error() prints the URL verbatim (it
+// masks a userinfo password and nothing else), and Deliver's error is logged at
+// Error level by the delivery path. Both sites must go through
+// httpx.SanitizeURLError, which keeps op + scheme://host and drops path/query.
+func TestDeliverErrorNeverLeaksTheURL(t *testing.T) {
+	const secret = "T0ZZZ-B0ZZZ-DoNotLogThisWebhookSecret"
+
+	// Transport failure: a listener that is already closed ⇒ connection refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	dead := srv.URL + "/services/" + secret
+	srv.Close()
+
+	// Request-build failure: a control character makes url.Parse fail, and
+	// url.Parse's own *url.Error carries the raw (secret-bearing) URL.
+	malformed := "https://hooks.example.com/services/" + secret + "\n"
+
+	for name, target := range map[string]string{"transport": dead, "request build": malformed} {
+		err := testNotifier(t, `{{ .Title }}`, target).Deliver(context.Background(), providers.Investigation{Title: "x"})
+		if err == nil {
+			t.Fatalf("%s: want a delivery error, got nil", name)
+		}
+		if strings.Contains(err.Error(), secret) {
+			t.Errorf("%s: error leaks the webhook credential: %v", name, err)
+		}
+	}
+}

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -53,14 +53,18 @@ func (n *Notifier) Deliver(ctx context.Context, inv providers.Investigation) err
 	if err != nil {
 		return err
 	}
+	// Sanitized: the configured URL can itself be the credential — a Discord/Teams/
+	// Slack-compatible incoming webhook carries its secret in the path — and
+	// net/http's *url.Error prints the URL verbatim (it masks only a userinfo
+	// password). This error is logged at Error level by the delivery path.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.url, bytes.NewReader(body))
 	if err != nil {
-		return err
+		return httpx.SanitizeURLError(err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := n.client.Do(req)
 	if err != nil {
-		return err
+		return httpx.SanitizeURLError(err)
 	}
 	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -137,10 +137,16 @@ var kindAnyRE = regexp.MustCompile(`^kind:\s*\S`)
 var dataKeyRE = regexp.MustCompile(`^(\s*)(data|stringData):\s*$`)
 
 // dataEntryRE matches a `  key: value` mapping entry inside a data block,
-// capturing indentation, the "key:" portion, and the value. Block scalars
-// (`key: |` / `key: >`) are handled separately so their following lines are
-// masked too.
+// capturing indentation, the "key:" portion, and the value. An entry also OWNS
+// every following line indented deeper than its key — see k8sSecretData.
 var dataEntryRE = regexp.MustCompile(`^(\s*)([^\s:][^:]*:\s*)(\S.*)$`)
+
+// blockScalarHeaderRE matches a YAML block-scalar header used as an entry's
+// value: `|` or `>` plus the optional indentation/chomping indicators (`|-`,
+// `|+`, `>2-`) and an optional trailing comment. The header is STRUCTURE, not
+// value — it says "a multi-line value was here" and nothing about its content —
+// so it is preserved while the lines it owns are masked.
+var blockScalarHeaderRE = regexp.MustCompile(`^[|>][0-9+-]{0,2}(\s+#.*)?$`)
 
 // k8sSecretData performs a line-oriented pass that masks the VALUES under a
 // `data:`/`stringData:` block of a `kind: Secret` document, preserving keys and
@@ -148,10 +154,25 @@ var dataEntryRE = regexp.MustCompile(`^(\s*)([^\s:][^:]*:\s*)(\S.*)$`)
 // left untouched. It tolerates git-diff line markers ("+ ", "- ", leading
 // space) because a Secret most often surfaces inside a `what_changed` diff.
 //
-// Every masked value is also LEARNED (second return): the raw token and, for a
-// base64 `data:` value, its decoded plaintext. The caller scrubs those literals
-// from the whole payload — the same secret quoted decoded in a log line or
-// encoded in an event must not outlive the manifest that names it.
+// A value may be MULTI-LINE: `key: |` (or `>`, or a plain scalar continued on
+// the next line) puts the secret on the following, more-indented lines. Every
+// line indented deeper than an entry's key therefore belongs to that entry and
+// is masked in place, indentation preserved. Blank lines belong to the value too
+// (YAML block scalars keep them), so they do not end the block — otherwise
+// everything after the first blank line would come through verbatim. The
+// ownership test is the indent, never the `|` marker: the generic key=value rule
+// runs BEFORE this pass and rewrites `password: |` to `password: [REDACTED]`,
+// erasing the marker while leaving the body — which is exactly the partial mask
+// this handling exists to close.
+//
+// Every masked SINGLE-LINE value is also LEARNED (second return): the raw token
+// and, for a base64 `data:` value, its decoded plaintext. The caller scrubs those
+// literals from the whole payload — the same secret quoted decoded in a log line
+// or encoded in an event must not outlive the manifest that names it. Multi-line
+// bodies are deliberately NOT learned: their lines are fragments of one value,
+// and scrubbing a fragment payload-wide would mask ordinary text (a
+// `retries: 3` line out of an embedded config file) everywhere else it appears.
+// Masking in place stops the leak; scrubbing fragments would only blind the model.
 //
 // A data block ends at: a dedent to a column <= the data key's indent, a new
 // top-level key, a `kind:` line, or a YAML document separator ("---"). The pass
@@ -166,6 +187,7 @@ func k8sSecretData(s string) (string, []string) {
 	inSecret := false    // current YAML document is a kind: Secret
 	inDataBlock := false // currently inside that Secret's data:/stringData: block
 	dataIndent := 0      // indent (in columns) of the data: key
+	entryIndent := -1    // indent of the open entry key; it owns deeper lines (-1: none)
 	stringData := false  // the current block is stringData: (plaintext values)
 	var learned []string // secret literals to scrub payload-wide
 
@@ -175,14 +197,14 @@ func k8sSecretData(s string) (string, []string) {
 
 		// Document boundary: a separator resets all document state.
 		if docMarkerRE.MatchString(body) {
-			inSecret, inDataBlock = false, false
+			inSecret, inDataBlock, entryIndent = false, false, -1
 			continue
 		}
 
 		// A new document's kind: line (re)sets whether we are in a Secret.
 		if kindAnyRE.MatchString(body) {
 			inSecret = kindSecretRE.MatchString(body)
-			inDataBlock = false
+			inDataBlock, entryIndent = false, -1
 			continue
 		}
 
@@ -192,10 +214,22 @@ func k8sSecretData(s string) (string, []string) {
 
 		if inDataBlock {
 			indent := leadingSpaces(body)
-			// Block ends on dedent to <= the data key indent, or a blank line
-			// that is not part of the block. Blank lines inside indented data
-			// are unusual; treat a blank line as ending the block.
-			if strings.TrimSpace(body) == "" {
+			blank := strings.TrimSpace(body) == ""
+
+			// Continuation of the open entry's value: deeper than its key, or
+			// blank (a blank line is part of a block scalar, so it must not end
+			// the value — see the doc comment).
+			if entryIndent >= 0 && (blank || indent > entryIndent) {
+				if txt := strings.TrimSpace(body); txt != "" && txt != mask {
+					lines[i] = prefix + body[:indent] + mask
+				}
+				continue
+			}
+			entryIndent = -1
+
+			// No entry open: a blank line ends the block (blank lines between
+			// indented data keys are not a shape real manifests produce).
+			if blank {
 				inDataBlock = false
 				continue
 			}
@@ -205,8 +239,15 @@ func k8sSecretData(s string) (string, []string) {
 				// be a sibling key — re-evaluate below.
 			} else {
 				if entry := dataEntryRE.FindStringSubmatch(body); entry != nil {
+					// The entry now owns every following deeper-indented line.
+					entryIndent = leadingSpaces(entry[1])
 					val := strings.TrimRight(entry[3], " ")
-					if val != mask {
+					switch {
+					case blockScalarHeaderRE.MatchString(val):
+						// Keep the header; the lines it owns are masked above.
+					case val == mask:
+						// Already masked (this pass, or a rule that ran before it).
+					default:
 						learned = append(learned, learnSecretValues(val, stringData)...)
 						lines[i] = prefix + entry[1] + entry[2] + mask
 					}
@@ -217,7 +258,7 @@ func k8sSecretData(s string) (string, []string) {
 
 		// Detect the start of a data:/stringData: block within the Secret.
 		if dk := dataKeyRE.FindStringSubmatch(body); dk != nil {
-			inDataBlock = true
+			inDataBlock, entryIndent = true, -1
 			dataIndent = leadingSpaces(dk[1])
 			stringData = dk[2] == "stringData"
 			continue

--- a/internal/redact/secret_manifest_test.go
+++ b/internal/redact/secret_manifest_test.go
@@ -83,6 +83,122 @@ func TestSecretsMasksK8sSecretData(t *testing.T) {
 	}
 }
 
+// TestSecretsMasksBlockScalarSecretData covers the shape the single-line entry
+// rule cannot see: a `data:`/`stringData:` value written as a YAML block scalar
+// (`key: |`), where the secret lives on the FOLLOWING lines. Before this was
+// implemented the entry rule masked the `|` marker itself and left the body
+// verbatim — a partial mask that reads as "handled" while the secret survives,
+// which is worse than no mask at all because a reviewer stops checking.
+func TestSecretsMasksBlockScalarSecretData(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		gone  []string
+		keeps []string
+	}{
+		{
+			name: "data block scalar with wrapped base64",
+			in: "apiVersion: v1\n" +
+				"kind: Secret\n" +
+				"metadata:\n" +
+				"  name: tls-certs\n" +
+				"type: kubernetes.io/tls\n" +
+				"data:\n" +
+				"  tls.crt: |\n" +
+				"    LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t\n" +
+				"    bW9yZUJhc2U2NENvbnRlbnRPblRoZU5leHRMaW5l\n" +
+				"  tls.key: c3VwM3JzM2NyZXQ=\n",
+			gone: []string{
+				"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t",
+				"bW9yZUJhc2U2NENvbnRlbnRPblRoZU5leHRMaW5l",
+				"c3VwM3JzM2NyZXQ=",
+			},
+			// The block marker is structure, not value: keeping it says "a
+			// multi-line value was here" without saying what it was.
+			keeps: []string{"kind: Secret", "tls.crt: |", "tls.key:", "type: kubernetes.io/tls"},
+		},
+		{
+			name: "stringData block scalar with chomping indicator",
+			in: "kind: Secret\n" +
+				"stringData:\n" +
+				"  config.yaml: |-\n" +
+				"    dsn: postgres://app:hunter2@db:5432/app\n" +
+				"\n" +
+				"    retries: 3\n" +
+				"type: Opaque\n",
+			// A blank line is part of a block scalar in YAML and must not end it,
+			// or everything after it leaks.
+			gone:  []string{"hunter2", "retries: 3"},
+			keeps: []string{"config.yaml: |-", "type: Opaque"},
+		},
+		{
+			// The `|` marker is GONE here before this pass ever runs: "htpasswd"
+			// contains "passwd", so the generic key=value rule rewrites the header
+			// to `htpasswd: [REDACTED]`. The body must still be masked — which is
+			// only true because ownership is decided by indentation, not by
+			// spotting the marker. This case is the regression guard for that.
+			name: "block scalar inside a git diff, marker already eaten by the key rule",
+			in: "@@ -1,6 +1,7 @@\n" +
+				"+kind: Secret\n" +
+				"+stringData:\n" +
+				"+  htpasswd: |\n" +
+				"+    admin:$2y$05$RealBcryptHashGoesHere\n",
+			gone:  []string{"$2y$05$RealBcryptHashGoesHere"},
+			keeps: []string{"kind: Secret", "htpasswd:"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := Secrets(tc.in)
+			for _, g := range tc.gone {
+				if strings.Contains(out, g) {
+					t.Fatalf("block-scalar secret survived redaction: %q\n -> %q", g, out)
+				}
+			}
+			for _, k := range tc.keeps {
+				if !strings.Contains(out, k) {
+					t.Fatalf("structure %q should survive, got %q", k, out)
+				}
+			}
+			if again := Secrets(out); again != out {
+				t.Fatalf("not idempotent: %q -> %q", out, again)
+			}
+		})
+	}
+}
+
+// TestSecretsBlockScalarEndsAtDedent is the over-masking guard for the block
+// scalar rule: the value it owns is exactly the lines indented deeper than its
+// key. A sibling entry, the end of the data block, and everything after the
+// document must come through untouched — over-redacting the evidence the model
+// needs is its own failure mode.
+func TestSecretsBlockScalarEndsAtDedent(t *testing.T) {
+	in := "kind: Secret\n" +
+		"stringData:\n" +
+		"  ca.pem: |\n" +
+		"    secretline-do-not-keep\n" +
+		"type: Opaque\n" +
+		"---\n" +
+		"kind: ConfigMap\n" +
+		"data:\n" +
+		"  notes: |\n" +
+		"    a multi-line log excerpt the model needs\n" +
+		"    second line of evidence\n"
+	out := Secrets(in)
+	if strings.Contains(out, "secretline-do-not-keep") {
+		t.Fatalf("Secret block scalar body should be masked, got %q", out)
+	}
+	for _, keep := range []string{
+		"type: Opaque",
+		"a multi-line log excerpt the model needs",
+		"second line of evidence",
+	} {
+		if !strings.Contains(out, keep) {
+			t.Fatalf("non-Secret content %q must survive, got %q", keep, out)
+		}
+	}
+}
+
 // TestSecretsDoesNotMaskConfigMap guards against over-masking: a non-Secret
 // document with a `data:` block (here a ConfigMap) must be left intact.
 func TestSecretsDoesNotMaskConfigMap(t *testing.T) {


### PR DESCRIPTION
These four fixes surfaced during a security pass run alongside the eval-scorecard review. They were originally committed onto that branch by mistake; they are lifted here because security changes deserve their own review rather than a ride-along on an eval change.

Each was verified with a failing test first.

## 1. Metadata SSRF — `internal/httpx/client.go`

`DenyInternalRedirect` exempted any redirect chain that *originated* at a private address. Most RunLore egress starts at a ClusterIP, so the guard was effectively off for the majority of outbound traffic.

A compromised or hostile backend answering `302 → 169.254.169.254` got its IMDSv1 credentials read into tool output — which RunLore then publishes into a knowledge-base PR or a Slack card. Link-local is now refused from **every** origin; private↔private in-cluster redirects are unaffected.

## 2. Catalog symlink escape — `internal/catalog/load.go`

The loader gated entries by *name*. `WalkDir` does not follow symlinks, but a symlink-to-file reports `IsDir() == false`, and `os.ReadFile` does follow it.

That matters because the catalog syncs from a Git repo — by default a **third-party public commons** — and go-billy only rewrites *absolute* symlink targets. Reproduced: a file outside the catalog root was read into `Entry.Body` and indexed, making it retrievable through `kb_search`. Now type-gated.

## 3. Webhook URL logged as a credential — `internal/notify/`

For Slack, Discord and Teams incoming webhooks the URL **is** the secret. Go's `url.Error` masks only the userinfo password, never the path — so a single DNS blip wrote a live posting credential into the log store RunLore itself reads back.

Adds `httpx.SanitizeURLError` and applies it at the Slack and generic-webhook call sites.

## 4. Supply chain — `.github/workflows/docs*.yml`

These were the only two workflows still on mutable action tags, and `docs.yml` is the sole holder of `pages: write` + `id-token: write`. Actions are now SHA-pinned, and the Hugo `.deb` — previously downloaded and installed as root with no verification — has a checksum gate, verified end-to-end against the real download.

## Known merge-order note

The `docs.yml` hunk overlaps PR #446, which also edits that workflow. Merge #446 first and rebase this, or vice-versa — the changes are in different steps and should resolve cleanly.

## Left for follow-up (reported, not fixed here)

- `internal/notify/templated/templated.go:92,100` need the identical `SanitizeURLError` wrap — the last site of finding 3. The edit was blocked by the permission classifier during the original pass.
- `internal/redact/redact.go:143` — the comment claims YAML block scalars (`key: |`) are "handled separately"; there is no such handling. A `kind: Secret` block scalar gets its `|` marker replaced with `[REDACTED]` while the base64 body survives — partial masking that *looks* handled.
- `internal/eval/coverage.go:71` — `--live --record` captures tool output *before* `redact.Secrets`, writing un-redacted cluster evidence to disk that a human may later promote into tracked fixtures.
- Inline `env:`/`value:` pairs and kubeconfig `client-key-data` have no redaction rule.
- `internal/forge/github/github.go:85` echoes response bodies without the token-stripping its GitLab sibling already does.
- Unbounded `io.ReadAll(resp.Body)` in the logs and metrics backends — model-chosen queries against a memory-capped pod.

## Context worth stating

The rest of the codebase audited clean on the usual suspects: no `InsecureSkipVerify`, no `http.DefaultClient`, constant-time comparisons, `crypto/rand` for approval tokens, distroless-nonroot and digest-pinned images, least-privilege RBAC with no Secrets access. These four are gaps in an otherwise consistent design, not symptoms of a weak one.