### PR TITLE
feat(investigate): read an object's spec, so config faults stop being inferred

### DIFF
--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -45,6 +45,14 @@ rules:
   # NOTE: execution rights (patch) are intentionally NOT granted cluster-wide here.
   # They are scoped to rbac.actionNamespaces as namespaced Roles below, so a
   # confused/compromised agent cannot mutate flux-system or another team's workloads.
+  # resource_spec (read an arbitrary object's .spec/.status): an operator-owned, read-only
+  # allowlist of spec-bearing kinds — see rbac.resourceSpecRules in values.yaml, which also
+  # explains why a `resources: ["*"]` wildcard must never include secrets. A kind missing
+  # from the list is reported to the agent as a DENIAL, never as a missing object, so a gap
+  # here degrades the tool rather than fabricating evidence.
+  {{- with .Values.rbac.resourceSpecRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/helm/runlore/values.schema.json
+++ b/deploy/helm/runlore/values.schema.json
@@ -120,6 +120,10 @@
         "controllerLogNamespaces": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "resourceSpecRules": {
+          "type": "array",
+          "items": { "type": "object" }
         }
       }
     },

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -493,6 +493,58 @@ rbac:
   # Role is skipped. If you render client-side (e.g. deploy via Argo CD) and guarantee
   # the namespace exists, set this false to keep the RBAC deterministic.
   skipMissingControllerLogNamespaces: true
+  # resource_spec reads an arbitrary object's .spec/.status: a Service selector matching no
+  # pods, a scrape CR pointing at an absent namespace, a NetworkPolicy with no egress to
+  # kube-dns, an HPA on a metric nothing reports. Resolution is discovery-driven, so the
+  # tool handles any kind — but only what RBAC actually grants, and the rules above cover
+  # Flux, Argo CD, events and pods and nothing else. Without this list every one of those
+  # questions comes back "forbidden".
+  #
+  # A read-only (get) allowlist of SPEC-BEARING kinds. Add your operators' CRDs here; a
+  # kind that is absent is reported to the agent as a denial, never as a missing object.
+  #
+  # DO NOT replace this with `resources: ["*"]`. A wildcard includes `secrets`, and the
+  # ServiceAccount's token then reads every Secret in the cluster. The tool itself refuses
+  # the Secret kind — before AND after resolution — but that refusal is an application-layer
+  # policy, not a boundary: RBAC is the boundary. If you must use a wildcard, keep secrets
+  # out of the grant.
+  resourceSpecRules:
+    - apiGroups: [""]
+      resources: ["services", "persistentvolumeclaims", "persistentvolumes", "nodes", "namespaces", "serviceaccounts"]
+      verbs: ["get"]
+    - apiGroups: ["apps"]
+      resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+      verbs: ["get"]
+    - apiGroups: ["batch"]
+      resources: ["jobs", "cronjobs"]
+      verbs: ["get"]
+    - apiGroups: ["networking.k8s.io"]
+      resources: ["ingresses", "networkpolicies", "ingressclasses"]
+      verbs: ["get"]
+    - apiGroups: ["autoscaling"]
+      resources: ["horizontalpodautoscalers"]
+      verbs: ["get"]
+    - apiGroups: ["policy"]
+      resources: ["poddisruptionbudgets"]
+      verbs: ["get"]
+    - apiGroups: ["storage.k8s.io"]
+      resources: ["storageclasses", "volumeattachments"]
+      verbs: ["get"]
+    - apiGroups: ["discovery.k8s.io"]
+      resources: ["endpointslices"]
+      verbs: ["get"]
+    - apiGroups: ["apiextensions.k8s.io"]
+      resources: ["customresourcedefinitions"]
+      verbs: ["get"]
+    # Scrape/alert CRs: the case this tool was built for was a VMServiceScrape whose
+    # namespaceSelector named a namespace that did not exist. A rule naming an API group
+    # the cluster does not serve is inert, so both operators are listed by default.
+    - apiGroups: ["operator.victoriametrics.com"]
+      resources: ["vmservicescrapes", "vmpodscrapes", "vmscrapeconfigs", "vmrules", "vmagents", "vmalerts"]
+      verbs: ["get"]
+    - apiGroups: ["monitoring.coreos.com"]
+      resources: ["servicemonitors", "podmonitors", "prometheusrules", "probes"]
+      verbs: ["get"]
 
 # Default-deny NetworkPolicy: restrict ingress to the webhook/health port and egress
 # to DNS + HTTPS + the Kubernetes API. Tighten egress to your model/git/observability

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -245,6 +245,14 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 		kubeReader = cr
 		tools = append(tools, clusterTools(cr, cfg)...)
 	}
+	// resource_spec: read an arbitrary object's .spec/.status. Registered separately from
+	// clusterTools because it needs a DYNAMIC client plus discovery (the typed clientset
+	// cannot read a CRD), and it is absent rather than broken when either is unavailable —
+	// a tool that cannot answer must not exist, per the same reasoning that gates
+	// controller_logs on the engine.
+	if sr := BuildResourceSpecReader(log); sr != nil {
+		tools = append(tools, investigate.ResourceSpecTool{Reader: sr})
+	}
 	// Cloud context (AWS): CloudTrail "what changed" + EC2/ASG/EKS health. Opt-in.
 	var cloudProvider providers.CloudProvider
 	if cfg.Cloud.Provider == "aws" {

--- a/internal/app/kube.go
+++ b/internal/app/kube.go
@@ -5,9 +5,15 @@ package app
 import (
 	"log/slog"
 
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/providers/cluster"
 )
 
 // KubeClientset builds a read-only clientset for pod-log access, or nil when no
@@ -33,4 +39,40 @@ func RestConfig() (*rest.Config, error) {
 	}
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{}).ClientConfig()
+}
+
+// BuildResourceSpecReader builds the read-only arbitrary-object spec reader, or nil when
+// the cluster is unreachable or discovery is unavailable.
+//
+// It needs BOTH a dynamic client and a RESTMapper: the typed clientset cannot read a CRD
+// at all, and without discovery a kind can only be resolved from a hardcoded map — which
+// is exactly the limitation that makes the Flux/ArgoCD inspectors blind to every kind they
+// were not compiled with.
+//
+// Returning nil rather than a half-working reader is deliberate. A tool that cannot answer
+// should not be registered, for the same reason controller_logs is gated on the engine: an
+// unanswerable question gets answered with a misleading negative, and the model reasons
+// from it.
+//
+// Discovery is memoised and lazy: the round trip happens on first use rather than at
+// startup, so an unreachable API server delays a tool call instead of blocking boot.
+func BuildResourceSpecReader(log *slog.Logger) providers.ResourceSpecReader {
+	restCfg, err := RestConfig()
+	if err != nil {
+		return nil
+	}
+	dc, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		log.Warn("dynamic client unavailable; resource_spec disabled", "err", err)
+		return nil
+	}
+	disco, err := discovery.NewDiscoveryClientForConfig(restCfg)
+	if err != nil {
+		log.Warn("discovery client unavailable; resource_spec disabled", "err", err)
+		return nil
+	}
+	// Memoised discovery: resolving a Kind costs one round trip the first time and nothing
+	// after, and Invalidate() on a miss means a CRD installed after RunLore started is
+	// still readable without a restart.
+	return cluster.NewSpecReader(dc, memory.NewMemCacheClient(disco))
 }

--- a/internal/app/kube.go
+++ b/internal/app/kube.go
@@ -44,9 +44,9 @@ func RestConfig() (*rest.Config, error) {
 // BuildResourceSpecReader builds the read-only arbitrary-object spec reader, or nil when
 // the cluster is unreachable or discovery is unavailable.
 //
-// It needs BOTH a dynamic client and a RESTMapper: the typed clientset cannot read a CRD
-// at all, and without discovery a kind can only be resolved from a hardcoded map — which
-// is exactly the limitation that makes the Flux/ArgoCD inspectors blind to every kind they
+// It needs BOTH a dynamic client and discovery: the typed clientset cannot read a CRD at
+// all, and without discovery a kind can only be resolved from a hardcoded map — which is
+// exactly the limitation that makes the Flux/ArgoCD inspectors blind to every kind they
 // were not compiled with.
 //
 // Returning nil rather than a half-working reader is deliberate. A tool that cannot answer
@@ -72,7 +72,11 @@ func BuildResourceSpecReader(log *slog.Logger) providers.ResourceSpecReader {
 		return nil
 	}
 	// Memoised discovery: resolving a Kind costs one round trip the first time and nothing
-	// after, and Invalidate() on a miss means a CRD installed after RunLore started is
-	// still readable without a restart.
+	// after. memcache caches FAILURES as permanently as successes, so the reader drops the
+	// cache and retries once on a miss — otherwise a CRD installed after RunLore started
+	// would be "this cluster serves no such kind" for the pod's whole lifetime, and one
+	// aggregated-APIService blip would poison a group forever. That retry is behind a type
+	// assertion on Invalidate(); TestResourceSpecDiscoveryIsInvalidatable pins that the
+	// client wired here satisfies it.
 	return cluster.NewSpecReader(dc, memory.NewMemCacheClient(disco))
 }

--- a/internal/app/resource_spec_wiring_test.go
+++ b/internal/app/resource_spec_wiring_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"testing"
+
+	"k8s.io/client-go/discovery/cached/memory"
+)
+
+// TestResourceSpecDiscoveryIsInvalidatable pins the one thing about this wiring that can
+// break silently.
+//
+// The spec reader drops its memoised discovery and retries once when a Kind does not
+// resolve — the difference between "a CRD installed after startup is readable" and "this
+// cluster serves no such kind, for the pod's whole lifetime". It reaches Invalidate()
+// through a TYPE ASSERTION, because the reader's discovery interface is deliberately
+// narrow, and a type assertion that stops matching does not fail to compile: it just stops
+// invalidating, and every stale answer is reported to the model as a fact about the
+// cluster.
+func TestResourceSpecDiscoveryIsInvalidatable(t *testing.T) {
+	var client any = memory.NewMemCacheClient(nil)
+	if _, ok := client.(interface{ Invalidate() }); !ok {
+		t.Fatal("the memoised discovery client wired into resource_spec no longer implements " +
+			"Invalidate(): a stale or failed discovery result is now permanent for the process")
+	}
+}

