### PR TITLE
  docs: lead with the recall cost delta and the zero-setup trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,48 +34,61 @@ next time gets an instant answer — no fresh investigation.
 
 **Learns your platform · single Go binary · runs in your cluster · on your models.**
 
-> **The autonomy ladder.** Teams that want more than the read-only default can climb `suggest` →
-> `approve`: even at the top supported rung RunLore only executes *reversible* GitOps operations after
-> an **explicit human approval** — a human stays in the loop at every step
-> (see [Project status](#project-status--stability)).
-
-**Who it's for** — **SRE and platform teams** who want their incident knowledge **portable and
-self-hosted** (no lock-in, your models, your data), and would rather an agent say *"I don't know"* than
-guess. It shines if you run **GitOps** (Flux/Argo CD) — RunLore turns *"what changed?"* into an exact Git
-diff (and, with an opt-in source-repo allowlist, into the offending commit inside an image bump) — but
-GitOps isn't required: every data source is pluggable, and an unset one simply disables its tool.
-
 ## See it in action
 
-Two sides of the same incident, delivered to your chat (shown here in Slack; Matrix delivers the same findings) — the whole point of the learning loop in one place.
+The same incident, twice — and the second time is the whole point. Shown here in Slack; Matrix
+delivers the same findings.
 
-**First time — a full investigation.** A verdict-first summary: the actionability call
-(no action / suggested / required / inconclusive), the confidence-scored root cause, top-cause "why",
-suggested next steps it will *not* apply for you, and the affected resource with what changed in Git.
-Alert metadata, recurrence and a link to the knowledge-base PR appear alongside when the incident
-carries them. With the Slack notifier's **bot token**, the full analysis lands as a threaded reply —
-open questions, data gaps and ruled-out hypotheses. The footer shows the real cost: model calls and
-tokens.
+**First time — a full investigation.** **7 model calls, 131,354 tokens.** A verdict-first card: the
+actionability call, a confidence-scored root cause with the evidence behind it, and suggested next
+steps it will *not* apply for you.
 
 <div align="center">
 <img src="assets/slack-notification.png" alt="RunLore Slack notification — a verdict-first card headed 'ImageGalleryUnavailable — apps/xplane-image-gallery': Action required, High confidence 92%, the cause traced to a manual AWS Secrets Manager DeleteSecret, read-only suggested next steps, a What changed line citing the CloudTrail event, a footer of 7 model calls and 121,758 in / 9,596 out tokens, feedback buttons, and a link to the knowledge-base pull request it opened" width="760" />
 </div>
 
-**Next time — an instant recall.** Once that entry is merged, the same incident — even under a
-*different, generic alert* — is answered straight from your knowledge base: **no investigation, no new
-PR**, just the known cause, the human-reviewed resolution, and the entry it came from. Several times
-cheaper, delivered in seconds: as shipped a recall is **two** model calls — the LLM reranker that
-picks the entry, then the adversarial verify pass — against the **7 calls** the same incident's full
-investigation took. Both cards above and below are that one incident on a live cluster, so the cost is
-a matched pair: **8,289 tokens recalled against 131,354 investigated — about 6%.** A recall is
-re-checked, not replayed: the verify pass is why the recalled card reads 78% where the stored entry
-says 92%, and it will fall through to a full investigation if it cannot confirm the entry. Once the
-entry has a track record, its resolve rate is shown alongside — and it weighs whether recall is
-trusted enough to fire at all.
+**Next time — an instant recall. 2 model calls, 8,289 tokens: about 6% of the cost, in seconds.**
+Once you merge the entry, the same failure — even under a *different, generic alert* — is answered
+straight from your knowledge base: no investigation, no second PR, and it cites the entry so you can
+check it.
 
 <div align="center">
 <img src="assets/recall-notification.png" alt="RunLore Slack notification — an instant recall: an ⚡ Instant recall banner reading 'answered from your knowledge base, no investigation was run', the known cause carried over from the merged entry, High confidence 78% after the verify pass, and a cost footer showing 2 model calls and 4,764 in / 3,525 out tokens" width="760" />
 </div>
+
+<details>
+<summary><b>What's in those cards, in full</b></summary>
+
+Both cards are that one incident on a live cluster, so the cost is a matched pair — 8,289 tokens
+recalled against 131,354 investigated.
+
+**On the investigation.** The actionability call is one of *no action / suggested / required /
+inconclusive*. Alert metadata, recurrence and a link to the knowledge-base PR appear alongside when
+the incident carries them. With the Slack notifier's **bot token**, the full analysis lands as a
+threaded reply — open questions, data gaps and ruled-out hypotheses. The footer shows the real cost:
+model calls and tokens.
+
+**On the recall.** As shipped it is **two** model calls — the LLM reranker that picks the entry, then
+the adversarial verify pass — against the **7** the full investigation took. A recall is *re-checked,
+not replayed*: the verify pass is why the recalled card reads 78% where the stored entry says 92%,
+and it falls through to a full investigation if it cannot confirm the entry. Once the entry has a
+track record its resolve rate is shown alongside, and that record weighs whether recall is trusted
+enough to fire at all.
+
+</details>
+
+## ⚡ Try it in one minute — no cluster, no keys
+
+Before you wire up anything, watch RunLore investigate a real incident and reach a real root cause —
+no Kubernetes, no LLM key, no network. You only need Go:
+
+```bash
+hack/demo.sh
+```
+
+It replays a transcript recorded once against a live model through the **real investigation loop**:
+the same ReAct tool calls, verify pass, and verdict-card renderer that run in production, over fake
+(but realistic) evidence. [What it prints ↓](#what-the-demo-prints)
 
 ## How it works
 
@@ -203,18 +216,10 @@ to Claude Code, HolmesGPT, or any other MCP client.
 
 → [MCP configuration](https://runlore.io/docs/configuration/mcp/)
 
-## ⚡ Try it in one minute — no cluster, no keys
+## What the demo prints
 
-Before you wire up a cluster, watch RunLore investigate a real incident and reach a real root
-cause — no Kubernetes, no LLM key, no network. You only need Go:
-
-```bash
-hack/demo.sh
-```
-
-It builds the binary and replays a transcript recorded once against a live model through the
-**real investigation loop**: the same ReAct tool calls, verify pass, and verdict-card renderer
-that run in production, over fake (but realistic) evidence:
+[`hack/demo.sh`](#-try-it-in-one-minute--no-cluster-no-keys) builds the binary and replays the
+recorded transcript through the real investigation loop:
 
 ```text
 == RunLore demo: investigating "harbor-chart-bump" (recorded model turns, fake providers, no cluster) ==
@@ -248,6 +253,19 @@ with chat and knowledge-base write-back. Curious about the filter that decides w
 investigated in the first place? `hack/demo-trigger-policy.sh` fires mocked Alertmanager alerts
 through the trigger policy. To exercise every feature end-to-end on a throwaway cluster,
 `hack/e2e-k3d.sh` spins one up with [k3d](https://k3d.io/).
+
+## Who it's for
+
+**SRE and platform teams** who want their incident knowledge **portable and self-hosted** (no
+lock-in, your models, your data), and would rather an agent say *"I don't know"* than guess. It
+shines if you run **GitOps** (Flux/Argo CD) — RunLore turns *"what changed?"* into an exact Git diff
+(and, with an opt-in source-repo allowlist, into the offending commit inside an image bump) — but
+GitOps isn't required: every data source is pluggable, and an unset one simply disables its tool.
+
+> **The autonomy ladder.** Teams that want more than the read-only default can climb `suggest` →
+> `approve`: even at the top supported rung RunLore only executes *reversible* GitOps operations after
+> an **explicit human approval** — a human stays in the loop at every step
+> (see [Project status](#project-status--stability)).
 
 ## 🚀 Getting started (production install)
 
@@ -312,7 +330,7 @@ between commits. It's usable today, but "stable" means different things across t
 - **The supported golden path is eval-tested and stable.** That's **Flux** +
   **VictoriaMetrics / Prometheus** + an **Anthropic or OpenAI-compatible** model + a **chat
   notifier** (Slack in the eval) + **GitHub** for the knowledge base. This is the path the
-  [nightly eval](CONTRIBUTING.md#nightly-eval-ci) and the [k3d e2e suite](CONTRIBUTING.md#end-to-end-on-k3d)
+  [nightly eval](CONTRIBUTING.md#nightly-eval-ci) and the [k3d e2e suite](CONTRIBUTING.md#end-to-end-on-k3d-or-kind)
   exercise — run it with confidence.
 - **Argo CD is now end-to-end tested**, alongside Flux — including the **`approve` rung**: the k3d
   suite reconfigures to the `argocd` engine, drives an `Application Degraded` failure through a full

--- a/website/assets/css/custom.css
+++ b/website/assets/css/custom.css
@@ -200,6 +200,52 @@
   font-weight: 700;
 }
 
+/* ---- The zero-setup trial ----
+   Sits immediately under the two output cards, before the feature grid, because
+   that is the one moment the reader has just seen what RunLore produces and has
+   not yet been given anything to do. Everything below it — feature cards, docs
+   grid — asks for more reading; this asks for one command. It is deliberately
+   the only bordered block on the page so it reads as an action, not a section.
+   The frame is rgba-teal over whatever the page background is, so it needs no
+   dark-mode override; the command well is fixed dark on purpose — a terminal
+   reads as a terminal in both themes, and mint-on-navy clears contrast either
+   way. */
+.rl-try {
+  margin: 1.5rem 0 0;
+  padding: 1.25rem 1.4rem;
+  border: 1px solid rgba(20, 201, 166, 0.45);
+  border-radius: 12px;
+  background: rgba(20, 201, 166, 0.06);
+}
+.rl-try-lead {
+  margin: 0;
+  font-size: 15.5px;
+  line-height: 1.55;
+}
+.rl-try pre {
+  margin: 0.9rem 0 0;
+  padding: 0.7rem 0.9rem;
+  overflow-x: auto;
+  border-radius: 8px;
+  background: rgba(2, 6, 23, 0.72);
+}
+.rl-try pre code {
+  font-size: 13.5px;
+  color: #d5f7ee;
+  white-space: pre;
+}
+.rl-try-note {
+  margin: 0.85rem 0 0;
+  font-size: 13.5px;
+  opacity: 0.72;
+  line-height: 1.5;
+}
+.rl-try-note a {
+  color: #14c9a6;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 /* ---- Feature cards + docs cards: subtle lift + teal accent on hover ---- */
 .hextra-feature-grid a:hover,
 .hextra-card:hover {

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -35,13 +35,13 @@ images:
     <a class="rl-shot-zoom" href="#shot-investigation" aria-label="Enlarge the investigation screenshot">
       <img src="/images/slack-notification.png" width="1328" height="2046" loading="lazy" alt="RunLore Slack notification: a verdict-first incident card headed 'ImageGalleryUnavailable — apps/xplane-image-gallery' with an Action required flag, High confidence 92%, the cause traced to a manual AWS Secrets Manager DeleteSecret, read-only suggested next steps, a What changed line citing the CloudTrail event, a cost footer of 7 model calls and 121,758 in / 9,596 out tokens, feedback buttons, and a link to the knowledge-base pull request it opened." />
     </a>
-    <figcaption><strong>An investigation.</strong> The verdict first, then the evidence behind it — plus what it ruled out, what it still doesn&rsquo;t know, and next steps it will <em>not</em> apply for you.</figcaption>
+    <figcaption><strong>An investigation — 7 model calls, 131,354 tokens.</strong> The verdict first, then the evidence behind it — plus what it ruled out, what it still doesn&rsquo;t know, and next steps it will <em>not</em> apply for you.</figcaption>
   </figure>
   <figure class="rl-shot">
     <a class="rl-shot-zoom" href="#shot-recall" aria-label="Enlarge the instant-recall screenshot">
       <img src="/images/recall-notification.png" width="1328" height="1812" loading="lazy" alt="RunLore Slack notification showing an instant recall: an ⚡ Instant recall banner reading 'answered from your knowledge base, no investigation was run', the known cause carried over from the merged entry, High confidence 78% after the verify pass, and a cost footer showing 2 model calls and 4,764 in / 3,525 out tokens." />
     </a>
-    <figcaption><strong>The same failure, next time.</strong> Answered straight from the entry you merged &mdash; no investigation, no second pull request, and it cites the entry so you can check it. Two model calls (the reranker, then the adversarial verify pass) against the seven the same incident&rsquo;s full investigation took: <strong>8,289 tokens instead of 131,354</strong>. The verify pass is why the confidence reads lower than the stored entry&rsquo;s &mdash; a recall is re-checked, not replayed.</figcaption>
+    <figcaption><strong>The same failure, next time &mdash; 2 model calls, 8,289 tokens. About 6% of the cost, in seconds.</strong> Answered straight from the entry you merged: no investigation, no second pull request, and it cites the entry so you can check it. The two calls are the reranker and the adversarial verify pass &mdash; which is why the confidence reads lower than the stored entry&rsquo;s. A recall is re-checked, not replayed.</figcaption>
   </figure>
 </div>
 
@@ -52,6 +52,13 @@ images:
 <div class="rl-shot-overlay" id="shot-recall" role="dialog" aria-label="Instant-recall screenshot, enlarged">
   <a class="rl-shot-overlay-close" href="#shots" aria-label="Close">&times;</a>
   <img src="/images/recall-notification.png" width="1328" height="1812" loading="lazy" alt="" />
+</div>
+
+<p class="rl-eyebrow">Try it before you wire anything up</p>
+<div class="rl-try">
+  <p class="rl-try-lead">Watch RunLore investigate that incident and reach that root cause on your own machine — <strong>no Kubernetes, no LLM key, no network.</strong> You only need Go.</p>
+  <pre><code>git clone https://github.com/Smana/runlore &amp;&amp; cd runlore &amp;&amp; hack/demo.sh</code></pre>
+  <p class="rl-try-note">It replays a transcript recorded once against a live model through the <em>real</em> investigation loop — the same ReAct tool calls, verify pass and verdict renderer that run in production, over fake but realistic evidence. About a minute, most of it the Go build. <a href="https://github.com/Smana/runlore#-try-it-in-one-minute--no-cluster-no-keys">See what it prints →</a></p>
 </div>
 
 {{< hextra/feature-grid cols="2" >}}


### PR DESCRIPTION
 ## Why

  RunLore has been announced several times and sits at 12 stars, 2 forks. That points away from reach as the bottleneck and toward what a visitor actually sees before deciding.

  Two things that already exist were effectively invisible:

  - **The cost delta.** "7 model calls / 131,354 tokens" against "2 calls / 8,289 tokens" is the single most concrete claim on the page, and it sat mid-paragraph in a long caption on both the README and the
  homepage.
  - **The zero-setup trial.** `hack/demo.sh` runs the real investigation loop with no cluster, no key and no network — and it was at README line 206, below the fold by any measure, with **no equivalent on the
  homepage at all**. A recent external review of the project read both the site and the repo and did not find it; it recommended building a hosted sandbox to solve a problem this already solves.

  Neither needed new content. They needed to be reachable.

  ## What

  **README, above the fold — by deletion, not addition.**

  - The autonomy-ladder note and "Who it's for" move down to sit immediately before *Getting started*, where they qualify an install rather than stand between the reader and the hook.
  - The two long screenshot lead-ins fold into a `<details>` block. Nothing is lost — the detail is one disclosure away instead of being the thing you must read to reach the images.
  - Net effect: `hack/demo.sh` moves from **line 206 to line 80**.

  **Numbers first, prose second.** The README captions and both homepage `figcaption`s now open with the figures rather than closing with them.

  **The homepage gains a trial block.** It previously had nothing to *do* between the screenshots and the feature grid — the one moment a reader has just seen the output and is most likely to act. It is
  deliberately the only bordered element on the page, so it reads as an action rather than another section. The frame is rgba-teal over the page background so it needs no dark-mode override; the command well is
  fixed dark on purpose, since a terminal should read as a terminal in both themes.

  **Drive-by fix:** `CONTRIBUTING.md#end-to-end-on-k3d` never resolved — the heading is "End-to-end on k3d (or kind)".

  ## What this deliberately does not change

  The hero (*"No two platforms fail the same way. RunLore learns yours."*) is untouched. The same review proposed replacing it with a cost-led line built on the word *"replay"* — which contradicts the documented
  behaviour that a recall is **re-checked, not replayed**, and reframes RunLore as a cheaper competitor rather than a different one. The density problem is real, but it is on the second screen, not in the hero.

  ## Verification

  - `hugo --minify --gc` builds clean. Local Hugo is 0.164.0 against CI's pinned 0.156.0; the only warning is the pre-existing `languageCode` deprecation, which the pinned version does not emit.
  - `hack/check-anchors.sh` — 390 in-page anchors across 66 pages all resolve.
  - `hack/check-screenshots-fresh.sh` passes.
  - The docs-check rule "no raw `docs/*.md` links in README/CONTRIBUTING" passes.
  - README internal anchors checked with a GitHub-equivalent slugger: all resolve, including the two new ones.
  - **`hack/demo.sh` was actually run** before being promoted to the primary CTA: 37s from a cold build, correct root cause, verdict card as documented. "One minute" holds.
  - The new homepage block was **rendered and inspected in both light and dark** (Playwright, `colorScheme` + `localStorage` theme forced, since the site defaults to `system`).

  No Go code is touched, so the build/vet/test/lint gates are unaffected.