### PR TITLE
ci: re-point the screenshot acknowledgement after the squash merges

### DIFF
--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -37,8 +37,8 @@ RENDERER=(internal/notify/slack.go internal/notify/format.go)
 #     fails again, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_RENDERER="4eb0ce7c19d1eab3211fef68ceb6581bb7226dfe"
-ACKNOWLEDGED_REASON="The VISUAL drift is still #432's: it removed the fabricated 'What changed: No Git change identified' line and both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt. The named commit is newer only because a non-visual change (resolving the Slack delivery target for feedback buttons) touched slack.go — RENDERER is a file list and cannot tell visual edits from non-visual ones, so it re-armed on a no-op."
+ACKNOWLEDGED_RENDERER="e99955442a51ba29f3e3b72c7e0557e9ea3c1619"
+ACKNOWLEDGED_REASON="The VISUAL drift is still #432's: it removed the fabricated 'What changed: No Git change identified' line and both shipped screenshots still show it. Retaking needs a live Slack workspace, unavailable until the demo cluster is rebuilt. The named commit is newer only because two non-visual changes (#450 sanitising the webhook URL out of an error log, #452 resolving the Slack delivery target) touched slack.go without changing a pixel."
 
 last_commit_time() {
   local t


### PR DESCRIPTION
`hack/check-screenshots-fresh.sh` currently fails on `main`.

#450 and #452 each touched `internal/notify/slack.go` **without changing a pixel** — one sanitised the webhook URL out of an error log, the other resolved the Slack delivery target for feedback buttons. Both branches carried their own re-point of `ACKNOWLEDGED_RENDERER`, but squash-merging rewrote the sha each named, so main's acknowledgement points at commits that exist only in the merged branches' history.

```
renderer last changed   : 2026-08-03 (e999554) fix(notify): require and verify a Slack delivery target… (#452)
(an acknowledgement exists for 4eb0ce7c…, but the renderer has moved past it)
```

This is the guard working as designed, not a defect in it: `RENDERER` is a file list and cannot distinguish a visual edit from a non-visual one, so **any** renderer commit re-arms it — and the acknowledgement can only name a sha that exists on `main`, which is knowable only after the merge. Re-pointing after the fact is the same move `747ac7c` made.

The reason string now names both no-ops explicitly, so the audit trail does not imply the shipped screenshots are two refactors behind. **The actual visual drift is still #432's alone** — the fabricated "What changed: No Git change identified" line that both images still show. Retaking them needs a live Slack workspace, which is why the acknowledgement exists at all.

Verified: `bash hack/check-screenshots-fresh.sh` exits 0 on this branch.

## Worth considering separately

The guard re-arms on *any* commit to `slack.go`, so every non-visual change to that file costs a follow-up PR. Options, none taken here: narrow `RENDERER` to the block-building functions rather than whole files, or move card rendering into a file that carries nothing else. Both are real changes with their own review; this PR just unblocks `main`.