### PR TITLE
fix(recall): ground the adversarial review of a recalled finding

### DIFF
--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -37,8 +37,14 @@ RENDERER=(internal/notify/slack.go internal/notify/format.go)
 #     fails again, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_RENDERER="96e1dc6df8eefc1f7651b6ef0d2f02567e53e3ce"
-ACKNOWLEDGED_REASON="adds a 'confidence not stated' variant for a finding that carries no confidence at all. The stated-confidence line both captures actually show is byte-identical — 96e1dc6 exists specifically to restore its bolding after an incidental change — so neither image is WRONG, only incomplete: they cannot show a variant that had not been written when they were taken. Retake when a live workspace is next available."
+#
+# Pin the commit AS IT EXISTS ON MAIN. This repo squash-merges, so a branch SHA is dead
+# on arrival: #475 acknowledged its own branch commit (96e1dc6), the squash collapsed
+# that into 0280367, and main went red the moment it merged. An acknowledgement can
+# therefore only be written by a PR that does NOT itself touch the renderer, naming the
+# squash commit that last did.
+ACKNOWLEDGED_RENDERER="02803679726992b3b79e8b123bfca5bcb99c9cc8"
+ACKNOWLEDGED_REASON="#475 added a 'confidence not stated' variant for a finding that carries no confidence at all. The stated-confidence line both captures actually show is byte-identical — an incidental re-bolding was deliberately reverted to keep it so — meaning neither image is WRONG, only incomplete: they cannot show a variant that did not exist when they were taken. Retake when a live workspace is next available."
 
 last_commit_time() {
   local t

--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -26,15 +26,40 @@ var recallConfirmTools = []string{"pod_status", "kube_events"}
 // absent tools, or a tool error yields gathered=false. gathered is true when at
 // least one confirm tool returned non-empty output (including "no pods"/"no events"
 // — still real current state).
-func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, bool) {
+//
+// It ALSO returns those results shaped as a tool transcript, which the caller passes
+// to verifyFindings. Both forms are needed and they are not redundant:
+//
+//   - the evidence bullets are what the DELIVERED card shows a human;
+//   - the transcript is what the REVIEWER is allowed to treat as verified fact.
+//
+// The verify prompt's central rule is "each cited piece of evidence must trace to a
+// tool result in the transcript excerpt below … if it cannot be found in the
+// transcript, treat it as unverified — reject or downgrade it". The recall path used
+// to pass a nil transcript, so renderForReview emitted no excerpt at all and that
+// rule was unsatisfiable BY CONSTRUCTION: every recalled finding was, correctly by
+// its own instructions, downgraded. The confirm output was sitting right there in the
+// evidence list, but as an assertion by the author rather than as tool output the
+// reviewer could check against — which is precisely the distinction the rule draws.
+//
+// Handing over the same results as a transcript makes the review sharper, not softer:
+// a reviewer that can read current state can now CONTRADICT a stale or poisoned entry
+// (entry says pods are OOMKilling, pod_status shows them Running) instead of being
+// reduced to "cannot verify" on everything.
+func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, []providers.Message, bool) {
 	if req.Workload.Namespace == "" || len(inv.RootCauses) == 0 {
-		return inv, false
+		return inv, nil, false
 	}
 	byName := make(map[string]Tool, len(li.Tools))
 	for _, t := range li.Tools {
 		byName[t.Name()] = t
 	}
 	gathered := false
+	// One synthetic assistant turn carrying the calls, then one tool turn per result —
+	// the shape transcriptExcerpt walks to label each result with the tool that
+	// produced it. Call IDs are deterministic (no loop ran, so nothing else mints them).
+	var calls []providers.ToolCall
+	var results []providers.Message
 	for _, name := range recallConfirmTools {
 		t, ok := byName[name]
 		if !ok {
@@ -52,9 +77,16 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		}
 		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
 			fmt.Sprintf("current state — %s:\n%s", name, out))
+		id := "recall-confirm-" + name
+		calls = append(calls, providers.ToolCall{ID: id, Name: name, Args: confirmArgs(req.Workload)})
+		results = append(results, providers.Message{Role: "tool", ToolCallID: id, Content: out})
 		gathered = true
 	}
