### PR TITLE
feat(chart): enable the knowledge commons in the standard profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,12 @@ The autonomous *alert → RCA → chat* loop is a commodity. What isn't: a knowl
 Git repo you control, PR-reviewed, with full provenance. Knowledge that consistently resolves
 incidents gains trust; knowledge that keeps failing decays.
 
-Starting from empty is optional. The [knowledge commons](https://github.com/Smana/runlore-kb-commons)
-is a shared bundle of generic playbooks you can mount as a second, read-only catalog root, so
-`kb_search` is useful on day one. Your own entries always win ties, and the curator never writes
-there — it is a floor, not a substitute for knowledge from your own incidents.
+Starting from empty is optional — and in the `standard` Helm profile you don't. The
+[knowledge commons](https://github.com/Smana/runlore-kb-commons) is a shared bundle of generic
+playbooks mounted as a second, read-only catalog root, so `kb_search` is useful on day one; it
+ships on in `standard` and `full`, off in `minimal`. Your own entries always win ties, and the
+curator never writes there — it is a floor, not a substitute for knowledge from your own
+incidents, and commons entries never fire instant recall.
 
 An instant recall is never a blind cache hit — three gates stand in front of it: the entry must
 **structurally match** the incident (same workload/resource, retrieval score above a floor), it must

--- a/deploy/helm/runlore/values-standard.yaml
+++ b/deploy/helm/runlore/values-standard.yaml
@@ -88,6 +88,33 @@ config:
       interval: 5m
       # token_env: KB_GIT_TOKEN  # optional; a PRIVATE repo reuses the App below by default
 
+    # A SECOND, read-only catalog root, ON in this profile. Without it a fresh install
+    # searches an empty catalog: the learning loop only starts paying once YOU have
+    # curated entries, which is weeks of incidents away. The commons is a shared corpus
+    # of generic playbooks (CrashLoopBackOff, ImagePullBackOff, unbound PVCs, stuck
+    # cert-manager challenges…) so kb_search grounds an investigation from day one.
+    #
+    # What this does NOT do: commons entries never fire instant recall. They are
+    # resource-less by construction — they describe a failure class, not one cluster's
+    # workload — and recall's structural filter rejects a resource-less entry for any
+    # alert carrying a workload. Day-one value here is BETTER INVESTIGATIONS, not the
+    # cheap instant answers; those still require entries curated from your own incidents.
+    #
+    # Your own entries win scoring ties, and the curator never writes here — drafted
+    # entries always land in your KB repo above. The commons can only ever be a floor.
+    #
+    # It tracks `main` of a repo you do not control, so upstream corrections reach you
+    # without action. To review before it grounds anything, replace `branch` with
+    # `ref: <40-char commit id>` (mutually exclusive; the agent refuses both). Removing
+    # the block entirely is also fine — everything else in this profile still works.
+    #
+    # `dir` MUST sit outside catalog.dir; the chart refuses to render otherwise.
+    commons:
+      url: https://github.com/Smana/runlore-kb-commons
+      branch: main
+      interval: 24h # a shared corpus changes slowly; do not poll it like your own
+      dir: /var/lib/runlore/commons
+
   # Curation — the LEARN half. A verified, confident root cause opens a PR drafting
   # an OKF entry on the KB repo; anything below the bar is delivered to chat only.
   forge:

--- a/website/content/docs/concepts/knowledge-commons.md
+++ b/website/content/docs/concepts/knowledge-commons.md
@@ -3,14 +3,24 @@ title: Knowledge Commons
 weight: 55
 ---
 
-A fresh RunLore deployment has an empty catalog. `kb_search` returns nothing, and it stays
-that way until you have investigated enough incidents to curate entries of your own. The
-**knowledge commons** fills that gap: a shared, read-only corpus of generic playbooks —
-`CrashLoopBackOff`, `ImagePullBackOff`, unbound PVCs, stuck cert-manager challenges,
-unschedulable pods — that covers failure *classes* every Kubernetes platform hits.
+A RunLore deployment starts with an empty catalog of its own. `kb_search` returns nothing
+from it, and it stays that way until you have investigated enough incidents to curate entries
+worth keeping. The **knowledge commons** fills that gap: a shared, read-only corpus of generic
+playbooks — `CrashLoopBackOff`, `ImagePullBackOff`, unbound PVCs, stuck cert-manager
+challenges, unschedulable pods — that covers failure *classes* every Kubernetes platform hits.
 
-It is a **second catalog root**, indexed alongside your own. Enable it and the investigation
-loop has something to ground on from day one.
+It is a **second catalog root**, indexed alongside your own, so the investigation loop has
+something to ground on from day one.
+
+> [!NOTE]
+> **It is on by default in the `standard` Helm profile.** If you installed with
+> `values-standard.yaml` you already have it; `minimal` and the chart defaults leave it off,
+> and `full` enables it too. Remove the `catalog.commons` block to opt out — nothing else
+> depends on it.
+
+What it does *not* do is make instant recall work on day one — see
+[below](#why-commons-entries-never-fire-instant-recall). Day-one value is a better-grounded
+*investigation*, not a cheap instant answer.
 
 ```yaml
 catalog:

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -304,12 +304,16 @@ configured in your `runlore.yaml` refines titles/descriptions/tags (purely
 optional — a model failure falls back to the deterministic result). Re-running
 the same import is a no-op.
 
-## Step 1c — Add the knowledge commons (optional)
+## Step 1c — The knowledge commons (already on in `standard`)
 
-If you have no runbooks to import either, point RunLore at the
-[knowledge commons](https://github.com/Smana/runlore-kb-commons) — a shared, vendor-neutral
-bundle of generic playbooks (CrashLoopBackOff, unbound PVCs, stuck cert-manager challenges,
-unschedulable pods) that ships as a **second, read-only catalog root**:
+If you have no runbooks to import either, the
+[knowledge commons](https://github.com/Smana/runlore-kb-commons) covers the gap — a shared,
+vendor-neutral bundle of generic playbooks (CrashLoopBackOff, unbound PVCs, stuck cert-manager
+challenges, unschedulable pods) mounted as a **second, read-only catalog root**.
+
+**The `standard` and `full` profiles enable it for you**, so if you installed with one of
+those, skip ahead — this step is already done. Add the block yourself only when starting from
+`minimal` or the chart defaults, or when you want to pin the corpus:
 
 ```yaml
 catalog:


### PR DESCRIPTION
## Why

  `values-standard.yaml` describes itself as "the profile most teams want" and turns on the LEARN half of the loop — but shipped with a single, **empty** catalog root, with no mention of the commons at all, not
  even commented.

  So the profile most teams install enables the learning loop against nothing. `kb_search` returns no results until the team has curated entries of their own, which is weeks of incidents away — and the first week
  is when someone decides whether to keep RunLore at all.

  ## What

  `standard` (and already `full`) now mount the [knowledge commons](https://github.com/Smana/runlore-kb-commons) as a second, read-only catalog root: generic playbooks for CrashLoopBackOff, ImagePullBackOff,
  unbound PVCs, stuck cert-manager challenges. `minimal` and the chart defaults are untouched.

  Docs corrected where they now understated it — the concept page opened *"a fresh RunLore deployment has an empty catalog"*, and Getting Started framed the commons as a manual step. Neither is true for `standard`
  any more.

  ## What this deliberately does NOT claim

  **Not day-one instant recall.** Commons entries are resource-less by construction — they describe a failure class, not one cluster's workload — and recall's structural filter rejects a resource-less entry for any
  alert carrying a workload. They can never fire a recall.

  The day-one win is a **better-grounded investigation**. The cheap instant answers still require entries curated from your own incidents. The profile comment, the concept page and the README all say so, because
  overselling this is the fastest way to make the loop look broken when the first recall doesn't fire.

  ## Behaviour change

  A `standard` install now clones `github.com/Smana/runlore-kb-commons` at startup and re-syncs every 24h.

  This is a second git fetch, not a new capability — the profile already syncs the operator's own KB repo over the network — but it is a repo they do not control, tracking `main`. The block documents how to pin a
  commit instead, and states that deleting it breaks nothing else.

  ## Verification

  - `helm lint` passes on all three profiles (this is what CI runs).
  - The `standard` render carries the commons volume, mount, and ConfigMap block.
  - `minimal` renders zero commons references; the chart default (`values.yaml` alone) templates unchanged.
  - Docs build; all anchors resolve.

  ## Linked issue

  n/a