### PR TITLE
fix(thread): derive a note entry's identity from the note, not the finding

### DIFF
--- a/internal/curate/dedup.go
+++ b/internal/curate/dedup.go
@@ -47,10 +47,11 @@ func (d Dedup) Run(ctx context.Context) error {
 	//
 	// Operator notes: ConceptEntry deliberately leaves Fingerprint unset (a note is
 	// not a curated finding), so two notes ALWAYS fall through to title-Jaccard —
-	// and every note PR shares the title prefix "KB: Operator note: <finding
-	// title>", so two notes filed on the same recurring incident score 1.0. Pairing
-	// them here would let RunLore silently close a human's correction, which
-	// defeats the entire premise of thread capture (see operatorNoteLabel).
+	// and every note PR shares the title prefix "KB: Operator note: ", on top of
+	// which two humans correcting the same recurring incident write about the same
+	// thing in much the same words. Pairing them here would let RunLore silently
+	// close a human's correction, which defeats the entire premise of thread
+	// capture (see operatorNoteLabel).
 	prs = slices.DeleteFunc(prs, func(pr providers.CuratedIssue) bool { return isAutoCloseExempt(pr.Labels) })
 	sort.Slice(prs, func(i, j int) bool { return prs[i].Number < prs[j].Number })
 	canonicalOf := map[int]int{} // dup PR number -> canonical PR number

--- a/internal/curate/lifecycle.go
+++ b/internal/curate/lifecycle.go
@@ -81,9 +81,10 @@ func isOperatorNote(labels []string) bool {
 //     auto-closed note is never suppressed, never escalated, never read back
 //     as a veto by anything in this codebase. Operator notes stay exempt from
 //     DEDUP for a narrower, genuine reason instead: ConceptEntry always
-//     titles a note "KB: Operator note: <finding title>", so two notes on the
-//     same recurring incident score ~1.0 on the title-Jaccard fallback (see
-//     TestDedupNeverClosesAnOperatorNote) — closing one as a "duplicate" of
+//     titles a note "KB: Operator note: <the note's own claim>", so two humans
+//     correcting the same recurring incident score high on the title-Jaccard
+//     fallback — up to 1.0 when they say the same thing (see
+//     TestDedupNeverClosesAnOperatorNote) — and closing one as a "duplicate" of
 //     the other would discard a human's contribution outright. They are NOT
 //     exempt from the stale sweep: closing an untouched note is ordinary
 //     housekeeping, not discarding one, provided the close comment says so

--- a/internal/curate/selfveto_test.go
+++ b/internal/curate/selfveto_test.go
@@ -134,13 +134,14 @@ func TestEntryEditProposalDetectionIsLabelExact(t *testing.T) {
 // housekeeping is indistinguishable from a human veto — for a stronger reason:
 // ConceptEntry deliberately leaves Fingerprint unset, so every note PR falls
 // through dedup's title-Jaccard fallback, and every note PR shares the title
-// prefix "KB: Operator note: <finding title>". Two notes on the SAME recurring
-// incident therefore score a Jaccard of 1.0 — the strongest possible match —
-// with no label protection at all.
+// prefix "KB: Operator note: ". Two humans correcting the SAME recurring
+// incident write about the same thing in much the same words, so their titles
+// score at or near a Jaccard of 1.0 — the strongest possible match — with no
+// label protection at all.
 
 // operatorNoteTitle is the shared, colliding title two notes on the same
 // recurring incident would carry — arming the hazard these tests pin.
-const operatorNoteTitle = "KB: Operator note: Kustomization DependencyNotReady"
+const operatorNoteTitle = "KB: Operator note: Kustomization DependencyNotReady is stuck on a missing GitRepository"
 
 func TestDedupNeverClosesAnOperatorNote(t *testing.T) {
 	// Arm the hazard: identical titles score the maximum possible Jaccard.

--- a/internal/curator/draft.go
+++ b/internal/curator/draft.go
@@ -155,9 +155,18 @@ func alertResourceIfDistinct(inv providers.Investigation) string {
 // It reuses Workload.Ref(), so the namespace is never touched and the empty /
 // bare-namespace cases pass through unchanged; w is a value copy, so mutating its
 // Name is local. Idempotent (NormalizeWorkloadName is).
+//
+// The Ref() is then narrowed by providers.EntryResourceRef, because Workload.Name
+// on a curated finding is MODEL-WRITTEN free text and a whitespace-bearing one
+// ("essentials, monitoring, argocd-app-of-apps") fails RunLore's own merge gate —
+// the curator would draft an entry its own `validate` job rejects. That was
+// reported against thread capture (#491), which shares this exact source; only
+// the value the model happened to produce differed, so fixing one path and not
+// the other would leave the same defect armed here. Whitespace-free refs are
+// returned unchanged, so no entry that merges today is written differently.
 func normalizeResource(w providers.Workload) string {
 	w.Name = normalizeWorkloadName(w.Name)
-	return w.Ref()
+	return providers.EntryResourceRef(w.Ref())
 }
 
 // entryType derives the OKF type for a drafted entry. The default is Incident: a

--- a/internal/curator/draft_test.go
+++ b/internal/curator/draft_test.go
@@ -463,3 +463,49 @@ func TestCapTitleExported(t *testing.T) {
 		t.Fatalf("must cap at 120 bytes, got %d", len(capped))
 	}
 }
+
+// TestDraftKBEntryResourceClearsTheMergeGate pins the curator half of #491.
+//
+// The issue was reported against thread capture, and attributed the defect to
+// that path alone — the curator "does not have this bug" — on the evidence of
+// one PR, minutes apart, whose resource happened to carry no whitespace. It is
+// the same source: Workload.Name on a curated finding is MODEL-WRITTEN free text
+// (submit_findings' affected_resource), so a finding covering several objects
+// reaches Ref() as the model's own list. Written verbatim, the curator drafts an
+// entry that its OWN validate job rejects — kbvalidate errors on any `resource`
+// containing whitespace — so the KB PR can never be merged.
+func TestDraftKBEntryResourceClearsTheMergeGate(t *testing.T) {
+	inv := providers.Investigation{
+		Title:      "Core Argo CD Applications stuck OutOfSync",
+		Confidence: 0.9,
+		Resource:   providers.Workload{Namespace: "argocd", Name: "essentials, monitoring, argocd-app-of-apps"},
+		RootCauses: []providers.Hypothesis{{Summary: `"system" ApplicationSet lost syncPolicy.automated`, Confidence: 0.9}},
+	}
+
+	// Positive control: the unnarrowed ref really does fail the gate.
+	if !kbvalidate.HasErrors(kbvalidate.ValidateStructural(catalog.Entry{
+		Type: "Incident", Title: inv.Title, Description: "d", Resource: inv.Resource.Ref(),
+		Tags: []string{"t"}, Body: "## Symptom\n\ns\n\n## Cause\n\nc\n\n## Resolution\n\nr\n",
+	})) {
+		t.Fatalf("fixture is inert: %q already clears the merge gate", inv.Resource.Ref())
+	}
+
+	e := draftKBEntry(inv)
+	if e.Resource != "argocd/essentials" {
+		t.Errorf("KBEntry.Resource = %q, want %q", e.Resource, "argocd/essentials")
+	}
+	for _, is := range kbvalidate.ValidateStructural(catalog.Entry{
+		Type: e.Type, Title: e.Title, Description: e.Description,
+		Resource: e.Resource, Tags: e.Tags, Body: e.Body,
+	}) {
+		if is.Severity == kbvalidate.SeverityError {
+			t.Errorf("the curator drafted an entry that fails its own merge gate: %s: %s", is.Field, is.Message)
+		}
+	}
+	// The alert-side index gets the same treatment: it is written to frontmatter
+	// too, and recall matches an incoming alert against it.
+	inv.AlertResource = providers.Workload{Namespace: "argocd", Name: "essentials, monitoring"}
+	if got := draftKBEntry(inv).AlertResource; strings.ContainsAny(got, " \t\r\n") {
+		t.Errorf("KBEntry.AlertResource = %q still carries whitespace", got)
+	}
+}

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -29,9 +29,12 @@ import (
 //
 // Callers apply this ONLY to a bundle that already has an index.md: an index's
 // structure is the owner's choice, so RunLore never invents one.
+//
+// The title goes through linkText: it is the LABEL of a markdown link, and a "]"
+// in it closes the link early — see that function.
 func UpdateIndex(existing []byte, e providers.KBEntry, entryPath string) []byte {
 	section := "## " + e.Type + "s"
-	line := fmt.Sprintf("- [%s](%s) — %s", e.Title, entryPath, e.Description)
+	line := fmt.Sprintf("- [%s](%s) — %s", linkText(e.Title), entryPath, e.Description)
 
 	lines := strings.Split(strings.TrimRight(string(existing), "\n"), "\n")
 	start := -1
@@ -66,7 +69,7 @@ func UpdateIndex(existing []byte, e providers.KBEntry, entryPath string) []byte 
 // is fully specified by the spec, so there is nothing to impose.
 func UpdateLog(existing []byte, e providers.KBEntry, entryPath, date string) []byte {
 	heading := "## " + date
-	line := fmt.Sprintf("* **Creation**: Added [%s](%s).", e.Title, entryPath)
+	line := fmt.Sprintf("* **Creation**: Added [%s](%s).", linkText(e.Title), entryPath)
 
 	cur := strings.TrimRight(string(existing), "\n")
 	if strings.TrimSpace(cur) == "" {
@@ -91,3 +94,29 @@ func UpdateLog(existing []byte, e providers.KBEntry, entryPath, date string) []b
 	}
 	return []byte(strings.Join(slices.Insert(lines, at, heading, "", line, ""), "\n") + "\n")
 }
+
+// linkTextEscaper escapes the three characters that let an entry TITLE break out
+// of the markdown link label it is rendered as. Backslash first, so the escapes
+// this adds are not themselves re-escaped.
+var linkTextEscaper = strings.NewReplacer(`\`, `\\`, `[`, `\[`, `]`, `\]`)
+
+// linkText prepares a title for use as the LABEL of a markdown link — the "%s"
+// in "[%s](path)".
+//
+// A "]" in the label closes the link early, so everything after it re-parses:
+// a title of `boom](https://evil.example) x` rendered `[boom](https://evil.example) x](path.md)`,
+// a working link to the attacker's URL where the index's own link to the entry
+// should be. Backslash escapes are the CommonMark answer — `\]` is a literal
+// "]" and does not close the label — so the title still reads as written.
+//
+// It escapes rather than strips because these lines are the catalog's human
+// index: a title is the one string a reader scans the file for, and silently
+// dropping characters from it would make the index disagree with the entry.
+//
+// It is applied HERE, at the point the structural assumption is made, rather
+// than at each producer. Both producers are exposed: internal/curator titles an
+// entry from model-written text, and internal/thread titles an operator note
+// from a chat message any channel member can send. A defusal in one of them
+// would leave the other open, and neither is the place that decided a title
+// would be a link label.
+func linkText(s string) string { return linkTextEscaper.Replace(s) }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -89,15 +89,31 @@ func (w Workload) Ref() string {
 // against and is a real object, so keeping it preserves the index. Nothing is
 // lost — the full list still reaches the entry BODY verbatim.
 //
-// Whitespace-free input is returned unchanged, so this is a no-op for every ref a
-// well-formed Workload produces: a Kubernetes object name cannot contain a space.
-// It deliberately does NOT split a comma-joined list that carries no whitespace
-// ("a,b,c"): that value clears the gate today, and quietly rewriting what a merged
-// entry is indexed under is a bigger change than closing the gate defect.
+// Whitespace-free input is returned EXACTLY as given — the single-field early
+// return below exists for that promise alone. It is what lets every caller say
+// that no entry which merges today is written differently, and it is why the
+// punctuation trim is guarded rather than unconditional: an unguarded trim also
+// rewrites "argocd/app," and "a;b;", which are whitespace-free, clear the gate
+// today, and are none of this function's business.
+//
+// So it deliberately does NOT split a comma-joined list that carries no
+// whitespace ("a,b,c"): that value merges today, and quietly rewriting what an
+// existing entry is indexed under is a bigger change than closing a gate defect.
+//
+// KNOWN CONSEQUENCE: two different multi-object findings that happen to lead with
+// the same object now write the SAME `resource`, while curator.DupFingerprint
+// keeps them distinct (it hashes the full, un-narrowed Ref()). So the frontmatter
+// index can collide where the dedup identity does not — a new class, and stated
+// here rather than left to be discovered. It is strictly better than what it
+// replaces, where neither entry could be merged at all, and the entry body still
+// distinguishes them for a reader.
 func EntryResourceRef(ref string) string {
 	fields := strings.Fields(ref)
 	if len(fields) == 0 {
 		return ""
+	}
+	if len(fields) == 1 {
+		return fields[0]
 	}
 	// Trailing list punctuation is what the split left behind ("argocd/essentials,"),
 	// not part of the name; a trailing "/" would leave a ref with an empty name half.

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -68,6 +68,42 @@ func (w Workload) Ref() string {
 	return w.Namespace + "/" + w.Name
 }
 
+// EntryResourceRef narrows a rendered workload ref to the single, whitespace-free
+// value RunLore's own merge gate accepts in a knowledge-base entry's `resource:`
+// frontmatter — kbvalidate rejects any resource containing " \t\r\n" outright.
+//
+// It exists because Ref() renders whatever is in Workload.Name, and on a curated
+// or captured finding that is MODEL-WRITTEN free text: submit_findings fills
+// affected_resource (internal/investigate/tools.go), and a finding covering
+// several objects routinely arrives as a list — "essentials, monitoring,
+// argocd-app-of-apps" — which Ref() renders as "argocd/essentials, monitoring,
+// argocd-app-of-apps". Written verbatim, that value fails the gate, so the entry's
+// pull request can never be merged. On the thread-capture path that is the worst
+// possible shape of failure: the human is told the write succeeded and the
+// announcement fires, because both are 1:1 with the LANDED FORGE WRITE, which did
+// land — only the merge is impossible, and nothing surfaces it.
+//
+// Narrowing, not dropping: `resource` is the structural-recall index (see
+// investigate's resourceAgrees), so an entry with no resource is reachable
+// lexically only. The first listed object is the one the namespace was rendered
+// against and is a real object, so keeping it preserves the index. Nothing is
+// lost — the full list still reaches the entry BODY verbatim.
+//
+// Whitespace-free input is returned unchanged, so this is a no-op for every ref a
+// well-formed Workload produces: a Kubernetes object name cannot contain a space.
+// It deliberately does NOT split a comma-joined list that carries no whitespace
+// ("a,b,c"): that value clears the gate today, and quietly rewriting what a merged
+// entry is indexed under is a bigger change than closing the gate defect.
+func EntryResourceRef(ref string) string {
+	fields := strings.Fields(ref)
+	if len(fields) == 0 {
+		return ""
+	}
+	// Trailing list punctuation is what the split left behind ("argocd/essentials,"),
+	// not part of the name; a trailing "/" would leave a ref with an empty name half.
+	return strings.TrimRight(fields[0], ",;/")
+}
+
 // reDeployPod matches a volatile pod-name suffix: a Deployment pod is
 // <name>-<rs-hash>-<pod-hash>, e.g. "harbor-registry-59598dbd57-ltkzw". The suffix
 // names one ephemeral pod, not the controller family it belongs to.

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -287,6 +287,14 @@ func TestEntryResourceRefNarrowsToTheMergeGatesShape(t *testing.T) {
 		{"empty stays empty", "", ""},
 		{"whitespace-only yields empty rather than a blank resource", "   \t ", ""},
 		{"a comma-joined list WITHOUT whitespace clears the gate already and is left alone", "argocd/a,b,c", "argocd/a,b,c"},
+		// The "whitespace-free input is returned exactly as given" promise is what
+		// lets every caller say no entry that merges today is written differently,
+		// so it has to hold for input the punctuation trim would otherwise rewrite.
+		// These three end IN that trim's cutset, which the case above does not —
+		// and an unguarded TrimRight silently changed all three.
+		{"a trailing comma is left alone when there was nothing to split", "argocd/a,b,c,", "argocd/a,b,c,"},
+		{"a trailing semicolon likewise", "a;b;", "a;b;"},
+		{"a trailing slash likewise", "argocd/app/", "argocd/app/"},
 		{"surrounding whitespace is trimmed", "  tooling/harbor  ", "tooling/harbor"},
 		{"a tab separator counts as whitespace too", "tooling/harbor\tregistry", "tooling/harbor"},
 		{"a dangling slash would leave an empty name half", "tooling/ harbor", "tooling"},

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
@@ -262,5 +263,43 @@ func TestKBUpdateClassifiesEveryFieldForEscaping(t *testing.T) {
 				t.Errorf("KBUpdate has no field %q — stale classification entry", name)
 			}
 		}
+	}
+}
+
+// TestEntryResourceRefNarrowsToTheMergeGatesShape pins the one property the
+// knowledge base's merge gate cares about — kbvalidate rejects any `resource:`
+// containing whitespace — and the one property recall cares about: the value
+// that survives is still a usable structural index, not an empty string.
+//
+// The whitespace-bearing fixtures are the live one from #491: a finding covering
+// three Argo CD Applications reached Workload.Name as the model's own
+// comma-and-space list, so Ref() rendered "argocd/essentials, monitoring,
+// argocd-app-of-apps" and the entry's own validate job rejected it.
+func TestEntryResourceRefNarrowsToTheMergeGatesShape(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{"model listed several objects, comma-and-space", "argocd/essentials, monitoring, argocd-app-of-apps", "argocd/essentials"},
+		{"a plain ref is untouched", "tooling/harbor-registry", "tooling/harbor-registry"},
+		{"a bare namespace is untouched", "tooling", "tooling"},
+		{"empty stays empty", "", ""},
+		{"whitespace-only yields empty rather than a blank resource", "   \t ", ""},
+		{"a comma-joined list WITHOUT whitespace clears the gate already and is left alone", "argocd/a,b,c", "argocd/a,b,c"},
+		{"surrounding whitespace is trimmed", "  tooling/harbor  ", "tooling/harbor"},
+		{"a tab separator counts as whitespace too", "tooling/harbor\tregistry", "tooling/harbor"},
+		{"a dangling slash would leave an empty name half", "tooling/ harbor", "tooling"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := providers.EntryResourceRef(tt.ref)
+			if got != tt.want {
+				t.Errorf("EntryResourceRef(%q) = %q, want %q", tt.ref, got, tt.want)
+			}
+			if strings.ContainsAny(got, " \t\r\n") {
+				t.Errorf("EntryResourceRef(%q) = %q — still contains whitespace, which the merge gate rejects outright", tt.ref, got)
+			}
+		})
 	}
 }

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -430,35 +430,25 @@ func noteEntryTitle(tc Context, n Note) string {
 	// files nothing for an empty draft. Naming the finding still beats a bare
 	// "Operator note", and "on" reads as ABOUT the finding rather than as a claim
 	// the note makes about it.
-	if s := collapseSpaces(noteField(tc.Title)); s != "" {
+	if s := noteLine(tc.Title); s != "" {
 		return truncateWords("Operator note on "+s, maxNoteTitle)
 	}
 	return "Operator note"
 }
 
 // noteClaim renders the note's own leading words as one bounded, single-line
-// claim: redacted and flattened (noteField), squeezed, stripped of the Markdown
+// claim: redacted and squeezed to one line (noteLine), stripped of the Markdown
 // a chat reply opens with, and cut on a WORD boundary.
 //
 // It returns "" for a note that has no word in it at all — a lone bullet, a row
 // of punctuation. "Operator note: -" is not an identity, and the caller has a
 // better fallback than a title that says nothing.
 func noteClaim(text string, maxBytes int) string {
-	s := stripLeadingMarkup(collapseSpaces(noteField(text)))
-	if !hasWordRune(s) {
+	s := stripLeadingMarkup(noteLine(text))
+	if !strings.ContainsFunc(s, func(r rune) bool { return unicode.IsLetter(r) || unicode.IsDigit(r) }) {
 		return ""
 	}
 	return truncateWords(s, maxBytes)
-}
-
-// hasWordRune reports whether s carries anything a reader would call a word.
-func hasWordRune(s string) bool {
-	for _, r := range s {
-		if unicode.IsLetter(r) || unicode.IsDigit(r) {
-			return true
-		}
-	}
-	return false
 }
 
 // conceptDescription renders the entry's one-line description.
@@ -488,14 +478,14 @@ func hasWordRune(s string) bool {
 // Every part is bounded on its own rather than the whole line truncated at the
 // end, so the provenance clause can never be the part that gets cut.
 func conceptDescription(tc Context, n Note) string {
+	who := truncateWords(noteLine(n.Author), maxNoteAuthor)
 	var b strings.Builder
-	who := truncateWords(collapseSpaces(noteField(n.Author)), maxNoteAuthor)
 	if n.modelDrafted() {
 		fmt.Fprintf(&b, "Note drafted by RunLore from @%s's %s thread message, pending review", who, transportName(tc.Transport))
 	} else {
 		fmt.Fprintf(&b, "Operator knowledge from @%s via %s", who, transportName(tc.Transport))
 	}
-	if s := truncateWords(collapseSpaces(noteField(tc.Title)), maxNoteDescriptionContext); s != "" {
+	if s := truncateWords(noteLine(tc.Title), maxNoteDescriptionContext); s != "" {
 		fmt.Fprintf(&b, ", on the finding %q", s)
 	}
 	if claim := noteClaim(n.Text, maxNoteDescriptionClaim); claim != "" {
@@ -506,11 +496,17 @@ func conceptDescription(tc Context, n Note) string {
 	return b.String()
 }
 
-// collapseSpaces squeezes every run of whitespace to a single space and trims
-// the ends — the shape a one-line YAML title or description needs. noteField
-// already maps line breaks (and the control/format runes that render as one) to
-// spaces; this removes the runs they leave behind.
-func collapseSpaces(s string) string { return strings.Join(strings.Fields(s), " ") }
+// noteLine prepares one identity field — an author, an alert-derived title, the
+// note text — for a single-line YAML title or description: noteField redacts it
+// and maps line breaks (and the control/format runes that render as one) to
+// spaces, then strings.Fields squeezes the runs they leave behind and trims the
+// ends.
+//
+// One function rather than two composed at each call site, because no caller
+// wants either half alone: a squeezed but unredacted field would put a secret in
+// an entry's title, which outlives the pull request it arrived on (see
+// ConceptEntry).
+func noteLine(s string) string { return strings.Join(strings.Fields(noteField(s)), " ") }
 
 // leadingMarkupMarkers are the one-character Markdown markers a chat reply
 // opens a line with. Only a marker followed by a SPACE counts, so "-1 replica"

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -18,6 +18,30 @@ import (
 // characters.
 const maxNoteTitle = 90
 
+// noteTitlePrefix leads every generated entry title. What follows it is the
+// NOTE's own claim, not the finding's headline — see noteEntryTitle.
+const noteTitlePrefix = "Operator note: "
+
+// The description's parts are each bounded on their own, so the line as a whole
+// is bounded without a final truncation — which would cut the provenance clause,
+// the one part that must never be lost (see conceptDescription).
+const (
+	// maxNoteDescriptionClaim gives the note's own words room for roughly two
+	// sentences. Bigger than the title's share deliberately: the description is
+	// the half of instant recall's root-cause claim that can afford to be
+	// complete, and the merge gate puts no limit on it (only `title` is capped).
+	maxNoteDescriptionClaim = 200
+	// maxNoteDescriptionContext bounds the finding title carried as context. 120
+	// is the merge gate's own title limit, which curator.CapTitle already caps
+	// every curated title to — so an ordinary finding arrives here WHOLE, and the
+	// alert's distinguishing words (the ones that make the note reachable from
+	// the alert again) are not the ones a cut takes off the end.
+	maxNoteDescriptionContext = 120
+	// maxNoteAuthor bounds a chat handle. Defensive: an author string comes from
+	// the transport, and nothing else here caps it.
+	maxNoteAuthor = 40
+)
+
 // DefaultMaxNoteBytes bounds one human message's INPUT, in bytes, before it
 // is written to the knowledge base or shown to a model.
 //
@@ -309,11 +333,11 @@ func cutToRuneBoundary(s string, n int) string {
 // It matters because ConceptEntry deliberately leaves Fingerprint unset (a
 // note is not a curated finding — see the comment below), so two notes are
 // ALWAYS compared by dedup's title-Jaccard fallback. Every note PR shares the
-// title prefix "KB: Operator note: <finding title>", so two notes on the same
-// recurring incident score a Jaccard of 1.0 — the strongest possible dedup
-// match. Without this label RunLore would silently close a human's
-// correction as a "duplicate" of another human's correction, which defeats
-// the entire premise of thread capture.
+// title prefix "KB: Operator note: ", and two humans correcting the same
+// recurring incident write about the same thing in much the same words, so
+// their titles score near the top of that fallback. Without this label RunLore
+// would silently close a human's correction as a "duplicate" of another
+// human's correction, which defeats the entire premise of thread capture.
 //
 // internal/thread depends only on providers and internal/catalog by design,
 // so this literal is duplicated — not imported — in internal/curate. Kept in
@@ -339,12 +363,6 @@ const noteForgeLabel = "runlore-operator-note"
 // outlives the pull request it arrived on. Redaction is idempotent, so a field
 // NoteBody already masked costs nothing here.
 func ConceptEntry(tc Context, n Note, at time.Time, maxBytes int) providers.KBEntry {
-	title := "Operator note"
-	if tc.Title != "" {
-		title = "Operator note: " + noteField(tc.Title)
-	}
-	title = truncate(title, maxNoteTitle)
-
 	var body strings.Builder
 	body.WriteString(NoteBody(tc, n, at, maxBytes))
 	if tc.RecalledEntry != "" || tc.TriggerKey != "" || tc.Resource != "" {
@@ -365,9 +383,13 @@ func ConceptEntry(tc Context, n Note, at time.Time, maxBytes int) providers.KBEn
 
 	return providers.KBEntry{
 		Type:        "Concept",
-		Title:       title,
-		Description: truncate(conceptDescription(tc, n), maxNoteTitle*2),
-		Resource:    tc.Resource,
+		Title:       noteEntryTitle(tc, n),
+		Description: conceptDescription(tc, n),
+		// Narrowed to the one whitespace-free value the merge gate accepts — the
+		// body's Context section above still carries tc.Resource in full. See
+		// providers.EntryResourceRef for what this closes and why it narrows
+		// rather than drops.
+		Resource:    providers.EntryResourceRef(tc.Resource),
 		Tags:        []string{"operator-note", transportName(tc.Transport)},
 		ExtraLabels: []string{noteForgeLabel},
 		Body:        body.String(),
@@ -377,16 +399,148 @@ func ConceptEntry(tc Context, n Note, at time.Time, maxBytes int) providers.KBEn
 	}
 }
 
-// conceptDescription renders the entry's one-line description, which is the
-// only provenance a catalog listing or a search hit shows — the body's
-// heading never reaches either. It therefore has to make the same
-// human-wrote-it / model-drafted-it distinction NoteBody's header does,
-// otherwise the distinction survives only for a reader who opens the entry.
-func conceptDescription(tc Context, n Note) string {
-	if n.modelDrafted() {
-		return fmt.Sprintf("Note drafted by RunLore from @%s's %s thread message, pending review.", noteField(n.Author), transportName(tc.Transport))
+// noteEntryTitle names the entry after the NOTE, not after the finding the note
+// was written in reply to.
+//
+// The finding's title used to BE the identity ("Operator note: <finding
+// title>"), and that is wrong twice over.
+//
+// It files a note that CORRECTS a finding under the headline of the very thing
+// it corrects. Live, the reranker then matched such an entry and quoted the
+// refuted hypothesis back as its grounds for matching.
+//
+// And it truncated on a byte boundary, so the title routinely ended mid-word
+// ("… stu…"). That is not cosmetic: instant recall builds its whole root-cause
+// claim as `title + " — " + description` (investigate.recalledInvestigation),
+// and a Concept note has no Cause/Resolution sections to add to it — by
+// construction, since escapeOKFSections exists to stop a note forging them. So
+// those two fields ARE the claim verify judges, verify correctly rejected an
+// unintelligible one every time, and a corrected entry could never take the
+// cheap instant-recall path it exists to earn.
+//
+// The finding is not dropped, it is demoted from identity to CONTEXT:
+// conceptDescription names it, and the body's "Thread:" line and Context section
+// carry it in full.
+func noteEntryTitle(tc Context, n Note) string {
+	if claim := noteClaim(n.Text, maxNoteTitle-len(noteTitlePrefix)); claim != "" {
+		return noteTitlePrefix + claim
 	}
-	return fmt.Sprintf("Operator knowledge captured from a %s thread by @%s.", transportName(tc.Transport), noteField(n.Author))
+	// Only reachable when the note is empty or is nothing but markup:
+	// Responder.Handle answers an empty "note:" without writing, and freeform
+	// files nothing for an empty draft. Naming the finding still beats a bare
+	// "Operator note", and "on" reads as ABOUT the finding rather than as a claim
+	// the note makes about it.
+	if s := collapseSpaces(noteField(tc.Title)); s != "" {
+		return truncateWords("Operator note on "+s, maxNoteTitle)
+	}
+	return "Operator note"
+}
+
+// noteClaim renders the note's own leading words as one bounded, single-line
+// claim: redacted and flattened (noteField), squeezed, stripped of the Markdown
+// a chat reply opens with, and cut on a WORD boundary.
+//
+// It returns "" for a note that has no word in it at all — a lone bullet, a row
+// of punctuation. "Operator note: -" is not an identity, and the caller has a
+// better fallback than a title that says nothing.
+func noteClaim(text string, maxBytes int) string {
+	s := stripLeadingMarkup(collapseSpaces(noteField(text)))
+	if !hasWordRune(s) {
+		return ""
+	}
+	return truncateWords(s, maxBytes)
+}
+
+// hasWordRune reports whether s carries anything a reader would call a word.
+func hasWordRune(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// conceptDescription renders the entry's one-line description.
+//
+// It is the only provenance a catalog listing or a search hit shows — the body's
+// heading never reaches either — so it has to make the same human-wrote-it /
+// model-drafted-it distinction NoteBody's header does, otherwise the distinction
+// survives only for a reader who opens the entry.
+//
+// It also has to carry SIGNAL, which it used to carry none of: a fixed sentence
+// naming the author and the transport, byte-identical across every operator
+// note, on the field with three consumers that all read it as content. It is
+// half of what instant recall hands verify as the root-cause claim (see
+// noteEntryTitle), it is what the reranker is shown for each candidate
+// (investigate.renderRerankCandidates), and it is indexed for lexical search
+// (catalog.Entry's search text).
+//
+// So it renders three things in this order:
+//
+//   - the provenance clause FIRST, because a listing that clips the line must
+//     never clip the fact that RunLore, not the human, wrote the text;
+//   - the finding the note annotates, as context — it is what keeps the note
+//     reachable from the alert that produced it, and it must not be the note's
+//     identity (see noteEntryTitle);
+//   - the note's own claim, at greater length than the title had room for.
+//
+// Every part is bounded on its own rather than the whole line truncated at the
+// end, so the provenance clause can never be the part that gets cut.
+func conceptDescription(tc Context, n Note) string {
+	var b strings.Builder
+	who := truncateWords(collapseSpaces(noteField(n.Author)), maxNoteAuthor)
+	if n.modelDrafted() {
+		fmt.Fprintf(&b, "Note drafted by RunLore from @%s's %s thread message, pending review", who, transportName(tc.Transport))
+	} else {
+		fmt.Fprintf(&b, "Operator knowledge from @%s via %s", who, transportName(tc.Transport))
+	}
+	if s := truncateWords(collapseSpaces(noteField(tc.Title)), maxNoteDescriptionContext); s != "" {
+		fmt.Fprintf(&b, ", on the finding %q", s)
+	}
+	if claim := noteClaim(n.Text, maxNoteDescriptionClaim); claim != "" {
+		fmt.Fprintf(&b, ": %s", claim)
+	} else {
+		b.WriteString(".")
+	}
+	return b.String()
+}
+
+// collapseSpaces squeezes every run of whitespace to a single space and trims
+// the ends — the shape a one-line YAML title or description needs. noteField
+// already maps line breaks (and the control/format runes that render as one) to
+// spaces; this removes the runs they leave behind.
+func collapseSpaces(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+// leadingMarkupMarkers are the one-character Markdown markers a chat reply
+// opens a line with. Only a marker followed by a SPACE counts, so "-1 replica"
+// keeps its minus sign.
+const leadingMarkupMarkers = ">-*+"
+
+// stripLeadingMarkup removes the Markdown a chat reply routinely opens with — a
+// bullet, a blockquote marker, an ATX heading — so a note's title reads as its
+// claim rather than as "- the cause was …".
+//
+// Heading detection goes through atxHeadingText, the same parse the read path
+// performs, rather than a second spelling of it.
+//
+// Bounded rather than looped to a fixed point: nesting deeper than a few levels
+// is not something a chat reply does, and a bound is one less way for untrusted
+// text to control how long this runs.
+func stripLeadingMarkup(s string) string {
+	s = strings.TrimSpace(s)
+	for range 4 {
+		if h := atxHeadingText(s); h != "" {
+			s = h
+			continue
+		}
+		if len(s) >= 2 && strings.IndexByte(leadingMarkupMarkers, s[0]) >= 0 && s[1] == ' ' {
+			s = strings.TrimSpace(s[2:])
+			continue
+		}
+		break
+	}
+	return s
 }
 
 // transportName normalises an empty transport so rendering never emits "via ".
@@ -568,6 +722,33 @@ func singleLine(s string) string {
 		}
 		return r
 	}, s)
+}
+
+// truncateWords shortens s to around n bytes like truncate, but cuts on a WORD
+// boundary wherever one is available.
+//
+// truncate's rune-boundary cut is right for a machine-generated field nobody
+// reads as a sentence, and wrong for anything a model then has to UNDERSTAND: it
+// produced entry titles ending "… stu…", which verify rejected as
+// unintelligible rather than as false — see noteEntryTitle for the whole path.
+//
+// The word boundary is only taken when it keeps at least half of what was cut
+// to. A single unbroken token longer than the budget — a URL, a hash, one very
+// long word — has no boundary to cut on, and backing off to an early space would
+// throw away nearly everything the field had room for; there, the rune boundary
+// is the honest cut. Trailing punctuation left dangling by the cut is dropped so
+// the mark reads as a continuation, not as a comma followed by an ellipsis.
+//
+// Like truncate, the result can exceed n by the ellipsis' 2 extra bytes.
+func truncateWords(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	kept := cutToRuneBoundary(s, n-1)
+	if i := strings.LastIndexByte(kept, ' '); i > 0 && 2*i >= len(kept) {
+		kept = kept[:i]
+	}
+	return strings.TrimRight(kept, " ,;:—-") + "…"
 }
 
 // truncate shortens s to around n bytes: it cuts at or before byte index n-1

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -381,10 +381,13 @@ func ConceptEntry(tc Context, n Note, at time.Time, maxBytes int) providers.KBEn
 		}
 	}
 
+	// Derived ONCE, from the same bounded text the body above files, and shared by
+	// both identity fields — see noteClaim and noteClaimSource.
+	claim := noteClaim(n.Text, maxBytes)
 	return providers.KBEntry{
 		Type:        "Concept",
-		Title:       noteEntryTitle(tc, n),
-		Description: conceptDescription(tc, n),
+		Title:       noteEntryTitle(tc, claim),
+		Description: conceptDescription(tc, n, claim),
 		// Narrowed to the one whitespace-free value the merge gate accepts — the
 		// body's Context section above still carries tc.Resource in full. See
 		// providers.EntryResourceRef for what this closes and why it narrows
@@ -421,9 +424,11 @@ func ConceptEntry(tc Context, n Note, at time.Time, maxBytes int) providers.KBEn
 // The finding is not dropped, it is demoted from identity to CONTEXT:
 // conceptDescription names it, and the body's "Thread:" line and Context section
 // carry it in full.
-func noteEntryTitle(tc Context, n Note) string {
-	if claim := noteClaim(n.Text, maxNoteTitle-len(noteTitlePrefix)); claim != "" {
-		return noteTitlePrefix + claim
+// claim is the note's own words, already bounded and defused by noteClaim; the
+// title re-cuts it to its own smaller budget.
+func noteEntryTitle(tc Context, claim string) string {
+	if claim != "" {
+		return noteTitlePrefix + truncateWords(claim, maxNoteTitle-len(noteTitlePrefix))
 	}
 	// Only reachable when the note is empty or is nothing but markup:
 	// Responder.Handle answers an empty "note:" without writing, and freeform
@@ -437,18 +442,75 @@ func noteEntryTitle(tc Context, n Note) string {
 }
 
 // noteClaim renders the note's own leading words as one bounded, single-line
-// claim: redacted and squeezed to one line (noteLine), stripped of the Markdown
-// a chat reply opens with, and cut on a WORD boundary.
+// claim: drawn from at most maxBytes of the message (noteClaimSource), redacted,
+// squeezed and defused (noteLine), stripped of the Markdown a chat reply opens
+// with, and cut on a WORD boundary.
+//
+// It is bounded to maxNoteDescriptionClaim — the largest budget any caller has —
+// and callers needing less re-cut the result, so this runs ONCE per entry rather
+// than once per field. Two calls over a 1 MiB message cost ~1 s and ~86 MB
+// between them; see noteClaimSource for the rest of that story.
 //
 // It returns "" for a note that has no word in it at all — a lone bullet, a row
 // of punctuation. "Operator note: -" is not an identity, and the caller has a
 // better fallback than a title that says nothing.
 func noteClaim(text string, maxBytes int) string {
-	s := stripLeadingMarkup(noteLine(text))
+	s := stripLeadingMarkup(noteLine(noteClaimSource(text, maxBytes)))
 	if !strings.ContainsFunc(s, func(r rune) bool { return unicode.IsLetter(r) || unicode.IsDigit(r) }) {
 		return ""
 	}
-	return truncateWords(s, maxBytes)
+	return truncateWords(s, maxNoteDescriptionClaim)
+}
+
+// noteClaimSource bounds the raw message a claim is drawn from to maxBytes — the
+// operator's own notify.thread.max_note_bytes, the same cap the BODY is filed
+// under.
+//
+// Two reasons, and the second is the one that makes maxBytes the right number
+// rather than merely a small one.
+//
+// Cost. Nothing upstream bounds Note.Text: DefaultMaxNoteBytes is applied inside
+// NoteBody -> noteText -> capNoteText, which is downstream of here, while a
+// Matrix event carries up to 64 KiB and a Slack request body up to 1 MiB. Run
+// unbounded, one claim over a 1 MiB message costs ~500 ms and ~43 MB in
+// redact.Secrets and strings.Fields alone — roughly what the whole entry cost
+// before claims existed — on a path any channel member can trigger. Bounded, the
+// same claim costs ~3.7 ms and ~0.35 MB.
+//
+// Coherence. The title and description must never quote words the entry BODY
+// does not contain, and the body holds maxBytes of the message. Drawing the
+// claim from more text than the body kept would let an entry be titled after a
+// sentence a reviewer cannot find anywhere in it.
+//
+// The trailing partial token is dropped whenever the cut actually bites, and
+// that is a REDACTION guarantee, not tidiness. noteText redacts BEFORE it caps,
+// precisely because redact.Secrets needs a whole token to recognise one — the
+// GitHub rule wants 20+ suffix characters, the JWT rule three segments — so a
+// half-cut secret is one it no longer matches, and the surviving prefix would
+// ship verbatim into a title. Here the cut necessarily comes first (redacting
+// first is the cost this function exists to avoid), so the cut is made harmless
+// instead: a secret can only ever be severed AT the cut, and the severed piece
+// is exactly the last token. Dropping it means no fragment of a secret can reach
+// a claim, whatever maxBytes an operator configures — which a "maxBytes is much
+// larger than the claim budget" argument would NOT give, since config.Validate
+// rejects only a negative one.
+//
+// A message with no whitespace at all in its first maxBytes is one unbroken
+// token — a base64 blob, not a sentence — and yields no claim rather than a
+// possibly-severed one. The title then falls back to naming the finding.
+func noteClaimSource(text string, maxBytes int) string {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxNoteBytes
+	}
+	if len(text) <= maxBytes {
+		return text
+	}
+	cut := cutToRuneBoundary(text, maxBytes)
+	i := strings.LastIndexFunc(cut, unicode.IsSpace)
+	if i < 0 {
+		return ""
+	}
+	return cut[:i]
 }
 
 // conceptDescription renders the entry's one-line description.
@@ -477,7 +539,8 @@ func noteClaim(text string, maxBytes int) string {
 //
 // Every part is bounded on its own rather than the whole line truncated at the
 // end, so the provenance clause can never be the part that gets cut.
-func conceptDescription(tc Context, n Note) string {
+// claim is the note's own words, already bounded and defused by noteClaim.
+func conceptDescription(tc Context, n Note, claim string) string {
 	who := truncateWords(noteLine(n.Author), maxNoteAuthor)
 	var b strings.Builder
 	if n.modelDrafted() {
@@ -488,7 +551,7 @@ func conceptDescription(tc Context, n Note) string {
 	if s := truncateWords(noteLine(tc.Title), maxNoteDescriptionContext); s != "" {
 		fmt.Fprintf(&b, ", on the finding %q", s)
 	}
-	if claim := noteClaim(n.Text, maxNoteDescriptionClaim); claim != "" {
+	if claim != "" {
 		fmt.Fprintf(&b, ": %s", claim)
 	} else {
 		b.WriteString(".")
@@ -502,11 +565,55 @@ func conceptDescription(tc Context, n Note) string {
 // spaces, then strings.Fields squeezes the runs they leave behind and trims the
 // ends.
 //
-// One function rather than two composed at each call site, because no caller
-// wants either half alone: a squeezed but unredacted field would put a secret in
-// an entry's title, which outlives the pull request it arrived on (see
-// ConceptEntry).
-func noteLine(s string) string { return strings.Join(strings.Fields(noteField(s)), " ") }
+// One function rather than three composed at each call site, because no caller
+// wants any part alone: a squeezed but unredacted field would put a secret in an
+// entry's title, which outlives the pull request it arrived on (see
+// ConceptEntry), and an undefused one is the hole below.
+//
+// The defusal is what makes this safe to put in FRONTMATTER, and it is the half
+// noteField does not do. A title and a description are not read only out of the
+// YAML: okf.UpdateIndex interpolates both into index.md as `- [%s](%s) — %s`,
+// okf.UpdateLog interpolates the title into log.md, and github.prBody puts the
+// description in the pull-request body — three markdown renderers, none of which
+// defuses anything (prBody applies the image regex alone, and that copy still
+// carries the raw-HTML gap its own comment admits). All three write a PERMANENT,
+// merged repository file.
+//
+// Two concrete failures, both measured before this was added: a note reading
+// `<img src="https://evil.example/px.gif">` put a live tracking pixel into
+// index.md and log.md, firing from every reader's browser; and a note reading
+// `boom](evil)` produced `- [Operator note: boom](evil) ## Incidents](path.md)`,
+// so the index's own link FOR THAT ENTRY pointed at the attacker's URL.
+//
+// It runs BEFORE every caller's truncation, not after, because the defusals
+// EXPAND — up to 3x for neutralizeImages, 2.5x for neutralizeHTML — and each
+// caller then bounds the result to a budget it states. Defusing afterwards would
+// make every one of those budgets a lie by the same factor: maxNoteAuthor and
+// maxNoteDescriptionContext are applied here and never re-cut, and the
+// finding-fallback title in noteEntryTitle is capped once at maxNoteTitle, which
+// is what keeps it inside the merge gate's 120 bytes.
+//
+// The note's own claim is the one field that would survive the wrong order, and
+// only by accident: noteClaim bounds it and noteEntryTitle re-cuts it, so the
+// title comes out short either way while the DESCRIPTION carries the whole
+// expansion. Ordering it here means no field depends on that accident.
+//
+// A cut landing inside an escape ("&lt;" cut to "&l") is cosmetic and cannot
+// re-expose markup: neither defusal's output contains a "<" or a "![" for a
+// later cut to uncover.
+//
+// escapeOKFSections is deliberately NOT applied. It defuses ATX headings, which
+// are a BODY concern: a heading has to start a line, and this is a single line
+// interpolated mid-line into every one of those sinks. Frontmatter is never
+// parsed for OKF sections at all.
+func noteLine(s string) string {
+	return defuseMarkup(strings.Join(strings.Fields(noteField(s)), " "))
+}
+
+// defuseMarkup neutralises the two markup shapes an identity field can smuggle
+// into a renderer: image syntax and raw HTML. It is the pair noteText applies to
+// the note BODY, minus the heading escape — see noteLine for why.
+func defuseMarkup(s string) string { return neutralizeImages(neutralizeHTML(s)) }
 
 // leadingMarkupMarkers are the one-character Markdown markers a chat reply
 // opens a line with. Only a marker followed by a SPACE counts, so "-1 replica"
@@ -523,6 +630,12 @@ const leadingMarkupMarkers = ">-*+"
 // Bounded rather than looped to a fixed point: nesting deeper than a few levels
 // is not something a chat reply does, and a bound is one less way for untrusted
 // text to control how long this runs.
+//
+// So it strips up to four levels, not all of them: "- - - - - - - - the cause"
+// keeps the markers the bound did not reach. That is the deliberate trade and
+// not a case worth chasing — the cost is a slightly uglier title on input nobody
+// writes by accident, while the alternative hands an unbounded loop to text
+// anyone in the channel can send.
 func stripLeadingMarkup(s string) string {
 	s = strings.TrimSpace(s)
 	for range 4 {
@@ -735,8 +848,19 @@ func singleLine(s string) string {
 // is the honest cut. Trailing punctuation left dangling by the cut is dropped so
 // the mark reads as a continuation, not as a comma followed by an ellipsis.
 //
-// Like truncate, the result can exceed n by the ellipsis' 2 extra bytes.
+// Like truncate, the result can exceed n by the ellipsis' 2 extra bytes — but
+// only for a positive n. A budget of zero or less leaves no room even for the
+// mark, so it yields "" rather than a bare "…" that would break the bound this
+// comment states; unlike truncate, which panics outright at n == 0.
+//
+// It assumes valid UTF-8, which every call site guarantees by piping through
+// noteLine (strings.Map replaces each invalid byte with U+FFFD). Called directly
+// on invalid UTF-8 it can emit invalid UTF-8: cutToRuneBoundary walks back over
+// continuation bytes, and a lone continuation byte is not one.
 func truncateWords(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
 	if len(s) <= n {
 		return s
 	}

--- a/internal/thread/note_sinks_test.go
+++ b/internal/thread/note_sinks_test.go
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is package thread_test, not package thread, on purpose: it reaches
+// into internal/okf to exercise the REAL sinks an entry's identity fields flow
+// into, and internal/thread's own dependency set is deliberately narrow (see the
+// note on noteForgeLabel). An external test package keeps that promise intact —
+// its imports are the test binary's, not the package's.
+package thread_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
+)
+
+var sinkAt = time.Date(2026, 8, 14, 10, 30, 0, 0, time.UTC)
+
+// noteEntry builds the entry a thread note files, for a note the attacker wrote.
+func noteEntry(t *testing.T, note string) providers.KBEntry {
+	t.Helper()
+	return thread.ConceptEntry(
+		thread.Context{Transport: "slack", Title: "OOM in payments"},
+		thread.HumanNote("alice", note),
+		sinkAt, thread.DefaultMaxNoteBytes,
+	)
+}
+
+// TestNoteIdentityFieldsAreDefusedInEveryBundleSink is the test whose absence
+// made this invisible: everything pinned the entry's own fields, and nothing
+// pinned what the FORGE then writes with them.
+//
+// An entry's title and description are not read only out of its YAML. Both are
+// interpolated raw into index.md by okf.UpdateIndex ("- [%s](%s) — %s"), the
+// title into log.md by okf.UpdateLog, and the description into the pull-request
+// body by github.prBody — permanent, merged, markdown-rendered repository files.
+// Since the note-identity fix, both fields are arbitrary chat text from any
+// channel member, where before this the description was a fixed sentence and the
+// title was alert-derived.
+func TestNoteIdentityFieldsAreDefusedInEveryBundleSink(t *testing.T) {
+	const pixel = `<img src="https://evil.example/px.gif">`
+	const image = `![x](https://evil.example/y.png)`
+
+	tests := []struct {
+		name string
+		note string
+		// banned must not appear in ANY rendered sink: each is live markup.
+		banned []string
+		// kept must survive somewhere: neutralise, never censor — a reviewer has
+		// to be able to read exactly what was submitted.
+		kept string
+		// escaped is the defused spelling of the markup character itself. It is
+		// what separates ESCAPING from STRIPPING: deleting "<img" also removes the
+		// live markup and also leaves the URL behind, so `kept` alone cannot tell
+		// the two apart, and a censoring implementation would pass.
+		escaped string
+	}{
+		{
+			name:    "raw HTML is a tracking pixel firing from every reader's browser",
+			note:    "the cause was " + pixel,
+			banned:  []string{pixel, "<img"},
+			kept:    "evil.example/px.gif",
+			escaped: "&lt;img",
+		},
+		{
+			name:    "image markdown is the same pixel by another syntax",
+			note:    "the cause was " + image,
+			banned:  []string{image, "!["},
+			kept:    "evil.example/y.png",
+			escaped: "!&#91;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := noteEntry(t, tt.note)
+			sinks := map[string]string{
+				"entry title":       e.Title,
+				"entry description": e.Description,
+				"index.md":          string(okf.UpdateIndex([]byte("# Index\n\n## Concepts\n"), e, "concepts/n.md")),
+				"log.md":            string(okf.UpdateLog(nil, e, "concepts/n.md", "2026-08-14")),
+			}
+			for where, got := range sinks {
+				for _, b := range tt.banned {
+					if strings.Contains(got, b) {
+						t.Errorf("%s renders live markup %q:\n%s", where, b, got)
+					}
+				}
+			}
+			if !strings.Contains(e.Description, tt.kept) {
+				t.Errorf("the submitted text must survive as inert text, not be censored: %q", e.Description)
+			}
+			if !strings.Contains(e.Description, tt.escaped) {
+				t.Errorf("the markup character must be ESCAPED (%q), not deleted — a reviewer has to see exactly what was submitted: %q",
+					tt.escaped, e.Description)
+			}
+		})
+	}
+}
+
+// TestNoteTitleCannotHijackTheBundleLink covers the third vector, which the
+// image/HTML defusal above does NOT close and must not be assumed to: a bare "]"
+// is not markup either function knows about.
+//
+// A title of `boom](https://evil.example) x` rendered as
+// `- [boom](https://evil.example) x](concepts/n.md) — …`, so the index's own
+// link FOR THAT ENTRY pointed at the attacker's URL while still looking like the
+// entry's row. The fix is in okf, where the "a title is a link label" assumption
+// is made — see okf.linkText for why there rather than here.
+//
+// This asserts the rendered SINKS, not the entry's fields: "](" is ordinary text
+// in a YAML title and defusing it there would put escapes in the catalog for a
+// rendering concern that belongs to the renderer.
+func TestNoteTitleCannotHijackTheBundleLink(t *testing.T) {
+	for _, note := range []string{
+		"boom](https://evil.example) more",
+		// A backslash before the bracket is the second half of the escape, and
+		// the reason linkText escapes "\" too. Escaping only the brackets turns
+		// `\]` into `\\]` — an escaped BACKSLASH followed by a live bracket — so
+		// the label closes anyway and the hijack works through the fix.
+		`boom\](https://evil.example) more`,
+		`boom\\](https://evil.example) more`,
+	} {
+		t.Run(note, func(t *testing.T) {
+			e := noteEntry(t, note)
+			for name, doc := range map[string]string{
+				"index.md": string(okf.UpdateIndex([]byte("# Index\n\n## Concepts\n"), e, "concepts/n.md")),
+				"log.md":   string(okf.UpdateLog(nil, e, "concepts/n.md", "2026-08-14")),
+			} {
+				line := ""
+				for _, l := range strings.Split(doc, "\n") {
+					if strings.Contains(l, "concepts/n.md") {
+						line = l
+					}
+				}
+				if line == "" {
+					t.Fatalf("%s has no line for the entry:\n%s", name, doc)
+				}
+				// The property is where the line's FIRST link points: that link is
+				// the entry's own, and the hijack works by ending its label early so
+				// the target becomes the attacker's URL instead of the entry's path.
+				if target := firstLinkTarget(line); target != "concepts/n.md" {
+					t.Errorf("%s: the entry's own link points at %q, want %q: %q", name, target, "concepts/n.md", line)
+				}
+				// Neutralise, never censor: the reviewer still reads what was sent.
+				if !strings.Contains(line, "evil.example") {
+					t.Errorf("%s dropped the submitted text instead of escaping it: %q", name, line)
+				}
+				// And the bracket itself survives, backslash-escaped. Deleting the
+				// brackets would also stop the hijack and also keep the URL, so the
+				// check above cannot tell escaping from stripping on its own.
+				if !strings.Contains(line, `\]`) {
+					t.Errorf("%s stripped the title's bracket instead of escaping it, so the index no longer says what the entry is called: %q", name, line)
+				}
+			}
+		})
+	}
+}
+
+// TestNoteIdentityFieldBudgetsSurviveTheDefusal pins the ORDER the defusal runs
+// in, which is invisible to a test that only checks the markup is gone.
+//
+// neutralizeImages expands "![" 3x and neutralizeHTML "<x" 2.5x. noteLine defuses
+// BEFORE each caller truncates, so every stated budget bounds the expanded text.
+// Defusing afterwards would inflate each field by that factor while every test
+// asserting "no live markup" still passed — the description worst of all, since
+// nothing downstream re-cuts it.
+func TestNoteIdentityFieldBudgetsSurviveTheDefusal(t *testing.T) {
+	hostile := strings.Repeat("![a](b) ", 200)
+	e := thread.ConceptEntry(
+		thread.Context{Transport: "slack", Title: strings.Repeat("<img x> ", 100)},
+		thread.HumanNote(strings.Repeat("<b>", 40), hostile),
+		sinkAt, thread.DefaultMaxNoteBytes,
+	)
+	// maxNoteDescriptionClaim(200) + Context(120) + author(40) + fixed framing,
+	// each +2 for its ellipsis. Comfortably under 500 when the order is right;
+	// 2.5-3x over it when it is not.
+	if len(e.Description) > 500 {
+		t.Errorf("Description is %d bytes, past the sum of its stated part budgets: %q", len(e.Description), e.Description)
+	}
+	// The finding-fallback title is capped exactly once, so its budget is the one
+	// standing between an expansion and the merge gate's 120-byte limit.
+	fallback := thread.ConceptEntry(
+		thread.Context{Transport: "slack", Title: strings.Repeat("<img x> ", 100)},
+		thread.HumanNote("alice", "- "), // no words: falls back to naming the finding
+		sinkAt, thread.DefaultMaxNoteBytes,
+	)
+	if len(fallback.Title) > 120 {
+		t.Errorf("fallback Title is %d bytes, over kbvalidate's 120-byte limit: %q", len(fallback.Title), fallback.Title)
+	}
+}
+
+// TestNoteIdentityFieldsStayInsideTheMergeGateWhenDefused pins the ordering the
+// defusal depends on. neutralizeImages expands "![" 3x and neutralizeHTML "<x"
+// 2.5x, so defusing AFTER the cut would push a title past the 120-byte limit
+// kbvalidate enforces — the entry would then fail the very gate the rest of this
+// work exists to clear. Defusing first means the cut bounds the expanded text.
+func TestNoteIdentityFieldsStayInsideTheMergeGateWhenDefused(t *testing.T) {
+	// A note that is nothing but image markup: the worst case for expansion.
+	e := noteEntry(t, strings.Repeat("![a](b) ", 200))
+	if len(e.Title) > 120 {
+		t.Errorf("Title is %d bytes, over kbvalidate's 120-byte limit: %q", len(e.Title), e.Title)
+	}
+	if strings.Contains(e.Title, "![") {
+		t.Errorf("Title still carries live image markup: %q", e.Title)
+	}
+}
+
+// firstLinkTarget returns the target of the first markdown link in line, or ""
+// when there is none. It honours backslash escapes, which is the whole point:
+// `\]` is a literal bracket and does NOT end the label, so a test that merely
+// counted "](" would call the escaped, harmless form a hijack.
+func firstLinkTarget(line string) string {
+	open := strings.IndexByte(line, '[')
+	if open < 0 {
+		return ""
+	}
+	for i := open + 1; i < len(line); i++ {
+		if line[i] == '\\' { // escaped character: skip what it escapes
+			i++
+			continue
+		}
+		if line[i] != ']' {
+			continue
+		}
+		rest := line[i+1:]
+		if !strings.HasPrefix(rest, "(") {
+			return "" // a label that closes but opens no target is not a link
+		}
+		end := strings.IndexByte(rest, ')')
+		if end < 0 {
+			return ""
+		}
+		return rest[1:end]
+	}
+	return ""
+}

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -883,7 +883,13 @@ func TestConceptEntryIsTitledAfterTheNoteNotTheFinding(t *testing.T) {
 	}
 	// The finding's own distinctive words must not be the entry's identity. They
 	// are still carried as CONTEXT, in the description and the body.
-	if strings.Contains(e.Title, "OutOfSync") {
+	//
+	// "Core Argo CD" comes from the START of the finding title, deliberately, not
+	// "OutOfSync" from its end: the old code cut the title at 90 bytes and lost
+	// "OutOfSync" anyway, so a guard naming the tail passes against the very code
+	// this test exists to reject. Only a word the broken title really carried
+	// discriminates between fixed and unfixed.
+	if strings.Contains(e.Title, "Core Argo CD") {
 		t.Errorf("the title is still the finding's headline, which is what the note contradicts: %q", e.Title)
 	}
 	if !strings.Contains(e.Description, "OutOfSync") || !strings.Contains(e.Body, "OutOfSync") {
@@ -1054,5 +1060,94 @@ func TestTruncateWordsCutsOnAWordBoundary(t *testing.T) {
 				t.Errorf("truncateWords(%q, %d) = %q is %d bytes, over the documented n+2 worst case", tt.s, tt.n, got, len(got))
 			}
 		})
+	}
+}
+
+// TestNoteClaimIsDrawnOnlyFromTheTextTheBodyFiles pins the bound on the claim's
+// INPUT. Nothing upstream caps Note.Text — DefaultMaxNoteBytes is applied inside
+// NoteBody, downstream of the claim — while a Matrix event carries up to 64 KiB
+// and a Slack body up to 1 MiB.
+//
+// The assertion is the COHERENCE one rather than a timing one, because it is the
+// property a reader can check: an entry must never be titled after words its own
+// body does not contain.
+func TestNoteClaimIsDrawnOnlyFromTheTextTheBodyFiles(t *testing.T) {
+	// The cap must be SMALLER than maxNoteDescriptionClaim, or the fixture proves
+	// nothing: with a cap of 300 the claim's own 200-byte budget stops short of
+	// the sentinel anyway, and an entirely unbounded claim passes the test.
+	const maxBytes = 60
+	if maxBytes >= maxNoteDescriptionClaim {
+		t.Fatalf("fixture is inert: a cap of %d is past the claim's own %d-byte budget", maxBytes, maxNoteDescriptionClaim)
+	}
+	// "beyond" sits past the cap but well inside the claim's budget.
+	note := "opening words " + strings.Repeat("x ", 30) + "beyond-the-cap-sentinel"
+	if len(note) <= maxBytes {
+		t.Fatalf("fixture is inert: the note is %d bytes, inside the %d-byte cap", len(note), maxBytes)
+	}
+	e := ConceptEntry(Context{Title: "OOM"}, HumanNote("alice", note), noteAt, maxBytes)
+
+	for name, field := range map[string]string{"title": e.Title, "description": e.Description, "body": e.Body} {
+		if strings.Contains(field, "beyond-the-cap-sentinel") {
+			t.Errorf("%s quotes text from past the note cap, which the body never filed: %q", name, field)
+		}
+	}
+	if !strings.Contains(e.Title, "opening words") {
+		t.Errorf("the claim must still come from the start of the note: %q", e.Title)
+	}
+}
+
+// TestNoteClaimCannotLeakASecretSeveredByItsOwnCut is the redaction half of that
+// bound, and the reason noteClaimSource drops the trailing partial token.
+//
+// noteText redacts BEFORE it caps, because redact.Secrets needs a whole token to
+// match one. The claim path cuts FIRST (redacting a 1 MiB message is the cost the
+// cut exists to avoid), so a secret straddling the cut would be handed to
+// redaction already severed — unrecognised, and its surviving prefix would ship
+// verbatim into a title that outlives the pull request.
+//
+// The cap here is small on purpose. It makes the cut land inside the secret with
+// the claim budget still spanning it, which is exactly the case a "maxBytes is
+// far larger than the claim" argument would wave away — config.Validate rejects
+// only a NEGATIVE max_note_bytes, so nothing stops an operator configuring this.
+func TestNoteClaimCannotLeakASecretSeveredByItsOwnCut(t *testing.T) {
+	const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"
+	const maxBytes = 120
+	// Pad so the cut falls 12 bytes into the secret, leaving a long prefix.
+	lead := "note " + strings.Repeat(" ", maxBytes-12-len("note "))
+	note := lead + secret
+	severed := secret[:12]
+
+	if len(lead) >= maxBytes || len(note) <= maxBytes {
+		t.Fatalf("fixture is inert: the cut at %d does not fall inside the secret (lead=%d, note=%d)", maxBytes, len(lead), len(note))
+	}
+	e := ConceptEntry(Context{Title: "OOM"}, HumanNote("alice", note), noteAt, maxBytes)
+
+	for name, field := range map[string]string{"title": e.Title, "description": e.Description} {
+		if strings.Contains(field, severed) {
+			t.Errorf("%s carries %q, a fragment of a secret that the claim's own cut severed past recognition: %q", name, severed, field)
+		}
+	}
+}
+
+// TestNoteClaimYieldsNothingForOneUnbrokenToken covers what dropping the partial
+// token costs: a message with no whitespace at all inside the cap is one token —
+// a base64 blob, not a sentence — and there is no safe piece of it to keep.
+func TestNoteClaimYieldsNothingForOneUnbrokenToken(t *testing.T) {
+	e := ConceptEntry(Context{Title: "OOM in payments"}, HumanNote("alice", strings.Repeat("a", 500)), noteAt, 100)
+	if want := "Operator note on OOM in payments"; e.Title != want {
+		t.Errorf("Title = %q, want the finding fallback %q", e.Title, want)
+	}
+}
+
+// TestTruncateWordsHoldsItsBoundAtAZeroBudget pins the edge its doc comment
+// states. It used to return a bare "…" — 3 bytes for a 0-byte budget, breaking
+// the "n+2 worst case" the comment promises. Unreachable today (every budget is
+// a positive constant), which is exactly why it needs a test rather than a
+// reader's attention.
+func TestTruncateWordsHoldsItsBoundAtAZeroBudget(t *testing.T) {
+	for _, n := range []int{0, -1, -100} {
+		if got := truncateWords("the cause was a spot reclaim", n); got != "" {
+			t.Errorf("truncateWords(_, %d) = %q, want %q", n, got, "")
+		}
 	}
 }

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -396,6 +396,10 @@ func TestConceptEntryPassesTheMergeGate(t *testing.T) {
 		// carrying an embedded newline must still clear the merge gate: nothing
 		// upstream of ConceptEntry guarantees a single-line title.
 		{"title with embedded newline", Context{Title: "ImageGalleryUnavailable\r\nX-Injected: header"}},
+		// #491: every fixture above names ONE resource, which is exactly why this
+		// table stayed green while a live multi-object finding produced a note PR
+		// that could never be merged.
+		{"multi-object resource", multiObjectContext()},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -808,5 +812,247 @@ func TestBlockquoteCoversEveryLine(t *testing.T) {
 	// line terminates a Markdown blockquote, so everything after it escapes.
 	if !strings.Contains(got, "> \n") && !strings.Contains(got, ">\n") {
 		t.Errorf("the blank line inside the quoted message was left unquoted, which ends the blockquote early:\n%s", got)
+	}
+}
+
+// The live #491/#492 fixture, kept in one place so both bugs are pinned against
+// the SAME thread context they were reported from: a finding covering three Argo
+// CD Applications, whose title runs past the entry-title budget and whose
+// resource carries the model's own comma-and-space list.
+const (
+	multiObjectFinding  = "Core Argo CD Applications (essentials, monitoring, argocd-app-of-apps) stuck OutOfSync"
+	multiObjectResource = "argocd/essentials, monitoring, argocd-app-of-apps"
+)
+
+// multiObjectContext is that finding as thread capture sees it.
+func multiObjectContext() Context {
+	return Context{Transport: "slack", Title: multiObjectFinding, Resource: multiObjectResource, TriggerKey: "tk-1"}
+}
+
+// TestConceptEntryResourceClearsTheMergeGateForAMultiObjectFinding closes #491.
+//
+// tc.Resource is the finding's rendered ref, and Workload.Name on a finding is
+// model-written free text: a finding covering several objects arrives as a list,
+// so the ref carries ", " and kbvalidate rejects a `resource` containing
+// whitespace. The write path was emitting a value its own merge gate rejects —
+// the note PR could never be merged, while the thread reply said the write
+// succeeded and the channel announcement fired, because both are 1:1 with the
+// landed forge write, which did land.
+//
+// The full list is not lost: it still reaches the entry body verbatim, which is
+// what makes narrowing the frontmatter safe rather than lossy.
+func TestConceptEntryResourceClearsTheMergeGateForAMultiObjectFinding(t *testing.T) {
+	e := ConceptEntry(multiObjectContext(), HumanNote("alice", "the poisoned chart cache theory is wrong"), noteAt, DefaultMaxNoteBytes)
+
+	// Positive control: the raw ref really does fail the gate, so this test
+	// cannot pass by accident on a fixture the gate never objected to.
+	raw := kbvalidate.ValidateStructural(catalog.Entry{
+		Type: e.Type, Title: e.Title, Description: e.Description,
+		Resource: multiObjectResource, Tags: e.Tags, Body: e.Body,
+	})
+	if !kbvalidate.HasErrors(raw) {
+		t.Fatalf("fixture is inert: %q already clears the merge gate, so this test pins nothing", multiObjectResource)
+	}
+
+	if e.Resource != "argocd/essentials" {
+		t.Errorf("Resource = %q, want %q", e.Resource, "argocd/essentials")
+	}
+	for _, is := range kbvalidate.ValidateStructural(catalog.Entry{
+		Type: e.Type, Title: e.Title, Description: e.Description,
+		Resource: e.Resource, Tags: e.Tags, Body: e.Body,
+	}) {
+		if is.Severity == kbvalidate.SeverityError {
+			t.Errorf("the entry the note path writes fails its own merge gate: %s: %s", is.Field, is.Message)
+		}
+	}
+	if !strings.Contains(e.Body, multiObjectResource) {
+		t.Errorf("the body must still carry every object the finding named, verbatim:\n%s", e.Body)
+	}
+}
+
+// TestConceptEntryIsTitledAfterTheNoteNotTheFinding closes the first half of
+// #492. A note that CORRECTS a finding was filed under the headline of the very
+// thing it corrects, so the entry claimed the opposite of what the human wrote —
+// and the reranker matched it while quoting the refuted hypothesis as its
+// grounds.
+func TestConceptEntryIsTitledAfterTheNoteNotTheFinding(t *testing.T) {
+	e := ConceptEntry(multiObjectContext(), HumanNote("alice", "the poisoned chart cache theory is wrong"), noteAt, DefaultMaxNoteBytes)
+
+	if want := "Operator note: the poisoned chart cache theory is wrong"; e.Title != want {
+		t.Errorf("Title = %q, want %q", e.Title, want)
+	}
+	// The finding's own distinctive words must not be the entry's identity. They
+	// are still carried as CONTEXT, in the description and the body.
+	if strings.Contains(e.Title, "OutOfSync") {
+		t.Errorf("the title is still the finding's headline, which is what the note contradicts: %q", e.Title)
+	}
+	if !strings.Contains(e.Description, "OutOfSync") || !strings.Contains(e.Body, "OutOfSync") {
+		t.Errorf("the finding must survive as context in the description and body:\ndescription=%q\nbody=%s", e.Description, e.Body)
+	}
+}
+
+// TestConceptEntryTitleNeverCutsMidWord closes the second half of #492. Instant
+// recall builds its whole root-cause claim as `title + " — " + description`
+// (investigate.recalledInvestigation) and a Concept note carries no
+// Cause/Resolution sections to add to it, so a title ending "… stu…" is the
+// entire claim verify is asked to judge — and verify correctly rejected it as
+// unintelligible every time, which is why a corrected entry never survived to
+// short-circuit an investigation.
+func TestConceptEntryTitleNeverCutsMidWord(t *testing.T) {
+	const note = "the poisoned Helm chart cache theory is wrong: syncPolicy.automated was removed from the system ApplicationSet by a manual edit in the UI"
+	e := ConceptEntry(multiObjectContext(), HumanNote("alice", note), noteAt, DefaultMaxNoteBytes)
+
+	// Positive control: this note MUST be long enough to force a cut, otherwise
+	// the assertion below is vacuous.
+	if !strings.HasSuffix(e.Title, "…") {
+		t.Fatalf("fixture is inert: %q was not truncated, so no word boundary was under test", e.Title)
+	}
+	kept := strings.TrimSuffix(e.Title, "…")
+	body := strings.TrimPrefix(kept, "Operator note: ")
+	if body == kept {
+		t.Fatalf("Title = %q, want it to start with %q", e.Title, "Operator note: ")
+	}
+	// The kept text must end where a word ends in the source: either at the end
+	// of the note, or immediately before a space.
+	if note != body && !strings.HasPrefix(note, body+" ") {
+		t.Errorf("Title = %q cuts mid-word — %q is not a whole-word prefix of the note", e.Title, body)
+	}
+	if len(e.Title) > 120 {
+		t.Errorf("Title is %d bytes, over the merge gate's 120-byte limit: %q", len(e.Title), e.Title)
+	}
+}
+
+// TestConceptEntryDescriptionCarriesTheNote closes the third part of #492: the
+// description was a fixed sentence naming only the author and the transport,
+// BYTE-IDENTICAL across every operator note, on a field with three consumers
+// that all read it as content — instant recall's claim, the reranker's candidate
+// line, and the catalog's lexical search text.
+func TestConceptEntryDescriptionCarriesTheNote(t *testing.T) {
+	tc := multiObjectContext()
+	first := ConceptEntry(tc, HumanNote("alice", "the poisoned chart cache theory is wrong"), noteAt, DefaultMaxNoteBytes)
+	second := ConceptEntry(tc, HumanNote("alice", "the ApplicationSet lost syncPolicy.automated"), noteAt, DefaultMaxNoteBytes)
+
+	if first.Description == second.Description {
+		t.Errorf("two different notes on the same finding produced a byte-identical description, which carries no signal at all: %q", first.Description)
+	}
+	if !strings.Contains(first.Description, "the poisoned chart cache theory is wrong") {
+		t.Errorf("the description must carry the note's own claim: %q", first.Description)
+	}
+	if !strings.Contains(first.Description, "alice") || !strings.Contains(first.Description, "slack") {
+		t.Errorf("the description must keep the provenance a catalog listing shows: %q", first.Description)
+	}
+	// The provenance clause leads, so a listing that clips the line cannot clip
+	// the fact that a human, not RunLore's model, wrote the text.
+	drafted := ConceptEntry(tc, ProposedNote("alice", "was it the chart cache?", "the poisoned chart cache theory is wrong"), noteAt, DefaultMaxNoteBytes)
+	if !strings.HasPrefix(drafted.Description, "Note drafted by RunLore") {
+		t.Errorf("a model-drafted note must say so before anything else: %q", drafted.Description)
+	}
+	if strings.HasPrefix(first.Description, "Note drafted by RunLore") {
+		t.Errorf("a human's own words were described as RunLore's draft: %q", first.Description)
+	}
+}
+
+// TestConceptEntryRecallClaimIsIntelligible pins the assembled string that
+// actually failed in production. instant recall builds one root-cause summary as
+// `Title + " — " + Description` (investigate/recall.go, recalledInvestigation)
+// and hands it to verify, which sees nothing else: a Concept note has no
+// Cause/Resolution sections, by construction — escapeOKFSections exists to stop
+// a note forging them. Neither field is wrong on its own; the defect was only
+// visible in the pair, which is why this reads both at once.
+func TestConceptEntryRecallClaimIsIntelligible(t *testing.T) {
+	const note = "the poisoned chart cache theory is wrong: a manual UI edit removed syncPolicy.automated"
+	e := ConceptEntry(multiObjectContext(), HumanNote("alice", note), noteAt, DefaultMaxNoteBytes)
+	claim := e.Title + " — " + e.Description
+
+	if !strings.Contains(claim, note) {
+		t.Errorf("the claim verify is handed does not contain the note it is supposed to state:\n%s", claim)
+	}
+	// The old failure shape, exactly: the finding's headline as the claim, cut
+	// mid-word. Both halves are asserted because either one alone made verify
+	// reject the entry.
+	if strings.Contains(claim, "stu…") {
+		t.Errorf("the claim still ends a word mid-way, which verify rejects as unintelligible:\n%s", claim)
+	}
+	if strings.HasPrefix(e.Title, "Operator note: Core Argo CD Applications") {
+		t.Errorf("the claim still leads with the finding the note refutes:\n%s", claim)
+	}
+}
+
+// TestNoteClaimStripsTheMarkupAChatReplyOpensWith keeps the title readable as a
+// claim: an on-call routinely writes a note as a bullet or a quote, and
+// "Operator note: - the cause was …" reads as neither.
+func TestNoteClaimStripsTheMarkupAChatReplyOpensWith(t *testing.T) {
+	tests := []struct {
+		name string
+		note string
+		want string
+	}{
+		{"bullet", "- the cause was a spot reclaim", "Operator note: the cause was a spot reclaim"},
+		{"blockquote", "> the cause was a spot reclaim", "Operator note: the cause was a spot reclaim"},
+		{"heading", "## the cause was a spot reclaim", "Operator note: the cause was a spot reclaim"},
+		{"nested", "> - the cause was a spot reclaim", "Operator note: the cause was a spot reclaim"},
+		{"a negative number keeps its sign", "-1 replicas is the cause", "Operator note: -1 replicas is the cause"},
+		{"a hashtag is not a heading", "#oncall the cause was a spot reclaim", "Operator note: #oncall the cause was a spot reclaim"},
+		{"line breaks collapse to one space", "the cause\n\nwas a spot reclaim", "Operator note: the cause was a spot reclaim"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConceptEntry(Context{Title: "OOM"}, HumanNote("alice", tt.note), noteAt, DefaultMaxNoteBytes).Title; got != tt.want {
+				t.Errorf("Title = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConceptEntryFallsBackToTheFindingWhenTheNoteHasNoWords covers the note
+// that is nothing but markup. Responder.Handle answers an empty "note:" without
+// writing, so this is reachable only defensively — but ConceptEntry must be
+// total, and naming the finding still beats an unqualified "Operator note".
+// "on" reads as ABOUT the finding rather than as a claim the note makes.
+func TestConceptEntryFallsBackToTheFindingWhenTheNoteHasNoWords(t *testing.T) {
+	e := ConceptEntry(Context{Title: "OOM in payments"}, HumanNote("alice", "- "), noteAt, DefaultMaxNoteBytes)
+	if want := "Operator note on OOM in payments"; e.Title != want {
+		t.Errorf("Title = %q, want %q", e.Title, want)
+	}
+	bare := ConceptEntry(Context{}, HumanNote("alice", " "), noteAt, DefaultMaxNoteBytes)
+	if bare.Title != "Operator note" {
+		t.Errorf("Title = %q, want %q", bare.Title, "Operator note")
+	}
+	if strings.TrimSpace(bare.Description) == "" {
+		t.Error("description is required by the merge gate and must never render empty")
+	}
+}
+
+// TestTruncateWordsCutsOnAWordBoundary pins the truncator directly, including
+// the case where there is no boundary to cut on: one unbroken token longer than
+// the budget (a URL, a hash) has none, and backing off to an early space would
+// throw away nearly everything the field had room for.
+func TestTruncateWordsCutsOnAWordBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		n    int
+		want string
+	}{
+		{"short enough is untouched", "the cause was a spot reclaim", 90, "the cause was a spot reclaim"},
+		{"cuts back to the last whole word", "the cause was a spot reclaim on a node", 20, "the cause was a…"},
+		{"trailing punctuation left by the cut is dropped", "the cause, the effect, the fix", 13, "the cause…"},
+		{"one unbroken token has no boundary, so the rune cut stands", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 10, "aaaaaaaaa…"},
+		{"an early space is not worth backing off to", "a bbbbbbbbbbbbbbbbbbbbbbbbbbbb", 10, "a bbbbbbb…"},
+		{"never splits a multibyte rune", "éééééééééééé", 9, "éééé…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateWords(tt.s, tt.n)
+			if got != tt.want {
+				t.Errorf("truncateWords(%q, %d) = %q, want %q", tt.s, tt.n, got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("truncateWords(%q, %d) = %q — split a rune", tt.s, tt.n, got)
+			}
+			if len(got) > tt.n+2 {
+				t.Errorf("truncateWords(%q, %d) = %q is %d bytes, over the documented n+2 worst case", tt.s, tt.n, got, len(got))
+			}
+		})
 	}
 }

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -2464,8 +2464,10 @@ func TestReplyQuotesTheRecordedNote(t *testing.T) {
 		if len(f.opened) != 1 {
 			t.Fatalf("opened = %d, want 1", len(f.opened))
 		}
+		// The entry is named after the NOTE, not after the finding the thread was
+		// about ("OOM in payments") — see noteEntryTitle.
 		want := "📝 Opened knowledge-base PR #99 with your note — «https://github.com/o/r/pull/99»\n" +
-			"Entry: «Operator note: OOM in payments»\n" +
+			"Entry: «Operator note: stale since Karpenter»\n" +
 			"> «stale since Karpenter»"
 		if got := RenderReply(reply, visibleEscape); got != want {
 			t.Errorf("rendered reply =\n%q\nwant\n%q", got, want)
@@ -2779,7 +2781,7 @@ func TestReplyQuotesTheModelDraftAsModelDrafted(t *testing.T) {
 // the "Entry:" line second, so the message read
 //
 //	Drafted by RunLore from your message — not your own words, pending review:
-//	Entry: Operator note: OOM in payments
+//	Entry: Operator note: the real cause was a spot-node reclaim
 //	> the real cause was a spot-node reclaim
 //
 // — a colon promising a quote, answered by a title. Two colons in a row, the
@@ -2933,7 +2935,7 @@ func TestOpenPRStatusLineNamesWhoseNoteItOpenedWith(t *testing.T) {
 		// why that order moved.
 		want := "> «Noted — that changes the root cause.»\n" +
 			"📝 Opened knowledge-base PR #99 with a note drafted from your message — «https://github.com/o/r/pull/99»\n" +
-			"Entry: «Operator note: OOM in payments»\n" +
+			"Entry: «Operator note: The real cause was a spot-node reclaim, not the CNI.»\n" +
 			"Drafted by RunLore from your message — not your own words, pending review:\n" +
 			"> «The real cause was a spot-node reclaim, not the CNI.»"
 		if got := RenderReply(reply, visibleEscape); got != want {


### PR DESCRIPTION
Closes #491. Closes #492.

Two reports, one defect stated twice: **a knowledge-base entry written from a chat thread derived its identity from the finding instead of from the note.**

## #491 — the write path emitted a value its own merge gate rejects

`resource:` came from the finding's `Workload.Ref()`. `Workload.Name` on a curated finding is **model-written free text** — `submit_findings` copies `affected_resource` verbatim — so a finding covering several objects arrives as `essentials, monitoring, argocd-app-of-apps` and renders as `argocd/essentials, monitoring, argocd-app-of-apps`. `kbvalidate` rejects any `resource` containing whitespace (`kbvalidate.go:154`), so `validate` fails and the PR can never merge.

On the thread path that is the worst available failure shape: the human is told the write succeeded and the announcement fires, because both are 1:1 with the **landed forge write** — which did land. Only the merge is impossible, and nothing surfaces it.

**Correction to the issue: the curator has the same bug.** It reads the same field through the same `Ref()` and does no string-munging anywhere. Its PR passed only because that investigation's model output happened to omit the spaces. There was no "shared better source" to copy — one was created (`providers.EntryResourceRef`) and both paths now use it.

It **narrows rather than drops**: `resource` is the structural-recall index, so an entry without one is reachable lexically only. Whitespace-free refs pass through unchanged, so no entry that merges today is written differently — and a comma-joined list with no spaces is deliberately left alone, since it already clears the gate and silently re-indexing merged entries is a bigger change than closing the defect.

## #492 — a note that corrects a finding was unverifiable by construction

`title:` was the finding's title, prefixed and truncated **mid-word** (`… argocd-app-of-apps) stu…`); `description:` was byte-identical boilerplate for every operator note.

**This is worse than the issue states.** `recalledInvestigation` builds the claim verify sees as `e.Title + " — " + e.Description` (`recall.go:737`), and `Prior` is empty for a note *by construction* — `escapeOKFSections` exists precisely to stop a note forging those sections. So those two fields are the **entire** claim. A note whose content is "the root cause is wrong", filed under the headline of the wrong root cause with a boilerplate description, is unintelligible to verify, which correctly rejects it. Instant recall — the cheap path that makes a corrected entry pay for itself — could never survive.

Now: the title is `Operator note: <the note's own claim>`, markup-stripped and truncated on a **word boundary**; the description leads with provenance (a clipped listing must not lose "RunLore drafted this"), then the finding as *context*, then the note's claim. Each part is bounded separately so the provenance clause can never be the part cut.

## Known, not fixed

- **The reranker's excerpt still leads with the finding.** It is `firstNonEmptyLines(body, 240)` (`rerank.go:233`), and a note body opens with the provenance header and a `Thread: <finding title>` line. The description fix changes what the reranker is *told*; body ordering is untouched. That is why the issue saw the reranker quoting the hypothesis the note refutes.
- **`truncate` panics for `n <= 0`** on a non-empty string (`cut = n-1 = -1`, then `s[:-1]`). Pre-existing, outside this change, and unreachable today since every caller passes a positive constant. Noted rather than fixed so it is not rediscovered as a mystery.

## Testing

13 mutations, all killed, including reverting each bug independently and pushing the title budget past the gate's own 120-byte limit. Positive controls were added to the new gate tests so an inert fixture fails loudly instead of passing.

Worth recording: one mutation **silently no-op'd** on first run — `gofmt` had realigned the struct field, so the string replace matched nothing and the test "passed". A killed-mutation-that-passes is itself a signal; it was caught, re-applied correctly, and every later mutation script asserts that its edit actually landed.

A follow-up commit folds two helpers the fix introduced: `collapseSpaces` was only ever called as `collapseSpaces(noteField(x))`, now `noteLine`, so "redact before you squeeze" is enforced by construction rather than by convention at four call sites — a squeezed-but-unredacted field would put a secret in an entry title, which outlives the PR it arrived on.

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`.