-	return inv, gathered
+	if !gathered {
+		return inv, nil, false
+	}
+	transcript := append([]providers.Message{{Role: "assistant", ToolCalls: calls}}, results...)
+	return inv, transcript, true
 }
 
 // confirmArgs builds the JSON args for a confirmatory tool: namespace-scoped, but

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -40,7 +40,7 @@ func TestConfirmRecallAppendsCurrentState(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
 	if !gathered {
 		t.Fatal("expected gathered=true when a confirm tool returns output")
 	}
@@ -59,7 +59,7 @@ func TestConfirmRecallIsNamespaceWideNotObjectScoped(t *testing.T) {
 	ev := &fakeConfirmTool{name: "kube_events", out: "Warning"}
 	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
+	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
 		t.Fatal("expected gathered=true")
 	}
 	if !strings.Contains(ps.gotArgs, `"namespace":"apps"`) {
@@ -77,7 +77,7 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "x"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{}} // no namespace
-	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
 	if gathered {
 		t.Fatal("no namespace must skip confirmation")
 	}
@@ -92,7 +92,7 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 func TestConfirmRecallToolsAbsentSkips(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "what_changed", out: "x"}}}
 	req := Request{Workload: providers.Workload{Namespace: "apps"}}
-	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
+	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
 		t.Fatal("no confirm tools present must yield gathered=false")
 	}
 }
@@ -102,7 +102,7 @@ func TestConfirmRecallToolErrorTolerated(t *testing.T) {
 	good := &fakeConfirmTool{name: "kube_events", out: "Warning FailedMount"}
 	li := &LoopInvestigator{Tools: []Tool{bad, good}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
 	if !gathered {
 		t.Fatal("one tool erroring must not prevent the other from confirming")
 	}
@@ -119,5 +119,81 @@ func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
 	}
 	if out.RootCauses[1].Confidence != 0.5 {
 		t.Fatalf("a value already below the ceiling must be untouched, got %v", out.RootCauses[1].Confidence)
+	}
+}
+
+// TestConfirmRecallGroundsTheReview pins the fix for recalled findings being
+// downgraded on principle rather than on their merits.
+//
+// The verify prompt's central rule is "each cited piece of evidence must trace to a
+// tool result in the transcript excerpt below … if it cannot be found in the
+// transcript, treat it as unverified — reject or downgrade it". The recall path
+// passed a nil transcript, so renderForReview emitted NO excerpt section at all and
+// that rule was unsatisfiable by construction — the reviewer was told to check
+// against a document that did not exist, and correctly downgraded every recall.
+// Measured live: the only recall that ever fired went 0.72 -> 0.45, and
+// runlore_recall_hits_total{result="downgraded"} was 1 of 1.
+//
+// The confirm output was always there, but as an evidence bullet — an assertion by
+// the author, not tool output the reviewer may treat as fact. That is exactly the
+// distinction the groundedness rule draws, so it has to be handed over as both.
+func TestConfirmRecallGroundsTheReview(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "web-abc  Running ready=1/1"}
+	ev := &fakeConfirmTool{name: "kube_events", out: "(no Warning events)"}
+	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
+	req := Request{Title: "WebDown", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+
+	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("expected gathered=true")
+	}
+
+	// The transcript must be the shape transcriptExcerpt walks: an assistant turn
+	// carrying the calls (so each result can be labelled with its tool) plus one tool
+	// turn per result. Without the assistant turn the excerpt renders "[tool]" for
+	// everything and the reviewer cannot tell pod_status from kube_events.
+	if len(transcript) != 3 {
+		t.Fatalf("want 1 assistant turn + 2 tool results, got %d messages", len(transcript))
+	}
+	if transcript[0].Role != "assistant" || len(transcript[0].ToolCalls) != 2 {
+		t.Fatalf("first message must be the assistant turn carrying both calls, got %+v", transcript[0])
+	}
+	for _, m := range transcript[1:] {
+		if m.Role != "tool" || m.ToolCallID == "" {
+			t.Fatalf("result messages must be tool turns with a call id, got %+v", m)
+		}
+	}
+
+	// The property that actually matters: the review the model sees now CONTAINS a
+	// transcript excerpt, with each result attributed to the tool that produced it.
+	review := renderForReview(req, inv, transcript)
+	if !strings.Contains(review, "Tool transcript excerpt") {
+		t.Fatalf("the review must carry a transcript excerpt, else the prompt's groundedness "+
+			"rule is unsatisfiable and every recall is downgraded on principle:\n%s", review)
+	}
+	for _, want := range []string{"[pod_status] web-abc  Running ready=1/1", "[kube_events] (no Warning events)"} {
+		if !strings.Contains(review, want) {
+			t.Errorf("review must attribute each result to its tool; missing %q:\n%s", want, review)
+		}
+	}
+}
+
+// TestConfirmRecallNoTranscriptWhenNothingGathered keeps the degraded path honest: if
+// no current state could be gathered there is nothing the reviewer may treat as
+// verified, so it must get NO transcript rather than an empty or fabricated one. The
+// caller de-rates that case via recallUnconfirmedCap.
+func TestConfirmRecallNoTranscriptWhenNothingGathered(t *testing.T) {
+	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "pod_status", out: "  "}}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	_, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if gathered {
+		t.Fatal("blank tool output must not count as gathered")
+	}
+	if transcript != nil {
+		t.Fatalf("no gathered state must yield a nil transcript, got %+v", transcript)
+	}
+	// And a nil transcript must still render a reviewable message (no excerpt section).
+	if review := renderForReview(req, recalledInv(), nil); strings.Contains(review, "Tool transcript excerpt") {
+		t.Fatalf("a nil transcript must not render an empty excerpt section:\n%s", review)
 	}
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -717,7 +717,7 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	li.Log.Info("instant recall (catalog hit; skipping the loop)",
 		"title", req.Title, "entry", entry.Path, "confidence", fmt.Sprintf("%.2f", conf))
 	rec := recalledInvestigation(req, *entry, conf)
