### PR TITLE
fix(whatchanged): clone SSH GitOps repoURLs over HTTPS, confined to the credential's host

### DIFF
--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -44,11 +44,27 @@ func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) pro
 // TokenHost unset keeps every HTTPS clone that works today byte-identical,
 // including a GitHub Enterprise install whose API host differs from its git host
 // (githubGitHost derives from the API URL, so confining auth on it could withhold
-// the credential from a repo that clones fine today).
+// the credential from a repo that clones fine today). That bounds the REWRITE,
+// not the credential: a hostile HTTPS repoURL still receives the token — see
+// whatchanged.Differ.effectiveCloneURL for what is and is not closed.
+//
+// SSHRewriteHost is left EMPTY when there is no GitHub App credential, because
+// githubGitHost would otherwise name github.com for a deployment that holds no
+// github.com token — a host the rewrite must not trust on that basis. On a GitLab
+// forge BuildForgeTokenSource returns nil (it mints GitHub App tokens only), so
+// SSH repoURLs there still fail exactly as RunLore #495 reports. That gap is
+// LOGGED rather than papered over: handing the GitOps differ a GitLab credential
+// is a new credential path and belongs in its own change — the way
+// BuildKBTokenSource was split out for the identical silent failure on catalog
+// sync (see forge.go).
 func buildGitOpsDiffer(cfg *config.Config, log *slog.Logger) *whatchanged.Differ {
-	differ := &whatchanged.Differ{
-		TokenSource:    BuildForgeTokenSource(cfg, log),
-		SSHRewriteHost: githubGitHost(cfg.Forge.GitHubAPIURL),
+	differ := &whatchanged.Differ{TokenSource: BuildForgeTokenSource(cfg, log)}
+	if differ.TokenSource != nil {
+		differ.SSHRewriteHost = githubGitHost(cfg.Forge.GitHubAPIURL)
+	} else {
+		log.Warn("what_changed: no GitHub App credential; SSH repoURLs cannot be cloned and are "+
+			"not rewritten to HTTPS — change correlation stays empty for any GitOps object "+
+			"whose source is an SSH URL", "forge_provider", cfg.Forge.Provider)
 	}
 	if cfg.GitOps.Mirror.IsEnabled() {
 		if mc, err := whatchanged.NewMirrorCache(cfg.GitOps.Mirror.Dir, cfg.GitOps.Mirror.Max); err != nil {

--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -23,7 +23,33 @@ import (
 // on the source repo). A nil token source (no App configured) means public/local
 // repos only.
 func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) providers.GitOpsProvider {
-	differ := &whatchanged.Differ{TokenSource: BuildForgeTokenSource(cfg, log)}
+	differ := buildGitOpsDiffer(cfg, log)
+	if GitopsEngine(cfg) == "argocd" {
+		log.Info("gitops engine", "engine", "argocd")
+		return argocd.New(argocd.NewDynamicReader(dc), differ)
+	}
+	log.Info("gitops engine", "engine", "flux")
+	return flux.New(flux.NewDynamicReader(dc), differ)
+}
+
+// buildGitOpsDiffer builds the what_changed differ. Split out of BuildGitOps so
+// the credential wiring is reachable by a test: BuildGitOps hands the differ to a
+// provider that keeps it unexported, and an unset SSHRewriteHost would silently
+// leave RunLore #495 unfixed.
+//
+// SSHRewriteHost is set — and TokenHost deliberately is not. The differ may only
+// rewrite an SSH repoURL into a live HTTPS request toward the host the App token
+// is actually for, so an attacker-chosen "repoURL: ssh://git@attacker.example/x"
+// stays SSH and dies at "invalid auth method" with nothing transmitted. Leaving
+// TokenHost unset keeps every HTTPS clone that works today byte-identical,
+// including a GitHub Enterprise install whose API host differs from its git host
+// (githubGitHost derives from the API URL, so confining auth on it could withhold
+// the credential from a repo that clones fine today).
+func buildGitOpsDiffer(cfg *config.Config, log *slog.Logger) *whatchanged.Differ {
+	differ := &whatchanged.Differ{
+		TokenSource:    BuildForgeTokenSource(cfg, log),
+		SSHRewriteHost: githubGitHost(cfg.Forge.GitHubAPIURL),
+	}
 	if cfg.GitOps.Mirror.IsEnabled() {
 		if mc, err := whatchanged.NewMirrorCache(cfg.GitOps.Mirror.Dir, cfg.GitOps.Mirror.Max); err != nil {
 			log.Warn("gitops: mirror cache unavailable; falling back to clone-per-call", "err", err)
@@ -31,12 +57,7 @@ func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) pro
 			differ.Mirrors = mc
 		}
 	}
-	if GitopsEngine(cfg) == "argocd" {
-		log.Info("gitops engine", "engine", "argocd")
-		return argocd.New(argocd.NewDynamicReader(dc), differ)
-	}
-	log.Info("gitops engine", "engine", "flux")
-	return flux.New(flux.NewDynamicReader(dc), differ)
+	return differ
 }
 
 // BuildExecutor returns the rung-2/3 action executor for the configured GitOps

--- a/internal/app/sourcediff_wiring_test.go
+++ b/internal/app/sourcediff_wiring_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/whatchanged"
 )
 
 func TestAppendSourceDiffTool(t *testing.T) {
@@ -25,22 +27,64 @@ func TestAppendSourceDiffTool(t *testing.T) {
 			t.Fatalf("source_diff not registered; got %v", toolNames(got))
 		}
 	})
+	// source_diff's clone URLs come out of sourcerepo.Allowlist.Match, which
+	// already emits HTTPS — so the SSH→HTTPS rewrite has nothing to do there and
+	// must stay off. Setting SSHRewriteHost would arm a rewrite on a path whose
+	// URLs are MODEL-chosen across the whole allowlist, which is exactly the input
+	// the allowlist exists to distrust. TokenHost, by contrast, must stay set:
+	// that is what stops a github.com token being sent to an allowlisted repo on
+	// another host.
+	t.Run("source_diff arms no SSH rewrite and keeps its token confined", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.SourceRepos.Allow = []string{"github.com/acme/*"}
+		d := sourceDifferFrom(t, appendSourceDiffTool(cfg, nil, log))
+		if d.SSHRewriteHost != "" {
+			t.Fatalf("source_diff SSHRewriteHost = %q, want empty — its clone URLs are already "+
+				"HTTPS and model-chosen; the rewrite must not be armed there", d.SSHRewriteHost)
+		}
+		if d.TokenHost != "github.com" {
+			t.Fatalf("source_diff TokenHost = %q, want github.com — the token must stay confined "+
+				"to the forge host across a multi-host allowlist", d.TokenHost)
+		}
+	})
+}
+
+// sourceDifferFrom digs the concrete Differ out of the registered source_diff
+// tool so its credential wiring can be asserted.
+func sourceDifferFrom(t *testing.T, tools []investigate.Tool) *whatchanged.Differ {
+	t.Helper()
+	for _, tl := range tools {
+		sd, ok := tl.(investigate.SourceDiffTool)
+		if !ok {
+			continue
+		}
+		d, ok := sd.Source.(*whatchanged.Differ)
+		if !ok {
+			t.Fatalf("source_diff Source is %T, want *whatchanged.Differ", sd.Source)
+		}
+		return d
+	}
+	t.Fatal("source_diff tool not registered")
+	return nil
 }
 
 // TestBuildGitOpsDifferConfinesSSHRewrite pins the what_changed credential
 // wiring (RunLore #495).
 //
-// Two halves, and BOTH are load-bearing:
+// Three halves, all load-bearing:
 //
