### PR TITLE
fix(notify): require and verify a Slack delivery target for feedback buttons

### DIFF
--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -280,8 +280,11 @@ config:
   #     # signing_secret_env: SLACK_SIGNING_SECRET  # only needed for rung-2 approve/reject buttons
   #     # feedback_buttons: true        # OPT-IN 👍/👎 rating buttons feeding the learning loop.
   #     #   Requires Slack to reach POST /slack/interactions (Interactivity Request URL through
-  #     #   your ingress — same exposure as approve/reject buttons), plus signing_secret_env
-  #     #   and outcome.ledger_path. Startup fails loud if either is missing.
+  #     #   your ingress — same exposure as approve/reject buttons), plus signing_secret_env,
+  #     #   outcome.ledger_path AND a delivery target (Option A or Option B above — buttons
+  #     #   render on either). Startup fails loud if any is missing. Mount the secret too: an
+  #     #   EMPTY credential env var skips the Slack notifier entirely (startup warns, no
+  #     #   buttons are delivered and no rating can be recorded).
   #   matrix: { homeserver: https://matrix.org, room_id: "!r:hs", access_token_env: MATRIX_TOKEN }
   #   # matrix.feedback_reactions: true  # OPT-IN 👍/👎 reactions feeding the learning loop.
   #   #   ZERO-INGRESS (outbound /sync long-poll — nothing to expose, unlike Slack buttons).

--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -37,8 +37,8 @@ RENDERER=(internal/notify/slack.go internal/notify/format.go)
 #     fails again, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_RENDERER="a97b1df68c58cc4663d86f42ee160ca5f9f5a638"
-ACKNOWLEDGED_REASON="The VISUAL drift is still #432's: it removed the fabricated 'What changed: No Git change identified' line and both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt. The named commit is newer only because a security fix (webhook URL sanitised out of an error log) touched slack.go without changing a pixel — RENDERER cannot tell visual edits from non-visual ones, so it re-armed on a no-op."
+ACKNOWLEDGED_RENDERER="4eb0ce7c19d1eab3211fef68ceb6581bb7226dfe"
+ACKNOWLEDGED_REASON="The VISUAL drift is still #432's: it removed the fabricated 'What changed: No Git change identified' line and both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt. The named commit is newer only because a non-visual change (resolving the Slack delivery target for feedback buttons) touched slack.go — RENDERER is a file list and cannot tell visual edits from non-visual ones, so it re-armed on a no-op."
 
 last_commit_time() {
   local t

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -18,6 +18,28 @@ func BuildNotifier(cfg *config.Config, log *slog.Logger) (*notify.Multi, error) 
 	return notify.BuildEnabled(notify.Deps{Cfg: cfg, Log: log})
 }
 
