### PR TITLE
fix(eval): stop the nightly eval dying silently at its own timeout

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -8,6 +8,22 @@
 # but the skip is LOUD: a `::warning::` annotation (surfaced in the Actions
 # run summary / checks UI) plus a $GITHUB_STEP_SUMMARY line, so a run with no
 # key configured can never be mistaken for a real green eval.
+#
+# The same honesty requirement applies to a run that OVERRUNS, and used not to hold.
+# The eval is ~30 live LLM investigations run sequentially (6 cases x -n 5), so it is
+# slow and its duration drifts with the suite, the provider, and how often recall
+# falls through to a full investigation. Every nightly run from 2026-08-07 to
+# 2026-08-14 hit the old 20-minute JOB ceiling mid-run: `lore` was killed with no
+# report written, no scorecard was published, and the run reported itself as
+# CANCELLED — which GitHub does not notify on the way it notifies on failure. A
+# broken eval therefore looked like a run somebody had cancelled, for a week, while
+# the docs site kept rebuilding against the last real numbers (2026-08-09) as if
+# they were fresh.
+#
+# So the budget is enforced INSIDE the step by `timeout`, whose exit 124 fails the
+# step and turns the job RED. timeout-minutes stays above it as a pure backstop: it
+# must never be the thing that fires, because a job-level timeout is the silent
+# outcome. Raise EVAL_BUDGET, not just timeout-minutes, when the suite grows.
 name: eval
 on:
   schedule:
@@ -24,10 +40,19 @@ concurrency:
   group: eval-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # The eval's real budget. `timeout` enforces it so an overrun is a FAILED step
+  # (notified) rather than a cancelled job (silent). Keep it comfortably below the
+  # job's timeout-minutes so this is always what fires first.
+  EVAL_BUDGET: 40m
+
 jobs:
   replay-eval:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Backstop only — EVAL_BUDGET above is the budget that should ever fire. Kept
+    # well above it (40m budget + ~3m for checkout/setup/build + publish headroom)
+    # precisely so a job-level cancel stops being a possible outcome.
+    timeout-minutes: 55
     permissions:
       contents: write   # push the scorecard to the eval-scorecard branch only
     steps:
@@ -67,7 +92,21 @@ jobs:
         if: steps.guard.outputs.has_key == 'true'
         env:
           RUNLORE_EVAL_API_KEY: ${{ secrets.RUNLORE_EVAL_API_KEY }}
-        run: ./lore eval -config eval/ci.runlore.yaml -cases examples/eval -n 5 -fail-under 0.7 -report-dir eval/reports
+        run: |
+          # `|| rc=$?` rather than `if ! …`, which would capture the negated status.
+          rc=0
+          timeout "$EVAL_BUDGET" \
+            ./lore eval -config eval/ci.runlore.yaml -cases examples/eval \
+              -n 5 -fail-under 0.7 -report-dir eval/reports || rc=$?
+          if [ "$rc" -eq 124 ]; then
+            # Distinguish "did not finish" from "finished and scored badly". Only the
+            # latter is a statement about the model; this one measured nothing, and
+            # writes no report, so the scorecard step below must not publish.
+            echo "::error title=Eval timed out::the eval did not finish within $EVAL_BUDGET and was killed, so nothing was scored and no report was written. Either the suite/provider got slower (raise EVAL_BUDGET) or a case is hanging."
+            echo "## eval timed out" >> "$GITHUB_STEP_SUMMARY"
+            echo "The eval exceeded its \`$EVAL_BUDGET\` budget and was killed before writing a report. **No scorecard was published** and the numbers on the docs site are unchanged." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$rc"
 
       - name: upload report
         # always() so a genuine eval failure (key present, score < gate) still
@@ -80,6 +119,7 @@ jobs:
           if-no-files-found: warn
 
       - name: publish scorecard (eval-scorecard branch)
+        id: publish
         # always(): a gate failure (score < 70%) must publish exactly like a pass —
         # the scorecard's value is honesty. Guarded to main so a workflow_dispatch
         # from a feature branch can't overwrite the published numbers, and to
