### PR TITLE
feat(thread): show what landed in the KB, and announce it to every sink

### DIFF
--- a/dev/superpowers/plans/2026-08-16-thread-interaction-pr4-feedback.md
+++ b/dev/superpowers/plans/2026-08-16-thread-interaction-pr4-feedback.md
@@ -1,0 +1,214 @@
+# PR4 — tell the human what landed, and tell the other sinks
+
+Stacked on PR3 (#484). Two features, decided with the owner:
+
+1. The thread reply shows **what was recorded**, not just a PR link.
+2. A KB write is **announced to every configured notifier**, not only the thread it came from.
+
+Constraints carried from `.superpowers/sdd/pr4-scope.md`. Read that file first.
+
+## Why these two are one PR
+
+Both need the same thing that does not exist today: a description of what a write actually
+did. `write()` returns `(msg string, landed bool, err error)` and builds `NoteBody` /
+`ConceptEntry` inline, so nothing downstream can name the entry, quote the note, or say
+which route was taken. Task 1 produces that value once; tasks 2 and 4 consume it.
+
+## Non-goals
+
+- No new forge calls. The reply and the announcement describe what was already written; they
+  never re-read the forge to enrich it.
+- No diff of the KB. `providers.Ref` is `{URL string}`; asking the forge what files changed is
+  a second round trip on the incident path.
+- No new model calls anywhere in this PR.
+
+---
+
+### Task 1: Return what the write actually did
+
+**Files:** `internal/thread/responder.go`, `internal/thread/responder_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+- `write()` reports the route taken (`comment` on a linked PR, or `open_pr`), the PR number,
+  the URL, and — on the `open_pr` route — the entry title `ConceptEntry` generated.
+- It reports the note text **as written**: redacted and capped, not the caller's raw input.
+  Assert with a message carrying a secret and exceeding the cap: the reported text must be
+  masked and capped, byte-identical to what reached the forge.
+- Every existing return path keeps its current reply string byte-for-byte. This task changes
+  what `write()` RETURNS, not what it says.
+- A throttled, capped, or failed write reports no result — a caller must not be able to
+  announce a write that did not happen.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+`go test ./internal/thread/ -run TestWriteReports -v` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+Add a `KBWrite` struct and return `(string, *KBWrite, error)` — a nil pointer where `landed`
+was false, so "nothing landed" and "here is what landed" are one value that cannot disagree
+with itself. That is deliberate: the current `(msg, landed, err)` shape lets a caller read
+`landed` and ignore `err`, and this package has shipped that class of bug three times.
+
+The note text must come from ONE evaluation of the redact+cap pipeline, shared with the body
+that goes to the forge. Do not re-derive it separately — two call sites drift.
+
+- [ ] **Step 4: Run tests and commit**
+
+```bash
+git commit -m "refactor(thread): report what a knowledge write did, not just that it did
+
+write() built its body inline and returned a bool, so no caller could name the
+entry, quote what was filed, or say which route was taken. The reply strings are
+unchanged; only the return value grows." -- internal/thread/responder.go internal/thread/responder_test.go
+```
+
+---
+
+### Task 2: Quote what was recorded, back into the thread
+
+**Files:** `internal/thread/responder.go`, `internal/thread/responder_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+- After a note lands, the reply quotes the recorded text and names the entry (`open_pr` route)
+  or the PR it was added to (`comment` route). The URL stays.
+- **The quote is bounded independently of `MaxNoteBytes`.** A note at the 8 KiB cap must not
+  produce an 8 KiB chat message. Assert a preview ceiling and that a truncated preview says so.
+- **The quoted text is marked `Untrusted`** (PR3's mechanism) so each transport escapes it.
+  This is the highest-value assertion in the task: the quote is note content echoed back into
+  a chat system, and on the model-drafted route the model wrote it.
+- The model-drafted route is still marked as model-drafted in the reply — quoting the text must
+  not make it read as the human's words. `ProposedNote` already carries the distinction.
+- A `note:` write with chat off quotes it too: the human should see what was captured either way.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+`go test ./internal/thread/ -run TestReplyQuotes -v` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+Render from Task 1's `KBWrite`. Keep RunLore's own framing (the `📝` status line, the URL)
+outside the untrusted mark, exactly as `modelVoice` does — the marks wrap CONTENT, never
+RunLore's own bytes.
+
+- [ ] **Step 4: Run tests and commit**
+
+---
+
+### Task 3: A KB-update event, and the capability to receive it
+
+**Files:** `internal/providers/providers.go`, `internal/providers/providers_test.go`,
+`internal/notify/slack.go` (Multi), `internal/notify/slack_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+- `Multi.DeliverKBUpdate` fans out to every notifier implementing the new capability and
+  **skips those that do not**, exactly as `DeliverProgress` does its `ProgressNotifier` check.
+- Best-effort: a failing sink is logged and swallowed, never propagated. A broadcast must never
+  fail or roll back a KB write that already happened.
+- A nil/empty `Multi` is a no-op.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Implement**
+
+Add `providers.KBUpdate` (transport and thread root of origin, route, entry title, URL, author,
+the recorded note text, timestamp) and `providers.KBUpdateNotifier` as an OPTIONAL interface.
+**Do not widen `providers.Notifier`** — every existing sink would have to change, and the repo's
+own pattern for "some sinks can do this" is the capability check.
+
+Document on `KBUpdate` that `Note`, `Title` and `Author` are UNTRUSTED — redacted upstream, but
+still model- or human-authored — so every implementer escapes them like any other untrusted text.
+
+- [ ] **Step 4: Run tests and commit**
+
+---
+
+### Task 4: Announce a write through the notifier fan-out
+
+**Files:** `internal/thread/responder.go`, `internal/thread/responder_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+- On a successful write, the responder emits one `KBUpdate` carrying Task 1's values.
+- **Nothing is emitted when nothing landed** — throttled, capped, failed, or no note proposed.
+  Assert each.
+- A nil sink is off and must not panic (the package's nil-safe contract).
+- The emit is **best-effort and must not affect the reply**: a sink that errors or blocks must
+  not change what the human is told, nor delay it. Decide sync vs async deliberately and say why
+  in the doc comment; if async, it must be bounded and drainable like `thread.Dispatcher`.
+- The `KBUpdate` names its origin transport and thread root, so a consumer can tell where it
+  came from.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Implement**
+
+`Responder` gains a sink field (nil ⇒ off). Keep `internal/thread` transport-agnostic: it emits
+a `providers.KBUpdate`, it does not know what a room or a channel is.
+
+**Bounding:** every emit follows a forge write, which `ForgeWrites` already caps globally per
+hour, so the announcement rate is bounded by that ceiling and needs no second one. State this in
+the doc comment — and if the analysis turns out to be wrong, add the ceiling instead of assuming.
+
+- [ ] **Step 4: Run tests and commit**
+
+---
+
+### Task 5: Config and wiring
+
+**Files:** `internal/config/config.go`, `internal/config/config_test.go`,
+`internal/app/notify.go`, `internal/app/notify_test.go`, `internal/app/serve.go`,
+`internal/app/serve_thread_wiring_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+- `notify.thread.announce_kb_updates` (bool, **default false**). Opt-in: it adds notification
+  volume to channels that did not ask for it, and the thread reply is already the direct
+  acknowledgement.
+- Absent ⇒ off; explicitly false ⇒ off; true ⇒ the responder gets a real sink.
+- **The wiring is pinned through the real construction path**, not by building the struct by
+  hand. Extend `serve_thread_wiring_test.go`'s static guard — this series has four times shipped
+  something green and inert, and this is another closure-assigned dependency.
+- With the key on but no notifier configured, startup must not claim the feature is active.
+  Consider a `*Warning` (the repo's convention, and `warnings_wired_test.go` will require it to
+  be emitted).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run tests and commit**
+
+---
+
+### Task 6: Implement the capability on the real sinks, and document it
+
+**Files:** `internal/notify/slack.go`, `internal/notify/matrix.go`,
+`internal/notify/webhook/`, `internal/notify/templated/`, their tests, `website/content/docs/`
+
+- [ ] **Step 1: Write the failing test**
+
+- Slack and Matrix render a KB-update announcement and **escape its untrusted spans** — assert
+  `<!channel>` and `@room` are neutralised, the same guarantee PR3 established for replies. This
+  is a NEW egress for model-authored text; it needs the guarantee from its first commit, not
+  from a later review.
+- Webhook/templated: either implement the capability or deliberately do not. Whichever you
+  choose, a test states it — an unimplemented capability is a silent skip in `Multi`, which must
+  be intentional rather than accidental.
+- Docs: extend the "Four ways knowledge gets in" section (`concepts/reviewing-knowledge.md`) and
+  the transport pages with the new key and what it broadcasts. Note that the announcement carries
+  note content, so a private note reaches every configured sink — that is the operator's call to
+  make knowingly.
+- `internal/docsguard` covers any new default that appears in the docs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+- [ ] **Step 3: Implement**
+
+- [ ] **Step 4: Run full gate, build the site, commit**
+
+Site build: `/usr/bin/hugo` (0.164.0 — the one on PATH is 0.139.0 and cannot build this site),
+`--destination` to a scratch dir outside the repo, never edit `website/public/`.

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -112,7 +112,14 @@ func ThreadCaptureDeliverable(cfg *config.Config, log *slog.Logger) bool {
 // built once by buildThreadChat and carried on the same single responder for
 // the same reason ForgeWrites is: its per-hour Budget must bound token spend
 // system-wide, not once per transport.
-func buildThreadResponder(cfg *config.Config, threadRegistry *thread.Registry, forge thread.Forge, chat *thread.Chat, metrics *telemetry.Metrics, log *slog.Logger) *thread.Responder {
+//
+// notifier is the process's fan-out sink, and it is here for the announcement
+// half: with notify.thread.announce_kb_updates on, a landed knowledge write is
+// broadcast to every configured notifier's OWN channel or room (see
+// buildKBAnnouncer), never back into the thread the reply already went to. It
+// may be nil — the log-only path builds no notifier at all — which is one of
+// the two ways announcements end up off.
+func buildThreadResponder(cfg *config.Config, threadRegistry *thread.Registry, forge thread.Forge, chat *thread.Chat, notifier *notify.Multi, metrics *telemetry.Metrics, log *slog.Logger) *thread.Responder {
 	return &thread.Responder{
 		Forge:             forge,
 		Registry:          threadRegistry,
@@ -121,9 +128,90 @@ func buildThreadResponder(cfg *config.Config, threadRegistry *thread.Registry, f
 		MaxNoteBytes:      cfg.Notify.Thread.EffectiveMaxNoteBytes(),
 		ForgeRepo:         forgeRepoRef(cfg),
 		Chat:              chat,
+		Announcer:         buildKBAnnouncer(cfg, notifier, log),
 		Metrics:           metrics,
 		Log:               log,
 	}
+}
+
+// buildKBAnnouncer assembles the knowledge-base announcer, or returns nil when
+// announcements are off — either because notify.thread.announce_kb_updates was
+// not turned on (the default) or because there is no sink to deliver to.
+//
+// nil is the feature's off switch (thread.Responder.Announcer is nil-safe), and
+// the two conditions collapse into that ONE value deliberately: an announcer
+// wired to a notifier holding no sinks would hold a dispatcher, its slots and
+// its goroutines to deliver every announcement to nobody, which is a live
+// feature by every observable signal and a no-op in fact.
+//
+// The nil check on notifier before handing it over is not incidental. It is a
+// concrete *notify.Multi and thread.NewKBAnnouncer takes an interface: passing a
+// nil pointer through would produce a NON-nil providers.KBUpdateNotifier holding
+// a nil Multi, so "announcements are off" and "announcements are on, delivering
+// nowhere" would become indistinguishable — the same typed-nil trap
+// buildThreadChat documents for Chat.Catalog.
+//
+// The Info line states the capability check rather than claiming delivery:
+// notify.Multi announces only to sinks implementing providers.KBUpdateNotifier
+// and silently skips the rest, so the number of CONFIGURED notifiers is an upper
+// bound on how many will actually render an announcement, not a promise.
+func buildKBAnnouncer(cfg *config.Config, notifier *notify.Multi, log *slog.Logger) *thread.KBAnnouncer {
+	sinks := 0
+	if notifier != nil {
+		sinks = notifier.Len()
+	}
+	if msg := KBAnnounceInertWarning(cfg, sinks); msg != "" {
+		log.Warn(msg)
+	}
+	if !cfg.Notify.Thread.AnnounceKBUpdates || sinks == 0 {
+		return nil
+	}
+	log.Info("thread knowledge-base announcements enabled",
+		"notifiers", sinks,
+		"note", "each configured notifier that implements the announcement capability receives them, in its own channel or room; the thread reply is unchanged")
+	return thread.NewKBAnnouncer(notifier, log)
+}
+
+// KBAnnounceInertWarning reports that notify.thread.announce_kb_updates is on
+// while nothing can act on it, naming which end is missing; "" when the key is
+// off or the feature can actually fire.
+//
+// Every dependency on this path is nil-safe by design — a nil sink means
+// announcements are off, and nothing anywhere errors — so both failures are
+// completely silent today. Startup must not stay silent about a feature that was
+// explicitly asked for and cannot fire.
+//
+// The two ends the announcement needs are checked separately because the fix
+// differs. Delivery: no notifier was built (none configured, or the only one's
+// credential resolved empty at runtime and left Multi with nothing in it), so
+// every announcement goes to nobody. Production: no transport captures knowledge
+// from a thread, so no write ever happens to announce — the same reachability
+// gap ChatWithoutCaptureWarning reports for the chat layer, on the feature that
+// sits one hop further along the same path. One message at a time: they have
+// different remedies, and a deployment with both is a deployment where the key
+// was set before anything else was.
+//
+// A warning rather than a Validate error, for the same reason
+// ChatWithoutCaptureWarning is one: the operator may be staging the rest of the
+// configuration, and nothing else is degraded — with capture on, the note is
+// still written and the human in the thread is still answered. Only the
+// broadcast is missing.
+func KBAnnounceInertWarning(cfg *config.Config, sinks int) string {
+	if !cfg.Notify.Thread.AnnounceKBUpdates {
+		return ""
+	}
+	if sinks == 0 {
+		return "notify.thread.announce_kb_updates is enabled but no notifier is configured, so a knowledge-base " +
+			"write is announced to nobody: the note is still written and the thread still gets its reply, but " +
+			"nothing is broadcast — configure notify.slack / notify.matrix (or another registered notifier), or " +
+			"turn the key off"
+	}
+	if !cfg.Notify.Slack.ThreadCapture && !cfg.Notify.Matrix.ThreadCapture {
+		return "notify.thread.announce_kb_updates is enabled but neither notify.slack.thread_capture nor " +
+			"notify.matrix.thread_capture is: no thread can write to the knowledge base, so there is never " +
+			"anything to announce — enable capture on a transport, or this is dead config"
+	}
+	return ""
 }
 
 // forgeRepoRef is the WEB identity of the repository RunLore curates into —

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -345,7 +345,7 @@ func TestBuildThreadMentionWiresForgeWritesAndMetrics(t *testing.T) {
 		t.Fatalf("BuildEnabled: %v", err)
 	}
 	metrics := telemetry.NewMetrics()
-	responder := buildThreadResponder(cfg, reg, fakeThreadForge{}, nil, metrics, log)
+	responder := buildThreadResponder(cfg, reg, fakeThreadForge{}, nil, nil, metrics, log)
 
 	m := BuildThreadMention(cfg, responder, notifier, log)
 	if m == nil {
@@ -398,7 +398,7 @@ func TestBuildThreadResponderWiresTheForgeRepoRef(t *testing.T) {
 			cfg := &config.Config{}
 			cfg.Forge.KBRepo = "acme/kb"
 			tt.mut(cfg)
-			if got := buildThreadResponder(cfg, reg, fakeThreadForge{}, nil, nil, log).ForgeRepo; got != tt.want {
+			if got := buildThreadResponder(cfg, reg, fakeThreadForge{}, nil, nil, nil, log).ForgeRepo; got != tt.want {
 				t.Fatalf("ForgeRepo = %q, want %q", got, tt.want)
 			}
 		})
@@ -803,21 +803,170 @@ func TestBuildThreadResponderCarriesTheChatLayer(t *testing.T) {
 		t.Fatal("test setup is wrong: model.chat is configured")
 	}
 
-	r := buildThreadResponder(cfg, reg, fakeThreadForge{}, chat, nil, log)
+	r := buildThreadResponder(cfg, reg, fakeThreadForge{}, chat, nil, nil, log)
 	if r.Chat != chat {
 		t.Fatal("Responder.Chat is not the shared chat layer — freeform stays on the PR2 deterministic path in production")
 	}
 	// And the PR2 shape survives: no model.chat means no Chat on the responder.
-	off := buildThreadResponder(chatCfg(), reg, fakeThreadForge{}, buildThreadChat(chatCfg(), nil, nil, log), nil, log)
+	off := buildThreadResponder(chatCfg(), reg, fakeThreadForge{}, buildThreadChat(chatCfg(), nil, nil, log), nil, nil, log)
 	if off.Chat != nil {
 		t.Fatalf("no model.chat must leave Responder.Chat nil, got %+v", off.Chat)
 	}
 }
 
-// threadBoundsCfg returns a config with EVERY notify.thread key set to a
+// TestKBAnnounceInertWarning covers the guard on its own: the operator asked for
+// knowledge-base announcements and one of the two ends the feature needs is
+// missing. Every dependency on this path is nil-safe — a nil *notify.Multi means
+// "announcements are off" and nothing anywhere fails — so without this the
+// startup log would be silent about a feature the operator explicitly turned on
+// and will never see fire.
+//
+// The two causes are asserted by their remedy, not merely by "something was
+// logged": an operator told to configure a notifier when what they are missing
+// is thread_capture is worse off than one told nothing, because they will go and
+// check the notifier.
+func TestKBAnnounceInertWarning(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		announce bool
+		capture  bool
+		sinks    int
+		wantCue  string // substring the message must carry; "" ⇒ no warning at all
+	}{
+		{name: "off, with nothing else configured either: the default warrants nothing"},
+		{name: "off, with everything else configured", sinks: 2, capture: true},
+		{name: "on, with a notifier and capture", announce: true, sinks: 1, capture: true, wantCue: ""},
+		{name: "on, with capture but no notifier", announce: true, capture: true, wantCue: "no notifier is configured"},
+		{name: "on, with a notifier but nothing capturing", announce: true, sinks: 1, wantCue: "thread_capture"},
+		{
+			// Both ends missing: one message, and it must be the delivery one —
+			// reporting them in a fixed order keeps the line deterministic.
+			name: "on, with neither end", announce: true, wantCue: "no notifier is configured",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Notify.Thread.AnnounceKBUpdates = tc.announce
+			cfg.Notify.Slack.ThreadCapture = tc.capture
+			got := KBAnnounceInertWarning(cfg, tc.sinks)
+			if tc.wantCue == "" {
+				if got != "" {
+					t.Fatalf("KBAnnounceInertWarning = %q, want no warning", got)
+				}
+				return
+			}
+			// The message has to name the key the operator wrote, so the line is
+			// actionable from the log alone rather than requiring them to guess
+			// which of several notification options is inert.
+			if !strings.Contains(got, "announce_kb_updates") || !strings.Contains(got, tc.wantCue) {
+				t.Fatalf("the warning must name notify.thread.announce_kb_updates and the missing end %q, got: %q",
+					tc.wantCue, got)
+			}
+		})
+	}
+}
+
+// TestKBAnnounceInertWarningSeesMatrixCaptureToo pins the capture check against
+// the same Matrix-only deployment BuildThreadRegistry once got wrong: a
+// transport is a transport, and reading only notify.slack.thread_capture would
+// call a working Matrix-only setup dead config.
+func TestKBAnnounceInertWarningSeesMatrixCaptureToo(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Notify.Thread.AnnounceKBUpdates = true
+	cfg.Notify.Matrix.ThreadCapture = true
+	if got := KBAnnounceInertWarning(cfg, 1); got != "" {
+		t.Fatalf("matrix thread_capture alone must satisfy the capture end, got: %q", got)
+	}
+}
+
+// TestBuildThreadResponderAnnouncerIsOptIn pins the switch END TO END through
+// the builder RunServe actually calls, not through a hand-built Responder.
+//
+// Responder.Announcer is nil-safe by contract (nil means announcements are
+// off), so every wrong answer here is silent: an announcer built when nobody
+// asked fans note content out to channels the operator never opted in, and one
+// NOT built when they did asked leaves the feature dead with no diagnostic.
+// Neither fails anything on its own.
+//
+// The two "on but nowhere to deliver" rows are the reason the builder consults
+// the notifier at all rather than only the config bool: a *notify.Multi with no
+// sinks in it delivers every announcement to nobody, so wiring an announcer to
+// it would spend a dispatcher and its goroutines to produce nothing, while
+// startup implied the feature was live.
+func TestBuildThreadResponderAnnouncerIsOptIn(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		announce bool
+		notifier func() *notify.Multi
+		want     bool // want an announcer on the responder
+		wantWarn bool
+	}{
+		{
+			name:     "off, with a notifier configured",
+			notifier: func() *notify.Multi { return notify.NewMulti(discardLog(), &captureNotifier{}) },
+		},
+		{
+			name: "off, with no notifier at all: nothing was asked for, so nothing is said",
+		},
+		{
+			name:     "on, with a notifier configured",
+			announce: true,
+			notifier: func() *notify.Multi { return notify.NewMulti(discardLog(), &captureNotifier{}) },
+			want:     true,
+		},
+		{
+			name:     "on, but no notifier was built at all",
+			announce: true,
+			wantWarn: true,
+		},
+		{
+			name:     "on, but the notifier holds no sinks",
+			announce: true,
+			notifier: func() *notify.Multi { return notify.NewMulti(discardLog()) },
+			wantWarn: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg, err := thread.NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10)
+			if err != nil {
+				t.Fatalf("NewRegistry: %v", err)
+			}
+			cfg := &config.Config{}
+			cfg.Notify.Thread.AnnounceKBUpdates = tc.announce
+			// Capture on, so the only thing varying across the table is the
+			// sink: with no transport capturing, KBAnnounceInertWarning would
+			// fire for a second reason and every row would look the same.
+			cfg.Notify.Slack.ThreadCapture = true
+			var buf bytes.Buffer
+			log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			var notifier *notify.Multi
+			if tc.notifier != nil {
+				notifier = tc.notifier()
+			}
+
+			r := buildThreadResponder(cfg, reg, fakeThreadForge{}, nil, notifier, nil, log)
+			if got := r.Announcer != nil; got != tc.want {
+				t.Fatalf("Responder.Announcer != nil = %v, want %v — announcements are opt-in and must be "+
+					"wired exactly when notify.thread.announce_kb_updates is on AND a sink exists", got, tc.want)
+			}
+			if warned := strings.Contains(buf.String(), "announce_kb_updates"); warned != tc.wantWarn {
+				t.Fatalf("warned about an inert announce_kb_updates = %v, want %v; log: %s",
+					warned, tc.wantWarn, buf.String())
+			}
+		})
+	}
+}
+
+// threadBoundsCfg returns a config with EVERY notify.thread BOUND set to a
 // distinctive non-default value, so a bound that arrives with its default
 // cannot be mistaken for one that was delivered. Chat capture and a ledger path
 // are on because BuildThreadRegistry needs both to build an enabled registry.
+//
+// announce_kb_updates is deliberately not here: it is the one key in the block
+// that is a switch rather than a bound, so "the value that arrived is not the
+// default" is not a question that can be asked of it — a bool has no third
+// state. TestBuildThreadResponderAnnouncerIsOptIn covers its delivery instead,
+// through the same builder.
 func threadBoundsCfg(t *testing.T) *config.Config {
 	t.Helper()
 	cfg := chatCfg()
@@ -968,7 +1117,7 @@ func TestNotifyThreadBoundsReachTheObjectsTheyConfigure(t *testing.T) {
 			if chat == nil {
 				t.Fatal("test setup is wrong: model.chat is configured")
 			}
-			tc.check(t, reg, buildThreadResponder(cfg, reg, fakeThreadForge{}, chat, nil, log), chat)
+			tc.check(t, reg, buildThreadResponder(cfg, reg, fakeThreadForge{}, chat, nil, nil, log), chat)
 		})
 	}
 }

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -224,7 +224,7 @@ func RunServe(version string, args []string) error {
 	// second git-sync goroutine on the same checkout.
 	forge := buildForge(cfg, log)
 	threadChat := buildThreadChat(cfg, cat, metrics, log)
-	threadResponder := buildThreadResponder(cfg, threadRegistry, forge, threadChat, metrics, log)
+	threadResponder := buildThreadResponder(cfg, threadRegistry, forge, threadChat, notifier, metrics, log)
 	queue := investigate.NewQueue(inv, log)
 	var rlStarts *ratelimit.Window
 	if rl := cfg.Investigation.RateLimit; rl.MaxPerWindow != nil && *rl.MaxPerWindow > 0 {
@@ -505,12 +505,28 @@ func RunServe(version string, args []string) error {
 		// survives independently of workCtx. None of these depend on
 		// workCtx/the leader lease — unlike the investigation queue — so
 		// draining them has no ordering requirement relative to stopWork()
-		// below. All four drains share dctx's single deadline rather than
+		// below. All five drains share dctx's single deadline rather than
 		// getting drainGracePeriod each, so total shutdown time stays bounded
 		// the same way it always has.
+		//
+		// The announcer is drained AFTER those three and that order is required,
+		// not cosmetic: every announcement is scheduled BY a mention handler, so
+		// the three drains above are exactly the code that can still hand it new
+		// work. Drained earlier, it would return while Slack's and Matrix's
+		// handlers were still landing knowledge writes, and each of those
+		// announcements — for a write already on the forge — would be dropped by
+		// a shutdown that looks like it waits. It sits before queue.Drain rather
+		// than last because the investigation queue schedules no announcements
+		// and can be slow: waiting on it first would spend the shared deadline
+		// and hand the announcer an already-expired context, which is the
+		// starvation server.Drain's own doc comment describes.
+		//
+		// Nil-safe: with notify.thread.announce_kb_updates off (the default)
+		// there is no announcer, and Drain on a nil one returns immediately.
 		srv.Drain(dctx)
 		matrixDispatch.Drain(dctx)
 		matrixBusyDispatch.Drain(dctx)
+		threadResponder.Announcer.Drain(dctx)
 		queue.Drain(dctx)
 		cancelDrain()
 		stopWork() // release the leader lease + stop the queue/watch/coalescer

--- a/internal/app/serve_thread_wiring_test.go
+++ b/internal/app/serve_thread_wiring_test.go
@@ -47,6 +47,19 @@ import (
 // internal/app's notify_test.go builds its own responder by hand and so cannot
 // see any of this; only the call sites in RunServe can.
 //
+// The same argument covers the two hops the announcement path adds. The sink a
+// knowledge-base announcement is delivered to is the process's ONE *notify.Multi
+// — the same fan-out that carries investigation findings — and RunServe is the
+// only place it meets the responder; buildThreadResponder's own test proves the
+// announcer is built from whatever notifier it is handed, and says nothing about
+// which value production hands it. nil there is silently "announcements off"
+// with the operator's announce_kb_updates: true still in the file. And the
+// announcer must be DRAINED at shutdown, after everything that can still hand it
+// work: an announcement is scheduled on a bounded dispatcher, so one in flight
+// when SIGTERM arrives is dropped unless something waits for it — for a write
+// that already reached the forge. Drain existing, tested and called from nowhere
+// is precisely how it shipped.
+//
 // It is a static guard because RunServe is not callable from a test: it loads a
 // config file, dials Kubernetes, elects a leader and blocks in ListenAndServe.
 // What that costs is a KNOWN, ACCEPTED FALSE POSITIVE, the same trade
@@ -78,30 +91,50 @@ func TestRunServeComposesTheChatLayer(t *testing.T) {
 func TestThreadWiringGuardCatchesADroppedLayer(t *testing.T) {
 	// The intact shape, minus every dependency: enough for the checker, and it
 	// must report nothing so the mutations below are known to be what fails.
-	// The %s slots are, in order: the catalog handed to buildThreadChat, the chat
-	// layer handed to buildThreadResponder, an extra statement (empty unless a
-	// case builds a second responder), and the responder handed to each transport.
+	// The %s slots are, in order: the statement that binds the investigation
+	// queue, the catalog handed to buildThreadChat, the chat layer and the
+	// notifier handed to buildThreadResponder, an extra statement (empty unless a
+	// case builds a second responder), the responder handed to each transport,
+	// and the shutdown drain sequence.
 	const intact = `package x
 
 func BuildInvestigator() (investigate.Investigator, *catalog.Catalog, *notify.Multi, error) { return nil, nil, nil, nil }
 func buildThreadChat(cfg *config.Config, cat *catalog.Catalog) *thread.Chat { return nil }
-func buildThreadResponder(cfg *config.Config, chat *thread.Chat) *thread.Responder { return nil }
+func buildThreadResponder(cfg *config.Config, chat *thread.Chat, notifier *notify.Multi) *thread.Responder { return nil }
 func BuildThreadMention(cfg *config.Config, responder *thread.Responder) *thread.Mention { return nil }
-func BuildMatrixFeedback(cfg *config.Config, responder *thread.Responder) *notify.MatrixFeedback { return nil }
+func BuildMatrixFeedback(cfg *config.Config, responder *thread.Responder, dispatch, busyDispatch *thread.Dispatcher) *notify.MatrixFeedback { return nil }
 
 func RunServe() {
 	inv, cat, notifier, err := BuildInvestigator()
 	_, _, _ = inv, notifier, err
-	threadChat := buildThreadChat(cfg, %s)
-	threadResponder := buildThreadResponder(cfg, %s)
 	%s
-	mfb := BuildMatrixFeedback(cfg, %s)
+	threadChat := buildThreadChat(cfg, %s)
+	threadResponder := buildThreadResponder(cfg, %s, %s)
+	%s
+	mfb := BuildMatrixFeedback(cfg, %s, matrixDispatch, matrixBusyDispatch)
 	mention := BuildThreadMention(cfg, %s)
+	srv := server.New(acts)
+	go func() {
+		%s
+	}()
 	_, _, _, _ = threadChat, threadResponder, mfb, mention
 }
 `
+	// How production binds the investigation queue — the drain the announcer's
+	// must come BEFORE, and the one the guard resolves its name from.
+	const queueDecl = `queue := investigate.NewQueue(inv, log)`
+
+	// The shutdown order production uses: the mention pools first (each can
+	// still schedule an announcement while it drains), then the announcer, then
+	// the investigation queue, which cannot.
+	const drains = `srv.Drain(dctx)
+		matrixDispatch.Drain(dctx)
+		matrixBusyDispatch.Drain(dctx)
+		threadResponder.Announcer.Drain(dctx)
+		queue.Drain(dctx)`
+
 	for _, tc := range []struct {
-		name, cat, chat, extra, matrix, slack, want string
+		name, queue, cat, chat, notifier, extra, matrix, slack, drains, want string
 	}{
 		{
 			name: "intact wiring reports nothing",
@@ -141,14 +174,61 @@ func RunServe() {
 			matrix: "nil",
 			want:   "BuildMatrixFeedback",
 		},
+		{
+			// notify.thread.announce_kb_updates: true in the operator's file,
+			// no sink on the responder, and NewKBAnnouncer's nil-sink contract
+			// turns that into "announcements are off" without a word.
+			name:     "the notifier never reaches the responder, so nothing is ever announced",
+			notifier: "nil",
+			want:     "buildThreadResponder",
+		},
+		{
+			// The Task 4 shape exactly: Drain written, tested, called nowhere.
+			name:   "the announcer is never drained at shutdown",
+			drains: "srv.Drain(dctx)\n\t\tmatrixDispatch.Drain(dctx)\n\t\tmatrixBusyDispatch.Drain(dctx)\n\t\tqueue.Drain(dctx)",
+			want:   "Announcer",
+		},
+		{
+			// Present but useless: the pools it drains ahead of are the ones
+			// still scheduling announcements, so every announcement produced
+			// during their drain is dropped — by a Drain call that is right
+			// there in the diff.
+			name:   "the announcer is drained before the handlers that can still schedule one",
+			drains: "threadResponder.Announcer.Drain(dctx)\n\t\tsrv.Drain(dctx)\n\t\tmatrixDispatch.Drain(dctx)\n\t\tmatrixBusyDispatch.Drain(dctx)",
+			want:   "Announcer",
+		},
+		{
+			// The other end of the same window, and the half serve.go's own
+			// drain-order comment calls out: all five drains share ONE deadline,
+			// the investigation queue schedules no announcements and is the slow
+			// one, so waiting on it first spends the grace period and hands the
+			// announcer a context that has already expired. Every announcement
+			// still in flight is then dropped — by a Drain called in the right
+			// place, in the wrong order.
+			name:   "the announcer is drained after the investigation queue, on the shared deadline",
+			drains: "srv.Drain(dctx)\n\t\tmatrixDispatch.Drain(dctx)\n\t\tmatrixBusyDispatch.Drain(dctx)\n\t\tqueue.Drain(dctx)\n\t\tthreadResponder.Announcer.Drain(dctx)",
+			want:   "queue",
+		},
+		{
+			// The guard's own inertness, which is the failure this whole file
+			// exists to catch: with the queue bound from something this checker
+			// does not recognise it cannot compare the two positions at all, and
+			// must say so rather than pass.
+			name:  "the queue is bound from a constructor the guard cannot resolve",
+			queue: "queue := investigate.NewWorkQueue(inv, log)",
+			want:  "inert",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			src := fmt.Sprintf(intact,
+				cmp.Or(tc.queue, queueDecl),
 				cmp.Or(tc.cat, "cat"),
 				cmp.Or(tc.chat, "threadChat"),
+				cmp.Or(tc.notifier, "notifier"),
 				tc.extra,
 				cmp.Or(tc.matrix, "threadResponder"),
 				cmp.Or(tc.slack, "threadResponder"),
+				cmp.Or(tc.drains, drains),
 			)
 			got := threadWiringViolations(parseFuncDecls(t, src))
 			if tc.want == "" {
@@ -237,7 +317,157 @@ func threadWiringViolations(fns map[string]*ast.FuncDecl) []string {
 		"Matrix's thread capture no longer runs on the shared responder — nil makes buildMatrixThreadMention warn "+
 			"and drop capture from the listener while feedback reactions keep it looking healthy, and a second "+
 			"responder doubles the same two global ceilings")...)
+
+	// The announcement sink is that same single *notify.Multi: announcing to
+	// each notifier's own channel is the entire feature, and the fan-out is
+	// where the configured notifiers live.
+	notifierIdx := resultIndex(invBuilder, "*notify.Multi")
+	if notifierIdx < 0 {
+		return append(bad, "BuildInvestigator no longer returns a *notify.Multi: this guard can no longer tell "+
+			"which identifier is the shared notifier the knowledge-base announcement is delivered through")
+	}
+	if len(catNames) <= notifierIdx || catNames[notifierIdx] == "_" {
+		return append(bad, "RunServe does not bind BuildInvestigator's *notify.Multi result: a knowledge-base "+
+			"write can then be announced to nobody, whatever notify.thread.announce_kb_updates says")
+	}
+	bad = append(bad, checkArg(serve, respBuilder, "buildThreadResponder", "notifier", catNames[notifierIdx],
+		"notify.thread.announce_kb_updates is then on in the operator's config and off in the process — "+
+			"buildKBAnnouncer builds no announcer without a sink, thread.Responder.Announcer is nil-safe, and "+
+			"every landed knowledge write is announced to nobody with nothing logged")...)
+	bad = append(bad, announcerDrainViolations(serve, matrixBuilder, respNames[0])...)
 	return bad
+}
+
+// announcerDrainViolations reports whether RunServe drains the announcer at
+// shutdown, and whether it does so in the one window where draining it is worth
+// anything — after everything that can still schedule an announcement, and
+// before the one drain that can eat the shared deadline.
+//
+// Three distinct failures, one silent each. Never draining it means an
+// announcement still in flight when SIGTERM arrives is dropped, for a write that
+// is already on the forge — the KBAnnouncer's dispatcher runs its deliveries on
+// a context stripped of cancellation, so nothing else waits for them. Draining
+// it too early means the same drop with a Drain call sitting in the diff: the
+// Slack server and the Matrix mention pools are what RUN the handlers that
+// schedule announcements, so anything they deliver while THEY drain arrives
+// after an announcer drain that has already returned. Draining it too LATE is
+// the same drop again: all five drains share ONE dctx deadline (see serve.go's
+// drain-order comment), and the investigation queue — which schedules no
+// announcements at all — is the slow one, so waiting on it first hands the
+// announcer an already-expired context.
+//
+// Both ends are bounded by drains RunServe itself names, and every one of them
+// is resolved from the source rather than spelled out here — see
+// announcementSchedulers and announcementDeadlineSpenders. Either resolving to
+// nothing is reported as an inert guard, because a checker that quietly stopped
+// comparing is the failure this file exists to catch.
+func announcerDrainViolations(serve, matrixBuilder *ast.FuncDecl, respName string) []string {
+	want := respName + ".Announcer"
+	drains := drainCalls(serve)
+	at, ok := drains[want]
+	if !ok {
+		return []string{fmt.Sprintf("RunServe never calls %s.Drain: an announcement in flight at shutdown is "+
+			"dropped for a knowledge write that already reached the forge. thread.KBAnnouncer.Drain exists and "+
+			"is tested; a Drain nobody calls is the same as no Drain at all", want)}
+	}
+	var bad []string
+	schedulers := announcementSchedulers(serve, matrixBuilder)
+	if len(schedulers) == 0 {
+		bad = append(bad, "this guard is inert about draining the announcer too EARLY: it can no longer identify "+
+			"the handlers that schedule announcements (neither server.New's result nor BuildMatrixFeedback's "+
+			"dispatch arguments resolved)")
+	}
+	for _, recv := range schedulers {
+		pos, drained := drains[recv]
+		if !drained || pos < at {
+			continue
+		}
+		bad = append(bad, fmt.Sprintf("RunServe drains %s BEFORE %s: %s is still running the mention handlers "+
+			"that schedule announcements, so every announcement produced while it drains is dropped — by a "+
+			"Drain call that looks correct in review. Drain the announcer after it", want, recv, recv))
+	}
+	spenders := announcementDeadlineSpenders(serve)
+	if len(spenders) == 0 {
+		bad = append(bad, "this guard is inert about draining the announcer too LATE: nothing in RunServe is bound "+
+			"from investigate.NewQueue, so it can no longer identify the drain that must not run first")
+	}
+	for _, recv := range spenders {
+		pos, drained := drains[recv]
+		if !drained || pos > at {
+			continue
+		}
+		bad = append(bad, fmt.Sprintf("RunServe drains %s BEFORE %s: they share one dctx deadline and %s "+
+			"schedules no announcements, so a slow investigation spends the whole grace period and the announcer "+
+			"is then drained on an expired context — the same dropped announcement, from the other side. Drain "+
+			"the announcer before it", recv, want, recv))
+	}
+	return bad
+}
+
+// announcementDeadlineSpenders returns the receiver expressions of the shutdown
+// drains that must happen AFTER the announcer's: the investigation queue, whose
+// in-flight work is the slowest thing shutdown waits on and the only one of the
+// five that can hand nothing to the announcer.
+//
+// Resolved from the source like the schedulers are — by the identifier RunServe
+// binds from investigate.NewQueue — so a rename moves the guard with it, and a
+// shape it cannot resolve is reported as inert by the caller rather than
+// passing quietly. A queue that is bound but never drained is not this check's
+// business: there is then no order to get wrong.
+func announcementDeadlineSpenders(serve *ast.FuncDecl) []string {
+	var out []string
+	for _, name := range boundNames(serve, "investigate.NewQueue") {
+		if name != "_" {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// announcementSchedulers returns the receiver expressions of the shutdown drains
+// that must happen BEFORE the announcer's: the Slack server (its own Drain waits
+// on the detached mention handlers) and the two Matrix mention dispatchers.
+//
+// Both are resolved from the source, not spelled out: the server by the
+// identifier RunServe binds from server.New, the dispatchers by the arguments it
+// passes in BuildMatrixFeedback's own dispatch/busyDispatch parameter slots. A
+// rename moves the guard with it, and a shape it cannot resolve is reported as
+// an inert guard by the caller rather than passing quietly.
+func announcementSchedulers(serve, matrixBuilder *ast.FuncDecl) []string {
+	var out []string
+	if names := boundNames(serve, "server.New"); len(names) == 1 && names[0] != "_" {
+		out = append(out, names[0])
+	}
+	if calls := callsTo(serve, "BuildMatrixFeedback"); len(calls) == 1 {
+		for _, param := range []string{"dispatch", "busyDispatch"} {
+			idx := paramIndex(matrixBuilder, param)
+			if idx >= 0 && idx < len(calls[0].Args) {
+				out = append(out, types.ExprString(calls[0].Args[idx]))
+			}
+		}
+	}
+	return out
+}
+
+// drainCalls maps the receiver expression of every Drain call in fn to its
+// position, so the checker can compare shutdown ORDER as well as presence. A
+// receiver drained twice keeps the last position — the later call is the one
+// that decides whether the wait actually covered the work.
+func drainCalls(fn *ast.FuncDecl) map[string]token.Pos {
+	out := map[string]token.Pos{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Drain" {
+			return true
+		}
+		out[types.ExprString(sel.X)] = call.Pos()
+		return true
+	})
+	return out
 }
 
 // checkArg asserts RunServe calls builder exactly once, passing want in the
@@ -268,7 +498,10 @@ func checkArg(serve, builder *ast.FuncDecl, builderName, param, want, why string
 		got, builderName, param, want, why)}
 }
 
-// callsTo returns every direct call to callee inside fn's body.
+// callsTo returns every call to callee inside fn's body. callee is matched as
+// the source renders it, so both a same-package name ("BuildInvestigator") and a
+// qualified one ("server.New") work — the announcer's drain order is checked
+// against a value RunServe binds from another package's constructor.
 func callsTo(fn *ast.FuncDecl, callee string) []*ast.CallExpr {
 	var out []*ast.CallExpr
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
@@ -276,7 +509,7 @@ func callsTo(fn *ast.FuncDecl, callee string) []*ast.CallExpr {
 		if !ok {
 			return true
 		}
-		if id, ok := call.Fun.(*ast.Ident); ok && id.Name == callee {
+		if types.ExprString(call.Fun) == callee {
 			out = append(out, call)
 		}
 		return true
@@ -298,7 +531,7 @@ func boundNames(fn *ast.FuncDecl, callee string) []string {
 		if !ok {
 			return true
 		}
-		if id, ok := call.Fun.(*ast.Ident); !ok || id.Name != callee {
+		if types.ExprString(call.Fun) != callee {
 			return true
 		}
 		for _, lhs := range as.Lhs {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -931,6 +931,26 @@ type ThreadNotify struct {
 	// path, because that field compares the size of the next request against
 	// the limit rather than a running total.
 	ChatTokensPerHour int64 `yaml:"chat_tokens_per_hour"`
+	// AnnounceKBUpdates broadcasts a landed knowledge write to every configured
+	// notifier — each one's own channel or room, never back into the thread — so
+	// a knowledge-base update reaches people who were not reading the thread it
+	// came from.
+	//
+	// Default FALSE. It is the one field in this block that is a switch rather
+	// than a bound, and the only one whose zero value turns something OFF rather
+	// than selecting a default, so the "0 means the default" convention above
+	// does not apply to it. Opt-in for two reasons: it adds notification volume
+	// to channels that did not ask for it, while the thread reply is already the
+	// direct acknowledgement to the person who typed; and the announcement
+	// carries the note's own text, so enabling it sends what someone wrote in
+	// one thread to every sink configured here. That is an operator's decision
+	// to take knowingly, which makes the unconfigured state the off state.
+	//
+	// With a single transport configured, one write then produces both the
+	// thread reply and a channel post. That is intended rather than duplication
+	// — the channel is how people who were not in the thread learn the knowledge
+	// base moved — and it is the whole reason the feature exists.
+	AnnounceKBUpdates bool `yaml:"announce_kb_updates"`
 }
 
 // EffectiveMaxNotesPerThread resolves the configured cap, falling back to

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1267,6 +1267,7 @@ notify:
     max_note_bytes: 4096
     chat_calls_per_hour: 45
     chat_tokens_per_hour: 123456
+    announce_kb_updates: true
 `
 	var c Config
 	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
@@ -1275,7 +1276,7 @@ notify:
 	th := c.Notify.Thread
 	if th.MaxNotesPerThread != 5 || th.ForgeWritesPerHour != 3 || th.RegistryTTL.Std() != 48*time.Hour ||
 		th.RegistryMax != 100 || th.MaxNoteBytes != 4096 ||
-		th.ChatCallsPerHour != 45 || th.ChatTokensPerHour != 123456 {
+		th.ChatCallsPerHour != 45 || th.ChatTokensPerHour != 123456 || !th.AnnounceKBUpdates {
 		t.Fatalf("notify.thread not parsed: %+v", th)
 	}
 	if got := th.EffectiveMaxNotesPerThread(); got != 5 {
@@ -1298,6 +1299,65 @@ notify:
 	}
 	if got := th.EffectiveChatTokensPerHour(); got != 123456 {
 		t.Fatalf("EffectiveChatTokensPerHour() = %d, want the explicit 123456", got)
+	}
+}
+
+// TestAnnounceKBUpdatesIsOptIn pins the DEFAULT of
+// notify.thread.announce_kb_updates, which is the whole decision recorded for
+// it: absent means off, and explicitly false means off, because the
+// announcement adds notification volume to channels nobody asked to have it in
+// — the thread reply is already the direct acknowledgement to the person who
+// typed — and, since the announcement carries note content, turning it on sends
+// a note written in one thread to every configured sink. That is an operator's
+// call to make knowingly, so the safe state is the unconfigured state.
+//
+// All three states are asserted separately rather than just "absent": a bool
+// whose zero value is the default reads as covered the moment anything asserts
+// false, and the case that would actually reveal a wrong-way default — an
+// operator writing the key out explicitly to turn it OFF — is the one a
+// zero-value-only test never exercises.
+func TestAnnounceKBUpdatesIsOptIn(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "absent from a notify.thread block that sets other keys",
+			yaml: "notify:\n  thread:\n    max_note_bytes: 4096\n",
+		},
+		{
+			name: "no notify block at all",
+			yaml: "model:\n  provider: anthropic\n",
+		},
+		{
+			name: "explicitly false",
+			yaml: "notify:\n  thread:\n    announce_kb_updates: false\n",
+		},
+		{
+			name: "explicitly true",
+			yaml: "notify:\n  thread:\n    announce_kb_updates: true\n",
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var c Config
+			if err := yaml.Unmarshal([]byte(tc.yaml), &c); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := c.Notify.Thread.AnnounceKBUpdates; got != tc.want {
+				t.Fatalf("notify.thread.announce_kb_updates = %v, want %v — the announcement fans a note "+
+					"written in one thread out to every configured sink, so the unconfigured state must be off",
+					got, tc.want)
+			}
+			// The key must land on the named Thread field, never in Notify.Extra,
+			// for the same reason every other notify.thread key must: an inline
+			// map entry would shadow a notifier registered under that name (see
+			// TestNotifyThreadDoesNotShadowARegisteredNotifier).
+			if _, ok := c.Notify.Extra["thread"]; ok {
+				t.Fatal("notify.thread must not also land in Notify.Extra")
+			}
+		})
 	}
 }
 

