### PR TITLE
docs: publish a roadmap and name the bus factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,11 +348,41 @@ between commits. It's usable today, but "stable" means different things across t
 If you stay on the golden path with a human in the approval loop, you're on the surface
 we test hardest.
 
+## Who maintains this
+
+**One person, today.** RunLore is written and maintained by [@Smana](https://github.com/Smana).
+That is the honest answer to the question you should be asking before you run an agent next to
+your production cluster, so here is what it does and doesn't mean.
+
+**What it means.** There is no support rotation and no SLA. Issues get answered as fast as one
+person with a day job can answer them. A bus-factor of one is a real risk and no amount of test
+coverage retires it.
+
+**What it doesn't mean.** If RunLore stopped being maintained tomorrow, you would lose the
+agent — not what it learned. That is deliberate, and it is the whole reason the knowledge base
+is shaped the way it is:
+
+- Your catalog is **plain [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog)
+  markdown in a Git repo you already own**. Not a database, not a proprietary format, not
+  hosted here. It stays greppable and readable by whatever you use next.
+- There is **no hosted component** and no account. Nothing switches off remotely.
+- It's **Apache-2.0**, a single Go binary, with a published Helm chart. Fork it and carry on.
+
+So the worst case is that you stop getting new features and keep everything you built. That
+trade is the point — the same reason the catalog is portable is the reason abandonment isn't
+fatal.
+
+**Reducing the risk.** The fastest way to widen the bus factor is people running RunLore and
+saying where it breaks. If you're using it, [`ADOPTERS.md`](ADOPTERS.md) or a
+[discussion](https://github.com/Smana/runlore/discussions) helps — anonymously is fine. If you
+want to go further, [`CONTRIBUTING.md`](CONTRIBUTING.md) has the setup, and the
+[roadmap](ROADMAP.md) says what's next and what's deliberately out of scope.
+
 ## Docs
 
 📐 [Design](https://runlore.io/docs/concepts/design/) · 📚 [Learning loop](https://runlore.io/docs/concepts/learning-loop/) · ✅ [Reviewing knowledge](https://runlore.io/docs/concepts/reviewing-knowledge/) · 🧑‍🔧 [KB steward skill](https://runlore.io/docs/reference/kb-steward/) · 🚀 [Getting started](https://runlore.io/docs/getting-started/) · 🧪 [Worked example](https://runlore.io/docs/reference/examples/harbor-registry-down/) ·
 🔌 [Data sources](https://runlore.io/docs/concepts/data-sources/) · ⚙️ [Configuration](https://runlore.io/docs/configuration/configuration/) · 🔗 [MCP — server & client](https://runlore.io/docs/configuration/mcp/) · 📊 [Observability](https://runlore.io/docs/operations/observability/) · 🩺 [Troubleshooting](https://runlore.io/docs/operations/troubleshooting/) ·
-🔒 [Security model](https://runlore.io/docs/security/security-model/) · 🛡 [LLM security architecture](https://runlore.io/docs/security/security-architecture/) · ⬆️ [Upgrade & uninstall](https://runlore.io/docs/operations/upgrade-uninstall/) · 🧭 [Prior art](https://runlore.io/docs/concepts/prior-art/) · 📊 [Benchmarking models](https://runlore.io/docs/reference/benchmarking/) · 🧮 [Nightly eval scorecard](https://runlore.io/eval) · 🛠 [Contributing](CONTRIBUTING.md)
+🔒 [Security model](https://runlore.io/docs/security/security-model/) · 🛡 [LLM security architecture](https://runlore.io/docs/security/security-architecture/) · ⬆️ [Upgrade & uninstall](https://runlore.io/docs/operations/upgrade-uninstall/) · 🧭 [Prior art](https://runlore.io/docs/concepts/prior-art/) · 📊 [Benchmarking models](https://runlore.io/docs/reference/benchmarking/) · 🧮 [Nightly eval scorecard](https://runlore.io/eval) · 🗺 [Roadmap](ROADMAP.md) · 🛠 [Contributing](CONTRIBUTING.md)
 
 ## Who's using RunLore
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,83 @@
+# Roadmap
+
+Where RunLore is going, and what it is deliberately not going to do.
+
+**No dates.** RunLore is built by a single maintainer (see
+[Who maintains this](README.md#who-maintains-this)), so committing to a calendar would be
+dishonest. This is direction and ordering, not a schedule. Ordering changes when someone
+running RunLore tells me it should — see [What would change this](#what-would-change-this).
+
+Everything below is either already public in the repo or tracked as an open issue. Shipped
+work lives in [`CHANGELOG.md`](CHANGELOG.md); the current stability surface — what is
+eval-tested versus what is merely functional — is in
+[Project status](README.md#project-status--stability).
+
+## Now
+
+Model-provider robustness, plus one security hardening. These are the things that make
+RunLore fail badly today, and they are what a new adopter hits first.
+
+| Item | Why it matters |
+|---|---|
+| [Gemini 3.x is unusable](https://github.com/Smana/runlore/issues/392) — the client omits `thought_signature` on function-call parts, so investigations fail on turn 2 | One of three advertised model providers is broken end-to-end |
+| [glm-4.6 stalls on forced `tool_choice`](https://github.com/Smana/runlore/issues/391), silently degrading verify, recall reranking and the eval judge | Silent degradation of the safety passes is worse than a loud failure |
+| [Model-comparison report publishes vacuous columns](https://github.com/Smana/runlore/issues/394) when cases lack `ground_truth` | The published eval is a trust artifact; it must not overstate what it measured |
+| [Wrap untrusted tool outputs in an explicit delimiter](https://github.com/Smana/runlore/issues/362) (project-wide) | Prompt-injection hardening on the boundary where cluster data enters the model |
+
+## Next
+
+Widening what RunLore can plug into **without requiring Go**, and making recall scale with
+the knowledge base.
+
+- **Templated webhook source** — wire Grafana, Datadog and similar alert sources by config
+  alone, no new Go provider per vendor.
+- **Templated notifier** — the same idea on the delivery side (Teams, Discord…), via Go
+  templates rather than a new notifier type each time.
+- **Persisted vector cache + incremental indexing** — path-keyed document IDs and a cache
+  invalidated by model and dimension, so a growing catalog does not mean re-embedding
+  everything on reload.
+- **Graduating hybrid recall out of `EXPERIMENTAL`** — the criteria are already written down
+  and public in
+  [Configuration](https://runlore.io/docs/configuration/configuration/); it graduates when a
+  live-endpoint measurement run meets them, or it gets documented as a dead end. It will not
+  graduate on vibes.
+
+## Later
+
+Direction, not commitment — these may change shape entirely or never be built.
+
+- **Multi-KB federation** — *design only*, deliberately. A merged index with per-source
+  weights and a single writable KB. It carries open questions and an explicit "when NOT to
+  build this" gate, and it stays a design until someone has the problem for real.
+- **Hot-path benchmarks** — catalog reload, recall query, ledger replay, ingest storm.
+  Hermetic, and deliberately not in the PR gate.
+- **The `auto` autonomy rung** — experimental, frozen, and not recommended on real clusters.
+  It stays off by default. The supported posture remains read-only → `suggest` → `approve`,
+  with a human in the loop. This will not be unfrozen quietly.
+
+## Not on the roadmap
+
+Saying no is part of the design. RunLore will not:
+
+- **Match the big agents on native integrations.** RunLore ships a narrow, deliberate native
+  tool set and an MCP client. Vendor coverage comes through MCP, not through 50 hand-written
+  toolsets. This is a permanent choice, not a backlog gap.
+- **Approximate-nearest-neighbour search.** Exact search is fine at the catalog sizes RunLore
+  targets; ANN is a non-goal until roughly 1–2k entries make it necessary.
+- **Write to your infrastructure outside the action gate.** Writes go to Git via reviewed
+  PRs. The `approve` rung executes only *reversible*, allowlisted operations after an
+  explicit human approval.
+
+Smaller deliberate non-goals — ledger-file splitting, deduper eviction, PagerDuty replay
+windows — are listed with their reasoning in the audit roadmap under `dev/plans/`.
+
+## What would change this
+
+The ordering above reflects one maintainer's read of what matters, informed by running
+RunLore on one platform. That is a narrow sample and I know it.
+
+If you are running RunLore — or evaluating it and stopped at something specific — that is the
+input most likely to reorder this list. Open an
+[issue](https://github.com/Smana/runlore/issues), start a
+[discussion](https://github.com/Smana/runlore/discussions), or add yourself to
+[`ADOPTERS.md`](ADOPTERS.md). "We stopped because X" is more useful than a feature request.


### PR DESCRIPTION
## Why

  Two questions a prospective adopter has that no amount of test coverage answers: **where is this going**, and **what happens if the one maintainer stops**. Neither was addressed anywhere in the repo.

  ## What

  **`ROADMAP.md` — Now / Next / Later, with no dates.** Committing to a calendar would be dishonest for a solo project, so the file says so outright and gives direction and ordering instead. Every item traces to an
  open issue, `dev/plans/2026-07-19-audit-roadmap.md`, or an existing public doc. Nothing here is a new promise.

  Two sections carry most of the weight:

  - **"Not on the roadmap"** states the permanent noes — no hosted RunLore, no race to match native integration counts, no ANN below ~1–2k entries, no writes outside the action gate. Saying no is a design position,
  and someone deciding whether to depend on this needs it more than a wishlist.
  - **"What would change this"** says the ordering reflects one maintainer running RunLore on one platform, and asks for the input that would reorder it. *"We stopped because X"* is worth more than a feature
  request.

  **README gains "Who maintains this".** It answers the bus-factor question plainly — one person, no SLA, a real risk that test coverage does not retire — and then makes the argument that matters: if RunLore
  stopped tomorrow you would lose the agent, **not what it learned**. Plain OKF markdown in a repo you already own, no hosted component, Apache-2.0.

  That connection was never stated anywhere, and it is the strongest answer available: the portability that sells the product is the same property that makes abandonment survivable.

  ## Verification

  - All 16 README/ROADMAP cross-links and anchors resolve, checked with a GitHub-equivalent slugger — including the relative file links (`ADOPTERS.md`, `CONTRIBUTING.md`, `CHANGELOG.md`).
  - Hugo builds clean; `hack/check-anchors.sh` passes (390 anchors / 66 pages).
  - The docs-check rule "no raw `docs/*.md` links" passes.
  - The four issues backing the **Now** section re-checked against the API at time of writing.

  ## Linked issue

  n/a