### PR TITLE
fix(notify): bound the Matrix thread stamp, and the whole event with it

### DIFF
--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -121,13 +121,20 @@ func (m *Matrix) send(ctx context.Context, room string, content map[string]any) 
 // formatted_body (org.matrix.custom.html) so the message's mrkdwn renders as
 // bold/links/code instead of leaking raw *asterisks* to Matrix clients.
 //
-// Both bodies are bounded — see boundMatrixBodies. Format(inv) is model-authored
-// end to end (the title, every hypothesis, every evidence line) and
-// buildInvestigation caps none of it, so without a bound the size of this event
-// is whatever the model wrote. A Matrix event is capped at 65,536 bytes by the
-// spec, signatures and hashes included, and a homeserver rejects the whole event
-// past it: an investigation that ran, spent its model budget and reached a
+// EVERY field this function writes is bounded, and the ceilings are chosen to
+// sum: two bodies at matrixDeliverBodyBytes (boundMatrixBodies) plus two stamps
+// at matrixStampBytes (boundStamp) is 40,960 bytes, leaving 24,576 of the spec's
+// 65,536 for the federation envelope, the content hash and the signatures. That
+// arithmetic is the point. Format(inv) is model-authored end to end (the title,
+// every hypothesis, every evidence line) and buildInvestigation caps none of it,
+// so the size of this event is whatever the model wrote unless something here
+// says otherwise — and a homeserver rejects the whole event past the ceiling,
+// which is an investigation that ran, spent its model budget and reached a
 // verdict, that nobody is ever told about.
