### PR TITLE
fix(investigate): close three escapes past the egress redaction chokepoint

### DIFF
--- a/internal/action/auto.go
+++ b/internal/action/auto.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Smana/runlore/internal/audit"
 	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/providers"
+	"github.com/Smana/runlore/internal/redact"
 )
 
 // Auto executes remediations without human approval (mode "auto"), under layered
@@ -129,8 +130,19 @@ func (a *Auto) runOne(ctx context.Context, inv providers.Investigation, act prov
 		}
 		// executed/failed are audited at the executor seam (NewAuditedExecutor).
 		if err := a.exec.Execute(ContextWithActor(ctx, "auto"), act); err != nil {
-			a.log.Error("auto-execute failed", "op", act.Op, "target", target(act), "err", err)
-			return annotate("[auto: FAILED — " + err.Error() + "]")
+			// Redacted because this string is DELIVERED and the egress chokepoint has
+			// already run: Auto.Run is called from app.onInvestigationComplete, which
+			// investigate.LoopInvestigator.deliver invokes only AFTER
+			// redactInvestigation — and notify.Format renders Action.Description
+			// verbatim into the webhook payload with no second pass. The reason is a
+			// live apiserver response body, so it carries whatever the apiserver put
+			// in it. Every other annotation on this path is server-derived (the op
+			// enum, the target workload, policy/config values), which is why this is
+			// the only one that needs scrubbing. The log line needs it for the same
+			// reason the curate-failure log does — it lands in the log aggregator.
+			reason := redact.Secrets(err.Error())
+			a.log.Error("auto-execute failed", "op", act.Op, "target", target(act), "err", reason)
+			return annotate("[auto: FAILED — " + reason + "]")
 		}
 		a.log.Info("auto-executed", "op", act.Op, "target", target(act))
 		return annotate("[auto-executed]")