+// SlackFeedbackDeliverable reports whether the opt-in 👍/👎 buttons can actually
+// reach Slack, and warns when they cannot. Call it only with
+// notify.slack.feedback_buttons on.
+//
+// Validate already requires a delivery target to be CONFIGURED alongside the
+// option, but configuration is not delivery: the env var holding the webhook URL
+// or bot token can be present and EMPTY at runtime (an unmounted secret, a blank
+// Helm value), and the Slack builder then returns no notifier at all. Nothing is
+// delivered, so no buttons render and no rating can ever be recorded — while
+// startup announced the feature as enabled. That is the same runtime gap
+// BuildMatrixFeedback closes for an empty Matrix access token, checked the same
+// way and in the same place.
+func SlackFeedbackDeliverable(cfg *config.Config, log *slog.Logger) bool {
+	sl := cfg.Notify.Slack
+	if notify.SlackDeliveryTarget(sl) != "" {
+		return true
+	}
+	log.Warn("slack feedback_buttons enabled but no slack delivery target resolved (credential env var empty); no message is delivered, so no buttons render and no feedback can be recorded",
+		"webhook_url_env", sl.WebhookURLEnv, "bot_token_env", sl.BotTokenEnv, "channel", sl.Channel)
+	return false
+}
+
 // BuildMatrixFeedback assembles the opt-in Matrix reaction listener
 // (notify.matrix.feedback_reactions): nil unless the option is on, the outcome
 // ledger persists, and the access token is actually present — a listener that

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// TestSlackFeedbackDeliverable covers the runtime half of the feedback-buttons
+// contract, the half Validate cannot see: an env var that is SET BUT EMPTY (an
+// unmounted secret, a Helm value left blank) passes config validation and still
+// leaves the Slack notifier skipped — no message, no buttons, no feedback — while
+// startup used to log "slack feedback buttons enabled" regardless.
+//
+// So the guard reports whether a message can actually carry the buttons and warns
+// when it cannot, exactly as BuildMatrixFeedback does for an empty Matrix access
+// token. The warning must name the env var the operator has to fix.
+func TestSlackFeedbackDeliverable(t *testing.T) {
+	tests := []struct {
+		name    string
+		slack   config.SlackNotify
+		env     map[string]string
+		want    bool
+		wantLog string // substring the warning must carry; "" ⇒ nothing may be logged
+	}{
+		{
+			name:  "incoming webhook present",
+			slack: config.SlackNotify{WebhookURLEnv: "TEST_SLACK_WEBHOOK_URL"},
+			env:   map[string]string{"TEST_SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/x"},
+			want:  true,
+		},
+		{
+			name:  "bot token present",
+			slack: config.SlackNotify{BotTokenEnv: "TEST_SLACK_BOT_TOKEN", Channel: "C123"},
+			env:   map[string]string{"TEST_SLACK_BOT_TOKEN": "xoxb-test"},
+			want:  true,
+		},
+		{
+			name:    "webhook env set but empty",
+			slack:   config.SlackNotify{WebhookURLEnv: "TEST_SLACK_WEBHOOK_URL"},
+			env:     map[string]string{"TEST_SLACK_WEBHOOK_URL": ""},
+			want:    false,
+			wantLog: "TEST_SLACK_WEBHOOK_URL",
+		},
+		{
+			name:    "bot token env set but empty",
+			slack:   config.SlackNotify{BotTokenEnv: "TEST_SLACK_BOT_TOKEN", Channel: "C123"},
+			env:     map[string]string{"TEST_SLACK_BOT_TOKEN": ""},
+			want:    false,
+			wantLog: "TEST_SLACK_BOT_TOKEN",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			var buf bytes.Buffer
+			log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			cfg := &config.Config{}
+			cfg.Notify.Slack = tc.slack
+			cfg.Notify.Slack.FeedbackButtons = true
+
+			got := SlackFeedbackDeliverable(cfg, log)
+			if got != tc.want {
+				t.Fatalf("SlackFeedbackDeliverable = %v, want %v", got, tc.want)
+			}
+			if tc.wantLog == "" {
+				if buf.Len() > 0 {
+					t.Fatalf("a deliverable configuration must warn about nothing, got: %s", buf.String())
+				}
+				return
+			}
+			out := buf.String()
+			if !strings.Contains(out, "feedback_buttons") || !strings.Contains(out, tc.wantLog) {
+				t.Fatalf("the warning must name the feature and the env var %q, got: %s", tc.wantLog, out)
+			}
+			// Pinned phrase: configuration.md and integrations/notifications/slack.md
+			// both tell operators to grep the startup logs for it, so rewording the
+			// warning without updating those pages breaks the documented procedure.
+			const documentedGrep = "no slack delivery target resolved"
+			if !strings.Contains(out, documentedGrep) {
+				t.Fatalf("the warning must contain the documented grep phrase %q, got: %s", documentedGrep, out)
+			}
+		})
+	}
+}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -389,8 +389,16 @@ func RunServe(version string, args []string) error {
 	// the option, and Enabled() guards the typed-nil/disabled-ledger cases) — so
 	// with the option off the endpoint behaves exactly as before.
 	if cfg.Notify.Slack.FeedbackButtons && ledger.Enabled() {
+		// The recorder is wired either way — a click that does arrive must land in the
+		// ledger — but the capability is only ANNOUNCED when a Slack message can
+		// actually carry the buttons. SlackFeedbackDeliverable warns instead when the
+		// delivery credential is empty at runtime and the notifier was skipped:
+		// "enabled" printed over a sink that delivers nothing is the lie this guard
+		// exists to stop.
 		acts.Feedback = ledger
-		log.Info("slack feedback buttons enabled", "endpoint", "/slack/interactions")
+		if SlackFeedbackDeliverable(cfg, log) {
+			log.Info("slack feedback buttons enabled", "endpoint", "/slack/interactions")
+		}
 	}
 	// /readyz is process + catalog health, NOT leadership (#264): every warm
 	// replica reports Ready (so `helm upgrade --wait` / Flux kstatus succeeds

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -799,8 +799,9 @@ type SlackNotify struct {
 	// messages; clicks are recorded in the outcome ledger and weigh the recalled
 	// entry's trust like resolve signals do. Requires exposing POST
 	// /slack/interactions to Slack (an interactivity Request URL — the same
-	// endpoint approve-mode buttons use) plus signing_secret_env and
-	// outcome.ledger_path; Validate fails loud when either is missing.
+	// endpoint approve-mode buttons use), signing_secret_env, outcome.ledger_path
+	// AND a delivery target (webhook_url_env, or bot_token_env + channel — buttons
+	// render and dispatch on either path); Validate fails loud when any is missing.
 	FeedbackButtons bool `yaml:"feedback_buttons"`
 }
 
@@ -1446,6 +1447,26 @@ func (c *Config) Validate() error {
 		}
 		if c.Outcome.LedgerPath == "" {
 			return fmt.Errorf("notify.slack.feedback_buttons requires outcome.ledger_path: ratings are recorded in the outcome ledger")
+		}
+		// …and a delivery target, because a button only ever exists on a message the
+		// Slack notifier delivered. That notifier is built from an incoming webhook OR
+		// a bot token + channel; with neither, notify/slack.go's builder returns nil and
+		// the notifier is skipped silently — no message, no buttons, no feedback, while
+		// startup happily reported the feature on.
+		//
+		// Either target qualifies: Slack dispatches block_actions for interactive
+		// components posted through an incoming webhook exactly as it does for
+		// chat.postMessage ("incoming webhooks conform to the same rules and
+		// functionality as any of our other messaging APIs"), and the click is answered
+		// via the payload's response_url, which needs no bot token. Requiring the bot
+		// token here would break working webhook deployments.
+		//
+		// This mirrors the builder's static preconditions exactly, so it rejects only
+		// configs where no notifier could ever be built regardless of the environment —
+		// i.e. where the buttons were already dead. Runtime emptiness (an env var set
+		// but unmounted) is not knowable here; app.SlackFeedbackDeliverable warns for it.
+		if sl := c.Notify.Slack; sl.WebhookURLEnv == "" && (sl.BotTokenEnv == "" || sl.Channel == "") {
+			return fmt.Errorf("notify.slack.feedback_buttons requires a Slack delivery target: set notify.slack.webhook_url_env, or notify.slack.bot_token_env together with notify.slack.channel — with neither the Slack notifier is skipped, so no message is delivered, no buttons render and no feedback can ever be recorded")
 		}
 	}
 	// Same fail-loud contract for the Matrix reaction listener: without the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -589,37 +589,113 @@ func TestValidateSkipVerdicts(t *testing.T) {
 }
 
 // TestValidateFeedbackButtons guards the opt-in contract of the Slack feedback
