### PR TITLE
fix(telemetry): bucket the BM25 score histograms for a real corpus

### DIFF
--- a/internal/telemetry/buckets_test.go
+++ b/internal/telemetry/buckets_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -51,6 +52,84 @@ func TestLatencyHistogramsUseSLOBuckets(t *testing.T) {
 			t.Errorf("%s missing SLO boundary le=\"2.5\" — buckets not SLO-aligned\n", series)
 		}
 	}
+}
+
+// TestScoreHistogramsUseScoreBuckets asserts the BM25-score histograms carry the
+// score-scale boundaries rather than the OTel SDK defaults. The defaults start at
+// 5, so a real corpus (~0.1–1.2) lands entirely in the first bucket and the
+// distribution is unreadable; le="0.5" can only exist under the explicit view.
+func TestScoreHistogramsUseScoreBuckets(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+
+	h, shutdown, err := Setup(context.Background())
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	defer func() { _ = shutdown(context.Background()) }()
+
+	m := NewMetrics()
+	ctx := context.Background()
+	// Two samples in the real-corpus range that the SDK defaults cannot separate:
+	// both fall in the default (0,5] bucket, but land in different score buckets.
+	m.RecallScore.Record(ctx, 0.494)
+	m.CurationDedupScore.Record(ctx, 0.9)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	body := rec.Body.String()
+
+	for _, series := range []string{
+		"runlore_recall_score_bucket",
+		"runlore_curation_dedup_score_bucket",
+	} {
+		// A sub-1 boundary proves the view is installed.
+		if !bucketHasBoundary(body, series, "0.5") {
+			t.Errorf("%s missing boundary le=\"0.5\" — score buckets not installed\n", series)
+		}
+		// Each decision threshold must be its own boundary, so a bucket count
+		// answers "how much of the corpus clears this gate?" directly.
+		for _, gate := range []string{"0.1", "1", "4", "5"} {
+			if !bucketHasBoundary(body, series, gate) {
+				t.Errorf("%s missing decision-threshold boundary le=%q\n", series, gate)
+			}
+		}
+	}
+
+	// The point of the change: the two sub-1 samples must be DISTINGUISHABLE.
+	// Under the SDK defaults both fall in the same (0,5] bucket. Here 0.494 is
+	// <= 0.5 and 0.9 is not, so the cumulative counts differ at that boundary.
+	if got := bucketCount(t, body, "runlore_recall_score_bucket", "0.5"); got != 1 {
+		t.Errorf("recall_score 0.494 should be in le=\"0.5\"; got count %d", got)
+	}
+	if got := bucketCount(t, body, "runlore_curation_dedup_score_bucket", "0.5"); got != 0 {
+		t.Errorf("curation_dedup_score 0.9 should NOT be in le=\"0.5\"; got count %d", got)
+	}
+	// ...and both are counted by the time the ladder reaches 1.
+	if got := bucketCount(t, body, "runlore_curation_dedup_score_bucket", "1"); got != 1 {
+		t.Errorf("curation_dedup_score 0.9 should be in le=\"1\"; got count %d", got)
+	}
+}
+
+// bucketCount returns the cumulative count on the given histogram bucket series at
+// the given le boundary. Fails the test if the line is absent. Labels are matched
+// individually rather than as a literal substring: the exporter emits otel_scope_*
+// labels ahead of le, so the series name and le are not adjacent in the output.
+func bucketCount(t *testing.T, body, series, le string) int {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, series) || !strings.Contains(line, `le="`+le+`"`) {
+			continue
+		}
+		fields := strings.Fields(line)
+		n, err := strconv.Atoi(fields[len(fields)-1])
+		if err != nil {
+			t.Fatalf("%s le=%q: unparseable count in %q: %v", series, le, line, err)
+		}
+		return n
+	}
+	t.Fatalf("%s has no line for le=%q\n%s", series, le, body)
+	return 0
 }
 
 // bucketHasBoundary reports whether the exposition body has a line for the given

--- a/internal/telemetry/buckets_test.go
+++ b/internal/telemetry/buckets_test.go
@@ -6,12 +6,15 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/Smana/runlore/internal/config"
 )
 
 // TestLatencyHistogramsUseSLOBuckets asserts the seconds-scale latency histograms
