### PR TITLE
fix(ci): pin the screenshot guard to the rendered card, not slack.go's history

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -10,9 +10,12 @@ on:
       - 'README.md'
       - 'CONTRIBUTING.md'
       - 'assets/**'
-      # The card renderer: changing it is what makes the shipped screenshots wrong.
-      - 'internal/notify/slack.go'
-      - 'internal/notify/format.go'
+      # The rendered card, not the files that render it: what makes the shipped
+      # screenshots wrong is a change a READER would notice, and this golden moves
+      # if and only if one happened. Triggering on slack.go instead ran the whole
+      # Hugo build for every transport change and, worse, failed the screenshot
+      # step on four PRs that moved no pixel.
+      - 'internal/notify/testdata/incident-card.golden.json'
       - 'hack/check-screenshots-fresh.sh'
       - '.github/workflows/docs-check.yml'
   push:
@@ -22,9 +25,12 @@ on:
       - 'README.md'
       - 'CONTRIBUTING.md'
       - 'assets/**'
-      # The card renderer: changing it is what makes the shipped screenshots wrong.
-      - 'internal/notify/slack.go'
-      - 'internal/notify/format.go'
+      # The rendered card, not the files that render it: what makes the shipped
+      # screenshots wrong is a change a READER would notice, and this golden moves
+      # if and only if one happened. Triggering on slack.go instead ran the whole
+      # Hugo build for every transport change and, worse, failed the screenshot
+      # step on four PRs that moved no pixel.
+      - 'internal/notify/testdata/incident-card.golden.json'
       - 'hack/check-screenshots-fresh.sh'
       - '.github/workflows/docs-check.yml'
 
@@ -79,7 +85,9 @@ jobs:
           fi
           echo "OK: no raw docs/*.md links in README/CONTRIBUTING"
 
-      - name: Screenshots must not predate the card renderer
-        # Needs full history (fetch-depth: 0 above) — it compares git commit times,
-        # not mtimes, which a fresh clone would make all equal.
+      - name: Screenshots must show the card RunLore actually draws
+        # Compares a digest of the rendered card, so it needs no git history — the
+        # fetch-depth: 0 above is Hugo's (lastmod from git), not this step's. The
+        # golden it reads is kept honest by TestSlackCardMatchesTheShippedGolden in
+        # the `ci` workflow; this step alone would accept a hand-edited file.
         run: hack/check-screenshots-fresh.sh

--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -1,92 +1,120 @@
 #!/usr/bin/env bash
-# Fail if the shipped Slack screenshots are older than the code that renders them.
+# Fail if the shipped Slack screenshots depict a card RunLore no longer draws.
 #
-# README.md embeds two captures of the incident card. Nothing tied them to the
-# renderer, so a card refactor silently turned them into pictures of a layout that
-# no longer exists — the README kept advertising it, confidently and wrongly.
+# README.md and the website home page embed two captures of the incident card.
+# Nothing tied them to the renderer, so a card refactor silently turned them into
+# advertisements for a layout that no longer exists — the README kept showing it,
+# confidently and wrongly. That is not hypothetical: on 2026-08-02 the card was
+# refactored twice in one day (#399 moved the metadata below the answer, #409
+# restored the investigation's own conclusion to the verdict line) while the
+# images sat unchanged from 2026-07-14.
 #
-# That is not hypothetical. On 2026-08-02 the card was refactored twice in one day
-# (#399 moved the metadata below the answer, #409 restored the investigation's own
-# conclusion to the verdict line) while the images sat unchanged from 2026-07-14.
+# WHAT THIS COMPARES — and why it is no longer commit history.
 #
-# Timestamps come from git, not the filesystem: a fresh clone stamps every file
-# with the checkout time, so mtimes would compare equal and this would pass in CI
-# while failing to check anything.
+# The first version of this guard asked "has internal/notify/slack.go changed since
+# the screenshots were committed?". That is a proxy for the real question, and it
+# was wrong in both directions:
 #
-# Requires full history — run it where actions/checkout uses fetch-depth: 0.
+#   - It cried wolf. slack.go carries the transport as well as the card, so adding
+#     thread capture (#482) moved no pixel and failed this guard on four stacked
+#     PRs with nothing the author could honestly do about it. "A guard that cries
+#     wolf gets muted" was already written in this file; it took four days to come
+#     true.
+#   - Its escape hatch was dead on arrival. The acknowledgement named a COMMIT, and
+#     this repo squash-merges: #475 acknowledged its own branch commit, the squash
+#     collapsed that into a different SHA, and main went red the moment it merged.
+#     Only a PR that did not itself touch the renderer could ever write a valid one.
+#
+# So it compares the CARD ITSELF. internal/notify/testdata/incident-card.golden.json
+# is the Block Kit payload slackMessageWith renders for a fixture set chosen to hold
+# every arm of the card open (see internal/notify/card_golden_test.go). Two tests
+# make that file trustworthy:
+#
+#   TestSlackCardMatchesTheShippedGolden      the golden tracks the renderer, so it
+#                                             cannot be hand-edited to any digest
+#   TestCardGoldenCoversEveryRenderedBranch   the fixtures reach every arm, so a
+#                                             changed branch cannot leave the
+#                                             digest standing still
+#
+# Both run in `ci`, on every PR. This script is the other half: it asks whether the
+# card has moved away from what the pictures show.
+#
+# Being content rather than history, the digest survives a squash-merge untouched,
+# needs no git history at all, and stays silent for every change a reader of the
+# README would never see.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 SHOTS=(assets/slack-notification.png assets/recall-notification.png)
-# The files whose output the screenshots depict. Deliberately narrow: a change to
-# the webhook client or the notifier registry does not alter what the card LOOKS
-# like, and a guard that cries wolf gets muted.
-RENDERER=(internal/notify/slack.go internal/notify/format.go)
+CARD_GOLDEN=internal/notify/testdata/incident-card.golden.json
 
