### PR TITLE
fix(recall): stop instant recall self-destructing after a single use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/Smana/runlore
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.35

--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -37,8 +37,8 @@ RENDERER=(internal/notify/slack.go internal/notify/format.go)
 #     fails again, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_RENDERER=""
-ACKNOWLEDGED_REASON=""
+ACKNOWLEDGED_RENDERER="96e1dc6df8eefc1f7651b6ef0d2f02567e53e3ce"
+ACKNOWLEDGED_REASON="adds a 'confidence not stated' variant for a finding that carries no confidence at all. The stated-confidence line both captures actually show is byte-identical — 96e1dc6 exists specifically to restore its bolding after an incidental change — so neither image is WRONG, only incomplete: they cannot show a variant that had not been written when they were taken. Retake when a live workspace is next available."
 
 last_commit_time() {
   local t

--- a/internal/curate/retirement.go
+++ b/internal/curate/retirement.go
@@ -34,6 +34,12 @@ type RetireForge interface {
 // what keeps them from ever disagreeing about an entry's track record.
 type EntryStats interface {
 	OpenCounts() (map[string]outcome.Aggregate, error)
+	// ResolveChannelLive reports whether a resolve could ever arrive in this
+	// deployment. Retirement must consult it for the same reason the recall gate does
+	// (see investigate.Recall.outcomeGate): where no resolve can arrive, an entry's
+	// unresolved recalls are not failures, and retiring on them would garbage-collect
+	// correct entries. Sharing this interface is what stops the two gates disagreeing.
+	ResolveChannelLive() bool
 }
 
 // Retirement opens a human-reviewed "retire" PR for a merged catalog entry whose
@@ -64,8 +70,15 @@ func (p Retirement) Run(ctx context.Context) error {
 	// Candidate = an entry whose decay is BOTH deep (Factor < Floor) and sustained
 	// (>= MinObservations observations) — a single bad recall must never retire an
 	// entry. Sorted for deterministic logs and tests.
+	// Where no resolve can ever arrive, an unresolved recall is not a failed one — see
+	// EntryStats.ResolveChannelLive. Human votes still count, so the pass keeps working
+	// on those deployments; only entries with NO outcome at all are spared.
+	resolveChannelLive := p.Stats.ResolveChannelLive()
 	var candidates []string
 	for path, agg := range counts {
+		if !agg.HasEvidence() && !resolveChannelLive {
+			continue
+		}
 		obs := agg.Recalls + agg.FeedbackUp + agg.FeedbackDown
 		if obs < p.MinObservations {
 			continue

--- a/internal/curate/retirement_test.go
+++ b/internal/curate/retirement_test.go
@@ -56,6 +56,18 @@ type mapStats map[string]outcome.Aggregate
 
 func (m mapStats) OpenCounts() (map[string]outcome.Aggregate, error) { return m, nil }
 
+// Live by default, so every pre-existing retirement test keeps asserting the
+// resolve-driven decay it was written for. deadChannelStats is the opt-in variant.
+func (m mapStats) ResolveChannelLive() bool { return true }
+
+// deadChannelStats models a deployment where a resolve can never arrive
+// (Alertmanager with send_resolved off, or a source with no resolve channel).
+type deadChannelStats map[string]outcome.Aggregate
+
+func (m deadChannelStats) OpenCounts() (map[string]outcome.Aggregate, error) { return m, nil }
+
+func (m deadChannelStats) ResolveChannelLive() bool { return false }
+
 // *github.Client must satisfy the consumer-side RetireForge interface.
 var _ RetireForge = (*github.Client)(nil)
 
@@ -98,6 +110,27 @@ func TestRetirement(t *testing.T) {
 		}
 		if !strings.Contains(body, "merging this PR retires the entry") {
 			t.Errorf("body missing veto-honest phrasing:\n%s", body)
+		}
+	})
+
+	t.Run("spares unresolvable entries when no resolve can ever arrive", func(t *testing.T) {
+		// Same aggregates as above, on a deployment where a resolve never arrives
+		// (Alertmanager with send_resolved off). Unresolved recalls are then not
+		// failures — retiring on them would garbage-collect correct entries. This
+		// mirrors investigate.Recall.outcomeGate so the two gates cannot disagree.
+		stats := deadChannelStats{
+			"incidents/decayed-recalls.md": {Recalls: 3},                  // no outcome at all -> spare
+			"incidents/decayed-votes.md":   {Recalls: 2, FeedbackDown: 1}, // a human 👎 is ground truth -> retire
+			"incidents/healthy.md":         {Recalls: 4, Resolved: 4},     // factor 0.83 -> keep
+		}
+		forge := &fakeRetireForge{}
+		if err := newRetirement(forge, stats).Run(context.Background()); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		want := []string{"incidents/decayed-votes.md"}
+		if !slices.Equal(forge.proposed, want) {
+			t.Fatalf("proposed=%v, want %v — recalls with no possible resolve must not retire "+
+				"an entry, but human feedback must still bite", forge.proposed, want)
 		}
 	})
 

--- a/internal/docsguard/recall_decay_test.go
+++ b/internal/docsguard/recall_decay_test.go
@@ -232,14 +232,25 @@ func TestRecallDecayGateFailSafeIsFullTrustNotThePrior(t *testing.T) {
 	unreachableFloor := 1.0000001
 
 	derivedFP := outcome.DeriveFingerprint(outcome.GitOpsFingerprintPrefix, "apps/worker|HealthCheckFailed")
-	if !recallFires(t, derivedFP, unreachableFloor) {
+	if !recallFires(t, derivedFP, unreachableFloor, true) {
 		t.Errorf("a recall whose only history is an excluded (synthetic) fingerprint was rejected at "+
 			"floor %v — it should never reach a factor at all, so §6's claim of the 1.0 fail-safe "+
 			"(and not the %g prior) is now wrong", unreachableFloor, f.priorMean)
 	}
-	if recallFires(t, realFingerprint, f.floor) {
+	if recallFires(t, realFingerprint, f.floor, true) {
 		t.Errorf("a recall with ONE unresolved real-fingerprint history (factor %.3f) still fires at "+
-			"the shipped floor %g — §6 says instant recall stops firing it", f.realFactor, f.floor)
+			"the shipped floor %g on a deployment whose resolve channel is PROVEN live — §6 says "+
+			"instant recall stops firing it", f.realFactor, f.floor)
+	}
+	// The other half of §6's qualification, and the live bug it was written for: the
+	// SAME history on a deployment that has never delivered a resolve must still fire.
+	// Counting it decays a correct entry on evidence the source cannot provide, which
+	// locked instant recall out after a single use (measured: one recall ever, then the
+	// same alert re-investigated from scratch three times in 12h).
+	if !recallFires(t, realFingerprint, f.floor, false) {
+		t.Errorf("a recall with ONE unresolved real-fingerprint history was rejected at floor %g on a "+
+			"deployment where NO resolve has ever arrived — with no resolve channel the silence is "+
+			"not evidence of failure, and decaying on it disables the entry permanently", f.floor)
 	}
 	page := flattenProse(readDoc(t, learningLoopPath))
 	if pagePriorFreezeRE.MatchString(page) {
@@ -257,7 +268,14 @@ func TestRecallDecayGateFailSafeIsFullTrustNotThePrior(t *testing.T) {
 // magnitude gates are tuned low (a one-entry corpus scores small) so the only gate
 // that can reject here is outcome decay — proven by the ledger-less baseline, which
 // must fire.
-func recallFires(t *testing.T, fp string, floor float64) bool {
+//
+// resolveChannelLive seeds the ledger with one resolve on an UNRELATED fingerprint.
+// That resolve credits nothing (it belongs to no open here) — it exists only to prove
+// the deployment's resolve channel works, which is the precondition resolve-based decay
+// now requires: silence after a recall is evidence of failure only where a resolve
+// could have arrived. Without it the fixture is indistinguishable from an Alertmanager
+// receiver running send_resolved:false, where decay is deliberately withheld.
+func recallFires(t *testing.T, fp string, floor float64, resolveChannelLive bool) bool {
 	t.Helper()
 	cat := decayGuardCatalog(t)
 	entry := cat.Entries()[0].Path
@@ -270,6 +288,14 @@ func recallFires(t *testing.T, fp string, floor float64) bool {
 		t.Fatalf("outcome.New: %v", err)
 	}
 	openUnresolvedRecall(t, l, fp, entry)
+	if resolveChannelLive {
+		if _, _, err := l.Resolve("0000deadbeef0000", time.Now()); err != nil {
+			t.Fatalf("ledger.Resolve (channel-liveness seed): %v", err)
+		}
+		if !l.ResolveChannelLive() {
+			t.Fatal("seeding one resolve must mark the channel live; the liveness signal has moved")
+		}
+	}
 	return runRecall(t, cat, l, floor)
 }
 

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -22,6 +22,11 @@ import (
 // *outcome.Ledger satisfies it.
 type OutcomeStats interface {
 	OpenCounts() (map[string]outcome.Aggregate, error)
+	// ResolveChannelLive reports whether a ground-truth resolve signal can actually
+	// arrive. Resolve-based decay reads post-recall silence as failure, which is only
+	// sound when a resolve was possible; see outcome.Ledger.ResolveChannelLive for the
+	// deployments where it is not, and outcomeGate for what is withheld when it is false.
+	ResolveChannelLive() bool
 }
 
 // Recall short-circuits an investigation when the knowledge catalog already has a
@@ -649,6 +654,22 @@ func clampF(v, lo, hi float64) float64 {
 func (r *Recall) outcomeGate(counts map[string]outcome.Aggregate, path string) (float64, bool) {
 	agg, ok := counts[path]
 	if !ok {
+		return 1, true
+	}
+	// Second fail-safe, same principle as the first: an entry that has been recalled
+	// but has accumulated NO outcome of any kind — no resolve, no vote, no confirm —
+	// while the deployment has never delivered a single resolve is not a failing entry.
+	// It is an entry nobody can grade. Decaying it treats "we never asked" as "the
+	// answer was wrong": with the default k=2 a single recall lands at 0.333, under the
+	// 0.5 floor, and the entry is locked out permanently after ONE use. Withhold decay
+	// until some ground truth exists — a human 👍/👎 still works here and is, per
+	// docs/learning-loop.md, the only evidence these deployments can ever accumulate.
+	//
+	// Scoped tightly so the intended decay is untouched: the moment the entry earns any
+	// evidence, OR the ledger observes any resolve at all, the full posterior applies —
+	// including every unresolved recall banked up to that point. A genuinely stale entry
+	// on a working resolve channel still decays exactly as before.
+	if !agg.HasEvidence() && !r.Outcome.ResolveChannelLive() {
 		return 1, true
 	}
 	f := outcomeFactor(agg.Recalls, agg.Resolved, agg.FeedbackUp, agg.FeedbackDown, agg.Confirms, r.OutcomePrior)

--- a/internal/investigate/recall_decay_integration_test.go
+++ b/internal/investigate/recall_decay_integration_test.go
@@ -88,6 +88,95 @@ apps/worker pods are OOMKilled shortly after a values change lowered the memory 
 	}
 }
 
+// TestRecallDecayWithheldWithoutResolveChannel pins the fix for the live failure
+// where instant recall fired exactly ONCE and was then locked out permanently.
+//
+// The deployment ran Alertmanager with `send_resolved: false`, so a resolve could
+// never arrive. Recalls still incremented, Resolved could not, and with k=2 a single
+// recall put a correct, human-validated entry at (0+1)/(1+2)=0.333 — below the 0.5
+// floor. Measured: one recall total, then the same alert re-investigated from scratch
+// three times in 12h. docs/learning-loop.md already promised this case was excluded
+// from resolve-based decay; only outcome.Derived(fingerprint) enforced it, which
+// cannot see the sender's config.
+//
+// The contract this pins: silence decays an entry only where a resolve was POSSIBLE.
+func TestRecallDecayWithheldWithoutResolveChannel(t *testing.T) {
+	dir := t.TempDir()
+	entry := `---
+type: Incident
+title: worker OOMKilled after memory limit drop
+description: apps/worker pods OOMKilled; raise the container memory limit
+resource: apps/worker
+tags: [oom, memory, worker]
+---
+
+# Symptom
+apps/worker pods are OOMKilled shortly after a values change lowered the memory limit.
+`
+	if err := os.WriteFile(filepath.Join(dir, "worker-oom.md"), []byte(entry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cat, err := catalog.New(dir)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	path := cat.Entries()[0].Path
+
+	req := Request{
+		Title:    "WorkerOOM",
+		Message:  "apps/worker pods OOMKilled after memory limit drop",
+		Workload: providers.Workload{Namespace: "apps", Name: "worker"},
+	}
+	newRecall := func(o OutcomeStats) *Recall {
+		return &Recall{
+			Catalog:      cat,
+			MinScore:     0.001,
+			SoloFloor:    0.001,
+			MarginGap:    0.001,
+			Outcome:      o,
+			OutcomePrior: 2.0,
+			OutcomeFloor: 0.5,
+		}
+	}
+	// The exact live shape: recalled once, nothing heard back, no resolve channel.
+	unresolvable := map[string]outcome.Aggregate{path: {Recalls: 1, Resolved: 0}}
+
+	// Premise guard: under the plain formula this history IS sub-floor. Without the
+	// channel check the entry would be rejected here — that is the bug being fixed.
+	if f := outcomeFactor(1, 0, 0, 0, 0, 2.0); f >= 0.5 {
+		t.Fatalf("fixture invalid: outcomeFactor(1,0,0,0,0,2)=%v must be below the 0.5 floor "+
+			"for this test to exercise the withheld decay", f)
+	}
+
+	// Dead channel + no other evidence → decay is withheld, recall still fires.
+	dead := newRecall(fakeOutcome{counts: unresolvable, deadResolveChannel: true})
+	if e, conf := dead.lookup(context.Background(), req); e == nil {
+		t.Fatal("recall must FIRE when no resolve could ever have arrived: an ungradeable " +
+			"entry is not a failing one, and decaying it locks recall out after a single use")
+	} else if conf <= 0 {
+		t.Fatalf("fired recall must carry a positive confidence, got %v", conf)
+	}
+
+	// Same history on a LIVE channel → the silence is real evidence → still rejected.
+	// This is the guard against over-correcting: the intended decay must survive.
+	live := newRecall(fakeOutcome{counts: unresolvable})
+	if e, _ := live.lookup(context.Background(), req); e != nil {
+		t.Fatalf("with a working resolve channel an unresolved recall must still decay "+
+			"and be REJECTED, but it fired: %+v", e)
+	}
+
+	// A 👎 is ground truth these deployments CAN accumulate (docs/learning-loop.md),
+	// so it must bite even with a dead channel — the withholding is scoped to entries
+	// with no evidence at all, not to every entry on a resolve-less source.
+	voted := newRecall(fakeOutcome{
+		counts:             map[string]outcome.Aggregate{path: {Recalls: 1, FeedbackDown: 1}},
+		deadResolveChannel: true,
+	})
+	if e, _ := voted.lookup(context.Background(), req); e != nil {
+		t.Fatalf("a human 👎 must still decay the entry on a resolve-less source, but recall fired: %+v", e)
+	}
+}
+
 // TestRecallRecoversAfterConfirmations pins the 👎 recovery contract end to end
 // over the real Recall gate: one standing 👎 rejects the recall; one machine
 // confirmation still rejects (human outranks a single confirm); the second

--- a/internal/investigate/recall_test.go
+++ b/internal/investigate/recall_test.go
@@ -271,9 +271,15 @@ func TestOutcomeFactor(t *testing.T) {
 type fakeOutcome struct {
 	counts map[string]outcome.Aggregate
 	err    error
+	// deadResolveChannel models a deployment where a resolve can never arrive
+	// (Alertmanager with send_resolved off, or a source with no resolve channel).
+	// Zero value = live, so every pre-existing decay test keeps asserting decay.
+	deadResolveChannel bool
 }
 
 func (f fakeOutcome) OpenCounts() (map[string]outcome.Aggregate, error) { return f.counts, f.err }
+
+func (f fakeOutcome) ResolveChannelLive() bool { return !f.deadResolveChannel }
 
 // soloRecall builds a Recall over a single strong hit that clears the margin +
 // solo gates for an apps/web workload, with decay configured (k=2, floor=0.5).

--- a/internal/investigate/recalleval_test.go
+++ b/internal/investigate/recalleval_test.go
@@ -108,7 +108,10 @@ func evalWorkloadFromLabels(labels map[string]string) (kind, name string) {
 		{"daemonset", "DaemonSet"},
 		{"replicaset", "ReplicaSet"},
 		{"cronjob", "CronJob"},
-		{"job", "Job"},
+		// job_name, not job: `job` is the Prometheus SCRAPE job, never a Kubernetes
+		// Job. See alertmanager.workloadFromLabels for why reading it here shadowed
+		// the real workload on every metric-derived alert.
+		{"job_name", "Job"},
 	} {
 		if v := labels[c.label]; v != "" {
 			return c.kind, v

--- a/internal/investigate/tools.go
+++ b/internal/investigate/tools.go
@@ -76,9 +76,9 @@ func submitFindingsSpec() providers.ToolSpec {
 "confidence":{"type":"number"},
 "affected_resource":{"type":"object","description":"the workload your investigation identified as the failing/affected resource","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}}},
 "root_causes":{"type":"array","items":{"type":"object","properties":{
-"summary":{"type":"string"},"confidence":{"type":"number"},"change_ref":{"type":"string"},
+"summary":{"type":"string"},"confidence":{"type":"number","description":"how strongly the evidence supports THIS root cause, 0-1. Required: an omitted confidence is delivered as 0%, which reads to the on-call as 'no confidence' and buries a sound finding under a red badge"},"change_ref":{"type":"string"},
 "evidence":{"type":"array","items":{"type":"string"}},"suggested_action":{"type":"string"},"reversible":{"type":"boolean"}},
-"required":["summary"]}},
+"required":["summary","confidence"]}},
 "unresolved":{"type":"array","items":{"type":"string"},"description":"genuine open questions only a human can answer - put tool or data limitations in data_gaps instead"},
 "verdict":{"type":"string","enum":["no_action","action_suggested","action_required","inconclusive"],"description":"actionability for the on-call: no_action (benign/self-healed/synthetic), action_suggested (a human should follow the next steps), action_required (live impact needing prompt action), inconclusive (you genuinely could not determine the cause, and data_gaps/unresolved say what blocked you). A recurrence of a fault you DID identify is NOT inconclusive - naming a known cause again is still a conclusion, so restate it with the actionability verdict it deserves"},
 "ruled_out":{"type":"array","items":{"type":"string"},"description":"hypotheses you considered and REJECTED, one line each naming the disproving evidence"},

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -58,8 +58,8 @@ func Format(inv providers.Investigation) string {
 	}
 	// Confidence — shown once. confidenceBadge is the SAME function Slack calls,
 	// so the two never headline different numbers for the same investigation.
-	emoji, level, pct := confidenceBadge(inv)
-	fmt.Fprintf(&b, "%s %s confidence · %d%%\n", emoji, level, pct)
+	emoji, level, pct, stated := confidenceBadge(inv)
+	fmt.Fprintf(&b, "%s %s\n", emoji, confidenceText(level, pct, stated))
 	if note := recallConfidenceNote(inv, pct); note != "" {
 		fmt.Fprintf(&b, "   (%s)\n", note)
 	}
@@ -125,7 +125,13 @@ func Format(inv providers.Investigation) string {
 		}
 	}
 	for i, rc := range inv.RootCauses {
-		fmt.Fprintf(&b, "%d. *%s* (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
+		// An unstated per-cause confidence renders as nothing rather than "(0%)" —
+		// same reason as the headline; see confidenceText.
+		if rc.Confidence > 0 {
+			fmt.Fprintf(&b, "%d. *%s* (%.0f%%)\n", i+1, rc.Summary, rc.Confidence*100)
+		} else {
+			fmt.Fprintf(&b, "%d. *%s*\n", i+1, rc.Summary)
+		}
 		// The change the root cause pins the incident on — previously rendered only
 		// in the Slack blocks, so Matrix/webhook/CLI readers never saw it.
 		if rc.ChangeRef != "" {

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -346,6 +346,42 @@ func TestFormatConfidenceMatchesSlack(t *testing.T) {
 	}
 }
 
+// TestUnstatedConfidenceIsNotLowConfidence pins the distinction between "the model
+// judged this very unlikely" and "the model judged nothing".
+//
+// `confidence` used to be optional everywhere in the findings schema, so a model that
+// omitted it on the top level AND every root cause produced a delivered 0 — and the
+// verify pass, which may only LOWER, pinned it there. The card then read "🔴 Low
+// confidence · 0%" on an investigation that named a concrete cause, quoted metrics for
+// it, and passed the adversarial review. Observed live on NodeSystemSaturation. A red
+// 0% badge on sound work teaches the on-call to ignore the number entirely.
+func TestUnstatedConfidenceIsNotLowConfidence(t *testing.T) {
+	unstated := providers.Investigation{
+		Title:      "NodeSystemSaturation",
+		RootCauses: []providers.Hypothesis{{Summary: "workspace pod consuming 7 of 8 cores"}},
+		Verified:   true,
+	}
+	out := Format(unstated)
+	if strings.Contains(out, "0%") {
+		t.Fatalf("an unstated confidence must not be rendered as a number:\n%s", out)
+	}
+	if !strings.Contains(out, "confidence not stated") {
+		t.Fatalf("an unstated confidence must say so:\n%s", out)
+	}
+	if strings.Contains(out, "Low confidence") {
+		t.Fatalf("absent is not low — the two must not render alike:\n%s", out)
+	}
+
+	// Guard against over-correcting: a genuine low confidence still reads as Low.
+	low := providers.Investigation{
+		Title:      "NodeSystemSaturation",
+		RootCauses: []providers.Hypothesis{{Summary: "maybe", Confidence: 0.1}},
+	}
+	if out := Format(low); !strings.Contains(out, "Low confidence · 10%") {
+		t.Fatalf("a stated low confidence must still render as Low:\n%s", out)
+	}
+}
+
 // TestFormatMetadataBelowAnswer proves the reordering: trigger-time metadata
 // (Resource/alert facts/Started) now renders AFTER the root causes, mirroring
 // the Slack card's move — orienting detail is not the thing to lead with.

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -465,7 +465,13 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 	// from this DELIVERED number (see confidenceBadge); when it does,
 	// recallConfidenceNote spells out both so the reader never has to
 	// reconcile two bare, seemingly-contradictory percentages alone.
-	confText := fmt.Sprintf("%s *%s*", emoji, confidenceText(level, pct, stated))
+	// Bold covers the level only, never the percentage — byte-identical to what the
+	// README's shipped card captures show. The unstated variant has no level to bold,
+	// so it bolds the whole phrase.
+	confText := fmt.Sprintf("%s *%s confidence* · %d%%", emoji, level, pct)
+	if !stated {
+		confText = fmt.Sprintf("%s *%s*", emoji, confidenceText(level, pct, stated))
+	}
 	if note := recallConfidenceNote(inv, pct); note != "" {
 		confText += "\n_" + note + "_"
 	}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -306,12 +306,12 @@ func feedbackBlocks(inv providers.Investigation) []map[string]any {
 // never embeds a slackDate token (raw <>), so it stays a single safe line.
 func fallbackText(inv providers.Investigation) string {
 	title := displayTitle(inv.Title)
-	_, level, pct := confidenceBadge(inv)
+	_, level, pct, stated := confidenceBadge(inv)
 	s := "🔍 " + title
 	if _, label := verdictBadge(inv.Verdict); label != "" {
 		s += " — " + label
 	}
-	return escapeMrkdwn(fmt.Sprintf("%s (%s confidence · %d%%)", s, level, pct))
+	return escapeMrkdwn(fmt.Sprintf("%s (%s)", s, confidenceText(level, pct, stated)))
 }
 
 // displayTitle falls back to a generic label when the model/trigger gave no title.
@@ -392,7 +392,7 @@ func escapeMrkdwn(s string) string { return mrkdwnEscaper.Replace(s) }
 // single-message webhook path.
 func summaryBlocks(inv providers.Investigation) []map[string]any {
 	title := displayTitle(inv.Title)
-	emoji, level, pct := confidenceBadge(inv)
+	emoji, level, pct, stated := confidenceBadge(inv)
 
 	// 1. Header (plain_text — Slack renders it literally, no mrkdwn parsing, so the
 	// untrusted alert name / title needs no escaping). When the source named the
@@ -465,7 +465,7 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 	// from this DELIVERED number (see confidenceBadge); when it does,
 	// recallConfidenceNote spells out both so the reader never has to
 	// reconcile two bare, seemingly-contradictory percentages alone.
-	confText := fmt.Sprintf("%s *%s confidence* · %d%%", emoji, level, pct)
+	confText := fmt.Sprintf("%s *%s*", emoji, confidenceText(level, pct, stated))
 	if note := recallConfidenceNote(inv, pct); note != "" {
 		confText += "\n_" + note + "_"
 	}
@@ -686,7 +686,13 @@ func detailBlocks(inv providers.Investigation) []map[string]any {
 	}
 	for i, rc := range inv.RootCauses {
 		var s strings.Builder
-		fmt.Fprintf(&s, "*%d. %s*  `%.0f%%`", i+1, escapeMrkdwn(rc.Summary), rc.Confidence*100)
+		// An unstated per-cause confidence renders as nothing rather than a `0%`
+		// chip — same reason as the headline; see confidenceText.
+		if rc.Confidence > 0 {
+			fmt.Fprintf(&s, "*%d. %s*  `%.0f%%`", i+1, escapeMrkdwn(rc.Summary), rc.Confidence*100)
+		} else {
+			fmt.Fprintf(&s, "*%d. %s*", i+1, escapeMrkdwn(rc.Summary))
+		}
 		if rc.ChangeRef != "" {
 			fmt.Fprintf(&s, "\n📦 *What changed:* `%s`", escapeMrkdwn(rc.ChangeRef))
 		}
@@ -726,22 +732,48 @@ func appendListSection(blocks []map[string]any, header string, items []string) [
 // must render AS-IS — maxing it against the top hypothesis's raw match
 // confidence would silently hide a bad track record behind the larger number.
 // See recallConfidenceNote for how the two are disclosed when they diverge.
-func confidenceBadge(inv providers.Investigation) (emoji, level string, pct int) {
+// The fourth return, `stated`, separates "the model assessed this as very low" from
+// "the model assessed nothing at all" — see confidenceText for why those two must not
+// render alike.
+func confidenceBadge(inv providers.Investigation) (emoji, level string, pct int, stated bool) {
 	c := inv.Confidence
 	if !inv.Recalled {
 		for _, rc := range inv.RootCauses {
 			c = max(c, rc.Confidence)
 		}
 	}
+	// A recalled investigation's confidence is derived by the recall pipeline, never
+	// left to a model, so it is always stated — even at 0.
+	stated = inv.Recalled || c > 0
 	pct = int(c*100 + 0.5)
 	switch {
 	case c >= 0.7:
-		return "🟢", "High", pct
+		return "🟢", "High", pct, stated
 	case c >= 0.4:
-		return "🟡", "Medium", pct
+		return "🟡", "Medium", pct, stated
+	case stated:
+		return "🔴", "Low", pct, stated
 	default:
-		return "🔴", "Low", pct
+		return "⚪", "Unstated", pct, stated
 	}
+}
+
+// confidenceText renders the confidence fragment every delivery path headlines, so the
+// four of them can never disagree about the same investigation.
+//
+// When the model stated no confidence anywhere it reads "confidence not stated" rather
+// than "Low confidence · 0%". An absent self-assessment is not a zero one, and the
+// difference is not cosmetic: `confidence` was optional in the findings schema, so a
+// model that simply omitted it turned a sound, fully-evidenced, verify-passed finding
+// into a red 0% card. Observed live — a NodeSystemSaturation investigation that
+// correctly pinned a workspace pod consuming 7 of a node's 8 cores, metrics quoted,
+// shipped as "🔴 Low confidence · 0%". Per-root-cause confidence is now required in the
+// schema; this is the honest fallback for a model that ignores it.
+func confidenceText(level string, pct int, stated bool) string {
+	if !stated {
+		return "confidence not stated"
+	}
+	return fmt.Sprintf("%s confidence · %d%%", level, pct)
 }
 
 // recallConfidenceNote discloses a recalled entry's own match confidence

--- a/internal/outcome/ledger.go
+++ b/internal/outcome/ledger.go
@@ -190,6 +190,13 @@ type Ledger struct {
 	// compaction does not lose it.
 	staleResolves int
 
+	// resolvesSeen counts every resolve event this ledger has ever folded, paired or
+	// not. It is not a statistic — it is the PROOF that a ground-truth resolve channel
+	// exists at all, which resolve-based decay is meaningless without (see
+	// ResolveChannelLive). Deliberately incremented before any pairing decision: a
+	// resolve that buffers, or is dropped as stale, still proves the channel works.
+	resolvesSeen int
+
 	// maxEvents bounds the JSONL before loadLocked compacts it (0 disables). corruptLines
 	// records how many lines the last load could not parse (so the skip is observable, not
 	// silent). log carries a logger for those warnings; never nil after New.
@@ -221,6 +228,11 @@ type checkpointData struct {
 	TriggerConfirms map[string]int               `json:"trigger_confirms,omitempty"`
 	DroppedResolves int                          `json:"dropped_resolves,omitempty"`
 	StaleResolves   int                          `json:"stale_resolves,omitempty"`
+	// ResolvesSeen carries the resolve-channel liveness proof across compaction. Absent
+	// from a checkpoint written before this field existed; a replay then reconstructs it
+	// from the retained tail only, which degrades to "channel not proven" — conservative
+	// (decay is withheld), never the reverse.
+	ResolvesSeen int `json:"resolves_seen,omitempty"`
 }
 
 type triggerAggJSON struct {
@@ -403,6 +415,7 @@ func (l *Ledger) resetStateLocked() {
 	l.triggerConfirms = map[string]int{}
 	l.droppedResolves = 0
 	l.staleResolves = 0
+	l.resolvesSeen = 0
 }
 
 // foldLocked folds one replayed event into the derived state. Open/resolve maintain the
@@ -468,6 +481,7 @@ func (l *Ledger) seedCheckpointLocked(cd *checkpointData) {
 	}
 	l.droppedResolves += cd.DroppedResolves
 	l.staleResolves += cd.StaleResolves
+	l.resolvesSeen += cd.ResolvesSeen
 }
 
 // compactLocked rewrites the ledger file as [checkpoint][recent tail]: it folds the
@@ -506,6 +520,7 @@ func (l *Ledger) snapshotCheckpointLocked() *checkpointData {
 		PendingResolves: l.pendingResolves,
 		DroppedResolves: l.droppedResolves,
 		StaleResolves:   l.staleResolves,
+		ResolvesSeen:    l.resolvesSeen,
 	}
 	if len(l.byTrigger) > 0 {
 		cd.ByTrigger = make(map[string]triggerAggJSON, len(l.byTrigger))
@@ -673,6 +688,10 @@ func (l *Ledger) applyOpenLocked(e Event) {
 // if it was a counted recall, credit its resolution; with no pending open, buffer
 // the resolve for a later open. Must be called with mu held (or during New).
 func (l *Ledger) applyResolveLocked(fp string, at time.Time) {
+	// Channel-liveness proof, recorded before any pairing decision: whether this
+	// resolve pairs, buffers, or is discarded says nothing about whether the SENDER
+	// emits resolves, and that is the only question ResolveChannelLive answers.
+	l.resolvesSeen++
 	stack := l.pendingOpens[fp]
 	if len(stack) == 0 {
 		// No pending open yet — buffer this resolve for a later open (resolve-before-open).
@@ -1062,6 +1081,18 @@ type Aggregate struct {
 // confirmation — with k=2 and floor 0.5, one 👎 needs TWO confirmations to recover.
 const confirmWeight = 0.5
 
+// HasEvidence reports whether the aggregate holds any ground-truth OUTCOME —
+// a paired resolve, a human vote, or a machine confirmation.
+//
+// Recalls is deliberately excluded: it is the count of times the entry was USED,
+// which is the trial count, not an outcome. An aggregate with recalls and nothing
+// else says only "we answered N times and heard nothing back". Whether that silence
+// means failure depends entirely on whether a resolve could have arrived — see
+// Ledger.ResolveChannelLive, the other half of this decision.
+func (a Aggregate) HasEvidence() bool {
+	return a.Resolved > 0 || a.FeedbackUp > 0 || a.FeedbackDown > 0 || a.Confirms > 0
+}
+
 // Factor is the entry's outcome-decay factor: the posterior mean of a symmetric
 // Beta(k/2, k/2) prior over the success rate, folding resolves, human votes, and
 // machine confirmations into one trust signal:
@@ -1083,6 +1114,44 @@ func (a Aggregate) Factor(k float64) float64 {
 	return (float64(a.Resolved+a.FeedbackUp) + c + k/2) / (float64(a.Recalls+a.FeedbackUp+a.FeedbackDown) + c + k)
 }
 
+// ResolveChannelLive reports whether a ground-truth resolve signal can actually
+// reach this ledger — true once ANY resolve event has ever been folded.
+//
+// Resolve-based decay assumes silence after a recall is evidence of failure. That
+// only holds when a resolve COULD have arrived. Two deployments make it false:
+// Alertmanager configured with `send_resolved: false`, and any source whose
+// notifications simply never carry a resolve. In both, every recall increments
+// Recalls with a Resolved that can never follow, so the Beta posterior collapses:
+// with the default k=2, ONE recall takes a correct entry to (0+1)/(1+2)=0.333,
+// below the 0.5 floor, and instant recall is disabled for that entry forever.
+// Measured live on a shared cluster in 2026-08: exactly one recall had ever fired
+// and the same alert was then re-investigated from scratch three times in 12h.
+//
+// docs/learning-loop.md already promises this case is excluded ("sources with no
+// resolve channel … are deliberately excluded from resolve-based decay"), but the
+// only signal the open path had was outcome.Derived(fingerprint) — which detects a
+// SYNTHETIC fingerprint (GitOps, reinvestigate) and cannot see the sender's
+// Alertmanager config. This closes that gap empirically instead: a channel that has
+// never delivered a single resolve is not a channel.
+//
+// Why liveness is read at GATE time and never at fold time: the cached aggregate is
+// contractually "equal to a fresh full replay for any event sequence". Skipping the
+// Recalls++ while the channel looked dead would make that false — a resolve arriving
+// later would leave earlier opens uncounted live, yet counted after a restart replays
+// the file with the proof already in hand. Counting stays unconditional; only the
+// interpretation of the counts is conditioned.
+//
+// Conservative in every failure mode: unknown ⇒ withhold decay ⇒ an entry keeps
+// firing. A nil ledger reports false.
+func (l *Ledger) ResolveChannelLive() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.resolvesSeen > 0
+}
+
 // OpenCounts rolls recall episodes up per catalog entry (fresh investigations
 // carry no entry). It is the input to recall decay: resolve-rate ≈
 // (Resolved+k)/(Recalls+k), and runs on the recall hot path once per incident
@@ -1094,6 +1163,10 @@ func (a Aggregate) Factor(k float64) float64 {
 // Episodes() replay may diverge.
 // A disabled/empty ledger yields an empty (non-nil) map. The returned map is a
 // fresh copy the caller may freely mutate.
+//
+// The counts alone do not decide decay: an unresolved recall is evidence of failure
+// only where a resolve could have arrived, so the gate reads ResolveChannelLive
+// alongside them.
 //
 // Behaviour note: because the read moved to New/Reload, OpenCounts no longer performs
 // file I/O and so can no longer return a read error — any error reading the ledger

--- a/internal/outcome/ledger_test.go
+++ b/internal/outcome/ledger_test.go
@@ -1604,3 +1604,73 @@ func TestLegacyOpenWithoutStartedAtUsesAgeBound(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveChannelLive pins the resolve-channel liveness proof that gates
+// resolve-based decay. It answers one question — "could a resolve ever arrive?" —
+// and must answer it conservatively (unknown ⇒ false ⇒ decay withheld ⇒ the entry
+// keeps firing), survive compaction, and never be confused with pairing success.
+func TestResolveChannelLive(t *testing.T) {
+	t0 := time.Unix(17000, 0)
+
+	t.Run("nil ledger reports dead", func(t *testing.T) {
+		var l *Ledger
+		if l.ResolveChannelLive() {
+			t.Fatal("a nil ledger must report the channel dead (conservative default)")
+		}
+	})
+
+	t.Run("opens alone never prove a channel", func(t *testing.T) {
+		l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+		for i := range 5 {
+			_ = l.Open(Event{Fingerprint: fmt.Sprintf("fp%d", i), Kind: "recall", Entry: "x.md", At: t0})
+		}
+		if l.ResolveChannelLive() {
+			t.Fatal("recall opens are the trial count, not evidence a resolve can arrive; " +
+				"this is exactly the send_resolved:false shape that must stay dead")
+		}
+	})
+
+	t.Run("one resolve proves it", func(t *testing.T) {
+		l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+		_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0})
+		if _, _, err := l.Resolve("fp", t0.Add(time.Minute)); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if !l.ResolveChannelLive() {
+			t.Fatal("a delivered resolve must mark the channel live")
+		}
+	})
+
+	t.Run("an unpaired resolve still proves it", func(t *testing.T) {
+		// Liveness is a property of the SENDER, so it must not depend on whether the
+		// resolve found an open to pair with.
+		l, _ := New(filepath.Join(t.TempDir(), "o.jsonl"))
+		if _, _, err := l.Resolve("never-opened", t0); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		if !l.ResolveChannelLive() {
+			t.Fatal("an orphan resolve still proves the sender emits resolves")
+		}
+	})
+
+	t.Run("survives reload and compaction", func(t *testing.T) {
+		p := filepath.Join(t.TempDir(), "o.jsonl")
+		l, _ := New(p)
+		_ = l.Open(Event{Fingerprint: "fp", Kind: "recall", Entry: "x.md", At: t0})
+		if _, _, err := l.Resolve("fp", t0.Add(time.Minute)); err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		// Pad past the bound so the reload compacts the proving resolve into a checkpoint.
+		for i := range 20 {
+			_ = l.Open(Event{Fingerprint: fmt.Sprintf("pad%d", i), Kind: "recall", Entry: "x.md", At: t0})
+		}
+		l2, err := NewWithMaxEvents(p, 5)
+		if err != nil {
+			t.Fatalf("NewWithMaxEvents: %v", err)
+		}
+		if !l2.ResolveChannelLive() {
+			t.Fatal("compaction must carry the liveness proof into the checkpoint; losing it " +
+				"would silently switch a healthy deployment back to withheld decay")
+		}
+	})
+}

--- a/internal/source/alertmanager/alertmanager.go
+++ b/internal/source/alertmanager/alertmanager.go
@@ -36,6 +36,17 @@ type amAlert struct {
 
 // workloadFromLabels derives the affected workload (kind, name) from Alertmanager
 // labels, preferring a stable controller name over an ephemeral pod name.
+//
+// The Kubernetes Job name is `job_name`, NOT `job`. In Prometheus `job` is the
+// SCRAPE job — it is present on essentially every metric-derived alert and names the
+// scrape target, not a workload. Reading it as a Kubernetes Job was wrong twice over:
+// it invented a Job that does not exist, and — because this loop runs ahead of the
+// `pod` fallback — it SHADOWED the real object the alert was about. Live examples on
+// a VictoriaMetrics stack: `KubeJobFailed` carries job="kube-state-metrics" with the
+// actual Job in job_name, and `TooManyLogs` carries job="vmagent-victoria-metrics-
+// k8s-stack" for a Deployment, which was reported as `Job observability/vmagent-…`.
+// kube-state-metrics has exposed the Job name as job_name since it began setting
+// job="kube-state-metrics" on its own series, so job_name is the only correct source.
 func workloadFromLabels(labels map[string]string) (kind, name string) {
 	for _, c := range []struct{ label, kind string }{
 		{"deployment", "Deployment"},
@@ -43,7 +54,7 @@ func workloadFromLabels(labels map[string]string) (kind, name string) {
 		{"daemonset", "DaemonSet"},
 		{"replicaset", "ReplicaSet"},
 		{"cronjob", "CronJob"},
-		{"job", "Job"},
+		{"job_name", "Job"},
 	} {
 		if v := labels[c.label]; v != "" {
 			return c.kind, v

--- a/internal/source/alertmanager/alertmanager_test.go
+++ b/internal/source/alertmanager/alertmanager_test.go
@@ -167,6 +167,29 @@ func TestWorkloadFromLabels(t *testing.T) {
 		{"workload with type", map[string]string{"workload": "w", "workload_type": "Rollout"}, "Rollout", "w"},
 		{"workload no type -> empty kind", map[string]string{"workload": "w"}, "", "w"},
 		{"none", map[string]string{"severity": "critical"}, "", ""},
+
+		// `job` is the Prometheus SCRAPE job, not a Kubernetes Job. It rides on
+		// essentially every metric-derived alert, so treating it as a workload both
+		// invented a Job and shadowed the real object.
+		{
+			"scrape job alone is not a workload",
+			map[string]string{"job": "kube-state-metrics"},
+			"", "",
+		},
+		{
+			// Live shape of KubeJobFailed: job=kube-state-metrics (the scraper),
+			// job_name=the actual Job.
+			"job_name is the Kubernetes Job",
+			map[string]string{"job": "kube-state-metrics", "job_name": "backup-27460"},
+			"Job", "backup-27460",
+		},
+		{
+			// Live shape of TooManyLogs: the scrape job happens to be named after a
+			// Deployment. The pod label is the only real object here.
+			"scrape job does not shadow the pod",
+			map[string]string{"job": "vmagent-victoria-metrics-k8s-stack", "pod": "vmagent-victoria-metrics-k8s-stack-58cfb869b-tpzzf"},
+			"Pod", "vmagent-victoria-metrics-k8s-stack-58cfb869b-tpzzf",
+		},
 	}
 	for _, c := range cases {
 		k, n := workloadFromLabels(c.labels)

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -563,16 +563,33 @@ judgment on the *diagnosis itself*, which an alert merely clearing never proves.
 
 **An Alertmanager alert is never in that excluded set** — not even when its receiver has
 `send_resolved` off. Resolvability is read off the fingerprint alone
-(`resolvable := !outcome.Derived(fp)`), never off `send_resolved`, which lives in the
-operator's receiver config: RunLore never reads it, and has no startup or per-event
-signal it could condition on. A real alert fingerprint is always recorded resolvable, so
-when the resolve never comes the failure runs the **opposite** way from the synthetic
-case. Every recall increments `recalls` while `resolved` stays 0, and the factor drops
-at once: **one** unresolved recall already lands the entry at **0.333**, below the
-shipped `outcome_floor` of **0.5**, and Gate 3 stops firing it. A rejected recall
-records nothing further, so it stays there — and retirement does not rescue it either,
-because the observation count freezes at 1, below `min_observations`. Neither failure
-mode is self-correcting; a 👍/👎 channel is the one thing that closes both.
+(`resolvable := !outcome.Derived(fp)`), never off the receiver config, which RunLore
+cannot see. A real alert fingerprint is therefore always recorded resolvable, and every
+recall increments `recalls` while `resolved` stays 0. The factor drops at once: **one**
+unresolved recall already lands the entry at **0.333**, below the shipped
+`outcome_floor` of **0.5**.
+
+That arithmetic is correct only where a resolve could actually have arrived, so **Gate 3
+withholds decay until the ledger has observed at least one resolve, from any
+fingerprint** (`Ledger.ResolveChannelLive`). An entry with no outcome of any kind — no
+resolve, no vote, no confirmation — on a deployment that has never delivered a single
+resolve is not a failing entry; it is one nobody can grade, and decaying it treats *we
+never asked* as *the answer was wrong*. That is not hypothetical: measured on a shared
+cluster in 2026-08 with `send_resolved: false`, exactly one recall had ever fired and
+the same alert was then re-investigated from scratch three times in twelve hours.
+
+The withholding is scoped as tightly as possible. The moment the entry earns any ground
+truth, **or** the ledger sees any resolve at all, the full posterior applies —
+including every unresolved recall banked up to that point — so a genuinely stale entry
+on a working resolve channel still decays exactly as described above. A human 👎 bites
+either way, which is what makes it, per the paragraph above, the one signal a
+resolve-less deployment can always accumulate.
+
+Two consequences worth stating plainly. Turning `send_resolved` **on** is what makes
+resolve-based decay work at all, and it costs nothing: a resolved alert decodes to a
+resolution, never to an investigation. Leaving it **off** does not merely disable
+learning — it also silently voids `triggers.incidents.debounce`, which holds a firing
+alert and investigates only if no resolve arrived in the window.
 
 ```mermaid
 stateDiagram-v2


### PR DESCRIPTION
⏺ ## Summary

  Three defects found by auditing 8 live investigations over 12h on a shared cluster, where
  the **same benign alert was investigated from scratch 4 times** (31 model calls, ~$1.13)
  while a human-validated KB entry for it sat unused.

  ### 1. Outcome decay counted silence as failure where no resolve could ever arrive

  `resolvable := !outcome.Derived(fp)` (`internal/app/investigate.go`) only detects a
  *synthetic* fingerprint, so an Alertmanager alert always counted toward decay — including
  when the receiver runs `send_resolved: false`, where a resolve is impossible. With `k=2`,
  one recall then puts a correct entry at `(0+1)/(1+2) = 0.333`, below `outcome_floor` 0.5,
  and it is rejected for good.

  Measured on the affected cluster:

      runlore_recall_hits_total{result="downgraded"}         1     ← the only recall, ever
      runlore_recall_rejections_total{reason="low_outcome"}  3     ← the 3 re-investigations

  `learning-loop.md` §6 already promised this case was excluded from resolve-based decay
  ("sources with no resolve channel … are deliberately excluded"), and the comments on
  `Event.Resolvable` / `applyOpenLocked` name the `send_resolved` case explicitly — but
  nothing implemented it, because the sender's receiver config is not something RunLore can
  read.

  This closes the gap **empirically instead of by declaration**: a channel that has never
  delivered a single resolve is not a channel (`Ledger.ResolveChannelLive`). Gate 3 now
  withholds decay while an entry has *no outcome of any kind* — no resolve, no vote, no
  confirm — **and** the ledger has never observed any resolve.

  Two design points worth reviewing closely:

  - **Liveness is read at gate time, never at fold time.** Skipping the `Recalls++` while the
    channel looked dead would break the cached aggregate's contract ("equal to a fresh full
    replay for any event sequence") — a resolve arriving later would leave earlier opens
    uncounted live but counted after a restart. Counting stays unconditional; only the
    *interpretation* is conditioned.
  - **Scoped as tightly as I could make it.** The moment the entry earns any ground truth, or
    the ledger sees any resolve at all, the full posterior applies — including every
    unresolved recall banked up to that point. A genuinely stale entry on a working resolve
    channel decays exactly as before. A human 👎 bites either way, which is what keeps it the
    one signal a resolve-less deployment can always accumulate.

  `curate.Retirement` shares the guard. The two gates read one interface precisely so they
  cannot disagree about a track record, and leaving retirement out would have created exactly
  the divergence that comment warns about.

  ### 2. The Prometheus `job` label was read as a Kubernetes Job

  `workloadFromLabels` mapped `job` → kind `Job`, ahead of the `pod` fallback. In Prometheus
  `job` is the **scrape** job — it rides on nearly every metric-derived alert — so this both
  invented a Job that does not exist and **shadowed the real object**. Live examples:

  | Alert | `job` | Real object | Was reported as |
  |---|---|---|---|
  | `KubeJobFailed` | `kube-state-metrics` | `job_name` label | `Job <ns>/kube-state-metrics` |
  | `TooManyLogs` | `vmagent-victoria-metrics-k8s-stack` | the `pod` | `Job observability/vmagent-…` |

  Now reads `job_name`, which is where kube-state-metrics actually puts the Job name.

  ### 3. An unstated confidence rendered as "🔴 Low confidence · 0%"

  `confidence` was optional throughout the findings schema, so a model that omitted it on the
  top level *and* every root cause produced a delivered `0` — which the verify pass, being
  allowed only to lower, then pinned there. Observed live: a `NodeSystemSaturation`
  investigation that named a concrete cause (a workspace pod consuming 7 of a node's 8 cores),
  quoted the metrics for it, and passed adversarial review, shipped as a red 0% card.

  Per-root-cause `confidence` is now **required** in the schema, and absent renders as
  "confidence not stated" rather than as a number — headline and per-cause line alike. A
  genuinely low stated confidence still reads as Low; the new test pins both directions.

  ## Linked issue

  n/a — found by live audit, not filed.

  ## How was it verified?

  Full quality gate, exactly as CI runs it:

      go build ./...                → OK
      go vet ./...                  → OK
      gofmt -l .                    → (empty)
      golangci-lint run ./...       → 0 issues
      go test ./...                 → all packages ok
      go test -race ./internal/{outcome,investigate,curate,notify,docsguard,source}/...
                                    → all ok

  New regression tests, each pinning the live failure rather than the implementation:

  cannot disagree about a track record, and leaving retirement out would have created exactly
  the divergence that comment warns about.

  ### 2. The Prometheus `job` label was read as a Kubernetes Job

  `workloadFromLabels` mapped `job` → kind `Job`, ahead of the `pod` fallback. In Prometheus
  `job` is the **scrape** job — it rides on nearly every metric-derived alert — so this both
  invented a Job that does not exist and **shadowed the real object**. Live examples:

  | Alert | `job` | Real object | Was reported as |
  |---|---|---|---|
  | `KubeJobFailed` | `kube-state-metrics` | `job_name` label | `Job <ns>/kube-state-metrics` |
  | `TooManyLogs` | `vmagent-victoria-metrics-k8s-stack` | the `pod` | `Job observability/vmagent-…` |

  Now reads `job_name`, which is where kube-state-metrics actually puts the Job name.

  ### 3. An unstated confidence rendered as "🔴 Low confidence · 0%"

  `confidence` was optional throughout the findings schema, so a model that omitted it on the
  top level *and* every root cause produced a delivered `0` — which the verify pass, being
  allowed only to lower, then pinned there. Observed live: a `NodeSystemSaturation`
  investigation that named a concrete cause (a workspace pod consuming 7 of a node's 8 cores),
  quoted the metrics for it, and passed adversarial review, shipped as a red 0% card.

  Per-root-cause `confidence` is now **required** in the schema, and absent renders as
  "confidence not stated" rather than as a number — headline and per-cause line alike. A
  genuinely low stated confidence still reads as Low; the new test pins both directions.

  ### On PR scope

  This is three concerns, not one. (1) and (2) share the audit and both sit on the recall
  path; (3) is independent and could be split out if you'd rather review it separately. Say
  the word and I'll break it up.

  ## Linked issue

  n/a — found by live audit, not filed.

  ## How was it verified?

  Full quality gate, exactly as CI runs it:

      go build ./...                → OK
      go vet ./...                  → OK
      gofmt -l .                    → (empty)
      golangci-lint run ./...       → 0 issues
      go test ./...                 → all packages ok
      go test -race ./internal/{outcome,investigate,curate,notify,docsguard,source}/...
                                    → all ok

  New regression tests, each pinning the live failure rather than the implementation:

  - `TestRecallDecayWithheldWithoutResolveChannel` — the exact observed shape (one recall, no
    resolve, dead channel) must still fire; the *same* history on a live channel must still be
    rejected (guard against over-correcting); a 👎 must still bite on a dead channel.
  - `TestResolveChannelLive` — nil ledger reports dead; opens alone never prove a channel; one
    resolve proves it; an *unpaired* resolve still proves it (liveness is a property of the
    sender, not of pairing); and the proof survives compaction into a checkpoint.
  - `TestRetirement/spares unresolvable entries when no resolve can ever arrive`.
  - `TestWorkloadFromLabels` — three cases from real alert payloads: a bare scrape job is not a
    workload, `job_name` is the Job, and a scrape job must not shadow the pod.
  - `TestUnstatedConfidenceIsNotLowConfidence`.

  **`internal/docsguard` did its job here and is worth a look.** `TestRecallDecayGateFailSafeIsFullTrustNotThePrior`
  failed on the behaviour change, exactly as its author intended — the file says *"if someone
  ever does implement the exclusion … the measurement flips and these guards demand the
  opposite prose instead of quietly passing."* So `learning-loop.md` §6 is rewritten with the
  new qualification, and the guard now measures **both** channel states rather than one.

  Not run: `hack/e2e-k3d.sh`. This touches the alertmanager decode path and the recall gate, so
  applying the **`run-e2e`** label before merge seems worth the 15 minutes — your call.

  ## Checklist

  - [x] `go build ./...` passes
  - [x] `go vet ./...` passes
  - [x] `go test ./...` passes (`-race` on every touched package)
  - [x] `gofmt -l .` prints nothing
  - [x] `golangci-lint run ./...` reports 0 issues
  - [ ] **Test added first (TDD)** — partially, and I'd rather flag it than tick it. For (1) an
        existing `docsguard` test failed first, by design. For (2) and (3) the implementation
        came before the new tests; they were written from the live evidence, but after the fix.
  - [x] Docs updated — `learning-loop.md` §6 rewritten; `Event.Resolvable`, `applyOpenLocked`,
        `OpenCounts`, `OutcomeStats` and `EntryStats` comments updated to match.
  - [x] Respects **read-only-first** — no new cluster access of any kind; all three changes are
        pure interpretation of data already in hand.