### PR TITLE
fix(gitops)!: confine the forge credential to the forge's own git host

### DIFF
--- a/internal/app/catalog_cmd.go
+++ b/internal/app/catalog_cmd.go
@@ -56,7 +56,7 @@ func RunCatalogSync(args []string) error {
 		if t := os.Getenv(env); t != "" {
 			token = func(context.Context) (string, error) { return t, nil }
 		}
-	} else if ft := BuildKBTokenSource(cfg, log); ft != nil {
+	} else if ft := BuildCloneTokenSource(cfg, log); ft != nil {
 		token = catalog.TokenFunc(ft)
 	}
 	syncer := &catalog.Syncer{URL: g.URL, Branch: g.Branch, Dir: dir, Token: token, Log: log}

--- a/internal/app/forge.go
+++ b/internal/app/forge.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/Smana/runlore/internal/config"
 
@@ -59,25 +60,56 @@ func BuildGitLabTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
 	return func(context.Context) (string, error) { return tok, nil }
 }
 
-// BuildKBTokenSource picks the credential for reading the KNOWLEDGE-BASE repo —
-// the catalog git-sync — by forge provider.
+// BuildCloneTokenSource picks the credential for CLONING a git repository over
+// HTTPS, by forge provider. Every clone path uses it: the catalog git-sync that
+// reads the KB repo, the what_changed differ that clones GitOps source repos,
+// and source_diff.
 //
-// This is deliberately separate from BuildForgeTokenSource, which mints GitHub App
-// installation tokens and is correct for the GitHub-only paths (curate, sweeps, the
-// what-changed differ that clones source repos). Catalog sync is different: it reads
-// the same repo the curator writes to, so it must follow forge.provider.
+// It is deliberately separate from BuildForgeTokenSource, which mints GitHub App
+// installation tokens and is correct only for the paths that talk to the GitHub
+// API itself (curate, sweeps). A clone is not one of those: it authenticates to
+// whichever forge the operator configured.
 //
-// Before this existed, catalog sync fell back to the GitHub App identity on every
-// deployment. On GitLab that source is nil, so the syncer cloned ANONYMOUSLY: with a
-// private KB project, RunLore opened the merge request, a human merged it, and the
-// merged knowledge never came back into the catalog. The learning loop was severed at
-// the seam, silently — the log line explaining the fallback did not even fire, because
-// the token source was nil rather than wrong.
+// Getting that wrong fails SILENTLY, which is why this exists at all. Catalog
+// sync used to fall back to the GitHub App identity on every deployment; on
+// GitLab that source is nil, so the syncer cloned ANONYMOUSLY — with a private KB
+// project, RunLore opened the merge request, a human merged it, and the merged
+// knowledge never came back into the catalog. The learning loop was severed at
+// the seam, silently: the log line explaining the fallback did not even fire,
+// because the token source was nil rather than wrong. The what_changed differ
+// held the identical bug against a private GitOps repo — the differ cloned
+// anonymously and what_changed produced nothing for EVERY object — until it was
+// moved onto this same rule.
 //
-// catalog.git.token_env still wins over this; it is the explicit escape hatch.
-func BuildKBTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
+// One username serves both forges: the token is the basic-auth PASSWORD, and
+// GitLab accepts any non-blank username alongside a project/group access token
+// (see catalog.Syncer.auth and whatchanged.Differ.auth, both "x-access-token").
+//
+// catalog.git.token_env still wins over this for the KB repo; it is the explicit
+// escape hatch.
+func BuildCloneTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
 	if cfg.Forge.Provider == "gitlab" {
 		return BuildGitLabTokenSource(cfg, log)
 	}
 	return BuildForgeTokenSource(cfg, log)
+}
+
+// forgeGitHost names the ONE host a clone credential from BuildCloneTokenSource
+// may be sent to — the host the configured forge serves GIT REMOTES from.
+//
+// It is the credential boundary for what_changed and source_diff, so it is TOTAL
+// on purpose: it always names a host, and never returns "" (which a Differ reads
+// as "attach the token everywhere"). An operator override wins; otherwise the
+// host is derived, and it is derived from forgeWebHost because git and web share
+// a host on both forges — only GitHub's API can be split onto an api.* subdomain,
+// which is precisely the case config.Validate refuses without forge.git_host.
+//
+// A wrong value here does not leak the credential — it withholds it, which shows
+// up as an empty what_changed. That is why the ambiguous case is a startup
+// failure rather than a default.
+func forgeGitHost(cfg *config.Config) string {
+	if h := strings.ToLower(strings.TrimSpace(cfg.Forge.GitHost)); h != "" {
+		return h
+	}
+	return forgeWebHost(cfg)
 }

--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -44,11 +44,27 @@ func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) pro
 // TokenHost unset keeps every HTTPS clone that works today byte-identical,
 // including a GitHub Enterprise install whose API host differs from its git host
 // (githubGitHost derives from the API URL, so confining auth on it could withhold
