### PR TITLE
fix(investigate): stop the GitOps tools reporting a scope limit as an absent object

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/source"
 )
 
@@ -226,12 +227,49 @@ func OutcomeKind(recalled bool) string {
 	return "fresh"
 }
 
-// GitopsEngine returns the configured GitOps engine, defaulting to flux.
+// GitopsEngine returns the configured GitOps engine, defaulting to flux. Anything it
+// does not recognise resolves to flux SILENTLY, which is why nothing may state a fact
+// about the cluster from it — see UnknownGitopsEngineWarning and WiredGitopsEngine.
 func GitopsEngine(cfg *config.Config) string {
 	if cfg.GitOps.Engine == "argocd" {
 		return "argocd"
 	}
 	return "flux"
+}
+
+// WiredGitopsEngine returns the engine of the GitOps provider actually built, falling
+// back to the configured value when the provider does not report one (a nil provider, or
+// a fake in a test).
+//
+// The distinction matters because the tool descriptions are read by the model on every
+// turn: sourcing the engine from a config string nothing validates means "argo" or
+// "ArgoCD" silently describes an Argo CD deployment as running Flux. The provider was
+// selected by the same config, so this usually agrees — but when it does not, the
+// provider is the one that will answer the calls.
+func WiredGitopsEngine(gp providers.GitOpsProvider, cfg *config.Config) string {
+	if r, ok := gp.(providers.GitOpsEngineReporter); ok {
+		return string(r.GitOpsEngine())
+	}
+	return GitopsEngine(cfg)
+}
+
+// UnknownGitopsEngineWarning decides the startup warning for a gitops.engine value
+// nothing recognises, returning "" when the value is valid or absent.
+//
+// GitopsEngine folds every unrecognised value into flux without a word, so a deployment
+// that wrote "argo", "ArgoCD" or "argo-cd" runs the whole Flux path: the Flux provider,
+// controller_logs registered, and the GitOps tools advertising Kustomization/HelmRelease
+// on a cluster that has no Flux CRDs. That is runlore#503's exact setup, reached by a
+// typo, and it is silent in every log. Config validation does not reject it (the field is
+// free-form and the default is meaningful), so the operator gets told instead.
+func UnknownGitopsEngineWarning(engine string) string {
+	if engine == "" || engine == "flux" || engine == "argocd" {
+		return ""
+	}
+	return fmt.Sprintf("gitops.engine=%q is not a recognised engine (want %q or %q) — falling back to "+
+		"flux. If this cluster runs Argo CD, every GitOps tool is now scoped to Flux kinds it can "+
+		"never find, and controller_logs is registered against controllers that do not exist.",
+		engine, "flux", "argocd")
 }
 
 // CostCeilingWithoutPricingWarning decides the startup warning for a cost ceiling

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -58,14 +58,16 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		// Deep read-only GitOps introspection (status/events + dependency tree), when
 		// the GitOps provider supports it (both Flux and Argo CD do).
 		//
-		// Engine is passed so each tool advertises ONLY the kinds the configured engine
-		// can own. Same reasoning as clusterTools gating controller_logs on Flux: a kind
-		// the engine cannot own is answerable only with a MISLEADING negative, and a model
-		// reads "HelmRelease not found" on an Argo CD cluster as "the workload is not
-		// deployed" rather than "that question has no possible answer here". See
+		// Engine is passed so each tool advertises ONLY the kinds that engine can own.
+		// Same reasoning as clusterTools gating controller_logs on Flux: a kind the engine
+		// cannot own is answerable only with a MISLEADING negative, and a model reads
+		// "HelmRelease not found" on an Argo CD cluster as "the workload is not deployed"
+		// rather than "that question has no possible answer here". See
 		// investigate.GitOpsKinds for the live case this comes from.
+		//
+		// It comes from the PROVIDER, not the config — see WiredGitopsEngine.
 		if insp, ok := gp.(providers.GitOpsInspector); ok {
-			engine := GitopsEngine(cfg)
+			engine := WiredGitopsEngine(gp, cfg)
 			tools = append(tools,
 				investigate.GitOpsStatusTool{Inspector: insp, Engine: engine},
 				investigate.GitOpsTreeTool{Inspector: insp, Engine: engine},

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -55,10 +55,21 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	var tools []investigate.Tool
 	if gp != nil {
 		tools = append(tools, investigate.WhatChangedTool{GitOps: gp})
-		// Deep read-only Flux introspection (status/events + dependency tree), when
-		// the GitOps provider supports it (Flux does).
+		// Deep read-only GitOps introspection (status/events + dependency tree), when
+		// the GitOps provider supports it (both Flux and Argo CD do).
+		//
+		// Engine is passed so each tool advertises ONLY the kinds the configured engine
+		// can own. Same reasoning as clusterTools gating controller_logs on Flux: a kind
+		// the engine cannot own is answerable only with a MISLEADING negative, and a model
+		// reads "HelmRelease not found" on an Argo CD cluster as "the workload is not
+		// deployed" rather than "that question has no possible answer here". See
+		// investigate.GitOpsKinds for the live case this comes from.
 		if insp, ok := gp.(providers.GitOpsInspector); ok {
-			tools = append(tools, investigate.GitOpsStatusTool{Inspector: insp}, investigate.GitOpsTreeTool{Inspector: insp})
+			engine := GitopsEngine(cfg)
+			tools = append(tools,
+				investigate.GitOpsStatusTool{Inspector: insp, Engine: engine},
+				investigate.GitOpsTreeTool{Inspector: insp, Engine: engine},
+			)
 		}
 	}
 	var recall *investigate.Recall

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -216,6 +217,99 @@ func TestClusterToolsControllerLogsGatedByEngine(t *testing.T) {
 			}
 		})
 	}
