### PR TITLE
Fix/recall confirm egress and cleanups

### DIFF
--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -37,8 +37,14 @@ RENDERER=(internal/notify/slack.go internal/notify/format.go)
 #     fails again, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_RENDERER="96e1dc6df8eefc1f7651b6ef0d2f02567e53e3ce"
-ACKNOWLEDGED_REASON="adds a 'confidence not stated' variant for a finding that carries no confidence at all. The stated-confidence line both captures actually show is byte-identical — 96e1dc6 exists specifically to restore its bolding after an incidental change — so neither image is WRONG, only incomplete: they cannot show a variant that had not been written when they were taken. Retake when a live workspace is next available."
+#
+# Pin the commit AS IT EXISTS ON MAIN. This repo squash-merges, so a branch SHA is dead
+# on arrival: #475 acknowledged its own branch commit (96e1dc6), the squash collapsed
+# that into 0280367, and main went red the moment it merged. An acknowledgement can
+# therefore only be written by a PR that does NOT itself touch the renderer, naming the
+# squash commit that last did.
+ACKNOWLEDGED_RENDERER="02803679726992b3b79e8b123bfca5bcb99c9cc8"
+ACKNOWLEDGED_REASON="#475 added a 'confidence not stated' variant for a finding that carries no confidence at all. The stated-confidence line both captures actually show is byte-identical — an incidental re-bolding was deliberately reverted to keep it so — meaning neither image is WRONG, only incomplete: they cannot show a variant that did not exist when they were taken. Retake when a live workspace is next available."
 
 last_commit_time() {
   local t

--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -26,15 +26,40 @@ var recallConfirmTools = []string{"pod_status", "kube_events"}
 // absent tools, or a tool error yields gathered=false. gathered is true when at
 // least one confirm tool returned non-empty output (including "no pods"/"no events"
 // — still real current state).
-func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, bool) {
+//
+// It ALSO returns those results shaped as a tool transcript, which the caller passes
+// to verifyFindings. Both forms are needed and they are not redundant:
+//
+//   - the evidence bullets are what the DELIVERED card shows a human;
+//   - the transcript is what the REVIEWER is allowed to treat as verified fact.
+//
+// The verify prompt's central rule is "each cited piece of evidence must trace to a
+// tool result in the transcript excerpt below … if it cannot be found in the
+// transcript, treat it as unverified — reject or downgrade it". The recall path used
+// to pass a nil transcript, so renderForReview emitted no excerpt at all and that
+// rule was unsatisfiable BY CONSTRUCTION: every recalled finding was, correctly by
+// its own instructions, downgraded. The confirm output was sitting right there in the
+// evidence list, but as an assertion by the author rather than as tool output the
+// reviewer could check against — which is precisely the distinction the rule draws.
+//
+// Handing over the same results as a transcript makes the review sharper, not softer:
+// a reviewer that can read current state can now CONTRADICT a stale or poisoned entry
+// (entry says pods are OOMKilling, pod_status shows them Running) instead of being
+// reduced to "cannot verify" on everything.
+func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, []providers.Message, bool) {
 	if req.Workload.Namespace == "" || len(inv.RootCauses) == 0 {
-		return inv, false
+		return inv, nil, false
 	}
 	byName := make(map[string]Tool, len(li.Tools))
 	for _, t := range li.Tools {
 		byName[t.Name()] = t
 	}
 	gathered := false
+	// One synthetic assistant turn carrying the calls, then one tool turn per result —
+	// the shape transcriptExcerpt walks to label each result with the tool that
+	// produced it. Call IDs are deterministic (no loop ran, so nothing else mints them).
+	var calls []providers.ToolCall
+	var results []providers.Message
 	for _, name := range recallConfirmTools {
 		t, ok := byName[name]
 		if !ok {
@@ -52,9 +77,16 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		}
 		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
 			fmt.Sprintf("current state — %s:\n%s", name, out))
+		id := "recall-confirm-" + name
+		calls = append(calls, providers.ToolCall{ID: id, Name: name, Args: confirmArgs(req.Workload)})
+		results = append(results, providers.Message{Role: "tool", ToolCallID: id, Content: out})
 		gathered = true
 	}
-	return inv, gathered
+	if !gathered {
+		return inv, nil, false
+	}
+	transcript := append([]providers.Message{{Role: "assistant", ToolCalls: calls}}, results...)
+	return inv, transcript, true
 }
 
 // confirmArgs builds the JSON args for a confirmatory tool: namespace-scoped, but