-// the credential from a repo that clones fine today).
+// the credential from a repo that clones fine today). That bounds the REWRITE,
+// not the credential: a hostile HTTPS repoURL still receives the token — see
+// whatchanged.Differ.effectiveCloneURL for what is and is not closed.
+//
+// SSHRewriteHost is left EMPTY when there is no GitHub App credential, because
+// githubGitHost would otherwise name github.com for a deployment that holds no
+// github.com token — a host the rewrite must not trust on that basis. On a GitLab
+// forge BuildForgeTokenSource returns nil (it mints GitHub App tokens only), so
+// SSH repoURLs there still fail exactly as RunLore #495 reports. That gap is
+// LOGGED rather than papered over: handing the GitOps differ a GitLab credential
+// is a new credential path and belongs in its own change — the way
+// BuildKBTokenSource was split out for the identical silent failure on catalog
+// sync (see forge.go).
 func buildGitOpsDiffer(cfg *config.Config, log *slog.Logger) *whatchanged.Differ {
-	differ := &whatchanged.Differ{
-		TokenSource:    BuildForgeTokenSource(cfg, log),
-		SSHRewriteHost: githubGitHost(cfg.Forge.GitHubAPIURL),
+	differ := &whatchanged.Differ{TokenSource: BuildForgeTokenSource(cfg, log)}
+	if differ.TokenSource != nil {
+		differ.SSHRewriteHost = githubGitHost(cfg.Forge.GitHubAPIURL)
+	} else {
+		log.Warn("what_changed: no GitHub App credential; SSH repoURLs cannot be cloned and are "+
+			"not rewritten to HTTPS — change correlation stays empty for any GitOps object "+
+			"whose source is an SSH URL", "forge_provider", cfg.Forge.Provider)
 	}
 	if cfg.GitOps.Mirror.IsEnabled() {
 		if mc, err := whatchanged.NewMirrorCache(cfg.GitOps.Mirror.Dir, cfg.GitOps.Mirror.Max); err != nil {

--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -34,37 +34,45 @@ func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) pro
 
 // buildGitOpsDiffer builds the what_changed differ. Split out of BuildGitOps so
 // the credential wiring is reachable by a test: BuildGitOps hands the differ to a
-// provider that keeps it unexported, and an unset SSHRewriteHost would silently
-// leave RunLore #495 unfixed.
+// provider that keeps it unexported, and either half of this wiring fails
+// silently — an unset SSHRewriteHost leaves RunLore #495 unfixed, an unset
+// TokenHost hands the credential to whatever host a repoURL names.
 //
-// SSHRewriteHost is set — and TokenHost deliberately is not. The differ may only
-// rewrite an SSH repoURL into a live HTTPS request toward the host the App token
-// is actually for, so an attacker-chosen "repoURL: ssh://git@attacker.example/x"
-// stays SSH and dies at "invalid auth method" with nothing transmitted. Leaving
-// TokenHost unset keeps every HTTPS clone that works today byte-identical,
-// including a GitHub Enterprise install whose API host differs from its git host
-// (githubGitHost derives from the API URL, so confining auth on it could withhold
-// the credential from a repo that clones fine today). That bounds the REWRITE,
-// not the credential: a hostile HTTPS repoURL still receives the token — see
-// whatchanged.Differ.effectiveCloneURL for what is and is not closed.
+// The credential is CONFINED to the forge's own git host, and that is the point.
+// A GitOps spec.source.repoURL is cluster state: in a shared cluster anyone who
+// can create an Argo CD Application or a Flux GitRepository picks it, so an
+// unconfined differ sends the forge credential wherever "repoURL:
+// https://attacker.example/org/repo.git" points. Confinement takes away nothing
+// an operator relies on — a forge credential authenticates only on its own forge,
+// so every clone that succeeds today still succeeds, and the clones that stop
+// carrying the token were only ever leaking it. Which host that is comes from
+// forgeGitHost, whose one ambiguous input (a GHE API on an api.* subdomain) is a
+// config-load failure rather than a guess, because guessing it wrong would
+// withhold the credential from every GitOps repo and show up only as an empty
+// what_changed.
 //
-// SSHRewriteHost is left EMPTY when there is no GitHub App credential, because
-// githubGitHost would otherwise name github.com for a deployment that holds no
-// github.com token — a host the rewrite must not trust on that basis. On a GitLab
-// forge BuildForgeTokenSource returns nil (it mints GitHub App tokens only), so
-// SSH repoURLs there still fail exactly as RunLore #495 reports. That gap is
-// LOGGED rather than papered over: handing the GitOps differ a GitLab credential
-// is a new credential path and belongs in its own change — the way
-// BuildKBTokenSource was split out for the identical silent failure on catalog
-// sync (see forge.go).
+// SSHRewriteHost is the same host for a narrower reason: the SSH→HTTPS rewrite
+// turns a repoURL into a live HTTPS request, so it may only aim at the host the
+// credential is for (see whatchanged.Differ.effectiveCloneURL). Both stay EMPTY
+// when there is no credential at all — nothing to confine, and a rewrite with no
+// token would trade go-git's SSH-agent path for an anonymous 401.
+//
+// The credential follows forge.provider (BuildCloneTokenSource), not the GitHub
+// App alone. It was the App alone, which left a GitLab forge with no clone
+// credential whatsoever: a private GitOps repo cloned ANONYMOUSLY and
+// what_changed produced nothing for any object — the same silent severing catalog
+// sync suffered, in the same shape, at a second seam.
 func buildGitOpsDiffer(cfg *config.Config, log *slog.Logger) *whatchanged.Differ {
-	differ := &whatchanged.Differ{TokenSource: BuildForgeTokenSource(cfg, log)}
+	differ := &whatchanged.Differ{TokenSource: BuildCloneTokenSource(cfg, log)}
 	if differ.TokenSource != nil {
-		differ.SSHRewriteHost = githubGitHost(cfg.Forge.GitHubAPIURL)
+		host := forgeGitHost(cfg)
+		differ.TokenHost, differ.SSHRewriteHost = host, host
+		log.Info("what_changed: forge credential confined to the forge git host", "git_host", host)
 	} else {
-		log.Warn("what_changed: no GitHub App credential; SSH repoURLs cannot be cloned and are "+
-			"not rewritten to HTTPS — change correlation stays empty for any GitOps object "+
-			"whose source is an SSH URL", "forge_provider", cfg.Forge.Provider)
+		log.Warn("what_changed: no forge credential; GitOps repos are cloned anonymously and SSH "+
+			"repoURLs are not rewritten to HTTPS — change correlation stays empty for any private "+
+			"repo, and for any GitOps object whose source is an SSH URL",
+			"forge_provider", cfg.Forge.Provider)
 	}
 	if cfg.GitOps.Mirror.IsEnabled() {
 		if mc, err := whatchanged.NewMirrorCache(cfg.GitOps.Mirror.Dir, cfg.GitOps.Mirror.Max); err != nil {

--- a/internal/app/gitops.go
+++ b/internal/app/gitops.go
@@ -23,7 +23,33 @@ import (
 // on the source repo). A nil token source (no App configured) means public/local
 // repos only.
 func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) providers.GitOpsProvider {
-	differ := &whatchanged.Differ{TokenSource: BuildForgeTokenSource(cfg, log)}
+	differ := buildGitOpsDiffer(cfg, log)
+	if GitopsEngine(cfg) == "argocd" {
+		log.Info("gitops engine", "engine", "argocd")
+		return argocd.New(argocd.NewDynamicReader(dc), differ)
+	}
+	log.Info("gitops engine", "engine", "flux")
+	return flux.New(flux.NewDynamicReader(dc), differ)
+}
+
+// buildGitOpsDiffer builds the what_changed differ. Split out of BuildGitOps so
+// the credential wiring is reachable by a test: BuildGitOps hands the differ to a
+// provider that keeps it unexported, and an unset SSHRewriteHost would silently
+// leave RunLore #495 unfixed.
+//
+// SSHRewriteHost is set — and TokenHost deliberately is not. The differ may only
+// rewrite an SSH repoURL into a live HTTPS request toward the host the App token
+// is actually for, so an attacker-chosen "repoURL: ssh://git@attacker.example/x"
+// stays SSH and dies at "invalid auth method" with nothing transmitted. Leaving
+// TokenHost unset keeps every HTTPS clone that works today byte-identical,
+// including a GitHub Enterprise install whose API host differs from its git host
+// (githubGitHost derives from the API URL, so confining auth on it could withhold
+// the credential from a repo that clones fine today).
+func buildGitOpsDiffer(cfg *config.Config, log *slog.Logger) *whatchanged.Differ {
+	differ := &whatchanged.Differ{
+		TokenSource:    BuildForgeTokenSource(cfg, log),
+		SSHRewriteHost: githubGitHost(cfg.Forge.GitHubAPIURL),
+	}
 	if cfg.GitOps.Mirror.IsEnabled() {
 		if mc, err := whatchanged.NewMirrorCache(cfg.GitOps.Mirror.Dir, cfg.GitOps.Mirror.Max); err != nil {
 			log.Warn("gitops: mirror cache unavailable; falling back to clone-per-call", "err", err)
@@ -31,12 +57,7 @@ func BuildGitOps(cfg *config.Config, dc dynamic.Interface, log *slog.Logger) pro
 			differ.Mirrors = mc
 		}
 	}
-	if GitopsEngine(cfg) == "argocd" {
-		log.Info("gitops engine", "engine", "argocd")
-		return argocd.New(argocd.NewDynamicReader(dc), differ)
-	}
-	log.Info("gitops engine", "engine", "flux")
-	return flux.New(flux.NewDynamicReader(dc), differ)
+	return differ
 }
 
 // BuildExecutor returns the rung-2/3 action executor for the configured GitOps

--- a/internal/app/gitops_token_test.go
+++ b/internal/app/gitops_token_test.go
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// cloneSecret is the credential these tests watch for on the wire. It stands in
+// for the minted GitHub App installation token / the GitLab access token: the
+// real sources are swapped out AFTER buildGitOpsDiffer has wired the differ, so
+// what is under test is the confinement, not the minting (which would need a
+// live forge).
+const cloneSecret = "tok_CLONE_SECRET"
+
+// recordingRemote is a stand-in git remote. It answers every request with 404 —
+// go-git gives up immediately — while recording that the request ARRIVED and
+// which credential it carried.
+//
+// Both halves matter. The credential assertion alone is vacuous: a differ that
+// never dials at all (a refused rewrite, a parse failure, a typo in the test's
+// URL) also records no Authorization header, so every leak test here first
+// asserts the request reached the remote. That is the HTTPS analogue of
+// TestSSHRewriteNeverReachesAForeignHost's paired "invalid auth method" check.
+type recordingRemote struct {
+	srv *httptest.Server
+
+	mu    sync.Mutex
+	hits  int
+	saw   bool   // a request carried HTTP basic auth
+	token string // the password it carried
+}
+
+func newRecordingRemote(t *testing.T) *recordingRemote {
+	t.Helper()
+	r := &recordingRemote{}
+	r.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		_, pass, ok := req.BasicAuth()
+		r.mu.Lock()
+		r.hits++
+		if ok {
+			r.saw, r.token = true, pass
+		}
+		r.mu.Unlock()
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(r.srv.Close)
+	return r
+}
+
+// host is the remote's bare host, with no port — the spelling forge.git_host
+// takes and the spelling the differ compares a clone URL against.
+func (r *recordingRemote) host(t *testing.T) string {
+	t.Helper()
+	u, err := url.Parse(r.srv.URL)
+	if err != nil {
+		t.Fatalf("parse stub remote url: %v", err)
+	}
+	return u.Hostname()
+}
+
+func (r *recordingRemote) cloneURL() string { return r.srv.URL + "/org/repo.git" }
+
+func (r *recordingRemote) observed() (hits int, saw bool, token string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.hits, r.saw, r.token
+}
+
+// gitlabForge returns a config whose forge is a self-managed GitLab at host,
+// with a live access token in the environment.
+func gitlabForge(t *testing.T, host string) *config.Config {
+	t.Helper()
+	t.Setenv("TEST_GITOPS_GITLAB_TOKEN", cloneSecret)
+	cfg := &config.Config{}
+	cfg.Forge.Provider = "gitlab"
+	cfg.Forge.GitLab.BaseURL = "https://" + host
+	cfg.Forge.GitLab.TokenEnv = "TEST_GITOPS_GITLAB_TOKEN"
+	return cfg
+}
+
+// TestBuildGitOpsDifferConfinesTheForgeCredential pins WHICH host the
+// what_changed differ may send its forge credential to.
+//
+// A GitOps spec.source.repoURL is cluster state: in a shared cluster anyone who
+// can create an Argo CD Application or a Flux GitRepository chooses it. Until
+// this was confined, the differ ran with TokenHost EMPTY, so "repoURL:
+// https://attacker.example/org/repo.git" received the GitHub App installation
+// token. Confining costs nothing an operator relies on — a forge credential is
+// only ever valid on its own forge, so a clone that authenticates today keeps
+// authenticating and a clone on any other host was already going to fail, just
+// noisily instead of leaking.
+//
+// SSHRewriteHost must track the same host: the rewrite turns an SSH repoURL into
+// a live HTTPS request, and it may only do that toward the host the credential
+// is for.
+func TestBuildGitOpsDifferConfinesTheForgeCredential(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  func(t *testing.T) *config.Config
+		want string
+	}{
+		{
+			name: "default github",
+			cfg:  forgeConfigured,
+			want: "github.com",
+		},
+		{
+			name: "github enterprise, api on the git host",
+			cfg: func(t *testing.T) *config.Config {
+				c := forgeConfigured(t)
+				c.Forge.GitHubAPIURL = "https://ghe.example.com/api/v3"
+				return c
+			},
+			want: "ghe.example.com",
+		},
+		{
+			// Subdomain isolation: the API is at api.HOST, git is at HOST. The
+			// API URL cannot answer which host serves git, so the operator names
+			// it — config.Validate refuses this shape without the override
+			// rather than letting the credential be withheld from every repo.
+			name: "github enterprise with subdomain isolation, git host named",
+			cfg: func(t *testing.T) *config.Config {
+				c := forgeConfigured(t)
+				c.Forge.GitHubAPIURL = "https://api.ghe.example.com"
+				c.Forge.GitHost = "ghe.example.com"
+				return c
+			},
+			want: "ghe.example.com",
+		},
+		{
+			name: "gitlab follows its instance root",
+			cfg:  func(t *testing.T) *config.Config { return gitlabForge(t, "gitlab.example.com") },
+			want: "gitlab.example.com",
+		},
+		{
+			name: "gitlab.com by default",
+			cfg: func(t *testing.T) *config.Config {
+				c := gitlabForge(t, "unused.example")
+				c.Forge.GitLab.BaseURL = ""
+				return c
+			},
+			want: "gitlab.com",
+		},
+		{
+			// An explicit override wins on every provider, not only GitHub.
+			name: "git_host overrides the derived host",
+			cfg: func(t *testing.T) *config.Config {
+				c := gitlabForge(t, "gitlab.example.com")
+				c.Forge.GitHost = "Git.Example.COM"
+				return c
+			},
+			want: "git.example.com",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := buildGitOpsDiffer(tc.cfg(t), discardLog())
+			if d.TokenSource == nil {
+				t.Fatal("no clone credential was wired; this test's premise is stale")
+			}
+			if d.TokenHost != tc.want {
+				t.Fatalf("TokenHost = %q, want %q — an unconfined differ sends the forge "+
+					"credential to whatever host a repoURL names", d.TokenHost, tc.want)
+			}
+			if d.SSHRewriteHost != tc.want {
+				t.Fatalf("SSHRewriteHost = %q, want %q — the rewrite must aim at the same host "+
+					"the credential is for", d.SSHRewriteHost, tc.want)
+			}
+		})
+	}
+
+	// No credential at all (an unconfigured forge; a GitLab one whose token_env is
+	// unset). There is nothing to confine, and the rewrite must NOT be armed on a
+	// host merely derived from a forge URL — rewriting an SSH repoURL with no token
+	// in hand trades go-git's SSH-agent path for an anonymous HTTPS 401 (#495).
+	t.Run("no credential arms nothing", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Forge.Provider = "gitlab"
+		d := buildGitOpsDiffer(cfg, discardLog())
+		if d.TokenSource != nil {
+			t.Fatal("an unconfigured forge must yield no clone credential; this test's premise is stale")
+		}
+		if d.SSHRewriteHost != "" || d.TokenHost != "" {
+			t.Fatalf("TokenHost = %q, SSHRewriteHost = %q with no credential, want both empty",
+				d.TokenHost, d.SSHRewriteHost)
+		}
+	})
+}
+
+// TestWhatChangedCredentialNeverReachesAForeignHost is the transport-level
+// proof: not "auth() returned nil" but "nothing carrying the credential arrived
+// at the attacker's server".
+func TestWhatChangedCredentialNeverReachesAForeignHost(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  func(t *testing.T) *config.Config
+	}{
+		{"github app", forgeConfigured},
+		{"gitlab token", func(t *testing.T) *config.Config { return gitlabForge(t, "gitlab.example.com") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attacker := newRecordingRemote(t)
+			d := buildGitOpsDiffer(tc.cfg(t), discardLog())
+			d.TokenSource = func(context.Context) (string, error) { return cloneSecret, nil }
+
+			if _, err := d.Remote(context.Background(), attacker.cloneURL(), "a", "b", ""); err == nil {
+				t.Fatal("want a clone error from the stub remote, got nil")
+			}
+			hits, saw, tok := attacker.observed()
+			if hits == 0 {
+				t.Fatal("no request reached the stub remote — the credential assertion below " +
+					"would pass vacuously")
+			}
+			if saw {
+				t.Fatalf("the forge credential was sent to a host the repoURL merely named: "+
+					"basic-auth password %q reached %s", tok, attacker.host(t))
+			}
+		})
+	}
+}
+
+// TestWhatChangedAuthenticatesItsOwnGitHost is the other direction, and the
+// reason this confinement was deferred once already: withholding the credential
+// from the operator's OWN GitOps repo turns every what_changed into an empty
+// result, reported only as a data-gaps line (RunLore #495).
+//
+// The config here is the shape that makes the derivation ambiguous — GitHub
+// Enterprise with subdomain isolation, API at api.HOST and git at HOST — resolved
+// by naming the git host explicitly.
+func TestWhatChangedAuthenticatesItsOwnGitHost(t *testing.T) {
+	forge := newRecordingRemote(t)
+	cfg := forgeConfigured(t)
+	cfg.Forge.GitHubAPIURL = "https://api." + forge.host(t)
+	cfg.Forge.GitHost = forge.host(t)
+
+	d := buildGitOpsDiffer(cfg, discardLog())
+	d.TokenSource = func(context.Context) (string, error) { return cloneSecret, nil }
+
+	if _, err := d.Remote(context.Background(), forge.cloneURL(), "a", "b", ""); err == nil {
+		t.Fatal("want a clone error from the stub remote, got nil")
+	}
+	hits, saw, tok := forge.observed()
+	if hits == 0 {
+		t.Fatal("no request reached the operator's own forge")
+	}
+	if !saw || tok != cloneSecret {
+		t.Fatalf("the operator's own GitOps repo cloned WITHOUT the forge credential "+
+			"(saw=%v token=%q) — a private repo would produce no diff at all, the silent "+
+			"data gap this confinement must not reintroduce", saw, tok)
+	}
+}

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -50,8 +50,8 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 	}
 	model := BuildModel(cfg, apiKey)
 	// Catalog sync reads the KB repo, so it follows forge.provider — not the
-	// GitHub-App-only source used by the curate/sweep/differ paths.
-	forgeTok := BuildKBTokenSource(cfg, log)
+	// GitHub-App-only source the curate/sweep paths talk to the API with.
+	forgeTok := BuildCloneTokenSource(cfg, log)
 	var tools []investigate.Tool
 	if gp != nil {
 		tools = append(tools, investigate.WhatChangedTool{GitOps: gp})
@@ -334,13 +334,16 @@ func appendSourceDiffTool(cfg *config.Config, tools []investigate.Tool, log *slo
 		log.Warn("source_repos: invalid allowlist; source_diff disabled", "err", err)
 		return tools
 	}
-	// Confine the GitHub App token to the forge's own host: source_diff clone
-	// URLs are model-chosen across the whole allowlist, so without this a
-	// github.com token would be transmitted to any other allowlisted host (e.g.
-	// a gitlab.com repo). Off-host repos clone anonymously.
+	// Confine the forge credential to the forge's own git host: source_diff clone
+	// URLs are model-chosen across the whole allowlist, so without this the token
+	// would be transmitted to any other allowlisted host (e.g. a gitlab.com repo
+	// on a GitHub forge). Off-host repos clone anonymously. The credential and the
+	// host it is confined to come from the same provider switch that what_changed
+	// uses, so a GitLab forge confines a GitLab token to the GitLab host rather
+	// than pinning it to github.com — a mismatch there withholds silently.
 	sd := &whatchanged.Differ{
-		TokenSource: BuildForgeTokenSource(cfg, log),
-		TokenHost:   githubGitHost(cfg.Forge.GitHubAPIURL),
+		TokenSource: BuildCloneTokenSource(cfg, log),
+		TokenHost:   forgeGitHost(cfg),
 	}
 	if cfg.GitOps.Mirror.IsEnabled() {
 		base := cfg.GitOps.Mirror.Dir

--- a/internal/app/sourcediff_wiring_test.go
+++ b/internal/app/sourcediff_wiring_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/Smana/runlore/internal/config"
+	"github.com/Smana/runlore/internal/investigate"
+	"github.com/Smana/runlore/internal/whatchanged"
 )
 
 func TestAppendSourceDiffTool(t *testing.T) {
@@ -25,22 +27,64 @@ func TestAppendSourceDiffTool(t *testing.T) {
 			t.Fatalf("source_diff not registered; got %v", toolNames(got))
 		}
 	})
+	// source_diff's clone URLs come out of sourcerepo.Allowlist.Match, which
+	// already emits HTTPS — so the SSH→HTTPS rewrite has nothing to do there and
+	// must stay off. Setting SSHRewriteHost would arm a rewrite on a path whose
+	// URLs are MODEL-chosen across the whole allowlist, which is exactly the input
+	// the allowlist exists to distrust. TokenHost, by contrast, must stay set:
+	// that is what stops a github.com token being sent to an allowlisted repo on
+	// another host.
+	t.Run("source_diff arms no SSH rewrite and keeps its token confined", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.SourceRepos.Allow = []string{"github.com/acme/*"}
+		d := sourceDifferFrom(t, appendSourceDiffTool(cfg, nil, log))
+		if d.SSHRewriteHost != "" {
+			t.Fatalf("source_diff SSHRewriteHost = %q, want empty — its clone URLs are already "+
+				"HTTPS and model-chosen; the rewrite must not be armed there", d.SSHRewriteHost)
+		}
+		if d.TokenHost != "github.com" {
+			t.Fatalf("source_diff TokenHost = %q, want github.com — the token must stay confined "+
+				"to the forge host across a multi-host allowlist", d.TokenHost)
+		}
+	})
+}
+
+// sourceDifferFrom digs the concrete Differ out of the registered source_diff
+// tool so its credential wiring can be asserted.
+func sourceDifferFrom(t *testing.T, tools []investigate.Tool) *whatchanged.Differ {
+	t.Helper()
+	for _, tl := range tools {
+		sd, ok := tl.(investigate.SourceDiffTool)
+		if !ok {
+			continue
+		}
+		d, ok := sd.Source.(*whatchanged.Differ)
+		if !ok {
+			t.Fatalf("source_diff Source is %T, want *whatchanged.Differ", sd.Source)
+		}
+		return d
+	}
+	t.Fatal("source_diff tool not registered")
+	return nil
 }
 
 // TestBuildGitOpsDifferConfinesSSHRewrite pins the what_changed credential
 // wiring (RunLore #495).
 //
-// Two halves, and BOTH are load-bearing:
+// Three halves, all load-bearing:
 //
-//   - SSHRewriteHost must be SET, or the SSH→HTTPS rewrite never fires and #495
-//     is silently un-fixed — the exact silent-data-gap failure the issue is about.
+//   - With a GitHub App credential, SSHRewriteHost must be SET, or the SSH→HTTPS
+//     rewrite never fires and #495 is silently un-fixed — the exact silent-data-gap
+//     failure the issue is about.
 //   - TokenHost must stay UNSET, because it governs which clones may carry the
 //     token and is derived from the forge API URL. A GitHub Enterprise install
 //     whose API host differs from its git host would start withholding the
 //     credential from repos that clone fine today.
+//   - With NO credential, SSHRewriteHost must stay EMPTY: githubGitHost would
+//     otherwise name github.com for a deployment holding no github.com token.
 //
