### PR TITLE
fix(ci): check cross-page anchors, and fix three that were already broken

### DIFF
--- a/hack/check-anchors.sh
+++ b/hack/check-anchors.sh
@@ -33,6 +33,19 @@ fail=0
 pages=0
 checked=0
 
+# Map a rendered page back to the content file that produced it, for the ::error
+# annotation. `docs/foo/index.html` is usually `docs/foo.md`, but a SECTION index comes
+# from `docs/foo/_index.md` — and an annotation naming a file that does not exist is one
+# GitHub silently drops, so the reviewer sees the failure only in the raw log.
+source_file() {
+  local rel="${1#"$PUBLIC"/}"; rel="${rel%/index.html}"
+  if [ -f "$ROOT/website/content/${rel}/_index.md" ]; then
+    echo "website/content/${rel}/_index.md"
+  else
+    echo "website/content/${rel}.md"
+  fi
+}
+
 while IFS= read -r page; do
   pages=$((pages + 1))
 
@@ -46,15 +59,58 @@ while IFS= read -r page; do
     [ -z "$frag" ] && continue
     checked=$((checked + 1))
     if ! grep -qxF "$frag" <<<"$ids"; then
-      rel="${page#"$PUBLIC"/}"
-      echo "::error file=website/content/${rel%/index.html}.md::broken in-page anchor #${frag} — no heading with that id"
+      echo "::error file=$(source_file "$page")::broken in-page anchor #${frag} — no heading with that id"
       fail=1
     fi
   done < <(grep -oE 'href="#[^"]*"|href=#[^ >]+' "$page" | sed 's/^href=//; s/^"//; s/"$//; s/^#//' | sort -u || true)
 done < <(find "$PUBLIC" -name index.html)
 
+# ---------------------------------------------------------------------------
+# Cross-page anchors: `[x]({{< relref "other.md#section" >}})`.
+#
+# The loop above only sees href="#frag" — same-page links. A relref to ANOTHER page
+# renders as href="/docs/…/other/#frag", which it never matched, and Hugo's
+# refLinksErrorLevel: ERROR validates only the page half of that reference: the
+# fragment is unchecked by both. So the site's most fragile links — the ones whose
+# target heading lives in a file you are not editing — were the only ones with no
+# guard at all.
+#
+# Found the hard way. Three links pointed at
+# security-model.md#the-feedback-channels--exposure--trust-model with two hyphens; the
+# heading is "## The feedback channels (👍/👎) — exposure & trust model", where the
+# dropped emoji-in-parens AND the dropped em dash each leave a separator behind, so the
+# real id has THREE. Same trap as the em-dash case in the header comment above, one
+# level nastier, and it had already shipped.
+#
+# Index is "<url-path>#<id>" lines so a link can be checked with one grep -qxF and no
+# associative arrays (the URL path is exactly what href= contains, so no normalising).
+index="$(mktemp)"
+trap 'rm -f "$index"' EXIT
+while IFS= read -r page; do
+  url="/${page#"$PUBLIC"/}"; url="${url%index.html}"
+  grep -oE 'id="[^"]*"|id=[^ >]+' "$page" \
+    | sed "s/^id=//; s/^\"//; s/\"$//; s|^|${url}#|" >> "$index" || true
+done < <(find "$PUBLIC" -name index.html)
+sort -u -o "$index" "$index"
+
+xchecked=0
+while IFS= read -r page; do
+  while IFS= read -r link; do
+    [ -z "$link" ] && continue
+    xchecked=$((xchecked + 1))
+    if ! grep -qxF "$link" "$index"; then
+      # Only links into pages this build produced. An href to a path with no rendered
+      # page is a broken *page* ref, which refLinksErrorLevel already fails on; flagging
+      # it here too would just double-report someone else's error.
+      [ -f "$PUBLIC${link%%#*}index.html" ] || continue
+      echo "::error file=$(source_file "$page")::broken cross-page anchor ${link} — that page has no heading with that id"
+      fail=1
+    fi
+  done < <(grep -oE 'href="/[^"#]*#[^"]*"|href=/[^ >#]*#[^ >]+' "$page" | sed 's/^href=//; s/^"//; s/"$//' | sort -u || true)
+done < <(find "$PUBLIC" -name index.html)
+
 if [ "$fail" -ne 0 ]; then
-  echo "FAIL: broken in-page anchors above" >&2
+  echo "FAIL: broken anchors above" >&2
   exit 1
 fi
 
@@ -66,5 +122,11 @@ if [ "$checked" -lt 50 ]; then
        "no longer matching the rendered HTML and is checking nothing" >&2
   exit 1
 fi
+# Same reasoning for the cross-page pass, at the scale that pass actually operates on.
+if [ "$xchecked" -lt 20 ]; then
+  echo "::error::found only $xchecked cross-page anchors across $pages pages — the" \
+       "cross-page pass is no longer matching the rendered HTML and is checking nothing" >&2
+  exit 1
+fi
 