--- a/internal/config/chart_rbac_test.go
+++ b/internal/config/chart_rbac_test.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// policyRule is the slice of a Kubernetes RBAC rule this guard checks.
+type policyRule struct {
+	APIGroups []string `yaml:"apiGroups"`
+	Resources []string `yaml:"resources"`
+	Verbs     []string `yaml:"verbs"`
+}
+
+// readResourceSpecRules decodes rbac.resourceSpecRules out of the chart's values.yaml —
+// the real parse target Helm itself reads, not a copy of it.
+func readResourceSpecRules(t *testing.T) []policyRule {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(chartDir, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	var v struct {
+		RBAC struct {
+			ResourceSpecRules []policyRule `yaml:"resourceSpecRules"`
+		} `yaml:"rbac"`
+	}
+	if err := yaml.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("values.yaml is not valid YAML: %v", err)
+	}
+	if len(v.RBAC.ResourceSpecRules) == 0 {
+		t.Fatal("rbac.resourceSpecRules is empty: resource_spec is non-functional on a stock " +
+			"install — every kind it was built for comes back forbidden")
+	}
+	return v.RBAC.ResourceSpecRules
+}
+
+// TestResourceSpecRBACCoversTheMotivatingKinds: the tool resolves kinds through discovery,
+// so it handles anything — but only what RBAC grants. The ClusterRole covered Flux, Argo CD,
+// events and pods, which meant every example in the issue this tool closes (a Service
+// selector matching nothing, a NetworkPolicy with no egress to kube-dns, an HPA on a metric
+// nothing reports, a PVC bound to a vanished storage class, and the VMServiceScrape the
+// issue is actually about) answered "forbidden" on a stock install.
+//
+// That is a security problem before it is a functional one: the obvious operator response
+// to a wall of denials is `resources: ["*"]`, which includes secrets.
+func TestResourceSpecRBACCoversTheMotivatingKinds(t *testing.T) {
+	rules := readResourceSpecRules(t)
+	granted := map[string]bool{}
+	for _, r := range rules {
+		for _, g := range r.APIGroups {
+			for _, res := range r.Resources {
+				granted[g+"/"+res] = true
+			}
+		}
+	}
+	for _, want := range []string{
+		"/services",                                     // a selector that matches no pods
+		"networking.k8s.io/networkpolicies",             // no egress rule to kube-dns
+		"autoscaling/horizontalpodautoscalers",          // a metric that never reports
+		"/persistentvolumeclaims",                       // a storage class that no longer exists
+		"operator.victoriametrics.com/vmservicescrapes", // the CR the issue is about
+		"apps/deployments",                              // the workload behind most incidents
+	} {
+		if !granted[want] {
+			t.Errorf("resource_spec cannot read %q: it is not in rbac.resourceSpecRules", want)
+		}
+	}
+}
+
+// TestResourceSpecRBACNeverGrantsSecrets is the boundary itself.
+//
+// The tool refuses the Secret kind before AND after resolution, but that is an
+// application-layer policy: RBAC is what actually stops the ServiceAccount's token from
+// reading every Secret in the cluster. A wildcard here would quietly undo it, and the
+// refusal — which today makes a stock Secret read an existence oracle rather than a dump —
+// would be the only thing left standing.
+func TestResourceSpecRBACNeverGrantsSecrets(t *testing.T) {
+	for _, r := range readResourceSpecRules(t) {
+		for _, res := range r.Resources {
+			if res == "secrets" || res == "*" {
+				t.Errorf("rbac.resourceSpecRules grants %q on apiGroups %v — a wildcard includes "+
+					"secrets, and RBAC is the boundary the Secret refusal is NOT", res, r.APIGroups)
+			}
+		}
+		// Read-only, cluster-wide: this list is bound to the ClusterRole, so a write verb
+		// here is a cluster-wide write grant. Execution rights are namespace-scoped Roles
+		// gated on rbac.allowActions, deliberately and separately.
+		for _, v := range r.Verbs {
+			if !slices.Contains([]string{"get", "list", "watch"}, v) {
+				t.Errorf("rbac.resourceSpecRules grants the write verb %q on %v", v, r.Resources)
+			}
+		}
+	}
+}
+
+// TestResourceSpecRBACIsWiredAndWarned: the list is inert unless the template renders it,
+// and the wildcard warning is the only thing standing between an operator staring at a
+// denial and `resources: ["*"]`. Both are one careless edit from disappearing.
+func TestResourceSpecRBACIsWiredAndWarned(t *testing.T) {
+	tpl, err := os.ReadFile(filepath.Join(chartDir, "templates", "rbac.yaml"))
+	if err != nil {
+		t.Fatalf("read rbac.yaml: %v", err)
+	}
+	if !strings.Contains(string(tpl), ".Values.rbac.resourceSpecRules") {
+		t.Error("the ClusterRole does not render rbac.resourceSpecRules: the values key is inert")
+	}
+	values, err := os.ReadFile(filepath.Join(chartDir, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	for _, want := range []string{`resources: ["*"]`, "secrets"} {
+		if !strings.Contains(string(values), want) {
+			t.Errorf("values.yaml no longer warns about %q next to resourceSpecRules", want)
+		}
+	}
+}

--- a/internal/investigate/resource_spec_tool.go
+++ b/internal/investigate/resource_spec_tool.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
+)
+
+// ResourceSpecTool reads one Kubernetes object's desired state (.spec) and observed
+// state (.status), for any kind the cluster serves.
+//
+// It exists because every other reader answers "what is happening" while a large class
+// of incidents is "the SPEC says X and reality is Y": a Service selector matching no
+// pods, a scrape CR targeting a namespace that does not exist, a NetworkPolicy with no
+// egress rule to kube-dns, an HPA on a metric that never reports. Those were previously
+// only inferable from consequences, and the inference goes wrong — an investigation
+// concluded a VMServiceScrape had been deleted and advised restoring it from Git history
+// when the object was present and its namespaceSelector simply pointed nowhere. One read
+// of .spec would have settled it.
+type ResourceSpecTool struct {
+	Reader providers.ResourceSpecReader
+}
+
+// Name returns the tool name.
+func (t ResourceSpecTool) Name() string { return "resource_spec" }
+
+// Description returns the tool description.
+func (t ResourceSpecTool) Description() string {
+	return "Read one Kubernetes object's DESIRED state (.spec) and observed state (.status), for " +
+		"any kind the cluster serves, including CRDs. Use it when the question is whether " +
+		"configuration matches reality — a selector that matches nothing, a namespaceSelector " +
+		"pointing at a namespace that does not exist, a missing egress rule, a metric an HPA " +
+		"references but nothing reports. Prefer this over inferring config from its consequences. " +
+		"Secret is refused. Namespaced kinds require namespace. A denial or an unknown kind is " +
+		"reported as such and is NOT evidence that the object is absent."
+}
+
+// Schema returns the JSON schema for the arguments.
+func (t ResourceSpecTool) Schema() string {
+	return `{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name"]}`
+}
+
+// Call reads the object and renders it.
+//
+// Each outcome renders differently ON PURPOSE. Collapsing "you may not read this" and
+// "this cluster has no such kind" into "not found" is the defect that made
+// gitops_resource_status hand the model a fabricated fact, so the distinction is carried
+// all the way into the text the model sees, together with an explicit statement of what
+// the answer does NOT establish.
+func (t ResourceSpecTool) Call(ctx context.Context, args string) (string, error) {
+	var in struct{ Kind, Name, Namespace string }
+	if err := json.Unmarshal([]byte(args), &in); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	if t.Reader == nil {
+		return "resource_spec is not configured (no cluster access).", nil
+	}
+	rs, err := t.Reader.ResourceSpec(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})
+	if err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(fmt.Sprintf("%s %s", in.Kind, strings.TrimPrefix(in.Namespace+"/"+in.Name, "/")))
+	switch rs.Outcome {
+	case providers.ResourceAbsent:
+		return id + ": ABSENT — the API server reports no such object. This IS evidence the " +
+			"object does not exist. Whether that absence explains the incident is for you to " +
+			"establish from other evidence.", nil
+	case providers.ResourceForbidden:
+		// The one the model most needs spelled out: a denial is not absence. Left
+		// unstated, "cannot read" gets reasoned about as "not there".
+		return id + ": FORBIDDEN — " + redact.Secrets(rs.Detail) + "\nThis says NOTHING about " +
+			"whether the object exists; it says this agent may not read it. Do NOT treat it as " +
+			"evidence of absence.", nil
+	case providers.ResourceKindUnknown:
+		return id + ": UNKNOWN KIND — " + redact.Secrets(rs.Detail) + "\nThis says NOTHING about " +
+			"whether any object exists. Re-check the kind's spelling, or use a tool suited to it.", nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s (%s)\n", id, rs.APIVersion)
+	// Redaction on the way out, at the boundary that crosses to the provider. A spec can
+	// carry an inline credential (an env value, a connection string, a token in an
+	// annotation-shaped field), so this is the same treatment pod_logs output gets — the
+	// difference being that here it is the only line of defence for non-Secret kinds,
+	// which is why Secret itself is refused by kind rather than trusted to this.
+	if rs.Spec != "" {
+		fmt.Fprintf(&b, "spec:\n%s\n", indentBlock(redact.Secrets(rs.Spec)))
+	} else {
+		b.WriteString("spec: (none — this kind has no spec)\n")
+	}
+	if rs.Status != "" {
+		fmt.Fprintf(&b, "status:\n%s\n", indentBlock(redact.Secrets(rs.Status)))
+	}
+	return b.String(), nil
+}
+
+// indentBlock indents a YAML block by two spaces so spec and status read as nested
+// sections rather than running together with the header line.
+func indentBlock(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		if l != "" {
+			lines[i] = "  " + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/investigate/resource_spec_tool.go
+++ b/internal/investigate/resource_spec_tool.go
@@ -37,13 +37,23 @@ func (t ResourceSpecTool) Description() string {
 		"configuration matches reality — a selector that matches nothing, a namespaceSelector " +
 		"pointing at a namespace that does not exist, a missing egress rule, a metric an HPA " +
 		"references but nothing reports. Prefer this over inferring config from its consequences. " +
-		"Secret is refused. Namespaced kinds require namespace. A denial or an unknown kind is " +
+		"Secret is refused. Namespaced kinds require namespace; cluster-scoped kinds take none. " +
+		"When a kind is served by several API groups the read is refused as ambiguous — call again " +
+		"with group set to the one you mean. A denial or an unknown kind is " +
 		"reported as such and is NOT evidence that the object is absent."
 }
 
 // Schema returns the JSON schema for the arguments.
+//
+// group is optional and exists so an ambiguous kind is not a dead end: Event is served by
+// both the core group and events.k8s.io on every cluster, and NetworkPolicy by both
+// networking.k8s.io and crd.projectcalico.org on any cluster running Calico. Without it,
+// the reader's refusal to guess would leave the model no way to say which one it meant.
 func (t ResourceSpecTool) Schema() string {
-	return `{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name"]}`
+	return `{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},` +
+		`"namespace":{"type":"string"},` +
+		`"group":{"type":"string","description":"optional API group, e.g. networking.k8s.io (\"core\" for the core group) — only needed when a kind is served by more than one group"}},` +
+		`"required":["kind","name"]}`
 }
 
 // Call reads the object and renders it.
@@ -54,29 +64,47 @@ func (t ResourceSpecTool) Schema() string {
 // all the way into the text the model sees, together with an explicit statement of what
 // the answer does NOT establish.
 func (t ResourceSpecTool) Call(ctx context.Context, args string) (string, error) {
-	var in struct{ Kind, Name, Namespace string }
+	var in struct{ Kind, Name, Namespace, Group string }
 	if err := json.Unmarshal([]byte(args), &in); err != nil {
 		return "", fmt.Errorf("parse args: %w", err)
 	}
 	if t.Reader == nil {
 		return "resource_spec is not configured (no cluster access).", nil
 	}
-	rs, err := t.Reader.ResourceSpec(ctx, providers.Workload{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace})
+	q := providers.ResourceSpecQuery{Kind: in.Kind, Name: in.Name, Namespace: in.Namespace, Group: in.Group}
+	rs, err := t.Reader.ResourceSpec(ctx, q)
 	if err != nil {
 		return "", err
 	}
-	id := strings.TrimSpace(fmt.Sprintf("%s %s", in.Kind, strings.TrimPrefix(in.Namespace+"/"+in.Name, "/")))
+	// Identify the object by what the reader RESOLVED, not by what was asked for: a
+	// cluster-scoped kind called with a namespace would otherwise be reported back as
+	// "StorageClass totally-made-up-ns/fast", stating the caller's mistake as fact.
+	id := specID(rs.Query)
+	if rs.Query.Name == "" {
+		id = specID(q)
+	}
 	switch rs.Outcome {
 	case providers.ResourceAbsent:
 		return id + ": ABSENT — the API server reports no such object. This IS evidence the " +
 			"object does not exist. Whether that absence explains the incident is for you to " +
 			"establish from other evidence.", nil
+	case providers.ResourceRefused:
+		// Distinct from FORBIDDEN on purpose. Rendered as an RBAC denial, the human fix
+		// looks like "widen the ClusterRole" — which is how a policy refusal turns into a
+		// grant on secrets. This one is not about permissions and cannot be configured away.
+		return id + ": REFUSED — " + redact.Secrets(rs.Detail) + "\nThis is a policy of this " +
+			"agent, NOT an RBAC denial: widening the ClusterRole will not change it, and it says " +
+			"NOTHING about whether the object exists.", nil
 	case providers.ResourceForbidden:
 		// The one the model most needs spelled out: a denial is not absence. Left
 		// unstated, "cannot read" gets reasoned about as "not there".
 		return id + ": FORBIDDEN — " + redact.Secrets(rs.Detail) + "\nThis says NOTHING about " +
 			"whether the object exists; it says this agent may not read it. Do NOT treat it as " +
 			"evidence of absence.", nil
+	case providers.ResourceKindAmbiguous:
+		return id + ": AMBIGUOUS KIND — " + redact.Secrets(rs.Detail) + "\nNothing was read, " +
+			"because reading the wrong object and describing it confidently is worse than " +
+			"answering nothing. This says NOTHING about whether any object exists.", nil
 	case providers.ResourceKindUnknown:
 		return id + ": UNKNOWN KIND — " + redact.Secrets(rs.Detail) + "\nThis says NOTHING about " +
 			"whether any object exists. Re-check the kind's spelling, or use a tool suited to it.", nil
@@ -97,6 +125,16 @@ func (t ResourceSpecTool) Call(ctx context.Context, args string) (string, error)
 		fmt.Fprintf(&b, "status:\n%s\n", indentBlock(redact.Secrets(rs.Status)))
 	}
 	return b.String(), nil
+}
+
+// specID renders the object's identity, "Kind namespace/name" — or "Kind name" for a
+// cluster-scoped object, which has no namespace to render.
+func specID(q providers.ResourceSpecQuery) string {
+	ref := q.Name
+	if q.Namespace != "" {
+		ref = q.Namespace + "/" + q.Name
+	}
+	return strings.TrimSpace(q.Kind + " " + ref)
 }
 
 // indentBlock indents a YAML block by two spaces so spec and status read as nested

--- a/internal/investigate/resource_spec_tool_test.go
+++ b/internal/investigate/resource_spec_tool_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+type fakeSpecReader struct {
+	out providers.ResourceSpec
+	err error
+	got providers.Workload
+}
+
+func (f *fakeSpecReader) ResourceSpec(_ context.Context, w providers.Workload) (providers.ResourceSpec, error) {
+	f.got = w
+	return f.out, f.err
+}
+
+func callSpec(t *testing.T, r providers.ResourceSpecReader, args string) string {
+	t.Helper()
+	out, err := ResourceSpecTool{Reader: r}.Call(context.Background(), args)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	return out
+}
+
+// TestResourceSpecOutcomesAreNotConflated is the whole point of the tool's rendering, and
+// the reason it exists at all. "You may not read this" and "this cluster has no such kind"
+// are NOT "the object is absent" — collapsing them is the defect that made
+// gitops_resource_status hand back a fabricated fact and a wrong root cause.
+//
+// Only the ABSENT case may claim the object does not exist.
+func TestResourceSpecOutcomesAreNotConflated(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		outcome     providers.ResourceSpecOutcome
+		detail      string
+		wantMarker  string
+		mustDisclam bool
+	}{
+		{"absent", providers.ResourceAbsent, "the API server reports no such object", "ABSENT", false},
+		{"forbidden", providers.ResourceForbidden, `vmservicescrapes.operator.victoriametrics.com is forbidden`, "FORBIDDEN", true},
+		{"unknown kind", providers.ResourceKindUnknown, `this cluster serves no kind "Widget"`, "UNKNOWN KIND", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &fakeSpecReader{out: providers.ResourceSpec{Outcome: tc.outcome, Detail: tc.detail}}
+			out := callSpec(t, r, `{"kind":"VMServiceScrape","name":"x","namespace":"observability"}`)
+			if !strings.Contains(out, tc.wantMarker) {
+				t.Fatalf("outcome %s not distinguishable in output:\n%s", tc.outcome, out)
+			}
+			if tc.mustDisclam {
+				if !strings.Contains(out, "NOTHING about whether") {
+					t.Errorf("%s does not disclaim evidence of absence:\n%s", tc.outcome, out)
+				}
+				// The failure mode being guarded: a non-absence outcome that nonetheless
+				// tells the model the object is not there.
+				if strings.Contains(out, "does not exist") {
+					t.Errorf("%s claims the object does not exist:\n%s", tc.outcome, out)
+				}
+			}
+		})
+	}
+	// And the converse: a genuine absence MUST still say so plainly, or the tool is
+	// useless for the case it is most often needed in.
+	r := &fakeSpecReader{out: providers.ResourceSpec{Outcome: providers.ResourceAbsent, Detail: "gone"}}
+	if out := callSpec(t, r, `{"kind":"Service","name":"x","namespace":"n"}`); !strings.Contains(out, "does not exist") {
+		t.Errorf("a real absence must be stated as evidence:\n%s", out)
+	}
+}
+
+// TestResourceSpecRedactsSpecAndStatus pins the only line of defence for non-Secret kinds.
+// A spec can carry an inline credential — an env value, a connection string, a token in a
+// free-form field — and this output crosses the provider boundary.
+func TestResourceSpecRedactsSpecAndStatus(t *testing.T) {
+	const tok = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	r := &fakeSpecReader{out: providers.ResourceSpec{
+		Outcome:    providers.ResourceFound,
+		APIVersion: "v1",
+		Spec:       "containers:\n- env:\n  - name: TOKEN\n    value: " + tok,
+		Status:     "message: auth failed for " + tok,
+	}}
+	out := callSpec(t, r, `{"kind":"Pod","name":"p","namespace":"n"}`)
+	if strings.Contains(out, tok) {
+		t.Fatalf("a credential in the spec/status reached the model verbatim:\n%s", out)
+	}
+	// A denial's detail is server-provided text and gets the same treatment.
+	r2 := &fakeSpecReader{out: providers.ResourceSpec{Outcome: providers.ResourceForbidden, Detail: "denied using " + tok}}
+	if out := callSpec(t, r2, `{"kind":"Pod","name":"p","namespace":"n"}`); strings.Contains(out, tok) {
+		t.Fatalf("a credential in a denial message reached the model verbatim:\n%s", out)
+	}
+}
+
+// TestResourceSpecPassesTheWorkloadThrough guards the plumbing: a tool that silently drops
+// the namespace would read the wrong object and report confidently about it.
+func TestResourceSpecPassesTheWorkloadThrough(t *testing.T) {
+	r := &fakeSpecReader{out: providers.ResourceSpec{Outcome: providers.ResourceFound, APIVersion: "v1", Spec: "k: v"}}
+	callSpec(t, r, `{"kind":"VMServiceScrape","name":"datagrok-rabbitmq","namespace":"observability"}`)
+	want := providers.Workload{Kind: "VMServiceScrape", Name: "datagrok-rabbitmq", Namespace: "observability"}
+	if r.got != want {
+		t.Fatalf("reader received %+v, want %+v", r.got, want)
+	}
+}
+
+// TestResourceSpecUnconfiguredIsHonest: with no cluster access the tool must say so rather
+// than return an empty result that reads like "the object has no spec".
+func TestResourceSpecUnconfiguredIsHonest(t *testing.T) {
+	out, err := ResourceSpecTool{}.Call(context.Background(), `{"kind":"Pod","name":"p","namespace":"n"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "not configured") {
+		t.Fatalf("an unwired tool must say so:\n%s", out)
+	}
+}
+
+// TestResourceSpecDescriptionSetsExpectations: the description is the only place the model
+// learns that Secret is refused and that a denial is not absence, so those claims must be
+// present. A model that believes it can read a Secret will waste a call and, worse, may
+// read a refusal as absence.
+func TestResourceSpecDescriptionSetsExpectations(t *testing.T) {
+	d := ResourceSpecTool{}.Description()
+	for _, want := range []string{"Secret is refused", "NOT evidence", "spec"} {
+		if !strings.Contains(d, want) {
+			t.Errorf("description missing %q:\n%s", want, d)
+		}
+	}
+}

--- a/internal/investigate/resource_spec_tool_test.go
+++ b/internal/investigate/resource_spec_tool_test.go
@@ -4,6 +4,8 @@ package investigate
 
 import (
 	"context"
+	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -13,11 +15,11 @@ import (
 type fakeSpecReader struct {
 	out providers.ResourceSpec
 	err error
-	got providers.Workload
+	got providers.ResourceSpecQuery
 }
 
-func (f *fakeSpecReader) ResourceSpec(_ context.Context, w providers.Workload) (providers.ResourceSpec, error) {
-	f.got = w
+func (f *fakeSpecReader) ResourceSpec(_ context.Context, q providers.ResourceSpecQuery) (providers.ResourceSpec, error) {
+	f.got = q
 	return f.out, f.err
 }
 
@@ -74,20 +76,29 @@ func TestResourceSpecOutcomesAreNotConflated(t *testing.T) {
 	}
 }
 
-// TestResourceSpecRedactsSpecAndStatus pins the only line of defence for non-Secret kinds.
-// A spec can carry an inline credential — an env value, a connection string, a token in a
-// free-form field — and this output crosses the provider boundary.
+// TestResourceSpecRedactsSpecAndStatus pins the LAST pass over spec/status text on its way
+// to the provider: a credential in a free-form field, a connection string, a token quoted
+// in a status message.
+//
+// It is deliberately NOT the guard for a container's env. That shape — the sensitive word
+// in the VALUE of `name:`, the credential under the literal key `value:` — is invisible to
+// a key-name-oriented string ruleset, and this test used to "cover" it only because the
+// fixture's value happened to carry a ghp_ prefix that a token rule matched on its own.
+// The env shape is masked STRUCTURALLY, before anything is marshalled, and is pinned by
+// cluster.TestResourceSpecMasksContainerEnvValues.
 func TestResourceSpecRedactsSpecAndStatus(t *testing.T) {
 	const tok = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
 	r := &fakeSpecReader{out: providers.ResourceSpec{
 		Outcome:    providers.ResourceFound,
 		APIVersion: "v1",
-		Spec:       "containers:\n- env:\n  - name: TOKEN\n    value: " + tok,
+		Spec:       "database:\n  connection_string: postgres://app:hunter2supersecret@db:5432/x\n  token: " + tok,
 		Status:     "message: auth failed for " + tok,
 	}}
 	out := callSpec(t, r, `{"kind":"Pod","name":"p","namespace":"n"}`)
-	if strings.Contains(out, tok) {
-		t.Fatalf("a credential in the spec/status reached the model verbatim:\n%s", out)
+	for _, gone := range []string{tok, "hunter2supersecret"} {
+		if strings.Contains(out, gone) {
+			t.Fatalf("a credential in the spec/status reached the model verbatim:\n%s", out)
+		}
 	}
 	// A denial's detail is server-provided text and gets the same treatment.
 	r2 := &fakeSpecReader{out: providers.ResourceSpec{Outcome: providers.ResourceForbidden, Detail: "denied using " + tok}}
@@ -96,14 +107,90 @@ func TestResourceSpecRedactsSpecAndStatus(t *testing.T) {
 	}
 }
 
-// TestResourceSpecPassesTheWorkloadThrough guards the plumbing: a tool that silently drops
-// the namespace would read the wrong object and report confidently about it.
-func TestResourceSpecPassesTheWorkloadThrough(t *testing.T) {
+// TestResourceSpecPassesTheQueryThrough guards the plumbing: a tool that silently drops the
+// namespace would read the wrong object and report confidently about it. The optional group
+// argument travels the same path — without it, an ambiguous kind stays a dead end.
+//
+// It also covers the fallback identity: a reader that echoes no resolved query (as this
+// fake does) must still produce the object's id from the request rather than a blank.
+func TestResourceSpecPassesTheQueryThrough(t *testing.T) {
 	r := &fakeSpecReader{out: providers.ResourceSpec{Outcome: providers.ResourceFound, APIVersion: "v1", Spec: "k: v"}}
-	callSpec(t, r, `{"kind":"VMServiceScrape","name":"datagrok-rabbitmq","namespace":"observability"}`)
-	want := providers.Workload{Kind: "VMServiceScrape", Name: "datagrok-rabbitmq", Namespace: "observability"}
+	out := callSpec(t, r, `{"kind":"NetworkPolicy","name":"deny-all","namespace":"apps","group":"networking.k8s.io"}`)
+	want := providers.ResourceSpecQuery{Kind: "NetworkPolicy", Name: "deny-all", Namespace: "apps", Group: "networking.k8s.io"}
 	if r.got != want {
 		t.Fatalf("reader received %+v, want %+v", r.got, want)
+	}
+	if !strings.Contains(out, "NetworkPolicy apps/deny-all") {
+		t.Fatalf("the object is not identified in the output:\n%s", out)
+	}
+}
+
+// TestResourceSpecIdentifiesWhatWasREAD, not what was asked for. A cluster-scoped kind
+// called with a namespace was read anyway and the invented namespace rendered back as
+// fact — "StorageClass totally-made-up-ns/fast" — which is a fabricated detail in exactly
+// the register the model treats as evidence.
+func TestResourceSpecIdentifiesWhatWasRead(t *testing.T) {
+	r := &fakeSpecReader{out: providers.ResourceSpec{
+		Outcome:    providers.ResourceFound,
+		APIVersion: "storage.k8s.io/v1",
+		Query:      providers.ResourceSpecQuery{Kind: "StorageClass", Name: "fast", Group: "storage.k8s.io"},
+		Spec:       "provisioner: ebs.csi.aws.com",
+	}}
+	out := callSpec(t, r, `{"kind":"storageclass","name":"fast","namespace":"totally-made-up-ns"}`)
+	if strings.Contains(out, "totally-made-up-ns") {
+		t.Fatalf("a namespace the object does not have was rendered as fact:\n%s", out)
+	}
+	if !strings.Contains(out, "StorageClass fast") {
+		t.Fatalf("the resolved identity is not rendered:\n%s", out)
+	}
+}
+
+// TestResourceSpecRefusalIsNotADenial: the Secret refusal used to render as FORBIDDEN,
+// which reads to a human as an RBAC gap. The obvious fix for an RBAC gap is to widen the
+// ClusterRole — and the widest fix, resources: ["*"], grants `secrets`. A policy refusal
+// that pushes an operator toward granting the very thing it refuses is a bad ending, so it
+// says what it is.
+func TestResourceSpecRefusalIsNotADenial(t *testing.T) {
+	r := &fakeSpecReader{out: providers.ResourceSpec{
+		Outcome: providers.ResourceRefused,
+		Detail:  "Secret objects are never readable through this tool",
+	}}
+	out := callSpec(t, r, `{"kind":"Secret","name":"db","namespace":"apps"}`)
+	if !strings.Contains(out, "REFUSED") {
+		t.Fatalf("a refusal must be distinguishable from a denial:\n%s", out)
+	}
+	if strings.Contains(out, "FORBIDDEN") {
+		t.Fatalf("a policy refusal still renders as an RBAC denial:\n%s", out)
+	}
+	if !strings.Contains(out, "NOT an RBAC denial") {
+		t.Fatalf("the refusal does not steer the reader away from widening RBAC:\n%s", out)
+	}
+	if strings.Contains(out, "does not exist") {
+		t.Fatalf("a refusal claims the object does not exist:\n%s", out)
+	}
+}
+
+// TestResourceSpecAmbiguityIsActionable: an ambiguous kind is its own ending, and the
+// output must carry the way out of it — the group argument — or the model's only options
+// are to give up or to re-ask the identical question.
+func TestResourceSpecAmbiguityIsActionable(t *testing.T) {
+	r := &fakeSpecReader{out: providers.ResourceSpec{
+		Outcome: providers.ResourceKindAmbiguous,
+		Detail: `kind "NetworkPolicy" is served by more than one API group ` +
+			`(networking.k8s.io/v1, crd.projectcalico.org/v1); nothing was read. ` +
+			`Call again with the group argument set to the one you mean`,
+	}}
+	out := callSpec(t, r, `{"kind":"NetworkPolicy","name":"deny-all","namespace":"apps"}`)
+	if !strings.Contains(out, "AMBIGUOUS KIND") {
+		t.Fatalf("ambiguity is not distinguishable from an unknown kind:\n%s", out)
+	}
+	for _, want := range []string{"group", "crd.projectcalico.org/v1", "NOTHING about whether"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "does not exist") {
+		t.Fatalf("an ambiguous kind claims the object does not exist:\n%s", out)
 	}
 }
 
@@ -129,5 +216,29 @@ func TestResourceSpecDescriptionSetsExpectations(t *testing.T) {
 		if !strings.Contains(d, want) {
 			t.Errorf("description missing %q:\n%s", want, d)
 		}
+	}
+}
+
+// TestResourceSpecSchemaDeclaresGroup: the group argument is the only escape from an
+// ambiguous kind, so the model has to be able to see it — and the schema is hand-written
+// JSON with an embedded quoted example, which is exactly the kind of string that breaks
+// silently and leaves the tool uncallable.
+func TestResourceSpecSchemaDeclaresGroup(t *testing.T) {
+	var schema struct {
+		Properties map[string]any `json:"properties"`
+		Required   []string       `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(ResourceSpecTool{}.Schema()), &schema); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	for _, want := range []string{"kind", "name", "namespace", "group"} {
+		if _, ok := schema.Properties[want]; !ok {
+			t.Errorf("schema declares no %q argument", want)
+		}
+	}
+	// group must stay OPTIONAL: it is only needed for the ambiguous minority, and
+	// requiring it would force the model to guess a group for every ordinary read.
+	if slices.Contains(schema.Required, "group") {
+		t.Error("group must be optional")
 	}
 }

--- a/internal/providers/cluster/resourcespec.go
+++ b/internal/providers/cluster/resourcespec.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
 )
 
 // maxSpecBytes bounds one rendered section (spec or status). A spec is normally a few
@@ -25,16 +26,49 @@ import (
 // from consuming that whole budget and evicting the rest of the evidence.
 const maxSpecBytes = 8 << 10
 
+// refusedKind is a kind this tool never reads, refused by policy rather than left to
+// redaction.
+type refusedKind struct{ kind, why string }
+
 // refusedKinds are never readable through this path, by kind rather than by redaction.
 //
 // Secret is the obvious one and redaction is NOT considered sufficient for it: a Secret
 // IS the payload, so a redactor missing one pattern leaks the whole object, whereas for
 // every other kind a credential is an incidental field. Refusing by kind fails closed;
 // relying on redaction fails open.
-var refusedKinds = map[string]string{
-	"secret": "Secret objects are never readable through this tool — a Secret is entirely " +
+var refusedKinds = []refusedKind{{
+	kind: "Secret",
+	why: "Secret objects are never readable through this tool — a Secret is entirely " +
 		"sensitive, so refusing the kind fails closed where redaction would fail open. " +
 		"Read the workload that CONSUMES it instead (its spec names the keys it mounts).",
+}}
+
+// refusedResources are refused by RESOURCE name after resolution, in ANY API group.
+//
+// The kind pre-check cannot see this: an aggregated API server or a CRD may serve a
+// `secrets` resource under a Kind of its own choosing, which the pre-check would wave
+// through because it only ever compares the caller's spelling against a kind list.
+var refusedResources = map[string]string{
+	"secrets": "a resource named \"secrets\" is never readable through this tool, whatever " +
+		"Kind or API group serves it — the payload is the secret, so refusing fails closed " +
+		"where redaction would fail open.",
+}
+
+// refusalFor reports why kind is refused, comparing with EqualFold on BOTH sides.
+//
+// The folding MUST match the one resolution uses. It did not: the refusal keyed a
+// lowercase map with strings.ToLower while resolution matched with strings.EqualFold, and
+// the two disagree on Unicode simple folding — U+017F ("ſ") lowercases to itself but folds
+// to "s", so `ſecret` missed the refusal and still resolved to v1/secrets. That is the
+// same defect class as the IDN homoglyph bypass in #498: a case-folding mismatch between
+// the check and the use.
+func refusalFor(kind string) (string, bool) {
+	for _, r := range refusedKinds {
+		if strings.EqualFold(r.kind, kind) {
+			return r.why, true
+		}
+	}
+	return "", false
 }
 
 // resourceDiscoverer is the slice of discovery this reader needs. Narrow on purpose: it
@@ -44,6 +78,13 @@ var refusedKinds = map[string]string{
 // kind served by several GROUPS can, which is a genuine ambiguity worth reporting.
 type resourceDiscoverer interface {
 	ServerPreferredResources() ([]*metav1.APIResourceList, error)
+}
+
+// discoveryInvalidator is the optional half of discovery: dropping a memoised result.
+// The production client (client-go's memcache) implements it; the narrow interface above
+// deliberately does not require it, so a plain discovery client still works.
+type discoveryInvalidator interface {
+	Invalidate()
 }
 
 // SpecReader reads one object's spec/status for an arbitrary kind.
@@ -70,6 +111,7 @@ func NewSpecReader(client dynamic.Interface, disco resourceDiscoverer) *SpecRead
 // resolved is one served resource matching a Kind.
 type resolved struct {
 	gvr        schema.GroupVersionResource
+	kind       string // the Kind as the server spells it, not as the caller did
 	namespaced bool
 }
 
@@ -79,7 +121,27 @@ type resolved struct {
 // both networking.k8s.io and (historically) extensions, and silently picking one would be
 // the same class of quiet wrongness this tool exists to remove. Subresources are skipped —
 // "pods/log" is not an object you can read a spec from.
+//
+// A miss RETRIES once against fresh discovery. The production client memoises, and
+// client-go's memcache caches failures exactly as permanently as successes: without this,
+// a CRD installed after RunLore started is "this cluster serves no such kind" for the
+// pod's whole lifetime, and a single aggregated-APIService blip poisons a group forever.
+// Both would be reported to the model as a fact about the cluster.
 func (r *SpecReader) resolveKind(kind string) ([]resolved, error) {
+	matches, err := r.resolveKindCached(kind)
+	if len(matches) > 0 {
+		return matches, nil
+	}
+	inv, ok := r.disco.(discoveryInvalidator)
+	if !ok {
+		return matches, err
+	}
+	inv.Invalidate()
+	return r.resolveKindCached(kind)
+}
+
+// resolveKindCached is one pass over whatever discovery currently holds.
+func (r *SpecReader) resolveKindCached(kind string) ([]resolved, error) {
 	lists, err := r.disco.ServerPreferredResources()
 	// A partial discovery failure (one broken aggregated APIService) still returns usable
 	// lists, so the error is only fatal when nothing came back at all.
@@ -101,6 +163,7 @@ func (r *SpecReader) resolveKind(kind string) ([]resolved, error) {
 			}
 			out = append(out, resolved{
 				gvr:        gv.WithResource(ar.Name),
+				kind:       ar.Kind,
 				namespaced: ar.Namespaced,
 			})
 		}
@@ -108,94 +171,182 @@ func (r *SpecReader) resolveKind(kind string) ([]resolved, error) {
 	return out, nil
 }
 
+// matchGroup reports whether m belongs to the API group the caller asked for. An empty
+// request means "no preference"; "core" is accepted as a spelling of the core group,
+// whose real name is the empty string and which a model cannot otherwise name.
+func matchGroup(m resolved, group string) bool {
+	if group == "" {
+		return true
+	}
+	if strings.EqualFold(group, "core") {
+		return m.gvr.Group == ""
+	}
+	return strings.EqualFold(m.gvr.Group, group)
+}
+
 var _ providers.ResourceSpecReader = (*SpecReader)(nil)
 
-// ResourceSpec reads w's .spec and .status.
+// ResourceSpec reads q's .spec and .status.
 //
 // The outcome taxonomy is the point of this function, not an implementation detail.
-// Four endings, and only ONE of them is evidence that the object is absent:
+// The endings, and only ONE of them is evidence that the object is absent:
 //
-//	found        — read it
-//	absent       — the API server says no such object
-//	forbidden    — RBAC denied the read; the object may well exist
-//	kind_unknown — this cluster serves no such kind; says nothing about any object
+//	found          — read it
+//	absent         — the API server says no such OBJECT
+//	forbidden      — RBAC denied the read; the object may well exist
+//	kind_unknown   — this cluster serves no such kind; says nothing about any object
+//	kind_ambiguous — several groups serve this kind; nothing was read, name one
+//	refused        — this agent refuses the kind by policy; not an RBAC problem
 //
-// Flattening the last two into "not found" is exactly the defect that made
+// Flattening any of them into "not found" is exactly the defect that made
 // gitops_resource_status produce a confidently wrong root cause, so they are kept
 // distinct all the way out to the model.
-func (r *SpecReader) ResourceSpec(ctx context.Context, w providers.Workload) (providers.ResourceSpec, error) {
-	out := providers.ResourceSpec{Workload: w}
-	if w.Kind == "" || w.Name == "" {
+func (r *SpecReader) ResourceSpec(ctx context.Context, q providers.ResourceSpecQuery) (providers.ResourceSpec, error) {
+	out := providers.ResourceSpec{Query: q}
+	if q.Kind == "" || q.Name == "" {
 		return out, fmt.Errorf("kind and name are required")
 	}
-	if why, refused := refusedKinds[strings.ToLower(w.Kind)]; refused {
-		out.Outcome = providers.ResourceForbidden
+	if why, refused := refusalFor(q.Kind); refused {
+		out.Outcome = providers.ResourceRefused
 		out.Detail = why
 		return out, nil
 	}
-	matches, err := r.resolveKind(w.Kind)
+	matches, err := r.resolveKind(q.Kind)
 	if err != nil {
 		return out, err
+	}
+	if q.Group != "" {
+		kept := matches[:0]
+		for _, m := range matches {
+			if matchGroup(m, q.Group) {
+				kept = append(kept, m)
+			}
+		}
+		matches = kept
 	}
 	switch len(matches) {
 	case 0:
 		out.Outcome = providers.ResourceKindUnknown
-		out.Detail = fmt.Sprintf("this cluster serves no kind %q", w.Kind)
+		out.Detail = fmt.Sprintf("this cluster serves no kind %q", q.Kind)
+		if q.Group != "" {
+			out.Detail += fmt.Sprintf(" in API group %q", q.Group)
+		}
 		return out, nil
 	case 1:
 	default:
 		// Ambiguous: several API groups serve this Kind. Reporting it beats guessing —
 		// reading the wrong object and describing it confidently is the failure this tool
-		// exists to prevent, so the ambiguity is handed back with the candidates named.
+		// exists to prevent, so the ambiguity is handed back with the candidates named
+		// AND with the argument that resolves it, so it is not a dead end.
 		groups := make([]string, 0, len(matches))
 		for _, m := range matches {
 			groups = append(groups, m.gvr.GroupVersion().String())
 		}
-		out.Outcome = providers.ResourceKindUnknown
+		out.Outcome = providers.ResourceKindAmbiguous
 		out.Detail = fmt.Sprintf("kind %q is served by more than one API group (%s); "+
-			"this is ambiguous, so nothing was read", w.Kind, strings.Join(groups, ", "))
+			"nothing was read. Call again with the group argument set to the one you mean",
+			q.Kind, strings.Join(groups, ", "))
 		return out, nil
 	}
 	match := matches[0]
+	// Refuse AGAIN, on what resolution actually produced. The pre-check only ever sees the
+	// caller's spelling of the KIND, so it cannot refuse a Secret reached under a Kind of
+	// somebody else's choosing — which is what an aggregated API server or a CRD serving a
+	// `secrets` resource does.
+	//
+	// Re-checking the resolved KIND as well would be a no-op: resolution matches Kind with
+	// the same EqualFold the refusal uses, so the two cover exactly the same spellings.
+	// TestRefusalAndResolutionAgreeOnFolding pins that equivalence, so a change to either
+	// matcher fails loudly instead of quietly opening a bypass.
+	if why, refused := refusedResources[match.gvr.Resource]; refused {
+		out.Outcome = providers.ResourceRefused
+		out.Detail = why
+		return out, nil
+	}
+	// Echo the identity that was actually resolved: the server's spelling of the Kind,
+	// the group that answered, and NO namespace for a cluster-scoped kind. Repeating the
+	// request verbatim would render a caller's mistake as fact — "StorageClass
+	// totally-made-up-ns/fast" for an object that has no namespace at all.
+	out.Query.Kind, out.Query.Group = match.kind, match.gvr.Group
 	var ri dynamic.ResourceInterface = r.client.Resource(match.gvr)
 	if match.namespaced {
-		if w.Namespace == "" {
-			return out, fmt.Errorf("kind %q is namespaced: namespace is required", w.Kind)
+		if q.Namespace == "" {
+			return out, fmt.Errorf("kind %q is namespaced: namespace is required", match.kind)
 		}
-		ri = r.client.Resource(match.gvr).Namespace(w.Namespace)
+		ri = r.client.Resource(match.gvr).Namespace(q.Namespace)
+	} else {
+		out.Query.Namespace = ""
 	}
-	obj, err := ri.Get(ctx, w.Name, metav1.GetOptions{})
+	obj, err := ri.Get(ctx, q.Name, metav1.GetOptions{})
 	switch {
 	case err == nil:
 	case apierrors.IsNotFound(err):
+		// IsNotFound is true for BOTH "no such object" and "no such resource at this
+		// path" — a CRD deleted since discovery ran, an aggregated APIService that
+		// stopped serving. Only the first is evidence about an object, and reporting
+		// the second as absence is the #503 conflation this tool exists to remove.
+		if !objectLevelNotFound(err) {
+			out.Outcome = providers.ResourceKindUnknown
+			out.Detail = fmt.Sprintf("the API server no longer serves %s (discovery may be stale); "+
+				"no object was looked up", match.gvr.GroupResource().String())
+			return out, nil
+		}
 		out.Outcome = providers.ResourceAbsent
 		out.Detail = "the API server reports no such object"
 		return out, nil
 	case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
-		// RBAC is the boundary for this tool, exactly as for pod_logs — and a denial
-		// must never be rendered as absence. Whatever the ClusterRole grants is what is
-		// readable; anything else says nothing about whether the object exists.
+		// RBAC is the boundary for this tool. A denial must never be rendered as
+		// absence: whatever the ClusterRole grants is what is readable, and anything
+		// else says nothing about whether the object exists.
 		out.Outcome = providers.ResourceForbidden
 		out.Detail = strings.TrimSpace(err.Error())
 		return out, nil
 	default:
 		var status apierrors.APIStatus
 		if errors.As(err, &status) {
-			return out, fmt.Errorf("get %s %s/%s: %s", w.Kind, w.Namespace, w.Name, status.Status().Message)
+			return out, fmt.Errorf("get %s %s/%s: %s", match.kind, q.Namespace, q.Name, status.Status().Message)
 		}
-		return out, fmt.Errorf("get %s %s/%s: %w", w.Kind, w.Namespace, w.Name, err)
+		return out, fmt.Errorf("get %s %s/%s: %w", match.kind, q.Namespace, q.Name, err)
 	}
 	out.Outcome = providers.ResourceFound
+	out.Query.Name, out.Query.Namespace = obj.GetName(), obj.GetNamespace()
 	// Report the version the read actually used. A kind can be served at several
 	// versions, so "which one answered" is part of reading the spec honestly.
 	out.APIVersion = match.gvr.GroupVersion().String()
+	// Mask the {name, value} credential shape STRUCTURALLY, before anything is
+	// marshalled. redact.Secrets is key-name oriented — it masks `password: <value>` —
+	// while a container's env inverts that: the sensitive word is the value of `name`
+	// and the credential sits under the literal key `value`, which is in no keyword
+	// vocabulary. A copy is masked so the client's object is left untouched.
+	obj = obj.DeepCopy()
+	redact.SensitiveNameValues(obj.Object)
 	out.Spec = renderSection(obj, "spec")
 	out.Status = renderSection(obj, "status")
 	return out, nil
 }
 
-// renderSection returns one top-level field as YAML, bounded. Missing is "" rather than
-// an error: plenty of kinds legitimately have no spec (ConfigMap) or no status yet.
+// objectLevelNotFound reports whether a 404 was about an OBJECT rather than about the
+// resource path. The API server names the object it could not find in Status.Details;
+// an unserved path carries no details at all ("the server could not find the requested
+// resource").
+func objectLevelNotFound(err error) bool {
+	var status apierrors.APIStatus
+	if !errors.As(err, &status) {
+		return false
+	}
+	d := status.Status().Details
+	return d != nil && d.Name != ""
+}
+
+// renderSection returns one top-level field as YAML, redacted and bounded. Missing is ""
+// rather than an error: plenty of kinds legitimately have no spec (ConfigMap) or no
+// status yet.
+//
+// Redaction runs BEFORE the cap, which is the documented invariant for every other
+// boundary (see the tool-output chokepoint in the investigation loop): a secret that
+// straddles the cap must be MASKED, not sliced. Cutting first broke anchored rules — a
+// PEM block whose -----END----- fell past the cap had no terminator left to match, and
+// the key body shipped verbatim.
 func renderSection(obj *unstructured.Unstructured, field string) string {
 	v, found, err := unstructured.NestedFieldNoCopy(obj.Object, field)
 	if err != nil || !found || v == nil {
@@ -205,15 +356,18 @@ func renderSection(obj *unstructured.Unstructured, field string) string {
 	if err != nil {
 		return ""
 	}
-	s := strings.TrimRight(string(b), "\n")
-	if len(s) > maxSpecBytes {
-		// Cut on a line boundary so the result stays parseable-looking YAML rather than
-		// ending mid-key, which reads as corruption instead of truncation.
-		cut := strings.LastIndexByte(s[:maxSpecBytes], '\n')
-		if cut <= 0 {
-			cut = maxSpecBytes
-		}
-		s = s[:cut] + "\n… (truncated)"
+	s := redact.Secrets(strings.TrimRight(string(b), "\n"))
+	if len(s) <= maxSpecBytes {
+		return s
 	}
-	return s
+	// Cut on a line boundary so the result stays parseable-looking YAML rather than
+	// ending mid-key, which reads as corruption instead of truncation. A partial line is
+	// dropped rather than sliced: a fragment of a token the ruleset did not recognise is
+	// still a fragment of a secret, and it is no longer recognisable to anything
+	// downstream either.
+	cut := strings.LastIndexByte(s[:maxSpecBytes], '\n')
+	if cut <= 0 {
+		return "… (truncated: a single line exceeded the section cap)"
+	}
+	return s[:cut] + "\n… (truncated)"
 }

--- a/internal/providers/cluster/resourcespec.go
+++ b/internal/providers/cluster/resourcespec.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// maxSpecBytes bounds one rendered section (spec or status). A spec is normally a few
+// hundred bytes; a Deployment's status or a big CRD can be larger, and an
+// unstructured object has no natural ceiling. The investigation loop caps tool output
+// globally (investigation.max_tool_output_bytes), but a section cap keeps ONE object
+// from consuming that whole budget and evicting the rest of the evidence.
+const maxSpecBytes = 8 << 10
+
+// refusedKinds are never readable through this path, by kind rather than by redaction.
+//
+// Secret is the obvious one and redaction is NOT considered sufficient for it: a Secret
+// IS the payload, so a redactor missing one pattern leaks the whole object, whereas for
+// every other kind a credential is an incidental field. Refusing by kind fails closed;
+// relying on redaction fails open.
+var refusedKinds = map[string]string{
+	"secret": "Secret objects are never readable through this tool — a Secret is entirely " +
+		"sensitive, so refusing the kind fails closed where redaction would fail open. " +
+		"Read the workload that CONSUMES it instead (its spec names the keys it mounts).",
+}
+
+// resourceDiscoverer is the slice of discovery this reader needs. Narrow on purpose: it
+// keeps the reader unit-testable without a live API server, and ServerPreferredResources
+// (rather than the full group/version listing) means one preferred version per
+// group-resource, so a kind served at several versions cannot be ambiguous here — only a
+// kind served by several GROUPS can, which is a genuine ambiguity worth reporting.
+type resourceDiscoverer interface {
+	ServerPreferredResources() ([]*metav1.APIResourceList, error)
+}
+
+// SpecReader reads one object's spec/status for an arbitrary kind.
+//
+// Resolution goes through DISCOVERY rather than a compiled-in kind→GVR table, which is what
+// lets an operator's CRD be read without a code change per operator — the limitation that
+// makes the Flux/ArgoCD inspectors blind to every kind they were not built with.
+//
+// A bare Kind is deliberately what callers pass, because that is what a model has: it reads
+// "VMServiceScrape" off an alert or a manifest, not "vmservicescrapes.v1beta1.operator.
+// victoriametrics.com". Resolving that means searching served resources by Kind, which is
+// also the only way to notice that two API GROUPS serve the same Kind.
+type SpecReader struct {
+	client dynamic.Interface
+	disco  resourceDiscoverer
+}
+
+// NewSpecReader builds a read-only spec reader from a dynamic client and a discovery
+// client.
+func NewSpecReader(client dynamic.Interface, disco resourceDiscoverer) *SpecReader {
+	return &SpecReader{client: client, disco: disco}
+}
+
+// resolved is one served resource matching a Kind.
+type resolved struct {
+	gvr        schema.GroupVersionResource
+	namespaced bool
+}
+
+// resolveKind finds every served resource whose Kind matches, case-insensitively.
+//
+// Returning ALL matches rather than the first is the honest choice: "Ingress" is served by
+// both networking.k8s.io and (historically) extensions, and silently picking one would be
+// the same class of quiet wrongness this tool exists to remove. Subresources are skipped —
+// "pods/log" is not an object you can read a spec from.
+func (r *SpecReader) resolveKind(kind string) ([]resolved, error) {
+	lists, err := r.disco.ServerPreferredResources()
+	// A partial discovery failure (one broken aggregated APIService) still returns usable
+	// lists, so the error is only fatal when nothing came back at all.
+	if err != nil && len(lists) == 0 {
+		return nil, fmt.Errorf("discover served resources: %w", err)
+	}
+	var out []resolved
+	for _, l := range lists {
+		if l == nil {
+			continue
+		}
+		gv, perr := schema.ParseGroupVersion(l.GroupVersion)
+		if perr != nil {
+			continue
+		}
+		for _, ar := range l.APIResources {
+			if strings.Contains(ar.Name, "/") || !strings.EqualFold(ar.Kind, kind) {
+				continue
+			}
+			out = append(out, resolved{
+				gvr:        gv.WithResource(ar.Name),
+				namespaced: ar.Namespaced,
+			})
+		}
+	}
+	return out, nil
+}
+
+var _ providers.ResourceSpecReader = (*SpecReader)(nil)
+
+// ResourceSpec reads w's .spec and .status.
+//
+// The outcome taxonomy is the point of this function, not an implementation detail.
+// Four endings, and only ONE of them is evidence that the object is absent:
+//
+//	found        — read it
+//	absent       — the API server says no such object
+//	forbidden    — RBAC denied the read; the object may well exist
+//	kind_unknown — this cluster serves no such kind; says nothing about any object
+//
+// Flattening the last two into "not found" is exactly the defect that made
+// gitops_resource_status produce a confidently wrong root cause, so they are kept
+// distinct all the way out to the model.
+func (r *SpecReader) ResourceSpec(ctx context.Context, w providers.Workload) (providers.ResourceSpec, error) {
+	out := providers.ResourceSpec{Workload: w}
+	if w.Kind == "" || w.Name == "" {
+		return out, fmt.Errorf("kind and name are required")
+	}
+	if why, refused := refusedKinds[strings.ToLower(w.Kind)]; refused {
+		out.Outcome = providers.ResourceForbidden
+		out.Detail = why
+		return out, nil
+	}
+	matches, err := r.resolveKind(w.Kind)
+	if err != nil {
+		return out, err
+	}
+	switch len(matches) {
+	case 0:
+		out.Outcome = providers.ResourceKindUnknown
+		out.Detail = fmt.Sprintf("this cluster serves no kind %q", w.Kind)
+		return out, nil
+	case 1:
+	default:
+		// Ambiguous: several API groups serve this Kind. Reporting it beats guessing —
+		// reading the wrong object and describing it confidently is the failure this tool
+		// exists to prevent, so the ambiguity is handed back with the candidates named.
+		groups := make([]string, 0, len(matches))
+		for _, m := range matches {
+			groups = append(groups, m.gvr.GroupVersion().String())
+		}
+		out.Outcome = providers.ResourceKindUnknown
+		out.Detail = fmt.Sprintf("kind %q is served by more than one API group (%s); "+
+			"this is ambiguous, so nothing was read", w.Kind, strings.Join(groups, ", "))
+		return out, nil
+	}
+	match := matches[0]
+	var ri dynamic.ResourceInterface = r.client.Resource(match.gvr)
+	if match.namespaced {
+		if w.Namespace == "" {
+			return out, fmt.Errorf("kind %q is namespaced: namespace is required", w.Kind)
+		}
+		ri = r.client.Resource(match.gvr).Namespace(w.Namespace)
+	}
+	obj, err := ri.Get(ctx, w.Name, metav1.GetOptions{})
+	switch {
+	case err == nil:
+	case apierrors.IsNotFound(err):
+		out.Outcome = providers.ResourceAbsent
+		out.Detail = "the API server reports no such object"
+		return out, nil
+	case apierrors.IsForbidden(err), apierrors.IsUnauthorized(err):
+		// RBAC is the boundary for this tool, exactly as for pod_logs — and a denial
+		// must never be rendered as absence. Whatever the ClusterRole grants is what is
+		// readable; anything else says nothing about whether the object exists.
+		out.Outcome = providers.ResourceForbidden
+		out.Detail = strings.TrimSpace(err.Error())
+		return out, nil
+	default:
+		var status apierrors.APIStatus
+		if errors.As(err, &status) {
+			return out, fmt.Errorf("get %s %s/%s: %s", w.Kind, w.Namespace, w.Name, status.Status().Message)
+		}
+		return out, fmt.Errorf("get %s %s/%s: %w", w.Kind, w.Namespace, w.Name, err)
+	}
+	out.Outcome = providers.ResourceFound
+	// Report the version the read actually used. A kind can be served at several
+	// versions, so "which one answered" is part of reading the spec honestly.
+	out.APIVersion = match.gvr.GroupVersion().String()
+	out.Spec = renderSection(obj, "spec")
+	out.Status = renderSection(obj, "status")
+	return out, nil
+}
+
+// renderSection returns one top-level field as YAML, bounded. Missing is "" rather than
+// an error: plenty of kinds legitimately have no spec (ConfigMap) or no status yet.
+func renderSection(obj *unstructured.Unstructured, field string) string {
+	v, found, err := unstructured.NestedFieldNoCopy(obj.Object, field)
+	if err != nil || !found || v == nil {
+		return ""
+	}
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return ""
+	}
+	s := strings.TrimRight(string(b), "\n")
+	if len(s) > maxSpecBytes {
+		// Cut on a line boundary so the result stays parseable-looking YAML rather than
+		// ending mid-key, which reads as corruption instead of truncation.
+		cut := strings.LastIndexByte(s[:maxSpecBytes], '\n')
+		if cut <= 0 {
+			cut = maxSpecBytes
+		}
+		s = s[:cut] + "\n… (truncated)"
+	}
+	return s
+}

--- a/internal/providers/cluster/resourcespec_test.go
+++ b/internal/providers/cluster/resourcespec_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// fakeDiscovery serves a fixed resource list, so resolution is testable without an API
+// server. err is returned alongside the lists to model a PARTIAL discovery failure (one
+// broken aggregated APIService), which must not make the whole read fail.
+type fakeDiscovery struct {
+	lists []*metav1.APIResourceList
+	err   error
+}
+
+func (f fakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return f.lists, f.err
+}
+
+func discoServing(gv string, res ...metav1.APIResource) fakeDiscovery {
+	return fakeDiscovery{lists: []*metav1.APIResourceList{{GroupVersion: gv, APIResources: res}}}
+}
+
+// TestResourceSpecRefusesSecretByKind is the load-bearing security property, and it is
+// checked BEFORE any client or mapper is touched — hence the nil client here, which also
+// proves no API call is made.
+//
+// Refusal is by KIND rather than by redaction on purpose: a Secret is entirely sensitive,
+// so a redactor missing one pattern leaks the whole object. Refusing fails closed;
+// redacting fails open.
+func TestResourceSpecRefusesSecretByKind(t *testing.T) {
+	r := NewSpecReader(nil, nil)
+	for _, kind := range []string{"Secret", "secret", "SECRET"} {
+		got, err := r.ResourceSpec(context.Background(), providers.Workload{
+			Kind: kind, Name: "runlore-secrets", Namespace: "runlore",
+		})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", kind, err)
+		}
+		if got.Outcome != providers.ResourceForbidden {
+			t.Errorf("%s: outcome = %q, want forbidden", kind, got.Outcome)
+		}
+		if got.Spec != "" || got.Status != "" {
+			t.Errorf("%s: refused read still returned content", kind)
+		}
+		if !strings.Contains(got.Detail, "never readable") {
+			t.Errorf("%s: refusal does not explain itself: %q", kind, got.Detail)
+		}
+	}
+}
+
+// TestResourceSpecUnknownKindIsNotAbsence pins the taxonomy at the reader boundary: a kind
+// this cluster does not serve must NOT be reported as an absent object. This is the exact
+// conflation that made gitops_resource_status produce a fabricated fact.
+func TestResourceSpecUnknownKindIsNotAbsence(t *testing.T) {
+	// Discovery serves nothing matching, so the kind cannot resolve.
+	r := NewSpecReader(nil, discoServing("v1", metav1.APIResource{Name: "pods", Kind: "Pod", Namespaced: true}))
+	got, err := r.ResourceSpec(context.Background(), providers.Workload{Kind: "Widget", Name: "w", Namespace: "n"})
+	if err != nil {
+		t.Fatalf("an unknown kind must be an OUTCOME, not an error: %v", err)
+	}
+	if got.Outcome != providers.ResourceKindUnknown {
+		t.Fatalf("outcome = %q, want kind_unknown", got.Outcome)
+	}
+	if got.Outcome == providers.ResourceAbsent {
+		t.Fatal("an unserved kind was reported as an absent object")
+	}
+}
+
+// TestResourceSpecReadsSpecAndStatus covers the happy path against a fake dynamic client,
+// including that the version actually used is reported — a kind can be served at several
+// versions, so "which one answered" is part of reading honestly.
+func TestResourceSpecReadsSpecAndStatus(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "operator.victoriametrics.com", Version: "v1beta1", Resource: "vmservicescrapes"}
+	gvk := gvr.GroupVersion().WithKind("VMServiceScrape")
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gvr.GroupVersion().String(),
+		"kind":       "VMServiceScrape",
+		"metadata":   map[string]any{"name": "datagrok-rabbitmq", "namespace": "observability"},
+		"spec": map[string]any{
+			"namespaceSelector": map[string]any{"matchNames": []any{"datagrok"}},
+		},
+		"status": map[string]any{"conditions": []any{}},
+	}}
+	scheme := runtime.NewScheme()
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{gvr: "VMServiceScrapeList"}, obj)
+	disco := discoServing(gvr.GroupVersion().String(),
+		metav1.APIResource{Name: gvr.Resource, Kind: gvk.Kind, Namespaced: true})
+
+	r := NewSpecReader(client, disco)
+	got, err := r.ResourceSpec(context.Background(), providers.Workload{
+		Kind: "VMServiceScrape", Name: "datagrok-rabbitmq", Namespace: "observability",
+	})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Outcome != providers.ResourceFound {
+		t.Fatalf("outcome = %q (detail %q), want found", got.Outcome, got.Detail)
+	}
+	// The field the live investigation needed and could not read: it inferred the object
+	// had been deleted when its namespaceSelector simply pointed at an absent namespace.
+	if !strings.Contains(got.Spec, "datagrok") {
+		t.Errorf("spec does not carry namespaceSelector.matchNames:\n%s", got.Spec)
+	}
+	if got.APIVersion != gvr.GroupVersion().String() {
+		t.Errorf("APIVersion = %q, want %q", got.APIVersion, gvr.GroupVersion().String())
+	}
+}
+
+// TestResourceSpecMissingObjectIsAbsent: for a SERVED kind, a genuinely missing object is
+// the one outcome that IS evidence of absence.
+func TestResourceSpecMissingObjectIsAbsent(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+	gvk := gvr.GroupVersion().WithKind("Service")
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "ServiceList"})
+	disco := discoServing("v1", metav1.APIResource{Name: "services", Kind: gvk.Kind, Namespaced: true})
+
+	got, err := NewSpecReader(client, disco).ResourceSpec(context.Background(),
+		providers.Workload{Kind: "Service", Name: "nope", Namespace: "default"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Outcome != providers.ResourceAbsent {
+		t.Fatalf("outcome = %q, want absent", got.Outcome)
+	}
+}
+
+// TestRenderSectionTruncatesOnALineBoundary: an unstructured object has no natural size
+// ceiling, and one object must not consume the whole tool-output budget and evict the rest
+// of the evidence. Cutting on a line boundary keeps the result reading as truncated YAML
+// rather than as corruption.
+func TestRenderSectionTruncatesOnALineBoundary(t *testing.T) {
+	big := make([]any, 4000)
+	for i := range big {
+		big[i] = "a-fairly-long-entry-to-blow-past-the-section-cap"
+	}
+	obj := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"items": big}}}
+	out := renderSection(obj, "spec")
+	if len(out) > maxSpecBytes+64 {
+		t.Fatalf("section not bounded: %d bytes", len(out))
+	}
+	if !strings.HasSuffix(out, "… (truncated)") {
+		t.Fatalf("a cut section must say it was cut:\n%s", out[max(0, len(out)-120):])
+	}
+	if strings.Contains(strings.TrimSuffix(out, "\n… (truncated)"), "\n\n") {
+		t.Error("truncation left a dangling blank line")
+	}
+	// Absent and nil sections are "" rather than an error: many kinds have no spec.
+	if got := renderSection(&unstructured.Unstructured{Object: map[string]any{}}, "spec"); got != "" {
+		t.Errorf("missing section = %q, want empty", got)
+	}
+}
+
+// TestResourceSpecAmbiguousKindReadsNothing pins the choice to report an ambiguity rather
+// than resolve it. "Ingress" was served by both networking.k8s.io and extensions, and
+// picking one silently would read a DIFFERENT object than the caller meant and then
+// describe it confidently — the exact failure this tool exists to remove.
+func TestResourceSpecAmbiguousKindReadsNothing(t *testing.T) {
+	disco := fakeDiscovery{lists: []*metav1.APIResourceList{
+		{GroupVersion: "networking.k8s.io/v1", APIResources: []metav1.APIResource{
+			{Name: "ingresses", Kind: "Ingress", Namespaced: true}}},
+		{GroupVersion: "extensions/v1beta1", APIResources: []metav1.APIResource{
+			{Name: "ingresses", Kind: "Ingress", Namespaced: true}}},
+	}}
+	// nil client: an ambiguous kind must be refused before any read is attempted.
+	got, err := NewSpecReader(nil, disco).ResourceSpec(context.Background(),
+		providers.Workload{Kind: "Ingress", Name: "web", Namespace: "apps"})
+	if err != nil {
+		t.Fatalf("ambiguity must be an outcome, not an error: %v", err)
+	}
+	if got.Outcome == providers.ResourceAbsent || got.Outcome == providers.ResourceFound {
+		t.Fatalf("outcome = %q: an ambiguous kind must not read or claim absence", got.Outcome)
+	}
+	for _, want := range []string{"more than one API group", "networking.k8s.io/v1", "extensions/v1beta1"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Errorf("detail does not name the ambiguity (%q): %q", want, got.Detail)
+		}
+	}
+}
+
+// TestResolveKindSkipsSubresourcesAndSurvivesPartialDiscovery: "pods/log" is not an object
+// with a spec, and a single broken aggregated APIService must not make every read fail —
+// discovery returns usable lists alongside its error in that case.
+func TestResolveKindSkipsSubresourcesAndSurvivesPartialDiscovery(t *testing.T) {
+	disco := fakeDiscovery{
+		lists: []*metav1.APIResourceList{{GroupVersion: "v1", APIResources: []metav1.APIResource{
+			{Name: "pods/log", Kind: "Pod", Namespaced: true},
+			{Name: "pods", Kind: "Pod", Namespaced: true},
+		}}},
+		err: errors.New("unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1"),
+	}
+	got, err := NewSpecReader(nil, disco).resolveKind("Pod")
+	if err != nil {
+		t.Fatalf("a partial discovery failure must not fail the read: %v", err)
+	}
+	if len(got) != 1 || got[0].gvr.Resource != "pods" {
+		t.Fatalf("resolveKind = %+v, want exactly the pods resource (subresource skipped)", got)
+	}
+	// But a TOTAL discovery failure — nothing usable came back — must surface.
+	if _, err := NewSpecReader(nil, fakeDiscovery{err: errors.New("connection refused")}).resolveKind("Pod"); err == nil {
+		t.Error("a total discovery failure must be an error, not silently zero matches")
+	}
+}

--- a/internal/providers/cluster/resourcespec_test.go
+++ b/internal/providers/cluster/resourcespec_test.go
@@ -8,11 +8,13 @@ import (
 	"strings"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/Smana/runlore/internal/providers"
 )
@@ -33,6 +35,25 @@ func discoServing(gv string, res ...metav1.APIResource) fakeDiscovery {
 	return fakeDiscovery{lists: []*metav1.APIResourceList{{GroupVersion: gv, APIResources: res}}}
 }
 
+// invalidatableDiscovery models the MEMOISED discovery client the reader gets in
+// production (client-go's memcache): it serves nothing until Invalidate() is called,
+// after which `after` is served. memcache caches failures as permanently as successes,
+// so a CRD installed after startup — or one aggregated APIService that blipped — stays
+// invisible for the process's whole life unless the cache is dropped and retried.
+type invalidatableDiscovery struct {
+	after       []*metav1.APIResourceList
+	invalidated int
+}
+
+func (d *invalidatableDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	if d.invalidated == 0 {
+		return nil, errors.New("unable to retrieve the complete list of server APIs")
+	}
+	return d.after, nil
+}
+
+func (d *invalidatableDiscovery) Invalidate() { d.invalidated++ }
+
 // TestResourceSpecRefusesSecretByKind is the load-bearing security property, and it is
 // checked BEFORE any client or mapper is touched — hence the nil client here, which also
 // proves no API call is made.
@@ -42,22 +63,82 @@ func discoServing(gv string, res ...metav1.APIResource) fakeDiscovery {
 // redacting fails open.
 func TestResourceSpecRefusesSecretByKind(t *testing.T) {
 	r := NewSpecReader(nil, nil)
-	for _, kind := range []string{"Secret", "secret", "SECRET"} {
-		got, err := r.ResourceSpec(context.Background(), providers.Workload{
+	for _, kind := range []string{"Secret", "secret", "SECRET", "ſecret"} {
+		got, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{
 			Kind: kind, Name: "runlore-secrets", Namespace: "runlore",
 		})
 		if err != nil {
-			t.Fatalf("%s: unexpected error: %v", kind, err)
+			t.Fatalf("%q: unexpected error: %v", kind, err)
 		}
-		if got.Outcome != providers.ResourceForbidden {
-			t.Errorf("%s: outcome = %q, want forbidden", kind, got.Outcome)
+		if got.Outcome != providers.ResourceRefused {
+			t.Errorf("%q: outcome = %q, want refused", kind, got.Outcome)
 		}
 		if got.Spec != "" || got.Status != "" {
-			t.Errorf("%s: refused read still returned content", kind)
+			t.Errorf("%q: refused read still returned content", kind)
 		}
 		if !strings.Contains(got.Detail, "never readable") {
-			t.Errorf("%s: refusal does not explain itself: %q", kind, got.Detail)
+			t.Errorf("%q: refusal does not explain itself: %q", kind, got.Detail)
 		}
+	}
+}
+
+// TestResourceSpecRefusalSurvivesCaseFolding is the S2 regression, and the same defect
+// class as the IDN homoglyph bypass in #498: a case-folding MISMATCH between the check
+// and the use.
+//
+// The refusal used strings.ToLower while resolution used strings.EqualFold, and the two
+// disagree on Unicode simple folding. U+017F LATIN SMALL LETTER LONG S lowercases to
+// itself, so "ſecret" was not in the refused map — yet EqualFold("Secret", "ſecret") is
+// true, so it resolved to v1/secrets and was read. It is reachable by prompt injection
+// through an alert annotation.
+//
+// This is the end-to-end case: served kind, live object, and the bypass spelling. The two
+// halves it depends on are pinned separately — TestRefusalAndResolutionAgreeOnFolding for
+// the pre-check's folding, TestResourceSpecRefusesASecretsResourceUnderAnyKind for the
+// post-resolution refusal.
+func TestResourceSpecRefusalSurvivesCaseFolding(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "Secret",
+		"metadata": map[string]any{"name": "runlore-secrets", "namespace": "runlore"},
+		// A stock Secret has no spec, which is why the live bypass is an existence
+		// ORACLE rather than a dump. A Secret-shaped CRD does have one, and that is
+		// what turns the oracle into a leak — so the fixture carries one, and the
+		// test fails loudly instead of passing on an empty payload.
+		"spec": map[string]any{"password": "pr0d-Pa55w0rd-x9"},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "SecretList"}, obj)
+	disco := discoServing("v1", metav1.APIResource{Name: "secrets", Kind: "Secret", Namespaced: true})
+
+	got, err := NewSpecReader(client, disco).ResourceSpec(context.Background(),
+		providers.ResourceSpecQuery{Kind: "ſecret", Name: "runlore-secrets", Namespace: "runlore"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Outcome != providers.ResourceRefused {
+		t.Fatalf("outcome = %q, want refused: a case-folding variant defeated the refusal", got.Outcome)
+	}
+	if got.Spec != "" || got.Status != "" {
+		t.Fatalf("a refused kind still rendered content:\nspec=%q\nstatus=%q", got.Spec, got.Status)
+	}
+}
+
+// TestResourceSpecRefusesASecretsResourceUnderAnyKind: the pre-check is by KIND and never
+// sees the resolved GVR, so a CRD or an aggregated API server exposing a `secrets`
+// resource under some other Kind slipped through it entirely. Refusing the RESOURCE name
+// after resolution, in any group, closes that.
+func TestResourceSpecRefusesASecretsResourceUnderAnyKind(t *testing.T) {
+	disco := discoServing("vault.example.com/v1",
+		metav1.APIResource{Name: "secrets", Kind: "VaultCredential", Namespaced: true})
+	// nil client: the refusal must land before any read is attempted.
+	got, err := NewSpecReader(nil, disco).ResourceSpec(context.Background(),
+		providers.ResourceSpecQuery{Kind: "VaultCredential", Name: "db", Namespace: "apps"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Outcome != providers.ResourceRefused {
+		t.Fatalf("outcome = %q, want refused for a resource named secrets", got.Outcome)
 	}
 }
 
@@ -67,7 +148,7 @@ func TestResourceSpecRefusesSecretByKind(t *testing.T) {
 func TestResourceSpecUnknownKindIsNotAbsence(t *testing.T) {
 	// Discovery serves nothing matching, so the kind cannot resolve.
 	r := NewSpecReader(nil, discoServing("v1", metav1.APIResource{Name: "pods", Kind: "Pod", Namespaced: true}))
-	got, err := r.ResourceSpec(context.Background(), providers.Workload{Kind: "Widget", Name: "w", Namespace: "n"})
+	got, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{Kind: "Widget", Name: "w", Namespace: "n"})
 	if err != nil {
 		t.Fatalf("an unknown kind must be an OUTCOME, not an error: %v", err)
 	}
@@ -101,7 +182,7 @@ func TestResourceSpecReadsSpecAndStatus(t *testing.T) {
 		metav1.APIResource{Name: gvr.Resource, Kind: gvk.Kind, Namespaced: true})
 
 	r := NewSpecReader(client, disco)
-	got, err := r.ResourceSpec(context.Background(), providers.Workload{
+	got, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{
 		Kind: "VMServiceScrape", Name: "datagrok-rabbitmq", Namespace: "observability",
 	})
 	if err != nil {
@@ -130,7 +211,7 @@ func TestResourceSpecMissingObjectIsAbsent(t *testing.T) {
 	disco := discoServing("v1", metav1.APIResource{Name: "services", Kind: gvk.Kind, Namespaced: true})
 
 	got, err := NewSpecReader(client, disco).ResourceSpec(context.Background(),
-		providers.Workload{Kind: "Service", Name: "nope", Namespace: "default"})
+		providers.ResourceSpecQuery{Kind: "Service", Name: "nope", Namespace: "default"})
 	if err != nil {
 		t.Fatalf("ResourceSpec: %v", err)
 	}
@@ -165,6 +246,293 @@ func TestRenderSectionTruncatesOnALineBoundary(t *testing.T) {
 	}
 }
 
+// TestRenderSectionRedactsBeforeTruncating is the S3 regression. The documented
+// invariant (website/content/docs/security/security-architecture.md) is:
+//
+//	"Redaction runs before truncation, so a secret that straddles the size cap is
+//	 masked, not sliced."
+//
+// renderSection inverted it — it cut first and left redaction to the caller — so an
+// anchored rule lost its anchor. A PEM block whose -----END----- falls past the cap has
+// no terminator left to match, and ~8 KB of key body shipped verbatim.
+func TestRenderSectionRedactsBeforeTruncating(t *testing.T) {
+	const line = "MIIEowIBAAKCAQEAx7Rm9d3sLpQ2vN8kZ1fT"
+	pem := "-----BEGIN RSA PRIVATE KEY-----\n" + strings.Repeat(line+"\n", 400) + "-----END RSA PRIVATE KEY-----"
+	obj := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"tls.key": pem}}}
+	out := renderSection(obj, "spec")
+	if strings.Contains(out, line) {
+		t.Fatalf("a private key straddling the cap shipped verbatim:\n%s", out[:min(len(out), 300)])
+	}
+	if !strings.Contains(out, "[REDACTED PRIVATE KEY]") {
+		t.Fatalf("the key was neither masked nor recognisable as masked:\n%s", out[:min(len(out), 300)])
+	}
+}
+
+// TestRenderSectionDropsAPartialLine covers the branch the old test was NAMED after but
+// never reached: when the first maxSpecBytes contain no newline at all, the cut fell back
+// to the byte offset and sliced mid-token. A ghp_/JWT/AKIA value straddling that offset
+// survived as an unrecognisable — and therefore unmasked — fragment.
+//
+// Redaction now runs first, so the token is already masked; the partial line is dropped
+// as well, because a fragment of an UNRECOGNISED secret is still a fragment of a secret.
+func TestRenderSectionDropsAPartialLine(t *testing.T) {
+	tok := "ghp_" + strings.Repeat("A", 36)
+	// One scalar, no spaces: the YAML emitter has nowhere to fold it, so the rendered
+	// section is a single line longer than the cap.
+	// The token straddles the cap; the trailing padding is non-alphanumeric so the
+	// token rule cannot swallow it and shorten the line back under the cap.
+	one := strings.Repeat("x", maxSpecBytes-20) + tok + strings.Repeat("-z", 200)
+	obj := &unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"k": one}}}
+	out := renderSection(obj, "spec")
+	if strings.Contains(out, "ghp_") {
+		t.Fatalf("a token sliced by the cap survived: %q", out[max(0, len(out)-120):])
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Fatalf("a dropped section must say it was cut: %q", out)
+	}
+	// The partial line is DROPPED, not sliced. Nothing of that line may survive: a
+	// fragment of a token the ruleset did not recognise is still a fragment of a secret,
+	// and nothing downstream can recognise it either.
+	if strings.Contains(out, "xxxx") {
+		t.Fatalf("the over-long line was sliced rather than dropped: %q", out[:min(len(out), 120)])
+	}
+	if len(out) > maxSpecBytes+64 {
+		t.Fatalf("section not bounded: %d bytes", len(out))
+	}
+}
+
+// TestResourceSpecMasksContainerEnvValues is the S1 regression, at the wiring level.
+//
+// redact.Secrets is KEY-NAME oriented — it masks `password: <value>`. Kubernetes' env
+// shape puts the sensitive word in the VALUE of `name:` and the credential under the
+// literal key `value:`, which is in no keyword vocabulary, so the whole env block reached
+// the model in plaintext. The chart grants `pods` get/list CLUSTER-WIDE and no tool
+// exposed a pod's .spec before this one, so it was a new egress category.
+//
+// The values here deliberately carry NO recognisable token prefix: a ghp_-shaped value
+// would be masked by the string rules and prove nothing.
+func TestResourceSpecMasksContainerEnvValues(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1", "kind": "Pod",
+		"metadata": map[string]any{"name": "api-0", "namespace": "apps"},
+		"spec": map[string]any{"containers": []any{map[string]any{
+			"name":  "api",
+			"image": "registry.k8s.io/pause:3.9",
+			"env": []any{
+				map[string]any{"name": "POSTGRES_PASSWORD", "value": "pr0d-Pa55w0rd-x9"},
+				map[string]any{"name": "REDIS_AUTH", "value": "hunter2hunter2"},
+				map[string]any{"name": "DB_PASSWORD", "value": "hunter2supersecret"},
+				map[string]any{"name": "LOG_LEVEL", "value": "debug"},
+			},
+		}}},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "PodList"}, obj)
+	disco := discoServing("v1", metav1.APIResource{Name: "pods", Kind: "Pod", Namespaced: true})
+
+	got, err := NewSpecReader(client, disco).ResourceSpec(context.Background(),
+		providers.ResourceSpecQuery{Kind: "Pod", Name: "api-0", Namespace: "apps"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	for _, cred := range []string{"pr0d-Pa55w0rd-x9", "hunter2hunter2", "hunter2supersecret"} {
+		if strings.Contains(got.Spec, cred) {
+			t.Errorf("env credential %q reached the model in plaintext:\n%s", cred, got.Spec)
+		}
+	}
+	// Structure survives: the model still needs to see WHICH variables are set, and
+	// benign configuration must not be destroyed on the way.
+	for _, keep := range []string{"POSTGRES_PASSWORD", "LOG_LEVEL", "debug", "registry.k8s.io/pause:3.9"} {
+		if !strings.Contains(got.Spec, keep) {
+			t.Errorf("%q should survive redaction:\n%s", keep, got.Spec)
+		}
+	}
+}
+
+// TestResourceSpecClassifiesADenial pins CLASSIFICATION, not rendering: the
+// IsForbidden/IsUnauthorized branch had no coverage at all, because the taxonomy tests
+// drive a fake whose outcome is pre-set — they never exercise the code that decides which
+// outcome an API error is. A denial silently classified as absence is the #503 defect.
+func TestResourceSpecClassifiesADenial(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "operator.victoriametrics.com", Version: "v1beta1", Resource: "vmservicescrapes"}
+	disco := discoServing(gvr.GroupVersion().String(),
+		metav1.APIResource{Name: gvr.Resource, Kind: "VMServiceScrape", Namespaced: true})
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"forbidden", apierrors.NewForbidden(gvr.GroupResource(), "datagrok-rabbitmq",
+			errors.New(`User "system:serviceaccount:runlore:runlore" cannot get resource "vmservicescrapes"`))},
+		{"unauthorized", apierrors.NewUnauthorized("token expired")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{gvr: "VMServiceScrapeList"})
+			client.PrependReactor("get", gvr.Resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, tc.err
+			})
+			got, err := NewSpecReader(client, disco).ResourceSpec(context.Background(),
+				providers.ResourceSpecQuery{Kind: "VMServiceScrape", Name: "datagrok-rabbitmq", Namespace: "observability"})
+			if err != nil {
+				t.Fatalf("a denial must be an OUTCOME, not an error: %v", err)
+			}
+			if got.Outcome != providers.ResourceForbidden {
+				t.Fatalf("outcome = %q, want forbidden", got.Outcome)
+			}
+			if got.Outcome == providers.ResourceAbsent {
+				t.Fatal("a denial was reported as absence")
+			}
+			if got.Detail == "" {
+				t.Error("a denial must carry the server's own message")
+			}
+		})
+	}
+}
+
+// TestResourceSpecResourceLevel404IsNotAbsence: apierrors.IsNotFound is true for BOTH
+// "no such object" and "no such resource at this path" (a CRD deleted since discovery
+// ran, an aggregated APIService that stopped serving). Reporting the second as absence
+// tells the model "this IS evidence the object does not exist" about an object the
+// server was never asked for — the #503 conflation this batch exists to remove.
+func TestResourceSpecResourceLevel404IsNotAbsence(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "operator.victoriametrics.com", Version: "v1beta1", Resource: "vmservicescrapes"}
+	disco := discoServing(gvr.GroupVersion().String(),
+		metav1.APIResource{Name: gvr.Resource, Kind: "VMServiceScrape", Namespaced: true})
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "VMServiceScrapeList"})
+	// What a real API server returns for an unserved path: reason NotFound, code 404,
+	// and NO details naming an object.
+	client.PrependReactor("get", gvr.Resource, func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, &apierrors.StatusError{ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Reason:  metav1.StatusReasonNotFound,
+			Code:    404,
+			Message: "the server could not find the requested resource",
+		}}
+	})
+	got, err := NewSpecReader(client, disco).ResourceSpec(context.Background(),
+		providers.ResourceSpecQuery{Kind: "VMServiceScrape", Name: "datagrok-rabbitmq", Namespace: "observability"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Outcome == providers.ResourceAbsent {
+		t.Fatal("a resource-level 404 was reported as evidence the OBJECT does not exist")
+	}
+	if got.Outcome != providers.ResourceKindUnknown {
+		t.Fatalf("outcome = %q, want kind_unknown", got.Outcome)
+	}
+}
+
+// TestResourceSpecClusterScopedIsNotNamespaced: a cluster-scoped kind used to be read
+// anyway when a namespace was supplied, and the bogus namespace was then rendered back as
+// fact ("StorageClass totally-made-up-ns/fast"). The identity must come from the object
+// that was actually read.
+func TestResourceSpecClusterScopedIsNotNamespaced(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "storage.k8s.io/v1", "kind": "StorageClass",
+		"metadata": map[string]any{"name": "fast"},
+		"spec":     map[string]any{"provisioner": "ebs.csi.aws.com"},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "StorageClassList"}, obj)
+	disco := discoServing(gvr.GroupVersion().String(),
+		metav1.APIResource{Name: gvr.Resource, Kind: "StorageClass", Namespaced: false})
+	r := NewSpecReader(client, disco)
+
+	// With a namespace the caller invented.
+	got, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{
+		Kind: "StorageClass", Name: "fast", Namespace: "totally-made-up-ns"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Outcome != providers.ResourceFound {
+		t.Fatalf("outcome = %q (detail %q), want found", got.Outcome, got.Detail)
+	}
+	if got.Query.Namespace != "" {
+		t.Errorf("a cluster-scoped object came back namespaced as %q", got.Query.Namespace)
+	}
+	// And without one, which is the normal call: a cluster-scoped kind must not demand
+	// a namespace.
+	bare, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{Kind: "StorageClass", Name: "fast"})
+	if err != nil {
+		t.Fatalf("a cluster-scoped kind must not require a namespace: %v", err)
+	}
+	if bare.Outcome != providers.ResourceFound {
+		t.Fatalf("outcome = %q (detail %q), want found", bare.Outcome, bare.Detail)
+	}
+	// The non-found endings need the same treatment: there is no object to take the
+	// identity from, so an invented namespace would otherwise be rendered alongside a
+	// statement the model treats as evidence ("StorageClass made-up/gone: ABSENT").
+	gone, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{
+		Kind: "StorageClass", Name: "gone", Namespace: "totally-made-up-ns"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if gone.Outcome != providers.ResourceAbsent {
+		t.Fatalf("outcome = %q, want absent", gone.Outcome)
+	}
+	if gone.Query.Namespace != "" {
+		t.Errorf("an absent cluster-scoped object came back namespaced as %q", gone.Query.Namespace)
+	}
+}
+
+// TestResourceSpecCanonicalisesTheKind: the resolved kind is echoed in the casing the
+// SERVER serves it under, so "vmservicescrape" off an alert comes back as
+// "VMServiceScrape" rather than being repeated as the caller mistyped it.
+func TestResourceSpecCanonicalisesTheKind(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "operator.victoriametrics.com", Version: "v1beta1", Resource: "vmservicescrapes"}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": gvr.GroupVersion().String(), "kind": "VMServiceScrape",
+		"metadata": map[string]any{"name": "rabbit", "namespace": "observability"},
+		"spec":     map[string]any{"jobLabel": "app"},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "VMServiceScrapeList"}, obj)
+	disco := discoServing(gvr.GroupVersion().String(),
+		metav1.APIResource{Name: gvr.Resource, Kind: "VMServiceScrape", Namespaced: true})
+	got, err := NewSpecReader(client, disco).ResourceSpec(context.Background(),
+		providers.ResourceSpecQuery{Kind: "vmservicescrape", Name: "rabbit", Namespace: "observability"})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Query.Kind != "VMServiceScrape" || got.Query.Group != gvr.Group {
+		t.Errorf("query echo = %+v, want the resolved kind and group", got.Query)
+	}
+}
+
+// TestResolveKindInvalidatesStaleDiscovery: discovery is memoised by a memcache client,
+// and memcache caches FAILURES as well as successes. Without an invalidation, a CRD
+// installed after RunLore started is kind_unknown for the pod's whole lifetime, and one
+// aggregated-APIService blip poisons a group forever — both of which read to the model as
+// "this cluster serves no such kind".
+func TestResolveKindInvalidatesStaleDiscovery(t *testing.T) {
+	d := &invalidatableDiscovery{
+		after: []*metav1.APIResourceList{{GroupVersion: "operator.victoriametrics.com/v1beta1",
+			APIResources: []metav1.APIResource{{Name: "vmservicescrapes", Kind: "VMServiceScrape", Namespaced: true}}}},
+	}
+	got, err := NewSpecReader(nil, d).resolveKind("VMServiceScrape")
+	if err != nil {
+		t.Fatalf("resolveKind: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("a kind served only after invalidation was not found: %+v (invalidated=%d)", got, d.invalidated)
+	}
+	if d.invalidated != 1 {
+		t.Errorf("Invalidate() called %d times, want exactly 1", d.invalidated)
+	}
+	// A kind that is genuinely unserved must not invalidate on EVERY call beyond the
+	// first retry — one refresh per miss, not a loop.
+	d2 := &invalidatableDiscovery{}
+	if _, err := NewSpecReader(nil, d2).resolveKind("Widget"); err != nil {
+		t.Fatalf("resolveKind: %v", err)
+	}
+	if d2.invalidated != 1 {
+		t.Errorf("Invalidate() called %d times for an unserved kind, want exactly 1", d2.invalidated)
+	}
+}
+
 // TestResourceSpecAmbiguousKindReadsNothing pins the choice to report an ambiguity rather
 // than resolve it. "Ingress" was served by both networking.k8s.io and extensions, and
 // picking one silently would read a DIFFERENT object than the caller meant and then
@@ -178,17 +546,71 @@ func TestResourceSpecAmbiguousKindReadsNothing(t *testing.T) {
 	}}
 	// nil client: an ambiguous kind must be refused before any read is attempted.
 	got, err := NewSpecReader(nil, disco).ResourceSpec(context.Background(),
-		providers.Workload{Kind: "Ingress", Name: "web", Namespace: "apps"})
+		providers.ResourceSpecQuery{Kind: "Ingress", Name: "web", Namespace: "apps"})
 	if err != nil {
 		t.Fatalf("ambiguity must be an outcome, not an error: %v", err)
 	}