-// The rewrite is confined by SSHRewriteHost instead, so a wrong host costs an
-// unrewritten SSH URL rather than a broken clone or a leaked credential.
+// The rewrite is confined by SSHRewriteHost instead of TokenHost, so a wrong host
+// costs an unrewritten SSH URL rather than a broken clone or a leaked credential.
 func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
 	log := slog.Default()
 	for _, tc := range []struct{ name, apiURL, want string }{
@@ -48,7 +92,7 @@ func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
 		{"github enterprise", "https://ghe.example.com/api/v3", "ghe.example.com"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := &config.Config{}
+			cfg := forgeConfigured(t)
 			cfg.Forge.GitHubAPIURL = tc.apiURL
 			d := buildGitOpsDiffer(cfg, log)
 			if d.SSHRewriteHost != tc.want {
@@ -61,6 +105,23 @@ func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
 			}
 		})
 	}
+
+	// No GitHub App (an unconfigured forge, or a GitLab one — BuildForgeTokenSource
+	// mints GitHub App tokens only). githubGitHost would still say "github.com",
+	// which must NOT become an armed rewrite host for a deployment that holds no
+	// github.com token. #495 stays open on that path; buildGitOpsDiffer logs it.
+	t.Run("no credential arms no rewrite", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.Forge.Provider = "gitlab"
+		d := buildGitOpsDiffer(cfg, log)
+		if d.TokenSource != nil {
+			t.Fatal("BuildForgeTokenSource must be nil without a GitHub App; this test's premise is stale")
+		}
+		if d.SSHRewriteHost != "" {
+			t.Fatalf("SSHRewriteHost = %q with no credential, want empty — the rewrite must not trust "+
+				"a host derived from a forge URL when no token for it exists", d.SSHRewriteHost)
+		}
+	})
 }
 
 func TestGithubGitHost(t *testing.T) {

--- a/internal/app/sourcediff_wiring_test.go
+++ b/internal/app/sourcediff_wiring_test.go
@@ -27,6 +27,42 @@ func TestAppendSourceDiffTool(t *testing.T) {
 	})
 }
 
+// TestBuildGitOpsDifferConfinesSSHRewrite pins the what_changed credential
+// wiring (RunLore #495).
+//
+// Two halves, and BOTH are load-bearing:
+//
+//   - SSHRewriteHost must be SET, or the SSH→HTTPS rewrite never fires and #495
+//     is silently un-fixed — the exact silent-data-gap failure the issue is about.
+//   - TokenHost must stay UNSET, because it governs which clones may carry the
+//     token and is derived from the forge API URL. A GitHub Enterprise install
+//     whose API host differs from its git host would start withholding the
+//     credential from repos that clone fine today.
+//
+// The rewrite is confined by SSHRewriteHost instead, so a wrong host costs an
+// unrewritten SSH URL rather than a broken clone or a leaked credential.
+func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
+	log := slog.Default()
+	for _, tc := range []struct{ name, apiURL, want string }{
+		{"default forge", "", "github.com"},
+		{"github enterprise", "https://ghe.example.com/api/v3", "ghe.example.com"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Forge.GitHubAPIURL = tc.apiURL
+			d := buildGitOpsDiffer(cfg, log)
+			if d.SSHRewriteHost != tc.want {
+				t.Fatalf("SSHRewriteHost = %q, want %q — an unset host leaves SSH repoURLs unclonable (#495)",
+					d.SSHRewriteHost, tc.want)
+			}
+			if d.TokenHost != "" {
+				t.Fatalf("TokenHost = %q, want empty — confining auth here changes every HTTPS clone that "+
+					"works today; the SSH rewrite is confined by SSHRewriteHost instead", d.TokenHost)
+			}
+		})
+	}
+}
+
 func TestGithubGitHost(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
 		{"", "github.com"},

--- a/internal/app/sourcediff_wiring_test.go
+++ b/internal/app/sourcediff_wiring_test.go
@@ -68,62 +68,6 @@ func sourceDifferFrom(t *testing.T, tools []investigate.Tool) *whatchanged.Diffe
 	return nil
 }
 
-// TestBuildGitOpsDifferConfinesSSHRewrite pins the what_changed credential
-// wiring (RunLore #495).
-//
-// Three halves, all load-bearing:
-//
-//   - With a GitHub App credential, SSHRewriteHost must be SET, or the SSH→HTTPS
-//     rewrite never fires and #495 is silently un-fixed — the exact silent-data-gap
-//     failure the issue is about.
-//   - TokenHost must stay UNSET, because it governs which clones may carry the
-//     token and is derived from the forge API URL. A GitHub Enterprise install
-//     whose API host differs from its git host would start withholding the
-//     credential from repos that clone fine today.
-//   - With NO credential, SSHRewriteHost must stay EMPTY: githubGitHost would
-//     otherwise name github.com for a deployment holding no github.com token.
-//
-// The rewrite is confined by SSHRewriteHost instead of TokenHost, so a wrong host
-// costs an unrewritten SSH URL rather than a broken clone or a leaked credential.
-func TestBuildGitOpsDifferConfinesSSHRewrite(t *testing.T) {
-	log := slog.Default()
-	for _, tc := range []struct{ name, apiURL, want string }{
-		{"default forge", "", "github.com"},
-		{"github enterprise", "https://ghe.example.com/api/v3", "ghe.example.com"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := forgeConfigured(t)
-			cfg.Forge.GitHubAPIURL = tc.apiURL
-			d := buildGitOpsDiffer(cfg, log)
-			if d.SSHRewriteHost != tc.want {
-				t.Fatalf("SSHRewriteHost = %q, want %q — an unset host leaves SSH repoURLs unclonable (#495)",
-					d.SSHRewriteHost, tc.want)
-			}
-			if d.TokenHost != "" {
-				t.Fatalf("TokenHost = %q, want empty — confining auth here changes every HTTPS clone that "+
-					"works today; the SSH rewrite is confined by SSHRewriteHost instead", d.TokenHost)
-			}
-		})
-	}
-
-	// No GitHub App (an unconfigured forge, or a GitLab one — BuildForgeTokenSource
-	// mints GitHub App tokens only). githubGitHost would still say "github.com",
-	// which must NOT become an armed rewrite host for a deployment that holds no
-	// github.com token. #495 stays open on that path; buildGitOpsDiffer logs it.
-	t.Run("no credential arms no rewrite", func(t *testing.T) {
-		cfg := &config.Config{}
-		cfg.Forge.Provider = "gitlab"
-		d := buildGitOpsDiffer(cfg, log)
-		if d.TokenSource != nil {
-			t.Fatal("BuildForgeTokenSource must be nil without a GitHub App; this test's premise is stale")
-		}
-		if d.SSHRewriteHost != "" {
-			t.Fatalf("SSHRewriteHost = %q with no credential, want empty — the rewrite must not trust "+
-				"a host derived from a forge URL when no token for it exists", d.SSHRewriteHost)
-		}
-	})
-}
-
 func TestGithubGitHost(t *testing.T) {
 	for _, tc := range []struct{ in, want string }{
 		{"", "github.com"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1392,6 +1392,85 @@ func validGitLabProjectPath(s string) bool {
 	return gitlabProjectPathRE.MatchString(s)
 }
 
+// validateForgeGitHost checks that RunLore can name — unambiguously — the ONE
+// git host its forge credential may be sent to.
+//
+// Every clone RunLore makes (what_changed's GitOps source repos, source_diff's
+// allowlisted repos) attaches the forge credential only when the clone URL's
+// host matches that host, because a GitOps spec.source.repoURL is cluster state:
+// in a shared cluster, whoever can create an Argo CD Application or a Flux
+// GitRepository chooses where an unconfined credential would be POSTed.
+//
+// Confining is only safe when the host is KNOWN, and there is exactly one shape
+// where it is not. GitHub Enterprise with subdomain isolation serves the API from
+// api.HOSTNAME while git and web stay on HOSTNAME, so "https://api.ghe.example.com"
+// is consistent with both "git lives at ghe.example.com" (isolation) and "git
+// lives at api.ghe.example.com" (an instance that happens to be named api.*).
+// Both guesses fail badly and one of them fails SILENTLY: withholding the
+// credential from the operator's own GitOps repo empties what_changed on every
+// investigation, surfacing only as a data-gaps line at the foot of a finding
+// (RunLore #495). So the ambiguity is refused at config load and the operator
+// names the host — loud once, at startup, instead of quiet forever.
+func validateForgeGitHost(f Forge) error {
+	if f.GitHost != "" {
+		if !bareHost(f.GitHost) {
+			return fmt.Errorf("forge.git_host %q is not a bare host: want just the hostname your git "+
+				"remotes use (e.g. \"ghe.example.com\"), with no scheme, path, port, userinfo or "+
+				"non-ASCII characters. It is compared against the host of every clone URL, so any "+
+				"other spelling matches nothing and silently withholds the forge credential from "+
+				"every repository", f.GitHost)
+		}
+		return nil
+	}
+	if f.Provider == "gitlab" {
+		return nil // gitlab.base_url IS the instance root: git, web and API share that host
+	}
+	u, err := url.Parse(f.GitHubAPIURL)
+	if err != nil {
+		return nil // unparseable ⇒ the github.com default; nothing ambiguous to resolve
+	}
+	h := strings.ToLower(u.Hostname())
+	if h == "" || h == "api.github.com" || !strings.HasPrefix(h, "api.") {
+		return nil
+	}
+	return fmt.Errorf("forge.github_api_url %q serves the API from an \"api.\" subdomain, so RunLore "+
+		"cannot tell which host serves your git remotes: set forge.git_host to %q if this is GitHub "+
+		"Enterprise with subdomain isolation (API on api.HOSTNAME, git on HOSTNAME), or to %q if git "+
+		"really is served from the API host. Guessing would either send the installation token to a "+
+		"host it is not valid for, or withhold it from every GitOps repository — which shows up only "+
+		"as an empty what_changed",
+		f.GitHubAPIURL, strings.TrimPrefix(h, "api."), h)
+}
+
+// bareHost reports whether s is a hostname and nothing else: ASCII letters,
+// digits, '-' and '.', starting and ending alphanumeric. It is deliberately
+// narrower than "what net/url would parse" — a scheme, a path, a port, userinfo
+// or a non-ASCII label all mean the operator wrote something that can never
+// equal a clone URL's parsed host.
+//
+// ASCII-only is the same guard internal/whatchanged applies to a rewrite host
+// and internal/sourcerepo applies to an allowlist entry: host comparison
+// lowercases with strings.ToLower (Unicode simple case mapping) while net/http
+// resolves through idna.Lookup.ToASCII, and the two disagree on non-ASCII input
+// — "gİthub.com" compares equal to "github.com" while the connection goes to the
+// separately registrable "xn--github-qyd.com".
+func bareHost(s string) bool {
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		alnum := c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
+		if !alnum && c != '-' && c != '.' {
+			return false
+		}
+		if !alnum && (i == 0 || i == len(s)-1) {
+			return false
+		}
+	}
+	return true
+}
+
 // checkSecureKeyEndpoint rejects a base_url that would send an API key in cleartext.
 // A key is "present" when apiKeyEnv is non-empty; an empty base_url uses the provider's
 // built-in (https) default and is always fine. http is allowed only to a private host.
@@ -1790,6 +1869,9 @@ func (c *Config) Validate() error {
 	default:
 		return fmt.Errorf("forge.provider %q is invalid (want \"github\" or \"gitlab\")", c.Forge.Provider)
 	}
+	if err := validateForgeGitHost(c.Forge); err != nil {
+		return err
+	}
 	// The recurrence cooldown reads the outcome ledger's trigger index; without a
 	// ledger it would silently never suppress — fail loud instead. A negative
 	// duration is always a misconfiguration (mirrors tool_timeout).
@@ -2165,6 +2247,25 @@ type Forge struct {
 	// inconclusive). Empty (default) draws no distinction: every verdict is eligible,
 	// preserving pre-gate behaviour. Recommended production value: ["no_action"].
 	SkipVerdicts []string `yaml:"skip_verdicts"`
+	// GitHost names the host the forge serves GIT REMOTES from — the ONE host
+	// RunLore's forge credential may be sent to when it clones (what_changed's
+	// GitOps repos, source_diff's allowlisted repos). Empty (the default) derives
+	// it: github_api_url's host for GitHub (api.github.com ⇒ github.com),
+	// gitlab.base_url's host for GitLab.
+	//
+	// It exists for GitHub Enterprise with SUBDOMAIN ISOLATION, the one shape the
+	// derivation cannot resolve: the API is served from api.HOSTNAME while git and
+	// web stay on HOSTNAME, so an API URL of "https://api.ghe.example.com" says
+	// nothing about which of the two hosts a clone should authenticate to.
+	// Guessing is not an option in either direction — guess api.HOSTNAME and the
+	// credential is withheld from every GitOps repo (an empty what_changed on
+	// every investigation, visible only as a data-gaps line, RunLore #495); guess
+	// HOSTNAME and a deployment that really does serve git from api.HOSTNAME sends
+	// its token to a host it is not valid for. Validate therefore REFUSES an
+	// "api."-prefixed API host (other than api.github.com) unless this names the
+	// git host, so the misconfiguration is loud at startup instead of silent
+	// forever. A bare host: no scheme, path, port, userinfo, and ASCII only.
+	GitHost string `yaml:"git_host"`
 }
 
 // GitLab holds GitLab forge credentials. Unlike GitHubApp (a short-lived,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -942,6 +942,90 @@ func TestValidateForgeProviderGitLab(t *testing.T) {
 	}
 }
 