+}
+
+// inspectingGitOps is a GitOpsProvider that ALSO satisfies providers.GitOpsInspector,
+// so BuildModelAndTools takes the branch that registers gitops_resource_status and
+// gitops_tree. The methods are never called — only the type assertion matters.
+type inspectingGitOps struct{ fakeGitOps }
+
+func (inspectingGitOps) ResourceStatus(context.Context, providers.Workload) (providers.ResourceStatus, error) {
+	return providers.ResourceStatus{}, nil
+}
+
+func (inspectingGitOps) DependencyTree(context.Context, providers.Workload) (providers.DepNode, error) {
+	return providers.DepNode{}, nil
+}
+
+// TestGitOpsToolsAdvertiseTheConfiguredEngine pins the wiring the engine-scoping fix
+// depends on, and had none: replacing GitopsEngine(cfg) with "" in BuildModelAndTools
+// built cleanly and left ./internal/app/... and ./internal/investigate/... fully green,
+// so the whole of #503's fix could be deleted without a red test.
+//
+// Deleting it is not a return to the old behaviour, it is worse than it. Engine defaults
+// to flux, so on an Argo CD deployment the model would again be offered HelmRelease and
+// Kustomization — #503's exact shape, three authoritative negatives on a cluster with no
+// Flux CRDs — while Application, the one kind that DOES exist there, would be refused by
+// the enum.
+//
+// Same shape as TestClusterToolsControllerLogsGatedByEngine next door, including the
+// empty-engine row: "" resolves to flux, so a wiring bug that loses the engine looks
+// exactly like the default and only the argocd row catches it.
+func TestGitOpsToolsAdvertiseTheConfiguredEngine(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent-kubeconfig"))
+	log := discardLog()
+	base := config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}
+
+	tests := []struct {
+		name       string
+		engine     string
+		wantKinds  []string
+		wantAbsent []string
+	}{
+		{"flux", "flux", []string{"HelmRelease", "Kustomization", "ExternalArtifact"}, []string{"Application"}},
+		{"default (empty) -> flux", "", []string{"HelmRelease", "Kustomization"}, []string{"Application"}},
+		{"argocd", "argocd", []string{"Application"}, []string{"HelmRelease", "Kustomization"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{Model: base}
+			cfg.GitOps.Engine = tc.engine
+			_, tools, _, _ := BuildModelAndTools(context.Background(), cfg, inspectingGitOps{}, nil, log)
+
+			found := 0
+			for _, tl := range tools {
+				if tl.Name() != "gitops_resource_status" && tl.Name() != "gitops_tree" {
+					continue
+				}
+				found++
+				enum := schemaKindEnum(t, tl.Name(), tl.Schema())
+				for _, want := range tc.wantKinds {
+					if !slices.Contains(enum, want) {
+						t.Errorf("%s: engine %q must offer kind %q, enum = %v", tl.Name(), tc.engine, want, enum)
+					}
+				}
+				for _, absent := range tc.wantAbsent {
+					if slices.Contains(enum, absent) {
+						t.Errorf("%s: engine %q offers %q, which that engine cannot own, enum = %v",
+							tl.Name(), tc.engine, absent, enum)
+					}
+				}
+			}
+			if found != 2 {
+				t.Fatalf("want gitops_resource_status + gitops_tree registered, found %d in %v", found, toolNames(tools))
+			}
+		})
+	}
+}
+
+// schemaKindEnum extracts properties.kind.enum from a tool's argument schema.
+func schemaKindEnum(t *testing.T, tool, schema string) []string {
+	t.Helper()
+	var got struct {
+		Properties struct {
+			Kind struct {
+				Enum []string `json:"enum"`
+			} `json:"kind"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(schema), &got); err != nil {
+		t.Fatalf("%s: schema is not valid JSON: %v", tool, err)
+	}
+	if len(got.Properties.Kind.Enum) == 0 {
+		t.Fatalf("%s: kind carries no enum, so any kind can be asked: %s", tool, schema)
+	}
+	return got.Properties.Kind.Enum
 }
 
 // TestBuildInvestigatorSelectsImplementation asserts the central wiring decision:

--- a/internal/app/investigate_test.go
+++ b/internal/app/investigate_test.go
@@ -284,12 +284,78 @@ func TestGitOpsToolsAdvertiseTheConfiguredEngine(t *testing.T) {
 						t.Errorf("%s: engine %q offers %q, which that engine cannot own, enum = %v",
 							tl.Name(), tc.engine, absent, enum)
 					}
+					// The description is a second, independent channel to the model: prose
+					// naming a kind the enum refuses sends it to a dead end.
+					if strings.Contains(tl.Description(), absent) {
+						t.Errorf("%s: engine %q describes %q, which the enum refuses:\n%s",
+							tl.Name(), tc.engine, absent, tl.Description())
+					}
 				}
 			}
 			if found != 2 {
 				t.Fatalf("want gitops_resource_status + gitops_tree registered, found %d in %v", found, toolNames(tools))
 			}
 		})
+	}
+}
+
+// argoReportingGitOps is an inspecting provider that reports itself as Argo CD, the way
+// *argocd.Provider does. The config it is paired with says something else.
+type argoReportingGitOps struct{ inspectingGitOps }
+
+func (argoReportingGitOps) GitOpsEngine() providers.Engine { return providers.EngineArgoCD }
+
+// TestGitOpsToolsFollowTheWiredProvider pins where the engine comes from.
+//
+// The tool description states which engine this deployment runs, in the tool list, on
+// every turn. Sourcing that from gitops.engine means an operator typo decides it:
+// GitopsEngine folds "argo", "ArgoCD" and everything else into flux without a word
+// (pinned as intended by TestGitopsEngine), so an Argo CD cluster would be described as
+// running Flux and offered Flux kinds it can never own — runlore#503 reached by a
+// misspelling. The provider that will actually answer the calls knows better, so it is
+// asked.
+func TestGitOpsToolsFollowTheWiredProvider(t *testing.T) {
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "nonexistent-kubeconfig"))
+	log := discardLog()
+
+	cfg := &config.Config{Model: config.Model{Provider: "openai", BaseURL: "http://vllm:8000/v1", Model: "test-model"}}
+	cfg.GitOps.Engine = "argo" // a misspelling: GitopsEngine silently resolves it to flux
+	_, tools, _, _ := BuildModelAndTools(context.Background(), cfg, argoReportingGitOps{}, nil, log)
+
+	found := 0
+	for _, tl := range tools {
+		if tl.Name() != "gitops_resource_status" && tl.Name() != "gitops_tree" {
+			continue
+		}
+		found++
+		if enum := schemaKindEnum(t, tl.Name(), tl.Schema()); !slices.Equal(enum, []string{"Application"}) {
+			t.Errorf("%s: enum = %v, want [Application] — the wired provider reports Argo CD, "+
+				"whatever gitops.engine says", tl.Name(), enum)
+		}
+	}
+	if found != 2 {
+		t.Fatalf("want both GitOps tools registered, found %d", found)
+	}
+}
+
+// TestUnknownGitopsEngineWarns pins the startup warning for the same misconfiguration.
+// The fallback is deliberate and stays, but it must not be silent: a deployment scoped to
+// the wrong engine looks identical to a correctly configured one in every log line.
+func TestUnknownGitopsEngineWarns(t *testing.T) {
+	for _, quiet := range []string{"", "flux", "argocd"} {
+		if msg := UnknownGitopsEngineWarning(quiet); msg != "" {
+			t.Errorf("gitops.engine=%q is valid but warned: %s", quiet, msg)
+		}
+	}
+	for _, typo := range []string{"argo", "ArgoCD", "argo-cd", "fluxcd"} {
+		msg := UnknownGitopsEngineWarning(typo)
+		if msg == "" {
+			t.Errorf("gitops.engine=%q silently resolves to flux with no warning", typo)
+			continue
+		}
+		if !strings.Contains(msg, typo) {
+			t.Errorf("the warning for %q does not name the offending value: %s", typo, msg)
+		}
 	}
 }
 

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -159,6 +159,12 @@ func RunServe(version string, args []string) error {
 	if msg := CostCeilingWithoutPricingWarning(cfg); msg != "" {
 		log.Warn(msg)
 	}
+	// An unrecognised gitops.engine resolves to flux without a word, so an Argo CD
+	// deployment that typed "argo" gets the whole Flux path — including GitOps tools
+	// scoped to kinds its cluster cannot own, which is runlore#503 reached by a typo.
+	if msg := UnknownGitopsEngineWarning(cfg.GitOps.Engine); msg != "" {
+		log.Warn(msg)
+	}
 
 	// Set up the single shared OTel metrics instance before building the investigator
 	// so recall + the investigation loop can record to it from the first request.

--- a/internal/docsguard/gitops_rbac_test.go
+++ b/internal/docsguard/gitops_rbac_test.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/Smana/runlore/internal/providers/gitops/argocd"
+	"github.com/Smana/runlore/internal/providers/gitops/flux"
+)
+
+const gitopsRBACPath = "../../deploy/helm/runlore/templates/rbac.yaml"
+
+// helmAction matches a Helm template action so the chart can be YAML-parsed. Every
+// action in rbac.yaml sits in metadata (names, labels, subjects) or wraps a whole
+// document; none of them produce a rule, so blanking them leaves the rules intact.
+var helmAction = regexp.MustCompile(`{{-?.*?-?}}`)
+
+// clusterRoleRule is one entry of a ClusterRole's rules[].
+type clusterRoleRule struct {
+	APIGroups []string `yaml:"apiGroups"`
+	Resources []string `yaml:"resources"`
+	Verbs     []string `yaml:"verbs"`
+}
+
+type clusterRoleDoc struct {
+	Kind  string            `yaml:"kind"`
+	Rules []clusterRoleRule `yaml:"rules"`
+}
+
+// TestGitOpsInspectionKindsAreRBACGranted pins the chart's cluster-wide read grant to
+// the kinds the GitOps providers actually resolve.
+//
+// gitops_resource_status and gitops_tree advertise exactly flux.GitOpsKinds() /
+// argocd.GitOpsKinds() (see investigate.GitOpsKinds), so a kind added to a provider
+// without the matching RBAC rule is advertised to the model, called, and answered with
+// a Forbidden — and a denial the tools cannot distinguish from an absence is precisely
+// the #503 failure mode. The reverse drift is cheaper but still worth naming: a grant
+// for a resource no provider resolves is unused privilege in a ClusterRole.
+//
+// This reflects over the providers' own maps, so it fails the moment kindToGVR and the
+// chart disagree in either direction.
+func TestGitOpsInspectionKindsAreRBACGranted(t *testing.T) {
+	raw, err := os.ReadFile(gitopsRBACPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", gitopsRBACPath, err)
+	}
+	granted := clusterWideReads(t, string(raw))
+
+	want := append(flux.GitOpsResources(), argocd.GitOpsResources()...)
+	for _, res := range want {
+		if !granted[res] {
+			t.Errorf("%s grants no cluster-wide get/list/watch on %q, yet a GitOps provider "+
+				"resolves a kind backed by it — the tool would advertise that kind and be denied",
+				gitopsRBACPath, res)
+		}
+	}
+	// The reverse: nothing in the GitOps CRD groups may be granted that no provider
+	// resolves. Core resources (pods, events) and the Argo CD extras the chart documents
+	// as investigation context are excluded by name, so this stays a GitOps-kind guard
+	// rather than a whole-ClusterRole freeze.
+	notAKind := []string{"applicationsets", "appprojects"}
+	for res := range granted {
+		if slices.Contains(want, res) || slices.Contains(notAKind, res) || !gitopsCRDResource(res) {
+			continue
+		}
+		t.Errorf("%s grants %q in a GitOps CRD group, but no provider resolves a kind backed "+
+			"by it — either wire the kind or drop the grant", gitopsRBACPath, res)
+	}
+}
+
+// gitopsCRDResource reports whether a granted resource belongs to the Flux/Argo CD CRD
+// surface this guard owns, as opposed to the core Kubernetes reads (pods, events) the
+// same ClusterRole carries for pod_status/kube_events.
+func gitopsCRDResource(res string) bool {
+	return !slices.Contains([]string{"pods", "events"}, res)
+}
+
+// clusterWideReads returns the resources the chart's ClusterRole grants get+list+watch
+// on. Namespaced Roles in the same file are ignored: the GitOps inspector reads any
+// namespace, so only a ClusterRole rule actually authorises it.
+func clusterWideReads(t *testing.T, chart string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	for _, doc := range strings.Split(helmAction.ReplaceAllString(chart, ""), "\n---\n") {
+		var cr clusterRoleDoc
+		if err := yaml.Unmarshal([]byte(doc), &cr); err != nil {
+			t.Fatalf("parse a document of %s as YAML: %v", gitopsRBACPath, err)
+		}
+		if cr.Kind != "ClusterRole" {
+			continue
+		}
+		for _, rule := range cr.Rules {
+			if !slices.Contains(rule.Verbs, "get") || !slices.Contains(rule.Verbs, "list") {
+				continue
+			}
+			for _, res := range rule.Resources {
+				out[res] = true
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("no ClusterRole read rules found in %s — the guard is not reading the chart", gitopsRBACPath)
+	}
+	return out
+}

--- a/internal/investigate/gitops_kinds.go
+++ b/internal/investigate/gitops_kinds.go
@@ -6,20 +6,22 @@ import (
 	"encoding/json"
 	"slices"
 	"strings"
-)
 
-// The kinds each GitOps engine can own. gitops_resource_status and gitops_tree resolve
-// GitOps objects only — they are not a generic Kubernetes resource reader.
-var (
-	argoCDGitOpsKinds = []string{"Application"}
-	fluxGitOpsKinds   = []string{
-		"Kustomization", "HelmRelease", "GitRepository",
-		"OCIRepository", "HelmRepository", "HelmChart", "Bucket",
-	}
+	"github.com/Smana/runlore/internal/providers/gitops/argocd"
+	"github.com/Smana/runlore/internal/providers/gitops/flux"
 )
 
 // GitOpsKinds returns the resource kinds the GitOps introspection tools can resolve on
-// the configured engine.
+// the configured engine. gitops_resource_status and gitops_tree resolve GitOps objects
+// only — they are not a generic Kubernetes resource reader.
+//
+// The lists are DERIVED from the providers that do the resolving (flux.GitOpsKinds,
+// argocd.GitOpsKinds) rather than restated here. The first version of this file kept
+// its own copy and it drifted immediately: it omitted ExternalArtifact, which the Flux
+// provider resolves and the chart grants RBAC for, so a model following a sourceRef to
+// one — exactly what this repo's gitops-broken-kustomization eval renders — was told
+// the kind is not a GitOps object and sent to pod_status. That is #503's defect with
+// the sign flipped, and a restated list is what made it possible.
 //
 // It is engine-scoped for the same reason clusterTools registers controller_logs ONLY
 // under Flux: a kind the configured engine cannot own is not merely unanswerable, it is
@@ -42,9 +44,9 @@ var (
 // default lives in one place rather than being restated here.
 func GitOpsKinds(engine string) []string {
 	if engine == "argocd" {
-		return slices.Clone(argoCDGitOpsKinds)
+		return argocd.GitOpsKinds()
 	}
-	return slices.Clone(fluxGitOpsKinds)
+	return flux.GitOpsKinds()
 }
 
 // gitopsKindSupported reports whether the tools can resolve kind on this engine. Matching

--- a/internal/investigate/gitops_kinds.go
+++ b/internal/investigate/gitops_kinds.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/providers/gitops/argocd"
 	"github.com/Smana/runlore/internal/providers/gitops/flux"
 )
@@ -94,6 +95,73 @@ func gitopsUnsupportedKind(engine, kind string) string {
 		"about whether the object exists — it is a statement about this tool's scope, not " +
 		"about the cluster. Do NOT treat it as evidence of absence or as a root cause. To " +
 		"check a non-GitOps object, use pod_status, kube_events or query_metrics."
+}
+
+// gitopsLookupAnswer renders a read that returned no object, as what the lookup
+// ESTABLISHED rather than as a verdict on the cluster.
+//
+// The wording this replaces — "searched the given namespace, flux-system, and all
+// namespaces by name, and no such object exists" — was wrong in three separate states,
+// all of which reach it on the SUPPORTED-kind path that engine scoping does not touch:
+//
+//   - a CRD the API does not serve 404s exactly like an absent object, so #503's own
+//     mechanism survived here untouched;
+//   - a Forbidden on the all-namespaces List was swallowed, so the answer claimed a
+//     cluster-wide search that RBAC had refused;
+//   - on Argo CD flux-system is never searched, yet the sentence named it — and the
+//     branch's own test asserted that string with Engine:"argocd".
+//
+// So the scopes come from the provider (only searches that actually completed are
+// listed) and each reason gets its own answer. Nothing here says "does not exist": the
+// earlier forbidden-word list contained that exact phrase and "no such object exists"
+// slipped past it, which is why the wording is checked against the SHAPE of the claim
+// below rather than a blocklist.
+func gitopsLookupAnswer(id string, lk providers.Lookup) string {
+	const notEvidence = " This is NOT evidence that the object is absent and NOT a root " +
+		"cause — do not build a mechanism on it."
+	switch lk.Reason {
+	case providers.LookupKindNotServed:
+		return id + ": the API server serves no such resource type on this cluster, so no " +
+			"object of that kind could be returned by any query." + notEvidence +
+			" It says the CRD is missing or not installed, which is a fact about the cluster's " +
+			"API surface, not about this object."
+	case providers.LookupDenied:
+		return id + ": " + searchedClause(lk.Scopes) + " returned no object, and the " +
+			"cluster-wide search by name was DENIED by RBAC, so it never ran." + notEvidence +
+			" The object may exist in a namespace this agent cannot list."
+	default:
+		return id + ": NOT FOUND — " + searchedClause(lk.Scopes) + " returned no object of " +
+			"that name. That is the result of a name lookup, not a diagnosis: whether an " +
+			"absence explains the incident is for you to establish from other evidence, so do " +
+			"not assume it is the root cause. If you expected it to exist, re-check the " +
+			"kind/name and namespace before concluding it was deleted."
+	}
+}
+
+// searchedClause names the scopes a provider actually completed. With none recorded it
+// stays silent about scope rather than inventing one — the failure being fixed here is a
+// message that named searches that never happened.
+func searchedClause(scopes []string) string {
+	if len(scopes) == 0 {
+		return "the lookup"
+	}
+	return "a search of " + strings.Join(scopes, ", ")
+}
+
+// gitopsLookupNote is the one-line form for a dependency-tree node.
+func gitopsLookupNote(lk providers.Lookup) string {
+	switch lk.Reason {
+	case providers.LookupKindNotServed:
+		return "kind not served by this cluster's API (not evidence of absence)"
+	case providers.LookupDenied:
+		return "search DENIED by RBAC (not evidence of absence)"
+	case providers.LookupUnresolvable:
+		return "not a kind these tools resolve — not looked up (not evidence of absence)"
+	case providers.LookupFailed:
+		return "read FAILED (not evidence of absence)"
+	default:
+		return "not found by name"
+	}
 }
 
 // gitopsKindSchema builds the argument schema with kind constrained to what the engine can

--- a/internal/investigate/gitops_kinds.go
+++ b/internal/investigate/gitops_kinds.go
@@ -177,13 +177,30 @@ func gitopsKindSchema(engine string) string {
 		`"required":["kind","name","namespace"]}`
 }
 
-// gitopsKindProse renders the supported kinds for a tool description, naming the engine so
-// the model is told why the list is short rather than left to infer a missing capability.
+// gitopsKindProse renders the supported kinds for a tool description, naming the engine
+// so the model is told why the list is short rather than left to infer a missing
+// capability.
+//
+// What it deliberately does NOT say is what used to follow: "this deployment runs Argo
+// CD; Flux kinds cannot exist here". That is a claim about the CLUSTER, made in the tool
+// list on every turn, derived from a config string nothing validates — app.GitopsEngine
+// maps "argo", "ArgoCD" and every other misspelling silently to flux — and false outright
+// on a cluster running both engines mid-migration. Before this branch that case produced
+// an honest tool ERROR, which the loop already reads as missing data; a fluent unhedged
+// claim in the prompt is worse, because the model has nothing to notice.
+//
+// Which kinds this tool resolves is a fact about the tool, and that is all this says.
 func gitopsKindProse(engine string) string {
-	if engine == "argocd" {
-		return "kind must be one of: " + strings.Join(GitOpsKinds(engine), ", ") +
-			" (this deployment runs Argo CD; Flux kinds cannot exist here)."
-	}
 	return "kind must be one of: " + strings.Join(GitOpsKinds(engine), ", ") +
-		" (this deployment runs Flux; Argo CD kinds cannot exist here)."
+		" — the GitOps kinds this deployment's " + engineDisplayName(engine) + " provider " +
+		"resolves. Any other kind is outside this tool's scope, which is not evidence about " +
+		"whether such an object exists; use pod_status, kube_events or query_metrics for those."
+}
+
+// engineDisplayName renders an engine for prose.
+func engineDisplayName(engine string) string {
+	if engine == "argocd" {
+		return "Argo CD"
+	}
+	return "Flux"
 }

--- a/internal/investigate/gitops_kinds.go
+++ b/internal/investigate/gitops_kinds.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+)
+
+// The kinds each GitOps engine can own. gitops_resource_status and gitops_tree resolve
+// GitOps objects only — they are not a generic Kubernetes resource reader.
+var (
+	argoCDGitOpsKinds = []string{"Application"}
+	fluxGitOpsKinds   = []string{
+		"Kustomization", "HelmRelease", "GitRepository",
+		"OCIRepository", "HelmRepository", "HelmChart", "Bucket",
+	}
+)
+
+// GitOpsKinds returns the resource kinds the GitOps introspection tools can resolve on
+// the configured engine.
+//
+// It is engine-scoped for the same reason clusterTools registers controller_logs ONLY
+// under Flux: a kind the configured engine cannot own is not merely unanswerable, it is
+// answerable only with a MISLEADING negative. Flux objects can never exist on an Argo CD
+// deployment, so asking about a HelmRelease there always reports "not found" — and a model
+// reasonably reads that as "the workload is not deployed" rather than "you asked a question
+// with no possible answer".
+//
+// That is not hypothetical. A live investigation cited three such calls as evidence:
+//
+//	gitops_resource_status(HelmRelease, coder, coder)         => NOT FOUND
+//	gitops_resource_status(HelmRelease, coder, observability) => NOT FOUND
+//	gitops_resource_status(Kustomization, coder, flux-system) => NOT FOUND
+//
+// Three authoritative negatives, zero information: the cluster runs engine "argocd" and has
+// no Flux CRDs at all. Advertising only what the engine can own is what stops the question
+// being asked, which is stronger than describing the trap in the answer.
+//
+// An empty engine yields the Flux set, mirroring app.GitopsEngine's own default so the
+// default lives in one place rather than being restated here.
+func GitOpsKinds(engine string) []string {
+	if engine == "argocd" {
+		return slices.Clone(argoCDGitOpsKinds)
+	}
+	return slices.Clone(fluxGitOpsKinds)
+}
+
+// gitopsKindSupported reports whether the tools can resolve kind on this engine. Matching
+// is case-insensitive: the model writes the kind as prose and "helmrelease" should be
+// refused for the same reason as "HelmRelease", not fall through to a lookup.
+func gitopsKindSupported(engine, kind string) bool {
+	return slices.ContainsFunc(GitOpsKinds(engine), func(k string) bool {
+		return strings.EqualFold(k, kind)
+	})
+}
+
+// gitopsUnsupportedKind is the answer for a kind this tool cannot resolve.
+//
+// It exists because the alternative — reusing the NOT FOUND wording — states a fact about
+// the world in answer to a question about the tool's scope. Observed live: asked about a
+// VMServiceScrape (never a supported kind), the tool replied "the object genuinely does not
+// exist (likely the cascade root)"; the model quoted that as evidence, built its mechanism
+// on it, and advised recovering the object from Git history while the object sat in the
+// cluster the whole time.
+//
+// So this says what the tool is, and says explicitly what the answer is NOT. The negative
+// claim is the load-bearing half: without it the model has no way to know the reply is
+// silent about existence rather than asserting absence.
+func gitopsUnsupportedKind(engine, kind string) string {
+	return kind + " is not a GitOps object these tools can resolve (supported on this " +
+		"deployment: " + strings.Join(GitOpsKinds(engine), ", ") + "). This says NOTHING " +
+		"about whether the object exists — it is a statement about this tool's scope, not " +
+		"about the cluster. Do NOT treat it as evidence of absence or as a root cause. To " +
+		"check a non-GitOps object, use pod_status, kube_events or query_metrics."
+}
+
+// gitopsKindSchema builds the argument schema with kind constrained to what the engine can
+// own. The enum is the part that actually prevents the failure: a description can be
+// disregarded, whereas an out-of-enum value is refused before the call is made.
+func gitopsKindSchema(engine string) string {
+	enum, err := json.Marshal(GitOpsKinds(engine))
+	if err != nil { // unreachable: a []string always marshals
+		enum = []byte(`[]`)
+	}
+	return `{"type":"object","properties":{"kind":{"type":"string","enum":` + string(enum) +
+		`},"name":{"type":"string"},"namespace":{"type":"string"}},` +
+		`"required":["kind","name","namespace"]}`
+}
+
+// gitopsKindProse renders the supported kinds for a tool description, naming the engine so
+// the model is told why the list is short rather than left to infer a missing capability.
+func gitopsKindProse(engine string) string {
+	if engine == "argocd" {
+		return "kind must be one of: " + strings.Join(GitOpsKinds(engine), ", ") +
+			" (this deployment runs Argo CD; Flux kinds cannot exist here)."
+	}
+	return "kind must be one of: " + strings.Join(GitOpsKinds(engine), ", ") +
+		" (this deployment runs Flux; Argo CD kinds cannot exist here)."
+}

--- a/internal/investigate/gitops_kinds.go
+++ b/internal/investigate/gitops_kinds.go
@@ -197,6 +197,27 @@ func gitopsKindProse(engine string) string {
 		"whether such an object exists; use pod_status, kube_events or query_metrics for those."
 }
 
+// engineFromTools reports the GitOps engine the REGISTERED tools are scoped to, empty
+// when no GitOps introspection tool is wired.
+//
+// The system prompt is built from this rather than from a field on the investigator, so
+// the prose and the schemas cannot disagree at any of the six LoopInvestigator
+// construction sites. A prompt that tells the model to follow a Kustomization's sourceRef
+// and read kustomize-controller's logs, next to a schema that refuses Flux kinds and a
+// tool list with no controller_logs in it, is prompt/schema mismatch — which is how #503
+// reached the model in the first place.
+func engineFromTools(tools []Tool) string {
+	for _, t := range tools {
+		switch g := t.(type) {
+		case GitOpsStatusTool:
+			return g.Engine
+		case GitOpsTreeTool:
+			return g.Engine
+		}
+	}
+	return ""
+}
+
 // engineDisplayName renders an engine for prose.
 func engineDisplayName(engine string) string {
 	if engine == "argocd" {

--- a/internal/investigate/gitops_kinds.go
+++ b/internal/investigate/gitops_kinds.go
@@ -49,13 +49,31 @@ func GitOpsKinds(engine string) []string {
 	return flux.GitOpsKinds()
 }
 
-// gitopsKindSupported reports whether the tools can resolve kind on this engine. Matching
-// is case-insensitive: the model writes the kind as prose and "helmrelease" should be
-// refused for the same reason as "HelmRelease", not fall through to a lookup.
-func gitopsKindSupported(engine, kind string) bool {
-	return slices.ContainsFunc(GitOpsKinds(engine), func(k string) bool {
+// canonicalGitOpsKind resolves kind to the exact spelling the engine's provider uses,
+// reporting false when this engine cannot own it.
+//
+// Matching is case-insensitive because the model writes the kind as prose, so
+// "helmrelease" must be ACCEPTED rather than refused as out of scope — but the canonical
+// spelling is what the caller has to forward. The resolvers are exact-match maps
+// (flux.kindToGVR, argocd.kindToGVR), so a lowercase kind that cleared a case-insensitive
+// guard and was then passed on verbatim missed the map: gitops_tree swallows that
+// resolution failure and rendered "helmrelease apps/api (Ready=unknown)" — a node for an
+// object nobody ever looked up. Returning the canonical form is what keeps the guard and
+// the resolver talking about the same object.
+func canonicalGitOpsKind(engine, kind string) (string, bool) {
+	kinds := GitOpsKinds(engine)
+	if i := slices.IndexFunc(kinds, func(k string) bool {
 		return strings.EqualFold(k, kind)
-	})
+	}); i >= 0 {
+		return kinds[i], true
+	}
+	return "", false
+}
+
+// gitopsKindSupported reports whether the tools can resolve kind on this engine.
+func gitopsKindSupported(engine, kind string) bool {
+	_, ok := canonicalGitOpsKind(engine, kind)
+	return ok
 }
 
 // gitopsUnsupportedKind is the answer for a kind this tool cannot resolve.

--- a/internal/investigate/gitops_kinds_test.go
+++ b/internal/investigate/gitops_kinds_test.go
@@ -256,6 +256,164 @@ func TestGitOpsNotFoundDoesNotNominateARootCause(t *testing.T) {
 	}
 }
 
+// TestGitOpsNegativeReportsTheLookupNotAVerdict covers the three states in which the
+// softened NOT FOUND wording was still false. All of them are on the SUPPORTED-kind
+// path, which engine scoping does not touch, so #503's mechanism survived there:
+//
+//   - an unserved CRD 404s exactly like an absent object;
+//   - a Forbidden on the all-namespaces List was swallowed, so the answer claimed a
+//     cluster-wide search that never ran;
+//   - flux-system was named unconditionally, including on Argo CD, which never
+//     searches it — and the earlier test asserted that very string with Engine:"argocd".
+//
+// The old wording's own guard is why this checks the SHAPE of the claim rather than a
+// blocklist: the forbidden-word list contained "does not exist", and "and no such object
+// exists" walked straight past it.
+func TestGitOpsNegativeReportsTheLookupNotAVerdict(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		engine  string
+		lookup  providers.Lookup
+		want    []string
+		wantNot []string
+	}{
+		{
+			name:   "absent on argocd names only the scopes that ran",
+			engine: "argocd",
+			lookup: providers.Lookup{Reason: providers.LookupAbsent,
+				Scopes: []string{"apps", providers.AllNamespaces}},
+			want: []string{"NOT FOUND", "apps", providers.AllNamespaces, "do not assume it is the root cause"},
+			// The whole point: Argo CD never searches flux-system, so the answer may not
+			// say it did.
+			wantNot: []string{"flux-system"},
+		},
+		{
+			name:   "unserved CRD is reported as a missing type, not a missing object",
+			engine: "flux",
+			lookup: providers.Lookup{Reason: providers.LookupKindNotServed, Scopes: []string{"apps", "flux-system"}},
+			want: []string{"serves no such resource type",
+				"NOT evidence that the object is absent"},
+			wantNot: []string{"NOT FOUND"},
+		},
+		{
+			name:   "denied cluster-wide search is reported as denied",
+			engine: "flux",
+			lookup: providers.Lookup{Reason: providers.LookupDenied, Scopes: []string{"apps", "flux-system"}},
+			want: []string{"DENIED by RBAC", "never ran", "NOT evidence that the object is absent",
+				"may exist in a namespace this agent cannot list"},
+			// The search it did not do must not be listed as one it did.
+			wantNot: []string{providers.AllNamespaces},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			insp := fakeInspector{status: providers.ResourceStatus{NotFound: true, Lookup: tc.lookup}}
+			kind := "HelmRelease"
+			if tc.engine == "argocd" {
+				kind = "Application"
+			}
+			out, err := GitOpsStatusTool{Inspector: insp, Engine: tc.engine}.Call(context.Background(),
+				`{"kind":"`+kind+`","name":"api","namespace":"apps"}`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(out, w) {
+					t.Errorf("answer is missing %q:\n%s", w, out)
+				}
+			}
+			for _, w := range tc.wantNot {
+				if strings.Contains(out, w) {
+					t.Errorf("answer claims %q, which this lookup did not establish:\n%s", w, out)
+				}
+			}
+			// No wording, in any state, may assert the object is absent from the cluster.
+			for _, claim := range []string{"does not exist", "no such object exists", "genuinely", "cascade root"} {
+				if strings.Contains(strings.ToLower(out), claim) {
+					t.Errorf("answer asserts %q from one name lookup:\n%s", claim, out)
+				}
+			}
+		})
+	}
+}
+
+// TestGitOpsTreeReportsTheLookupPerNode is gitops_tree's half of the same property. It
+// used to render a node the API never returned as "NOT FOUND  ← root" — which this
+// branch's own comment calls nominating the absence as the cause outright — and a node
+// whose read merely FAILED as "(Ready=unknown)", asserting an object nobody read.
+func TestGitOpsTreeReportsTheLookupPerNode(t *testing.T) {
+	tree := providers.DepNode{
+		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"},
+		Ready:    "False", Reason: "DependencyNotReady",
+		Children: []providers.DepNode{
+			{Workload: providers.Workload{Kind: "GitRepository", Name: "gone", Namespace: "flux-system"},
+				NotFound: true, Lookup: providers.Lookup{Reason: providers.LookupAbsent}},
+			{Workload: providers.Workload{Kind: "HelmRelease", Name: "denied", Namespace: "apps"},
+				Lookup: providers.Lookup{Reason: providers.LookupDenied}},
+			{Workload: providers.Workload{Kind: "ArtifactGenerator", Name: "split", Namespace: "flux-system"},
+				Lookup: providers.Lookup{Reason: providers.LookupUnresolvable}},
+			{Workload: providers.Workload{Kind: "Bucket", Name: "flaky", Namespace: "flux-system"},
+				Lookup: providers.Lookup{Reason: providers.LookupFailed}},
+		},
+	}
+	out, err := GitOpsTreeTool{Inspector: fakeInspector{tree: tree}, Engine: "flux"}.Call(context.Background(),
+		`{"kind":"Kustomization","name":"apps","namespace":"flux-system"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"gone: not found by name",
+		"denied: search DENIED by RBAC (not evidence of absence)",
+		"split: not a kind these tools resolve — not looked up (not evidence of absence)",
+		"flaky: read FAILED (not evidence of absence)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("tree is missing %q:\n%s", want, out)
+		}
+	}
+	// A node nobody could read must never render as an existing one.
+	if strings.Contains(out, "Ready=unknown") {
+		t.Errorf("a node the API did not return is rendered with a Ready state:\n%s", out)
+	}
+	if strings.Contains(out, "← root") {
+		t.Errorf("the tree still nominates a root cause from one name lookup:\n%s", out)
+	}
+}
+
+// TestGitOpsTreeRecordsOnlyNodesItActuallyRead pins the observed-set side of the same
+// change. recordObservedTree gated on NotFound alone, so a node whose read was DENIED or
+// errored — never returned by the API — was recorded as server-confirmed and became a
+// legitimate action target (guardUnobservedTargets). Only a node the provider actually
+// read may count.
+func TestGitOpsTreeRecordsOnlyNodesItActuallyRead(t *testing.T) {
+	tree := providers.DepNode{
+		Workload: providers.Workload{Kind: "Kustomization", Name: "apps", Namespace: "flux-system"}, Ready: "True",
+		Children: []providers.DepNode{
+			{Workload: providers.Workload{Kind: "HelmRelease", Name: "denied", Namespace: "apps"},
+				Lookup: providers.Lookup{Reason: providers.LookupDenied}},
+			{Workload: providers.Workload{Kind: "Bucket", Name: "flaky", Namespace: "flux-system"},
+				Lookup: providers.Lookup{Reason: providers.LookupFailed}},
+		},
+	}
+	ctx := WithObservedResources(context.Background())
+	if _, err := (GitOpsTreeTool{Inspector: fakeInspector{tree: tree}, Engine: "flux"}).Call(ctx,
+		`{"kind":"Kustomization","name":"apps","namespace":"flux-system"}`); err != nil {
+		t.Fatal(err)
+	}
+	obs := observedFrom(ctx)
+	if !obs.matches(providers.Workload{Name: "apps", Namespace: "flux-system"}) {
+		t.Error("a node that WAS read is not recorded as observed")
+	}
+	for _, ghost := range []providers.Workload{
+		{Name: "denied", Namespace: "apps"},
+		{Name: "flaky", Namespace: "flux-system"},
+	} {
+		if obs.matches(ghost) {
+			t.Errorf("%s/%s was recorded as observed, but the API never returned it",
+				ghost.Namespace, ghost.Name)
+		}
+	}
+}
+
 // TestGitOpsDescriptionsMatchTheEngine stops the prose and the enum drifting apart: a
 // description naming kinds the schema refuses would send the model to a dead end, which is
 // the same class of confusion in the opposite direction.

