### PR TITLE
fix(investigate): charge failed calls and recall embeddings to the run's ceiling

### DIFF
--- a/internal/app/catalog.go
+++ b/internal/app/catalog.go
@@ -97,8 +97,11 @@ func BuildCatalog(ctx context.Context, cfg *config.Config, forgeTok ForgeToken, 
 		// The embeddings endpoint bills like any other model call — once per
 		// hybrid-recall query, and in bulk on every catalog reload — so give it the
 		// shared metrics instance. It reports under provider="embed" on the same
-		// instruments as the main/verify/rerank tiers. That makes the spend visible,
-		// not bounded; see the inventory in docs/configuration/configuration.md.
+		// instruments as the main/verify/rerank tiers. The QUERY embed is additionally
+		// bounded: an investigation installs an embed.UsageSink on its context, so those
+		// tokens land in the totals its spend ceilings read. The BULK reload below has no
+		// investigation to charge and stays visible-but-unbounded; see the inventory in
+		// docs/configuration/configuration.md.
 		ec.Metrics = metrics
 		embedder = ec
 		log.Info("hybrid recall: embeddings endpoint configured", "base_url", e.BaseURL, "model", e.Model)

--- a/internal/docsguard/spend_coverage_test.go
+++ b/internal/docsguard/spend_coverage_test.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"strings"
+	"testing"
+)
+
+// The "What these ceilings do *not* cover" table is the one place an operator learns
+// the SCOPE of a spend ceiling, and scope claims rot in the worst direction: the page
+// keeps reading as true while the code underneath it changes what is covered. It had
+// already happened twice by the time these guards were written — the page still said
+// `lore eval` "builds its investigators with no ceilings and no pricing at all" long
+// after app.evalSpend started forwarding the operator's configured ones, and it said
+// the embeddings endpoint's tokens "are not in the investigation's totals" while that
+// was being made false.
+//
+// Anchors are the SENTENCES that carry the claim, not keywords: a table row can be
+// rewritten into its own opposite without losing any single word in it.
+var spendCoverageClaims = []string{
+	// The half of the embeddings gap an investigation-scoped ceiling CAN close.
+	"The hybrid-recall query embed's *tokens* now count against `max_tokens_per_investigation`",
+	// …and the half it deliberately cannot, said plainly rather than implied.
+	"there is no `model.embeddings.pricing`, so RunLore has no rate to price them with and refuses " +
+		"to borrow a completion model's",
+	// The bulk reload is outside every ceiling, and the page must say WHY rather than
+	// leaving it looking like an oversight.
+	"no investigation to charge, so no investigation-scoped ceiling can reach it, and RunLore ships " +
+		"none of its own",
+	// A campaign's real bound, replacing the stale "no ceilings and no pricing at all".
+	"`--max-total-tokens` is the run-level ceiling; **unset, a campaign has none**",
+}
+
+// TestSpendCoverageTableStatesWhatIsAndIsNotBounded pins those four claims.
+func TestSpendCoverageTableStatesWhatIsAndIsNotBounded(t *testing.T) {
+	doc := flattenProse(readDoc(t, configurationPath))
+	for _, want := range spendCoverageClaims {
+		if !strings.Contains(doc, flattenProse(want)) {
+			t.Errorf("configuration.md must state %q — the spend-coverage table is where an operator "+
+				"learns the SCOPE of a ceiling, and a scope claim that has quietly become false is "+
+				"worse than no claim at all", want)
+		}
+	}
+}
+
+// TestSpendCoverageStaleClaimsAreGone is the other direction: the superseded wording
+// must not survive anywhere on the page. A table rewritten by adding rows while the
+// old row stays put would satisfy every anchor above and still tell an operator that
+// embedding tokens are unbounded and that eval runs with no ceilings.
+func TestSpendCoverageStaleClaimsAreGone(t *testing.T) {
+	doc := flattenProse(readDoc(t, configurationPath))
+	for _, stale := range []string{
+		"Its tokens are not in the investigation's totals and it is not gated by either ceiling",
+		"Builds its investigators with no ceilings and no pricing at all",
+	} {
+		if strings.Contains(doc, flattenProse(stale)) {
+			t.Errorf("configuration.md still carries the superseded claim %q — it was true when it "+
+				"was written and is not now", stale)
+		}
+	}
+}
+
+// TestSpendCoverageAnchorsRejectTheWeakerWording is the mutation test for the guard
+// above, in this package's convention: each anchor must FAIL to match prose that
+// sounds like it makes the same claim but does not. Without this, an anchor loose
+// enough to match any spend paragraph would pin nothing at all — which is how a guard
+// passes forever while the thing it guards drifts.
+func TestSpendCoverageAnchorsRejectTheWeakerWording(t *testing.T) {
+	for _, weaker := range []string{
+		// Visible is not bounded — the exact distinction these fixes turn on.
+		"the /embeddings endpoint is fully instrumented: its calls, latency and tokens are all " +
+			"visible under provider=\"embed\", so its spend is accounted for",
+		// A cost ceiling that claims to cover embeddings by borrowing a rate.
+		"embedding tokens are priced at the main model's rate so max_cost_per_investigation " +
+			"covers them too",
+		// The bulk reload described as bounded by the per-investigation ceiling.
+		"the bulk corpus embed runs inside the investigation that triggered the reload, so " +
+			"max_tokens_per_investigation bounds it",
+		// A campaign described as bounded by the per-case ceilings.
+		"lore eval runs every case under the configured investigation ceilings, so a campaign " +
+			"is bounded",
+	} {
+		flat := flattenProse(weaker)
+		for _, claim := range spendCoverageClaims {
+			if strings.Contains(flat, flattenProse(claim)) {
+				t.Errorf("anchor %q matches the weaker wording %q — it pins nothing", claim, weaker)
+			}
+		}
+	}
+}

--- a/internal/embed/embed.go
+++ b/internal/embed/embed.go
@@ -46,11 +46,17 @@ type Client struct {
 	// under provider="embed" on the shared model instruments keeps it separable by
 	// label instead of inventing a metric name, matching the reranker's precedent.
 	//
-	// This makes the spend VISIBLE, not bounded: the query embed is not folded into
-	// the per-investigation totals (it does not flow through the Embedder interface,
-	// which returns vectors only) and the corpus embed runs on the git-sync goroutine
-	// with no investigation to charge. See the spend inventory in
-	// docs/configuration/configuration.md.
+	// Metrics makes that spend VISIBLE for every caller; UsageSink is what makes it
+	// ATTRIBUTABLE to one, and only an attributable figure can be bounded. A caller
+	// that installs a sink on the context — internal/investigate does, for the duration
+	// of one investigation — folds these tokens into the totals its spend ceilings
+	// compare against, which is how the cost reaches its payer despite the Embedder
+	// interface returning vectors only.
+	//
+	// The BULK corpus embed has no such payer: it runs on the git-sync goroutine with
+	// no investigation to charge, so it stays visible but UNBOUNDED, deliberately — see
+	// the spend inventory in docs/configuration/configuration.md for why a ceiling
+	// there would be a knob with nothing to bound.
 	Metrics *telemetry.Metrics
 }
 