--- a/internal/docsguard/thread_defaults_test.go
+++ b/internal/docsguard/thread_defaults_test.go
@@ -3,6 +3,10 @@
 package docsguard
 
 import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -13,6 +17,9 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/thread"
 )
 
@@ -104,6 +111,242 @@ func TestThreadDefaultsMatchTheDocs(t *testing.T) {
 	}
 }
 
+// TestThreadBooleanDefaultsMatchTheDocs is the sibling of the test above for
+// the `notify.thread` defaults the docs state as a BOOLEAN.
+//
+// The numeric guard parses numbers only, so a page stating that
+// `announce_kb_updates` defaults to `false` was pinned by nothing at all: the
+// key could be flipped to opt-OUT in code and four pages would keep telling an
+// operator it was off. That is worse than the numeric drift this file was
+// written for, because the key decides whether note content — what someone
+// typed in one thread — is broadcast to every configured sink. A doc saying
+// "off unless you set it" while the code ships it on is a privacy claim the
+// software does not honour.
+//
+// The default comes from decoding an EMPTY config through the real type, not
+// from a literal repeated here: that is what "the default" means operationally
+// — what an operator who wrote no such key gets.
+//
+// That makes this a HALF guard, and it is worth saying so plainly rather than
+// leaving it implied. It bites in one direction only: from the DOCS. The code
+// side is structurally unfalsifiable — AnnounceKBUpdates is a plain bool with no
+// unmarshaler, so decoding "{}" can only ever yield false, and there is no edit
+// to internal/config that makes an unconfigured deployment announce. Flipping
+// the default would mean changing the field's TYPE (a *bool, or a custom
+// unmarshaler defaulting to true), which is a change nobody makes by accident
+// and which this test would then catch from the docs it disagreed with. Until
+// that day the only failure this can produce is a page stating "true", so read
+// its passing as "no page claims the wrong default", never as "the default is
+// verified false".
+//
+// What counts as a claim is narrower than for numbers, and deliberately so: the
+// word "default" must appear between the key (or the previous boolean in the
+// same unit) and the token. A boolean's YAML value in a sample is a
+// DEMONSTRATION rather than a default — `announce_kb_updates: true` is how a
+// page shows you how to turn an opt-in on — whereas a numeric sample
+// conventionally prints the default itself. Reading the YAML value as a claim
+// would fail every page that documents how to enable the feature.
+func TestThreadBooleanDefaultsMatchTheDocs(t *testing.T) {
+	var c config.Config
+	if err := yaml.Unmarshal([]byte("{}"), &c); err != nil {
+		t.Fatalf("decode an empty config: %v", err)
+	}
+	pinned := map[string]bool{
+		"announce_kb_updates": c.Notify.Thread.AnnounceKBUpdates,
+	}
+
+	seenIn := make(map[string]map[string]bool, len(pinned))
+	for _, path := range threadDocPages(t) {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		rel := relToRepo(t, path)
+		for _, c := range threadBoolClaims(rel, string(src), pinned) {
+			if seenIn[c.key] == nil {
+				seenIn[c.key] = map[string]bool{}
+			}
+			seenIn[c.key][c.file] = true
+			if c.bool == pinned[c.key] {
+				continue
+			}
+			t.Errorf("%s:%d states notify.thread.%s defaults to %v, but an empty config resolves it to %v.\n"+
+				"  claim: %s\n"+
+				"  Restate it here, or change the default — do not leave them disagreeing. "+
+				"announce_kb_updates decides whether a note written in one thread is broadcast to every "+
+				"configured sink, so a page promising it is off while the code ships it on is a claim about "+
+				"where an operator's words go that the software does not honour.",
+				c.file, c.line, c.key, c.bool, pinned[c.key], c.text)
+		}
+	}
+
+	// Guard the guard, exactly as the numeric test does: every pinned key is
+	// stated somewhere in the shipped docs today, so finding none means the
+	// parse stopped matching and this is reporting success over nothing.
+	for _, key := range sortedStrings(pinned) {
+		if len(seenIn[key]) == 0 {
+			t.Errorf("found no stated default for notify.thread.%s in any shipped page — "+
+				"either the docs stopped documenting it or threadBoolClaims no longer "+
+				"recognises how they phrase it, and this guard is inert for that key", key)
+		}
+	}
+	// It is documented on the configuration reference, both notification pages
+	// and the reviewing-knowledge concept page. Requiring several holds the
+	// guard to catching a partial fix — the failure where someone corrects one
+	// page and leaves the others promising the opposite.
+	if n := len(seenIn["announce_kb_updates"]); n < 3 {
+		t.Errorf("announce_kb_updates' default is stated on only %d page(s); it is documented on the "+
+			"configuration reference, both notification pages and the reviewing-knowledge concept page, "+
+			"so a count this low means the guard has stopped seeing most of them", n)
+	}
+}
+
+// docQuoteCapRE matches the announcement's note-quote ceiling as the transport
+// pages phrase it. It reads a joined UNIT rather than a raw line because both
+// pages hard-wrap the sentence, and each wraps it in a different place: slack.md
+// breaks before "capped at", matrix.md between "capped at" and the number.
+//
+// "bytes" is the whole of what keeps this narrow. Every other "capped at" in the
+// shipped docs states a MiB size or a probability, so this phrase belongs to the
+// quoted note and nothing else; a page that needs to state a different byte cap
+// should name its config key and be read by threadDefaultClaims instead.
+var docQuoteCapRE = regexp.MustCompile(`capped at (\d[\d,_]*) bytes`)
+
+// TestAnnouncedNoteQuoteCapMatchesTheDocs pins the "capped at 512 bytes"
+// sentence on the Slack and Matrix pages to notify.kbNotePreviewBytes, the
+// constant that actually cuts the quote.
+//
+// The numeric guard above cannot: it only reads a number the docs attribute to a
+// `notify.thread.*` KEY, and this ceiling has no key — it is not configurable,
+// deliberately, because it is derived from the transports' own message limits
+// (see the const block in internal/notify/kbupdate.go). So both pages stated a
+// number that nothing in the build compared against anything, on a sentence an
+// operator uses to decide whether announcing is safe for their channel: told the
+// quote stops at 512 bytes, they get however much the constant currently emits.
+//
+// The constant is read out of the source file rather than imported, for the same
+// reason logsProviderIDs parses detect.go: it is unexported, and exporting a
+// notifier's internal ceiling so a guard can see it would widen an API to serve
+// a test. A rename or a non-literal value makes this guard INERT rather than
+// wrong, which is what the error below reports.
+func TestAnnouncedNoteQuoteCapMatchesTheDocs(t *testing.T) {
+	want, err := notifyIntConst(repoRoot(t), "kbNotePreviewBytes")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, path := range threadDocPages(t) {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		rel := relToRepo(t, path)
+		for _, u := range splitDocUnits(string(src)) {
+			for _, m := range docQuoteCapRE.FindAllStringSubmatchIndex(u.text, -1) {
+				seen[rel] = true
+				lit := u.text[m[2]:m[3]]
+				got, err := strconv.ParseInt(strings.NewReplacer(",", "", "_", "").Replace(lit), 10, 64)
+				if err != nil || got == want {
+					continue
+				}
+				t.Errorf("%s:%d says the announced note quote is capped at %d bytes, but "+
+					"notify.kbNotePreviewBytes cuts it at %d.\n  claim: %s\n"+
+					"  Restate the number here, or change the constant — do not leave them disagreeing. "+
+					"This sentence is what an operator reads to decide how much of a private note "+
+					"reaches every configured sink.",
+					rel, u.lineAt(m[0]), got, want, docSnippet(u.text, m[0]-60, m[1]+20))
+			}
+		}
+	}
+
+	// Guard the guard. Both notification pages state this today; finding fewer
+	// means the sentence was reworded and this is reporting success over nothing.
+	if len(seen) < 2 {
+		t.Errorf("found the announced note quote's cap stated on %d page(s), want the Slack and "+
+			"Matrix notification pages at least — either they stopped saying it or docQuoteCapRE "+
+			"no longer recognises how they phrase it, and this guard is inert", len(seen))
+	}
+}
+
+// notifyIntConst returns the value of one untyped integer constant declared in
+// internal/notify/kbupdate.go, read from the source file itself.
+//
+// Go cannot enumerate another package's unexported constants at runtime, and the
+// alternative — repeating the number here — is the drift this whole package
+// exists to catch, reproduced inside the catcher: the guard would compare the
+// docs against a copy free to disagree with the code.
+func notifyIntConst(root, name string) (int64, error) {
+	path := filepath.Join(root, "internal", "notify", "kbupdate.go")
+	f, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, id := range vs.Names {
+				if id.Name != name || i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.INT {
+					return 0, fmt.Errorf("%s: %s is no longer a plain integer literal, so this guard "+
+						"can no longer read it and is inert", path, name)
+				}
+				return strconv.ParseInt(strings.NewReplacer(",", "", "_", "").Replace(lit.Value), 10, 64)
+			}
+		}
+	}
+	return 0, fmt.Errorf("%s declares no const %s — it was renamed or moved, and this guard is inert", path, name)
+}
+
+// docBoolRE matches a boolean as the docs write it, bold markers and backticks
+// being separate tokens either side of it.
+var docBoolRE = regexp.MustCompile(`\b(?:true|false)\b`)
+
+// threadBoolClaims extracts the boolean default claims a single markdown page
+// makes about the pinned keys. It mirrors threadDefaultClaims — same units,
+// same nearest-key-before attribution — minus the YAML-value and table-cell
+// readings; see TestThreadBooleanDefaultsMatchTheDocs for why those two are
+// wrong for a boolean.
+func threadBoolClaims(file, src string, pinned map[string]bool) []docClaim {
+	var claims []docClaim
+	for _, u := range splitDocUnits(src) {
+		keys := docKeyRE.FindAllStringIndex(u.text, -1)
+		prevEnd := 0
+		for _, tok := range docBoolRE.FindAllStringIndex(u.text, -1) {
+			key, end := nearestKeyBefore(u.text, keys, tok[0])
+			anchor := max(end, prevEnd)
+			prevEnd = tok[1]
+			if key == "" {
+				continue
+			}
+			if _, ok := pinned[key]; !ok {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(u.text[anchor:tok[0]]), "default") {
+				continue
+			}
+			claims = append(claims, docClaim{
+				file: file,
+				line: u.lineAt(tok[0]),
+				key:  key,
+				text: docSnippet(u.text, tok[0]-60, tok[1]+20),
+				bool: u.text[tok[0]:tok[1]] == "true",
+			})
+		}
+	}
+	return claims
+}
+
 // docClaim is one number a page states as a key's default, kept with enough
 // provenance to point an operator-facing failure at the exact line.
 type docClaim struct {
@@ -112,6 +355,7 @@ type docClaim struct {
 	key  string
 	text string
 	val  int64
+	bool bool
 }
 
 var (

--- a/internal/notify/kbupdate.go
+++ b/internal/notify/kbupdate.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+// What one announcement may render of each UNTRUSTED KBUpdate field.
+//
+// These bound what is SAID in a channel, not what was WRITTEN to the knowledge
+// base, and the two are deliberately different numbers. KBUpdate.Note carries
+// the note at full length — up to max_note_bytes, 8 KiB by default and
+// operator-raisable — precisely so a webhook sink receives the whole record;
+// rendered straight into a chat channel that is an 8 KiB post, on a path any
+// channel member can trigger. KBUpdate.Author is redacted and flattened
+// upstream but never length-capped at all (the 100-byte cap in
+// internal/thread's chat layer bounds what a MODEL PROMPT carries, not what
+// reaches a notifier), so without a bound here it arrives unbounded.
+//
+// The note ceiling is the same 512 bytes the thread reply's own quote uses, and
+// for the same derivation: every untrusted span is escaped before it goes on
+// the wire, the widest of those escapes (Slack's "&" to "&amp;") expands 5x, so
+// 512 bytes reaches the transport as at most ~2.5k characters. It is restated
+// here rather than shared because the two bounds answer to different owners —
+// that one is the thread package's own reply, this one is a notifier's channel
+// post — and because a chat message's size is a transport concern, which is the
+// same division boundPostedReply draws.
+const (
+	kbNotePreviewBytes = 512
+	kbTitleBytes       = 200
+	kbAuthorBytes      = 100
+	kbURLBytes         = 512
+)
+
+const (
+	// kbNoteTruncatedNotice is what a shortened quote says instead of simply
+	// stopping. A reader who cannot tell the quote was cut reads what survived
+	// as the whole note.
+	kbNoteTruncatedNotice = "(quote truncated — open the pull request for the full note)"
+	// kbFieldEllipsis marks a one-line field cut to its ceiling.
+	kbFieldEllipsis = "…"
+)
+
+// kbUpdateAnnouncement composes the chat announcement for a knowledge-base
+// write that already landed, marking every untrusted span with thread.Untrusted
+// so the calling transport escapes it with its OWN escaper — the same boundary
+// PR3 drew for thread replies, and for the same reason: only this side knows
+// which bytes came from where, and only the transport knows what its chat
+// system treats as markup.
+//
+// It is a NEW egress for model-authored text, and a wider one than the reply it
+// accompanies: on the freeform route RunLore's own chat model wrote the note,
+// and this lands in the notifier's configured channel — where investigation
+// findings are posted under the same bot identity — rather than in the thread
+// the note came from.
+//
+// Two measures carry that, both of them the reply's:
+//
+//   - Every untrusted field is inside a span, so the transport neutralises it.
+//     Unescaped, "<!channel>" mass-pings a Slack channel and "@room" a Matrix
+//     room, and "<https://evil|https://github.com/acme/kb/pull/7>" renders as a
+//     live link whose visible text is a trusted knowledge-base URL.
+//   - The note is blockquoted line by line, by thread.QuoteUntrusted, so no line
+//     of it can sit at the left margin where RunLore's own claims sit — and the
+//     status glyphs RunLore's own lines lead with are stripped from it.
+//
+// It calls that helper rather than keeping a local one. This file HAD a local
+// one, narrower on purpose: it left the glyph strip out on the grounds that
+// duplicating the glyph list across the package boundary would create a second
+// copy free to drift. The two drifted regardless, and in a way neither list
+// would have shown — the copy never learned that a line is not only what "\n"
+// separates (see thread.mandatoryBreaks), so a note carrying a single U+2028
+// put a forged "📚 Knowledge base updated — …" at the left margin of the very
+// channel investigation findings are posted to, with the real headline directly
+// above it. One shared implementation is what makes the two surfaces equal.
+//
+// Nothing here re-reads the forge or re-derives the note: the event describes a
+// write that already happened, and every value it renders was produced by the
+// write itself.
+func kbUpdateAnnouncement(up providers.KBUpdate) string {
+	lines := []string{kbHeadline(up)}
+	if title := kbField(up.Title, kbTitleBytes); title != "" {
+		// Not blockquoted: it is one flattened line (see thread.noteField) that
+		// cannot reach the left margin on a line of its own.
+		lines = append(lines, "Entry: "+thread.Untrusted(title))
+	}
+	if from := kbProvenanceLine(up); from != "" {
+		lines = append(lines, from)
+	}
+	preview := cutBytesToRuneBoundary(up.Note, kbNotePreviewBytes)
+	if preview != "" {
+		lines = append(lines, thread.QuoteUntrusted(preview))
+	}
+	if len(preview) < len(up.Note) {
+		lines = append(lines, kbNoteTruncatedNotice)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// kbHeadline is RunLore's own claim about what it did, so every byte of it
+// except the forge URL is RunLore's and stays outside any span. It names the
+// route in the words a human uses rather than the enum value a metric label
+// uses, and drops the "#n" when the forge returned a URL carrying no parseable
+// number — which is not an error, and must not suppress the announcement.
+func kbHeadline(up providers.KBUpdate) string {
+	what := "noted on"
+	if up.Route == providers.KBRouteOpenPR {
+		what = "opened"
+	}
+	head := "📚 Knowledge base updated — " + what + " PR"
+	if up.PR > 0 {
+		head = fmt.Sprintf("%s #%d", head, up.PR)
+	}
+	if url := kbField(up.URL, kbURLBytes); url != "" {
+		head += " — " + thread.Untrusted(url)
+	}
+	return head
+}
+
+// kbProvenanceLine names who the note came from and which chat system it was
+// typed in. Transport is RunLore's own value (it is the notifier's Transport(),
+// not anything a message carried), so it is never marked; Author is whatever
+// the chat transport reported and always is.
+func kbProvenanceLine(up providers.KBUpdate) string {
+	author := kbField(up.Author, kbAuthorBytes)
+	switch {
+	case author != "" && up.Transport != "":
+		return "By " + thread.Untrusted(author) + " in a " + up.Transport + " thread"
+	case author != "":
+		return "By " + thread.Untrusted(author)
+	case up.Transport != "":
+		return "From a " + up.Transport + " thread"
+	}
+	return ""
+}
+
+// kbField caps one untrusted single-line field, marking the cut so a truncated
+// value is not read as a whole one. The ellipsis sits inside the span the
+// caller wraps it in, which costs nothing: neither escaper touches it.
+func kbField(s string, maxBytes int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= maxBytes {
+		return s
+	}
+	return cutBytesToRuneBoundary(s, maxBytes-len(kbFieldEllipsis)) + kbFieldEllipsis
+}
+
+// slackKBUpdateMessage renders the announcement for both Slack delivery paths:
+// escaped for mrkdwn, then bounded at the transport's own ceiling, exactly as a
+// thread reply is. Plain text rather than Block Kit — the message is a short
+// status line plus a quote, and a section block would only add a second, lower
+// ceiling to keep in step with this one.
+func slackKBUpdateMessage(up providers.KBUpdate) map[string]any {
+	return map[string]any{
+		"text": boundPostedReply(thread.RenderReply(kbUpdateAnnouncement(up), escapeMrkdwn), slackReplyBytes),
+	}
+}
+
+// DeliverKBUpdate announces a landed knowledge-base write to the configured
+// incoming webhook (providers.KBUpdateNotifier).
+//
+// The incoming-webhook path implements this for the same reason the bot path
+// does: Multi SKIPS a notifier that does not implement the capability, so a
+// supported delivery target that lacked the method would turn
+// notify.thread.announce_kb_updates into a switch that silently does nothing
+// for every operator on it.
+func (s *Slack) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
+	return s.post(ctx, slackKBUpdateMessage(up))
+}
+
+// DeliverKBUpdate announces a landed knowledge-base write to the configured
+// channel (providers.KBUpdateNotifier).
+//
+// It posts to the CHANNEL, never into the originating thread: the thread
+// already received the direct reply to the person who typed, and the whole
+// point of the announcement is reaching the people who were not reading it. So
+// no thread_ts is set here, deliberately — see ReplyInThread for the other
+// destination.
+func (s *SlackBot) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
+	_, err := s.post(ctx, slackKBUpdateMessage(up))
+	return err
+}
+
+// DeliverKBUpdate announces a landed knowledge-base write to the configured
+// room (providers.KBUpdateNotifier), as a plain m.notice with no m.thread
+// relation — see SlackBot.DeliverKBUpdate for why the destination is the room
+// rather than the thread.
+//
+// The body goes through thread.RenderReply with escapeMatrixReply: a plain body
+// has no markup to inject, but .m.rule.roomnotif matches "@room" in it and
+// notifies every member of the room, which model-authored note text can reach
+// the same way it reaches Slack's <!channel>.
+func (m *Matrix) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
+	_, err := m.send(ctx, m.roomID, map[string]any{
+		"msgtype": "m.notice",
+		"body":    boundPostedReply(thread.RenderReply(kbUpdateAnnouncement(up), escapeMatrixReply), matrixReplyBytes),
+	})
+	return err
+}

--- a/internal/notify/kbupdate_test.go
+++ b/internal/notify/kbupdate_test.go
@@ -1,0 +1,541 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// hostileKBUpdate fills EVERY field providers.KBUpdate documents as untrusted —
+// Note, Title, Author, URL and Root, all five — with the payload that transport
+// treats as markup. Filling all five rather than the ones a renderer happens to
+// use today is the point: a field this announcement does not render yet is one
+// escape away from being rendered, and the assertion has to already cover it.
+func hostileKBUpdate(payload string) providers.KBUpdate {
+	return providers.KBUpdate{
+		Transport: "slack",
+		Root:      payload,
+		Route:     providers.KBRouteOpenPR,
+		PR:        99,
+		URL:       payload,
+		Title:     "Operator note: " + payload,
+		Author:    payload,
+		Note:      "the registry PVC filled up — " + payload,
+		At:        time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+	}
+}
+
+// kbUpdateSinkOnFakeTransport wires both chat notifiers at one httptest server
+// and returns them keyed by transport, with the sink holding what they posted.
+func kbUpdateSinkOnFakeTransport(t *testing.T) (map[string]providers.KBUpdateNotifier, *[]string) {
+	t.Helper()
+	var sent []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sent = append(sent, string(body))
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1","event_id":"$1"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	bot := NewSlackBot("xoxb-test", "C1")
+	bot.baseURL = srv.URL
+	mx := NewMatrix(srv.URL, "!room:example.org", "tok")
+	return map[string]providers.KBUpdateNotifier{"slack": bot, "matrix": mx}, &sent
+}
+
+// TestSlackKBUpdateAnnouncementNeutralisesUntrustedFields is the guarantee this
+// egress needs from its first commit rather than from a later review.
+//
+// The announcement is a NEW destination for model-authored text: on the
+// freeform route RunLore's own chat model wrote KBUpdate.Note, and unlike the
+// thread reply this lands in the notifier's CONFIGURED channel, where RunLore
+// posts investigation findings. Unescaped, "<!channel>" in that text mass-pings
+// the channel and "<https://evil|https://github.com/acme/kb/pull/7>" renders as
+// a clickable link whose visible text is a trusted knowledge-base URL — the
+// same pair PR3's Untrusted/RenderReply boundary was built for, arriving
+// through a different door.
+func TestSlackKBUpdateAnnouncementNeutralisesUntrustedFields(t *testing.T) {
+	sinks, sent := kbUpdateSinkOnFakeTransport(t)
+	up := hostileKBUpdate("<!channel> <https://evil.example|https://github.com/acme/kb/pull/7>")
+
+	*sent = nil
+	if err := sinks["slack"].DeliverKBUpdate(context.Background(), up); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("posted %d messages, want 1", len(*sent))
+	}
+	text := postedThreadText(t, (*sent)[0])
+
+	for _, live := range []string{"<!channel>", "<https://evil.example|"} {
+		if strings.Contains(text, live) {
+			t.Errorf("an untrusted field reached Slack as live mrkdwn (%q):\n%s", live, text)
+		}
+	}
+	if !strings.Contains(text, "&lt;!channel&gt;") {
+		t.Errorf("the untrusted text must still be READABLE, escaped rather than censored:\n%s", text)
+	}
+	// RunLore's own framing is not escaped with it: the blockquote markers are
+	// what keep the quoted note distinguishable from RunLore's own claims, and
+	// mrkdwnEscaper would turn them into literal "&gt; ".
+	if !strings.Contains(text, "\n> ") {
+		t.Errorf("the quoted note lost its blockquote markers to escaping:\n%s", text)
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "&gt;") {
+			t.Errorf("RunLore's own blockquote marker was escaped, so the quote no longer renders as one: %q", line)
+		}
+	}
+	if strings.Contains(text, "\ue000") {
+		t.Errorf("an untrusted-span mark reached the chat system:\n%s", text)
+	}
+}
+
+// TestMatrixKBUpdateAnnouncementNeutralisesUntrustedFields is the same
+// guarantee against Matrix's own hazard. A plain m.notice body has no markup to
+// inject, but .m.rule.roomnotif matches "@room" in content.body and notifies
+// every member of the room — the direct analogue of Slack's <!channel>, and
+// reachable the same way, through text RunLore's model wrote.
+func TestMatrixKBUpdateAnnouncementNeutralisesUntrustedFields(t *testing.T) {
+	sinks, sent := kbUpdateSinkOnFakeTransport(t)
+	up := hostileKBUpdate("@room now")
+
+	*sent = nil
+	if err := sinks["matrix"].DeliverKBUpdate(context.Background(), up); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	if len(*sent) != 1 {
+		t.Fatalf("posted %d messages, want 1", len(*sent))
+	}
+	body := postedThreadText(t, (*sent)[0])
+
+	if strings.Contains(body, "@room") {
+		t.Errorf("an untrusted field reached the room as a live @room ping:\n%s", body)
+	}
+	if !strings.Contains(body, "@\u2060room") {
+		t.Errorf("the token must be marked, not censored — a human still has to be able to read it:\n%s", body)
+	}
+	if strings.Contains(body, "\ue000") {
+		t.Errorf("an untrusted-span mark reached the room:\n%s", body)
+	}
+}
+
+// TestAnnouncedNoteCannotBreakOutOfTheBlockquote is the announcement's half of
+// the same defect, and the worse half.
+//
+// The blockquote is what stops a line of note text sitting where RunLore's own
+// claims sit, and the announcement is the surface where that matters most: it
+// lands in the CONFIGURED channel, next to investigation findings, under the
+// same bot identity, and the headline it would be forging is right there in the
+// same message for comparison. Splitting the note on "\n" alone made that
+// forgery a single rune away — UAX #14 gives seven characters a mandatory
+// break, and a client renders a new visual line at every one of them, at the
+// left margin, outside the quote.
+//
+// This is asserted byte for byte on the text each transport actually posts, for
+// both of them, because the announcement had no second measure to fall back on:
+// it did not strip RunLore's status glyphs either, so the escaped line came out
+// reading exactly like kbHeadline. Sharing thread.QuoteUntrusted is what closes
+// both at once, and the 📚 the note carries below is what pins the glyph strip
+// arriving with it.
+func TestAnnouncedNoteCannotBreakOutOfTheBlockquote(t *testing.T) {
+	const head = "📚 Knowledge base updated — opened PR #42 — https://github.com/o/r/pull/42"
+	const forged = "Knowledge base updated — opened PR #999 — https://evil.example/kb"
+
+	sinks, sent := kbUpdateSinkOnFakeTransport(t)
+	for _, br := range []struct{ name, sep string }{
+		{"LF U+000A", "\n"},
+		{"CR U+000D", "\r"},
+		{"CRLF is one break, not two", "\r\n"},
+		{"VT U+000B", "\v"},
+		{"FF U+000C", "\f"},
+		{"NEL U+0085", "\u0085"},
+		{"LS U+2028", "\u2028"},
+		{"PS U+2029", "\u2029"},
+	} {
+		up := providers.KBUpdate{
+			Route: providers.KBRouteOpenPR, PR: 42, URL: "https://github.com/o/r/pull/42",
+			Note: "harmless" + br.sep + "📚 " + forged,
+		}
+		for transport, sink := range sinks {
+			t.Run(br.name+"/"+transport, func(t *testing.T) {
+				*sent = nil
+				if err := sink.DeliverKBUpdate(context.Background(), up); err != nil {
+					t.Fatalf("DeliverKBUpdate: %v", err)
+				}
+				got := postedThreadText(t, (*sent)[0])
+				want := head + "\n> harmless\n> " + forged
+				if got != want {
+					t.Errorf("a %s in the note escaped the blockquote.\n got %q\nwant %q", br.name, got, want)
+				}
+			})
+		}
+	}
+}
+
+// TestAnnouncementFieldCapsHaveTheirDocumentedValues pins the NUMBERS, the way
+// config.TestThreadDefaultsHaveTheirDocumentedValues pins the thread defaults.
+//
+// The bound test below cannot: every ceiling it checks is recomputed from the
+// constant under test, so both sides move together. Raise kbNotePreviewBytes
+// from 512 to 3072 and it stays green while the announcement grows unchecked —
+// and the announcement is the wider egress of the two, landing in the configured
+// channel where investigation findings go rather than in the thread the note
+// came from.
+//
+// 512 is derived rather than picked, and derived the same way the thread reply's
+// own notePreviewBytes is (see this file's const block): every untrusted span is
+// escaped before it goes on the wire, and the widest escape — Slack's "&" to
+// "&amp;" — expands 5x, so 512 bytes reaches the transport as at most ~2.5k
+// characters. The three one-line field caps bound values that arrive length-
+// capped by NOTHING upstream: KBUpdate.Author in particular is redacted and
+// flattened but never shortened (internal/thread's 100-byte cap bounds a MODEL
+// PROMPT, not what reaches a notifier).
+func TestAnnouncementFieldCapsHaveTheirDocumentedValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"kbNotePreviewBytes", kbNotePreviewBytes, 512},
+		{"kbTitleBytes", kbTitleBytes, 200},
+		{"kbAuthorBytes", kbAuthorBytes, 100},
+		{"kbURLBytes", kbURLBytes, 512},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %d, want %d — if this was a deliberate retune, redo the 5x-escape "+
+				"arithmetic against slackReplyBytes/matrixReplyBytes, and restate the number "+
+				"wherever the docs quote it (internal/docsguard will list the pages)", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestKBUpdateAnnouncementIsBoundedPerTransport pins the second half of making
+// this egress safe: what is RENDERED is bounded, independently of what was
+// WRITTEN.
+//
+// KBUpdate.Note deliberately carries the whole note, up to max_note_bytes —
+// 8 KiB by default and operator-raisable — so a webhook sink gets the complete
+// record. Rendered straight into a chat channel that is an 8 KiB post, on a
+// path any channel member can trigger. KBUpdate.Author is redacted and
+// flattened but never length-capped at all (chat.go's 100-byte cap is
+// prompt-side only), so it arrives unbounded.
+func TestKBUpdateAnnouncementIsBoundedPerTransport(t *testing.T) {
+	sinks, sent := kbUpdateSinkOnFakeTransport(t)
+	tail := "THE-VERY-END-OF-THE-NOTE"
+	up := providers.KBUpdate{
+		Transport: "slack",
+		Root:      "111.222",
+		Route:     providers.KBRouteOpenPR,
+		PR:        99,
+		URL:       "https://github.com/o/r/pull/99",
+		Title:     strings.Repeat("t", 4<<10),
+		Author:    strings.Repeat("a", 4<<10),
+		Note:      strings.Repeat("note text ", 800) + tail, // 8 KiB, the default cap
+		At:        time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+	}
+
+	for transport, sink := range sinks {
+		t.Run(transport, func(t *testing.T) {
+			*sent = nil
+			if err := sink.DeliverKBUpdate(context.Background(), up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			text := postedThreadText(t, (*sent)[0])
+
+			if len(text) > 4<<10 {
+				t.Errorf("announcement is %d bytes: an 8 KiB note became an 8 KiB channel post", len(text))
+			}
+			if strings.Contains(text, tail) {
+				t.Errorf("the whole note was rendered; only a preview belongs in a channel post:\n%.500s", text)
+			}
+			// Each one-line field is cut to its OWN cap, exactly. Asking only
+			// that 200 bytes of author or 400 of title be absent left twice the
+			// real ceiling unchecked in both cases — a renderer passing 150 to
+			// kbField for the author would have satisfied it while posting half
+			// again what the cap allows. The expected run is the cap minus the
+			// ellipsis kbField appends in place of what it dropped, so a value
+			// silently hard-cut with no mark fails here too: a truncated field
+			// read as a whole one is the thing that mark exists to prevent.
+			for _, f := range []struct {
+				name  string
+				char  byte
+				limit int
+			}{
+				{"Author", 'a', kbAuthorBytes},
+				{"Title", 't', kbTitleBytes},
+			} {
+				got, want := longestRun(text, f.char), f.limit-len(kbFieldEllipsis)
+				if got != want {
+					t.Errorf("KBUpdate.%s rendered as a %d-byte run, want exactly %d (its cap is %d, less the %q that marks the cut):\n%.500s",
+						f.name, got, want, f.limit, kbFieldEllipsis, text)
+				}
+			}
+			// A reader who cannot tell the quote was shortened reads what
+			// survived as the whole note.
+			if !strings.Contains(text, "truncated") {
+				t.Errorf("a shortened quote must say so:\n%.500s", text)
+			}
+			// The record itself is never what gets dropped.
+			if !strings.Contains(text, "https://github.com/o/r/pull/99") {
+				t.Errorf("the pull-request URL must survive:\n%.500s", text)
+			}
+		})
+	}
+}
+
+// longestRun returns the length of the longest unbroken run of c in s. It is
+// how the test above measures a rendered one-line field without asking the
+// renderer where it put it: the fixture fills each field with a single repeated
+// character no other part of the announcement repeats.
+func longestRun(s string, c byte) int {
+	best, run := 0, 0
+	for i := range len(s) {
+		if s[i] != c {
+			run = 0
+			continue
+		}
+		run++
+		if run > best {
+			best = run
+		}
+	}
+	return best
+}
+
+// TestKBUpdateAnnouncementNamesWhatLanded pins the content an operator reading
+// the channel needs: which route the write took, the pull request, the entry it
+// created, and who it came from.
+//
+// The route WORDING is asserted on both routes, and each case also denies the
+// other route's words. That is not symmetry for its own sake: the headline is
+// RunLore's own claim about what it did, and hard-coding it to always say
+// "opened" passed this whole suite — the comment case listed no route wording at
+// all — so an announcement could tell a channel a new pull request had been
+// opened when the note was in fact appended as a comment to one someone else
+// owns. Denying the opposite wording is what stops a fix from over-correcting
+// into the mirror-image defect.
+func TestKBUpdateAnnouncementNamesWhatLanded(t *testing.T) {
+	sinks, sent := kbUpdateSinkOnFakeTransport(t)
+	for _, tc := range []struct {
+		name string
+		up   providers.KBUpdate
+		want []string
+		deny []string
+	}{
+		{
+			name: "open_pr names the entry it created",
+			up: providers.KBUpdate{
+				Transport: "slack", Root: "111.222", Route: providers.KBRouteOpenPR, PR: 99,
+				URL: "https://github.com/o/r/pull/99", Title: "Operator note: OOM in payments",
+				Author: "sre-jane", Note: "the real cause was a spot reclaim",
+			},
+			want: []string{"opened PR #99", "https://github.com/o/r/pull/99", "Operator note: OOM in payments",
+				"sre-jane", "> the real cause was a spot reclaim", "slack"},
+			deny: []string{"noted on"},
+		},
+		{
+			name: "comment names the pull request it joined",
+			up: providers.KBUpdate{
+				Transport: "matrix", Root: "$evt", Route: providers.KBRouteComment, PR: 42,
+				URL: "https://github.com/o/r/pull/42", Author: "sre-jane", Note: "it recurs after node rotation",
+			},
+			want: []string{"noted on PR #42", "https://github.com/o/r/pull/42", "sre-jane",
+				"> it recurs after node rotation", "matrix"},
+			deny: []string{"opened"},
+		},
+		{
+			name: "an unnumbered forge URL still announces the write",
+			up: providers.KBUpdate{
+				Transport: "slack", Route: providers.KBRouteOpenPR,
+				URL: "https://github.com/o/r/kb", Note: "capture this",
+			},
+			want: []string{"opened PR", "https://github.com/o/r/kb", "> capture this"},
+			deny: []string{"noted on", "#0"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			*sent = nil
+			if err := sinks["slack"].DeliverKBUpdate(context.Background(), tc.up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			text := postedThreadText(t, (*sent)[0])
+			for _, want := range tc.want {
+				if !strings.Contains(text, want) {
+					t.Errorf("announcement does not name %q:\n%s", want, text)
+				}
+			}
+			for _, deny := range tc.deny {
+				if strings.Contains(text, deny) {
+					t.Errorf("announcement says %q on the %s route — it is reporting a route the write did not take:\n%s",
+						deny, tc.up.Route, text)
+				}
+			}
+		})
+	}
+}
+
+// TestEveryChatNotifierAnnouncesKBUpdates is the guard against the failure mode
+// the capability check itself creates: Multi SKIPS a notifier that does not
+// implement KBUpdateNotifier, silently and by design, so a chat sink that never
+// grew the method turns announce_kb_updates into a switch that does nothing at
+// all — configured, logged as enabled, delivering to nobody.
+//
+// Every notifier that posts to a channel is listed here on purpose, the
+// incoming-webhook Slack path included: it is a documented, supported delivery
+// target, and an operator on it would otherwise get exactly that silent no-op.
+func TestEveryChatNotifierAnnouncesKBUpdates(t *testing.T) {
+	for _, n := range []providers.Notifier{
+		NewSlack("https://hooks.slack.com/services/x"),
+		NewSlackBot("xoxb-test", "C1"),
+		NewMatrix("https://hs.example.org", "!room:example.org", "tok"),
+	} {
+		if _, ok := n.(providers.KBUpdateNotifier); !ok {
+			t.Errorf("%T does not implement providers.KBUpdateNotifier — Multi will skip it silently and the operator's announce_kb_updates will do nothing",
+				n)
+		}
+	}
+}
+
+// TestMultiFansAKBUpdateOutToTheRealChatNotifiers closes the same gap end to
+// end, through the fan-out an operator actually configures rather than through
+// a type assertion: both real chat notifiers receive the announcement.
+func TestMultiFansAKBUpdateOutToTheRealChatNotifiers(t *testing.T) {
+	var sent []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sent = append(sent, string(body))
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1","event_id":"$1"}`))
+	}))
+	defer srv.Close()
+
+	bot := NewSlackBot("xoxb-test", "C1")
+	bot.baseURL = srv.URL
+	mx := NewMatrix(srv.URL, "!room:example.org", "tok")
+	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), bot, mx)
+
+	if err := m.DeliverKBUpdate(context.Background(), providers.KBUpdate{
+		Transport: "slack", Root: "111.222", Route: providers.KBRouteOpenPR, PR: 99,
+		URL: "https://github.com/o/r/pull/99", Author: "sre-jane", Note: "a spot reclaim",
+	}); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	if len(sent) != 2 {
+		t.Fatalf("the fan-out posted %d announcements, want one per chat notifier (2)", len(sent))
+	}
+	for i, body := range sent {
+		if !strings.Contains(postedThreadText(t, body), "https://github.com/o/r/pull/99") {
+			t.Errorf("announcement %d does not carry the pull request:\n%s", i, body)
+		}
+	}
+}
+
+// TestKBUpdateAnnouncementNeverPostsIntoAThread pins the destination decision.
+// The thread reply is the acknowledgement to the person who typed; the
+// announcement is what reaches everyone who was not reading that thread. It
+// goes to each notifier's own configured channel or room, so it must carry no
+// threading relation — not Slack's thread_ts, not Matrix's m.thread.
+func TestKBUpdateAnnouncementNeverPostsIntoAThread(t *testing.T) {
+	sinks, sent := kbUpdateSinkOnFakeTransport(t)
+	up := providers.KBUpdate{
+		Transport: "slack", Root: "111.222", Route: providers.KBRouteOpenPR, PR: 99,
+		URL: "https://github.com/o/r/pull/99", Note: "a spot reclaim",
+	}
+	for transport, sink := range sinks {
+		t.Run(transport, func(t *testing.T) {
+			*sent = nil
+			if err := sink.DeliverKBUpdate(context.Background(), up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			for _, forbidden := range []string{"thread_ts", "m.thread", "111.222"} {
+				if strings.Contains((*sent)[0], forbidden) {
+					t.Errorf("the announcement carries %q — it must post to the configured channel, never into the originating thread:\n%s",
+						forbidden, (*sent)[0])
+				}
+			}
+		})
+	}
+}
+
+// TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot keeps the renderer honest
+// about the event it is given. providers.KBUpdate has a reflection test forcing
+// every field to be classified trusted or untrusted; this is the notifier's
+// side of it — a field added to the event must be either shown to the operator
+// or listed here as deliberately withheld, so "we forgot to render it" cannot
+// pass as "we chose not to".
+func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
+	// What the announcement must show, and the form it shows it in — Route is a
+	// sentence a human reads, not the raw enum value.
+	shows := map[string]string{
+		"Transport": "matrix",
+		"Route":     "opened PR",
+		"PR":        "4242",
+		"URL":       "https://github.com/o/r/pull/4242",
+		"Title":     "Operator note: OOM",
+		"Author":    "sre-jane",
+		"Note":      "a spot reclaim",
+	}
+	// Root is an opaque per-transport handle (a Slack thread_ts, a Matrix event
+	// id). It identifies the thread for a programmatic consumer; printed into a
+	// channel it is noise a human cannot act on, and the announcement already
+	// names the transport it came from. At is the wall clock of a message the
+	// chat system timestamps itself.
+	withheld := map[string]string{
+		"Root": "$evt-root",
+		"At":   "2026-08-16T09:00:00Z",
+	}
+
+	sinks, sent := kbUpdateSinkOnFakeTransport(t)
+	up := providers.KBUpdate{
+		Transport: "matrix", Root: "$evt-root", Route: providers.KBRouteOpenPR, PR: 4242,
+		URL: "https://github.com/o/r/pull/4242", Title: "Operator note: OOM",
+		Author: "sre-jane", Note: "a spot reclaim", At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+	}
+	*sent = nil
+	if err := sinks["slack"].DeliverKBUpdate(context.Background(), up); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	text := postedThreadText(t, (*sent)[0])
+
+	rt := reflect.TypeOf(up)
+	for i := range rt.NumField() {
+		name := rt.Field(i).Name
+		want, shown := shows[name]
+		hide, hidden := withheld[name]
+		switch {
+		case shown == hidden:
+			t.Errorf("KBUpdate.%s is in neither or both of shows/withheld — decide whether an operator reading the channel is told it", name)
+		case shown && !strings.Contains(text, want):
+			t.Errorf("KBUpdate.%s must be announced as %q, and is not:\n%s", name, want, text)
+		case hidden && strings.Contains(text, hide):
+			t.Errorf("KBUpdate.%s is listed as deliberately withheld but is rendered — update the list or stop rendering it:\n%s", name, text)
+		}
+	}
+
+	// The reverse direction, which its internal/providers sibling
+	// (TestKBUpdateClassifiesEveryFieldForEscaping) already checks and this side
+	// did not: an entry naming a field KBUpdate no longer has asserts nothing
+	// about anything. The loop above only walks the STRUCT, so a renamed or
+	// deleted field leaves its entry behind, still listed, still reading in
+	// review as a decision someone made about a field that is being rendered —
+	// and the new field that replaced it falls straight into the "in neither"
+	// arm, whose message is about the new name rather than the stale one.
+	for _, m := range []map[string]string{shows, withheld} {
+		for name := range m {
+			if _, ok := rt.FieldByName(name); !ok {
+				t.Errorf("shows/withheld classifies %q, but KBUpdate has no such field — stale entry, "+
+					"so nothing is checking whatever replaced it", name)
+			}
+		}
+	}
+}

