### PR TITLE
fix(chart): make the ClusterRole honest about what it grants

### DIFF
--- a/deploy/helm/runlore/templates/NOTES.txt
+++ b/deploy/helm/runlore/templates/NOTES.txt
@@ -40,14 +40,19 @@ Enable persistence (a ReadWriteMany volume) and keep outcome.ledger_path under
 catalog.mountPath ({{ .Values.catalog.mountPath }}) so both pods share the ledger.
 {{- end }}
 
-{{- if and (dig "notify" "slack" "thread_capture" false .Values.config) (not (and .Values.persistence.enabled (eq .Values.workloadKind "Deployment") (has "ReadWriteMany" .Values.persistence.accessModes))) }}
+{{- if and (or (dig "notify" "slack" "thread_capture" false .Values.config) (dig "notify" "matrix" "thread_capture" false .Values.config)) (not (and .Values.persistence.enabled (eq .Values.workloadKind "Deployment") (has "ReadWriteMany" .Values.persistence.accessModes))) }}
 
-WARNING: notify.slack.thread_capture is enabled, but this deployment shape does
-not durably persist the thread registry that maps a live Slack thread to its
-investigation. POST /slack/events is leader-forwarded, so a pod restart,
-upgrade, or leader failover empties it: a human replying `@runlore note: ...`
-to a thread delivered before that is told RunLore has no context for it, and
-the knowledge is lost right where this feature exists to capture it.
+WARNING: thread_capture is enabled ({{ if dig "notify" "slack" "thread_capture" false .Values.config }}notify.slack.thread_capture{{ end }}{{ if and (dig "notify" "slack" "thread_capture" false .Values.config) (dig "notify" "matrix" "thread_capture" false .Values.config) }} + {{ end }}{{ if dig "notify" "matrix" "thread_capture" false .Values.config }}notify.matrix.thread_capture{{ end }}), but this
+deployment shape does not durably persist the thread registry that maps a live
+chat thread to its investigation. The registry is held by the leader — Slack
+replies arrive on the leader-forwarded POST /slack/events, Matrix replies on the
+leader's outbound /sync long-poll — so a pod restart, upgrade, or leader
+failover empties it: a human replying `@runlore note: ...` to a thread delivered
+before that is told RunLore has no context for it, and the knowledge is lost
+right where this feature exists to capture it. Both transports require
+outcome.ledger_path at config load for exactly this durability, and that check
+cannot see the volume underneath it — this warning is the half Validate cannot
+make.
 Set persistence.enabled=true, workloadKind=Deployment and a ReadWriteMany
 accessMode so every replica shares the same registry across a failover — a
 StatefulSet + ReadWriteOnce volume still gives each replica its OWN copy and

--- a/deploy/helm/runlore/templates/rbac.yaml
+++ b/deploy/helm/runlore/templates/rbac.yaml
@@ -45,11 +45,33 @@ rules:
   # NOTE: execution rights (patch) are intentionally NOT granted cluster-wide here.
   # They are scoped to rbac.actionNamespaces as namespaced Roles below, so a
   # confused/compromised agent cannot mutate flux-system or another team's workloads.
+  # workload_ownership (G4) walks a failing pod's ownerReferences to its TOP controller
+  # (Pod → ReplicaSet → Deployment/StatefulSet/DaemonSet/Job) and reads the GitOps
+  # tracking labels off it. These are the only controller kinds the walk can follow
+  # (internal/providers/cluster/ownership.go, fetchOwner), and the tool is registered
+  # unconditionally whenever the cluster reader is.
+  #
+  # Granted HERE, statically, and NOT left to rbac.resourceSpecRules — even though that
+  # list happens to name the same kinds. They belong to a different consumer, and a
+  # denial on one of them does not surface as an error: it STOPS the walk, and the last
+  # resolvable hop is reported as the top controller. An operator narrowing an allowlist
+  # documented as belonging to resource_spec would otherwise turn every "Deployment X,
+  # owned by Kustomization Y" into a bare "ReplicaSet X" — quietly, suite green.
+  - apiGroups: ["apps"]
+    resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
+    verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get"]
   # resource_spec (read an arbitrary object's .spec/.status): an operator-owned, read-only
   # allowlist of spec-bearing kinds — see rbac.resourceSpecRules in values.yaml, which also
   # explains why a `resources: ["*"]` wildcard must never include secrets. A kind missing
   # from the list is reported to the agent as a DENIAL, never as a missing object, so a gap
   # here degrades the tool rather than fabricating evidence.