-	if got.Outcome == providers.ResourceAbsent || got.Outcome == providers.ResourceFound {
-		t.Fatalf("outcome = %q: an ambiguous kind must not read or claim absence", got.Outcome)
+	// The exact outcome, not merely "neither absent nor found": ambiguity is its OWN
+	// ending, distinct from kind_unknown, because the caller's next move differs. An
+	// unknown kind means re-check the spelling; an ambiguous one means name the group.
+	if got.Outcome != providers.ResourceKindAmbiguous {
+		t.Fatalf("outcome = %q, want kind_ambiguous", got.Outcome)
 	}
-	for _, want := range []string{"more than one API group", "networking.k8s.io/v1", "extensions/v1beta1"} {
+	for _, want := range []string{"more than one API group", "networking.k8s.io", "extensions"} {
 		if !strings.Contains(got.Detail, want) {
 			t.Errorf("detail does not name the ambiguity (%q): %q", want, got.Detail)
 		}
+	}
+	// And it must be a DEAD END no longer: the detail has to tell the caller how to
+	// resolve it, with the argument that actually exists.
+	if !strings.Contains(got.Detail, "group") {
+		t.Errorf("an ambiguity the caller cannot resolve is a dead end: %q", got.Detail)
+	}
+}
+
+// TestResourceSpecGroupDisambiguates: the way OUT of an ambiguity. NetworkPolicy is
+// served by both networking.k8s.io and crd.projectcalico.org on any Calico cluster, and
+// it is one of the five examples in the issue this tool closes — so "ambiguous" had to
+// stop being a terminal answer.
+func TestResourceSpecGroupDisambiguates(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "networking.k8s.io/v1", "kind": "NetworkPolicy",
+		"metadata": map[string]any{"name": "deny-all", "namespace": "apps"},
+		"spec":     map[string]any{"podSelector": map[string]any{}},
+	}}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{gvr: "NetworkPolicyList"}, obj)
+	disco := fakeDiscovery{lists: []*metav1.APIResourceList{
+		{GroupVersion: "networking.k8s.io/v1", APIResources: []metav1.APIResource{
+			{Name: "networkpolicies", Kind: "NetworkPolicy", Namespaced: true}}},
+		{GroupVersion: "crd.projectcalico.org/v1", APIResources: []metav1.APIResource{
+			{Name: "networkpolicies", Kind: "NetworkPolicy", Namespaced: true}}},
+	}}
+	r := NewSpecReader(client, disco)
+	got, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{
+		Kind: "NetworkPolicy", Name: "deny-all", Namespace: "apps", Group: "networking.k8s.io",
+	})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if got.Outcome != providers.ResourceFound {
+		t.Fatalf("outcome = %q (detail %q), want found", got.Outcome, got.Detail)
+	}
+	if got.APIVersion != "networking.k8s.io/v1" {
+		t.Errorf("APIVersion = %q, want the group the caller asked for", got.APIVersion)
+	}
+	// A group nothing serves must not silently fall back to the other candidate —
+	// reading a DIFFERENT object than the caller named is the failure this tool exists
+	// to remove.
+	other, err := r.ResourceSpec(context.Background(), providers.ResourceSpecQuery{
+		Kind: "NetworkPolicy", Name: "deny-all", Namespace: "apps", Group: "nope.example.com",
+	})
+	if err != nil {
+		t.Fatalf("ResourceSpec: %v", err)
+	}
+	if other.Outcome == providers.ResourceFound {
+		t.Fatal("an unserved group fell back to another group's object")
 	}
 }
 
