### PR TITLE
chore: ignore the SDD scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,11 @@ eval/fixtures/
 website/public/
 website/resources/
 website/.hugo_build.lock
+
+# Subagent-driven-development scratch (scope notes, review findings, raw diffs).
+# Session-local working notes, not a record: what survives a task is the PR body,
+# the commit message and dev/superpowers/plans/ — which IS tracked, deliberately,
+# and must keep being tracked. Ignored because it was neither tracked nor ignored,
+# so a routine `git add -A` swept seven files including a 228 KB review diff into
+# a feature branch (caught in #485 before it merged).
+/.superpowers/


### PR DESCRIPTION
One line in `.gitignore`, from a real near-miss.

`.superpowers/` — the scratch directory the subagent-driven-development workflow writes scope notes, review findings and raw diffs into — was **neither tracked nor ignored**. So a routine `git add -A` while rebuilding a branch swept seven session working notes into a feature branch, including a **228 KB raw review diff**.

Caught in #485 before it merged. Nothing reached `main`; verified with `git ls-tree -r origin/main | grep '^\.superpowers/'` returning zero.

## Scoped deliberately

Anchored with a leading slash so it matches only the repo root.

**`dev/superpowers/plans/` is a different thing and stays tracked** — 149 files, the durable record of how features were designed, and several PRs reference it. This ignores the session scratch that happens to sit beside it, not the plans. Both directions verified:

| path | expected | `git check-ignore` |
|---|---|---|
| `.superpowers/sdd/probe.md` | ignored | matches `/.superpowers/` |
| `dev/superpowers/plans/2026-06-21-…md` | **not** ignored | no match |

Tracked file count under `dev/superpowers` is unchanged at 149.

## Why ignore rather than track

What survives a task is the PR body, the commit message, and `dev/superpowers/plans/`. The scratch is session-local by construction — it names branches that get deleted and quotes diffs that get squashed — so tracking it would commit a record that is stale the moment it lands.