--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -77,6 +77,7 @@ func NewMatrix(homeserver, roomID, token string) *Matrix {
 
 var _ providers.Notifier = (*Matrix)(nil)
 var _ providers.ThreadNotifier = (*Matrix)(nil)
+var _ providers.KBUpdateNotifier = (*Matrix)(nil)
 
 // send posts content as an m.room.message event to room via the Matrix
 // client-server send API, handling the transaction id, auth header, and status
@@ -196,11 +197,16 @@ func escapeMatrixReply(s string) string {
 // SlackBot.ReplyInThread for the same boundary drawn against mrkdwn. Calling
 // it is not optional even for a transport with little to escape: RenderReply
 // is also what removes the in-band span marks, which must never reach a room.
+//
+// The rendered body is then bounded at matrixReplyBytes. A Matrix event has a
+// hard 65,536-byte ceiling, so an oversized body is a rejected event and a
+// human left in silence about a note that was already written; see
+// boundPostedReply for why the bound sits after rendering and what it drops.
 func (m *Matrix) ReplyInThread(ctx context.Context, root, channel, text string) error {
 	room := cmp.Or(channel, m.roomID)
 	content := map[string]any{
 		"msgtype": "m.notice",
-		"body":    thread.RenderReply(text, escapeMatrixReply),
+		"body":    boundPostedReply(thread.RenderReply(text, escapeMatrixReply), matrixReplyBytes),
 		"m.relates_to": map[string]any{
 			"rel_type": "m.thread",
 			"event_id": root,

--- a/internal/notify/payload.go
+++ b/internal/notify/payload.go
@@ -82,3 +82,49 @@ func NewPayload(inv providers.Investigation) Payload {
 		Prior: prior, MatchedKnowledge: matched,
 	}
 }
+
+// kbUpdateEvent is the value KBUpdatePayload.Event always carries. It exists
+// because both deliveries go to the SAME operator-configured URL: an
+// investigation and a knowledge-base update are different shapes, and a
+// receiver written against Payload would otherwise decode an update into a
+// zero-valued investigation and report an empty finding. Payload itself does
+// NOT grow this key — its wire format is what external consumers already parse.
+const kbUpdateEvent = "kb_update"
+
+// KBUpdatePayload is the delivery payload for a knowledge-base write that
+// already landed on the forge — the programmatic counterpart of the chat
+// announcement notify's Slack and Matrix notifiers render.
+//
+// It carries the note at the length it was WRITTEN, with no preview ceiling: a
+// receiver here wants the record, and bounding what is RENDERED is a chat
+// transport's job (see notify's kbNotePreviewBytes). The fields providers.KBUpdate
+// documents as untrusted are untrusted here too, and they leave the network —
+// that is what a webhook is for — but the hazard on this path is a malformed or
+// injected JSON body rather than chat markup, so encoding/json is the whole
+// defence and every value goes out verbatim. A chat escaper applied here would
+// corrupt the record instead of protecting it.
+type KBUpdatePayload struct {
+	Event     string `json:"event"` // always kbUpdateEvent
+	Transport string `json:"transport,omitempty"`
+	Root      string `json:"root,omitempty"`
+	Route     string `json:"route"`
+	PR        int    `json:"pr,omitempty"`
+	URL       string `json:"url,omitempty"`
+	Title     string `json:"title,omitempty"`
+	Author    string `json:"author,omitempty"`
+	Note      string `json:"note,omitempty"`
+	At        string `json:"at,omitempty"` // RFC3339; "" when unknown
+}
+
+// NewKBUpdatePayload maps a KBUpdate to the delivery payload.
+func NewKBUpdatePayload(up providers.KBUpdate) KBUpdatePayload {
+	at := ""
+	if !up.At.IsZero() {
+		at = up.At.UTC().Format(time.RFC3339)
+	}
+	return KBUpdatePayload{
+		Event: kbUpdateEvent, Transport: up.Transport, Root: up.Root,
+		Route: string(up.Route), PR: up.PR, URL: up.URL,
+		Title: up.Title, Author: up.Author, Note: up.Note, At: at,
+	}
+}

--- a/internal/notify/reply_bound.go
+++ b/internal/notify/reply_bound.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Per-transport ceilings for one posted message, in bytes of the FINAL text —
+// what the transport actually receives, after every escape has been applied.
+//
+// They are stated here, in the notifier package, because a message limit is a
+// property of the chat system and of nothing else. internal/thread composes a
+// reply without knowing which transport will carry it (it may be carried by
+// two at once), and the layer above it — the chat model's max_tokens — is
+// operator-configurable with no upper bound at all, so nothing upstream can
+// promise a reply fits.
+const (
+	// slackReplyBytes bounds chat.postMessage's "text". Slack documents ~40,000
+	// characters; this stays under that with room for the JSON envelope, and it
+	// is a BYTE count against a CHARACTER limit, which errs in the safe
+	// direction — a byte count is never smaller than the character count it
+	// encodes.
+	slackReplyBytes = 35_000
+	// matrixReplyBytes bounds an m.notice body. The Matrix spec caps a whole
+	// event at 65,536 bytes — signatures, hashes and relations included — and
+	// the body is one field of it, so half is the share it may claim.
+	matrixReplyBytes = 32 << 10
+)
+
+// What a shortened reply says instead of stopping silently. RunLore's own
+// bytes: appended AFTER escaping, so they must carry no markup of their own
+// (no & < > for mrkdwn, no @room for Matrix), and they lead with the ⚠️ status
+// glyph because they are a claim RunLore makes about what it did.
+//
+// A human who cannot tell a message was shortened reads what survived as the
+// whole of it — the same failure noteTruncatedNotice prevents for the note
+// quote one layer up.
+const (
+	replyHeadDroppedNotice = "⚠️ (this reply was too long to post — the earlier part was dropped)"
+	replyTailCutNotice     = "⚠️ (this reply was too long to post — it was cut off here)"
+)
+
+// boundPostedReply caps a fully rendered thread reply at maxBytes, dropping the
+// model's prose before the record of what happened.
+//
+// It runs on the RENDERED text — after thread.RenderReply has escaped the
+// untrusted spans — because that is the string the transport receives. Bounding
+// the composed reply instead would bound the wrong thing: escapeMrkdwn turns
+// each "&" into "&amp;", so a reply that measures well under the budget as
+// composed can arrive five times over it.
+//
+// WHAT it drops follows from how internal/thread composes the message. On the
+// freeform route the reply is the model's answer, then RunLore's status line,
+// then the recorded note quoted back (see Responder.freeform and
+// recordedBlock) — the record is at the END. So whole lines are dropped from
+// the FRONT: the PR link and the quote are what the human cannot reconstruct
+// from anywhere else, and the tail of a long answer is what they can.
+//
+// Whole LINES, never part of one, and that is load-bearing rather than tidy:
+// every line of model prose is blockquoted, and a cut through the middle of one
+// would leave the remainder at the left margin, where RunLore's own claims sit —
+// the exact forgery thread.modelVoice's blockquote exists to prevent.
+//
+// The one case whole lines cannot fix is a single line longer than the whole
+// budget — a model answer with no newline in it. There is no record below it to
+// protect (a record is several short lines, and a reply shaped like this has
+// none), so its head is kept instead, "> " prefix included, and the cut lands
+// on a rune boundary so no invalid UTF-8 reaches the wire.
+func boundPostedReply(rendered string, maxBytes int) string {
+	if maxBytes <= 0 || len(rendered) <= maxBytes {
+		return rendered
+	}
+	lines := strings.Split(rendered, "\n")
+
+	// Keep whole lines from the end while they fit under what the notice leaves.
+	budget := maxBytes - len(replyHeadDroppedNotice) - 1 // -1: the newline joining the notice
+	kept, size := 0, 0
+	for i := len(lines) - 1; i >= 0; i-- {
+		add := len(lines[i])
+		if kept > 0 {
+			add++ // the newline this line is joined by
+		}
+		if size+add > budget {
+			break
+		}
+		size += add
+		kept++
+	}
+	if kept == 0 {
+		last := lines[len(lines)-1]
+		return cutBytesToRuneBoundary(last, maxBytes-len(replyTailCutNotice)-1) + "\n" + replyTailCutNotice
+	}
+	return replyHeadDroppedNotice + "\n" + strings.Join(lines[len(lines)-kept:], "\n")
+}
+
+// cutBytesToRuneBoundary truncates s to at most n bytes without splitting a
+// rune. A byte-sliced cut would hand the chat system invalid UTF-8, which is a
+// rejected post — the same failure the bound exists to avoid, arrived at from
+// the other side.
+func cutBytesToRuneBoundary(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
+}

--- a/internal/notify/reply_bound_test.go
+++ b/internal/notify/reply_bound_test.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+// threadReplyBudgets is each transport's own ceiling, keyed the way
+// Multi.ThreadRepliers keys its repliers, so the table below drives the real
+// providers.ThreadNotifier surface rather than a concrete type — a third
+// transport wired into Multi fails these the day it is added.
+var threadReplyBudgets = map[string]int{
+	"slack":  slackReplyBytes,
+	"matrix": matrixReplyBytes,
+}
+
+// postedThreadText decodes the one field each transport carries a thread
+// reply's text in: Slack's chat.postMessage "text", Matrix's m.notice "body".
+func postedThreadText(t *testing.T, body string) string {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		t.Fatalf("decode posted body: %v", err)
+	}
+	for _, k := range []string{"text", "body"} {
+		if s, ok := m[k].(string); ok {
+			return s
+		}
+	}
+	t.Fatalf(`posted body carries neither a Slack "text" nor a Matrix "body": %s`, body)
+	return ""
+}
+
+// threadRepliersOnFakeTransport wires both real repliers at one httptest
+// server and returns them with the sink that captured what they posted.
+func threadRepliersOnFakeTransport(t *testing.T) (map[string]providers.ThreadNotifier, *[]string) {
+	t.Helper()
+	var sent []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sent = append(sent, string(body))
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1","event_id":"$1"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	bot := NewSlackBot("xoxb-test", "C1")
+	bot.baseURL = srv.URL
+	mx := NewMatrix(srv.URL, "!room:example.org", "tok")
+	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), bot, mx)
+	return m.ThreadRepliers(), &sent
+}
+
+// TestTransportReplyBudgetsHaveTheirDocumentedValues pins the NUMBERS, the way
+// config.TestThreadDefaultsHaveTheirDocumentedValues pins the thread defaults.
+//
+// Nothing else in this file can. threadReplyBudgets is BUILT from these two
+// constants, and every bound test below reads its budget out of that map, so
+// both sides of `len(text) > budget` move together and the assertions hold for
+// any value at all. Raising slackReplyBytes to 100_000 — roughly 3x the ~40,000
+// characters Slack documents — keeps the whole suite green while a 148-byte
+// reply becomes a 50,476-byte post: rejected by Slack, so the human is told
+// NOTHING about a note that WAS written to the forge, which is the one outcome
+// this feature exists to make impossible and the exact failure this bound was
+// added for.
+//
+// Each number is a property of the chat system, not a tuning knob, and each is
+// derived: see the constants' own doc comments for the derivation. Changing one
+// should be a deliberate edit here against the transport's published limit.
+func TestTransportReplyBudgetsHaveTheirDocumentedValues(t *testing.T) {
+	if got, want := slackReplyBytes, 35_000; got != want {
+		t.Errorf("slackReplyBytes = %d, want %d — Slack documents ~40,000 characters for "+
+			"chat.postMessage's text, and this stays under that with room for the JSON envelope; "+
+			"raising it past the real limit turns a long reply into a rejected post and the human "+
+			"hears nothing about a write that landed", got, want)
+	}
+	if got, want := matrixReplyBytes, 32<<10; got != want {
+		t.Errorf("matrixReplyBytes = %d, want %d — the Matrix spec caps a whole event at 65,536 "+
+			"bytes including signatures, hashes and relations, and the body is one field of it", got, want)
+	}
+	// The map every bound test reads its budget from really is built from the two
+	// constants above: a transport wired into Multi whose budget came from
+	// somewhere else would be pinned by neither.
+	for transport, want := range map[string]int{"slack": slackReplyBytes, "matrix": matrixReplyBytes} {
+		if got := threadReplyBudgets[transport]; got != want {
+			t.Errorf("threadReplyBudgets[%q] = %d, want the transport's own constant (%d)", transport, got, want)
+		}
+	}
+}
+
+// TestThreadReplyIsBoundedAtTheTransport is the guard on the failure the whole
+// thread-feedback feature exists to prevent, reached by turning a documented
+// knob.
+//
+// model.chat.max_tokens is operator-configurable and config.Validate rejects
+// only a negative value, so raising it raises what one ChatReply.Reply can be —
+// and the reply path only TrimSpaces it. Neither ReplyInThread bounded the
+// composed message before posting, so a large enough answer makes the post
+// itself FAIL: Slack's text budget is ~40k characters and its worst-case
+// mrkdwn escape (& to &amp;) expands 5x. The human is then told NOTHING, while
+// their note WAS written to the forge — silence after a write, which is the one
+// outcome this feature exists to make impossible.
+//
+// So the bound sits at the transport, where the limit lives, and what it drops
+// is the model's prose. The PR link and the quoted note are the record of what
+// happened; the tail of an answer is not. A truncated reply says so, because a
+// human who cannot tell a message was shortened reads what survived as the
+// whole of it.
+func TestThreadReplyIsBoundedAtTheTransport(t *testing.T) {
+	repliers, sent := threadRepliersOnFakeTransport(t)
+	if len(repliers) == 0 {
+		t.Fatal("test setup: no thread repliers to check")
+	}
+	// The shape internal/thread composes on the freeform route: the model's
+	// answer through modelVoice, then RunLore's own status line, then the
+	// recorded note quoted back (see Responder.freeform and recordedBlock).
+	prose := strings.TrimSpace(strings.Repeat("the pod was evicted and rescheduled ", 3000))
+	const kbURL = "https://github.com/o/r/pull/42"
+	const noteQuote = "the real cause was a spot-node reclaim"
+	reply := "> " + thread.Untrusted(prose) + "\n" +
+		"📝 Noted on the knowledge-base PR #42 — " + thread.Untrusted(kbURL) + "\n" +
+		"> " + thread.Untrusted(noteQuote)
+
+	for transport, tn := range repliers {
+		t.Run(transport, func(t *testing.T) {
+			budget, ok := threadReplyBudgets[transport]
+			if !ok {
+				t.Fatalf("transport %q has no stated reply budget — a transport wired into Multi with no bound is the defect this test exists for", transport)
+			}
+			*sent = nil
+			if err := tn.ReplyInThread(context.Background(), "$root", "", reply); err != nil {
+				t.Fatalf("ReplyInThread: %v", err)
+			}
+			if len(*sent) != 1 {
+				t.Fatalf("sent %d requests, want 1", len(*sent))
+			}
+			text := postedThreadText(t, (*sent)[0])
+
+			if len(text) > budget {
+				t.Errorf("posted %d bytes, over this transport's %d-byte budget — the post would be rejected and the human told nothing about a write that happened", len(text), budget)
+			}
+			// The record survives. Dropping THIS is the failure; dropping prose is
+			// the remedy.
+			for _, must := range []string{kbURL, noteQuote} {
+				if !strings.Contains(text, must) {
+					t.Errorf("the record of what was written did not survive truncation (%q missing) — prose is what gets dropped, never this:\n%.400s", must, text)
+				}
+			}
+			if !strings.Contains(text, "too long") {
+				t.Errorf("a shortened reply must say it was shortened; got:\n%.400s", text)
+			}
+			// Whole lines are dropped, never part of one: a blockquoted line cut
+			// in the middle would leave model prose at the left margin, where
+			// RunLore's own claims sit — the exact forgery thread.modelVoice's
+			// blockquote exists to prevent.
+			for _, line := range strings.Split(text, "\n") {
+				if line == "" || strings.HasPrefix(line, "> ") {
+					continue
+				}
+				if strings.HasPrefix(line, "⚠️") || strings.HasPrefix(line, "📝") {
+					continue // RunLore's own status lines
+				}
+				t.Errorf("truncation left a fragment at the left margin, where RunLore's own lines sit: %q", line)
+			}
+		})
+	}
+}
+
+// TestSlackThreadReplyIsBoundedAfterEscapingNotBefore pins WHERE the bound is
+// applied, which is the half that is easy to get wrong and impossible to see.
+//
+// escapeMrkdwn expands: every "&" becomes "&amp;", five bytes for one. A reply
+// measured BEFORE escaping can therefore pass a byte check and still arrive at
+// Slack five times over its budget — the bound would be real, tested, and
+// bounding the wrong string. What has to fit is what goes on the wire.
+func TestSlackThreadReplyIsBoundedAfterEscapingNotBefore(t *testing.T) {
+	repliers, sent := threadRepliersOnFakeTransport(t)
+	tn := repliers["slack"]
+	if tn == nil {
+		t.Fatal("test setup: no slack replier")
+	}
+	// Comfortably under the budget as written, five times over it once escaped.
+	amps := strings.Repeat("&", slackReplyBytes/2)
+	reply := "> " + thread.Untrusted(amps) + "\n" +
+		"📝 Noted on the knowledge-base PR #42 — " + thread.Untrusted("https://github.com/o/r/pull/42")
+	if len(reply) > slackReplyBytes {
+		t.Fatalf("test setup: the unescaped reply (%d bytes) must fit the budget (%d) so only the escaped size can trip the bound", len(reply), slackReplyBytes)
+	}
+
+	*sent = nil
+	if err := tn.ReplyInThread(context.Background(), "$root", "", reply); err != nil {
+		t.Fatalf("ReplyInThread: %v", err)
+	}
+	text := postedThreadText(t, (*sent)[0])
+	if len(text) > slackReplyBytes {
+		t.Errorf("posted %d escaped bytes over a %d-byte budget: the bound was applied to the reply as composed, not to what actually goes on the wire", len(text), slackReplyBytes)
+	}
+	if !strings.Contains(text, "https://github.com/o/r/pull/42") {
+		t.Errorf("the knowledge-base URL did not survive:\n%.400s", text)
+	}
+}
+
+// TestThreadReplyUnderBudgetIsPostedUnchanged is the other half of the bound:
+// the ordinary reply — every reply, in practice — must reach the room exactly
+// as composed, with no truncation notice bolted onto it.
+func TestThreadReplyUnderBudgetIsPostedUnchanged(t *testing.T) {
+	repliers, sent := threadRepliersOnFakeTransport(t)
+	reply := "> " + thread.Untrusted("It was a spot reclaim.") + "\n" +
+		"📝 Noted on the knowledge-base PR #42 — " + thread.Untrusted("https://github.com/o/r/pull/42")
+	want := "> It was a spot reclaim.\n📝 Noted on the knowledge-base PR #42 — https://github.com/o/r/pull/42"
+
+	for transport, tn := range repliers {
+		t.Run(transport, func(t *testing.T) {
+			*sent = nil
+			if err := tn.ReplyInThread(context.Background(), "$root", "", reply); err != nil {
+				t.Fatalf("ReplyInThread: %v", err)
+			}
+			if got := postedThreadText(t, (*sent)[0]); got != want {
+				t.Errorf("a reply within budget was altered:\ngot  %q\nwant %q", got, want)
+			}
+		})
+	}
+}
+
+// TestThreadReplyBoundsOneUnbrokenLine covers the case dropping whole lines
+// cannot fix: a model answer with no newline in it at all, longer on its own
+// than the whole budget. There is no record below it to protect — the record is
+// several short lines, and this reply has none — so the head is kept, which is
+// the part a human reads first, and the blockquote marker that keeps it
+// distinguishable from RunLore's own claims is kept with it.
+func TestThreadReplyBoundsOneUnbrokenLine(t *testing.T) {
+	repliers, sent := threadRepliersOnFakeTransport(t)
+	one := strings.Repeat("x", 2*slackReplyBytes)
+
+	for transport, tn := range repliers {
+		t.Run(transport, func(t *testing.T) {
+			budget := threadReplyBudgets[transport]
+			*sent = nil
+			if err := tn.ReplyInThread(context.Background(), "$root", "", "> "+thread.Untrusted(one)); err != nil {
+				t.Fatalf("ReplyInThread: %v", err)
+			}
+			text := postedThreadText(t, (*sent)[0])
+			if len(text) > budget {
+				t.Errorf("posted %d bytes over a %d-byte budget", len(text), budget)
+			}
+			if !strings.HasPrefix(text, "> ") {
+				t.Errorf("the blockquote marker was cut away, so model prose now sits at the left margin: %.80q", text)
+			}
+			if !strings.Contains(text, "too long") {
+				t.Errorf("a cut-off reply must say it was cut off; got:\n%.200s", text)
+			}
+		})
+	}
+}

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -112,6 +112,7 @@ func NewSlack(webhookURL string) *Slack {
 var (
 	_ providers.Notifier         = (*Slack)(nil)
 	_ providers.ProgressNotifier = (*Slack)(nil)
+	_ providers.KBUpdateNotifier = (*Slack)(nil)
 )
 
 // Deliver posts the formatted investigation to the webhook. When an action carries
@@ -180,6 +181,7 @@ var (
 	_ providers.Notifier         = (*SlackBot)(nil)
 	_ providers.ProgressNotifier = (*SlackBot)(nil)
 	_ providers.ThreadNotifier   = (*SlackBot)(nil)
+	_ providers.KBUpdateNotifier = (*SlackBot)(nil)
 )
 
 // Deliver posts the compact summary to the channel, then the full analysis as a
@@ -233,8 +235,13 @@ func (s *SlackBot) DeliverProgress(ctx context.Context, up providers.ProgressUpd
 // RunLore's claims about what it did (see thread.modelVoice). The angle
 // brackets in FreeformNotRecordedReply's backticked "`note: <text>`" example
 // are RunLore's own too.
+//
+// The rendered result is then bounded at slackReplyBytes — AFTER escaping,
+// because escaping is what can make it overflow. Without that bound a long
+// enough model answer makes the post itself fail, and the human is told nothing
+// about a note that was already written; see boundPostedReply.
 func (s *SlackBot) ReplyInThread(ctx context.Context, root, channel, text string) error {
-	msg := map[string]any{"text": thread.RenderReply(text, escapeMrkdwn), "thread_ts": root}
+	msg := map[string]any{"text": boundPostedReply(thread.RenderReply(text, escapeMrkdwn), slackReplyBytes), "thread_ts": root}
 	if channel != "" {
 		msg["channel"] = channel
 	}
@@ -946,6 +953,7 @@ func NewMulti(log *slog.Logger, notifiers ...providers.Notifier) *Multi {
 var (
 	_ providers.Notifier         = (*Multi)(nil)
 	_ providers.ProgressNotifier = (*Multi)(nil)
+	_ providers.KBUpdateNotifier = (*Multi)(nil)
 )
 
 // Deliver fans out to every notifier (best-effort: one bad sink never blocks the
@@ -975,6 +983,36 @@ func (m *Multi) DeliverProgress(ctx context.Context, up providers.ProgressUpdate
 		}
 		if err := pn.DeliverProgress(ctx, up); err != nil {
 			m.log.Error("progress delivery failed (swallowed)", "err", err)
+		}
+	}
+	return nil
+}
+
+// DeliverKBUpdate announces a knowledge-base write to every wrapped notifier
+// that implements KBUpdateNotifier (the same type-assert capability check
+// DeliverProgress does), skipping those that don't — an announcement is not an
+// Investigation, and a sink that cannot render one is skipped rather than
+// erroring.
+//
+// It is best-effort by contract, exactly like DeliverProgress: a failing sink is
+// logged and swallowed, never propagated, and it returns nil always. The write
+// being announced has ALREADY landed on the forge before this is called, so a
+// broadcast that could fail would report a write that in fact succeeded as
+// failed — and there is nothing here to roll back.
+//
+// Nil-safe: an unwired Multi is a no-op, so the KB-write path can hold a nil
+// sink to mean "announcements are off" without a nil check at every call site.
+func (m *Multi) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
+	if m == nil {
+		return nil
+	}
+	for _, n := range m.notifiers {
+		kn, ok := n.(providers.KBUpdateNotifier)
+		if !ok {
+			continue
+		}
+		if err := kn.DeliverKBUpdate(ctx, up); err != nil {
+			m.log.Error("knowledge-base update delivery failed (swallowed)", "err", err, "url", up.URL, "route", string(up.Route))
 		}
 	}
 	return nil

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -1630,3 +1630,68 @@ func TestThreadRepliersLeaveNoUntrustedMarksInThePostedText(t *testing.T) {
 		}
 	}
 }
+
+// captureKBUpdate is a fake KBUpdateNotifier recording every announcement (and
+// optionally failing) — the test double for the KB-update capability fan-out,
+// mirroring captureProgress above.
+type captureKBUpdate struct {
+	got  []providers.KBUpdate
+	fail bool
+}
+
+func (c *captureKBUpdate) Deliver(context.Context, providers.Investigation) error { return nil }
+func (c *captureKBUpdate) DeliverKBUpdate(_ context.Context, up providers.KBUpdate) error {
+	c.got = append(c.got, up)
+	if c.fail {
+		return errors.New("boom")
+	}
+	return nil
+}
+
+// TestMultiDeliverKBUpdateCapability proves Multi announces a knowledge-base
+// write only to notifiers implementing KBUpdateNotifier — a plain notifier is
+// SKIPPED, not called and not crashed on — and that a failing sink is attempted
+// and then swallowed. The write already landed on the forge before this call:
+// a broadcast that propagated an error would report a failure for something
+// that in fact succeeded.
+func TestMultiDeliverKBUpdateCapability(t *testing.T) {
+	plain := notifierFunc(func(context.Context, providers.Investigation) error {
+		t.Fatal("a plain (non-KB-update) notifier must not receive Deliver on a KB-update announcement")
+		return nil
+	})
+	cap1 := &captureKBUpdate{}
+	cap2 := &captureKBUpdate{fail: true} // failing sink: must be swallowed
+	m := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)), plain, cap1, cap2)
+	up := providers.KBUpdate{
+		Transport: "slack", Root: "111.222",
+		Route: providers.KBRouteOpenPR, PR: 12,
+		URL:    "https://github.com/o/r/pull/12",
+		Title:  "Operator note: HarborDown",
+		Author: "sre-jane",
+		Note:   "the registry PVC was full",
+		At:     time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+	}
+	if err := m.DeliverKBUpdate(context.Background(), up); err != nil {
+		t.Fatalf("DeliverKBUpdate must swallow sink errors, got %v", err)
+	}
+	if len(cap1.got) != 1 || cap1.got[0] != up {
+		t.Fatalf("KB-update-capable notifier got %+v, want exactly one announcement equal to %+v", cap1.got, up)
+	}
+	if len(cap2.got) != 1 {
+		t.Fatalf("a failing KB-update sink must still be attempted, got %d", len(cap2.got))
+	}
+}
+
+// TestMultiDeliverKBUpdateNilAndEmptyAreNoOps pins the nil-safe contract: the
+// announcement is opt-in, so an unwired or notifier-less Multi is a silent no-op
+// rather than a panic on the path that just wrote to the knowledge base.
+func TestMultiDeliverKBUpdateNilAndEmptyAreNoOps(t *testing.T) {
+	var nilMulti *Multi
+	if err := nilMulti.DeliverKBUpdate(context.Background(), providers.KBUpdate{}); err != nil {
+		t.Fatalf("nil Multi: got %v, want nil", err)
+	}
+	empty := NewMulti(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err := empty.DeliverKBUpdate(context.Background(), providers.KBUpdate{}); err != nil {
+		t.Fatalf("empty Multi: got %v, want nil", err)
+	}
+}

--- a/internal/notify/templated/templated.go
+++ b/internal/notify/templated/templated.go
@@ -58,6 +58,16 @@ type instance struct {
 }
 
 // Notifier fans one delivery out to every configured template instance.
+//
+// It deliberately does NOT implement providers.KBUpdateNotifier: an instance's
+// template is written by the operator against notify.Payload, a finished
+// investigation, and a knowledge-base update is not one — executed through that
+// template it would render every field as a zero value and POST a finding with
+// no title, verdict or confidence. Announcing one properly needs a second,
+// separately configured template, which is a schema change rather than a
+// method. Until then notify.Multi skips this sink for KB updates, and an
+// operator wanting a machine-readable announcement has notify.webhook. See
+// TestTemplatedDeliberatelyDoesNotAnnounceKBUpdates.
 type Notifier struct {
 	instances []instance
 	client    *http.Client

--- a/internal/notify/templated/templated_test.go
+++ b/internal/notify/templated/templated_test.go
@@ -152,3 +152,31 @@ func TestDeliverErrorNeverLeaksTheURL(t *testing.T) {
 		}
 	}
 }
