### PR TITLE
fix(recall): redact confirm output before verify, and simplify the transcript plumbing

### DIFF
--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -24,38 +24,42 @@ var recallConfirmTools = []string{"pod_status", "kube_events"}
 // confirmRecall gathers current cluster state for the recalled workload and appends
 // it to the top hypothesis's evidence, so the verify pass can judge the recalled
 // cause against reality rather than a tautology. Best-effort: a missing namespace,
-// absent tools, or a tool error yields gathered=false. gathered is true when at
-// least one confirm tool returned non-empty output (including "no pods"/"no events"
-// — still real current state).
+// absent tools, or a tool error gathers nothing. Empty output does not count, but
+// "no pods"/"no events" does — that IS real current state.
 //
-// It ALSO returns those results shaped as a tool transcript, which the caller passes
-// to verifyFindings. Both forms are needed and they are not redundant:
+// It returns those results in two forms, which are not redundant:
 //
 //   - the evidence bullets are what the DELIVERED card shows a human;
 //   - the transcript is what the REVIEWER is allowed to treat as verified fact.
 //
-// The verify prompt's central rule is "each cited piece of evidence must trace to a
-// tool result in the transcript excerpt below … if it cannot be found in the
-// transcript, treat it as unverified — reject or downgrade it". The recall path used
+// The distinction matters because verifyPrompt's groundedness rule (verify.go)
+// requires each cited piece of evidence to trace to a tool result in the transcript
+// excerpt, and treats what it cannot find there as unverified. The recall path used
 // to pass a nil transcript, so renderForReview emitted no excerpt at all and that
 // rule was unsatisfiable BY CONSTRUCTION: every recalled finding was, correctly by
 // its own instructions, downgraded. The confirm output was sitting right there in the
 // evidence list, but as an assertion by the author rather than as tool output the
-// reviewer could check against — which is precisely the distinction the rule draws.
+// reviewer could check against — precisely the distinction the rule draws.
 //
 // Handing over the same results as a transcript makes the review sharper, not softer:
 // a reviewer that can read current state can now CONTRADICT a stale or poisoned entry
 // (entry says pods are OOMKilling, pod_status shows them Running) instead of being
 // reduced to "cannot verify" on everything.
-func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, []providers.Message, bool) {
+//
+// A nil transcript means nothing was gathered — the only state the caller needs, and
+// the case it de-rates via recallUnconfirmedCap.
+func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv providers.Investigation) (providers.Investigation, []providers.Message) {
 	if req.Workload.Namespace == "" || len(inv.RootCauses) == 0 {
-		return inv, nil, false
+		return inv, nil
 	}
 	byName := make(map[string]Tool, len(li.Tools))
 	for _, t := range li.Tools {
 		byName[t.Name()] = t
 	}
-	gathered := false
+	// Invariant across the loop (it encodes the namespace only). Recording the SAME
+	// string the call was made with also keeps the transcript's args honest by
+	// construction, rather than resting on two marshals agreeing.
+	args := confirmArgs(req.Workload)
 	// One synthetic assistant turn carrying the calls, then one tool turn per result —
 	// the shape transcriptExcerpt walks to label each result with the tool that
 	// produced it. Call IDs are deterministic (no loop ran, so nothing else mints them).
@@ -66,7 +70,7 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		if !ok {
 			continue
 		}
-		out, err := t.Call(ctx, confirmArgs(req.Workload))
+		out, err := t.Call(ctx, args)
 		if err != nil {
 			if li.Log != nil {
 				li.Log.Debug("recall confirm tool failed", "tool", name, "err", err)
@@ -86,15 +90,13 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
 			fmt.Sprintf("current state — %s:\n%s", name, out))
 		id := "recall-confirm-" + name
-		calls = append(calls, providers.ToolCall{ID: id, Name: name, Args: confirmArgs(req.Workload)})
+		calls = append(calls, providers.ToolCall{ID: id, Name: name, Args: args})
 		results = append(results, providers.Message{Role: "tool", ToolCallID: id, Content: out})
-		gathered = true
 	}
-	if !gathered {
-		return inv, nil, false
+	if len(results) == 0 {
+		return inv, nil
 	}
-	transcript := append([]providers.Message{{Role: "assistant", ToolCalls: calls}}, results...)
-	return inv, transcript, true
+	return inv, append([]providers.Message{{Role: "assistant", ToolCalls: calls}}, results...)
 }
 
 // confirmArgs builds the JSON args for a confirmatory tool: namespace-scoped, but

--- a/internal/investigate/confirm.go
+++ b/internal/investigate/confirm.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
 )
 
 // recallUnconfirmedCap is the recall-confidence ceiling applied when current cluster
