### PR TITLE
docs(chart): say why instant recall is off in the standard profile

### DIFF
--- a/deploy/helm/runlore/values-standard.yaml
+++ b/deploy/helm/runlore/values-standard.yaml
@@ -127,6 +127,35 @@ config:
       interval: 24h # a shared corpus changes slowly; do not poll it like your own
       dir: /var/lib/runlore/commons
 
+    # INSTANT RECALL IS OFF IN THIS PROFILE — deliberately. This is the one place where
+    # the headline behaviour (a repeat incident answered in seconds for a fraction of the
+    # cost) does NOT describe what you just installed, so it is worth saying plainly
+    # rather than leaving you to wonder why it never fires.
+    #
+    # Why: a recall is not a cache hit. Its confidence is weighted by each entry's real
+    # resolve rate, and that record lives in the outcome ledger — a file. This profile has
+    # no persistent volume (catalog and commons are both emptyDir), so a ledger here would
+    # reset on every restart and every entry would look untested forever. Recall would
+    # still fire; it would just have no track record behind it, which is the property that
+    # makes short-circuiting an investigation safe rather than reckless.
+    #
+    # To turn it on, add all three. The first is what makes the other two mean anything:
+    #
+    #   persistence:
+    #     enabled: true
+    #     size: 5Gi
+    #   config:
+    #     outcome:
+    #       ledger_path: /var/lib/runlore/catalog/outcomes.jsonl  # under catalog.mountPath
+    #     catalog:
+    #       instant_recall:
+    #         enabled: true
+    #
+    # Worth adding at the same time: notify.slack.feedback_buttons (which also requires
+    # notify.slack.signing_secret_env) — 👍/👎 is what writes real outcomes to that ledger.
+    # Without it the ledger records only what the loop infers, and trust decays more slowly
+    # than your on-call's actual experience. values-full.yaml ships this whole set together.
+
   # Curation — the LEARN half. A verified, confident root cause opens a PR drafting
   # an OKF entry on the KB repo; anything below the bar is delivered to chat only.
   forge:


### PR DESCRIPTION
  ## Why

  Two silent divergences between what the minimal profile implies and what it does. Both are the same species as the instant-recall gap in #466: nothing is broken, nothing warns, and the operator has no way to find
  out.

  ## `gitops.engine` was never set

  The chart default enables the gitops **source**, and `what_changed` reads the same engine — but neither `values-minimal.yaml` nor the chart's `values.yaml` sets `engine`, so `GitopsEngine()` falls through to
  `"flux"`. I confirmed the rendered minimal ConfigMap contained **zero** occurrences of `engine`.

  An Argo CD cluster installing minimal therefore gets a watcher for CRDs that do not exist and a `what_changed` that finds nothing — with no error, because falling back to a default is not a failure. That silently
  mis-targets the tool the product is built around, on the profile someone evaluating RunLore reaches for first.

  **This is the one change here that alters rendered output**: the ConfigMap gains `gitops.engine: flux` and nothing else, verified by diffing the render. Behaviour is unchanged for everyone — flux was already the
  effective default — so this buys visibility, not new semantics, and `-f` overriding to `argocd` still works.

  ## The header didn't say what minimal cannot see

  It listed the missing **features** (no catalog, no curation, no actions) but not the missing **evidence**. With no `metrics.url` and no `logs.url`, `query_metrics` and `query_logs` are never registered, so the
  loop runs on Kubernetes state plus the GitOps diff.

  That is a real investigation and the header now says so plainly — but it is narrower than the docs describe for a full install, and `serve` emits no notice, because the `"running without metrics/logs"` line lives
  only on the `lore investigate` CLI path.

  ## Deliberately not done here

  Teaching `serve` to emit that notice. Whether under-configuration deserves a warning on every boot is a design question with its own trade-offs, and it doesn't belong smuggled into a docs change. Happy to file it
  as an issue.

  ## Verification

  - `helm lint` passes on all three profiles.
  - The minimal render diff is **exactly** the two `gitops.engine` lines — nothing else moved.
  - `-f` with `engine: argocd` still overrides correctly from the minimal base.

  ## Linked issue

  n/a