### PR TITLE
fix(thread): every note in a thread reaches the entry, not only the first

### DIFF
--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -25,14 +25,17 @@ import (
 // (providers.ReinvestForge) need a client satisfying BOTH, so buildForge
 // returns one concrete type wired for whichever provider is configured.
 //
-// IsPROpen is included too (rather than left to a narrower cast at the thread
-// call site) because it is the same concrete client either way: serve.go hands
-// this exact value to thread.Responder, which needs it to refuse to comment on
-// a merged KB PR — see thread.Forge.
+// IsPROpen and AppendToEntryOnPR are included too (rather than left to a
+// narrower cast at the thread call site) because it is the same concrete client
+// either way: serve.go hands this exact value to thread.Responder, which needs
+// IsPROpen to refuse to write onto a merged KB PR and AppendToEntryOnPR to put
+// a thread's later notes INSIDE the entry its first note opened rather than
+// beside it — see thread.Forge.
 type forgeClient interface {
 	providers.CurationForge
 	providers.ReinvestForge
 	IsPROpen(ctx context.Context, number int) (bool, error)
+	AppendToEntryOnPR(ctx context.Context, number int, body string) error
 }
 
 // buildForge constructs the curation/reinvestigation forge client selected by

--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -35,7 +35,7 @@ type forgeClient interface {
 	providers.CurationForge
 	providers.ReinvestForge
 	IsPROpen(ctx context.Context, number int) (bool, error)
-	AppendToEntryOnPR(ctx context.Context, number int, body string) error
+	AppendToEntryOnPR(ctx context.Context, number int, body, key string) error
 }
 
 // buildForge constructs the curation/reinvestigation forge client selected by

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -205,7 +205,8 @@ func (fakeThreadForge) CommentOnPR(context.Context, int, string) error { return 
 func (fakeThreadForge) OpenPR(context.Context, providers.KBEntry) (providers.Ref, error) {
 	return providers.Ref{}, nil
 }
-func (fakeThreadForge) IsPROpen(context.Context, int) (bool, error) { return true, nil }
+func (fakeThreadForge) IsPROpen(context.Context, int) (bool, error)          { return true, nil }
+func (fakeThreadForge) AppendToEntryOnPR(context.Context, int, string) error { return nil }
 
 // TestBuildThreadMentionNamesTheBotTokenCause pins the fix for the dead-code
 // warning: ThreadCaptureDeliverable's "no bot-token delivery target resolved"

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -205,8 +205,8 @@ func (fakeThreadForge) CommentOnPR(context.Context, int, string) error { return 
 func (fakeThreadForge) OpenPR(context.Context, providers.KBEntry) (providers.Ref, error) {
 	return providers.Ref{}, nil
 }
-func (fakeThreadForge) IsPROpen(context.Context, int) (bool, error)          { return true, nil }
-func (fakeThreadForge) AppendToEntryOnPR(context.Context, int, string) error { return nil }
+func (fakeThreadForge) IsPROpen(context.Context, int) (bool, error)                  { return true, nil }
+func (fakeThreadForge) AppendToEntryOnPR(context.Context, int, string, string) error { return nil }
 
 // TestBuildThreadMentionNamesTheBotTokenCause pins the fix for the dead-code
 // warning: ThreadCaptureDeliverable's "no bot-token delivery target resolved"

--- a/internal/forge/github/bundle.go
+++ b/internal/forge/github/bundle.go
@@ -77,11 +77,23 @@ func (c *Client) getFile(ctx context.Context, path, ref string) (data []byte, sh
 		return nil, "", false, fmt.Errorf("github GET %s: status %d", path, resp.StatusCode)
 	}
 	var out struct {
-		SHA     string `json:"sha"`
-		Content string `json:"content"`
+		SHA      string `json:"sha"`
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, "", false, err
+	}
+	// Refuse anything that is not base64. For a blob over 1 MB the contents API
+	// answers 200 with an EMPTY content field and encoding "none" — which
+	// base64-decodes without error, so a caller that trusts (raw, found) is handed
+	// zero bytes from a "successful" read. On the read-modify-write append path
+	// that becomes replacing a whole entry with the newest note, since
+	// okf.AppendBlock returns the block ALONE when what it appends to is empty.
+	// Failing here degrades to the caller's comment fallback; reading nothing
+	// silently does not.
+	if out.Encoding != "base64" {
+		return nil, "", false, fmt.Errorf("github GET %s: content encoding %q, want base64 (blob too large for the contents API?)", path, out.Encoding)
 	}
 	// The contents API base64-wraps with newlines; the std decoder wants them gone.
 	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(out.Content, "\n", ""))

--- a/internal/forge/github/bundle_test.go
+++ b/internal/forge/github/bundle_test.go
@@ -35,7 +35,7 @@ func TestOpenPRMaintainsBundleFiles(t *testing.T) {
 	})
 	mux.HandleFunc("GET /repos/o/r/contents/index.md", func(w http.ResponseWriter, _ *http.Request) {
 		content := base64.StdEncoding.EncodeToString([]byte("# Catalog\n\n## Incidents\n"))
-		_, _ = w.Write([]byte(`{"sha":"idxsha","content":"` + content + `"}`))
+		_, _ = w.Write([]byte(`{"sha":"idxsha","encoding":"base64","content":"` + content + `"}`))
 	})
 	mux.HandleFunc("GET /repos/o/r/contents/log.md", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/forge/github/noteappend.go
+++ b/internal/forge/github/noteappend.go
@@ -149,10 +149,7 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body, key st
 	// caller: thread.NoteBody neutralises the note TEXT but interpolates identity
 	// fields (author, thread title) around it, and on the first-draft path those
 	// are covered by renderEntry, not by NoteBody.
-	block := neutralizeImages(body)
-	if key != "" {
-		block += "\n\n" + okf.NoteMarker(key)
-	}
+	block := okf.WithNoteMarker(neutralizeImages(body), key)
 	if err := c.putFile(ctx, entry, pr.Head.Ref, sha, "runlore: append operator note to "+entry,
 		okf.AppendBlock(raw, block)); err != nil {
 		return c.appendLanded(ctx, entry, pr.Head.Ref, key, err)

--- a/internal/forge/github/noteappend.go
+++ b/internal/forge/github/noteappend.go
@@ -15,15 +15,19 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
 )
 
 // prFilesPerPage asks for every changed path in one page. A RunLore curation PR
 // changes at most three files (the entry plus the reserved index.md / log.md),
-// so this is a ceiling far above the real case rather than a pagination scheme:
-// okf.EntryFile refuses anything other than exactly one entry, which is what
-// would catch a truncated listing rather than let it pick the wrong file.
+// so this is a ceiling far above the real case rather than a pagination scheme.
+//
+// It is NOT okf.EntryFile that catches a truncated listing — a >100-file pull
+// request whose first page happens to hold exactly one non-reserved .md resolves
+// cleanly to the wrong file. A full page is refused explicitly below instead.
 const prFilesPerPage = 100
 
 // AppendToEntryOnPR appends body to the KB entry file carried by the pull
@@ -44,17 +48,40 @@ const prFilesPerPage = 100
 // human's words even when this route cannot run — but that choice is the
 // caller's to make with the error in hand, not this function's to make by
 // pretending it succeeded.
-func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string) error {
+func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body, key string) error {
 	var pr struct {
-		Head struct {
-			Ref string `json:"ref"`
+		State string `json:"state"`
+		Head  struct {
+			Ref  string `json:"ref"`
+			Repo struct {
+				FullName string `json:"full_name"`
+			} `json:"repo"`
 		} `json:"head"`
 	}
 	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/pulls/%d", c.owner, c.repo, number), nil, &pr); err != nil {
 		return err
 	}
+	// Re-checked here, out of a response this call already makes, even though the
+	// caller checked one round trip ago: four calls run between the two, and a PR
+	// that merged in the window either 404s on a deleted branch — sending the
+	// caller to comment on a MERGED pull request, the silent-loss case its
+	// IsPROpen check exists to prevent — or takes a commit onto a branch that will
+	// never reach base while this reports success. Zero extra calls.
+	if pr.State != "open" {
+		return fmt.Errorf("github PR %d is %q: %w", number, pr.State, providers.ErrPRNotOpen)
+	}
 	if pr.Head.Ref == "" {
 		return fmt.Errorf("github PR %d: no head branch to commit onto", number)
+	}
+	// head.ref is a bare BRANCH NAME while every write below addresses
+	// c.owner/c.repo, so for a pull request opened from a FORK the branch named
+	// lives in another repository — commonly "main" — and this would commit onto
+	// the configured repository's own main. Not reachable today (the append route
+	// requires a PR RunLore itself opened, recorded from OpenPR's own return), but
+	// it is the single check standing between "commit onto a note branch" and
+	// "commit onto main", so it does not depend on that staying true.
+	if want := c.owner + "/" + c.repo; !strings.EqualFold(pr.Head.Repo.FullName, want) {
+		return fmt.Errorf("github PR %d: head branch is in %q, not %q (fork); refusing to commit", number, pr.Head.Repo.FullName, want)
 	}
 
 	var files []struct {
@@ -63,6 +90,15 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string)
 	if err := c.do(ctx, http.MethodGet,
 		fmt.Sprintf("/repos/%s/%s/pulls/%d/files?per_page=%d", c.owner, c.repo, number, prFilesPerPage), nil, &files); err != nil {
 		return err
+	}
+	// A FULL page means one of two things, and neither permits a write: either
+	// this is not a RunLore curation pull request (they change at most three
+	// files — the entry plus the reserved index.md and log.md), or the listing was
+	// truncated and okf.EntryFile is about to choose among a fraction of the
+	// changed paths with no way to know it did. "The one .md on page 1" is not a
+	// fact about the pull request, so it is not a file to rewrite.
+	if len(files) >= prFilesPerPage {
+		return fmt.Errorf("github PR %d: %d changed files in one page; the listing may be truncated, refusing to pick an entry from it", number, len(files))
 	}
 	changed := make([]string, 0, len(files))
 	for _, f := range files {
@@ -83,6 +119,24 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string)
 	if !found {
 		return fmt.Errorf("github PR %d: entry %s is not on branch %s", number, entry, pr.Head.Ref)
 	}
+	// Never write blind. okf.AppendBlock returns the block ALONE when what it is
+	// appending to is empty — correct behaviour, it is how a first draft is
+	// built — so a read that yields nothing while reporting success would replace
+	// the entry with one note, frontmatter and every earlier note gone, and the
+	// PUT would succeed because it carries a valid blob sha. getFile now refuses a
+	// non-base64 body, which is the known way to get here; this is the guard that
+	// does not depend on knowing the next one.
+	if !okf.HasFrontmatter(raw) {
+		return fmt.Errorf("github PR %d: %s on branch %s does not read as a catalog entry; refusing to rewrite it", number, entry, pr.Head.Ref)
+	}
+	if okf.HasNoteMarker(raw, key) {
+		// Already recorded: a replayed chat delivery, or a retry of a write whose
+		// response was lost. Reporting success is honest — the note IS in the entry —
+		// and appending again would duplicate it permanently in catalog content that
+		// kb_search then indexes twice.
+		return nil
+	}
+
 	// The blob sha makes this an UPDATE of the revision just read: GitHub rejects
 	// the PUT if anything else committed to that file in between, so a racing
 	// writer loses the call rather than silently overwriting the note it did not
@@ -95,6 +149,37 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string)
 	// caller: thread.NoteBody neutralises the note TEXT but interpolates identity
 	// fields (author, thread title) around it, and on the first-draft path those
 	// are covered by renderEntry, not by NoteBody.
-	return c.putFile(ctx, entry, pr.Head.Ref, sha, "runlore: append operator note to "+entry,
-		okf.AppendBlock(raw, neutralizeImages(body)))
+	block := neutralizeImages(body)
+	if key != "" {
+		block += "\n\n" + okf.NoteMarker(key)
+	}
+	if err := c.putFile(ctx, entry, pr.Head.Ref, sha, "runlore: append operator note to "+entry,
+		okf.AppendBlock(raw, block)); err != nil {
+		return c.appendLanded(ctx, entry, pr.Head.Ref, key, err)
+	}
+	return nil
+}
+
+// appendLanded turns "the write landed but the response did not" into success.
+//
+// c.do returns an error for any transport failure, including one AFTER the server
+// processed the request — a response timeout, a reset connection, a cancelled
+// context. The commit is on the branch; the caller sees an error, falls back to a
+// comment, and the note ends up BOTH in the entry and duplicated in the
+// conversation, reported to the human with the comment's wording and counted
+// under the comment route. That metric exists precisely to separate a note that
+// became knowledge from one discarded at merge, so it would be wrong on the one
+// case where it matters.
+//
+// Re-reading is cheap and unambiguous: the marker is either there or it is not.
+// With no key there is nothing to look for, so the original error stands.
+func (c *Client) appendLanded(ctx context.Context, entry, branch, key string, putErr error) error {
+	if key == "" {
+		return putErr
+	}
+	raw, _, found, err := c.getFile(ctx, entry, branch)
+	if err != nil || !found || !okf.HasNoteMarker(raw, key) {
+		return putErr
+	}
+	return nil
 }

--- a/internal/forge/github/noteappend.go
+++ b/internal/forge/github/noteappend.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+// This file is the "add to the entry, not beside it" write: one further commit
+// onto a pull request RunLore itself opened, appending an operator note to the
+// KB entry that pull request carries.
+//
+// It exists because a comment is not knowledge. A note filed as a PR comment
+// lives in the forge's conversation, which the catalog never indexes — so a
+// thread whose second, third and fourth notes were comments merged as an entry
+// holding only the first, and kb_search never saw the rest.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Smana/runlore/internal/okf"
+)
+
+// prFilesPerPage asks for every changed path in one page. A RunLore curation PR
+// changes at most three files (the entry plus the reserved index.md / log.md),
+// so this is a ceiling far above the real case rather than a pagination scheme:
+// okf.EntryFile refuses anything other than exactly one entry, which is what
+// would catch a truncated listing rather than let it pick the wrong file.
+const prFilesPerPage = 100
+
+// AppendToEntryOnPR appends body to the KB entry file carried by the pull
+// request numbered `number`, as one further commit on that pull request's OWN
+// head branch. It never touches the base branch and never merges: the pull
+// request stays the proposal and a human stays the gate, exactly as when the
+// entry was first drafted.
+//
+// Four calls: read the PR (its head branch), list its changed paths, read the
+// entry on that branch, PUT it back. The entry is located from the pull request
+// itself rather than passed in, so no caller has to persist a path it wrote
+// weeks ago and no stale path can send a commit somewhere unintended — see
+// okf.EntryFile, which refuses to guess when the changed paths do not name
+// exactly one entry.
+//
+// Every failure is returned rather than swallowed. The thread responder's
+// fallback for one is a comment (thread.Responder.addToPR), which keeps the
+// human's words even when this route cannot run — but that choice is the
+// caller's to make with the error in hand, not this function's to make by
+// pretending it succeeded.
+func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string) error {
+	var pr struct {
+		Head struct {
+			Ref string `json:"ref"`
+		} `json:"head"`
+	}
+	if err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/%s/pulls/%d", c.owner, c.repo, number), nil, &pr); err != nil {
+		return err
+	}
+	if pr.Head.Ref == "" {
+		return fmt.Errorf("github PR %d: no head branch to commit onto", number)
+	}
+
+	var files []struct {
+		Filename string `json:"filename"`
+	}
+	if err := c.do(ctx, http.MethodGet,
+		fmt.Sprintf("/repos/%s/%s/pulls/%d/files?per_page=%d", c.owner, c.repo, number, prFilesPerPage), nil, &files); err != nil {
+		return err
+	}
+	changed := make([]string, 0, len(files))
+	for _, f := range files {
+		changed = append(changed, f.Filename)
+	}
+	entry, err := okf.EntryFile(changed)
+	if err != nil {
+		return fmt.Errorf("github PR %d: %w", number, err)
+	}
+
+	// Read the entry on the PR's OWN branch, not the base branch: the entry does
+	// not exist on base until the PR merges, and reading base would either 404 or
+	// — for a PR editing a merged entry — append onto the wrong revision.
+	raw, sha, found, err := c.getFile(ctx, entry, pr.Head.Ref)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("github PR %d: entry %s is not on branch %s", number, entry, pr.Head.Ref)
+	}
+	// The blob sha makes this an UPDATE of the revision just read: GitHub rejects
+	// the PUT if anything else committed to that file in between, so a racing
+	// writer loses the call rather than silently overwriting the note it did not
+	// see.
+	//
+	// neutralizeImages for the same reason renderEntry applies it to a first
+	// draft — the appended block is untrusted text, and an entry file rendered on
+	// a review page must not be able to fire a request from the reviewer's
+	// browser. It is applied HERE, on the whole block, rather than trusted to the
+	// caller: thread.NoteBody neutralises the note TEXT but interpolates identity
+	// fields (author, thread title) around it, and on the first-draft path those
+	// are covered by renderEntry, not by NoteBody.
+	return c.putFile(ctx, entry, pr.Head.Ref, sha, "runlore: append operator note to "+entry,
+		okf.AppendBlock(raw, neutralizeImages(body)))
+}

--- a/internal/forge/github/noteappend_test.go
+++ b/internal/forge/github/noteappend_test.go
@@ -6,61 +6,145 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
 )
 
-// appendMux builds a GitHub stub serving one note PR: head branch `branch`,
-// changed files `changed`, and `entry` holding `content` on that branch. It
-// returns the mux and a pointer to the PUT the client makes, so a test can
-// assert what was committed and where.
-type recordedPut struct {
-	path, branch, sha, content string
-	made                       bool
+const noteEntry = "---\ntype: Concept\ntitle: Operator note: OOM\n---\n\n### 📝 Operator note\n\nthe first note\n"
+
+// recordedPut is one contents-API PUT the client made.
+type recordedPut struct{ path, branch, sha, content string }
+
+// stubPR is a configurable GitHub stub serving ONE note pull request. Every
+// field a guard in AppendToEntryOnPR reads is a knob, so each test breaks
+// exactly one thing and the rest stays valid — the alternative, a per-test
+// hand-rolled mux, hides which guard a test is actually exercising.
+//
+// Defaults describe the healthy case: an open PR whose head branch is in the
+// configured repo, three changed files, and a well-formed entry.
+type stubPR struct {
+	state    string // "open" unless set
+	branch   string // head ref; "runlore/kb-oom-1" unless set
+	headRepo string // head.repo.full_name; "o/r" unless set. "-" omits head.repo entirely
+	changed  []string
+	entry    string // the path the contents API serves
+	encoding string // "base64" unless set
+
+	// putStatus, when non-zero, is the HTTP status the PUT answers with — 409 is
+	// the sha-conflict a racing writer causes.
+	putStatus int
+	// putLands models the response being lost AFTER GitHub applied the write: the
+	// content is updated, then the call fails. It is the only way to reach
+	// appendLanded, and the case a fake that simply errors cannot express.
+	putLands bool
+
+	mu      sync.Mutex
+	content string
+	sha     string
+	puts    []recordedPut
 }
 
-func appendMux(t *testing.T, branch string, changed []string, entry, content string, put *recordedPut) *http.ServeMux {
+func (s *stubPR) or(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+// emptyEntry asks the stub to serve a ZERO-BYTE file. "" cannot say that: an
+// unset content field means "serve the default entry", so the two need
+// different spellings.
+const emptyEntry = "\x00"
+
+func (s *stubPR) start(t *testing.T) *Client {
 	t.Helper()
+	if s.content == emptyEntry {
+		s.content = ""
+	} else {
+		s.content = s.or(s.content, noteEntry)
+	}
+	s.sha = "entrysha0"
+	if s.changed == nil {
+		s.changed = []string{"index.md", "log.md", "concepts/oom-1.md"}
+	}
+	s.entry = s.or(s.entry, "concepts/oom-1.md")
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repos/o/r/pulls/84", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(`{"head":{"ref":"` + branch + `"}}`))
+		head := `"head":{"ref":"` + s.or(s.branch, "runlore/kb-oom-1") + `"`
+		if repo := s.or(s.headRepo, "o/r"); repo != "-" {
+			head += `,"repo":{"full_name":"` + repo + `"}`
+		}
+		_, _ = w.Write([]byte(`{"state":"` + s.or(s.state, "open") + `",` + head + `}}`))
 	})
 	mux.HandleFunc("GET /repos/o/r/pulls/84/files", func(w http.ResponseWriter, _ *http.Request) {
-		var b strings.Builder
-		b.WriteString("[")
-		for i, f := range changed {
-			if i > 0 {
-				b.WriteString(",")
-			}
-			b.WriteString(`{"filename":"` + f + `"}`)
+		out := make([]map[string]string, 0, len(s.changed))
+		for _, f := range s.changed {
+			out = append(out, map[string]string{"filename": f})
 		}
-		b.WriteString("]")
-		_, _ = w.Write([]byte(b.String()))
+		_ = json.NewEncoder(w).Encode(out)
 	})
 	mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
-		if r.PathValue("path") != entry || r.URL.Query().Get("ref") != branch {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if r.PathValue("path") != s.entry || r.URL.Query().Get("ref") != s.or(s.branch, "runlore/kb-oom-1") {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		_, _ = w.Write([]byte(`{"sha":"entrysha","content":"` + base64.StdEncoding.EncodeToString([]byte(content)) + `"}`))
+		enc := s.or(s.encoding, "base64")
+		body := map[string]string{"sha": s.sha, "encoding": enc, "content": base64.StdEncoding.EncodeToString([]byte(s.content))}
+		if enc != "base64" {
+			// What GitHub actually answers for a blob over 1 MB: 200, a real sha,
+			// and NO content.
+			body["content"] = ""
+		}
+		_ = json.NewEncoder(w).Encode(body)
 	})
 	mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Content string `json:"content"`
-			SHA     string `json:"sha"`
-			Branch  string `json:"branch"`
-		}
+		var body struct{ Content, SHA, Branch string }
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		raw, _ := base64.StdEncoding.DecodeString(body.Content)
-		*put = recordedPut{path: r.PathValue("path"), branch: body.Branch, sha: body.SHA, content: string(raw), made: true}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		s.puts = append(s.puts, recordedPut{path: r.PathValue("path"), branch: body.Branch, sha: body.SHA, content: string(raw)})
+		if s.putLands {
+			s.content, s.sha = string(raw), s.sha+"x"
+		}
+		if s.putStatus != 0 || s.putLands {
+			status := s.putStatus
+			if status == 0 {
+				status = http.StatusBadGateway
+			}
+			w.WriteHeader(status)
+			return
+		}
+		s.content, s.sha = string(raw), s.sha+"x"
 		_, _ = w.Write([]byte(`{}`))
 	})