+
+// TestTemplatedDeliberatelyDoesNotAnnounceKBUpdates states this package's
+// answer to the KB-update capability, so that answer is a decision on the
+// record rather than an omission nobody noticed.
+//
+// It does NOT implement providers.KBUpdateNotifier, and the reason is the
+// notifier's whole design: an instance is an operator-supplied text/template
+// executed over notify.Payload — a finished investigation. A knowledge-base
+// update is not one. Running the operator's finding template over it would
+// render every field as its zero value and POST that to Teams, Discord or
+// ntfy: a notification claiming an investigation with no title, no verdict and
+// no confidence, which is worse than not notifying at all.
+//
+// Doing it properly needs a SECOND template key, for a shape no operator has
+// written a template for — a config change with its own schema, validation and
+// docs, not a method. Until that key exists, being skipped by notify.Multi is
+// the honest behaviour, and an operator wanting a machine-readable KB update
+// today has notify.webhook, which sends the whole record as JSON.
+//
+// Deleting this test is the way to change the decision; it should not survive
+// an implementation.
+func TestTemplatedDeliberatelyDoesNotAnnounceKBUpdates(t *testing.T) {
+	var n providers.Notifier = &Notifier{}
+	if _, ok := n.(providers.KBUpdateNotifier); ok {
+		t.Fatal("templated implements providers.KBUpdateNotifier — if that is intended, delete this test and document the template key the announcement renders through; " +
+			"an instance's template is written against notify.Payload, and a KB update executed through it renders an investigation of zero values")
+	}
+}

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -49,7 +49,14 @@ type payload = notify.Payload
 
 // Deliver marshals the investigation to JSON and POSTs it to the configured URL.
 func (n *Notifier) Deliver(ctx context.Context, inv providers.Investigation) error {
-	body, err := json.Marshal(notify.NewPayload(inv))
+	return n.post(ctx, notify.NewPayload(inv))
+}
+
+// post marshals v and POSTs it to the configured URL, shared by Deliver and
+// DeliverKBUpdate so both deliveries get the same transport handling — and the
+// same error sanitizing, which is the part that must not be re-derived.
+func (n *Notifier) post(ctx context.Context, v any) error {
+	body, err := json.Marshal(v)
 	if err != nil {
 		return err
 	}
@@ -106,4 +113,24 @@ func init() {
 			return New(url), nil
 		},
 	})
+}
+
+var _ providers.KBUpdateNotifier = (*Notifier)(nil)
+
+// DeliverKBUpdate POSTs a landed knowledge-base write to the configured URL as
+// JSON (providers.KBUpdateNotifier).
+//
+// Implemented deliberately, and this is the sink the event was shaped for: a
+// programmatic receiver — an incident tool, a changelog, an index — wants the
+// whole record, which is why providers.KBUpdate carries the note at the length
+// it was written rather than a chat-sized preview. Declining the capability
+// would also be invisible: notify.Multi SKIPS a notifier that does not
+// implement it, so an operator who turned announce_kb_updates on would get
+// silence from the one sink built to receive it.
+//
+// It shares Deliver's endpoint, so the body carries an "event" discriminator —
+// see notify.KBUpdatePayload for why, and for why the untrusted fields go out
+// verbatim here rather than escaped.
+func (n *Notifier) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
+	return n.post(ctx, notify.NewKBUpdatePayload(up))
 }