--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -24,38 +24,42 @@ var recallConfirmTools = []string{"pod_status", "kube_events"}
 // confirmRecall gathers current cluster state for the recalled workload and appends
 // it to the top hypothesis's evidence, so the verify pass can judge the recalled
 // cause against reality rather than a tautology. Best-effort: a missing namespace,
-// absent tools, or a tool error yields gathered=false. gathered is true when at
-// least one confirm tool returned non-empty output (including "no pods"/"no events"
-// — still real current state).
+// absent tools, or a tool error gathers nothing. Empty output does not count, but
+// "no pods"/"no events" does — that IS real current state.
 //
-// It ALSO returns those results shaped as a tool transcript, which the caller passes
-// to verifyFindings. Both forms are needed and they are not redundant:
+// It returns those results in two forms, which are not redundant:
 //
 //   - the evidence bullets are what the DELIVERED card shows a human;
 //   - the transcript is what the REVIEWER is allowed to treat as verified fact.
 //
-// The verify prompt's central rule is "each cited piece of evidence must trace to a
-// tool result in the transcript excerpt below … if it cannot be found in the
-// transcript, treat it as unverified — reject or downgrade it". The recall path used
+// The distinction matters because verifyPrompt's groundedness rule (verify.go)
+// requires each cited piece of evidence to trace to a tool result in the transcript
+// excerpt, and treats what it cannot find there as unverified. The recall path used
 // to pass a nil transcript, so renderForReview emitted no excerpt at all and that
 // rule was unsatisfiable BY CONSTRUCTION: every recalled finding was, correctly by
 // its own instructions, downgraded. The confirm output was sitting right there in the
 // evidence list, but as an assertion by the author rather than as tool output the
-// reviewer could check against — which is precisely the distinction the rule draws.
+// reviewer could check against — precisely the distinction the rule draws.
 //
 // Handing over the same results as a transcript makes the review sharper, not softer:
 // a reviewer that can read current state can now CONTRADICT a stale or poisoned entry
 // (entry says pods are OOMKilling, pod_status shows them Running) instead of being
 // reduced to "cannot verify" on everything.
-func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, []providers.Message, bool) {
+//
+// A nil transcript means nothing was gathered — the only state the caller needs, and
+// the case it de-rates via recallUnconfirmedCap.
+func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, []providers.Message) {
 	if req.Workload.Namespace == "" || len(inv.RootCauses) == 0 {
-		return inv, nil, false
+		return inv, nil
 	}
 	byName := make(map[string]Tool, len(li.Tools))
 	for _, t := range li.Tools {
 		byName[t.Name()] = t
 	}
-	gathered := false
+	// Invariant across the loop (it encodes the namespace only). Recording the SAME
+	// string the call was made with also keeps the transcript's args honest by
+	// construction, rather than resting on two marshals agreeing.
+	args := confirmArgs(req.Workload)
 	// One synthetic assistant turn carrying the calls, then one tool turn per result —
 	// the shape transcriptExcerpt walks to label each result with the tool that
 	// produced it. Call IDs are deterministic (no loop ran, so nothing else mints them).
@@ -66,7 +70,7 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		if !ok {
 			continue
 		}
-		out, err := t.Call(ctx, confirmArgs(req.Workload))
+		out, err := t.Call(ctx, args)
 		if err != nil {
 			if li.Log != nil {
 				li.Log.Debug("recall confirm tool failed", "tool", name, "err", err)
@@ -86,15 +90,13 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
 			fmt.Sprintf("current state — %s:\n%s", name, out))
 		id := "recall-confirm-" + name
-		calls = append(calls, providers.ToolCall{ID: id, Name: name, Args: confirmArgs(req.Workload)})
+		calls = append(calls, providers.ToolCall{ID: id, Name: name, Args: args})
 		results = append(results, providers.Message{Role: "tool", ToolCallID: id, Content: out})
-		gathered = true
 	}
-	if !gathered {
-		return inv, nil, false
+	if len(results) == 0 {
+		return inv, nil
 	}
-	transcript := append([]providers.Message{{Role: "assistant", ToolCalls: calls}}, results...)
-	return inv, transcript, true
+	return inv, append([]providers.Message{{Role: "assistant", ToolCalls: calls}}, results...)
 }
 
 // confirmArgs builds the JSON args for a confirmatory tool: namespace-scoped, but

--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
 )
 
 // recallUnconfirmedCap is the recall-confidence ceiling applied when current cluster
@@ -75,6 +76,13 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		if out = strings.TrimSpace(out); out == "" {
 			continue
 		}
