### PR TITLE
fix(forge): ASCII-refuse the DERIVED forge git host, on both providers

### DIFF
--- a/internal/app/forge.go
+++ b/internal/app/forge.go
@@ -107,9 +107,43 @@ func BuildCloneTokenSource(cfg *config.Config, log *slog.Logger) ForgeToken {
 // A wrong value here does not leak the credential — it withholds it, which shows
 // up as an empty what_changed. That is why the ambiguous case is a startup
 // failure rather than a default.
+//
+// Every branch folds through asciiLowerHost, so no input reaching this function
+// can produce a boundary that is fold-equal to an ASCII host it is not. The loud
+// remedy lives in config.Validate (validateForgeGitHost / asciiForgeHost), which
+// refuses a non-ASCII forge host at startup naming the key it came from; this is
+// the backstop for a *config.Config assembled without Load.
 func forgeGitHost(cfg *config.Config) string {
-	if h := strings.ToLower(strings.TrimSpace(cfg.Forge.GitHost)); h != "" {
+	if h := asciiLowerHost(strings.TrimSpace(cfg.Forge.GitHost)); h != "" {
 		return h
 	}
 	return forgeWebHost(cfg)
+}
+
+// asciiLowerHost lowercases host when it is 7-bit ASCII and returns it UNCHANGED
+// otherwise. It is the single fold every forge host derivation goes through —
+// forgeGitHost, forgeWebHost and githubGitHost — because each of their results
+// becomes a credential boundary somewhere: Differ.TokenHost, Differ.SSHRewriteHost,
+// the source_diff token host, the forge repo reference a thread link is matched
+// against.
+//
+// Folding a non-ASCII host is the bug, not the input. strings.ToLower applies
+// Unicode simple case mapping and maps U+0130 to plain 'i'; whatever dials the
+// host resolves it through idna.Lookup.ToASCII, which does not. So a forge at
+// "gİtlab.example.com" folded to the boundary "gitlab.example.com" — handing the
+// token to anyone who registers that ASCII name, and withholding it from the
+// operator's own instance, which is the silent what_changed gap of #495.
+//
+// Returning the host UNFOLDED (rather than "") is deliberate on both counts: ""
+// reads as "attach the token everywhere" in whatchanged.Differ, while a retained
+// non-ASCII host equals no clone URL's host at all — whatchanged.hostOf refuses
+// non-ASCII and returns "" — so the credential is confined to nothing until the
+// operator fixes the config that config.Validate already refused to load.
+func asciiLowerHost(host string) string {
+	for i := 0; i < len(host); i++ {
+		if host[i] >= 0x80 {
+			return host
+		}
+	}
+	return strings.ToLower(host)
 }

--- a/internal/app/forge_host_confine_test.go
+++ b/internal/app/forge_host_confine_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+// dottedCapitalI is U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE. strings.ToLower
+// maps it to a plain ASCII 'i' (Unicode simple case mapping); idna.Lookup.ToASCII,
+// which is what actually resolves a host before it is dialled, maps it to "i" +
+// U+0307 and yields a different registrable label. It is written as an escape so
+// this file does not itself contain the confusable it is about.
+const dottedCapitalI = "\u0130"
+
+// TestForgeGitHostNeverFoldsANonASCIIForgeHost pins the DERIVATION, on every key
+// that can produce the credential boundary.
+//
+// forgeGitHost's result is Differ.TokenHost and Differ.SSHRewriteHost for
+// what_changed and Differ.TokenHost for source_diff, which is to say: it decides
+// who receives the forge credential. It used to reach that decision through a
+// bare strings.ToLower, so a forge at "gİtlab.example.com" produced the boundary
+// "gitlab.example.com" — a name someone else can register — while the operator's
+// own instance, resolved through IDNA, matched nothing and was refused the
+// credential it owns.
+//
+// config.Validate now refuses these configs outright (see
+// TestValidateRefusesANonASCIIDerivedForgeHost), which is the loud half. This is
+// the backstop: a *config.Config assembled without Load must still not produce a
+// boundary that is fold-equal to a host it is not.
+func TestForgeGitHostNeverFoldsANonASCIIForgeHost(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cfg     func(t *testing.T) *config.Config
+		notWant string // the ASCII host the old fold produced
+	}{
+		{
+			name: "gitlab base_url",
+			cfg: func(t *testing.T) *config.Config {
+				return gitlabForge(t, "g"+dottedCapitalI+"tlab.example.com")
+			},
+			notWant: "gitlab.example.com",
+		},
+		{
+			name: "github api url",
+			cfg: func(t *testing.T) *config.Config {
+				c := forgeConfigured(t)
+				c.Forge.GitHubAPIURL = "https://g" + dottedCapitalI + "he.example.com/api/v3"
+				return c
+			},
+			notWant: "ghe.example.com",
+		},
+		{
+			name: "explicit git_host",
+			cfg: func(t *testing.T) *config.Config {
+				c := forgeConfigured(t)
+				c.Forge.GitHost = "g" + dottedCapitalI + "thub.com"
+				return c
+			},
+			notWant: "github.com",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := forgeGitHost(tc.cfg(t))
+			if got == tc.notWant {
+				t.Fatalf("forgeGitHost folded a non-ASCII forge host into %q. That host is "+
+					"separately registrable and now collects the forge credential, while the "+
+					"operator's own forge — which resolves elsewhere through IDNA — is refused "+
+					"it, emptying what_changed with only a data-gaps line to show for it", got)
+			}
+			// Empty is not an acceptable answer either: whatchanged.Differ reads
+			// an empty TokenHost as "attach the credential to EVERY clone".
+			if got == "" {
+				t.Fatal("forgeGitHost returned \"\", which whatchanged.Differ reads as an " +
+					"unconfined credential — worse than the fold it replaced")
+			}
+			if !strings.Contains(got, dottedCapitalI) {
+				t.Fatalf("forgeGitHost = %q: a host it will not fold must be returned "+
+					"unchanged, so that it equals no clone URL's host at all", got)
+			}
+		})
+	}
+
+	// The other direction: ASCII case folding is exactly what this function is
+	// for, and it must keep doing it. An operator who writes GIT_HOST in caps, or
+	// a GHE API URL with a capitalised host, still gets a boundary that matches
+	// the lowercased host every clone URL is reduced to.
+	for _, tc := range []struct {
+		name string
+		cfg  func(t *testing.T) *config.Config
+		want string
+	}{
+		{"github.com by default", forgeConfigured, "github.com"},
+		{
+			name: "github enterprise, mixed case api url",
+			cfg: func(t *testing.T) *config.Config {
+				c := forgeConfigured(t)
+				c.Forge.GitHubAPIURL = "https://GHE.Example.COM/api/v3"
+				return c
+			},
+			want: "ghe.example.com",
+		},
+		{
+			name: "self-hosted gitlab, mixed case base_url",
+			cfg:  func(t *testing.T) *config.Config { return gitlabForge(t, "GitLab.Example.COM") },
+			want: "gitlab.example.com",
+		},
+		{
+			name: "punycode idn forge is ASCII and folds normally",
+			cfg:  func(t *testing.T) *config.Config { return gitlabForge(t, "XN--Gtlab-56a.example.com") },
+			want: "xn--gtlab-56a.example.com",
+		},
+		{
+			name: "explicit git_host, mixed case",
+			cfg: func(t *testing.T) *config.Config {
+				c := forgeConfigured(t)
+				c.Forge.GitHost = "  GHE.Example.COM  "
+				return c
+			},
+			want: "ghe.example.com",
+		},
+	} {
+		t.Run("ascii "+tc.name, func(t *testing.T) {
+			if got := forgeGitHost(tc.cfg(t)); got != tc.want {
+				t.Fatalf("forgeGitHost = %q, want %q — an ASCII forge that stops matching its "+
+					"own clone URLs is the silent withholding of #495", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestForgeCredentialIsNotMintedForAHomoglyphOfTheForgeHost executes the
+// credential decision rather than reasoning about it.
+//
+// whatchanged.Differ.auth returns BEFORE calling TokenSource when the clone URL
+// is off-host, so "was the credential minted at all" is a direct, observable
+// answer to "would this clone have carried the token" — no DNS and no reachable
+// remote required, and it does not depend on where the subsequent dial ends up.
+//
+// The attacking clone URL here is the ASCII host the OLD fold produced. On the
+// unfixed derivation the differ's TokenHost was exactly that string, so this
+// clone minted and attached the forge credential.
+func TestForgeCredentialIsNotMintedForAHomoglyphOfTheForgeHost(t *testing.T) {
+	// .invalid is guaranteed never to resolve (RFC 2606), so the clone fails fast
+	// and locally after the credential decision has already been made.
+	const asciiFold = "gitlab.invalid"
+
+	cfg := gitlabForge(t, "g"+dottedCapitalI+"tlab.invalid")
+	d := buildGitOpsDiffer(cfg, discardLog())
+	if d.TokenSource == nil {
+		t.Fatal("no clone credential was wired; this test's premise is stale")
+	}
+	var minted atomic.Int32
+	d.TokenSource = func(context.Context) (string, error) {
+		minted.Add(1)
+		return cloneSecret, nil
+	}
+
+	if _, err := d.Remote(context.Background(), "https://"+asciiFold+"/org/repo.git", "a", "b", ""); err == nil {
+		t.Fatal("want a clone error from an unresolvable host, got nil")
+	}
+	if n := minted.Load(); n != 0 {
+		t.Fatalf("the forge credential was minted %d time(s) for %q — the ASCII host the "+
+			"operator's non-ASCII forge folds to. Anyone can register that name; on the "+
+			"unfixed derivation it received the token", n, asciiFold)
+	}
+
+	// Non-vacuity, and the reason this probe means anything: the same probe on
+	// the same differ DOES mint when the clone URL is the host the credential
+	// belongs to. Without this, a differ that never minted for any reason at all
+	// would pass the assertion above.
+	t.Run("the probe is not vacuous", func(t *testing.T) {
+		ascii := gitlabForge(t, asciiFold)
+		ad := buildGitOpsDiffer(ascii, discardLog())
+		var got atomic.Int32
+		ad.TokenSource = func(context.Context) (string, error) {
+			got.Add(1)
+			return cloneSecret, nil
+		}
+		if _, err := ad.Remote(context.Background(), "https://"+asciiFold+"/org/repo.git", "a", "b", ""); err == nil {
+			t.Fatal("want a clone error from an unresolvable host, got nil")
+		}
+		if got.Load() == 0 {
+			t.Fatalf("a legitimate ASCII forge did not mint its own credential for its own "+
+				"repo (%s) — the assertion above would pass vacuously, and a real deployment "+
+				"would see an empty what_changed", asciiFold)
+		}
+	})
+}
+
+// TestSelfHostedForgeStillAuthenticatesItsOwnRepo is the transport-level other
+// direction, on the provider path this change touched.
+//
+// TestWhatChangedAuthenticatesItsOwnGitHost already covers GitHub Enterprise
+// with an explicit git_host. This covers the DERIVED path — the one that carries
+// the defect and the one most deployments use — for a self-hosted GitLab: the
+// boundary comes from forge.gitlab.base_url through forgeWebHost, and the token
+// has to arrive on the wire at that host.
+func TestSelfHostedForgeStillAuthenticatesItsOwnRepo(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  func(t *testing.T, host string) *config.Config
+	}{
+		{
+			name: "self-hosted gitlab derives its host from base_url",
+			cfg:  gitlabForge,
+		},
+		{
+			name: "github enterprise derives its host from github_api_url",
+			cfg: func(t *testing.T, host string) *config.Config {
+				c := forgeConfigured(t)
+				c.Forge.GitHubAPIURL = "https://" + host + "/api/v3"
+				return c
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			forge := newRecordingRemote(t)
+			d := buildGitOpsDiffer(tc.cfg(t, forge.host(t)), discardLog())
+			d.TokenSource = func(context.Context) (string, error) { return cloneSecret, nil }
+
+			if _, err := d.Remote(context.Background(), forge.cloneURL(), "a", "b", ""); err == nil {
+				t.Fatal("want a clone error from the stub remote, got nil")
+			}
+			hits, saw, tok := forge.observed()
+			if hits == 0 {
+				t.Fatal("no request reached the operator's own forge")
+			}
+			if !saw || tok != cloneSecret {
+				t.Fatalf("the operator's own GitOps repo cloned WITHOUT the forge credential "+
+					"(saw=%v token=%q) — a private repo would produce no diff at all, which is "+
+					"the silent data gap this must not reintroduce", saw, tok)
+			}
+		})
+	}
+}

--- a/internal/app/investigate.go
+++ b/internal/app/investigate.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -383,6 +382,10 @@ func appendSourceDiffTool(cfg *config.Config, tools []investigate.Tool, log *slo
 // configured GitHub API URL. Default/empty ⇒ github.com. A GitHub Enterprise
 // API URL (https://ghe.example.com/api/v3) shares its host with the git remote,
 // so the host is returned as-is; the public api.github.com maps to github.com.
+//
+// The fold goes through asciiLowerHost because this result reaches TokenHost via
+// forgeGitHost: a non-ASCII API host must not be folded into an ASCII name it is
+// not. See asciiLowerHost.
 func githubGitHost(apiURL string) string {
 	if apiURL == "" {
 		return "github.com"
@@ -391,7 +394,7 @@ func githubGitHost(apiURL string) string {
 	if err != nil || u.Hostname() == "" {
 		return "github.com"
 	}
-	if h := strings.ToLower(u.Hostname()); h != "api.github.com" {
+	if h := asciiLowerHost(u.Hostname()); h != "api.github.com" {
 		return h
 	}
 	return "github.com"

--- a/internal/app/notify.go
+++ b/internal/app/notify.go
@@ -239,6 +239,11 @@ func forgeRepoRef(cfg *config.Config) string {
 // hosts: GitHub derives it from the API base, exactly as githubGitHost already
 // does for source-diff allowlisting; GitLab's base_url IS the instance root,
 // which is the host its web_url uses.
+//
+// forgeGitHost derives the CREDENTIAL BOUNDARY from this function, so the fold
+// here is a security decision and not presentation: it goes through
+// asciiLowerHost, which refuses to fold a host that Go and IDNA would normalise
+// to different names. See asciiLowerHost.
 func forgeWebHost(cfg *config.Config) string {
 	if cfg.Forge.Provider != "gitlab" {
 		return githubGitHost(cfg.Forge.GitHubAPIURL)
@@ -250,7 +255,7 @@ func forgeWebHost(cfg *config.Config) string {
 	if err != nil || u.Hostname() == "" {
 		return "gitlab.com"
 	}
-	return strings.ToLower(u.Hostname())
+	return asciiLowerHost(u.Hostname())
 }
 
 // buildThreadChat assembles the conversational reply layer, or returns nil when

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1509,6 +1509,13 @@ func validGitLabProjectPath(s string) bool {
 // investigation, surfacing only as a data-gaps line at the foot of a finding
 // (RunLore #495). So the ambiguity is refused at config load and the operator
 // names the host — loud once, at startup, instead of quiet forever.
+//
+// forge.git_host NAMES that host, but most deployments never set it: the host is
+// DERIVED from forge.github_api_url or from forge.gitlab.base_url instead. A
+// check that only looked at the explicit key therefore guarded the path almost
+// nobody takes, which is how a non-ASCII forge host reached the credential
+// boundary twice over (once per provider). Every key that can produce the
+// boundary is checked here — see asciiForgeHost.
 func validateForgeGitHost(f Forge) error {
 	if f.GitHost != "" {
 		if !bareHost(f.GitHost) {
@@ -1521,7 +1528,12 @@ func validateForgeGitHost(f Forge) error {
 		return nil
 	}
 	if f.Provider == "gitlab" {
-		return nil // gitlab.base_url IS the instance root: git, web and API share that host
+		// gitlab.base_url IS the instance root: git, web and API share that host,
+		// so this key alone decides the credential boundary.
+		return asciiForgeHost("forge.gitlab.base_url", f.GitLab.BaseURL)
+	}
+	if err := asciiForgeHost("forge.github_api_url", f.GitHubAPIURL); err != nil {
+		return err
 	}
 	u, err := url.Parse(f.GitHubAPIURL)
 	if err != nil {
@@ -1538,6 +1550,59 @@ func validateForgeGitHost(f Forge) error {
 		"host it is not valid for, or withhold it from every GitOps repository — which shows up only "+
 		"as an empty what_changed",
 		f.GitHubAPIURL, strings.TrimPrefix(h, "api."), h)
+}
+
+// asciiForgeHost refuses a forge URL whose HOST carries a byte above 7-bit
+// ASCII, naming the key that carries it.
+//
+// RunLore derives from this URL the one host its forge credential may be sent
+// to, and compares that host against every clone URL after strings.ToLower. On a
+// non-ASCII host that fold and the IDNA mapping the dialler applies disagree:
+// ToLower maps U+0130 to plain 'i', so a base_url of "https://gİtlab.example.com"
+// yields the boundary "gitlab.example.com" — a SEPARATELY REGISTRABLE host that
+// now collects the token — while the operator's real instance resolves to
+// "xn--gtlab-56a.example.com" and is refused the credential it owns, emptying
+// what_changed with nothing but a data-gaps line to show for it (RunLore #495).
+// Both halves of that are silent, so this is a startup failure rather than a
+// normalisation.
+//
+// The check is ASCII, not the full bareHost shape the explicit forge.git_host
+// gets: url.Hostname() has already stripped the scheme, port, userinfo and path
+// that bareHost exists to reject, and an IPv6 literal or an underscore label
+// reaching it is a legitimate self-hosted spelling that folds identically either
+// way. ASCII is the whole of what makes the normalisers agree.
+func asciiForgeHost(key, rawURL string) error {
+	if rawURL == "" {
+		return nil // the provider's built-in default host, which is ASCII
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return nil // no host to derive from: the built-in default is used instead
+	}
+	if h := u.Hostname(); !asciiHost(h) {
+		return fmt.Errorf("%s %q has the non-ASCII host %q, which RunLore cannot use as a credential "+
+			"boundary: it lowercases that host to compare it against every clone URL, and the "+
+			"lowercased spelling is a DIFFERENT registrable name from the one your git client "+
+			"resolves through IDNA. Accepting it would attach the forge token to whichever host the "+
+			"fold names and withhold it from yours, which surfaces only as an empty what_changed. "+
+			"Write the host in its ASCII (punycode, \"xn--\") form, or set forge.git_host to that "+
+			"form explicitly", key, rawURL, h)
+	}
+	return nil
+}
+
+// asciiHost reports whether s is free of bytes above 7-bit ASCII — the one
+// property that makes strings.ToLower, strings.EqualFold and idna.Lookup.ToASCII
+// agree about which host is being named. Same guard as whatchanged.isASCII and
+// sourcerepo's allowlist character check, applied where a host is DERIVED rather
+// than where one arrives.
+func asciiHost(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 // bareHost reports whether s is a hostname and nothing else: ASCII letters,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1027,6 +1027,121 @@ func TestValidateForgeGitHost(t *testing.T) {
 	})
 }
 
+// TestValidateRefusesANonASCIIDerivedForgeHost is the contract the rejected
+// git_host cases above already had, applied to the keys that ACTUALLY produce
+// the host in most deployments.
+//
+// forge.git_host has been refused for non-ASCII since the confinement shipped.
+// But it is an OVERRIDE: leave it unset — as nearly every install does — and the
+// boundary is derived from forge.github_api_url or forge.gitlab.base_url, and
+// neither was checked. A base_url of "https://gİtlab.example.com" loaded
+// clean, and RunLore lowercased it into the credential boundary
+// "gitlab.example.com" — a SEPARATELY REGISTRABLE name that now collects the
+// forge token, while the operator's own instance (which resolves through IDNA to
+// xn--gtlab-56a.example.com) is refused the credential it owns and produces the
+// empty what_changed of RunLore #495. Both halves silent, on both providers.
+//
+// The remedy has to be LOUD. Quietly withholding IS the #495 failure mode, so
+// this fails config load naming the key the operator has to edit.
+func TestValidateRefusesANonASCIIDerivedForgeHost(t *testing.T) {
+	// U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE: strings.ToLower maps it to a
+	// plain ASCII 'i', idna.Lookup.ToASCII does not. Written as an escape so this
+	// test does not itself contain the confusable it is about.
+	const dottedCapitalI = "\u0130"
+
+	for _, tc := range []struct {
+		name, key string
+		apply     func(c *Config)
+	}{
+		{
+			name: "gitlab base_url",
+			key:  "forge.gitlab.base_url",
+			apply: func(c *Config) {
+				c.Forge.Provider = "gitlab"
+				c.Forge.GitLab.TokenEnv = "GITLAB_TOKEN"
+				c.Forge.GitLab.BaseURL = "https://g" + dottedCapitalI + "tlab.example.com"
+			},
+		},
+		{
+			name: "github api url",
+			key:  "forge.github_api_url",
+			apply: func(c *Config) {
+				c.Forge.GitHubAPIURL = "https://g" + dottedCapitalI + "he.example.com/api/v3"
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Config{}
+			tc.apply(c)
+			err := c.Validate()
+			if err == nil {
+				t.Fatalf("a non-ASCII host in %s loaded clean; RunLore lowercases it into the "+
+					"credential boundary, so the forge token goes to the ASCII name that fold "+
+					"produces and is withheld from the operator's own forge", tc.key)
+			}
+			if !strings.Contains(err.Error(), tc.key) {
+				t.Fatalf("the refusal must name the key the operator has to edit (%s), got: %v",
+					tc.key, err)
+			}
+		})
+	}
+
+	// The other direction, and the one this refusal must not cost: every ASCII
+	// forge spelling an operator legitimately runs still loads. Over-refusing
+	// here would be #495 again, arriving as a startup crash instead of an empty
+	// result.
+	for _, tc := range []struct {
+		name  string
+		apply func(c *Config)
+	}{
+		{"github.com default", func(*Config) {}},
+		{"github.com spelled out", func(c *Config) { c.Forge.GitHubAPIURL = "https://api.github.com" }},
+		{"github enterprise", func(c *Config) { c.Forge.GitHubAPIURL = "https://ghe.example.com/api/v3" }},
+		{"github enterprise on a port", func(c *Config) {
+			c.Forge.GitHubAPIURL = "https://ghe.example.com:8443/api/v3"
+		}},
+		{"gitlab.com", func(c *Config) {
+			c.Forge.Provider = "gitlab"
+			c.Forge.GitLab.TokenEnv = "GITLAB_TOKEN"
+		}},
+		{"self-hosted gitlab", func(c *Config) {
+			c.Forge.Provider = "gitlab"
+			c.Forge.GitLab.TokenEnv = "GITLAB_TOKEN"
+			c.Forge.GitLab.BaseURL = "https://gitlab.example.com"
+		}},
+		// The derived keys get an ASCII refusal, NOT the full bareHost shape the
+		// explicit git_host gets: url.Hostname() has already stripped what
+		// bareHost exists to reject, and these two spellings fold identically
+		// under every normaliser, so refusing them would break real deployments
+		// for no security gain.
+		{"self-hosted gitlab with an underscore label", func(c *Config) {
+			c.Forge.Provider = "gitlab"
+			c.Forge.GitLab.TokenEnv = "GITLAB_TOKEN"
+			c.Forge.GitLab.BaseURL = "https://git_lab.internal"
+		}},
+		{"self-hosted gitlab on an IPv6 literal", func(c *Config) {
+			c.Forge.Provider = "gitlab"
+			c.Forge.GitLab.TokenEnv = "GITLAB_TOKEN"
+			c.Forge.GitLab.BaseURL = "https://[2001:db8::1]:8443"
+		}},
+		// Punycode IS the ASCII spelling of an internationalised forge, so an
+		// operator who runs one has a way through that does not need git_host.
+		{"punycode idn forge", func(c *Config) {
+			c.Forge.Provider = "gitlab"
+			c.Forge.GitLab.TokenEnv = "GITLAB_TOKEN"
+			c.Forge.GitLab.BaseURL = "https://xn--gtlab-56a.example.com"
+		}},
+	} {
+		t.Run("accepted "+tc.name, func(t *testing.T) {
+			c := &Config{}
+			tc.apply(c)
+			if err := c.Validate(); err != nil {
+				t.Fatalf("a legitimate ASCII forge must still load, got: %v", err)
+			}
+		})
+	}
+}
+
 // TestLogsIndexValidate: logs.index is interpolated into the Elasticsearch
 // request PATH. The client escapes it so a malformed value can no longer change
 // the request's SHAPE, but escaping alone turns a typo into a puzzling 4xx from

--- a/internal/foldguard/doc.go
+++ b/internal/foldguard/doc.go
@@ -19,6 +19,17 @@
 //     not, so kind "ſecret" (U+017F) skipped the refusal and still resolved to
 //     v1/secrets.
 //
+// A third instance shipped after the guard did, and is why it has three arms
+// rather than two: internal/app derived the forge git host from
+// forge.gitlab.base_url / forge.github_api_url with a bare strings.ToLower and
+// stored the result in whatchanged.Differ.TokenHost. A GitLab base_url of
+// "https://g\u0130tlab.example.com" became the credential boundary
+// "gitlab.example.com" — a separately registrable host that then collected the
+// forge token, while the operator's own instance was refused it and what_changed
+// went silently empty. The fold and the comparison sat in DIFFERENT PACKAGES,
+// which is exactly what the first two arms cannot see, so the third arm keys on
+// the assignment that carries a host across that edge.
+//
 // The guard itself lives entirely in foldguard_test.go, which states what it
 // does and does not cover.
 package foldguard

--- a/internal/foldguard/foldguard_test.go
+++ b/internal/foldguard/foldguard_test.go
@@ -137,6 +137,100 @@ func TestEveryCaseFoldedHostComparisonIsPinned(t *testing.T) {
 	}
 }
 
+// TestEveryHostCredentialBoundaryIsPinned is the arm for instance 3, and it
+// exists because the two arms above BOTH looked straight past it.
+//
+// Instance 3 was a fold in package app (forgeGitHost -> forgeWebHost) whose
+// result was stored into whatchanged.Differ.TokenHost and compared in package
+// whatchanged. Neither arm could see it:
+//
+//   - the divergence arm groups folds BY PACKAGE, and there is only one fold on
+//     each side of the boundary;
+//   - the comparison arm is keyed by the function that COMPARES, and the
+//     comparing function (whatchanged auth) was already pinned as protected —
+//     protected against a bad clone URL, which is a different operand from the
+//     one that went bad;
+//   - and valueKey keys cfg.Forge.GitHost as "githost", not as a host, so the
+//     deriving function was not recognised as touching a host at all.
+//
+// So this arm changes what it keys on. Not the fold and not the comparison, but
+// the WRITE: a value stored into a field whose name ends in "host" is a host that
+// outlives the function that computed it, and every such field in this repo is
+// something a credential is later confined to (Differ.TokenHost,
+// Differ.SSHRewriteHost) or a request is later aimed at (url.URL.Host). Where the
+// value came from does not matter, which is exactly the property the other two
+// arms lacked: a boundary assembled across a package edge is still one assignment.
+//
+// It pins rather than proves, like the comparison arm, and for the same reason —
+// whether a given write is safe depends on what produced the value, which may be
+// three packages away. What it buys is that the population cannot grow in
+// silence, and that a new sink for a derived host has to be argued for in prose
+// by whoever adds it.
+//
+// Deliberately NOT flagged: a local variable named host. Every host derivation
+// writes one, so keying on locals would pin eight functions that merely compute
+// and report nothing about where the value ends up. Fields are the edge that
+// matters.
+func TestEveryHostCredentialBoundaryIsPinned(t *testing.T) {
+	pkgs, _ := internalPackages(t)
+
+	found := map[string]bool{}
+	for _, p := range pkgs {
+		for _, site := range hostBoundaryWrites(p.name, p.files) {
+			found[site] = true
+		}
+	}
+	if len(found) == 0 {
+		t.Fatal("found no write into a host-named field anywhere under internal/, but " +
+			"knownHostBoundaries names several — the reader has gone inert")
+	}
+
+	for site := range found {
+		if _, ok := knownHostBoundaries[site]; !ok {
+			t.Errorf("%s WRITES A HOST INTO A CREDENTIAL BOUNDARY.\n"+
+				"A host stored in a field outlives the function that derived it: whatchanged.Differ "+
+				"confines the forge token to TokenHost and aims its SSH rewrite at SSHRewriteHost, so "+
+				"whatever fold produced the value decides who receives the credential — in a DIFFERENT "+
+				"package from the one that compares it, which is why neither other arm sees this.\n"+
+				"Derive the value through a fold that refuses non-ASCII (internal/app asciiLowerHost is "+
+				"the pattern) and refuse it loudly at config load, then add %q to knownHostBoundaries "+
+				"naming what protects it.", site, site)
+		}
+	}
+	for site, why := range knownHostBoundaries {
+		if !found[site] {
+			t.Errorf("knownHostBoundaries pins %q, which no longer writes a host into a field "+
+				"(%s). Delete the entry: a pin that has stopped matching is an acknowledgement that has "+
+				"silently become permanent.", site, why)
+		}
+	}
+}
+
+// knownHostBoundaries is every function under internal/ that stores a host into a
+// field, with what keeps the stored value honest.
+var knownHostBoundaries = map[string]string{
+	"app buildGitOpsDiffer": "sets Differ.TokenHost and Differ.SSHRewriteHost from forgeGitHost — the " +
+		"what_changed credential boundary, and the site instance 3 shipped through. PROTECTED on both " +
+		"halves: forgeGitHost folds through asciiLowerHost so the stored host is never the fold-equal " +
+		"twin of an ASCII name, and config.validateForgeGitHost refuses a non-ASCII forge host at load " +
+		"on every key that can produce one (forge.git_host, forge.github_api_url, " +
+		"forge.gitlab.base_url). Both are needed: the fold alone fails CLOSED, which withholds the " +
+		"credential from the operator's own repo and shows up only as an empty what_changed.",
+
+	"app appendSourceDiffTool": "sets Differ.TokenHost for source_diff from the same forgeGitHost. " +
+		"Same protection, and the exposure is wider rather than narrower: source_diff clone URLs are " +
+		"model-chosen across the whole source_repos.allow list, so an off-by-one-rune boundary hands " +
+		"the forge token to any allowlisted host that happens to match the fold.",
+
+	"server proxy": "sets url.URL.Host to the leader address before relaying an authenticated request " +
+		"(bearer token, Slack/PagerDuty HMAC) to it. PROTECTED, and not by a fold at all: addr comes " +
+		"from the leader-election Lease — a net.ParseIP-validated pod IP written through authenticated " +
+		"API-server access — plus this replica's own serve port, so it is never request-controlled and " +
+		"never case-normalised. Listed because it is a host aimed at with credentials attached, which " +
+		"is the shape this arm watches; if addr ever became operator- or request-supplied, this entry " +
+		"is where that has to be argued.",
+}
+
 // knownHostComparisons is every function under internal/ that compares a
 // case-folded host, with the reason it is (or is not yet) safe.
 //
@@ -168,11 +262,19 @@ var knownHostComparisons = map[string]string{
 		"IDNA cannot disagree. EqualFold rather than ToLower is deliberate here: ASCII case is the only " +
 		"difference a faithful rewrite may introduce.",
 
-	"config validateForgeGitHost": "validates the operator-supplied forge.git_host. PROTECTED, and it " +
-		"is the protection the whatchanged auth entry above depends on: it refuses anything that is not " +
-		"a bare ASCII hostname, so the value every clone host is later compared against can never be " +
-		"the fold-equal half of an IDNA-different pair. Loosening this to accept an IDN would reopen " +
-		"instance 1 through the HTTPS path rather than the SSH one.",
+	"config validateForgeGitHost": "validates the forge git host on EVERY key that can produce it, " +
+		"which is what this entry used to claim without it being true. It said the function refused " +
+		"anything that was not a bare ASCII hostname, 'so the value every clone host is later compared " +
+		"against can never be the fold-equal half of an IDNA-different pair' — false on both providers " +
+		"as written: bareHost was applied ONLY to an explicit forge.git_host, and the DERIVED path most " +
+		"deployments actually use (forge.github_api_url, forge.gitlab.base_url) returned nil unchecked, " +
+		"so gitlab.base_url \"https://g\\u0130tlab.example.com\" loaded clean and became the boundary " +
+		"\"gitlab.example.com\". PROTECTED now, and only now: forge.git_host still gets bareHost, and " +
+		"the two derived keys get asciiForgeHost, which refuses a non-ASCII url.Hostname() at load " +
+		"naming the key. That refusal also guards this function's OWN ToLower(u.Hostname()), which runs " +
+		"after it on the same URL. What it is NOT is a bareHost check on the derived keys: an IPv6 " +
+		"literal or an underscore label still passes, because those fold identically and refusing them " +
+		"would break real self-hosted spellings.",
 
 	"httpx DenyInternalRedirect": "decides whether to strip provider key headers when a redirect " +
 		"changes host. UNPROTECTED: neither hostname is ASCII-checked. The exploitable direction is " +
@@ -187,9 +289,21 @@ var knownHostComparisons = map[string]string{
 		"classified — the disagreement has no second half here.",
 
 	"app githubGitHost": "derives the git host from the configured GitHub API URL and compares it to " +
-		"api.github.com. Operator-supplied config rather than cluster state, so it is not the same " +
-		"threat as a repoURL anyone with Application create can set; still folded, still compared, " +
-		"still worth failing on if a second comparison is added here.",
+		"api.github.com. PROTECTED at the fold: it folds through asciiLowerHost, which returns a " +
+		"non-ASCII host UNCHANGED, so the operand compared here is either ASCII or a value no ASCII " +
+		"host can equal. Operator config rather than cluster state, but it feeds forgeGitHost and " +
+		"therefore Differ.TokenHost, which is why the fold is not merely cosmetic.",
+
+	"app forgeGitHost": "derives the ONE host the forge clone credential may be sent to — " +
+		"Differ.TokenHost and Differ.SSHRewriteHost both come from here — and compares the folded " +
+		"result against \"\" to choose between the explicit forge.git_host and the host derived from " +
+		"the provider URL. It became VISIBLE to this reader only when the fold moved to asciiLowerHost: " +
+		"before that it folded cfg.Forge.GitHost, which valueKey keys as \"githost\" rather than as a " +
+		"host, so the credential boundary of the whole repo was derived in a function this guard could " +
+		"not see. PROTECTED at the fold by asciiLowerHost; the LOUD half is config.validateForgeGitHost, " +
+		"which refuses a non-ASCII forge host at startup naming the key, because a boundary that merely " +
+		"fails closed here withholds the credential from the operator's own forge and empties " +
+		"what_changed (#495) instead of saying so.",
 
 	"thread prNumberInRepo": "matches a link's host against the configured forge repo before " +
 		"reading a PR number out of it. Both sides are operator config, and the function's own comment " +
@@ -219,7 +333,7 @@ const minFoldSites = 40
 // makes about itself and then watched come true.
 func TestFoldGuardCatchesTheShapesItClaimsTo(t *testing.T) {
 	for _, tc := range []struct {
-		name, src, wantDiverge, wantHost string
+		name, src, wantDiverge, wantHost, wantBoundary string
 		// noFolds marks the one fixture that deliberately contains no case
 		// normalisation at all, so the emptiness check below stays an assertion
 		// everywhere else.
@@ -391,7 +505,79 @@ func hostOf(s string) string { return strings.ToLower(u.Hostname()) }
 			wantHost: "forge pick",
 		},
 
+		// ---- instance 3: a host derived in one package, confined in another ----
+		{
+			// Exactly as it shipped. wantHost is EMPTY on purpose and is the
+			// whole point of the fixture: no function here compares a folded
+			// host, because forgeGitHost folds cfg.Forge.GitHost (keyed
+			// "githost", not a host) and buildGitOpsDiffer only STORES the
+			// result. The comparison that consumes it lives in package
+			// whatchanged, whose own entry was already pinned as protected —
+			// against a hostile clone URL, not against a folded TokenHost.
+			name: "INSTANCE 3: the credential boundary is derived here and compared a package away",
+			src: `package app
+
+func forgeWebHost(cfg *config.Config) string {
+	u, err := url.Parse(cfg.Forge.GitLab.BaseURL)
+	if err != nil || u.Hostname() == "" {
+		return "gitlab.com"
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+func forgeGitHost(cfg *config.Config) string {
+	if h := strings.ToLower(strings.TrimSpace(cfg.Forge.GitHost)); h != "" {
+		return h
+	}
+	return forgeWebHost(cfg)
+}
+
+func buildGitOpsDiffer(cfg *config.Config) *whatchanged.Differ {
+	differ := &whatchanged.Differ{TokenSource: BuildCloneTokenSource(cfg)}
+	if differ.TokenSource != nil {
+		host := forgeGitHost(cfg)
+		differ.TokenHost, differ.SSHRewriteHost = host, host
+	}
+	return differ
+}
+`,
+			wantBoundary: "app buildGitOpsDiffer",
+		},
+		{
+			name: "INSTANCE 3 written as a composite literal, which is the same boundary",
+			src: `package app
+
+func appendSourceDiffTool(cfg *config.Config) {
+	sd := &whatchanged.Differ{
+		TokenSource: BuildCloneTokenSource(cfg),
+		TokenHost:   forgeGitHost(cfg),
+	}
+	register(sd)
+}
+
+func forgeGitHost(cfg *config.Config) string { return strings.ToLower(cfg.Forge.GitHost) }
+`,
+			wantBoundary: "app appendSourceDiffTool",
+		},
+
 		// ---- shapes the guard MUST stay silent on ----
+		{
+			// A local named host is a derivation, not a boundary: it dies with
+			// the function. Keying on locals would pin every host-deriving
+			// function in the repo while saying nothing about who receives the
+			// value. The comparison arm still fires here, which is what keeps
+			// the two arms independent rather than one being a rename of the
+			// other.
+			name: "a folded host in a LOCAL is compared, but crosses no boundary",
+			src: `package httpx
+
+func trustedHost(req *http.Request) bool {
+	host := strings.ToLower(req.URL.Hostname())
+	return trusted[host]
+}
+`,
+			wantHost: "httpx trustedHost",
+		},
 		{
 			name: "one normaliser used many times on one value is fine",
 			src: `package kbimport
@@ -530,6 +716,14 @@ func (d *Differ) auth(cloneURL string) error {
 			case tc.wantHost != "" && !slices.Contains(hosts, tc.wantHost):
 				t.Errorf("want the host comparison %q reported, got %v", tc.wantHost, hosts)
 			}
+
+			bounds := hostBoundaryWrites(pkg, files)
+			switch {
+			case tc.wantBoundary == "" && len(bounds) != 0:
+				t.Errorf("want no host credential boundary reported, got %v", bounds)
+			case tc.wantBoundary != "" && !slices.Contains(bounds, tc.wantBoundary):
+				t.Errorf("want the host boundary %q reported, got %v", tc.wantBoundary, bounds)
+			}
 		})
 	}
 }
@@ -637,6 +831,12 @@ func TestTheNormalisersReallyDisagreeAndOnlyOnNonASCII(t *testing.T) {
 //     this guard against a820c95. Had it instead widened what the already-pinned
 //     auth accepts, nothing here would have moved. Two same-named methods on
 //     different types in one package also collide into one key.
+//   - THE BOUNDARY ARM IS KEYED BY FIELD NAME, so it finds a host stored in
+//     TokenHost or url.URL.Host and misses one stored in a field called Endpoint,
+//     Remote or Target. It also says nothing about whether the stored value is
+//     safe — that judgement is prose in knownHostBoundaries, and the prose in the
+//     entry it replaced was WRONG for a whole release, which is the standing
+//     argument for checking these claims by running them rather than reading them.
 // ---------------------------------------------------------------------------
 
 // normalisers maps a fully-qualified callee to the case normalisation it applies.
@@ -771,6 +971,56 @@ func hostComparisons(pkg string, files []*ast.File) []string {
 	}
 	sort.Strings(out)
 	return slices.Compact(out)
+}
+
+// hostBoundaryWrites returns "<pkg> <func>" for every function that STORES a host
+// into a field — the invisible half of instance 3.
+//
+// A write counts when the target is a field (x.TokenHost = v) or a composite
+// literal key (Differ{TokenHost: v}) whose name ends in "host". Locals do not
+// count: see the test's comment for why. The value's provenance is not inspected
+// at all — that is the point, since the fold that produced it may be in another
+// package, which is precisely what hid this instance from the other two arms.
+func hostBoundaryWrites(pkg string, files []*ast.File) []string {
+	var out []string
+	for _, f := range files {
+		eachScope(f, func(fn string, n ast.Node) {
+			if writesHostField(n) {
+				out = append(out, pkg+" "+fn)
+			}
+		})
+	}
+	sort.Strings(out)
+	return slices.Compact(out)
+}
+
+// writesHostField reports whether the scope assigns into a host-named field.
+func writesHostField(n ast.Node) bool {
+	found := false
+	ast.Inspect(n, func(n ast.Node) bool {
+		switch e := n.(type) {
+		case *ast.AssignStmt:
+			for _, lhs := range e.Lhs {
+				if sel, ok := lhs.(*ast.SelectorExpr); ok && isHostField(sel.Sel.Name) {
+					found = true
+				}
+			}
+		case *ast.KeyValueExpr:
+			if id, ok := e.Key.(*ast.Ident); ok && isHostField(id.Name) {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// isHostField reports whether a field name names a host. "Host", "Hostname",
+// "TokenHost" and "SSHRewriteHost" all qualify; the suffix rule is what catches a
+// boundary field nobody has invented yet.
+func isHostField(name string) bool {
+	n := strings.ToLower(name)
+	return n == "hostname" || strings.HasSuffix(n, "host")
 }
 
 // hostReturningFuncs finds the same-package functions whose body case-normalises


### PR DESCRIPTION
The third instance this release of the same defect class: **the string checked is normalised differently from the string used.** The first two were the `@`-smuggling scp/RFC3986 disagreement and the IDN homoglyph on the SSH rewrite. This is the HTTPS side of the same leak, on the *derived* forge host.

### Reproduced by executing, before any change

```
gitlab base_url = "https://gİtlab.example.com"
config.Validate ACCEPTED
forgeWebHost = "gitlab.example.com"    forgeGitHost = "gitlab.example.com"
TokenHost = "gitlab.example.com"       SSHRewriteHost = "gitlab.example.com"

github_api_url = "https://gİthe.example.com/api/v3"
config.Validate ACCEPTED               forgeGitHost = "githe.example.com"
```

`İ` (U+0130) lowercases under Go's simple case mapping to `i̇` — but `strings.ToLower` on the *host* produced plain `gitlab.example.com`, so a host the operator does not own became the host the token is scoped to. Both providers.

And the leak is real at the credential decision, not merely in the derived value: with the unfixed derivation, `Differ.Remote` on `https://gitlab.invalid/...` **minted the token** (`minted=1`) for a host the operator does not own, while the operator's own forge matched nothing.

### The fix

| Where | What |
|---|---|
| `internal/config/config.go` | `asciiForgeHost(key, rawURL)` refuses a non-ASCII `url.Hostname()` at config load, **naming the key**. Wired into `validateForgeGitHost` for `forge.gitlab.base_url` and `forge.github_api_url`. `forge.git_host` keeps `bareHost`. |
| `internal/app/forge.go` | `asciiLowerHost` — the single fold all three derivations now go through. Returns a non-ASCII host **unchanged**, never `""`, because `""` means "attach the token everywhere" in `Differ`. |
| `notify.go`, `investigate.go` | `forgeWebHost` and `githubGitHost` fold through it. |

ASCII refusal rather than full `bareHost` on the derived keys: `url.Hostname()` already strips scheme, port, userinfo and path, and IPv6 literals and underscore labels fold identically — refusing them would break real deployments for no gain. Verified still loading: `https://[2001:db8::1]:8443`, `https://git_lab.internal`, `https://xn--gtlab-56a.example.com`.

It fails loud: config load stops and names the key. The app-side refusal is the backstop for a `*config.Config` built without `Load`.

### A false claim in the existing pin, corrected

`foldguard_test.go:171` asserted that `validateForgeGitHost` "refuses anything that is not a bare ASCII hostname, so the value every clone host is later compared against can never be the fold-equal half of an IDNA-different pair." **False on both providers.** Rewritten to quote the old claim, say why it was false, state what is true now, and state what it still does not do.

### foldguard's third arm

`TestEveryHostCredentialBoundaryIsPinned` keys on neither the fold nor the comparison — neither survives a package edge — but on the **write**: a value stored into a field whose name ends in `host`. Pins `app buildGitOpsDiffer`, `app appendSourceDiffTool`, `server proxy`. Locals are excluded deliberately; including them pins 8 unrelated derivations, proved by mutation M8.

Side effect worth recording: routing `forgeGitHost`'s fold through a host-*named* parameter made it visible to the **existing** comparison arm, which now pins it. Previously `valueKey` keyed `cfg.Forge.GitHost` as `"githost"`, so the repo's credential boundary was derived in a function the guard could not see at all.

### Mutations — 8, each asserted applied

| # | Mutation | Result |
|---|---|---|
| M1 | app-side `asciiLowerHost` → `strings.ToLower` (×3) | 3 subtests fail; **credential minted 1×** for the ASCII twin |
| M2 | both config refusals removed | both provider subtests fail |
| M3 | GitLab refusal only | **only** gitlab fails — providers covered independently |
| M4 | `asciiLowerHost` returns `""` | "unconfined credential — worse than the fold it replaced" fires |
| M5 | `asciiLowerHost` never folds | ASCII direction fails |
| M6 | `writesHostField` → false | stale pins fail **and** both instance-3 fixtures fail |
| M7 | `isHostField` → true | 464 unpinned sites reported — new-site direction live |
| M8 | locals counted | silence fixture fails (`got [httpx trustedHost]`) |

Non-vacuity is built in: the minting probe has a positive control (an ASCII forge does mint for its own repo), and `TestSelfHostedForgeStillAuthenticatesItsOwnRepo` proves on the wire that a self-hosted GitLab and a GHE derived from `github_api_url` still receive the token.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.
