### PR TITLE
docs(upgrade): state the 0.15.0 migration correctly, and guard the footer defect that broke it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history AND tags. internal/docsguard's breaking-change-footer guard
+          # scans <last release tag>..HEAD — the exact set release-please will parse
+          # into the next CHANGELOG entry — so it needs the tag and every commit back
+          # to it. actions/checkout defaults to depth 1 with no tags, which leaves that
+          # guard no window at all; it fails loudly rather than passing vacuously, so
+          # this is load-bearing, not an optimisation.
+          fetch-depth: 0
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to RunLore are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-RunLore is **pre-1.0 and under active development** — there are no tagged releases
-yet, so everything currently lives under `[Unreleased]`.
+RunLore is **pre-1.0 and under active development**: a breaking change bumps the
+**minor** version, not the major, so a `0.x` upgrade can still require migration.
+Read the ⚠ BREAKING CHANGES section of every release you cross; the migration steps
+are spelled out under
+[Upgrade & Uninstall](https://runlore.io/docs/operations/upgrade-uninstall/).
 
 ## [0.14.0](https://github.com/Smana/runlore/compare/v0.13.0...v0.14.0) (2026-08-14)
 

--- a/internal/docsguard/breaking_change_footers_test.go
+++ b/internal/docsguard/breaking_change_footers_test.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// This file guards the ONE mechanism that carries migration prose — not just a subject
+// line — from a commit into CHANGELOG.md: the `BREAKING CHANGE:` footer.
+//
+// It exists because that mechanism failed silently and shipped. The 0.15.0 release notes
+// told operators "The default is unchanged at 100000" while the shipped default was
+// 400000, twice over, and both instances trace to the footer parser rather than to
+// anything a human wrote wrong in isolation:
+//
+//   - release-please's toConventionalChangelogFormat keeps a SINGLE breaking.text, filled
+//     by the FIRST body-level node it finds. A squash body carrying two footers therefore
+//     renders the FIRST one — and in a stacked branch the first is the OLDEST, i.e. the
+//     superseded one. 8d26929's correct footer (400000, the derived quarter, the
+//     compaction trigger, the measured overshoot) never reached the changelog at all.
+//   - A branch stacked on that one inherited the footer. 0ef4507's subject is
+//     `fix(eval):` with no `!`, but the inherited footer made release-please render it as
+//     breaking anyway — emitting the same wrong paragraph a second time, under a scope
+//     that never made a breaking change.
+//
+// Both are mechanical and both are visible in git history before the release PR is ever
+// generated, which is where this guard reads them.
+
+// breakingFooterRE matches a conventional-commits BREAKING CHANGE footer token: it must
+// open a line, and both the spec's spellings count. Matching anywhere in the line would
+// fire on prose that merely quotes the token (this very repo's commit bodies discuss it
+// at length), so the anchor is deliberately line-anchored.
+var breakingFooterRE = regexp.MustCompile(`(?m)^BREAKING[ -]CHANGE:`)
+
+// conventionalSubjectRE splits a conventional-commit subject into its type, optional
+// scope and the `!` that marks it breaking — the same shape release-please parses.
+var conventionalSubjectRE = regexp.MustCompile(`^([a-zA-Z]+)(\([^()]*\))?(!)?:`)
+
+// countBreakingFooters returns how many BREAKING CHANGE footers a commit BODY carries.
+// More than one is the defect: release-please keeps a single breaking.text and fills it
+// from the first, so every footer after the first is silently discarded — and the one
+// that survives is the one written earliest, which in a stacked branch is the one later
+// work superseded.
+func countBreakingFooters(body string) int {
+	return len(breakingFooterRE.FindAllString(body, -1))
+}
+
+// subjectMarksBreaking reports whether a conventional-commit subject carries the `!`
+// that declares the change breaking. A subject with no `!` whose body carries a footer
+// is still rendered as breaking by release-please, so the two must agree or the
+// changelog attributes a migration to a scope that never made one.
+func subjectMarksBreaking(subject string) bool {
+	m := conventionalSubjectRE.FindStringSubmatch(subject)
+	return m != nil && m[3] == "!"
+}
+
+// footerExemptions are commits ALREADY ON MAIN when this guard landed. They cannot be
+// rewritten — main is protected and every SHA below is public — so the remedy for them
+// is the corrected prose in website/content/docs/operations/upgrade-uninstall.md and a
+// hand-correction of the release PR's changelog, not a history rewrite.
+//
+// They are not dead weight once 0.15.0 is tagged and they leave the scanned window:
+// TestBreakingFooterExemptionsAreStillEarned asserts each still resolves and still
+// violates, so they go on serving as real-history fixtures proving this file's detector
+// fires on the exact commits that caused the incident. Delete an entry only when its
+// claim stops being true.
+var footerExemptions = map[string]string{
+	"8d26929403971aac24b4f5b71cdd2bb82f50bc4c": "two footers: the stacked branch's superseded " +
+		"100000 note won over the correct 400000 one. Already on main; corrected in the upgrade docs.",
+	"0ef4507090d6859e93532fcf5d88087310465e40": "two footers inherited from the branch it was " +
+		"stacked on, under a `fix(eval):` subject with no `!`. Already on main.",
+}
+
+// commitRecord is one commit as this guard reads it: the subject release-please parses
+// and the body it mines footers from.
+type commitRecord struct {
+	SHA     string
+	Subject string
+	Body    string
+}
+
+// TestNoCommitCarriesTwoBreakingChangeFooters fails a commit whose body declares the
+// breaking change twice. Only the first survives into CHANGELOG.md, so the second is
+// prose the author believed they had published and nobody will ever read.
+func TestNoCommitCarriesTwoBreakingChangeFooters(t *testing.T) {
+	for _, c := range releaseWindow(t) {
+		if _, exempt := footerExemptions[c.SHA]; exempt {
+			continue
+		}
+		if n := countBreakingFooters(c.Body); n > 1 {
+			t.Errorf("commit %s (%s) carries %d BREAKING CHANGE: footers.\n"+
+				"release-please keeps ONE breaking.text and fills it from the FIRST body-level "+
+				"node, so the other %d are silently dropped — and in a stacked branch the first "+
+				"is the one later commits superseded. Squash the migration into a SINGLE footer "+
+				"stating what is true of the merged change.",
+				c.SHA[:8], c.Subject, n, n-1)
+		}
+	}
+}
+
+// TestBreakingFooterRequiresABangSubject fails a commit whose body declares a breaking
+// change while its subject does not.
+//
+// release-please renders such a commit under ⚠ BREAKING CHANGES regardless, attributed
+// to the subject's scope. That is how a `fix(eval):` commit came to announce a
+// migration to investigation.max_tokens_per_investigation — a key it does not own —
+// duplicating the note under a second heading. The `!` is also what the version bump
+// reads, so a footer without one is a migration the release number does not reflect.
+func TestBreakingFooterRequiresABangSubject(t *testing.T) {
+	for _, c := range releaseWindow(t) {
+		if _, exempt := footerExemptions[c.SHA]; exempt {
+			continue
+		}
+		if countBreakingFooters(c.Body) > 0 && !subjectMarksBreaking(c.Subject) {
+			t.Errorf("commit %s carries a BREAKING CHANGE: footer but its subject has no `!`:\n"+
+				"  %s\n"+
+				"release-please renders it under ⚠ BREAKING CHANGES anyway, attributed to that "+
+				"scope. Add the `!` (type(scope)!: …) so the subject, the changelog and the "+
+				"version bump agree — or drop the footer if the change is not breaking. PRs are "+
+				"squash-merged, so this is the PR TITLE.",
+				c.SHA[:8], c.Subject)
+		}
+	}
+}
+
+// TestBreakingFooterExemptionsAreStillEarned keeps the exemption list honest in both
+// directions: every entry must name a commit this repo actually contains, and that
+// commit must still violate a rule above. An exemption that matches nothing is a licence
+// nobody is using, and it would go on silencing whatever SHA later collided with it.
+func TestBreakingFooterExemptionsAreStillEarned(t *testing.T) {
+	for sha, why := range footerExemptions {
+		out, err := gitTry("rev-parse", "--verify", "--quiet", sha+"^{commit}")
+		if err != nil || strings.TrimSpace(out) != sha {
+			t.Errorf("exempted commit %s (%q) does not resolve in this repository — a stale "+
+				"exemption silences nothing it names and would cover any SHA that later matched",
+				sha, why)
+			continue
+		}
+		c := readCommit(t, sha)
+		if countBreakingFooters(c.Body) <= 1 && subjectMarksBreaking(c.Subject) {
+			t.Errorf("exempted commit %s no longer violates either rule — delete the exemption "+
+				"rather than leaving a licence that grants nothing", sha)
+		}
+	}
+}
+
+// TestBreakingFooterDetectorsFlip is the mutation test. Each rule has to fire on the
+// shape that actually shipped and stay quiet on the shape that is correct — including
+// on prose that merely MENTIONS the footer token, which this repo's commit bodies do at
+// length and which an un-anchored matcher would count as a footer.
+func TestBreakingFooterDetectorsFlip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want int
+	}{
+		{"no footer", "Just a body explaining the change.\n", 0},
+		{"one footer", "Body.\n\nBREAKING CHANGE: the key means something else now.\n", 1},
+		{"hyphenated spelling", "Body.\n\nBREAKING-CHANGE: the key means something else now.\n", 1},
+		{"two footers, the shipped defect", "Body.\n\nBREAKING CHANGE: default unchanged at 100000.\n" +
+			"\nMore body.\n\nBREAKING CHANGE: default raised to 400000.\n", 2},
+		{"mentioned in prose, not a footer", "The repo has never marked one: no `!` in any " +
+			"subject, no BREAKING CHANGE: footer in 1000+ commits.\n", 0},
+		{"indented, so not a footer token", "Body.\n\n  BREAKING CHANGE: quoted in a list.\n", 0},
+		{"lowercase is not the token", "Body.\n\nbreaking change: not the spec spelling.\n", 0},
+	} {
+		if got := countBreakingFooters(tc.body); got != tc.want {
+			t.Errorf("countBreakingFooters(%s) = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+
+	for _, tc := range []struct {
+		subject string
+		want    bool
+	}{
+		{"feat(investigate)!: cap what one investigation may spend", true},
+		{"fix(gitops)!: confine the forge credential to the forge's own git host", true},
+		{"fix!: a breaking change with no scope", true},
+		{"fix(eval): bound lore eval, and report what the CLI's model calls spend", false},
+		{"feat(investigate): cap what one investigation may spend", false},
+		{"docs: not breaking", false},
+		{"a subject that is not conventional at all", false},
+		{"fix(scope): a body that later says BREAKING CHANGE: is still not a `!` subject", false},
+	} {
+		if got := subjectMarksBreaking(tc.subject); got != tc.want {
+			t.Errorf("subjectMarksBreaking(%q) = %v, want %v", tc.subject, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reading the window. Everything below exists to make this guard fail rather than
+// quietly scan nothing.
+//
+// The failure mode being designed against is specific and this repo has been bitten by
+// it before (see hack/check-anchors.sh, whose zero-check is "the load-bearing part"):
+// a guard that reads the environment passes vacuously when the environment is thinner
+// than it assumed. actions/checkout defaults to fetch-depth: 1 — ONE commit and NO
+// tags — so a history guard dropped into CI unexamined reports success having examined
+// nothing at all. ci.yaml therefore sets fetch-depth: 0, and every probe below fails
+// loudly rather than degrading to a pass.
+
+// windowCache memoises the scan so the two rule tests do not each shell out to git.
+var windowCache []commitRecord
+
+// releaseWindow returns every commit since the last release tag — the exact set
+// release-please will parse into the next CHANGELOG entry, which is what makes this the
+// right range: a footer defect is caught while it can still be fixed on the branch,
+// before the release PR is generated from it.
+//
+// Failing loudly is the point of every branch in here. Note that "is this repository
+// shallow" is NOT the question asked: a clone can report shallow and still contain the
+// whole window (this repo's own working clones do), while a depth-1 clone that fetched
+// a tag would answer the question the wrong way round. The honest test is whether the
+// window itself is walkable, which is what merge-base --is-ancestor proves.
+func releaseWindow(t *testing.T) []commitRecord {
+	t.Helper()
+	if windowCache != nil {
+		return windowCache
+	}
+	if _, err := gitTry("rev-parse", "--git-dir"); err != nil {
+		t.Fatalf("cannot read git history (%v).\nThis guard reads the commits release-please "+
+			"will parse; with no repository it can only scan nothing and pass, which is the "+
+			"inert-guard failure it exists to prevent.", err)
+	}
+
+	base, err := gitTry("describe", "--tags", "--abbrev=0", "HEAD")
+	if err != nil {
+		t.Fatalf("no release tag is reachable from HEAD (%v).\nThe scanned range is "+
+			"<last tag>..HEAD, so without tags this guard has no window and would pass "+
+			"vacuously. In CI this means the checkout is shallow: set fetch-depth: 0 "+
+			"(actions/checkout defaults to 1 commit and no tags).", err)
+	}
+	base = strings.TrimSpace(base)
+
+	// At the release commit itself HEAD *is* the tag, so <tag>..HEAD is legitimately
+	// empty. Step back to the previous tag and re-scan the window that was just
+	// released rather than reporting an empty scan — the guard must never have nothing
+	// to look at, and the commits it would skip here are exactly the released ones.
+	if rev(t, base) == rev(t, "HEAD") {
+		prev, err := gitTry("describe", "--tags", "--abbrev=0", "HEAD~1")
+		if err != nil {
+			t.Fatalf("HEAD is the release tag %s and no earlier tag is reachable (%v) — "+
+				"the window cannot be established", base, err)
+		}
+		base = strings.TrimSpace(prev)
+	}
+
+	// Proves the ENTIRE window is present in the object store. A clone truncated
+	// between base and HEAD fails here instead of silently yielding a short list.
+	if _, err := gitTry("merge-base", "--is-ancestor", base, "HEAD"); err != nil {
+		t.Fatalf("%s is not walkable from HEAD (%v).\nThe clone is truncated inside the range "+
+			"this guard claims to scan, so it would examine only part of it. Fetch full "+
+			"history (fetch-depth: 0).", base, err)
+	}
+
+	out, err := gitTry("log", "--format=%H%x1f%s%x1f%b%x1e", base+"..HEAD")
+	if err != nil {
+		t.Fatalf("git log %s..HEAD: %v", base, err)
+	}
+	window := parseCommits(out)
+	if len(window) == 0 {
+		t.Fatalf("scanned 0 commits in %s..HEAD — this guard is inert.\nEither the range is "+
+			"wrong or the clone cannot see the history it claims to check; a guard that "+
+			"examines nothing must fail, not report success.", base)
+	}
+	windowCache = window
+	return window
+}
+
+// parseCommits splits the record-separated `git log` output this file asks for.
+func parseCommits(out string) []commitRecord {
+	var commits []commitRecord
+	for _, rec := range strings.Split(out, "\x1e") {
+		rec = strings.TrimLeft(rec, "\n")
+		if strings.TrimSpace(rec) == "" {
+			continue
+		}
+		parts := strings.SplitN(rec, "\x1f", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		commits = append(commits, commitRecord{SHA: parts[0], Subject: parts[1], Body: parts[2]})
+	}
+	return commits
+}
+
+// readCommit reads one commit by SHA, for the exemption audit.
+func readCommit(t *testing.T, sha string) commitRecord {
+	t.Helper()
+	out, err := gitTry("log", "-1", "--format=%H%x1f%s%x1f%b%x1e", sha)
+	if err != nil {
+		t.Fatalf("git log -1 %s: %v", sha, err)
+	}
+	c := parseCommits(out)
+	if len(c) != 1 {
+		t.Fatalf("git log -1 %s returned %d commits", sha, len(c))
+	}
+	return c[0]
+}
+
+// rev resolves a revision to its commit SHA.
+func rev(t *testing.T, s string) string {
+	t.Helper()
+	out, err := gitTry("rev-parse", s+"^{commit}")
+	if err != nil {
+		t.Fatalf("git rev-parse %s: %v", s, err)
+	}
+	return strings.TrimSpace(out)
+}
+
+// gitTry runs git in the repo root, returning its stdout. stderr is folded into the
+// error so a failure says what git actually complained about.
+func gitTry(args ...string) (string, error) {
+	root, err := moduleDir()
+	if err != nil {
+		return "", err
+	}
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("%w: %s", err, msg)
+		}
+		return "", err
+	}
+	return string(out), nil
+}
+
+// moduleDir returns the repo root without needing a *testing.T, so gitTry can be used
+// from probes that report an error rather than failing outright.
+func moduleDir() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", errors.New("not inside a git working tree")
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/docsguard/breaking_change_footers_test.go
+++ b/internal/docsguard/breaking_change_footers_test.go
@@ -209,69 +209,99 @@ func TestBreakingFooterDetectorsFlip(t *testing.T) {
 // windowCache memoises the scan so the two rule tests do not each shell out to git.
 var windowCache []commitRecord
 
-// releaseWindow returns every commit since the last release tag — the exact set
-// release-please will parse into the next CHANGELOG entry, which is what makes this the
-// right range: a footer defect is caught while it can still be fixed on the branch,
-// before the release PR is generated from it.
-//
-// Failing loudly is the point of every branch in here. Note that "is this repository
-// shallow" is NOT the question asked: a clone can report shallow and still contain the
-// whole window (this repo's own working clones do), while a depth-1 clone that fetched
-// a tag would answer the question the wrong way round. The honest test is whether the
-// window itself is walkable, which is what merge-base --is-ancestor proves.
+// gitRunner runs a git command and returns its stdout. Injecting it is what makes every
+// refusal below testable: TestReleaseWindowRefusesToScanNothing drives each branch with
+// a fake git and asserts it returns an error, because a branch that has never been
+// exercised is exactly the kind of thing that turns out to pass quietly.
+type gitRunner func(args ...string) (string, error)
+
+// releaseWindow returns the commits release-please will parse, failing the test if the
+// window cannot be trusted.
 func releaseWindow(t *testing.T) []commitRecord {
 	t.Helper()
 	if windowCache != nil {
 		return windowCache
 	}
-	if _, err := gitTry("rev-parse", "--git-dir"); err != nil {
-		t.Fatalf("cannot read git history (%v).\nThis guard reads the commits release-please "+
-			"will parse; with no repository it can only scan nothing and pass, which is the "+
-			"inert-guard failure it exists to prevent.", err)
+	window, err := resolveWindow(gitTry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	windowCache = window
+	return window
+}
+
+// resolveWindow returns every commit since the last release tag — the exact set
+// release-please will parse into the next CHANGELOG entry, which is what makes this the
+// right range: a footer defect is caught while it can still be fixed on the branch,
+// before the release PR is generated from it.
+//
+// Every failure path REFUSES to scan rather than returning a short or empty list. That
+// asymmetry is the whole design: this guard reads the environment, and a guard that
+// reads the environment passes vacuously the moment the environment is thinner than it
+// assumed. actions/checkout defaults to fetch-depth 1 — one commit, no tags — so the
+// difference between "refuse" and "return nothing" is the difference between a guard
+// and a green tick that means nothing.
+//
+// Note that "is this repository shallow" is deliberately NOT the question asked: a clone
+// can report shallow and still contain the whole window (this repo's own working clones
+// do), while a depth-1 clone that fetched a tag would answer it the wrong way round. The
+// honest test is whether the window itself is walkable, which merge-base proves.
+func resolveWindow(git gitRunner) ([]commitRecord, error) {
+	if _, err := git("rev-parse", "--git-dir"); err != nil {
+		return nil, fmt.Errorf("cannot read git history (%w).\nThis guard reads the commits "+
+			"release-please will parse; with no repository it can only scan nothing and pass, "+
+			"which is the inert-guard failure it exists to prevent", err)
 	}
 
-	base, err := gitTry("describe", "--tags", "--abbrev=0", "HEAD")
+	out, err := git("describe", "--tags", "--abbrev=0", "HEAD")
 	if err != nil {
-		t.Fatalf("no release tag is reachable from HEAD (%v).\nThe scanned range is "+
-			"<last tag>..HEAD, so without tags this guard has no window and would pass "+
+		return nil, fmt.Errorf("no release tag is reachable from HEAD (%w).\nThe scanned range "+
+			"is <last tag>..HEAD, so without tags this guard has no window and would pass "+
 			"vacuously. In CI this means the checkout is shallow: set fetch-depth: 0 "+
-			"(actions/checkout defaults to 1 commit and no tags).", err)
+			"(actions/checkout defaults to 1 commit and no tags)", err)
 	}
-	base = strings.TrimSpace(base)
+	base := strings.TrimSpace(out)
 
 	// At the release commit itself HEAD *is* the tag, so <tag>..HEAD is legitimately
 	// empty. Step back to the previous tag and re-scan the window that was just
-	// released rather than reporting an empty scan — the guard must never have nothing
-	// to look at, and the commits it would skip here are exactly the released ones.
-	if rev(t, base) == rev(t, "HEAD") {
-		prev, err := gitTry("describe", "--tags", "--abbrev=0", "HEAD~1")
+	// released rather than reporting an empty scan: the guard must never have nothing
+	// to look at, and it must not fail spuriously on every release either.
+	headSHA, err := git("rev-parse", "HEAD^{commit}")
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve HEAD: %w", err)
+	}
+	baseSHA, err := git("rev-parse", base+"^{commit}")
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve tag %s: %w", base, err)
+	}
+	if strings.TrimSpace(headSHA) == strings.TrimSpace(baseSHA) {
+		prev, err := git("describe", "--tags", "--abbrev=0", "HEAD~1")
 		if err != nil {
-			t.Fatalf("HEAD is the release tag %s and no earlier tag is reachable (%v) — "+
-				"the window cannot be established", base, err)
+			return nil, fmt.Errorf("HEAD is the release tag %s and no earlier tag is reachable "+
+				"(%w) — the window cannot be established", base, err)
 		}
 		base = strings.TrimSpace(prev)
 	}
 
-	// Proves the ENTIRE window is present in the object store. A clone truncated
-	// between base and HEAD fails here instead of silently yielding a short list.
-	if _, err := gitTry("merge-base", "--is-ancestor", base, "HEAD"); err != nil {
-		t.Fatalf("%s is not walkable from HEAD (%v).\nThe clone is truncated inside the range "+
-			"this guard claims to scan, so it would examine only part of it. Fetch full "+
-			"history (fetch-depth: 0).", base, err)
+	// Proves the ENTIRE window is present in the object store. A clone truncated between
+	// base and HEAD fails here instead of silently yielding a short list.
+	if _, err := git("merge-base", "--is-ancestor", base, "HEAD"); err != nil {
+		return nil, fmt.Errorf("%s is not walkable from HEAD (%w).\nThe clone is truncated "+
+			"inside the range this guard claims to scan, so it would examine only part of it. "+
+			"Fetch full history (fetch-depth: 0)", base, err)
 	}
 
-	out, err := gitTry("log", "--format=%H%x1f%s%x1f%b%x1e", base+"..HEAD")
+	out, err = git("log", "--format=%H%x1f%s%x1f%b%x1e", base+"..HEAD")
 	if err != nil {
-		t.Fatalf("git log %s..HEAD: %v", base, err)
+		return nil, fmt.Errorf("git log %s..HEAD: %w", base, err)
 	}
 	window := parseCommits(out)
 	if len(window) == 0 {
-		t.Fatalf("scanned 0 commits in %s..HEAD — this guard is inert.\nEither the range is "+
-			"wrong or the clone cannot see the history it claims to check; a guard that "+
-			"examines nothing must fail, not report success.", base)
+		return nil, fmt.Errorf("scanned 0 commits in %s..HEAD — this guard is inert.\nEither "+
+			"the range is wrong or the clone cannot see the history it claims to check; a "+
+			"guard that examines nothing must fail, not report success", base)
 	}
-	windowCache = window
-	return window
+	return window, nil
 }
 
 // parseCommits splits the record-separated `git log` output this file asks for.
@@ -305,16 +335,6 @@ func readCommit(t *testing.T, sha string) commitRecord {
 	return c[0]
 }
 
-// rev resolves a revision to its commit SHA.
-func rev(t *testing.T, s string) string {
-	t.Helper()
-	out, err := gitTry("rev-parse", s+"^{commit}")
-	if err != nil {
-		t.Fatalf("git rev-parse %s: %v", s, err)
-	}
-	return strings.TrimSpace(out)
-}
-
 // gitTry runs git in the repo root, returning its stdout. stderr is folded into the
 // error so a failure says what git actually complained about.
 func gitTry(args ...string) (string, error) {
@@ -343,4 +363,130 @@ func moduleDir() (string, error) {
 		return "", errors.New("not inside a git working tree")
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// fakeGit builds a gitRunner from a table keyed on the joined arguments. A key mapped to
+// the empty string returns empty output; a key absent from the table returns an error,
+// which models the git failures the real probes are reading for.
+func fakeGit(responses map[string]string) gitRunner {
+	return func(args ...string) (string, error) {
+		key := strings.Join(args, " ")
+		out, ok := responses[key]
+		if !ok {
+			return "", fmt.Errorf("fake git: no response for %q", key)
+		}
+		return out, nil
+	}
+}
+
+// healthy is the response table for a repository this guard can trust: a tag two commits
+// behind HEAD, the whole range walkable, two commits in the window.
+func healthy() map[string]string {
+	return map[string]string{
+		"rev-parse --git-dir":                   ".git\n",
+		"describe --tags --abbrev=0 HEAD":       "v0.14.0\n",
+		"rev-parse HEAD^{commit}":               "aaaa1111\n",
+		"rev-parse v0.14.0^{commit}":            "bbbb2222\n",
+		"merge-base --is-ancestor v0.14.0 HEAD": "",
+		"log --format=%H%x1f%s%x1f%b%x1e v0.14.0..HEAD": "aaaa1111\x1ffix: one\x1fbody one\n\x1e" +
+			"cccc3333\x1ffeat: two\x1fbody two\n\x1e",
+	}
+}
+
+// TestReleaseWindowRefusesToScanNothing drives every inertness branch and asserts each
+// REFUSES rather than returning an empty window.
+//
+// This is the failure this repo keeps being bitten by, and it is invisible by
+// construction: the guard reports success, CI is green, and nothing was examined. Two of
+// these branches were also verified against real clones (a depth-1 checkout, and one
+// where the tag object was fetched but the path to it truncated); the table below covers
+// the ones a real clone cannot easily be coerced into, so no branch goes unexercised.
+func TestReleaseWindowRefusesToScanNothing(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(map[string]string)
+		wantErr string
+	}{
+		{
+			name:    "no git repository at all",
+			mutate:  func(r map[string]string) { delete(r, "rev-parse --git-dir") },
+			wantErr: "cannot read git history",
+		},
+		{
+			name:    "shallow checkout: no tag reachable",
+			mutate:  func(r map[string]string) { delete(r, "describe --tags --abbrev=0 HEAD") },
+			wantErr: "set fetch-depth: 0",
+		},
+		{
+			name: "history truncated inside the window",
+			mutate: func(r map[string]string) {
+				delete(r, "merge-base --is-ancestor v0.14.0 HEAD")
+			},
+			wantErr: "is not walkable from HEAD",
+		},
+		{
+			name: "window resolves but contains no commits",
+			mutate: func(r map[string]string) {
+				r["log --format=%H%x1f%s%x1f%b%x1e v0.14.0..HEAD"] = ""
+			},
+			wantErr: "this guard is inert",
+		},
+		{
+			name: "HEAD is the release tag and there is no earlier tag",
+			mutate: func(r map[string]string) {
+				r["rev-parse v0.14.0^{commit}"] = "aaaa1111\n" // same as HEAD
+			},
+			wantErr: "no earlier tag is reachable",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			responses := healthy()
+			tc.mutate(responses)
+			window, err := resolveWindow(fakeGit(responses))
+			if err == nil {
+				t.Fatalf("resolveWindow returned %d commits and no error — this branch passes "+
+					"vacuously, which is the exact failure this guard exists to prevent", len(window))
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error does not explain the failure: want it to contain %q, got: %v",
+					tc.wantErr, err)
+			}
+		})
+	}
+}
+
+// TestReleaseWindowScansTheReleasedWindowAtATag pins the one case that must NOT fail: at
+// the release commit HEAD *is* the tag, so <tag>..HEAD is legitimately empty. Failing
+// there would break CI on main at every single release, and passing on an empty scan
+// would be inert — so it steps back to the previous tag and scans the window just
+// released.
+func TestReleaseWindowScansTheReleasedWindowAtATag(t *testing.T) {
+	r := healthy()
+	r["rev-parse v0.14.0^{commit}"] = "aaaa1111\n" // HEAD is the tag
+	r["describe --tags --abbrev=0 HEAD~1"] = "v0.13.0\n"
+	r["merge-base --is-ancestor v0.13.0 HEAD"] = ""
+	r["log --format=%H%x1f%s%x1f%b%x1e v0.13.0..HEAD"] = "dddd4444\x1ffix: released\x1fbody\n\x1e"
+
+	window, err := resolveWindow(fakeGit(r))
+	if err != nil {
+		t.Fatalf("at a release tag the guard must scan the window just released, got: %v", err)
+	}
+	if len(window) != 1 || window[0].Subject != "fix: released" {
+		t.Errorf("expected the previous tag's window, got %+v", window)
+	}
+}
+
+// TestReleaseWindowParsesTheHealthyCase proves the table above is not passing merely
+// because resolveWindow rejects everything.
+func TestReleaseWindowParsesTheHealthyCase(t *testing.T) {
+	window, err := resolveWindow(fakeGit(healthy()))
+	if err != nil {
+		t.Fatalf("healthy repository must resolve: %v", err)
+	}
+	if len(window) != 2 {
+		t.Fatalf("want 2 commits, got %d (%+v)", len(window), window)
+	}
+	if window[0].SHA != "aaaa1111" || window[1].Subject != "feat: two" {
+		t.Errorf("commits parsed wrong: %+v", window)
+	}
 }

--- a/internal/docsguard/release_notes_test.go
+++ b/internal/docsguard/release_notes_test.go
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package docsguard
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Smana/runlore/internal/config"
+)
+
+const (
+	// upgradePath is the page an upgrading operator actually opens, and the durable
+	// home of the migration notes for each release's breaking changes.
+	upgradePath = "../../website/content/docs/operations/upgrade-uninstall.md"
+	// changelogPath is the file release-please regenerates. Only its PREAMBLE is
+	// hand-maintained — release-please prepends each new release section below it —
+	// so the preamble is the one part of this file a guard can meaningfully pin.
+	changelogPath = "../../CHANGELOG.md"
+)
+
+// TestMigrationNoteStatesTheRaisedDefault pins the number the 0.15.0 breaking-changes
+// note exists to communicate, off ApplyDefaults rather than typed in.
+//
+// This is the defect that shipped: the generated changelog told operators "The default
+// is unchanged at 100000" under both `investigate:` and `eval:`, while the shipped
+// default had been raised to 400000 in the very commit being described. An operator
+// who believed it would have sized their spend against a quarter of the real ceiling.
+func TestMigrationNoteStatesTheRaisedDefault(t *testing.T) {
+	var c config.Config
+	config.ApplyDefaults(&c)
+	inv := c.Investigation
+
+	doc := flattenProse(readDoc(t, upgradePath))
+	want := fmt.Sprintf("the default is raised from `100000` to `%d`", inv.MaxTokensPerInvestigation)
+	if !strings.Contains(doc, want) {
+		t.Errorf("%s must state the migration verbatim as %q — this is the number the 0.15.0 "+
+			"breaking-changes note got wrong, and the page is the corrected record", upgradePath, want)
+	}
+	// The opt-out semantics are the other half an operator gets wrong: 0 is NOT the
+	// off switch, and a config written to remove the cap with 0 silently gets the
+	// bounded default instead.
+	if !strings.Contains(doc, "**`0` does not disable it.**") {
+		t.Errorf("%s must say plainly that `0` does not disable %s — 0 applies the bounded "+
+			"default and -1 is the opt-out", upgradePath, tagOf(inv, "MaxTokensPerInvestigation"))
+	}
+}
+
+// unchangedDefaultRE captures the claim that shipped wrong, in the shape it shipped in.
+var unchangedDefaultRE = regexp.MustCompile(`(?i)default is unchanged at (\d+)`)
+
+// TestNoShippedDocClaimsTheTokenDefaultIsUnchanged is the direct anti-recurrence guard.
+//
+// The wrong paragraph reached CHANGELOG.md because a superseded BREAKING CHANGE: footer
+// won over the correct one (see breaking_change_footers_test.go for the mechanism, now
+// guarded). Belt and braces: even if a stale migration paragraph is reintroduced by
+// hand — by re-applying an old changelog section, or by copying the superseded footer —
+// this fails the moment its number disagrees with what ApplyDefaults actually ships.
+//
+// It scans the CHANGELOG too, deliberately. That file is generated, but it is generated
+// ONTO this branch and merged, so a wrong claim in it is a wrong claim this repo ships.
+func TestNoShippedDocClaimsTheTokenDefaultIsUnchanged(t *testing.T) {
+	var c config.Config
+	config.ApplyDefaults(&c)
+	shipped := c.Investigation.MaxTokensPerInvestigation
+
+	for _, path := range []string{changelogPath, configurationPath, upgradePath} {
+		doc := flattenProse(readDoc(t, path))
+		for _, m := range unchangedDefaultRE.FindAllStringSubmatch(doc, -1) {
+			claimed, err := strconv.Atoi(m[1])
+			if err != nil {
+				continue
+			}
+			if claimed != shipped {
+				t.Errorf("%s claims %q, but ApplyDefaults ships %d. A migration note that "+
+					"misstates the default it exists to announce is worse than none — an "+
+					"operator sizes their spend against the number they were given.",
+					path, m[0], shipped)
+			}
+		}
+	}
+}
+
+// TestUnchangedDefaultREFlips is the mutation test for the anchor above: it must fire on
+// the paragraph that actually shipped and stay quiet on the corrected one. Without this,
+// a regexp that matched nothing would pin nothing while still reporting success.
+func TestUnchangedDefaultREFlips(t *testing.T) {
+	const shipped = "not a check on the next request's estimated size. The default is unchanged at " +
+		"100000, so the same number binds far earlier than it used to"
+	const corrected = "not a check on the next request's estimated size, and its default is raised " +
+		"from 100000 to 400000 to suit the new meaning"
+
+	got := unchangedDefaultRE.FindStringSubmatch(shipped)
+	if got == nil {
+		t.Fatal("the anchor does not match the paragraph that actually shipped — it pins nothing")
+	}
+	if got[1] != "100000" {
+		t.Errorf("the anchor must capture the claimed default; got %q", got[1])
+	}
+	if unchangedDefaultRE.MatchString(corrected) {
+		t.Error("the anchor matches the corrected wording — it would fail on a page that is right")
+	}
+}
+
+// TestMigrationNoteAndConfigurationPageCannotDrift pins the claims that must read the
+// same on both pages.
+//
+// The migration note is a one-shot read at upgrade time; the configuration page is the
+// standing reference. They describe one behaviour, and the failure mode this repo keeps
+// hitting is that one of the two is corrected and the other is not. Each claim below is
+// the SENTENCE that carries it, flattened, so a rewrite on either page fails here rather
+// than leaving the two quietly disagreeing.
+//
+// The derived FIGURES (the per-request quarter, the compaction trigger, the 1.25x
+// multiplier) are pinned against the code itself by
+// TestSpendCeilingDocsStateTheDerivedThresholds, which covers both pages and the chart;
+// that derivation is internal to internal/investigate and cannot be reached from here.
+func TestMigrationNoteAndConfigurationPageCannotDrift(t *testing.T) {
+	shared := []string{
+		// What the ceiling now counts. The whole migration turns on "cumulative".
+		"one investigation's model tokens (provider-reported input + output, loop **and** verify",
+		// What an operator with an explicit value must understand.
+		"still says `100000`, and now",
+		// The residual overshoot, which makes the ceiling not an exact cap.
+		"the nudge exists to give the model one turn to conclude",
+	}
+	pages := map[string]string{
+		upgradePath:       flattenProse(readDoc(t, upgradePath)),
+		configurationPath: flattenProse(readDoc(t, configurationPath)),
+	}
+	for _, claim := range shared {
+		for path, doc := range pages {
+			if !strings.Contains(doc, claim) {
+				t.Errorf("%s no longer states %q. The migration note and the configuration "+
+					"reference describe one behaviour; correcting one and not the other is how "+
+					"this page drifted in the first place.", path, claim)
+			}
+		}
+	}
+}
+
+// TestChangelogPreambleDoesNotDenyItsOwnReleases catches the third defect in the same
+// file: the preamble still read "there are no tagged releases yet, so everything
+// currently lives under `[Unreleased]`" while sitting directly above `## [0.14.0]`, with
+// no `[Unreleased]` section anywhere in the file.
+//
+// release-please prepends each release section BELOW this preamble and never rewrites
+// it, so the preamble is hand-maintained and drifts silently — it was true exactly once,
+// before the first release, and nothing noticed when that stopped being so. It is the
+// first thing a reader of the changelog sees.
+func TestChangelogPreambleDoesNotDenyItsOwnReleases(t *testing.T) {
+	raw := readDoc(t, changelogPath)
+	preamble, _, found := strings.Cut(raw, "\n## ")
+	if !found {
+		t.Fatalf("%s has no `## ` release section — the preamble guard has nothing to compare "+
+			"against and would pass trivially", changelogPath)
+	}
+	releases := regexp.MustCompile(`(?m)^## \[\d+\.\d+\.\d+\]`).FindAllString(raw, -1)
+	if len(releases) == 0 {
+		t.Fatalf("%s contains no released `## [x.y.z]` section; this guard exists to compare the "+
+			"preamble against the releases below it", changelogPath)
+	}
+
+	flat := flattenProse(preamble)
+	if strings.Contains(flat, "no tagged releases") {
+		t.Errorf("%s preamble says there are no tagged releases, but the file lists %d of them "+
+			"(most recent: %s)", changelogPath, len(releases), releases[0])
+	}
+	if strings.Contains(flat, "[Unreleased]") && !strings.Contains(raw, "## [Unreleased]") {
+		t.Errorf("%s preamble points the reader at an `[Unreleased]` section that does not exist "+
+			"in the file", changelogPath)
+	}
+}

--- a/internal/investigate/spend_ceiling_test.go
+++ b/internal/investigate/spend_ceiling_test.go
@@ -766,6 +766,13 @@ func TestShippedTokenCeilingFundsARealInvestigation(t *testing.T) {
 const (
 	spendDocPath   = "../../website/content/docs/configuration/configuration.md"
 	spendChartPath = "../../deploy/helm/runlore/values.yaml"
+	// spendUpgradePath carries the MIGRATION note — the one an operator reads once,
+	// while upgrading, and the only place these derived figures are stated as a
+	// before/after. It is pinned here for the same reason as the other two, and for
+	// one more: the 0.15.0 changelog shipped this migration claiming "the default is
+	// unchanged at 100000" when it had in fact been raised to 400000, so the numbers
+	// on this page are the corrected record and must not be allowed to rot back.
+	spendUpgradePath = "../../website/content/docs/operations/upgrade-uninstall.md"
 )
 
 // ungroupDigits removes the spaces a prose page puts inside long numbers ("100 000"),
@@ -825,6 +832,12 @@ func TestSpendCeilingDocsStateTheDerivedThresholds(t *testing.T) {
 			"A QUARTER of this (" + perRequest + " here) additionally bounds",
 			"compaction triggers at 70% of that quarter (" + compaction + ")",
 			"budget ~" + overshoot + "x",
+		}},
+		{spendUpgradePath, []string{
+			"A quarter of it (**" + perRequest + "** at the default) additionally bounds",
+			"compaction triggers at 70 % of that quarter (**" + compaction + "**)",
+			"budget **≈" + overshoot + "×** the number you set",
+			"against a " + strconv.Itoa(ceiling) + " ceiling",
 		}},
 	} {
 		raw, err := os.ReadFile(tc.path)

--- a/website/content/docs/operations/upgrade-uninstall.md
+++ b/website/content/docs/operations/upgrade-uninstall.md
@@ -5,6 +5,71 @@ weight: 30
 
 How to upgrade RunLore in place, what survives a restart, and how to remove it cleanly.
 
+## Breaking changes in 0.15.0
+
+RunLore is **pre-1.0**, and a breaking change bumps the **minor** version — so a `0.x` upgrade can
+still require migration. Read this section before upgrading onto `0.15.0`.
+
+### `investigation.max_tokens_per_investigation` is now a whole-run budget, and its default is raised
+
+The key used to bound the estimated size of the **next request**. It is now a **cumulative** ceiling
+on one investigation's model tokens (provider-reported input + output, loop **and** verify), so
+twenty steps of 99k each — which previously passed cleanly against a `100000` "budget" — now stop
+after the fourth. Read as a run budget that old value funds only four or five steps, so **the default
+is raised from `100000` to `400000`** to suit the new meaning. It is *not* unchanged.
+
+A quarter of it (**100 000** at the default) additionally bounds the estimated size of any single
+request, and mid-loop compaction triggers at 70 % of that quarter (**70 000**). Those are exactly the
+values in force before the ceiling became cumulative, so what one request may cost changes for nobody.
+
+**What you have to do**
+
+- **If you never set the key** — nothing. The raised default is applied for you, and investigations
+  that a `100000` run budget would have cut short with `result="budget_exceeded"` now run to
+  completion.
+- **If you set it explicitly** — your value is **left untouched** and is now read as a whole-run
+  budget: a config pinned to `100000` still says `100000`, and now funds roughly four steps rather
+  than twenty. Set it to the total you are willing to pay per incident (summed across all turns, not
+  the size of one), or `-1` for the previous unbounded behaviour.
+- **`0` does not disable it.** `0` applies the bounded default and `-1` is the opt-out, so a config
+  written to remove the cap with `0` gets the default instead — the opposite of what it asked for.
+
+Budget for the ceiling **plus one request**: the check compares the *projected* total — already spent
+plus the request about to be sent — so a run stops on the first request that would cross, but that
+request is still sent: the nudge exists to give the model one turn to conclude. That conceded
+request is itself capped at the quarter, so budget **≈1.25×** the number you set. Measured at the
+shipped defaults: **≈467 000 tokens delivered against a 400 000 ceiling** (≈1.17×).
+
+Runs stopped by the running total report `reason="tokens_total"`; runs stopped by the per-request
+bound report `reason="tokens_request"`, and are fixed by lowering `max_tool_output_bytes` or enabling
+`compaction`, not by raising the run budget. Watch
+`runlore_investigation_budget_trips_total{reason,stage}` after upgrading. Full reference:
+[Configuration → `investigation`]({{< relref "/docs/configuration/configuration.md#investigation--loop-bounds--noise-control" >}}).
+
+### GitHub Enterprise with subdomain isolation must set `forge.git_host`
+
+A GitHub Enterprise install whose `forge.github_api_url` is an **`api.` subdomain** (subdomain
+isolation: the API on `api.HOSTNAME`, git and web on `HOSTNAME`) must now set **`forge.git_host`** to
+the bare hostname serving its git remotes. `serve` **refuses to start** until it does, rather than
+guessing and silently withholding the forge credential from every GitOps repository.
+
+```yaml
+forge:
+  github_api_url: https://api.ghe.example.com
+  git_host: ghe.example.com   # the host your git remotes use — no scheme, path or port
+```
+
+The credential is confined to that host because a GitOps `spec.source.repoURL` is cluster state:
+whoever can create an Argo CD `Application` or a Flux `GitRepository` chooses where an unconfined
+token would be sent. Guessing wrong fails either loudly (the token goes to a host it is not valid
+for) or **silently** — withholding it from your own GitOps repo empties `what_changed` on every
+investigation, surfacing only as a data-gaps line at the foot of a finding. Loud once at startup
+beats quiet forever.
+
+**Every other configuration is untouched and needs no new key**: `github.com`, GitHub Enterprise
+serving its API at `HOSTNAME/api/v3`, and GitLab (whose `base_url` is already the instance root that
+git, web and API share).
+
 ## Upgrading
 
 RunLore is a Helm release — upgrade like any other chart (the chart is an OCI artifact on GHCR;


### PR DESCRIPTION
The generated release notes tell an upgrading operator the wrong number. Reproduced against the **real generated artifact** (`origin/release-please--branches--main--components--runlore:CHANGELOG.md`), not merely inferred from the commits: its `### ⚠ BREAKING CHANGES` carries three bullets — `gitops` (correct), plus `eval` and `investigate` both saying *"The default is unchanged at 100000."*

The shipped default is **400000** (`internal/config/load.go:154`, `deploy/helm/runlore/values.yaml:143`).

### Mechanical causes, confirmed over the 26-commit window

| commit | `BREAKING CHANGE:` footers | `!` in subject | verdict |
|---|---|---|---|
| `3fa30db0` `fix(gitops)!:` | 1 | yes | the correct model |
| `8d269294` `feat(investigate)!:` | **2** | yes | superseded footer wins |
| `0ef45070` `fix(eval):` | **2** | **no** | inherited footer, rendered breaking anyway |

release-please's `toConventionalChangelogFormat` keeps a single `breaking.text` filled by the first body-level node, so the correct paragraph — the one stating 400000, the derived quarter, the compaction trigger and the measured overshoot — never reached the changelog at all.

### Every figure checked against code, not against prose

| Claim | Source of truth |
|---|---|
| default `400000` | `internal/config/load.go:154`, `values.yaml:143` |
| quarter = `100000` | `requestBudgetFraction = 0.25` — `internal/investigate/budget.go:215` |
| compaction = `70000` | `compactionBudgetFraction = 0.7` — `internal/investigate/compact.go:15` |
| overshoot ≈ `1.25×` | `1 + requestBudgetFraction` |
| `-1` unlimited, `0` bounded default | the switch at `load.go:150-155` |
| `forge.git_host` trigger | `validateForgeGitHost`, `config.go:1512` — fires when the API host starts `api.` and is not `api.github.com`; GitLab exempt; must be a bare host |

**A third defect, confirmed:** the CHANGELOG preamble still said *"there are no tagged releases yet… everything currently lives under `[Unreleased]`"* — sitting above 16 released sections, with no `[Unreleased]` section anywhere. Fixed and guarded.

### The corrected prose

Its durable home is `website/content/docs/operations/upgrade-uninstall.md` — the page an operator actually opens while upgrading, which already carried a versioned migration section. It reuses `configuration.md`'s sentences rather than rewriting them, and a drift guard now fails if either copy is reworded alone.

**For #488 itself:** delete the `**eval:**` bullet entirely (it is not a breaking change) and replace the `**investigate:**` one with the raised-default text. The `**gitops:**` bullet is already correct. That edit is applied last, by hand, because release-please regenerates that file whenever `main` moves.

### The guard, and the part that mattered most

`internal/docsguard/breaking_change_footers_test.go` enforces two rules over `<last release tag>..HEAD` — the exact set release-please parses: at most one `BREAKING CHANGE:` footer per body, and a footer requires `!` in the subject. Detectors are line-anchored, because this repo's commit bodies discuss the token in prose.

`8d26929` and `0ef4507` are exempt by full SHA (they are on `main` and unrewritable), but each must still **resolve and still violate** — so they are live fixtures, not dead licences.

**Inertness.** `ci.yaml`'s checkout had **no `fetch-depth`** — depth 1, no tags — so the guard would have reported success having read nothing. Now `fetch-depth: 0`. And "is the repo shallow" turned out to be the wrong question: working clones report `shallow: true` yet contain the whole window, so the check is whether the window is **walkable** (`merge-base --is-ancestor`). At a release commit `<tag>..HEAD` is legitimately empty, so it steps back to the previous tag rather than failing on every release.

### Mutations

Exemptions emptied → both rules fire on exactly the right commits, each on its own defect. A real `--depth 1` clone → fails naming `fetch-depth: 0`. A real clone with the tag object fetched but the path truncated → fails. Five injected-git branches (no repo / no tag / truncated / **zero commits** / tag with no predecessor) → each refuses, message naming the fix. Wrong claim reintroduced → both default guards fire. Old preamble restored → preamble guard fires. One shared sentence reworded on `configuration.md` only → drift guard fires. `requestBudgetFraction` 0.25→0.5 → all three derived figures fail.

The third commit exists because those refusals were originally only reachable by building a real clone, and the zero-commit backstop had never executed. Window resolution is now a pure function over an injectable git runner, so every branch is proven to refuse.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues** · `hugo` exit 0 · `check-anchors.sh` — 424 in-page and 70 cross-page anchors across 67 pages all resolve.

**One judgement call:** the exemptions do not self-expire when 0.15.0 is tagged, because failing then would break CI on `main` at exactly the wrong moment. Each entry must instead keep resolving and keep violating. Say the word if you would rather they hard-expire.