-# ACKNOWLEDGED_RENDERER records a renderer commit whose visual change we KNOW the
-# shipped screenshots do not yet reflect, because retaking them is blocked on
-# something outside this repo: the card can only be rendered by a live Slack
-# workspace, and the credentials for one live in the demo cluster.
+# DIGEST_AT_SHOT is the card AS THE SHIPPED SCREENSHOTS DEPICT IT: the golden as
+# rendered by the renderer at 3c87467 (#455, "retake both Slack screenshots from a
+# live incident"), the commit that last replaced both images. Reproduce it by
+# checking that commit out into a worktree, copying in card_golden_test.go, and
+# running the test with -update-card-golden.
+#
+# Update it in the same commit that lands retaken screenshots — and clear the
+# acknowledgement below at the same time.
+DIGEST_AT_SHOT="f73e6221440fceab4e2bed088ec6cb72bbb6b827bb075e643b5fcae708d810cb"
+
+# ACKNOWLEDGED_DIGEST records ONE card the shipped screenshots are known not to
+# show, because retaking them is blocked on something outside this repo: the card
+# can only be rendered by a live Slack workspace, and the credentials for one live
+# in the demo cluster.
 #
 # It is a deliberate, auditable escape — not a mute:
-#   - it names ONE commit, so it states exactly which drift is accepted;
+#   - it names ONE digest, so it states exactly which drift is accepted;
 #   - the guard still reports the staleness loudly on every run;
-#   - and it RE-ARMS: the moment the renderer moves past this commit the guard
-#     fails again, so an acknowledgement cannot silently become permanent.
+#   - and it RE-ARMS: the moment the card changes again the digest stops matching
+#     and this fails, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-#
-# Pin the commit AS IT EXISTS ON MAIN. This repo squash-merges, so a branch SHA is dead
-# on arrival: #475 acknowledged its own branch commit (96e1dc6), the squash collapsed
-# that into 0280367, and main went red the moment it merged. An acknowledgement can
-# therefore only be written by a PR that does NOT itself touch the renderer, naming the
-# squash commit that last did.
-ACKNOWLEDGED_RENDERER="02803679726992b3b79e8b123bfca5bcb99c9cc8"
-ACKNOWLEDGED_REASON="#475 added a 'confidence not stated' variant for a finding that carries no confidence at all. The stated-confidence line both captures actually show is byte-identical — an incidental re-bolding was deliberately reverted to keep it so — meaning neither image is WRONG, only incomplete: they cannot show a variant that did not exist when they were taken. Retake when a live workspace is next available."
+ACKNOWLEDGED_DIGEST="3c84e7a74cd4e1581f4ea306fc8d5d133d73994e476866663f9109a474c6f7c4"
+ACKNOWLEDGED_REASON="#475 added a 'confidence not stated' variant for a finding that carries no confidence at all. Diffing the golden across the two renderers shows that variant is the ONLY thing that moved — every other fixture is byte-identical, and the stated-confidence line both captures actually show is unchanged. So neither image is WRONG, only incomplete: they cannot show a variant that did not exist when they were taken. Retake when a live workspace is next available."
 
-last_commit_time() {
-  local t
-  t=$(git log -1 --format=%ct -- "$@" 2>/dev/null || true)
-  [ -n "$t" ] || return 1
-  printf '%s' "$t"
-}
-
-for f in "${SHOTS[@]}" "${RENDERER[@]}"; do
+for f in "${SHOTS[@]}" "$CARD_GOLDEN"; do
   [ -f "$f" ] || { echo "::error::$f is missing — update hack/check-screenshots-fresh.sh" >&2; exit 1; }
 done
 
-shot_t=$(last_commit_time "${SHOTS[@]}") || {
-  echo "::error::no git history for the screenshots — this needs fetch-depth: 0" >&2; exit 1; }
-rend_t=$(last_commit_time "${RENDERER[@]}") || {
-  echo "::error::no git history for the renderer — this needs fetch-depth: 0" >&2; exit 1; }
-
-shot_when=$(git log -1 --format='%ad (%h)' --date=short -- "${SHOTS[@]}")
-rend_when=$(git log -1 --format='%ad (%h) %s' --date=short -- "${RENDERER[@]}")
-
-if [ "$rend_t" -gt "$shot_t" ]; then
-  rend_sha=$(git log -1 --format='%H' -- "${RENDERER[@]}")
-  if [ -n "$ACKNOWLEDGED_RENDERER" ] && [ "$rend_sha" = "$ACKNOWLEDGED_RENDERER" ]; then
-    echo "::warning file=README.md::the incident-card screenshots are known to be stale (acknowledged)"
-    echo "  screenshots last updated: $shot_when" >&2
-    echo "  renderer last changed   : $rend_when" >&2
-    echo "  acknowledged because    : $ACKNOWLEDGED_REASON" >&2
-    echo >&2
-    echo "Accepted for exactly this renderer commit. Any further renderer change fails" >&2
-    echo "again. Clear ACKNOWLEDGED_RENDERER when the screenshots are retaken." >&2
-    exit 0
-  fi
-  echo "::error file=README.md::the incident-card screenshots are older than the code that draws them"
-  echo "  screenshots last updated: $shot_when" >&2
-  echo "  renderer last changed   : $rend_when" >&2
-  if [ -n "$ACKNOWLEDGED_RENDERER" ]; then
-    echo "  (an acknowledgement exists for $ACKNOWLEDGED_RENDERER, but the renderer has moved past it)" >&2
-  fi
-  echo >&2
-  echo "README.md embeds these images as what RunLore actually produces. Retake both" >&2
-  echo "against a real investigation, commit them, and this passes again." >&2
+# A copy-paste that set both to the same value would accept every future card
+# forever, while still looking like a one-off acknowledgement.
+if [ -n "$ACKNOWLEDGED_DIGEST" ] && [ "$ACKNOWLEDGED_DIGEST" = "$DIGEST_AT_SHOT" ]; then
+  echo "::error::ACKNOWLEDGED_DIGEST equals DIGEST_AT_SHOT — that is not an acknowledgement, it is a permanent mute. Clear it." >&2
   exit 1
 fi
 