-// loop: enabling notify.slack.feedback_buttons requires BOTH the signing secret
-// (clicks arrive on the exposed /slack/interactions endpoint and must be
-// signature-verified) and the outcome ledger (a rendered button whose click
-// cannot be recorded would be a lie). Off (the default) validates clean with
-// neither.
+// loop end to end: enabling notify.slack.feedback_buttons requires the signing
+// secret (clicks arrive on the exposed /slack/interactions endpoint and must be
+// signature-verified), the outcome ledger (a rendered button whose click cannot
+// be recorded would be a lie) AND a delivery target — a button only exists on a
+// message the Slack notifier actually delivered, and that notifier is only built
+// from an incoming webhook or a bot token + channel. Both are genuine targets:
+// Slack dispatches block_actions for interactive components posted either way,
+// and the click is answered via the payload's response_url, which needs no bot
+// token. Off (the default) validates clean with none of it.
 func TestValidateFeedbackButtons(t *testing.T) {
-	off := &Config{}
-	if err := off.Validate(); err != nil {
-		t.Fatalf("feedback_buttons off must validate clean, got: %v", err)
+	const (
+		secretEnv  = "SLACK_SIGNING_SECRET"
+		ledgerPath = "/var/lib/runlore/outcomes.jsonl"
+	)
+	// on returns a config with feedback_buttons and everything BUT the delivery
+	// target, so each case only spells out the target combination under test.
+	on := func() *Config {
+		c := &Config{}
+		c.Notify.Slack.FeedbackButtons = true
+		c.Notify.Slack.SigningSecretEnv = secretEnv
+		c.Outcome.LedgerPath = ledgerPath
+		return c
 	}
-
-	noSecret := &Config{}
-	noSecret.Notify.Slack.FeedbackButtons = true
-	noSecret.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
-	if err := noSecret.Validate(); err == nil {
-		t.Fatal("feedback_buttons without notify.slack.signing_secret_env must be rejected")
+	tests := []struct {
+		name    string
+		cfg     func() *Config
+		wantErr string // substring the rejection must name; "" ⇒ must validate clean
+	}{
+		{name: "off by default", cfg: func() *Config { return &Config{} }},
+		{
+			name: "on without the signing secret",
+			cfg: func() *Config {
+				c := on()
+				c.Notify.Slack.SigningSecretEnv = ""
+				c.Notify.Slack.WebhookURLEnv = "SLACK_WEBHOOK_URL"
+				return c
+			},
+			wantErr: "notify.slack.signing_secret_env",
+		},
+		{
+			name: "on without the outcome ledger",
+			cfg: func() *Config {
+				c := on()
+				c.Outcome.LedgerPath = ""
+				c.Notify.Slack.WebhookURLEnv = "SLACK_WEBHOOK_URL"
+				return c
+			},
+			wantErr: "outcome.ledger_path",
+		},
+		{
+			name:    "on with no delivery target at all",
+			cfg:     on,
+			wantErr: "notify.slack.webhook_url_env",
+		},
+		{
+			name: "on with a bot token but no channel",
+			cfg: func() *Config {
+				c := on()
+				c.Notify.Slack.BotTokenEnv = "SLACK_BOT_TOKEN"
+				return c
+			},
+			wantErr: "notify.slack.channel",
+		},
+		{
+			name: "on with an incoming webhook",
+			cfg: func() *Config {
+				c := on()
+				c.Notify.Slack.WebhookURLEnv = "SLACK_WEBHOOK_URL"
+				return c
+			},
+		},
+		{
+			name: "on with a bot token and channel",
+			cfg: func() *Config {
+				c := on()
+				c.Notify.Slack.BotTokenEnv = "SLACK_BOT_TOKEN"
+				c.Notify.Slack.Channel = "#alerts"
+				return c
+			},
+		},
+		{
+			name: "on with both targets",
+			cfg: func() *Config {
+				c := on()
+				c.Notify.Slack.WebhookURLEnv = "SLACK_WEBHOOK_URL"
+				c.Notify.Slack.BotTokenEnv = "SLACK_BOT_TOKEN"
+				c.Notify.Slack.Channel = "#alerts"
+				return c
+			},
+		},
 	}
-
-	noLedger := &Config{}
-	noLedger.Notify.Slack.FeedbackButtons = true
-	noLedger.Notify.Slack.SigningSecretEnv = "SLACK_SIGNING_SECRET"
-	if err := noLedger.Validate(); err == nil {
-		t.Fatal("feedback_buttons without outcome.ledger_path must be rejected")
-	}
-
-	ok := &Config{}
-	ok.Notify.Slack.FeedbackButtons = true
-	ok.Notify.Slack.SigningSecretEnv = "SLACK_SIGNING_SECRET"
-	ok.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
-	if err := ok.Validate(); err != nil {
-		t.Fatalf("feedback_buttons with secret + ledger must validate clean, got: %v", err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg().Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("must validate clean, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("must be rejected (error naming %q), got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error must name the missing key %q, got: %v", tc.wantErr, err)
+			}
+		})
 	}
 }
 

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -16,28 +16,53 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/httpx"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+// Delivery targets SlackDeliveryTarget can resolve to.
+const (
+	slackTargetBot     = "bot"     // chat.postMessage with a bot token
+	slackTargetWebhook = "webhook" // incoming webhook
+)
+
+// SlackDeliveryTarget reports which delivery path the Slack notifier resolves to
+// for sl against the current environment: "bot" (chat.postMessage), "webhook"
+// (incoming webhook), or "" when neither is usable — nothing configured, or the
+// env var holding the credential is present but EMPTY (an unmounted secret). ""
+// means the builder below returns no notifier and Slack delivery is silently
+// skipped, which is why this is exported: a startup guard must be able to detect
+// that without re-deriving the precedence rules and drifting from them.
+func SlackDeliveryTarget(sl config.SlackNotify) string {
+	// Bot token (chat.postMessage) takes precedence over an incoming webhook: when
+	// it is configured, an empty token does NOT fall back to the webhook.
+	if sl.BotTokenEnv != "" && sl.Channel != "" {
+		if os.Getenv(sl.BotTokenEnv) != "" {
+			return slackTargetBot
+		}
+		return ""
+	}
+	if sl.WebhookURLEnv != "" && os.Getenv(sl.WebhookURLEnv) != "" {
+		return slackTargetWebhook
+	}
+	return ""
+}
 
 func init() {
 	Register(Descriptor{
 		Name: "slack",
 		Build: func(d Deps) (providers.Notifier, error) {
 			sl := d.Cfg.Notify.Slack
-			// Bot token (chat.postMessage) takes precedence over an incoming webhook.
-			if sl.BotTokenEnv != "" && sl.Channel != "" {
-				if tok := os.Getenv(sl.BotTokenEnv); tok != "" {
-					b := NewSlackBot(tok, sl.Channel)
-					b.FeedbackButtons = sl.FeedbackButtons
-					return b, nil
-				}
-			} else if sl.WebhookURLEnv != "" {
-				if url := os.Getenv(sl.WebhookURLEnv); url != "" {
-					s := NewSlack(url)
-					s.FeedbackButtons = sl.FeedbackButtons
-					return s, nil
-				}
+			switch SlackDeliveryTarget(sl) {
+			case slackTargetBot:
+				b := NewSlackBot(os.Getenv(sl.BotTokenEnv), sl.Channel)
+				b.FeedbackButtons = sl.FeedbackButtons
+				return b, nil
+			case slackTargetWebhook:
+				s := NewSlack(os.Getenv(sl.WebhookURLEnv))
+				s.FeedbackButtons = sl.FeedbackButtons
+				return s, nil
 			}
 			return nil, nil
 		},

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -1237,6 +1238,76 @@ func TestSlackCardEscapesTitleOnBothBranches(t *testing.T) {
 			}
 			if !strings.Contains(joined, "&lt;https://evil.example|click here to remediate&gt;") {
 				t.Fatalf("title neither escaped nor present:\n%s", joined)
+			}
+		})
+	}
+}
+
+// TestSlackDeliveryTarget pins what the Slack builder resolves against the
+// environment — the fact a startup guard needs in order to warn instead of
+// announcing feedback buttons nobody will ever see. The set-but-EMPTY cases are
+// the live gap: an unmounted secret leaves the env var present and empty, the
+// builder returns nil, the notifier is skipped and nothing is delivered.
+func TestSlackDeliveryTarget(t *testing.T) {
+	tests := []struct {
+		name string
+		sl   config.SlackNotify
+		env  map[string]string
+		want string
+	}{
+		{name: "nothing configured", want: ""},
+		{
+			name: "incoming webhook, env present",
+			sl:   config.SlackNotify{WebhookURLEnv: "TEST_SLACK_WEBHOOK_URL"},
+			env:  map[string]string{"TEST_SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/x"},
+			want: "webhook",
+		},
+		{
+			name: "incoming webhook, env set but empty",
+			sl:   config.SlackNotify{WebhookURLEnv: "TEST_SLACK_WEBHOOK_URL"},
+			env:  map[string]string{"TEST_SLACK_WEBHOOK_URL": ""},
+			want: "",
+		},
+		{
+			name: "bot token + channel, env present",
+			sl:   config.SlackNotify{BotTokenEnv: "TEST_SLACK_BOT_TOKEN", Channel: "C123"},
+			env:  map[string]string{"TEST_SLACK_BOT_TOKEN": "xoxb-test"},
+			want: "bot",
+		},
+		{
+			// The bot token wins when configured, so an empty one does NOT silently
+			// fall back to a configured webhook — pinned, because that asymmetry is
+			// exactly the shape an operator misreads as "the webhook still works".
+			name: "bot token set but empty, webhook configured",
+			sl:   config.SlackNotify{BotTokenEnv: "TEST_SLACK_BOT_TOKEN", Channel: "C123", WebhookURLEnv: "TEST_SLACK_WEBHOOK_URL"},
+			env:  map[string]string{"TEST_SLACK_BOT_TOKEN": "", "TEST_SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/x"},
+			want: "",
+		},
+		{
+			name: "bot token without a channel falls through to the webhook",
+			sl:   config.SlackNotify{BotTokenEnv: "TEST_SLACK_BOT_TOKEN", WebhookURLEnv: "TEST_SLACK_WEBHOOK_URL"},
+			env:  map[string]string{"TEST_SLACK_BOT_TOKEN": "xoxb-test", "TEST_SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/x"},
+			want: "webhook",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			if got := SlackDeliveryTarget(tc.sl); got != tc.want {
+				t.Fatalf("SlackDeliveryTarget = %q, want %q", got, tc.want)
+			}
+			// The builder must agree with the guard: a resolved target builds a
+			// notifier, an unresolved one is skipped.
+			cfg := &config.Config{}
+			cfg.Notify.Slack = tc.sl
+			n, err := registry["slack"].Build(Deps{Cfg: cfg, Log: discardLog})
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			if (n != nil) != (tc.want != "") {
+				t.Fatalf("builder returned notifier=%v, but SlackDeliveryTarget said %q", n != nil, tc.want)
 			}
 		})
 	}

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -357,8 +357,12 @@ limitations, kept distinct from human-only open questions):
 - **Slack, bot token (`bot_token_env`).** Posts a compact verdict-first summary to `channel`, then the
   full analysis as a **threaded reply**. When `signing_secret_env` is set and action mode is `approve`,
   the summary carries Approve/Reject buttons on any suggested remediation (see below).
