### PR TITLE
fix(gitlab): give the note-append the guards its own doc claimed

### DIFF
--- a/internal/forge/gitlab/noteappend.go
+++ b/internal/forge/gitlab/noteappend.go
@@ -10,10 +10,24 @@ package gitlab
 //
 // "Mirrors" is a claim about the SAFETY PROPERTIES, not only about the shape.
 // Every guard the GitHub sibling has, this has; where GitLab spells one
-// differently the difference is stated at the guard rather than left for a
-// reader to infer from its absence — see last_commit_id below, which an earlier
-// version of this file omitted while still claiming the mirror, and so shipped
-// a read-modify-write that silently reverted whoever it raced.
+// differently the difference is stated AT the guard rather than left for a
+// reader to infer from its absence.
+//
+// That sentence has been false twice, both times because the sentence was
+// cheaper to write than the guard, so it is worth naming what it now covers:
+//
+//   - last_commit_id, which an earlier version omitted outright, then sent only
+//     when the read happened to return one — so an absent value silently
+//     downgraded the Commits API to an unconditional overwrite, the very
+//     read-modify-write revert the field exists to prevent. commitEntry now
+//     refuses instead.
+//   - the truncated-listing refusal, which had no GitLab spelling at all.
+//     GitHub's is a full-page check; `/changes` is not paginated, so a full page
+//     is not a signal here and its absence was not safety. Read `overflow` and
+//     changes_count below.
+//
+// The rule this file works under: a guard the sibling has is either present
+// here, or the sentence above is edited. Not the third thing.
 
 import (
 	"context"
@@ -21,11 +35,20 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/Smana/runlore/internal/okf"
 	"github.com/Smana/runlore/internal/providers"
 )
+
+// maxChangedPaths is the ceiling on how large a merge request this will commit
+// into. Deliberately the same number as github.prFilesPerPage so the two forges
+// refuse the identically shaped request, but it is NOT the same kind of number:
+// GitHub's is a page size doing double duty, while `/changes` takes no page
+// parameter, so this one is only the sanity ceiling. A RunLore curation request
+// changes at most three files (the entry plus the reserved index.md / log.md).
+const maxChangedPaths = 100
 
 // AppendToEntryOnPR appends body to the KB entry file carried by the merge
 // request with this iid, as one further commit on that merge request's OWN
@@ -55,7 +78,12 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body, key st
 		SourceBranch    string `json:"source_branch"`
 		SourceProjectID int64  `json:"source_project_id"`
 		TargetProjectID int64  `json:"target_project_id"`
-		Changes         []struct {
+		// Overflow is GitLab's truncation signal, and ChangesCount the count it
+		// computed for itself — both read below, because a listing that was cut is
+		// not a listing to choose a file to rewrite out of.
+		Overflow     bool   `json:"overflow"`
+		ChangesCount string `json:"changes_count"`
+		Changes      []struct {
 			NewPath string `json:"new_path"`
 		} `json:"changes"`
 	}
