### PR TITLE
docs(slack): pre-flight the thread-capture endpoint and warn about bot-token rotation

### DIFF
--- a/website/content/docs/integrations/notifications/slack.md
+++ b/website/content/docs/integrations/notifications/slack.md
@@ -115,12 +115,80 @@ for the full breakdown. Without that combination, a restart or failover empties
 the registry: a reply to a thread delivered before it gets "I don't have
 context for this thread," even though the finding is still on screen.
 
-In your Slack app:
+#### Pre-flight: prove the endpoint answers
 
 `POST /slack/events` 404s until `thread_capture: true` is actually deployed and
 running, so configure the Event Subscription only once that rollout is live —
 otherwise Slack's URL verification fails and the feature looks broken before
-it's even been tried.
+it's even been tried. Send one unsigned POST from outside the cluster, against
+the hostname Slack will use, and **read the body, not just the code** — the body
+is what tells you whether RunLore answered or something in front of it did:
+
+```console
+$ curl -sS -w '\n%{http_code}\n' -X POST https://<your-runlore>/slack/events
+unauthorized
+401
+```
+
+| code | body | what it means | do next |
+|---|---|---|---|
+| **401** | `unauthorized` | the request reached RunLore and failed signature verification: the path routes and the HMAC is enforced | configure Slack |
+| **404** | `slack events not enabled` | **RunLore answered** — the path routes, but the handler is not wired | see *not wired* below |
+| **404** | anything else (HTML, `default backend`) | your ingress answered — the path is **not routed** to RunLore | see *not routed* below |
+| **200** | anything | nothing is verifying signatures on that URL | stop — do not point Slack at it |
+| **405** | `Method Not Allowed` | you sent a `GET`; the route is `POST`-only | resend with `-X POST` |
+| **503** | `no leader known; retry` / `leader unreachable; retry` | leader-forwarded, and no leader is routable right now | retry once leader election settles |
+| **421** | `not the leader (request already forwarded once)` | mid-failover, on a stale holder view | retry against the Service |
+| anything else | — | the ingress or a proxy answered, not RunLore (`502`, `504`, a redirect to an SSO page…) | read the body; fix routing first |
+
+**Not wired.** A handler that is actually serving announces itself at startup:
+
+```
+msg="slack thread capture enabled" endpoint=/slack/events
+```
+
+No such line ⇒ grep the warning beside it, which names the reason: `no forge is
+configured`, `no bot-token delivery target resolved`, or `no thread-capable
+notifier resolved`. **The endpoint is also unserved when `signing_secret_env`
+names a variable that is present but empty** (an unmounted secret, a blank Helm
+value) — an endpoint that cannot verify a signature is not exposed at all. That
+one is the trap: the startup line still prints, and nothing warns. So treat the
+pre-flight as authoritative for *routing*, and the startup log as authoritative
+for *wiring*; check both.
+
+**Not routed.** `/slack/events` is a **separate route** from
+`/slack/interactions`. On an ingress that lists paths individually rather than
+forwarding the whole service, that is the failure this check exists to catch:
+Approve/Reject and the feedback buttons keep working, so the Slack integration
+looks healthy, while every mention silently never arrives. Route both.
+
+#### Configure the Slack app
+
+> [!WARNING]
+> **Reinstalling can issue a new bot token — verify, don't assume.** If it does
+> and your secret store still holds the previous value, finding delivery stops
+> outright, which is loud. The quiet half is threads posted *before* the
+> rotation: a note against one still reaches the knowledge base and only the
+> acknowledgement fails, which reads as broken capture. Verify against the value
+> the cluster actually holds, not whatever is in your shell:
+>
+> ```console
+> $ TOKEN=$(kubectl -n runlore get secret runlore-secrets \
+>     -o jsonpath='{.data.SLACK_BOT_TOKEN}' | base64 -d)
+> $ curl -sS -X POST -H "Authorization: Bearer $TOKEN" https://slack.com/api/auth.test
+> {"ok":true,…}
+> ```
+>
+> `{"ok":false,"error":"not_authed"}` means the token was empty, not that it was
+> rejected. `invalid_auth`, `token_revoked`, `token_expired` and
+> `account_inactive` all mean the same remedy: copy the current **Bot User OAuth
+> Token** from **OAuth & Permissions** into the secret store, then **restart the
+> pod** — the token is read from the environment once, at startup, so until you
+> restart, the pod is still using whatever the Secret held when it started.
+>
+> The **signing secret is per-app, not per-install**, so a reinstall never
+> touches it: mentions keep arriving, and `/slack/events` keeps answering `401`
+> to the pre-flight, while replies fail.
 
 1. **OAuth & Permissions** → add the `app_mentions:read` bot scope (`chat:write`
    is already required for delivery), then reinstall the app.