+// TestValidateForgeGitHost pins the startup contract for the host RunLore's
+// forge credential may be cloned with.
+//
+// The credential is confined to that ONE host (a GitOps repoURL is cluster
+// state, so anyone who can create an Argo CD Application would otherwise pick
+// where the token goes). Confining is only safe if the host is KNOWN, and there
+// is exactly one shape where it is not: GitHub Enterprise with subdomain
+// isolation serves the API from api.HOSTNAME and git from HOSTNAME, so the API
+// URL cannot answer the question. Guessing api.HOSTNAME would withhold the
+// credential from every GitOps repo — the silent data gap of RunLore #495,
+// traded for a leak. So that shape is refused at config load, loudly, until the
+// operator names the git host.
+func TestValidateForgeGitHost(t *testing.T) {
+	t.Run("api-subdomain forge api url is refused without git_host", func(t *testing.T) {
+		c := &Config{}
+		c.Forge.GitHubAPIURL = "https://api.ghe.example.com"
+		err := c.Validate()
+		if err == nil || !strings.Contains(err.Error(), "forge.git_host") {
+			t.Fatalf("a subdomain-isolated GHE api url must fail load naming forge.git_host, got: %v", err)
+		}
+	})
+
+	t.Run("naming the git host resolves it", func(t *testing.T) {
+		c := &Config{}
+		c.Forge.GitHubAPIURL = "https://api.ghe.example.com"
+		c.Forge.GitHost = "ghe.example.com"
+		if err := c.Validate(); err != nil {
+			t.Fatalf("an explicit git host must validate clean, got: %v", err)
+		}
+	})
+
+	// Every unambiguous shape keeps working with no new config: this must not
+	// become a key every operator has to learn.
+	for _, apiURL := range []string{
+		"",                                // github.com
+		"https://api.github.com",          // github.com, spelled out
+		"https://ghe.example.com/api/v3",  // GHE without subdomain isolation
+		"https://api-gateway.example.com", // "api" is a label PREFIX here, not a label
+		"not a url",
+	} {
+		t.Run("unambiguous api url "+apiURL, func(t *testing.T) {
+			c := &Config{}
+			c.Forge.GitHubAPIURL = apiURL
+			if err := c.Validate(); err != nil {
+				t.Fatalf("github_api_url %q must validate clean without forge.git_host, got: %v", apiURL, err)
+			}
+		})
+	}
+
+	// git_host is compared against a clone URL's host, which arrives already
+	// reduced to a bare hostname. Anything that is not one would never match, so
+	// it would withhold the credential from every clone in silence.
+	for _, bad := range []string{
+		"https://ghe.example.com", // a URL, not a host
+		"ghe.example.com/api/v3",  // a path
+		"ghe.example.com:8443",    // a port (a clone URL's host is compared portless)
+		"git@ghe.example.com",     // userinfo
+		"ghe example.com",         // whitespace
+		"   ",                     // blank
+		"gİthub.com",              // non-ASCII: ToLower and IDNA disagree about which host this is
+	} {
+		t.Run("rejected git_host "+bad, func(t *testing.T) {
+			c := &Config{}
+			c.Forge.GitHost = bad
+			err := c.Validate()
+			if err == nil || !strings.Contains(err.Error(), "forge.git_host") {
+				t.Fatalf("forge.git_host %q must be refused at load, got: %v", bad, err)
+			}
+		})
+	}
+
+	// A GitLab forge derives its git host from base_url and needs no override,
+	// but may still set one.
+	t.Run("gitlab needs no git_host", func(t *testing.T) {
+		c := &Config{}
+		c.Forge.Provider = "gitlab"
+		c.Forge.GitLab.TokenEnv = "GITLAB_TOKEN"
+		c.Forge.GitLab.BaseURL = "https://gitlab.example.com"
+		if err := c.Validate(); err != nil {
+			t.Fatalf("a gitlab forge must validate clean without forge.git_host, got: %v", err)
+		}
+	})
+}
+
 // TestLogsIndexValidate: logs.index is interpolated into the Elasticsearch
 // request PATH. The client escapes it so a malformed value can no longer change
 // the request's SHAPE, but escaping alone turns a typo into a puzzling 4xx from

--- a/internal/investigate/sourcediff_tool_test.go
+++ b/internal/investigate/sourcediff_tool_test.go
@@ -56,12 +56,18 @@ func TestSourceDiffRejectsNonAllowlistedRepo(t *testing.T) {
 	}
 }
 
-// TestSourceDiffClonesOnlyTheAllowlistedURL guards the boundary that RunLore
-// #495's SSH→HTTPS clone normalisation must not weaken.
+// TestSourceDiffClonesOnlyTheAllowlistedURL pins pre-existing behaviour that
+// RunLore #495 depends on but does not change.
 //
-// The allowlist is a security control, and it is only a control while the string
-// it CHECKED is the string that gets CLONED. Whatever spelling the model sends —
-// including the SSH forms #495 taught the clone layer to understand — the URL
+// It exercises sourcerepo + SourceDiffTool ONLY: fakeSourceDiffer short-circuits
+// before any whatchanged code runs, so nothing here reaches the SSH→HTTPS
+// rewrite, and this passes unmodified against origin/main — by design. The
+// interaction between the rewrite and the allowlist is covered by
+// whatchanged.TestCloneRewriteCannotBypassSourceRepoAllowlist.
+//
+// What it pins is the precondition that test depends on: the allowlist is a
+// security control only while the string it CHECKED is the string that gets
+// CLONED. Whatever spelling the model sends — the SSH forms included — the URL
 // handed to the differ must be the canonical one Allowlist.Match itself produced,
 // never the model's raw text and never a second, independently-normalised copy of
 // it. Two normalisations of one input is exactly how an allow check gets bypassed.

--- a/internal/investigate/sourcediff_tool_test.go
+++ b/internal/investigate/sourcediff_tool_test.go
@@ -56,6 +56,60 @@ func TestSourceDiffRejectsNonAllowlistedRepo(t *testing.T) {
 	}
 }
 