@@ -75,6 +76,13 @@ func (li *LoopInvestigator) confirmRecall(ctx context.Context, req Request, inv 
 		if out = strings.TrimSpace(out); out == "" {
 			continue
 		}
+		// The same LLM-vendor egress boundary dispatchTools applies to every tool
+		// result. This path calls the tool directly rather than through runTool, so
+		// this is the only place it can be applied — and it must be, because BOTH
+		// forms below reach the verify model, and redactInvestigation does not run
+		// until deliver(), long after verify. Redact before truncating so a secret
+		// near the cap is still masked.
+		out, _ = truncateOutput(redact.Secrets(out), li.MaxToolOutputBytes)
 		inv.RootCauses[0].Evidence = append(inv.RootCauses[0].Evidence,
 			fmt.Sprintf("current state — %s:\n%s", name, out))
 		id := "recall-confirm-" + name

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -40,9 +40,9 @@ func TestConfirmRecallAppendsCurrentState(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
-		t.Fatal("expected gathered=true when a confirm tool returns output")
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
+		t.Fatal("expected a transcript when a confirm tool returns output")
 	}
 	joined := strings.Join(inv.RootCauses[0].Evidence, "\n")
 	if !strings.Contains(joined, "CrashLoopBackOff") || !strings.Contains(joined, "pod_status") {
@@ -59,8 +59,8 @@ func TestConfirmRecallIsNamespaceWideNotObjectScoped(t *testing.T) {
 	ev := &fakeConfirmTool{name: "kube_events", out: "Warning"}
 	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); !gathered {
-		t.Fatal("expected gathered=true")
+	if _, transcript := li.confirmRecall(context.Background(), req, recalledInv()); transcript == nil {
+		t.Fatal("expected a transcript")
 	}
 	if !strings.Contains(ps.gotArgs, `"namespace":"apps"`) {
 		t.Fatalf("pod_status not scoped to namespace: %q", ps.gotArgs)
@@ -77,8 +77,8 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 	ps := &fakeConfirmTool{name: "pod_status", out: "x"}
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{}} // no namespace
-	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if gathered {
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript != nil {
 		t.Fatal("no namespace must skip confirmation")
 	}
 	if ps.gotArgs != "" {
@@ -92,8 +92,8 @@ func TestConfirmRecallNoNamespaceSkips(t *testing.T) {
 func TestConfirmRecallToolsAbsentSkips(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "what_changed", out: "x"}}}
 	req := Request{Workload: providers.Workload{Namespace: "apps"}}
-	if _, _, gathered := li.confirmRecall(context.Background(), req, recalledInv()); gathered {
-		t.Fatal("no confirm tools present must yield gathered=false")
+	if _, transcript := li.confirmRecall(context.Background(), req, recalledInv()); transcript != nil {
+		t.Fatal("no confirm tools present must yield no transcript")
 	}
 }
 
@@ -102,12 +102,22 @@ func TestConfirmRecallToolErrorTolerated(t *testing.T) {
 	good := &fakeConfirmTool{name: "kube_events", out: "Warning FailedMount"}
 	li := &LoopInvestigator{Tools: []Tool{bad, good}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	inv, _, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
 		t.Fatal("one tool erroring must not prevent the other from confirming")
 	}
 	if !strings.Contains(strings.Join(inv.RootCauses[0].Evidence, "\n"), "FailedMount") {
 		t.Fatal("the surviving tool's output should be appended")
+	}
+	// A PARTIAL gather is where calls and results can drift apart: the erroring tool
+	// must contribute neither, so every result still has a matching call to be labelled
+	// from. If they desync, transcriptExcerpt falls back to "[tool]" and the reviewer
+	// silently loses attribution — with every all-succeed test still green.
+	if got := len(transcript[0].ToolCalls); got != len(transcript)-1 {
+		t.Fatalf("calls must match results: %d calls for %d results", got, len(transcript)-1)
+	}
+	if !strings.Contains(renderForReview(req, inv, transcript), "[kube_events] Warning FailedMount") {
+		t.Fatal("the surviving tool's result must be attributed to kube_events in the excerpt")
 	}
 }
 
@@ -126,9 +136,9 @@ func TestConfirmRecallRedactsBeforeTheModelSeesIt(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{ps}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
 
-	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
-		t.Fatal("expected gathered=true")
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
+		t.Fatal("expected a transcript")
 	}
 	// Both forms, and the assembled review that carries them to the provider.
 	if joined := strings.Join(inv.RootCauses[0].Evidence, "\n"); strings.Contains(joined, secret) {
@@ -157,11 +167,11 @@ func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
 // TestConfirmRecallGroundsTheReview pins the fix for recalled findings being
 // downgraded on principle rather than on their merits.
 //
-// The verify prompt's central rule is "each cited piece of evidence must trace to a
-// tool result in the transcript excerpt below … if it cannot be found in the
-// transcript, treat it as unverified — reject or downgrade it". The recall path
-// passed a nil transcript, so renderForReview emitted NO excerpt section at all and
-// that rule was unsatisfiable by construction — the reviewer was told to check
+// verifyPrompt's groundedness rule (see verify.go — quoted nowhere here, so the two
+// cannot drift) requires each cited piece of evidence to trace to a tool result in the
+// transcript excerpt, and treats what it cannot find there as unverified. The recall
+// path passed a nil transcript, so renderForReview emitted NO excerpt section at all
+// and that rule was unsatisfiable by construction — the reviewer was told to check
 // against a document that did not exist, and correctly downgraded every recall.
 // Measured live: the only recall that ever fired went 0.72 -> 0.45, and
 // runlore_recall_hits_total{result="downgraded"} was 1 of 1.
@@ -175,20 +185,24 @@ func TestConfirmRecallGroundsTheReview(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{ps, ev}}
 	req := Request{Title: "WebDown", Workload: providers.Workload{Namespace: "apps", Name: "web"}}
 
-	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if !gathered {
-		t.Fatal("expected gathered=true")
+	inv, transcript := li.confirmRecall(context.Background(), req, recalledInv())
+	if transcript == nil {
+		t.Fatal("expected a transcript")
 	}
 
-	// The transcript must be the shape transcriptExcerpt walks: an assistant turn
+	// The transcript must be the shape transcriptExcerpt walks: one assistant turn
 	// carrying the calls (so each result can be labelled with its tool) plus one tool
 	// turn per result. Without the assistant turn the excerpt renders "[tool]" for
-	// everything and the reviewer cannot tell pod_status from kube_events.
-	if len(transcript) != 3 {
-		t.Fatalf("want 1 assistant turn + 2 tool results, got %d messages", len(transcript))
+	// everything and the reviewer cannot tell pod_status from kube_events. Counts are
+	// derived, not literal, so adding a confirm tool does not fail a test about shape.
+	if transcript[0].Role != "assistant" {
+		t.Fatalf("first message must be the assistant turn carrying the calls, got %+v", transcript[0])
 	}
-	if transcript[0].Role != "assistant" || len(transcript[0].ToolCalls) != 2 {
-		t.Fatalf("first message must be the assistant turn carrying both calls, got %+v", transcript[0])
+	if got, want := len(transcript[0].ToolCalls), len(transcript)-1; got != want {
+		t.Fatalf("want one call per result: %d calls for %d results", got, want)
+	}
+	if len(transcript[0].ToolCalls) != len(li.Tools) {
+		t.Fatalf("both fixture tools should have been called, got %d", len(transcript[0].ToolCalls))
 	}
 	for _, m := range transcript[1:] {
 		if m.Role != "tool" || m.ToolCallID == "" {
@@ -217,12 +231,9 @@ func TestConfirmRecallGroundsTheReview(t *testing.T) {
 func TestConfirmRecallNoTranscriptWhenNothingGathered(t *testing.T) {
 	li := &LoopInvestigator{Tools: []Tool{&fakeConfirmTool{name: "pod_status", out: "  "}}}
 	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
-	_, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
-	if gathered {
-		t.Fatal("blank tool output must not count as gathered")
-	}
+	_, transcript := li.confirmRecall(context.Background(), req, recalledInv())
 	if transcript != nil {
-		t.Fatalf("no gathered state must yield a nil transcript, got %+v", transcript)
+		t.Fatalf("blank tool output must not count as gathered, got %+v", transcript)
 	}
 	// And a nil transcript must still render a reviewable message (no excerpt section).
 	if review := renderForReview(req, recalledInv(), nil); strings.Contains(review, "Tool transcript excerpt") {

--- a/internal/investigate/confirm_test.go
+++ b/internal/investigate/confirm_test.go
@@ -111,6 +111,38 @@ func TestConfirmRecallToolErrorTolerated(t *testing.T) {
 	}
 }
 
+// TestConfirmRecallRedactsBeforeTheModelSeesIt pins the egress boundary on this path.
+//
+// confirmRecall calls its tools DIRECTLY rather than through runTool/dispatchTools, so
+// it does not inherit the loop's `truncateOutput(redact.Secrets(...))` hook, and the
+// only other scrubber (redactInvestigation) runs in deliver() — AFTER verify. Both the
+// evidence bullet and the transcript reach the verify model via renderForReview, so
+// without masking here a secret in a pod's terminated message or a FailedMount event
+// ships to the provider verbatim. pod_status advertises exactly that content ("the
+// message names the exact cause, e.g. a missing Secret/ConfigMap key").
+func TestConfirmRecallRedactsBeforeTheModelSeesIt(t *testing.T) {
+	const secret = "ghp_0123456789abcdefghijklmnopqrstuvwx"
+	ps := &fakeConfirmTool{name: "pod_status", out: "web CrashLoopBackOff: bad token " + secret}
+	li := &LoopInvestigator{Tools: []Tool{ps}}
+	req := Request{Workload: providers.Workload{Namespace: "apps", Name: "web"}}
+
+	inv, transcript, gathered := li.confirmRecall(context.Background(), req, recalledInv())
+	if !gathered {
+		t.Fatal("expected gathered=true")
+	}
+	// Both forms, and the assembled review that carries them to the provider.
+	if joined := strings.Join(inv.RootCauses[0].Evidence, "\n"); strings.Contains(joined, secret) {
+		t.Errorf("evidence bullet leaks the token: %q", joined)
+	}
+	if review := renderForReview(req, inv, transcript); strings.Contains(review, secret) {
+		t.Errorf("the message sent to the verify model leaks the token:\n%s", review)
+	}
+	// The surrounding diagnostic text must survive — masking, not dropping.
+	if !strings.Contains(strings.Join(inv.RootCauses[0].Evidence, "\n"), "CrashLoopBackOff") {
+		t.Error("redaction must mask the secret, not discard the tool output")
+	}
+}
+
 func TestCapRecallConfidenceOnlyLowers(t *testing.T) {
 	inv := providers.Investigation{Confidence: 0.9, RootCauses: []providers.Hypothesis{{Confidence: 0.9}, {Confidence: 0.5}}}
 	out := capRecallConfidence(inv, 0.70)

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -717,8 +717,8 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	li.Log.Info("instant recall (catalog hit; skipping the loop)",
 		"title", req.Title, "entry", entry.Path, "confidence", fmt.Sprintf("%.2f", conf))
 	rec := recalledInvestigation(req, *entry, conf)
-	rec, confirmTranscript, confirmed := li.confirmRecall(ctx, req, rec)
-	if !confirmed {
+	rec, confirmTranscript := li.confirmRecall(ctx, req, rec)
+	if confirmTranscript == nil {
 		// Could not confront the entry with current state — be less assertive
 		// so an unverifiable recall does not present at full recall confidence.
 		rec = capRecallConfidence(rec, recallUnconfirmedCap)
@@ -729,14 +729,11 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 		// Catalog content is untrusted: verify a recalled finding too, so a
 		// crafted high-recall entry can't bypass the adversarial review.
 		//
-		// The transcript is confirmRecall's tool results — the CURRENT cluster state,
+		// The transcript is confirmRecall's tool results — the current cluster state,
 		// the only independently-gathered fact on this path and so the only thing the
-		// reviewer may treat as verified. Passing nil here (as this did) left the
-		// prompt's groundedness rule with nothing to check against, which downgraded
-		// every recalled finding on principle; see confirmRecall for the full account.
-		// It is still nil when confirm gathered nothing (no namespace, tools absent,
-		// every call errored) — the review then runs on catalog text alone, which is
-		// exactly the case recallUnconfirmedCap above has already de-rated.
+		// reviewer may treat as verified. It is nil only when confirm gathered nothing,
+		// the case recallUnconfirmedCap above has already de-rated; see confirmRecall
+		// for why passing nil to a path that DID gather evidence downgrades it.
 		rec, verified = li.verifyFindings(ctx, req, rec, confirmTranscript, verifyTotals)
 	}
 	if !verified {

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -76,10 +76,10 @@ func parseVerdicts(args string) ([]verdict, error) {
 // rather than merely asserted.
 //
 // Passing nil is a claim, not merely an option: it says nothing here is independently
-// verified, leaving the prompt's groundedness rule with nothing to check against, so
-// the reviewer can only downgrade. Reserve it for when that is actually true (confirm
-// gathered no state at all). Handing nil to a path that DID gather evidence downgrades
-// sound findings on principle — see confirmRecall for the live case where it did.
+// verified, which leaves the groundedness rule with nothing to check against, so the
+// reviewer can only downgrade. Reserve it for when that is actually true — handing nil
+// to a path that DID gather evidence downgrades sound findings on principle, as the
+// recall path once did (see confirmRecall).
 //
 // The second return, verified, reports whether an adversarial review actually
 // happened: true when the returned investigation reflects a completed review
@@ -281,7 +281,8 @@ const maxVerifyTranscriptBytes = 4000
 // leak. The MOST RECENT tool results are preferred (they are the ones the model saw
 // just before concluding, so the most decision-relevant) and the excerpt is assembled
 // oldest-first up to maxVerifyTranscriptBytes. Returns "" when there are no tool
-// results (e.g. the recall short-circuit path, where no loop ran).
+// results — a loop that concluded without calling a tool, or a recall whose confirm
+// step gathered nothing (a confirmed recall DOES carry results; see confirmRecall).
 func transcriptExcerpt(transcript []providers.Message) string {
 	// Collect tool-result contents with a short call-name label (from the assistant
 	// turn that requested them) so the reviewer can tell which tool produced what.


### PR DESCRIPTION
 ## Summary

  Follow-ups from reviewing #476, now that it has merged. Two commits, independently
  reviewable and independently revertable:

  ### 1. `fix(recall)`: redact and cap confirm output before the verify model sees it

  The one behaviour change here, and the reason this isn't purely a cleanup PR.

  `confirmRecall` calls `pod_status`/`kube_events` **directly** rather than through
  `runTool`/`dispatchTools`, so it never inherited the loop's egress hook —
  `truncateOutput(redact.Secrets(...), MaxToolOutputBytes)` — and the only other
  scrubber, `redactInvestigation`, doesn't run until `deliver()`, long after verify.

  So the confirm output reaches the verify model unredacted. `pod_status` renders
  per-container waiting/terminated messages (its own `Description` advertises *"the
  message names the exact cause, e.g. a missing Secret/ConfigMap key"*) and
  `kube_events` renders arbitrary controller text, so a token, DSN or JWT quoted in a
  terminated message or a `FailedMount` event goes to the provider verbatim.

  **The asymmetry is what made this easy to miss.** `transcriptExcerpt` re-applies
  `redact.Secrets` as defence in depth, so #476's *transcript* copy is masked while the
  *evidence-bullet* copy of the same bytes — rendered directly above it in the same
  prompt — is not. Removing the fix and running the new test prints exactly that:

  ```
      - current state — pod_status:
  web CrashLoopBackOff: bad token ghp_0123456789abcdefghijklmnopqrstuvwx   ← bullet
  ...
  [pod_status] web CrashLoopBackOff: bad token [REDACTED]                  ← excerpt
  ```

  Uncapped mattered too: `confirmArgs` is deliberately namespace-wide and
  `PodStatusTool` falls back to the whole namespace when a selector matches nothing, so
  a busy namespace could push an unbounded blob into the verify prompt. The loop caps
  that; this path didn't.

  This commit touches only the egress line and its test — it does not depend on commit 2,
  so it can be reviewed, reverted, or landed on its own.

  ### 2. `refactor(recall)`: derive the confirm transcript state instead of tracking it twice

  No behaviour change.

  - **`gathered` was exactly `transcript != nil`** by construction, so it was a third
    return carrying nothing the second didn't. Two sources of truth for one fact can
    drift: an edit that appends to `results` without setting the bool (or the reverse)
    yields an assistant turn with no tool results — which `transcriptExcerpt` renders as
    `""`, so the review silently gets no excerpt while the caller skips
    `recallUnconfirmedCap` and keeps full recall confidence. Now derived.
  - **`confirmArgs` is loop-invariant** yet ran twice per iteration (once for the call,
    once for the recorded `ToolCall.Args`). Hoisted — which also makes the recorded args
    byte-identical to what the tool was passed, rather than resting on two marshals
    agreeing.
  - **`verifyPrompt`'s groundedness rule was quoted verbatim in three places** while
    living in `verify.go`; the two copies would drift the first time the prompt is
    edited. Now pointers. The same narrative was restated in full at the `loop.go` call
    site and in `verifyFindings`' doc, each right beside a "see confirmRecall"
    cross-reference — cut to the reference they already carried.
  - **A doc comment #476 made wrong**: `transcriptExcerpt` still gave "the recall
    short-circuit path, where no loop ran" as its example of having no tool results. A
    confirmed recall now does carry results.
  - **`len(transcript) != 3`** coupled a test about transcript *shape* to the current
    length of `recallConfirmTools` — adding a third confirm tool would have failed it
    with nothing broken. Counts derived.
  - **The partial-gather path was unasserted**: `TestConfirmRecallToolErrorTolerated`
    discarded the transcript, leaving the one case where `calls` and `results` can
    actually desync untested. It now checks every result has a matching call and that the
    surviving tool's output is attributed to `kube_events` in the rendered excerpt.

  ## Linked issue

  n/a — follow-ups from the review of #476.

  ## How was it verified?

  ```
  go build ./...                        → OK
  go vet ./...                          → OK
  gofmt -l .                            → (empty)
  go test ./...                         → all packages ok
  go test -race ./internal/investigate  → ok
  ```

  Not run: `golangci-lint run ./...` (not installed locally) and `hack/e2e-k3d.sh` (no
  new cluster access — `confirmRecall` calls the same two read-only tools it already
  called).

  **The redaction fix was verified by removing it**, not by inspection: the new test
  fails with `evidence bullet leaks the token: "…ghp_0123456789…"` while the excerpt in
  the same output already reads `[REDACTED]`, which is the asymmetry described above. It
  also asserts the surrounding diagnostic text survives — masking, not dropping.

  Each commit builds and passes `go test ./internal/investigate` on its own.

  ## Not addressed here

  The review also turned up a design issue that is **not** a cleanup, so it is left for a
  separate decision: `verifyPrompt` is shared between the full-loop and recall paths, and
  on the recall path the transcript is *current* state gathered just now, not evidence of
  the historical cause. Under the prompt's "reject … if it contradicts the evidence"
  clause, a recall whose symptom has since cleared (healthy `pod_status`, no Warning
  events) can now be **rejected** rather than merely downgraded — which empties
  `RootCauses` and forces a full investigation. `internal/eval/judge.go` already has the
  shape that avoids this, conditioning groundedness on *"when a tool-transcript excerpt is
  provided"*; `verifyPrompt` has only the missing-*line* hedge, not the missing-*excerpt*
  one.

  ## Checklist

  - [x] `go build ./...` passes
  - [x] `go vet ./...` passes
  - [x] `go test ./...` passes (`-race` on the touched package)
  - [x] `gofmt -l .` prints nothing
  - [ ] `golangci-lint run ./...` — not installed locally; CI covers it
  - [x] Test added first (TDD) — the leak was demonstrated before the fix, and the
        assertion became the regression test
  - [x] Docs updated — doc comments carry the reasoning; one comment #476 had made stale
        is corrected
  - [x] Respects **read-only-first** — no new cluster access; strictly less data leaves
        the process than before