### PR TITLE
docs(chart): state the commons failure mode and correct two details

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ incidents gains trust; knowledge that keeps failing decays.
 Starting from empty is optional — and in the `standard` Helm profile you don't. The
 [knowledge commons](https://github.com/Smana/runlore-kb-commons) is a shared bundle of generic
 playbooks mounted as a second, read-only catalog root, so `kb_search` is useful on day one; it
-ships on in `standard` and `full`, off in `minimal`. Your own entries always win ties, and the
+ships on in `standard` and `full`, off in `minimal` and the chart defaults. Your own entries win ties, and the
 curator never writes there — it is a floor, not a substitute for knowledge from your own
 incidents, and commons entries never fire instant recall.
 

--- a/deploy/helm/runlore/values-standard.yaml
+++ b/deploy/helm/runlore/values-standard.yaml
@@ -104,9 +104,21 @@ config:
     # entries always land in your KB repo above. The commons can only ever be a floor.
     #
     # It tracks `main` of a repo you do not control, so upstream corrections reach you
-    # without action. To review before it grounds anything, replace `branch` with
-    # `ref: <40-char commit id>` (mutually exclusive; the agent refuses both). Removing
-    # the block entirely is also fine — everything else in this profile still works.
+    # without action. To review before it grounds anything, replace `branch` with `ref:`
+    # — a tag or a full 40-character commit id (mutually exclusive with branch; the
+    # agent refuses both). Removing the block entirely is also fine: everything else in
+    # this profile still works.
+    #
+    # It cannot break your install. The commons syncer runs in the background, off the
+    # startup path: if the clone fails — no egress, GitHub down, a typo here — it logs a
+    # warning and the agent serves normally from your own catalog. The one cost of a
+    # failed clone is that the retry waits a full `interval` (below), so a transient
+    # failure at boot means no commons until the next tick or a pod restart.
+    #
+    # Egress: this is an HTTPS clone, so the chart's default NetworkPolicy (any
+    # destination on 443) already allows it. Under `networkPolicy.strict: true` you must
+    # add the host to egress.allowedCIDRs — already covered if your own KB repo is on
+    # the same forge, and a separate entry if it is not.
     #
     # `dir` MUST sit outside catalog.dir; the chart refuses to render otherwise.
     commons:


### PR DESCRIPTION
  ## Why

  Follow-up to #464. A review of that change found its most important operational fact missing, and the review commit landed on the branch after the PR had already merged — so none of it made it to `main`.

  The commons is a **default-on network dependency** now. "It cannot break your install" has to be written down, not inferred.

  ## What

  **The failure mode.** `armCommons` starts the syncer in a goroutine, off the startup path, and a failed `Sync` only logs a warning — the agent serves normally from the operator's own catalog. The one real cost is
  that the retry waits a full `interval`, so a transient failure at boot means no commons for 24h or until a pod restart. Both facts are now in the profile.

  **Egress, explicitly.** An HTTPS clone passes the chart's default NetworkPolicy (any destination on 443); only `networkPolicy.strict: true` needs an `allowedCIDRs` entry, and that is already covered when the
  operator's own KB repo sits on the same forge.

  **Two corrections.** `ref:` accepts a tag *or* a 40-character commit id — the comment offered only the commit id. And the README said the commons is off in `minimal`, omitting that a plain `helm install` with no
  profile also leaves it off; the concept page already had this right.

  ## Verification

  `helm lint` passes on all three profiles; docs build. Comment-only — no rendered-manifest change, which `helm template` confirms.

  ## Linked issue

  Follows up #464.