### PR TITLE
fix(whatchanged): refuse a non-ASCII host in hostOf, and repair two post-merge guards

### DIFF
--- a/internal/docsguard/operator_note_recall_test.go
+++ b/internal/docsguard/operator_note_recall_test.go
@@ -44,7 +44,7 @@ func filedOperatorNote(t *testing.T) (description, body string) {
 // reviewer is asked to accept as a causal chain, so if the filer stops saying it — or
 // starts saying something that reads as evidence — the quotation is stale and the
 // paragraph's whole argument has to be re-derived.
-var noteDescriptionRE = regexp.MustCompile(`^Operator knowledge captured from a \w+ thread by @\S+\.$`)
+var noteDescriptionRE = regexp.MustCompile(`^Operator knowledge from @\S+ via \w+(, on the finding ".*")?(: .+|\.)$`)
 
 // TestOperatorNoteFilesNoCausalEvidence derives the two facts learning-loop.md §10
 // rests on, from the code that decides them:
@@ -77,7 +77,7 @@ func TestOperatorNoteFilesNoCausalEvidence(t *testing.T) {
 	// The page quotes the same sentence, elided the way prose elides it (and wrapped,
 	// so the line break is part of the match). Anchored on both ends of the real
 	// sentence, so a rewritten description leaves a quotation that no longer exists.
-	if doc := readDoc(t, operatorNotePage); !strings.Contains(doc, "Operator knowledge captured\n  from a … thread by @…") {
+	if doc := readDoc(t, operatorNotePage); !strings.Contains(doc, "Operator knowledge from @… via …, on the finding \"…\": …") {
 		t.Errorf("learning-loop.md §10 no longer quotes the description an operator note actually files (%q) — "+
 			"without it the paragraph asserts a rejection reason the reader cannot check", description)
 	}

--- a/internal/foldguard/foldguard_test.go
+++ b/internal/foldguard/foldguard_test.go
@@ -146,20 +146,33 @@ func TestEveryCaseFoldedHostComparisonIsPinned(t *testing.T) {
 // internationalised self-hosted forge — and belongs in its own change with its
 // own tests. What the inventory buys is that the list cannot GROW in silence.
 //
-// A FIXED SITE STILL NEEDS AN ENTRY, and that is deliberate. The remediation both
-// incidents converged on refuses non-ASCII input; it does not remove the fold, so
-// the comparison is still here and this reader still sees it. Verified against
-// fix/gitops-ssh-repourl-normalise: after the ASCII guard lands, whatchanged's
-// effectiveCloneURL and sshToHTTPS still report, and the branch will have to add
-// two entries here saying so. That is the entry doing its job — the prose is where
-// "this one is protected, and by what" gets written down, which is exactly the
-// knowledge #495 was missing when it reused a fold that predated it.
+// A site whose fix refuses non-ASCII AT THE FOLD leaves this list, because the
+// reader stops seeing a fold that can disagree with IDNA. A site whose fix refuses
+// it somewhere else — in a caller, in a sibling function — stays, and its entry
+// carries where. Both kinds have happened here, and the difference is worth
+// knowing: whatchanged's auth and effectiveCloneURL left when hostOf itself began
+// refusing non-ASCII, while sshToHTTPS remains because its refusal guards the
+// input rather than the comparison.
+//
+// Writing these entries is not paperwork. The auth entry was drafted asserting
+// that TokenHost being a bare ASCII host made the comparison safe; checking that
+// claim instead of shipping it found a live leak — an https:// repoURL never
+// passes through the SSH-side refusal, so a homoglyph host folded to the
+// configured one, took the token, and was dialled at its punycode form. The prose
+// is where "this one is protected, and by what" gets written down, which is
+// exactly the knowledge #495 was missing when it reused a fold that predated it.
 var knownHostComparisons = map[string]string{
-	"whatchanged auth": "confines a GitHub App installation token to TokenHost. This is instance 1's " +
-		"package. The fold is hostOf's strings.ToLower; the ASCII refusal that closes it lands in " +
-		"sshToHTTPS on fix/gitops-ssh-repourl-normalise. Until that merges, an HTTPS clone URL with a " +
-		"non-ASCII host still reaches auth — a hole that PREDATES the SSH rewrite and is called out in " +
-		"effectiveCloneURL's own 'WHAT THIS DOES NOT DO' comment.",
+	"whatchanged sshToHTTPS": "round-trip guard: the rewritten URL must re-parse to exactly the host " +
+		"go-git resolved, compared with EqualFold. PROTECTED by the isASCII(ep.Host) refusal a few " +
+		"lines above it in the same function — both operands are ASCII by then, so simple folding and " +
+		"IDNA cannot disagree. EqualFold rather than ToLower is deliberate here: ASCII case is the only " +
+		"difference a faithful rewrite may introduce.",
+
+	"config validateForgeGitHost": "validates the operator-supplied forge.git_host. PROTECTED, and it " +
+		"is the protection the whatchanged auth entry above depends on: it refuses anything that is not " +
+		"a bare ASCII hostname, so the value every clone host is later compared against can never be " +
+		"the fold-equal half of an IDNA-different pair. Loosening this to accept an IDN would reopen " +
+		"instance 1 through the HTTPS path rather than the SSH one.",
 
 	"httpx DenyInternalRedirect": "decides whether to strip provider key headers when a redirect " +
 		"changes host. UNPROTECTED: neither hostname is ASCII-checked. The exploitable direction is " +

--- a/internal/whatchanged/differ.go
+++ b/internal/whatchanged/differ.go
@@ -365,21 +365,35 @@ func isASCII(s string) bool {
 // hostOf returns the lowercased host of an https/http/ssh clone URL, or "" for
 // a local path or an unparseable/hostless URL.
 //
-// Two callers, and the second is stricter than the first. auth uses it to confine
-// a host-scoped token: a "" host never equals a non-empty TokenHost, so a local
-// clone is always treated as off-host (correct — local repos need no token).
-// effectiveCloneURL uses it to AUTHORIZE turning an SSH URL into a live HTTPS
-// request, which demands that the host named here be the host that is actually
-// dialled. strings.ToLower does not guarantee that for non-ASCII input, so
-// sshToHTTPS refuses non-ASCII hosts before this is ever consulted for that
-// decision. Anything else routed through here for an authorization decision needs
-// the same precaution.
+// Both callers use it for an AUTHORIZATION decision, so a non-ASCII host is
+// refused here rather than at either call site.
+//
+// strings.ToLower is Unicode simple case mapping; net/http resolves the same host
+// through idna.Lookup.ToASCII, and the two disagree. ToLower maps U+0130 to plain
+// 'i', so "gİthub.com" reads as "github.com" here while the request is dialled at
+// the separately registrable "xn--github-qyd.com". A host that compares equal to
+// TokenHost and resolves elsewhere is precisely how an installation token reaches
+// a stranger.
+//
+// sshToHTTPS already refuses the class on the rewrite path, and that was mistaken
+// for sufficient: an https:// repoURL never passes through it, so
+// "https://gİthub.com/org/repo.git" — cluster state anyone with Application create
+// can set — folded to the configured host, collected the token and dialled the
+// punycode one. Refusing here closes both paths with one check, and a "" host
+// never equals a non-empty TokenHost, so the failure is a withheld credential
+// rather than a misdirected one.
 func hostOf(cloneURL string) string {
 	u, err := url.Parse(cloneURL)
 	if err != nil {
 		return ""
 	}
-	return strings.ToLower(u.Hostname())
+	h := u.Hostname()
+	for i := 0; i < len(h); i++ {
+		if h[i] >= 0x80 {
+			return ""
+		}
+	}
+	return strings.ToLower(h)
 }
 
 // Remote clones url to disk (auth via the installation token when set) and diffs

--- a/internal/whatchanged/differ_test.go
+++ b/internal/whatchanged/differ_test.go
@@ -479,3 +479,20 @@ func TestRevisionsInWindowZeroWindow(t *testing.T) {
 		t.Fatalf("want 2 in-window revisions via clone, got %d: %+v", len(revs), revs)
 	}
 }
+
+// TestHostOfRefusesANonASCIIHost pins the fold that instance 1 was exploited
+// through, on the HTTPS path that the SSH-side refusal does not cover.
+//
+// strings.ToLower maps U+0130 to 'i' while idna.Lookup.ToASCII maps it to
+// i+U+0307, so "gİthub.com" compares equal to "github.com" here and resolves to
+// "xn--github-qyd.com" on the wire. Returning "" makes it unequal to any
+// configured TokenHost, so the token is withheld rather than misdirected.
+func TestHostOfRefusesANonASCIIHost(t *testing.T) {
+	if got := hostOf("https://g\u0130thub.com/o/r.git"); got != "" {
+		t.Errorf("hostOf = %q, want \"\" — a host that folds to the credential's host but "+
+			"resolves elsewhere is how an installation token reaches a stranger", got)
+	}
+	if got := hostOf("https://GitHub.com/o/r.git"); got != "github.com" {
+		t.Errorf("hostOf = %q, want github.com — ASCII case folding must still work", got)
+	}
+}

--- a/website/content/docs/concepts/learning-loop.md
+++ b/website/content/docs/concepts/learning-loop.md
@@ -815,10 +815,17 @@ Honesty is part of the design:
   So there is never a recallable entry that is *both* the operator's words and an
   evidence chain: on the primary route the note is not an entry, and on the standalone
   route the entry has neither section — only the words, under a one-line description
-  saying exactly where they came from: *"Operator knowledge captured
-  from a … thread by @…"*.
+  that names their provenance and then quotes the note's own claim:
+  *"Operator knowledge from @… via …, on the finding "…": …"*.
 
-  That description is nearly all the adversarial reviewer ever sees of it.
+  That description is nearly all the adversarial reviewer ever sees of it, and it
+  is worth being precise about what changed: it used to be pure boilerplate, naming
+  the author and transport and nothing else, so the reviewer was asked to judge a
+  claim it could not read. Since the note-identity fix it carries the operator's
+  actual words. **The four measured rejections below predate that change**, so what
+  they establish is that a note *as filed then* carried nothing admissible — not
+  that a reviewer shown the claim would still reject it. That has not been
+  re-measured.
   `renderForReview` shows each root cause's **summary** — on the recall path, the entry's
   title and description — plus its evidence bullets and the confirm step's tool
   transcript. **The entry's body never reaches the reviewer**, which is exactly why


### PR DESCRIPTION
`main` went red after the batch landed: two guards fired on combinations no single PR's CI could see. One of them was right about something worse than drift.

## The guard found a live token leak that #515 did not close

`foldguard`'s host-comparison pin listed the sites #498 would have to acknowledge once it merged. **Writing that acknowledgement is what found the hole.** The entry was drafted claiming `whatchanged auth` was safe because `TokenHost` is a bare ASCII host — checking the claim rather than shipping it showed it false:

```
https://gİthub.com/org/repo.git
  hostOf → "github.com"   == TokenHost "github.com"   → token attached
  net/http dials            xn--github-qyd.com
```

`sshToHTTPS` refuses non-ASCII on the **rewrite** path, but an `https://` repoURL never passes through it. So #515 confined the credential to a host while the confinement comparison itself still used the vulnerable fold. Reproduced against `main` before fixing; the repoURL is cluster state anyone who can create an Application may set.

`hostOf` now refuses any host carrying a byte above 7-bit ASCII, which closes both paths **at the fold** rather than at one caller. A `""` host never equals a non-empty `TokenHost`, so the failure is a *withheld* credential, not a misdirected one. The legitimate ASCII path is unchanged and pinned beside it.

That fix removes `auth` and `effectiveCloneURL` from the population the pin tracks, so their entries go with them — *"a pin that has stopped matching is an acknowledgement that has silently become permanent"*, which the guard says about itself. The rationale now lives in `hostOf`'s doc comment, where the next reader of that function will find it.

## The other failure was ordinary drift

`docsguard`'s operator-note guard fired because #499 changed `conceptDescription` to carry the note's own claim, while #511 quoted the old boilerplate. Neither PR could see the other.

Regex and quotation updated together — and the paragraph now says what actually changed: **the four measured rejections predate a description that carried no claim at all**, so they establish that a note *as filed then* carried nothing admissible, not that a reviewer shown the claim would still reject it. That has not been re-measured, and the page now says so rather than implying otherwise.

## Testing

`TestHostOfRefusesANonASCIIHost` pins the fix; reverting the refusal fails it with the reason. Full gate green: build, vet, `-race`, gofmt silent, `golangci-lint` `0 issues`.

## Worth noting for the process

Both failures are the guards working. Neither could have been caught by the PRs that caused them, because each was green in isolation — the combination only exists on `main`. That is an argument for these guards existing, not against the merge order.
