### PR TITLE
docs: ask for feedback where the demo ends

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,11 @@ investigated in the first place? `hack/demo-trigger-policy.sh` fires mocked Aler
 through the trigger policy. To exercise every feature end-to-end on a throwaway cluster,
 `hack/e2e-k3d.sh` spins one up with [k3d](https://k3d.io/).
 
+**Ran it? Tell me where it would have been wrong.** Whether that verdict matches a failure you
+have actually had — and where it would have missed on *your* platform — is the single most useful
+thing you can send, and that includes deciding RunLore isn't for you. A
+[discussion](https://github.com/Smana/runlore/discussions) is enough; no deployment required.
+
 ## Who it's for
 
 **SRE and platform teams** who want their incident knowledge **portable and self-hosted** (no
@@ -359,6 +364,10 @@ we test hardest.
 Teams running RunLore in production are listed in [`ADOPTERS.md`](ADOPTERS.md) — open a PR to add
 yours, or say hello in a [discussion](https://github.com/Smana/runlore/discussions) if you'd rather
 stay unlisted.
+
+Nothing deployed yet? That's still worth hearing. Running
+[`hack/demo.sh`](#-try-it-in-one-minute--no-cluster-no-keys) takes a minute and needs no cluster,
+and what it got wrong about your platform is more useful to me than a star.
 
 ## License
 

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -14,3 +14,23 @@ BIN="$(mktemp -d)/lore"
 go build -o "$BIN" "$ROOT/cmd/lore"
 cd "$ROOT"          # the transcript + scenario paths are repo-relative
 "$BIN" demo investigate --offline default
+
+# The one ask, and it lives here rather than in the README on purpose: someone who
+# has just watched a correct verdict land — at zero cost, zero risk, no key and no
+# cluster — is as willing as they are ever going to be. A single question, printed
+# once, worth more than a star.
+#
+# It is a printed line and nothing else. No ping, no counter, no opt-out to explain:
+# this demo runs offline by design, and quietly walking that back to measure
+# interest would cost more trust than the number could possibly be worth.
+cat <<'ASK'
+
+────────────────────────────────────────────────────────────────────────────
+ Did that verdict match a failure you have actually had?
+
+ Where would it have been wrong on your platform? That is the most useful
+ thing you can tell me — including if you decide RunLore is not for you.
+
+ → https://github.com/Smana/runlore/discussions
+────────────────────────────────────────────────────────────────────────────
+ASK


### PR DESCRIPTION

## Why

  #460 moved `hack/demo.sh` to the top of the README, so the demo now actually gets reached. It produces a correct root cause in about a minute — no key, no cluster, no network — and then asks for nothing.

  That is the moment of peak willingness, and it was being spent on a blank prompt.

  There is also a gap this fills. **GitHub Discussions has been enabled since the start and has never had a single post.** That is a signal about the existing invitations, not about interest: `ADOPTERS.md` asks for
  a team running RunLore *in production*, and there is no rung between "read the README" and that. This adds one.

  Crucially, the question is answerable by someone who has decided **not** to adopt — which is the feedback there is currently no way to collect at all, and probably the most valuable kind at this stage.

  ## What

  `hack/demo.sh` ends with a single question:

   Did that verdict match a failure you have actually had?

   Where would it have been wrong on your platform? That is the most useful
   thing you can tell me — including if you decide RunLore is not for you.

   → https://github.com/Smana/runlore/discussions

  **No telemetry, and that is deliberate.** It is a printed line and nothing else — no ping, no counter, no opt-out to explain. The demo runs offline by design, and instrumenting it to measure interest would cost
  more trust than the number could possibly be worth. The reasoning lives in a comment in the script so it stays with the code rather than in a PR nobody re-reads.

  **README** echoes the ask *below* the demo output rather than beside the run command, so it does not compete with the call to action #460 just surfaced. **"Who's using RunLore"** now names the smaller rung next
  to the production one.

  ## Verification

  - `shellcheck hack/demo.sh` is clean — CI runs `shellcheck hack/*.sh`, so this is a real gate.
  - `bash -n hack/demo.sh` passes.
  - **`hack/demo.sh` run end to end**: exit 0, the block renders after the cost footer, output otherwise unchanged.
  - All four README internal anchors resolve (checked with a GitHub-equivalent slugger).
  - The docs-check rule "no raw `docs/*.md` links" passes.

  ## Linked issue

  n/a