@@ -213,5 +635,26 @@ func TestResolveKindSkipsSubresourcesAndSurvivesPartialDiscovery(t *testing.T) {
 	// But a TOTAL discovery failure — nothing usable came back — must surface.
 	if _, err := NewSpecReader(nil, fakeDiscovery{err: errors.New("connection refused")}).resolveKind("Pod"); err == nil {
 		t.Error("a total discovery failure must be an error, not silently zero matches")
+	}
+}
+
+// TestRefusalAndResolutionAgreeOnFolding pins the equivalence the refusal RELIES on.
+//
+// The bypass in S2 was exactly this equivalence breaking: the refusal folded with
+// strings.ToLower while resolution folded with strings.EqualFold, and "ſecret" (U+017F)
+// sits in the gap — ToLower leaves it alone, EqualFold matches it against "Secret". Any
+// spelling that RESOLVES to a refused kind must also be REFUSED, or a bypass exists; any
+// spelling that does not resolve must not be refused, or ordinary kinds become unreadable.
+//
+// The post-resolution check covers a Secret reached under another Kind; this covers the
+// pre-check, which is what keeps a refused kind from ever reaching the client at all.
+func TestRefusalAndResolutionAgreeOnFolding(t *testing.T) {
+	for _, s := range []string{"Secret", "secret", "SECRET", "SeCrEt", "ſecret", "Secrets", "sealedsecret", "Sekret", ""} {
+		_, refused := refusalFor(s)
+		// strings.EqualFold is the matcher resolveKind uses against a served ar.Kind.
+		if want := strings.EqualFold("Secret", s); refused != want {
+			t.Errorf("refusalFor(%q) = %v, but resolution would match it = %v: "+
+				"the refusal and resolution fold differently, which is a bypass", s, refused, want)
+		}
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -241,7 +241,7 @@ type GitOpsInspector interface {
 	DependencyTree(ctx context.Context, w Workload) (DepNode, error)
 }
 
-// ResourceSpecOutcome distinguishes the four ways a spec read can end. They are
+// ResourceSpecOutcome distinguishes the ways a spec read can end. They are
 // SEPARATE values because conflating them is what made gitops_resource_status
 // dangerous: it answered "the object genuinely does not exist" for a kind it never
 // supported, and a model reasoned from that as evidence of absence. Only
@@ -250,11 +250,31 @@ type ResourceSpecOutcome string
 
 // The outcomes of a resource spec read.
 const (
-	ResourceFound       ResourceSpecOutcome = "found"        // the object was read
-	ResourceAbsent      ResourceSpecOutcome = "absent"       // the server says it does not exist
-	ResourceForbidden   ResourceSpecOutcome = "forbidden"    // RBAC denied the read; says NOTHING about existence
-	ResourceKindUnknown ResourceSpecOutcome = "kind_unknown" // this cluster serves no such kind; says NOTHING about existence
+	ResourceFound         ResourceSpecOutcome = "found"          // the object was read
+	ResourceAbsent        ResourceSpecOutcome = "absent"         // the server says this OBJECT does not exist
+	ResourceForbidden     ResourceSpecOutcome = "forbidden"      // RBAC denied the read; says NOTHING about existence
+	ResourceKindUnknown   ResourceSpecOutcome = "kind_unknown"   // this cluster serves no such kind; says NOTHING about existence
+	ResourceKindAmbiguous ResourceSpecOutcome = "kind_ambiguous" // several API groups serve this kind; nothing was read
+	ResourceRefused       ResourceSpecOutcome = "refused"        // this agent refuses the kind by policy (Secret)
 )
+
+// ResourceSpecQuery identifies the object to read.
+//
+// Kind is BARE ("VMServiceScrape") because that is what a model has: it reads the
+// kind off an alert or a manifest, not a fully-qualified resource. Group is the
+// optional disambiguator for the case where a bare Kind is served by more than one
+// API group — Event (core and events.k8s.io) and NetworkPolicy (networking.k8s.io
+// and crd.projectcalico.org) on any cluster running Calico. Without it, an
+// ambiguity would be a dead end: the reader refuses to guess, and the caller would
+// have no way to say which one it meant.
+type ResourceSpecQuery struct {
+	Kind      string
+	Name      string
+	Namespace string
+	// Group narrows resolution to one API group ("" means "no preference", and
+	// "core" is accepted as a spelling of the core group's empty name).
+	Group string
+}
 
 // ResourceSpec is one Kubernetes object's desired and observed state, as YAML.
 //
@@ -262,8 +282,12 @@ const (
 // ARBITRARY kinds — including CRDs the binary has never heard of — so there is no
 // Go type to unmarshal into.
 type ResourceSpec struct {
-	Workload Workload
-	Outcome  ResourceSpecOutcome
+	// Query echoes the request NORMALIZED to what was actually read: the Kind in
+	// the casing the server serves it under, the Group that answered, and NO
+	// namespace for a cluster-scoped kind. Rendering the request back verbatim
+	// would state a caller's mistake as fact — "StorageClass made-up-ns/fast".
+	Query   ResourceSpecQuery
+	Outcome ResourceSpecOutcome
 	// APIVersion the object was actually read at, so a reader can tell which of
 	// several served versions answered.
 	APIVersion string
@@ -283,10 +307,11 @@ type ResourceSpec struct {
 // from consequences — see the investigation that concluded a VMServiceScrape had been
 // deleted when its namespaceSelector simply pointed at a namespace that did not exist.
 //
-// Implementations MUST refuse Secret outright and MUST report RBAC denials as
-// ResourceForbidden rather than as absence.
+// Implementations MUST refuse Secret outright — both before AND after resolution, so a
+// kind that folds to "secret" cannot slip past the pre-check — and MUST report RBAC
+// denials as ResourceForbidden rather than as absence.
 type ResourceSpecReader interface {
-	ResourceSpec(ctx context.Context, w Workload) (ResourceSpec, error)
+	ResourceSpec(ctx context.Context, q ResourceSpecQuery) (ResourceSpec, error)
 }
 
 // MetricsProvider abstracts VictoriaMetrics/Prometheus (both speak PromQL).

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -241,6 +241,54 @@ type GitOpsInspector interface {
 	DependencyTree(ctx context.Context, w Workload) (DepNode, error)
 }
 
+// ResourceSpecOutcome distinguishes the four ways a spec read can end. They are
+// SEPARATE values because conflating them is what made gitops_resource_status
+// dangerous: it answered "the object genuinely does not exist" for a kind it never
+// supported, and a model reasoned from that as evidence of absence. Only
+// ResourceAbsent is evidence about the cluster's contents.
+type ResourceSpecOutcome string
+
+// The outcomes of a resource spec read.
+const (
+	ResourceFound       ResourceSpecOutcome = "found"        // the object was read
+	ResourceAbsent      ResourceSpecOutcome = "absent"       // the server says it does not exist
+	ResourceForbidden   ResourceSpecOutcome = "forbidden"    // RBAC denied the read; says NOTHING about existence
+	ResourceKindUnknown ResourceSpecOutcome = "kind_unknown" // this cluster serves no such kind; says NOTHING about existence
+)
+
+// ResourceSpec is one Kubernetes object's desired and observed state, as YAML.
+//
+// Spec and Status are rendered rather than typed because the point is to read
+// ARBITRARY kinds — including CRDs the binary has never heard of — so there is no
+// Go type to unmarshal into.
+type ResourceSpec struct {
+	Workload Workload
+	Outcome  ResourceSpecOutcome
+	// APIVersion the object was actually read at, so a reader can tell which of
+	// several served versions answered.
+	APIVersion string
+	Spec       string // .spec as YAML ("" when the kind has no spec, e.g. ConfigMap)
+	Status     string // .status as YAML ("" when absent)
+	// Detail carries the server's own message for a non-found outcome, so a denial
+	// reads as a denial rather than being flattened into "not found".
+	Detail string
+}
+
+// ResourceSpecReader reads one object's spec/status by kind, name and namespace.
+//
+// It exists because every other reader here answers "what is happening" while a large
+// class of incidents is "the spec says X and reality is Y": a Service selector matching
+// no pods, a scrape CR targeting an absent namespace, a NetworkPolicy with no egress to
+// kube-dns, an HPA on a metric that never reports. Those were previously only inferable
+// from consequences — see the investigation that concluded a VMServiceScrape had been
+// deleted when its namespaceSelector simply pointed at a namespace that did not exist.
+//
+// Implementations MUST refuse Secret outright and MUST report RBAC denials as
+// ResourceForbidden rather than as absence.
+type ResourceSpecReader interface {
+	ResourceSpec(ctx context.Context, w Workload) (ResourceSpec, error)
+}
+
 // MetricsProvider abstracts VictoriaMetrics/Prometheus (both speak PromQL).
 //
 // LabelValues is metric/label discovery: it answers "what exists?" so the agent

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -96,7 +96,72 @@ var rules = []rule{
 	{regexp.MustCompile(`(?i)(\bapikey\s+)[A-Za-z0-9+/]{20,}={0,2}`), `${1}[REDACTED]`},
 	// Sensitive key = value / key: value (the value is masked, the key kept). An
 	// env-var-style prefix (DB_SECRET, OPENAI_API_KEY) is allowed before the keyword.
-	{regexp.MustCompile(`(?i)([\w.\-]*(?:password|passwd|secret|api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|token|credentials?|dsn|connection[_-]?string)"?\s*[:=]\s*"?)([^\s"',}]+)`), `${1}[REDACTED]`},
+	{regexp.MustCompile(`(?i)([\w.\-]*(?:` + sensitiveKeywords + `)"?\s*[:=]\s*"?)([^\s"',}]+)`), `${1}[REDACTED]`},
+}
+
+// sensitiveKeywords is the vocabulary of key names whose VALUE is treated as a
+// credential. It is shared by the generic key=value rule above and by
+// SensitiveNameValues below, so the two cannot drift into disagreeing about what
+// counts as sensitive.
+const sensitiveKeywords = `password|passwd|secret|api[_-]?key|access[_-]?key|secret[_-]?key|` +
+	`private[_-]?key|client[_-]?secret|token|credentials?|dsn|connection[_-]?string`
+
+// sensitiveNameRE matches a NAME — not a key — that identifies a credential, for
+// the {name, value} shape SensitiveNameValues handles.
+//
+// It requires the keyword to be a whole SEGMENT of the name (delimited by a
+// non-alphanumeric character or an end of string) rather than any substring:
+// POSTGRES_PASSWORD and REDIS_AUTH match, while GIT_AUTHOR_NAME ("auth" + "or")
+// and TOKENIZER_MODE ("token" + "izer") do not. Masking those would plant a
+// spurious [REDACTED] in otherwise-correct evidence, which is not a safe failure.
+//
+// The vocabulary is the shared one plus three names that only ever appear as an
+// identifier and would be too broad as a free-text key: `auth` (REDIS_AUTH), `pwd`
+// and `passphrase`.
+var sensitiveNameRE = regexp.MustCompile(`(?i)(?:^|[^a-z0-9])(?:` + sensitiveKeywords + `|auth|pwd|passphrase)(?:$|[^a-z0-9])`)
+
+// SensitiveNameValues masks, IN PLACE, the `value` of every {name: …, value: …}
+// pair in a decoded object tree (map[string]any / []any, as unmarshalled from
+// YAML or JSON) whose `name` is credential-shaped.
+//
+// It exists because the string ruleset structurally cannot see this shape.
+// Secrets is KEY-NAME oriented: it masks `password: hunter2` because "password"
+// is the key. Kubernetes' EnvVar inverts that — the sensitive word is the VALUE
+// of `name`, and the credential sits under the literal key `value`, which is in
+// no keyword vocabulary:
+//
+//   - name: POSTGRES_PASSWORD
+//     value: pr0d-Pa55w0rd-x9      # untouched by Secrets
+//
+// The walk is over the whole tree rather than a fixed list of paths, because the
+// shape appears at spec.containers[] on a Pod, spec.template.spec.containers[] on
+// a Deployment, one level deeper again on a CronJob, and anywhere at all in an
+// operator CRD that embeds a PodSpec. It is deliberately NOT limited to `env`:
+// {name, value} with a credential name means the same thing wherever it appears.
+//
+// `valueFrom` (a secretKeyRef) is left alone: it names a Secret key rather than
+// carrying it, and the model needs to see WHICH secret a workload consumes.
+//
+// Idempotent: a value that is already the mask is left as it is.
+func SensitiveNameValues(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		if name, ok := t["name"].(string); ok && sensitiveNameRE.MatchString(name) {
+			// Any type of value, not just a string: a CRD may carry {name, value}
+			// with a non-string value, and masking must not depend on the shape of
+			// what is being masked.
+			if cur, has := t["value"]; has && cur != nil && cur != mask {
+				t["value"] = mask
+			}
+		}
+		for _, child := range t {
+			SensitiveNameValues(child)
+		}
+	case []any:
+		for _, child := range t {
+			SensitiveNameValues(child)
+		}
+	}
 }
 
 // Secrets masks secret-shaped substrings in s, returning the redacted text.

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -4,6 +4,7 @@ package redact
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -217,5 +218,76 @@ func TestApiKeyRedactionRequiresCredentialShape(t *testing.T) {
 		if got := Secrets(s); got != s {
 			t.Errorf("prose was over-redacted:\n  in:  %q\n  out: %q", s, got)
 		}
+	}
+}
+
+// TestSensitiveNameValuesMasksTheEnvVarShape closes the hole S1 reproduced: the
+// string ruleset is KEY-NAME oriented — it masks `password: hunter2` — while
+// Kubernetes' EnvVar inverts the shape. The sensitive word is the VALUE of `name`
+// and the credential sits under the literal key `value`, which is in no keyword
+// vocabulary, so `Secrets` walks straight past it.
+//
+// Before this walker, a Pod's `.spec.containers[].env[].value` reached the model
+// verbatim.
+func TestSensitiveNameValuesMasksTheEnvVarShape(t *testing.T) {
+	// The exact shape reproduced against the real redactor, with a value carrying
+	// NO recognizable prefix — a `ghp_`-shaped token would be masked by the string
+	// rules and prove nothing about this walker.
+	obj := map[string]any{"spec": map[string]any{"containers": []any{
+		map[string]any{"name": "app", "env": []any{
+			map[string]any{"name": "POSTGRES_PASSWORD", "value": "pr0d-Pa55w0rd-x9"},
+			map[string]any{"name": "REDIS_AUTH", "value": "hunter2hunter2"},
+			map[string]any{"name": "DB_PASSWORD", "value": "hunter2supersecret"},
+			// A reference is not a credential: valueFrom names a Secret key, it
+			// does not carry it, and masking it would blind the model to WHICH
+			// secret a workload consumes.
+			map[string]any{"name": "API_TOKEN", "valueFrom": map[string]any{
+				"secretKeyRef": map[string]any{"name": "api", "key": "token"}}},
+			// Benign env survives: over-redaction destroys otherwise-correct
+			// evidence, and the model needs to see ordinary configuration.
+			map[string]any{"name": "LOG_LEVEL", "value": "debug"},
+			map[string]any{"name": "GIT_AUTHOR_NAME", "value": "runlore"},
+			map[string]any{"name": "TOKENIZER_MODE", "value": "fast"},
+		}},
+	}}}
+	SensitiveNameValues(obj)
+
+	env := obj["spec"].(map[string]any)["containers"].([]any)[0].(map[string]any)["env"].([]any)
+	for i, want := range []string{mask, mask, mask, "", "debug", "runlore", "fast"} {
+		e := env[i].(map[string]any)
+		got, _ := e["value"].(string)
+		if got != want {
+			t.Errorf("env[%d] (%v): value = %q, want %q", i, e["name"], got, want)
+		}
+	}
+	// The reference itself is untouched, keys and all.
+	if ref := env[3].(map[string]any)["valueFrom"]; ref == nil {
+		t.Error("valueFrom reference was dropped; the model can no longer see which Secret is consumed")
+	}
+	// Idempotent, like every other pass here.
+	SensitiveNameValues(obj)
+	if got := env[0].(map[string]any)["value"]; got != mask {
+		t.Errorf("second pass changed a masked value: %q", got)
+	}
+}
+
+// TestSensitiveNameValuesReachesEveryEmbeddedPodSpec: the shape is not only a bare
+// Pod. A Deployment nests it under spec.template.spec, a CronJob two levels deeper,
+// and any operator CRD may embed a PodSpec wholesale — so the walk is over the
+// whole tree rather than a fixed list of paths.
+func TestSensitiveNameValuesReachesEveryEmbeddedPodSpec(t *testing.T) {
+	env := func() []any {
+		return []any{map[string]any{"name": "APP_SECRET", "value": "leakme-please-1234"}}
+	}
+	obj := map[string]any{"spec": map[string]any{
+		"template": map[string]any{"spec": map[string]any{
+			"initContainers":      []any{map[string]any{"name": "init", "env": env()}},
+			"containers":          []any{map[string]any{"name": "app", "env": env()}},
+			"ephemeralContainers": []any{map[string]any{"name": "dbg", "env": env()}},
+		}},
+	}}
+	SensitiveNameValues(obj)
+	if s := fmt.Sprint(obj); strings.Contains(s, "leakme-please-1234") {
+		t.Fatalf("a nested container env value survived:\n%s", s)
 	}
 }

--- a/website/content/docs/concepts/data-sources.md
+++ b/website/content/docs/concepts/data-sources.md
@@ -16,7 +16,7 @@ assumed).
 | Logs | `query_logs`, `logs_error_summary`, `discover_log_fields` | `LogsProvider` | VictoriaLogs (LogsQL) · Grafana Loki (LogQL) · Elasticsearch/OpenSearch (`_search` DSL) | `logs.url` (+ optional `logs.provider`) |
 | Network flows | `network_drops` | `NetworkProvider` | Cilium Hubble · AWS VPC Flow Logs · GCP Firewall Logs | `network.provider` |
 | Cloud control plane | `cloud_*` | `CloudProvider` | AWS (CloudTrail + EC2/ASG/EKS) | `cloud.provider` |
-| Kubernetes | `pod_status`, `kube_events`, `controller_logs`, `pod_logs` | `KubeReader`/`LogReader` | client-go | (in-cluster) |
+| Kubernetes | `pod_status`, `kube_events`, `controller_logs`, `pod_logs`, `resource_spec` | `KubeReader`/`LogReader`/`ResourceSpecReader` | client-go | (in-cluster) |
 | Knowledge | `kb_search` | catalog index | bleve BM25 | `catalog.*` |
 | Source repos | `source_diff` | built-in (go-git) | any git host over HTTPS (GitHub App auth) | `source_repos.allow` |
 

--- a/website/content/docs/integrations/data-sources/kubernetes.md
+++ b/website/content/docs/integrations/data-sources/kubernetes.md
@@ -4,8 +4,9 @@ weight: 306
 integration: {kind: kubernetes, id: kubernetes}
 ---
 
-**What it gives you** — `pod_status`, `kube_events`, `controller_logs` and `pod_logs`: the baseline
-cluster-introspection tools every investigation can reach for, via client-go.
+**What it gives you** — `pod_status`, `kube_events`, `controller_logs`, `pod_logs` and
+`resource_spec`: the baseline cluster-introspection tools every investigation can reach for, via
+client-go.
 
 ## How it's enabled
 
@@ -16,6 +17,10 @@ local run with no kubeconfig) simply leaves them unregistered; nothing else chan
 
 `controller_logs` is additionally gated on `gitops.engine: flux` — it exists to surface why a Flux
 controller failed to reconcile, so it isn't registered under `argocd`.
+
+`resource_spec` needs a **dynamic** client plus **discovery** (the typed clientset cannot read a
+CRD), and is left unregistered when either is unavailable — a tool that cannot answer must not
+exist, or its unanswerable questions get answered with a misleading negative.
 
 ## Verify it locally
 
@@ -42,6 +47,21 @@ kubectl -n runlore logs deploy/runlore | grep 'clientset unavailable'
   request for any other namespace is rejected at the app layer, not just denied by RBAC. The chart
   auto-defaults the app-layer allowlist to the RBAC namespace list, so the two stay in sync unless you
   override one.
+- **`resource_spec` reads one object's `.spec`/`.status` for any kind the cluster serves**, CRDs
+  included, resolving a bare `Kind` through discovery rather than a compiled-in table. Its four
+  endings are kept apart deliberately — `found`, `absent`, `forbidden`, `kind_unknown` — plus
+  `refused` and `kind_ambiguous`; **only `absent` is evidence that an object does not exist**. A
+  kind served by several API groups (`Event` everywhere, `NetworkPolicy` on a Calico cluster) reads
+  nothing and names the candidates; pass `group` to pick one.
+- **`resource_spec` is bounded by an RBAC allowlist, not by a wildcard.** `rbac.resourceSpecRules`
+  (chart values) grants `get` on the spec-bearing kinds it reads. `Secret` is refused by the tool
+  outright — before and after kind resolution — but the ClusterRole is the real boundary, so
+  **never** widen the list to `resources: ["*"]`: that includes `secrets`. A kind you have not
+  granted comes back as a *denial*, never as a missing object.
+- **A container's env values are masked structurally** on the way out (`name: POSTGRES_PASSWORD` /
+  `value: …`), because the secret-shaped-key ruleset cannot see a shape that puts the sensitive word
+  in the *value* of `name:`. `valueFrom` references are kept — the model still needs to see which
+  Secret a workload consumes.
 - Every pod's log fetch is bounded: up to 5 matching pods, 300 tail lines each, and every container is
   read explicitly (a pod with 2+ containers — an istio/linkerd/cloudsql sidecar, say — rejects a log
   request with no container named, so RunLore always names one).

