### PR TITLE
feat(investigate)!: cap what one investigation may spend, in tokens and in dollars

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,7 @@ Thanks for contributing to RunLore! Keep the change small and focused
 - [ ] Test added first (TDD) — the failing test came before the implementation
 - [ ] Docs updated (README / `docs/`) if behavior or config changed
 - [ ] Respects **read-only-first**: no new cluster writes; the only writes are to Git via reviewed PRs
+- [ ] If this changes what an existing config key **means**: the PR **title** carries `!`
+      (`fix(scope)!: …`) and the squash body carries a `BREAKING CHANGE:` footer with the migration
+      note — that footer is the only thing that reaches `CHANGELOG.md` besides the subject line
+      (see [Releasing](../CONTRIBUTING.md#releasing))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,23 @@ the rendered HTML.
 Releases are fully automated from the [Conventional Commits](https://www.conventionalcommits.org/) you
 already write — there is nothing to tag by hand.
 
+> ### Changing existing behaviour? Say so, or the migration note goes nowhere.
+>
+> `CHANGELOG.md` renders **only the commit subject line** for every type. However good the explanation
+> in your commit body, an operator upgrading never sees it — the one exception is a
+> `BREAKING CHANGE:` footer, whose prose release-please lifts verbatim into a `⚠ BREAKING CHANGES`
+> section at the top of the release. So a change that alters what an existing config key *means* needs:
+>
+> 1. **`!` after the type/scope** — `fix(investigate)!: …` — and, because PRs are **squash-merged**,
+>    the PR **title** is what release-please parses, not the commits on your branch. Put the marker
+>    there.
+> 2. **A `BREAKING CHANGE:` footer in the squash-commit body** (editable in the GitHub merge dialog)
+>    carrying the migration paragraph: what changed, what an operator will observe, and what to set.
+>
+> Nothing in CI lints this — a missing marker fails silently by simply not appearing in the changelog,
+> which is why it is written down here. Pre-1.0 a breaking change bumps the **minor** version
+> (`bump-minor-pre-major` in `release-please-config.json`); it does not cut a 1.0.0.
+
 1. **You merge `feat:` / `fix:` / etc. PRs to `main`** as usual.
 2. **[release-please](https://github.com/googleapis/release-please) opens (and keeps updating) a release
    PR** — `.github/workflows/release-please.yml`. It computes the next [SemVer](https://semver.org/) from

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -110,15 +110,29 @@ config:
     name: runlore-leader
   # Cost controls — these ship with SAFE, BOUNDED defaults (not unlimited) so a
   # default install can't run away in LLM spend. Tune for your environment, or set
-  # a field to 0 for unlimited (where noted). Coalesce/rate-limit sub-fields left
+  # a field to -1 for unlimited (where noted). Coalesce/rate-limit sub-fields left
   # unset default in the agent to 30s debounce, 2m max-wait, 50 batch, 10m cooldown,
   # 1h window.
   investigation:
-    # Per-investigation context ceiling (estimated request tokens): when crossed, the
-    # agent is nudged to wrap up, then hard-stops and delivers what it has rather than
-    # growing context unbounded. 0 = unlimited.
+    # CUMULATIVE token ceiling for ONE investigation: the provider-reported tokens of
+    # every model call it makes (loop + verify), plus a check that the next request
+    # alone doesn't exceed this. When crossed, the agent is nudged to wrap up and
+    # forced to submit findings, then hard-stops and delivers what it has.
+    # -1 = unlimited.
+    #
+    # NOTE this bounds the WHOLE RUN, not one request — it used to bound only the next
+    # request, so 100000 now binds far earlier than it did before. If investigations
+    # start reporting result="budget_exceeded", raise this to the total you are willing
+    # to pay per incident (summed across all turns), not the size of one turn.
     max_tokens_per_investigation: 100000
-    # Cap each tool result fed back to the model (truncates large logs/diffs). 0 = unlimited.
+    # The same ceiling in USD, compared against the running estimated spend. OPT-IN:
+    # unset/0 = no cost ceiling. Deliberately not defaulted — a dollar figure depends on
+    # the model and rates you chose, so RunLore cannot pick one for you.
+    #
+    # REQUIRES model.pricing: with no rates configured there is no cost to compare and
+    # this can never fire (the agent warns loudly at startup if you set it anyway).
+    # max_cost_per_investigation: 2.50
+    # Cap each tool result fed back to the model (truncates large logs/diffs). -1 = unlimited.
     max_tool_output_bytes: 32768
     # How mid-loop history compaction treats the older tool outputs it elides once the
     # estimate crosses 0.7x max_tokens_per_investigation. "elide" (default) drops their

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -124,6 +124,12 @@ config:
     # request, so 100000 now binds far earlier than it did before. If investigations
     # start reporting result="budget_exceeded", raise this to the total you are willing
     # to pay per incident (summed across all turns), not the size of one turn.
+    #
+    # BUDGET FOR THIS NUMBER PLUS ONE REQUEST. The check compares the PROJECTED total
+    # (already spent + the request about to be sent), so a run stops on the first
+    # request that would cross — but that request is still sent, because the nudge has
+    # to give the model a turn to conclude. Measured at these defaults: ~117000 tokens
+    # delivered against a 100000 ceiling (~1.2x).
     max_tokens_per_investigation: 100000
     # The same ceiling in USD, compared against the running estimated spend. OPT-IN:
     # unset/0 = no cost ceiling. Deliberately not defaulted — a dollar figure depends on

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -115,22 +115,32 @@ config:
   # 1h window.
   investigation:
     # CUMULATIVE token ceiling for ONE investigation: the provider-reported tokens of
-    # every model call it makes (loop + verify), plus a check that the next request
-    # alone doesn't exceed this. When crossed, the agent is nudged to wrap up and
-    # forced to submit findings, then hard-stops and delivers what it has.
+    # every model call it makes (loop + verify). When crossed, the agent is nudged to
+    # wrap up and forced to submit findings, then hard-stops and delivers what it has.
     # -1 = unlimited.
     #
+    # A QUARTER of this (100000 here) additionally bounds ONE request's estimated size,
+    # and mid-loop compaction triggers at 70% of that quarter (70000). The two are
+    # different problems: "the run spent too much in total" (reason=tokens_total) is
+    # fixed by raising this number, "one request is too big" (reason=tokens_request) by
+    # lowering max_tool_output_bytes or enabling compaction below.
+    #
     # NOTE this bounds the WHOLE RUN, not one request — it used to bound only the next
-    # request, so 100000 now binds far earlier than it did before. If investigations
-    # start reporting result="budget_exceeded", raise this to the total you are willing
-    # to pay per incident (summed across all turns), not the size of one turn.
+    # request. Read as a run budget the old 100000 default funded four or five steps, so
+    # the default was raised to 400000: an investigation whose every tool result hits
+    # max_tool_output_bytes costs ~327000 tokens over seven model calls, and an ordinary
+    # tool-heavy one (8 KiB results, twelve steps) ~379000. AN EXPLICIT VALUE HERE IS
+    # LEFT ALONE and is now read as a whole-run budget: if you pinned 100000, it still
+    # says 100000 and now means ~four steps. Set it to the total you are willing to pay
+    # per incident (summed across all turns), not the size of one turn.
     #
     # BUDGET FOR THIS NUMBER PLUS ONE REQUEST. The check compares the PROJECTED total
     # (already spent + the request about to be sent), so a run stops on the first
     # request that would cross — but that request is still sent, because the nudge has
-    # to give the model a turn to conclude. Measured at these defaults: ~117000 tokens
-    # delivered against a 100000 ceiling (~1.2x).
-    max_tokens_per_investigation: 100000
+    # to give the model a turn to conclude. That conceded request is itself capped at the
+    # quarter above, so budget ~1.25x. Measured at these defaults: ~467000 tokens
+    # delivered against a 400000 ceiling (~1.17x).
+    max_tokens_per_investigation: 400000
     # The same ceiling in USD, compared against the running estimated spend. OPT-IN:
     # unset/0 = no cost ceiling. Deliberately not defaulted — a dollar figure depends on
     # the model and rates you chose, so RunLore cannot pick one for you.

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -141,7 +141,8 @@ config:
     # Cap each tool result fed back to the model (truncates large logs/diffs). -1 = unlimited.
     max_tool_output_bytes: 32768
     # How mid-loop history compaction treats the older tool outputs it elides once the
-    # estimate crosses 0.7x max_tokens_per_investigation. "elide" (default) drops their
+    # estimate crosses the compaction target: 0.7x the PER-REQUEST budget, itself a
+    # quarter of max_tokens_per_investigation. "elide" (default) drops their
     # bodies for short markers (lossy). "summarize" first asks a model for ONE compact
     # factual digest of the elided batch per compaction event (routed to model.verify when
     # set, else the main model) and keeps that in place of the markers; any summarizer

--- a/deploy/observability/alerts/prometheusrule.yaml
+++ b/deploy/observability/alerts/prometheusrule.yaml
@@ -182,9 +182,11 @@ spec:
             runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreslowresolution"
 
         # 12. Investigation token cost is high.
-        # p95 estimated tokens per investigation over 30m exceeds 100k — a cost
-        # guardrail. 100000 is a starting point; set it from your token budget
-        # and the model's pricing.
+        # runlore_investigation_tokens_estimated records the size of the LAST request an
+        # investigation made, not its cumulative spend, so 100000 is the per-request
+        # bound the agent itself enforces (a quarter of max_tokens_per_investigation's
+        # 400000 default): p95 at that bound means typical runs are ending on a
+        # maximum-size request. Scale it with max_tokens_per_investigation if you retune.
         - alert: RunloreInvestigationCostHigh
           expr: histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[30m])) by (le)) > 100000
           for: 30m
@@ -192,5 +194,5 @@ spec:
             severity: warning
           annotations:
             summary: "RunLore investigation token cost is high"
-            description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — investigations are consuming an unusually large token budget; review cost."
+            description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — typical investigations are ending on a request at the per-request bound; review cost, max_tool_output_bytes and compaction."
             runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationcosthigh"

--- a/deploy/observability/alerts/vmrule.yaml
+++ b/deploy/observability/alerts/vmrule.yaml
@@ -178,9 +178,11 @@ spec:
             runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreslowresolution"
 
         # 12. Investigation token cost is high.
-        # p95 estimated tokens per investigation over 30m exceeds 100k — a cost
-        # guardrail. 100000 is a starting point; set it from your token budget
-        # and the model's pricing.
+        # runlore_investigation_tokens_estimated records the size of the LAST request an
+        # investigation made, not its cumulative spend, so 100000 is the per-request
+        # bound the agent itself enforces (a quarter of max_tokens_per_investigation's
+        # 400000 default): p95 at that bound means typical runs are ending on a
+        # maximum-size request. Scale it with max_tokens_per_investigation if you retune.
         - alert: RunloreInvestigationCostHigh
           expr: histogram_quantile(0.95, sum(rate(runlore_investigation_tokens_estimated_bucket[30m])) by (le)) > 100000
           for: 30m
@@ -188,5 +190,5 @@ spec:
             severity: warning
           annotations:
             summary: "RunLore investigation token cost is high"
-            description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — investigations are consuming an unusually large token budget; review cost."
+            description: "p95 estimated tokens per investigation is {{ $value | humanize }} over the last 30m (>100k) — typical investigations are ending on a request at the per-request bound; review cost, max_tool_output_bytes and compaction."
             runbook_url: "https://github.com/Smana/runlore/blob/main/docs/observability.md#runloreinvestigationcosthigh"

--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -93,7 +93,14 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 		if e.APIKeyEnv != "" {
 			key = os.Getenv(e.APIKeyEnv)
 		}
-		embedder = embed.New(e.BaseURL, e.Model, key)
+		ec := embed.New(e.BaseURL, e.Model, key)
+		// The embeddings endpoint bills like any other model call — once per
+		// hybrid-recall query, and in bulk on every catalog reload — so give it the
+		// shared metrics instance. It reports under provider="embed" on the same
+		// instruments as the main/verify/rerank tiers. That makes the spend visible,
+		// not bounded; see the inventory in docs/configuration/configuration.md.
+		ec.Metrics = metrics
+		embedder = ec
 		log.Info("hybrid recall: embeddings endpoint configured", "base_url", e.BaseURL, "model", e.Model)
 	}
 	// armVecCache persists the embedding cache across restarts (default on with

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -232,3 +232,52 @@ func GitopsEngine(cfg *config.Config) string {
 	}
 	return "flux"
 }
+
+// CostCeilingWithoutPricingWarning decides the startup warning for a cost ceiling
+// that cannot fire, returning "" when no warning is warranted.
+//
+// investigation.max_cost_per_investigation is compared against the investigation's
+// running estimated spend, and that estimate exists only when model.pricing supplies
+// token rates: aggregateUsage sets UsageTotals.Priced (and a CostUSD worth reading)
+// off cfg.Model.Pricing alone. So a ceiling configured without pricing is not a
+// stricter limit that rarely fires — it is structurally incapable of firing, for
+// every investigation, forever. An operator who wrote a dollar figure into their
+// config has stated an intent to cap spend; leaving that intent silently inert is the
+// exact "a limit that is neither enforced nor signalled" shape this warning exists to
+// break. It stays a warning rather than a hard failure because the rest of the
+// deployment is perfectly valid: unpriced token accounting is a supported mode, and
+// refusing to start would punish a config that is merely incomplete.
+//
+// Two distinct dead configurations, two messages, because the fix differs:
+//
+//   - No model.pricing at all — nothing is priced, so add the rates.
+//   - model.pricing present but every rate 0 — cost is computed and is always exactly
+//     $0.00, which is under any positive ceiling. This one is the more dangerous of
+//     the two: the finding footer prints "~$0.00" and the investigation_cost_usd
+//     metric reports zero, so the deployment LOOKS instrumented for cost. A rate card
+//     of all zeros is a placeholder someone meant to fill in.
+//
+// model.verify.pricing is deliberately not consulted: it only overrides the verify
+// pass's rates and inherits model.pricing when unset, so it can neither make an
+// unpriced investigation priced nor rescue an all-zero main rate card.
+func CostCeilingWithoutPricingWarning(cfg *config.Config) string {
+	if cfg.Investigation.MaxCostPerInvestigation <= 0 {
+		return ""
+	}
+	const fix = "Set model.pricing (input_usd_per_mtok, output_usd_per_mtok, cached_input_usd_per_mtok) " +
+		"to your provider's rates, or drop the ceiling and bound spend with " +
+		"investigation.max_tokens_per_investigation instead (docs/configuration/configuration.md)"
+	p := cfg.Model.Pricing
+	if p == nil {
+		return fmt.Sprintf("investigation.max_cost_per_investigation is set ($%g) but model.pricing is not "+
+			"configured, so NO cost is ever computed and the ceiling can never fire — this deployment has no "+
+			"spend limit denominated in currency. "+fix, cfg.Investigation.MaxCostPerInvestigation)
+	}
+	if p.InputUSDPerMTok == 0 && p.OutputUSDPerMTok == 0 && p.CachedInputUSDPerMTok == 0 {
+		return fmt.Sprintf("investigation.max_cost_per_investigation is set ($%g) but every model.pricing rate "+
+			"is 0, so every investigation costs exactly $0.00 and the ceiling can never fire — while the "+
+			"notification footer and runlore_investigation_cost_usd both report a cost, making the deployment "+
+			"look instrumented for spend when it is not. "+fix, cfg.Investigation.MaxCostPerInvestigation)
+	}
+	return ""
+}

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/source"
@@ -248,14 +249,36 @@ func GitopsEngine(cfg *config.Config) string {
 // deployment is perfectly valid: unpriced token accounting is a supported mode, and
 // refusing to start would punish a config that is merely incomplete.
 //
-// Two distinct dead configurations, two messages, because the fix differs:
+// Three dead-or-lying configurations, three messages, because the fix differs:
 //
 //   - No model.pricing at all — nothing is priced, so add the rates.
 //   - model.pricing present but every rate 0 — cost is computed and is always exactly
-//     $0.00, which is under any positive ceiling. This one is the more dangerous of
-//     the two: the finding footer prints "~$0.00" and the investigation_cost_usd
+//     $0.00, which is under any positive ceiling. This one is more dangerous than the
+//     first: the finding footer prints "~$0.00" and the investigation_cost_usd
 //     metric reports zero, so the deployment LOOKS instrumented for cost. A rate card
 //     of all zeros is a placeholder someone meant to fill in.
+//   - model.pricing present with SOME rate at 0 — the ceiling fires, but late, and by
+//     an amount nothing reveals. Every token class RunLore counts is billed by every
+//     provider it speaks: cost() prices uncached input, cached input and output
+//     separately (internal/investigate/cost.go), and all three clients populate
+//     CachedInputTokens (anthropic CacheReadInputTokens, openai
+//     prompt_tokens_details.cached_tokens, gemini cachedContentTokenCount). So a rate
+//     left at 0 does not mean "this class is free", it means a whole class of real
+//     spend is estimated at $0 — the most commonly forgotten being
+//     cached_input_usd_per_mtok, which on a cache-heavy run understates the input term
+//     several-fold while the footer and the metric report a confident wrong number.
+//     This is the all-zero case's own reasoning applied to a rate card that is merely
+//     incomplete rather than empty.
+//
+// Why warn rather than refuse to price (leaving UsageTotals.Priced false, so the
+// ceiling goes inert): that would trade a ceiling that binds late for no ceiling at
+// all, silently, which is precisely the failure the first two messages exist to
+// announce. An incomplete rate card still yields a real, comparable number — it is
+// just an under-estimate — so the honest move is to keep enforcing it and tell the
+// operator which rate is making it loose. A deployment whose provider genuinely does
+// not bill a class separately can silence the warning by setting that rate to the one
+// it shares (e.g. cached_input_usd_per_mtok = input_usd_per_mtok), which costs it
+// nothing because the corresponding token count is then always 0.
 //
 // model.verify.pricing is deliberately not consulted: it only overrides the verify
 // pass's rates and inherits model.pricing when unset, so it can neither make an
@@ -279,5 +302,33 @@ func CostCeilingWithoutPricingWarning(cfg *config.Config) string {
 			"notification footer and runlore_investigation_cost_usd both report a cost, making the deployment "+
 			"look instrumented for spend when it is not. "+fix, cfg.Investigation.MaxCostPerInvestigation)
 	}
+	if missing := unpricedRates(p); len(missing) > 0 {
+		return fmt.Sprintf("investigation.max_cost_per_investigation is set ($%g) but model.pricing leaves %s "+
+			"at 0, so every token of that kind is estimated at $0.00 — the ceiling still fires, but only after "+
+			"materially more real spend than its number, and the notification footer and "+
+			"runlore_investigation_cost_usd both report the same under-estimate. Every provider RunLore speaks "+
+			"bills all three token classes and reports them separately. "+fix,
+			cfg.Investigation.MaxCostPerInvestigation, strings.Join(missing, " and "))
+	}
 	return ""
+}
+
+// unpricedRates names the model.pricing keys left at 0, in the order they appear in
+// the config, so the warning can list every one rather than sending the operator round
+// the loop once per rate.
+func unpricedRates(p *config.Pricing) []string {
+	var missing []string
+	for _, r := range []struct {
+		key  string
+		rate float64
+	}{
+		{"input_usd_per_mtok", p.InputUSDPerMTok},
+		{"output_usd_per_mtok", p.OutputUSDPerMTok},
+		{"cached_input_usd_per_mtok", p.CachedInputUSDPerMTok},
+	} {
+		if r.rate == 0 {
+			missing = append(missing, r.key)
+		}
+	}
+	return missing
 }

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -537,12 +537,22 @@ func TestOutcomeKind(t *testing.T) {
 }
 
 // TestCostCeilingWithoutPricingWarning covers the (ceiling set × pricing shape)
-// matrix. The two dead configurations warn; a ceiling with real rates, and no ceiling
-// at all, stay silent — a warning that fired on a correct config would be muted
-// within a day and take the real ones with it.
+// matrix. Every rate card that cannot price what the provider actually bills warns;
+// a complete rate card, and no ceiling at all, stay silent — a warning that fired on a
+// correct config would be muted within a day and take the real ones with it.
+//
+// The PARTIAL cases are what the all-zero check missed. cached_input_usd_per_mtok is
+// the most commonly forgotten of the three, and all three model providers RunLore
+// speaks report cache reads (anthropic CacheReadInputTokens, openai
+// prompt_tokens_details.cached_tokens, gemini cachedContentTokenCount), so leaving it
+// at 0 prices every cache read at $0: on a cache-heavy run that under-estimates the
+// input term several-fold, the ceiling permits materially more than its number, and
+// the footer plus runlore_investigation_cost_usd report a confident wrong figure. Same
+// "looks instrumented for spend when it is not" failure the all-zero warning catches.
 func TestCostCeilingWithoutPricingWarning(t *testing.T) {
-	rates := &config.Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15}
+	rates := &config.Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15, CachedInputUSDPerMTok: 0.3}
 	zeroed := &config.Pricing{}
+	noCached := &config.Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15}
 
 	tests := []struct {
 		name     string
@@ -553,9 +563,15 @@ func TestCostCeilingWithoutPricingWarning(t *testing.T) {
 	}{
 		{"no ceiling, no pricing", 0, nil, false, ""},
 		{"no ceiling, with pricing", 0, rates, false, ""},
-		{"ceiling with real rates", 2.5, rates, false, ""},
+		{"no ceiling, partial rates", 0, noCached, false, ""},
+		{"ceiling with a complete rate card", 2.5, rates, false, ""},
 		{"ceiling, no pricing at all", 2.5, nil, true, "model.pricing is not configured"},
 		{"ceiling, all rates zero", 2.5, zeroed, true, "every model.pricing rate is 0"},
+		{"ceiling, cached rate omitted", 2.5, noCached, true, "cached_input_usd_per_mtok"},
+		{"ceiling, input rate omitted", 2.5,
+			&config.Pricing{OutputUSDPerMTok: 15, CachedInputUSDPerMTok: 0.3}, true, "input_usd_per_mtok"},
+		{"ceiling, output rate omitted", 2.5,
+			&config.Pricing{InputUSDPerMTok: 3, CachedInputUSDPerMTok: 0.3}, true, "output_usd_per_mtok"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -575,12 +591,30 @@ func TestCostCeilingWithoutPricingWarning(t *testing.T) {
 			}
 			// Every warning must carry the key at issue and a way out; a paragraph
 			// that only says "this is wrong" costs an operator a docs hunt.
-			for _, want := range []string{"max_cost_per_investigation", "model.pricing", "can never fire"} {
+			for _, want := range []string{"max_cost_per_investigation", "model.pricing"} {
 				if !strings.Contains(got, want) {
 					t.Fatalf("message missing %q — it must name the key, the missing input and the consequence: %q", want, got)
 				}
 			}
 		})
+	}
+}
+
+// TestPartialPricingWarningNamesEveryMissingRate pins that the message lists ALL the
+// rates left at 0, not just the first one found, and accuses none that are set. An
+// operator who fixes the one rate the warning named and restarts into the same warning
+// learns to distrust it.
+func TestPartialPricingWarningNamesEveryMissingRate(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Investigation.MaxCostPerInvestigation = 2.5
+	cfg.Model.Pricing = &config.Pricing{OutputUSDPerMTok: 15}
+	got := CostCeilingWithoutPricingWarning(cfg)
+	// The accusation clause must list both unset rates and neither the set one. Pinned
+	// as one phrase rather than three Contains calls because the remedy sentence names
+	// all three keys by design — only the accusation may be selective.
+	const want = "leaves input_usd_per_mtok and cached_input_usd_per_mtok at 0"
+	if !strings.Contains(got, want) {
+		t.Fatalf("the warning must accuse exactly the rates left at 0, want it to say %q: %q", want, got)
 	}
 }
 

--- a/internal/app/config_test.go
+++ b/internal/app/config_test.go
@@ -535,3 +535,65 @@ func TestOutcomeKind(t *testing.T) {
 		t.Fatalf("OutcomeKind(false) = %q, want %q", got, "fresh")
 	}
 }
+
+// TestCostCeilingWithoutPricingWarning covers the (ceiling set × pricing shape)
+// matrix. The two dead configurations warn; a ceiling with real rates, and no ceiling
+// at all, stay silent — a warning that fired on a correct config would be muted
+// within a day and take the real ones with it.
+func TestCostCeilingWithoutPricingWarning(t *testing.T) {
+	rates := &config.Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15}
+	zeroed := &config.Pricing{}
+
+	tests := []struct {
+		name     string
+		ceiling  float64
+		pricing  *config.Pricing
+		wantWarn bool
+		wantSays string // a phrase the message must carry, naming the specific dead config
+	}{
+		{"no ceiling, no pricing", 0, nil, false, ""},
+		{"no ceiling, with pricing", 0, rates, false, ""},
+		{"ceiling with real rates", 2.5, rates, false, ""},
+		{"ceiling, no pricing at all", 2.5, nil, true, "model.pricing is not configured"},
+		{"ceiling, all rates zero", 2.5, zeroed, true, "every model.pricing rate is 0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Investigation.MaxCostPerInvestigation = tc.ceiling
+			cfg.Model.Pricing = tc.pricing
+			got := CostCeilingWithoutPricingWarning(cfg)
+			if (got != "") != tc.wantWarn {
+				t.Fatalf("CostCeilingWithoutPricingWarning(ceiling=%v, pricing=%+v) = %q, wantWarn = %v",
+					tc.ceiling, tc.pricing, got, tc.wantWarn)
+			}
+			if !tc.wantWarn {
+				return
+			}
+			if !strings.Contains(got, tc.wantSays) {
+				t.Fatalf("message must name the specific dead configuration (%q): %q", tc.wantSays, got)
+			}
+			// Every warning must carry the key at issue and a way out; a paragraph
+			// that only says "this is wrong" costs an operator a docs hunt.
+			for _, want := range []string{"max_cost_per_investigation", "model.pricing", "can never fire"} {
+				if !strings.Contains(got, want) {
+					t.Fatalf("message missing %q — it must name the key, the missing input and the consequence: %q", want, got)
+				}
+			}
+		})
+	}
+}
+
+// TestCostCeilingWarningIgnoresVerifyPricing pins that model.verify.pricing cannot
+// silence the warning. It only overrides the VERIFY pass's rates and inherits
+// model.pricing when unset, so it can neither price an otherwise-unpriced
+// investigation nor rescue an all-zero main rate card — a deployment that sets it
+// alone still has a ceiling that never fires.
+func TestCostCeilingWarningIgnoresVerifyPricing(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Investigation.MaxCostPerInvestigation = 2.5
+	cfg.Model.Verify = &config.ModelOverride{Pricing: &config.Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15}}
+	if got := CostCeilingWithoutPricingWarning(cfg); got == "" {
+		t.Fatal("model.verify.pricing alone leaves the loop unpriced — the ceiling still cannot fire, so the warning must stand")
+	}
+}