+  #
+  # It ships POPULATED — a default grant, not an opt-in menu. `rbac.resourceSpecRules: []`
+  # declines it in full and still renders valid YAML (that is what the guard below is
+  # for), leaving every rule above intact.
   {{- with .Values.rbac.resourceSpecRules }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/deploy/helm/runlore/values-full.yaml
+++ b/deploy/helm/runlore/values-full.yaml
@@ -266,6 +266,15 @@ config:
       app_id: 123456
       installation_id: 7654321
       private_key_env: GITHUB_APP_PRIVATE_KEY
+    # GitHub Enterprise Server only — both keys are absent on github.com.
+    # github_api_url: https://ghe.example.com/api/v3
+    # git_host names the one host RunLore may send the forge credential to when it
+    # clones; it is derived from github_api_url and needed ONLY under subdomain
+    # isolation (API on api.HOSTNAME, git on HOSTNAME), which RunLore refuses to guess:
+    # the pod CrashLoopBackOffs at config load until you set it. Under
+    # networkPolicy.strict above, remember to add BOTH hosts to egress.allowedCIDRs.
+    #   github_api_url: https://api.ghe.example.com
+    #   git_host: ghe.example.com
 
   # Phase-2 grooming. The chart's values.yaml already ships stale_after,
   # recurrence_threshold and the in-server sweeps (DRY-RUN by default — nothing below

--- a/deploy/helm/runlore/values-standard.yaml
+++ b/deploy/helm/runlore/values-standard.yaml
@@ -166,6 +166,14 @@ config:
       app_id: 123456 # from the GitHub App you created
       installation_id: 7654321
       private_key_env: GITHUB_APP_PRIVATE_KEY
+    # GitHub Enterprise Server only — both keys are absent on github.com.
+    # github_api_url: https://ghe.example.com/api/v3
+    # git_host names the one host RunLore may send the forge credential to when it
+    # clones; it is derived from github_api_url and needed ONLY under subdomain
+    # isolation (API on api.HOSTNAME, git on HOSTNAME), which RunLore refuses to guess:
+    # the pod CrashLoopBackOffs at config load until you set it.
+    #   github_api_url: https://api.ghe.example.com
+    #   git_host: ghe.example.com
 
   # Evidence backends: each URL registers the tool it unlocks (query_metrics,
   # query_logs). Leave one out and the agent simply investigates without it.

--- a/deploy/helm/runlore/values.yaml
+++ b/deploy/helm/runlore/values.yaml
@@ -341,6 +341,19 @@ config:
   #   kb_repo: owner/name
   #   base_branch: main
   #   github_app: { app_id: 0, installation_id: 0, private_key_env: GITHUB_APP_PRIVATE_KEY }
+  #   # GitHub Enterprise Server ONLY — omit both for github.com.
+  #   github_api_url: https://ghe.example.com/api/v3
+  #   # git_host is the ONE host the forge credential may be sent to when RunLore clones
+  #   # (what_changed's GitOps repo, source_diff, the catalog git-sync); every other host
+  #   # clones anonymously, because a GitOps spec.source.repoURL is cluster state. It is
+  #   # DERIVED from github_api_url (or gitlab.base_url) and needs no value here — except
+  #   # on GitHub Enterprise with SUBDOMAIN ISOLATION, where the API is served from
+  #   # api.HOSTNAME while git stays on HOSTNAME. That one shape is unresolvable, so
+  #   # RunLore REFUSES TO START until you name the git host — a Helm-only install meets
+  #   # it as a CrashLoopBackOff, not as a warning:
+  #   #   github_api_url: https://api.ghe.example.com   # API (subdomain isolation)
+  #   #   git_host: ghe.example.com                     # git remotes / clone auth
+  #   # Bare hostname only: no scheme, path, port or userinfo.
   # Investigate signals (optional). metrics/logs enable query_metrics/query_logs.
   # metrics: { url: http://vmsingle.observability.svc:8429 }   # PromQL (VictoriaMetrics/Prometheus)
   # Logs backend (query_logs / logs_error_summary / discover_log_fields). The provider is
@@ -503,14 +516,40 @@ rbac:
   # A read-only (get) allowlist of SPEC-BEARING kinds. Add your operators' CRDs here; a
   # kind that is absent is reported to the agent as a denial, never as a missing object.
   #
+  # THIS IS A DEFAULT GRANT, NOT AN OPT-IN MENU. The list below ships POPULATED and is
+  # rendered into the ClusterRole, so a `helm upgrade` that changes no values adds these
+  # 10 rules — 28 resource types, 23 of them granted nowhere else — as cluster-wide `get`
+  # on the ServiceAccount. Read it as "what you are about to grant", not as "examples you
+  # may enable".
+  #
+  # TO DECLINE THE WHOLE GRANT:
+  #
+  #   rbac:
+  #     resourceSpecRules: []      # ClusterRole drops back to its 9 base rules
+  #
+  # An empty list renders cleanly (the template guards the block) and costs you exactly
+  # one tool: resource_spec answers "forbidden" for every kind not already granted above.
+  # It does NOT break workload_ownership — the owner-chain kinds are granted separately
+  # and unconditionally in templates/rbac.yaml, precisely so narrowing this list cannot
+  # silently truncate an owner chain. Narrow the list freely; it is yours to scope.
+  #
   # DO NOT replace this with `resources: ["*"]`. A wildcard includes `secrets`, and the
   # ServiceAccount's token then reads every Secret in the cluster. The tool itself refuses
   # the Secret kind — before AND after resolution — but that refusal is an application-layer
   # policy, not a boundary: RBAC is the boundary. If you must use a wildcard, keep secrets
   # out of the grant.
+  #
+  # Kinds with NEITHER .spec NOR .status are deliberately absent (ServiceAccount,
+  # EndpointSlice, StorageClass, ConfigMap …): the tool renders only those two sections,
+  # so the read returns "spec: (none — this kind has no spec)" while the grant stays
+  # entirely real. serviceaccounts in particular was granted and removed — a cluster-wide
+  # read of every ServiceAccount exposes the IRSA / Workload-Identity role ARNs in its
+  # annotations and names every Secret in its `secrets`/`imagePullSecrets`, and returns
+  # nothing to the tool in exchange. Do not re-add a kind here without checking it has a
+  # spec or a status to read.
   resourceSpecRules:
     - apiGroups: [""]
-      resources: ["services", "persistentvolumeclaims", "persistentvolumes", "nodes", "namespaces", "serviceaccounts"]
+      resources: ["services", "persistentvolumeclaims", "persistentvolumes", "nodes", "namespaces"]
       verbs: ["get"]
     - apiGroups: ["apps"]
       resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
@@ -527,11 +566,11 @@ rbac:
     - apiGroups: ["policy"]
       resources: ["poddisruptionbudgets"]
       verbs: ["get"]
+    # storageclasses is NOT here on purpose: it has no .spec and no .status, so the read
+    # comes back empty. "A PVC bound to a vanished storage class" is answered from the
+    # PVC's own spec/status, which IS granted above.
     - apiGroups: ["storage.k8s.io"]
-      resources: ["storageclasses", "volumeattachments"]
-      verbs: ["get"]
-    - apiGroups: ["discovery.k8s.io"]
-      resources: ["endpointslices"]
+      resources: ["volumeattachments"]
       verbs: ["get"]
     - apiGroups: ["apiextensions.k8s.io"]
       resources: ["customresourcedefinitions"]

--- a/internal/config/chart_rbac_test.go
+++ b/internal/config/chart_rbac_test.go
@@ -3,6 +3,9 @@
 package config
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"slices"
@@ -120,5 +123,327 @@ func TestResourceSpecRBACIsWiredAndWarned(t *testing.T) {
 		if !strings.Contains(string(values), want) {
 			t.Errorf("values.yaml no longer warns about %q next to resourceSpecRules", want)
 		}
+	}
+}
+
+// readStaticClusterRoleRules decodes the rules the ClusterRole template hard-codes —
+// the ones an operator cannot narrow through values. The template is not YAML (it
+// carries Helm actions), so the `rules:` block of the first document is extracted and
+// every template line dropped; what is left is the literal, unconditional grant.
+func readStaticClusterRoleRules(t *testing.T) []policyRule {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(chartDir, "templates", "rbac.yaml"))
+	if err != nil {
+		t.Fatalf("read rbac.yaml: %v", err)
+	}
+	var block []string
+	in := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		if !in {
+			in = line == "rules:"
+			continue
+		}
+		// The rules block ends at the document break or any other column-0 key.
+		if strings.HasPrefix(line, "---") {
+			break
+		}
+		if line != "" && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			break
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), "{{") {
+			continue // a Helm action, not a literal rule
+		}
+		block = append(block, line)
+	}
+	if len(block) == 0 {
+		t.Fatal("no `rules:` block found in templates/rbac.yaml")
+	}
+	var rules []policyRule
+	if err := yaml.Unmarshal([]byte(strings.Join(block, "\n")), &rules); err != nil {
+		t.Fatalf("the static rules of templates/rbac.yaml do not parse as YAML: %v", err)
+	}
+	if len(rules) == 0 {
+		t.Fatal("templates/rbac.yaml renders no static rules at all")
+	}
+	return rules
+}
+
+// grantedGetSet indexes rules as "apiGroup/resource" for the rules that grant `get`.
+func grantedGetSet(rules []policyRule) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range rules {
+		if !slices.Contains(r.Verbs, "get") {
+			continue
+		}
+		for _, g := range r.APIGroups {
+			for _, res := range r.Resources {
+				out[g+"/"+res] = true
+			}
+		}
+	}
+	return out
+}
+
+// clientGroupAccessors maps a client-go typed-client group accessor to the RBAC
+// apiGroup it reads. Only the accessors ownership.go actually uses need an entry; an
+// unmapped one fails the test rather than passing vacuously.
+var clientGroupAccessors = map[string]string{
+	"AppsV1":  "apps",
+	"BatchV1": "batch",
+	"CoreV1":  "",
+}
+
+// ownerWalkGrants derives, from the real source of internal/providers/cluster/ownership.go,
+// every apiGroup/resource the owner-chain walk performs a typed Get on. It reads the
+// `fetchOwner` switch rather than a copy of it: each arm is a
+// `r.client.<GroupAccessor>().<Plural>(ns).Get(...)` chain, and both halves of the RBAC
+// rule fall out of the AST — the accessor names the apiGroup, the method IS the plural
+// resource name. Adding a `case "CronJob"` therefore fails this test until the chart
+// grants batch/cronjobs.
+func ownerWalkGrants(t *testing.T) map[string]bool {
+	t.Helper()
+	src := filepath.Join("..", "providers", "cluster", "ownership.go")
+	f, err := parser.ParseFile(token.NewFileSet(), src, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", src, err)
+	}
+	var fn *ast.FuncDecl
+	for _, d := range f.Decls {
+		if d, ok := d.(*ast.FuncDecl); ok && d.Name.Name == "fetchOwner" {
+			fn = d
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("fetchOwner not found in %s: the owner-walk RBAC guard has lost its parse target", src)
+	}
+	grants := map[string]bool{}
+	ast.Inspect(fn, func(n ast.Node) bool {
+		// Match `<something>.<GroupAccessor>().<Plural>(...)`.
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		inner, ok := sel.X.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		innerSel, ok := inner.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		group, ok := clientGroupAccessors[innerSel.Sel.Name]
+		if !ok {
+			if strings.HasSuffix(innerSel.Sel.Name, "V1") || strings.HasSuffix(innerSel.Sel.Name, "V1beta1") {
+				t.Errorf("fetchOwner reads through the client-go accessor %q, which this guard cannot map "+
+					"to an apiGroup: add it to clientGroupAccessors so its RBAC grant is checked",
+					innerSel.Sel.Name)
+			}
+			return true
+		}
+		grants[group+"/"+strings.ToLower(sel.Sel.Name)] = true
+		return true
+	})
+	if len(grants) == 0 {
+		t.Fatal("no typed Gets found in fetchOwner: the owner-walk RBAC guard is asserting nothing")
+	}
+	return grants
+}
+
+// TestOwnerWalkRBACIsGrantedStatically is the fix for a silent break.
+//
+// workload_ownership walks Pod → ReplicaSet → Deployment/StatefulSet/DaemonSet/Job. Those
+// kinds arrived in the ClusterRole as a side effect of rbac.resourceSpecRules — a list
+// documented as belonging to a DIFFERENT tool. An operator narrowing that allowlist (or
+// setting it to [], which the values file now tells them how to do) would have severed the
+// walk, and it does not fail loudly: fetchOwner treats an error as "top of chain reached",
+// so every "Deployment X, owned by Kustomization Y" silently degrades to a bare
+// "ReplicaSet X" with the whole suite green.
+//
+// So the grant belongs to its consumer: these rules are STATIC in the template, and this
+// test reads both ends — the kinds from the walk's own source, the grant from the template's
+// literal rules.
+func TestOwnerWalkRBACIsGrantedStatically(t *testing.T) {
+	granted := grantedGetSet(readStaticClusterRoleRules(t))
+	for want := range ownerWalkGrants(t) {
+		if !granted[want] {
+			t.Errorf("workload_ownership Gets %q, but no STATIC rule in templates/rbac.yaml grants it: "+
+				"an RBAC denial there does not error, it truncates the owner chain silently", want)
+		}
+	}
+}
+
+// TestOwnerWalkRBACSurvivesDecliningResourceSpec: values.yaml now tells operators that
+// `resourceSpecRules: []` "does NOT break workload_ownership". That promise is only true
+// while the static rules carry the walk, so the claim and the template are checked
+// together — a template edit that folds the owner-chain grants back into the values-driven
+// block turns a documented safe opt-out into a silent truncation.
+func TestOwnerWalkRBACSurvivesDecliningResourceSpec(t *testing.T) {
+	static := grantedGetSet(readStaticClusterRoleRules(t))
+	walk := ownerWalkGrants(t)
+	// The decline path renders the static rules and nothing else.
+	missing := 0
+	for want := range walk {
+		if !static[want] {
+			missing++
+		}
+	}
+	if missing > 0 {
+		t.Errorf("with rbac.resourceSpecRules: [] the ClusterRole misses %d of the %d kinds "+
+			"workload_ownership walks", missing, len(walk))
+	}
+	raw, err := os.ReadFile(filepath.Join(chartDir, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	if !strings.Contains(string(raw), "does NOT break workload_ownership") {
+		t.Error("values.yaml no longer promises that declining rbac.resourceSpecRules leaves " +
+			"workload_ownership intact: that promise is why the opt-out is safe to document")
+	}
+}
+
+// specLessKinds have neither .spec nor .status, so resource_spec renders
+// "spec: (none — this kind has no spec)" for them: the read returns nothing while the
+// cluster-wide grant is entirely real. serviceaccounts, endpointslices and storageclasses
+// all shipped in the default allowlist under the heading "SPEC-BEARING kinds".
+var specLessKinds = []string{
+	"serviceaccounts", // annotations carry IRSA / Workload-Identity role ARNs; names every Secret it mounts
+	"endpointslices",
+	"storageclasses",
+	"configmaps",
+	"endpoints",
+	"roles",
+	"clusterroles",
+	"rolebindings",
+	"clusterrolebindings",
+}
+
+// TestResourceSpecRBACGrantsNothingItCannotRead: the list is introduced to operators as an
+// allowlist of SPEC-BEARING kinds, and every entry is a cluster-wide `get`. A kind with no
+// spec and no status buys the tool literally nothing and costs the full grant, which is the
+// worst trade in the file.
+func TestResourceSpecRBACGrantsNothingItCannotRead(t *testing.T) {
+	for _, r := range readResourceSpecRules(t) {
+		for _, res := range r.Resources {
+			if slices.Contains(specLessKinds, res) {
+				t.Errorf("rbac.resourceSpecRules grants %q (apiGroups %v), which has neither .spec nor "+
+					".status: resource_spec renders \"spec: (none — this kind has no spec)\" while the "+
+					"cluster-wide read grant is real", res, r.APIGroups)
+			}
+		}
+	}
+}
+
+// TestResourceSpecRBACSaysItIsADefaultGrant. The block ships POPULATED and renders into the
+// ClusterRole, so a `helm upgrade` changing no values widens the ServiceAccount. Nothing in
+// the file said so, and nothing said `resourceSpecRules: []` declines it cleanly — the block
+// read as an opt-in menu. Both facts are load-bearing for an operator reviewing what they
+// grant, so both are pinned.
+func TestResourceSpecRBACSaysItIsADefaultGrant(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(chartDir, "values.yaml"))
+	if err != nil {
+		t.Fatalf("read values.yaml: %v", err)
+	}
+	values := string(raw)
+	for _, want := range []string{
+		"DEFAULT GRANT, NOT AN OPT-IN MENU",
+		"resourceSpecRules: []",
+	} {
+		if !strings.Contains(values, want) {
+			t.Errorf("values.yaml no longer states %q next to rbac.resourceSpecRules: the block reads as "+
+				"an opt-in menu again, and it is a default grant", want)
+		}
+	}
+	// The documented `resourceSpecRules: []` opt-out only renders because the toYaml is
+	// GUARDED. Verified empirically against helm 3.14: an unguarded
+	// `{{- toYaml .Values.rbac.resourceSpecRules | nindent 2 }}` emits a bare `[]` into the
+	// middle of the rules sequence and the whole template fails to render, so an operator
+	// following the instruction in values.yaml would get an error instead of a narrow
+	// ClusterRole. Either guard form works (`with` and `if` are both falsy on an empty
+	// list); what must not happen is losing the guard.
+	tpl, err := os.ReadFile(filepath.Join(chartDir, "templates", "rbac.yaml"))
+	if err != nil {
+		t.Fatalf("read rbac.yaml: %v", err)
+	}
+	guarded := strings.Contains(string(tpl), "{{- with .Values.rbac.resourceSpecRules }}") ||
+		strings.Contains(string(tpl), "{{- if .Values.rbac.resourceSpecRules }}")
+	if !guarded {
+		t.Error("templates/rbac.yaml renders rbac.resourceSpecRules without a `with`/`if` guard: " +
+			"the documented `resourceSpecRules: []` opt-out then emits a bare `[]` into the rules " +
+			"sequence and the chart fails to render")
+	}
+}
+
+// TestChartDocumentsForgeGitHost: forge.git_host and forge.github_api_url appeared NOWHERE
+// in the chart — not values.yaml, not any profile. GitHub Enterprise with subdomain
+// isolation is a hard startup refusal without git_host (config.validateForgeGitHost), so a
+// Helm-only operator met that refusal as a CrashLoopBackOff with no key in the file to
+// point at. Pinned in values.yaml and in every profile that ships a forge block.
+func TestChartDocumentsForgeGitHost(t *testing.T) {
+	files := []string{"values.yaml"}
+	for _, p := range valuesProfiles {
+		raw, err := os.ReadFile(filepath.Join(chartDir, p))
+		if err != nil {
+			t.Fatalf("read %s: %v", p, err)
+		}
+		if strings.Contains(string(raw), "\n  forge:") {
+			files = append(files, p)
+		}
+	}
+	if len(files) < 2 {
+		t.Fatal("no values profile ships a forge block: this guard has lost its subject")
+	}
+	for _, f := range files {
+		raw, err := os.ReadFile(filepath.Join(chartDir, f))
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, want := range []string{"git_host", "github_api_url"} {
+			if !strings.Contains(string(raw), want) {
+				t.Errorf("%s ships a forge block but never mentions %q: a GitHub Enterprise install "+
+					"with subdomain isolation fails config load, and the operator has no key in the "+
+					"chart to set", f, want)
+			}
+		}
+	}
+}
+
+// TestThreadRegistryWarningCoversBothTransports: NOTES.txt gated the thread-registry
+// persistence warning on notify.slack.thread_capture ALONE, so a Matrix-only thread-capture
+// deployment was never warned that its registry does not survive a restart — even though
+// Validate's Matrix arm requires outcome.ledger_path for exactly that durability. The
+// warning is the only place the VOLUME under that path is checked.
+func TestThreadRegistryWarningCoversBothTransports(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(chartDir, "templates", "NOTES.txt"))
+	if err != nil {
+		t.Fatalf("read NOTES.txt: %v", err)
+	}
+	notes := string(raw)
+	idx := strings.Index(notes, "thread registry")
+	if idx < 0 {
+		t.Fatal("NOTES.txt no longer warns about the thread registry at all")
+	}
+	// The guard expression is the `{{- if ... }}` immediately preceding the warning body.
+	guardStart := strings.LastIndex(notes[:idx], "{{- if ")
+	if guardStart < 0 {
+		t.Fatal("the thread-registry warning in NOTES.txt has no `{{- if }}` guard")
+	}
+	guard := notes[guardStart:idx]
+	for _, want := range []string{
+		`"notify" "slack" "thread_capture"`,
+		`"notify" "matrix" "thread_capture"`,
+	} {
+		if !strings.Contains(guard, want) {
+			t.Errorf("the thread-registry warning is not gated on %s: that transport's operator is "+
+				"never told the registry does not survive a restart", want)
+		}
+	}
+	if !strings.Contains(guard, "or ") {
+		t.Error("the thread-registry warning gate does not combine its transports with `or`: one of " +
+			"them can no longer trigger the warning on its own")
 	}
 }

--- a/website/content/docs/integrations/data-sources/kubernetes.md
+++ b/website/content/docs/integrations/data-sources/kubernetes.md
@@ -54,7 +54,9 @@ kubectl -n runlore logs deploy/runlore | grep 'clientset unavailable'
   kind served by several API groups (`Event` everywhere, `NetworkPolicy` on a Calico cluster) reads
   nothing and names the candidates; pass `group` to pick one.
 - **`resource_spec` is bounded by an RBAC allowlist, not by a wildcard.** `rbac.resourceSpecRules`
-  (chart values) grants `get` on the spec-bearing kinds it reads. `Secret` is refused by the tool
+  (chart values) grants `get` on the spec-bearing kinds it reads. **It ships populated**, so a stock
+  `helm install` already grants those kinds cluster-wide; `rbac.resourceSpecRules: []` declines the
+  whole grant and costs you this tool alone. `Secret` is refused by the tool
   outright — before and after kind resolution — but the ClusterRole is the real boundary, so
   **never** widen the list to `resources: ["*"]`: that includes `secrets`. A kind you have not
   granted comes back as a *denial*, never as a missing object.

--- a/website/content/docs/security/security-model.md
+++ b/website/content/docs/security/security-model.md
@@ -113,8 +113,17 @@ The chart's RBAC is scoped tightly (`deploy/helm/runlore/templates/rbac.yaml`):
   `flux-system`. The app guard must stay a superset of the RBAC namespaces, or `pod_logs` is blocked at
   the app layer for namespaces RBAC would otherwise permit.
 - **`resource_spec`'s read-only kind allowlist:** `rbac.resourceSpecRules` grants `get` on the
-  spec-bearing kinds the tool reads (Services, workloads, NetworkPolicies, HPAs, PVCs, StorageClasses,
-  scrape CRs …). It is an **allowlist, never a wildcard**, on purpose: `resources: ["*"]` includes
+  spec-bearing kinds the tool reads (Services, workloads, NetworkPolicies, HPAs, PVCs, PVs, Nodes,
+  scrape CRs …). **It ships populated — this is a default grant, not an opt-in menu**: a stock
+  install adds 10 rules — 28 resource types, 23 of them granted nowhere else — of cluster-wide
+  `get`, on top of the ClusterRole's 9 base rules. Set
+  `rbac.resourceSpecRules: []` to decline it in full (that costs you `resource_spec` and nothing
+  else — `workload_ownership`'s owner-chain kinds are granted separately and unconditionally, so
+  narrowing this list can never silently truncate an owner chain). Kinds with **neither `.spec` nor
+  `.status`** — ServiceAccount, EndpointSlice, StorageClass, ConfigMap — are deliberately absent:
+  the read would return nothing while the grant stayed entirely real, and a cluster-wide
+  ServiceAccount read in particular exposes the IRSA / Workload-Identity role ARNs in its
+  annotations. It is an **allowlist, never a wildcard**, on purpose: `resources: ["*"]` includes
   `secrets`. The tool refuses the `Secret` kind before *and* after resolution — a spelling that
   case-folds to "secret", and any resource literally named `secrets` in any API group, is refused —
   but that is an application-layer policy. **RBAC is the boundary.** A kind missing from the list is


### PR DESCRIPTION
`rbac.resourceSpecRules` ships **populated**, so a `helm upgrade` that changes no values widens the ClusterRole — and nothing said so, nor how to decline.

### Rule counts (`helm template`, identical across all three profiles — none overrides the list)

| | ClusterRole rules | resource types |
|---|---|---|
| **Before**, stock | 18 | 44 |
| **Before**, `resourceSpecRules: []` | 7 | 13 |
| **After**, stock | 19 | 41 |
| **After**, `resourceSpecRules: []` | 9 | 18 |

The list contributes 10 rules / 28 resource types, **23 of them granted nowhere else**.

### Three dead grants removed

`serviceaccounts`, `endpointslices` and `storageclasses` have neither `.spec` nor `.status`, so `renderSection` returns `""` and the tool prints `spec: (none — this kind has no spec)`. The read returns nothing while the grant stays entirely real. `serviceaccounts` is the one that matters: its annotations carry IRSA / Workload-Identity role ARNs. `discovery.k8s.io` disappears entirely; `storage.k8s.io` keeps only `volumeattachments`. A PVC bound to a vanished StorageClass is answered from the PVC's own spec, which is still granted.

### `workload_ownership`'s grants are now static, and belong to their consumer

The `apps` apiGroup did not exist in this ClusterRole before `resource_spec` landed, yet `ownership.go`'s `fetchOwner` needs `get` on `apps/{replicasets,deployments,statefulsets,daemonsets}` and `batch/jobs`. A denial there **does not error** — `ownership.go:102-106` reads it as "top of chain reached" and reports the last resolvable hop. So an operator narrowing an allowlist documented as belonging to a *different* tool would turn every "Deployment X, owned by Kustomization Y" into a bare "ReplicaSet X", quietly, suite green.

Pinning the allowlist would have left that silent-failure mode one careless narrowing away. Granting the five kinds statically removes it structurally: `rbac.resourceSpecRules: []` now provably leaves the walk intact (verified — the 9-rule render still carries both rules).

### Also

- **`forge.git_host` and `forge.github_api_url` appeared nowhere in the chart.** `git_host` is a hard startup refusal on GitHub Enterprise with subdomain isolation, so a Helm-only operator met it as a CrashLoopBackOff. Both are now in `values.yaml` and both profiles, commented, saying so.
- **`NOTES.txt`** gated the thread-registry persistence warning on Slack alone, so a Matrix-only deployment was never warned its registry does not survive a restart — despite `Validate`'s Matrix arm requiring exactly that durability. Now gates on either, names which transports are on, and describes both ingress paths. Verified across five render combinations.
- **`security-model.md` still listed StorageClasses as granted.**

### Guards (`internal/config/chart_rbac_test.go`, +325)

The owner-walk guard **derives** its expected kinds by AST-parsing `fetchOwner`'s own switch — the accessor (`BatchV1`) gives the apiGroup, the method (`Jobs`) is the resource plural — then checks them against the template's *static* rules only. Adding a `case "CronJob"` fails the test until the chart grants it.

All six guards mutation-tested; each one bit:

| Mutation | Guard that caught it |
|---|---|
| re-add `serviceaccounts` | spec-less kind guard |
| delete the static `apps` rule | static owner-walk grant |
| add a `CronJob` arm to `fetchOwner` | AST-derived kind list |
| revert the NOTES gate to Slack-only | both-transport gate |
| strip `git_host` from a profile | forge key pin |
| remove the `toYaml` guard | opt-out render pin |

That last one corrected a false rationale mid-flight: the first draft asserted `if` would break the `[]` render. It does not — `with` and `if` are both falsy on `[]`. The real hazard is *removing* the guard, where a bare `toYaml` emits `[]` into the rules sequence and the render fails. The test and the chart comments were corrected rather than shipping the wrong reason.

The existing wildcard/secrets warning and its guard are untouched.

Gate: `go build` · `go vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues** · `helm lint` 0 failed across all profiles and the opt-out · `hugo` exit 0.
