### PR TITLE
docs(recall): stop the Go comments calling the reranker opt-in

### DIFF
--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -81,7 +81,7 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 				"margin_gap", cfg.Catalog.InstantRecall.MarginGap, "solo_floor", cfg.Catalog.InstantRecall.SoloFloor,
 				"outcome_prior", cfg.Catalog.InstantRecall.OutcomePrior, "outcome_floor", cfg.Catalog.InstantRecall.OutcomeFloor,
 				"stale_after", cfg.Catalog.InstantRecall.StaleAfter.Std())
-			// LLM reranker (opt-in): replace the corpus-dependent BM25-magnitude fire gate
+			// LLM reranker (ON by default): replace the corpus-dependent BM25-magnitude fire gate
 			// with a CALIBRATED match-confidence gate. Route the one cheap call to the
 			// verify tier (cheaper/faster) when configured, else the main model — mirroring
 			// how verifyFindings picks its model. Metrics/Log are set here so the reranker

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1402,7 +1402,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("catalog.commons.dir (%q) and catalog.dir (%q) must not contain one another: the loader walks recursively, so a nested root is indexed twice — once as shared, once as the operator's own", com, own)
 		}
 	}
-	// Instant-recall reranker (opt-in): its knobs are only meaningful when enabled.
+	// Instant-recall reranker (ON by default): its knobs are only meaningful when enabled.
 	// ApplyDefaults fills unset (0) values, so only an explicitly out-of-range setting
 	// reaches here — fail loud rather than silently gating on a nonsensical threshold.
 	// A threshold in (0,1] is a calibrated PROBABILITY (the reranker returns 0.0–1.0);

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -190,7 +190,7 @@ func ApplyDefaults(c *Config) {
 		if ir.OutcomeFloor == 0 {
 			ir.OutcomeFloor = 0.5
 		}
-		// Reranker (opt-in) defaults: a STABLE, corpus-independent threshold (0.7) is the
+		// Reranker (ON by default) defaults: a STABLE, corpus-independent threshold (0.7) is the
 		// whole point — unlike solo_floor it does not need per-cluster tuning. K is bounded
 		// small (one cheap call over a few candidates); the trivial min-score floor keeps
 		// the paid call from ever running when retrieval surfaced nothing plausible.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -622,7 +622,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 //
 // It threads two pieces of Investigate's state by pointer, mirroring the inline block
 // exactly: `result` (the deferred completion-metric label — "recall" on a short
-// circuit) and `verifyTotals` (so the opt-in reranker + the recall verify pass price
+// circuit) and `verifyTotals` (so the reranker + the recall verify pass price
 // their tokens into the per-investigation cost; both run on the verify tier).
 //
 // Instant recall is disabled under auto-execution: a poisoned catalog entry must not
@@ -634,7 +634,7 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	if li.Recall == nil || (li.Actions != nil && li.Actions.IsAuto()) {
 		return nil, false
 	}
-	// Thread verifyTotals so the (opt-in) reranker's tokens fold into the
+	// Thread verifyTotals so the reranker's tokens fold into the
 	// per-investigation cost — it runs on the verify tier, so it prices there.
 	entry, conf, outcomeRejected := li.Recall.lookupWithUsage(ctx, req, verifyTotals)
 	if entry == nil {

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -52,8 +52,9 @@ type Recall struct {
 	// short-circuits only on the reranker's CALIBRATED, corpus-INDEPENDENT match
 	// confidence. nil ⇒ the BM25-magnitude gate is used, byte-for-byte unchanged. The
 	// structural pre-filter, outcome decay, confirm and verify steps are identical
-	// either way — the reranker only changes WHICH signal decides the fire. Opt-in
-	// (catalog.instant_recall.rerank). See the Reranker doc for the full rationale.
+	// either way — the reranker only changes WHICH signal decides the fire. ON by
+	// default (catalog.instant_recall.rerank: nil ⇒ on). See the Reranker doc for the
+	// full rationale.
 	Rerank *Reranker
 
 	Outcome      OutcomeStats // optional; nil ⇒ no outcome decay
@@ -223,8 +224,8 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 
 	// The fire gate produces the recalled entry `e` and its confidence `conf`. Two
 	// mutually-exclusive gates set them:
-	//   - Reranker gate (opt-in): a CALIBRATED, corpus-independent match confidence.
-	//   - BM25-magnitude gate (default): the classic margin/solo-floor logic, unchanged.
+	//   - Reranker gate (default): a CALIBRATED, corpus-independent match confidence.
+	//   - BM25-magnitude gate (`rerank: false`): the classic margin/solo-floor logic, unchanged.
 	var e catalog.Entry
 	var conf float64
 	var margin float64 // meaningful only in the magnitude gate; 0 (and logged as such) under rerank

--- a/internal/investigate/rerank.go
+++ b/internal/investigate/rerank.go
@@ -18,7 +18,9 @@ import (
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
-// Reranker is the opt-in LLM reranking stage of instant recall.
+// Reranker is the LLM reranking stage of instant recall. It is ON by default whenever
+// instant_recall is enabled; only an explicit `rerank: false` falls back to the legacy
+// BM25-magnitude gate.
 //
 // WHY it exists. Query enrichment fixed retrieval RANKING (the correct runbook now
 // ranks #1 on real BM25), but the short-circuit still gated on the ABSOLUTE BM25
@@ -38,9 +40,11 @@ import (
 // through confirmRecall (live-state confrontation) and the adversarial verifyFindings
 // pass. This is a retrieval-time decision, NOT a second verify.
 //
-// COST discipline. It is one cheap call (~1–2k tokens vs the ~100k a full
-// investigation costs) and only ever runs when retrieval already surfaced a plausible
-// candidate (Recall.lookup applies the MinScore cost guard before calling rank).
+// COST discipline. It is one cheap call (~1–2k tokens) that buys back a whole
+// investigation when it fires — the recorded demo transcript's came to 7 calls /
+// ~15.6k tokens, and max_tokens_per_investigation caps a run at 100k. It only ever
+// runs when retrieval already surfaced a plausible candidate (Recall.lookup applies
+// the MinScore cost guard before calling rank).
 //
 // FALSE-RECALL guard. A reranker that hallucinates a match is worse than no recall, so
 // rank fails SAFE: a model error, a "no match", or an entry_id outside the candidate


### PR DESCRIPTION
The instant-recall LLM reranker is **on by default** — `InstantRecall.RerankEnabled()` is `Enabled && (Rerank == nil || *Rerank)`. Ten Go doc comments still described it as opt-in, and `internal/config/config.go` contradicted itself within a single file: `RerankEnabled` and the `Rerank` field comment correctly say "nil (unset) ⇒ ON", while a few hundred lines away `:1405` called it opt-in.

PR #443 fixed the same claim in the prose docs and the chart values; it could not touch these, because a docs branch should not carry code changes.

Comments only. No logic, no signatures, no defaults.

## Sites

`rerank.go` ×2 · `recall.go` ×3 · `loop.go` ×2 · `config/load.go` · `config/config.go` · `app/investigate.go`

One was not on the original list and is the reason a partial fix would have been worse than none: `recall.go:227` labelled the reranker gate "(opt-in)" and the **very next line** labelled the BM25-magnitude gate "(default)". Correcting only the first would have left two mutually exclusive gates both called "default". The legacy one is now labelled by the setting that selects it, `rerank: false`.

## The `~100k` figure

`rerank.go` also claimed the reranker costs "~1–2k tokens vs the **~100k a full investigation costs**". `~100k` is the `max_tokens_per_investigation` **ceiling** (`config/load.go:152`), not a measured cost. The only full investigation this repo has recorded is `examples/demo/harbor-chart-bump.transcript.json` — verified by summing `usage` across its turns: **7 calls, 14,034 in + 1,537 out ≈ 15.6k**.

Reworded to cite the measurement and name 100k as the cap, mirroring the wording PR #443 landed in `learning-loop.md` §3 rather than inventing a second phrasing for the same fact.

## Sweep

Grepped `opt-in`, `opt in`, `optional`, `when enabled`, and `100k|100,000|100_000|100000` across all Go in `internal/` and `cmd/`. No further reranker sites. Correctly opt-in and left alone: hybrid cosine recall, the recurrence cooldown, the retirement pass, and the `optional; nil-safe` field comments on `Metrics`/`Log`/`Outcome`.

`internal/docsguard/` pins nothing about the reranker, and no test pins these strings, so no guard update was needed.

## Merge note

Touches `loop.go`, `config.go` and `load.go`, which PRs #444, #448 and #449 also touch — in different regions (a metrics block, revalidation config, pinned-ref config). Edits here are comment-only and minimal, so conflicts should be trivial.