@@ -80,9 +108,49 @@ func (c *Client) AppendToEntryOnPR(ctx context.Context, number int, body, key st
 	// main. Comparing the two project ids needs no extra lookup and no knowledge
 	// of either id: on a same-project merge request they are equal by
 	// construction.
+	// Two ids GitLab did not send compare EQUAL, which is the one input on which
+	// "the ids match" stops meaning "same-project merge request" — and the branch
+	// named would then be committed onto c.projectPath regardless of where it
+	// lives. GitHub's fork guard fails closed on its missing field for free (an
+	// absent full_name never equals the configured owner/repo); this comparison
+	// does not, so the absence is refused explicitly.
+	if mr.SourceProjectID == 0 || mr.TargetProjectID == 0 {
+		return fmt.Errorf("gitlab MR %d: response names no source/target project (source %d, target %d); refusing to commit without knowing which project the source branch is in",
+			number, mr.SourceProjectID, mr.TargetProjectID)
+	}
 	if mr.SourceProjectID != mr.TargetProjectID {
 		return fmt.Errorf("gitlab MR %d: source branch is in project %d, not the target project %d (fork); refusing to commit",
 			number, mr.SourceProjectID, mr.TargetProjectID)
+	}
+	// The GitLab spelling of GitHub's truncated-listing refusal, which is where
+	// the two most needed stating apart: GitHub reads truncation off a FULL PAGE,
+	// because its file listing is paginated. `/changes` takes no page parameter at
+	// all (only access_raw_diffs and unidiff), so there is no full page to notice
+	// and its absence is not safety. GitLab truncates on DIFF SIZE instead — max
+	// files, max lines, max patch bytes — and reports that it did in `overflow`. A
+	// merge request of five huge files can come back holding two changes, far under
+	// any count ceiling, and okf.EntryFile would resolve "the one .md" out of that
+	// fraction with no way to know it did — the outcome its own doc calls strictly
+	// worse than refusing.
+	if mr.Overflow {
+		return fmt.Errorf("gitlab MR %d: the changes listing overflowed GitLab's diff limits and is truncated; refusing to pick an entry from it", number)
+	}
+	// The half that does not depend on `overflow` being emitted. changes_count is
+	// the count GitLab computed for ITSELF, so it disagreeing with the array handed
+	// over says the array is not the whole listing. It is a string because it is
+	// capped: past the file limit GitLab answers "1000+", which does not parse.
+	// Empty does not parse either, and is GitLab's documented "the diff is still
+	// being computed" — not a statement that this listing is complete, so it is
+	// refused rather than read as agreement.
+	if n, err := strconv.Atoi(mr.ChangesCount); err != nil || n != len(mr.Changes) {
+		return fmt.Errorf("gitlab MR %d: changes_count %q does not account for the %d changed paths returned; refusing to pick an entry from a listing that may be cut",
+			number, mr.ChangesCount, len(mr.Changes))
+	}
+	// The other thing GitHub's full page refuses, independently of truncation: a
+	// merge request this large is not a RunLore curation request, so whichever file
+	// okf.EntryFile resolves is a file somebody else is changing.
+	if len(mr.Changes) >= maxChangedPaths {
+		return fmt.Errorf("gitlab MR %d: %d changed paths; not a curation merge request, refusing to pick an entry from it", number, len(mr.Changes))
 	}
 	changed := make([]string, 0, len(mr.Changes))
 	for _, ch := range mr.Changes {
@@ -168,20 +236,27 @@ func (c *Client) getEntryFile(ctx context.Context, path, ref string) (data []byt
 }
 
 // commitEntry writes content back to path on branch as one update action,
-// refusing if anything committed to that file since lastCommit.
+// refusing if anything committed to that file since lastCommit — and refusing
+// outright if there is no lastCommit to write against.
 //
 // GitLab answers a stale last_commit_id with 400 ("You are attempting to update
 // a file that has changed since you started editing it"), which is exactly the
 // outcome wanted: the racing writer keeps their commit, and this note goes down
 // the caller's comment fallback instead of overwriting them.
 func (c *Client) commitEntry(ctx context.Context, path, branch, lastCommit, content string) error {
-	action := map[string]any{
-		"action":    "update",
-		"file_path": path,
-		"content":   content,
+	// Refused rather than sent without it. An action carrying no last_commit_id is
+	// not a weaker write, it is a different one: GitLab applies it unconditionally,
+	// which turns this read-modify-write into exactly the silent revert the whole
+	// file exists to avoid. The check lives here, at the only place that builds the
+	// action, so no caller can reintroduce the downgrade by passing "".
+	if lastCommit == "" {
+		return fmt.Errorf("gitlab commit %s on %s: no last_commit_id to write against; refusing an unconditional overwrite", path, branch)
 	}
-	if lastCommit != "" {
-		action["last_commit_id"] = lastCommit
+	action := map[string]any{
+		"action":         "update",
+		"file_path":      path,
+		"content":        content,
+		"last_commit_id": lastCommit,
 	}
 	return c.do(ctx, http.MethodPost, fmt.Sprintf("/projects/%s/repository/commits", c.projectSeg()), map[string]any{
 		"branch":         branch,

--- a/internal/forge/gitlab/noteappend_test.go
+++ b/internal/forge/gitlab/noteappend_test.go
@@ -8,9 +8,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -36,6 +38,21 @@ type stubMR struct {
 	entry    string
 	encoding string // "base64" unless set
 
+	// overflow is GitLab's truncation signal on /changes: true when the diff
+	// limits (max files, lines, patch bytes) cut the listing being returned.
+	overflow bool
+	// changesCount overrides changes_count, which defaults to agreeing with the
+	// changes array. "-" serves it EMPTY, which is what GitLab answers while a
+	// freshly created merge request's diff is still being computed.
+	changesCount string
+	// noProjects omits source_project_id / target_project_id entirely, the shape
+	// in which a zero-value id can reach the fork guard.
+	noProjects bool
+	// noLastCommitID serves the entry with an empty last_commit_id, which is the
+	// only input that can turn the Commits API write into an unconditional
+	// overwrite.
+	noLastCommitID bool
+
 	// commitStatus, when non-zero, is the status the Commits API answers with —
 	// 400 is what a stale last_commit_id gets.
 	commitStatus int
@@ -56,7 +73,9 @@ func (s *stubMR) start(t *testing.T) *Client {
 	} else {
 		s.content = cmp.Or(s.content, noteEntry)
 	}
-	s.lastCommit = "commit0"
+	if !s.noLastCommitID {
+		s.lastCommit = "commit0"
+	}
 	if s.changed == nil {
 		s.changed = []string{"index.md", "log.md", "concepts/oom-1.md"}
 	}
@@ -74,10 +93,20 @@ func (s *stubMR) start(t *testing.T) *Client {
 			if src == 0 {
 				src = 7
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
+			count := cmp.Or(s.changesCount, strconv.Itoa(len(s.changed)))
+			if count == "-" {
+				count = ""
+			}
+			payload := map[string]any{
 				"state": cmp.Or(s.state, "opened"), "source_branch": cmp.Or(s.branch, "runlore/kb-oom-1"),
 				"source_project_id": src, "target_project_id": 7, "changes": changes,
-			})
+				"changes_count": count, "overflow": s.overflow,
+			}
+			if s.noProjects {
+				delete(payload, "source_project_id")
+				delete(payload, "target_project_id")
+			}
+			_ = json.NewEncoder(w).Encode(payload)
 		case strings.Contains(path, "/repository/files/"):
 			s.mu.Lock()
 			defer s.mu.Unlock()
@@ -230,8 +259,16 @@ func TestAppendToEntryOnPRPropagatesAConflict(t *testing.T) {
 func TestAppendToEntryOnPRRefusesAnUnreadableEntry(t *testing.T) {
 	s := &stubMR{encoding: "none"}
 	c := s.start(t)
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err == nil {
+	err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1")
+	if err == nil {
 		t.Fatal("want an error: a read that returns nothing must never be treated as an empty entry")
+	}
+	// Named, not merely non-nil. An unreadable body decodes to zero bytes, which
+	// the frontmatter guard behind this one also refuses — so without naming the
+	// encoding this test scores that guard and would keep passing with the read's
+	// own check deleted.
+	if !strings.Contains(err.Error(), "encoding") {
+		t.Errorf("err = %v, want the read to refuse the encoding rather than lean on the guard behind it", err)
 	}
 	if commits := s.writes(); len(commits) != 0 {
 		t.Fatalf("the entry was rewritten from an unreadable read: %+v", commits)
@@ -391,10 +428,18 @@ func TestAppendToEntryOnPRRefusesWhenTheEntryIsAmbiguous(t *testing.T) {
 // TestAppendToEntryOnPRRefusesWithoutASourceBranch: an MR payload with no
 // source_branch must not become a commit onto the empty branch name, which
 // GitLab would resolve to the project default.
+//
+// The payload is healthy in every OTHER respect — three changed paths naming one
+// entry, matching changes_count, same-project ids — deliberately. An earlier
+// version served no changes at all, so deleting the guard under test still
+// produced an error (from okf.EntryFile, one line further down) and the test went
+// on passing while pinning nothing.
 func TestAppendToEntryOnPRRefusesWithoutASourceBranch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.EscapedPath(), "/merge_requests/84/changes") {
-			_, _ = w.Write([]byte(`{"state":"opened","source_project_id":7,"target_project_id":7,"changes":[]}`))
+			_, _ = w.Write([]byte(`{"state":"opened","source_project_id":7,"target_project_id":7,` +
+				`"changes_count":"3","overflow":false,"changes":[{"new_path":"index.md"},` +
+				`{"new_path":"log.md"},{"new_path":"concepts/oom-1.md"}]}`))
 			return
 		}
 		t.Errorf("reached %s %s past the source-branch guard", r.Method, r.URL.EscapedPath())
@@ -403,7 +448,100 @@ func TestAppendToEntryOnPRRefusesWithoutASourceBranch(t *testing.T) {
 	defer srv.Close()
 
 	c := New(srv.URL, "o/r", "main", staticToken("tok"))
-	if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+	err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1")
+	if err == nil {
 		t.Fatal("want an error when the merge request names no source branch")
+	}
+	if !strings.Contains(err.Error(), "source branch") {
+		t.Errorf("err = %v, want the source-branch refusal rather than whatever a later guard happened to catch", err)
+	}
+}
+
+// TestAppendToEntryOnPRRefusesATruncatedChangesListing is the GitLab spelling of
+// github's full-page refusal, and the guard whose absence made this client's
+// "every guard the sibling has" claim false.
+//
+// `/changes` takes no page parameter, so there is no full page to notice. GitLab
+// truncates on DIFF SIZE instead and says so in `overflow`; changes_count is the
+// count it computed for itself, capped to the string "1000+" past the file
+// limit. Each of those is a listing okf.EntryFile would resolve just as cleanly
+// to the wrong file — the changed paths here are the healthy three, so nothing
+// but the truncation signal can produce the refusal.
+func TestAppendToEntryOnPRRefusesATruncatedChangesListing(t *testing.T) {
+	for name, s := range map[string]*stubMR{
+		"overflow":               {overflow: true},
+		"count past the cap":     {changesCount: "1000+"},
+		"count exceeds listing":  {changesCount: "40"},
+		"count not yet computed": {changesCount: "-"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := s.start(t)
+			if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+				t.Fatal("want a refusal: a truncated listing cannot be told from a complete one")
+			}
+			if commits := s.writes(); len(commits) != 0 {
+				t.Errorf("committed from a truncated listing: %+v", commits)
+			}
+		})
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAnOversizedChangesListing is the other half of what
+// github's full-page check refuses: a merge request this large is not a RunLore
+// curation request (entry plus, at most, the reserved index.md and log.md),
+// whatever GitLab reports about truncation.
+//
+// Reproduces the divergence directly: a hundred changed paths of which exactly
+// one is a non-reserved .md is a listing okf.EntryFile resolves without
+// complaint, so before this guard GitLab answered nil and committed into
+// someone else's file inside a human's open merge request, while GitHub refused
+// the identically shaped pull request.
+func TestAppendToEntryOnPRRefusesAnOversizedChangesListing(t *testing.T) {
+	changed := []string{"concepts/oom-1.md"}
+	for i := range maxChangedPaths - 1 {
+		changed = append(changed, fmt.Sprintf("chart/values-%d.yaml", i))
+	}
+	s := &stubMR{changed: changed}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+		t.Fatal("want a refusal: a merge request this size is not a curation merge request")
+	}
+	if commits := s.writes(); len(commits) != 0 {
+		t.Errorf("committed from an oversized listing: %+v", commits)
+	}
+}
+
+// TestAppendToEntryOnPRRefusesWithoutALastCommitID: the Commits API treats a
+// missing last_commit_id as "overwrite unconditionally", so sending the action
+// without it is not a weaker write, it is the read-modify-write this file exists
+// to avoid — a reviewer's Web IDE edit reverted with nothing reporting it.
+//
+// GitHub's counterpart cannot reach that state: its contents API rejects a PUT
+// over an existing file with no sha. GitLab's accepts it, so the refusal has to
+// be spelled here.
+func TestAppendToEntryOnPRRefusesWithoutALastCommitID(t *testing.T) {
+	s := &stubMR{noLastCommitID: true}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "the second note", "k1"); err == nil {
+		t.Fatal("want an error: an absent last_commit_id must not downgrade the write to an unconditional overwrite")
+	}
+	if commits := s.writes(); len(commits) != 0 {
+		t.Fatalf("sent an unconditional overwrite: %+v", commits)
+	}
+}
+
+// TestAppendToEntryOnPRRefusesAnMRWithoutProjectIDs: the fork guard compares two
+// ids, so a response carrying NEITHER compares 0 against 0 and passes — the one
+// input on which "equal ids" stops meaning "same-project merge request". GitHub's
+// fork guard fails closed on its missing field (an empty full_name never equals
+// the configured repo), so this one has to as well.
+func TestAppendToEntryOnPRRefusesAnMRWithoutProjectIDs(t *testing.T) {
+	s := &stubMR{noProjects: true, branch: "main"}
+	c := s.start(t)
+	if err := c.AppendToEntryOnPR(context.Background(), 84, "note", "k1"); err == nil {
+		t.Fatal("want a refusal rather than reading two absent ids as a same-project merge request")
+	}
+	if commits := s.writes(); len(commits) != 0 {
+		t.Errorf("committed onto %v without knowing which project the branch is in", commits)
 	}
 }


### PR DESCRIPTION
`internal/forge/gitlab/noteappend.go` opens by claiming that every guard the GitHub sibling has, this has, with any difference in spelling stated *at* the guard. Two guards were absent and a third failed open on a missing field.

Each was reproduced against the pre-fix code first — every one returned `err=<nil>` and sent a commit:

```
oversized 100 paths  err=<nil>  commits=1  file=concepts/oom-1.md  branch=runlore/kb-oom-1
overflow=true        err=<nil>  commits=1  file=concepts/oom-1.md  branch=runlore/kb-oom-1
changes_count 1000+  err=<nil>  commits=1  file=concepts/oom-1.md  branch=runlore/kb-oom-1
no last_commit_id    err=<nil>  commits=1  last_commit_id=<nil>    branch=runlore/kb-oom-1
no project ids       err=<nil>  commits=1                          branch=main
```

### No truncated-listing refusal

GitHub refuses when a file page comes back full, because it cannot tell a full page from a cut one. `/changes` takes no page parameter at all, so there was nothing here to check — and its absence was read as safety. GitLab truncates on **diff size** instead (max files, lines, patch bytes) and reports it in a top-level `overflow` that this never decoded. A merge request of a hundred changed paths holding one non-reserved `.md` resolved cleanly through `okf.EntryFile` and committed into somebody else's file inside a human's open merge request.

Three refusals now: `overflow`; `changes_count` disagreeing with the array returned (it is a string because it caps to `"1000+"`, and empty is GitLab's documented "diff still being computed"); and a `maxChangedPaths = 100` ceiling. `overflow` matters independently of the ceiling — five huge files can come back as two changes, far under any count.

### Optimistic concurrency failed open

`last_commit_id` was sent only when the read happened to return one, so an absent value silently downgraded the Commits API to an unconditional overwrite: the read-modify-write revert of a reviewer's Web IDE edit that the field exists to prevent. GitHub's counterpart cannot reach that state, since its contents API rejects a PUT over an existing file with no sha. The refusal went into `commitEntry`, the only place that builds the action, so no caller can reintroduce the downgrade by passing `""`.

### Fork guard failed open on absent ids

It compares `source_project_id` with `target_project_id`, and two ids GitLab did not send compare **equal** — the one input on which "the ids match" stops meaning "same-project merge request". The named branch would then be committed onto the configured project regardless of where it lives; that is the `branch=main` line above. GitHub's fails closed for free, since an empty `full_name` never equals the configured `owner/repo`.

### The rest of the parity claim, verified rather than trusted

State re-check, fork refusal, frontmatter guard, idempotency marker, landed-recovery, source-branch check, base64 encoding check, `neutralizeImages`, non-2xx handling — all present and equivalent, no further unstated divergence. But **two existing tests were passing without pinning the guard they named**: the source-branch test served zero changes, so deleting its guard still errored one line down in `okf.EntryFile`; the unreadable-entry test was being scored by the frontmatter guard behind it. Both now assert *which* refusal fired.

### Mutation testing

Twelve guards were each deliberately broken and watched failing, with the mutation asserted to have actually applied (match count `== 1` plus a byte-diff check on disk). `changes_count` was additionally run per-subtest: the three count cases die, the `overflow` case survives — killed by its own mutation instead, which is the correct layering.

### The header comment

Rewritten rather than left standing, since overstating a safety property is how this survived review. It now names both holes as things the sentence covered without holding, and ends with the rule: a guard the sibling has is either present here, or the sentence above is edited — not the third thing.

Gate: `go build` · `go vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