--- a/website/content/docs/security/security-architecture.md
+++ b/website/content/docs/security/security-architecture.md
@@ -144,6 +144,15 @@ Slack / Stripe / Google / OpenAI-style / AWS key formats, `user:password@host` U
 **values under `data:`/`stringData:` of a `kind: Secret` manifest**, including one surfaced inside
 a `what_changed` git diff.
 
+One shape is **structural rather than textual**. The ruleset is key-name oriented — it masks
+`password: <value>` because the sensitive word is the *key*. A Kubernetes container's env inverts
+that: the sensitive word is the *value* of `name:`, and the credential sits under the literal key
+`value:`, which is in no keyword vocabulary. `redact.SensitiveNameValues` therefore walks the
+decoded object — every `{name, value}` pair, at any depth, so an embedded PodSpec in a CRD is
+covered too — and masks the value when the name is credential-shaped, **before** anything is
+marshalled to YAML. `resource_spec` applies it to every object it reads. A `valueFrom` reference is
+left intact: it names a Secret key rather than carrying it.
+
 > [!WARNING]
 > **Redaction is a mitigation, not a guarantee**
 >

--- a/website/content/docs/security/security-model.md
+++ b/website/content/docs/security/security-model.md
@@ -78,7 +78,10 @@ generic `*(password|secret|api_key|token|…): <value>` pairs, and the values un
 manifest's `data:`/`stringData:` block — including one surfaced inside a git diff. A masked
 Secret value is also **learned**: its base64 blob is decoded and both forms are scrubbed from the
 **whole payload**, so the same secret quoted decoded in a log line or encoded in an event does not
