### PR TITLE
fix: five correctness findings from the review programme

### DIFF
--- a/internal/app/curator.go
+++ b/internal/app/curator.go
@@ -83,14 +83,13 @@ func BuildCurator(cfg *config.Config, cat *catalog.Catalog, metrics *telemetry.M
 	if client == nil {
 		return nil
 	}
-	dup := cfg.Forge.DupScore
-	if dup == 0 {
-		dup = 5.0
-	}
-	minConf := cfg.Forge.MinConfidence
-	if minConf == 0 {
-		minConf = 0.75
-	}
+	// dup_score / min_confidence are resolved by config.ApplyDefaults (5.0 / 0.75),
+	// not coalesced here. They used to be defaulted in this function, which made the
+	// effective threshold visible on this construction path and nowhere else — the
+	// same numbers were 0 to `lore config show` and to every guard reading the
+	// config. Read them straight, so what the curator runs under is what the
+	// resolved config says.
+	dup, minConf := cfg.Forge.DupScore, cfg.Forge.MinConfidence
 	// Verdicts the operator has configured to stay out of the KB review queue (e.g.
 	// no_action). nil when unset ⇒ every verdict is eligible to draft a PR. Validated
 	// against the verdict enum in Config.Validate, so entries here are already known.

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -108,16 +108,13 @@ func BuildModelAndTools(ctx context.Context, cfg *config.Config, gp providers.Gi
 			}
 			// Hybrid (cosine-gated) recall — opt-in, and only effective once the catalog
 			// actually built vectors (an embedder was configured + embedding succeeded).
+			// The cosine gates are resolved by config.ApplyDefaults (0.80 / 0.05) rather
+			// than coalesced here, so the effective thresholds are readable from the
+			// config instead of existing only on this construction path.
 			if cfg.Catalog.InstantRecall.Hybrid {
 				recall.Hybrid = cat
 				recall.HybridMinScore = cfg.Catalog.InstantRecall.HybridMinScore
 				recall.HybridMarginGap = cfg.Catalog.InstantRecall.HybridMarginGap
-				if recall.HybridMinScore == 0 {
-					recall.HybridMinScore = 0.80
-				}
-				if recall.HybridMarginGap == 0 {
-					recall.HybridMarginGap = 0.05
-				}
 				log.Info("hybrid recall enabled (EXPERIMENTAL — tune cosine thresholds via the instant-recall eval)",
 					"hybrid_min_score", recall.HybridMinScore, "hybrid_margin_gap", recall.HybridMarginGap,
 					"vectors_ready", cat.HasVectors())

--- a/internal/app/serve_guard_test.go
+++ b/internal/app/serve_guard_test.go
@@ -167,106 +167,20 @@ func TestRecallDecayWarningIsEmittedOnceAtStartup(t *testing.T) {
 	}
 }
 
-// TestEveryStartupWarningIsRaised generalises the pin above to the whole convention:
-// a `*Warning` function in this package returns a message that MUST reach a logger on
-// the startup path, or the config problem it describes is neither enforced nor
-// signalled — the worst of both worlds, and precisely the failure mode several of
-// these warnings exist to prevent.
+// TestEveryStartupWarningIsRaised, which generalised the pin above to every
+// *Warning in package app, has been folded into
+// TestEveryStartupWarningIsRaisedExactlyOnce (warnings_wired_test.go). That
+// guard keeps this one's whole contract — exactly one non-test call site, result
+// bound to a real variable, that variable passed to a .Warn(...) in the SAME
+// statement — and adds the reach the older warnings_wired guard had and this one
+// did not: internal/ and cmd/ rather than package app alone, and qualified calls
+// (config.ChatWithoutCaptureWarning) rather than bare identifiers alone.
 //
-// The set is DISCOVERED, not listed: every exported top-level func in package app
-// whose name ends in "Warning" and returns a string is covered the day it is written.
-// A hand-maintained list would rot in exactly the direction this guard exists to
-// catch — a new warning added, never listed, never raised, and nothing failing.
-//
-// The contract per warning is the same one assertWarningIsRaised checks: exactly one
-// non-test call site, its result bound to a real variable (not `_`), and that variable
-// passed to a `.Warn(...)` in the same statement. It deliberately does NOT require the
-// caller to be RunServe — WebhookAuthWarning and RecallDecayWarning both live there
-// today, but a future warning belonging on `lore curate`'s startup is legitimate. The
-// stricter "once, at startup, outside any closure" pin stays specific to
-// RecallDecayWarning above, whose paragraph would be intolerable per alert.
-func TestEveryStartupWarningIsRaised(t *testing.T) {
-	files, err := filepath.Glob(filepath.Join(".", "*.go"))
-	if err != nil {
-		t.Fatalf("glob: %v", err)
-	}
-	fset := token.NewFileSet()
-	type site struct {
-		file string
-		stmt ast.Stmt
-	}
-	declared := map[string]bool{}
-	calls := map[string][]site{}
-
-	for _, path := range files {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
-		}
-		src, err := os.ReadFile(path) //nolint:gosec // test-owned path in this package
-		if err != nil {
-			t.Fatalf("read %s: %v", path, err)
-		}
-		f, err := parser.ParseFile(fset, path, src, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", path, err)
-		}
-		for _, decl := range f.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
-			}
-			if fn.Recv == nil && isWarningFunc(fn) {
-				declared[fn.Name.Name] = true
-			}
-			var stack []ast.Node
-			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				if n == nil {
-					stack = stack[:len(stack)-1]
-					return false
-				}
-				stack = append(stack, n)
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				id, ok := call.Fun.(*ast.Ident)
-				if !ok || !strings.HasSuffix(id.Name, "Warning") || id.Name == fn.Name.Name {
-					return true
-				}
-				calls[id.Name] = append(calls[id.Name], site{filepath.Base(path), outermostStmt(stack)})
-				return true
-			})
-		}
-	}
-
-	if len(declared) == 0 {
-		t.Fatal("no *Warning functions found in package app — this guard is inert")
-	}
-	for name := range declared {
-		sites := calls[name]
-		if len(sites) != 1 {
-			t.Errorf("%s has %d non-test call sites, want exactly 1 — a warning nobody raises "+
-				"leaves the condition it describes neither enforced nor signalled, and two raisers "+
-				"print it twice", name, len(sites))
-			continue
-		}
-		assertWarningIsRaised(t, sites[0].file, sites[0].stmt, name, "Warn")
-	}
-}
-
-// isWarningFunc reports whether fn is one of the package's startup-warning
-// functions: named *Warning and returning a message string.
-func isWarningFunc(fn *ast.FuncDecl) bool {
-	if !strings.HasSuffix(fn.Name.Name, "Warning") {
-		return false
-	}
-	res := fn.Type.Results
-	if res == nil || len(res.List) != 1 {
-		return false
-	}
-	id, ok := res.List[0].Type.(*ast.Ident)
-	return ok && id.Name == "string"
-}
+// assertWarningIsRaised and outermostStmt below stay here, shared: the
+// RecallDecayWarning pin above still needs them for its stricter
+// "once, at startup, outside any closure" property, which is specific to a
+// warning whose paragraph would be intolerable per alert and does not
+// generalise.
 
 // outermostStmt returns the top-level statement of the enclosing function body that
 // contains the visited node — stack[0] is the *ast.BlockStmt body itself, so the next
