### PR TITLE
feat(thread): write knowledge back to the KB from a Matrix thread

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,24 @@ A good report lets us reproduce and assess impact quickly:
 - **reproduction steps** or a proof of concept;
 - any relevant logs or config — **redact secrets, tokens, and cluster identifiers**.
 
+## Opt-in features that widen what RunLore receives
+
+Two chat-transport features are off by default and change RunLore's exposure or inbound event
+surface once turned on:
+
+- **`notify.slack.thread_capture`** exposes a second HTTP endpoint, `POST /slack/events`, alongside
+  the alert webhook and (if used) `/slack/interactions`.
+- **`notify.matrix.thread_capture`** exposes nothing new, but widens RunLore's Matrix `/sync` filter
+  from `["m.reaction"]` to also include `["m.room.message"]`. Stated plainly: **the process starts
+  receiving message events** from the configured room, where by default it receives only reactions.
+  RunLore acts only on messages that address it and are rooted in one of its own messages —
+  everything else is dropped immediately without its body being logged, but every message in the
+  room does transit the process first.
+
+Both are opt-in, both fail closed on missing credentials, and full detail — the addressing/attribution
+checks, the invite-only-room recommendation, and why Matrix still needs no exposed endpoint for this —
+is in the runtime [security model](https://runlore.io/docs/security/security-model/#matrix-thread-capture-notifymatrixthread_capture--a-widened-sync-filter).
+
 ## Supply chain
 
 Every tagged release (`v*`) ships with the following, all produced by

--- a/dev/superpowers/plans/2026-08-15-thread-interaction-pr2-matrix.md
+++ b/dev/superpowers/plans/2026-08-15-thread-interaction-pr2-matrix.md
@@ -1,0 +1,987 @@
+# Thread Interaction PR2 — Matrix Transport Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A human replying in a Matrix thread with `@runlore note: <text>` gets that text written into the knowledge base, exactly as PR1 delivers for Slack.
+
+**Architecture:** PR1's `internal/thread` core is transport-agnostic and is reused unchanged in substance. Matrix needs no new inbound surface and no new permission: the existing `MatrixFeedback` `/sync` long-poll already reads the room, and `Matrix.Deliver` already stamps a custom event field that the reaction listener reads back. This PR widens both, adds a reply path, and extracts PR1's bounded-dispatch machinery out of `internal/server` so both transports share it.
+
+**Tech Stack:** Go 1.26, stdlib only. Matrix Client-Server API v3 (`/sync`, `/rooms/{id}/send`, `/rooms/{id}/event/{id}`, `/account/whoami`). Existing internals: `internal/thread` (PR1 core), `internal/notify` (Matrix + Slack notifiers), `internal/config`, `internal/app`.
+
+Source spec: `dev/superpowers/specs/2026-08-14-thread-interaction-design.md` (§Matrix transport).
+Predecessor: `dev/superpowers/plans/2026-08-14-thread-interaction-pr1.md`.
+
+**Branch:** `feat/thread-interaction-pr2-matrix`, stacked on `feat/thread-interaction-pr1`. Worktree `/home/smana/Sources/runlore.worktrees/matrix-thread`. Rebase onto PR1's final head before Task 1 if PR1 has moved.
+
+## Global Constraints
+
+- **Quality gate, run before every commit:** `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...`. `gofmt -l .` must print nothing; golangci-lint must report `0 issues`.
+- **TDD.** Failing test first, then the minimal implementation. Prefer table-driven tests. Tests verify behaviour, not mocks.
+- **Every file starts with** `// SPDX-License-Identifier: Apache-2.0`.
+- **Every exported symbol carries a doc comment** (enforced by `revive`).
+- **Errors** wrap with `%w`; compare with `errors.Is` / `errors.As` (enforced by `errorlint`).
+- **`context.Context` is the first parameter** of any function that does I/O.
+- Module path `github.com/Smana/runlore`. No new third-party dependencies.
+- **Nothing in this PR may block or fail investigation delivery.** Every new call site is best-effort relative to its host path.
+- **The existing 👍/👎 reaction listener must keep working unchanged.** Its `io.runlore.trigger_key` field and its behaviour are load-bearing and already shipped.
+- `notify.matrix.thread_capture` defaults to `false`.
+- Known lint traps in this repo: `revive` flags identifiers shadowing Go builtins (`max`, `min`, `clear`); staticcheck QF1012 flags `b.WriteString(fmt.Sprintf(...))` — use `fmt.Fprintf(&b, ...)`; `gosec` G304 on file opens built from a variable (see the `//nolint:gosec` precedent in `internal/outcome/ledger.go`).
+- The Hugo on `PATH` is 0.139.0 and **cannot** build this site (theme needs ≥0.146.0). Use `/usr/bin/hugo` (0.164.0), and build to a directory outside the repo so `website/public/` is not dirtied.
+
+---
+
+## Three problems this plan solves that the spec did not anticipate
+
+Read these before Task 1; they explain why tasks 1 and 4 exist at all.
+
+1. **`Multi.ThreadReplier()` is ambiguous with two transports.** `internal/notify/slack.go:932-939` returns the *first* notifier implementing `providers.ThreadNotifier`. In PR1 only `SlackBot` implements it, so it is unambiguous. The moment `Matrix` implements it too, a deployment configuring both gets a single replier for both transports — a Matrix thread would be answered via Slack, or not at all. Task 4 fixes this.
+2. **The Matrix sync loop is single-goroutine and synchronous.** `MatrixFeedback.Run` (`matrix_feedback.go:135-140`) calls `handleReaction` inline. A note that opens a PR costs ~6 sequential forge calls, so handling a mention inline would stall long-polling for minutes — pausing 👍/👎 recording and making the room look dead. PR1 already built exactly the right machinery (bounded slots, `Busy` reply, per-handler timeout, drain on shutdown) but it lives inside `internal/server`. Task 1 extracts it so both transports share one implementation.
+3. **`Matrix.Deliver` discards its send response** (`matrix.go:103-111`), so it never learns the `event_id` of the message it posted — and that id *is* the thread root. Task 2 decodes it.
+
+**One design refinement over the spec.** The spec said Matrix needs no registry for lookup because context rides on the event. That is half right. `Responder.Handle` writes `Notes` and `NoteURL` back through `Registry.Update`, and a miss there is a silent no-op — so without registry entries every Matrix note would open a fresh PR. Matrix therefore registers on delivery like Slack does, **and** stamps the context onto the event. Registry first, event-stamp as fallback: that combination survives a restart or leader failover, which neither does alone, and is a genuine advantage Matrix has over Slack.
+
+---
+
+## File Structure
+
+**Create:**
+
+| File | Responsibility |
+|---|---|
+| `internal/thread/dispatch.go` | `Dispatcher` — bounded, timeout-bounded, drainable detached execution. Extracted from `internal/server`; used by both transports. |
+| `internal/thread/dispatch_test.go` | Its tests. |
+| `internal/notify/matrix_thread.go` | Matrix thread capture: the `io.runlore.thread` content field, `contextFor`, message-event handling, `ReplyInThread`. Kept out of `matrix_feedback.go` so the reaction listener stays readable. |
+| `internal/notify/matrix_thread_test.go` | Its tests. |
+
+**Modify:**
+
+| File | Change |
+|---|---|
+| `internal/server/server.go` | Replace the inline slot pool with `thread.Dispatcher`. Behaviour identical. |
+| `internal/notify/matrix.go` | Decode `event_id` from the send response; stamp `io.runlore.thread`; add `Threads ThreadSink`; register the root after a successful send. |
+| `internal/notify/matrix_feedback.go` | Widen `matrixEvent` and the `/sync` filter; generalise `triggerKeyFor`; route `m.room.message` to the mention handler via the dispatcher. |
+| `internal/notify/slack.go` | Replace `Multi.ThreadReplier()` with a transport-scoped lookup. |
+| `internal/config/config.go` | `MatrixNotify.ThreadCapture` + `Validate` rules. |
+| `internal/app/notify.go`, `internal/app/serve.go` | Wire the Matrix listener's thread capture. |
+| `website/content/docs/…`, `SECURITY.md` | Setup docs + the sync-filter disclosure. |
+
+---
+
+### Task 1: Move the bounded dispatcher into `internal/thread`
+
+**Read this first — the plan's earlier description of this task was written against older code.**
+`internal/server` no longer has an *inline* pool. PR1's final commits already factored out:
+
+- `func (s *Server) dispatch(slots chan struct{}, fn func()) bool` (`server.go:574`) — non-blocking
+  slot acquire, `s.wg.Add/Done`, slot release, panic recovery, returns whether `fn` started.
+- `func (s *Server) Drain(ctx context.Context)` (`server.go:604`) — `s.wg.Wait()` raced against `ctx`.
+- Fields `eventSlots`, a second small slots channel for the "busy" reply, `wg sync.WaitGroup`,
+  `mentionTimeout`.
+
+So this task is a **move**, not an extraction from tangled code. Matrix needs the identical
+behaviour, and a second copy would guarantee the two drift.
+
+**One deliberate behaviour change, and it must not be smuggled in silently.** Today the timeout is
+built at the *call site* (`server.go:541`):
+
+```go
+ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), s.mentionTimeout)
+```
+
+and that single `ctx`/`cancel` pair is shared by the mention closure, the busy closure, and a
+trailing call — guarded by a comment promising "cancel is always invoked by exactly one of the
+three paths below … never left uncalled". That is a real invariant held together by hand.
+
+Moving the timeout *inside* the dispatcher gives each dispatched unit its own context and its own
+`cancel`, deleting the three-path dance. The busy reply then gets its own timeout rather than
+inheriting the mention's remaining budget. **That is an improvement, not a regression — but it IS a
+change**, so Step 7 below is "prove the observable behaviour is unchanged", not "prove nothing
+changed at all". Call it out in the commit message.
+
+**Files:**
+- Create: `internal/thread/dispatch.go`
+- Create: `internal/thread/dispatch_test.go`
+- Modify: `internal/server/server.go` — replace `dispatch`, `Drain`, `wg`, the slots channels and
+  the call-site timeout with two `*thread.Dispatcher` instances (one for mentions, one for the
+  busy reply), preserving the existing slot counts, timeout value and log levels exactly.
+- Modify: `internal/app/serve.go` — the shutdown drain now drains both dispatchers.
+
+**Interfaces:**
+- Produces:
+  - `func NewDispatcher(slots int, timeout time.Duration, log *slog.Logger) *Dispatcher`
+  - `func (d *Dispatcher) Go(ctx context.Context, fn func(context.Context)) bool`
+  - `func (d *Dispatcher) Drain(ctx context.Context)`
+
+`Go` applies `context.WithoutCancel` then `context.WithTimeout` internally and hands the result to
+`fn`; it returns `false` immediately, having run nothing, when every slot is busy.
+
+Keep the existing constants where they are defined today (`maxConcurrentMentions`,
+`mentionHandlerTimeout`, the busy pool's size) — move only the mechanism, not the policy.
+
+- [ ] **Step 1: Read what exists**
+
+Run: `grep -n "dispatch\|eventSlots\|mentionTimeout\|wg \|func (s \*Server) Drain" internal/server/server.go`
+Expected: the helper, both slots channels, the WaitGroup, the timeout field, and the Drain method.
+Note the exact slot counts, the timeout value and the log levels — all three must survive the move.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `internal/thread/dispatch_test.go`. These eight tests encode the three bounds and the two
+subtleties that matter — a slot must survive a panic, and work must outlive the caller's request
+context:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package thread
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestDispatcherRunsWork(t *testing.T) {
+	d := NewDispatcher(2, time.Minute, testLogger())
+	done := make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(done) }) {
+		t.Fatal("Go returned false with free slots")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("work never ran")
+	}
+}
+
+func TestDispatcherRefusesWhenSaturated(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	block, running := make(chan struct{}), make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(running); <-block }) {
+		t.Fatal("first Go refused")
+	}
+	<-running
+	if d.Go(context.Background(), func(context.Context) { t.Error("must not run when saturated") }) {
+		t.Fatal("Go returned true while saturated")
+	}
+	close(block)
+}
+
+func TestDispatcherSlotIsReleasedAfterWork(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	for i := 0; i < 3; i++ {
+		done := make(chan struct{})
+		if !d.Go(context.Background(), func(context.Context) { close(done) }) {
+			t.Fatalf("Go %d refused: the slot was not released", i)
+		}
+		<-done
+		d.Drain(context.Background())
+	}
+}
+
+func TestDispatcherSlotIsReleasedAfterPanic(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	panicked := make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(panicked); panic("boom") }) {
+		t.Fatal("first Go refused")
+	}
+	<-panicked
+	d.Drain(context.Background())
+	done := make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(done) }) {
+		t.Fatal("slot leaked after a panic")
+	}
+	<-done
+}
+
+func TestDispatcherAppliesTimeout(t *testing.T) {
+	d := NewDispatcher(1, 50*time.Millisecond, testLogger())
+	var cancelled atomic.Bool
+	done := make(chan struct{})
+	d.Go(context.Background(), func(ctx context.Context) {
+		<-ctx.Done()
+		cancelled.Store(true)
+		close(done)
+	})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the timeout never fired")
+	}
+	if !cancelled.Load() {
+		t.Fatal("work context was not cancelled by the timeout")
+	}
+}
+
+func TestDispatcherWorkOutlivesTheCallersContext(t *testing.T) {
+	// The caller's context is a request context that is cancelled the moment the
+	// handler returns. Work must NOT die with it — only with the dispatcher's own
+	// timeout — or every mention would be cancelled before it could be written.
+	d := NewDispatcher(1, time.Minute, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	started, result := make(chan struct{}), make(chan error, 1)
+	d.Go(ctx, func(wctx context.Context) {
+		close(started)
+		time.Sleep(50 * time.Millisecond)
+		result <- wctx.Err()
+	})
+	<-started
+	cancel()
+	if err := <-result; err != nil {
+		t.Fatalf("work context was cancelled with the caller's: %v", err)
+	}
+}
+
+func TestDispatcherDrainWaitsForInFlightWork(t *testing.T) {
+	d := NewDispatcher(2, time.Minute, testLogger())
+	var finished atomic.Int32
+	release := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		d.Go(context.Background(), func(context.Context) { <-release; finished.Add(1) })
+	}
+	go func() { time.Sleep(50 * time.Millisecond); close(release) }()
+	d.Drain(context.Background())
+	if got := finished.Load(); got != 2 {
+		t.Fatalf("Drain returned with %d/2 finished", got)
+	}
+}
+
+func TestDispatcherDrainIsBounded(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	block := make(chan struct{})
+	defer close(block)
+	d.Go(context.Background(), func(context.Context) { <-block })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	d.Drain(ctx)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("Drain blocked %v on a wedged handler; it must honour its context", elapsed)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/thread/ -run TestDispatcher -v`
+Expected: FAIL — `undefined: NewDispatcher`.
+
+- [ ] **Step 4: Write `internal/thread/dispatch.go`**
+
+Create `internal/thread/dispatch.go`. Its `Go`/`Drain` bodies are line-for-line equivalent to the
+existing `Server.dispatch`/`Server.Drain` plus the internalised timeout:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package thread
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+// Dispatcher runs detached work under three bounds: how much runs at once, how
+// long any single piece may run, and a drain that lets shutdown wait for what is
+// in flight.
+//
+// It exists because both transports need identical behaviour here. A chat
+// transport acknowledges the platform BEFORE doing the work (Slack retries
+// anything unacked within 3 seconds; the Matrix sync loop must keep
+// long-polling), so the work necessarily outlives the call that scheduled it —
+// and unbounded detached goroutines on an internet-facing path is its own
+// problem. Duplicating this per transport would guarantee the two drift.
+type Dispatcher struct {
+	slots   chan struct{}
+	timeout time.Duration
+	wg      sync.WaitGroup
+	log     *slog.Logger
+}
+
+// NewDispatcher returns a Dispatcher allowing `slots` concurrent pieces of work,
+// each bounded by `timeout`.
+func NewDispatcher(slots int, timeout time.Duration, log *slog.Logger) *Dispatcher {
+	if slots <= 0 {
+		slots = 1
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Dispatcher{slots: make(chan struct{}, slots), timeout: timeout, log: log}
+}
+
+// Go runs fn on a bounded worker and reports whether it was accepted. It never
+// blocks: when every slot is busy it returns false immediately, having run
+// nothing, so the caller can tell the human rather than queue silently.
+//
+// fn receives a context derived from ctx with cancellation stripped and the
+// dispatcher's timeout applied. Stripping cancellation is deliberate: ctx is
+// typically a request context that dies the moment its handler returns, which
+// would cancel the work before it could do anything.
+func (d *Dispatcher) Go(ctx context.Context, fn func(context.Context)) bool {
+	select {
+	case d.slots <- struct{}{}:
+	default:
+		return false
+	}
+	work := context.WithoutCancel(ctx)
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		defer func() { <-d.slots }()
+		defer func() {
+			if rec := recover(); rec != nil {
+				d.log.Error("recovered from panic in detached work", "panic", rec, "stack", string(debug.Stack()))
+			}
+		}()
+		if d.timeout > 0 {
+			var cancel context.CancelFunc
+			work, cancel = context.WithTimeout(work, d.timeout)
+			defer cancel()
+		}
+		fn(work)
+	}()
+	return true
+}
+
+// Drain waits for in-flight work to finish, bounded by ctx. A wedged handler
+// must not be able to block shutdown forever.
+func (d *Dispatcher) Drain(ctx context.Context) {
+	done := make(chan struct{})
+	go func() { d.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		d.log.Warn("drain timed out with work still in flight")
+	}
+}
+```
+
+- [ ] **Step 5: Run the dispatcher tests**
+
+Run: `go test ./internal/thread/ -run TestDispatcher -v -race`
+Expected: PASS — all eight.
+
+- [ ] **Step 6: Move `internal/server` onto it**
+
+Replace the two slots channels, `wg`, `dispatch` and `Drain` with two `*thread.Dispatcher` fields.
+`Server.Drain` stays as the public entry point and delegates to both, so `internal/app/serve.go`'s
+call site keeps working — check whether it needs a second call and update it if so.
+
+At the saturation path, keep everything exactly as it is: `Error`-level log, the
+`MentionsDroppedOnSaturation` metric increment, then the `Busy` reply. `Go` returning `false` is
+the saturation signal, replacing `dispatch` returning `false`.
+
+Delete the now-unnecessary shared-`cancel` comment at `server.go:534-540` — it documents an
+invariant that no longer exists. Leaving it would be worse than never having written it.
+
+- [ ] **Step 7: Prove the observable behaviour is unchanged**
+
+Run: `go test ./internal/server/ ./internal/thread/ ./internal/app/ -race`
+Expected: PASS — every pre-existing server test, unedited.
+
+If a test needs changing for any reason other than a constructor signature, stop and report it:
+that means the move altered behaviour the tests pin. The one sanctioned difference is the busy
+reply now having its own timeout instead of sharing the mention's; if a test pins the shared-cancel
+behaviour, say so in your report rather than quietly rewriting it.
+
+- [ ] **Step 8: Full gate and commit**
+
+Run: `go build ./... && go vet ./... && go test ./... && gofmt -l . && golangci-lint run ./...`
+
+```bash
+git add internal/thread/dispatch.go internal/thread/dispatch_test.go internal/server/server.go internal/app/serve.go
+git commit -m "refactor(thread): move the bounded dispatcher out of internal/server
+
+Slack acks before working and the Matrix sync loop must keep long-polling, so
+in both cases the work outlives the call that scheduled it — under the same
+three bounds: concurrency, per-item timeout, and a drain shutdown can wait on.
+A second copy for Matrix would guarantee the two drift.
+
+One deliberate change: the timeout moves from the call site into the
+dispatcher, so each dispatched unit owns its own context and cancel. That
+removes the hand-held invariant that one shared cancel was invoked by exactly
+one of three paths, and gives the busy reply its own budget rather than the
+mention's remainder."
+```
+
+---
+
+### Task 2: `Matrix.Deliver` learns its own event id, stamps the context, and registers the root
+
+**Files:**
+- Modify: `internal/notify/matrix.go`
+- Create: `internal/notify/matrix_thread.go` (the content-field constant and the payload type)
+- Test: `internal/notify/matrix_test.go`
+
+**Interfaces:**
+- Consumes: `notify.ThreadSink` (PR1), `thread.Context` (PR1).
+- Produces:
+  - `const threadContentField = "io.runlore.thread"`
+  - `type threadStamp struct { … }` with JSON tags — the on-event payload
+  - `Matrix.Threads ThreadSink` field
+  - `Matrix.Deliver` returns after registering the sent event id as the thread root
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/notify/matrix_test.go`:
+
+```go
+func TestMatrixDeliverRegistersTheEventAsThreadRoot(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = w.Write([]byte(`{"event_id":"$evt123"}`))
+	}))
+	defer srv.Close()
+
+	sink := &recordingThreadSink{}
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	m.Threads = sink
+
+	inv := providers.Investigation{Title: "OOMKilled", TriggerKey: "tk-1", CuratedURL: "https://github.com/o/r/pull/42"}
+	if err := m.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+
+	if sink.calls != 1 {
+		t.Fatalf("Register calls = %d, want 1", sink.calls)
+	}
+	if sink.root != "$evt123" {
+		t.Errorf("root = %q, want the sent event id $evt123", sink.root)
+	}
+	if sink.channel != "!room:example.org" {
+		t.Errorf("channel = %q, want the room id", sink.channel)
+	}
+	if body[threadContentField] == nil {
+		t.Fatalf("the event content must carry %s: %v", threadContentField, body)
+	}
+	if body[triggerKeyContentField] != "tk-1" {
+		t.Errorf("the pre-existing trigger-key field must be unchanged, got %v", body[triggerKeyContentField])
+	}
+}
+
+func TestMatrixDeliverSucceedsWithNoThreadSink(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"event_id":"$evt123"}`))
+	}))
+	defer srv.Close()
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	if err := m.Deliver(context.Background(), providers.Investigation{Title: "OOMKilled"}); err != nil {
+		t.Fatalf("Deliver with a nil thread sink: %v", err)
+	}
+}
+
+func TestMatrixDeliverSucceedsWhenTheResponseHasNoEventID(t *testing.T) {
+	// A homeserver that returns 2xx with an unexpected body must not fail
+	// delivery — the message was sent; only the thread root is unknown.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	sink := &recordingThreadSink{}
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	m.Threads = sink
+	if err := m.Deliver(context.Background(), providers.Investigation{Title: "OOMKilled"}); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if sink.calls != 0 {
+		t.Fatal("an empty event id must never be registered")
+	}
+}
+```
+
+`recordingThreadSink` already exists in `internal/notify/slack_test.go` (same package) — reuse it, do not redefine it. Check its field names and match them.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/notify/ -run TestMatrixDeliver -v`
+Expected: FAIL — `m.Threads undefined`, `undefined: threadContentField`.
+
+- [ ] **Step 3: Create the content-field payload**
+
+Create `internal/notify/matrix_thread.go`:
+
+```go
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+// threadContentField is the custom event-content field Deliver stamps on
+// investigation messages so a threaded reply can be attributed to the
+// investigation it answers — the same mechanism triggerKeyContentField already
+// uses for 👍/👎, widened to carry the whole thread context.
+//
+// It is ADDITIVE: triggerKeyContentField keeps its exact meaning and value, so
+// the reaction listener and every event sent before this field existed behave
+// unchanged. Namespaced per the Matrix convention for custom keys.
+const threadContentField = "io.runlore.thread"
+
+// threadStamp is the thread context as carried on a Matrix event. It holds
+// identifiers only — never prose — so the event stays small and nothing
+// sensitive is duplicated into room history that is not already in the message.
+type threadStamp struct {
+	TriggerKey     string `json:"trigger_key,omitempty"`
+	DupFingerprint string `json:"dup_fingerprint,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Resource       string `json:"resource,omitempty"`
+	Verdict        string `json:"verdict,omitempty"`
+	CuratedURL     string `json:"curated_url,omitempty"`
+	RecalledEntry  string `json:"recalled_entry,omitempty"`
+}
+
+// stampFor renders the investigation's thread identifiers for the event content.
+func stampFor(inv providers.Investigation) threadStamp {
+	return threadStamp{
+		TriggerKey:     inv.TriggerKey,
+		Title:          inv.Title,
+		Resource:       inv.Resource.Ref(),
+		Verdict:        string(inv.Verdict),
+		CuratedURL:     inv.CuratedURL,
+		RecalledEntry:  inv.RecalledEntry,
+	}
+}
+
+// contextFromStamp rebuilds a thread.Context from a stamped event. root and
+// room come from the event itself, not from the stamp, so a forged stamp cannot
+// redirect where a note is written.
+func contextFromStamp(s threadStamp, root, room string) thread.Context {
+	return thread.Context{
+		Transport:      "matrix",
+		Root:           root,
+		Channel:        room,
+		TriggerKey:     s.TriggerKey,
+		DupFingerprint: s.DupFingerprint,
+		Title:          s.Title,
+		Resource:       s.Resource,
+		Verdict:        providers.Verdict(s.Verdict),
+		CuratedURL:     s.CuratedURL,
+		RecalledEntry:  s.RecalledEntry,
+	}
+}
+```
+
+- [ ] **Step 4: Wire it into `Matrix.Deliver`**
+
+In `internal/notify/matrix.go`: add a `Threads ThreadSink` field to `Matrix` with a doc comment matching `SlackBot.Threads`'s. Stamp `content[threadContentField] = stampFor(inv)` alongside the existing trigger-key stamp — unconditionally, like that one, because the field is inert data and the *listener* is the opt-in. Decode the send response into `struct{ EventID string \`json:"event_id"\` }`, and when both `Threads != nil` and the id is non-empty, call `s.Threads.Register(eventID, m.roomID, inv)`.
+
+Registration is best-effort and must not affect the returned error: a send that succeeded stays succeeded.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `go test ./internal/notify/ -run TestMatrix -v`
+Expected: PASS — the three new tests plus every pre-existing Matrix test, including the reaction-listener ones.
+
+- [ ] **Step 6: Full gate and commit**
+
+```bash
+git add internal/notify/matrix.go internal/notify/matrix_thread.go internal/notify/matrix_test.go
+git commit -m "feat(notify): stamp the thread context on Matrix investigation events
+
+Deliver discarded its send response, so it never learned the event id of the
+message it had just posted — and that id is the thread root. Decode it, stamp
+the thread identifiers alongside the existing trigger-key field, and register
+the root. The trigger-key field is untouched, so the reaction listener and
+every previously-sent event behave exactly as before."
+```
+
+---
+
+### Task 3: `Matrix.ReplyInThread`
+
+**Files:**
+- Modify: `internal/notify/matrix.go`
+- Test: `internal/notify/matrix_test.go`
+
+**Interfaces:**
+- Consumes: `providers.ThreadNotifier` (PR1).
+- Produces: `func (m *Matrix) ReplyInThread(ctx context.Context, root, channel, text string) error`, and `var _ providers.ThreadNotifier = (*Matrix)(nil)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestMatrixReplyInThread(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = w.Write([]byte(`{"event_id":"$reply1"}`))
+	}))
+	defer srv.Close()
+
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	if err := m.ReplyInThread(context.Background(), "$evt123", "!room:example.org", "📝 Noted"); err != nil {
+		t.Fatalf("ReplyInThread: %v", err)
+	}
+
+	rel, ok := body["m.relates_to"].(map[string]any)
+	if !ok {
+		t.Fatalf("reply must carry m.relates_to: %v", body)
+	}
+	if rel["rel_type"] != "m.thread" {
+		t.Errorf("rel_type = %v, want m.thread", rel["rel_type"])
+	}
+	if rel["event_id"] != "$evt123" {
+		t.Errorf("event_id = %v, want the thread root $evt123", rel["event_id"])
+	}
+	if body["body"] != "📝 Noted" {
+		t.Errorf("body = %v, want the reply text", body["body"])
+	}
+}
+
+func TestMatrixReplyInThreadReportsSendFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	if err := m.ReplyInThread(context.Background(), "$evt123", "!room:example.org", "x"); err == nil {
+		t.Fatal("a non-2xx send must be reported")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/notify/ -run TestMatrixReplyInThread -v`
+Expected: FAIL — `m.ReplyInThread undefined`.
+
+- [ ] **Step 3: Implement it**
+
+Post an `m.room.message` with `msgtype: "m.notice"` (matching `Deliver`, so a reply is not treated as a user message by clients), the plain `body`, and:
+
+```go
+"m.relates_to": map[string]any{"rel_type": "m.thread", "event_id": root},
+```
+
+Reuse `Deliver`'s transaction-id and send mechanics rather than duplicating the HTTP call — extract a small unexported `send(ctx, content map[string]any) (string, error)` that both use, returning the event id. Target the passed `channel` when non-empty, falling back to `m.roomID`, mirroring `SlackBot.ReplyInThread`.
+
+Reply text is plain (no `formatted_body`): the responder's replies are RunLore's own short acknowledgements, not investigation prose.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/notify/ -run TestMatrix -v -race`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/notify/matrix.go internal/notify/matrix_test.go
+git commit -m "feat(notify): reply into a Matrix thread"
+```
+
+---
+
+### Task 4: Make the replier lookup transport-aware
+
+`Multi.ThreadReplier()` returns the first notifier implementing `providers.ThreadNotifier` (`internal/notify/slack.go:932-939`). With Task 3 done, a deployment configuring **both** Slack and Matrix has two — and gets whichever is registered first for both transports. A Matrix thread would be answered via Slack, or not at all.
+
+**Files:**
+- Modify: `internal/notify/slack.go` (the `Multi` methods)
+- Modify: `internal/app/serve.go` (the call site)
+- Test: `internal/notify/slack_test.go`
+
+**Interfaces:**
+- Produces: `func (m *Multi) ThreadRepliers() map[string]providers.ThreadNotifier` — transport name → replier. `ThreadReplier()` is removed.
+- Requires: `providers.ThreadNotifier` gains `Transport() string`, implemented as `"slack"` by `SlackBot` and `"matrix"` by `Matrix`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestMultiThreadRepliersAreTransportScoped(t *testing.T) {
+	bot := NewSlackBot("xoxb-test", "C1")
+	mx := NewMatrix("https://hs.example.org", "!room:example.org", "tok")
+	m := NewMulti(testNotifyLogger(), NewSlack("https://hooks.slack.com/x"), bot, mx)
+
+	got := m.ThreadRepliers()
+	if len(got) != 2 {
+		t.Fatalf("ThreadRepliers = %d entries, want 2", len(got))
+	}
+	if got["slack"] != providers.ThreadNotifier(bot) {
+		t.Errorf("slack replier = %v, want the SlackBot", got["slack"])
+	}
+	if got["matrix"] != providers.ThreadNotifier(mx) {
+		t.Errorf("matrix replier = %v, want the Matrix notifier", got["matrix"])
+	}
+}
+
+func TestMultiThreadRepliersEmptyWhenNoneCanReply(t *testing.T) {
+	m := NewMulti(testNotifyLogger(), NewSlack("https://hooks.slack.com/x"))
+	if got := m.ThreadRepliers(); len(got) != 0 {
+		t.Fatalf("ThreadRepliers = %v, want empty", got)
+	}
+}
+```
+
+Use whatever discard-logger helper `slack_test.go` already defines; if there is none, construct `slog.New(slog.NewTextHandler(io.Discard, nil))` inline rather than adding a helper.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/notify/ -run TestMultiThreadRepliers -v`
+Expected: FAIL — `m.ThreadRepliers undefined`.
+
+- [ ] **Step 3: Add `Transport()` to the capability**
+
+In `internal/providers/providers.go`, add to `ThreadNotifier`:
+
+```go
+	// Transport names the chat system this notifier replies on ("slack",
+	// "matrix"). It is what lets a deployment running several transports route
+	// each thread's reply back to the system the human is actually in — the
+	// alternative, picking the first notifier that can reply, silently answers
+	// one transport's threads on another.
+	Transport() string
+```
+
+Implement `func (s *SlackBot) Transport() string { return "slack" }` and `func (m *Matrix) Transport() string { return "matrix" }`, each with a doc comment.
+
+Replace `Multi.ThreadReplier` with `ThreadRepliers`, keyed by `Transport()`. Where two notifiers report the same transport, keep the first and log a warning naming the collision — silently dropping one would be the same class of bug this task fixes.
+
+- [ ] **Step 4: Update the wiring**
+
+In `internal/app/serve.go`, take the Slack replier from `ThreadRepliers()["slack"]`. Keep the existing "no thread-capable notifier resolved" warning behaviour for the case where the map has no entry for the transport being wired.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `go test ./internal/notify/ ./internal/app/ -race`
+Expected: PASS, including PR1's Slack-only wiring tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/providers/providers.go internal/notify/slack.go internal/notify/matrix.go internal/notify/slack_test.go internal/app/serve.go
+git commit -m "fix(notify): scope the thread replier by transport
+
+ThreadReplier returned the first notifier that could reply, which was
+unambiguous only while Slack was the sole implementation. With Matrix able to
+reply too, a deployment running both would answer one transport's threads on
+the other. Key the lookup by transport instead."
+```
+
+---
+
+### Task 5: `contextFor` — read the thread context back off an event
+
+Generalise `MatrixFeedback.triggerKeyFor` so the same fetch, the same self-check and the same cache serve both the reaction listener and thread capture.
+
+**Files:**
+- Modify: `internal/notify/matrix_feedback.go`
+- Modify: `internal/notify/matrix_thread.go`
+- Test: `internal/notify/matrix_feedback_test.go`
+
+**Interfaces:**
+- Produces: `func (f *MatrixFeedback) contextFor(ctx context.Context, eventID string) (thread.Context, bool, error)` — the second return is `false` when the event is not one of RunLore's own investigation messages. `triggerKeyFor` keeps working, implemented on top of the same fetch.
+
+- [ ] **Step 1: Write the failing test**
+
+Cover, at minimum: an event stamped with `io.runlore.thread` and sent by the bot yields a populated `thread.Context` with `Root` and `Channel` taken from the fetch parameters, not the stamp; **an event carrying the field but sent by somebody else yields `false`** (the trust anchor — a room member must not be able to stamp their own message and redirect where notes are written); an event with only the legacy `io.runlore.trigger_key` still yields a context carrying that key; an unstamped event yields `false`; and the existing `triggerKeyFor` behaviour is unchanged for all four.
+
+Follow the HTTP-fake pattern already in `matrix_feedback_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/notify/ -run TestMatrixContextFor -v`
+Expected: FAIL — `f.contextFor undefined`.
+
+- [ ] **Step 3: Implement**
+
+Refactor the fetch in `triggerKeyFor` into an unexported `fetchEvent(ctx, eventID) (sender string, content map[string]any, err error)`. Build `contextFor` on it: decode `content[threadContentField]` into a `threadStamp` (re-marshal the `any` through `json` rather than hand-casting), fall back to `content[triggerKeyContentField]` when the thread field is absent, and return `false` when `sender != f.self` — the identical anchor `triggerKeyFor` already enforces, for the identical reason.
+
+Change the cache from `map[string]string` to hold the resolved context, keeping the same crude cap-and-reset bound and the same "the live working set is tiny" comment. **The cache is currently unsynchronised because only the sync goroutine touches it** — keep every `contextFor` call on the sync goroutine (Task 6 detaches the *handling*, not the lookup), or add a mutex. State which you chose in a comment.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/notify/ -race -v`
+Expected: PASS, including every pre-existing reaction test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/notify/matrix_feedback.go internal/notify/matrix_thread.go internal/notify/matrix_feedback_test.go
+git commit -m "feat(notify): read the thread context back off a Matrix event
+
+One fetch, one self-check, one cache, now serving both the reaction listener
+and thread capture. The trust anchor is unchanged and load-bearing: a stamped
+event that RunLore did not send attributes nothing, or any room member could
+stamp their own message and redirect where a note is written."
+```
+
+---
+
+### Task 6: Handle `m.room.message` in the sync loop
+
+**Files:**
+- Modify: `internal/notify/matrix_feedback.go`
+- Test: `internal/notify/matrix_feedback_test.go`
+
+**Interfaces:**
+- Consumes: `contextFor` (Task 5), `thread.Dispatcher` (Task 1), `thread.Mention` (PR1).
+- Produces: `MatrixFeedback` gains `Mentions *thread.Mention` and `Dispatch *thread.Dispatcher` fields; `handleMessage(ctx, e matrixEvent)`.
+
+- [ ] **Step 1: Widen the event struct**
+
+`matrixEvent` currently decodes only `Type`, `Sender` and `Content.RelatesTo`. Add the event's own `EventID` (`event_id`), `Content.Body`, `Content.MsgType`, `Content.Mentions.UserIDs` (`m.mentions` → `user_ids`, MSC3952), and `Content.RelatesTo.InReplyTo.EventID` (`m.in_reply_to` → `event_id`).
+
+- [ ] **Step 2: Write the failing test**
+
+Cover: a threaded (`rel_type: m.thread`) message mentioning the bot dispatches to the mention handler with the **root** event id, not the reply's own id; a reply-fallback message (`m.in_reply_to`, no `rel_type`) resolves its root the same way; a message not mentioning the bot dispatches nothing; a message from the bot itself (`sender == self`) dispatches nothing (loop guard); a message with no thread relation dispatches nothing; and a message whose root event is not one of RunLore's dispatches nothing.
+
+Use a fake `thread.Mention` collaborator — or a small interface the listener depends on — rather than a live forge. Make the assertions deterministic: have the fake close a channel the test waits on, never a sleep.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/notify/ -run TestMatrixHandleMessage -v`
+Expected: FAIL — `f.handleMessage undefined`.
+
+- [ ] **Step 4: Implement**
+
+In `sync()`, widen the inline filter's `timeline.types` from `["m.reaction"]` to `["m.reaction","m.room.message"]` **only when thread capture is enabled** — a deployment that has not opted in must keep receiving exactly what it receives today. Thread that flag through the constructor.
+
+In `Run`'s event loop, dispatch by `e.Type`: `m.reaction` → `handleReaction` (unchanged, still inline — recording a rating is a local ledger write), `m.room.message` → `handleMessage`.
+
+`handleMessage` must, in order: ignore `sender == f.self`; require the bot to be addressed (`m.mentions.user_ids` contains `f.self`, falling back to the body containing the MXID or its localpart); resolve the thread root (`m.relates_to.rel_type == "m.thread"` → `event_id`; else `m.in_reply_to.event_id`; else return); call `contextFor(root)` **on the sync goroutine** and return when it reports `false`; then hand the work to the dispatcher.
+
+When `Dispatch.Go` returns `false`, call the mention handler's `Busy` — the same contract the Slack path uses, so a saturated Matrix listener tells the human to retype instead of dropping silently.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `go test ./internal/notify/ -race -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/notify/matrix_feedback.go internal/notify/matrix_feedback_test.go
+git commit -m "feat(notify): handle addressed Matrix thread messages
+
+The sync loop now also sees m.room.message when thread capture is on, and
+hands an addressed threaded reply to the shared responder. Handling is
+detached: a note that opens a PR costs several sequential forge calls, and
+doing that inline would stall long-polling and pause feedback recording.
+The filter is widened only when the feature is enabled."
+```
+
+---
+
+### Task 7: Config — `notify.matrix.thread_capture`
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Test: `internal/config/config_test.go`
+
+**Interfaces:**
+- Produces: `config.MatrixNotify.ThreadCapture bool` (yaml `thread_capture`).
+
+- [ ] **Step 1: Write the failing test**
+
+Table-driven, mirroring PR1's `TestValidateThreadCapture`. `thread_capture: true` requires `homeserver`, `room_id`, `access_token_env` (the listener long-polls the configured room and authenticates as the bot) **and** `outcome.ledger_path` (the registry lives beside the ledger; PR1 made this a hard requirement for Slack and the same reasoning applies). Off requires nothing.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestValidateMatrixThreadCapture -v`
+Expected: FAIL — `unknown field ThreadCapture`.
+
+- [ ] **Step 3: Implement**
+
+Add the field with a doc comment whose requirement list is **complete** and matches what `Validate` enforces — PR1 shipped a comment that omitted a requirement and a reviewer correctly called it misleading. Add the rules immediately after the existing `matrix.feedback_reactions` block, matching its structure and message style.
+
+- [ ] **Step 4: Run the tests and commit**
+
+Run: `go test ./internal/config/`
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(config): notify.matrix.thread_capture"
+```
+
+---
+
+### Task 8: Wiring, docs, and the sync-filter disclosure
+
+**Files:**
+- Modify: `internal/app/notify.go`, `internal/app/serve.go`
+- Test: `internal/app/notify_test.go`
+- Modify: `website/content/docs/integrations/notifications/matrix.md` (or the existing Matrix page — find it with `grep -rln "feedback_reactions" website/content/`), `website/content/docs/configuration/configuration.md`, `website/content/docs/security/security-model.md`, `SECURITY.md`
+
+- [ ] **Step 1: Write the failing test**
+
+Extend `BuildMatrixFeedback`'s tests: with `thread_capture` on and a registry, forge and replier available, the returned listener carries a non-nil `Mentions` and `Dispatch`; with `thread_capture` off it carries neither and behaves exactly as today; with no Matrix replier resolvable it logs and leaves thread capture off rather than panicking.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/app/ -run TestBuildMatrixFeedback -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Wire it**
+
+Extend `BuildMatrixFeedback` (`internal/app/notify.go:50`) to accept what thread capture needs and populate the listener's `Mentions`/`Dispatch` **only** when `thread_capture` is on, the registry is enabled, a forge is configured and `ThreadRepliers()["matrix"]` is non-nil. Reuse the same `*thread.Responder` and `*thread.Registry` instances the Slack path already builds — one responder, two transports, per the spec. Follow PR1's guard-and-warn structure in `serve.go` rather than inventing a new shape.
+
+Drain the Matrix dispatcher at shutdown alongside the Slack one.
+
+- [ ] **Step 4: Write the docs**
+
+The Matrix integration page gets a "Write knowledge back from a thread" section mirroring the Slack page's: the `note:` grammar, what happens when the finding has no KB PR, the config block, and the fact that no Slack-style endpoint or ingress change is required — this is the transport's genuine advantage and worth stating.
+
+Add `thread_capture` to the Matrix keys in `configuration.md`, matching the treatment `notify.slack.thread_capture` received.
+
+**The disclosure, which is the point of this step.** In `website/content/docs/security/security-model.md` and `SECURITY.md`, state plainly: with `notify.matrix.thread_capture` on, RunLore's `/sync` filter widens from `["m.reaction"]` to also include `["m.room.message"]`, so the process **receives message events** from the configured room where today it receives only reactions. It acts only on messages that address it and are rooted in one of its own messages, and non-matching events are dropped immediately without their bodies being logged — but they do transit the process. Say that the filter is widened only when the feature is enabled. Do not soften it.
+
+- [ ] **Step 5: Verify the docs build**
+
+Run: `cd website && /usr/bin/hugo --quiet --destination /tmp/hugo-pr2-check`
+Expected: exit 0, no warnings. (`hugo` on `PATH` is too old — see Global Constraints.) Then confirm the new content rendered: `grep -rl thread_capture /tmp/hugo-pr2-check --include=*.html`.
+
+- [ ] **Step 6: Full gate and commit**
+
+Run: `go build ./... && go vet ./... && go test ./... -race && gofmt -l . && golangci-lint run ./...`
+
+```bash
+git add internal/app/ website/ SECURITY.md
+git commit -m "feat(app): wire Matrix thread capture
+
+One responder, two transports: Matrix reuses the same responder and registry
+the Slack path builds. Documents the sync-filter widening honestly — with the
+feature on, the process receives room messages where it previously received
+only reactions."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (§Matrix transport of the design doc):
+
+| Spec requirement | Task |
+|---|---|
+| Stamp `io.runlore.thread`, keep `io.runlore.trigger_key` unchanged | 2 |
+| Generalise `triggerKeyFor` into a context lookup, same fetch + cache | 5 |
+| Registry used for the `NoteURL` write-back | 2 (registers on delivery) |
+| Widen the `/sync` filter, only when enabled | 6 |
+| Addressed detection: `m.mentions` with MXID/localpart fallback | 6 |
+| `m.thread` with `m.in_reply_to` fallback | 6 |
+| Trust anchor: root event sent by `self` | 5 |
+| Loop guard: ignore own messages | 6 |
+| Reply via `m.relates_to: {rel_type: m.thread}` | 3 |
+| Honest disclosure of the widened filter | 8 |
+| `notify.matrix.thread_capture` | 7 |
+
+Not in the spec, added here because implementation requires them: Task 1 (shared dispatcher — the spec assumed handling could be inline), Task 4 (transport-scoped replier — the spec did not foresee the `Multi.ThreadReplier` ambiguity), and Task 2's `event_id` decode (the spec assumed `Deliver` already knew its own event id).
+
+**Placeholder scan:** none — every step names exact files, commands and expected output. Tasks 5, 6 and 8 describe test *cases* rather than pasting full test bodies, because each depends on the fake/HTTP-stub conventions already established in `matrix_feedback_test.go`; the implementer is told to follow those and exactly which behaviours to cover.
+
+**Type consistency:** `threadContentField`, `threadStamp`, `stampFor`, `contextFromStamp`, `Matrix.Threads`, `Matrix.ReplyInThread`, `Matrix.Transport`, `Multi.ThreadRepliers`, `MatrixFeedback.contextFor`, `fetchEvent`, `handleMessage`, `MatrixFeedback.Mentions`, `MatrixFeedback.Dispatch`, `thread.NewDispatcher`, `Dispatcher.Go`, `Dispatcher.Drain` are each declared once and referenced with the same signature throughout. `Dispatcher.Go` returning `bool` (accepted / refused) is relied on by both Task 1's server switch and Task 6's `Busy` path.
+
+**Risk to flag at execution time:** Task 1 touches PR1 code that is already merged-pending-review in #482. If PR1 changes before this lands, rebase and re-run Task 1 Step 7 — its whole value is proving the extraction changed nothing.

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -36,16 +36,22 @@ const (
 )
 
 // BuildThreadRegistry assembles the thread-context registry backing
-// notify.slack.thread_capture: nil-path (disabled) unless the option is on AND
-// the outcome ledger has a path.
+// notify.slack.thread_capture AND notify.matrix.thread_capture: nil-path
+// (disabled) unless EITHER option is on AND the outcome ledger has a path.
 //
 // The ledger path is the dependency because it names the durable state
 // directory — the registry has to survive a restart or a leader failover for the
 // same reason the ledger does, and inventing a second location for one file
 // would be a second thing to mount. Without it, capture degrades to
 // unavailable, which the human is told, rather than to silently forgetful.
+//
+// One registry backs both transports: a thread opened over Slack is exactly
+// as answerable as one opened over Matrix, so there is exactly one durable
+// file and one in-memory set, never one per transport — see
+// buildThreadResponder for the matching invariant on the write side.
 func BuildThreadRegistry(cfg *config.Config) (*thread.Registry, error) {
-	if !cfg.Notify.Slack.ThreadCapture || cfg.Outcome.LedgerPath == "" {
+	captureWanted := cfg.Notify.Slack.ThreadCapture || cfg.Notify.Matrix.ThreadCapture
+	if !captureWanted || cfg.Outcome.LedgerPath == "" {
 		return thread.NewRegistry("", threadRegistryTTL, threadRegistryMax)
 	}
 	path := filepath.Join(filepath.Dir(cfg.Outcome.LedgerPath), "threads.jsonl")
@@ -72,10 +78,42 @@ func ThreadCaptureDeliverable(cfg *config.Config, log *slog.Logger) bool {
 	return false
 }
 
+// buildThreadResponder assembles the knowledge-write responder shared by
+// every transport's thread capture. It is built exactly once (see serve.go)
+// regardless of how many transports end up using it, so OpenPRs — the global
+// per-hour cap on standalone note PRs — bounds forge writes system-wide
+// instead of once per transport: "one responder, two transports," per the
+// design.
+//
+// forge may be nil (no forge.kb_repo configured, or no usable credential): the
+// responder is still constructed, always the same instance, so callers check
+// Forge == nil themselves and report their own transport-flavoured warning
+// rather than this helper guessing which transport's operator to address.
+//
+// metrics is always non-nil in production (bound to the global no-op provider
+// when telemetry is disabled — see serve.go) but the parameter itself stays
+// nil-safe: thread.Responder guards it before every use, same as every other
+// optional *telemetry.Metrics field in RunLore.
+func buildThreadResponder(threadRegistry *thread.Registry, forge thread.Forge, metrics *telemetry.Metrics, log *slog.Logger) *thread.Responder {
+	return &thread.Responder{
+		Forge:             forge,
+		Registry:          threadRegistry,
+		MaxNotesPerThread: thread.DefaultMaxNotesPerThread,
+		ForgeWrites:       ratelimit.New(20, time.Hour),
+		Metrics:           metrics,
+		Log:               log,
+	}
+}
+
 // BuildThreadMention assembles the Slack thread-capture handler when
 // notify.slack.thread_capture can actually work end to end, or returns nil
 // (warning exactly once, naming the specific reason) when it cannot. Called
 // only with the option on and threadRegistry persisted — see serve.go.
+//
+// responder is the shared knowledge-write responder built once by
+// buildThreadResponder (see BuildMatrixFeedback for the Matrix side reusing
+// the identical instance); a nil responder, or one with a nil Forge, means no
+// forge is configured.
 //
 // ThreadCaptureDeliverable is checked BEFORE asking notifier for a replier —
 // not after, as an earlier version of this wiring did. replier == nil is
@@ -91,24 +129,23 @@ func ThreadCaptureDeliverable(cfg *config.Config, log *slog.Logger) bool {
 // SlackBotDelivery(sl) had already returned true, so ThreadCaptureDeliverable's
 // own "no bot-token delivery target resolved" warning could never fire in
 // production. This ordering is what makes it reachable.
-// metrics is always non-nil in production (bound to the global no-op provider
-// when telemetry is disabled — see serve.go) but the parameter itself stays
-// nil-safe: thread.Responder guards it before every use, same as every other
-// optional *telemetry.Metrics field in RunLore.
-func BuildThreadMention(cfg *config.Config, threadRegistry *thread.Registry, forge thread.Forge, notifier *notify.Multi, metrics *telemetry.Metrics, log *slog.Logger) *thread.Mention {
-	if forge == nil {
+func BuildThreadMention(cfg *config.Config, responder *thread.Responder, notifier *notify.Multi, log *slog.Logger) *thread.Mention {
+	if responder == nil || responder.Forge == nil {
 		log.Warn("slack thread_capture enabled but no forge is configured (forge.kb_repo / credentials); knowledge cannot be written")
 		return nil
 	}
 	if !ThreadCaptureDeliverable(cfg, log) {
 		return nil
 	}
-	// notifier is nil on the log-only path (no model configured); ThreadReplier
+	// notifier is nil on the log-only path (no model configured); ThreadRepliers
 	// is a pointer-receiver method that dereferences it, so a nil check here
-	// avoids a startup panic on that otherwise-valid configuration.
+	// avoids a startup panic on that otherwise-valid configuration. This wiring
+	// is Slack-specific, so it always takes the "slack" entry from the
+	// transport-keyed map — a deployment also running Matrix does not change
+	// which replier answers a Slack thread.
 	var replier providers.ThreadNotifier
 	if notifier != nil {
-		replier = notifier.ThreadReplier()
+		replier = notifier.ThreadRepliers()["slack"]
 	}
 	if replier == nil {
 		log.Warn("slack thread_capture enabled but no thread-capable notifier resolved; replies cannot be posted")
@@ -116,17 +153,10 @@ func BuildThreadMention(cfg *config.Config, threadRegistry *thread.Registry, for
 	}
 	log.Info("slack thread capture enabled", "endpoint", "/slack/events")
 	return &thread.Mention{
-		Responder: &thread.Responder{
-			Forge:             forge,
-			Registry:          threadRegistry,
-			MaxNotesPerThread: thread.DefaultMaxNotesPerThread,
-			ForgeWrites:       ratelimit.New(20, time.Hour),
-			Metrics:           metrics,
-			Log:               log,
-		},
-		Registry: threadRegistry,
-		Replier:  replier,
-		Log:      log,
+		Responder: responder,
+		Registry:  responder.Registry,
+		Replier:   replier,
+		Log:       log,
 	}
 }
 
@@ -152,22 +182,113 @@ func SlackFeedbackDeliverable(cfg *config.Config, log *slog.Logger) bool {
 	return false
 }
 
-// BuildMatrixFeedback assembles the opt-in Matrix reaction listener
-// (notify.matrix.feedback_reactions): nil unless the option is on, the outcome
-// ledger persists, and the access token is actually present — a listener that
-// could record nowhere or authenticate as no one must not start. Validate has
-// already required the notifier fields and the ledger path with the option on;
-// the token presence is an env-var runtime fact, checked here like the
-// notifier's own builder does.
-func BuildMatrixFeedback(cfg *config.Config, ledger *outcome.Ledger, log *slog.Logger) *notify.MatrixFeedback {
+// Matrix thread-capture dispatcher bounds. matrixMentionConcurrency is sized
+// the same as the Slack server's eventDispatcher (internal/server): each slot
+// holds one forge round-trip, not a heavy computation, so a wide pool stays
+// cheap, and the timeout guarantees the pool drains through a degraded forge
+// in bounded time instead of being held hostage indefinitely. Matrix mirrors
+// Slack's separate, smaller "busy notice" pool too (matrixBusyConcurrency
+// below): even under a burst of addressed messages while the main pool is
+// saturated, telling humans about it stays detached from the /sync goroutine
+// — see MatrixFeedback.BusyDispatch.
+const (
+	matrixMentionConcurrency = 16
+	matrixMentionTimeout     = 2 * time.Minute
+	// matrixBusyConcurrency bounds detached "I'm too busy, try again" Matrix
+	// replies (MatrixFeedback.BusyDispatch), sized the same as the Slack
+	// server's busyDispatcher (internal/server.maxConcurrentBusyNotices):
+	// deliberately separate and small from matrixMentionConcurrency, since
+	// telling humans about an overload is itself a network round-trip and must
+	// never become the next unbounded liability.
+	matrixBusyConcurrency = 4
+)
+
+// buildMatrixThreadMention assembles the Matrix thread-capture handler when
+// notify.matrix.thread_capture can actually work end to end, or returns nil
+// (warning exactly once, naming the specific reason) when it cannot. Mirrors
+// BuildThreadMention's guard order (forge, then registry, then replier).
+// Matrix has no bot-token-style runtime deliverability gap to check
+// separately here: by the time BuildMatrixFeedback calls this, the access
+// token has already been confirmed present, which is everything Matrix
+// delivery needs.
+func buildMatrixThreadMention(cfg *config.Config, responder *thread.Responder, notifier *notify.Multi, log *slog.Logger) *thread.Mention {
+	if responder == nil || responder.Forge == nil {
+		log.Warn("matrix thread_capture enabled but no forge is configured (forge.kb_repo / credentials); knowledge cannot be written")
+		return nil
+	}
+	if !responder.Registry.Enabled() {
+		log.Warn("matrix thread_capture enabled but the thread registry is unavailable (outcome.ledger_path not set); knowledge cannot be attributed to a thread")
+		return nil
+	}
+	// notifier is nil on the log-only path (no model configured); ThreadRepliers
+	// is a pointer-receiver method that dereferences it, so a nil check here
+	// avoids a startup panic on that otherwise-valid configuration.
+	var replier providers.ThreadNotifier
+	if notifier != nil {
+		replier = notifier.ThreadRepliers()["matrix"]
+	}
+	if replier == nil {
+		log.Warn("matrix thread_capture enabled but no Matrix thread-capable notifier resolved; replies cannot be posted")
+		return nil
+	}
+	log.Info("matrix thread capture enabled", "room", cfg.Notify.Matrix.RoomID)
+	return &thread.Mention{
+		Responder: responder,
+		Registry:  responder.Registry,
+		Replier:   replier,
+		Log:       log,
+	}
+}
+
+// BuildMatrixFeedback assembles the opt-in Matrix listener backing BOTH
+// notify.matrix.feedback_reactions and notify.matrix.thread_capture: one
+// /sync long-poll loop serves either or both, so the listener is built
+// whenever EITHER option is on. Returns nil when neither option is on, the
+// outcome ledger cannot persist, or the access token is actually empty at
+// runtime — a listener that could record nowhere or authenticate as no one
+// must not start. Validate has already required the notifier fields and the
+// ledger path with either option on; the token presence is an env-var runtime
+// fact, checked here like the notifier's own builder does.
+//
+// Thread capture (the returned listener's Mentions/Dispatch) is wired on top
+// ONLY when notify.matrix.thread_capture is on AND buildMatrixThreadMention
+// can resolve a forge, an enabled registry and a Matrix replier — see that
+// function for the guard-and-warn per condition. Missing any of the three
+// degrades to a listener with thread capture off (feedback reactions still
+// work if that option is on); it is never a reason to fail startup, and
+// WithThreadCapture is simply not called — see its doc for why that leaves
+// Mentions/Dispatch nil rather than partially set.
+//
+// responder, dispatch and busyDispatch are the SAME instances the Slack path
+// builds and drains (see serve.go): exactly one *thread.Responder and two
+// *thread.Dispatcher (mentions, busy notices) exist for the process
+// regardless of how many transports use them — "one responder, two
+// transports." metrics is the process's shared instrument set (nil-safe
+// throughout notify.MatrixFeedback, same as internal/server.Server's own
+// telemetryMetrics field) — wired unconditionally so a dropped mention is
+// counted (runlore_mentions_dropped_on_saturation_total) exactly like a
+// dropped Slack mention already is.
+func BuildMatrixFeedback(cfg *config.Config, ledger *outcome.Ledger, responder *thread.Responder, dispatch, busyDispatch *thread.Dispatcher, notifier *notify.Multi, metrics *telemetry.Metrics, log *slog.Logger) *notify.MatrixFeedback {
 	mc := cfg.Notify.Matrix
-	if !mc.FeedbackReactions || !ledger.Enabled() {
+	if !mc.FeedbackReactions && !mc.ThreadCapture {
+		return nil
+	}
+	if !ledger.Enabled() {
 		return nil
 	}
 	tok := os.Getenv(mc.AccessTokenEnv)
 	if tok == "" {
-		log.Warn("matrix feedback_reactions enabled but the access token env is empty; listener disabled", "env", mc.AccessTokenEnv)
+		log.Warn("matrix feedback_reactions/thread_capture enabled but the access token env is empty; listener disabled", "env", mc.AccessTokenEnv)
 		return nil
 	}
-	return notify.NewMatrixFeedback(mc.Homeserver, mc.RoomID, tok, ledger, log)
+	opts := []notify.MatrixFeedbackOption{notify.WithMetrics(metrics)}
+	if mc.FeedbackReactions {
+		opts = append(opts, notify.WithFeedbackReactions())
+	}
+	if mc.ThreadCapture {
+		if mention := buildMatrixThreadMention(cfg, responder, notifier, log); mention != nil {
+			opts = append(opts, notify.WithThreadCapture(mention, dispatch, busyDispatch))
+		}
+	}
+	return notify.NewMatrixFeedback(mc.Homeserver, mc.RoomID, tok, ledger, log, opts...)
 }

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/notify"
+	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
 	"github.com/Smana/runlore/internal/thread"
@@ -135,6 +136,31 @@ func TestBuildThreadRegistryUsesTheLedgerDirectory(t *testing.T) {
 	}
 }
 
+// TestBuildThreadRegistryEnabledForMatrixOnly pins the Task 8 fix: the
+// registry must persist for a deployment that only turns on
+// notify.matrix.thread_capture (Slack's flag left off). Before this fix,
+// BuildThreadRegistry's gate checked ONLY notify.slack.thread_capture, so a
+// Matrix-only deployment always got a disabled (no-op) registry no matter how
+// notify.matrix.thread_capture and outcome.ledger_path were set — Matrix
+// thread capture could never work.
+func TestBuildThreadRegistryEnabledForMatrixOnly(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{}
+	cfg.Outcome.LedgerPath = filepath.Join(dir, "ledger.jsonl")
+	cfg.Notify.Matrix = config.MatrixNotify{
+		Homeserver: "https://matrix.example.org", RoomID: "!room:example.org",
+		AccessTokenEnv: "T", ThreadCapture: true,
+	}
+
+	reg, err := BuildThreadRegistry(cfg)
+	if err != nil {
+		t.Fatalf("BuildThreadRegistry: %v", err)
+	}
+	if !reg.Enabled() {
+		t.Fatal("matrix thread_capture alone (slack's flag off) must yield an enabled registry")
+	}
+}
+
 func TestBuildThreadRegistryDisabledWithoutLedgerPath(t *testing.T) {
 	// The registry needs somewhere durable to live. Without a ledger path there is
 	// no state directory, so capture degrades to unavailable rather than to
@@ -213,7 +239,7 @@ func TestBuildThreadMentionNamesTheBotTokenCause(t *testing.T) {
 		t.Fatalf("BuildEnabled: %v", err)
 	}
 
-	m := BuildThreadMention(cfg, reg, fakeThreadForge{}, notifier, nil, log)
+	m := BuildThreadMention(cfg, &thread.Responder{Forge: fakeThreadForge{}, Registry: reg}, notifier, log)
 	if m != nil {
 		t.Fatal("must not wire the handler when the bot token cannot actually deliver")
 	}
@@ -247,7 +273,7 @@ func TestBuildThreadMentionStillReportsNoNotifierWhenNoneWasBuilt(t *testing.T) 
 
 	// notifier is nil, exactly as serve.go passes it on the log-only (no model
 	// configured) startup path.
-	m := BuildThreadMention(cfg, reg, fakeThreadForge{}, nil, nil, log)
+	m := BuildThreadMention(cfg, &thread.Responder{Forge: fakeThreadForge{}, Registry: reg}, nil, log)
 	if m != nil {
 		t.Fatal("must not wire the handler when no notifier was built at all")
 	}
@@ -278,7 +304,7 @@ func TestBuildThreadMentionWiresWhenEverythingIsReachable(t *testing.T) {
 		t.Fatalf("BuildEnabled: %v", err)
 	}
 
-	m := BuildThreadMention(cfg, reg, fakeThreadForge{}, notifier, nil, log)
+	m := BuildThreadMention(cfg, &thread.Responder{Forge: fakeThreadForge{}, Registry: reg}, notifier, log)
 	if m == nil {
 		t.Fatal("must wire the handler when forge, bot-token delivery and the notifier are all reachable")
 	}
@@ -288,10 +314,11 @@ func TestBuildThreadMentionWiresWhenEverythingIsReachable(t *testing.T) {
 }
 
 // TestBuildThreadMentionWiresForgeWritesAndMetrics pins wiring that none of
-// the other TestBuildThreadMention* tests check: with everything reachable,
-// the returned Responder must actually carry the global rate limit and the
-// metrics instrument set — the same idiom TestWireRecallSetsEveryRuntimeDependency
-// uses for investigate.Recall (see wire_recall_test.go).
+// the other TestBuildThreadMention* tests check: the shared Responder built by
+// buildThreadResponder (see serve.go) and threaded through BuildThreadMention
+// must actually carry the global rate limit and the metrics instrument set —
+// the same idiom TestWireRecallSetsEveryRuntimeDependency uses for
+// investigate.Recall (see wire_recall_test.go).
 //
 // Both assignments are load-bearing but invisible to the rest of the suite if
 // dropped: Responder.write nil-checks ForgeWrites before calling it
@@ -317,8 +344,9 @@ func TestBuildThreadMentionWiresForgeWritesAndMetrics(t *testing.T) {
 		t.Fatalf("BuildEnabled: %v", err)
 	}
 	metrics := telemetry.NewMetrics()
+	responder := buildThreadResponder(reg, fakeThreadForge{}, metrics, log)
 
-	m := BuildThreadMention(cfg, reg, fakeThreadForge{}, notifier, metrics, log)
+	m := BuildThreadMention(cfg, responder, notifier, log)
 	if m == nil {
 		t.Fatal("must wire the handler when everything is reachable")
 	}
@@ -326,23 +354,233 @@ func TestBuildThreadMentionWiresForgeWritesAndMetrics(t *testing.T) {
 		t.Fatal("Responder.ForgeWrites is nil — the global forge-write rate limit is unenforced in production")
 	}
 	if m.Responder.Metrics != metrics {
-		t.Fatal("Responder.Metrics is not the *telemetry.Metrics passed to BuildThreadMention — " +
+		t.Fatal("Responder.Metrics is not the *telemetry.Metrics passed to buildThreadResponder — " +
 			"ThreadWritesThrottled/ThreadNotesWritten go dead")
 	}
 }
 
-// TestBuildThreadMentionReportsMissingForge pins the unchanged forge==nil case.
+// TestBuildThreadMentionReportsMissingForge pins the unchanged
+// responder==nil/Forge==nil case.
 func TestBuildThreadMentionReportsMissingForge(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Notify.Slack.ThreadCapture = true
 	var buf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	m := BuildThreadMention(cfg, &thread.Registry{}, nil, nil, nil, log)
+	m := BuildThreadMention(cfg, nil, nil, log)
 	if m != nil {
 		t.Fatal("must not wire the handler when no forge is configured")
 	}
 	if !strings.Contains(buf.String(), "no forge is configured") {
 		t.Fatalf("must name the missing forge; got: %s", buf.String())
+	}
+}
+
+// fakeMatrixReplier is a minimal providers.ThreadNotifier stub identifying as
+// the "matrix" transport — enough for BuildMatrixFeedback's / buildMatrixThreadMention's
+// tests to resolve a replier via Multi.ThreadRepliers() without a live homeserver.
+type fakeMatrixReplier struct{}
+
+func (fakeMatrixReplier) Deliver(context.Context, providers.Investigation) error { return nil }
+func (fakeMatrixReplier) ReplyInThread(context.Context, string, string, string) error {
+	return nil
+}
+func (fakeMatrixReplier) Transport() string { return "matrix" }
+
+// readyMatrixResponder builds a *thread.Responder with a real, enabled
+// registry (backed by a temp file) and a fake forge — everything
+// buildMatrixThreadMention needs to succeed, for the test cases that want it
+// reachable.
+func readyMatrixResponder(t *testing.T) *thread.Responder {
+	t.Helper()
+	reg, err := thread.NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return &thread.Responder{Forge: fakeThreadForge{}, Registry: reg}
+}
+
+// TestBuildMatrixThreadMentionReportsMissingForge mirrors
+// TestBuildThreadMentionReportsMissingForge for the Matrix analogue.
+func TestBuildMatrixThreadMentionReportsMissingForge(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Notify.Matrix.ThreadCapture = true
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	m := buildMatrixThreadMention(cfg, nil, nil, log)
+	if m != nil {
+		t.Fatal("must not wire the handler when no forge is configured")
+	}
+	if !strings.Contains(buf.String(), "no forge is configured") {
+		t.Fatalf("must name the missing forge; got: %s", buf.String())
+	}
+}
+
+// TestBuildMatrixThreadMentionReportsDisabledRegistry pins the registry guard:
+// a responder whose Registry is disabled (no path — e.g. outcome.ledger_path
+// unset) must degrade rather than wire a Mention no reply could ever be
+// attributed through.
+func TestBuildMatrixThreadMentionReportsDisabledRegistry(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Notify.Matrix.ThreadCapture = true
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	responder := &thread.Responder{Forge: fakeThreadForge{}, Registry: &thread.Registry{}} // disabled: empty path
+	m := buildMatrixThreadMention(cfg, responder, nil, log)
+	if m != nil {
+		t.Fatal("must not wire the handler when the thread registry is disabled")
+	}
+	if !strings.Contains(buf.String(), "thread registry is unavailable") {
+		t.Fatalf("must name the disabled registry; got: %s", buf.String())
+	}
+}
+
+// TestBuildMatrixFeedbackNeitherOptionOnIsNil pins the compound top gate: with
+// BOTH notify.matrix.feedback_reactions and notify.matrix.thread_capture off,
+// no listener is built at all — same as before Task 8.
+func TestBuildMatrixFeedbackNeitherOptionOnIsNil(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Notify.Matrix = config.MatrixNotify{Homeserver: "https://matrix.example.org", RoomID: "!room:x", AccessTokenEnv: "T"}
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	mfb := BuildMatrixFeedback(cfg, ledger, nil, nil, nil, nil, nil, log)
+	if mfb != nil {
+		t.Fatal("neither option on must yield no listener")
+	}
+}
+
+// TestBuildMatrixFeedbackTokenEmptyDisables pins the unchanged runtime-empty
+// access-token guard, now covering both options (message must not go stale
+// once thread_capture can also request the listener).
+func TestBuildMatrixFeedbackTokenEmptyDisables(t *testing.T) {
+	t.Setenv("TEST_MATRIX_TOKEN_EMPTY", "")
+	cfg := &config.Config{}
+	cfg.Notify.Matrix = config.MatrixNotify{
+		Homeserver: "https://matrix.example.org", RoomID: "!room:x",
+		AccessTokenEnv: "TEST_MATRIX_TOKEN_EMPTY", FeedbackReactions: true,
+	}
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	mfb := BuildMatrixFeedback(cfg, ledger, nil, nil, nil, nil, nil, log)
+	if mfb != nil {
+		t.Fatal("an empty access token must disable the listener")
+	}
+	if !strings.Contains(buf.String(), "TEST_MATRIX_TOKEN_EMPTY") {
+		t.Fatalf("must name the empty env var; got: %s", buf.String())
+	}
+}
+
+// TestBuildMatrixFeedbackThreadCaptureWiresStandalone pins the Task 8 fix at
+// the top gate: the listener must build — and thread capture must wire — from
+// notify.matrix.thread_capture ALONE, with feedback_reactions off. Before this
+// wiring, BuildMatrixFeedback's top gate checked ONLY FeedbackReactions, so
+// thread_capture had no observable effect no matter what Task 6/7 built (see
+// task-6-report.md's "Concerns").
+func TestBuildMatrixFeedbackThreadCaptureWiresStandalone(t *testing.T) {
+	t.Setenv("TEST_MATRIX_TOKEN_STANDALONE", "matrix-token")
+	cfg := &config.Config{}
+	cfg.Notify.Matrix = config.MatrixNotify{
+		Homeserver: "https://matrix.example.org", RoomID: "!room:x",
+		AccessTokenEnv: "TEST_MATRIX_TOKEN_STANDALONE", ThreadCapture: true, // FeedbackReactions left false
+	}
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	responder := readyMatrixResponder(t)
+	dispatch := thread.NewDispatcher(4, time.Minute, log)
+	busyDispatch := thread.NewDispatcher(4, time.Minute, log)
+	notifier := notify.NewMulti(log, fakeMatrixReplier{})
+
+	mfb := BuildMatrixFeedback(cfg, ledger, responder, dispatch, busyDispatch, notifier, nil, log)
+	if mfb == nil {
+		t.Fatal("thread_capture alone (feedback_reactions off) must still build the listener")
+	}
+	if mfb.Mentions == nil || mfb.Dispatch == nil || mfb.BusyDispatch == nil {
+		t.Fatal("thread_capture on with a reachable registry, forge and replier must wire Mentions, Dispatch and BusyDispatch")
+	}
+	if !strings.Contains(buf.String(), "matrix thread capture enabled") {
+		t.Fatalf("must log that thread capture is enabled; got: %s", buf.String())
+	}
+}
+
+// TestBuildMatrixFeedbackThreadCaptureOffLeavesNeitherWired pins "supplying no
+// option must leave thread capture off": with thread_capture off (even with
+// everything else reachable), the built listener carries neither Mentions nor
+// Dispatch, exactly reproducing the pre-thread-capture listener.
+func TestBuildMatrixFeedbackThreadCaptureOffLeavesNeitherWired(t *testing.T) {
+	t.Setenv("TEST_MATRIX_TOKEN_OFF", "matrix-token")
+	cfg := &config.Config{}
+	cfg.Notify.Matrix = config.MatrixNotify{
+		Homeserver: "https://matrix.example.org", RoomID: "!room:x",
+		AccessTokenEnv: "TEST_MATRIX_TOKEN_OFF", FeedbackReactions: true, // thread_capture left false
+	}
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	responder := readyMatrixResponder(t)
+	dispatch := thread.NewDispatcher(4, time.Minute, log)
+	busyDispatch := thread.NewDispatcher(4, time.Minute, log)
+	notifier := notify.NewMulti(log, fakeMatrixReplier{})
+
+	mfb := BuildMatrixFeedback(cfg, ledger, responder, dispatch, busyDispatch, notifier, nil, log)
+	if mfb == nil {
+		t.Fatal("feedback_reactions on must still build the listener")
+	}
+	if mfb.Mentions != nil || mfb.Dispatch != nil || mfb.BusyDispatch != nil {
+		t.Fatal("thread_capture off must leave Mentions, Dispatch and BusyDispatch nil")
+	}
+}
+
+// TestBuildMatrixFeedbackDegradesWithoutReplier pins the no-panic degrade:
+// with thread_capture on but no notifier built at all (so no Matrix replier is
+// resolvable), the listener still builds (feedback_reactions covers that) but
+// leaves thread capture off and logs the specific cause — never panics.
+func TestBuildMatrixFeedbackDegradesWithoutReplier(t *testing.T) {
+	t.Setenv("TEST_MATRIX_TOKEN_NOREPLIER", "matrix-token")
+	cfg := &config.Config{}
+	cfg.Notify.Matrix = config.MatrixNotify{
+		Homeserver: "https://matrix.example.org", RoomID: "!room:x",
+		AccessTokenEnv: "TEST_MATRIX_TOKEN_NOREPLIER", FeedbackReactions: true, ThreadCapture: true,
+	}
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "ledger.jsonl"))
+	if err != nil {
+		t.Fatalf("outcome.New: %v", err)
+	}
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	responder := readyMatrixResponder(t)
+	dispatch := thread.NewDispatcher(4, time.Minute, log)
+	busyDispatch := thread.NewDispatcher(4, time.Minute, log)
+
+	// notifier is nil: no notifier built at all — the same "no replier resolvable"
+	// case BuildThreadMention's Slack analogue covers.
+	mfb := BuildMatrixFeedback(cfg, ledger, responder, dispatch, busyDispatch, nil, nil, log)
+	if mfb == nil {
+		t.Fatal("feedback_reactions on must still build the listener even when thread capture cannot wire")
+	}
+	if mfb.Mentions != nil || mfb.Dispatch != nil || mfb.BusyDispatch != nil {
+		t.Fatal("no resolvable Matrix replier must leave thread capture off")
+	}
+	if !strings.Contains(buf.String(), "no Matrix thread-capable notifier resolved") {
+		t.Fatalf("must log the specific cause; got: %s", buf.String())
 	}
 }

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/Smana/runlore/internal/source/grafana"      // self-registers the Grafana Alerting webhook source
 	"github.com/Smana/runlore/internal/source/pagerduty"
 	"github.com/Smana/runlore/internal/telemetry"
+	"github.com/Smana/runlore/internal/thread"
 	"github.com/Smana/runlore/internal/trigger"
 )
 
@@ -192,6 +193,23 @@ func RunServe(version string, args []string) error {
 	if err != nil {
 		return fmt.Errorf("thread registry: %w", err)
 	}
+	// One responder, two transports: built ONCE and shared by both Slack's and
+	// Matrix's thread-capture wiring below, so the per-hour OpenPRs budget
+	// (buildThreadResponder) bounds forge writes system-wide rather than once
+	// per transport. forge may be nil (no forge.kb_repo / credentials); the
+	// responder is still built so it stays the single shared instance either
+	// way — each transport's own guard reports the missing-forge case.
+	forge := buildForge(cfg, log)
+	threadResponder := buildThreadResponder(threadRegistry, forge, metrics, log)
+	// Matrix's detached mention handlers (one forge round-trip each), bounded
+	// and drained exactly like the Slack server's eventDispatcher — see
+	// matrixMentionConcurrency/matrixMentionTimeout. matrixBusyDispatch is the
+	// separate, smaller pool for "I'm too busy" replies when matrixDispatch is
+	// saturated — mirroring the Slack server's eventDispatcher/busyDispatcher
+	// split (internal/server/server.go) so telling a human about an overload
+	// never itself blocks the /sync goroutine.
+	matrixDispatch := thread.NewDispatcher(matrixMentionConcurrency, matrixMentionTimeout, log)
+	matrixBusyDispatch := thread.NewDispatcher(matrixBusyConcurrency, matrixMentionTimeout, log)
 	inv, cat, notifier, err := BuildInvestigator(ctx, cfg, deps, approvals, auto, metrics, ledger, threadRegistry, log)
 	if err != nil {
 		return fmt.Errorf("build investigator: %w", err)
@@ -343,10 +361,17 @@ func RunServe(version string, args []string) error {
 			log.Info("re-investigate poller enabled", "label", investigate.ReinvestigateLabel)
 			go reinv.Poll(workCtx, 2*time.Minute)
 		}
-		// Opt-in Matrix reaction listener — leader-only like the pollers above, so an
-		// HA deployment records each 👍/👎 exactly once, into the leader's ledger.
-		if mfb := BuildMatrixFeedback(cfg, ledger, log); mfb != nil {
-			log.Info("matrix feedback reactions enabled", "room", cfg.Notify.Matrix.RoomID)
+		// Opt-in Matrix listener (reactions and/or thread capture) — leader-only
+		// like the pollers above, so an HA deployment records each 👍/👎 exactly
+		// once, into the leader's ledger, and answers each mention exactly once.
+		// The "enabled" announcements are split so each only fires for the
+		// option that is actually on: BuildMatrixFeedback itself logs
+		// "matrix thread capture enabled" (see buildMatrixThreadMention) when
+		// that half wires successfully, so it must not be repeated here.
+		if mfb := BuildMatrixFeedback(cfg, ledger, threadResponder, matrixDispatch, matrixBusyDispatch, notifier, metrics, log); mfb != nil {
+			if cfg.Notify.Matrix.FeedbackReactions {
+				log.Info("matrix feedback reactions enabled", "room", cfg.Notify.Matrix.RoomID)
+			}
 			go mfb.Run(workCtx)
 		}
 		// In-server grooming sweeps (leader-only, like the pollers above, so one
@@ -422,7 +447,7 @@ func RunServe(version string, args []string) error {
 	// nowhere to write it — would be worse than not having one. See
 	// BuildThreadMention for why deliverability is checked before the notifier.
 	if cfg.Notify.Slack.ThreadCapture && threadRegistry.Enabled() {
-		acts.Threads = BuildThreadMention(cfg, threadRegistry, buildForge(cfg, log), notifier, metrics, log)
+		acts.Threads = BuildThreadMention(cfg, threadResponder, notifier, log)
 	}
 	// /readyz is process + catalog health, NOT leadership (#264): every warm
 	// replica reports Ready (so `helm upgrade --wait` / Flux kstatus succeeds
@@ -450,7 +475,7 @@ func RunServe(version string, args []string) error {
 	}
 	httpSrv := NewHTTPServer(*addr, srv.Handler())
 	// Graceful shutdown: on SIGTERM, stop accepting webhooks, let the in-flight
-	// investigation AND any detached Slack mention handler (see
+	// investigation AND any detached Slack or Matrix mention handler (see
 	// server.Server.Drain — handleSlackEvent acks and returns before its work is
 	// done, so httpSrv.Shutdown alone does not wait for it) finish within a
 	// bounded grace (lease still held), then release.
@@ -461,13 +486,20 @@ func RunServe(version string, args []string) error {
 		log.Info("shutdown: stopping intake; draining in-flight investigation")
 		_ = httpSrv.Shutdown(context.Background())
 		dctx, cancelDrain := context.WithTimeout(context.Background(), drainGracePeriod)
-		// Detached mention handlers first: they are a direct extension of the HTTP
-		// intake httpSrv.Shutdown just stopped, and — unlike the investigation
-		// queue — they do not depend on workCtx/the leader lease, so draining them
-		// has no ordering requirement relative to stopWork() below. Both drains
-		// share dctx's single deadline rather than getting drainGracePeriod each,
-		// so total shutdown time stays bounded the same way it always has.
+		// Detached mention handlers first: Slack's (srv.Drain) are a direct
+		// extension of the HTTP intake httpSrv.Shutdown just stopped; Matrix's
+		// (matrixDispatch.Drain, matrixBusyDispatch.Drain) are a direct extension
+		// of the /sync long-poll loop, whose dispatched work already runs on a
+		// context stripped of cancellation (thread.Dispatcher.Go), so it too
+		// survives independently of workCtx. None of these depend on
+		// workCtx/the leader lease — unlike the investigation queue — so
+		// draining them has no ordering requirement relative to stopWork()
+		// below. All four drains share dctx's single deadline rather than
+		// getting drainGracePeriod each, so total shutdown time stays bounded
+		// the same way it always has.
 		srv.Drain(dctx)
+		matrixDispatch.Drain(dctx)
+		matrixBusyDispatch.Drain(dctx)
 		queue.Drain(dctx)
 		cancelDrain()
 		stopWork() // release the leader lease + stop the queue/watch/coalescer

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -845,6 +845,15 @@ type MatrixNotify struct {
 	// OUTBOUND request authenticated by the access token above. Requires the three
 	// notifier fields and outcome.ledger_path; Validate fails loud otherwise.
 	FeedbackReactions bool `yaml:"feedback_reactions"`
+	// ThreadCapture (opt-in, default off) registers each delivered investigation's
+	// thread root so a later `@runlore note: …` reply in that thread can be
+	// attributed to it and written into the knowledge base. Like FeedbackReactions,
+	// nothing is exposed: mentions arrive over the same client-server /sync
+	// long-poll, authenticated by the access token above. Requires the three
+	// notifier fields (homeserver, room_id, access_token_env) and
+	// outcome.ledger_path — the thread registry lives beside the ledger and must
+	// survive a restart and a leader failover; Validate fails loud otherwise.
+	ThreadCapture bool `yaml:"thread_capture"`
 }
 
 // GitOps selects the GitOps engine RunLore reads (what-changed + failure watch).
@@ -1533,6 +1542,19 @@ func (c *Config) Validate() error {
 		}
 		if c.Outcome.LedgerPath == "" {
 			return fmt.Errorf("notify.matrix.feedback_reactions requires outcome.ledger_path: ratings are recorded in the outcome ledger")
+		}
+	}
+	// Same fail-loud contract for the Matrix thread-capture listener: without the
+	// notifier fields it would sync nothing, without the ledger the thread
+	// registry has nowhere durable to live — both silent lies to whoever enabled
+	// the option.
+	if c.Notify.Matrix.ThreadCapture {
+		m := c.Notify.Matrix
+		if m.Homeserver == "" || m.RoomID == "" || m.AccessTokenEnv == "" {
+			return fmt.Errorf("notify.matrix.thread_capture requires homeserver, room_id and access_token_env (the listener long-polls the configured room and authenticates as the bot)")
+		}
+		if c.Outcome.LedgerPath == "" {
+			return fmt.Errorf("notify.matrix.thread_capture requires outcome.ledger_path: the thread registry lives beside the ledger and must survive a restart and a leader failover, so without a ledger path there is nowhere durable to record which thread belongs to which investigation")
 		}
 	}
 	if g := c.Catalog.Git; g.URL != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -767,6 +767,65 @@ func TestValidateMatrixFeedbackReactions(t *testing.T) {
 	}
 }
 
+// TestValidateMatrixThreadCapture guards the opt-in contract of
+// notify.matrix.thread_capture: it requires the same notifier fields as
+// feedback_reactions (homeserver, room_id, access_token_env — the listener
+// long-polls the configured room and authenticates as the bot) plus
+// outcome.ledger_path, because the thread registry lives beside the ledger
+// and must survive a restart and a leader failover. Off (the default)
+// validates clean with none of it.
+func TestValidateMatrixThreadCapture(t *testing.T) {
+	base := func() *Config {
+		c := &Config{}
+		c.Notify.Matrix = MatrixNotify{
+			Homeserver:     "https://matrix.example.org",
+			RoomID:         "!r:example.org",
+			AccessTokenEnv: "MATRIX_TOKEN",
+			ThreadCapture:  true,
+		}
+		c.Outcome.LedgerPath = "/var/lib/runlore/outcomes.jsonl"
+		return c
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{"valid", func(*Config) {}, ""},
+		{"off needs nothing", func(c *Config) {
+			c.Notify.Matrix = MatrixNotify{ThreadCapture: false}
+		}, ""},
+		{"missing homeserver", func(c *Config) {
+			c.Notify.Matrix.Homeserver = ""
+		}, "homeserver"},
+		{"missing room_id", func(c *Config) {
+			c.Notify.Matrix.RoomID = ""
+		}, "room_id"},
+		{"missing access_token_env", func(c *Config) {
+			c.Notify.Matrix.AccessTokenEnv = ""
+		}, "access_token_env"},
+		{"missing ledger path", func(c *Config) {
+			c.Outcome.LedgerPath = ""
+		}, "ledger_path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := base()
+			tt.mutate(c)
+			err := c.Validate()
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("Validate() = %v, want nil", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("Validate() = nil, want an error mentioning %q", tt.wantErr)
+			case tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr):
+				t.Fatalf("Validate() = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestGitOpsMirrorConfig covers the gitops.mirror block: zero-value defaults to
 // enabled (the Rerank *bool idiom), an explicit false disables, and a negative
 // max is rejected by Validate.

--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -27,7 +27,11 @@ func init() {
 		Build: func(d Deps) (providers.Notifier, error) {
 			if mc := d.Cfg.Notify.Matrix; mc.Homeserver != "" && mc.RoomID != "" && mc.AccessTokenEnv != "" {
 				if tok := os.Getenv(mc.AccessTokenEnv); tok != "" {
-					return NewMatrix(mc.Homeserver, mc.RoomID, tok), nil
+					m := NewMatrix(mc.Homeserver, mc.RoomID, tok)
+					if mc.ThreadCapture {
+						m.Threads = d.Threads
+					}
+					return m, nil
 				}
 			}
 			return nil, nil
@@ -42,6 +46,11 @@ type Matrix struct {
 	token      string
 	http       *http.Client
 	txn        atomic.Int64
+
+	// Threads, when set (notify.matrix.thread_capture), receives the thread
+	// root of each delivered investigation, so a later reply can be
+	// attributed. nil (the default) disables thread capture.
+	Threads ThreadSink
 }
 
 // NewMatrix builds a Matrix notifier. homeserver is the base URL (e.g.
@@ -66,16 +75,50 @@ func NewMatrix(homeserver, roomID, token string) *Matrix {
 }
 
 var _ providers.Notifier = (*Matrix)(nil)
+var _ providers.ThreadNotifier = (*Matrix)(nil)
+
+// send posts content as an m.room.message event to room via the Matrix
+// client-server send API, handling the transaction id, auth header, and status
+// check shared by every event Matrix posts. It returns the event id the
+// homeserver assigned, or "" if the response body didn't decode to one — a
+// send that got a 2xx is still a success in that case; only the event id, used
+// to register a thread root or chain a reply, is unknown.
+func (m *Matrix) send(ctx context.Context, room string, content map[string]any) (string, error) {
+	txn := fmt.Sprintf("runlore-%d", m.txn.Add(1))
+	endpoint := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/send/m.room.message/%s",
+		m.homeserver, url.PathEscape(room), url.PathEscape(txn))
+
+	body, err := json.Marshal(content)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.token)
+	resp, err := m.http.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("matrix send: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return "", fmt.Errorf("matrix status %d", resp.StatusCode)
+	}
+
+	var sent struct {
+		EventID string `json:"event_id"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&sent)
+	return sent.EventID, nil
+}
 
 // Deliver sends the formatted investigation as an m.notice message. It carries
 // both a plaintext body (the fallback Matrix renders literally) and a rich
 // formatted_body (org.matrix.custom.html) so the message's mrkdwn renders as
 // bold/links/code instead of leaking raw *asterisks* to Matrix clients.
 func (m *Matrix) Deliver(ctx context.Context, inv providers.Investigation) error {
-	txn := fmt.Sprintf("runlore-%d", m.txn.Add(1))
-	endpoint := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/send/m.room.message/%s",
-		m.homeserver, url.PathEscape(m.roomID), url.PathEscape(txn))
-
 	msg := Format(inv)
 	content := map[string]any{
 		"msgtype":        "m.notice",
@@ -90,26 +133,48 @@ func (m *Matrix) Deliver(ctx context.Context, inv providers.Investigation) error
 	if key := cmp.Or(inv.TriggerKey, inv.Fingerprint); key != "" {
 		content[triggerKeyContentField] = key
 	}
-	body, err := json.Marshal(content)
+	// Stamp the thread context alongside it — additive, same rationale: inert
+	// data, unconditional, the eventual reply listener is the opt-in.
+	content[threadContentField] = stampFor(inv)
+
+	eventID, err := m.send(ctx, m.roomID, content)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+m.token)
-	resp, err := m.http.Do(req)
-	if err != nil {
-		return fmt.Errorf("matrix send: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("matrix status %d", resp.StatusCode)
+
+	// Registration is best-effort: a send that succeeded stays succeeded no
+	// matter what happens below. eventID is "" when the homeserver's response
+	// didn't decode to one, in which case the root just stays unregistered.
+	if m.Threads != nil && eventID != "" {
+		m.Threads.Register(m.Transport(), eventID, m.roomID, inv)
 	}
 	return nil
 }
+
+// ReplyInThread posts text as an m.notice reply into the Matrix thread rooted
+// at root (providers.ThreadNotifier), via the MSC3440 m.thread relation. Text
+// is plain — no formatted_body — because these are RunLore's own short
+// acknowledgements ("📝 Noted on…"), not investigation prose. It targets the
+// passed channel (room) when non-empty, falling back to the notifier's
+// configured room, mirroring SlackBot.ReplyInThread: a reply can only go where
+// the thread root it answers was sent.
+func (m *Matrix) ReplyInThread(ctx context.Context, root, channel, text string) error {
+	room := cmp.Or(channel, m.roomID)
+	content := map[string]any{
+		"msgtype": "m.notice",
+		"body":    text,
+		"m.relates_to": map[string]any{
+			"rel_type": "m.thread",
+			"event_id": root,
+		},
+	}
+	_, err := m.send(ctx, room, content)
+	return err
+}
+
+// Transport identifies this notifier's chat system (providers.ThreadNotifier),
+// the key Multi.ThreadRepliers scopes thread replies by.
+func (m *Matrix) Transport() string { return "matrix" }
 
 // boldRe / codeRe match the small mrkdwn subset that Format emits (plus inline
 // code for robustness): *bold* and `code`.  URL auto-linkification has been

--- a/internal/notify/matrix_feedback.go
+++ b/internal/notify/matrix_feedback.go
@@ -10,10 +10,15 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/telemetry"
+	"github.com/Smana/runlore/internal/thread"
 )
 
 // triggerKeyContentField is the custom event-content field Deliver stamps on
@@ -30,10 +35,16 @@ type FeedbackSink interface {
 	Feedback(triggerKey, rating, user string, at time.Time) error
 }
 
-// MatrixFeedback is the opt-in reaction listener
-// (notify.matrix.feedback_reactions): it long-polls the homeserver's /sync for
-// m.reaction events in the configured room and records 👍/👎 on RunLore's own
-// investigation messages into the outcome ledger.
+// MatrixFeedback is the opt-in Matrix listener backing two INDEPENDENT
+// capabilities, each gated by its own flag and its own functional option:
+// recording 👍/👎 reactions into the outcome ledger
+// (notify.matrix.feedback_reactions, WithFeedbackReactions) and capturing
+// addressed thread replies into the knowledge base
+// (notify.matrix.thread_capture, WithThreadCapture). One /sync long-poll
+// loop serves whichever of the two are on; the /sync filter itself is
+// narrowed to request only the event types the enabled capabilities actually
+// need (see sync) — a deployment that enabled thread capture alone must never
+// even ask the homeserver for reactions, let alone record one.
 //
 // Unlike the Slack feedback path, NOTHING is exposed: /sync is an outbound
 // HTTPS long-poll authenticated by the notifier's access token — no inbound
@@ -62,10 +73,88 @@ type MatrixFeedback struct {
 	// reference buttons the app itself posted); Matrix must enforce it explicitly.
 	self string
 
-	// keyByEvent caches target-event → trigger-key lookups so N reactions to the
-	// same message cost one fetch. Bounded crudely (reset past cap): the working
-	// set is "messages still being reacted to", a handful.
-	keyByEvent map[string]string
+	// selfDisplayName is the bot's own Matrix profile display name, resolved
+	// once via GET /_matrix/client/v3/profile/{userId}/displayname alongside
+	// /whoami at Run start (see fetchDisplayName). Empty when the homeserver
+	// has none set, the lookup failed, or Run has not resolved it yet — the
+	// lookup is deliberately NON-FATAL (see Run), so any of those just leaves
+	// stripSelfMention with one fewer candidate to match, exactly like
+	// before this field existed. It is a best-effort ENHANCEMENT to
+	// addressing, not the sole guard against a reserved command hiding
+	// behind an unstripped mention: a display name can still be missed
+	// entirely (changed after startup, a room-specific per-member override,
+	// a client that renders it differently) — see handleMessage's own
+	// backstop for the case this field cannot cover.
+	selfDisplayName string
+
+	// contextByEvent caches target-event → resolved thread.Context lookups
+	// (contextFor) so N reactions to the same message, or a reaction followed by
+	// a threaded reply to it, cost one fetch between them. Bounded crudely (reset
+	// past cap): the working set is "messages still being reacted to or replied
+	// to", a handful.
+	//
+	// Unsynchronised BY DESIGN, not oversight: today the only caller is the
+	// /sync loop goroutine — handleReaction, and handleMessage's contextFor call
+	// resolving the root BEFORE it dispatches the mention handler. Mention
+	// HANDLING itself runs on Dispatch's worker pool, but this lookup stays on
+	// the sync goroutine; if that ever changes, this map needs a mutex.
+	contextByEvent map[string]eventLookup
+
+	// feedbackReactions mirrors notify.matrix.feedback_reactions: only when true
+	// does sync's /sync filter carry m.reaction, and only then does
+	// handleReaction ever record one. Set via WithFeedbackReactions; false (the
+	// default) means a listener started for thread capture alone never asks the
+	// homeserver for reactions, and never records one even if a non-compliant
+	// homeserver sends one anyway — the same wire-vs-code-guarantee reasoning
+	// as threadCapture/handleMessage below.
+	feedbackReactions bool
+
+	// threadCapture mirrors notify.matrix.thread_capture: only when true does
+	// sync widen its /sync filter to also carry m.room.message, and only then
+	// does handleMessage ever run. Set via WithThreadCapture; false (the
+	// default) reproduces today's listener exactly.
+	threadCapture bool
+
+	// Mentions turns an addressed, RunLore-rooted thread message into a
+	// knowledge-base write and posts the reply back. nil unless WithThreadCapture
+	// was supplied.
+	Mentions *thread.Mention
+
+	// Dispatch runs Mentions.HandleMention detached from the sync goroutine: a
+	// note that opens a pull request costs several sequential forge round-trips,
+	// and doing that inline would stall /sync long-polling for minutes — pausing
+	// 👍/👎 recording and making the room look dead. nil unless WithThreadCapture
+	// was supplied.
+	Dispatch *thread.Dispatcher
+
+	// BusyDispatch runs Mentions.Busy detached from the sync goroutine too, under
+	// its own small, separate budget — mirroring the Slack transport's
+	// eventDispatcher/busyDispatcher split (internal/server/server.go). Busy
+	// performs a real HTTP POST (Mention.reply → Matrix.ReplyInThread); calling
+	// it inline from handleMessage would chain blocking network calls on the
+	// SAME sync goroutine that must keep long-polling, for every addressed
+	// message that arrives while Dispatch is saturated — up to the /sync
+	// filter's limit:50 events per batch. That reproduces exactly the "/sync
+	// stalls, feedback pauses" harm Dispatch's own detachment exists to
+	// prevent. Separate from Dispatch, and deliberately small: telling a human
+	// the mention pool is busy must never itself become the next unbounded
+	// liability. nil unless WithThreadCapture was supplied.
+	BusyDispatch *thread.Dispatcher
+
+	// metrics is the optional telemetry sink for
+	// MentionsDroppedOnSaturation — nil unless WithMetrics was supplied, and
+	// every use is nil-checked: a deployment with no telemetry provider
+	// configured must observe and reply to mentions exactly as it always did.
+	metrics *telemetry.Metrics
+}
+
+// eventLookup is one contextByEvent cache entry: the thread.Context resolved
+// from an event's content, and whether the event was one of RunLore's own
+// investigation messages (ok) — cached together so a miss (wrong sender, no
+// stamp) is not re-fetched on every subsequent reaction either.
+type eventLookup struct {
+	ctx thread.Context
+	ok  bool
 }
 
 // syncTimeout is the server-side long-poll hold; the HTTP client timeout must
@@ -75,21 +164,87 @@ const syncTimeout = 30 * time.Second
 // retryBackoff is the pause after a failed sync before re-polling.
 const retryBackoff = 5 * time.Second
 
-// keyByEventCap bounds the target-event cache (reset, not evicted — simplicity
-// over LRU for a cache whose working set is a handful of recent messages).
-const keyByEventCap = 256
+// eventCacheCap bounds contextByEvent (reset, not evicted — simplicity over
+// LRU for a cache whose working set is a handful of recent messages).
+const eventCacheCap = 256
 
-// NewMatrixFeedback builds the reaction listener. homeserver/roomID/token are
-// the notifier's own settings; sink is where ratings land (the outcome ledger).
-func NewMatrixFeedback(homeserver, roomID, token string, sink FeedbackSink, log *slog.Logger) *MatrixFeedback {
-	return &MatrixFeedback{
-		homeserver: strings.TrimRight(homeserver, "/"),
-		roomID:     roomID,
-		token:      token,
-		sink:       sink,
-		log:        log,
-		http:       httpx.SecureClient(syncTimeout + 15*time.Second),
-		keyByEvent: map[string]string{},
+// NewMatrixFeedback builds the Matrix listener. homeserver/roomID/token are
+// the notifier's own settings; sink is where ratings land (the outcome
+// ledger). Both CAPABILITIES default OFF: pass WithFeedbackReactions to
+// record 👍/👎 reactions, and/or WithThreadCapture to also opt into handling
+// addressed thread messages; WithMetrics is a plain optional dependency, not
+// a capability, and app.BuildMatrixFeedback supplies it unconditionally.
+//
+// A listener with NEITHER capability option requests neither event type over
+// /sync and processes nothing. That is not purely hypothetical: contrary to
+// an earlier version of this comment, app.BuildMatrixFeedback does not
+// always avoid it — when notify.matrix.thread_capture is the only capability
+// configured on and buildMatrixThreadMention degrades (no forge, no
+// persisted registry, no resolvable replier), BuildMatrixFeedback still
+// constructs a listener whose only option is WithMetrics, functionally
+// identical to the zero-capability listener this paragraph describes, just
+// with a non-empty opts slice. Its /sync loop still runs and still resolves
+// /whoami; it simply never receives an event worth acting on.
+func NewMatrixFeedback(homeserver, roomID, token string, sink FeedbackSink, log *slog.Logger, opts ...MatrixFeedbackOption) *MatrixFeedback {
+	f := &MatrixFeedback{
+		homeserver:     strings.TrimRight(homeserver, "/"),
+		roomID:         roomID,
+		token:          token,
+		sink:           sink,
+		log:            log,
+		http:           httpx.SecureClient(syncTimeout + 15*time.Second),
+		contextByEvent: map[string]eventLookup{},
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
+}
+
+// MatrixFeedbackOption configures optional MatrixFeedback behaviour beyond its
+// required delivery target and identity. The zero set of options reproduces
+// today's listener exactly.
+type MatrixFeedbackOption func(*MatrixFeedback)
+
+// WithFeedbackReactions turns on Matrix reaction feedback
+// (notify.matrix.feedback_reactions): the /sync filter carries m.reaction,
+// and Run's switch actually routes those events to handleReaction. Threaded
+// exactly like WithThreadCapture (see feedbackReactions): a listener started
+// for thread capture alone never asks the homeserver for reactions, and one
+// that was never given this option never records a reaction even if it
+// somehow received one.
+func WithFeedbackReactions() MatrixFeedbackOption {
+	return func(f *MatrixFeedback) {
+		f.feedbackReactions = true
+	}
+}
+
+// WithThreadCapture turns on Matrix thread capture
+// (notify.matrix.thread_capture): the /sync filter widens to also carry
+// m.room.message, and an addressed message rooted in one of RunLore's own
+// investigations is handed to mentions via dispatch — detached from the sync
+// goroutine, since a note that opens a pull request costs several sequential
+// forge round-trips. busyDispatch runs the "I'm too busy" reply under its own,
+// separate, smaller budget when dispatch is saturated — see BusyDispatch for
+// why it must never share dispatch's pool or run inline.
+func WithThreadCapture(mentions *thread.Mention, dispatch *thread.Dispatcher, busyDispatch *thread.Dispatcher) MatrixFeedbackOption {
+	return func(f *MatrixFeedback) {
+		f.threadCapture = true
+		f.Mentions = mentions
+		f.Dispatch = dispatch
+		f.BusyDispatch = busyDispatch
+	}
+}
+
+// WithMetrics wires the optional telemetry instrument set: today, solely
+// MentionsDroppedOnSaturation, incremented when Dispatch is saturated and an
+// addressed mention is unrecoverably lost (see handleMessage). m may be nil
+// (equivalent to not calling this option at all); every use inside
+// MatrixFeedback is nil-checked regardless, so a deployment with no
+// telemetry provider configured is unaffected either way.
+func WithMetrics(m *telemetry.Metrics) MatrixFeedbackOption {
+	return func(f *MatrixFeedback) {
+		f.metrics = m
 	}
 }
 
@@ -115,6 +270,18 @@ func (f *MatrixFeedback) Run(ctx context.Context) {
 		}
 		f.self = self
 	}
+	// Best-effort display-name resolution: an ENHANCEMENT to addressing (see
+	// selfDisplayName), never a new hard dependency. One attempt, no retry
+	// loop unlike whoami above — a homeserver that errors, times out, or has
+	// no display name set for the account must leave the listener exactly as
+	// functional as before this lookup existed, so this is logged at Debug,
+	// not Warn/Error, and never blocks or delays the sync loop below.
+	if dn, err := f.fetchDisplayName(ctx, f.self); err != nil {
+		f.log.Debug("matrix feedback: display name lookup failed; addressing falls back to MXID/localpart only", "err", err)
+	} else if dn != "" {
+		f.selfDisplayName = dn
+		f.log.Debug("matrix feedback: resolved own display name", "display_name", dn)
+	}
 	since := ""
 	for ctx.Err() == nil {
 		next, events, err := f.sync(ctx, since)
@@ -134,32 +301,66 @@ func (f *MatrixFeedback) Run(ctx context.Context) {
 		// (historical) events. Everything after is live.
 		if since != "" {
 			for _, e := range events {
-				f.handleReaction(ctx, e)
+				switch e.Type {
+				case "m.reaction":
+					f.handleReaction(ctx, e)
+				case "m.room.message":
+					f.handleMessage(ctx, e)
+				}
 			}
 		}
 		since = next
 	}
 }
 
-// matrixEvent is the subset of a timeline event the listener needs.
+// matrixEvent is the subset of a timeline event the listener needs — an
+// m.reaction (RelatesTo.Key names the emoji) or an m.room.message (Body,
+// Mentions, and either thread relation resolve whether, and where, to reply).
 type matrixEvent struct {
 	Type    string `json:"type"`
 	Sender  string `json:"sender"`
+	EventID string `json:"event_id"`
 	Content struct {
+		Body    string `json:"body"`
+		MsgType string `json:"msgtype"`
+		// Mentions is MSC3952's m.mentions: the authoritative "was RunLore
+		// addressed" signal when the client sends it.
+		Mentions struct {
+			UserIDs []string `json:"user_ids"`
+		} `json:"m.mentions"`
 		RelatesTo struct {
 			RelType string `json:"rel_type"`
 			EventID string `json:"event_id"`
 			Key     string `json:"key"`
+			// InReplyTo is the MSC3440 fallback: a plain reply (rel_type
+			// unset) or a thread client that also sends the immediate-parent
+			// fallback alongside rel_type m.thread.
+			InReplyTo struct {
+				EventID string `json:"event_id"`
+			} `json:"m.in_reply_to"`
 		} `json:"m.relates_to"`
 	} `json:"content"`
 }
 
 // sync performs one filtered /sync long-poll and returns the next batch token
-// plus the room's new timeline events. The inline filter narrows the response
-// to m.reaction events in the configured room — no presence, state, or other
-// rooms' traffic ever crosses the wire.
+// plus the room's new timeline events. The inline filter requests ONLY the
+// event types the enabled capabilities actually need — no presence, state, or
+// other rooms' traffic ever crosses the wire, and neither does an event type
+// belonging to a capability this listener was not opted into: m.reaction only
+// when feedbackReactions is on, m.room.message only when threadCapture is on.
+// A deployment that has not opted into a capability must keep receiving
+// exactly what it receives today for that capability — including "nothing",
+// so it never even asks the homeserver for events it would just discard.
 func (f *MatrixFeedback) sync(ctx context.Context, since string) (string, []matrixEvent, error) {
-	filter := fmt.Sprintf(`{"presence":{"types":[]},"account_data":{"types":[]},"room":{"rooms":[%q],"state":{"types":[]},"ephemeral":{"types":[]},"account_data":{"types":[]},"timeline":{"types":["m.reaction"],"limit":50}}}`, f.roomID)
+	var types []string
+	if f.feedbackReactions {
+		types = append(types, `"m.reaction"`)
+	}
+	if f.threadCapture {
+		types = append(types, `"m.room.message"`)
+	}
+	timelineTypes := "[" + strings.Join(types, ",") + "]"
+	filter := fmt.Sprintf(`{"presence":{"types":[]},"account_data":{"types":[]},"room":{"rooms":[%q],"state":{"types":[]},"ephemeral":{"types":[]},"account_data":{"types":[]},"timeline":{"types":%s,"limit":50}}}`, f.roomID, timelineTypes)
 	q := url.Values{"filter": {filter}, "timeout": {fmt.Sprintf("%d", syncTimeout.Milliseconds())}}
 	if since != "" {
 		q.Set("since", since)
@@ -204,6 +405,17 @@ func (f *MatrixFeedback) sync(ctx context.Context, since string) (string, []matr
 // target's content — a target without the field is not one of RunLore's
 // investigation messages and is skipped.
 func (f *MatrixFeedback) handleReaction(ctx context.Context, e matrixEvent) {
+	// Guard on the opt-in flag, not just the /sync filter that requests
+	// m.reaction only when it is set: that filter is a wire-level guarantee,
+	// not a code-level one, and a listener started for thread capture alone
+	// must never record a reaction even if a non-compliant homeserver sends
+	// one anyway. Deployments that enabled only notify.matrix.thread_capture
+	// must not silently also get 👍/👎 recording into the outcome ledger — a
+	// capability, and a learning-loop trust-weighting input, its operator
+	// never opted into.
+	if !f.feedbackReactions {
+		return
+	}
 	if e.Type != "m.reaction" || e.Content.RelatesTo.RelType != "m.annotation" {
 		return
 	}
@@ -231,6 +443,308 @@ func (f *MatrixFeedback) handleReaction(ctx context.Context, e matrixEvent) {
 		return
 	}
 	f.log.Info("matrix feedback recorded", "key", key, "rating", rating, "user", e.Sender)
+}
+
+// handleMessage reacts to one m.room.message event: when it addresses RunLore
+// and is rooted in one of RunLore's own investigation messages, the actual
+// knowledge-base write is handed to Dispatch — detached, because a note that
+// opens a pull request costs several sequential forge round-trips, and doing
+// that inline would stall this /sync long-poll for minutes, pausing 👍/👎
+// recording and making the room look dead. When Dispatch is saturated, the
+// "I'm too busy" reply is ALSO detached, through BusyDispatch's own separate,
+// smaller budget — never run inline here, or the same stall this function
+// exists to avoid would reappear one call later, for every addressed message
+// arriving in the same 50-event /sync batch.
+//
+// contextFor — the trust-anchored lookup deciding whether the root belongs to
+// RunLore — is resolved HERE, on the sync goroutine, before Dispatch ever
+// runs: its cache (contextByEvent) is deliberately unsynchronised, so calling
+// it from the dispatched closure would race with the next sync iteration's own
+// cache access. Its result is also handed to HandleMention as the
+// registry-miss fallback (see HandleMention's fallback parameter): the
+// thread.Registry can miss (TTL, the size cap, a leader failover onto a
+// replica without its JSONL) in cases where the root event's own stamp still
+// carries everything needed to answer the mention — the advantage a Matrix
+// event has over a Slack thread_ts, which carries nothing on its own.
+//
+// There is deliberately no transport-side backstop here for a reserved
+// command (e.g. "reinvestigate:") sitting behind a mention token
+// stripSelfMention could not identify and remove — an earlier version of
+// this function had one, gated on stripSelfMention's own success. That gate
+// was the bug: it only fired when stripping FAILED, so a message where
+// stripping SUCCEEDED but a filler word still separated the mention from the
+// command ("@runlore please reinvestigate: …" → stripped to "please
+// reinvestigate: …") sailed straight past it. The actual fix belongs in
+// thread.Parse itself — matching a reserved prefix as a whole, colon-anchored
+// token ANYWHERE in the text, not only at position 0 (see Parse's doc) — so
+// every caller of Responder.Handle is covered by construction, on both
+// transports, regardless of whether or how a mention token got stripped
+// first. That makes the old backstop here fully redundant, not merely
+// narrower: HandleMention below already routes every addressed message
+// through Parse via Responder.Handle, so the reserved-anywhere match applies
+// identically whether text still carries an unstripped mention token or not.
+func (f *MatrixFeedback) handleMessage(ctx context.Context, e matrixEvent) {
+	// Guard FIRST, before the self-guard below: the /sync filter only requests
+	// m.room.message when threadCapture is on (see sync), but that is a
+	// wire-level guarantee, not a code-level one — a non-compliant homeserver,
+	// or a future filter-construction regression, can still deliver one. Without
+	// this, a root that happens to resolve against RunLore's own history (very
+	// plausible: investigation messages persist in the room regardless of the
+	// option) would reach f.Dispatch.Go on a nil *thread.Dispatcher and panic,
+	// contradicting Run's own documented invariant that a flaky homeserver must
+	// never crash the agent.
+	if !f.threadCapture || f.Dispatch == nil || f.Mentions == nil || f.BusyDispatch == nil {
+		return
+	}
+	if e.Sender == f.self {
+		return // loop guard: never answer our own messages
+	}
+	if !f.addressed(e) {
+		return
+	}
+	root := threadRootOf(e)
+	if root == "" {
+		return
+	}
+	tc, ok, err := f.contextFor(ctx, root)
+	if err != nil {
+		f.log.Warn("matrix thread capture: root event lookup failed", "event_id", root, "err", err)
+		return
+	}
+	if !ok {
+		return // not rooted in one of RunLore's own investigation messages
+	}
+	channel, author := f.roomID, e.Sender
+	// stripped is unused beyond stripSelfMention's own doc contract (which text
+	// callers get, stripped or not): whether a reserved command sitting behind
+	// an unstripped mention token gets refused no longer depends on it — see
+	// this function's doc comment above for why that used to matter and no
+	// longer does. text always reaches Parse (via Responder.Handle, below)
+	// exactly as stripSelfMention returns it, stripped or not.
+	text, _ := stripSelfMention(e.Content.Body, f.self, f.selfDisplayName)
+	if f.Dispatch.Go(ctx, func(wctx context.Context) {
+		// tc is the context resolved HERE, on the sync goroutine, off the root
+		// event's own stamp — passed through as HandleMention's registry-miss
+		// fallback rather than re-resolved inside this closure. contextByEvent is
+		// deliberately unsynchronised (see its doc): only the sync goroutine may
+		// touch it, and this closure runs on Dispatch's worker pool.
+		f.Mentions.HandleMention(wctx, channel, root, author, text, &tc)
+	}) {
+		return
+	}
+	// Dispatch is saturated: the mention itself is unrecoverably lost.
+	// /sync's `since` will have advanced past this event by the time this
+	// batch finishes, so — unlike a queued retry — the homeserver never
+	// redelivers it. Error, not Warn, mirroring the Slack mention path
+	// (internal/server/server.go's own "mention dropped, handler pool
+	// saturated" log): this loss is permanent, for a feature whose entire
+	// premise is not losing the operator's knowledge.
+	f.log.Error("matrix thread capture: mention dropped, dispatcher saturated", "channel", channel, "root", root)
+	if f.metrics != nil {
+		f.metrics.MentionsDroppedOnSaturation.Add(ctx, 1)
+	}
+	// Telling the human is itself another network call
+	// (Mention.Busy → Matrix.ReplyInThread), so it gets the same treatment as
+	// the mention handler itself: run through BusyDispatch's own small budget,
+	// detached from this sync goroutine — never called inline here. If
+	// BusyDispatch is ALSO saturated, log and move on: this /sync loop must
+	// keep long-polling no matter what, at worst leaving one human with no
+	// "try again" notice this round.
+	if !f.BusyDispatch.Go(ctx, func(wctx context.Context) {
+		f.Mentions.Busy(wctx, channel, root)
+	}) {
+		f.log.Error("matrix thread capture: busy notice dropped, busy dispatcher saturated", "channel", channel, "root", root)
+	}
+}
+
+// addressed reports whether e addresses RunLore. MSC3952's m.mentions is
+// authoritative when a client sends it; clients that don't are matched by the
+// message body containing the bot's full MXID or its localpart (the
+// "runlore" in "@runlore:example.org") as a WHOLE WORD — see containsWord for
+// why a plain substring match is not enough. Both fallbacks apply the same
+// boundary rule: a full MXID is just as embeddable in a longer token (e.g.
+// "x@runlore:hs" or "@runlore:hs2") as a bare localpart is.
+func (f *MatrixFeedback) addressed(e matrixEvent) bool {
+	for _, id := range e.Content.Mentions.UserIDs {
+		if id == f.self {
+			return true
+		}
+	}
+	if f.self == "" {
+		return false
+	}
+	if containsWord(e.Content.Body, f.self) {
+		return true
+	}
+	lp := selfLocalpart(f.self)
+	return lp != "" && containsWord(e.Content.Body, lp)
+}
+
+// selfLocalpart returns a Matrix user id's localpart — "runlore" from
+// "@runlore:example.org" — used as addressed's body-match fallback.
+func selfLocalpart(mxid string) string {
+	mxid = strings.TrimPrefix(mxid, "@")
+	if i := strings.IndexByte(mxid, ':'); i >= 0 {
+		return mxid[:i]
+	}
+	return mxid
+}
+
+// containsWord reports whether body contains word bounded on both sides by a
+// non-word RUNE (anything that is not a Unicode letter, digit, or combining
+// mark — see isWordRune) or the start/end of body. A plain strings.Contains
+// would treat the localpart "sre" as addressing RunLore inside "misread", or
+// "ops" inside "oops" — not cosmetic, since thread.Responder.Handle treats an
+// unprefixed message (IntentFreeform) the same as an explicit "note:", so a
+// false positive here can open or comment on a real knowledge-base PR
+// containing text nobody intended to record.
+func containsWord(body, word string) bool {
+	if word == "" {
+		return false
+	}
+	for i := 0; i+len(word) <= len(body); i++ {
+		if body[i:i+len(word)] != word {
+			continue
+		}
+		if i > 0 {
+			if r, _ := utf8.DecodeLastRuneInString(body[:i]); isWordRune(r) {
+				continue
+			}
+		}
+		if j := i + len(word); j < len(body) {
+			if r, _ := utf8.DecodeRuneInString(body[j:]); isWordRune(r) {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// isWordRune reports whether r is a Unicode letter, digit, or combining
+// mark — the boundary condition containsWord and stripSelfMention both
+// require immediately before and/or after a match. RUNE-aware, not
+// byte-aware: the byte-only predicate this replaced (isAlphanumericByte,
+// ASCII a-z/A-Z/0-9 only) never recognised a UTF-8 CONTINUATION byte as
+// alphanumeric, because a continuation byte in isolation never is — so a
+// non-ASCII letter or digit sitting immediately next to a match (e.g.
+// "runlore" inside "runloreé", or next to a fullwidth digit) was silently
+// treated as a word boundary, a false positive containsWord's own doc warns
+// can write unintended text into the knowledge base.
+// DecodeLastRuneInString/DecodeRuneInString decode the one full rune
+// adjacent to the match instead of a single byte of it; utf8.RuneError (an
+// empty string, or invalid encoding) is neither a letter, digit, nor mark,
+// so it is correctly treated as a boundary like any other non-word
+// character.
+//
+// unicode.IsMark(r) — true for the Mn/Mc/Me categories — covers a residual
+// gap IsLetter/IsDigit alone leave open: an NFC (precomposed) accented
+// letter like 'é' (U+00E9) is one rune and IsLetter already reports true for
+// it, but an NFD (decomposed) accent is TWO runes — the base letter followed
+// by a standalone COMBINING mark such as U+0301 COMBINING ACUTE ACCENT — and
+// a combining mark on its own is neither a letter nor a digit. A combining
+// mark does not start a new character; it continues the grapheme of the
+// rune immediately before it. So without IsMark here, matching "runlore"
+// against NFD "runloré" (== "runlore" + U+0301) would decode that trailing
+// U+0301 as the neighbour rune, find it is neither a letter nor a digit, and
+// misread the middle of a single accented character as a word boundary —
+// the exact same false-positive class the rune-awareness above fixed for
+// NFC, just one normalization form later. Real Matrix clients send NFD in
+// practice (it's the default output of macOS input methods), so this is not
+// a hypothetical input shape.
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r)
+}
+
+// selfMentionPrefixes returns the leading-mention tokens stripSelfMention
+// matches against, longest first: self's full MXID with the "@" sigil, the
+// full MXID without it, "@"+localpart, the bare localpart, and — when known —
+// the resolved display name. Longest-first matters — for self "@runlore:hs"
+// the bare localpart "runlore" is itself a prefix of the full MXID, so trying
+// it before the full-MXID candidates would strip only "runlore" and leave
+// ":hs" sitting in front of the command; sorting by length rather than
+// hand-ordering also keeps this correct regardless of how displayName's
+// length happens to compare to the MXID/localpart candidates.
+func selfMentionPrefixes(self, displayName string) []string {
+	lp := selfLocalpart(self)
+	mxid := strings.TrimPrefix(self, "@")
+	var out []string
+	if mxid != "" {
+		out = append(out, "@"+mxid, mxid)
+	}
+	if lp != "" {
+		out = append(out, "@"+lp, lp)
+	}
+	if displayName != "" {
+		out = append(out, displayName)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return len(out[i]) > len(out[j]) })
+	return out
+}
+
+// stripSelfMention removes ONE leading token addressing RunLore from a Matrix
+// message body — a bare MXID ("@runlore:hs"), a localpart alone ("runlore"),
+// the resolved display name when one is known, or any of those immediately
+// followed by ":" or "," — before thread.Parse ever sees the text. The second
+// return reports whether a token was actually found and removed: false means
+// body is returned completely unchanged, which callers use to tell "the
+// mention really wasn't there in a form we recognise" apart from "we
+// recognised and stripped it, and what's left just happens to look the same"
+// (impossible here, since a match always consumes at least one byte, but the
+// bool makes that guarantee explicit rather than inferred by callers
+// re-deriving it from string equality).
+//
+// This exists because thread.Parse strips only Slack's "<@U…>" mention
+// encoding, which real Matrix clients never send: a client puts a bare MXID,
+// a localpart, or a display name directly in body instead. Without stripping
+// it here, the mention token sits in front of "note:"/"reinvestigate:" and
+// Parse's prefix match never fires — every addressed message falls through to
+// IntentFreeform, silently including the RESERVED "reinvestigate:" prefix
+// (see thread.IntentReinvestigate's doc), with the mention text still
+// embedded in what gets written to the knowledge base.
+//
+// Matching is case-insensitive and whole-token only (the same rune-aware
+// boundary rule as containsWord/addressed — see isWordRune): "runlore" must
+// not strip the front of a longer word like "runlored" or "runloreé". A
+// client-configured DISPLAY NAME unrelated to the localpart (e.g. an
+// operator-set "Ops Bot") is stripped only when
+// displayName carries it — MatrixFeedback.Run resolves it once via a
+// best-effort profile lookup (see fetchDisplayName/selfDisplayName); pass ""
+// when it is unknown. Even then, a display name can still go unrecognised
+// (never resolved, changed after startup, a room-specific per-member
+// override) — handleMessage's own backstop covers that residual case rather
+// than this function trying to. A display name that happens to equal the
+// localpart case-insensitively — the common case, since Matrix's own
+// suggested display name IS the localpart — is stripped regardless, via the
+// bare-localpart candidate.
+func stripSelfMention(body, self, displayName string) (string, bool) {
+	body = strings.TrimSpace(body)
+	for _, cand := range selfMentionPrefixes(self, displayName) {
+		if cand == "" || len(body) < len(cand) || !strings.EqualFold(body[:len(cand)], cand) {
+			continue
+		}
+		rest := body[len(cand):]
+		if rest != "" {
+			if r, _ := utf8.DecodeRuneInString(rest); isWordRune(r) {
+				continue // not a whole-token match — e.g. "runlored" must not strip as "runlore"
+			}
+		}
+		return strings.TrimSpace(strings.TrimLeft(rest, ":,")), true
+	}
+	return body, false
+}
+
+// threadRootOf resolves e's thread root: an m.thread relation's event_id names
+// the root directly (MSC3440), so a reply nested anywhere in the thread still
+// resolves to the same root. Otherwise the m.in_reply_to fallback names the
+// immediate parent, which for a fallback-only (non-threaded) reply IS the
+// root. "" means e carries no thread relation at all.
+func threadRootOf(e matrixEvent) string {
+	rel := e.Content.RelatesTo
+	if rel.RelType == "m.thread" && rel.EventID != "" {
+		return rel.EventID
+	}
+	return rel.InReplyTo.EventID
 }
 
 // whoami resolves the access token's own user id — the sender every legitimate
@@ -261,20 +775,14 @@ func (f *MatrixFeedback) whoami(ctx context.Context) (string, error) {
 	return res.UserID, nil
 }
 
-// triggerKeyFor fetches the reaction's target event and returns its embedded
-// trigger identity ("" when absent, when the target was NOT sent by the bot
-// itself — a room member could otherwise stamp the field onto their own message
-// and misdirect votes — or for one of ours from before the field existed).
-// Cached per event id.
-func (f *MatrixFeedback) triggerKeyFor(ctx context.Context, eventID string) (string, error) {
-	if eventID == "" {
-		return "", nil
-	}
-	if key, ok := f.keyByEvent[eventID]; ok {
-		return key, nil
-	}
-	endpoint := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/event/%s",
-		f.homeserver, url.PathEscape(f.roomID), url.PathEscape(eventID))
+// fetchDisplayName resolves userID's Matrix profile display name via
+// GET /_matrix/client/v3/profile/{userId}/displayname. A 404 is a VALID
+// answer, not a failure: per the Client-Server spec (and every homeserver
+// implementation checked — Synapse, Dendrite), an account with no display
+// name set responds 404 M_NOT_FOUND rather than 200 with an empty field, so
+// it is reported here as ("", nil) rather than an error a caller would log.
+func (f *MatrixFeedback) fetchDisplayName(ctx context.Context, userID string) (string, error) {
+	endpoint := f.homeserver + "/_matrix/client/v3/profile/" + url.PathEscape(userID) + "/displayname"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return "", err
@@ -285,23 +793,92 @@ func (f *MatrixFeedback) triggerKeyFor(ctx context.Context, eventID string) (str
 		return "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil // no display name set for this account
+	}
 	if resp.StatusCode/100 != 2 {
-		return "", fmt.Errorf("matrix event fetch status %d", resp.StatusCode)
+		return "", fmt.Errorf("matrix displayname status %d", resp.StatusCode)
+	}
+	var res struct {
+		DisplayName string `json:"displayname"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&res); err != nil {
+		return "", err
+	}
+	return res.DisplayName, nil
+}
+
+// fetchEvent fetches one event by id from the configured room and returns its
+// sender and raw content — the single HTTP call shared by contextFor (and,
+// through it, triggerKeyFor).
+func (f *MatrixFeedback) fetchEvent(ctx context.Context, eventID string) (sender string, content map[string]any, err error) {
+	endpoint := fmt.Sprintf("%s/_matrix/client/v3/rooms/%s/event/%s",
+		f.homeserver, url.PathEscape(f.roomID), url.PathEscape(eventID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+f.token)
+	resp, err := f.http.Do(req)
+	if err != nil {
+		return "", nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return "", nil, fmt.Errorf("matrix event fetch status %d", resp.StatusCode)
 	}
 	var ev struct {
 		Sender  string         `json:"sender"`
 		Content map[string]any `json:"content"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&ev); err != nil {
+		return "", nil, err
+	}
+	return ev.Sender, ev.Content, nil
+}
+
+// contextFor fetches eventID and rebuilds the thread.Context RunLore stamped
+// on it. The second return is false when the event is not one of RunLore's
+// own investigation messages: no recognised field in its content (unstamped,
+// or one of ours from before the field existed), or — the trust anchor —
+// sent by anyone OTHER than the bot itself. Without that check, any room
+// member could stamp io.runlore.thread (or the legacy io.runlore.trigger_key)
+// onto their own message and redirect where a human's note gets written;
+// Slack has no equivalent hole (interaction payloads only ever reference
+// content the app itself posted), so Matrix must enforce it explicitly.
+//
+// Results are cached per event id; see contextByEvent for the cache's
+// concurrency contract.
+func (f *MatrixFeedback) contextFor(ctx context.Context, eventID string) (thread.Context, bool, error) {
+	if eventID == "" {
+		return thread.Context{}, false, nil
+	}
+	if cached, hit := f.contextByEvent[eventID]; hit {
+		return cached.ctx, cached.ok, nil
+	}
+	sender, content, err := f.fetchEvent(ctx, eventID)
+	if err != nil {
+		return thread.Context{}, false, err
+	}
+	tc, ok := contextFromContent(content, eventID, f.roomID)
+	if sender != f.self {
+		tc, ok = thread.Context{}, false // not our message: whatever it claims attributes nothing
+	}
+	if len(f.contextByEvent) >= eventCacheCap {
+		f.contextByEvent = map[string]eventLookup{} // crude bound; the live working set is tiny
+	}
+	f.contextByEvent[eventID] = eventLookup{ctx: tc, ok: ok}
+	return tc, ok, nil
+}
+
+// triggerKeyFor returns the trigger identity embedded in eventID's event, or
+// "" when contextFor found none (absent, or not sent by the bot — see
+// contextFor for the trust anchor this enforces). Built on the identical
+// fetch, self-check and cache contextFor uses.
+func (f *MatrixFeedback) triggerKeyFor(ctx context.Context, eventID string) (string, error) {
+	tc, ok, err := f.contextFor(ctx, eventID)
+	if err != nil || !ok {
 		return "", err
 	}
-	key, _ := ev.Content[triggerKeyContentField].(string)
-	if ev.Sender != f.self {
-		key = "" // not our message: whatever the field claims, it attributes nothing
-	}
-	if len(f.keyByEvent) >= keyByEventCap {
-		f.keyByEvent = map[string]string{} // crude bound; the live working set is tiny
-	}
-	f.keyByEvent[eventID] = key
-	return key, nil
+	return tc.TriggerKey, nil
 }

--- a/internal/notify/matrix_feedback_test.go
+++ b/internal/notify/matrix_feedback_test.go
@@ -10,10 +10,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
 )
 
 // recordSink collects Feedback calls and signals doneAt when the expected
@@ -45,6 +49,11 @@ func reactionJSON(sender, target, key string) string {
 // a 👍 (variation selector included), a 👎, a foreign emoji, and a reaction to a
 // message without the trigger field — only the two votes reach the sink, with
 // the Matrix user ids as identities. ctx cancellation stops Run.
+//
+// Constructs the listener WithFeedbackReactions: Fix 4 made reaction
+// recording its own opt-in (mirroring WithThreadCapture) rather than the
+// zero-options default, so this pre-existing test needs that option to keep
+// exercising what it always meant to.
 func TestMatrixFeedbackRun(t *testing.T) {
 	const room = "!r:hs"
 	sink := &recordSink{doneAt: 2, done: make(chan struct{})}
@@ -55,6 +64,10 @@ func TestMatrixFeedbackRun(t *testing.T) {
 		switch {
 		case r.URL.Path == "/_matrix/client/v3/account/whoami":
 			_ = json.NewEncoder(w).Encode(map[string]string{"user_id": "@runlore:hs"})
+		case strings.HasSuffix(r.URL.Path, "/displayname"):
+			// Run's non-fatal display-name lookup: 404 is the spec-accurate
+			// "no display name set" response, not exercised further by this test.
+			w.WriteHeader(http.StatusNotFound)
 		case strings.HasPrefix(r.URL.Path, "/_matrix/client/v3/sync"):
 			mu.Lock()
 			syncCalls++
@@ -108,7 +121,7 @@ func TestMatrixFeedbackRun(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewMatrixFeedback(srv.URL, room, "tok", sink, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	f := NewMatrixFeedback(srv.URL, room, "tok", sink, slog.New(slog.NewTextHandler(io.Discard, nil)), WithFeedbackReactions())
 	ctx, cancel := context.WithCancel(context.Background())
 	stopped := make(chan struct{})
 	go func() { f.Run(ctx); close(stopped) }()
@@ -133,8 +146,126 @@ func TestMatrixFeedbackRun(t *testing.T) {
 	}
 }
 
+// TestMatrixSyncFilterNarrowsToEnabledCapabilities pins Fix 4's wire-level
+// half: the /sync filter requests ONLY the event types the capabilities
+// actually enabled on this listener need — m.reaction only with
+// WithFeedbackReactions, m.room.message only with WithThreadCapture. A
+// listener started for one capability alone must never even ASK the
+// homeserver for the other's events. Covers all four flag combinations
+// (neither is exercised here at the wire level only — app.BuildMatrixFeedback
+// is what guarantees a listener is never actually started with neither on).
+func TestMatrixSyncFilterNarrowsToEnabledCapabilities(t *testing.T) {
+	const room = "!r:hs"
+	log := matrixTestLog()
+
+	tests := []struct {
+		name       string
+		reactions  bool
+		thread     bool
+		wantReact  bool
+		wantThread bool
+	}{
+		{name: "neither enabled: filter requests nothing"},
+		{name: "reactions only", reactions: true, wantReact: true},
+		{name: "thread capture only", thread: true, wantThread: true},
+		{name: "both enabled", reactions: true, thread: true, wantReact: true, wantThread: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotFilter string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotFilter = r.URL.Query().Get("filter")
+				_, _ = fmt.Fprintf(w, `{"next_batch":"s1","rooms":{}}`)
+			}))
+			defer srv.Close()
+
+			var opts []MatrixFeedbackOption
+			if tc.reactions {
+				opts = append(opts, WithFeedbackReactions())
+			}
+			if tc.thread {
+				opts = append(opts, WithThreadCapture(&thread.Mention{}, thread.NewDispatcher(1, time.Minute, log), thread.NewDispatcher(1, time.Minute, log)))
+			}
+			f := NewMatrixFeedback(srv.URL, room, "tok", nil, log, opts...)
+			if _, _, err := f.sync(context.Background(), ""); err != nil {
+				t.Fatalf("sync: %v", err)
+			}
+
+			if got := strings.Contains(gotFilter, "m.reaction"); got != tc.wantReact {
+				t.Errorf("filter carries m.reaction = %v, want %v: %s", got, tc.wantReact, gotFilter)
+			}
+			if got := strings.Contains(gotFilter, "m.room.message"); got != tc.wantThread {
+				t.Errorf("filter carries m.room.message = %v, want %v: %s", got, tc.wantThread, gotFilter)
+			}
+		})
+	}
+}
+
+// TestMatrixHandleReactionGatedByFlag pins Fix 4's code-level half: even a
+// well-formed m.reaction event must be recorded ONLY when feedbackReactions
+// is on — a listener started for thread capture alone (or with neither
+// capability, defence in depth beyond the /sync filter narrowing) must never
+// route a reaction into the outcome ledger, an opt-in its operator never
+// granted and one that feeds the learning loop's trust weighting.
+func TestMatrixHandleReactionGatedByFlag(t *testing.T) {
+	const room = "!r:hs"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"sender": "@runlore:hs",
+			"content": map[string]any{triggerKeyContentField: "trig-1"}})
+	}))
+	defer srv.Close()
+
+	reaction := func() matrixEvent {
+		e := matrixEvent{Type: "m.reaction", Sender: "@alice:hs"}
+		e.Content.RelatesTo.RelType = "m.annotation"
+		e.Content.RelatesTo.EventID = "$msg1"
+		e.Content.RelatesTo.Key = "👍"
+		return e
+	}
+
+	tests := []struct {
+		name      string
+		opts      []MatrixFeedbackOption
+		wantCount int
+	}{
+		{name: "neither capability on: not recorded", wantCount: 0},
+		{name: "feedback_reactions only: recorded", opts: []MatrixFeedbackOption{WithFeedbackReactions()}, wantCount: 1},
+		{
+			name:      "thread_capture only, reactions off: not recorded",
+			opts:      []MatrixFeedbackOption{WithThreadCapture(&thread.Mention{}, thread.NewDispatcher(1, time.Minute, matrixTestLog()), thread.NewDispatcher(1, time.Minute, matrixTestLog()))},
+			wantCount: 0,
+		},
+		{
+			name: "both capabilities on: recorded",
+			opts: []MatrixFeedbackOption{
+				WithFeedbackReactions(),
+				WithThreadCapture(&thread.Mention{}, thread.NewDispatcher(1, time.Minute, matrixTestLog()), thread.NewDispatcher(1, time.Minute, matrixTestLog())),
+			},
+			wantCount: 1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &recordSink{}
+			f := NewMatrixFeedback(srv.URL, room, "tok", sink, matrixTestLog(), tc.opts...)
+			f.self = "@runlore:hs"
+
+			f.handleReaction(context.Background(), reaction())
+
+			sink.mu.Lock()
+			got := len(sink.got)
+			sink.mu.Unlock()
+			if got != tc.wantCount {
+				t.Errorf("recorded %d reactions, want %d", got, tc.wantCount)
+			}
+		})
+	}
+}
+
 // TestMatrixFeedbackSyncErrorRetries: a failing homeserver is logged and
 // retried, never fatal — Run keeps polling and records once the server heals.
+// Constructs the listener WithFeedbackReactions — see TestMatrixFeedbackRun's
+// doc for why this pre-existing test needed that option after Fix 4.
 func TestMatrixFeedbackSyncErrorRetries(t *testing.T) {
 	const room = "!r:hs"
 	sink := &recordSink{doneAt: 1, done: make(chan struct{})}
@@ -143,6 +274,13 @@ func TestMatrixFeedbackSyncErrorRetries(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/_matrix/client/v3/account/whoami" {
 			_ = json.NewEncoder(w).Encode(map[string]string{"user_id": "@runlore:hs"})
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/displayname") {
+			// Run's non-fatal display-name lookup: 404 is the spec-accurate "no
+			// display name set" response, kept out of the `calls` counter below,
+			// which counts /sync attempts specifically.
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		if strings.HasPrefix(r.URL.Path, "/_matrix/client/v3/rooms/") {
@@ -166,7 +304,7 @@ func TestMatrixFeedbackSyncErrorRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := NewMatrixFeedback(srv.URL, room, "tok", sink, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	f := NewMatrixFeedback(srv.URL, room, "tok", sink, slog.New(slog.NewTextHandler(io.Discard, nil)), WithFeedbackReactions())
 	// Shrink the retry pause for the test via a tiny wrapper: not configurable by
 	// design (operators shouldn't tune it), so just tolerate the one 5s backoff.
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -176,5 +314,858 @@ func TestMatrixFeedbackSyncErrorRetries(t *testing.T) {
 	case <-sink.done:
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for recovery after a transient sync failure")
+	}
+}
+
+// TestMatrixFetchDisplayName pins fetchDisplayName's three outcomes: a
+// resolved name, the spec-accurate 404 "no display name set" (a valid answer,
+// not an error — see the function's own doc), and a genuine homeserver
+// failure. Run's own non-fatal wiring around this call is exercised
+// end-to-end by TestMatrixFeedbackRun and TestMatrixFeedbackSyncErrorRetries,
+// both of which serve 404 here and still complete their /sync work
+// unaffected.
+func TestMatrixFetchDisplayName(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantName   string
+		wantErr    bool
+		wantErrStr string
+	}{
+		{name: "resolved", status: http.StatusOK, body: `{"displayname":"Ops Bot"}`, wantName: "Ops Bot"},
+		{name: "404: no display name set is a valid answer, not an error", status: http.StatusNotFound, wantName: ""},
+		{name: "homeserver failure", status: http.StatusInternalServerError, wantErr: true, wantErrStr: "matrix displayname status 500"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got := r.URL.Path; got != "/_matrix/client/v3/profile/@runlore:hs/displayname" {
+					t.Errorf("unexpected path %s", got)
+				}
+				w.WriteHeader(tc.status)
+				if tc.body != "" {
+					_, _ = w.Write([]byte(tc.body))
+				}
+			}))
+			defer srv.Close()
+
+			f := NewMatrixFeedback(srv.URL, "!r:hs", "tok", nil, matrixTestLog())
+			got, err := f.fetchDisplayName(context.Background(), "@runlore:hs")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("fetchDisplayName: want an error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrStr) {
+					t.Errorf("err = %q, want it to contain %q", err.Error(), tc.wantErrStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("fetchDisplayName: %v", err)
+			}
+			if got != tc.wantName {
+				t.Errorf("displayName = %q, want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestMatrixContextFor pins contextFor against the four cases that matter: a
+// stamped event sent by the bot, the identical stamp sent by somebody else
+// (the trust anchor: it must attribute nothing), a legacy trigger-key-only
+// event, and an unstamped event. triggerKeyFor is exercised against the same
+// fixtures to prove it is unchanged — same fetch, same self-check, same
+// cache, now shared through contextFor.
+func TestMatrixContextFor(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+
+	responses := map[string]string{
+		"$evt1": fmt.Sprintf(`{"sender":%q,"content":{%q:{"trigger_key":"tk-1","title":"OOMKilled","resource":"prod/api","verdict":"action_required","curated_url":"https://x/pr/1","dup_fingerprint":"fp1","recalled_entry":"catalog/oom.md"}}}`,
+			self, threadContentField),
+		"$evt2": fmt.Sprintf(`{"sender":"@eve:hs","content":{%q:{"trigger_key":"victim-trigger"}}}`, threadContentField),
+		"$evt3": fmt.Sprintf(`{"sender":%q,"content":{%q:"tk-legacy"}}`, self, triggerKeyContentField),
+		"$evt4": fmt.Sprintf(`{"sender":%q,"content":{"body":"a human reply, no stamp"}}`, self),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for id, body := range responses {
+			if strings.HasSuffix(r.URL.Path, "/event/"+id) {
+				_, _ = w.Write([]byte(body))
+				return
+			}
+		}
+		t.Fatalf("unexpected event fetch: %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name        string
+		eventID     string
+		wantCtx     thread.Context
+		wantOK      bool
+		wantTrigKey string
+	}{
+		{
+			name:    "stamped and sent by the bot",
+			eventID: "$evt1",
+			wantCtx: thread.Context{
+				Transport: "matrix", Root: "$evt1", Channel: room,
+				TriggerKey: "tk-1", DupFingerprint: "fp1", Title: "OOMKilled",
+				Resource: "prod/api", Verdict: providers.VerdictActionRequired,
+				CuratedURL: "https://x/pr/1", RecalledEntry: "catalog/oom.md",
+			},
+			wantOK:      true,
+			wantTrigKey: "tk-1",
+		},
+		{
+			name:        "stamped but sent by somebody else must attribute nothing",
+			eventID:     "$evt2",
+			wantCtx:     thread.Context{},
+			wantOK:      false,
+			wantTrigKey: "",
+		},
+		{
+			name:    "legacy trigger-key-only event",
+			eventID: "$evt3",
+			wantCtx: thread.Context{
+				Transport: "matrix", Root: "$evt3", Channel: room, TriggerKey: "tk-legacy",
+			},
+			wantOK:      true,
+			wantTrigKey: "tk-legacy",
+		},
+		{
+			name:        "unstamped event",
+			eventID:     "$evt4",
+			wantCtx:     thread.Context{},
+			wantOK:      false,
+			wantTrigKey: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := NewMatrixFeedback(srv.URL, room, "tok", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			f.self = self
+
+			gotCtx, gotOK, err := f.contextFor(context.Background(), tc.eventID)
+			if err != nil {
+				t.Fatalf("contextFor: %v", err)
+			}
+			if gotOK != tc.wantOK {
+				t.Errorf("contextFor ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotCtx != tc.wantCtx {
+				t.Errorf("contextFor = %+v, want %+v", gotCtx, tc.wantCtx)
+			}
+
+			// A fresh instance (fresh cache) so this exercises the fetch path too,
+			// not a cache hit left over from the contextFor call above.
+			g := NewMatrixFeedback(srv.URL, room, "tok", nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			g.self = self
+			gotKey, err := g.triggerKeyFor(context.Background(), tc.eventID)
+			if err != nil {
+				t.Fatalf("triggerKeyFor: %v", err)
+			}
+			if gotKey != tc.wantTrigKey {
+				t.Errorf("triggerKeyFor = %q, want %q", gotKey, tc.wantTrigKey)
+			}
+		})
+	}
+}
+
+// fakeMentionReplier is thread.Replier: it records every reply so
+// handleMessage's dispatch can be observed without a live forge or a real
+// Matrix homeserver reply endpoint. doneAt/done let a test wait for the
+// detached work to finish deterministically, never by sleeping.
+type fakeMentionReplier struct {
+	mu     sync.Mutex
+	calls  []mentionReply
+	doneAt int
+	done   chan struct{}
+}
+
+// mentionReply is one recorded ReplyInThread call.
+type mentionReply struct{ root, channel, text string }
+
+func (f *fakeMentionReplier) ReplyInThread(_ context.Context, root, channel, text string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, mentionReply{root: root, channel: channel, text: text})
+	if f.done != nil && len(f.calls) == f.doneAt {
+		close(f.done)
+	}
+	return nil
+}
+
+func (f *fakeMentionReplier) snapshot() []mentionReply {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]mentionReply(nil), f.calls...)
+}
+
+// matrixThreadCaptureServer serves the two root events handleMessage's
+// contextFor gate needs: $root-ours (stamped, sent by self — one of RunLore's
+// own investigation messages) and $root-foreign (identically stamped, but sent
+// by somebody else — the trust anchor contextFor must reject). Any other path
+// fails the test loudly rather than hanging, matching TestMatrixContextFor's
+// convention.
+func matrixThreadCaptureServer(t *testing.T, self string) *httptest.Server {
+	t.Helper()
+	responses := map[string]string{
+		"$root-ours":    fmt.Sprintf(`{"sender":%q,"content":{%q:"trig-ours"}}`, self, triggerKeyContentField),
+		"$root-foreign": fmt.Sprintf(`{"sender":"@eve:hs","content":{%q:"trig-foreign"}}`, triggerKeyContentField),
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for id, body := range responses {
+			if strings.HasSuffix(r.URL.Path, "/event/"+id) {
+				_, _ = w.Write([]byte(body))
+				return
+			}
+		}
+		t.Fatalf("unexpected event fetch: %s", r.URL.Path)
+	}))
+}
+
+// newTestMatrixHandler builds a MatrixFeedback wired for handleMessage tests:
+// self is set directly (Run normally resolves it via /whoami). Mentions'
+// Registry is nil (disabled) — every dispatched mention therefore resolves
+// its thread.Context from handleMessage's event-stamp fallback (Fix 3), the
+// same "registry miss" path a leader failover or a TTL expiry hits in
+// production. The Responder's Forge is a no-op-succeeding fake purely so that
+// fallback write completes without erroring; these tests still assert only
+// routing (root/channel), not what the Forge records — that stays thread
+// package's own Responder/Forge coverage. busyDispatch defaults to a roomy
+// standalone dispatcher when nil, so callers that don't care about
+// busy-notice behaviour don't have to construct one.
+func newTestMatrixHandler(t *testing.T, srv *httptest.Server, room, self string, dispatch, busyDispatch *thread.Dispatcher, rep *fakeMentionReplier) *MatrixFeedback {
+	t.Helper()
+	log := matrixTestLog()
+	if busyDispatch == nil {
+		busyDispatch = thread.NewDispatcher(4, time.Minute, log)
+	}
+	responder := &thread.Responder{Forge: &fakeReinvestigateForge{}, Log: log}
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, log, WithThreadCapture(&thread.Mention{Responder: responder, Replier: rep, Log: log}, dispatch, busyDispatch))
+	f.self = self
+	return f
+}
+
+// TestMatrixHandleMessage pins handleMessage's routing: which addressed,
+// threaded messages get dispatched to the mention handler (with the thread
+// ROOT, never the reply's own event id), and which are dropped before ever
+// reaching Dispatch. Bodies use a realistic bare-MXID Matrix shape
+// ("@runlore:hs note: …"), not Slack's "<@U…>" encoding — a real Matrix
+// client never sends the latter, and stripSelfMention is what makes this
+// shape parse at all (see matrix_grammar_test.go for the grammar coverage
+// itself; these assertions only check routing, not intent classification).
+func TestMatrixHandleMessage(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+
+	t.Run("threaded message mentioning the bot dispatches with the root event id", func(t *testing.T) {
+		rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+		f := newTestMatrixHandler(t, srv, room, self, thread.NewDispatcher(4, time.Minute, matrixTestLog()), nil, rep)
+		e := matrixEvent{Sender: "@alice:hs", EventID: "$reply1"}
+		e.Content.Body = "@runlore:hs note: it was a bad deploy"
+		e.Content.Mentions.UserIDs = []string{self}
+		e.Content.RelatesTo.RelType = "m.thread"
+		e.Content.RelatesTo.EventID = "$root-ours"
+
+		f.handleMessage(context.Background(), e)
+		waitForReplies(t, rep)
+
+		if got := rep.snapshot(); len(got) != 1 || got[0].root != "$root-ours" || got[0].channel != room {
+			t.Fatalf("replies = %+v, want one reply rooted at $root-ours/%s", got, room)
+		}
+	})
+
+	t.Run("reply-fallback message resolves its root the same way", func(t *testing.T) {
+		rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+		f := newTestMatrixHandler(t, srv, room, self, thread.NewDispatcher(4, time.Minute, matrixTestLog()), nil, rep)
+		e := matrixEvent{Sender: "@alice:hs", EventID: "$reply2"}
+		// No m.mentions: addressed via the body containing the bot's localpart —
+		// the fallback for clients that don't send MSC3952 mentions.
+		e.Content.Body = "runlore note: it was a bad deploy"
+		e.Content.RelatesTo.InReplyTo.EventID = "$root-ours"
+
+		f.handleMessage(context.Background(), e)
+		waitForReplies(t, rep)
+
+		if got := rep.snapshot(); len(got) != 1 || got[0].root != "$root-ours" {
+			t.Fatalf("replies = %+v, want one reply rooted at $root-ours", got)
+		}
+	})
+
+	notDispatched := []struct {
+		name string
+		e    func() matrixEvent
+	}{
+		{
+			name: "message not mentioning the bot dispatches nothing",
+			e: func() matrixEvent {
+				e := matrixEvent{Sender: "@alice:hs", EventID: "$reply3"}
+				e.Content.Body = "just chatting, no mention here"
+				e.Content.RelatesTo.RelType = "m.thread"
+				e.Content.RelatesTo.EventID = "$root-ours"
+				return e
+			},
+		},
+		{
+			name: "message from the bot itself dispatches nothing",
+			e: func() matrixEvent {
+				e := matrixEvent{Sender: self, EventID: "$reply4"}
+				e.Content.Body = "@runlore:hs note: talking to myself"
+				e.Content.Mentions.UserIDs = []string{self}
+				e.Content.RelatesTo.RelType = "m.thread"
+				e.Content.RelatesTo.EventID = "$root-ours"
+				return e
+			},
+		},
+		{
+			name: "message with no thread relation dispatches nothing",
+			e: func() matrixEvent {
+				e := matrixEvent{Sender: "@alice:hs", EventID: "$reply5"}
+				e.Content.Body = "@runlore:hs note: floating message"
+				e.Content.Mentions.UserIDs = []string{self}
+				return e
+			},
+		},
+		{
+			name: "message whose root is not one of RunLore's dispatches nothing",
+			e: func() matrixEvent {
+				e := matrixEvent{Sender: "@alice:hs", EventID: "$reply6"}
+				e.Content.Body = "@runlore:hs note: not really ours"
+				e.Content.Mentions.UserIDs = []string{self}
+				e.Content.RelatesTo.RelType = "m.thread"
+				e.Content.RelatesTo.EventID = "$root-foreign"
+				return e
+			},
+		},
+	}
+	for _, tc := range notDispatched {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := &fakeMentionReplier{}
+			d := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+			f := newTestMatrixHandler(t, srv, room, self, d, nil, rep)
+
+			f.handleMessage(context.Background(), tc.e())
+			// Drain blocks until any in-flight dispatched work finishes; with
+			// nothing dispatched it returns immediately — deterministic either
+			// way, never a sleep.
+			d.Drain(context.Background())
+
+			if got := rep.snapshot(); len(got) != 0 {
+				t.Fatalf("replies = %+v, want none dispatched", got)
+			}
+		})
+	}
+}
+
+// TestMatrixHandleMessageRegistryMissFallsBackToEventStamp is the end-to-end
+// regression test for Fix 3, at the Matrix transport level: with the thread
+// registry enabled but missing this specific root — standing in for a miss
+// (TTL expiry, the 2000-entry size cap, or a leader failover onto a replica
+// whose registry JSONL had not yet caught up; see
+// internal/app.BuildThreadRegistry) — a note in a thread rooted at one of
+// RunLore's own investigation messages must still be recorded, using the
+// context handleMessage already resolved off the root event's own stamp
+// (contextFor), rather than refused with "I don't have context for this
+// thread" even though the event carries everything needed to answer it.
+//
+// The registry is deliberately ENABLED (a real, empty backing file), not
+// disabled: since thread.Mention.HandleMention now rehydrates a registry miss
+// via Registry.GetOrCreate (see internal/thread/mention.go), a genuinely
+// DISABLED registry (empty path) hits ErrThreadNotEstablishable and refuses
+// by design — that is pinned separately by
+// TestMentionFallbackOnDisabledRegistryDoesNotWriteWithZeroValueContext in
+// internal/thread. This test's whole premise is the miss-on-an-otherwise-live-
+// registry path, so it must exercise that path, not the disabled one.
+func TestMatrixHandleMessageRegistryMissFallsBackToEventStamp(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+
+	reg, err := thread.NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10) // enabled, but no entry for this root: a genuine miss
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	forge := &fakeReinvestigateForge{}
+	responder := &thread.Responder{Forge: forge, Registry: reg, Log: matrixTestLog()}
+	rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+	mention := &thread.Mention{Responder: responder, Registry: reg, Replier: rep, Log: matrixTestLog()}
+
+	dispatch := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	busy := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, matrixTestLog(), WithThreadCapture(mention, dispatch, busy))
+	f.self = self
+
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply-fallback"}
+	e.Content.Body = "@runlore:hs note: the real cause was a spot-node reclaim"
+	e.Content.Mentions.UserIDs = []string{self}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours"
+
+	f.handleMessage(context.Background(), e)
+	waitForReplies(t, rep)
+
+	got := rep.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("replies = %+v, want exactly one", got)
+	}
+	if strings.Contains(strings.ToLower(got[0].text), "don't have context") {
+		t.Fatalf("reply = %q, want the note recorded via the event-stamp fallback, not refused", got[0].text)
+	}
+	if opened, _ := forge.counts(); opened != 1 {
+		t.Fatalf("forge.opened = %d, want 1 — the note must still land in the knowledge base via the fallback context", opened)
+	}
+}
+
+// TestMatrixAddressedLocalpartBoundary pins Fix 3: the localpart fallback
+// (the "runlore" in "@runlore:example.org") must only match as a whole word —
+// a plain strings.Contains treats "sre" as addressing RunLore inside
+// "misread", or "ops" inside "oops". This matters beyond cosmetics: a false
+// positive here still hands the message to thread.Responder.Handle, and any
+// ordinary prose that happens to start with "note:" — never intended for
+// RunLore at all — would then be recorded to the knowledge base exactly as
+// if it had been genuinely addressed (Responder.Handle no longer treats bare
+// IntentFreeform as a write, but it cannot tell an accidental match from a
+// deliberate one once addressed() has already said yes).
+func TestMatrixAddressedLocalpartBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		self string
+		e    matrixEvent
+		want bool
+	}{
+		{
+			name: "exact mention via m.mentions.user_ids (primary path, unchanged)",
+			self: "@runlore:hs",
+			e: func() matrixEvent {
+				e := matrixEvent{}
+				e.Content.Body = "unrelated text"
+				e.Content.Mentions.UserIDs = []string{"@runlore:hs"}
+				return e
+			}(),
+			want: true,
+		},
+		{
+			name: "localpart as a whole word",
+			self: "@sre:hs",
+			e: func() matrixEvent {
+				e := matrixEvent{}
+				e.Content.Body = "hey sre, can you look at this"
+				return e
+			}(),
+			want: true,
+		},
+		{
+			name: "localpart embedded in a larger word must NOT match",
+			self: "@sre:hs",
+			e: func() matrixEvent {
+				e := matrixEvent{}
+				e.Content.Body = "this alert was misread by the pager"
+				return e
+			}(),
+			want: false,
+		},
+		{
+			name: "localpart at the very start of the body",
+			self: "@sre:hs",
+			e: func() matrixEvent {
+				e := matrixEvent{}
+				e.Content.Body = "sre please take a look"
+				return e
+			}(),
+			want: true,
+		},
+		{
+			name: "localpart at the very end of the body",
+			self: "@sre:hs",
+			e: func() matrixEvent {
+				e := matrixEvent{}
+				e.Content.Body = "please take a look sre"
+				return e
+			}(),
+			want: true,
+		},
+		{
+			name: "empty localpart never matches",
+			self: "@:hs", // selfLocalpart("@:hs") == ""
+			e: func() matrixEvent {
+				e := matrixEvent{}
+				e.Content.Body = "hs is mentioned here but there is no localpart to match"
+				return e
+			}(),
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &MatrixFeedback{self: tc.self}
+			if got := f.addressed(tc.e); got != tc.want {
+				t.Errorf("addressed(%+v) = %v, want %v", tc.e.Content.Body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMatrixAddressedFullMXIDBoundary is the companion of
+// TestMatrixAddressedLocalpartBoundary above: Fix 3 added the word-boundary
+// rule to the localpart fallback but left the full-MXID fallback
+// (e.Content.Body containing f.self verbatim) on a plain strings.Contains, so
+// "@runlore:hs" still matched embedded inside a longer token like
+// "x@runlore:hs" or "@runlore:hs2" — the exact false-positive class Fix 3 was
+// meant to close, just on the other fallback path.
+//
+// self is deliberately "@:hs" — an EMPTY localpart — throughout this table,
+// not a normal id like "@runlore:hs". With a real localpart, self's own
+// literal text always embeds "@localpart:" as a substring, and localpart's
+// immediate neighbours ('@' before, ':' after) are non-alphanumeric BY
+// CONSTRUCTION — so the (already boundary-checked, per Fix 3) localpart
+// fallback would independently return true for every case below regardless
+// of whether the full-MXID path is fixed, masking exactly the bug this test
+// exists to catch. An empty localpart makes `lp != "" && …` short-circuit
+// false, isolating the full-MXID fallback as the only path that can return
+// true — the same isolation trick TestMatrixAddressedLocalpartBoundary's own
+// "empty localpart never matches" case relies on, in reverse.
+func TestMatrixAddressedFullMXIDBoundary(t *testing.T) {
+	const self = "@:hs"
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "full MXID as a whole token", body: "hey @:hs can you take a look", want: true},
+		{name: "full MXID embedded in a larger token (preceded) must NOT match", body: "please cc x@:hs on this", want: false},
+		{name: "full MXID embedded in a larger token (followed) must NOT match", body: "reaches @:hstail instead", want: false},
+		{name: "full MXID at the very start of the body", body: "@:hs please look", want: true},
+		{name: "full MXID at the very end of the body", body: "please look @:hs", want: true},
+		{name: "full MXID as the entire body", body: "@:hs", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := matrixEvent{}
+			e.Content.Body = tc.body
+			f := &MatrixFeedback{self: self}
+			if got := f.addressed(e); got != tc.want {
+				t.Errorf("addressed(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContainsWordRuneBoundary pins containsWord's boundary check as
+// RUNE-aware, not byte-aware. The pre-fix check read one BYTE adjacent to a
+// match and asked whether it was ASCII-alphanumeric: a UTF-8 continuation
+// byte from a non-ASCII letter or digit is never ASCII-alphanumeric by that
+// test, so a match like "runlore" inside "runloré blah" was wrongly treated
+// as bounded — body[7] is 0xC3, the first byte of 'é', which
+// isAlphanumericByte reports as false, so containsWord returned true. That
+// is a false POSITIVE: an unaddressed message treated as addressing RunLore,
+// which — per containsWord's own doc — can open or comment on a real
+// knowledge-base PR containing text nobody intended to record. This table
+// exercises both sides of the match (a non-ASCII rune immediately before,
+// and immediately after) plus a non-ASCII DIGIT case distinct from the
+// letter cases: unicode.IsDigit and unicode.IsLetter are separate
+// predicates (U+FF13 FULLWIDTH DIGIT THREE is a digit but not a letter), so
+// a fix that checked only IsLetter would still misclassify it as a
+// boundary.
+func TestContainsWordRuneBoundary(t *testing.T) {
+	const word = "runlore"
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "non-ASCII letter immediately after the match is not a boundary (the bug)",
+			body: "runloreé blah", // "runlore" immediately followed by 'é', not "runlore" with its 'e' replaced
+			want: false,
+		},
+		{
+			name: "non-ASCII letter immediately before the match is not a boundary",
+			body: "érunlore blah",
+			want: false,
+		},
+		{
+			name: "non-ASCII digit immediately after the match is not a boundary",
+			body: "runlore３ blah", // U+FF13 FULLWIDTH DIGIT THREE: IsDigit true, IsLetter false
+			want: false,
+		},
+		{
+			name: "non-ASCII digit immediately before the match is not a boundary",
+			body: "３runlore blah",
+			want: false,
+		},
+		{
+			name: "punctuation neighbour is still a boundary — must still match",
+			body: "runlore, please look",
+			want: true,
+		},
+		{
+			name: "existing ASCII case is unaffected — must still not match",
+			body: "runlored note: x",
+			want: false,
+		},
+		{
+			name: "word alone",
+			body: "runlore",
+			want: true,
+		},
+		{
+			name: "word at the very start of the body",
+			body: "runlore please",
+			want: true,
+		},
+		{
+			name: "word at the very end of the body",
+			body: "please look runlore",
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containsWord(tc.body, word); got != tc.want {
+				t.Errorf("containsWord(%q, %q) = %v, want %v", tc.body, word, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContainsWordCombiningMarkBoundary pins the residual gap
+// TestContainsWordRuneBoundary's fix left open: it made the boundary check
+// RUNE-aware, which correctly rejects NFC (precomposed) "é" — a single rune,
+// U+00E9, that unicode.IsLetter reports true for. It does NOT, by itself,
+// reject NFD (decomposed) "é": 'e' (U+0065) followed by U+0301 COMBINING
+// ACUTE ACCENT as two separate runes. Matching "runlore" against NFD
+// "runloré" stops right after the plain 'e', and the next rune is the
+// combining mark alone — neither a letter nor a digit — so the pre-fix
+// predicate misread it as a boundary and treated the accented word
+// "runloré" as the bare word "runlore". Real Matrix clients send NFD in
+// practice (it's the default output of macOS input methods), so this is not
+// exotic. A combining mark continues the PRECEDING grapheme rather than
+// starting a new character, so it must count as word-forming too.
+func TestContainsWordCombiningMarkBoundary(t *testing.T) {
+	const word = "runlore"
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "NFD combining acute accent immediately after the match is not a boundary",
+			body: "runloré blah", // 'e' + U+0301 spells NFD "runloré", not "runlore"
+			want: false,
+		},
+		{
+			name: "NFC precomposed é immediately after the match is still not a boundary (regression guard)",
+			body: "runloreé blah", // "runlore" + U+00E9 as one extra rune, the case TestContainsWordRuneBoundary already pins
+			want: false,
+		},
+		{
+			name: "punctuation neighbour is still a boundary — must still match",
+			body: "runlore, please look",
+			want: true,
+		},
+		{
+			name: "word alone",
+			body: "runlore",
+			want: true,
+		},
+		{
+			name: "word at the very start of the body",
+			body: "runlore please",
+			want: true,
+		},
+		{
+			name: "word at the very end of the body",
+			body: "please look runlore",
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containsWord(tc.body, word); got != tc.want {
+				t.Errorf("containsWord(%q, %q) = %v, want %v", tc.body, word, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMatrixHandleMessageCaptureOffReturnsQuietly pins Fix 2: an m.room.message
+// event reaching handleMessage while thread capture is off (threadCapture
+// false, Dispatch and Mentions nil) must return quietly rather than
+// dereference a nil *thread.Dispatcher. A non-compliant homeserver — or a
+// future filter-construction regression — can deliver m.room.message even
+// though the /sync filter never asked for it, and if its thread root happens
+// to resolve against RunLore's own history (very plausible: investigation
+// messages persist in the room regardless of the option), the pre-fix code
+// panics. Run's own documented invariant is "a flaky homeserver must never
+// crash the agent; at worst feedback pauses."
+func TestMatrixHandleMessageCaptureOffReturnsQuietly(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+
+	// No WithThreadCapture supplied: threadCapture is false, Dispatch and
+	// Mentions are both nil — exactly the state of a deployment that never
+	// opted in to notify.matrix.thread_capture.
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, matrixTestLog())
+	f.self = self
+
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply9"}
+	e.Content.Body = "<@runlore:hs> note: this must not panic"
+	e.Content.Mentions.UserIDs = []string{self}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours" // resolves against RunLore's own history
+
+	f.handleMessage(context.Background(), e) // must return quietly, not panic
+}
+
+// TestMatrixHandleMessageBusyOnSaturation: when Dispatch has no free slot,
+// handleMessage must tell the human to retry rather than drop the message
+// silently — the same contract the Slack mention path uses. The Busy notice
+// itself runs through the separate BusyDispatch (Fix 1), so this waits on the
+// reply landing rather than draining the (still occupied) main Dispatch.
+func TestMatrixHandleMessageBusyOnSaturation(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+
+	rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+	d := thread.NewDispatcher(1, time.Minute, matrixTestLog())
+	busy := thread.NewDispatcher(1, time.Minute, matrixTestLog())
+	block, running := make(chan struct{}), make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(running); <-block }) {
+		t.Fatal("first Go refused with a free slot")
+	}
+	<-running // the one slot is now occupied
+
+	f := newTestMatrixHandler(t, srv, room, self, d, busy, rep)
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply7"}
+	e.Content.Body = "<@runlore:hs> note: please record this"
+	e.Content.Mentions.UserIDs = []string{self}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours"
+
+	f.handleMessage(context.Background(), e)
+	waitForReplies(t, rep)
+	close(block)
+	d.Drain(context.Background())
+	busy.Drain(context.Background())
+
+	got := rep.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("replies = %+v, want exactly one Busy notice", got)
+	}
+	if got[0].root != "$root-ours" || got[0].channel != room {
+		t.Errorf("Busy reply = %+v, want root $root-ours channel %s", got[0], room)
+	}
+	if !strings.Contains(strings.ToLower(got[0].text), "too many messages") {
+		t.Errorf("Busy reply text = %q, want it to explain the saturation", got[0].text)
+	}
+}
+
+// blockingReplier wraps a fakeMentionReplier and blocks inside ReplyInThread
+// until the test releases it, signalling entered the first time it is called.
+// It lets a test prove a call happened off some OTHER goroutine (by observing
+// entered fire while the caller has already returned) rather than inline.
+type blockingReplier struct {
+	inner   *fakeMentionReplier
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingReplier) ReplyInThread(ctx context.Context, root, channel, text string) error {
+	b.once.Do(func() { close(b.entered) })
+	<-b.release
+	return b.inner.ReplyInThread(ctx, root, channel, text)
+}
+
+// TestMatrixHandleMessageBusyRunsDetached pins Fix 1: when Dispatch is
+// saturated, handleMessage must hand the "I'm too busy" reply to BusyDispatch
+// rather than call Mentions.Busy (a real HTTP POST) inline. It proves this by
+// making the Busy reply's own network call block, then asserting
+// handleMessage still RETURNS well before that call unblocks — the whole
+// point being that a burst of addressed messages (the /sync filter allows
+// limit:50 per batch) must never chain blocking network calls on the sync
+// goroutine, or /sync stalls and 👍/👎 recording pauses right along with it.
+func TestMatrixHandleMessageBusyRunsDetached(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+	log := matrixTestLog()
+
+	// Saturate the main dispatcher so handleMessage takes the Busy path.
+	mainDispatch := thread.NewDispatcher(1, time.Minute, log)
+	blockMain, runningMain := make(chan struct{}), make(chan struct{})
+	if !mainDispatch.Go(context.Background(), func(context.Context) { close(runningMain); <-blockMain }) {
+		t.Fatal("first Go refused with a free slot")
+	}
+	<-runningMain
+
+	rep := &fakeMentionReplier{}
+	blocking := &blockingReplier{inner: rep, entered: make(chan struct{}), release: make(chan struct{})}
+	busyDispatch := thread.NewDispatcher(1, time.Minute, log)
+
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, log,
+		WithThreadCapture(&thread.Mention{Replier: blocking, Log: log}, mainDispatch, busyDispatch))
+	f.self = self
+
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply8"}
+	e.Content.Body = "<@runlore:hs> note: please record this"
+	e.Content.Mentions.UserIDs = []string{self}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours"
+
+	returned := make(chan struct{})
+	go func() {
+		f.handleMessage(context.Background(), e)
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleMessage blocked instead of dispatching the Busy reply off the sync goroutine")
+	}
+
+	// handleMessage already returned; now confirm the Busy reply actually ran
+	// (on BusyDispatch's own goroutine), then let it finish.
+	select {
+	case <-blocking.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Busy notice was never dispatched")
+	}
+	close(blocking.release)
+	close(blockMain)
+	busyDispatch.Drain(context.Background())
+	mainDispatch.Drain(context.Background())
+
+	if got := rep.snapshot(); len(got) != 1 {
+		t.Fatalf("replies = %+v, want exactly one Busy notice", got)
+	}
+}
+
+// matrixTestLog is a discard logger shared by handleMessage tests.
+func matrixTestLog() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// waitForReplies blocks until rep's doneAt-th reply lands, or fails the test
+// after a bound — the dispatched work runs on another goroutine, so waiting on
+// a channel the fake closes is the only deterministic way to observe it
+// finish.
+func waitForReplies(t *testing.T, rep *fakeMentionReplier) {
+	t.Helper()
+	select {
+	case <-rep.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the dispatched mention handler to reply")
 	}
 }

--- a/internal/notify/matrix_grammar_test.go
+++ b/internal/notify/matrix_grammar_test.go
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+// TestMatrixMentionGrammar pins Fix 1: thread.Parse strips only Slack's
+// "<@U…>" mention encoding. Real Matrix clients never send that shape — the
+// body carries a bare MXID, a localpart, or a display name instead — so
+// without stripping the mention Matrix-side FIRST, the mention token sits in
+// front of "note:"/"reinvestigate:" and every addressed message falls
+// through to IntentFreeform with the mention still attached.
+//
+// Deliberately NOT in the "<@runlore:hs> note: …" fixture style the rest of
+// this package's tests use for handleMessage routing: that shape is exactly
+// what real Matrix clients never produce, which is why the defect this test
+// pins was invisible before.
+func TestMatrixMentionGrammar(t *testing.T) {
+	const self = "@runlore:hs"
+	tests := []struct {
+		name       string
+		body       string
+		wantIntent thread.Intent
+		wantText   string
+	}{
+		// bare MXID
+		{"bare MXID + note", "@runlore:hs note: it was a bad deploy", thread.IntentNote, "it was a bad deploy"},
+		{"bare MXID + reinvestigate", "@runlore:hs reinvestigate: go look again", thread.IntentReinvestigate, "go look again"},
+		{"bare MXID + neither", "@runlore:hs is anyone around?", thread.IntentFreeform, "is anyone around?"},
+		// localpart only
+		{"localpart + note", "runlore note: it was a bad deploy", thread.IntentNote, "it was a bad deploy"},
+		{"localpart + reinvestigate", "runlore reinvestigate: go look again", thread.IntentReinvestigate, "go look again"},
+		{"localpart + neither", "runlore is anyone around?", thread.IntentFreeform, "is anyone around?"},
+		// display name that happens to match the localpart case-insensitively
+		// (Matrix's own suggested display name IS the localpart, so this is the
+		// common case, not a corner case)
+		{"display name + note", "RunLore: note: it was a bad deploy", thread.IntentNote, "it was a bad deploy"},
+		{"display name + reinvestigate", "RunLore: reinvestigate: go look again", thread.IntentReinvestigate, "go look again"},
+		{"display name + neither", "RunLore: is anyone around?", thread.IntentFreeform, "is anyone around?"},
+		// leading comma variant: TrimLeft(rest, ":,") applies to this shape too.
+		{"bare MXID + comma + note", "@runlore:hs, note: it was a bad deploy", thread.IntentNote, "it was a bad deploy"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			text, _ := stripSelfMention(tc.body, self, "")
+			got := thread.Parse(text)
+			if got.Intent != tc.wantIntent {
+				t.Errorf("Intent = %v, want %v (body %q)", got.Intent, tc.wantIntent, tc.body)
+			}
+			if got.Text != tc.wantText {
+				t.Errorf("Text = %q, want %q (body %q)", got.Text, tc.wantText, tc.body)
+			}
+		})
+	}
+}
+
+// TestStripSelfMentionWholeTokenBoundary pins the isAlphanumericByte guard
+// inside stripSelfMention itself: "runlored" must not have its leading
+// "runlore" stripped as if it were the bare localpart followed by
+// punctuation — the same whole-token rule containsWord/addressed apply,
+// exercised here at the stripping site directly rather than only indirectly
+// through a Parse-level assertion.
+func TestStripSelfMentionWholeTokenBoundary(t *testing.T) {
+	const body = "runlored note: it was a bad deploy"
+	got, stripped := stripSelfMention(body, "@runlore:hs", "")
+	if stripped {
+		t.Fatalf("stripped = true, want false — %q must not be treated as the localpart", "runlore")
+	}
+	if got != body {
+		t.Fatalf("body = %q, want it returned unchanged", got)
+	}
+}
+
+// TestStripSelfMentionRuneBoundary is stripSelfMention's companion to
+// TestContainsWordRuneBoundary: the same pre-fix bug — a boundary check that
+// read one BYTE immediately after a matched candidate and asked whether it
+// was ASCII-alphanumeric — lived here too, on the post-match side only
+// (stripSelfMention matches a LEADING token, so there is no "before the
+// match" side to check). A UTF-8 continuation byte from a non-ASCII letter
+// or digit right after "runlore" was never ASCII-alphanumeric, so
+// "runloré note: x" was wrongly treated as the bare localpart "runlore"
+// followed by a boundary, stripped down to "é note: x", and handed to
+// thread.Parse as if the message genuinely addressed RunLore. Includes a
+// non-ASCII DIGIT case distinct from the letter cases for the same reason as
+// TestContainsWordRuneBoundary: IsDigit and IsLetter are separate
+// predicates.
+func TestStripSelfMentionRuneBoundary(t *testing.T) {
+	const self = "@runlore:hs"
+	tests := []struct {
+		name         string
+		body         string
+		wantStripped bool
+		wantText     string
+	}{
+		{
+			name:         "non-ASCII letter immediately after the candidate is not a boundary (the bug)",
+			body:         "runloreé note: x", // "runlore" immediately followed by 'é', not "runlore" with its 'e' replaced
+			wantStripped: false,
+			wantText:     "runloreé note: x",
+		},
+		{
+			name:         "non-ASCII digit immediately after the candidate is not a boundary",
+			body:         "runlore３ note: x", // U+FF13 FULLWIDTH DIGIT THREE: IsDigit true, IsLetter false
+			wantStripped: false,
+			wantText:     "runlore３ note: x",
+		},
+		{
+			name:         "punctuation neighbour is still a boundary — must still strip",
+			body:         "runlore, note: x",
+			wantStripped: true,
+			wantText:     "note: x",
+		},
+		{
+			name:         "existing ASCII case is unaffected — must still not strip",
+			body:         "runlored note: x",
+			wantStripped: false,
+			wantText:     "runlored note: x",
+		},
+		{
+			name:         "candidate is the entire body",
+			body:         "runlore",
+			wantStripped: true,
+			wantText:     "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, stripped := stripSelfMention(tc.body, self, "")
+			if stripped != tc.wantStripped {
+				t.Errorf("stripped = %v, want %v (body %q)", stripped, tc.wantStripped, tc.body)
+			}
+			if got != tc.wantText {
+				t.Errorf("text = %q, want %q (body %q)", got, tc.wantText, tc.body)
+			}
+		})
+	}
+}
+
+// TestStripSelfMentionCombiningMarkBoundary is stripSelfMention's companion
+// to TestContainsWordCombiningMarkBoundary: TestStripSelfMentionRuneBoundary
+// already pins NFC (precomposed) "é" as a non-boundary, but NFC alone
+// does not cover NFD (decomposed) "é" — 'e' (U+0065, already the
+// candidate's own trailing rune) followed by U+0301 COMBINING ACUTE ACCENT as
+// a separate rune. Matching the bare-localpart candidate "runlore" against
+// NFD "runloré" stops right after the plain 'e', and the next rune is the
+// combining mark alone — neither a letter nor a digit — so the
+// pre-fix predicate misread it as a boundary and stripped "runlore" off the
+// front of the accented word "runloré", handing thread.Parse "́ note: x"
+// (a lone combining mark plus the rest) as if the message genuinely
+// addressed RunLore. Matrix clients send NFD in practice (macOS input
+// methods default to it), so this is not exotic.
+func TestStripSelfMentionCombiningMarkBoundary(t *testing.T) {
+	const self = "@runlore:hs"
+	tests := []struct {
+		name         string
+		body         string
+		wantStripped bool
+		wantText     string
+	}{
+		{
+			name:         "NFD combining acute accent immediately after the candidate is not a boundary",
+			body:         "runloré note: x", // 'e' (candidate's own trailing rune) + U+0301 spells NFD "runloré", not "runlore" + boundary
+			wantStripped: false,
+			wantText:     "runloré note: x",
+		},
+		{
+			name:         "punctuation neighbour is still a boundary — must still strip (regression guard)",
+			body:         "runlore, note: x",
+			wantStripped: true,
+			wantText:     "note: x",
+		},
+		{
+			name:         "candidate is the entire body (regression guard)",
+			body:         "runlore",
+			wantStripped: true,
+			wantText:     "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, stripped := stripSelfMention(tc.body, self, "")
+			if stripped != tc.wantStripped {
+				t.Errorf("stripped = %v, want %v (body %q)", stripped, tc.wantStripped, tc.body)
+			}
+			if got != tc.wantText {
+				t.Errorf("text = %q, want %q (body %q)", got, tc.wantText, tc.body)
+			}
+		})
+	}
+}
+
+// TestMatrixMentionGrammarUnrelatedDisplayNameNotStripped pins
+// stripSelfMention's own behaviour in isolation: a display name unrelated to
+// the localpart (e.g. an operator-configured "Ops Bot") is not stripped
+// unless that exact name was actually resolved and passed in — "" here
+// simulates a profile lookup that never ran or never learned it.
+//
+// This is NOT, by itself, a safe degradation for an ordinary freeform
+// question — a nuisance at worst, since thread.Parse falls through to
+// IntentFreeform either way. For the RESERVED "reinvestigate:" prefix it
+// would have been the actual bug this file's
+// TestMatrixHandleMessageUnrelatedDisplayNameReinvestigateBackstop pins,
+// below, if thread.Parse itself did not ALSO match a reserved prefix
+// anywhere in the text (not only at position 0) — see thread.Parse's doc.
+// Because it does, the unstripped mention token here changes nothing about
+// whether "reinvestigate:" is still recognised downstream.
+func TestMatrixMentionGrammarUnrelatedDisplayNameNotStripped(t *testing.T) {
+	text, stripped := stripSelfMention("Ops Bot: note: it was a bad deploy", "@runlore:hs", "")
+	if stripped {
+		t.Fatal("stripped = true, want false — an unrelated, unresolved display name must not match")
+	}
+	got := thread.Parse(text)
+	if got.Intent != thread.IntentFreeform {
+		t.Fatalf("Intent = %v, want %v — an unrelated display name is not stripped", got.Intent, thread.IntentFreeform)
+	}
+}
+
+// fakeReinvestigateForge is thread.Forge, recording whether either write
+// entry point was ever called. It is used to prove that
+// IntentReinvestigate — reached only once the mention is stripped
+// Matrix-side — never writes to the knowledge base, no matter which route
+// write() would otherwise have taken.
+type fakeReinvestigateForge struct {
+	mu        sync.Mutex
+	opened    int
+	commented int
+}
+
+func (f *fakeReinvestigateForge) OpenPR(context.Context, providers.KBEntry) (providers.Ref, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.opened++
+	return providers.Ref{URL: "https://forge.example/pull/1"}, nil
+}
+
+func (f *fakeReinvestigateForge) CommentOnPR(context.Context, int, string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.commented++
+	return nil
+}
+
+func (f *fakeReinvestigateForge) IsPROpen(context.Context, int) (bool, error) { return true, nil }
+
+func (f *fakeReinvestigateForge) counts() (opened, commented int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.opened, f.commented
+}
+
+// TestMatrixHandleMessageReinvestigateIsReservedNotFreeform is the end-to-end
+// regression test for Fix 1's severity-1 consequence: before the mention was
+// stripped Matrix-side, "@runlore:hs reinvestigate: go look again" parsed as
+// IntentFreeform (the mention token still attached, so "reinvestigate:" never
+// matched as a prefix) and IntentFreeform is treated exactly like an explicit
+// note — opening a junk knowledge-base PR containing the sentence. Driven
+// through the REAL handleMessage → Dispatch → thread.Mention.HandleMention →
+// thread.Responder.Handle pipeline (a real Registry entry, a real Responder,
+// a fake Forge), not a hand-built thread.Parse call, so a regression anywhere
+// in that chain — not just in the grammar — would also be caught here.
+func TestMatrixHandleMessageReinvestigateIsReservedNotFreeform(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+
+	reg, err := thread.NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Put(thread.Context{Root: "$root-ours", Transport: "matrix", Channel: room, TriggerKey: "trig-ours"}); err != nil {
+		t.Fatalf("registry Put: %v", err)
+	}
+	forge := &fakeReinvestigateForge{}
+	responder := &thread.Responder{Forge: forge, Registry: reg, Log: matrixTestLog()}
+	rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+	mention := &thread.Mention{Responder: responder, Registry: reg, Replier: rep, Log: matrixTestLog()}
+
+	dispatch := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	busy := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, matrixTestLog(), WithThreadCapture(mention, dispatch, busy))
+	f.self = self
+
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply-reinvestigate"}
+	e.Content.Body = "@runlore:hs reinvestigate: go look again"
+	e.Content.Mentions.UserIDs = []string{self}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours"
+
+	f.handleMessage(context.Background(), e)
+	waitForReplies(t, rep)
+
+	if got := rep.snapshot(); len(got) != 1 || got[0].text != thread.ReinvestigateNotSupportedReply {
+		t.Fatalf("replies = %+v, want exactly one reply %q", got, thread.ReinvestigateNotSupportedReply)
+	}
+	if opened, commented := forge.counts(); opened != 0 || commented != 0 {
+		t.Fatalf("forge: opened=%d commented=%d, want 0/0 — the reserved reinvestigate: prefix must never write to the knowledge base", opened, commented)
+	}
+}
+
+// newBackstopFixture builds the shared scaffolding the three tests below
+// need: a registry with one root of RunLore's own, a fake forge, a real
+// Responder/Mention wired through it, and a fresh MatrixFeedback with
+// WithThreadCapture — identical in shape to
+// TestMatrixHandleMessageReinvestigateIsReservedNotFreeform's setup, factored
+// out because all three share it verbatim. Named for the transport-side
+// backstop these tests originally pinned; that backstop has since been
+// removed as redundant (see handleMessage's doc comment) once thread.Parse
+// itself started matching a reserved prefix anywhere in the text — the
+// fixture and the tests built on it stayed, since the scenarios they cover
+// (an unstripped mention token hiding a reserved command, or a genuine note)
+// are still exactly what needs pinning, just via the ordinary Dispatch path
+// now instead of a dedicated one.
+func newBackstopFixture(t *testing.T) (*MatrixFeedback, *fakeReinvestigateForge, *fakeMentionReplier) {
+	t.Helper()
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	t.Cleanup(srv.Close)
+
+	reg, err := thread.NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Put(thread.Context{Root: "$root-ours", Transport: "matrix", Channel: room, TriggerKey: "trig-ours"}); err != nil {
+		t.Fatalf("registry Put: %v", err)
+	}
+	forge := &fakeReinvestigateForge{}
+	responder := &thread.Responder{Forge: forge, Registry: reg, Log: matrixTestLog()}
+	rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+	mention := &thread.Mention{Responder: responder, Registry: reg, Replier: rep, Log: matrixTestLog()}
+
+	dispatch := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	busy := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, matrixTestLog(), WithThreadCapture(mention, dispatch, busy))
+	f.self = self
+	return f, forge, rep
+}
+
+// backstopEvent builds one m.thread reply from @alice:hs rooted at
+// $root-ours, addressed via MSC3952 m.mentions, carrying body — the shape
+// every test below sends through handleMessage.
+func backstopEvent(body string) matrixEvent {
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply-backstop"}
+	e.Content.Body = body
+	e.Content.Mentions.UserIDs = []string{"@runlore:hs"}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours"
+	return e
+}
+
+// TestMatrixHandleMessageUnrelatedDisplayNameReinvestigateBackstop pins the
+// residual gap left by stripSelfMention alone: a Matrix bot account whose
+// profile display name differs from its localpart (an ordinary operator
+// choice, e.g. "Ops Bot", not a corner case) strips nothing, so
+// "Ops Bot: reinvestigate: go look again" still carries "reinvestigate:"
+// behind an unrecognised mention token by the time it reaches handleMessage.
+// addressed() says yes (m.mentions), stripSelfMention leaves the mention
+// attached, and the text is handed to thread.Parse via the ordinary
+// Dispatch → HandleMention → Responder.Handle pipeline exactly like any
+// other addressed message — no special-cased transport-side backstop
+// involved (there used to be one; see handleMessage's doc comment for why it
+// was removed as redundant). thread.Parse's own reserved-anywhere match (not
+// only at position 0) is what refuses this, proven here end-to-end with a
+// fake forge so this pins BEFORE any forge call is possible — not merely
+// that some parse function returns the right enum.
+func TestMatrixHandleMessageUnrelatedDisplayNameReinvestigateBackstop(t *testing.T) {
+	f, forge, rep := newBackstopFixture(t)
+	// No selfDisplayName resolved — the profile lookup never ran, or ran and
+	// failed, or the homeserver has none set: exactly the state Fix 1's
+	// lookup leaves a fresh or unlucky listener in.
+
+	f.handleMessage(context.Background(), backstopEvent("Ops Bot: reinvestigate: go look again"))
+	waitForReplies(t, rep)
+
+	if got := rep.snapshot(); len(got) != 1 || got[0].text != thread.ReinvestigateNotSupportedReply {
+		t.Fatalf("replies = %+v, want exactly one reply %q", got, thread.ReinvestigateNotSupportedReply)
+	}
+	if opened, commented := forge.counts(); opened != 0 || commented != 0 {
+		t.Fatalf("forge: opened=%d commented=%d, want 0/0 — an unrelated display name must not open the reinvestigate: request as a knowledge-base PR", opened, commented)
+	}
+}
+
+// TestMatrixHandleMessageUnrelatedDisplayNameResolvedViaProfileLookup is the
+// companion proving the display-name-stripping path itself: once the display
+// name IS known (a successful profile lookup at Run start, simulated here by
+// setting selfDisplayName directly), stripSelfMention removes "Ops Bot:" like
+// any other mention form, thread.Parse sees "reinvestigate:" at position 0
+// the ordinary way, and Responder.Handle's own reserved-prefix case answers —
+// the same reply as the unstripped case above, since thread.Parse refuses a
+// reserved prefix identically whether or not a mention token precedes it.
+func TestMatrixHandleMessageUnrelatedDisplayNameResolvedViaProfileLookup(t *testing.T) {
+	f, forge, rep := newBackstopFixture(t)
+	f.selfDisplayName = "Ops Bot"
+
+	f.handleMessage(context.Background(), backstopEvent("Ops Bot: reinvestigate: go look again"))
+	waitForReplies(t, rep)
+
+	if got := rep.snapshot(); len(got) != 1 || got[0].text != thread.ReinvestigateNotSupportedReply {
+		t.Fatalf("replies = %+v, want exactly one reply %q", got, thread.ReinvestigateNotSupportedReply)
+	}
+	if opened, commented := forge.counts(); opened != 0 || commented != 0 {
+		t.Fatalf("forge: opened=%d commented=%d, want 0/0 — resolving the display name must route through Responder.Handle's reserved case, not write anything", opened, commented)
+	}
+}
+
+// TestMatrixHandleMessageDisplayNameStrippedGenuineNoteStillRecorded proves
+// thread.Parse's reserved-anywhere match is narrow: prose that merely uses
+// the word "reinvestigate" mid-sentence — no trailing ':' — must still be
+// recorded as a genuine note, once the message is addressed in a form
+// stripSelfMention actually recognises (the resolved display name, mirroring
+// TestMatrixHandleMessageUnrelatedDisplayNameResolvedViaProfileLookup above).
+//
+// This test used to run with the display name left UNSTRIPPED ("Ops Bot:
+// note: …" with no selfDisplayName set) and still pass — but only because
+// the write happened via IntentFreeform's old behaviour of writing exactly
+// like IntentNote (the security-audit bug FreeformNotRecordedReply's doc
+// comment describes; see internal/thread/responder.go). Now that Handle
+// never writes for IntentFreeform, an unrecognised leading token yields
+// IntentFreeform unconditionally — which never reaches a forge call no
+// matter what reservedTokenIndex decides — so that scenario can no longer
+// prove anything about reservedTokenIndex's narrowness specifically: it would
+// pass (opened == 0) for the wrong reason. Stripping the mention first is
+// what lets "note:" actually reach position 0 in thread.Parse and this test
+// exercise the intended thing again: a genuine note containing the bare word
+// "reinvestigate" is recorded, not refused.
+func TestMatrixHandleMessageDisplayNameStrippedGenuineNoteStillRecorded(t *testing.T) {
+	f, forge, rep := newBackstopFixture(t)
+	f.selfDisplayName = "Ops Bot"
+
+	f.handleMessage(context.Background(), backstopEvent("Ops Bot: note: we should reinvestigate the network config next time"))
+	waitForReplies(t, rep)
+
+	got := rep.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("replies = %+v, want exactly one", got)
+	}
+	if got[0].text == thread.ReinvestigateNotSupportedReply {
+		t.Fatalf("reply = %q, want the note recorded, not refused — the word \"reinvestigate\" appears without a trailing ':'", got[0].text)
+	}
+	if opened, _ := forge.counts(); opened != 1 {
+		t.Fatalf("forge.opened = %d, want 1 — a genuine note must still be recorded even though the mention token could not be stripped", opened)
+	}
+}

--- a/internal/notify/matrix_metrics_test.go
+++ b/internal/notify/matrix_metrics_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/Smana/runlore/internal/telemetry"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+// meteredNotifyInstruments mirrors internal/server's own helper of the same
+// shape (meteredInstruments): installs a REAL SDK meter provider backed by a
+// manual reader, and returns the instrument set bound to it plus a reader
+// that sums an int64 counter by its exported series name (0, false when the
+// series was never recorded). The provider is global, so a test using this
+// must not run in parallel with another that does; cleanup restores the
+// no-op provider.
+func meteredNotifyInstruments(t *testing.T) (*telemetry.Metrics, func(series string) (int64, bool)) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	return telemetry.NewMetrics(), func(series string) (int64, bool) {
+		var rm metricdata.ResourceMetrics
+		if err := reader.Collect(context.Background(), &rm); err != nil {
+			t.Fatalf("collect metrics: %v", err)
+		}
+		for _, sm := range rm.ScopeMetrics {
+			for _, md := range sm.Metrics {
+				if md.Name != series {
+					continue
+				}
+				sum, ok := md.Data.(metricdata.Sum[int64])
+				if !ok {
+					t.Fatalf("series %q is not an int64 sum (%T)", series, md.Data)
+				}
+				var total int64
+				for _, dp := range sum.DataPoints {
+					total += dp.Value
+				}
+				return total, true
+			}
+		}
+		return 0, false
+	}
+}
+
+// TestMatrixHandleMessageMentionDroppedLogsAndCounts is the regression test
+// for Fix 4: when Dispatch itself is saturated, the mention is
+// unrecoverably lost — /sync's position token has already advanced past
+// this event by the time this run finishes, so the homeserver will never
+// redeliver it — yet before this fix nothing was logged and nothing was
+// counted (only the DOUBLE-saturation case, busy dispatch also full,
+// logged). Mirrors Slack's own regression test,
+// TestEventsSaturatedPoolNotifiesBusyAndCountsMetric
+// (internal/server/events_test.go).
+func TestMatrixHandleMessageMentionDroppedLogsAndCounts(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+
+	m, read := meteredNotifyInstruments(t)
+
+	rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+	d := thread.NewDispatcher(1, time.Minute, matrixTestLog())
+	busy := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	block, running := make(chan struct{}), make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(running); <-block }) {
+		t.Fatal("first Go refused with a free slot")
+	}
+	<-running // the one slot is now occupied
+	defer close(block)
+
+	responder := &thread.Responder{Forge: &fakeReinvestigateForge{}, Log: matrixTestLog()}
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, matrixTestLog(),
+		WithThreadCapture(&thread.Mention{Responder: responder, Replier: rep, Log: matrixTestLog()}, d, busy),
+		WithMetrics(m))
+	f.self = self
+
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply-drop"}
+	e.Content.Body = "@runlore:hs note: please record this"
+	e.Content.Mentions.UserIDs = []string{self}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours"
+
+	f.handleMessage(context.Background(), e)
+	// The main dispatcher is saturated, so handleMessage falls through to the
+	// busy-notice path (its own, separate dispatcher) — wait for that reply to
+	// land before reading the counter, so the read is not a race against the
+	// detached Add call.
+	waitForReplies(t, rep)
+
+	if got, ok := read("runlore_mentions_dropped_on_saturation_total"); !ok || got != 1 {
+		t.Fatalf("runlore_mentions_dropped_on_saturation_total = %d (recorded=%v), want 1", got, ok)
+	}
+}
+
+// TestMatrixHandleMessageMentionDroppedNilMetricsSafe pins the nil-safety
+// half of Fix 4: MatrixFeedback built without WithMetrics (every listener
+// before this fix, and every test that doesn't opt in) must not panic when a
+// mention is dropped.
+func TestMatrixHandleMessageMentionDroppedNilMetricsSafe(t *testing.T) {
+	const room = "!r:hs"
+	const self = "@runlore:hs"
+	srv := matrixThreadCaptureServer(t, self)
+	defer srv.Close()
+
+	rep := &fakeMentionReplier{doneAt: 1, done: make(chan struct{})}
+	d := thread.NewDispatcher(1, time.Minute, matrixTestLog())
+	busy := thread.NewDispatcher(4, time.Minute, matrixTestLog())
+	block, running := make(chan struct{}), make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(running); <-block }) {
+		t.Fatal("first Go refused with a free slot")
+	}
+	<-running
+	defer close(block)
+
+	responder := &thread.Responder{Forge: &fakeReinvestigateForge{}, Log: matrixTestLog()}
+	f := NewMatrixFeedback(srv.URL, room, "tok", nil, matrixTestLog(),
+		WithThreadCapture(&thread.Mention{Responder: responder, Replier: rep, Log: matrixTestLog()}, d, busy))
+	f.self = self
+
+	e := matrixEvent{Sender: "@alice:hs", EventID: "$reply-drop-nil-metrics"}
+	e.Content.Body = "@runlore:hs note: please record this"
+	e.Content.Mentions.UserIDs = []string{self}
+	e.Content.RelatesTo.RelType = "m.thread"
+	e.Content.RelatesTo.EventID = "$root-ours"
+
+	f.handleMessage(context.Background(), e) // must not panic with no metrics wired
+	waitForReplies(t, rep)
+}

--- a/internal/notify/matrix_test.go
+++ b/internal/notify/matrix_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
 )
 
 func TestMatrixDeliver(t *testing.T) {
@@ -252,5 +253,297 @@ func TestMatrixDeliverEmbedsTriggerKey(t *testing.T) {
 	}
 	if _, ok := gotBody[triggerKeyContentField]; ok {
 		t.Fatalf("no trigger identity ⇒ field must be omitted, got %v", gotBody[triggerKeyContentField])
+	}
+}
+
+func TestMatrixDeliverRegistersTheEventAsThreadRoot(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = w.Write([]byte(`{"event_id":"$evt123"}`))
+	}))
+	defer srv.Close()
+
+	sink := &recordingThreadSink{}
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	m.Threads = sink
+
+	inv := providers.Investigation{Title: "OOMKilled", TriggerKey: "tk-1", CuratedURL: "https://github.com/o/r/pull/42"}
+	if err := m.Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+
+	if sink.calls != 1 {
+		t.Fatalf("Register calls = %d, want 1", sink.calls)
+	}
+	if sink.root != "$evt123" {
+		t.Errorf("root = %q, want the sent event id $evt123", sink.root)
+	}
+	if sink.channel != "!room:example.org" {
+		t.Errorf("channel = %q, want the room id", sink.channel)
+	}
+	if sink.transport != "matrix" {
+		t.Errorf("transport = %q, want matrix", sink.transport)
+	}
+	if body[threadContentField] == nil {
+		t.Fatalf("the event content must carry %s: %v", threadContentField, body)
+	}
+	if body[triggerKeyContentField] != "tk-1" {
+		t.Errorf("the pre-existing trigger-key field must be unchanged, got %v", body[triggerKeyContentField])
+	}
+}
+
+func TestMatrixDeliverSucceedsWithNoThreadSink(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"event_id":"$evt123"}`))
+	}))
+	defer srv.Close()
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	if err := m.Deliver(context.Background(), providers.Investigation{Title: "OOMKilled"}); err != nil {
+		t.Fatalf("Deliver with a nil thread sink: %v", err)
+	}
+}
+
+func TestMatrixDeliverSucceedsWhenTheResponseHasNoEventID(t *testing.T) {
+	// A homeserver that returns 2xx with an unexpected body must not fail
+	// delivery — the message was sent; only the thread root is unknown.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	sink := &recordingThreadSink{}
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	m.Threads = sink
+	if err := m.Deliver(context.Background(), providers.Investigation{Title: "OOMKilled"}); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if sink.calls != 0 {
+		t.Fatal("an empty event id must never be registered")
+	}
+}
+
+// TestContextFromStamp proves the reconstructed thread.Context takes its Root
+// and Channel from the fetch parameters (the event itself), never from the
+// stamp — threadStamp carries no root/channel field, so there is nothing in a
+// forged stamp that could redirect where a note is written. stampFor and
+// contextFromStamp round-trip the rest of the identifiers unchanged; a later
+// task (the reaction/thread listener) builds its event lookup on this pair.
+func TestContextFromStamp(t *testing.T) {
+	inv := providers.Investigation{
+		TriggerKey:    "tk-1",
+		Title:         "OOMKilled",
+		Resource:      providers.Workload{Namespace: "prod", Name: "harbor-registry"},
+		Verdict:       providers.VerdictActionRequired,
+		CuratedURL:    "https://github.com/o/r/pull/42",
+		RecalledEntry: "catalog/oom.md",
+	}
+
+	got := contextFromStamp(stampFor(inv), "$evt123", "!room:example.org")
+
+	want := thread.Context{
+		Transport:     "matrix",
+		Root:          "$evt123",
+		Channel:       "!room:example.org",
+		TriggerKey:    "tk-1",
+		Title:         "OOMKilled",
+		Resource:      "prod/harbor-registry",
+		Verdict:       providers.VerdictActionRequired,
+		CuratedURL:    "https://github.com/o/r/pull/42",
+		RecalledEntry: "catalog/oom.md",
+	}
+	if got != want {
+		t.Fatalf("contextFromStamp = %+v, want %+v", got, want)
+	}
+}
+
+// TestMatrixEventStampTriggerKeyThroughDeliver pins Fix 2: Deliver writes the
+// legacy triggerKeyContentField as cmp.Or(TriggerKey, Fingerprint), but (pre-fix)
+// stamped the new threadContentField's trigger_key from TriggerKey alone — and
+// contextFromContent decodes threadContentField FIRST, returning as soon as it
+// decodes, so the legacy field was never even looked at on any event this
+// notifier produces. A re-investigation (Request built with a Fingerprint but no
+// TriggerKey — see internal/investigate/reinvestigate.go) would resolve an empty
+// TriggerKey, silently breaking notify.matrix.feedback_reactions for exactly the
+// operators who enabled nothing else on this branch.
+//
+// Driven through Matrix.Deliver's REAL posted content (round-tripped through
+// JSON exactly as fetchEvent would decode it), not a hand-built fixture — the
+// pre-existing "legacy trigger-key-only" fixture in TestMatrixContextFor carries
+// a field combination Deliver never actually emits (threadContentField absent),
+// which is why the shadowing was invisible.
+func TestMatrixEventStampTriggerKeyThroughDeliver(t *testing.T) {
+	const room = "!r:hs"
+	tests := []struct {
+		name        string
+		inv         providers.Investigation
+		wantTrigKey string
+	}{
+		{
+			name:        "alert: TriggerKey set",
+			inv:         providers.Investigation{Title: "OOMKilled", TriggerKey: "tk-1"},
+			wantTrigKey: "tk-1",
+		},
+		{
+			name:        "re-investigation: Fingerprint only, no TriggerKey",
+			inv:         providers.Investigation{Title: "OOMKilled", Fingerprint: "fp9"},
+			wantTrigKey: "fp9",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				_, _ = w.Write([]byte(`{"event_id":"$evt1"}`))
+			}))
+			defer srv.Close()
+
+			m := NewMatrix(srv.URL, room, "tok")
+			if err := m.Deliver(context.Background(), tc.inv); err != nil {
+				t.Fatalf("Deliver: %v", err)
+			}
+
+			gotCtx, ok := contextFromContent(gotBody, "$evt1", room)
+			if !ok {
+				t.Fatalf("contextFromContent: not recognised as one of RunLore's own investigation messages: %v", gotBody)
+			}
+			if gotCtx.TriggerKey != tc.wantTrigKey {
+				t.Errorf("TriggerKey = %q, want %q — the legacy trigger key is shadowed by the (fingerprint-blind) thread stamp", gotCtx.TriggerKey, tc.wantTrigKey)
+			}
+		})
+	}
+}
+
+// TestStampForFallsBackToFingerprint pins the write-side half of Fix 2:
+// stampFor must embed the same identity Deliver already writes into the legacy
+// field (cmp.Or(TriggerKey, Fingerprint)), not TriggerKey alone.
+func TestStampForFallsBackToFingerprint(t *testing.T) {
+	got := stampFor(providers.Investigation{Fingerprint: "fp9"})
+	if got.TriggerKey != "fp9" {
+		t.Fatalf("stampFor TriggerKey = %q, want %q (fingerprint fallback)", got.TriggerKey, "fp9")
+	}
+}
+
+// TestContextFromContentFallsBackToLegacyTriggerKey pins the read-side half of
+// Fix 2, in isolation from stampFor: even a threadContentField stamp whose own
+// trigger_key is empty must not shadow a non-empty legacy triggerKeyContentField
+// sitting in the same content map. Defense in depth alongside the stampFor fix —
+// covers a stamp built some other way than stampFor, now or later.
+func TestContextFromContentFallsBackToLegacyTriggerKey(t *testing.T) {
+	content := map[string]any{
+		threadContentField:     map[string]any{"title": "OOMKilled"}, // trigger_key deliberately absent
+		triggerKeyContentField: "tk-legacy",
+	}
+	got, ok := contextFromContent(content, "$evt1", "!r:hs")
+	if !ok {
+		t.Fatal("contextFromContent: want ok=true")
+	}
+	if got.TriggerKey != "tk-legacy" {
+		t.Errorf("TriggerKey = %q, want %q", got.TriggerKey, "tk-legacy")
+	}
+	if got.Title != "OOMKilled" {
+		t.Errorf("Title = %q, want the rest of the stamp preserved", got.Title)
+	}
+}
+
+func TestMatrixReplyInThread(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_, _ = w.Write([]byte(`{"event_id":"$reply1"}`))
+	}))
+	defer srv.Close()
+
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	if err := m.ReplyInThread(context.Background(), "$evt123", "!room:example.org", "📝 Noted"); err != nil {
+		t.Fatalf("ReplyInThread: %v", err)
+	}
+
+	rel, ok := body["m.relates_to"].(map[string]any)
+	if !ok {
+		t.Fatalf("reply must carry m.relates_to: %v", body)
+	}
+	if rel["rel_type"] != "m.thread" {
+		t.Errorf("rel_type = %v, want m.thread", rel["rel_type"])
+	}
+	if rel["event_id"] != "$evt123" {
+		t.Errorf("event_id = %v, want the thread root $evt123", rel["event_id"])
+	}
+	if body["body"] != "📝 Noted" {
+		t.Errorf("body = %v, want the reply text", body["body"])
+	}
+	if mt, _ := body["msgtype"].(string); mt != "m.notice" {
+		t.Errorf("msgtype = %v, want m.notice (so clients don't render it as a human message)", body["msgtype"])
+	}
+	// Replies are plain text — no rich formatting, unlike Deliver's content. A
+	// copy-paste from Deliver's content-building would silently carry these
+	// over; catch it here.
+	if _, ok := body["format"]; ok {
+		t.Errorf("reply content must not carry format: %v", body)
+	}
+	if _, ok := body["formatted_body"]; ok {
+		t.Errorf("reply content must not carry formatted_body: %v", body)
+	}
+}
+
+// TestMatrixReplyInThreadRoutesToThePassedChannel pins the routing in
+// ReplyInThread: room := cmp.Or(channel, m.roomID) must resolve to the passed
+// channel when it's non-empty, even though the notifier was configured with a
+// different room. TestMatrixReplyInThread alone can't catch a regression that
+// drops the channel parameter (e.g. "room := m.roomID") because it constructs
+// the notifier and calls ReplyInThread with the SAME room — this test uses
+// deliberately divergent values and checks the request's URL path, which is
+// where the Matrix send endpoint encodes the target room
+// (/_matrix/client/v3/rooms/{roomID}/send/...).
+func TestMatrixReplyInThreadRoutesToThePassedChannel(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"event_id":"$reply1"}`))
+	}))
+	defer srv.Close()
+
+	m := NewMatrix(srv.URL, "!configured:example.org", "tok")
+	if err := m.ReplyInThread(context.Background(), "$evt123", "!live:example.org", "📝 Noted"); err != nil {
+		t.Fatalf("ReplyInThread: %v", err)
+	}
+
+	if !strings.Contains(gotPath, "/rooms/!live:example.org/send/") {
+		t.Fatalf("path = %q, want the reply routed to the passed channel !live:example.org", gotPath)
+	}
+	if strings.Contains(gotPath, "!configured") {
+		t.Fatalf("path = %q, must not target the configured room when a different channel was passed", gotPath)
+	}
+}
+
+// TestMatrixReplyInThreadFallsBackToConfiguredRoom proves an empty channel
+// argument falls back to the notifier's configured room — the other half of
+// cmp.Or(channel, m.roomID).
+func TestMatrixReplyInThreadFallsBackToConfiguredRoom(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"event_id":"$reply1"}`))
+	}))
+	defer srv.Close()
+
+	m := NewMatrix(srv.URL, "!configured:example.org", "tok")
+	if err := m.ReplyInThread(context.Background(), "$evt123", "", "📝 Noted"); err != nil {
+		t.Fatalf("ReplyInThread: %v", err)
+	}
+
+	if !strings.Contains(gotPath, "/rooms/!configured:example.org/send/") {
+		t.Fatalf("path = %q, want the reply to fall back to the configured room !configured:example.org", gotPath)
+	}
+}
+
+func TestMatrixReplyInThreadReportsSendFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	m := NewMatrix(srv.URL, "!room:example.org", "tok")
+	if err := m.ReplyInThread(context.Background(), "$evt123", "!room:example.org", "x"); err == nil {
+		t.Fatal("a non-2xx send must be reported")
 	}
 }