+		// The same LLM-vendor egress boundary dispatchTools applies to every tool
+		// result. This path calls the tool directly rather than through runTool, so
+		// this is the only place it can be applied — and it must be, because BOTH
+		// forms below reach the verify model, and redactInvestigation does not run
+		// until deliver(), long after verify. Redact before truncating so a secret
+		// near the cap is still masked.
+		out, _ = truncateOutput(redact.Secrets(out), li.MaxToolOutputBytes)
 		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
 			fmt.Sprintf("current state — %s:\n%s", name, out))
 		id := "recall-confirm-" + name

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -40,7 +40,7 @@ func TestConfirmRecallAppendsCurrentState(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
 	if !gathered {
 		t.Fatal("expected gathered=true when a confirm tool returns output")
 	}
@@ -59,7 +59,7 @@ func TestConfirmRecallIsNamespaceWideNotObjectScoped(t *testing.T) {
 	ev := &fakeConfirmTool{name: "kube_events", out: "Warning"}
 	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
+	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
 		t.Fatal("expected gathered=true")
 	}
 	if !strings.Contains(ps.gotArgs, `"namespace":"apps"`) {
@@ -77,7 +77,7 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "x"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{}} // no namespace
-	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
 	if gathered {
 		t.Fatal("no namespace must skip confirmation")
 	}
@@ -92,7 +92,7 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 func TestConfirmRecallToolsAbsentSkips(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "what_changed", out: "x"}}}
 	req := Request{Workload: providers.Workload{Namespace: "apps"}}
-	if _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
+	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
 		t.Fatal("no confirm tools present must yield gathered=false")
 	}
 }