--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -127,6 +127,10 @@ func BuildReinvestigator(cfg *config.Config, deps *Deps, metrics *telemetry.Metr
 	// copy. See Deps: a second catalog means a second git-sync goroutine on the same
 	// directory, and an index that disagrees with the investigator's.
 	model, tools, recall := deps.Model, deps.Tools, deps.Recall
+	// A re-investigation is a full paid loop, so it gets the same rate cards and the
+	// same ceilings as the serve path — without Pricing the cost ceiling below would
+	// be handed through and then be structurally unable to fire.
+	loopPricing, verifyPricing := investigationPricing(cfg)
 	run := func(ctx context.Context, req investigate.Request) (providers.Investigation, error) {
 		var res providers.Investigation
 		var got bool
@@ -141,9 +145,12 @@ func BuildReinvestigator(cfg *config.Config, deps *Deps, metrics *telemetry.Metr
 			Model: model, VerifyModel: BuildVerifyModel(cfg), Tools: tools, Recall: recall, Verify: true, Log: log,
 			Metrics:                   metrics,
 			ModelProvider:             cfg.Model.Provider,
+			Pricing:                   loopPricing,
+			VerifyPricing:             verifyPricing,
 			MaxSteps:                  cfg.Investigation.MaxSteps,
 			MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 			MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
+			MaxCostPerInvestigation:   cfg.Investigation.MaxCostPerInvestigation,
 			Timeout:                   cfg.Investigation.Timeout.Std(),
 			KBMatchScore:              kbMatchScore(recall), // visibility bar tracks the configured recall floor
 			OnComplete:                func(inv providers.Investigation) { res, got = inv, true },

--- a/internal/app/demo.go
+++ b/internal/app/demo.go
@@ -248,17 +248,27 @@ func runDemoInvestigateWithModel(args []string, out, errOut io.Writer, model pro
 			demoMinScore, demoSoloFloor)
 	}
 
+	// The demo drives the operator's real, billed model against a canned scenario, so
+	// it carries the same spend ceilings as every other loop — a walkthrough is a bad
+	// place to discover an unbounded run.
+	loopPricing, verifyPricing := investigationPricing(cfg)
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
-		Model:         model,
-		VerifyModel:   verifyModel,
-		Tools:         tools,
-		Recall:        recall,
-		Log:           log,
-		Verify:        true,
-		ModelProvider: cfg.Model.Provider,
-		Timeout:       cfg.Investigation.Timeout.Std(),
-		OnComplete:    func(inv providers.Investigation) { result = &inv },
+		Model:                     model,
+		VerifyModel:               verifyModel,
+		Tools:                     tools,
+		Recall:                    recall,
+		Log:                       log,
+		Verify:                    true,
+		ModelProvider:             cfg.Model.Provider,
+		Pricing:                   loopPricing,
+		VerifyPricing:             verifyPricing,
+		MaxSteps:                  cfg.Investigation.MaxSteps,
+		MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
+		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
+		MaxCostPerInvestigation:   cfg.Investigation.MaxCostPerInvestigation,
+		Timeout:                   cfg.Investigation.Timeout.Std(),
+		OnComplete:                func(inv providers.Investigation) { result = &inv },
 	}
 	req := investigate.Request{
 		Source:   investigate.SourceAlert,

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -450,6 +450,24 @@ func toPricing(p *config.Pricing) *investigate.Pricing {
 	}
 }
 
+// investigationPricing returns the two rate cards every LoopInvestigator needs: the
+// main model's, and the verify pass's — which inherits the main one WHOLE when the
+// override sets none, so a cheaper verify model is costed at its own rates and an
+// unset one is not accidentally costed at zero.
+//
+// Shared by all four construction sites rather than repeated at each: pricing is no
+// longer only a reporting detail (a wrong or missing rate card used to mean a missing
+// dollar figure on a notification; it now means a cost ceiling that cannot fire), so
+// the derivation must be identical everywhere it is built.
+func investigationPricing(cfg *config.Config) (loop, verify *investigate.Pricing) {
+	loop = toPricing(cfg.Model.Pricing)
+	verify = loop
+	if v := cfg.Model.Verify; v != nil && v.Pricing != nil {
+		verify = toPricing(v.Pricing)
+	}
+	return loop, verify
+}
+
 // kbMatchScore returns the BM25 bar the kb-match visibility signal
 // (Investigation.MatchedKnowledge — the "📚 Matches known runbook" block) uses to decide
 // a full investigation's kb_search hit is a clear known-runbook match worth surfacing.
@@ -596,11 +614,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, deps *Deps, appr
 	// Per-investigation cost reporting (optional). The verify override inherits the
 	// main pricing when it sets none (whole-struct inherit), so a cheaper verify
 	// model is costed correctly.
-	mainPricing := toPricing(cfg.Model.Pricing)
-	verifyPricing := mainPricing
-	if v := cfg.Model.Verify; v != nil && v.Pricing != nil {
-		verifyPricing = toPricing(v.Pricing)
-	}
+	mainPricing, verifyPricing := investigationPricing(cfg)
 	// A nil *catalog.Catalog must stay a nil INTERFACE here: assigning a typed-nil
 	// *catalog.Catalog to prior would make prior != nil true (interface holds a
 	// non-nil type descriptor even with a nil pointer), and onInvestigationComplete's
@@ -629,6 +643,7 @@ func BuildInvestigator(ctx context.Context, cfg *config.Config, deps *Deps, appr
 		MaxSteps:                  cfg.Investigation.MaxSteps,
 		MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
 		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
+		MaxCostPerInvestigation:   cfg.Investigation.MaxCostPerInvestigation,
 		Compaction:                cfg.Investigation.Compaction,
 		Timeout:                   cfg.Investigation.Timeout.Std(),
 		ToolTimeout:               toolTimeout,

--- a/internal/app/investigate_cmd.go
+++ b/internal/app/investigate_cmd.go
@@ -66,13 +66,25 @@ func RunInvestigate(args []string) error {
 	ctx := context.Background()
 
 	model, tools, recall, _ := BuildModelAndTools(ctx, cfg, GitOpsFromKube(cfg, log), nil, log)
+	// The one-shot CLI bills the operator's model exactly as the server does, so it
+	// gets the same spend ceilings. It ran with NONE of them until now, contradicting
+	// internal/config/load.go, which applies the bounded defaults precisely so that
+	// "anyone running `lore serve --config` or `lore investigate` directly" is covered
+	// — the defaults were computed and then never handed to the loop.
+	loopPricing, verifyPricing := investigationPricing(cfg)
 	var result *providers.Investigation
 	li := &investigate.LoopInvestigator{
 		Model: model, VerifyModel: BuildVerifyModel(cfg), Tools: tools, Recall: recall, Actions: action.New(cfg.Actions), Log: log, Verify: true,
-		ModelProvider: cfg.Model.Provider,
-		Timeout:       cfg.Investigation.Timeout.Std(),
-		KBMatchScore:  kbMatchScore(recall), // visibility bar tracks the configured recall floor
-		OnComplete:    func(inv providers.Investigation) { result = &inv },
+		ModelProvider:             cfg.Model.Provider,
+		Pricing:                   loopPricing,
+		VerifyPricing:             verifyPricing,
+		MaxSteps:                  cfg.Investigation.MaxSteps,
+		MaxToolOutputBytes:        cfg.Investigation.MaxToolOutputBytes,
+		MaxTokensPerInvestigation: cfg.Investigation.MaxTokensPerInvestigation,
+		MaxCostPerInvestigation:   cfg.Investigation.MaxCostPerInvestigation,
+		Timeout:                   cfg.Investigation.Timeout.Std(),
+		KBMatchScore:              kbMatchScore(recall), // visibility bar tracks the configured recall floor
+		OnComplete:                func(inv providers.Investigation) { result = &inv },
 	}
 	title := *alert
 	if title == "" {

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -603,3 +603,30 @@ func TestElasticFieldOverridesReachTheWire(t *testing.T) {
 		t.Errorf("logs.fields.timestamp_field did not reach date_histogram.field: got %q, want %q", gotTimestamp, "event.created")
 	}
 }
+
+// TestBuildInvestigatorWiresTheCostCeiling pins that investigation.max_cost_per_investigation
+// reaches the loop. A ceiling parsed into the config but never handed to the
+// investigator is the same silent no-op the warning exists to announce — except
+// nothing would announce it, because the warning's precondition (pricing configured)
+// would be satisfied.
+func TestBuildInvestigatorWiresTheCostCeiling(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent-kubeconfig"))
+	log := discardLog()
+	cfg := &config.Config{Model: config.Model{
+		Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model",
+		Pricing: &config.Pricing{InputUSDPerMTok: 3, OutputUSDPerMTok: 15},
+	}}
+	cfg.Investigation.MaxCostPerInvestigation = 4.25
+	deps := BuildDeps(context.Background(), cfg, nil, nil, nil, log)
+	inv, _, err := BuildInvestigator(context.Background(), cfg, deps, nil, nil, nil, nil, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	li, ok := inv.(*investigate.LoopInvestigator)
+	if !ok {
+		t.Fatalf("want *LoopInvestigator, got %T", inv)
+	}
+	if li.MaxCostPerInvestigation != 4.25 {
+		t.Fatalf("max_cost_per_investigation not wired: got %v, want 4.25", li.MaxCostPerInvestigation)
+	}
+}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -151,6 +151,13 @@ func RunServe(version string, args []string) error {
 	if msg := WebhookAuthWarning(alertmanagerEnabled, webhookToken, cfg.Actions.Mode); msg != "" {
 		log.Warn(msg)
 	}
+	// A cost ceiling with no usable rate card is not a stricter limit that rarely
+	// fires — it can never fire. Raised here, beside the other pure-config startup
+	// warnings and once per process: the condition does not change between incidents,
+	// so anywhere on the investigation path would repeat it per alert.
+	if msg := CostCeilingWithoutPricingWarning(cfg); msg != "" {
+		log.Warn(msg)
+	}
 
 	// Set up the single shared OTel metrics instance before building the investigator
 	// so recall + the investigation loop can record to it from the first request.

--- a/internal/app/serve_guard_test.go
+++ b/internal/app/serve_guard_test.go
@@ -167,6 +167,107 @@ func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
 	}
 }
 
+// TestEveryStartupWarningIsRaised generalises the pin above to the whole convention:
+// a `*Warning` function in this package returns a message that MUST reach a logger on
+// the startup path, or the config problem it describes is neither enforced nor
+// signalled — the worst of both worlds, and precisely the failure mode several of
+// these warnings exist to prevent.
+//
+// The set is DISCOVERED, not listed: every exported top-level func in package app
+// whose name ends in "Warning" and returns a string is covered the day it is written.
+// A hand-maintained list would rot in exactly the direction this guard exists to
+// catch — a new warning added, never listed, never raised, and nothing failing.
+//
+// The contract per warning is the same one assertWarningIsRaised checks: exactly one
+// non-test call site, its result bound to a real variable (not `_`), and that variable
+// passed to a `.Warn(...)` in the same statement. It deliberately does NOT require the
+// caller to be RunServe — WebhookAuthWarning and RecallDecayWarning both live there
+// today, but a future warning belonging on `lore curate`'s startup is legitimate. The
+// stricter "once, at startup, outside any closure" pin stays specific to
+// RecallDecayWarning above, whose paragraph would be intolerable per alert.
+func TestEveryStartupWarningIsRaised(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join(".", "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	fset := token.NewFileSet()
+	type site struct {
+		file string
+		stmt ast.Stmt
+	}
+	declared := map[string]bool{}
+	calls := map[string][]site{}
+
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path) //nolint:gosec // test-owned path in this package
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			if fn.Recv == nil && isWarningFunc(fn) {
+				declared[fn.Name.Name] = true
+			}
+			var stack []ast.Node
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if n == nil {
+					stack = stack[:len(stack)-1]
+					return false
+				}
+				stack = append(stack, n)
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				id, ok := call.Fun.(*ast.Ident)
+				if !ok || !strings.HasSuffix(id.Name, "Warning") || id.Name == fn.Name.Name {
+					return true
+				}
+				calls[id.Name] = append(calls[id.Name], site{filepath.Base(path), outermostStmt(stack)})
+				return true
+			})
+		}
+	}
+
+	if len(declared) == 0 {
+		t.Fatal("no *Warning functions found in package app — this guard is inert")
+	}
+	for name := range declared {
+		sites := calls[name]
+		if len(sites) != 1 {
+			t.Errorf("%s has %d non-test call sites, want exactly 1 — a warning nobody raises "+
+				"leaves the condition it describes neither enforced nor signalled, and two raisers "+
+				"print it twice", name, len(sites))
+			continue
+		}
+		assertWarningIsRaised(t, sites[0].file, sites[0].stmt, name, "Warn")
+	}
+}
+
+// isWarningFunc reports whether fn is one of the package's startup-warning
+// functions: named *Warning and returning a message string.
+func isWarningFunc(fn *ast.FuncDecl) bool {
+	if !strings.HasSuffix(fn.Name.Name, "Warning") {
+		return false
+	}
+	res := fn.Type.Results
+	if res == nil || len(res.List) != 1 {
+		return false
+	}
+	id, ok := res.List[0].Type.(*ast.Ident)
+	return ok && id.Name == "string"
+}
+
 // outermostStmt returns the top-level statement of the enclosing function body that
 // contains the visited node — stack[0] is the *ast.BlockStmt body itself, so the next
 // statement down is the one whose whole subtree (an `if` with its init AND its body)