--- a/internal/notify/matrix_thread.go
+++ b/internal/notify/matrix_thread.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"cmp"
+	"encoding/json"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+// threadContentField is the custom event-content field Deliver stamps on
+// investigation messages so a threaded reply can be attributed to the
+// investigation it answers — the same mechanism triggerKeyContentField already
+// uses for 👍/👎, widened to carry the whole thread context.
+//
+// It is ADDITIVE: triggerKeyContentField keeps its exact meaning and value, so
+// the reaction listener and every event sent before this field existed behave
+// unchanged. Namespaced per the Matrix convention for custom keys.
+const threadContentField = "io.runlore.thread"
+
+// threadStamp is the thread context as carried on a Matrix event. It holds
+// identifiers only — never prose — so the event stays small and nothing
+// sensitive is duplicated into room history that is not already in the message.
+type threadStamp struct {
+	TriggerKey     string `json:"trigger_key,omitempty"`
+	DupFingerprint string `json:"dup_fingerprint,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Resource       string `json:"resource,omitempty"`
+	Verdict        string `json:"verdict,omitempty"`
+	CuratedURL     string `json:"curated_url,omitempty"`
+	RecalledEntry  string `json:"recalled_entry,omitempty"`
+}
+
+// stampFor renders the investigation's thread identifiers for the event
+// content. TriggerKey falls back to Fingerprint exactly like Deliver's legacy
+// triggerKeyContentField does (cmp.Or): a re-investigation's Request carries a
+// Fingerprint but no TriggerKey (internal/investigate/reinvestigate.go), and
+// without the same fallback here the stamp's own trigger_key would be empty —
+// which contextFromContent decodes and returns FIRST, before ever looking at
+// the legacy field, silently breaking notify.matrix.feedback_reactions for
+// every re-investigation.
+func stampFor(inv providers.Investigation) threadStamp {
+	return threadStamp{
+		TriggerKey:    cmp.Or(inv.TriggerKey, inv.Fingerprint),
+		Title:         inv.Title,
+		Resource:      inv.Resource.Ref(),
+		Verdict:       string(inv.Verdict),
+		CuratedURL:    inv.CuratedURL,
+		RecalledEntry: inv.RecalledEntry,
+	}
+}
+
+// contextFromStamp rebuilds a thread.Context from a stamped event. root and
+// room come from the event itself, not from the stamp, so a forged stamp cannot
+// redirect where a note is written.
+func contextFromStamp(s threadStamp, root, room string) thread.Context {
+	return thread.Context{
+		Transport:      "matrix",
+		Root:           root,
+		Channel:        room,
+		TriggerKey:     s.TriggerKey,
+		DupFingerprint: s.DupFingerprint,
+		Title:          s.Title,
+		Resource:       s.Resource,
+		Verdict:        providers.Verdict(s.Verdict),
+		CuratedURL:     s.CuratedURL,
+		RecalledEntry:  s.RecalledEntry,
+	}
+}
+
+// contextFromContent extracts a thread.Context from one fetched event's
+// content map — root and room are always the fetch's own parameters, never
+// anything read from content, so a forged field cannot redirect where a note
+// is written (the caller still owns the sender trust-check; this function only
+// decodes).
+//
+// io.runlore.thread wins when present: content[threadContentField] is an
+// `any` decoded off the wire, so it is re-marshalled through encoding/json
+// into threadStamp rather than hand-cast field by field — a hand-cast would
+// silently yield zero values on any type mismatch instead of surfacing it.
+// Failing that, the legacy io.runlore.trigger_key field is used on its own.
+// Neither field present (or the thread field present but undecodable) yields
+// false: not one of RunLore's stamped messages.
+//
+// A decoded stamp whose OWN trigger_key is empty still falls back to the
+// legacy field when present — defense in depth alongside stampFor's identical
+// cmp.Or fallback: stampFor (the only builder today) never leaves trigger_key
+// empty while a trigger identity exists, but this keeps the read side correct
+// independently of that, for a stamp built any other way.
+func contextFromContent(content map[string]any, root, room string) (thread.Context, bool) {
+	legacyKey, _ := content[triggerKeyContentField].(string)
+	if raw, ok := content[threadContentField]; ok {
+		if b, err := json.Marshal(raw); err == nil {
+			var stamp threadStamp
+			if err := json.Unmarshal(b, &stamp); err == nil {
+				tc := contextFromStamp(stamp, root, room)
+				if tc.TriggerKey == "" && legacyKey != "" {
+					tc.TriggerKey = legacyKey
+				}
+				return tc, true
+			}
+		}
+	}
+	if legacyKey != "" {
+		return thread.Context{Transport: "matrix", Root: root, Channel: room, TriggerKey: legacyKey}, true
+	}
+	return thread.Context{}, false
+}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -63,7 +63,11 @@ func SlackBotDelivery(sl config.SlackNotify) bool {
 // stored. Nil-safe by contract at every call site: registration is best-effort
 // and must never affect delivery.
 type ThreadSink interface {
-	Register(root, channel string, inv providers.Investigation)
+	// Register records inv against root, on channel, as delivered over
+	// transport (the caller's own Transport() — "slack", "matrix", …), so the
+	// stored entry is attributed to the transport that actually delivered it
+	// rather than assumed.
+	Register(transport, root, channel string, inv providers.Investigation)
 }
 
 func init() {
@@ -195,7 +199,7 @@ func (s *SlackBot) Deliver(ctx context.Context, inv providers.Investigation) err
 	// Record the thread root so a reply here can be attributed. Best-effort and
 	// nil-safe: capture is an opt-in extra, delivery is the contract.
 	if s.Threads != nil && ts != "" {
-		s.Threads.Register(ts, s.channel, inv)
+		s.Threads.Register(s.Transport(), ts, s.channel, inv)
 	}
 	detail := detailBlocks(inv)
 	if ts == "" || len(detail) == 0 {
@@ -225,6 +229,10 @@ func (s *SlackBot) ReplyInThread(ctx context.Context, root, channel, text string
 	_, err := s.post(ctx, msg)
 	return err
 }
+
+// Transport identifies this notifier's chat system (providers.ThreadNotifier),
+// the key Multi.ThreadRepliers scopes thread replies by.
+func (s *SlackBot) Transport() string { return "slack" }
 
 // post targets the message at the configured channel and sends it via
 // chat.postMessage, surfacing transport and Slack API (ok:false) errors, and
@@ -963,15 +971,31 @@ func (m *Multi) DeliverProgress(ctx context.Context, up providers.ProgressUpdate
 // Len reports how many notifiers are configured.
 func (m *Multi) Len() int { return len(m.notifiers) }
 
-// ThreadReplier returns the first configured notifier that can carry a reply
-// back into a thread, or nil when none can. The wiring needs one concrete
-// replier and Multi is where the built notifiers live; this is the same
-// capability discovery Deliver does for ProgressNotifier, exposed.
-func (m *Multi) ThreadReplier() providers.ThreadNotifier {
+// ThreadRepliers returns the configured notifiers that can carry a reply back
+// into a thread, keyed by Transport(). The wiring needs the concrete replier
+// for the specific transport a thread lives on — Multi is where the built
+// notifiers live, so this is the same capability discovery Deliver does for
+// ProgressNotifier, exposed and transport-scoped: with two thread-capable
+// transports configured (Slack, Matrix), picking just the first one found
+// would answer one transport's threads on the other, or not at all.
+//
+// When two notifiers report the same transport, the first registered wins
+// and the collision is logged — silently dropping one would be the same
+// class of bug this scoping fixes.
+func (m *Multi) ThreadRepliers() map[string]providers.ThreadNotifier {
+	repliers := make(map[string]providers.ThreadNotifier)
 	for _, n := range m.notifiers {
-		if tn, ok := n.(providers.ThreadNotifier); ok {
-			return tn
+		tn, ok := n.(providers.ThreadNotifier)
+		if !ok {
+			continue
 		}
+		transport := tn.Transport()
+		if _, collide := repliers[transport]; collide {
+			m.log.Warn("multiple thread-capable notifiers registered for the same transport; keeping the first, dropping the rest",
+				"transport", transport)
+			continue
+		}
+		repliers[transport] = tn
 	}
-	return nil
+	return repliers
 }

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -1249,13 +1249,13 @@ func TestSlackCardEscapesTitleOnBothBranches(t *testing.T) {
 // the live gap: an unmounted secret leaves the env var present and empty, the
 // builder returns nil, the notifier is skipped and nothing is delivered.
 type recordingThreadSink struct {
-	root, channel string
-	inv           providers.Investigation
-	calls         int
+	transport, root, channel string
+	inv                      providers.Investigation
+	calls                    int
 }
 
-func (r *recordingThreadSink) Register(root, channel string, inv providers.Investigation) {
-	r.root, r.channel, r.inv, r.calls = root, channel, inv, r.calls+1
+func (r *recordingThreadSink) Register(transport, root, channel string, inv providers.Investigation) {
+	r.transport, r.root, r.channel, r.inv, r.calls = transport, root, channel, inv, r.calls+1
 }
 
 // TestSlackBotRegistersTheThreadRoot proves the registered thread root is the
@@ -1304,6 +1304,9 @@ func TestSlackBotRegistersTheThreadRoot(t *testing.T) {
 	}
 	if sink.channel != "C1" {
 		t.Errorf("channel = %q, want C1", sink.channel)
+	}
+	if sink.transport != "slack" {
+		t.Errorf("transport = %q, want slack", sink.transport)
 	}
 	if sink.inv.TriggerKey != "tk-1" {
 		t.Errorf("investigation not passed through: %+v", sink.inv)
@@ -1410,16 +1413,52 @@ func TestSlackBotReplyInThread(t *testing.T) {
 	}
 }
 
-func TestMultiThreadReplier(t *testing.T) {
+func TestMultiThreadRepliersAreTransportScoped(t *testing.T) {
 	bot := NewSlackBot("xoxb-test", "C1")
-	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), NewSlack("https://hooks.slack.com/x"), bot)
-	if got := m.ThreadReplier(); got != providers.ThreadNotifier(bot) {
-		t.Fatalf("ThreadReplier = %v, want the bot notifier", got)
-	}
+	mx := NewMatrix("https://hs.example.org", "!room:example.org", "tok")
+	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), NewSlack("https://hooks.slack.com/x"), bot, mx)
 
-	none := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), NewSlack("https://hooks.slack.com/x"))
-	if got := none.ThreadReplier(); got != nil {
-		t.Fatalf("ThreadReplier = %v, want nil when no notifier can reply", got)
+	got := m.ThreadRepliers()
+	if len(got) != 2 {
+		t.Fatalf("ThreadRepliers = %d entries, want 2", len(got))
+	}
+	if got["slack"] != providers.ThreadNotifier(bot) {
+		t.Errorf("slack replier = %v, want the SlackBot", got["slack"])
+	}
+	if got["matrix"] != providers.ThreadNotifier(mx) {
+		t.Errorf("matrix replier = %v, want the Matrix notifier", got["matrix"])
+	}
+}
+
+func TestMultiThreadRepliersEmptyWhenNoneCanReply(t *testing.T) {
+	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), NewSlack("https://hooks.slack.com/x"))
+	if got := m.ThreadRepliers(); len(got) != 0 {
+		t.Fatalf("ThreadRepliers = %v, want empty", got)
+	}
+}
+
+// TestMultiThreadRepliersLogsTransportCollision pins the collision-handling
+// requirement: two notifiers reporting the same transport must not silently
+// drop one (the same class of bug the transport-keyed lookup exists to fix).
+// The first-registered notifier wins and the collision is logged, naming the
+// transport.
+func TestMultiThreadRepliersLogsTransportCollision(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	first := NewSlackBot("xoxb-first", "C1")
+	second := NewSlackBot("xoxb-second", "C2")
+	m := NewMulti(log, first, second)
+
+	got := m.ThreadRepliers()
+	if len(got) != 1 {
+		t.Fatalf("ThreadRepliers = %d entries, want 1 (collision keeps only the first)", len(got))
+	}
+	if got["slack"] != providers.ThreadNotifier(first) {
+		t.Errorf("slack replier = %v, want the first-registered SlackBot", got["slack"])
+	}
+	out := buf.String()
+	if !strings.Contains(out, "slack") {
+		t.Fatalf("must log a warning naming the colliding transport; got: %s", out)
 	}
 }
 

--- a/internal/notify/thread_capture_build_test.go
+++ b/internal/notify/thread_capture_build_test.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+// TestBuildEnabledWiresThreadCaptureForEveryTransport is the regression test
+// for the defect where notify.matrix's Build closure constructed a *Matrix but
+// never assigned its Threads sink: every test that exercised registration
+// built Matrix/SlackBot directly and set Threads by hand, bypassing Build
+// entirely, so the miswiring shipped green. This test goes through the REAL
+// notify.BuildEnabled → Descriptor.Build registry path — the same path
+// app.BuildNotifier uses in production — for BOTH thread-capable transports,
+// deliberately side by side: asserting only one (e.g. "at least one notifier
+// has Threads set") would let a broken second transport hide behind a
+// passing first one. This does NOT generalise to a hypothetical third
+// thread-capable transport, though: the assertions below look up
+// repliers["matrix"] and repliers["slack"] by name, so a third transport that
+// forgets to wire its sink would simply never be checked here and would pass
+// silently. Extending this test to cover one would mean iterating
+// m.ThreadRepliers() itself rather than two hardcoded keys.
+func TestBuildEnabledWiresThreadCaptureForEveryTransport(t *testing.T) {
+	var matrixGotBody bool
+	matrixSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		matrixGotBody = true
+		_, _ = w.Write([]byte(`{"event_id":"$matrix-root"}`))
+	}))
+	defer matrixSrv.Close()
+	slackSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"111.222"}`))
+	}))
+	defer slackSrv.Close()
+
+	t.Setenv("TC_MATRIX_TOK", "syt_x")
+	t.Setenv("TC_SLACK_BOT", "xoxb-test")
+
+	cfg := &config.Config{}
+	cfg.Notify.Matrix = config.MatrixNotify{
+		Homeserver:     matrixSrv.URL,
+		RoomID:         "!r:example.org",
+		AccessTokenEnv: "TC_MATRIX_TOK",
+		ThreadCapture:  true,
+	}
+	cfg.Notify.Slack = config.SlackNotify{
+		BotTokenEnv:   "TC_SLACK_BOT",
+		Channel:       "C1",
+		ThreadCapture: true,
+	}
+
+	reg, err := thread.NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	m, err := BuildEnabled(Deps{Cfg: cfg, Log: slog.New(slog.DiscardHandler), Threads: reg})
+	if err != nil {
+		t.Fatalf("BuildEnabled: %v", err)
+	}
+	repliers := m.ThreadRepliers()
+
+	matrixNotifier, ok := repliers["matrix"].(*Matrix)
+	if !ok {
+		t.Fatalf("no *Matrix among thread repliers: %#v", repliers)
+	}
+	if matrixNotifier.Threads == nil {
+		t.Fatal("Matrix: BuildEnabled did not wire Threads even though notify.matrix.thread_capture is on — " +
+			"a delivered investigation's thread root is never registered, so every later reply misses")
+	}
+
+	slackNotifier, ok := repliers["slack"].(*SlackBot)
+	if !ok {
+		t.Fatalf("no *SlackBot among thread repliers: %#v", repliers)
+	}
+	if slackNotifier.Threads == nil {
+		t.Fatal("Slack: BuildEnabled did not wire Threads even though notify.slack.thread_capture is on")
+	}
+	// SlackBot's baseURL ("https://slack.com") is not YAML-configurable by
+	// design (it's a real endpoint, not a deployment setting) — point this
+	// already-built instance at the local test server, the same override
+	// slack_test.go uses.
+	slackNotifier.baseURL = slackSrv.URL
+
+	// Deliver through both notifiers exactly as built (not hand-constructed)
+	// and confirm the registry recorded each root under the CALLER's
+	// transport, not a hardcoded one.
+	ctx := context.Background()
+	if err := matrixNotifier.Deliver(ctx, providers.Investigation{Title: "matrix-inv"}); err != nil {
+		t.Fatalf("matrix Deliver: %v", err)
+	}
+	if !matrixGotBody {
+		t.Fatal("matrix homeserver never received the send request")
+	}
+	if tc, ok := reg.Get("$matrix-root"); !ok {
+		t.Fatal("matrix delivery was never registered in the thread registry")
+	} else if tc.Transport != "matrix" {
+		t.Errorf("matrix delivery registered with Transport = %q, want %q", tc.Transport, "matrix")
+	}
+
+	if err := slackNotifier.Deliver(ctx, providers.Investigation{Title: "slack-inv"}); err != nil {
+		t.Fatalf("slack Deliver: %v", err)
+	}
+	if tc, ok := reg.Get("111.222"); !ok {
+		t.Fatal("slack delivery was never registered in the thread registry")
+	} else if tc.Transport != "slack" {
+		t.Errorf("slack delivery registered with Transport = %q, want %q", tc.Transport, "slack")
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -539,6 +539,12 @@ type ThreadNotifier interface {
 	// handles are transport-specific opaque strings (Slack: thread_ts and a
 	// channel id).
 	ReplyInThread(ctx context.Context, root, channel, text string) error
+	// Transport names the chat system this notifier replies on ("slack",
+	// "matrix"). It is what lets a deployment running several transports route
+	// each thread's reply back to the system the human is actually in — the
+	// alternative, picking the first notifier that can reply, silently answers
+	// one transport's threads on another.
+	Transport() string
 }
 
 // CurationForge is the forge surface the curator's file-time gate needs: open a

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -423,13 +423,13 @@ func TestEventsSaturatedPoolWithNilMetricsDoesNotPanic(t *testing.T) {
 // unbounded-lifetime defect: handleSlackEvent used to hand the detached
 // handler a context.WithoutCancel-derived context with NO deadline, so a
 // degraded/rate-limited forge could hold a pool slot indefinitely instead of
-// for as long as the mention itself takes. s.mentionTimeout is shortened here
-// so the test proves the real wiring deterministically, without waiting out
-// the production mentionHandlerTimeout (2 minutes) for real.
+// for as long as the mention itself takes. s.eventDispatcher is swapped for one
+// with a short timeout here so the test proves the real wiring deterministically,
+// without waiting out the production mentionHandlerTimeout (2 minutes) for real.
 func TestEventsMentionHandlerContextTimesOut(t *testing.T) {
 	h := newCtxAwareThreadHandler()
 	s := newEventServer(t, h)
-	s.mentionTimeout = 20 * time.Millisecond
+	s.eventDispatcher = thread.NewDispatcher(maxConcurrentMentions, 20*time.Millisecond, discardLog)
 	t.Cleanup(func() { close(h.release) }) // safety net if the handler is somehow still blocked
 
 	body := `{"type":"event_callback","event_id":"Etimeout","event":{"type":"app_mention","user":"U1","text":"note: x","channel":"C1","thread_ts":"111.222"}}`
@@ -524,5 +524,111 @@ func TestDrainIsBounded(t *testing.T) {
 	s.Drain(dctx)
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("Drain took %v to return after its bound expired — it must never block shutdown forever", elapsed)
+	}
+}
+
+// syncLogBuf is a concurrency-safe io.Writer that captures log output so a test
+// can inspect exactly what was logged (slog handlers may be written to from
+// multiple goroutines).
+type syncLogBuf struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *syncLogBuf) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncLogBuf) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// TestDrainAwaitsBusyDispatcherConcurrentlyWithEventDispatcher is the
+// regression test for the sequential-drain defect: Server.Drain used to drain
+// eventDispatcher and busyDispatcher one after another against the SAME ctx.
+// Once eventDispatcher's wait hit ctx.Done() (mention work outlasting the
+// grace period — precisely the degraded-forge scenario the drain exists for),
+// busyDispatcher.Drain(ctx) was handed an already-expired context and returned
+// almost instantly WITHOUT waiting for its own real in-flight work — while
+// still logging "drain timed out with work still in flight" for work it never
+// actually awaited.
+//
+// This constructs exactly that state: eventDispatcher holds work that never
+// completes (so its Drain call is guaranteed to hit ctx.Done()), and
+// busyDispatcher holds REAL in-flight work that finishes with a huge margin
+// inside the grace period — but only if busyDispatcher gets to wait for it
+// concurrently with eventDispatcher, rather than being queued behind it.
+func TestDrainAwaitsBusyDispatcherConcurrentlyWithEventDispatcher(t *testing.T) {
+	logBuf := &syncLogBuf{}
+	s := New(nil, Actions{}, nil, nil, nil, nil, slog.New(slog.NewTextHandler(logBuf, nil)))
+
+	// eventDispatcher's one in-flight handler never completes on its own — it
+	// only stops when Drain gives up on its ctx, matching "mention work
+	// outlasts the grace period".
+	eventRelease := make(chan struct{})
+	t.Cleanup(func() { close(eventRelease) })
+	if !s.eventDispatcher.Go(context.Background(), func(context.Context) { <-eventRelease }) {
+		t.Fatal("eventDispatcher.Go refused")
+	}
+
+	// busyDispatcher's one in-flight handler is REAL work that finishes on its
+	// own well before the grace period ends.
+	busyStarted := make(chan struct{})
+	busyFinished := make(chan struct{})
+	busyRelease := make(chan struct{})
+	if !s.busyDispatcher.Go(context.Background(), func(context.Context) {
+		close(busyStarted)
+		<-busyRelease
+		close(busyFinished)
+	}) {
+		t.Fatal("busyDispatcher.Go refused")
+	}
+	<-busyStarted
+
+	const grace = 150 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), grace)
+	defer cancel()
+
+	// Release the busy work at a fixed, generous margin before the grace
+	// period ends: a Drain that gives busyDispatcher independent access to the
+	// full ctx budget has ~110ms of slack to observe this; a Drain that only
+	// starts waiting on busyDispatcher AFTER eventDispatcher has already
+	// exhausted that budget gets none, no matter how early the busy work
+	// finished.
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		close(busyRelease)
+	}()
+
+	drainDone := make(chan struct{})
+	go func() {
+		s.Drain(ctx)
+		close(drainDone)
+	}()
+
+	select {
+	case <-busyFinished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("busy work never finished")
+	}
+	select {
+	case <-drainDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Drain never returned")
+	}
+
+	// eventDispatcher's work never finished, so exactly one legitimate timeout
+	// log is expected. A second occurrence means busyDispatcher was ALSO
+	// handed an expired context and logged a spurious timeout for work that
+	// had already completed on its own — the exact defect this test guards
+	// against.
+	const timeoutMsg = "drain timed out with work still in flight"
+	if got := strings.Count(logBuf.String(), timeoutMsg); got != 1 {
+		t.Fatalf("%q logged %d times, want exactly 1 (only eventDispatcher's genuine timeout); log:\n%s",
+			timeoutMsg, got, logBuf.String())
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// maxConcurrentMentions bounds detached Slack mention handlers running at once
-	// (s.eventSlots). Each slot holds one forge round-trip — read the thread,
+	// (s.eventDispatcher). Each slot holds one forge round-trip — read the thread,
 	// comment or open a PR — not a heavy computation, so a wide pool stays cheap.
 	// What is NOT cheap is exceeding it: the ack has already gone out, so a mention
 	// dropped here is unrecoverable (Slack will never retry it). 16 gives real
@@ -40,7 +40,7 @@ const (
 	// against unbounded goroutines.
 	maxConcurrentMentions = 16
 	// maxConcurrentBusyNotices bounds the best-effort "I'm too busy, try again"
-	// replies sent when maxConcurrentMentions is saturated (s.busySlots).
+	// replies sent when maxConcurrentMentions is saturated (s.busyDispatcher).
 	// Deliberately separate and small: telling humans about an overload is itself
 	// a Slack round-trip, and it must never become the next unbounded-goroutine
 	// problem. A burst wide enough to exhaust even this budget just means those
@@ -79,17 +79,14 @@ type Server struct {
 	guard            *authGuard         // failed-auth backoff for the shared-token endpoints
 	threads          ThreadHandler      // nil unless notify.slack.thread_capture is on
 	seenEvents       *seenSet           // Slack event_id dedup for delivery retries
-	eventSlots       chan struct{}      // bounds concurrent detached mention handlers
-	busySlots        chan struct{}      // separate, smaller bound for the "pool saturated" reply
 	telemetryMetrics *telemetry.Metrics // nil unless telemetry is configured; nil-safe throughout
-	// mentionTimeout bounds a detached mention/busy handler's context (see
-	// mentionHandlerTimeout). Defaulted by New; a field rather than a bare
-	// reference to the constant so tests can shorten it deterministically
-	// instead of waiting out the real 2 minutes to prove the wiring cancels.
-	mentionTimeout time.Duration
-	// wg tracks every detached handler dispatch (see dispatch) so Drain can wait
-	// for them at shutdown instead of abandoning whatever is in flight.
-	wg sync.WaitGroup
+	// eventDispatcher and busyDispatcher run detached mention handlers and the
+	// "pool saturated" busy reply respectively, each under its own concurrency
+	// bound and timeout (see internal/thread.Dispatcher). Separate pools:
+	// telling a human the mention pool is busy is itself a Slack round-trip, and
+	// it must never become the next unbounded-goroutine problem.
+	eventDispatcher *thread.Dispatcher
+	busyDispatcher  *thread.Dispatcher
 
 	metrics http.Handler // optional; GET /metrics (OTel Prometheus exposition)
 	log     *slog.Logger
@@ -167,10 +164,9 @@ func New(ready func() bool, acts Actions, built []source.Built, pipe *source.Pip
 		guard:            newAuthGuard(),
 		threads:          acts.Threads,
 		seenEvents:       newSeenSet(1024),
-		eventSlots:       make(chan struct{}, maxConcurrentMentions),
-		busySlots:        make(chan struct{}, maxConcurrentBusyNotices),
 		telemetryMetrics: acts.Metrics,
-		mentionTimeout:   mentionHandlerTimeout,
+		eventDispatcher:  thread.NewDispatcher(maxConcurrentMentions, mentionHandlerTimeout, log),
+		busyDispatcher:   thread.NewDispatcher(maxConcurrentBusyNotices, mentionHandlerTimeout, log),
 	}
 	mux := http.NewServeMux()
 	// work marks a route as work-bearing: on a follower the request is proxied
@@ -535,16 +531,10 @@ func (s *Server) handleSlackEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Detached from the request: the response is already written. WithoutCancel
-	// keeps request-scoped values while surviving the handler's return; the
-	// fresh WithTimeout then bounds how long the detached work may run instead
-	// of leaving it unbounded (WithoutCancel strips any deadline too) — see
-	// mentionHandlerTimeout. cancel is always invoked by exactly one of the
-	// three paths below (the mention closure, the busy closure, or the trailing
-	// call when neither pool accepts the work) — never left uncalled.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), s.mentionTimeout)
-	if s.dispatch(s.eventSlots, func() {
-		defer cancel()
+	// Detached from the request: the response is already written. s.eventDispatcher
+	// strips cancellation and applies its own timeout so the work outlives this
+	// handler's return instead of dying with it (see thread.Dispatcher.Go).
+	if s.eventDispatcher.Go(r.Context(), func(ctx context.Context) {
 		// Slack carries no context a fallback could be decoded from — nil here
 		// always means "consult the registry only", never "skip the registry".
 		s.threads.HandleMention(ctx, ev.Event.Channel, ev.Event.ThreadTS, ev.Event.User, ev.Event.Text, nil)
@@ -559,65 +549,44 @@ func (s *Server) handleSlackEvent(w http.ResponseWriter, r *http.Request) {
 	// premise is not losing the operator's knowledge.
 	s.log.Error("slack event: mention dropped, handler pool saturated", "channel", ev.Event.Channel, "root", ev.Event.ThreadTS)
 	if s.telemetryMetrics != nil {
-		s.telemetryMetrics.MentionsDroppedOnSaturation.Add(ctx, 1)
+		s.telemetryMetrics.MentionsDroppedOnSaturation.Add(r.Context(), 1)
 	}
 	// Telling the human is itself another Slack round-trip, so it gets the same
 	// treatment as the mention handler itself: detached and bounded, under its own
 	// small budget, never blocking this request goroutine.
-	if !s.dispatch(s.busySlots, func() {
-		defer cancel()
+	s.busyDispatcher.Go(r.Context(), func(ctx context.Context) {
 		s.threads.Busy(ctx, ev.Event.Channel, ev.Event.ThreadTS)
-	}) {
-		cancel() // neither pool accepted the work: nothing else will call cancel
-	}
+	})
 }
 
-// dispatch runs fn detached, gated by slots — a bounded semaphore channel — so the
-// caller never blocks: it reports whether fn was actually started. With slots full it
-// returns false immediately (non-blocking) and fn never runs. A panic inside fn is
-// recovered and logged rather than crashing the process. Every dispatched fn is
-// tracked in s.wg so Drain can wait for it at shutdown instead of abandoning it.
-func (s *Server) dispatch(slots chan struct{}, fn func()) bool {
-	select {
-	case slots <- struct{}{}:
-	default:
-		return false
-	}
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-		defer func() { <-slots }()
-		defer func() {
-			if rec := recover(); rec != nil {
-				s.log.Error("recovered from detached handler panic", "panic", rec, "stack", string(debug.Stack()))
-			}
-		}()
-		fn()
-	}()
-	return true
-}
-
-// Drain waits for every currently in-flight detached handler dispatched via
-// dispatch (mention processing, and the "busy" reply sent when the pool is
-// saturated) to finish, bounded by ctx. Call it during shutdown AFTER the HTTP
-// listener has stopped accepting new requests (so dispatch can no longer be
-// invoked) and before tearing down anything a handler might still depend on.
+// Drain waits for every currently in-flight detached handler (mention
+// processing, and the "busy" reply sent when the pool is saturated) to finish,
+// bounded by ctx. Call it during shutdown AFTER the HTTP listener has stopped
+// accepting new requests (so neither dispatcher can be handed new work) and
+// before tearing down anything a handler might still depend on.
+//
+// The two dispatchers are drained CONCURRENTLY, each against its own goroutine
+// racing the SAME ctx, so each gets independent access to the full ctx budget
+// from the moment Drain is called. Draining them one after another would let
+// an expired deadline silently starve the second pool of its grace period: a
+// context's Done() channel stays closed forever once its deadline passes, so
+// if the first dispatcher's wait ran out the clock (mention work outlasting
+// the grace period — precisely the degraded-forge scenario this drain exists
+// for), the second would be handed an already-expired context and return
+// almost instantly without waiting for real in-flight work, while still
+// logging a timeout for work it never actually awaited.
 //
 // Mirrors investigate.Queue.Drain's shape: if ctx's deadline fires first,
 // Drain returns anyway rather than blocking shutdown forever. A handler still
-// running at that point is not killed — its own mentionTimeout-bounded
+// running at that point is not killed — its own dispatcher-timeout-bounded
 // context (see handleSlackEvent) is what eventually stops it — Drain simply
 // stops waiting on it.
 func (s *Server) Drain(ctx context.Context) {
-	done := make(chan struct{})
-	go func() {
-		s.wg.Wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-ctx.Done():
-	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); s.eventDispatcher.Drain(ctx) }()
+	go func() { defer wg.Done(); s.busyDispatcher.Drain(ctx) }()
+	wg.Wait()
 }
 
 // seenSet is a bounded set of recently-seen ids. It exists so Slack's delivery

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -35,7 +35,7 @@ type Metrics struct {
 	GitOpsFailuresDebounced     metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
 	IncidentsDebounced          metric.Int64Counter // firing alerts dropped as self-resolving (resolved within the incident debounce window)
 	IncidentsDroppedOnShutdown  metric.Int64Counter // firing alerts LOST: still held in the debounce window when the process shut down (accepted, never investigated)
-	MentionsDroppedOnSaturation metric.Int64Counter // slack mentions LOST: the concurrent handler pool was saturated when the human's note arrived (accepted, acked, never processed)
+	MentionsDroppedOnSaturation metric.Int64Counter // chat mentions LOST (Slack app_mention, or a Matrix addressed thread message): the concurrent handler pool was saturated when the human's note arrived (accepted, never processed — Slack acks 200 and is never retried; Matrix's /sync position has already advanced and never redelivers)
 	ThreadNotesWritten          metric.Int64Counter // knowledge writes LANDED via internal/thread's @runlore note: path — CommentOnPR or OpenPR (label: route)
 	ThreadWritesThrottled       metric.Int64Counter // thread note writes DENIED by internal/thread's global per-hour forge-write window (Responder.ForgeWrites) and told to retry — this feature's one global cap, otherwise invisible to an operator
 	ToolOutputTruncatedBytes    metric.Int64Counter
@@ -117,7 +117,7 @@ func NewMetrics() *Metrics {
 		GitOpsFailuresDebounced:     ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
 		IncidentsDebounced:          ctr("incidents_debounced_total", "firing alerts dropped as self-resolving: a matching resolved webhook arrived within the incident debounce window before investigating"),
 		IncidentsDroppedOnShutdown:  ctr("incidents_dropped_on_shutdown_total", "firing alerts LOST: still held in the incident debounce window when the process shut down — accepted (200 to Alertmanager) but never investigated, and not retried until Alertmanager's repeat_interval"),
-		MentionsDroppedOnSaturation: ctr("mentions_dropped_on_saturation_total", "slack mentions LOST: the concurrent handler pool was saturated when the human's `@runlore note:` arrived — accepted (200 to Slack) and acked, but never processed; the human is told to retry via a best-effort in-thread reply"),
+		MentionsDroppedOnSaturation: ctr("mentions_dropped_on_saturation_total", "chat mentions LOST — Slack app_mention or a Matrix addressed thread message: the concurrent handler pool was saturated when the human's `@runlore note:` arrived, accepted but never processed (Slack: acked 200, never retried; Matrix: /sync's position token already advanced, never redelivered); the human is told to retry via a best-effort in-thread reply"),
 		ThreadNotesWritten:          ctr("thread_notes_written_total", "knowledge writes landed from an `@runlore note:` thread reply, via CommentOnPR or OpenPR (label: route)"),
 		ThreadWritesThrottled:       ctr("thread_writes_throttled_total", "thread note writes denied by internal/thread's global per-hour forge-write window and told to retry"),
 		ToolOutputTruncatedBytes:    ctr("tool_output_truncated_bytes_total", "bytes elided by output truncation"),

--- a/internal/thread/dispatch.go
+++ b/internal/thread/dispatch.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package thread
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+// Dispatcher runs detached work under three bounds: how much runs at once, how
+// long any single piece may run, and a drain that lets shutdown wait for what is
+// in flight.
+//
+// It exists because both transports need identical behaviour here. A chat
+// transport acknowledges the platform BEFORE doing the work (Slack retries
+// anything unacked within 3 seconds; the Matrix sync loop must keep
+// long-polling), so the work necessarily outlives the call that scheduled it —
+// and unbounded detached goroutines on an internet-facing path is its own
+// problem. Duplicating this per transport would guarantee the two drift.
+type Dispatcher struct {
+	slots   chan struct{}
+	timeout time.Duration
+	wg      sync.WaitGroup
+	log     *slog.Logger
+}
+
+// NewDispatcher returns a Dispatcher allowing `slots` concurrent pieces of work,
+// each bounded by `timeout`.
+func NewDispatcher(slots int, timeout time.Duration, log *slog.Logger) *Dispatcher {
+	if slots <= 0 {
+		slots = 1
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Dispatcher{slots: make(chan struct{}, slots), timeout: timeout, log: log}
+}
+
+// Go runs fn on a bounded worker and reports whether it was accepted. It never
+// blocks: when every slot is busy it returns false immediately, having run
+// nothing, so the caller can tell the human rather than queue silently.
+//
+// fn receives a context derived from ctx with cancellation stripped and the
+// dispatcher's timeout applied. Stripping cancellation is deliberate: ctx is
+// typically a request context that dies the moment its handler returns, which
+// would cancel the work before it could do anything.
+func (d *Dispatcher) Go(ctx context.Context, fn func(context.Context)) bool {
+	select {
+	case d.slots <- struct{}{}:
+	default:
+		return false
+	}
+	work := context.WithoutCancel(ctx)
+	d.wg.Add(1)
+	go func() {
+		defer d.wg.Done()
+		defer func() { <-d.slots }()
+		defer func() {
+			if rec := recover(); rec != nil {
+				d.log.Error("recovered from panic in detached work", "panic", rec, "stack", string(debug.Stack()))
+			}
+		}()
+		if d.timeout > 0 {
+			var cancel context.CancelFunc
+			work, cancel = context.WithTimeout(work, d.timeout)
+			defer cancel()
+		}
+		fn(work)
+	}()
+	return true
+}
+
+// Drain waits for in-flight work to finish, bounded by ctx. A wedged handler
+// must not be able to block shutdown forever.
+func (d *Dispatcher) Drain(ctx context.Context) {
+	done := make(chan struct{})
+	go func() { d.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		d.log.Warn("drain timed out with work still in flight")
+	}
+}

--- a/internal/thread/dispatch_test.go
+++ b/internal/thread/dispatch_test.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package thread
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestDispatcherRunsWork(t *testing.T) {
+	d := NewDispatcher(2, time.Minute, testLogger())
+	done := make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(done) }) {
+		t.Fatal("Go returned false with free slots")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("work never ran")
+	}
+}
+
+func TestDispatcherRefusesWhenSaturated(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	block, running := make(chan struct{}), make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(running); <-block }) {
+		t.Fatal("first Go refused")
+	}
+	<-running
+	if d.Go(context.Background(), func(context.Context) { t.Error("must not run when saturated") }) {
+		t.Fatal("Go returned true while saturated")
+	}
+	close(block)
+}
+
+func TestDispatcherSlotIsReleasedAfterWork(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	for i := 0; i < 3; i++ {
+		done := make(chan struct{})
+		if !d.Go(context.Background(), func(context.Context) { close(done) }) {
+			t.Fatalf("Go %d refused: the slot was not released", i)
+		}
+		<-done
+		d.Drain(context.Background())
+	}
+}
+
+func TestDispatcherSlotIsReleasedAfterPanic(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	panicked := make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(panicked); panic("boom") }) {
+		t.Fatal("first Go refused")
+	}
+	<-panicked
+	d.Drain(context.Background())
+	done := make(chan struct{})
+	if !d.Go(context.Background(), func(context.Context) { close(done) }) {
+		t.Fatal("slot leaked after a panic")
+	}
+	<-done
+}
+
+func TestDispatcherAppliesTimeout(t *testing.T) {
+	d := NewDispatcher(1, 50*time.Millisecond, testLogger())
+	var cancelled atomic.Bool
+	done := make(chan struct{})
+	d.Go(context.Background(), func(ctx context.Context) {
+		<-ctx.Done()
+		cancelled.Store(true)
+		close(done)
+	})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the timeout never fired")
+	}
+	if !cancelled.Load() {
+		t.Fatal("work context was not cancelled by the timeout")
+	}
+}
+
+func TestDispatcherWorkOutlivesTheCallersContext(t *testing.T) {
+	// The caller's context is a request context that is cancelled the moment the
+	// handler returns. Work must NOT die with it — only with the dispatcher's own
+	// timeout — or every mention would be cancelled before it could be written.
+	d := NewDispatcher(1, time.Minute, testLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	started, result := make(chan struct{}), make(chan error, 1)
+	d.Go(ctx, func(wctx context.Context) {
+		close(started)
+		time.Sleep(50 * time.Millisecond)
+		result <- wctx.Err()
+	})
+	<-started
+	cancel()
+	if err := <-result; err != nil {
+		t.Fatalf("work context was cancelled with the caller's: %v", err)
+	}
+}
+
+func TestDispatcherDrainWaitsForInFlightWork(t *testing.T) {
+	d := NewDispatcher(2, time.Minute, testLogger())
+	var finished atomic.Int32
+	release := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		d.Go(context.Background(), func(context.Context) { <-release; finished.Add(1) })
+	}
+	go func() { time.Sleep(50 * time.Millisecond); close(release) }()
+	d.Drain(context.Background())
+	if got := finished.Load(); got != 2 {
+		t.Fatalf("Drain returned with %d/2 finished", got)
+	}
+}
+
+func TestDispatcherDrainIsBounded(t *testing.T) {
+	d := NewDispatcher(1, time.Minute, testLogger())
+	block := make(chan struct{})
+	defer close(block)
+	d.Go(context.Background(), func(context.Context) { <-block })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	d.Drain(ctx)
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("Drain blocked %v on a wedged handler; it must honour its context", elapsed)
+	}
+}