--- a/internal/notify/webhook/webhook_test.go
+++ b/internal/notify/webhook/webhook_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -245,5 +246,141 @@ func TestBuildRegisteredFromExtra(t *testing.T) {
 	}
 	if m2.Len() != 0 {
 		t.Errorf("expected 0 notifiers when env is unset, got %d", m2.Len())
+	}
+}
+
+// TestDeliverKBUpdatePOSTsJSON pins the webhook notifier's deliberate answer to
+// the KB-update capability: it implements it, and it sends the WHOLE record.
+//
+// This is the sink the event was shaped for. providers.KBUpdate carries the note
+// at the length it was written — up to max_note_bytes — precisely because a
+// programmatic receiver wants the record rather than a chat-sized quote, and
+// bounding what is RENDERED is a chat transport's job. So no preview ceiling
+// applies here, and the full note is asserted to arrive.
+func TestDeliverKBUpdatePOSTsJSON(t *testing.T) {
+	ts, body, ct := captureServer(t, http.StatusOK)
+
+	note := strings.Repeat("the registry PVC filled up. ", 200) // far past any chat preview
+	up := providers.KBUpdate{
+		Transport: "slack",
+		Root:      "111.222",
+		Route:     providers.KBRouteOpenPR,
+		PR:        99,
+		URL:       "https://github.com/o/r/pull/99",
+		Title:     "Operator note: HarborDown",
+		Author:    "sre-jane",
+		Note:      note,
+		At:        time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+	}
+
+	n := New(ts.URL)
+	if err := n.DeliverKBUpdate(context.Background(), up); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	if got := ct(); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+
+	var got notify.KBUpdatePayload
+	if err := json.Unmarshal(body(), &got); err != nil {
+		t.Fatalf("decode posted body: %v\n%s", err, body())
+	}
+	want := notify.KBUpdatePayload{
+		Event: "kb_update", Transport: "slack", Root: "111.222", Route: "open_pr",
+		PR: 99, URL: "https://github.com/o/r/pull/99", Title: "Operator note: HarborDown",
+		Author: "sre-jane", Note: note, At: "2026-08-16T09:00:00Z",
+	}
+	if got != want {
+		t.Errorf("payload =\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+// TestDeliverKBUpdateIsDistinguishableFromAnInvestigation is the compatibility
+// half. Both deliveries POST to the SAME operator-configured URL, and the two
+// bodies are different shapes; a receiver written against the investigation
+// payload would otherwise decode a KB update into a zero-valued investigation
+// and report an empty finding. The "event" discriminator is what lets it tell
+// them apart — absent on the investigation payload, which keeps its original
+// wire format byte for byte.
+func TestDeliverKBUpdateIsDistinguishableFromAnInvestigation(t *testing.T) {
+	ts, body, _ := captureServer(t, http.StatusOK)
+	n := New(ts.URL)
+
+	if err := n.Deliver(context.Background(), providers.Investigation{Title: "X"}); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	var inv map[string]any
+	if err := json.Unmarshal(body(), &inv); err != nil {
+		t.Fatalf("decode investigation body: %v", err)
+	}
+	if _, ok := inv["event"]; ok {
+		t.Errorf(`the investigation payload grew an "event" key — its wire format is what external consumers parse: %s`, body())
+	}
+
+	if err := n.DeliverKBUpdate(context.Background(), providers.KBUpdate{Route: providers.KBRouteComment}); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	var upd map[string]any
+	if err := json.Unmarshal(body(), &upd); err != nil {
+		t.Fatalf("decode kb-update body: %v", err)
+	}
+	if upd["event"] != "kb_update" {
+		t.Errorf(`kb-update body must carry event="kb_update" so a receiver can tell the two apart: %s`, body())
+	}
+}
+
+// TestDeliverKBUpdateEscapesForJSONNotForChat is the escaping question this sink
+// answers differently from Slack and Matrix. The untrusted fields still leave
+// the network — that is what a webhook is for — but the hazard is a broken or
+// injected JSON body, not chat markup, so encoding/json is the whole defence
+// and the values must arrive byte-identical. Applying a chat escaper here would
+// corrupt the record the receiver is being sent.
+func TestDeliverKBUpdateEscapesForJSONNotForChat(t *testing.T) {
+	ts, body, _ := captureServer(t, http.StatusOK)
+	hostile := "\"},{\"injected\":true} <!channel> @room\nsecond line\ttab"
+
+	n := New(ts.URL)
+	if err := n.DeliverKBUpdate(context.Background(), providers.KBUpdate{
+		Route: providers.KBRouteOpenPR, Note: hostile, Title: hostile, Author: hostile,
+		URL: hostile, Root: hostile,
+	}); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	var got struct {
+		notify.KBUpdatePayload
+		Injected bool `json:"injected"`
+	}
+	if err := json.Unmarshal(body(), &got); err != nil {
+		t.Fatalf("the posted body is not valid JSON — an untrusted field broke out of its string: %v\n%s", err, body())
+	}
+	for name, val := range map[string]string{"note": got.Note, "title": got.Title, "author": got.Author, "url": got.URL, "root": got.Root} {
+		if val != hostile {
+			t.Errorf("%s arrived as %q, want the record verbatim — a chat escaper here would corrupt what the receiver is sent", name, val)
+		}
+	}
+	if got.Injected {
+		t.Errorf("an untrusted field injected a sibling JSON key: %s", body())
+	}
+}
+
+// TestDeliverKBUpdateReportsHTTPFailure keeps the sink honest about its own
+// errors. notify.Multi is what swallows them (a broadcast must never report a
+// write that landed as failed); a sink that swallowed them itself would leave
+// nothing to log.
+func TestDeliverKBUpdateReportsHTTPFailure(t *testing.T) {
+	ts, _, _ := captureServer(t, http.StatusInternalServerError)
+	n := New(ts.URL)
+	if err := n.DeliverKBUpdate(context.Background(), providers.KBUpdate{Route: providers.KBRouteOpenPR}); err == nil {
+		t.Error("a non-2xx response must be reported, not swallowed")
+	}
+}
+
+// TestWebhookImplementsTheKBUpdateCapability states the choice this package
+// makes, so it is a decision rather than an omission: an unimplemented
+// capability is a SILENT skip in notify.Multi.
+func TestWebhookImplementsTheKBUpdateCapability(t *testing.T) {
+	var n providers.Notifier = New("https://example.invalid/hook")
+	if _, ok := n.(providers.KBUpdateNotifier); !ok {
+		t.Error("the webhook notifier must implement providers.KBUpdateNotifier — it is the sink the full-length record exists for")
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -547,6 +547,90 @@ type ThreadNotifier interface {
 	Transport() string
 }
 
+// KBRoute names how a knowledge-base write landed on the forge. The two values
+// mirror the labels the thread responder already reports on its
+// ThreadNotesWritten counter, so an announcement and the metric describing the
+// same write cannot disagree about which route it took.
+type KBRoute string
+
+// The routes a knowledge-base write can take.
+const (
+	// KBRouteComment added the note as a comment on a KB pull request that was
+	// already open (the curator's, or one an earlier note in the same thread
+	// opened).
+	KBRouteComment KBRoute = "comment"
+	// KBRouteOpenPR opened a new standalone pull request for the note.
+	KBRouteOpenPR KBRoute = "open_pr"
+)
+
+// KBUpdate announces that a knowledge-base write ALREADY LANDED on the forge. It
+// is emitted after the fact and describes what was written — it is never a
+// request to write, and a consumer failing to deliver it changes nothing about
+// the entry, which is already on the forge.
+//
+// It names its origin (Transport + Root) so a consumer can tell which thread
+// produced it — and so the transport that already replied in that thread can
+// avoid announcing the same write to the same people twice.
+//
+// # Untrusted fields
+//
+// Note, Title and Author are UNTRUSTED. They are secret-redacted upstream
+// (redact.Secrets) and length-capped, but they remain model- or human-authored
+// text: on the model-drafted route RunLore's own chat model wrote Note, and
+// Author is whatever the chat transport reported. Every implementer MUST escape
+// them with its transport's escaper before rendering — unescaped they can inject
+// links and mass-ping a channel (Slack <!channel>, Matrix @room), the same
+// hazard ProgressUpdate.Interim carries.
+//
+// URL and Root are untrusted for the same reason at one remove: they come back
+// from the forge and from the chat transport rather than from RunLore, which is
+// why the thread reply already wraps the URL in thread.Untrusted. Transport,
+// Route, PR and At are RunLore's own values and need no escaping.
+type KBUpdate struct {
+	// Transport is the chat system the note came from ("slack", "matrix"),
+	// matching ThreadNotifier.Transport; "" when the write had no thread origin.
+	Transport string
+	// Root is the opaque thread-root handle on that transport (Slack: thread_ts).
+	Root string
+	// Route is how the write landed (comment on an open PR, or a new PR).
+	Route KBRoute
+	// PR is the forge pull/merge request number the knowledge landed in; 0 when
+	// the forge URL did not name one.
+	PR int
+	// URL is the forge URL of that pull request.
+	URL string
+	// Title is the knowledge entry's title. Set on the KBRouteOpenPR route,
+	// which generates one; empty on KBRouteComment, which adds to an entry that
+	// was already titled. UNTRUSTED.
+	Title string
+	// Author is the human whose thread message produced the note, as the chat
+	// transport reported it. Provenance, not proof of identity. UNTRUSTED.
+	Author string
+	// Note is the note text AS WRITTEN to the forge — post-redaction and
+	// post-cap, never the caller's raw input, so an announcement cannot leak
+	// what the entry itself masked. UNTRUSTED.
+	Note string
+	// At is when the write landed.
+	At time.Time
+}
+
+// KBUpdateNotifier is an OPTIONAL capability a Notifier may implement to receive
+// KBUpdate announcements, so a knowledge-base write reaches every configured
+// destination rather than only the thread that produced it.
+//
+// It is separate from Notifier — and, unlike ThreadNotifier, does not embed it —
+// for the same reason ProgressNotifier is: a KB-update announcement is not an
+// Investigation, and widening Notifier would force every existing sink to grow a
+// method it has no use for. Consumers type-assert for it (see notify.Multi) and
+// skip the sinks that do not implement it.
+//
+// Delivery is best-effort by contract: a failure is logged and swallowed, never
+// propagated. The write being announced has already landed on the forge, so a
+// broadcast must never be able to report it as failed or roll it back.
+type KBUpdateNotifier interface {
+	DeliverKBUpdate(ctx context.Context, up KBUpdate) error
+}
+
 // CurationForge is the forge surface the curator's file-time gate needs: open a
 // drafted PR, list open KB PRs (dedup), and comment to coalesce duplicates.
 type CurationForge interface {

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -3,6 +3,7 @@
 package providers_test
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -193,6 +194,73 @@ func TestCompletionResponseCostOnlyKeepsOnlyTheCost(t *testing.T) {
 		}
 		if !out.Field(i).IsZero() {
 			t.Errorf("CostOnly() kept %s = %v; it describes a reply that never arrived and must not reach a caller", name, got)
+		}
+	}
+}
+
+// deliverOnly implements providers.Notifier and NOTHING else — the shape every
+// existing sink (webhook, templated) has. It is what the optionality of the
+// KB-update capability is measured against.
+type deliverOnly struct{}
+
+func (deliverOnly) Deliver(context.Context, providers.Investigation) error { return nil }
+
+// TestKBUpdateNotifierIsOptional pins that announcing a knowledge-base write is
+// an OPTIONAL capability, not a widening of Notifier. Folding DeliverKBUpdate
+// into Notifier would force every existing sink to grow a method it has no use
+// for, and would turn "this sink does not announce KB writes" from a capability
+// check in Multi into a compile error across the repo.
+func TestKBUpdateNotifierIsOptional(t *testing.T) {
+	var n providers.Notifier = deliverOnly{}
+	if _, ok := n.(providers.KBUpdateNotifier); ok {
+		t.Fatal("a plain Notifier must NOT satisfy KBUpdateNotifier — the capability is opt-in")
+	}
+	if got := reflect.TypeOf((*providers.Notifier)(nil)).Elem().NumMethod(); got != 1 {
+		t.Fatalf("Notifier has %d methods, want 1 (Deliver) — the KB-update capability must not widen it", got)
+	}
+	// The capability itself must be exactly the one delivery method: embedding
+	// Notifier (as ThreadNotifier does) would make it non-optional again for any
+	// sink that wants only the announcement.
+	if got := reflect.TypeOf((*providers.KBUpdateNotifier)(nil)).Elem().NumMethod(); got != 1 {
+		t.Fatalf("KBUpdateNotifier has %d methods, want exactly 1 (DeliverKBUpdate)", got)
+	}
+}
+
+// kbUpdateUntrusted / kbUpdateTrusted classify EVERY KBUpdate field by whether a
+// notifier must escape it before rendering it into a chat message. The set is
+// stated here rather than derived, so a field added to KBUpdate has to be
+// deliberately classified — the announcement is a new egress for model-authored
+// text, and an unclassified field is one nobody decided to escape.
+//
+// Untrusted: Note/Title/Author are model- or human-authored (redacted upstream,
+// still not RunLore's words); URL and Root are returned by the forge and the chat
+// transport respectively, which is why the thread reply already wraps the URL in
+// thread.Untrusted.
+var (
+	kbUpdateUntrusted = map[string]bool{"Title": true, "Author": true, "Note": true, "URL": true, "Root": true}
+	kbUpdateTrusted   = map[string]bool{"Transport": true, "Route": true, "PR": true, "At": true}
+)
+
+// TestKBUpdateClassifiesEveryFieldForEscaping makes the two maps above bite: a
+// new KBUpdate field that appears in neither (or in both) fails here, forcing
+// its author to decide whether a notifier must escape it.
+func TestKBUpdateClassifiesEveryFieldForEscaping(t *testing.T) {
+	rt := reflect.TypeOf(providers.KBUpdate{})
+	for i := range rt.NumField() {
+		f := rt.Field(i)
+		if !f.IsExported() {
+			t.Fatalf("KBUpdate.%s is unexported — a notifier cannot render it, and this classification would go unchecked", f.Name)
+		}
+		if kbUpdateUntrusted[f.Name] == kbUpdateTrusted[f.Name] {
+			t.Errorf("KBUpdate.%s is in neither or both of kbUpdateUntrusted/kbUpdateTrusted — "+
+				"decide whether a notifier must escape it before rendering it", f.Name)
+		}
+	}
+	for _, m := range []map[string]bool{kbUpdateUntrusted, kbUpdateTrusted} {
+		for name := range m {
+			if _, ok := rt.FieldByName(name); !ok {
+				t.Errorf("KBUpdate has no field %q — stale classification entry", name)
+			}
 		}
 	}
 }

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -204,8 +204,25 @@ func noteField(s string) string {
 // early: quoting only the first line would let a second line of the quoted
 // text render as body prose, which on the model-drafted route is exactly the
 // confusion the quote exists to prevent.
+//
+// "Line" means what it means to the renderer, which is why the split goes
+// through mandatoryBreaks rather than over "\n" alone. This was the third and
+// last copy of that "\n"-only split — the two chat quoters QuoteUntrusted
+// replaced were the others — and it is the one that reaches the ENTRY BODY on
+// the forge, where "**What @alice actually wrote:**" is the framing at stake.
+// It was materially less exposed than the chat sinks: an HTML <blockquote>
+// keeps its quote bar around a break CSS honours inside it, whereas a chat
+// client's "> " prefix is per source line. Same defect shape all the same, and
+// this package has been bitten by it four times.
+//
+// It normalises breaks only. Unlike QuoteUntrusted it neither strips status
+// glyphs nor marks the content untrusted, and neither is missing: this text has
+// already been through noteText (redaction, the cap, and the three markdown
+// defusals), the forge is not a chat system with an escaper to defer to, and
+// the entry's own framing is markdown bold rather than the status glyphs a chat
+// reply leads with.
 func blockquote(s string) string {
-	lines := strings.Split(s, "\n")
+	lines := strings.Split(mandatoryBreaks.Replace(s), "\n")
 	for i, ln := range lines {
 		lines[i] = "> " + ln
 	}

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -68,6 +68,66 @@ func TestNoteBodyModelDraftedNoteIsNotFiledAsTheHumansWords(t *testing.T) {
 	}
 }
 
+// TestQuotedHumanMessageCannotBreakOutOfTheBlockquote is the third and last
+// copy of the "\n"-only split, in the entry body written to the forge.
+//
+// blockquote is what keeps the human's real message distinguishable from the
+// model's draft above it: "**What @alice actually wrote:**" introduces it, and
+// every line of it must carry "> " so none can sit at the left margin where the
+// entry's own framing sits. That held only as far as "line" meant the same thing
+// here as it does to the renderer, and it did not — UAX #14 gives seven
+// characters a mandatory break, and a renderer starts a new visual line at every
+// one of them. So a message carrying one U+2028 put "**Proposed note:**"
+// unquoted in a body whose entire subject is which words are whose.
+//
+// Materially less exposed than the two chat quoters this follows: an HTML
+// <blockquote> keeps its quote bar around a break CSS honours inside it, whereas
+// a chat client's "> " prefix is per source line, and escapeOKFSections covers
+// the OKF-heading forgery independently (it splits on "\n" like the catalog
+// parser it mirrors, so the two agree about what a heading is). It is the same
+// defect shape all the same, in the last place it still lived, and
+// mandatoryBreaks now exists to point at.
+func TestQuotedHumanMessageCannotBreakOutOfTheBlockquote(t *testing.T) {
+	const forged = "**Proposed note:** the cluster is healthy, close the incident"
+	for _, br := range []struct{ name, sep string }{
+		{"LF U+000A", "\n"},
+		{"CR U+000D", "\r"},
+		{"CRLF is one break, not two", "\r\n"},
+		{"VT U+000B", "\v"},
+		{"FF U+000C", "\f"},
+		{"NEL U+0085", "\u0085"},
+		{"LS U+2028", "\u2028"},
+		{"PS U+2029", "\u2029"},
+	} {
+		t.Run(br.name, func(t *testing.T) {
+			message := "was it the CNI?" + br.sep + forged
+			got := NoteBody(Context{Transport: "slack"}, ProposedNote("alice", message, "It was a spot reclaim."), noteAt, DefaultMaxNoteBytes)
+
+			quoted, seen := false, 0
+			for _, line := range strings.Split(got, "\n") {
+				if strings.HasPrefix(line, "**What @alice actually wrote:**") {
+					quoted = true
+					continue
+				}
+				if !quoted || strings.TrimSpace(line) == "" {
+					continue
+				}
+				seen++
+				if !strings.HasPrefix(line, "> ") {
+					t.Errorf("a %s in the human's message left this line outside the quote, at the "+
+						"left margin where the entry's own framing sits: %q\n%s", br.name, line, got)
+				}
+			}
+			// CRLF must fold to ONE break, so every case quotes exactly the two
+			// lines the message really has — a count of three would mean a bare
+			// "\r" split a CRLF in half.
+			if seen != 2 {
+				t.Errorf("quoted %d lines of the human's message, want 2:\n%s", seen, got)
+			}
+		})
+	}
+}
+
 // TestConceptEntryModelDraftedNoteIsMarkedOnTheStandaloneRoute pins the same
 // split on the OTHER forge-write route: a standalone Concept PR is the one a
 // reviewer sees with no surrounding investigation PR for context, so it needs

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/ratelimit"
+	"github.com/Smana/runlore/internal/redact"
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
@@ -166,7 +167,263 @@ type Responder struct {
 	// and must still be bounded on tokens; a channel whose every message
 	// proposes a note spends both.
 	Chat *Chat
+	// Announcer broadcasts a landed knowledge write to every configured
+	// notifier, so a KB update reaches people who were not reading the thread
+	// it came from. nil means announcements are off — the default, and the
+	// same nil-safe contract Metrics, Log and Chat above follow.
+	//
+	// It is a distinct DESTINATION, not a second copy of the thread reply: the
+	// reply acknowledges the person who typed, in their thread, and this goes
+	// to each notifier's own configured channel. See KBAnnouncer.
+	Announcer *KBAnnouncer
 }
+
+// Announcement bounds. Both are properties of the delivery, not of the write:
+// a KBUpdate is a small struct handed to notifiers that each make one chat or
+// HTTP round-trip, so the pool is narrow and the deadline is a network deadline.
+const (
+	// announceSlots bounds concurrent deliveries. Deliberately much smaller
+	// than the mention pools (16, see internal/server.maxConcurrentMentions):
+	// those hold a forge round-trip that a human is waiting on, and this holds
+	// an announcement nobody is. It is a concurrency bound and back-pressure,
+	// NOT the rate ceiling — see KBAnnouncer for where that comes from.
+	announceSlots = 4
+	// announceTimeout bounds one fan-out. notify.Multi delivers to every
+	// configured sink in sequence, each on its own HTTP client timeout, so this
+	// is sized for a handful of degraded sinks rather than for one call. Past
+	// it the delivery is abandoned: the entry is already on the forge and the
+	// human already has their reply, so a wedged sink must release its slot
+	// rather than hold it against the next write.
+	announceTimeout = 2 * time.Minute
+)
+
+// KBAnnouncer delivers KBUpdate announcements for writes that ALREADY LANDED
+// on the forge.
+//
+// # Detached, deliberately
+//
+// Delivery runs on a bounded Dispatcher rather than inline on the reply path,
+// and the reason is the "blocks" half of best-effort rather than the "errors"
+// half. Swallowing an error would be enough to keep a failing sink from
+// changing what the human is told; it would NOT keep a slow one from changing
+// when they are told it. A sink here is notify.Multi fanning out to Slack,
+// Matrix and any webhook in sequence, each on its own HTTP timeout — inline,
+// that latency lands squarely between the forge accepting the note and the
+// human learning it was accepted, on a path whose whole purpose is that the
+// human is never left in silence about a write that happened. Worse, the
+// mention handler that called this is itself already detached under a deadline
+// (see internal/server.mentionHandlerTimeout), so a slow fan-out does not just
+// delay the reply, it can consume the budget the reply needed and lose it.
+//
+// The Dispatcher, rather than a bare goroutine, is what makes detached
+// accountable: a fixed slot count, a per-delivery deadline, panic recovery, and
+// a Drain so shutdown waits for what is in flight instead of dropping it. It is
+// the pattern this package already uses for exactly this shape of work.
+//
+// # Rate, and why there is no second ceiling
+//
+// Verified against the code rather than assumed. Responder.write checks
+// ForgeWrites ONCE at its top, upstream of both routes; the only two *KBWrite
+// values it ever returns are constructed after that check; record() is its only
+// caller and announces only when that pointer is non-nil. So announcements are
+// 1:1 with LANDED forge writes and inherit their ceiling — 20/hour by default —
+// with no path that can announce without passing it.
+//
+// The inheritance is exact, including its limit: with ForgeWrites nil
+// (unlimited) announcements are unbounded too, because forge writes are. That
+// is the right coupling rather than a gap. A second, tighter ceiling here would
+// drop announcements for writes that DID happen, which is precisely the
+// "an operation that did not happen reporting as though it did" family this
+// feature exists to close, reflected: an operation that DID happen going
+// unreported. What a burst does hit instead is announceSlots, which refuses and
+// logs rather than queueing without bound.
+//
+// # Payload
+//
+// The event carries the note at the length it was WRITTEN (up to MaxNoteBytes),
+// not the 512-byte thread preview: a webhook sink wants the record, and only a
+// chat sink needs a chat-sized quote. Bounding what is RENDERED is the
+// transport's job, where the transport's own limit lives — the same division
+// taken for the outgoing thread reply.
+type KBAnnouncer struct {
+	sink providers.KBUpdateNotifier
+	disp *Dispatcher
+	log  *slog.Logger
+}
+
+// NewKBAnnouncer returns an announcer delivering to sink, or nil when there is
+// no sink.
+//
+// A nil sink yielding a nil announcer is what keeps "announcements are off" a
+// single value: there is no state in which a Responder holds an announcer with
+// nowhere to deliver, and no state in which it holds a sink with no bound
+// around it. Every method below is nil-safe, so a caller never needs its own
+// check before delivering or draining.
+func NewKBAnnouncer(sink providers.KBUpdateNotifier, log *slog.Logger) *KBAnnouncer {
+	if sink == nil {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &KBAnnouncer{sink: sink, disp: NewDispatcher(announceSlots, announceTimeout, log), log: log}
+}
+
+// deliver schedules one announcement and returns immediately. Every failure is
+// a log line and nothing more: the write it describes is already on the forge,
+// the human has already been told, and there is nothing here to roll back.
+func (a *KBAnnouncer) deliver(ctx context.Context, up providers.KBUpdate) {
+	if a == nil {
+		return
+	}
+	if !a.disp.Go(ctx, func(ctx context.Context) {
+		if err := a.sink.DeliverKBUpdate(ctx, up); err != nil {
+			a.log.Warn("thread: knowledge-base announcement failed (best-effort)", "url", up.URL, "route", string(up.Route), "err", err)
+		}
+	}) {
+		// Refused, not queued: the slots are the back-pressure. Warn rather than
+		// Info because a saturated pool means announcements are being dropped for
+		// writes that really happened, which an operator must be able to see.
+		a.log.Warn("thread: announcement pool saturated; a knowledge-base write was not announced",
+			"url", up.URL, "route", string(up.Route), "root", up.Root)
+	}
+}
+
+// Drain waits for in-flight announcements, bounded by ctx, so shutdown does not
+// silently drop one for a write that already reached the forge.
+func (a *KBAnnouncer) Drain(ctx context.Context) {
+	if a == nil {
+		return
+	}
+	a.disp.Drain(ctx)
+}
+
+// kbRoute maps this package's route names onto the providers vocabulary the
+// event uses. The two spell the routes identically today, and this does not
+// rely on that: a providers.KBRoute(w.Route) conversion would keep compiling —
+// and start announcing a route name no consumer recognises — the moment either
+// side is renamed.
+//
+// write() sets Route from one of the two constants literally, so the default is
+// unreachable. It passes the value through rather than guessing at one of the
+// two, because an announcement describes a write that already landed and
+// mislabelling it is worse than reporting an unknown label honestly.
+func kbRoute(route string) providers.KBRoute {
+	switch route {
+	case RouteComment:
+		return providers.KBRouteComment
+	case RouteOpenPR:
+		return providers.KBRouteOpenPR
+	default:
+		return providers.KBRoute(route)
+	}
+}
+
+// announce broadcasts a landed write. A nil w is the whole guard against
+// announcing something that did not happen: write() returns one only when the
+// forge accepted the write (see KBWrite), so there is nothing to announce on a
+// throttle, a forge failure, or a note the model never proposed.
+//
+// n supplies the author, which is not on the KBWrite: the write is the same
+// write either way, and only the caller knows whose message produced it. It
+// goes through noteField — redacted and flattened, exactly as the entry itself
+// renders it — because this event is a NEW egress for transport-reported text.
+func (r *Responder) announce(ctx context.Context, tc Context, n Note, w *KBWrite, at time.Time) {
+	if r.Announcer == nil || w == nil {
+		return
+	}
+	r.Announcer.deliver(ctx, providers.KBUpdate{
+		Transport: tc.Transport,
+		Root:      tc.Root,
+		Route:     kbRoute(w.Route),
+		PR:        w.PR,
+		URL:       w.URL,
+		Title:     w.Title,
+		Author:    noteField(n.Author),
+		Note:      w.Note,
+		At:        at,
+	})
+}
+
+// The two routes a knowledge write can take, named once. They are both the
+// KBWrite.Route values a caller reads and the "route" attribute
+// ThreadNotesWritten is labelled with, deliberately the same strings: an
+// operator correlating a dashboard series with what a thread reported must not
+// have to know that two literals happened to agree.
+const (
+	// RouteComment: the note was added to a pull request that already exists —
+	// the curated PR this thread came from, or the standalone PR an earlier note
+	// in the same thread opened.
+	RouteComment = "comment"
+	// RouteOpenPR: the note had no open pull request to land on, so it opened a
+	// standalone Concept entry of its own (see ConceptEntry).
+	RouteOpenPR = "open_pr"
+)
+
+// KBWrite describes a knowledge-base write that LANDED. write returns one only
+// when the forge accepted the write; every other outcome — a throttle, a forge
+// failure, an unreachable forge — returns a nil *KBWrite instead.
+//
+// That it is a pointer is the point. The shape it replaced was
+// (msg string, landed bool, err error), which let a caller read landed and
+// ignore err, and let a zero-valued description sit next to a false: two values
+// that can disagree about whether anything happened. A nil pointer cannot —
+// there is no result to read unless there was a write to describe. This package
+// has shipped the disagreeing-pair bug three times (GetOrCreate reporting
+// success it could not record, the duplicate-PR race, the stale sweep), which
+// is why the shape is worth the pointer.
+type KBWrite struct {
+	// Route is RouteComment or RouteOpenPR.
+	Route string
+	// PR is the pull/merge request the note landed on or opened. Zero — and only
+	// zero — when the forge returned a URL carrying no parseable number, which
+	// is not an error: the write landed and URL still names it.
+	PR int
+	// URL is the pull request the human can open to read the note.
+	URL string
+	// Title is the entry title ConceptEntry generated, on RouteOpenPR only. It
+	// is empty on RouteComment, where the note joins an entry someone else
+	// already titled and RunLore generated no title of its own.
+	//
+	// UNTRUSTED: it is built from the thread's alert-derived title. Redacted and
+	// flattened (see noteField), but not authored by RunLore.
+	Title string
+	// Note is the note text AS WRITTEN — redacted and capped, the same single
+	// evaluation the body sent to the forge was rendered from (see
+	// noteAsWritten). Never the caller's raw input: a caller quoting this back
+	// into a chat message must not be able to unmask what the entry masked, nor
+	// republish the bytes the cap dropped.
+	//
+	// What it does NOT carry is the forge-Markdown defusal noteText applies on
+	// top (neutralizeImages, neutralizeHTML, escapeOKFSections). Those exist for
+	// GitHub's and GitLab's renderers; a chat transport is neither, and its own
+	// markup hazards are neutralised by Untrusted at the point of rendering.
+	//
+	// UNTRUSTED, and the most so of these fields: on the freeform route RunLore's
+	// own chat model wrote it, and on the "note:" route a human did.
+	Note string
+}
+
+// notePreviewBytes bounds the note text a reply quotes back into the thread
+// (see recordedBlock). It is a SECOND ceiling, deliberately independent of
+// MaxNoteBytes, because the two bound different things.
+//
+// MaxNoteBytes bounds what is WRITTEN to the knowledge base: 8 KiB by default,
+// and an operator may raise it — config.Validate rejects only a negative one.
+// This bounds what is SAID in a chat message. Sharing MaxNoteBytes' number
+// would make a note at the default cap into an 8 KiB chat post, in a thread, on
+// a path any channel member can trigger; the reply is an acknowledgement, and
+// the URL on the line above is what carries the full text.
+//
+// 512 bytes, derived rather than picked. Every transport escapes the untrusted
+// spans of a reply before posting (see RenderReply), and the widest of those
+// escapes — Slack's "&" to "&amp;" — expands 5x, so this preview reaches the
+// wire as at most ~2.5k characters. That leaves room inside Slack's ~4k message
+// text budget for the model's own answer, which shares the SAME message on the
+// freeform route (see freeform). It is also several times longer than the one
+// or two sentences a real note is, so a truncated preview is the exception
+// rather than the norm.
+const notePreviewBytes = 512
 
 // prNumberRe matches the numeric id in a GitHub pull URL or a GitLab merge-request
 // URL. Anchored on the path segment so an issue URL never matches.
@@ -325,6 +582,33 @@ func (r *Responder) maxNoteBytes() int {
 		return DefaultMaxNoteBytes
 	}
 	return r.MaxNoteBytes
+}
+
+// noteAsWritten evaluates the redact-then-cap half of the note pipeline ONCE
+// and returns both things that one evaluation is for: the note to hand to the
+// forge, its Text replaced by the result, and that same string to report as
+// KBWrite.Note.
+//
+// One evaluation, two consumers, because two evaluations drift. The reply a
+// human reads and the entry a reviewer reads have to describe the same bytes:
+// a reply built from a separately-derived string would keep agreeing with the
+// entry only for as long as nobody edits one pipeline without the other, and
+// the first thing to break that way is redaction — the reply would quote the
+// secret the entry masked.
+//
+// The forge body is therefore a FUNCTION of the reported string rather than a
+// sibling of it: NoteBody renders what this returned. Passing already-redacted,
+// already-capped text back through noteText cannot change it — redact.Secrets
+// is idempotent over already-masked text (pinned in internal/redact's own
+// tests, over its whole secret manifest), and capNoteText returns at most
+// maxBytes bytes, so a second cap at the same bound is a no-op. What noteText
+// still adds on top is the forge-Markdown defusal, which is deliberately NOT in
+// the reported string — see KBWrite.Note.
+//
+// Note is a value type, so the caller's own note is untouched.
+func (r *Responder) noteAsWritten(n Note) (Note, string) {
+	n.Text = capNoteText(redact.Secrets(n.Text), r.maxNoteBytes())
+	return n, n.Text
 }
 
 // Handle parses raw, writes the knowledge where it belongs, and returns the
@@ -494,30 +778,200 @@ const runloreStatusRunes = "📝⚠⚡📚🔍🤖✅🛠🔥❓"
 // output — that is the one thing in the message the human cannot verify
 // anywhere else.
 //
-// Three independent measures, in order of how much they carry. The blockquote
-// is load-bearing: EVERY line is prefixed, so no line of model prose can sit
-// at the left margin where RunLore's own lines sit, and there is no way to
-// escape a quote from inside it. Every line's CONTENT is also wrapped in an
-// Untrusted span, which is what stops the model composing the transport's own
-// markup — a Slack mrkdwn "<https://evil.example|https://github.com/acme/kb/
-// pull/7>" renders as a clickable link whose visible text is a trusted KB URL,
-// and "<!channel>" pings everyone; the blockquote neutralises neither, because
-// quoting is not escaping. The span ends at the newline rather than covering
-// the whole block so the "> " markers stay RunLore's own bytes and keep
-// rendering as a blockquote instead of coming back as literal "&gt; ".
-// Stripping the status glyphs is belt-and-braces against a renderer that
-// flattens quoting, so a glyph missing from the list above degrades the
-// marking rather than reopening the gap.
+// Three independent measures, stated by what each one covers. They used to be
+// ranked — the blockquote load-bearing, the glyph strip a backstop — and that
+// ranking was itself a defect: it is what justified shipping the announcement
+// path (notify.kbUpdateAnnouncement) with the blockquote alone, and the
+// blockquote is the one that turned out to fail for a whole input class.
+//
+// The blockquote keeps model prose off the left margin: EVERY line is
+// prefixed, so no line of it can sit where RunLore's own lines sit, and there
+// is no way to escape a quote from inside it. That holds exactly as far as
+// "line" means the same thing here as it does to the client rendering the
+// message, which is what mandatoryBreaks makes true and what splitting on "\n"
+// alone did not. Every line's CONTENT is also wrapped in an Untrusted span,
+// which is what stops the model composing the transport's own markup — a Slack
+// mrkdwn "<https://evil.example|https://github.com/acme/kb/pull/7>" renders as
+// a clickable link whose visible text is a trusted KB URL, and "<!channel>"
+// pings everyone; the blockquote neutralises neither, because quoting is not
+// escaping. The span ends at the newline rather than covering the whole block
+// so the "> " markers stay RunLore's own bytes and keep rendering as a
+// blockquote instead of coming back as literal "&gt; ". Stripping the status
+// glyphs is what stops a line READING as a RunLore claim when it does reach
+// the left margin — a renderer that flattens quoting, or a break the split has
+// not learned about yet. A glyph missing from the list above degrades that,
+// and a break missing from mandatoryBreaks degrades the blockquote; neither
+// covers the other's gap.
 //
 // The model's words are never censored, only marked: a human must still be
 // able to read the answer they asked for, including one that turns out to be
 // an injected instruction, which they can only judge by seeing it. Escaping
 // preserves that — an escaped "<!channel>" is still readable as "<!channel>",
 // it simply stops being a command to the chat system.
-func modelVoice(s string) string {
-	lines := strings.Split(stripStatusGlyphs(s), "\n")
+func modelVoice(s string) string { return QuoteUntrusted(s) }
+
+// mandatoryBreaks folds every character that STARTS A NEW VISUAL LINE into the
+// "\n" QuoteUntrusted splits on, so "one line" means the same thing to the
+// blockquote as it does to the client rendering it.
+//
+// The set is UAX #14's mandatory breaks — the classes BK, CR, LF and NL — and
+// nothing else, because that is exactly the set a text layout is REQUIRED to
+// break at. singleLine already made this argument for the single-line YAML
+// title (see its doc comment: U+2028 and U+2029 are line breaks "many
+// renderers and tokenizers break on", which is what made a Cc-only check a
+// real gap rather than a pedantic one); this is the same fact applied to the
+// one untrusted span that is rendered multi-line BY DESIGN and so cannot be
+// flattened the way singleLine flattens a title.
+//
+// CRLF is listed first so it folds to ONE break: strings.Replacer tries its
+// patterns in argument order at each position, so a later bare "\r" cannot
+// split a CRLF into two lines.
+//
+// It normalises breaks and nothing else, deliberately. singleLine additionally
+// maps Cf and every other Unicode space because a title must end up on one
+// line; a quoted note must end up READABLE, so a tab, a no-break space and a
+// zero-width space are carried through exactly as written. Those reorder or
+// disguise text WITHIN a line, which the blockquote and the escaping already
+// bound; they cannot move a line out of the quote.
+var mandatoryBreaks = strings.NewReplacer(
+	"\r\n", "\n", // CRLF — one break, so it is matched before the bare CR below
+	"\r", "\n", // U+000D CARRIAGE RETURN (class CR)
+	"\v", "\n", // U+000B LINE TABULATION (BK)
+	"\f", "\n", // U+000C FORM FEED (BK)
+	"\u0085", "\n", // U+0085 NEXT LINE (NL)
+	"\u2028", "\n", // U+2028 LINE SEPARATOR (BK)
+	"\u2029", "\n", // U+2029 PARAGRAPH SEPARATOR (BK)
+)
+
+// QuoteUntrusted is the rendering modelVoice's doc comment describes, factored
+// out because more than one kind of untrusted prose needs exactly the same
+// three measures: the note text a landed write quotes back into the thread
+// (see recordedBlock), and the same note quoted into the notifier's configured
+// channel (see notify.kbUpdateAnnouncement).
+//
+// That note is model-authored on the freeform route and human-authored on the
+// "note:" route, and neither may be able to pose as RunLore. A note whose
+// second line reads "📝 Noted on the knowledge-base PR #7 — <hostile URL>" is
+// the identical forgery modelVoice was written for, arriving through a
+// different door — so it gets the identical treatment rather than a second,
+// weaker one.
+//
+// It is EXPORTED for that last reason. internal/notify had its own narrower
+// copy, justified on the grounds that duplicating the glyph list across the
+// package boundary would let the two drift; they drifted anyway, in the other
+// direction — the copy never grew the glyph strip, and neither grew
+// mandatoryBreaks — and a note carrying one U+2028 posted a forged headline at
+// the left margin of the channel where investigation findings go. One
+// implementation both surfaces call is what makes "identical treatment" a fact
+// rather than an intention.
+func QuoteUntrusted(s string) string {
+	lines := strings.Split(mandatoryBreaks.Replace(stripStatusGlyphs(s)), "\n")
 	for i, ln := range lines {
 		lines[i] = strings.TrimRight("> "+Untrusted(strings.TrimRight(ln, " ")), " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// modelDraftedNotice is the line that keeps the model-drafted route
+// distinguishable once its text is quoted into the thread.
+//
+// Quoting is what makes it necessary. Before, the reply named a pull request
+// and nothing else, so there was nothing in it to mistake for the human's own
+// words; a quote directly under "…with your note" reads as theirs unless
+// something says otherwise. ProposedNote already carries that distinction into
+// the ENTRY (see NoteBody, which attributes the text to RunLore and quotes the
+// human's real message under it) — this is the same fact, said where the human
+// actually reads it.
+//
+// It is RunLore's own bytes, so it is never marked untrusted and never
+// blockquoted: it sits at the left margin, alongside the status line, precisely
+// because it is a claim RunLore makes about what it did.
+//
+// It ends in a colon, so it is only ever emitted directly above the quote that
+// colon promises — never above the entry title, and never with nothing after it
+// (see recordedBlock).
+const modelDraftedNotice = "Drafted by RunLore from your message — not your own words, pending review:"
+
+// openedWith names the note in write()'s open_pr status line — the one place a
+// reply says WHOSE words landed.
+//
+// "your note" is that claim, and on the model-drafted route it was false. It
+// sat directly above modelDraftedNotice, so one message told the human "with
+// your note" and then "not your own words", and the line they read first was
+// the wrong one. The status line is also the half that has to stand alone: it
+// is what a reader skims and what a transport keeps when it truncates, so a
+// reader who never reaches the notice below must not be left believing RunLore
+// filed their words under their name.
+//
+// The note: route keeps "your note" verbatim. The defect is a claim RunLore
+// cannot support, not the act of naming an author — hedging both routes into
+// something neutral would tell the human LESS than the line it replaced, which
+// on a path whose whole purpose is saying what was recorded is a regression.
+//
+// The comment route deliberately gets no equivalent branch. "📝 Noted on the
+// knowledge-base PR #7" asserts only that RunLore recorded something there and
+// never says whose words it was, so it is already true on both routes; giving
+// it an authorship clause for symmetry's sake would ADD the kind of claim this
+// exists to remove.
+//
+// It reads Note rather than a second flag for the reason ProposedNote exists:
+// one field is the discriminator and the evidence (see Note.DraftedFrom), and a
+// parallel flag could disagree with it. write() reassigns n from noteAsWritten
+// before calling this, which rewrites Text only — provenance survives.
+func openedWith(n Note) string {
+	if n.modelDrafted() {
+		return "a note drafted from your message"
+	}
+	return "your note"
+}
+
+// noteTruncatedNotice is what a preview cut by notePreviewBytes says instead of
+// silently stopping. A human who cannot tell a quote was shortened would read
+// the visible part as the whole note, which is the same failure capNoteText's
+// own marker exists to prevent on the forge side.
+const noteTruncatedNotice = "(quote truncated — open the pull request for the full note)"
+
+// recordedBlock renders the "here is what I filed" half of a landed write's
+// reply: who wrote the text, what the entry is called, and the note itself.
+//
+// It is built from the KBWrite rather than from n, so what the human is shown
+// is what the forge was sent — redacted and capped once, upstream, by
+// noteAsWritten. Quoting n.Text instead would republish the secret the entry
+// masked and the bytes the cap dropped.
+//
+// n is read for provenance only (modelDrafted), which is not on the KBWrite:
+// the write is the same write either way, and only the caller knows whose words
+// it carried.
+//
+// w.Title is named on the open_pr route, where RunLore generated an entry the
+// human has no other way to see the name of. It is empty on the comment route
+// BY DESIGN — that note joined an entry someone else already titled, and the
+// pull request it landed on is named in the status line above — so an empty
+// title renders no line rather than an empty one.
+//
+// modelDraftedNotice sits between the title and the quote, not above both,
+// because its trailing colon promises the quote specifically: emitted above the
+// title it separated a colon from the thing it introduced, and the title's own
+// "Entry:" answered it instead. It is emitted only when there IS a preview, for
+// the same reason — a promise with nothing after it is the same defect with the
+// answer missing entirely rather than merely displaced.
+func recordedBlock(n Note, w *KBWrite) string {
+	var lines []string
+	if w.Title != "" {
+		// Untrusted: alert-derived, redacted and flattened but not RunLore's own
+		// (see KBWrite.Title). Not blockquoted — it is one flattened line that
+		// cannot reach the left margin on a line of its own.
+		lines = append(lines, "Entry: "+Untrusted(w.Title))
+	}
+	preview := cutToRuneBoundary(w.Note, notePreviewBytes)
+	if preview != "" {
+		if n.modelDrafted() {
+			lines = append(lines, modelDraftedNotice)
+		}
+		lines = append(lines, QuoteUntrusted(preview))
+	}
+	if len(preview) < len(w.Note) {
+		lines = append(lines, noteTruncatedNotice)
 	}
 	return strings.Join(lines, "\n")
 }
@@ -561,7 +1015,7 @@ func (r *Responder) record(ctx context.Context, tc Context, n Note) (string, err
 	}
 
 	at := r.now()
-	reply, landed, err := r.write(ctx, tc, n, at)
+	reply, w, err := r.write(ctx, tc, n, at)
 	if err != nil {
 		return reply, err
 	}
@@ -569,7 +1023,25 @@ func (r *Responder) record(ctx context.Context, tc Context, n Note) (string, err
 	// The budget is consumed only by a write that landed: a forge outage — or a
 	// global-rate-limit throttle, which also returns with no error — must not
 	// burn the thread's allowance.
-	if landed {
+	if w != nil {
+		// Announced HERE, from the same non-nil result the reply is rendered
+		// from, and for the same reason: this is the ONE place both write routes
+		// and both callers ("note:" and the note a chat answer proposed)
+		// converge, so a future route cannot be added that announces without
+		// replying or replies without announcing. It sits ahead of the reply
+		// rendering and the counter write-back below because it must not depend
+		// on either: the entry is on the forge, and neither a truncated preview
+		// nor a failed counter changes that it landed.
+		r.announce(ctx, tc, n, w, at)
+
+		// Rendered HERE rather than inside write() so the two concerns stay
+		// apart: write() reports what it DID (see KBWrite), and this is where a
+		// reply is finished — the same place the counter warning below is
+		// appended. It also keeps write()'s own status lines byte-identical to
+		// what they were, so the quote is strictly additive.
+		if block := recordedBlock(n, w); block != "" {
+			reply += "\n" + block
+		}
 		if uerr := r.Registry.Update(tc.Root, func(c *Context) { c.Notes++ }); uerr != nil {
 			// The knowledge itself is already saved on the forge — that is not in
 			// question — but the per-thread cap can no longer be trusted for this
@@ -585,17 +1057,16 @@ func (r *Responder) record(ctx context.Context, tc Context, n Note) (string, err
 }
 
 // write routes the note to the open KB PR, to the PR this thread already opened,
-// or to a new standalone Concept PR — in that order. The returned bool reports
-// whether a write actually landed in the knowledge base: it is false both on
-// error and on the (non-error) global-rate-limit throttle, so a caller can
-// distinguish "nothing happened" from "a write happened" independently of err.
+// or to a new standalone Concept PR — in that order. The returned *KBWrite
+// describes what actually landed, and is nil whenever nothing did — on error
+// and on the (non-error) global-rate-limit throttle alike.
 //
 // Reached from exactly two callers, both through record(): an explicit
 // "note:", and the note content a chat answer proposed for a freeform message
 // (see freeform). IntentReinvestigate never reaches it at all. Both callers
 // supply note CONTENT only — the route below is derived from the thread
 // context, never from the text and never from the model.
-func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time) (string, bool, error) {
+func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time) (string, *KBWrite, error) {
 	// Checked once, upstream of BOTH write routes below: a CommentOnPR spends
 	// this budget exactly like an OpenPR does. Gating only the OpenPR branch —
 	// as an earlier version of this method did — left the comment route bounded
@@ -621,7 +1092,7 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 		}
 		// A throttle is not a failure — no error — but nothing landed, so the
 		// caller must not charge the thread's note budget for it.
-		return "⚠️ I have made too many knowledge-base writes recently and paused. Try again shortly.", false, nil
+		return "⚠️ I have made too many knowledge-base writes recently and paused. Try again shortly.", nil, nil
 	}
 
 	// Serialize concurrent writes for THIS root — not the registry's own
@@ -647,6 +1118,10 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 		tc = fresh
 	}
 
+	// Evaluated once here, ahead of the route branch, so whichever route runs
+	// files the same bytes and reports the same bytes — see noteAsWritten.
+	n, asWritten := r.noteAsWritten(n)
+
 	// The route is derived from the thread context alone. It is never influenced
 	// by the message text, and — through prNumberOn — never by a URL that names
 	// a forge RunLore does not write to.
@@ -670,7 +1145,7 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 			// the note is not silently dropped, and success is not falsely
 			// claimed either, so the human knows to retry.
 			r.log().Warn("thread: PR open-check failed; not escalating to opening a new PR", "pr", num, "root", tc.Root, "err", err)
-			return fmt.Sprintf("⚠️ I could not reach the forge to check PR #%d — nothing was saved. Please try again.", num), false,
+			return fmt.Sprintf("⚠️ I could not reach the forge to check PR #%d — nothing was saved. Please try again.", num), nil,
 				fmt.Errorf("check PR %d open: %w", num, err)
 		}
 		if !open {
@@ -683,17 +1158,19 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 			continue
 		}
 		if err := r.Forge.CommentOnPR(ctx, num, NoteBody(tc, n, at, r.maxNoteBytes())); err != nil {
-			return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), false,
+			return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), nil,
 				fmt.Errorf("comment on PR %d: %w", num, err)
 		}
 		r.log().Info("thread: note recorded on KB PR", "pr", num, "root", tc.Root, "author", n.Author)
-		r.recordWrite(ctx, "comment")
-		return fmt.Sprintf("📝 Noted on the knowledge-base PR #%d — %s", num, Untrusted(candidate)), true, nil
+		r.recordWrite(ctx, RouteComment)
+		return fmt.Sprintf("📝 Noted on the knowledge-base PR #%d — %s", num, Untrusted(candidate)),
+			&KBWrite{Route: RouteComment, PR: num, URL: candidate, Note: asWritten}, nil
 	}
 
-	ref, err := r.Forge.OpenPR(ctx, ConceptEntry(tc, n, at, r.maxNoteBytes()))
+	entry := ConceptEntry(tc, n, at, r.maxNoteBytes())
+	ref, err := r.Forge.OpenPR(ctx, entry)
 	if err != nil {
-		return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), false,
+		return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), nil,
 			fmt.Errorf("open note PR: %w", err)
 	}
 	if uerr := r.Registry.Update(tc.Root, func(c *Context) { c.NoteURL = ref.URL }); uerr != nil {
@@ -701,9 +1178,15 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 			"root", tc.Root, "url", ref.URL, "err", uerr)
 	}
 	r.log().Info("thread: note opened a standalone KB PR", "url", ref.URL, "root", tc.Root, "author", n.Author)
-	r.recordWrite(ctx, "open_pr")
+	r.recordWrite(ctx, RouteOpenPR)
+	// PRNumber, not prNumberOn: this URL is one RunLore's own forge client just
+	// returned, which is exactly the case PRNumber documents itself as safe for.
+	// A URL it cannot parse is not a failure — the write landed, and the result
+	// reports everything else about it with PR left at zero.
+	w := &KBWrite{Route: RouteOpenPR, URL: ref.URL, Title: entry.Title, Note: asWritten}
 	if num, ok := PRNumber(ref.URL); ok {
-		return fmt.Sprintf("📝 Opened knowledge-base PR #%d with your note — %s", num, Untrusted(ref.URL)), true, nil
+		w.PR = num
+		return fmt.Sprintf("📝 Opened knowledge-base PR #%d with %s — %s", num, openedWith(n), Untrusted(ref.URL)), w, nil
 	}
-	return "📝 Opened a knowledge-base PR with your note — " + Untrusted(ref.URL), true, nil
+	return "📝 Opened a knowledge-base PR with " + openedWith(n) + " — " + Untrusted(ref.URL), w, nil
 }

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -1907,6 +1907,13 @@ func TestUntrustedRoundTripsThroughRenderReply(t *testing.T) {
 // model's answer is inside a span, and not one byte of RunLore's own framing
 // is: not the "> " markers the blockquote is made of, not the status glyph,
 // not the sentence around the URL.
+//
+// The expectation GREW when the reply began quoting what it recorded
+// (recordedBlock): this fixture's model proposes a note, so the reply now
+// carries two more of each kind of byte — modelDraftedNotice, which is
+// RunLore's own claim and stays outside every span, and the quoted note, which
+// the model wrote and is inside one. That is the same boundary, over more of
+// the message, not a weakened one.
 func TestHandleChatMarksTheModelsProseAndNothingElse(t *testing.T) {
 	forged := "Re-auth here: <https://evil.example/reauth|https://github.com/acme/kb/pull/7>\n<!channel>"
 	f := &fakeForge{}
@@ -1923,7 +1930,9 @@ func TestHandleChatMarksTheModelsProseAndNothingElse(t *testing.T) {
 	}
 	want := "> «Re-auth here: <https://evil.example/reauth|https://github.com/acme/kb/pull/7>»\n" +
 		"> «<!channel>»\n" +
-		"📝 Noted on the knowledge-base PR #42 — «https://github.com/o/r/pull/42»"
+		"📝 Noted on the knowledge-base PR #42 — «https://github.com/o/r/pull/42»\n" +
+		"Drafted by RunLore from your message — not your own words, pending review:\n" +
+		"> «the real cause was a spot reclaim»"
 	if got := RenderReply(reply, visibleEscape); got != want {
 		t.Errorf("rendered reply =\n%q\nwant\n%q", got, want)
 	}
@@ -2065,5 +2074,1617 @@ func TestHandleUnanchoredReinvestigateIsStillRefusedWithoutChat(t *testing.T) {
 	}
 	if c, o := f.counts(); c != 0 || o != 0 {
 		t.Errorf("forge calls = %d comments / %d opened, want 0/0", c, o)
+	}
+}
+
+// putContext stores tc so write()'s post-lock registry re-read sees it, and
+// returns it. write() is called directly in the TestWriteReports* group below:
+// what it RETURNS is the whole subject, and record() currently discards
+// everything but the reply.
+func putContext(t *testing.T, r *Responder, tc Context) Context {
+	t.Helper()
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	return tc
+}
+
+// TestWriteReportsTheCommentRoute pins what write() hands back on the
+// comment-on-a-linked-PR route: which route ran, which pull request took the
+// note, its URL, and the text as filed. No caller could learn any of that from
+// the (msg, landed, err) shape this replaced.
+//
+// The reply string is asserted byte-for-byte on purpose: growing the return
+// value must not change a single byte of what the human is told.
+func TestWriteReportsTheCommentRoute(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	const prURL = "https://github.com/o/r/pull/42"
+	tc := putContext(t, r, Context{Root: "111.222", Title: "OOM", CuratedURL: prURL})
+
+	reply, w, err := r.write(context.Background(), tc, HumanNote("alice", "spot reclaim, not OOM"), noteAt)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if w == nil {
+		t.Fatal("write reported no result for a note that landed on PR #42")
+	}
+	if w.Route != RouteComment {
+		t.Errorf("Route = %q, want %q", w.Route, RouteComment)
+	}
+	if w.PR != 42 {
+		t.Errorf("PR = %d, want 42", w.PR)
+	}
+	if w.URL != prURL {
+		t.Errorf("URL = %q, want %q", w.URL, prURL)
+	}
+	if w.Note != "spot reclaim, not OOM" {
+		t.Errorf("Note = %q, want the note text as filed", w.Note)
+	}
+	// The comment route adds to an entry that already exists; it generates no
+	// title of its own, and inventing one would name something nobody wrote.
+	if w.Title != "" {
+		t.Errorf("Title = %q, want empty on the comment route — no entry was generated", w.Title)
+	}
+	if want := "📝 Noted on the knowledge-base PR #42 — " + Untrusted(prURL); reply != want {
+		t.Errorf("reply = %q, want %q — this change grows what write RETURNS, never what it says", reply, want)
+	}
+}
+
+// TestWriteReportsTheOpenPRRoute pins the standalone-PR route, including the
+// entry title ConceptEntry generated — the one value the human cannot see
+// anywhere else without opening the pull request.
+func TestWriteReportsTheOpenPRRoute(t *testing.T) {
+	t.Run("numbered URL", func(t *testing.T) {
+		f := &fakeForge{openURL: "https://github.com/o/r/pull/99"}
+		r := newTestResponder(t, f)
+		tc := putContext(t, r, Context{Root: "111.222", Title: "OOM in payments"})
+
+		reply, w, err := r.write(context.Background(), tc, HumanNote("alice", "stale since Karpenter"), noteAt)
+		if err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if w == nil {
+			t.Fatal("write reported no result for a note that opened PR #99")
+		}
+		if w.Route != RouteOpenPR {
+			t.Errorf("Route = %q, want %q", w.Route, RouteOpenPR)
+		}
+		if w.PR != 99 {
+			t.Errorf("PR = %d, want 99", w.PR)
+		}
+		if w.URL != "https://github.com/o/r/pull/99" {
+			t.Errorf("URL = %q, want the forge's own Ref URL", w.URL)
+		}
+		if len(f.opened) != 1 {
+			t.Fatalf("opened = %d, want 1", len(f.opened))
+		}
+		if w.Title != f.opened[0].Title {
+			t.Errorf("Title = %q, want %q — the title the entry was actually filed under", w.Title, f.opened[0].Title)
+		}
+		if w.Title == "" {
+			t.Error("Title is empty; the open_pr route generates one and must report it")
+		}
+		if w.Note != "stale since Karpenter" {
+			t.Errorf("Note = %q, want the note text as filed", w.Note)
+		}
+		if want := "📝 Opened knowledge-base PR #99 with your note — " + Untrusted("https://github.com/o/r/pull/99"); reply != want {
+			t.Errorf("reply = %q, want %q", reply, want)
+		}
+	})
+
+	// A Ref URL with no pull-request number in it is not an error — the write
+	// landed, and the human still gets the URL. The result must say the same:
+	// everything known, and 0 for the one thing that is not.
+	t.Run("unnumbered URL", func(t *testing.T) {
+		f := &fakeForge{openURL: "https://github.com/o/r/kb"}
+		r := newTestResponder(t, f)
+		tc := putContext(t, r, Context{Root: "111.222", Title: "OOM"})
+
+		reply, w, err := r.write(context.Background(), tc, HumanNote("alice", "note text"), noteAt)
+		if err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if w == nil {
+			t.Fatal("write reported no result for a note that opened a PR")
+		}
+		if w.PR != 0 {
+			t.Errorf("PR = %d, want 0 — the Ref URL carries no number", w.PR)
+		}
+		if w.URL != "https://github.com/o/r/kb" {
+			t.Errorf("URL = %q, want the forge's own Ref URL", w.URL)
+		}
+		if w.Route != RouteOpenPR {
+			t.Errorf("Route = %q, want %q", w.Route, RouteOpenPR)
+		}
+		if want := "📝 Opened a knowledge-base PR with your note — " + Untrusted("https://github.com/o/r/kb"); reply != want {
+			t.Errorf("reply = %q, want %q", reply, want)
+		}
+	})
+}
+
+// TestWriteReportsTheNoteAsWritten is the security-relevant assertion of the
+// group: what write() reports is the text that REACHED THE FORGE — redacted
+// and capped — not the caller's raw input. A caller that quotes it back into a
+// chat message (PR4's whole point) must not be able to unmask what the entry
+// masked, nor republish the bytes the cap dropped.
+//
+// One message carries both hazards at once, deliberately: a secret AND more
+// bytes than the cap allows. Separately they would each pass against an
+// implementation that applied only the other transform.
+func TestWriteReportsTheNoteAsWritten(t *testing.T) {
+	const secret = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWX"
+	// No "![", no "<" and no "#": those are the FORGE-markdown defusals, which
+	// run downstream of the shared redact+cap value (see
+	// TestWriteReportsTheHumansTextNotItsForgeMarkdownDefusal). Keeping them out
+	// of this input makes noteText an identity beyond redact+cap, so the
+	// Contains check below is a byte-identity check on the whole block.
+	raw := "the deploy token " + secret + " leaked into the log; " + strings.Repeat("padding ", 60)
+
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	r.MaxNoteBytes = 200
+	const prURL = "https://github.com/o/r/pull/42"
+	tc := putContext(t, r, Context{Root: "111.222", Title: "OOM", CuratedURL: prURL})
+
+	_, w, err := r.write(context.Background(), tc, HumanNote("alice", raw), noteAt)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if w == nil {
+		t.Fatal("write reported no result for a note that landed")
+	}
+	if strings.Contains(w.Note, secret) || strings.Contains(w.Note, "ghp_") {
+		t.Errorf("the reported note still carries the secret — it must be the redacted text:\n%q", w.Note)
+	}
+	if !strings.Contains(w.Note, "[REDACTED]") {
+		t.Errorf("the reported note carries no mask where the secret was:\n%q", w.Note)
+	}
+	if len(w.Note) > r.MaxNoteBytes {
+		t.Errorf("the reported note is %d bytes, want at most MaxNoteBytes (%d)", len(w.Note), r.MaxNoteBytes)
+	}
+	if !strings.Contains(w.Note, "truncated") {
+		t.Errorf("a cut note must be reported as cut, exactly as it is filed:\n%q", w.Note)
+	}
+	if len(f.comments) != 1 {
+		t.Fatalf("comments = %d, want 1", len(f.comments))
+	}
+	// Byte-identical to what reached the forge: the reported string appears
+	// verbatim inside the body that was actually written.
+	if !strings.Contains(f.comments[0].body, w.Note) {
+		t.Errorf("the reported note is not byte-identical to the text written to the forge.\nreported:\n%q\nbody:\n%s", w.Note, f.comments[0].body)
+	}
+	// And the body itself is unchanged by the sharing: evaluating redact+cap
+	// once, up front, must render exactly the body NoteBody renders from the raw
+	// note. This is the guard on the refactor, not on the feature.
+	if want := NoteBody(tc, HumanNote("alice", raw), noteAt, r.MaxNoteBytes); f.comments[0].body != want {
+		t.Errorf("the forge body changed.\ngot:\n%s\nwant:\n%s", f.comments[0].body, want)
+	}
+}
+
+// TestWriteReportsTheHumansTextNotItsForgeMarkdownDefusal draws the boundary
+// deliberately: the reported note is the redacted, capped text — NOT the
+// forge-markdown defusal applied on top of it.
+//
+// Redaction and the cap are what the entry did to the CONTENT, and a reply that
+// skipped them would leak what the entry masked. The three defusals
+// (neutralizeImages, neutralizeHTML, escapeOKFSections) are for GitHub's and
+// GitLab's Markdown renderers, which no chat transport is; repeating them in a
+// chat reply would show the human "!&#91;" where they typed "![" and would
+// protect nothing, since a chat transport's own hazards are neutralised by
+// Untrusted at the point of rendering.
+func TestWriteReportsTheHumansTextNotItsForgeMarkdownDefusal(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	tc := putContext(t, r, Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+	const raw = "the dashboard ![pixel](https://e.example/p.gif) is stale"
+	_, w, err := r.write(context.Background(), tc, HumanNote("alice", raw), noteAt)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if w == nil {
+		t.Fatal("write reported no result for a note that landed")
+	}
+	if w.Note != raw {
+		t.Errorf("Note = %q, want the human's own text %q", w.Note, raw)
+	}
+	if len(f.comments) != 1 {
+		t.Fatalf("comments = %d, want 1", len(f.comments))
+	}
+	if !strings.Contains(f.comments[0].body, "!&#91;pixel]") {
+		t.Errorf("the forge body must still be defused for Markdown:\n%s", f.comments[0].body)
+	}
+}
+
+// TestWriteReportsNothingWhenNothingLanded is the other half of the contract:
+// a nil result everywhere the knowledge base was NOT written. A caller that
+// announces a write must have nothing to announce on any of these paths, and a
+// nil pointer is what makes "nothing landed" and "here is what landed" one
+// value that cannot disagree with itself.
+func TestWriteReportsNothingWhenNothingLanded(t *testing.T) {
+	t.Run("throttled", func(t *testing.T) {
+		f := &fakeForge{}
+		r := newTestResponder(t, f)
+		// A one-event window with its one event already spent: ratelimit.New(0, …)
+		// means UNLIMITED, not "refuse everything".
+		r.ForgeWrites = ratelimit.New(1, time.Hour)
+		if !r.ForgeWrites.Allow() {
+			t.Fatal("the window refused its first event; this test cannot reach the throttled path")
+		}
+		tc := putContext(t, r, Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		reply, w, err := r.write(context.Background(), tc, HumanNote("alice", "x"), noteAt)
+		if err != nil {
+			t.Fatalf("a throttle is not an error: %v", err)
+		}
+		if w != nil {
+			t.Errorf("throttled write reported %+v, want no result", *w)
+		}
+		if !strings.Contains(reply, "paused") {
+			t.Errorf("reply = %q, want the throttle message", reply)
+		}
+		if c, o := f.counts(); c != 0 || o != 0 {
+			t.Errorf("forge calls = %d/%d, want 0/0", c, o)
+		}
+	})
+
+	t.Run("comment failed", func(t *testing.T) {
+		f := &fakeForge{commErr: errors.New("forge down")}
+		r := newTestResponder(t, f)
+		tc := putContext(t, r, Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		_, w, err := r.write(context.Background(), tc, HumanNote("alice", "x"), noteAt)
+		if err == nil {
+			t.Fatal("a failed comment must still be an error")
+		}
+		if w != nil {
+			t.Errorf("failed write reported %+v, want no result", *w)
+		}
+	})
+
+	t.Run("open PR failed", func(t *testing.T) {
+		f := &fakeForge{openErr: errors.New("forge down")}
+		r := newTestResponder(t, f)
+		tc := putContext(t, r, Context{Root: "111.222"})
+
+		_, w, err := r.write(context.Background(), tc, HumanNote("alice", "x"), noteAt)
+		if err == nil {
+			t.Fatal("a failed OpenPR must still be an error")
+		}
+		if w != nil {
+			t.Errorf("failed write reported %+v, want no result", *w)
+		}
+	})
+
+	t.Run("open-check failed", func(t *testing.T) {
+		f := &fakeForge{prOpenErr: errors.New("forge unreachable")}
+		r := newTestResponder(t, f)
+		tc := putContext(t, r, Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		_, w, err := r.write(context.Background(), tc, HumanNote("alice", "x"), noteAt)
+		if err == nil {
+			t.Fatal("an unreachable forge must still be an error")
+		}
+		if w != nil {
+			t.Errorf("failed write reported %+v, want no result", *w)
+		}
+	})
+
+	// The per-thread cap is enforced in record(), UPSTREAM of write(), so a
+	// capped note produces no result for the simplest possible reason: write()
+	// never runs and the forge is never touched. Asserted here rather than
+	// assumed, because that placement is what makes the cap a real ceiling on
+	// anything a caller could later announce.
+	t.Run("capped", func(t *testing.T) {
+		f := &fakeForge{}
+		r := newTestResponder(t, f)
+		r.MaxNotesPerThread = 1
+		tc := putContext(t, r, Context{Root: "111.222", Notes: 1, CuratedURL: "https://github.com/o/r/pull/42"})
+
+		reply, err := r.record(context.Background(), tc, HumanNote("alice", "x"))
+		if err != nil {
+			t.Fatalf("record: %v", err)
+		}
+		if !strings.Contains(reply, "note limit") {
+			t.Errorf("reply = %q, want the per-thread cap message", reply)
+		}
+		if c, o := f.counts(); c != 0 || o != 0 {
+			t.Errorf("forge calls = %d/%d, want 0/0 — a capped note never reaches write()", c, o)
+		}
+	})
+}
+
+// untrustedSpans returns the CONTENT of every span Untrusted marked in reply,
+// in order — the test-side inverse of RenderReply. It is what a transport's
+// escape function is handed, and nothing else: everything RunLore wrote itself
+// falls on the even indices and is dropped here.
+func untrustedSpans(reply string) []string {
+	parts := strings.Split(reply, untrustedMark)
+	spans := make([]string, 0, len(parts)/2)
+	for i := 1; i < len(parts); i += 2 {
+		spans = append(spans, parts[i])
+	}
+	return spans
+}
+
+// TestReplyQuotesTheRecordedNote is the feature: after a note lands the human
+// is told WHAT was filed, not only where it went.
+//
+// Before this, the reply was a PR number and a URL. On the model-drafted route
+// that meant a human read "Opened knowledge-base PR #12 with your note" about
+// text RunLore's own model wrote in their name, and could not see a word of it
+// without leaving the thread. The `note:` route was barely better: a human
+// whose message was redacted or cut had no way to see that from the reply.
+//
+// Both routes are asserted, and the `note:` one with the chat layer OFF — the
+// default deployment. The whole rendered reply is pinned byte-for-byte rather
+// than probed with Contains, because the SHAPE is the property: RunLore's
+// status line at the left margin, the quote blockquoted under it, and the
+// untrusted spans exactly where they belong (see
+// TestReplyQuotesTheNoteAsUntrustedAndNothingElse).
+func TestReplyQuotesTheRecordedNote(t *testing.T) {
+	t.Run("comment route, note: with chat off", func(t *testing.T) {
+		f := &fakeForge{}
+		r := newTestResponder(t, f)
+		if r.Chat != nil {
+			t.Fatal("test setup: this case must run with the chat layer off")
+		}
+		tc := Context{Root: "111.222", Title: "OOM", CuratedURL: "https://github.com/o/r/pull/42"}
+		if err := r.Registry.Put(tc); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: spot reclaim, not OOM")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		// No "Entry:" line: the comment route adds to an entry someone else
+		// already titled, and the pull request it joined is named in the status
+		// line above. KBWrite.Title is empty here by design, not by omission.
+		want := "📝 Noted on the knowledge-base PR #42 — «https://github.com/o/r/pull/42»\n" +
+			"> «spot reclaim, not OOM»"
+		if got := RenderReply(reply, visibleEscape); got != want {
+			t.Errorf("rendered reply =\n%q\nwant\n%q", got, want)
+		}
+	})
+
+	t.Run("open_pr route names the entry it created", func(t *testing.T) {
+		f := &fakeForge{}
+		r := newTestResponder(t, f)
+		tc := Context{Root: "111.222", Title: "OOM in payments"}
+		if err := r.Registry.Put(tc); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: stale since Karpenter")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		if len(f.opened) != 1 {
+			t.Fatalf("opened = %d, want 1", len(f.opened))
+		}
+		want := "📝 Opened knowledge-base PR #99 with your note — «https://github.com/o/r/pull/99»\n" +
+			"Entry: «Operator note: OOM in payments»\n" +
+			"> «stale since Karpenter»"
+		if got := RenderReply(reply, visibleEscape); got != want {
+			t.Errorf("rendered reply =\n%q\nwant\n%q", got, want)
+		}
+		// The name in the reply is the name the entry was actually filed under,
+		// not a second rendering of the same inputs that could drift from it.
+		if !strings.Contains(reply, f.opened[0].Title) {
+			t.Errorf("the reply names %q, but the entry was filed as %q", reply, f.opened[0].Title)
+		}
+	})
+}
+
+// TestReplyQuotesWithinAPreviewCeiling pins the bound that makes quoting safe
+// to do at all: the quote is capped by notePreviewBytes, INDEPENDENTLY of
+// MaxNoteBytes.
+//
+// The two bound different things. MaxNoteBytes bounds what is written to the
+// knowledge base — 8 KiB by default, and an operator may set it higher
+// (config.Validate rejects only a negative one). Without a second ceiling here,
+// a note at that cap would be echoed back verbatim as a chat message of the
+// same size, in a thread, on a path any channel member can trigger.
+//
+// The fixture therefore sets MaxNoteBytes far ABOVE the default and files a
+// note that is comfortably under it: nothing about this bound can come from the
+// note cap, because the note cap never fires.
+func TestReplyQuotesWithinAPreviewCeiling(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	r.MaxNoteBytes = 64 << 10
+	// Trimmed: Parse trims the text it hands on, so a fixture ending in a space
+	// would not appear verbatim in the body the forge received.
+	note := strings.TrimSpace(strings.Repeat("spot reclaim ", 4000)) // ~52 KiB, under MaxNoteBytes
+	if len(note) >= r.MaxNoteBytes {
+		t.Fatalf("test setup: the note (%d bytes) must stay under MaxNoteBytes (%d) so the note cap never fires", len(note), r.MaxNoteBytes)
+	}
+	tc := Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: "+note)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(f.comments) != 1 {
+		t.Fatalf("comments = %d, want 1", len(f.comments))
+	}
+	// The forge still got the whole note: the ceiling bounds what is SAID, never
+	// what is WRITTEN.
+	if !strings.Contains(f.comments[0].body, note) {
+		t.Error("the preview ceiling must not shorten what reaches the knowledge base")
+	}
+	for i, span := range untrustedSpans(reply) {
+		if len(span) > notePreviewBytes {
+			t.Errorf("untrusted span %d is %d bytes, want at most notePreviewBytes (%d)", i, len(span), notePreviewBytes)
+		}
+	}
+	// Framing headroom over the ceiling: a status line, a URL and the truncation
+	// notice, and nothing that scales with the note.
+	rendered := RenderReply(reply, nil)
+	if ceiling := notePreviewBytes + 256; len(rendered) > ceiling {
+		t.Errorf("reply is %d bytes, want at most %d — a %d-byte note must not become a %d-byte chat message",
+			len(rendered), ceiling, len(note), len(rendered))
+	}
+	if !strings.Contains(rendered, "truncated") {
+		t.Errorf("a cut quote must say it was cut:\n%q", rendered)
+	}
+	if !strings.Contains(rendered, "spot reclaim") {
+		t.Errorf("the preview must still carry the start of the note:\n%q", rendered)
+	}
+	// A note that FITS says nothing about truncation — the notice has to be a
+	// signal, not decoration.
+	t.Run("a short note is quoted whole", func(t *testing.T) {
+		f := &fakeForge{}
+		r := newTestResponder(t, f)
+		tc := Context{Root: "333.444", CuratedURL: "https://github.com/o/r/pull/42"}
+		if err := r.Registry.Put(tc); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: short and complete")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		if strings.Contains(reply, "truncated") {
+			t.Errorf("an uncut quote must not claim truncation:\n%q", reply)
+		}
+	})
+}
+
+// TestNotePreviewCeilingHasItsDocumentedValue pins the NUMBER, the way
+// config.TestThreadDefaultsHaveTheirDocumentedValues pins the thread defaults.
+//
+// The test above cannot. It asserts len(span) <= notePreviewBytes and bounds the
+// whole reply at notePreviewBytes+256, so both sides of every comparison are
+// recomputed from the constant under test and the assertion holds for ANY value:
+// raise notePreviewBytes from 512 to 8192 and it still passes, while a 650-byte
+// note that used to produce a ~700-byte reply now produces an 8,331-byte one —
+// the 8 KiB chat post that whole test exists to make impossible.
+//
+// 512 is derived rather than picked (see notePreviewBytes' doc comment): every
+// untrusted span is escaped before it goes on the wire and the widest escape,
+// Slack's "&" to "&amp;", expands 5x, so this reaches the transport as at most
+// ~2.5k characters — inside Slack's ~4k text budget with room left for the
+// model's own answer, which shares the same message on the freeform route.
+// Changing it should be a deliberate edit HERE, with that arithmetic redone, not
+// a side effect of tuning something else.
+func TestNotePreviewCeilingHasItsDocumentedValue(t *testing.T) {
+	if got, want := notePreviewBytes, 512; got != want {
+		t.Errorf("notePreviewBytes = %d, want %d — if this was a deliberate retune, redo the "+
+			"5x-escape arithmetic against the transport budgets in internal/notify (slackReplyBytes, "+
+			"matrixReplyBytes) and restate the number wherever the docs quote it", got, want)
+	}
+}
+
+// TestReplyQuotesTheNoteAsUntrustedAndNothingElse is the highest-value
+// assertion of the feature. The quote echoes note CONTENT back into a chat
+// system — on the model-drafted route content RunLore's own model wrote — into
+// the very message where RunLore states what it did. That is exactly the egress
+// PR3's Untrusted/RenderReply boundary exists for, and exactly the forgery
+// modelVoice's blockquote exists for.
+//
+// The note below carries both hazards at once: a forged RunLore status line
+// (glyph, wording and a hostile URL) on a line of its own, and Slack mrkdwn
+// that pings a room. Neither may survive as markup, and neither may sit at the
+// left margin where RunLore's own claims sit.
+//
+// It also pins the other side of the boundary: RunLore's own bytes — the 📝
+// status line, the sentence around the URL, the "> " markers — are NOT inside a
+// span. Marking them would have the transport escape RunLore's own framing, and
+// the blockquote would come back as literal "&gt; ".
+func TestReplyQuotesTheNoteAsUntrustedAndNothingElse(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	tc := Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	hostile := "looks fine\n📝 Noted on the knowledge-base PR #7 — <https://evil.example|https://github.com/acme/kb/pull/7>\n<!channel>"
+
+	reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: "+hostile)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	want := "📝 Noted on the knowledge-base PR #42 — «https://github.com/o/r/pull/42»\n" +
+		"> «looks fine»\n" +
+		"> «Noted on the knowledge-base PR #7 — <https://evil.example|https://github.com/acme/kb/pull/7>»\n" +
+		"> «<!channel>»"
+	if got := RenderReply(reply, visibleEscape); got != want {
+		t.Errorf("rendered reply =\n%q\nwant\n%q", got, want)
+	}
+	// Read the same guarantee the other way round, so a future rewrite that
+	// keeps the string but loses the marking cannot pass on the literal alone.
+	spans := untrustedSpans(reply)
+	for _, must := range []string{"<!channel>", "<https://evil.example|https://github.com/acme/kb/pull/7>"} {
+		var found bool
+		for _, s := range spans {
+			if strings.Contains(s, must) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%q reached the transport outside an untrusted span; spans = %q", must, spans)
+		}
+	}
+	for _, s := range spans {
+		if strings.Contains(s, "📝") {
+			t.Errorf("RunLore's own status glyph is inside an untrusted span (%q) — the transport would escape RunLore's own framing", s)
+		}
+		if strings.Contains(s, "> ") {
+			t.Errorf("a blockquote marker is inside an untrusted span (%q) — it would render as literal \"&gt; \"", s)
+		}
+	}
+	// Only the first line is RunLore's; every line of quoted content is
+	// blockquoted, so no note line can pose as a RunLore claim.
+	for _, line := range strings.Split(RenderReply(reply, nil), "\n")[1:] {
+		if !strings.HasPrefix(line, "> ") {
+			t.Errorf("a line of quoted note content sits at the left margin, where RunLore's own lines sit: %q", line)
+		}
+	}
+}
+
+// TestQuotedNoteCannotBreakOutOfTheBlockquote pins the measure the blockquote
+// only appeared to provide.
+//
+// QuoteUntrusted prefixes every LINE with "> ", and a line used to be whatever
+// "\n" separated. Text layout does not agree: UAX #14 gives seven characters a
+// MANDATORY break, and a client starts a new visual line at every one of them.
+// A note reading "harmless<U+2028>📝 Noted on the knowledge-base PR #7 —
+// <hostile URL>" therefore put its second half OUTSIDE the quote, at the left
+// margin, in RunLore's own vocabulary — the exact forgery modelVoice's
+// blockquote exists to stop, arriving through a rune that is not "\n".
+//
+// singleLine had already made this argument for the YAML title (see its doc
+// comment: U+2028 and U+2029 are the ones "many renderers and tokenizers break
+// on"), and noteField applies it to Author and Title. The note BODY is the one
+// untrusted span rendered multi-line BY DESIGN, so it is the one span that
+// cannot be flattened — and it was therefore the one span with no line-break
+// handling of any kind.
+//
+// Each break is asserted through the real reply, byte for byte: the forged line
+// must arrive with a "> " in front of it, nothing else may move, and CRLF must
+// count as one break rather than two.
+func TestQuotedNoteCannotBreakOutOfTheBlockquote(t *testing.T) {
+	const status = "📝 Noted on the knowledge-base PR #42 — https://github.com/o/r/pull/42"
+	const forged = "Noted on the knowledge-base PR #7 — https://evil.example/kb"
+
+	for _, br := range []struct{ name, sep string }{
+		{"LF U+000A", "\n"},
+		{"CR U+000D", "\r"},
+		{"CRLF is one break, not two", "\r\n"},
+		{"VT U+000B", "\v"},
+		{"FF U+000C", "\f"},
+		{"NEL U+0085", "\u0085"},
+		{"LS U+2028", "\u2028"},
+		{"PS U+2029", "\u2029"},
+	} {
+		t.Run(br.name, func(t *testing.T) {
+			r := newTestResponder(t, &fakeForge{})
+			tc := Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"}
+			if err := r.Registry.Put(tc); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+			reply, err := r.Handle(context.Background(), tc, "alice",
+				"<@U0BOT> note: harmless"+br.sep+"📝 "+forged)
+			if err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+			want := status + "\n> harmless\n> " + forged
+			if got := RenderReply(reply, nil); got != want {
+				t.Errorf("a %s in the note escaped the blockquote.\n got %q\nwant %q", br.name, got, want)
+			}
+		})
+	}
+
+	// The other direction, and the reason the fix normalises BREAKS rather than
+	// mapping whitespace the way singleLine does: a tab, a no-break space and a
+	// blank line are not line breaks, so the quote must carry them through
+	// untouched. Flattening them would censor the note the human asked to read.
+	t.Run("everything that is not a break survives byte for byte", func(t *testing.T) {
+		r := newTestResponder(t, &fakeForge{})
+		tc := Context{Root: "333.444", CuratedURL: "https://github.com/o/r/pull/42"}
+		if err := r.Registry.Put(tc); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		note := "one\ttabbed\n\nblank line above, no-break\u00a0space, zero\u200bwidth"
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: "+note)
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		want := status + "\n> one\ttabbed\n>\n> blank line above, no-break\u00a0space, zero\u200bwidth"
+		if got := RenderReply(reply, nil); got != want {
+			t.Errorf("ordinary note text was not quoted byte for byte.\n got %q\nwant %q", got, want)
+		}
+	})
+}
+
+// TestReplyQuotesTheModelDraftAsModelDrafted keeps the two routes apart in the
+// one place the human actually reads. ProposedNote already carries the
+// distinction into the ENTRY (see NoteBody), and quoting the text into the
+// thread is precisely what could erase it there: a human who sees their own
+// words quoted back reads them as their own, and a human who sees the MODEL's
+// words quoted back under "your note" would read those as their own too.
+//
+// So the reply says who wrote them, immediately above the quote.
+func TestReplyQuotesTheModelDraftAsModelDrafted(t *testing.T) {
+	f := &fakeForge{}
+	model := &fakeChatModel{resp: wellFormedReply("Noted — that changes the root cause.", "The real cause was a spot-node reclaim, not the CNI.")}
+	r := newChatResponder(t, f, model)
+	tc := Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> it was actually a spot reclaim")
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	want := "> «Noted — that changes the root cause.»\n" +
+		"📝 Noted on the knowledge-base PR #42 — «https://github.com/o/r/pull/42»\n" +
+		"Drafted by RunLore from your message — not your own words, pending review:\n" +
+		"> «The real cause was a spot-node reclaim, not the CNI.»"
+	if got := RenderReply(reply, visibleEscape); got != want {
+		t.Errorf("rendered reply =\n%q\nwant\n%q", got, want)
+	}
+
+	// The `note:` route must NOT carry that line: it files the human's own
+	// words, and telling them RunLore drafted them would be a lie in the other
+	// direction.
+	t.Run("the note: route claims no such thing", func(t *testing.T) {
+		f := &fakeForge{}
+		r := newTestResponder(t, f)
+		tc := Context{Root: "555.666", CuratedURL: "https://github.com/o/r/pull/42"}
+		if err := r.Registry.Put(tc); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: it was a spot reclaim")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		if strings.Contains(reply, "Drafted by RunLore") {
+			t.Errorf("the human's own words were reported as RunLore's draft:\n%q", reply)
+		}
+	})
+}
+
+// TestModelDraftedNoticeIntroducesTheQuoteItPromises pins the ONE thing
+// modelDraftedNotice's trailing colon claims: that what follows it is the
+// quote.
+//
+// On the open_pr route it was not. recordedBlock emitted the notice first and
+// the "Entry:" line second, so the message read
+//
+//	Drafted by RunLore from your message — not your own words, pending review:
+//	Entry: Operator note: OOM in payments
+//	> the real cause was a spot-node reclaim
+//
+// — a colon promising a quote, answered by a title. Two colons in a row, the
+// second one introducing something the first one did not name. This whole PR
+// exists to make the feedback readable, so the notice sits immediately above
+// the block it introduces.
+//
+// The second case is the same rule read the other way: a notice whose colon
+// promises a quote that does not exist is the same defect with nothing after
+// it at all, so an empty preview renders no notice. Nothing is lost by that —
+// the status line's "a note drafted from your message" (see openedWith)
+// already carries the provenance, and it is the half that stands alone.
+func TestModelDraftedNoticeIntroducesTheQuoteItPromises(t *testing.T) {
+	t.Run("the assembled open_pr reply puts the notice against the quote", func(t *testing.T) {
+		f := &fakeForge{}
+		model := &fakeChatModel{resp: wellFormedReply("Noted — that changes the root cause.", "The real cause was a spot-node reclaim, not the CNI.")}
+		r := newChatResponder(t, f, model)
+		tc := putContext(t, r, Context{Root: "111.222", Title: "OOM in payments"})
+
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> it was actually a spot reclaim")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		lines := strings.Split(RenderReply(reply, visibleEscape), "\n")
+		at := -1
+		for i, ln := range lines {
+			if ln == modelDraftedNotice {
+				at = i
+			}
+		}
+		if at < 0 {
+			t.Fatalf("the model-drafted notice is missing from the reply:\n%q", lines)
+		}
+		if at == len(lines)-1 {
+			t.Fatalf("the notice promises a quote and is the last line:\n%q", lines)
+		}
+		if next := lines[at+1]; !strings.HasPrefix(next, "> ") {
+			t.Errorf("the line under the model-drafted notice is %q, want the quote it introduces (a \"> \" line).\n"+
+				"The notice ends in a colon; whatever answers that colon is what the human reads as the drafted text.\nfull reply:\n%q",
+				next, lines)
+		}
+	})
+
+	// recordedBlock directly: the reply path always has note text, so the
+	// promise-with-nothing-after-it case is only reachable here — and this is
+	// the function that must not emit it.
+	t.Run("no quote, no notice", func(t *testing.T) {
+		block := recordedBlock(ProposedNote("alice", "was it the CNI?", "drafted"),
+			&KBWrite{Route: RouteOpenPR, PR: 99, URL: "https://github.com/o/r/pull/99", Title: "Operator note: OOM in payments"})
+		if strings.Contains(block, modelDraftedNotice) {
+			t.Errorf("the notice promises a quote, and there is none to show:\n%q", block)
+		}
+		if !strings.Contains(block, "Operator note: OOM in payments") {
+			t.Errorf("the entry title must still be named:\n%q", block)
+		}
+	})
+}
+
+// TestOpenPRStatusLineNamesWhoseNoteItOpenedWith closes a contradiction the
+// open_pr reply shipped: "📝 Opened knowledge-base PR #99 with your note" sat
+// directly above "Drafted by RunLore from your message — not your own words".
+// Two adjacent lines of one message disagreed about who wrote the thing that
+// was filed, and the human read the false one first.
+//
+// The status line is the half that has to be right on its own. It is what a
+// truncating transport keeps and what a human skims; a reader who stops after
+// it must not come away believing RunLore filed their words under their name
+// when it filed its own paraphrase.
+//
+// The `note:` route keeps "your note" unchanged, and that is asserted here too:
+// the fix is to stop claiming authorship RunLore does not have, not to stop
+// naming authorship at all. A reply that hedged both routes would be vaguer
+// than the one it replaced, which on this path is a regression.
+//
+// The comment route is deliberately absent from this table. Its status line
+// ("📝 Noted on the knowledge-base PR #42") makes no authorship claim to be
+// wrong about, so it is already true on both routes — see openedWith.
+func TestOpenPRStatusLineNamesWhoseNoteItOpenedWith(t *testing.T) {
+	draft := ProposedNote("alice", "was it the CNI?", "The real cause was a spot-node reclaim, not the CNI.")
+	typed := HumanNote("alice", "The real cause was a spot-node reclaim, not the CNI.")
+
+	// write()-level, both URL shapes: the unnumbered branch is a separate return
+	// with its own copy of the sentence, so it can drift from the numbered one.
+	t.Run("write", func(t *testing.T) {
+		for _, tt := range []struct {
+			name    string
+			note    Note
+			openURL string
+			want    string
+		}{
+			{
+				name:    "model-drafted, numbered URL",
+				note:    draft,
+				openURL: "https://github.com/o/r/pull/99",
+				want:    "📝 Opened knowledge-base PR #99 with a note drafted from your message — «https://github.com/o/r/pull/99»",
+			},
+			{
+				name:    "model-drafted, unnumbered URL",
+				note:    draft,
+				openURL: "https://github.com/o/r/kb",
+				want:    "📝 Opened a knowledge-base PR with a note drafted from your message — «https://github.com/o/r/kb»",
+			},
+			{
+				name:    "note:, numbered URL",
+				note:    typed,
+				openURL: "https://github.com/o/r/pull/99",
+				want:    "📝 Opened knowledge-base PR #99 with your note — «https://github.com/o/r/pull/99»",
+			},
+			{
+				name:    "note:, unnumbered URL",
+				note:    typed,
+				openURL: "https://github.com/o/r/kb",
+				want:    "📝 Opened a knowledge-base PR with your note — «https://github.com/o/r/kb»",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				f := &fakeForge{openURL: tt.openURL}
+				r := newTestResponder(t, f)
+				tc := putContext(t, r, Context{Root: "111.222", Title: "OOM in payments"})
+
+				reply, w, err := r.write(context.Background(), tc, tt.note, noteAt)
+				if err != nil {
+					t.Fatalf("write: %v", err)
+				}
+				if w == nil {
+					t.Fatal("write reported no result for a note that opened a PR")
+				}
+				if got := RenderReply(reply, visibleEscape); got != tt.want {
+					t.Errorf("status line =\n%q\nwant\n%q", got, tt.want)
+				}
+			})
+		}
+	})
+
+	// End to end, because the contradiction was only visible in the assembled
+	// message: neither line was wrong in isolation, and no test read both at
+	// once. The whole rendered reply is pinned so a future edit to either line
+	// has to look at the other.
+	t.Run("the assembled model-drafted reply agrees with itself", func(t *testing.T) {
+		f := &fakeForge{}
+		model := &fakeChatModel{resp: wellFormedReply("Noted — that changes the root cause.", "The real cause was a spot-node reclaim, not the CNI.")}
+		r := newChatResponder(t, f, model)
+		tc := putContext(t, r, Context{Root: "111.222", Title: "OOM in payments"})
+
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> it was actually a spot reclaim")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		// The notice sits UNDER the entry title, against the quote its colon
+		// promises — see TestModelDraftedNoticeIntroducesTheQuoteItPromises for
+		// why that order moved.
+		want := "> «Noted — that changes the root cause.»\n" +
+			"📝 Opened knowledge-base PR #99 with a note drafted from your message — «https://github.com/o/r/pull/99»\n" +
+			"Entry: «Operator note: OOM in payments»\n" +
+			"Drafted by RunLore from your message — not your own words, pending review:\n" +
+			"> «The real cause was a spot-node reclaim, not the CNI.»"
+		if got := RenderReply(reply, visibleEscape); got != want {
+			t.Errorf("rendered reply =\n%q\nwant\n%q", got, want)
+		}
+		// The new clause is RunLore's own framing, so it must reach the transport
+		// unmarked — exactly like the status line it is part of. Marked, the
+		// transport would escape RunLore's own words.
+		for _, s := range untrustedSpans(reply) {
+			if strings.Contains(s, "drafted from your message") {
+				t.Errorf("RunLore's own status wording is inside an untrusted span: %q", s)
+			}
+		}
+	})
+}
+
+// TestReplyQuotesTheTextAsWrittenNotTheRawInput is the security half of
+// quoting. What the reply shows must be the text that REACHED THE FORGE —
+// redacted and capped by noteAsWritten — never the caller's raw input.
+//
+// Quoting n.Text instead would be a strictly worse egress than the entry it
+// describes: the reply would republish, into a chat room, both the secret the
+// entry masked and the bytes the entry's cap dropped. Task 1 put that value on
+// KBWrite.Note for exactly this consumer; this pins that the consumer uses it.
+//
+// The fixture carries both hazards at once — a secret AND more bytes than
+// MaxNoteBytes — and stays well under notePreviewBytes, so nothing here can be
+// mistaken for the preview ceiling doing the work.
+func TestReplyQuotesTheTextAsWrittenNotTheRawInput(t *testing.T) {
+	const secret = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWX"
+	// No "![", "<" or "#": those trigger the forge-Markdown defusals, which are
+	// deliberately NOT in the quoted text (see KBWrite.Note), and would make the
+	// byte-identity check below fail for the wrong reason.
+	raw := "the deploy token " + secret + " leaked into the log; " + strings.TrimSpace(strings.Repeat("padding ", 30))
+
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	r.MaxNoteBytes = 200
+	if len(raw) <= r.MaxNoteBytes || r.MaxNoteBytes >= notePreviewBytes {
+		t.Fatalf("test setup: the note (%d bytes) must exceed MaxNoteBytes (%d), which must itself stay under notePreviewBytes (%d)",
+			len(raw), r.MaxNoteBytes, notePreviewBytes)
+	}
+	tc := Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: "+raw)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	rendered := RenderReply(reply, nil)
+	if strings.Contains(rendered, secret) || strings.Contains(rendered, "ghp_") {
+		t.Errorf("the reply quoted the secret the entry masked:\n%q", rendered)
+	}
+	if !strings.Contains(rendered, "[REDACTED]") {
+		t.Errorf("the reply carries no mask where the secret was:\n%q", rendered)
+	}
+	if !strings.Contains(rendered, "input bytes dropped") {
+		t.Errorf("the reply must carry the cap's own truncation mark, exactly as the entry does:\n%q", rendered)
+	}
+	// Byte-identical to what was written: unquoting the blockquote must yield a
+	// string that appears verbatim in the body the forge received.
+	var quoted []string
+	for _, ln := range strings.Split(rendered, "\n") {
+		if s, ok := strings.CutPrefix(ln, ">"); ok {
+			quoted = append(quoted, strings.TrimPrefix(s, " "))
+		}
+	}
+	got := strings.Join(quoted, "\n")
+	if got == "" {
+		t.Fatalf("the reply quoted nothing:\n%q", rendered)
+	}
+	if len(got) > r.MaxNoteBytes {
+		t.Errorf("the quote is %d bytes, want at most MaxNoteBytes (%d) — it must be the capped text, not the raw input", len(got), r.MaxNoteBytes)
+	}
+	if len(f.comments) != 1 {
+		t.Fatalf("comments = %d, want 1", len(f.comments))
+	}
+	if !strings.Contains(f.comments[0].body, got) {
+		t.Errorf("the quote is not byte-identical to the text written to the forge.\nquoted:\n%q\nbody:\n%s", got, f.comments[0].body)
+	}
+}
+
+// ---- announcing a landed write to every configured sink --------------------
+
+// fakeKBSink is a providers.KBUpdateNotifier that records every announcement it
+// is handed.
+//
+// mu guards got because deliveries run DETACHED from the reply (see
+// KBAnnouncer): the goroutine that asserts is never the goroutine that
+// appended, so reading the slice unguarded would be a data race the -race
+// detector catches independently of anything under test.
+type fakeKBSink struct {
+	mu  sync.Mutex
+	got []providers.KBUpdate
+	err error
+	// entered and release are optional rendezvous channels, used by the tests
+	// that must prove the reply never waits for a sink: when entered is
+	// non-nil DeliverKBUpdate announces its arrival on it, and when release is
+	// non-nil it then blocks until release is closed.
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (s *fakeKBSink) DeliverKBUpdate(_ context.Context, up providers.KBUpdate) error {
+	if s.entered != nil {
+		s.entered <- struct{}{}
+	}
+	if s.release != nil {
+		<-s.release
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.got = append(s.got, up)
+	return s.err
+}
+
+// updates returns a copy of what the sink has received so far, taken under the
+// lock.
+func (s *fakeKBSink) updates() []providers.KBUpdate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]providers.KBUpdate(nil), s.got...)
+}
+
+// newAnnouncingResponder is newTestResponder with announcements wired to a
+// recording sink.
+func newAnnouncingResponder(t *testing.T, f *fakeForge) (*Responder, *fakeKBSink) {
+	t.Helper()
+	r := newTestResponder(t, f)
+	sink := &fakeKBSink{}
+	r.Announcer = NewKBAnnouncer(sink, silentLog())
+	return r, sink
+}
+
+// drainAnnouncements waits for every detached announcement to finish, so an
+// assertion never races the delivery it is about. Bounded: a wedged sink must
+// fail this test rather than hang the suite.
+func drainAnnouncements(t *testing.T, r *Responder) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	r.Announcer.Drain(ctx)
+	if ctx.Err() != nil {
+		t.Fatal("announcements did not drain within 10s")
+	}
+}
+
+// TestAnnounceALandedWrite is the feature: one KBUpdate per successful write,
+// carrying everything write() reported plus where it came from.
+//
+// Both routes are driven, and the whole event is compared as ONE value rather
+// than field by field: a missing field is the failure this is for, and a
+// per-field probe would pass over one that was never populated at all.
+func TestAnnounceALandedWrite(t *testing.T) {
+	t.Run("comment route", func(t *testing.T) {
+		f := &fakeForge{}
+		r, sink := newAnnouncingResponder(t, f)
+		const prURL = "https://github.com/o/r/pull/42"
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", Title: "OOM", CuratedURL: prURL})
+
+		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: spot reclaim, not OOM"); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		drainAnnouncements(t, r)
+
+		got := sink.updates()
+		if len(got) != 1 {
+			t.Fatalf("announcements = %d, want exactly 1 per landed write", len(got))
+		}
+		// Title is empty on this route by design — the note joined an entry
+		// someone else already titled (see KBWrite.Title).
+		want := providers.KBUpdate{
+			Transport: "slack",
+			Root:      "111.222",
+			Route:     providers.KBRouteComment,
+			PR:        42,
+			URL:       prURL,
+			Author:    "alice",
+			Note:      "spot reclaim, not OOM",
+			At:        noteAt,
+		}
+		if got[0] != want {
+			t.Errorf("announcement =\n%+v\nwant\n%+v", got[0], want)
+		}
+	})
+
+	t.Run("open_pr route", func(t *testing.T) {
+		f := &fakeForge{}
+		r, sink := newAnnouncingResponder(t, f)
+		tc := putContext(t, r, Context{Transport: "matrix", Root: "$evt:example.org", Title: "OOM in payments"})
+
+		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: stale since Karpenter"); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		drainAnnouncements(t, r)
+
+		if len(f.opened) != 1 {
+			t.Fatalf("opened = %d, want 1", len(f.opened))
+		}
+		got := sink.updates()
+		if len(got) != 1 {
+			t.Fatalf("announcements = %d, want exactly 1 per landed write", len(got))
+		}
+		want := providers.KBUpdate{
+			Transport: "matrix",
+			Root:      "$evt:example.org",
+			Route:     providers.KBRouteOpenPR,
+			PR:        99,
+			URL:       "https://github.com/o/r/pull/99",
+			// The name the entry was actually filed under, not a second
+			// rendering of the same inputs that could drift from it.
+			Title:  f.opened[0].Title,
+			Author: "alice",
+			Note:   "stale since Karpenter",
+			At:     noteAt,
+		}
+		if got[0] != want {
+			t.Errorf("announcement =\n%+v\nwant\n%+v", got[0], want)
+		}
+		if got[0].Title == "" {
+			t.Error("Title is empty; the open_pr route generates one and the announcement must name it")
+		}
+	})
+}
+
+// TestAnnounceNamesItsOriginatingTransportAndRoot pins the half of the event a
+// consumer needs to tell where a write came from — and pins it as a value READ
+// from the thread context rather than a constant.
+//
+// This is what the owner's "distinct destination, not exclusion" decision rests
+// on: the announcement goes to each notifier's configured channel and never
+// into a thread, so the origin travels with the event instead of being used to
+// suppress it. A responder that stamped "slack" unconditionally would pass the
+// test above, which runs one transport.
+func TestAnnounceNamesItsOriginatingTransportAndRoot(t *testing.T) {
+	for _, tt := range []struct{ transport, root string }{
+		{"slack", "111.222"},
+		{"matrix", "$evt:example.org"},
+	} {
+		t.Run(tt.transport, func(t *testing.T) {
+			f := &fakeForge{}
+			r, sink := newAnnouncingResponder(t, f)
+			tc := putContext(t, r, Context{Transport: tt.transport, Root: tt.root, CuratedURL: "https://github.com/o/r/pull/42"})
+
+			if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x"); err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+			drainAnnouncements(t, r)
+
+			got := sink.updates()
+			if len(got) != 1 {
+				t.Fatalf("announcements = %d, want 1", len(got))
+			}
+			if got[0].Transport != tt.transport {
+				t.Errorf("Transport = %q, want %q — the origin is read from the thread, never assumed", got[0].Transport, tt.transport)
+			}
+			if got[0].Root != tt.root {
+				t.Errorf("Root = %q, want %q", got[0].Root, tt.root)
+			}
+		})
+	}
+}
+
+// TestAnnounceNeverPostsIntoTheThread is the other half of that decision,
+// asserted end to end through the real transport-facing entry point: an
+// announcement is a SECOND destination, not a second message in the thread.
+//
+// Driven through Mention rather than Responder because Mention is the only
+// thing in this package that can post into a thread at all. Exactly one reply
+// goes to the Replier, and the announcement reaches the sink instead.
+func TestAnnounceNeverPostsIntoTheThread(t *testing.T) {
+	f, rep := &fakeForge{}, &fakeReplier{}
+	m := newTestMention(t, f, rep)
+	sink := &fakeKBSink{}
+	m.Responder.Announcer = NewKBAnnouncer(sink, silentLog())
+	if err := m.Registry.Put(Context{Transport: "slack", Root: "111.222", Channel: "C1", CuratedURL: "https://github.com/o/r/pull/42"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	m.HandleMention(context.Background(), "C1", "111.222", "alice", "<@U0BOT> note: spot reclaim", nil)
+	drainAnnouncements(t, m.Responder)
+
+	if len(rep.replies) != 1 {
+		t.Fatalf("replies into the thread = %d, want exactly 1 — the announcement must not post a second one", len(rep.replies))
+	}
+	if got := sink.updates(); len(got) != 1 {
+		t.Fatalf("announcements = %d, want exactly 1", len(got))
+	}
+}
+
+// TestAnnounceNothingWhenNothingLanded is the assertion this package has
+// shipped wrong three times: an operation that did not happen must not report
+// as though it did. Every path that leaves the knowledge base untouched is
+// asserted SEPARATELY — one of them silently regressing behind another's pass
+// is exactly how that class of bug survives.
+func TestAnnounceNothingWhenNothingLanded(t *testing.T) {
+	assertSilent := func(t *testing.T, r *Responder, sink *fakeKBSink) {
+		t.Helper()
+		drainAnnouncements(t, r)
+		if got := sink.updates(); len(got) != 0 {
+			t.Fatalf("announced %+v; nothing was written, so there is nothing to announce", got)
+		}
+	}
+
+	t.Run("throttled", func(t *testing.T) {
+		f := &fakeForge{}
+		r, sink := newAnnouncingResponder(t, f)
+		// A one-event window with its one event already spent: ratelimit.New(0, …)
+		// means UNLIMITED, not "refuse everything".
+		r.ForgeWrites = ratelimit.New(1, time.Hour)
+		if !r.ForgeWrites.Allow() {
+			t.Fatal("the window refused its first event; this test cannot reach the throttled path")
+		}
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x")
+		if err != nil {
+			t.Fatalf("a throttle is not an error: %v", err)
+		}
+		if !strings.Contains(reply, "paused") {
+			t.Fatalf("reply = %q, want the throttle message — this test did not reach the throttled path", reply)
+		}
+		assertSilent(t, r, sink)
+	})
+
+	t.Run("comment failed", func(t *testing.T) {
+		f := &fakeForge{commErr: errors.New("forge down")}
+		r, sink := newAnnouncingResponder(t, f)
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x"); err == nil {
+			t.Fatal("a failed comment must still be an error")
+		}
+		assertSilent(t, r, sink)
+	})
+
+	t.Run("open PR failed", func(t *testing.T) {
+		f := &fakeForge{openErr: errors.New("forge down")}
+		r, sink := newAnnouncingResponder(t, f)
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222"})
+
+		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x"); err == nil {
+			t.Fatal("a failed OpenPR must still be an error")
+		}
+		assertSilent(t, r, sink)
+	})
+
+	t.Run("open-check failed", func(t *testing.T) {
+		f := &fakeForge{prOpenErr: errors.New("forge unreachable")}
+		r, sink := newAnnouncingResponder(t, f)
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x"); err == nil {
+			t.Fatal("an unreachable forge must still be an error")
+		}
+		assertSilent(t, r, sink)
+	})
+
+	t.Run("capped", func(t *testing.T) {
+		f := &fakeForge{}
+		r, sink := newAnnouncingResponder(t, f)
+		r.MaxNotesPerThread = 1
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", Notes: 1, CuratedURL: "https://github.com/o/r/pull/42"})
+
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		if !strings.Contains(reply, "note limit") {
+			t.Fatalf("reply = %q, want the per-thread cap message — this test did not reach the capped path", reply)
+		}
+		assertSilent(t, r, sink)
+	})
+
+	// The model answered but proposed nothing to file: "record nothing", not an
+	// omission. There is no write, so there is no announcement — a channel must
+	// not learn about a question that produced no knowledge.
+	t.Run("no note proposed", func(t *testing.T) {
+		f := &fakeForge{}
+		r, sink := newAnnouncingResponder(t, f)
+		r.Chat = &Chat{Model: &fakeChatModel{resp: wellFormedReply("The CNI was ruled out.", "")}, Log: silentLog()}
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> was it the CNI?"); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		if c, o := f.counts(); c != 0 || o != 0 {
+			t.Fatalf("forge calls = %d/%d, want 0/0 — this test did not reach the empty-kb_note path", c, o)
+		}
+		assertSilent(t, r, sink)
+	})
+
+	// The default deployment: no chat layer, so freeform records nothing at all.
+	t.Run("freeform with chat off", func(t *testing.T) {
+		f := &fakeForge{}
+		r, sink := newAnnouncingResponder(t, f)
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> was it the CNI?")
+		if err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		if reply != FreeformNotRecordedReply {
+			t.Fatalf("reply = %q, want FreeformNotRecordedReply", reply)
+		}
+		assertSilent(t, r, sink)
+	})
+}
+
+// TestAnnounceSurvivesAFailedCounterWriteBack is the other side of the test
+// above: everything that DID land must be announced, including when a later
+// bookkeeping step fails.
+//
+// record()'s own comment says the announce sits ahead of the counter write-back
+// "because it must not depend on either: the entry is on the forge, and neither
+// a truncated preview nor a failed counter changes that it landed." Nothing
+// asserted it. Moving r.announce below the write-back and gating it on
+// Registry.Update succeeding passed ./internal/thread in full, and that path is
+// real rather than theoretical — an entry that aged out of the registry, or a
+// disabled one, is exactly what TestHandleUncountableWriteIsSurfaced drives.
+// Under that gate the note is permanently on the forge and no channel is ever
+// told, which is the silent-write failure this whole feature exists to remove,
+// arriving through the one path that also returns an error to the human.
+//
+// tc is deliberately never Put into the registry, so the Notes++ write-back
+// misses and record() returns its error.
+func TestAnnounceSurvivesAFailedCounterWriteBack(t *testing.T) {
+	f := &fakeForge{}
+	r, sink := newAnnouncingResponder(t, f)
+	const prURL = "https://github.com/o/r/pull/42"
+	tc := Context{Transport: "slack", Root: "111.222", CuratedURL: prURL}
+
+	reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: spot reclaim")
+	if err == nil {
+		t.Fatal("test setup: an uncountable write must still surface as an error, or this test is not on the path it exists for")
+	}
+	if len(f.comments) != 1 {
+		t.Fatalf("the forge write itself must have landed; comments = %d", len(f.comments))
+	}
+	if !strings.Contains(reply, "I saved that") {
+		t.Fatalf("reply = %q, want the counter warning — this test did not reach the uncountable path", reply)
+	}
+
+	drainAnnouncements(t, r)
+	got := sink.updates()
+	if len(got) != 1 {
+		t.Fatalf("announcements = %d, want 1 — the entry is on the forge, and a counter that could not be written does not unwrite it", len(got))
+	}
+	if got[0].URL != prURL {
+		t.Errorf("URL = %q, want %q — the announcement must still name the write that landed", got[0].URL, prURL)
+	}
+	if got[0].Note != "spot reclaim" {
+		t.Errorf("Note = %q, want the text that reached the forge", got[0].Note)
+	}
+}
+
+// TestAnnounceWithNoSinkIsOffAndDoesNotPanic pins the package's nil-safe
+// contract — the one Budget, Metrics and Log on this same struct already
+// follow. Announcements are opt-in (notify.thread.announce_kb_updates defaults
+// to false), so the UNWIRED responder is the common deployment and must not be
+// the one that panics.
+func TestAnnounceWithNoSinkIsOffAndDoesNotPanic(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	if r.Announcer != nil {
+		t.Fatal("test setup: newTestResponder must leave announcements unwired")
+	}
+	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+	// A landed write, the throttled path, and the open_pr path: every branch
+	// that touches the announcement, with nothing to announce to.
+	if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	tc2 := putContext(t, r, Context{Transport: "slack", Root: "333.444"})
+	if _, err := r.Handle(context.Background(), tc2, "alice", "<@U0BOT> note: y"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+
+	// "Off" is ONE value, not a flag beside a sink: constructing an announcer
+	// with no sink yields no announcer, so there is no half-wired state in
+	// which announcements are enabled with nowhere to go.
+	if a := NewKBAnnouncer(nil, silentLog()); a != nil {
+		t.Errorf("NewKBAnnouncer(nil) = %+v, want nil — a missing sink means announcements are off", a)
+	}
+	// And every method is safe on that nil, so a caller never needs its own
+	// nil check before draining at shutdown.
+	var off *KBAnnouncer
+	off.deliver(context.Background(), providers.KBUpdate{})
+	off.Drain(context.Background())
+}
+
+// TestAnnounceFailureDoesNotChangeTheReply pins that the announcement is
+// best-effort in the strongest sense available: the bytes the human reads are
+// IDENTICAL with a failing sink and with no sink at all, and the error the
+// caller sees is unchanged.
+//
+// The baseline is computed by running the same message through a responder
+// with announcements off, rather than by writing the expected string out —
+// there is then no expectation to quietly adjust if the reply ever changes.
+func TestAnnounceFailureDoesNotChangeTheReply(t *testing.T) {
+	const msg = "<@U0BOT> note: spot reclaim, not OOM"
+	newCase := func(t *testing.T) (*Responder, Context) {
+		t.Helper()
+		r := newTestResponder(t, &fakeForge{})
+		return r, putContext(t, r, Context{Transport: "slack", Root: "111.222", Title: "OOM", CuratedURL: "https://github.com/o/r/pull/42"})
+	}
+
+	quiet, quietCtx := newCase(t)
+	baseline, baselineErr := quiet.Handle(context.Background(), quietCtx, "alice", msg)
+	if baselineErr != nil {
+		t.Fatalf("baseline Handle: %v", baselineErr)
+	}
+
+	loud, loudCtx := newCase(t)
+	sink := &fakeKBSink{err: errors.New("channel_not_found")}
+	loud.Announcer = NewKBAnnouncer(sink, silentLog())
+	reply, err := loud.Handle(context.Background(), loudCtx, "alice", msg)
+	if err != nil {
+		t.Errorf("Handle returned %v; a failing announcement must never fail the write that already landed", err)
+	}
+	if reply != baseline {
+		t.Errorf("reply changed when the sink failed.\ngot:\n%q\nwant:\n%q", reply, baseline)
+	}
+	drainAnnouncements(t, loud)
+	if got := sink.updates(); len(got) != 1 {
+		t.Fatalf("announcements = %d, want 1 — the sink must still have been tried", len(got))
+	}
+}
+
+// TestAnnounceDoesNotDelayTheReply is why the delivery is detached rather than
+// inline. A sink is a network call to a chat system; a slow or wedged one must
+// not hold up the acknowledgement to the human whose note already landed.
+//
+// Proven without a timing threshold: the sink blocks until this test releases
+// it, and the release happens only AFTER Handle has returned. A synchronous
+// implementation could not reach that point, and fails on the deadline below
+// rather than deadlocking the suite.
+func TestAnnounceDoesNotDelayTheReply(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	sink := &fakeKBSink{entered: make(chan struct{}), release: make(chan struct{})}
+	r.Announcer = NewKBAnnouncer(sink, silentLog())
+	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+	type result struct {
+		reply string
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		reply, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: spot reclaim")
+		done <- result{reply, err}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Handle did not return while the sink was blocked — the announcement is sitting on the reply path")
+	}
+	if got.err != nil {
+		t.Fatalf("Handle: %v", got.err)
+	}
+	if !strings.Contains(got.reply, "#42") {
+		t.Errorf("reply = %q, want the human told where their note landed", got.reply)
+	}
+
+	// The delivery really was in flight, not skipped. Bounded, so an
+	// announcement that never happens fails here rather than wedging the suite.
+	select {
+	case <-sink.entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the sink was never called — the write landed and nothing announced it")
+	}
+	close(sink.release)
+	drainAnnouncements(t, r)
+	if u := sink.updates(); len(u) != 1 {
+		t.Fatalf("announcements = %d, want 1", len(u))
+	}
+}
+
+// TestAnnounceIsDrainable pins that detached does not mean unaccounted for: an
+// in-flight delivery is waited on, so shutdown does not drop an announcement
+// for a write that already reached the forge.
+func TestAnnounceIsDrainable(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	sink := &fakeKBSink{release: make(chan struct{})}
+	r.Announcer = NewKBAnnouncer(sink, silentLog())
+	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+	if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	go func() { time.Sleep(50 * time.Millisecond); close(sink.release) }()
+	drainAnnouncements(t, r)
+
+	if got := sink.updates(); len(got) != 1 {
+		t.Fatalf("Drain returned with %d/1 deliveries finished", len(got))
+	}
+}
+
+// TestAnnounceIsBoundedByTheForgeWriteWindow is the bounding analysis stated as
+// a test rather than as an assumption in a comment.
+//
+// The claim is that announcements need no ceiling of their own because every
+// one of them follows a forge write, and ForgeWrites already caps those
+// globally per hour. What that reduces to is a 1:1 invariant — announcements
+// equal landed forge writes, never more — and this drives more messages than
+// the window allows to pin exactly that: the throttled attempts produce a reply
+// and nothing else.
+func TestAnnounceIsBoundedByTheForgeWriteWindow(t *testing.T) {
+	f := &fakeForge{}
+	r, sink := newAnnouncingResponder(t, f)
+	r.ForgeWrites = ratelimit.New(2, time.Hour)
+	// The per-thread cap must not be what stops this: tc is passed unchanged
+	// each time, so tc.Notes stays 0 and only the window can refuse.
+	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+	for i := 0; i < 5; i++ {
+		if _, err := r.Handle(context.Background(), tc, "alice", fmt.Sprintf("<@U0BOT> note: attempt %d", i)); err != nil {
+			t.Fatalf("Handle %d: %v", i, err)
+		}
+	}
+	drainAnnouncements(t, r)
+
+	comments, opened := f.counts()
+	if comments != 2 || opened != 0 {
+		t.Fatalf("forge writes = %d comments / %d opened, want 2/0 — the window must have refused the rest", comments, opened)
+	}
+	if got := sink.updates(); len(got) != comments {
+		t.Errorf("announcements = %d, want %d — one per LANDED forge write, and none for a throttled attempt", len(got), comments)
+	}
+}
+
+// TestAnnounceReportsTheNoteAsWritten pins the redaction guarantee at what is a
+// NEW egress: the announcement leaves RunLore for every configured sink, so it
+// must carry the post-redaction, post-cap text the entry carries — never the
+// caller's raw input.
+//
+// The author name goes through the same masking, because it is transport-
+// reported text that this event now publishes somewhere the entry's own
+// rendering does not reach.
+func TestAnnounceReportsTheNoteAsWritten(t *testing.T) {
+	const secret = "ghp_" + "ABCDEFGHIJKLMNOPQRSTUVWX"
+	f := &fakeForge{}
+	r, sink := newAnnouncingResponder(t, f)
+	r.MaxNoteBytes = 200
+	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+	raw := "the deploy token " + secret + " leaked; " + strings.Repeat("padding ", 60)
+
+	if _, err := r.Handle(context.Background(), tc, "alice "+secret, "<@U0BOT> note: "+raw); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	drainAnnouncements(t, r)
+
+	got := sink.updates()
+	if len(got) != 1 {
+		t.Fatalf("announcements = %d, want 1", len(got))
+	}
+	if strings.Contains(got[0].Note, "ghp_") {
+		t.Errorf("the announced note still carries the secret:\n%q", got[0].Note)
+	}
+	if !strings.Contains(got[0].Note, "[REDACTED]") {
+		t.Errorf("the announced note carries no mask where the secret was:\n%q", got[0].Note)
+	}
+	if len(got[0].Note) > r.MaxNoteBytes {
+		t.Errorf("the announced note is %d bytes, want at most MaxNoteBytes (%d)", len(got[0].Note), r.MaxNoteBytes)
+	}
+	if strings.Contains(got[0].Author, "ghp_") {
+		t.Errorf("the announced author still carries the secret: %q", got[0].Author)
+	}
+	if len(f.comments) != 1 {
+		t.Fatalf("comments = %d, want 1", len(f.comments))
+	}
+	// Byte-identical to what reached the forge: an announcement that described a
+	// different string than the entry holds would be a second, drifting account
+	// of the same write.
+	if !strings.Contains(f.comments[0].body, got[0].Note) {
+		t.Errorf("the announced note is not byte-identical to the text written to the forge.\nannounced:\n%q\nbody:\n%s", got[0].Note, f.comments[0].body)
+	}
+}
+
+// TestAnnounceCarriesTheModelDraftedNote drives the route the announcement
+// matters most on: with model.chat wired, RunLore's own model wrote the note,
+// and the people who were not reading that thread learn about it only through
+// this event.
+func TestAnnounceCarriesTheModelDraftedNote(t *testing.T) {
+	f := &fakeForge{}
+	r, sink := newAnnouncingResponder(t, f)
+	const drafted = "The real cause was a spot-node reclaim, not the CNI."
+	r.Chat = &Chat{Model: &fakeChatModel{resp: wellFormedReply("Noted.", drafted)}, Log: silentLog()}
+	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
+
+	if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> it was actually a spot reclaim"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	drainAnnouncements(t, r)
+
+	got := sink.updates()
+	if len(got) != 1 {
+		t.Fatalf("announcements = %d, want 1", len(got))
+	}
+	if got[0].Note != drafted {
+		t.Errorf("Note = %q, want the model's drafted text %q", got[0].Note, drafted)
+	}
+	if got[0].Author != "alice" {
+		t.Errorf("Author = %q, want the human whose message produced the draft", got[0].Author)
+	}
+}
+
+// TestKBRouteVocabulariesAgree pins the mapping between this package's route
+// names and the providers vocabulary the event uses. They spell the two routes
+// identically today; a direct string conversion would keep compiling — and
+// start emitting a route no consumer recognises — the moment either side is
+// renamed.
+//
+// Both sides are pinned to their LITERAL spelling, not merely to each other.
+// kbRoute switches on RouteComment and returns providers.KBRouteComment, so
+// `kbRoute(RouteComment) == providers.KBRouteComment` is true for any pair of
+// values whatever: rename RouteComment to "commented" and the switch still
+// matches it, still returns the providers constant, and the assertion still
+// holds while every dashboard series and every consumer reading the old word
+// goes quiet. These four strings are a wire vocabulary — RouteComment and
+// RouteOpenPR are also the "route" attribute ThreadNotesWritten is labelled
+// with (see their doc comment), and the providers pair is what a KBUpdate
+// consumer switches on — so changing one is an operator-visible break that
+// belongs in a diff.
+func TestKBRouteVocabulariesAgree(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"RouteComment", RouteComment, "comment"},
+		{"RouteOpenPR", RouteOpenPR, "open_pr"},
+		{"providers.KBRouteComment", string(providers.KBRouteComment), "comment"},
+		{"providers.KBRouteOpenPR", string(providers.KBRouteOpenPR), "open_pr"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q — this word is on a metric label or in a delivered event, "+
+				"so renaming it silently retires whatever was reading the old one", tc.name, tc.got, tc.want)
+		}
+	}
+	if got := kbRoute(RouteComment); got != providers.KBRouteComment {
+		t.Errorf("kbRoute(%q) = %q, want %q", RouteComment, got, providers.KBRouteComment)
+	}
+	if got := kbRoute(RouteOpenPR); got != providers.KBRouteOpenPR {
+		t.Errorf("kbRoute(%q) = %q, want %q", RouteOpenPR, got, providers.KBRouteOpenPR)
 	}
 }