-//   - SSHRewriteHost must be SET, or the SSH→HTTPS rewrite never fires and #495
-//     is silently un-fixed — the exact silent-data-gap failure the issue is about.
+//   - With a GitHub App credential, SSHRewriteHost must be SET, or the SSH→HTTPS
+//     rewrite never fires and #495 is silently un-fixed — the exact silent-data-gap
+//     failure the issue is about.
 //   - TokenHost must stay UNSET, because it governs which clones may carry the
 //     token and is derived from the forge API URL. A GitHub Enterprise install
 //     whose API host differs from its git host would start withholding the
 //     credential from repos that clone fine today.
+//   - With NO credential, SSHRewriteHost must stay EMPTY: githubGitHost would
+//     otherwise name github.com for a deployment holding no github.com token.
 //
-// The rewrite is confined by SSHRewriteHost instead, so a wrong host costs an
-// unrewritten SSH URL rather than a broken clone or a leaked credential.
+// The rewrite is confined by SSHRewriteHost instead of TokenHost, so a wrong host
+// costs an unrewritten SSH URL rather than a broken clone or a leaked credential.
 func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
 	log := slog.Default()
 	for _, tc := range []struct{ name, apiURL, want string }{
@@ -48,7 +92,7 @@ func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
 		{"github enterprise", "https://ghe.example.com/api/v3", "ghe.example.com"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := &config.Config{}
+			cfg := forgeConfigured(t)
 			cfg.Forge.GitHubAPIURL = tc.apiURL
 			d := buildGitOpsDiffer(cfg, log)
 			if d.SSHRewriteHost != tc.want {
@@ -61,6 +105,23 @@ func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
 			}
 		})
 	}
+
+	// No GitHub App (an unconfigured forge, or a GitLab one — BuildForgeTokenSource
+	// mints GitHub App tokens only). githubGitHost would still say "github.com",
+	// which must NOT become an armed rewrite host for a deployment that holds no
+	// github.com token. #495 stays open on that path; buildGitOpsDiffer logs it.
+	t.Run("no credential arms no rewrite", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Forge.Provider = "gitlab"
+		d := buildGitOpsDiffer(cfg, log)
+		if d.TokenSource != nil {
+			t.Fatal("BuildForgeTokenSource must be nil without a GitHub App; this test's premise is stale")
+		}
+		if d.SSHRewriteHost != "" {
+			t.Fatalf("SSHRewriteHost = %q with no credential, want empty — the rewrite must not trust "+
+				"a host derived from a forge URL when no token for it exists", d.SSHRewriteHost)
+		}
+	})
 }
 
 func TestGithubGitHost(t *testing.T) {

--- a/internal/app/sourcediff_wiring_test.go
+++ b/internal/app/sourcediff_wiring_test.go
@@ -27,6 +27,42 @@ func TestAppendSourceDiffTool(t *testing.T) {
 	})
 }
 
+// TestBuildGitOpsDifferConfinesSSHRewrite pins the what_changed credential
+// wiring (RunLore #495).
+//
+// Two halves, and BOTH are load-bearing:
+//
+//   - SSHRewriteHost must be SET, or the SSH→HTTPS rewrite never fires and #495
+//     is silently un-fixed — the exact silent-data-gap failure the issue is about.
+//   - TokenHost must stay UNSET, because it governs which clones may carry the
+//     token and is derived from the forge API URL. A GitHub Enterprise install
+//     whose API host differs from its git host would start withholding the
+//     credential from repos that clone fine today.
+//
+// The rewrite is confined by SSHRewriteHost instead, so a wrong host costs an
+// unrewritten SSH URL rather than a broken clone or a leaked credential.
+func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
+	log := slog.Default()
+	for _, tc := range []struct{ name, apiURL, want string }{
+		{"default forge", "", "github.com"},
+		{"github enterprise", "https://ghe.example.com/api/v3", "ghe.example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Forge.GitHubAPIURL = tc.apiURL
+			d := buildGitOpsDiffer(cfg, log)
+			if d.SSHRewriteHost != tc.want {
+				t.Fatalf("SSHRewriteHost = %q, want %q — an unset host leaves SSH repoURLs unclonable (#495)",
+					d.SSHRewriteHost, tc.want)
+			}
+			if d.TokenHost != "" {
+				t.Fatalf("TokenHost = %q, want empty — confining auth here changes every HTTPS clone that "+
+					"works today; the SSH rewrite is confined by SSHRewriteHost instead", d.TokenHost)
+			}
+		})
+	}
+}
+
 func TestGithubGitHost(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
 		{"", "github.com"},

--- a/internal/investigate/sourcediff_tool_test.go
+++ b/internal/investigate/sourcediff_tool_test.go
@@ -56,12 +56,18 @@ func TestSourceDiffRejectsNonAllowlistedRepo(t *testing.T) {
 	}
 }
 
-// TestSourceDiffClonesOnlyTheAllowlistedURL guards the boundary that RunLore
-// #495's SSH→HTTPS clone normalisation must not weaken.
+// TestSourceDiffClonesOnlyTheAllowlistedURL pins pre-existing behaviour that
+// RunLore #495 depends on but does not change.
 //
-// The allowlist is a security control, and it is only a control while the string
-// it CHECKED is the string that gets CLONED. Whatever spelling the model sends —
-// including the SSH forms #495 taught the clone layer to understand — the URL
+// It exercises sourcerepo + SourceDiffTool ONLY: fakeSourceDiffer short-circuits
+// before any whatchanged code runs, so nothing here reaches the SSH→HTTPS
+// rewrite, and this passes unmodified against origin/main — by design. The
+// interaction between the rewrite and the allowlist is covered by
+// whatchanged.TestCloneRewriteCannotBypassSourceRepoAllowlist.
+//
+// What it pins is the precondition that test depends on: the allowlist is a
+// security control only while the string it CHECKED is the string that gets
+// CLONED. Whatever spelling the model sends — the SSH forms included — the URL
 // handed to the differ must be the canonical one Allowlist.Match itself produced,
 // never the model's raw text and never a second, independently-normalised copy of
 // it. Two normalisations of one input is exactly how an allow check gets bypassed.

--- a/internal/investigate/sourcediff_tool_test.go
+++ b/internal/investigate/sourcediff_tool_test.go
@@ -56,6 +56,60 @@ func TestSourceDiffRejectsNonAllowlistedRepo(t *testing.T) {
 	}
 }
 