--- a/internal/thread/registry.go
+++ b/internal/thread/registry.go
@@ -398,15 +398,16 @@ func (r *Registry) GetOrCreate(root string, fallback Context) (tc Context, creat
 }
 
 // Register records a delivered investigation against the thread root it was
-// posted to. It implements notify.ThreadSink, so the Slack notifier can hand
-// over the ts it already has without knowing what a registry is. Best-effort by
-// contract: a failure here must never affect delivery, so the error is dropped.
-func (r *Registry) Register(root, channel string, inv providers.Investigation) {
+// posted to on transport. It implements notify.ThreadSink, so a notifier (Slack,
+// Matrix, …) can hand over the root/channel it already has, plus which transport
+// delivered it, without knowing what a registry is. Best-effort by contract: a
+// failure here must never affect delivery, so the error is dropped.
+func (r *Registry) Register(transport, root, channel string, inv providers.Investigation) {
 	if root == "" {
 		return
 	}
 	_ = r.Put(Context{
-		Transport:     "slack",
+		Transport:     transport,
 		Root:          root,
 		Channel:       channel,
 		TriggerKey:    inv.TriggerKey,

--- a/internal/thread/registry_test.go
+++ b/internal/thread/registry_test.go
@@ -128,7 +128,7 @@ func TestRegistryRegisterFromInvestigation(t *testing.T) {
 		RecalledEntry: "incidents/foo.md",
 		Resource:      providers.Workload{Kind: "Deployment", Name: "gallery", Namespace: "apps"},
 	}
-	r.Register("111.222", "C1", inv)
+	r.Register("slack", "111.222", "C1", inv)
 
 	got, ok := r.Get("111.222")
 	if !ok {
@@ -455,8 +455,30 @@ func TestRegistryRegisterIgnoresEmptyRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
-	r.Register("", "C1", providers.Investigation{Title: "x"})
+	r.Register("slack", "", "C1", providers.Investigation{Title: "x"})
 	if _, ok := r.Get(""); ok {
 		t.Fatal("an empty root must never be stored")
+	}
+}
+
+// TestRegistryRegisterUsesCallerTransport proves Register stamps the
+// transport its CALLER passed, not a hardcoded one — Register used to always
+// write Transport: "slack" regardless of which notifier called it, which
+// mislabels every Matrix-originated note as coming from Slack in the
+// generated KB PR (thread.NoteBody / thread.ConceptEntry render tc.Transport
+// verbatim). A registry fed by a Matrix delivery must record "matrix".
+func TestRegistryRegisterUsesCallerTransport(t *testing.T) {
+	r, err := NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	r.Register("matrix", "$evt123", "!room:example.org", providers.Investigation{Title: "OOMKilled"})
+
+	got, ok := r.Get("$evt123")
+	if !ok {
+		t.Fatal("Register did not store the thread")
+	}
+	if got.Transport != "matrix" {
+		t.Fatalf("Transport = %q, want matrix — Register must not hardcode the caller's transport", got.Transport)
 	}
 }

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -461,8 +461,9 @@ synthetic findings out of the review queue while still notifying chat (see
 
 ### `notify` — where findings go
 `slack` (`webhook_url_env` or `bot_token_env`, `channel`, `signing_secret_env`, `approver_ids`,
-`feedback_buttons`, `thread_capture`), `matrix` (`homeserver`, `room_id`, `access_token_env`), plus
-inline blocks for any registered notifier (e.g. `webhook` with `url_env`).
+`feedback_buttons`, `thread_capture`), `matrix` (`homeserver`, `room_id`, `access_token_env`,
+`feedback_reactions`, `thread_capture`), plus inline blocks for any registered notifier (e.g.
+`webhook` with `url_env`).
 
 Every notifier now leads with the model's **verdict** (`no_action` / `action_suggested` /
 `action_required` / `inconclusive`) and carries the trigger-time alert metadata (severity, environment,
@@ -534,6 +535,17 @@ attributes nothing). Startup fails loud unless `homeserver`/`room_id`/`access_to
 `outcome.ledger_path` are set. Use an **invite-only room** — any room member can vote (see
 [security-model.md]({{< relref "security-model.md#the-feedback-channels---exposure--trust-model" >}})).
 
+> [!NOTE]
+> **`feedback_reactions` and Matrix `thread_capture` (below) are two independently-gated
+> capabilities sharing ONE listener.** Turning on either starts the same leader-only `/sync` long-poll
+> goroutine — there is one Matrix listener and one `/sync` connection per process, never two, no matter
+> how many of the two flags are on. Each flag independently controls both what that shared `/sync`
+> filter asks the homeserver for (`m.reaction` for `feedback_reactions`, `m.room.message` for
+> `thread_capture`) AND, in code, whether the corresponding handler is allowed to act — enabling one
+> never turns the other's handling on. The practical upshot: enabling only one still means both ride
+> the same poll loop, so a homeserver hiccup or a leadership change pauses whichever of the two you
+> have enabled together.
+
 **🧵 Thread capture — `thread_capture` (opt-in, default `false`).** When enabled, replying inside a
 Slack investigation thread with `@runlore note: <text>` writes what you know back into the knowledge
 base as a reviewed PR — a comment on the finding's existing KB PR, or a small `Concept` entry PR when
@@ -579,6 +591,41 @@ the `reinvestigate` label to the knowledge-base issue instead.
 
 With the option off (the default), `@runlore note: …` mentions are ignored and the endpoint behaves
 exactly as before (404 unless another feature wired it).
+
+**🧵 Matrix thread capture — `thread_capture` (opt-in, default `false`).** The same feature as
+Slack's thread capture, over Matrix: replying inside an investigation thread with
+`@runlore note: <text>` writes what you know back into the knowledge base as a reviewed PR — a
+comment on the finding's existing KB PR, or a small `Concept` entry PR when the finding has none, so
+the knowledge still lands somewhere. A human reviews and merges it like every other entry.
+`@runlore reinvestigate: …` is reserved and not supported yet. RunLore recognises being addressed via
+MSC3952 `m.mentions`, or — as a fallback — the bot's full Matrix ID or localpart in the message body;
+a reply is attributed to its thread via the MSC3440 `m.thread` relation (falling back to
+`m.in_reply_to`). One thread registry backs both transports, so a thread capture note is written back
+through the same responder Slack's uses (same per-hour PR-open budget, same `Concept`-entry fallback).
+
+> [!IMPORTANT]
+> **The `/sync` filter widens while this is on — said plainly, not softened.** With
+> `thread_capture: false` (the default), RunLore's `/sync` filter requests only `["m.reaction"]`.
+> With `thread_capture: true`, it widens to `["m.reaction","m.room.message"]`: **the process now
+> receives message events** from the configured room, where before it received only reactions.
+> RunLore acts only on messages that address it and are rooted in one of its own investigation
+> messages — everything else is dropped immediately, its body never logged — but every message
+> in the room does transit the process first. Unlike Slack's thread capture, **no exposed HTTP
+> endpoint, no ingress change and no new permission is required**: this rides the same outbound
+> long-poll RunLore already runs for `feedback_reactions`. See
+> [security-model.md → Matrix thread
+> capture]({{< relref "/docs/security/security-model.md#matrix-thread-capture-notifymatrixthread_capture--a-widened-sync-filter" >}})
+> for the full trade-off against Slack's exposed endpoint.
+
+> [!NOTE]
+> **Mount the credential, too.** If `access_token_env` names an env var that is present but **empty**,
+> the listener never starts: no message is delivered or received, and no knowledge can be captured.
+> Config validation cannot see runtime emptiness, so startup logs a **warning** naming the empty env
+> var instead of announcing the feature.
+
+Startup fails loud unless `homeserver`/`room_id`/`access_token_env` and `outcome.ledger_path` are set
+— the same requirement `matrix.feedback_reactions` has above. With the option off (the default), the
+`/sync` filter is unchanged and `@runlore note: …` mentions are not read.
 
 ### Generic templated notifier (`notify.templated`)
 

--- a/website/content/docs/integrations/notifications/matrix.md
+++ b/website/content/docs/integrations/notifications/matrix.md
@@ -47,6 +47,69 @@ kubectl -n runlore logs deploy/runlore | grep 'msg=findings'
 - Startup fails loud unless `homeserver`/`room_id`/`access_token_env` and `outcome.ledger_path` are
   set.
 - Use an **invite-only room** — any room member can vote.
+- **`feedback_reactions` and `thread_capture` are two independently-gated capabilities sharing ONE
+  listener.** Enabling either starts the same `/sync` long-poll and the same leader-only goroutine —
+  there is one Matrix listener and one `/sync` connection per process, never two. What differs per
+  flag is which event types that shared `/sync` filter requests and which handler actually acts on
+  them: `feedback_reactions` alone asks for `m.reaction` and only ever calls the reaction handler;
+  `thread_capture` alone asks for `m.room.message` and only ever calls the message handler. With both
+  on, the filter requests both event types over that same connection. Turning one on never turns the
+  other's handling on — each is gated on its own flag in code, not just requested-or-not on the wire —
+  but it does mean a homeserver hiccup or a leadership change pauses whichever capabilities are
+  enabled together, since they ride the same poll loop.
+
+### Write knowledge back from a thread
+
+With `thread_capture` on, replying inside an investigation thread records what you know into the
+knowledge base:
+
+    @runlore note: the real cause was the spot-node reclaim at 14:02
+
+RunLore recognises being addressed via MSC3952 `m.mentions` when your client sends it, or — as a
+fallback — the bot's full Matrix ID or its localpart (`runlore` in `@runlore:example.org`)
+appearing anywhere in the message body. A reply is attributed to its thread via the MSC3440
+`m.thread` relation, falling back to `m.in_reply_to` for clients that only send the legacy
+non-threaded reply fallback.
+
+The note lands as a comment on that finding's knowledge-base PR. When the finding has no PR — an
+instant recall, or a `no_action` verdict — RunLore opens a small `Concept` entry PR instead, so the
+knowledge still lands somewhere. A human reviews and merges it, like every other entry.
+
+`@runlore reinvestigate: …` is reserved and not supported yet; add the `reinvestigate` label to the
+knowledge-base issue to re-run an investigation.
+
+```yaml
+notify:
+  matrix:
+    homeserver: https://matrix.org
+    room_id: "!yourroom:matrix.org"
+    access_token_env: MATRIX_TOKEN
+    thread_capture: true
+outcome:
+  ledger_path: /var/lib/runlore/outcome.jsonl   # required: the thread registry lives beside it
+```
+
+`thread_capture: true` also requires `outcome.ledger_path` — the same registry Slack's thread
+capture uses (one registry, shared by both transports): see [Configuration →
+`notify`]({{< relref "/docs/configuration/configuration.md#notify--where-findings-go" >}}) for the
+full persistence breakdown. **Matrix degrades more gracefully than Slack when the registry itself
+is unavailable** (past its TTL, evicted past the size cap, or orphaned by a restart or leader
+failover onto a replica that never saw it): every investigation message RunLore posts also carries
+its own thread identity stamped directly on the Matrix event. A reply still resolves against that
+stamp — fetched straight from the homeserver and re-verified as sent by RunLore itself — so a
+registry miss answers the note instead of refusing it with "no context for this thread." What the
+registry alone tracks (the standalone note PR a thread already opened, and how many notes it has
+used against the per-thread cap) is unavailable on a fallback resolution, so a note recorded this
+way opens a fresh `Concept` PR rather than commenting on one an earlier note in the same thread
+opened. Slack has no per-event stamp to fall back to, so a registry miss there is unrecoverable —
+see Configuration's restart/leader-failover warning for what that costs.
+
+**Unlike Slack, this needs no exposed HTTP endpoint, no ingress change and no new permission.**
+Mentions arrive over the same outbound `/sync` long-poll RunLore already runs for
+`feedback_reactions` — turning `thread_capture` on only widens what that poll asks the homeserver
+for. That widening is real and worth understanding before you flip the flag: see [Security model →
+Matrix thread
+capture]({{< relref "/docs/security/security-model.md#matrix-thread-capture-notifymatrixthread_capture--a-widened-sync-filter" >}}).
 
 ## Reference
 

--- a/website/content/docs/security/security-model.md
+++ b/website/content/docs/security/security-model.md
@@ -238,6 +238,46 @@ verified the same way, so an attacker cannot repoint your endpoint by guessing t
 **Expose only the paths you use** above — `/slack/events` needs the same ingress treatment as
 `/slack/interactions`, nothing more.
 
+## Matrix thread capture (`notify.matrix.thread_capture`) — a widened `/sync` filter
+
+Opt-in and separate from the feedback channels above, same as Slack's: replying `@runlore note: …`
+inside an investigation thread lets a human write what they know straight into a knowledge-base PR —
+reviewed and merged like any other curated entry, never applied automatically. It shares Matrix
+feedback's *exposure* story above (nothing inbound-reachable), but not its vote trust model, which is
+why it gets its own section here too.
+
+**The `/sync` filter widens while this is on — stated plainly, not softened.** With
+`notify.matrix.thread_capture` off (the default), RunLore's `/sync` filter requests only
+`["m.reaction"]`: the process receives reactions in the configured room and nothing else. With
+`notify.matrix.thread_capture: true`, the filter widens to `["m.reaction","m.room.message"]` —
+**the process now receives message events** from the configured room, where before it received only
+reactions. That is what the option does the moment it is on; it is not a hypothetical worst case.
+
+RunLore does not act on every message it receives. Two checks run before anything else happens: is
+the message addressed to it (`m.mentions`, or the bot's own MXID/localpart appearing in the body —
+the same detection `addressed()` implements in the listener), and is it rooted, via the `m.thread`
+relation or the `m.in_reply_to` fallback, in one of RunLore's own investigation messages (the same
+sender-is-the-bot trust anchor the feedback-reactions attribution check above uses). A message that
+fails either check is dropped immediately, and its body is never logged. But — the honest part —
+**every message in the room does transit the process first**: the homeserver delivers it over
+`/sync`, and RunLore parses it far enough to run those two checks, before deciding to discard it. A
+member's ordinary chatter, and anything typed in a thread RunLore never started, reaches the process
+and is read, even though nothing from it is ever stored or written anywhere.
+
+**The trade Matrix makes here is the transport's genuine advantage over Slack.** Enabling this needs
+no exposed HTTP endpoint, no ingress change, and no new Kubernetes permission: the widened filter
+rides the same outbound long-poll RunLore already runs for `feedback_reactions`, so there is nothing
+new to route through your ingress or open in a NetworkPolicy. Weigh the two transports' opposite
+trade-offs before choosing between them: [Slack's thread
+capture](#slack-thread-capture-notifyslackthread_capture--a-second-exposed-endpoint) keeps its
+inbound event stream limited to `app_mention` but adds an exposed, internet-reachable endpoint;
+Matrix's stays unexposed but widens what it reads from a room it already polls.
+
+Operational requirement, same reasoning as `matrix.feedback_reactions` above: use an **invite-only
+room**. With thread capture on, every room member's messages reach the process (even though only an
+addressed, correctly-rooted one is ever acted on), so an open room widens who can even attempt to be
+heard by it.
+
 ## Honest limitations
 
 - **The model sees cluster data.** Even with redaction, tool output reaches your model provider. The


### PR DESCRIPTION
Adds the **Matrix** transport for thread interaction. Same feature as #482, same core, second chat system:

```
RunLore  ImageGalleryUnavailable — apps/xplane-image-gallery
         Action required · High confidence 92% · cause: AWS DeleteSecret
         📎 knowledge-base PR #42

  └ you   @runlore note: real cause was the spot-node reclaim at 14:02.

  └ RunLore  📝 Noted on KB PR #42 — it'll be there when you review it.
```

> **Stacked on #482.** Review that one first; this branch is based on it and the diff below is Matrix-only.

## Why this is cheap on Matrix

Slack needed a new internet-facing endpoint, an ingress change and an `app_mentions:read` scope. Matrix needs **none of those**. RunLore already long-polls `/sync` for 👍/👎 reactions, and `Matrix.Deliver` already stamps a custom content field the reaction listener reads back. This widens both.

The cost is one thing, and it's disclosed prominently rather than buried: with `thread_capture` on, the `/sync` filter widens from `["m.reaction"]` to also include `["m.room.message"]`, so **every message in the room transits the process**. RunLore acts only on messages addressing it and rooted in its own messages, and drops the rest immediately without logging their bodies — but they do transit. The filter widens only when the feature is enabled, and a reactions-only deployment never asks the homeserver for messages at all.

## One responder, two transports

`internal/thread` was built transport-agnostic in #482 and is reused unchanged in substance. Both transports now share one `Responder`, one `Registry` and one forge. What differs is only how each answers three questions: *did a human address us*, *which investigation is this thread about*, and *how do we reply*.

Matrix answers the middle one twice over: the registry (primary — it holds the `NoteURL`/`Notes` write-back state) with the event stamp as fallback. That combination survives a restart or leader failover, which neither does alone.

## Three things the spec got wrong, and the code corrected

The design spec was written before reading `matrix_feedback.go` closely. Three of its assumptions didn't survive contact:

- **The `/sync` loop is a single goroutine.** Handling a note inline would stall long-polling for minutes while forge round-trips complete, pausing reaction recording. The bounded dispatcher #482 built inside `internal/server` was extracted to `internal/thread` so both transports share one implementation rather than drifting.
- **`Multi.ThreadReplier()` returned the first capable notifier** — unambiguous while Slack was the only one. The moment Matrix could reply, a deployment running both would answer Matrix threads via Slack. Now keyed by transport.
- **`Matrix.Deliver` discarded its send response**, so it never learned the `event_id` of the message it had just posted — and that id *is* the thread root.

## Config

```yaml
notify:
  matrix:
    homeserver: https://matrix.example.org
    room_id: "!abc:example.org"
    access_token_env: MATRIX_TOKEN
    thread_capture: true          # default false
outcome:
  ledger_path: /var/lib/runlore/outcome.jsonl   # required; startup fails loud without it
```

`thread_capture` and `feedback_reactions` are independently gated but share one listener and one `/sync` connection — the docs say so explicitly, because the naming suggests otherwise.

**Backward compatible.** A deployment using only Slack thread capture, or only Matrix reactions, behaves exactly as before.

## Review notes

- Spec: `dev/superpowers/specs/2026-08-14-thread-interaction-design.md` (§Matrix transport)
- Plan: `dev/superpowers/plans/2026-08-15-thread-interaction-pr2-matrix.md`

Several commits fix defects found in review rather than adding features, and they're the most informative reading:

- The thread sink was never wired in the notifier registry, so **the feature could not function at all** — every reply hit a registry miss. It passed six task reviews because every test set the sink by hand, bypassing the real constructor. There is now a regression test that goes through it.
- The new event stamp **shadowed the legacy trigger-key field**, silently stopping 👍/👎 recording for every `reinvestigate`-label re-run — in deployments that enabled nothing on this branch.
- The thread grammar was **dead on Matrix**: `Parse` strips Slack-shaped `<@U…>` tokens, but Matrix clients send a display name or bare MXID. `note:` never parsed, and the deliberately-reserved `reinvestigate:` fell through to freeform — which is treated like a note — so it opened a junk `Concept` PR containing the operator's re-run request.

All three were invisible to a green `-race` suite because the fixtures described a world the code doesn't live in. The tests added alongside the fixes drive the real pipeline and assert forge calls, not parser output.

## Not in scope

Conversational replies (PR3), gated on the presence of `model.chat`. This branch contains **no model calls**.