@@ -102,7 +102,7 @@ func TestConfirmRecallToolErrorTolerated(t *testing.T) {
 	good := &fakeConfirmTool{name: "kube_events", out: "Warning FailedMount"}
 	li := &LoopInvestigator{Tools: []Tool{bad, good}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
 	if !gathered {
 		t.Fatal("one tool erroring must not prevent the other from confirming")
 	}
@@ -119,5 +119,81 @@ func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
 	}
 	if out.RootCauses[1].Confidence != 0.5 {
 		t.Fatalf("a value already below the ceiling must be untouched, got %v", out.RootCauses[1].Confidence)
+	}
+}
+
+// TestConfirmRecallGroundsTheReview pins the fix for recalled findings being
+// downgraded on principle rather than on their merits.
+//
+// The verify prompt's central rule is "each cited piece of evidence must trace to a
+// tool result in the transcript excerpt below … if it cannot be found in the
+// transcript, treat it as unverified — reject or downgrade it". The recall path
+// passed a nil transcript, so renderForReview emitted NO excerpt section at all and
+// that rule was unsatisfiable by construction — the reviewer was told to check
+// against a document that did not exist, and correctly downgraded every recall.
+// Measured live: the only recall that ever fired went 0.72 -> 0.45, and
+// runlore_recall_hits_total{result="downgraded"} was 1 of 1.
+//
+// The confirm output was always there, but as an evidence bullet — an assertion by
+// the author, not tool output the reviewer may treat as fact. That is exactly the
+// distinction the groundedness rule draws, so it has to be handed over as both.
+func TestConfirmRecallGroundsTheReview(t *testing.T) {
+	ps := &fakeConfirmTool{name: "pod_status", out: "web-abc  Running ready=1/1"}
+	ev := &fakeConfirmTool{name: "kube_events", out: "(no Warning events)"}
+	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
+	req := Request{Title: "WebDown", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+
+	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("expected gathered=true")
+	}
+
+	// The transcript must be the shape transcriptExcerpt walks: an assistant turn
+	// carrying the calls (so each result can be labelled with its tool) plus one tool
+	// turn per result. Without the assistant turn the excerpt renders "[tool]" for
+	// everything and the reviewer cannot tell pod_status from kube_events.
+	if len(transcript) != 3 {
+		t.Fatalf("want 1 assistant turn + 2 tool results, got %d messages", len(transcript))
+	}
+	if transcript[0].Role != "assistant" || len(transcript[0].ToolCalls) != 2 {
+		t.Fatalf("first message must be the assistant turn carrying both calls, got %+v", transcript[0])
+	}
+	for _, m := range transcript[1:] {
+		if m.Role != "tool" || m.ToolCallID == "" {
+			t.Fatalf("result messages must be tool turns with a call id, got %+v", m)
+		}
+	}
+
+	// The property that actually matters: the review the model sees now CONTAINS a
+	// transcript excerpt, with each result attributed to the tool that produced it.
+	review := renderForReview(req, inv, transcript)
+	if !strings.Contains(review, "Tool transcript excerpt") {
+		t.Fatalf("the review must carry a transcript excerpt, else the prompt's groundedness "+
+			"rule is unsatisfiable and every recall is downgraded on principle:\n%s", review)
+	}
+	for _, want := range []string{"[pod_status] web-abc  Running ready=1/1", "[kube_events] (no Warning events)"} {
+		if !strings.Contains(review, want) {
+			t.Errorf("review must attribute each result to its tool; missing %q:\n%s", want, review)
+		}
+	}
+}
+
+// TestConfirmRecallNoTranscriptWhenNothingGathered keeps the degraded path honest: if
+// no current state could be gathered there is nothing the reviewer may treat as
+// verified, so it must get NO transcript rather than an empty or fabricated one. The
+// caller de-rates that case via recallUnconfirmedCap.
+func TestConfirmRecallNoTranscriptWhenNothingGathered(t *testing.T) {
+	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "pod_status", out: "  "}}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+	_, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if gathered {
+		t.Fatal("blank tool output must not count as gathered")
+	}
+	if transcript != nil {
+		t.Fatalf("no gathered state must yield a nil transcript, got %+v", transcript)
+	}
+	// And a nil transcript must still render a reviewable message (no excerpt section).
+	if review := renderForReview(req, recalledInv(), nil); strings.Contains(review, "Tool transcript excerpt") {
+		t.Fatalf("a nil transcript must not render an empty excerpt section:\n%s", review)
 	}
 }

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -40,9 +40,9 @@ func TestConfirmRecallAppendsCurrentState(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
-		t.Fatal("expected gathered=true when a confirm tool returns output")
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
+		t.Fatal("expected a transcript when a confirm tool returns output")
 	}
 	joined := strings.Join(inv.RootCauses[0].Evidence, "\n")
 	if !strings.Contains(joined, "CrashLoopBackOff") || !strings.Contains(joined, "pod_status") {
@@ -59,8 +59,8 @@ func TestConfirmRecallIsNamespaceWideNotObjectScoped(t *testing.T) {
 	ev := &fakeConfirmTool{name: "kube_events", out: "Warning"}
 	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
-		t.Fatal("expected gathered=true")
+	if _, transcript := li.confirmRecall(context.Background(), req, recalledInv()); transcript == nil {
+		t.Fatal("expected a transcript")
 	}
 	if !strings.Contains(ps.gotArgs, `"namespace":"apps"`) {
 		t.Fatalf("pod_status not scoped to namespace: %q", ps.gotArgs)
@@ -77,8 +77,8 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "x"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{}} // no namespace
-	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if gathered {
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript != nil {
 		t.Fatal("no namespace must skip confirmation")
 	}
 	if ps.gotArgs != "" {
@@ -92,8 +92,8 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 func TestConfirmRecallToolsAbsentSkips(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "what_changed", out: "x"}}}
 	req := Request{Workload: providers.Workload{Namespace: "apps"}}
-	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
-		t.Fatal("no confirm tools present must yield gathered=false")
+	if _, transcript := li.confirmRecall(context.Background(), req, recalledInv()); transcript != nil {
+		t.Fatal("no confirm tools present must yield no transcript")
 	}
 }
 
@@ -102,12 +102,22 @@ func TestConfirmRecallToolErrorTolerated(t *testing.T) {
 	good := &fakeConfirmTool{name: "kube_events", out: "Warning FailedMount"}
 	li := &LoopInvestigator{Tools: []Tool{bad, good}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
 		t.Fatal("one tool erroring must not prevent the other from confirming")
 	}
 	if !strings.Contains(strings.Join(inv.RootCauses[0].Evidence, "\n"), "FailedMount") {
 		t.Fatal("the surviving tool's output should be appended")
+	}
+	// A PARTIAL gather is where calls and results can drift apart: the erroring tool
+	// must contribute neither, so every result still has a matching call to be labelled
+	// from. If they desync, transcriptExcerpt falls back to "[tool]" and the reviewer
+	// silently loses attribution — with every all-succeed test still green.
+	if got := len(transcript[0].ToolCalls); got != len(transcript)-1 {
+		t.Fatalf("calls must match results: %d calls for %d results", got, len(transcript)-1)
+	}
+	if !strings.Contains(renderForReview(req, inv, transcript), "[kube_events] Warning FailedMount") {
+		t.Fatal("the surviving tool's result must be attributed to kube_events in the excerpt")
 	}
 }
 
@@ -126,9 +136,9 @@ func TestConfirmRecallRedactsBeforeTheModelSeesIt(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
 
-	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
-		t.Fatal("expected gathered=true")
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
+		t.Fatal("expected a transcript")
 	}
 	// Both forms, and the assembled review that carries them to the provider.
 	if joined := strings.Join(inv.RootCauses[0].Evidence, "\n"); strings.Contains(joined, secret) {
@@ -157,11 +167,11 @@ func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
 // TestConfirmRecallGroundsTheReview pins the fix for recalled findings being
 // downgraded on principle rather than on their merits.
 //
-// The verify prompt's central rule is "each cited piece of evidence must trace to a
-// tool result in the transcript excerpt below … if it cannot be found in the
-// transcript, treat it as unverified — reject or downgrade it". The recall path
-// passed a nil transcript, so renderForReview emitted NO excerpt section at all and
-// that rule was unsatisfiable by construction — the reviewer was told to check
+// verifyPrompt's groundedness rule (see verify.go — quoted nowhere here, so the two
+// cannot drift) requires each cited piece of evidence to trace to a tool result in the
+// transcript excerpt, and treats what it cannot find there as unverified. The recall
+// path passed a nil transcript, so renderForReview emitted NO excerpt section at all
+// and that rule was unsatisfiable by construction — the reviewer was told to check
 // against a document that did not exist, and correctly downgraded every recall.
 // Measured live: the only recall that ever fired went 0.72 -> 0.45, and
 // runlore_recall_hits_total{result="downgraded"} was 1 of 1.
@@ -175,20 +185,24 @@ func TestConfirmRecallGroundsTheReview(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
 	req := Request{Title: "WebDown", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
 
-	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
-		t.Fatal("expected gathered=true")
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
+		t.Fatal("expected a transcript")
 	}
 
-	// The transcript must be the shape transcriptExcerpt walks: an assistant turn
+	// The transcript must be the shape transcriptExcerpt walks: one assistant turn
 	// carrying the calls (so each result can be labelled with its tool) plus one tool
 	// turn per result. Without the assistant turn the excerpt renders "[tool]" for
-	// everything and the reviewer cannot tell pod_status from kube_events.
-	if len(transcript) != 3 {
-		t.Fatalf("want 1 assistant turn + 2 tool results, got %d messages", len(transcript))
+	// everything and the reviewer cannot tell pod_status from kube_events. Counts are
+	// derived, not literal, so adding a confirm tool does not fail a test about shape.
+	if transcript[0].Role != "assistant" {
+		t.Fatalf("first message must be the assistant turn carrying the calls, got %+v", transcript[0])
 	}
-	if transcript[0].Role != "assistant" || len(transcript[0].ToolCalls) != 2 {
-		t.Fatalf("first message must be the assistant turn carrying both calls, got %+v", transcript[0])
+	if got, want := len(transcript[0].ToolCalls), len(transcript)-1; got != want {
+		t.Fatalf("want one call per result: %d calls for %d results", got, want)
+	}
+	if len(transcript[0].ToolCalls) != len(li.Tools) {
+		t.Fatalf("both fixture tools should have been called, got %d", len(transcript[0].ToolCalls))
 	}
 	for _, m := range transcript[1:] {
 		if m.Role != "tool" || m.ToolCallID == "" {
@@ -217,12 +231,9 @@ func TestConfirmRecallGroundsTheReview(t *testing.T) {
 func TestConfirmRecallNoTranscriptWhenNothingGathered(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "pod_status", out: "  "}}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	_, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if gathered {
-		t.Fatal("blank tool output must not count as gathered")
-	}
+	_, transcript := li.confirmRecall(context.Background(), req, recalledInv())
 	if transcript != nil {
-		t.Fatalf("no gathered state must yield a nil transcript, got %+v", transcript)
+		t.Fatalf("blank tool output must not count as gathered, got %+v", transcript)
 	}
 	// And a nil transcript must still render a reviewable message (no excerpt section).
 	if review := renderForReview(req, recalledInv(), nil); strings.Contains(review, "Tool transcript excerpt") {

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -111,6 +111,38 @@ func TestConfirmRecallToolErrorTolerated(t *testing.T) {
 	}
 }
 
+// TestConfirmRecallRedactsBeforeTheModelSeesIt pins the egress boundary on this path.
+//
+// confirmRecall calls its tools DIRECTLY rather than through runTool/dispatchTools, so
+// it does not inherit the loop's `truncateOutput(redact.Secrets(...))` hook, and the
+// only other scrubber (redactInvestigation) runs in deliver() — AFTER verify. Both the
+// evidence bullet and the transcript reach the verify model via renderForReview, so
+// without masking here a secret in a pod's terminated message or a FailedMount event
+// ships to the provider verbatim. pod_status advertises exactly that content ("the
+// message names the exact cause, e.g. a missing Secret/ConfigMap key").
+func TestConfirmRecallRedactsBeforeTheModelSeesIt(t *testing.T) {
+	const secret = "ghp_0123456789abcdefghijklmnopqrstuvwx"
+	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff: bad token " + secret}
+	li := &LoopInvestigator{Tools: []Tool{ps}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+
+	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("expected gathered=true")
+	}
+	// Both forms, and the assembled review that carries them to the provider.
+	if joined := strings.Join(inv.RootCauses[0].Evidence, "\n"); strings.Contains(joined, secret) {
+		t.Errorf("evidence bullet leaks the token: %q", joined)
+	}
+	if review := renderForReview(req, inv, transcript); strings.Contains(review, secret) {
+		t.Errorf("the message sent to the verify model leaks the token:\n%s", review)
+	}
+	// The surrounding diagnostic text must survive — masking, not dropping.
+	if !strings.Contains(strings.Join(inv.RootCauses[0].Evidence, "\n"), "CrashLoopBackOff") {
+		t.Error("redaction must mask the secret, not discard the tool output")
+	}
+}
+
 func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
 	inv := providers.Investigation{Confidence: 0.9, RootCauses: []providers.Hypothesis{{Confidence: 0.9}, {Confidence: 0.5}}}
 	out := capRecallConfidence(inv, 0.70)

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -717,8 +717,8 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	li.Log.Info("instant recall (catalog hit; skipping the loop)",
 		"title", req.Title, "entry", entry.Path, "confidence", fmt.Sprintf("%.2f", conf))
 	rec := recalledInvestigation(req, *entry, conf)
-	rec, confirmTranscript, confirmed := li.confirmRecall(ctx, req, rec)
-	if !confirmed {
+	rec, confirmTranscript := li.confirmRecall(ctx, req, rec)
+	if confirmTranscript == nil {
 		// Could not confront the entry with current state — be less assertive
 		// so an unverifiable recall does not present at full recall confidence.
 		rec = capRecallConfidence(rec, recallUnconfirmedCap)
@@ -729,14 +729,11 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 		// Catalog content is untrusted: verify a recalled finding too, so a
 		// crafted high-recall entry can't bypass the adversarial review.
 		//
-		// The transcript is confirmRecall's tool results — the CURRENT cluster state,
+		// The transcript is confirmRecall's tool results — the current cluster state,
 		// the only independently-gathered fact on this path and so the only thing the
-		// reviewer may treat as verified. Passing nil here (as this did) left the
-		// prompt's groundedness rule with nothing to check against, which downgraded
-		// every recalled finding on principle; see confirmRecall for the full account.
-		// It is still nil when confirm gathered nothing (no namespace, tools absent,
-		// every call errored) — the review then runs on catalog text alone, which is
-		// exactly the case recallUnconfirmedCap above has already de-rated.
+		// reviewer may treat as verified. It is nil only when confirm gathered nothing,
+		// the case recallUnconfirmedCap above has already de-rated; see confirmRecall
+		// for why passing nil to a path that DID gather evidence downgrades it.
 		rec, verified = li.verifyFindings(ctx, req, rec, confirmTranscript, verifyTotals)
 	}
 	if !verified {

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -717,7 +717,7 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	li.Log.Info("instant recall (catalog hit; skipping the loop)",
 		"title", req.Title, "entry", entry.Path, "confidence", fmt.Sprintf("%.2f", conf))
 	rec := recalledInvestigation(req, *entry, conf)
-	rec, confirmed := li.confirmRecall(ctx, req, rec)
+	rec, confirmTranscript, confirmed := li.confirmRecall(ctx, req, rec)
 	if !confirmed {
 		// Could not confront the entry with current state — be less assertive
 		// so an unverifiable recall does not present at full recall confidence.
@@ -727,10 +727,17 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	verified := true // no Verify configured ⇒ nothing to fail; behaves as before
 	if li.Verify {
 		// Catalog content is untrusted: verify a recalled finding too, so a
-		// crafted high-recall entry can't bypass the adversarial review. No loop
-		// ran on this short-circuit path, so there is no tool transcript to ground
-		// against (nil) — the recalled finding is judged on the catalog text alone.
-		rec, verified = li.verifyFindings(ctx, req, rec, nil, verifyTotals)
+		// crafted high-recall entry can't bypass the adversarial review.
+		//
+		// The transcript is confirmRecall's tool results — the CURRENT cluster state,
+		// the only independently-gathered fact on this path and so the only thing the
+		// reviewer may treat as verified. Passing nil here (as this did) left the
+		// prompt's groundedness rule with nothing to check against, which downgraded
+		// every recalled finding on principle; see confirmRecall for the full account.
+		// It is still nil when confirm gathered nothing (no namespace, tools absent,
+		// every call errored) — the review then runs on catalog text alone, which is
+		// exactly the case recallUnconfirmedCap above has already de-rated.
+		rec, verified = li.verifyFindings(ctx, req, rec, confirmTranscript, verifyTotals)
 	}
 	if !verified {
 		// verifyFindings could not run (model error, or no usable verdicts) rather than

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -76,10 +76,10 @@ func parseVerdicts(args string) ([]verdict, error) {
 // rather than merely asserted.
 //
 // Passing nil is a claim, not merely an option: it says nothing here is independently
-// verified, leaving the prompt's groundedness rule with nothing to check against, so
-// the reviewer can only downgrade. Reserve it for when that is actually true (confirm
-// gathered no state at all). Handing nil to a path that DID gather evidence downgrades
-// sound findings on principle — see confirmRecall for the live case where it did.
+// verified, which leaves the groundedness rule with nothing to check against, so the
+// reviewer can only downgrade. Reserve it for when that is actually true — handing nil
+// to a path that DID gather evidence downgrades sound findings on principle, as the
+// recall path once did (see confirmRecall).
 //
 // The second return, verified, reports whether an adversarial review actually
 // happened: true when the returned investigation reflects a completed review
@@ -281,7 +281,8 @@ const maxVerifyTranscriptBytes = 4000
 // leak. The MOST RECENT tool results are preferred (they are the ones the model saw
 // just before concluding, so the most decision-relevant) and the excerpt is assembled
 // oldest-first up to maxVerifyTranscriptBytes. Returns "" when there are no tool
-// results (e.g. the recall short-circuit path, where no loop ran).
+// results — a loop that concluded without calling a tool, or a recall whose confirm
+// step gathered nothing (a confirmed recall DOES carry results; see confirmRecall).
 func transcriptExcerpt(transcript []providers.Message) string {
 	// Collect tool-result contents with a short call-name label (from the assistant
 	// turn that requested them) so the reviewer can tell which tool produced what.

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -69,10 +69,17 @@ func parseVerdicts(args string) ([]verdict, error) {
 // causes, rejecting correlation-only/unverified claims and downgrading unproven
 // ones before delivery/curation. The verify completion's token usage is accumulated
 // into totals (when non-nil) so the per-investigation cost includes the verify pass.
-// transcript is the loop's accumulated message history (may be nil, e.g. the
-// recall short-circuit path where no loop ran). A bounded, redacted excerpt of its
-// tool results is fed to the reviewer so groundedness ("does this cause trace to a
-// tool result?") can be checked rather than merely asserted.
+// transcript is the tool history the reviewer may treat as verified fact: the loop's
+// accumulated messages on the full path, confirmRecall's current-state results on the
+// recall short-circuit. A bounded, redacted excerpt of its tool results is fed to the
+// reviewer so groundedness ("does this cause trace to a tool result?") can be checked
+// rather than merely asserted.
+//
+// Passing nil is a claim, not merely an option: it says nothing here is independently
+// verified, leaving the prompt's groundedness rule with nothing to check against, so
+// the reviewer can only downgrade. Reserve it for when that is actually true (confirm
+// gathered no state at all). Handing nil to a path that DID gather evidence downgrades
+// sound findings on principle — see confirmRecall for the live case where it did.
 //
 // The second return, verified, reports whether an adversarial review actually
 // happened: true when the returned investigation reflects a completed review


### PR DESCRIPTION
## Summary

  Follow-ups from reviewing #476, stacked **on top of it** (base is
     current — the one thing the scorecard is supposed never to do.
  3. **`publish scorecard` treated a missing report as a warning with `exit 0`.**

  The workflow's own header already promises that a run which did not really happen
  "can never be mistaken for a real green eval". That guarantee held for a missing API
  key and failed completely for an overrun.

  ### The fix

  **The budget is enforced inside the step by `timeout` (`EVAL_BUDGET: 40m`)**, whose
  exit 124 fails the step and turns the job red. `timeout-minutes` rises to 55 as a
  pure backstop that should never be what fires — precisely because it is the silent
  outcome. Raise `EVAL_BUDGET`, not just `timeout-minutes`, when the suite grows.

  A timeout is annotated **distinctly from a gate failure**, because the two mean
  opposite things: a gate failure is a statement about the model, while a timeout
  measured nothing and writes no report. Keeping them apart is what makes the red
  actionable.

  **The docs rebuild is gated on the scorecard actually having been published** (a
  `published` step output), so a timed-out or no-change run can no longer republish old
  numbers as fresh. A missing report is now an error, not a warning.

  **Per-case progress on stderr.** The step printed *nothing* for its entire 18-minute
  run: `RunN` is sequential and holds every result until the campaign ends, so "the
  eval is broken" was indistinguishable from "the eval is slow", with no clue as to
  which case ate the budget. Progress goes to stderr because stdout carries the result
  table.

  ## Linked issue

  n/a — found while checking whether #476's recall-verify change had affected the
  learning-loop numbers.

  ## How was it verified?

  Full gate, as CI runs it:

  ```
  go build ./...                          → OK
  go vet ./...                            → OK
  gofmt -l .                              → (empty)
  go test ./...                           → all packages ok
  go test -race ./internal/eval ./internal/app → ok
  ```

  Not run: `golangci-lint run ./...` (not installed locally) and `hack/e2e-k3d.sh`
  (this touches CI wiring and eval reporting, no feature path).

  **The shell logic is the part most likely to be wrong, so it was tested rather than
  reasoned about.** Against a stub emulating GNU `timeout`'s contract, all three paths
  behave:

  | Scenario | Exit | Annotation |
  |---|---|---|
  | overruns the budget | `124` | timeout error + step summary |
  | gate failure | `1` propagated | none (correctly not reported as a timeout) |
  | success | `0` | none |

  `|| rc=$?` is used rather than `if ! cmd`, which would capture the *negated* status.

  **The progress output is pinned at both levels**, and both tests were confirmed to
  fail before the fix:

  - `TestRunNReportsProgressPerCase` — one tick per case, in case order, with a running
    count, and the aggregate handed to the hook is the one that lands in the campaign
    (progress reporting a different verdict than the report would be worse than none).
    Plus `TestRunNNilProgressHookIsFine` for the nil hook every non-CLI caller uses.
  - `TestRunEvalReportsProgressToStderr` — drives the real `RunEval` against the
    existing keyless mock model and asserts one line per case on **stderr**, with
    elapsed time, and nothing leaking onto stdout. Unwiring `runner.OnCaseDone` makes it
    fail with `want 2 progress lines, got 0`.

  `docs-check` does not trigger on any path this PR touches, so `main`'s current
  screenshot-guard failure (fixed separately in #476) is unrelated here.

  ## Not addressed here

  **The pass rate itself.** The last published scorecard reached **1/6 cases (17%)**
  against the 0.7 gate, down from **4/4** on 2026-08-03, with output tokens **doubled**
  (29.5k → 58.6k):

  ```
  2026-08-03  reached 4/4  pass_rate 1.00  out 29,558
  2026-08-09  reached 1/6  pass_rate 0.17  out 58,590
  ```

  Two cases were added in that window (`node-eviction-*`, both `gate: false`), but
  *three previously-passing cases also regressed*. Doubled output tokens on a
  recall-heavy suite is the signature of recall being rejected and falling through to
  full investigations — which is what #476 is about, and would also explain the growth
  into the 20-minute wall. Diagnosing it needs a live run with the key, so it is
  deliberately out of scope: this PR makes the failure **visible and honest**, which is
  the prerequisite for fixing it.

  Worth a `workflow_dispatch` once this lands, to see the real duration and where the
  suite actually stands.

  ## Checklist

  - [x] `go build ./...` passes
  - [x] `go vet ./...` passes
  - [x] `go test ./...` passes (`-race` on the touched packages)
  - [x] `gofmt -l .` prints nothing
  - [ ] `golangci-lint run ./...` — not installed locally; CI covers it
  - [x] Test added first (TDD) — both progress tests were confirmed failing before the
        wiring existed; the shell paths were exercised against a `timeout` stub before
        the step was finalised
  - [x] Docs updated — the workflow's own header comment now records the timeout trap
        and says to raise `EVAL_BUDGET` rather than `timeout-minutes`
  - [x] Respects **read-only-first** — no cluster access; CI wiring and stderr
        reporting only