### PR TITLE
fix(curator): log the dedup score on every decision, not only when it…

### DIFF
--- a/internal/curator/curator.go
+++ b/internal/curator/curator.go
@@ -114,10 +114,33 @@ func (c *Curator) Curate(ctx context.Context, inv providers.Investigation) (prov
 		if c.Metrics != nil {
 			c.Metrics.CurationDedupScore.Record(ctx, hits[0].Score)
 		}
+		// Log the score on EVERY dedup decision, not only when the gate fires.
+		//
+		// dup_score cannot be tuned by observation unless the below-threshold case is
+		// visible, and previously only the firing branch logged. A deployment where the
+		// gate never fires therefore produced no score data at all — and the
+		// curation_dedup_score histogram cannot fill that gap, because its lowest
+		// boundary above zero is 5, which is also the default threshold: every
+		// non-firing observation collapses into one bucket.
+		//
+		// Not hypothetical. On a ~50-entry catalog measured 2026-08-14 the BM25 scores
+		// run sub-1 (a live instant-recall hit scored 0.494) against the default
+		// dup_score of 5.0, so the gate is effectively inert: RunLore re-filed an entry
+		// for a fault the catalog already documented, under the same resource. Nothing
+		// in the operator's data could have told them what to set instead.
+		//
+		// Info rather than Debug: curation is infrequent (5 decisions in 30 days on that
+		// deployment), so this is a handful of lines, and it is the only way to answer
+		// "what should dup_score be?".
 		if hits[0].Score >= c.DupScore {
-			c.Log.Info("finding duplicates a catalog entry; not filing", "entry", hits[0].Entry.Title, "score", hits[0].Score)
+			c.Log.Info("dedup: duplicates a catalog entry; not filing",
+				"entry", hits[0].Entry.Title, "path", hits[0].Entry.Path,
+				"score", hits[0].Score, "dup_score", c.DupScore)
 			return providers.Ref{}, nil
 		}
+		c.Log.Info("dedup: top hit below dup_score; filing",
+			"top_entry", hits[0].Entry.Title, "path", hits[0].Entry.Path,
+			"score", hits[0].Score, "dup_score", c.DupScore)
 	}
 	if n, ok, err := c.duplicateOpenPR(ctx, inv); err != nil {
 		c.Log.Warn("dedup: list open PRs failed", "err", err)

--- a/internal/curator/curator_test.go
+++ b/internal/curator/curator_test.go
@@ -3,6 +3,7 @@
 package curator
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -473,5 +474,47 @@ func TestCurateRecordsDedupScore(t *testing.T) {
 	h.ServeHTTP(rec, req)
 	if !strings.Contains(rec.Body.String(), "runlore_curation_dedup_score") {
 		t.Fatalf("runlore_curation_dedup_score not found in metrics output:\n%s", rec.Body.String())
+	}
+}
+
+// TestCurateLogsDedupScoreBothWays pins the property that makes dup_score tunable:
+// the top-hit BM25 score is logged on EVERY dedup decision, not only when the gate
+// fires.
+//
+// Before this, only the firing branch logged. A deployment whose scores never reach
+// the threshold produced no score data at all, and the curation_dedup_score histogram
+// could not fill the gap — its lowest boundary above zero is 5, the same as the default
+// threshold, so every non-firing observation lands in one bucket. Measured on a
+// ~50-entry catalog: BM25 scores run sub-1 against a dup_score of 5.0, so the gate is
+// inert and the operator has nothing to tune from.
+func TestCurateLogsDedupScoreBothWays(t *testing.T) {
+	capture := func(score float64) string {
+		var buf bytes.Buffer
+		c := newCurator(&fakeForge{}, fakeScored{score: score, title: "Some entry"})
+		c.Log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		if _, err := c.Curate(context.Background(), goodFinding()); err != nil {
+			t.Fatalf("curate at score %v: %v", score, err)
+		}
+		return buf.String()
+	}
+
+	// Below the 5.0 threshold: the entry IS filed, and the score must still be logged —
+	// this is the case that previously produced nothing.
+	below := capture(2.0)
+	if !strings.Contains(below, "score=2") {
+		t.Errorf("a below-threshold dedup decision must log its score; got:\n%s", below)
+	}
+	if !strings.Contains(below, "dup_score=5") {
+		t.Errorf("the log must carry the threshold it was compared against, so the two "+
+			"can be read together; got:\n%s", below)
+	}
+
+	// At/above the threshold: still logged, and still carries both numbers.
+	above := capture(7.5)
+	if !strings.Contains(above, "score=7.5") || !strings.Contains(above, "dup_score=5") {
+		t.Errorf("an above-threshold dedup decision must log score and threshold; got:\n%s", above)
+	}
+	if !strings.Contains(above, "not filing") {
+		t.Errorf("the suppressing branch must still say it suppressed the PR; got:\n%s", above)
 	}
 }


### PR DESCRIPTION
## Summary

  `dup_score` is not tunable by observation today, because the only place the top-hit
  BM25 score was logged is the branch where the gate **fires**. A deployment whose
  scores never reach the threshold produced no score data at all — so the operator has
  nothing to answer "what should `dup_score` be?" with.

  The `curation_dedup_score` histogram cannot fill that gap. It is registered with no
  explicit bucket boundaries (`internal/telemetry/metrics.go`), so it inherits the
  OpenTelemetry SDK defaults — `[0, 5, 10, 25, …]`. Its lowest boundary above zero is
  **5**, which is also the default `dup_score` (`internal/config/config.go`). Every
  non-firing observation therefore lands in the same `(0, 5]` bucket: 0.49 and 4.9 are
  indistinguishable in the metric.

  **Not hypothetical.** On a ~50-entry catalog measured 2026-08-14 the BM25 scores run
  sub-1 — a live instant-recall hit scored 0.494 — against the default `dup_score` of
  5.0. The gate is effectively inert, and RunLore re-filed an entry for a fault the
  catalog already documented, under the same resource. Nothing in the data available to
  the operator could have told them what to set instead.

  So both branches now log, and both carry the score **and** the threshold it was
  compared against, so the two can be read together:

  ```
  dedup: top hit below dup_score; filing   top_entry=… path=… score=0.494 dup_score=5
  dedup: duplicates a catalog entry; not filing  entry=… path=… score=7.5 dup_score=5
  ```

  `Info` rather than `Debug` deliberately: curation is infrequent (5 decisions in 30 days
  on that deployment), so this is a handful of lines, and it is the only way to answer the
  tuning question. The suppressing branch also gained the entry `path`, so the duplicate
  it matched can actually be opened.

  ## Linked issue

  n/a

  ## How was it verified?

  ```
  go build ./...                    → OK
  go vet ./...                      → OK
  gofmt -l .                        → (empty)
  go test ./...                     → all packages ok
  go test -race ./internal/curator  → ok
  ```

  Not run: `golangci-lint run ./...` (not installed locally) and `hack/e2e-k3d.sh` — this
  adds log lines to an existing decision, no behaviour or cluster access change.

  `TestCurateLogsDedupScoreBothWays` drives `Curate` at a score **below** the threshold
  (2.0, the case that previously logged nothing) and **above** it (7.5), asserting each
  logs both numbers and that the suppressing branch still says it suppressed. Confirmed
  non-vacuous: deleting the new below-threshold log line fails it with
  `a below-threshold dedup decision must log its score`.

  The two factual claims above were checked against the source rather than assumed — the
  default `dup_score` of 5.0 in `config.go`, and the absence of any
  `ExplicitBucketBoundaries` for `curation_dedup_score`, which is what leaves it on the
  SDK defaults.

  ## Not addressed here

  **The threshold itself is still wrong, and this PR does not fix it.** If BM25 scores
  run sub-1 on a real catalog, a default `dup_score` of 5.0 means the dedup gate never
  fires — the re-filed duplicate above is that bug, not a tuning accident. This change
  only makes it *diagnosable*: it is the measurement that has to come first, since
  picking a new default without score data would be guessing. Worth a follow-up once a
  few of these lines have accumulated.

  **Same blind spot, sibling metric:** `recall_score` is registered the same way
  (`histF`, no explicit boundaries), so if recall's BM25 scores are also sub-1 then that
  histogram is equally uninformative — everything in one bucket. Not touched here, but
  the fix is the same shape (explicit boundaries suited to BM25's actual range).

  ## Checklist

  - [x] `go build ./...` passes
  - [x] `go vet ./...` passes
  - [x] `go test ./...` passes (`-race` on the touched package)
  - [x] `gofmt -l .` prints nothing
  - [ ] `golangci-lint run ./...` — not installed locally; CI covers it
  - [x] Test added first (TDD) — the missing below-threshold line was demonstrated before
        the fix, and the assertion became the regression test
  - [x] Docs updated — the reasoning (including why `Info` and why the histogram cannot
        substitute) is carried in the code comment at the decision point
  - [x] Respects **read-only-first** — logging only; no new cluster access, no writes