@@ -286,6 +200,11 @@ func outermostStmt(stack []ast.Node) ast.Stmt {
 // i.e. the warning is emitted, not computed and dropped. Go rejects an unused local,
 // so `_ = f()` and a bare `f()` are the only ways to discard the result, and both are
 // caught here.
+//
+// The call is matched through warningCallName, so BOTH spellings count: a
+// same-package identifier (WebhookAuthWarning) and a qualified selector
+// (config.ChatWithoutCaptureWarning). Matching only the first is what let the
+// package-app guard this replaced miss every cross-package warning.
 func assertWarningIsRaised(t *testing.T, file string, stmt ast.Stmt, guarded, raiser string) {
 	t.Helper()
 	if stmt == nil {
@@ -299,11 +218,7 @@ func assertWarningIsRaised(t *testing.T, file string, stmt ast.Stmt, guarded, ra
 			return true
 		}
 		for i, rhs := range as.Rhs {
-			call, isCall := rhs.(*ast.CallExpr)
-			if !isCall {
-				continue
-			}
-			if id, isIdent := call.Fun.(*ast.Ident); !isIdent || id.Name != guarded {
+			if warningCallName(rhs) != guarded {
 				continue
 			}
 			if i < len(as.Lhs) {

--- a/internal/app/warnings_wired_test.go
+++ b/internal/app/warnings_wired_test.go
@@ -26,55 +26,135 @@ const warningSuffix = "Warning"
 // under test).
 var scanRoots = []string{"../../internal", "../../cmd"}
 
-// TestEveryStartupWarningIsEmitted closes a CLASS of bug this repo has now hit
-// twice: a guard with complete unit coverage and zero production callers.
+// warningRaiser is the logger method a warning's message must reach. Narrow on
+// purpose: every shipped warning uses log.Warn, and a set that also accepted
+// Info or Error would wave through a guard demoted to a level operators filter
+// out. Widen it deliberately, with the reason, if a warning ever belongs
+// elsewhere.
+const warningRaiser = "Warn"
+
+// minScannedFiles is the floor on how many non-test .go files the walk must
+// actually parse, and it exists because "found no problems" and "stopped
+// looking" are the same green.
 //
-// ThreadCaptureDeliverable was written, tested, and left unreachable — its
+// A guard whose roots shrink — to package app, to one directory, to a path that
+// no longer exists — still discovers the warnings that remain in view, still
+// finds them correctly wired, and still passes, while every warning outside the
+// new roots goes unchecked. That is not hypothetical: scanning package app alone
+// is exactly what the serve_guard half of this did, and it is why
+// ChatWithoutCaptureWarning (declared in internal/config) could sit uncalled
+// under a green suite.
+//
+// 150 against ~221 files today: comfortably above package app on its own (26),
+// with room for the tree to shrink without a false alarm.
+const minScannedFiles = 150
+
+// warningSite is one non-test call of a *Warning function: the file it sits in,
+// and the top-level statement of the enclosing function body that contains it.
+// The STATEMENT, not the function, is the scope the raise is judged in — see
+// TestEveryStartupWarningIsRaisedExactlyOnce.
+type warningSite struct {
+	file string
+	stmt ast.Stmt
+}
+
+// TestEveryStartupWarningIsRaisedExactlyOnce closes a CLASS of bug this repo has
+// now hit several times: a guard with complete unit coverage and zero — or
+// merely decorative — production wiring.
+//
+// ThreadCaptureDeliverable was written, tested, and left unreachable: its
 // warning could never fire because the wiring checked a replier first, which
 // implied the condition the guard diagnoses had already passed.
-// ChatWithoutCaptureWarning was written, tested, and simply never called: it
-// catches an operator who configured a paid model for a feature no transport
-// can trigger, and it sat green and silent instead. Neither failed a test,
-// because a function nobody calls is not a function anyone can observe.
+// ChatWithoutCaptureWarning was written, tested, and simply never called — it
+// catches an operator who configured a paid model for a feature no transport can
+// trigger, and it sat green and silent instead. `_ = RecallDecayWarning(cfg)`,
+// computed and thrown away, is the state an interrupted edit actually left on a
+// branch. None of them failed a test, because a function nobody calls — or whose
+// result nobody logs — is not a function anyone can observe.
 //
-// So this asserts the property directly rather than one instance of it: every
-// *Warning function must have at least one non-test caller. The list is
-// DERIVED from the naming convention, not hand-maintained, so a warning added
-// tomorrow is covered the day it is written and cannot be forgotten out of an
-// exemption list — the same reason notifier_imports_test.go reads the directory
-// instead of comparing two hand-written lists.
+// So this asserts the property directly rather than one instance of it. Per
+// *Warning function, all four parts:
+//
+//  1. the set is DISCOVERED from the naming convention rather than hand-listed,
+//     so a warning added tomorrow is covered the day it is written and cannot be
+//     forgotten out of an exemption list — the same reason
+//     notifier_imports_test.go reads the directory instead of comparing two
+//     hand-written lists;
+//  2. across internal/ AND cmd/, in both call spellings — a bare identifier for
+//     a same-package call (WebhookAuthWarning in serve.go) and a selector for a
+//     cross-package one (config.ChatWithoutCaptureWarning) — since a scanner
+//     handling only one shape waves the other through;
+//  3. EXACTLY ONE non-test call site: zero leaves the condition neither enforced
+//     nor signalled, two prints the same paragraph at operators twice;
+//  4. at that site the result is bound to a real variable (not `_`) and that
+//     variable reaches a `.Warn(...)` IN THE SAME STATEMENT. Same statement, not
+//     merely the same function: `if msg := X(); msg != "" { log.Warn(msg) }` is
+//     the shape all five shipped sites use, and anything looser lets a binding
+//     be "raised" by an unrelated log call elsewhere in the function.
+//
+// This is one guard where there were two, written on branches that could not see
+// each other. The older warnings_wired guard scanned internal/+cmd/ and both call
+// spellings, but asked only that the message reach a logger somewhere in the same
+// function; serve_guard's TestEveryStartupWarningIsRaised required exactly one
+// call site and a same-statement raise, but looked only at package app and only
+// at unqualified calls. Each waved through what the other caught. This takes the
+// stronger half of every axis, and TestEveryStartupWarningGuardDetectsItsOwnInertness
+// proves it still holds each one rather than having quietly averaged the two.
 //
 // A deliberately unwired warning has no exemption here and is not meant to: the
-// way to satisfy this test is to call the function, and if there is nowhere to
-// call it from, the guard is not ready to be merged.
-func TestEveryStartupWarningIsEmitted(t *testing.T) {
-	declared, called := scanWarnings(t)
+// way to satisfy this test is to raise the function, and if there is nowhere to
+// raise it from, the guard is not ready to be merged.
+//
+// KNOWN, ACCEPTED FALSE POSITIVE (inherited, deliberately): splitting the bind
+// and the Warn across two statements fails here even though it is
+// behaviour-preserving. That is the trade — a pin that costs an occasional
+// refactor an explicit update is worth far more than one that green-lights a
+// silent regression.
+func TestEveryStartupWarningIsRaisedExactlyOnce(t *testing.T) {
+	declared, sites, scanned := scanWarnings(t)
 
+	if scanned < minScannedFiles {
+		t.Fatalf("the walk parsed only %d non-test .go files under %v, want at least %d — the scanner has "+
+			"stopped seeing most of the tree, so every warning outside what it still reaches is unchecked "+
+			"while this suite stays green", scanned, scanRoots, minScannedFiles)
+	}
 	if len(declared) == 0 {
 		t.Fatal("no *Warning function found under internal/ or cmd/ — the naming convention changed " +
 			"and this guard is inert, which is the exact failure it exists to catch")
 	}
 	for name, where := range declared {
-		if !called[name] {
+		switch got := sites[name]; len(got) {
+		case 1:
+			assertWarningIsRaised(t, got[0].file, got[0].stmt, name, warningRaiser)
+		case 0:
 			t.Errorf("%s is declared at %s but no non-test file calls it: its warning can never reach an "+
-				"operator's logs, so it is green and inert. Emit it on the startup path that owns the "+
+				"operator's logs, so it is green and inert. Raise it on the startup path that owns the "+
 				"feature it diagnoses (see WebhookAuthWarning in serve.go, ChatWithoutCaptureWarning in "+
 				"buildThreadChat), or delete it.", name, where)
+		default:
+			at := make([]string, 0, len(got))
+			for _, s := range got {
+				at = append(at, s.file)
+			}
+			t.Errorf("%s (declared at %s) has %d non-test call sites (%s), want exactly 1 — a warning "+
+				"nobody raises leaves the condition it describes neither enforced nor signalled, and two "+
+				"raisers print it twice", name, where, len(got), strings.Join(at, ", "))
 		}
 	}
 }
 
-// TestEveryStartupWarningIsEmittedDetectsAnUnwiredGuard is the guard's own
-// mutation test: a scanner that silently matched nothing would pass
-// TestEveryStartupWarningIsEmitted forever. It feeds the collectors a synthetic
-// package covering all three shapes and requires each to be classified right.
+// TestEveryStartupWarningGuardDetectsItsOwnInertness is the guard's own mutation
+// test: a scanner that silently matched nothing would pass
+// TestEveryStartupWarningIsRaisedExactlyOnce forever. It feeds the collectors a
+// synthetic package covering every shape and requires each to be classified
+// right — with one fixture per property the merge could have dropped, so a
+// merged guard that checks LESS than either of the two it replaced fails here.
 //
-// DiscardedWarning is the case this fixture previously got backwards. It used
+// DiscardedWarning is the case an earlier fixture got backwards. It used
 // `_ = OtherWarning()` as the WIRED example — so the guard's own self-test
-// asserted that a discarded return counts as emitted, certifying as fixed the
-// very bug the guard exists to catch. A discarded warning is now a NEGATIVE,
-// alongside the never-called one.
-func TestEveryStartupWarningIsEmittedDetectsAnUnwiredGuard(t *testing.T) {
+// asserted that a discarded return counts as raised, certifying as fixed the
+// very bug the guard exists to catch.
+func TestEveryStartupWarningGuardDetectsItsOwnInertness(t *testing.T) {
 	dir := t.TempDir()
 	src := "package x\n" +
 		"\n" +
@@ -82,6 +162,10 @@ func TestEveryStartupWarningIsEmittedDetectsAnUnwiredGuard(t *testing.T) {
 		"func DiscardedWarning() string  { return \"\" }\n" +
 		"func LoggedWarning() string     { return \"\" }\n" +
 		"func QualifiedWarning() string  { return \"\" }\n" +
+		"func TwiceWarning() string      { return \"\" }\n" +
+		"func TwiceInOneFuncWarning() string { return \"\" }\n" +
+		"func FarLoggedWarning() string  { return \"\" }\n" +
+		"func InfoOnlyWarning() string   { return \"\" }\n" +
 		"\n" +
 		"func discards() { _ = DiscardedWarning() }\n" +
 		"\n" +
@@ -92,41 +176,109 @@ func TestEveryStartupWarningIsEmittedDetectsAnUnwiredGuard(t *testing.T) {
 		"\tif msg := pkg.QualifiedWarning(); msg != \"\" {\n" +
 		"\t\tlog.Warn(msg, \"key\", 1)\n" +
 		"\t}\n" +
+		"\tif msg := InfoOnlyWarning(); msg != \"\" {\n" +
+		"\t\tlog.Info(msg)\n" +
+		"\t}\n" +
+		"\tfar := FarLoggedWarning()\n" +
+		"\tlog.Warn(far)\n" +
+		"}\n" +
+		"\n" +
+		"func twiceInOneFunc(log logger) {\n" +
+		"\tif msg := TwiceInOneFuncWarning(); msg != \"\" {\n" +
+		"\t\tlog.Warn(msg)\n" +
+		"\t}\n" +
+		"\tif msg := TwiceInOneFuncWarning(); msg != \"\" {\n" +
+		"\t\tlog.Warn(msg)\n" +
+		"\t}\n" +
+		"}\n" +
+		"\n" +
+		"func twiceA(log logger) {\n" +
+		"\tif msg := TwiceWarning(); msg != \"\" {\n" +
+		"\t\tlog.Warn(msg)\n" +
+		"\t}\n" +
+		"}\n" +
+		"\n" +
+		"func twiceB(log logger) {\n" +
+		"\tif msg := TwiceWarning(); msg != \"\" {\n" +
+		"\t\tlog.Warn(msg)\n" +
+		"\t}\n" +
 		"}\n"
 	if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte(src), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	declared, called := scanWarningsIn(t, []string{dir})
+	declared, sites, scanned := scanWarningsIn(t, []string{dir})
+	if scanned != 1 {
+		t.Fatalf("the fixture package is one file; scanned=%d, so the file counter does not count files", scanned)
+	}
 
-	for _, name := range []string{"InertGuardWarning", "DiscardedWarning", "LoggedWarning", "QualifiedWarning"} {
+	for _, name := range []string{
+		"InertGuardWarning", "DiscardedWarning", "LoggedWarning", "QualifiedWarning",
+		"TwiceWarning", "TwiceInOneFuncWarning", "FarLoggedWarning", "InfoOnlyWarning",
+	} {
 		if _, ok := declared[name]; !ok {
 			t.Fatalf("the declaration scanner missed %s — it would miss a real one too", name)
 		}
 	}
-	if called["InertGuardWarning"] {
-		t.Fatal("the call scanner reported a caller for a function nothing calls — the guard cannot fail")
+
+	// COUNTING. Zero and two are both failures, and the pre-merge "is it called at
+	// all?" property could not see the second.
+	if n := len(sites["InertGuardWarning"]); n != 0 {
+		t.Errorf("the call scanner reported %d call sites for a function nothing calls — the guard cannot fail", n)
 	}
-	if called["DiscardedWarning"] {
-		t.Fatal("`_ = DiscardedWarning()` was counted as emitted: the result is thrown away, so no operator " +
-			"can ever see it. Counting it is exactly how an inert guard passes this test.")
+	if n := len(sites["TwiceWarning"]); n != 2 {
+		t.Errorf("two call sites in two functions were counted as %d — the exactly-once property is gone, "+
+			"and a warning printed twice at startup now passes", n)
 	}
-	if !called["LoggedWarning"] {
-		t.Fatal("a plain (unqualified) call whose message reaches log.Warn was missed — it would miss a real one too")
+	// Two raises of the same warning in ONE function. This is the case a
+	// map[string]ast.Stmt collapses to a single site, and it is the shape a
+	// duplicate actually takes — a second raise pasted into RunServe beside the
+	// first, not a second raiser in a second function. The two-function case above
+	// passes against that bug, which is why both are here.
+	if n := len(sites["TwiceInOneFuncWarning"]); n != 2 {
+		t.Errorf("two call sites in ONE function were counted as %d — a duplicate raise added next to the "+
+			"existing one is invisible, which is the likeliest way this regresses", n)
 	}
-	if !called["QualifiedWarning"] {
-		t.Fatal("a qualified call (pkg.XWarning) whose message reaches log.Warn was missed — " +
-			"config.ChatWithoutCaptureWarning has exactly this shape")
+	// A qualified call and a bare one bound to the SAME idiomatic `msg` in one
+	// function must both be seen: RunServe does exactly this, and an ident-keyed
+	// map would let one binding evict the other.
+	for _, name := range []string{"LoggedWarning", "QualifiedWarning", "DiscardedWarning"} {
+		if n := len(sites[name]); n != 1 {
+			t.Errorf("%s: got %d call sites, want 1 — config.ChatWithoutCaptureWarning has the qualified "+
+				"shape, and `_ = X()` is still a CALL (it is the raise it fails, not the call)", name, n)
+		}
 	}
-	// Two guards binding the same idiomatic `msg` in one function must both be
-	// seen; RunServe does exactly this, and an ident-keyed map would drop one.
-	if !called["LoggedWarning"] || !called["QualifiedWarning"] {
-		t.Fatal("two warnings bound to the same identifier in one function: both must be reported")
+
+	// RAISING. Run the same assertion the real guard runs, against a recorder, and
+	// require each fixture to land on the right side of it.
+	for _, tc := range []struct {
+		name      string
+		wantRaise bool
+		why       string
+	}{
+		{"LoggedWarning", true, "a bare call bound to msg and passed to log.Warn in the same statement is the shipped shape"},
+		{"QualifiedWarning", true, "a qualified call raised the same way must be accepted too"},
+		{"DiscardedWarning", false, "`_ = DiscardedWarning()` throws the message away; counting it as raised is exactly how an inert guard passes"},
+		{"FarLoggedWarning", false, "bound in one statement and logged in the NEXT is not the same statement — " +
+			"accepting it restores the same-function looseness the merge removed"},
+		{"InfoOnlyWarning", false, "raised at Info, not Warn — a warning demoted to a level operators filter out is not raised"},
+	} {
+		got := sites[tc.name]
+		if len(got) != 1 {
+			t.Errorf("%s: want 1 call site to assert against, got %d", tc.name, len(got))
+			continue
+		}
+		rec := &testing.T{}
+		assertWarningIsRaised(rec, got[0].file, got[0].stmt, tc.name, warningRaiser)
+		if raised := !rec.Failed(); raised != tc.wantRaise {
+			t.Errorf("%s: assertWarningIsRaised said raised=%v, want %v — %s",
+				tc.name, raised, tc.wantRaise, tc.why)
+		}
 	}
 }
 
 // scanWarnings collects, from the shipped (non-test) tree, every *Warning
-// declaration and every *Warning called.
-func scanWarnings(t *testing.T) (declared map[string]string, called map[string]bool) {
+// declaration and every non-test site that calls one.
+func scanWarnings(t *testing.T) (declared map[string]string, sites map[string][]warningSite, scanned int) {
 	t.Helper()
 	return scanWarningsIn(t, scanRoots)
 }
@@ -134,13 +286,15 @@ func scanWarnings(t *testing.T) (declared map[string]string, called map[string]b
 // scanWarningsIn is scanWarnings over an explicit set of roots, so the guard's
 // own mutation test can point it at a synthetic package.
 //
-// Calls are matched both as a bare identifier (a same-package call, e.g.
-// WebhookAuthWarning in serve.go) and as a selector (config.ChatWithoutCapture
-// Warning), since the two live in different packages and a scanner that handled
-// only one shape would wave the other through.
-func scanWarningsIn(t *testing.T, roots []string) (declared map[string]string, called map[string]bool) {
+// declared maps a warning's name to the file declaring it; sites maps it to
+// every non-test call, each carrying the top-level statement containing it —
+// which is the scope assertWarningIsRaised judges. scanned is how many non-test
+// .go files were actually parsed; the caller asserts a floor on it, because a
+// scanner that quietly stops looking at most of the tree finds nothing to
+// complain about and reports success — see minScannedFiles.
+func scanWarningsIn(t *testing.T, roots []string) (declared map[string]string, sites map[string][]warningSite, scanned int) {
 	t.Helper()
-	declared, called = map[string]string{}, map[string]bool{}
+	declared, sites = map[string]string{}, map[string][]warningSite{}
 	fset := token.NewFileSet()
 
 	for _, root := range roots {
@@ -155,10 +309,11 @@ func scanWarningsIn(t *testing.T, roots []string) (declared map[string]string, c
 			if perr != nil {
 				return perr
 			}
-			ast.Inspect(f, func(n ast.Node) bool {
-				fn, ok := n.(*ast.FuncDecl)
-				if !ok {
-					return true
+			scanned++
+			for _, decl := range f.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
 				}
 				// Methods are excluded: the convention is a package-level pure
 				// function, and a method named *Warning would be a different
@@ -166,115 +321,58 @@ func scanWarningsIn(t *testing.T, roots []string) (declared map[string]string, c
 				if fn.Recv == nil && strings.HasSuffix(fn.Name.Name, warningSuffix) {
 					declared[fn.Name.Name] = path
 				}
-				// A call is only counted from inside the function that contains
-				// it, so the binding it produces and the logger that consumes it
-				// are matched within one scope.
-				for name := range loggedWarningsIn(fn) {
-					called[name] = true
+				for name, stmts := range warningCallsIn(fn) {
+					for _, stmt := range stmts {
+						sites[name] = append(sites[name], warningSite{file: filepath.Base(path), stmt: stmt})
+					}
 				}
-				return true
-			})
+			}
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("walk %s: %v", root, err)
 		}
 	}
-	return declared, called
+	return declared, sites, scanned
 }
 
-// loggerMethods are the slog methods a warning's message may reach. A *Warning
-// whose result flows into one of these has been emitted; one whose result is
-// discarded, or merely compared and dropped, has not.
-var loggerMethods = map[string]bool{
-	"Warn": true, "Warnf": true,
-	"Error": true, "Errorf": true,
-	"Info": true, "Infof": true,
-}
-
-// loggedWarningsIn returns the *Warning functions called inside fn whose
-// returned message demonstrably reaches a logger.
+// warningCallsIn returns every *Warning called inside fn, mapped to the
+// top-level statement of fn's body containing each call — the scope the raise
+// must happen in. A warning calling itself is not a call site.
 //
-// Merely finding a call is not enough, and that gap is the reason this helper
-// exists. Every one of these guards is a pure function returning a string, so
-// `_ = ChatWithoutCaptureWarning(cfg)` compiles, runs, satisfies a
-// call-site-exists check, and emits precisely nothing — which is the exact
-// failure TestEveryStartupWarningIsEmitted claims to catch. The earlier version
-// counted any call, and its own synthetic fixture used the discarded form as
-// the WIRED example, so the guard certified the bug as fixed.
-//
-// The shape recognised is the one all three real call sites use:
-//
-//	if msg := SomeWarning(x); msg != "" {
-//	    log.Warn(msg)
-//	}
-//
-// i.e. the result is bound to a non-blank identifier, and that identifier is
-// then passed to a logger method somewhere in the same function. Requiring the
-// same function keeps this a syntactic check with no type information, which is
-// what lets it run over ../../internal and ../../cmd without building them.
-func loggedWarningsIn(fn *ast.FuncDecl) map[string]bool {
-	if fn.Body == nil {
-		return nil
-	}
-	// binding: identifier name -> every *Warning whose result it has held.
-	//
-	// A SET per identifier, not one name: RunServe emits several guards and each
-	// uses the same idiomatic `msg` in its own if-scope, so a map keyed by
-	// identifier alone would let the last binding evict the earlier ones and
-	// report a genuinely-wired warning as inert.
-	binding := map[string]map[string]bool{}
-	// logged: identifiers passed to a logger method anywhere in this function.
-	logged := map[string]bool{}
-
+// A SLICE per name, not a single statement: two calls to the same warning inside
+// ONE function are two call sites. An earlier draft returned
+// map[string]ast.Stmt and silently collapsed them into one, so the
+// exactly-once property held only across functions — and its fixture put the
+// duplicate pair in two different functions, so it never noticed. The shape that
+// actually happens is a second raise pasted into RunServe beside the first.
+func warningCallsIn(fn *ast.FuncDecl) map[string][]ast.Stmt {
+	out := map[string][]ast.Stmt{}
+	// stack tracks the ancestry of the node being visited, so a call site can be
+	// resolved back to the statement it sits in, not merely to its function.
+	var stack []ast.Node
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		if as, ok := n.(*ast.AssignStmt); ok {
-			for i, rhs := range as.Rhs {
-				name := warningCallName(rhs)
-				if name == "" || i >= len(as.Lhs) {
-					continue
-				}
-				// `_ = SomeWarning()` binds nothing and can never be logged.
-				if id, ok := as.Lhs[i].(*ast.Ident); ok && id.Name != "_" {
-					if binding[id.Name] == nil {
-						binding[id.Name] = map[string]bool{}
-					}
-					binding[id.Name][name] = true
-				}
-			}
+		if n == nil {
+			stack = stack[:len(stack)-1]
+			return false
 		}
-		if call, ok := n.(*ast.CallExpr); ok {
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok || !loggerMethods[sel.Sel.Name] {
-				return true
-			}
-			for _, arg := range call.Args {
-				if id, ok := arg.(*ast.Ident); ok {
-					logged[id.Name] = true
-				}
-			}
+		stack = append(stack, n)
+		name := warningCallName(n)
+		if name == "" || name == fn.Name.Name {
+			return true
 		}
+		out[name] = append(out[name], outermostStmt(stack))
 		return true
 	})
-
-	out := map[string]bool{}
-	for ident, warnings := range binding {
-		if !logged[ident] {
-			continue
-		}
-		for warning := range warnings {
-			out[warning] = true
-		}
-	}
 	return out
 }
 
-// warningCallName reports the *Warning function e calls, or "" if e is not such
+// warningCallName reports the *Warning function n calls, or "" if n is not such
 // a call. Both shapes are recognised: a same-package bare identifier
 // (WebhookAuthWarning in serve.go) and a qualified selector
 // (config.ChatWithoutCaptureWarning).
-func warningCallName(e ast.Expr) string {
-	call, ok := e.(*ast.CallExpr)
+func warningCallName(n ast.Node) string {
+	call, ok := n.(*ast.CallExpr)
 	if !ok {
 		return ""
 	}

--- a/internal/catalog/section.go
+++ b/internal/catalog/section.go
@@ -22,18 +22,15 @@ func (e Entry) Section(name string) string {
 	want := strings.TrimSpace(name)
 	var para []string
 	in := false
-	inFence := false
-	for _, ln := range strings.Split(e.Body, "\n") {
+	lines := strings.Split(e.Body, "\n")
+	fenced := FencedLines(lines)
+	for i, ln := range lines {
 		trimmed := strings.TrimSpace(ln)
 		// Fenced code blocks are opaque: a "# comment" line inside one is code,
 		// not a section boundary, and commands aren't quotable prose — skip the
 		// whole fence (markers included) wherever it appears, so the excerpt is
 		// the section's first PROSE paragraph.
-		if strings.HasPrefix(trimmed, "```") {
-			inFence = !inFence
-			continue
-		}
-		if inFence {
+		if fenced[i] || strings.HasPrefix(trimmed, "```") {
 			continue
 		}
 		if h := headingText(trimmed); h != "" {
@@ -56,6 +53,44 @@ func (e Entry) Section(name string) string {
 	}
 	s := strings.ReplaceAll(strings.Join(para, " "), "**", "")
 	return truncateRunes(s, sectionMaxRunes)
+}
+
+// FencedLines reports, per line, whether it sits inside a fenced code block —
+// markers included. It is the single answer to "is this line code?" that RunLore's
+// two section parsers share: this file's Entry.Section, and kbvalidate.Sections
+// (the merge gate). Exported for exactly that reason.
+//
+// They used to answer it separately, and one of them did not answer it at all.
+// Entry.Section tracked fences; kbvalidate.Sections walked every line with no
+// fence state, so a "# comment" opening a resolution's command block ended the
+// section, and OKF headings wrapped in ``` forged a complete Incident for the
+// merge gate while rendering as an inert code sample. thread.escapeOKFSections
+// had to escape the UNION of both parsers' heading shapes to cover the gap. One
+// implementation is the only version of this that cannot drift back apart.
+//
+// An UNTERMINATED fence marks nothing. The naive toggle treats a single stray
+// ``` as opening a block that never closes, so every heading after it disappears
+// — which for the merge gate means rejecting an otherwise complete entry over an
+// authoring slip, and for an excerpt means silently having nothing to quote.
+// Only a CLOSED pair marks its range, so an unmatched opener degrades to
+// ordinary text.
+func FencedLines(lines []string) []bool {
+	fenced := make([]bool, len(lines))
+	open := -1
+	for i, ln := range lines {
+		if !strings.HasPrefix(strings.TrimSpace(ln), "```") {
+			continue
+		}
+		if open < 0 {
+			open = i
+			continue
+		}
+		for j := open; j <= i; j++ {
+			fenced[j] = true
+		}
+		open = -1
+	}
+	return fenced
 }
 
 // headingText returns the text of an ATX markdown heading line ("## Cause" →

--- a/internal/config/config_investigation_test.go
+++ b/internal/config/config_investigation_test.go
@@ -107,6 +107,67 @@ func TestApplyDefaultsInstantRecall(t *testing.T) {
 	}
 }
 
+// TestApplyDefaultsCurationGates pins the curation gates to ApplyDefaults, where
+// every sibling default already lives.
+//
+// They used to be filled inside app.BuildCurator, which meant any path that did
+// not build a curator saw 0: `lore config show`, the Helm values guards, and
+// telemetry's scoreBuckets alignment test, which had to restate 5.0 as a bare
+// literal because there was no resolved value to read. A default that only
+// exists on one construction path is not the deployment's default, it is that
+// path's local variable.
+//
+// Applied unconditionally (not gated on forge credentials) precisely so the
+// resolved value is readable without building a forge client; it is inert when
+// no curator is wired.
+func TestApplyDefaultsCurationGates(t *testing.T) {
+	var c Config
+	ApplyDefaults(&c)
+	if c.Forge.DupScore != 5.0 {
+		t.Errorf("default forge.dup_score: got %g, want 5.0", c.Forge.DupScore)
+	}
+	if c.Forge.MinConfidence != 0.75 {
+		t.Errorf("default forge.min_confidence: got %g, want 0.75", c.Forge.MinConfidence)
+	}
+	// Explicit values are respected, not overwritten.
+	var c2 Config
+	c2.Forge.DupScore, c2.Forge.MinConfidence = 2.5, 0.9
+	ApplyDefaults(&c2)
+	if c2.Forge.DupScore != 2.5 || c2.Forge.MinConfidence != 0.9 {
+		t.Errorf("explicit curation gates overwritten: dup_score=%g min_confidence=%g", c2.Forge.DupScore, c2.Forge.MinConfidence)
+	}
+}
+
+// TestApplyDefaultsHybridRecall covers the same class for hybrid recall's cosine
+// gates, which had their defaults stranded in app.BuildInvestigator. Gated on
+// `hybrid: true` for the same reason the other instant-recall knobs are gated on
+// `enabled`: a disabled block stays at its zero value.
+func TestApplyDefaultsHybridRecall(t *testing.T) {
+	var c Config
+	c.Catalog.InstantRecall.Enabled = true
+	c.Catalog.InstantRecall.Hybrid = true
+	ApplyDefaults(&c)
+	ir := c.Catalog.InstantRecall
+	if ir.HybridMinScore != 0.80 || ir.HybridMarginGap != 0.05 {
+		t.Errorf("hybrid recall defaults not applied: min_score=%g margin_gap=%g", ir.HybridMinScore, ir.HybridMarginGap)
+	}
+	// Off ⇒ untouched, so the zero value still means "hybrid is not running".
+	var off Config
+	off.Catalog.InstantRecall.Enabled = true
+	ApplyDefaults(&off)
+	if off.Catalog.InstantRecall.HybridMinScore != 0 || off.Catalog.InstantRecall.HybridMarginGap != 0 {
+		t.Errorf("hybrid defaults filled while hybrid is off: %+v", off.Catalog.InstantRecall)
+	}
+	// Explicit values are respected.
+	var c2 Config
+	c2.Catalog.InstantRecall.Enabled, c2.Catalog.InstantRecall.Hybrid = true, true
+	c2.Catalog.InstantRecall.HybridMinScore, c2.Catalog.InstantRecall.HybridMarginGap = 0.6, 0.2
+	ApplyDefaults(&c2)
+	if c2.Catalog.InstantRecall.HybridMinScore != 0.6 || c2.Catalog.InstantRecall.HybridMarginGap != 0.2 {
+		t.Errorf("explicit hybrid gates overwritten: %+v", c2.Catalog.InstantRecall)
+	}
+}
+
 func TestApplyDefaultsRecallDecayExplicit(t *testing.T) {
 	// Explicit decay knobs must not be overwritten.
 	var c Config

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -218,6 +218,32 @@ func ApplyDefaults(c *Config) {
 				ir.RerankMinScore = 0.1
 			}
 		}
+		// Hybrid (cosine-gated) recall defaults, filled only once hybrid is on so a
+		// disabled block stays at its zero value — the same rule the reranker above
+		// follows. These were previously applied in app.BuildInvestigator, so nothing
+		// but that one construction path could see them.
+		if ir.Hybrid {
+			if ir.HybridMinScore == 0 {
+				ir.HybridMinScore = 0.80
+			}
+			if ir.HybridMarginGap == 0 {
+				ir.HybridMarginGap = 0.05
+			}
+		}
+	}
+	// Curation gates: the file-time dedup threshold and quality bar. Applied
+	// UNCONDITIONALLY — unlike the opt-in blocks above — because the point is that
+	// the resolved value is readable from the config alone, by `lore config show`,
+	// by the Helm/telemetry guards, by anything that wants to know what the curator
+	// would do without constructing one. They were previously filled inside
+	// app.BuildCurator, so every other path saw 0: a threshold of 0 makes the dedup
+	// gate fire on any hit at all, and a quality bar of 0 admits every finding.
+	// Filling them here is inert when no forge is configured (no curator is built).
+	if c.Forge.DupScore == 0 {
+		c.Forge.DupScore = 5.0
+	}
+	if c.Forge.MinConfidence == 0 {
+		c.Forge.MinConfidence = 0.75
 	}
 	// Retirement pass defaults (opt-in): only fill the tuning knobs once the pass is
 	// enabled, so a disabled block stays at its zero value and never wires the pass

--- a/internal/docsguard/troubleshooting_logs_test.go
+++ b/internal/docsguard/troubleshooting_logs_test.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// troubleshootingPath is the operations page that tells an operator which log
+// line to grep for each symptom. Every claim on it is a quoted string that must
+// exist in the code, and nothing compiles, imports, or executes the page — so a
+// reworded log message leaves it directing operators at text the agent has never
+// emitted, with no error anywhere.
+const troubleshootingPath = "website/content/docs/operations/troubleshooting.md"
+
+// quotedLogRE matches the page's own convention for quoting a log line:
+// msg="…". Structured slog output renders the message under the `msg` key, so
+// this is both how the docs write it and how an operator greps for it.
+var quotedLogRE = regexp.MustCompile(`msg="([^"]*)"`)
+
+// logMethods are the slog methods whose FIRST argument is the message an
+// operator sees as msg=. The Context variants take ctx first; that shift is
+// handled where the argument is read.
+var logMethods = map[string]int{
+	"Debug": 0, "Info": 0, "Warn": 0, "Error": 0,
+	"DebugContext": 1, "InfoContext": 1, "WarnContext": 1, "ErrorContext": 1,
+}
+
+// logScanRoots are the trees searched for emitted messages, relative to the repo
+// root.
+var logScanRoots = []string{"internal", "cmd"}
+
+// minQuotedLogLines and minEmittedLogLines are inertness floors. A regex that
+// stopped matching, or a scan that stopped finding log calls, proves nothing and
+// reports success — the same failure this package exists to catch, reproduced
+// inside the catcher (see logsProviderIDs). The page quotes 29 messages against
+// ~1000 emitted today; the floors sit well below both, so ordinary editing does
+// not trip them.
+const (
+	minQuotedLogLines  = 20
+	minEmittedLogLines = 300
+)
+
+// TestTroubleshootingQuotesRealLogLines pins every msg="…" on the troubleshooting
+// page to a message the agent can actually emit.
+//
+// The page is a symptom-to-grep table: an operator reads "runlore_incidents_
+// dropped_on_shutdown_total > 0" and is told to grep msg="held incident DROPPED:
+// …". When the code's wording moves and the page does not, that grep returns
+// nothing — which is indistinguishable from "the thing never happened", the
+// single most misleading answer a troubleshooting page can give.
+//
+// It had drifted twice by the time this guard was written:
+//
+//   - msg="finding duplicates a catalog entry; not filing" — the code logs
+//     "dedup: duplicates a catalog entry; not filing". The row is the one an
+//     operator reads when RunLore declines to file a finding, so the grep that
+//     confirms the dedup gate fired matched nothing.
+//   - msg="investigation rate limit engaged; throttling…" — an ellipsis where
+//     the real message continues "throttling new investigations this window".
+//     A reader who greps the quoted string verbatim gets nothing back.
+//
+// The message is matched EXACTLY, not by prefix. An elided quote is precisely
+// the failure above: it looks like documentation and does not work as a grep.
+// Where a message is genuinely too long to quote whole, quote a shorter true
+// substring outside msg="…" rather than an elided one inside it.
+func TestTroubleshootingQuotesRealLogLines(t *testing.T) {
+	root := repoRoot(t)
+
+	page, err := os.ReadFile(filepath.Join(root, troubleshootingPath))
+	if err != nil {
+		t.Fatalf("read %s: %v", troubleshootingPath, err)
+	}
+	quoted := map[string][]int{} // message -> 1-based line numbers quoting it
+	for i, line := range strings.Split(string(page), "\n") {
+		for _, m := range quotedLogRE.FindAllStringSubmatch(line, -1) {
+			quoted[m[1]] = append(quoted[m[1]], i+1)
+		}
+	}
+	if len(quoted) < minQuotedLogLines {
+		t.Fatalf("%s: found only %d distinct msg=\"…\" quotes, want at least %d — the page's quoting "+
+			"convention changed and this guard is now inert, which is the exact failure it exists to catch",
+			troubleshootingPath, len(quoted), minQuotedLogLines)
+	}
+
+	emitted := emittedLogMessages(t, root)
+	if len(emitted) < minEmittedLogLines {
+		t.Fatalf("found only %d log messages under %v, want at least %d — the scanner has stopped "+
+			"recognising log calls, so every quote on the page passes unchecked",
+			len(emitted), logScanRoots, minEmittedLogLines)
+	}
+
+	for _, msg := range unquotableMessages(quoted, emitted) {
+		t.Errorf("%s:%v quotes msg=%q, which no log call in %v emits — an operator who greps it gets "+
+			"nothing back, which reads as \"this never happened\" rather than \"the docs are stale\".%s",
+			troubleshootingPath, quoted[msg], msg, logScanRoots, nearestHint(msg, emitted))
+	}
+}
+
+// unquotableMessages returns the quoted messages that no log call emits.
+//
+// Extracted so TestTroubleshootingLogGuardDetectsDrift exercises the REAL
+// matching rule rather than a restatement of it. Its first version asserted
+// against the emitted map directly, which left the comparison above untested:
+// relaxing it from equality to a prefix match — the exact way this guard would
+// be weakened to make a truncated quote "pass" — changed nothing that failed.
+//
+// Equality, deliberately. A quote is a grep an operator will run verbatim, so a
+// prefix or a substring is not a weaker check, it is the wrong one.
+func unquotableMessages(quoted map[string][]int, emitted map[string]string) []string {
+	var out []string
+	for msg := range quoted {
+		if _, ok := emitted[msg]; !ok {
+			out = append(out, msg)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestTroubleshootingLogGuardDetectsDrift is the guard's own mutation test: it
+// runs unquotableMessages — the same matcher the guard above runs — over a
+// synthetic page of near-misses, and requires every one to be reported. A guard
+// that matched on a prefix, or that silently found nothing to check, would pass
+// the test above forever.
+func TestTroubleshootingLogGuardDetectsDrift(t *testing.T) {
+	emitted := emittedLogMessages(t, repoRoot(t))
+
+	const accurate = "dedup: duplicates a catalog entry; not filing"
+	if got := unquotableMessages(map[string][]int{accurate: {1}}, emitted); len(got) != 0 {
+		t.Fatalf("the guard rejected %q, a message internal/curator/curator.go really emits — "+
+			"it would reject every accurate quote on the page too", accurate)
+	}
+
+	// Every way this page has drifted, or could. Each is a near-miss for the real
+	// message above, and each must be reported: a quote is a grep an operator
+	// runs verbatim, so "nearly right" returns nothing at all.
+	drifted := map[string][]int{
+		"dedup: duplicates a catalog entry":                 {1}, // truncated (a prefix of the real one)
+		"dedup: duplicates a catalog entry; not filing…":    {2}, // elided with an ellipsis
+		"finding duplicates a catalog entry; not filing":    {3}, // reworded — the drift actually found
+		"Dedup: duplicates a catalog entry; not filing":     {4}, // case changed
+		" dedup: duplicates a catalog entry; not filing":    {5}, // leading space
+		"dedup: duplicates a catalog entry; not filing now": {6}, // extended
+	}
+	got := unquotableMessages(drifted, emitted)
+	if len(got) != len(drifted) {
+		accepted := make([]string, 0, len(drifted))
+		for msg := range drifted {
+			if !slices.Contains(got, msg) {
+				accepted = append(accepted, msg)
+			}
+		}
+		sort.Strings(accepted)
+		t.Errorf("the guard accepted %d of %d drifted quotes (%q) — the match is no longer exact, "+
+			"so a truncated or reworded quote passes and the page keeps directing operators at a "+
+			"grep that returns nothing", len(accepted), len(drifted), accepted)
+	}
+}
+
+// emittedLogMessages returns every string literal passed as the MESSAGE argument
+// of an slog call under logScanRoots, mapped to the file it is emitted from.
+//
+// Parsed from the source rather than listed, for the reason logsProviderIDs
+// gives: a hand-written list is an independent copy that drifts in exactly the
+// direction the guard exists to catch. Non-test files only — a message that only
+// a test emits is not one an operator can grep for.
+//
+// Non-literal messages (a fmt.Sprintf, a variable) are skipped rather than
+// approximated. They cannot be quoted verbatim on the page either, so a doc line
+// claiming one is a doc line that was already wrong.
+func emittedLogMessages(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	fset := token.NewFileSet()
+
+	for _, dir := range logScanRoots {
+		err := filepath.WalkDir(filepath.Join(root, dir), func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			f, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				return perr
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				at, ok := logMethods[sel.Sel.Name]
+				if !ok || at >= len(call.Args) {
+					return true
+				}
+				lit, ok := call.Args[at].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				msg, uerr := strconv.Unquote(lit.Value)
+				if uerr != nil {
+					return true
+				}
+				if _, seen := out[msg]; !seen {
+					out[msg] = path
+				}
+				return true
+			})
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", dir, err)
+		}
+	}
+	return out
+}
+
+// nearestHint names the emitted message a stale quote most likely drifted from,
+// so the failure says what to write instead of only what is wrong. Chosen by
+// longest shared word run, which is what a rewording leaves behind.
+func nearestHint(msg string, emitted map[string]string) string {
+	words := strings.Fields(msg)
+	best, bestScore := "", 0
+	for cand := range emitted {
+		score := 0
+		cw := strings.Fields(cand)
+		for _, w := range words {
+			for _, c := range cw {
+				if w == c {
+					score++
+					break
+				}
+			}
+		}
+		if score > bestScore {
+			best, bestScore = cand, score
+		}
+	}
+	if bestScore < 2 {
+		return ""
+	}
+	return "\n    closest emitted message: " + strconv.Quote(best) + " (" + emitted[best] + ")"
+}

--- a/internal/kbvalidate/kbvalidate.go
+++ b/internal/kbvalidate/kbvalidate.go
@@ -205,6 +205,18 @@ func ValidateStructural(e catalog.Entry) []Issue {
 // Sections maps each "## Heading" (lowercased) to its trimmed content. Exported
 // so `lore kb import` can infer Incident-vs-Playbook from a source document's
 // OKF sections using the same heading parser the validator gates on.
+//
+// A heading inside a fenced code block is CODE, not a heading — the same answer
+// catalog.Entry.Section gives, from the same scanner (catalog.FencedLines), so
+// the merge gate and the read path cannot disagree about what a section is. See
+// FencedLines for what the two cost while they did.
+//
+// Fence CONTENT is still part of the section, and that is where this parser and
+// catalog.Entry.Section legitimately differ: that one builds a quotable prose
+// excerpt for a chat notification and drops code, while this one only asks
+// whether a section is present and non-empty — and a resolution's command block
+// is part of the resolution. They must agree on headings; they need not agree on
+// what is worth quoting.
 func Sections(body string) map[string]string {
 	out := map[string]string{}
 	cur := ""
@@ -215,11 +227,15 @@ func Sections(body string) map[string]string {
 		}
 		buf = nil
 	}
-	for _, line := range strings.Split(body, "\n") {
-		if label, ok := heading(line); ok {
-			flush()
-			cur = label
-			continue
+	lines := strings.Split(body, "\n")
+	fenced := catalog.FencedLines(lines)
+	for i, line := range lines {
+		if !fenced[i] {
+			if label, ok := heading(line); ok {
+				flush()
+				cur = label
+				continue
+			}
 		}
 		if cur != "" {
 			buf = append(buf, line)

--- a/internal/kbvalidate/kbvalidate_test.go
+++ b/internal/kbvalidate/kbvalidate_test.go
@@ -236,3 +236,155 @@ func TestSectionsExported(t *testing.T) {
 		t.Fatalf("got %#v", secs)
 	}
 }
+
+// TestSectionsTreatsFencesAsOpaqueForHeadings pins the reconciliation between
+// this package's section parser and catalog.Entry.Section: a "# …" line inside a
+// fenced code block is CODE, and is a heading to neither.
+//
+// The two used to disagree. catalog.Entry.Section tracked fences; Sections
+// walked every line with no fence state at all, and that cost real things in
+// both directions:
+//
+//   - a live entry lost most of its Resolution.
+//     internal/investigate/testdata/realkb/harbor-helmrelease-terminal-failed.md
+//     resolves with a fenced command block whose first line is the shell comment
+//     "# only the failed release exists (…)". Read fence-blind, that comment ends
+//     the resolution section — so secs["resolution"] stopped at the opening
+//     fence, dropping the `--reset` explanation, the verification step and the
+//     "human-approved, not a blind bulk sweep" warning, and inventing a section
+//     named after the comment.
+//   - a fenced block forged a whole Incident. HasIncidentSections is built on
+//     Sections, so wrapping Symptom/Cause/Resolution in ``` produced a body that
+//     passed the incident test while rendering as an inert code sample. That is
+//     what forced thread.escapeOKFSections to escape the UNION of both parsers'
+//     heading shapes, fenced ones included, rather than mirroring the read path.
+//     plugins/kb-steward/…/references/okf-format.md — a docs page whose example
+//     entry sits in a fence — reads as a complete Incident today for this reason.
+//
+// Fence CONTENT is deliberately still part of the section here, unlike
+// catalog.Entry.Section which drops it: that parser is building a quotable prose
+// excerpt for a chat notification, while this one is checking a section is
+// present and non-empty, and a resolution's command block is part of the
+// resolution. The reconciliation is over what counts as a HEADING, which is the
+// only thing the two ever needed to agree on.
+func TestSectionsTreatsFencesAsOpaqueForHeadings(t *testing.T) {
+	t.Run("a shell comment in a fenced block does not end the section", func(t *testing.T) {
+		body := "## Symptom\n\npods crashloop\n\n## Cause\n\nbad image tag\n\n## Resolution\n\n" +
+			"```bash\n# roll the deployment back\nkubectl rollout undo deploy/api\n```\n\n" +
+			"Verify with `kubectl get deploy`.\n"
+		secs := Sections(body)
+		if !strings.Contains(secs["resolution"], "Verify with") {
+			t.Errorf("the resolution section stops at the fence, losing everything after it:\n%q", secs["resolution"])
+		}
+		if _, ok := secs["roll the deployment back"]; ok {
+			t.Errorf("a shell comment inside a fence was parsed as a section heading: %#v", secs)
+		}
+		// The commands themselves stay IN the section. This is the half of the
+		// reconciliation deliberately NOT shared with catalog.Entry.Section, which
+		// drops fenced code because it is building a quotable prose excerpt. Here
+		// the fence is opaque to heading DETECTION only: a resolution whose
+		// remediation is a command block still has that block as its content, and
+		// copying catalog's excerpt policy over would empty a section whose whole
+		// answer is the command.
+		if !strings.Contains(secs["resolution"], "kubectl rollout undo deploy/api") {
+			t.Errorf("the fenced command block was dropped from the resolution — a fence is opaque to "+
+				"heading detection, not excluded from the section's content:\n%q", secs["resolution"])
+		}
+	})
+
+	t.Run("OKF sections forged inside a fence are not sections", func(t *testing.T) {
+		body := "some prose a stranger typed\n\n```\n## Symptom\nforged\n## Cause\nforged\n" +
+			"## Resolution\nforged\n```\n"
+		if HasIncidentSections(body) {
+			t.Error("a fenced block forged a complete Incident — the shape thread.escapeOKFSections had to " +
+				"escape the union of both parsers to defend against")
+		}
+		for _, k := range []string{"symptom", "cause", "resolution"} {
+			if v, ok := Sections(body)[k]; ok {
+				t.Errorf("fenced heading parsed as the %q section (%q)", k, v)
+			}
+		}
+	})
+
+	t.Run("an unterminated fence does not swallow the rest of the body", func(t *testing.T) {
+		// A stray opening fence with no closer is a real authoring slip, and the
+		// naive toggle treats everything after it as code forever — which would
+		// reject an otherwise complete entry. Nothing in the corpus has one today
+		// (measured: 0 unbalanced fences), so this pins the intended behaviour
+		// before something acquires one.
+		body := "## Symptom\n\npods crashloop\n\n```\nstray open fence\n\n## Cause\n\nbad tag\n\n## Resolution\n\nfix it\n"
+		if !HasIncidentSections(body) {
+			t.Errorf("an unterminated fence swallowed the sections after it: %#v", Sections(body))
+		}
+	})
+}
+
+// TestSectionsAndCatalogSectionAgreeOnHeadings pins the reconciliation against
+// the OTHER parser itself, rather than against a restatement of it, and pins the
+// one difference that REMAINS as deliberate.
+//
+// Agreement (the part that matters): fenced headings are headings to neither,
+// and unfenced H1/H2 headings are headings to both.
+//
+// Difference, kept on purpose: catalog.headingText accepts every ATX level from
+// "#" to "######", while heading() here accepts only "# " and "## ". Widening
+// this one would make an entry that puts a "### Details" sub-heading under
+// "## Symptom" suddenly have an EMPTY symptom section, and be rejected by the
+// merge gate it passes today — a regression for a legitimate entry, to close a
+// gap that is not a hole: being MORE permissive about sub-headings costs a merge
+// gate nothing, and thread.escapeOKFSections already escapes every level, so no
+// forged heading reaches either parser regardless.
+func TestSectionsAndCatalogSectionAgreeOnHeadings(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		body          string
+		wantKbvalid   bool // "cause" is a section to Sections
+		wantCatalog   bool // "Cause" is a section to catalog.Entry.Section
+		whyTheyDiffer string
+	}{
+		{
+			name:        "H2, unfenced",
+			body:        "## Cause\n\nthe real cause\n",
+			wantKbvalid: true, wantCatalog: true,
+		},
+		{
+			name:        "H1, unfenced",
+			body:        "# Cause\n\nthe real cause\n",
+			wantKbvalid: true, wantCatalog: true,
+		},
+		{
+			name:        "H2, inside a fence",
+			body:        "prose\n\n```\n## Cause\n\nforged cause\n```\n",
+			wantKbvalid: false, wantCatalog: false,
+		},
+		{
+			name:        "H1, inside a fence",
+			body:        "prose\n\n```\n# Cause\n\nforged cause\n```\n",
+			wantKbvalid: false, wantCatalog: false,
+		},
+		{
+			name:        "H3, unfenced",
+			body:        "### Cause\n\nthe real cause\n",
+			wantKbvalid: false, wantCatalog: true,
+			whyTheyDiffer: "deliberate: the merge gate reads only H1/H2, so a sub-heading under a " +
+				"section stays part of that section instead of truncating it",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, gotKbvalid := Sections(tc.body)["cause"]
+			gotCatalog := (catalog.Entry{Body: tc.body}).Section("Cause") != ""
+			if gotKbvalid != tc.wantKbvalid {
+				t.Errorf("kbvalidate.Sections saw a %q section: %v, want %v", "cause", gotKbvalid, tc.wantKbvalid)
+			}
+			if gotCatalog != tc.wantCatalog {
+				t.Errorf("catalog.Entry.Section saw a %q section: %v, want %v", "Cause", gotCatalog, tc.wantCatalog)
+			}
+			if tc.whyTheyDiffer == "" && gotKbvalid != gotCatalog {
+				t.Errorf("the two parsers disagree on %s with no documented reason — kbvalidate=%v catalog=%v. "+
+					"Every undocumented disagreement is a shape one parser accepts and the other does not, "+
+					"which is what thread.escapeOKFSections has to escape the union of.",
+					tc.name, gotKbvalid, gotCatalog)
+			}
+		})
+	}
+}

--- a/internal/telemetry/buckets_alignment_test.go
+++ b/internal/telemetry/buckets_alignment_test.go
@@ -26,12 +26,12 @@ import (
 // the panel keeps rendering, keeps looking authoritative, and silently stops
 // answering the question the comment promises.
 //
-// The instant-recall gates come from ApplyDefaults, so this reads what an
-// operator actually runs under. dup_score is asserted as a literal because its
-// default is applied in app.BuildCurator rather than in ApplyDefaults — unlike
-// every sibling here — so there is no resolved value to read without building a
-// forge client. That asymmetry is worth fixing at the source; until it is, this
-// test states the number and where it comes from.
+// Every gate here comes from ApplyDefaults, so this reads what an operator
+// actually runs under — dup_score included. It used to be asserted as a bare
+// 5.0 literal, because its default was applied in app.BuildCurator instead and
+// there was no resolved value to read without building a forge client; a guard
+// checking the ladder against its own copy of a number is a guard that cannot
+// notice the number moving.
 func TestScoreBucketsAlignWithTheDecisionThresholds(t *testing.T) {
 	// instant_recall is off by default and ApplyDefaults only fills its knobs once
 	// it is enabled, so the fixture enables it. The reranker is on by default,
@@ -49,7 +49,7 @@ func TestScoreBucketsAlignWithTheDecisionThresholds(t *testing.T) {
 		{"catalog.instant_recall.min_score", ir.MinScore},
 		{"catalog.instant_recall.margin_gap", ir.MarginGap},
 		{"catalog.instant_recall.solo_floor", ir.SoloFloor},
-		{"forge.dup_score (default applied in app.BuildCurator)", 5.0},
+		{"forge.dup_score", cfg.Forge.DupScore},
 	} {
 		if tc.value == 0 {
 			t.Errorf("%s resolved to 0 — either the default moved out of ApplyDefaults or the field was renamed; "+

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -471,27 +471,30 @@ var okfSectionNames = []string{"Symptom", "Cause", "Resolution"}
 // is just as much a section as "## Cause".
 //
 // Fenced headings are escaped TOO, and deliberately so, even though a heading
-// inside a code fence is not a heading to a Markdown renderer.
+// inside a code fence is not a heading to a Markdown renderer — nor, any longer,
+// to either of RunLore's section parsers.
 //
-// The reason is that RunLore has TWO section parsers and they disagree.
-// catalog.Entry.Section (catalog/section.go:25) tracks fences and skips what is
-// inside them. kbvalidate.Sections (kbvalidate/kbvalidate.go:208) does not: it
-// walks every line and calls heading(line) with no fence state at all, and
-// HasIncidentSections is built on it. This function used to mirror the first
-// one exactly — which read as careful, and was the hole. A note that wrapped
+// It started that way because the two parsers disagreed. catalog.Entry.Section
+// tracked fences; kbvalidate.Sections walked every line with no fence state at
+// all, and HasIncidentSections is built on it. This function once mirrored the
+// first parser exactly — which read as careful, and was the hole. A note that
+// wrapped
 //
 //	## Symptom / ## Cause / ## Resolution
 //
 // in a ``` fence was escaped NOWHERE and parsed EVERYWHERE the fence-blind
-// parser looks, so HasIncidentSections returned true for a body a stranger
-// typed into a chat thread.
+// parser looks, so HasIncidentSections returned true for a body a stranger typed
+// into a chat thread.
 //
-// So the rule is the UNION, not either parser: escape every shape ANY reader
-// accepts as a section. Over-escaping costs a visible backslash inside a pasted
-// code block; under-escaping costs a forged entry. Aligning the two parsers is
-// the better long-term fix, but kbvalidate is the merge gate and changing what
-// it accepts reaches every existing entry, so that is not this function's call
-// to make.
+// That disagreement is now closed at the source: both parsers take their answer
+// from catalog.FencedLines, so a fenced heading is a heading to neither. The
+// UNION rule stays anyway, which makes the escaping here the SECOND of two
+// independent defences rather than the only one. Keeping it costs a visible
+// backslash inside a pasted code block. Dropping it would put a THIRD markdown
+// parser on the write path — this function would have to track fences itself to
+// know which headings to skip — and would stake the whole property on the read
+// path never regressing. TestSectionsAndCatalogSectionAgreeOnHeadings pins the
+// two parsers to each other; this keeps a note safe even if that pin is relaxed.
 //
 // Callers must still flatten anything they interpolate around this text (see
 // NoteBody): identity fields are single-lined before they reach here.

--- a/internal/thread/note.go
+++ b/internal/thread/note.go
@@ -574,7 +574,16 @@ func singleLine(s string) string {
 // (walking back to a rune boundary) and appends a 3-byte "…", so the result
 // can be up to n+2 bytes in the worst case. Bytes, because that is what the
 // validator's limit counts.
+//
+// A budget of n <= 0 yields "", matching cutToRuneBoundary's guard rather than
+// diverging from it. Without it `cut := n - 1` is -1, the walk-back's `cut > 0`
+// condition keeps it there, and s[:-1] panics on any non-empty s. No shipped
+// caller passes a non-positive n today — they all pass a positive constant — so
+// this is defence against a future one, not a live fix.
 func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
 	if len(s) <= n {
 		return s
 	}

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -788,17 +788,18 @@ func TestNoteInputCapNeverOvershoots(t *testing.T) {
 // tracking in escapeOKFSections opened.
 //
 // escapeOKFSections skipped any line between ``` markers, modelling a Markdown
-// semantic the READ path does not implement: kbvalidate.Sections
-// (kbvalidate.go:218) iterates every line and calls heading(line) with no fence
-// awareness at all, and internal/catalog has none either. So a note that wrapped
-// its forged headings in a code fence was escaped NOWHERE and parsed EVERYWHERE
-// — HasIncidentSections returned true on a body a human typed into a chat
-// thread, which is exactly what escaping exists to prevent.
+// semantic the READ path did not implement: kbvalidate.Sections iterated every
+// line and called heading(line) with no fence awareness at all. So a note that
+// wrapped its forged headings in a code fence was escaped NOWHERE and parsed
+// EVERYWHERE — HasIncidentSections returned true on a body a human typed into a
+// chat thread, which is exactly what escaping exists to prevent.
 //
-// atxHeadingText's own doc comment already states the rule this violated: "a
-// shape Section accepts and this does not is a hole." A backslash rendering
-// inside a pasted code block is the price of matching the parser that actually
-// runs.
+// The read path has since been reconciled (both parsers share
+// catalog.FencedLines, so a fenced heading is a heading to neither), which means
+// this property now holds for TWO independent reasons. The test is deliberately
+// end-to-end for that: it asserts what a human's note can do to the merge gate,
+// so it keeps failing if EITHER defence is removed, and it does not care which
+// one is currently carrying it.
 func TestNoteBodyCannotForgeOKFSectionsInsideACodeFence(t *testing.T) {
 	msg := "here is my note\n\n```\n## Symptom\nforged symptom\n## Cause\nforged cause\n" +
 		"## Resolution\nforged resolution\n```\n"

--- a/internal/thread/note_test.go
+++ b/internal/thread/note_test.go
@@ -586,6 +586,38 @@ func TestNoteInputCapMidRuneCutStaysValidUTF8(t *testing.T) {
 	})
 }
 
+// TestTruncateNonPositiveBudgetYieldsNothing pins truncate's behaviour for a
+// budget of zero or less, which used to PANIC: `cut := n - 1` gives -1, the
+// walk-back loop's `cut > 0` guard declines to run, and `s[:-1]` on a non-empty
+// string is a slice-bounds-out-of-range.
+//
+// Not a live bug — every caller passes a positive constant (MaxEvidenceItemBytes,
+// maxNoteTitle, maxChatCatalogFieldBytes) — so this is defence, and it is here
+// because its sibling cutToRuneBoundary already carries exactly this guard. Two
+// byte-cutting helpers in one file, one of which crashes on an input the other
+// handles, is a difference a future caller has no way to anticipate.
+//
+// "" rather than "…": n <= 0 is no budget at all, and the ellipsis is 3 bytes.
+// An empty string is the only answer that respects the cap it was given, and it
+// is the answer cutToRuneBoundary already gives.
+func TestTruncateNonPositiveBudgetYieldsNothing(t *testing.T) {
+	for _, n := range []int{0, -1, -100} {
+		for _, s := range []string{"", "a", "hello", "玉玉玉"} {
+			if got := truncate(s, n); got != "" {
+				t.Errorf("truncate(%q, %d) = %q, want \"\"", s, n, got)
+			}
+		}
+	}
+	// Either side of the boundary is unchanged: n=1 leaves room for the mark and
+	// nothing else, and a budget the input already fits in returns it untouched.
+	if got := truncate("hello", 1); got != "…" {
+		t.Errorf("truncate(%q, 1) = %q, want %q", "hello", got, "…")
+	}
+	if got := truncate("hello", 5); got != "hello" {
+		t.Errorf("truncate(%q, 5) = %q, want it unchanged", "hello", got)
+	}
+}
+
 // TestNoteInputCapNonPositiveMeansTheDefault pins capNoteText's documented
 // choice for a caller-supplied maxBytes <= 0: fall back to
 // DefaultMaxNoteBytes rather than "unlimited". Diverging silently from

--- a/website/content/docs/operations/troubleshooting.md
+++ b/website/content/docs/operations/troubleshooting.md
@@ -63,7 +63,7 @@ msg=incident alert=<name> severity=<sev> namespace=<ns> investigate=<bool> reaso
 | signal | meaning | fix |
 |---|---|---|
 | `runlore_leader == 0` on all pods | no leader elected → nothing runs | check the `leases` RBAC and `leader_election` config; look for `msg="acquired leadership"` |
-| `runlore_investigations_throttled_total` rising | rate limiter engaged (`investigation.rate_limit`); `msg="investigation rate limit engaged; throttling…"` | raise `rate_limit.max_per_window` / `window`, or accept the budget |
+| `runlore_investigations_throttled_total` rising | rate limiter engaged (`investigation.rate_limit`); `msg="investigation rate limit engaged; throttling new investigations this window"` | raise `rate_limit.max_per_window` / `window`, or accept the budget |
 | `runlore_investigations_dropped_total` rising | dropped by `rate_limit.max_requeues` or the token-budget hard-stop | see the timeout/budget section below |
 | `runlore_alerts_coalesced_total` rising | folded into an existing batch (`investigation.coalesce`) | expected noise control — one investigation covers the batch |
 | `runlore_alerts_suppressed_total` rising | dropped by the coalescer **cooldown** | expected — a recently-investigated correlation is in cooldown |
@@ -122,7 +122,7 @@ for everything. Check `runlore_curations_total{kind="pr",result=…}` and the cu
 |---|---|---|
 | recalled answer (cache hit) | `msg="skipping curation of a recalled finding (cache hit, not novel)"` | expected — not novel |
 | below the quality bar | `msg="finding below the quality bar; chat-only, no KB artifact"` | expected — `confidence < forge.min_confidence` (default 0.75) |
-| duplicates a catalog entry | `msg="finding duplicates a catalog entry; not filing"` | expected — within `forge.dup_score` |
+| duplicates a catalog entry | `msg="dedup: duplicates a catalog entry; not filing"` | expected — within `forge.dup_score` |
 | coalesced onto an open PR | `msg="finding coalesced onto an open PR"` (`result="coalesced"`) | expected — added to an existing PR |
 | **opened** | `msg="curated as PR"` with the `url` | success |
 | **error** | `msg="curate findings"` with `err=` (`result="error"`) | a forge/GitHub-App problem — check App scopes & `forge.kb_repo` |


### PR DESCRIPTION
Five small findings accumulated across this review programme. All five confirmed; three turned up more than was reported.

## 1. Defaults resolved in the wrong place

`app.BuildCurator` coalesced `dup_score 0 → 5.0` and `min_confidence 0 → 0.75`; `config.ApplyDefaults` had neither, so any path not going through `BuildCurator` saw `0`. It had already cost something: `internal/telemetry/buckets_alignment_test.go` asserted a bare `5.0` **literal**, with a comment explaining that there was no resolved value to read.

**Two more keys had the same problem** — `hybrid_min_score` / `hybrid_margin_gap` in `appendKBTools`. All four moved into `ApplyDefaults`, and the telemetry guard now reads `cfg.Forge.DupScore` like its siblings.

## 2. `truncate` panicked on a non-positive budget

`cut := n - 1 = -1`, the `cut > 0` walk-back declines to run, `s[:-1]` panics. Unreachable today, so this is defence. **My brief named the wrong sibling** — the function with the existing guard is `cutToRuneBoundary`, not `truncateWords`; the fix matches its `""` return.

## 3. The two startup-warning guards are now one

Merged into `TestEveryStartupWarningIsRaisedExactlyOnce`, taking the stronger half of each axis — `internal/`+`cmd/` scope, both call spellings, exactly-one call site, same-*statement* raise — plus one deliberate strengthening (raiser narrowed to `.Warn`).

**Mutation found two defects in the merge that reading did not**: call sites were keyed per *function*, so two raises inside one function collapsed to one — the self-test fixture had happened to put its pair in two different functions — and shrinking the scan roots back to package `app` still passed, because a scanner that stops looking finds nothing to complain about. The walk now counts parsed files against a floor.

## 4. The fence disagreement was reachable, with a live victim

`kbvalidate.Sections` and `catalog.Entry.Section` scanned the same markdown with different fence semantics. In shipped test data, `harbor-helmrelease-terminal-failed.md` opens its resolution command block with `# only the failed release exists (…)`. Read fence-blind, that comment **is** an H1 — so the Resolution section stopped at the fence, losing the `--reset` explanation, the verification step, and the *"human-approved, not a blind bulk sweep"* warning.

Verified after the fix: that section now yields 882 bytes and contains all three. In the other direction, `okf-format.md` reads as a complete Incident purely because its example sits inside a fence.

**Reconciled rather than documented** — `catalog.FencedLines` is now the single scanner both call, so they cannot drift again. The whole corpus was measured before the change: **0 entries change validation verdict, 0 unbalanced fences**, one flip (`okf-format.md`, correct).

Two differences are deliberately kept and now pinned: `Sections` keeps fence *content* (a resolution's command block is part of the resolution), and it reads only H1/H2, because widening to H1–H6 would empty the Symptom of any entry using a `### Details` sub-heading and reject an entry that passes today.

Note `Entry.Section` is unchanged in purpose — it returns the first *prose* paragraph as a quotable excerpt and still skips fences deliberately. I checked that specifically, having first misread it as a regression.

## 5. Two quoted log lines had drifted, not one

Line 125 (`finding …` → `dedup: duplicates a catalog entry; not filing`) and line 66, where an ellipsis elided `throttling new investigations this window`. The other 27 quotes on the page are exact.

`docsguard` **can** pin these cheaply, so it does now: every slog call's literal message under `internal/`+`cmd/` is parsed (following the `logsProviderIDs` precedent) and exact equality required, with floors on both inertness modes. Its self-test only passed after the matcher was extracted so the test runs the **real** comparison rather than a restatement of it.

## Testing

Mutations per finding: 2 / 1 / 8 / 6 / 7, all caught. hugo exit 0, `check-anchors.sh` exit 0 (418 in-page + 66 cross-page). Gate: build, vet, `-race`, gofmt silent, `golangci-lint` `0 issues`.

## Merge note

Finding 4 touches `catalog.Entry.Section`, which the recall and notification read paths use. Behaviour is unchanged on the current corpus (measured), but it is the widest blast radius of the five — worth reviewing on its own commit, `e20ed8f`.

Finding 2 will conflict with #499, which adds a `truncateWords` alongside `truncate`. Whichever lands second should keep both guards.
