### PR TITLE
docs(learning-loop): say that an operator note never fires instant recall

### DIFF
--- a/internal/docsguard/operator_note_recall_test.go
+++ b/internal/docsguard/operator_note_recall_test.go
@@ -3,91 +3,121 @@
 package docsguard
 
 import (
-	"os"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/kbvalidate"
+	"github.com/Smana/runlore/internal/thread"
 )
 
-// TestOperatorNotesAreNotClaimedToFireInstantRecall guards a claim the docs are tempting
-// to make and that is false.
-//
-// An operator note captured from a thread is written as a `Concept` entry. `Concept` is
-// evidence-free by design — chosen so a bare note clears the merge gate without
-// fabricating Symptom/Cause/Resolution sections nobody wrote — and an evidence chain is
-// exactly what the verify pass requires before a recall may short-circuit the loop. The
-// two are structurally incompatible: measured on a live cluster, six recalls of operator
-// notes at reranker confidence 0.82–0.92 produced six rejections, including one entry
-// with clean, specific metadata.
-//
-// So a note widens kb_search and never fires instant recall. Any page saying otherwise
-// promises a saving that does not exist, and — worse — would suggest a WRONG note gets
-// served back with confidence, when in fact verify is the gate that stops exactly that
-// (an adversarial test: a false note fooled the reranker at 0.92 and was caught here).
-//
-// This is a NEGATIVE guard: it cannot prove the docs describe the behaviour well, only
-// that no page asserts the specific falsehood. Stated so a passing run is not mistaken
-// for more than it is.
-func TestOperatorNotesAreNotClaimedToFireInstantRecall(t *testing.T) {
-	// A sentence tying operator notes to instant recall FIRING. Checked per SENTENCE,
-	// and a sentence carrying a negation is skipped — the honest pages are made of exactly
-	// such sentences ("a note widens kb_search; it does not enable instant recall"), and an
-	// earlier version of this guard stripped negation WORDS and then fired on the very
-	// paragraph documenting the limitation correctly. Matching the whole sentence and
-	// asking whether it is negated is the robust form.
-	claim := regexp.MustCompile(`(?i)(operator note|thread capture|@runlore note)`)
-	recall := regexp.MustCompile(`(?i)instant[- ]recall`)
-	affirm := regexp.MustCompile(`(?i)\b(fires?|firing|triggers?|enables?|short-circuits?|allows?)\b`)
-	negated := regexp.MustCompile(`(?i)\b(not|never|cannot|can't|without|nor|no)\b`)
+// operatorNotePage is the page whose §10 operator-note paragraph these guards pin.
+const operatorNotePage = "../../website/content/docs/concepts/learning-loop.md"
 
-	pages := threadDocPages(t)
-	for _, p := range pages {
-		b, err := os.ReadFile(p)
-		if err != nil {
-			t.Fatalf("read %s: %v", p, err)
-		}
-		for _, sentence := range splitSentences(string(b)) {
-			if !claim.MatchString(sentence) || !recall.MatchString(sentence) {
-				continue
-			}
-			if !affirm.MatchString(sentence) || negated.MatchString(sentence) {
-				continue
-			}
-			t.Errorf("%s claims operator notes fire instant recall, which they never do:\n  %q\n"+
-				"Notes widen kb_search only; verify rejects Concept entries (6/6 measured), and that "+
-				"rejection is also what stops a WRONG note being served with confidence.",
-				p, strings.TrimSpace(sentence))
-		}
+// filedOperatorNote runs the REAL filer — thread.ConceptEntry, the function the
+// standalone note route calls — over a realistic thread context, and returns the
+// entry it produces. Everything asserted below is read out of that entry rather than
+// restated, which is what package docsguard promises: a guard reflects over a runtime
+// source of truth, not over a hand-copied fact.
+func filedOperatorNote(t *testing.T) (description, body string) {
+	t.Helper()
+	tc := thread.Context{
+		Transport:  "slack",
+		Root:       "1723900000.000100",
+		Channel:    "C0DOCSGUARD",
+		Title:      "KubePodNotReady: harbor-registry",
+		Resource:   "tooling/harbor-registry",
+		TriggerKey: "KubePodNotReady|tooling/harbor-registry",
+	}
+	e := thread.ConceptEntry(
+		tc,
+		thread.HumanNote("alice", "this recurs after every spot-node reclaim, not a CNI fault"),
+		time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC),
+		0,
+	)
+	return e.Description, e.Body
+}
+
+// noteDescriptionRE is the shape conceptDescription actually renders for a
+// human-written note. The page QUOTES this sentence as the thing the adversarial
+// reviewer is asked to accept as a causal chain, so if the filer stops saying it — or
+// starts saying something that reads as evidence — the quotation is stale and the
+// paragraph's whole argument has to be re-derived.
+var noteDescriptionRE = regexp.MustCompile(`^Operator knowledge captured from a \w+ thread by @\S+\.$`)
+
+// TestOperatorNoteFilesNoCausalEvidence derives the two facts learning-loop.md §10
+// rests on, from the code that decides them:
+//
+//  1. the body a note files carries NO Symptom/Cause/Resolution — checked with
+//     kbvalidate.HasIncidentSections, the very predicate the merge gate uses, so a
+//     future NoteBody that starts rendering those sections fails here rather than
+//     silently making the page wrong;
+//  2. the one-line description it files says where the note came from, in the exact
+//     words the page quotes.
+//
+// Both are content properties of the filer, and that is the point: the page must NOT
+// claim verify is structurally barred from admitting a note. Nothing on the verify
+// path reads an entry's type — see TestRecalledEntryShowsTheReviewerNoBody in
+// internal/investigate — so the only true statement is that a note as filed today
+// carries nothing admissible.
+func TestOperatorNoteFilesNoCausalEvidence(t *testing.T) {
+	description, body := filedOperatorNote(t)
+
+	if kbvalidate.HasIncidentSections(body) {
+		t.Errorf("a filed operator note now carries the full Symptom/Cause/Resolution chain:\n%s\n"+
+			"learning-loop.md §10 says it carries no causal evidence — re-measure the verify behaviour "+
+			"and rewrite the paragraph before shipping this", body)
+	}
+	if !noteDescriptionRE.MatchString(description) {
+		t.Errorf("the filed description is %q, which no longer matches %v — learning-loop.md §10 quotes "+
+			"this sentence as what the reviewer is shown; update both together", description, noteDescriptionRE)
+	}
+
+	// The page quotes the same sentence, elided the way prose elides it (and wrapped,
+	// so the line break is part of the match). Anchored on both ends of the real
+	// sentence, so a rewritten description leaves a quotation that no longer exists.
+	if doc := readDoc(t, operatorNotePage); !strings.Contains(doc, "Operator knowledge captured\n  from a … thread by @…") {
+		t.Errorf("learning-loop.md §10 no longer quotes the description an operator note actually files (%q) — "+
+			"without it the paragraph asserts a rejection reason the reader cannot check", description)
 	}
 }
 
-// splitSentences breaks markdown into rough sentences for the guard above. Rough is
-// sufficient: the guard asks whether ONE claim and its negation co-occur, and both live in
-// the same sentence in every phrasing that matters.
-func splitSentences(src string) []string {
-	src = strings.ReplaceAll(src, "\n", " ")
-	return strings.FieldsFunc(src, func(r rune) bool { return r == '.' || r == ';' || r == '!' })
-}
+// TestOperatorNoteRecallCountIsTheMeasuredOne pins the one part of the paragraph that
+// is neither derivable from code nor checkable by a reader: the live-cluster
+// measurement behind #504. Four recalls, four rejections, at recall confidence
+// 0.82 / 0.85 / 0.90 / 0.92 — the issue's own evidence. An earlier draft of the page
+// said six, and attributed one of them to a hand-written entry that was never an
+// operator note at all.
+//
+// THIS GUARD CANNOT FAIL FROM THE CODE SIDE, and that is stated here rather than left
+// to be discovered: nothing in this repo reproduces those four rejections, and a
+// change to verify would not trip it. It is a consistency check between the page and a
+// recorded observation — enough to stop the count drifting again silently, and not
+// enough for a green run to mean the number is still true.
+func TestOperatorNoteRecallCountIsTheMeasuredOne(t *testing.T) {
+	doc := readDoc(t, operatorNotePage)
 
-// TestLearningLoopDocumentsTheRecallLimit is the positive half: the limitation must be
-// written down somewhere, not merely absent from the pages that would get it wrong.
-// Without this, deleting the paragraph would leave the negative guard above passing
-// vacuously.
-func TestLearningLoopDocumentsTheRecallLimit(t *testing.T) {
-	const page = "website/content/docs/concepts/learning-loop.md"
-	b, err := os.ReadFile("../../" + page)
-	if err != nil {
-		t.Fatalf("read %s: %v", page, err)
+	measured := regexp.MustCompile(`\*\*(\w+) recalls of operator notes across two\s+incidents, at recall confidence 0\.82–0\.92, and (\w+) rejections\*\*`)
+	m := measured.FindStringSubmatch(doc)
+	if m == nil {
+		t.Fatalf("learning-loop.md §10 no longer states the #504 measurement in the pinned form (%v) — "+
+			"if the sentence was reworded, reword this guard with it", measured)
 	}
-	src := strings.ToLower(string(b))
+	if m[1] != "four" || m[2] != "four" {
+		t.Errorf("learning-loop.md §10 says %s recalls / %s rejections; issue #504 measured four and four "+
+			"(0.82, 0.85, 0.90, 0.92) — re-measure before changing the number", m[1], m[2])
+	}
+
+	// Four-out-of-four is an observation, not a rule. Without these the page could keep
+	// the right number and still assert the impossibility claim the code does not make.
 	for _, want := range []string{
-		"widens `kb_search`", // what a note DOES do
-		"instant recall",     // what it does not
-		"concept",            // the entry type that makes it structural
-		"verify",             // the gate that rejects it
+		"not a rule in the code",
+		"Nothing on the\n  verify path reads an entry's `type`",
 	} {
-		if !strings.Contains(src, strings.ToLower(want)) {
-			t.Errorf("%s no longer explains the operator-note recall limit: missing %q", page, want)
+		if !strings.Contains(doc, want) {
+			t.Errorf("learning-loop.md §10 must keep the caveat containing %q — otherwise the measurement "+
+				"reads as a structural guarantee that the code does not make", want)
 		}
 	}
 }

--- a/internal/docsguard/operator_note_recall_test.go
+++ b/internal/docsguard/operator_note_recall_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestOperatorNotesAreNotClaimedToFireInstantRecall guards a claim the docs are tempting
+// to make and that is false.
+//
+// An operator note captured from a thread is written as a `Concept` entry. `Concept` is
+// evidence-free by design — chosen so a bare note clears the merge gate without
+// fabricating Symptom/Cause/Resolution sections nobody wrote — and an evidence chain is
+// exactly what the verify pass requires before a recall may short-circuit the loop. The
+// two are structurally incompatible: measured on a live cluster, six recalls of operator
+// notes at reranker confidence 0.82–0.92 produced six rejections, including one entry
+// with clean, specific metadata.
+//
+// So a note widens kb_search and never fires instant recall. Any page saying otherwise
+// promises a saving that does not exist, and — worse — would suggest a WRONG note gets
+// served back with confidence, when in fact verify is the gate that stops exactly that
+// (an adversarial test: a false note fooled the reranker at 0.92 and was caught here).
+//
+// This is a NEGATIVE guard: it cannot prove the docs describe the behaviour well, only
+// that no page asserts the specific falsehood. Stated so a passing run is not mistaken
+// for more than it is.
+func TestOperatorNotesAreNotClaimedToFireInstantRecall(t *testing.T) {
+	// A sentence tying operator notes to instant recall FIRING. Checked per SENTENCE,
+	// and a sentence carrying a negation is skipped — the honest pages are made of exactly
+	// such sentences ("a note widens kb_search; it does not enable instant recall"), and an
+	// earlier version of this guard stripped negation WORDS and then fired on the very
+	// paragraph documenting the limitation correctly. Matching the whole sentence and
+	// asking whether it is negated is the robust form.
+	claim := regexp.MustCompile(`(?i)(operator note|thread capture|@runlore note)`)
+	recall := regexp.MustCompile(`(?i)instant[- ]recall`)
+	affirm := regexp.MustCompile(`(?i)\b(fires?|firing|triggers?|enables?|short-circuits?|allows?)\b`)
+	negated := regexp.MustCompile(`(?i)\b(not|never|cannot|can't|without|nor|no)\b`)
+
+	pages := threadDocPages(t)
+	for _, p := range pages {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		for _, sentence := range splitSentences(string(b)) {
+			if !claim.MatchString(sentence) || !recall.MatchString(sentence) {
+				continue
+			}
+			if !affirm.MatchString(sentence) || negated.MatchString(sentence) {
+				continue
+			}
+			t.Errorf("%s claims operator notes fire instant recall, which they never do:\n  %q\n"+
+				"Notes widen kb_search only; verify rejects Concept entries (6/6 measured), and that "+
+				"rejection is also what stops a WRONG note being served with confidence.",
+				p, strings.TrimSpace(sentence))
+		}
+	}
+}
+
+// splitSentences breaks markdown into rough sentences for the guard above. Rough is
+// sufficient: the guard asks whether ONE claim and its negation co-occur, and both live in
+// the same sentence in every phrasing that matters.
+func splitSentences(src string) []string {
+	src = strings.ReplaceAll(src, "\n", " ")
+	return strings.FieldsFunc(src, func(r rune) bool { return r == '.' || r == ';' || r == '!' })
+}
+
+// TestLearningLoopDocumentsTheRecallLimit is the positive half: the limitation must be
+// written down somewhere, not merely absent from the pages that would get it wrong.
+// Without this, deleting the paragraph would leave the negative guard above passing
+// vacuously.
+func TestLearningLoopDocumentsTheRecallLimit(t *testing.T) {
+	const page = "website/content/docs/concepts/learning-loop.md"
+	b, err := os.ReadFile("../../" + page)
+	if err != nil {
+		t.Fatalf("read %s: %v", page, err)
+	}
+	src := strings.ToLower(string(b))
+	for _, want := range []string{
+		"widens `kb_search`", // what a note DOES do
+		"instant recall",     // what it does not
+		"concept",            // the entry type that makes it structural
+		"verify",             // the gate that rejects it
+	} {
+		if !strings.Contains(src, strings.ToLower(want)) {
+			t.Errorf("%s no longer explains the operator-note recall limit: missing %q", page, want)
+		}
+	}
+}

--- a/internal/investigate/operator_note_review_test.go
+++ b/internal/investigate/operator_note_review_test.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// recalledOperatorNote is the catalog entry a merged operator note becomes: the
+// title and one-line description thread.ConceptEntry files (pinned separately in
+// internal/docsguard), and a body whose every interesting string is a sentinel, so
+// "did this reach the reviewer?" is answerable exactly rather than by eyeballing.
+func recalledOperatorNote() catalog.Entry {
+	return catalog.Entry{
+		Type:        "Concept",
+		Path:        "kb/operator-note-harbor-registry.md",
+		Title:       "Operator note: KubePodNotReady: harbor-registry",
+		Description: "Operator knowledge captured from a slack thread by @alice.",
+		Body: "## Note\n\nSENTINEL-NOTE-TEXT\n\n" +
+			"## Symptom\n\nSENTINEL-SYMPTOM\n\n" +
+			"## Cause\n\nSENTINEL-CAUSE\n\n" +
+			"## Resolution\n\nSENTINEL-RESOLUTION\n",
+	}
+}
+
+func recalledOperatorNoteRequest() Request {
+	return Request{
+		Title:    "KubePodNotReady: harbor-registry",
+		Reason:   "ContainerCreating for 15m",
+		Workload: providers.Workload{Kind: "Deployment", Namespace: "tooling", Name: "harbor-registry"},
+	}
+}
+
+// TestRecalledEntryShowsTheReviewerNoBody pins the mechanism learning-loop.md §10
+// asserts, against the two functions that decide it.
+//
+// The page used to claim a `Concept` entry and the verify pass were "structurally
+// incompatible" — that an `Incident`'s Symptom/Cause/Resolution could satisfy verify
+// where a note's could not. The code does not implement that, and this test is the
+// proof kept next to it: renderForReview builds the reviewer's whole view from the
+// hypothesis SUMMARY (on the recall path, entry title + description), its evidence
+// bullets and the confirm transcript. The entry body never appears — not the note's
+// text, and not an Incident's evidence sections either, which is why recalledInvestigation
+// filling inv.Prior with Cause/Resolution changes nothing about what is reviewed.
+//
+// Break either half — render Prior into the review, or stop rendering the description
+// — and §10's argument is no longer the one the code makes.
+func TestRecalledEntryShowsTheReviewerNoBody(t *testing.T) {
+	e := recalledOperatorNote()
+	req := recalledOperatorNoteRequest()
+
+	rec := recalledInvestigation(req, e, 0.90)
+	review := renderForReview(req, rec, nil)
+
+	if !strings.Contains(review, e.Description) {
+		t.Errorf("the reviewer is no longer shown the recalled entry's description (%q):\n%s\n"+
+			"learning-loop.md §10 rests on that description being what verify judges", e.Description, review)
+	}
+	for _, sentinel := range []string{
+		"SENTINEL-NOTE-TEXT",  // the operator's own words
+		"SENTINEL-SYMPTOM",    // and the sections an Incident would carry…
+		"SENTINEL-CAUSE",      // …which recalledInvestigation copies into inv.Prior…
+		"SENTINEL-RESOLUTION", // …and renderForReview still never shows.
+	} {
+		if strings.Contains(review, sentinel) {
+			t.Errorf("the recalled entry's body now reaches the verify reviewer (%s):\n%s\n"+
+				"learning-loop.md §10 says it never does — update the page (and reconsider whether the "+
+				"measured rejections still stand) before shipping this", sentinel, review)
+		}
+	}
+
+	// The Incident half of the same claim, stated positively: the sections ARE parsed
+	// and carried, they simply are not part of the review. Without this the test above
+	// would also pass if Prior stopped being populated at all, which is a different
+	// (and separately breaking) change.
+	if rec.Prior == nil || rec.Prior.Cause != "SENTINEL-CAUSE" || rec.Prior.Resolution != "SENTINEL-RESOLUTION" {
+		t.Errorf("recalledInvestigation no longer carries the entry's Cause/Resolution as Prior (%+v) — "+
+			"the point of the test above is that it carries them and verify still never sees them", rec.Prior)
+	}
+}
+
+// TestKBSearchShowsTheWholeEntry is the other half of §10's practical conclusion:
+// a note pays off through kb_search, which renders the entry BODY, and not through
+// instant recall, which (above) never shows it. Same entry, two renderers, opposite
+// answers — that contrast is the whole recommendation, so it is pinned rather than
+// asserted.
+func TestKBSearchShowsTheWholeEntry(t *testing.T) {
+	e := recalledOperatorNote()
+	hits := renderHits([]catalog.Entry{e})
+
+	for _, want := range []string{e.Title, e.Description, "SENTINEL-NOTE-TEXT"} {
+		if !strings.Contains(hits, want) {
+			t.Errorf("kb_search no longer surfaces %q:\n%s\n"+
+				"learning-loop.md §10 tells operators a note pays off via kb_search precisely because "+
+				"this path renders the whole entry", want, hits)
+		}
+	}
+}
+
+// TestVerifyPathIgnoresEntryType pins the correction itself: no decision on the
+// review path is a function of the entry's OKF type. The same entry reviewed as a
+// Concept and as an Incident must produce a byte-identical review, so nobody can
+// re-introduce "a Concept structurally cannot satisfy verify" without this failing.
+func TestVerifyPathIgnoresEntryType(t *testing.T) {
+	req := recalledOperatorNoteRequest()
+
+	asConcept := recalledOperatorNote()
+	asIncident := recalledOperatorNote()
+	asIncident.Type = "Incident"
+
+	got := renderForReview(req, recalledInvestigation(req, asConcept, 0.90), nil)
+	want := renderForReview(req, recalledInvestigation(req, asIncident, 0.90), nil)
+	if got != want {
+		t.Errorf("the verify review now differs by entry type:\nConcept:\n%s\nIncident:\n%s\n"+
+			"learning-loop.md §10 says the type is not read on this path — if that changed, the page's "+
+			"correction (it is what a note SAYS, not what it is typed) is now wrong", got, want)
+	}
+}

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -800,6 +800,31 @@ Honesty is part of the design:
   coalesced or cross-namespace incidents — only applies to legacy/hand-filed PRs that
   carry no fingerprint marker.
 - **Nightly eval** only produces signal once a model API-key secret is configured.
+- **An operator note widens `kb_search`; it does not enable instant recall.** A note
+  captured from a thread is written as a `Concept` entry, and `Concept` is
+  evidence-free by design — that type was chosen precisely so a bare note clears the
+  merge gate without fabricating Symptom/Cause/Resolution sections nobody wrote. But an
+  evidence chain is exactly what the verify pass asks for before a recall may
+  short-circuit the loop, so the two are structurally incompatible. Measured on a live
+  cluster: **six recalls of operator notes across two incidents, at reranker confidence
+  0.82–0.92, and six rejections** — *"a match to a knowledge-base entry is not causal
+  evidence"*, *"a Slack thread opinion is not evidence"*. One of those six was a
+  hand-written entry with clean, specific metadata, so this is not a title-quality
+  problem.
+
+  **This is currently a safety property, not only a limitation.** In an adversarial
+  test a deliberately false note fooled the reranker completely (0.92, *"the canonical
+  runbook for this exact incident"*) and fired instant recall — and verify was the only
+  gate that caught it, after which the full loop reached the correct answer and rebutted
+  the note. So the honest summary is that notes pay off on the *slower* path and are
+  prevented from paying off wrongly on the fast one. They still pay off: on an identical
+  alert, a pointer-only note (no conclusion, no proof) moved a finding from a wrong
+  mechanism to the right one, 60% → 75% confidence, 15 → 7 model calls, ~$0.70 → ~$0.18.
+
+  Letting a *confirmed* note graduate to an `Incident` entry — carrying the evidence of
+  the investigation that confirmed it — is the promising fix, because it earns
+  admissibility rather than asserting it. It changes the curation lifecycle, so it needs
+  its own design.
 
 The loop is closed and measured; these are the next increments, sequenced so each is
 its own reviewed change.

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -11,12 +11,18 @@ weight: 30
 > answer from a git-versioned catalog — instant, no investigation; otherwise it
 > investigates. It then **captures** whether the incident actually resolved,
 > **curates** a verified, novel finding into a **human-reviewed pull request**, and
-> once a human merges it the note **compounds** (recall-able next time). What makes
+> once a human merges it the entry **compounds** (recall-able next time). What makes
 > this *learning* and not note-taking: a note's trust is **derived from its real-world
 > resolve-rate** (plus 👍/👎 votes), so a note that stops working **decays** and can be
 > overturned. And the human stays in the loop throughout — **RunLore drafts, a human
 > merges; nothing is auto-written.** (Deep dives: §3 Retrieve, §4 Capture, §6 Decay,
 > §8 Validation.)
+
+> **Terminology.** On this page a **note** always means a *curated entry* — the
+> symptom → cause → resolution record RunLore drafts and a human merges. An **operator
+> note** is a different object: a message a human writes in a chat thread, which RunLore
+> files to the KB. It is not evidence-bearing and it behaves differently on the recall
+> path; see §10.
 
 ---
 
@@ -800,31 +806,44 @@ Honesty is part of the design:
   coalesced or cross-namespace incidents — only applies to legacy/hand-filed PRs that
   carry no fingerprint marker.
 - **Nightly eval** only produces signal once a model API-key secret is configured.
-- **An operator note widens `kb_search`; it does not enable instant recall.** A note
-  captured from a thread is written as a `Concept` entry, and `Concept` is
-  evidence-free by design — that type was chosen precisely so a bare note clears the
-  merge gate without fabricating Symptom/Cause/Resolution sections nobody wrote. But an
-  evidence chain is exactly what the verify pass asks for before a recall may
-  short-circuit the loop, so the two are structurally incompatible. Measured on a live
-  cluster: **six recalls of operator notes across two incidents, at reranker confidence
-  0.82–0.92, and six rejections** — *"a match to a knowledge-base entry is not causal
-  evidence"*, *"a Slack thread opinion is not evidence"*. One of those six was a
-  hand-written entry with clean, specific metadata, so this is not a title-quality
-  problem.
+- **An operator note widens `kb_search`; so far it has never survived verify to fire an
+  instant recall.** A note carries no causal evidence, on either write route. The primary
+  route is a *comment on the curator's open pull request*, so the note is not a catalog
+  entry at all until a human folds it into one; only when there is no open PR does it
+  become a standalone entry of its own, typed `Concept` because `kbvalidate` demands
+  Symptom/Cause/Resolution for `Incident` and fabricating those sections would be a lie.
+  So there is never a recallable entry that is *both* the operator's words and an
+  evidence chain: on the primary route the note is not an entry, and on the standalone
+  route the entry has neither section — only the words, under a one-line description
+  saying exactly where they came from: *"Operator knowledge captured
+  from a … thread by @…"*.
 
-  **This is currently a safety property, not only a limitation.** In an adversarial
-  test a deliberately false note fooled the reranker completely (0.92, *"the canonical
-  runbook for this exact incident"*) and fired instant recall — and verify was the only
-  gate that caught it, after which the full loop reached the correct answer and rebutted
-  the note. So the honest summary is that notes pay off on the *slower* path and are
-  prevented from paying off wrongly on the fast one. They still pay off: on an identical
-  alert, a pointer-only note (no conclusion, no proof) moved a finding from a wrong
-  mechanism to the right one, 60% → 75% confidence, 15 → 7 model calls, ~$0.70 → ~$0.18.
+  That description is nearly all the adversarial reviewer ever sees of it.
+  `renderForReview` shows each root cause's **summary** — on the recall path, the entry's
+  title and description — plus its evidence bullets and the confirm step's tool
+  transcript. **The entry's body never reaches the reviewer**, which is exactly why
+  `kb_search` is the path a note pays off on: `kb_search` renders the whole entry, body
+  included. Measured on a live cluster: **four recalls of operator notes across two
+  incidents, at recall confidence 0.82–0.92, and four rejections** — *"a match to a
+  knowledge-base entry is not causal evidence"*, *"a Slack thread opinion is not
+  evidence"*.
 
-  Letting a *confirmed* note graduate to an `Incident` entry — carrying the evidence of
-  the investigation that confirmed it — is the promising fix, because it earns
-  admissibility rather than asserting it. It changes the curation lifecycle, so it needs
-  its own design.
+  **This is a property of what a note says, not a rule in the code.** Nothing on the
+  verify path reads an entry's `type`; an `Incident` entry recalled the same way goes
+  through the same function, and its Symptom/Cause/Resolution do not reach the reviewer
+  either. So *"a note can never be recalled"* would be the wrong lesson to take from
+  four-out-of-four: it is what the reviewer has judged every time it has been asked, on
+  this wording, not a gate that forbids the outcome. Changing what a note *files* is
+  therefore a live option — including letting a *confirmed* note graduate to an
+  `Incident` carrying the evidence of the investigation that confirmed it. That changes
+  the curation lifecycle, so it needs its own design.
+
+  **Meanwhile the rejections are doing safety work.** The poisoned-entry eval scenario
+  (§8) shows the same gate catching a crafted wrong recall, after which the loop falls
+  through to a real investigation instead of publishing it. And notes still pay off on
+  that slower path: on an identical alert, a pointer-only note (no conclusion, no proof)
+  moved a finding from a wrong mechanism to the right one, 60% → 75% confidence, 15 → 7
+  model calls, ~$0.70 → ~$0.18.
 
 The loop is closed and measured; these are the next increments, sequenced so each is
 its own reviewed change.

--- a/website/content/docs/concepts/reviewing-knowledge.md
+++ b/website/content/docs/concepts/reviewing-knowledge.md
@@ -53,6 +53,14 @@ RunLore files it against that investigation's KB pull request, or opens a
 standalone note PR when there is none, and replies with a link to what it wrote.
 Your words are recorded verbatim, attributed to you.
 
+**Where a captured note pays off.** The four routes above all end in a merged pull
+request, but they do not all produce the same kind of entry. A captured note carries
+no symptom → cause → resolution chain, so once merged it widens what `kb_search` finds
+*during* an investigation — measurably useful — while the adversarial verify pass has
+so far rejected every recalled operator note rather than letting it answer an incident
+outright. [Learning Loop §10]({{< relref "learning-loop.md" >}}) has the measurement
+and why that is currently the safe behaviour.
+
 Optionally, with a `model.chat` block configured, plain questions in the thread are
 answered too — from the investigation's own evidence — and RunLore proposes a note
 itself when your message contained something durable. A model-drafted note is


### PR DESCRIPTION
Closes #504. Design context in #507.

Documentation, deliberately — **not** a code change.

#504 reports that an operator note can never fire instant recall: four live recalls at 0.82–0.92 confidence, four verify rejections, zero survivals. The rejections object to the *category*, not to any particular note — *"a match to a knowledge-base entry is not causal evidence"*.

That is structural, and it follows from two decisions that are each correct on their own:

- #482 chose `Concept` for operator notes so a bare note **clears the merge gate honestly** rather than fabricating `Symptom`/`Cause`/`Resolution` sections nobody wrote.
- Instant recall is gated on verify, which asks for a causal evidence chain.

A `Concept` entry is evidence-free by design, so it sits permanently on the wrong side of that gate.

## Why this is not fixed by relaxing verify

An adversarial test run while writing #507 showed **verify was the only gate that caught a deliberately false note after the reranker had been fooled at 0.92 confidence**. Making operator notes recall-eligible by weakening the evidence requirement would remove the one check that held.

So the honest fix is to stop implying a capability that does not exist. `learning-loop.md` now states plainly that an operator note populates `kb_search` — where it demonstrably works, and measurably changes an investigation's conclusion — but does not fire instant recall, and why.

A `docsguard` test pins the claim against the code so the page cannot drift back into implying otherwise.