@@ -115,6 +121,17 @@ func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, e
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
+	// Charge this round trip to whoever is accounting for it. Deferred, and placed
+	// after the marshal (which sends nothing), so EVERY path that reaches the wire is
+	// charged — including the ones that return an error: a request the endpoint
+	// accepted is billed whether or not we could read its answer, the same rule the
+	// investigation loop's own completions follow. promptTokens is filled in below
+	// when the endpoint reports it and stays 0 otherwise, meaning unknown rather than
+	// free.
+	promptTokens := 0
+	if sink := UsageSinkFrom(ctx); sink != nil {
+		defer func() { sink.record(promptTokens) }()
+	}
 	newReq := func() (*http.Request, error) {
 		r, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/embeddings", bytes.NewReader(body))
 		if err != nil {
@@ -146,6 +163,7 @@ func (c *Client) embedBatch(ctx context.Context, texts []string) ([][]float32, e
 	if err := json.Unmarshal(data, &er); err != nil {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
+	promptTokens = er.Usage.PromptTokens
 	if c.Metrics != nil && er.Usage.PromptTokens > 0 {
 		c.Metrics.ModelInputTokens.Add(ctx, int64(er.Usage.PromptTokens), embedAttrs)
 	}

--- a/internal/embed/usage.go
+++ b/internal/embed/usage.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package embed
+
+import (
+	"context"
+	"sync"
+)
+
+// UsageSink accumulates what the /embeddings endpoint billed for the calls made
+// under one context. It is how an embedding call's cost reaches a CALLER that has a
+// spend ceiling — an investigation — without widening catalog.Embedder, which returns
+// vectors only and is deliberately narrow (the catalog must not have to know what an
+// embedder costs).
+//
+// A context-scoped side channel rather than a return value because the call sits two
+// interfaces below its payer: investigate.Recall asks catalog.HybridSearcher, which
+// asks catalog.Embedder, and only the third of those touches money. Threading a usage
+// return up through both would put spend accounting into two interfaces that have no
+// other reason to know about it, and would break every fake implementing them.
+// internal/investigate already carries per-investigation state this way (see
+// WithObservedResources), so this is the shape that package's readers expect.
+//
+// Concurrency-safe: one sink is shared by every embedding call an investigation makes,
+// and nothing promises those are sequential.
+//
+// The zero value is a usable, empty sink.
+type UsageSink struct {
+	mu     sync.Mutex
+	calls  int
+	tokens int
+}
+
+// record charges one /embeddings round trip to the sink. promptTokens is what the
+// endpoint reported for it, or 0 when it reported nothing — which means UNKNOWN, not
+// free, exactly as providers.Usage's zero value does. The call is counted either way:
+// a request the endpoint accepted is billed whether or not we could parse its answer.
+func (s *UsageSink) record(promptTokens int) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.tokens += promptTokens
+}
+
+// Totals reports how many /embeddings requests have been charged to this sink and
+// their total reported prompt tokens. Nil-safe: a caller that never installed a sink
+// reads 0, 0.
+//
+// Embeddings have no output half — the reply is a vector, and every OpenAI-compatible
+// endpoint reports the cost as prompt tokens only — so one token figure is the whole
+// bill, not the input half of one.
+func (s *UsageSink) Totals() (calls, promptTokens int) {
+	if s == nil {
+		return 0, 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls, s.tokens
+}
+
+type usageSinkKey struct{}
+
+// WithUsageSink derives a context whose embedding calls charge sink. Callers that
+// bound or report their own spend install one for the duration of the work they are
+// accounting for; everything else (the CLI, the catalog syncer) passes a plain
+// context and behaves exactly as before.
+func WithUsageSink(ctx context.Context, sink *UsageSink) context.Context {
+	return context.WithValue(ctx, usageSinkKey{}, sink)
+}
+
+// UsageSinkFrom returns the sink installed on ctx, or nil. The returned pointer is
+// always safe to call Totals on.
+func UsageSinkFrom(ctx context.Context) *UsageSink {
+	s, _ := ctx.Value(usageSinkKey{}).(*UsageSink)
+	return s
+}

--- a/internal/embed/usage_test.go
+++ b/internal/embed/usage_test.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package embed
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// usageServer answers every /embeddings request with one vector and the given
+// prompt_tokens, and counts the requests it served. The counter is atomic: net/http
+// serves each request on its own goroutine.
+func usageServer(t *testing.T, promptTokens int) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var served atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		served.Add(1)
+		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[1.0,0.0]}],` +
+			`"usage":{"prompt_tokens":` + strconv.Itoa(promptTokens) + `}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &served
+}
+
+// TestUsageSinkCollectsWhatTheEndpointBilled is the accounting half of bounding the
+// embeddings endpoint: a caller that installs a sink on the context gets back the
+// provider-reported prompt tokens of every embedding call made under it, which is
+// what lets an investigation fold its own hybrid-recall query embeds into the total
+// its spend ceiling compares against.
+//
+// The metric wiring made this spend VISIBLE; a per-caller sink is what makes it
+// ATTRIBUTABLE, and only an attributable figure can be bounded.
+func TestUsageSinkCollectsWhatTheEndpointBilled(t *testing.T) {
+	srv, _ := usageServer(t, 4242)
+	var sink UsageSink
+	ctx := WithUsageSink(context.Background(), &sink)
+
+	c := New(srv.URL, "text-embed", "")
+	if _, err := c.Embed(ctx, []string{"a"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if _, err := c.Embed(ctx, []string{"b"}); err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	calls, tokens := sink.Totals()
+	if calls != 2 || tokens != 8484 {
+		t.Fatalf("sink recorded %d calls / %d tokens, want 2 / 8484 — the sink must accumulate "+
+			"every /embeddings round trip made under its context", calls, tokens)
+	}
+}
+
+// TestUsageSinkChargesEveryChunkOfALargeBatch pins that chunking is invisible to the
+// accounting: Embed splits an oversized input into maxEmbedBatch-sized requests and
+// the endpoint bills each one, so the sink must see each one.
+func TestUsageSinkChargesEveryChunkOfALargeBatch(t *testing.T) {
+	srv, served := usageServer(t, 100)
+	var sink UsageSink
+	texts := make([]string, maxEmbedBatch+1)
+	for i := range texts {
+		texts[i] = "t"
+	}
+	// The fake returns ONE vector per request, so the count check rejects the call —
+	// irrelevant here: the request was still sent, and still billed.
+	_, _ = New(srv.URL, "text-embed", "").Embed(WithUsageSink(context.Background(), &sink), texts)
+	if served.Load() < 1 {
+		t.Fatal("the server was never called")
+	}
+	calls, _ := sink.Totals()
+	if int64(calls) != served.Load() {
+		t.Fatalf("sink recorded %d calls for %d requests actually served: chunking must not "+
+			"hide round trips from the caller charging for them", calls, served.Load())
+	}
+}
+
+// TestUsageSinkChargesAFailedCall pins the same rule the investigation loop's model
+// calls now follow: a request the endpoint accepted and then failed to answer usably
+// is still a call. It is recorded with ZERO tokens — "unknown", never a claim that it
+// was free — because a failure before the usage block leaves nothing honest to report.
+func TestUsageSinkChargesAFailedCall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	var sink UsageSink
+	if _, err := New(srv.URL, "text-embed", "").Embed(WithUsageSink(context.Background(), &sink), []string{"a"}); err == nil {
+		t.Fatal("a 500 must fail the call")
+	}
+	calls, tokens := sink.Totals()
+	if calls != 1 || tokens != 0 {
+		t.Fatalf("sink recorded %d calls / %d tokens for one failed request, want 1 / 0", calls, tokens)
+	}
+}
+
+// TestUsageSinkIsOptionalAndNilSafe pins that every path without a sink — the CLI, the
+// catalog syncer, any test — behaves exactly as before, and that reading a sink that
+// was never installed is safe rather than a nil dereference at an incident's worst
+// moment.
+func TestUsageSinkIsOptionalAndNilSafe(t *testing.T) {
+	srv, _ := usageServer(t, 7)
+	if _, err := New(srv.URL, "text-embed", "").Embed(context.Background(), []string{"a"}); err != nil {
+		t.Fatalf("Embed without a sink: %v", err)
+	}
+	if calls, tokens := UsageSinkFrom(context.Background()).Totals(); calls != 0 || tokens != 0 {
+		t.Fatalf("a context with no sink must total 0/0, got %d/%d", calls, tokens)
+	}
+	var nilSink *UsageSink
+	if calls, tokens := nilSink.Totals(); calls != 0 || tokens != 0 {
+		t.Fatalf("a nil sink must total 0/0, got %d/%d", calls, tokens)
+	}
+}
+
+// TestUsageSinkRecordAndTotalsRace hammers the sink's own two operations directly —
+// interleaved writes and reads from many goroutines, which the HTTP-driven test below
+// cannot express because it only reads Totals once at the end.
+//
+// It exists as its own test because the first -race run of this package DID report a
+// race, and the report named this file's HTTP fixture (a plain `served++` counter),
+// with every frame in both stacks inside net/http and none inside usage.go. "It was
+// only the test" is exactly what a real sink race looks like from the inside, so the
+// sink's guarantee is asserted here on its own, with no HTTP server near it.
+func TestUsageSinkRecordAndTotalsRace(t *testing.T) {
+	var sink UsageSink
+	var wg sync.WaitGroup
+	const workers, iterations = 32, 200
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				sink.record(3)
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_, _ = sink.Totals()
+			}
+		}()
+	}
+	wg.Wait()
+	calls, tokens := sink.Totals()
+	if calls != workers*iterations || tokens != workers*iterations*3 {
+		t.Fatalf("sink lost updates under contention: %d calls / %d tokens, want %d / %d",
+			calls, tokens, workers*iterations, workers*iterations*3)
+	}
+}
+
+// TestUsageSinkIsConcurrencySafe: one sink is shared by every embedding call made
+// under one investigation's context, and nothing promises those are sequential.
+func TestUsageSinkIsConcurrencySafe(t *testing.T) {
+	srv, _ := usageServer(t, 10)
+	var sink UsageSink
+	ctx := WithUsageSink(context.Background(), &sink)
+	c := New(srv.URL, "text-embed", "")
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = c.Embed(ctx, []string{"a"})
+		}()
+	}
+	wg.Wait()
+	if calls, tokens := sink.Totals(); calls != 16 || tokens != 160 {
+		t.Fatalf("sink recorded %d calls / %d tokens, want 16 / 160", calls, tokens)
+	}
+}