-outlive the manifest that names it.
+outlive the manifest that names it. One shape is masked **structurally** rather than textually: a
+container's `env` puts the sensitive word in the *value* of `name:` and the credential under the
+literal key `value:`, which no key-name rule can see, so `resource_spec` walks the decoded object
+and masks it before anything is rendered.
 
 > [!WARNING]
 > **Redaction is a mitigation, not a guarantee**
@@ -109,6 +112,14 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
   silent drift); leaving both at the defaults limits raw-log reads to the incident namespace plus
   `flux-system`. The app guard must stay a superset of the RBAC namespaces, or `pod_logs` is blocked at
   the app layer for namespaces RBAC would otherwise permit.
+- **`resource_spec`'s read-only kind allowlist:** `rbac.resourceSpecRules` grants `get` on the
+  spec-bearing kinds the tool reads (Services, workloads, NetworkPolicies, HPAs, PVCs, StorageClasses,
+  scrape CRs …). It is an **allowlist, never a wildcard**, on purpose: `resources: ["*"]` includes
+  `secrets`. The tool refuses the `Secret` kind before *and* after resolution — a spelling that
+  case-folds to "secret", and any resource literally named `secrets` in any API group, is refused —
+  but that is an application-layer policy. **RBAC is the boundary.** A kind missing from the list is
+  reported to the model as a *denial*, never as a missing object, so a gap degrades the tool instead
+  of fabricating evidence.
 - **Namespaced Role for actions:** only when `rbac.allowActions` is set, `get/patch` on
   `kustomizations`/`helmreleases` over `rbac.actionNamespaces` — a bounded, opt-in blast radius that
   must mirror `config.actions.allow.namespaces`.