+// TestSourceDiffClonesOnlyTheAllowlistedURL guards the boundary that RunLore
+// #495's SSH→HTTPS clone normalisation must not weaken.
+//
+// The allowlist is a security control, and it is only a control while the string
+// it CHECKED is the string that gets CLONED. Whatever spelling the model sends —
+// including the SSH forms #495 taught the clone layer to understand — the URL
+// handed to the differ must be the canonical one Allowlist.Match itself produced,
+// never the model's raw text and never a second, independently-normalised copy of
+// it. Two normalisations of one input is exactly how an allow check gets bypassed.
+func TestSourceDiffClonesOnlyTheAllowlistedURL(t *testing.T) {
+	const canonical = "https://github.com/acme/checkout"
+
+	t.Run("every allowed spelling collapses to the checked URL", func(t *testing.T) {
+		for _, repo := range []string{
+			"github.com/acme/checkout",
+			"https://github.com/acme/checkout.git",
+			"git@github.com:acme/checkout.git",
+			"ssh://git@github.com/acme/checkout",
+			"git@GitHub.COM:acme/checkout.git",
+		} {
+			f := &fakeSourceDiffer{sc: fixtureChanges()}
+			tool := SourceDiffTool{Source: f, Allow: mustAllow(t, "github.com/acme/*")}
+			if _, err := tool.Call(context.Background(), `{"repo":"`+repo+`","from":"1","to":"2"}`); err != nil {
+				t.Fatalf("%s: unexpected error: %v", repo, err)
+			}
+			if f.gotURL != canonical {
+				t.Fatalf("%s: cloned %q, want the allowlist's own canonical URL %q", repo, f.gotURL, canonical)
+			}
+		}
+	})
+
+	// Crafted so a sloppy normaliser and the allowlist would disagree: the SSH
+	// userinfo (or a path segment) names the ALLOWED host while the real
+	// authority is foreign. These must be refused outright — never reshaped into
+	// a URL that clones the foreign host.
+	t.Run("crafted host/userinfo divergence is refused, not normalised", func(t *testing.T) {
+		for _, repo := range []string{
+			"ssh://git@github.com@evil.example/acme/checkout",
+			"git@evil.example:github.com/acme/checkout",
+			"ssh://git@github.com:22/acme/checkout",
+			"git@github.com:acme/../evil/checkout.git",
+		} {
+			f := &fakeSourceDiffer{sc: fixtureChanges()}
+			tool := SourceDiffTool{Source: f, Allow: mustAllow(t, "github.com/acme/*")}
+			if _, err := tool.Call(context.Background(), `{"repo":"`+repo+`","from":"1","to":"2"}`); err == nil {
+				t.Fatalf("%s: want an allowlist rejection, got none (cloned %q)", repo, f.gotURL)
+			}
+			if f.gotURL != "" {
+				t.Fatalf("%s: a rejected repo still reached the clone layer as %q", repo, f.gotURL)
+			}
+		}
+	})
+}
+
 func TestSourceDiffSummary(t *testing.T) {
 	f := &fakeSourceDiffer{sc: fixtureChanges()}
 	tool := SourceDiffTool{Source: f, Allow: mustAllow(t, "github.com/acme/*")}

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -50,7 +50,9 @@ type Differ struct {
 	// their HTTPS equivalent (see effectiveCloneURL). It must be the host the
 	// TokenSource credential belongs to. Empty (the default) disables the rewrite
 	// entirely — fail closed — so a Differ that does not know where its credential
-	// is valid never turns an SSH URL into a live HTTPS request.
+	// is valid never turns an SSH URL into a live HTTPS request. It bounds the
+	// rewrite only; it is not a general credential boundary, and an HTTPS clone
+	// URL is unaffected by it (see effectiveCloneURL).
 	//
 	// It is deliberately NOT TokenHost, and folding the two together would be a
 	// silent regression in one direction or the other. TokenHost governs which
@@ -192,8 +194,9 @@ func (d *Differ) auth(ctx context.Context, cloneURL string) (transport.AuthMetho
 // An SSH rawURL is rewritten to its HTTPS equivalent first (see
 // effectiveCloneURL); every downstream key — clone cache, mirror dir, auth host
 // check — is derived from that ONE effective URL, so the URL authorized is
-// always the URL dialled, and an ssh:// and https:// spelling of the same repo
-// share a mirror instead of cloning twice.
+// always the URL dialled. Keys are the effective URL verbatim, not a canonical
+// form: two spellings of one repo share a clone only when they rewrite to the
+// same bytes, and case or a ".git" suffix is enough to keep them apart.
 func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repository, func(), error) {
 	noop := func() {}
 	url := d.effectiveCloneURL(rawURL)
@@ -251,17 +254,24 @@ func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repositor
 // very same repository; the installation still scopes what may be read, so this
 // grants no access the operator had not already granted.
 //
-// The rewrite is applied ONLY toward SSHRewriteHost, the host the credential is
-// actually for, and only when there is a credential at all. That confinement is
-// load-bearing, not tidiness. A GitOps repoURL is cluster state, so in a shared
-// cluster anyone who can create an Application picks it; the what_changed differ
+// The rewrite fires only toward SSHRewriteHost — the host the credential is for,
+// compared on an ASCII-only host so the comparison cannot disagree with the host
+// net/http will dial (see sshToHTTPS) — and only when there is a credential at
+// all. That confinement is load-bearing. A GitOps repoURL is cluster state, so in
+// a shared cluster anyone who can create an Application picks it, and this differ
 // runs with TokenHost empty, meaning auth attaches the App token to whatever host
-// it ends up cloning. Before this rewrite existed, "invalid auth method" rejected
-// every SSH URL before a single byte left the process — the bug was inadvertently
-// acting as a CREDENTIAL BOUNDARY. Rewriting unconfined would have removed that
-// boundary and turned "repoURL: ssh://git@attacker.example/x" into the App
-// installation token being POSTed to attacker.example. Do not "simplify" this
-// host check away without replacing what it holds.
+// it clones. Unconfined, the rewrite would turn
+// "repoURL: ssh://git@attacker.example/x" into that token being POSTed to
+// attacker.example. Do not "simplify" the host check away.
+//
+// WHAT THIS DOES NOT DO. It narrows the SSH path only. A hostile HTTPS repoURL —
+// "repoURL: https://attacker.example/x" — still receives the token today: auth is
+// unconfined on this differ and the rewrite never sees an HTTPS URL. That hole
+// predates the rewrite and is not closed here. Closing it means confining
+// TokenHost on this differ, which needs an operator override for a GitHub
+// Enterprise install whose API host differs from its git host, and is its own
+// change. Read this check as "the rewrite cannot introduce a new leak", not as a
+// credential boundary — it is not one.
 //
 // With no TokenSource (public or local repos) the raw SSH URL is kept so go-git's
 // default SSH-agent path remains available — rewriting it would trade a working
@@ -292,8 +302,22 @@ func (d *Differ) effectiveCloneURL(rawURL string) string {
 // carrying userinfo would let a crafted URL smuggle credentials into the
 // rewritten URL's authority.
 //
+// The host must also be pure ASCII. Every host comparison in this package goes
+// through hostOf, which lowercases with strings.ToLower — Unicode SIMPLE case
+// mapping — while net/http resolves the very same URL through
+// idna.Lookup.ToASCII. The two disagree on non-ASCII input, which puts the
+// authorization check on the wrong side of the disagreement: ToLower maps U+0130
+// ('İ') to 'i', so "gİthub.com" reads as "github.com" to effectiveCloneURL while
+// net/http dials the separately registrable "xn--github-qyd.com" — an attacker
+// registers it, serves a valid cert, and reads the App token off the
+// Authorization header. Refusing non-ASCII hosts kills the whole class
+// (homoglyphs, fullwidth forms, ZWSP, soft hyphen), not the one rune;
+// internal/sourcerepo's allowlist refuses them for the same reason, see
+// firstDisallowedRepoChar there.
+//
 // A rewrite is then either FAITHFUL or does not happen: the result must parse
-// back to exactly the host and path it was built from. An SSH path is opaque
+// back to the same host — up to ASCII case, since this comparison is EqualFold —
+// and the byte-identical path it was built from. An SSH path is opaque
 // bytes while an HTTPS path is not, so the path half of that round trip refuses a
 // '?' or '#' that would silently become a query or fragment, and percent-encoded
 // traversal ("%2e%2e") that a literal ".." scan misses. The host half is the
@@ -309,7 +333,7 @@ func (d *Differ) effectiveCloneURL(rawURL string) string {
 // Refusal costs nothing — the caller simply keeps the raw URL.
 func sshToHTTPS(rawURL string) (string, bool) {
 	ep, err := transport.NewEndpoint(strings.TrimSpace(rawURL))
-	if err != nil || ep.Protocol != "ssh" || ep.Host == "" {
+	if err != nil || ep.Protocol != "ssh" || ep.Host == "" || !isASCII(ep.Host) {
 		return "", false
 	}
 	repoPath := strings.TrimPrefix(ep.Path, "/")
@@ -324,10 +348,31 @@ func sshToHTTPS(rawURL string) (string, bool) {
 	return out, true
 }
 
+// isASCII reports whether s is free of bytes outside 7-bit ASCII. It is the
+// host-side guard in sshToHTTPS: see that function's comment for why a non-ASCII
+// host makes strings.ToLower and idna.Lookup.ToASCII disagree about which host is
+// being named.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
 // hostOf returns the lowercased host of an https/http/ssh clone URL, or "" for
-// a local path or an unparseable/hostless URL. Used by auth to confine a
-// host-scoped token; a "" host never equals a non-empty TokenHost, so a local
+// a local path or an unparseable/hostless URL.
+//
+// Two callers, and the second is stricter than the first. auth uses it to confine
+// a host-scoped token: a "" host never equals a non-empty TokenHost, so a local
 // clone is always treated as off-host (correct — local repos need no token).
+// effectiveCloneURL uses it to AUTHORIZE turning an SSH URL into a live HTTPS
+// request, which demands that the host named here be the host that is actually
+// dialled. strings.ToLower does not guarantee that for non-ASCII input, so
+// sshToHTTPS refuses non-ASCII hosts before this is ever consulted for that
+// decision. Anything else routed through here for an authorization decision needs
+// the same precaution.
 func hostOf(cloneURL string) string {
 	u, err := url.Parse(cloneURL)
 	if err != nil {

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -46,6 +46,22 @@ type Differ struct {
 	// preserving the original behavior. source_diff sets this because its clone
 	// URLs are model-chosen across the whole allowlist.
 	TokenHost string
+	// SSHRewriteHost names the ONE host whose SSH clone URLs may be rewritten to
+	// their HTTPS equivalent (see effectiveCloneURL). It must be the host the
+	// TokenSource credential belongs to. Empty (the default) disables the rewrite
+	// entirely — fail closed — so a Differ that does not know where its credential
+	// is valid never turns an SSH URL into a live HTTPS request.
+	//
+	// It is deliberately NOT TokenHost, and folding the two together would be a
+	// silent regression in one direction or the other. TokenHost governs which
+	// clones may CARRY the token and is empty on the what_changed differ on
+	// purpose (see above); setting it there would change auth for every HTTPS
+	// clone that works today, and it is derived from the forge API URL, which on a
+	// GitHub Enterprise install with subdomain isolation is a different host from
+	// the git remote. SSHRewriteHost governs only whether a rewrite HAPPENS, so a
+	// wrong value costs at most an unrewritten SSH URL — never a withheld
+	// credential on a clone that works today.
+	SSHRewriteHost string
 	// Mirrors, when set, backs clones with a persistent per-repo bare mirror
 	// (incremental fetch, shared across investigations). nil ⇒ full clone per
 	// call, exactly as before. Mirror errors fall back to clone-per-call.
@@ -235,21 +251,28 @@ func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repositor
 // very same repository; the installation still scopes what may be read, so this
 // grants no access the operator had not already granted.
 //
-// The rewrite is applied ONLY when an HTTPS credential is actually in play for
-// that host. With no TokenSource (public or local repos) or with a host-confined
-// token that would not attach here, the raw SSH URL is kept so go-git's default
-// SSH-agent path remains available — rewriting it would trade a working clone
-// for an unauthenticated HTTPS 401.
+// The rewrite is applied ONLY toward SSHRewriteHost, the host the credential is
+// actually for, and only when there is a credential at all. That confinement is
+// load-bearing, not tidiness. A GitOps repoURL is cluster state, so in a shared
+// cluster anyone who can create an Application picks it; the what_changed differ
+// runs with TokenHost empty, meaning auth attaches the App token to whatever host
+// it ends up cloning. Before this rewrite existed, "invalid auth method" rejected
+// every SSH URL before a single byte left the process — the bug was inadvertently
+// acting as a CREDENTIAL BOUNDARY. Rewriting unconfined would have removed that
+// boundary and turned "repoURL: ssh://git@attacker.example/x" into the App
+// installation token being POSTed to attacker.example. Do not "simplify" this
+// host check away without replacing what it holds.
+//
+// With no TokenSource (public or local repos) the raw SSH URL is kept so go-git's
+// default SSH-agent path remains available — rewriting it would trade a working
+// clone for an unauthenticated HTTPS 401.
 func (d *Differ) effectiveCloneURL(rawURL string) string {
-	if d.TokenSource == nil {
-		return rawURL // no HTTPS credential in play; leave SSH to the SSH transport
+	if d.TokenSource == nil || d.SSHRewriteHost == "" {
+		return rawURL // no credential, or no host it is known to be valid for
 	}
 	httpsURL, ok := sshToHTTPS(rawURL)
-	if !ok {
-		return rawURL
-	}
-	if d.TokenHost != "" && hostOf(httpsURL) != d.TokenHost {
-		return rawURL // the token would not attach to this host; rewriting buys nothing
+	if !ok || hostOf(httpsURL) != d.SSHRewriteHost {
+		return rawURL // not SSH, or SSH toward a host this credential is not for
 	}
 	return httpsURL
 }

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -32,37 +32,40 @@ type providersFileDiff = providers.FileDiff
 
 // Differ computes path-scoped diffs between Git revisions.
 type Differ struct {
-	// TokenSource mints a GitHub App installation token for HTTPS clone auth in
-	// Remote/RemoteFromParent. It is called once per clone so a short-lived
-	// (~1h) installation token stays fresh across a long-running agent. nil
-	// disables auth (e.g. public or local repos).
+	// TokenSource yields the forge credential for HTTPS clone auth in
+	// Remote/RemoteFromParent — a minted GitHub App installation token, a GitLab
+	// access token. It is called once per clone so a short-lived (~1h)
+	// installation token stays fresh across a long-running agent. nil disables
+	// auth (e.g. public or local repos).
 	TokenSource func(context.Context) (string, error)
 	// TokenHost, when non-empty, confines the TokenSource credential to clones of
-	// that exact host — the GitHub App installation token is only valid for (and
-	// must only be sent to) the GitHub instance the App is installed on. A clone
-	// of any other host proceeds unauthenticated so a github.com token can never
-	// leak to, say, gitlab.com. Empty (the default, used by what_changed on the
-	// operator's own single-host GitOps repo) attaches the token to every clone,
-	// preserving the original behavior. source_diff sets this because its clone
-	// URLs are model-chosen across the whole allowlist.
+	// that exact host — a forge credential is only valid for (and must only be
+	// sent to) the forge it came from. A clone of any other host proceeds
+	// unauthenticated, so a github.com token can never leak to, say,
+	// attacker.example. Both callers set it: source_diff because its clone URLs
+	// are model-chosen across the whole allowlist, what_changed because a GitOps
+	// repoURL is cluster state and names any host its author likes.
+	//
+	// Empty attaches the credential to EVERY clone. That is the correct default
+	// only for a Differ with no credential at all; a caller that sets TokenSource
+	// and leaves this empty has an unconfined credential.
 	TokenHost string
 	// SSHRewriteHost names the ONE host whose SSH clone URLs may be rewritten to
 	// their HTTPS equivalent (see effectiveCloneURL). It must be the host the
 	// TokenSource credential belongs to. Empty (the default) disables the rewrite
 	// entirely — fail closed — so a Differ that does not know where its credential
-	// is valid never turns an SSH URL into a live HTTPS request. It bounds the
-	// rewrite only; it is not a general credential boundary, and an HTTPS clone
-	// URL is unaffected by it (see effectiveCloneURL).
+	// is valid never turns an SSH URL into a live HTTPS request.
 	//
-	// It is deliberately NOT TokenHost, and folding the two together would be a
-	// silent regression in one direction or the other. TokenHost governs which
-	// clones may CARRY the token and is empty on the what_changed differ on
-	// purpose (see above); setting it there would change auth for every HTTPS
-	// clone that works today, and it is derived from the forge API URL, which on a
-	// GitHub Enterprise install with subdomain isolation is a different host from
-	// the git remote. SSHRewriteHost governs only whether a rewrite HAPPENS, so a
-	// wrong value costs at most an unrewritten SSH URL — never a withheld
-	// credential on a clone that works today.
+	// It is a separate field from TokenHost because it answers a different
+	// question — whether a rewrite HAPPENS, not whether the credential may be
+	// carried — and the two have different defaults: source_diff confines its
+	// credential but arms no rewrite, because sourcerepo.Allowlist.Match already
+	// emits HTTPS. what_changed sets both, to the same host. Keeping them apart
+	// also keeps the rewrite's own check honest: it must refuse a foreign host on
+	// its own terms, so that an SSH repoURL toward attacker.example dies at
+	// go-git's "invalid auth method" without a request ever being formed, rather
+	// than becoming an anonymous HTTPS request that TokenHost merely declined to
+	// authenticate.
 	SSHRewriteHost string
 	// Mirrors, when set, backs clones with a persistent per-repo bare mirror
 	// (incremental fetch, shared across investigations). nil ⇒ full clone per
@@ -154,13 +157,18 @@ type singleFilePatch struct{ fp diff.FilePatch }
 func (p singleFilePatch) FilePatches() []diff.FilePatch { return []diff.FilePatch{p.fp} }
 func (p singleFilePatch) Message() string               { return "" }
 
-// auth builds the clone auth method for cloneURL from a freshly-minted
-// installation token. Returns (nil, nil) when no token source is configured, it
-// yields an empty token (public/local repos), or TokenHost is set and cloneURL's
-// host does not match it — in which case the clone proceeds unauthenticated so
-// the GitHub App token is never transmitted to a foreign host. A token-source
+// auth builds the clone auth method for cloneURL from a freshly-minted forge
+// credential. Returns (nil, nil) when no token source is configured, it yields
+// an empty token (public/local repos), or TokenHost is set and cloneURL's host
+// does not match it — in which case the clone proceeds unauthenticated so the
+// credential is never transmitted to a host it is not valid for. A token-source
 // error is surfaced so a private same-host clone fails loudly instead of
 // silently attempting unauthenticated access.
+//
+// The off-host branch returns BEFORE calling TokenSource, so a foreign clone URL
+// does not even cause a credential to be minted. cloneToDisk passes the
+// EFFECTIVE clone URL (see effectiveCloneURL), so the host authorized here is
+// always the host dialled.
 func (d *Differ) auth(ctx context.Context, cloneURL string) (transport.AuthMethod, error) {
 	if d.TokenSource == nil {
 		return nil, nil
@@ -247,31 +255,24 @@ func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repositor
 // A GitOps engine's spec.source.repoURL is very often an SSH URL
 // ("git@github.com:org/repo.git") because the engine itself authenticates with a
 // deploy key. RunLore holds no SSH credential at all — auth only ever produces
-// HTTP basic auth from a GitHub App installation token — so go-git's SSH
-// transport rejected every one of those clones with "invalid auth method", and
-// what_changed / source_diff silently produced no change correlation for ANY
-// object (RunLore #495). Rewriting to HTTPS lets the App token authenticate the
-// very same repository; the installation still scopes what may be read, so this
-// grants no access the operator had not already granted.
+// HTTP basic auth from a forge token — so go-git's SSH transport rejected every
+// one of those clones with "invalid auth method", and what_changed / source_diff
+// silently produced no change correlation for ANY object (RunLore #495).
+// Rewriting to HTTPS lets the forge token authenticate the very same repository;
+// the installation/token still scopes what may be read, so this grants no access
+// the operator had not already granted.
 //
 // The rewrite fires only toward SSHRewriteHost — the host the credential is for,
 // compared on an ASCII-only host so the comparison cannot disagree with the host
 // net/http will dial (see sshToHTTPS) — and only when there is a credential at
-// all. That confinement is load-bearing. A GitOps repoURL is cluster state, so in
-// a shared cluster anyone who can create an Application picks it, and this differ
-// runs with TokenHost empty, meaning auth attaches the App token to whatever host
-// it clones. Unconfined, the rewrite would turn
-// "repoURL: ssh://git@attacker.example/x" into that token being POSTed to
-// attacker.example. Do not "simplify" the host check away.
-//
-// WHAT THIS DOES NOT DO. It narrows the SSH path only. A hostile HTTPS repoURL —
-// "repoURL: https://attacker.example/x" — still receives the token today: auth is
-// unconfined on this differ and the rewrite never sees an HTTPS URL. That hole
-// predates the rewrite and is not closed here. Closing it means confining
-// TokenHost on this differ, which needs an operator override for a GitHub
-// Enterprise install whose API host differs from its git host, and is its own
-// change. Read this check as "the rewrite cannot introduce a new leak", not as a
-// credential boundary — it is not one.
+// all. That confinement is load-bearing and is NOT made redundant by TokenHost.
+// TokenHost decides whether a request carries the credential; this decides
+// whether the request is made at all. Without this check,
+// "repoURL: ssh://git@attacker.example/x" — cluster state, chosen by anyone who
+// can create an Application — would become a live HTTPS request to
+// attacker.example that merely happened to be unauthenticated, instead of dying
+// at "invalid auth method" with nothing transmitted. Do not "simplify" the host
+// check away on the grounds that the token is confined elsewhere.
 //
 // With no TokenSource (public or local repos) the raw SSH URL is kept so go-git's
 // default SSH-agent path remains available — rewriting it would trade a working
@@ -325,10 +326,10 @@ func (d *Differ) effectiveCloneURL(rawURL string) string {
 // go-git's scp syntax (which takes the FIRST '@' as userinfo, then fails) and a
 // different one to RFC 3986 (which takes the LAST), so an unchecked rewrite would
 // turn a URL that could not clone at all into a working clone of evil.example
-// with "github.com" demoted to userinfo — and what_changed, which attaches its
-// App token to every host it clones, would hand the token over. Because the
-// authority is built as exactly ep.Host, userinfo can only appear in the result
-// when ep.Host itself holds an '@', which this same check rejects.
+// with "github.com" demoted to userinfo — and the caller's host check, reading
+// the host as "github.com", would authorize the rewrite AND the credential.
+// Because the authority is built as exactly ep.Host, userinfo can only appear in
+// the result when ep.Host itself holds an '@', which this same check rejects.
 //
 // Refusal costs nothing — the caller simply keeps the raw URL.
 func sshToHTTPS(rawURL string) (string, bool) {

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -171,8 +172,15 @@ func (d *Differ) auth(ctx context.Context, cloneURL string) (transport.AuthMetho
 // per batch: a cache hit returns the shared clone with a no-op cleanup (the cache
 // owns the temp dir and removes it on close). Without a cache, the caller owns the
 // returned cleanup, as before.
-func (d *Differ) cloneToDisk(ctx context.Context, url string) (*git.Repository, func(), error) {
+//
+// An SSH rawURL is rewritten to its HTTPS equivalent first (see
+// effectiveCloneURL); every downstream key — clone cache, mirror dir, auth host
+// check — is derived from that ONE effective URL, so the URL authorized is
+// always the URL dialled, and an ssh:// and https:// spelling of the same repo
+// share a mirror instead of cloning twice.
+func (d *Differ) cloneToDisk(ctx context.Context, rawURL string) (*git.Repository, func(), error) {
 	noop := func() {}
+	url := d.effectiveCloneURL(rawURL)
 	cc := cacheFrom(ctx)
 	if cc != nil {
 		if repo, ok := cc.get(url); ok {
@@ -213,6 +221,84 @@ func (d *Differ) cloneToDisk(ctx context.Context, url string) (*git.Repository, 
 		return winner, noop, nil // cache owns cleanup
 	}
 	return repo, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+// effectiveCloneURL returns the URL cloneToDisk should actually clone.
+//
+// A GitOps engine's spec.source.repoURL is very often an SSH URL
+// ("git@github.com:org/repo.git") because the engine itself authenticates with a
+// deploy key. RunLore holds no SSH credential at all — auth only ever produces
+// HTTP basic auth from a GitHub App installation token — so go-git's SSH
+// transport rejected every one of those clones with "invalid auth method", and
+// what_changed / source_diff silently produced no change correlation for ANY
+// object (RunLore #495). Rewriting to HTTPS lets the App token authenticate the
+// very same repository; the installation still scopes what may be read, so this
+// grants no access the operator had not already granted.
+//
+// The rewrite is applied ONLY when an HTTPS credential is actually in play for
+// that host. With no TokenSource (public or local repos) or with a host-confined
+// token that would not attach here, the raw SSH URL is kept so go-git's default
+// SSH-agent path remains available — rewriting it would trade a working clone
+// for an unauthenticated HTTPS 401.
+func (d *Differ) effectiveCloneURL(rawURL string) string {
+	if d.TokenSource == nil {
+		return rawURL // no HTTPS credential in play; leave SSH to the SSH transport
+	}
+	httpsURL, ok := sshToHTTPS(rawURL)
+	if !ok {
+		return rawURL
+	}
+	if d.TokenHost != "" && hostOf(httpsURL) != d.TokenHost {
+		return rawURL // the token would not attach to this host; rewriting buys nothing
+	}
+	return httpsURL
+}
+
+// sshToHTTPS rewrites an SSH clone URL to its HTTPS equivalent — both the
+// scp-style "git@host:org/repo.git" and the "ssh://git@host[:port]/org/repo.git"
+// spellings become "https://host/org/repo.git". ok is false for anything that is
+// not an SSH endpoint (https, http, git://, a local path), leaving the caller's
+// URL untouched.
+//
+// SECURITY. The host is taken from go-git's OWN endpoint parser, the same one
+// that would have resolved the raw URL, so the rewrite can never redirect a
+// clone to a host the raw URL did not already designate — including the
+// "ssh://git@good.example@evil.example/x" shape, where the real host is
+// evil.example under RFC 3986 and stays evil.example here. SSH userinfo and port
+// are DROPPED rather than carried across: neither means anything over HTTPS, and
+// carrying userinfo would let a crafted URL smuggle credentials into the
+// rewritten URL's authority.
+//
+// A rewrite is then either FAITHFUL or does not happen: the result must parse
+// back to exactly the host and path it was built from. An SSH path is opaque
+// bytes while an HTTPS path is not, so the path half of that round trip refuses a
+// '?' or '#' that would silently become a query or fragment, and percent-encoded
+// traversal ("%2e%2e") that a literal ".." scan misses. The host half is the
+// credential guard: "git@github.com@evil.example:org/repo.git" is one host to
+// go-git's scp syntax (which takes the FIRST '@' as userinfo, then fails) and a
+// different one to RFC 3986 (which takes the LAST), so an unchecked rewrite would
+// turn a URL that could not clone at all into a working clone of evil.example
+// with "github.com" demoted to userinfo — and what_changed, which attaches its
+// App token to every host it clones, would hand the token over. Because the
+// authority is built as exactly ep.Host, userinfo can only appear in the result
+// when ep.Host itself holds an '@', which this same check rejects.
+//
+// Refusal costs nothing — the caller simply keeps the raw URL.
+func sshToHTTPS(rawURL string) (string, bool) {
+	ep, err := transport.NewEndpoint(strings.TrimSpace(rawURL))
+	if err != nil || ep.Protocol != "ssh" || ep.Host == "" {
+		return "", false
+	}
+	repoPath := strings.TrimPrefix(ep.Path, "/")
+	if repoPath == "" || slices.Contains(strings.Split(repoPath, "/"), "..") {
+		return "", false
+	}
+	out := "https://" + ep.Host + "/" + repoPath
+	u, perr := url.Parse(out)
+	if perr != nil || u.Path != "/"+repoPath || !strings.EqualFold(u.Host, ep.Host) {
+		return "", false
+	}
+	return out, true
 }
 
 // hostOf returns the lowercased host of an https/http/ssh clone URL, or "" for

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -24,7 +24,10 @@ import (
 func TestRemoteClonesSSHRepoURLOverHTTPS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+	d := &Differ{
+		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
+		SSHRewriteHost: "github.com",
+	}
 	_, err := d.Remote(ctx, "git@github.com:Aqemia/engineering.git", "a", "b", "")
 	if err == nil {
 		t.Fatal("want an error from a cancelled clone, got nil")
@@ -101,13 +104,14 @@ func TestSSHToHTTPS(t *testing.T) {
 }
 
 // TestEffectiveCloneURLGating pins WHEN the SSH→HTTPS rewrite applies: only when
-// an HTTPS credential is actually in play for that host. Rewriting when RunLore
-// has no token would trade go-git's working SSH-agent path for an
-// unauthenticated HTTPS 401.
+// there is a credential AND a host it is known to be valid for. Rewriting with no
+// token would trade go-git's working SSH-agent path for an unauthenticated HTTPS
+// 401; rewriting with no known host is the credential leak guarded below.
 func TestEffectiveCloneURLGating(t *testing.T) {
 	const ssh = "git@github.com:acme/x.git"
 	const https = "https://github.com/acme/x.git"
 	tok := func(context.Context) (string, error) { return "ghs_tok", nil }
+	armed := func(host string) *Differ { return &Differ{TokenSource: tok, SSHRewriteHost: host} }
 
 	tests := []struct {
 		name string
@@ -115,12 +119,12 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 		in   string
 		want string
 	}{
-		{"no token source keeps SSH for the ssh-agent path", &Differ{}, ssh, ssh},
-		{"token source rewrites to HTTPS", &Differ{TokenSource: tok}, ssh, https},
-		{"matching TokenHost rewrites", &Differ{TokenSource: tok, TokenHost: "github.com"}, ssh, https},
-		{"foreign TokenHost keeps SSH", &Differ{TokenSource: tok, TokenHost: "ghe.example.com"}, ssh, ssh},
-		{"https is never touched", &Differ{TokenSource: tok}, https, https},
-		{"local path is never touched", &Differ{TokenSource: tok}, "/srv/fixtures/repo", "/srv/fixtures/repo"},
+		{"no token source keeps SSH for the ssh-agent path", &Differ{SSHRewriteHost: "github.com"}, ssh, ssh},
+		{"credential host matches: rewrites to HTTPS", armed("github.com"), ssh, https},
+		{"unset credential host refuses to rewrite", &Differ{TokenSource: tok}, ssh, ssh},
+		{"foreign credential host keeps SSH", armed("ghe.example.com"), ssh, ssh},
+		{"https is never touched", armed("github.com"), https, https},
+		{"local path is never touched", armed("github.com"), "/srv/fixtures/repo", "/srv/fixtures/repo"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -129,6 +133,74 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSSHRewriteNeverReachesAForeignHost is the credential boundary the #495
+// rewrite must not dissolve.
+//
+// A GitOps repoURL is cluster state: in a shared cluster, anyone who can create
+// an Application chooses it. The what_changed differ runs with TokenHost EMPTY,
+// so auth attaches the GitHub App installation token to whatever host it clones.
+// Before the rewrite existed, "invalid auth method" killed every SSH URL before a
+// byte left the process — the bug was inadvertently acting as a credential
+// boundary. An unconfined rewrite would have turned
+// "repoURL: ssh://git@attacker.example/x" into that token being POSTed to
+// attacker.example.
+//
+// The clone runs on an already-cancelled context, which never touches the
+// network but does reveal WHICH transport was chosen: go-git names an HTTPS
+// target in the error ("Get \"https://…\"") and rejects an SSH one at
+// "invalid auth method" without forming a request at all. So the error text is
+// the proof that nothing was ever addressed to the foreign host.
+func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
+	// Wired exactly as buildGitOpsDiffer wires what_changed: a credential for
+	// github.com, and TokenHost left empty.
+	newDiffer := func() *Differ {
+		return &Differ{
+			TokenSource:    func(context.Context) (string, error) { return "ghs_SECRET", nil },
+			SSHRewriteHost: "github.com",
+		}
+	}
+
+	foreign := []string{
+		"ssh://git@attacker.example/org/repo.git",
+		"git@attacker.example:org/repo.git",
+		"ssh://git@gitlab.com/org/repo.git",
+		"git@ghe.example.com:org/repo.git",
+		// Lookalikes: neither is the credential's host.
+		"git@github.com.attacker.example:org/repo.git",
+		"git@notgithub.com:org/repo.git",
+	}
+	for _, raw := range foreign {
+		t.Run("foreign "+raw, func(t *testing.T) {
+			d := newDiffer()
+			if got := d.effectiveCloneURL(raw); got != raw {
+				t.Fatalf("rewrote an SSH URL toward a host the credential is not for: %q → %q", raw, got)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			_, err := d.Remote(ctx, raw, "a", "b", "")
+			if err == nil {
+				t.Fatal("want an error, got nil")
+			}
+			if strings.Contains(err.Error(), "https://") {
+				t.Fatalf("an HTTPS request was addressed to a foreign host — the App token would be sent there: %v", err)
+			}
+			if !strings.Contains(err.Error(), "invalid auth method") {
+				t.Fatalf("want the SSH transport to refuse before any request is formed, got %v", err)
+			}
+		})
+	}
+
+	// The credential's own host still gets the fix — the confinement must not
+	// have simply disabled #495.
+	t.Run("credential host is still rewritten", func(t *testing.T) {
+		d := newDiffer()
+		const raw = "git@github.com:org/repo.git"
+		if got := d.effectiveCloneURL(raw); got != "https://github.com/org/repo.git" {
+			t.Fatalf("effectiveCloneURL(%q) = %q, want the HTTPS equivalent", raw, got)
+		}
+	})
 }
 
 // TestCloneRewriteCannotBypassSourceRepoAllowlist is the security guard for #495.
@@ -149,9 +221,14 @@ func TestCloneRewriteCannotBypassSourceRepoAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build allowlist: %v", err)
 	}
-	// A worst-case differ: a token source and no TokenHost, so the rewrite is
-	// unconditionally armed for every host.
-	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+	// A worst-case differ for this boundary: the rewrite is armed, and armed for
+	// exactly the host the allowlist authorizes — so any drift between the string
+	// checked and the string cloned shows up here rather than being masked by the
+	// rewrite declining for an unrelated reason.
+	d := &Differ{
+		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
+		SSHRewriteHost: "github.com",
+	}
 
 	tests := []struct {
 		name, repo string

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package whatchanged
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/sourcerepo"
+)
+
+// TestRemoteClonesSSHRepoURLOverHTTPS is the RunLore #495 regression.
+//
+// Argo CD / Flux routinely point at their source repo over SSH because the
+// engine authenticates with a deploy key. RunLore has no SSH credential — auth
+// only ever mints an HTTP basic auth from the GitHub App token — so go-git's SSH
+// transport rejected every such clone with "invalid auth method" and what_changed
+// lost change correlation for EVERY object, visible only as a data-gaps line.
+//
+// The clone is driven with an already-cancelled context so it never touches the
+// network: go-git formats the target URL into the error before doing any I/O,
+// which is exactly the assertion we need — WHICH url was dialled.
+func TestRemoteClonesSSHRepoURLOverHTTPS(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+	_, err := d.Remote(ctx, "git@github.com:Aqemia/engineering.git", "a", "b", "")
+	if err == nil {
+		t.Fatal("want an error from a cancelled clone, got nil")
+	}
+	if strings.Contains(err.Error(), "invalid auth method") {
+		t.Fatalf("SSH repoURL still dialled over SSH with an HTTPS-only credential (#495): %v", err)
+	}
+	if !strings.Contains(err.Error(), "https://github.com/Aqemia/engineering.git") {
+		t.Fatalf("want the clone to target the HTTPS equivalent, got %v", err)
+	}
+}
+
+func TestSSHToHTTPS(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+		ok             bool
+	}{
+		{"scp-style github", "git@github.com:Aqemia/engineering.git", "https://github.com/Aqemia/engineering.git", true},
+		{"scp-style gitlab subgroup", "git@gitlab.com:group/sub/proj.git", "https://gitlab.com/group/sub/proj.git", true},
+		{"scp-style self-hosted gitlab", "git@gitlab.example.com:org/repo.git", "https://gitlab.example.com/org/repo.git", true},
+		{"ssh scheme", "ssh://git@github.com/acme/x.git", "https://github.com/acme/x.git", true},
+		{"ssh scheme drops the ssh port", "ssh://git@gitlab.example.com:2222/org/repo.git", "https://gitlab.example.com/org/repo.git", true},
+		{"ssh scheme without userinfo", "ssh://github.com/acme/x", "https://github.com/acme/x", true},
+		{"surrounding whitespace", "  git@github.com:acme/x.git\n", "https://github.com/acme/x.git", true},
+		// The RFC 3986 authority of this URL is evil.example — go-git would dial
+		// exactly that over SSH, and the rewrite must not "helpfully" prefer the
+		// userinfo's lookalike host. Same host in, same host out.
+		{"userinfo lookalike keeps the real host", "ssh://git@github.com@evil.example/acme/x", "https://evil.example/acme/x", true},
+		// '@' after the first '/' is path, not authority: the host stays github.com.
+		{"at-sign in the path is not authority", "git@github.com:x@evil.example/y.git", "https://github.com/x@evil.example/y.git", true},
+		{"https is left alone", "https://github.com/acme/x.git", "", false},
+		{"http is left alone", "http://github.com/acme/x", "", false},
+		{"git protocol is left alone", "git://github.com/acme/x.git", "", false},
+		{"local path is left alone", "/srv/fixtures/repo", "", false},
+		{"empty is left alone", "", "", false},
+		{"traversal segment is refused", "git@github.com:../../etc/passwd", "", false},
+		{"traversal segment under ssh scheme is refused", "ssh://git@github.com/acme/../../x", "", false},
+		// The round-trip guard: an SSH path is opaque bytes, an HTTPS path is
+		// not, so anything whose meaning would shift in the rewrite is refused
+		// rather than guessed at.
+		{"percent-encoded traversal is refused", "git@github.com:acme/%2e%2e/evil/x.git", "", false},
+		{"query-shaped path is refused", "git@github.com:acme/x?a=b", "", false},
+		{"fragment-shaped path is refused", "git@github.com:acme/x#ssh://git@evil.example/a", "", false},
+		{"control character in the host is refused", "git@github.com\x00evil.example:acme/x.git", "", false},
+		// The credential-exfiltration shape. go-git's scp syntax takes the FIRST
+		// '@' as userinfo, so it reads the host as the whole "github.com@evil.example"
+		// and fails; net/url takes the LAST, so an unguarded rewrite would emit a
+		// perfectly valid clone of evil.example with "github.com" demoted to
+		// userinfo — and what_changed, which attaches its App token to every host,
+		// would post the token there. Refused.
+		{"double-@ host is refused, never demoted to userinfo", "git@github.com@evil.example:acme/x.git", "", false},
+		{"double-@ host is refused (short form)", "git@a@b.example:acme/x.git", "", false},
+		{"hostless scp form is refused", "git@:acme/x.git", "", false},
+		// go-git's scp regex splits this at the FIRST colon, yielding host
+		// "[fd00" — a rewrite would name a host nobody asked for, so it is not
+		// attempted. (The ssh:// spelling below parses correctly and is fine.)
+		{"scp-style bracketed IPv6 is refused, not guessed", "git@[fd00::1]:acme/x.git", "", false},
+		{"ssh-scheme IPv6 host survives", "ssh://git@[fd00::1]/acme/x.git", "https://[fd00::1]/acme/x.git", true},
+		// go-git resolves the host to "user" here; the rewrite must report that
+		// same host and never promote the later, more plausible-looking one.
+		{"no host promotion from a later lookalike", "git@user:pass@github.com:acme/x.git", "https://user/pass@github.com:acme/x.git", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := sshToHTTPS(tc.in)
+			if ok != tc.ok {
+				t.Fatalf("sshToHTTPS(%q) ok = %v, want %v (got %q)", tc.in, ok, tc.ok, got)
+			}
+			if got != tc.want {
+				t.Fatalf("sshToHTTPS(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveCloneURLGating pins WHEN the SSH→HTTPS rewrite applies: only when
+// an HTTPS credential is actually in play for that host. Rewriting when RunLore
+// has no token would trade go-git's working SSH-agent path for an
+// unauthenticated HTTPS 401.
+func TestEffectiveCloneURLGating(t *testing.T) {
+	const ssh = "git@github.com:acme/x.git"
+	const https = "https://github.com/acme/x.git"
+	tok := func(context.Context) (string, error) { return "ghs_tok", nil }
+
+	tests := []struct {
+		name string
+		d    *Differ
+		in   string
+		want string
+	}{
+		{"no token source keeps SSH for the ssh-agent path", &Differ{}, ssh, ssh},
+		{"token source rewrites to HTTPS", &Differ{TokenSource: tok}, ssh, https},
+		{"matching TokenHost rewrites", &Differ{TokenSource: tok, TokenHost: "github.com"}, ssh, https},
+		{"foreign TokenHost keeps SSH", &Differ{TokenSource: tok, TokenHost: "ghe.example.com"}, ssh, ssh},
+		{"https is never touched", &Differ{TokenSource: tok}, https, https},
+		{"local path is never touched", &Differ{TokenSource: tok}, "/srv/fixtures/repo", "/srv/fixtures/repo"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.d.effectiveCloneURL(tc.in); got != tc.want {
+				t.Fatalf("effectiveCloneURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCloneRewriteCannotBypassSourceRepoAllowlist is the security guard for #495.
+//
+// source_diff's allowlist is the boundary that stops a prompt-injected model from
+// making RunLore clone arbitrary hosts (internal/sourcerepo). The tool checks the
+// model's raw string and hands cloneToDisk the URL that check itself produced —
+// so the clone-time SSH→HTTPS rewrite must be a strict NO-OP on anything the
+// allowlist authorized. If it were not, the string checked and the string dialled
+// could diverge and the boundary would be bypassable.
+//
+// The invariant asserted, over inputs crafted to make a sloppy rewriter diverge:
+// Allowlist.Match's output is a FIXED POINT of effectiveCloneURL, and the host
+// actually dialled is the host the allowlist authorized. Refused inputs must be
+// refused by the allowlist, never merely by the rewrite.
+func TestCloneRewriteCannotBypassSourceRepoAllowlist(t *testing.T) {
+	allow, err := sourcerepo.New([]string{"github.com/acme/*"})
+	if err != nil {
+		t.Fatalf("build allowlist: %v", err)
+	}
+	// A worst-case differ: a token source and no TokenHost, so the rewrite is
+	// unconditionally armed for every host.
+	d := &Differ{TokenSource: func(context.Context) (string, error) { return "ghs_tok", nil }}
+
+	tests := []struct {
+		name, repo string
+		allowed    bool
+	}{
+		{"plain host/org/repo", "github.com/acme/x", true},
+		{"https spelling", "https://github.com/acme/x.git", true},
+		{"scp-style ssh spelling", "git@github.com:acme/x.git", true},
+		{"ssh scheme spelling", "ssh://git@github.com/acme/x", true},
+		{"uppercase host", "git@GitHub.COM:acme/x.git", true},
+		{"userinfo lookalike host", "ssh://git@github.com@evil.example/acme/x", false},
+		{"allowed host smuggled into the path", "git@evil.example:github.com/acme/x", false},
+		{"ssh port smuggled as a path segment", "ssh://git@github.com:22/acme/x", false},
+		{"fragment carrying a second url", "git@github.com:acme/x.git#ssh://git@evil.example/a/b", false},
+		{"traversal out of the allowed org", "git@github.com:acme/../evil/x.git", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cloneURL, ok := allow.Match(tc.repo)
+			if ok != tc.allowed {
+				t.Fatalf("Match(%q) = (%q, %v), want allowed=%v", tc.repo, cloneURL, ok, tc.allowed)
+			}
+			if !ok {
+				return // never reaches the differ at all
+			}
+			if got := d.effectiveCloneURL(cloneURL); got != cloneURL {
+				t.Fatalf("clone rewrite moved an ALLOWLISTED url: authorized %q but would dial %q — "+
+					"the allow check and the clone must see the same string", cloneURL, got)
+			}
+			if h := hostOf(cloneURL); h != "github.com" {
+				t.Fatalf("authorized url %q resolves to host %q, want github.com", cloneURL, h)
+			}
+		})
+	}
+}

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/Smana/runlore/internal/sourcerepo"
 )
 
+// armedDiffer returns a Differ wired exactly as buildGitOpsDiffer wires
+// what_changed: a GitHub App credential, the SSH→HTTPS rewrite armed for host,
+// and TokenHost deliberately left EMPTY — so auth attaches the token to whatever
+// host the differ ends up cloning.
+//
+// That is the worst case on purpose. With TokenHost empty, the host check in
+// effectiveCloneURL is the only thing standing between a hostile repoURL and the
+// credential, so every leak these tests hunt for is reachable. Do NOT set
+// TokenHost here: it would mask the exact leak
+// TestSSHRewriteNeverReachesAForeignHost exists to catch.
+func armedDiffer(host string) *Differ {
+	return &Differ{
+		TokenSource:    func(context.Context) (string, error) { return "ghs_SECRET", nil },
+		SSHRewriteHost: host,
+	}
+}
+
 // TestRemoteClonesSSHRepoURLOverHTTPS is the RunLore #495 regression.
 //
 // Argo CD / Flux routinely point at their source repo over SSH because the
@@ -24,10 +41,7 @@ import (
 func TestRemoteClonesSSHRepoURLOverHTTPS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	d := &Differ{
-		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
-		SSHRewriteHost: "github.com",
-	}
+	d := armedDiffer("github.com")
 	_, err := d.Remote(ctx, "git@github.com:Aqemia/engineering.git", "a", "b", "")
 	if err == nil {
 		t.Fatal("want an error from a cancelled clone, got nil")
@@ -135,7 +149,6 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 	const ssh = "git@github.com:acme/x.git"
 	const https = "https://github.com/acme/x.git"
 	tok := func(context.Context) (string, error) { return "ghs_tok", nil }
-	armed := func(host string) *Differ { return &Differ{TokenSource: tok, SSHRewriteHost: host} }
 
 	tests := []struct {
 		name string
@@ -144,11 +157,11 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 		want string
 	}{
 		{"no token source keeps SSH for the ssh-agent path", &Differ{SSHRewriteHost: "github.com"}, ssh, ssh},
-		{"credential host matches: rewrites to HTTPS", armed("github.com"), ssh, https},
+		{"credential host matches: rewrites to HTTPS", armedDiffer("github.com"), ssh, https},
 		{"unset credential host refuses to rewrite", &Differ{TokenSource: tok}, ssh, ssh},
-		{"foreign credential host keeps SSH", armed("ghe.example.com"), ssh, ssh},
-		{"https is never touched", armed("github.com"), https, https},
-		{"local path is never touched", armed("github.com"), "/srv/fixtures/repo", "/srv/fixtures/repo"},
+		{"foreign credential host keeps SSH", armedDiffer("ghe.example.com"), ssh, ssh},
+		{"https is never touched", armedDiffer("github.com"), https, https},
+		{"local path is never touched", armedDiffer("github.com"), "/srv/fixtures/repo", "/srv/fixtures/repo"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -178,13 +191,9 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 // the proof that nothing was ever addressed to the foreign host.
 func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 	// Wired exactly as buildGitOpsDiffer wires what_changed: a credential for
-	// github.com, and TokenHost left empty.
-	newDiffer := func() *Differ {
-		return &Differ{
-			TokenSource:    func(context.Context) (string, error) { return "ghs_SECRET", nil },
-			SSHRewriteHost: "github.com",
-		}
-	}
+	// github.com, and TokenHost left empty. Shared across the subtests below —
+	// effectiveCloneURL and Remote never mutate a Differ.
+	d := armedDiffer("github.com")
 
 	foreign := []string{
 		"ssh://git@attacker.example/org/repo.git",
@@ -208,7 +217,6 @@ func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 	}
 	for _, raw := range foreign {
 		t.Run("foreign "+raw, func(t *testing.T) {
-			d := newDiffer()
 			if got := d.effectiveCloneURL(raw); got != raw {
 				t.Fatalf("rewrote an SSH URL toward a host the credential is not for: %q → %q", raw, got)
 			}
@@ -230,7 +238,6 @@ func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 	// The credential's own host still gets the fix — the confinement must not
 	// have simply disabled #495.
 	t.Run("credential host is still rewritten", func(t *testing.T) {
-		d := newDiffer()
 		const raw = "git@github.com:org/repo.git"
 		if got := d.effectiveCloneURL(raw); got != "https://github.com/org/repo.git" {
 			t.Fatalf("effectiveCloneURL(%q) = %q, want the HTTPS equivalent", raw, got)
@@ -260,10 +267,7 @@ func TestCloneRewriteCannotBypassSourceRepoAllowlist(t *testing.T) {
 	// exactly the host the allowlist authorizes — so any drift between the string
 	// checked and the string cloned shows up here rather than being masked by the
 	// rewrite declining for an unrelated reason.
-	d := &Differ{
-		TokenSource:    func(context.Context) (string, error) { return "ghs_tok", nil },
-		SSHRewriteHost: "github.com",
-	}
+	d := armedDiffer("github.com")
 
 	tests := []struct {
 		name, repo string

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -10,16 +10,18 @@ import (
 	"github.com/Smana/runlore/internal/sourcerepo"
 )
 
-// armedDiffer returns a Differ wired exactly as buildGitOpsDiffer wires
-// what_changed: a GitHub App credential, the SSH→HTTPS rewrite armed for host,
-// and TokenHost deliberately left EMPTY — so auth attaches the token to whatever
-// host the differ ends up cloning.
+// armedDiffer returns a Differ with a forge credential and the SSH→HTTPS rewrite
+// armed for host — and TokenHost deliberately left EMPTY, so auth would attach
+// the credential to whatever host the differ ends up cloning.
 //
-// That is the worst case on purpose. With TokenHost empty, the host check in
-// effectiveCloneURL is the only thing standing between a hostile repoURL and the
-// credential, so every leak these tests hunt for is reachable. Do NOT set
-// TokenHost here: it would mask the exact leak
-// TestSSHRewriteNeverReachesAForeignHost exists to catch.
+// That is STRICTER than production and deliberately so. buildGitOpsDiffer now
+// also sets TokenHost to the same host, but layering the two here would let the
+// rewrite's own host check rot unnoticed: with TokenHost empty, that check is the
+// only thing standing between a hostile repoURL and the credential, so every leak
+// these tests hunt for stays reachable. Do NOT set TokenHost here — it would mask
+// the exact leak TestSSHRewriteNeverReachesAForeignHost exists to catch. The
+// wiring that pairs the two lives in internal/app
+// (TestBuildGitOpsDifferConfinesTheForgeCredential).
 func armedDiffer(host string) *Differ {
 	return &Differ{
 		TokenSource:    func(context.Context) (string, error) { return "ghs_SECRET", nil },
@@ -90,8 +92,8 @@ func TestSSHToHTTPS(t *testing.T) {
 		// '@' as userinfo, so it reads the host as the whole "github.com@evil.example"
 		// and fails; net/url takes the LAST, so an unguarded rewrite would emit a
 		// perfectly valid clone of evil.example with "github.com" demoted to
-		// userinfo — and what_changed, which attaches its App token to every host,
-		// would post the token there. Refused.
+		// userinfo — and both host checks (the rewrite's and TokenHost's) would
+		// read that host as "github.com" and post the token there. Refused.
 		{"double-@ host is refused, never demoted to userinfo", "git@github.com@evil.example:acme/x.git", "", false},
 		{"double-@ host is refused (short form)", "git@a@b.example:acme/x.git", "", false},
 		{"hostless scp form is refused", "git@:acme/x.git", "", false},
@@ -176,13 +178,13 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 // rewrite must not dissolve.
 //
 // A GitOps repoURL is cluster state: in a shared cluster, anyone who can create
-// an Application chooses it. The what_changed differ runs with TokenHost EMPTY,
-// so auth attaches the GitHub App installation token to whatever host it clones.
-// Before the rewrite existed, "invalid auth method" killed every SSH URL before a
-// byte left the process — the bug was inadvertently acting as a credential
-// boundary. An unconfined rewrite would have turned
-// "repoURL: ssh://git@attacker.example/x" into that token being POSTed to
-// attacker.example.
+// an Application chooses it. The differ under test runs with TokenHost EMPTY, so
+// auth would attach the forge credential to whatever host it clones (see
+// armedDiffer for why the fixture is weaker than production). Before the rewrite
+// existed, "invalid auth method" killed every SSH URL before a byte left the
+// process — the bug was inadvertently acting as a credential boundary. An
+// unconfined rewrite would have turned "repoURL: ssh://git@attacker.example/x"
+// into that token being POSTed to attacker.example.
 //
 // The clone runs on an already-cancelled context, which never touches the
 // network but does reveal WHICH transport was chosen: go-git names an HTTPS
@@ -190,9 +192,8 @@ func TestEffectiveCloneURLGating(t *testing.T) {
 // "invalid auth method" without forming a request at all. So the error text is
 // the proof that nothing was ever addressed to the foreign host.
 func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
-	// Wired exactly as buildGitOpsDiffer wires what_changed: a credential for
-	// github.com, and TokenHost left empty. Shared across the subtests below —
-	// effectiveCloneURL and Remote never mutate a Differ.
+	// A credential for github.com, and TokenHost left empty. Shared across the
+	// subtests below — effectiveCloneURL and Remote never mutate a Differ.
 	d := armedDiffer("github.com")
 
 	foreign := []string{
@@ -227,7 +228,7 @@ func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 				t.Fatal("want an error, got nil")
 			}
 			if strings.Contains(err.Error(), "https://") {
-				t.Fatalf("an HTTPS request was addressed to a foreign host — the App token would be sent there: %v", err)
+				t.Fatalf("an HTTPS request was addressed to a foreign host — the forge credential would be sent there: %v", err)
 			}
 			if !strings.Contains(err.Error(), "invalid auth method") {
 				t.Fatalf("want the SSH transport to refuse before any request is formed, got %v", err)

--- a/internal/whatchanged/sshurl_test.go
+++ b/internal/whatchanged/sshurl_test.go
@@ -89,6 +89,30 @@ func TestSSHToHTTPS(t *testing.T) {
 		// go-git resolves the host to "user" here; the rewrite must report that
 		// same host and never promote the later, more plausible-looking one.
 		{"no host promotion from a later lookalike", "git@user:pass@github.com:acme/x.git", "https://user/pass@github.com:acme/x.git", true},
+		// Non-ASCII hosts. hostOf lowercases with strings.ToLower — Unicode SIMPLE
+		// case mapping — while net/http resolves through idna.Lookup.ToASCII, and
+		// the two disagree: ToLower maps U+0130 to 'i', so "gİthub.com" reads as
+		// "github.com" to the authorization check while net/http dials the
+		// separately registrable "xn--github-qyd.com". Refuse the class, not the
+		// one rune.
+		{"homoglyph host U+0130 is refused", "git@gİthub.com:org/repo.git", "", false},
+		{"homoglyph host under ssh scheme is refused", "ssh://git@gİthub.com/org/repo.git", "", false},
+		{"kelvin-sign host is refused", "git@bacKend.example:org/repo.git", "", false},
+		{"fullwidth host is refused", "git@ｇithub.com:org/repo.git", "", false},
+		{"zero-width space in the host is refused", "git@git\u200bhub.com:org/repo.git", "", false},
+		{"soft hyphen in the host is refused", "git@git\u00adhub.com:org/repo.git", "", false},
+		// A lone continuation byte is not valid UTF-8, so no rune-based check
+		// sees it and the round-trip guard passes it cleanly — only the byte
+		// scan rejects it. This pins the boundary at exactly 0x80: every valid
+		// non-ASCII rune has a lead byte >= 0xC2, so nothing else in this table
+		// would notice the boundary drifting upward.
+		{"raw 0x80 byte in the host is refused", "git@a\x80b.example:org/repo.git", "", false},
+		// Punycode written out is plain ASCII and stays its own distinct host —
+		// it must not be decoded back into a lookalike of anything.
+		{"punycode spelling is its own host", "git@xn--github-qyd.com:org/repo.git", "https://xn--github-qyd.com/org/repo.git", true},
+		// A non-ASCII PATH is not a host-confusion risk: it cannot change which
+		// host is dialled, and net/http escapes it on the wire.
+		{"non-ascii path is allowed", "git@github.com:org/répo.git", "https://github.com/org/répo.git", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -170,6 +194,17 @@ func TestSSHRewriteNeverReachesAForeignHost(t *testing.T) {
 		// Lookalikes: neither is the credential's host.
 		"git@github.com.attacker.example:org/repo.git",
 		"git@notgithub.com:org/repo.git",
+		// IDNA homoglyphs. These are the dangerous ones: hostOf lowercases with
+		// strings.ToLower, which maps U+0130 to 'i', so each of these reads as
+		// exactly "github.com" to the authorization check — while net/http
+		// resolves through idna.Lookup.ToASCII and dials a punycode host the
+		// attacker can register ("xn--github-qyd.com"), serve a valid cert for,
+		// and read the App token off the Authorization header.
+		"git@gİthub.com:org/repo.git",
+		"ssh://git@gİthub.com/org/repo.git",
+		"git@githუb.com:org/repo.git",
+		"git@ｇithub.com:org/repo.git",
+		"git@git\u200bhub.com:org/repo.git",
 	}
 	for _, raw := range foreign {
 		t.Run("foreign "+raw, func(t *testing.T) {

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -443,13 +443,25 @@ model or tier, or the ceiling drifts away from the bill it is meant to bound.
 ### `forge` — the Git host for curation
 `provider` (`github` — the default — or `gitlab`), `kb_repo` (GitHub: `owner/name`; GitLab: the
 project path, e.g. `group/project`, nested groups allowed), `base_branch` (default `main`),
-`github_api_url` (default `https://api.github.com`), `dup_score` (default **5.0**), `min_confidence`
+`github_api_url` (default `https://api.github.com`), `git_host` (default **derived**, see below),
+`dup_score` (default **5.0**), `min_confidence`
 (default **0.75**, the quality bar below which a finding is chat-only), `skip_verdicts` (default
 **empty** — draft every verdict). `github_app` — `app_id`, `installation_id`, and `private_key_ref`
 **or** `private_key_env`. `gitlab` — `base_url` (self-managed instance root; omit for gitlab.com) and
 `token_env` (a project/group access token, scope `api`); see
 [Integrations → GitLab]({{< relref "/docs/integrations/forge/gitlab.md" >}}). `provider: gitlab` with no
 `gitlab.token_env`, or a `kb_repo` that isn't a valid GitLab project path, fails config load closed.
+
+`git_host` is the **one host the forge credential may be sent to** when RunLore clones — `what_changed`
+against your GitOps repo, `source_diff` against an allowlisted source repo, the catalog git-sync
+against the KB repo. A clone of any other host proceeds anonymously, because a GitOps
+`spec.source.repoURL` is cluster state: anyone who can create an Argo CD `Application` picks it, and
+it must not be able to pick where your token goes. Leave it empty and it is derived — `github.com`
+from `api.github.com`, the API host for GitHub Enterprise, `gitlab.base_url`'s host for GitLab. Set it
+only for **GitHub Enterprise with subdomain isolation** (API on `api.HOSTNAME`, git on `HOSTNAME`),
+which is the one shape the derivation cannot resolve; that config **fails load** until `git_host`
+names the git host, rather than guessing and silently withholding the credential from every repo.
+The value is a bare hostname — no scheme, path, port or userinfo.
 
 `skip_verdicts` is a list of investigation verdicts that must **not** draft a KB PR — the finding
 still reaches chat, but no repo artifact is created. Values are validated at startup against the

--- a/website/content/docs/integrations/forge/github.md
+++ b/website/content/docs/integrations/forge/github.md
@@ -82,6 +82,25 @@ gh api /installation/repositories
   repos need no grant.
 - `github_api_url` is only needed for **GitHub Enterprise Server** (e.g.
   `https://ghe.example.com/api/v3`); omit it for github.com.
+- **The installation token is only ever sent to your forge's git host.** `what_changed` clones the
+  repo a GitOps `spec.source.repoURL` names, and that field is cluster state — anyone who can create
+  an Argo CD `Application` or a Flux `GitRepository` writes it. A repoURL on any other host therefore
+  clones **anonymously** (public repos still work; a private one produces no diff). Nothing is lost by
+  this: an installation token authenticates only on the instance the App is installed on.
+- **GitHub Enterprise with [subdomain isolation](https://docs.github.com/en/enterprise-server/admin/configuring-settings/hardening-security-for-your-instance/enabling-subdomain-isolation)
+  needs `forge.git_host`.** With isolation on, the API is served from `api.HOSTNAME` while git and web
+  stay on `HOSTNAME`, so `github_api_url` alone cannot say which host to authenticate a clone to.
+  RunLore refuses to start on that config rather than guess — guessing wrong would withhold the token
+  from *every* GitOps repo and show up only as an empty `what_changed`:
+
+  ```yaml
+  forge:
+    github_api_url: https://api.ghe.example.com   # API (subdomain isolation)
+    git_host: ghe.example.com                     # git remotes / clone auth
+  ```
+
+  Without isolation (`https://ghe.example.com/api/v3`), the host is unambiguous and `git_host` is not
+  needed.
 - RunLore's writes are confined to the forge — it has **no cluster-mutating permissions**.
 
 ## Reference

--- a/website/content/docs/integrations/forge/gitlab.md
+++ b/website/content/docs/integrations/forge/gitlab.md
@@ -80,6 +80,15 @@ curl --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
 - `provider: gitlab` with no `forge.gitlab.token_env`, or a `kb_repo` that isn't a valid GitLab
   project path, both **fail config load closed** — `serve` refuses to start rather than coming up
   with curation silently disabled.
+- The **same token clones private repos**: `what_changed` fetching your GitOps repo, `source_diff`
+  fetching an allowlisted source repo, and the catalog git-sync reading the KB project all
+  authenticate with it over HTTPS. It was GitHub-App-only before, which meant a GitLab deployment
+  cloned a private GitOps repo **anonymously** and `what_changed` silently produced nothing. Give the
+  token `read_repository` reach over the projects you want diffed (the `api` scope already covers
+  it), or those clones 404.
+- The token is sent **only to the host in `base_url`** (`gitlab.com` when it is omitted). A GitOps
+  `spec.source.repoURL` pointing anywhere else clones anonymously — a repoURL is cluster state, so it
+  must never be able to choose where RunLore's credential goes.
 - TLS verification is always on; there is no `insecure_skip_verify` escape hatch. A self-signed
   instance needs a certificate your cluster's trust store already accepts.
 - **Not yet verified against a live GitLab instance.** The provider is built against the GitLab v4
@@ -103,7 +112,6 @@ investigation and posts the findings back, and `index.md`/`log.md` stay in step 
 |------|--------------------|
 | `lore curate` (the backlog-grooming CLI: dedup, lifecycle, queue, recurrence, contested, retirement passes) | **Fails to start**, with a message naming a GitHub App — it has no GitLab code path |
 | In-server sweeps (`curate.sweeps.mode: apply`) | **Disabled, and it says so.** No sweeper is built, and startup logs `curate sweeps disabled: no usable KB forge — Phase-2 grooming is GitHub-only` |
-| Source-repo diff cloning for private repos (`gitops` source cloning) | GitHub-App auth only — unrelated to which forge hosts the KB, but it bites the same operator |
 
 Concretely: nothing prunes the KB backlog, stale merge requests are never closed, and entries are
 never promoted to `ready-to-merge` when the underlying incident resolves. Review and merge KB merge

--- a/website/content/docs/security/security-model.md
+++ b/website/content/docs/security/security-model.md
@@ -121,6 +121,13 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
 - **Scope the App to the KB repo** (Contents/PRs/Issues read-write), plus optional read-only on your
   GitOps source repos for the what-changed diff. Disable the App's webhook. See
   [Getting started → GitHub App]({{< relref "getting-started.md" >}}).
+- **The clone credential is confined to one host.** RunLore attaches the forge token only to clones of
+  `forge.git_host` (derived from `github_api_url` / `gitlab.base_url` unless you set it); any other
+  host clones anonymously. This matters because a GitOps `spec.source.repoURL` is *cluster state* — a
+  namespace admin who can create an Argo CD `Application` or a Flux `GitRepository` would otherwise
+  choose where the token is sent. A GitHub Enterprise install with subdomain isolation must name
+  `forge.git_host`, and **fails config load** until it does, so the credential is never quietly
+  withheld from your own GitOps repo either.
 - **Secrets by indirection.** Every credential is referenced by the *name* of an env var / Secret key,
   never inlined in config — so config can't leak a secret (see [Configuration]({{< relref "/docs/configuration/configuration.md" >}})).
 - **Webhook auth.** The incident webhook accepts a bearer token (`server.webhook_token_env`). It is


### PR DESCRIPTION
Closes the credential hole #498 explicitly left open, and a silent GitLab failure alongside it.

**Stacked on #498.** Review that first.

> ⚠️ **This is a breaking change for one deployment shape** — GitHub Enterprise with subdomain isolation. Use `!` in the squash-merge title and keep the commit's `BREAKING CHANGE:` footer. Every other configuration is untouched and needs no new key.

## The hole

`buildGitOpsDiffer` set only `SSHRewriteHost`, and `Differ.auth` skips its host check when `TokenHost == ""`. So `repoURL: https://attacker.example/org/repo.git` — cluster state any namespace-admin can create — received the GitHub App installation token. Confirmed empirically before fixing: the stub remote logged `Authorization: Basic eC1hY2Nlc3MtdG9rZW46Z2hzX1NDUkFUQ0hfU0VDUkVU` → `x-access-token:ghs_SCRATCH_SECRET`.

#498 closed the SSH spelling by confining the *rewrite*; this closes the credential itself.

**`source_diff` had the same pair of bugs**, which I had not spotted when scoping this: a GitHub-App-only credential *and* `TokenHost` pinned to `github.com` on a GitLab deployment. Handing it the GitLab token without moving the host would have been a **new** leak, so the two had to move together.

## Why this was deferred, and how it is resolved

The reason is real: `githubGitHost` derives from the **API** URL, so on GHE with subdomain isolation (API at `api.HOST`, git at `HOST`) confining on that value would withhold the credential from the operator's own GitOps repo — every Application — which is exactly the silent data gap #495 reported. Trading a leak for a silent failure is not a fix.

**Resolution: an explicit `forge.git_host` override, defaulting to the provider-derived host, plus a startup refusal of the one shape the derivation cannot resolve.**

- `forgeGitHost` is total by construction — it never returns `""`, which a `Differ` reads as "attach everywhere".
- `Validate` **refuses** an `api.`-prefixed `github_api_url` (other than `api.github.com`) unless `forge.git_host` is set. That is precisely subdomain isolation, where both guesses are wrong — one leaks, one silently withholds. Loud once at startup beats quiet forever.
- `forge.git_host` must be a bare ASCII hostname; anything else could never equal a parsed clone host, so accepting it would withhold silently by another door.

Rejected: **probing** the App installation (network I/O at startup, and no GitHub API reports the git host); **a set** of API host + derived host — under subdomain isolation those are the *same value*, so the set does not contain the git host and solves nothing while widening the boundary.

## The GitLab half

`buildGitOpsDiffer` used `BuildForgeTokenSource`, which mints GitHub App tokens only, so a GitLab forge cloned **anonymously** whatever the URL scheme and `what_changed` silently produced nothing. `BuildKBTokenSource` exists *because of an identical silent GitLab failure* on catalog sync — its comment says the learning loop "was severed at the seam, silently". It is now renamed `BuildCloneTokenSource` and is the rule for **every** clone path, not just the KB one.

## Testing

8 mutations, each verified as actually applied via `git diff`, in **both directions** — which matters more than usual here, because the failure modes are opposite:

- **Leak**: leaving `TokenHost` unset fails with *"credential was sent to a host the repoURL merely named"*.
- **Over-confinement**: ignoring the operator override fails with *"the operator's own GitOps repo cloned WITHOUT the forge credential… the silent data gap this must not reintroduce"*.
- **Over-rejection**: rejecting every non-github.com API host fails — `ghe.example.com/api/v3` and `api-gateway.example.com` must still load clean.

Both verified independently by me. The leak test is non-vacuous by construction: it asserts the request actually arrived (`hits > 0`) before asserting no credential was on it — the HTTPS analogue of #498's paired `invalid auth method` check.

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`.

Stale comments in `differ.go` claiming the HTTPS hole is open and `TokenHost` is "deliberately empty here" were rewritten — they would now actively mislead — and `gitlab.md`'s *"Source-repo diff cloning… GitHub-App auth only"* row was deleted as false.