+// TestSourceDiffClonesOnlyTheAllowlistedURL guards the boundary that RunLore
+// #495's SSH→HTTPS clone normalisation must not weaken.
+//
+// The allowlist is a security control, and it is only a control while the string
+// it CHECKED is the string that gets CLONED. Whatever spelling the model sends —
+// including the SSH forms #495 taught the clone layer to understand — the URL
+// handed to the differ must be the canonical one Allowlist.Match itself produced,
+// never the model's raw text and never a second, independently-normalised copy of
+// it. Two normalisations of one input is exactly how an allow check gets bypassed.
+func TestSourceDiffClonesOnlyTheAllowlistedURL(t *testing.T) {
+	const canonical = "https://github.com/acme/checkout"
+
+	t.Run("every allowed spelling collapses to the checked URL", func(t *testing.T) {
+		for _, repo := range []string{
+			"github.com/acme/checkout",
+			"https://github.com/acme/checkout.git",
+			"git@github.com:acme/checkout.git",
+			"ssh://git@github.com/acme/checkout",
+			"git@GitHub.COM:acme/checkout.git",
+		} {
+			f := &fakeSourceDiffer{sc: fixtureChanges()}
+			tool := SourceDiffTool{Source: f, Allow: mustAllow(t, "github.com/acme/*")}
+			if _, err := tool.Call(context.Background(), `{"repo":"`+repo+`","from":"1","to":"2"}`); err != nil {
+				t.Fatalf("%s: unexpected error: %v", repo, err)
+			}
+			if f.gotURL != canonical {
+				t.Fatalf("%s: cloned %q, want the allowlist's own canonical URL %q", repo, f.gotURL, canonical)
+			}
+		}
+	})
+
+	// Crafted so a sloppy normaliser and the allowlist would disagree: the SSH
+	// userinfo (or a path segment) names the ALLOWED host while the real
+	// authority is foreign. These must be refused outright — never reshaped into
+	// a URL that clones the foreign host.
+	t.Run("crafted host/userinfo divergence is refused, not normalised", func(t *testing.T) {
+		for _, repo := range []string{
+			"ssh://git@github.com@evil.example/acme/checkout",
+			"git@evil.example:github.com/acme/checkout",
+			"ssh://git@github.com:22/acme/checkout",
+			"git@github.com:acme/../evil/checkout.git",
+		} {
+			f := &fakeSourceDiffer{sc: fixtureChanges()}
+			tool := SourceDiffTool{Source: f, Allow: mustAllow(t, "github.com/acme/*")}
+			if _, err := tool.Call(context.Background(), `{"repo":"`+repo+`","from":"1","to":"2"}`); err == nil {
+				t.Fatalf("%s: want an allowlist rejection, got none (cloned %q)", repo, f.gotURL)
+			}
+			if f.gotURL != "" {
+				t.Fatalf("%s: a rejected repo still reached the clone layer as %q", repo, f.gotURL)
+			}
+		}
+	})
+}
+
 func TestSourceDiffSummary(t *testing.T) {
 	f := &fakeSourceDiffer{sc: fixtureChanges()}
 	tool := SourceDiffTool{Source: f, Allow: mustAllow(t, "github.com/acme/*")}

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -50,7 +50,9 @@ type Differ struct {
 	// their HTTPS equivalent (see effectiveCloneURL). It must be the host the
 	// TokenSource credential belongs to. Empty (the default) disables the rewrite
 	// entirely — fail closed — so a Differ that does not know where its credential
-	// is valid never turns an SSH URL into a live HTTPS request.
+	// is valid never turns an SSH URL into a live HTTPS request. It bounds the
+	// rewrite only; it is not a general credential boundary, and an HTTPS clone
+	// URL is unaffected by it (see effectiveCloneURL).
 	//
 	// It is deliberately NOT TokenHost, and folding the two together would be a
 	// silent regression in one direction or the other. TokenHost governs which
@@ -192,8 +194,9 @@ func (d *Differ) auth(ctx context.Context, cloneURL string) (transport.AuthMetho
 // An SSH rawURL is rewritten to its HTTPS equivalent first (see
 // effectiveCloneURL); every downstream key — clone cache, mirror dir, auth host
 // check — is derived from that ONE effective URL, so the URL authorized is
-// always the URL dialled, and an ssh:// and https:// spelling of the same repo
-// share a mirror instead of cloning twice.
+// always the URL dialled. Keys are the effective URL verbatim, not a canonical
+// form: two spellings of one repo share a clone only when they rewrite to the
+// same bytes, and case or a ".git" suffix is enough to keep them apart.
 func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repository, func(), error) {
 	noop := func() {}
 	url := d.effectiveCloneURL(rawURL)
@@ -251,17 +254,24 @@ func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repositor
 // very same repository; the installation still scopes what may be read, so this
 // grants no access the operator had not already granted.
 //
-// The rewrite is applied ONLY toward SSHRewriteHost, the host the credential is
-// actually for, and only when there is a credential at all. That confinement is
-// load-bearing, not tidiness. A GitOps repoURL is cluster state, so in a shared
-// cluster anyone who can create an Application picks it; the what_changed differ
+// The rewrite fires only toward SSHRewriteHost — the host the credential is for,
+// compared on an ASCII-only host so the comparison cannot disagree with the host
+// net/http will dial (see sshToHTTPS) — and only when there is a credential at
+// all. That confinement is load-bearing. A GitOps repoURL is cluster state, so in
+// a shared cluster anyone who can create an Application picks it, and this differ
 // runs with TokenHost empty, meaning auth attaches the App token to whatever host
-// it ends up cloning. Before this rewrite existed, "invalid auth method" rejected
-// every SSH URL before a single byte left the process — the bug was inadvertently
-// acting as a CREDENTIAL BOUNDARY. Rewriting unconfined would have removed that
-// boundary and turned "repoURL: ssh://git@attacker.example/x" into the App
-// installation token being POSTed to attacker.example. Do not "simplify" this
-// host check away without replacing what it holds.
+// it clones. Unconfined, the rewrite would turn
+// "repoURL: ssh://git@attacker.example/x" into that token being POSTed to
+// attacker.example. Do not "simplify" the host check away.
+//
+// WHAT THIS DOES NOT DO. It narrows the SSH path only. A hostile HTTPS repoURL —
+// "repoURL: https://attacker.example/x" — still receives the token today: auth is
+// unconfined on this differ and the rewrite never sees an HTTPS URL. That hole
+// predates the rewrite and is not closed here. Closing it means confining
+// TokenHost on this differ, which needs an operator override for a GitHub
+// Enterprise install whose API host differs from its git host, and is its own
+// change. Read this check as "the rewrite cannot introduce a new leak", not as a
+// credential boundary — it is not one.
 //
 // With no TokenSource (public or local repos) the raw SSH URL is kept so go-git's
 // default SSH-agent path remains available — rewriting it would trade a working
@@ -292,8 +302,22 @@ func (d *Differ) effectiveCloneURL(rawURL string) string {
 // carrying userinfo would let a crafted URL smuggle credentials into the
 // rewritten URL's authority.
 //
+// The host must also be pure ASCII. Every host comparison in this package goes
+// through hostOf, which lowercases with strings.ToLower — Unicode SIMPLE case
+// mapping — while net/http resolves the very same URL through
+// idna.Lookup.ToASCII. The two disagree on non-ASCII input, which puts the
+// authorization check on the wrong side of the disagreement: ToLower maps U+0130
+// ('İ') to 'i', so "gİthub.com" reads as "github.com" to effectiveCloneURL while
+// net/http dials the separately registrable "xn--github-qyd.com" — an attacker
+// registers it, serves a valid cert, and reads the App token off the
+// Authorization header. Refusing non-ASCII hosts kills the whole class
+// (homoglyphs, fullwidth forms, ZWSP, soft hyphen), not the one rune;
+// internal/sourcerepo's allowlist refuses them for the same reason, see
+// firstDisallowedRepoChar there.
+//
 // A rewrite is then either FAITHFUL or does not happen: the result must parse
-// back to exactly the host and path it was built from. An SSH path is opaque
+// back to the same host — up to ASCII case, since this comparison is EqualFold —
+// and the byte-identical path it was built from. An SSH path is opaque
 // bytes while an HTTPS path is not, so the path half of that round trip refuses a
 // '?' or '#' that would silently become a query or fragment, and percent-encoded
 // traversal ("%2e%2e") that a literal ".." scan misses. The host half is the
@@ -309,7 +333,7 @@ func (d *Differ) effectiveCloneURL(rawURL string) string {
 // Refusal costs nothing — the caller simply keeps the raw URL.
 func sshToHTTPS(rawURL string) (string, bool) {
 	ep, err := transport.NewEndpoint(strings.TrimSpace(rawURL))
-	if err != nil || ep.Protocol != "ssh" || ep.Host == "" {
+	if err != nil || ep.Protocol != "ssh" || ep.Host == "" || !isASCII(ep.Host) {
 		return "", false
 	}
 	repoPath := strings.TrimPrefix(ep.Path, "/")
@@ -324,10 +348,31 @@ func sshToHTTPS(rawURL string) (string, bool) {
 	return out, true
 }
 
+// isASCII reports whether s is free of bytes outside 7-bit ASCII. It is the
+// host-side guard in sshToHTTPS: see that function's comment for why a non-ASCII
+// host makes strings.ToLower and idna.Lookup.ToASCII disagree about which host is
+// being named.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
 // hostOf returns the lowercased host of an https/http/ssh clone URL, or "" for
-// a local path or an unparseable/hostless URL. Used by auth to confine a
-// host-scoped token; a "" host never equals a non-empty TokenHost, so a local
+// a local path or an unparseable/hostless URL.
+//
+// Two callers, and the second is stricter than the first. auth uses it to confine
+// a host-scoped token: a "" host never equals a non-empty TokenHost, so a local
 // clone is always treated as off-host (correct — local repos need no token).
+// effectiveCloneURL uses it to AUTHORIZE turning an SSH URL into a live HTTPS
+// request, which demands that the host named here be the host that is actually
+// dialled. strings.ToLower does not guarantee that for non-ASCII input, so
+// sshToHTTPS refuses non-ASCII hosts before this is ever consulted for that
+// decision. Anything else routed through here for an authorization decision needs
+// the same precaution.
 func hostOf(cloneURL string) string {
 	u, err := url.Parse(cloneURL)
 	if err != nil {

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -46,6 +46,22 @@ type Differ struct {
 	// preserving the original behavior. source_diff sets this because its clone
 	// URLs are model-chosen across the whole allowlist.
 	TokenHost string
+	// SSHRewriteHost names the ONE host whose SSH clone URLs may be rewritten to
+	// their HTTPS equivalent (see effectiveCloneURL). It must be the host the
+	// TokenSource credential belongs to. Empty (the default) disables the rewrite
+	// entirely — fail closed — so a Differ that does not know where its credential
+	// is valid never turns an SSH URL into a live HTTPS request.
+	//
+	// It is deliberately NOT TokenHost, and folding the two together would be a
+	// silent regression in one direction or the other. TokenHost governs which
+	// clones may CARRY the token and is empty on the what_changed differ on
+	// purpose (see above); setting it there would change auth for every HTTPS
+	// clone that works today, and it is derived from the forge API URL, which on a
+	// GitHub Enterprise install with subdomain isolation is a different host from
+	// the git remote. SSHRewriteHost governs only whether a rewrite HAPPENS, so a
+	// wrong value costs at most an unrewritten SSH URL — never a withheld
+	// credential on a clone that works today.
+	SSHRewriteHost string
 	// Mirrors, when set, backs clones with a persistent per-repo bare mirror
 	// (incremental fetch, shared across investigations). nil ⇒ full clone per
 	// call, exactly as before. Mirror errors fall back to clone-per-call.
@@ -235,21 +251,28 @@ func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repositor
 // very same repository; the installation still scopes what may be read, so this
 // grants no access the operator had not already granted.
 //
-// The rewrite is applied ONLY when an HTTPS credential is actually in play for
-// that host. With no TokenSource (public or local repos) or with a host-confined
-// token that would not attach here, the raw SSH URL is kept so go-git's default
-// SSH-agent path remains available — rewriting it would trade a working clone
-// for an unauthenticated HTTPS 401.
+// The rewrite is applied ONLY toward SSHRewriteHost, the host the credential is
+// actually for, and only when there is a credential at all. That confinement is
+// load-bearing, not tidiness. A GitOps repoURL is cluster state, so in a shared
+// cluster anyone who can create an Application picks it; the what_changed differ
+// runs with TokenHost empty, meaning auth attaches the App token to whatever host
+// it ends up cloning. Before this rewrite existed, "invalid auth method" rejected
+// every SSH URL before a single byte left the process — the bug was inadvertently
+// acting as a CREDENTIAL BOUNDARY. Rewriting unconfined would have removed that
+// boundary and turned "repoURL: ssh://git@attacker.example/x" into the App
+// installation token being POSTed to attacker.example. Do not "simplify" this
+// host check away without replacing what it holds.
+//
+// With no TokenSource (public or local repos) the raw SSH URL is kept so go-git's
+// default SSH-agent path remains available — rewriting it would trade a working
+// clone for an unauthenticated HTTPS 401.
 func (d *Differ) effectiveCloneURL(rawURL string) string {
-	if d.TokenSource == nil {
-		return rawURL // no HTTPS credential in play; leave SSH to the SSH transport
+	if d.TokenSource == nil || d.SSHRewriteHost == "" {
+		return rawURL // no credential, or no host it is known to be valid for
 	}
 	httpsURL, ok := sshToHTTPS(rawURL)
-	if !ok {
-		return rawURL
-	}
-	if d.TokenHost != "" && hostOf(httpsURL) != d.TokenHost {
-		return rawURL // the token would not attach to this host; rewriting buys nothing
+	if !ok || hostOf(httpsURL) != d.SSHRewriteHost {
+		return rawURL // not SSH, or SSH toward a host this credential is not for
 	}
 	return httpsURL
 }

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -171,8 +172,15 @@ func (d *Differ) auth(ctx context.Context, cloneURL string) (transport.AuthMetho
 // per batch: a cache hit returns the shared clone with a no-op cleanup (the cache
 // owns the temp dir and removes it on close). Without a cache, the caller owns the
 // returned cleanup, as before.
-func (d *Differ) cloneToDisk(ctx context.Context, url string) (*git.Repository, func(), error) {
+//
+// An SSH rawURL is rewritten to its HTTPS equivalent first (see
+// effectiveCloneURL); every downstream key — clone cache, mirror dir, auth host
+// check — is derived from that ONE effective URL, so the URL authorized is
+// always the URL dialled, and an ssh:// and https:// spelling of the same repo
+// share a mirror instead of cloning twice.
+func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repository, func(), error) {
 	noop := func() {}
+	url := d.effectiveCloneURL(rawURL)
 	cc := cacheFrom(ctx)
 	if cc != nil {
 		if repo, ok := cc.get(url); ok {
@@ -213,6 +221,84 @@ func (d *Differ) cloneToDisk(ctx context.Context, url string) (*git.Repository, 
 		return winner, noop, nil // cache owns cleanup
 	}
 	return repo, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+// effectiveCloneURL returns the URL cloneToDisk should actually clone.
+//
+// A GitOps engine's spec.source.repoURL is very often an SSH URL
+// ("git@github.com:org/repo.git") because the engine itself authenticates with a
+// deploy key. RunLore holds no SSH credential at all — auth only ever produces
+// HTTP basic auth from a GitHub App installation token — so go-git's SSH
+// transport rejected every one of those clones with "invalid auth method", and
+// what_changed / source_diff silently produced no change correlation for ANY
+// object (RunLore #495). Rewriting to HTTPS lets the App token authenticate the
+// very same repository; the installation still scopes what may be read, so this
+// grants no access the operator had not already granted.
+//
+// The rewrite is applied ONLY when an HTTPS credential is actually in play for
+// that host. With no TokenSource (public or local repos) or with a host-confined
+// token that would not attach here, the raw SSH URL is kept so go-git's default
+// SSH-agent path remains available — rewriting it would trade a working clone
+// for an unauthenticated HTTPS 401.
+func (d *Differ) effectiveCloneURL(rawURL string) string {
+	if d.TokenSource == nil {
+		return rawURL // no HTTPS credential in play; leave SSH to the SSH transport
+	}
+	httpsURL, ok := sshToHTTPS(rawURL)
+	if !ok {
+		return rawURL
+	}
+	if d.TokenHost != "" && hostOf(httpsURL) != d.TokenHost {
+		return rawURL // the token would not attach to this host; rewriting buys nothing
+	}
+	return httpsURL
+}
+
+// sshToHTTPS rewrites an SSH clone URL to its HTTPS equivalent — both the
+// scp-style "git@host:org/repo.git" and the "ssh://git@host[:port]/org/repo.git"
+// spellings become "https://host/org/repo.git". ok is false for anything that is
+// not an SSH endpoint (https, http, git://, a local path), leaving the caller's
+// URL untouched.
+//
+// SECURITY. The host is taken from go-git's OWN endpoint parser, the same one
+// that would have resolved the raw URL, so the rewrite can never redirect a
+// clone to a host the raw URL did not already designate — including the
+// "ssh://git@good.example@evil.example/x" shape, where the real host is
+// evil.example under RFC 3986 and stays evil.example here. SSH userinfo and port
+// are DROPPED rather than carried across: neither means anything over HTTPS, and
+// carrying userinfo would let a crafted URL smuggle credentials into the
+// rewritten URL's authority.
+//
+// A rewrite is then either FAITHFUL or does not happen: the result must parse
+// back to exactly the host and path it was built from. An SSH path is opaque
+// bytes while an HTTPS path is not, so the path half of that round trip refuses a
+// '?' or '#' that would silently become a query or fragment, and percent-encoded
+// traversal ("%2e%2e") that a literal ".." scan misses. The host half is the
+// credential guard: "git@github.com@evil.example:org/repo.git" is one host to
+// go-git's scp syntax (which takes the FIRST '@' as userinfo, then fails) and a
+// different one to RFC 3986 (which takes the LAST), so an unchecked rewrite would
+// turn a URL that could not clone at all into a working clone of evil.example
+// with "github.com" demoted to userinfo — and what_changed, which attaches its
+// App token to every host it clones, would hand the token over. Because the
+// authority is built as exactly ep.Host, userinfo can only appear in the result
+// when ep.Host itself holds an '@', which this same check rejects.
+//
+// Refusal costs nothing — the caller simply keeps the raw URL.
+func sshToHTTPS(rawURL string) (string, bool) {
+	ep, err := transport.NewEndpoint(strings.TrimSpace(rawURL))
+	if err != nil || ep.Protocol != "ssh" || ep.Host == "" {
+		return "", false
+	}
+	repoPath := strings.TrimPrefix(ep.Path, "/")
+	if repoPath == "" || slices.Contains(strings.Split(repoPath, "/"), "..") {
+		return "", false
+	}
+	out := "https://" + ep.Host + "/" + repoPath
+	u, perr := url.Parse(out)
+	if perr != nil || u.Path != "/"+repoPath || !strings.EqualFold(u.Host, ep.Host) {
+		return "", false
+	}
+	return out, true
 }
 
 // hostOf returns the lowercased host of an https/http/ssh clone URL, or "" for

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -24,7 +24,10 @@ import (
 func TestRemoteClonesSSHRepoURLOverHTTPS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+	d := &Differ{
+		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
+		SSHRewriteHost: "github.com",
+	}
 	_, err := d.Remote(ctx, "git@github.com:Aqemia/engineering.git", "a", "b", "")
 	if err == nil {
 		t.Fatal("want an error from a cancelled clone, got nil")
@@ -101,13 +104,14 @@ func TestSSHToHTTPS(t *testing.T) {
 }
 
 // TestEffectiveCloneURLGating pins WHEN the SSH→HTTPS rewrite applies: only when
-// an HTTPS credential is actually in play for that host. Rewriting when RunLore
-// has no token would trade go-git's working SSH-agent path for an
-// unauthenticated HTTPS 401.
+// there is a credential AND a host it is known to be valid for. Rewriting with no
+// token would trade go-git's working SSH-agent path for an unauthenticated HTTPS
+// 401; rewriting with no known host is the credential leak guarded below.
 func TestEffectiveCloneURLGating(t *testing.T) {
 	const ssh = "git@github.com:acme/x.git"
 	const https = "https://github.com/acme/x.git"
 	tok := func(context.Context) (string, error) { return "ghs_tok", nil }
+	armed := func(host string) *Differ { return &Differ{TokenSource: tok, SSHRewriteHost: host} }
 
 	tests := []struct {
 		name string
@@ -115,12 +119,12 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"no token source keeps SSH for the ssh-agent path", &Differ{}, ssh, ssh},
-		{"token source rewrites to HTTPS", &Differ{TokenSource: tok}, ssh, https},
-		{"matching TokenHost rewrites", &Differ{TokenSource: tok, TokenHost: "github.com"}, ssh, https},
-		{"foreign TokenHost keeps SSH", &Differ{TokenSource: tok, TokenHost: "ghe.example.com"}, ssh, ssh},
-		{"https is never touched", &Differ{TokenSource: tok}, https, https},
-		{"local path is never touched", &Differ{TokenSource: tok}, "/srv/fixtures/repo", "/srv/fixtures/repo"},
+		{"no token source keeps SSH for the ssh-agent path", &Differ{SSHRewriteHost: "github.com"}, ssh, ssh},
+		{"credential host matches: rewrites to HTTPS", armed("github.com"), ssh, https},
+		{"unset credential host refuses to rewrite", &Differ{TokenSource: tok}, ssh, ssh},
+		{"foreign credential host keeps SSH", armed("ghe.example.com"), ssh, ssh},
+		{"https is never touched", armed("github.com"), https, https},
+		{"local path is never touched", armed("github.com"), "/srv/fixtures/repo", "/srv/fixtures/repo"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -129,6 +133,74 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSSHRewriteNeverReachesAForeignHost is the credential boundary the #495
+// rewrite must not dissolve.
+//
+// A GitOps repoURL is cluster state: in a shared cluster, anyone who can create
+// an Application chooses it. The what_changed differ runs with TokenHost EMPTY,
+// so auth attaches the GitHub App installation token to whatever host it clones.
+// Before the rewrite existed, "invalid auth method" killed every SSH URL before a
+// byte left the process — the bug was inadvertently acting as a credential
+// boundary. An unconfined rewrite would have turned
+// "repoURL: ssh://git@attacker.example/x" into that token being POSTed to
+// attacker.example.
+//
+// The clone runs on an already-cancelled context, which never touches the
+// network but does reveal WHICH transport was chosen: go-git names an HTTPS
+// target in the error ("Get \"https://…\"") and rejects an SSH one at
+// "invalid auth method" without forming a request at all. So the error text is
+// the proof that nothing was ever addressed to the foreign host.
+func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
+	// Wired exactly as buildGitOpsDiffer wires what_changed: a credential for
+	// github.com, and TokenHost left empty.
+	newDiffer := func() *Differ {
+		return &Differ{
+			TokenSource:    func(context.Context) (string, error) { return "ghs_SECRET", nil },
+			SSHRewriteHost: "github.com",
+		}
+	}
+
+	foreign := []string{
+		"ssh://git@attacker.example/org/repo.git",
+		"git@attacker.example:org/repo.git",
+		"ssh://git@gitlab.com/org/repo.git",
+		"git@ghe.example.com:org/repo.git",
+		// Lookalikes: neither is the credential's host.
+		"git@github.com.attacker.example:org/repo.git",
+		"git@notgithub.com:org/repo.git",
+	}
+	for _, raw := range foreign {
+		t.Run("foreign "+raw, func(t *testing.T) {
+			d := newDiffer()
+			if got := d.effectiveCloneURL(raw); got != raw {
+				t.Fatalf("rewrote an SSH URL toward a host the credential is not for: %q → %q", raw, got)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			_, err := d.Remote(ctx, raw, "a", "b", "")
+			if err == nil {
+				t.Fatal("want an error, got nil")
+			}
+			if strings.Contains(err.Error(), "https://") {
+				t.Fatalf("an HTTPS request was addressed to a foreign host — the App token would be sent there: %v", err)
+			}
+			if !strings.Contains(err.Error(), "invalid auth method") {
+				t.Fatalf("want the SSH transport to refuse before any request is formed, got %v", err)
+			}
+		})
+	}
+
+	// The credential's own host still gets the fix — the confinement must not
+	// have simply disabled #495.
+	t.Run("credential host is still rewritten", func(t *testing.T) {
+		d := newDiffer()
+		const raw = "git@github.com:org/repo.git"
+		if got := d.effectiveCloneURL(raw); got != "https://github.com/org/repo.git" {
+			t.Fatalf("effectiveCloneURL(%q) = %q, want the HTTPS equivalent", raw, got)
+		}
+	})
 }
 
 // TestCloneRewriteCannotBypassSourceRepoAllowlist is the security guard for #495.
@@ -149,9 +221,14 @@ func TestCloneRewriteCannotBypassSourceRepoAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build allowlist: %v", err)
 	}
-	// A worst-case differ: a token source and no TokenHost, so the rewrite is
-	// unconditionally armed for every host.
-	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+	// A worst-case differ for this boundary: the rewrite is armed, and armed for
+	// exactly the host the allowlist authorizes — so any drift between the string
+	// checked and the string cloned shows up here rather than being masked by the
+	// rewrite declining for an unrelated reason.
+	d := &Differ{
+		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
+		SSHRewriteHost: "github.com",
+	}
 
 	tests := []struct {
 		name, repo string

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package whatchanged
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/sourcerepo"
+)
+
+// TestRemoteClonesSSHRepoURLOverHTTPS is the RunLore #495 regression.
+//
+// Argo CD / Flux routinely point at their source repo over SSH because the
+// engine authenticates with a deploy key. RunLore has no SSH credential — auth
+// only ever mints an HTTP basic auth from the GitHub App token — so go-git's SSH
+// transport rejected every such clone with "invalid auth method" and what_changed
+// lost change correlation for EVERY object, visible only as a data-gaps line.
+//
+// The clone is driven with an already-cancelled context so it never touches the
+// network: go-git formats the target URL into the error before doing any I/O,
+// which is exactly the assertion we need — WHICH url was dialled.
+func TestRemoteClonesSSHRepoURLOverHTTPS(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+	_, err := d.Remote(ctx, "git@github.com:Aqemia/engineering.git", "a", "b", "")
+	if err == nil {
+		t.Fatal("want an error from a cancelled clone, got nil")
+	}
+	if strings.Contains(err.Error(), "invalid auth method") {
+		t.Fatalf("SSH repoURL still dialled over SSH with an HTTPS-only credential (#495): %v", err)
+	}
+	if !strings.Contains(err.Error(), "https://github.com/Aqemia/engineering.git") {
+		t.Fatalf("want the clone to target the HTTPS equivalent, got %v", err)
+	}
+}
+
+func TestSSHToHTTPS(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+		ok             bool
+	}{
+		{"scp-style github", "git@github.com:Aqemia/engineering.git", "https://github.com/Aqemia/engineering.git", true},
+		{"scp-style gitlab subgroup", "git@gitlab.com:group/sub/proj.git", "https://gitlab.com/group/sub/proj.git", true},
+		{"scp-style self-hosted gitlab", "git@gitlab.example.com:org/repo.git", "https://gitlab.example.com/org/repo.git", true},
+		{"ssh scheme", "ssh://git@github.com/acme/x.git", "https://github.com/acme/x.git", true},
+		{"ssh scheme drops the ssh port", "ssh://git@gitlab.example.com:2222/org/repo.git", "https://gitlab.example.com/org/repo.git", true},
+		{"ssh scheme without userinfo", "ssh://github.com/acme/x", "https://github.com/acme/x", true},
+		{"surrounding whitespace", "  git@github.com:acme/x.git\n", "https://github.com/acme/x.git", true},
+		// The RFC 3986 authority of this URL is evil.example — go-git would dial
+		// exactly that over SSH, and the rewrite must not "helpfully" prefer the
+		// userinfo's lookalike host. Same host in, same host out.
+		{"userinfo lookalike keeps the real host", "ssh://git@github.com@evil.example/acme/x", "https://evil.example/acme/x", true},
+		// '@' after the first '/' is path, not authority: the host stays github.com.
+		{"at-sign in the path is not authority", "git@github.com:x@evil.example/y.git", "https://github.com/x@evil.example/y.git", true},
+		{"https is left alone", "https://github.com/acme/x.git", "", false},
+		{"http is left alone", "http://github.com/acme/x", "", false},
+		{"git protocol is left alone", "git://github.com/acme/x.git", "", false},
+		{"local path is left alone", "/srv/fixtures/repo", "", false},
+		{"empty is left alone", "", "", false},
+		{"traversal segment is refused", "git@github.com:../../etc/passwd", "", false},
+		{"traversal segment under ssh scheme is refused", "ssh://git@github.com/acme/../../x", "", false},
+		// The round-trip guard: an SSH path is opaque bytes, an HTTPS path is
+		// not, so anything whose meaning would shift in the rewrite is refused
+		// rather than guessed at.
+		{"percent-encoded traversal is refused", "git@github.com:acme/%2e%2e/evil/x.git", "", false},
+		{"query-shaped path is refused", "git@github.com:acme/x?a=b", "", false},
+		{"fragment-shaped path is refused", "git@github.com:acme/x#ssh://git@evil.example/a", "", false},
+		{"control character in the host is refused", "git@github.com\x00evil.example:acme/x.git", "", false},
+		// The credential-exfiltration shape. go-git's scp syntax takes the FIRST
+		// '@' as userinfo, so it reads the host as the whole "github.com@evil.example"
+		// and fails; net/url takes the LAST, so an unguarded rewrite would emit a
+		// perfectly valid clone of evil.example with "github.com" demoted to
+		// userinfo — and what_changed, which attaches its App token to every host,
+		// would post the token there. Refused.
+		{"double-@ host is refused, never demoted to userinfo", "git@github.com@evil.example:acme/x.git", "", false},
+		{"double-@ host is refused (short form)", "git@a@b.example:acme/x.git", "", false},
+		{"hostless scp form is refused", "git@:acme/x.git", "", false},
+		// go-git's scp regex splits this at the FIRST colon, yielding host
+		// "[fd00" — a rewrite would name a host nobody asked for, so it is not
+		// attempted. (The ssh:// spelling below parses correctly and is fine.)
+		{"scp-style bracketed IPv6 is refused, not guessed", "git@[fd00::1]:acme/x.git", "", false},
+		{"ssh-scheme IPv6 host survives", "ssh://git@[fd00::1]/acme/x.git", "https://[fd00::1]/acme/x.git", true},
+		// go-git resolves the host to "user" here; the rewrite must report that
+		// same host and never promote the later, more plausible-looking one.
+		{"no host promotion from a later lookalike", "git@user:pass@github.com:acme/x.git", "https://user/pass@github.com:acme/x.git", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := sshToHTTPS(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("sshToHTTPS(%q) ok = %v, want %v (got %q)", tc.in, ok, tc.ok, got)
+			}
+			if got != tc.want {
+				t.Fatalf("sshToHTTPS(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveCloneURLGating pins WHEN the SSH→HTTPS rewrite applies: only when
+// an HTTPS credential is actually in play for that host. Rewriting when RunLore
+// has no token would trade go-git's working SSH-agent path for an
+// unauthenticated HTTPS 401.
+func TestEffectiveCloneURLGating(t *testing.T) {
+	const ssh = "git@github.com:acme/x.git"
+	const https = "https://github.com/acme/x.git"
+	tok := func(context.Context) (string, error) { return "ghs_tok", nil }
+
+	tests := []struct {
+		name string
+		d    *Differ
+		in   string
+		want string
+	}{
+		{"no token source keeps SSH for the ssh-agent path", &Differ{}, ssh, ssh},
+		{"token source rewrites to HTTPS", &Differ{TokenSource: tok}, ssh, https},
+		{"matching TokenHost rewrites", &Differ{TokenSource: tok, TokenHost: "github.com"}, ssh, https},
+		{"foreign TokenHost keeps SSH", &Differ{TokenSource: tok, TokenHost: "ghe.example.com"}, ssh, ssh},
+		{"https is never touched", &Differ{TokenSource: tok}, https, https},
+		{"local path is never touched", &Differ{TokenSource: tok}, "/srv/fixtures/repo", "/srv/fixtures/repo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.d.effectiveCloneURL(tc.in); got != tc.want {
+				t.Fatalf("effectiveCloneURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCloneRewriteCannotBypassSourceRepoAllowlist is the security guard for #495.
+//
+// source_diff's allowlist is the boundary that stops a prompt-injected model from
+// making RunLore clone arbitrary hosts (internal/sourcerepo). The tool checks the
+// model's raw string and hands cloneToDisk the URL that check itself produced —
+// so the clone-time SSH→HTTPS rewrite must be a strict NO-OP on anything the
+// allowlist authorized. If it were not, the string checked and the string dialled
+// could diverge and the boundary would be bypassable.
+//
+// The invariant asserted, over inputs crafted to make a sloppy rewriter diverge:
+// Allowlist.Match's output is a FIXED POINT of effectiveCloneURL, and the host
+// actually dialled is the host the allowlist authorized. Refused inputs must be
+// refused by the allowlist, never merely by the rewrite.
+func TestCloneRewriteCannotBypassSourceRepoAllowlist(t *testing.T) {
+	allow, err := sourcerepo.New([]string{"github.com/acme/*"})
+	if err != nil {
+		t.Fatalf("build allowlist: %v", err)
+	}
+	// A worst-case differ: a token source and no TokenHost, so the rewrite is
+	// unconditionally armed for every host.
+	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+
+	tests := []struct {
+		name, repo string
+		allowed    bool
+	}{
+		{"plain host/org/repo", "github.com/acme/x", true},
+		{"https spelling", "https://github.com/acme/x.git", true},
+		{"scp-style ssh spelling", "git@github.com:acme/x.git", true},
+		{"ssh scheme spelling", "ssh://git@github.com/acme/x", true},
+		{"uppercase host", "git@GitHub.COM:acme/x.git", true},
+		{"userinfo lookalike host", "ssh://git@github.com@evil.example/acme/x", false},
+		{"allowed host smuggled into the path", "git@evil.example:github.com/acme/x", false},
+		{"ssh port smuggled as a path segment", "ssh://git@github.com:22/acme/x", false},
+		{"fragment carrying a second url", "git@github.com:acme/x.git#ssh://git@evil.example/a/b", false},
+		{"traversal out of the allowed org", "git@github.com:acme/../evil/x.git", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloneURL, ok := allow.Match(tc.repo)
+			if ok != tc.allowed {
+				t.Fatalf("Match(%q) = (%q, %v), want allowed=%v", tc.repo, cloneURL, ok, tc.allowed)
+			}
+			if !ok {
+				return // never reaches the differ at all
+			}
+			if got := d.effectiveCloneURL(cloneURL); got != cloneURL {
+				t.Fatalf("clone rewrite moved an ALLOWLISTED url: authorized %q but would dial %q — "+
+					"the allow check and the clone must see the same string", cloneURL, got)
+			}
+			if h := hostOf(cloneURL); h != "github.com" {
+				t.Fatalf("authorized url %q resolves to host %q, want github.com", cloneURL, h)
+			}
+		})
+	}
+}

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/Smana/runlore/internal/sourcerepo"
 )
 
+// armedDiffer returns a Differ wired exactly as buildGitOpsDiffer wires
+// what_changed: a GitHub App credential, the SSH→HTTPS rewrite armed for host,
+// and TokenHost deliberately left EMPTY — so auth attaches the token to whatever
+// host the differ ends up cloning.
+//
+// That is the worst case on purpose. With TokenHost empty, the host check in
+// effectiveCloneURL is the only thing standing between a hostile repoURL and the
+// credential, so every leak these tests hunt for is reachable. Do NOT set
+// TokenHost here: it would mask the exact leak
+// TestSSHRewriteNeverReachesAForeignHost exists to catch.
+func armedDiffer(host string) *Differ {
+	return &Differ{
+		TokenSource:    func(context.Context) (string, error) { return "ghs_SECRET", nil },
+		SSHRewriteHost: host,
+	}
+}
+
 // TestRemoteClonesSSHRepoURLOverHTTPS is the RunLore #495 regression.
 //
 // Argo CD / Flux routinely point at their source repo over SSH because the
@@ -24,10 +41,7 @@ import (
 func TestRemoteClonesSSHRepoURLOverHTTPS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	d := &Differ{
-		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
-		SSHRewriteHost: "github.com",
-	}
+	d := armedDiffer("github.com")
 	_, err := d.Remote(ctx, "git@github.com:Aqemia/engineering.git", "a", "b", "")
 	if err == nil {
 		t.Fatal("want an error from a cancelled clone, got nil")
@@ -135,7 +149,6 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 	const ssh = "git@github.com:acme/x.git"
 	const https = "https://github.com/acme/x.git"
 	tok := func(context.Context) (string, error) { return "ghs_tok", nil }
-	armed := func(host string) *Differ { return &Differ{TokenSource: tok, SSHRewriteHost: host} }
 
 	tests := []struct {
 		name string
@@ -144,11 +157,11 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 		want string
 	}{
 		{"no token source keeps SSH for the ssh-agent path", &Differ{SSHRewriteHost: "github.com"}, ssh, ssh},
-		{"credential host matches: rewrites to HTTPS", armed("github.com"), ssh, https},
+		{"credential host matches: rewrites to HTTPS", armedDiffer("github.com"), ssh, https},
 		{"unset credential host refuses to rewrite", &Differ{TokenSource: tok}, ssh, ssh},
-		{"foreign credential host keeps SSH", armed("ghe.example.com"), ssh, ssh},
-		{"https is never touched", armed("github.com"), https, https},
-		{"local path is never touched", armed("github.com"), "/srv/fixtures/repo", "/srv/fixtures/repo"},
+		{"foreign credential host keeps SSH", armedDiffer("ghe.example.com"), ssh, ssh},
+		{"https is never touched", armedDiffer("github.com"), https, https},
+		{"local path is never touched", armedDiffer("github.com"), "/srv/fixtures/repo", "/srv/fixtures/repo"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -178,13 +191,9 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 // the proof that nothing was ever addressed to the foreign host.
 func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 	// Wired exactly as buildGitOpsDiffer wires what_changed: a credential for
-	// github.com, and TokenHost left empty.
-	newDiffer := func() *Differ {
-		return &Differ{
-			TokenSource:    func(context.Context) (string, error) { return "ghs_SECRET", nil },
-			SSHRewriteHost: "github.com",
-		}
-	}
+	// github.com, and TokenHost left empty. Shared across the subtests below —
+	// effectiveCloneURL and Remote never mutate a Differ.
+	d := armedDiffer("github.com")
 
 	foreign := []string{
 		"ssh://git@attacker.example/org/repo.git",
@@ -208,7 +217,6 @@ func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 	}
 	for _, raw := range foreign {
 		t.Run("foreign "+raw, func(t *testing.T) {
-			d := newDiffer()
 			if got := d.effectiveCloneURL(raw); got != raw {
 				t.Fatalf("rewrote an SSH URL toward a host the credential is not for: %q → %q", raw, got)
 			}
@@ -230,7 +238,6 @@ func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 	// The credential's own host still gets the fix — the confinement must not
 	// have simply disabled #495.
 	t.Run("credential host is still rewritten", func(t *testing.T) {
-		d := newDiffer()
 		const raw = "git@github.com:org/repo.git"
 		if got := d.effectiveCloneURL(raw); got != "https://github.com/org/repo.git" {
 			t.Fatalf("effectiveCloneURL(%q) = %q, want the HTTPS equivalent", raw, got)
@@ -260,10 +267,7 @@ func TestCloneRewriteCannotBypassSourceRepoAllowlist(t *testing.T) {
 	// exactly the host the allowlist authorizes — so any drift between the string
 	// checked and the string cloned shows up here rather than being masked by the
 	// rewrite declining for an unrelated reason.
-	d := &Differ{
-		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
-		SSHRewriteHost: "github.com",
-	}
+	d := armedDiffer("github.com")
 
 	tests := []struct {
 		name, repo string

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -89,6 +89,30 @@ func TestSSHToHTTPS(t *testing.T) {
 		// go-git resolves the host to "user" here; the rewrite must report that
 		// same host and never promote the later, more plausible-looking one.
 		{"no host promotion from a later lookalike", "git@user:pass@github.com:acme/x.git", "https://user/pass@github.com:acme/x.git", true},
+		// Non-ASCII hosts. hostOf lowercases with strings.ToLower — Unicode SIMPLE
+		// case mapping — while net/http resolves through idna.Lookup.ToASCII, and
+		// the two disagree: ToLower maps U+0130 to 'i', so "gİthub.com" reads as
+		// "github.com" to the authorization check while net/http dials the
+		// separately registrable "xn--github-qyd.com". Refuse the class, not the
+		// one rune.
+		{"homoglyph host U+0130 is refused", "git@gİthub.com:org/repo.git", "", false},
+		{"homoglyph host under ssh scheme is refused", "ssh://git@gİthub.com/org/repo.git", "", false},
+		{"kelvin-sign host is refused", "git@bacKend.example:org/repo.git", "", false},
+		{"fullwidth host is refused", "git@ｇithub.com:org/repo.git", "", false},
+		{"zero-width space in the host is refused", "git@git\u200bhub.com:org/repo.git", "", false},
+		{"soft hyphen in the host is refused", "git@git\u00adhub.com:org/repo.git", "", false},
+		// A lone continuation byte is not valid UTF-8, so no rune-based check
+		// sees it and the round-trip guard passes it cleanly — only the byte
+		// scan rejects it. This pins the boundary at exactly 0x80: every valid
+		// non-ASCII rune has a lead byte >= 0xC2, so nothing else in this table
+		// would notice the boundary drifting upward.
+		{"raw 0x80 byte in the host is refused", "git@a\x80b.example:org/repo.git", "", false},
+		// Punycode written out is plain ASCII and stays its own distinct host —
+		// it must not be decoded back into a lookalike of anything.
+		{"punycode spelling is its own host", "git@xn--github-qyd.com:org/repo.git", "https://xn--github-qyd.com/org/repo.git", true},
+		// A non-ASCII PATH is not a host-confusion risk: it cannot change which
+		// host is dialled, and net/http escapes it on the wire.
+		{"non-ascii path is allowed", "git@github.com:org/répo.git", "https://github.com/org/répo.git", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -170,6 +194,17 @@ func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 		// Lookalikes: neither is the credential's host.
 		"git@github.com.attacker.example:org/repo.git",
 		"git@notgithub.com:org/repo.git",
+		// IDNA homoglyphs. These are the dangerous ones: hostOf lowercases with
+		// strings.ToLower, which maps U+0130 to 'i', so each of these reads as
+		// exactly "github.com" to the authorization check — while net/http
+		// resolves through idna.Lookup.ToASCII and dials a punycode host the
+		// attacker can register ("xn--github-qyd.com"), serve a valid cert for,
+		// and read the App token off the Authorization header.
+		"git@gİthub.com:org/repo.git",
+		"ssh://git@gİthub.com/org/repo.git",
+		"git@githუb.com:org/repo.git",
+		"git@ｇithub.com:org/repo.git",
+		"git@git\u200bhub.com:org/repo.git",
 	}
 	for _, raw := range foreign {
 		t.Run("foreign "+raw, func(t *testing.T) {


### PR DESCRIPTION
Closes #495.

`what_changed` failed with `invalid auth method` for **every** Application when the GitOps `repoURL` is an SSH URL — which is normal, since Argo CD and Flux authenticate with a deploy key. RunLore holds no SSH credential at all (`Differ.auth` only ever produces HTTP basic auth from a GitHub App token), so go-git rejected the clone before any I/O. It surfaces only as a "data gaps" line at the bottom of a finding, so change correlation silently never happens.

SSH `repoURL`s are now cloned over HTTPS, where the App token can authenticate them.

## One correction to the issue

**`source_diff` was not affected.** It clones `Allowlist.Match`'s output, and `sourcerepo.normalize` (`allowlist.go:89-107`) already collapses both SSH spellings to `https://host/org/repo`. Only `what_changed` was broken — and it has no allow-list at all, because the repoURL is trusted cluster state rather than model output. That asymmetry is the whole bug.

## Two vulnerabilities found while building this

Neither is a regression from the reported bug; both were found by mutating the fix.

**1. A naive rewrite is a token-exfiltration primitive.** `git@github.com@evil.example:org/repo.git` parses to host `github.com@evil.example` under go-git's scp syntax — which cannot dial — but to `evil.example` under RFC 3986, with `github.com` demoted to userinfo. An unchecked rewrite turns a URL that *cannot clone at all* into a working clone of `evil.example`, and `what_changed` attaches its App token to every host it clones. Anyone able to create an Application in a shared cluster could have used it.

The host now comes from go-git's **own** endpoint parser — the same one that would have dialled the raw URL — and the result must re-parse to exactly that host and path or the rewrite is refused. The path half of that round trip also rejects `%2e%2e` traversal that a literal `..` scan misses, and `?`/`#`, which change meaning between an opaque SSH path and an HTTPS one.

**2. The fix itself widened credential exposure, and that is now closed.** `BuildGitOps` sets only `TokenSource`; `TokenHost` is unset, and `auth()` skips its host check when it is empty. So a plain `ssh://git@attacker.example/x` — no trickery — would have been rewritten to HTTPS and handed the App token. Before this PR that URL failed at `invalid auth method`, which means **the bug was inadvertently acting as a credential boundary**.

The rewrite is now confined to a host the credential is known to be valid for, via a new `Differ.SSHRewriteHost` set from `githubGitHost(cfg.Forge.GitHubAPIURL)`. Confining `auth()` itself (setting `TokenHost`) was rejected deliberately: for `source_diff` a misderived host costs one anonymous clone, but for `what_changed` it would withhold the credential from *the operator's own GitOps repo* — every Application — which is precisely the failure this PR exists to fix. A wrong `SSHRewriteHost` costs only an unrewritten SSH URL, i.e. today's behaviour. It cannot regress anyone.

Both doc comments record that the pre-fix error was load-bearing, so the check is not "simplified" away later by someone who cannot see what it holds.

## Allow-list safety

`source_diff`'s allow-list cannot be bypassed: `Match` emits `https://host/org/repo`, on which the rewrite is a strict no-op, so the string checked *is* the string cloned. Pinned two ways — a fixed-point test over crafted inputs, and a tool-level test that every allowed spelling collapses to the checked URL while crafted divergences are refused rather than reshaped.

## Testing

17 mutations, all caught, in both directions — leak (confinement removed) and over-confinement (credential withheld from the host it is for). `TestSSHRewriteNeverReachesAForeignHost` fails against the first commit, which is the point.

That test asserts at transport level rather than on the helper: with a cancelled context, go-git names an HTTPS target in its error but rejects SSH at `invalid auth method` without forming a request — so asserting the error contains no `https://` proves nothing was ever addressed to the foreign host. It covers `attacker.example`, `gitlab.com`, `ghe.example.com`, and the lookalikes `github.com.attacker.example` and `notgithub.com`.

One clause was **deleted rather than shipped**: a `u.User != nil` check that no mutation could kill, because the host equality check provably subsumed it. Removing untestable defence is what forced the double-`@` input above to be found.

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`.

## Known, not fixed

- **`repoURL: https://attacker.example/x` still hands over the App token**, no SSH involved. Pre-existing, untouched by this PR, and closing it means confining `auth()` — which needs the GHE API-host-vs-git-host derivation sorted first. Deserves its own issue.
- **A GitLab forge with a private GitOps repo is broken independently of this.** `BuildGitOps` uses `BuildForgeTokenSource`, which returns nil for GitLab, so the differ clones anonymously whatever the scheme — same class as the KB-sync bug noted at `internal/app/forge.go:70-75`. It probably wants the provider-aware `BuildKBTokenSource`.
- **The reporter's startup-warning suggestion** was not implemented: it would need listing Applications at boot, and for the configured-App case the failure it would warn about no longer happens.