-	return mux
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "o", "r", "main", staticToken("tok"))
 }
 
-const noteEntry = "---\ntype: Concept\ntitle: Operator note: OOM\n---\n\n### 📝 Operator note\n\nthe first note\n"
+func (s *stubPR) writes() []recordedPut {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]recordedPut(nil), s.puts...)
+}
+
+func (s *stubPR) entryContent() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.content
+}
 
 // TestAppendToEntryOnPRCommitsOntoThePRsOwnBranch is the forge half of issue
 // #493: the note has to end up in the ENTRY FILE the pull request carries, on
@@ -72,55 +156,274 @@ const noteEntry = "---\ntype: Concept\ntitle: Operator note: OOM\n---\n\n### �
 // the PUT instead of silently clobbering), and the original content preserved
 // ahead of the new block.
 func TestAppendToEntryOnPRCommitsOntoThePRsOwnBranch(t *testing.T) {
-	var put recordedPut
-	srv := httptest.NewServer(appendMux(t, "runlore/kb-oom-1",
-		[]string{"index.md", "log.md", "concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &put))
-	defer srv.Close()
-
-	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "### 📝 Operator note\n\nthe second note"); err != nil {
+	s := &stubPR{}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "### 📝 Operator note\n\nthe second note", "k1"); err != nil {
 		t.Fatalf("AppendToEntryOnPR: %v", err)
 	}
-	if !put.made {
-		t.Fatal("nothing was committed")
+	puts := s.writes()
+	if len(puts) != 1 {
+		t.Fatalf("puts = %d, want 1", len(puts))
 	}
-	if put.path != "concepts/oom-1.md" {
-		t.Errorf("committed to %q, want the entry file — index.md and log.md are bundle upkeep, not the entry", put.path)
+	if puts[0].path != "concepts/oom-1.md" {
+		t.Errorf("committed to %q, want the entry file — index.md and log.md are bundle upkeep, not the entry", puts[0].path)
 	}
-	if put.branch != "runlore/kb-oom-1" {
-		t.Errorf("committed onto %q, want the pull request's own head branch", put.branch)
+	if puts[0].branch != "runlore/kb-oom-1" {
+		t.Errorf("committed onto %q, want the pull request's own head branch", puts[0].branch)
 	}
-	if put.sha != "entrysha" {
-		t.Errorf("sha = %q, want the blob sha just read — without it a racing writer is silently overwritten", put.sha)
+	if puts[0].sha != "entrysha0" {
+		t.Errorf("sha = %q, want the blob sha just read — without it a racing writer is silently overwritten", puts[0].sha)
 	}
-	if !strings.Contains(put.content, "the first note") || !strings.Contains(put.content, "the second note") {
-		t.Errorf("the entry must keep every note, got:\n%s", put.content)
+	if !strings.Contains(puts[0].content, "the first note") || !strings.Contains(puts[0].content, "the second note") {
+		t.Errorf("the entry must keep every note, got:\n%s", puts[0].content)
 	}
-	if strings.Index(put.content, "the first note") > strings.Index(put.content, "the second note") {
-		t.Errorf("notes must accumulate in order, got:\n%s", put.content)
+	if strings.Index(puts[0].content, "the first note") > strings.Index(puts[0].content, "the second note") {
+		t.Errorf("notes must accumulate in order, got:\n%s", puts[0].content)
 	}
 }
 
-// TestAppendToEntryOnPRNeutralizesImagesInTheBlock: an appended note lands in a
-// file a reviewer opens on the forge, so it gets the SAME image defusal
-// renderEntry applies to a first draft — this client's own neutralizeImages, the
-// one that rewrites the whole `![alt](url)` to a labelled code span. Without it
-// the second note into an entry could be a tracking pixel that the first note,
-// which went through renderEntry, could not have been.
-func TestAppendToEntryOnPRNeutralizesImagesInTheBlock(t *testing.T) {
-	var put recordedPut
-	srv := httptest.NewServer(appendMux(t, "b", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &put))
-	defer srv.Close()
+// TestAppendToEntryOnPRRefusesAnUnreadableEntry is the worst defect this file
+// guards, and the one an earlier version shipped.
+//
+// GitHub answers the contents API for a blob over 1 MB with 200, a real blob
+// sha, `"content": ""` and `"encoding": "none"`. base64-decoding that empty
+// string SUCCEEDS, so a client that does not check the encoding gets zero bytes
+// back and calls them the file. okf.AppendBlock returns the block ALONE when
+// what it appends to is empty, and the PUT carries the correct sha — so the
+// entry, its frontmatter and every earlier note are replaced by the newest note,
+// the forge accepts it, and the human is told it worked. Only git history has
+// the entry after that.
+//
+// An entry that grows by one rendered note per thread message can genuinely
+// reach 1 MB: config.Validate rejects only a NEGATIVE max_note_bytes, so a
+// configured 1 MiB crosses it on the second note, and even at defaults twenty
+// notes at the worst-case rendered size land near it.
+func TestAppendToEntryOnPRRefusesAnUnreadableEntry(t *testing.T) {
+	s := &stubPR{encoding: "none"}
+	c := s.start(t)
+	err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1")
+	if err == nil {
+		t.Fatal("want an error: a read that returns nothing must never be treated as an empty entry")
+	}
+	// Name the ENCODING, not merely "something refused it". The frontmatter guard
+	// one layer up rejects this same input, so without this the encoding check can
+	// be deleted with the whole suite green — the two layers quietly stop being
+	// independent, and nobody finds out until an unreadable read arrives that does
+	// carry frontmatter.
+	if !strings.Contains(err.Error(), "encoding") {
+		t.Errorf("error = %v; want the ENCODING check to be what refused this. If the "+
+			"frontmatter guard fired instead, the first layer is no longer pinned", err)
+	}
+	if puts := s.writes(); len(puts) != 0 {
+		t.Fatalf("the entry was rewritten from an unreadable read: %+v", puts)
+	}
+	if got := s.entryContent(); got != noteEntry {
+		t.Errorf("the entry changed:\n%s", got)
+	}
+}
 
-	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "look ![px](https://evil.example/px.gif)"); err != nil {
+// TestAppendToEntryOnPRRefusesAFileThatIsNotAnEntry is the independent half of
+// the same guard, one layer up from the encoding check: whatever the read
+// yielded, it is only written back if it reads as an OKF entry. It also covers
+// what okf.EntryFile cannot promise — that the one non-reserved .md in a pull
+// request is the catalog entry rather than some other markdown a reviewer
+// touched.
+func TestAppendToEntryOnPRRefusesAFileThatIsNotAnEntry(t *testing.T) {
+	for name, content := range map[string]string{
+		"empty file":      emptyEntry,
+		"no frontmatter":  "# Notes\n\nsome markdown a reviewer added\n",
+		"html leading in": "<!-- draft -->\n---\ntype: Concept\n---\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := &stubPR{content: content}
+			c := s.start(t)
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+				t.Fatal("want an error rather than a rewrite of a file that is not an entry")
+			}
+			if puts := s.writes(); len(puts) != 0 {
+				t.Fatalf("rewrote a non-entry: %+v", puts)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRIsIdempotent: the deliveries above this layer replay (a
+// bounded per-process dedup set, wiped wholesale, that no restart survives), and
+// a replayed append is permanent duplicate catalog content — unlike a replayed
+// comment, which is visibly duplicated and dies at merge. The second call must
+// therefore write nothing and still report success, because the note IS in the
+// entry.
+func TestAppendToEntryOnPRIsIdempotent(t *testing.T) {
+	s := &stubPR{}
+	c := s.start(t)
+	for i := range 3 {
+		if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if puts := s.writes(); len(puts) != 1 {
+		t.Fatalf("puts = %d, want 1 — a replayed delivery must not append the note again", len(puts))
+	}
+	if got := strings.Count(s.entryContent(), "the second note"); got != 1 {
+		t.Errorf("the note appears %d times in the entry, want 1:\n%s", got, s.entryContent())
+	}
+	// A DIFFERENT note must still land: the guard is per-note, not a lock on the
+	// entry.
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the third note", "k2"); err != nil {
+		t.Fatalf("a different note must still be appended: %v", err)
+	}
+	if puts := s.writes(); len(puts) != 2 {
+		t.Fatalf("puts = %d, want 2 — a different key is a different note", len(puts))
+	}
+}
+
+// TestAppendToEntryOnPRReportsSuccessWhenTheWriteLandedButTheResponseDidNot is
+// the case a fake that merely returns an error cannot express.
+//
+// c.do reports an error for every failed round trip, which includes every way a
+// RESPONSE can be lost after GitHub already applied the commit. Reported as a
+// failure, the caller files the same note again as a comment — so the note
+// exists twice — and, worse, reports the write on the COMMENT route, which is
+// the label an operator reads to tell whether a note became knowledge or will be
+// discarded at merge. It would say the wrong one on exactly the case it exists
+// for. One re-read on the error path settles it.
+func TestAppendToEntryOnPRReportsSuccessWhenTheWriteLandedButTheResponseDidNot(t *testing.T) {
+	s := &stubPR{putLands: true}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err != nil {
+		t.Fatalf("the commit landed; reporting failure sends the caller to double-write it as a comment: %v", err)
+	}
+	if !strings.Contains(s.entryContent(), "the second note") {
+		t.Fatalf("test is not exercising the case — the write did not land:\n%s", s.entryContent())
+	}
+}
+
+// TestAppendToEntryOnPRPropagatesAFailureThatDidNotLand is the other direction
+// of the same check: when the write genuinely did not land, the error must
+// survive so the caller degrades to a comment and the human's words are kept. A
+// re-read that finds no marker must not be read as success.
+func TestAppendToEntryOnPRPropagatesAFailureThatDidNotLand(t *testing.T) {
+	s := &stubPR{putStatus: http.StatusConflict}
+	c := s.start(t)
+	err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1")
+	if err == nil {
+		t.Fatal("a 409 means a racing writer won and the note is NOT in the entry; want an error so the caller falls back")
+	}
+	if strings.Contains(s.entryContent(), "the second note") {
+		t.Errorf("the entry must be untouched after a conflict:\n%s", s.entryContent())
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAPRThatIsNoLongerOpen closes the window between
+// the caller's open-check and this write. Both outcomes past a merge are silent
+// losses — a commit onto a merged PR's branch never reaches base, and the
+// caller's comment fallback lands on a PR the catalog never indexes — so the
+// case is NAMED, with providers.ErrPRNotOpen, and the caller opens a fresh entry
+// instead.
+func TestAppendToEntryOnPRRefusesAPRThatIsNoLongerOpen(t *testing.T) {
+	for _, state := range []string{"closed", "merged"} {
+		t.Run("state="+state, func(t *testing.T) {
+			s := &stubPR{state: state}
+			c := s.start(t)
+			err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1")
+			if !errors.Is(err, providers.ErrPRNotOpen) {
+				t.Fatalf("err = %v, want ErrPRNotOpen — the caller must not degrade to commenting on a finished PR", err)
+			}
+			if puts := s.writes(); len(puts) != 0 {
+				t.Errorf("committed onto a %s PR: %+v", s.state, puts)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAHeadOutsideTheConfiguredRepo: head.ref is a bare
+// branch name and every write here is addressed to the configured owner/repo, so
+// a fork PR's head — commonly "main" — would be committed onto the BASE
+// repository's main. Nothing reachable today opens such a PR on this path; this
+// is the only guard between a note branch and main, and it must not depend on
+// that staying true two packages away.
+func TestAppendToEntryOnPRRefusesAHeadOutsideTheConfiguredRepo(t *testing.T) {
+	for name, repo := range map[string]string{
+		"fork":            "attacker/r",
+		"deleted head":    "-",
+		"same name, else": "o2/r",
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := &stubPR{headRepo: repo, branch: "main"}
+			c := s.start(t)
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+				t.Fatal("want a refusal rather than a commit onto the base repository's branch")
+			}
+			if puts := s.writes(); len(puts) != 0 {
+				t.Errorf("committed onto %q in the configured repo: %+v", puts[0].branch, puts)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAPossiblyTruncatedFileListing: the listing asks
+// for one page. A FULL page means either this is not a RunLore curation PR (they
+// change at most three files) or the listing was cut and okf.EntryFile is
+// choosing among a fraction of the changed paths with no way to know. "The one
+// .md on page 1" is not a fact about the pull request, so it is not a file to
+// rewrite.
+func TestAppendToEntryOnPRRefusesAPossiblyTruncatedFileListing(t *testing.T) {
+	changed := make([]string, 0, prFilesPerPage)
+	changed = append(changed, "concepts/oom-1.md")
+	for i := range prFilesPerPage - 1 {
+		changed = append(changed, fmt.Sprintf("chart/values-%d.yaml", i))
+	}
+	s := &stubPR{changed: changed}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+		t.Fatal("want a refusal: a full page cannot be told from a truncated one")
+	}
+	if puts := s.writes(); len(puts) != 0 {
+		t.Errorf("committed from a possibly truncated listing: %+v", puts)
+	}
+}
+
+// TestAppendToEntryOnPRNeutralizesImagesInTheBlock keeps the appended block at
+// the same defusal level renderEntry gives a first draft — this client's own
+// neutralizeImages, which rewrites `![alt](url)` to a labelled code span.
+//
+// It is DEFENCE IN DEPTH rather than the only guard, and saying so precisely
+// matters: both routes render through thread.NoteBody, which has already
+// rewritten "![" in the note text, so a note cannot reach here carrying live
+// image markdown. What this covers is the rest of the block — the identity
+// fields NoteBody interpolates AROUND the note (author, thread title), which go
+// through noteField, not through the markdown defusals — and any future caller
+// that hands this method a block NoteBody did not build.
+func TestAppendToEntryOnPRNeutralizesImagesInTheBlock(t *testing.T) {
+	s := &stubPR{}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "look ![px](https://evil.example/px.gif)", "k1"); err != nil {
 		t.Fatalf("AppendToEntryOnPR: %v", err)
 	}
-	if strings.Contains(put.content, "![px](") || strings.Contains(put.content, "evil.example") {
-		t.Errorf("image markdown reached the entry file:\n%s", put.content)
+	got := s.writes()[0].content
+	if strings.Contains(got, "![px](") || strings.Contains(got, "evil.example") {
+		t.Errorf("image markdown reached the entry file:\n%s", got)
 	}
-	if !strings.Contains(put.content, "`[image: px]`") {
-		t.Errorf("want the defused label renderEntry would have produced:\n%s", put.content)
+	if !strings.Contains(got, "`[image: px]`") {
+		t.Errorf("want the defused label renderEntry would have produced:\n%s", got)
+	}
+}
+
+// TestAppendToEntryOnPRMarkerIsInvisibleAndSingular: the idempotency marker is
+// an HTML comment, so it never renders in the entry a human or the catalog
+// reads, and exactly one is written per note.
+func TestAppendToEntryOnPRMarkerIsInvisibleAndSingular(t *testing.T) {
+	s := &stubPR{}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err != nil {
+		t.Fatalf("AppendToEntryOnPR: %v", err)
+	}
+	got := s.writes()[0].content
+	if n := strings.Count(got, okf.NoteMarker("k1")); n != 1 {
+		t.Errorf("marker appears %d times, want 1:\n%s", n, got)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(okf.NoteMarker("k1")), "<!--") {
+		t.Error("the marker must be an HTML comment so it never renders in the entry")
 	}
 }
 
@@ -134,34 +437,39 @@ func TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous(t *testing.T) {
 		"no entry":    {"index.md", "log.md"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			var put recordedPut
-			srv := httptest.NewServer(appendMux(t, "b", changed, "concepts/a.md", noteEntry, &put))
-			defer srv.Close()
-
-			c := New(srv.URL, "o", "r", "main", staticToken("tok"))
-			if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+			s := &stubPR{changed: changed, entry: "concepts/a.md"}
+			c := s.start(t)
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
 				t.Fatal("want an error rather than a guess at which file to rewrite")
 			}
-			if put.made {
-				t.Errorf("committed to %q despite an ambiguous entry", put.path)
+			if puts := s.writes(); len(puts) != 0 {
+				t.Errorf("committed to %q despite an ambiguous entry", puts[0].path)
 			}
 		})
 	}
 }
 
-// TestAppendToEntryOnPRRefusesWithoutAHeadBranch: a PR payload with no head ref
-// must not become a commit onto the empty branch name (or onto the base).
+// TestAppendToEntryOnPRRefusesWithoutAHeadBranch: a PR payload carrying no head
+// ref must not become a commit onto the empty branch name — which the contents
+// API resolves to the repository's DEFAULT branch, i.e. straight onto main.
+//
+// Hand-built rather than driven through stubPR, because the shape under test is
+// a field that is absent from the payload entirely; the catch-all handler is the
+// assertion that nothing past the guard is ever reached.
 func TestAppendToEntryOnPRRefusesWithoutAHeadBranch(t *testing.T) {
-	var put recordedPut
-	mux := appendMux(t, "", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &put)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls/84", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"state":"open","head":{"repo":{"full_name":"o/r"}}}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("reached %s %s past the head-branch guard", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
 	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
 		t.Fatal("want an error when the pull request names no head branch")
-	}
-	if put.made {
-		t.Errorf("committed onto %q with no head branch", put.branch)
 	}
 }

--- a/internal/forge/github/noteappend_test.go
+++ b/internal/forge/github/noteappend_test.go
@@ -3,6 +3,7 @@
 package github
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -52,13 +53,6 @@ type stubPR struct {
 	puts    []recordedPut
 }
 
-func (s *stubPR) or(v, def string) string {
-	if v == "" {
-		return def
-	}
-	return v
-}
-
 // emptyEntry asks the stub to serve a ZERO-BYTE file. "" cannot say that: an
 // unset content field means "serve the default entry", so the two need
 // different spellings.
@@ -69,21 +63,21 @@ func (s *stubPR) start(t *testing.T) *Client {
 	if s.content == emptyEntry {
 		s.content = ""
 	} else {
-		s.content = s.or(s.content, noteEntry)
+		s.content = cmp.Or(s.content, noteEntry)
 	}
 	s.sha = "entrysha0"
 	if s.changed == nil {
 		s.changed = []string{"index.md", "log.md", "concepts/oom-1.md"}
 	}
-	s.entry = s.or(s.entry, "concepts/oom-1.md")
+	s.entry = cmp.Or(s.entry, "concepts/oom-1.md")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /repos/o/r/pulls/84", func(w http.ResponseWriter, _ *http.Request) {
-		head := `"head":{"ref":"` + s.or(s.branch, "runlore/kb-oom-1") + `"`
-		if repo := s.or(s.headRepo, "o/r"); repo != "-" {
+		head := `"head":{"ref":"` + cmp.Or(s.branch, "runlore/kb-oom-1") + `"`
+		if repo := cmp.Or(s.headRepo, "o/r"); repo != "-" {
 			head += `,"repo":{"full_name":"` + repo + `"}`
 		}
-		_, _ = w.Write([]byte(`{"state":"` + s.or(s.state, "open") + `",` + head + `}}`))
+		_, _ = w.Write([]byte(`{"state":"` + cmp.Or(s.state, "open") + `",` + head + `}}`))
 	})
 	mux.HandleFunc("GET /repos/o/r/pulls/84/files", func(w http.ResponseWriter, _ *http.Request) {
 		out := make([]map[string]string, 0, len(s.changed))
@@ -95,11 +89,11 @@ func (s *stubPR) start(t *testing.T) *Client {
 	mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		if r.PathValue("path") != s.entry || r.URL.Query().Get("ref") != s.or(s.branch, "runlore/kb-oom-1") {
+		if r.PathValue("path") != s.entry || r.URL.Query().Get("ref") != cmp.Or(s.branch, "runlore/kb-oom-1") {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		enc := s.or(s.encoding, "base64")
+		enc := cmp.Or(s.encoding, "base64")
 		body := map[string]string{"sha": s.sha, "encoding": enc, "content": base64.StdEncoding.EncodeToString([]byte(s.content))}
 		if enc != "base64" {
 			// What GitHub actually answers for a blob over 1 MB: 200, a real sha,

--- a/internal/forge/github/noteappend_test.go
+++ b/internal/forge/github/noteappend_test.go
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// appendMux builds a GitHub stub serving one note PR: head branch `branch`,
+// changed files `changed`, and `entry` holding `content` on that branch. It
+// returns the mux and a pointer to the PUT the client makes, so a test can
+// assert what was committed and where.
+type recordedPut struct {
+	path, branch, sha, content string
+	made                       bool
+}
+
+func appendMux(t *testing.T, branch string, changed []string, entry, content string, put *recordedPut) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls/84", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"head":{"ref":"` + branch + `"}}`))
+	})
+	mux.HandleFunc("GET /repos/o/r/pulls/84/files", func(w http.ResponseWriter, _ *http.Request) {
+		var b strings.Builder
+		b.WriteString("[")
+		for i, f := range changed {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			b.WriteString(`{"filename":"` + f + `"}`)
+		}
+		b.WriteString("]")
+		_, _ = w.Write([]byte(b.String()))
+	})
+	mux.HandleFunc("GET /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("path") != entry || r.URL.Query().Get("ref") != branch {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`{"sha":"entrysha","content":"` + base64.StdEncoding.EncodeToString([]byte(content)) + `"}`))
+	})
+	mux.HandleFunc("PUT /repos/o/r/contents/{path...}", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Content string `json:"content"`
+			SHA     string `json:"sha"`
+			Branch  string `json:"branch"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		raw, _ := base64.StdEncoding.DecodeString(body.Content)
+		*put = recordedPut{path: r.PathValue("path"), branch: body.Branch, sha: body.SHA, content: string(raw), made: true}
+		_, _ = w.Write([]byte(`{}`))
+	})
+	return mux
+}
+
+const noteEntry = "---\ntype: Concept\ntitle: Operator note: OOM\n---\n\n### 📝 Operator note\n\nthe first note\n"
+
+// TestAppendToEntryOnPRCommitsOntoThePRsOwnBranch is the forge half of issue
+// #493: the note has to end up in the ENTRY FILE the pull request carries, on
+// that pull request's OWN branch, keeping everything already there.
+//
+// Four separate facts, because getting any one of them wrong loses or corrupts
+// a human's note: the right file (not index.md or log.md), the right branch
+// (base has no such file until merge), the blob sha (so a racing writer loses
+// the PUT instead of silently clobbering), and the original content preserved
+// ahead of the new block.
+func TestAppendToEntryOnPRCommitsOntoThePRsOwnBranch(t *testing.T) {
+	var put recordedPut
+	srv := httptest.NewServer(appendMux(t, "runlore/kb-oom-1",
+		[]string{"index.md", "log.md", "concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &put))
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "### 📝 Operator note\n\nthe second note"); err != nil {
+		t.Fatalf("AppendToEntryOnPR: %v", err)
+	}
+	if !put.made {
+		t.Fatal("nothing was committed")
+	}
+	if put.path != "concepts/oom-1.md" {
+		t.Errorf("committed to %q, want the entry file — index.md and log.md are bundle upkeep, not the entry", put.path)
+	}
+	if put.branch != "runlore/kb-oom-1" {
+		t.Errorf("committed onto %q, want the pull request's own head branch", put.branch)
+	}
+	if put.sha != "entrysha" {
+		t.Errorf("sha = %q, want the blob sha just read — without it a racing writer is silently overwritten", put.sha)
+	}
+	if !strings.Contains(put.content, "the first note") || !strings.Contains(put.content, "the second note") {
+		t.Errorf("the entry must keep every note, got:\n%s", put.content)
+	}
+	if strings.Index(put.content, "the first note") > strings.Index(put.content, "the second note") {
+		t.Errorf("notes must accumulate in order, got:\n%s", put.content)
+	}
+}
+
+// TestAppendToEntryOnPRNeutralizesImagesInTheBlock: an appended note lands in a
+// file a reviewer opens on the forge, so it gets the SAME image defusal
+// renderEntry applies to a first draft — this client's own neutralizeImages, the
+// one that rewrites the whole `![alt](url)` to a labelled code span. Without it
+// the second note into an entry could be a tracking pixel that the first note,
+// which went through renderEntry, could not have been.
+func TestAppendToEntryOnPRNeutralizesImagesInTheBlock(t *testing.T) {
+	var put recordedPut
+	srv := httptest.NewServer(appendMux(t, "b", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &put))
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "look ![px](https://evil.example/px.gif)"); err != nil {
+		t.Fatalf("AppendToEntryOnPR: %v", err)
+	}
+	if strings.Contains(put.content, "![px](") || strings.Contains(put.content, "evil.example") {
+		t.Errorf("image markdown reached the entry file:\n%s", put.content)
+	}
+	if !strings.Contains(put.content, "`[image: px]`") {
+		t.Errorf("want the defused label renderEntry would have produced:\n%s", put.content)
+	}
+}
+
+// TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous: the next move is a commit
+// into a pull request a human is reviewing, so an unclear target is an error,
+// never a guess. The caller degrades to a comment on this error (see
+// thread.Responder.addToPR); a wrong write would have no such recovery.
+func TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous(t *testing.T) {
+	for name, changed := range map[string][]string{
+		"two entries": {"concepts/a.md", "concepts/b.md"},
+		"no entry":    {"index.md", "log.md"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var put recordedPut
+			srv := httptest.NewServer(appendMux(t, "b", changed, "concepts/a.md", noteEntry, &put))
+			defer srv.Close()
+
+			c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+				t.Fatal("want an error rather than a guess at which file to rewrite")
+			}
+			if put.made {
+				t.Errorf("committed to %q despite an ambiguous entry", put.path)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRRefusesWithoutAHeadBranch: a PR payload with no head ref
+// must not become a commit onto the empty branch name (or onto the base).
+func TestAppendToEntryOnPRRefusesWithoutAHeadBranch(t *testing.T) {
+	var put recordedPut
+	mux := appendMux(t, "", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &put)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := New(srv.URL, "o", "r", "main", staticToken("tok"))
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+		t.Fatal("want an error when the pull request names no head branch")
+	}
+	if put.made {
+		t.Errorf("committed onto %q with no head branch", put.branch)
+	}
+}

--- a/internal/forge/gitlab/noteappend.go
+++ b/internal/forge/gitlab/noteappend.go
@@ -118,10 +118,7 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body, key st
 	// neutralizeImages for the same reason renderEntry applies it to a first
 	// draft — see github.Client.AppendToEntryOnPR for the full argument; the
 	// appended block is untrusted text landing on a page a reviewer opens.
-	block := neutralizeImages(body)
-	if key != "" {
-		block += "\n\n" + okf.NoteMarker(key)
-	}
+	block := okf.WithNoteMarker(neutralizeImages(body), key)
 	if err := c.commitEntry(ctx, entry, mr.SourceBranch, lastCommit, string(okf.AppendBlock(raw, block))); err != nil {
 		return c.appendLanded(ctx, entry, mr.SourceBranch, key, err)
 	}

--- a/internal/forge/gitlab/noteappend.go
+++ b/internal/forge/gitlab/noteappend.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlab
+
+// This file mirrors internal/forge/github/noteappend.go: one further commit
+// onto a merge request RunLore itself opened, appending an operator note to the
+// KB entry that merge request carries — because a comment lives in the forge's
+// conversation, which the catalog never indexes, and only the entry becomes
+// knowledge when the request merges.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Smana/runlore/internal/okf"
+)
+
+// AppendToEntryOnPR appends body to the KB entry file carried by the merge
+// request with this iid, as one further commit on that merge request's OWN
+// source branch. It never touches the target branch and never merges.
+//
+// Three calls where GitHub needs four, the same one-call-shorter shape the rest
+// of this client has: `/changes` returns the merge request AND its changed paths
+// together, so the source branch and the entry come from one round trip, and the
+// Commits API writes the file back without a separate blob-sha read.
+//
+// `/changes` is GitLab's older single-MR-changes endpoint, deprecated in 15.7 in
+// favour of `/diffs` and still served (removal is scheduled for API v5, which
+// does not exist). It is used deliberately: `/diffs` returns the diffs ALONE, so
+// it would need a second call for `source_branch` — trading a live endpoint for
+// an extra round trip on every note. If v5 ever lands, this becomes two calls.
+//
+// Every failure is returned rather than swallowed; the thread responder decides
+// what to degrade to (see thread.Responder.addToPR).
+func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string) error {
+	var mr struct {
+		SourceBranch string `json:"source_branch"`
+		Changes      []struct {
+			NewPath string `json:"new_path"`
+		} `json:"changes"`
+	}
+	if err := c.do(ctx, http.MethodGet,
+		fmt.Sprintf("/projects/%s/merge_requests/%d/changes", c.projectSeg(), number), nil, &mr); err != nil {
+		return err
+	}
+	if mr.SourceBranch == "" {
+		return fmt.Errorf("gitlab MR %d: no source branch to commit onto", number)
+	}
+	changed := make([]string, 0, len(mr.Changes))
+	for _, ch := range mr.Changes {
+		changed = append(changed, ch.NewPath)
+	}
+	entry, err := okf.EntryFile(changed)
+	if err != nil {
+		return fmt.Errorf("gitlab MR %d: %w", number, err)
+	}
+
+	// Read the entry on the merge request's OWN branch: it does not exist on the
+	// target branch until the request merges.
+	raw, found, err := c.getRawFile(ctx, entry, mr.SourceBranch)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("gitlab MR %d: entry %s is not on branch %s", number, entry, mr.SourceBranch)
+	}
+	// neutralizeImages for the same reason renderEntry applies it to a first
+	// draft — see github.Client.AppendToEntryOnPR for the full argument; the
+	// appended block is untrusted text landing on a page a reviewer opens.
+	return c.do(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/repository/commits", c.projectSeg()), map[string]any{
+		"branch":         mr.SourceBranch,
+		"commit_message": "runlore: append operator note to " + entry,
+		"actions": []map[string]any{{
+			"action":    "update",
+			"file_path": entry,
+			"content":   string(okf.AppendBlock(raw, neutralizeImages(body))),
+		}},
+	}, nil)
+}

--- a/internal/forge/gitlab/noteappend.go
+++ b/internal/forge/gitlab/noteappend.go
@@ -7,36 +7,55 @@ package gitlab
 // KB entry that merge request carries — because a comment lives in the forge's
 // conversation, which the catalog never indexes, and only the entry becomes
 // knowledge when the request merges.
+//
+// "Mirrors" is a claim about the SAFETY PROPERTIES, not only about the shape.
+// Every guard the GitHub sibling has, this has; where GitLab spells one
+// differently the difference is stated at the guard rather than left for a
+// reader to infer from its absence — see last_commit_id below, which an earlier
+// version of this file omitted while still claiming the mirror, and so shipped
+// a read-modify-write that silently reverted whoever it raced.
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
 )
 
 // AppendToEntryOnPR appends body to the KB entry file carried by the merge
 // request with this iid, as one further commit on that merge request's OWN
 // source branch. It never touches the target branch and never merges.
 //
-// Three calls where GitHub needs four, the same one-call-shorter shape the rest
-// of this client has: `/changes` returns the merge request AND its changed paths
-// together, so the source branch and the entry come from one round trip, and the
-// Commits API writes the file back without a separate blob-sha read.
+// key identifies this note for idempotency (see okf.NoteMarker); an entry
+// already carrying it makes this a no-op reporting success.
+//
+// Three calls where GitHub needs four, and the saving is real rather than paid
+// for in safety: `/changes` returns the merge request AND its changed paths
+// together, and the non-raw repository-files endpoint returns the entry's
+// content AND the last_commit_id the write needs, so neither fact costs its own
+// round trip.
 //
 // `/changes` is GitLab's older single-MR-changes endpoint, deprecated in 15.7 in
 // favour of `/diffs` and still served (removal is scheduled for API v5, which
 // does not exist). It is used deliberately: `/diffs` returns the diffs ALONE, so
-// it would need a second call for `source_branch` — trading a live endpoint for
-// an extra round trip on every note. If v5 ever lands, this becomes two calls.
+// it would need a second call for source_branch and state. If v5 ever lands,
+// this becomes four calls.
 //
-// Every failure is returned rather than swallowed; the thread responder decides
-// what to degrade to (see thread.Responder.addToPR).
-func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string) error {
+// Failures are returned rather than swallowed, and providers.ErrPRNotOpen is
+// distinguished from the rest for the reason the GitHub sibling gives: it is the
+// one failure on which the caller's comment fallback would be lost too.
+func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body, key string) error {
 	var mr struct {
-		SourceBranch string `json:"source_branch"`
-		Changes      []struct {
+		State           string `json:"state"`
+		SourceBranch    string `json:"source_branch"`
+		SourceProjectID int64  `json:"source_project_id"`
+		TargetProjectID int64  `json:"target_project_id"`
+		Changes         []struct {
 			NewPath string `json:"new_path"`
 		} `json:"changes"`
 	}
@@ -44,8 +63,26 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string)
 		fmt.Sprintf("/projects/%s/merge_requests/%d/changes", c.projectSeg(), number), nil, &mr); err != nil {
 		return err
 	}
+	// Re-checked out of a response this call already makes — see the GitHub
+	// sibling for why the caller's check one round trip ago is not enough. GitLab
+	// spells the open state "opened"; "closed", "merged" and "locked" all mean
+	// finished.
+	if mr.State != "opened" {
+		return fmt.Errorf("gitlab MR %d is %q: %w", number, mr.State, providers.ErrPRNotOpen)
+	}
 	if mr.SourceBranch == "" {
 		return fmt.Errorf("gitlab MR %d: no source branch to commit onto", number)
+	}
+	// The GitLab spelling of GitHub's fork check. source_branch is a bare branch
+	// name while every write below addresses c.projectPath, so for a merge
+	// request opened from a FORK the branch named lives in another project —
+	// commonly "main" — and this would commit onto the configured project's own
+	// main. Comparing the two project ids needs no extra lookup and no knowledge
+	// of either id: on a same-project merge request they are equal by
+	// construction.
+	if mr.SourceProjectID != mr.TargetProjectID {
+		return fmt.Errorf("gitlab MR %d: source branch is in project %d, not the target project %d (fork); refusing to commit",
+			number, mr.SourceProjectID, mr.TargetProjectID)
 	}
 	changed := make([]string, 0, len(mr.Changes))
 	for _, ch := range mr.Changes {
@@ -58,23 +95,116 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body string)
 
 	// Read the entry on the merge request's OWN branch: it does not exist on the
 	// target branch until the request merges.
-	raw, found, err := c.getRawFile(ctx, entry, mr.SourceBranch)
+	raw, lastCommit, found, err := c.getEntryFile(ctx, entry, mr.SourceBranch)
 	if err != nil {
 		return err
 	}
 	if !found {
 		return fmt.Errorf("gitlab MR %d: entry %s is not on branch %s", number, entry, mr.SourceBranch)
 	}
+	// Never write blind — okf.AppendBlock returns the block ALONE when what it is
+	// appending to is empty, so a read that yields nothing while reporting success
+	// would replace the entry with one note. See okf.HasFrontmatter.
+	if !okf.HasFrontmatter(raw) {
+		return fmt.Errorf("gitlab MR %d: %s on branch %s does not read as a catalog entry; refusing to rewrite it", number, entry, mr.SourceBranch)
+	}
+	if okf.HasNoteMarker(raw, key) {
+		// Already recorded: a replayed chat delivery, or a retry of a write whose
+		// response was lost. Reporting success is honest — the note is in the entry
+		// — and appending it again would duplicate it permanently.
+		return nil
+	}
+
 	// neutralizeImages for the same reason renderEntry applies it to a first
 	// draft — see github.Client.AppendToEntryOnPR for the full argument; the
 	// appended block is untrusted text landing on a page a reviewer opens.
+	block := neutralizeImages(body)
+	if key != "" {
+		block += "\n\n" + okf.NoteMarker(key)
+	}
+	if err := c.commitEntry(ctx, entry, mr.SourceBranch, lastCommit, string(okf.AppendBlock(raw, block))); err != nil {
+		return c.appendLanded(ctx, entry, mr.SourceBranch, key, err)
+	}
+	return nil
+}
+
+// getEntryFile reads a file's bytes AND the id of the last commit that touched
+// it, at ref, via the non-raw repository-files endpoint.
+//
+// It exists rather than reusing getRawFile because of that second return value.
+// The Commits API overwrites a file UNCONDITIONALLY unless the update action
+// carries last_commit_id, and this whole call is a read-modify-write: without it
+// a reviewer fixing a typo in the web IDE has their commit silently reverted by
+// the next note in the thread, with nothing anywhere reporting that it happened.
+// GitHub's sibling gets that property from the blob sha its contents API hands
+// back; this file claims to mirror GitHub's guarantees, so it has to hold the
+// property rather than resemble it.
+//
+// The cost over /raw is one base64 decode, and it buys the concurrency control
+// AND the encoding check in the same call rather than a second round trip.
+// A 404 is not an error: found=false says the file is absent.
+func (c *Client) getEntryFile(ctx context.Context, path, ref string) (data []byte, lastCommit string, found bool, err error) {
+	var out struct {
+		Content      string `json:"content"`
+		Encoding     string `json:"encoding"`
+		LastCommitID string `json:"last_commit_id"`
+	}
+	err = c.do(ctx, http.MethodGet,
+		fmt.Sprintf("/projects/%s/repository/files/%s?ref=%s", c.projectSeg(), url.PathEscape(path), url.QueryEscape(ref)), nil, &out)
+	if isNotFound(err) {
+		return nil, "", false, nil
+	}
+	if err != nil {
+		return nil, "", false, err
+	}
+	// Checked, not assumed, for the reason github.getFile states at length: a
+	// read that reports success while handing back nothing turns an append into a
+	// replacement.
+	if out.Encoding != "base64" {
+		return nil, "", false, fmt.Errorf("gitlab GET %s: unsupported content encoding %q", path, out.Encoding)
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(out.Content, "\n", ""))
+	if err != nil {
+		return nil, "", false, err
+	}
+	return raw, out.LastCommitID, true, nil
+}
+
+// commitEntry writes content back to path on branch as one update action,
+// refusing if anything committed to that file since lastCommit.
+//
+// GitLab answers a stale last_commit_id with 400 ("You are attempting to update
+// a file that has changed since you started editing it"), which is exactly the
+// outcome wanted: the racing writer keeps their commit, and this note goes down
+// the caller's comment fallback instead of overwriting them.
+func (c *Client) commitEntry(ctx context.Context, path, branch, lastCommit, content string) error {
+	action := map[string]any{
+		"action":    "update",
+		"file_path": path,
+		"content":   content,
+	}
+	if lastCommit != "" {
+		action["last_commit_id"] = lastCommit
+	}
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/repository/commits", c.projectSeg()), map[string]any{
-		"branch":         mr.SourceBranch,
-		"commit_message": "runlore: append operator note to " + entry,
-		"actions": []map[string]any{{
-			"action":    "update",
-			"file_path": entry,
-			"content":   string(okf.AppendBlock(raw, neutralizeImages(body))),
-		}},
+		"branch":         branch,
+		"commit_message": "runlore: append operator note to " + path,
+		"actions":        []map[string]any{action},
 	}, nil)
+}
+
+// appendLanded turns "the commit reported an error" into "the commit reported an
+// error AND the note is not there", by looking. Same defect and same reasoning
+// as github.Client.appendLanded: a lost RESPONSE to a commit GitLab already
+// applied would otherwise be filed a second time as a comment and reported on
+// the wrong route. A failure to re-read returns the original error.
+func (c *Client) appendLanded(ctx context.Context, entry, branch, key string, commitErr error) error {
+	if key == "" {
+		return commitErr
+	}
+	raw, _, found, err := c.getEntryFile(ctx, entry, branch)
+	if err != nil || !found || !okf.HasNoteMarker(raw, key) {
+		return commitErr
+	}
+	return nil
 }

--- a/internal/forge/gitlab/noteappend_test.go
+++ b/internal/forge/gitlab/noteappend_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+const noteEntry = "---\ntype: Concept\ntitle: Operator note: OOM\n---\n\n### 📝 Operator note\n\nthe first note\n"
+
+// appendServer stubs the three calls AppendToEntryOnPR makes: the MR (source
+// branch + changed paths), the raw entry on that branch, and the commit that
+// writes it back. The commit body is captured into commit.
+func appendServer(t *testing.T, branch string, changed []string, entry, content string, commit *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.EscapedPath()
+		switch {
+		case strings.HasSuffix(path, "/merge_requests/84/changes"):
+			var b strings.Builder
+			b.WriteString(`{"source_branch":"` + branch + `","changes":[`)
+			for i, f := range changed {
+				if i > 0 {
+					b.WriteString(",")
+				}
+				b.WriteString(`{"new_path":"` + f + `"}`)
+			}
+			b.WriteString("]}")
+			_, _ = w.Write([]byte(b.String()))
+		case strings.Contains(path, "/repository/files/"):
+			// The file path must arrive URL-encoded as ONE segment and be read at
+			// the merge request's own ref — GitLab 404s an unencoded "/" in a way
+			// that looks like a permissions problem, so this is asserted rather
+			// than assumed.
+			want := "/repository/files/" + url.PathEscape(entry) + "/raw"
+			if !strings.HasSuffix(path, want) || r.URL.Query().Get("ref") != branch {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_, _ = w.Write([]byte(content))
+		case strings.HasSuffix(path, "/repository/commits"):
+			_ = json.NewDecoder(r.Body).Decode(commit)
+			_, _ = w.Write([]byte(`{"id":"abc123"}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestAppendToEntryOnPRUpdatesTheEntryOnTheSourceBranch is the GitLab half of
+// issue #493: the note reaches the ENTRY FILE — on the merge request's own
+// source branch, keeping every note already there — rather than a discussion
+// note the catalog never indexes.
+func TestAppendToEntryOnPRUpdatesTheEntryOnTheSourceBranch(t *testing.T) {
+	var commit map[string]any
+	srv := appendServer(t, "runlore/kb-oom-1",
+		[]string{"index.md", "log.md", "concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &commit)
+	defer srv.Close()
+
+	c := New(srv.URL, "o/r", "main", staticToken("tok"))
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "### 📝 Operator note\n\nthe second note"); err != nil {
+		t.Fatalf("AppendToEntryOnPR: %v", err)
+	}
+	if commit == nil {
+		t.Fatal("nothing was committed")
+	}
+	if commit["branch"] != "runlore/kb-oom-1" {
+		t.Errorf("branch = %v, want the merge request's own source branch", commit["branch"])
+	}
+	actions, _ := commit["actions"].([]any)
+	if len(actions) != 1 {
+		t.Fatalf("actions = %v, want exactly one (the entry update)", commit["actions"])
+	}
+	action, _ := actions[0].(map[string]any)
+	if action["action"] != "update" {
+		t.Errorf("action = %v, want update — a create would 400 on an existing file", action["action"])
+	}
+	if action["file_path"] != "concepts/oom-1.md" {
+		t.Errorf("file_path = %v, want the entry — index.md and log.md are bundle upkeep", action["file_path"])
+	}
+	body, _ := action["content"].(string)
+	if !strings.Contains(body, "the first note") || !strings.Contains(body, "the second note") {
+		t.Errorf("the entry must keep every note, got:\n%s", body)
+	}
+	if strings.Index(body, "the first note") > strings.Index(body, "the second note") {
+		t.Errorf("notes must accumulate in order, got:\n%s", body)
+	}
+}
+
+// TestAppendToEntryOnPRNeutralizesImages: the appended block gets the same image
+// defusal renderEntry gives a first draft, so a note written straight into an
+// entry cannot carry what a drafted one could not.
+func TestAppendToEntryOnPRNeutralizesImages(t *testing.T) {
+	var commit map[string]any
+	srv := appendServer(t, "b", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &commit)
+	defer srv.Close()
+
+	c := New(srv.URL, "o/r", "main", staticToken("tok"))
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "look ![px](https://evil.example/px.gif)"); err != nil {
+		t.Fatalf("AppendToEntryOnPR: %v", err)
+	}
+	actions, _ := commit["actions"].([]any)
+	action, _ := actions[0].(map[string]any)
+	body, _ := action["content"].(string)
+	if strings.Contains(body, "![px](") || strings.Contains(body, "evil.example") {
+		t.Errorf("image markdown reached the entry file:\n%s", body)
+	}
+	if !strings.Contains(body, "`[image: px]`") {
+		t.Errorf("want the defused label renderEntry would have produced:\n%s", body)
+	}
+}
+
+// TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous: the next move is a commit
+// into a merge request a human is reviewing, so an unclear target is an error,
+// never a guess — the caller degrades to a comment on it.
+func TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous(t *testing.T) {
+	for name, changed := range map[string][]string{
+		"two entries": {"concepts/a.md", "concepts/b.md"},
+		"no entry":    {"index.md", "log.md"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var commit map[string]any
+			srv := appendServer(t, "b", changed, "concepts/a.md", noteEntry, &commit)
+			defer srv.Close()
+
+			c := New(srv.URL, "o/r", "main", staticToken("tok"))
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+				t.Fatal("want an error rather than a guess at which file to rewrite")
+			}
+			if commit != nil {
+				t.Errorf("committed %v despite an ambiguous entry", commit)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRRefusesWithoutASourceBranch: an MR payload with no
+// source_branch must not become a commit onto the empty branch name, which
+// GitLab would resolve to the project default.
+func TestAppendToEntryOnPRRefusesWithoutASourceBranch(t *testing.T) {
+	var commit map[string]any
+	srv := appendServer(t, "", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &commit)
+	defer srv.Close()
+
+	c := New(srv.URL, "o/r", "main", staticToken("tok"))
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+		t.Fatal("want an error when the merge request names no source branch")
+	}
+	if commit != nil {
+		t.Errorf("committed %v with no source branch", commit)
+	}
+}

--- a/internal/forge/gitlab/noteappend_test.go
+++ b/internal/forge/gitlab/noteappend_test.go
@@ -3,6 +3,7 @@
 package gitlab
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -48,25 +49,18 @@ type stubMR struct {
 	commits    []map[string]any
 }
 
-func (s *stubMR) or(v, def string) string {
-	if v == "" {
-		return def
-	}
-	return v
-}
-
 func (s *stubMR) start(t *testing.T) *Client {
 	t.Helper()
 	if s.content == emptyEntry {
 		s.content = ""
 	} else {
-		s.content = s.or(s.content, noteEntry)
+		s.content = cmp.Or(s.content, noteEntry)
 	}
 	s.lastCommit = "commit0"
 	if s.changed == nil {
 		s.changed = []string{"index.md", "log.md", "concepts/oom-1.md"}
 	}
-	s.entry = s.or(s.entry, "concepts/oom-1.md")
+	s.entry = cmp.Or(s.entry, "concepts/oom-1.md")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.EscapedPath()
@@ -81,7 +75,7 @@ func (s *stubMR) start(t *testing.T) *Client {
 				src = 7
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"state": s.or(s.state, "opened"), "source_branch": s.or(s.branch, "runlore/kb-oom-1"),
+				"state": cmp.Or(s.state, "opened"), "source_branch": cmp.Or(s.branch, "runlore/kb-oom-1"),
 				"source_project_id": src, "target_project_id": 7, "changes": changes,
 			})
 		case strings.Contains(path, "/repository/files/"):
@@ -94,11 +88,11 @@ func (s *stubMR) start(t *testing.T) *Client {
 			// endpoint is the one carrying last_commit_id, which is why the client
 			// stopped using /raw here.
 			want := "/repository/files/" + url.PathEscape(s.entry)
-			if !strings.HasSuffix(path, want) || r.URL.Query().Get("ref") != s.or(s.branch, "runlore/kb-oom-1") {
+			if !strings.HasSuffix(path, want) || r.URL.Query().Get("ref") != cmp.Or(s.branch, "runlore/kb-oom-1") {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			enc := s.or(s.encoding, "base64")
+			enc := cmp.Or(s.encoding, "base64")
 			content := base64.StdEncoding.EncodeToString([]byte(s.content))
 			if enc != "base64" {
 				content = ""

--- a/internal/forge/gitlab/noteappend_test.go
+++ b/internal/forge/gitlab/noteappend_test.go
@@ -4,54 +4,165 @@ package gitlab
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/Smana/runlore/internal/okf"
+	"github.com/Smana/runlore/internal/providers"
 )
 
 const noteEntry = "---\ntype: Concept\ntitle: Operator note: OOM\n---\n\n### 📝 Operator note\n\nthe first note\n"
 
-// appendServer stubs the three calls AppendToEntryOnPR makes: the MR (source
-// branch + changed paths), the raw entry on that branch, and the commit that
-// writes it back. The commit body is captured into commit.
-func appendServer(t *testing.T, branch string, changed []string, entry, content string, commit *map[string]any) *httptest.Server {
+// emptyEntry asks the stub to serve a ZERO-BYTE file; "" means "serve the
+// default entry", so the two need different spellings.
+const emptyEntry = "\x00"
+
+// stubMR is a configurable GitLab stub serving ONE note merge request, mirroring
+// github's stubPR knob for knob so both clients' guards are exercised the same
+// way rather than each drifting to whatever its own tests happened to cover.
+type stubMR struct {
+	state    string // "opened" unless set
+	branch   string // source_branch; "runlore/kb-oom-1" unless set
+	srcProj  int64  // source_project_id; defaults equal to target (same-project MR)
+	changed  []string
+	entry    string
+	encoding string // "base64" unless set
+
+	// commitStatus, when non-zero, is the status the Commits API answers with —
+	// 400 is what a stale last_commit_id gets.
+	commitStatus int
+	// commitLands models a lost RESPONSE to a commit GitLab already applied: the
+	// content is updated, then the call fails. The only way to reach appendLanded.
+	commitLands bool
+
+	mu         sync.Mutex
+	content    string
+	lastCommit string
+	commits    []map[string]any
+}
+
+func (s *stubMR) or(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}
+
+func (s *stubMR) start(t *testing.T) *Client {
 	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	if s.content == emptyEntry {
+		s.content = ""
+	} else {
+		s.content = s.or(s.content, noteEntry)
+	}
+	s.lastCommit = "commit0"
+	if s.changed == nil {
+		s.changed = []string{"index.md", "log.md", "concepts/oom-1.md"}
+	}
+	s.entry = s.or(s.entry, "concepts/oom-1.md")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.EscapedPath()
 		switch {
 		case strings.HasSuffix(path, "/merge_requests/84/changes"):
-			var b strings.Builder
-			b.WriteString(`{"source_branch":"` + branch + `","changes":[`)
-			for i, f := range changed {
-				if i > 0 {
-					b.WriteString(",")
-				}
-				b.WriteString(`{"new_path":"` + f + `"}`)
+			changes := make([]map[string]string, 0, len(s.changed))
+			for _, f := range s.changed {
+				changes = append(changes, map[string]string{"new_path": f})
 			}
-			b.WriteString("]}")
-			_, _ = w.Write([]byte(b.String()))
+			src := s.srcProj
+			if src == 0 {
+				src = 7
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"state": s.or(s.state, "opened"), "source_branch": s.or(s.branch, "runlore/kb-oom-1"),
+				"source_project_id": src, "target_project_id": 7, "changes": changes,
+			})
 		case strings.Contains(path, "/repository/files/"):
+			s.mu.Lock()
+			defer s.mu.Unlock()
 			// The file path must arrive URL-encoded as ONE segment and be read at
 			// the merge request's own ref — GitLab 404s an unencoded "/" in a way
 			// that looks like a permissions problem, so this is asserted rather
-			// than assumed.
-			want := "/repository/files/" + url.PathEscape(entry) + "/raw"
-			if !strings.HasSuffix(path, want) || r.URL.Query().Get("ref") != branch {
+			// than assumed. Note the absence of a "/raw" suffix: the NON-raw
+			// endpoint is the one carrying last_commit_id, which is why the client
+			// stopped using /raw here.
+			want := "/repository/files/" + url.PathEscape(s.entry)
+			if !strings.HasSuffix(path, want) || r.URL.Query().Get("ref") != s.or(s.branch, "runlore/kb-oom-1") {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
-			_, _ = w.Write([]byte(content))
+			enc := s.or(s.encoding, "base64")
+			content := base64.StdEncoding.EncodeToString([]byte(s.content))
+			if enc != "base64" {
+				content = ""
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"encoding": enc, "content": content, "last_commit_id": s.lastCommit,
+			})
 		case strings.HasSuffix(path, "/repository/commits"):
-			_ = json.NewDecoder(r.Body).Decode(commit)
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			s.mu.Lock()
+			defer s.mu.Unlock()
+			s.commits = append(s.commits, body)
+			if s.commitStatus == 0 {
+				if actions, ok := body["actions"].([]any); ok && len(actions) == 1 {
+					if a, ok := actions[0].(map[string]any); ok {
+						s.content, _ = a["content"].(string)
+						s.lastCommit += "x"
+					}
+				}
+			}
+			if s.commitStatus != 0 || s.commitLands {
+				status := s.commitStatus
+				if status == 0 {
+					status = http.StatusBadGateway
+				}
+				w.WriteHeader(status)
+				return
+			}
 			_, _ = w.Write([]byte(`{"id":"abc123"}`))
 		default:
 			t.Errorf("unexpected request: %s %s", r.Method, path)
 			w.WriteHeader(http.StatusNotFound)
 		}
 	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "o/r", "main", staticToken("tok"))
+}
+
+func (s *stubMR) writes() []map[string]any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]map[string]any(nil), s.commits...)
+}
+
+func (s *stubMR) entryContent() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.content
+}
+
+// action returns the single file action of commit i.
+func (s *stubMR) action(t *testing.T, i int) map[string]any {
+	t.Helper()
+	commits := s.writes()
+	if len(commits) <= i {
+		t.Fatalf("commits = %d, want more than %d", len(commits), i)
+	}
+	actions, _ := commits[i]["actions"].([]any)
+	if len(actions) != 1 {
+		t.Fatalf("actions = %v, want exactly one (the entry update)", commits[i]["actions"])
+	}
+	a, _ := actions[0].(map[string]any)
+	return a
 }
 
 // TestAppendToEntryOnPRUpdatesTheEntryOnTheSourceBranch is the GitLab half of
@@ -59,33 +170,22 @@ func appendServer(t *testing.T, branch string, changed []string, entry, content 
 // source branch, keeping every note already there — rather than a discussion
 // note the catalog never indexes.
 func TestAppendToEntryOnPRUpdatesTheEntryOnTheSourceBranch(t *testing.T) {
-	var commit map[string]any
-	srv := appendServer(t, "runlore/kb-oom-1",
-		[]string{"index.md", "log.md", "concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &commit)
-	defer srv.Close()
-
-	c := New(srv.URL, "o/r", "main", staticToken("tok"))
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "### 📝 Operator note\n\nthe second note"); err != nil {
+	s := &stubMR{}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "### 📝 Operator note\n\nthe second note", "k1"); err != nil {
 		t.Fatalf("AppendToEntryOnPR: %v", err)
 	}
-	if commit == nil {
-		t.Fatal("nothing was committed")
+	if got := s.writes()[0]["branch"]; got != "runlore/kb-oom-1" {
+		t.Errorf("branch = %v, want the merge request's own source branch", got)
 	}
-	if commit["branch"] != "runlore/kb-oom-1" {
-		t.Errorf("branch = %v, want the merge request's own source branch", commit["branch"])
+	a := s.action(t, 0)
+	if a["action"] != "update" {
+		t.Errorf("action = %v, want update — a create would 400 on an existing file", a["action"])
 	}
-	actions, _ := commit["actions"].([]any)
-	if len(actions) != 1 {
-		t.Fatalf("actions = %v, want exactly one (the entry update)", commit["actions"])
+	if a["file_path"] != "concepts/oom-1.md" {
+		t.Errorf("file_path = %v, want the entry — index.md and log.md are bundle upkeep", a["file_path"])
 	}
-	action, _ := actions[0].(map[string]any)
-	if action["action"] != "update" {
-		t.Errorf("action = %v, want update — a create would 400 on an existing file", action["action"])
-	}
-	if action["file_path"] != "concepts/oom-1.md" {
-		t.Errorf("file_path = %v, want the entry — index.md and log.md are bundle upkeep", action["file_path"])
-	}
-	body, _ := action["content"].(string)
+	body, _ := a["content"].(string)
 	if !strings.Contains(body, "the first note") || !strings.Contains(body, "the second note") {
 		t.Errorf("the entry must keep every note, got:\n%s", body)
 	}
@@ -94,26 +194,182 @@ func TestAppendToEntryOnPRUpdatesTheEntryOnTheSourceBranch(t *testing.T) {
 	}
 }
 
-// TestAppendToEntryOnPRNeutralizesImages: the appended block gets the same image
-// defusal renderEntry gives a first draft, so a note written straight into an
-// entry cannot carry what a drafted one could not.
-func TestAppendToEntryOnPRNeutralizesImages(t *testing.T) {
-	var commit map[string]any
-	srv := appendServer(t, "b", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &commit)
-	defer srv.Close()
-
-	c := New(srv.URL, "o/r", "main", staticToken("tok"))
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "look ![px](https://evil.example/px.gif)"); err != nil {
+// TestAppendToEntryOnPRSendsLastCommitID is the concurrency control, and the
+// property this client CLAIMED to mirror from GitHub while not holding it.
+//
+// The Commits API overwrites unconditionally unless the update action carries
+// last_commit_id. Without it this read-modify-write silently reverts anyone who
+// committed to the entry in between — a reviewer fixing a typo in the web IDE
+// has their change erased by the next note in the thread, with nothing anywhere
+// reporting it. GitHub gets the same property free from the blob sha its
+// contents API hands back; here it has to be asked for.
+func TestAppendToEntryOnPRSendsLastCommitID(t *testing.T) {
+	s := &stubMR{}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err != nil {
 		t.Fatalf("AppendToEntryOnPR: %v", err)
 	}
-	actions, _ := commit["actions"].([]any)
-	action, _ := actions[0].(map[string]any)
-	body, _ := action["content"].(string)
+	if got := s.action(t, 0)["last_commit_id"]; got != "commit0" {
+		t.Errorf("last_commit_id = %v, want the id just read — without it a racing writer is silently reverted", got)
+	}
+}
+
+// TestAppendToEntryOnPRPropagatesAConflict: GitLab answers a stale
+// last_commit_id with 400. The racing writer keeps their commit, and this note
+// must surface as an error so the caller degrades to a comment rather than
+// losing the human's words.
+func TestAppendToEntryOnPRPropagatesAConflict(t *testing.T) {
+	s := &stubMR{commitStatus: http.StatusBadRequest}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err == nil {
+		t.Fatal("want an error so the caller falls back to a comment")
+	}
+	if strings.Contains(s.entryContent(), "the second note") {
+		t.Errorf("the entry must be untouched after a conflict:\n%s", s.entryContent())
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAnUnreadableEntry: a read that reports success
+// while handing back nothing would make okf.AppendBlock replace the entry with
+// the single note being appended to it. See the GitHub sibling for the full
+// account of how that shape arises.
+func TestAppendToEntryOnPRRefusesAnUnreadableEntry(t *testing.T) {
+	s := &stubMR{encoding: "none"}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err == nil {
+		t.Fatal("want an error: a read that returns nothing must never be treated as an empty entry")
+	}
+	if commits := s.writes(); len(commits) != 0 {
+		t.Fatalf("the entry was rewritten from an unreadable read: %+v", commits)
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAFileThatIsNotAnEntry is the independent half of
+// the same guard: whatever the read yielded, it is written back only if it reads
+// as an OKF entry. It also covers what okf.EntryFile cannot promise — that the
+// one non-reserved .md in a request is the catalog entry.
+func TestAppendToEntryOnPRRefusesAFileThatIsNotAnEntry(t *testing.T) {
+	for name, content := range map[string]string{
+		"empty file":     emptyEntry,
+		"no frontmatter": "# Notes\n\nsome markdown a reviewer added\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			s := &stubMR{content: content}
+			c := s.start(t)
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+				t.Fatal("want an error rather than a rewrite of a file that is not an entry")
+			}
+			if commits := s.writes(); len(commits) != 0 {
+				t.Fatalf("rewrote a non-entry: %+v", commits)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRIsIdempotent: a replayed chat delivery must not append
+// the same note twice — unlike a duplicate comment, a duplicate append is
+// permanent catalog content that recall then serves twice.
+func TestAppendToEntryOnPRIsIdempotent(t *testing.T) {
+	s := &stubMR{}
+	c := s.start(t)
+	for i := range 3 {
+		if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if commits := s.writes(); len(commits) != 1 {
+		t.Fatalf("commits = %d, want 1 — a replayed delivery must not append the note again", len(commits))
+	}
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the third note", "k2"); err != nil {
+		t.Fatalf("a different note must still be appended: %v", err)
+	}
+	if commits := s.writes(); len(commits) != 2 {
+		t.Fatalf("commits = %d, want 2 — a different key is a different note", len(commits))
+	}
+}
+
+// TestAppendToEntryOnPRReportsSuccessWhenTheWriteLandedButTheResponseDidNot:
+// c.do errors for every failed round trip, including a response lost after
+// GitLab applied the commit. Reported as a failure, the caller files the note
+// again as a comment and labels the write on the COMMENT route — the wrong
+// answer to the one question that label exists to answer.
+func TestAppendToEntryOnPRReportsSuccessWhenTheWriteLandedButTheResponseDidNot(t *testing.T) {
+	s := &stubMR{commitLands: true}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err != nil {
+		t.Fatalf("the commit landed; reporting failure sends the caller to double-write it as a comment: %v", err)
+	}
+	if !strings.Contains(s.entryContent(), "the second note") {
+		t.Fatalf("test is not exercising the case — the write did not land:\n%s", s.entryContent())
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAnMRThatIsNoLongerOpen closes the window between
+// the caller's open-check and this write, and NAMES the case so the caller opens
+// a fresh entry rather than commenting onto a finished merge request.
+func TestAppendToEntryOnPRRefusesAnMRThatIsNoLongerOpen(t *testing.T) {
+	for _, state := range []string{"closed", "merged", "locked"} {
+		t.Run("state="+state, func(t *testing.T) {
+			s := &stubMR{state: state}
+			c := s.start(t)
+			err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1")
+			if !errors.Is(err, providers.ErrPRNotOpen) {
+				t.Fatalf("err = %v, want ErrPRNotOpen", err)
+			}
+			if commits := s.writes(); len(commits) != 0 {
+				t.Errorf("committed onto a %s merge request: %+v", state, commits)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAForkSourceBranch is the GitLab spelling of
+// GitHub's fork guard: source_branch is a bare branch name, so a fork's "main"
+// would be committed onto the configured project's own main. The two project ids
+// settle it with no extra lookup.
+func TestAppendToEntryOnPRRefusesAForkSourceBranch(t *testing.T) {
+	s := &stubMR{srcProj: 99, branch: "main"}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+		t.Fatal("want a refusal rather than a commit onto the target project's branch")
+	}
+	if commits := s.writes(); len(commits) != 0 {
+		t.Errorf("committed from a fork merge request: %+v", commits)
+	}
+}
+
+// TestAppendToEntryOnPRNeutralizesImages keeps the appended block at the defusal
+// level renderEntry gives a first draft. Defence in depth: thread.NoteBody has
+// already rewritten "![" in the note TEXT, so what this actually covers is the
+// identity fields interpolated around it (author, thread title, which go through
+// noteField rather than the markdown defusals) and any future caller handing
+// this a block NoteBody did not build.
+func TestAppendToEntryOnPRNeutralizesImages(t *testing.T) {
+	s := &stubMR{}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "look ![px](https://evil.example/px.gif)", "k1"); err != nil {
+		t.Fatalf("AppendToEntryOnPR: %v", err)
+	}
+	body, _ := s.action(t, 0)["content"].(string)
 	if strings.Contains(body, "![px](") || strings.Contains(body, "evil.example") {
 		t.Errorf("image markdown reached the entry file:\n%s", body)
 	}
 	if !strings.Contains(body, "`[image: px]`") {
 		t.Errorf("want the defused label renderEntry would have produced:\n%s", body)
+	}
+}
+
+// TestAppendToEntryOnPRMarkerIsInvisibleAndSingular: exactly one HTML-comment
+// marker per note, so it never renders in the entry the catalog serves.
+func TestAppendToEntryOnPRMarkerIsInvisibleAndSingular(t *testing.T) {
+	s := &stubMR{}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err != nil {
+		t.Fatalf("AppendToEntryOnPR: %v", err)
+	}
+	body, _ := s.action(t, 0)["content"].(string)
+	if n := strings.Count(body, okf.NoteMarker("k1")); n != 1 {
+		t.Errorf("marker appears %d times, want 1:\n%s", n, body)
 	}
 }
 
@@ -126,16 +382,13 @@ func TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous(t *testing.T) {
 		"no entry":    {"index.md", "log.md"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			var commit map[string]any
-			srv := appendServer(t, "b", changed, "concepts/a.md", noteEntry, &commit)
-			defer srv.Close()
-
-			c := New(srv.URL, "o/r", "main", staticToken("tok"))
-			if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+			s := &stubMR{changed: changed, entry: "concepts/a.md"}
+			c := s.start(t)
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
 				t.Fatal("want an error rather than a guess at which file to rewrite")
 			}
-			if commit != nil {
-				t.Errorf("committed %v despite an ambiguous entry", commit)
+			if commits := s.writes(); len(commits) != 0 {
+				t.Errorf("committed %v despite an ambiguous entry", commits)
 			}
 		})
 	}
@@ -145,15 +398,18 @@ func TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous(t *testing.T) {
 // source_branch must not become a commit onto the empty branch name, which
 // GitLab would resolve to the project default.
 func TestAppendToEntryOnPRRefusesWithoutASourceBranch(t *testing.T) {
-	var commit map[string]any
-	srv := appendServer(t, "", []string{"concepts/oom-1.md"}, "concepts/oom-1.md", noteEntry, &commit)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.EscapedPath(), "/merge_requests/84/changes") {
+			_, _ = w.Write([]byte(`{"state":"opened","source_project_id":7,"target_project_id":7,"changes":[]}`))
+			return
+		}
+		t.Errorf("reached %s %s past the source-branch guard", r.Method, r.URL.EscapedPath())
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
 	defer srv.Close()
 
 	c := New(srv.URL, "o/r", "main", staticToken("tok"))
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "note"); err == nil {
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
 		t.Fatal("want an error when the merge request names no source branch")
-	}
-	if commit != nil {
-		t.Errorf("committed %v with no source branch", commit)
 	}
 }

--- a/internal/notify/kbupdate.go
+++ b/internal/notify/kbupdate.go
@@ -110,8 +110,14 @@ func kbUpdateAnnouncement(up providers.KBUpdate) string {
 // number — which is not an error, and must not suppress the announcement.
 func kbHeadline(up providers.KBUpdate) string {
 	what := "noted on"
-	if up.Route == providers.KBRouteOpenPR {
+	switch up.Route {
+	case providers.KBRouteOpenPR:
 		what = "opened"
+	case providers.KBRouteAppend:
+		// "added to the entry on", not "noted on": this route wrote INTO the entry
+		// the catalog gains on merge, and a comment does not. A reader deciding
+		// whether the knowledge is safely captured is deciding exactly that.
+		what = "added to the entry on"
 	}
 	head := "📚 Knowledge base updated — " + what + " PR"
 	if up.PR > 0 {

--- a/internal/notify/kbupdate_test.go
+++ b/internal/notify/kbupdate_test.go
@@ -539,3 +539,28 @@ func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
 		}
 	}
 }
+
+// TestKBHeadlineNamesEachRouteDistinctly: the headline is RunLore's own claim
+// about what it did, and the three routes did materially different things. A
+// reader in the notifier's channel is deciding whether the knowledge is safely
+// captured, and only the append and open_pr routes put it in an entry — a
+// comment is a remark a human still has to fold in. Reusing one word for all
+// three would answer that question wrongly for two of them.
+func TestKBHeadlineNamesEachRouteDistinctly(t *testing.T) {
+	want := map[providers.KBRoute]string{
+		providers.KBRouteComment: "📚 Knowledge base updated — noted on PR #7",
+		providers.KBRouteOpenPR:  "📚 Knowledge base updated — opened PR #7",
+		providers.KBRouteAppend:  "📚 Knowledge base updated — added to the entry on PR #7",
+	}
+	seen := map[string]providers.KBRoute{}
+	for route, head := range want {
+		got := kbHeadline(providers.KBUpdate{Route: route, PR: 7})
+		if got != head {
+			t.Errorf("kbHeadline(%q) = %q, want %q", route, got, head)
+		}
+		if other, dup := seen[got]; dup {
+			t.Errorf("routes %q and %q announce identically (%q) — a reader cannot tell them apart", route, other, got)
+		}
+		seen[got] = route
+	}
+}

--- a/internal/notify/matrix_feedback_test.go
+++ b/internal/notify/matrix_feedback_test.go
@@ -873,6 +873,13 @@ func TestMatrixFeedbackDrivesTheChatLayerEndToEnd(t *testing.T) {
 	if !strings.Contains(comments[0].body, "spot-node reclaim, not the CNI") {
 		t.Fatalf("the filed note lost the model's own text:\n%s", comments[0].body)
 	}
+	// A CURATED PR: someone else's draft, under review. A note on it is feedback
+	// a human reconciles at merge time, never a rewrite of their entry file —
+	// see thread.noteTarget for why the two destinations are not interchangeable,
+	// and why only the PR thread capture itself opened gets the append route.
+	if n := forge.appends(); n != 0 {
+		t.Fatalf("appends = %d, want 0 — RunLore must never rewrite an entry a human drafted", n)
+	}
 	stored, ok := reg.Get("$root-ours")
 	if !ok {
 		t.Fatal("the thread went missing from the registry")

--- a/internal/notify/matrix_grammar_test.go
+++ b/internal/notify/matrix_grammar_test.go
@@ -277,7 +277,7 @@ func (f *fakeThreadForge) CommentOnPR(_ context.Context, number int, body string
 
 func (f *fakeThreadForge) IsPROpen(context.Context, int) (bool, error) { return true, nil }
 
-func (f *fakeThreadForge) AppendToEntryOnPR(_ context.Context, _ int, _ string) error {
+func (f *fakeThreadForge) AppendToEntryOnPR(_ context.Context, _ int, _, _ string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.appended++

--- a/internal/notify/matrix_grammar_test.go
+++ b/internal/notify/matrix_grammar_test.go
@@ -246,6 +246,12 @@ type fakeThreadForge struct {
 	opened    int
 	commented int
 	comments  []forgeComment
+	// appended counts AppendToEntryOnPR calls. This package's tests all route
+	// through a CuratedURL — someone else's draft, where a comment is still the
+	// right answer — so it stays at zero and is here to PROVE that, not merely
+	// to satisfy the interface: an append onto a curator's entry file would be
+	// RunLore rewriting a human's PR from under them.
+	appended int
 }
 
 // forgeComment is one recorded CommentOnPR call.
@@ -271,10 +277,24 @@ func (f *fakeThreadForge) CommentOnPR(_ context.Context, number int, body string
 
 func (f *fakeThreadForge) IsPROpen(context.Context, int) (bool, error) { return true, nil }
 
+func (f *fakeThreadForge) AppendToEntryOnPR(_ context.Context, _ int, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.appended++
+	return nil
+}
+
 func (f *fakeThreadForge) counts() (opened, commented int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.opened, f.commented
+}
+
+// appends returns the AppendToEntryOnPR call count under the lock.
+func (f *fakeThreadForge) appends() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.appended
 }
 
 func (f *fakeThreadForge) commentsSnapshot() []forgeComment {

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -81,6 +81,18 @@ var reservedBundleFiles = []string{"index.md", "log.md"}
 // refusing degrades to a comment, and a wrong write silently rewrites somebody
 // else's change with no signal that it happened.
 //
+// WHAT IT DOES NOT GUARANTEE, stated plainly because an earlier version of this
+// comment overclaimed it: the result is "the one changed path that is a
+// non-reserved .md", which is not the same proposition as "the catalog entry".
+// A request that renamed the entry and also touched some other markdown resolves
+// to whichever of the two the filter leaves, with no error, because there is
+// nothing here to compare against. Nor can it detect a TRUNCATED listing: one
+// page of a large request that happens to hold exactly one non-reserved .md
+// resolves just as cleanly to the wrong file. Callers therefore verify that what
+// they got is an entry BEFORE writing to it (HasFrontmatter) and refuse a listing
+// that may have been cut. This function narrows the candidates; it is not the
+// last gate.
+//
 // It lives here, beside the functions that put those reserved files on the
 // branch in the first place, and is shared by both forge clients for the reason
 // this file's header gives: two copies of a rule about the bundle's shape drift,
@@ -121,6 +133,59 @@ func AppendBlock(existing []byte, block string) []byte {
 		return []byte(block + "\n")
 	}
 	return []byte(cur + "\n\n" + block + "\n")
+}
+
+// HasFrontmatter reports whether raw opens with a CLOSED YAML frontmatter fence,
+// i.e. whether it is an OKF entry rather than something else that happens to be
+// markdown.
+//
+// It exists for one caller shape and one failure: an append that reads the entry,
+// appends to what it read, and writes the result back. If the read yields
+// nothing, AppendBlock returns the block ALONE (that is its correct behaviour —
+// it is how a first draft is built), and the write then replaces a whole entry
+// with the newest note. Frontmatter, every earlier note, gone, and the write
+// reports success because it carried a valid blob sha.
+//
+// The empty case is not hypothetical. GitHub's contents API answers a blob over
+// 1 MB with an EMPTY content field and encoding "none", which base64-decodes
+// without error, so a "successful" read hands back zero bytes. Callers must treat
+// a false here as a refusal, not a reason to create the file.
+//
+// The fence must be FIRST: leading blank lines or an HTML comment before it mean
+// the file is not what the caller thinks it is, and guessing is the behaviour
+// this exists to prevent. A lone opening fence with no close is likewise refused.
+func HasFrontmatter(raw []byte) bool {
+	s := string(raw)
+	const fence = "---\n"
+	if !strings.HasPrefix(s, fence) {
+		return false
+	}
+	return strings.Contains(s[len(fence):], "\n---")
+}
+
+// NoteMarker renders the invisible idempotency marker an appended note carries,
+// keyed to that note. It is an HTML comment so it never renders in the entry a
+// human reviews or the catalog indexes.
+//
+// The key must identify ONE note. A marker matching any note would suppress
+// every note after the first — the original bug wearing a different hat.
+func NoteMarker(key string) string { return "<!-- runlore-note:" + key + " -->" }
+
+// HasNoteMarker reports whether raw already carries the note keyed by key, so a
+// replayed delivery appends nothing a second time.
+//
+// A comment is visibly duplicate and dies at merge; a duplicated APPEND is
+// permanent catalog content that kb_search then indexes twice. Retries are real:
+// the Slack event dedupe is per-process and its seen-set is cleared wholesale
+// when full, so a restart, a failover or a busy channel all replay.
+//
+// An empty key means "no idempotency", never "matches everything" — the latter
+// would drop every note from any caller that omitted a key.
+func HasNoteMarker(raw []byte, key string) bool {
+	if key == "" {
+		return false
+	}
+	return strings.Contains(string(raw), NoteMarker(key))
 }
 
 // UpdateLog records the entry in an OKF log: flat date-grouped entries, newest

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -171,6 +171,25 @@ func HasFrontmatter(raw []byte) bool {
 // every note after the first — the original bug wearing a different hat.
 func NoteMarker(key string) string { return "<!-- runlore-note:" + key + " -->" }
 
+// WithNoteMarker returns block carrying the marker for key, so the HasNoteMarker
+// check that runs before the NEXT append to the same entry finds it.
+//
+// It is the write half of that pair and lives beside it for the reason this
+// file's header gives: both forge clients build this block, and two copies of a
+// rule about the bundle's bytes drift. A marker written one way and looked for
+// another is not a cosmetic drift — it is the idempotency gone, silently, on
+// whichever forge fell behind.
+//
+// An empty key means "no idempotency", the same thing it means to HasNoteMarker:
+// the block is returned unmarked rather than carrying a keyless marker that
+// every later note would then match and be dropped by.
+func WithNoteMarker(block, key string) string {
+	if key == "" {
+		return block
+	}
+	return block + "\n\n" + NoteMarker(key)
+}
+
 // HasNoteMarker reports whether raw already carries the note keyed by key, so a
 // replayed delivery appends nothing a second time.
 //

--- a/internal/okf/bundle.go
+++ b/internal/okf/bundle.go
@@ -60,6 +60,69 @@ func UpdateIndex(existing []byte, e providers.KBEntry, entryPath string) []byte 
 	return []byte(strings.Join(slices.Insert(lines, end, line), "\n") + "\n")
 }
 
+// reservedBundleFiles are the OKF bundle files a curation PR touches ALONGSIDE
+// the entry it files (see UpdateIndex and UpdateLog, and the forge callers that
+// apply them). Subtracting them from a pull request's changed paths is what
+// leaves the entry itself.
+var reservedBundleFiles = []string{"index.md", "log.md"}
+
+// EntryFile picks the ONE catalog entry among a pull/merge request's changed
+// paths.
+//
+// It exists so a LATER commit onto that request — an operator note appended to
+// the entry it carries, see thread.Forge.AppendToEntryOnPR — can find the file
+// to edit without any caller having to remember where it was first written. A
+// RunLore curation request changes the entry plus, at most, the reserved pair
+// above, so what remains after removing them is the entry.
+//
+// Anything other than exactly one candidate is an ERROR rather than a guess.
+// The caller's next move is a commit into a pull request a human is reviewing,
+// and committing into the wrong file there is strictly worse than refusing:
+// refusing degrades to a comment, and a wrong write silently rewrites somebody
+// else's change with no signal that it happened.
+//
+// It lives here, beside the functions that put those reserved files on the
+// branch in the first place, and is shared by both forge clients for the reason
+// this file's header gives: two copies of a rule about the bundle's shape drift,
+// and a KB would then behave differently depending on which forge hosts it.
+func EntryFile(changed []string) (string, error) {
+	var entries []string
+	for _, p := range changed {
+		if !strings.HasSuffix(p, ".md") || slices.Contains(reservedBundleFiles, p) {
+			continue
+		}
+		entries = append(entries, p)
+	}
+	if len(entries) != 1 {
+		return "", fmt.Errorf("want exactly one catalog entry among the changed files, found %d: %v", len(entries), entries)
+	}
+	return entries[0], nil
+}
+
+// AppendBlock adds block to the end of an OKF entry's markdown, separated from
+// what is already there by one blank line and terminated by a newline.
+//
+// One blank line and NOTHING else: no "---" rule, no heading of its own. A
+// horizontal rule would be a second "---" in a file whose FIRST one delimits the
+// YAML frontmatter, and while every parser RunLore ships takes the first match
+// (see catalog.SplitFrontmatter, forge/github.frontmatterBlock), inviting a
+// reader of the raw file to wonder is not worth a divider. The blocks callers
+// append already open with their own heading, which separates them on the page.
+//
+// An empty block returns existing untouched — appending nothing must not rewrite
+// the file, since the caller's commit is a real change in a human's pull request.
+func AppendBlock(existing []byte, block string) []byte {
+	block = strings.Trim(block, "\n")
+	if block == "" {
+		return existing
+	}
+	cur := strings.TrimRight(string(existing), "\n")
+	if cur == "" {
+		return []byte(block + "\n")
+	}
+	return []byte(cur + "\n\n" + block + "\n")
+}
+
 // UpdateLog records the entry in an OKF log: flat date-grouped entries, newest
 // first, bold action word (§7). A nil/empty existing log gets the standard shape,
 // so callers CREATE log.md when the bundle lacks it — unlike index.md, its shape

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -148,3 +148,53 @@ func TestAppendBlockNormalisesSpacing(t *testing.T) {
 		t.Errorf("AppendBlock onto an empty file = %q, want no leading blank line", got)
 	}
 }
+
+// TestHasFrontmatterRefusesWhatWouldReplaceAnEntry is the guard that stands
+// between a read returning nothing and AppendBlock returning the note ALONE.
+// The two together are how an entry gets replaced by the newest note appended
+// to it, so the empty case is the one that matters most here.
+func TestHasFrontmatterRefusesWhatWouldReplaceAnEntry(t *testing.T) {
+	for name, tc := range map[string]struct {
+		content string
+		want    bool
+	}{
+		"a real entry":     {"---\ntype: Concept\n---\n\nbody\n", true},
+		"empty":            {"", false},
+		"plain markdown":   {"# Notes\n\nnot an entry\n", false},
+		"fence not first":  {"\n---\ntype: Concept\n---\n", false},
+		"fence unfinished": {"---", false},
+		"html then fence":  {"<!-- draft -->\n---\ntype: Concept\n---\n", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := HasFrontmatter([]byte(tc.content)); got != tc.want {
+				t.Errorf("HasFrontmatter(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNoteMarkerIsInvisibleAndKeyed: the marker must not render in the entry a
+// human or the catalog reads, and it must identify ONE note — a marker that
+// matched any note would suppress every note after the first, which is the
+// original bug wearing a different hat.
+func TestNoteMarkerIsInvisibleAndKeyed(t *testing.T) {
+	m := NoteMarker("abc123")
+	if !strings.HasPrefix(m, "<!--") || !strings.HasSuffix(m, "-->") {
+		t.Errorf("NoteMarker = %q, want an HTML comment so it never renders", m)
+	}
+	if !strings.Contains(m, "abc123") {
+		t.Errorf("NoteMarker = %q, want it to carry the key", m)
+	}
+	entry := []byte("---\ntype: Concept\n---\n\nnote one\n\n" + m + "\n")
+	if !HasNoteMarker(entry, "abc123") {
+		t.Error("HasNoteMarker must find the marker it wrote — otherwise a replay appends the note twice")
+	}
+	if HasNoteMarker(entry, "def456") {
+		t.Error("HasNoteMarker matched a DIFFERENT key — every later note in the thread would be silently dropped")
+	}
+	// An empty key means "no idempotency", never "matches everything": the latter
+	// would drop every note on any caller that omitted a key.
+	if HasNoteMarker(entry, "") {
+		t.Error("an empty key must never match")
+	}
+}

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -198,3 +198,30 @@ func TestNoteMarkerIsInvisibleAndKeyed(t *testing.T) {
 		t.Error("an empty key must never match")
 	}
 }
+
+// TestWithNoteMarkerRoundTripsThroughHasNoteMarker pins the two halves of the
+// idempotency pair against EACH OTHER, which is the only property that matters:
+// a block written by one forge and re-read by the append after it must be
+// recognised. Asserting the marker's bytes separately in each place is what
+// would let them drift apart while both files still passed their own tests.
+func TestWithNoteMarkerRoundTripsThroughHasNoteMarker(t *testing.T) {
+	entry := []byte("---\ntype: Concept\n---\n\nnote one\n")
+	appended := AppendBlock(entry, WithNoteMarker("### note two\n\nthe second note", "k2"))
+
+	if !HasNoteMarker(appended, "k2") {
+		t.Errorf("the marker WithNoteMarker wrote is not one HasNoteMarker finds — the next note would duplicate this one:\n%s", appended)
+	}
+	if !HasFrontmatter(appended) || !strings.Contains(string(appended), "note one") {
+		t.Errorf("appending the marked block lost what was already in the entry:\n%s", appended)
+	}
+	if n := strings.Count(string(appended), NoteMarker("k2")); n != 1 {
+		t.Errorf("marker written %d times, want exactly 1", n)
+	}
+
+	// An empty key is "no idempotency", the same thing it means to HasNoteMarker:
+	// no marker is written, rather than a keyless one every later note would then
+	// match and be dropped by.
+	if got := WithNoteMarker("### note two", ""); got != "### note two" {
+		t.Errorf("WithNoteMarker with no key = %q, want the block untouched", got)
+	}
+}

--- a/internal/okf/bundle_test.go
+++ b/internal/okf/bundle_test.go
@@ -85,3 +85,66 @@ func TestUpdateLogCreatesAndPrepends(t *testing.T) {
 		t.Fatalf("second same-day entry missing:\n%s", got)
 	}
 }
+
+// TestEntryFilePicksTheEntryNotTheBundleUpkeep: a RunLore curation request
+// changes the entry plus, at most, index.md and log.md. Only the entry is what
+// a later commit (an appended operator note) must edit — writing into log.md
+// instead would corrupt the bundle and lose the note in one move.
+func TestEntryFilePicksTheEntryNotTheBundleUpkeep(t *testing.T) {
+	got, err := EntryFile([]string{"index.md", "concepts/oom-1755.md", "log.md"})
+	if err != nil {
+		t.Fatalf("EntryFile: %v", err)
+	}
+	if got != "concepts/oom-1755.md" {
+		t.Errorf("EntryFile = %q, want the entry", got)
+	}
+}
+
+// TestEntryFileRefusesToGuess: the caller's next move is a commit into a pull
+// request a human is reviewing. Anything other than exactly one candidate must
+// be an error — a refusal degrades to a comment, while a wrong write silently
+// rewrites somebody else's change.
+func TestEntryFileRefusesToGuess(t *testing.T) {
+	for name, changed := range map[string][]string{
+		"nothing at all":     nil,
+		"upkeep only":        {"index.md", "log.md"},
+		"two entries":        {"concepts/a.md", "incidents/b.md"},
+		"no markdown at all": {"Makefile", "go.mod"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got, err := EntryFile(changed); err == nil {
+				t.Errorf("EntryFile(%v) = %q, want an error rather than a guess", changed, got)
+			}
+		})
+	}
+}
+
+func TestAppendBlockKeepsWhatIsAlreadyThere(t *testing.T) {
+	got := string(AppendBlock([]byte("---\ntype: Concept\n---\n\nfirst note\n"), "second note"))
+	want := "---\ntype: Concept\n---\n\nfirst note\n\nsecond note\n"
+	if got != want {
+		t.Errorf("AppendBlock =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// TestAppendBlockEmptyBlockChangesNothing: the caller's next move is a real
+// commit in a human's pull request, so appending nothing must not rewrite the
+// file — an empty-diff commit is noise a reviewer has to read.
+func TestAppendBlockEmptyBlockChangesNothing(t *testing.T) {
+	existing := []byte("body\n")
+	if got := string(AppendBlock(existing, "\n\n")); got != "body\n" {
+		t.Errorf("AppendBlock with an empty block = %q, want the file untouched", got)
+	}
+}
+
+// TestAppendBlockNormalisesSpacing pins the separation to exactly one blank
+// line however ragged either side is, so a note appended after a file that
+// already ends in three newlines does not drift further from one that does not.
+func TestAppendBlockNormalisesSpacing(t *testing.T) {
+	if got := string(AppendBlock([]byte("body\n\n\n"), "\n\nnote\n\n")); got != "body\n\nnote\n" {
+		t.Errorf("AppendBlock = %q, want exactly one blank line between the blocks", got)
+	}
+	if got := string(AppendBlock(nil, "note")); got != "note\n" {
+		t.Errorf("AppendBlock onto an empty file = %q, want no leading blank line", got)
+	}
+}

--- a/internal/providers/errors.go
+++ b/internal/providers/errors.go
@@ -70,3 +70,22 @@ func AttemptsOf(err error) int {
 	}
 	return 0
 }
+
+// ErrPRNotOpen reports that a pull/merge request a write was aimed at is no
+// longer open — merged, closed, or locked.
+//
+// It is a SENTINEL rather than a plain error because the caller's recovery
+// differs in kind. A transient forge failure means "try the other way of
+// recording this" — the thread responder degrades an entry append to a PR
+// comment. This means the opposite: the pull request is finished, so a comment
+// there is exactly the silent loss the open-check exists to prevent (a comment
+// on a merged request is never indexed by the catalog), and the note has to go
+// somewhere else entirely — a standalone entry of its own.
+//
+// It exists because the open-check and the write are two round trips with a
+// window between them, and the window is real: a reviewer merging a note PR
+// while an on-call is typing the next note into the thread is an ordinary
+// Tuesday, not a race that needs contriving. The write call already learns the
+// current state from the response it is reading anyway, so reporting it costs
+// nothing and closes the window at the only place it can be closed.
+var ErrPRNotOpen = errors.New("pull request is not open")

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -547,7 +547,7 @@ type ThreadNotifier interface {
 	Transport() string
 }
 
-// KBRoute names how a knowledge-base write landed on the forge. The two values
+// KBRoute names how a knowledge-base write landed on the forge. The values
 // mirror the labels the thread responder already reports on its
 // ThreadNotesWritten counter, so an announcement and the metric describing the
 // same write cannot disagree about which route it took.
@@ -555,12 +555,19 @@ type KBRoute string
 
 // The routes a knowledge-base write can take.
 const (
-	// KBRouteComment added the note as a comment on a KB pull request that was
-	// already open (the curator's, or one an earlier note in the same thread
-	// opened).
+	// KBRouteComment added the note as a comment on a KB pull request SOMEONE
+	// ELSE drafted — the curator's. There the note is review feedback on another
+	// author's draft: a human reconciles it at merge time, and until they do it
+	// is deliberately not part of the entry.
 	KBRouteComment KBRoute = "comment"
 	// KBRouteOpenPR opened a new standalone pull request for the note.
 	KBRouteOpenPR KBRoute = "open_pr"
+	// KBRouteAppend appended the note to the ENTRY FILE of a standalone note PR
+	// RunLore itself opened earlier in the same thread. It is a route of its own
+	// rather than a second spelling of KBRouteComment because the two land
+	// somewhere materially different: what this route writes is inside the entry
+	// the catalog gains when the PR merges, and what a comment writes is not.
+	KBRouteAppend KBRoute = "append"
 )
 
 // KBUpdate announces that a knowledge-base write ALREADY LANDED on the forge. It

--- a/internal/server/reserved_prefix_test.go
+++ b/internal/server/reserved_prefix_test.go
@@ -44,7 +44,7 @@ func (f *fakeSlackForge) CommentOnPR(context.Context, int, string) error {
 
 func (f *fakeSlackForge) IsPROpen(context.Context, int) (bool, error) { return true, nil }
 
-func (f *fakeSlackForge) AppendToEntryOnPR(context.Context, int, string) error {
+func (f *fakeSlackForge) AppendToEntryOnPR(context.Context, int, string, string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.appended++

--- a/internal/server/reserved_prefix_test.go
+++ b/internal/server/reserved_prefix_test.go
@@ -25,6 +25,7 @@ type fakeSlackForge struct {
 	mu        sync.Mutex
 	opened    int
 	commented int
+	appended  int
 }
 
 func (f *fakeSlackForge) OpenPR(context.Context, providers.KBEntry) (providers.Ref, error) {
@@ -43,10 +44,21 @@ func (f *fakeSlackForge) CommentOnPR(context.Context, int, string) error {
 
 func (f *fakeSlackForge) IsPROpen(context.Context, int) (bool, error) { return true, nil }
 
+func (f *fakeSlackForge) AppendToEntryOnPR(context.Context, int, string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.appended++
+	return nil
+}
+
+// counts sums EVERY knowledge-base write entry point, not only the two that
+// existed when this fake was written. A reserved command must reach none of
+// them, so a third route added later must be counted here or this fake would
+// keep reporting zero writes for a route it simply is not looking at.
 func (f *fakeSlackForge) counts() (opened, commented int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.opened, f.commented
+	return f.opened, f.commented + f.appended
 }
 
 // fakeSlackReplier is thread.Replier: it records every reply so the

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -4,6 +4,9 @@ package thread
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -48,10 +51,23 @@ type Forge interface {
 	// which treatment, and why the curator's PR deliberately still gets a
 	// comment.
 	//
-	// The forge locates the entry file from the pull request itself, so the
-	// contract here stays (number, body) — the same shape CommentOnPR takes, and
-	// no new state for the thread layer to persist and get wrong.
-	AppendToEntryOnPR(ctx context.Context, number int, body string) error
+	// The forge locates the entry file from the pull request itself, so no path
+	// is persisted here to go stale and misroute a commit later.
+	//
+	// key identifies this note so the write is IDEMPOTENT: an entry already
+	// carrying that key is left alone and success is reported. Unlike a comment,
+	// which is visibly duplicated conversation that dies at merge, a duplicated
+	// append is permanent catalog content that recall then serves twice — and the
+	// deliveries above this layer really do replay (see noteKey). The key is
+	// passed rather than derived from body inside the forge because body carries
+	// the provenance TIMESTAMP, so a retry renders different bytes; only this
+	// layer knows which inputs are stable.
+	//
+	// It may report providers.ErrPRNotOpen, which write() treats as the same case
+	// its own open-check does rather than as a failure to degrade around:
+	// commenting on a finished pull request is the silent loss that check exists
+	// to prevent.
+	AppendToEntryOnPR(ctx context.Context, number int, body, key string) error
 }
 
 // DefaultMaxNotesPerThread bounds how many knowledge writes one thread can make.
@@ -1149,9 +1165,18 @@ func noteTargets(tc Context) []noteTarget {
 func (r *Responder) addToPR(ctx context.Context, tc Context, n Note, at time.Time, num int, ours bool) (string, error) {
 	body := NoteBody(tc, n, at, r.maxNoteBytes())
 	if ours {
-		err := r.Forge.AppendToEntryOnPR(ctx, num, body)
+		err := r.Forge.AppendToEntryOnPR(ctx, num, body, noteKey(tc, n))
 		if err == nil {
 			return RouteAppend, nil
+		}
+		// The one failure that is NOT a reason to comment: the pull request
+		// finished between the open-check above and this write. A comment there is
+		// never indexed by the catalog, so falling back would be the silent loss
+		// the open-check exists to prevent, arriving through the window the check
+		// cannot cover. Passed up for write() to treat exactly as it treats its own
+		// closed-PR case — open a standalone entry instead.
+		if errors.Is(err, providers.ErrPRNotOpen) {
+			return "", err
 		}
 		r.log().Warn("thread: could not append the note to its entry; falling back to a comment, which the catalog will NOT index on merge",
 			"pr", num, "root", tc.Root, "err", err)
@@ -1160,6 +1185,40 @@ func (r *Responder) addToPR(ctx context.Context, tc Context, n Note, at time.Tim
 		return "", err
 	}
 	return RouteComment, nil
+}
+
+// noteKey is the stable identity of one note, used to make the entry append
+// idempotent (see okf.NoteMarker and Forge.AppendToEntryOnPR).
+//
+// It is needed because the layers above this one replay. internal/server dedups
+// Slack deliveries through a bounded, PER-PROCESS set that is wiped wholesale at
+// capacity (see seenSet), so a busy channel, a restart or a leader failover all
+// deliver the same message twice — and thread capture is detached from the ack,
+// so nothing downstream notices. As comments a replay was self-limiting: two
+// visibly identical comments on one pull request, both discarded at merge. As
+// appends it is two copies of the same knowledge in the catalog, indexed twice
+// and recalled twice, with no signal that either is a duplicate.
+//
+// The inputs are the ones that DO NOT move between a delivery and its replay:
+// the thread, the author, and the note's own text as written. Deliberately not
+// the rendered body, which carries the timestamp of the attempt — hashing that
+// yields a different key for the replay of the same note, which is the one case
+// this exists for. Deliberately not the thread's note counter either: a replay
+// re-enters write() at whatever count the registry has reached.
+//
+// Two genuinely identical notes from the same person in the same thread
+// therefore collapse into one. That is the right trade rather than a limitation:
+// the entry ends up saying what they said, once, and the alternative — a false
+// negative — is the permanent duplicate this is here to prevent.
+//
+// SHA-256 truncated to 16 hex characters. It is an identity, not a
+// authentication tag: the entry it is compared against is one RunLore wrote, and
+// note text reaching an entry has "<!" escaped out of it (see noteText), so a
+// marker cannot be forged into an entry to suppress a later note — which would
+// in any case require knowing that note's exact bytes in advance.
+func noteKey(tc Context, n Note) string {
+	sum := sha256.Sum256([]byte(tc.Root + "\x00" + n.Author + "\x00" + n.Text))
+	return hex.EncodeToString(sum[:])[:16]
 }
 
 // recordedOn renders the status line for a note that landed on a pull request
@@ -1283,6 +1342,17 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 			continue
 		}
 		route, err := r.addToPR(ctx, tc, n, at, num, candidate.ours)
+		// The PR was open a moment ago and is not any more — a reviewer merged it
+		// while this note was being written. Identical handling to the !open branch
+		// above, because it is the identical situation observed one round trip
+		// later: fall through and open a standalone entry. The two must not
+		// diverge, or a note that arrives a second too late is lost by a route the
+		// same note a second earlier survives.
+		if errors.Is(err, providers.ErrPRNotOpen) {
+			r.log().Info("thread: linked PR closed while the note was being written; opening a standalone note instead",
+				"pr", num, "root", tc.Root, "err", err)
+			continue
+		}
 		if err != nil {
 			return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), nil,
 				fmt.Errorf("comment on PR %d: %w", num, err)

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -21,18 +21,37 @@ import (
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
-// Forge is the write surface a thread note needs. It is a subset of
-// providers.CurationForge, which satisfies it — narrowed here so the responder
-// declares exactly the two calls it makes and can be faked in one struct.
+// Forge is the write surface a thread note needs. It is providers.CurationForge
+// plus two calls the curator has no use for — narrowed and restated here so the
+// responder declares exactly the calls it makes and can be faked in one struct.
 type Forge interface {
 	CommentOnPR(ctx context.Context, number int, body string) error
 	OpenPR(ctx context.Context, e providers.KBEntry) (providers.Ref, error)
 	// IsPROpen reports whether the pull/merge request numbered `number` is
-	// still open. write() calls this before commenting on a linked PR: a
-	// comment on a MERGED pull request is never indexed by the catalog, so
-	// commenting there would silently lose the human's knowledge while telling
+	// still open. write() calls this before recording a note on a linked PR: a
+	// comment on a MERGED pull request is never indexed by the catalog, and a
+	// commit on a merged PR's branch never reaches the base branch either, so
+	// writing there would silently lose the human's knowledge while telling
 	// them it was saved. github.Client and gitlab.Client both implement it.
 	IsPROpen(ctx context.Context, number int) (bool, error)
+	// AppendToEntryOnPR appends body to the knowledge-base ENTRY FILE the pull/
+	// merge request numbered `number` carries, as a further commit on that pull
+	// request's own branch. It never merges and never touches the base branch:
+	// the pull request stays the proposal and a human stays the gate.
+	//
+	// It is on this interface — rather than left to CommentOnPR, which the
+	// responder already has — because a comment and an entry are not two ways of
+	// writing the same thing. Only the entry is what the catalog gains when the
+	// pull request merges, so on the ONE pull request whose entry is RunLore's
+	// own note (Context.NoteURL), every note after the first has to go here or
+	// it never becomes knowledge at all. See write() for which pull request gets
+	// which treatment, and why the curator's PR deliberately still gets a
+	// comment.
+	//
+	// The forge locates the entry file from the pull request itself, so the
+	// contract here stays (number, body) — the same shape CommentOnPR takes, and
+	// no new state for the thread layer to persist and get wrong.
+	AppendToEntryOnPR(ctx context.Context, number int, body string) error
 }
 
 // DefaultMaxNotesPerThread bounds how many knowledge writes one thread can make.
@@ -304,16 +323,18 @@ func (a *KBAnnouncer) Drain(ctx context.Context) {
 // and start announcing a route name no consumer recognises — the moment either
 // side is renamed.
 //
-// write() sets Route from one of the two constants literally, so the default is
+// write() sets Route from one of the constants literally, so the default is
 // unreachable. It passes the value through rather than guessing at one of the
-// two, because an announcement describes a write that already landed and
-// mislabelling it is worse than reporting an unknown label honestly.
+// known routes, because an announcement describes a write that already landed
+// and mislabelling it is worse than reporting an unknown label honestly.
 func kbRoute(route string) providers.KBRoute {
 	switch route {
 	case RouteComment:
 		return providers.KBRouteComment
 	case RouteOpenPR:
 		return providers.KBRouteOpenPR
+	case RouteAppend:
+		return providers.KBRouteAppend
 	default:
 		return providers.KBRoute(route)
 	}
@@ -345,19 +366,28 @@ func (r *Responder) announce(ctx context.Context, tc Context, n Note, w *KBWrite
 	})
 }
 
-// The two routes a knowledge write can take, named once. They are both the
+// The routes a knowledge write can take, named once. They are both the
 // KBWrite.Route values a caller reads and the "route" attribute
 // ThreadNotesWritten is labelled with, deliberately the same strings: an
 // operator correlating a dashboard series with what a thread reported must not
 // have to know that two literals happened to agree.
 const (
-	// RouteComment: the note was added to a pull request that already exists —
-	// the curated PR this thread came from, or the standalone PR an earlier note
-	// in the same thread opened.
+	// RouteComment: the note was added as a comment on the CURATED pull request
+	// this thread came from — a draft somebody else wrote, on which the note is
+	// review feedback for a human to reconcile at merge time.
 	RouteComment = "comment"
 	// RouteOpenPR: the note had no open pull request to land on, so it opened a
 	// standalone Concept entry of its own (see ConceptEntry).
 	RouteOpenPR = "open_pr"
+	// RouteAppend: the note was appended to the entry file of the standalone PR
+	// an EARLIER note in this same thread opened — so the entry the catalog
+	// gains on merge carries every note in the thread, not only the first.
+	//
+	// It is separated from RouteComment on the metric for the reason the bug it
+	// closes was invisible for as long as it was: with both routes labelled
+	// "comment", nothing an operator could graph distinguished a note that
+	// becomes knowledge from one that is discarded when its pull request merges.
+	RouteAppend = "append"
 )
 
 // KBWrite describes a knowledge-base write that LANDED. write returns one only
@@ -373,7 +403,7 @@ const (
 // success it could not record, the duplicate-PR race, the stale sweep), which
 // is why the shape is worth the pointer.
 type KBWrite struct {
-	// Route is RouteComment or RouteOpenPR.
+	// Route is RouteComment, RouteAppend or RouteOpenPR.
 	Route string
 	// PR is the pull/merge request the note landed on or opened. Zero — and only
 	// zero — when the forge returned a URL carrying no parseable number, which
@@ -382,8 +412,10 @@ type KBWrite struct {
 	// URL is the pull request the human can open to read the note.
 	URL string
 	// Title is the entry title ConceptEntry generated, on RouteOpenPR only. It
-	// is empty on RouteComment, where the note joins an entry someone else
-	// already titled and RunLore generated no title of its own.
+	// is empty on RouteComment and RouteAppend, where the note joins an entry
+	// that already has a title — someone else's on the comment route, and one an
+	// earlier note in this same thread was already told about on the append
+	// route — so RunLore generated no title for THIS write.
 	//
 	// UNTRUSTED: it is built from the thread's alert-derived title. Redacted and
 	// flattened (see noteField), but not authored by RunLore.
@@ -1056,10 +1088,101 @@ func (r *Responder) record(ctx context.Context, tc Context, n Note) (string, err
 	return reply, nil
 }
 
+// noteTarget is one pull request write() may record a note on, plus the single
+// fact that decides HOW it records it: whether RunLore's own thread capture is
+// what opened that pull request.
+//
+// The distinction is the whole of issue #493. Both URLs used to be iterated as
+// a bare []string, and both got a comment — which is right for exactly one of
+// them and quietly lossy for the other:
+//
+//   - CuratedURL is the curator's draft. It has an author who is not RunLore, a
+//     body they wrote, and a review in progress. A note there is FEEDBACK, and a
+//     human decides at merge time what of it belongs in the entry. Rewriting
+//     their file from under them would be the wrong shape entirely.
+//
+//   - NoteURL is the standalone PR an earlier note in THIS thread opened. Its
+//     entry has no author but the operator and there is no draft to comment on,
+//     so a comment there is not feedback on anything — it is knowledge parked
+//     next to the entry instead of in it. Merge the PR and the catalog gains one
+//     entry holding the FIRST note; every later one stays behind as pull-request
+//     conversation the catalog never indexes, so kb_search and recall never see
+//     it. Four notes in, one out.
+//
+// Order is unchanged: the curated PR still wins when both are set and open.
+type noteTarget struct {
+	url string
+	// ours is true for the pull request thread capture itself opened, and is
+	// what selects the append route in addToPR. It is derived from WHICH context
+	// field the URL came from rather than from a label lookup on the forge: the
+	// registry already knows which PR it opened (Context.NoteURL), so asking the
+	// forge would be a round trip to re-learn a fact RunLore recorded itself —
+	// and one that fails open, on a network blip, straight back into the lossy
+	// route.
+	ours bool
+}
+
+// noteTargets lists the pull requests a note may land on, in priority order.
+func noteTargets(tc Context) []noteTarget {
+	return []noteTarget{{url: tc.CuratedURL}, {url: tc.NoteURL, ours: true}}
+}
+
+// addToPR records n on the already-open pull request numbered num and reports
+// which route landed it.
+//
+// On OUR OWN note PR the entry file is the destination, because that file is
+// the only part of the pull request the catalog gains on merge. On anyone
+// else's, a comment is — see noteTarget.
+//
+// The comment is also the FALLBACK when the append fails, and that ordering is
+// deliberate. An append is several forge calls against a branch (locate the
+// entry, read it, commit) and can fail for reasons that have nothing to do with
+// the human — a push race with another writer, a transient 5xx, a pull request
+// whose entry file has been renamed by a reviewer. Losing their words to any of
+// those would be a worse outcome than the bug this fixes: a comment is a
+// degraded record, not a missing one. It is logged at Warn because a note that
+// keeps degrading is exactly what nobody noticed the first time.
+//
+// Both routes send the SAME body — one NoteBody rendering, evaluated once — so
+// what a reviewer reads in the entry and what they would have read in a comment
+// can never drift.
+func (r *Responder) addToPR(ctx context.Context, tc Context, n Note, at time.Time, num int, ours bool) (string, error) {
+	body := NoteBody(tc, n, at, r.maxNoteBytes())
+	if ours {
+		err := r.Forge.AppendToEntryOnPR(ctx, num, body)
+		if err == nil {
+			return RouteAppend, nil
+		}
+		r.log().Warn("thread: could not append the note to its entry; falling back to a comment, which the catalog will NOT index on merge",
+			"pr", num, "root", tc.Root, "err", err)
+	}
+	if err := r.Forge.CommentOnPR(ctx, num, body); err != nil {
+		return "", err
+	}
+	return RouteComment, nil
+}
+
+// recordedOn renders the status line for a note that landed on a pull request
+// that already existed. The two routes get different words because they made
+// different promises: an appended note IS the entry the catalog will gain, and
+// a comment is a remark beside it that a human still has to fold in. A human
+// reading their own acknowledgement is the only one who can tell RunLore it
+// picked wrong, and they can only do that if the line says which it picked.
+func recordedOn(route string, num int, prURL string) string {
+	if route == RouteAppend {
+		return fmt.Sprintf("📝 Added to the knowledge-base entry on PR #%d — %s", num, Untrusted(prURL))
+	}
+	return fmt.Sprintf("📝 Noted on the knowledge-base PR #%d — %s", num, Untrusted(prURL))
+}
+
 // write routes the note to the open KB PR, to the PR this thread already opened,
 // or to a new standalone Concept PR — in that order. The returned *KBWrite
 // describes what actually landed, and is nil whenever nothing did — on error
 // and on the (non-error) global-rate-limit throttle alike.
+//
+// The first two destinations are not treated alike: a note on the curator's
+// draft is a comment, and a note on the standalone PR thread capture itself
+// opened is appended to that PR's entry file. See noteTarget.
 //
 // Reached from exactly two callers, both through record(): an explicit
 // "note:", and the note content a chat answer proposed for a freeform message
@@ -1125,8 +1248,8 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 	// The route is derived from the thread context alone. It is never influenced
 	// by the message text, and — through prNumberOn — never by a URL that names
 	// a forge RunLore does not write to.
-	for _, candidate := range []string{tc.CuratedURL, tc.NoteURL} {
-		num, ok := r.prNumberOn(candidate)
+	for _, candidate := range noteTargets(tc) {
+		num, ok := r.prNumberOn(candidate.url)
 		if !ok {
 			continue
 		}
@@ -1151,20 +1274,23 @@ func (r *Responder) write(ctx context.Context, tc Context, n Note, at time.Time)
 		if !open {
 			// A merged/closed PR is never indexed by the catalog, so a comment
 			// there would be silently lost while the human is told it was saved.
-			// Fall through to the standalone-Concept path instead — the same
-			// path the design doc's non-goal on amending a merged entry
+			// A commit appending to its entry is lost the same way: a merged PR's
+			// branch no longer reaches the base branch, and a closed one never
+			// will. Fall through to the standalone-Concept path instead — the
+			// same path the design doc's non-goal on amending a merged entry
 			// prescribes: "v1 opens a new entry that links the one it corrects."
 			r.log().Info("thread: linked PR is no longer open; opening a standalone note instead", "pr", num, "root", tc.Root)
 			continue
 		}
-		if err := r.Forge.CommentOnPR(ctx, num, NoteBody(tc, n, at, r.maxNoteBytes())); err != nil {
+		route, err := r.addToPR(ctx, tc, n, at, num, candidate.ours)
+		if err != nil {
 			return fmt.Sprintf("⚠️ I could not save that to the knowledge base: %s", Untrusted(err.Error())), nil,
 				fmt.Errorf("comment on PR %d: %w", num, err)
 		}
-		r.log().Info("thread: note recorded on KB PR", "pr", num, "root", tc.Root, "author", n.Author)
-		r.recordWrite(ctx, RouteComment)
-		return fmt.Sprintf("📝 Noted on the knowledge-base PR #%d — %s", num, Untrusted(candidate)),
-			&KBWrite{Route: RouteComment, PR: num, URL: candidate, Note: asWritten}, nil
+		r.log().Info("thread: note recorded on KB PR", "pr", num, "root", tc.Root, "route", route, "author", n.Author)
+		r.recordWrite(ctx, route)
+		return recordedOn(route, num, candidate.url),
+			&KBWrite{Route: route, PR: num, URL: candidate.url, Note: asWritten}, nil
 	}
 
 	entry := ConceptEntry(tc, n, at, r.maxNoteBytes())

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -75,9 +75,17 @@ type fakeForge struct {
 	// appends records every AppendToEntryOnPR call — the route a note takes onto
 	// the standalone PR thread capture itself opened, where the note has to reach
 	// the ENTRY FILE rather than the PR conversation the catalog never indexes.
+	//
+	// Recorded BEFORE appendErr is consulted, deliberately. A fake that returned
+	// the error without recording the call could not represent the failure that
+	// matters most here — the write LANDED and its response was lost — so a test
+	// named for the fallback could never observe the double-write that fallback
+	// then causes. The forge clients close that case by re-reading the entry
+	// (appendLanded); a fake unable to express it would pass either way.
 	appends []struct {
 		number int
 		body   string
+		key    string
 	}
 	opened  []providers.KBEntry
 	openURL string
@@ -85,7 +93,8 @@ type fakeForge struct {
 	commErr error
 	// appendErr, when set, fails every AppendToEntryOnPR — used to pin the
 	// degrade-to-a-comment fallback, so a forge that cannot rewrite the entry
-	// still keeps the human's words somewhere.
+	// still keeps the human's words somewhere. The call is still recorded, so a
+	// test can tell "it never ran" from "it ran and reported failure".
 	appendErr error
 	// prOpen reports the open state IsPROpen returns for a given PR number.
 	// A number absent from the map defaults to true (open) so every existing
@@ -134,17 +143,15 @@ func (f *fakeForge) CommentOnPR(_ context.Context, number int, body string) erro
 	return nil
 }
 
-func (f *fakeForge) AppendToEntryOnPR(_ context.Context, number int, body string) error {
+func (f *fakeForge) AppendToEntryOnPR(_ context.Context, number int, body, key string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.appendErr != nil {
-		return f.appendErr
-	}
 	f.appends = append(f.appends, struct {
 		number int
 		body   string
-	}{number, body})
-	return nil
+		key    string
+	}{number, body, key})
+	return f.appendErr
 }
 
 func (f *fakeForge) OpenPR(_ context.Context, e providers.KBEntry) (providers.Ref, error) {
@@ -497,6 +504,12 @@ func TestHandleAppendFailureFallsBackToCommenting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("a failed append must degrade to a comment, not to an error: %v", err)
 	}
+	// The append must have been ATTEMPTED. Without this the test passes just as
+	// well against a responder that never tries the entry at all — which is the
+	// bug #493 fixed, reintroduced and reported as a fallback.
+	if len(f.appends) != 1 {
+		t.Fatalf("appends = %d, want 1 — the comment is a FALLBACK, reached only after trying the entry", len(f.appends))
+	}
 	if len(f.comments) != 1 || f.comments[0].number != 77 {
 		t.Fatalf("the note must still land as a comment; comments = %+v", f.comments)
 	}
@@ -506,6 +519,131 @@ func TestHandleAppendFailureFallsBackToCommenting(t *testing.T) {
 	if !strings.Contains(reply, "77") {
 		t.Errorf("the reply must still name where the note landed: %q", reply)
 	}
+}
+
+// TestHandleAppendOntoAClosedPRDoesNotFallBackToCommenting is the ONE append
+// failure that must not degrade to a comment.
+//
+// The open-check and the write are two round trips, and a reviewer merging a
+// note PR while an on-call is typing the next note falls between them. Past that
+// merge both remaining options are silent losses — a commit onto a merged
+// branch never reaches base, and a comment on a merged PR is never indexed by
+// the catalog — so the forge reports providers.ErrPRNotOpen and this must be
+// handled exactly like the open-check's own closed-PR case: open a standalone
+// entry. A note arriving a second too late must not be lost by a route the same
+// note a second earlier survives.
+func TestHandleAppendOntoAClosedPRDoesNotFallBackToCommenting(t *testing.T) {
+	f := &fakeForge{appendErr: fmt.Errorf("github PR 77 is %q: %w", "merged", providers.ErrPRNotOpen)}
+	r := newTestResponder(t, f)
+	tc := Context{Root: "111.222", Title: "OOM", NoteURL: "https://github.com/o/r/pull/77"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	reply, err := r.Handle(context.Background(), tc, "alice", "note: spot reclaim")
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(f.comments) != 0 {
+		t.Fatalf("must never comment onto a PR that closed under the write; comments = %+v", f.comments)
+	}
+	if len(f.opened) != 1 {
+		t.Fatalf("opened = %d, want 1 — a finished PR means a standalone entry, the same answer the open-check gives", len(f.opened))
+	}
+	if !strings.Contains(reply, "99") {
+		t.Errorf("the reply must name the standalone PR it opened: %q", reply)
+	}
+}
+
+// TestNoteKeyIsStableAcrossARetryAndUniquePerNote pins the idempotency key the
+// entry append is made safe with.
+//
+// Stable, because the deliveries above this layer replay and a replayed APPEND
+// is permanent duplicate catalog content (a replayed comment merely looked
+// silly). The obvious key — a hash of the rendered body — does NOT have this
+// property, which is the whole reason the key is computed here: the body carries
+// the provenance timestamp, so the replay of one note renders different bytes
+// and would sail straight past its own marker.
+//
+// Unique, because a key that collided would suppress a genuinely different note
+// while telling its author it was saved.
+func TestNoteKeyIsStableAcrossARetryAndUniquePerNote(t *testing.T) {
+	tc := Context{Root: "111.222"}
+	base := HumanNote("alice", "it was a spot reclaim")
+
+	if got, want := noteKey(tc, base), noteKey(tc, base); got != want {
+		t.Fatalf("noteKey is not deterministic: %q vs %q", got, want)
+	}
+	// The retry: same thread, same author, same words, a later attempt. The KEY
+	// must not move even though the rendered body does.
+	early := NoteBody(tc, base, noteAt, DefaultMaxNoteBytes)
+	late := NoteBody(tc, base, noteAt.Add(9*time.Minute), DefaultMaxNoteBytes)
+	if early == late {
+		t.Fatal("test is not exercising the case — the rendered body must differ between attempts")
+	}
+	// The key is computed from tc and n alone, neither of which the timestamp
+	// touches, so the determinism check above IS the survival property: a key
+	// derived from `early` and one derived from `late` could not both equal it.
+	if strings.Contains(early, noteKey(tc, base)) || strings.Contains(late, noteKey(tc, base)) {
+		t.Error("the key must not be a function of the rendered body — that is what breaks across a retry")
+	}
+
+	seen := map[string]string{}
+	for name, n := range map[string]struct {
+		tc Context
+		n  Note
+	}{
+		"the note":         {tc, base},
+		"different text":   {tc, HumanNote("alice", "it was the CNI")},
+		"different author": {tc, HumanNote("bob", "it was a spot reclaim")},
+		"different thread": {Context{Root: "333.444"}, base},
+	} {
+		k := noteKey(n.tc, n.n)
+		if other, dup := seen[k]; dup {
+			t.Errorf("%q and %q share a key — one of them would be silently dropped", name, other)
+		}
+		seen[k] = name
+	}
+	// The model-drafted note carries the same TEXT as the human one, so it shares
+	// the key deliberately: it is the same sentence landing in the same entry, and
+	// filing it twice is exactly what the marker exists to prevent.
+	if noteKey(tc, base) != noteKey(tc, ProposedNote("alice", "what happened?", "it was a spot reclaim")) {
+		t.Error("identical filed text in one thread must share a key regardless of which route proposed it")
+	}
+}
+
+// TestHandlePassesAStableKeyToTheForge is the wiring half: the key the forge is
+// given must be the one noteKey computes, and it must repeat across a replayed
+// delivery. A responder that passed "" (or a fresh value per call) would compile,
+// pass every other test here, and leave the append with no idempotency at all.
+func TestHandlePassesAStableKeyToTheForge(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	tc := Context{Root: "111.222", Title: "OOM", NoteURL: "https://github.com/o/r/pull/77"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// The same message delivered twice — what a restart or a wiped dedup set
+	// produces upstream.
+	for i := range 2 {
+		cur, _ := r.Registry.Get("111.222")
+		if _, err := r.Handle(context.Background(), cur, "alice", "note: spot reclaim"); err != nil {
+			t.Fatalf("Handle %d: %v", i, err)
+		}
+	}
+	if len(f.appends) != 2 {
+		t.Fatalf("appends = %d, want 2 — this test needs both deliveries to reach the forge", len(f.appends))
+	}
+	want := noteKey(tc, HumanNote("alice", "spot reclaim"))
+	if f.appends[0].key != want {
+		t.Errorf("key = %q, want %q — the forge cannot dedup a key this layer never sends", f.appends[0].key, want)
+	}
+	if f.appends[0].key != f.appends[1].key {
+		t.Errorf("a replayed delivery sent a different key (%q then %q); the forge would append the note twice",
+			f.appends[0].key, f.appends[1].key)
+	}
+
 }
 
 func TestHandlePerThreadCap(t *testing.T) {

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -72,10 +72,21 @@ type fakeForge struct {
 		number int
 		body   string
 	}
+	// appends records every AppendToEntryOnPR call — the route a note takes onto
+	// the standalone PR thread capture itself opened, where the note has to reach
+	// the ENTRY FILE rather than the PR conversation the catalog never indexes.
+	appends []struct {
+		number int
+		body   string
+	}
 	opened  []providers.KBEntry
 	openURL string
 	openErr error
 	commErr error
+	// appendErr, when set, fails every AppendToEntryOnPR — used to pin the
+	// degrade-to-a-comment fallback, so a forge that cannot rewrite the entry
+	// still keeps the human's words somewhere.
+	appendErr error
 	// prOpen reports the open state IsPROpen returns for a given PR number.
 	// A number absent from the map defaults to true (open) so every existing
 	// test — none of which sets prOpen — keeps exercising the "comment on the
@@ -123,6 +134,19 @@ func (f *fakeForge) CommentOnPR(_ context.Context, number int, body string) erro
 	return nil
 }
 
+func (f *fakeForge) AppendToEntryOnPR(_ context.Context, number int, body string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.appendErr != nil {
+		return f.appendErr
+	}
+	f.appends = append(f.appends, struct {
+		number int
+		body   string
+	}{number, body})
+	return nil
+}
+
 func (f *fakeForge) OpenPR(_ context.Context, e providers.KBEntry) (providers.Ref, error) {
 	if f.entered != nil {
 		f.entered <- struct{}{}
@@ -141,12 +165,18 @@ func (f *fakeForge) OpenPR(_ context.Context, e providers.KBEntry) (providers.Re
 	return providers.Ref{URL: url}, nil
 }
 
-// counts returns the number of comments and PRs opened so far, taken under
-// the lock so a concurrency test can read them safely.
+// counts returns the number of writes onto an EXISTING pull request (comments
+// plus entry appends) and the number of PRs opened so far, taken under the lock
+// so a concurrency test can read them safely.
+//
+// The two existing-PR routes are summed rather than reported separately because
+// every caller of this asks the same question — "did the second writer reuse
+// the first writer's PR instead of opening another one?" — and the answer must
+// not depend on which of the two ways it recorded the note.
 func (f *fakeForge) counts() (comments, opened int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return len(f.comments), len(f.opened)
+	return len(f.comments) + len(f.appends), len(f.opened)
 }
 
 func newTestResponder(t *testing.T, f *fakeForge) *Responder {
@@ -386,9 +416,25 @@ func TestHandleNoteOpensStandalonePRWhenNoneLinked(t *testing.T) {
 	}
 }
 
-func TestHandleSecondNoteCommentsOnTheFirstNotesPR(t *testing.T) {
+// TestHandleEveryNoteAfterTheFirstReachesTheEntry closes issue #493, and it is
+// the whole point of the append route.
+//
+// The behaviour it replaced: the first note opened a standalone Concept PR and
+// every later note was a COMMENT on it. Only the first note was ever in the
+// entry file, so merging the PR gave the catalog one entry holding one note
+// while the rest stayed behind as pull-request conversation — never indexed,
+// never returned by kb_search, never recalled. Four notes went in and one came
+// out, and the field report that produced this issue was exactly that: three
+// notes lost on one thread.
+//
+// So the assertion is not "the second note reused the first note's PR" (the old
+// test asserted that much and passed throughout the bug). It is that the note
+// reached the ENTRY, which is the only part of that pull request the catalog
+// gains on merge — hence the body check, not merely a call count.
+func TestHandleEveryNoteAfterTheFirstReachesTheEntry(t *testing.T) {
 	f := &fakeForge{}
 	r := newTestResponder(t, f)
+	r.MaxNotesPerThread = 4 // the four notes of the field report this issue came from
 	tc := Context{Root: "111.222", Title: "OOM"}
 	if err := r.Registry.Put(tc); err != nil {
 		t.Fatalf("Put: %v", err)
@@ -397,19 +443,68 @@ func TestHandleSecondNoteCommentsOnTheFirstNotesPR(t *testing.T) {
 	if _, err := r.Handle(context.Background(), tc, "alice", "note: first"); err != nil {
 		t.Fatalf("first Handle: %v", err)
 	}
-	refreshed, _ := r.Registry.Get("111.222")
-	if _, err := r.Handle(context.Background(), refreshed, "bob", "note: second"); err != nil {
-		t.Fatalf("second Handle: %v", err)
+	notes := []string{"second", "third", "fourth"}
+	for _, text := range notes {
+		refreshed, _ := r.Registry.Get("111.222")
+		reply, err := r.Handle(context.Background(), refreshed, "bob", "note: "+text)
+		if err != nil {
+			t.Fatalf("Handle %q: %v", text, err)
+		}
+		// The acknowledgement has to say which of the two it did: "noted ON the
+		// PR" and "added to the ENTRY" are different promises about whether the
+		// knowledge survives the merge, and the human reading it is the only one
+		// who can tell RunLore it picked wrong.
+		if !strings.Contains(reply, "Added to the knowledge-base entry on PR #99") {
+			t.Errorf("the reply for %q must say the note went into the entry: %q", text, reply)
+		}
 	}
 
 	if len(f.opened) != 1 {
 		t.Fatalf("opened = %d, want exactly 1 — a thread opens at most one standalone PR", len(f.opened))
 	}
-	if len(f.comments) != 1 {
-		t.Fatalf("comments = %d, want 1 (the second note)", len(f.comments))
+	if len(f.comments) != 0 {
+		t.Fatalf("comments = %d, want 0 — a note on RunLore's OWN note PR belongs in the entry, "+
+			"not in a conversation the catalog never indexes: %+v", len(f.comments), f.comments)
 	}
-	if f.comments[0].number != 99 {
-		t.Errorf("second note went to PR %d, want 99 (the first note's PR)", f.comments[0].number)
+	if len(f.appends) != len(notes) {
+		t.Fatalf("appends = %d, want %d — every note after the first must reach the entry", len(f.appends), len(notes))
+	}
+	for i, text := range notes {
+		if f.appends[i].number != 99 {
+			t.Errorf("note %q appended to PR %d, want 99 (the first note's PR)", text, f.appends[i].number)
+		}
+		if !strings.Contains(f.appends[i].body, text) {
+			t.Errorf("the entry append for note %q lost its text: %s", text, f.appends[i].body)
+		}
+	}
+}
+
+// TestHandleAppendFailureFallsBackToCommenting pins the degradation. An append
+// is several forge calls against a branch and can fail for reasons that have
+// nothing to do with the human — a push race, a transient 5xx, a reviewer who
+// renamed the entry file. Losing their words to any of those would be worse
+// than the bug #493 fixed, so the note still lands, as a comment, and the reply
+// still tells them where.
+func TestHandleAppendFailureFallsBackToCommenting(t *testing.T) {
+	f := &fakeForge{appendErr: errors.New("409 conflict")}
+	r := newTestResponder(t, f)
+	tc := Context{Root: "111.222", Title: "OOM", NoteURL: "https://github.com/o/r/pull/77"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	reply, err := r.Handle(context.Background(), tc, "alice", "note: spot reclaim")
+	if err != nil {
+		t.Fatalf("a failed append must degrade to a comment, not to an error: %v", err)
+	}
+	if len(f.comments) != 1 || f.comments[0].number != 77 {
+		t.Fatalf("the note must still land as a comment; comments = %+v", f.comments)
+	}
+	if len(f.opened) != 0 {
+		t.Fatalf("a failed append must not escalate to opening another PR; opened = %d", len(f.opened))
+	}
+	if !strings.Contains(reply, "77") {
+		t.Errorf("the reply must still name where the note landed: %q", reply)
 	}
 }
 
@@ -918,8 +1013,11 @@ func TestHandleFallsBackToNoteURLWhenCuratedURLIsMerged(t *testing.T) {
 	if len(f.opened) != 0 {
 		t.Fatalf("must not open a third PR when NoteURL is still open; opened = %d", len(f.opened))
 	}
-	if len(f.comments) != 1 || f.comments[0].number != 77 {
-		t.Fatalf("must fall back to the still-open NoteURL; comments = %+v", f.comments)
+	// Appended, not commented: NoteURL is RunLore's own note PR whichever way the
+	// routing reached it, so falling back to it must not fall back to the lossy
+	// route as well.
+	if len(f.appends) != 1 || f.appends[0].number != 77 {
+		t.Fatalf("must fall back to the still-open NoteURL's entry; appends = %+v, comments = %+v", f.appends, f.comments)
 	}
 }
 
@@ -991,6 +1089,45 @@ func TestHandlePrefersCuratedURLOverNoteURL(t *testing.T) {
 	}
 }
 
+// TestHandleNeverRewritesTheCuratorsEntry is the half of issue #493 that must
+// NOT change, and it is the one with a real cost if it ever does.
+//
+// A curated PR has an author who is not RunLore, a body they wrote, and a review
+// in progress. A note there is FEEDBACK on their draft — a human decides at
+// merge time what of it belongs in the entry — so commenting is correct, and it
+// stays correct however many notes a thread produces. Appending would have
+// RunLore silently rewriting a human's file under them, mid-review, on the word
+// of anyone who can type in a chat channel.
+//
+// Every note in the thread is checked, not only the first: the routing decision
+// is taken per write, so a rule that held once and drifted on the second note
+// would be exactly as damaging.
+func TestHandleNeverRewritesTheCuratorsEntry(t *testing.T) {
+	f := &fakeForge{}
+	r := newTestResponder(t, f)
+	tc := Context{Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"}
+	if err := r.Registry.Put(tc); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	for _, text := range []string{"first", "second", "third"} {
+		cur, _ := r.Registry.Get("111.222")
+		reply, err := r.Handle(context.Background(), cur, "alice", "note: "+text)
+		if err != nil {
+			t.Fatalf("Handle %q: %v", text, err)
+		}
+		if !strings.Contains(reply, "Noted on the knowledge-base PR #42") {
+			t.Errorf("the reply for %q must say the note was recorded ON the PR, not written into it: %q", text, reply)
+		}
+	}
+	if len(f.appends) != 0 {
+		t.Fatalf("RunLore must never rewrite an entry somebody else drafted; appends = %+v", f.appends)
+	}
+	if len(f.comments) != 3 {
+		t.Fatalf("comments = %d, want 3 — every note on a curated PR is review feedback", len(f.comments))
+	}
+}
+
 // TestHandleThrottlePathLogsAndIncrementsCounter pins the fix for the defect
 // where a global-window throttle returned a reply string with no log line and
 // no metric: an operator had no way to tell the feature was throttling at
@@ -1048,8 +1185,10 @@ func TestHandleThrottlePathWithNilMetricsDoesNotPanic(t *testing.T) {
 
 // TestHandleSuccessfulWritesIncrementCounterByRoute pins the sibling fix: the
 // audit noted notes-written was slog.Info only, with no metric, so an
-// operator could see throttling but not volume. Both landing routes must
-// increment ThreadNotesWritten, distinguished by the route label.
+// operator could see throttling but not volume. EVERY landing route must
+// increment ThreadNotesWritten, distinguished by the route label — including
+// the append route, which was added precisely because nothing an operator could
+// graph distinguished a note that becomes knowledge from one that does not.
 func TestHandleSuccessfulWritesIncrementCounterByRoute(t *testing.T) {
 	f := &fakeForge{}
 	r := newTestResponder(t, f)
@@ -1072,9 +1211,20 @@ func TestHandleSuccessfulWritesIncrementCounterByRoute(t *testing.T) {
 		t.Fatalf("Handle: %v", err)
 	}
 
+	appendTC := Context{Root: "c", NoteURL: "https://github.com/o/r/pull/77"}
+	if err := r.Registry.Put(appendTC); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if _, err := r.Handle(context.Background(), appendTC, "carol", "note: via entry append"); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(f.appends) != 1 {
+		t.Fatalf("appends = %d, want 1 — this case is only meaningful if it took the append route", len(f.appends))
+	}
+
 	got, ok := read("runlore_thread_notes_written_total")
-	if !ok || got != 2 {
-		t.Errorf("runlore_thread_notes_written_total = %d (ok=%v), want 2 (one per landed route)", got, ok)
+	if !ok || got != 3 {
+		t.Errorf("runlore_thread_notes_written_total = %d (ok=%v), want 3 (one per landed route)", got, ok)
 	}
 }
 
@@ -3159,6 +3309,39 @@ func TestAnnounceALandedWrite(t *testing.T) {
 			t.Error("Title is empty; the open_pr route generates one and the announcement must name it")
 		}
 	})
+
+	t.Run("append route", func(t *testing.T) {
+		f := &fakeForge{}
+		r, sink := newAnnouncingResponder(t, f)
+		const prURL = "https://github.com/o/r/pull/77"
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", Title: "OOM", NoteURL: prURL})
+
+		if _, err := r.Handle(context.Background(), tc, "bob", "<@U0BOT> note: and the fix was a taint"); err != nil {
+			t.Fatalf("Handle: %v", err)
+		}
+		drainAnnouncements(t, r)
+
+		got := sink.updates()
+		if len(got) != 1 {
+			t.Fatalf("announcements = %d, want exactly 1 per landed write", len(got))
+		}
+		// Title is empty here for the same reason as on the comment route: the
+		// entry already had a title, generated when the FIRST note in this thread
+		// opened the PR, and this write generated none of its own.
+		want := providers.KBUpdate{
+			Transport: "slack",
+			Root:      "111.222",
+			Route:     providers.KBRouteAppend,
+			PR:        77,
+			URL:       prURL,
+			Author:    "bob",
+			Note:      "and the fix was a taint",
+			At:        noteAt,
+		}
+		if got[0] != want {
+			t.Errorf("announcement =\n%+v\nwant\n%+v", got[0], want)
+		}
+	})
 }
 
 // TestAnnounceNamesItsOriginatingTransportAndRoot pins the half of the event a
@@ -3649,7 +3832,7 @@ func TestAnnounceCarriesTheModelDraftedNote(t *testing.T) {
 }
 
 // TestKBRouteVocabulariesAgree pins the mapping between this package's route
-// names and the providers vocabulary the event uses. They spell the two routes
+// names and the providers vocabulary the event uses. They spell the routes
 // identically today; a direct string conversion would keep compiling — and
 // start emitting a route no consumer recognises — the moment either side is
 // renamed.
@@ -3660,9 +3843,9 @@ func TestAnnounceCarriesTheModelDraftedNote(t *testing.T) {
 // values whatever: rename RouteComment to "commented" and the switch still
 // matches it, still returns the providers constant, and the assertion still
 // holds while every dashboard series and every consumer reading the old word
-// goes quiet. These four strings are a wire vocabulary — RouteComment and
-// RouteOpenPR are also the "route" attribute ThreadNotesWritten is labelled
-// with (see their doc comment), and the providers pair is what a KBUpdate
+// goes quiet. These strings are a wire vocabulary — RouteComment, RouteOpenPR
+// and RouteAppend are also the "route" attribute ThreadNotesWritten is labelled
+// with (see their doc comment), and the providers trio is what a KBUpdate
 // consumer switches on — so changing one is an operator-visible break that
 // belongs in a diff.
 func TestKBRouteVocabulariesAgree(t *testing.T) {
@@ -3673,8 +3856,10 @@ func TestKBRouteVocabulariesAgree(t *testing.T) {
 	}{
 		{"RouteComment", RouteComment, "comment"},
 		{"RouteOpenPR", RouteOpenPR, "open_pr"},
+		{"RouteAppend", RouteAppend, "append"},
 		{"providers.KBRouteComment", string(providers.KBRouteComment), "comment"},
 		{"providers.KBRouteOpenPR", string(providers.KBRouteOpenPR), "open_pr"},
+		{"providers.KBRouteAppend", string(providers.KBRouteAppend), "append"},
 	} {
 		if tc.got != tc.want {
 			t.Errorf("%s = %q, want %q — this word is on a metric label or in a delivered event, "+
@@ -3686,5 +3871,8 @@ func TestKBRouteVocabulariesAgree(t *testing.T) {
 	}
 	if got := kbRoute(RouteOpenPR); got != providers.KBRouteOpenPR {
 		t.Errorf("kbRoute(%q) = %q, want %q", RouteOpenPR, got, providers.KBRouteOpenPR)
+	}
+	if got := kbRoute(RouteAppend); got != providers.KBRouteAppend {
+		t.Errorf("kbRoute(%q) = %q, want %q", RouteAppend, got, providers.KBRouteAppend)
 	}
 }

--- a/website/content/docs/concepts/reviewing-knowledge.md
+++ b/website/content/docs/concepts/reviewing-knowledge.md
@@ -53,6 +53,14 @@ RunLore files it against that investigation's KB pull request, or opens a
 standalone note PR when there is none, and replies with a link to what it wrote.
 Your words are recorded verbatim, attributed to you.
 
+Notes accumulate. On the investigation's own KB pull request each note is a
+comment — review feedback on a draft somebody else wrote, which a human folds in
+at merge time. On a standalone note PR, where the entry is nothing but your
+notes, every note after the first is **appended to the entry itself**, so a
+conversation that refines an answer — the cause, then the proof, then the fix —
+merges as one entry holding all of it rather than only the opening statement.
+The reply tells you which of the two happened.
+
 Optionally, with a `model.chat` block configured, plain questions in the thread are
 answered too — from the investigation's own evidence — and RunLore proposes a note
 itself when your message contained something durable. A model-drafted note is


### PR DESCRIPTION
Closes #493.

When a thread has no curator-authored KB PR — instant recall, a `no_action` verdict, or a finding below `curate.min_confidence` — the first `@runlore note:` opens a standalone `Concept` PR. **Every subsequent note was recorded as a comment on that PR.** Only the first reached the entry file. Four notes went in; one came out, and `kb_search` and recall never saw the rest.

The cause is one line: `responder.go:1128` iterated `[]string{tc.CuratedURL, tc.NoteURL}` and both reached `CommentOnPR`. Nothing distinguished the curator's PR from the one thread capture opened itself — even though `Context.NoteURL` is documented as "the standalone PR **THIS thread** opened". The discriminator was already in the context, unused.

That shape is exactly where a conversation *refines* an answer: first note states the cause, later notes add the proof, the fix, the caveat. Only the opening statement survived.

## One correction to the issue

**The stale sweep does not discard the comments** — GitHub keeps them on a closed PR, and `staleOperatorNoteComment` invites reopening. What was lost is *catalog membership*: comments are never indexed, so recall could not see them either way. This closes that; the sweep is unchanged.

## The fix

`noteTarget{url, ours}` replaces the bare `[]string`. **`ours` is derived from which context field the URL came from, not by reading the `runlore-operator-note` label back off the forge** — the registry already recorded which PR it opened, and a label lookup would fail open on a network blip straight back into the lossy route.

- `CuratedURL` → `CommentOnPR`, unchanged and still test-pinned. Appending there would have RunLore rewriting a human's file mid-review.
- `NoteURL` → append to the entry file.

**Interface widening**, because `Forge` had no way to edit a file: one method, `AppendToEntryOnPR(ctx, number, body)`, the same shape as `CommentOnPR`, so the fake stays one struct and the thread layer persists no new state. The forge locates the entry **from the PR itself** — read its head branch, list its changed paths, subtract the reserved `index.md`/`log.md` — and **errors rather than guessing** when that does not leave exactly one entry. The alternative, widening `providers.Ref` with a path, would have added persisted registry state that can go stale and misroute a commit.

**Append with a comment fallback**, not the issue's "comment *and* append": once the entry carries the note, a comment adds nothing, and the fallback covers the same failure the double-write hedges against at one forge call instead of two on the happy path. It logs at Warn.

A third route `append` is threaded through `KBWrite.Route`, `providers.KBRouteAppend` and the `ThreadNotesWritten` metric label, with distinct reply and announcement wording. **With both routes labelled `comment`, nothing an operator could graph distinguished a note that becomes knowledge from one discarded at merge** — which is a large part of why this went unnoticed.

## Testing

26 mutations, all killed. The two that matter most, re-verified independently: reverting `NoteURL` to the comment route fails `TestHandleEveryNoteAfterTheFirstReachesTheEntry`; letting `CuratedURL` take the append route fails `TestHandleNeverRewritesTheCuratorsEntry`. The old behaviour was *pinned* by `TestHandleSecondNoteCommentsOnTheFirstNotesPR`, which passed at `main` — that test was the bug, written down.

Two mutations initially failed to compile and were rerun in compiling form; only the compiling variants were counted.

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`.