--- a/website/content/docs/concepts/reviewing-knowledge.md
+++ b/website/content/docs/concepts/reviewing-knowledge.md
@@ -58,6 +58,22 @@ answered too — from the investigation's own evidence — and RunLore proposes 
 itself when your message contained something durable. A model-drafted note is
 marked as model-drafted, never filed as your words.
 
+**Announcing a write to everyone else.** By default a captured note is reported only
+into the thread it came from, so the knowledge lands but nobody outside that thread
+learns that it did. Setting `notify.thread.announce_kb_updates: true` (default
+**false**) also posts every landed write to each configured notifier's own channel or
+room — the same place investigation findings go — naming the pull request, the entry,
+who wrote it, and quoting the note. Two consequences to know before turning it on:
+
+- **With one transport configured you see two messages for one write**: the thread
+  reply, which answers the person who typed, and the channel post, which reaches
+  everyone who was not reading that thread. That is the feature rather than
+  duplication — the announcement never posts back into the thread.
+- **The announcement carries note content.** A note written in a thread nobody else
+  was watching is broadcast to every sink you have configured — the other chat
+  system, any webhook endpoint. That is an operator's call to make knowingly, which
+  is why the key is off unless you set it.
+
 Setup and the full cost picture:
 [Slack]({{< relref "/docs/integrations/notifications/slack.md" >}}) ·
 [Matrix]({{< relref "/docs/integrations/notifications/matrix.md" >}}) ·

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -634,6 +634,16 @@ transports), `max_note_bytes` (default **8192**, one human message's input), `re
 **168h**), `registry_max` (default **2000**), plus `chat_calls_per_hour` and `chat_tokens_per_hour`
 — which apply only with `model.chat` set, and are covered in full below.
 
