### PR TITLE
fix(notify): tell the human when a knowledge write failed

### DIFF
--- a/hack/check-screenshots-fresh.sh
+++ b/hack/check-screenshots-fresh.sh
@@ -72,8 +72,8 @@ DIGEST_AT_SHOT="f73e6221440fceab4e2bed088ec6cb72bbb6b827bb075e643b5fcae708d810cb
 #     and this fails, so an acknowledgement cannot silently become permanent.
 #
 # Clear it (set to "") in the same commit that lands retaken screenshots.
-ACKNOWLEDGED_DIGEST="3c84e7a74cd4e1581f4ea306fc8d5d133d73994e476866663f9109a474c6f7c4"
-ACKNOWLEDGED_REASON="#475 added a 'confidence not stated' variant for a finding that carries no confidence at all. Diffing the golden across the two renderers shows that variant is the ONLY thing that moved — every other fixture is byte-identical, and the stated-confidence line both captures actually show is unchanged. So neither image is WRONG, only incomplete: they cannot show a variant that did not exist when they were taken. Retake when a live workspace is next available."
+ACKNOWLEDGED_DIGEST="9fbc8ba3a250d4f2201b80c0a4ac5ba84e0303c786508bdba09807c700dee29b"
+ACKNOWLEDGED_REASON="#510 (closing #506) adds a 'curate_failed' variant: a finding whose knowledge-base write FAILED now says so in the card footer, next to the entry link. Diffing the golden shows the change is PURELY ADDITIVE — 108 inserted lines, zero deleted — so every fixture the captures depict is byte-identical, including both cards they actually show. Neither image is WRONG, only incomplete: they cannot show a footer arm that only appears when a forge write fails, which is not a state a capture session can stage. This supersedes the #475 acknowledgement, whose 'confidence not stated' variant is still equally absent and equally harmless. Retake when a live workspace is next available."
 
 for f in "${SHOTS[@]}" "$CARD_GOLDEN"; do
   [ -f "$f" ] || { echo "::error::$f is missing — update hack/check-screenshots-fresh.sh" >&2; exit 1; }

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -765,6 +765,14 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 	if cur != nil {
 		if ref, err := cur.Curate(context.Background(), found); err != nil {
 			log.Error("curate findings", "err", err)
+			// Carry the reason to delivery. Logging alone made this failure invisible to
+			// the human: an empty CuratedURL renders identically whether the write was
+			// skipped by design (below min_confidence, or a skip_verdicts verdict) or
+			// attempted and failed, and skipping is by far the common case. Observed live
+			// — an 85%-confidence finding whose KB PR 403'd was indistinguishable from a
+			// below-threshold one, and the operator only noticed because they happened to
+			// write a thread note, which DOES report the failure.
+			found.CurateError = err.Error()
 		} else if ref.URL != "" {
 			found.CuratedURL = ref.URL
 			log.Info("curated", "url", ref.URL)

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Smana/runlore/internal/providers"
 	awscloud "github.com/Smana/runlore/internal/providers/cloud/aws"
 	"github.com/Smana/runlore/internal/providers/cluster"
+	"github.com/Smana/runlore/internal/redact"
 	"github.com/Smana/runlore/internal/sourcerepo"
 	"github.com/Smana/runlore/internal/telemetry"
 	"github.com/Smana/runlore/internal/whatchanged"
@@ -764,7 +765,23 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 	// findings are still delivered.
 	if cur != nil {
 		if ref, err := cur.Curate(context.Background(), found); err != nil {
-			log.Error("curate findings", "err", err)
+			// Redacted ONCE, here, for both uses below.
+			//
+			// The egress chokepoint has already run. investigate.LoopInvestigator.deliver
+			// calls redactInvestigation and THEN OnComplete, so anything stamped onto
+			// `found` from here on has missed it — which would give CurateError the
+			// treatment of a redactionSkipField entry without being on that list, and
+			// falsify notify/templated's "the Investigation is already secret-redacted
+			// before any notifier runs". Every sink redacts again at render today, so
+			// there is no live leak; there would be one the moment curate_error is added
+			// to notify.Payload, which is the natural answer to #506's second ask.
+			// redact.Secrets is idempotent, so the render-site calls stay.
+			//
+			// The log line needs it just as much: a forge error carries a
+			// server-provided body, and this wrote it — credential and all — into
+			// whatever aggregator collects RunLore's logs.
+			reason := redact.Secrets(err.Error())
+			log.Error("curate findings", "err", reason)
 			// Carry the reason to delivery. Logging alone made this failure invisible to
 			// the human: an empty CuratedURL renders identically whether the write was
 			// skipped by design (below min_confidence, or a skip_verdicts verdict) or
@@ -772,7 +789,7 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 			// — an 85%-confidence finding whose KB PR 403'd was indistinguishable from a
 			// below-threshold one, and the operator only noticed because they happened to
 			// write a thread note, which DOES report the failure.
-			found.CurateError = err.Error()
+			found.CurateError = reason
 		} else if ref.URL != "" {
 			found.CuratedURL = ref.URL
 			log.Info("curated", "url", ref.URL)

--- a/internal/app/oncomplete_test.go
+++ b/internal/app/oncomplete_test.go
@@ -6,8 +6,12 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,6 +37,16 @@ type stubCurator struct{ url string }
 
 func (s stubCurator) Curate(context.Context, providers.Investigation) (providers.Ref, error) {
 	return providers.Ref{URL: s.url}, nil
+}
+
+// failingCurator stands in for a curator whose forge write was ATTEMPTED and failed —
+// the branch stubCurator can never reach. Both are needed: the fix for #506 turns on
+// telling a failed write apart from a skipped one, and a stub that only ever succeeds
+// leaves the whole distinction untested.
+type failingCurator struct{ err error }
+
+func (c failingCurator) Curate(context.Context, providers.Investigation) (providers.Ref, error) {
+	return providers.Ref{}, c.err
 }
 
 // openLine is the subset of a ledger open event the recurrence pointers read back.
@@ -130,6 +144,100 @@ func TestOnCompleteStampsRecurrenceAndPersistsOpen(t *testing.T) {
 	}
 	if last.Verdict != string(providers.VerdictActionRequired) {
 		t.Errorf("last open Verdict = %q, want %q", last.Verdict, providers.VerdictActionRequired)
+	}
+}
+
+// TestOnCompleteCarriesCurateFailureToDelivery pins the WIRING #506's fix depends on,
+// which nothing asserted: that the error branch stamps the reason onto the delivered
+// investigation, and — the half that gives the field its meaning — that the success
+// branch leaves it empty.
+//
+// Without the second assertion the field could be set unconditionally and every card
+// would warn about a write that in fact landed, which is a worse failure than the
+// silence it replaces: an operator who learns to ignore the warning has lost the signal
+// permanently.
+func TestOnCompleteCarriesCurateFailureToDelivery(t *testing.T) {
+	newLedger := func(t *testing.T) *outcome.Ledger {
+		t.Helper()
+		l, err := outcome.New(filepath.Join(t.TempDir(), "outcomes.jsonl"))
+		if err != nil {
+			t.Fatalf("new ledger: %v", err)
+		}
+		return l
+	}
+	found := providers.Investigation{Title: "disk pressure", Fingerprint: "fp1", TriggerKey: "k"}
+
+	t.Run("failed write is carried to the sink", func(t *testing.T) {
+		sink := &captureNotifier{}
+		cur := failingCurator{err: errors.New(
+			"open PR: github GET /repos/o/kb/git/ref/heads/main: status 403: Resource not accessible by integration")}
+		onInvestigationComplete(context.Background(), found, newLedger(t), nil, cur,
+			notify.NewMulti(discardLog(), sink), nil, nil, nil, discardLog())
+
+		if sink.got.CurateError == "" {
+			t.Fatal("a failed curate write reached delivery with no reason: the card cannot " +
+				"tell it apart from a write that was never attempted")
+		}
+		if !strings.Contains(sink.got.CurateError, "403") {
+			t.Errorf("delivered CurateError = %q, want the forge's own reason", sink.got.CurateError)
+		}
+		// A failure must never also claim a link — the two are mutually exclusive states.
+		if sink.got.CuratedURL != "" {
+			t.Errorf("delivered CuratedURL = %q after a failed write, want empty", sink.got.CuratedURL)
+		}
+	})
+
+	t.Run("successful write leaves it empty", func(t *testing.T) {
+		sink := &captureNotifier{}
+		onInvestigationComplete(context.Background(), found, newLedger(t), nil,
+			stubCurator{url: "https://kb/new"}, notify.NewMulti(discardLog(), sink),
+			nil, nil, nil, discardLog())
+
+		if sink.got.CurateError != "" {
+			t.Errorf("delivered CurateError = %q after a SUCCESSFUL write: the card would warn "+
+				"about a write that landed", sink.got.CurateError)
+		}
+		if sink.got.CuratedURL != "https://kb/new" {
+			t.Errorf("delivered CuratedURL = %q, want the link curate produced", sink.got.CuratedURL)
+		}
+	})
+}
+
+// TestOnCompleteRedactsTheCurateError pins the one thing this assignment does that no
+// other field on the delivered Investigation does: it runs AFTER the single egress
+// chokepoint.
+//
+// investigate.LoopInvestigator.deliver calls redactInvestigation and THEN OnComplete, so
+// a string stamped on here has already missed it — silently giving CurateError the
+// treatment of a redactionSkipField entry without being on that list, and falsifying
+// notify/templated's "the Investigation is already secret-redacted before any notifier
+// runs". No sink leaks it today only because each one redacts again at render; the leak
+// arrives the moment anyone adds curate_error to notify.Payload, which is the natural
+// answer to #506's second ask.
+//
+// The same redaction covers the log line, which until now wrote the raw forge body —
+// credential included — into whatever aggregator collects RunLore's logs.
+func TestOnCompleteRedactsTheCurateError(t *testing.T) {
+	const token = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	ledger, err := outcome.New(filepath.Join(t.TempDir(), "outcomes.jsonl"))
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	var logs strings.Builder
+	log := slog.New(slog.NewTextHandler(&logs, nil))
+
+	sink := &captureNotifier{}
+	cur := failingCurator{err: fmt.Errorf("open PR: bad credentials %s", token)}
+	onInvestigationComplete(context.Background(),
+		providers.Investigation{Title: "t", Fingerprint: "fp1", TriggerKey: "k"},
+		ledger, nil, cur, notify.NewMulti(discardLog(), sink), nil, nil, nil, log)
+
+	if strings.Contains(sink.got.CurateError, token) {
+		t.Errorf("CurateError reached the notifier unredacted — it is stamped AFTER "+
+			"redactInvestigation, so nothing else will scrub it: %q", sink.got.CurateError)
+	}
+	if strings.Contains(logs.String(), token) {
+		t.Errorf("the raw forge body, credential and all, was written to the log store:\n%s", logs.String())
 	}
 }
 

--- a/internal/httpx/redact.go
+++ b/internal/httpx/redact.go
@@ -94,6 +94,19 @@ const maxErrorBody = 512
 // Stripping happens BEFORE the cap so a credential straddling the cut cannot
 // leave a fragment behind. Empty secrets are ignored, so a caller can pass an
 // optional token unguarded.
+//
+// KNOWN GAP, and it is the reason this ordering is only half the guarantee: the
+// strip is exact-string replacement of the credentials the CALLER knew about.
+// A secret the caller did not pass — another tenant's token quoted back by a
+// proxy, a bearer header echoed by a debug endpoint — is only findable by
+// pattern, and the only pattern matcher is redact.Secrets, which runs much
+// later on err.Error() at each egress site. By then this byte-cut has already
+// happened, so such a credential straddling offset 512 arrives there as a
+// fragment shorter than redact.Secrets's {20,} quantifiers and passes through
+// unmasked. Closing it means running redact.Secrets here, before the cut,
+// rather than relying on the callers' secret lists; the cap is a per-line
+// budget, and moving the redaction under it is a change to every caller's error
+// text, so it is recorded rather than made in passing.
 func SafeErrorBody(body []byte, secrets ...string) string {
 	s := string(body)
 	for _, sec := range secrets {

--- a/internal/notify/card_golden_test.go
+++ b/internal/notify/card_golden_test.go
@@ -63,6 +63,10 @@ var updateCardGolden = flag.Bool("update-card-golden", false,
 //	                       at all, which bolds the whole phrase instead of a level
 //	bare_recall            a recall with no Prior and no alert name: the header falls
 //	                       back to the title and the whole card collapses to its minimum
+//	curate_failed          #506's card: a finding well above the curation bar whose KB
+//	                       write FAILED, so the footer carries the ⚠️ reason next to the
+//	                       prior entry's link — the arm that distinguishes a broken
+//	                       learning loop from a deliberately skipped write
 //
 // Times are fixed constants: slackDate emits a <!date^…> token built from a Unix
 // timestamp, so a time.Now() anywhere here would rewrite the golden on every run.
@@ -226,6 +230,37 @@ func cardGoldenFixtures() []struct {
 			Recalled:   true,
 			RootCauses: []providers.Hypothesis{{Summary: "the migration lock again"}},
 		}},
+
+		// The live #506 card: 85% confidence, action_suggested — comfortably above
+		// curate.min_confidence and not in skip_verdicts — whose KB PR got a 403. It
+		// carries PrevCuratedURL so the footer holds BOTH arms open at once: the prior
+		// entry's link, which on its own would read as this run's, and the ⚠️ reason
+		// that says it is not.
+		{"curate_failed", providers.Investigation{
+			Title:      "argocd-repo-server OOMKilled after the 2.11 bump",
+			AlertName:  "ArgoCDRepoServerDown",
+			Verdict:    providers.VerdictActionSuggested,
+			Confidence: 0.85,
+			Severity:   "warning",
+			Cluster:    "eu-west-1",
+			Resource:   providers.Workload{Kind: "Deployment", Namespace: "argocd", Name: "argocd-repo-server"},
+			StartedAt:  started,
+			RootCauses: []providers.Hypothesis{{
+				Summary:         "2.11 raised the manifest cache footprint past the 512Mi limit",
+				Confidence:      0.85,
+				Evidence:        []string{"container exit code 137 at 14:17"},
+				SuggestedAction: "raise the repo-server memory limit to 1Gi",
+				Reversible:      true,
+			}},
+			CurateError:    `open PR: github GET /repos/o/kb/git/ref/heads/main: status 403: {"message":"Resource not accessible by integration"}`,
+			PrevCuratedURL: "https://github.com/o/kb/pull/271",
+			TriggerKey:     "ArgoCDRepoServerDown/argocd/argocd-repo-server",
+			Occurrences:    2,
+			LastOccurrence: lastSeen,
+			Usage: providers.UsageTotals{
+				ModelCalls: 5, InputTokens: 51204, OutputTokens: 3117,
+			},
+		}},
 	}
 }
 
@@ -306,32 +341,33 @@ func TestSlackCardMatchesTheShippedGolden(t *testing.T) {
 func TestCardGoldenCoversEveryRenderedBranch(t *testing.T) {
 	rendered := string(renderCardGolden(t))
 	for _, want := range []string{
-		"Action required",       // verdictBadge, conclusive
-		"Inconclusive",          // verdictBadge, inconclusive arm
-		"confidence not stated", // the #475 unstated variant
-		"confidence*",           // the ordinary stated variant (level bolded, pct outside)
-		"Instant recall",        // Prior + Recalled
-		"Known cause",           // the recall labels
-		"Validated resolution",  //
-		"Seen before",           // Prior without Recalled
-		"Prior cause",           // the recurrence labels
-		"resolve rate",          // PriorKnowledge.Recalls
-		"Matches known runbook", // MatchedKnowledge with Prior nil
-		"Why:",                  // top root cause
-		"more hypothesis below", // the deeper-hypotheses pointer
-		"Suggested next steps",  // nextSteps
-		"Full analysis",         // detailBlocks
-		"What changed:",         // Hypothesis.ChangeRef
-		"Open questions",        // Unresolved
-		"Data gaps",             // DataGaps
-		"Ruled out",             // RuledOut
-		"verified",              // the footer's verify marker
-		"model calls",           // usageFooter
-		"Proposed action",       // an action awaiting approval
-		"Approve",               //
-		"👍 Accurate",            // feedbackBlocks
-		"…1 more",               // evidence / next-step overflow
-		"<!date^",               // slackDate, which is why the fixtures fix their times
+		"Action required",                      // verdictBadge, conclusive
+		"Inconclusive",                         // verdictBadge, inconclusive arm
+		"confidence not stated",                // the #475 unstated variant
+		"confidence*",                          // the ordinary stated variant (level bolded, pct outside)
+		"Instant recall",                       // Prior + Recalled
+		"Known cause",                          // the recall labels
+		"Validated resolution",                 //
+		"Seen before",                          // Prior without Recalled
+		"Prior cause",                          // the recurrence labels
+		"resolve rate",                         // PriorKnowledge.Recalls
+		"Matches known runbook",                // MatchedKnowledge with Prior nil
+		"Why:",                                 // top root cause
+		"more hypothesis below",                // the deeper-hypotheses pointer
+		"Suggested next steps",                 // nextSteps
+		"Full analysis",                        // detailBlocks
+		"What changed:",                        // Hypothesis.ChangeRef
+		"Open questions",                       // Unresolved
+		"Data gaps",                            // DataGaps
+		"Ruled out",                            // RuledOut
+		"verified",                             // the footer's verify marker
+		"could not save to the knowledge base", // the failed-curate footer arm (#506)
+		"model calls",                          // usageFooter
+		"Proposed action",                      // an action awaiting approval
+		"Approve",                              //
+		"👍 Accurate",                           // feedbackBlocks
+		"…1 more",                              // evidence / next-step overflow
+		"<!date^",                              // slackDate, which is why the fixtures fix their times
 	} {
 		if !contains(rendered, want) {
 			t.Errorf("no fixture reaches the branch that renders %q — the golden's digest "+

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -20,7 +20,65 @@ import (
 // operator which class of failure it was (auth, rate limit, validation). Deliberately
 // well under Slack's 3000-char section limit, because this line shares that budget with
 // the entire finding it is appended to.
+//
+// 300 and not the ~120 a "which class was it" pointer sounds like it needs, because
+// truncate cuts the HEAD: a wrapped Go error puts the diagnosis LAST
+// ("open PR: github GET /repos/o/r/git/ref/heads/main: status 403: Resource not
+// accessible by integration" is already 118 runes with a two-character owner/repo), so a
+// 120-rune cap would reliably keep the call site and drop the status and the message —
+// the only two things an operator can act on. The soft-wrap forgery a tighter cap would
+// have addressed is closed by the inline code span instead (see curateFailureReason).
 const curateErrorRunes = 300
+
+// curateFailureReason renders inv.CurateError into the one form every surface prints,
+// or "" when there is nothing to report. Both call sites go through it so the Slack
+// card and Format cannot drift into telling a human two different things — the drift
+// that made the first version of this fix miss the Slack card entirely, which is the
+// exact surface #506 reports.
+//
+// redact → strip backticks → flatten → cap, the same order and for the same reasons as
+// thread.chatSafe. A forge error carries a server-provided JSON body, so:
+//
+//   - redact.Secrets FIRST, because it may echo the credential it rejected, and running
+//     it before the cap means a cut can never hand it a half-token it no longer matches;
+//   - backticks become apostrophes, because every render site wraps the result in an
+//     inline code span and a backtick inside would close it early (notify's own codeRe
+//     is `([^`\n]+)`, so one backtick is all it takes). Apostrophe, not deletion, so the
+//     rune count and the reading of a quoted identifier both survive;
+//   - thread.SingleLine, not a local flattener, because a line break inside the body
+//     would put that text at the left margin where RunLore's own status lines sit — and
+//     a second copy of the mandatory-break class list is exactly the drift
+//     notify.kbUpdateAnnouncement documents having been bitten by;
+//   - cap LAST so it holds unconditionally.
+//
+// The inline code span the callers add is the fourth measure, and it is what flattening
+// alone does not buy: a reason this long soft-wraps in every client, and a continuation
+// line starts at the left margin with no quote bar (unlike thread.QuoteUntrusted, whose
+// "> " prefix survives wrapping). A padded body could otherwise put a forged
+// "📚 Knowledge base: https://evil…" at the start of a visual line. Inside a code span it
+// is <code> on Matrix and monospaced-with-a-background on Slack — visibly not RunLore's
+// own voice — and it degrades to literal backticks on the CLI, a surface with one reader
+// who ran the command themselves.
+//
+// The forge's own words are kept rather than classified into "auth / rate limit /
+// validation" deliberately. Classifying would need a parser over forge error strings —
+// a second, narrower copy of a vocabulary this package does not own, the same drift the
+// bullets above exist to avoid — and it would drop "Resource not accessible by
+// integration", the half that told the operator the fix was a GitHub App permission and
+// not a broken token. This is also not new egress: internal/thread already posts
+// err.Error() from the same forge client into the same room, uncapped and unredacted
+// (responder.go, "I could not save that to the knowledge base"), and #506 quotes that
+// message as the thing that worked. If server-supplied topology (internal DNS, RFC1918,
+// a GHE proxy banner) is judged too much for a chat room, that is a property of every
+// forge error RunLore already publishes and belongs in redact as a topology filter at
+// the single egress chokepoint — not as a special case on this one line.
+func curateFailureReason(inv providers.Investigation) string {
+	if inv.CurateError == "" {
+		return ""
+	}
+	safe := strings.ReplaceAll(redact.Secrets(inv.CurateError), "`", "'")
+	return truncate(thread.SingleLine(safe), curateErrorRunes)
+}
 
 // verdictBadge maps a model verdict to its emoji + human label. Empty/unknown
 // verdicts return ("", "") and are rendered nowhere — never invent a verdict.
@@ -219,15 +277,11 @@ func Format(inv providers.Investigation) string {
 	// deployment until an operator happened to write a thread note (that path DOES report
 	// it). The counter for alerting already exists: runlore_curations_total{result="error"}.
 	//
-	// redact → flatten → cap, the same order and for the same reasons as thread.chatSafe:
-	// a forge error carries a server-provided JSON body, so it may echo a credential, and
-	// a line break inside it would put that text at the left margin where RunLore's own
-	// status lines sit. thread.SingleLine rather than a local flattener on purpose — a
-	// second copy of the mandatory-break class list is exactly the drift
-	// notify.kbUpdateAnnouncement documents having been bitten by.
-	if inv.CurateError != "" {
-		fmt.Fprintf(&b, "⚠️ Could not save to the knowledge base: %s\n",
-			truncate(thread.SingleLine(redact.Secrets(inv.CurateError)), curateErrorRunes))
+	// The Slack card renders the same fact in its footer (slack.go, summaryBlocks step 8);
+	// both go through curateFailureReason, which is where the safety measures and the
+	// reasoning for them live.
+	if reason := curateFailureReason(inv); reason != "" {
+		fmt.Fprintf(&b, "⚠️ Could not save to the knowledge base: `%s`\n", reason)
 	}
 	if foot := usageFooter(inv.Usage); foot != "" {
 		fmt.Fprintf(&b, "%s\n", foot)

--- a/internal/notify/format.go
+++ b/internal/notify/format.go
@@ -10,7 +10,17 @@ import (
 	"time"
 
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
+	"github.com/Smana/runlore/internal/thread"
 )
+
+// curateErrorRunes caps the rendered curate-failure reason. It is a DIAGNOSTIC pointer,
+// not the payload: the full error is in the logs and the failure is counted by
+// runlore_curations_total{result="error"}, so the card only needs enough to tell an
+// operator which class of failure it was (auth, rate limit, validation). Deliberately
+// well under Slack's 3000-char section limit, because this line shares that budget with
+// the entire finding it is appended to.
+const curateErrorRunes = 300
 
 // verdictBadge maps a model verdict to its emoji + human label. Empty/unknown
 // verdicts return ("", "") and are rendered nowhere — never invent a verdict.
@@ -200,6 +210,24 @@ func Format(inv providers.Investigation) string {
 	}
 	if inv.CuratedURL != "" {
 		fmt.Fprintf(&b, "📚 Knowledge base: %s\n", inv.CuratedURL)
+	}
+	// The mirror of the line above, and the reason it exists: an EMPTY CuratedURL is
+	// ambiguous. It is the normal state for a finding below curate.min_confidence or
+	// carrying a skip_verdicts verdict — by far the common case — so "no KB link" cannot
+	// tell a human whether the learning loop is working. Without this line a failed write
+	// is indistinguishable from a skipped one, which is how a 403 ran unnoticed on a live
+	// deployment until an operator happened to write a thread note (that path DOES report
+	// it). The counter for alerting already exists: runlore_curations_total{result="error"}.
+	//
+	// redact → flatten → cap, the same order and for the same reasons as thread.chatSafe:
+	// a forge error carries a server-provided JSON body, so it may echo a credential, and
+	// a line break inside it would put that text at the left margin where RunLore's own
+	// status lines sit. thread.SingleLine rather than a local flattener on purpose — a
+	// second copy of the mandatory-break class list is exactly the drift
+	// notify.kbUpdateAnnouncement documents having been bitten by.
+	if inv.CurateError != "" {
+		fmt.Fprintf(&b, "⚠️ Could not save to the knowledge base: %s\n",
+			truncate(thread.SingleLine(redact.Secrets(inv.CurateError)), curateErrorRunes))
 	}
 	if foot := usageFooter(inv.Usage); foot != "" {
 		fmt.Fprintf(&b, "%s\n", foot)

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -466,3 +466,75 @@ func TestFormatUsageFooter(t *testing.T) {
 		t.Fatalf("a zero-usage investigation must omit the footer:\n%s", out)
 	}
 }
+
+// TestFormatCurateFailureIsVisible pins the reason this line exists at all: an EMPTY
+// CuratedURL is ambiguous. It is the normal state for a finding below
+// curate.min_confidence or carrying a skip_verdicts verdict, so a human cannot tell a
+// SKIPPED knowledge write from a FAILED one — which is how a 403 ran unnoticed on a live
+// deployment until an operator happened to write a thread note, the one path that already
+// reported it.
+//
+// The mutation this guards is precisely the old behaviour: the curate error being logged
+// at the call site and dropped instead of carried onto the investigation.
+func TestFormatCurateFailureIsVisible(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.CurateError = "open PR: github GET /repos/o/r/git/ref/heads/main: status 403: Resource not accessible by integration"
+	out := Format(inv)
+	if !strings.Contains(out, "Could not save to the knowledge base") {
+		t.Fatalf("a failed curate write is invisible on the card:\n%s", out)
+	}
+	if !strings.Contains(out, "403") {
+		t.Fatalf("the reason must say WHICH failure it was, so an operator can act:\n%s", out)
+	}
+	// A successful write and a failed one are mutually exclusive states; rendering both
+	// would tell the human two contradictory things about the same finding.
+	if strings.Contains(out, "📚 Knowledge base:") {
+		t.Fatalf("rendered a KB link alongside a curate failure:\n%s", out)
+	}
+}
+
+// TestFormatCurateFailureIsFlattenedAndRedacted pins the two properties that make this
+// line safe to print, both inherited from thread.chatSafe's ordering (redact → flatten →
+// cap) rather than re-derived here.
+//
+// Flattening is not cosmetic: a forge error carries a server-provided JSON body, and a
+// line break inside it would put that text at the LEFT MARGIN, where RunLore's own status
+// lines sit — the forged-headline class that notify.kbUpdateAnnouncement was bitten by.
+// U+2028 is included because a line is not only what "\n" separates.
+func TestFormatCurateFailureIsFlattenedAndRedacted(t *testing.T) {
+	for _, brk := range []string{"\n", "\r", " ", " ", "\v", "\f"} {
+		inv := sampleInvestigation()
+		inv.CurateError = "open PR: forbidden" + brk + "📚 Knowledge base: https://evil.example/forged"
+		out := Format(inv)
+		for _, line := range strings.Split(out, "\n") {
+			if strings.HasPrefix(line, "📚 Knowledge base: https://evil.example") {
+				t.Fatalf("break %q let error text forge a status line at the left margin:\n%s", brk, out)
+			}
+		}
+	}
+	// A forge error can echo the credential it was rejected for. Redaction runs BEFORE
+	// capping, so a cut cannot hand redact.Secrets a half-token it no longer matches.
+	inv := sampleInvestigation()
+	inv.CurateError = "open PR: bad credentials for ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	if out := Format(inv); strings.Contains(out, "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB") {
+		t.Fatalf("a credential echoed by the forge reached the card verbatim:\n%s", out)
+	}
+}
+
+// TestFormatCurateFailureIsCapped pins the cap to a literal rather than to itself: the
+// assertion fails if curateErrorRunes is raised, which is the point — this line shares
+// Slack's 3000-char section budget with the whole finding it is appended to.
+func TestFormatCurateFailureIsCapped(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.CurateError = strings.Repeat("x", 5000)
+	out := Format(inv)
+	if n := len([]rune(out)); n > 2000 {
+		t.Fatalf("card grew to %d runes; the curate reason is not capped", n)
+	}
+	if curateErrorRunes > 500 {
+		t.Fatalf("curateErrorRunes = %d: too large a share of Slack's section budget", curateErrorRunes)
+	}
+	if !strings.Contains(out, "…") {
+		t.Fatalf("a cut reason must show it was cut:\n%s", out)
+	}
+}

--- a/internal/notify/format_test.go
+++ b/internal/notify/format_test.go
@@ -493,31 +493,139 @@ func TestFormatCurateFailureIsVisible(t *testing.T) {
 	}
 }
 
-// TestFormatCurateFailureIsFlattenedAndRedacted pins the two properties that make this
-// line safe to print, both inherited from thread.chatSafe's ordering (redact → flatten →
-// cap) rather than re-derived here.
+// curateLinePrefix is the scaffolding Format writes ahead of the reason. Tests locate
+// the rendered line by it rather than by index, so an added footer line cannot silently
+// move an assertion onto the wrong text.
+const curateLinePrefix = "⚠️ Could not save to the knowledge base: "
+
+// curateLine returns the single rendered curate-failure line, minus its prefix.
 //
-// Flattening is not cosmetic: a forge error carries a server-provided JSON body, and a
-// line break inside it would put that text at the LEFT MARGIN, where RunLore's own status
-// lines sit — the forged-headline class that notify.kbUpdateAnnouncement was bitten by.
-// U+2028 is included because a line is not only what "\n" separates.
-func TestFormatCurateFailureIsFlattenedAndRedacted(t *testing.T) {
-	for _, brk := range []string{"\n", "\r", " ", " ", "\v", "\f"} {
-		inv := sampleInvestigation()
-		inv.CurateError = "open PR: forbidden" + brk + "📚 Knowledge base: https://evil.example/forged"
-		out := Format(inv)
-		for _, line := range strings.Split(out, "\n") {
-			if strings.HasPrefix(line, "📚 Knowledge base: https://evil.example") {
-				t.Fatalf("break %q let error text forge a status line at the left margin:\n%s", brk, out)
-			}
+// Splitting on "\n" here is legitimate in a way it was NOT as the flattening oracle:
+// this locates RunLore's OWN line, whose position is not in question. The oracle that
+// asks "did the reason stay on one line" has to look at the reason itself — see
+// TestFormatCurateFailureIsFlattened.
+func curateLine(t *testing.T, out string) string {
+	t.Helper()
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.HasPrefix(ln, curateLinePrefix) {
+			return strings.TrimPrefix(ln, curateLinePrefix)
 		}
 	}
-	// A forge error can echo the credential it was rejected for. Redaction runs BEFORE
-	// capping, so a cut cannot hand redact.Secrets a half-token it no longer matches.
+	t.Fatalf("no curate-failure line in:\n%s", out)
+	return ""
+}
+
+// TestFormatCurateFailureIsFlattened pins that no break rune inside a forge error can
+// put its text at the LEFT MARGIN, where RunLore's own status lines sit — the
+// forged-headline class that notify.kbUpdateAnnouncement was bitten by. A line is not
+// only what "\n" separates, which is why the class list runs past \r into the Unicode
+// separators and the other C0 breaks.
+//
+// The oracle is the RENDERED LINE, not strings.Split(out, "\n"). The earlier version of
+// this test looped over the same six breaks but detected with a split on "\n", so only
+// the "\n" arm could ever fail: replacing thread.SingleLine with
+// strings.ReplaceAll(s, "\n", " ") — precisely the "second, narrower copy of the break
+// list" this fix exists to avoid — passed the entire notify suite. Both assertions below
+// fail under that mutation, for every arm but the first.
+func TestFormatCurateFailureIsFlattened(t *testing.T) {
+	const forged = "📚 Knowledge base: https://evil.example/forged"
+	// Written as escapes, never as literal glyphs: five of these are invisible in a
+	// diff, and a reviewer cannot check a class list they cannot see.
+	for _, brk := range []string{
+		"\n", "\r", "\v", "\f", // C0 breaks
+		"\u2028", "\u2029", "\u0085", // Unicode line / paragraph / next-line separators
+		"\u200b", "\u202e", // Cf: zero-width space, and the bidi override that reorders a line
+	} {
+		inv := sampleInvestigation()
+		inv.CurateError = "open PR: forbidden" + brk + forged
+		line := curateLine(t, Format(inv))
+		// Everything the error said is still on the one line RunLore wrote — so no part
+		// of it started a line of its own.
+		if !strings.Contains(line, forged) {
+			t.Errorf("break %q split the reason off RunLore's line: %q", brk, line)
+		}
+		// And the break rune itself is gone, so no renderer downstream can break on it
+		// either. thread.SingleLine maps it to a space; a narrower flattener leaves it.
+		if strings.ContainsAny(line, brk) {
+			t.Errorf("break %q survived flattening and can still forge a line: %q", brk, line)
+		}
+	}
+}
+
+// TestFormatCurateFailureIsRedacted pins that a forge error echoing the credential it
+// was rejected for does not carry it onto the card.
+func TestFormatCurateFailureIsRedacted(t *testing.T) {
 	inv := sampleInvestigation()
 	inv.CurateError = "open PR: bad credentials for ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
 	if out := Format(inv); strings.Contains(out, "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB") {
 		t.Fatalf("a credential echoed by the forge reached the card verbatim:\n%s", out)
+	}
+}
+
+// TestFormatCurateFailureRedactsBeforeCapping pins the ORDER, which until now was
+// asserted in prose only: reordering curateFailureReason to cap first passed the whole
+// suite. redact.Secrets matches gh[pousr]_[A-Za-z0-9]{20,}; a cut that lands inside a
+// token leaves a shorter prefix that no longer matches, so capping first would publish
+// the token's leading characters — the half an attacker needs to confirm which
+// credential leaked, and enough of one to brute-force the rest of a short token.
+//
+// The token is positioned so that exactly that happens: it STRADDLES the cut, with 22 of
+// its 42 characters inside it. 22 and not "some of them" — "ghp_" plus 18, two short of
+// the {20,} quantifier, so the surviving prefix no longer matches and reaches the card
+// verbatim. (A 30-character prefix would still match and the mutation would survive; that
+// is not a hypothetical, it is what the first version of this test did.)
+//
+// It is NOT absolute upstream, and this test cannot make it so: httpx.SafeErrorBody
+// byte-cuts a forge body at 512 bytes before err.Error() exists, so a second credential
+// straddling THAT offset arrives here already too short for redact.Secrets to match.
+// Closing that needs the cut to move into the redactor's hands in internal/httpx; this
+// pins the half that is in reach.
+func TestFormatCurateFailureRedactsBeforeCapping(t *testing.T) {
+	const token = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	// truncate keeps curateErrorRunes-1 runes, so a prefix of exactly that minus 22 puts
+	// the token's first 22 characters inside the cut and its last 20 outside.
+	prefix := "open PR: " + strings.Repeat("x", curateErrorRunes-1-22-len("open PR: "))
+	// Trailing padding so the reason is still over the cap AFTER redaction shortens the
+	// token to "[REDACTED]" — otherwise the redact-first path would not cut at all and
+	// the "was it capped" assertion below would fail for the wrong reason.
+	inv := sampleInvestigation()
+	inv.CurateError = prefix + token + ": rejected " + strings.Repeat("y", 100)
+	out := Format(inv)
+	if strings.Contains(out, token[:22]) {
+		t.Fatalf("capping ran before redaction: the leading characters of a credential "+
+			"survived the cut and reached the card:\n%s", out)
+	}
+	// The cut still happened — otherwise this would pass for the wrong reason.
+	if !strings.Contains(out, "…") {
+		t.Fatalf("the reason was not capped at all, so this test proves nothing:\n%s", out)
+	}
+}
+
+// TestFormatCurateFailureCannotEscapeItsCodeSpan pins the measure flattening does NOT
+// buy. The reason is up to curateErrorRunes long and every renderer soft-wraps it;
+// continuation lines start at the left margin with no quote bar (unlike
+// thread.QuoteUntrusted, whose "> " prefix survives wrapping), so a padded forge body can
+// put a forged "📚 Knowledge base: …" at the start of a VISUAL line without using a break
+// rune at all. The inline code span is what neutralises that — and a backtick inside the
+// reason would close it early, putting the rest back outside.
+//
+// codeRe is the Matrix renderer's own regexp, so this asserts against what actually
+// wraps the text in <code>, not against a restatement of it.
+func TestFormatCurateFailureCannotEscapeItsCodeSpan(t *testing.T) {
+	const forged = "📚 Knowledge base: https://evil.example/forged"
+	inv := sampleInvestigation()
+	inv.CurateError = "open PR: `" + forged + "`"
+	line := curateLine(t, Format(inv))
+	span := codeRe.FindString(line)
+	if span == "" {
+		t.Fatalf("the reason is not wrapped in an inline code span: %q", line)
+	}
+	if !strings.Contains(span, forged) {
+		t.Fatalf("a backtick in the forge error closed the code span early, leaving the "+
+			"forged text outside it — span %q, line %q", span, line)
+	}
+	if span != line {
+		t.Fatalf("the code span does not cover the whole reason: span %q, line %q", span, line)
 	}
 }
 

--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -648,19 +648,40 @@ func summaryBlocks(inv providers.Investigation) []map[string]any {
 		blocks = append(blocks, map[string]any{"type": "section", "fields": fields})
 	}
 
-	// 8. Footer — provenance only: verified, model calls/cost, and the single
-	// link to view the entry (this investigation's own curated entry, or — on
-	// a recall/seen-before card with nothing freshly curated — the prior/
-	// recalled/matched entry; see entryLink). Confidence and the agent identity
-	// are NOT repeated here: confidence already owns the header (2b), and the
-	// Slack app's own identity already says who posted this — showing either
-	// twice reads as the card disagreeing with itself, not reinforcing it.
+	// 8. Footer — provenance only: verified, the single link to view the entry
+	// (this investigation's own curated entry, or — on a recall/seen-before card
+	// with nothing freshly curated — the prior/recalled/matched entry; see
+	// entryLink), why that link is missing when a write failed, and model
+	// calls/cost. Confidence and the agent identity are NOT repeated here:
+	// confidence already owns the header (2b), and the Slack app's own identity
+	// already says who posted this — showing either twice reads as the card
+	// disagreeing with itself, not reinforcing it.
 	var foot []string
 	if inv.Verified {
 		foot = append(foot, "✓ verified")
 	}
 	if link := entryLink(inv); link != "" {
 		foot = append(foot, link)
+	}
+	// Beside the entry link, because it is the same fact's other arm: this is what
+	// there is to say when the write that would have produced that link failed. An
+	// empty CuratedURL is ambiguous — it is also the normal state for a finding
+	// below curate.min_confidence or carrying a skip_verdicts verdict — so without
+	// this the card renders a broken learning loop exactly like a deliberately
+	// skipped one (#506, observed live: a 403 ran unnoticed until an operator
+	// happened to write a thread note, the one path that already reported it). On a
+	// recurring incident entryLink still resolves the PRIOR entry, so the two
+	// genuinely coexist, and the warning is what stops that stale link from reading
+	// as this run's.
+	//
+	// escapeMrkdwn is MANDATORY here, not defensive: the reason is forge-supplied
+	// text, so without it this would be the only unescaped untrusted span on the
+	// card and a body echoing <https://evil.example|click here> would render as a
+	// live phishing link in the incident channel. The inline code span is
+	// curateFailureReason's contract — backticks are already stripped from the
+	// reason, so it cannot close early.
+	if reason := curateFailureReason(inv); reason != "" {
+		foot = append(foot, "⚠️ could not save to the knowledge base: `"+escapeMrkdwn(reason)+"`")
 	}
 	if u := usageFooter(inv.Usage); u != "" {
 		foot = append(foot, u) // trusted scaffolding — digits/labels only, no mrkdwn meta

--- a/internal/notify/slack_test.go
+++ b/internal/notify/slack_test.go
@@ -727,6 +727,54 @@ func TestEntryLinkEscapesURL(t *testing.T) {
 	}
 }
 
+// TestSlackCardShowsCurateFailure pins the SLACK surface of #506 — the one the
+// issue actually reports ("The delivered Slack card carried no indication of
+// this"). It is a separate test from the notify.Format one on purpose: nothing on
+// the Slack path calls Format. Slack.Deliver and SlackBot.Deliver both go through
+// slackMessageWith → summaryBlocks + detailBlocks + fallbackText, so a curate
+// failure rendered only by Format is rendered nowhere a Slack reader can see it.
+//
+// The failure line and the "view entry" link are asserted TOGETHER: on a recurring
+// incident entryLink still resolves the PRIOR entry, so the two coexist, and a card
+// showing a stale link with no warning is the exact ambiguity #506 is about.
+func TestSlackCardShowsCurateFailure(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.CurateError = "open PR: github GET /repos/o/r/git/ref/heads/main: status 403: Resource not accessible by integration"
+	joined := strings.Join(mrkdwnTexts(summaryBlocks(inv)), "\n")
+	if !strings.Contains(joined, "could not save to the knowledge base") {
+		t.Fatalf("a failed knowledge write is invisible on the Slack card:\n%s", joined)
+	}
+	if !strings.Contains(joined, "403") {
+		t.Fatalf("the reason must say WHICH failure it was, so an operator can act:\n%s", joined)
+	}
+	if !strings.Contains(joined, "view entry") {
+		t.Fatalf("the prior entry link must survive alongside the warning:\n%s", joined)
+	}
+	// The line is provenance, so it belongs in the footer context block beside
+	// entryLink — not in the answer, which the woken-up on-call reads first.
+	if !strings.Contains(joined, "view entry>  ·  ⚠️ could not save to the knowledge base") {
+		t.Fatalf("the warning is not on the footer line beside the entry link:\n%s", joined)
+	}
+}
+
+// TestSlackCurateFailureIsEscaped is mandatory rather than defensive: the curate
+// reason is forge-supplied text, and without escapeMrkdwn it would be the ONLY
+// unescaped untrusted span on the card — a 403 body echoing
+// <https://evil.example|click here> would render as a live link in the incident
+// channel, which is a phishing vector wearing RunLore's own warning glyph.
+func TestSlackCurateFailureIsEscaped(t *testing.T) {
+	const hostile = "<https://evil.example|click here to fix it>"
+	inv := sampleInvestigation()
+	inv.CurateError = "open PR: " + hostile
+	joined := strings.Join(mrkdwnTexts(summaryBlocks(inv)), "\n")
+	if strings.Contains(joined, hostile) {
+		t.Fatalf("forge error text rendered as a LIVE mrkdwn link on the card:\n%s", joined)
+	}
+	if !strings.Contains(joined, "&lt;https://evil.example|click here to fix it&gt;") {
+		t.Fatalf("curate reason neither escaped nor present:\n%s", joined)
+	}
+}
+
 // TestSlackMessageFallbackEscaped proves the one-line fallback (Slack parses it
 // as mrkdwn for notifications) escapes its one untrusted field — the model title
 // — so a hostile title cannot inject a clickable phishing link, while the

--- a/internal/notify/testdata/incident-card.golden.json
+++ b/internal/notify/testdata/incident-card.golden.json
@@ -640,5 +640,113 @@
       ],
       "text": "🔍 harbor-db migration lock (Medium confidence · 55%)"
     }
+  },
+  {
+    "fixture": "curate_failed",
+    "card": {
+      "blocks": [
+        {
+          "text": {
+            "emoji": true,
+            "text": "🔍 ArgoCDRepoServerDown — eu-west-1/argocd/argocd-repo-server",
+            "type": "plain_text"
+          },
+          "type": "header"
+        },
+        {
+          "text": {
+            "text": "🛠 *Action suggested* — argocd-repo-server OOMKilled after the 2.11 bump",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "🟢 *High confidence* · 85%",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "text": {
+            "text": "*Why:* 2.11 raised the manifest cache footprint past the 512Mi limit\n• container exit code 137 at 14:17",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "text": {
+            "text": "*🛠 Suggested next steps*  _(read-only — RunLore won't apply these)_\n• raise the repo-server memory limit to 1Gi  _(reversible)_",
+            "type": "mrkdwn"
+          },
+          "type": "section"
+        },
+        {
+          "fields": [
+            {
+              "text": "*Alert:*\nArgoCDRepoServerDown (warning)",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Cluster:*\neu-west-1",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Resource:*\nDeployment argocd/argocd-repo-server",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Started:*\n<!date^1783072800^{date_short_pretty} {time}|2026-07-03T10:00:00Z>",
+              "type": "mrkdwn"
+            },
+            {
+              "text": "*Recurrence:*\n🔁 #2 · last <!date^1780304400^{date_short_pretty} {time}|2026-06-01T09:00:00Z>",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "section"
+        },
+        {
+          "elements": [
+            {
+              "text": "📚 <https://github.com/o/kb/pull/271|view entry>  ·  ⚠️ could not save to the knowledge base: `open PR: github GET /repos/o/kb/git/ref/heads/main: status 403: {\"message\":\"Resource not accessible by integration\"}`  ·  5 model calls · 51204 in / 3117 out tokens (0% cached)",
+              "type": "mrkdwn"
+            }
+          ],
+          "type": "context"
+        },
+        {
+          "elements": [
+            {
+              "action_id": "runlore_feedback_up",
+              "text": {
+                "emoji": true,
+                "text": "👍 Accurate",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "ArgoCDRepoServerDown/argocd/argocd-repo-server"
+            },
+            {
+              "action_id": "runlore_feedback_down",
+              "text": {
+                "emoji": true,
+                "text": "👎 Off-base",
+                "type": "plain_text"
+              },
+              "type": "button",
+              "value": "ArgoCDRepoServerDown/argocd/argocd-repo-server"
+            }
+          ],
+          "type": "actions"
+        }
+      ],
+      "text": "🔍 argocd-repo-server OOMKilled after the 2.11 bump — Action suggested (High confidence · 85%)"
+    }
   }
 ]

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -802,7 +802,15 @@ type Investigation struct {
 	// only when a write was ATTEMPTED and failed. It exists because an empty CuratedURL is
 	// ambiguous: it is also the normal state for a finding below curate.min_confidence or
 	// carrying a skip_verdicts verdict, so "no KB link" cannot tell a human whether the
-	// learning loop is working. Rendered by notify.Format; never written to the KB body.
+	// learning loop is working. Rendered by notify.Format AND by the Slack card's footer
+	// (notify.summaryBlocks), both through notify.curateFailureReason; never written to
+	// the KB body.
+	//
+	// The one field on this struct stamped AFTER investigate.redactInvestigation, because
+	// curation runs in the OnComplete pipeline rather than inside the loop. It is
+	// therefore redacted at its assignment (app.onInvestigationComplete) rather than by
+	// the reflection walk, and it is deliberately NOT on redactionSkipField — it is
+	// server-supplied free text, the opposite of what that list is for.
 	CurateError   string
 	Fingerprint   string      // originating alert fingerprint; for outcome-ledger attribution
 	Fingerprints  []string    // coalesced batch fingerprints; one outcome open is recorded per entry

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -796,14 +796,20 @@ type Investigation struct {
 	// the exact bound on resolve-before-open pairing (see outcome.resolvesSince) — the open
 	// itself is stamped at COMPLETION, so without this the pairing window is unknowable.
 	InvestigationStartedAt time.Time
-	Actions                []Action    // proposed remediations (autonomy ladder; never executed at rung "suggest")
-	CuratedURL             string      // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
-	Fingerprint            string      // originating alert fingerprint; for outcome-ledger attribution
-	Fingerprints           []string    // coalesced batch fingerprints; one outcome open is recorded per entry
-	TriggerKey             string      // deterministic incident identity set at trigger time (alerts: host-invariant per-class key from curator.IncidentKey; GitOps: failing resource+condition). curator.DupFingerprint prefers it so reworded re-investigations (#137) AND the same alert on a different pod/node (CORE-681) still dedupe
-	RecalledEntry          string      // when Recalled: the catalog entry Path that was matched
-	Verified               bool        // true when the adversarial verify pass ran and a root cause survived it
-	Usage                  UsageTotals // per-investigation model token/cost accounting (loop + verify); surfaced to humans + metrics, never written to the curated KB body
+	Actions                []Action // proposed remediations (autonomy ladder; never executed at rung "suggest")
+	CuratedURL             string   // runtime: KB issue/PR the curator opened, linked in delivery (set after curation)
+	// CurateError is the reason the curator could not write this finding to the KB, set
+	// only when a write was ATTEMPTED and failed. It exists because an empty CuratedURL is
+	// ambiguous: it is also the normal state for a finding below curate.min_confidence or
+	// carrying a skip_verdicts verdict, so "no KB link" cannot tell a human whether the
+	// learning loop is working. Rendered by notify.Format; never written to the KB body.
+	CurateError   string
+	Fingerprint   string      // originating alert fingerprint; for outcome-ledger attribution
+	Fingerprints  []string    // coalesced batch fingerprints; one outcome open is recorded per entry
+	TriggerKey    string      // deterministic incident identity set at trigger time (alerts: host-invariant per-class key from curator.IncidentKey; GitOps: failing resource+condition). curator.DupFingerprint prefers it so reworded re-investigations (#137) AND the same alert on a different pod/node (CORE-681) still dedupe
+	RecalledEntry string      // when Recalled: the catalog entry Path that was matched
+	Verified      bool        // true when the adversarial verify pass ran and a root cause survived it
+	Usage         UsageTotals // per-investigation model token/cost accounting (loop + verify); surfaced to humans + metrics, never written to the curated KB body
 	// Recurrence facts stamped at completion from the outcome ledger's per-TriggerKey
 	// index (never seen by the model). They describe PRIOR investigations of the same
 	// TriggerKey; this run's own open is recorded after they are read.

--- a/internal/thread/chat.go
+++ b/internal/thread/chat.go
@@ -474,7 +474,7 @@ func (c *Chat) renderContext(tc Context, author, text string) string {
 // and bounded to maxBytes. Redaction runs first for the same reason as in
 // renderContext, and the cap runs last so it holds unconditionally.
 func chatSafe(s string, maxBytes int) string {
-	return truncate(singleLine(strings.TrimSpace(redact.Secrets(s))), maxBytes)
+	return truncate(SingleLine(strings.TrimSpace(redact.Secrets(s))), maxBytes)
 }
 
 // writeEvidence renders what the investigation found. Only populated lists get

--- a/internal/thread/chat_test.go
+++ b/internal/thread/chat_test.go
@@ -1900,7 +1900,7 @@ func TestChatAnswerNilModelSpendsNothing(t *testing.T) {
 // unfenced region safe is that no evidence item can become a LINE of its own:
 // a bullet's content may be a stranger's, but its framing may not be.
 //
-// This pins the mitigation (chatSafe's singleLine), not the prose. It passed
+// This pins the mitigation (chatSafe's SingleLine), not the prose. It passed
 // when written — it is a regression pin on an invariant the code already holds,
 // added because nothing else asserted it.
 func TestChatContextEvidenceCannotForgeAFramingLine(t *testing.T) {

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -197,7 +197,7 @@ func noteText(s string, maxBytes int) string {
 // longer tracks fences, because kbvalidate's parser does not either — but the
 // flattening still matters for the plain-heading case above.
 func noteField(s string) string {
-	return singleLine(redact.Secrets(s))
+	return SingleLine(redact.Secrets(s))
 }
 
 // blockquote prefixes EVERY line of s with "> ", so a quoted block cannot end
@@ -533,7 +533,7 @@ func atxHeadingText(line string) string {
 	return strings.TrimSpace(line[i:])
 }
 
-// singleLine collapses every rune that can break or reorder a line — any
+// SingleLine collapses every rune that can break or reorder a line — any
 // Unicode whitespace other than the plain space, every control character (Cc)
 // and every format character (Cf) — to a space, so text pulled from untrusted
 // sources (an alert title, in particular) can never break a single-line YAML
@@ -558,7 +558,7 @@ func atxHeadingText(line string) string {
 // The plain space is excluded so ordinary text is left exactly as written;
 // everything else in those categories becomes one, which keeps the result the
 // same length in runes and never joins two words.
-func singleLine(s string) string {
+func SingleLine(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r == ' ' {
 			return r

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -642,7 +642,7 @@ func TestNeutralizeImagesWorstCaseExpansionFactor(t *testing.T) {
 // framing region of the chat prompt (Investigation:/Resource:/Verdict:, the
 // evidence bullets) single-line, and U+2028 is a line break to many renderers
 // and tokenizers — so an alert-derived title could plausibly forge a framing
-// line. And ConceptEntry's title lands in YAML frontmatter, where singleLine's
+// line. And ConceptEntry's title lands in YAML frontmatter, where SingleLine's
 // own doc says it exists because kbvalidate rejects a title containing \r or
 // \n — and YAML 1.1 counts U+2028/U+2029 as line breaks too.
 func TestSingleLineFlattensEveryLineBreakAndFormatRune(t *testing.T) {
@@ -654,8 +654,8 @@ func TestSingleLineFlattensEveryLineBreakAndFormatRune(t *testing.T) {
 		'\u200b', '\u200e', '\u202e', // zero-width space, LTR mark, RTL override
 		'\u061c', '\ufeff', // ARABIC LETTER MARK, BOM
 	} {
-		if got, want := singleLine("before"+string(r)+"after"), "before after"; got != want {
-			t.Errorf("singleLine(U+%04X) = %q, want %q", r, got, want)
+		if got, want := SingleLine("before"+string(r)+"after"), "before after"; got != want {
+			t.Errorf("SingleLine(U+%04X) = %q, want %q", r, got, want)
 		}
 	}
 }
@@ -664,8 +664,8 @@ func TestSingleLineFlattensEveryLineBreakAndFormatRune(t *testing.T) {
 // not mangle a title just because it is not ASCII.
 func TestSingleLineLeavesOrdinaryTextAlone(t *testing.T) {
 	for _, s := range []string{"ImageGalleryUnavailable", "pod OOMKilled — burst pool", "déjà vu", "国际化 test", "emoji 🔥 title", "a b  c"} {
-		if got := singleLine(s); got != s {
-			t.Errorf("singleLine(%q) = %q, want it unchanged", s, got)
+		if got := SingleLine(s); got != s {
+			t.Errorf("SingleLine(%q) = %q, want it unchanged", s, got)
 		}
 	}
 }

--- a/internal/thread/responder.go
+++ b/internal/thread/responder.go
@@ -816,18 +816,18 @@ func modelVoice(s string) string { return QuoteUntrusted(s) }
 //
 // The set is UAX #14's mandatory breaks — the classes BK, CR, LF and NL — and
 // nothing else, because that is exactly the set a text layout is REQUIRED to
-// break at. singleLine already made this argument for the single-line YAML
+// break at. SingleLine already made this argument for the single-line YAML
 // title (see its doc comment: U+2028 and U+2029 are line breaks "many
 // renderers and tokenizers break on", which is what made a Cc-only check a
 // real gap rather than a pedantic one); this is the same fact applied to the
 // one untrusted span that is rendered multi-line BY DESIGN and so cannot be
-// flattened the way singleLine flattens a title.
+// flattened the way SingleLine flattens a title.
 //
 // CRLF is listed first so it folds to ONE break: strings.Replacer tries its
 // patterns in argument order at each position, so a later bare "\r" cannot
 // split a CRLF into two lines.
 //
-// It normalises breaks and nothing else, deliberately. singleLine additionally
+// It normalises breaks and nothing else, deliberately. SingleLine additionally
 // maps Cf and every other Unicode space because a title must end up on one
 // line; a quoted note must end up READABLE, so a tab, a no-break space and a
 // zero-width space are carried through exactly as written. Those reorder or

--- a/internal/thread/responder_test.go
+++ b/internal/thread/responder_test.go
@@ -2658,7 +2658,7 @@ func TestReplyQuotesTheNoteAsUntrustedAndNothingElse(t *testing.T) {
 // margin, in RunLore's own vocabulary — the exact forgery modelVoice's
 // blockquote exists to stop, arriving through a rune that is not "\n".
 //
-// singleLine had already made this argument for the YAML title (see its doc
+// SingleLine had already made this argument for the YAML title (see its doc
 // comment: U+2028 and U+2029 are the ones "many renderers and tokenizers break
 // on"), and noteField applies it to Author and Title. The note BODY is the one
 // untrusted span rendered multi-line BY DESIGN, so it is the one span that
@@ -2701,7 +2701,7 @@ func TestQuotedNoteCannotBreakOutOfTheBlockquote(t *testing.T) {
 	}
 
 	// The other direction, and the reason the fix normalises BREAKS rather than
-	// mapping whitespace the way singleLine does: a tab, a no-break space and a
+	// mapping whitespace the way SingleLine does: a tab, a no-break space and a
 	// blank line are not line breaks, so the quote must carry them through
 	// untouched. Flattening them would censor the note the human asked to read.
 	t.Run("everything that is not a break survives byte for byte", func(t *testing.T) {


### PR DESCRIPTION
Closes #506. Design context in #507.

An **empty `CuratedURL` is ambiguous**. It is the normal state for a finding below `curate.min_confidence` or carrying a `skip_verdicts` verdict — by far the common case — so "no KB link" cannot tell an operator whether the learning loop is working. Three different outcomes rendered identically:

| outcome | card shows | |
|---|---|---|
| below `min_confidence` | no link | by design |
| verdict in `skip_verdicts` | no link | by design |
| **forge write failed** | no link | **something is broken** |

Observed live: an 85%-confidence `action_suggested` finding whose KB PR got a 403 was delivered with no link and no warning. The operator found out only because they happened to write a thread note — `internal/thread` **does** report the failure. The curate call site logged the error and dropped it.

## The metric was already there

`recordCuration` fires `result=error` on both failure paths, verified incrementing on a live cluster against the real 403. So this is the **human surface only**, which is why the diff is small. Alert with:

```promql
increase(runlore_curations_total{result="error"}[15m]) > 0
```

## The reason is redacted, flattened and capped — in that order

Same treatment and same reasons as `thread.chatSafe`. A forge error carries a server-provided JSON body, so it can echo a credential; and a line break inside it would put that text at the left margin where RunLore's own status lines sit. **Redaction runs before capping** so a cut never hands `redact.Secrets` a half-token it no longer matches.

`thread.singleLine` is exported as `SingleLine` and reused rather than copied into `notify`: a second copy of the mandatory-break class list is exactly the drift `kbUpdateAnnouncement` documents having been bitten by, where a lone U+2028 forged a headline in the channel findings are posted to.

## Testing

Each property watched failing against a deliberately broken implementation: rendering suppressed, flattening dropped, redaction dropped.