@@ -89,8 +129,12 @@ jobs:
           set -euo pipefail
           REPORT=$(ls -t eval/reports/*-replay.json 2>/dev/null | head -1 || true)
           if [ -z "$REPORT" ]; then
-            echo "::warning title=Scorecard skipped::no replay report found (eval crashed before writing one)"
-            exit 0
+            # A completed eval ALWAYS writes a report, pass or fail — so no report means
+            # the run never got far enough to measure anything. That was a warning with
+            # exit 0 until 2026-08-14, which is how a week of dead nightlies stayed
+            # quiet. It is a failure: there is nothing to publish and nothing to read.
+            echo "::error title=Scorecard not published::no replay report found — the eval never finished, so nothing was measured"
+            exit 1
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -104,13 +148,23 @@ jobs:
           fi
           ./lore eval scorecard -report "$REPORT" -dir "$OUT"
           git -C "$OUT" add -A
-          git -C "$OUT" commit -m "chore(eval): nightly scorecard $(date -u +%Y-%m-%d)" || { echo "no changes to publish"; exit 0; }
-          git -C "$OUT" push origin eval-scorecard
+          if git -C "$OUT" commit -m "chore(eval): nightly scorecard $(date -u +%Y-%m-%d)"; then
+            git -C "$OUT" push origin eval-scorecard
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no changes to publish"
+          fi
 
       # Tell the docs site to rebuild so /eval shows the fresh numbers. Without this
       # the page would only refresh when someone happens to push to website/.
+      #
+      # Gated on the scorecard having ACTUALLY been published, not merely on the job
+      # having run: rebuilding after a timed-out or unchanged run re-publishes the last
+      # numbers with a fresh build date, which is how stale figures come to look
+      # current. `published` can only be set by the step above, so this also subsumes
+      # its has_key and main-branch guards.
       - name: trigger docs rebuild
-        if: always() && steps.guard.outputs.has_key == 'true' && github.ref == 'refs/heads/main'
+        if: always() && steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/internal/app/eval.go
+++ b/internal/app/eval.go
@@ -117,6 +117,21 @@ func RunEval(args []string) error {
 	}
 	counting := &eval.CountingModel{Inner: BuildModel(cfg, apiKey)}
 	runner := &eval.Runner{Model: counting, Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	// Progress to STDERR (stdout carries the result table the report/scorecard read):
+	// a nightly campaign is ~30 sequential live investigations and used to print
+	// nothing at all until it finished, so a run killed by a CI timeout was
+	// indistinguishable from a slow one and showed no clue as to which case ate the
+	// budget. Elapsed time is cumulative from the campaign start.
+	start := time.Now()
+	fmt.Fprintf(os.Stderr, "eval: %d cases x n=%d, running sequentially\n", len(cases), *n)
+	runner.OnCaseDone = func(done, total int, a eval.CaseAggregate) {
+		status := "MISSED"
+		if a.Reached {
+			status = "REACHED"
+		}
+		fmt.Fprintf(os.Stderr, "eval: [%d/%d] %-32s %-7s pass-rate=%.0f%%  elapsed=%s\n",
+			done, total, a.Name, status, a.PassRate*100, time.Since(start).Round(time.Second))
+	}
 	camp := runner.RunN(context.Background(), cases, *n)
 	for _, a := range camp.Aggregates {
 		status := "MISSED"

--- a/internal/app/eval_progress_test.go
+++ b/internal/app/eval_progress_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestRunEvalReportsProgressToStderr pins the progress output the nightly eval needs
+// to be readable while it runs.
+//
+// The replay campaign is sequential and used to print nothing until every case had
+// finished, so the nightly job — ~30 live investigations — emitted 18 minutes of
+// silence and then, when CI killed it at its timeout, nothing at all. "The eval is
+// broken" was indistinguishable from "the eval is slow", and nothing said which case
+// had eaten the budget.
+//
+// Two properties matter and both are asserted here: the lines appear on STDERR (stdout
+// carries the result table, so progress must not contaminate it), and there is one
+// line per case carrying the case name and a running count.
+func TestRunEvalReportsProgressToStderr(t *testing.T) {
+	srv := mockModelServer(t)
+	base := srv.URL + "/v1"
+
+	dir := t.TempDir()
+	casesDir := filepath.Join(dir, "cases")
+	if err := os.MkdirAll(casesDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Two cases so the running count has something to count. Reusing the shared
+	// fixture for the first keeps this test about progress, not about scoring.
+	writeCompareCase(t, casesDir)
+	second := `
+name: second-case
+prompt: SomethingElse in apps
+tools:
+  what_changed: "unrelated change"
+  query_metrics: "up=1"
+  query_logs: "nothing"
+expected:
+  must_contain: [chart]
+  min_confidence: 0.5
+`
+	if err := os.WriteFile(filepath.Join(casesDir, "second.yaml"), []byte(second), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(dir, "runlore.yaml")
+	cfg := fmt.Sprintf("model:\n  provider: openai\n  model: mock\n  base_url: %s\n", base)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr := captureStdoutStderr(t)
+
+	// -fail-under 0 so scoring outcomes can never fail this test: it is about the
+	// progress output, not about whether the mock model reaches a root cause.
+	err := RunEval([]string{
+		"-config", cfgPath,
+		"-cases", casesDir,
+		"-report-dir", filepath.Join(dir, "reports"),
+		"-stamp", "2026-08-14T00:00:00Z",
+		"-n", "1",
+		"-fail-under", "0",
+	})
+	outText, errText := stdout(), stderr()
+	if err != nil {
+		t.Fatalf("RunEval: %v\nstderr:\n%s", err, errText)
+	}
+
+	// One progress line per case, in case order, each with a running count.
+	progress := regexp.MustCompile(`(?m)^eval: \[(\d)/2\] +(\S+)`)
+	matches := progress.FindAllStringSubmatch(errText, -1)
+	if len(matches) != 2 {
+		t.Fatalf("want 2 progress lines (one per case), got %d:\n%s", len(matches), errText)
+	}
+	for i, m := range matches {
+		if want := fmt.Sprint(i + 1); m[1] != want {
+			t.Errorf("progress line %d: want count %s, got %s", i, want, m[1])
+		}
+	}
+	names := []string{matches[0][2], matches[1][2]}
+	for _, want := range []string{"harbor-chart-bump", "second-case"} {
+		if !contains(names, want) {
+			t.Errorf("progress must name each case; %q missing from %v", want, names)
+		}
+	}
+	// Elapsed time is what makes a stalled case identifiable rather than merely late.
+	if !strings.Contains(errText, "elapsed=") {
+		t.Errorf("progress lines must carry elapsed time:\n%s", errText)
+	}
+
+	// Progress must NOT land on stdout: that stream is the result table, and the
+	// nightly pipes it around. The per-case verdict lines there are a different,
+	// pre-existing format ("REACHED  <name>  pass-rate=…"), with no "eval: [" prefix.
+	if strings.Contains(outText, "eval: [") {
+		t.Errorf("progress leaked onto stdout:\n%s", outText)
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// captureStdoutStderr swaps both streams for pipes and returns readers that drain
+// them. Both are read concurrently so a chatty run cannot fill a pipe buffer and
+// deadlock the code under test.
+func captureStdoutStderr(t *testing.T) (func() string, func() string) {
+	t.Helper()
+	origOut, origErr := os.Stdout, os.Stderr
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout, os.Stderr = outW, errW
+
+	outCh, errCh := make(chan string, 1), make(chan string, 1)
+	go func() { b, _ := io.ReadAll(outR); outCh <- string(b) }()
+	go func() { b, _ := io.ReadAll(errR); errCh <- string(b) }()
+
+	var outText, errText string
+	var done bool
+	finish := func() {
+		if done {
+			return
+		}
+		done = true
+		os.Stdout, os.Stderr = origOut, origErr
+		_ = outW.Close()
+		_ = errW.Close()
+		outText, errText = <-outCh, <-errCh
+	}
+	t.Cleanup(finish)
+	return func() string { finish(); return outText }, func() string { finish(); return errText }
+}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -19,6 +19,13 @@ import (
 type Runner struct {
 	Model providers.ModelProvider
 	Log   *slog.Logger
+	// OnCaseDone, when set, is called after each case finishes its n repeats, in
+	// case order. RunN is sequential and holds every result until the whole campaign
+	// ends, so without this a nightly run emits nothing for its entire duration —
+	// which left an eval that was being killed at the 20-minute mark looking
+	// indistinguishable from one that was merely slow. Progress only; the campaign
+	// value is unaffected.
+	OnCaseDone func(done, total int, a CaseAggregate)
 }
 
 // Run-error notes: the two Result.Missing entries that mean a repeat never produced
@@ -293,7 +300,11 @@ func (r *Runner) RunN(ctx context.Context, cases []Case, n int) Campaign {
 	}
 	camp := Campaign{N: n}
 	for _, c := range cases {
-		camp.Aggregates = append(camp.Aggregates, r.aggregateCase(ctx, c, n))
+		a := r.aggregateCase(ctx, c, n)
+		camp.Aggregates = append(camp.Aggregates, a)
+		if r.OnCaseDone != nil {
+			r.OnCaseDone(len(camp.Aggregates), len(cases), a)
+		}
 	}
 	return camp
 }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -435,6 +435,59 @@ func TestReplayCampaignPassRate(t *testing.T) {
 	}
 }
 
+// TestRunNReportsProgressPerCase pins the hook that makes a long campaign legible.
+//
+// RunN is sequential and returns nothing until every case is done, so a nightly run
+// killed by a CI timeout printed NOTHING — for a week that made "the eval is broken"
+// look identical to "the eval is slow", with no indication of which case ate the
+// budget. The hook must fire once per case, in case order, and carry a running count.
+func TestRunNReportsProgressPerCase(t *testing.T) {
+	miss := Case{Name: "miss", Prompt: "x", Tools: map[string]string{"what_changed": "y"},
+		Expected: Expected{MustContain: []string{"network policy"}}}
+	cases := []Case{harborCase(), miss}
+
+	r := newRateRunner(5)
+	type tick struct {
+		done, total int
+		name        string
+		reached     bool
+	}
+	var ticks []tick
+	r.OnCaseDone = func(done, total int, a CaseAggregate) {
+		ticks = append(ticks, tick{done, total, a.Name, a.Reached})
+	}
+	camp := r.RunN(context.Background(), cases, 5)
+
+	if len(ticks) != len(cases) {
+		t.Fatalf("want one tick per case, got %d for %d cases", len(ticks), len(cases))
+	}
+	for i, got := range ticks {
+		if got.done != i+1 || got.total != len(cases) {
+			t.Errorf("tick %d: want done=%d total=%d, got done=%d total=%d", i, i+1, len(cases), got.done, got.total)
+		}
+		if got.name != cases[i].Name {
+			t.Errorf("tick %d: want case %q (case order), got %q", i, cases[i].Name, got.name)
+		}
+	}
+	// The aggregate handed to the hook must be the one that lands in the campaign —
+	// progress reporting a different verdict than the report would be worse than none.
+	if !ticks[0].reached || ticks[1].reached {
+		t.Errorf("hook must carry each case's real verdict, got %+v", ticks)
+	}
+	if len(camp.Aggregates) != len(cases) {
+		t.Fatalf("campaign must be unaffected by the hook, got %d aggregates", len(camp.Aggregates))
+	}
+}
+
+// A nil hook is the normal case (every caller but the CLI) and must not panic.
+func TestRunNNilProgressHookIsFine(t *testing.T) {
+	r := newRateRunner(5)
+	r.OnCaseDone = nil
+	if camp := r.RunN(context.Background(), []Case{harborCase()}, 1); len(camp.Aggregates) != 1 {
+		t.Fatalf("want 1 aggregate, got %d", len(camp.Aggregates))
+	}
+}
+
 func TestGateError(t *testing.T) {
 	miss := Case{Name: "miss", Prompt: "x", Tools: map[string]string{"what_changed": "y"},
 		Expected: Expected{MustContain: []string{"network policy"}}}


### PR DESCRIPTION
  ## Summary

  **The nightly eval has been dead for a week and reported itself as `cancelled`.**

  Every run from 2026-08-07 to 2026-08-14 lasted ~20m15s — the `timeout-minutes: 20`
  job ceiling firing mid-run. The eval sits right on its own budget, so whether it
  finishes is a coin flip:

  | Date | Duration | Eval step | Outcome |
  |---|---|---|---|
  | 2026-08-09 | 20m15s | `failure` | finished at the wire, **failed the 0.7 gate**, published |
  | 2026-08-10 → 08-14 | ~20m15s | `cancelled` | killed mid-run, **no report, nothing published** |

  On 2026-08-14 the eval got 18m11s and the log ends with
  `Terminate orphan process: pid (10396) (lore)` followed by
  `no replay report found (eval crashed before writing one)`. The last real scorecard
  is **2026-08-09**.

  ### Why a week of this stayed quiet

  Three things, each individually reasonable:

  1. **A job-level timeout marks the run `cancelled`, not `failed`** — and GitHub does
     not notify on cancelled the way it notifies on failure. A broken eval looked like
     a run somebody had cancelled.
  2. **`trigger docs rebuild` ran on `always()`**, so the docs site kept rebuilding
     against 2026-08-09's numbers with a fresh build date. Stale figures presented as
     current — the one thing the scorecard is supposed never to do.
  3. **`publish scorecard` treated a missing report as a warning with `exit 0`.**

  The workflow's own header already promises that a run which did not really happen
  "can never be mistaken for a real green eval". That guarantee held for a missing API
  key and failed completely for an overrun.

  ### The fix

  **The budget is enforced inside the step by `timeout` (`EVAL_BUDGET: 40m`)**, whose
  exit 124 fails the step and turns the job red. `timeout-minutes` rises to 55 as a
  pure backstop that should never be what fires — precisely because it is the silent
  outcome. Raise `EVAL_BUDGET`, not just `timeout-minutes`, when the suite grows.

  A timeout is annotated **distinctly from a gate failure**, because the two mean
  opposite things: a gate failure is a statement about the model, while a timeout
  measured nothing and writes no report. Keeping them apart is what makes the red
  actionable.

  **The docs rebuild is gated on the scorecard actually having been published** (a
  `published` step output), so a timed-out or no-change run can no longer republish old
  numbers as fresh. A missing report is now an error, not a warning.

  **Per-case progress on stderr.** The step printed *nothing* for its entire 18-minute
  run: `RunN` is sequential and holds every result until the campaign ends, so "the
  eval is broken" was indistinguishable from "the eval is slow", with no clue as to
  which case ate the budget. Progress goes to stderr because stdout carries the result
  table.

  ## Linked issue

  n/a — found while checking whether #476's recall-verify change had affected the
  learning-loop numbers.

  ## How was it verified?

  Full gate, as CI runs it:

  ```
  go build ./...                          → OK
  go vet ./...                            → OK
  gofmt -l .                              → (empty)
  go test ./...                           → all packages ok
  go test -race ./internal/eval ./internal/app → ok
  ```

  Not run: `golangci-lint run ./...` (not installed locally) and `hack/e2e-k3d.sh`
  (this touches CI wiring and eval reporting, no feature path).

  **The shell logic is the part most likely to be wrong, so it was tested rather than
  reasoned about.** Against a stub emulating GNU `timeout`'s contract, all three paths
  behave:

  | Scenario | Exit | Annotation |
  |---|---|---|
  | overruns the budget | `124` | timeout error + step summary |
  | gate failure | `1` propagated | none (correctly not reported as a timeout) |
  | success | `0` | none |

  `|| rc=$?` is used rather than `if ! cmd`, which would capture the *negated* status.

  **The progress output is pinned at both levels**, and both tests were confirmed to
  fail before the fix:

  - `TestRunNReportsProgressPerCase` — one tick per case, in case order, with a running
    count, and the aggregate handed to the hook is the one that lands in the campaign
    (progress reporting a different verdict than the report would be worse than none).