+The same block holds the one key that is a switch rather than a ceiling:
+`announce_kb_updates` (default **false**). With it on, every knowledge write that lands is
+also announced to each configured notifier's own channel or room — never back into the thread
+that produced it, which already received the reply — so one write produces both a thread reply
+and a channel post. The announcement quotes the note, so a note written in one thread reaches
+every sink you have configured; that is why it is opt-in. See
+[Reviewing knowledge → Thread capture]({{< relref "/docs/concepts/reviewing-knowledge.md" >}})
+and the [Slack]({{< relref "/docs/integrations/notifications/slack.md" >}}) /
+[Matrix]({{< relref "/docs/integrations/notifications/matrix.md" >}}) pages.
+
 ### Conversational replies and what they cost
 
 **Off by default.** Setting a `model.chat` block turns it on: RunLore answers an addressed thread

--- a/website/content/docs/integrations/notifications/matrix.md
+++ b/website/content/docs/integrations/notifications/matrix.md
@@ -111,6 +111,44 @@ for. That widening is real and worth understanding before you flip the flag: see
 Matrix thread
 capture]({{< relref "/docs/security/security-model.md#matrix-thread-capture-notifymatrixthread_capture--a-widened-sync-filter" >}}).
 
+### Announce a knowledge write to the room
+
+A captured note is reported into the thread it came from, and nowhere else — so the
+knowledge lands, but the room never learns it did. `announce_kb_updates` changes that:
+every write that reaches the forge is also posted to the room this notifier delivers
+findings to.
+
+```yaml
+notify:
+  matrix:
+    homeserver: https://matrix.org
+    room_id: "!yourroom:matrix.org"
+    access_token_env: MATRIX_TOKEN
+    thread_capture: true
+  thread:
+    announce_kb_updates: true    # default false
+```
+
+The room post names the pull request, the entry that was created, who the note came
+from and which chat system they typed it in, and quotes the note itself — capped at
+512 bytes, with the pull request holding the full text. It is a plain `m.notice` with
+no `m.thread` relation, carrying the same secret-redacted, capped text that reached
+the forge, and everything a human or the model wrote in it is neutralised before
+sending: an `@room` inside a note is rendered readable but inert, never a room-wide
+notification.
+
+Two things to know before turning it on:
+
+- **One write produces two messages, and that is intended.** The thread reply answers
+  the person who typed; the room post reaches everyone who was not reading that thread
+  — which is the whole point of the feature. The announcement never posts back into the
+  thread, so it is a second destination rather than a duplicate. With Matrix as your
+  only transport you will still see both.
+- **The announcement carries note content.** A note written in a thread nobody else was
+  watching is broadcast to every sink you have configured — this room, a Slack channel
+  if you run both, any `webhook` endpoint. That is your decision to take knowingly,
+  which is why the key is off unless you set it.
+
 ### Conversational replies
 
 Without `model.chat`, anything you say in the thread that is not `note:` gets a fixed reply telling