--- a/internal/app/spend_controls_wired_test.go
+++ b/internal/app/spend_controls_wired_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+// TestEveryLoopInvestigatorCarriesTheSpendControls pins that no construction site of
+// the paid ReAct loop in this package is built without a spend ceiling.
+//
+// The ceiling only bounds the loops it is actually handed to, and package app builds
+// FOUR of them: the serve investigator, the reinvestigate poller, `lore investigate`,
+// and the demo. Three of the four omitted the caps entirely — `lore investigate` and
+// the demo set neither token nor cost ceiling, and the poller set no Pricing, which
+// leaves the cost ceiling structurally inert there. internal/config/load.go's comment
+// already claimed the opposite ("anyone running `lore serve --config` or `lore
+// investigate` directly gets the same bounded defaults as the Helm chart").
+//
+// A per-site unit test would not have caught that: each site is correct in isolation
+// and wrong only by omission, and the next site added would be wrong the same way. So
+// the guard is structural — every composite literal, discovered by parsing, must set
+// the whole set. It reads the field NAMES off the literal, not the values: what the
+// operator configured is config.Validate's business, whether the loop was told at all
+// is this one's.
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestEveryLoopInvestigatorCarriesTheSpendControls(t *testing.T) {
+	// Pricing is in the set because the cost ceiling cannot fire without it: a loop
+	// given MaxCostPerInvestigation and no Pricing produces no cost to compare, which
+	// is the same silent no-op CostCeilingWithoutPricingWarning exists to announce —
+	// except here the operator DID configure model.pricing, so nothing would warn.
+	required := []string{"MaxTokensPerInvestigation", "MaxCostPerInvestigation", "Pricing"}
+
+	files, err := filepath.Glob(filepath.Join(".", "*.go"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	fset := token.NewFileSet()
+	sites := 0
+	for _, path := range files {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(path) //nolint:gosec // test-owned path in this package
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		f, err := parser.ParseFile(fset, path, src, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok || !isLoopInvestigatorType(lit.Type) {
+				return true
+			}
+			sites++
+			set := map[string]bool{}
+			for _, elt := range lit.Elts {
+				kv, ok := elt.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				if key, ok := kv.Key.(*ast.Ident); ok {
+					set[key.Name] = true
+				}
+			}
+			var missing []string
+			for _, field := range required {
+				if !set[field] {
+					missing = append(missing, field)
+				}
+			}
+			if len(missing) > 0 {
+				sort.Strings(missing)
+				t.Errorf("%s:%d builds an investigate.LoopInvestigator without %s — "+
+					"a spend ceiling bounds only the loops it is handed to, and this one runs "+
+					"unbounded against the operator's paid model",
+					filepath.Base(path), fset.Position(lit.Pos()).Line, strings.Join(missing, ", "))
+			}
+			return true
+		})
+	}
+	if sites == 0 {
+		t.Fatal("no investigate.LoopInvestigator literals found in package app — this guard is inert")
+	}
+}
+
+// isLoopInvestigatorType reports whether a composite literal's type is
+// investigate.LoopInvestigator.
+func isLoopInvestigatorType(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "LoopInvestigator" {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	return ok && pkg.Name == "investigate"
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -409,7 +409,7 @@ type Investigation struct {
 	RateLimit                 RateLimit `yaml:"rate_limit"`
 	MaxSteps                  int       `yaml:"max_steps"`                    // 0 ⇒ loop default (20)
 	MaxToolOutputBytes        int       `yaml:"max_tool_output_bytes"`        // unset/0 ⇒ bounded default (32768); -1 ⇒ unlimited
-	MaxTokensPerInvestigation int       `yaml:"max_tokens_per_investigation"` // CUMULATIVE token ceiling for one investigation; unset/0 ⇒ bounded default (100000); -1 ⇒ unlimited
+	MaxTokensPerInvestigation int       `yaml:"max_tokens_per_investigation"` // CUMULATIVE token ceiling for one investigation, and a quarter of it bounds any single request; unset/0 ⇒ bounded default (400000); -1 ⇒ unlimited
 	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via ApplyDefaults
 	ToolTimeout               Duration  `yaml:"tool_timeout"`                 // per-TOOL-call timeout so one hung tool can't eat the budget; 0 ⇒ default (60s) at construction
 
@@ -418,7 +418,7 @@ type Investigation struct {
 	// same nudge-then-hard-stop ladder as the token ceiling.
 	//
 	// OPT-IN, with no default and no -1 opt-out — deliberately unlike the token key
-	// above. A token is provider-neutral, so 100000 means the same thing on every
+	// above. A token is provider-neutral, so 400000 means the same thing on every
 	// deployment and can be chosen on an operator's behalf. A dollar cannot: a
 	// self-hosted operator picks their own model and supplies their own rates, so any
 	// shipped USD figure would be generous for one deployment and punitive for the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -409,9 +409,25 @@ type Investigation struct {
 	RateLimit                 RateLimit `yaml:"rate_limit"`
 	MaxSteps                  int       `yaml:"max_steps"`                    // 0 ⇒ loop default (20)
 	MaxToolOutputBytes        int       `yaml:"max_tool_output_bytes"`        // unset/0 ⇒ bounded default (32768); -1 ⇒ unlimited
-	MaxTokensPerInvestigation int       `yaml:"max_tokens_per_investigation"` // unset/0 ⇒ bounded default (100000); -1 ⇒ unlimited
+	MaxTokensPerInvestigation int       `yaml:"max_tokens_per_investigation"` // CUMULATIVE token ceiling for one investigation; unset/0 ⇒ bounded default (100000); -1 ⇒ unlimited
 	Timeout                   Duration  `yaml:"timeout"`                      // per-investigation deadline; 0 ⇒ default (10m) via ApplyDefaults
 	ToolTimeout               Duration  `yaml:"tool_timeout"`                 // per-TOOL-call timeout so one hung tool can't eat the budget; 0 ⇒ default (60s) at construction
+
+	// MaxCostPerInvestigation caps one investigation's ESTIMATED spend in USD, priced
+	// from model.pricing (and model.verify.pricing for the verify pass). It feeds the
+	// same nudge-then-hard-stop ladder as the token ceiling.
+	//
+	// OPT-IN, with no default and no -1 opt-out — deliberately unlike the token key
+	// above. A token is provider-neutral, so 100000 means the same thing on every
+	// deployment and can be chosen on an operator's behalf. A dollar cannot: a
+	// self-hosted operator picks their own model and supplies their own rates, so any
+	// shipped USD figure would be generous for one deployment and punitive for the
+	// next. 0 already means "no ceiling", which leaves -1 nothing to express; a
+	// negative value is rejected by Validate rather than quietly read as an opt-out.
+	//
+	// INERT without model.pricing — no cost is computed, so nothing can be compared.
+	// app.CostCeilingWithoutPricingWarning says so at startup.
+	MaxCostPerInvestigation float64 `yaml:"max_cost_per_investigation"` // unset/0 ⇒ no cost ceiling
 
 	// RecurrenceCooldown (opt-in, 0 = off) suppresses re-investigating a trigger
 	// whose previous investigation completed less than this long ago, provided some
@@ -1318,6 +1334,14 @@ func (c *Config) Validate() error {
 		if err := validatePricing("model.verify.pricing", v.Pricing); err != nil {
 			return err
 		}
+	}
+	// Reject a negative cost ceiling. The sibling max_tokens_per_investigation teaches
+	// operators that -1 means "unlimited", so the idiom WILL be copied here — where 0
+	// already means no ceiling and a negative value would read as an explicit opt-out
+	// while being indistinguishable from one only by accident. Say what to write.
+	if mc := c.Investigation.MaxCostPerInvestigation; mc < 0 {
+		return fmt.Errorf("investigation.max_cost_per_investigation must be >= 0, got %g "+
+			"(unlike max_tokens_per_investigation there is no -1 opt-out: 0 or unset already means no cost ceiling)", mc)
 	}
 	// Reject a negative rate-limit budget: ApplyDefaults fills an unset nil with 30,
 	// so only an explicit negative reaches here — fail loud rather than silently

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -356,7 +356,7 @@ func TestValidatePricingNonNegative(t *testing.T) {
 
 // TestApplyDefaultsResourceCaps locks in the safe-by-default resource caps
 // (C3/B3-budget): a zero-value config must get the bounded Helm-chart defaults
-// (32768 bytes / 100000 tokens) so that `lore serve --config` and `lore
+// (32768 bytes / 400000 tokens) so that `lore serve --config` and `lore
 // investigate` are never silently unbounded.
 func TestApplyDefaultsResourceCaps(t *testing.T) {
 	// Unset (zero) → bounded defaults are applied (match the Helm chart values.yaml).
@@ -365,8 +365,8 @@ func TestApplyDefaultsResourceCaps(t *testing.T) {
 	if c.Investigation.MaxToolOutputBytes != 32768 {
 		t.Fatalf("default MaxToolOutputBytes: got %d, want 32768", c.Investigation.MaxToolOutputBytes)
 	}
-	if c.Investigation.MaxTokensPerInvestigation != 100000 {
-		t.Fatalf("default MaxTokensPerInvestigation: got %d, want 100000", c.Investigation.MaxTokensPerInvestigation)
+	if c.Investigation.MaxTokensPerInvestigation != 400000 {
+		t.Fatalf("default MaxTokensPerInvestigation: got %d, want 400000", c.Investigation.MaxTokensPerInvestigation)
 	}
 }
 
@@ -405,7 +405,7 @@ func TestApplyDefaultsResourceCapsExplicit(t *testing.T) {
 // TestMaxCostPerInvestigationIsOptIn pins the config surface of the USD ceiling and,
 // deliberately, its DIFFERENCE from the token sibling above.
 //
-// max_tokens_per_investigation ships a bounded default (100000) because a token is a
+// max_tokens_per_investigation ships a bounded default (400000) because a token is a
 // provider-neutral unit: the same number means the same thing on every model, so a
 // safe default can be chosen for an operator. A dollar is not. A self-hosted operator
 // picks their own model and supplies their own rates via model.pricing, so any default

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -401,3 +401,63 @@ func TestApplyDefaultsResourceCapsExplicit(t *testing.T) {
 		t.Fatalf("explicit MaxTokensPerInvestigation overwritten: got %d, want 50000", c.Investigation.MaxTokensPerInvestigation)
 	}
 }
+
+// TestMaxCostPerInvestigationIsOptIn pins the config surface of the USD ceiling and,
+// deliberately, its DIFFERENCE from the token sibling above.
+//
+// max_tokens_per_investigation ships a bounded default (100000) because a token is a
+// provider-neutral unit: the same number means the same thing on every model, so a
+// safe default can be chosen for an operator. A dollar is not. A self-hosted operator
+// picks their own model and supplies their own rates via model.pricing, so any default
+// denominated in USD would be generous for one deployment and punitive for the next —
+// and would silently cut runs short on an upgrade nobody asked for. Unset therefore
+// means NO cost ceiling, and there is no -1 opt-out to mirror (0 already means off,
+// so -1 would have no job).
+func TestMaxCostPerInvestigationIsOptIn(t *testing.T) {
+	var c Config
+	ApplyDefaults(&c)
+	if c.Investigation.MaxCostPerInvestigation != 0 {
+		t.Fatalf("max_cost_per_investigation must default to 0 (no ceiling), got %v — "+
+			"a dollar figure cannot be defaulted for an operator whose model and rates RunLore does not choose",
+			c.Investigation.MaxCostPerInvestigation)
+	}
+	var explicit Config
+	explicit.Investigation.MaxCostPerInvestigation = 2.5
+	ApplyDefaults(&explicit)
+	if explicit.Investigation.MaxCostPerInvestigation != 2.5 {
+		t.Fatalf("explicit max_cost_per_investigation overwritten: got %v, want 2.5",
+			explicit.Investigation.MaxCostPerInvestigation)
+	}
+}
+
+// TestMaxCostPerInvestigationParsesFromYAML pins the yaml key an operator actually
+// types; a struct-only test would pass with any tag.
+func TestMaxCostPerInvestigationParsesFromYAML(t *testing.T) {
+	var c Config
+	if err := yaml.Unmarshal([]byte("investigation:\n  max_cost_per_investigation: 1.75\n"), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Investigation.MaxCostPerInvestigation != 1.75 {
+		t.Fatalf("max_cost_per_investigation did not parse: got %v, want 1.75", c.Investigation.MaxCostPerInvestigation)
+	}
+}
+
+// TestValidateRejectsNegativeMaxCost fails a negative ceiling loudly instead of
+// treating it as "off". The token sibling teaches operators that -1 means unlimited;
+// copying that idiom here would produce a config that reads as an opt-out and
+// behaves as one only by accident, so it is rejected with the reason spelled out.
+func TestValidateRejectsNegativeMaxCost(t *testing.T) {
+	var c Config
+	c.Investigation.MaxCostPerInvestigation = -1
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("a negative max_cost_per_investigation must be rejected, not silently disabled")
+	}
+	if !strings.Contains(err.Error(), "max_cost_per_investigation") {
+		t.Fatalf("error must name the offending key, got %v", err)
+	}
+	c.Investigation.MaxCostPerInvestigation = 1.5
+	if err := c.Validate(); err != nil {
+		t.Fatalf("a positive ceiling must be accepted: %v", err)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -129,7 +129,7 @@ func ApplyDefaults(c *Config) {
 	// Safe-by-default resource caps (C3/B3-budget): anyone running `lore serve
 	// --config` or `lore investigate` directly gets the same bounded defaults as
 	// the Helm chart (values.yaml: max_tool_output_bytes=32768,
-	// max_tokens_per_investigation=100000). Without these defaults only the chart
+	// max_tokens_per_investigation=400000). Without these defaults only the chart
 	// values.yaml applied the caps; a bare YAML config or a direct CLI run got
 	// unlimited tool output and token budget, enabling unbounded LLM cost and
 	// memory pressure.
@@ -151,7 +151,7 @@ func ApplyDefaults(c *Config) {
 	case -1:
 		c.Investigation.MaxTokensPerInvestigation = 0 // -1 is the user-visible opt-out; map to consumer sentinel
 	case 0:
-		c.Investigation.MaxTokensPerInvestigation = 100000 // match the Helm chart default
+		c.Investigation.MaxTokensPerInvestigation = 400000 // match the Helm chart default
 	}
 	// Interim progress-update default: when enabled without an explicit cadence,
 	// ping every 5 steps — frequent enough to reassure on a long investigation,

--- a/internal/docsguard/investigation_budget_test.go
+++ b/internal/docsguard/investigation_budget_test.go
@@ -70,7 +70,9 @@ func TestInvestigationSpendCeilingsMatchTheDocs(t *testing.T) {
 // not the size of one request. It bounded only the request until this was fixed, and
 // the difference is the whole reason the same 100000 now stops runs it used to let
 // through — a page that describes it as a context/request ceiling would leave an
-// operator unable to explain their own budget_exceeded results.
+// operator unable to explain their own budget_exceeded results. (The default moved
+// with the meaning — 100000 funded four or five steps read as a run budget — so this
+// test's sibling above pins the number off ApplyDefaults rather than off this prose.)
 func TestConfigurationPageStatesTheCumulativeTokenSemantics(t *testing.T) {
 	doc := flattenProse(readDoc(t, configurationPath))
 	if !strings.Contains(doc, "a **cumulative** ceiling on one investigation's model tokens") {
@@ -99,7 +101,7 @@ var overshootClaims = []string{
 // TestConfigurationPageStatesTheOvershoot pins the ceiling's real cost, not its
 // nominal one. The ladder concedes one request past the trip on purpose — the nudge
 // has to give the model a turn to conclude — and because the transcript grows every
-// step, that request is the LARGEST of the run. A page that prints "default 100000"
+// step, that request is the LARGEST of the run. A page that prints "default 400000"
 // and stops there understates the bill by a whole request, which is the same
 // claim-vs-code gap the cumulative-semantics fix exists to close.
 func TestConfigurationPageStatesTheOvershoot(t *testing.T) {

--- a/internal/docsguard/investigation_budget_test.go
+++ b/internal/docsguard/investigation_budget_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// configurationPath is the operator-facing configuration reference.
+const configurationPath = "../../website/content/docs/configuration/configuration.md"
+
+// TestInvestigationSpendCeilingsMatchTheDocs pins the `investigation` block's spend
+// knobs to reality on both axes — the key NAME off the struct's yaml tag, the VALUE
+// off ApplyDefaults — so a rename and a retuning each fail here.
+//
+// These are the numbers an operator budgets money against, and the page had already
+// drifted: it stated "0 = unlimited" for both caps when 0 has meant "apply the bounded
+// default" since safe-by-default landed, and -1 is the actual opt-out. Nothing failed,
+// because nothing checked. An operator following that page to disable a cap got the
+// default instead — the opposite of what they asked for.
+func TestInvestigationSpendCeilingsMatchTheDocs(t *testing.T) {
+	var c config.Config
+	config.ApplyDefaults(&c)
+	inv := c.Investigation
+
+	doc := readDoc(t, configurationPath)
+	for _, want := range []string{
+		fmt.Sprintf("`%s` (**default %d**", tagOf(inv, "MaxToolOutputBytes"), inv.MaxToolOutputBytes),
+		fmt.Sprintf("`%s` (**default %d**", tagOf(inv, "MaxTokensPerInvestigation"), inv.MaxTokensPerInvestigation),
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("configuration.md must state the shipped cap verbatim as %q — "+
+				"the key or its default changed underneath the page", want)
+		}
+	}
+
+	// The cost ceiling is the opposite claim: it must be documented as having NO
+	// default, and ApplyDefaults must agree. A default quietly introduced later would
+	// change what every existing deployment spends, so the page and the code have to
+	// stay pinned to each other in this direction too.
+	if inv.MaxCostPerInvestigation != 0 {
+		t.Errorf("ApplyDefaults now sets %s = %v, but configuration.md documents it as opt-in "+
+			"with no default — introducing one silently changes what existing deployments spend",
+			tagOf(inv, "MaxCostPerInvestigation"), inv.MaxCostPerInvestigation)
+	}
+	if want := fmt.Sprintf("`%s` (**no default — opt-in**)", tagOf(inv, "MaxCostPerInvestigation")); !strings.Contains(doc, want) {
+		t.Errorf("configuration.md must state the cost ceiling verbatim as %q", want)
+	}
+
+	// The page must not still be telling operators that 0 disables these caps: 0 means
+	// "use the bounded default" and -1 is the opt-out, so the old wording sent anyone
+	// trying to remove a cap to exactly the wrong value.
+	for _, key := range []string{
+		tagOf(inv, "MaxToolOutputBytes"),
+		tagOf(inv, "MaxTokensPerInvestigation"),
+	} {
+		if strings.Contains(doc, "`"+key+"` (0 = unlimited") {
+			t.Errorf("configuration.md still says `%s` (0 = unlimited); 0 applies the bounded "+
+				"default and -1 is the opt-out", key)
+		}
+	}
+}
+
+// TestConfigurationPageStatesTheCumulativeTokenSemantics pins the CLAIM, not just the
+// number: max_tokens_per_investigation bounds an investigation's accumulated tokens,
+// not the size of one request. It bounded only the request until this was fixed, and
+// the difference is the whole reason the same 100000 now stops runs it used to let
+// through — a page that describes it as a context/request ceiling would leave an
+// operator unable to explain their own budget_exceeded results.
+func TestConfigurationPageStatesTheCumulativeTokenSemantics(t *testing.T) {
+	doc := flattenProse(readDoc(t, configurationPath))
+	if !strings.Contains(doc, "a **cumulative** ceiling on one investigation's model tokens") {
+		t.Error("configuration.md must describe max_tokens_per_investigation as a cumulative " +
+			"ceiling over the whole investigation, not a per-request one")
+	}
+	// The inertness of a cost ceiling without rates is the finding this whole feature
+	// exists to close ("a limit that is neither enforced nor signalled"). It is stated
+	// at startup by CostCeilingWithoutPricingWarning; it must be stated on the page too,
+	// because an operator reads the page BEFORE they get the warning.
+	if !strings.Contains(doc, "It does nothing without `model.pricing`") {
+		t.Error("configuration.md must say plainly that max_cost_per_investigation is inert " +
+			"without model.pricing — a ceiling that cannot fire has to be documented as such")
+	}
+}

--- a/internal/docsguard/investigation_budget_test.go
+++ b/internal/docsguard/investigation_budget_test.go
@@ -86,3 +86,48 @@ func TestConfigurationPageStatesTheCumulativeTokenSemantics(t *testing.T) {
 			"without model.pricing — a ceiling that cannot fire has to be documented as such")
 	}
 }
+
+// overshootClaims are the two halves of the statement an operator budgets money
+// against: WHAT is compared (the projected total, not spend already gone) and HOW FAR
+// past the ceiling a run may still be billed (one request).
+var overshootClaims = []string{
+	"compares the **projected** total — what the run has already spent plus the estimated size " +
+		"of the request about to be sent",
+	"exceed the ceiling **by up to the size of a single request**",
+}
+
+// TestConfigurationPageStatesTheOvershoot pins the ceiling's real cost, not its
+// nominal one. The ladder concedes one request past the trip on purpose — the nudge
+// has to give the model a turn to conclude — and because the transcript grows every
+// step, that request is the LARGEST of the run. A page that prints "default 100000"
+// and stops there understates the bill by a whole request, which is the same
+// claim-vs-code gap the cumulative-semantics fix exists to close.
+func TestConfigurationPageStatesTheOvershoot(t *testing.T) {
+	doc := flattenProse(readDoc(t, configurationPath))
+	for _, want := range overshootClaims {
+		if !strings.Contains(doc, want) {
+			t.Errorf("configuration.md must state %q — an operator sizing "+
+				"max_tokens_per_investigation has to know the ceiling is not an exact cap", want)
+		}
+	}
+}
+
+// TestOvershootClaimsRejectTheNominalWording is the mutation test for the guard above:
+// a page that describes the ceiling as a plain cap, or that says the check runs
+// against spend already incurred, must not satisfy either anchor. Without this, an
+// anchor loose enough to match any budget prose would pin nothing.
+func TestOvershootClaimsRejectTheNominalWording(t *testing.T) {
+	for _, nominal := range []string{
+		"a cumulative ceiling on one investigation's model tokens, checked against what the " +
+			"run has already spent; a run stops as soon as it crosses the number",
+		"the ceiling caps a run at 100k tokens",
+		"the overshoot is about two requests by design",
+	} {
+		flat := flattenProse(nominal)
+		for _, claim := range overshootClaims {
+			if strings.Contains(flat, claim) {
+				t.Errorf("anchor %q matches nominal wording %q — it pins nothing", claim, nominal)
+			}
+		}
+	}
+}

--- a/internal/docsguard/release_config_test.go
+++ b/internal/docsguard/release_config_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"encoding/json"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const (
+	releaseConfigPath   = "../../release-please-config.json"
+	releaseManifestPath = "../../.release-please-manifest.json"
+	contributingPath    = "../../CONTRIBUTING.md"
+)
+
+// TestBreakingChangesDoNotSilentlyCutAOneDotZero pins the release configuration
+// against the version it is actually operating on.
+//
+// release-please's default versioning strategy bumps a package whose major version is
+// 0 straight to 1.0.0 on the FIRST breaking change, unless bump-minor-pre-major is
+// set. This repo has never marked a breaking change — no `!` in any subject, no
+// `BREAKING CHANGE:` footer anywhere in 1000+ commits — so that path has never been
+// exercised, and nothing lints commit subjects or PR titles either. The day someone
+// correctly marks a config migration as breaking, the release automation would
+// silently cut a 1.0.0 that nobody decided to make, with the stability promise that
+// carries.
+//
+// The guard is scoped to the pre-1.0 window it protects: once the project genuinely
+// releases 1.x the setting stops mattering and this test stops asserting it, rather
+// than becoming a stale rule someone has to delete.
+func TestBreakingChangesDoNotSilentlyCutAOneDotZero(t *testing.T) {
+	if major := releasedMajor(t); major > 0 {
+		t.Skipf("released version is %d.x — bump-minor-pre-major no longer changes any bump", major)
+	}
+	pkg := releasePackageConfig(t)
+	bump, ok := pkg["bump-minor-pre-major"].(bool)
+	if !ok || !bump {
+		t.Errorf("release-please-config.json must set \"bump-minor-pre-major\": true while %s is pre-1.0.\n"+
+			"Without it, the first commit marked breaking (a `!` subject or a BREAKING CHANGE: footer) "+
+			"bumps 0.x straight to 1.0.0 — so marking a migration honestly and cutting a 1.0 release "+
+			"become the same action, and the only pressure that resolves it is to under-mark the migration.",
+			releaseManifestPath)
+	}
+}
+
+// TestChangelogSectionsCoverTheTypesWeWrite pins that the two commit types this repo
+// actually ships behaviour under both reach CHANGELOG.md. A type missing from
+// changelog-sections is not an error at release time — release-please just drops it —
+// so an operator reading the changelog would silently not see that class of change.
+func TestChangelogSectionsCoverTheTypesWeWrite(t *testing.T) {
+	pkg := releasePackageConfig(t)
+	sections, ok := pkg["changelog-sections"].([]any)
+	if !ok {
+		t.Fatalf("release-please-config.json has no changelog-sections array")
+	}
+	visible := map[string]bool{}
+	for _, s := range sections {
+		m, ok := s.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := m["type"].(string)
+		hidden, _ := m["hidden"].(bool)
+		visible[typ] = !hidden
+	}
+	for _, typ := range []string{"feat", "fix"} {
+		if !visible[typ] {
+			t.Errorf("changelog-sections must render %q — a behaviour change landed under a hidden "+
+				"type never reaches an upgrading operator", typ)
+		}
+	}
+}
+
+// TestContributingExplainsHowToMarkABreakingChange pins the one piece of guidance the
+// release pipeline cannot enforce for itself.
+//
+// Nothing in CI lints a commit subject or a PR title, PRs are squash-merged (so the PR
+// TITLE becomes the commit release-please parses, not the branch commits), and the
+// only mechanism that carries prose — not just a subject line — into CHANGELOG.md is a
+// BREAKING CHANGE: footer. All three facts have to be written down together or the
+// migration note for a behaviour change lands nowhere an operator reads.
+func TestContributingExplainsHowToMarkABreakingChange(t *testing.T) {
+	doc := flattenProse(readDoc(t, contributingPath))
+	for _, want := range []string{
+		"BREAKING CHANGE:",
+		"the PR **title** is what release-please parses",
+	} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("CONTRIBUTING.md must explain how to mark a breaking change so the migration note "+
+				"reaches CHANGELOG.md; missing %q", want)
+		}
+	}
+}
+
+// releasePackageConfig returns the "." package block of release-please-config.json.
+func releasePackageConfig(t *testing.T) map[string]any {
+	t.Helper()
+	var cfg struct {
+		Packages map[string]map[string]any `json:"packages"`
+	}
+	raw, err := os.ReadFile(releaseConfigPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", releaseConfigPath, err)
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse %s: %v", releaseConfigPath, err)
+	}
+	pkg, ok := cfg.Packages["."]
+	if !ok {
+		t.Fatalf("%s has no \".\" package", releaseConfigPath)
+	}
+	return pkg
+}
+
+// releasedMajor returns the major version release-please last released, read from the
+// manifest it maintains — the same file the tooling reads, not a number restated here.
+func releasedMajor(t *testing.T) int {
+	t.Helper()
+	raw, err := os.ReadFile(releaseManifestPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", releaseManifestPath, err)
+	}
+	var m map[string]string
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("parse %s: %v", releaseManifestPath, err)
+	}
+	v, ok := m["."]
+	if !ok {
+		t.Fatalf("%s has no \".\" entry", releaseManifestPath)
+	}
+	major, err := strconv.Atoi(v[:strings.Index(v+".", ".")])
+	if err != nil {
+		t.Fatalf("unparseable version %q in %s: %v", v, releaseManifestPath, err)
+	}
+	return major
+}

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -25,7 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/Smana/runlore/internal/httpx"
+	"github.com/Smana/runlore/internal/telemetry"
 )
 
 // Client calls an OpenAI-compatible /embeddings endpoint.
@@ -34,6 +38,20 @@ type Client struct {
 	model   string
 	apiKey  string
 	http    *http.Client
+
+	// Metrics is optional (nil-safe) telemetry for the embeddings endpoint. It is a
+	// PAID API — called once per hybrid-recall query, from inside an investigation
+	// that has spend ceilings, and in bulk on every catalog reload — and until it was
+	// wired here nothing counted its calls, its latency or its tokens. Recording
+	// under provider="embed" on the shared model instruments keeps it separable by
+	// label instead of inventing a metric name, matching the reranker's precedent.
+	//
+	// This makes the spend VISIBLE, not bounded: the query embed is not folded into
+	// the per-investigation totals (it does not flow through the Embedder interface,
+	// which returns vectors only) and the corpus embed runs on the git-sync goroutine
+	// with no investigation to charge. See the spend inventory in
+	// docs/configuration/configuration.md.
+	Metrics *telemetry.Metrics
 }
 
 // New builds an embeddings client. apiKey may be empty (keyless vLLM/Ollama).
@@ -56,6 +74,14 @@ type embedResponse struct {
 		Index     int       `json:"index"`
 		Embedding []float32 `json:"embedding"`
 	} `json:"data"`
+	// Usage is what the endpoint says it billed. The OpenAI-compatible /embeddings
+	// wire format returns it (vLLM and Ollama's shims included) and this struct used
+	// to discard it, which is why embedding spend had no token figure anywhere.
+	// Absent from a server that omits it ⇒ zero, and zero is simply not recorded.
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
 }
 
 // maxEmbedBatch bounds the inputs per /embeddings request. Providers cap the
@@ -100,7 +126,9 @@ func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, e
 		}
 		return r, nil
 	}
+	start := time.Now()
 	resp, err := httpx.DoWithRetry(ctx, c.http, 3, newReq)
+	c.recordRequest(ctx, start, err)
 	if err != nil {
 		return nil, fmt.Errorf("embeddings request: %w", err)
 	}
@@ -117,6 +145,9 @@ func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, e
 	var er embedResponse
 	if err := json.Unmarshal(data, &er); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
+	}
+	if c.Metrics != nil && er.Usage.PromptTokens > 0 {
+		c.Metrics.ModelInputTokens.Add(ctx, int64(er.Usage.PromptTokens), embedAttrs)
 	}
 	if len(er.Data) != len(texts) {
 		return nil, fmt.Errorf("embeddings: got %d vectors for %d inputs", len(er.Data), len(texts))
@@ -135,6 +166,26 @@ func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, e
 		}
 	}
 	return out, nil
+}
+
+// embedAttrs labels every embeddings sample with provider="embed", so the endpoint's
+// call volume, latency and tokens sit beside the main/verify/rerank tiers on the same
+// instruments and a dashboard can select or exclude it with one label matcher.
+var embedAttrs = metric.WithAttributes(attribute.String("provider", "embed"))
+
+// recordRequest emits one /embeddings round trip's call count and latency. Nil-safe:
+// a Client with no Metrics (every CLI path) records nothing.
+func (c *Client) recordRequest(ctx context.Context, start time.Time, err error) {
+	if c.Metrics == nil {
+		return
+	}
+	res := "ok"
+	if err != nil {
+		res = "error"
+	}
+	c.Metrics.ModelRequests.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("provider", "embed"), attribute.String("result", res)))
+	c.Metrics.ModelRequestDuration.Record(ctx, time.Since(start).Seconds(), embedAttrs)
 }
 
 // Cosine returns the cosine similarity of two equal-length vectors, in [-1, 1].

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -14,6 +14,11 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/Smana/runlore/internal/telemetry"
 )
 
 func TestEmbed(t *testing.T) {
@@ -39,6 +44,70 @@ func TestEmbed(t *testing.T) {
 	}
 	if len(vecs) != 2 || vecs[0][0] != 1.0 || vecs[1][1] != 1.0 {
 		t.Fatalf("vectors not placed by index: %v", vecs)
+	}
+}
+
+// TestEmbedRecordsItsSpend closes the fourth spend path that ran inside `serve` with
+// no accounting at all. The /embeddings endpoint is a paid API called once per
+// hybrid-recall query — inside an investigation that believes it has a ceiling — and
+// in bulk on every catalog reload, and nothing counted its calls, its latency or its
+// tokens. A spend path nobody can see is worse than one nobody bounds.
+//
+// It records under provider="embed" on the SAME instruments the main, verify and
+// rerank tiers use, so the traffic is separable by label rather than needing a metric
+// name of its own — the precedent the reranker set.
+func TestEmbedRecordsItsSpend(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	const promptTokens = 4242
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[1.0,0.0]}],` +
+			`"usage":{"prompt_tokens":` + strconv.Itoa(promptTokens) +
+			`,"total_tokens":` + strconv.Itoa(promptTokens) + `}}`))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "text-embed", "")
+	c.Metrics = telemetry.NewMetrics()
+	if _, err := c.Embed(context.Background(), []string{"a"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	body := rec.Body.String()
+	for _, want := range []string{
+		`runlore_model_requests_total`,
+		`provider="embed"`,
+		`runlore_model_request_duration_seconds`,
+		`runlore_model_input_tokens_total`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("embedding spend is invisible: metrics missing %s\n%s", want, body)
+		}
+	}
+	if !strings.Contains(body, strconv.Itoa(promptTokens)) {
+		t.Fatalf("the provider reported %d prompt tokens and none reached "+
+			"model_input_tokens_total — the /embeddings response's usage block is being discarded:\n%s",
+			promptTokens, body)
+	}
+}
+
+// TestEmbedMetricsAreOptional pins that the instrumentation is nil-safe: every CLI
+// path builds a Client without telemetry, and none of them may panic for it.
+func TestEmbedMetricsAreOptional(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[1.0]}]}`))
+	}))
+	defer srv.Close()
+	if _, err := New(srv.URL, "m", "").Embed(context.Background(), []string{"a"}); err != nil {
+		t.Fatalf("a Client with no Metrics must still embed: %v", err)
 	}
 }
 

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -19,6 +19,9 @@ const (
 	// budgetReasonTotalTokens: the tokens this investigation has ALREADY spent
 	// (provider-reported, loop + verify) exceed MaxTokensPerInvestigation.
 	budgetReasonTotalTokens = "tokens_total"
+	// budgetReasonCost: the estimated USD this investigation has already spent
+	// exceeds MaxCostPerInvestigation.
+	budgetReasonCost = "cost"
 )
 
 // Ladder rungs, used as the `stage` label on the budget-trip metric: a ceiling is