-- **Slack incoming webhook (`webhook_url_env`), Matrix, generic webhook.** Deliver the same content as a
-  **single** message (incoming webhooks cannot thread and expose no interaction buttons).
+- **Slack incoming webhook (`webhook_url_env`).** Delivers the same content as a **single** message
+  (incoming webhooks cannot thread). Interactive buttons *do* render and dispatch on this path —
+  incoming webhooks follow the same rules as `chat.postMessage`, and a click is answered through the
+  interaction's `response_url`, which needs no bot token.
+- **Matrix, generic webhook.** Deliver the same content as a **single** message, with no interaction
+  buttons (Matrix feedback arrives as reactions instead — see `matrix.feedback_reactions` below).
 
 **Generic webhook JSON payload** gained `verdict`, `severity`, `environment`, `cluster`, `tenant`,
 `alert_name`, `started_at` (RFC3339, empty when unknown), `occurrences`, `prev_curated_url`, `ruled_out`
@@ -381,8 +385,17 @@ This is the primary trust signal for incidents that have **no resolve channel** 
 > endpoint and the same exposure approve-mode buttons use; if you already run `actions.mode: approve`
 > with Slack buttons, nothing new is exposed). Route it through your ingress/gateway; if you use the
 > chart's `networkPolicy.ingressFrom`, allow your ingress controller, not the internet. Startup **fails