--- a/website/content/docs/integrations/notifications/slack.md
+++ b/website/content/docs/integrations/notifications/slack.md
@@ -132,6 +132,42 @@ it's even been tried.
 Only `app_mention` is subscribed — RunLore reads nothing in channels where it
 was not directly addressed.
 
+### Announce a knowledge write to the channel
+
+A captured note is reported into the thread it came from, and nowhere else — so
+the knowledge lands, but the channel never learns it did. `announce_kb_updates`
+changes that: every write that reaches the forge is also posted to the channel
+this notifier delivers findings to.
+
+```yaml
+notify:
+  slack:
+    bot_token_env: SLACK_BOT_TOKEN
+    channel: C0123456789
+    thread_capture: true
+  thread:
+    announce_kb_updates: true    # default false
+```
+
+The channel post names the pull request, the entry that was created, who the note
+came from and which chat system they typed it in, and quotes the note itself —
+capped at 512 bytes, with the pull request holding the full text. It carries the
+same secret-redacted, capped text that reached the forge, and everything a human
+or the model wrote in it is escaped before posting: a `<!channel>` inside a note
+renders as literal text, never as a channel-wide ping.
+
+Two things to know before turning it on:
+
+- **One write produces two messages, and that is intended.** The thread reply
+  answers the person who typed; the channel post reaches everyone who was not
+  reading that thread — which is the whole point of the feature. The announcement
+  never posts back into the thread, so it is a second destination rather than a
+  duplicate. With Slack as your only transport you will still see both.
+- **The announcement carries note content.** A note written in a thread nobody else
+  was watching is broadcast to every sink you have configured — this channel, a
+  Matrix room if you run both, any `webhook` endpoint. That is your decision to
+  take knowingly, which is why the key is off unless you set it.
+
 ### Conversational replies
 
 Without `model.chat`, anything you say in the thread that is not `note:` gets a


### PR DESCRIPTION
Follow-on to #484. Two things the thread-interaction series was missing: the human could not see **what** was recorded, and a knowledge write was visible only to whoever happened to be reading that thread.

**Stacked on #484.** Review that first; this PR's diff against `main` includes it.

## What changed

**The reply says what landed.**

```
📝 Opened knowledge-base PR #99 with your note — https://github.com/o/r/pull/99
Entry: Operator note: OOM in payments
> stale since Karpenter
```

and it stays honest about who wrote it:

```
> Noted — that changes the root cause.
📝 Opened knowledge-base PR #99 with a note drafted from your message — https://…
Drafted by RunLore from your message — not your own words, pending review:
> The real cause was a spot-node reclaim, not the CNI.
```

That second status line used to read "with your note" one line above "not your own words". It was pre-existing, but this PR is about telling the human the truth about what was recorded, so it moved.

**A landed write is announced to every configured sink**, behind `notify.thread.announce_kb_updates` (default **false**). Slack, Matrix and the webhook sink implement it; the templated sink deliberately does not, and a test says so — its template is operator-written against the investigation payload, so a KB update through it would render an investigation of zero values.

Opt-in because it adds volume to channels that did not ask for it, and because **the announcement carries note content**: a note written in a private thread reaches every configured sink. With a single transport you will see both a thread reply and a channel post for one write — intended, and documented rather than left to look like duplication.

## Guardrails

Announcements are **1:1 with landed forge writes** and inherit the `ForgeWrites` hourly ceiling — traced, not assumed: the check sits once at the top of `write()`, both result constructions are downstream of a successful forge call, and `record()` is the only caller. Nothing is announced for a write that was throttled, capped, forge-failed, or never proposed; each is asserted separately.

Delivery is async on a bounded dispatcher. Swallowing a sink error stops a failing sink changing *what* the human is told; only detaching stops a slow one changing *when* — the fan-out runs inside a mention handler that is already under a deadline. It is drained at shutdown, after everything that can still schedule an announcement and before the investigation queue, since they share one deadline.

**The outgoing thread reply is now bounded at the transport.** It was not before: `model.chat.max_tokens` is operator-configurable with no upper limit, so a raised value made the post exceed Slack's budget, the post failed, and the human was told nothing — while their note *was* written. Bounding runs after escaping (`&` → `&amp;` expands 5x, so bounding the composed text bounds the wrong thing), drops whole lines so a cut cannot leave prose at the left margin where RunLore's own claims sit, and drops the model's prose before the record of what happened.

## Security

The announcement is a new egress for model- and human-authored text, so it carries the same guarantees as the thread reply from its first commit: untrusted spans escaped per transport (`<!channel>` on Slack, `@room` on Matrix), the note blockquoted so it cannot pose as a RunLore status line, and every rendered field length-capped.

Review found one live defect, fixed here: **U+2028 escaped the blockquote.** Both quoting functions split on `"\n"` only, so a mandatory line break that is not `"\n"` rendered a second visual line at the left margin — byte-for-byte matching RunLore's own headline format, in the channel where findings go. Fixed in one shared helper covering UAX #14's mandatory-break classes, which also dissolved the reason the two copies existed. A third copy in the entry-body path was found and fixed the same way; 6 of its 8 break spellings failed before the fix.

The doc comment that ranked the blockquote as load-bearing and the glyph strip as belt-and-braces was corrected too — that ranking is what justified shipping the announcement with the blockquote alone, and for this input class the blockquote is the measure that fails.

## Testing

Every load-bearing property is pinned by a test watched failing against a deliberately broken implementation. The final review ran 30 mutations; 9 escaped and all are closed here. The most useful catch was a category rather than a bug: **every byte ceiling was asserted against itself**, so `slackReplyBytes` could be raised to three times Slack's real limit and a 50 KB reply went on the wire with the suite green. Each is now pinned to a literal, and each fix was verified by showing the *original* escaping mutation failing the new pin while the old test still passed.

Guards added: a reflection test requiring every `KBUpdate` field to be classified trusted/untrusted *and* rendered/withheld; the `RunServe` wiring guard extended to the notifier hop and to both ends of the drain ordering, reporting itself inert when it cannot resolve its targets; and `docsguard` extended to boolean defaults and to the documented 512-byte quote cap.

Gate: `go build`, `go vet`, `go test ./... -race` (uncached), `gofmt -l .` silent, `golangci-lint` `0 issues`. Site builds clean.

## Known, not fixed

- **Two other unbounded posts of the same shape as the reply fix**: `slackProgressMessage` and `Matrix.Deliver` both put unbounded model-derived text into a transport field. Not a one-line reuse — the reply helper keeps the tail because the record sits at the end, whereas a summary's head is what matters, and Matrix's HTML body needs bounding consistently without splitting a tag. Analysis in the branch; own PR.
- `TestKBUpdateAnnouncementIsBoundedPerTransport`'s outer assertion is still ~4x loose, though every cap it sums is now literal-pinned.
- The boolean docsguard's code side is structurally unfalsifiable (a plain `bool` with no unmarshaler), so a pass means "no page claims the wrong default", never "the default is verified". Stated in its doc comment rather than left implied.