@@ -141,4 +144,53 @@ func bucketHasBoundary(body, series, le string) bool {
 		}
 	}
 	return false
+}
+
+// TestScoreBucketsAlignWithTheDecisionThresholds pins scoreBuckets against the
+// thresholds it claims to serve, read from the config package rather than
+// restated here.
+//
+// scoreBuckets' doc comment maps four boundaries to four gates — rerank_min_score,
+// min_score/margin_gap, solo_floor, dup_score — and that mapping is the whole
+// reason the ladder is shaped the way it is: a bucket count is only an answer to
+// "how much of the corpus clears this gate?" while the boundary and the gate are
+// the same number. Nothing enforced that. Lower solo_floor's default to 3.5 and
+// the panel keeps rendering, keeps looking authoritative, and silently stops
+// answering the question the comment promises.
+//
+// The instant-recall gates come from ApplyDefaults, so this reads what an
+// operator actually runs under. dup_score is asserted as a literal because its
+// default is applied in app.BuildCurator rather than in ApplyDefaults — unlike
+// every sibling here — so there is no resolved value to read without building a
+// forge client. That asymmetry is worth fixing at the source; until it is, this
+// test states the number and where it comes from.
+func TestScoreBucketsAlignWithTheDecisionThresholds(t *testing.T) {
+	// instant_recall is off by default and ApplyDefaults only fills its knobs once
+	// it is enabled, so the fixture enables it. The reranker is on by default,
+	// so RerankMinScore resolves without further help.
+	var cfg config.Config
+	cfg.Catalog.InstantRecall.Enabled = true
+	config.ApplyDefaults(&cfg)
+	ir := cfg.Catalog.InstantRecall
+
+	for _, tc := range []struct {
+		gate  string
+		value float64
+	}{
+		{"catalog.instant_recall.rerank_min_score", ir.RerankMinScore},
+		{"catalog.instant_recall.min_score", ir.MinScore},
+		{"catalog.instant_recall.margin_gap", ir.MarginGap},
+		{"catalog.instant_recall.solo_floor", ir.SoloFloor},
+		{"forge.dup_score (default applied in app.BuildCurator)", 5.0},
+	} {
+		if tc.value == 0 {
+			t.Errorf("%s resolved to 0 — either the default moved out of ApplyDefaults or the field was renamed; "+
+				"this guard cannot check a gate it cannot read", tc.gate)
+			continue
+		}
+		if !slices.Contains(scoreBuckets, tc.value) {
+			t.Errorf("%s is %g, which is not a scoreBuckets boundary %v — a bucket count no longer answers "+
+				"\"how much of the corpus clears this gate?\" for it", tc.gate, tc.value, scoreBuckets)
+		}
+	}
 }

--- a/internal/telemetry/setup.go
+++ b/internal/telemetry/setup.go
@@ -32,14 +32,39 @@ var latencyHistograms = []string{
 	"runlore_incident_resolution_seconds",
 }
 