-echo "OK: $checked in-page anchors across $pages pages all resolve to a heading"
+echo "OK: $checked in-page and $xchecked cross-page anchors across $pages pages all resolve to a heading"

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -404,7 +404,7 @@ user)**, latest wins — duplicate clicks are idempotent and changing your mind 
 is an ephemeral "feedback recorded" note visible only to the clicker; the investigation message is
 never modified. With the option off (the default), no buttons render and the endpoint behaves exactly
 as before (404 unless approve mode wired it). Exposure hardening and the vote trust model are
-detailed in [security-model.md]({{< relref "security-model.md#the-feedback-channels--exposure--trust-model" >}}).
+detailed in [security-model.md]({{< relref "security-model.md#the-feedback-channels---exposure--trust-model" >}}).
 
 **Matrix 👍/👎 — `matrix.feedback_reactions` (opt-in, default `false`).** The same feedback loop over
 Matrix **reactions**: react 👍/👎 to a RunLore investigation message and the rating lands in the
@@ -416,7 +416,7 @@ before startup, ignores every emoji except 👍/👎, and only counts votes on m
 sent** (attribution is anchored on `/whoami`; a member-crafted message carrying the trigger field
 attributes nothing). Startup fails loud unless `homeserver`/`room_id`/`access_token_env` and
 `outcome.ledger_path` are set. Use an **invite-only room** — any room member can vote (see
-[security-model.md]({{< relref "security-model.md#the-feedback-channels--exposure--trust-model" >}})).
+[security-model.md]({{< relref "security-model.md#the-feedback-channels---exposure--trust-model" >}})).
 
 ### Generic templated notifier (`notify.templated`)
 

--- a/website/content/docs/integrations/notifications/matrix.md
+++ b/website/content/docs/integrations/notifications/matrix.md
@@ -52,5 +52,5 @@ kubectl -n runlore logs deploy/runlore | grep 'msg=findings'
 
 - [Configuration → `notify`]({{< relref "/docs/configuration/configuration.md#notify--where-findings-go" >}})
   for the full key reference.
-- [Security model → the feedback channels]({{< relref "/docs/security/security-model.md#the-feedback-channels--exposure--trust-model" >}})
+- [Security model → the feedback channels]({{< relref "/docs/security/security-model.md#the-feedback-channels---exposure--trust-model" >}})
   for the exposure and vote trust model.

--- a/website/content/docs/integrations/notifications/slack.md
+++ b/website/content/docs/integrations/notifications/slack.md
@@ -72,6 +72,6 @@ kubectl -n runlore logs deploy/runlore | grep 'msg=findings'
 
 - [Configuration → `notify`]({{< relref "/docs/configuration/configuration.md#notify--where-findings-go" >}})
   for the full key reference.
-- [Security model → the feedback channels]({{< relref "/docs/security/security-model.md#the-feedback-channels--exposure--trust-model" >}})
+- [Security model → the feedback channels]({{< relref "/docs/security/security-model.md#the-feedback-channels---exposure--trust-model" >}})
   for the exposure and vote trust model.
 - [Learning loop]({{< relref "/docs/concepts/learning-loop.md" >}}) — how feedback weighs recall.


### PR DESCRIPTION
## Why

  `check-anchors.sh` only ever matched `href="#frag"` — **same-page** fragments. A relref into another page renders as `href="/docs/…/other/#frag"`, which it never matched, and Hugo's `refLinksErrorLevel: ERROR`
  validates only the *page* half of that reference. The fragment was unchecked by both.

  So the site's most fragile links had no guard at all: the ones whose target heading lives in a file you are not editing, and which therefore break silently when someone renames a heading three directories away.

  ## Three were already broken

  All pointing at `security-model.md#the-feedback-channels--exposure--trust-model` with **two** hyphens. The heading is:

  The feedback channels (👍/👎) — exposure & trust model


  The dropped emoji-in-parens and the dropped em dash *each* leave a separator behind, so the real id has **three**. That is the same trap this script's own header comment documents for em dashes, one level nastier
  — and it had shipped. Fixed in `configuration.md`, `slack.md` and `matrix.md`.

  ## What the new pass does

  Indexes `<url-path>#<id>` for every rendered page and checks each cross-page link against it — one `grep`, no associative arrays, since the URL path is exactly what `href=` contains.

  It carries its own **"guard the guard"** floor. The original nearly shipped inert once already (see the script header: against a minified build it matched zero anchors and cheerfully printed OK), and a second
  pass that silently checks nothing would be the same failure with a new name.

  Links into paths this build did not render are skipped rather than double-reported — `refLinksErrorLevel` already fails those, and reporting them twice obscures whose error it is.

  ## Also: the annotation path for section indexes

  `docs/security` was reported as `docs/security.md`, which does not exist — and **GitHub silently drops an annotation naming a missing file**, so the failure would appear only in the raw log. Section pages come
  from `_index.md`; the helper now checks for that first.

  ## Verification

  - `shellcheck` clean (CI runs `shellcheck hack/*.sh`).
  - Passes on this tree: 399 in-page + 48 cross-page anchors across 67 pages.
  - **Negative-tested**: deliberately broke an anchor, confirmed a non-zero exit and an annotation pointing at the correct source file. A guard that has only ever been seen passing has not been tested.

  ## Linked issue

  n/a