-> loud** unless both `signing_secret_env` (every click is HMAC-verified, ±5 min replay window) and
-> `outcome.ledger_path` (where ratings land) are set.
+> loud** unless `signing_secret_env` (every click is HMAC-verified, ±5 min replay window),
+> `outcome.ledger_path` (where ratings land) **and a Slack delivery target** — `webhook_url_env`, or
+> `bot_token_env` with `channel` — are all set. A button only exists on a message RunLore actually
+> delivered, so feedback with no delivery target configured could never work.
+
+> [!NOTE]
+> **Mount the credential, too.** If the env var naming the webhook URL / bot token is present but
+> **empty** (an unmounted secret, a blank Helm value), the Slack notifier is skipped entirely: nothing
+> is delivered, no buttons render and no rating can be recorded. Config validation cannot see runtime
+> emptiness, so startup logs a **warning** instead of announcing the feature — grep the logs for
+> `no slack delivery target resolved` after enabling it.
 
 Feedback is deliberately **unprivileged**: any signature-valid member of your workspace can rate — a
 rating is an opinion feeding the learning loop, not a cluster mutation (approve/reject keep their

--- a/website/content/docs/integrations/notifications/slack.md
+++ b/website/content/docs/integrations/notifications/slack.md
@@ -44,8 +44,10 @@ kubectl -n runlore logs deploy/runlore | grep 'msg=findings'
 ## Notes
 
 - A **bot token takes precedence** over `webhook_url_env` when both are set.
-- An **incoming webhook** delivers the same content as a **single** message — it cannot thread and
-  exposes no interaction buttons.
+- An **incoming webhook** delivers the same content as a **single** message — it cannot thread. It
+  *does* carry interaction buttons: incoming webhooks follow the same messaging rules as
+  `chat.postMessage`, and a click is answered through the interaction's `response_url`, so neither
+  Approve/Reject nor `feedback_buttons` needs a bot token.
 - **Approve/Reject buttons** (`actions.mode: approve`) and **`feedback_buttons`** (opt-in 👍/👎 rating)
   both need `signing_secret_env` set **and** the same exposure: Slack **Interactivity** turned on, with
   Request URL `https://<your-runlore-host>/slack/interactions` reachable **from Slack's servers**.
@@ -54,8 +56,13 @@ kubectl -n runlore logs deploy/runlore | grep 'msg=findings'
   - Read-only deployments (no actions, no feedback buttons) need none of this.
   - Route it through your ingress/gateway; if you use the chart's `networkPolicy.ingressFrom`, allow
     your ingress controller, not the internet.
-- `feedback_buttons: true` also requires `outcome.ledger_path` — startup fails loud otherwise. Ratings
-  land in the outcome ledger and weigh the recalled entry's trust, exactly like resolve signals do.
+- `feedback_buttons: true` also requires `outcome.ledger_path` **and a delivery target**
+  (`webhook_url_env`, or `bot_token_env` with `channel`) — startup fails loud otherwise, since a button
+  only exists on a message RunLore actually delivered. Ratings land in the outcome ledger and weigh the
+  recalled entry's trust, exactly like resolve signals do.
+- Mount the credential too: an env var that is set but **empty** skips the Slack notifier altogether —
+  nothing is delivered, no buttons render, no rating can be recorded. Validation cannot see that, so
+  startup warns (`no slack delivery target resolved`) instead of reporting the feature enabled.
 - Feedback is deliberately **unprivileged**: any signature-valid member of your workspace can rate
   (approve/reject keep their own `approver_ids` allowlist). One live vote per (trigger key, Slack user);
   latest wins.


### PR DESCRIPTION
`notify.slack.feedback_buttons: true` could be configured with **no Slack delivery target**, and RunLore would start happily while no feedback was possible.

`Validate` required `signing_secret_env` and `outcome.ledger_path`, but neither `webhook_url_env` nor `bot_token_env`. With neither set, the Slack builder returns `(nil, nil)` and the registry skips the notifier silently — no messages, no buttons, no feedback ever recorded. Meanwhile `serve.go` logged *"slack feedback buttons enabled"*.

That matters because human 👍/👎 is one of only two ground-truth channels into the outcome ledger, and for sources with no resolve channel it is the **only** one. An operator who turned it on believed the learning loop's feedback edge was live when it was not.

## Buttons do not need the bot token — established before enforcing anything

Requiring `bot_token_env` would have been the strict-and-wrong direction, breaking working webhook deployments. Evidence:

1. **The click path uses no bot token.** Interactions are answered through the payload's `response_url` (restricted to `https://*.slack.com`), never `chat.update`/`chat.postMessage`. Verification uses `signing_secret_env`.
2. **The webhook path already renders buttons** — `slackMessageWith(inv, s.FeedbackButtons)` appends `feedbackBlocks` regardless of transport. Deliberate since the feature landed.
3. **Slack's own docs**: *"Incoming webhooks conform to the same rules and functionality as any of our other messaging APIs… you can use interactive components."* Dispatch is app-level via the Interactivity Request URL, which `signing_secret_env` already implies.

## Config-time

`feedback_buttons: true` now additionally requires `webhook_url_env`, **or** `bot_token_env` together with `channel`.

**Upgrade safety** comes from equivalence, not leniency: the rule mirrors the builder's *static* preconditions exactly. Any deployment where a Slack notifier can be built still passes. The only configs newly rejected are those where the builder returns nil *regardless of environment* — where the buttons were already dead and no feedback was ever possible.

Runtime emptiness is deliberately **not** enforced here: it isn't knowable at validation, and requiring env presence in `Validate` would break `lore investigate` and CI paths.

## Runtime

- `notify.SlackDeliveryTarget` returns `"bot"` / `"webhook"` / `""`, and the builder now switches on it — so the guard cannot drift from the precedence it describes.
- `app.SlackFeedbackDeliverable` warns when it resolves `""`, matching the placement and tone of the existing Matrix empty-token guard.
- `"slack feedback buttons enabled"` is logged **only** when deliverable. A log line asserting a capability that does not exist is the same defect class as the config gap.
- The ledger recorder stays wired either way, so a click that does arrive still lands.

Pinned behaviour worth knowing: with `bot_token_env` + `channel` set, an **empty** token does *not* fall back to a configured webhook. Pre-existing precedence, preserved and now tested — it is the shape an operator misreads as "the webhook still works".

## Docs correction

`configuration.md` and `integrations/notifications/slack.md` both claimed Slack incoming webhooks *"expose no interaction buttons"*. That has been contradicted by the code since the feature landed, and it becomes load-bearing once the webhook counts as a valid target. Corrected on both, alongside the new requirement lists.

## Tests

Table-driven, TDD, each failing first:

- `TestValidateFeedbackButtons` — 8 combinations, asserts the error *names the missing key*.
- `TestSlackDeliveryTarget` — 6 cases including set-but-empty; each also asserts the **builder agrees** with the resolver. Mutation-probed: relaxing the empty-env check makes it fail.
- `TestSlackFeedbackDeliverable` — asserts silence when deliverable, and that the warning names the env var plus the documented grep phrase, pinning it against docs drift.