-echo "OK: screenshots ($shot_when) are at least as recent as the renderer"
+current=$(sha256sum "$CARD_GOLDEN" | cut -d' ' -f1)
+
+if [ "$current" = "$DIGEST_AT_SHOT" ]; then
+  echo "OK: the card still renders as the shipped screenshots show it ($current)"
+  exit 0
+fi
+
+if [ -n "$ACKNOWLEDGED_DIGEST" ] && [ "$current" = "$ACKNOWLEDGED_DIGEST" ]; then
+  echo "::warning file=README.md::the incident-card screenshots are known to be stale (acknowledged)"
+  echo "  screenshots show card: $DIGEST_AT_SHOT" >&2
+  echo "  renderer now draws   : $current" >&2
+  echo "  acknowledged because : $ACKNOWLEDGED_REASON" >&2
+  echo >&2
+  echo "Accepted for exactly this card. Any further change to it fails again." >&2
+  echo "Clear ACKNOWLEDGED_DIGEST when the screenshots are retaken." >&2
+  exit 0
+fi
+
+echo "::error file=README.md::the incident card has changed since the shipped screenshots were taken"
+echo "  screenshots show card: $DIGEST_AT_SHOT" >&2
+echo "  renderer now draws   : $current" >&2
+if [ -n "$ACKNOWLEDGED_DIGEST" ]; then
+  echo "  (an acknowledgement exists for $ACKNOWLEDGED_DIGEST, but the card has moved past it)" >&2
+fi
+echo >&2
+echo "README.md and the website embed these images as what RunLore actually produces." >&2
+echo "Diff $CARD_GOLDEN against its previous revision to see what a reader would now" >&2
+echo "notice. Then either:" >&2
+echo "  - retake both captures against a real investigation and set DIGEST_AT_SHOT to" >&2
+echo "    $current, clearing ACKNOWLEDGED_DIGEST; or" >&2
+echo "  - set ACKNOWLEDGED_DIGEST to $current with a reason, if retaking is blocked." >&2
+exit 1