-// sloLatencyViews builds one explicit-bucket-histogram view per latency instrument.
-func sloLatencyViews() []sdkmetric.View {
-	views := make([]sdkmetric.View, 0, len(latencyHistograms))
-	for _, name := range latencyHistograms {
+// scoreBuckets are the bucket boundaries for RunLore's BM25 retrieval-score
+// histograms. The OTel SDK defaults start at 5, so an entire real corpus lands in
+// the first bucket and the distribution is unreadable — the panels built on these
+// histograms render as a single bar. An enriched real-corpus BM25 score is
+// ~0.1–1.2 (see the InstantRecall doc comment in internal/config/config.go), so
+// the ladder resolves that dense region finely and thins out above it.
+//
+// Every boundary that is also a DECISION THRESHOLD is deliberate, so a bucket
+// count answers "how much of the corpus clears this gate?" directly:
+//
+//	0.1 → instant_recall.rerank_min_score (skip the paid rerank call below this)
+//	1.0 → instant_recall.min_score / margin_gap
+//	4.0 → instant_recall.solo_floor
+//	5.0 → forge.dup_score
+//
+// Boundaries above 5 exist for deployments that hand-tuned their thresholds to a
+// differently-scaled corpus; +Inf captures anything beyond 10.
+var scoreBuckets = []float64{0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 7.5, 10}
+
+// scoreHistograms are the BM25-score instrument names that get the score buckets.
+var scoreHistograms = []string{
+	"runlore_recall_score",
+	"runlore_curation_dedup_score",
+}
+
+// bucketViews builds one explicit-bucket-histogram view per named instrument.
+func bucketViews(names []string, boundaries []float64) []sdkmetric.View {
+	views := make([]sdkmetric.View, 0, len(names))
+	for _, name := range names {
 		views = append(views, sdkmetric.NewView(
 			sdkmetric.Instrument{Name: name},
 			sdkmetric.Stream{Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: latencyBuckets,
+				Boundaries: boundaries,
 			}},
 		))
 	}
@@ -55,9 +80,11 @@ func Setup(_ context.Context) (http.Handler, func(context.Context) error, error)
 	if err != nil {
 		return nil, nil, err
 	}
+	views := bucketViews(latencyHistograms, latencyBuckets)
+	views = append(views, bucketViews(scoreHistograms, scoreBuckets)...)
 	mp := sdkmetric.NewMeterProvider(
 		sdkmetric.WithReader(exporter),
-		sdkmetric.WithView(sloLatencyViews()...),
+		sdkmetric.WithView(views...),
 	)
 	otel.SetMeterProvider(mp)
 	handler := promhttp.HandlerFor(reg, promhttp.HandlerOpts{})


### PR DESCRIPTION
## Problem

  `recall_score` and `curation_dedup_score` are on the OTel SDK **default** bucket boundaries, whose lowest non-zero edge is **5**.

  An enriched real-corpus BM25 score is **~0.1–1.2** — a fact this repo already states in the `InstantRecall` doc comment (`internal/config/config.go`, "an order of magnitude below the default SoloFloor 4.0"). So
  every sample lands in the single `(0,5]` bucket and the histogram carries no information.

  The visible symptom is the two **"score distribution (BM25)"** heatmaps rendering as one flat band. Their stated purpose is unachievable as shipped:

  > *"Use this to tune `min_score`."*
  > *"Use this to tune the dedup threshold."*

  The panel cannot resolve **any** of the thresholds an operator would actually move.

  This also made `forge.dup_score` untunable in practice — the score was only observable when the gate fired, and the histogram that should have filled the gap couldn't.

  ## Fix

  An explicit-bucket view for both instruments, mirroring the existing SLO latency buckets — which exist for exactly the same reason at a different scale.

  ```go
  var scoreBuckets = []float64{0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 4, 5, 7.5, 10}
  ```

  The ladder resolves the dense 0.1–1.2 region finely and thins above it. Every boundary that is also a **decision threshold** is deliberate, so a bucket count answers *"how much of the corpus clears this gate?"*
  with no interpolation:

  | boundary | gate |
  |---|---|
  | `0.1` | `instant_recall.rerank_min_score` |
  | `1.0` | `instant_recall.min_score` / `margin_gap` |
  | `4.0` | `instant_recall.solo_floor` |
  | `5.0` | `forge.dup_score` |

  Boundaries above 5 keep deployments that hand-tuned to a differently-scaled corpus on scale; `+Inf` takes the tail past 10.

  `sloLatencyViews()` becomes `bucketViews(names, boundaries)` so both ladders share one builder.

  ## No dashboard change needed

  Both panels query `sum(rate(..._bucket[$__rate_interval])) by (le)` with `min`/`max` on **auto**, so they pick up the new boundaries as-is. Checked specifically for a pinned y-axis range that would have clipped
  sub-1 values — there isn't one.

  ## Test plan

  - [x] New `TestScoreHistogramsUseScoreBuckets` asserts the sub-1 boundary exists and that **each decision threshold** is its own boundary.
  - [x] **Verified not vacuous** — with the view removed the test fails on the missing sub-1 boundaries. (`le="5"` is *not* among the failures, since the SDK defaults happen to include 5; the sub-1 edges are what
  discriminate.)
  - [x] The behavioural assertion: `0.494` and `0.9` are **indistinguishable** under the defaults (same `(0,5]` bucket) and land in different buckets here.
  - [x] `go test ./...` green, `go vet` clean.