--- a/internal/investigate/budget.go
+++ b/internal/investigate/budget.go
@@ -12,6 +12,21 @@ import (
 // with a forced submit_findings, then hard-kill with result="budget_exceeded"), so
 // the reason is what tells an operator WHICH ceiling stopped a run — on the metric
 // label, the log line and the delivered unresolved entry.
+//
+// The set is deliberately closed at these three, and stays closed as new spend is
+// brought under the ceilings. A reason names the KNOB TO RAISE, not the call site that
+// happened to cross it: hybrid-recall query embeddings and the tokens of a completion
+// that failed mid-flight are both counted into the running total now (see
+// aggregateUsage), and an overrun driven by either is still answered by raising
+// max_tokens_per_investigation — so both report tokens_total. An "embed" or
+// "failed_call" reason would split one ceiling across several metric series and point
+// an operator at knobs that do not exist.
+//
+// Nor is there a third STAGE. The recall reranker's pre-call check (Recall.affordRerank)
+// declines to spend but does not stop the run — the loop's own ladder stops it one step
+// later, with these same two rungs. Recording a rung there as well would report one
+// stop twice; a declined rerank is a recall REJECTION (rerank_over_budget), which is
+// where an operator already looks to learn why a rerank did not happen.
 const (
 	// budgetReasonRequestTokens: the next request on its own would exceed
 	// requestBudget(MaxTokensPerInvestigation) — a quarter of the run's budget.

--- a/internal/investigate/cost.go
+++ b/internal/investigate/cost.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/Smana/runlore/internal/embed"
 	"github.com/Smana/runlore/internal/providers"
 )
 
@@ -46,16 +47,37 @@ func addUsage(t *providers.UsageTotals, u providers.Usage) {
 	t.CachedInputTokens += u.CachedInputTokens
 }
 
-// aggregateUsage combines the loop's model usage with the verify pass's into one
-// per-investigation total and, when pricing is configured, estimates cost. The
-// loop tokens are priced at the main model's rate and the verify tokens at the
-// verify override's rate (which inherits the main rate when unset) — so a cheaper
-// verify model is costed correctly even though the token totals are reported
-// combined.
-func (li *LoopInvestigator) aggregateUsage(loop, verify providers.UsageTotals) providers.UsageTotals {
+// aggregateUsage combines the loop's model usage with the verify pass's and the
+// hybrid-recall query embeddings' into one per-investigation total and, when pricing
+// is configured, estimates cost. The loop tokens are priced at the main model's rate
+// and the verify tokens at the verify override's rate (which inherits the main rate
+// when unset) — so a cheaper verify model is costed correctly even though the token
+// totals are reported combined.
+//
+// EMBEDDINGS ARE COUNTED BUT NOT PRICED, deliberately, and the asymmetry is the honest
+// answer rather than an oversight:
+//
+//   - Their TOKENS are real and provider-reported (the OpenAI-compatible /embeddings
+//     wire format returns a usage block, which internal/embed reads), so they belong in
+//     the token total and under max_tokens_per_investigation. Leaving them out made an
+//     embed-heavy recall free by construction.
+//   - Their COST is not derivable. There is no model.embeddings.pricing, so the only
+//     rates in hand are the completion models', both wrong for an embeddings endpoint
+//     by an order of magnitude. Pricing embeddings at a completion rate would put a
+//     fabricated figure on the notification footer and in
+//     runlore_investigation_cost_usd — precisely the "looks instrumented for spend when
+//     it is not" failure that model.pricing's all-zero-rates warning exists to refuse.
+//     So max_cost_per_investigation errs LOW here: the same direction projectSpend
+//     already errs, written down on the configuration page rather than papered over.
+//
+// ModelCalls likewise stays a count of COMPLETIONS. An embedding is not a turn, and
+// this is the number an operator reads as how far the ReAct loop got; the embeddings
+// endpoint's own call volume is separately visible as
+// runlore_model_requests_total{provider="embed"}.
+func (li *LoopInvestigator) aggregateUsage(loop, verify, embedded providers.UsageTotals) providers.UsageTotals {
 	total := providers.UsageTotals{
 		ModelCalls:        loop.ModelCalls + verify.ModelCalls,
-		InputTokens:       loop.InputTokens + verify.InputTokens,
+		InputTokens:       loop.InputTokens + verify.InputTokens + embedded.InputTokens,
 		OutputTokens:      loop.OutputTokens + verify.OutputTokens,
 		CachedInputTokens: loop.CachedInputTokens + verify.CachedInputTokens,
 	}
@@ -68,6 +90,16 @@ func (li *LoopInvestigator) aggregateUsage(loop, verify providers.UsageTotals) p
 		total.CostUSD = li.Pricing.cost(loop) + verifyPricing.cost(verify)
 	}
 	return total
+}
+
+// embedSpend snapshots what THIS investigation has spent on hybrid-recall query
+// embeddings so far, read from the context-scoped sink Investigate installs. It is the
+// only reader of that sink, so every ceiling check and every delivered figure sees the
+// same number rather than re-deriving one. A context with no sink — every caller
+// outside Investigate — totals zero, so nothing else changes shape.
+func embedSpend(ctx context.Context) providers.UsageTotals {
+	_, tokens := embed.UsageSinkFrom(ctx).Totals()
+	return providers.UsageTotals{InputTokens: tokens}
 }
 
 // recordUsageMetrics emits the per-investigation token totals (and estimated cost

--- a/internal/investigate/cost_test.go
+++ b/internal/investigate/cost_test.go
@@ -93,9 +93,9 @@ func TestVerifyPricingInherits(t *testing.T) {
 	verify := providers.UsageTotals{ModelCalls: 1, InputTokens: 500, OutputTokens: 40}
 	li := &LoopInvestigator{Pricing: &Pricing{InputUSDPerMTok: 10, OutputUSDPerMTok: 30}}
 	// Inherit: verify tokens priced at the main rate.
-	inherited := li.aggregateUsage(loop, verify)
+	inherited := li.aggregateUsage(loop, verify, providers.UsageTotals{})
 	li.VerifyPricing = &Pricing{InputUSDPerMTok: 1, OutputUSDPerMTok: 3} // cheaper verify model
-	overridden := li.aggregateUsage(loop, verify)
+	overridden := li.aggregateUsage(loop, verify, providers.UsageTotals{})
 	if !(overridden.CostUSD < inherited.CostUSD) {
 		t.Fatalf("a cheaper verify pricing must lower the cost: inherited=%.8f overridden=%.8f",
 			inherited.CostUSD, overridden.CostUSD)

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -485,6 +485,18 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 				li.Metrics.ModelCachedInputTokens.Add(ctx, int64(resp.Usage.CachedInputTokens), provAttr)
 			}
 		}
+		// Accumulate the provider-reported usage BEFORE any of the terminal branches
+		// below, so no exit can drop a call that was already billed. A completion that
+		// FAILED still cost whatever the provider reported before it broke: every model
+		// client returns CompletionResponse.CostOnly() alongside its error for exactly
+		// this reader ("the token counts the provider reported before the failure are
+		// real and billed"), and a total that only counts successful calls lets a
+		// flapping provider spend without the ceiling ever seeing it. That is the same
+		// discipline summarizeElided already applies to the compaction digest; this is
+		// the loop's own call finally reading the same rule. Zero usage (a failure before
+		// the provider reported anything) still counts as a model call and adds no
+		// tokens — "unknown", never a claim that the call was free.
+		addUsage(&loopTotals, resp.Usage)
 		if err != nil {
 			// The per-investigation deadline fired (or the parent ctx was cancelled):
 			// deliver a synthetic timeout result rather than bubbling a bare error the
@@ -505,10 +517,12 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 		// Anchor subsequent budget estimates to reality: the provider just reported the
 		// true input size for the request we estimated as reqHeuristic. Zero usage
 		// (provider didn't report) is a no-op — the pure heuristic keeps driving the guard.
+		// Only a SUCCEEDED request calibrates: the ratio describes how a full request maps
+		// to reported input, and a stream that died mid-flight may have reported only part
+		// of it. The spend accounting above deliberately does not make that distinction —
+		// a partial figure is still money spent — but a partial figure would corrupt a
+		// ratio that is then applied to every later estimate.
 		calib.observe(reqHeuristic, resp.Usage)
-		// Accumulate the same reported usage the calibrator just read (no double
-		// count): one model call plus its tokens toward the per-investigation total.
-		addUsage(&loopTotals, resp.Usage)
 		li.Log.Debug("investigation step", "title", req.Title, "step", step, "tool_calls", len(resp.ToolCalls), "text_len", len(resp.Text))
 		// The provider declined the turn (a safety/refusal stop reason): deliver a
 		// first-class unresolved result rather than misreading the empty response as a

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -389,12 +389,14 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	// tryRecall runs the instant-recall short-circuit + near-miss block: it delivers
 	// (finish) and reports done==true when a recalled answer survives verify, and
 	// otherwise returns the near-miss lead (if any) to fold into the seed. It threads
-	// `result` (for the deferred completion metric) and `verifyTotals` (for the
-	// reranker/verify tokens) by pointer so a short-circuit records the same labels the
-	// inline block did. nearMiss is the top structurally-agreeing catalog candidate
+	// `result` (for the deferred completion metric) and BOTH totals by pointer:
+	// `verifyTotals` is where the reranker/verify tokens land, and `loopTotals` is read
+	// (with the query embeddings) to answer whether the reranker's paid call is
+	// affordable at all — the running total has to be the loop's own, not a
+	// reconstruction of it. nearMiss is the top structurally-agreeing catalog candidate
 	// surfaced when recall is consulted but does NOT fire — folded into the seed prompt
 	// as an UNVERIFIED lead (C2).
-	nearMiss, done := li.tryRecall(ctx, req, &result, &verifyTotals, finish)
+	nearMiss, done := li.tryRecall(ctx, req, &result, &loopTotals, &verifyTotals, finish)
 	if done {
 		return nil
 	}
@@ -722,23 +724,37 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 // returns immediately, skipping the full ReAct loop. Otherwise it returns the C2
 // near-miss lead (or nil) for the caller to fold into the seed prompt.
 //
-// It threads two pieces of Investigate's state by pointer, mirroring the inline block
-// exactly: `result` (the deferred completion-metric label — "recall" on a short
-// circuit) and `verifyTotals` (so the reranker + the recall verify pass price
-// their tokens into the per-investigation cost; both run on the verify tier).
+// It threads Investigate's state by pointer, mirroring the inline block exactly:
+// `result` (the deferred completion-metric label — "recall" on a short circuit) and
+// `verifyTotals` (so the reranker + the recall verify pass price their tokens into the
+// per-investigation cost; both run on the verify tier). `loopTotals` is read-only here
+// — the loop has not run yet, so it is zero on every real call — and is threaded
+// anyway rather than assumed zero: the affordability check below must read the same
+// aggregateUsage the loop's own ceiling does, and an assumption that happens to hold
+// today is how a guard quietly stops guarding.
 //
 // Instant recall is disabled under auto-execution: a poisoned catalog entry must not
 // short-circuit a real investigation straight into an auto-executed action. The
 // near-miss it may return shares that same `!IsAuto()` gate — it is only ever set
 // inside this block — so a poisoned KB entry can shape neither an auto-executed action
 // (instant recall) nor even the prompt under auto.
-func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *string, verifyTotals *providers.UsageTotals, finish func(providers.Investigation)) (nearMiss *catalog.Entry, done bool) {
+func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *string, loopTotals, verifyTotals *providers.UsageTotals, finish func(providers.Investigation)) (nearMiss *catalog.Entry, done bool) {
 	if li.Recall == nil || li.autoExecuting() {
 		return nil, false
 	}
-	// Thread verifyTotals so the reranker's tokens fold into the
-	// per-investigation cost — it runs on the verify tier, so it prices there.
-	entry, conf, outcomeRejected := li.Recall.lookupWithUsage(ctx, req, verifyTotals)
+	// The recall path's spend channel: BOTH halves of check-then-spend-then-account in
+	// one value. `totals` is verifyTotals so the reranker's tokens fold into the
+	// per-investigation cost at the tier it actually runs on; `afford` is the loop's own
+	// budgetTrip over its own aggregateUsage, so the ceiling the reranker is measured
+	// against is the same number, computed the same way, that stops the loop one step
+	// later — not a second opinion that could disagree with it.
+	spend := &recallSpend{
+		totals: verifyTotals,
+		afford: func(est int) string {
+			return li.budgetTrip(est, li.aggregateUsage(*loopTotals, *verifyTotals, embedSpend(ctx)))
+		},
+	}
+	entry, conf, outcomeRejected := li.Recall.lookupWithUsage(ctx, req, spend)
 	if entry == nil {
 		// Recall was consulted but no gate cleared: report the non-fire so a caller
 		// can distinguish it from a recall that fired and was later withdrawn.

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/embed"
 	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
 	"github.com/Smana/runlore/internal/redact"
@@ -284,16 +285,28 @@ func (li *LoopInvestigator) Investigate(ctx context.Context, req Request) error 
 	// target), augmented by what_changed and the gitops inspector tools. reviewActions
 	// consults the set to guard executable targets (see guardUnobservedTargets).
 	ctx = WithObservedResources(ctx, req.Workload)
+	// Charge this investigation for the embeddings it causes. The hybrid-recall path
+	// embeds the query against a PAID endpoint — once for the recall lookup, again for
+	// the near-miss lookup that follows a non-fire — from inside a run that has spend
+	// ceilings; but the call goes out through catalog.Embedder, which returns vectors
+	// and nothing else, so those tokens never reached the totals the ceilings compare
+	// against and an embed-heavy recall was free by construction. A context-scoped sink
+	// carries the spend to its payer without widening two interfaces (HybridSearcher,
+	// Embedder) that have no other reason to know what an embedding costs. Installed
+	// before tryRecall, which is where the embedding happens; embedSpend is its only
+	// reader.
+	ctx = embed.WithUsageSink(ctx, &embed.UsageSink{})
 	// Record wall-clock duration + a completion-result label at whichever exit we take.
 	start := time.Now()
 	result := "unresolved"
 	// Per-investigation token/cost accounting. loopTotals accumulates the ReAct
 	// loop's model calls; verifyTotals the adversarial verify pass's (main loop or
-	// recall). setUsage stamps the combined, priced totals onto whatever result we
-	// deliver, so cost is surfaced no matter which exit we take.
+	// recall); the query embeddings live on the context sink installed above. setUsage
+	// stamps the combined, priced totals onto whatever result we deliver, so cost is
+	// surfaced no matter which exit we take.
 	var loopTotals, verifyTotals providers.UsageTotals
 	setUsage := func(inv *providers.Investigation) {
-		inv.Usage = li.aggregateUsage(loopTotals, verifyTotals)
+		inv.Usage = li.aggregateUsage(loopTotals, verifyTotals, embedSpend(ctx))
 	}
 	// finish is the SINGLE terminal-delivery chokepoint (#234 follow-up): every exit
 	// that accepts an investigation — the happy submit_findings turn, the recall
@@ -819,16 +832,20 @@ func (li *LoopInvestigator) tryRecall(ctx context.Context, req Request, result *
 		m.RecallHits.Add(ctx, 1, metric.WithAttributes(attribute.String("result", recallResult)))
 		if len(rec.RootCauses) > 0 {
 			// What this short-circuit COST, measured — not a guess at what it saved. By
-			// here verifyTotals holds every model call the recall path made (the opt-in
-			// reranker plus the adversarial verify pass), so the real number is already in
-			// hand: a dashboard differences it against the per-investigation token
-			// histograms recordUsageMetrics emits to size what recall avoided. Cached input
-			// is included (providers.Usage.InputTokens already counts it), matching those
-			// histograms.
+			// here verifyTotals holds the recall path's completions (the opt-in reranker
+			// plus the adversarial verify pass) and the context sink holds the query
+			// embeddings it caused, so the real number is already in hand: a dashboard
+			// differences it against the per-investigation token histograms
+			// recordUsageMetrics emits to size what recall avoided. Cached input is
+			// included (providers.Usage.InputTokens already counts it), matching those
+			// histograms — as are the embeddings, for the same reason: they are on the
+			// other side of the subtraction too, so omitting them here would overstate the
+			// saving by exactly the amount recall itself spent on retrieval.
 			//
 			// Delivered short-circuits only: a recall the verify pass refutes falls through
 			// to a full investigation, which reports these tokens in its own totals.
-			m.RecallTokensSpent.Add(ctx, int64(verifyTotals.InputTokens+verifyTotals.OutputTokens))
+			m.RecallTokensSpent.Add(ctx, int64(verifyTotals.InputTokens+verifyTotals.OutputTokens+
+				embedSpend(ctx).InputTokens))
 		}
 	}
 	if len(rec.RootCauses) > 0 {
@@ -981,8 +998,9 @@ func (li *LoopInvestigator) enforceBudget(ctx context.Context, req Request, sys 
 	// Priced the same way the delivered finding is (loop tokens at Pricing, verify
 	// tokens at VerifyPricing). Read AFTER compaction so a summarize-mode digest call
 	// counts against the ceiling on the very step that paid for it, and after tryRecall
-	// so a recall fall-through's reranker + verify calls are already in it.
-	spent := li.aggregateUsage(*loopTotals, *verifyTotals)
+	// so a recall fall-through's reranker + verify calls — and its query embeddings —
+	// are already in it.
+	spent := li.aggregateUsage(*loopTotals, *verifyTotals, embedSpend(ctx))
 	crossed := li.budgetTrip(est, spent)
 	if crossed == "" {
 		return false

--- a/internal/investigate/loop_test.go
+++ b/internal/investigate/loop_test.go
@@ -1866,11 +1866,11 @@ func TestTryRecallNearMissOnNonFire(t *testing.T) {
 	}
 	req := Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}
 	result := "unresolved"
-	var totals providers.UsageTotals
+	var loopTotals, totals providers.UsageTotals
 	delivered := 0
 	finish := func(providers.Investigation) { delivered++ }
 
-	nearMiss, done := li.tryRecall(context.Background(), req, &result, &totals, finish)
+	nearMiss, done := li.tryRecall(context.Background(), req, &result, &loopTotals, &totals, finish)
 	if done {
 		t.Fatal("a non-firing recall must report done==false so the loop runs")
 	}
@@ -1903,9 +1903,9 @@ func TestTryRecallDisabledUnderAuto(t *testing.T) {
 	}
 	req := Request{Title: "HarborProbeFailure", Workload: providers.Workload{Namespace: "tooling", Name: "harbor"}}
 	result := "unresolved"
-	var totals providers.UsageTotals
+	var loopTotals, totals providers.UsageTotals
 	delivered := 0
-	nearMiss, done := li.tryRecall(context.Background(), req, &result, &totals, func(providers.Investigation) { delivered++ })
+	nearMiss, done := li.tryRecall(context.Background(), req, &result, &loopTotals, &totals, func(providers.Investigation) { delivered++ })
 	if done || delivered != 0 || nearMiss != nil {
 		t.Fatalf("instant recall must be disabled under auto: done=%v delivered=%d nearMiss=%+v", done, delivered, nearMiss)
 	}

--- a/internal/investigate/recall.go
+++ b/internal/investigate/recall.go
@@ -146,20 +146,21 @@ func buildRecallQuery(req Request) string {
 // lookup returns the matched entry and a DERIVED confidence when a recall is
 // trustworthy enough to short-circuit, else (nil, 0). The BM25 score is always
 // recorded (even on rejection) so the thresholds can be tuned from live data. It is a
-// thin wrapper over lookupWithUsage with no usage sink — kept for callers (and tests)
-// that don't thread the per-investigation token total.
+// thin wrapper over lookupWithUsage with no spend channel — kept for callers (and
+// tests) that neither bound nor account for the per-investigation total.
 func (r *Recall) lookup(ctx context.Context, req Request) (*catalog.Entry, float64) {
 	e, conf, _ := r.lookupWithUsage(ctx, req, nil)
 	return e, conf
 }
 
-// lookupWithUsage is lookup plus an optional usage sink: when a Reranker runs, its
-// completion's token usage is accumulated into totals (nil ⇒ ignored) so the loop can
-// fold the reranker's cost into the per-investigation total. The gate logic is
-// identical to lookup — totals is a side channel, never a decision input. The third
-// return lists the entry paths the outcome gate (Gate 3) rejected this lookup (nil
-// when none) so the caller's near-miss lead can exclude them.
-func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *providers.UsageTotals) (*catalog.Entry, float64, []string) {
+// lookupWithUsage is lookup plus an optional spend channel: when a Reranker would run,
+// the channel's ceiling is consulted BEFORE its paid completion and that completion's
+// usage is accumulated into the channel's totals after it (nil ⇒ neither, which is
+// exactly the old behaviour). The retrieval gate logic is identical to lookup — spend
+// never changes WHICH entry wins, only whether the paid ranking step is affordable at
+// all. The third return lists the entry paths the outcome gate (Gate 3) rejected this
+// lookup (nil when none) so the caller's near-miss lead can exclude them.
+func (r *Recall) lookupWithUsage(ctx context.Context, req Request, spend *recallSpend) (*catalog.Entry, float64, []string) {
 	if r == nil || r.Catalog == nil {
 		return nil, 0, nil
 	}
@@ -250,7 +251,13 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 		if k <= 0 || k > len(agreeing) {
 			k = len(agreeing)
 		}
-		matched, mconf, ok := r.Rerank.rank(ctx, req, agreeing[:k], totals)
+		// Cost guard 2 — the SPEND ceiling, consulted BEFORE the call rather than after
+		// it. The MinScore guard above asks "is this call worth making"; this one asks
+		// "can this investigation pay for it". Both fall through the same way.
+		if !r.affordRerank(ctx, req, agreeing[:k], spend) {
+			return nil, 0, nil
+		}
+		matched, mconf, ok := r.Rerank.rank(ctx, req, agreeing[:k], spend)
 		// Fire ONLY on a calibrated confidence at or above the (corpus-independent)
 		// threshold. A no-match / low-confidence / hallucinated-id verdict falls through —
 		// the false-recall guard (a wrong or absent match is worse than no recall).
@@ -304,7 +311,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 			f, ok := r.outcomeGate(counts, e.Path)
 			if !ok {
 				r.reject(ctx, "low_outcome")
-				return r.outcomeFallback(ctx, req, agreeing, counts, minScore, soloFloor, totals, []string{e.Path})
+				return r.outcomeFallback(ctx, req, agreeing, counts, minScore, soloFloor, spend, []string{e.Path})
 			}
 			conf = clampF(conf*f, 0, 0.90)
 		}
@@ -348,7 +355,7 @@ func (r *Recall) lookupWithUsage(ctx context.Context, req Request, totals *provi
 // argument justified only the original winner, so a skipped-winner candidate gets
 // the same bar as a lone hit. Candidates arrive in lexical order, so the first one
 // below the bar ends the walk.
-func (r *Recall) outcomeFallback(ctx context.Context, req Request, agreeing []catalog.ScoredEntry, counts map[string]outcome.Aggregate, minScore, soloFloor float64, totals *providers.UsageTotals, rejected []string) (*catalog.Entry, float64, []string) {
+func (r *Recall) outcomeFallback(ctx context.Context, req Request, agreeing []catalog.ScoredEntry, counts map[string]outcome.Aggregate, minScore, soloFloor float64, spend *recallSpend, rejected []string) (*catalog.Entry, float64, []string) {
 	if r.Rerank != nil {
 		// The rank verdict names ONE candidate, so a fallback needs a second — and
 		// FINAL — rank call over the remaining candidates. Bounded by construction:
@@ -367,7 +374,13 @@ func (r *Recall) outcomeFallback(ctx context.Context, req Request, agreeing []ca
 		if k <= 0 || k > len(remaining) {
 			k = len(remaining)
 		}
-		matched, mconf, ok := r.Rerank.rank(ctx, req, remaining[:k], totals)
+		// The SECOND rank call of this investigation, so unlike the first it has real
+		// prior spend to be measured against — the first call's tokens are already in the
+		// running total by now.
+		if !r.affordRerank(ctx, req, remaining[:k], spend) {
+			return nil, 0, rejected
+		}
+		matched, mconf, ok := r.Rerank.rank(ctx, req, remaining[:k], spend)
 		if !ok || mconf < r.Rerank.Threshold {
 			r.reject(ctx, "rerank_low_confidence")
 			return nil, 0, rejected
@@ -530,6 +543,33 @@ func nearMissAgrees(reqW providers.Workload, entryResource string, requireWorklo
 		return matchNamespace
 	}
 	return matchNone
+}
+
+// affordRerank reports whether this investigation may pay for a rank call over cands,
+// consulting the spend ceiling BEFORE the completion is sent. It is the checking half
+// of the rule Reranker.rank spends under; the two used to be one-sided, so the ceiling
+// was first read on the way back out with the money already gone.
+//
+// A refusal falls through exactly as a no-match does, which is deliberate and is what
+// keeps this inside the EXISTING ladder rather than beside it: declining the rerank
+// does not stop the run, it hands the run to the full loop, whose first enforceBudget
+// step sees the same crossed ceiling and fires the same nudge→kill rungs with the same
+// reason. Firing a rung here as well would report one stop twice on
+// runlore_investigation_budget_trips_total and inflate the nudge rate; recording it as
+// a recall REJECTION instead puts it beside rerank_no_signal and rerank_low_confidence,
+// where an operator already looks to learn why a rerank did not happen.
+func (r *Recall) affordRerank(ctx context.Context, req Request, cands []catalog.ScoredEntry, spend *recallSpend) bool {
+	reason := spend.refuses(r.Rerank.requestEstimate(req, cands))
+	if reason == "" {
+		return true
+	}
+	r.reject(ctx, "rerank_over_budget")
+	if r.Log != nil {
+		r.Log.Warn("recall reranker skipped: the investigation's spend ceiling is already crossed; "+
+			"falling through to a full investigation (which the budget ladder will stop)",
+			"title", req.Title, "ceiling", reason, "candidates", len(cands))
+	}
+	return false
 }
 
 // reject records a rejection reason (nil-safe).

--- a/internal/investigate/rerank.go
+++ b/internal/investigate/rerank.go
@@ -153,16 +153,22 @@ func (rr *Reranker) rank(ctx context.Context, req Request, cands []catalog.Score
 		rr.Metrics.ModelRequestDuration.Record(ctx, time.Since(start).Seconds(),
 			metric.WithAttributes(attribute.String("provider", "rerank")))
 	}
+	// Count the reranker's tokens toward the per-investigation total (it runs on the
+	// verify tier, so aggregateUsage prices it correctly) — BEFORE the failure branch.
+	// This one matters most of the three: a rank error does not end the run, it falls
+	// THROUGH to a full ReAct loop that then spends its whole budget on top. Tokens
+	// dropped here would stay missing from the running total the loop's ceiling reads
+	// for the entire rest of the investigation, so a flapping reranker would be free by
+	// construction. The provider reports them on the error path for this exact reason
+	// (CompletionResponse.CostOnly).
+	if totals != nil {
+		addUsage(totals, resp.Usage)
+	}
 	if err != nil {
 		if rr.Log != nil {
 			rr.Log.Warn("recall reranker failed; falling through to full investigation", "title", req.Title, "err", err)
 		}
 		return catalog.Entry{}, 0, false
-	}
-	// Count the reranker's tokens toward the per-investigation total (it runs on the
-	// verify tier, so aggregateUsage prices it correctly).
-	if totals != nil {
-		addUsage(totals, resp.Usage)
 	}
 	if rr.Metrics != nil {
 		rr.Metrics.ModelInputTokens.Add(ctx, int64(resp.Usage.InputTokens),

--- a/internal/investigate/rerank.go
+++ b/internal/investigate/rerank.go
@@ -72,6 +72,66 @@ type Reranker struct {
 // prose reply is never a decision, so the request forces this tool (ToolChoice).
 const rerankToolName = "rerank_match"
 
+// recallSpend is the per-investigation spend channel the recall path carries on the
+// loop's behalf. It holds BOTH halves of one rule, which is why they are one type
+// rather than two parameters: the ceiling that must clear BEFORE a paid reranker
+// completion (afford), and the totals its usage is accumulated into AFTER it (totals).
+//
+// Splitting them is precisely how the reranker came to account for a call it had never
+// been allowed to make — the accounting half was threaded down here and the checking
+// half was not, so the ceiling was first consulted with the money already gone. A
+// caller holding one now necessarily holds the other.
+//
+// Nil, or either field nil, is the unbounded/unaccounted case: the bare Recall.lookup
+// used by the CLI and by tests behaves byte-for-byte as before, and an operator who
+// opted out with max_tokens_per_investigation: -1 is not handed a derived bound they
+// never asked for.
+//
+// SCOPE, stated plainly because a partial guarantee that reads as a total one is the
+// whole failure mode here: it gates paid COMPLETIONS on the recall path. The query
+// EMBEDDING retrieval performs before ranking is charged (see embedSpend) but is not
+// itself gated — it is one small request, it runs before there is any spend to compare
+// it against, and the loop's own ladder fires on the very next step.
+type recallSpend struct {
+	totals *providers.UsageTotals
+	// afford reports the ceiling reason refusing a request of estTokens, or "" to
+	// proceed. It is li.budgetTrip over li.aggregateUsage — the same predicate against
+	// the same running total the loop's own guard uses, never a second opinion.
+	afford func(estTokens int) string
+}
+
+// refuses reports which ceiling, if any, forbids a request of estTokens. Nil-safe: no
+// channel, or no ceiling, refuses nothing.
+func (s *recallSpend) refuses(estTokens int) string {
+	if s == nil || s.afford == nil {
+		return ""
+	}
+	return s.afford(estTokens)
+}
+
+// add accumulates one completion's usage into the investigation's totals. Nil-safe.
+func (s *recallSpend) add(u providers.Usage) {
+	if s == nil || s.totals == nil {
+		return
+	}
+	addUsage(s.totals, u)
+}
+
+// requestEstimate is the pre-call size of the rerank completion this candidate set
+// would send, measured with providers.EstimateTokens over exactly what rank puts on
+// the wire — the same heuristic, over the same three parts, that the loop's budget
+// guard measures its own requests with, so the ceiling compares like with like.
+//
+// It renders the candidates a second time (rank renders them again for the call
+// itself). That is a few hundred bytes of string building, once per investigation, to
+// avoid restructuring rank's signature around a pre-rendered prompt — and the guard
+// has to measure what will ACTUALLY be sent, not an approximation of it.
+func (rr *Reranker) requestEstimate(req Request, cands []catalog.ScoredEntry) int {
+	return providers.EstimateTokens(rerankPrompt,
+		[]providers.Message{{Role: "user", Content: renderRerankCandidates(req, cands)}},
+		[]providers.ToolSpec{rerankSpec()})
+}
+
 // rerankPrompt drives the reranker. It gates on TOPICAL fit — "is this the canonical
 // runbook for this resource failing this way?" — not on proving the runbook's root
 // cause from the alert (alerts are generic; the cause is re-confirmed against live state
@@ -131,9 +191,13 @@ type rerankVerdict struct {
 // investigation — whenever the model finds no match, errors, returns no/garbled tool
 // call, or names an id outside the candidate set. It is best-effort by construction:
 // every failure path is a fall-through, never a wrong recall. The completion's token
-// usage is accumulated into totals (when non-nil) so the reranker's cost counts toward
+// usage is accumulated into spend (when non-nil) so the reranker's cost counts toward
 // the per-investigation total (priced at the verify tier, where it runs).
-func (rr *Reranker) rank(ctx context.Context, req Request, cands []catalog.ScoredEntry, totals *providers.UsageTotals) (catalog.Entry, float64, bool) {
+//
+// The caller MUST have cleared spend.refuses first — see Recall.affordRerank. This
+// function is the spending side of the rule, not the checking side: by the time it is
+// entered the decision to pay has already been made.
+func (rr *Reranker) rank(ctx context.Context, req Request, cands []catalog.ScoredEntry, spend *recallSpend) (catalog.Entry, float64, bool) {
 	start := time.Now()
 	resp, err := rr.Model.Complete(ctx, providers.CompletionRequest{
 		System:     rerankPrompt,
@@ -161,9 +225,7 @@ func (rr *Reranker) rank(ctx context.Context, req Request, cands []catalog.Score
 	// for the entire rest of the investigation, so a flapping reranker would be free by
 	// construction. The provider reports them on the error path for this exact reason
 	// (CompletionResponse.CostOnly).
-	if totals != nil {
-		addUsage(totals, resp.Usage)
-	}
+	spend.add(resp.Usage)
 	if err != nil {
 		if rr.Log != nil {
 			rr.Log.Warn("recall reranker failed; falling through to full investigation", "title", req.Title, "err", err)

--- a/internal/investigate/spend_embed_test.go
+++ b/internal/investigate/spend_embed_test.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/embed"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// embeddingHybrid is a HybridSearcher shaped like the real one: it embeds the query
+// through a REAL embed.Client (against a local endpoint that reports usage) and then
+// returns fixed hits. Using the real client rather than a hand-charged fake is the
+// point — it exercises the actual seam under test, from the /embeddings response's
+// usage block through embed.UsageSink to the investigation's totals.
+type embeddingHybrid struct {
+	client *embed.Client
+	hits   []catalog.ScoredEntry
+	calls  atomic.Int64
+}
+
+func (h *embeddingHybrid) SearchHybrid(ctx context.Context, query string, _ int) ([]catalog.ScoredEntry, error) {
+	h.calls.Add(1)
+	if _, err := h.client.Embed(ctx, []string{query}); err != nil {
+		return nil, err
+	}
+	return h.hits, nil
+}
+
+func (h *embeddingHybrid) HasVectors() bool { return true }
+
+// newEmbeddingHybrid stands up an /embeddings endpoint that bills promptTokens per
+// request and wires a hybrid searcher to it.
+func newEmbeddingHybrid(t *testing.T, promptTokens int, hits []catalog.ScoredEntry) *embeddingHybrid {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":[{"index":0,"embedding":[1.0,0.0]}],` +
+			`"usage":{"prompt_tokens":` + strconv.Itoa(promptTokens) + `}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return &embeddingHybrid{client: embed.New(srv.URL, "text-embed", ""), hits: hits}
+}
+
+// offTargetHit is a candidate that will NOT structurally agree with okReq()
+// (apps/web), so recall cannot fire and the loop runs — which is what puts BOTH
+// hybrid queries on the path: the recall lookup and the near-miss lookup that follows
+// a non-fire.
+func offTargetHit() []catalog.ScoredEntry {
+	return []catalog.ScoredEntry{{
+		Entry: catalog.Entry{Title: "Unrelated", Path: "other.md", Resource: "infra/etcd"},
+		Score: 0.9,
+	}}
+}
+
+// TestHybridRecallQueryEmbedCountsTowardTheInvestigation closes the half of the
+// embeddings gap that an investigation-scoped ceiling CAN cover.
+//
+// The /embeddings endpoint is a paid API called once per hybrid-recall query, from
+// inside an investigation that has spend ceilings — but the tokens never reached that
+// investigation's totals, because the call goes out through catalog.Embedder, which
+// returns vectors and nothing else. So an embed-heavy recall was free by construction:
+// the more queries it made, the more of the run's real spend the ceiling could not
+// see.
+//
+// Both queries on the non-fire path are charged: the recall lookup, and the near-miss
+// lookup that follows it. Missing the second would leave the commonest path — recall
+// consulted, recall did not fire — undercounted by half.
+func TestHybridRecallQueryEmbedCountsTowardTheInvestigation(t *testing.T) {
+	const perQuery = 500
+	hyb := newEmbeddingHybrid(t, perQuery, offTargetHit())
+	loop := &mixedModel{steps: []mixedStep{{resp: providers.CompletionResponse{
+		ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName,
+			Args: `{"confidence":0.8,"root_causes":[{"summary":"oom","confidence":0.8}]}`}},
+		Usage: providers.Usage{InputTokens: 1_000, OutputTokens: 50},
+	}}}}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:      loop,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		Recall:     &Recall{Catalog: fakeScored{}, Hybrid: hyb, HybridMinScore: 0.8, HybridMarginGap: 0.1},
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), okReq()); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if n := hyb.calls.Load(); n != 2 {
+		t.Fatalf("expected 2 hybrid queries (recall lookup + near-miss), got %d — the test no "+
+			"longer exercises the path it claims to", n)
+	}
+	if want := 1_000 + 2*perQuery; got.Usage.InputTokens != want {
+		t.Fatalf("the hybrid-recall query embeds must count toward the investigation's tokens: "+
+			"got %d, want %d (1000 loop + 2 x %d embed). The embeddings endpoint bills these and "+
+			"reports them; a per-investigation ceiling that cannot see them bounds less than it says.",
+			got.Usage.InputTokens, want, perQuery)
+	}
+	// ModelCalls stays a count of COMPLETIONS. An embedding is not a turn, and this is
+	// the number an operator reads as "how deep did the loop go"; the embeddings
+	// endpoint's own call volume is already published under provider="embed".
+	if got.Usage.ModelCalls != 1 {
+		t.Fatalf("ModelCalls must stay a completion count, got %d", got.Usage.ModelCalls)
+	}
+}
+
+// TestEmbedSpendTripsTheCumulativeTokenCeiling proves the folded-in embed spend
+// reaches the ladder, and — the question this answers for the metric's label set —
+// that it needs NO new `reason` value: reason names WHICH CEILING an operator has to
+// raise, not which call pushed it over, and the ceiling here is
+// max_tokens_per_investigation exactly as it would be for a loop-only overrun.
+//
+// The numbers are scaled so ONE embed charge is material against a deliberately small
+// ceiling; a shipped-default 400 000 ceiling would need hundreds of query embeds to
+// move the ladder, which is not a unit test. The arithmetic is what is under test.
+func TestEmbedSpendTripsTheCumulativeTokenCeiling(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	// perQuery x 2 queries = 12 000 charged before the loop's first request. Each loop
+	// call reports 7 000 input (under the 7 500 the 30 000 ceiling derives for ONE
+	// request, so the per-request arm cannot be what fires) and the next request
+	// projects another 7 000 on top.
+	//   counting the embeds:  12 000 + 2 calls (14 020) + 7 000 = 33 020  → over at call 2
+	//   ignoring them:                 4 calls (28 040) + 7 000 = 35 040  → over at call 4
+	const (
+		perQuery = 6_000
+		ceiling  = 30_000
+	)
+	hyb := newEmbeddingHybrid(t, perQuery, offTargetHit())
+	model := &reportingRunawayModel{inputTokens: 7_000}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:                     model,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: ceiling,
+		Metrics:                   telemetry.NewMetrics(),
+		Recall:                    &Recall{Catalog: fakeScored{}, Hybrid: hyb, HybridMinScore: 0.8, HybridMarginGap: 0.1},
+		OnComplete:                func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), okReq()); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if model.calls != 3 {
+		t.Fatalf("the ladder must engage after 2 calls once the %d embed tokens are counted "+
+			"(2 free calls, 1 nudged, then the kill = 3); got %d calls. Uncounted, this run gets "+
+			"5 calls against the same ceiling.", 2*perQuery, model.calls)
+	}
+	if !mentions(got.Unresolved, "budget") {
+		t.Fatalf("the hard-kill result must name the budget it hit; got: %v", got.Unresolved)
+	}
+	body := scrapeMetrics(t, h)
+	if !strings.Contains(body, `reason="tokens_total"`) {
+		t.Fatalf("an embed-driven overrun must trip the EXISTING cumulative-token reason — the "+
+			"label says which ceiling to raise, not which call spent it:\n%s", body)
+	}
+	if strings.Contains(body, `reason="embed"`) {
+		t.Fatalf("there must be no per-call-site reason value; reason names the ceiling:\n%s", body)
+	}
+}
+
+// TestEmbedTokensAreCountedButNotPriced pins the honest half of the decision. There is
+// no `model.embeddings.pricing`, so RunLore has no rate for an embedding token. The
+// tokens are real and provider-reported, so they belong in the token total and under
+// the token ceiling; the dollar figure is NOT derivable, so pricing them at the main
+// or verify model's rate — the only rates in hand, both wrong by an order of
+// magnitude — would fabricate a number the operator reads as measured.
+//
+// So the cost ceiling deliberately does not cover them, and errs LOW, which is the
+// direction the projection already errs and the direction the page states.
+func TestEmbedTokensAreCountedButNotPriced(t *testing.T) {
+	li := &LoopInvestigator{Pricing: &Pricing{InputUSDPerMTok: 1_000_000}} // $1 per token
+	loop := providers.UsageTotals{ModelCalls: 1, InputTokens: 3}
+	embedded := providers.UsageTotals{InputTokens: 7}
+
+	base := li.aggregateUsage(loop, providers.UsageTotals{}, providers.UsageTotals{})
+	withEmbed := li.aggregateUsage(loop, providers.UsageTotals{}, embedded)
+
+	if withEmbed.InputTokens != 10 {
+		t.Fatalf("embedding tokens must be in the token total: got %d, want 10", withEmbed.InputTokens)
+	}
+	if withEmbed.CostUSD != base.CostUSD {
+		t.Fatalf("embedding tokens must not be priced at the completion model's rate: cost moved "+
+			"from %v to %v. RunLore has no embeddings rate, and inventing one makes the reported "+
+			"figure look measured when it is a guess.", base.CostUSD, withEmbed.CostUSD)
+	}
+	if !withEmbed.Priced {
+		t.Fatal("Priced must still reflect that model.pricing is configured")
+	}
+}

--- a/internal/investigate/spend_failed_calls_test.go
+++ b/internal/investigate/spend_failed_calls_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// costOnlyOnDeadlineModel is a hung provider that reports what it had already been
+// billed for when the per-investigation deadline kills its request — the exact shape
+// every RunLore model client returns on failure (CompletionResponse.CostOnly()
+// alongside the error, see internal/model/clientcore.Stream). It exists because
+// blockingModel returns a ZERO response, which cannot tell "the tokens were charged
+// and then dropped" from "there were no tokens".
+type costOnlyOnDeadlineModel struct {
+	usage providers.Usage
+	calls int
+}
+
+func (m *costOnlyOnDeadlineModel) Complete(ctx context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	<-ctx.Done()
+	return providers.CompletionResponse{Usage: m.usage}, ctx.Err()
+}
+
+// TestFailedLoopStepIsChargedToTheInvestigation pins the accounting half of the
+// check-then-spend-then-account rule at the loop's own model call: a completion that
+// FAILED still billed for whatever the provider reported before it broke, and the
+// investigation must carry that spend.
+//
+// The clients make the figure available on purpose — every one of them returns
+// out.CostOnly() next to its error precisely "so a caller charging a spend budget"
+// can read it (providers.CompletionResponse.CostOnly). Dropping it makes the running
+// total under-report by a whole request, and the finding this run delivers reports a
+// cost it did not incur — downwards, which is the direction the repo has already
+// ruled out for the summarize digest (see summarizeElided).
+//
+// The deadline exit is the one that DELIVERS, so it is where the under-report is
+// observable: the plain-error exit returns an error and hands the queue a retry, but
+// the same accumulation covers both.
+func TestFailedLoopStepIsChargedToTheInvestigation(t *testing.T) {
+	model := &costOnlyOnDeadlineModel{usage: providers.Usage{InputTokens: 12_000, OutputTokens: 300}}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		Timeout:    30 * time.Millisecond,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "hung", Fingerprint: "fp-hung"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got.Usage.InputTokens != 12_000 || got.Usage.OutputTokens != 300 {
+		t.Fatalf("a failed completion's reported tokens must count toward the investigation: "+
+			"got %d input / %d output, want 12000 / 300. The provider billed them and said so "+
+			"(CompletionResponse.CostOnly on the error path); a total that skips them under-reports "+
+			"the run and lets a ceiling compare against a number that is too small.",
+			got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+	if got.Usage.ModelCalls != 1 {
+		t.Fatalf("a failed completion is still a model call; got ModelCalls=%d", got.Usage.ModelCalls)
+	}
+}
+
+// TestRefusedLoopStepIsChargedToTheInvestigation is a CHARACTERISATION pin, not a
+// fix: the refusal exit already accumulates, because addUsage sits above the
+// Refused() check. It is written down so the ordering that makes it true cannot be
+// undone by a later edit that moves accumulation back below the terminal branches —
+// the refusal path is the one where a provider reliably reports full usage for a turn
+// that produced no answer at all.
+func TestRefusedLoopStepIsChargedToTheInvestigation(t *testing.T) {
+	model := &mixedModel{steps: []mixedStep{{resp: providers.CompletionResponse{
+		StopReason: "refusal",
+		Usage:      providers.Usage{InputTokens: 9_000, OutputTokens: 5},
+	}}}}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "refused", Fingerprint: "fp-ref"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if got.Usage.InputTokens != 9_000 || got.Usage.OutputTokens != 5 {
+		t.Fatalf("a refused turn's tokens must count toward the investigation: got %d/%d, want 9000/5",
+			got.Usage.InputTokens, got.Usage.OutputTokens)
+	}
+}
+
+// TestFailedVerifyPassIsChargedToTheInvestigation is the same rule at the adversarial
+// verify call. Verify runs after the last budget check by design (documented), so
+// what is at stake here is the delivered figure rather than a ceiling: an
+// investigation that reports its own cost must not report a verify pass it paid for
+// as free.
+func TestFailedVerifyPassIsChargedToTheInvestigation(t *testing.T) {
+	model := &mixedModel{steps: []mixedStep{
+		// step 0: the loop concludes with a real finding, cheaply.
+		{resp: providers.CompletionResponse{
+			ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName,
+				Args: `{"confidence":0.8,"root_causes":[{"summary":"oom","confidence":0.8,"evidence":["OOMKilled"]}]}`}},
+			Usage: providers.Usage{InputTokens: 1_000, OutputTokens: 50},
+		}},
+		// step 1: the verify pass reports its prompt cost and then dies mid-stream.
+		{resp: providers.CompletionResponse{Usage: providers.Usage{InputTokens: 4_000, OutputTokens: 20}},
+			err: errors.New("read stream: unexpected EOF")},
+	}}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:      model,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		Verify:     true,
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), Request{Title: "verify-down", Fingerprint: "fp-vd"}); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if want := 5_000; got.Usage.InputTokens != want {
+		t.Fatalf("the failed verify pass's reported input tokens must be in the investigation's total: "+
+			"got %d, want %d (1000 loop + 4000 verify)", got.Usage.InputTokens, want)
+	}
+	if want := 70; got.Usage.OutputTokens != want {
+		t.Fatalf("the failed verify pass's reported output tokens must be in the total: got %d, want %d",
+			got.Usage.OutputTokens, want)
+	}
+}
+
+// costOnlyErrReranker reports its prompt cost and then fails — the mid-stream death
+// errReranker cannot express (it returns a zero response).
+type costOnlyErrReranker struct {
+	usage providers.Usage
+	calls int
+}
+
+func (m *costOnlyErrReranker) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	m.calls++
+	return providers.CompletionResponse{Usage: m.usage}, errors.New("reranker unavailable")
+}
+
+// TestFailedRerankIsChargedToTheInvestigation is the sharpest of the three, because
+// the reranker's failure does NOT end the run: a rank error falls through to a full
+// ReAct loop, which then spends its whole budget on top. Tokens dropped here are
+// therefore tokens the loop's own ceiling never sees — the running total is short by
+// the failed rank call for the entire rest of the investigation.
+func TestFailedRerankIsChargedToTheInvestigation(t *testing.T) {
+	rr := &costOnlyErrReranker{usage: providers.Usage{InputTokens: 2_000, OutputTokens: 30}}
+	loop := &mixedModel{steps: []mixedStep{{resp: providers.CompletionResponse{
+		ToolCalls: []providers.ToolCall{{ID: "1", Name: submitFindingsName,
+			Args: `{"confidence":0.8,"root_causes":[{"summary":"oom","confidence":0.8}]}`}},
+		Usage: providers.Usage{InputTokens: 1_000, OutputTokens: 10},
+	}}}}
+	var got providers.Investigation
+	li := &LoopInvestigator{
+		Model:      loop,
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:   5,
+		Recall:     rerankRecall(rr, []catalog.ScoredEntry{webHit("web.md", 0.6)}),
+		OnComplete: func(inv providers.Investigation) { got = inv },
+	}
+	if err := li.Investigate(context.Background(), okReq()); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if rr.calls != 1 {
+		t.Fatalf("the reranker must have been asked exactly once, got %d", rr.calls)
+	}
+	if want := 3_000; got.Usage.InputTokens != want {
+		t.Fatalf("the failed rerank call's input tokens must be in the investigation's total: got %d, want %d "+
+			"(2000 rerank + 1000 loop). A rank failure falls THROUGH to the full loop, so tokens dropped "+
+			"here stay missing from the running total for the whole rest of the run.",
+			got.Usage.InputTokens, want)
+	}
+	if want := 40; got.Usage.OutputTokens != want {
+		t.Fatalf("the failed rerank call's output tokens must be in the total: got %d, want %d",
+			got.Usage.OutputTokens, want)
+	}
+}

--- a/internal/investigate/spend_rerank_gate_test.go
+++ b/internal/investigate/spend_rerank_gate_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package investigate
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/outcome"
+	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/telemetry"
+)
+
+// rerankGateInvestigator builds a loop whose recall fire gate is the reranker, under a
+// given cumulative token ceiling. The loop model is a runaway (never concludes), so
+// whatever the reranker does, the run ends on the spend ladder rather than by luck.
+func rerankGateInvestigator(rr providers.ModelProvider, ceiling int, hyb catalog.HybridSearcher) (*LoopInvestigator, *reportingRunawayModel) {
+	model := &reportingRunawayModel{inputTokens: 7_000}
+	rec := rerankRecall(rr, []catalog.ScoredEntry{webHit("web.md", 0.6)})
+	if hyb != nil {
+		rec.Hybrid = hyb
+		rec.HybridMinScore, rec.HybridMarginGap = 0.1, 0.1
+	}
+	return &LoopInvestigator{
+		Model:                     model,
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: ceiling,
+		Recall:                    rec,
+		OnComplete:                func(providers.Investigation) {},
+	}, model
+}
+
+// TestRerankerIsNotCalledOnceTheCeilingIsCrossed is the ordering fix: the reranker is
+// a paid completion placed in FRONT of the "free" short-circuit, and the ceiling was
+// consulted only after it had already been spent — its usage was accumulated on the
+// way back out of rank. So an investigation whose budget could not fund the call made
+// it anyway, every time.
+//
+// A ceiling of 100 tokens cannot fund a ~1k rerank request under any reading, so the
+// call must not happen. The run still proceeds exactly as a no-match does — fall
+// through to a full investigation — where the EXISTING ladder stops it. That is the
+// point: this guard declines to spend, it does not invent a second way to stop a run.
+func TestRerankerIsNotCalledOnceTheCeilingIsCrossed(t *testing.T) {
+	fake := &countingReranker{resp: rerankResp(`{"match":true,"entry_id":"web.md","confidence":0.9}`)}
+	li, _ := rerankGateInvestigator(fake, 100, nil)
+	if err := li.Investigate(context.Background(), okReq()); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if fake.calls != 0 {
+		t.Fatalf("the reranker was called %d times against a 100-token ceiling it cannot fit in. "+
+			"The check has to run BEFORE the completion — accumulating its usage afterwards means "+
+			"the ceiling is consulted for the first time with the money already gone.", fake.calls)
+	}
+}
+
+// TestRerankerRunsNormallyUnderAnAffordableCeiling is the control that keeps the guard
+// from being "always refuse". A guard that never lets the reranker run would pass the
+// test above and silently disable instant recall for every deployment.
+func TestRerankerRunsNormallyUnderAnAffordableCeiling(t *testing.T) {
+	fake := &countingReranker{resp: rerankResp(`{"match":true,"entry_id":"web.md","confidence":0.9}`)}
+	r := rerankRecall(fake, []catalog.ScoredEntry{webHit("web.md", 0.6)})
+	li := &LoopInvestigator{
+		Model:                     &reportingRunawayModel{inputTokens: 7_000},
+		Log:                       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		MaxSteps:                  10,
+		MaxTokensPerInvestigation: 400_000, // the shipped default
+		Recall:                    r,
+		OnComplete:                func(providers.Investigation) {},
+	}
+	if err := li.Investigate(context.Background(), okReq()); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if fake.calls != 1 {
+		t.Fatalf("under the shipped 400000-token ceiling the reranker must run exactly once, got %d — "+
+			"the pre-call guard must not be refusing ordinary traffic", fake.calls)
+	}
+}
+
+// TestRerankerCeilingIsUncheckedWhenUnlimited pins that an operator who opted out with
+// -1 (or a caller with no ceiling at all, e.g. the CLI's plain lookup) is not handed a
+// bound they never asked for.
+func TestRerankerCeilingIsUncheckedWhenUnlimited(t *testing.T) {
+	fake := &countingReranker{resp: rerankResp(`{"match":true,"entry_id":"web.md","confidence":0.9}`)}
+	r := rerankRecall(fake, []catalog.ScoredEntry{webHit("web.md", 0.6)})
+	if e, _ := r.lookup(context.Background(), okReq()); e == nil {
+		t.Fatal("a bare lookup carries no spend channel and must behave exactly as before")
+	}
+	if fake.calls != 1 {
+		t.Fatalf("lookup without a spend channel must still rank, got %d calls", fake.calls)
+	}
+}
+
+// TestQueryEmbedSpendCanRefuseTheReranker is where the first and third gaps meet, and
+// the reason the ordering fix is load-bearing rather than theoretical.
+//
+// The reranker is normally the FIRST paid call of an investigation, so before the
+// query embeddings were folded into the totals there was nothing for a pre-call check
+// to compare against — spend was always zero. Now the hybrid query embed happens
+// inside the same lookup, BEFORE rank, and its tokens are in the running total. So a
+// run whose retrieval has already exhausted the budget declines the rerank instead of
+// spending past a ceiling it has demonstrably crossed.
+func TestQueryEmbedSpendCanRefuseTheReranker(t *testing.T) {
+	const (
+		perQuery = 25_000
+		ceiling  = 20_000 // retrieval alone has already overshot the whole run budget
+	)
+	hyb := newEmbeddingHybrid(t, perQuery, []catalog.ScoredEntry{webHit("web.md", 0.6)})
+	fake := &countingReranker{resp: rerankResp(`{"match":true,"entry_id":"web.md","confidence":0.9}`)}
+	li, _ := rerankGateInvestigator(fake, ceiling, hyb)
+	if err := li.Investigate(context.Background(), okReq()); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+	if n := hyb.calls.Load(); n == 0 {
+		t.Fatal("the hybrid query never ran — the test no longer exercises the path it claims to")
+	}
+	if fake.calls != 0 {
+		t.Fatalf("the reranker was called %d times after the query embed had already spent %d of a "+
+			"%d-token ceiling. The embed is charged inside the same lookup, before rank, so the "+
+			"pre-call check has real spend to compare against.", fake.calls, perQuery, ceiling)
+	}
+}
+
+// usageRerankModel is scriptedRerankModel that also REPORTS usage, so a first rank
+// call can move the running total far enough to price the second one out.
+type usageRerankModel struct {
+	calls    int
+	verdicts []string
+	usage    providers.Usage
+}
+
+func (m *usageRerankModel) Complete(_ context.Context, _ providers.CompletionRequest) (providers.CompletionResponse, error) {
+	i := m.calls
+	m.calls++
+	if i >= len(m.verdicts) {
+		return providers.CompletionResponse{Usage: m.usage}, nil
+	}
+	return providers.CompletionResponse{
+		ToolCalls: []providers.ToolCall{{Name: rerankToolName, Args: m.verdicts[i]}},
+		Usage:     m.usage,
+	}, nil
+}
+
+// TestOutcomeFallbackRerankIsAlsoGatedOnSpend covers the SECOND rank call.
+//
+// outcomeFallback exists because a decayed winner must not disable instant recall
+// while a healthy corrected entry sits behind it — and it pays for another completion
+// to find that entry. It is the one rank call with real prior spend to be measured
+// against (the first call's tokens are already in the total by then), so leaving it
+// ungated would mean the guard covers only the case where there was nothing to check.
+//
+// Ceiling 15 000; the first rank is affordable against an empty total and reports
+// exactly 15 000 tokens, so the second is refused whatever its estimate turns out to
+// be — no dependence on the prompt's current length.
+func TestOutcomeFallbackRerankIsAlsoGatedOnSpend(t *testing.T) {
+	cat, stalePath, fixedPath := twoEntryCatalog(t)
+	model := &usageRerankModel{
+		verdicts: []string{
+			`{"match":true,"entry_id":"` + stalePath + `","confidence":0.9}`,
+			`{"match":true,"entry_id":"` + fixedPath + `","confidence":0.85}`,
+		},
+		usage: providers.Usage{InputTokens: 14_990, OutputTokens: 10},
+	}
+	r := &Recall{
+		Catalog: cat,
+		Rerank:  &Reranker{Model: model, Threshold: 0.7, K: 5, MinScore: 0.001},
+		Outcome: fakeOutcome{counts: map[string]outcome.Aggregate{
+			stalePath: {Recalls: 4, Resolved: 0}, // decayed ⇒ the fallback runs
+			fixedPath: {Recalls: 3, Resolved: 3}, // healthy ⇒ it WOULD fire, if affordable
+		}},
+		OutcomePrior: 2.0, OutcomeFloor: 0.5,
+	}
+
+	li := &LoopInvestigator{MaxTokensPerInvestigation: 15_000}
+	var verifyTotals providers.UsageTotals
+	spend := &recallSpend{
+		totals: &verifyTotals,
+		afford: func(est int) string {
+			return li.budgetTrip(est, li.aggregateUsage(providers.UsageTotals{}, verifyTotals, providers.UsageTotals{}))
+		},
+	}
+	e, _, _ := r.lookupWithUsage(context.Background(), fallbackReq(), spend)
+
+	if model.calls != 1 {
+		t.Fatalf("the fallback rank call must be refused once the first has spent the whole "+
+			"ceiling: the reranker was called %d times, want 1", model.calls)
+	}
+	if e != nil {
+		t.Fatalf("a fallback that cannot be paid for must fall through, not fire: got %q", e.Path)
+	}
+	if verifyTotals.InputTokens != 14_990 {
+		t.Fatalf("the first rank call's tokens must be in the total the second is measured "+
+			"against: got %d, want 14990", verifyTotals.InputTokens)
+	}
+}
+
+// TestRerankOverBudgetIsVisibleAsARecallRejection pins the instrumentation choice.
+//
+// A declined rerank is recorded on recall_rejections_total, beside the reranker's
+// existing rerank_no_signal / rerank_low_confidence reasons — NOT as a budget trip.
+// The run is not stopped here: it falls through to the loop, whose first enforceBudget
+// step fires the real ladder with the reason that names the knob to raise. Counting a
+// rung here as well would report one stop twice on
+// runlore_investigation_budget_trips_total and inflate the nudge rate.
+func TestRerankOverBudgetIsVisibleAsARecallRejection(t *testing.T) {
+	t.Cleanup(func() { otel.SetMeterProvider(noop.NewMeterProvider()) })
+	h, shutdown, err := telemetry.Setup(context.Background())
+	if err != nil {
+		t.Fatalf("telemetry setup: %v", err)
+	}
+	t.Cleanup(func() { _ = shutdown(context.Background()) })
+
+	fake := &countingReranker{resp: rerankResp(`{"match":true,"entry_id":"web.md","confidence":0.9}`)}
+	li, _ := rerankGateInvestigator(fake, 100, nil)
+	li.Metrics = telemetry.NewMetrics()
+	li.Recall.Metrics = li.Metrics
+	if err := li.Investigate(context.Background(), okReq()); err != nil {
+		t.Fatalf("Investigate: %v", err)
+	}
+
+	body := scrapeMetrics(t, h)
+	if !strings.Contains(body, `reason="rerank_over_budget"`) {
+		t.Fatalf("a rerank declined on spend must be visible on recall_rejections_total, so an "+
+			"operator can tell it apart from a reranker that ran and found nothing:\n%s", body)
+	}
+	// The ladder still owns stopping the run, and must report exactly one nudge rung.
+	if strings.Contains(body, `stage="declined"`) {
+		t.Fatalf("the pre-call guard must not invent a third rung on the budget ladder:\n%s", body)
+	}
+	if !strings.Contains(body, `runlore_investigation_budget_trips_total`) {
+		t.Fatalf("declining the rerank must not stop the run: the loop's own ladder is what ends "+
+			"it, and it has to be the thing that records the trip:\n%s", body)
+	}
+}

--- a/internal/investigate/verify.go
+++ b/internal/investigate/verify.go
@@ -121,13 +121,17 @@ func (li *LoopInvestigator) verifyFindings(ctx context.Context, req Request, inv
 		// honesty check (no verdicts ⇒ findings pass through unreviewed).
 		ToolChoice: submitVerdictsName,
 	})
+	// Count the verify completion toward the per-investigation token/cost total —
+	// BEFORE the failure branch, not after it. A reviewer that reported its prompt
+	// cost and then died mid-stream billed for those tokens all the same (the client
+	// hands them back on the error path, see CompletionResponse.CostOnly), and a
+	// finding that reports its own cost must not report a pass it paid for as free.
+	if totals != nil {
+		addUsage(totals, resp.Usage)
+	}
 	if err != nil {
 		li.Log.Warn("verify pass failed; keeping findings as-is", "title", req.Title, "err", err)
 		return inv, false
-	}
-	// Count the verify completion toward the per-investigation token/cost total.
-	if totals != nil {
-		addUsage(totals, resp.Usage)
 	}
 	var verds []verdict
 	for _, tc := range resp.ToolCalls {

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -317,7 +317,13 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   rejection, which is decided *after* the ranking. A candidate that fails retrieval or the structural
   filter never reaches the reranker at all; past that point the last guard is `rerank_min_score`, and
   its default **0.1** sits at the *bottom* of the ~0.1–1.2 band real enriched BM25 scores occupy, so
-  it skips the call only when retrieval surfaced essentially nothing.
+  it skips the call only when retrieval surfaced essentially nothing. A second guard sits beside it:
+  the **spend ceiling is consulted before the ranking call, not after it**, so an investigation that
+  has already crossed `max_tokens_per_investigation` (or `max_cost_per_investigation`) declines to
+  rank rather than spending past a limit it has demonstrably hit. That is a fall-through like any
+  other — the run continues into a full investigation, where the ordinary nudge→kill ladder stops it
+  — and it is counted as `runlore_recall_rejections_total{reason="rerank_over_budget"}`, not as a
+  third rung on that ladder.
   In practice, then, enabling instant recall adds **one model call to the floor
   cost of nearly every investigation that has a structurally-agreeing candidate**, and buys back a
   full investigation on the subset that fires. A fired recall is consequently **two** model calls —

--- a/website/content/docs/configuration/configuration.md
+++ b/website/content/docs/configuration/configuration.md
@@ -167,7 +167,8 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   by `runlore_investigation_budget_trips_total{reason,stage}`.
 - `max_tokens_per_investigation` (**default 400000**; `-1` = unlimited) — a **cumulative** ceiling on
   one investigation's model tokens (provider-reported input + output, loop **and** verify, including
-  a recall short-circuit's reranker/verify calls).
+  a recall short-circuit's reranker/verify calls, the hybrid-recall **query embeddings**, and any call
+  that **failed** after the provider had already billed for it).
 
   **One number, two thresholds.** A quarter of it — **100 000** at the default — additionally bounds
   the estimated size of any **single request**, so one oversized request is caught before it is
@@ -237,9 +238,10 @@ incident webhook. Known keys: `alertmanager`, `gitops`, `pagerduty`, `custom`.
   | Outside the ceilings | Why, and what does bound it |
   |---|---|
   | Anything above one investigation | There is no daily, monthly or global budget. Total exposure is `investigation.rate_limit.max_per_window` (default 30 starts/hour) × the per-investigation ceiling — a product of two knobs, not a budget |
-  | The `/embeddings` endpoint | On the hybrid-recall path (`catalog.instant_recall.hybrid` + `model.embeddings`) it is called once per recall query — **inside** an investigation — and in bulk on every catalog reload. Its tokens are not in the investigation's totals and it is not gated by either ceiling. It IS visible: `runlore_model_requests_total{provider="embed"}` and `runlore_model_input_tokens_total{provider="embed"}` |
+  | The **bulk corpus embed** on catalog reload | It runs on the catalog-sync goroutine with no investigation to charge, so no investigation-scoped ceiling can reach it, and RunLore ships none of its own. What bounds it is the corpus, which is your input, not the model's: embeddings are content-hash cached and the cache is persisted across restarts (`instant_recall.vector_cache`), so steady-state cost tracks *changed* entries rather than corpus size, and there is no feedback loop to run away. A ceiling here could only fail all-or-nothing — partial vector sets are refused by design — so its one effect would be silently dropping to BM25 recall, which `catalog_embed_degraded_total` already reports. Visible as `runlore_model_requests_total{provider="embed"}` |
+  | The **dollar** cost of embeddings | The hybrid-recall query embed's *tokens* now count against `max_tokens_per_investigation`, but there is no `model.embeddings.pricing`, so RunLore has no rate to price them with and refuses to borrow a completion model's — that would put a fabricated figure on the notification footer and in `runlore_investigation_cost_usd`. `max_cost_per_investigation` therefore errs **low** by the embedding spend rather than quoting a number it cannot stand behind |
   | The adversarial verify pass's own cost | It runs after the last budget check, unconditionally, because verify is the honesty guarantee. A successful run can therefore deliver a `CostUSD` slightly above `max_cost_per_investigation` with no trip recorded |
-  | `lore eval` | Builds its investigators with no ceilings and no pricing at all. Bounded only by the step budget |
+  | A `lore eval` **campaign** as a whole | Each investigation it replays runs under the operator's configured `investigation.*` ceilings and `model.pricing` — the same limits production has — but a campaign is cases × n of them, so those ceilings multiply by the corpus size instead of capping the run. `--max-total-tokens` is the run-level ceiling; **unset, a campaign has none** |
   | CLI-only model calls | `lore validate --semantic`, `lore kb import --model`, and the eval judge each make completions outside any investigation. None runs under `serve` |
   | Non-model spend | Cloud API calls, git clones, metrics and logs queries are unpriced everywhere |
 - `compaction` — how mid-loop history compaction treats the older tool outputs it elides once the


### PR DESCRIPTION
Three gaps the spend-ceiling PRs (#486, #487) listed as known-not-fixed. Closing them turned up two more of the same shape that nobody had listed.

## What was actually wrong

**A failed completion's tokens were discarded.** `addUsage(&loopTotals, resp.Usage)` sat *below* the `err != nil` branches — but the tokens are real and knowable, since every client returns `CompletionResponse.CostOnly()` next to its error, documented as being *for* "a caller charging a spend budget".

**Half of that claim was wrong, and I pinned the correct half rather than "fixing" it.** The *refusal* path was already right — `addUsage` sat above the `Refused()` check. It now has a characterisation test so nobody re-breaks it while tidying.

**The same defect existed in `verify.go` and `rerank.go`, unclaimed** — and the rerank one is the only one that actually breaches a ceiling. A rank error *falls through* to a full loop, so its dropped tokens stay missing from the running total for the rest of the run. The loop's own two error exits both terminate, so there the damage is under-reporting rather than overrun. `summarize.go` already did this correctly and explains why; that reasoning was extended rather than reinvented.

**The reranker accounted after it spent** — confirmed exactly as reported, and the *second* rank call in `outcomeFallback` had the same hole.

**Query embeddings were outside both ceilings.** Confirmed at both call sites. (`kb_search` is BM25-only, so the query embed is ≤2 per investigation — recall lookup plus near-miss — not per tool call.)

## Design decisions

**Query embed goes inside the investigation; the bulk catalog reload stays deliberately unbounded.** The query embed has a payer, so it belongs in that run's total. The reload has none, and a ceiling there would bound nothing worth bounding: it is content-hash cached against a persisted cache, so steady-state cost tracks *changed* entries and there is no feedback loop to run away. It can only fail all-or-nothing — partial vector sets are refused by design — so a ceiling's sole effect would be a silent BM25 downgrade that `catalog_embed_degraded_total` already reports. Documented as unbounded rather than left looking accidental.

**Counted, not priced.** Tokens are provider-reported, so they go under the token ceiling. There is no `model.embeddings.pricing`, and borrowing a completion rate would put a fabricated figure on the notification footer — the exact *"looks instrumented for spend when it is not"* failure this repo already rejects config for. `max_cost_per_investigation` errs low and says so; `ModelCalls` stays a completion count.

**No new `reason` or `stage` values.** A reason names the knob to raise, not the call site, and both embed- and failed-call-driven overruns are answered by `max_tokens_per_investigation` — so both report `tokens_total`. The rerank guard *declines to spend* and falls through, and the existing ladder stops the run one step later, so recording a rung there would double-count one stop. It surfaces as `recall_rejections_total{reason="rerank_over_budget"}` instead.

**`recallSpend` bundles check-and-account into one value**, replacing a bare totals pointer. Splitting those two is how this bug happened.

## Two docs claims falsified

The `/embeddings` row said embeds are "not in the investigation's totals … not gated by either ceiling". And — pre-existing and unrelated — the `lore eval` row still claimed eval builds investigators "with no ceilings and no pricing at all", long after `app.evalSpend` began forwarding the configured ones. Both fixed.

## On the race

Mid-task I reported a `-race` failure as being in my own test helper. That was the convenient answer, so it was checked rather than assumed: reinstating the racy `served++` reproduced it with **every frame in both stacks inside `net/http`** and none in `usage.go`; stripping the sink's mutex produced a structurally different report naming `usage.go` directly. The two are distinct, and the sink then ran clean across 25 `-race` iterations. I re-ran it five more times independently — clean.

## Testing

Ten mutations, each verified as applied. **One survived the whole suite** — removing the `outcomeFallback` rerank guard — which produced `TestOutcomeFallbackRerankIsAlsoGatedOnSpend` rather than a clean report. Verified independently: neutering `recallSpend.refuses` fires three tests including that one.

Gate: `go build`, `go vet`, `go test ./... -race`, `gofmt -l .` silent, `golangci-lint` `0 issues`.

## Scope limit, stated rather than implied

The near-miss lookup performs a second query embed that is now **charged but not gated**. Left ungated on YAGNI grounds — it makes no completion, runs once, and the ladder fires on the next step — but said so explicitly on `recallSpend` rather than letting the guarantee read as total.