-	rec, confirmed := li.confirmRecall(ctx, req, rec)
+	rec, confirmTranscript, confirmed := li.confirmRecall(ctx, req, rec)
 	if !confirmed {
 		// Could not confront the entry with current state — be less assertive
 		// so an unverifiable recall does not present at full recall confidence.
@@ -727,10 +727,17 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	verified := true // no Verify configured ⇒ nothing to fail; behaves as before
 	if li.Verify {
 		// Catalog content is untrusted: verify a recalled finding too, so a
-		// crafted high-recall entry can't bypass the adversarial review. No loop
-		// ran on this short-circuit path, so there is no tool transcript to ground
-		// against (nil) — the recalled finding is judged on the catalog text alone.
-		rec, verified = li.verifyFindings(ctx, req, rec, nil, verifyTotals)
+		// crafted high-recall entry can't bypass the adversarial review.
+		//
+		// The transcript is confirmRecall's tool results — the CURRENT cluster state,
+		// the only independently-gathered fact on this path and so the only thing the
+		// reviewer may treat as verified. Passing nil here (as this did) left the
+		// prompt's groundedness rule with nothing to check against, which downgraded
+		// every recalled finding on principle; see confirmRecall for the full account.
+		// It is still nil when confirm gathered nothing (no namespace, tools absent,
+		// every call errored) — the review then runs on catalog text alone, which is
+		// exactly the case recallUnconfirmedCap above has already de-rated.
+		rec, verified = li.verifyFindings(ctx, req, rec, confirmTranscript, verifyTotals)
 	}
 	if !verified {
 		// verifyFindings could not run (model error, or no usable verdicts) rather than

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -69,10 +69,17 @@ func parseVerdicts(args string) ([]verdict, error) {
 // causes, rejecting correlation-only/unverified claims and downgrading unproven
 // ones before delivery/curation. The verify completion's token usage is accumulated
 // into totals (when non-nil) so the per-investigation cost includes the verify pass.
-// transcript is the loop's accumulated message history (may be nil, e.g. the
-// recall short-circuit path where no loop ran). A bounded, redacted excerpt of its
-// tool results is fed to the reviewer so groundedness ("does this cause trace to a
-// tool result?") can be checked rather than merely asserted.
+// transcript is the tool history the reviewer may treat as verified fact: the loop's
+// accumulated messages on the full path, confirmRecall's current-state results on the
+// recall short-circuit. A bounded, redacted excerpt of its tool results is fed to the
+// reviewer so groundedness ("does this cause trace to a tool result?") can be checked
+// rather than merely asserted.
+//
+// Passing nil is a claim, not merely an option: it says nothing here is independently
+// verified, leaving the prompt's groundedness rule with nothing to check against, so
+// the reviewer can only downgrade. Reserve it for when that is actually true (confirm
+// gathered no state at all). Handing nil to a path that DID gather evidence downgrades
+// sound findings on principle — see confirmRecall for the live case where it did.
 //
 // The second return, verified, reports whether an adversarial review actually
 // happened: true when the returned investigation reflects a completed review


### PR DESCRIPTION
  ## Summary

  Recalled findings were being downgraded **on principle rather than on their merits**, and
  the cause is not the reviewer — it is a prompt that cannot be satisfied.

  > ⚠️ This also un-reds `main`. See "Screenshot guard" at the bottom — my fault, from #475.

  ### The bug

  `verifyPrompt` states the groundedness rule as:

  > Groundedness: each cited piece of evidence must trace to a tool result in the transcript
  > excerpt below. If a root cause's evidence cannot be found in the transcript, treat it as
  > unverified — reject or downgrade it.

  The recall short-circuit passed `transcript = nil`, so `renderForReview` emitted **no
  excerpt section at all**. Rendering exactly what the reviewer receives today:

  ```
  Incident: TooManyLogs. Workload: observability/vmagent-victoria-metrics-k8s-stack. Reason: warning.

  Proposed root causes to review:
  [0] (confidence 0.72) benign kubelet scrape errors from scale-to-zero GPU nodepool churn
      - instant recall: matched knowledge-base entry "incidents/toomanylogs-....md"
      - current state — pod_status:
  vmagent-...-tpzzf  Running ready=3/3 age=7m
      - current state — kube_events:
  (no Warning events)
  ```

  No transcript. The reviewer is told to check each claim against a document that does not
  exist, and downgrades — correctly, given that prompt.

  This is a deterministic property of the prompt construction, not an inference from one
  observation. The single live observation agrees: on shared-0 the only recall that has ever
  fired went **0.72 → 0.45**, and `runlore_recall_hits_total{result="downgraded"}` was 1 of 1.
  Downstream, the dashboard's "Recall precision" tile counts only `result="verified"`, so it
  is pinned at 0% — the learning loop reads as worthless whether or not it is.

  ### The fix

  The evidence was already being gathered and thrown away. `confirmRecall` calls `pod_status`
  and `kube_events` and appends their output to the hypothesis — but as **evidence bullets**,
  i.e. assertions by the author, not tool output the reviewer may treat as fact. That is
  exactly the distinction the groundedness rule draws.

  It now returns the same results shaped as a transcript as well, and the recall call site
  hands them over. After:

  ```
  Tool transcript excerpt (most recent tool results, may be truncated — check each cited evidence against it):
  [pod_status] vmagent-...-tpzzf  Running ready=3/3 age=7m
  [kube_events] (no Warning events)
  ```

  **This makes the review stricter, not softer** — worth checking me on, since "recall was
  being downgraded, so I stopped it being downgraded" would be the wrong fix:

  - A reviewer that can read current state can now **contradict** a stale or poisoned entry —
    entry claims pods are OOMKilling, `pod_status` shows them Running. Previously it could
    only say "cannot verify", which is uninformative in *both* directions and gave a poisoned
    entry the same verdict as a correct one.
  - The poisoned-catalog guard is untouched: verify still runs on every recall,
    `verified == false` still forces the full-investigation fall-through, and nothing about
    `capRecallConfidence` or the outcome gate changes.
  - `nil` is still passed when confirm genuinely gathered nothing (no namespace, tools absent,
    every call errored) — which is the case `recallUnconfirmedCap` has already de-rated. That
    path is pinned by its own test.

  `verifyFindings`' doc comment now says passing `nil` is a *claim* ("nothing here is
  independently verified"), not merely an option, so the next caller doesn't repeat this.

  ## Linked issue

  n/a — found while auditing why the learning loop showed 0% precision after
  Smana/runlore#475 deployed.

  ## How was it verified?

  Full gate, as CI runs it:

  ```
  go build ./...                     → OK
  go vet ./...                       → OK
  gofmt -l .                         → (empty)
  golangci-lint run ./...            → 0 issues
  go test ./...                      → all packages ok
  go test -race ./internal/investigate  → ok
  hack/check-screenshots-fresh.sh    → exit 0 (was exit 1 on main)
  ```

  Method: I built a throwaway harness that rendered the real reviewer-facing message for a
  recalled finding **before** touching anything — that is the "no transcript" output quoted
  above, and it is what turned "verify seems harsh" into a specific, provable defect. It then
  drove the real `confirmRecall` to produce the "after" output. The harness was deleted and
  its assertions became:

  - `TestConfirmRecallGroundsTheReview` — the transcript is the shape `transcriptExcerpt`
    walks (assistant turn carrying the calls, so each result is labelled with the tool that
    produced it, plus one tool turn per result), and the rendered review actually contains the
    excerpt with both tools attributed. Without the assistant turn every result renders as
    `[tool]` and the reviewer cannot tell `pod_status` from `kube_events`.
  - `TestConfirmRecallNoTranscriptWhenNothingGathered` — nothing gathered yields a **nil**
    transcript, never an empty or fabricated one, and a nil transcript still renders a
    reviewable message with no empty excerpt section.

  The five pre-existing `confirmRecall` tests pass unchanged (signature updated only).

  Not run: `hack/e2e-k3d.sh`. This changes what the verify pass is shown on the recall path,

  I pinned `ACKNOWLEDGED_RENDERER` to my **branch** commit `96e1dc6`. This repo squash-merges,
  so that commit never reached `main` — the squash collapsed it into `0280367`, the guard's
  `rend_sha` no longer matched, and it re-armed the instant it landed. A branch SHA can never
  survive its own merge here.

  Re-pinned to `0280367` (the squash commit as it exists on `main`) and documented in the
  script, because the corollary is non-obvious: **an acknowledgement can only be written by a
  PR that does not itself touch the renderer**. This PR doesn't touch `slack.go`/`format.go`,
  so the pin stays valid after it merges.

  Longer term that escape hatch is awkward on a squash-merge repo — pinning content (a hash of
  the renderer files) rather than a commit would survive merges. Happy to do that separately if
  you want it; left alone here as a design call that is yours.

  ## Checklist

  - [x] `go build ./...` passes
  - [x] `go vet ./...` passes
  - [x] `go test ./...` passes (`-race` on the touched package)
  - [x] `gofmt -l .` prints nothing
  - [x] `golangci-lint run ./...` reports 0 issues
  - [x] **Test added first (TDD)** — the failing render was demonstrated before any fix, and
        became the regression tests. The final assertions were tightened after the fix.
  - [x] Docs updated — `confirmRecall` and `verifyFindings` doc comments carry the reasoning;
        the guard script documents the squash-merge pitfall.
  - [x] Respects **read-only-first** — no new cluster access. `confirmRecall` calls the same
        two read-only tools it already called; only what is done with the results changed.