--- a/internal/investigate/gitops_kinds_test.go
+++ b/internal/investigate/gitops_kinds_test.go
@@ -417,26 +417,56 @@ func TestGitOpsTreeRecordsOnlyNodesItActuallyRead(t *testing.T) {
 // TestGitOpsDescriptionsMatchTheEngine stops the prose and the enum drifting apart: a
 // description naming kinds the schema refuses would send the model to a dead end, which is
 // the same class of confusion in the opposite direction.
+//
+// The flux side is checked too, and it was not before — which is how the descriptions kept
+// naming "an Argo CD Application" on a Flux deployment whose enum refuses that kind.
 func TestGitOpsDescriptionsMatchTheEngine(t *testing.T) {
-	for _, d := range []string{
-		GitOpsStatusTool{Engine: "argocd"}.Description(),
-		GitOpsTreeTool{Engine: "argocd"}.Description(),
+	for engine, foreign := range map[string][]string{
+		"argocd": {"HelmRelease", "Kustomization", "OCIRepository", "Flux"},
+		"flux":   {"Application", "Argo CD"},
 	} {
-		for _, flux := range []string{"HelmRelease", "Kustomization", "OCIRepository"} {
-			if strings.Contains(d, flux) {
-				t.Errorf("argocd description advertises the Flux kind %s:\n%s", flux, d)
+		for _, d := range []string{
+			GitOpsStatusTool{Engine: engine}.Description(),
+			GitOpsTreeTool{Engine: engine}.Description(),
+		} {
+			for _, other := range foreign {
+				if strings.Contains(d, other) {
+					t.Errorf("%s description mentions %q, which this deployment's enum refuses:\n%s",
+						engine, other, d)
+				}
+			}
+			for _, own := range GitOpsKinds(engine) {
+				if !strings.Contains(d, own) {
+					t.Errorf("%s description omits the supported kind %s:\n%s", engine, own, d)
+				}
 			}
 		}
-		if !strings.Contains(d, "Application") {
-			t.Errorf("argocd description does not name its one supported kind:\n%s", d)
-		}
 	}
-	for _, d := range []string{
-		GitOpsStatusTool{Engine: "flux"}.Description(),
-		GitOpsTreeTool{Engine: "flux"}.Description(),
-	} {
-		if !strings.Contains(d, "HelmRelease") {
-			t.Errorf("flux description does not name HelmRelease:\n%s", d)
+}
+
+// TestGitOpsProseMakesNoClaimAboutTheCluster is F4. The description read:
+//
+//	(this deployment runs Argo CD; Flux kinds cannot exist here)
+//
+// A cluster fact, stated in the tool list on every single turn, derived from an
+// UNVALIDATED config string: app.GitopsEngine maps "argo", "ArgoCD" and every other
+// misspelling silently to flux (pinned as intended by its own test), and a cluster
+// mid-migration runs both engines at once. Before this branch that case produced an
+// honest tool ERROR, which the loop already reads as missing data; the branch turned it
+// into a fluent unhedged claim. The lie moved out of the answer and into the prompt.
+//
+// The list of kinds is a fact about this tool. What cannot exist on the cluster is not.
+func TestGitOpsProseMakesNoClaimAboutTheCluster(t *testing.T) {
+	for _, engine := range []string{"flux", "argocd", ""} {
+		prose := gitopsKindProse(engine)
+		for _, claim := range []string{"cannot exist", "do not exist", "does not exist", "no Flux", "no Argo"} {
+			if strings.Contains(strings.ToLower(prose), strings.ToLower(claim)) {
+				t.Errorf("engine %q: the kind list asserts %q about the cluster:\n%s", engine, claim, prose)
+			}
+		}
+		if !strings.Contains(prose, "not evidence") {
+			t.Errorf("engine %q: the kind list does not say an out-of-scope kind is not evidence "+
+				"of absence:\n%s", engine, prose)
 		}
 	}
 }

--- a/internal/investigate/gitops_kinds_test.go
+++ b/internal/investigate/gitops_kinds_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// countingInspector records what it was asked, so a test can assert the tool refused an
+// out-of-scope kind BEFORE any lookup rather than after one.
+type countingInspector struct {
+	calls    int
+	notFound bool
+}
+
+func (c *countingInspector) ResourceStatus(_ context.Context, w providers.Workload) (providers.ResourceStatus, error) {
+	c.calls++
+	return providers.ResourceStatus{Workload: w, NotFound: c.notFound, Ready: "True"}, nil
+}
+
+func (c *countingInspector) DependencyTree(_ context.Context, w providers.Workload) (providers.DepNode, error) {
+	c.calls++
+	return providers.DepNode{Workload: w, NotFound: c.notFound, Ready: "True"}, nil
+}
+
+// TestGitOpsKindsAreEngineScoped pins the capability boundary. Flux objects cannot exist on
+// an Argo CD deployment, so advertising them invites a question whose only possible answer
+// is a misleading negative — the live failure this comes from, where three
+// HelmRelease/Kustomization "NOT FOUND" replies were cited as evidence on a cluster with no
+// Flux CRDs at all.
+func TestGitOpsKindsAreEngineScoped(t *testing.T) {
+	argo := GitOpsKinds("argocd")
+	if len(argo) != 1 || argo[0] != "Application" {
+		t.Fatalf("argocd kinds = %v, want exactly [Application]", argo)
+	}
+	for _, k := range []string{"HelmRelease", "Kustomization", "GitRepository", "Bucket"} {
+		if gitopsKindSupported("argocd", k) {
+			t.Errorf("%s is advertised on argocd, where it can never exist", k)
+		}
+	}
+	if !gitopsKindSupported("flux", "HelmRelease") {
+		t.Error("HelmRelease must be supported on flux")
+	}
+	if gitopsKindSupported("flux", "Application") {
+		t.Error("Argo CD's Application is advertised on flux, where it can never exist")
+	}
+	// The default mirrors app.GitopsEngine's own ("" ⇒ flux) so the default lives in one
+	// place. A caller that forgets to set Engine therefore behaves as before, not worse.
+	if got, want := GitOpsKinds(""), GitOpsKinds("flux"); len(got) != len(want) {
+		t.Errorf("empty engine = %v, want the flux set %v", got, want)
+	}
+	// Case-insensitive: the model writes the kind as prose, and "helmrelease" must be
+	// refused for the same reason as "HelmRelease" rather than falling through to a lookup.
+	if !gitopsKindSupported("flux", "helmrelease") {
+		t.Error("kind matching must be case-insensitive")
+	}
+}
+
+// TestGitOpsSchemaConstrainsKind pins the enum, which is the part that actually prevents
+// the failure: a description can be disregarded by the model, an out-of-enum value cannot
+// be sent.
+func TestGitOpsSchemaConstrainsKind(t *testing.T) {
+	for _, engine := range []string{"argocd", "flux"} {
+		for name, schema := range map[string]string{
+			"gitops_resource_status": GitOpsStatusTool{Engine: engine}.Schema(),
+			"gitops_tree":            GitOpsTreeTool{Engine: engine}.Schema(),
+		} {
+			var got struct {
+				Properties struct {
+					Kind struct {
+						Enum []string `json:"enum"`
+					} `json:"kind"`
+				} `json:"properties"`
+			}
+			if err := json.Unmarshal([]byte(schema), &got); err != nil {
+				t.Fatalf("%s/%s: schema is not valid JSON: %v", name, engine, err)
+			}
+			if len(got.Properties.Kind.Enum) == 0 {
+				t.Fatalf("%s/%s: kind has no enum, so any kind can be asked: %s", name, engine, schema)
+			}
+			for _, k := range got.Properties.Kind.Enum {
+				if !gitopsKindSupported(engine, k) {
+					t.Errorf("%s/%s: enum offers %q, which the engine cannot own", name, engine, k)
+				}
+			}
+		}
+	}
+}
+
+// TestGitOpsUnsupportedKindIsNotEvidenceOfAbsence is the core regression. Asked about a
+// kind it never supported, the tool used to answer "the object genuinely does not exist
+// (likely the cascade root)" — a claim about the world in reply to a question about the
+// tool's scope. The model quoted it as evidence, built a wrong mechanism on it, and advised
+// recovering from Git history an object that was in the cluster the whole time.
+func TestGitOpsUnsupportedKindIsNotEvidenceOfAbsence(t *testing.T) {
+	for _, tc := range []struct {
+		tool string
+		call func(*countingInspector) (string, error)
+	}{
+		{"gitops_resource_status", func(i *countingInspector) (string, error) {
+			return GitOpsStatusTool{Inspector: i, Engine: "argocd"}.Call(context.Background(),
+				`{"kind":"VMServiceScrape","name":"datagrok-rabbitmq","namespace":"observability"}`)
+		}},
+		{"gitops_tree", func(i *countingInspector) (string, error) {
+			return GitOpsTreeTool{Inspector: i, Engine: "argocd"}.Call(context.Background(),
+				`{"kind":"VMServiceScrape","name":"datagrok-rabbitmq","namespace":"observability"}`)
+		}},
+	} {
+		insp := &countingInspector{notFound: true}
+		out, err := tc.call(insp)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.tool, err)
+		}
+		// The words that made the old answer dangerous. "not found" is included because the
+		// tree renderer emits "NOT FOUND  ← root", which hands back a root cause outright.
+		for _, forbidden := range []string{"does not exist", "genuinely", "cascade root", "← root"} {
+			if strings.Contains(strings.ToLower(out), strings.ToLower(forbidden)) {
+				t.Errorf("%s: out-of-scope kind answered with %q — that is a claim about the cluster:\n%s",
+					tc.tool, forbidden, out)
+			}
+		}
+		// The disclaimer is load-bearing: without it the model cannot tell that the reply
+		// is silent about existence rather than asserting absence.
+		if !strings.Contains(out, "NOTHING about whether the object exists") {
+			t.Errorf("%s: reply does not disclaim evidence of absence:\n%s", tc.tool, out)
+		}
+		// Refused BEFORE the lookup — a tool that cannot answer should not spend a call.
+		if insp.calls != 0 {
+			t.Errorf("%s: inspector was called %d times for an unsupported kind", tc.tool, insp.calls)
+		}
+	}
+}
+
+// TestGitOpsNotFoundDoesNotNominateARootCause covers the SUPPORTED-kind path. Absence is a
+// fact worth stating; that the absence caused the incident is for the loop to establish.
+// The old wording asserted both from a single name lookup.
+func TestGitOpsNotFoundDoesNotNominateARootCause(t *testing.T) {
+	insp := &countingInspector{notFound: true}
+	out, err := GitOpsStatusTool{Inspector: insp, Engine: "argocd"}.Call(context.Background(),
+		`{"kind":"Application","name":"runlore","namespace":"argocd"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "NOT FOUND") {
+		t.Fatalf("a genuinely absent supported object must still report absence:\n%s", out)
+	}
+	for _, forbidden := range []string{"genuinely does not exist", "likely the cascade root"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("NOT FOUND still over-claims with %q:\n%s", forbidden, out)
+		}
+	}
+	if !strings.Contains(out, "do not assume it is the root cause") {
+		t.Errorf("NOT FOUND does not warn against reading absence as causation:\n%s", out)
+	}
+}
+
+// TestGitOpsDescriptionsMatchTheEngine stops the prose and the enum drifting apart: a
+// description naming kinds the schema refuses would send the model to a dead end, which is
+// the same class of confusion in the opposite direction.
+func TestGitOpsDescriptionsMatchTheEngine(t *testing.T) {
+	for _, d := range []string{
+		GitOpsStatusTool{Engine: "argocd"}.Description(),
+		GitOpsTreeTool{Engine: "argocd"}.Description(),
+	} {
+		for _, flux := range []string{"HelmRelease", "Kustomization", "OCIRepository"} {
+			if strings.Contains(d, flux) {
+				t.Errorf("argocd description advertises the Flux kind %s:\n%s", flux, d)
+			}
+		}
+		if !strings.Contains(d, "Application") {
+			t.Errorf("argocd description does not name its one supported kind:\n%s", d)
+		}
+	}
+	for _, d := range []string{
+		GitOpsStatusTool{Engine: "flux"}.Description(),
+		GitOpsTreeTool{Engine: "flux"}.Description(),
+	} {
+		if !strings.Contains(d, "HelmRelease") {
+			t.Errorf("flux description does not name HelmRelease:\n%s", d)
+		}
+	}
+}

--- a/internal/investigate/gitops_kinds_test.go
+++ b/internal/investigate/gitops_kinds_test.go
@@ -194,65 +194,87 @@ func TestGitOpsSchemaConstrainsKind(t *testing.T) {
 // (likely the cascade root)" — a claim about the world in reply to a question about the
 // tool's scope. The model quoted it as evidence, built a wrong mechanism on it, and advised
 // recovering from Git history an object that was in the cluster the whole time.
+//
+// Both engines are exercised. The first version of this test only ever set
+// Engine:"argocd", so the flux-side guard — which is the DEFAULT, and therefore what a
+// deployment that never sets gitops.engine actually runs — was never called at all.
 func TestGitOpsUnsupportedKindIsNotEvidenceOfAbsence(t *testing.T) {
-	for _, tc := range []struct {
-		tool string
-		call func(*countingInspector) (string, error)
-	}{
-		{"gitops_resource_status", func(i *countingInspector) (string, error) {
-			return GitOpsStatusTool{Inspector: i, Engine: "argocd"}.Call(context.Background(),
-				`{"kind":"VMServiceScrape","name":"datagrok-rabbitmq","namespace":"observability"}`)
-		}},
-		{"gitops_tree", func(i *countingInspector) (string, error) {
-			return GitOpsTreeTool{Inspector: i, Engine: "argocd"}.Call(context.Background(),
-				`{"kind":"VMServiceScrape","name":"datagrok-rabbitmq","namespace":"observability"}`)
-		}},
-	} {
-		insp := &countingInspector{notFound: true}
-		out, err := tc.call(insp)
-		if err != nil {
-			t.Fatalf("%s: %v", tc.tool, err)
+	for _, engine := range []string{"argocd", "flux", ""} {
+		// Two shapes of out-of-scope kind: one no engine owns (the live #503 case), and
+		// one the OTHER engine owns, which is the shape the model is most likely to try.
+		foreign := "Application" // flux (and the default) cannot own Argo CD's Application
+		if engine == "argocd" {
+			foreign = "HelmRelease"
 		}
-		// The words that made the old answer dangerous. "not found" is included because the
-		// tree renderer emits "NOT FOUND  ← root", which hands back a root cause outright.
-		for _, forbidden := range []string{"does not exist", "genuinely", "cascade root", "← root"} {
-			if strings.Contains(strings.ToLower(out), strings.ToLower(forbidden)) {
-				t.Errorf("%s: out-of-scope kind answered with %q — that is a claim about the cluster:\n%s",
-					tc.tool, forbidden, out)
+		for _, kind := range []string{"VMServiceScrape", foreign} {
+			for _, tc := range []struct {
+				tool string
+				call func(*countingInspector) (string, error)
+			}{
+				{"gitops_resource_status", func(i *countingInspector) (string, error) {
+					return GitOpsStatusTool{Inspector: i, Engine: engine}.Call(context.Background(),
+						`{"kind":"`+kind+`","name":"datagrok-rabbitmq","namespace":"observability"}`)
+				}},
+				{"gitops_tree", func(i *countingInspector) (string, error) {
+					return GitOpsTreeTool{Inspector: i, Engine: engine}.Call(context.Background(),
+						`{"kind":"`+kind+`","name":"datagrok-rabbitmq","namespace":"observability"}`)
+				}},
+			} {
+				insp := &countingInspector{notFound: true}
+				out, err := tc.call(insp)
+				if err != nil {
+					t.Fatalf("%s/%s/%s: %v", engine, kind, tc.tool, err)
+				}
+				id := engine + "/" + kind + "/" + tc.tool
+				// The words that made the old answer dangerous, plus the tree renderer's
+				// "← root", which handed back a root cause outright.
+				for _, forbidden := range []string{"does not exist", "genuinely", "cascade root", "← root"} {
+					if strings.Contains(strings.ToLower(out), strings.ToLower(forbidden)) {
+						t.Errorf("%s: out-of-scope kind answered with %q — that is a claim about the cluster:\n%s",
+							id, forbidden, out)
+					}
+				}
+				// The disclaimer is load-bearing: without it the model cannot tell that the
+				// reply is silent about existence rather than asserting absence.
+				if !strings.Contains(out, "NOTHING about whether the object exists") {
+					t.Errorf("%s: reply does not disclaim evidence of absence:\n%s", id, out)
+				}
+				// Refused BEFORE the lookup — a tool that cannot answer should not spend a call.
+				if insp.calls != 0 {
+					t.Errorf("%s: inspector was called %d times for an unsupported kind", id, insp.calls)
+				}
 			}
-		}
-		// The disclaimer is load-bearing: without it the model cannot tell that the reply
-		// is silent about existence rather than asserting absence.
-		if !strings.Contains(out, "NOTHING about whether the object exists") {
-			t.Errorf("%s: reply does not disclaim evidence of absence:\n%s", tc.tool, out)
-		}
-		// Refused BEFORE the lookup — a tool that cannot answer should not spend a call.
-		if insp.calls != 0 {
-			t.Errorf("%s: inspector was called %d times for an unsupported kind", tc.tool, insp.calls)
 		}
 	}
 }
 
 // TestGitOpsNotFoundDoesNotNominateARootCause covers the SUPPORTED-kind path. Absence is a
 // fact worth stating; that the absence caused the incident is for the loop to establish.
-// The old wording asserted both from a single name lookup.
+// The old wording asserted both from a single name lookup — and was only ever tested on
+// argocd, so the default engine's answer went unchecked.
 func TestGitOpsNotFoundDoesNotNominateARootCause(t *testing.T) {
-	insp := &countingInspector{notFound: true}
-	out, err := GitOpsStatusTool{Inspector: insp, Engine: "argocd"}.Call(context.Background(),
-		`{"kind":"Application","name":"runlore","namespace":"argocd"}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(out, "NOT FOUND") {
-		t.Fatalf("a genuinely absent supported object must still report absence:\n%s", out)
-	}
-	for _, forbidden := range []string{"genuinely does not exist", "likely the cascade root"} {
-		if strings.Contains(out, forbidden) {
-			t.Errorf("NOT FOUND still over-claims with %q:\n%s", forbidden, out)
+	for _, tc := range []struct{ engine, kind, namespace string }{
+		{"argocd", "Application", "argocd"},
+		{"flux", "Kustomization", "flux-system"},
+		{"", "HelmRelease", "apps"},
+	} {
+		insp := &countingInspector{notFound: true}
+		out, err := GitOpsStatusTool{Inspector: insp, Engine: tc.engine}.Call(context.Background(),
+			`{"kind":"`+tc.kind+`","name":"runlore","namespace":"`+tc.namespace+`"}`)
+		if err != nil {
+			t.Fatal(err)
 		}
-	}
-	if !strings.Contains(out, "do not assume it is the root cause") {
-		t.Errorf("NOT FOUND does not warn against reading absence as causation:\n%s", out)
+		if !strings.Contains(out, "NOT FOUND") {
+			t.Fatalf("%s: an absent supported object must still report absence:\n%s", tc.engine, out)
+		}
+		for _, forbidden := range []string{"genuinely does not exist", "likely the cascade root", "no such object exists"} {
+			if strings.Contains(out, forbidden) {
+				t.Errorf("%s: NOT FOUND still over-claims with %q:\n%s", tc.engine, forbidden, out)
+			}
+		}
+		if !strings.Contains(out, "do not assume it is the root cause") {
+			t.Errorf("%s: NOT FOUND does not warn against reading absence as causation:\n%s", tc.engine, out)
+		}
 	}
 }
 

--- a/internal/investigate/gitops_kinds_test.go
+++ b/internal/investigate/gitops_kinds_test.go
@@ -54,16 +54,60 @@ func TestGitOpsKindsTrackTheProviders(t *testing.T) {
 type countingInspector struct {
 	calls    int
 	notFound bool
+	asked    providers.Workload // what the last call was actually given
 }
 
 func (c *countingInspector) ResourceStatus(_ context.Context, w providers.Workload) (providers.ResourceStatus, error) {
 	c.calls++
+	c.asked = w
 	return providers.ResourceStatus{Workload: w, NotFound: c.notFound, Ready: "True"}, nil
 }
 
 func (c *countingInspector) DependencyTree(_ context.Context, w providers.Workload) (providers.DepNode, error) {
 	c.calls++
+	c.asked = w
 	return providers.DepNode{Workload: w, NotFound: c.notFound, Ready: "True"}, nil
+}
+
+// TestGitOpsKindIsCanonicalisedBeforeTheLookup closes the gap between a
+// case-INSENSITIVE guard and a case-SENSITIVE resolver.
+//
+// gitopsKindSupported matched with EqualFold while Call forwarded in.Kind verbatim and
+// flux.kindToGVR is an exact-match map, so kind:"helmrelease" passed the guard and then
+// missed the map. gitops_resource_status surfaced that as an error, but gitops_tree
+// swallows a resolution failure (flux depNode: `if err != nil { return node }`) and
+// rendered
+//
+//	helmrelease apps/api (Ready=unknown)
+//
+// — a node for an object nobody looked up, asserting it exists. A fabricated node in a
+// dependency tree is the same class of false evidence as #503's false negative.
+func TestGitOpsKindIsCanonicalisedBeforeTheLookup(t *testing.T) {
+	for _, tc := range []struct {
+		tool string
+		call func(*countingInspector, string) (string, error)
+	}{
+		{"gitops_resource_status", func(i *countingInspector, kind string) (string, error) {
+			return GitOpsStatusTool{Inspector: i, Engine: "flux"}.Call(context.Background(),
+				`{"kind":"`+kind+`","name":"api","namespace":"apps"}`)
+		}},
+		{"gitops_tree", func(i *countingInspector, kind string) (string, error) {
+			return GitOpsTreeTool{Inspector: i, Engine: "flux"}.Call(context.Background(),
+				`{"kind":"`+kind+`","name":"api","namespace":"apps"}`)
+		}},
+	} {
+		for _, written := range []string{"helmrelease", "HELMRELEASE", "HelmRelease"} {
+			insp := &countingInspector{}
+			if _, err := tc.call(insp, written); err != nil {
+				t.Fatalf("%s/%s: %v", tc.tool, written, err)
+			}
+			if insp.asked.Kind != "HelmRelease" {
+				t.Errorf("%s: kind %q reached the inspector as %q — the resolver matches exactly, "+
+					"so anything but the canonical spelling silently fails to resolve",
+					tc.tool, written, insp.asked.Kind)
+			}
+		}
+	}
 }
 
 // TestGitOpsKindsAreEngineScoped pins the capability boundary. Flux objects cannot exist on
@@ -94,10 +138,19 @@ func TestGitOpsKindsAreEngineScoped(t *testing.T) {
 	if got, want := GitOpsKinds(""), GitOpsKinds("flux"); !slices.Equal(got, want) {
 		t.Errorf("empty engine = %v, want the flux set %v", got, want)
 	}
-	// Case-insensitive: the model writes the kind as prose, and "helmrelease" must be
-	// refused for the same reason as "HelmRelease" rather than falling through to a lookup.
-	if !gitopsKindSupported("flux", "helmrelease") {
-		t.Error("kind matching must be case-insensitive")
+	// Case-insensitive in BOTH directions, which the earlier version only half-asserted:
+	// the model writes the kind as prose, so "helmrelease" is accepted on flux (and
+	// canonicalised — see TestGitOpsKindIsCanonicalisedBeforeTheLookup), and refused on
+	// argocd for exactly the same reason "HelmRelease" is. A guard that folds case when
+	// accepting but not when refusing is a hole, not a convenience.
+	if got, ok := canonicalGitOpsKind("flux", "helmrelease"); !ok || got != "HelmRelease" {
+		t.Errorf(`canonicalGitOpsKind("flux","helmrelease") = %q,%v; want "HelmRelease",true`, got, ok)
+	}
+	if gitopsKindSupported("argocd", "helmrelease") {
+		t.Error("lowercase helmrelease is accepted on argocd, where the engine cannot own it")
+	}
+	if gitopsKindSupported("flux", "APPLICATION") {
+		t.Error("uppercase APPLICATION is accepted on flux, where the engine cannot own it")
 	}
 }
 

--- a/internal/investigate/gitops_kinds_test.go
+++ b/internal/investigate/gitops_kinds_test.go
@@ -5,11 +5,49 @@ package investigate
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/providers/gitops/argocd"
+	"github.com/Smana/runlore/internal/providers/gitops/flux"
 )
+
+// TestGitOpsKindsTrackTheProviders is the drift guard the first version of this file
+// lacked. The advertised set was typed out by hand next to a provider that resolves its
+// own, and they diverged on the very first edit: flux.kindToGVR resolves
+// ExternalArtifact (and the chart grants RBAC for it, and this repo's own eval renders
+// one as a source node), yet the tools refused it as "not a GitOps object these tools
+// can resolve" — the same defect as #503 with the sign flipped, since every clause of
+// that refusal was false.
+//
+// Both directions matter. A kind the provider resolves but the tools hide is an
+// unreachable capability plus a false refusal; a kind the tools offer but the provider
+// cannot resolve reaches an inspector that errors, or worse (see the canonicalisation
+// test) renders a fabricated node.
+func TestGitOpsKindsTrackTheProviders(t *testing.T) {
+	for engine, resolvable := range map[string][]string{
+		"flux":   flux.GitOpsKinds(),
+		"argocd": argocd.GitOpsKinds(),
+	} {
+		advertised := GitOpsKinds(engine)
+		if !slices.Equal(slices.Sorted(slices.Values(advertised)), slices.Sorted(slices.Values(resolvable))) {
+			t.Errorf("%s: advertised kinds %v != the kinds the provider resolves %v",
+				engine, advertised, resolvable)
+		}
+		for _, k := range resolvable {
+			if !gitopsKindSupported(engine, k) {
+				t.Errorf("%s: the provider resolves %s but the tools refuse it", engine, k)
+			}
+		}
+	}
+	// Named explicitly: this is the kind that was actually dropped, so a future edit
+	// that re-hand-rolls the list fails here with the incident's own name on it.
+	if !gitopsKindSupported("flux", "ExternalArtifact") {
+		t.Error("ExternalArtifact is refused on flux, yet the provider resolves it and the chart grants RBAC for it")
+	}
+}
 
 // countingInspector records what it was asked, so a test can assert the tool refused an
 // out-of-scope kind BEFORE any lookup rather than after one.
@@ -51,7 +89,9 @@ func TestGitOpsKindsAreEngineScoped(t *testing.T) {
 	}
 	// The default mirrors app.GitopsEngine's own ("" ⇒ flux) so the default lives in one
 	// place. A caller that forgets to set Engine therefore behaves as before, not worse.
-	if got, want := GitOpsKinds(""), GitOpsKinds("flux"); len(got) != len(want) {
+	// Compared element-wise: the earlier length-only check passed a seven-element list
+	// that had dropped Bucket and gained Application.
+	if got, want := GitOpsKinds(""), GitOpsKinds("flux"); !slices.Equal(got, want) {
 		t.Errorf("empty engine = %v, want the flux set %v", got, want)
 	}
 	// Case-insensitive: the model writes the kind as prose, and "helmrelease" must be
@@ -64,7 +104,12 @@ func TestGitOpsKindsAreEngineScoped(t *testing.T) {
 // TestGitOpsSchemaConstrainsKind pins the enum, which is the part that actually prevents
 // the failure: a description can be disregarded by the model, an out-of-enum value cannot
 // be sent.
+//
+// The enum is checked against what the PROVIDER resolves, not against
+// gitopsKindSupported: both of those derive from GitOpsKinds, so comparing them proves
+// nothing, and the earlier version of this test was that tautology.
 func TestGitOpsSchemaConstrainsKind(t *testing.T) {
+	resolvable := map[string][]string{"argocd": argocd.GitOpsKinds(), "flux": flux.GitOpsKinds()}
 	for _, engine := range []string{"argocd", "flux"} {
 		for name, schema := range map[string]string{
 			"gitops_resource_status": GitOpsStatusTool{Engine: engine}.Schema(),
@@ -83,10 +128,9 @@ func TestGitOpsSchemaConstrainsKind(t *testing.T) {
 			if len(got.Properties.Kind.Enum) == 0 {
 				t.Fatalf("%s/%s: kind has no enum, so any kind can be asked: %s", name, engine, schema)
 			}
-			for _, k := range got.Properties.Kind.Enum {
-				if !gitopsKindSupported(engine, k) {
-					t.Errorf("%s/%s: enum offers %q, which the engine cannot own", name, engine, k)
-				}
+			want := slices.Sorted(slices.Values(resolvable[engine]))
+			if got := slices.Sorted(slices.Values(got.Properties.Kind.Enum)); !slices.Equal(got, want) {
+				t.Errorf("%s/%s: enum offers %v, but the %s provider resolves %v", name, engine, got, engine, want)
 			}
 		}
 	}

--- a/internal/investigate/gitops_kinds_test.go
+++ b/internal/investigate/gitops_kinds_test.go
@@ -444,6 +444,67 @@ func TestGitOpsDescriptionsMatchTheEngine(t *testing.T) {
 	}
 }
 
+// TestSystemPromptFollowsTheRegisteredTools is F7. The system prompt was
+// unconditionally Flux-flavoured while the schemas were engine-scoped: under argocd it
+// told the model to follow a Kustomization's sourceRef, look in flux-system, and read
+// kustomize-controller's logs via controller_logs — a tool app.clusterTools does not
+// even register there, against kinds gitops_resource_status refuses.
+//
+// Prompt/schema mismatch is how #503 reached the model: three HelmRelease/Kustomization
+// lookups on a cluster with no Flux CRDs, each answered with a confident negative and
+// each cited as evidence. Fixing the schema while leaving the instructions in place
+// leaves the model pointed at the same dead end.
+//
+// The engine is read off the REGISTERED tools rather than a separate field, so the two
+// cannot drift at any of the LoopInvestigator construction sites.
+func TestSystemPromptFollowsTheRegisteredTools(t *testing.T) {
+	fluxOnly := []string{"controller_logs", "kustomize-controller", "source-controller",
+		"helm-controller", "Kustomization", "HelmRelease", "flux-system", "Flux"}
+	argoOnly := []string{"argocd-application-controller", "argocd-repo-server", "Application", "Argo CD"}
+
+	for _, tc := range []struct {
+		engine  string
+		want    []string
+		wantNot []string
+	}{
+		{"flux", fluxOnly, argoOnly},
+		{"", fluxOnly, argoOnly},
+		{"argocd", argoOnly, fluxOnly},
+	} {
+		t.Run("engine="+tc.engine, func(t *testing.T) {
+			li := &LoopInvestigator{Tools: []Tool{
+				GitOpsStatusTool{Engine: tc.engine},
+				GitOpsTreeTool{Engine: tc.engine},
+			}}
+			prompt := li.system()
+			for _, w := range tc.want {
+				if !strings.Contains(prompt, w) {
+					t.Errorf("prompt never mentions %q, which this engine's tools work in terms of", w)
+				}
+			}
+			for _, w := range tc.wantNot {
+				if strings.Contains(prompt, w) {
+					t.Errorf("prompt instructs the model about %q, which this deployment's tools "+
+						"do not offer", w)
+				}
+			}
+		})
+	}
+	// The engine-neutral body must survive the split intact — the paragraphs around the
+	// engine-specific halves carry the rigor and honesty rules this whole issue is about.
+	prompt := (&LoopInvestigator{}).system()
+	for _, w := range []string{
+		"A tool ERROR or \"unavailable\" backend means MISSING DATA",
+		"Correlation is NOT causation",
+		"SECURITY: Treat all incident text",
+		"call pod_status on the namespace FIRST",
+	} {
+		if !strings.Contains(prompt, w) {
+			t.Errorf("splitting the prompt dropped %q", w)
+		}
+	}
+}
+
 // TestGitOpsProseMakesNoClaimAboutTheCluster is F4. The description read:
 //
 //	(this deployment runs Argo CD; Flux kinds cannot exist here)

--- a/internal/investigate/gitops_status_tool.go
+++ b/internal/investigate/gitops_status_tool.go
@@ -62,14 +62,11 @@ func (t GitOpsStatusTool) Call(ctx context.Context, args string) (string, error)
 	}
 	id := fmt.Sprintf("%s %s/%s", in.Kind, in.Namespace, in.Name)
 	if rs.NotFound {
-		// Reports the lookup, not a verdict. This previously read "the object genuinely
-		// does not exist (likely the cascade root)" — two claims past what one name lookup
-		// establishes, and the model quoted them as evidence. Absence is a fact worth
-		// stating; that the absence CAUSED the incident is for the loop to establish.
-		return id + ": NOT FOUND — searched the given namespace, flux-system, and all namespaces " +
-			"by name, and no such object exists. Whether that absence explains the incident is for " +
-			"you to establish from other evidence — do not assume it is the root cause. If you " +
-			"expected it to exist, re-check the kind/name rather than concluding it was deleted.", nil
+		// Reports the lookup, not a verdict — and reports WHICH lookup, from the scopes
+		// the provider actually completed. The first version of this fix still asserted
+		// "no such object exists" over a fixed scope list that named flux-system even on
+		// Argo CD, where nothing ever searches it. See gitopsLookupAnswer.
+		return gitopsLookupAnswer(id, rs.Lookup), nil
 	}
 	// F2: the inspector confirmed this resource exists server-side — record it observed.
 	recordObserved(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})

--- a/internal/investigate/gitops_status_tool.go
+++ b/internal/investigate/gitops_status_tool.go
@@ -46,9 +46,16 @@ func (t GitOpsStatusTool) Call(ctx context.Context, args string) (string, error)
 	// Refuse an out-of-scope kind BEFORE the lookup. The schema enum should already have
 	// prevented it, but a provider that ignores enums (or an MCP client) must not reach a
 	// path whose only possible answer is a misleading negative.
-	if !gitopsKindSupported(t.Engine, in.Kind) {
+	//
+	// The guard also CANONICALISES: it matches case-insensitively (the model writes the
+	// kind as prose) while the providers resolve by exact map lookup, so forwarding the
+	// model's spelling verbatim is what let "helmrelease" pass the guard and then fail
+	// to resolve.
+	kind, ok := canonicalGitOpsKind(t.Engine, in.Kind)
+	if !ok {
 		return gitopsUnsupportedKind(t.Engine, in.Kind), nil
 	}
+	in.Kind = kind
 	rs, err := t.Inspector.ResourceStatus(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})
 	if err != nil {
 		return "", err

--- a/internal/investigate/gitops_status_tool.go
+++ b/internal/investigate/gitops_status_tool.go
@@ -26,12 +26,18 @@ type GitOpsStatusTool struct {
 // Name returns the tool name.
 func (t GitOpsStatusTool) Name() string { return "gitops_resource_status" }
 
-// Description returns the tool description.
+// Description returns the tool description, describing only the engine this deployment
+// actually runs: naming the other one's concepts alongside an enum that refuses them is
+// the same dead end as advertising its kinds.
 func (t GitOpsStatusTool) Description() string {
-	return "Get a GitOps resource's status (a Flux Ready condition or an Argo CD " +
-		"Application's health/sync: status, reason, message), key spec refs, and recent Events. Use " +
-		"this to learn WHY a resource is failing — follow its refs to the root. This reads GitOps " +
-		"objects ONLY, not arbitrary Kubernetes resources: " + gitopsKindProse(t.Engine)
+	lens := "its Flux Ready condition"
+	if t.Engine == "argocd" {
+		lens = "the Argo CD Application's health/sync"
+	}
+	return "Get a GitOps resource's status (" + lens + ": status, reason, message), key spec " +
+		"refs, and recent Events. Use this to learn WHY a resource is failing — follow its refs " +
+		"to the root. This reads GitOps objects ONLY, not arbitrary Kubernetes resources: " +
+		gitopsKindProse(t.Engine)
 }
 
 // Schema returns the JSON schema for the arguments.

--- a/internal/investigate/gitops_status_tool.go
+++ b/internal/investigate/gitops_status_tool.go
@@ -17,6 +17,10 @@ import (
 // Events — so the model can learn WHY a resource is failing, not just that it is.
 type GitOpsStatusTool struct {
 	Inspector providers.GitOpsInspector
+	// Engine is the configured GitOps engine ("argocd"/"flux"), which bounds the kinds
+	// this tool advertises and accepts. See GitOpsKinds for why that bound matters:
+	// a kind the engine cannot own is answerable only with a misleading negative.
+	Engine string
 }
 
 // Name returns the tool name.
@@ -24,17 +28,14 @@ func (t GitOpsStatusTool) Name() string { return "gitops_resource_status" }
 
 // Description returns the tool description.
 func (t GitOpsStatusTool) Description() string {
-	return "Get a GitOps/Kubernetes resource's status (a Flux Ready condition or an Argo CD " +
+	return "Get a GitOps resource's status (a Flux Ready condition or an Argo CD " +
 		"Application's health/sync: status, reason, message), key spec refs, and recent Events. Use " +
-		"this to learn WHY a resource is failing — follow its refs to the root. kind is one of: " +
-		"Application (Argo CD); Kustomization, HelmRelease, GitRepository, OCIRepository, " +
-		"HelmRepository, HelmChart, Bucket (Flux)."
+		"this to learn WHY a resource is failing — follow its refs to the root. This reads GitOps " +
+		"objects ONLY, not arbitrary Kubernetes resources: " + gitopsKindProse(t.Engine)
 }
 
 // Schema returns the JSON schema for the arguments.
-func (t GitOpsStatusTool) Schema() string {
-	return `{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name","namespace"]}`
-}
+func (t GitOpsStatusTool) Schema() string { return gitopsKindSchema(t.Engine) }
 
 // Call fetches the resource status and renders it.
 func (t GitOpsStatusTool) Call(ctx context.Context, args string) (string, error) {
@@ -42,15 +43,26 @@ func (t GitOpsStatusTool) Call(ctx context.Context, args string) (string, error)
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)
 	}
+	// Refuse an out-of-scope kind BEFORE the lookup. The schema enum should already have
+	// prevented it, but a provider that ignores enums (or an MCP client) must not reach a
+	// path whose only possible answer is a misleading negative.
+	if !gitopsKindSupported(t.Engine, in.Kind) {
+		return gitopsUnsupportedKind(t.Engine, in.Kind), nil
+	}
 	rs, err := t.Inspector.ResourceStatus(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})
 	if err != nil {
 		return "", err
 	}
 	id := fmt.Sprintf("%s %s/%s", in.Kind, in.Namespace, in.Name)
 	if rs.NotFound {
-		return id + ": NOT FOUND — searched the given namespace, flux-system, and all namespaces by " +
-			"name; the object genuinely does not exist (likely the cascade root). If you expected it to " +
-			"exist, re-check the kind/name rather than concluding it was deleted.", nil
+		// Reports the lookup, not a verdict. This previously read "the object genuinely
+		// does not exist (likely the cascade root)" — two claims past what one name lookup
+		// establishes, and the model quoted them as evidence. Absence is a fact worth
+		// stating; that the absence CAUSED the incident is for the loop to establish.
+		return id + ": NOT FOUND — searched the given namespace, flux-system, and all namespaces " +
+			"by name, and no such object exists. Whether that absence explains the incident is for " +
+			"you to establish from other evidence — do not assume it is the root cause. If you " +
+			"expected it to exist, re-check the kind/name rather than concluding it was deleted.", nil
 	}
 	// F2: the inspector confirmed this resource exists server-side — record it observed.
 	recordObserved(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})

--- a/internal/investigate/gitops_tools_test.go
+++ b/internal/investigate/gitops_tools_test.go
@@ -65,8 +65,14 @@ func TestGitOpsTreeTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	if !strings.Contains(out, "NOT FOUND  ← root") || !strings.Contains(out, "infra-artifact") {
-		t.Fatalf("tree output missing the root marker:\n%s", out)
+	// The node the API did not return is reported as a lookup result, NOT nominated as
+	// the cause: "← root" hands back a root cause outright, which is the very reason
+	// this branch gives for refusing an out-of-scope kind in this tool.
+	if !strings.Contains(out, "not found by name") || !strings.Contains(out, "infra-artifact") {
+		t.Fatalf("tree output does not report the missing node:\n%s", out)
+	}
+	if strings.Contains(out, "← root") {
+		t.Fatalf("tree output still nominates a root cause from one name lookup:\n%s", out)
 	}
 	// The root should be indented deeper than the top node.
 	if !strings.Contains(out, "    GitRepository flux-system/infra-artifact") {

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -46,11 +46,15 @@ func (t GitOpsTreeTool) Call(ctx context.Context, args string) (string, error) {
 		return "", fmt.Errorf("parse args: %w", err)
 	}
 	// Refuse an out-of-scope kind before the walk, for the same reason as
-	// gitops_resource_status — and more urgently, because a missing root renders as
-	// "NOT FOUND  ← root".
-	if !gitopsKindSupported(t.Engine, in.Kind) {
+	// gitops_resource_status — and canonicalise it, which matters MORE here: this tool
+	// swallows a resolution failure and renders the node anyway, so a kind that passes
+	// the case-insensitive guard and then misses the exact-match resolver comes back as
+	// "helmrelease apps/api (Ready=unknown)" — a node for an object nobody looked up.
+	kind, ok := canonicalGitOpsKind(t.Engine, in.Kind)
+	if !ok {
 		return gitopsUnsupportedKind(t.Engine, in.Kind), nil
 	}
+	in.Kind = kind
 	root, err := t.Inspector.DependencyTree(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})
 	if err != nil {
 		return "", err

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -67,9 +67,12 @@ func (t GitOpsTreeTool) Call(ctx context.Context, args string) (string, error) {
 	return b.String(), nil
 }
 
-// recordObservedTree records every existing (non-NotFound) node of a dependency tree.
+// recordObservedTree records every node whose object was actually READ. A node carrying
+// a Lookup is one the API did not return — absent, denied, an unserved or unresolvable
+// kind, or a failed read — and recording it as observed would let an action target a
+// resource nothing confirmed server-side (see guardUnobservedTargets).
 func recordObservedTree(ctx context.Context, n providers.DepNode) {
-	if !n.NotFound {
+	if n.Lookup.Reason == "" && !n.NotFound {
 		recordObserved(ctx, n.Workload)
 	}
 	for _, c := range n.Children {
@@ -78,13 +81,17 @@ func recordObservedTree(ctx context.Context, n providers.DepNode) {
 }
 
 // renderDepNode renders a node and its children with indentation, flagging the
-// not-Ready / NOT FOUND nodes that are candidate roots.
+// not-Ready nodes and the ones the API did not return.
 func renderDepNode(b *strings.Builder, n providers.DepNode, depth int) {
 	indent := strings.Repeat("  ", depth)
 	id := fmt.Sprintf("%s %s/%s", n.Workload.Kind, n.Workload.Namespace, n.Workload.Name)
 	switch {
-	case n.NotFound:
-		fmt.Fprintf(b, "%s%s: NOT FOUND  ← root\n", indent, id)
+	case n.Lookup.Reason != "" || n.NotFound:
+		// No "← root". The branch's own commit message says that arrow "hands back a
+		// root cause outright", which was the argument for refusing an out-of-scope kind
+		// here — and then it stayed on the supported path, so the two tools contradicted
+		// each other about the same object. Nominating the root is the loop's job.
+		fmt.Fprintf(b, "%s%s: %s\n", indent, id, gitopsLookupNote(n.Lookup))
 	case n.Ready == "False" || n.Ready == "Unknown":
 		fmt.Fprintf(b, "%s%s (Ready=%s%s)\n", indent, id, n.Ready, reasonSuffix(n.Reason))
 	case n.Ready == "":

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -27,13 +27,19 @@ type GitOpsTreeTool struct {
 // Name returns the tool name.
 func (t GitOpsTreeTool) Name() string { return "gitops_tree" }
 
-// Description returns the tool description.
+// Description returns the tool description, describing only the engine this deployment
+// actually runs — see GitOpsStatusTool.Description.
 func (t GitOpsTreeTool) Description() string {
-	return "Walk a GitOps resource's dependency graph (a Flux resource's dependsOn/sourceRef, or an " +
-		"Argo CD Application's managed-resource tree) and render it with each node's Ready/health state. " +
-		"Use it on a failing resource to find the ROOT cause — the first not-Ready/Degraded or NOT FOUND " +
-		"node — instead of the downstream symptom. GitOps objects ONLY, not arbitrary Kubernetes " +
-		"resources: " + gitopsKindProse(t.Engine)
+	graph := "a Flux resource's dependsOn/sourceRef edges"
+	if t.Engine == "argocd" {
+		graph = "an Argo CD Application's managed-resource tree"
+	}
+	return "Walk a GitOps resource's dependency graph (" + graph + ") and render it with each " +
+		"node's Ready/health state. Use it on a failing resource to look for the ROOT cause — the " +
+		"first not-Ready/Degraded node, or one the API did not return — instead of the downstream " +
+		"symptom. A node the API did not return is a lookup result, not a root cause: establish " +
+		"that from other evidence. GitOps objects ONLY, not arbitrary Kubernetes resources: " +
+		gitopsKindProse(t.Engine)
 }
 
 // Schema returns the JSON schema for the arguments.

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -12,15 +12,19 @@ import (
 )
 
 // GitOpsTreeTool walks a resource's dependency graph (Flux dependsOn/sourceRef, or an
-// Argo CD Application's managed-resource tree) and renders it, so the model can find
-// the ROOT failing resource behind a cascade (the not-Ready/Degraded or missing
-// node), not just the downstream symptom.
+// Argo CD Application's managed-resource tree) and renders it, so the model can look for
+// the ROOT failing resource behind a cascade — the not-Ready/Degraded node, or one the
+// API did not return — rather than the downstream symptom.
 type GitOpsTreeTool struct {
 	Inspector providers.GitOpsInspector
 	// Engine bounds the kinds this tool advertises and accepts, exactly as on
-	// GitOpsStatusTool. It matters MORE here: a missing root node renders as
-	// "NOT FOUND  ← root", which nominates the absence as the cause outright, so an
-	// out-of-scope kind does not merely mislead — it hands back a root cause.
+	// GitOpsStatusTool, and selects the engine-specific half of its description.
+	//
+	// It matters MORE here because a node this tool cannot read is still rendered, so
+	// an out-of-scope or unresolvable kind does not merely go unanswered — it produces a
+	// line in a dependency tree. Every such line now says what the lookup was
+	// (renderDepNode + gitopsLookupNote); it used to say "NOT FOUND  ← root", nominating
+	// the absence as the cause outright.
 	Engine string
 }
 

--- a/internal/investigate/gitops_tree_tool.go
+++ b/internal/investigate/gitops_tree_tool.go
@@ -17,6 +17,11 @@ import (
 // node), not just the downstream symptom.
 type GitOpsTreeTool struct {
 	Inspector providers.GitOpsInspector
+	// Engine bounds the kinds this tool advertises and accepts, exactly as on
+	// GitOpsStatusTool. It matters MORE here: a missing root node renders as
+	// "NOT FOUND  ← root", which nominates the absence as the cause outright, so an
+	// out-of-scope kind does not merely mislead — it hands back a root cause.
+	Engine string
 }
 
 // Name returns the tool name.
@@ -27,19 +32,24 @@ func (t GitOpsTreeTool) Description() string {
 	return "Walk a GitOps resource's dependency graph (a Flux resource's dependsOn/sourceRef, or an " +
 		"Argo CD Application's managed-resource tree) and render it with each node's Ready/health state. " +
 		"Use it on a failing resource to find the ROOT cause — the first not-Ready/Degraded or NOT FOUND " +
-		"node — instead of the downstream symptom."
+		"node — instead of the downstream symptom. GitOps objects ONLY, not arbitrary Kubernetes " +
+		"resources: " + gitopsKindProse(t.Engine)
 }
 
 // Schema returns the JSON schema for the arguments.
-func (t GitOpsTreeTool) Schema() string {
-	return `{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name","namespace"]}`
-}
+func (t GitOpsTreeTool) Schema() string { return gitopsKindSchema(t.Engine) }
 
 // Call walks the dependency tree and renders it.
 func (t GitOpsTreeTool) Call(ctx context.Context, args string) (string, error) {
 	var in struct{ Kind, Name, Namespace string }
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)
+	}
+	// Refuse an out-of-scope kind before the walk, for the same reason as
+	// gitops_resource_status — and more urgently, because a missing root renders as
+	// "NOT FOUND  ← root".
+	if !gitopsKindSupported(t.Engine, in.Kind) {
+		return gitopsUnsupportedKind(t.Engine, in.Kind), nil
 	}
 	root, err := t.Inspector.DependencyTree(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})
 	if err != nil {

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -24,7 +24,64 @@ import (
 	"github.com/Smana/runlore/internal/telemetry"
 )
 
-const systemPrompt = `You are an SRE incident investigator. The cause is unknown — investigate by
+// systemPrompt assembles the system prompt for the GitOps engine this deployment runs.
+//
+// It is engine-conditional because the tool SCHEMAS are: gitops_resource_status refuses
+// Flux kinds under argocd, and controller_logs is not registered there at all, yet the
+// prompt told the model to follow a Kustomization's sourceRef and read
+// kustomize-controller's logs. A prompt that instructs what the schema forbids is how the
+// original bug (#503) reached the model — three HelmRelease/Kustomization lookups on a
+// cluster with no Flux CRDs, all answered "NOT FOUND", all cited as evidence.
+func systemPrompt(engine string) string {
+	return systemPromptIntro +
+		"\n\n" + gitopsDrillPrompt(engine) +
+		"\n\n" + workloadPrompt(engine) +
+		"\n\n" + systemPromptRigor
+}
+
+// gitopsDrillPrompt is the symptom-to-root drill, in the vocabulary of the engine that is
+// actually wired — including which controller logs are reachable: controller_logs is
+// registered under Flux ONLY (see app.clusterTools), so naming it under argocd sends the
+// model at a tool that is not in its list.
+func gitopsDrillPrompt(engine string) string {
+	if engine == "argocd" {
+		return `Drill from symptom to ROOT cause — don't stop at the first failing resource. When an Argo CD
+Application is failing, call gitops_resource_status on it; read its sync/health status, conditions and
+source refs; use gitops_tree to walk its managed resources (and app-of-apps children) down to the
+failing one; and use query_logs on the responsible controller (argocd-application-controller,
+argocd-repo-server) to learn WHY it failed. Confirm hypotheses with metrics and, where relevant,
+network drops.`
+	}
+	return `Drill from symptom to ROOT cause — don't stop at the first failing resource. When a Flux
+resource is failing, call gitops_resource_status on it; follow its sourceRef/dependsOn; use gitops_tree
+to find the root (a not-Ready node, or one the API did not return); and use controller_logs /
+query_logs on the relevant controller (e.g. kustomize-controller, source-controller, helm-controller)
+to learn WHY it failed. Confirm hypotheses with metrics and, where relevant, network drops.`
+}
+
+// workloadPrompt is the pod-level triage paragraph. Only the two engine-specific tokens
+// vary — the symptom shape it opens with, and where the owning GitOps object lives —
+// so the paragraph itself stays single-sourced.
+func workloadPrompt(engine string) string {
+	stuck, where := "a HelmRelease install timing out", `remember the Flux Kustomization/HelmRelease
+usually lives in flux-system, not the workload's namespace; but you do NOT need to hunt for it —
+what_changed takes the FAILING WORKLOAD'S namespace and resolves the owning Kustomization for you.`
+	if engine == "argocd" {
+		stuck, where = "an Application stuck Progressing or Degraded", `remember the Argo CD Application
+usually lives in the argocd namespace, not the workload's; but you do NOT need to hunt for it —
+what_changed takes the FAILING WORKLOAD'S namespace and resolves the owning Application for you.`
+	}
+	return `When a WORKLOAD won't run (pods not Ready, ` + stuck + `), the cause is usually at
+the pod level — call pod_status on the namespace FIRST: it names container failures verbatim
+(CreateContainerConfigError → the exact missing Secret/ConfigMap key; ImagePullBackOff; CrashLoopBackOff;
+RunContainerError). Then call kube_events for causes that live only in the event stream
+(FailedScheduling "Insufficient cpu/memory", FailedMount, FailedAttachVolume, failing probes). These two
+tools see pod-level failures that logs and GitOps status cannot — a container that never started has no
+logs, and "Insufficient cpu" is an Event, not a log line. When you inspect a GitOps object directly
+(gitops_resource_status/gitops_tree), ` + where
+}
+
+const systemPromptIntro = `You are an SRE incident investigator. The cause is unknown — investigate by
 calling the available tools to gather evidence (start with what_changed), reason about both
 change-caused and no-change causes, then call submit_findings exactly once with ranked root causes,
 evidence, and anything you could not determine. Be honest about uncertainty.
@@ -43,32 +100,16 @@ root cause and the fix directly; use it to guide the rest of the investigation.
 A tool ERROR or "unavailable" backend means MISSING DATA — it is NEVER evidence of a problem. If
 network_drops errors, that does NOT mean there is a network issue; if query_logs errors, that does
 NOT mean logging is the cause. Note the missing signal as unresolved and base your conclusion on the
-tools that DID return data. Do not blame the subsystem whose tool failed.
+tools that DID return data. Do not blame the subsystem whose tool failed.`
 
-Drill from symptom to ROOT cause — don't stop at the first failing resource. When a Flux/GitOps
-resource is failing, call gitops_resource_status on it; follow its sourceRef/dependsOn; use gitops_tree
-to find the root (a not-Ready or NOT FOUND node); and use controller_logs / query_logs on the
-relevant controller (e.g. kustomize-controller, source-controller, helm-controller) to learn WHY it
-failed. Confirm hypotheses with metrics and, where relevant, network drops.
-
-When a WORKLOAD won't run (pods not Ready, a HelmRelease install timing out), the cause is usually at
-the pod level — call pod_status on the namespace FIRST: it names container failures verbatim
-(CreateContainerConfigError → the exact missing Secret/ConfigMap key; ImagePullBackOff; CrashLoopBackOff;
-RunContainerError). Then call kube_events for causes that live only in the event stream
-(FailedScheduling "Insufficient cpu/memory", FailedMount, FailedAttachVolume, failing probes). These two
-tools see pod-level failures that logs and Flux status cannot — a container that never started has no
-logs, and "Insufficient cpu" is an Event, not a log line. When you inspect a GitOps object directly
-(gitops_resource_status/gitops_tree), remember the Flux Kustomization/HelmRelease usually lives in
-flux-system, not the workload's namespace; but you do NOT need to hunt for it — what_changed takes the
-FAILING WORKLOAD'S namespace and resolves the owning Kustomization/Application for you.
-
-RIGOR — correctness over plausibility. A wrong-but-confident root cause is worse than an honest
+const systemPromptRigor = `RIGOR — correctness over plausibility. A wrong-but-confident root cause is worse than an honest
 "unresolved":
 - Correlation is NOT causation. "The incident started after change X" does not prove X caused it.
   Before naming a change as a root cause you MUST read its actual diff and confirm it plausibly
   affects THIS failing workload (its namespace, or a resource it depends on). Call what_changed with
-  the failing workload's namespace and let it resolve the owning GitOps object — do not query
-  flux-system directly for it, and do not pin the incident on an unrelated cluster-wide change.
+  the failing workload's namespace and let it resolve the owning GitOps object — do not query the
+  GitOps controller's own namespace directly for it, and do not pin the incident on an unrelated
+  cluster-wide change.
 - Never propose reverting or modifying something you have not inspected. If you couldn't read a
   change's diff, you cannot claim it's the cause — say so in unresolved.
 - Calibrate confidence to the evidence: a verified causal chain (read the change, saw the matching
@@ -250,7 +291,7 @@ type LoopInvestigator struct {
 // system returns the system prompt, extended with action proposals when the policy is
 // enabled, and with an MCP-tools note when external MCP tools (name contains "__") are present.
 func (li *LoopInvestigator) system() string {
-	s := systemPrompt
+	s := systemPrompt(engineFromTools(li.Tools))
 	if li.Actions != nil && li.Actions.Enabled() {
 		s += "\n\n" + actionsPrompt
 	}

--- a/internal/providers/gitops/argocd/dynamic.go
+++ b/internal/providers/gitops/argocd/dynamic.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/Smana/runlore/internal/providers"
 )
 
 // applicationGVR is the Argo CD Application resource.
@@ -80,7 +82,14 @@ func (r *dynamicReader) ListApplications(ctx context.Context) ([]application, er
 // live in the argocd namespace, not the workload's; if the caller passes the
 // workload's namespace and the app isn't there, fall back to a name search across all
 // namespaces before trusting the NotFound.
+//
+// A read that returns no object comes back as a providers.LookupError carrying the
+// scopes this call actually completed and what the negative established. Note what is
+// NOT among those scopes: Argo CD has no flux-system convention and this reader never
+// looks there, so nothing downstream may claim it did — the reply it feeds used to name
+// flux-system unconditionally, on every engine (runlore#503).
 func (r *dynamicReader) GetApplication(ctx context.Context, namespace, name string) (*unstructured.Unstructured, error) {
+	lk := providers.Lookup{Reason: providers.LookupAbsent, Scopes: []string{namespace}}
 	u, err := r.client.Resource(applicationGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
 		return u, nil
@@ -88,14 +97,26 @@ func (r *dynamicReader) GetApplication(ctx context.Context, namespace, name stri
 	if !apierrors.IsNotFound(err) {
 		return nil, err
 	}
-	if list, lerr := r.client.Resource(applicationGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); lerr == nil {
+	list, lerr := r.client.Resource(applicationGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	switch {
+	case lerr == nil:
+		lk.Scopes = append(lk.Scopes, providers.AllNamespaces)
 		for i := range list.Items {
 			if list.Items[i].GetName() == name {
 				return &list.Items[i], nil
 			}
 		}
+	case apierrors.IsForbidden(lerr):
+		// The cluster-wide search never ran; the old `if lerr == nil` swallowed that and
+		// let the answer claim a search RBAC had refused.
+		lk.Reason = providers.LookupDenied
+	case apierrors.IsNotFound(lerr):
+		// A List against a served resource returns an empty list, never a 404, so a 404
+		// here means the Application CRD is not served — an Argo CD tool pointed at a
+		// cluster without Argo CD, which is not evidence about the named object.
+		lk.Reason = providers.LookupKindNotServed
 	}
-	return nil, err // genuinely absent in every namespace: return the original NotFound
+	return nil, &providers.LookupError{Lookup: lk, Err: err}
 }
 
 // ListEvents returns recent Event lines for an involved object, filtered by name

--- a/internal/providers/gitops/argocd/dynamic.go
+++ b/internal/providers/gitops/argocd/dynamic.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,6 +21,27 @@ import (
 
 // applicationGVR is the Argo CD Application resource.
 var applicationGVR = schema.GroupVersionResource{Group: "argoproj.io", Version: "v1alpha1", Resource: "applications"}
+
+// kindToGVR maps the Argo CD Kinds this provider can resolve to their GVR. Argo CD
+// models everything it deploys as one Application, so the map has a single entry —
+// but it is a map, and the accessors below derive from it, so the investigation
+// tools and the chart's RBAC track this provider instead of restating it. See
+// flux.GitOpsKinds for the drift that motivated the shape.
+var kindToGVR = map[string]schema.GroupVersionResource{"Application": applicationGVR}
+
+// GitOpsKinds returns, sorted, every Argo CD Kind this provider can resolve.
+func GitOpsKinds() []string { return slices.Sorted(maps.Keys(kindToGVR)) }
+
+// GitOpsResources returns, sorted, the API resource (plural) name of every Kind
+// GitOpsKinds advertises — what an RBAC rule has to grant for those reads to succeed.
+func GitOpsResources() []string {
+	out := make([]string, 0, len(kindToGVR))
+	for _, gvr := range kindToGVR {
+		out = append(out, gvr.Resource)
+	}
+	slices.Sort(out)
+	return out
+}
 
 // eventsGVR is the core v1 Events resource (for ListEvents).
 var eventsGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}

--- a/internal/providers/gitops/argocd/dynamic_test.go
+++ b/internal/providers/gitops/argocd/dynamic_test.go
@@ -4,14 +4,20 @@ package argocd
 
 import (
 	"context"
+	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/Smana/runlore/internal/providers"
 )
 
 func TestApplicationFromUnstructured(t *testing.T) {
@@ -206,5 +212,51 @@ func TestDynamicReaderWatch(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for informer event")
+	}
+}
+
+// TestGetApplicationNeverClaimsFluxSystem pins the scopes this reader actually searches.
+//
+// Argo CD has no flux-system convention and appNode/GetApplication never look there, yet
+// the reply built on this lookup said "searched the given namespace, flux-system, and
+// all namespaces" on every engine — and the fix's own test asserted that string with
+// Engine:"argocd". Reporting the scopes from the provider is what makes the sentence
+// true by construction.
+func TestGetApplicationNeverClaimsFluxSystem(t *testing.T) {
+	gvrToListKind := map[schema.GroupVersionResource]string{applicationGVR: "ApplicationList"}
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "argoproj.io", Resource: "applications"},
+		"", errors.New("no permission"))
+
+	for _, tc := range []struct {
+		name       string
+		listErr    error
+		wantReason providers.LookupReason
+		wantScopes []string
+	}{
+		{"absent", nil, providers.LookupAbsent, []string{"apps", providers.AllNamespaces}},
+		{"cluster-wide search denied", forbidden, providers.LookupDenied, []string{"apps"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+			if tc.listErr != nil {
+				client.PrependReactor("list", "applications", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, tc.listErr
+				})
+			}
+			_, err := NewDynamicReader(client).GetApplication(context.Background(), "apps", "api")
+			lk, ok := providers.LookupOf(err)
+			if !ok {
+				t.Fatalf("no Lookup attached: %v", err)
+			}
+			if lk.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", lk.Reason, tc.wantReason)
+			}
+			if !slices.Equal(lk.Scopes, tc.wantScopes) {
+				t.Errorf("Scopes = %v, want %v", lk.Scopes, tc.wantScopes)
+			}
+			if slices.Contains(lk.Scopes, "flux-system") {
+				t.Error("the Argo CD reader reported searching flux-system, which it never does")
+			}
+		})
 	}
 }

--- a/internal/providers/gitops/argocd/inspect.go
+++ b/internal/providers/gitops/argocd/inspect.go
@@ -14,13 +14,18 @@ import (
 
 // ResourceStatus reports an Argo CD Application's health + sync status, key
 // source/destination refs, error conditions, and recent Events — the Argo analogue of
-// the Flux inspector's "why is it failing" lens. A missing Application is reported via
-// NotFound (often the cascade root), not an error.
+// the Flux inspector's "why is it failing" lens. A read that returns no Application is
+// reported via NotFound + Lookup, not an error, so the caller can say what the negative
+// established rather than assert the Application is absent.
 func (p *Provider) ResourceStatus(ctx context.Context, w providers.Workload) (providers.ResourceStatus, error) {
 	rs := providers.ResourceStatus{Workload: w, Refs: map[string]string{}}
 	u, err := p.reader.GetApplication(ctx, w.Namespace, w.Name)
+	if lk, ok := providers.LookupOf(err); ok {
+		rs.NotFound, rs.Lookup = true, lk
+		return rs, nil
+	}
 	if apierrors.IsNotFound(err) {
-		rs.NotFound = true
+		rs.NotFound, rs.Lookup = true, providers.Lookup{Reason: providers.LookupAbsent}
 		return rs, nil
 	}
 	if err != nil {
@@ -72,18 +77,28 @@ func (p *Provider) appNode(ctx context.Context, w providers.Workload, seen map[s
 	}
 	seen[key] = true
 	u, err := p.reader.GetApplication(ctx, w.Namespace, w.Name)
+	if lk, ok := providers.LookupOf(err); ok {
+		node.NotFound = lk.Reason == providers.LookupAbsent
+		node.Lookup = lk
+		return node
+	}
 	if apierrors.IsNotFound(err) {
 		node.NotFound = true
+		node.Lookup = providers.Lookup{Reason: providers.LookupAbsent}
 		return node
 	}
 	if err != nil {
-		return node
+		node.Lookup = providers.Lookup{Reason: providers.LookupFailed}
+		return node // do not claim the node exists with an unknown Ready state
 	}
 	node.Ready, node.Reason, _ = appReady(u)
 	for _, r := range managedResources(u) {
 		if r.Kind == "Application" && r.Name != "" { // app-of-apps: recurse, surface if not healthy
 			child := p.appNode(ctx, providers.Workload{Kind: "Application", Name: r.Name, Namespace: r.Namespace}, seen)
-			if child.Ready != "True" || child.NotFound || len(child.Children) > 0 {
+			// Lookup covers every read that returned no object, not just an absent one:
+			// a child whose read was denied or errored is exactly what the tree must
+			// surface rather than silently drop as "healthy enough".
+			if child.Ready != "True" || child.Lookup.Reason != "" || len(child.Children) > 0 {
 				node.Children = append(node.Children, child)
 			}
 			continue

--- a/internal/providers/gitops/argocd/inspect.go
+++ b/internal/providers/gitops/argocd/inspect.go
@@ -12,6 +12,9 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 )
 
+// GitOpsEngine reports the engine this provider speaks — see flux.Provider.GitOpsEngine.
+func (p *Provider) GitOpsEngine() providers.Engine { return providers.EngineArgoCD }
+
 // ResourceStatus reports an Argo CD Application's health + sync status, key
 // source/destination refs, error conditions, and recent Events — the Argo analogue of
 // the Flux inspector's "why is it failing" lens. A read that returns no Application is

--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/Smana/runlore/internal/providers"
 )
 
 // fluxSystemNamespace is where Flux objects conventionally live, regardless of the
@@ -118,13 +120,24 @@ func (r *dynamicReader) SourceRevision(ctx context.Context, kind, namespace, nam
 }
 
 // GetResource fetches one object by kind/namespace/name. The kind must be one the
-// inspector knows (see kindToGVR). A NotFound error is returned verbatim so callers
-// can distinguish "missing" from other failures.
+// inspector knows (see kindToGVR).
+//
+// A read that returns no object comes back as a providers.LookupError wrapping the
+// original API error (so apierrors.IsNotFound still works) and carrying the scopes this
+// call actually completed plus what the negative established. That distinction is the
+// point: the dynamic client 404s identically for "no object of that name" and "the API
+// serves no such kind", and a cluster-wide List refused by RBAC never ran at all, so
+// reporting all three as one NotFound is how a limit of the tool became a claim about
+// the cluster (runlore#503).
 func (r *dynamicReader) GetResource(ctx context.Context, kind, namespace, name string) (*unstructured.Unstructured, error) {
 	gvr, ok := kindToGVR[kind]
 	if !ok {
-		return nil, fmt.Errorf("unsupported kind %q", kind)
+		return nil, &providers.LookupError{
+			Lookup: providers.Lookup{Reason: providers.LookupUnresolvable},
+			Err:    fmt.Errorf("unsupported kind %q", kind),
+		}
 	}
+	lk := providers.Lookup{Reason: providers.LookupAbsent, Scopes: []string{namespace}}
 	u, err := r.client.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err == nil {
 		return u, nil
@@ -138,18 +151,33 @@ func (r *dynamicReader) GetResource(ctx context.Context, kind, namespace, name s
 	// that reads as "the resource doesn't exist". Retry in flux-system, then search
 	// all namespaces by name, before trusting the NotFound.
 	if namespace != fluxSystemNamespace {
+		lk.Scopes = append(lk.Scopes, fluxSystemNamespace)
 		if u2, err2 := r.client.Resource(gvr).Namespace(fluxSystemNamespace).Get(ctx, name, metav1.GetOptions{}); err2 == nil {
 			return u2, nil
 		}
 	}
-	if list, lerr := r.client.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{}); lerr == nil {
+	list, lerr := r.client.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	switch {
+	case lerr == nil:
+		lk.Scopes = append(lk.Scopes, providers.AllNamespaces)
 		for i := range list.Items {
 			if list.Items[i].GetName() == name {
 				return &list.Items[i], nil
 			}
 		}
+	case apierrors.IsForbidden(lerr):
+		// The cluster-wide search never ran. Swallowing this (the old `if lerr == nil`)
+		// is what let the answer claim a search of all namespaces that RBAC refused.
+		lk.Reason = providers.LookupDenied
+	case apierrors.IsNotFound(lerr):
+		// A List against a SERVED resource returns an empty list, never a 404 — so a
+		// 404 here means the API serves no such resource type. That is the one signal
+		// separating "kind not served" from "object absent": both make the Get above
+		// return a 404 that apierrors.IsNotFound reports identically, which is #503's
+		// mechanism surviving on the SUPPORTED path.
+		lk.Reason = providers.LookupKindNotServed
 	}
-	return nil, err // genuinely absent in every namespace: return the original NotFound
+	return nil, &providers.LookupError{Lookup: lk, Err: err}
 }
 
 // ListEvents returns recent Event lines for an object, filtered client-side by the

--- a/internal/providers/gitops/flux/dynamic.go
+++ b/internal/providers/gitops/flux/dynamic.go
@@ -5,6 +5,8 @@ package flux
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +40,27 @@ var kindToGVR = map[string]schema.GroupVersionResource{
 	"HelmChart":        {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "helmcharts"},
 	"Bucket":           {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "buckets"},
 	"ExternalArtifact": {Group: "source.toolkit.fluxcd.io", Version: "v1", Resource: "externalartifacts"},
+}
+
+// GitOpsKinds returns, sorted, every Flux Kind this provider can actually resolve.
+//
+// It exists so nothing has to restate the list. The investigation tools used to keep
+// their own copy, and it diverged on its first edit: ExternalArtifact is in kindToGVR
+// and RBAC-granted in the chart, yet gitops_resource_status answered "ExternalArtifact
+// is not a GitOps object these tools can resolve" and pointed the model at pod_status —
+// false in every clause, on a kind this repo's own eval renders as a source node.
+// Deriving the list makes that divergence unrepresentable rather than merely tested for.
+func GitOpsKinds() []string { return slices.Sorted(maps.Keys(kindToGVR)) }
+
+// GitOpsResources returns, sorted, the API resource (plural) name of every Kind
+// GitOpsKinds advertises — what an RBAC rule has to grant for those reads to succeed.
+func GitOpsResources() []string {
+	out := make([]string, 0, len(kindToGVR))
+	for _, gvr := range kindToGVR {
+		out = append(out, gvr.Resource)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // dynamicReader reads Flux CRDs as unstructured objects via the dynamic client.

--- a/internal/providers/gitops/flux/dynamic_test.go
+++ b/internal/providers/gitops/flux/dynamic_test.go
@@ -4,14 +4,18 @@ package flux
 
 import (
 	"context"
+	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -316,5 +320,93 @@ func TestDynamicReaderWatch(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for informer event")
+	}
+}
+
+// TestGetResourceReportsWhatTheLookupEstablished pins the three outcomes a bare 404
+// used to collapse into one.
+//
+// The dynamic client reports "no object of that name" and "the API serves no such kind"
+// as the same NotFound, and the cluster-wide List's error was discarded outright
+// (`if lerr == nil`), so a search RBAC refused was reported as a search that found
+// nothing. Those are the states in which "and no such object exists" was false —
+// runlore#503's mechanism, alive on the SUPPORTED-kind path that engine scoping never
+// touched.
+//
+// The discriminator for an unserved kind is the List: against a served resource it
+// returns an empty list, never a 404.
+func TestGetResourceReportsWhatTheLookupEstablished(t *testing.T) {
+	gvrToListKind := map[schema.GroupVersionResource]string{helmReleaseGVR: "HelmReleaseList"}
+	forbidden := apierrors.NewForbidden(schema.GroupResource{Group: "helm.toolkit.fluxcd.io", Resource: "helmreleases"},
+		"", errors.New("no permission"))
+	unserved := apierrors.NewNotFound(schema.GroupResource{Group: "helm.toolkit.fluxcd.io", Resource: "helmreleases"}, "")
+
+	for _, tc := range []struct {
+		name       string
+		listErr    error
+		wantReason providers.LookupReason
+		wantScopes []string
+	}{
+		{
+			name:       "served kind, nothing by that name anywhere",
+			wantReason: providers.LookupAbsent,
+			wantScopes: []string{"apps", "flux-system", providers.AllNamespaces},
+		},
+		{
+			name:       "cluster-wide search refused by RBAC",
+			listErr:    forbidden,
+			wantReason: providers.LookupDenied,
+			// "all namespaces" must NOT appear: it never ran, and claiming it did is the
+			// half of the old message that was simply untrue.
+			wantScopes: []string{"apps", "flux-system"},
+		},
+		{
+			name:       "CRD not served by this API server",
+			listErr:    unserved,
+			wantReason: providers.LookupKindNotServed,
+			wantScopes: []string{"apps", "flux-system"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
+			if tc.listErr != nil {
+				client.PrependReactor("list", "helmreleases", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, tc.listErr
+				})
+			}
+			_, err := NewDynamicReader(client).GetResource(context.Background(), "HelmRelease", "apps", "api")
+			if err == nil {
+				t.Fatal("want an error for a missing object")
+			}
+			if !apierrors.IsNotFound(err) {
+				t.Errorf("the API's NotFound must stay recoverable through the wrapper: %v", err)
+			}
+			lk, ok := providers.LookupOf(err)
+			if !ok {
+				t.Fatalf("no Lookup attached, so the caller can only guess at a verdict: %v", err)
+			}
+			if lk.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", lk.Reason, tc.wantReason)
+			}
+			if !slices.Equal(lk.Scopes, tc.wantScopes) {
+				t.Errorf("Scopes = %v, want %v — a reply may only name searches that ran", lk.Scopes, tc.wantScopes)
+			}
+		})
+	}
+}
+
+// TestGetResourceUnresolvableKindIsNotANegative pins that a kind this provider has no
+// mapping for is reported as a scope limit, not as a lookup that found nothing — no
+// request is ever issued, so there is nothing to report about the object.
+func TestGetResourceUnresolvableKindIsNotANegative(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{helmReleaseGVR: "HelmReleaseList"})
+	_, err := NewDynamicReader(client).GetResource(context.Background(), "ArtifactGenerator", "flux-system", "monorepo-split")
+	lk, ok := providers.LookupOf(err)
+	if !ok || lk.Reason != providers.LookupUnresolvable {
+		t.Fatalf("Lookup = %+v (ok=%v), want reason %q", lk, ok, providers.LookupUnresolvable)
+	}
+	if apierrors.IsNotFound(err) {
+		t.Error("an unresolvable kind must not masquerade as a NotFound: nothing was looked up")
 	}
 }

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -393,6 +393,11 @@ func parseRevision(rev string) string {
 	return rev
 }
 
+// GitOpsEngine reports the engine this provider speaks, so a consumer can describe the
+// deployment from the provider it was handed instead of from the unvalidated
+// gitops.engine string. It is the same fact every Change already carries.
+func (p *Provider) GitOpsEngine() providers.Engine { return providers.EngineFlux }
+
 // ResourceStatus returns a Flux/K8s object's Ready condition, key spec refs
 // (sourceRef, dependsOn, url) and recent Events — the "why is it failing" lens.
 // A read that returns no object is reported via NotFound + Lookup, not an error, so the

--- a/internal/providers/gitops/flux/flux.go
+++ b/internal/providers/gitops/flux/flux.go
@@ -395,12 +395,22 @@ func parseRevision(rev string) string {
 
 // ResourceStatus returns a Flux/K8s object's Ready condition, key spec refs
 // (sourceRef, dependsOn, url) and recent Events — the "why is it failing" lens.
-// A missing object is reported via NotFound (often the cascade root), not an error.
+// A read that returns no object is reported via NotFound + Lookup, not an error, so the
+// caller can say what the negative established rather than assert the object is absent.
 func (p *Provider) ResourceStatus(ctx context.Context, w providers.Workload) (providers.ResourceStatus, error) {
 	rs := providers.ResourceStatus{Workload: w, Refs: map[string]string{}}
 	u, err := p.reader.GetResource(ctx, w.Kind, w.Namespace, w.Name)
+	if lk, ok := providers.LookupOf(err); ok {
+		// A kind this provider cannot resolve is a scope limit, not a negative about the
+		// cluster, so it stays an ERROR — which the loop already reads as missing data.
+		if lk.Reason == providers.LookupUnresolvable {
+			return rs, err
+		}
+		rs.NotFound, rs.Lookup = true, lk
+		return rs, nil
+	}
 	if apierrors.IsNotFound(err) {
-		rs.NotFound = true
+		rs.NotFound, rs.Lookup = true, providers.Lookup{Reason: providers.LookupAbsent}
 		return rs, nil
 	}
 	if err != nil {
@@ -439,12 +449,24 @@ func (p *Provider) depNode(ctx context.Context, w providers.Workload, seen map[s
 	}
 	seen[key] = true
 	u, err := p.reader.GetResource(ctx, w.Kind, w.Namespace, w.Name)
+	if lk, ok := providers.LookupOf(err); ok {
+		// Every negative is recorded, including the ones that are NOT about the object:
+		// an unresolvable kind (a sourceRef into a kind this provider has no mapping for
+		// — this repo's own eval walks into an ArtifactGenerator) used to fall through to
+		// "leave Ready empty", which renders as "(Ready=unknown)" and asserts a node
+		// nobody looked up.
+		node.NotFound = lk.Reason == providers.LookupAbsent
+		node.Lookup = lk
+		return node
+	}
 	if apierrors.IsNotFound(err) {
 		node.NotFound = true
+		node.Lookup = providers.Lookup{Reason: providers.LookupAbsent}
 		return node
 	}
 	if err != nil {
-		return node // unknown kind / transient — leave Ready empty, keep walking siblings
+		node.Lookup = providers.Lookup{Reason: providers.LookupFailed}
+		return node // transient — keep walking siblings, but do not claim the node exists
 	}
 	node.Ready, node.Reason, _ = readyCondition(u)
 	for _, dep := range dependsOn(u, w.Kind, w.Namespace) {

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -309,6 +309,18 @@ type DepNode struct {
 	Children []DepNode
 }
 
+// GitOpsEngineReporter is an optional capability: a GitOps provider naming the engine it
+// speaks. Consumers type-assert for it exactly like GitOpsInspector.
+//
+// It exists so a consumer can source the engine from the provider it was actually handed
+// rather than from gitops.engine, which nothing validates — "argo" and "ArgoCD" both fall
+// through to flux — and which therefore cannot support a statement about the deployment.
+// Both providers already tag every Change they emit with their Engine; this exposes the
+// same fact before there is a Change to read.
+type GitOpsEngineReporter interface {
+	GitOpsEngine() Engine
+}
+
 // GitOpsInspector is optional read-only deep introspection for an investigation:
 // a resource's status/refs/events and its dependency tree. Not every engine
 // implements it (Flux does); consumers type-assert for it.

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -15,6 +15,7 @@ package providers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -209,11 +210,83 @@ type GitOpsProvider interface {
 	WatchFailures(ctx context.Context) (<-chan FailureEvent, error)
 }
 
+// LookupReason says what a read that returned no object actually ESTABLISHED, which is
+// not always "the object is absent".
+//
+// The dynamic client reports a 404 identically whether a served kind has no object of
+// that name or the API serves no such kind at all; an RBAC-refused cluster-wide search
+// never ran; and a kind the provider has no mapping for never reached the API at all.
+// Collapsing those into one "not found" is how runlore#503 turned a limit of the tool
+// into a claim about the cluster. A provider knows which case it hit, so it says so.
+type LookupReason string
+
+const (
+	// LookupAbsent — the kind is served, the search ran, and no object of that name came
+	// back from any scope searched. The only reason that is genuinely about the object.
+	LookupAbsent LookupReason = "absent"
+	// LookupKindNotServed — the API serves no such resource type, so no object of that
+	// kind could have been returned. Says nothing about the named object.
+	LookupKindNotServed LookupReason = "kind-not-served"
+	// LookupDenied — a search the answer would otherwise claim to have made was refused
+	// by RBAC and never ran. The object may sit in a scope this agent cannot read.
+	LookupDenied LookupReason = "denied"
+	// LookupUnresolvable — this provider has no mapping for the kind, so no request was
+	// ever issued. A statement about the provider's scope, not about the cluster.
+	LookupUnresolvable LookupReason = "unresolvable"
+	// LookupFailed — the read errored for some other reason, so nothing was established.
+	LookupFailed LookupReason = "failed"
+)
+
+// AllNamespaces is the Lookup scope name for a completed cluster-wide search by name.
+const AllNamespaces = "all namespaces"
+
+// Lookup records what a name lookup DID, so a tool can report the lookup instead of
+// asserting a conclusion the lookup does not support.
+type Lookup struct {
+	Reason LookupReason
+	// Scopes are the search scopes the provider actually COMPLETED, in order: a
+	// namespace name, or AllNamespaces. A scope that was skipped or refused is not
+	// listed — naming a search that never ran is the false half of #503's message,
+	// which claimed the namespace, flux-system and all namespaces unconditionally.
+	Scopes []string
+}
+
+// LookupError is a failed read that knows what it established. Providers return it so a
+// caller can report the lookup rather than infer a verdict from a bare 404; the
+// underlying API error is wrapped, so apierrors.IsNotFound and friends still work.
+type LookupError struct {
+	Lookup Lookup
+	Err    error
+}
+
+func (e *LookupError) Error() string {
+	if e.Err == nil {
+		return string(e.Lookup.Reason)
+	}
+	return string(e.Lookup.Reason) + ": " + e.Err.Error()
+}
+
+func (e *LookupError) Unwrap() error { return e.Err }
+
+// LookupOf recovers the Lookup a provider attached to a failed read, reporting false
+// for a nil error or one that carries no such record.
+func LookupOf(err error) (Lookup, bool) {
+	var le *LookupError
+	if errors.As(err, &le) {
+		return le.Lookup, true
+	}
+	return Lookup{}, false
+}
+
 // ResourceStatus is a read-only snapshot of a GitOps/Kubernetes object's health,
 // used to investigate WHY a resource is failing (not just that it is).
 type ResourceStatus struct {
 	Workload Workload
-	NotFound bool              // the object does not exist (often the cascade root)
+	// NotFound reports that the read returned no object. Lookup says what that
+	// ESTABLISHED — read them together, because "not found" on its own does not
+	// distinguish an absent object from an unserved kind or a denied search.
+	NotFound bool
+	Lookup   Lookup
 	Ready    string            // Ready condition status: "True"/"False"/"Unknown"/""
 	Reason   string            // Ready condition reason
 	Message  string            // Ready condition message
@@ -226,6 +299,11 @@ type ResourceStatus struct {
 type DepNode struct {
 	Workload Workload
 	NotFound bool
+	// Lookup is set whenever this node's own read returned no object — absent, unserved
+	// kind, denied, unresolvable kind, or a failed read. A zero Lookup means the object
+	// WAS read, so a renderer has to consult it before printing a Ready state: a node
+	// whose read failed used to render as "(Ready=unknown)", which asserts it exists.
+	Lookup   Lookup
 	Ready    string // Ready condition status
 	Reason   string
 	Children []DepNode


### PR DESCRIPTION
Closes #503. Design context in #507.

Asked about a kind it never supported, `gitops_resource_status` answered:

> `NOT FOUND — searched the given namespace, flux-system, and all namespaces by name; the object genuinely does not exist (likely the cascade root).`

**That is a claim about the cluster in reply to a question about the tool's scope.**

Observed live: asked about a `VMServiceScrape` — never a supported kind, and present in the cluster the entire time (verified uid, a single served CRD version, RBAC allowed) — the model quoted the answer as evidence, built its mechanism on it, and advised recovering the object from Git history. Wrong root cause, 60% confidence, 15 model calls.

## Three changes, and the second is the one that actually prevents it

**The advertised kind set is derived from the configured engine.** Same reasoning as `clusterTools` registering `controller_logs` only under Flux: a kind the engine cannot own is answerable only with a misleading negative. On Argo CD the Flux kinds always report "not found" — and a second live finding cited three such calls (`HelmRelease` ×2, `Kustomization`) as evidence, on a cluster with no Flux CRDs. Three confident negatives, zero information.

**`kind` is constrained by an enum in the schema.** A description can be disregarded; an out-of-enum value cannot be sent. The `Call` path still refuses, so a provider that ignores enums cannot reach the misleading branch either — and it refuses *before* the lookup rather than after it.

**The unsupported-kind reply says what the tool is and, load-bearing, what the answer is NOT:** silent about existence, not evidence of absence.

`gitops_tree` gets the same treatment and needed it more — a missing root renders as `NOT FOUND  ← root`, which hands back a root cause outright, and the same investigation cited it as corroboration.

The supported-kind NOT FOUND wording is softened too. Absence is a fact worth stating; that the absence *caused* the incident is for the loop to establish, not for one name lookup to assert.

## Testing

Each property watched failing against a deliberately broken implementation: engine scoping removed, the kind check bypassed, and the old wording restored.