@@ -43,8 +46,11 @@ func spentTokens(t providers.UsageTotals) int { return t.InputTokens + t.OutputT
 // to know whether to raise tokens or dollars.
 func budgetKillResult(req Request, reason string) providers.Investigation {
 	which := "per-request token budget (investigation.max_tokens_per_investigation)"
-	if reason == budgetReasonTotalTokens {
+	switch reason {
+	case budgetReasonTotalTokens:
 		which = "cumulative token budget (investigation.max_tokens_per_investigation)"
+	case budgetReasonCost:
+		which = "estimated cost ceiling (investigation.max_cost_per_investigation)"
 	}
 	return providers.Investigation{
 		Title:       req.Title,
@@ -171,6 +177,20 @@ func (c *tokenCalibration) heuristicTarget(target int) int {
 
 // overBudget reports whether est exceeds budget. budget <= 0 means unlimited.
 func overBudget(est, budget int) bool { return budget > 0 && est > budget }
+
+// overCostBudget reports whether an investigation's accumulated estimated spend
+// exceeds ceiling, in USD. ceiling <= 0 means no cost ceiling.
+//
+// The Priced guard states the contract rather than relying on a coincidence:
+// CostUSD is 0 both for "this run has cost nothing yet" and for "no model.pricing
+// is configured, so no cost was ever computed", and only the first is a figure that
+// may be compared. aggregateUsage happens to leave the unpriced case at 0 today, so
+// the guard changes no outcome — but a comparison that reads CostUSD without asking
+// whether it means anything is the shape of the bug where an unpriced deployment
+// believes a ceiling is in force.
+func overCostBudget(spent providers.UsageTotals, ceiling float64) bool {
+	return ceiling > 0 && spent.Priced && spent.CostUSD > ceiling
+}
 
 // budgetNudge is the single-use message injected once when the token estimate
 // exceeds MaxTokensPerInvestigation, prompting the model to wrap up now.

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -8,16 +8,51 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
-// budgetKillResult synthesises an unresolved investigation for use when the
-// token-budget hard-kill fires (nudge fired, model did not submit findings in time).
-func budgetKillResult(req Request) providers.Investigation {
+// Spend-ceiling reasons. Every ceiling feeds the SAME two-rung ladder (nudge once
+// with a forced submit_findings, then hard-kill with result="budget_exceeded"), so
+// the reason is what tells an operator WHICH ceiling stopped a run — on the metric
+// label, the log line and the delivered unresolved entry.
+const (
+	// budgetReasonRequestTokens: the next request on its own would exceed
+	// MaxTokensPerInvestigation. Caught before it is sent.
+	budgetReasonRequestTokens = "tokens_request"
+	// budgetReasonTotalTokens: the tokens this investigation has ALREADY spent
+	// (provider-reported, loop + verify) exceed MaxTokensPerInvestigation.
+	budgetReasonTotalTokens = "tokens_total"
+)
+
+// Ladder rungs, used as the `stage` label on the budget-trip metric: a ceiling is
+// tripped twice before a run dies, and the two are operationally different — a
+// nudge still delivers real findings, a kill delivers an unresolved stub.
+const (
+	budgetStageNudge = "nudge"
+	budgetStageKill  = "kill"
+)
+
+// spentTokens is the running per-investigation token total a ceiling is compared
+// against: provider-reported input (which INCLUDES cached — see providers.Usage)
+// plus output, summed over every model call the investigation has made so far.
+// Same arithmetic as the recall_tokens_spent_total counter, so "tokens spent"
+// means one thing across RunLore.
+func spentTokens(t providers.UsageTotals) int { return t.InputTokens + t.OutputTokens }
+
+// budgetKillResult synthesises an unresolved investigation for use when a spend
+// ceiling's hard-kill fires (nudge fired, model did not submit findings in time).
+// reason names the ceiling so the delivered finding says which limit was hit — an
+// operator reading only the notification should not have to correlate a log line
+// to know whether to raise tokens or dollars.
+func budgetKillResult(req Request, reason string) providers.Investigation {
+	which := "per-request token budget (investigation.max_tokens_per_investigation)"
+	if reason == budgetReasonTotalTokens {
+		which = "cumulative token budget (investigation.max_tokens_per_investigation)"
+	}
 	return providers.Investigation{
 		Title:       req.Title,
 		Resource:    req.Workload,
 		Fingerprint: req.Fingerprint,
 		Verdict:     providers.VerdictInconclusive,
 		Unresolved: []string{
-			"investigation stopped: token budget exceeded after nudge (model did not submit findings in time)",
+			"investigation stopped: " + which + " exceeded after nudge (model did not submit findings in time)",
 		},
 	}
 }

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -14,7 +14,8 @@ import (
 // label, the log line and the delivered unresolved entry.
 const (
 	// budgetReasonRequestTokens: the next request on its own would exceed
-	// MaxTokensPerInvestigation. Caught before it is sent.
+	// requestBudget(MaxTokensPerInvestigation) — a quarter of the run's budget.
+	// Caught before it is sent.
 	budgetReasonRequestTokens = "tokens_request"
 	// budgetReasonTotalTokens: the tokens this investigation has ALREADY spent
 	// (provider-reported, loop + verify) exceed MaxTokensPerInvestigation.
@@ -45,7 +46,7 @@ func spentTokens(t providers.UsageTotals) int { return t.InputTokens + t.OutputT
 // operator reading only the notification should not have to correlate a log line
 // to know whether to raise tokens or dollars.
 func budgetKillResult(req Request, reason string) providers.Investigation {
-	which := "per-request token budget (investigation.max_tokens_per_investigation)"
+	which := "per-request token budget (a quarter of investigation.max_tokens_per_investigation)"
 	switch reason {
 	case budgetReasonTotalTokens:
 		which = "cumulative token budget (investigation.max_tokens_per_investigation)"
@@ -177,6 +178,42 @@ func (c *tokenCalibration) heuristicTarget(target int) int {
 
 // overBudget reports whether est exceeds budget. budget <= 0 means unlimited.
 func overBudget(est, budget int) bool { return budget > 0 && est > budget }
+
+// requestBudgetFraction is the share of an investigation's whole token budget that
+// ONE request may take: a ceiling has to fund at least four full-size requests to be
+// a run budget at all.
+//
+// The two quantities need separate thresholds because they are separate failures with
+// separate fixes. "This run has spent too much in total" is answered by raising
+// max_tokens_per_investigation; "this single request is too big" is answered by
+// shrinking a request — max_tool_output_bytes, compaction — and raising the run budget
+// does not help. Comparing one request against the whole run's budget states that a
+// single request may consume the entire investigation, which bounds nothing, and drags
+// mid-loop compaction down with it: compaction triggers at 0.7x whatever bounds one
+// request, so pointed at the cumulative number its trigger sits at 0.7x a figure the
+// run's ACCUMULATED spend reaches first. On a monotonically growing transcript
+// sum(est_i) crosses the ceiling long before any single est_i reaches 0.7 of it, so
+// the ladder always fires first and compaction is unreachable at every configuration.
+//
+// A quarter, rather than an operator-facing knob: this is a structural relationship
+// between two quantities, not a preference. It also derives, rather than duplicates,
+// the bound the per-request check has always used — at the shipped default it is 100
+// 000 tokens with compaction at 70 000, exactly the pair in force before the ceiling
+// became cumulative, so this changes what one request may cost for nobody. The fraction
+// is small enough that a growing transcript reaches the compaction trigger with the run
+// budget still largely unspent: measured at the shipped max_tool_output_bytes,
+// compaction fires on the sixth request with 186 718 of 400 000 tokens spent.
+const requestBudgetFraction = 0.25
+
+// requestBudget converts an investigation's cumulative token budget into the ceiling
+// on ONE request. cumulative <= 0 (unlimited) passes straight through, so an operator
+// who opted out with -1 is not handed a derived bound they never asked for.
+func requestBudget(cumulative int) int {
+	if cumulative <= 0 {
+		return 0
+	}
+	return int(float64(cumulative) * requestBudgetFraction)
+}
 
 // overCostBudget reports whether an investigation's accumulated estimated spend
 // exceeds ceiling, in USD. ceiling <= 0 means no cost ceiling.

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -202,7 +202,9 @@ func overBudget(est, budget int) bool { return budget > 0 && est > budget }
 // became cumulative, so this changes what one request may cost for nobody. The fraction
 // is small enough that a growing transcript reaches the compaction trigger with the run
 // budget still largely unspent: measured at the shipped max_tool_output_bytes,
-// compaction fires on the sixth request with 186 718 of 400 000 tokens spent.
+// compaction fires on the sixth request with 186 758 of 400 000 tokens spent (the
+// figure TestCompactionFiresBeforeTheCumulativeCeiling drives, and asserts is under the
+// ceiling).
 const requestBudgetFraction = 0.25
 
 // requestBudget converts an investigation's cumulative token budget into the ceiling

--- a/internal/investigate/compact.go
+++ b/internal/investigate/compact.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	// compactionBudgetFraction is the fraction of MaxTokensPerInvestigation at which
+	// compactionBudgetFraction is the fraction of the PER-REQUEST budget at which
 	// compaction triggers and the size it elides back down to (headroom for more steps).
 	compactionBudgetFraction = 0.7
 	// keepRecentToolOutputs is the number of most-recent tool results kept verbatim
@@ -50,13 +50,18 @@ func isElidedMarker(s string) bool {
 	return strings.HasPrefix(s, elidedPrefix) && strings.HasSuffix(s, elidedSuffix)
 }
 
-// compactionTarget returns the estimate at/below which compaction stops: 0.7 * budget.
-// budget <= 0 disables compaction (returns 0).
-func compactionTarget(budget int) int {
-	if budget <= 0 {
-		return 0
-	}
-	return int(float64(budget) * compactionBudgetFraction)
+// compactionTarget returns the estimate at/below which compaction stops: 0.7 x the
+// budget for ONE request, itself a quarter of the investigation's cumulative token
+// budget. cumulative <= 0 disables compaction (returns 0).
+//
+// It keys off the per-request budget because that is the quantity compaction can act
+// on: it shrinks the NEXT request, and can never un-spend what is already billed.
+// Keyed off the cumulative budget the trigger sits at a size no single request reaches
+// before the run's accumulated spend has crossed the ceiling — see
+// requestBudgetFraction, and TestCompactionFiresBeforeTheCumulativeCeiling, which
+// drives the loop until compaction actually fires rather than asserting it could.
+func compactionTarget(cumulative int) int {
+	return int(float64(requestBudget(cumulative)) * compactionBudgetFraction)
 }
 
 // elidedOutput records one tool-result body that compaction removed: the tool that

--- a/internal/investigate/compact_test.go
+++ b/internal/investigate/compact_test.go
@@ -171,11 +171,32 @@ func TestCompactSkipsBodiesNoLargerThanMarker(t *testing.T) {
 	}
 }
 
+// TestCompactionTarget pins the two derived thresholds and, more importantly, their
+// ORDER: compaction has to trigger below the bound on one request, which has to sit
+// below the run's whole budget. Collapse any two of the three and the middle rung
+// stops existing — which is how compaction became unreachable once the per-request
+// check and the run budget were read off the same number.
 func TestCompactionTarget(t *testing.T) {
+	if requestBudget(0) != 0 || requestBudget(-5) != 0 {
+		t.Fatal("cumulative<=0 is the unlimited sentinel: it must not derive a per-request bound")
+	}
 	if compactionTarget(0) != 0 || compactionTarget(-5) != 0 {
 		t.Fatal("budget<=0 disables compaction")
 	}
-	if got := compactionTarget(100000); got != 70000 {
-		t.Fatalf("compactionTarget(100000)=%d, want 70000", got)
+	// At the shipped default the derived pair is the one that was already in force
+	// before this ceiling became cumulative, so what a single request may cost, and the
+	// size at which compaction kicks in, are unchanged for every existing deployment.
+	if got := requestBudget(400000); got != 100000 {
+		t.Fatalf("requestBudget(400000)=%d, want 100000", got)
+	}
+	if got := compactionTarget(400000); got != 70000 {
+		t.Fatalf("compactionTarget(400000)=%d, want 70000", got)
+	}
+	for _, cumulative := range []int{6_000, 100_000, 400_000, 5_000_000} {
+		target, req := compactionTarget(cumulative), requestBudget(cumulative)
+		if target <= 0 || target >= req || req >= cumulative {
+			t.Errorf("thresholds must stay strictly ordered compaction < request < run at "+
+				"cumulative=%d; got target=%d request=%d", cumulative, target, req)
+		}
 	}
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -190,8 +190,11 @@ type LoopInvestigator struct {
 	ToolTimeout time.Duration
 
 	// Cost controls (0 means disabled/unlimited):
-	MaxToolOutputBytes        int // truncate tool results larger than this before adding to history
-	MaxTokensPerInvestigation int // ceiling on BOTH the next request's estimated size and the investigation's accumulated tokens
+	MaxToolOutputBytes int // truncate tool results larger than this before adding to history
+	// MaxTokensPerInvestigation is the CUMULATIVE token ceiling for one investigation.
+	// It also derives the bound on a single request — requestBudget, a quarter of it —
+	// and, from that, the mid-loop compaction target.
+	MaxTokensPerInvestigation int
 
 	// MaxCostPerInvestigation is the ceiling, in USD, on this investigation's
 	// accumulated estimated spend (loop tokens priced at Pricing, verify tokens at
@@ -862,9 +865,15 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 // structurally cannot — twenty affordable requests. Order only decides which reason
 // is reported when several are true at once; any one of them enters the same ladder,
 // and the reason is latched at the nudge so the kill cannot rename it.
+//
+// It compares against requestBudget, NOT against the cumulative ceiling: the two are
+// different failures with different fixes, and reusing one number for both says a
+// single request may consume the whole investigation — which bounds nothing and leaves
+// mid-loop compaction (0.7x whatever bounds one request) unreachable. See
+// requestBudgetFraction.
 func (li *LoopInvestigator) budgetTrip(est int, spent providers.UsageTotals) string {
 	switch {
-	case overBudget(est, li.MaxTokensPerInvestigation):
+	case overBudget(est, requestBudget(li.MaxTokensPerInvestigation)):
 		return budgetReasonRequestTokens
 	case overBudget(spentTokens(spent)+est, li.MaxTokensPerInvestigation):
 		return budgetReasonTotalTokens
@@ -929,7 +938,7 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 	// Mid-loop compaction: before the budget guard, elide superseded/old tool outputs
 	// to stay under budget so a long investigation can finish instead of hard-killing.
 	// The target is converted into raw-heuristic space (compactHistory measures with
-	// estimateTokens) so a calibrated loop compacts down to a REAL 0.7×budget.
+	// estimateTokens) so a calibrated loop compacts down to a REAL compaction target.
 	if target := compactionTarget(li.MaxTokensPerInvestigation); target > 0 && est > target {
 		if compacted, elided, removed := compactHistoryDetailed(*messages, sys, specs, calib.heuristicTarget(target)); elided > 0 {
 			// summarize mode: replace the just-elided batch with one model-produced

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -432,7 +432,13 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// the sticky toolChoice, and the one-shot budgetNudged/compactionLogged flags)
 		// through pointers so behaviour is identical to the inline block, and reports
 		// done==true after delivering the hard-kill result — the caller then returns nil.
-		if li.enforceBudget(ctx, req, sys, specs, &calib, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish) {
+		// Everything this investigation has already paid for, priced the same way the
+		// delivered finding is (aggregateUsage — loop tokens at the main rate, verify
+		// tokens at the verify rate). verifyTotals is already populated here whenever
+		// the recall path ran and fell through, so a recall that spent a reranker + a
+		// verify call before the loop even started counts against the same ceiling.
+		spent := li.aggregateUsage(loopTotals, verifyTotals)
+		if li.enforceBudget(ctx, req, sys, specs, &calib, spent, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish) {
 			return nil
 		}
 		// Step-budget exhaustion: on the LAST step (only this request remains), force a
@@ -826,11 +832,36 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 	return nearMiss, false
 }
 
-// enforceBudget runs the per-step token-budget guard extracted from Investigate: it
+// budgetTrip reports which spend ceiling this step has crossed, or "" for none.
+// est is the anchored size of the request about to be sent; spent is everything the
+// investigation has ALREADY paid for (loop + whatever verify usage is known — the
+// recall path's reranker and verify calls are both already folded in by the time the
+// loop's first step runs).
+//
+// The per-request check comes first and is kept for what it alone catches: a single
+// oversized request, caught BEFORE it is billed. The running totals catch what it
+// structurally cannot — twenty affordable requests. Order only decides which reason
+// is reported when several are true at once; any one of them enters the same ladder.
+func (li *LoopInvestigator) budgetTrip(est int, spent providers.UsageTotals) string {
+	switch {
+	case overBudget(est, li.MaxTokensPerInvestigation):
+		return budgetReasonRequestTokens
+	case overBudget(spentTokens(spent), li.MaxTokensPerInvestigation):
+		return budgetReasonTotalTokens
+	}
+	return ""
+}
+
+// enforceBudget runs the per-step spend guard extracted from Investigate: it
 // estimates the request size, compacts old tool outputs mid-loop to stay under budget,
-// and — when still over — injects the one-time budget nudge and, if that already fired,
-// hard-kills the investigation. It reports done==true after delivering the hard-kill
-// result (through `finish`) so Investigate returns nil.
+// and — when a ceiling is crossed — injects the one-time budget nudge and, if that
+// already fired, hard-kills the investigation. It reports done==true after delivering
+// the hard-kill result (through `finish`) so Investigate returns nil.
+//
+// `spent` is the investigation's accumulated, provider-reported usage; it makes the
+// token ceiling a RUNNING TOTAL rather than a per-request check. Compaction can shrink
+// the next request but can never un-spend what is already billed, so a cumulative trip
+// falls straight through to the ladder — which is the point.
 //
 // It mutates the loop-local state it needs through pointers so behaviour is byte-for-
 // byte the inline block's: `messages` (compaction reassigns it; the nudge appends to
@@ -840,7 +871,7 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 // set to "budget_exceeded" on a hard-kill). The token estimate is the chars/4 heuristic
 // anchored to the previous completion's reported usage (calib); providers that report
 // no usage fall back to the pure heuristic.
-func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys string, specs []providers.ToolSpec, calib *tokenCalibration, messages *[]providers.Message, budgetNudged, compactionLogged *bool, toolChoice, result *string, finish func(providers.Investigation)) (done bool) {
+func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys string, specs []providers.ToolSpec, calib *tokenCalibration, spent providers.UsageTotals, messages *[]providers.Message, budgetNudged, compactionLogged *bool, toolChoice, result *string, finish func(providers.Investigation)) (done bool) {
 	// Budget control: when the estimated request size exceeds the configured ceiling,
 	// inject a one-time nudge asking the model to wrap up. If the model did not wind
 	// down and the estimate is still over budget on the next step, hard-kill: deliver
@@ -875,31 +906,48 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 			}
 		}
 	}
-	if overBudget(est, li.MaxTokensPerInvestigation) {
-		if !*budgetNudged {
-			*messages = append(*messages, providers.Message{Role: "user", Content: budgetNudge})
-			*budgetNudged = true
-			// From here on, force submit_findings on every remaining request: the
-			// model has been told to wrap up, so it must conclude — it may not
-			// ramble in prose or keep calling investigation tools. Normal loop
-			// steps (before the nudge) keep ToolChoice empty so the model stays
-			// free to pick tools or answer.
-			*toolChoice = submitFindingsName
-		} else {
-			// Hard-kill: nudge already fired but the model is still over budget.
-			li.Log.Warn("investigation hard-stopped at token budget",
-				"title", req.Title,
-				"estimate_tokens", est,
-				"budget_tokens", li.MaxTokensPerInvestigation)
-			if li.Metrics != nil {
-				li.Metrics.InvestigationsDropped.Add(ctx, 1)
-			}
-			*result = "budget_exceeded"
-			finish(budgetKillResult(req))
-			return true
+	reason := li.budgetTrip(est, spent)
+	if reason == "" {
+		return false
+	}
+	// One counter, two labels: `reason` says which ceiling an operator has to raise,
+	// `stage` says whether the run still delivered findings (nudge) or died (kill).
+	trip := func(stage string) {
+		if li.Metrics != nil {
+			li.Metrics.InvestigationBudgetTrips.Add(ctx, 1, metric.WithAttributes(
+				attribute.String("reason", reason), attribute.String("stage", stage)))
 		}
 	}
-	return false
+	if !*budgetNudged {
+		trip(budgetStageNudge)
+		li.Log.Info("investigation budget nudge: forcing the model to conclude",
+			"title", req.Title, "reason", reason,
+			"estimate_tokens", est, "spent_tokens", spentTokens(spent),
+			"budget_tokens", li.MaxTokensPerInvestigation)
+		*messages = append(*messages, providers.Message{Role: "user", Content: budgetNudge})
+		*budgetNudged = true
+		// From here on, force submit_findings on every remaining request: the
+		// model has been told to wrap up, so it must conclude — it may not
+		// ramble in prose or keep calling investigation tools. Normal loop
+		// steps (before the nudge) keep ToolChoice empty so the model stays
+		// free to pick tools or answer.
+		*toolChoice = submitFindingsName
+		return false
+	}
+	// Hard-kill: nudge already fired but a ceiling is still crossed.
+	trip(budgetStageKill)
+	li.Log.Warn("investigation hard-stopped at token budget",
+		"title", req.Title,
+		"reason", reason,
+		"estimate_tokens", est,
+		"spent_tokens", spentTokens(spent),
+		"budget_tokens", li.MaxTokensPerInvestigation)
+	if li.Metrics != nil {
+		li.Metrics.InvestigationsDropped.Add(ctx, 1)
+	}
+	*result = "budget_exceeded"
+	finish(budgetKillResult(req, reason))
+	return true
 }
 
 // maxConcurrentToolCalls bounds how many of one assistant turn's tool calls run at

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -191,7 +191,18 @@ type LoopInvestigator struct {
 
 	// Cost controls (0 means disabled/unlimited):
 	MaxToolOutputBytes        int // truncate tool results larger than this before adding to history
-	MaxTokensPerInvestigation int // inject a budget-nudge message when the estimated token count exceeds this
+	MaxTokensPerInvestigation int // ceiling on BOTH the next request's estimated size and the investigation's accumulated tokens
+
+	// MaxCostPerInvestigation is the ceiling, in USD, on this investigation's
+	// accumulated estimated spend (loop tokens priced at Pricing, verify tokens at
+	// VerifyPricing — the same arithmetic aggregateUsage reports on the finding).
+	// 0 ⇒ no cost ceiling.
+	//
+	// It is INERT without Pricing: an unpriced investigation has no dollar figure to
+	// compare against, so the ceiling can never fire. That combination is a
+	// misconfiguration worth saying out loud rather than failing silently — see
+	// app.CostCeilingWithoutPricingWarning, raised on the startup path.
+	MaxCostPerInvestigation float64
 
 	// Compaction selects how mid-loop history compaction treats the tool outputs it
 	// elides: "" / "elide" (default) drops their bodies for markers; "summarize" first
@@ -848,6 +859,8 @@ func (li *LoopInvestigator) budgetTrip(est int, spent providers.UsageTotals) str
 		return budgetReasonRequestTokens
 	case overBudget(spentTokens(spent), li.MaxTokensPerInvestigation):
 		return budgetReasonTotalTokens
+	case overCostBudget(spent, li.MaxCostPerInvestigation):
+		return budgetReasonCost
 	}
 	return ""
 }
@@ -923,7 +936,8 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 		li.Log.Info("investigation budget nudge: forcing the model to conclude",
 			"title", req.Title, "reason", reason,
 			"estimate_tokens", est, "spent_tokens", spentTokens(spent),
-			"budget_tokens", li.MaxTokensPerInvestigation)
+			"budget_tokens", li.MaxTokensPerInvestigation,
+			"spent_usd", spent.CostUSD, "budget_usd", li.MaxCostPerInvestigation)
 		*messages = append(*messages, providers.Message{Role: "user", Content: budgetNudge})
 		*budgetNudged = true
 		// From here on, force submit_findings on every remaining request: the
@@ -941,7 +955,9 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 		"reason", reason,
 		"estimate_tokens", est,
 		"spent_tokens", spentTokens(spent),
-		"budget_tokens", li.MaxTokensPerInvestigation)
+		"budget_tokens", li.MaxTokensPerInvestigation,
+		"spent_usd", spent.CostUSD,
+		"budget_usd", li.MaxCostPerInvestigation)
 	if li.Metrics != nil {
 		li.Metrics.InvestigationsDropped.Add(ctx, 1)
 	}

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -443,13 +443,7 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// the sticky toolChoice, and the one-shot budgetNudged/compactionLogged flags)
 		// through pointers so behaviour is identical to the inline block, and reports
 		// done==true after delivering the hard-kill result — the caller then returns nil.
-		// Everything this investigation has already paid for, priced the same way the
-		// delivered finding is (aggregateUsage — loop tokens at the main rate, verify
-		// tokens at the verify rate). verifyTotals is already populated here whenever
-		// the recall path ran and fell through, so a recall that spent a reranker + a
-		// verify call before the loop even started counts against the same ceiling.
-		spent := li.aggregateUsage(loopTotals, verifyTotals)
-		if li.enforceBudget(ctx, req, sys, specs, &calib, spent, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish) {
+		if li.enforceBudget(ctx, req, sys, specs, &calib, &loopTotals, &verifyTotals, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish) {
 			return nil
 		}
 		// Step-budget exhaustion: on the LAST step (only this request remains), force a
@@ -871,10 +865,13 @@ func (li *LoopInvestigator) budgetTrip(est int, spent providers.UsageTotals) str
 // already fired, hard-kills the investigation. It reports done==true after delivering
 // the hard-kill result (through `finish`) so Investigate returns nil.
 //
-// `spent` is the investigation's accumulated, provider-reported usage; it makes the
-// token ceiling a RUNNING TOTAL rather than a per-request check. Compaction can shrink
-// the next request but can never un-spend what is already billed, so a cumulative trip
-// falls straight through to the ladder — which is the point.
+// `loopTotals`/`verifyTotals` are the investigation's accumulated, provider-reported
+// usage; combining them here makes the ceilings RUNNING TOTALS rather than per-request
+// checks. Compaction can shrink the next request but can never un-spend what is
+// already billed, so a cumulative trip falls straight through to the ladder — which is
+// the point. They arrive by pointer because summarize-mode compaction, run below,
+// makes a model call of its own that must land in the same total it is then measured
+// against.
 //
 // It mutates the loop-local state it needs through pointers so behaviour is byte-for-
 // byte the inline block's: `messages` (compaction reassigns it; the nudge appends to
@@ -884,7 +881,7 @@ func (li *LoopInvestigator) budgetTrip(est int, spent providers.UsageTotals) str
 // set to "budget_exceeded" on a hard-kill). The token estimate is the chars/4 heuristic
 // anchored to the previous completion's reported usage (calib); providers that report
 // no usage fall back to the pure heuristic.
-func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys string, specs []providers.ToolSpec, calib *tokenCalibration, spent providers.UsageTotals, messages *[]providers.Message, budgetNudged, compactionLogged *bool, toolChoice, result *string, finish func(providers.Investigation)) (done bool) {
+func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys string, specs []providers.ToolSpec, calib *tokenCalibration, loopTotals, verifyTotals *providers.UsageTotals, messages *[]providers.Message, budgetNudged, compactionLogged *bool, toolChoice, result *string, finish func(providers.Investigation)) (done bool) {
 	// Budget control: when the estimated request size exceeds the configured ceiling,
 	// inject a one-time nudge asking the model to wrap up. If the model did not wind
 	// down and the estimate is still over budget on the next step, hard-kill: deliver
@@ -900,7 +897,7 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 			// digest (best-effort — on any summarizer failure `compacted` already
 			// carries the plain elision markers, so this only ever adds information).
 			if li.Compaction == compactionSummarize {
-				li.summarizeElided(ctx, compacted, removed)
+				li.summarizeElided(ctx, compacted, removed, verifyTotals)
 			}
 			*messages = compacted
 			est = calib.estimate(sys, *messages, specs)
@@ -919,6 +916,11 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 			}
 		}
 	}
+	// Priced the same way the delivered finding is (loop tokens at Pricing, verify
+	// tokens at VerifyPricing). Read AFTER compaction so a summarize-mode digest call
+	// counts against the ceiling on the very step that paid for it, and after tryRecall
+	// so a recall fall-through's reranker + verify calls are already in it.
+	spent := li.aggregateUsage(*loopTotals, *verifyTotals)
 	reason := li.budgetTrip(est, spent)
 	if reason == "" {
 		return false

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -428,8 +428,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		maxSteps = 20
 	}
 
-	nudged := false            // set when the prose-turn nudge has fired once
-	budgetNudged := false      // set when the token-budget nudge has fired once
+	nudged := false // set when the prose-turn nudge has fired once
+	// budgetStop latches WHICH ceiling engaged the spend ladder, "" until it does. It
+	// is the nudge's one-shot flag and the kill's reason in one value, so the two rungs
+	// of a single stop can never name different ceilings.
+	budgetStop := ""
 	toolChoice := ""           // forced tool for every remaining request; set (sticky) when the budget nudge fires
 	forcedFinal := false       // set when the final-step nudge forced submit_findings, so a delivery on that turn is labelled degraded
 	truncationNudged := false  // set when the output-truncation nudge has fired once
@@ -440,10 +443,11 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	for step := 0; step < maxSteps; step++ {
 		// enforceBudget runs the token-budget estimate + mid-loop history compaction +
 		// budget nudge/hard-kill. It mutates the loop-local state it needs (messages,
-		// the sticky toolChoice, and the one-shot budgetNudged/compactionLogged flags)
-		// through pointers so behaviour is identical to the inline block, and reports
-		// done==true after delivering the hard-kill result — the caller then returns nil.
-		if li.enforceBudget(ctx, req, sys, specs, &calib, &loopTotals, &verifyTotals, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish) {
+		// the sticky toolChoice, the latched budgetStop and the one-shot
+		// compactionLogged flag) through pointers so behaviour is identical to the
+		// inline block, and reports done==true after delivering the hard-kill result —
+		// the caller then returns nil.
+		if li.enforceBudget(ctx, req, sys, specs, &calib, &loopTotals, &verifyTotals, &messages, &budgetStop, &compactionLogged, &toolChoice, &result, finish) {
 			return nil
 		}
 		// Step-budget exhaustion: on the LAST step (only this request remains), force a
@@ -902,12 +906,21 @@ func (li *LoopInvestigator) projectSpend(spent providers.UsageTotals, est int) p
 // It mutates the loop-local state it needs through pointers so behaviour is byte-for-
 // byte the inline block's: `messages` (compaction reassigns it; the nudge appends to
 // it), the sticky `toolChoice` (set to submitFindingsName once the nudge fires — from
-// then on every remaining request forces submit_findings), the one-shot `budgetNudged`
-// and `compactionLogged` flags, and `result` (the deferred completion-metric label,
-// set to "budget_exceeded" on a hard-kill). The token estimate is the chars/4 heuristic
-// anchored to the previous completion's reported usage (calib); providers that report
-// no usage fall back to the pure heuristic.
-func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys string, specs []providers.ToolSpec, calib *tokenCalibration, loopTotals, verifyTotals *providers.UsageTotals, messages *[]providers.Message, budgetNudged, compactionLogged *bool, toolChoice, result *string, finish func(providers.Investigation)) (done bool) {
+// then on every remaining request forces submit_findings), the latched `budgetStop`,
+// the one-shot `compactionLogged` flag, and `result` (the deferred completion-metric
+// label, set to "budget_exceeded" on a hard-kill). The token estimate is the chars/4
+// heuristic anchored to the previous completion's reported usage (calib); providers
+// that report no usage fall back to the pure heuristic.
+//
+// `budgetStop` is the ladder's memory: "" until a ceiling engages it, then the reason
+// that did, carried unchanged to the kill. It replaces a plain nudged/not-nudged bool
+// because budgetTrip's ordered switch is re-evaluated every step against DIFFERENT
+// numbers — the nudged turn itself moves them — so recomputing the reason at the kill
+// could name a ceiling that never stopped anything, sending the operator to the wrong
+// knob and splitting one stop across two metric series. The ceiling that first stopped
+// the run is the one that answers "what do I raise", so that is the one both rungs
+// report.
+func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys string, specs []providers.ToolSpec, calib *tokenCalibration, loopTotals, verifyTotals *providers.UsageTotals, messages *[]providers.Message, budgetStop *string, compactionLogged *bool, toolChoice, result *string, finish func(providers.Investigation)) (done bool) {
 	// Budget control: when the estimated request size exceeds the configured ceiling,
 	// inject a one-time nudge asking the model to wrap up. If the model did not wind
 	// down and the estimate is still over budget on the next step, hard-kill: deliver
@@ -947,10 +960,18 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 	// counts against the ceiling on the very step that paid for it, and after tryRecall
 	// so a recall fall-through's reranker + verify calls are already in it.
 	spent := li.aggregateUsage(*loopTotals, *verifyTotals)
-	reason := li.budgetTrip(est, spent)
-	if reason == "" {
+	crossed := li.budgetTrip(est, spent)
+	if crossed == "" {
 		return false
 	}
+	// The reason reported on BOTH rungs is the one latched when the ladder engaged —
+	// see this function's doc comment. The first crossing latches it and takes the
+	// nudge; every later rung of the same stop reads it back and hard-kills.
+	nudge := *budgetStop == ""
+	if nudge {
+		*budgetStop = crossed
+	}
+	reason := *budgetStop
 	// One counter, two labels: `reason` says which ceiling an operator has to raise,
 	// `stage` says whether the run still delivered findings (nudge) or died (kill).
 	trip := func(stage string) {
@@ -959,7 +980,7 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 				attribute.String("reason", reason), attribute.String("stage", stage)))
 		}
 	}
-	if !*budgetNudged {
+	if nudge {
 		trip(budgetStageNudge)
 		li.Log.Info("investigation budget nudge: forcing the model to conclude",
 			"title", req.Title, "reason", reason,
@@ -967,7 +988,6 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 			"budget_tokens", li.MaxTokensPerInvestigation,
 			"spent_usd", spent.CostUSD, "budget_usd", li.MaxCostPerInvestigation)
 		*messages = append(*messages, providers.Message{Role: "user", Content: budgetNudge})
-		*budgetNudged = true
 		// From here on, force submit_findings on every remaining request: the
 		// model has been told to wrap up, so it must conclude — it may not
 		// ramble in prose or keep calling investigation tools. Normal loop

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -843,20 +843,46 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 // recall path's reranker and verify calls are both already folded in by the time the
 // loop's first step runs).
 //
+// The cumulative arms compare the PROJECTED total — spent + est, what the run will
+// have cost once this request is sent — not what it has cost already. Comparing spend
+// already gone concedes a whole extra request after the ceiling is known to be
+// crossed, and because the transcript grows monotonically that request is the largest
+// of the run: measured, a 100 000-token ceiling delivered 186 742 tokens. Projecting
+// moves the trip one turn earlier, so the request the ladder concedes for the nudge is
+// the one that crosses rather than the one after it. Some overshoot remains by design
+// — the nudged turn still has to be paid for — bounded by one request (see
+// TestTokenCeilingBoundsTheTokensActuallyDelivered).
+//
 // The per-request check comes first and is kept for what it alone catches: a single
 // oversized request, caught BEFORE it is billed. The running totals catch what it
 // structurally cannot — twenty affordable requests. Order only decides which reason
-// is reported when several are true at once; any one of them enters the same ladder.
+// is reported when several are true at once; any one of them enters the same ladder,
+// and the reason is latched at the nudge so the kill cannot rename it.
 func (li *LoopInvestigator) budgetTrip(est int, spent providers.UsageTotals) string {
 	switch {
 	case overBudget(est, li.MaxTokensPerInvestigation):
 		return budgetReasonRequestTokens
-	case overBudget(spentTokens(spent), li.MaxTokensPerInvestigation):
+	case overBudget(spentTokens(spent)+est, li.MaxTokensPerInvestigation):
 		return budgetReasonTotalTokens
-	case overCostBudget(spent, li.MaxCostPerInvestigation):
+	case overCostBudget(li.projectSpend(spent, est), li.MaxCostPerInvestigation):
 		return budgetReasonCost
 	}
 	return ""
+}
+
+// projectSpend folds the pending request's estimated cost into spent, so the cost
+// ceiling is compared against the same projected total the token ceiling uses.
+//
+// The pending request is priced as uncached input at the MAIN model's rate: before it
+// is sent the loop knows neither its cache-hit rate nor how long the answer will be,
+// and both omissions err towards counting too little — so this is a lower bound on
+// what the request will actually cost, never an inflated one. spent is a value copy;
+// the caller's totals are untouched.
+func (li *LoopInvestigator) projectSpend(spent providers.UsageTotals, est int) providers.UsageTotals {
+	if li.Pricing != nil {
+		spent.CostUSD += li.Pricing.cost(providers.UsageTotals{InputTokens: est})
+	}
+	return spent
 }
 
 // enforceBudget runs the per-step spend guard extracted from Investigate: it

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -1908,8 +1908,8 @@ func TestTryRecallDisabledUnderAuto(t *testing.T) {
 
 // TestEnforceBudgetNudgeThenHardKill unit-tests the extracted enforceBudget helper
 // directly across its two over-budget outcomes on a fixed message set: the first call
-// (nudge not yet fired) appends the budget nudge, flips budgetNudged, sets the sticky
-// toolChoice, and reports done==false; the second (nudge already fired, still over)
+// (ladder not yet engaged) appends the budget nudge, latches budgetStop, sets the
+// sticky toolChoice, and reports done==false; the second (already engaged, still over)
 // hard-kills — delivering once, setting result, and reporting done==true.
 func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -1921,18 +1921,20 @@ func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	specs := []providers.ToolSpec{submitFindingsSpec()}
 	messages := []providers.Message{{Role: "user", Content: "seed"}}
 	var calib tokenCalibration
-	budgetNudged, compactionLogged := false, false
+	budgetStop := ""
+	compactionLogged := false
 	toolChoice := ""
 	result := "unresolved"
 	delivered := 0
 	finish := func(providers.Investigation) { delivered++ }
 
 	// First over-budget call: nudge fires, no delivery.
-	if done := li.enforceBudget(context.Background(), Request{Title: "x"}, sys, specs, &calib, &providers.UsageTotals{}, &providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); done {
+	if done := li.enforceBudget(context.Background(), Request{Title: "x"}, sys, specs, &calib, &providers.UsageTotals{}, &providers.UsageTotals{}, &messages, &budgetStop, &compactionLogged, &toolChoice, &result, finish); done {
 		t.Fatal("first over-budget call must nudge (done==false), not hard-kill")
 	}
-	if !budgetNudged {
-		t.Fatal("first over-budget call must set budgetNudged")
+	if budgetStop != budgetReasonRequestTokens {
+		t.Fatalf("first over-budget call must latch the ceiling that engaged the ladder; got %q, want %q",
+			budgetStop, budgetReasonRequestTokens)
 	}
 	if toolChoice != submitFindingsName {
 		t.Fatalf("nudge must make toolChoice sticky-force %q, got %q", submitFindingsName, toolChoice)
@@ -1945,7 +1947,7 @@ func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	}
 
 	// Second over-budget call: hard-kill, exactly one delivery.
-	if done := li.enforceBudget(context.Background(), Request{Title: "x", Fingerprint: "fp-kill"}, sys, specs, &calib, &providers.UsageTotals{}, &providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); !done {
+	if done := li.enforceBudget(context.Background(), Request{Title: "x", Fingerprint: "fp-kill"}, sys, specs, &calib, &providers.UsageTotals{}, &providers.UsageTotals{}, &messages, &budgetStop, &compactionLogged, &toolChoice, &result, finish); !done {
 		t.Fatal("second over-budget call must hard-kill (done==true)")
 	}
 	if result != "budget_exceeded" {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -1928,7 +1928,7 @@ func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	finish := func(providers.Investigation) { delivered++ }
 
 	// First over-budget call: nudge fires, no delivery.
-	if done := li.enforceBudget(context.Background(), Request{Title: "x"}, sys, specs, &calib, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); done {
+	if done := li.enforceBudget(context.Background(), Request{Title: "x"}, sys, specs, &calib, providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); done {
 		t.Fatal("first over-budget call must nudge (done==false), not hard-kill")
 	}
 	if !budgetNudged {
@@ -1945,7 +1945,7 @@ func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	}
 
 	// Second over-budget call: hard-kill, exactly one delivery.
-	if done := li.enforceBudget(context.Background(), Request{Title: "x", Fingerprint: "fp-kill"}, sys, specs, &calib, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); !done {
+	if done := li.enforceBudget(context.Background(), Request{Title: "x", Fingerprint: "fp-kill"}, sys, specs, &calib, providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); !done {
 		t.Fatal("second over-budget call must hard-kill (done==true)")
 	}
 	if result != "budget_exceeded" {

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -1516,12 +1516,14 @@ func TestBudgetNudgeForcesSubmitFindings(t *testing.T) {
 		MaxSteps:   10,
 		OnComplete: func(inv providers.Investigation) { got = &inv },
 	}
-	// Budget = exactly the step-0 estimate (overBudget is a strict >), so step 0 is
-	// unforced and step 1 — grown by the assistant turn and the tool result — trips
-	// the nudge.
+	// PER-REQUEST budget = exactly the step-0 estimate (overBudget is a strict >), so
+	// step 0 is unforced and step 1 — grown by the assistant turn and the tool result —
+	// trips the nudge. The configured ceiling is four times that, because the arm this
+	// fixture exercises compares against requestBudget (a quarter of the run's budget),
+	// not against the run's budget itself; x4 keeps the threshold it was written for.
 	req := Request{Title: "budget-forcing"}
 	seed := []providers.Message{{Role: "user", Content: redact.Secrets(seedPrompt(req, seedContext{}))}}
-	li.MaxTokensPerInvestigation = estimateTokens(li.system(), seed, []providers.ToolSpec{submitFindingsSpec()})
+	li.MaxTokensPerInvestigation = 4 * estimateTokens(li.system(), seed, []providers.ToolSpec{submitFindingsSpec()})
 	if err := li.Investigate(context.Background(), req); err != nil {
 		t.Fatalf("Investigate: %v", err)
 	}
@@ -1711,11 +1713,14 @@ func TestCompactionLetsInvestigationFinish(t *testing.T) {
 
 	var got *providers.Investigation
 	li := &LoopInvestigator{
-		Model:                     &scriptModel{responses: resp},
-		Tools:                     []Tool{bigTool{size: 4000}},
-		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
-		MaxSteps:                  10,
-		MaxTokensPerInvestigation: 6000, // low: without compaction, 6 x ~1000-token outputs hard-kill
+		Model:    &scriptModel{responses: resp},
+		Tools:    []Tool{bigTool{size: 4000}},
+		Log:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps: 10,
+		// Low: without compaction, 6 x ~1000-token outputs hard-kill. Expressed as the
+		// run budget whose derived PER-REQUEST bound is 6000 — the threshold this fixture
+		// was written against, back when one number served as both.
+		MaxTokensPerInvestigation: 24000,
 		OnComplete:                func(inv providers.Investigation) { got = &inv },
 	}
 	if err := li.Investigate(context.Background(), Request{Title: "compaction finish test"}); err != nil {
@@ -1915,7 +1920,7 @@ func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
 	li := &LoopInvestigator{
 		Log:                       discard,
-		MaxTokensPerInvestigation: 1, // any real prompt exceeds this ⇒ always over budget
+		MaxTokensPerInvestigation: 4, // per-request bound 1 ⇒ any real prompt is over budget
 	}
 	sys := li.system()
 	specs := []providers.ToolSpec{submitFindingsSpec()}

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -1928,7 +1928,7 @@ func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	finish := func(providers.Investigation) { delivered++ }
 
 	// First over-budget call: nudge fires, no delivery.
-	if done := li.enforceBudget(context.Background(), Request{Title: "x"}, sys, specs, &calib, providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); done {
+	if done := li.enforceBudget(context.Background(), Request{Title: "x"}, sys, specs, &calib, &providers.UsageTotals{}, &providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); done {
 		t.Fatal("first over-budget call must nudge (done==false), not hard-kill")
 	}
 	if !budgetNudged {
@@ -1945,7 +1945,7 @@ func TestEnforceBudgetNudgeThenHardKill(t *testing.T) {
 	}
 
 	// Second over-budget call: hard-kill, exactly one delivery.
-	if done := li.enforceBudget(context.Background(), Request{Title: "x", Fingerprint: "fp-kill"}, sys, specs, &calib, providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); !done {
+	if done := li.enforceBudget(context.Background(), Request{Title: "x", Fingerprint: "fp-kill"}, sys, specs, &calib, &providers.UsageTotals{}, &providers.UsageTotals{}, &messages, &budgetNudged, &compactionLogged, &toolChoice, &result, finish); !done {
 		t.Fatal("second over-budget call must hard-kill (done==true)")
 	}
 	if result != "budget_exceeded" {

--- a/internal/investigate/recall_tokens_test.go
+++ b/internal/investigate/recall_tokens_test.go
@@ -57,8 +57,8 @@ func meteredInstruments(t *testing.T) (*telemetry.Metrics, func(series string) (
 // recall ACTUALLY spent, not to the configured budget ceiling.
 //
 // The regression it guards: the counter used to record MaxTokensPerInvestigation (the
-// ceiling — 100k by default, ~7x a real investigation's observed spend) and never
-// subtracted the recall's own model calls, so the series asserted a saving nobody
+// ceiling — 400k by default, many times a real investigation's observed spend) and
+// never subtracted the recall's own model calls, so the series asserted a saving nobody
 // measured. Both cases below configure a 100_000 ceiling precisely so a metric that
 // still reads the ceiling cannot pass.
 //

--- a/internal/investigate/rerank.go
+++ b/internal/investigate/rerank.go
@@ -42,7 +42,7 @@ import (
 //
 // COST discipline. It is one cheap call (~1–2k tokens) that buys back a whole
 // investigation when it fires — the recorded demo transcript's came to 7 calls /
-// ~15.6k tokens, and max_tokens_per_investigation caps a run at 100k. It only ever
+// ~15.6k tokens, against a max_tokens_per_investigation default of 400k. It only ever
 // runs when retrieval already surfaced a plausible candidate (Recall.lookup applies
 // the MinScore cost guard before calling rank).
 //

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -196,8 +196,11 @@ func TestCostCeilingIsInertWithoutPricing(t *testing.T) {
 	}
 }
 
-// TestCompactionDigestCountsTowardTheRunningTotal closes the last model call that was
-// spending outside the per-investigation accounting.
+// TestCompactionDigestCountsTowardTheRunningTotal closes the last COMPLETION inside
+// the investigation loop that was spending outside the per-investigation accounting.
+// Not the last spend path overall: the /embeddings call on the hybrid-recall query
+// path also runs inside an investigation and is still uncounted (instrumented, not
+// bounded — see internal/embed and the inventory in docs/configuration).
 //
 // Under `compaction: summarize` the loop pays for an extra completion on every
 // compaction event: a digest of the batch it just elided. Its tokens reached

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -21,26 +22,26 @@ import (
 // spend, not merely the size of the next request.
 //
 // The shape that made the old guard vacuous is reproduced exactly: every request
-// is modest (30k reported input tokens, well under the 100k ceiling), the message
-// history stays tiny, and the model never winds down. Under a next-request-only
-// check nothing ever exceeds the ceiling, so the loop runs the full step budget
-// and bills ~10 x 30k against a "100k budget". With a running total the ladder
-// must engage on the step whose request would carry the run past 100_000 — the
-// fourth, since 3 x 30_010 already spent plus a fourth ~30k request projects to
-// 120_030.
+// is modest — 60k reported input tokens, comfortably under the 100_000 bound this
+// ceiling derives for one request — the message history stays tiny, and the model
+// never winds down. Under a next-request-only check nothing ever exceeds anything,
+// so the loop runs the full step budget and bills ~10 x 60k against a "400k budget".
+// With a running total the ladder must engage on the step whose request would carry
+// the run past 400_000: the seventh, since 6 x 60_010 already spent plus a seventh
+// ~60k request projects to 420_060.
 //
 // The exact call count is the assertion, not a range: it pins WHERE on the ladder
-// the stop happens. Three free calls, one nudged call (the model is told to conclude
+// the stop happens. Six free calls, one nudged call (the model is told to conclude
 // and forced to submit_findings), then the hard-kill — the same two-rung ladder the
 // per-request ceiling has always used, so an operator sees one behaviour.
 func TestTokenCeilingIsARunningTotal(t *testing.T) {
 	const (
-		perCall  = 30_010 // reportingRunawayModel: 30_000 input + 10 output
-		perEst   = 30_000 // the anchored estimate of the NEXT request: its input half
-		ceiling  = 100_000
+		perCall  = 60_010 // reportingRunawayModel: 60_000 input + 10 output
+		perEst   = 60_000 // the anchored estimate of the NEXT request: its input half
+		ceiling  = 400_000
 		maxSteps = 10
 	)
-	model := &reportingRunawayModel{inputTokens: 30_000}
+	model := &reportingRunawayModel{inputTokens: perEst}
 	var got *providers.Investigation
 	li := &LoopInvestigator{
 		Model:                     model,
@@ -260,10 +261,12 @@ func TestBudgetTripTelemetryNamesTheCeilingAndRung(t *testing.T) {
 	t.Cleanup(func() { _ = shutdown(context.Background()) })
 
 	li := &LoopInvestigator{
-		Model:                     &reportingRunawayModel{inputTokens: 30_000},
+		// 60k per request against a 400_000 ceiling: modest next to the 100_000 bound
+		// the ceiling derives for one request, so only the CUMULATIVE arm can fire.
+		Model:                     &reportingRunawayModel{inputTokens: 60_000},
 		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
 		MaxSteps:                  10,
-		MaxTokensPerInvestigation: 100_000,
+		MaxTokensPerInvestigation: 400_000,
 		Metrics:                   telemetry.NewMetrics(),
 		OnComplete:                func(providers.Investigation) {},
 	}
@@ -313,16 +316,18 @@ func TestBudgetTripReportsOneCeilingForTheWholeRun(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = shutdown(context.Background()) })
 
-	// Per call: 30_010 tokens, $0.3005. Each step projects one more request on top:
-	// +30_000 tokens, +$0.30 (input only — see projectSpend).
-	//   after 2 calls: 60_020 tokens / $0.6010 → projects to  90_020 / $0.9010
-	//   after 3 calls: 90_030 tokens / $0.9015 → projects to 120_030 / $1.2015
-	// $0.85 is crossed a step BEFORE 100_000 is, so the COST arm engages the ladder;
+	// Per call: 60_010 tokens, $0.6005. Each step projects one more request on top:
+	// +60_000 tokens, +$0.60 (input only — see projectSpend).
+	//   after 4 calls: 240_040 tokens / $2.4020 → projects to 300_040 / $3.0020
+	//   after 5 calls: 300_050 tokens / $3.0025 → projects to 360_050 / $3.6025
+	// $3.40 is crossed a step BEFORE 400_000 is, so the COST arm engages the ladder;
 	// by the kill the token projection is over too, and the ordered switch — which
 	// puts tokens ahead of cost — would answer tokens_total if it were re-evaluated.
+	// 60_000 stays under the 100_000 bound the ceiling derives for one request, so the
+	// per-request arm is not a third candidate here.
 	const (
-		perEst     = 30_000 // the anchored estimate of the next request
-		tokCeiling = 100_000
+		perEst     = 60_000 // the anchored estimate of the next request
+		tokCeiling = 400_000
 	)
 	var got providers.Investigation
 	li := &LoopInvestigator{
@@ -331,7 +336,7 @@ func TestBudgetTripReportsOneCeilingForTheWholeRun(t *testing.T) {
 		MaxSteps:                  10,
 		Pricing:                   costPricing,
 		MaxTokensPerInvestigation: tokCeiling,
-		MaxCostPerInvestigation:   0.85,
+		MaxCostPerInvestigation:   3.40,
 		Metrics:                   telemetry.NewMetrics(),
 		OnComplete:                func(inv providers.Investigation) { got = inv },
 	}
@@ -388,15 +393,39 @@ func (b bulkTool) Call(context.Context, string) (string, error) {
 // It concludes the moment the loop forces submit_findings, i.e. on the nudged turn,
 // so a run takes the ladder's BEST case: nudge, one more request, done. Every worse
 // path (model keeps rambling, hard-kill) bills at least as much.
+//
+// tool names the tool it calls each turn, because that decides whether mid-loop
+// compaction may touch the transcript at all: `what_changed` is on compactHistory's
+// keep list (never elided), `big_tool` is ordinary and therefore elidable. A fixture
+// that only ever calls a keep-listed tool cannot observe compaction, so the field is
+// explicit rather than defaulted.
 type growingUsageModel struct {
 	density int
+	tool    string
 	calls   int
 	billed  []int // reported input+output tokens per call, in order
+
+	// elidedAtCall is the 1-based index of the first request that arrived carrying an
+	// elision marker — i.e. the first request compaction had shrunk. 0 means compaction
+	// never fired. spentBeforeElision is what the run had already billed at that point,
+	// so a test can assert compaction happened while the ceiling still had headroom
+	// rather than after the ladder had already stopped the run.
+	elidedAtCall       int
+	spentBeforeElision int
 }
 
 func (m *growingUsageModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
 	m.calls++
 	const out = 300
+	if m.elidedAtCall == 0 {
+		for _, msg := range req.Messages {
+			if isElidedMarker(msg.Content) {
+				m.elidedAtCall = m.calls
+				m.spentBeforeElision = m.spent()
+				break
+			}
+		}
+	}
 	in := m.density * estimateTokens(req.System, req.Messages, req.Tools)
 	m.billed = append(m.billed, in+out)
 	resp := providers.CompletionResponse{Usage: providers.Usage{InputTokens: in, OutputTokens: out}}
@@ -405,8 +434,20 @@ func (m *growingUsageModel) Complete(_ context.Context, req providers.Completion
 			Args: `{"confidence":0.5,"root_causes":[{"summary":"wrapped up at the ceiling"}]}`}}
 		return resp, nil
 	}
-	resp.ToolCalls = []providers.ToolCall{{ID: "t", Name: "what_changed", Args: `{}`}}
+	// A distinct id per call: compactHistory attributes a tool RESULT to its tool
+	// through the call id, and a fixture that reused one id would make every result
+	// look like a repeat of the same call.
+	resp.ToolCalls = []providers.ToolCall{{ID: "t" + strconv.Itoa(m.calls), Name: m.tool, Args: `{}`}}
 	return resp, nil
+}
+
+// spent is everything this model has reported so far.
+func (m *growingUsageModel) spent() int {
+	n := 0
+	for _, b := range m.billed {
+		n += b
+	}
+	return n
 }
 
 // largestBilled returns the biggest single completion this model was billed for.
@@ -436,7 +477,7 @@ func (m *growingUsageModel) largestBilled() int {
 // earlier, so the nudged turn is the request that crosses rather than the one after it.
 func TestTokenCeilingBoundsTheTokensActuallyDelivered(t *testing.T) {
 	const ceiling = 100_000
-	model := &growingUsageModel{density: 2}
+	model := &growingUsageModel{density: 2, tool: "what_changed"}
 	var got providers.Investigation
 	li := &LoopInvestigator{
 		Model:                     model,
@@ -466,6 +507,144 @@ func TestTokenCeilingBoundsTheTokensActuallyDelivered(t *testing.T) {
 			"the cumulative arm must trip on spent+est — what the run will have cost once this "+
 			"request is sent — not on what it has cost already.",
 			ceiling, delivered, float64(delivered)/ceiling, model.billed, ceiling+largest)
+	}
+}
+
+// TestCompactionFiresBeforeTheCumulativeCeiling pins the property that made
+// `compaction: summarize` dead code the moment the token ceiling became a running
+// total: mid-loop compaction has to be REACHABLE.
+//
+// Compaction is the loop's answer to a transcript that outgrows one request. It has
+// to trigger off a bound on ONE request, because that is the quantity it can do
+// something about — it shrinks the next request; it cannot un-spend what is already
+// billed. Keyed off the CUMULATIVE ceiling instead, its trigger sits at 0.7x a number
+// the run's accumulated spend reaches first: on a monotonically growing transcript
+// sum(est_i) passes the ceiling long before any single est_i reaches 0.7 of it, so the
+// ladder always stops the run first and compaction never runs. Measured at the shipped
+// tool-output cap before this was split: the largest single request of a run was 51 323
+// tokens against a 70 000 trigger — compaction never fired at any ceiling.
+//
+// The whole existing compaction suite passed throughout, because its main model
+// reports ZERO usage: with loopTotals pinned at 0 the cumulative arm can never engage,
+// so those tests cannot see this at all. That is why this one drives the loop with a
+// model that reports usage proportional to the request it was actually sent, and why
+// it asserts the run had really started spending before compaction fired.
+func TestCompactionFiresBeforeTheCumulativeCeiling(t *testing.T) {
+	const ceiling = 400_000
+	// big_tool is NOT on compactHistory's keep list, so its outputs are elidable —
+	// the case an operator's log/diff-heavy investigation actually hits.
+	model := &growingUsageModel{density: 2, tool: "big_tool"}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     model,
+		Tools:                     []Tool{bigTool{size: 32768}},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  20,
+		MaxToolOutputBytes:        32768,
+		MaxTokensPerInvestigation: ceiling,
+		OnComplete:                func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "compaction-reachable", Fingerprint: "fp-compact"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	// Premise: this fixture really is billing tokens. A model reporting zero usage
+	// keeps the cumulative arm at 0 forever, which is exactly how the regression hid.
+	if delivered := got.Usage.InputTokens + got.Usage.OutputTokens; delivered == 0 {
+		t.Fatal("premise failed — the model reported no usage, so the cumulative ceiling was " +
+			"never engaged and this test could not observe the interaction it exists to pin")
+	}
+	if model.elidedAtCall == 0 {
+		t.Fatalf("mid-loop compaction never fired in %d requests against a %d-token ceiling "+
+			"(billed per call %v). The compaction trigger must key off the bound on ONE request, "+
+			"not off the cumulative run budget: keyed off the cumulative number its trigger sits "+
+			"above what a single request ever reaches, so the ladder stops the run first and "+
+			"`compaction: summarize` cannot run at any default-shaped config.",
+			model.calls, ceiling, model.billed)
+	}
+	// …and it fired while the ceiling still had headroom. Compaction that only ever
+	// ran on the nudged turn would technically "fire" while still being useless: by
+	// then the spend it exists to avoid has already happened.
+	if model.spentBeforeElision >= ceiling {
+		t.Fatalf("compaction first fired on call %d, by which point the run had already billed "+
+			"%d of its %d-token ceiling — compaction exists to keep a run under the ceiling, so "+
+			"firing at or past it buys nothing", model.elidedAtCall, model.spentBeforeElision, ceiling)
+	}
+}
+
+// TestPerRequestCeilingIsAFractionOfTheCumulativeOne pins the second half of the same
+// split: the per-request arm needs its OWN threshold.
+//
+// One number cannot mean both "what the whole run may spend" and "what one request may
+// spend". Read as a run budget it is right; reused as the per-request bound it says a
+// single request may consume the entire investigation's budget — which is no bound at
+// all, and leaves compaction (0.7x of it) unreachable. So the per-request arm compares
+// against requestBudget: a quarter of the run's budget, i.e. "the ceiling must fund at
+// least four full-size requests".
+//
+// The fixture is the shape only the per-request arm can catch: one request four times
+// the size of a normal one, arriving while the run's cumulative spend is still well
+// under the ceiling. Against a per-request arm set to the whole ceiling, nothing stops
+// it — the run drifts on and is eventually stopped by the cumulative arm instead, which
+// names a different knob to the operator and lets the oversized request be billed twice
+// over before anything reacts.
+func TestPerRequestCeilingIsAFractionOfTheCumulativeOne(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	// perCall is over the per-request bound but small enough that three of them still
+	// project under the run budget — so the cumulative arm demonstrably has room left
+	// when the per-request arm fires, and only the per-request arm can explain the stop.
+	const (
+		ceiling  = 400_000 // ⇒ per-request bound 100_000
+		perCall  = 120_000 // one request, a fifth over that bound
+		wantCall = 2       // one free call, then the nudged one; the next check kills
+	)
+	model := &reportingRunawayModel{inputTokens: perCall}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     model,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: ceiling,
+		Metrics:                   telemetry.NewMetrics(),
+		OnComplete:                func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "oversized-request", Fingerprint: "fp-req"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	if model.calls != wantCall {
+		t.Fatalf("the model was called %d times, want %d: a request of %d tokens is over a %d-token "+
+			"per-request bound (a quarter of the %d ceiling) and must be caught before it is sent "+
+			"a second time, not left to the cumulative arm several requests later",
+			model.calls, wantCall, perCall, ceiling/4, ceiling)
+	}
+	// Premise: the CUMULATIVE arm cannot be what stopped this. Even projecting one more
+	// request on top of everything billed, the run is under the ceiling — so a stop here
+	// can only have come from the per-request arm.
+	spent := got.Usage.InputTokens + got.Usage.OutputTokens
+	if spent+perCall > ceiling {
+		t.Fatalf("premise failed — the run billed %d and projects to %d against a %d ceiling, so "+
+			"the cumulative arm could have stopped it and this test would pass vacuously",
+			spent, spent+perCall, ceiling)
+	}
+	body := scrapeMetrics(t, h)
+	if !strings.Contains(body, `reason="tokens_request"`) {
+		t.Fatalf("a single oversized request must be reported as a per-request trip — the operator's "+
+			"fix is to shrink one request (max_tool_output_bytes, compaction), not to raise the run "+
+			"budget:\n%s", body)
+	}
+	if strings.Contains(body, `reason="tokens_total"`) {
+		t.Fatalf("this run never approached its cumulative budget, so a tokens_total series points "+
+			"the operator at the wrong knob:\n%s", body)
+	}
+	if !mentions(got.Unresolved, "per-request") {
+		t.Fatalf("the delivered stub must name the per-request bound it hit; got: %v", got.Unresolved)
 	}
 }
 

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -25,16 +25,18 @@ import (
 // history stays tiny, and the model never winds down. Under a next-request-only
 // check nothing ever exceeds the ceiling, so the loop runs the full step budget
 // and bills ~10 x 30k against a "100k budget". With a running total the ladder
-// must engage after the fourth call, which is the first moment accumulated spend
-// (4 x 30_010 = 120_040) crosses 100_000.
+// must engage on the step whose request would carry the run past 100_000 — the
+// fourth, since 3 x 30_010 already spent plus a fourth ~30k request projects to
+// 120_030.
 //
 // The exact call count is the assertion, not a range: it pins WHERE on the ladder
-// the stop happens. Four free calls, one nudged call (the model is told to conclude
+// the stop happens. Three free calls, one nudged call (the model is told to conclude
 // and forced to submit_findings), then the hard-kill — the same two-rung ladder the
 // per-request ceiling has always used, so an operator sees one behaviour.
 func TestTokenCeilingIsARunningTotal(t *testing.T) {
 	const (
 		perCall  = 30_010 // reportingRunawayModel: 30_000 input + 10 output
+		perEst   = 30_000 // the anchored estimate of the NEXT request: its input half
 		ceiling  = 100_000
 		maxSteps = 10
 	)
@@ -51,12 +53,13 @@ func TestTokenCeilingIsARunningTotal(t *testing.T) {
 		t.Fatalf("Investigate: %v", err)
 	}
 
-	// freeCalls = the smallest k whose accumulated spend k*perCall crosses the
-	// ceiling; the nudge fires at the top of the step after those. One nudged call
-	// follows (the model is forced to conclude and refuses), then the next check
-	// hard-kills — so the model is called freeCalls+1 times in total.
+	// freeCalls = how many requests fit before the PROJECTED total (what is already
+	// spent plus the request about to be sent) crosses the ceiling. The nudge fires on
+	// the step after those; one nudged call follows (the model is forced to conclude
+	// and refuses), then the next check hard-kills — so the model is called
+	// freeCalls+1 times in total.
 	freeCalls := 0
-	for spent := 0; spent <= ceiling; spent += perCall {
+	for spent := 0; spent+perEst <= ceiling; spent += perCall {
 		freeCalls++
 	}
 	wantCalls := freeCalls + 1
@@ -106,11 +109,16 @@ func costCeilingInvestigator(pricing *Pricing, ceilingUSD float64) (*LoopInvesti
 //
 // The token ceiling is explicitly disabled here, so the only thing that can stop this
 // runaway loop before max_steps is max_cost_per_investigation. One call costs
-// $0.3005; against a $1.00 ceiling the fourth call is the first to cross it, so the
-// ladder nudges on the step after that and kills on the one after.
+// $0.3005, and the pending request projects at $0.30 (its input half, priced as
+// uncached); against a $1.00 ceiling the fourth request is the first whose projection
+// crosses, so the ladder nudges on that step and kills on the one after.
 func TestCostCeilingStopsTheInvestigation(t *testing.T) {
 	const (
 		perCallUSD = costPerCallUSD
+		// estCostUSD is what the NEXT request projects at: 30_000 input tokens at
+		// $10/Mtok. Output length is unknown before the request is sent, so the
+		// projection deliberately omits it and errs low.
+		estCostUSD = 0.30
 		ceilingUSD = 1.00
 	)
 	li, model := costCeilingInvestigator(costPricing, ceilingUSD)
@@ -121,7 +129,7 @@ func TestCostCeilingStopsTheInvestigation(t *testing.T) {
 	}
 
 	freeCalls := 0
-	for spent := 0.0; spent <= ceilingUSD; spent += perCallUSD {
+	for spent := 0.0; spent+estCostUSD <= ceilingUSD; spent += perCallUSD {
 		freeCalls++
 	}
 	if want := freeCalls + 1; model.calls != want {
@@ -276,6 +284,109 @@ func TestBudgetTripTelemetryNamesTheCeilingAndRung(t *testing.T) {
 	// so a series labelled tokens_request would be pointing at the wrong knob.
 	if strings.Contains(body, `reason="tokens_request"`) {
 		t.Fatalf("modest requests must not be reported as a per-request trip:\n%s", body)
+	}
+}
+
+// bulkTool is a tool whose result is a fixed, large blob, so the message history —
+// and therefore every subsequent request — grows the way a real tool-heavy
+// investigation's does. size is the reply length in bytes.
+type bulkTool struct{ size int }
+
+func (bulkTool) Name() string        { return "what_changed" }
+func (bulkTool) Description() string { return "returns a bulky tool result" }
+func (bulkTool) Schema() string      { return `{"type":"object"}` }
+func (b bulkTool) Call(context.Context, string) (string, error) {
+	return strings.Repeat("evidence line for the investigation transcript\n", b.size/45), nil
+}
+
+// growingUsageModel reports provider usage proportional to the request it was
+// actually sent, so the reported total grows monotonically with the transcript —
+// which is what makes the requests AFTER a ceiling trips the largest of the run.
+// density is the tokens-per-heuristic-token ratio a real tokenizer shows once JSON
+// envelope and role overhead are counted; reporting off the request rather than off
+// a fixed script means the fixture cannot drift away from what the loop really sent.
+//
+// It concludes the moment the loop forces submit_findings, i.e. on the nudged turn,
+// so a run takes the ladder's BEST case: nudge, one more request, done. Every worse
+// path (model keeps rambling, hard-kill) bills at least as much.
+type growingUsageModel struct {
+	density int
+	calls   int
+	billed  []int // reported input+output tokens per call, in order
+}
+
+func (m *growingUsageModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	const out = 300
+	in := m.density * estimateTokens(req.System, req.Messages, req.Tools)
+	m.billed = append(m.billed, in+out)
+	resp := providers.CompletionResponse{Usage: providers.Usage{InputTokens: in, OutputTokens: out}}
+	if req.ToolChoice == submitFindingsName {
+		resp.ToolCalls = []providers.ToolCall{{ID: "s", Name: submitFindingsName,
+			Args: `{"confidence":0.5,"root_causes":[{"summary":"wrapped up at the ceiling"}]}`}}
+		return resp, nil
+	}
+	resp.ToolCalls = []providers.ToolCall{{ID: "t", Name: "what_changed", Args: `{}`}}
+	return resp, nil
+}
+
+// largestBilled returns the biggest single completion this model was billed for.
+func (m *growingUsageModel) largestBilled() int {
+	n := 0
+	for _, b := range m.billed {
+		if b > n {
+			n = b
+		}
+	}
+	return n
+}
+
+// TestTokenCeilingBoundsTheTokensActuallyDelivered measures what the ceiling costs
+// rather than asserting what the guard compares.
+//
+// The ladder is allowed exactly ONE request past the trip by design: the nudge has to
+// give the model a turn to conclude. So the honest bound is `ceiling + the largest
+// single completion the run made` — one request of residual overshoot, no more.
+//
+// Comparing what is ALREADY spent against the ceiling cannot hold that bound: the
+// cumulative arm only fires once spend has crossed, and THEN spends a further request
+// on the nudged turn — and because the transcript grows monotonically, that request is
+// the largest of the run. Two of the run's biggest requests land past the ceiling
+// instead of one, which is how a 100k ceiling delivers ~1.9x its number. Tripping on
+// the PROJECTED total (spent + the request about to be sent) moves the trip one turn
+// earlier, so the nudged turn is the request that crosses rather than the one after it.
+func TestTokenCeilingBoundsTheTokensActuallyDelivered(t *testing.T) {
+	const ceiling = 100_000
+	model := &growingUsageModel{density: 2}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     model,
+		Tools:                     []Tool{bulkTool{size: 32768}},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  20,
+		MaxToolOutputBytes:        32768,
+		MaxTokensPerInvestigation: ceiling,
+		OnComplete:                func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "delivered-tokens", Fingerprint: "fp-delivered"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	delivered := got.Usage.InputTokens + got.Usage.OutputTokens
+	// Premise: the run really did have to be stopped by the ceiling, and it really did
+	// grow — otherwise the bound below would hold for uninteresting reasons.
+	if model.calls < 3 || model.calls >= li.MaxSteps {
+		t.Fatalf("premise failed — the ceiling must stop a growing run before max_steps; %d calls of %d, billed %v",
+			model.calls, li.MaxSteps, model.billed)
+	}
+	if largest := model.largestBilled(); delivered > ceiling+largest {
+		t.Fatalf("a %d-token ceiling delivered %d tokens (%.2fx), billed per call %v.\n"+
+			"The ladder concedes ONE request past the trip (the nudged turn), so the most an "+
+			"operator may be billed is ceiling+largest request = %d. Anything beyond that is a "+
+			"second oversized request charged after the ceiling was already known to be crossed: "+
+			"the cumulative arm must trip on spent+est — what the run will have cost once this "+
+			"request is sent — not on what it has cost already.",
+			ceiling, delivered, float64(delivered)/ceiling, model.billed, ceiling+largest)
 	}
 }
 

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/noop"
 
+	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/telemetry"
 )
@@ -399,11 +401,17 @@ func (b bulkTool) Call(context.Context, string) (string, error) {
 // keep list (never elided), `big_tool` is ordinary and therefore elidable. A fixture
 // that only ever calls a keep-listed tool cannot observe compaction, so the field is
 // explicit rather than defaulted.
+// convergesAfter is how many tool calls the model makes before submitting findings of
+// its own accord; 0 means it never winds down and only a forced submit_findings stops
+// it. nudged records whether the spend ladder was what forced it — distinct from the
+// loop's own final-step nudge, which is not a budget event.
 type growingUsageModel struct {
-	density int
-	tool    string
-	calls   int
-	billed  []int // reported input+output tokens per call, in order
+	density        int
+	tool           string
+	convergesAfter int
+	calls          int
+	nudged         bool
+	billed         []int // reported input+output tokens per call, in order
 
 	// elidedAtCall is the 1-based index of the first request that arrived carrying an
 	// elision marker — i.e. the first request compaction had shrunk. 0 means compaction
@@ -417,21 +425,21 @@ type growingUsageModel struct {
 func (m *growingUsageModel) Complete(_ context.Context, req providers.CompletionRequest) (providers.CompletionResponse, error) {
 	m.calls++
 	const out = 300
-	if m.elidedAtCall == 0 {
-		for _, msg := range req.Messages {
-			if isElidedMarker(msg.Content) {
-				m.elidedAtCall = m.calls
-				m.spentBeforeElision = m.spent()
-				break
-			}
+	for _, msg := range req.Messages {
+		if m.elidedAtCall == 0 && isElidedMarker(msg.Content) {
+			m.elidedAtCall = m.calls
+			m.spentBeforeElision = m.spent()
+		}
+		if msg.Content == budgetNudge {
+			m.nudged = true
 		}
 	}
 	in := m.density * estimateTokens(req.System, req.Messages, req.Tools)
 	m.billed = append(m.billed, in+out)
 	resp := providers.CompletionResponse{Usage: providers.Usage{InputTokens: in, OutputTokens: out}}
-	if req.ToolChoice == submitFindingsName {
+	if req.ToolChoice == submitFindingsName || (m.convergesAfter > 0 && m.calls > m.convergesAfter) {
 		resp.ToolCalls = []providers.ToolCall{{ID: "s", Name: submitFindingsName,
-			Args: `{"confidence":0.5,"root_causes":[{"summary":"wrapped up at the ceiling"}]}`}}
+			Args: `{"confidence":0.5,"root_causes":[{"summary":"concluded"}]}`}}
 		return resp, nil
 	}
 	// A distinct id per call: compactHistory attributes a tool RESULT to its tool
@@ -645,6 +653,169 @@ func TestPerRequestCeilingIsAFractionOfTheCumulativeOne(t *testing.T) {
 	}
 	if !mentions(got.Unresolved, "per-request") {
 		t.Fatalf("the delivered stub must name the per-request bound it hit; got: %v", got.Unresolved)
+	}
+}
+
+// TestShippedTokenCeilingFundsARealInvestigation sizes the shipped default against
+// what an investigation actually costs, rather than against what the number used to
+// mean.
+//
+// 100000 was chosen when it bounded ONE request, and survived the change to cumulative
+// semantics unrevisited — under which it funded four or five steps. A default that cuts
+// a normal investigation short is as wrong as no default at all: the operator's first
+// experience is a stream of result="budget_exceeded" on incidents that were converging
+// fine, and the only remedy the docs can offer is to raise the number RunLore chose.
+//
+// So the bar is stated as investigations that must FINISH, at the tool-output sizes the
+// shipped config permits, and the default is read from ApplyDefaults rather than
+// written here — retuning either key re-runs this against the other. The rows are the
+// cost curve's three regimes: spend grows quadratically in steps, because the whole
+// transcript is re-sent every turn, so the affordable step count falls sharply as tool
+// results get bigger.
+//
+//	tool result | steps | model calls | cumulative tokens
+//	   32768 B  |     6 |           7 |           327 022  (compaction fires)
+//	    8192 B  |    12 |          13 |           379 022
+//	    2048 B  |    19 |          20 |           286 354  (the whole max_steps budget)
+//
+// 400000 is the smallest round figure that funds all three. The 8 KiB row binds: an
+// ordinary tool-heavy incident costs 379 022 tokens, so anything at or below 350000 cuts
+// it off. The 2 KiB row is why max_steps: 20 is a reachable setting again rather than
+// two shipped defaults where one can never be met. And the ceiling's own overshoot is
+// covered by the quarter that bounds one request, so the delivered total stays inside
+// ~1.25x the number an operator budgets against.
+func TestShippedTokenCeilingFundsARealInvestigation(t *testing.T) {
+	var c config.Config
+	config.ApplyDefaults(&c)
+	ceiling, toolCap := c.Investigation.MaxTokensPerInvestigation, c.Investigation.MaxToolOutputBytes
+
+	for _, tc := range []struct {
+		name      string
+		toolBytes int
+		steps     int
+	}{
+		{"every tool result at the shipped cap", toolCap, 6},
+		{"a quarter of the cap: an ordinary tool-heavy incident", toolCap / 4, 12},
+		{"small results, run out to the whole step budget", toolCap / 16, 19},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			model := &growingUsageModel{density: 2, tool: "big_tool", convergesAfter: tc.steps}
+			var got providers.Investigation
+			li := &LoopInvestigator{
+				Model:                     model,
+				Tools:                     []Tool{bigTool{size: tc.toolBytes}},
+				Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+				MaxSteps:                  20,
+				MaxToolOutputBytes:        toolCap,
+				MaxTokensPerInvestigation: ceiling,
+				OnComplete:                func(inv providers.Investigation) { got = inv },
+			}
+			if err := li.Investigate(context.Background(), Request{Title: "sizing", Fingerprint: "fp-sizing"}); err != nil {
+				t.Fatalf("Investigate: %v", err)
+			}
+			delivered := got.Usage.InputTokens + got.Usage.OutputTokens
+			if model.nudged {
+				t.Fatalf("a %d-step investigation with %d-byte tool results was cut short by the "+
+					"spend ladder after %d of %d calls (%d tokens billed against a %d-token ceiling). "+
+					"The shipped default has to fund an investigation that converges normally at the "+
+					"tool-output sizes the shipped max_tool_output_bytes permits — otherwise every "+
+					"real incident ends in budget_exceeded and the only fix is to raise the number "+
+					"RunLore picked.",
+					tc.steps, tc.toolBytes, model.calls, tc.steps+1, delivered, ceiling)
+			}
+			if len(got.RootCauses) == 0 {
+				t.Fatalf("the investigation delivered no root cause: %+v", got)
+			}
+			if want := tc.steps + 1; model.calls != want {
+				t.Fatalf("model called %d times, want %d (%d tool turns then the conclusion): "+
+					"something other than the spend ceiling changed how far the loop got",
+					model.calls, want, tc.steps)
+			}
+		})
+	}
+}
+
+// Operator-facing surfaces that state the spend ceilings' numbers. internal/docsguard
+// pins the cumulative default off ApplyDefaults; the DERIVED figures can only be pinned
+// from in here, where requestBudget and compactionTarget live.
+const (
+	spendDocPath   = "../../website/content/docs/configuration/configuration.md"
+	spendChartPath = "../../deploy/helm/runlore/values.yaml"
+)
+
+// ungroupDigits removes the spaces a prose page puts inside long numbers ("100 000"),
+// so one anchor matches both the page's typography and the chart's bare integers.
+func ungroupDigits(s string) string {
+	out := []rune(s)
+	for i := 1; i+1 < len(out); i++ {
+		if out[i] == ' ' && out[i-1] >= '0' && out[i-1] <= '9' && out[i+1] >= '0' && out[i+1] <= '9' {
+			out[i] = 0
+		}
+	}
+	var b strings.Builder
+	for _, r := range out {
+		if r != 0 {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// TestSpendCeilingDocsStateTheDerivedThresholds pins the two numbers an operator can
+// only get from the page, because nothing in the config file spells them out: the bound
+// on ONE request, and the size at which mid-loop compaction starts.
+//
+// Both are derived from max_tokens_per_investigation, so retuning that key — or the
+// fraction it derives them with — silently changes what the page means while every word
+// on it stays true-looking. That is the drift this repo keeps shipping, and the reason
+// docsguard exists; these two just cannot live there, since the derivation is internal
+// to this package. The overshoot multiplier is pinned for the same reason: it is
+// 1 + the fraction, and it is what an operator multiplies their bill by.
+//
+// Each anchor is the SENTENCE that makes the claim, with the derived figure computed
+// from the code rather than typed in — so a retune of the fraction and a rewrite of the
+// prose both fail here. The digits alone would not do: these pages quote several
+// six-figure token counts, and the migration note names the old default in its own
+// right, so an anchor on "100000" is satisfied by prose that says something else
+// entirely (demonstrated — deleting the per-request sentence left a digits-only guard
+// passing).
+func TestSpendCeilingDocsStateTheDerivedThresholds(t *testing.T) {
+	var c config.Config
+	config.ApplyDefaults(&c)
+	ceiling := c.Investigation.MaxTokensPerInvestigation
+	perRequest := strconv.Itoa(requestBudget(ceiling))
+	compaction := strconv.Itoa(compactionTarget(ceiling))
+	overshoot := strconv.FormatFloat(1+requestBudgetFraction, 'g', -1, 64)
+
+	for _, tc := range []struct {
+		path   string
+		claims []string
+	}{
+		{spendDocPath, []string{
+			"A quarter of it — **" + perRequest + "** at the default — additionally bounds",
+			"mid-loop compaction triggers at 70 % of *that* (**" + compaction + "**)",
+			"≈" + overshoot + "× the number you set",
+		}},
+		{spendChartPath, []string{
+			"A QUARTER of this (" + perRequest + " here) additionally bounds",
+			"compaction triggers at 70% of that quarter (" + compaction + ")",
+			"budget ~" + overshoot + "x",
+		}},
+	} {
+		raw, err := os.ReadFile(tc.path)
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.path, err)
+		}
+		doc := ungroupDigits(string(raw))
+		for _, want := range tc.claims {
+			if !strings.Contains(doc, want) {
+				t.Errorf("%s no longer states %q. At a %d-token ceiling one request is bounded at "+
+					"%d, compaction triggers at %d, and a run may still deliver %sx the ceiling — "+
+					"none of which an operator can compute from the page, so all three have to be "+
+					"written down and kept honest here.",
+					tc.path, want, ceiling, requestBudget(ceiling), compactionTarget(ceiling), overshoot)
+			}
+		}
 	}
 }
 

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -376,9 +376,16 @@ func TestBudgetTripReportsOneCeilingForTheWholeRun(t *testing.T) {
 // bulkTool is a tool whose result is a fixed, large blob, so the message history —
 // and therefore every subsequent request — grows the way a real tool-heavy
 // investigation's does. size is the reply length in bytes.
-type bulkTool struct{ size int }
+//
+// name decides whether compaction may touch those blobs: compactHistory keeps
+// `what_changed` and the rest of the root-cause skeleton verbatim, so a fixture using
+// that name models a transcript that cannot be shrunk at all.
+type bulkTool struct {
+	size int
+	name string
+}
 
-func (bulkTool) Name() string        { return "what_changed" }
+func (b bulkTool) Name() string      { return b.name }
 func (bulkTool) Description() string { return "returns a bulky tool result" }
 func (bulkTool) Schema() string      { return `{"type":"object"}` }
 func (b bulkTool) Call(context.Context, string) (string, error) {
@@ -484,15 +491,24 @@ func (m *growingUsageModel) largestBilled() int {
 // the PROJECTED total (spent + the request about to be sent) moves the trip one turn
 // earlier, so the nudged turn is the request that crosses rather than the one after it.
 func TestTokenCeilingBoundsTheTokensActuallyDelivered(t *testing.T) {
-	const ceiling = 100_000
-	model := &growingUsageModel{density: 2, tool: "what_changed"}
+	// Run at the SHIPPED defaults, because the overshoot figure the docs quote is the
+	// one an operator meets. It also keeps the fixture honest: every request has to stay
+	// inside the per-request bound the ceiling derives, which the premise below asserts.
+	var c config.Config
+	config.ApplyDefaults(&c)
+	ceiling := c.Investigation.MaxTokensPerInvestigation
+	// An ORDINARY tool, not a keep-listed one: compaction is part of the shipped
+	// behaviour, so a fixture whose every blob is exempt from it would measure a
+	// configuration nobody runs — and would be stopped by the per-request arm instead,
+	// which is a different guard from the one this test measures.
+	model := &growingUsageModel{density: 2, tool: "big_tool"}
 	var got providers.Investigation
 	li := &LoopInvestigator{
 		Model:                     model,
-		Tools:                     []Tool{bulkTool{size: 32768}},
+		Tools:                     []Tool{bulkTool{size: c.Investigation.MaxToolOutputBytes, name: "big_tool"}},
 		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
 		MaxSteps:                  20,
-		MaxToolOutputBytes:        32768,
+		MaxToolOutputBytes:        c.Investigation.MaxToolOutputBytes,
 		MaxTokensPerInvestigation: ceiling,
 		OnComplete:                func(inv providers.Investigation) { got = inv },
 	}
@@ -507,6 +523,15 @@ func TestTokenCeilingBoundsTheTokensActuallyDelivered(t *testing.T) {
 		t.Fatalf("premise failed — the ceiling must stop a growing run before max_steps; %d calls of %d, billed %v",
 			model.calls, li.MaxSteps, model.billed)
 	}
+	// Premise: it is the CUMULATIVE arm being measured. Every request stayed inside the
+	// per-request bound, so nothing here was stopped for being individually oversized —
+	// otherwise this measures the wrong guard while reading as though it measures this
+	// one, and the overshoot it reports is not the overshoot the docs quote.
+	if largest := model.largestBilled(); largest > requestBudget(ceiling) {
+		t.Fatalf("premise failed — a single request billed %d against a %d per-request bound, so the "+
+			"per-request arm stopped this run and the cumulative overshoot is not what was measured; "+
+			"billed %v", largest, requestBudget(ceiling), model.billed)
+	}
 	if largest := model.largestBilled(); delivered > ceiling+largest {
 		t.Fatalf("a %d-token ceiling delivered %d tokens (%.2fx), billed per call %v.\n"+
 			"The ladder concedes ONE request past the trip (the nudged turn), so the most an "+
@@ -514,7 +539,7 @@ func TestTokenCeilingBoundsTheTokensActuallyDelivered(t *testing.T) {
 			"second oversized request charged after the ceiling was already known to be crossed: "+
 			"the cumulative arm must trip on spent+est — what the run will have cost once this "+
 			"request is sent — not on what it has cost already.",
-			ceiling, delivered, float64(delivered)/ceiling, model.billed, ceiling+largest)
+			ceiling, delivered, float64(delivered)/float64(ceiling), model.billed, ceiling+largest)
 	}
 }
 

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -74,6 +74,120 @@ func TestTokenCeilingIsARunningTotal(t *testing.T) {
 	}
 }
 
+// costPerCallUSD is what one reportingRunawayModel{inputTokens: 30_000} completion
+// costs under costPricing: 30_000 input @ $10/Mtok = $0.3000, plus its 10 output
+// tokens @ $50/Mtok = $0.0005.
+const costPerCallUSD = 0.3005
+
+// costPricing is the rate card costPerCallUSD is derived from.
+var costPricing = &Pricing{InputUSDPerMTok: 10, OutputUSDPerMTok: 50}
+
+// costCeilingInvestigator builds a runaway loop whose every completion reports the
+// same usage. Pricing is passed in so the caller can also exercise the unpriced
+// case, where the ceiling is inert by construction.
+func costCeilingInvestigator(pricing *Pricing, ceilingUSD float64) (*LoopInvestigator, *reportingRunawayModel) {
+	model := &reportingRunawayModel{inputTokens: 30_000}
+	return &LoopInvestigator{
+		Model:   model,
+		Log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Pricing: pricing,
+		// The token ceiling is OFF so nothing but the currency comparison can stop
+		// this loop — otherwise a passing test would not tell the two apart.
+		MaxTokensPerInvestigation: 0,
+		MaxCostPerInvestigation:   ceilingUSD,
+		MaxSteps:                  10,
+		OnComplete:                func(providers.Investigation) {},
+	}, model
+}
+
+// TestCostCeilingStopsTheInvestigation pins the second half of the audit finding:
+// there was no ceiling denominated in CURRENCY at any scope. model.pricing computed
+// a cost at the END of an investigation and nothing compared it to anything.
+//
+// The token ceiling is explicitly disabled here, so the only thing that can stop this
+// runaway loop before max_steps is max_cost_per_investigation. One call costs
+// $0.3005; against a $1.00 ceiling the fourth call is the first to cross it, so the
+// ladder nudges on the step after that and kills on the one after.
+func TestCostCeilingStopsTheInvestigation(t *testing.T) {
+	const (
+		perCallUSD = costPerCallUSD
+		ceilingUSD = 1.00
+	)
+	li, model := costCeilingInvestigator(costPricing, ceilingUSD)
+	var got *providers.Investigation
+	li.OnComplete = func(inv providers.Investigation) { got = &inv }
+	if err := li.Investigate(context.Background(), Request{Title: "runaway-cost", Fingerprint: "fp-cost"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	freeCalls := 0
+	for spent := 0.0; spent <= ceilingUSD; spent += perCallUSD {
+		freeCalls++
+	}
+	if want := freeCalls + 1; model.calls != want {
+		t.Fatalf("model was called %d times at $%.2f per call against a $%.2f ceiling "+
+			"(estimated spend $%.2f); want %d. model.pricing must gate the run, not merely report on it.",
+			model.calls, perCallUSD, ceilingUSD, float64(model.calls)*perCallUSD, want)
+	}
+	if got == nil {
+		t.Fatal("OnComplete never called: the cost hard-kill must still deliver an unresolved result")
+	}
+	if !mentions(got.Unresolved, "cost") {
+		t.Fatalf("the hard-kill result must name the cost ceiling it hit; got: %v", got.Unresolved)
+	}
+	// Premise: the delivered finding really is priced, so the comparison had a
+	// dollar figure to work with rather than passing on a zero.
+	if !got.Usage.Priced || got.Usage.CostUSD <= ceilingUSD {
+		t.Fatalf("premise failed — delivered usage must be priced and over the ceiling: %+v", got.Usage)
+	}
+}
+
+// TestOverCostBudgetRequiresAPricedTotal pins the guard that separates "$0 spent so
+// far" from "no dollar figure exists". Both leave UsageTotals.CostUSD at 0, so only
+// the Priced flag can tell them apart, and only the first may be compared.
+//
+// Today aggregateUsage never produces a CostUSD without setting Priced, so the loop
+// test above cannot reach this case — which is exactly why it is pinned here
+// directly. Reading CostUSD without the flag is the bug that would let an unpriced
+// deployment believe a ceiling was in force.
+func TestOverCostBudgetRequiresAPricedTotal(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		spent   providers.UsageTotals
+		ceiling float64
+		want    bool
+	}{
+		{"unpriced totals never trip, whatever CostUSD holds",
+			providers.UsageTotals{CostUSD: 5, Priced: false}, 1, false},
+		{"priced and over", providers.UsageTotals{CostUSD: 5, Priced: true}, 1, true},
+		{"priced and under", providers.UsageTotals{CostUSD: 0.5, Priced: true}, 1, false},
+		{"priced exactly at the ceiling is not over (strict >)",
+			providers.UsageTotals{CostUSD: 1, Priced: true}, 1, false},
+		{"no ceiling configured", providers.UsageTotals{CostUSD: 999, Priced: true}, 0, false},
+	} {
+		if got := overCostBudget(tc.spent, tc.ceiling); got != tc.want {
+			t.Errorf("%s: overCostBudget(%+v, %v) = %v, want %v", tc.name, tc.spent, tc.ceiling, got, tc.want)
+		}
+	}
+}
+
+// TestCostCeilingIsInertWithoutPricing states the limitation plainly rather than
+// leaving it implied: with no model.pricing there is no cost to compare, so
+// max_cost_per_investigation cannot fire and the run goes the full distance. This is
+// exactly the silent-no-op that CostCeilingWithoutPricingWarning exists to announce
+// at startup — the guard for that lives in internal/app.
+func TestCostCeilingIsInertWithoutPricing(t *testing.T) {
+	li, model := costCeilingInvestigator(nil /* unpriced */, 0.01)
+	if err := li.Investigate(context.Background(), Request{Title: "unpriced"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if model.calls != li.MaxSteps {
+		t.Fatalf("model was called %d times, want %d (the full step budget): an unpriced "+
+			"investigation has no cost to compare, so the ceiling must be inert — not "+
+			"accidentally firing on a zero cost", model.calls, li.MaxSteps)
+	}
+}
+
 // TestBudgetTripTelemetryNamesTheCeilingAndRung pins what an operator can actually
 // see when a ceiling fires in production.
 //

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -287,6 +287,82 @@ func TestBudgetTripTelemetryNamesTheCeilingAndRung(t *testing.T) {
 	}
 }
 
+// TestBudgetTripReportsOneCeilingForTheWholeRun pins that a run names ONE ceiling.
+//
+// budgetTrip is an ordered switch (tokens_request → tokens_total → cost) re-evaluated
+// on every rung, so the two rungs can disagree: the ceilings below are set so the COST
+// arm is the one that stops the run, while the nudged turn it concedes pushes the token
+// total past its own ceiling. Re-evaluated at the kill, the ordered switch answers
+// "tokens_total" — a different knob from the one the operator was told about at the
+// nudge, and the wrong one to raise. The delivered stub then names the cumulative token
+// budget for a run that only ever exceeded its dollar ceiling, and
+// `sum by (reason) (rate(...))` splits one stop across two series.
+//
+// The reason is therefore latched when the ladder first engages and carried to the
+// kill. Recomputing at the kill with the original ordering would not fix this: the
+// spend it reads has grown since, so the ordering can still land on a different arm.
+// Only the ceiling that FIRST stopped the run answers "which knob do I raise".
+func TestBudgetTripReportsOneCeilingForTheWholeRun(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	// Per call: 30_010 tokens, $0.3005. Each step projects one more request on top:
+	// +30_000 tokens, +$0.30 (input only — see projectSpend).
+	//   after 2 calls: 60_020 tokens / $0.6010 → projects to  90_020 / $0.9010
+	//   after 3 calls: 90_030 tokens / $0.9015 → projects to 120_030 / $1.2015
+	// $0.85 is crossed a step BEFORE 100_000 is, so the COST arm engages the ladder;
+	// by the kill the token projection is over too, and the ordered switch — which
+	// puts tokens ahead of cost — would answer tokens_total if it were re-evaluated.
+	const (
+		perEst     = 30_000 // the anchored estimate of the next request
+		tokCeiling = 100_000
+	)
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     &reportingRunawayModel{inputTokens: perEst},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		Pricing:                   costPricing,
+		MaxTokensPerInvestigation: tokCeiling,
+		MaxCostPerInvestigation:   0.85,
+		Metrics:                   telemetry.NewMetrics(),
+		OnComplete:                func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "one-ceiling", Fingerprint: "fp-one"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	body := scrapeMetrics(t, h)
+	for _, want := range []string{
+		`reason="cost",stage="nudge"`,
+		`reason="cost",stage="kill"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("budget-trip telemetry missing %s — the ceiling that stopped the run must be "+
+				"the one reported on BOTH rungs:\n%s", want, body)
+		}
+	}
+	// Premise: at the kill the TOKEN arm is genuinely crossed too — otherwise the
+	// ordered switch would have nothing else to name and the test would pass vacuously.
+	if spent := got.Usage.InputTokens + got.Usage.OutputTokens; spent+perEst <= tokCeiling {
+		t.Fatalf("premise failed — by the kill the projected token total must be over %d so the "+
+			"ordered switch has a second arm to land on; spent %d, projected %d",
+			tokCeiling, spent, spent+perEst)
+	}
+	if strings.Contains(body, `reason="tokens_total"`) {
+		t.Fatalf("the kill renamed the ceiling: this run was stopped by max_cost_per_investigation, "+
+			"so a tokens_total series tells the operator to raise the wrong knob:\n%s", body)
+	}
+	if !mentions(got.Unresolved, "cost ceiling") {
+		t.Fatalf("the delivered stub must name the ceiling that stopped the run (the cost one); got: %v",
+			got.Unresolved)
+	}
+}
+
 // bulkTool is a tool whose result is a fixed, large blob, so the message history —
 // and therefore every subsequent request — grows the way a real tool-heavy
 // investigation's does. size is the reply length in bytes.

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// TestTokenCeilingIsARunningTotal pins the property the audit found missing:
+// max_tokens_per_investigation must bound the investigation's CUMULATIVE model
+// spend, not merely the size of the next request.
+//
+// The shape that made the old guard vacuous is reproduced exactly: every request
+// is modest (30k reported input tokens, well under the 100k ceiling), the message
+// history stays tiny, and the model never winds down. Under a next-request-only
+// check nothing ever exceeds the ceiling, so the loop runs the full step budget
+// and bills ~10 x 30k against a "100k budget". With a running total the ladder
+// must engage after the fourth call, which is the first moment accumulated spend
+// (4 x 30_010 = 120_040) crosses 100_000.
+//
+// The exact call count is the assertion, not a range: it pins WHERE on the ladder
+// the stop happens. Four free calls, one nudged call (the model is told to conclude
+// and forced to submit_findings), then the hard-kill — the same two-rung ladder the
+// per-request ceiling has always used, so an operator sees one behaviour.
+func TestTokenCeilingIsARunningTotal(t *testing.T) {
+	const (
+		perCall  = 30_010 // reportingRunawayModel: 30_000 input + 10 output
+		ceiling  = 100_000
+		maxSteps = 10
+	)
+	model := &reportingRunawayModel{inputTokens: 30_000}
+	var got *providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     model,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  maxSteps,
+		MaxTokensPerInvestigation: ceiling,
+		OnComplete:                func(inv providers.Investigation) { got = &inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "runaway-total", Fingerprint: "fp-total"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	// freeCalls = the smallest k whose accumulated spend k*perCall crosses the
+	// ceiling; the nudge fires at the top of the step after those. One nudged call
+	// follows (the model is forced to conclude and refuses), then the next check
+	// hard-kills — so the model is called freeCalls+1 times in total.
+	freeCalls := 0
+	for spent := 0; spent <= ceiling; spent += perCall {
+		freeCalls++
+	}
+	wantCalls := freeCalls + 1
+	if model.calls != wantCalls {
+		t.Fatalf("model was called %d times against a %d-token ceiling at %d tokens per call "+
+			"(cumulative spend %d); want %d. A per-REQUEST check alone never trips here — "+
+			"max_tokens_per_investigation must bound accumulated spend.",
+			model.calls, ceiling, perCall, model.calls*perCall, wantCalls)
+	}
+	if got == nil {
+		t.Fatal("OnComplete never called: the hard-kill must still deliver an unresolved result")
+	}
+	if !mentions(got.Unresolved, "budget") {
+		t.Fatalf("the hard-kill result must name the budget it hit; got: %v", got.Unresolved)
+	}
+}
+
+// TestBudgetTripTelemetryNamesTheCeilingAndRung pins what an operator can actually
+// see when a ceiling fires in production.
+//
+// investigations_dropped_total already counts the kills, but it cannot answer either
+// question that matters: WHICH ceiling to raise, and how often runs are being cut
+// short WITHOUT dying — the nudge rung still delivers findings, so it leaves no other
+// trace at all. Both labels are therefore asserted on both rungs.
+func TestBudgetTripTelemetryNamesTheCeilingAndRung(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	li := &LoopInvestigator{
+		Model:                     &reportingRunawayModel{inputTokens: 30_000},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: 100_000,
+		Metrics:                   telemetry.NewMetrics(),
+		OnComplete:                func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "trip-telemetry"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	body := scrapeMetrics(t, h)
+	for _, want := range []string{
+		`runlore_investigation_budget_trips_total`,
+		`reason="tokens_total"`,
+		`stage="nudge"`,
+		`stage="kill"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("budget-trip telemetry missing %s — an operator cannot see which ceiling fired "+
+				"or which rung of the ladder it reached:\n%s", want, body)
+		}
+	}
+	// The reason must be the CUMULATIVE one: every individual request here is small,
+	// so a series labelled tokens_request would be pointing at the wrong knob.
+	if strings.Contains(body, `reason="tokens_request"`) {
+		t.Fatalf("modest requests must not be reported as a per-request trip:\n%s", body)
+	}
+}
+
+// mentions reports whether any line contains sub (case-insensitively).
+func mentions(lines []string, sub string) bool {
+	for _, l := range lines {
+		if strings.Contains(strings.ToLower(l), sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -188,6 +188,51 @@ func TestCostCeilingIsInertWithoutPricing(t *testing.T) {
 	}
 }
 
+// TestCompactionDigestCountsTowardTheRunningTotal closes the last model call that was
+// spending outside the per-investigation accounting.
+//
+// Under `compaction: summarize` the loop pays for an extra completion on every
+// compaction event: a digest of the batch it just elided. Its tokens reached
+// model_input_tokens_total but never loopTotals/verifyTotals, so they were absent from
+// the delivered cost footer, from investigation_cost_usd, and — once the ceilings
+// became running totals — from both ceilings. A ceiling with a hole in it is worse
+// than none, because it reports a number the operator believes.
+//
+// It is folded into the VERIFY totals, not the loop's: the digest call routes to
+// VerifyModel when one is configured, so aggregateUsage's existing split prices it at
+// the verify rate, which is the rate that was actually billed.
+func TestCompactionDigestCountsTowardTheRunningTotal(t *testing.T) {
+	// Small enough that the digests fit summarizeLoop's 6000-token ceiling: this test
+	// is about the tokens being COUNTED, and a fixture that also tripped the ceiling
+	// would stop the loop early and confuse the two properties.
+	const digestTokens = 400
+	sm := &fakeSummarizer{resp: providers.CompletionResponse{
+		Text:  digestSentinel,
+		Usage: providers.Usage{InputTokens: digestTokens, OutputTokens: 7},
+	}}
+	li, got := summarizeLoop(t, sm, nil)
+	// The main scriptModel reports zero usage, so every token in the delivered totals
+	// is the summarizer's — and the digest count is exactly its call count.
+	if err := li.Investigate(context.Background(), Request{Title: "digest accounting"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	digests := sm.count()
+	if digests == 0 {
+		t.Fatal("premise failed — no compaction digest was produced, so there is nothing to account for")
+	}
+	wantTokens := digests * (digestTokens + 7)
+	if spent := got.Usage.InputTokens + got.Usage.OutputTokens; spent != wantTokens {
+		t.Fatalf("delivered usage counts %d tokens after %d compaction digests; want %d — "+
+			"the digest call is billed like any other, so a running-total ceiling that cannot "+
+			"see it under-counts every summarize-mode investigation",
+			spent, digests, wantTokens)
+	}
+	if got.Usage.ModelCalls < digests {
+		t.Fatalf("delivered usage counts %d model calls but the summarizer alone made %d",
+			got.Usage.ModelCalls, digests)
+	}
+}
+
 // TestBudgetTripTelemetryNamesTheCeilingAndRung pins what an operator can actually
 // see when a ceiling fires in production.
 //

--- a/internal/investigate/summarize.go
+++ b/internal/investigate/summarize.go
@@ -38,7 +38,13 @@ Do NOT speculate, diagnose, rank causes, or add anything not present in the inpu
 // stored in history — already run through redact.Secrets at ingestion (loop.go). The
 // digest is derived only from that already-redacted text, so it introduces no new
 // egress seam; the delivery-time egress redaction still covers anything human-facing.
-func (li *LoopInvestigator) summarizeElided(ctx context.Context, out []providers.Message, removed []elidedOutput) bool {
+// totals accumulates this call's provider-reported usage into the investigation's
+// running spend. It is the VERIFY totals, because the digest call routes to
+// VerifyModel when one is configured — so aggregateUsage's existing loop/verify split
+// prices it at the rate that was actually billed. Counting it is not optional
+// bookkeeping: the spend ceilings compare against these totals, and a model call they
+// cannot see makes every summarize-mode investigation under-count its own spend.
+func (li *LoopInvestigator) summarizeElided(ctx context.Context, out []providers.Message, removed []elidedOutput, totals *providers.UsageTotals) bool {
 	if len(removed) == 0 {
 		return false
 	}
@@ -60,6 +66,11 @@ func (li *LoopInvestigator) summarizeElided(ctx context.Context, out []providers
 		System:   summarizePrompt,
 		Messages: []providers.Message{{Role: "user", Content: b.String()}},
 	})
+	// Fold the digest call into the per-investigation totals BEFORE the fail-safe
+	// returns below: a summarizer that errored, refused or truncated still billed for
+	// the tokens it consumed, and a ceiling that only counts successful calls would let
+	// a flapping summarizer spend without limit.
+	addUsage(totals, resp.Usage)
 	// Count the summarizer's cost into the model-request metrics exactly like a main
 	// loop call, so its token spend is not invisible. It is NOT anchored into the
 	// token calibration (calib): that ratio must reflect the MAIN request's

--- a/internal/investigate/summarize_test.go
+++ b/internal/investigate/summarize_test.go
@@ -218,14 +218,20 @@ func TestSummarizeBudgetAccountingAndOnePerEvent(t *testing.T) {
 	//
 	// It must also FIT the loop's budget: summarizeLoop configures a 6000-token ceiling,
 	// and the digest call's tokens now count against it like any other model call. The
-	// old fixture spent 4242 per digest — three digests, 12726 tokens, over twice the
-	// ceiling it ran under — and completed only because that spend was invisible to the
-	// budget. Under a running total the same fixture is a budget overrun, and the
+	// original fixture spent 4242 per digest — three digests, 12726 tokens, over twice
+	// the ceiling it ran under — and completed only because that spend was invisible to
+	// the budget. Under a running total the same fixture is a budget overrun, and the
 	// investigation correctly hard-stops before reaching submit_findings, which would
-	// fail this test's premise. The magnitude is arbitrary to what is being asserted
-	// here (the tokens are counted, one digest per compaction event), so it is lowered
-	// rather than any assertion being relaxed.
-	const summTokens = 1234
+	// fail this test's premise.
+	//
+	// The headroom shrank again when the cumulative arm moved to the PROJECTED total
+	// (spent + the request about to be sent): a digest now has to fit under 6000 minus
+	// the size of a pending request rather than under 6000 flat, so 1234 no longer fits
+	// either. That squeeze is real, not a fixture accident — it is the same one that
+	// makes mid-loop compaction hard to reach under a cumulative ceiling. The magnitude
+	// is arbitrary to what is asserted here (the tokens are counted, one digest per
+	// compaction event), so it is lowered again rather than any assertion being relaxed.
+	const summTokens = 303
 	sm := &fakeSummarizer{resp: providers.CompletionResponse{
 		Text:  digestSentinel,
 		Usage: providers.Usage{InputTokens: summTokens},

--- a/internal/investigate/summarize_test.go
+++ b/internal/investigate/summarize_test.go
@@ -215,7 +215,17 @@ func TestSummarizeBudgetAccountingAndOnePerEvent(t *testing.T) {
 
 	// A distinctive input-token count so we can see it land in the counter. The main
 	// scriptModel reports zero usage, so any nonzero model_input_tokens is the summarizer's.
-	const summTokens = 4242
+	//
+	// It must also FIT the loop's budget: summarizeLoop configures a 6000-token ceiling,
+	// and the digest call's tokens now count against it like any other model call. The
+	// old fixture spent 4242 per digest — three digests, 12726 tokens, over twice the
+	// ceiling it ran under — and completed only because that spend was invisible to the
+	// budget. Under a running total the same fixture is a budget overrun, and the
+	// investigation correctly hard-stops before reaching submit_findings, which would
+	// fail this test's premise. The magnitude is arbitrary to what is being asserted
+	// here (the tokens are counted, one digest per compaction event), so it is lowered
+	// rather than any assertion being relaxed.
+	const summTokens = 1234
 	sm := &fakeSummarizer{resp: providers.CompletionResponse{
 		Text:  digestSentinel,
 		Usage: providers.Usage{InputTokens: summTokens},

--- a/internal/investigate/summarize_test.go
+++ b/internal/investigate/summarize_test.go
@@ -67,12 +67,17 @@ func summarizeLoop(t *testing.T, sm providers.ModelProvider, m *telemetry.Metric
 	}})
 	got := new(providers.Investigation)
 	li := &LoopInvestigator{
-		Model:                     &scriptModel{responses: resp},
-		VerifyModel:               sm,
-		Tools:                     []Tool{bigTool{size: 4000}},
-		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
-		MaxSteps:                  10,
-		MaxTokensPerInvestigation: 6000,
+		Model:       &scriptModel{responses: resp},
+		VerifyModel: sm,
+		Tools:       []Tool{bigTool{size: 4000}},
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:    10,
+		// The run budget whose derived PER-REQUEST bound is 6000, and whose compaction
+		// trigger is therefore 4200 — the two thresholds this fixture was authored
+		// against, back when one number served as both. Stated as the run budget it
+		// always meant, the digest calls have a whole investigation's budget to fit
+		// inside rather than one request's.
+		MaxTokensPerInvestigation: 24000,
 		Compaction:                "summarize",
 		ModelProvider:             "anthropic",
 		Metrics:                   m,
@@ -216,22 +221,20 @@ func TestSummarizeBudgetAccountingAndOnePerEvent(t *testing.T) {
 	// A distinctive input-token count so we can see it land in the counter. The main
 	// scriptModel reports zero usage, so any nonzero model_input_tokens is the summarizer's.
 	//
-	// It must also FIT the loop's budget: summarizeLoop configures a 6000-token ceiling,
-	// and the digest call's tokens now count against it like any other model call. The
-	// original fixture spent 4242 per digest — three digests, 12726 tokens, over twice
-	// the ceiling it ran under — and completed only because that spend was invisible to
-	// the budget. Under a running total the same fixture is a budget overrun, and the
-	// investigation correctly hard-stops before reaching submit_findings, which would
-	// fail this test's premise.
+	// It must also FIT the loop's budget: the digest call's tokens count against the
+	// run's ceiling like any other model call, so a fixture that overruns it hard-stops
+	// before reaching submit_findings and fails this test's premise rather than its
+	// assertions.
 	//
-	// The headroom shrank again when the cumulative arm moved to the PROJECTED total
-	// (spent + the request about to be sent): a digest now has to fit under 6000 minus
-	// the size of a pending request rather than under 6000 flat, so 1234 no longer fits
-	// either. That squeeze is real, not a fixture accident — it is the same one that
-	// makes mid-loop compaction hard to reach under a cumulative ceiling. The magnitude
-	// is arbitrary to what is asserted here (the tokens are counted, one digest per
-	// compaction event), so it is lowered again rather than any assertion being relaxed.
-	const summTokens = 303
+	// This figure was lowered twice while the ceiling was cumulative but the per-request
+	// check and mid-loop compaction still read off the same number: 4242 became 1234,
+	// then 303, because each digest had to fit under what was nominally a whole
+	// investigation's budget minus a pending request. Both reductions were symptoms, not
+	// fixture noise — the squeeze that shrank them is exactly the one that made mid-loop
+	// compaction unreachable (see requestBudgetFraction). With the per-request bound
+	// derived separately, summarizeLoop states a run budget of 24000 whose request bound
+	// is the 6000 it always meant, and the original 4242 fits again.
+	const summTokens = 4242
 	sm := &fakeSummarizer{resp: providers.CompletionResponse{
 		Text:  digestSentinel,
 		Usage: providers.Usage{InputTokens: summTokens},

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -109,7 +109,7 @@ func NewMetrics() *Metrics {
 		InvestigationsStarted:      ctr("investigations_started_total", "investigations actually begun"),
 		InvestigationsThrottled:    ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
 		InvestigationsDropped:      ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or spend-ceiling hard-kill"),
-		InvestigationBudgetTrips:   ctr("investigation_budget_trips_total", "spend ceilings crossed during an investigation (label: reason=tokens_request|tokens_total, stage=nudge|kill)"),
+		InvestigationBudgetTrips:   ctr("investigation_budget_trips_total", "spend ceilings crossed during an investigation (label: reason=tokens_request|tokens_total|cost, stage=nudge|kill)"),
 		InvestigationsCancelled:    ctr("investigations_cancelled_total", "queued (not yet started) investigations cancelled: the incident resolved before its investigation began (triggers.incidents.cancel_queued_on_resolve)"),
 		GitOpsFailuresDebounced:    ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
 		IncidentsDebounced:         ctr("incidents_debounced_total", "firing alerts dropped as self-resolving: a matching resolved webhook arrived within the incident debounce window before investigating"),

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -18,12 +18,19 @@ const scope = "github.com/Smana/runlore"
 
 // Metrics is the RunLore instrument set, created once and shared.
 type Metrics struct {
-	AlertsReceived             metric.Int64Counter
-	AlertsCoalesced            metric.Int64Counter
-	AlertsSuppressed           metric.Int64Counter
-	InvestigationsStarted      metric.Int64Counter
-	InvestigationsThrottled    metric.Int64Counter
-	InvestigationsDropped      metric.Int64Counter
+	AlertsReceived          metric.Int64Counter
+	AlertsCoalesced         metric.Int64Counter
+	AlertsSuppressed        metric.Int64Counter
+	InvestigationsStarted   metric.Int64Counter
+	InvestigationsThrottled metric.Int64Counter
+	InvestigationsDropped   metric.Int64Counter
+	// InvestigationBudgetTrips counts spend ceilings crossed DURING an investigation
+	// (label: reason, stage). InvestigationsDropped already counts the kills, but a
+	// bare drop cannot say which ceiling to raise, and it cannot see the rung below —
+	// the nudge, which still delivers findings and so leaves no other trace that the
+	// run was cut short. `reason` distinguishes the ceilings from one another;
+	// `stage` distinguishes nudge (concluded early) from kill (unresolved stub).
+	InvestigationBudgetTrips   metric.Int64Counter
 	InvestigationsCancelled    metric.Int64Counter // queued (not yet started) investigations cancelled because the incident resolved first (cancel_queued_on_resolve)
 	GitOpsFailuresDebounced    metric.Int64Counter // GitOps failures dropped as transient (cleared within the debounce window)
 	IncidentsDebounced         metric.Int64Counter // firing alerts dropped as self-resolving (resolved within the incident debounce window)
@@ -101,7 +108,8 @@ func NewMetrics() *Metrics {
 		AlertsSuppressed:           ctr("alerts_suppressed_total", "incidents dropped by cooldown"),
 		InvestigationsStarted:      ctr("investigations_started_total", "investigations actually begun"),
 		InvestigationsThrottled:    ctr("investigations_throttled_total", "starts requeued by the rate limiter"),
-		InvestigationsDropped:      ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or token-budget hard-kill"),
+		InvestigationsDropped:      ctr("investigations_dropped_total", "investigations dropped — rate-limiter max_requeues or spend-ceiling hard-kill"),
+		InvestigationBudgetTrips:   ctr("investigation_budget_trips_total", "spend ceilings crossed during an investigation (label: reason=tokens_request|tokens_total, stage=nudge|kill)"),
 		InvestigationsCancelled:    ctr("investigations_cancelled_total", "queued (not yet started) investigations cancelled: the incident resolved before its investigation began (triggers.incidents.cancel_queued_on_resolve)"),
 		GitOpsFailuresDebounced:    ctr("gitops_failures_debounced_total", "GitOps failures dropped as transient: cleared within the debounce window before investigating"),
 		IncidentsDebounced:         ctr("incidents_debounced_total", "firing alerts dropped as self-resolving: a matching resolved webhook arrived within the incident debounce window before investigating"),

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "package-name": "runlore",
       "include-component-in-tag": false,
       "initial-version": "0.1.0",
+      "bump-minor-pre-major": true,
       "extra-files": [
         {
           "type": "yaml",

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -164,7 +164,7 @@ then the answer is confirmed against live state and re-reviewed.
 > **0.1**, the bottom of the ~0.1–1.2 band real scores occupy, so it rarely skips). It
 > routes to `model.verify` (cheaper/faster) when configured, costs ~1–2k tokens, and
 > buys back a whole investigation when it fires — the recorded demo transcript's came to
-> 7 calls / ~15.6k tokens, and `max_tokens_per_investigation` caps a run at 100k. A
+> 7 calls / ~15.6k tokens, against a `max_tokens_per_investigation` default of 400k. A
 > reranker that hallucinates a match is worse than no recall, so it fails **safe**: it
 > only ranks candidates that already passed the structural filter, ignores any
 > `entry_id` it did not offer, and

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -155,8 +155,48 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   hung/slow provider (a stuck git clone, an unresponsive metrics/logs endpoint) so it can't eat the
   whole per-investigation budget; on expiry the tool result is a non-fatal "timed out" note and the
   investigation continues.
-- `max_steps` (**default 20**), `max_tool_output_bytes` (0 = unlimited), `max_tokens_per_investigation`
-  (0 = unlimited, else a hard token ceiling).
+- `max_steps` (**default 20**) — model turns one investigation may take.
+- `max_tool_output_bytes` (**default 32768**; `-1` = unlimited) — each tool result is truncated to
+  this many bytes before it is fed back to the model.
+
+- **Spend ceilings** — two knobs bound what one investigation may spend, and both feed the **same
+  two-rung ladder**, so there is one behaviour to learn and one result code to watch. On the first
+  crossing RunLore injects a nudge and forces `submit_findings`, so the run **still delivers real
+  findings**; if the model has not concluded by the next step it is **hard-stopped** with
+  `result="budget_exceeded"` and an unresolved stub naming the ceiling it hit. Both rungs are counted
+  by `runlore_investigation_budget_trips_total{reason,stage}`.
+- `max_tokens_per_investigation` (**default 100000**; `-1` = unlimited) — a **cumulative** ceiling on
+  one investigation's model tokens (provider-reported input + output, loop **and** verify, including
+  a recall short-circuit's reranker/verify calls). The estimated size of the **next request** is
+  checked against the same number as well, so a single oversized request is still caught before it is
+  billed.
+
+  > **This ceiling used to bound one request, not the run.** It was previously compared only against
+  > the estimated size of the next request, so twenty steps of 99k each passed cleanly against a 100k
+  > "budget". It is now a running total, which means **the same number binds far earlier than it
+  > used to**: at the default, a long tool-heavy investigation that resends a growing history every
+  > step can now stop after a handful of turns. If your investigations start reporting
+  > `budget_exceeded` after upgrading, that is the ceiling doing what it says — raise
+  > `max_tokens_per_investigation` to the total you are actually willing to pay per incident (the sum
+  > across all turns, not the size of one), or set `-1` for the old unbounded behaviour.
+
+- `max_cost_per_investigation` (**no default — opt-in**) — the same ceiling denominated in **USD**,
+  compared against the running estimated spend priced from `model.pricing` (and `model.verify.pricing`
+  for the verify pass). Unset or `0` means no cost ceiling. There is deliberately **no `-1` opt-out**:
+  `0` already means off, and a negative value is rejected at startup rather than quietly read as one.
+
+  *Why opt-in when the token ceiling ships a default:* a token is provider-neutral — 100000 means the
+  same thing on every model, so a safe value can be chosen on your behalf. A dollar is not. You pick
+  your own model and supply your own rates, so any figure RunLore shipped would be generous for one
+  deployment and punitive for the next, and would silently cut runs short on an upgrade nobody asked
+  for.
+
+  **It does nothing without `model.pricing`.** With no rates configured there is no cost to compare,
+  so the ceiling can never fire — for any investigation, ever. RunLore says so loudly at startup
+  rather than letting the limit sit inert, and warns about the same trap when `model.pricing` is
+  present with **every rate at `0`**: cost is then always exactly `$0.00`, which is under any ceiling,
+  while the notification footer and `runlore_investigation_cost_usd` both report a figure and make the
+  deployment look instrumented for spend.
 - `compaction` — how mid-loop history compaction treats the older tool outputs it elides once the
   estimate crosses the compaction target (0.7× `max_tokens_per_investigation`). **`elide`** (default)
   drops their bodies for short markers (lossy). **`summarize`** first asks a model for **one** compact
@@ -345,6 +385,12 @@ the delivered finding gains a footer line (`N model calls · X in / Y out tokens
 show. Totals sum the investigation loop **and** the verify pass — loop tokens price at `model.pricing`,
 verify tokens at `model.verify.pricing` (inheriting `model.pricing` when empty). Cost never enters the
 curated KB entry, only the notification.
+
+`pricing` is also what makes `investigation.max_cost_per_investigation` (see the `investigation`
+section above) enforceable — without it there is no cost to compare, so a configured USD ceiling can
+never fire and RunLore warns about it at startup. Rates are yours to supply and RunLore never fetches or updates them, so a ceiling
+is only as accurate as the numbers here: check them against your provider's price list when you change
+model or tier, or the ceiling drifts away from the bill it is meant to bound.
 
 ### `forge` — the Git host for curation
 `provider` (`github` — the default — or `gitlab`), `kb_repo` (GitHub: `owner/name`; GitLab: the

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -233,7 +233,8 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   | CLI-only model calls | `lore validate --semantic`, `lore kb import --model`, and the eval judge each make completions outside any investigation. None runs under `serve` |
   | Non-model spend | Cloud API calls, git clones, metrics and logs queries are unpriced everywhere |
 - `compaction` — how mid-loop history compaction treats the older tool outputs it elides once the
-  estimate crosses the compaction target (0.7× `max_tokens_per_investigation`). **`elide`** (default)
+  estimate crosses the compaction target — 0.7× the **per-request** budget, itself a quarter of
+  `max_tokens_per_investigation` (see above). **`elide`** (default)
   drops their bodies for short markers (lossy). **`summarize`** first asks a model for **one** compact
   factual digest of the elided batch (per compaction event) — "preserve identifiers, timestamps, error
   strings, counts; no speculation" — and keeps that, clearly labelled, in place of the markers.

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -209,6 +209,17 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   present with **every rate at `0`**: cost is then always exactly `$0.00`, which is under any ceiling,
   while the notification footer and `runlore_investigation_cost_usd` both report a figure and make the
   deployment look instrumented for spend.
+
+  **Fill in all three rates.** A rate left at `0` is not "this class is free" — it is a whole class of
+  real spend estimated at `$0.00`. `cached_input_usd_per_mtok` is the one most often forgotten, and
+  every provider RunLore speaks reports cache reads separately (Anthropic `cache_read_input_tokens`,
+  OpenAI `prompt_tokens_details.cached_tokens`, Gemini `cachedContentTokenCount`), so on a cache-heavy
+  run omitting it understates the input term several-fold: the ceiling still fires, but only after
+  materially more real spend than the number you wrote, and the footer and metric report the same
+  under-estimate. RunLore warns at startup and names each rate left at `0`. If your provider genuinely
+  does not bill a class separately, set that rate equal to the one it shares (e.g.
+  `cached_input_usd_per_mtok: <your input rate>`) — the corresponding token count is then always 0, so
+  it costs nothing and the warning goes quiet.
 - `compaction` — how mid-loop history compaction treats the older tool outputs it elides once the
   estimate crosses the compaction target (0.7× `max_tokens_per_investigation`). **`elide`** (default)
   drops their bodies for short markers (lossy). **`summarize`** first asks a model for **one** compact

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -180,6 +180,18 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   > `max_tokens_per_investigation` to the total you are actually willing to pay per incident (the sum
   > across all turns, not the size of one), or set `-1` for the old unbounded behaviour.
 
+  **Budget for the ceiling plus one request.** The check runs *before* each request and compares the
+  **projected** total — what the run has already spent plus the estimated size of the request about
+  to be sent — so a run stops on the first request that would carry it past the number. That request
+  is still sent: the nudge exists to give the model one turn to conclude. The delivered total can
+  therefore exceed the ceiling **by up to the size of a single request**, and because the transcript
+  grows every step that is the *largest* request of the run. Measured at the shipped defaults, with
+  `max_tool_output_bytes: 32768` and a provider reporting real usage: **≈117 000 tokens delivered
+  against a 100 000 ceiling**, ≈1.2×. Size the ceiling with that headroom in mind rather than reading
+  it as an exact cap. The same applies to `max_cost_per_investigation` below, whose projection prices
+  the pending request's input at `model.pricing` — its output length is not knowable before it is
+  sent, so the projection errs low.
+
 - `max_cost_per_investigation` (**no default — opt-in**) — the same ceiling denominated in **USD**,
   compared against the running estimated spend priced from `model.pricing` (and `model.verify.pricing`
   for the verify pass). Unset or `0` means no cost ceiling. There is deliberately **no `-1` opt-out**:

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -165,39 +165,49 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   findings**; if the model has not concluded by the next step it is **hard-stopped** with
   `result="budget_exceeded"` and an unresolved stub naming the ceiling it hit. Both rungs are counted
   by `runlore_investigation_budget_trips_total{reason,stage}`.
-- `max_tokens_per_investigation` (**default 100000**; `-1` = unlimited) — a **cumulative** ceiling on
+- `max_tokens_per_investigation` (**default 400000**; `-1` = unlimited) — a **cumulative** ceiling on
   one investigation's model tokens (provider-reported input + output, loop **and** verify, including
-  a recall short-circuit's reranker/verify calls). The estimated size of the **next request** is
-  checked against the same number as well, so a single oversized request is still caught before it is
-  billed.
+  a recall short-circuit's reranker/verify calls).
 
-  > **This ceiling used to bound one request, not the run.** It was previously compared only against
-  > the estimated size of the next request, so twenty steps of 99k each passed cleanly against a 100k
-  > "budget". It is now a running total, which means **the same number binds far earlier than it
-  > used to**: at the default, a long tool-heavy investigation that resends a growing history every
-  > step can now stop after a handful of turns. If your investigations start reporting
-  > `budget_exceeded` after upgrading, that is the ceiling doing what it says — raise
-  > `max_tokens_per_investigation` to the total you are actually willing to pay per incident (the sum
-  > across all turns, not the size of one), or set `-1` for the old unbounded behaviour.
+  **One number, two thresholds.** A quarter of it — **100 000** at the default — additionally bounds
+  the estimated size of any **single request**, so one oversized request is caught before it is
+  billed, and mid-loop compaction triggers at 70 % of *that* (**70 000**). The two are separate
+  failures with separate fixes: "this run has spent too much in total" is answered by raising
+  `max_tokens_per_investigation`; "this one request is too big" is answered by lowering
+  `max_tool_output_bytes` or enabling `compaction`, and raising the run budget does not help. A run
+  stopped by the per-request bound is labelled `reason="tokens_request"`, one stopped by the running
+  total `reason="tokens_total"`.
+
+  > **This ceiling used to bound one request, not the run — and its default has been raised to
+  > match.** It was previously compared only against the estimated size of the next request, so
+  > twenty steps of 99k each passed cleanly against a `100000` "budget". It is now a running total.
+  > Read that way the old value funded only four or five steps, so the default is now **400000**: an
+  > investigation whose every tool result is at the shipped `max_tool_output_bytes` costs ≈327 000
+  > tokens over seven model calls, and an ordinary tool-heavy one (8 KiB results, twelve steps)
+  > ≈379 000. **If you set `max_tokens_per_investigation` explicitly, your value is untouched and is
+  > now read as a whole-run budget** — a config that said `100000` still says `100000`, and now means
+  > roughly four steps rather than twenty. Set it to the total you are willing to pay per incident
+  > (summed across all turns, not the size of one), or `-1` for the old unbounded behaviour. Watch
+  > `runlore_investigation_budget_trips_total` after upgrading.
 
   **Budget for the ceiling plus one request.** The check runs *before* each request and compares the
   **projected** total — what the run has already spent plus the estimated size of the request about
   to be sent — so a run stops on the first request that would carry it past the number. That request
   is still sent: the nudge exists to give the model one turn to conclude. The delivered total can
   therefore exceed the ceiling **by up to the size of a single request**, and because the transcript
-  grows every step that is the *largest* request of the run. Measured at the shipped defaults, with
-  `max_tool_output_bytes: 32768` and a provider reporting real usage: **≈117 000 tokens delivered
-  against a 100 000 ceiling**, ≈1.2×. Size the ceiling with that headroom in mind rather than reading
-  it as an exact cap. The same applies to `max_cost_per_investigation` below, whose projection prices
-  the pending request's input at `model.pricing` — its output length is not knowable before it is
-  sent, so the projection errs low.
+  grows every step that is the *largest* request of the run. That conceded request is itself bounded
+  by the per-request quarter, so **≈1.25× the number you set** is the figure to budget against.
+  Measured at the shipped defaults, with `max_tool_output_bytes: 32768` and a provider reporting real
+  usage: **≈467 000 tokens delivered against a 400 000 ceiling**, ≈1.17×. The same applies to
+  `max_cost_per_investigation` below, whose projection prices the pending request's input at
+  `model.pricing` — its output length is not knowable before it is sent, so the projection errs low.
 
 - `max_cost_per_investigation` (**no default — opt-in**) — the same ceiling denominated in **USD**,
   compared against the running estimated spend priced from `model.pricing` (and `model.verify.pricing`
   for the verify pass). Unset or `0` means no cost ceiling. There is deliberately **no `-1` opt-out**:
   `0` already means off, and a negative value is rejected at startup rather than quietly read as one.
 
-  *Why opt-in when the token ceiling ships a default:* a token is provider-neutral — 100000 means the
+  *Why opt-in when the token ceiling ships a default:* a token is provider-neutral — 400000 means the
   same thing on every model, so a safe value can be chosen on your behalf. A dollar is not. You pick
   your own model and supply your own rates, so any figure RunLore shipped would be generous for one
   deployment and punitive for the next, and would silently cut runs short on an upgrade nobody asked
@@ -290,7 +300,7 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   retrieval-score floor below which the paid call is skipped — the cost guard). The call routes to
   **`model.verify`** when configured (cheaper/faster), else the main model. It costs ~1–2k tokens and
   buys back a whole investigation when it fires — the recorded demo transcript's came to 7 calls /
-  ~15.6k tokens, and `max_tokens_per_investigation` caps a run at 100k. False-recall guards: it only
+  ~15.6k tokens, against a `max_tokens_per_investigation` default of 400k. False-recall guards: it only
   ever ranks candidates that already passed the structural filter, ignores any `entry_id` it did not offer
   (hallucination guard), and fails **safe** on a "no match", a low confidence, or a model error (fall
   through to a full investigation). Off ⇒ the BM25-magnitude gate is unchanged. The recalled answer

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -206,8 +206,10 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   summarizer error, refusal, or truncation falls back to plain elision — a compaction failure never
   loses the investigation. The digest is derived only from the already-redacted tool outputs, so it
   adds no new egress path. Requires `max_tokens_per_investigation > 0` (compaction is off without a
-  budget). Metrics: `history_summarizations_total`, `history_summarize_fallbacks_total`; the digest
-  call's token usage is counted into `model_input_tokens_total`.
+  budget). Metrics: `history_summarizations_total`, `history_summarize_fallbacks_total`. **The digest
+  call is billed like any other**, so its tokens count into `model_input_tokens_total`, into the
+  investigation's reported usage and cost, and against both spend ceilings — including when the
+  summarizer errors or truncates, since a failed call still consumed its input.
 - `progress_updates` — interim delivery for long investigations. **Off by default.** `enabled`; when
   enabled the loop delivers a progress ping (incident title, step count, tools used so far, and the
   model's latest interim text — redacted and mrkdwn-escaped like any other untrusted field) every

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -220,6 +220,18 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   does not bill a class separately, set that rate equal to the one it shares (e.g.
   `cached_input_usd_per_mtok: <your input rate>`) — the corresponding token count is then always 0, so
   it costs nothing and the warning goes quiet.
+
+  **What these ceilings do *not* cover.** Both bound ONE investigation. Stated plainly, because a
+  limit whose scope is assumed is a limit that surprises someone:
+
+  | Outside the ceilings | Why, and what does bound it |
+  |---|---|
+  | Anything above one investigation | There is no daily, monthly or global budget. Total exposure is `investigation.rate_limit.max_per_window` (default 30 starts/hour) × the per-investigation ceiling — a product of two knobs, not a budget |
+  | The `/embeddings` endpoint | On the hybrid-recall path (`catalog.instant_recall.hybrid` + `model.embeddings`) it is called once per recall query — **inside** an investigation — and in bulk on every catalog reload. Its tokens are not in the investigation's totals and it is not gated by either ceiling. It IS visible: `runlore_model_requests_total{provider="embed"}` and `runlore_model_input_tokens_total{provider="embed"}` |
+  | The adversarial verify pass's own cost | It runs after the last budget check, unconditionally, because verify is the honesty guarantee. A successful run can therefore deliver a `CostUSD` slightly above `max_cost_per_investigation` with no trip recorded |
+  | `lore eval` | Builds its investigators with no ceilings and no pricing at all. Bounded only by the step budget |
+  | CLI-only model calls | `lore validate --semantic`, `lore kb import --model`, and the eval judge each make completions outside any investigation. None runs under `serve` |
+  | Non-model spend | Cloud API calls, git clones, metrics and logs queries are unpriced everywhere |
 - `compaction` — how mid-loop history compaction treats the older tool outputs it elides once the
   estimate crosses the compaction target (0.7× `max_tokens_per_investigation`). **`elide`** (default)
   drops their bodies for short markers (lossy). **`summarize`** first asks a model for **one** compact

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -68,8 +68,8 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 |---|---|---|---|
 | `runlore_tool_calls_total` | counter | `tool`, `result` | investigation tool calls (`ok`/`error`) |
 | `runlore_tool_call_duration_seconds` | histogram | `tool` | per-tool latency |
-| `runlore_model_requests_total` | counter | `provider`, `result` | LLM completion requests (`ok`/`error`) |
-| `runlore_model_request_duration_seconds` | histogram | `provider` | LLM completion latency |
+| `runlore_model_requests_total` | counter | `provider`, `result` | LLM requests (`ok`/`error`). `provider` is the wire protocol for the main model, plus the synthetic tiers `rerank` (instant recall's LLM reranker) and `embed` (the `/embeddings` endpoint on the hybrid-recall path) |
+| `runlore_model_request_duration_seconds` | histogram | `provider` | LLM request latency, same `provider` vocabulary |
 | `runlore_investigation_tokens_estimated` | histogram | — | per-investigation token estimate (pre-request `chars/4` heuristic, investigation loop only — excludes the adversarial verify phase). This is what the `RunloreInvestigationCostHigh` alert watches |
 | `runlore_investigation_model_calls` | histogram | `result` | model completions per investigation (loop + verify) |
 | `runlore_investigation_input_tokens` | histogram | `result` | provider-reported input tokens per investigation, including cached (loop + verify) |

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -76,7 +76,13 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_investigation_output_tokens` | histogram | `result` | provider-reported output tokens per investigation (loop + verify) |
 | `runlore_investigation_cached_input_tokens` | histogram | `result` | input tokens served from cache per investigation (loop + verify) |
 | `runlore_investigation_cost_usd` | histogram | `result` | estimated per-investigation cost in USD (only when `model.pricing` is configured) |
-| `runlore_investigation_budget_trips_total` | counter | `reason`, `stage` | spend ceilings crossed during an investigation. `reason` = `tokens_request` (the next request alone exceeded `max_tokens_per_investigation`), `tokens_total` (the run's cumulative tokens did), or `cost` (`max_cost_per_investigation`). `stage` = `nudge` (forced to conclude early; findings still delivered) or `kill` (hard-stopped, `result="budget_exceeded"`) |
+| `runlore_investigation_budget_trips_total` | counter | `reason`, `stage` | spend ceilings crossed during an investigation. `reason` = `tokens_request` (the next request alone exceeded `max_tokens_per_investigation`), `tokens_total` (the run's projected cumulative tokens did), or `cost` (`max_cost_per_investigation`). `stage` = `nudge` (forced to conclude early; findings still delivered) or `kill` (hard-stopped, `result="budget_exceeded"`) |
+
+**One run reports one `reason`.** The ceiling that first engaged the ladder is latched at the nudge
+and carried to the kill, so the two rungs of a single stop always agree. Without that, the nudged
+turn's own spend could push a *second* ceiling over the line and the kill would name that one
+instead — telling you to raise a knob that never stopped anything, and splitting one stop across two
+series in the `sum by (reason)` recipe below.
 
 `budget_trips_total{stage="nudge"}` is the one to alert on. A nudged investigation completes and
 records `result="resolved"` like any other, so it is invisible in every other series — only this

--- a/website/content/docs/operations/observability.md
+++ b/website/content/docs/operations/observability.md
@@ -76,6 +76,21 @@ estimate) keep the SDK defaults and are read as heatmaps, not percentiles.
 | `runlore_investigation_output_tokens` | histogram | `result` | provider-reported output tokens per investigation (loop + verify) |
 | `runlore_investigation_cached_input_tokens` | histogram | `result` | input tokens served from cache per investigation (loop + verify) |
 | `runlore_investigation_cost_usd` | histogram | `result` | estimated per-investigation cost in USD (only when `model.pricing` is configured) |
+| `runlore_investigation_budget_trips_total` | counter | `reason`, `stage` | spend ceilings crossed during an investigation. `reason` = `tokens_request` (the next request alone exceeded `max_tokens_per_investigation`), `tokens_total` (the run's cumulative tokens did), or `cost` (`max_cost_per_investigation`). `stage` = `nudge` (forced to conclude early; findings still delivered) or `kill` (hard-stopped, `result="budget_exceeded"`) |
+
+`budget_trips_total{stage="nudge"}` is the one to alert on. A nudged investigation completes and
+records `result="resolved"` like any other, so it is invisible in every other series — only this
+counter distinguishes "the ceiling is comfortable" from "the ceiling has been silently truncating
+investigations for a week":
+
+```promql
+# share of investigations cut short by a ceiling, whether or not they died
+sum(rate(runlore_investigation_budget_trips_total{stage="nudge"}[1h]))
+  / sum(rate(runlore_investigations_completed_total[1h]))
+
+# which ceiling to raise
+sum by (reason) (rate(runlore_investigation_budget_trips_total[1h]))
+```
 
 The five usage histograms carry the same `result` values as
 `runlore_investigations_completed_total`, so `{result="recall"}` selects exactly the

--- a/website/content/docs/operations/troubleshooting.md
+++ b/website/content/docs/operations/troubleshooting.md
@@ -94,7 +94,7 @@ Check `runlore_investigations_completed_total{result=…}` — the `result` labe
 | `resolved` / `unresolved` | finished; `unresolved` = honest "couldn't determine" | `msg="investigation complete"` | — |
 | `recall` | answered instantly from the catalog | `msg="instant recall (catalog hit; skipping the loop)"` | — |
 | `timeout` | hit `investigation.timeout` (default **10m**) | `msg="investigation hit per-investigation deadline"` | raise `investigation.timeout`; check for a hung tool/provider |
-| `budget_exceeded` | hit `investigation.max_tokens_per_investigation` | `msg="investigation hard-stopped at token budget"` | raise the budget, or accept the cap |
+| `budget_exceeded` | hit a spend ceiling: `investigation.max_tokens_per_investigation` (the next request's size **or** the run's cumulative tokens) or `investigation.max_cost_per_investigation` | `msg="investigation hard-stopped at token budget"`, with `reason=tokens_request`, `tokens_total` or `cost` naming which | raise the ceiling `reason` names, or accept the cap |
 | `max_steps` | hit `investigation.max_steps` (default **20**) without calling `submit_findings` | `msg="investigation hit max steps"` | raise `max_steps`, or the loop is looping — inspect tool calls |
 | `max_steps_degraded` | hit `max_steps` but `submit_findings` was called mid-loop (degraded answer, not inconclusive) | `msg="investigation complete"` | the loop ran out of budget but still produced a finding — raise `max_steps` if you want a complete answer |
 | `inconclusive` | model never called `submit_findings` after a nudge | `msg="investigation inconclusive (no submit_findings after nudge)"` | often a weak/over-quantized model; try a stronger one |
@@ -103,6 +103,13 @@ Check `runlore_investigations_completed_total{result=…}` — the `result` labe
 Supporting metrics: `runlore_tool_calls_total{tool,result}` and `runlore_model_requests_total{provider,result}`
 (watch the `result="error"` slice), `runlore_model_responses_truncated_total` (completions cut off at the
 output-token ceiling — a frequent cause of `inconclusive`), and `runlore_investigation_duration_seconds{result}`.
+
+`result="budget_exceeded"` only counts the runs that **died**. Watch
+`runlore_investigation_budget_trips_total{reason,stage}` for the rung above it:
+`stage="nudge"` is an investigation that hit a ceiling, was forced to conclude early and still
+delivered findings — it looks like a normal `resolved` run in every other series, so a steadily
+rising nudge rate is how you learn your ceilings are cutting work short before any of them start
+failing.
 
 ---
 


### PR DESCRIPTION
RunLore had no cumulative spend ceiling of any kind. This adds one, and fixes the ceiling that looked like one but wasn't.

Independent of the thread-interaction stack (#482–#485); branches from `main`.

## Two gaps

**The token ceiling was not a running total.** `investigation.max_tokens_per_investigation` was enforced against the estimated size of the *next request* (`overBudget(est, budget)`), so twenty steps of 99k each passed a 100k "budget" cleanly. Meanwhile `loopTotals` — a real running total — was accumulated on every step and compared against nothing.

**There was no ceiling in currency at any scope.** `model.pricing` is a reporting table: cost was computed at the *end* of an investigation and never compared to a threshold. No `max_cost` key existed anywhere.

## What changed

Both new checks feed the **existing** stop ladder rather than a parallel mechanism — inject the budget nudge once and force `submit_findings`, then hard-stop with `result="budget_exceeded"` if the model is still over. One behaviour, one result code, whichever ceiling trips.

| reason | comparison |
|---|---|
| `tokens_request` | the pre-existing next-request check, kept — a single oversized request is still worth catching before it is sent |
| `tokens_total` | the accumulated spend, new |
| `cost` | accumulated cost against `max_cost_per_investigation`, new |

Spend is read from `aggregateUsage(loopTotals, verifyTotals)` — the function that already splits main-model and verify-model rates — rather than re-deriving the arithmetic, and it is read *after* compaction and recall so a summarize digest and a recall fall-through's reranker calls count on the step that paid for them.

## `max_cost_per_investigation` is opt-in, with no default

A token is provider-neutral: `100000` means the same thing on every model, so a safe default can be chosen for the operator. A dollar cannot. RunLore is self-hosted — the operator picks the model *and* supplies the rates — so any USD figure shipped here would be generous for one deployment, punitive for the next, and would silently cut runs short on an upgrade nobody asked for. `0`/unset means no ceiling; a negative value is rejected at load with the reason stated.

**A cost ceiling with no pricing configured is inert, so it says so.** `CostCeilingWithoutPricingWarning` fires both when `model.pricing` is absent and when every rate is `0` — the second case being the nastier one, because the cost footer and `investigation_cost_usd` make the deployment look instrumented while every total is `$0.00`. A test discovers every `*Warning` function in the package and requires its result to reach a logger, so an unwired one fails the build.

## ⚠️ Action required when merging this PR

**Put `!` in the squash-merge PR title** (`feat(investigate)!: …`) and use **`d940c8a`'s** `BREAKING CHANGE:` footer in the squash body — not `4ee67ca`'s, which says "the default is unchanged at 100000" and was superseded when the default moved to 400000. That earlier footer was left in place deliberately rather than rewritten, because a sibling branch is stacked on this one and rewriting history would break it.

That is not ceremony. Three things had to be true for the migration note to reach `CHANGELOG.md` and none of them were: this repo has no breaking-change precedent (no `!` in any subject, no footer in 1000+ commits, nothing lints subjects or PR titles), PRs are **squash-merged** so release-please parses the **PR title** rather than the branch commits, and `bump-minor-pre-major` was unset — so the first breaking change would have bumped 0.14.0 straight to **1.0.0**, making "mark this honestly" and "cut a 1.0 release" the same action. That flag is now set, `CONTRIBUTING.md` documents the mechanism, the PR template carries a checklist item, and `internal/docsguard` pins all of it.

## ⚠️ Behaviour change

**`max_tokens_per_investigation` changes meaning** — from "cap one request" to "cap the whole run" — and its default moves **100000 → 400000** to match.

The default was derived, not guessed. Three measured constraints bind it: compaction's smallest reachable request at the 32 KiB tool cap is 53,592 tokens, so the per-request bound must exceed it; compaction's own target must be reachable too; and an ordinary 8 KiB × 12-step convergence costs 379,022. 400,000 is the smallest round figure clearing all three, and it makes `max_steps: 20` reachable again at small tool results — two shipped defaults that previously could never both be met.

At 400,000 the derived pair is **100,000 per request / 70,000 compaction** — exactly the two values in force *before* this PR conflated them. So on defaults, what one request may cost and when compaction fires change for nobody; only the cumulative arm is new.

**An operator who set the value explicitly is the one who feels this**: their number now bounds the whole run rather than one request, so it buys roughly a quarter as many steps. `0` still means "apply the default", not "unlimited" — `-1` is the opt-out.

Three loops also gained ceilings they never had: `lore investigate` and `lore demo` carried no token or cost ceiling at all, contradicting the loader that computes those defaults precisely so direct CLI runs are covered — they were computed and never handed to the loop. The reinvestigate poller had no pricing, which would have left its cost ceiling inert.

## Telemetry

`runlore_investigation_budget_trips_total{reason,stage}` where stage is `nudge` or `kill`. The existing `InvestigationsDropped` counts only hard kills and cannot say which ceiling to raise — and it cannot see the nudge rung at all, since a nudged run completes as `resolved` and leaves no other trace that work was cut short.

## Still unbounded — stated, not hedged

- **Nothing caps spend *above* one investigation.** No daily or monthly budget. Total exposure is `rate_limit.max_per_window` (default 30 starts/hour) × the per-investigation ceiling — a product of two knobs, not a budget.
- **`lore eval` is fully unbounded.** `internal/eval` builds three `LoopInvestigator`s with no ceilings and no pricing whatsoever; verified, zero references.
- **Four spend paths sit outside investigation accounting.** Three are CLI-only (`kbvalidate/semantic.go`, `kbimport/enrich.go`, `eval/judge.go`); the fourth, the `/embeddings` endpoint (`internal/embed`), runs **inside `serve`** — once per hybrid-recall query, within an investigation that has ceilings, and in bulk on every catalog reload. It is now instrumented (`provider="embed"`) but **not bounded**.
- **Overshoot is by design**: the ceiling is checked between steps and the ladder deliberately issues one more nudged request, so real spend can exceed it by roughly two requests.
- **The cost figure is an estimate from operator-supplied rates**, not the provider's invoice — cache-write surcharges, thinking-token pricing, tiered/long-context rates and batch discounts are not modelled, and RunLore never fetches rates.
- **Non-model spend is unpriced**: cloud API calls, git clones, metrics and logs queries.

## Testing

Every property is pinned by a test watched failing first. Seven mutations were run against the finished code; **one survived** — dropping the `Priced` guard from the cost comparison — and a test was added for it rather than the result being reported as clean. Its comment was also corrected to say the guard states a contract rather than changing an outcome today.

One existing test's *fixture* changed, not its assertions: it spent 4242 tokens per digest under a 6000-token ceiling and only reached `submit_findings` because that spend was invisible. Under a running total that fixture is a budget overrun and the loop correctly stops. The magnitude is irrelevant to what it asserts, so the number came down and every assertion stayed.

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`. Site builds clean.

## Merge note

The thread-interaction stack (#482) adds a startup-warning guard of its own in `internal/app/warnings_wired_test.go`, written independently because this branch is off `main` where that file does not exist. Whichever lands second should unify the two — they check the same property, the stack's version covering `internal/` and `cmd/` and requiring the message reach a logger, this one covering package `app` and requiring exactly one call site.