### PR DESCRIPTION
Closes #505. Design context in #507. Constructive counterpart to #503.

RunLore reads pod status, events, logs, metrics, cloud state and GitOps objects — but **not the spec of an arbitrary Kubernetes object**. A large class of incidents is *"the spec says X and reality is Y"*: a Service selector matching no pods, a scrape CR targeting an absent namespace, a NetworkPolicy with no egress to kube-dns, an HPA on a metric nothing reports.

Those could only be inferred from consequences, and the inference goes wrong. An investigation concluded a `VMServiceScrape` had been deleted and advised restoring it from Git history, while the object sat in the cluster with a `namespaceSelector` pointing at a namespace that did not exist. One read of `.spec` settles it.

`resource_spec` takes a **bare Kind**, because that is what a model has: it reads `VMServiceScrape` off an alert, not a fully-qualified resource. Resolution goes through **discovery** rather than a compiled-in kind map, so an operator's CRD works with no code change — the limitation that makes the Flux/Argo CD inspectors blind to every kind they were not built with.

## The outcome taxonomy is the design, not a detail

Four endings, and only **one** is evidence about the cluster's contents:

| outcome | meaning |
|---|---|
| `found` | read it |
| `absent` | the API server says no such object |
| `forbidden` | RBAC denied it — **the object may well exist** |
| `kind_unknown` | this cluster serves no such kind |

Collapsing the last two into "not found" is precisely the defect #503 fixes, so the distinction is carried all the way into the text the model sees, together with an explicit statement of what the answer does *not* establish.

## Security

- **`Secret` is refused by kind**, before any client call. A Secret is entirely sensitive, so a redactor missing one pattern leaks the whole object: refusing fails closed, redacting fails open.
- Every rendered section passes `redact.Secrets` on the way out — the only line of defence for non-Secret kinds, whose specs can carry an inline credential.
- **RBAC is the boundary**, as for `pod_logs`, and a denial is reported as a denial.
- **An ambiguous kind** (two API groups serving it, e.g. `Ingress`) reads *nothing* and reports the candidates. Guessing would read a different object than the caller meant and describe it confidently.
- Sections are bounded so one object cannot consume the whole tool-output budget and evict the rest of the evidence.

## Worth knowing

The first implementation was wrong in exactly the way the issue is about: it resolved `GroupKind{Group: "", Kind: ...}`, so no CRD in any API group could ever be found. The happy-path test caught it.