@@ -128,6 +196,17 @@ it's even been tried.
    `https://<your-runlore>/slack/events`, and subscribe to the bot event
    `app_mention`. Slack verifies the URL with a signed challenge, so the endpoint
    must be reachable before you save.
+
+The bot must be **a member of the channel**: Slack only sends `app_mention` from
+conversations the app is in. Delivery already requires this, so if findings are
+arriving, it is satisfied.
+
+Saving the Request URL **is** the live test of `signing_secret_env`: Slack signs
+the `url_verification` challenge like every other delivery, and RunLore verifies
+it before echoing it back. **Success is silence** — an accepted challenge logs
+nothing. A mismatched secret logs
+`msg="rejected slack event: bad signature"` and Slack reports the URL as
+unverified.
 
 Only `app_mention` is subscribed — RunLore reads nothing in channels where it
 was not directly addressed.
@@ -214,3 +293,5 @@ has none.
 - [Security model → the feedback channels]({{< relref "/docs/security/security-model.md#the-feedback-channels---exposure--trust-model" >}})
   for the exposure and vote trust model.
 - [Learning loop]({{< relref "/docs/concepts/learning-loop.md" >}}) — how feedback weighs recall.
+- [Troubleshooting → A Slack mention in a thread does nothing]({{< relref "/docs/operations/troubleshooting.md#a-slack-mention-in-a-thread-does-nothing" >}})
+  — the log lines to grep once it is deployed and a mention lands nowhere.

--- a/website/content/docs/operations/troubleshooting.md
+++ b/website/content/docs/operations/troubleshooting.md
@@ -179,6 +179,51 @@ with `count=` confirms how many sinks were wired — `count=0` means none are co
 
 ---
 
