### PR TITLE
feat(thread): route a knowledge-base announcement into the thread it came from

### DIFF
--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -115,10 +115,10 @@ func ThreadCaptureDeliverable(cfg *config.Config, log *slog.Logger) bool {
 //
 // notifier is the process's fan-out sink, and it is here for the announcement
 // half: with notify.thread.announce_kb_updates on, a landed knowledge write is
-// broadcast to every configured notifier's OWN channel or room (see
-// buildKBAnnouncer), never back into the thread the reply already went to. It
-// may be nil — the log-only path builds no notifier at all — which is one of
-// the two ways announcements end up off.
+// broadcast to every configured notifier — its own channel or room by default,
+// or into the originating thread when the key selects that (see
+// buildKBAnnouncer). It may be nil — the log-only path builds no notifier at all
+// — which is one of the two ways announcements end up off.
 func buildThreadResponder(cfg *config.Config, threadRegistry *thread.Registry, forge thread.Forge, chat *thread.Chat, notifier *notify.Multi, metrics *telemetry.Metrics, log *slog.Logger) *thread.Responder {
 	return &thread.Responder{
 		Forge:             forge,
@@ -163,13 +163,14 @@ func buildKBAnnouncer(cfg *config.Config, notifier *notify.Multi, log *slog.Logg
 	if msg := KBAnnounceInertWarning(cfg, sinks); msg != "" {
 		log.Warn(msg)
 	}
-	if !cfg.Notify.Thread.AnnounceKBUpdates || sinks == 0 {
+	if !cfg.Notify.Thread.AnnounceKBUpdates.On() || sinks == 0 {
 		return nil
 	}
 	log.Info("thread knowledge-base announcements enabled",
 		"notifiers", sinks,
-		"note", "each configured notifier that implements the announcement capability receives them, in its own channel or room; the thread reply is unchanged")
-	return thread.NewKBAnnouncer(notifier, log)
+		"delivery", string(cfg.Notify.Thread.AnnounceKBUpdates),
+		"note", "each configured notifier that implements the announcement capability receives them; a thread delivery reaches the originating thread on its own transport and the channel on every other sink; the thread reply is unchanged")
+	return thread.NewKBAnnouncer(notifier, cfg.Notify.Thread.AnnounceKBUpdates.Delivery(), log)
 }
 
 // KBAnnounceInertWarning reports that notify.thread.announce_kb_updates is on
@@ -197,7 +198,7 @@ func buildKBAnnouncer(cfg *config.Config, notifier *notify.Multi, log *slog.Logg
 // still written and the human in the thread is still answered. Only the
 // broadcast is missing.
 func KBAnnounceInertWarning(cfg *config.Config, sinks int) string {
-	if !cfg.Notify.Thread.AnnounceKBUpdates {
+	if !cfg.Notify.Thread.AnnounceKBUpdates.On() {
 		return ""
 	}
 	if sinks == 0 {

--- a/internal/app/notify_test.go
+++ b/internal/app/notify_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -828,21 +829,27 @@ func TestBuildThreadResponderCarriesTheChatLayer(t *testing.T) {
 func TestKBAnnounceInertWarning(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		announce bool
+		announce config.AnnounceMode
 		capture  bool
 		sinks    int
 		wantCue  string // substring the message must carry; "" ⇒ no warning at all
 	}{
 		{name: "off, with nothing else configured either: the default warrants nothing"},
 		{name: "off, with everything else configured", sinks: 2, capture: true},
-		{name: "on, with a notifier and capture", announce: true, sinks: 1, capture: true, wantCue: ""},
-		{name: "on, with capture but no notifier", announce: true, capture: true, wantCue: "no notifier is configured"},
-		{name: "on, with a notifier but nothing capturing", announce: true, sinks: 1, wantCue: "thread_capture"},
+		{name: "explicitly off, with everything else configured", announce: config.AnnounceOff, sinks: 2, capture: true},
+		{name: "on, with a notifier and capture", announce: config.AnnounceChannel, sinks: 1, capture: true, wantCue: ""},
+		{name: "on, with capture but no notifier", announce: config.AnnounceChannel, capture: true, wantCue: "no notifier is configured"},
+		{name: "on, with a notifier but nothing capturing", announce: config.AnnounceChannel, sinks: 1, wantCue: "thread_capture"},
 		{
 			// Both ends missing: one message, and it must be the delivery one —
 			// reporting them in a fixed order keeps the line deterministic.
-			name: "on, with neither end", announce: true, wantCue: "no notifier is configured",
+			name: "on, with neither end", announce: config.AnnounceChannel, wantCue: "no notifier is configured",
 		},
+		// Routing does not change reachability: a thread-routed announcement still
+		// needs a sink and still needs a transport capturing, and an operator who
+		// wrote the new value must get the same diagnostic as one who wrote true.
+		{name: "thread-routed, with capture but no notifier", announce: config.AnnounceThread, capture: true, wantCue: "no notifier is configured"},
+		{name: "both, with a notifier but nothing capturing", announce: config.AnnounceBoth, sinks: 1, wantCue: "thread_capture"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &config.Config{}
@@ -872,7 +879,7 @@ func TestKBAnnounceInertWarning(t *testing.T) {
 // call a working Matrix-only setup dead config.
 func TestKBAnnounceInertWarningSeesMatrixCaptureToo(t *testing.T) {
 	cfg := &config.Config{}
-	cfg.Notify.Thread.AnnounceKBUpdates = true
+	cfg.Notify.Thread.AnnounceKBUpdates = config.AnnounceChannel
 	cfg.Notify.Matrix.ThreadCapture = true
 	if got := KBAnnounceInertWarning(cfg, 1); got != "" {
 		t.Fatalf("matrix thread_capture alone must satisfy the capture end, got: %q", got)
@@ -896,7 +903,7 @@ func TestKBAnnounceInertWarningSeesMatrixCaptureToo(t *testing.T) {
 func TestBuildThreadResponderAnnouncerIsOptIn(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		announce bool
+		announce config.AnnounceMode
 		notifier func() *notify.Multi
 		want     bool // want an announcer on the responder
 		wantWarn bool
@@ -909,19 +916,39 @@ func TestBuildThreadResponderAnnouncerIsOptIn(t *testing.T) {
 			name: "off, with no notifier at all: nothing was asked for, so nothing is said",
 		},
 		{
+			name:     "explicitly off, with a notifier configured",
+			announce: config.AnnounceOff,
+			notifier: func() *notify.Multi { return notify.NewMulti(discardLog(), &captureNotifier{}) },
+		},
+		{
 			name:     "on, with a notifier configured",
-			announce: true,
+			announce: config.AnnounceChannel,
+			notifier: func() *notify.Multi { return notify.NewMulti(discardLog(), &captureNotifier{}) },
+			want:     true,
+		},
+		{
+			// Every destination is the same switch: routing decides WHERE, never
+			// whether. A mode that built no announcer would be a key that reads as
+			// enabled and does nothing.
+			name:     "thread-routed, with a notifier configured",
+			announce: config.AnnounceThread,
+			notifier: func() *notify.Multi { return notify.NewMulti(discardLog(), &captureNotifier{}) },
+			want:     true,
+		},
+		{
+			name:     "both, with a notifier configured",
+			announce: config.AnnounceBoth,
 			notifier: func() *notify.Multi { return notify.NewMulti(discardLog(), &captureNotifier{}) },
 			want:     true,
 		},
 		{
 			name:     "on, but no notifier was built at all",
-			announce: true,
+			announce: config.AnnounceChannel,
 			wantWarn: true,
 		},
 		{
 			name:     "on, but the notifier holds no sinks",
-			announce: true,
+			announce: config.AnnounceChannel,
 			notifier: func() *notify.Multi { return notify.NewMulti(discardLog()) },
 			wantWarn: true,
 		},
@@ -952,6 +979,96 @@ func TestBuildThreadResponderAnnouncerIsOptIn(t *testing.T) {
 			if warned := strings.Contains(buf.String(), "announce_kb_updates"); warned != tc.wantWarn {
 				t.Fatalf("warned about an inert announce_kb_updates = %v, want %v; log: %s",
 					warned, tc.wantWarn, buf.String())
+			}
+		})
+	}
+}
+
+// kbSinkNotifier is a Notifier that also accepts announcements, so the fan-out
+// the builder wires actually reaches something a test can read.
+type kbSinkNotifier struct {
+	mu  sync.Mutex
+	got []providers.KBUpdate
+}
+
+func (*kbSinkNotifier) Deliver(context.Context, providers.Investigation) error { return nil }
+
+func (s *kbSinkNotifier) DeliverKBUpdate(_ context.Context, up providers.KBUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.got = append(s.got, up)
+	return nil
+}
+
+func (s *kbSinkNotifier) updates() []providers.KBUpdate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]providers.KBUpdate(nil), s.got...)
+}
+
+// TestAnnounceDestinationReachesTheSink closes the wiring gap between the key an
+// operator writes and the routing decision a notifier acts on.
+//
+// Every piece of this is unit-tested on its own: config resolves the mode to a
+// providers.KBDelivery, the announcer stamps its delivery onto the event, and
+// the notifiers route on that stamp. None of that is worth anything if the
+// builder passes a literal instead of the configured value — `thread` in the
+// file would read as enabled, log as enabled, and still post to the channel,
+// which is precisely the complaint the destination exists to answer. The only
+// thing that catches it is driving the real builder from a real config and
+// reading what arrives at the sink.
+//
+// The thread handles are asserted alongside the destination because a routing
+// instruction with no address is inert: a sink told to reply in a thread, given
+// no channel, falls back — silently, and correctly — so the destination alone
+// proves nothing about whether the announcement can ever reach a thread.
+func TestAnnounceDestinationReachesTheSink(t *testing.T) {
+	for _, tc := range []struct {
+		mode config.AnnounceMode
+		want providers.KBDelivery
+	}{
+		{mode: config.AnnounceChannel, want: providers.KBDeliverChannel},
+		{mode: config.AnnounceThread, want: providers.KBDeliverThread},
+		{mode: config.AnnounceBoth, want: providers.KBDeliverBoth},
+	} {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			reg, err := thread.NewRegistry(filepath.Join(t.TempDir(), "threads.jsonl"), time.Hour, 10)
+			if err != nil {
+				t.Fatalf("NewRegistry: %v", err)
+			}
+			origin := thread.Context{Transport: "slack", Root: "111.222", Channel: "C-ORIGIN", Title: "OOM"}
+			if err := reg.Put(origin); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+
+			cfg := &config.Config{}
+			cfg.Notify.Thread.AnnounceKBUpdates = tc.mode
+			cfg.Notify.Slack.ThreadCapture = true
+			sink := &kbSinkNotifier{}
+			r := buildThreadResponder(cfg, reg, fakeThreadForge{}, nil, notify.NewMulti(discardLog(), sink), nil, discardLog())
+			if r.Announcer == nil {
+				t.Fatal("no announcer was wired; every destination is the same switch")
+			}
+
+			if _, err := r.Handle(context.Background(), origin, "alice", "<@U0BOT> note: spot reclaim, not OOM"); err != nil {
+				t.Fatalf("Handle: %v", err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			r.Announcer.Drain(ctx)
+
+			got := sink.updates()
+			if len(got) != 1 {
+				t.Fatalf("the sink received %d announcements, want exactly 1 per landed write", len(got))
+			}
+			if got[0].Delivery != tc.want {
+				t.Errorf("announce_kb_updates: %s reached the sink as Delivery %q, want %q — the builder is not "+
+					"passing the configured destination through", tc.mode, string(got[0].Delivery), string(tc.want))
+			}
+			if got[0].Root != "111.222" || got[0].Channel != "C-ORIGIN" {
+				t.Errorf("the announcement carries root=%q channel=%q, want both handles from the thread context — "+
+					"without them every thread-routed delivery silently falls back to the channel",
+					got[0].Root, got[0].Channel)
 			}
 		})
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1015,11 +1015,16 @@ func (m *AnnounceMode) UnmarshalYAML(value *yaml.Node) error {
 		}
 		return nil
 	}
-	var s string
-	if err := value.Decode(&s); err != nil {
+	// Named for what it is rather than "s": internal/foldguard groups
+	// case-normalised values per package BY NAME, and an unrelated `s` folded with
+	// EqualFold elsewhere in this file made the two look like one value reached by
+	// two normalisers — the exact defect that guard exists to catch. A distinct
+	// name is the honest fix; an allowlist entry would have hidden a real one later.
+	var raw string
+	if err := value.Decode(&raw); err != nil {
 		return fmt.Errorf("notify.thread.announce_kb_updates must be a boolean or one of %s: %w", announceModeList, err)
 	}
-	*m = AnnounceMode(strings.ToLower(strings.TrimSpace(s)))
+	*m = AnnounceMode(strings.ToLower(strings.TrimSpace(raw)))
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -931,12 +931,12 @@ type ThreadNotify struct {
 	// path, because that field compares the size of the next request against
 	// the limit rather than a running total.
 	ChatTokensPerHour int64 `yaml:"chat_tokens_per_hour"`
-	// AnnounceKBUpdates broadcasts a landed knowledge write to every configured
-	// notifier — each one's own channel or room, never back into the thread — so
-	// a knowledge-base update reaches people who were not reading the thread it
-	// came from.
+	// AnnounceKBUpdates broadcasts a landed knowledge write to the configured
+	// notifiers, so a knowledge-base update reaches people who were not reading
+	// the thread it came from — and says WHERE. See AnnounceMode for the
+	// accepted spellings and what each one delivers.
 	//
-	// Default FALSE. It is the one field in this block that is a switch rather
+	// Default OFF. It is the one field in this block that is a switch rather
 	// than a bound, and the only one whose zero value turns something OFF rather
 	// than selecting a default, so the "0 means the default" convention above
 	// does not apply to it. Opt-in for two reasons: it adds notification volume
@@ -945,12 +945,105 @@ type ThreadNotify struct {
 	// carries the note's own text, so enabling it sends what someone wrote in
 	// one thread to every sink configured here. That is an operator's decision
 	// to take knowingly, which makes the unconfigured state the off state.
-	//
-	// With a single transport configured, one write then produces both the
-	// thread reply and a channel post. That is intended rather than duplication
-	// — the channel is how people who were not in the thread learn the knowledge
-	// base moved — and it is the whole reason the feature exists.
-	AnnounceKBUpdates bool `yaml:"announce_kb_updates"`
+	AnnounceKBUpdates AnnounceMode `yaml:"announce_kb_updates"`
+}
+
+// AnnounceMode says whether a landed knowledge write is announced, and to which
+// destination. It accepts a YAML BOOLEAN as well as its own names, because
+// `false` and `true` shipped first and an operator's existing file must keep
+// meaning exactly what it meant: false is off, true is channel — today's
+// behaviour, unchanged, down to the message and the destination.
+//
+// The routing values exist because "a second destination" is only a second
+// destination when there are several sinks. The channel post reaches people who
+// were not reading the thread, which is the whole point — but with a SINGLE
+// transport the thread already lives in the channel the announcement posts to,
+// so every write restated in the channel what the thread had just said. An
+// operator's only remedy was turning the feature off, losing the signal along
+// with the echo.
+type AnnounceMode string
+
+// The announcement destinations. "" (the absent key) is off, as is the explicit
+// "off" — the same empty-plus-explicit pair Curate.Sweeps.Mode uses.
+const (
+	// AnnounceOff makes no announcement at all. The default: an unconfigured
+	// deployment never broadcasts what someone typed in a thread.
+	AnnounceOff AnnounceMode = "off"
+	// AnnounceChannel posts to each configured notifier's own channel or room
+	// and nowhere else. What `true` has always meant.
+	AnnounceChannel AnnounceMode = "channel"
+	// AnnounceThread delivers into the ORIGINATING thread on the transport the
+	// note was typed in, instead of that transport's channel. Sinks on any other
+	// transport — a Matrix room when the note came from Slack, a webhook, an
+	// incoming-webhook Slack that cannot reply in a thread — still receive it at
+	// channel level: see providers.KBDelivery for why that fallback rather than
+	// a skip.
+	AnnounceThread AnnounceMode = "thread"
+	// AnnounceBoth delivers into the originating thread AND to every sink's
+	// channel. For a deployment that wants the announcement's provenance line
+	// (who wrote the note, on which chat system — which the thread reply does
+	// not carry) in the thread, and the broadcast as well.
+	AnnounceBoth AnnounceMode = "both"
+)
+
+// UnmarshalYAML accepts either a boolean or one of the mode names.
+//
+// The boolean is tried FIRST, and that ordering is the compatibility guarantee:
+// every value that decodes into a Go bool today still decodes into one here, so
+// `true`, `false` and YAML 1.1's `on`/`off`/`yes`/`no` — all of which yaml.v3
+// resolves when the target is a bool — resolve exactly as they did when this
+// field was a plain bool. Only a value that is NOT a boolean reaches the string
+// branch, which is where the new names live.
+//
+// A null (`announce_kb_updates:` with nothing after it) never reaches this
+// method at all: yaml.v3 short-circuits a null node before it looks for an
+// Unmarshaler, leaving the field at its ZERO VALUE. That is why "" is a valid
+// off state in its own right in Validate and On() rather than being normalised
+// to AnnounceOff here — the normalisation would never run. The bool field this
+// replaces resolved a null to false, so the answer is unchanged either way.
+//
+// An unrecognised name is stored rather than rejected here, so Validate reports
+// it with the file's own spelling and the list of what is accepted — a decode
+// error would name the Go type instead.
+func (m *AnnounceMode) UnmarshalYAML(value *yaml.Node) error {
+	var b bool
+	if err := value.Decode(&b); err == nil {
+		if b {
+			*m = AnnounceChannel
+		} else {
+			*m = AnnounceOff
+		}
+		return nil
+	}
+	var s string
+	if err := value.Decode(&s); err != nil {
+		return fmt.Errorf("notify.thread.announce_kb_updates must be a boolean or one of %s: %w", announceModeList, err)
+	}
+	*m = AnnounceMode(strings.ToLower(strings.TrimSpace(s)))
+	return nil
+}
+
+// announceModeList is the accepted-values list, written once so the decode
+// error and the validation error cannot drift apart.
+const announceModeList = "off|channel|thread|both"
+
+// On reports whether anything is announced at all. Both spellings of off — the
+// absent key and the explicit "off" — answer false.
+func (m AnnounceMode) On() bool { return m != "" && m != AnnounceOff }
+
+// Delivery maps the configured mode onto the destination the notifiers act on
+// (providers.KBDelivery). Off has no delivery and resolves to the channel value
+// like any other unset enum; On is what decides whether an announcer exists at
+// all, so this is never reached for an off deployment.
+func (m AnnounceMode) Delivery() providers.KBDelivery {
+	switch m {
+	case AnnounceThread:
+		return providers.KBDeliverThread
+	case AnnounceBoth:
+		return providers.KBDeliverBoth
+	default:
+		return providers.KBDeliverChannel
+	}
 }
 
 // EffectiveMaxNotesPerThread resolves the configured cap, falling back to
@@ -1650,6 +1743,16 @@ func (c *Config) Validate() error {
 	if c.Notify.Thread.ChatTokensPerHour < 0 {
 		return fmt.Errorf("notify.thread.chat_tokens_per_hour must be >= 0 (0 = use the default %d), got %d",
 			thread.DefaultChatTokensPerHour, c.Notify.Thread.ChatTokensPerHour)
+	}
+	// announce_kb_updates is the one key here that is an enum, and a typo in it
+	// must fail loud: "treads" or "chanel" silently falling back to channel would
+	// leave an operator believing the echo they configured away is gone while
+	// every write still restates itself in the channel.
+	switch c.Notify.Thread.AnnounceKBUpdates {
+	case "", AnnounceOff, AnnounceChannel, AnnounceThread, AnnounceBoth:
+	default:
+		return fmt.Errorf("unknown notify.thread.announce_kb_updates %q (want a boolean or %s; false = off, true = channel, empty = off)",
+			string(c.Notify.Thread.AnnounceKBUpdates), announceModeList)
 	}
 	// source_repos.allow is compiled at startup; a bad pattern must fail config
 	// load, not silently disable the tool at wiring time.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/thread"
 )
 
@@ -1276,7 +1277,7 @@ notify:
 	th := c.Notify.Thread
 	if th.MaxNotesPerThread != 5 || th.ForgeWritesPerHour != 3 || th.RegistryTTL.Std() != 48*time.Hour ||
 		th.RegistryMax != 100 || th.MaxNoteBytes != 4096 ||
-		th.ChatCallsPerHour != 45 || th.ChatTokensPerHour != 123456 || !th.AnnounceKBUpdates {
+		th.ChatCallsPerHour != 45 || th.ChatTokensPerHour != 123456 || !th.AnnounceKBUpdates.On() {
 		t.Fatalf("notify.thread not parsed: %+v", th)
 	}
 	if got := th.EffectiveMaxNotesPerThread(); got != 5 {
@@ -1311,11 +1312,16 @@ notify:
 // a note written in one thread to every configured sink. That is an operator's
 // call to make knowingly, so the safe state is the unconfigured state.
 //
-// All three states are asserted separately rather than just "absent": a bool
+// All three states are asserted separately rather than just "absent": a switch
 // whose zero value is the default reads as covered the moment anything asserts
-// false, and the case that would actually reveal a wrong-way default — an
+// off, and the case that would actually reveal a wrong-way default — an
 // operator writing the key out explicitly to turn it OFF — is the one a
 // zero-value-only test never exercises.
+//
+// It asserts On() rather than the raw value on purpose: On() is what every
+// consumer branches on, and it is the property "the unconfigured state does not
+// broadcast" is a claim about. The exact mode each spelling resolves to is
+// TestAnnounceModeAcceptsBooleansAndNames' job.
 func TestAnnounceKBUpdatesIsOptIn(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -1335,8 +1341,17 @@ func TestAnnounceKBUpdatesIsOptIn(t *testing.T) {
 			yaml: "notify:\n  thread:\n    announce_kb_updates: false\n",
 		},
 		{
+			name: "explicitly off",
+			yaml: "notify:\n  thread:\n    announce_kb_updates: \"off\"\n",
+		},
+		{
 			name: "explicitly true",
 			yaml: "notify:\n  thread:\n    announce_kb_updates: true\n",
+			want: true,
+		},
+		{
+			name: "explicitly thread-routed",
+			yaml: "notify:\n  thread:\n    announce_kb_updates: thread\n",
 			want: true,
 		},
 	} {
@@ -1345,10 +1360,10 @@ func TestAnnounceKBUpdatesIsOptIn(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(tc.yaml), &c); err != nil {
 				t.Fatalf("unmarshal: %v", err)
 			}
-			if got := c.Notify.Thread.AnnounceKBUpdates; got != tc.want {
-				t.Fatalf("notify.thread.announce_kb_updates = %v, want %v — the announcement fans a note "+
+			if got := c.Notify.Thread.AnnounceKBUpdates.On(); got != tc.want {
+				t.Fatalf("notify.thread.announce_kb_updates = %q, On() = %v, want %v — the announcement fans a note "+
 					"written in one thread out to every configured sink, so the unconfigured state must be off",
-					got, tc.want)
+					string(c.Notify.Thread.AnnounceKBUpdates), got, tc.want)
 			}
 			// The key must land on the named Thread field, never in Notify.Extra,
 			// for the same reason every other notify.thread key must: an inline
@@ -1356,6 +1371,145 @@ func TestAnnounceKBUpdatesIsOptIn(t *testing.T) {
 			// TestNotifyThreadDoesNotShadowARegisteredNotifier).
 			if _, ok := c.Notify.Extra["thread"]; ok {
 				t.Fatal("notify.thread must not also land in Notify.Extra")
+			}
+		})
+	}
+}
+
+// TestAnnounceModeAcceptsBooleansAndNames is the BACKWARD-COMPATIBILITY pin for
+// notify.thread.announce_kb_updates.
+//
+// The key shipped and was documented as a plain YAML boolean before it grew
+// destinations, so every file already in an operator's repository must keep
+// meaning exactly what it meant. That is a stronger claim than "true still
+// parses": `true` must still resolve to the CHANNEL destination — the message,
+// the sink set and the place it lands, all unchanged — because an operator who
+// upgrades and finds their announcements silently moved into threads has had
+// their configuration reinterpreted under them.
+//
+// YAML 1.1's `on`/`off`/`yes`/`no` are covered too, and not as a courtesy: this
+// field was a Go bool, and yaml.v3 resolves all of those into a bool target, so
+// they are values that WORK today whether or not any page documents them. A
+// string-first unmarshaler would silently turn `off` into an unknown mode and
+// fail an operator's existing file at startup.
+func TestAnnounceModeAcceptsBooleansAndNames(t *testing.T) {
+	for _, tc := range []struct {
+		val  string
+		want AnnounceMode
+	}{
+		// The two shipped spellings. These are the compatibility contract.
+		{val: "true", want: AnnounceChannel},
+		{val: "false", want: AnnounceOff},
+		// YAML 1.1 booleans, which the bool field accepted before this type existed.
+		{val: "on", want: AnnounceChannel},
+		{val: "off", want: AnnounceOff},
+		{val: "yes", want: AnnounceChannel},
+		{val: "no", want: AnnounceOff},
+		{val: "TRUE", want: AnnounceChannel},
+		// An empty value is a null node. yaml.v3 short-circuits null BEFORE it
+		// looks for an Unmarshaler, so UnmarshalYAML is never called and the
+		// field keeps its zero value — which is why "" has to be off in its own
+		// right rather than by being normalised to AnnounceOff on the way in.
+		// The bool field it replaces resolved a null to false, so this is the
+		// same answer by a different route.
+		{val: "", want: ""},
+		{val: "~", want: ""},
+		{val: "null", want: ""},
+		// The names.
+		{val: "channel", want: AnnounceChannel},
+		{val: "thread", want: AnnounceThread},
+		{val: "both", want: AnnounceBoth},
+		{val: `"off"`, want: AnnounceOff},
+		{val: "Thread", want: AnnounceThread},
+		{val: `"  both  "`, want: AnnounceBoth},
+	} {
+		t.Run(tc.val, func(t *testing.T) {
+			var c Config
+			y := "notify:\n  thread:\n    announce_kb_updates: " + tc.val + "\n"
+			if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+				t.Fatalf("unmarshal %q: %v", tc.val, err)
+			}
+			if got := c.Notify.Thread.AnnounceKBUpdates; got != tc.want {
+				t.Fatalf("announce_kb_updates: %s parsed as %q, want %q", tc.val, string(got), string(tc.want))
+			}
+			if err := c.Validate(); err != nil {
+				t.Fatalf("announce_kb_updates: %s must validate clean: %v", tc.val, err)
+			}
+			// On() is the property every consumer branches on, so both spellings
+			// of off must answer it the same way. "" reaches here only via the
+			// null path above, where no unmarshaler ran to normalise it.
+			if want := tc.want != AnnounceOff && tc.want != ""; c.Notify.Thread.AnnounceKBUpdates.On() != want {
+				t.Fatalf("announce_kb_updates: %s parsed as %q, On() = %v, want %v",
+					tc.val, string(tc.want), !want, want)
+			}
+		})
+	}
+}
+
+// TestAnnounceModeDeliveryIsTotal pins the mapping from the operator's word onto
+// the destination the notifiers act on (providers.KBDelivery).
+//
+// The two enums are separate because only config has an OFF state — On() is what
+// decides an announcer exists at all — and a mapping that is written once and
+// read nowhere else is exactly the kind that quietly loses a case. A mode added
+// here without a Delivery arm would fall through to the channel and turn a new
+// destination into a silent no-op, which is the failure the default arm of a
+// switch is very good at hiding.
+func TestAnnounceModeDeliveryIsTotal(t *testing.T) {
+	for mode, want := range map[AnnounceMode]providers.KBDelivery{
+		AnnounceChannel: providers.KBDeliverChannel,
+		AnnounceThread:  providers.KBDeliverThread,
+		AnnounceBoth:    providers.KBDeliverBoth,
+		// Off has no delivery; it must resolve to the harmless zero value rather
+		// than to a route.
+		AnnounceOff: providers.KBDeliverChannel,
+		"":          providers.KBDeliverChannel,
+	} {
+		if got := mode.Delivery(); got != want {
+			t.Errorf("AnnounceMode(%q).Delivery() = %q, want %q", string(mode), string(got), string(want))
+		}
+	}
+	// The routing modes must be distinguishable from the shipped one, or the
+	// mapping above is satisfied by a function that returns the zero value.
+	if AnnounceThread.Delivery() == AnnounceChannel.Delivery() {
+		t.Error("thread and channel resolve to the same delivery — routing would be inert")
+	}
+	if !AnnounceThread.Delivery().IntoThread() || !AnnounceBoth.Delivery().IntoThread() {
+		t.Error("thread/both must resolve to a delivery that asks for the originating thread")
+	}
+	if AnnounceChannel.Delivery().IntoThread() {
+		t.Error("channel must not ask for the originating thread — that is the shipped behaviour of `true`")
+	}
+}
+
+// TestAnnounceModeRejectsAnUnknownName pins that a typo fails LOAD rather than
+// falling back.
+//
+// Silently reading "treads" as the channel would leave an operator believing the
+// echo they configured away is gone while every write still restates itself in
+// the channel — the exact complaint the routing exists to answer, now invisible.
+// The message must name the accepted values, because the operator who typed a
+// wrong one has no other way to learn what the right ones are.
+func TestAnnounceModeRejectsAnUnknownName(t *testing.T) {
+	for _, val := range []string{"treads", "chanel", "room", `"true"`, "thread,channel"} {
+		t.Run(val, func(t *testing.T) {
+			var c Config
+			y := "notify:\n  thread:\n    announce_kb_updates: " + val + "\n"
+			if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+				t.Fatalf("unmarshal %q must not fail — Validate is what reports it: %v", val, err)
+			}
+			err := c.Validate()
+			if err == nil {
+				t.Fatalf("announce_kb_updates: %s validated clean; an unknown destination must fail at load", val)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "announce_kb_updates") {
+				t.Errorf("the error must name the key, got: %v", err)
+			}
+			for _, want := range []string{"off", "channel", "thread", "both"} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("the error must name the valid value %q so the operator can fix it, got: %v", want, err)
+				}
 			}
 		})
 	}

--- a/internal/docsguard/thread_defaults_test.go
+++ b/internal/docsguard/thread_defaults_test.go
@@ -111,97 +111,165 @@ func TestThreadDefaultsMatchTheDocs(t *testing.T) {
 	}
 }
 
-// TestThreadBooleanDefaultsMatchTheDocs is the sibling of the test above for
-// the `notify.thread` defaults the docs state as a BOOLEAN.
+// TestAnnounceKBUpdatesDefaultMatchesTheDocs pins the default of
+// notify.thread.announce_kb_updates against every page that states it.
 //
-// The numeric guard parses numbers only, so a page stating that
-// `announce_kb_updates` defaults to `false` was pinned by nothing at all: the
-// key could be flipped to opt-OUT in code and four pages would keep telling an
-// operator it was off. That is worse than the numeric drift this file was
-// written for, because the key decides whether note content — what someone
-// typed in one thread — is broadcast to every configured sink. A doc saying
-// "off unless you set it" while the code ships it on is a privacy claim the
-// software does not honour.
+// The numeric guard parses numbers only, so a page stating this key's default
+// was pinned by nothing at all: it could be flipped to opt-OUT in code and four
+// pages would keep telling an operator it was off. That is worse than the
+// numeric drift this file was written for, because the key decides whether note
+// content — what someone typed in one thread — is broadcast to every configured
+// sink. A doc saying "off unless you set it" while the code ships it on is a
+// privacy claim the software does not honour.
 //
 // The default comes from decoding an EMPTY config through the real type, not
 // from a literal repeated here: that is what "the default" means operationally
 // — what an operator who wrote no such key gets.
 //
-// It used to be a HALF guard, biting only from the DOCS: AnnounceKBUpdates was a
-// plain bool with no unmarshaler, so decoding "{}" could only ever yield false
-// and no edit to internal/config could make an unconfigured deployment announce.
-// That is no longer true. The field is now config.AnnounceMode, which HAS a
-// custom unmarshaler and several non-boolean states, so the code side is
-// falsifiable in exactly the way the old comment said would take a type change —
-// and the type change happened. A default that resolved On() to true, by a
-// mistake in the unmarshaler or by someone deciding the empty state should
-// announce, now fails here against every page that promises otherwise.
+// # Why this is no longer the boolean guard it replaces
 //
-// It reads On() rather than the raw mode for the same reason the pages state a
-// boolean: the operator-facing claim is "nothing is broadcast unless you ask",
-// which is what On() answers. Which DESTINATION a mode selects is a different
-// claim, and internal/config's own tests pin that one.
+// This was a bool-only parse, and that had become a trap. The key stopped being
+// a boolean when it grew destinations (config.AnnounceMode: off, channel,
+// thread, both), but the parse still recognised only `true|false`. It passed
+// solely because every page happens to write `default **false**` before any
+// other boolean token — so rewriting a page to the equally correct
+// `default **off**`, the obvious follow-up edit, would have made the guard walk
+// past it, find the `true` in "# also true (= channel)" as the next boolean
+// after the word "default", and report that the docs claim the key defaults to
+// TRUE. The failure would have pointed the reader at changing the code default
+// on the strength of a sentence explaining an alias.
 //
-// What counts as a claim is narrower than for numbers, and deliberately so: the
-// word "default" must appear between the key (or the previous boolean in the
-// same unit) and the token. A boolean's YAML value in a sample is a
-// DEMONSTRATION rather than a default — `announce_kb_updates: true` is how a
-// page shows you how to turn an opt-in on — whereas a numeric sample
-// conventionally prints the default itself. Reading the YAML value as a claim
-// would fail every page that documents how to enable the feature.
-func TestThreadBooleanDefaultsMatchTheDocs(t *testing.T) {
+// So the vocabulary is the key's OWN, and a claim is now recognised only where
+// the value token immediately follows the word "default" (see
+// docAnnounceDefaultRE). Both halves matter: widening the vocabulary alone would
+// have made every ordinary "the thread reply" and "the channel post" in this
+// feature's prose a candidate claim, which is a far bigger surface of English
+// than `true|false` ever was.
+//
+// # What it does and does not verify
+//
+// It compares DESTINATIONS, not just on/off, through announceDocModes — which
+// is also where `false` and `off`, and `true` and `channel`, are recorded as the
+// same claim. That equivalence is the compatibility promise config.AnnounceMode
+// makes to an operator, so a page may state the default in either spelling and a
+// page that starts saying `channel` where the code says off still fails.
+//
+// It bites from BOTH sides now. It used to be a half guard — AnnounceKBUpdates
+// was a plain bool with no unmarshaler, so decoding "{}" could only ever yield
+// false and no edit to internal/config could make an unconfigured deployment
+// announce. The type has a custom unmarshaler and several states today, so a
+// default that resolved to anything but off — by a mistake in the unmarshaler,
+// or by someone deciding the empty state should announce — fails here against
+// every page that promises otherwise.
+func TestAnnounceKBUpdatesDefaultMatchesTheDocs(t *testing.T) {
 	var c config.Config
 	if err := yaml.Unmarshal([]byte("{}"), &c); err != nil {
 		t.Fatalf("decode an empty config: %v", err)
 	}
-	pinned := map[string]bool{
-		"announce_kb_updates": c.Notify.Thread.AnnounceKBUpdates.On(),
+	want := canonAnnounceMode(c.Notify.Thread.AnnounceKBUpdates)
+
+	// The pages are compared against the resolved DESTINATION above, but every
+	// consumer branches on On(), which is a different function. A default that
+	// reads "off" while On() answers true would satisfy every page below and
+	// still announce, so the two are pinned to each other here — otherwise this
+	// guard's claim ("no page promises an off state the code does not honour")
+	// rests on a value nothing downstream reads.
+	if got := c.Notify.Thread.AnnounceKBUpdates.On(); got != (want != config.AnnounceOff) {
+		t.Fatalf("an empty config resolves announce_kb_updates to destination %q but On() answers %v — "+
+			"the value these pages are checked against and the switch that decides whether anything is "+
+			"announced disagree, so every page below is being compared to the wrong thing",
+			string(want), got)
 	}
 
-	seenIn := make(map[string]map[string]bool, len(pinned))
+	seenIn := map[string]bool{}
 	for _, path := range threadDocPages(t) {
 		src, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("read %s: %v", path, err)
 		}
 		rel := relToRepo(t, path)
-		for _, c := range threadBoolClaims(rel, string(src), pinned) {
-			if seenIn[c.key] == nil {
-				seenIn[c.key] = map[string]bool{}
-			}
-			seenIn[c.key][c.file] = true
-			if c.bool == pinned[c.key] {
+		for _, claim := range announceDefaultClaims(rel, string(src)) {
+			seenIn[claim.file] = true
+			if canonAnnounceMode(announceDocModes[claim.text]) == want {
 				continue
 			}
-			t.Errorf("%s:%d states notify.thread.%s defaults to %v, but an empty config resolves it to %v.\n"+
-				"  claim: %s\n"+
+			t.Errorf("%s:%d states notify.thread.announce_kb_updates defaults to %q, but an empty config resolves it to %q.\n"+
 				"  Restate it here, or change the default — do not leave them disagreeing. "+
 				"announce_kb_updates decides whether a note written in one thread is broadcast to every "+
 				"configured sink, so a page promising it is off while the code ships it on is a claim about "+
 				"where an operator's words go that the software does not honour.",
-				c.file, c.line, c.key, c.bool, pinned[c.key], c.text)
+				claim.file, claim.line, claim.text, string(want))
 		}
 	}
 
-	// Guard the guard, exactly as the numeric test does: every pinned key is
-	// stated somewhere in the shipped docs today, so finding none means the
-	// parse stopped matching and this is reporting success over nothing.
-	for _, key := range sortedStrings(pinned) {
-		if len(seenIn[key]) == 0 {
-			t.Errorf("found no stated default for notify.thread.%s in any shipped page — "+
-				"either the docs stopped documenting it or threadBoolClaims no longer "+
-				"recognises how they phrase it, and this guard is inert for that key", key)
+	// Guard the guard, exactly as the numeric test does: the key is documented
+	// today, so finding nothing means the parse stopped matching and this is
+	// reporting success over nothing.
+	//
+	// It is stated on the configuration reference, both notification pages and the
+	// reviewing-knowledge concept page. Requiring several holds the guard to
+	// catching a PARTIAL fix — the failure where someone corrects one page and
+	// leaves the others promising the opposite.
+	if len(seenIn) < 3 {
+		t.Errorf("announce_kb_updates' default is stated on %d page(s); it is documented on the "+
+			"configuration reference, both notification pages and the reviewing-knowledge concept page, "+
+			"so a count this low means docAnnounceDefaultRE has stopped recognising how they phrase it "+
+			"and this guard is inert", len(seenIn))
+	}
+}
+
+// announceDocModes maps every spelling a page may state this default in onto the
+// destination it means. `false` and `off` are the same claim, and so are `true`
+// and `channel` — that equivalence is the compatibility promise
+// config.AnnounceMode makes, so a page is free to use either.
+var announceDocModes = map[string]config.AnnounceMode{
+	"false":   config.AnnounceOff,
+	"off":     config.AnnounceOff,
+	"true":    config.AnnounceChannel,
+	"channel": config.AnnounceChannel,
+	"thread":  config.AnnounceThread,
+	"both":    config.AnnounceBoth,
+}
+
+// canonAnnounceMode folds the absent key onto the explicit "off" so a doc
+// stating either spelling compares equal to a config that resolved to the other.
+func canonAnnounceMode(m config.AnnounceMode) config.AnnounceMode {
+	if m == "" {
+		return config.AnnounceOff
+	}
+	return m
+}
+
+// docAnnounceDefaultRE matches a stated default for this key: the word
+// "default", then at most a few bytes of markup or punctuation, then one of the
+// key's own values. The gap covers "default **false**", "default `off`",
+// "default false" and "default: channel"; it deliberately does NOT let arbitrary
+// prose sit between the two, which is what stops "…so a note written in one
+// thread…" from being read as a claim about a key mentioned a sentence earlier.
+var docAnnounceDefaultRE = regexp.MustCompile(`(?i)default[^\w]{0,4}(true|false|off|channel|thread|both)\b`)
+
+// announceDefaultClaims extracts the default claims one markdown page makes
+// about announce_kb_updates, attributed the way threadDefaultClaims attributes
+// numbers: the nearest config key before the match, so a "default off" belonging
+// to some other key is never read as this one's.
+func announceDefaultClaims(file, src string) []docClaim {
+	var claims []docClaim
+	for _, u := range splitDocUnits(src) {
+		keys := docKeyRE.FindAllStringIndex(u.text, -1)
+		for _, m := range docAnnounceDefaultRE.FindAllStringSubmatchIndex(u.text, -1) {
+			key, _ := nearestKeyBefore(u.text, keys, m[0])
+			if key != "announce_kb_updates" {
+				continue
+			}
+			claims = append(claims, docClaim{
+				file: file,
+				line: u.lineAt(m[0]),
+				key:  key,
+				text: strings.ToLower(u.text[m[2]:m[3]]),
+			})
 		}
 	}
-	// It is documented on the configuration reference, both notification pages
-	// and the reviewing-knowledge concept page. Requiring several holds the
-	// guard to catching a partial fix — the failure where someone corrects one
-	// page and leaves the others promising the opposite.
-	if n := len(seenIn["announce_kb_updates"]); n < 3 {
-		t.Errorf("announce_kb_updates' default is stated on only %d page(s); it is documented on the "+
-			"configuration reference, both notification pages and the reviewing-knowledge concept page, "+
-			"so a count this low means the guard has stopped seeing most of them", n)
-	}
+	return claims
 }
 
 // docQuoteCapRE matches the announcement's note-quote ceiling as the transport
@@ -311,45 +379,6 @@ func notifyIntConst(root, name string) (int64, error) {
 	return 0, fmt.Errorf("%s declares no const %s — it was renamed or moved, and this guard is inert", path, name)
 }
 
-// docBoolRE matches a boolean as the docs write it, bold markers and backticks
-// being separate tokens either side of it.
-var docBoolRE = regexp.MustCompile(`\b(?:true|false)\b`)
-
-// threadBoolClaims extracts the boolean default claims a single markdown page
-// makes about the pinned keys. It mirrors threadDefaultClaims — same units,
-// same nearest-key-before attribution — minus the YAML-value and table-cell
-// readings; see TestThreadBooleanDefaultsMatchTheDocs for why those two are
-// wrong for a boolean.
-func threadBoolClaims(file, src string, pinned map[string]bool) []docClaim {
-	var claims []docClaim
-	for _, u := range splitDocUnits(src) {
-		keys := docKeyRE.FindAllStringIndex(u.text, -1)
-		prevEnd := 0
-		for _, tok := range docBoolRE.FindAllStringIndex(u.text, -1) {
-			key, end := nearestKeyBefore(u.text, keys, tok[0])
-			anchor := max(end, prevEnd)
-			prevEnd = tok[1]
-			if key == "" {
-				continue
-			}
-			if _, ok := pinned[key]; !ok {
-				continue
-			}
-			if !strings.Contains(strings.ToLower(u.text[anchor:tok[0]]), "default") {
-				continue
-			}
-			claims = append(claims, docClaim{
-				file: file,
-				line: u.lineAt(tok[0]),
-				key:  key,
-				text: docSnippet(u.text, tok[0]-60, tok[1]+20),
-				bool: u.text[tok[0]:tok[1]] == "true",
-			})
-		}
-	}
-	return claims
-}
-
 // docClaim is one number a page states as a key's default, kept with enough
 // provenance to point an operator-facing failure at the exact line.
 type docClaim struct {
@@ -358,7 +387,6 @@ type docClaim struct {
 	key  string
 	text string
 	val  int64
-	bool bool
 }
 
 var (

--- a/internal/docsguard/thread_defaults_test.go
+++ b/internal/docsguard/thread_defaults_test.go
@@ -127,17 +127,20 @@ func TestThreadDefaultsMatchTheDocs(t *testing.T) {
 // from a literal repeated here: that is what "the default" means operationally
 // — what an operator who wrote no such key gets.
 //
-// That makes this a HALF guard, and it is worth saying so plainly rather than
-// leaving it implied. It bites in one direction only: from the DOCS. The code
-// side is structurally unfalsifiable — AnnounceKBUpdates is a plain bool with no
-// unmarshaler, so decoding "{}" can only ever yield false, and there is no edit
-// to internal/config that makes an unconfigured deployment announce. Flipping
-// the default would mean changing the field's TYPE (a *bool, or a custom
-// unmarshaler defaulting to true), which is a change nobody makes by accident
-// and which this test would then catch from the docs it disagreed with. Until
-// that day the only failure this can produce is a page stating "true", so read
-// its passing as "no page claims the wrong default", never as "the default is
-// verified false".
+// It used to be a HALF guard, biting only from the DOCS: AnnounceKBUpdates was a
+// plain bool with no unmarshaler, so decoding "{}" could only ever yield false
+// and no edit to internal/config could make an unconfigured deployment announce.
+// That is no longer true. The field is now config.AnnounceMode, which HAS a
+// custom unmarshaler and several non-boolean states, so the code side is
+// falsifiable in exactly the way the old comment said would take a type change —
+// and the type change happened. A default that resolved On() to true, by a
+// mistake in the unmarshaler or by someone deciding the empty state should
+// announce, now fails here against every page that promises otherwise.
+//
+// It reads On() rather than the raw mode for the same reason the pages state a
+// boolean: the operator-facing claim is "nothing is broadcast unless you ask",
+// which is what On() answers. Which DESTINATION a mode selects is a different
+// claim, and internal/config's own tests pin that one.
 //
 // What counts as a claim is narrower than for numbers, and deliberately so: the
 // word "default" must appear between the key (or the previous boolean in the
@@ -152,7 +155,7 @@ func TestThreadBooleanDefaultsMatchTheDocs(t *testing.T) {
 		t.Fatalf("decode an empty config: %v", err)
 	}
 	pinned := map[string]bool{
-		"announce_kb_updates": c.Notify.Thread.AnnounceKBUpdates,
+		"announce_kb_updates": c.Notify.Thread.AnnounceKBUpdates.On(),
 	}
 
 	seenIn := make(map[string]map[string]bool, len(pinned))

--- a/internal/notify/kbupdate.go
+++ b/internal/notify/kbupdate.go
@@ -4,6 +4,7 @@ package notify
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -170,36 +171,90 @@ func slackKBUpdateMessage(up providers.KBUpdate) map[string]any {
 // supported delivery target that lacked the method would turn
 // notify.thread.announce_kb_updates into a switch that silently does nothing
 // for every operator on it.
+//
+// It ignores up.Delivery, and that is the documented fallback rather than an
+// omission: an incoming webhook posts to the channel the URL was issued for and
+// has no thread_ts to set, so it is one of the sinks providers.KBDelivery says
+// receives a thread-routed announcement at channel level instead of not at all.
 func (s *Slack) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
 	return s.post(ctx, slackKBUpdateMessage(up))
 }
 
-// DeliverKBUpdate announces a landed knowledge-base write to the configured
-// channel (providers.KBUpdateNotifier).
+// kbAnnounceTargets decides where ONE sink delivers ONE announcement, given the
+// transport that sink speaks. It is the whole of the routing rule
+// providers.KBDelivery documents, written once so Slack and Matrix cannot answer
+// it differently.
 //
-// It posts to the CHANNEL, never into the originating thread: the thread
-// already received the direct reply to the person who typed, and the whole
-// point of the announcement is reaching the people who were not reading it. So
-// no thread_ts is set here, deliberately — see ReplyInThread for the other
-// destination.
-func (s *SlackBot) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
-	_, err := s.post(ctx, slackKBUpdateMessage(up))
-	return err
+// A sink may deliver into the thread only when all three hold: the delivery asks
+// for it, the sink speaks the transport the note was typed in, and BOTH thread
+// handles arrived. A root without a channel is not a thread a reply can reach —
+// Slack's chat.postMessage needs the channel, and Matrix's send needs the room —
+// so a half-handle is treated exactly like no handle: fall back rather than post
+// a threaded message into the wrong place or none at all.
+//
+// toChannel is true whenever the thread route was not taken, which is what makes
+// the fallback total: every announcement lands somewhere. The one case where
+// both are true is KBDeliverBoth on the originating transport, which is what it
+// asks for.
+func kbAnnounceTargets(up providers.KBUpdate, transport string) (toThread, toChannel bool) {
+	toThread = up.Delivery.IntoThread() && up.Transport == transport && up.Root != "" && up.Channel != ""
+	return toThread, !toThread || up.Delivery == providers.KBDeliverBoth
 }
 
-// DeliverKBUpdate announces a landed knowledge-base write to the configured
-// room (providers.KBUpdateNotifier), as a plain m.notice with no m.thread
-// relation — see SlackBot.DeliverKBUpdate for why the destination is the room
-// rather than the thread.
+// DeliverKBUpdate announces a landed knowledge-base write
+// (providers.KBUpdateNotifier), to the channel, into the originating thread, or
+// to both — see kbAnnounceTargets.
 //
-// The body goes through thread.RenderReply with escapeMatrixReply: a plain body
-// has no markup to inject, but .m.rule.roomnotif matches "@room" in it and
+// The default destination is still the CHANNEL and still for the original
+// reason: the thread already received the direct reply to the person who typed,
+// and the point of the announcement is reaching the people who were not reading
+// it. What changed is that with ONE transport configured those are the same
+// people, because the thread lives in that very channel — so an operator can now
+// route the announcement into the thread instead of restating it beside it.
+//
+// The threaded post goes through ReplyInThread rather than a second local
+// render: that is the method that already escapes for mrkdwn, bounds at the
+// transport's ceiling and targets the passed channel, and a threaded
+// announcement must be neutralised exactly as a threaded reply is.
+//
+// Errors from the two posts are joined rather than short-circuited. A failure to
+// reach the thread must not suppress the channel half of KBDeliverBoth, and the
+// announcer swallows the result either way — the write is already on the forge.
+func (s *SlackBot) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
+	toThread, toChannel := kbAnnounceTargets(up, s.Transport())
+	var errs []error
+	if toThread {
+		errs = append(errs, s.ReplyInThread(ctx, up.Root, up.Channel, kbUpdateAnnouncement(up)))
+	}
+	if toChannel {
+		_, err := s.post(ctx, slackKBUpdateMessage(up))
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+// DeliverKBUpdate announces a landed knowledge-base write
+// (providers.KBUpdateNotifier), to the configured room as a plain m.notice with
+// no m.thread relation, into the originating thread via ReplyInThread's MSC3440
+// relation, or both — see SlackBot.DeliverKBUpdate and kbAnnounceTargets.
+//
+// The room body goes through thread.RenderReply with escapeMatrixReply: a plain
+// body has no markup to inject, but .m.rule.roomnotif matches "@room" in it and
 // notifies every member of the room, which model-authored note text can reach
-// the same way it reaches Slack's <!channel>.
+// the same way it reaches Slack's <!channel>. ReplyInThread applies the same
+// escaper to the threaded copy.
 func (m *Matrix) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
-	_, err := m.send(ctx, m.roomID, map[string]any{
-		"msgtype": "m.notice",
-		"body":    boundPostedReply(thread.RenderReply(kbUpdateAnnouncement(up), escapeMatrixReply), matrixReplyBytes),
-	})
-	return err
+	toThread, toRoom := kbAnnounceTargets(up, m.Transport())
+	var errs []error
+	if toThread {
+		errs = append(errs, m.ReplyInThread(ctx, up.Root, up.Channel, kbUpdateAnnouncement(up)))
+	}
+	if toRoom {
+		_, err := m.send(ctx, m.roomID, map[string]any{
+			"msgtype": "m.notice",
+			"body":    boundPostedReply(thread.RenderReply(kbUpdateAnnouncement(up), escapeMatrixReply), matrixReplyBytes),
+		})
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
 }

--- a/internal/notify/kbupdate.go
+++ b/internal/notify/kbupdate.go
@@ -48,12 +48,15 @@ const (
 	kbFieldEllipsis = "…"
 )
 
-// kbUpdateAnnouncement composes the chat announcement for a knowledge-base
-// write that already landed, marking every untrusted span with thread.Untrusted
-// so the calling transport escapes it with its OWN escaper — the same boundary
-// PR3 drew for thread replies, and for the same reason: only this side knows
-// which bytes came from where, and only the transport knows what its chat
-// system treats as markup.
+// kbUpdateAnnouncement composes the CHANNEL form of the chat announcement for a
+// knowledge-base write that already landed, marking every untrusted span with
+// thread.Untrusted so the calling transport escapes it with its OWN escaper —
+// the same boundary PR3 drew for thread replies, and for the same reason: only
+// this side knows which bytes came from where, and only the transport knows what
+// its chat system treats as markup.
+//
+// kbThreadAnnouncement is the shorter form used when the announcement is
+// delivered into the thread the note came from; see it for why the two differ.
 //
 // It is a NEW egress for model-authored text, and a wider one than the reply it
 // accompanies: on the freeform route RunLore's own chat model wrote the note,
@@ -87,8 +90,8 @@ const (
 func kbUpdateAnnouncement(up providers.KBUpdate) string {
 	lines := []string{kbHeadline(up)}
 	if title := kbField(up.Title, kbTitleBytes); title != "" {
-		// Not blockquoted: it is one flattened line (see thread.noteField) that
-		// cannot reach the left margin on a line of its own.
+		// Not blockquoted: kbField has flattened it to one line, so it cannot
+		// reach the left margin on a line of its own.
 		lines = append(lines, "Entry: "+thread.Untrusted(title))
 	}
 	if from := kbProvenanceLine(up); from != "" {
@@ -100,6 +103,40 @@ func kbUpdateAnnouncement(up providers.KBUpdate) string {
 	}
 	if len(preview) < len(up.Note) {
 		lines = append(lines, kbNoteTruncatedNotice)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// kbThreadAnnouncement composes the announcement for delivery INTO the thread
+// the note was typed in: the headline and the provenance line, and nothing else.
+//
+// It is deliberately not the same message as kbUpdateAnnouncement above, because
+// the reader is not the same reader. In a channel the announcement is the only
+// thing anyone sees about that write, so it carries the entry name and quotes
+// the note. In the originating thread, the reply to the person who typed is
+// sitting directly above it and already carries both — the same pull-request
+// URL, the same "Entry: …" line, and the same 512-byte quote of the same note
+// (see thread.recordedBlock). Repeating them would answer the complaint this
+// destination exists for by relocating it: the operator who wrote that three
+// notes produced three channel posts restating the thread would get three THREAD
+// posts restating the message directly above each one, which is worse, not
+// better — the two would be adjacent instead of a channel apart.
+//
+// What is left is exactly the delta: who wrote the note and which chat system
+// they typed it in. The reply does not say either — it answers the person who
+// typed, so it has no reason to name them — and the issue asking for this
+// destination named that delta as the reason to want the announcement at all.
+//
+// A consequence worth stating: ORDER between the two is not guaranteed. The
+// announcement is scheduled on the announcer's dispatcher before the reply is
+// posted (see thread.Responder.record and thread.Mention.reply), so it can land
+// first. That is tolerable only because this form does not restate the reply —
+// two messages that each say something the other does not read correctly in
+// either order, where a message and its near-duplicate do not.
+func kbThreadAnnouncement(up providers.KBUpdate) string {
+	lines := []string{kbHeadline(up)}
+	if from := kbProvenanceLine(up); from != "" {
+		lines = append(lines, from)
 	}
 	return strings.Join(lines, "\n")
 }
@@ -141,11 +178,35 @@ func kbProvenanceLine(up providers.KBUpdate) string {
 	return ""
 }
 
-// kbField caps one untrusted single-line field, marking the cut so a truncated
-// value is not read as a whole one. The ellipsis sits inside the span the
-// caller wraps it in, which costs nothing: neither escaper touches it.
+// kbField flattens and caps one untrusted single-line field, marking the cut so
+// a truncated value is not read as a whole one. The ellipsis sits inside the
+// span the caller wraps it in, which costs nothing: neither escaper touches it.
+//
+// It FLATTENS as well as capping, and that half is a safety property rather than
+// tidiness. Every caller interpolates the result into a line at the LEFT MARGIN
+// — "Entry: …", "By … in a slack thread", the headline's URL — where the note
+// text never goes: the note is blockquoted line by line by thread.QuoteUntrusted,
+// which splits on every mandatory break AND strips RunLore's status glyphs.
+// These fields have neither defence, so one U+2028 in an author renders a new
+// visual line whose content the sender chose, at the exact indent RunLore's own
+// claims sit at — a forged "📚 Knowledge base updated — opened PR #999" directly
+// under the real headline.
+//
+// Escaping does not cover it: neither escapeMrkdwn nor escapeMatrixReply touches
+// a line separator, because on every other path the breaks were already gone.
+// The producer in internal/thread does flatten these (see noteField), so this
+// closes the gap for a providers.KBUpdate composed anywhere else — which is the
+// premise of the field-classification guard in internal/providers: a notifier
+// answers for what it renders, not for who filled the struct.
+//
+// It matters most on the IN-THREAD announcement, where kbThreadAnnouncement
+// drops the title and the quote and the provenance line is one of only two lines
+// in the message.
+//
+// Flattening runs BEFORE the cap so a break cannot survive by sitting past the
+// ceiling, and it never changes the rune count, so it cannot push a field over.
 func kbField(s string, maxBytes int) string {
-	s = strings.TrimSpace(s)
+	s = strings.TrimSpace(thread.FlattenLine(s))
 	if len(s) <= maxBytes {
 		return s
 	}
@@ -224,7 +285,7 @@ func (s *SlackBot) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) e
 	toThread, toChannel := kbAnnounceTargets(up, s.Transport())
 	var errs []error
 	if toThread {
-		errs = append(errs, s.ReplyInThread(ctx, up.Root, up.Channel, kbUpdateAnnouncement(up)))
+		errs = append(errs, s.ReplyInThread(ctx, up.Root, up.Channel, kbThreadAnnouncement(up)))
 	}
 	if toChannel {
 		_, err := s.post(ctx, slackKBUpdateMessage(up))
@@ -247,7 +308,7 @@ func (m *Matrix) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) err
 	toThread, toRoom := kbAnnounceTargets(up, m.Transport())
 	var errs []error
 	if toThread {
-		errs = append(errs, m.ReplyInThread(ctx, up.Root, up.Channel, kbUpdateAnnouncement(up)))
+		errs = append(errs, m.ReplyInThread(ctx, up.Root, up.Channel, kbThreadAnnouncement(up)))
 	}
 	if toRoom {
 		_, err := m.send(ctx, m.roomID, map[string]any{

--- a/internal/notify/kbupdate_test.go
+++ b/internal/notify/kbupdate_test.go
@@ -605,13 +605,14 @@ func TestKBUpdateAnnouncementNeverPostsIntoAThread(t *testing.T) {
 }
 
 // kbRoutingSinks wires both chat notifiers at one httptest server, recording the
-// request PATH alongside the body.
+// request PATH alongside the body, and returns them keyed by transport the way
+// kbUpdateSinkOnFakeTransport does.
 //
 // The path is what carries the destination on Matrix — the room id is in the
 // URL, not the payload — so a test that read only bodies could not tell an
 // announcement delivered into the originating room from one delivered into the
 // notifier's configured room, which is the entire distinction being tested.
-func kbRoutingSinks(t *testing.T) (slack, matrix providers.KBUpdateNotifier, posts *[]kbPost) {
+func kbRoutingSinks(t *testing.T) (map[string]providers.KBUpdateNotifier, *[]kbPost) {
 	t.Helper()
 	var sent []kbPost
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -623,7 +624,8 @@ func kbRoutingSinks(t *testing.T) (slack, matrix providers.KBUpdateNotifier, pos
 
 	bot := NewSlackBot("xoxb-test", "C-CONFIGURED")
 	bot.baseURL = srv.URL
-	return bot, NewMatrix(srv.URL, "!configured-room:example.org", "tok"), &sent
+	mx := NewMatrix(srv.URL, "!configured-room:example.org", "tok")
+	return map[string]providers.KBUpdateNotifier{"slack": bot, "matrix": mx}, &sent
 }
 
 type kbPost struct{ path, body string }
@@ -688,27 +690,24 @@ func matrixOrigin(d providers.KBDelivery) providers.KBUpdate {
 // room is in the URL where a body-only assertion cannot see it at all.
 func TestAnnouncementRoutesIntoTheOriginatingThread(t *testing.T) {
 	for _, tc := range []struct {
-		name             string
+		sink             string
 		up               providers.KBUpdate
-		sink             func(slack, matrix providers.KBUpdateNotifier) providers.KBUpdateNotifier
 		wantRoot, wantTo string
 	}{
 		{
-			name:     "slack",
+			sink:     "slack",
 			up:       slackOrigin(providers.KBDeliverThread),
-			sink:     func(s, _ providers.KBUpdateNotifier) providers.KBUpdateNotifier { return s },
 			wantRoot: "111.222", wantTo: "C-ORIGIN",
 		},
 		{
-			name:     "matrix",
+			sink:     "matrix",
 			up:       matrixOrigin(providers.KBDeliverThread),
-			sink:     func(_, m providers.KBUpdateNotifier) providers.KBUpdateNotifier { return m },
 			wantRoot: "$evt-root", wantTo: "/_matrix/client/v3/rooms/!room-of-origin:example.org/send/m.room.message/",
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			slack, matrix, posts := kbRoutingSinks(t)
-			if err := tc.sink(slack, matrix).DeliverKBUpdate(context.Background(), tc.up); err != nil {
+		t.Run(tc.sink, func(t *testing.T) {
+			sinks, posts := kbRoutingSinks(t)
+			if err := sinks[tc.sink].DeliverKBUpdate(context.Background(), tc.up); err != nil {
 				t.Fatalf("DeliverKBUpdate: %v", err)
 			}
 			if len(*posts) != 1 {
@@ -761,25 +760,25 @@ func TestAnnouncementFallsBackToTheChannelForANonOriginatingSink(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		up     providers.KBUpdate
-		sink   func(slack, matrix providers.KBUpdateNotifier) providers.KBUpdateNotifier
+		sink   string
 		wantTo string
 	}{
 		{
 			name:   "matrix sink, slack-born note",
 			up:     slackOrigin(providers.KBDeliverThread),
-			sink:   func(_, m providers.KBUpdateNotifier) providers.KBUpdateNotifier { return m },
+			sink:   "matrix",
 			wantTo: "/_matrix/client/v3/rooms/!configured-room:example.org/send/m.room.message/",
 		},
 		{
 			name:   "slack sink, matrix-born note",
 			up:     matrixOrigin(providers.KBDeliverThread),
-			sink:   func(s, _ providers.KBUpdateNotifier) providers.KBUpdateNotifier { return s },
+			sink:   "slack",
 			wantTo: "C-CONFIGURED",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			slack, matrix, posts := kbRoutingSinks(t)
-			if err := tc.sink(slack, matrix).DeliverKBUpdate(context.Background(), tc.up); err != nil {
+			sinks, posts := kbRoutingSinks(t)
+			if err := sinks[tc.sink].DeliverKBUpdate(context.Background(), tc.up); err != nil {
 				t.Fatalf("DeliverKBUpdate: %v", err)
 			}
 			if len(*posts) != 1 {
@@ -850,10 +849,10 @@ func TestAnnouncementFallsBackToTheChannelWithoutBothThreadHandles(t *testing.T)
 		{name: "neither"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			slack, _, posts := kbRoutingSinks(t)
+			sinks, posts := kbRoutingSinks(t)
 			up := slackOrigin(providers.KBDeliverThread)
 			up.Root, up.Channel = tc.root, tc.chann
-			if err := slack.DeliverKBUpdate(context.Background(), up); err != nil {
+			if err := sinks["slack"].DeliverKBUpdate(context.Background(), up); err != nil {
 				t.Fatalf("DeliverKBUpdate: %v", err)
 			}
 			if len(*posts) != 1 {
@@ -887,32 +886,29 @@ func TestAnnouncementFallsBackToTheChannelWithoutBothThreadHandles(t *testing.T)
 // original inline m.send while Slack's is a helper call.
 func TestAnnouncementBothReachesTheThreadAndTheChannel(t *testing.T) {
 	for _, tc := range []struct {
-		name                   string
+		sink                   string
 		up                     providers.KBUpdate
-		pick                   func(slack, matrix providers.KBUpdateNotifier) providers.KBUpdateNotifier
 		wantRoot               string
 		threadDest, configured string
 	}{
 		{
-			name:       "slack",
+			sink:       "slack",
 			up:         slackOrigin(providers.KBDeliverBoth),
-			pick:       func(s, _ providers.KBUpdateNotifier) providers.KBUpdateNotifier { return s },
 			wantRoot:   "111.222",
 			threadDest: "C-ORIGIN",
 			configured: "C-CONFIGURED",
 		},
 		{
-			name:       "matrix",
+			sink:       "matrix",
 			up:         matrixOrigin(providers.KBDeliverBoth),
-			pick:       func(_, m providers.KBUpdateNotifier) providers.KBUpdateNotifier { return m },
 			wantRoot:   "$evt-root",
 			threadDest: "/_matrix/client/v3/rooms/!room-of-origin:example.org/send/m.room.message/",
 			configured: "/_matrix/client/v3/rooms/!configured-room:example.org/send/m.room.message/",
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			slack, matrix, posts := kbRoutingSinks(t)
-			if err := tc.pick(slack, matrix).DeliverKBUpdate(context.Background(), tc.up); err != nil {
+		t.Run(tc.sink, func(t *testing.T) {
+			sinks, posts := kbRoutingSinks(t)
+			if err := sinks[tc.sink].DeliverKBUpdate(context.Background(), tc.up); err != nil {
 				t.Fatalf("DeliverKBUpdate: %v", err)
 			}
 			if len(*posts) != 2 {

--- a/internal/notify/kbupdate_test.go
+++ b/internal/notify/kbupdate_test.go
@@ -4,6 +4,7 @@ package notify
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -440,30 +441,356 @@ func TestMultiFansAKBUpdateOutToTheRealChatNotifiers(t *testing.T) {
 	}
 }
 
-// TestKBUpdateAnnouncementNeverPostsIntoAThread pins the destination decision.
+// TestKBUpdateAnnouncementNeverPostsIntoAThread pins the DEFAULT destination,
+// which is also the only one `announce_kb_updates: true` has ever selected.
 // The thread reply is the acknowledgement to the person who typed; the
-// announcement is what reaches everyone who was not reading that thread. It
-// goes to each notifier's own configured channel or room, so it must carry no
-// threading relation — not Slack's thread_ts, not Matrix's m.thread.
+// announcement is what reaches everyone who was not reading that thread. At the
+// channel destination it must carry no threading relation — not Slack's
+// thread_ts, not Matrix's m.thread — even with both origin handles in hand.
+//
+// The zero-valued Delivery is asserted alongside the explicit channel value on
+// purpose: providers.KBDelivery's zero value IS the channel precisely so a
+// producer that predates routing cannot change destination by omission, and a
+// test that only ever set the field would not notice that guarantee breaking.
 func TestKBUpdateAnnouncementNeverPostsIntoAThread(t *testing.T) {
-	sinks, sent := kbUpdateSinkOnFakeTransport(t)
-	up := providers.KBUpdate{
-		Transport: "slack", Root: "111.222", Route: providers.KBRouteOpenPR, PR: 99,
-		URL: "https://github.com/o/r/pull/99", Note: "a spot reclaim",
+	for _, delivery := range []providers.KBDelivery{"", providers.KBDeliverChannel} {
+		sinks, sent := kbUpdateSinkOnFakeTransport(t)
+		up := providers.KBUpdate{
+			Transport: "slack", Root: "111.222", Channel: "C-ORIGIN", Delivery: delivery,
+			Route: providers.KBRouteOpenPR, PR: 99,
+			URL: "https://github.com/o/r/pull/99", Note: "a spot reclaim",
+		}
+		for transport, sink := range sinks {
+			t.Run(transport+"/"+string(delivery), func(t *testing.T) {
+				*sent = nil
+				if err := sink.DeliverKBUpdate(context.Background(), up); err != nil {
+					t.Fatalf("DeliverKBUpdate: %v", err)
+				}
+				if len(*sent) != 1 {
+					t.Fatalf("posted %d messages, want exactly 1 — the channel destination is one post", len(*sent))
+				}
+				for _, forbidden := range []string{"thread_ts", "m.thread", "111.222"} {
+					if strings.Contains((*sent)[0], forbidden) {
+						t.Errorf("the announcement carries %q — it must post to the configured channel, never into the originating thread:\n%s",
+							forbidden, (*sent)[0])
+					}
+				}
+			})
+		}
 	}
-	for transport, sink := range sinks {
-		t.Run(transport, func(t *testing.T) {
-			*sent = nil
-			if err := sink.DeliverKBUpdate(context.Background(), up); err != nil {
+}
+
+// kbRoutingSinks wires both chat notifiers at one httptest server, recording the
+// request PATH alongside the body.
+//
+// The path is what carries the destination on Matrix — the room id is in the
+// URL, not the payload — so a test that read only bodies could not tell an
+// announcement delivered into the originating room from one delivered into the
+// notifier's configured room, which is the entire distinction being tested.
+func kbRoutingSinks(t *testing.T) (slack, matrix providers.KBUpdateNotifier, posts *[]kbPost) {
+	t.Helper()
+	var sent []kbPost
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sent = append(sent, kbPost{path: r.URL.Path, body: string(body)})
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1","event_id":"$1"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	bot := NewSlackBot("xoxb-test", "C-CONFIGURED")
+	bot.baseURL = srv.URL
+	return bot, NewMatrix(srv.URL, "!configured-room:example.org", "tok"), &sent
+}
+
+type kbPost struct{ path, body string }
+
+// threadedTo reports the thread root a post relates to, and the destination it
+// was addressed at, for whichever transport wrote it. "" for a root means the
+// post carries no threading relation at all.
+func (p kbPost) threadedTo(t *testing.T) (root, dest string) {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(p.body), &m); err != nil {
+		t.Fatalf("decode posted body: %v", err)
+	}
+	if ts, ok := m["thread_ts"].(string); ok { // Slack
+		ch, _ := m["channel"].(string)
+		return ts, ch
+	}
+	if rel, ok := m["m.relates_to"].(map[string]any); ok { // Matrix
+		if rel["rel_type"] == "m.thread" {
+			id, _ := rel["event_id"].(string)
+			return id, p.path
+		}
+	}
+	if ch, ok := m["channel"].(string); ok {
+		return "", ch
+	}
+	return "", p.path
+}
+
+// slackOrigin / matrixOrigin are one landed write as each transport reports it,
+// with both thread handles present.
+func slackOrigin(d providers.KBDelivery) providers.KBUpdate {
+	return providers.KBUpdate{
+		Transport: "slack", Root: "111.222", Channel: "C-ORIGIN", Delivery: d,
+		Route: providers.KBRouteOpenPR, PR: 99, URL: "https://github.com/o/r/pull/99",
+		Author: "sre-jane", Note: "a spot reclaim",
+	}
+}
+
+func matrixOrigin(d providers.KBDelivery) providers.KBUpdate {
+	up := slackOrigin(d)
+	up.Transport, up.Root, up.Channel = "matrix", "$evt-root", "!room-of-origin:example.org"
+	return up
+}
+
+// TestAnnouncementRoutesIntoTheOriginatingThread is the feature: with the thread
+// destination selected, the transport the note was typed in delivers the
+// announcement INTO that thread instead of beside it.
+//
+// The echo it removes is specific to a single-transport deployment, and so is
+// the reasoning. The channel destination is defended as a second destination —
+// "the thread reply answers the person who typed, the channel post reaches
+// everyone who was not reading that thread" — which holds only when there are
+// several sinks. With one, the thread already lives inside the channel the
+// announcement posts to, so the second destination IS the first: three notes in
+// one thread produced three channel posts restating what the thread had just
+// said, and the only remedy was turning the feature off and losing the signal.
+//
+// Both halves are asserted, and the destination half is the one that bites: a
+// Slack post carrying thread_ts but addressed at the notifier's CONFIGURED
+// channel rather than the thread's own lands nowhere useful, and on Matrix the
+// room is in the URL where a body-only assertion cannot see it at all.
+func TestAnnouncementRoutesIntoTheOriginatingThread(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		up               providers.KBUpdate
+		sink             func(slack, matrix providers.KBUpdateNotifier) providers.KBUpdateNotifier
+		wantRoot, wantTo string
+	}{
+		{
+			name:     "slack",
+			up:       slackOrigin(providers.KBDeliverThread),
+			sink:     func(s, _ providers.KBUpdateNotifier) providers.KBUpdateNotifier { return s },
+			wantRoot: "111.222", wantTo: "C-ORIGIN",
+		},
+		{
+			name:     "matrix",
+			up:       matrixOrigin(providers.KBDeliverThread),
+			sink:     func(_, m providers.KBUpdateNotifier) providers.KBUpdateNotifier { return m },
+			wantRoot: "$evt-root", wantTo: "/_matrix/client/v3/rooms/!room-of-origin:example.org/send/m.room.message/",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			slack, matrix, posts := kbRoutingSinks(t)
+			if err := tc.sink(slack, matrix).DeliverKBUpdate(context.Background(), tc.up); err != nil {
 				t.Fatalf("DeliverKBUpdate: %v", err)
 			}
-			for _, forbidden := range []string{"thread_ts", "m.thread", "111.222"} {
-				if strings.Contains((*sent)[0], forbidden) {
-					t.Errorf("the announcement carries %q — it must post to the configured channel, never into the originating thread:\n%s",
-						forbidden, (*sent)[0])
-				}
+			if len(*posts) != 1 {
+				t.Fatalf("posted %d messages, want exactly 1 — the thread destination replaces the channel post, "+
+					"it does not accompany it; that echo is what the operator turned the feature off to escape", len(*posts))
+			}
+			root, dest := (*posts)[0].threadedTo(t)
+			if root != tc.wantRoot {
+				t.Errorf("the announcement relates to thread root %q, want %q:\n%s", root, tc.wantRoot, (*posts)[0].body)
+			}
+			if !strings.HasPrefix(dest, tc.wantTo) {
+				t.Errorf("the announcement was addressed at %q, want the thread's own channel/room %q — "+
+					"a threaded post sent to the configured channel lands in the wrong conversation", dest, tc.wantTo)
+			}
+			// It is still the announcement, not the thread reply: the provenance
+			// line is the whole reason to want it in the thread at all.
+			if text := postedThreadText(t, (*posts)[0].body); !strings.Contains(text, "sre-jane") ||
+				!strings.Contains(text, "Knowledge base updated") {
+				t.Errorf("the threaded announcement lost its own content (who wrote the note, what landed):\n%s", text)
 			}
 		})
+	}
+}
+
+// TestAnnouncementFallsBackToTheChannelForANonOriginatingSink pins the decision
+// taken for every sink that is NOT the transport the note was typed in.
+//
+// Only one sink can ever reply into a given thread. A Matrix room cannot reply
+// into a Slack thread; the choice for the others is fall back to the channel or
+// skip them, and this contract is FALL BACK. Skipping would answer "stop
+// repeating yourself in my one channel" with "stop telling the other rooms":
+// the echo exists only on the originating transport, where the thread already
+// sits inside the announcement's channel, and a room that never saw the thread
+// has no echo to remove and no other way to learn the knowledge base moved.
+func TestAnnouncementFallsBackToTheChannelForANonOriginatingSink(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		up     providers.KBUpdate
+		sink   func(slack, matrix providers.KBUpdateNotifier) providers.KBUpdateNotifier
+		wantTo string
+	}{
+		{
+			name:   "matrix sink, slack-born note",
+			up:     slackOrigin(providers.KBDeliverThread),
+			sink:   func(_, m providers.KBUpdateNotifier) providers.KBUpdateNotifier { return m },
+			wantTo: "/_matrix/client/v3/rooms/!configured-room:example.org/send/m.room.message/",
+		},
+		{
+			name:   "slack sink, matrix-born note",
+			up:     matrixOrigin(providers.KBDeliverThread),
+			sink:   func(s, _ providers.KBUpdateNotifier) providers.KBUpdateNotifier { return s },
+			wantTo: "C-CONFIGURED",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			slack, matrix, posts := kbRoutingSinks(t)
+			if err := tc.sink(slack, matrix).DeliverKBUpdate(context.Background(), tc.up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			if len(*posts) != 1 {
+				t.Fatalf("posted %d messages, want exactly 1 — a sink that cannot reach the thread must still "+
+					"announce to its own channel, never be skipped", len(*posts))
+			}
+			root, dest := (*posts)[0].threadedTo(t)
+			if root != "" {
+				t.Errorf("a non-originating sink threaded its announcement to %q — it cannot reach another "+
+					"transport's thread, and a relation to a root it does not own is a broken message", root)
+			}
+			if !strings.HasPrefix(dest, tc.wantTo) {
+				t.Errorf("the announcement was addressed at %q, want the sink's own configured destination %q", dest, tc.wantTo)
+			}
+		})
+	}
+}
+
+// TestThreadRoutingDoesNotSilenceAThreadlessSink is the same fallback for a sink
+// that cannot reply into ANY thread, on its own transport or another's.
+//
+// An incoming-webhook Slack posts to the channel its URL was issued for and has
+// no thread_ts to set. It reports Transport "slack" nowhere and cannot, so it
+// would be the easiest sink to lose to a routing change: nothing about it errors,
+// and an operator who moved their announcements into threads would simply stop
+// seeing them here with no signal at all.
+func TestThreadRoutingDoesNotSilenceAThreadlessSink(t *testing.T) {
+	var sent []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sent = append(sent, string(body))
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	hook := NewSlack(srv.URL)
+	if err := hook.DeliverKBUpdate(context.Background(), slackOrigin(providers.KBDeliverThread)); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	if len(sent) != 1 {
+		t.Fatalf("posted %d messages, want exactly 1 — a sink with no thread to reply into must still announce", len(sent))
+	}
+	if strings.Contains(sent[0], "thread_ts") {
+		t.Errorf("an incoming webhook cannot address a thread; it must not claim to:\n%s", sent[0])
+	}
+	if !strings.Contains(postedThreadText(t, sent[0]), "https://github.com/o/r/pull/99") {
+		t.Errorf("the fallback announcement lost its content:\n%s", sent[0])
+	}
+}
+
+// TestAnnouncementFallsBackToTheChannelWithoutBothThreadHandles covers the
+// originating transport with an incomplete origin.
+//
+// A thread root alone does not address a reply: Slack's chat.postMessage needs
+// the channel and Matrix's send needs the room, and a KBUpdate can carry a root
+// without one — a thread context rebuilt from a Matrix event stamp after a
+// restart, an origin that was never a thread. The write has already landed, so
+// the fallback must ANNOUNCE it at channel level rather than drop it: losing an
+// announcement for a write that really happened is the failure this whole path
+// exists to avoid.
+func TestAnnouncementFallsBackToTheChannelWithoutBothThreadHandles(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		root, chann string
+	}{
+		{name: "no channel", root: "111.222"},
+		{name: "no root", chann: "C-ORIGIN"},
+		{name: "neither"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			slack, _, posts := kbRoutingSinks(t)
+			up := slackOrigin(providers.KBDeliverThread)
+			up.Root, up.Channel = tc.root, tc.chann
+			if err := slack.DeliverKBUpdate(context.Background(), up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			if len(*posts) != 1 {
+				t.Fatalf("posted %d messages, want exactly 1 — an unaddressable thread must fall back to the "+
+					"channel, not swallow the announcement for a write that landed", len(*posts))
+			}
+			root, dest := (*posts)[0].threadedTo(t)
+			if root != "" {
+				t.Errorf("threaded to %q with an incomplete origin (root=%q channel=%q) — a half handle cannot "+
+					"address a reply", root, tc.root, tc.chann)
+			}
+			if dest != "C-CONFIGURED" {
+				t.Errorf("addressed at %q, want the configured channel C-CONFIGURED", dest)
+			}
+		})
+	}
+}
+
+// TestAnnouncementBothReachesTheThreadAndTheChannel pins the third destination:
+// the thread gets the announcement's provenance (who wrote the note, on which
+// chat system — which the thread reply does not carry) and the channel still
+// gets the broadcast.
+//
+// It is deliberately NOT what `true` maps to: `both` produces strictly more
+// messages than the shipped behaviour, so an operator has to ask for it.
+func TestAnnouncementBothReachesTheThreadAndTheChannel(t *testing.T) {
+	slack, _, posts := kbRoutingSinks(t)
+	if err := slack.DeliverKBUpdate(context.Background(), slackOrigin(providers.KBDeliverBoth)); err != nil {
+		t.Fatalf("DeliverKBUpdate: %v", err)
+	}
+	if len(*posts) != 2 {
+		t.Fatalf("posted %d messages, want 2 (the thread and the channel)", len(*posts))
+	}
+	seen := map[string]string{}
+	for _, p := range *posts {
+		root, dest := p.threadedTo(t)
+		seen[root] = dest
+	}
+	if got, ok := seen["111.222"]; !ok || got != "C-ORIGIN" {
+		t.Errorf("no announcement reached the originating thread (root→dest: %v)", seen)
+	}
+	if got, ok := seen[""]; !ok || got != "C-CONFIGURED" {
+		t.Errorf("no unthreaded announcement reached the configured channel (root→dest: %v)", seen)
+	}
+}
+
+// TestBothStillPostsToTheChannelWhenTheThreadPostFails pins that the two
+// deliveries are independent. A wedged or renamed thread must not cost the
+// broadcast a write that already landed on the forge, so the errors are joined
+// rather than short-circuited.
+func TestBothStillPostsToTheChannelWhenTheThreadPostFails(t *testing.T) {
+	var sent []kbPost
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		sent = append(sent, kbPost{path: r.URL.Path, body: string(body)})
+		if strings.Contains(string(body), "thread_ts") {
+			_, _ = w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true,"ts":"1"}`))
+	}))
+	defer srv.Close()
+
+	bot := NewSlackBot("xoxb-test", "C-CONFIGURED")
+	bot.baseURL = srv.URL
+
+	err := bot.DeliverKBUpdate(context.Background(), slackOrigin(providers.KBDeliverBoth))
+	if err == nil {
+		t.Error("a failed thread post must be reported, not swallowed here — the announcer is what decides to swallow it")
+	}
+	if len(sent) != 2 {
+		t.Fatalf("posted %d messages, want 2 — the channel half must survive the thread half failing", len(sent))
+	}
+	if root, _ := sent[1].threadedTo(t); root != "" {
+		t.Errorf("the second post is threaded (%q); the channel half never was", root)
 	}
 }
 
@@ -485,19 +812,25 @@ func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
 		"Author":    "sre-jane",
 		"Note":      "a spot reclaim",
 	}
-	// Root is an opaque per-transport handle (a Slack thread_ts, a Matrix event
-	// id). It identifies the thread for a programmatic consumer; printed into a
-	// channel it is noise a human cannot act on, and the announcement already
+	// Root and Channel are opaque per-transport handles (a Slack thread_ts and
+	// channel id, a Matrix event id and room id). They identify the thread for a
+	// programmatic consumer and address a threaded delivery; printed into a
+	// channel they are noise a human cannot act on, and the announcement already
 	// names the transport it came from. At is the wall clock of a message the
-	// chat system timestamps itself.
+	// chat system timestamps itself. Delivery is an instruction to the sink about
+	// where to post, not a fact about the write, so nothing about it belongs in
+	// the message a human reads.
 	withheld := map[string]string{
-		"Root": "$evt-root",
-		"At":   "2026-08-16T09:00:00Z",
+		"Root":     "$evt-root",
+		"Channel":  "!room-of-origin:example.org",
+		"Delivery": "both",
+		"At":       "2026-08-16T09:00:00Z",
 	}
 
 	sinks, sent := kbUpdateSinkOnFakeTransport(t)
 	up := providers.KBUpdate{
-		Transport: "matrix", Root: "$evt-root", Route: providers.KBRouteOpenPR, PR: 4242,
+		Transport: "matrix", Root: "$evt-root", Channel: "!room-of-origin:example.org",
+		Delivery: providers.KBDeliverBoth, Route: providers.KBRouteOpenPR, PR: 4242,
 		URL: "https://github.com/o/r/pull/4242", Title: "Operator note: OOM",
 		Author: "sre-jane", Note: "a spot reclaim", At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
 	}

--- a/internal/notify/kbupdate_test.go
+++ b/internal/notify/kbupdate_test.go
@@ -15,17 +15,35 @@ import (
 	"time"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/thread"
 )
 
 // hostileKBUpdate fills EVERY field providers.KBUpdate documents as untrusted —
-// Note, Title, Author, URL and Root, all five — with the payload that transport
-// treats as markup. Filling all five rather than the ones a renderer happens to
-// use today is the point: a field this announcement does not render yet is one
-// escape away from being rendered, and the assertion has to already cover it.
-func hostileKBUpdate(payload string) providers.KBUpdate {
+// Note, Title, Author, URL, Root and Channel, all six — with the payload that
+// transport treats as markup. Filling all six rather than the ones a renderer
+// happens to use today is the point: a field this announcement does not render
+// yet is one escape away from being rendered, and the assertion has to already
+// cover it.
+//
+// transport and delivery are PARAMETERS rather than constants because the
+// announcement now has two renderings and three destinations, and hostility is a
+// property of each. A fixture pinned to Transport "slack" with no Channel and no
+// Delivery — which is what this was — can only ever exercise the channel post:
+// kbAnnounceTargets refuses the thread route without both handles, so every
+// neutralisation assertion in this file silently covered one of the two paths.
+// Replacing both ReplyInThread calls with a raw, unescaped, unbounded post left
+// the entire repository green.
+//
+// Channel carries the payload rather than a benign id for the reason Root does:
+// it is a transport-reported string, so it is untrusted, and on the thread route
+// it is also ADDRESSING. Hostile bytes there prove it is used as a handle and
+// never interpolated into the message.
+func hostileKBUpdate(payload, transport string, delivery providers.KBDelivery) providers.KBUpdate {
 	return providers.KBUpdate{
-		Transport: "slack",
+		Transport: transport,
 		Root:      payload,
+		Channel:   payload,
+		Delivery:  delivery,
 		Route:     providers.KBRouteOpenPR,
 		PR:        99,
 		URL:       payload,
@@ -34,6 +52,39 @@ func hostileKBUpdate(payload string) providers.KBUpdate {
 		Note:      "the registry PVC filled up — " + payload,
 		At:        time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
 	}
+}
+
+// kbDestinations is every destination an announcement can be delivered at.
+// Hostility tests run the whole set: the in-thread rendering and the channel
+// rendering are different messages built by different functions and posted by
+// different methods, and "both" is the only case that exercises them together.
+var kbDestinations = []providers.KBDelivery{
+	providers.KBDeliverChannel, providers.KBDeliverThread, providers.KBDeliverBoth,
+}
+
+// kbDestName names a destination for a subtest, spelling the zero value "channel"
+// rather than "".
+func kbDestName(d providers.KBDelivery) string {
+	if d == providers.KBDeliverChannel {
+		return "channel"
+	}
+	return string(d)
+}
+
+// postedTexts returns the rendered message of EVERY post captured, so an
+// assertion covers each one rather than only (*sent)[0]. A "both" delivery makes
+// two posts from two different renderers, and reading the first would leave
+// whichever the transport happens to send second wholly unasserted.
+func postedTexts(t *testing.T, sent []string) []string {
+	t.Helper()
+	if len(sent) == 0 {
+		t.Fatal("nothing was posted at all")
+	}
+	out := make([]string, 0, len(sent))
+	for _, body := range sent {
+		out = append(out, postedThreadText(t, body))
+	}
+	return out
 }
 
 // kbUpdateSinkOnFakeTransport wires both chat notifiers at one httptest server
@@ -66,68 +117,141 @@ func kbUpdateSinkOnFakeTransport(t *testing.T) (map[string]providers.KBUpdateNot
 // same pair PR3's Untrusted/RenderReply boundary was built for, arriving
 // through a different door.
 func TestSlackKBUpdateAnnouncementNeutralisesUntrustedFields(t *testing.T) {
-	sinks, sent := kbUpdateSinkOnFakeTransport(t)
-	up := hostileKBUpdate("<!channel> <https://evil.example|https://github.com/acme/kb/pull/7>")
+	for _, dest := range kbDestinations {
+		t.Run(kbDestName(dest), func(t *testing.T) {
+			sinks, sent := kbUpdateSinkOnFakeTransport(t)
+			up := hostileKBUpdate("<!channel> <https://evil.example|https://github.com/acme/kb/pull/7>", "slack", dest)
 
-	*sent = nil
-	if err := sinks["slack"].DeliverKBUpdate(context.Background(), up); err != nil {
-		t.Fatalf("DeliverKBUpdate: %v", err)
-	}
-	if len(*sent) != 1 {
-		t.Fatalf("posted %d messages, want 1", len(*sent))
-	}
-	text := postedThreadText(t, (*sent)[0])
-
-	for _, live := range []string{"<!channel>", "<https://evil.example|"} {
-		if strings.Contains(text, live) {
-			t.Errorf("an untrusted field reached Slack as live mrkdwn (%q):\n%s", live, text)
-		}
-	}
-	if !strings.Contains(text, "&lt;!channel&gt;") {
-		t.Errorf("the untrusted text must still be READABLE, escaped rather than censored:\n%s", text)
-	}
-	// RunLore's own framing is not escaped with it: the blockquote markers are
-	// what keep the quoted note distinguishable from RunLore's own claims, and
-	// mrkdwnEscaper would turn them into literal "&gt; ".
-	if !strings.Contains(text, "\n> ") {
-		t.Errorf("the quoted note lost its blockquote markers to escaping:\n%s", text)
-	}
-	for _, line := range strings.Split(text, "\n") {
-		if strings.HasPrefix(line, "&gt;") {
-			t.Errorf("RunLore's own blockquote marker was escaped, so the quote no longer renders as one: %q", line)
-		}
-	}
-	if strings.Contains(text, "\ue000") {
-		t.Errorf("an untrusted-span mark reached the chat system:\n%s", text)
+			*sent = nil
+			if err := sinks["slack"].DeliverKBUpdate(context.Background(), up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			for i, text := range postedTexts(t, *sent) {
+				for _, live := range []string{"<!channel>", "<https://evil.example|"} {
+					if strings.Contains(text, live) {
+						t.Errorf("post %d: an untrusted field reached Slack as live mrkdwn (%q):\n%s", i, live, text)
+					}
+				}
+				if !strings.Contains(text, "&lt;!channel&gt;") {
+					t.Errorf("post %d: the untrusted text must still be READABLE, escaped rather than censored:\n%s", i, text)
+				}
+				if strings.Contains(text, "") {
+					t.Errorf("post %d: an untrusted-span mark reached the chat system:\n%s", i, text)
+				}
+				// RunLore's own framing is not escaped with the untrusted spans: the
+				// blockquote markers are what keep the quoted note distinguishable
+				// from RunLore's own claims, and mrkdwnEscaper would turn them into
+				// literal "&gt; ". Only the CHANNEL form quotes the note at all — the
+				// in-thread form drops it — so the marker is required exactly where
+				// the quote is and absent where it is not, which also pins that the
+				// two forms did not quietly become one message again.
+				if quoted := strings.Contains(text, "the registry PVC filled up"); quoted != strings.Contains(text, "\n> ") {
+					t.Errorf("post %d: the quoted note and its blockquote markers must arrive together:\n%s", i, text)
+				}
+				for _, line := range strings.Split(text, "\n") {
+					if strings.HasPrefix(line, "&gt;") {
+						t.Errorf("post %d: RunLore's own blockquote marker was escaped, so the quote no longer renders as one: %q", i, line)
+					}
+				}
+			}
+		})
 	}
 }
 
-// TestMatrixKBUpdateAnnouncementNeutralisesUntrustedFields is the same
-// guarantee against Matrix's own hazard. A plain m.notice body has no markup to
-// inject, but .m.rule.roomnotif matches "@room" in content.body and notifies
-// every member of the room — the direct analogue of Slack's <!channel>, and
-// reachable the same way, through text RunLore's model wrote.
+// TestMatrixKBUpdateAnnouncementNeutralisesUntrustedFields is the same guarantee
+// against Matrix's own hazard, across the same destinations. A plain m.notice
+// body has no markup to inject, but .m.rule.roomnotif matches "@room" in
+// content.body and notifies every member of the room — the direct analogue of
+// Slack's <!channel>, reachable the same way, through text RunLore's model
+// wrote. That push rule matches a THREADED m.notice exactly as it matches an
+// unthreaded one, so the m.thread relation buys the room nothing.
 func TestMatrixKBUpdateAnnouncementNeutralisesUntrustedFields(t *testing.T) {
+	for _, dest := range kbDestinations {
+		t.Run(kbDestName(dest), func(t *testing.T) {
+			sinks, sent := kbUpdateSinkOnFakeTransport(t)
+			up := hostileKBUpdate("@room now", "matrix", dest)
+
+			*sent = nil
+			if err := sinks["matrix"].DeliverKBUpdate(context.Background(), up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			for i, body := range postedTexts(t, *sent) {
+				if strings.Contains(body, "@room") {
+					t.Errorf("post %d: an untrusted field reached the room as a live @room ping:\n%s", i, body)
+				}
+				if !strings.Contains(body, "@\u2060room") {
+					t.Errorf("post %d: the token must be marked, not censored — a human still has to be able to read it:\n%s", i, body)
+				}
+				if strings.Contains(body, "") {
+					t.Errorf("post %d: an untrusted-span mark reached the room:\n%s", i, body)
+				}
+			}
+		})
+	}
+}
+
+// TestAnnouncementProvenanceCannotForgeALine is the in-thread form's own version
+// of the blockquote-escape defect below, aimed at the field that form still
+// renders.
+//
+// kbThreadAnnouncement drops the title and the note quote, so the message is the
+// headline plus "By <author> in a slack thread" — two lines, one of which
+// interpolates an untrusted value at the LEFT MARGIN with no blockquote around
+// it. thread.QuoteUntrusted, which is what makes a mandatory break harmless
+// inside the note, never sees this field, and neither escaper touches a line
+// separator. One U+2028 in an author therefore renders a third visual line the
+// sender chose, directly under RunLore's real headline and indented identically
+// — and the headline is precisely the line worth forging, because it is the one
+// claiming a pull request exists.
+//
+// Every mandatory break is driven rather than U+2028 alone, for the reason
+// thread.mandatoryBreaks exists: a list that learns one break at a time is wrong
+// until the next report. The channel destination runs with it because the same
+// field reaches the same margin there — the flattening closes both at once.
+func TestAnnouncementProvenanceCannotForgeALine(t *testing.T) {
+	const forged = "\U0001F4DA Knowledge base updated — opened PR #999 — https://evil.example/kb"
+
 	sinks, sent := kbUpdateSinkOnFakeTransport(t)
-	up := hostileKBUpdate("@room now")
-
-	*sent = nil
-	if err := sinks["matrix"].DeliverKBUpdate(context.Background(), up); err != nil {
-		t.Fatalf("DeliverKBUpdate: %v", err)
-	}
-	if len(*sent) != 1 {
-		t.Fatalf("posted %d messages, want 1", len(*sent))
-	}
-	body := postedThreadText(t, (*sent)[0])
-
-	if strings.Contains(body, "@room") {
-		t.Errorf("an untrusted field reached the room as a live @room ping:\n%s", body)
-	}
-	if !strings.Contains(body, "@\u2060room") {
-		t.Errorf("the token must be marked, not censored — a human still has to be able to read it:\n%s", body)
-	}
-	if strings.Contains(body, "\ue000") {
-		t.Errorf("an untrusted-span mark reached the room:\n%s", body)
+	for _, br := range []struct{ name, sep string }{
+		{"LF U+000A", "\n"},
+		{"CR U+000D", "\r"},
+		{"CRLF", "\r\n"},
+		{"VT U+000B", "\v"},
+		{"FF U+000C", "\f"},
+		{"NEL U+0085", "\u0085"},
+		{"LS U+2028", "\u2028"},
+		{"PS U+2029", "\u2029"},
+	} {
+		for _, dest := range kbDestinations {
+			t.Run(br.name+"/"+kbDestName(dest), func(t *testing.T) {
+				up := providers.KBUpdate{
+					Transport: "slack", Root: "111.222", Channel: "C-ORIGIN", Delivery: dest,
+					Route: providers.KBRouteOpenPR, PR: 42, URL: "https://github.com/o/r/pull/42",
+					Author: "alice" + br.sep + forged,
+					Note:   "the registry PVC filled up",
+				}
+				*sent = nil
+				if err := sinks["slack"].DeliverKBUpdate(context.Background(), up); err != nil {
+					t.Fatalf("DeliverKBUpdate: %v", err)
+				}
+				for i, text := range postedTexts(t, *sent) {
+					for n, line := range strings.Split(text, "\n") {
+						if n == 0 {
+							continue // RunLore's own headline, the only one allowed
+						}
+						if strings.HasPrefix(strings.TrimSpace(line), "\U0001F4DA") {
+							t.Errorf("post %d: a %s in the author put a forged RunLore headline at the left margin:\n%q",
+								i, br.name, text)
+						}
+					}
+					// Flattened, not censored: a human must still be able to read
+					// what the author field said, on the one line it is given.
+					if !strings.Contains(text, "alice") || !strings.Contains(text, "opened PR #999") {
+						t.Errorf("post %d: the author was censored rather than flattened:\n%q", i, text)
+					}
+				}
+			})
+		}
 	}
 }
 
@@ -535,7 +659,7 @@ func slackOrigin(d providers.KBDelivery) providers.KBUpdate {
 	return providers.KBUpdate{
 		Transport: "slack", Root: "111.222", Channel: "C-ORIGIN", Delivery: d,
 		Route: providers.KBRouteOpenPR, PR: 99, URL: "https://github.com/o/r/pull/99",
-		Author: "sre-jane", Note: "a spot reclaim",
+		Author: "sre-jane", Note: "a spot reclaim", Title: "Operator note: OOM in payments",
 	}
 }
 
@@ -601,9 +725,23 @@ func TestAnnouncementRoutesIntoTheOriginatingThread(t *testing.T) {
 			}
 			// It is still the announcement, not the thread reply: the provenance
 			// line is the whole reason to want it in the thread at all.
-			if text := postedThreadText(t, (*posts)[0].body); !strings.Contains(text, "sre-jane") ||
-				!strings.Contains(text, "Knowledge base updated") {
+			text := postedThreadText(t, (*posts)[0].body)
+			if !strings.Contains(text, "sre-jane") || !strings.Contains(text, "Knowledge base updated") {
 				t.Errorf("the threaded announcement lost its own content (who wrote the note, what landed):\n%s", text)
+			}
+			// And it is the SHORT form. In the thread, the reply RunLore already
+			// posted carries the entry title and quotes the note back; repeating
+			// both here is the echo this feature exists to remove, moved closer to
+			// its source rather than removed. Without these two assertions the
+			// reduced renderer can be swapped for the full one with the suite green
+			// — which is how the echo would come back.
+			for _, unwanted := range []struct{ frag, why string }{
+				{"Operator note: OOM in payments", "the entry title — the reply one message up already states it"},
+				{"a spot reclaim", "the note itself — the reply already quotes it back to the person who typed it"},
+			} {
+				if strings.Contains(text, unwanted.frag) {
+					t.Errorf("the in-thread announcement restates %s:\n%s", unwanted.why, text)
+				}
 			}
 		})
 	}
@@ -741,69 +879,154 @@ func TestAnnouncementFallsBackToTheChannelWithoutBothThreadHandles(t *testing.T)
 //
 // It is deliberately NOT what `true` maps to: `both` produces strictly more
 // messages than the shipped behaviour, so an operator has to ask for it.
+//
+// Both transports are driven. They do not share an implementation — each
+// DeliverKBUpdate composes its own two posts — so forcing the room half off when
+// the thread half fires leaves the other transport's test green, and Matrix is
+// the one where that mistake is easiest to make: its channel post is the
+// original inline m.send while Slack's is a helper call.
 func TestAnnouncementBothReachesTheThreadAndTheChannel(t *testing.T) {
-	slack, _, posts := kbRoutingSinks(t)
-	if err := slack.DeliverKBUpdate(context.Background(), slackOrigin(providers.KBDeliverBoth)); err != nil {
-		t.Fatalf("DeliverKBUpdate: %v", err)
-	}
-	if len(*posts) != 2 {
-		t.Fatalf("posted %d messages, want 2 (the thread and the channel)", len(*posts))
-	}
-	seen := map[string]string{}
-	for _, p := range *posts {
-		root, dest := p.threadedTo(t)
-		seen[root] = dest
-	}
-	if got, ok := seen["111.222"]; !ok || got != "C-ORIGIN" {
-		t.Errorf("no announcement reached the originating thread (root→dest: %v)", seen)
-	}
-	if got, ok := seen[""]; !ok || got != "C-CONFIGURED" {
-		t.Errorf("no unthreaded announcement reached the configured channel (root→dest: %v)", seen)
+	for _, tc := range []struct {
+		name                   string
+		up                     providers.KBUpdate
+		pick                   func(slack, matrix providers.KBUpdateNotifier) providers.KBUpdateNotifier
+		wantRoot               string
+		threadDest, configured string
+	}{
+		{
+			name:       "slack",
+			up:         slackOrigin(providers.KBDeliverBoth),
+			pick:       func(s, _ providers.KBUpdateNotifier) providers.KBUpdateNotifier { return s },
+			wantRoot:   "111.222",
+			threadDest: "C-ORIGIN",
+			configured: "C-CONFIGURED",
+		},
+		{
+			name:       "matrix",
+			up:         matrixOrigin(providers.KBDeliverBoth),
+			pick:       func(_, m providers.KBUpdateNotifier) providers.KBUpdateNotifier { return m },
+			wantRoot:   "$evt-root",
+			threadDest: "/_matrix/client/v3/rooms/!room-of-origin:example.org/send/m.room.message/",
+			configured: "/_matrix/client/v3/rooms/!configured-room:example.org/send/m.room.message/",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			slack, matrix, posts := kbRoutingSinks(t)
+			if err := tc.pick(slack, matrix).DeliverKBUpdate(context.Background(), tc.up); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			if len(*posts) != 2 {
+				t.Fatalf("posted %d messages, want 2 (the thread and the channel)", len(*posts))
+			}
+			seen := map[string]string{}
+			for _, p := range *posts {
+				root, dest := p.threadedTo(t)
+				seen[root] = dest
+			}
+			if got, ok := seen[tc.wantRoot]; !ok || !strings.HasPrefix(got, tc.threadDest) {
+				t.Errorf("no announcement reached the originating thread (root→dest: %v)", seen)
+			}
+			if got, ok := seen[""]; !ok || !strings.HasPrefix(got, tc.configured) {
+				t.Errorf("no unthreaded announcement reached the configured channel/room (root→dest: %v)", seen)
+			}
+		})
 	}
 }
 
 // TestBothStillPostsToTheChannelWhenTheThreadPostFails pins that the two
 // deliveries are independent. A wedged or renamed thread must not cost the
-// broadcast a write that already landed on the forge, so the errors are joined
+// broadcast a write that already landed on the forge, so the errors are JOINED
 // rather than short-circuited.
+//
+// Matrix is driven alongside Slack, and it is the transport this matters most
+// on: a thread root that has been redacted still exists as an event id, so the
+// homeserver accepts the relation and the message renders detached — and a
+// room whose power levels changed rejects the send outright. Its channel post is
+// also the one written inline rather than through a helper, so a `return err`
+// slipped into the thread half is easiest to miss exactly here.
 func TestBothStillPostsToTheChannelWhenTheThreadPostFails(t *testing.T) {
-	var sent []kbPost
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		sent = append(sent, kbPost{path: r.URL.Path, body: string(body)})
-		if strings.Contains(string(body), "thread_ts") {
-			_, _ = w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`))
-			return
-		}
-		_, _ = w.Write([]byte(`{"ok":true,"ts":"1"}`))
-	}))
-	defer srv.Close()
+	for _, tc := range []struct {
+		name     string
+		up       providers.KBUpdate
+		failWhen string // substring of the request that identifies the THREAD post
+		build    func(url string) providers.KBUpdateNotifier
+	}{
+		{
+			name:     "slack",
+			up:       slackOrigin(providers.KBDeliverBoth),
+			failWhen: "thread_ts",
+			build: func(url string) providers.KBUpdateNotifier {
+				bot := NewSlackBot("xoxb-test", "C-CONFIGURED")
+				bot.baseURL = url
+				return bot
+			},
+		},
+		{
+			name:     "matrix",
+			up:       matrixOrigin(providers.KBDeliverBoth),
+			failWhen: "m.thread",
+			build: func(url string) providers.KBUpdateNotifier {
+				return NewMatrix(url, "!configured-room:example.org", "tok")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var sent []kbPost
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				sent = append(sent, kbPost{path: r.URL.Path, body: string(body)})
+				if strings.Contains(string(body), tc.failWhen) {
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(`{"ok":false,"error":"thread_not_found"}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"ok":true,"ts":"1","event_id":"$1"}`))
+			}))
+			defer srv.Close()
 
-	bot := NewSlackBot("xoxb-test", "C-CONFIGURED")
-	bot.baseURL = srv.URL
-
-	err := bot.DeliverKBUpdate(context.Background(), slackOrigin(providers.KBDeliverBoth))
-	if err == nil {
-		t.Error("a failed thread post must be reported, not swallowed here — the announcer is what decides to swallow it")
-	}
-	if len(sent) != 2 {
-		t.Fatalf("posted %d messages, want 2 — the channel half must survive the thread half failing", len(sent))
-	}
-	if root, _ := sent[1].threadedTo(t); root != "" {
-		t.Errorf("the second post is threaded (%q); the channel half never was", root)
+			if err := tc.build(srv.URL).DeliverKBUpdate(context.Background(), tc.up); err == nil {
+				t.Error("a failed thread post must be reported, not swallowed here — the announcer is what decides to swallow it")
+			}
+			if len(sent) != 2 {
+				t.Fatalf("posted %d messages, want 2 — the channel half must survive the thread half failing", len(sent))
+			}
+			if root, _ := sent[1].threadedTo(t); root != "" {
+				t.Errorf("the second post is threaded (%q); the channel half never was", root)
+			}
+		})
 	}
 }
 
-// TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot keeps the renderer honest
-// about the event it is given. providers.KBUpdate has a reflection test forcing
-// every field to be classified trusted or untrusted; this is the notifier's
-// side of it — a field added to the event must be either shown to the operator
-// or listed here as deliberately withheld, so "we forgot to render it" cannot
-// pass as "we chose not to".
+// TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot keeps the renderers honest
+// about the event they are given. providers.KBUpdate has a reflection test
+// forcing every field to be classified trusted or untrusted; this is the
+// notifier's side of it — a field added to the event must be either shown to the
+// operator or listed here as deliberately withheld, so "we forgot to render it"
+// cannot pass as "we chose not to".
+//
+// BOTH renderings are walked, each against its own list. There are two messages
+// now — the channel form and the shorter in-thread form — and this used to
+// inspect one: it set Delivery to "both" but on a matrix-born event delivered
+// through the SLACK sink, which is not the originating transport, so the thread
+// route was never taken and only the channel post was ever read. It looked
+// stronger than it was.
+//
+// The in-thread list is also what pins the reduced form itself. Title and Note
+// are WITHHELD there, deliberately: the reply to the person who typed is sitting
+// directly above it carrying both, and repeating them is the echo this
+// destination exists to remove. If someone points the thread post back at
+// kbUpdateAnnouncement, those two entries fail — which is the guard the
+// destination's whole justification rests on.
 func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
-	// What the announcement must show, and the form it shows it in — Route is a
-	// sentence a human reads, not the raw enum value.
-	shows := map[string]string{
+	up := providers.KBUpdate{
+		Transport: "matrix", Root: "$evt-root", Channel: "!room-of-origin:example.org",
+		Delivery: providers.KBDeliverBoth, Route: providers.KBRouteOpenPR, PR: 4242,
+		URL: "https://github.com/o/r/pull/4242", Title: "Operator note: OOM",
+		Author: "sre-jane", Note: "a spot reclaim", At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+	}
+	// Values a list may search for, one per field, so an entry cannot be written
+	// against a value the fixture does not carry.
+	value := map[string]string{
 		"Transport": "matrix",
 		"Route":     "opened PR",
 		"PR":        "4242",
@@ -811,64 +1034,77 @@ func TestKBUpdateFieldsAreAllRenderedOrDeliberatelyNot(t *testing.T) {
 		"Title":     "Operator note: OOM",
 		"Author":    "sre-jane",
 		"Note":      "a spot reclaim",
-	}
-	// Root and Channel are opaque per-transport handles (a Slack thread_ts and
-	// channel id, a Matrix event id and room id). They identify the thread for a
-	// programmatic consumer and address a threaded delivery; printed into a
-	// channel they are noise a human cannot act on, and the announcement already
-	// names the transport it came from. At is the wall clock of a message the
-	// chat system timestamps itself. Delivery is an instruction to the sink about
-	// where to post, not a fact about the write, so nothing about it belongs in
-	// the message a human reads.
-	withheld := map[string]string{
-		"Root":     "$evt-root",
-		"Channel":  "!room-of-origin:example.org",
-		"Delivery": "both",
-		"At":       "2026-08-16T09:00:00Z",
+		"Root":      "$evt-root",
+		"Channel":   "!room-of-origin:example.org",
+		"Delivery":  "both",
+		"At":        "2026-08-16T09:00:00Z",
 	}
 
-	sinks, sent := kbUpdateSinkOnFakeTransport(t)
-	up := providers.KBUpdate{
-		Transport: "matrix", Root: "$evt-root", Channel: "!room-of-origin:example.org",
-		Delivery: providers.KBDeliverBoth, Route: providers.KBRouteOpenPR, PR: 4242,
-		URL: "https://github.com/o/r/pull/4242", Title: "Operator note: OOM",
-		Author: "sre-jane", Note: "a spot reclaim", At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
-	}
-	*sent = nil
-	if err := sinks["slack"].DeliverKBUpdate(context.Background(), up); err != nil {
-		t.Fatalf("DeliverKBUpdate: %v", err)
-	}
-	text := postedThreadText(t, (*sent)[0])
-
-	rt := reflect.TypeOf(up)
-	for i := range rt.NumField() {
-		name := rt.Field(i).Name
-		want, shown := shows[name]
-		hide, hidden := withheld[name]
-		switch {
-		case shown == hidden:
-			t.Errorf("KBUpdate.%s is in neither or both of shows/withheld — decide whether an operator reading the channel is told it", name)
-		case shown && !strings.Contains(text, want):
-			t.Errorf("KBUpdate.%s must be announced as %q, and is not:\n%s", name, want, text)
-		case hidden && strings.Contains(text, hide):
-			t.Errorf("KBUpdate.%s is listed as deliberately withheld but is rendered — update the list or stop rendering it:\n%s", name, text)
-		}
-	}
-
-	// The reverse direction, which its internal/providers sibling
-	// (TestKBUpdateClassifiesEveryFieldForEscaping) already checks and this side
-	// did not: an entry naming a field KBUpdate no longer has asserts nothing
-	// about anything. The loop above only walks the STRUCT, so a renamed or
-	// deleted field leaves its entry behind, still listed, still reading in
-	// review as a decision someone made about a field that is being rendered —
-	// and the new field that replaced it falls straight into the "in neither"
-	// arm, whose message is about the new name rather than the stale one.
-	for _, m := range []map[string]string{shows, withheld} {
-		for name := range m {
-			if _, ok := rt.FieldByName(name); !ok {
-				t.Errorf("shows/withheld classifies %q, but KBUpdate has no such field — stale entry, "+
-					"so nothing is checking whatever replaced it", name)
+	for _, form := range []struct {
+		name   string
+		render func(providers.KBUpdate) string
+		shows  []string
+	}{
+		{
+			// The CHANNEL form is the only thing anyone in that channel sees about
+			// the write, so it carries the entry name and quotes the note.
+			name: "channel", render: kbUpdateAnnouncement,
+			shows: []string{"Transport", "Route", "PR", "URL", "Title", "Author", "Note"},
+		},
+		{
+			// The IN-THREAD form drops Title and Note: the reply above it already
+			// carries the same entry name and the same quote of the same note.
+			// What is left is exactly the delta the reply lacks.
+			name: "thread", render: kbThreadAnnouncement,
+			shows: []string{"Transport", "Route", "PR", "URL", "Author"},
+		},
+	} {
+		t.Run(form.name, func(t *testing.T) {
+			shown := map[string]bool{}
+			for _, name := range form.shows {
+				shown[name] = true
 			}
+			// Rendered through the real transport rather than read off the composer,
+			// so what is asserted is what goes on the wire.
+			text := thread.RenderReply(form.render(up), escapeMrkdwn)
+
+			rt := reflect.TypeOf(up)
+			for i := range rt.NumField() {
+				name := rt.Field(i).Name
+				want, ok := value[name]
+				if !ok {
+					t.Errorf("KBUpdate.%s has no entry in the value map — add one so both forms can be "+
+						"checked for it", name)
+					continue
+				}
+				switch {
+				case shown[name] && !strings.Contains(text, want):
+					t.Errorf("the %s announcement must show KBUpdate.%s as %q, and does not:\n%s",
+						form.name, name, want, text)
+				case !shown[name] && strings.Contains(text, want):
+					t.Errorf("the %s announcement renders KBUpdate.%s, which it is listed as withholding — "+
+						"update the list or stop rendering it:\n%s", form.name, name, text)
+				}
+			}
+			// The reverse direction: a `shows` entry naming a field KBUpdate no
+			// longer has asserts nothing about anything, and the loop above only
+			// walks the STRUCT, so a stale name would sit there reading in review as
+			// a decision someone made.
+			for _, name := range form.shows {
+				if _, ok := rt.FieldByName(name); !ok {
+					t.Errorf("the %s form claims to show %q, but KBUpdate has no such field — stale entry",
+						form.name, name)
+				}
+			}
+		})
+	}
+
+	// The value map is checked the same way, for the same reason.
+	rt := reflect.TypeOf(up)
+	for name := range value {
+		if _, ok := rt.FieldByName(name); !ok {
+			t.Errorf("the value map classifies %q, but KBUpdate has no such field — stale entry, "+
+				"so nothing is checking whatever replaced it", name)
 		}
 	}
 }

--- a/internal/notify/payload.go
+++ b/internal/notify/payload.go
@@ -107,13 +107,25 @@ type KBUpdatePayload struct {
 	Event     string `json:"event"` // always kbUpdateEvent
 	Transport string `json:"transport,omitempty"`
 	Root      string `json:"root,omitempty"`
-	Route     string `json:"route"`
-	PR        int    `json:"pr,omitempty"`
-	URL       string `json:"url,omitempty"`
-	Title     string `json:"title,omitempty"`
-	Author    string `json:"author,omitempty"`
-	Note      string `json:"note,omitempty"`
-	At        string `json:"at,omitempty"` // RFC3339; "" when unknown
+	// Channel is the other half of the thread handle, and it ships because
+	// "root" alone does not identify a conversation to anything outside this
+	// process: a Slack thread_ts is scoped to its channel and a Matrix event id
+	// to its room, so a receiver building a permalink back to where the note was
+	// typed — which is the use "root" exists for — cannot do it without this.
+	// Sending one and not the other made the pair useless while looking complete.
+	//
+	// providers.KBUpdate.Delivery is deliberately NOT here: it is a routing
+	// instruction for the chat sinks, not a fact about the write, and this
+	// payload is the record. See TestKBUpdatePayloadCarriesEveryRecordedField for
+	// where that decision is written down and enforced.
+	Channel string `json:"channel,omitempty"`
+	Route   string `json:"route"`
+	PR      int    `json:"pr,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Title   string `json:"title,omitempty"`
+	Author  string `json:"author,omitempty"`
+	Note    string `json:"note,omitempty"`
+	At      string `json:"at,omitempty"` // RFC3339; "" when unknown
 }
 
 // NewKBUpdatePayload maps a KBUpdate to the delivery payload.
@@ -123,7 +135,7 @@ func NewKBUpdatePayload(up providers.KBUpdate) KBUpdatePayload {
 		at = up.At.UTC().Format(time.RFC3339)
 	}
 	return KBUpdatePayload{
-		Event: kbUpdateEvent, Transport: up.Transport, Root: up.Root,
+		Event: kbUpdateEvent, Transport: up.Transport, Root: up.Root, Channel: up.Channel,
 		Route: string(up.Route), PR: up.PR, URL: up.URL,
 		Title: up.Title, Author: up.Author, Note: up.Note, At: at,
 	}

--- a/internal/notify/payload_test.go
+++ b/internal/notify/payload_test.go
@@ -3,6 +3,7 @@
 package notify
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -44,5 +45,84 @@ func TestNewPayloadMapping(t *testing.T) {
 	}
 	if q := NewPayload(providers.Investigation{}); q.StartedAt != "" {
 		t.Errorf("zero StartedAt must render empty, got %q", q.StartedAt)
+	}
+}
+
+// kbPayloadOmitted names every providers.KBUpdate field the webhook payload
+// deliberately does NOT carry, with the reason. Stated here rather than derived,
+// exactly as internal/providers states the untrusted/trusted split, so dropping a
+// field from the record is a decision someone writes down.
+//
+// Delivery is a routing instruction for the chat sinks — where to post the
+// announcement — not a fact about the write. A receiver storing the record has
+// nothing to do with it, and shipping it would invite one to branch on RunLore's
+// chat configuration.
+var kbPayloadOmitted = map[string]string{
+	"Delivery": "a chat routing instruction, not a fact about the write",
+}
+
+// TestKBUpdatePayloadCarriesEveryRecordedField is the webhook payload's version
+// of the chat renderers' field guard, and it exists because this side had none.
+//
+// The chat announcement has a reflection test forcing every KBUpdate field to be
+// rendered or explicitly withheld. The payload had only a whole-value comparison
+// in the delivery test, which is structurally blind to a field the PAYLOAD TYPE
+// lacks: a KBUpdate field with no counterpart here simply cannot appear in the
+// expected value either, so both sides agree about a field neither carries and
+// the test passes. Channel was added to the event and never reached the wire
+// that way — a receiver got a thread root it could not resolve to a conversation.
+//
+// This walks providers.KBUpdate instead, so the direction is the one that bites:
+// every field of the EVENT must be either present on the payload or listed in
+// kbPayloadOmitted.
+func TestKBUpdatePayloadCarriesEveryRecordedField(t *testing.T) {
+	event := reflect.TypeOf(providers.KBUpdate{})
+	payload := reflect.TypeOf(KBUpdatePayload{})
+
+	for i := range event.NumField() {
+		name := event.Field(i).Name
+		_, omitted := kbPayloadOmitted[name]
+		_, carried := payload.FieldByName(name)
+		switch {
+		case carried && omitted:
+			t.Errorf("KBUpdatePayload carries %q while kbPayloadOmitted claims it is withheld — "+
+				"one of the two is wrong", name)
+		case !carried && !omitted:
+			t.Errorf("providers.KBUpdate.%s reaches no webhook receiver and is not listed in "+
+				"kbPayloadOmitted. Add it to KBUpdatePayload, or record why the record does not "+
+				"include it — a field dropped silently is one a receiver cannot know it is missing.", name)
+		}
+	}
+	for name := range kbPayloadOmitted {
+		if _, ok := event.FieldByName(name); !ok {
+			t.Errorf("kbPayloadOmitted names %q, which providers.KBUpdate no longer has — stale entry, "+
+				"so nothing is checking whatever replaced it", name)
+		}
+	}
+}
+
+// TestNewKBUpdatePayloadPopulatesEveryFieldItDeclares closes the other half:
+// a field can exist on the payload and still never be assigned. The guard above
+// only compares TYPES, and NewKBUpdatePayload is a hand-written struct literal —
+// exactly the shape where a new field is declared, documented, and then left at
+// its zero value on the wire.
+func TestNewKBUpdatePayloadPopulatesEveryFieldItDeclares(t *testing.T) {
+	got := NewKBUpdatePayload(providers.KBUpdate{
+		Transport: "slack", Root: "111.222", Channel: "C-ORIGIN",
+		Route: providers.KBRouteOpenPR, PR: 99, URL: "https://github.com/o/r/pull/99",
+		Title: "Operator note: OOM", Author: "sre-jane", Note: "a spot reclaim",
+		At: time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC),
+	})
+
+	rv := reflect.ValueOf(got)
+	for i := range rv.NumField() {
+		if rv.Field(i).IsZero() {
+			t.Errorf("KBUpdatePayload.%s is zero after mapping a fully populated KBUpdate — it is "+
+				"declared but never assigned, so a receiver never sees it", rv.Type().Field(i).Name)
+		}
+	}
+	if got.Channel != "C-ORIGIN" {
+		t.Errorf("channel = %q, want the originating channel — root alone does not identify a "+
+			"conversation, so a receiver cannot build a permalink without it", got.Channel)
 	}
 }

--- a/internal/notify/webhook/webhook.go
+++ b/internal/notify/webhook/webhook.go
@@ -131,6 +131,12 @@ var _ providers.KBUpdateNotifier = (*Notifier)(nil)
 // It shares Deliver's endpoint, so the body carries an "event" discriminator —
 // see notify.KBUpdatePayload for why, and for why the untrusted fields go out
 // verbatim here rather than escaped.
+//
+// up.Delivery is ignored, deliberately: an HTTP endpoint has no thread to route
+// into, so a thread-routed announcement reaches it exactly as a channel-routed
+// one does. That is the fallback providers.KBDelivery documents, and this is the
+// sink it matters most for — an index or an incident tool must not stop being
+// fed because a chat destination changed.
 func (n *Notifier) DeliverKBUpdate(ctx context.Context, up providers.KBUpdate) error {
 	return n.post(ctx, notify.NewKBUpdatePayload(up))
 }

--- a/internal/notify/webhook/webhook_test.go
+++ b/internal/notify/webhook/webhook_test.go
@@ -295,6 +295,39 @@ func TestDeliverKBUpdatePOSTsJSON(t *testing.T) {
 	}
 }
 
+// TestDeliverKBUpdateIgnoresTheChatDestination pins that a thread-routed
+// announcement still reaches this sink, unchanged.
+//
+// An HTTP endpoint has no thread to post into, so the only two answers available
+// were "deliver it anyway" and "skip it". Skipping would mean an operator moving
+// their CHAT announcements into threads silently stopped feeding whatever this
+// URL points at — an index, a changelog, an incident tool — with nothing
+// anywhere reporting it, because delivery here is best-effort and a skipped sink
+// is indistinguishable from a quiet one. The record is not a chat message and
+// does not move with one.
+func TestDeliverKBUpdateIgnoresTheChatDestination(t *testing.T) {
+	for _, d := range []providers.KBDelivery{"", providers.KBDeliverChannel, providers.KBDeliverThread, providers.KBDeliverBoth} {
+		t.Run(string(d), func(t *testing.T) {
+			ts, body, _ := captureServer(t, http.StatusOK)
+			n := New(ts.URL)
+			if err := n.DeliverKBUpdate(context.Background(), providers.KBUpdate{
+				Transport: "slack", Root: "111.222", Channel: "C-ORIGIN", Delivery: d,
+				Route: providers.KBRouteOpenPR, PR: 99, URL: "https://github.com/o/r/pull/99",
+				Note: "a spot reclaim",
+			}); err != nil {
+				t.Fatalf("DeliverKBUpdate: %v", err)
+			}
+			var got notify.KBUpdatePayload
+			if err := json.Unmarshal(body(), &got); err != nil {
+				t.Fatalf("nothing was POSTed for delivery %q, or it did not decode: %v", string(d), err)
+			}
+			if got.Note != "a spot reclaim" || got.URL != "https://github.com/o/r/pull/99" {
+				t.Errorf("the record changed with the chat destination %q: %+v", string(d), got)
+			}
+		})
+	}
+}
+
 // TestDeliverKBUpdateIsDistinguishableFromAnInvestigation is the compatibility
 // half. Both deliveries POST to the SAME operator-configured URL, and the two
 // bodies are different shapes; a receiver written against the investigation

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -563,14 +563,67 @@ const (
 	KBRouteOpenPR KBRoute = "open_pr"
 )
 
+// KBDelivery says WHERE a KBUpdate announcement is to be delivered. It is set
+// once from configuration (config.AnnounceMode) and read by every sink.
+//
+// # A sink that is not the originating transport falls back to the channel
+//
+// Only ONE sink can ever deliver into the thread a note was typed in: the
+// transport that thread lives on. A Matrix room cannot reply into a Slack
+// thread, an incoming-webhook Slack cannot reply into any thread, and an HTTP
+// webhook has no thread at all. The choice for those sinks is fall back to the
+// channel, or skip them; this contract is FALL BACK, and the sinks that cannot
+// thread-route are the reason.
+//
+// Skipping would make thread-routing silently un-configure an operator's other
+// sinks. The echo KBDeliverThread exists to remove is specific to the
+// originating transport, where the thread already lives inside the channel the
+// announcement would post to; a Matrix room that never saw the Slack thread has
+// no echo to remove, and the announcement is the only way it learns anything at
+// all. Dropping it there would answer "stop repeating yourself in one channel"
+// with "stop telling the other rooms", which is a different feature and a worse
+// one. The same argument holds harder for a webhook sink feeding an index or an
+// incident tool: it wants the record either way.
+//
+// The fallback is also what makes a missing handle safe. A KBUpdate whose Root
+// or Channel is empty — a thread context rebuilt after a restart, an origin that
+// was never a thread — cannot be replied into by anyone, and the write it
+// describes has already landed. Falling back to the channel reports it; skipping
+// would lose an announcement for a write that really happened, which is the
+// failure this whole path is built to avoid.
+type KBDelivery string
+
+// Where an announcement lands.
+const (
+	// KBDeliverChannel posts to each sink's own configured channel or room and
+	// nowhere else.
+	//
+	// It is the ZERO VALUE deliberately: a KBUpdate built without deciding
+	// behaves exactly as every announcement did before routing existed, so no
+	// producer that predates this field can change destination by omission.
+	KBDeliverChannel KBDelivery = ""
+	// KBDeliverThread delivers into the originating thread where the sink can
+	// (see above), and to the sink's channel where it cannot.
+	KBDeliverThread KBDelivery = "thread"
+	// KBDeliverBoth delivers into the originating thread AND to every sink's
+	// channel.
+	KBDeliverBoth KBDelivery = "both"
+)
+
+// IntoThread reports whether this delivery wants the originating thread. It does
+// NOT report that a given sink can honour that — only the sink knows whether it
+// is the originating transport and holds both handles.
+func (d KBDelivery) IntoThread() bool { return d == KBDeliverThread || d == KBDeliverBoth }
+
 // KBUpdate announces that a knowledge-base write ALREADY LANDED on the forge. It
 // is emitted after the fact and describes what was written — it is never a
 // request to write, and a consumer failing to deliver it changes nothing about
 // the entry, which is already on the forge.
 //
-// It names its origin (Transport + Root) so a consumer can tell which thread
-// produced it — and so the transport that already replied in that thread can
-// avoid announcing the same write to the same people twice.
+// It names its origin (Transport + Root + Channel) so a consumer can tell which
+// thread produced it — and so the transport that already replied in that thread
+// can avoid announcing the same write to the same people twice, or deliver into
+// that thread rather than beside it (see Delivery).
 //
 // # Untrusted fields
 //
@@ -582,16 +635,26 @@ const (
 // links and mass-ping a channel (Slack <!channel>, Matrix @room), the same
 // hazard ProgressUpdate.Interim carries.
 //
-// URL and Root are untrusted for the same reason at one remove: they come back
-// from the forge and from the chat transport rather than from RunLore, which is
-// why the thread reply already wraps the URL in thread.Untrusted. Transport,
-// Route, PR and At are RunLore's own values and need no escaping.
+// URL, Root and Channel are untrusted for the same reason at one remove: they
+// come back from the forge and from the chat transport rather than from RunLore,
+// which is why the thread reply already wraps the URL in thread.Untrusted.
+// Transport, Route, PR, At and Delivery are RunLore's own values and need no
+// escaping.
 type KBUpdate struct {
 	// Transport is the chat system the note came from ("slack", "matrix"),
 	// matching ThreadNotifier.Transport; "" when the write had no thread origin.
 	Transport string
 	// Root is the opaque thread-root handle on that transport (Slack: thread_ts).
 	Root string
+	// Channel is where that thread lives (Slack: channel id; Matrix: room id) —
+	// the second half of the handle ReplyInThread needs, since a thread root
+	// alone does not say which channel to post it in. "" when the write had no
+	// thread origin, or when the origin was rebuilt without one.
+	Channel string
+	// Delivery says where this announcement is to be delivered. It is a routing
+	// instruction rather than a fact about the write, and the only field here
+	// that is: everything else describes what landed on the forge.
+	Delivery KBDelivery
 	// Route is how the write landed (comment on an open PR, or a new PR).
 	Route KBRoute
 	// PR is the forge pull/merge request number the knowledge landed in; 0 when

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -233,12 +233,20 @@ func TestKBUpdateNotifierIsOptional(t *testing.T) {
 // text, and an unclassified field is one nobody decided to escape.
 //
 // Untrusted: Note/Title/Author are model- or human-authored (redacted upstream,
-// still not RunLore's words); URL and Root are returned by the forge and the chat
-// transport respectively, which is why the thread reply already wraps the URL in
-// thread.Untrusted.
+// still not RunLore's words); URL, Root and Channel are returned by the forge and
+// the chat transport respectively, which is why the thread reply already wraps the
+// URL in thread.Untrusted.
+//
+// Channel is untrusted for Root's reason and needs the classification for a
+// second one: it is ADDRESSING as well as data. A sink that renders it must
+// escape it like any transport-reported string, and no announcement does today —
+// it is used to address a threaded delivery, which is not rendering.
+//
+// Delivery is trusted because RunLore sets it from its own configuration; it is
+// never reported by a chat system and never rendered at all.
 var (
-	kbUpdateUntrusted = map[string]bool{"Title": true, "Author": true, "Note": true, "URL": true, "Root": true}
-	kbUpdateTrusted   = map[string]bool{"Transport": true, "Route": true, "PR": true, "At": true}
+	kbUpdateUntrusted = map[string]bool{"Title": true, "Author": true, "Note": true, "URL": true, "Root": true, "Channel": true}
+	kbUpdateTrusted   = map[string]bool{"Transport": true, "Route": true, "PR": true, "At": true, "Delivery": true}
 )
 
 // TestKBUpdateClassifiesEveryFieldForEscaping makes the two maps above bite: a

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -558,6 +558,9 @@ func atxHeadingText(line string) string {
 // The plain space is excluded so ordinary text is left exactly as written;
 // everything else in those categories becomes one, which keeps the result the
 // same length in runes and never joins two words.
+//
+// FlattenLine is this same rule, exported for the chat notifiers — see its doc
+// comment for why it is shared rather than reimplemented there.
 func singleLine(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r == ' ' {
@@ -569,6 +572,25 @@ func singleLine(s string) string {
 		return r
 	}, s)
 }
+
+// FlattenLine folds every break-or-reorder rune in s to a space, so a value a
+// caller intends to render as ONE line cannot become two.
+//
+// It exists for the chat notifiers' one-line announcement fields (an author, an
+// entry title, a forge URL), which are interpolated into a message at the left
+// margin rather than blockquoted — so unlike the note text, no later escape and
+// no "> " prefix stands between them and a forged line. A U+2028 inside an
+// author is a new visual line to every client that renders one, and the text
+// after it sits exactly where RunLore's own claims sit.
+//
+// Exported rather than reimplemented in internal/notify because that package has
+// already been bitten by a private copy of a break list: kbUpdateAnnouncement's
+// own doc records a local quoter that never learned a line is not only what "\n"
+// separates, and put a forged "📚 Knowledge base updated — …" at the left margin
+// of the findings channel. The list of what breaks a line belongs in one place;
+// this is that place, and QuoteUntrusted's mandatoryBreaks is its sibling for
+// multi-line text.
+func FlattenLine(s string) string { return singleLine(s) }
 
 // truncate shortens s to around n bytes: it cuts at or before byte index n-1
 // (walking back to a rune boundary) and appends a 3-byte "…", so the result

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -172,9 +172,11 @@ type Responder struct {
 	// it came from. nil means announcements are off — the default, and the
 	// same nil-safe contract Metrics, Log and Chat above follow.
 	//
-	// It is a distinct DESTINATION, not a second copy of the thread reply: the
-	// reply acknowledges the person who typed, in their thread, and this goes
-	// to each notifier's own configured channel. See KBAnnouncer.
+	// It is a distinct MESSAGE, not a second copy of the thread reply: the reply
+	// acknowledges the person who typed, and this names who wrote the note and
+	// which chat system it came from, for readers who have neither. Where it
+	// goes — each notifier's own channel, or back into the originating thread —
+	// is the announcer's own setting; see KBAnnouncer and providers.KBDelivery.
 	Announcer *KBAnnouncer
 }
 
@@ -246,9 +248,10 @@ const (
 // transport's job, where the transport's own limit lives — the same division
 // taken for the outgoing thread reply.
 type KBAnnouncer struct {
-	sink providers.KBUpdateNotifier
-	disp *Dispatcher
-	log  *slog.Logger
+	sink     providers.KBUpdateNotifier
+	delivery providers.KBDelivery
+	disp     *Dispatcher
+	log      *slog.Logger
 }
 
 // NewKBAnnouncer returns an announcer delivering to sink, or nil when there is
@@ -259,23 +262,37 @@ type KBAnnouncer struct {
 // nowhere to deliver, and no state in which it holds a sink with no bound
 // around it. Every method below is nil-safe, so a caller never needs its own
 // check before delivering or draining.
-func NewKBAnnouncer(sink providers.KBUpdateNotifier, log *slog.Logger) *KBAnnouncer {
+//
+// delivery is where announcements go (providers.KBDelivery), held here rather
+// than passed per write because it is one deployment-wide setting and an
+// announcer that could route two writes from the same deployment differently
+// would be a setting nobody configured. Its zero value is the channel, so an
+// announcer built without a decision behaves as every announcer did before
+// routing existed.
+func NewKBAnnouncer(sink providers.KBUpdateNotifier, delivery providers.KBDelivery, log *slog.Logger) *KBAnnouncer {
 	if sink == nil {
 		return nil
 	}
 	if log == nil {
 		log = slog.Default()
 	}
-	return &KBAnnouncer{sink: sink, disp: NewDispatcher(announceSlots, announceTimeout, log), log: log}
+	return &KBAnnouncer{sink: sink, delivery: delivery, disp: NewDispatcher(announceSlots, announceTimeout, log), log: log}
 }
 
 // deliver schedules one announcement and returns immediately. Every failure is
 // a log line and nothing more: the write it describes is already on the forge,
 // the human has already been told, and there is nothing here to roll back.
+//
+// The destination is stamped here, on the announcer's own copy of the event,
+// rather than by the caller that describes the write: announce() knows what
+// landed and where it came from, and this knows where the operator asked for it
+// to go. That keeps a caller from being able to compose a KBUpdate that routes
+// somewhere the configuration never selected.
 func (a *KBAnnouncer) deliver(ctx context.Context, up providers.KBUpdate) {
 	if a == nil {
 		return
 	}
+	up.Delivery = a.delivery
 	if !a.disp.Go(ctx, func(ctx context.Context) {
 		if err := a.sink.DeliverKBUpdate(ctx, up); err != nil {
 			a.log.Warn("thread: knowledge-base announcement failed (best-effort)", "url", up.URL, "route", string(up.Route), "err", err)
@@ -328,6 +345,13 @@ func kbRoute(route string) providers.KBRoute {
 // write either way, and only the caller knows whose message produced it. It
 // goes through noteField — redacted and flattened, exactly as the entry itself
 // renders it — because this event is a NEW egress for transport-reported text.
+//
+// tc supplies BOTH thread handles, Root and Channel. Root alone names a thread
+// only to the transport that already knows which channel it is in; a sink asked
+// to reply into it needs the channel too, and one arriving without the other is
+// what makes a delivery fall back to the channel (see providers.KBDelivery).
+// Neither is escaped here — they are marked untrusted on the event, and the
+// transport that renders them is the one that knows how.
 func (r *Responder) announce(ctx context.Context, tc Context, n Note, w *KBWrite, at time.Time) {
 	if r.Announcer == nil || w == nil {
 		return
@@ -335,6 +359,7 @@ func (r *Responder) announce(ctx context.Context, tc Context, n Note, w *KBWrite
 	r.Announcer.deliver(ctx, providers.KBUpdate{
 		Transport: tc.Transport,
 		Root:      tc.Root,
+		Channel:   tc.Channel,
 		Route:     kbRoute(w.Route),
 		PR:        w.PR,
 		URL:       w.URL,

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -3066,7 +3066,7 @@ func newAnnouncingResponder(t *testing.T, f *fakeForge) (*Responder, *fakeKBSink
 	t.Helper()
 	r := newTestResponder(t, f)
 	sink := &fakeKBSink{}
-	r.Announcer = NewKBAnnouncer(sink, silentLog())
+	r.Announcer = NewKBAnnouncer(sink, providers.KBDeliverChannel, silentLog())
 	return r, sink
 }
 
@@ -3210,7 +3210,7 @@ func TestAnnounceNeverPostsIntoTheThread(t *testing.T) {
 	f, rep := &fakeForge{}, &fakeReplier{}
 	m := newTestMention(t, f, rep)
 	sink := &fakeKBSink{}
-	m.Responder.Announcer = NewKBAnnouncer(sink, silentLog())
+	m.Responder.Announcer = NewKBAnnouncer(sink, providers.KBDeliverChannel, silentLog())
 	if err := m.Registry.Put(Context{Transport: "slack", Root: "111.222", Channel: "C1", CuratedURL: "https://github.com/o/r/pull/42"}); err != nil {
 		t.Fatalf("Put: %v", err)
 	}
@@ -3418,7 +3418,7 @@ func TestAnnounceWithNoSinkIsOffAndDoesNotPanic(t *testing.T) {
 	// "Off" is ONE value, not a flag beside a sink: constructing an announcer
 	// with no sink yields no announcer, so there is no half-wired state in
 	// which announcements are enabled with nowhere to go.
-	if a := NewKBAnnouncer(nil, silentLog()); a != nil {
+	if a := NewKBAnnouncer(nil, providers.KBDeliverChannel, silentLog()); a != nil {
 		t.Errorf("NewKBAnnouncer(nil) = %+v, want nil — a missing sink means announcements are off", a)
 	}
 	// And every method is safe on that nil, so a caller never needs its own
@@ -3452,7 +3452,7 @@ func TestAnnounceFailureDoesNotChangeTheReply(t *testing.T) {
 
 	loud, loudCtx := newCase(t)
 	sink := &fakeKBSink{err: errors.New("channel_not_found")}
-	loud.Announcer = NewKBAnnouncer(sink, silentLog())
+	loud.Announcer = NewKBAnnouncer(sink, providers.KBDeliverChannel, silentLog())
 	reply, err := loud.Handle(context.Background(), loudCtx, "alice", msg)
 	if err != nil {
 		t.Errorf("Handle returned %v; a failing announcement must never fail the write that already landed", err)
@@ -3478,7 +3478,7 @@ func TestAnnounceDoesNotDelayTheReply(t *testing.T) {
 	f := &fakeForge{}
 	r := newTestResponder(t, f)
 	sink := &fakeKBSink{entered: make(chan struct{}), release: make(chan struct{})}
-	r.Announcer = NewKBAnnouncer(sink, silentLog())
+	r.Announcer = NewKBAnnouncer(sink, providers.KBDeliverChannel, silentLog())
 	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
 
 	type result struct {
@@ -3525,7 +3525,7 @@ func TestAnnounceIsDrainable(t *testing.T) {
 	f := &fakeForge{}
 	r := newTestResponder(t, f)
 	sink := &fakeKBSink{release: make(chan struct{})}
-	r.Announcer = NewKBAnnouncer(sink, silentLog())
+	r.Announcer = NewKBAnnouncer(sink, providers.KBDeliverChannel, silentLog())
 	tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", CuratedURL: "https://github.com/o/r/pull/42"})
 
 	if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: x"); err != nil {

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -3094,7 +3094,7 @@ func TestAnnounceALandedWrite(t *testing.T) {
 		f := &fakeForge{}
 		r, sink := newAnnouncingResponder(t, f)
 		const prURL = "https://github.com/o/r/pull/42"
-		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", Title: "OOM", CuratedURL: prURL})
+		tc := putContext(t, r, Context{Transport: "slack", Root: "111.222", Channel: "C-ORIGIN", Title: "OOM", CuratedURL: prURL})
 
 		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: spot reclaim, not OOM"); err != nil {
 			t.Fatalf("Handle: %v", err)
@@ -3110,12 +3110,18 @@ func TestAnnounceALandedWrite(t *testing.T) {
 		want := providers.KBUpdate{
 			Transport: "slack",
 			Root:      "111.222",
-			Route:     providers.KBRouteComment,
-			PR:        42,
-			URL:       prURL,
-			Author:    "alice",
-			Note:      "spot reclaim, not OOM",
-			At:        noteAt,
+			// Channel travels with Root, and the comparison below is the only
+			// thing checking it does: a KBUpdate carrying a thread root with no
+			// channel cannot be replied into, so every thread-routed delivery
+			// would silently fall back to the channel — the destination an
+			// operator configured away, restored without a word.
+			Channel: "C-ORIGIN",
+			Route:   providers.KBRouteComment,
+			PR:      42,
+			URL:     prURL,
+			Author:  "alice",
+			Note:    "spot reclaim, not OOM",
+			At:      noteAt,
 		}
 		if got[0] != want {
 			t.Errorf("announcement =\n%+v\nwant\n%+v", got[0], want)
@@ -3125,7 +3131,7 @@ func TestAnnounceALandedWrite(t *testing.T) {
 	t.Run("open_pr route", func(t *testing.T) {
 		f := &fakeForge{}
 		r, sink := newAnnouncingResponder(t, f)
-		tc := putContext(t, r, Context{Transport: "matrix", Root: "$evt:example.org", Title: "OOM in payments"})
+		tc := putContext(t, r, Context{Transport: "matrix", Root: "$evt:example.org", Channel: "!room:example.org", Title: "OOM in payments"})
 
 		if _, err := r.Handle(context.Background(), tc, "alice", "<@U0BOT> note: stale since Karpenter"); err != nil {
 			t.Fatalf("Handle: %v", err)
@@ -3142,6 +3148,7 @@ func TestAnnounceALandedWrite(t *testing.T) {
 		want := providers.KBUpdate{
 			Transport: "matrix",
 			Root:      "$evt:example.org",
+			Channel:   "!room:example.org",
 			Route:     providers.KBRouteOpenPR,
 			PR:        99,
 			URL:       "https://github.com/o/r/pull/99",
@@ -3159,6 +3166,49 @@ func TestAnnounceALandedWrite(t *testing.T) {
 			t.Error("Title is empty; the open_pr route generates one and the announcement must name it")
 		}
 	})
+}
+
+// TestAnnouncerStampsItsOwnDestinationUnconditionally pins deliver()'s claim
+// that a caller cannot compose a KBUpdate routed somewhere the configuration
+// never selected.
+//
+// The stamp is what makes that true, and only if it is UNCONDITIONAL. Written as
+// `if up.Delivery == "" { up.Delivery = a.delivery }` — the shape that reads as
+// a harmless default — it becomes the opposite: a caller that sets the field
+// wins, and the announcer's own configuration is what gets defaulted. Nothing
+// else in either package notices, because every production caller leaves the
+// field zero and every other test sets it on the announcer.
+//
+// It matters because the field is a DESTINATION. A caller able to set it can
+// route an announcement into a thread on a deployment whose operator asked for
+// channel-level delivery only, or the reverse — and the announcer is the only
+// place that knows which was asked for.
+func TestAnnouncerStampsItsOwnDestinationUnconditionally(t *testing.T) {
+	for _, caller := range []providers.KBDelivery{
+		"", providers.KBDeliverChannel, providers.KBDeliverThread, providers.KBDeliverBoth,
+	} {
+		t.Run("caller sets "+string(caller), func(t *testing.T) {
+			sink := &fakeKBSink{}
+			a := NewKBAnnouncer(sink, providers.KBDeliverThread, silentLog())
+			a.deliver(context.Background(), providers.KBUpdate{
+				Transport: "slack", Root: "111.222", Channel: "C-ORIGIN",
+				Delivery: caller, Route: providers.KBRouteComment, URL: "https://github.com/o/r/pull/1",
+			})
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			a.Drain(ctx)
+
+			got := sink.updates()
+			if len(got) != 1 {
+				t.Fatalf("announcements = %d, want 1", len(got))
+			}
+			if got[0].Delivery != providers.KBDeliverThread {
+				t.Errorf("a caller-set Delivery %q survived to the sink as %q — the announcer's own "+
+					"destination must overwrite it, or a caller can route an announcement somewhere the "+
+					"operator never configured", string(caller), string(got[0].Delivery))
+			}
+		})
+	}
 }
 
 // TestAnnounceNamesItsOriginatingTransportAndRoot pins the half of the event a

--- a/website/content/docs/concepts/reviewing-knowledge.md
+++ b/website/content/docs/concepts/reviewing-knowledge.md
@@ -60,19 +60,24 @@ marked as model-drafted, never filed as your words.
 
 **Announcing a write to everyone else.** By default a captured note is reported only
 into the thread it came from, so the knowledge lands but nobody outside that thread
-learns that it did. Setting `notify.thread.announce_kb_updates: true` (default
-**false**) also posts every landed write to each configured notifier's own channel or
-room — the same place investigation findings go — naming the pull request, the entry,
-who wrote it, and quoting the note. Two consequences to know before turning it on:
+learns that it did. Setting `notify.thread.announce_kb_updates` (default **false**)
+announces every landed write, naming the pull request, the entry, who wrote it and
+which chat system they typed it in, and quoting the note. The value says where it
+lands — `true` and `channel` both mean each notifier's own channel or room, `thread`
+means the thread the note was typed in, `both` means both. Two consequences to know
+before turning it on:
 
-- **With one transport configured you see two messages for one write**: the thread
-  reply, which answers the person who typed, and the channel post, which reaches
-  everyone who was not reading that thread. That is the feature rather than
-  duplication — the announcement never posts back into the thread.
+- **`channel` gives you two messages for one write**: the thread reply, which answers
+  the person who typed, and the channel post, which reaches everyone who was not
+  reading that thread. With several sinks that is the feature rather than duplication.
+  With **one** transport it is an echo — the thread already lives in that channel —
+  and `thread` is the answer: the announcement goes into the thread instead, and any
+  sink that cannot reach it still gets its own channel.
 - **The announcement carries note content.** A note written in a thread nobody else
   was watching is broadcast to every sink you have configured — the other chat
   system, any webhook endpoint. That is an operator's call to make knowingly, which
-  is why the key is off unless you set it.
+  is why the key is off unless you set it. Routing it into a thread narrows who sees
+  it on the originating transport; it does not stop the other sinks receiving it.
 
 Setup and the full cost picture:
 [Slack]({{< relref "/docs/integrations/notifications/slack.md" >}}) ·

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -636,11 +636,37 @@ transports), `max_note_bytes` (default **8192**, one human message's input), `re
 
 The same block holds the one key that is a switch rather than a ceiling:
 `announce_kb_updates` (default **false**). With it on, every knowledge write that lands is
-also announced to each configured notifier's own channel or room — never back into the thread
-that produced it, which already received the reply — so one write produces both a thread reply
-and a channel post. The announcement quotes the note, so a note written in one thread reaches
-every sink you have configured; that is why it is opt-in. See
-[Reviewing knowledge → Thread capture]({{< relref "/docs/concepts/reviewing-knowledge.md" >}})
+also announced to your notifiers — naming the pull request, the entry, who wrote the note and
+which chat system they typed it in, and quoting the note itself. The announcement carries note
+content, so a note written in one thread reaches every sink you have configured; that is why it
+is opt-in.
+
+It takes a boolean or a destination name, and the two spellings you may already have keep their
+meaning exactly:
+
+| Value | Where the announcement lands |
+|---|---|
+| `false` (or omitted) | nowhere — no announcement |
+| `true` | identical to `channel` |
+| `channel` | each notifier's own channel or room, never the thread |
+| `thread` | into the thread the note was typed in, on that transport; every other sink still gets its channel |
+| `both` | the originating thread **and** every sink's channel |
+
+`channel` is the right answer when people watch the channel but not every thread, and it is what
+`true` has always done. `thread` is for a **single-transport** deployment: there the thread
+already lives in the channel the announcement would post to, so a channel post restates what the
+thread just said — an echo rather than a second audience. A typo (`treads`, `chanel`) fails
+startup naming the accepted values, rather than quietly falling back.
+
+**A sink that is not the originating transport falls back to channel level.** Only one sink can
+reply into a given thread: a Matrix room cannot reply into a Slack thread, an incoming-webhook
+Slack cannot reply into any thread, and a `webhook` endpoint has no thread at all. Those sinks are
+not skipped — the echo `thread` removes exists only where the thread and the channel are the same
+place, and a room that never saw the thread has no other way to learn the knowledge base moved.
+The same fallback covers a thread RunLore can no longer address (a context rebuilt after a
+restart): the write already landed, so it is announced at channel level rather than dropped.
+
+See [Reviewing knowledge → Thread capture]({{< relref "/docs/concepts/reviewing-knowledge.md" >}})
 and the [Slack]({{< relref "/docs/integrations/notifications/slack.md" >}}) /
 [Matrix]({{< relref "/docs/integrations/notifications/matrix.md" >}}) pages.
 

--- a/website/content/docs/integrations/notifications/matrix.md
+++ b/website/content/docs/integrations/notifications/matrix.md
@@ -111,12 +111,12 @@ for. That widening is real and worth understanding before you flip the flag: see
 Matrix thread
 capture]({{< relref "/docs/security/security-model.md#matrix-thread-capture-notifymatrixthread_capture--a-widened-sync-filter" >}}).
 
-### Announce a knowledge write to the room
+### Announce a knowledge write
 
 A captured note is reported into the thread it came from, and nowhere else — so the
-knowledge lands, but the room never learns it did. `announce_kb_updates` changes that:
-every write that reaches the forge is also posted to the room this notifier delivers
-findings to.
+knowledge lands, but nobody outside that thread learns it did. `announce_kb_updates`
+changes that: every write that reaches the forge is also announced, with its own
+message naming who wrote the note and where.
 
 ```yaml
 notify:
@@ -126,24 +126,32 @@ notify:
     access_token_env: MATRIX_TOKEN
     thread_capture: true
   thread:
-    announce_kb_updates: true    # default false
+    announce_kb_updates: channel  # default false; also true (= channel), thread, both
 ```
 
-The room post names the pull request, the entry that was created, who the note came
-from and which chat system they typed it in, and quotes the note itself — capped at
-512 bytes, with the pull request holding the full text. It is a plain `m.notice` with
-no `m.thread` relation, carrying the same secret-redacted, capped text that reached
-the forge, and everything a human or the model wrote in it is neutralised before
-sending: an `@room` inside a note is rendered readable but inert, never a room-wide
-notification.
+The post names the pull request, the entry that was created, who the note came from
+and which chat system they typed it in, and quotes the note itself — capped at
+512 bytes, with the pull request holding the full text. It carries the same
+secret-redacted, capped text that reached the forge, and everything a human or the
+model wrote in it is neutralised before sending: an `@room` inside a note is rendered
+readable but inert, never a room-wide notification. That holds wherever it lands.
 
-Two things to know before turning it on:
+**Where it lands is yours to pick.** `channel` (what `true` has always meant) sends a
+plain `m.notice` with no `m.thread` relation to the room this notifier delivers
+findings to. `thread` sends it into the thread the note was typed in, as an
+`m.notice` carrying the MSC3440 `m.thread` relation. `both` does each.
 
-- **One write produces two messages, and that is intended.** The thread reply answers
-  the person who typed; the room post reaches everyone who was not reading that thread
-  — which is the whole point of the feature. The announcement never posts back into the
-  thread, so it is a second destination rather than a duplicate. With Matrix as your
-  only transport you will still see both.
+- **`channel` produces two messages for one write, and with several sinks that is the
+  point.** The thread reply answers the person who typed; the room post reaches
+  everyone who was not reading that thread. But **with Matrix as your only transport
+  those are the same people** — the thread lives in that very room — so each write
+  restates in the room what the thread just said. That is what `thread` is for: the
+  announcement goes into the thread instead, keeping the provenance line the reply
+  does not carry, without the echo.
+- **`thread` never silences your other sinks.** A Slack channel, a `webhook`
+  endpoint — neither can post into a Matrix thread, so they each receive the
+  announcement in their own channel exactly as before. The echo only exists where the
+  thread and the room are the same place.
 - **The announcement carries note content.** A note written in a thread nobody else was
   watching is broadcast to every sink you have configured — this room, a Slack channel
   if you run both, any `webhook` endpoint. That is your decision to take knowingly,

--- a/website/content/docs/integrations/notifications/slack.md
+++ b/website/content/docs/integrations/notifications/slack.md
@@ -132,12 +132,12 @@ it's even been tried.
 Only `app_mention` is subscribed — RunLore reads nothing in channels where it
 was not directly addressed.
 
-### Announce a knowledge write to the channel
+### Announce a knowledge write
 
 A captured note is reported into the thread it came from, and nowhere else — so
-the knowledge lands, but the channel never learns it did. `announce_kb_updates`
-changes that: every write that reaches the forge is also posted to the channel
-this notifier delivers findings to.
+the knowledge lands, but nobody outside that thread learns it did.
+`announce_kb_updates` changes that: every write that reaches the forge is also
+announced, with its own message naming who wrote the note and where.
 
 ```yaml
 notify:
@@ -146,23 +146,31 @@ notify:
     channel: C0123456789
     thread_capture: true
   thread:
-    announce_kb_updates: true    # default false
+    announce_kb_updates: channel  # default false; also true (= channel), thread, both
 ```
 
-The channel post names the pull request, the entry that was created, who the note
-came from and which chat system they typed it in, and quotes the note itself —
-capped at 512 bytes, with the pull request holding the full text. It carries the
-same secret-redacted, capped text that reached the forge, and everything a human
-or the model wrote in it is escaped before posting: a `<!channel>` inside a note
-renders as literal text, never as a channel-wide ping.
+The post names the pull request, the entry that was created, who the note came
+from and which chat system they typed it in, and quotes the note itself — capped
+at 512 bytes, with the pull request holding the full text. It carries the same
+secret-redacted, capped text that reached the forge, and everything a human or the
+model wrote in it is escaped before posting: a `<!channel>` inside a note renders
+as literal text, never as a channel-wide ping. That holds wherever it lands.
 
-Two things to know before turning it on:
+**Where it lands is yours to pick.** `channel` (what `true` has always meant) posts
+to the channel this notifier delivers findings to. `thread` posts into the thread
+the note was typed in. `both` does each.
 
-- **One write produces two messages, and that is intended.** The thread reply
-  answers the person who typed; the channel post reaches everyone who was not
-  reading that thread — which is the whole point of the feature. The announcement
-  never posts back into the thread, so it is a second destination rather than a
-  duplicate. With Slack as your only transport you will still see both.
+- **`channel` produces two messages for one write, and with several sinks that is
+  the point.** The thread reply answers the person who typed; the channel post
+  reaches everyone who was not reading that thread. But **with Slack as your only
+  transport those are the same people** — the thread lives in that very channel —
+  so each write restates in the channel what the thread just said. That is what
+  `thread` is for: the announcement goes into the thread instead, keeping the
+  provenance line the reply does not carry, without the echo.
+- **`thread` never silences your other sinks.** A Matrix room, an incoming-webhook
+  Slack, a `webhook` endpoint — none of them can post into a Slack thread, so they
+  each receive the announcement in their own channel exactly as before. The echo
+  only exists where the thread and the channel are the same place.
 - **The announcement carries note content.** A note written in a thread nobody else
   was watching is broadcast to every sink you have configured — this channel, a
   Matrix room if you run both, any `webhook` endpoint. That is your decision to


### PR DESCRIPTION
Closes #494.

`announce_kb_updates: true` posts a landed knowledge write at **channel** level. The docs argue correctly that a thread reply plus a channel post is intended rather than duplication — but that reasoning assumes several sinks. With **one** transport the thread already lives in the channel the announcement posts to, so the "second destination" is the same destination. The reporter got three channel posts restating what their thread had just said, and turned the feature off — losing the signal they actually wanted.

`notify.thread.announce_kb_updates` now accepts `off | channel | thread | both`.

## Backward compatibility is the load-bearing part

The key is already shipped and documented as a boolean. `AnnounceMode`'s `UnmarshalYAML` **tries `bool` first**, and that ordering *is* the guarantee: yaml.v3 resolves `true`/`false` **and YAML 1.1's `on`/`off`/`yes`/`no`** into a bool target, so every value that worked before resolves identically. `true` → `channel`, unchanged down to the message and the destination.

Verified across every spelling — `true`, `false`, `on`, `off`, `yes`, `no`, `TRUE`, `False` — plus the new names case-insensitively and trimmed.

An unknown name **decodes cleanly** and would otherwise report "on" with no destination, so `Validate` is what rejects it, naming the accepted list (precedent: `curate.sweeps.mode`). A silent fallback to `channel` would leave an operator believing the echo they configured away was gone while every write still restated itself.

> **yaml.v3 gotcha, documented at the unmarshaler:** a custom `UnmarshalYAML` is **never called for a null node** — `decoder.prepare` short-circuits `!!null` before it looks for the `Unmarshaler` interface. So `announce_kb_updates:` with no value leaves the zero value, and the zero value must independently mean what null should mean. It does (`off`), and that is now pinned rather than incidental.

## The design decision: non-originating sinks fall back to the channel, they are not skipped

Only one sink can ever reply into a given thread. The echo the reporter hit exists **only** on the originating transport, where the thread sits inside the channel being posted to. A Matrix room that never saw the Slack thread has no echo to remove and no other way to learn the KB moved; a webhook feeding an index or incident tool must not go quiet because a *chat* destination changed.

Skipping would answer *"stop repeating yourself in my one channel"* with *"stop telling the other rooms"*. The same fallback covers a half-addressed origin — a root with no channel, from a context rebuilt after a restart — so a write that landed is never announced to nobody.

**Trade-off, documented on all four affected pages:** `thread` is not "announce only in the thread". A multi-sink operator still gets channel posts everywhere else. For the single-transport deployment this issue is about, that distinction is invisible; for anyone else it must not be a surprise.

The threaded post goes through `ReplyInThread` rather than a second local render — that method already escapes for the transport, bounds at its byte ceiling and targets the passed channel. A threaded announcement must be neutralised exactly as a threaded reply is.

## Testing

17 mutations, all caught. The two load-bearing ones, re-verified independently:

- making the thread route *also* post to the channel fails with `posted 2 messages, want exactly 1` — that echo is the entire reason the feature was turned off;
- skipping non-originating sinks instead of falling back fails with `posted 0 messages, want exactly 1`.

`docsguard`'s `TestThreadBooleanDefaultsMatchTheDocs` pinned this field as a raw `bool`, and its comment argued the code side was "structurally unfalsifiable" because a plain `bool` has no unmarshaler. That is now obsolete — the field has a real one — so it reads `.On()` and is a genuine two-way guard, proven by a mutation that makes the zero value mean "on" and is caught from four shipped pages.

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`, site builds clean.