--- a/internal/notify/card_golden_test.go
+++ b/internal/notify/card_golden_test.go
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// The Slack incident card is the one thing this project ships a PICTURE of:
+// README.md and the website home page embed two captures of it. Pictures cannot
+// be diffed, so nothing stopped a card refactor from turning them into
+// advertisements for a layout that no longer exists — which is exactly what
+// happened on 2026-08-02 (see hack/check-screenshots-fresh.sh).
+//
+// This golden is the machine-readable half of that guard. It records the Block Kit
+// payload the renderer actually produces, so:
+//
+//   - any change to what the card LOOKS like fails this test until the golden is
+//     regenerated, and regenerating it changes the file's digest;
+//   - hack/check-screenshots-fresh.sh compares that digest against the card the
+//     shipped screenshots depict, and fails when they have diverged.
+//
+// The two halves are load-bearing together and neither works alone: without this
+// test the golden could be hand-edited to match any digest; without the digest
+// check a regenerated golden would silently accept stale screenshots.
+//
+// It is deliberately NOT a readability assertion. Everything about whether the
+// card says the right thing is pinned by the tests in slack_test.go; this file
+// only answers "is it still the same picture?".
+const cardGoldenPath = "testdata/incident-card.golden.json"
+
+var updateCardGolden = flag.Bool("update-card-golden", false,
+	"rewrite "+cardGoldenPath+" from the current renderer")
+
+// cardGoldenFixtures are the investigations the golden renders. Each one exists to
+// hold open a distinct arm of summaryBlocks/detailBlocks, because a fixture set
+// that misses an arm is the dangerous failure: the card changes, the digest does
+// not, and the guard passes while the screenshots go stale.
+//
+// The arms currently covered, one fixture each:
+//
+//	action_required        the full alert-driven card the README's first capture shows —
+//	                       verdict + restated title, stated confidence, top cause with
+//	                       overflow evidence, next steps with overflow, metadata fields,
+//	                       verified/entry-link/usage footer, approval buttons, feedback
+//	                       buttons, and a detail section (extra hypotheses, open
+//	                       questions, data gaps, ruled out)
+//	instant_recall         the README's second capture — Prior + Recalled: the ⚡ banner,
+//	                       known cause / validated resolution labels, resolve rate, the
+//	                       recall confidence note, no verdict
+//	seen_before            Prior WITHOUT Recalled: the 📚 counter branch and its
+//	                       prior-cause labels, which the recall branch replaces
+//	matched_runbook        MatchedKnowledge with Prior nil — the block that is
+//	                       suppressed whenever either fixture above renders
+//	no_confidence_stated   the variant #475 added: a finding that states no confidence
+//	                       at all, which bolds the whole phrase instead of a level
+//	bare_recall            a recall with no Prior and no alert name: the header falls
+//	                       back to the title and the whole card collapses to its minimum
+//
+// Times are fixed constants: slackDate emits a <!date^…> token built from a Unix
+// timestamp, so a time.Now() anywhere here would rewrite the golden on every run.
+func cardGoldenFixtures() []struct {
+	Name string
+	Inv  providers.Investigation
+} {
+	started := time.Date(2026, 7, 3, 10, 0, 0, 0, time.UTC)
+	lastSeen := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	return []struct {
+		Name string
+		Inv  providers.Investigation
+	}{
+		{"action_required", providers.Investigation{
+			Title:       "harbor-db crash-looping after the chart 1.15 migration",
+			AlertName:   "HarborDown",
+			Verdict:     providers.VerdictActionRequired,
+			Confidence:  0.92,
+			Severity:    "critical",
+			Environment: "prod",
+			Cluster:     "eu-west-1",
+			Tenant:      "platform",
+			Resource:    providers.Workload{Kind: "HelmRelease", Namespace: "tooling", Name: "harbor"},
+			StartedAt:   started,
+			RootCauses: []providers.Hypothesis{
+				{
+					Summary:    "chart 1.15 enabled DB migrations; harbor-db is in CrashLoopBackOff",
+					Confidence: 0.92,
+					Evidence: []string{
+						"pg_up=0 since 10:02",
+						"migration lock timeout in harbor-db logs",
+						"HelmRelease revision moved 1.14.2 -> 1.15.0",
+						"registry pod readiness probe failing on /api/v2.0/ping",
+					},
+					ChangeRef:       "flux-system/apps: abc123..def456",
+					SuggestedAction: "flux rollback hr/harbor to 1.14.2",
+					Reversible:      true,
+				},
+				{
+					Summary:    "the shared postgres volume filled up",
+					Confidence: 0.11,
+					Evidence:   []string{"no disk metrics available for harbor-db"},
+				},
+			},
+			Actions: []providers.Action{
+				{Description: "suspend the harbor HelmRelease", Op: "suspend", Reversible: true, ApprovalID: "apr-7f3"},
+			},
+			Unresolved:     []string{"why the migration lock never released"},
+			DataGaps:       []string{"harbor-db disk metrics unavailable (scrape target down)"},
+			RuledOut:       []string{"network partition disproven by pg reachable from the api pod"},
+			Verified:       true,
+			CuratedURL:     "https://github.com/o/kb/pull/312",
+			TriggerKey:     "HarborDown/tooling/harbor",
+			Occurrences:    3,
+			LastOccurrence: lastSeen,
+			Usage: providers.UsageTotals{
+				ModelCalls: 7, InputTokens: 121758, OutputTokens: 9596,
+			},
+		}},
+
+		{"instant_recall", providers.Investigation{
+			Title:      "harbor-db crash-looping after the chart 1.15 migration",
+			AlertName:  "HarborDown",
+			Confidence: 0.78,
+			Recalled:   true,
+			Resource:   providers.Workload{Kind: "HelmRelease", Namespace: "tooling", Name: "harbor"},
+			Cluster:    "eu-west-1",
+			Tenant:     "platform",
+			StartedAt:  started,
+			RootCauses: []providers.Hypothesis{{
+				Summary:    "chart 1.15 enabled DB migrations; harbor-db is in CrashLoopBackOff",
+				Confidence: 0.94,
+			}},
+			Prior: &providers.PriorKnowledge{
+				Cause:      "chart 1.15 enables DB migrations that need a manual lock release",
+				Resolution: "roll back to 1.14.2, clear the migration lock, then re-apply",
+				EntryPath:  "entries/harbor-db-migration-lock.md",
+				Recalls:    4,
+				Resolved:   3,
+			},
+			RecalledEntry:  "entries/harbor-db-migration-lock.md",
+			Verified:       true,
+			PrevCuratedURL: "https://github.com/o/kb/pull/298",
+			TriggerKey:     "HarborDown/tooling/harbor",
+			Occurrences:    5,
+			LastOccurrence: lastSeen,
+			Usage: providers.UsageTotals{
+				ModelCalls: 2, InputTokens: 4764, OutputTokens: 3525,
+			},
+		}},
+
+		{"seen_before", providers.Investigation{
+			Title:      "harbor-db crash-looping again after the chart bump",
+			AlertName:  "HarborDown",
+			Verdict:    providers.VerdictActionSuggested,
+			Confidence: 0.64,
+			Resource:   providers.Workload{Kind: "HelmRelease", Namespace: "tooling", Name: "harbor"},
+			Cluster:    "eu-west-1",
+			StartedAt:  started,
+			RootCauses: []providers.Hypothesis{{
+				Summary:    "the same migration lock, not released by the previous rollback",
+				Confidence: 0.64,
+				Evidence:   []string{"lock row still present in the migrations table"},
+			}},
+			Prior: &providers.PriorKnowledge{
+				Cause:      "chart 1.15 enables DB migrations that need a manual lock release",
+				Resolution: "roll back to 1.14.2, clear the migration lock, then re-apply",
+				EntryPath:  "entries/harbor-db-migration-lock.md",
+				Recalls:    4,
+				Resolved:   3,
+			},
+			Occurrences:    2,
+			LastOccurrence: lastSeen,
+			PrevCuratedURL: "https://github.com/o/kb/pull/298",
+			TriggerKey:     "HarborDown/tooling/harbor",
+		}},
+
+		{"matched_runbook", providers.Investigation{
+			Title:      "image pulls failing across the gallery namespace",
+			AlertName:  "ImageGalleryUnavailable",
+			Verdict:    providers.VerdictActionRequired,
+			Confidence: 0.71,
+			Resource:   providers.Workload{Kind: "Deployment", Namespace: "apps", Name: "xplane-image-gallery"},
+			Tenant:     "apps",
+			StartedAt:  started,
+			RootCauses: []providers.Hypothesis{{
+				Summary:    "a manual AWS Secrets Manager DeleteSecret removed the registry credentials",
+				Confidence: 0.71,
+				Evidence:   []string{"CloudTrail DeleteSecret at 09:58 by an IAM user"},
+				ChangeRef:  "aws: DeleteSecret registry/pull-token",
+			}},
+			MatchedKnowledge: &providers.MatchedEntry{
+				Path:  "entries/registry-credentials-deleted.md",
+				Title: "Registry pull credentials deleted out of band",
+				URL:   "https://github.com/o/kb/blob/main/entries/registry-credentials-deleted.md",
+				Score: 6.4,
+			},
+			Fingerprint: "fp-9a1",
+			Usage: providers.UsageTotals{
+				ModelCalls: 4, InputTokens: 38210, OutputTokens: 2914,
+			},
+		}},
+
+		{"no_confidence_stated", providers.Investigation{
+			Title:     "could not determine why the gallery is unavailable",
+			AlertName: "ImageGalleryUnavailable",
+			Verdict:   providers.VerdictInconclusive,
+			Resource:  providers.Workload{Kind: "Deployment", Namespace: "apps", Name: "xplane-image-gallery"},
+			StartedAt: started,
+			RootCauses: []providers.Hypothesis{{
+				Summary: "no signal separated a registry outage from a credentials change",
+			}},
+			DataGaps:    []string{"CloudTrail lookup returned no events in the window"},
+			Fingerprint: "fp-9a2",
+		}},
+
+		{"bare_recall", providers.Investigation{
+			Title:      "harbor-db migration lock",
+			Confidence: 0.55,
+			Recalled:   true,
+			RootCauses: []providers.Hypothesis{{Summary: "the migration lock again"}},
+		}},
+	}
+}
+
+// renderCardGolden renders every fixture through slackMessageWith — the exact
+// entry point the bot path posts (summary + detail + feedback buttons) — and
+// encodes the result with sorted map keys, so the bytes are a pure function of
+// the renderer.
+//
+// HTML escaping is off: Slack's own mrkdwn vocabulary is built from <, > and &
+// (<!date^…>, <url|label>, &gt; escapes), and < everywhere would make the
+// golden unreadable in review — the one place a human is meant to SEE the card
+// change in a diff.
+func renderCardGolden(t *testing.T) []byte {
+	t.Helper()
+	type card struct {
+		Fixture string         `json:"fixture"`
+		Card    map[string]any `json:"card"`
+	}
+	cards := make([]card, 0, len(cardGoldenFixtures()))
+	for _, f := range cardGoldenFixtures() {
+		cards = append(cards, card{Fixture: f.Name, Card: slackMessageWith(f.Inv, true)})
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(cards); err != nil {
+		t.Fatalf("marshal golden: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestSlackCardMatchesTheShippedGolden is the falsifiable half of the screenshot
+// guard: it makes the golden track the renderer, so the golden's digest is a
+// trustworthy stand-in for "what the card looks like".
+//
+// Regenerate with:
+//
+//	go test ./internal/notify -run TestSlackCardMatchesTheShippedGolden -update-card-golden
+//
+// and expect hack/check-screenshots-fresh.sh to fail afterwards — that is the
+// guard doing its job, not collateral damage. Retake the two captures, or
+// acknowledge the drift in that script with a reason.
+func TestSlackCardMatchesTheShippedGolden(t *testing.T) {
+	got := renderCardGolden(t)
+
+	if *updateCardGolden {
+		if err := os.WriteFile(cardGoldenPath, got, 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("wrote %s — hack/check-screenshots-fresh.sh now needs the new digest", cardGoldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(cardGoldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v (regenerate with -update-card-golden)", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("the Slack incident card no longer matches %s.\n\n"+
+			"If the change is intended, the two shipped screenshots (assets/slack-notification.png,\n"+
+			"assets/recall-notification.png) now show a card RunLore does not draw. Regenerate with\n"+
+			"  go test ./internal/notify -run %s -update-card-golden\n"+
+			"then retake the captures, or acknowledge the drift in hack/check-screenshots-fresh.sh.\n\n"+
+			"got:\n%s\n\nwant:\n%s", cardGoldenPath, t.Name(), got, want)
+	}
+}
+
+// TestCardGoldenCoversEveryRenderedBranch keeps the fixture set honest. The golden
+// is only as good as its coverage: an arm no fixture reaches can be rewritten
+// without moving the digest, which is a silent pass on exactly the drift the guard
+// exists to catch.
+//
+// Each string below is scaffolding the renderer emits for one branch — literal
+// text no fixture could produce as data. It fails loudly when a fixture stops
+// reaching its arm; it cannot detect a branch added later, which is why the
+// fixture doc comment names what each one holds open.
+func TestCardGoldenCoversEveryRenderedBranch(t *testing.T) {
+	rendered := string(renderCardGolden(t))
+	for _, want := range []string{
+		"Action required",       // verdictBadge, conclusive
+		"Inconclusive",          // verdictBadge, inconclusive arm
+		"confidence not stated", // the #475 unstated variant
+		"confidence*",           // the ordinary stated variant (level bolded, pct outside)
+		"Instant recall",        // Prior + Recalled
+		"Known cause",           // the recall labels
+		"Validated resolution",  //
+		"Seen before",           // Prior without Recalled
+		"Prior cause",           // the recurrence labels
+		"resolve rate",          // PriorKnowledge.Recalls
+		"Matches known runbook", // MatchedKnowledge with Prior nil
+		"Why:",                  // top root cause
+		"more hypothesis below", // the deeper-hypotheses pointer
+		"Suggested next steps",  // nextSteps
+		"Full analysis",         // detailBlocks
+		"What changed:",         // Hypothesis.ChangeRef
+		"Open questions",        // Unresolved
+		"Data gaps",             // DataGaps
+		"Ruled out",             // RuledOut
+		"verified",              // the footer's verify marker
+		"model calls",           // usageFooter
+		"Proposed action",       // an action awaiting approval
+		"Approve",               //
+		"👍 Accurate",            // feedbackBlocks
+		"…1 more",               // evidence / next-step overflow
+		"<!date^",               // slackDate, which is why the fixtures fix their times
+	} {
+		if !contains(rendered, want) {
+			t.Errorf("no fixture reaches the branch that renders %q — the golden's digest "+
+				"would not move if that branch changed", want)
+		}
+	}
+}

--- a/internal/notify/testdata/incident-card.golden.json
+++ b/internal/notify/testdata/incident-card.golden.json
@@ -1,0 +1,644 @@
+[
+  {
+    "fixture": "action_required",
+    "card": {
+      "blocks": [
+        {
+          "text": {
+            "emoji": true,
+            "text": "🔍 HarborDown — platform/tooling/harbor",
+            "type": "plain_text"
+          },
+          "type": "header"
+        },
+        {
+          "text": {
+            "text": "🔥 *Action required* — harbor-db crash-looping after the chart 1.15 migration",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "🟢 *High confidence* · 92%",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "*Why:* chart 1.15 enabled DB migrations; harbor-db is in CrashLoopBackOff\n• pg_up=0 since 10:02\n• migration lock timeout in harbor-db logs\n• HelmRelease revision moved 1.14.2 -&gt; 1.15.0\n• _…1 more_",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "_…1 more hypothesis below_",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "text": {
+            "text": "*🛠 Suggested next steps*  _(read-only — RunLore won't apply these)_\n• flux rollback hr/harbor to 1.14.2  _(reversible)_\n• suspend the harbor HelmRelease  _(reversible)_",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "fields": [
+            {
+              "text": "*Alert:*\nHarborDown (critical)",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Cluster:*\nplatform · eu-west-1",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Resource:*\nHelmRelease tooling/harbor",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Started:*\n<!date^1783072800^{date_short_pretty} {time}|2026-07-03T10:00:00Z>",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*What changed:*\nflux-system/apps: abc123..def456",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Recurrence:*\n🔁 #3 · last <!date^1780304400^{date_short_pretty} {time}|2026-06-01T09:00:00Z>",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "✓ verified  ·  📚 <https://github.com/o/kb/pull/312|view entry>  ·  7 model calls · 121758 in / 9596 out tokens (0% cached)",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "*Proposed action:* suspend the harbor HelmRelease",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "action_id": "runlore_approve",
+              "style": "primary",
+              "text": {
+                "text": "Approve",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "apr-7f3"
+            },
+            {
+              "action_id": "runlore_reject",
+              "style": "danger",
+              "text": {
+                "text": "Reject",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "apr-7f3"
+            }
+          ],
+          "type": "actions"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "text": {
+            "text": "*Full analysis*",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*1. chart 1.15 enabled DB migrations; harbor-db is in CrashLoopBackOff*  `92%`\n📦 *What changed:* `flux-system/apps: abc123..def456`\n• pg_up=0 since 10:02\n• migration lock timeout in harbor-db logs\n• HelmRelease revision moved 1.14.2 -&gt; 1.15.0\n• registry pod readiness probe failing on /api/v2.0/ping",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*2. the shared postgres volume filled up*  `11%`\n• no disk metrics available for harbor-db",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*❓ Open questions* _(needs a human)_\n• why the migration lock never released",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*⚠️ Data gaps:*\n• harbor-db disk metrics unavailable (scrape target down)",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*❌ Ruled out:*\n• network partition disproven by pg reachable from the api pod",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "action_id": "runlore_feedback_up",
+              "text": {
+                "emoji": true,
+                "text": "👍 Accurate",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "HarborDown/tooling/harbor"
+            },
+            {
+              "action_id": "runlore_feedback_down",
+              "text": {
+                "emoji": true,
+                "text": "👎 Off-base",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "HarborDown/tooling/harbor"
+            }
+          ],
+          "type": "actions"
+        }
+      ],
+      "text": "🔍 harbor-db crash-looping after the chart 1.15 migration — Action required (High confidence · 92%)"
+    }
+  },
+  {
+    "fixture": "instant_recall",
+    "card": {
+      "blocks": [
+        {
+          "text": {
+            "emoji": true,
+            "text": "🔍 HarborDown — platform/tooling/harbor",
+            "type": "plain_text"
+          },
+          "type": "header"
+        },
+        {
+          "text": {
+            "text": "harbor-db crash-looping after the chart 1.15 migration",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "🟢 *High confidence* · 78%\n_entry's own confidence 94%, adjusted to 78% by its track record_",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "⚡ *Instant recall* — answered from your knowledge base, no investigation was run\n*Known cause:* chart 1.15 enables DB migrations that need a manual lock release\n*Validated resolution:* roll back to 1.14.2, clear the migration lock, then re-apply\nresolve rate 3/4",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*Why:* chart 1.15 enabled DB migrations; harbor-db is in CrashLoopBackOff",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "fields": [
+            {
+              "text": "*Alert:*\nHarborDown",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Cluster:*\nplatform · eu-west-1",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Resource:*\nHelmRelease tooling/harbor",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Started:*\n<!date^1783072800^{date_short_pretty} {time}|2026-07-03T10:00:00Z>",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "✓ verified  ·  📚 <https://github.com/o/kb/pull/298|view entry>  ·  2 model calls · 4764 in / 3525 out tokens (0% cached)",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "elements": [
+            {
+              "action_id": "runlore_feedback_up",
+              "text": {
+                "emoji": true,
+                "text": "👍 Accurate",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "HarborDown/tooling/harbor"
+            },
+            {
+              "action_id": "runlore_feedback_down",
+              "text": {
+                "emoji": true,
+                "text": "👎 Off-base",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "HarborDown/tooling/harbor"
+            }
+          ],
+          "type": "actions"
+        }
+      ],
+      "text": "🔍 harbor-db crash-looping after the chart 1.15 migration (High confidence · 78%)"
+    }
+  },
+  {
+    "fixture": "seen_before",
+    "card": {
+      "blocks": [
+        {
+          "text": {
+            "emoji": true,
+            "text": "🔍 HarborDown — eu-west-1/tooling/harbor",
+            "type": "plain_text"
+          },
+          "type": "header"
+        },
+        {
+          "text": {
+            "text": "🛠 *Action suggested* — harbor-db crash-looping again after the chart bump",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "🟡 *Medium confidence* · 64%",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "📚 *Seen before ×2* — last <!date^1780304400^{date_short_pretty} {time}|2026-06-01T09:00:00Z>\n*Prior cause:* chart 1.15 enables DB migrations that need a manual lock release\n*Prior resolution:* roll back to 1.14.2, clear the migration lock, then re-apply\nresolve rate 3/4",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*Why:* the same migration lock, not released by the previous rollback\n• lock row still present in the migrations table",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "fields": [
+            {
+              "text": "*Alert:*\nHarborDown",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Cluster:*\neu-west-1",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Resource:*\nHelmRelease tooling/harbor",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Started:*\n<!date^1783072800^{date_short_pretty} {time}|2026-07-03T10:00:00Z>",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "📚 <https://github.com/o/kb/pull/298|view entry>",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "elements": [
+            {
+              "action_id": "runlore_feedback_up",
+              "text": {
+                "emoji": true,
+                "text": "👍 Accurate",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "HarborDown/tooling/harbor"
+            },
+            {
+              "action_id": "runlore_feedback_down",
+              "text": {
+                "emoji": true,
+                "text": "👎 Off-base",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "HarborDown/tooling/harbor"
+            }
+          ],
+          "type": "actions"
+        }
+      ],
+      "text": "🔍 harbor-db crash-looping again after the chart bump — Action suggested (Medium confidence · 64%)"
+    }
+  },
+  {
+    "fixture": "matched_runbook",
+    "card": {
+      "blocks": [
+        {
+          "text": {
+            "emoji": true,
+            "text": "🔍 ImageGalleryUnavailable — apps/apps/xplane-image-gallery",
+            "type": "plain_text"
+          },
+          "type": "header"
+        },
+        {
+          "text": {
+            "text": "🔥 *Action required* — image pulls failing across the gallery namespace",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "🟢 *High confidence* · 71%",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "📚 *Matches known runbook:* Registry pull credentials deleted out of band — RunLore has prior knowledge for this incident.",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*Why:* a manual AWS Secrets Manager DeleteSecret removed the registry credentials\n• CloudTrail DeleteSecret at 09:58 by an IAM user",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "fields": [
+            {
+              "text": "*Alert:*\nImageGalleryUnavailable",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Cluster:*\napps",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Resource:*\nDeployment apps/xplane-image-gallery",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Started:*\n<!date^1783072800^{date_short_pretty} {time}|2026-07-03T10:00:00Z>",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*What changed:*\naws: DeleteSecret registry/pull-token",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "📚 <https://github.com/o/kb/blob/main/entries/registry-credentials-deleted.md|view entry>  ·  4 model calls · 38210 in / 2914 out tokens (0% cached)",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "elements": [
+            {
+              "action_id": "runlore_feedback_up",
+              "text": {
+                "emoji": true,
+                "text": "👍 Accurate",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "fp-9a1"
+            },
+            {
+              "action_id": "runlore_feedback_down",
+              "text": {
+                "emoji": true,
+                "text": "👎 Off-base",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "fp-9a1"
+            }
+          ],
+          "type": "actions"
+        }
+      ],
+      "text": "🔍 image pulls failing across the gallery namespace — Action required (High confidence · 71%)"
+    }
+  },
+  {
+    "fixture": "no_confidence_stated",
+    "card": {
+      "blocks": [
+        {
+          "text": {
+            "emoji": true,
+            "text": "🔍 ImageGalleryUnavailable — apps/xplane-image-gallery",
+            "type": "plain_text"
+          },
+          "type": "header"
+        },
+        {
+          "text": {
+            "text": "❓ *Inconclusive* — could not determine why the gallery is unavailable",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "⚪ *confidence not stated*",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "*Why:* no signal separated a registry outage from a credentials change",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "fields": [
+            {
+              "text": "*Alert:*\nImageGalleryUnavailable",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Resource:*\nDeployment apps/xplane-image-gallery",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Started:*\n<!date^1783072800^{date_short_pretty} {time}|2026-07-03T10:00:00Z>",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "section"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "text": {
+            "text": "*Full analysis*",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*1. no signal separated a registry outage from a credentials change*",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "text": {
+            "text": "*⚠️ Data gaps:*\n• CloudTrail lookup returned no events in the window",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "action_id": "runlore_feedback_up",
+              "text": {
+                "emoji": true,
+                "text": "👍 Accurate",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "fp-9a2"
+            },
+            {
+              "action_id": "runlore_feedback_down",
+              "text": {
+                "emoji": true,
+                "text": "👎 Off-base",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "fp-9a2"
+            }
+          ],
+          "type": "actions"
+        }
+      ],
+      "text": "🔍 could not determine why the gallery is unavailable — Inconclusive (confidence not stated)"
+    }
+  },
+  {
+    "fixture": "bare_recall",
+    "card": {
+      "blocks": [
+        {
+          "text": {
+            "emoji": true,
+            "text": "🔍 harbor-db migration lock",
+            "type": "plain_text"
+          },
+          "type": "header"
+        },
+        {
+          "elements": [
+            {
+              "text": "🟡 *Medium confidence* · 55%\n_entry's own confidence 0%, adjusted to 55% by its track record_",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "*Why:* the migration lock again",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        }
+      ],
+      "text": "🔍 harbor-db migration lock (Medium confidence · 55%)"
+    }
+  }
+]


### PR DESCRIPTION
`Build docs site` is red on #482, #483, #484 and #485. None of them changed the card. This fixes the guard that says they did.

Branches from `main`, independent of every open PR. **It should land before the thread stack**, which goes green the moment it does.

## What was wrong

The guard asked *"has `internal/notify/slack.go` changed since the screenshots were committed?"* — a proxy for the real question, wrong in both directions.

**It cried wolf.** `slack.go` carries the transport as well as the card. The thread-capture series adds a `Threads` field, a `ReplyInThread` method and a channel-override in `post` — nothing that draws a block. Four stacked PRs went red with nothing the author could honestly do about it. *"A guard that cries wolf gets muted"* was already written in the script; it took four days to come true.

**Its escape hatch was dead on arrival.** The acknowledgement named a **commit**, and this repo squash-merges, so a branch SHA never survives: #475 acknowledged its own branch commit, the squash collapsed it into a different SHA, and `main` went red the moment it merged. The script's own comment had worked this out and concluded that only a PR which does *not* touch the renderer can ever write a valid acknowledgement — which is a rule about who may edit a file, standing in for a fact about pixels.

## What it compares now

The card itself. `internal/notify/testdata/incident-card.golden.json` is the Block Kit payload `slackMessageWith` renders for six fixtures, and the script compares its **sha256** against the card the shipped screenshots depict.

Two tests make that digest mean something, and neither works alone:

| test | what it stops |
|---|---|
| `TestSlackCardMatchesTheShippedGolden` | the golden being hand-edited to match any digest — it must equal what the renderer produces |
| `TestCardGoldenCoversEveryRenderedBranch` | a fixture set that misses an arm, where the card changes and the digest does not |

Both run in `ci`, on every PR. The script is the other half and knows it: it says so where a reader would otherwise trust it alone.

Being content rather than history, the digest **survives a squash-merge untouched** — the failure mode the old comment documented and could not fix — and the check needs no git history at all.

## The baseline is measured, not assumed

`DIGEST_AT_SHOT` is the card as the shipped images actually show it: the same six fixtures rendered by the renderer at **`3c87467`**, the commit that last retook both captures.

Diffing that golden against `main`'s is the interesting result. The **only** thing that moved is #475's `confidence not stated` variant:

```diff
-  "text": "🔴 *Low confidence* · 0%",
+  "text": "⚪ *confidence not stated*",
```

Every other fixture is byte-identical — which is precisely what the existing acknowledgement claimed, now demonstrated rather than asserted. So the acknowledgement is carried forward, keyed to content, with the evidence in its reason.

And the whole card on the thread stack's tip (`feat/thread-interaction-pr4-feedback`, all four PRs' `internal/notify` changes) renders to `3c84e7a7…` — **byte-identical to `main`**. The red CI was a false positive, proven rather than argued.

## Guardrails on the escape hatch

`ACKNOWLEDGED_DIGEST` keeps every property the old one had — names one card, reports loudly on every run, re-arms on the next change — and gains one it lacked: setting it equal to `DIGEST_AT_SHOT` is rejected explicitly. That copy-paste would accept every future card forever while still reading as a one-off.

## Trigger

`docs-check` now fires on the golden instead of on `slack.go`/`format.go`. That is the precise trigger — the golden moves if and only if a reader would notice — and it stops a full Hugo build running for every transport change.

## Testing

Six mutations, all caught:

| mutation | caught by |
|---|---|
| rename a card label (`*Why:*` → `*Cause:*`) | golden test fails |
| regenerate the golden after that rename | guard fails: matches neither digest |
| hand-edit the golden | golden test fails |
| drop the fixture that uniquely covers the recall arm | coverage test names all three lost branches |
| `ACKNOWLEDGED_DIGEST` = `DIGEST_AT_SHOT` | rejected as a permanent mute |
| clear `ACKNOWLEDGED_DIGEST` | guard fails — so it is load-bearing, not decorative |

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`, `shellcheck` clean.

## Known limits

- **The coverage test cannot detect a branch added later.** It fails when a fixture stops reaching a known arm; a brand-new arm nobody wrote a fixture for is invisible to it. The fixture doc comment names what each one holds open so the next author has somewhere to add to — that is a convention, not an enforcement.
- **The golden pins the bot card only** (`slackMessageWith`). `Format` — the webhook path — and the Matrix renderer ship no screenshots, so neither is covered here.
- **The screenshots are still stale**, and this PR does not change that. It makes the staleness precise: one variant, named, with a diff.