+//
+// Bounding each field on its own was not enough, and this function is where that
+// was learned: the bodies took 16 KiB each and the stamp beside them took 78, so
+// three ceilings existed and none of them was a ceiling on the EVENT.
 func (m *Matrix) Deliver(ctx context.Context, inv providers.Investigation) error {
 	body, formatted := boundMatrixBodies(Format(inv))
 	content := map[string]any{
@@ -142,16 +149,33 @@ func (m *Matrix) Deliver(ctx context.Context, inv providers.Investigation) error
 		"format":         "org.matrix.custom.html",
 		"formatted_body": formatted,
 	}
-	// Stamp the trigger identity into the event content (a custom field — legal in
-	// Matrix events, invisible in clients) so the opt-in reaction listener can join
-	// a 👍/👎 on this message back to the incident. Unconditional: the field is
-	// inert data; the LISTENER is the opt-in (notify.matrix.feedback_reactions).
-	if key := cmp.Or(inv.TriggerKey, inv.Fingerprint); key != "" {
-		content[triggerKeyContentField] = key
+	// Stamp the thread context into the event content (a custom field — legal in
+	// Matrix events, invisible in clients) so a threaded reply can be attributed
+	// back to this investigation. Unconditional: the field is inert data; the
+	// LISTENER is the opt-in (notify.matrix.thread_capture).
+	//
+	// stampFor bounds it — see boundStamp. That the bound lives inside the builder
+	// rather than out here is the fix for this defect and not a stylistic choice:
+	// the bodies were bounded on the first line of this function and the stamp
+	// assigned unbounded twenty-two lines below, so the event honoured two
+	// ceilings and blew straight through the one that actually applies to it.
+	stamp := stampFor(inv)
+	content[threadContentField] = stamp
+	// The legacy trigger field the opt-in reaction listener reads to join a 👍/👎
+	// on this message back to the incident (notify.matrix.feedback_reactions), and
+	// contextFromContent's fallback when a decoded stamp carries no trigger_key of
+	// its own.
+	//
+	// It is taken FROM the stamp rather than recomputed off inv, which does two
+	// things. It keeps the two from contradicting each other: a fallback naming an
+	// identity the stamp had just dropped would be worse than no fallback at all.
+	// And it puts this field inside the same bound, instead of leaving the event
+	// unbounded through the one field nobody was looking at. The value is
+	// byte-identical for every finding that fits — stampFor applies the same
+	// cmp.Or(TriggerKey, Fingerprint) this line used to.
+	if stamp.TriggerKey != "" {
+		content[triggerKeyContentField] = stamp.TriggerKey
 	}
-	// Stamp the thread context alongside it — additive, same rationale: inert
-	// data, unconditional, the eventual reply listener is the opt-in.
-	content[threadContentField] = stampFor(inv)
 
 	eventID, err := m.send(ctx, m.roomID, content)
 	if err != nil {

--- a/internal/notify/matrix_stamp_bound_test.go
+++ b/internal/notify/matrix_stamp_bound_test.go
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/Smana/runlore/internal/providers"
+)
+
+// Every ceiling in this file is written as a LITERAL, and every assertion states
+// the number instead of reading it back out of the constant it is checking — the
+// same rule post_bound_test.go states, for the same reason: this package has
+// already shipped a byte ceiling asserted against itself, which could be tripled
+// with the suite still green.
+
+// deliveredMatrixContent runs a real Matrix.Deliver against a fake homeserver and
+// returns the event content exactly as it left the process. Nothing here is
+// composed by the test: the stamp, the legacy trigger field and both bodies are
+// whatever Deliver actually put on the wire.
+func deliveredMatrixContent(t *testing.T, inv providers.Investigation) map[string]any {
+	t.Helper()
+	var raw []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"event_id":"$1"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := NewMatrix(srv.URL, "!room:hs", "tok").Deliver(context.Background(), inv); err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if raw == nil {
+		t.Fatal("no event reached the homeserver")
+	}
+	var content map[string]any
+	if err := json.Unmarshal(raw, &content); err != nil {
+		t.Fatalf("the delivered event is not JSON: %v", err)
+	}
+	return content
+}
+
+// canonicalEventBytes is the size the HOMESERVER measures the event at, which is
+// not the size Go put on the wire.
+//
+// The Matrix spec caps an event at 65,536 bytes "encoded as Canonical JSON", and
+// canonical JSON escapes only what JSON requires — the quote, the backslash and
+// the control characters below 0x20. Go's encoding/json additionally escapes
+// "<", ">" and "&" as six-byte \u003c-style escapes by default, which would make
+// an HTML formatted_body measure about twice its canonical size here and cut the
+// card for a limit no homeserver applies. SetEscapeHTML(false) is what makes this
+// the homeserver's arithmetic rather than Go's.
+func canonicalEventBytes(t *testing.T, content map[string]any) int {
+	t.Helper()
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(content); err != nil {
+		t.Fatalf("canonical encode: %v", err)
+	}
+	return buf.Len() - len("\n") // Encode appends a newline that no event carries
+}
+
+// deliveredStamp returns the io.runlore.thread stamp Deliver put on the event,
+// decoded the same way contextFromContent decodes it off the wire.
+func deliveredStamp(t *testing.T, inv providers.Investigation) threadStamp {
+	t.Helper()
+	raw, ok := deliveredMatrixContent(t, inv)[threadContentField]
+	if !ok {
+		t.Fatal("Deliver stamped no io.runlore.thread field")
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatalf("re-marshal stamp: %v", err)
+	}
+	var stamp threadStamp
+	if err := json.Unmarshal(b, &stamp); err != nil {
+		t.Fatalf("decode stamp: %v", err)
+	}
+	return stamp
+}
+
+// pathologicalInvestigation is a finding whose every stamped field is far past
+// any event's budget. Not a contrivance: buildInvestigation
+// (internal/investigate/tools.go) copies every string out of submit_findings
+// verbatim with no length cap, Resource.Ref() renders model-written free text,
+// and TriggerKey is assembled from untrusted alert labels.
+func pathologicalInvestigation() providers.Investigation {
+	inv := hugeInvestigation()
+	inv.Title = strings.Repeat("the harbor-db pod is CrashLoopBackOff ", 2000)
+	inv.TriggerKey = strings.Repeat("k", 4096)
+	inv.CuratedURL = "https://forge.example/o/r/pull/" + strings.Repeat("9", 4096)
+	inv.RecalledEntry = strings.Repeat("catalog/entry/path/", 400)
+	inv.Resource = providers.Workload{Namespace: "tooling", Name: strings.Repeat("harbor-", 2000)}
+	inv.Verdict = providers.Verdict(strings.Repeat("action_required ", 500))
+	return inv
+}
+
+// TestMatrixDeliverEventFitsTheSpecCeiling is the defect itself, stated as the
+// only assertion that actually matters: the WHOLE event, not any one field of it.
+//
+// Deliver bounded its two bodies and then assigned an unbounded stamp beside
+// them, so a 64 KiB model title produced a 78 KiB stamp next to a 33 KiB pair of
+// bodies — a 115 KiB event against a 65,536-byte spec ceiling, rejected outright
+// by the homeserver. That is the exact silent-delivery failure the body bound was
+// written to prevent, reached one field to the right of it.
+//
+// The budget below is the whole event minus what Deliver does not write. The
+// homeserver adds the federation envelope — room_id, sender, origin_server_ts,
+// depth, prev_events, auth_events — plus the content hash and one signature per
+// participating server, and none of that is visible from here. 24,576 bytes is
+// held back for it, an order of magnitude more than a real envelope costs,
+// because guessing low is a rejected event while guessing high only costs card
+// text.
+func TestMatrixDeliverEventFitsTheSpecCeiling(t *testing.T) {
+	content := deliveredMatrixContent(t, pathologicalInvestigation())
+	if got := canonicalEventBytes(t, content); got > 40_960 {
+		t.Errorf("the delivered event is %d canonical bytes, over the 40,960 the content may claim "+
+			"of a 65,536-byte event with 24,576 held back for the federation envelope, hashes and "+
+			"signatures — a homeserver rejects the whole event, so an investigation that ran and "+
+			"reached a verdict is one nobody is ever told about", got)
+	}
+}
+
+// TestMatrixDeliverEventFitsWhenEveryFieldIsEscapeHeavy is the same ceiling
+// against the input that makes a bound measured on the SOURCE useless.
+//
+// A byte ceiling counted on the composed string is not a ceiling on the event:
+// canonical JSON renders one control character as a six-byte \u001b escape,
+// so 16,384 source bytes of ESC arrive as 98,304 — and the two bodies
+// alone then come to three times the whole spec ceiling while each still measures
+// exactly at its documented limit. ESC is not a hypothetical byte either: it is
+// what a container log line carrying ANSI colour codes puts into evidence text,
+// which Format splices into both bodies verbatim.
+func TestMatrixDeliverEventFitsWhenEveryFieldIsEscapeHeavy(t *testing.T) {
+	for name, filler := range map[string]string{
+		"ansi escape":  "\x1b",
+		"double quote": `"`,
+		"backslash":    `\`,
+	} {
+		inv := pathologicalInvestigation()
+		inv.Title = strings.Repeat(filler, 100_000)
+		inv.RootCauses[0].Summary = strings.Repeat(filler, 100_000)
+		content := deliveredMatrixContent(t, inv)
+		if got := canonicalEventBytes(t, content); got > 40_960 {
+			t.Errorf("%s: the delivered event is %d canonical bytes, over 40,960 — the bound was "+
+				"measured on the string as composed rather than on the escaped bytes the homeserver "+
+				"counts", name, got)
+		}
+	}
+}
+
+// TestMatrixStampCeilingsHaveTheirDocumentedValues pins the numbers and the
+// derivation that produced them, so the ceilings cannot drift apart from the
+// event they have to fit inside.
+func TestMatrixStampCeilingsHaveTheirDocumentedValues(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		got  int
+		want int
+		why  string
+	}{
+		{"matrixStampBytes", matrixStampBytes, 4 << 10,
+			"the encoded stamp's share of the event: two of them (the stamp and the legacy trigger " +
+				"field it feeds) beside two 16,384-byte bodies leave 24,576 bytes for the envelope"},
+		{"matrixStampTitleBytes", matrixStampTitleBytes, 200,
+			"the largest budget any reader of thread.Context.Title applies (thread's own " +
+				"maxChatIdentityFieldBytes), so the stamp never hands a reader less than it would " +
+				"have re-cut for itself"},
+		{"matrixStampIDBytes", matrixStampIDBytes, 512,
+			"generous for every identifier stamped (a namespace/name, a forge URL, a catalog path, " +
+				"an alert-derived trigger key) and small enough that all six together stay under " +
+				"the stamp's share"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d — %s", c.name, c.got, c.want, c.why)
+		}
+	}
+
+	// The per-field caps must sum UNDER the encoded ceiling, or the shed in
+	// boundStamp would be load-bearing for an ordinary card rather than a
+	// backstop against escape expansion.
+	if fields, framing := 200+6*512, 256; fields+framing > 4<<10 {
+		t.Errorf("the field caps total %d bytes and the stamp's JSON framing about %d more, over the "+
+			"4,096-byte encoded ceiling: an ordinary card would start shedding identity", fields, framing)
+	}
+	// And the whole content budget must leave the envelope its share.
+	if content := 2*(16<<10) + 2*(4<<10); content > 40_960 {
+		t.Errorf("two 16,384-byte bodies and two 4,096-byte stamps total %d bytes, over the 40,960 "+
+			"the content may claim of a 65,536-byte event", content)
+	}
+}
+
+// TestMatrixStampTruncatesTheTitleAndKeepsEveryIdentifier is the design decision
+// this file exists for, as an executable claim.
+//
+// The title is PROSE and the only field on the stamp that is. A truncated title
+// is still a true and useful answer to "which investigation is this thread
+// about" — every reader of thread.Context.Title already re-cuts it (200 bytes in
+// Chat.renderContext, 120 in conceptDescription), so the cut takes off only what
+// a reader would have taken off anyway. So it is truncated, and marked with an
+// ellipsis so a reader can tell.
+func TestMatrixStampTruncatesTheTitleAndKeepsEveryIdentifier(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.Title = strings.Repeat("the harbor-db pod is CrashLoopBackOff ", 2000)
+	inv.TriggerKey = "harbordown|tooling|helmrelease|harbor|eu-west-1"
+	inv.CuratedURL = "https://forge.example/o/r/pull/42"
+	inv.RecalledEntry = "catalog/incidents/harbor-down.md"
+
+	stamp := deliveredStamp(t, inv)
+	if len(stamp.Title) > 200 {
+		t.Errorf("the stamped title is %d bytes, over the 200-byte prose ceiling", len(stamp.Title))
+	}
+	if !utf8.ValidString(stamp.Title) {
+		t.Error("the stamped title is not valid UTF-8: the cut split a rune")
+	}
+	if !strings.HasPrefix(inv.Title, strings.TrimSuffix(stamp.Title, "…")) {
+		t.Errorf("the stamped title is not a prefix of the finding's own title:\n%q", stamp.Title)
+	}
+	if !strings.HasSuffix(stamp.Title, "…") {
+		t.Errorf("a shortened title must be marked as shortened — a model handed a silently cut "+
+			"title answers about an investigation it has been told the wrong name for:\n%q", stamp.Title)
+	}
+	// Truncating the prose must not cost the identity around it.
+	for name, pair := range map[string][2]string{
+		"trigger_key":    {stamp.TriggerKey, inv.TriggerKey},
+		"resource":       {stamp.Resource, inv.Resource.Ref()},
+		"verdict":        {stamp.Verdict, string(inv.Verdict)},
+		"curated_url":    {stamp.CuratedURL, inv.CuratedURL},
+		"recalled_entry": {stamp.RecalledEntry, inv.RecalledEntry},
+	} {
+		if pair[0] != pair[1] {
+			t.Errorf("%s = %q, want %q — bounding the prose must not disturb the identifiers",
+				name, pair[0], pair[1])
+		}
+	}
+}
+
+// TestMatrixStampDropsAnOversizedIdentifierRatherThanTruncatingIt is the other
+// half of that decision, and the half that is not symmetric with it.
+//
+// Truncating an identifier does not shorten it, it CHANGES it. A cut trigger_key
+// names no incident at all, or — on a prefix collision — a different one, and
+// that is a thumbs-up recorded against the wrong finding in the outcome ledger,
+// which weights future trust. A cut curated_url is a write destination that is
+// not the pull request it claims to be. Absence, by contrast, is a state every
+// reader already handles: an empty trigger_key falls through to the legacy field
+// and then to "not one of ours", and an empty curated_url makes the thread open
+// its own PR. A wrong identity is a state nothing handles, because nothing can
+// detect it.
+func TestMatrixStampDropsAnOversizedIdentifierRatherThanTruncatingIt(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.Title = "HarborDown"
+	inv.TriggerKey = strings.Repeat("k", 4096)
+	inv.Fingerprint = ""
+	inv.CuratedURL = "https://forge.example/o/r/pull/" + strings.Repeat("9", 4096)
+	inv.RecalledEntry = strings.Repeat("catalog/entry/", 400)
+
+	stamp := deliveredStamp(t, inv)
+	for name, got := range map[string]string{
+		"trigger_key":    stamp.TriggerKey,
+		"curated_url":    stamp.CuratedURL,
+		"recalled_entry": stamp.RecalledEntry,
+	} {
+		if got != "" {
+			t.Errorf("%s survived as %d bytes (%.40q) — an over-long identifier must be dropped "+
+				"whole, never cut down to a shorter identifier naming something else", name, len(got), got)
+		}
+	}
+	if stamp.Title != "HarborDown" {
+		t.Errorf("title = %q, want %q — dropping an oversized identifier must not cost the prose "+
+			"that was within budget", stamp.Title, "HarborDown")
+	}
+}
+
+// TestMatrixStampAndLegacyTriggerKeyCarryTheSameValue pins the sibling field.
+//
+// io.runlore.trigger_key is the pre-stamp field the reaction listener still
+// reads, and contextFromContent falls back to it when the stamp's own
+// trigger_key is empty. Bounding one and not the other would leave the event
+// unbounded through the field nobody was looking at, and would also make the
+// fallback disagree with what it is a fallback FOR — the decoded stamp saying "no
+// trigger identity" while the legacy field beside it named one.
+func TestMatrixStampAndLegacyTriggerKeyCarryTheSameValue(t *testing.T) {
+	ordinary := sampleInvestigation()
+	ordinary.TriggerKey = "harbordown|tooling|helmrelease|harbor|eu-west-1"
+
+	fallback := sampleInvestigation()
+	fallback.TriggerKey, fallback.Fingerprint = "", "abc123def456"
+
+	oversized := sampleInvestigation()
+	oversized.TriggerKey, oversized.Fingerprint = strings.Repeat("k", 4096), ""
+
+	for name, inv := range map[string]providers.Investigation{
+		"ordinary":             ordinary,
+		"fingerprint fallback": fallback,
+		"oversized":            oversized,
+	} {
+		legacy, _ := deliveredMatrixContent(t, inv)[triggerKeyContentField].(string)
+		stamp := deliveredStamp(t, inv)
+		if legacy != stamp.TriggerKey {
+			t.Errorf("%s: io.runlore.trigger_key = %q but the stamp's trigger_key = %q — the legacy "+
+				"field is the stamp's own fallback and must neither contradict it nor escape its bound",
+				name, legacy, stamp.TriggerKey)
+		}
+		if len(legacy) > 512 {
+			t.Errorf("%s: io.runlore.trigger_key is %d bytes, over the 512-byte identifier ceiling — "+
+				"the field beside the stamp is the same event", name, len(legacy))
+		}
+	}
+}
+
+// TestMatrixStampUnderBudgetIsUnchanged is the ordinary card, which is every card
+// in practice: nothing about the stamp may change for a finding that fits.
+func TestMatrixStampUnderBudgetIsUnchanged(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.TriggerKey = "harbordown|tooling|helmrelease|harbor|eu-west-1"
+	inv.CuratedURL = "https://forge.example/o/r/pull/42"
+	inv.RecalledEntry = "catalog/incidents/harbor-down.md"
+	inv.Title = "HarborDown: registry unreachable"
+
+	got := deliveredStamp(t, inv)
+	want := threadStamp{
+		TriggerKey:    inv.TriggerKey,
+		Title:         inv.Title,
+		Resource:      inv.Resource.Ref(),
+		Verdict:       string(inv.Verdict),
+		CuratedURL:    inv.CuratedURL,
+		RecalledEntry: inv.RecalledEntry,
+	}
+	if got != want {
+		t.Errorf("a finding within budget had its stamp altered:\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+// TestMatrixStampShedsProseBeforeIdentity covers what the per-field caps alone
+// cannot: escaping. Every field below is within its own cap as composed, and the
+// encoded stamp is still far over its share, because canonical JSON renders each
+// of these bytes as a six-byte \u001b escape.
+//
+// What is given up first is the prose. A rebuilt context with no title still
+// names the right incident; one with no trigger_key names nothing at all.
+func TestMatrixStampShedsProseBeforeIdentity(t *testing.T) {
+	inv := sampleInvestigation()
+	inv.Title = strings.Repeat("\x1b", 200)
+	inv.TriggerKey = strings.Repeat("\x1b", 512)
+	inv.CuratedURL = strings.Repeat("\x1b", 512)
+	inv.RecalledEntry = strings.Repeat("\x1b", 512)
+	inv.Resource = providers.Workload{
+		Namespace: strings.Repeat("\x1b", 250),
+		Name:      strings.Repeat("\x1b", 250),
+	}
+
+	stamp := deliveredStamp(t, inv)
+	b, err := json.Marshal(stamp)
+	if err != nil {
+		t.Fatalf("marshal stamp: %v", err)
+	}
+	if len(b) > 4<<10 {
+		t.Errorf("the encoded stamp is %d bytes, over its 4,096-byte share: the ceiling was applied "+
+			"to the fields as composed, not to the bytes they encode to", len(b))
+	}
+	if stamp.Title != "" {
+		t.Errorf("title survived a shed that dropped identity — prose is the first thing given up, "+
+			"because a context with no title still names the right incident: %q", stamp.Title)
+	}
+	if stamp.TriggerKey == "" {
+		t.Error("trigger_key was shed while other fields survived: it is the join to the incident " +
+			"and the last field the stamp gives up")
+	}
+}
+
+// TestContextFromStampBoundsAStampItDidNotWrite is the READ side, and it is not
+// belt-and-braces: a room's history already holds events this process did not
+// send. Every investigation delivered before this bound existed carries an
+// unbounded stamp, and the registry-miss path fetches exactly those events after
+// a restart, a TTL expiry or an eviction — then hands what it decodes to a model
+// prompt (thread.Chat.renderContext) and to a knowledge-base entry body
+// (thread.NoteBody's "Thread:" line, which caps nothing).
+func TestContextFromStampBoundsAStampItDidNotWrite(t *testing.T) {
+	content := map[string]any{
+		triggerKeyContentField: "legacy-key",
+		threadContentField: map[string]any{
+			"trigger_key":    strings.Repeat("k", 4096),
+			"title":          strings.Repeat("prose ", 20_000),
+			"resource":       strings.Repeat("r", 4096),
+			"curated_url":    strings.Repeat("u", 4096),
+			"recalled_entry": strings.Repeat("p", 4096),
+		},
+	}
+	tc, ok := contextFromContent(content, "$root:hs", "!room:hs")
+	if !ok {
+		t.Fatal("a stamped event must still decode")
+	}
+	if len(tc.Title) > 200 {
+		t.Errorf("Title decoded to %d bytes: an event written before the bound existed is still an "+
+			"event this process reads back", len(tc.Title))
+	}
+	for name, got := range map[string]string{
+		"TriggerKey":    tc.TriggerKey,
+		"Resource":      tc.Resource,
+		"CuratedURL":    tc.CuratedURL,
+		"RecalledEntry": tc.RecalledEntry,
+	} {
+		if len(got) > 512 {
+			t.Errorf("%s decoded to %d bytes, over the 512-byte identifier ceiling", name, len(got))
+		}
+	}
+	// Dropping the stamp's own oversized trigger_key must fall through to the
+	// legacy field, exactly as an absent one always has.
+	if tc.TriggerKey != "legacy-key" {
+		t.Errorf("TriggerKey = %q, want the legacy field %q — a dropped stamp key is an ABSENT key, "+
+			"and an absent key has always fallen back", tc.TriggerKey, "legacy-key")
+	}
+	// Bounding must not widen what is trusted: root and room still come from the
+	// fetch's own parameters, never from the stamp.
+	if tc.Root != "$root:hs" || tc.Channel != "!room:hs" {
+		t.Errorf("root/room came from the stamp: root=%q channel=%q", tc.Root, tc.Channel)
+	}
+}

--- a/internal/notify/matrix_thread.go
+++ b/internal/notify/matrix_thread.go
@@ -3,6 +3,7 @@
 package notify
 
 import (
+	"bytes"
 	"cmp"
 	"encoding/json"
 
@@ -20,9 +21,35 @@ import (
 // unchanged. Namespaced per the Matrix convention for custom keys.
 const threadContentField = "io.runlore.thread"
 
-// threadStamp is the thread context as carried on a Matrix event. It holds
-// identifiers only — never prose — so the event stays small and nothing
-// sensitive is duplicated into room history that is not already in the message.
+// threadStamp is the thread context as carried on a Matrix event: six
+// identifiers and exactly one prose field, every one of them BOUNDED at the
+// point the stamp is built and read (see boundStamp, which stampFor and
+// contextFromStamp both funnel through).
+//
+// The "identifiers only — never prose" this comment used to claim was never
+// true. Title has been on the stamp since the field existed and is filled from
+// inv.Title, which Matrix.Deliver's own doc comment calls model-authored and
+// uncapped — so the sentence promising the event stayed small was the thing
+// standing in for the bound that was missing. A 64 KiB model title produced a
+// 78 KiB stamp beside two bodies that had dutifully bounded themselves to 16 KiB
+// each, and the homeserver rejected all 115 KiB of it: the silent-delivery
+// failure boundMatrixBodies exists to prevent, reached one field to its right.
+//
+// Title EARNS its place rather than merely surviving here. contextFromStamp is
+// the registry-miss path (thread.Registry TTL expiry, eviction, a leader
+// failover onto a replica without the JSONL, a restart), and on that path the
+// stamp is the only thing that knows which investigation the thread is about —
+// the advantage a Matrix event id has over a Slack thread_ts, which carries
+// nothing on its own. Drop Title and every note written after a restart says
+// only "Operator note" with no finding named: thread.Chat.renderContext loses
+// its "Investigation:" line, thread.NoteBody loses its "Thread:" line, and
+// conceptDescription loses the "on the finding %q" clause that makes the note
+// reachable from the alert again.
+//
+// What does NOT belong here is anything larger than an identity. Evidence is the
+// worked example and thread.Context.Evidence documents its own exclusion: a
+// stamp is forgeable, so evidence read back off one would be attacker-controlled
+// text flowing straight into a model prompt.
 type threadStamp struct {
 	TriggerKey     string `json:"trigger_key,omitempty"`
 	DupFingerprint string `json:"dup_fingerprint,omitempty"`
@@ -33,8 +60,157 @@ type threadStamp struct {
 	RecalledEntry  string `json:"recalled_entry,omitempty"`
 }
 
+// The stamp's ceilings. They are stated in ENCODED bytes where the whole stamp
+// is concerned, because that is the only measure the homeserver shares: the
+// Matrix spec caps an event at 65,536 bytes "encoded as Canonical JSON", and
+// canonical JSON turns one control byte into a six-byte \u001b escape. A cap
+// counted on the string as composed is therefore not a cap on the event — the
+// same mistake, one layer down, as bounding the bodies and not the stamp.
+const (
+	// matrixStampBytes is the encoded stamp's share of one event. Two fields
+	// claim it — this stamp and the legacy triggerKeyContentField it feeds — so
+	// the arithmetic for the whole event is:
+	//
+	//	 32,768  two bodies at matrixDeliverBodyBytes each
+	//	  8,192  two stamps at matrixStampBytes each
+	//	 ------
+	//	 40,960  everything Deliver writes
+	//	 24,576  left for what it does not: the federation envelope (room_id,
+	//	         sender, origin_server_ts, depth, prev_events, auth_events), the
+	//	         content hash and one signature per participating server
+	//	 ------
+	//	 65,536  the spec's hard ceiling
+	//
+	// A real envelope is one to two KiB, so the holdback is an order of
+	// magnitude over what it needs. That asymmetry is deliberate: guessing low
+	// is a rejected event and an on-call told nothing, guessing high costs card
+	// text nobody was going to read.
+	matrixStampBytes = 4 << 10
+	// matrixStampTitleBytes bounds the one PROSE field. 200 is the largest
+	// budget any reader of thread.Context.Title applies — thread's own
+	// maxChatIdentityFieldBytes, which Chat.renderContext re-cuts to anyway,
+	// while conceptDescription re-cuts to 120 — so the stamp never hands a
+	// reader less than that reader would have cut for itself, and an ordinary
+	// finding's title (curator.CapTitle caps a curated one at 120) crosses
+	// whole.
+	matrixStampTitleBytes = 200
+	// matrixStampIDBytes bounds ONE identifier. Generous for every one stamped:
+	// a "namespace/name" ref, a forge pull-request URL, a catalog entry path,
+	// and a trigger key assembled as "alertname|namespace|kind|name|cluster"
+	// from alert labels (curator.IncidentKey), whose Kubernetes-shaped parts
+	// come to a couple of hundred bytes in the worst realistic case. Small
+	// enough that all six plus the title stay under matrixStampBytes with room
+	// for the JSON framing, so the shed below is a backstop against escape
+	// expansion rather than something an ordinary card ever reaches.
+	matrixStampIDBytes = 512
+)
+
+// stampEllipsis marks a shortened prose field. A reader who cannot tell a title
+// was cut reads what survived as the whole of it — and unlike a human reading a
+// shortened card, the reader here is a model being told what to answer about.
+const stampEllipsis = "…"
+
+// boundStamp makes a stamp fit the event, and is the single funnel BOTH
+// directions go through: stampFor cannot build an unbounded stamp and
+// contextFromStamp cannot decode one. Making it a step a caller has to remember
+// is precisely how the defect above happened — the bodies were bounded at
+// matrix.go:132 and the stamp assigned unbounded at :154, twenty-two lines
+// later.
+//
+// Prose is TRUNCATED and identifiers are DROPPED, and the asymmetry is the whole
+// design:
+//
+//   - A shortened title is still a true answer to "which investigation is this".
+//     Every reader re-cuts it anyway, so the cut takes off only what would have
+//     come off downstream; the ellipsis says it happened.
+//   - A shortened identifier is not a shortened anything — it is a DIFFERENT
+//     identifier. A cut trigger_key names no incident, or on a prefix collision
+//     the wrong one, and that is a 👍 recorded against another finding in the
+//     outcome ledger, where it weights future trust. A cut curated_url is a
+//     write destination that is not the pull request it claims to be. Absence is
+//     a state every reader already handles — an empty trigger_key falls through
+//     to the legacy field and then to "not one of ours", an empty curated_url
+//     makes the thread open its own PR — and a wrong identity is a state nothing
+//     handles, because nothing can detect it.
+//
+// The per-field caps cannot finish the job on their own, because escaping
+// happens after them: six identifiers of ANSI escape bytes sit inside their caps
+// as composed and encode to six times that. So the encoded stamp is then
+// MEASURED and fields are shed until it fits — see stampShedOrder for what goes
+// first. Shedding terminates because an empty stamp encodes to two bytes.
+func boundStamp(s threadStamp) threadStamp {
+	s.Title = stampProse(s.Title, matrixStampTitleBytes)
+	for _, id := range []*string{
+		&s.TriggerKey, &s.DupFingerprint, &s.Resource,
+		&s.Verdict, &s.CuratedURL, &s.RecalledEntry,
+	} {
+		*id = stampIdentifier(*id, matrixStampIDBytes)
+	}
+	for _, field := range stampShedOrder(&s) {
+		if stampEncodedBytes(s) <= matrixStampBytes {
+			break
+		}
+		*field = ""
+	}
+	return s
+}
+
+// stampShedOrder lists the stamp's fields in the order they are given up when
+// the encoded stamp is still over budget after the per-field caps, least
+// costly to lose first.
+//
+// Prose goes first: a context with no title still names the right incident,
+// while a context with no trigger_key names nothing at all. Then the fields a
+// reader can do without one at a time, and trigger_key last — it is the join to
+// the investigation, the key the outcome ledger records against and the key
+// thread.Registry is looked up by, so a stamp that has given up everything else
+// is still worth sending for that one field alone.
+func stampShedOrder(s *threadStamp) []*string {
+	return []*string{
+		&s.Title, &s.RecalledEntry, &s.Resource, &s.Verdict,
+		&s.CuratedURL, &s.DupFingerprint, &s.TriggerKey,
+	}
+}
+
+// stampProse bounds one prose field, cutting on a rune boundary so no invalid
+// UTF-8 reaches the wire, and marking the cut. The ellipsis is reserved INSIDE
+// maxBytes, so the result is never longer than the budget it was given.
+func stampProse(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	return cutBytesToRuneBoundary(s, maxBytes-len(stampEllipsis)) + stampEllipsis
+}
+
+// stampIdentifier returns id when it fits maxBytes and "" when it does not —
+// see boundStamp for why an identifier is dropped rather than cut down.
+func stampIdentifier(id string, maxBytes int) string {
+	if len(id) > maxBytes {
+		return ""
+	}
+	return id
+}
+
+// stampEncodedBytes is the stamp's size as the HOMESERVER counts it, which is
+// not the sum of its field lengths.
+//
+// SetEscapeHTML(false) is what makes it the homeserver's arithmetic rather than
+// Go's: encoding/json escapes "<", ">" and "&" into six-byte \u003c-style
+// escapes by default, and Matrix's canonical JSON does not, so measuring with
+// the default would shed identity off stamps that fit perfectly well.
+func stampEncodedBytes(s threadStamp) int {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(s) // a struct of strings cannot fail to encode
+	return buf.Len() - len("\n")
+}
+
 // stampFor renders the investigation's thread identifiers for the event
-// content. TriggerKey falls back to Fingerprint exactly like Deliver's legacy
+// content, bounded — see boundStamp, which every stamp is built through so that
+// no caller can produce one that does not fit the event.
+//
+// TriggerKey falls back to Fingerprint exactly like Deliver's legacy
 // triggerKeyContentField does (cmp.Or): a re-investigation's Request carries a
 // Fingerprint but no TriggerKey (internal/investigate/reinvestigate.go), and
 // without the same fallback here the stamp's own trigger_key would be empty —
@@ -42,14 +218,14 @@ type threadStamp struct {
 // the legacy field, silently breaking notify.matrix.feedback_reactions for
 // every re-investigation.
 func stampFor(inv providers.Investigation) threadStamp {
-	return threadStamp{
+	return boundStamp(threadStamp{
 		TriggerKey:    cmp.Or(inv.TriggerKey, inv.Fingerprint),
 		Title:         inv.Title,
 		Resource:      inv.Resource.Ref(),
 		Verdict:       string(inv.Verdict),
 		CuratedURL:    inv.CuratedURL,
 		RecalledEntry: inv.RecalledEntry,
-	}
+	})
 }
 
 // contextFromStamp rebuilds a thread.Context from a stamped event. root and
@@ -68,7 +244,21 @@ func stampFor(inv providers.Investigation) threadStamp {
 // point a note at another repository's pull-request numbering — not on another
 // host, and not on the same host either, which is what a host-only anchor left
 // wide open.
+//
+// The stamp is re-bounded on the way IN, and that is not belt-and-braces on
+// stampFor's bound: a room's history holds events THIS process did not send.
+// Every investigation delivered before boundStamp existed carries an unbounded
+// stamp, and the registry-miss path fetches exactly those — an eviction, a TTL
+// expiry or a restart is what sends it looking. What it decodes goes into a
+// model prompt (thread.Chat.renderContext) and into a knowledge-base entry body
+// (thread.NoteBody's "Thread:" line, which caps nothing), so an upgrade must not
+// leave a 64 KiB title reachable through room history.
+//
+// Bounding NARROWS what is taken from the stamp; it widens nothing. root and
+// room are still the caller's own, and every trust control named above is
+// unchanged.
 func contextFromStamp(s threadStamp, root, room string) thread.Context {
+	s = boundStamp(s)
 	return thread.Context{
 		Transport:      "matrix",
 		Root:           root,
@@ -102,8 +292,16 @@ func contextFromStamp(s threadStamp, root, room string) thread.Context {
 // cmp.Or fallback: stampFor (the only builder today) never leaves trigger_key
 // empty while a trigger identity exists, but this keeps the read side correct
 // independently of that, for a stamp built any other way.
+//
+// The legacy key gets the stamp's own identifier rule applied to it (dropped
+// whole when over matrixStampIDBytes, never cut down), for the same reason
+// contextFromStamp re-bounds: this field is also read back off events written
+// before any bound existed, and it is the one the outcome ledger records a
+// rating against. An over-long one now reads as no trigger identity at all,
+// which every caller already handles.
 func contextFromContent(content map[string]any, root, room string) (thread.Context, bool) {
 	legacyKey, _ := content[triggerKeyContentField].(string)
+	legacyKey = stampIdentifier(legacyKey, matrixStampIDBytes)
 	if raw, ok := content[threadContentField]; ok {
 		if b, err := json.Marshal(raw); err == nil {
 			var stamp threadStamp

--- a/internal/notify/post_bound.go
+++ b/internal/notify/post_bound.go
@@ -2,7 +2,11 @@
 
 package notify
 
-import "strings"
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
 
 // Bounding a POSTED message — a progress ping, a delivered finding — as opposed
 // to a thread reply, which reply_bound.go already handles.
@@ -26,14 +30,18 @@ import "strings"
 // verdict and keeps the cost line.
 
 // matrixDeliverBodyBytes bounds ONE of the two renderings Matrix.Deliver puts on
-// a single event.
+// a single event, in ENCODED bytes — what the rendering costs inside the JSON
+// string it travels in, not how long the Go string is. See jsonBodyBytes for why
+// those are different numbers and why only the first one is a bound on anything.
 //
 // It is not matrixReplyBytes and must not be derived from it. That constant is
 // the share ONE body may claim of an event — half of the spec's hard 65,536-byte
 // ceiling, with the other half left to signatures, hashes and relations. Deliver
 // carries the same message TWICE, as the plaintext body and as the HTML
 // formatted_body, and both count against the one event, so the two together get
-// that half and each gets a quarter.
+// that half and each gets a quarter. Of the half left over, the stamps take
+// 2 x matrixStampBytes and the envelope keeps the rest — Matrix.Deliver's doc
+// comment adds it up.
 const matrixDeliverBodyBytes = 16 << 10
 
 // postTruncatedNotice is what a shortened post says instead of stopping silently.
@@ -119,7 +127,7 @@ func boundPostedHead(rendered string, maxBytes int) string {
 // "&amp;" or "<br/>".
 func boundMatrixBodies(msg string) (body, formatted string) {
 	body, formatted = renderMatrixBodies(msg)
-	if len(body) <= matrixDeliverBodyBytes && len(formatted) <= matrixDeliverBodyBytes {
+	if jsonBodyBytes(body) <= matrixDeliverBodyBytes && jsonBodyBytes(formatted) <= matrixDeliverBodyBytes {
 		return body, formatted
 	}
 	return renderMatrixBodies(boundMatrixSource(msg))
@@ -142,8 +150,8 @@ func renderMatrixBodies(msg string) (body, formatted string) {
 // therefore gives the same bytes as rendering the joined prefix.
 func boundMatrixSource(msg string) string {
 	plainNotice, richNotice := renderMatrixBodies("\n" + postTruncatedNotice)
-	plainBudget := matrixDeliverBodyBytes - len(plainNotice)
-	richBudget := matrixDeliverBodyBytes - len(richNotice)
+	plainBudget := matrixDeliverBodyBytes - jsonBodyBytes(plainNotice)
+	richBudget := matrixDeliverBodyBytes - jsonBodyBytes(richNotice)
 	if plainBudget <= 0 || richBudget <= 0 {
 		return ""
 	}
@@ -152,10 +160,10 @@ func boundMatrixSource(msg string) string {
 	kept, plainSize, richSize := 0, 0, 0
 	for _, line := range lines {
 		plain, rich := renderMatrixBodies(line)
-		addPlain, addRich := len(plain), len(rich)
+		addPlain, addRich := jsonBodyBytes(plain), jsonBodyBytes(rich)
 		if kept > 0 {
-			addPlain++              // the newline this line is joined by
-			addRich += len("<br/>") // which mrkdwnToHTML renders as a break
+			addPlain += jsonBodyBytes("\n")   // the newline this line is joined by
+			addRich += jsonBodyBytes("<br/>") // which mrkdwnToHTML renders as a break
 		}
 		if plainSize+addPlain > plainBudget || richSize+addRich > richBudget {
 			break
@@ -185,9 +193,35 @@ func cutMatrixLine(line string, plainBudget, richBudget int) string {
 	for n := min(len(line), richBudget); n > 0; n = n * 3 / 4 {
 		cut := cutBytesToRuneBoundary(line, n)
 		plain, rich := renderMatrixBodies(cut)
-		if len(plain) <= plainBudget && len(rich) <= richBudget {
+		if jsonBodyBytes(plain) <= plainBudget && jsonBodyBytes(rich) <= richBudget {
 			return cut
 		}
 	}
 	return ""
+}
+
+// jsonBodyBytes is what s costs INSIDE a JSON string on the event: every escape
+// the encoder applies, and nothing for the quotes around it, so the costs of
+// consecutive lines add up exactly the way the lines themselves do.
+//
+// The bound above has to be counted in these bytes rather than in len(s),
+// because len(s) is not a bound on anything the homeserver measures. The Matrix
+// spec caps an event at 65,536 bytes "encoded as Canonical JSON", and canonical
+// JSON renders every control character below 0x20 as a six-byte \u001b-style
+// escape. A card whose evidence quotes a container log line carrying ANSI colour
+// codes — an ordinary log line, not a crafted one — therefore measured 16,384
+// bytes at the ceiling and arrived at 98,304, and the two bodies together came to
+// three times the whole event budget while each sat exactly at its documented
+// limit.
+//
+// SetEscapeHTML(false) is what makes this the homeserver's arithmetic rather
+// than Go's. encoding/json escapes "<", ">" and "&" by default and canonical
+// JSON does not; measuring with the default would count an HTML formatted_body
+// at roughly twice its real cost and cut the card for a limit nothing enforces.
+func jsonBodyBytes(s string) int {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(s) // a string cannot fail to encode
+	return buf.Len() - len(`""`) - len("\n")
 }


### PR DESCRIPTION
`matrix_thread.go:24` promised the thread stamp *"holds identifiers only — never prose — so the event stays small"*. `Title` was in it, filled from model-authored, uncapped `inv.Title`; and `content[threadContentField] = stampFor(inv)` was assigned at `matrix.go:154`, **after** `boundMatrixBodies` ran at `:132`. The bodies obeyed their bound; the stamp did not, so the homeserver rejected the whole event — precisely the silent-delivery failure the bounding work exists to prevent.

### Measured through a real `Deliver` against a fake homeserver

Sized as the homeserver sizes it — Canonical JSON with `SetEscapeHTML(false)`, since Go's default `<`/`>`/`&` escaping is a Go quirk the spec does not share.

| case | body | formatted_body | stamp | **event** |
|---|---|---|---|---|
| 64 KiB title | 16,380 | 16,384 | **77,960** | **114,956** |
| 100 K `\x1b` title | 16,380 | 16,384 | — | **796,010** |
| 100 K `"` title | 16,380 | 16,384 | — | **220,605** |

Matrix's cap is 65,536.

Row 1 is the reported defect. **Rows 2–3 are a second defect it exposed:** the body ceiling was counted on the Go string, while canonical JSON renders a control byte as a 6-byte escape — so the two bodies alone reach ~196 KB while each measures *exactly* 16,384 at its documented limit. ANSI colour codes in container-log evidence are an ordinary input, not a crafted one. A per-field bound that still sums past the cap is the same defect one step later, so both had to change.

After: ordinary card **1,881**; the original 64 KiB case **33,084**; the ANSI case **27,507**. All under the 40,960 content budget.

### The design decision

**The stamp carries identifiers *and* one prose field, and the comment now says so.** "Identifiers only — never prose" was never true of `Title`; it was standing in for the missing bound.

`Title` is kept rather than removed. `contextFromStamp` is the registry-miss path, where the stamp is the only thing that knows which investigation a thread is about — the advantage a Matrix event id has over a Slack `thread_ts`. Removing it makes every post-restart note say only "Operator note": `Chat.renderContext` loses its `Investigation:` line, `NoteBody` its `Thread:` line, `conceptDescription` the clause that makes the note reachable from the alert again.

**Prose is truncated; identifiers are dropped whole.** That asymmetry is the core of it. A shortened title is still true, and every reader re-cuts it anyway (200 in chat, 120 in the description). A shortened identifier is a *different* identifier: a cut `trigger_key` names no incident, or on a prefix collision the wrong one — a rating landing on another finding in the outcome ledger, where it weights future trust. Absence is a state every reader already handles; a wrong identity is one nothing can detect.

Three things beyond the literal ask:

- **`io.runlore.trigger_key` escaped the bound too** (`matrix.go:150`, uncapped). It now comes *from* the bounded stamp, so the two cannot contradict each other.
- **Bounding on read**, because room history holds events sent before this bound existed — and the registry-miss path fetches exactly those, then feeds them into a model prompt and a KB entry body.
- **The bound moved inside `stampFor`/`contextFromStamp`**, so it is not a step a caller must remember. Being a separate step is how this happened.

Nothing trusted was widened: root and room still come from the event envelope, never the stamp. Bounding only narrows.

### Mutations — 11, all caught

Including the original defect itself (`stampFor` returning an unbounded stamp), which proves the event-ceiling test is not vacuous.

One apparent survivor turned out to be a wrong expectation rather than a weak test: removing the per-field title cap does not breach the event ceiling, because the encoded-size shed still drops `Title` — two layers doing separate jobs. The expectation was corrected, not the test.

Gate: `build` · `vet` · `go test ./... -race` · `gofmt -l .` silent · `golangci-lint run ./...` **0 issues**.

### Adjacent finding, deliberately not fixed

`Matrix.ReplyInThread` and `DeliverKBUpdate` bound their reply bodies at `matrixReplyBytes` using raw `len` — the same escaping gap, on a different event. Not a one-line fix: `boundPostedReply` is shared with Slack, where the limit is *characters*, so it needs a per-transport measure. Left out to keep this diff to the event under review.