+## A Slack mention in a thread does nothing
+
+`@runlore note: …` fails silently in both directions, so first establish that Slack can reach the
+endpoint at all: run the
+[`/slack/events` pre-flight]({{< relref "/docs/integrations/notifications/slack.md#pre-flight-prove-the-endpoint-answers" >}})
+(one unsigned `curl`; `401` is the healthy answer). Everything below assumes it passes.
+
+*(Matrix thread capture has the same symptom and no HTTP endpoint — skip the pre-flight, the log
+lines here are shared.)*
+
+| symptom | log line | this is… |
+|---|---|---|
+| nothing happens, and **no log line at all** | — | the event was never delivered, or was dropped before anything logs it. In rough order of likelihood: the bot is **not a member of the channel**; `app_mentions:read` was added but the app was **not reinstalled**; the mention was **not inside a thread** (a top-level `@runlore` has no root to attribute knowledge to); it was a bot's own message (loop guard); or the payload was not an `app_mention`. Confirm delivery from Slack's side first — **Event Subscriptions → Recent Deliveries** |
+| the thread answers *"I don't have context for this thread"* | `msg="thread: mention in an unrecognised thread"` | the registry has no entry for that root: past `registry_ttl` (default **168h**), evicted past `registry_max` (default **2000** live threads), or orphaned by a restart / leader failover onto a replica that never saw it. Slack has no per-event fallback, so this is unrecoverable — see [Configuration → `notify`]({{< relref "/docs/configuration/configuration.md#notify--where-findings-go" >}}) for the persistence shape that prevents the third case |
+| *"I'm handling too many messages right now"* | `msg="slack event: mention dropped, handler pool saturated"` (**ERROR**) + `runlore_mentions_dropped_on_saturation_total` | the note is **permanently lost** — Slack was already acked, so it will not retry. Send it again |
+| a duplicate mention was ignored | `msg="slack event: duplicate delivery ignored"` (debug) | expected — Slack retried a delivery RunLore had already handled |
+| the note reached the KB but the thread stayed quiet | `msg="thread: note recorded on KB PR"` / `msg="thread: note opened a standalone KB PR"` **and** `msg="thread: reply failed (best-effort)"` | the write succeeded and only the acknowledgement failed — see the bot-token note below |
+| the announcement never reached the channel | `msg="knowledge-base update delivery failed (swallowed)"` (**ERROR**), or `msg="thread: announcement pool saturated; a knowledge-base write was not announced"` | `notify.thread.announce_kb_updates` only: the write landed and the broadcast did not. Per-sink, so other transports may still have received it |
+| the write itself failed | `msg="thread: knowledge write failed"` with `err=` | a forge problem — same causes as the curator section above |
+
+> [!NOTE]
+> **A stale bot token is a narrow cause, not the usual one.** One token serves finding delivery,
+> progress updates and thread replies alike, so a token that has been rotated out from under the pod
+> stops *everything* — which shows up loudly as
+> [findings never delivered](#findings-were-investigated-but-never-delivered-to-chat), not as a quiet
+> thread. It explains the pattern above only for threads posted **before** the rotation: those
+> messages exist, so a note against them still writes, and only the reply fails —
+> `err="slack chat.postMessage: invalid_auth"` (or `token_revoked` / `token_expired`).
+>
+> Reinstalling the Slack app can rotate the bot token. Verify against the value the cluster holds
+> rather than whatever is in your shell, and note that the pod read it **once, at startup** — so a
+> Secret you have already corrected still needs a restart:
+>
+> ```console
+> $ TOKEN=$(kubectl -n runlore get secret runlore-secrets \
+>     -o jsonpath='{.data.SLACK_BOT_TOKEN}' | base64 -d)
+> $ curl -sS -X POST -H "Authorization: Bearer $TOKEN" https://slack.com/api/auth.test
+> {"ok":true,…}
+> ```
+>
+> `not_authed` means the token was empty. The **signing secret is per-app, not per-install**, so a
+> reinstall never affects it — which is why the pre-flight still answers `401` while replies fail.
+
+---
+
 ## `/readyz` never goes green
 
 `/readyz` is gated by **catalog warmth** (`internal/app/runtime.go`) — deliberately **not** by


### PR DESCRIPTION
Closes #496.

Two silent-failure gaps in the Slack thread-capture setup, reported from a rollout on a path-restricted ingress. Docs only — no Go source changed.

## The pre-flight nobody could run

The docs already said `/slack/events` "404s until `thread_capture: true` is actually deployed" and "must be reachable before you save" — and never gave the command that tells you which state you are in. One unsigned `curl` is fully diagnostic, and the `401` **is** the proof: RunLore read the body, computed the HMAC and refused.

The reporter's 401/404/200 triage is the core of it. Two more live outcomes are added because the route has them: **503** (`/slack/events` is leader-forwarded — `server.go:180` → `forward.go:129`) and **405** (the route is `POST`-only).

**`/slack/events` is a separate route from `/slack/interactions`** (`server.go:179-180`). On an ingress that lists paths individually, that is the whole failure: Approve/Reject and the feedback buttons keep working, so the integration looks healthy, while every mention silently never arrives.

## Four corrections to the issue, found in the code

The report was accurate on everything it asserted. It was incomplete in ways that matter:

1. **A 404 has a cause the issue missed, and the startup line is not proof.** `BuildThreadMention` never inspects the signing secret (`app/notify.go:353-380`), so with `signing_secret_env` naming a **present-but-empty** variable — an unmounted secret, a blank Helm value — startup prints `slack thread capture enabled` *and* the endpoint still 404s, because `s.slackSecret == ""` short-circuits at `server.go:485`. Unlike the empty bot token, **nothing warns about it**. Documented explicitly, since "the startup line printed, so it must be serving" is exactly the inference a reader would draw.
2. **Recovery needs a pod restart.** The bot token is read via `os.Getenv` once at notifier build time (`notify/slack.go:81` → `NewSlackBot`, `slack.go:176`). Updating the secret alone does nothing. The issue's advice stopped at "copy the token into the secret store".
3. **"The channel announcement never appears" is conditional.** `announce_kb_updates` is opt-in and defaults to `false` (`config.go:934-953`). Both pages now say "if you enabled it".
4. **Two more outcomes in the triage**, as above.

Also added the identifying strings the issue lacked: `slack chat.postMessage: invalid_auth` as the tell for a stale token, and `thread: note recorded on KB PR` / `thread: note opened a standalone KB PR` as the proof the write succeeded while only the acknowledgement failed.

## What landed

- **`integrations/notifications/slack.md`** — a `Pre-flight: prove the endpoint answers` section (curl, five-row status table, the separate-route callout, the two 404 causes), the reinstall step under its own heading with a `[!WARNING]` carrying verify-don't-assume `auth.test` guidance, and a paragraph stating that saving the Request URL *is* the live test of `signing_secret_env` — success is silence, a mismatch logs `rejected slack event: bad signature`.
- **`operations/troubleshooting.md`** — a new `A mention in a thread does nothing` section: the same triage, then a symptom→log-line table covering not-in-a-thread, unrecognised thread, pool saturation, duplicate delivery, write-succeeded-reply-failed, and write-failed.

## Verification

Every log line, route, status code and config key was read out of the source rather than transcribed from the issue. All eight cited log strings were then grep-confirmed verbatim against non-test code.

| check | result |
|---|---|
| `/usr/bin/hugo --minify --gc` | exit 0 |
| `hack/check-anchors.sh` | exit 0 — 421 in-page + 68 cross-page anchors across 67 pages (baseline 418/66; both new relrefs resolve) |
| `go test ./internal/docsguard/...` | exit 0 |

## Note on attribution

The reporter had written their own version and offered a PR; we had already started, and said so on the issue. Their framing — the status code *is* the diagnostic — is what this is built on. Review from them would be welcome, since they have run this path on a real cluster.