--- a/internal/action/auto_test.go
+++ b/internal/action/auto_test.go
@@ -4,6 +4,7 @@ package action
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -139,5 +140,38 @@ func TestAutoDeniesProtectedNamespace(t *testing.T) {
 	}
 	if !strings.Contains(out[0].Description, "denied") {
 		t.Fatalf("expected denied annotation: %q", out[0].Description)
+	}
+}
+
+// TestAutoRedactsTheExecutorError closes the third field written PAST the single
+// egress chokepoint (after Prior and CurateError).
+//
+// investigate.LoopInvestigator.deliver redacts and THEN calls OnComplete;
+// app.onInvestigationComplete then replaces found.Actions with Auto.Run's output, so
+// this annotation lands on an Investigation that will never be scrubbed again. The
+// spliced text is a live executor error — a Kubernetes API response body, whatever
+// the apiserver chose to put in it — and notify.Format renders Action.Description
+// verbatim into the webhook payload's text with no second redaction pass.
+func TestAutoRedactsTheExecutorError(t *testing.T) {
+	const token = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	exec := &fakeExec{err: fmt.Errorf("apiserver rejected the patch: bearer %s", token)}
+	a := NewAuto(exec, config.AutoPolicy{MinConfidence: 0.5}, autoPolicy(), nil, discardLog())
+	a.Resume() // NewAuto starts paused (fail closed); opt in to execution
+
+	out := a.Run(context.Background(), autoInv(0.9, revAction))
+
+	if len(out) != 1 {
+		t.Fatalf("expected one annotated action, got %d", len(out))
+	}
+	if !strings.Contains(out[0].Description, "auto: FAILED") {
+		t.Fatalf("a failed execution must still be reported to the human: %q", out[0].Description)
+	}
+	if strings.Contains(out[0].Description, token) {
+		t.Errorf("the executor's error reached a delivered field verbatim — it is annotated "+
+			"AFTER redactInvestigation, so nothing downstream will scrub it: %q", out[0].Description)
+	}
+	// Masking the credential must not cost the operator the diagnosis.
+	if !strings.Contains(out[0].Description, "apiserver rejected the patch") {
+		t.Errorf("redaction ate the non-secret part of the reason: %q", out[0].Description)
 	}
 }

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -755,9 +755,23 @@ func onInvestigationComplete(ctx context.Context, found providers.Investigation,
 	// recalled entry IS the answer being delivered. Best-effort by construction:
 	// no merged entry, empty sections, or a ledger error leave Prior nil and the
 	// notification falls back to the counter+link it already carries.
+	//
+	// The excerpts are redacted HERE, at the assignment, for the same reason
+	// CurateError is below: the egress chokepoint has already run. These two are the
+	// only fields on the delivered Investigation stamped past it, and both carry free
+	// text of external origin — a KB entry's Cause/Resolution is whatever the
+	// investigation wrote plus whatever a human edited in during review, so a pasted
+	// controller log or kubectl transcript carries what it carried. EntryPath is a
+	// catalog path (the loop's redactionSkipField treats it as server-derived) and
+	// stays verbatim. The chat path already scrubs the SAME excerpt
+	// (thread.chatSafe over catalog.Entry.Section), so leaving it raw here made the
+	// two egress paths disagree — and notify.NewPayload copies Cause/Resolution
+	// straight into the webhook JSON under a comment promising an "(already-redacted)"
+	// Investigation, with no second pass at render to save it. redact.Secrets is
+	// idempotent, so scrubbing here costs the render sites nothing.
 	if found.Occurrences > 1 && !found.Recalled && prior != nil {
 		if e, ok := prior.FindFingerprint(dupFP); ok {
-			cause, resolution := e.Section("Cause"), e.Section("Resolution")
+			cause, resolution := redact.Secrets(e.Section("Cause")), redact.Secrets(e.Section("Resolution"))
 			if cause != "" || resolution != "" {
 				pk := &providers.PriorKnowledge{Cause: cause, Resolution: resolution, EntryPath: e.Path}
 				if counts, err := ledger.OpenCounts(); err == nil {

--- a/internal/app/oncomplete_test.go
+++ b/internal/app/oncomplete_test.go
@@ -11,11 +11,14 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Smana/runlore/internal/action"
 	"github.com/Smana/runlore/internal/catalog"
+	"github.com/Smana/runlore/internal/config"
 	"github.com/Smana/runlore/internal/notify"
 	"github.com/Smana/runlore/internal/outcome"
 	"github.com/Smana/runlore/internal/providers"
@@ -529,4 +532,234 @@ func TestOnCompleteRecordsInvestigationStartTime(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestOnCompleteRedactsPriorKnowledge pins the second field stamped past the single
+// egress chokepoint, alongside CurateError above.
+//
+// investigate.LoopInvestigator.deliver calls redactInvestigation and THEN OnComplete,
+// so found.Prior — built here from a merged KB entry's Cause/Resolution sections —
+// has already missed it. Those sections are a KB body: whatever the investigation
+// wrote plus whatever a human edited in during review, and a pasted controller log
+// or a kubectl transcript in either one carries whatever it carried. Chat scrubs the
+// SAME excerpt (thread.chatSafe on catalog.Entry.Section), so the two egress paths
+// disagreed; the webhook is the one that lost, since notify.NewPayload copies Cause
+// and Resolution straight into PriorPayload's JSON under a comment promising an
+// "(already-redacted) Investigation".
+func TestOnCompleteRedactsPriorKnowledge(t *testing.T) {
+	const token = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	path := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	ledger, err := outcome.New(path)
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	// A prior open for the same trigger key makes this run occurrence #2, which is
+	// the only condition under which Prior is stamped from the catalog.
+	if err := ledger.Open(outcome.Event{
+		Fingerprint: "fp0", TriggerKey: "k", At: time.Now().Add(-4 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+
+	entry := catalog.Entry{
+		Path: "incidents/e.md",
+		Body: "## Cause\n\nregistry auth failed with token " + token +
+			"\n\n## Resolution\n\nrotate it and re-apply with password=hunter2horse\n",
+	}
+	sink := &captureNotifier{}
+	onInvestigationComplete(context.Background(),
+		providers.Investigation{Title: "t", Fingerprint: "fp1", TriggerKey: "k"},
+		ledger, fakePrior{e: entry, ok: true}, nil, notify.NewMulti(discardLog(), sink),
+		nil, nil, nil, discardLog())
+
+	p := sink.got.Prior
+	if p == nil {
+		t.Fatal("Prior not stamped on a recurring fresh investigation")
+	}
+	if strings.Contains(p.Cause, token) {
+		t.Errorf("Prior.Cause reached the notifier unredacted — it is stamped AFTER "+
+			"redactInvestigation, so nothing else will scrub it: %q", p.Cause)
+	}
+	if strings.Contains(p.Resolution, "hunter2horse") {
+		t.Errorf("Prior.Resolution reached the notifier unredacted — it is stamped AFTER "+
+			"redactInvestigation, so nothing else will scrub it: %q", p.Resolution)
+	}
+	// The excerpt must still be an excerpt: masking the secret is not licence to drop
+	// the sentence the on-call reads instead of clicking through to the forge.
+	if !strings.Contains(p.Cause, "registry auth failed") {
+		t.Errorf("Prior.Cause lost its non-secret text: %q", p.Cause)
+	}
+	if !strings.Contains(p.Resolution, "rotate it and re-apply") {
+		t.Errorf("Prior.Resolution lost its non-secret text: %q", p.Resolution)
+	}
+	// EntryPath is a catalog path (a redactionSkipField entry inside the loop) and must
+	// stay verbatim, or the notification's link to the merged entry breaks.
+	if p.EntryPath != "incidents/e.md" {
+		t.Errorf("Prior.EntryPath = %q, want the catalog path verbatim", p.EntryPath)
+	}
+}
+
+// TestPriorPayloadCarriesNoSecret is the same fact asserted at the sink that actually
+// serialises it. notify.NewPayload's doc calls its input an "(already-redacted)
+// Investigation" and copies Prior.Cause/Resolution verbatim into JSON: unlike the
+// Slack and Matrix renderers there is no second redaction pass at render, so the
+// webhook body is the exact place an unscrubbed Prior escapes the process.
+func TestPriorPayloadCarriesNoSecret(t *testing.T) {
+	const token = "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"
+	path := filepath.Join(t.TempDir(), "outcomes.jsonl")
+	ledger, err := outcome.New(path)
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	if err := ledger.Open(outcome.Event{
+		Fingerprint: "fp0", TriggerKey: "k", At: time.Now().Add(-4 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	entry := catalog.Entry{
+		Path: "incidents/e.md",
+		Body: "## Cause\n\ntoken " + token + " expired\n\n## Resolution\n\nrotate\n",
+	}
+	sink := &captureNotifier{}
+	onInvestigationComplete(context.Background(),
+		providers.Investigation{Title: "t", Fingerprint: "fp1", TriggerKey: "k"},
+		ledger, fakePrior{e: entry, ok: true}, nil, notify.NewMulti(discardLog(), sink),
+		nil, nil, nil, discardLog())
+
+	body, err := json.Marshal(notify.NewPayload(sink.got))
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if strings.Contains(string(body), token) {
+		t.Errorf("the webhook JSON carries a credential verbatim:\n%s", body)
+	}
+}
+
+// failingExec stands in for a cluster executor whose write was rejected by the
+// apiserver, so the test can reach Auto's FAILED annotation — the only branch that
+// splices an externally-supplied string into a delivered Action.Description.
+type failingExec struct{ err error }
+
+func (f failingExec) Execute(context.Context, providers.Action) error { return f.err }
+
+// TestOnCompleteDeliversNothingUnredacted is the guard that the post-chokepoint leaks
+// have so far each lacked.
+//
+// investigate.redactInvestigation is called by LoopInvestigator.deliver BEFORE
+// OnComplete, so every string this pipeline stamps afterwards is past the single
+// egress chokepoint and will never be scrubbed by it. investigate's own reflection
+// guard cannot see any of this: it tests the redactor, which has already run by the
+// time this function starts. So both known leaks (CurateError, then Prior) were found
+// by a human reading the ordering — which is not a control.
+//
+// This closes that: it feeds a secret in at EVERY external seam the pipeline reads
+// from — the curator's error, the merged KB entry's body, the executor's error — then
+// reflectively walks the Investigation actually handed to the notifier and fails if
+// the secret is anywhere in it. A future field stamped here from an external source
+// fails this test on the day it is added, without anyone re-deriving the ordering.
+func TestOnCompleteDeliversNothingUnredacted(t *testing.T) {
+	const marker = "hunter2horse"
+	secret := "password=" + marker
+
+	dir := t.TempDir()
+	ledger, err := outcome.New(filepath.Join(dir, "outcomes.jsonl"))
+	if err != nil {
+		t.Fatalf("new ledger: %v", err)
+	}
+	// A prior open makes this occurrence #2, the only state in which Prior is stamped.
+	if err := ledger.Open(outcome.Event{
+		Fingerprint: "fp0", TriggerKey: "k", CuratedURL: "https://kb/prev",
+		At: time.Now().Add(-4 * time.Hour),
+	}); err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+
+	// Seam 1: the merged KB entry's body — free text a human edited during review.
+	entry := catalog.Entry{
+		Path: "incidents/e.md",
+		Body: "## Cause\n\ncause " + secret + "\n\n## Resolution\n\nresolution " + secret + "\n",
+	}
+	// Seam 2: the forge's own error body, which carries whatever it carries.
+	cur := failingCurator{err: fmt.Errorf("open PR: %s", secret)}
+	// Seam 3: the apiserver's rejection of an auto-executed remediation.
+	auto := action.NewAuto(
+		failingExec{err: fmt.Errorf("patch rejected: %s", secret)},
+		config.AutoPolicy{MinConfidence: 0.5},
+		action.New(config.ActionPolicy{
+			Mode:  config.ActionAuto,
+			Allow: config.ActionAllow{ReversibleOnly: true, Namespaces: []string{"apps"}},
+		}),
+		nil, discardLog(),
+	)
+	auto.Resume() // NewAuto starts paused (fail closed)
+
+	// The investigation itself arrives CLEAN: it has been through the chokepoint, so
+	// anything secret-shaped in the delivered result came from a seam above.
+	found := providers.Investigation{
+		Title: "disk pressure", Fingerprint: "fp1", TriggerKey: "k", Confidence: 0.9,
+		Actions: []providers.Action{{
+			Name: "suspend web", Description: "suspend the Kustomization", Op: "suspend",
+			Reversible: true,
+			Target:     providers.Workload{Kind: "Kustomization", Name: "web", Namespace: "apps"},
+		}},
+	}
+	sink := &captureNotifier{}
+	onInvestigationComplete(context.Background(), found, ledger, fakePrior{e: entry, ok: true},
+		cur, notify.NewMulti(discardLog(), sink), auto, nil, nil, discardLog())
+
+	// Every seam must actually have fired, or the walk below proves nothing.
+	if sink.got.Prior == nil {
+		t.Fatal("Prior was not stamped — the KB seam never fired, so this guard is vacuous")
+	}
+	if sink.got.CurateError == "" {
+		t.Fatal("CurateError was not stamped — the curator seam never fired, so this guard is vacuous")
+	}
+	if len(sink.got.Actions) != 1 || !strings.Contains(sink.got.Actions[0].Description, "auto: FAILED") {
+		t.Fatalf("the executor seam never fired, so this guard is vacuous: %+v", sink.got.Actions)
+	}
+
+	for path, val := range reachableStrings(sink.got) {
+		if strings.Contains(val, marker) {
+			t.Errorf("%s reached the notifier with a secret the egress chokepoint never saw: %q\n"+
+				"It is stamped by onInvestigationComplete, which runs AFTER "+
+				"investigate.redactInvestigation — redact it at its assignment, as CurateError "+
+				"and Prior are.", path, val)
+		}
+	}
+}
+
+// reachableStrings collects every exported string reachable from inv, keyed by its
+// full field path. Deliberately total: this pipeline's whole failure mode is a field
+// nobody thought to check, so the walk prunes nothing.
+func reachableStrings(inv providers.Investigation) map[string]string {
+	out := map[string]string{}
+	var walk func(path string, v reflect.Value)
+	walk = func(path string, v reflect.Value) {
+		switch v.Kind() {
+		case reflect.String:
+			out[path] = v.String()
+		case reflect.Pointer, reflect.Interface:
+			if !v.IsNil() {
+				walk(path, v.Elem())
+			}
+		case reflect.Struct:
+			tp := v.Type()
+			for i := 0; i < v.NumField(); i++ {
+				if tp.Field(i).PkgPath != "" {
+					continue
+				}
+				walk(path+"."+tp.Field(i).Name, v.Field(i))
+			}
+		case reflect.Slice, reflect.Array:
+			for i := 0; i < v.Len(); i++ {
+				walk(path, v.Index(i))
+			}
+		case reflect.Map:
+			for _, k := range v.MapKeys() {
+				walk(path, v.MapIndex(k))
+			}
+		}
+	}
+	walk("Investigation", reflect.ValueOf(inv))
+	return out
 }

--- a/internal/investigate/loop.go
+++ b/internal/investigate/loop.go
@@ -1324,26 +1324,34 @@ var redactionSkipTypes = map[reflect.Type]bool{
 	reflect.TypeOf(providers.Workload{}): true,
 }
 
-// redactionSkipField is the allowlist of exported STRING fields (by name) that are
+// redactionSkipField is the allowlist of exported STRING fields that are
 // server-derived and must NOT be scrubbed: dedup identity, curator-set links, the
 // catalog paths of matched/recalled entries, and the server-controlled action/
 // verdict vocabularies. Kept deliberately short (a skip-list, not an include-list —
-// #197): everything not named here is treated as potentially untrusted free text
-// and scrubbed. Matched by field name because these names are distinctive across
-// the Investigation's nested shape (EntryPath/CuratedURL/ApprovalID/etc.).
+// #197): everything not listed here is treated as potentially untrusted free text
+// and scrubbed.
+//
+// Keys are TYPE-QUALIFIED ("StructName.FieldName"), not bare field names. The bare
+// form exempted by NAME GLOBALLY, so an entry justified for one struct silently
+// spared every same-named field anywhere in the Investigation's nested shape: "Path"
+// was added for MatchedEntry.Path (a catalog path) and, without anyone deciding it,
+// also spared Change.Source.Path — which internal/providers/cloud/aws/cloudtrail.go
+// packs a verbatim CloudTrail ErrorMessage into. Qualifying the key makes each entry
+// a statement about one field of one struct, so a collision cannot happen by
+// accident; a same-named field on a new struct now has to be exempted deliberately.
 var redactionSkipField = map[string]bool{
-	"Verdict":        true, // server-controlled classification enum
-	"Op":             true, // Action.Op — server-controlled executable-operation enum
-	"ApprovalID":     true, // Action.ApprovalID — server-generated approval token
-	"CuratedURL":     true, // curator-set KB link
-	"PrevCuratedURL": true, // curator-set KB link (prior occurrence)
-	"RecalledEntry":  true, // catalog path the answer was recalled from
-	"EntryPath":      true, // PriorKnowledge.EntryPath — catalog path
-	"Path":           true, // MatchedEntry.Path — catalog path
-	"URL":            true, // MatchedEntry.URL — server-derived web link
-	"Fingerprint":    true, // deterministic alert dedup id
-	"Fingerprints":   true, // coalesced batch dedup ids
-	"TriggerKey":     true, // deterministic incident-identity dedup key
+	"Investigation.Verdict":        true, // server-controlled classification enum
+	"Action.Op":                    true, // server-controlled executable-operation enum
+	"Action.ApprovalID":            true, // server-generated approval token
+	"Investigation.CuratedURL":     true, // curator-set KB link
+	"Investigation.PrevCuratedURL": true, // curator-set KB link (prior occurrence)
+	"Investigation.RecalledEntry":  true, // catalog path the answer was recalled from
+	"PriorKnowledge.EntryPath":     true, // catalog path of the merged entry
+	"MatchedEntry.Path":            true, // catalog path of the matched entry
+	"MatchedEntry.URL":             true, // server-derived web link to that entry
+	"Investigation.Fingerprint":    true, // deterministic alert dedup id
+	"Investigation.Fingerprints":   true, // coalesced batch dedup ids
+	"Investigation.TriggerKey":     true, // deterministic incident-identity dedup key
 }
 
 // redactStrings recursively walks v and applies redact.Secrets to every settable
@@ -1370,7 +1378,9 @@ func redactStrings(v reflect.Value) {
 			if t.Field(i).PkgPath != "" { // unexported: not settable, skip
 				continue
 			}
-			if redactionSkipField[t.Field(i).Name] {
+			// Type-qualified, so a skip-list entry can only ever spare the one field it
+			// names — see redactionSkipField.
+			if redactionSkipField[t.Name()+"."+t.Field(i).Name] {
 				continue
 			}
 			redactStrings(v.Field(i))

--- a/internal/investigate/redact_egress_test.go
+++ b/internal/investigate/redact_egress_test.go
@@ -47,126 +47,232 @@ func TestRedactInvestigation(t *testing.T) {
 	}
 }
 
-// secretVal is a secret-shaped value the redactor is known to mask (the generic
-// key=value rule). Every free-text string in the fully-populated fixture below is
-// set to this so the reflection walk has something detectable to scrub.
-const secretVal = "password=hunter2horse"
+const (
+	// secretVal is a secret-shaped value the redactor is known to mask (the generic
+	// key=value rule). EVERY exported string reachable from the fixture below is set
+	// to it, so the reflection walk always has something detectable to scrub.
+	secretVal = "password=hunter2horse"
+	// secretMarker is the part of secretVal that must not survive redaction. The
+	// "password=" half does survive (only the value is masked), so containment has to
+	// be tested against this half alone.
+	secretMarker = "hunter2horse"
+	// maxRedactWalkDepth bounds both reflection walks below. Investigation's shape is
+	// ~5 levels deep; a self-referential type added later would otherwise hang the
+	// suite instead of failing it.
+	maxRedactWalkDepth = 16
+)
 
-// TestRedactInvestigationReflectionCoverage is the #197 guard: it builds an
-// Investigation with EVERY exported string set to a secret-shaped value, runs the
-// egress redaction, then reflectively asserts that every exported string carries
-// the scrub marker — EXCEPT the server-derived skip-list. Adding a new
-// model-authored string field without redaction fails HERE (not a future audit),
-// because the fixture-builder sets it to secretVal and this walk finds it
-// un-scrubbed. It also explicitly pins the previously-missed fields (RuledOut,
-// DataGaps, Hypothesis.ChangeRef).
-func TestRedactInvestigationReflectionCoverage(t *testing.T) {
-	inv := &providers.Investigation{
-		Title:      secretVal,
-		RootCauses: []providers.Hypothesis{{Summary: secretVal, ChangeRef: secretVal, Evidence: []string{secretVal}, SuggestedAction: secretVal}},
-		Changes:    []providers.Change{{ManagedBy: secretVal, FromRev: secretVal, ToRev: secretVal, DiffRef: secretVal}},
-		Unresolved: []string{secretVal},
-		RuledOut:   []string{secretVal},
-		DataGaps:   []string{secretVal},
-		Verdict:    providers.Verdict(secretVal),                                               // skip-listed: server-controlled enum, kept verbatim
-		Resource:   providers.Workload{Kind: secretVal, Name: secretVal, Namespace: secretVal}, // skip-listed type
-		// Trigger-time facts (free text derived from untrusted alert labels) — scrubbed.
-		Severity:    secretVal,
-		Environment: secretVal,
-		Cluster:     secretVal,
-		Tenant:      secretVal,
-		AlertName:   secretVal,
-		Actions: []providers.Action{{
-			Name: secretVal, Description: secretVal,
-			Op:         secretVal,                           // skip-listed enum
-			ApprovalID: secretVal,                           // skip-listed server id
-			Target:     providers.Workload{Name: secretVal}, // skip-listed type
-		}},
-		// Server-derived identity/links — all skip-listed, must stay verbatim.
-		CuratedURL:     secretVal,
-		Fingerprint:    secretVal,
-		Fingerprints:   []string{secretVal},
-		TriggerKey:     secretVal,
-		RecalledEntry:  secretVal,
-		PrevCuratedURL: secretVal,
-		Prior:          &providers.PriorKnowledge{Cause: secretVal, Resolution: secretVal, EntryPath: secretVal}, // EntryPath skip-listed
-		MatchedKnowledge: &providers.MatchedEntry{
-			Path: secretVal, URL: secretVal, // both skip-listed
-			Title: secretVal, // NOT skip-listed: it is KB entry text → scrubbed
-		},
+// egressVerbatim is this guard's OWN expectation of what egress redaction leaves
+// untouched, keyed by the FULL field path from the Investigation root (slice, array
+// and map elements do not add an index — every element of a slice sits at its
+// field's path).
+//
+// It is hand-written on purpose. The previous version of this test pruned its walk
+// with redactInvestigation's own redactionSkipField map and skipped the same struct
+// types as redactionSkipTypes, so it exempted precisely what the redactor exempted:
+// it agreed with the redactor by construction and could not, even in principle,
+// observe a skip-list entry firing on the wrong field. That is how a skip-list keyed
+// by the bare name "Path" — added for MatchedEntry.Path, a catalog path — silently
+// also spared Change.Source.Path, which internal/providers/cloud/aws/cloudtrail.go
+// packs a verbatim CloudTrail ErrorMessage into.
+//
+// So: a path here is a claim that the value is SERVER-DERIVED and must reach chat
+// and the (possibly public) KB verbatim. Everything else must come back scrubbed.
+// Adding an entry means writing the qualified path out where a reviewer can see
+// which struct it belongs to.
+var egressVerbatim = map[string]bool{
+	// Investigation-level server-derived identity and links.
+	"Investigation.Verdict":        true, // server-controlled classification enum
+	"Investigation.CuratedURL":     true, // curator-set KB link
+	"Investigation.PrevCuratedURL": true, // curator-set KB link (prior occurrence)
+	"Investigation.RecalledEntry":  true, // catalog path the answer was recalled from
+	"Investigation.Fingerprint":    true, // deterministic alert dedup id
+	"Investigation.Fingerprints":   true, // coalesced batch dedup ids
+	"Investigation.TriggerKey":     true, // deterministic incident-identity dedup key
+	// Catalog paths and links of matched/prior entries.
+	"Investigation.Prior.EntryPath":       true,
+	"Investigation.MatchedKnowledge.Path": true,
+	"Investigation.MatchedKnowledge.URL":  true,
+	// Server-controlled action vocabulary and approval token.
+	"Investigation.Actions.Op":         true,
+	"Investigation.Actions.ApprovalID": true,
+	// providers.Workload is a Kubernetes resource identifier the executor acts on,
+	// never free text — spelled out per reachable occurrence rather than waved
+	// through by type, so a new Workload-shaped field cannot be exempted silently.
+	"Investigation.Resource.Kind":                 true,
+	"Investigation.Resource.Name":                 true,
+	"Investigation.Resource.Namespace":            true,
+	"Investigation.AlertResource.Kind":            true,
+	"Investigation.AlertResource.Name":            true,
+	"Investigation.AlertResource.Namespace":       true,
+	"Investigation.Actions.Target.Kind":           true,
+	"Investigation.Actions.Target.Name":           true,
+	"Investigation.Actions.Target.Namespace":      true,
+	"Investigation.Changes.Workload.Kind":         true,
+	"Investigation.Changes.Workload.Name":         true,
+	"Investigation.Changes.Workload.Namespace":    true,
+	"Investigation.Changes.BlastRadius.Kind":      true,
+	"Investigation.Changes.BlastRadius.Name":      true,
+	"Investigation.Changes.BlastRadius.Namespace": true,
+}
+
+// TestRedactInvestigationCoversEveryReachableString is the #197 guard, rebuilt so it
+// can actually see what it is guarding.
+//
+// It builds an Investigation whose every exported string — through pointers, slices
+// and maps — is set to a secret-shaped value, BY REFLECTION rather than by hand, so
+// a string field added anywhere in the shape is exercised the day it is added. It
+// then runs the egress redaction and walks the result comparing each path against
+// egressVerbatim above, an expectation written independently of the redactor's own
+// skip-list. A field that is neither scrubbed nor declared server-derived fails
+// here, which is what makes "the single egress chokepoint" a checked claim rather
+// than a comment.
+func TestRedactInvestigationCoversEveryReachableString(t *testing.T) {
+	inv := &providers.Investigation{}
+	populateStrings(t, "Investigation", reflect.ValueOf(inv).Elem(), 0)
+
+	// The fixture must genuinely reach through a pointer, a slice, and nested structs
+	// before the redaction assertions mean anything. These are the paths a hand-written
+	// fixture is most likely to miss — Changes.Source.Path is the one it did miss.
+	populated := walkStrings(t, inv)
+	for _, path := range []string{
+		"Investigation.Prior.Cause",              // through a nil pointer
+		"Investigation.RootCauses.Evidence",      // slice of strings inside a slice of structs
+		"Investigation.Changes.Source.Path",      // nested struct inside a slice
+		"Investigation.Changes.BlastRadius.Name", // slice of structs inside a slice of structs
+		"Investigation.MatchedKnowledge.Title",   // through a nil pointer
+	} {
+		if got := populated[path]; got != secretVal {
+			t.Fatalf("fixture did not populate %s (got %q) — the coverage claim below is void", path, got)
+		}
 	}
 
 	redactInvestigation(inv)
 
-	// Spot-check the audit's named gaps first, with clear failure messages.
-	if strings.Contains(inv.RuledOut[0], "hunter2horse") {
-		t.Error("RuledOut was not scrubbed (the #197 gap)")
-	}
-	if strings.Contains(inv.DataGaps[0], "hunter2horse") {
-		t.Error("DataGaps was not scrubbed (the #197 gap)")
-	}
-	if strings.Contains(inv.RootCauses[0].ChangeRef, "hunter2horse") {
-		t.Error("Hypothesis.ChangeRef was not scrubbed (the #197 gap)")
-	}
-
-	// The skip-list must remain verbatim (server-derived).
-	for name, got := range map[string]string{
-		"Verdict":               string(inv.Verdict),
-		"Resource.Name":         inv.Resource.Name,
-		"CuratedURL":            inv.CuratedURL,
-		"PrevCuratedURL":        inv.PrevCuratedURL,
-		"Fingerprint":           inv.Fingerprint,
-		"Fingerprints[0]":       inv.Fingerprints[0],
-		"TriggerKey":            inv.TriggerKey,
-		"RecalledEntry":         inv.RecalledEntry,
-		"Prior.EntryPath":       inv.Prior.EntryPath,
-		"MatchedKnowledge.Path": inv.MatchedKnowledge.Path,
-		"MatchedKnowledge.URL":  inv.MatchedKnowledge.URL,
-		"Action.Op":             inv.Actions[0].Op,
-		"Action.ApprovalID":     inv.Actions[0].ApprovalID,
-		"Action.Target.Name":    inv.Actions[0].Target.Name,
-	} {
-		if got != secretVal {
-			t.Errorf("skip-listed server-derived field %s was scrubbed (must stay verbatim): %q", name, got)
+	got := walkStrings(t, inv)
+	for path, val := range got {
+		switch {
+		case egressVerbatim[path]:
+			if val != secretVal {
+				t.Errorf("%s is declared server-derived but was scrubbed to %q — "+
+					"drop it from egressVerbatim, or add it to redactionSkipField", path, val)
+			}
+		case strings.Contains(val, secretMarker):
+			t.Errorf("%s survived egress redaction: %q — either redact it, or (if it really is "+
+				"server-derived) add the QUALIFIED path to redactionSkipField and to egressVerbatim", path, val)
 		}
 	}
+	for path := range egressVerbatim {
+		if _, ok := got[path]; !ok {
+			t.Errorf("egressVerbatim claims %s is server-derived, but no such string is reachable "+
+				"from Investigation — stale entry, or the field was renamed", path)
+		}
+	}
+}
 
-	// Total coverage: reflectively walk the redacted investigation and assert that
-	// every exported string reachable OUTSIDE the skip-list no longer carries the
-	// secret. Skip subtrees the redactor deliberately spares (Workload type,
-	// skip-listed field names) so this mirrors the redactor's contract exactly.
-	var walk func(path string, v reflect.Value)
-	walk = func(path string, v reflect.Value) {
+// populateStrings sets every exported string reachable from v to secretVal,
+// allocating nil pointers and giving every empty slice and map one element. The
+// fixture is therefore exhaustive BY CONSTRUCTION: nobody has to remember to extend
+// a literal struct when a field is added, which is exactly how the previous
+// hand-written fixture left Change.Source.Path unexercised.
+//
+// Map KEYS are deliberately left non-secret: redactStrings rewrites map values, not
+// keys, so a secret-shaped key would assert a property the redactor does not claim.
+func populateStrings(t *testing.T, path string, v reflect.Value, depth int) {
+	t.Helper()
+	if depth > maxRedactWalkDepth {
+		t.Fatalf("fixture walk exceeded depth %d at %s — a self-referential type?", maxRedactWalkDepth, path)
+	}
+	switch v.Kind() {
+	case reflect.String:
+		if v.CanSet() {
+			v.SetString(secretVal)
+		}
+	case reflect.Pointer:
+		if v.IsNil() {
+			if !v.CanSet() {
+				return
+			}
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		populateStrings(t, path, v.Elem(), depth+1)
+	case reflect.Struct:
+		tp := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			if tp.Field(i).PkgPath != "" { // unexported: never settable
+				continue
+			}
+			populateStrings(t, path+"."+tp.Field(i).Name, v.Field(i), depth+1)
+		}
+	case reflect.Slice:
+		if v.Len() == 0 {
+			if !v.CanSet() {
+				return
+			}
+			v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+		}
+		for i := 0; i < v.Len(); i++ {
+			populateStrings(t, path, v.Index(i), depth+1)
+		}
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			populateStrings(t, path, v.Index(i), depth+1)
+		}
+	case reflect.Map:
+		if !v.CanSet() {
+			return
+		}
+		if v.IsNil() {
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+		key := reflect.New(v.Type().Key()).Elem()
+		if key.Kind() == reflect.String {
+			key.SetString("k")
+		}
+		val := reflect.New(v.Type().Elem()).Elem()
+		populateStrings(t, path, val, depth+1)
+		v.SetMapIndex(key, val)
+	}
+}
+
+// walkStrings collects every exported string reachable from inv, keyed by its full
+// field path. It prunes NOTHING — no skip-list, no skipped types — which is the
+// whole point: the expectation lives in egressVerbatim, a table this walk cannot
+// influence, so a redactor skip-list entry that fires on the wrong field shows up
+// as a mismatch instead of being mirrored into agreement.
+func walkStrings(t *testing.T, inv *providers.Investigation) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	var walk func(path string, v reflect.Value, depth int)
+	walk = func(path string, v reflect.Value, depth int) {
+		if depth > maxRedactWalkDepth {
+			t.Fatalf("verification walk exceeded depth %d at %s — a self-referential type?", maxRedactWalkDepth, path)
+		}
 		switch v.Kind() {
 		case reflect.String:
-			if strings.Contains(v.String(), "hunter2horse") {
-				t.Errorf("exported string %s survived egress redaction: %q — add it to the redactor or the skip-list", path, v.String())
-			}
+			out[path] = v.String()
 		case reflect.Pointer, reflect.Interface:
 			if !v.IsNil() {
-				walk(path, v.Elem())
+				walk(path, v.Elem(), depth+1)
 			}
 		case reflect.Struct:
-			if v.Type() == reflect.TypeOf(providers.Workload{}) {
-				return // skip-listed type
-			}
 			tp := v.Type()
 			for i := 0; i < v.NumField(); i++ {
-				f := tp.Field(i)
-				if f.PkgPath != "" || redactionSkipField[f.Name] {
+				if tp.Field(i).PkgPath != "" {
 					continue
 				}
-				walk(path+"."+f.Name, v.Field(i))
+				walk(path+"."+tp.Field(i).Name, v.Field(i), depth+1)
 			}
 		case reflect.Slice, reflect.Array:
 			for i := 0; i < v.Len(); i++ {
-				walk(path, v.Index(i))
+				walk(path, v.Index(i), depth+1)
 			}
 		case reflect.Map:
 			for _, k := range v.MapKeys() {
-				walk(path, v.MapIndex(k))
+				walk(path, v.MapIndex(k), depth+1)
 			}
 		}
 	}
-	walk("Investigation", reflect.ValueOf(inv).Elem())
+	walk("Investigation", reflect.ValueOf(inv).Elem(), 0)
+	return out
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1091,11 +1091,14 @@ type Investigation struct {
 	// (notify.summaryBlocks), both through notify.curateFailureReason; never written to
 	// the KB body.
 	//
-	// The one field on this struct stamped AFTER investigate.redactInvestigation, because
-	// curation runs in the OnComplete pipeline rather than inside the loop. It is
+	// One of exactly two free-text fields on this struct stamped AFTER
+	// investigate.redactInvestigation — the other is Prior (Cause/Resolution) — because
+	// both are produced by the OnComplete pipeline rather than inside the loop. Each is
 	// therefore redacted at its assignment (app.onInvestigationComplete) rather than by
-	// the reflection walk, and it is deliberately NOT on redactionSkipField — it is
-	// server-supplied free text, the opposite of what that list is for.
+	// the reflection walk, and neither is on redactionSkipField: both are untrusted free
+	// text, the opposite of what that list is for. Everything else the pipeline stamps
+	// past the chokepoint is a number, a time, or a server-derived identifier already on
+	// that list (CuratedURL, PrevCuratedURL, Action.ApprovalID).
 	CurateError   string
 	Fingerprint   string      // originating alert fingerprint; for outcome-ledger attribution
 	Fingerprints  []string    // coalesced batch fingerprints; one outcome open is recorded per entry
@@ -1144,6 +1147,11 @@ type MatchedEntry struct {
 // ledger. Stamped at completion — never seen by the model — and only on FRESH
 // investigations of a recurring TriggerKey whose merged entry is findable by
 // dup-fingerprint; nil otherwise, so notifiers fall back to the counter+link.
+//
+// Cause and Resolution are KB body text of external origin (whatever a human wrote
+// during review, verbatim), and they are stamped PAST investigate.redactInvestigation
+// — so app.onInvestigationComplete secret-redacts them at the assignment. EntryPath
+// is a catalog path and stays verbatim.
 type PriorKnowledge struct {
 	Cause      string // excerpt of the merged entry's "## Cause" section
 	Resolution string // excerpt of "## Resolution" — carries the human's review edits, the payoff of curation


### PR DESCRIPTION
`internal/investigate/loop.go` calls itself the single egress chokepoint and runs `redactInvestigation` before `OnComplete`. Three fields escaped it, and the guard meant to catch them could not.

### Gap 1 — `Prior.Cause` / `Prior.Resolution` were a LIVE leak, not a latent one

`internal/app/investigate.go:766` sets `found.Prior` from KB sections *inside* `OnComplete`, past the chokepoint. The working assumption was that every sink redacts again at render, so nothing escaped. That assumption is false: `redact.Secrets` appears exactly **once** in the whole `notify` package — `format.go:79`, on `inv.CurateError` alone. `Format` renders everything else verbatim.

Pre-fix output of the new `TestPriorPayloadCarriesNoSecret`:

```json
"text":"...Prior cause: token ghp_0123...AB expired\n   Prior resolution: rotate\n",
"prior":{"cause":"token ghp_0123...AB expired",...}
```

The token escaped in **both** the webhook JSON and the rendered text. Now redacted at the assignment, exactly as `CurateError` already was.

### Gap 2 — the skip-list was keyed by bare field name, globally

`"Path"`, skip-listed for `MatchedEntry.Path`, also spared `Change.Source.Path` — which `cloudtrail.go:145` packs a verbatim CloudTrail `ErrorMessage` into. Latent only because `Investigation.Changes` is written nowhere outside tests. The lookup is now type-qualified (`"MatchedEntry.Path"`).

### The guard was inert by construction — proved, not argued

`redact_egress_test.go` pruned its walk with `redactionSkipField` **itself**, so it exempted precisely what the redactor exempted. At `HEAD`, giving the old fixture a populated `Change.Source`:

```
--- PASS: TestRedactInvestigationReflectionCoverage
    Change.Source.Path    after redaction = "password=hunter2horse"
    Change.Source.RepoURL after redaction = "password=[REDACTED]"
```

It passed while holding the secret. `RepoURL`, the sibling field of the same struct, *was* scrubbed — so the walk reached the struct and simply refused to look.

The guard is rebuilt on two independent halves: a fixture that populates every exported string reachable from `providers.Investigation` by reflection (allocating nil pointers, filling empty slices and maps), and `egressVerbatim`, a hand-written table of fully-qualified paths the redactor cannot reach. The walk prunes nothing. It fails in both directions, and has a stale-entry check plus a fixture-completeness precondition so it cannot go vacuous.

### Gap 3 — found while auditing, not in the brief

`internal/action/auto.go:133` spliced the apiserver's raw error into `Action.Description` via `"[auto: FAILED — " + err.Error() + "]"`. `Auto.Run` is called from `onInvestigationComplete`, so it is past the chokepoint, and `notify.Format` renders `Action.Description` verbatim into the webhook `text`. Committed separately (`64793cf8`) so it is trivially droppable.

### Full audit of post-chokepoint writes

Seven `OnComplete` assignment sites. Six are pure captures that mutate nothing, and their consumers are read-only renders. Only `app/investigate.go:677` writes: `Occurrences`/`LastOccurrence`/`Prior.Recalls` are non-string; `PrevCuratedURL`/`CuratedURL`/`Prior.EntryPath` are server-derived and skip-listed; `CurateError` was already redacted at assignment; the three above were not.

### `TestOnCompleteDeliversNothingUnredacted`

The structural guard the reading-based finds lacked. It injects a secret at all three external seams (curator error, KB entry body, executor error), asserts each seam actually fired so it cannot go vacuous, then reflectively walks what the notifier really receives.

### Mutations

Each verified applied, then reverted. Notably **M2** — adding a new free-text field `PriorKnowledge.Operator` — **passes, correctly**: the redactor is scrub-by-default, so a new field is safe by construction. **M3**, sneaking `"PriorKnowledge.Cause"` onto the skip-list, fails; that is the class the old guard could never see. Reverting each of the three production fixes individually makes the structural guard name exactly the field reverted.

Also corrected: the `Investigation.CurateError` doc claiming it was "the one field" stamped after the chokepoint.

Gate on each commit individually and on HEAD: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
