### PR TITLE
docs(chart): make the minimal profile's gitops engine and evidence gaps explicit

### DIFF
--- a/deploy/helm/runlore/values-minimal.yaml
+++ b/deploy/helm/runlore/values-minimal.yaml
@@ -2,6 +2,15 @@
 # catalog, no curation, no actions. Create the `runlore-secrets` Secret and point
 # Alertmanager at the webhook first; step up with values-standard.yaml.
 #
+# What "investigate" means HERE, precisely: no metrics and no logs backend is wired,
+# so query_metrics and query_logs are never registered. The loop runs on Kubernetes
+# state (pod status, events, controller logs) plus the GitOps diff. That is a real
+# investigation and it reaches real root causes — but it is a narrower one than a
+# full install, and `serve` does NOT warn about it at startup (the "running without
+# metrics/logs" notice exists only on the `lore investigate` CLI path). Add
+# config.metrics.url and config.logs.url — see values-standard.yaml — the moment you
+# want evidence from beyond the cluster itself.
+#
 # An OVERLAY on the chart's values.yaml, not the effective config: Helm deep-merges
 # the two, so the running agent also carries the chart defaults absent here (the
 # GitOps source, critical-only triggers, leader election, the investigation rate
@@ -14,6 +23,15 @@ envFrom:
   - secretRef:
       name: runlore-secrets  # ANTHROPIC_API_KEY, RUNLORE_WEBHOOK_TOKEN, SLACK_WEBHOOK_URL
 config:
+  # Stated explicitly, though `flux` is also the built-in default — that is the point.
+  # The chart default enables the gitops SOURCE (react to Flux/Argo CD Ready=False),
+  # and what_changed reads this same engine. Leave the key out on an Argo CD cluster
+  # and you get a watcher for CRDs that do not exist and a what_changed that finds
+  # nothing, silently, because falling back to a default is not an error. Writing it
+  # here changes nothing for Flux users; it makes the choice visible to everyone else.
+  gitops:
+    engine: flux             # or "argocd"
+
   sources:
     alertmanager: {}         # presence is enablement — accept the alert webhook
   model:

--- a/website/content/docs/getting-started.md
+++ b/website/content/docs/getting-started.md
@@ -451,6 +451,8 @@ envFrom:
   - secretRef:
       name: runlore-secrets  # ANTHROPIC_API_KEY, RUNLORE_WEBHOOK_TOKEN, SLACK_WEBHOOK_URL
 config:
+  gitops:
+    engine: flux             # or "argocd" — stated because the default is flux either way
   sources:
     alertmanager: {}         # presence is enablement — accept the alert webhook
   model:


### PR DESCRIPTION

Two silent divergences between what the minimal profile implies and what it does. Both are the same species as the instant-recall gap: nothing is broken, nothing warns, and the operator has no way to find out.

gitops.engine is now written out. The chart default enables the gitops SOURCE, and what_changed reads the same engine — but neither the profile nor the chart's values.yaml set `engine`, so GitopsEngine() falls through to "flux". An Argo CD cluster installing minimal therefore gets a watcher for CRDs that do not exist and a what_changed that finds nothing, without an error, because falling back to a default is not a failure. That silently mis-targets the tool the product is built around, on the profile someone evaluating RunLore reaches for first.

This is the one change here that alters rendered output: the ConfigMap gains `gitops.engine: flux` and nothing else (verified by diffing the render). Behaviour is unchanged for everyone — flux was already the effective default — so this buys visibility, not new semantics, and `-f` overriding it to argocd still works.

The header now also says what minimal cannot see. It listed the missing FEATURES (no catalog, no curation, no actions) but not the missing EVIDENCE: with no metrics.url and no logs.url, query_metrics and query_logs are never registered, so the loop runs on Kubernetes state plus the GitOps diff. That is a real investigation and worth saying so, but it is narrower than the docs describe for a full install — and `serve` emits no notice, because the "running without metrics/logs" line lives only on the `lore investigate` CLI path.

Deliberately NOT done here: teaching `serve` to emit that notice. Whether under-configuration deserves a warning on every boot is a design question with its own trade-offs, and it does not belong smuggled into a docs change.

Verified: helm lint passes on all three profiles; the minimal render diff
is exactly the two engine lines; `-f` with engine: argocd still overrides.

